### PR TITLE
Add dependency trust verification for notebook security

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2033,6 +2033,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "html5ever"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3087,15 +3096,19 @@ version = "1.0.0"
 dependencies = [
  "anyhow",
  "bytes",
+ "chrono",
  "dirs 5.0.1",
  "env_logger",
  "futures",
+ "hex",
+ "hmac",
  "jupyter-protocol",
  "log",
  "nbformat",
  "pathdiff",
  "petname",
  "pyproject-toml",
+ "rand 0.8.5",
  "rattler",
  "rattler_cache",
  "rattler_conda_types",
@@ -3108,6 +3121,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "strsim",
  "tauri",
  "tauri-build",
  "tauri-jupyter",

--- a/apps/notebook/src/components/TrustDialog.tsx
+++ b/apps/notebook/src/components/TrustDialog.tsx
@@ -1,0 +1,197 @@
+import { useCallback } from "react";
+import { AlertTriangleIcon, PackageIcon, ShieldAlertIcon, ExternalLinkIcon } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import type { TrustInfo, TyposquatWarning } from "../hooks/useTrust";
+
+interface TrustDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  trustInfo: TrustInfo | null;
+  typosquatWarnings: TyposquatWarning[];
+  onApprove: () => Promise<boolean>;
+  onDecline: () => void;
+  loading?: boolean;
+}
+
+/** Open PyPI page for a package */
+function openPyPI(pkg: string) {
+  // Extract package name without version specifiers
+  const name = pkg.split(/[><=!~\[;@]/)[0].trim();
+  window.open(`https://pypi.org/project/${name}/`, "_blank");
+}
+
+/** Open conda-forge page for a package */
+function openCondaForge(pkg: string) {
+  const name = pkg.split(/[><=!~\[]/)[0].trim();
+  window.open(`https://anaconda.org/conda-forge/${name}`, "_blank");
+}
+
+/** Package list item with optional typosquat warning */
+function PackageItem({
+  pkg,
+  warning,
+  onViewPyPI,
+}: {
+  pkg: string;
+  warning?: TyposquatWarning;
+  onViewPyPI?: () => void;
+}) {
+  return (
+    <div className="flex items-center justify-between py-1 px-2 rounded hover:bg-muted/50 group">
+      <div className="flex items-center gap-2 min-w-0 flex-1">
+        <PackageIcon className="size-4 shrink-0 text-muted-foreground" />
+        <span className="font-mono text-sm truncate">{pkg}</span>
+        {warning && (
+          <span className="inline-flex items-center gap-1 text-xs text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-900/30 px-1.5 py-0.5 rounded">
+            <AlertTriangleIcon className="size-3" />
+            Similar to "{warning.similar_to}"
+          </span>
+        )}
+      </div>
+      {onViewPyPI && (
+        <Button
+          variant="ghost"
+          size="icon-xs"
+          className="opacity-0 group-hover:opacity-100 transition-opacity"
+          onClick={onViewPyPI}
+          title="View on PyPI"
+        >
+          <ExternalLinkIcon className="size-3" />
+        </Button>
+      )}
+    </div>
+  );
+}
+
+export function TrustDialog({
+  open,
+  onOpenChange,
+  trustInfo,
+  typosquatWarnings,
+  onApprove,
+  onDecline,
+  loading = false,
+}: TrustDialogProps) {
+  const handleApprove = useCallback(async () => {
+    const success = await onApprove();
+    if (success) {
+      onOpenChange(false);
+    }
+  }, [onApprove, onOpenChange]);
+
+  const handleDecline = useCallback(() => {
+    onDecline();
+    onOpenChange(false);
+  }, [onDecline, onOpenChange]);
+
+  // Build a map of package -> warning for quick lookup
+  const warningMap = new Map<string, TyposquatWarning>();
+  for (const warning of typosquatWarnings) {
+    warningMap.set(warning.package.toLowerCase(), warning);
+  }
+
+  const getWarning = (pkg: string): TyposquatWarning | undefined => {
+    const name = pkg.split(/[><=!~\[;@]/)[0].trim().toLowerCase();
+    return warningMap.get(name);
+  };
+
+  const hasTyposquats = typosquatWarnings.length > 0;
+  const isSignatureInvalid = trustInfo?.status === "signature_invalid";
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg" showCloseButton={false}>
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <ShieldAlertIcon className="size-5 text-amber-500" />
+            {isSignatureInvalid
+              ? "Dependencies Modified"
+              : "Review Dependencies"}
+          </DialogTitle>
+          <DialogDescription>
+            {isSignatureInvalid
+              ? "This notebook's dependencies have been modified since you last approved them. Review and approve to continue."
+              : "This notebook wants to install packages. Review them before running code."}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="max-h-[300px] overflow-y-auto space-y-4">
+          {/* UV (PyPI) Dependencies */}
+          {trustInfo && trustInfo.uv_dependencies.length > 0 && (
+            <div>
+              <h4 className="text-sm font-medium text-muted-foreground mb-2">
+                PyPI Packages
+              </h4>
+              <div className="border rounded-md divide-y">
+                {trustInfo.uv_dependencies.map((pkg) => (
+                  <PackageItem
+                    key={pkg}
+                    pkg={pkg}
+                    warning={getWarning(pkg)}
+                    onViewPyPI={() => openPyPI(pkg)}
+                  />
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Conda Dependencies */}
+          {trustInfo && trustInfo.conda_dependencies.length > 0 && (
+            <div>
+              <h4 className="text-sm font-medium text-muted-foreground mb-2">
+                Conda Packages
+                {trustInfo.conda_channels.length > 0 && (
+                  <span className="font-normal text-xs ml-2">
+                    ({trustInfo.conda_channels.join(", ")})
+                  </span>
+                )}
+              </h4>
+              <div className="border rounded-md divide-y">
+                {trustInfo.conda_dependencies.map((pkg) => (
+                  <PackageItem
+                    key={pkg}
+                    pkg={pkg}
+                    warning={getWarning(pkg)}
+                    onViewPyPI={() => openCondaForge(pkg)}
+                  />
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Typosquat Warning */}
+          {hasTyposquats && (
+            <div className="flex items-start gap-2 p-3 rounded-md bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800">
+              <AlertTriangleIcon className="size-5 text-amber-600 dark:text-amber-400 shrink-0 mt-0.5" />
+              <div className="text-sm">
+                <p className="font-medium text-amber-800 dark:text-amber-200">
+                  Potential typosquatting detected
+                </p>
+                <p className="text-amber-700 dark:text-amber-300 mt-1">
+                  Some package names are similar to popular packages. Verify these are intentional before approving.
+                </p>
+              </div>
+            </div>
+          )}
+        </div>
+
+        <DialogFooter className="gap-2 sm:gap-0">
+          <Button variant="outline" onClick={handleDecline} disabled={loading}>
+            Don't Install
+          </Button>
+          <Button onClick={handleApprove} disabled={loading}>
+            {loading ? "Approving..." : "Trust & Install"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/notebook/src/components/TrustDialog.tsx
+++ b/apps/notebook/src/components/TrustDialog.tsx
@@ -1,5 +1,5 @@
 import { useCallback } from "react";
-import { AlertTriangleIcon, PackageIcon, ShieldAlertIcon, ExternalLinkIcon } from "lucide-react";
+import { AlertTriangleIcon, PackageIcon, ShieldAlertIcon } from "lucide-react";
 import {
   Dialog,
   DialogContent,
@@ -21,51 +21,23 @@ interface TrustDialogProps {
   loading?: boolean;
 }
 
-/** Open PyPI page for a package */
-function openPyPI(pkg: string) {
-  // Extract package name without version specifiers
-  const name = pkg.split(/[><=!~\[;@]/)[0].trim();
-  window.open(`https://pypi.org/project/${name}/`, "_blank");
-}
-
-/** Open conda-forge page for a package */
-function openCondaForge(pkg: string) {
-  const name = pkg.split(/[><=!~\[]/)[0].trim();
-  window.open(`https://anaconda.org/conda-forge/${name}`, "_blank");
-}
-
 /** Package list item with optional typosquat warning */
 function PackageItem({
   pkg,
   warning,
-  onViewPyPI,
 }: {
   pkg: string;
   warning?: TyposquatWarning;
-  onViewPyPI?: () => void;
 }) {
   return (
-    <div className="flex items-center justify-between py-1 px-2 rounded hover:bg-muted/50 group">
-      <div className="flex items-center gap-2 min-w-0 flex-1">
-        <PackageIcon className="size-4 shrink-0 text-muted-foreground" />
-        <span className="font-mono text-sm truncate">{pkg}</span>
-        {warning && (
-          <span className="inline-flex items-center gap-1 text-xs text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-900/30 px-1.5 py-0.5 rounded">
-            <AlertTriangleIcon className="size-3" />
-            Similar to "{warning.similar_to}"
-          </span>
-        )}
-      </div>
-      {onViewPyPI && (
-        <Button
-          variant="ghost"
-          size="icon-xs"
-          className="opacity-0 group-hover:opacity-100 transition-opacity"
-          onClick={onViewPyPI}
-          title="View on PyPI"
-        >
-          <ExternalLinkIcon className="size-3" />
-        </Button>
+    <div className="flex items-center gap-2 py-1.5 px-2">
+      <PackageIcon className="size-4 shrink-0 text-muted-foreground" />
+      <span className="font-mono text-sm truncate">{pkg}</span>
+      {warning && (
+        <span className="inline-flex items-center gap-1 text-xs text-amber-600 dark:text-amber-400 bg-amber-50 dark:bg-amber-900/30 px-1.5 py-0.5 rounded">
+          <AlertTriangleIcon className="size-3" />
+          Similar to "{warning.similar_to}"
+        </span>
       )}
     </div>
   );
@@ -136,7 +108,6 @@ export function TrustDialog({
                     key={pkg}
                     pkg={pkg}
                     warning={getWarning(pkg)}
-                    onViewPyPI={() => openPyPI(pkg)}
                   />
                 ))}
               </div>
@@ -160,7 +131,6 @@ export function TrustDialog({
                     key={pkg}
                     pkg={pkg}
                     warning={getWarning(pkg)}
-                    onViewPyPI={() => openCondaForge(pkg)}
                   />
                 ))}
               </div>

--- a/apps/notebook/src/hooks/useTrust.ts
+++ b/apps/notebook/src/hooks/useTrust.ts
@@ -1,0 +1,109 @@
+import { useState, useCallback, useEffect } from "react";
+import { invoke } from "@tauri-apps/api/core";
+
+/** Trust status from the backend */
+export type TrustStatusType =
+  | "trusted"
+  | "untrusted"
+  | "signature_invalid"
+  | "no_dependencies";
+
+export interface TrustInfo {
+  status: TrustStatusType;
+  uv_dependencies: string[];
+  conda_dependencies: string[];
+  conda_channels: string[];
+}
+
+export interface TyposquatWarning {
+  package: string;
+  similar_to: string;
+  distance: number;
+}
+
+export function useTrust() {
+  const [trustInfo, setTrustInfo] = useState<TrustInfo | null>(null);
+  const [typosquatWarnings, setTyposquatWarnings] = useState<TyposquatWarning[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Check trust status
+  const checkTrust = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const info = await invoke<TrustInfo>("verify_notebook_trust");
+      setTrustInfo(info);
+
+      // Check for typosquats in all dependencies
+      const allDeps = [
+        ...info.uv_dependencies,
+        ...info.conda_dependencies,
+      ];
+      if (allDeps.length > 0) {
+        const warnings = await invoke<TyposquatWarning[]>("check_typosquats", {
+          packages: allDeps,
+        });
+        setTyposquatWarnings(warnings);
+      } else {
+        setTyposquatWarnings([]);
+      }
+
+      return info;
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      setError(message);
+      console.error("Failed to check trust:", e);
+      return null;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  // Approve the notebook (sign dependencies)
+  const approveTrust = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await invoke("approve_notebook_trust");
+      // Re-check trust status after approval
+      await checkTrust();
+      return true;
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      setError(message);
+      console.error("Failed to approve trust:", e);
+      return false;
+    } finally {
+      setLoading(false);
+    }
+  }, [checkTrust]);
+
+  // Check trust on mount
+  useEffect(() => {
+    checkTrust();
+  }, [checkTrust]);
+
+  // Computed properties
+  const isTrusted = trustInfo?.status === "trusted" || trustInfo?.status === "no_dependencies";
+  const needsApproval = trustInfo?.status === "untrusted" || trustInfo?.status === "signature_invalid";
+  const hasDependencies = trustInfo?.status !== "no_dependencies";
+
+  // Total dependency count
+  const totalDependencies =
+    (trustInfo?.uv_dependencies.length ?? 0) +
+    (trustInfo?.conda_dependencies.length ?? 0);
+
+  return {
+    trustInfo,
+    typosquatWarnings,
+    loading,
+    error,
+    isTrusted,
+    needsApproval,
+    hasDependencies,
+    totalDependencies,
+    checkTrust,
+    approveTrust,
+  };
+}

--- a/crates/notebook/Cargo.toml
+++ b/crates/notebook/Cargo.toml
@@ -33,6 +33,11 @@ petname = "2"
 log = "0.4"
 env_logger = "0.11"
 sha2 = "0.10"
+hmac = "0.12"
+rand = "0.8"
+strsim = "0.11"  # For Levenshtein distance (typosquat detection)
+hex = "0.4"
+chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
 dirs = "5"
 toml = "0.8"
 pathdiff = "0.2"

--- a/crates/notebook/fixtures/trust-tests/README.md
+++ b/crates/notebook/fixtures/trust-tests/README.md
@@ -1,0 +1,35 @@
+# Trust Test Fixtures
+
+These notebooks are designed to test the dependency trust verification system.
+
+## Test Cases
+
+### `untrusted-valid-deps.ipynb`
+- Has valid PyPI dependencies (pandas, numpy)
+- No trust signature
+- **Expected**: Shows trust dialog with package list, no warnings
+
+### `untrusted-typosquat.ipynb`
+- Has typosquatted package names (numppy, pandass, reqeusts)
+- No trust signature
+- **Expected**: Shows trust dialog with typosquat warnings
+
+### `untrusted-mixed-deps.ipynb`
+- Mix of valid (pandas, numpy) and suspicious (scikitlearn, matplotib) packages
+- No trust signature
+- **Expected**: Shows trust dialog with some typosquat warnings
+
+### `untrusted-conda-deps.ipynb`
+- Uses conda dependencies instead of PyPI
+- No trust signature
+- **Expected**: Shows trust dialog with conda packages and channels listed
+
+### `tampered-signature.ipynb`
+- Has a trust signature, but dependencies were modified after signing
+- **Expected**: Shows "Dependencies Modified" dialog variant
+
+## How to Test
+
+1. Build the app: `pnpm notebook:build && cargo tauri build --debug`
+2. Open a fixture: `./target/debug/notebook crates/notebook/fixtures/trust-tests/<file>.ipynb`
+3. Try to run a cell - the trust dialog should appear

--- a/crates/notebook/fixtures/trust-tests/tampered-signature.ipynb
+++ b/crates/notebook/fixtures/trust-tests/tampered-signature.ipynb
@@ -7,11 +7,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# This notebook has a trust signature, but the deps were modified.\n",
-    "# The signature was created when deps were just ['pandas'],\n",
-    "# but now 'malicious-pkg' has been added.\n",
-    "#\n",
-    "# Opening this should show 'Dependencies Modified' dialog."
+    "# This notebook has a trust signature, but the dependencies were modified.\n",
+    "# Opening it should show \"Dependencies Modified\" dialog variant."
    ]
   },
   {
@@ -22,7 +19,7 @@
    "outputs": [],
    "source": [
     "import pandas as pd\n",
-    "# import malicious_pkg  # added by attacker"
+    "import malicious_pkg  # This was added AFTER signing!"
    ]
   }
  ],
@@ -36,16 +33,13 @@
    "name": "python",
    "version": "3.11.0"
   },
-  "additional": {
-   "uv": {
-    "dependencies": ["pandas", "malicious-pkg"],
-    "requires-python": ">=3.10"
-   },
-   "runt": {
-    "env_id": "test-tampered-001",
-    "trust_signature": "hmac-sha256:deadbeefcafebabe0000111122223333444455556666777788889999aaaabbbb",
-    "trust_timestamp": "2024-01-01T00:00:00Z"
-   }
+  "uv": {
+   "dependencies": ["pandas", "malicious-pkg"],
+   "requires-python": ">=3.10"
+  },
+  "runt": {
+   "trust_signature": "fake-signature-that-wont-validate",
+   "trust_timestamp": "2024-01-15T10:30:00Z"
   }
  },
  "nbformat": 4,

--- a/crates/notebook/fixtures/trust-tests/tampered-signature.ipynb
+++ b/crates/notebook/fixtures/trust-tests/tampered-signature.ipynb
@@ -1,0 +1,53 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This notebook has a trust signature, but the deps were modified.\n",
+    "# The signature was created when deps were just ['pandas'],\n",
+    "# but now 'malicious-pkg' has been added.\n",
+    "#\n",
+    "# Opening this should show 'Dependencies Modified' dialog."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "# import malicious_pkg  # added by attacker"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  },
+  "additional": {
+   "uv": {
+    "dependencies": ["pandas", "malicious-pkg"],
+    "requires-python": ">=3.10"
+   },
+   "runt": {
+    "env_id": "test-tampered-001",
+    "trust_signature": "hmac-sha256:deadbeefcafebabe0000111122223333444455556666777788889999aaaabbbb",
+    "trust_timestamp": "2024-01-01T00:00:00Z"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/crates/notebook/fixtures/trust-tests/untrusted-conda-deps.ipynb
+++ b/crates/notebook/fixtures/trust-tests/untrusted-conda-deps.ipynb
@@ -34,15 +34,10 @@
    "name": "python",
    "version": "3.11.0"
   },
-  "additional": {
-   "conda": {
-    "dependencies": ["numpy", "scipy", "matplotlib"],
-    "channels": ["conda-forge"],
-    "python": "3.11"
-   },
-   "runt": {
-    "env_id": "test-conda-001"
-   }
+  "conda": {
+   "dependencies": ["numpy", "scipy", "matplotlib"],
+   "channels": ["conda-forge"],
+   "python": "3.11"
   }
  },
  "nbformat": 4,

--- a/crates/notebook/fixtures/trust-tests/untrusted-conda-deps.ipynb
+++ b/crates/notebook/fixtures/trust-tests/untrusted-conda-deps.ipynb
@@ -1,0 +1,50 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This notebook uses conda dependencies.\n",
+    "# Opening it should show the trust dialog with conda packages listed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import scipy\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  },
+  "additional": {
+   "conda": {
+    "dependencies": ["numpy", "scipy", "matplotlib"],
+    "channels": ["conda-forge"],
+    "python": "3.11"
+   },
+   "runt": {
+    "env_id": "test-conda-001"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/crates/notebook/fixtures/trust-tests/untrusted-mixed-deps.ipynb
+++ b/crates/notebook/fixtures/trust-tests/untrusted-mixed-deps.ipynb
@@ -1,0 +1,49 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This notebook has a mix of valid and suspicious packages.\n",
+    "# The trust dialog should show warnings for 'scikitlearn' (looks like scikit-learn)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "from sklearn.linear_model import LinearRegression"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  },
+  "additional": {
+   "uv": {
+    "dependencies": ["pandas>=2.0", "numpy", "scikitlearn", "matplotib"],
+    "requires-python": ">=3.10"
+   },
+   "runt": {
+    "env_id": "test-mixed-001"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/crates/notebook/fixtures/trust-tests/untrusted-mixed-deps.ipynb
+++ b/crates/notebook/fixtures/trust-tests/untrusted-mixed-deps.ipynb
@@ -34,14 +34,9 @@
    "name": "python",
    "version": "3.11.0"
   },
-  "additional": {
-   "uv": {
-    "dependencies": ["pandas>=2.0", "numpy", "scikitlearn", "matplotib"],
-    "requires-python": ">=3.10"
-   },
-   "runt": {
-    "env_id": "test-mixed-001"
-   }
+  "uv": {
+   "dependencies": ["pandas", "numpy", "scikitlearn", "matplotib"],
+   "requires-python": ">=3.10"
   }
  },
  "nbformat": 4,

--- a/crates/notebook/fixtures/trust-tests/untrusted-typosquat.ipynb
+++ b/crates/notebook/fixtures/trust-tests/untrusted-typosquat.ipynb
@@ -1,0 +1,52 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# WARNING: This notebook contains typosquatted package names!\n",
+    "# Opening it should show the trust dialog with typosquat warnings.\n",
+    "#\n",
+    "# - 'numppy' looks like 'numpy'\n",
+    "# - 'pandass' looks like 'pandas'\n",
+    "# - 'reqeusts' looks like 'requests'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numppy  # typosquat!\n",
+    "import pandass  # typosquat!"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  },
+  "additional": {
+   "uv": {
+    "dependencies": ["numppy", "pandass", "reqeusts"],
+    "requires-python": ">=3.10"
+   },
+   "runt": {
+    "env_id": "test-typosquat-001"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/crates/notebook/fixtures/trust-tests/untrusted-typosquat.ipynb
+++ b/crates/notebook/fixtures/trust-tests/untrusted-typosquat.ipynb
@@ -37,14 +37,9 @@
    "name": "python",
    "version": "3.11.0"
   },
-  "additional": {
-   "uv": {
-    "dependencies": ["numppy", "pandass", "reqeusts"],
-    "requires-python": ">=3.10"
-   },
-   "runt": {
-    "env_id": "test-typosquat-001"
-   }
+  "uv": {
+   "dependencies": ["numppy", "pandass", "reqeusts"],
+   "requires-python": ">=3.10"
   }
  },
  "nbformat": 4,

--- a/crates/notebook/fixtures/trust-tests/untrusted-valid-deps.ipynb
+++ b/crates/notebook/fixtures/trust-tests/untrusted-valid-deps.ipynb
@@ -1,0 +1,51 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "\n",
+    "# This notebook has valid dependencies but no trust signature.\n",
+    "# Opening it should show the trust approval dialog."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.DataFrame({'x': np.random.randn(100)})\n",
+    "df.describe()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  },
+  "additional": {
+   "uv": {
+    "dependencies": ["pandas", "numpy"],
+    "requires-python": ">=3.10"
+   },
+   "runt": {
+    "env_id": "test-valid-deps-001"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/crates/notebook/fixtures/trust-tests/untrusted-valid-deps.ipynb
+++ b/crates/notebook/fixtures/trust-tests/untrusted-valid-deps.ipynb
@@ -36,14 +36,9 @@
    "name": "python",
    "version": "3.11.0"
   },
-  "additional": {
-   "uv": {
-    "dependencies": ["pandas", "numpy"],
-    "requires-python": ">=3.10"
-   },
-   "runt": {
-    "env_id": "test-valid-deps-001"
-   }
+  "uv": {
+   "dependencies": ["pandas", "numpy"],
+   "requires-python": ">=3.10"
   }
  },
  "nbformat": 4,

--- a/crates/notebook/src/trust.rs
+++ b/crates/notebook/src/trust.rs
@@ -82,7 +82,7 @@ pub fn get_or_create_trust_key() -> Result<[u8; 32], String> {
                 .map_err(|e| format!("Failed to create config directory: {}", e))?;
         }
 
-        std::fs::write(&key_path, &key).map_err(|e| format!("Failed to write trust key: {}", e))?;
+        std::fs::write(&key_path, key).map_err(|e| format!("Failed to write trust key: {}", e))?;
 
         Ok(key)
     }

--- a/crates/notebook/src/trust.rs
+++ b/crates/notebook/src/trust.rs
@@ -1,0 +1,385 @@
+//! Notebook trust verification using HMAC signatures over dependency metadata.
+//!
+//! # Security Model
+//!
+//! Notebooks can embed arbitrary package dependencies that get installed with full
+//! OS permissions when a kernel starts. This creates an attack vector: a malicious
+//! notebook could trigger installation of malware via `setup.py`.
+//!
+//! To mitigate this, we sign the dependency-related metadata fields with a per-machine
+//! HMAC key. Only notebooks created or approved on this machine will have valid signatures.
+//!
+//! Key insight: we sign ONLY the dependency metadata, not cell contents. This means:
+//! - Editing code in cells: notebook stays trusted
+//! - External modification of dependencies: requires re-approval
+
+use hmac::{Hmac, Mac};
+use serde::{Deserialize, Serialize};
+use sha2::Sha256;
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// Result of verifying a notebook's trust status.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum TrustStatus {
+    /// Notebook has a valid signature matching current dependencies.
+    Trusted,
+
+    /// Notebook has no signature (new or external notebook).
+    Untrusted,
+
+    /// Notebook has a signature but it doesn't match current dependencies.
+    /// This indicates external modification of the dependency fields.
+    SignatureInvalid,
+
+    /// No dependencies configured, no trust check needed.
+    NoDependencies,
+}
+
+/// Information about notebook trust for the frontend.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TrustInfo {
+    pub status: TrustStatus,
+    /// The UV dependencies that will be installed (if any).
+    pub uv_dependencies: Vec<String>,
+    /// The conda dependencies that will be installed (if any).
+    pub conda_dependencies: Vec<String>,
+    /// Conda channels configured.
+    pub conda_channels: Vec<String>,
+}
+
+/// Path to the trust key file.
+fn trust_key_path() -> Option<PathBuf> {
+    dirs::config_dir().map(|d| d.join("runt").join("trust-key"))
+}
+
+/// Get or create the per-machine trust key.
+///
+/// The key is stored in `~/.config/runt/trust-key` (or platform equivalent).
+/// It's generated randomly on first use and never leaves the machine.
+pub fn get_or_create_trust_key() -> Result<[u8; 32], String> {
+    let key_path = trust_key_path().ok_or_else(|| "Could not determine config directory".to_string())?;
+
+    if key_path.exists() {
+        // Read existing key
+        let key_bytes = std::fs::read(&key_path).map_err(|e| format!("Failed to read trust key: {}", e))?;
+        if key_bytes.len() != 32 {
+            return Err("Trust key file is corrupted (wrong size)".to_string());
+        }
+        let mut key = [0u8; 32];
+        key.copy_from_slice(&key_bytes);
+        Ok(key)
+    } else {
+        // Generate new key
+        let key: [u8; 32] = rand::random();
+
+        // Create directory if needed
+        if let Some(parent) = key_path.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| format!("Failed to create config directory: {}", e))?;
+        }
+
+        std::fs::write(&key_path, &key).map_err(|e| format!("Failed to write trust key: {}", e))?;
+
+        Ok(key)
+    }
+}
+
+/// Extract the dependency-related fields from notebook metadata for signing.
+///
+/// We sign a canonical JSON representation of:
+/// - `metadata.additional["uv"]` (UV dependencies)
+/// - `metadata.additional["conda"]` (conda dependencies)
+///
+/// This does NOT include cell contents, outputs, or other metadata.
+fn extract_signable_content(metadata: &HashMap<String, serde_json::Value>) -> String {
+    let mut signable = serde_json::Map::new();
+
+    // Extract UV deps (sort keys for canonical representation)
+    if let Some(uv) = metadata.get("uv") {
+        signable.insert("uv".to_string(), uv.clone());
+    }
+
+    // Extract conda deps
+    if let Some(conda) = metadata.get("conda") {
+        signable.insert("conda".to_string(), conda.clone());
+    }
+
+    // Create canonical JSON (sorted keys)
+    serde_json::to_string(&serde_json::Value::Object(signable)).unwrap_or_default()
+}
+
+/// Compute HMAC signature over dependency metadata.
+pub fn compute_signature(
+    key: &[u8; 32],
+    metadata: &HashMap<String, serde_json::Value>,
+) -> String {
+    let content = extract_signable_content(metadata);
+
+    let mut mac = HmacSha256::new_from_slice(key).expect("HMAC can accept any key size");
+    mac.update(content.as_bytes());
+    let result = mac.finalize();
+
+    // Encode as hex
+    format!("hmac-sha256:{}", hex::encode(result.into_bytes()))
+}
+
+/// Verify a signature against the current dependency metadata.
+pub fn verify_signature(
+    key: &[u8; 32],
+    metadata: &HashMap<String, serde_json::Value>,
+    signature: &str,
+) -> bool {
+    // Parse the signature format
+    let expected_prefix = "hmac-sha256:";
+    if !signature.starts_with(expected_prefix) {
+        return false;
+    }
+
+    let expected_hex = &signature[expected_prefix.len()..];
+    let expected_bytes = match hex::decode(expected_hex) {
+        Ok(b) => b,
+        Err(_) => return false,
+    };
+
+    // Compute current signature
+    let content = extract_signable_content(metadata);
+
+    let mut mac = HmacSha256::new_from_slice(key).expect("HMAC can accept any key size");
+    mac.update(content.as_bytes());
+
+    // Constant-time comparison
+    mac.verify_slice(&expected_bytes).is_ok()
+}
+
+/// Check if a notebook has any dependencies configured.
+pub fn has_dependencies(metadata: &HashMap<String, serde_json::Value>) -> bool {
+    // Check UV dependencies
+    if let Some(uv) = metadata.get("uv") {
+        if let Some(deps) = uv.get("dependencies").and_then(|v| v.as_array()) {
+            if !deps.is_empty() {
+                return true;
+            }
+        }
+    }
+
+    // Check conda dependencies
+    if let Some(conda) = metadata.get("conda") {
+        if let Some(deps) = conda.get("dependencies").and_then(|v| v.as_array()) {
+            if !deps.is_empty() {
+                return true;
+            }
+        }
+    }
+
+    false
+}
+
+/// Verify the trust status of a notebook.
+///
+/// Returns the trust status and information about what dependencies would be installed.
+pub fn verify_notebook_trust(
+    metadata: &HashMap<String, serde_json::Value>,
+) -> Result<TrustInfo, String> {
+    // Extract dependencies for the response
+    let uv_dependencies: Vec<String> = metadata
+        .get("uv")
+        .and_then(|v| v.get("dependencies"))
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let conda_dependencies: Vec<String> = metadata
+        .get("conda")
+        .and_then(|v| v.get("dependencies"))
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let conda_channels: Vec<String> = metadata
+        .get("conda")
+        .and_then(|v| v.get("channels"))
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    // If no dependencies, no trust check needed
+    if uv_dependencies.is_empty() && conda_dependencies.is_empty() {
+        return Ok(TrustInfo {
+            status: TrustStatus::NoDependencies,
+            uv_dependencies,
+            conda_dependencies,
+            conda_channels,
+        });
+    }
+
+    // Get the trust key
+    let key = get_or_create_trust_key()?;
+
+    // Check for existing signature
+    let signature = metadata
+        .get("runt")
+        .and_then(|v| v.get("trust_signature"))
+        .and_then(|v| v.as_str());
+
+    let status = match signature {
+        None => TrustStatus::Untrusted,
+        Some(sig) => {
+            if verify_signature(&key, metadata, sig) {
+                TrustStatus::Trusted
+            } else {
+                TrustStatus::SignatureInvalid
+            }
+        }
+    };
+
+    Ok(TrustInfo {
+        status,
+        uv_dependencies,
+        conda_dependencies,
+        conda_channels,
+    })
+}
+
+/// Sign the notebook's dependencies and return the signature.
+///
+/// The caller is responsible for storing this in `metadata.additional["runt"]["trust_signature"]`.
+pub fn sign_notebook_dependencies(
+    metadata: &HashMap<String, serde_json::Value>,
+) -> Result<String, String> {
+    let key = get_or_create_trust_key()?;
+    Ok(compute_signature(&key, metadata))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_test_metadata(uv_deps: Vec<&str>, conda_deps: Vec<&str>) -> HashMap<String, serde_json::Value> {
+        let mut metadata = HashMap::new();
+
+        if !uv_deps.is_empty() {
+            metadata.insert(
+                "uv".to_string(),
+                serde_json::json!({
+                    "dependencies": uv_deps,
+                }),
+            );
+        }
+
+        if !conda_deps.is_empty() {
+            metadata.insert(
+                "conda".to_string(),
+                serde_json::json!({
+                    "dependencies": conda_deps,
+                    "channels": ["conda-forge"],
+                }),
+            );
+        }
+
+        metadata
+    }
+
+    #[test]
+    fn test_no_dependencies_is_trusted() {
+        let metadata = HashMap::new();
+        let info = verify_notebook_trust(&metadata).unwrap();
+        assert_eq!(info.status, TrustStatus::NoDependencies);
+    }
+
+    #[test]
+    fn test_unsigned_notebook_is_untrusted() {
+        let metadata = make_test_metadata(vec!["pandas"], vec![]);
+        let info = verify_notebook_trust(&metadata).unwrap();
+        assert_eq!(info.status, TrustStatus::Untrusted);
+    }
+
+    #[test]
+    fn test_sign_and_verify() {
+        let metadata = make_test_metadata(vec!["pandas", "numpy"], vec![]);
+
+        // Sign the notebook
+        let signature = sign_notebook_dependencies(&metadata).unwrap();
+
+        // Add signature to metadata
+        let mut signed_metadata = metadata.clone();
+        signed_metadata.insert(
+            "runt".to_string(),
+            serde_json::json!({
+                "trust_signature": signature,
+            }),
+        );
+
+        // Verify it's now trusted
+        let info = verify_notebook_trust(&signed_metadata).unwrap();
+        assert_eq!(info.status, TrustStatus::Trusted);
+    }
+
+    #[test]
+    fn test_modified_deps_invalidates_signature() {
+        let metadata = make_test_metadata(vec!["pandas"], vec![]);
+
+        // Sign the notebook
+        let signature = sign_notebook_dependencies(&metadata).unwrap();
+
+        // Add signature to metadata
+        let mut signed_metadata = metadata;
+        signed_metadata.insert(
+            "runt".to_string(),
+            serde_json::json!({
+                "trust_signature": signature,
+            }),
+        );
+
+        // Modify dependencies (simulate external edit)
+        signed_metadata.insert(
+            "uv".to_string(),
+            serde_json::json!({
+                "dependencies": ["pandas", "malicious-pkg"],
+            }),
+        );
+
+        // Verify signature is now invalid
+        let info = verify_notebook_trust(&signed_metadata).unwrap();
+        assert_eq!(info.status, TrustStatus::SignatureInvalid);
+    }
+
+    #[test]
+    fn test_signature_format() {
+        let metadata = make_test_metadata(vec!["pandas"], vec![]);
+        let signature = sign_notebook_dependencies(&metadata).unwrap();
+        assert!(signature.starts_with("hmac-sha256:"));
+    }
+
+    #[test]
+    fn test_trust_info_serialization() {
+        // Verify TrustInfo serializes with status as a simple string, not nested object
+        let info = TrustInfo {
+            status: TrustStatus::NoDependencies,
+            uv_dependencies: vec![],
+            conda_dependencies: vec![],
+            conda_channels: vec![],
+        };
+
+        let json = serde_json::to_value(&info).unwrap();
+
+        // status should be a string "no_dependencies", not {"status": "no_dependencies"}
+        assert_eq!(json["status"], "no_dependencies");
+        assert!(json["status"].is_string());
+    }
+}

--- a/crates/notebook/src/typosquat.rs
+++ b/crates/notebook/src/typosquat.rs
@@ -1,0 +1,329 @@
+//! Typosquatting detection for package names.
+//!
+//! Warns users when a package name is suspiciously similar to a popular package,
+//! helping prevent supply chain attacks via typosquatting (e.g., `numppy` instead of `numpy`).
+
+use serde::{Deserialize, Serialize};
+use strsim::levenshtein;
+
+/// A warning about a potentially typosquatted package name.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TyposquatWarning {
+    /// The package name that was checked.
+    pub package: String,
+    /// The popular package it might be confused with.
+    pub similar_to: String,
+    /// The edit distance between the names.
+    pub distance: usize,
+}
+
+/// Top PyPI packages by download count.
+/// This list is used to detect typosquatting attempts.
+///
+/// Source: https://hugovk.github.io/top-pypi-packages/ (regularly updated)
+const POPULAR_PACKAGES: &[&str] = &[
+    // Top 100 most downloaded packages (roughly)
+    "boto3",
+    "botocore",
+    "urllib3",
+    "requests",
+    "setuptools",
+    "charset-normalizer",
+    "certifi",
+    "idna",
+    "typing-extensions",
+    "python-dateutil",
+    "s3transfer",
+    "packaging",
+    "aiobotocore",
+    "pyyaml",
+    "numpy",
+    "six",
+    "cryptography",
+    "pip",
+    "jmespath",
+    "s3fs",
+    "fsspec",
+    "cffi",
+    "attrs",
+    "pycparser",
+    "wheel",
+    "zipp",
+    "importlib-metadata",
+    "aiohttp",
+    "pyasn1",
+    "multidict",
+    "pandas",
+    "platformdirs",
+    "yarl",
+    "rsa",
+    "pytz",
+    "google-api-core",
+    "async-timeout",
+    "awscli",
+    "protobuf",
+    "googleapis-common-protos",
+    "filelock",
+    "wrapt",
+    "markupsafe",
+    "frozenlist",
+    "colorama",
+    "aiosignal",
+    "click",
+    "jinja2",
+    "jsonschema",
+    "tomli",
+    "pyparsing",
+    "pydantic",
+    "grpcio",
+    "pyarrow",
+    "sqlalchemy",
+    "tqdm",
+    "docutils",
+    "google-auth",
+    "werkzeug",
+    "pillow",
+    "scipy",
+    "decorator",
+    "pluggy",
+    "greenlet",
+    "cachetools",
+    "exceptiongroup",
+    "tzdata",
+    "pytest",
+    "iniconfig",
+    "flask",
+    "pyjwt",
+    "google-cloud-storage",
+    "lxml",
+    "pyopenssl",
+    "psutil",
+    "oauthlib",
+    "soupsieve",
+    "beautifulsoup4",
+    "google-cloud-core",
+    "requests-oauthlib",
+    "httplib2",
+    "pygments",
+    "isodate",
+    "openpyxl",
+    "networkx",
+    "et-xmlfile",
+    "httpx",
+    "sniffio",
+    "anyio",
+    "httpcore",
+    "h11",
+    "distlib",
+    "virtualenv",
+    "matplotlib",
+    "scikit-learn",
+    "joblib",
+    "threadpoolctl",
+    "pynacl",
+    "bcrypt",
+    "paramiko",
+    // Additional commonly targeted packages
+    "tensorflow",
+    "torch",
+    "keras",
+    "opencv-python",
+    "selenium",
+    "scrapy",
+    "django",
+    "fastapi",
+    "uvicorn",
+    "gunicorn",
+    "celery",
+    "redis",
+    "pymongo",
+    "psycopg2",
+    "mysqlclient",
+    "elasticsearch",
+    "boto",
+    "aws-cdk-lib",
+    "black",
+    "flake8",
+    "mypy",
+    "isort",
+    "pylint",
+    "coverage",
+    "nose",
+    "mock",
+    "faker",
+    "factory-boy",
+    "hypothesis",
+    "httpretty",
+    "responses",
+    "moto",
+    "ipython",
+    "jupyter",
+    "notebook",
+    "jupyterlab",
+    "ipykernel",
+    "ipywidgets",
+    "nbformat",
+    "nbconvert",
+    "traitlets",
+    "rich",
+    "typer",
+    "pydantic-settings",
+    "python-dotenv",
+    "python-multipart",
+    "starlette",
+    "aiofiles",
+    "orjson",
+    "ujson",
+    "msgpack",
+    "cloudpickle",
+    "dill",
+    "joblib",
+    "transformers",
+    "tokenizers",
+    "huggingface-hub",
+    "accelerate",
+    "safetensors",
+    "datasets",
+    "evaluate",
+    "timm",
+    "torchvision",
+    "torchaudio",
+    "lightning",
+    "wandb",
+    "mlflow",
+    "ray",
+    "dask",
+    "xarray",
+    "zarr",
+    "numba",
+    "cython",
+];
+
+/// Extract package name from a dependency specifier.
+/// Handles version specifiers like `pandas>=2.0`, `numpy[extra]`, etc.
+fn extract_package_name(dep: &str) -> &str {
+    // Split on version specifiers and extras
+    dep.split(&['>', '<', '=', '!', '~', '[', ';', '@'][..])
+        .next()
+        .unwrap_or(dep)
+        .trim()
+}
+
+/// Normalize a package name for comparison.
+/// PyPI considers `_`, `-`, and `.` as equivalent, and is case-insensitive.
+fn normalize_name(name: &str) -> String {
+    name.to_lowercase()
+        .replace('_', "-")
+        .replace('.', "-")
+}
+
+/// Check if a package name is suspiciously similar to a popular package.
+///
+/// Returns `Some(TyposquatWarning)` if the package name is within edit distance
+/// threshold of a popular package (but not an exact match).
+pub fn check_typosquat(package: &str) -> Option<TyposquatWarning> {
+    let pkg_name = extract_package_name(package);
+    let normalized = normalize_name(pkg_name);
+
+    // Skip if the package is itself a popular package (exact match)
+    for &popular in POPULAR_PACKAGES {
+        if normalize_name(popular) == normalized {
+            return None;
+        }
+    }
+
+    // Check edit distance against popular packages
+    let threshold = match normalized.len() {
+        0..=3 => 1,   // Very short names: only 1 edit allowed
+        4..=6 => 2,   // Short names: 2 edits
+        _ => 3,       // Longer names: 3 edits
+    };
+
+    let mut best_match: Option<(&str, usize)> = None;
+
+    for &popular in POPULAR_PACKAGES {
+        let popular_normalized = normalize_name(popular);
+        let distance = levenshtein(&normalized, &popular_normalized);
+
+        // Skip exact matches (handled above)
+        if distance == 0 {
+            continue;
+        }
+
+        // Check if within threshold and better than current best
+        if distance <= threshold {
+            if best_match.is_none() || distance < best_match.unwrap().1 {
+                best_match = Some((popular, distance));
+            }
+        }
+    }
+
+    best_match.map(|(similar_to, distance)| TyposquatWarning {
+        package: pkg_name.to_string(),
+        similar_to: similar_to.to_string(),
+        distance,
+    })
+}
+
+/// Check multiple packages for typosquatting.
+///
+/// Returns warnings for any packages that look like typosquats.
+pub fn check_packages(packages: &[String]) -> Vec<TyposquatWarning> {
+    packages
+        .iter()
+        .filter_map(|pkg| check_typosquat(pkg))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_exact_match_no_warning() {
+        assert!(check_typosquat("numpy").is_none());
+        assert!(check_typosquat("pandas").is_none());
+        assert!(check_typosquat("requests").is_none());
+    }
+
+    #[test]
+    fn test_with_version_specifier() {
+        assert!(check_typosquat("numpy>=1.20").is_none());
+        assert!(check_typosquat("pandas[sql]>=2.0").is_none());
+    }
+
+    #[test]
+    fn test_typosquat_detection() {
+        // Common typosquats
+        let warning = check_typosquat("numppy").expect("should detect typosquat");
+        assert_eq!(warning.similar_to, "numpy");
+
+        let warning = check_typosquat("padas").expect("should detect typosquat");
+        assert_eq!(warning.similar_to, "pandas");
+
+        let warning = check_typosquat("requets").expect("should detect typosquat");
+        assert_eq!(warning.similar_to, "requests");
+    }
+
+    #[test]
+    fn test_normalization() {
+        // PyPI normalizes these characters
+        assert!(check_typosquat("Numpy").is_none()); // Case insensitive
+        assert!(check_typosquat("typing_extensions").is_none()); // _ == -
+    }
+
+    #[test]
+    fn test_unrelated_package_no_warning() {
+        // Random package names shouldn't trigger warnings
+        assert!(check_typosquat("my-custom-package").is_none());
+        assert!(check_typosquat("foobarqux").is_none());
+    }
+
+    #[test]
+    fn test_extract_package_name() {
+        assert_eq!(extract_package_name("pandas>=2.0"), "pandas");
+        assert_eq!(extract_package_name("numpy[extra]"), "numpy");
+        assert_eq!(extract_package_name("requests~=2.28"), "requests");
+        assert_eq!(extract_package_name("torch @ https://..."), "torch");
+    }
+}

--- a/crates/notebook/src/typosquat.rs
+++ b/crates/notebook/src/typosquat.rs
@@ -212,9 +212,7 @@ fn extract_package_name(dep: &str) -> &str {
 /// Normalize a package name for comparison.
 /// PyPI considers `_`, `-`, and `.` as equivalent, and is case-insensitive.
 fn normalize_name(name: &str) -> String {
-    name.to_lowercase()
-        .replace('_', "-")
-        .replace('.', "-")
+    name.to_lowercase().replace(['_', '.'], "-")
 }
 
 /// Check if a package name is suspiciously similar to a popular package.
@@ -251,10 +249,8 @@ pub fn check_typosquat(package: &str) -> Option<TyposquatWarning> {
         }
 
         // Check if within threshold and better than current best
-        if distance <= threshold {
-            if best_match.is_none() || distance < best_match.unwrap().1 {
-                best_match = Some((popular, distance));
-            }
+        if distance <= threshold && (best_match.is_none() || distance < best_match.unwrap().1) {
+            best_match = Some((popular, distance));
         }
     }
 


### PR DESCRIPTION
## Summary

Implements HMAC-SHA256 based trust verification for notebook dependencies. Notebooks can embed arbitrary package dependencies that get installed with full OS permissions when a kernel starts - this creates a supply chain attack vector. This change adds:

- **Trust signing**: Per-machine trust keys stored in `~/.config/runt/trust-key`
- **Approval dialog**: Shows package list with typosquat warnings before installation
- **Typosquat detection**: Fuzzy matching against ~150 popular PyPI packages
- **Auto-signing**: Local notebooks stay trusted when user modifies deps via UI
- **Metadata signing only**: Code edits don't invalidate trust, only dep changes do

## Test Scenarios

Each fixture can be tested by:
```
pnpm notebook:build && cargo tauri build --debug
./target/debug/notebook crates/notebook/fixtures/trust-tests/<fixture>.ipynb
Try to run a cell - trust dialog should appear
```

### Valid Dependencies (untrusted-valid-deps.ipynb)
Shows dialog with pandas, numpy - no warnings

<img width="1212" height="862" alt="image-v7" src="https://github.com/user-attachments/assets/e39a2b40-ddb7-4121-a73e-82961045f3b5" />

### Typosquat Detection (untrusted-typosquat.ipynb)
Shows warnings for numppy, pandass, reqeusts with "similar to" tags

<img width="1212" height="862" alt="image-v8" src="https://github.com/user-attachments/assets/8caca39e-acea-429c-ba97-d128267ec6cd" />

### Mixed Packages (untrusted-mixed-deps.ipynb)
Valid packages (pandas, numpy) + suspicious (scikitlearn, matplotib)

<img width="1212" height="862" alt="image-v9" src="https://github.com/user-attachments/assets/686d4ea2-b95f-46d8-b153-b62f9242d1d6" />

### Conda Packages (untrusted-conda-deps.ipynb)
Lists conda dependencies with conda-forge channel

<img width="1212" height="862" alt="image-v10" src="https://github.com/user-attachments/assets/1b536320-584b-47cb-837b-1e6584043a92" />

### Tampered Dependencies (tampered-signature.ipynb)
Shows "Dependencies Modified" variant when signature is invalid

<img width="1212" height="862" alt="image-v11" src="https://github.com/user-attachments/assets/c58c3a63-1691-4c33-a227-a877bd9e9a35" />


Co-Authored-By: QuillAid <261289082+quillaid@users.noreply.github.com>