### PR TITLE
Default to uv for new notebooks instead of conda/rattler

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -69,6 +69,7 @@ function AppContent() {
     dependencies,
     uvAvailable,
     hasDependencies: hasUvDependencies,
+    isUvConfigured,
     loading: depsLoading,
     syncedWhileRunning,
     needsKernelRestart,
@@ -92,11 +93,11 @@ function AppContent() {
   } = useCondaDependencies();
 
   // Auto-detect environment type based on what's configured
-  // Conda takes priority if metadata exists (even with empty deps)
-  const envType = isCondaConfigured
-    ? "conda"
-    : hasUvDependencies
-      ? "uv"
+  // uv takes priority if metadata exists (even with empty deps)
+  const envType = isUvConfigured
+    ? "uv"
+    : isCondaConfigured
+      ? "conda"
       : null;
 
   // Combine hasDependencies for toolbar badge

--- a/apps/notebook/src/hooks/useDependencies.ts
+++ b/apps/notebook/src/hooks/useDependencies.ts
@@ -136,10 +136,14 @@ export function useDependencies() {
   const hasDependencies =
     dependencies !== null && dependencies.dependencies.length > 0;
 
+  // True if uv metadata exists (even with empty deps)
+  const isUvConfigured = dependencies !== null;
+
   return {
     dependencies,
     uvAvailable,
     hasDependencies,
+    isUvConfigured,
     loading,
     syncedWhileRunning,
     needsKernelRestart,

--- a/crates/notebook/src/notebook_state.rs
+++ b/crates/notebook/src/notebook_state.rs
@@ -80,13 +80,12 @@ impl NotebookState {
         // Generate unique environment ID for this notebook
         let env_id = Uuid::new_v4().to_string();
 
-        // Set up default conda metadata
+        // Set up default uv metadata (faster startup than conda/rattler)
         let mut additional = HashMap::new();
         additional.insert(
-            "conda".to_string(),
+            "uv".to_string(),
             serde_json::json!({
                 "dependencies": Vec::<String>::new(),
-                "channels": ["conda-forge"],
             }),
         );
         additional.insert(


### PR DESCRIPTION
## Summary
Changed the default package manager for new notebooks from conda/rattler to uv for faster kernel startup. uv provides significantly quicker environment initialization while conda notebooks remain fully supported through their metadata detection.

## Changes
- Added `start_default_uv_kernel` backend command
- Changed new notebook metadata to use uv instead of conda
- Updated kernel selection fallback to use uv instead of conda
- Added `isUvConfigured` flag to dependency hook
- Updated environment type detection to prioritize uv

## Testing
- Create a new notebook with Cmd+N and verify kernel starts with uv
- Verify existing conda notebooks continue to work normally
- Check metadata shows `uv` key for new notebooks