### PR TITLE
Add dark/light/system theme support to notebook

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -8,6 +8,7 @@ import { useNotebook } from "./hooks/useNotebook";
 import { useKernel } from "./hooks/useKernel";
 import { useDependencies } from "./hooks/useDependencies";
 import { useCondaDependencies } from "./hooks/useCondaDependencies";
+import { useTheme } from "@/hooks/useTheme";
 import { WidgetStoreProvider, useWidgetStoreRequired } from "@/components/widgets/widget-store-context";
 import { MediaProvider } from "@/components/outputs/media-provider";
 import { WidgetView } from "@/components/widgets/widget-view";
@@ -39,6 +40,8 @@ function AppContent() {
     appendOutput,
     setExecutionCount,
   } = useNotebook();
+
+  const { theme, setTheme } = useTheme("notebook-theme");
 
   const [executingCellIds, setExecutingCellIds] = useState<Set<string>>(
     new Set()
@@ -174,6 +177,8 @@ function AppContent() {
         kernelStatus={kernelStatus}
         dirty={dirty}
         hasDependencies={hasDependencies}
+        theme={theme}
+        onThemeChange={setTheme}
         onSave={save}
         onStartKernel={handleStartKernel}
         onInterruptKernel={interruptKernel}

--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -101,7 +101,7 @@ export function CodeCell({
       onExecute={handleExecute}
       onInterrupt={onInterrupt}
       className="h-4 w-4"
-      focusedClass="text-gray-700"
+      focusedClass="text-gray-700 dark:text-gray-300"
     />
   );
 

--- a/apps/notebook/src/components/CondaDependencyHeader.tsx
+++ b/apps/notebook/src/components/CondaDependencyHeader.tsx
@@ -87,7 +87,7 @@ export function CondaDependencyHeader({
 
         {/* Sync notice */}
         {syncedWhileRunning && (
-          <div className="mb-3 flex items-start gap-2 rounded bg-blue-500/10 px-2 py-1.5 text-xs text-blue-700">
+          <div className="mb-3 flex items-start gap-2 rounded bg-blue-500/10 px-2 py-1.5 text-xs text-blue-700 dark:text-blue-400">
             <Info className="h-3.5 w-3.5 mt-0.5 shrink-0" />
             <span>
               Dependencies synced to environment. New packages can be imported
@@ -98,7 +98,7 @@ export function CondaDependencyHeader({
 
         {/* Kernel restart needed notice */}
         {needsKernelRestart && (
-          <div className="mb-3 flex items-start gap-2 rounded bg-amber-500/10 px-2 py-1.5 text-xs text-amber-700">
+          <div className="mb-3 flex items-start gap-2 rounded bg-amber-500/10 px-2 py-1.5 text-xs text-amber-700 dark:text-amber-400">
             <Info className="h-3.5 w-3.5 mt-0.5 shrink-0" />
             <span>
               Restart kernel to use these dependencies. Conda environments

--- a/apps/notebook/src/components/DependencyHeader.tsx
+++ b/apps/notebook/src/components/DependencyHeader.tsx
@@ -46,7 +46,7 @@ export function DependencyHeader({
       <div className="px-3 py-3">
           {/* Sync notice */}
           {syncedWhileRunning && (
-            <div className="mb-3 flex items-start gap-2 rounded bg-blue-500/10 px-2 py-1.5 text-xs text-blue-700">
+            <div className="mb-3 flex items-start gap-2 rounded bg-blue-500/10 px-2 py-1.5 text-xs text-blue-700 dark:text-blue-400">
               <Info className="h-3.5 w-3.5 mt-0.5 shrink-0" />
               <span>
                 Dependencies synced to environment. New packages can be imported
@@ -57,7 +57,7 @@ export function DependencyHeader({
 
           {/* Kernel restart needed notice */}
           {needsKernelRestart && (
-            <div className="mb-3 flex items-start gap-2 rounded bg-amber-500/10 px-2 py-1.5 text-xs text-amber-700">
+            <div className="mb-3 flex items-start gap-2 rounded bg-amber-500/10 px-2 py-1.5 text-xs text-amber-700 dark:text-amber-400">
               <Info className="h-3.5 w-3.5 mt-0.5 shrink-0" />
               <span>
                 Restart kernel to use these dependencies. The current kernel
@@ -68,7 +68,7 @@ export function DependencyHeader({
 
           {/* UV availability notice */}
           {uvAvailable === false && (
-            <div className="mb-3 rounded bg-amber-500/10 px-2 py-1.5 text-xs text-amber-700">
+            <div className="mb-3 rounded bg-amber-500/10 px-2 py-1.5 text-xs text-amber-700 dark:text-amber-400">
               <span className="font-medium">uv not found.</span> Install it with{" "}
               <code className="rounded bg-amber-500/20 px-1">
                 curl -LsSf https://astral.sh/uv/install.sh | sh

--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -1,12 +1,20 @@
 import { useCallback, useEffect, useState } from "react";
-import { Save, Play, Square, Plus, Package } from "lucide-react";
+import { Save, Play, Square, Plus, Package, Settings, Sun, Moon, Monitor } from "lucide-react";
 import { cn } from "@/lib/utils";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import type { ThemeMode } from "@/hooks/useTheme";
 import type { KernelspecInfo } from "../types";
 
 interface NotebookToolbarProps {
   kernelStatus: string;
   dirty: boolean;
   hasDependencies: boolean;
+  theme: ThemeMode;
+  onThemeChange: (theme: ThemeMode) => void;
   onSave: () => void;
   onStartKernel: (name: string) => void;
   onInterruptKernel: () => void;
@@ -15,10 +23,18 @@ interface NotebookToolbarProps {
   listKernelspecs: () => Promise<KernelspecInfo[]>;
 }
 
+const themeOptions: { value: ThemeMode; label: string; icon: typeof Sun }[] = [
+  { value: "light", label: "Light", icon: Sun },
+  { value: "dark", label: "Dark", icon: Moon },
+  { value: "system", label: "System", icon: Monitor },
+];
+
 export function NotebookToolbar({
   kernelStatus,
   dirty,
   hasDependencies,
+  theme,
+  onThemeChange,
   onSave,
   onStartKernel,
   onInterruptKernel,
@@ -27,6 +43,7 @@ export function NotebookToolbar({
   listKernelspecs,
 }: NotebookToolbarProps) {
   const [kernelspecs, setKernelspecs] = useState<KernelspecInfo[]>([]);
+  const [settingsOpen, setSettingsOpen] = useState(false);
 
   useEffect(() => {
     listKernelspecs().then(setKernelspecs);
@@ -49,105 +66,154 @@ export function NotebookToolbar({
     kernelStatus === "starting";
 
   return (
-    <header className="sticky top-0 z-10 border-b bg-background/95 backdrop-blur supports-backdrop-filter:bg-background/60">
-      <div className="flex h-10 items-center gap-2 px-3">
-        {/* Save */}
-        <button
-          type="button"
-          onClick={onSave}
-          className={cn(
-            "flex items-center gap-1 rounded px-2 py-1 text-xs transition-colors hover:bg-muted",
-            dirty
-              ? "text-foreground"
-              : "text-muted-foreground"
-          )}
-          title="Save (Cmd+S)"
-        >
-          <Save className="h-3.5 w-3.5" />
-          {dirty && <span className="text-[10px]">&bull;</span>}
-        </button>
-
-        <div className="h-4 w-px bg-border" />
-
-        {/* Add cells */}
-        <button
-          type="button"
-          onClick={() => onAddCell("code")}
-          className="flex items-center gap-1 rounded px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-          title="Add code cell"
-        >
-          <Plus className="h-3 w-3" />
-          Code
-        </button>
-        <button
-          type="button"
-          onClick={() => onAddCell("markdown")}
-          className="flex items-center gap-1 rounded px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-          title="Add markdown cell"
-        >
-          <Plus className="h-3 w-3" />
-          Markdown
-        </button>
-
-        <div className="h-4 w-px bg-border" />
-
-        {/* Dependencies */}
-        <button
-          type="button"
-          onClick={onToggleDependencies}
-          className={cn(
-            "flex items-center gap-1 rounded px-2 py-1 text-xs transition-colors hover:bg-muted",
-            hasDependencies ? "text-foreground" : "text-muted-foreground"
-          )}
-          title="Manage dependencies"
-        >
-          <Package className="h-3.5 w-3.5" />
-          Deps
-        </button>
-
-        <div className="flex-1" />
-
-        {/* Kernel controls */}
-        {!isKernelRunning ? (
+    <Collapsible open={settingsOpen} onOpenChange={setSettingsOpen}>
+      <header className="sticky top-0 z-10 border-b bg-background/95 backdrop-blur supports-backdrop-filter:bg-background/60">
+        <div className="flex h-10 items-center gap-2 px-3">
+          {/* Save */}
           <button
             type="button"
-            onClick={handleStartKernel}
-            disabled={kernelspecs.length === 0}
-            className="flex items-center gap-1 rounded px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:opacity-50"
-            title="Start kernel"
-          >
-            <Play className="h-3 w-3" fill="currentColor" />
-            Start Kernel
-          </button>
-        ) : (
-          <button
-            type="button"
-            onClick={onInterruptKernel}
-            className="flex items-center gap-1 rounded px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-            title="Interrupt kernel"
-          >
-            <Square className="h-3 w-3" />
-            Interrupt
-          </button>
-        )}
-
-        {/* Kernel status */}
-        <div className="flex items-center gap-1.5">
-          <div
+            onClick={onSave}
             className={cn(
-              "h-2 w-2 rounded-full",
-              kernelStatus === "idle" && "bg-green-500",
-              kernelStatus === "busy" && "bg-amber-500",
-              kernelStatus === "starting" && "bg-blue-500 animate-pulse",
-              kernelStatus === "not started" && "bg-gray-400",
-              kernelStatus === "error" && "bg-red-500"
+              "flex items-center gap-1 rounded px-2 py-1 text-xs transition-colors hover:bg-muted",
+              dirty ? "text-foreground" : "text-muted-foreground"
             )}
-          />
-          <span className="text-xs text-muted-foreground capitalize">
-            {kernelStatus}
-          </span>
+            title="Save (Cmd+S)"
+          >
+            <Save className="h-3.5 w-3.5" />
+            {dirty && <span className="text-[10px]">&bull;</span>}
+          </button>
+
+          <div className="h-4 w-px bg-border" />
+
+          {/* Add cells */}
+          <button
+            type="button"
+            onClick={() => onAddCell("code")}
+            className="flex items-center gap-1 rounded px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            title="Add code cell"
+          >
+            <Plus className="h-3 w-3" />
+            Code
+          </button>
+          <button
+            type="button"
+            onClick={() => onAddCell("markdown")}
+            className="flex items-center gap-1 rounded px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            title="Add markdown cell"
+          >
+            <Plus className="h-3 w-3" />
+            Markdown
+          </button>
+
+          <div className="h-4 w-px bg-border" />
+
+          {/* Dependencies */}
+          <button
+            type="button"
+            onClick={onToggleDependencies}
+            className={cn(
+              "flex items-center gap-1 rounded px-2 py-1 text-xs transition-colors hover:bg-muted",
+              hasDependencies ? "text-foreground" : "text-muted-foreground"
+            )}
+            title="Manage dependencies"
+          >
+            <Package className="h-3.5 w-3.5" />
+            Deps
+          </button>
+
+          <div className="flex-1" />
+
+          {/* Kernel controls */}
+          {!isKernelRunning ? (
+            <button
+              type="button"
+              onClick={handleStartKernel}
+              disabled={kernelspecs.length === 0}
+              className="flex items-center gap-1 rounded px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:opacity-50"
+              title="Start kernel"
+            >
+              <Play className="h-3 w-3" fill="currentColor" />
+              Start Kernel
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={onInterruptKernel}
+              className="flex items-center gap-1 rounded px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+              title="Interrupt kernel"
+            >
+              <Square className="h-3 w-3" />
+              Interrupt
+            </button>
+          )}
+
+          {/* Kernel status */}
+          <div className="flex items-center gap-1.5">
+            <div
+              className={cn(
+                "h-2 w-2 rounded-full",
+                kernelStatus === "idle" && "bg-green-500",
+                kernelStatus === "busy" && "bg-amber-500",
+                kernelStatus === "starting" && "bg-blue-500 animate-pulse",
+                kernelStatus === "not started" && "bg-gray-400 dark:bg-gray-500",
+                kernelStatus === "error" && "bg-red-500"
+              )}
+            />
+            <span className="text-xs text-muted-foreground capitalize">
+              {kernelStatus}
+            </span>
+          </div>
+
+          <div className="h-4 w-px bg-border" />
+
+          {/* Settings gear */}
+          <CollapsibleTrigger asChild>
+            <button
+              type="button"
+              className={cn(
+                "flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground",
+                settingsOpen && "bg-muted text-foreground"
+              )}
+              aria-label="Settings"
+            >
+              <Settings className="h-4 w-4" />
+            </button>
+          </CollapsibleTrigger>
         </div>
-      </div>
-    </header>
+
+        {/* Collapsible settings panel */}
+        <CollapsibleContent>
+          <div className="border-t bg-background px-4 py-3">
+            <div className="flex items-center gap-3">
+              <span className="text-xs font-medium text-muted-foreground">
+                Theme
+              </span>
+              <div className="flex items-center gap-1 rounded-md border bg-muted/50 p-0.5">
+                {themeOptions.map((option) => {
+                  const Icon = option.icon;
+                  const isActive = theme === option.value;
+                  return (
+                    <button
+                      key={option.value}
+                      type="button"
+                      onClick={() => onThemeChange(option.value)}
+                      className={cn(
+                        "flex items-center gap-1.5 rounded-sm px-2.5 py-1 text-xs transition-colors",
+                        isActive
+                          ? "bg-background text-foreground shadow-sm"
+                          : "text-muted-foreground hover:text-foreground"
+                      )}
+                    >
+                      <Icon className="h-3.5 w-3.5" />
+                      {option.label}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+        </CollapsibleContent>
+      </header>
+    </Collapsible>
   );
 }

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -30,7 +30,7 @@ function AddCellButtons({
       {/* Gutter spacer - matches cell gutter: action area + ribbon */}
       <div className="flex-shrink-0 flex h-full">
         <div className="w-6" />
-        <div className="w-1 bg-gray-200" />
+        <div className="w-1 bg-gray-200 dark:bg-gray-700" />
       </div>
       {/* Content area with centered buttons */}
       <div className="flex-1 relative flex items-center justify-center">

--- a/apps/sidecar/src/App.tsx
+++ b/apps/sidecar/src/App.tsx
@@ -38,7 +38,7 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
-import { useTheme } from "~/hooks/use-theme";
+import { useTheme } from "@/hooks/useTheme";
 import { SettingsPanel } from "~/components/settings-panel";
 
 function getStatusColorClass(status: string): string {
@@ -123,7 +123,7 @@ function AppContent() {
   const pendingClearRef = useRef<Set<string>>(new Set());
   const widgetPendingClearsRef = useRef(new Set<string>());
   const { handleMessage: handleWidgetMessage, store } = useWidgetStoreRequired();
-  const { theme, setTheme } = useTheme();
+  const { theme, setTheme } = useTheme("sidecar-theme");
   const [settingsOpen, setSettingsOpen] = useState(false);
   const handleClearAllOutputs = useCallback(() => {
     setOutputs([]);

--- a/apps/sidecar/src/components/settings-panel.tsx
+++ b/apps/sidecar/src/components/settings-panel.tsx
@@ -1,5 +1,5 @@
 import { Sun, Moon, Monitor, Trash2 } from "lucide-react";
-import type { ThemeMode } from "~/hooks/use-theme";
+import type { ThemeMode } from "@/hooks/useTheme";
 import { cn } from "@/lib/utils";
 
 interface SettingsPanelProps {

--- a/src/components/cell/CellContainer.tsx
+++ b/src/components/cell/CellContainer.tsx
@@ -18,20 +18,24 @@ interface CellContainerProps {
 const getGutterColor = (cellType?: "code" | "markdown", isFocused?: boolean) => {
   switch (cellType) {
     case "markdown":
-      return isFocused ? "bg-amber-400" : "bg-amber-200";
+      return isFocused
+        ? "bg-amber-400 dark:bg-amber-500"
+        : "bg-amber-200 dark:bg-amber-700";
     case "code":
     default:
-      return isFocused ? "bg-gray-400" : "bg-gray-200";
+      return isFocused
+        ? "bg-gray-400 dark:bg-gray-500"
+        : "bg-gray-200 dark:bg-gray-700";
   }
 };
 
 const getFocusBgColor = (cellType?: "code" | "markdown") => {
   switch (cellType) {
     case "markdown":
-      return "bg-amber-50/50";
+      return "bg-amber-50/50 dark:bg-amber-900/20";
     case "code":
     default:
-      return "bg-gray-50/50";
+      return "bg-gray-50/50 dark:bg-gray-800/30";
   }
 };
 

--- a/src/components/ui/theme-toggle.tsx
+++ b/src/components/ui/theme-toggle.tsx
@@ -1,0 +1,51 @@
+import { Sun, Moon, Monitor } from "lucide-react";
+import type { ThemeMode } from "@/hooks/useTheme";
+import { cn } from "@/lib/utils";
+
+interface ThemeToggleProps {
+  theme: ThemeMode;
+  onThemeChange: (theme: ThemeMode) => void;
+  className?: string;
+}
+
+const themeOptions: { value: ThemeMode; icon: typeof Sun; label: string }[] = [
+  { value: "light", icon: Sun, label: "Light theme" },
+  { value: "dark", icon: Moon, label: "Dark theme" },
+  { value: "system", icon: Monitor, label: "System theme" },
+];
+
+export function ThemeToggle({
+  theme,
+  onThemeChange,
+  className,
+}: ThemeToggleProps) {
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-0.5 rounded-md border bg-muted/50 p-0.5",
+        className,
+      )}
+    >
+      {themeOptions.map((option) => {
+        const Icon = option.icon;
+        const isActive = theme === option.value;
+        return (
+          <button
+            key={option.value}
+            type="button"
+            onClick={() => onThemeChange(option.value)}
+            className={cn(
+              "flex items-center justify-center rounded-sm p-1 transition-colors",
+              isActive
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground hover:text-foreground",
+            )}
+            title={option.label}
+          >
+            <Icon className="h-3.5 w-3.5" />
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -2,11 +2,9 @@ import { useState, useEffect, useCallback } from "react";
 
 export type ThemeMode = "light" | "dark" | "system";
 
-const STORAGE_KEY = "sidecar-theme";
-
-function getStoredTheme(): ThemeMode {
+function getStoredTheme(storageKey: string): ThemeMode {
   try {
-    const stored = localStorage.getItem(STORAGE_KEY);
+    const stored = localStorage.getItem(storageKey);
     if (stored === "light" || stored === "dark" || stored === "system") {
       return stored;
     }
@@ -34,20 +32,25 @@ function applyThemeToDOM(resolved: "light" | "dark") {
   }
 }
 
-export function useTheme() {
-  const [theme, setThemeState] = useState<ThemeMode>(getStoredTheme);
+export function useTheme(storageKey = "theme") {
+  const [theme, setThemeState] = useState<ThemeMode>(() =>
+    getStoredTheme(storageKey),
+  );
   const [resolvedTheme, setResolvedTheme] = useState<"light" | "dark">(() =>
-    resolveTheme(getStoredTheme()),
+    resolveTheme(getStoredTheme(storageKey)),
   );
 
-  const setTheme = useCallback((newTheme: ThemeMode) => {
-    setThemeState(newTheme);
-    try {
-      localStorage.setItem(STORAGE_KEY, newTheme);
-    } catch {
-      // ignore
-    }
-  }, []);
+  const setTheme = useCallback(
+    (newTheme: ThemeMode) => {
+      setThemeState(newTheme);
+      try {
+        localStorage.setItem(storageKey, newTheme);
+      } catch {
+        // ignore
+      }
+    },
+    [storageKey],
+  );
 
   useEffect(() => {
     const resolved = resolveTheme(theme);


### PR DESCRIPTION
Adds full theme support to the notebook app matching Sidecar's implementation.

**Changes:**
- Moved theme hook to shared `src/hooks/useTheme.ts` for code reuse
- Added collapsible settings panel in notebook toolbar with gear icon
- Theme options: Light, Dark, System (auto-detects OS preference)
- Fixed hardcoded colors throughout notebook UI for dark mode support
- Both apps now share the same theme management logic and storage patterns

Theme persists across sessions and responds to system preference changes in real-time.