### PR TITLE
Update nteract elements components and improve typography

### DIFF
--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -1,8 +1,7 @@
 import { useCallback, useRef, useEffect, useMemo } from "react";
 import type { KeyBinding } from "@codemirror/view";
 import { CellContainer } from "@/components/cell/CellContainer";
-import { PlayButton } from "@/components/cell/PlayButton";
-import { ExecutionCount } from "@/components/cell/ExecutionCount";
+import { CompactExecutionButton } from "@/components/cell/CompactExecutionButton";
 import { OutputArea } from "@/components/cell/OutputArea";
 import { AnsiOutput } from "@/components/outputs/ansi-output";
 import {
@@ -159,16 +158,24 @@ export function CodeCell({
     handleExecuteWithClear();
   }, [handleExecuteWithClear]);
 
-  const playButton = (
-    <PlayButton
-      executionState={isExecuting ? "running" : "idle"}
-      cellType="code"
-      isFocused={isFocused}
+  const gutterContent = (
+    <CompactExecutionButton
+      count={cell.execution_count}
+      isExecuting={isExecuting}
       onExecute={handleExecute}
       onInterrupt={onInterrupt}
-      className="h-4 w-4"
-      focusedClass="text-gray-700 dark:text-gray-300"
     />
+  );
+
+  const rightGutterContent = (
+    <button
+      type="button"
+      onClick={onDelete}
+      className="flex items-center justify-center rounded p-1 text-muted-foreground/40 transition-colors hover:text-destructive"
+      title="Delete cell"
+    >
+      <Trash2 className="h-3.5 w-3.5" />
+    </button>
   );
 
   return (
@@ -177,30 +184,11 @@ export function CodeCell({
       cellType="code"
       isFocused={isFocused}
       onFocus={onFocus}
-      gutterContent={playButton}
+      gutterContent={gutterContent}
+      rightGutterContent={rightGutterContent}
     >
-      {/* Cell header: execution count + controls */}
-      <div className="flex items-center gap-1 px-2 py-1">
-        <ExecutionCount
-          count={cell.execution_count}
-          isExecuting={isExecuting}
-          className="text-xs"
-        />
-        <div className="flex-1" />
-        <div className="cell-controls opacity-0 group-hover:opacity-100 transition-opacity">
-          <button
-            type="button"
-            onClick={onDelete}
-            className="flex items-center justify-center rounded p-1 text-muted-foreground/40 transition-colors hover:text-destructive"
-            title="Delete cell"
-          >
-            <Trash2 className="h-3.5 w-3.5" />
-          </button>
-        </div>
-      </div>
-
       {/* Editor */}
-      <div className="px-2">
+      <div>
         <CodeMirrorEditor
           ref={editorRef}
           value={cell.source}
@@ -226,7 +214,7 @@ export function CodeCell({
 
       {/* Outputs */}
       {cell.outputs.length > 0 && (
-        <div className="px-2 py-2">
+        <div className="py-2">
           <OutputArea outputs={cell.outputs} />
         </div>
       )}

--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -109,7 +109,7 @@ export function MarkdownCell({
     >
       {editing ? (
         <>
-          <div className="flex items-center gap-1 px-2 py-1">
+          <div className="flex items-center gap-1 py-1">
             <span className="text-xs text-muted-foreground font-mono">md</span>
             <div className="flex-1" />
             <div className="cell-controls opacity-0 group-hover:opacity-100 transition-opacity">
@@ -123,7 +123,7 @@ export function MarkdownCell({
               </button>
             </div>
           </div>
-          <div className="px-2">
+          <div>
             <CodeMirrorEditor
               ref={editorRef}
               value={cell.source}
@@ -139,7 +139,7 @@ export function MarkdownCell({
         </>
       ) : (
         <div
-          className="px-2 py-2 prose prose-sm max-w-none cursor-text relative group/md"
+          className="py-2 prose prose-sm max-w-none cursor-text relative group/md"
           onDoubleClick={handleDoubleClick}
         >
           {cell.source ? (

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -31,8 +31,8 @@ function AddCellButtons({
   return (
     <div className="group/betweener flex h-4 w-full items-center">
       {/* Gutter spacer - matches cell gutter: action area + ribbon */}
-      <div className="flex-shrink-0 flex h-full">
-        <div className="w-6" />
+      <div className="flex h-full flex-shrink-0">
+        <div className="w-10" />
         <div className="w-1 bg-gray-200 dark:bg-gray-700" />
       </div>
       {/* Content area with centered buttons */}
@@ -176,7 +176,7 @@ function NotebookViewContent({
   );
 
   return (
-    <div ref={containerRef} className="max-w-4xl mx-auto px-4 py-4">
+    <div ref={containerRef} className="py-4 pl-8 pr-4">
       {cells.length === 0 ? (
         <div className="flex flex-col items-center justify-center py-20 text-muted-foreground">
           <p className="text-sm">Empty notebook</p>

--- a/src/components/cell/CellBetweener.tsx
+++ b/src/components/cell/CellBetweener.tsx
@@ -1,0 +1,43 @@
+import { cn } from "@/lib/utils";
+import { type GutterColorConfig, getGutterColors } from "./gutter-colors";
+
+interface CellBetweenerProps {
+  /** Cell type to determine ribbon color - defaults to "code" */
+  cellType?: string;
+  /** Custom color configuration */
+  customGutterColors?: Record<string, GutterColorConfig>;
+  /** Optional content for the betweener area (e.g., add cell button) */
+  children?: React.ReactNode;
+  className?: string;
+}
+
+/**
+ * A spacer component that maintains gutter ribbon continuity between cells.
+ * Place this between CellContainer components to create an unbroken
+ * "paper edge" effect down the left side of the notebook.
+ */
+export function CellBetweener({
+  cellType = "code",
+  customGutterColors,
+  children,
+  className,
+}: CellBetweenerProps) {
+  const colors = getGutterColors(cellType, customGutterColors);
+
+  return (
+    <div
+      data-slot="cell-betweener"
+      className={cn("flex h-4 w-full items-center", className)}
+    >
+      {/* Gutter spacer - matches cell gutter structure */}
+      <div className="flex h-full flex-shrink-0">
+        {/* Action area spacer - matches CellContainer w-10 */}
+        <div className="w-10" />
+        {/* Ribbon continues */}
+        <div className={cn("w-1", colors.ribbon.default)} />
+      </div>
+      {/* Content area - could hold add-cell buttons */}
+      <div className="flex-1">{children}</div>
+    </div>
+  );
+}

--- a/src/components/cell/CompactExecutionButton.tsx
+++ b/src/components/cell/CompactExecutionButton.tsx
@@ -1,0 +1,73 @@
+import { cn } from "@/lib/utils";
+
+interface CompactExecutionButtonProps {
+  /** Execution count - null means never executed */
+  count: number | null;
+  /** Whether the cell is currently executing */
+  isExecuting?: boolean;
+  /** Called when user clicks to execute */
+  onExecute?: () => void;
+  /** Called when user clicks to interrupt */
+  onInterrupt?: () => void;
+  /** Additional classes */
+  className?: string;
+}
+
+/**
+ * Compact execution button combining play + execution count into one element.
+ *
+ * - Never run: `[ ▶ ]` - click to execute
+ * - Running: `[■]` with pulse - click to stop
+ * - Executed: `[1]` - hover to show play, click to re-run
+ */
+export function CompactExecutionButton({
+  count,
+  isExecuting = false,
+  onExecute,
+  onInterrupt,
+  className,
+}: CompactExecutionButtonProps) {
+  const handleClick = () => {
+    if (isExecuting) {
+      onInterrupt?.();
+    } else {
+      onExecute?.();
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      className={cn(
+        "group/exec inline-flex items-center font-mono text-sm tabular-nums",
+        "text-muted-foreground hover:text-foreground",
+        "transition-colors duration-150",
+        className,
+      )}
+      title={isExecuting ? "Stop execution" : "Run cell"}
+    >
+      <span className="opacity-60">[</span>
+      <span className="relative inline-flex min-w-4 items-center justify-center">
+        {isExecuting ? (
+          // Running state: show stop with pulse
+          <span className="text-destructive animate-pulse">■</span>
+        ) : count !== null ? (
+          // Has count: show count, play on hover
+          <>
+            <span className="group-hover/exec:opacity-0 transition-opacity">
+              {count}
+            </span>
+            <span className="absolute inset-0 flex items-center justify-center opacity-0 group-hover/exec:opacity-100 transition-opacity">
+              ▶
+            </span>
+          </>
+        ) : (
+          // Never run: show play
+          <span>▶</span>
+        )}
+      </span>
+      <span className="opacity-60">]:</span>
+    </button>
+  );
+}

--- a/src/components/cell/ExecutionCount.tsx
+++ b/src/components/cell/ExecutionCount.tsx
@@ -15,7 +15,10 @@ export function ExecutionCount({
   return (
     <span
       data-slot="execution-count"
-      className={cn("font-mono text-sm text-muted-foreground", className)}
+      className={cn(
+        "font-mono text-sm tabular-nums text-muted-foreground",
+        className,
+      )}
     >
       [{display}]:
     </span>

--- a/src/components/cell/PlayButton.tsx
+++ b/src/components/cell/PlayButton.tsx
@@ -11,6 +11,11 @@ interface PlayButtonProps {
   className?: string;
   focusedClass?: string;
   isAutoLaunching?: boolean;
+  /**
+   * When true, uses gutter-optimized visibility (invisible when unfocused,
+   * visible on focus or parent hover). Default: false for backwards compatibility.
+   */
+  gutterMode?: boolean;
 }
 
 export const PlayButton: React.FC<PlayButtonProps> = ({
@@ -22,6 +27,7 @@ export const PlayButton: React.FC<PlayButtonProps> = ({
   className = "",
   focusedClass = "text-foreground",
   isAutoLaunching = false,
+  gutterMode = false,
 }) => {
   const isRunning = executionState === "running" || executionState === "queued";
   const title = isAutoLaunching
@@ -30,6 +36,19 @@ export const PlayButton: React.FC<PlayButtonProps> = ({
       ? "Stop execution"
       : `Execute ${cellType} cell`;
 
+  // Visibility classes differ based on mode
+  const visibilityClass = gutterMode
+    ? isRunning
+      ? "text-destructive hover:text-destructive animate-pulse"
+      : isFocused
+        ? focusedClass
+        : "text-transparent group-hover:text-muted-foreground hover:text-foreground"
+    : isRunning
+      ? "text-destructive hover:text-destructive shadow-destructive/20 animate-pulse drop-shadow-sm"
+      : isFocused
+        ? focusedClass
+        : "text-muted-foreground/40 hover:text-foreground group-hover:text-foreground";
+
   return (
     <button
       data-slot="play-button"
@@ -37,26 +56,32 @@ export const PlayButton: React.FC<PlayButtonProps> = ({
       disabled={isAutoLaunching}
       className={cn(
         "flex items-center justify-center transition-all",
-        isRunning
-          ? "text-destructive hover:text-destructive animate-pulse"
-          : isFocused
-            ? focusedClass
-            : "text-transparent group-hover:text-muted-foreground hover:text-foreground",
+        gutterMode
+          ? "rounded-sm p-0.5" // Minimal padding in gutter mode
+          : "hover:bg-muted/80 rounded-sm bg-background p-1",
+        visibilityClass,
         isAutoLaunching && "cursor-wait opacity-75",
         className,
       )}
       title={title}
     >
       {isAutoLaunching ? (
-        <Loader2 className="size-3 animate-spin" />
+        <Loader2
+          className={cn(gutterMode ? "size-3.5" : "size-4", "animate-spin")}
+        />
       ) : isRunning ? (
         <Square
-          fill="currentColor"
-          stroke="none"
-          className="size-2.5"
+          fill={gutterMode ? "currentColor" : "none"}
+          stroke={gutterMode ? "none" : "currentColor"}
+          strokeWidth={gutterMode ? undefined : "2"}
+          className={gutterMode ? "size-2.5" : "size-4"}
         />
       ) : (
-        <Play fill="currentColor" stroke="none" className="size-3 translate-x-[1px]" />
+        <Play
+          fill="currentColor"
+          stroke="none"
+          className={cn(gutterMode ? "size-3.5" : "size-4")}
+        />
       )}
     </button>
   );

--- a/src/components/cell/gutter-colors.ts
+++ b/src/components/cell/gutter-colors.ts
@@ -1,0 +1,98 @@
+export interface GutterColorConfig {
+  ribbon: {
+    default: string;
+    focused: string;
+  };
+  background: {
+    focused: string;
+  };
+}
+
+/**
+ * Default gutter colors for built-in cell types.
+ * Colors are designed to match the existing CellTypeButton color scheme.
+ */
+export const defaultGutterColors: Record<string, GutterColorConfig> = {
+  code: {
+    ribbon: {
+      default: "bg-gray-200 dark:bg-gray-700",
+      focused: "bg-sky-400 dark:bg-sky-600",
+    },
+    background: {
+      focused: "bg-sky-50/20 dark:bg-sky-900/10",
+    },
+  },
+  markdown: {
+    ribbon: {
+      default: "bg-gray-200 dark:bg-gray-700",
+      focused: "bg-emerald-400 dark:bg-emerald-600",
+    },
+    background: {
+      focused: "bg-emerald-50/20 dark:bg-emerald-900/10",
+    },
+  },
+  sql: {
+    ribbon: {
+      default: "bg-blue-200 dark:bg-blue-800",
+      focused: "bg-blue-400 dark:bg-blue-600",
+    },
+    background: {
+      focused: "bg-blue-50/50 dark:bg-blue-900/30",
+    },
+  },
+  ai: {
+    ribbon: {
+      default: "bg-purple-200 dark:bg-purple-800",
+      focused: "bg-purple-400 dark:bg-purple-600",
+    },
+    background: {
+      focused: "bg-purple-50/50 dark:bg-purple-900/30",
+    },
+  },
+  raw: {
+    ribbon: {
+      default: "bg-rose-200 dark:bg-rose-800",
+      focused: "bg-rose-400 dark:bg-rose-600",
+    },
+    background: {
+      focused: "bg-rose-50/50 dark:bg-rose-900/30",
+    },
+  },
+};
+
+/**
+ * Fallback colors for unknown cell types.
+ * Uses neutral gray styling.
+ */
+export const fallbackGutterColors: GutterColorConfig = {
+  ribbon: {
+    default: "bg-gray-200 dark:bg-gray-700",
+    focused: "bg-gray-400 dark:bg-gray-500",
+  },
+  background: {
+    focused: "bg-gray-50/50 dark:bg-gray-900/30",
+  },
+};
+
+/**
+ * Get gutter colors for a cell type.
+ * Falls back to neutral gray for unknown types.
+ *
+ * @param cellType - The cell type to get colors for
+ * @param customColors - Optional custom color overrides
+ */
+export function getGutterColors(
+  cellType: string,
+  customColors?: Record<string, GutterColorConfig>,
+): GutterColorConfig {
+  // Check custom colors first
+  if (customColors?.[cellType]) {
+    return customColors[cellType];
+  }
+  // Then check defaults
+  if (defaultGutterColors[cellType]) {
+    return defaultGutterColors[cellType];
+  }
+  // Fall back to neutral
+  return fallbackGutterColors;
+}

--- a/src/components/editor/codemirror-editor.tsx
+++ b/src/components/editor/codemirror-editor.tsx
@@ -17,7 +17,6 @@ import {
   useState,
 } from "react";
 
-import { cn } from "@/lib/utils";
 import { defaultExtensions } from "./extensions";
 import { getLanguageExtension, type SupportedLanguage } from "./languages";
 import { darkTheme, isDarkMode, lightTheme, type ThemeMode } from "./themes";
@@ -252,7 +251,7 @@ export const CodeMirrorEditor = forwardRef<
         ref={editorRef}
         onBlur={onBlur}
         onFocus={handleFocus}
-        className={cn("text-sm", className)}
+        className={className}
       />
     );
   },

--- a/src/components/editor/extensions.ts
+++ b/src/components/editor/extensions.ts
@@ -34,6 +34,10 @@ export const notebookEditorTheme = EditorView.theme({
   "&.cm-focused": {
     outline: "none",
   },
+  // Font size to match gutter elements (text-sm = 14px)
+  ".cm-content": {
+    fontSize: "14px",
+  },
   // Mobile-friendly padding
   "@media (max-width: 640px)": {
     ".cm-content": {


### PR DESCRIPTION
## Summary
Brings in upstream nteract/elements components with dark mode support and new CompactExecutionButton. Typography now explicitly sized to 14px with tabular-nums for alignment. Increased left page margin for breathing room.

## Changes
- Add CellBetweener, CompactExecutionButton, gutter-colors.ts from nteract/elements
- Update CellContainer, PlayButton, ExecutionCount to use upstream versions
- Fix CodeMirror font-size to match gutter elements (14px)
- Increase page left padding for multi-digit execution counts