### PR TITLE
Add dark mode support to markdown output and fix ANSI colors

### DIFF
--- a/contributing/nteract-elements.md
+++ b/contributing/nteract-elements.md
@@ -53,10 +53,7 @@ Keep local changes that:
 
 ### How to Upstream
 
-1. **Clone nteract/elements** (if you haven't):
-   ```bash
-   git clone https://github.com/nteract/elements ~/code/nteract/elements
-   ```
+1. **Clone nteract/elements** (if you haven't already)
 
 2. **Make the change** in the registry source files:
    - Component code: `registry/outputs/`, `registry/cell/`, etc.
@@ -64,7 +61,6 @@ Keep local changes that:
 
 3. **Test locally** by running the elements docs site:
    ```bash
-   cd ~/code/nteract/elements
    pnpm install
    pnpm dev
    ```

--- a/contributing/nteract-elements.md
+++ b/contributing/nteract-elements.md
@@ -1,0 +1,121 @@
+# Working with nteract/elements
+
+This project uses components from the [nteract/elements](https://github.com/nteract/elements) registry via shadcn. This guide covers how to update components, make local customizations, and contribute upstream.
+
+## Architecture
+
+```
+nteract/elements (upstream)    →    this repo (consumer)
+├── registry.json                   ├── src/components/
+├── registry/outputs/               │   ├── outputs/      (from registry)
+├── registry/cell/                  │   ├── cell/         (from registry)
+└── registry/editor/                │   └── editor/       (from registry)
+```
+
+Components are installed via `npx shadcn add @nteract/<component>`. Once installed, they become local files we can modify.
+
+## Updating Components
+
+Pull the latest version from the registry:
+
+```bash
+npx shadcn@latest add @nteract/markdown-output --overwrite
+npx shadcn@latest add @nteract/ansi-output --overwrite
+```
+
+The `--overwrite` flag replaces local files with upstream versions.
+
+## Local Customizations
+
+When you need to modify a component locally:
+
+1. **Make the change** in `src/components/`
+2. **Document why** in a code comment if the change is intentional divergence
+3. **Consider upstreaming** if the change would benefit other consumers
+
+Local changes will be overwritten by `--overwrite`. To preserve customizations:
+- Don't use `--overwrite` for that component, OR
+- Upstream the change to nteract/elements first
+
+## Contributing Upstream
+
+### When to Upstream
+
+Upstream changes that:
+- Fix bugs in the registry components
+- Add generally useful features
+- Improve dark mode / theme support
+- Fix CSS variable issues
+
+Keep local changes that:
+- Are specific to this project's needs
+- Depend on local utilities not in the registry
+
+### How to Upstream
+
+1. **Clone nteract/elements** (if you haven't):
+   ```bash
+   git clone https://github.com/nteract/elements ~/code/nteract/elements
+   ```
+
+2. **Make the change** in the registry source files:
+   - Component code: `registry/outputs/`, `registry/cell/`, etc.
+   - CSS variables: Both `app/global.css` AND `registry.json` (see below)
+
+3. **Test locally** by running the elements docs site:
+   ```bash
+   cd ~/code/nteract/elements
+   pnpm install
+   pnpm dev
+   ```
+
+4. **Create a PR** to nteract/elements
+
+5. **After merge**, update this repo:
+   ```bash
+   npx shadcn@latest add @nteract/<component> --overwrite
+   ```
+
+### CSS Variables (Important!)
+
+CSS variables must be defined in **two places** in nteract/elements:
+
+1. **`app/global.css`** — For the docs site
+2. **`registry.json`** — For consumers installing via shadcn
+
+If you change a CSS variable, update both files with identical values. See [nteract/elements contributing/css-variables.md](https://github.com/nteract/elements/blob/main/contributing/css-variables.md).
+
+## Shared Utilities
+
+Some utilities are shared across components:
+
+| Utility | Location | Purpose |
+|---------|----------|---------|
+| `isDarkMode()` | `@/components/themes` | Theme detection |
+| `cn()` | `@/lib/utils` | Class name merging |
+
+If nteract/elements bundles utilities with components (like `dark-mode.ts` with `markdown-output`), we can either:
+- Use the bundled version (self-contained)
+- Use our shared module and adjust the import
+
+## Troubleshooting
+
+### Import path mismatches
+
+If a component imports from a path that doesn't exist (e.g., `@/components/themes` vs `@/components/editor/themes`):
+
+1. Check what path nteract/elements expects
+2. Either create the expected path, or adjust the import locally
+
+### CSS variables not applying
+
+1. Ensure `src/styles/ansi.css` (or similar) is imported in `src/index.css`
+2. Check that the `.dark` selector matches your dark mode implementation
+3. Verify values match between local CSS and registry.json
+
+### Build errors after update
+
+Run `pnpm run types:check` to catch TypeScript errors. Common issues:
+- Missing imports (add the dependency)
+- Path mismatches (adjust imports)
+- Type mismatches (check component prop changes)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4188,7 +4188,7 @@ snapshots:
       '@lumino/signaling': 2.1.5
       '@lumino/virtualdom': 2.0.4
       '@lumino/widgets': 2.7.5
-      '@rjsf/core': 5.24.13(@rjsf/utils@5.24.13(react@18.3.1))(react@18.3.1)
+      '@rjsf/core': 5.24.13(@rjsf/utils@5.24.13(react@19.2.4))(react@18.3.1)
       '@rjsf/utils': 5.24.13(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -5091,9 +5091,9 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
-  '@rjsf/core@5.24.13(@rjsf/utils@5.24.13(react@18.3.1))(react@18.3.1)':
+  '@rjsf/core@5.24.13(@rjsf/utils@5.24.13(react@19.2.4))(react@18.3.1)':
     dependencies:
-      '@rjsf/utils': 5.24.13(react@18.3.1)
+      '@rjsf/utils': 5.24.13(react@19.2.4)
       lodash: 4.17.23
       lodash-es: 4.17.23
       markdown-to-jsx: 7.7.17(react@18.3.1)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4188,7 +4188,7 @@ snapshots:
       '@lumino/signaling': 2.1.5
       '@lumino/virtualdom': 2.0.4
       '@lumino/widgets': 2.7.5
-      '@rjsf/core': 5.24.13(@rjsf/utils@5.24.13(react@19.2.4))(react@18.3.1)
+      '@rjsf/core': 5.24.13(@rjsf/utils@5.24.13(react@18.3.1))(react@18.3.1)
       '@rjsf/utils': 5.24.13(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -5091,9 +5091,9 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
-  '@rjsf/core@5.24.13(@rjsf/utils@5.24.13(react@19.2.4))(react@18.3.1)':
+  '@rjsf/core@5.24.13(@rjsf/utils@5.24.13(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@rjsf/utils': 5.24.13(react@19.2.4)
+      '@rjsf/utils': 5.24.13(react@18.3.1)
       lodash: 4.17.23
       lodash-es: 4.17.23
       markdown-to-jsx: 7.7.17(react@18.3.1)

--- a/src/components/editor/themes.ts
+++ b/src/components/editor/themes.ts
@@ -1,10 +1,15 @@
 import type { Extension } from "@codemirror/state";
 import { githubDark, githubLight } from "@uiw/codemirror-theme-github";
 
-/**
- * Theme mode options
- */
-export type ThemeMode = "light" | "dark" | "system";
+// Re-export generic theme utilities from shared module
+export {
+  type ThemeMode,
+  prefersDarkMode,
+  documentHasDarkMode,
+  isDarkMode,
+} from "@/components/themes";
+
+import { isDarkMode } from "@/components/themes";
 
 /**
  * Light theme - GitHub Light
@@ -19,7 +24,7 @@ export const darkTheme: Extension = githubDark;
 /**
  * Get the appropriate theme extension based on mode
  */
-export function getTheme(mode: ThemeMode): Extension {
+export function getTheme(mode: "light" | "dark" | "system"): Extension {
   if (mode === "light") {
     return lightTheme;
   }
@@ -35,86 +40,6 @@ export function getTheme(mode: ThemeMode): Extension {
   }
   // SSR fallback
   return lightTheme;
-}
-
-/**
- * Check if the current environment prefers dark mode via system preference
- */
-export function prefersDarkMode(): boolean {
-  if (typeof window === "undefined") {
-    return false;
-  }
-  return window.matchMedia("(prefers-color-scheme: dark)").matches;
-}
-
-/**
- * Check if the document has dark mode enabled
- * Checks multiple common patterns:
- * - class="dark" or class="... dark ..." on <html>
- * - color-scheme: dark on <html>
- * - data-theme="dark" attribute
- */
-export function documentHasDarkMode(): boolean {
-  if (typeof document === "undefined") {
-    return false;
-  }
-
-  const html = document.documentElement;
-
-  // Check for 'dark' in classList (Tailwind / fumadocs pattern)
-  if (html.classList.contains("dark")) {
-    return true;
-  }
-
-  // Check color-scheme style
-  const colorScheme =
-    html.style.colorScheme || getComputedStyle(html).colorScheme;
-  if (colorScheme === "dark") {
-    return true;
-  }
-
-  // Check data-theme attribute (another common pattern)
-  if (html.getAttribute("data-theme") === "dark") {
-    return true;
-  }
-
-  // Check data-mode attribute
-  if (html.getAttribute("data-mode") === "dark") {
-    return true;
-  }
-
-  return false;
-}
-
-/**
- * Detect dark mode from either document state or system preference
- * Prioritizes document state (site-level toggle) over system preference
- */
-export function isDarkMode(): boolean {
-  // Check document state first (site-level dark mode toggle)
-  if (documentHasDarkMode()) {
-    return true;
-  }
-
-  // Check if document explicitly has light mode set
-  if (typeof document !== "undefined") {
-    const html = document.documentElement;
-
-    // If 'light' class is present, respect it
-    if (html.classList.contains("light")) {
-      return false;
-    }
-
-    // If color-scheme is explicitly light, respect it
-    const colorScheme =
-      html.style.colorScheme || getComputedStyle(html).colorScheme;
-    if (colorScheme === "light") {
-      return false;
-    }
-  }
-
-  // Fall back to system preference
-  return prefersDarkMode();
 }
 
 /**

--- a/src/components/outputs/markdown-output.tsx
+++ b/src/components/outputs/markdown-output.tsx
@@ -13,7 +13,7 @@ import rehypeRaw from "rehype-raw";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 import { cn } from "@/lib/utils";
-import { isDarkMode } from "@/components/themes";
+import { isDarkMode } from "@/components/editor/themes";
 
 import "katex/dist/katex.min.css";
 

--- a/src/components/outputs/markdown-output.tsx
+++ b/src/components/outputs/markdown-output.tsx
@@ -13,7 +13,7 @@ import rehypeRaw from "rehype-raw";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 import { cn } from "@/lib/utils";
-import { isDarkMode } from "@/components/editor/themes";
+import { isDarkMode } from "@/components/themes";
 
 import "katex/dist/katex.min.css";
 

--- a/src/components/themes.ts
+++ b/src/components/themes.ts
@@ -1,0 +1,91 @@
+/**
+ * Generic theme detection utilities
+ *
+ * These functions detect dark/light mode from document state or system preferences.
+ * Used by various components (markdown output, code editor, etc.) for theme-aware rendering.
+ */
+
+/**
+ * Theme mode options
+ */
+export type ThemeMode = "light" | "dark" | "system";
+
+/**
+ * Check if the current environment prefers dark mode via system preference
+ */
+export function prefersDarkMode(): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+  return window.matchMedia("(prefers-color-scheme: dark)").matches;
+}
+
+/**
+ * Check if the document has dark mode enabled
+ * Checks multiple common patterns:
+ * - class="dark" or class="... dark ..." on <html>
+ * - color-scheme: dark on <html>
+ * - data-theme="dark" attribute
+ */
+export function documentHasDarkMode(): boolean {
+  if (typeof document === "undefined") {
+    return false;
+  }
+
+  const html = document.documentElement;
+
+  // Check for 'dark' in classList (Tailwind / fumadocs pattern)
+  if (html.classList.contains("dark")) {
+    return true;
+  }
+
+  // Check color-scheme style
+  const colorScheme =
+    html.style.colorScheme || getComputedStyle(html).colorScheme;
+  if (colorScheme === "dark") {
+    return true;
+  }
+
+  // Check data-theme attribute (another common pattern)
+  if (html.getAttribute("data-theme") === "dark") {
+    return true;
+  }
+
+  // Check data-mode attribute
+  if (html.getAttribute("data-mode") === "dark") {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Detect dark mode from either document state or system preference
+ * Prioritizes document state (site-level toggle) over system preference
+ */
+export function isDarkMode(): boolean {
+  // Check document state first (site-level dark mode toggle)
+  if (documentHasDarkMode()) {
+    return true;
+  }
+
+  // Check if document explicitly has light mode set
+  if (typeof document !== "undefined") {
+    const html = document.documentElement;
+
+    // If 'light' class is present, respect it
+    if (html.classList.contains("light")) {
+      return false;
+    }
+
+    // If color-scheme is explicitly light, respect it
+    const colorScheme =
+      html.style.colorScheme || getComputedStyle(html).colorScheme;
+    if (colorScheme === "light") {
+      return false;
+    }
+  }
+
+  // Fall back to system preference
+  return prefersDarkMode();
+}

--- a/src/styles/ansi.css
+++ b/src/styles/ansi.css
@@ -56,7 +56,7 @@
     --ansi-black-bg: #484f58;
     --ansi-red-bg: #b31d28;
     --ansi-green-bg: #176f2c;
-    --ansi-yellow-bg: #735c0f;
+    --ansi-yellow-bg: #b5a000;
     --ansi-blue-bg: #1158c7;
     --ansi-magenta-bg: #5a32a3;
     --ansi-cyan-bg: #0e7481;


### PR DESCRIPTION
## Summary
- Updates markdown-output with dark mode support via `useDarkMode()` hook
- Theme-aware code syntax highlighting (oneLight/oneDark)
- Dark mode styles for tables, links, blockquotes, inline code, copy buttons
- Fixes dark mode ANSI yellow background to #b5a000 for better visibility

## Notes
The ANSI yellow fix aligns with nteract/elements PR #146 which updates the registry.json.