### PR TITLE
Add happy path tests for UV support and conda fallback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3121,6 +3121,7 @@ dependencies = [
  "runtimelib",
  "serde",
  "serde_json",
+ "serial_test",
  "sha2",
  "strsim",
  "tauri",
@@ -5253,12 +5254,21 @@ dependencies = [
 
 [[package]]
 name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd 3.0.10",
+]
+
+[[package]]
+name = "scc"
 version = "3.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4bd9d1727de391b6982925d830baad51692fa2aa6e337733c03d95121ca2793"
 dependencies = [
  "saa",
- "sdd",
+ "sdd 4.6.2",
 ]
 
 [[package]]
@@ -5332,6 +5342,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "sdd"
@@ -5558,6 +5574,32 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d0b343e184fc3b7bb44dff0705fffcf4b3756ba6aff420dddd8b24ca145e555"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc 2.4.0",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f50427f258fb77356e4cd4aa0e87e2bd2c66dbcee41dc405282cae2bfc26c83"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -8190,7 +8232,7 @@ dependencies = [
  "parking_lot",
  "rand 0.9.2",
  "regex",
- "scc",
+ "scc 3.5.6",
  "thiserror 1.0.69",
  "tokio",
  "tokio-util",

--- a/crates/notebook/Cargo.toml
+++ b/crates/notebook/Cargo.toml
@@ -57,6 +57,7 @@ url = "2.5"
 
 [dev-dependencies]
 tempfile = "3"
+serial_test = "3"
 
 [build-dependencies]
 tauri-build = { version = "2", features = [] }

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -825,7 +825,7 @@ async fn start_default_conda_kernel(
 }
 
 /// Start a default kernel, automatically choosing uv or conda based on availability.
-/// Uses uv if available (faster), falls back to conda/rattler if not.
+/// Prefers uv when available, falls back to conda/rattler otherwise.
 #[tauri::command]
 async fn start_default_kernel(
     app: tauri::AppHandle,

--- a/crates/notebook/src/notebook_state.rs
+++ b/crates/notebook/src/notebook_state.rs
@@ -81,7 +81,7 @@ impl NotebookState {
         // Generate unique environment ID for this notebook
         let env_id = Uuid::new_v4().to_string();
 
-        // Set up default uv metadata (faster startup than conda/rattler)
+        // Set up default uv metadata for PyPI-based dependencies
         let mut additional = HashMap::new();
         additional.insert(
             "uv".to_string(),

--- a/crates/notebook/tests/env_fallback.rs
+++ b/crates/notebook/tests/env_fallback.rs
@@ -1,0 +1,303 @@
+//! Integration tests for UV support and Rattler conda fallback.
+//!
+//! These tests verify the happy paths for environment detection and creation:
+//! - UV is detected when available on PATH
+//! - Conda/rattler fallback happens when UV is unavailable
+//! - Environment creation works correctly for both backends
+//!
+//! Tests that modify PATH are marked with `#[serial]` to prevent race conditions.
+
+use notebook::{conda_env, uv_env};
+use serial_test::serial;
+use std::path::PathBuf;
+
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
+// =============================================================================
+// UV Availability Detection Tests
+// =============================================================================
+
+/// Test that check_uv_available returns false when PATH excludes uv.
+#[tokio::test]
+#[serial]
+async fn test_uv_available_returns_false_with_empty_path() {
+    let original_path = std::env::var("PATH").unwrap_or_default();
+
+    // Set PATH to a nonexistent directory
+    std::env::set_var("PATH", "/nonexistent");
+
+    let result = uv_env::check_uv_available().await;
+
+    // Restore PATH before assertion (in case assertion fails)
+    std::env::set_var("PATH", &original_path);
+
+    assert!(!result, "check_uv_available should return false when uv is not in PATH");
+}
+
+/// Test that check_uv_available returns true when a fake uv script is in PATH.
+#[tokio::test]
+#[serial]
+#[cfg(unix)]
+async fn test_uv_available_with_fake_uv_script() {
+    let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let fake_uv = temp_dir.path().join("uv");
+
+    // Create a fake uv script that outputs a version string
+    std::fs::write(&fake_uv, "#!/bin/sh\necho 'uv 0.1.0'").expect("Failed to write fake uv");
+    std::fs::set_permissions(&fake_uv, std::fs::Permissions::from_mode(0o755))
+        .expect("Failed to set permissions");
+
+    let original_path = std::env::var("PATH").unwrap_or_default();
+
+    // Set PATH to only include our temp directory
+    std::env::set_var("PATH", temp_dir.path().to_str().unwrap());
+
+    let result = uv_env::check_uv_available().await;
+
+    // Restore PATH
+    std::env::set_var("PATH", &original_path);
+
+    assert!(result, "check_uv_available should return true with fake uv in PATH");
+}
+
+/// Test that check_uv_available returns true when real uv is installed.
+/// This test is skipped if uv is not actually installed on the system.
+#[tokio::test]
+#[serial]
+async fn test_uv_available_with_real_uv() {
+    let result = uv_env::check_uv_available().await;
+
+    if result {
+        println!("Real uv is installed on this system");
+    } else {
+        println!("Real uv is NOT installed - this is expected in some CI environments");
+    }
+
+    // This test just verifies the function runs without panicking
+    // The result depends on the actual system configuration
+}
+
+// =============================================================================
+// UV Environment Creation Tests (Happy Path)
+// =============================================================================
+
+/// Test UV environment creation with no dependencies (just ipykernel).
+/// Skipped if uv is not installed on the system.
+#[tokio::test]
+#[serial]
+async fn test_uv_environment_creation_with_no_deps() {
+    if !uv_env::check_uv_available().await {
+        println!("Skipping test: uv not installed on this system");
+        return;
+    }
+
+    let deps = uv_env::NotebookDependencies {
+        dependencies: vec![],
+        requires_python: None,
+    };
+
+    let result = uv_env::prepare_environment(&deps).await;
+
+    assert!(result.is_ok(), "prepare_environment should succeed: {:?}", result.err());
+
+    let env = result.unwrap();
+    assert!(env.python_path.exists(), "Python path should exist: {:?}", env.python_path);
+    assert!(env.venv_path.exists(), "Venv path should exist: {:?}", env.venv_path);
+
+    // Verify the path is in the expected cache location
+    let venv_str = env.venv_path.to_string_lossy();
+    assert!(
+        venv_str.contains("runt") && venv_str.contains("envs"),
+        "Venv should be in runt/envs cache: {}",
+        venv_str
+    );
+}
+
+/// Test that UV environment uses cache correctly (same deps = same env).
+#[tokio::test]
+#[serial]
+async fn test_uv_environment_uses_cache_correctly() {
+    if !uv_env::check_uv_available().await {
+        println!("Skipping test: uv not installed on this system");
+        return;
+    }
+
+    let deps = uv_env::NotebookDependencies {
+        dependencies: vec![],
+        requires_python: Some(">=3.9".to_string()),
+    };
+
+    // Create environment twice
+    let env1 = uv_env::prepare_environment(&deps).await.expect("First prepare should succeed");
+    let env2 = uv_env::prepare_environment(&deps).await.expect("Second prepare should succeed");
+
+    // Same dependencies should result in same cached environment
+    assert_eq!(
+        env1.venv_path, env2.venv_path,
+        "Same deps should use same cached environment"
+    );
+}
+
+// =============================================================================
+// Conda Environment Creation Tests (Happy Path)
+// =============================================================================
+
+/// Test conda environment creation with ipykernel.
+/// This test may take a while on first run as it downloads packages.
+#[tokio::test]
+async fn test_conda_environment_creation_with_ipykernel() {
+    // Use a unique env_id to avoid conflicts with other tests
+    let env_id = format!("test-{}", uuid::Uuid::new_v4());
+
+    let deps = conda_env::CondaDependencies {
+        dependencies: vec![],
+        channels: vec!["conda-forge".to_string()],
+        python: Some("3.11".to_string()),
+        env_id: Some(env_id),
+    };
+
+    // Note: We pass None for AppHandle since we're not emitting frontend events
+    let result = conda_env::prepare_environment(&deps, None).await;
+
+    assert!(result.is_ok(), "prepare_environment should succeed: {:?}", result.err());
+
+    let env = result.unwrap();
+    assert!(env.python_path.exists(), "Python path should exist: {:?}", env.python_path);
+    assert!(env.env_path.exists(), "Env path should exist: {:?}", env.env_path);
+
+    // Verify the path is in the expected cache location
+    let env_str = env.env_path.to_string_lossy();
+    assert!(
+        env_str.contains("runt") && env_str.contains("conda-envs"),
+        "Env should be in runt/conda-envs cache: {}",
+        env_str
+    );
+}
+
+/// Test that conda environment uses cache correctly (same deps = same env).
+#[tokio::test]
+async fn test_conda_environment_uses_cache_correctly() {
+    // Use a fixed env_id to test caching
+    let env_id = "test-cache-check".to_string();
+
+    let deps = conda_env::CondaDependencies {
+        dependencies: vec![],
+        channels: vec!["conda-forge".to_string()],
+        python: Some("3.11".to_string()),
+        env_id: Some(env_id),
+    };
+
+    // Create environment twice
+    let env1 = conda_env::prepare_environment(&deps, None)
+        .await
+        .expect("First prepare should succeed");
+    let env2 = conda_env::prepare_environment(&deps, None)
+        .await
+        .expect("Second prepare should succeed");
+
+    // Same dependencies should result in same cached environment
+    assert_eq!(
+        env1.env_path, env2.env_path,
+        "Same deps should use same cached environment"
+    );
+}
+
+// =============================================================================
+// Fallback Decision Logic Tests
+// =============================================================================
+
+/// Test that the environment selection logic works correctly.
+/// When UV is available, it should be selected; otherwise, conda.
+#[tokio::test]
+#[serial]
+async fn test_environment_selection_logic() {
+    let uv_available = uv_env::check_uv_available().await;
+
+    // This mirrors the logic in start_default_kernel()
+    let selected = if uv_available { "uv" } else { "conda" };
+
+    println!(
+        "Environment selection: {} (uv_available={})",
+        selected, uv_available
+    );
+
+    // Selection should be one of the two valid options
+    assert!(
+        selected == "uv" || selected == "conda",
+        "Selected environment should be 'uv' or 'conda', got: {}",
+        selected
+    );
+}
+
+/// Test that UV is NOT selected when PATH excludes uv.
+#[tokio::test]
+#[serial]
+async fn test_selects_conda_when_uv_unavailable() {
+    let original_path = std::env::var("PATH").unwrap_or_default();
+
+    // Remove uv from PATH
+    std::env::set_var("PATH", "/nonexistent");
+
+    let uv_available = uv_env::check_uv_available().await;
+
+    // Restore PATH
+    std::env::set_var("PATH", &original_path);
+
+    assert!(!uv_available, "UV should not be available with empty PATH");
+
+    // In this scenario, the app would select conda
+    let selected = if uv_available { "uv" } else { "conda" };
+    assert_eq!(selected, "conda", "Should select conda when uv unavailable");
+}
+
+/// Test that UV IS selected when a fake uv is in PATH.
+#[tokio::test]
+#[serial]
+#[cfg(unix)]
+async fn test_selects_uv_when_available() {
+    let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+    let fake_uv = temp_dir.path().join("uv");
+
+    // Create a fake uv script
+    std::fs::write(&fake_uv, "#!/bin/sh\necho 'uv 0.1.0'").expect("Failed to write fake uv");
+    std::fs::set_permissions(&fake_uv, std::fs::Permissions::from_mode(0o755))
+        .expect("Failed to set permissions");
+
+    let original_path = std::env::var("PATH").unwrap_or_default();
+    std::env::set_var("PATH", temp_dir.path().to_str().unwrap());
+
+    let uv_available = uv_env::check_uv_available().await;
+
+    // Restore PATH
+    std::env::set_var("PATH", &original_path);
+
+    assert!(uv_available, "UV should be available with fake uv in PATH");
+
+    // In this scenario, the app would select uv
+    let selected = if uv_available { "uv" } else { "conda" };
+    assert_eq!(selected, "uv", "Should select uv when available");
+}
+
+// =============================================================================
+// Hash Stability Tests (cross-module verification)
+// =============================================================================
+
+/// Verify that UV and conda use different cache directories.
+#[test]
+fn test_uv_and_conda_use_different_cache_dirs() {
+    let uv_cache = dirs::cache_dir()
+        .unwrap_or_else(|| PathBuf::from("/tmp"))
+        .join("runt")
+        .join("envs");
+
+    let conda_cache = dirs::cache_dir()
+        .unwrap_or_else(|| PathBuf::from("/tmp"))
+        .join("runt")
+        .join("conda-envs");
+
+    assert_ne!(
+        uv_cache, conda_cache,
+        "UV and conda should use different cache directories"
+    );
+}

--- a/e2e/specs/env-detection.spec.js
+++ b/e2e/specs/env-detection.spec.js
@@ -1,0 +1,188 @@
+/**
+ * E2E Test: Environment Detection Happy Path
+ *
+ * Verifies that the application correctly detects and uses
+ * the appropriate environment backend (uv or conda/rattler).
+ * Tests that:
+ * 1. Kernel starts successfully with a managed environment
+ * 2. Python executable is from the correct cache directory
+ * 3. ipykernel is available in the environment
+ */
+
+import { browser, expect } from "@wdio/globals";
+
+describe("Environment Detection", () => {
+  // Allow extra time for environment creation on first run
+  const KERNEL_STARTUP_TIMEOUT = 120000;
+  const EXECUTION_TIMEOUT = 15000;
+
+  let codeCell;
+
+  before(async () => {
+    // Wait for app to fully load
+    await browser.pause(5000);
+
+    const title = await browser.getTitle();
+    const url = await browser.getUrl();
+    console.log("Page title:", title);
+    console.log("Page URL:", url);
+  });
+
+  /**
+   * Helper to type text character by character with delay to avoid dropped keys
+   */
+  async function typeSlowly(text, delay = 50) {
+    for (const char of text) {
+      await browser.keys(char);
+      await browser.pause(delay);
+    }
+  }
+
+  /**
+   * Helper to wait for output containing specific text
+   */
+  async function waitForOutput(expectedText, timeout) {
+    await browser.waitUntil(
+      async () => {
+        const streamOutput = await codeCell.$('[data-slot="ansi-stream-output"]');
+        if (!(await streamOutput.isExisting())) {
+          return false;
+        }
+        const text = await streamOutput.getText();
+        console.log("Current output:", JSON.stringify(text));
+        return text.includes(expectedText);
+      },
+      {
+        timeout,
+        timeoutMsg: `Output "${expectedText}" did not appear within timeout.`,
+        interval: 500,
+      }
+    );
+  }
+
+  it("should detect environment type and start kernel successfully", async () => {
+    // Step 1: Ensure we have a code cell
+    codeCell = await $('[data-cell-type="code"]');
+    const cellExists = await codeCell.isExisting();
+
+    if (!cellExists) {
+      console.log("No code cell found, adding one...");
+      const addCodeButton = await $("button*=Code");
+      await addCodeButton.waitForClickable({ timeout: 5000 });
+      await addCodeButton.click();
+      await browser.pause(500);
+
+      codeCell = await $('[data-cell-type="code"]');
+      await codeCell.waitForExist({ timeout: 5000 });
+    }
+
+    console.log("Code cell found");
+
+    // Step 2: Focus the CodeMirror editor
+    const editor = await codeCell.$('.cm-content[contenteditable="true"]');
+    await editor.waitForExist({ timeout: 5000 });
+    await editor.click();
+    await browser.pause(200);
+
+    // Clear any existing content
+    await browser.keys(["Control", "a"]);
+    await browser.pause(100);
+
+    // Step 3: Type code to print the Python executable path
+    const testCode = "import sys; print(sys.executable)";
+    console.log("Typing code:", testCode);
+    await typeSlowly(testCode);
+    await browser.pause(300);
+
+    // Step 4: Execute the cell
+    await browser.keys(["Shift", "Enter"]);
+    console.log("Triggered execution (kernel will start)");
+
+    // Step 5: Wait for output (longer timeout for kernel startup)
+    await browser.waitUntil(
+      async () => {
+        const output = await codeCell.$('[data-slot="ansi-stream-output"]');
+        return await output.isExisting();
+      },
+      {
+        timeout: KERNEL_STARTUP_TIMEOUT,
+        timeoutMsg: "Kernel did not start - no output appeared",
+        interval: 1000,
+      }
+    );
+
+    // Step 6: Verify the Python path is from a managed environment
+    const outputText = await codeCell
+      .$('[data-slot="ansi-stream-output"]')
+      .getText();
+    console.log("Python executable:", outputText);
+
+    // Should be from either runt/envs (uv) or runt/conda-envs (conda)
+    const isUvEnv = outputText.includes("runt/envs");
+    const isCondaEnv = outputText.includes("runt/conda-envs");
+
+    expect(isUvEnv || isCondaEnv).toBe(true);
+
+    const envType = isUvEnv ? "uv" : "conda";
+    console.log(`Environment type detected: ${envType}`);
+    console.log("Test passed: Kernel started with managed environment");
+  });
+
+  it("should have ipykernel available in the environment", async () => {
+    // This test depends on the previous test having started the kernel
+
+    // Focus editor and type code to check ipykernel
+    const editor = await codeCell.$('.cm-content[contenteditable="true"]');
+    await editor.click();
+    await browser.pause(200);
+
+    // Clear and type new code
+    await browser.keys(["Control", "a"]);
+    await browser.pause(100);
+
+    const testCode = 'import ipykernel; print(f"ipykernel {ipykernel.__version__}")';
+    console.log("Typing code:", testCode);
+    await typeSlowly(testCode);
+    await browser.pause(300);
+
+    // Execute
+    await browser.keys(["Shift", "Enter"]);
+    console.log("Triggered execution");
+
+    // Wait for ipykernel output
+    await waitForOutput("ipykernel", EXECUTION_TIMEOUT);
+
+    const outputText = await codeCell
+      .$('[data-slot="ansi-stream-output"]')
+      .getText();
+    expect(outputText).toContain("ipykernel");
+    console.log("ipykernel check passed:", outputText);
+  });
+
+  it("should be able to execute Python code in the environment", async () => {
+    // Verify the environment is fully functional by running some code
+
+    const editor = await codeCell.$('.cm-content[contenteditable="true"]');
+    await editor.click();
+    await browser.pause(200);
+
+    await browser.keys(["Control", "a"]);
+    await browser.pause(100);
+
+    // Simple computation to verify the kernel is working
+    const testCode = "print(2 + 2)";
+    console.log("Typing code:", testCode);
+    await typeSlowly(testCode);
+    await browser.pause(300);
+
+    await browser.keys(["Shift", "Enter"]);
+
+    await waitForOutput("4", EXECUTION_TIMEOUT);
+
+    const outputText = await codeCell
+      .$('[data-slot="ansi-stream-output"]')
+      .getText();
+    expect(outputText).toContain("4");
+    console.log("Computation test passed");
+  });
+});


### PR DESCRIPTION
## Summary

Add comprehensive test coverage for the UV/conda environment selection logic:

- **Rust integration tests** (11 tests): UV availability detection, environment creation, caching, and fallback logic
- **E2E tests** (3 tests): Kernel startup with environment type detection, ipykernel verification, and code execution

These tests verify that UV is properly detected and used when available, and that the system gracefully falls back to conda/rattler when needed.

## Test Plan

Run Rust tests with:
```bash
cd crates/notebook
cargo test --test env_fallback
```

Run E2E tests with:
```bash
pnpm test:e2e:dev --spec e2e/specs/env-detection.spec.js
```