### PR TITLE
Enable Shift+Enter navigation from markdown cells

### DIFF
--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -80,6 +80,7 @@ export function MarkdownCell({
   const navigationKeyMap = useCellKeyboardNavigation({
     onFocusPrevious: onFocusPrevious ?? (() => {}),
     onFocusNext: handleFocusNextOrCreate,
+    onExecute: () => {}, // No-op for markdown, enables Shift+Enter navigation
   });
 
   // Combine navigation with markdown-specific keys


### PR DESCRIPTION
When navigating through a notebook with Shift+Enter, users were getting stuck on markdown cells. Shift+Enter only worked for code cells because the MarkdownCell component didn't pass an `onExecute` callback to the keyboard navigation hook.

This fix adds a no-op `onExecute` callback, enabling the Shift+Enter and Cmd+Enter keybindings for markdown cells to work properly. Users can now navigate smoothly through all cell types without getting stuck in edit mode.