### PR TITLE
Implement Jupyter page payload support for introspection

### DIFF
--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -4,6 +4,7 @@ import { CellContainer } from "@/components/cell/CellContainer";
 import { PlayButton } from "@/components/cell/PlayButton";
 import { ExecutionCount } from "@/components/cell/ExecutionCount";
 import { OutputArea } from "@/components/cell/OutputArea";
+import { AnsiOutput } from "@/components/outputs/ansi-output";
 import {
   CodeMirrorEditor,
   type CodeMirrorEditorRef,
@@ -15,12 +16,6 @@ import { useEditorRegistry } from "../hooks/useEditorRegistry";
 import type { CodeCell as CodeCellType } from "../types";
 import type { CellPagePayload } from "../App";
 import type { MimeBundle } from "../hooks/useKernel";
-
-/** Strip ANSI escape codes from text */
-function stripAnsi(text: string): string {
-  // eslint-disable-next-line no-control-regex
-  return text.replace(/\x1b\[[0-9;]*m/g, "");
-}
 
 /** Page payload display component - Zed REPL style */
 function PagePayloadDisplay({
@@ -49,7 +44,7 @@ function PagePayloadDisplay({
         {typeof htmlContent === "string" ? (
           <div dangerouslySetInnerHTML={{ __html: htmlContent }} />
         ) : typeof textContent === "string" ? (
-          <pre className="cm-page-payload-text">{stripAnsi(textContent)}</pre>
+          <AnsiOutput className="cm-page-payload-text">{textContent}</AnsiOutput>
         ) : (
           <pre className="cm-page-payload-text">
             {JSON.stringify(data, null, 2)}

--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -32,9 +32,9 @@ function PagePayloadDisplay({
     <div className="cm-page-payload">
       <div className="cm-page-payload-content">
         {typeof htmlContent === "string" ? (
-          <div dangerouslySetInnerHTML={{ __html: htmlContent }} />
+          <div dangerouslySetInnerHTML={{ __html: htmlContent.trim() }} />
         ) : typeof textContent === "string" ? (
-          <AnsiOutput className="cm-page-payload-text">{textContent}</AnsiOutput>
+          <AnsiOutput className="cm-page-payload-text">{textContent.trim()}</AnsiOutput>
         ) : (
           <pre className="cm-page-payload-text">
             {JSON.stringify(data, null, 2)}

--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -30,16 +30,6 @@ function PagePayloadDisplay({
 
   return (
     <div className="cm-page-payload">
-      <div className="cm-page-payload-gutter">
-        <button
-          type="button"
-          className="cm-page-payload-dismiss"
-          onClick={onDismiss}
-          title="Dismiss (Escape)"
-        >
-          <X className="h-3 w-3" />
-        </button>
-      </div>
       <div className="cm-page-payload-content">
         {typeof htmlContent === "string" ? (
           <div dangerouslySetInnerHTML={{ __html: htmlContent }} />
@@ -50,6 +40,16 @@ function PagePayloadDisplay({
             {JSON.stringify(data, null, 2)}
           </pre>
         )}
+      </div>
+      <div className="cm-page-payload-gutter">
+        <button
+          type="button"
+          className="cm-page-payload-dismiss"
+          onClick={onDismiss}
+          title="Dismiss (Escape)"
+        >
+          <X className="h-3 w-3" />
+        </button>
       </div>
     </div>
   );

--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -32,9 +32,9 @@ function PagePayloadDisplay({
     <div className="cm-page-payload">
       <div className="cm-page-payload-content">
         {typeof htmlContent === "string" ? (
-          <div dangerouslySetInnerHTML={{ __html: htmlContent.trim() }} />
+          <div dangerouslySetInnerHTML={{ __html: htmlContent }} />
         ) : typeof textContent === "string" ? (
-          <AnsiOutput className="cm-page-payload-text">{textContent.trim()}</AnsiOutput>
+          <AnsiOutput className="cm-page-payload-text">{textContent}</AnsiOutput>
         ) : (
           <pre className="cm-page-payload-text">
             {JSON.stringify(data, null, 2)}

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -5,17 +5,20 @@ import { CodeCell } from "./CodeCell";
 import { MarkdownCell } from "./MarkdownCell";
 import { EditorRegistryProvider, useEditorRegistry } from "../hooks/useEditorRegistry";
 import type { NotebookCell } from "../types";
+import type { CellPagePayload } from "../App";
 
 interface NotebookViewProps {
   cells: NotebookCell[];
   focusedCellId: string | null;
   executingCellIds: Set<string>;
+  pagePayloads: Map<string, CellPagePayload>;
   onFocusCell: (cellId: string) => void;
   onUpdateCellSource: (cellId: string, source: string) => void;
   onExecuteCell: (cellId: string) => void;
   onInterruptKernel: () => void;
   onDeleteCell: (cellId: string) => void;
   onAddCell: (type: "code" | "markdown", afterCellId?: string | null) => void;
+  onClearPagePayload: (cellId: string) => void;
 }
 
 function AddCellButtons({
@@ -66,12 +69,14 @@ function NotebookViewContent({
   cells,
   focusedCellId,
   executingCellIds,
+  pagePayloads,
   onFocusCell,
   onUpdateCellSource,
   onExecuteCell,
   onInterruptKernel,
   onDeleteCell,
   onAddCell,
+  onClearPagePayload,
 }: NotebookViewProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const { focusCell } = useEditorRegistry();
@@ -102,12 +107,14 @@ function NotebookViewContent({
       };
 
       if (cell.cell_type === "code") {
+        const pagePayload = pagePayloads.get(cell.id) ?? null;
         return (
           <CodeCell
             key={cell.id}
             cell={cell}
             isFocused={isFocused}
             isExecuting={isExecuting}
+            pagePayload={pagePayload}
             onFocus={() => onFocusCell(cell.id)}
             onUpdateSource={(source) => onUpdateCellSource(cell.id, source)}
             onExecute={() => onExecuteCell(cell.id)}
@@ -116,6 +123,7 @@ function NotebookViewContent({
             onFocusPrevious={onFocusPrevious}
             onFocusNext={onFocusNext}
             onInsertCellAfter={() => onAddCell("code", cell.id)}
+            onClearPagePayload={() => onClearPagePayload(cell.id)}
             isLastCell={index === cells.length - 1}
           />
         );
@@ -153,6 +161,7 @@ function NotebookViewContent({
     [
       focusedCellId,
       executingCellIds,
+      pagePayloads,
       cellIds,
       cells.length,
       onFocusCell,
@@ -161,6 +170,7 @@ function NotebookViewContent({
       onInterruptKernel,
       onDeleteCell,
       onAddCell,
+      onClearPagePayload,
       focusCell,
     ]
   );

--- a/apps/notebook/src/index.css
+++ b/apps/notebook/src/index.css
@@ -130,7 +130,7 @@ code {
   align-items: flex-start;
   padding-top: 0.5rem;
   padding-left: 0.25rem;
-  padding-right: 0.25rem;
+  padding-right: 0.5rem;
 }
 
 .cm-page-payload-dismiss {
@@ -157,7 +157,7 @@ code {
 
 .cm-page-payload-content {
   flex: 1;
-  padding: 0.5rem 0.75rem 0.5rem 0;
+  padding: 0.5rem 0 0.5rem 0.75rem;
   overflow-y: auto;
   max-height: 300px;
 }

--- a/apps/notebook/src/index.css
+++ b/apps/notebook/src/index.css
@@ -114,6 +114,104 @@ code {
   font-family: "SF Mono", Consolas, Monaco, "Andale Mono", monospace;
 }
 
+/* Page Payload Widget - Zed REPL / Light Table style */
+.cm-page-payload {
+  display: flex;
+  margin: 0.25rem 0;
+  background: var(--muted);
+  border-radius: 0.25rem;
+  max-height: 300px;
+  overflow: hidden;
+}
+
+.cm-page-payload-gutter {
+  flex-shrink: 0;
+  display: flex;
+  align-items: flex-start;
+  padding-top: 0.5rem;
+  padding-left: 0.25rem;
+  padding-right: 0.25rem;
+}
+
+.cm-page-payload-dismiss {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1rem;
+  height: 1rem;
+  border: none;
+  background: transparent;
+  color: var(--muted-foreground);
+  cursor: pointer;
+  border-radius: 0.125rem;
+  font-size: 0.875rem;
+  line-height: 1;
+  opacity: 0.6;
+  transition: opacity 0.15s, color 0.15s;
+}
+
+.cm-page-payload-dismiss:hover {
+  opacity: 1;
+  color: var(--foreground);
+}
+
+.cm-page-payload-content {
+  flex: 1;
+  padding: 0.5rem 0.75rem 0.5rem 0;
+  overflow-y: auto;
+  max-height: 300px;
+}
+
+.cm-page-payload-text {
+  margin: 0;
+  font-size: 0.8125rem;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  color: var(--foreground);
+}
+
+/* Style for HTML content from rich docstrings */
+.cm-page-payload-content h1,
+.cm-page-payload-content h2,
+.cm-page-payload-content h3 {
+  margin-top: 0.75rem;
+  margin-bottom: 0.5rem;
+  font-weight: 600;
+  color: var(--foreground);
+}
+
+.cm-page-payload-content h1:first-child,
+.cm-page-payload-content h2:first-child,
+.cm-page-payload-content h3:first-child {
+  margin-top: 0;
+}
+
+.cm-page-payload-content p {
+  margin: 0.5rem 0;
+}
+
+.cm-page-payload-content code {
+  background: var(--secondary);
+  padding: 0.125rem 0.25rem;
+  border-radius: var(--radius-sm);
+  font-size: 0.8125rem;
+}
+
+.cm-page-payload-content pre code {
+  background: transparent;
+  padding: 0;
+}
+
+.cm-page-payload-content a {
+  color: oklch(0.546 0.245 262.881);
+  text-decoration: underline;
+}
+
+.dark .cm-page-payload-content a {
+  color: oklch(0.707 0.165 254.624);
+}
+
 @layer base {
   * {
     @apply border-border outline-ring/50;


### PR DESCRIPTION
Add support for displaying inline documentation when users run introspection queries like `len?` or `obj??` in code cells. The page payload is displayed as a React component between the code editor and outputs with a Zed REPL-style UI featuring a subtle dismiss button.

## Changes

- Extract page payloads from ExecuteReply messages in Rust kernel
- Emit kernel:page_payload events to frontend
- Listen for page payloads in useKernel hook
- Render documentation inline with × dismiss button (right side) and Escape support
- ANSI escape codes are rendered with colors using AnsiOutput component

## Test Plan

- Run a code cell with `len?` to trigger introspection
- Verify documentation displays inline with × dismiss button on the right
- Test Escape key to dismiss
- Test clicking × button to dismiss
- Verify re-executing cell clears previous documentation