### PR TITLE
Fix dependency management kernel detection

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -50,6 +50,7 @@ function AppContent() {
     hasDependencies,
     loading: depsLoading,
     syncedWhileRunning,
+    needsKernelRestart,
     addDependency,
     removeDependency,
   } = useDependencies();
@@ -153,6 +154,7 @@ function AppContent() {
           uvAvailable={uvAvailable}
           loading={depsLoading}
           syncedWhileRunning={syncedWhileRunning}
+          needsKernelRestart={needsKernelRestart}
           onAdd={addDependency}
           onRemove={removeDependency}
         />

--- a/apps/notebook/src/components/DependencyHeader.tsx
+++ b/apps/notebook/src/components/DependencyHeader.tsx
@@ -7,6 +7,7 @@ interface DependencyHeaderProps {
   uvAvailable: boolean | null;
   loading: boolean;
   syncedWhileRunning: boolean;
+  needsKernelRestart: boolean;
   onAdd: (pkg: string) => Promise<void>;
   onRemove: (pkg: string) => Promise<void>;
 }
@@ -17,6 +18,7 @@ export function DependencyHeader({
   uvAvailable,
   loading,
   syncedWhileRunning,
+  needsKernelRestart,
   onAdd,
   onRemove,
 }: DependencyHeaderProps) {
@@ -49,6 +51,17 @@ export function DependencyHeader({
               <span>
                 Dependencies synced to environment. New packages can be imported
                 now. Restart kernel if you updated existing packages.
+              </span>
+            </div>
+          )}
+
+          {/* Kernel restart needed notice */}
+          {needsKernelRestart && (
+            <div className="mb-3 flex items-start gap-2 rounded bg-amber-500/10 px-2 py-1.5 text-xs text-amber-700">
+              <Info className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+              <span>
+                Restart kernel to use these dependencies. The current kernel
+                wasn&apos;t started with dependency management.
               </span>
             </div>
           )}

--- a/apps/notebook/src/hooks/useKernel.ts
+++ b/apps/notebook/src/hooks/useKernel.ts
@@ -191,6 +191,7 @@ export function useKernel({
       try {
         // If useUv is explicitly requested, use uv-managed kernel
         if (opts?.useUv) {
+          console.log("[kernel] useUv explicitly requested");
           await startKernelWithUv();
           return;
         }
@@ -201,23 +202,29 @@ export function useKernel({
         );
         const uvAvailable = await invoke<boolean>("check_uv_available");
 
+        console.log("[kernel] deps check:", { deps, uvAvailable });
+
         if (deps && deps.dependencies.length > 0 && uvAvailable) {
           // Use uv-managed kernel for notebooks with dependencies
+          console.log("[kernel] starting uv-managed kernel with deps:", deps.dependencies);
           await startKernelWithUv();
           return;
         }
 
         // Fall back to system kernelspec
+        console.log("[kernel] falling back to system kernelspec");
         const preferred = await invoke<string | null>(
           "get_preferred_kernelspec"
         );
         if (preferred) {
+          console.log("[kernel] using preferred kernelspec:", preferred);
           await startKernel(preferred);
           return;
         }
         // Fall back to first available kernelspec
         const specs = await listKernelspecs();
         if (specs.length > 0) {
+          console.log("[kernel] using first available kernelspec:", specs[0].name);
           await startKernel(specs[0].name);
         }
       } finally {

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -333,6 +333,15 @@ async fn start_kernel_with_uv(
         .map_err(|e| e.to_string())
 }
 
+/// Check if a kernel is currently running.
+#[tauri::command]
+async fn is_kernel_running(
+    kernel_state: tauri::State<'_, tokio::sync::Mutex<NotebookKernel>>,
+) -> Result<bool, String> {
+    let kernel = kernel_state.lock().await;
+    Ok(kernel.is_running())
+}
+
 /// Check if the running kernel has a uv-managed environment.
 #[tauri::command]
 async fn kernel_has_uv_env(
@@ -430,6 +439,7 @@ pub fn run(notebook_path: Option<PathBuf>) -> anyhow::Result<()> {
             add_dependency,
             remove_dependency,
             start_kernel_with_uv,
+            is_kernel_running,
             kernel_has_uv_env,
             sync_kernel_dependencies,
         ])


### PR DESCRIPTION
## Summary

Fixes the uv dependency management feature to properly detect when a kernel is running. Previously, the app would show a "restart kernel" warning even on fresh notebooks without a running kernel.

## Changes

- Add `is_kernel_running` command to distinguish between "no kernel" vs "kernel without uv"
- Only show restart warning when kernel is actually running but not uv-managed
- Add console logging to trace kernel selection logic for debugging
- Improve dependency sync logic with better state management

## How It Works

When adding dependencies:
- **No kernel running** → deps saved, will be used when kernel starts (no warning)
- **Kernel running with uv** → deps synced to environment (blue notice)
- **Kernel running without uv** → shows amber "restart needed" warning