### PR TITLE
Implement Ctrl+R IPython history search

### DIFF
--- a/apps/notebook/src/components/HistorySearchDialog.tsx
+++ b/apps/notebook/src/components/HistorySearchDialog.tsx
@@ -1,0 +1,198 @@
+import { useEffect, useCallback, useState, useMemo, useRef, memo, useDeferredValue } from "react";
+import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
+import {
+  oneDark,
+  oneLight,
+} from "react-syntax-highlighter/dist/esm/styles/prism";
+import {
+  Command,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+} from "@/components/ui/command";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { isDarkMode } from "@/components/themes";
+import {
+  useHistorySearch,
+  type HistoryEntry,
+} from "../hooks/useHistorySearch";
+
+interface HistorySearchDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSelect: (source: string) => void;
+}
+
+/** Syntax-highlighted code preview for history entries (memoized to avoid re-renders) */
+const CodePreview = memo(function CodePreview({ code, maxLines = 8 }: { code: string; maxLines?: number }) {
+  const isDark = isDarkMode();
+
+  // Truncate to maxLines
+  const lines = code.split("\n");
+  const truncated = lines.length > maxLines;
+  const displayCode = truncated
+    ? lines.slice(0, maxLines).join("\n") + "\n..."
+    : code;
+
+  return (
+    <SyntaxHighlighter
+      language="python"
+      style={isDark ? oneDark : oneLight}
+      customStyle={{
+        margin: 0,
+        padding: "0.5rem",
+        fontSize: "0.75rem",
+        lineHeight: "1.4",
+        background: "transparent",
+        overflow: "hidden",
+      }}
+      codeTagProps={{
+        style: {
+          fontFamily: "var(--font-mono, ui-monospace, monospace)",
+        },
+      }}
+    >
+      {displayCode}
+    </SyntaxHighlighter>
+  );
+});
+
+export function HistorySearchDialog({
+  open,
+  onOpenChange,
+  onSelect,
+}: HistorySearchDialogProps) {
+  const { entries, isLoading, error, searchHistory, clearEntries } =
+    useHistorySearch();
+  const [searchValue, setSearchValue] = useState("");
+  // Defer the search value for filtering to keep input responsive
+  const deferredSearchValue = useDeferredValue(searchValue);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Fetch initial history (Tail) when dialog opens
+  useEffect(() => {
+    if (open) {
+      searchHistory(); // No pattern = Tail request
+      setSearchValue("");
+    } else {
+      clearEntries();
+    }
+  }, [open, searchHistory, clearEntries]);
+
+  // Debounced kernel search when user types
+  useEffect(() => {
+    if (!open) return;
+
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+    }
+
+    debounceRef.current = setTimeout(() => {
+      // Only call kernel search if there's a non-empty search term
+      if (searchValue.trim()) {
+        searchHistory(searchValue.trim());
+      } else {
+        // Empty search = fetch tail again
+        searchHistory();
+      }
+    }, 300);
+
+    return () => {
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+      }
+    };
+  }, [searchValue, open, searchHistory]);
+
+  // Filter client-side using deferred value to keep input responsive
+  const filteredEntries = useMemo(() => {
+    if (!deferredSearchValue.trim()) {
+      return entries;
+    }
+    const search = deferredSearchValue.toLowerCase();
+    return entries.filter((entry) =>
+      entry.source.toLowerCase().includes(search)
+    );
+  }, [entries, deferredSearchValue]);
+
+  const handleSelect = useCallback(
+    (entry: HistoryEntry) => {
+      onSelect(entry.source);
+      onOpenChange(false);
+    },
+    [onSelect, onOpenChange]
+  );
+
+  // Determine what empty message to show
+  // Only show loading/empty messages when there are no entries to display
+  const emptyMessage = useMemo(() => {
+    if (error) {
+      if (error.includes("No kernel running")) {
+        return "Start a kernel to search history.";
+      }
+      return `Error: ${error}`;
+    }
+    // Show loading message only when we have nothing to display
+    if (isLoading && filteredEntries.length === 0) {
+      return "Searching history...";
+    }
+    if (entries.length === 0) {
+      return "No history found.";
+    }
+    if (filteredEntries.length === 0) {
+      return "No matching history.";
+    }
+    return null;
+  }, [error, isLoading, entries.length, filteredEntries.length]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogHeader className="sr-only">
+        <DialogTitle>History Search</DialogTitle>
+        <DialogDescription>
+          Search through your IPython command history (Ctrl+R)
+        </DialogDescription>
+      </DialogHeader>
+      <DialogContent className="overflow-hidden p-0 max-w-2xl" showCloseButton={false}>
+        <Command
+          shouldFilter={false}
+          className="[&_[cmdk-group-heading]]:text-muted-foreground **:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-1 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5"
+        >
+          <CommandInput
+            placeholder="Search history..."
+            value={searchValue}
+            onValueChange={setSearchValue}
+          />
+          <CommandList className="max-h-[400px]">
+            {emptyMessage ? (
+              <CommandEmpty>{emptyMessage}</CommandEmpty>
+            ) : (
+              <CommandGroup heading={`History${isLoading ? " (searching...)" : ""}`}>
+                {filteredEntries.map((entry, index) => (
+                  <CommandItem
+                    key={`${entry.session}-${entry.line}-${index}`}
+                    value={`${entry.session}-${entry.line}`}
+                    onSelect={() => handleSelect(entry)}
+                    className="cursor-pointer"
+                  >
+                    <div className="w-full overflow-hidden rounded border border-border/50">
+                      <CodePreview code={entry.source} maxLines={6} />
+                    </div>
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            )}
+          </CommandList>
+        </Command>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/notebook/src/hooks/useHistorySearch.ts
+++ b/apps/notebook/src/hooks/useHistorySearch.ts
@@ -1,0 +1,111 @@
+import { useState, useCallback, useRef } from "react";
+import { invoke } from "@tauri-apps/api/core";
+
+export interface HistoryEntry {
+  session: number;
+  line: number;
+  source: string;
+}
+
+interface HistoryResult {
+  entries: HistoryEntry[];
+}
+
+// MRU cache for search queries (pattern -> entries)
+// Uses Map iteration order: oldest at start, newest at end
+const MAX_CACHE_SIZE = 20;
+const searchCache = new Map<string, HistoryEntry[]>();
+
+function getCacheKey(pattern: string | undefined): string {
+  return pattern ?? "__tail__";
+}
+
+function getCachedResult(pattern: string | undefined): HistoryEntry[] | null {
+  const key = getCacheKey(pattern);
+  const result = searchCache.get(key);
+  if (result) {
+    // Move to end (most recently used) - delete and re-add
+    searchCache.delete(key);
+    searchCache.set(key, result);
+    return result;
+  }
+  return null;
+}
+
+function setCacheResult(pattern: string | undefined, entries: HistoryEntry[]) {
+  const key = getCacheKey(pattern);
+  // Remove if exists (will re-add at end)
+  searchCache.delete(key);
+  // Evict oldest if at capacity
+  if (searchCache.size >= MAX_CACHE_SIZE) {
+    const oldestKey = searchCache.keys().next().value;
+    if (oldestKey !== undefined) {
+      searchCache.delete(oldestKey);
+    }
+  }
+  searchCache.set(key, entries);
+}
+
+// Alias for backward compatibility
+function getTailCache(): HistoryEntry[] {
+  return getCachedResult(undefined) ?? [];
+}
+
+export function useHistorySearch() {
+  const [entries, setEntries] = useState<HistoryEntry[]>(getTailCache);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  // Track the current search pattern to avoid race conditions
+  const currentSearchRef = useRef<string | undefined>(undefined);
+
+  const searchHistory = useCallback(async (pattern?: string) => {
+    // Track this search request
+    currentSearchRef.current = pattern;
+
+    // Check cache first - if we have results, show them immediately
+    const cached = getCachedResult(pattern);
+    if (cached) {
+      setEntries(cached);
+      // Still fetch fresh results in background, but don't show loading
+      // This gives instant feedback for typo corrections / backspace
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const result = await invoke<HistoryResult>("get_history", {
+        pattern: pattern || null,
+        n: 100,
+      });
+
+      // Only update if this is still the current search (avoid race conditions)
+      if (currentSearchRef.current === pattern) {
+        setEntries(result.entries);
+        // Cache the result
+        setCacheResult(pattern, result.entries);
+      }
+    } catch (e) {
+      const errorMsg = e instanceof Error ? e.message : String(e);
+      // Only update error if this is still the current search
+      if (currentSearchRef.current === pattern) {
+        setError(errorMsg);
+        // Don't clear entries on error - keep showing what we have
+      }
+    } finally {
+      // Only clear loading if this is still the current search
+      if (currentSearchRef.current === pattern) {
+        setIsLoading(false);
+      }
+    }
+  }, []);
+
+  const clearEntries = useCallback(() => {
+    // Reset to tail cache (or empty if no cache)
+    setEntries(getTailCache());
+    setError(null);
+    currentSearchRef.current = undefined;
+  }, []);
+
+  return { entries, isLoading, error, searchHistory, clearEntries };
+}


### PR DESCRIPTION
## Summary

Add readline-style Ctrl+R history search to notebook cells. When pressed, opens a dialog showing IPython command history with Python syntax highlighting. Supports hybrid search: starts with recent history (tail), switches to kernel search when typing. Results are cached (MRU, 20 entries) for instant response on corrections.

## Features

- Ctrl+R opens searchable history dialog with syntax highlighting
- Tail mode shows recent history instantly on open
- Kernel search on typing with substring matching  
- Client-side filtering for immediate feedback during debounce
- Query result caching (20 entries) to avoid refetch on typo corrections
- Input responsiveness via `useDeferredValue` deferred filtering
- Memoized code preview to prevent re-rendering during typing

## Technical

- Backend: Jupyter protocol HistoryRequest (Tail/Search variants)
- Frontend: React hooks for caching/debouncing, cmdk for UI
- Performance: Deferred value for non-blocking input, MRU cache