### PR TITLE
default `pnpm build` to build both UIs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/runt",
     "crates/notebook",
 ]
+default-members = ["crates/notebook"]
 resolver = "2"
 
 [workspace.package]

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "packageManager": "pnpm@10.12.1",
   "scripts": {
-    "build": "pnpm --dir packages/sidecar-ui build",
+    "build": "pnpm --dir packages/sidecar-ui build && pnpm --dir packages/notebook-ui build",
     "ui:build": "pnpm --dir packages/sidecar-ui build",
     "notebook:build": "pnpm --dir packages/notebook-ui build",
     "notebook:dev": "pnpm --dir packages/notebook-ui dev"


### PR DESCRIPTION
Also, make default cargo target be the notebook.