### PR TITLE
Add Cmd+O keyboard shortcut to open notebooks

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -48,6 +48,7 @@ function AppContent() {
     addCell,
     deleteCell,
     save,
+    openNotebook,
     dirty,
     appendOutput,
     setExecutionCount,
@@ -226,6 +227,28 @@ onKernelStarted: loadCondaDependencies,
       unlistenPromise.then((unlisten) => unlisten());
     };
   }, [save]);
+
+  // Cmd+O to open (keyboard and native menu)
+  useEffect(() => {
+    // Listen for native menu open event
+    const unlistenPromise = listen("menu:open", () => {
+      openNotebook();
+    });
+
+    // Keep keyboard shortcut as fallback
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === "o") {
+        e.preventDefault();
+        openNotebook();
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+      unlistenPromise.then((unlisten) => unlisten());
+    };
+  }, [openNotebook]);
 
   return (
     <div className="min-h-screen bg-background">

--- a/apps/notebook/src/hooks/useNotebook.ts
+++ b/apps/notebook/src/hooks/useNotebook.ts
@@ -1,6 +1,6 @@
 import { useState, useCallback, useEffect } from "react";
 import { invoke } from "@tauri-apps/api/core";
-import { save as saveDialog } from "@tauri-apps/plugin-dialog";
+import { save as saveDialog, open as openDialog } from "@tauri-apps/plugin-dialog";
 import type { NotebookCell, JupyterOutput } from "../types";
 
 export function useNotebook() {
@@ -111,6 +111,25 @@ export function useNotebook() {
     }
   }, []);
 
+  const openNotebook = useCallback(async () => {
+    try {
+      const filePath = await openDialog({
+        multiple: false,
+        filters: [{ name: "Jupyter Notebook", extensions: ["ipynb"] }],
+      });
+
+      if (!filePath || typeof filePath !== "string") {
+        // User cancelled or unexpected type
+        return;
+      }
+
+      // Open the notebook in a new window
+      await invoke("open_notebook_in_new_window", { path: filePath });
+    } catch (e) {
+      console.error("open_notebook failed:", e);
+    }
+  }, []);
+
   const appendOutput = useCallback(
     (cellId: string, output: JupyterOutput) => {
       setCells((prev) =>
@@ -164,6 +183,7 @@ export function useNotebook() {
     addCell,
     deleteCell,
     save,
+    openNotebook,
     dirty,
     appendOutput,
     setExecutionCount,

--- a/crates/notebook/src/menu.rs
+++ b/crates/notebook/src/menu.rs
@@ -2,6 +2,7 @@ use tauri::menu::{Menu, MenuItem, PredefinedMenuItem, Submenu};
 use tauri::{AppHandle, Wry};
 
 pub const MENU_NEW_NOTEBOOK: &str = "new_notebook";
+pub const MENU_OPEN: &str = "open";
 pub const MENU_SAVE: &str = "save";
 
 /// Build the application menu bar
@@ -29,6 +30,13 @@ pub fn create_menu(app: &AppHandle) -> tauri::Result<Menu<Wry>> {
         "New Notebook",
         true,
         Some("CmdOrCtrl+N"),
+    )?)?;
+    file_menu.append(&MenuItem::with_id(
+        app,
+        MENU_OPEN,
+        "Open...",
+        true,
+        Some("CmdOrCtrl+O"),
     )?)?;
     file_menu.append(&PredefinedMenuItem::separator(app)?)?;
     file_menu.append(&MenuItem::with_id(


### PR DESCRIPTION
## Summary

Adds Cmd+O (Ctrl+O on Windows/Linux) keyboard shortcut to open notebooks. Pressing Cmd+O displays a file picker filtered to .ipynb files, and selecting a notebook opens it in a new window.

## Changes

- Added "Open..." menu item with Cmd+O shortcut in File menu
- Implemented file open dialog using Tauri's dialog plugin
- Added keyboard and menu event handlers following existing Cmd+S pattern
- New notebooks open in separate windows (consistent with "New Notebook" behavior)

## Testing

- Press Cmd+O or use File > Open... menu
- Select a .ipynb file from the dialog
- Verify new window opens with the selected notebook
- Cancel dialog should not trigger any action