### PR TITLE
Add debug banner with git branch and workspace descriptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ __pycache__/
 **/*.egg-info/
 .venv/
 **/.venv/
+
+# Agent workspace context (per-worktree state)
+.context/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# Agent Instructions
+
+This document provides guidance for AI agents working in this repository.
+
+## Workspace Description
+
+When working in a worktree, set a human-readable description of what you're working on by writing to `.context/workspace-description`:
+
+```bash
+mkdir -p .context
+echo "Your description here" > .context/workspace-description
+```
+
+This description appears in the notebook app's debug banner (visible in debug builds only), helping identify what each worktree is testing when multiple are running in parallel.
+
+Keep descriptions short and descriptive, e.g.:
+- "Testing conda environment creation"
+- "Fixing kernel interrupt handling"
+- "Adding ipywidgets support"
+
+The `.context/` directory is gitignored and used for per-worktree state that shouldn't be committed.

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -4,10 +4,12 @@ import { NotebookToolbar } from "./components/NotebookToolbar";
 import { NotebookView } from "./components/NotebookView";
 import { DependencyHeader } from "./components/DependencyHeader";
 import { CondaDependencyHeader } from "./components/CondaDependencyHeader";
+import { DebugBanner } from "./components/DebugBanner";
 import { useNotebook } from "./hooks/useNotebook";
 import { useKernel } from "./hooks/useKernel";
 import { useDependencies } from "./hooks/useDependencies";
 import { useCondaDependencies } from "./hooks/useCondaDependencies";
+import { useGitInfo } from "./hooks/useGitInfo";
 import { useTheme } from "@/hooks/useTheme";
 import { WidgetStoreProvider, useWidgetStoreRequired } from "@/components/widgets/widget-store-context";
 import { MediaProvider } from "@/components/outputs/media-provider";
@@ -27,6 +29,8 @@ async function sendMessage(message: unknown): Promise<void> {
 }
 
 function AppContent() {
+  const gitInfo = useGitInfo();
+
   const {
     cells,
     focusedCellId,
@@ -173,6 +177,13 @@ function AppContent() {
 
   return (
     <div className="min-h-screen bg-background">
+      {gitInfo && (
+        <DebugBanner
+          branch={gitInfo.branch}
+          commit={gitInfo.commit}
+          description={gitInfo.description}
+        />
+      )}
       <NotebookToolbar
         kernelStatus={kernelStatus}
         dirty={dirty}

--- a/apps/notebook/src/components/DebugBanner.tsx
+++ b/apps/notebook/src/components/DebugBanner.tsx
@@ -1,0 +1,27 @@
+import { GitBranch } from "lucide-react";
+
+interface DebugBannerProps {
+  branch: string;
+  commit: string;
+  description?: string | null;
+}
+
+export function DebugBanner({ branch, commit, description }: DebugBannerProps) {
+  return (
+    <div className="flex items-center justify-center gap-2 bg-violet-600/90 px-3 py-1 text-xs text-white">
+      <GitBranch className="h-3 w-3" />
+      <span className="font-medium">{branch}</span>
+      <span className="text-violet-200">@</span>
+      <span className="font-mono text-violet-200">{commit}</span>
+      {description && (
+        <>
+          <span className="text-violet-300">|</span>
+          <span className="text-violet-100">{description}</span>
+        </>
+      )}
+      <span className="ml-2 rounded bg-violet-500/50 px-1.5 py-0.5 text-[10px] font-medium uppercase">
+        Dev
+      </span>
+    </div>
+  );
+}

--- a/apps/notebook/src/hooks/useGitInfo.ts
+++ b/apps/notebook/src/hooks/useGitInfo.ts
@@ -1,0 +1,22 @@
+import { useState, useEffect } from "react";
+import { invoke } from "@tauri-apps/api/core";
+
+interface GitInfo {
+  branch: string;
+  commit: string;
+  description: string | null;
+}
+
+export function useGitInfo() {
+  const [gitInfo, setGitInfo] = useState<GitInfo | null>(null);
+
+  useEffect(() => {
+    invoke<GitInfo | null>("get_git_info")
+      .then(setGitInfo)
+      .catch((e) => {
+        console.error("Failed to get git info:", e);
+      });
+  }, []);
+
+  return gitInfo;
+}

--- a/crates/notebook/build.rs
+++ b/crates/notebook/build.rs
@@ -1,3 +1,31 @@
+use std::process::Command;
+
 fn main() {
+    // Capture git branch name
+    let branch = Command::new("git")
+        .args(["rev-parse", "--abbrev-ref", "HEAD"])
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    // Capture short commit hash
+    let commit = Command::new("git")
+        .args(["rev-parse", "--short=7", "HEAD"])
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    // Set environment variables for use in Rust code
+    println!("cargo:rustc-env=GIT_BRANCH={}", branch);
+    println!("cargo:rustc-env=GIT_COMMIT={}", commit);
+
+    // Re-run if git HEAD changes (detects branch switches, commits)
+    println!("cargo:rerun-if-changed=../../.git/HEAD");
+    println!("cargo:rerun-if-changed=../../.git/index");
+
     tauri_build::build()
 }

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -19,6 +19,38 @@ struct KernelspecInfo {
     language: String,
 }
 
+/// Git information for debug banner display.
+#[derive(Serialize)]
+struct GitInfo {
+    branch: String,
+    commit: String,
+    description: Option<String>,
+}
+
+/// Get git information for the debug banner.
+/// Returns None in release builds.
+#[tauri::command]
+async fn get_git_info() -> Option<GitInfo> {
+    #[cfg(debug_assertions)]
+    {
+        // Try to read workspace description from .context/workspace-description
+        let description = std::fs::read_to_string(".context/workspace-description")
+            .ok()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty());
+
+        Some(GitInfo {
+            branch: env!("GIT_BRANCH").to_string(),
+            commit: env!("GIT_COMMIT").to_string(),
+            description,
+        })
+    }
+    #[cfg(not(debug_assertions))]
+    {
+        None
+    }
+}
+
 #[tauri::command]
 async fn load_notebook(
     state: tauri::State<'_, Mutex<NotebookState>>,
@@ -647,6 +679,8 @@ pub fn run(notebook_path: Option<PathBuf>) -> anyhow::Result<()> {
             start_kernel_with_conda,
             kernel_has_conda_env,
             sync_conda_dependencies,
+            // Debug info
+            get_git_info,
         ])
         .setup(move |app| {
             if let Some(window) = app.get_webview_window("main") {


### PR DESCRIPTION
## Summary

Adds a debug-only banner to the notebook app showing git branch, commit hash, and optional workspace description. Helps identify which worktree/branch is running when testing multiple instances in parallel.

## Changes

- **build.rs**: Captures git branch and commit hash at build time
- **get_git_info command**: Returns git info only in debug builds (None in release)
- **DebugBanner component**: Displays banner with git info and optional description
- **useGitInfo hook**: Fetches git info from backend
- **AGENTS.md**: Documentation for agents on setting workspace descriptions
- **.gitignore**: Added .context/ for per-worktree state

## How to Use

Set a description for the current worktree:
```bash
mkdir -p .context
echo "Testing conda environment creation" > .context/workspace-description
```

The description appears in the banner: `🔀 branch-name @ abc1234 | Testing conda environment creation DEV`

The banner only appears in debug builds, automatically hidden in release builds.