### PR TITLE
Add Deno kernel support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3097,6 +3097,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "chrono",
+ "clap",
  "dirs 5.0.1",
  "env_logger",
  "futures",

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -78,6 +78,16 @@ function AppContent() {
   // Track pending kernel start that was blocked by trust dialog
   const pendingKernelStartRef = useRef(false);
 
+  // Notebook runtime type (python or deno)
+  const [runtime, setRuntime] = useState<"python" | "deno">("python");
+
+  // Load runtime from notebook metadata on mount
+  useEffect(() => {
+    invoke<string>("get_notebook_runtime").then((r) => {
+      setRuntime(r as "python" | "deno");
+    });
+  }, []);
+
   // Page payload state: maps cell_id -> payload (transient, not saved)
   const [pagePayloads, setPagePayloads] = useState<Map<string, CellPagePayload>>(
     new Map()
@@ -325,6 +335,7 @@ onKernelStarted: loadCondaDependencies,
         hasDependencies={hasDependencies}
         theme={theme}
         envProgress={envProgress.isActive ? envProgress : null}
+        runtime={runtime}
         onThemeChange={setTheme}
         onSave={save}
         onStartKernel={handleStartKernel}

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -417,6 +417,7 @@ onKernelStarted: loadCondaDependencies,
         focusedCellId={focusedCellId}
         executingCellIds={executingCellIds}
         pagePayloads={pagePayloads}
+        runtime={runtime}
         onFocusCell={setFocusedCellId}
         onUpdateCellSource={updateCellSource}
         onExecuteCell={handleExecuteCell}

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -126,16 +126,8 @@ function AppContent() {
     setPython: setCondaPython,
   } = useCondaDependencies();
 
-  // Deno permissions management
-  const {
-    permissions: denoPermissions,
-    denoAvailable,
-    denoConfigInfo,
-    loading: denoLoading,
-    addPermission: addDenoPermission,
-    removePermission: removeDenoPermission,
-    togglePermission: toggleDenoPermission,
-  } = useDenoDependencies();
+  // Deno config detection
+  const { denoAvailable, denoConfigInfo } = useDenoDependencies();
 
   // Auto-detect environment type based on what's configured
   // uv takes priority if metadata exists (even with empty deps)
@@ -146,10 +138,9 @@ function AppContent() {
       : null;
 
   // Combine hasDependencies for toolbar badge
-  // For Deno, we show the badge if any permissions are set
-  const hasDenoPermissions = denoPermissions.length > 0;
+  // For Deno, show badge if deno.json is found with imports
   const hasDependencies = runtime === "deno"
-    ? hasDenoPermissions
+    ? denoConfigInfo?.has_imports ?? false
     : hasUvDependencies || hasCondaDependencies;
 
   // Get widget store handler for routing comm messages
@@ -364,13 +355,8 @@ onKernelStarted: loadCondaDependencies,
       />
       {dependencyHeaderOpen && runtime === "deno" && (
         <DenoDependencyHeader
-          permissions={denoPermissions}
           denoAvailable={denoAvailable}
           denoConfigInfo={denoConfigInfo}
-          loading={denoLoading}
-          onTogglePermission={toggleDenoPermission}
-          onAddPermission={addDenoPermission}
-          onRemovePermission={removeDenoPermission}
         />
       )}
       {dependencyHeaderOpen && runtime === "python" && envType === "conda" && (

--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -8,6 +8,7 @@ import {
   CodeMirrorEditor,
   type CodeMirrorEditorRef,
 } from "@/components/editor/codemirror-editor";
+import type { SupportedLanguage } from "@/components/editor/languages";
 import { Trash2, X } from "lucide-react";
 import { kernelCompletionExtension } from "../lib/kernel-completion";
 import { useCellKeyboardNavigation } from "../hooks/useCellKeyboardNavigation";
@@ -57,6 +58,7 @@ function PagePayloadDisplay({
 
 interface CodeCellProps {
   cell: CodeCellType;
+  language?: SupportedLanguage;
   isFocused: boolean;
   isExecuting: boolean;
   pagePayload: CellPagePayload | null;
@@ -74,6 +76,7 @@ interface CodeCellProps {
 
 export function CodeCell({
   cell,
+  language = "python",
   isFocused,
   isExecuting,
   pagePayload,
@@ -215,7 +218,7 @@ export function CodeCell({
           <CodeMirrorEditor
             ref={editorRef}
             value={cell.source}
-            language="python"
+            language={language}
             onValueChange={onUpdateSource}
             keyMap={keyMap}
             extensions={[kernelCompletionExtension]}

--- a/apps/notebook/src/components/DenoDependencyHeader.tsx
+++ b/apps/notebook/src/components/DenoDependencyHeader.tsx
@@ -1,0 +1,220 @@
+import { useState, useCallback, type KeyboardEvent } from "react";
+import { X, Plus, Info, FileText, Shield, ShieldCheck, ShieldAlert } from "lucide-react";
+import type { DenoConfigInfo } from "../hooks/useDenoDependencies";
+import { COMMON_PERMISSIONS } from "../hooks/useDenoDependencies";
+
+interface DenoDependencyHeaderProps {
+  permissions: string[];
+  denoAvailable: boolean | null;
+  denoConfigInfo: DenoConfigInfo | null;
+  loading: boolean;
+  onTogglePermission: (flag: string) => Promise<void>;
+  onAddPermission: (permission: string) => Promise<void>;
+  onRemovePermission: (permission: string) => Promise<void>;
+}
+
+export function DenoDependencyHeader({
+  permissions,
+  denoAvailable,
+  denoConfigInfo,
+  loading,
+  onTogglePermission,
+  onAddPermission,
+  onRemovePermission,
+}: DenoDependencyHeaderProps) {
+  const [newPermission, setNewPermission] = useState("");
+
+  const handleAdd = useCallback(async () => {
+    if (newPermission.trim()) {
+      await onAddPermission(newPermission.trim());
+      setNewPermission("");
+    }
+  }, [newPermission, onAddPermission]);
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        handleAdd();
+      }
+    },
+    [handleAdd]
+  );
+
+  // Check if --allow-all is set
+  const hasAllowAll = permissions.includes("--allow-all");
+
+  // Get custom permissions (those not in COMMON_PERMISSIONS)
+  const commonFlags: Set<string> = new Set(COMMON_PERMISSIONS.map((p) => p.flag));
+  const customPermissions = permissions.filter(
+    (p) => !commonFlags.has(p) && p !== "--allow-all"
+  );
+
+  return (
+    <div className="border-b bg-emerald-500/5 dark:bg-emerald-500/10">
+      <div className="px-3 py-3">
+        {/* Deno badge */}
+        <div className="mb-2 flex items-center gap-2">
+          <span className="rounded bg-emerald-500/20 px-1.5 py-0.5 text-xs font-medium text-emerald-600 dark:text-emerald-400">
+            Deno
+          </span>
+          <span className="text-xs text-muted-foreground">Permissions</span>
+        </div>
+
+        {/* Deno availability notice */}
+        {denoAvailable === false && (
+          <div className="mb-3 rounded bg-amber-500/10 px-2 py-1.5 text-xs text-amber-700 dark:text-amber-400">
+            <span className="font-medium">Deno not found.</span> Install it with{" "}
+            <code className="rounded bg-amber-500/20 px-1">
+              curl -fsSL https://deno.land/install.sh | sh
+            </code>
+          </div>
+        )}
+
+        {/* deno.json detected banner */}
+        {denoConfigInfo && (
+          <div className="mb-3 rounded bg-emerald-500/10 px-2 py-1.5 text-xs text-emerald-600 dark:text-emerald-400">
+            <div className="flex items-center gap-2">
+              <FileText className="h-3.5 w-3.5 shrink-0" />
+              <span>
+                Using config from{" "}
+                <code className="rounded bg-emerald-500/20 px-1">
+                  {denoConfigInfo.relative_path}
+                </code>
+                {denoConfigInfo.name && (
+                  <span className="text-muted-foreground ml-1">
+                    ({denoConfigInfo.name})
+                  </span>
+                )}
+              </span>
+            </div>
+            {(denoConfigInfo.has_imports || denoConfigInfo.has_tasks) && (
+              <div className="mt-1.5 flex gap-2 text-emerald-500/80">
+                {denoConfigInfo.has_imports && (
+                  <span className="rounded bg-emerald-500/10 px-1.5 py-0.5">
+                    imports
+                  </span>
+                )}
+                {denoConfigInfo.has_tasks && (
+                  <span className="rounded bg-emerald-500/10 px-1.5 py-0.5">
+                    tasks
+                  </span>
+                )}
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Permissions info */}
+        <div className="mb-3 flex items-start gap-2 rounded bg-muted/50 px-2 py-1.5 text-xs text-muted-foreground">
+          <Info className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+          <span>
+            Deno runs in a sandbox by default. Grant permissions for file system,
+            network, or other system access.
+          </span>
+        </div>
+
+        {/* Allow all toggle */}
+        <div className="mb-3">
+          <button
+            type="button"
+            onClick={() => onTogglePermission("--allow-all")}
+            disabled={loading}
+            className={`flex items-center gap-2 rounded px-2 py-1.5 text-xs transition-colors ${
+              hasAllowAll
+                ? "bg-amber-500/20 text-amber-700 dark:text-amber-400"
+                : "bg-muted/50 text-muted-foreground hover:bg-muted"
+            }`}
+          >
+            {hasAllowAll ? (
+              <ShieldAlert className="h-3.5 w-3.5" />
+            ) : (
+              <Shield className="h-3.5 w-3.5" />
+            )}
+            <span className="font-medium">--allow-all</span>
+            <span className="text-muted-foreground">
+              {hasAllowAll ? "(all permissions granted)" : "(grant all permissions)"}
+            </span>
+          </button>
+        </div>
+
+        {/* Common permissions grid */}
+        {!hasAllowAll && (
+          <div className="mb-3 grid grid-cols-2 gap-1.5 sm:grid-cols-4">
+            {COMMON_PERMISSIONS.map(({ flag, label, description }) => {
+              const isEnabled = permissions.includes(flag);
+              return (
+                <button
+                  key={flag}
+                  type="button"
+                  onClick={() => onTogglePermission(flag)}
+                  disabled={loading}
+                  className={`flex items-center gap-1.5 rounded px-2 py-1.5 text-xs transition-colors ${
+                    isEnabled
+                      ? "bg-emerald-500/20 text-emerald-600 dark:text-emerald-400"
+                      : "bg-muted/50 text-muted-foreground hover:bg-muted"
+                  }`}
+                  title={description}
+                >
+                  {isEnabled ? (
+                    <ShieldCheck className="h-3 w-3" />
+                  ) : (
+                    <Shield className="h-3 w-3" />
+                  )}
+                  <span>{label}</span>
+                </button>
+              );
+            })}
+          </div>
+        )}
+
+        {/* Custom permissions list */}
+        {customPermissions.length > 0 && (
+          <div className="mb-3 flex flex-wrap gap-1.5">
+            {customPermissions.map((perm) => (
+              <div
+                key={perm}
+                className="flex items-center gap-1 rounded bg-background px-2 py-1 text-xs border"
+              >
+                <span className="font-mono">{perm}</span>
+                <button
+                  type="button"
+                  onClick={() => onRemovePermission(perm)}
+                  className="text-muted-foreground hover:text-foreground transition-colors"
+                  disabled={loading}
+                  title={`Remove ${perm}`}
+                >
+                  <X className="h-3 w-3" />
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Add custom permission input */}
+        <div className="flex gap-2">
+          <input
+            type="text"
+            value={newPermission}
+            onChange={(e) => setNewPermission(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="--allow-read=/path or --allow-net=example.com"
+            className="flex-1 rounded border bg-background px-2 py-1 text-xs placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-emerald-500"
+            disabled={loading}
+            autoComplete="off"
+            spellCheck={false}
+          />
+          <button
+            type="button"
+            onClick={handleAdd}
+            disabled={loading || !newPermission.trim()}
+            className="flex items-center gap-1 rounded bg-emerald-500 px-2 py-1 text-xs text-white transition-colors hover:bg-emerald-600 disabled:opacity-50"
+          >
+            <Plus className="h-3 w-3" />
+            Add
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/notebook/src/components/DenoDependencyHeader.tsx
+++ b/apps/notebook/src/components/DenoDependencyHeader.tsx
@@ -1,55 +1,15 @@
-import { useState, useCallback, type KeyboardEvent } from "react";
-import { X, Plus, Info, FileText, Shield, ShieldCheck, ShieldAlert } from "lucide-react";
+import { Info, FileText, Package, ExternalLink } from "lucide-react";
 import type { DenoConfigInfo } from "../hooks/useDenoDependencies";
-import { COMMON_PERMISSIONS } from "../hooks/useDenoDependencies";
 
 interface DenoDependencyHeaderProps {
-  permissions: string[];
   denoAvailable: boolean | null;
   denoConfigInfo: DenoConfigInfo | null;
-  loading: boolean;
-  onTogglePermission: (flag: string) => Promise<void>;
-  onAddPermission: (permission: string) => Promise<void>;
-  onRemovePermission: (permission: string) => Promise<void>;
 }
 
 export function DenoDependencyHeader({
-  permissions,
   denoAvailable,
   denoConfigInfo,
-  loading,
-  onTogglePermission,
-  onAddPermission,
-  onRemovePermission,
 }: DenoDependencyHeaderProps) {
-  const [newPermission, setNewPermission] = useState("");
-
-  const handleAdd = useCallback(async () => {
-    if (newPermission.trim()) {
-      await onAddPermission(newPermission.trim());
-      setNewPermission("");
-    }
-  }, [newPermission, onAddPermission]);
-
-  const handleKeyDown = useCallback(
-    (e: KeyboardEvent<HTMLInputElement>) => {
-      if (e.key === "Enter") {
-        e.preventDefault();
-        handleAdd();
-      }
-    },
-    [handleAdd]
-  );
-
-  // Check if --allow-all is set
-  const hasAllowAll = permissions.includes("--allow-all");
-
-  // Get custom permissions (those not in COMMON_PERMISSIONS)
-  const commonFlags: Set<string> = new Set(COMMON_PERMISSIONS.map((p) => p.flag));
-  const customPermissions = permissions.filter(
-    (p) => !commonFlags.has(p) && p !== "--allow-all"
-  );
-
   return (
     <div className="border-b bg-emerald-500/5 dark:bg-emerald-500/10">
       <div className="px-3 py-3">
@@ -58,7 +18,7 @@ export function DenoDependencyHeader({
           <span className="rounded bg-emerald-500/20 px-1.5 py-0.5 text-xs font-medium text-emerald-600 dark:text-emerald-400">
             Deno
           </span>
-          <span className="text-xs text-muted-foreground">Permissions</span>
+          <span className="text-xs text-muted-foreground">Dependencies</span>
         </div>
 
         {/* Deno availability notice */}
@@ -77,7 +37,7 @@ export function DenoDependencyHeader({
             <div className="flex items-center gap-2">
               <FileText className="h-3.5 w-3.5 shrink-0" />
               <span>
-                Using config from{" "}
+                Using{" "}
                 <code className="rounded bg-emerald-500/20 px-1">
                   {denoConfigInfo.relative_path}
                 </code>
@@ -105,115 +65,69 @@ export function DenoDependencyHeader({
           </div>
         )}
 
-        {/* Permissions info */}
-        <div className="mb-3 flex items-start gap-2 rounded bg-muted/50 px-2 py-1.5 text-xs text-muted-foreground">
-          <Info className="h-3.5 w-3.5 mt-0.5 shrink-0" />
-          <span>
-            Deno runs in a sandbox by default. Grant permissions for file system,
-            network, or other system access.
-          </span>
-        </div>
-
-        {/* Allow all toggle */}
-        <div className="mb-3">
-          <button
-            type="button"
-            onClick={() => onTogglePermission("--allow-all")}
-            disabled={loading}
-            className={`flex items-center gap-2 rounded px-2 py-1.5 text-xs transition-colors ${
-              hasAllowAll
-                ? "bg-amber-500/20 text-amber-700 dark:text-amber-400"
-                : "bg-muted/50 text-muted-foreground hover:bg-muted"
-            }`}
-          >
-            {hasAllowAll ? (
-              <ShieldAlert className="h-3.5 w-3.5" />
-            ) : (
-              <Shield className="h-3.5 w-3.5" />
-            )}
-            <span className="font-medium">--allow-all</span>
-            <span className="text-muted-foreground">
-              {hasAllowAll ? "(all permissions granted)" : "(grant all permissions)"}
+        {/* No config file - explain how Deno handles deps */}
+        {!denoConfigInfo && denoAvailable !== false && (
+          <div className="mb-3 flex items-start gap-2 rounded bg-muted/50 px-2 py-1.5 text-xs text-muted-foreground">
+            <Info className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+            <span>
+              No <code className="rounded bg-muted px-1">deno.json</code> found.
+              Deno can import modules directly without configuration.
             </span>
-          </button>
-        </div>
-
-        {/* Common permissions grid */}
-        {!hasAllowAll && (
-          <div className="mb-3 grid grid-cols-2 gap-1.5 sm:grid-cols-4">
-            {COMMON_PERMISSIONS.map(({ flag, label, description }) => {
-              const isEnabled = permissions.includes(flag);
-              return (
-                <button
-                  key={flag}
-                  type="button"
-                  onClick={() => onTogglePermission(flag)}
-                  disabled={loading}
-                  className={`flex items-center gap-1.5 rounded px-2 py-1.5 text-xs transition-colors ${
-                    isEnabled
-                      ? "bg-emerald-500/20 text-emerald-600 dark:text-emerald-400"
-                      : "bg-muted/50 text-muted-foreground hover:bg-muted"
-                  }`}
-                  title={description}
-                >
-                  {isEnabled ? (
-                    <ShieldCheck className="h-3 w-3" />
-                  ) : (
-                    <Shield className="h-3 w-3" />
-                  )}
-                  <span>{label}</span>
-                </button>
-              );
-            })}
           </div>
         )}
 
-        {/* Custom permissions list */}
-        {customPermissions.length > 0 && (
-          <div className="mb-3 flex flex-wrap gap-1.5">
-            {customPermissions.map((perm) => (
-              <div
-                key={perm}
-                className="flex items-center gap-1 rounded bg-background px-2 py-1 text-xs border"
-              >
-                <span className="font-mono">{perm}</span>
-                <button
-                  type="button"
-                  onClick={() => onRemovePermission(perm)}
-                  className="text-muted-foreground hover:text-foreground transition-colors"
-                  disabled={loading}
-                  title={`Remove ${perm}`}
-                >
-                  <X className="h-3 w-3" />
-                </button>
-              </div>
-            ))}
+        {/* Import examples */}
+        <div className="space-y-2">
+          <div className="text-xs font-medium text-muted-foreground">
+            Import modules directly in your code:
+          </div>
+
+          {/* npm packages */}
+          <div className="rounded border bg-background px-2.5 py-2">
+            <div className="flex items-center gap-1.5 text-xs text-muted-foreground mb-1">
+              <Package className="h-3 w-3" />
+              <span className="font-medium">npm packages</span>
+            </div>
+            <code className="text-xs text-emerald-600 dark:text-emerald-400">
+              import _ from "npm:lodash@4";
+            </code>
+          </div>
+
+          {/* JSR (recommended) */}
+          <div className="rounded border bg-background px-2.5 py-2">
+            <div className="flex items-center gap-1.5 text-xs text-muted-foreground mb-1">
+              <Package className="h-3 w-3" />
+              <span className="font-medium">JSR</span>
+              <span className="rounded bg-emerald-500/20 px-1 py-0.5 text-[10px] text-emerald-600 dark:text-emerald-400">
+                recommended
+              </span>
+            </div>
+            <code className="text-xs text-emerald-600 dark:text-emerald-400">
+              import &#123; assert &#125; from "jsr:@std/assert";
+            </code>
+          </div>
+
+          {/* URL imports */}
+          <div className="rounded border bg-background px-2.5 py-2">
+            <div className="flex items-center gap-1.5 text-xs text-muted-foreground mb-1">
+              <ExternalLink className="h-3 w-3" />
+              <span className="font-medium">URL imports</span>
+            </div>
+            <code className="text-xs text-emerald-600 dark:text-emerald-400 break-all">
+              import &#123; serve &#125; from "https://deno.land/std/http/server.ts";
+            </code>
+          </div>
+        </div>
+
+        {/* Tip for import maps */}
+        {!denoConfigInfo && (
+          <div className="mt-3 text-xs text-muted-foreground">
+            <span className="font-medium">Tip:</span> Create a{" "}
+            <code className="rounded bg-muted px-1">deno.json</code> with an{" "}
+            <code className="rounded bg-muted px-1">"imports"</code> field to use
+            shorter import specifiers.
           </div>
         )}
-
-        {/* Add custom permission input */}
-        <div className="flex gap-2">
-          <input
-            type="text"
-            value={newPermission}
-            onChange={(e) => setNewPermission(e.target.value)}
-            onKeyDown={handleKeyDown}
-            placeholder="--allow-read=/path or --allow-net=example.com"
-            className="flex-1 rounded border bg-background px-2 py-1 text-xs placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-emerald-500"
-            disabled={loading}
-            autoComplete="off"
-            spellCheck={false}
-          />
-          <button
-            type="button"
-            onClick={handleAdd}
-            disabled={loading || !newPermission.trim()}
-            className="flex items-center gap-1 rounded bg-emerald-500 px-2 py-1 text-xs text-white transition-colors hover:bg-emerald-600 disabled:opacity-50"
-          >
-            <Plus className="h-3 w-3" />
-            Add
-          </button>
-        </div>
       </div>
     </div>
   );

--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -10,12 +10,58 @@ import type { ThemeMode } from "@/hooks/useTheme";
 import type { KernelspecInfo } from "../types";
 import type { EnvProgressState } from "../hooks/useEnvProgress";
 
+/** Notebook runtime type */
+export type Runtime = "python" | "deno";
+
+/** Deno logo icon (from tabler icons) */
+function DenoIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
+      <path d="M3 12a9 9 0 1 0 18 0a9 9 0 1 0 -18 0" />
+      <path d="M13.47 20.882l-1.47 -5.882c-2.649 -.088 -5 -1.624 -5 -3.5c0 -1.933 2.239 -3.5 5 -3.5s4 1 5 3c.024 .048 .69 2.215 2 6.5" />
+      <path d="M12 11h.01" />
+    </svg>
+  );
+}
+
+/** Python logo icon (from tabler icons) */
+function PythonIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+    >
+      <path d="M12 9h-7a2 2 0 0 0 -2 2v4a2 2 0 0 0 2 2h3" />
+      <path d="M12 15h7a2 2 0 0 0 2 -2v-4a2 2 0 0 0 -2 -2h-3" />
+      <path d="M8 9v-4a2 2 0 0 1 2 -2h4a2 2 0 0 1 2 2v5a2 2 0 0 1 -2 2h-4a2 2 0 0 0 -2 2v5a2 2 0 0 0 2 2h4a2 2 0 0 0 2 -2v-4" />
+      <path d="M11 6l0 .01" />
+      <path d="M13 18l0 .01" />
+    </svg>
+  );
+}
+
 interface NotebookToolbarProps {
   kernelStatus: string;
   dirty: boolean;
   hasDependencies: boolean;
   theme: ThemeMode;
   envProgress: EnvProgressState | null;
+  runtime?: Runtime;
   onThemeChange: (theme: ThemeMode) => void;
   onSave: () => void;
   onStartKernel: (name: string) => void;
@@ -38,6 +84,7 @@ export function NotebookToolbar({
   hasDependencies,
   theme,
   envProgress,
+  runtime = "python",
   onThemeChange,
   onSave,
   onStartKernel,
@@ -162,6 +209,29 @@ export function NotebookToolbar({
               </button>
             </>
           )}
+
+          {/* Runtime badge */}
+          <div
+            className={cn(
+              "flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium",
+              runtime === "deno"
+                ? "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
+                : "bg-blue-500/10 text-blue-600 dark:text-blue-400"
+            )}
+            title={runtime === "deno" ? "Deno/TypeScript notebook" : "Python notebook"}
+          >
+            {runtime === "deno" ? (
+              <>
+                <DenoIcon className="h-3 w-3" />
+                <span>Deno</span>
+              </>
+            ) : (
+              <>
+                <PythonIcon className="h-3 w-3" />
+                <span>Python</span>
+              </>
+            )}
+          </div>
 
           {/* Kernel status */}
           <div className="flex items-center gap-1.5">

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -6,12 +6,14 @@ import { MarkdownCell } from "./MarkdownCell";
 import { EditorRegistryProvider, useEditorRegistry } from "../hooks/useEditorRegistry";
 import type { NotebookCell } from "../types";
 import type { CellPagePayload } from "../App";
+import type { Runtime } from "./NotebookToolbar";
 
 interface NotebookViewProps {
   cells: NotebookCell[];
   focusedCellId: string | null;
   executingCellIds: Set<string>;
   pagePayloads: Map<string, CellPagePayload>;
+  runtime?: Runtime;
   onFocusCell: (cellId: string) => void;
   onUpdateCellSource: (cellId: string, source: string) => void;
   onExecuteCell: (cellId: string) => void;
@@ -70,6 +72,7 @@ function NotebookViewContent({
   focusedCellId,
   executingCellIds,
   pagePayloads,
+  runtime = "python",
   onFocusCell,
   onUpdateCellSource,
   onExecuteCell,
@@ -108,10 +111,13 @@ function NotebookViewContent({
 
       if (cell.cell_type === "code") {
         const pagePayload = pagePayloads.get(cell.id) ?? null;
+        // Use TSX for Deno (TypeScript with JSX), Python otherwise
+        const language = runtime === "deno" ? "tsx" : "python";
         return (
           <CodeCell
             key={cell.id}
             cell={cell}
+            language={language}
             isFocused={isFocused}
             isExecuting={isExecuting}
             pagePayload={pagePayload}
@@ -162,6 +168,7 @@ function NotebookViewContent({
       focusedCellId,
       executingCellIds,
       pagePayloads,
+      runtime,
       cellIds,
       cells.length,
       onFocusCell,

--- a/apps/notebook/src/hooks/useDenoDependencies.ts
+++ b/apps/notebook/src/hooks/useDenoDependencies.ts
@@ -1,0 +1,96 @@
+import { useState, useEffect, useCallback } from "react";
+import { invoke } from "@tauri-apps/api/core";
+
+export interface DenoConfigInfo {
+  path: string;
+  relative_path: string;
+  name: string | null;
+  has_imports: boolean;
+  has_tasks: boolean;
+}
+
+/** Common Deno permissions with descriptions */
+export const COMMON_PERMISSIONS = [
+  { flag: "--allow-read", label: "Read", description: "File system read access" },
+  { flag: "--allow-write", label: "Write", description: "File system write access" },
+  { flag: "--allow-net", label: "Network", description: "Network access" },
+  { flag: "--allow-env", label: "Env", description: "Environment variables" },
+  { flag: "--allow-run", label: "Run", description: "Subprocess execution" },
+  { flag: "--allow-ffi", label: "FFI", description: "Foreign function interface" },
+  { flag: "--allow-sys", label: "System", description: "System information" },
+] as const;
+
+export function useDenoDependencies() {
+  const [permissions, setPermissionsState] = useState<string[]>([]);
+  const [denoAvailable, setDenoAvailable] = useState<boolean | null>(null);
+  const [denoConfigInfo, setDenoConfigInfo] = useState<DenoConfigInfo | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  // Check Deno availability and load permissions on mount
+  useEffect(() => {
+    const init = async () => {
+      try {
+        const available = await invoke<boolean>("check_deno_available");
+        setDenoAvailable(available);
+
+        const perms = await invoke<string[]>("get_deno_permissions");
+        setPermissionsState(perms);
+
+        const config = await invoke<DenoConfigInfo | null>("detect_deno_config");
+        setDenoConfigInfo(config);
+      } catch (e) {
+        console.error("Failed to initialize Deno dependencies:", e);
+      }
+    };
+    init();
+  }, []);
+
+  const setPermissions = useCallback(async (newPermissions: string[]) => {
+    setLoading(true);
+    try {
+      await invoke("set_deno_permissions", { permissions: newPermissions });
+      setPermissionsState(newPermissions);
+    } catch (e) {
+      console.error("Failed to set Deno permissions:", e);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const addPermission = useCallback(async (permission: string) => {
+    if (!permission.trim() || permissions.includes(permission.trim())) {
+      return;
+    }
+    const newPermissions = [...permissions, permission.trim()];
+    await setPermissions(newPermissions);
+  }, [permissions, setPermissions]);
+
+  const removePermission = useCallback(async (permission: string) => {
+    const newPermissions = permissions.filter((p) => p !== permission);
+    await setPermissions(newPermissions);
+  }, [permissions, setPermissions]);
+
+  const togglePermission = useCallback(async (flag: string) => {
+    if (permissions.includes(flag)) {
+      await removePermission(flag);
+    } else {
+      await addPermission(flag);
+    }
+  }, [permissions, addPermission, removePermission]);
+
+  const hasPermission = useCallback((flag: string) => {
+    return permissions.includes(flag);
+  }, [permissions]);
+
+  return {
+    permissions,
+    denoAvailable,
+    denoConfigInfo,
+    loading,
+    addPermission,
+    removePermission,
+    togglePermission,
+    hasPermission,
+    setPermissions,
+  };
+}

--- a/apps/notebook/src/hooks/useDenoDependencies.ts
+++ b/apps/notebook/src/hooks/useDenoDependencies.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect } from "react";
 import { invoke } from "@tauri-apps/api/core";
 
 export interface DenoConfigInfo {
@@ -9,32 +9,16 @@ export interface DenoConfigInfo {
   has_tasks: boolean;
 }
 
-/** Common Deno permissions with descriptions */
-export const COMMON_PERMISSIONS = [
-  { flag: "--allow-read", label: "Read", description: "File system read access" },
-  { flag: "--allow-write", label: "Write", description: "File system write access" },
-  { flag: "--allow-net", label: "Network", description: "Network access" },
-  { flag: "--allow-env", label: "Env", description: "Environment variables" },
-  { flag: "--allow-run", label: "Run", description: "Subprocess execution" },
-  { flag: "--allow-ffi", label: "FFI", description: "Foreign function interface" },
-  { flag: "--allow-sys", label: "System", description: "System information" },
-] as const;
-
 export function useDenoDependencies() {
-  const [permissions, setPermissionsState] = useState<string[]>([]);
   const [denoAvailable, setDenoAvailable] = useState<boolean | null>(null);
   const [denoConfigInfo, setDenoConfigInfo] = useState<DenoConfigInfo | null>(null);
-  const [loading, setLoading] = useState(false);
 
-  // Check Deno availability and load permissions on mount
+  // Check Deno availability and detect config on mount
   useEffect(() => {
     const init = async () => {
       try {
         const available = await invoke<boolean>("check_deno_available");
         setDenoAvailable(available);
-
-        const perms = await invoke<string[]>("get_deno_permissions");
-        setPermissionsState(perms);
 
         const config = await invoke<DenoConfigInfo | null>("detect_deno_config");
         setDenoConfigInfo(config);
@@ -45,52 +29,8 @@ export function useDenoDependencies() {
     init();
   }, []);
 
-  const setPermissions = useCallback(async (newPermissions: string[]) => {
-    setLoading(true);
-    try {
-      await invoke("set_deno_permissions", { permissions: newPermissions });
-      setPermissionsState(newPermissions);
-    } catch (e) {
-      console.error("Failed to set Deno permissions:", e);
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  const addPermission = useCallback(async (permission: string) => {
-    if (!permission.trim() || permissions.includes(permission.trim())) {
-      return;
-    }
-    const newPermissions = [...permissions, permission.trim()];
-    await setPermissions(newPermissions);
-  }, [permissions, setPermissions]);
-
-  const removePermission = useCallback(async (permission: string) => {
-    const newPermissions = permissions.filter((p) => p !== permission);
-    await setPermissions(newPermissions);
-  }, [permissions, setPermissions]);
-
-  const togglePermission = useCallback(async (flag: string) => {
-    if (permissions.includes(flag)) {
-      await removePermission(flag);
-    } else {
-      await addPermission(flag);
-    }
-  }, [permissions, addPermission, removePermission]);
-
-  const hasPermission = useCallback((flag: string) => {
-    return permissions.includes(flag);
-  }, [permissions]);
-
   return {
-    permissions,
     denoAvailable,
     denoConfigInfo,
-    loading,
-    addPermission,
-    removePermission,
-    togglePermission,
-    hasPermission,
-    setPermissions,
   };
 }

--- a/crates/notebook/Cargo.toml
+++ b/crates/notebook/Cargo.toml
@@ -16,6 +16,7 @@ name = "notebook"
 path = "src/main.rs"
 
 [dependencies]
+clap = { version = "4", features = ["derive"] }
 tauri = { version = "2", features = ["devtools"] }
 tauri-plugin-dialog = "2"
 serde = { workspace = true }

--- a/crates/notebook/src/deno_env.rs
+++ b/crates/notebook/src/deno_env.rs
@@ -233,7 +233,7 @@ fn strip_jsonc_comments(content: &str) -> String {
                 Some('/') => {
                     // Single-line comment - skip until newline
                     chars.next();
-                    while let Some(cc) = chars.next() {
+                    for cc in chars.by_ref() {
                         if cc == '\n' {
                             result.push('\n');
                             break;
@@ -243,13 +243,12 @@ fn strip_jsonc_comments(content: &str) -> String {
                 Some('*') => {
                     // Multi-line comment - skip until */
                     chars.next();
-                    while let Some(cc) = chars.next() {
-                        if cc == '*' {
-                            if chars.peek() == Some(&'/') {
-                                chars.next();
-                                break;
-                            }
+                    let mut prev_was_star = false;
+                    for cc in chars.by_ref() {
+                        if prev_was_star && cc == '/' {
+                            break;
                         }
+                        prev_was_star = cc == '*';
                     }
                 }
                 _ => {

--- a/crates/notebook/src/deno_env.rs
+++ b/crates/notebook/src/deno_env.rs
@@ -1,0 +1,441 @@
+//! Deno environment detection and configuration for notebook environments.
+//!
+//! This module handles:
+//! - Detecting if Deno is installed on the system
+//! - Finding deno.json/deno.jsonc configuration files
+//! - Extracting Deno configuration from notebook metadata
+//! - Managing Deno permissions for kernel execution
+
+use anyhow::{anyhow, Result};
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+
+/// Deno permissions and configuration stored in notebook metadata
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct DenoDependencies {
+    /// Deno permission flags (e.g., ["--allow-net", "--allow-read"])
+    #[serde(default)]
+    pub permissions: Vec<String>,
+
+    /// Path to import_map.json (relative to notebook or absolute)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub import_map: Option<String>,
+
+    /// Path to deno.json config file (relative to notebook or absolute)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub config: Option<String>,
+}
+
+/// Configuration extracted from a deno.json file
+#[derive(Debug, Clone)]
+pub struct DenoConfig {
+    /// Path to the deno.json file
+    pub path: PathBuf,
+    /// Project name from deno.json (if present)
+    pub name: Option<String>,
+    /// Import map URL/path
+    pub import_map: Option<String>,
+    /// Whether the config has imports defined
+    pub has_imports: bool,
+    /// Whether the config has tasks defined
+    pub has_tasks: bool,
+}
+
+/// Serializable info about a detected deno.json for the frontend
+#[derive(Debug, Clone, Serialize)]
+pub struct DenoConfigInfo {
+    /// Absolute path to the deno.json file
+    pub path: String,
+    /// Path relative to the notebook
+    pub relative_path: String,
+    /// Project name if available
+    pub name: Option<String>,
+    /// Whether the config has imports
+    pub has_imports: bool,
+    /// Whether the config has tasks
+    pub has_tasks: bool,
+}
+
+// Raw deno.json structure for parsing
+#[derive(Debug, Deserialize, Default)]
+struct RawDenoConfig {
+    name: Option<String>,
+    #[serde(rename = "importMap")]
+    import_map: Option<String>,
+    imports: Option<serde_json::Value>,
+    tasks: Option<serde_json::Value>,
+}
+
+/// Check if Deno is available on the system
+pub async fn check_deno_available() -> bool {
+    tokio::process::Command::new("deno")
+        .arg("--version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .await
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Get the installed Deno version
+pub async fn get_deno_version() -> Result<String> {
+    let output = tokio::process::Command::new("deno")
+        .arg("--version")
+        .output()
+        .await
+        .map_err(|e| anyhow!("Failed to run deno --version: {}", e))?;
+
+    if !output.status.success() {
+        return Err(anyhow!("deno --version failed"));
+    }
+
+    let version_str = String::from_utf8_lossy(&output.stdout);
+    // Output is like "deno 2.1.0 (release, ...)". Extract just the version.
+    let version = version_str
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().nth(1))
+        .unwrap_or("unknown")
+        .to_string();
+
+    Ok(version)
+}
+
+/// Check if Deno Jupyter support is available (Deno 1.37+)
+pub async fn check_deno_jupyter_available() -> Result<bool> {
+    let output = tokio::process::Command::new("deno")
+        .args(["jupyter", "--help"])
+        .output()
+        .await
+        .map_err(|e| anyhow!("Failed to check deno jupyter: {}", e))?;
+
+    Ok(output.status.success())
+}
+
+/// Find a deno.json or deno.jsonc file by walking up from the given path
+///
+/// Starts from the given path (or its parent if it's a file) and walks up
+/// the directory tree until a deno config is found or a stopping condition
+/// is met (home directory or filesystem root).
+pub fn find_deno_config(start_path: &Path) -> Option<PathBuf> {
+    // Start from the directory containing the file, or the directory itself
+    let start_dir = if start_path.is_file() {
+        start_path.parent()?
+    } else {
+        start_path
+    };
+
+    let home_dir = dirs::home_dir();
+
+    let mut current = start_dir.to_path_buf();
+    loop {
+        // Check for both deno.json and deno.jsonc
+        for name in &["deno.json", "deno.jsonc"] {
+            let candidate = current.join(name);
+            if candidate.exists() {
+                return Some(candidate);
+            }
+        }
+
+        // Stop at home directory
+        if let Some(ref home) = home_dir {
+            if current == *home {
+                return None;
+            }
+        }
+
+        // Move to parent directory
+        match current.parent() {
+            Some(parent) if parent != current => {
+                current = parent.to_path_buf();
+            }
+            _ => return None, // Reached root
+        }
+    }
+}
+
+/// Parse a deno.json file and extract relevant configuration
+pub fn parse_deno_config(path: &Path) -> Result<DenoConfig> {
+    let content =
+        std::fs::read_to_string(path).map_err(|e| anyhow!("Failed to read deno.json: {}", e))?;
+
+    // Handle JSONC (JSON with comments) by stripping comments
+    let clean_content = strip_jsonc_comments(&content);
+
+    let raw: RawDenoConfig = serde_json::from_str(&clean_content)
+        .map_err(|e| anyhow!("Failed to parse deno.json: {}", e))?;
+
+    Ok(DenoConfig {
+        path: path.to_path_buf(),
+        name: raw.name,
+        import_map: raw.import_map,
+        has_imports: raw.imports.is_some(),
+        has_tasks: raw.tasks.is_some(),
+    })
+}
+
+/// Create DenoConfigInfo from a config for sending to the frontend
+pub fn create_deno_config_info(config: &DenoConfig, notebook_path: &Path) -> DenoConfigInfo {
+    let relative_path =
+        pathdiff::diff_paths(&config.path, notebook_path.parent().unwrap_or(notebook_path))
+            .map(|p| p.display().to_string())
+            .unwrap_or_else(|| config.path.display().to_string());
+
+    DenoConfigInfo {
+        path: config.path.display().to_string(),
+        relative_path,
+        name: config.name.clone(),
+        has_imports: config.has_imports,
+        has_tasks: config.has_tasks,
+    }
+}
+
+/// Extract Deno configuration from notebook metadata
+pub fn extract_deno_metadata(
+    metadata: &nbformat::v4::Metadata,
+) -> Option<DenoDependencies> {
+    metadata
+        .additional
+        .get("deno")
+        .and_then(|v| serde_json::from_value(v.clone()).ok())
+}
+
+/// Strip JSONC comments from content (single-line // and multi-line /* */)
+fn strip_jsonc_comments(content: &str) -> String {
+    let mut result = String::with_capacity(content.len());
+    let mut chars = content.chars().peekable();
+    let mut in_string = false;
+    let mut escape_next = false;
+
+    while let Some(c) = chars.next() {
+        if escape_next {
+            result.push(c);
+            escape_next = false;
+            continue;
+        }
+
+        if c == '\\' && in_string {
+            result.push(c);
+            escape_next = true;
+            continue;
+        }
+
+        if c == '"' {
+            in_string = !in_string;
+            result.push(c);
+            continue;
+        }
+
+        if !in_string && c == '/' {
+            match chars.peek() {
+                Some('/') => {
+                    // Single-line comment - skip until newline
+                    chars.next();
+                    while let Some(cc) = chars.next() {
+                        if cc == '\n' {
+                            result.push('\n');
+                            break;
+                        }
+                    }
+                }
+                Some('*') => {
+                    // Multi-line comment - skip until */
+                    chars.next();
+                    while let Some(cc) = chars.next() {
+                        if cc == '*' {
+                            if chars.peek() == Some(&'/') {
+                                chars.next();
+                                break;
+                            }
+                        }
+                    }
+                }
+                _ => {
+                    result.push(c);
+                }
+            }
+        } else {
+            result.push(c);
+        }
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::TempDir;
+
+    fn create_deno_config(dir: &Path, content: &str) {
+        let path = dir.join("deno.json");
+        let mut file = std::fs::File::create(path).unwrap();
+        file.write_all(content.as_bytes()).unwrap();
+    }
+
+    #[test]
+    fn test_find_deno_config_same_dir() {
+        let temp = TempDir::new().unwrap();
+        create_deno_config(temp.path(), "{}");
+
+        let found = find_deno_config(temp.path());
+        assert!(found.is_some());
+        assert_eq!(found.unwrap(), temp.path().join("deno.json"));
+    }
+
+    #[test]
+    fn test_find_deno_config_parent_dir() {
+        let temp = TempDir::new().unwrap();
+        let subdir = temp.path().join("notebooks");
+        std::fs::create_dir(&subdir).unwrap();
+        create_deno_config(temp.path(), "{}");
+
+        let found = find_deno_config(&subdir);
+        assert!(found.is_some());
+        assert_eq!(found.unwrap(), temp.path().join("deno.json"));
+    }
+
+    #[test]
+    fn test_find_deno_config_not_found() {
+        let temp = TempDir::new().unwrap();
+        let found = find_deno_config(temp.path());
+        assert!(found.is_none());
+    }
+
+    #[test]
+    fn test_find_deno_jsonc() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("deno.jsonc");
+        std::fs::write(&path, "{}").unwrap();
+
+        let found = find_deno_config(temp.path());
+        assert!(found.is_some());
+        assert_eq!(found.unwrap(), path);
+    }
+
+    #[test]
+    fn test_parse_deno_config_minimal() {
+        let temp = TempDir::new().unwrap();
+        create_deno_config(temp.path(), "{}");
+
+        let config = parse_deno_config(&temp.path().join("deno.json")).unwrap();
+        assert!(config.name.is_none());
+        assert!(!config.has_imports);
+        assert!(!config.has_tasks);
+    }
+
+    #[test]
+    fn test_parse_deno_config_with_fields() {
+        let temp = TempDir::new().unwrap();
+        create_deno_config(
+            temp.path(),
+            r#"{
+                "name": "my-project",
+                "importMap": "./import_map.json",
+                "imports": {
+                    "@std/": "https://deno.land/std@0.200.0/"
+                },
+                "tasks": {
+                    "dev": "deno run --watch main.ts"
+                }
+            }"#,
+        );
+
+        let config = parse_deno_config(&temp.path().join("deno.json")).unwrap();
+        assert_eq!(config.name, Some("my-project".to_string()));
+        assert_eq!(config.import_map, Some("./import_map.json".to_string()));
+        assert!(config.has_imports);
+        assert!(config.has_tasks);
+    }
+
+    #[test]
+    fn test_parse_deno_jsonc_with_comments() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("deno.jsonc");
+        std::fs::write(
+            &path,
+            r#"{
+                // This is a comment
+                "name": "my-project",
+                /* Multi-line
+                   comment */
+                "imports": {}
+            }"#,
+        )
+        .unwrap();
+
+        let config = parse_deno_config(&path).unwrap();
+        assert_eq!(config.name, Some("my-project".to_string()));
+        assert!(config.has_imports);
+    }
+
+    #[test]
+    fn test_strip_jsonc_comments() {
+        let input = r#"{
+            // Single line comment
+            "key": "value", // Trailing comment
+            /* Block
+               comment */
+            "other": "test"
+        }"#;
+
+        let result = strip_jsonc_comments(input);
+        assert!(!result.contains("//"));
+        assert!(!result.contains("/*"));
+        assert!(result.contains("\"key\""));
+        assert!(result.contains("\"value\""));
+    }
+
+    #[test]
+    fn test_strip_jsonc_preserves_urls() {
+        let input = r#"{"url": "https://example.com"}"#;
+        let result = strip_jsonc_comments(input);
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn test_deno_dependencies_default() {
+        let deps = DenoDependencies::default();
+        assert!(deps.permissions.is_empty());
+        assert!(deps.import_map.is_none());
+        assert!(deps.config.is_none());
+    }
+
+    #[test]
+    fn test_deno_dependencies_serde() {
+        let deps = DenoDependencies {
+            permissions: vec!["--allow-net".to_string(), "--allow-read".to_string()],
+            import_map: Some("./import_map.json".to_string()),
+            config: None,
+        };
+
+        let json = serde_json::to_string(&deps).unwrap();
+        let parsed: DenoDependencies = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(parsed.permissions.len(), 2);
+        assert_eq!(parsed.import_map, Some("./import_map.json".to_string()));
+    }
+
+    #[test]
+    fn test_create_deno_config_info() {
+        let temp = TempDir::new().unwrap();
+        let notebooks_dir = temp.path().join("notebooks");
+        std::fs::create_dir(&notebooks_dir).unwrap();
+
+        create_deno_config(
+            temp.path(),
+            r#"{"name": "my-project", "imports": {}}"#,
+        );
+
+        let config = parse_deno_config(&temp.path().join("deno.json")).unwrap();
+        let notebook_path = notebooks_dir.join("test.ipynb");
+        let info = create_deno_config_info(&config, &notebook_path);
+
+        assert_eq!(info.name, Some("my-project".to_string()));
+        assert!(info.has_imports);
+        assert_eq!(info.relative_path, "../deno.json");
+    }
+}

--- a/crates/notebook/src/kernel.rs
+++ b/crates/notebook/src/kernel.rs
@@ -1167,6 +1167,285 @@ impl NotebookKernel {
         Ok(())
     }
 
+    /// Start a Deno kernel.
+    ///
+    /// Uses the system `deno jupyter` command to launch a Deno/TypeScript kernel.
+    /// Optionally accepts permissions and a workspace directory (for deno.json detection).
+    pub async fn start_with_deno(
+        &mut self,
+        app: AppHandle,
+        permissions: &[String],
+        workspace_dir: Option<&std::path::Path>,
+    ) -> Result<()> {
+        // Shutdown existing kernel if any
+        self.shutdown().await.ok();
+
+        info!("Starting Deno kernel with permissions: {:?}", permissions);
+
+        // Reserve ports
+        let ip = std::net::IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
+        let ports = runtimelib::peek_ports(ip, 5).await?;
+
+        let connection_info = ConnectionInfo {
+            transport: jupyter_protocol::connection_info::Transport::TCP,
+            ip: ip.to_string(),
+            stdin_port: ports[0],
+            control_port: ports[1],
+            hb_port: ports[2],
+            shell_port: ports[3],
+            iopub_port: ports[4],
+            signature_scheme: "hmac-sha256".to_string(),
+            key: Uuid::new_v4().to_string(),
+            kernel_name: Some("deno".to_string()),
+        };
+
+        let runtime_dir = runtimelib::dirs::runtime_dir();
+        tokio::fs::create_dir_all(&runtime_dir).await?;
+
+        let kernel_id: String =
+            petname::petname(2, "-").unwrap_or_else(|| Uuid::new_v4().to_string());
+        let connection_file_path = runtime_dir.join(format!("runt-kernel-{}.json", kernel_id));
+
+        tokio::fs::write(
+            &connection_file_path,
+            serde_json::to_string_pretty(&connection_info)?,
+        )
+        .await?;
+
+        info!(
+            "Starting Deno kernel at {:?}",
+            connection_file_path
+        );
+
+        // Build the deno command
+        let mut cmd = tokio::process::Command::new("deno");
+        cmd.arg("jupyter")
+            .arg("--kernel")
+            .arg("--conn")
+            .arg(&connection_file_path);
+
+        // Add any permissions
+        for perm in permissions {
+            cmd.arg(perm);
+        }
+
+        // Set working directory if specified (e.g., for deno.json discovery)
+        if let Some(dir) = workspace_dir {
+            cmd.current_dir(dir);
+        }
+
+        let process = cmd
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .kill_on_drop(true)
+            .spawn()?;
+
+        // Give Deno time to start
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
+        self.session_id = Uuid::new_v4().to_string();
+
+        // Create iopub connection and spawn listener
+        let mut iopub = runtimelib::create_client_iopub_connection(
+            &connection_info,
+            "",
+            &self.session_id,
+        )
+        .await?;
+
+        let app_handle = app.clone();
+        let cell_id_map = self.cell_id_map.clone();
+        let queue_tx = self.queue_tx.clone();
+        let iopub_task = tokio::spawn(async move {
+            loop {
+                match iopub.read().await {
+                    Ok(message) => {
+                        debug!(
+                            "iopub: type={} parent_msg_id={:?}",
+                            message.header.msg_type,
+                            message.parent_header.as_ref().map(|h| &h.msg_id)
+                        );
+
+                        // Look up cell_id from the msg_id → cell_id map
+                        let cell_id = message
+                            .parent_header
+                            .as_ref()
+                            .and_then(|h| cell_id_map.lock().ok()?.get(&h.msg_id).cloned());
+
+                        // Check for status: idle to signal execution completion
+                        if let JupyterMessageContent::Status(ref status) = message.content {
+                            if status.execution_state == jupyter_protocol::ExecutionState::Idle {
+                                if let Some(ref cid) = cell_id {
+                                    if let Some(ref tx) = queue_tx {
+                                        let _ = tx.try_send(QueueCommand::ExecutionDone {
+                                            cell_id: cid.clone(),
+                                        });
+                                    }
+                                }
+                            }
+                        }
+
+                        let tauri_msg = TauriJupyterMessage {
+                            header: message.header,
+                            parent_header: message.parent_header,
+                            metadata: message.metadata,
+                            content: message.content,
+                            buffers: message.buffers,
+                            channel: message.channel,
+                            cell_id,
+                        };
+
+                        if let Err(e) = app_handle.emit("kernel:iopub", &tauri_msg) {
+                            error!("Failed to emit kernel:iopub: {}", e);
+                            break;
+                        }
+                    }
+                    Err(e) => {
+                        error!("iopub read error: {}", e);
+                        break;
+                    }
+                }
+            }
+        });
+
+        // Create persistent shell connection
+        let identity = runtimelib::peer_identity_for_session(&self.session_id)?;
+        let mut shell = runtimelib::create_client_shell_connection_with_identity(
+            &connection_info,
+            &self.session_id,
+            identity,
+        )
+        .await?;
+
+        // Verify kernel is alive with kernel_info handshake
+        let request: JupyterMessage = KernelInfoRequest::default().into();
+        shell.send(request).await?;
+
+        let reply = tokio::time::timeout(std::time::Duration::from_secs(30), shell.read()).await;
+        match reply {
+            Ok(Ok(msg)) => {
+                info!("Deno kernel alive: got {} reply", msg.header.msg_type);
+            }
+            Ok(Err(e)) => {
+                error!("Error reading kernel_info_reply: {}", e);
+                return Err(anyhow::anyhow!("Deno kernel did not respond: {}", e));
+            }
+            Err(_) => {
+                error!("Timeout waiting for kernel_info_reply");
+                return Err(anyhow::anyhow!("Deno kernel did not respond within 30s"));
+            }
+        }
+
+        // Split shell into persistent writer + reader
+        let (shell_writer, mut shell_reader) = shell.split();
+
+        let pending = self.pending_completions.clone();
+        let pending_hist = self.pending_history.clone();
+        let shell_app = app.clone();
+        let shell_cell_id_map = self.cell_id_map.clone();
+        let shell_reader_task = tokio::spawn(async move {
+            loop {
+                match shell_reader.read().await {
+                    Ok(msg) => {
+                        let parent_msg_id = msg.parent_header.as_ref().map(|h| h.msg_id.clone());
+
+                        match msg.content {
+                            JupyterMessageContent::CompleteReply(reply) => {
+                                if let Some(ref msg_id) = parent_msg_id {
+                                    if let Some(sender) = pending.lock().unwrap().remove(msg_id) {
+                                        let _ = sender.send(CompletionResult {
+                                            matches: reply.matches,
+                                            cursor_start: reply.cursor_start,
+                                            cursor_end: reply.cursor_end,
+                                        });
+                                    }
+                                }
+                            }
+                            JupyterMessageContent::HistoryReply(reply) => {
+                                if let Some(ref msg_id) = parent_msg_id {
+                                    if let Some(sender) =
+                                        pending_hist.lock().unwrap().remove(msg_id)
+                                    {
+                                        let entries = reply
+                                            .history
+                                            .into_iter()
+                                            .map(|entry| match entry {
+                                                jupyter_protocol::HistoryEntry::Input(
+                                                    session,
+                                                    line,
+                                                    source,
+                                                ) => HistoryEntryData {
+                                                    session,
+                                                    line,
+                                                    source,
+                                                },
+                                                jupyter_protocol::HistoryEntry::InputOutput(
+                                                    session,
+                                                    line,
+                                                    (source, _),
+                                                ) => HistoryEntryData {
+                                                    session,
+                                                    line,
+                                                    source,
+                                                },
+                                            })
+                                            .collect();
+                                        let _ = sender.send(HistoryResult { entries });
+                                    }
+                                }
+                            }
+                            JupyterMessageContent::ExecuteReply(ref reply) => {
+                                // Handle page payloads (for inspect/help features)
+                                if !reply.payload.is_empty() {
+                                    if let Some(ref msg_id) = parent_msg_id {
+                                        if let Some(cell_id) =
+                                            shell_cell_id_map.lock().ok().and_then(|map| {
+                                                map.get(msg_id).cloned()
+                                            })
+                                        {
+                                            for p in &reply.payload {
+                                                if let Payload::Page { data, start } = p {
+                                                    let event = PagePayloadEvent {
+                                                        cell_id: cell_id.clone(),
+                                                        data: data.clone(),
+                                                        start: *start,
+                                                    };
+                                                    if let Err(e) =
+                                                        shell_app.emit("kernel:page_payload", &event)
+                                                    {
+                                                        error!("Failed to emit page_payload: {}", e);
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                            _ => {
+                                debug!("shell reply: type={}", msg.header.msg_type);
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        error!("shell read error: {}", e);
+                        break;
+                    }
+                }
+            }
+        });
+
+        self.connection_info = Some(connection_info);
+        self.connection_file = Some(connection_file_path);
+        self.iopub_task = Some(iopub_task);
+        self.shell_reader_task = Some(shell_reader_task);
+        self.shell_writer = Some(shell_writer);
+        self._process = Some(process);
+        // Note: No uv_environment or conda_environment for Deno
+
+        info!("Deno kernel started: {}", kernel_id);
+        Ok(())
+    }
+
     /// Execute code and return the msg_id. Registers the cell_id mapping
     /// before sending so the iopub listener can tag responses.
     pub async fn execute(&mut self, code: &str, cell_id: &str) -> Result<String> {

--- a/crates/notebook/src/main.rs
+++ b/crates/notebook/src/main.rs
@@ -1,6 +1,19 @@
+use clap::Parser;
+use notebook::Runtime;
 use std::path::PathBuf;
 
+#[derive(Parser, Debug)]
+#[command(name = "notebook", about = "Runt Notebook - Interactive computing environment")]
+struct Args {
+    /// Path to notebook file to open or create
+    path: Option<PathBuf>,
+
+    /// Runtime for new notebooks (python, deno)
+    #[arg(long, short, default_value = "python")]
+    runtime: Runtime,
+}
+
 fn main() {
-    let path = std::env::args().nth(1).map(PathBuf::from);
-    notebook::run(path).expect("notebook app failed");
+    let args = Args::parse();
+    notebook::run(args.path, args.runtime).expect("notebook app failed");
 }

--- a/crates/notebook/src/menu.rs
+++ b/crates/notebook/src/menu.rs
@@ -1,7 +1,9 @@
 use tauri::menu::{Menu, MenuItem, PredefinedMenuItem, Submenu};
 use tauri::{AppHandle, Wry};
 
-pub const MENU_NEW_NOTEBOOK: &str = "new_notebook";
+// Menu item IDs for new notebook types
+pub const MENU_NEW_PYTHON_NOTEBOOK: &str = "new_python_notebook";
+pub const MENU_NEW_DENO_NOTEBOOK: &str = "new_deno_notebook";
 pub const MENU_OPEN: &str = "open";
 pub const MENU_SAVE: &str = "save";
 
@@ -24,13 +26,25 @@ pub fn create_menu(app: &AppHandle) -> tauri::Result<Menu<Wry>> {
 
     // File menu
     let file_menu = Submenu::new(app, "File", true)?;
-    file_menu.append(&MenuItem::with_id(
+
+    // New Notebook submenu with Python and Deno options
+    let new_notebook_submenu = Submenu::new(app, "New Notebook", true)?;
+    new_notebook_submenu.append(&MenuItem::with_id(
         app,
-        MENU_NEW_NOTEBOOK,
-        "New Notebook",
+        MENU_NEW_PYTHON_NOTEBOOK,
+        "Python",
         true,
         Some("CmdOrCtrl+N"),
     )?)?;
+    new_notebook_submenu.append(&MenuItem::with_id(
+        app,
+        MENU_NEW_DENO_NOTEBOOK,
+        "Deno (TypeScript)",
+        true,
+        Some("CmdOrCtrl+Shift+N"),
+    )?)?;
+    file_menu.append(&new_notebook_submenu)?;
+
     file_menu.append(&MenuItem::with_id(
         app,
         MENU_OPEN,

--- a/crates/notebook/src/runtime.rs
+++ b/crates/notebook/src/runtime.rs
@@ -1,0 +1,67 @@
+//! Runtime type for notebooks - Python or Deno
+
+use serde::{Deserialize, Serialize};
+
+/// Supported notebook runtime environments
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum Runtime {
+    #[default]
+    Python,
+    Deno,
+}
+
+impl std::fmt::Display for Runtime {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Runtime::Python => write!(f, "python"),
+            Runtime::Deno => write!(f, "deno"),
+        }
+    }
+}
+
+impl std::str::FromStr for Runtime {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "python" | "py" => Ok(Runtime::Python),
+            "deno" | "typescript" | "ts" => Ok(Runtime::Deno),
+            _ => Err(format!("Unknown runtime: {}", s)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_runtime_display() {
+        assert_eq!(Runtime::Python.to_string(), "python");
+        assert_eq!(Runtime::Deno.to_string(), "deno");
+    }
+
+    #[test]
+    fn test_runtime_from_str() {
+        assert_eq!("python".parse::<Runtime>().unwrap(), Runtime::Python);
+        assert_eq!("py".parse::<Runtime>().unwrap(), Runtime::Python);
+        assert_eq!("deno".parse::<Runtime>().unwrap(), Runtime::Deno);
+        assert_eq!("typescript".parse::<Runtime>().unwrap(), Runtime::Deno);
+        assert_eq!("ts".parse::<Runtime>().unwrap(), Runtime::Deno);
+        assert!("unknown".parse::<Runtime>().is_err());
+    }
+
+    #[test]
+    fn test_runtime_default() {
+        assert_eq!(Runtime::default(), Runtime::Python);
+    }
+
+    #[test]
+    fn test_runtime_serde() {
+        assert_eq!(serde_json::to_string(&Runtime::Python).unwrap(), "\"python\"");
+        assert_eq!(serde_json::to_string(&Runtime::Deno).unwrap(), "\"deno\"");
+        assert_eq!(serde_json::from_str::<Runtime>("\"python\"").unwrap(), Runtime::Python);
+        assert_eq!(serde_json::from_str::<Runtime>("\"deno\"").unwrap(), Runtime::Deno);
+    }
+}

--- a/crates/notebook/src/settings.rs
+++ b/crates/notebook/src/settings.rs
@@ -1,0 +1,96 @@
+//! Application settings persistence for notebook preferences.
+//!
+//! Settings are stored in a JSON file in the user's config directory:
+//! - macOS: ~/Library/Application Support/runt-notebook/settings.json
+//! - Linux: ~/.config/runt-notebook/settings.json
+//! - Windows: C:\Users\<User>\AppData\Roaming\runt-notebook\settings.json
+
+use crate::runtime::Runtime;
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+/// Application settings for notebook preferences
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppSettings {
+    /// Default runtime for new notebooks (used by Cmd+N)
+    #[serde(default)]
+    pub default_runtime: Runtime,
+
+    /// Default Deno permissions for new notebooks
+    #[serde(default)]
+    pub default_deno_permissions: Vec<String>,
+}
+
+impl Default for AppSettings {
+    fn default() -> Self {
+        Self {
+            default_runtime: Runtime::Python,
+            default_deno_permissions: vec![],
+        }
+    }
+}
+
+/// Get the path to the settings file
+fn settings_path() -> PathBuf {
+    dirs::config_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("runt-notebook")
+        .join("settings.json")
+}
+
+/// Load settings from disk, returning defaults if file doesn't exist
+pub fn load_settings() -> AppSettings {
+    let path = settings_path();
+    if path.exists() {
+        std::fs::read_to_string(&path)
+            .ok()
+            .and_then(|s| serde_json::from_str(&s).ok())
+            .unwrap_or_default()
+    } else {
+        AppSettings::default()
+    }
+}
+
+/// Save settings to disk
+pub fn save_settings(settings: &AppSettings) -> Result<()> {
+    let path = settings_path();
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(&path, serde_json::to_string_pretty(settings)?)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_settings() {
+        let settings = AppSettings::default();
+        assert_eq!(settings.default_runtime, Runtime::Python);
+        assert!(settings.default_deno_permissions.is_empty());
+    }
+
+    #[test]
+    fn test_settings_serde() {
+        let settings = AppSettings {
+            default_runtime: Runtime::Deno,
+            default_deno_permissions: vec!["--allow-net".to_string()],
+        };
+
+        let json = serde_json::to_string(&settings).unwrap();
+        let parsed: AppSettings = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(parsed.default_runtime, Runtime::Deno);
+        assert_eq!(parsed.default_deno_permissions.len(), 1);
+    }
+
+    #[test]
+    fn test_settings_path_is_valid() {
+        let path = settings_path();
+        // Should end with the expected path components
+        assert!(path.ends_with("runt-notebook/settings.json"));
+    }
+}

--- a/examples/deno-hello.ipynb
+++ b/examples/deno-hello.ipynb
@@ -1,0 +1,201 @@
+{
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Deno",
+      "language": "typescript",
+      "name": "deno"
+    },
+    "language_info": {
+      "name": "typescript",
+      "version": "5.0.0",
+      "mimetype": "text/x.typescript",
+      "file_extension": ".ts",
+      "codemirror_mode": "typescript"
+    },
+    "runt": {
+      "runtime": "deno"
+    },
+    "deno": {
+      "permissions": ["--allow-net"]
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5,
+  "cells": [
+    {
+      "id": "welcome",
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Hello Deno! 🦕\n",
+        "\n",
+        "This notebook runs on Deno's Jupyter kernel. You get:\n",
+        "- TypeScript out of the box\n",
+        "- Top-level await\n",
+        "- Web standard APIs (fetch, URL, etc.)\n",
+        "- Secure by default (explicit permissions)"
+      ]
+    },
+    {
+      "id": "basics",
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "// TypeScript works out of the box\n",
+        "interface Dinosaur {\n",
+        "  name: string;\n",
+        "  period: string;\n",
+        "  diet: \"herbivore\" | \"carnivore\" | \"omnivore\";\n",
+        "}\n",
+        "\n",
+        "const deno: Dinosaur = {\n",
+        "  name: \"Deno\",\n",
+        "  period: \"Modern Era\",\n",
+        "  diet: \"omnivore\", // eats JavaScript and TypeScript\n",
+        "};\n",
+        "\n",
+        "console.log(`Meet ${deno.name} from the ${deno.period}!`);\n",
+        "deno"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "id": "fetch-example",
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Fetch API\n",
+        "\n",
+        "Deno has web-standard `fetch` built in. Let's grab some data!"
+      ]
+    },
+    {
+      "id": "fetch-code",
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "// Top-level await just works\n",
+        "const response = await fetch(\"https://api.github.com/repos/denoland/deno\");\n",
+        "const repo = await response.json();\n",
+        "\n",
+        "console.log(`⭐ ${repo.full_name}: ${repo.stargazers_count.toLocaleString()} stars`);\n",
+        "console.log(`📝 ${repo.description}`);"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "id": "generics",
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## TypeScript Generics\n",
+        "\n",
+        "Full TypeScript support means you can use generics, utility types, and more."
+      ]
+    },
+    {
+      "id": "generics-code",
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "// Generic function with constraints\n",
+        "function getProperty<T, K extends keyof T>(obj: T, key: K): T[K] {\n",
+        "  return obj[key];\n",
+        "}\n",
+        "\n",
+        "const config = {\n",
+        "  host: \"localhost\",\n",
+        "  port: 8000,\n",
+        "  secure: true,\n",
+        "};\n",
+        "\n",
+        "// Type-safe property access\n",
+        "const host = getProperty(config, \"host\"); // string\n",
+        "const port = getProperty(config, \"port\"); // number\n",
+        "\n",
+        "console.log(`Server: ${host}:${port}`);\n",
+        "\n",
+        "// Utility types\n",
+        "type ReadonlyConfig = Readonly<typeof config>;\n",
+        "type ConfigKeys = keyof typeof config;\n",
+        "\n",
+        "\"Config keys: \" + ([\"host\", \"port\", \"secure\"] as ConfigKeys[]).join(\", \")"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "id": "imports",
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## URL Imports\n",
+        "\n",
+        "Deno can import modules directly from URLs - no package.json needed!"
+      ]
+    },
+    {
+      "id": "imports-code",
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "// Import directly from a URL\n",
+        "import { bold, green, yellow } from \"https://deno.land/std@0.224.0/fmt/colors.ts\";\n",
+        "\n",
+        "console.log(bold(green(\"Success!\")) + \" Imported from deno.land/std\");\n",
+        "console.log(yellow(\"No npm install required\"));"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "id": "async-iteration",
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Async Iteration\n",
+        "\n",
+        "Modern JavaScript features work seamlessly."
+      ]
+    },
+    {
+      "id": "async-code",
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "// Async generator\n",
+        "async function* countdown(n: number): AsyncGenerator<number> {\n",
+        "  while (n > 0) {\n",
+        "    yield n--;\n",
+        "    await new Promise(r => setTimeout(r, 100));\n",
+        "  }\n",
+        "}\n",
+        "\n",
+        "// Async iteration\n",
+        "const numbers: number[] = [];\n",
+        "for await (const n of countdown(5)) {\n",
+        "  numbers.push(n);\n",
+        "}\n",
+        "\n",
+        "console.log(\"Countdown:\", numbers.join(\" → \"), \"→ 🚀\");"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "id": "outro",
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "---\n",
+        "\n",
+        "That's a quick tour of Deno in notebooks! Check out:\n",
+        "- [Deno Manual](https://deno.land/manual)\n",
+        "- [Deno Standard Library](https://deno.land/std)\n",
+        "- [Deno Third Party Modules](https://deno.land/x)"
+      ]
+    }
+  ]
+}

--- a/src/components/editor/languages.ts
+++ b/src/components/editor/languages.ts
@@ -15,7 +15,9 @@ export type SupportedLanguage =
   | "sql"
   | "html"
   | "javascript"
+  | "jsx"
   | "typescript"
+  | "tsx"
   | "json"
   | "plain";
 
@@ -34,8 +36,12 @@ export function getLanguageExtension(language: SupportedLanguage): Extension {
       return html();
     case "javascript":
       return javascript();
+    case "jsx":
+      return javascript({ jsx: true });
     case "typescript":
       return javascript({ typescript: true });
+    case "tsx":
+      return javascript({ typescript: true, jsx: true });
     case "json":
       return json();
     default:
@@ -52,7 +58,9 @@ export const languageDisplayNames: Record<SupportedLanguage, string> = {
   sql: "SQL",
   html: "HTML",
   javascript: "JavaScript",
+  jsx: "JavaScript (JSX)",
   typescript: "TypeScript",
+  tsx: "TypeScript (TSX)",
   json: "JSON",
   plain: "Plain Text",
 };
@@ -68,9 +76,9 @@ export const fileExtensionToLanguage: Record<string, SupportedLanguage> = {
   ".html": "html",
   ".htm": "html",
   ".js": "javascript",
-  ".jsx": "javascript",
+  ".jsx": "jsx",
   ".ts": "typescript",
-  ".tsx": "typescript",
+  ".tsx": "tsx",
   ".json": "json",
   ".txt": "plain",
 };


### PR DESCRIPTION
## Summary

From Python

<img width="880" height="405" alt="image" src="https://github.com/user-attachments/assets/f4bd9686-8e91-4ad4-ba71-cba4b17160d9" />

to Deno

<img width="879" height="405" alt="image" src="https://github.com/user-attachments/assets/40e9c6a5-15b2-4acc-b036-a7cd2e33383f" />

<img width="2424" height="1724" alt="image" src="https://github.com/user-attachments/assets/7705c327-ce98-4b85-ac9d-836802a0e61b" />


Implements full Deno/TypeScript notebook support alongside existing Python notebooks:

- New `Runtime` enum and notebook metadata storage for both Python and Deno
- Deno kernel startup using `deno jupyter --kernel` with workspace integration
- CLI flag `--runtime deno` for creating Deno notebooks from command line
- File > New Notebook submenu with Python and Deno options
- Runtime indicator badges with logos (Python snake + Deno dinosaur) in toolbar
- Comprehensive Deno config detection and workspace support
- Foundation for settings-based default runtime preference

## Test plan

- [x] Run `./target/debug/notebook --runtime deno` to create a new Deno notebook
- [x] Use File > New Notebook > Deno (TypeScript) menu to create Deno notebooks  
- [x] Verify runtime badge shows correct icon in toolbar (Deno/Python)
- [x] Execute TypeScript code in Deno notebooks and verify it works
- [x] Open existing Python notebooks and verify they still work with Python runtime