### PR TITLE
Share Rust cache between Linux CI jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,8 @@ jobs:
         uses: dsherret/rust-toolchain-file@v1
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ${{ matrix.platform.runner }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -85,6 +87,8 @@ jobs:
         uses: dsherret/rust-toolchain-file@v1
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ubuntu-latest
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary

- Configure `shared-key` for rust-cache to allow Linux build and e2e jobs to share Rust compilation artifacts
- Linux jobs now use `ubuntu-latest` as the shared cache key
- macOS jobs use `macos-latest` as the shared cache key

## Problem

After #52 renamed CI jobs from `build (ubuntu-latest, ...)` to `Linux`, the rust-cache keys changed (since job name is part of the key by default). This caused:

1. **No main branch cache** for the new job names - every PR had to build from scratch
2. **E2E job and Linux build job** didn't share caches despite both building Rust on Linux
3. **~6 minute tauri-cli compilation** on every e2e run

## Expected Impact

| Metric | Before | After (estimated) |
|--------|--------|-------------------|
| Linux Clippy | 1m 41s | ~20s |
| Linux Build | 5m 7s | ~2-3m |
| E2E tauri-cli install | ~6m | <1m (cached) |

## Test plan

- [ ] Verify cache hit on Linux build job
- [ ] Verify cache hit on e2e job  
- [ ] Confirm build times decrease after cache is populated