### PR TITLE
Add E2E happy path test and fix output clearing bug

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -57,6 +57,7 @@ function AppContent() {
     dirty,
     appendOutput,
     setExecutionCount,
+    clearCellOutputs,
   } = useNotebook();
 
   const { theme, setTheme } = useTheme("notebook-theme");
@@ -247,6 +248,8 @@ onKernelStarted: loadCondaDependencies,
 
   const handleExecuteCell = useCallback(
     (cellId: string) => {
+      // Clear outputs immediately so user sees feedback
+      clearCellOutputs(cellId);
       // Queue FIRST to preserve order - don't await so rapid executions queue in order
       queueCell(cellId);
       // Then ensure kernel is started (queue processor will wait for it)
@@ -254,7 +257,7 @@ onKernelStarted: loadCondaDependencies,
         tryStartKernel();
       }
     },
-    [queueCell, kernelStatus, tryStartKernel]
+    [clearCellOutputs, queueCell, kernelStatus, tryStartKernel]
   );
 
   const handleAddCell = useCallback(

--- a/apps/notebook/src/hooks/useNotebook.ts
+++ b/apps/notebook/src/hooks/useNotebook.ts
@@ -25,9 +25,11 @@ export function useNotebook() {
     invoke("update_cell_source", { cellId, source }).catch(console.error);
   }, []);
 
-  const executeCell = useCallback(async (cellId: string) => {
-    console.log("[notebook] executeCell:", cellId);
-    // Clear old outputs and mark running
+  /**
+   * Clear outputs and execution count for a cell.
+   * Called before queuing a cell for execution to ensure a clean slate.
+   */
+  const clearCellOutputs = useCallback((cellId: string) => {
     setCells((prev) =>
       prev.map((c) =>
         c.id === cellId && c.cell_type === "code"
@@ -35,6 +37,12 @@ export function useNotebook() {
           : c
       )
     );
+  }, []);
+
+  const executeCell = useCallback(async (cellId: string) => {
+    console.log("[notebook] executeCell:", cellId);
+    // Clear old outputs and mark running
+    clearCellOutputs(cellId);
     try {
       const msgId = await invoke<string>("execute_cell", { cellId });
       console.log("[notebook] execute_cell returned msg_id:", msgId);
@@ -43,7 +51,7 @@ export function useNotebook() {
       console.error("[notebook] execute_cell failed:", e);
       return null;
     }
-  }, []);
+  }, [clearCellOutputs]);
 
   const addCell = useCallback(
     async (cellType: "code" | "markdown", afterCellId?: string | null) => {
@@ -180,6 +188,7 @@ export function useNotebook() {
     setFocusedCellId,
     updateCellSource,
     executeCell,
+    clearCellOutputs,
     addCell,
     deleteCell,
     save,

--- a/contributing/e2e.md
+++ b/contributing/e2e.md
@@ -1,0 +1,310 @@
+# E2E Testing Guide
+
+This guide covers writing and running end-to-end tests for the notebook application.
+
+## Overview
+
+E2E tests verify the full application works correctly from a user's perspective. We use:
+
+- **WebdriverIO** - Browser automation framework
+- **Mocha** - Test runner
+- **Tauri WebDriver** - Drives the Tauri app via WebDriver protocol
+- **Docker** - Required because Tauri WebDriver has macOS sandboxing issues
+
+## Running Tests
+
+### CI Mode (Full Build)
+
+For CI pipelines or when you need a clean, reproducible build:
+
+```bash
+pnpm test:e2e:docker
+```
+
+This builds everything from scratch (~4-5 minutes).
+
+### Dev Mode (Fast Iteration)
+
+For rapid iteration during development:
+
+```bash
+# First time only: Build base image with cached dependencies
+pnpm e2e:base:build
+
+# Then run tests quickly (~1-2 minutes)
+pnpm test:e2e:dev
+```
+
+### Interactive Debugging
+
+For debugging failing tests:
+
+```bash
+pnpm e2e:dev:shell
+```
+
+Inside the container:
+```bash
+# Run all tests
+pnpm test:e2e
+
+# Run a single spec
+pnpm wdio run e2e/wdio.conf.js --spec e2e/specs/notebook-execution.spec.js
+```
+
+## Writing Tests
+
+### File Location
+
+Tests live in `e2e/specs/` with the `.spec.js` extension:
+
+```
+e2e/
+├── specs/
+│   ├── iframe-isolation.spec.js    # Security tests
+│   └── notebook-execution.spec.js  # Happy path tests
+├── wdio.conf.js                    # WebdriverIO config
+└── Dockerfile                      # CI build
+```
+
+### Basic Structure
+
+```javascript
+import { browser, expect } from "@wdio/globals";
+
+describe("Feature Name", () => {
+  before(async () => {
+    // Setup before all tests in this describe block
+    await browser.pause(5000); // Wait for app to load
+  });
+
+  it("should do something specific", async () => {
+    // Arrange: Set up test state
+    const element = await $('[data-testid="my-element"]');
+
+    // Act: Perform actions
+    await element.click();
+
+    // Assert: Verify results
+    expect(await element.getText()).toContain("expected text");
+  });
+});
+```
+
+### Common Patterns
+
+#### Finding Elements
+
+Use data attributes for reliable selection:
+
+```javascript
+// By test ID (preferred)
+const button = await $('[data-testid="execute-button"]');
+
+// By data attributes
+const codeCell = await $('[data-cell-type="code"]');
+const output = await $('[data-slot="ansi-stream-output"]');
+
+// By CSS class (less stable)
+const editor = await $('.cm-content[contenteditable="true"]');
+
+// Within a parent element
+const cellOutput = await codeCell.$('[data-slot="ansi-stream-output"]');
+```
+
+#### Typing Text
+
+```javascript
+// Click to focus, then type
+await editor.click();
+await browser.keys("print('hello world')");
+
+// For reliable typing (avoids dropped characters)
+async function typeSlowly(text, delay = 50) {
+  for (const char of text) {
+    await browser.keys(char);
+    await browser.pause(delay);
+  }
+}
+await typeSlowly("print('hello')");
+
+// Keyboard shortcuts
+await browser.keys(["Shift", "Enter"]); // Execute cell
+await browser.keys(["Control", "a"]);   // Select all
+```
+
+#### Waiting for Async Operations
+
+```javascript
+// Wait for element to exist
+await element.waitForExist({ timeout: 5000 });
+
+// Wait for element to be clickable
+await button.waitForClickable({ timeout: 5000 });
+
+// Wait for custom condition
+await browser.waitUntil(
+  async () => {
+    const output = await $('[data-slot="ansi-stream-output"]');
+    if (!(await output.isExisting())) return false;
+    const text = await output.getText();
+    return text.includes("expected output");
+  },
+  {
+    timeout: 30000,
+    timeoutMsg: "Output did not appear",
+    interval: 500,
+  }
+);
+```
+
+#### Working with Iframes
+
+For testing isolated content in iframes:
+
+```javascript
+// Switch to iframe
+const iframe = await $('iframe[sandbox]');
+await browser.switchToFrame(iframe);
+
+// Run assertions inside iframe
+const result = await browser.execute(() => {
+  return window.someValue;
+});
+
+// Switch back to main frame
+await browser.switchToParentFrame();
+```
+
+### Available Selectors
+
+| Selector | Element |
+|----------|---------|
+| `[data-cell-type="code"]` | Code cell container |
+| `[data-cell-type="markdown"]` | Markdown cell container |
+| `[data-cell-id="..."]` | Cell by specific ID |
+| `[data-testid="execute-button"]` | Run cell button |
+| `[data-slot="output-area"]` | Cell output area |
+| `[data-slot="ansi-stream-output"]` | Stream output (stdout/stderr) |
+| `[data-slot="ansi-error-output"]` | Error output with traceback |
+| `.cm-content[contenteditable="true"]` | CodeMirror editor |
+| `iframe[sandbox]` | Isolated output iframe |
+
+### Timeout Guidelines
+
+| Operation | Timeout |
+|-----------|---------|
+| App load | 5 seconds |
+| Kernel startup (first run) | 30-60 seconds |
+| Cell execution (kernel ready) | 15 seconds |
+| Element appear | 5 seconds |
+| Button clickable | 5 seconds |
+
+### Adding data-testid Attributes
+
+When adding new features, include `data-testid` attributes for testing:
+
+```tsx
+// In your React component
+<button
+  onClick={handleClick}
+  data-testid="my-feature-button"
+>
+  Click me
+</button>
+```
+
+Naming conventions:
+- Use kebab-case: `data-testid="execute-button"`
+- Be specific: `data-testid="cell-delete-button"` not `data-testid="delete"`
+- Match component names when sensible
+
+## Debugging Tips
+
+### Console Output
+
+Tests log progress to the console:
+
+```javascript
+console.log("Step completed:", someValue);
+```
+
+### Page State
+
+Inspect the page during test development:
+
+```javascript
+// Get page source
+const html = await browser.getPageSource();
+console.log(html);
+
+// Get page title/URL
+console.log("Title:", await browser.getTitle());
+console.log("URL:", await browser.getUrl());
+
+// Execute JS in the page
+const result = await browser.execute(() => {
+  return document.querySelector('[data-cell-type]')?.outerHTML;
+});
+```
+
+### Pausing Tests
+
+Add pauses to observe behavior:
+
+```javascript
+await browser.pause(5000); // Pause for 5 seconds
+```
+
+### Screenshots (not currently available)
+
+Note: Screenshot functionality requires additional setup in the Docker environment.
+
+## Test Configuration
+
+Configuration is in `e2e/wdio.conf.js`:
+
+- **maxInstances**: 1 (single Tauri app instance)
+- **timeout**: 60000ms per test
+- **waitforTimeout**: 10000ms for waitFor* methods
+- **connectionRetryTimeout**: 120000ms for WebDriver connection
+
+## CI Integration
+
+Tests run automatically in CI via `pnpm test:e2e:docker`. The Docker build ensures:
+
+- Consistent Linux environment
+- All dependencies installed
+- Xvfb for headless display
+- WebDriver properly configured
+
+## Troubleshooting
+
+### "No such element" Errors
+
+- Element may not be rendered yet - add `waitForExist()`
+- Selector may be wrong - verify with `browser.getPageSource()`
+- Element may be in an iframe - use `switchToFrame()`
+
+### Timeout Errors
+
+- Kernel startup is slow on first run - increase timeout to 60s
+- Check if the app loaded correctly
+- Verify the expected element is actually rendered
+
+### Flaky Tests
+
+- Add explicit waits instead of `pause()`
+- Use `waitUntil()` for async conditions
+- Type slowly to avoid dropped keystrokes
+- Check for race conditions in the app
+
+### Docker Build Issues
+
+```bash
+# Force rebuild without cache
+docker compose build --no-cache tauri-e2e
+
+# Rebuild dev image after code changes
+pnpm e2e:dev:build
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,13 @@
 services:
-  # E2E test environment with Tauri app and WebDriver
-  # Runs tests inside the container since tauri-driver only binds to localhost
+  # =============================================================================
+  # CI Mode: Full isolated build (default)
+  # =============================================================================
+  # Used in CI pipelines. Builds everything from scratch for reproducibility.
+  #
+  # Usage:
+  #   pnpm test:e2e:docker
+  #   docker compose run --rm tauri-e2e
+  #
   tauri-e2e:
     platform: linux/amd64
     build:
@@ -12,7 +19,6 @@ services:
     environment:
       - DISPLAY=:99
       - TAURI_APP_PATH=/app/target/release/notebook
-    # Run tests inside the container
     command: >
       bash -c "
         Xvfb :99 -screen 0 1920x1080x24 &
@@ -21,4 +27,79 @@ services:
         sleep 3 &&
         cd /app &&
         pnpm test:e2e
+      "
+
+  # =============================================================================
+  # Dev Mode: Fast iteration with cached base image
+  # =============================================================================
+  # Uses pre-built base image with dependencies cached. Much faster for
+  # iterating on code changes.
+  #
+  # First time setup (run once, or when deps change):
+  #   pnpm e2e:base:build
+  #   docker build -f e2e/Dockerfile.base -t vienna-e2e-base .
+  #
+  # Usage:
+  #   pnpm test:e2e:dev
+  #   docker compose run --rm tauri-e2e-dev
+  #
+  tauri-e2e-dev:
+    platform: linux/amd64
+    profiles: ["dev"]
+    build:
+      context: .
+      dockerfile: e2e/Dockerfile.dev
+    volumes:
+      # Mount e2e tests for live updates
+      - ./e2e:/app/e2e:ro
+    environment:
+      - DISPLAY=:99
+      - TAURI_APP_PATH=/app/target/release/notebook
+    command: >
+      bash -c "
+        Xvfb :99 -screen 0 1920x1080x24 &
+        sleep 2 &&
+        DISPLAY=:99 tauri-driver --port 4444 &
+        sleep 3 &&
+        cd /app &&
+        pnpm test:e2e
+      "
+
+  # =============================================================================
+  # Dev Shell: Interactive debugging
+  # =============================================================================
+  # Starts container with Xvfb and tauri-driver running, drops you into a shell.
+  # Useful for debugging test failures interactively.
+  #
+  # Usage:
+  #   docker compose run --rm tauri-e2e-shell
+  #
+  # Then inside container:
+  #   pnpm test:e2e                    # Run all tests
+  #   pnpm wdio run e2e/wdio.conf.js --spec e2e/specs/notebook-execution.spec.js
+  #
+  tauri-e2e-shell:
+    platform: linux/amd64
+    profiles: ["dev"]
+    build:
+      context: .
+      dockerfile: e2e/Dockerfile.dev
+    volumes:
+      - ./e2e:/app/e2e:ro
+    environment:
+      - DISPLAY=:99
+      - TAURI_APP_PATH=/app/target/release/notebook
+    stdin_open: true
+    tty: true
+    command: >
+      bash -c "
+        Xvfb :99 -screen 0 1920x1080x24 &
+        sleep 2 &&
+        DISPLAY=:99 tauri-driver --port 4444 &
+        sleep 3 &&
+        echo '=== E2E Dev Shell ===' &&
+        echo 'Run tests: pnpm test:e2e' &&
+        echo 'Run single: pnpm wdio run e2e/wdio.conf.js --spec e2e/specs/notebook-execution.spec.js' &&
+        echo '' &&
+        bash
       "

--- a/e2e/Dockerfile.base
+++ b/e2e/Dockerfile.base
@@ -1,0 +1,32 @@
+# Base image for E2E testing with all dependencies pre-installed
+# Build this once and reuse for faster dev iterations
+#
+# Build: docker build -f e2e/Dockerfile.base -t vienna-e2e-base .
+# This image is cached and only needs rebuilding when dependencies change
+
+FROM ivangabriele/tauri:debian-bookworm-20
+
+# Install test dependencies
+RUN apt-get update && apt-get install -y \
+    xvfb \
+    webkit2gtk-driver \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Install tauri-cli (this is slow, so cache it in base image)
+RUN cargo install tauri-cli --locked
+
+# Pre-cache Rust dependencies by building a dummy project
+# This speeds up subsequent builds significantly
+COPY Cargo.toml Cargo.lock rust-toolchain.toml ./
+COPY crates/ crates/
+
+# Build dependencies only (creates cached artifacts)
+RUN cargo fetch
+RUN cargo build --release --package notebook 2>/dev/null || true
+
+# The base image now has:
+# - All system dependencies
+# - tauri-cli installed
+# - Rust dependencies cached

--- a/e2e/Dockerfile.dev
+++ b/e2e/Dockerfile.dev
@@ -1,0 +1,34 @@
+# Dev mode Dockerfile - Uses pre-built base image for fast iteration
+#
+# Prerequisites:
+#   docker build -f e2e/Dockerfile.base -t vienna-e2e-base .
+#
+# Usage:
+#   docker compose --profile dev run --rm tauri-e2e-dev
+
+FROM vienna-e2e-base
+
+WORKDIR /app
+
+# Copy package files for JS dependencies
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY apps/notebook/package.json apps/notebook/
+COPY apps/sidecar/package.json apps/sidecar/
+COPY packages/ packages/
+
+# Install JS dependencies
+RUN corepack enable && pnpm install --frozen-lockfile
+
+# Copy source code (these layers change frequently)
+COPY . .
+
+# Build frontend assets
+RUN pnpm run isolated-renderer:build
+RUN pnpm --dir apps/notebook build
+
+# Build Tauri app (incremental, uses cached deps from base image)
+WORKDIR /app/crates/notebook
+RUN cargo tauri build --ci --config '{"build":{"beforeBuildCommand":""}}'
+WORKDIR /app
+
+EXPOSE 4444 4445

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,126 @@
+# E2E Testing
+
+End-to-end tests for the notebook application using WebdriverIO and Tauri's WebDriver.
+
+## Why Docker?
+
+Tauri's WebDriver on macOS is blocked by sandboxing restrictions. We run tests in a Linux Docker container with Xvfb for headless display rendering.
+
+## Quick Start
+
+### CI Mode (Full Build)
+
+For CI pipelines or first-time setup. Builds everything from scratch:
+
+```bash
+pnpm test:e2e:docker
+```
+
+This takes 4-5 minutes due to Rust compilation.
+
+### Dev Mode (Fast Iteration)
+
+For rapid iteration during development. Uses cached dependencies:
+
+```bash
+# First time only: Build base image with cached deps (takes ~5 min)
+pnpm e2e:base:build
+
+# Then iterate quickly (takes ~1-2 min)
+pnpm test:e2e:dev
+```
+
+The base image caches:
+- System dependencies (xvfb, webkit2gtk-driver)
+- tauri-cli installation
+- Rust dependency downloads
+
+### Interactive Debugging
+
+Drop into a shell with the test environment ready:
+
+```bash
+pnpm e2e:dev:shell
+```
+
+Inside the container:
+```bash
+# Run all tests
+pnpm test:e2e
+
+# Run a single spec file
+pnpm wdio run e2e/wdio.conf.js --spec e2e/specs/notebook-execution.spec.js
+```
+
+## Test Files
+
+| File | Description |
+|------|-------------|
+| `specs/iframe-isolation.spec.js` | Security tests for iframe sandbox isolation |
+| `specs/notebook-execution.spec.js` | Happy path: create, edit, run cell, see output |
+
+## Dockerfile Variants
+
+| File | Purpose |
+|------|---------|
+| `Dockerfile` | CI mode - full isolated build |
+| `Dockerfile.base` | Base image with cached dependencies |
+| `Dockerfile.dev` | Dev mode - builds on base image |
+
+## npm Scripts
+
+| Script | Description |
+|--------|-------------|
+| `test:e2e:docker` | Run tests in CI mode (full build) |
+| `test:e2e:dev` | Run tests in dev mode (fast, needs base image) |
+| `e2e:base:build` | Build the base image (run once) |
+| `e2e:dev:build` | Rebuild dev image after code changes |
+| `e2e:dev:shell` | Interactive shell for debugging |
+
+## Writing Tests
+
+Tests use WebdriverIO with Mocha. Key patterns:
+
+```javascript
+import { browser, expect } from "@wdio/globals";
+
+describe("My Feature", () => {
+  it("should do something", async () => {
+    // Find elements using CSS selectors
+    const cell = await $('[data-cell-type="code"]');
+
+    // Interact with elements
+    await cell.click();
+    await browser.keys("print('hello')");
+
+    // Wait for async operations
+    await browser.waitUntil(async () => {
+      const output = await $('[data-slot="ansi-stream-output"]');
+      return output.isExisting();
+    }, { timeout: 30000 });
+
+    // Assert
+    const text = await output.getText();
+    expect(text).toContain("hello");
+  });
+});
+```
+
+## Selectors
+
+Use these data attributes for reliable element selection:
+
+| Selector | Element |
+|----------|---------|
+| `[data-cell-type="code"]` | Code cell container |
+| `[data-cell-id="..."]` | Cell by ID |
+| `[data-testid="execute-button"]` | Run cell button |
+| `[data-slot="ansi-stream-output"]` | Stream output (stdout/stderr) |
+| `.cm-content[contenteditable="true"]` | CodeMirror editor |
+
+## Timeouts
+
+- **App load**: 5 seconds
+- **Kernel startup**: 30-60 seconds (first execution)
+- **Cell execution**: 15 seconds (after kernel is ready)
+- **Element appear**: 5 seconds

--- a/e2e/specs/notebook-execution.spec.js
+++ b/e2e/specs/notebook-execution.spec.js
@@ -1,0 +1,166 @@
+/**
+ * E2E Test: Notebook Execution Happy Path
+ *
+ * Tests the basic workflow: create notebook, write code, execute, see output.
+ * Also verifies that outputs are properly cleared on re-execution.
+ */
+
+import { browser, expect } from "@wdio/globals";
+
+describe("Notebook Execution Happy Path", () => {
+  // Allow time for kernel startup (first execution takes longer)
+  const KERNEL_STARTUP_TIMEOUT = 60000;
+  const EXECUTION_TIMEOUT = 15000;
+
+  let codeCell;
+
+  before(async () => {
+    // Wait for app to fully load
+    await browser.pause(5000);
+
+    // Debug: Log page state
+    const title = await browser.getTitle();
+    const url = await browser.getUrl();
+    console.log("Page title:", title);
+    console.log("Page URL:", url);
+  });
+
+  /**
+   * Helper to type text character by character with delay to avoid dropped keys
+   */
+  async function typeSlowly(text, delay = 50) {
+    for (const char of text) {
+      await browser.keys(char);
+      await browser.pause(delay);
+    }
+  }
+
+  /**
+   * Helper to wait for output containing specific text
+   */
+  async function waitForOutput(expectedText, timeout) {
+    await browser.waitUntil(
+      async () => {
+        const streamOutput = await codeCell.$('[data-slot="ansi-stream-output"]');
+        if (!(await streamOutput.isExisting())) {
+          return false;
+        }
+        const text = await streamOutput.getText();
+        console.log("Current output:", JSON.stringify(text));
+        return text.includes(expectedText);
+      },
+      {
+        timeout,
+        timeoutMsg: `Output "${expectedText}" did not appear within timeout.`,
+        interval: 500,
+      }
+    );
+  }
+
+  /**
+   * Helper to count output elements in the cell
+   */
+  async function countOutputs() {
+    const outputs = await codeCell.$$('[data-slot="ansi-stream-output"]');
+    return outputs.length;
+  }
+
+  it("should execute code and display output", async () => {
+    // Step 1: Ensure we have a code cell
+    codeCell = await $('[data-cell-type="code"]');
+    const cellExists = await codeCell.isExisting();
+
+    if (!cellExists) {
+      // Notebook is empty - click "Code Cell" button to add first cell
+      console.log("No code cell found, adding one...");
+      const addCodeButton = await $("button*=Code");
+      await addCodeButton.waitForClickable({ timeout: 5000 });
+      await addCodeButton.click();
+      await browser.pause(500);
+
+      // Re-fetch the cell
+      codeCell = await $('[data-cell-type="code"]');
+      await codeCell.waitForExist({ timeout: 5000 });
+    }
+
+    console.log("Code cell found");
+
+    // Step 2: Focus the CodeMirror editor and enter code
+    const editor = await codeCell.$('.cm-content[contenteditable="true"]');
+    await editor.waitForExist({ timeout: 5000 });
+    await editor.click();
+    await browser.pause(200);
+
+    // Clear any existing content
+    await browser.keys(["Control", "a"]);
+    await browser.pause(100);
+
+    // Type code slowly to avoid dropped characters
+    const testCode = 'print("hello world")';
+    console.log("Typing code:", testCode);
+    await typeSlowly(testCode);
+    await browser.pause(300);
+
+    // Step 3: Execute the cell with Shift+Enter
+    await browser.keys(["Shift", "Enter"]);
+    console.log("Triggered execution (first time - kernel will start)");
+
+    // Step 4: Wait for output (longer timeout for kernel startup)
+    await waitForOutput("hello world", KERNEL_STARTUP_TIMEOUT);
+    console.log("First execution output appeared!");
+
+    // Step 5: Verify output
+    let outputText = await codeCell.$('[data-slot="ansi-stream-output"]').getText();
+    expect(outputText).toContain("hello world");
+    console.log("First execution verified successfully");
+  });
+
+  it("should clear previous outputs when re-executing", async () => {
+    // This test catches the bug where outputs accumulate instead of being cleared
+
+    // First, check how many outputs we have after the first test
+    const initialOutputCount = await countOutputs();
+    console.log("Initial output count:", initialOutputCount);
+
+    // Re-focus the editor and change the code
+    const editor = await codeCell.$('.cm-content[contenteditable="true"]');
+    await editor.click();
+    await browser.pause(200);
+
+    // Select all and replace with new code
+    await browser.keys(["Control", "a"]);
+    await browser.pause(100);
+
+    const newCode = 'print("second run")';
+    console.log("Typing new code:", newCode);
+    await typeSlowly(newCode);
+    await browser.pause(300);
+
+    // Execute again
+    await browser.keys(["Shift", "Enter"]);
+    console.log("Triggered second execution");
+
+    // Wait for new output
+    await waitForOutput("second run", EXECUTION_TIMEOUT);
+    console.log("Second execution output appeared!");
+
+    // KEY TEST: Check that old outputs were cleared
+    const finalOutputCount = await countOutputs();
+    console.log("Final output count:", finalOutputCount);
+
+    // There should only be ONE stream output, not accumulated outputs
+    expect(finalOutputCount).toBe(1);
+
+    // Verify the output is the NEW text, not old + new
+    const outputText = await codeCell.$('[data-slot="ansi-stream-output"]').getText();
+    console.log("Final output text:", JSON.stringify(outputText));
+
+    // Should contain new output
+    expect(outputText).toContain("second run");
+
+    // Should NOT contain old output (this is the key assertion for the bug)
+    expect(outputText).not.toContain("hello world");
+
+    console.log("Test passed: Outputs are properly cleared on re-execution");
+  });
+});

--- a/package.json
+++ b/package.json
@@ -12,8 +12,12 @@
     "test:run": "vitest run",
     "test:e2e": "wdio run e2e/wdio.conf.js",
     "test:e2e:docker": "docker compose run --rm tauri-e2e",
+    "test:e2e:dev": "docker compose --profile dev run --rm tauri-e2e-dev",
     "e2e:docker:build": "docker compose build tauri-e2e",
-    "e2e:docker:shell": "docker compose run --rm tauri-e2e bash"
+    "e2e:docker:shell": "docker compose run --rm tauri-e2e bash",
+    "e2e:base:build": "docker build -f e2e/Dockerfile.base -t vienna-e2e-base .",
+    "e2e:dev:build": "docker compose --profile dev build tauri-e2e-dev",
+    "e2e:dev:shell": "docker compose --profile dev run --rm tauri-e2e-shell"
   },
   "dependencies": {
     "@codemirror/autocomplete": "^6.20.0",

--- a/src/components/cell/CompactExecutionButton.tsx
+++ b/src/components/cell/CompactExecutionButton.tsx
@@ -46,6 +46,7 @@ export function CompactExecutionButton({
         className,
       )}
       title={isExecuting ? "Stop execution" : "Run cell"}
+      data-testid="execute-button"
     >
       <span className="opacity-60">[</span>
       <span className="relative inline-flex min-w-4 items-center justify-center">


### PR DESCRIPTION
## Summary

Adds comprehensive E2E testing infrastructure for the notebook application. Includes a happy path test that creates a notebook, executes code, and verifies output. Also fixes a bug where cell outputs were not being cleared on re-execution.

- **New E2E test**: notebook creation → code execution → output verification
- **Bug fix**: Outputs are now properly cleared when cells are re-executed
- **Dev workflow**: Fast iteration mode using cached Docker base image (1-2 min vs 4-5 min)
- **Documentation**: E2E guide in contributing docs and README

## Changes

- `e2e/specs/notebook-execution.spec.js`: Happy path test with output clearing verification
- `apps/notebook/src/hooks/useNotebook.ts`: Added `clearCellOutputs()` function
- `apps/notebook/src/App.tsx`: Call `clearCellOutputs()` in `handleExecuteCell()` before queuing
- `e2e/Dockerfile.base`: Base image with cached dependencies for dev mode
- `e2e/Dockerfile.dev`: Dev build using cached base image
- `docker-compose.yml`: Added dev and interactive shell services
- `package.json`: New npm scripts for dev workflow
- `contributing/e2e.md`: Comprehensive E2E testing guide
- `e2e/README.md`: Quick start and patterns for E2E tests
- `src/components/cell/CompactExecutionButton.tsx`: Added `data-testid` for test reliability

## Test Results

All tests passing:
- ✓ Iframe isolation security tests (6 tests)
- ✓ Notebook execution happy path (2 tests)

## Usage

```bash
# Dev mode (fast iteration)
pnpm e2e:base:build    # Once: build base image
pnpm test:e2e:dev      # Run tests (~1-2 min)

# CI mode (reproducible)
pnpm test:e2e:docker   # Full build (~4-5 min)

# Interactive debugging
pnpm e2e:dev:shell
```

Co-Authored-By: QuillAid <261289082+quillaid@users.noreply.github.com>