### PR TITLE
make sure to deserialize parent headers from tauri message properly

### DIFF
--- a/crates/notebook/src/kernel.rs
+++ b/crates/notebook/src/kernel.rs
@@ -65,7 +65,7 @@ where
 #[derive(Deserialize)]
 struct IncomingMessage {
     header: jupyter_protocol::Header,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "jupyter_protocol::deserialize_parent_header")]
     parent_header: Option<jupyter_protocol::Header>,
     #[serde(default)]
     metadata: Value,


### PR DESCRIPTION
Since we can't use `runtimelib`'s deserializer outright, gotta handle this the same as sidecar.