### PR TITLE
Add E2E screenshot capabilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ __pycache__/
 
 # Agent workspace context (per-worktree state)
 .context/
+
+# E2E test screenshots
+e2e-screenshots/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,8 @@ services:
     volumes:
       # Mount e2e tests for live updates during development
       - ./e2e:/app/e2e:ro
+      # Writable volume for screenshots
+      - ./e2e-screenshots:/app/e2e-screenshots
     environment:
       - DISPLAY=:99
       - TAURI_APP_PATH=/app/target/release/notebook
@@ -52,6 +54,8 @@ services:
     volumes:
       # Mount e2e tests for live updates
       - ./e2e:/app/e2e:ro
+      # Writable volume for screenshots
+      - ./e2e-screenshots:/app/e2e-screenshots
     environment:
       - DISPLAY=:99
       - TAURI_APP_PATH=/app/target/release/notebook
@@ -86,6 +90,8 @@ services:
       dockerfile: e2e/Dockerfile.dev
     volumes:
       - ./e2e:/app/e2e:ro
+      # Writable volume for screenshots
+      - ./e2e-screenshots:/app/e2e-screenshots
     environment:
       - DISPLAY=:99
       - TAURI_APP_PATH=/app/target/release/notebook

--- a/e2e/specs/notebook-execution.spec.js
+++ b/e2e/specs/notebook-execution.spec.js
@@ -7,6 +7,21 @@
 
 import { browser, expect } from "@wdio/globals";
 
+/**
+ * Screenshot helper for capturing milestone moments
+ */
+async function takeScreenshot(name) {
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const safeName = name.replace(/[^a-zA-Z0-9]/g, "-");
+  const screenshotPath = `/app/e2e-screenshots/${safeName}-${timestamp}.png`;
+  try {
+    await browser.saveScreenshot(screenshotPath);
+    console.log(`Screenshot saved: ${screenshotPath}`);
+  } catch (error) {
+    console.error(`Failed to save screenshot "${name}":`, error.message);
+  }
+}
+
 describe("Notebook Execution Happy Path", () => {
   // Allow time for kernel startup (first execution takes longer)
   const KERNEL_STARTUP_TIMEOUT = 60000;
@@ -23,6 +38,9 @@ describe("Notebook Execution Happy Path", () => {
     const url = await browser.getUrl();
     console.log("Page title:", title);
     console.log("Page URL:", url);
+
+    // Screenshot: Initial app state
+    await takeScreenshot("01-app-loaded");
   });
 
   /**
@@ -101,6 +119,9 @@ describe("Notebook Execution Happy Path", () => {
     await typeSlowly(testCode);
     await browser.pause(300);
 
+    // Screenshot: Code typed in editor
+    await takeScreenshot("02-code-typed");
+
     // Step 3: Execute the cell with Shift+Enter
     await browser.keys(["Shift", "Enter"]);
     console.log("Triggered execution (first time - kernel will start)");
@@ -113,6 +134,9 @@ describe("Notebook Execution Happy Path", () => {
     let outputText = await codeCell.$('[data-slot="ansi-stream-output"]').getText();
     expect(outputText).toContain("hello world");
     console.log("First execution verified successfully");
+
+    // Screenshot: First execution with output
+    await takeScreenshot("03-first-execution-output");
   });
 
   it("should clear previous outputs when re-executing", async () => {
@@ -160,6 +184,9 @@ describe("Notebook Execution Happy Path", () => {
 
     // Should NOT contain old output (this is the key assertion for the bug)
     expect(outputText).not.toContain("hello world");
+
+    // Screenshot: Second execution with cleared output
+    await takeScreenshot("04-second-execution-cleared");
 
     console.log("Test passed: Outputs are properly cleared on re-execution");
   });

--- a/e2e/wdio.conf.js
+++ b/e2e/wdio.conf.js
@@ -48,4 +48,23 @@ export const config = {
     ui: "bdd",
     timeout: 60000,
   },
+
+  /**
+   * Hook that gets executed after a test
+   * Captures screenshot on failure for debugging
+   */
+  afterTest: async function (test, context, { error }) {
+    if (error) {
+      const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+      const safeName = test.title.replace(/[^a-zA-Z0-9]/g, "-").slice(0, 50);
+      const screenshotPath = `/app/e2e-screenshots/failures/${safeName}-${timestamp}.png`;
+      try {
+        const { browser } = await import("@wdio/globals");
+        await browser.saveScreenshot(screenshotPath);
+        console.log(`Failure screenshot saved: ${screenshotPath}`);
+      } catch (screenshotError) {
+        console.error("Failed to capture screenshot:", screenshotError.message);
+      }
+    }
+  },
 };


### PR DESCRIPTION
## Summary

- Add WebdriverIO screenshot support to e2e tests for capturing test execution milestones
- Screenshots are automatically saved during successful test runs and on failures
- Configure Docker volumes to persist screenshots outside container

## Screenshots

Screenshots will appear in the following locations:
- Success: `e2e-screenshots/{milestone}-{timestamp}.png`
  - `01-app-loaded`
  - `02-code-typed`
  - `03-first-execution-output`
  - `04-second-execution-cleared`
- Failures: `e2e-screenshots/failures/{test-name}-{timestamp}.png`

<img width="1100" height="725" alt="01-app-loaded-2026-02-15T00-58-23-628Z" src="https://github.com/user-attachments/assets/57652906-fa6c-4c8d-950a-9f1b6c90558d" />
<img width="1100" height="725" alt="02-code-typed-2026-02-15T00-58-26-393Z" src="https://github.com/user-attachments/assets/3d8efae0-5f5f-4f85-85fb-6d1b0ac9c1ac" />
<img width="1100" height="725" alt="03-first-execution-output-2026-02-15T00-58-52-557Z" src="https://github.com/user-attachments/assets/f49d9a76-98ec-46ac-8d55-3c65d4579fa9" />
<img width="1100" height="725" alt="04-second-execution-cleared-2026-02-15T00-58-55-319Z" src="https://github.com/user-attachments/assets/a78ae855-a5b6-40e3-80f6-45229ea18ed6" />


## Test plan

Run `pnpm test:e2e:docker` and verify:
- Screenshots are created in `./e2e-screenshots/`
- Milestone screenshots capture key test moments
- No test failures introduced