### PR TITLE
Update README: use cargo tauri dev with -p flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Both apps share components from `src/`. Changes there are reflected in both.
 
 ```bash
 # Notebook UI with hot reload (runs Vite dev server + Tauri)
-cd crates/notebook && cargo tauri dev
+cargo tauri dev -- -p notebook
 
 # Sidecar UI dev server (for styling/component work)
 pnpm --dir apps/sidecar dev


### PR DESCRIPTION
Simplifies the notebook development workflow by allowing developers to run the dev command from the repo root instead of requiring a directory change to crates/notebook.

The `-p notebook` flag specifies which workspace package to develop, making the command clearer and more convenient.