### PR TITLE
Add contributing guidelines and CLAUDE.md symlink for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,3 +19,9 @@ Keep descriptions short and descriptive, e.g.:
 - "Adding ipywidgets support"
 
 The `.context/` directory is gitignored and used for per-worktree state that shouldn't be committed.
+
+## Contributing Guidelines
+
+See the `contributing/` directory for detailed guides:
+- `contributing/ui.md` - UI components and shadcn setup
+- `contributing/nteract-elements.md` - Working with nteract/elements registry

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Summary
- Add contributing guidelines section to AGENTS.md referencing UI and nteract documentation
- Create CLAUDE.md symlink pointing to AGENTS.md to support Claude Code agent instructions

Until Claude Code natively supports AGENTS.md fallback (anthropics/claude-code#6235), the symlink ensures agents can read the same instructions through CLAUDE.md.

## Test Plan
- Verify CLAUDE.md symlink resolves correctly: `cat CLAUDE.md`
- Confirm both files have identical content
- Validate agent sessions pick up the contributing guidelines reference