### PR TITLE
Add progress events for conda environment preparation

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -11,6 +11,7 @@ import { useKernel, type MimeBundle } from "./hooks/useKernel";
 import { useDependencies } from "./hooks/useDependencies";
 import { useCondaDependencies } from "./hooks/useCondaDependencies";
 import { useGitInfo } from "./hooks/useGitInfo";
+import { useEnvProgress } from "./hooks/useEnvProgress";
 import { useTheme } from "@/hooks/useTheme";
 import { WidgetStoreProvider, useWidgetStoreRequired } from "@/components/widgets/widget-store-context";
 import { MediaProvider } from "@/components/outputs/media-provider";
@@ -174,6 +175,9 @@ onKernelStarted: loadCondaDependencies,
     onPagePayload: handlePagePayload,
   });
 
+  // Environment preparation progress
+  const envProgress = useEnvProgress();
+
   const handleExecuteCell = useCallback(
     async (cellId: string) => {
       setExecutingCellIds((prev) => new Set(prev).add(cellId));
@@ -237,6 +241,7 @@ onKernelStarted: loadCondaDependencies,
         dirty={dirty}
         hasDependencies={hasDependencies}
         theme={theme}
+        envProgress={envProgress.isActive ? envProgress : null}
         onThemeChange={setTheme}
         onSave={save}
         onStartKernel={handleStartKernel}

--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -8,12 +8,14 @@ import {
 } from "@/components/ui/collapsible";
 import type { ThemeMode } from "@/hooks/useTheme";
 import type { KernelspecInfo } from "../types";
+import type { EnvProgressState } from "../hooks/useEnvProgress";
 
 interface NotebookToolbarProps {
   kernelStatus: string;
   dirty: boolean;
   hasDependencies: boolean;
   theme: ThemeMode;
+  envProgress: EnvProgressState | null;
   onThemeChange: (theme: ThemeMode) => void;
   onSave: () => void;
   onStartKernel: (name: string) => void;
@@ -35,6 +37,7 @@ export function NotebookToolbar({
   dirty,
   hasDependencies,
   theme,
+  envProgress,
   onThemeChange,
   onSave,
   onStartKernel,
@@ -172,8 +175,10 @@ export function NotebookToolbar({
                 kernelStatus === "error" && "bg-red-500"
               )}
             />
-            <span className="text-xs text-muted-foreground capitalize">
-              {kernelStatus}
+            <span className="text-xs text-muted-foreground">
+              {envProgress ? envProgress.statusText : (
+                <span className="capitalize">{kernelStatus}</span>
+              )}
             </span>
           </div>
 

--- a/apps/notebook/src/hooks/useEnvProgress.ts
+++ b/apps/notebook/src/hooks/useEnvProgress.ts
@@ -1,0 +1,117 @@
+import { useState, useEffect, useCallback } from "react";
+import { listen } from "@tauri-apps/api/event";
+import type { EnvProgressEvent, EnvProgressPhase } from "../types";
+
+export interface EnvProgressState {
+  /** Whether environment preparation is currently active */
+  isActive: boolean;
+  /** Current phase name */
+  phase: string | null;
+  /** Environment type (conda or uv) */
+  envType: "conda" | "uv" | null;
+  /** Error message if phase is "error" */
+  error: string | null;
+  /** Human-readable status text */
+  statusText: string;
+  /** Elapsed time for current/last operation in ms */
+  elapsedMs: number | null;
+}
+
+function getStatusText(event: EnvProgressEvent): string {
+  const phase = event.phase;
+  switch (phase) {
+    case "starting":
+      return "Preparing environment...";
+    case "cache_hit":
+      return "Using cached environment";
+    case "fetching_repodata": {
+      const e = event as Extract<EnvProgressPhase, { phase: "fetching_repodata" }>;
+      return `Fetching package index (${e.channels.join(", ")})`;
+    }
+    case "repodata_complete": {
+      const e = event as Extract<EnvProgressPhase, { phase: "repodata_complete" }>;
+      return `Loaded ${e.record_count.toLocaleString()} packages`;
+    }
+    case "solving": {
+      const e = event as Extract<EnvProgressPhase, { phase: "solving" }>;
+      return `Solving dependencies (${e.spec_count} specs)`;
+    }
+    case "solve_complete": {
+      const e = event as Extract<EnvProgressPhase, { phase: "solve_complete" }>;
+      return `Resolved ${e.package_count} packages`;
+    }
+    case "installing": {
+      const e = event as Extract<EnvProgressPhase, { phase: "installing" }>;
+      return `Installing ${e.total} packages...`;
+    }
+    case "install_complete":
+      return "Installation complete";
+    case "ready":
+      return "Environment ready";
+    case "error": {
+      const e = event as Extract<EnvProgressPhase, { phase: "error" }>;
+      return `Error: ${e.message}`;
+    }
+    default:
+      return "Preparing...";
+  }
+}
+
+export function useEnvProgress() {
+  const [state, setState] = useState<EnvProgressState>({
+    isActive: false,
+    phase: null,
+    envType: null,
+    error: null,
+    statusText: "",
+    elapsedMs: null,
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const unlisten = listen<EnvProgressEvent>("env:progress", (event) => {
+      if (cancelled) return;
+
+      const payload = event.payload;
+      const phase = payload.phase;
+      const isTerminal = phase === "ready" || phase === "error" || phase === "cache_hit";
+      const error = phase === "error"
+        ? (payload as Extract<EnvProgressPhase, { phase: "error" }>).message
+        : null;
+
+      // Extract elapsed_ms from phases that have it
+      let elapsedMs: number | null = null;
+      if ("elapsed_ms" in payload && typeof payload.elapsed_ms === "number") {
+        elapsedMs = payload.elapsed_ms;
+      }
+
+      setState({
+        isActive: !isTerminal,
+        phase,
+        envType: payload.env_type,
+        error,
+        statusText: getStatusText(payload),
+        elapsedMs,
+      });
+    });
+
+    return () => {
+      cancelled = true;
+      unlisten.then((fn) => fn());
+    };
+  }, []);
+
+  const reset = useCallback(() => {
+    setState({
+      isActive: false,
+      phase: null,
+      envType: null,
+      error: null,
+      statusText: "",
+      elapsedMs: null,
+    });
+  }, []);
+
+  return { ...state, reset };
+}

--- a/apps/notebook/src/types.ts
+++ b/apps/notebook/src/types.ts
@@ -68,3 +68,20 @@ export interface JupyterMessage {
   channel?: string;
   cell_id?: string;
 }
+
+// Environment preparation progress events
+export type EnvProgressPhase =
+  | { phase: "starting"; env_hash: string }
+  | { phase: "cache_hit"; env_path: string }
+  | { phase: "fetching_repodata"; channels: string[] }
+  | { phase: "repodata_complete"; record_count: number; elapsed_ms: number }
+  | { phase: "solving"; spec_count: number }
+  | { phase: "solve_complete"; package_count: number; elapsed_ms: number }
+  | { phase: "installing"; total: number }
+  | { phase: "install_complete"; elapsed_ms: number }
+  | { phase: "ready"; env_path: string; python_path: string }
+  | { phase: "error"; message: string };
+
+export type EnvProgressEvent = EnvProgressPhase & {
+  env_type: "conda" | "uv";
+};

--- a/crates/notebook/src/kernel.rs
+++ b/crates/notebook/src/kernel.rs
@@ -520,8 +520,8 @@ impl NotebookKernel {
 
         info!("Preparing conda environment with deps: {:?}", deps.dependencies);
 
-        // Prepare the conda environment
-        let env = crate::conda_env::prepare_environment(deps).await?;
+        // Prepare the conda environment with progress events
+        let env = crate::conda_env::prepare_environment(deps, Some(&app)).await?;
 
         // Reserve ports
         let ip = std::net::IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));


### PR DESCRIPTION
## Summary

- Emit Tauri events during conda environment preparation so users can see what's happening during the rattler process
- Display progress status in the toolbar when environment preparation is active
- Remove `.no_gzip()` from HTTP client which was slowing downloads

## Progress phases

The frontend now shows status text for each phase:
- "Preparing environment..." (starting)
- "Using cached environment" (cache hit - fast path)
- "Fetching package index (conda-forge, ...)" (fetching repodata)
- "Loaded N packages" (repodata complete)
- "Solving dependencies (N specs)" (solving)
- "Resolved N packages" (solve complete)
- "Installing N packages..." (installing)
- "Installation complete" (install complete)
- "Environment ready" / "Error: ..." (terminal states)