### PR TITLE
Add uv-style dependency management for notebooks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -729,11 +729,32 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.4.6",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -744,7 +765,7 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.2",
  "windows-sys 0.61.2",
 ]
 
@@ -2263,6 +2284,7 @@ version = "1.0.0"
 dependencies = [
  "anyhow",
  "bytes",
+ "dirs 5.0.1",
  "env_logger",
  "futures",
  "jupyter-protocol",
@@ -2272,6 +2294,7 @@ dependencies = [
  "runtimelib",
  "serde",
  "serde_json",
+ "sha2",
  "tauri",
  "tauri-build",
  "tauri-jupyter",
@@ -3282,6 +3305,17 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
@@ -3443,7 +3477,7 @@ dependencies = [
  "bytes",
  "chrono",
  "data-encoding",
- "dirs",
+ "dirs 6.0.0",
  "futures",
  "glob",
  "jupyter-protocol",
@@ -3824,7 +3858,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b1fdf65dd6331831494dd616b30351c38e96e45921a27745cf98490458b90bb"
 dependencies = [
- "dirs",
+ "dirs 6.0.0",
 ]
 
 [[package]]
@@ -4163,7 +4197,7 @@ checksum = "e7b0bc1aec81bda6bc455ea98fcaed26b3c98c1648c627ad6ff1c704e8bf8cbc"
 dependencies = [
  "anyhow",
  "bytes",
- "dirs",
+ "dirs 6.0.0",
  "dunce",
  "embed_plist",
  "futures-util",
@@ -4214,7 +4248,7 @@ checksum = "d7a0350f0df1db385ca5c02888a83e0e66655c245b7443db8b78a70da7d7f8fc"
 dependencies = [
  "anyhow",
  "cargo_toml",
- "dirs",
+ "dirs 6.0.0",
  "glob",
  "heck 0.5.0",
  "json-patch",
@@ -4687,7 +4721,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7eee98ec5c90daf179d55c20a49d8c0d043054ce7c26336c09a24d31f14fa0"
 dependencies = [
  "crossbeam-channel",
- "dirs",
+ "dirs 6.0.0",
  "libappindicator",
  "muda 0.16.1",
  "objc2 0.6.3",
@@ -5329,6 +5363,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -5376,6 +5419,21 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -5437,6 +5495,12 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -5455,6 +5519,12 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -5470,6 +5540,12 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5503,6 +5579,12 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -5518,6 +5600,12 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5539,6 +5627,12 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -5554,6 +5648,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -2,8 +2,10 @@ import { useCallback, useEffect, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { NotebookToolbar } from "./components/NotebookToolbar";
 import { NotebookView } from "./components/NotebookView";
+import { DependencyHeader } from "./components/DependencyHeader";
 import { useNotebook } from "./hooks/useNotebook";
 import { useKernel } from "./hooks/useKernel";
+import { useDependencies } from "./hooks/useDependencies";
 import { WidgetStoreProvider, useWidgetStoreRequired } from "@/components/widgets/widget-store-context";
 import { MediaProvider } from "@/components/outputs/media-provider";
 import { WidgetView } from "@/components/widgets/widget-view";
@@ -39,6 +41,18 @@ function AppContent() {
   const [executingCellIds, setExecutingCellIds] = useState<Set<string>>(
     new Set()
   );
+  const [dependencyHeaderOpen, setDependencyHeaderOpen] = useState(false);
+
+  // Dependency management
+  const {
+    dependencies,
+    uvAvailable,
+    hasDependencies,
+    loading: depsLoading,
+    syncedWhileRunning,
+    addDependency,
+    removeDependency,
+  } = useDependencies();
 
   // Get widget store handler for routing comm messages
   const { handleMessage: handleWidgetMessage } = useWidgetStoreRequired();
@@ -124,12 +138,25 @@ function AppContent() {
       <NotebookToolbar
         kernelStatus={kernelStatus}
         dirty={dirty}
+        hasDependencies={hasDependencies}
         onSave={save}
         onStartKernel={startKernel}
         onInterruptKernel={interruptKernel}
         onAddCell={handleAddCell}
+        onToggleDependencies={() => setDependencyHeaderOpen((prev) => !prev)}
         listKernelspecs={listKernelspecs}
       />
+      {dependencyHeaderOpen && (
+        <DependencyHeader
+          dependencies={dependencies?.dependencies ?? []}
+          requiresPython={dependencies?.requires_python ?? null}
+          uvAvailable={uvAvailable}
+          loading={depsLoading}
+          syncedWhileRunning={syncedWhileRunning}
+          onAdd={addDependency}
+          onRemove={removeDependency}
+        />
+      )}
       <NotebookView
         cells={cells}
         focusedCellId={focusedCellId}

--- a/apps/notebook/src/components/DependencyHeader.tsx
+++ b/apps/notebook/src/components/DependencyHeader.tsx
@@ -1,0 +1,124 @@
+import { useState, useCallback, type KeyboardEvent } from "react";
+import { X, Plus, Info } from "lucide-react";
+
+interface DependencyHeaderProps {
+  dependencies: string[];
+  requiresPython: string | null;
+  uvAvailable: boolean | null;
+  loading: boolean;
+  syncedWhileRunning: boolean;
+  onAdd: (pkg: string) => Promise<void>;
+  onRemove: (pkg: string) => Promise<void>;
+}
+
+export function DependencyHeader({
+  dependencies,
+  requiresPython,
+  uvAvailable,
+  loading,
+  syncedWhileRunning,
+  onAdd,
+  onRemove,
+}: DependencyHeaderProps) {
+  const [newDep, setNewDep] = useState("");
+
+  const handleAdd = useCallback(async () => {
+    if (newDep.trim()) {
+      await onAdd(newDep.trim());
+      setNewDep("");
+    }
+  }, [newDep, onAdd]);
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        handleAdd();
+      }
+    },
+    [handleAdd]
+  );
+
+  return (
+    <div className="border-b bg-muted/30">
+      <div className="px-3 py-3">
+          {/* Sync notice */}
+          {syncedWhileRunning && (
+            <div className="mb-3 flex items-start gap-2 rounded bg-blue-500/10 px-2 py-1.5 text-xs text-blue-700">
+              <Info className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+              <span>
+                Dependencies synced to environment. New packages can be imported
+                now. Restart kernel if you updated existing packages.
+              </span>
+            </div>
+          )}
+
+          {/* UV availability notice */}
+          {uvAvailable === false && (
+            <div className="mb-3 rounded bg-amber-500/10 px-2 py-1.5 text-xs text-amber-700">
+              <span className="font-medium">uv not found.</span> Install it with{" "}
+              <code className="rounded bg-amber-500/20 px-1">
+                curl -LsSf https://astral.sh/uv/install.sh | sh
+              </code>
+            </div>
+          )}
+
+          {/* Python version */}
+          {requiresPython && (
+            <div className="mb-2 text-xs text-muted-foreground">
+              Python: <span className="font-mono">{requiresPython}</span>
+            </div>
+          )}
+
+          {/* Dependencies list */}
+          {dependencies.length > 0 ? (
+            <div className="mb-3 flex flex-wrap gap-1.5">
+              {dependencies.map((dep) => (
+                <div
+                  key={dep}
+                  className="flex items-center gap-1 rounded bg-background px-2 py-1 text-xs border"
+                >
+                  <span className="font-mono">{dep}</span>
+                  <button
+                    type="button"
+                    onClick={() => onRemove(dep)}
+                    className="text-muted-foreground hover:text-foreground transition-colors"
+                    disabled={loading}
+                    title={`Remove ${dep}`}
+                  >
+                    <X className="h-3 w-3" />
+                  </button>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="mb-3 text-xs text-muted-foreground">
+              No dependencies. Add packages to create an isolated environment.
+            </div>
+          )}
+
+          {/* Add dependency input */}
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={newDep}
+              onChange={(e) => setNewDep(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="package or package>=version"
+              className="flex-1 rounded border bg-background px-2 py-1 text-xs placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
+              disabled={loading}
+            />
+            <button
+              type="button"
+              onClick={handleAdd}
+              disabled={loading || !newDep.trim()}
+              className="flex items-center gap-1 rounded bg-primary px-2 py-1 text-xs text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50"
+            >
+              <Plus className="h-3 w-3" />
+              Add
+            </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -1,25 +1,29 @@
 import { useCallback, useEffect, useState } from "react";
-import { Save, Play, Square, Plus } from "lucide-react";
+import { Save, Play, Square, Plus, Package } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { KernelspecInfo } from "../types";
 
 interface NotebookToolbarProps {
   kernelStatus: string;
   dirty: boolean;
+  hasDependencies: boolean;
   onSave: () => void;
   onStartKernel: (name: string) => void;
   onInterruptKernel: () => void;
   onAddCell: (type: "code" | "markdown") => void;
+  onToggleDependencies: () => void;
   listKernelspecs: () => Promise<KernelspecInfo[]>;
 }
 
 export function NotebookToolbar({
   kernelStatus,
   dirty,
+  hasDependencies,
   onSave,
   onStartKernel,
   onInterruptKernel,
   onAddCell,
+  onToggleDependencies,
   listKernelspecs,
 }: NotebookToolbarProps) {
   const [kernelspecs, setKernelspecs] = useState<KernelspecInfo[]>([]);
@@ -83,6 +87,22 @@ export function NotebookToolbar({
         >
           <Plus className="h-3 w-3" />
           Markdown
+        </button>
+
+        <div className="h-4 w-px bg-border" />
+
+        {/* Dependencies */}
+        <button
+          type="button"
+          onClick={onToggleDependencies}
+          className={cn(
+            "flex items-center gap-1 rounded px-2 py-1 text-xs transition-colors hover:bg-muted",
+            hasDependencies ? "text-foreground" : "text-muted-foreground"
+          )}
+          title="Manage dependencies"
+        >
+          <Package className="h-3.5 w-3.5" />
+          Deps
         </button>
 
         <div className="flex-1" />

--- a/apps/notebook/src/hooks/useDependencies.ts
+++ b/apps/notebook/src/hooks/useDependencies.ts
@@ -1,0 +1,129 @@
+import { useState, useCallback, useEffect } from "react";
+import { invoke } from "@tauri-apps/api/core";
+
+export interface NotebookDependencies {
+  dependencies: string[];
+  requires_python: string | null;
+}
+
+export function useDependencies() {
+  const [dependencies, setDependencies] =
+    useState<NotebookDependencies | null>(null);
+  const [uvAvailable, setUvAvailable] = useState<boolean | null>(null);
+  const [loading, setLoading] = useState(false);
+  // Track if deps were synced to a running kernel (user may need to restart for some changes)
+  const [syncedWhileRunning, setSyncedWhileRunning] = useState(false);
+
+  // Check if uv is available on mount
+  useEffect(() => {
+    invoke<boolean>("check_uv_available").then(setUvAvailable);
+  }, []);
+
+  const loadDependencies = useCallback(async () => {
+    try {
+      const deps = await invoke<NotebookDependencies | null>(
+        "get_notebook_dependencies"
+      );
+      setDependencies(deps);
+    } catch (e) {
+      console.error("Failed to load dependencies:", e);
+    }
+  }, []);
+
+  // Load dependencies on mount
+  useEffect(() => {
+    loadDependencies();
+  }, [loadDependencies]);
+
+  // Try to sync deps to running kernel
+  const syncToKernel = useCallback(async (): Promise<boolean> => {
+    try {
+      const synced = await invoke<boolean>("sync_kernel_dependencies");
+      if (synced) {
+        setSyncedWhileRunning(true);
+      }
+      return synced;
+    } catch (e) {
+      console.error("Failed to sync dependencies to kernel:", e);
+      return false;
+    }
+  }, []);
+
+  const addDependency = useCallback(
+    async (pkg: string) => {
+      if (!pkg.trim()) return;
+      setLoading(true);
+      try {
+        await invoke("add_dependency", { package: pkg.trim() });
+        await loadDependencies();
+        // Try to sync to running kernel
+        await syncToKernel();
+      } catch (e) {
+        console.error("Failed to add dependency:", e);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [loadDependencies, syncToKernel]
+  );
+
+  const removeDependency = useCallback(
+    async (pkg: string) => {
+      setLoading(true);
+      try {
+        await invoke("remove_dependency", { package: pkg });
+        await loadDependencies();
+        // Note: removing a dep doesn't uninstall from running kernel
+        // User would need to restart for that
+        const hasUvEnv = await invoke<boolean>("kernel_has_uv_env");
+        if (hasUvEnv) {
+          setSyncedWhileRunning(true);
+        }
+      } catch (e) {
+        console.error("Failed to remove dependency:", e);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [loadDependencies]
+  );
+
+  // Clear the synced notice (e.g., when kernel restarts)
+  const clearSyncNotice = useCallback(() => {
+    setSyncedWhileRunning(false);
+  }, []);
+
+  const setRequiresPython = useCallback(
+    async (version: string | null) => {
+      setLoading(true);
+      try {
+        await invoke("set_notebook_dependencies", {
+          dependencies: dependencies?.dependencies ?? [],
+          requiresPython: version,
+        });
+        await loadDependencies();
+      } catch (e) {
+        console.error("Failed to set requires-python:", e);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [dependencies, loadDependencies]
+  );
+
+  const hasDependencies =
+    dependencies !== null && dependencies.dependencies.length > 0;
+
+  return {
+    dependencies,
+    uvAvailable,
+    hasDependencies,
+    loading,
+    syncedWhileRunning,
+    loadDependencies,
+    addDependency,
+    removeDependency,
+    setRequiresPython,
+    clearSyncNotice,
+  };
+}

--- a/crates/notebook/Cargo.toml
+++ b/crates/notebook/Cargo.toml
@@ -31,6 +31,8 @@ nbformat = "1.0.0"
 petname = "2"
 log = "0.4"
 env_logger = "0.11"
+sha2 = "0.10"
+dirs = "5"
 
 [build-dependencies]
 tauri-build = { version = "2", features = [] }

--- a/crates/notebook/src/uv_env.rs
+++ b/crates/notebook/src/uv_env.rs
@@ -1,0 +1,282 @@
+//! UV-based environment management for notebook dependencies.
+//!
+//! This module handles creating ephemeral virtual environments using `uv`
+//! for notebooks that declare inline dependencies in their metadata.
+
+use anyhow::{anyhow, Result};
+use log::info;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::path::PathBuf;
+use std::process::Stdio;
+
+/// Dependencies extracted from notebook metadata.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NotebookDependencies {
+    pub dependencies: Vec<String>,
+    #[serde(rename = "requires-python")]
+    pub requires_python: Option<String>,
+}
+
+/// Result of environment preparation.
+#[derive(Debug)]
+pub struct UvEnvironment {
+    pub venv_path: PathBuf,
+    pub python_path: PathBuf,
+}
+
+/// Check if uv is available on the system.
+pub async fn check_uv_available() -> bool {
+    tokio::process::Command::new("uv")
+        .arg("--version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .await
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Extract dependencies from notebook metadata.
+///
+/// Looks for the `uv` key in the metadata's additional fields,
+/// which should contain `dependencies` and optionally `requires-python`.
+pub fn extract_dependencies(metadata: &nbformat::v4::Metadata) -> Option<NotebookDependencies> {
+    let uv_value = metadata.additional.get("uv")?;
+    serde_json::from_value(uv_value.clone()).ok()
+}
+
+/// Compute a cache key for the given dependencies.
+fn compute_env_hash(deps: &NotebookDependencies) -> String {
+    let mut hasher = Sha256::new();
+
+    // Sort dependencies for consistent hashing
+    let mut sorted_deps = deps.dependencies.clone();
+    sorted_deps.sort();
+
+    for dep in &sorted_deps {
+        hasher.update(dep.as_bytes());
+        hasher.update(b"\n");
+    }
+
+    if let Some(ref py) = deps.requires_python {
+        hasher.update(b"requires-python:");
+        hasher.update(py.as_bytes());
+    }
+
+    let hash = hasher.finalize();
+    format!("{:x}", hash)[..16].to_string()
+}
+
+/// Get the cache directory for runt environments.
+fn get_cache_dir() -> PathBuf {
+    dirs::cache_dir()
+        .unwrap_or_else(|| PathBuf::from("/tmp"))
+        .join("runt")
+        .join("envs")
+}
+
+/// Prepare a virtual environment with the given dependencies.
+///
+/// Uses cached environments when possible (keyed by dependency hash).
+/// If the cache doesn't exist or is invalid, creates a new environment.
+pub async fn prepare_environment(deps: &NotebookDependencies) -> Result<UvEnvironment> {
+    let hash = compute_env_hash(deps);
+    let cache_dir = get_cache_dir();
+    let venv_path = cache_dir.join(&hash);
+
+    // Determine python path based on platform
+    #[cfg(target_os = "windows")]
+    let python_path = venv_path.join("Scripts").join("python.exe");
+    #[cfg(not(target_os = "windows"))]
+    let python_path = venv_path.join("bin").join("python");
+
+    // Check if cached environment exists and is valid
+    if venv_path.exists() && python_path.exists() {
+        info!("Using cached environment at {:?}", venv_path);
+        return Ok(UvEnvironment {
+            venv_path,
+            python_path,
+        });
+    }
+
+    info!("Creating new environment at {:?}", venv_path);
+
+    // Ensure cache directory exists
+    tokio::fs::create_dir_all(&cache_dir).await?;
+
+    // Remove partial/invalid environment if it exists
+    if venv_path.exists() {
+        tokio::fs::remove_dir_all(&venv_path).await?;
+    }
+
+    // Create virtual environment with uv
+    let mut venv_cmd = tokio::process::Command::new("uv");
+    venv_cmd.arg("venv").arg(&venv_path);
+
+    // Add python version constraint if specified
+    if let Some(ref py_version) = deps.requires_python {
+        // Extract version number from constraint like ">=3.10" -> "3.10"
+        let version = py_version
+            .trim_start_matches(|c: char| !c.is_ascii_digit())
+            .to_string();
+        if !version.is_empty() {
+            venv_cmd.arg("--python").arg(&version);
+        }
+    }
+
+    let venv_status = venv_cmd
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .status()
+        .await?;
+
+    if !venv_status.success() {
+        return Err(anyhow!("Failed to create virtual environment"));
+    }
+
+    // Install ipykernel and dependencies
+    let mut install_args = vec![
+        "pip".to_string(),
+        "install".to_string(),
+        "--python".to_string(),
+        python_path.to_string_lossy().to_string(),
+        "ipykernel".to_string(),
+    ];
+
+    for dep in &deps.dependencies {
+        install_args.push(dep.clone());
+    }
+
+    let install_status = tokio::process::Command::new("uv")
+        .args(&install_args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .status()
+        .await?;
+
+    if !install_status.success() {
+        // Clean up failed environment
+        tokio::fs::remove_dir_all(&venv_path).await.ok();
+        return Err(anyhow!("Failed to install dependencies"));
+    }
+
+    info!("Environment ready at {:?}", venv_path);
+
+    Ok(UvEnvironment {
+        venv_path,
+        python_path,
+    })
+}
+
+/// Clean up an ephemeral environment.
+///
+/// Note: We don't actually remove cached environments since they can be reused.
+/// This is called on kernel shutdown but only cleans up if needed.
+pub async fn cleanup_environment(_env: &UvEnvironment) -> Result<()> {
+    // For now, we keep cached environments for reuse.
+    // Could add LRU eviction or size-based cleanup later.
+    Ok(())
+}
+
+/// Force remove a cached environment (for manual cleanup).
+#[allow(dead_code)]
+pub async fn remove_environment(env: &UvEnvironment) -> Result<()> {
+    if env.venv_path.exists() {
+        tokio::fs::remove_dir_all(&env.venv_path).await?;
+    }
+    Ok(())
+}
+
+/// Install additional dependencies into an existing environment.
+///
+/// This is used to sync new dependencies when the kernel is already running.
+pub async fn sync_dependencies(env: &UvEnvironment, deps: &[String]) -> Result<()> {
+    if deps.is_empty() {
+        return Ok(());
+    }
+
+    info!("Syncing {} dependencies to {:?}", deps.len(), env.venv_path);
+
+    let mut install_args = vec![
+        "pip".to_string(),
+        "install".to_string(),
+        "--python".to_string(),
+        env.python_path.to_string_lossy().to_string(),
+    ];
+
+    for dep in deps {
+        install_args.push(dep.clone());
+    }
+
+    let output = tokio::process::Command::new("uv")
+        .args(&install_args)
+        .output()
+        .await?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(anyhow!("Failed to sync dependencies: {}", stderr));
+    }
+
+    info!("Dependencies synced successfully");
+    Ok(())
+}
+
+/// Clear all cached environments.
+#[allow(dead_code)]
+pub async fn clear_cache() -> Result<()> {
+    let cache_dir = get_cache_dir();
+    if cache_dir.exists() {
+        tokio::fs::remove_dir_all(&cache_dir).await?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_compute_env_hash_stable() {
+        let deps = NotebookDependencies {
+            dependencies: vec!["pandas".to_string(), "numpy".to_string()],
+            requires_python: Some(">=3.10".to_string()),
+        };
+
+        let hash1 = compute_env_hash(&deps);
+        let hash2 = compute_env_hash(&deps);
+
+        assert_eq!(hash1, hash2);
+    }
+
+    #[test]
+    fn test_compute_env_hash_order_independent() {
+        let deps1 = NotebookDependencies {
+            dependencies: vec!["pandas".to_string(), "numpy".to_string()],
+            requires_python: None,
+        };
+
+        let deps2 = NotebookDependencies {
+            dependencies: vec!["numpy".to_string(), "pandas".to_string()],
+            requires_python: None,
+        };
+
+        assert_eq!(compute_env_hash(&deps1), compute_env_hash(&deps2));
+    }
+
+    #[test]
+    fn test_compute_env_hash_different_deps() {
+        let deps1 = NotebookDependencies {
+            dependencies: vec!["pandas".to_string()],
+            requires_python: None,
+        };
+
+        let deps2 = NotebookDependencies {
+            dependencies: vec!["numpy".to_string()],
+            requires_python: None,
+        };
+
+        assert_ne!(compute_env_hash(&deps1), compute_env_hash(&deps2));
+    }
+}

--- a/test-uv-deps.ipynb
+++ b/test-uv-deps.ipynb
@@ -1,0 +1,47 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "test-cell-1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests\n",
+    "print(f\"requests version: {requests.__version__}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "test-cell-2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Test making a request\n",
+    "response = requests.get('https://httpbin.org/get')\n",
+    "print(f\"Status: {response.status_code}\")\n",
+    "response.json()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  },
+  "uv": {
+   "dependencies": [
+    "requests"
+   ],
+   "requires-python": ">=3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

Notebooks can now declare Python dependencies in metadata using PEP 723 format. The app automatically creates isolated, ephemeral virtual environments with `uv` when starting kernels with dependencies. New dependencies can be added/removed from a collapsible UI panel and are synced to running kernels on-the-fly.

## Features

- Store deps in `metadata.uv.dependencies` in notebook files
- Auto-detect and create uv-managed kernels (no pre-installed system kernels needed)
- Sync new deps to running environments without restarting
- Clean cached venvs at `~/.cache/runt/envs/`
- UI panel for dependency management (toggle via "Deps" button in toolbar)

## Test Plan

- [x] Open a notebook with `metadata.uv.dependencies: ["requests"]`
- [x] Execute a cell - kernel should start in isolated uv venv
- [x] Run `import requests` - should work
- [x] Add another dep via UI, check sync notice appears
- [x] Verify `import` works for newly synced packages