### PR TITLE
Add vite-env.d.ts type declarations for KaTeX CSS import

### DIFF
--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="vite/client" />
+
+// KaTeX CSS type declaration for side-effect imports
+declare module "katex/dist/katex.min.css";


### PR DESCRIPTION
## Summary

Fixes TypeScript error TS2307 when importing `katex/dist/katex.min.css` in markdown and math widget components. The Vite client types reference handles general CSS imports, but KaTeX's package path needs an explicit module declaration.

## Changes

- Added `src/vite-env.d.ts` with Vite client types reference and KaTeX CSS module declaration
- Resolves type checking errors for contributors without changing runtime behavior