### PR TITLE
Disable browser autocomplete and spellcheck for dependency inputs

### DIFF
--- a/apps/notebook/src/components/CondaDependencyHeader.tsx
+++ b/apps/notebook/src/components/CondaDependencyHeader.tsx
@@ -149,6 +149,8 @@ export function CondaDependencyHeader({
                   className="w-32 rounded border bg-background px-1.5 py-0.5 text-xs placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
                   autoFocus
                   disabled={loading}
+                  autoComplete="off"
+                  spellCheck={false}
                 />
                 <button
                   type="button"
@@ -183,6 +185,8 @@ export function CondaDependencyHeader({
             placeholder="3.11"
             className="w-20 rounded border bg-background px-1.5 py-0.5 text-xs font-mono placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
             disabled={loading}
+            autoComplete="off"
+            spellCheck={false}
           />
         </div>
 
@@ -223,6 +227,8 @@ export function CondaDependencyHeader({
             placeholder="package or package>=version"
             className="flex-1 rounded border bg-background px-2 py-1 text-xs placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
             disabled={loading}
+            autoComplete="off"
+            spellCheck={false}
           />
           <button
             type="button"

--- a/apps/notebook/src/components/DependencyHeader.tsx
+++ b/apps/notebook/src/components/DependencyHeader.tsx
@@ -192,6 +192,8 @@ export function DependencyHeader({
               placeholder="package or package>=version"
               className="flex-1 rounded border bg-background px-2 py-1 text-xs placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
               disabled={loading}
+              autoComplete="off"
+              spellCheck={false}
             />
             <button
               type="button"


### PR DESCRIPTION
Prevents the browser from interfering with package names and version specifications in the dependency management UI. The autocomplete and spellcheck features were showing unwanted suggestions and red underlines for valid package names.