### PR TITLE
Redesign notebook UI with gutter ribbon layout

### DIFF
--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -93,28 +93,28 @@ export function CodeCell({
     onExecute();
   }, [onExecute]);
 
+  const playButton = (
+    <PlayButton
+      executionState={isExecuting ? "running" : "idle"}
+      cellType="code"
+      isFocused={isFocused}
+      onExecute={handleExecute}
+      onInterrupt={onInterrupt}
+      className="h-4 w-4"
+      focusedClass="text-gray-700"
+    />
+  );
+
   return (
     <CellContainer
       id={cell.id}
       cellType="code"
       isFocused={isFocused}
       onFocus={onFocus}
+      gutterContent={playButton}
     >
-      {/* Gutter play button - breaks left border */}
-      <div className="absolute left-0 top-3 z-20 -translate-x-1/2">
-        <PlayButton
-          executionState={isExecuting ? "running" : "idle"}
-          cellType="code"
-          isFocused={isFocused}
-          onExecute={handleExecute}
-          onInterrupt={onInterrupt}
-          className="h-5 w-5 rounded-full bg-white shadow-[0_1px_3px_rgba(0,0,0,0.12),0_1px_2px_rgba(0,0,0,0.06)] border border-gray-200/80 hover:shadow-md hover:border-gray-300 transition-all"
-          focusedClass="text-gray-700"
-        />
-      </div>
-
-      {/* Cell header: execution count */}
-      <div className="flex items-center gap-1 px-2 py-1 pl-4">
+      {/* Cell header: execution count + controls */}
+      <div className="flex items-center gap-1 px-2 py-1">
         <ExecutionCount
           count={cell.execution_count}
           isExecuting={isExecuting}
@@ -134,7 +134,7 @@ export function CodeCell({
       </div>
 
       {/* Editor */}
-      <div className="pl-4 pr-1">
+      <div className="px-2">
         <CodeMirrorEditor
           ref={editorRef}
           value={cell.source}
@@ -148,24 +148,9 @@ export function CodeCell({
         />
       </div>
 
-      {/* Execution summary */}
-      {(cell.execution_count !== null || cell.outputs.length > 0) && (
-        <div className="flex h-7 items-center justify-between pl-4 pr-2 text-xs text-muted-foreground">
-          {cell.execution_count !== null && (
-            <span className="animate-in fade-in duration-300">Executed</span>
-          )}
-          <div className="flex-1" />
-          {cell.outputs.length > 0 && (
-            <span>
-              {cell.outputs.length} output{cell.outputs.length > 1 ? "s" : ""}
-            </span>
-          )}
-        </div>
-      )}
-
       {/* Outputs */}
       {cell.outputs.length > 0 && (
-        <div className="pl-4 pr-2 py-1">
+        <div className="px-2 py-2">
           <OutputArea outputs={cell.outputs} />
         </div>
       )}

--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -54,7 +54,7 @@ export function CodeCell({
       id={cell.id}
       isFocused={isFocused}
       onFocus={onFocus}
-      className="rounded-md my-1"
+      className=""
     >
       {/* Cell header: execution count + play button */}
       <div className="flex items-center gap-1 px-2 py-1">
@@ -85,7 +85,7 @@ export function CodeCell({
       </div>
 
       {/* Editor */}
-      <div className="border-t border-border/50 px-1">
+      <div className="px-1">
         <CodeMirrorEditor
           ref={editorRef}
           value={cell.source}
@@ -101,7 +101,7 @@ export function CodeCell({
 
       {/* Outputs */}
       {cell.outputs.length > 0 && (
-        <div className="border-t border-border/50 px-2 py-1">
+        <div className="px-2 py-1">
           <OutputArea outputs={cell.outputs} />
         </div>
       )}

--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from "react";
+import { useCallback, useRef, useEffect, useMemo } from "react";
 import type { KeyBinding } from "@codemirror/view";
 import { CellContainer } from "@/components/cell/CellContainer";
 import { PlayButton } from "@/components/cell/PlayButton";
@@ -10,6 +10,8 @@ import {
 } from "@/components/editor/codemirror-editor";
 import { Trash2 } from "lucide-react";
 import { kernelCompletionExtension } from "../lib/kernel-completion";
+import { useCellKeyboardNavigation } from "../hooks/useCellKeyboardNavigation";
+import { useEditorRegistry } from "../hooks/useEditorRegistry";
 import type { CodeCell as CodeCellType } from "../types";
 
 interface CodeCellProps {
@@ -21,6 +23,10 @@ interface CodeCellProps {
   onExecute: () => void;
   onInterrupt: () => void;
   onDelete: () => void;
+  onFocusPrevious?: (cursorPosition: "start" | "end") => void;
+  onFocusNext?: (cursorPosition: "start" | "end") => void;
+  onInsertCellAfter?: () => void;
+  isLastCell?: boolean;
 }
 
 export function CodeCell({
@@ -32,18 +38,56 @@ export function CodeCell({
   onExecute,
   onInterrupt,
   onDelete,
+  onFocusPrevious,
+  onFocusNext,
+  onInsertCellAfter,
+  isLastCell = false,
 }: CodeCellProps) {
   const editorRef = useRef<CodeMirrorEditorRef>(null);
+  const { registerEditor, unregisterEditor } = useEditorRegistry();
 
-  const keyMap: KeyBinding[] = [
-    {
-      key: "Shift-Enter",
-      run: () => {
-        onExecute();
-        return true;
-      },
+  // Register editor with the registry for cross-cell navigation
+  useEffect(() => {
+    if (editorRef.current) {
+      registerEditor(cell.id, {
+        focus: () => editorRef.current?.focus(),
+        setCursorPosition: (position) =>
+          editorRef.current?.setCursorPosition(position),
+      });
+    }
+    return () => unregisterEditor(cell.id);
+  }, [cell.id, registerEditor, unregisterEditor]);
+
+  // Handle focus next, creating a new cell if at the end
+  const handleFocusNextOrCreate = useCallback(
+    (cursorPosition: "start" | "end") => {
+      if (isLastCell && onInsertCellAfter) {
+        onInsertCellAfter();
+      } else if (onFocusNext) {
+        onFocusNext(cursorPosition);
+      }
     },
-  ];
+    [isLastCell, onFocusNext, onInsertCellAfter]
+  );
+
+  // Get keyboard navigation bindings
+  const navigationKeyMap = useCellKeyboardNavigation({
+    onFocusPrevious: onFocusPrevious ?? (() => {}),
+    onFocusNext: handleFocusNextOrCreate,
+    onExecute,
+    onExecuteAndInsert: onInsertCellAfter
+      ? () => {
+          onExecute();
+          onInsertCellAfter();
+        }
+      : undefined,
+  });
+
+  // Merge navigation keybindings (navigation bindings take precedence for Shift-Enter)
+  const keyMap: KeyBinding[] = useMemo(
+    () => [...navigationKeyMap],
+    [navigationKeyMap]
+  );
 
   const handleExecute = useCallback(() => {
     onExecute();
@@ -52,27 +96,32 @@ export function CodeCell({
   return (
     <CellContainer
       id={cell.id}
+      cellType="code"
       isFocused={isFocused}
       onFocus={onFocus}
-      className=""
     >
-      {/* Cell header: execution count + play button */}
-      <div className="flex items-center gap-1 px-2 py-1">
-        <ExecutionCount
-          count={cell.execution_count}
-          isExecuting={isExecuting}
-          className="text-xs"
-        />
-        <div className="flex-1" />
+      {/* Gutter play button - breaks left border */}
+      <div className="absolute left-0 top-3 z-20 -translate-x-1/2">
         <PlayButton
           executionState={isExecuting ? "running" : "idle"}
           cellType="code"
           isFocused={isFocused}
           onExecute={handleExecute}
           onInterrupt={onInterrupt}
-          className="h-6 w-6"
+          className="h-5 w-5 rounded-full bg-white shadow-[0_1px_3px_rgba(0,0,0,0.12),0_1px_2px_rgba(0,0,0,0.06)] border border-gray-200/80 hover:shadow-md hover:border-gray-300 transition-all"
+          focusedClass="text-gray-700"
         />
-        {isFocused && (
+      </div>
+
+      {/* Cell header: execution count */}
+      <div className="flex items-center gap-1 px-2 py-1 pl-4">
+        <ExecutionCount
+          count={cell.execution_count}
+          isExecuting={isExecuting}
+          className="text-xs"
+        />
+        <div className="flex-1" />
+        <div className="cell-controls opacity-0 group-hover:opacity-100 transition-opacity">
           <button
             type="button"
             onClick={onDelete}
@@ -81,11 +130,11 @@ export function CodeCell({
           >
             <Trash2 className="h-3.5 w-3.5" />
           </button>
-        )}
+        </div>
       </div>
 
       {/* Editor */}
-      <div className="px-1">
+      <div className="pl-4 pr-1">
         <CodeMirrorEditor
           ref={editorRef}
           value={cell.source}
@@ -99,9 +148,24 @@ export function CodeCell({
         />
       </div>
 
+      {/* Execution summary */}
+      {(cell.execution_count !== null || cell.outputs.length > 0) && (
+        <div className="flex h-7 items-center justify-between pl-4 pr-2 text-xs text-muted-foreground">
+          {cell.execution_count !== null && (
+            <span className="animate-in fade-in duration-300">Executed</span>
+          )}
+          <div className="flex-1" />
+          {cell.outputs.length > 0 && (
+            <span>
+              {cell.outputs.length} output{cell.outputs.length > 1 ? "s" : ""}
+            </span>
+          )}
+        </div>
+      )}
+
       {/* Outputs */}
       {cell.outputs.length > 0 && (
-        <div className="px-2 py-1">
+        <div className="pl-4 pr-2 py-1">
           <OutputArea outputs={cell.outputs} />
         </div>
       )}

--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -63,7 +63,7 @@ export function MarkdownCell({
       id={cell.id}
       isFocused={isFocused}
       onFocus={onFocus}
-      className="rounded-md my-1"
+      className=""
     >
       {editing ? (
         <>
@@ -81,7 +81,7 @@ export function MarkdownCell({
               </button>
             )}
           </div>
-          <div className="border-t border-border/50 px-1">
+          <div className="px-1">
             <CodeMirrorEditor
               ref={editorRef}
               value={cell.source}

--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef } from "react";
+import { useState, useCallback, useRef, useEffect, useMemo } from "react";
 import type { KeyBinding } from "@codemirror/view";
 import { CellContainer } from "@/components/cell/CellContainer";
 import {
@@ -7,6 +7,8 @@ import {
 } from "@/components/editor/codemirror-editor";
 import { MarkdownOutput } from "@/components/outputs/markdown-output";
 import { Trash2, Pencil } from "lucide-react";
+import { useCellKeyboardNavigation } from "../hooks/useCellKeyboardNavigation";
+import { useEditorRegistry } from "../hooks/useEditorRegistry";
 import type { MarkdownCell as MarkdownCellType } from "../types";
 
 interface MarkdownCellProps {
@@ -15,6 +17,10 @@ interface MarkdownCellProps {
   onFocus: () => void;
   onUpdateSource: (source: string) => void;
   onDelete: () => void;
+  onFocusPrevious?: (cursorPosition: "start" | "end") => void;
+  onFocusNext?: (cursorPosition: "start" | "end") => void;
+  onInsertCellAfter?: () => void;
+  isLastCell?: boolean;
 }
 
 export function MarkdownCell({
@@ -23,9 +29,26 @@ export function MarkdownCell({
   onFocus,
   onUpdateSource,
   onDelete,
+  onFocusPrevious,
+  onFocusNext,
+  onInsertCellAfter,
+  isLastCell = false,
 }: MarkdownCellProps) {
   const [editing, setEditing] = useState(cell.source === "");
   const editorRef = useRef<CodeMirrorEditorRef>(null);
+  const { registerEditor, unregisterEditor } = useEditorRegistry();
+
+  // Register editor with the registry for cross-cell navigation
+  useEffect(() => {
+    if (editing && editorRef.current) {
+      registerEditor(cell.id, {
+        focus: () => editorRef.current?.focus(),
+        setCursorPosition: (position) =>
+          editorRef.current?.setCursorPosition(position),
+      });
+    }
+    return () => unregisterEditor(cell.id);
+  }, [cell.id, editing, registerEditor, unregisterEditor]);
 
   const handleDoubleClick = useCallback(() => {
     setEditing(true);
@@ -37,40 +60,58 @@ export function MarkdownCell({
     }
   }, [cell.source]);
 
-  const keyMap: KeyBinding[] = [
-    {
-      key: "Shift-Enter",
-      run: () => {
-        if (cell.source.trim()) {
-          setEditing(false);
-        }
-        return true;
-      },
+  // Handle focus next, creating a new cell if at the end
+  const handleFocusNextOrCreate = useCallback(
+    (cursorPosition: "start" | "end") => {
+      // For markdown, close edit mode first
+      if (cell.source.trim()) {
+        setEditing(false);
+      }
+      if (isLastCell && onInsertCellAfter) {
+        onInsertCellAfter();
+      } else if (onFocusNext) {
+        onFocusNext(cursorPosition);
+      }
     },
-    {
-      key: "Escape",
-      run: () => {
-        if (cell.source.trim()) {
-          setEditing(false);
-        }
-        return true;
+    [cell.source, isLastCell, onFocusNext, onInsertCellAfter]
+  );
+
+  // Get keyboard navigation bindings
+  const navigationKeyMap = useCellKeyboardNavigation({
+    onFocusPrevious: onFocusPrevious ?? (() => {}),
+    onFocusNext: handleFocusNextOrCreate,
+  });
+
+  // Combine navigation with markdown-specific keys
+  const keyMap: KeyBinding[] = useMemo(
+    () => [
+      ...navigationKeyMap,
+      {
+        key: "Escape",
+        run: () => {
+          if (cell.source.trim()) {
+            setEditing(false);
+          }
+          return true;
+        },
       },
-    },
-  ];
+    ],
+    [navigationKeyMap, cell.source]
+  );
 
   return (
     <CellContainer
       id={cell.id}
+      cellType="markdown"
       isFocused={isFocused}
       onFocus={onFocus}
-      className=""
     >
       {editing ? (
         <>
-          <div className="flex items-center gap-1 px-2 py-1">
+          <div className="flex items-center gap-1 px-2 py-1 pl-4">
             <span className="text-xs text-muted-foreground font-mono">md</span>
             <div className="flex-1" />
-            {isFocused && (
+            <div className="cell-controls opacity-0 group-hover:opacity-100 transition-opacity">
               <button
                 type="button"
                 onClick={onDelete}
@@ -79,9 +120,9 @@ export function MarkdownCell({
               >
                 <Trash2 className="h-3.5 w-3.5" />
               </button>
-            )}
+            </div>
           </div>
-          <div className="px-1">
+          <div className="pl-4 pr-1">
             <CodeMirrorEditor
               ref={editorRef}
               value={cell.source}

--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -108,7 +108,7 @@ export function MarkdownCell({
     >
       {editing ? (
         <>
-          <div className="flex items-center gap-1 px-2 py-1 pl-4">
+          <div className="flex items-center gap-1 px-2 py-1">
             <span className="text-xs text-muted-foreground font-mono">md</span>
             <div className="flex-1" />
             <div className="cell-controls opacity-0 group-hover:opacity-100 transition-opacity">
@@ -122,7 +122,7 @@ export function MarkdownCell({
               </button>
             </div>
           </div>
-          <div className="pl-4 pr-1">
+          <div className="px-2">
             <CodeMirrorEditor
               ref={editorRef}
               value={cell.source}
@@ -138,7 +138,7 @@ export function MarkdownCell({
         </>
       ) : (
         <div
-          className="px-4 py-2 prose prose-sm max-w-none cursor-text relative group/md"
+          className="px-2 py-2 prose prose-sm max-w-none cursor-text relative group/md"
           onDoubleClick={handleDoubleClick}
         >
           {cell.source ? (

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -1,7 +1,9 @@
-import { useCallback, useRef } from "react";
+import { useCallback, useRef, useMemo } from "react";
 import { Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
 import { CodeCell } from "./CodeCell";
 import { MarkdownCell } from "./MarkdownCell";
+import { EditorRegistryProvider, useEditorRegistry } from "../hooks/useEditorRegistry";
 import type { NotebookCell } from "../types";
 
 interface NotebookViewProps {
@@ -24,28 +26,36 @@ function AddCellButtons({
   onAdd: (type: "code" | "markdown", afterCellId?: string | null) => void;
 }) {
   return (
-    <div className="flex items-center justify-center gap-1 py-0.5 opacity-0 hover:opacity-100 focus-within:opacity-100 transition-opacity">
-      <button
-        type="button"
-        onClick={() => onAdd("code", afterCellId)}
-        className="flex items-center gap-0.5 rounded px-2 py-0.5 text-[10px] text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-      >
-        <Plus className="h-2.5 w-2.5" />
-        Code
-      </button>
-      <button
-        type="button"
-        onClick={() => onAdd("markdown", afterCellId)}
-        className="flex items-center gap-0.5 rounded px-2 py-0.5 text-[10px] text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-      >
-        <Plus className="h-2.5 w-2.5" />
-        Markdown
-      </button>
+    <div className="group/betweener relative flex h-6 w-full items-center justify-center">
+      {/* Thin line appears on hover */}
+      <div className="absolute inset-x-0 h-px bg-transparent group-hover/betweener:bg-border transition-colors" />
+
+      {/* Buttons appear on hover */}
+      <div className="flex items-center gap-1 opacity-0 group-hover/betweener:opacity-100 transition-opacity">
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-6 gap-1 px-2 text-xs text-muted-foreground hover:text-foreground"
+          onClick={() => onAdd("code", afterCellId)}
+        >
+          <Plus className="h-3 w-3" />
+          Code
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-6 gap-1 px-2 text-xs text-muted-foreground hover:text-foreground"
+          onClick={() => onAdd("markdown", afterCellId)}
+        >
+          <Plus className="h-3 w-3" />
+          Markdown
+        </Button>
+      </div>
     </div>
   );
 }
 
-export function NotebookView({
+function NotebookViewContent({
   cells,
   focusedCellId,
   executingCellIds,
@@ -57,11 +67,32 @@ export function NotebookView({
   onAddCell,
 }: NotebookViewProps) {
   const containerRef = useRef<HTMLDivElement>(null);
+  const { focusCell } = useEditorRegistry();
+
+  // Memoize cell IDs array
+  const cellIds = useMemo(() => cells.map((c) => c.id), [cells]);
 
   const renderCell = useCallback(
-    (cell: NotebookCell) => {
+    (cell: NotebookCell, index: number) => {
       const isFocused = cell.id === focusedCellId;
       const isExecuting = executingCellIds.has(cell.id);
+
+      // Navigation callbacks
+      const onFocusPrevious = (cursorPosition: "start" | "end") => {
+        if (index > 0) {
+          const prevCellId = cellIds[index - 1];
+          onFocusCell(prevCellId);
+          focusCell(prevCellId, cursorPosition);
+        }
+      };
+
+      const onFocusNext = (cursorPosition: "start" | "end") => {
+        if (index < cellIds.length - 1) {
+          const nextCellId = cellIds[index + 1];
+          onFocusCell(nextCellId);
+          focusCell(nextCellId, cursorPosition);
+        }
+      };
 
       if (cell.cell_type === "code") {
         return (
@@ -75,6 +106,10 @@ export function NotebookView({
             onExecute={() => onExecuteCell(cell.id)}
             onInterrupt={onInterruptKernel}
             onDelete={() => onDeleteCell(cell.id)}
+            onFocusPrevious={onFocusPrevious}
+            onFocusNext={onFocusNext}
+            onInsertCellAfter={() => onAddCell("code", cell.id)}
+            isLastCell={index === cells.length - 1}
           />
         );
       }
@@ -88,6 +123,10 @@ export function NotebookView({
             onFocus={() => onFocusCell(cell.id)}
             onUpdateSource={(source) => onUpdateCellSource(cell.id, source)}
             onDelete={() => onDeleteCell(cell.id)}
+            onFocusPrevious={onFocusPrevious}
+            onFocusNext={onFocusNext}
+            onInsertCellAfter={() => onAddCell("markdown", cell.id)}
+            isLastCell={index === cells.length - 1}
           />
         );
       }
@@ -107,11 +146,15 @@ export function NotebookView({
     [
       focusedCellId,
       executingCellIds,
+      cellIds,
+      cells.length,
       onFocusCell,
       onUpdateCellSource,
       onExecuteCell,
       onInterruptKernel,
       onDeleteCell,
+      onAddCell,
+      focusCell,
     ]
   );
 
@@ -122,22 +165,24 @@ export function NotebookView({
           <p className="text-sm">Empty notebook</p>
           <p className="text-xs mt-1">Add a cell to get started</p>
           <div className="mt-4 flex gap-2">
-            <button
-              type="button"
+            <Button
+              variant="outline"
+              size="sm"
               onClick={() => onAddCell("code")}
-              className="flex items-center gap-1 rounded-md border px-3 py-1.5 text-xs transition-colors hover:bg-muted"
+              className="gap-1"
             >
               <Plus className="h-3 w-3" />
               Code Cell
-            </button>
-            <button
-              type="button"
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
               onClick={() => onAddCell("markdown")}
-              className="flex items-center gap-1 rounded-md border px-3 py-1.5 text-xs transition-colors hover:bg-muted"
+              className="gap-1"
             >
               <Plus className="h-3 w-3" />
               Markdown Cell
-            </button>
+            </Button>
           </div>
         </div>
       ) : (
@@ -147,12 +192,20 @@ export function NotebookView({
               {index === 0 && (
                 <AddCellButtons afterCellId={null} onAdd={onAddCell} />
               )}
-              {renderCell(cell)}
+              {renderCell(cell, index)}
               <AddCellButtons afterCellId={cell.id} onAdd={onAddCell} />
             </div>
           ))}
         </>
       )}
     </div>
+  );
+}
+
+export function NotebookView(props: NotebookViewProps) {
+  return (
+    <EditorRegistryProvider>
+      <NotebookViewContent {...props} />
+    </EditorRegistryProvider>
   );
 }

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -26,30 +26,37 @@ function AddCellButtons({
   onAdd: (type: "code" | "markdown", afterCellId?: string | null) => void;
 }) {
   return (
-    <div className="group/betweener relative flex h-6 w-full items-center justify-center">
-      {/* Thin line appears on hover */}
-      <div className="absolute inset-x-0 h-px bg-transparent group-hover/betweener:bg-border transition-colors" />
-
-      {/* Buttons appear on hover */}
-      <div className="flex items-center gap-1 opacity-0 group-hover/betweener:opacity-100 transition-opacity">
-        <Button
-          variant="ghost"
-          size="sm"
-          className="h-6 gap-1 px-2 text-xs text-muted-foreground hover:text-foreground"
-          onClick={() => onAdd("code", afterCellId)}
-        >
-          <Plus className="h-3 w-3" />
-          Code
-        </Button>
-        <Button
-          variant="ghost"
-          size="sm"
-          className="h-6 gap-1 px-2 text-xs text-muted-foreground hover:text-foreground"
-          onClick={() => onAdd("markdown", afterCellId)}
-        >
-          <Plus className="h-3 w-3" />
-          Markdown
-        </Button>
+    <div className="group/betweener flex h-4 w-full items-center">
+      {/* Gutter spacer - matches cell gutter: action area + ribbon */}
+      <div className="flex-shrink-0 flex h-full">
+        <div className="w-6" />
+        <div className="w-1 bg-gray-200" />
+      </div>
+      {/* Content area with centered buttons */}
+      <div className="flex-1 relative flex items-center justify-center">
+        {/* Thin line appears on hover */}
+        <div className="absolute inset-x-0 h-px bg-transparent group-hover/betweener:bg-border transition-colors" />
+        {/* Buttons appear on hover */}
+        <div className="flex items-center gap-1 opacity-0 group-hover/betweener:opacity-100 transition-opacity z-10 bg-background px-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-5 gap-1 px-2 text-xs text-muted-foreground hover:text-foreground"
+            onClick={() => onAdd("code", afterCellId)}
+          >
+            <Plus className="h-3 w-3" />
+            Code
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-5 gap-1 px-2 text-xs text-muted-foreground hover:text-foreground"
+            onClick={() => onAdd("markdown", afterCellId)}
+          >
+            <Plus className="h-3 w-3" />
+            Markdown
+          </Button>
+        </div>
       </div>
     </div>
   );

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -96,7 +96,7 @@ export function NotebookView({
       return (
         <div
           key={cell.id}
-          className="my-1 rounded border border-border/50 px-4 py-2"
+          className="px-4 py-2"
         >
           <pre className="text-sm text-muted-foreground whitespace-pre-wrap">
             {cell.source}

--- a/apps/notebook/src/hooks/useCellKeyboardNavigation.ts
+++ b/apps/notebook/src/hooks/useCellKeyboardNavigation.ts
@@ -1,0 +1,72 @@
+import type { KeyBinding } from "@codemirror/view";
+
+interface UseCellKeyboardNavigationOptions {
+  onFocusPrevious: (cursorPosition: "start" | "end") => void;
+  onFocusNext: (cursorPosition: "start" | "end") => void;
+  onExecute?: () => void;
+  onExecuteAndInsert?: () => void;
+}
+
+export function useCellKeyboardNavigation({
+  onFocusPrevious,
+  onFocusNext,
+  onExecute,
+  onExecuteAndInsert,
+}: UseCellKeyboardNavigationOptions): KeyBinding[] {
+  return [
+    {
+      key: "ArrowUp",
+      run: (view) => {
+        const { from } = view.state.selection.main;
+        if (from === 0) {
+          onFocusPrevious("end");
+          return true;
+        }
+        return false;
+      },
+    },
+    {
+      key: "ArrowDown",
+      run: (view) => {
+        const { from } = view.state.selection.main;
+        const docLength = view.state.doc.length;
+        if (from === docLength) {
+          onFocusNext("start");
+          return true;
+        }
+        return false;
+      },
+    },
+    ...(onExecute
+      ? [
+          {
+            key: "Shift-Enter",
+            run: () => {
+              onExecute();
+              onFocusNext("start");
+              return true;
+            },
+          },
+          {
+            key: "Mod-Enter",
+            run: () => {
+              onExecute();
+              onFocusNext("start");
+              return true;
+            },
+          },
+        ]
+      : []),
+    ...(onExecuteAndInsert
+      ? [
+          {
+            key: "Alt-Enter",
+            run: () => {
+              onExecuteAndInsert();
+              return true;
+            },
+          },
+        ]
+      : []),
+  ];
+}

--- a/apps/notebook/src/hooks/useEditorRegistry.tsx
+++ b/apps/notebook/src/hooks/useEditorRegistry.tsx
@@ -1,0 +1,70 @@
+import {
+  createContext,
+  useContext,
+  useRef,
+  useCallback,
+  type ReactNode,
+} from "react";
+
+export interface EditorRef {
+  focus: () => void;
+  setCursorPosition: (position: "start" | "end") => void;
+}
+
+interface EditorRegistryContextType {
+  registerEditor: (cellId: string, ref: EditorRef) => void;
+  unregisterEditor: (cellId: string) => void;
+  focusCell: (cellId: string, cursorPosition: "start" | "end") => void;
+}
+
+const EditorRegistryContext = createContext<EditorRegistryContextType | null>(
+  null
+);
+
+export function EditorRegistryProvider({ children }: { children: ReactNode }) {
+  const editorsRef = useRef<Map<string, EditorRef>>(new Map());
+
+  const registerEditor = useCallback((cellId: string, ref: EditorRef) => {
+    editorsRef.current.set(cellId, ref);
+  }, []);
+
+  const unregisterEditor = useCallback((cellId: string) => {
+    editorsRef.current.delete(cellId);
+  }, []);
+
+  const focusCell = useCallback(
+    (cellId: string, cursorPosition: "start" | "end") => {
+      const editor = editorsRef.current.get(cellId);
+      if (editor) {
+        editor.setCursorPosition(cursorPosition);
+        editor.focus();
+        // Scroll the cell into view
+        const cellElement = document.querySelector(
+          `[data-cell-id="${cellId}"]`
+        );
+        if (cellElement) {
+          cellElement.scrollIntoView({ behavior: "smooth", block: "nearest" });
+        }
+      }
+    },
+    []
+  );
+
+  return (
+    <EditorRegistryContext.Provider
+      value={{ registerEditor, unregisterEditor, focusCell }}
+    >
+      {children}
+    </EditorRegistryContext.Provider>
+  );
+}
+
+export function useEditorRegistry() {
+  const context = useContext(EditorRegistryContext);
+  if (!context) {
+    throw new Error(
+      "useEditorRegistry must be used within EditorRegistryProvider"
+    );
+  }
+  return context;
+}

--- a/crates/notebook/tauri.conf.json
+++ b/crates/notebook/tauri.conf.json
@@ -4,8 +4,10 @@
   "version": "0.1.0",
   "identifier": "com.runtimed.notebook",
   "build": {
+    "devUrl": "http://localhost:5174",
     "frontendDist": "../../apps/notebook/dist",
-    "beforeBuildCommand": "pnpm --dir ../../apps/notebook build"
+    "beforeDevCommand": "pnpm --dir apps/notebook dev",
+    "beforeBuildCommand": "pnpm --dir apps/notebook build"
   },
   "app": {
     "windows": [

--- a/src/components/cell/CellContainer.tsx
+++ b/src/components/cell/CellContainer.tsx
@@ -3,6 +3,7 @@ import { cn } from "@/lib/utils";
 
 interface CellContainerProps {
   id: string;
+  cellType?: "code" | "markdown";
   isFocused?: boolean;
   onFocus?: () => void;
   children: ReactNode;
@@ -10,14 +11,31 @@ interface CellContainerProps {
   onDragOver?: (e: React.DragEvent) => void;
   onDrop?: (e: React.DragEvent) => void;
   className?: string;
-  focusBgColor?: string;
-  focusBorderColor?: string;
 }
+
+const getCellStyling = (cellType?: "code" | "markdown") => {
+  switch (cellType) {
+    case "markdown":
+      return {
+        focusBgColor: "bg-amber-50",
+        focusBorderColor: "border-l-amber-400",
+        hoverBorderColor: "hover:border-l-amber-300",
+      };
+    case "code":
+    default:
+      return {
+        focusBgColor: "bg-gray-50",
+        focusBorderColor: "border-l-gray-900",
+        hoverBorderColor: "hover:border-l-gray-400",
+      };
+  }
+};
 
 export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
   (
     {
       id,
+      cellType,
       isFocused = false,
       onFocus,
       children,
@@ -25,11 +43,11 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
       onDragOver,
       onDrop,
       className,
-      focusBgColor = "",
-      focusBorderColor = "border-l-primary",
     },
     ref,
   ) => {
+    const { focusBgColor, focusBorderColor, hoverBorderColor } = getCellStyling(cellType);
+
     return (
       <div
         ref={ref}
@@ -39,7 +57,7 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
           "cell-container group relative border-l-2 transition-all duration-200",
           isFocused
             ? [focusBgColor, focusBorderColor]
-            : "border-l-transparent",
+            : ["border-l-transparent", hoverBorderColor],
           className,
         )}
         onMouseDown={onFocus}

--- a/src/components/cell/CellContainer.tsx
+++ b/src/components/cell/CellContainer.tsx
@@ -7,27 +7,31 @@ interface CellContainerProps {
   isFocused?: boolean;
   onFocus?: () => void;
   children: ReactNode;
+  /** Content to render in the gutter (e.g., play button) */
+  gutterContent?: ReactNode;
   onDragStart?: (e: React.DragEvent) => void;
   onDragOver?: (e: React.DragEvent) => void;
   onDrop?: (e: React.DragEvent) => void;
   className?: string;
 }
 
-const getCellStyling = (cellType?: "code" | "markdown") => {
+const getGutterColor = (cellType?: "code" | "markdown", isFocused?: boolean) => {
   switch (cellType) {
     case "markdown":
-      return {
-        focusBgColor: "bg-amber-50",
-        focusBorderColor: "border-l-amber-400",
-        hoverBorderColor: "hover:border-l-amber-300",
-      };
+      return isFocused ? "bg-amber-400" : "bg-amber-200";
     case "code":
     default:
-      return {
-        focusBgColor: "bg-gray-50",
-        focusBorderColor: "border-l-gray-900",
-        hoverBorderColor: "hover:border-l-gray-400",
-      };
+      return isFocused ? "bg-gray-400" : "bg-gray-200";
+  }
+};
+
+const getFocusBgColor = (cellType?: "code" | "markdown") => {
+  switch (cellType) {
+    case "markdown":
+      return "bg-amber-50/50";
+    case "code":
+    default:
+      return "bg-gray-50/50";
   }
 };
 
@@ -39,6 +43,7 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
       isFocused = false,
       onFocus,
       children,
+      gutterContent,
       onDragStart,
       onDragOver,
       onDrop,
@@ -46,7 +51,8 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
     },
     ref,
   ) => {
-    const { focusBgColor, focusBorderColor, hoverBorderColor } = getCellStyling(cellType);
+    const gutterColor = getGutterColor(cellType, isFocused);
+    const focusBgColor = getFocusBgColor(cellType);
 
     return (
       <div
@@ -54,10 +60,8 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
         data-slot="cell-container"
         data-cell-id={id}
         className={cn(
-          "cell-container group relative border-l-2 transition-all duration-200",
-          isFocused
-            ? [focusBgColor, focusBorderColor]
-            : ["border-l-transparent", hoverBorderColor],
+          "cell-container group flex transition-colors duration-150",
+          isFocused && focusBgColor,
           className,
         )}
         onMouseDown={onFocus}
@@ -66,7 +70,24 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
         onDragOver={onDragOver}
         onDrop={onDrop}
       >
-        {children}
+        {/* Gutter area: action button + thin ribbon */}
+        <div className="flex-shrink-0 flex">
+          {/* Action button area (play button for code cells) */}
+          <div className="w-6 flex items-start justify-center pt-1.5">
+            {gutterContent}
+          </div>
+          {/* Thin ribbon */}
+          <div
+            className={cn(
+              "w-1 transition-colors duration-150",
+              gutterColor,
+            )}
+          />
+        </div>
+        {/* Cell content */}
+        <div className="flex-1 min-w-0">
+          {children}
+        </div>
       </div>
     );
   },

--- a/src/components/cell/CellContainer.tsx
+++ b/src/components/cell/CellContainer.tsx
@@ -25,8 +25,8 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
       onDragOver,
       onDrop,
       className,
-      focusBgColor = "bg-primary/5",
-      focusBorderColor = "border-primary/60",
+      focusBgColor = "",
+      focusBorderColor = "border-l-primary",
     },
     ref,
   ) => {
@@ -36,10 +36,10 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
         data-slot="cell-container"
         data-cell-id={id}
         className={cn(
-          "cell-container group relative border-2 transition-all duration-200",
+          "cell-container group relative border-l-2 transition-all duration-200",
           isFocused
             ? [focusBgColor, focusBorderColor]
-            : "border-transparent hover:bg-muted/10",
+            : "border-l-transparent",
           className,
         )}
         onMouseDown={onFocus}

--- a/src/components/cell/PlayButton.tsx
+++ b/src/components/cell/PlayButton.tsx
@@ -41,7 +41,7 @@ export const PlayButton: React.FC<PlayButtonProps> = ({
           ? "text-destructive hover:text-destructive animate-pulse"
           : isFocused
             ? focusedClass
-            : "text-muted-foreground/50 hover:text-foreground group-hover:text-muted-foreground",
+            : "text-transparent group-hover:text-muted-foreground hover:text-foreground",
         isAutoLaunching && "cursor-wait opacity-75",
         className,
       )}

--- a/src/components/cell/PlayButton.tsx
+++ b/src/components/cell/PlayButton.tsx
@@ -36,28 +36,27 @@ export const PlayButton: React.FC<PlayButtonProps> = ({
       onClick={isRunning ? onInterrupt : onExecute}
       disabled={isAutoLaunching}
       className={cn(
-        "hover:bg-muted/80 flex items-center justify-center rounded-sm bg-background p-1 transition-colors",
+        "flex items-center justify-center transition-all",
         isRunning
-          ? "text-destructive hover:text-destructive shadow-destructive/20 animate-pulse drop-shadow-sm"
+          ? "text-destructive hover:text-destructive animate-pulse"
           : isFocused
             ? focusedClass
-            : "text-muted-foreground/40 hover:text-foreground group-hover:text-foreground",
+            : "text-muted-foreground/50 hover:text-foreground group-hover:text-muted-foreground",
         isAutoLaunching && "cursor-wait opacity-75",
         className,
       )}
       title={title}
     >
       {isAutoLaunching ? (
-        <Loader2 className="size-4 animate-spin" />
+        <Loader2 className="size-3 animate-spin" />
       ) : isRunning ? (
         <Square
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          className="size-4"
+          fill="currentColor"
+          stroke="none"
+          className="size-2.5"
         />
       ) : (
-        <Play fill="currentColor" className="size-4" />
+        <Play fill="currentColor" stroke="none" className="size-3 translate-x-[1px]" />
       )}
     </button>
   );


### PR DESCRIPTION
## Summary

Completely redesigned the notebook interface to feel cleaner and more like Google Colab. Replaced the stocky card design with a paper-like aesthetic featuring a continuous left-side gutter ribbon.

## Key Changes

- **Gutter ribbon system**: Each cell displays a thin colored ribbon on the left that changes color by cell type (gray for code, amber for markdown)
- **Smart play button**: Positioned in the gutter action area, visible when focused or on cell hover, hidden otherwise
- **Simplified cell design**: Removed execution metadata lines ("Executed") for a more focused interface
- **Keyboard navigation**: Added smart cell navigation with Shift-Enter creating new cells at the end
- **Duplicate output fix**: Fixed React StrictMode causing duplicate outputs via callback ref pattern

## Testing

- Play button appears/disappears correctly based on focus state
- Gutter ribbon color changes per cell type
- Keyboard navigation works between cells
- New cells created automatically when needed