### PR TITLE
Add TypeScript unit tests for widgets and outputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,8 @@
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.1.8",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
     "@types/node": "^20.10.0",
     "@types/react": "^19.1.6",
     "@types/react-dom": "^19.1.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,12 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.1.8
         version: 4.1.18(vite@6.4.1(@types/node@20.19.33)(jiti@2.6.1)(lightningcss@1.30.2))
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@types/node':
         specifier: ^20.10.0
         version: 20.19.33
@@ -412,6 +418,9 @@ importers:
         version: 6.4.1(@types/node@22.19.9)(jiti@2.6.1)(lightningcss@1.30.2)
 
 packages:
+
+  '@adobe/css-tools@4.4.4':
+    resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
@@ -1988,6 +1997,29 @@ packages:
   '@tauri-apps/plugin-dialog@2.6.0':
     resolution: {integrity: sha512-q4Uq3eY87TdcYzXACiYSPhmpBA76shgmQswGkSVio4C82Sz2W4iehe9TnKYwbq7weHiL88Yw19XZm7v28+Micg==}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@tootallnate/quickjs-emscripten@0.23.0':
     resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
 
@@ -2002,6 +2034,9 @@ packages:
 
   '@tsconfig/node16@1.0.4':
     resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -2419,6 +2454,9 @@ packages:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
 
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
     engines: {node: '>= 0.4'}
@@ -2764,6 +2802,9 @@ packages:
   css-value@0.0.1:
     resolution: {integrity: sha512-FUV3xaJ63buRLgHrLQVlVgQnQdR4yqdLGaDu7g8CQcWjInDfM9plBTPI9FRfpahju1UBSaMckeb2/46ApS/V1Q==}
 
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
   cssstyle@4.6.0:
     resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
     engines: {node: '>=18'}
@@ -2898,6 +2939,12 @@ packages:
   diff@7.0.0:
     resolution: {integrity: sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==}
     engines: {node: '>=0.3.1'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
@@ -3466,6 +3513,10 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
+
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
     deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
@@ -3868,6 +3919,10 @@ packages:
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -4047,6 +4102,10 @@ packages:
   mimic-response@4.0.0:
     resolution: {integrity: sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
 
   minimatch@3.0.8:
     resolution: {integrity: sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==}
@@ -4297,6 +4356,10 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   pretty-format@29.7.0:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -4389,6 +4452,9 @@ packages:
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
@@ -4485,6 +4551,10 @@ packages:
   recursive-readdir@2.2.3:
     resolution: {integrity: sha512-8HrF5ZsXk5FAH9dgsx3BlUer73nIhuj+9OrQwEbLTPOBzGkL1lsFCR01am+v+0m2Cmbs1nP12hLDl5FA7EszKA==}
     engines: {node: '>=6.0.0'}
+
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
 
   refractor@3.6.0:
     resolution: {integrity: sha512-MY9W41IOWxxk31o+YvFCNyNzdkc9M20NoZK5vq6jkv4I/uh2zkWcfudj0Q1fovjUQJrNewS9NMzeTtqPf+n5EA==}
@@ -4728,6 +4798,10 @@ packages:
   strip-final-newline@3.0.0:
     resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
     engines: {node: '>=12'}
+
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
 
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
@@ -5295,6 +5369,8 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
+
+  '@adobe/css-tools@4.4.4': {}
 
   '@asamuzakjp/css-color@3.2.0':
     dependencies:
@@ -7241,6 +7317,36 @@ snapshots:
     dependencies:
       '@tauri-apps/api': 2.10.1
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.28.6
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.4.4
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.13))(@types/react@19.2.13)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@babel/runtime': 7.28.6
+      '@testing-library/dom': 10.4.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.13
+      '@types/react-dom': 19.2.3(@types/react@19.2.13)
+
   '@tootallnate/quickjs-emscripten@0.23.0': {}
 
   '@tsconfig/node10@1.0.12': {}
@@ -7250,6 +7356,8 @@ snapshots:
   '@tsconfig/node14@1.0.3': {}
 
   '@tsconfig/node16@1.0.4': {}
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/babel__core@7.20.5':
     dependencies:
@@ -7883,6 +7991,10 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
   aria-query@5.3.2: {}
 
   assertion-error@2.0.1: {}
@@ -8223,6 +8335,8 @@ snapshots:
 
   css-value@0.0.1: {}
 
+  css.escape@1.5.1: {}
+
   cssstyle@4.6.0:
     dependencies:
       '@asamuzakjp/css-color': 3.2.0
@@ -8318,6 +8432,10 @@ snapshots:
   diff@5.2.2: {}
 
   diff@7.0.0: {}
+
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
 
   dom-serializer@2.0.0:
     dependencies:
@@ -9046,6 +9164,8 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
+  indent-string@4.0.0: {}
+
   inflight@1.0.6:
     dependencies:
       once: 1.4.0
@@ -9417,6 +9537,8 @@ snapshots:
   lucide-react@0.513.0(react@19.2.4):
     dependencies:
       react: 19.2.4
+
+  lz-string@1.5.0: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -9813,6 +9935,8 @@ snapshots:
 
   mimic-response@4.0.0: {}
 
+  min-indent@1.0.1: {}
+
   minimatch@3.0.8:
     dependencies:
       brace-expansion: 1.1.12
@@ -10065,6 +10189,12 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   pretty-format@29.7.0:
     dependencies:
       '@jest/schemas': 29.6.3
@@ -10221,6 +10351,8 @@ snapshots:
 
   react-is@16.13.1: {}
 
+  react-is@17.0.2: {}
+
   react-is@18.3.1: {}
 
   react-markdown@10.1.0(@types/react@19.2.13)(react@19.2.4):
@@ -10346,6 +10478,11 @@ snapshots:
   recursive-readdir@2.2.3:
     dependencies:
       minimatch: 3.1.2
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
 
   refractor@3.6.0:
     dependencies:
@@ -10655,6 +10792,10 @@ snapshots:
       ansi-regex: 6.2.2
 
   strip-final-newline@3.0.0: {}
+
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
 
   strip-json-comments@3.1.1: {}
 

--- a/src/components/outputs/__tests__/ansi-output.test.tsx
+++ b/src/components/outputs/__tests__/ansi-output.test.tsx
@@ -1,0 +1,351 @@
+/**
+ * Tests for ansi-output.tsx - ANSI escape sequence rendering.
+ *
+ * These tests verify that ANSI escape sequences are properly parsed
+ * and rendered with appropriate styles and CSS classes.
+ */
+
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import {
+  AnsiOutput,
+  AnsiStreamOutput,
+  AnsiErrorOutput,
+} from "../ansi-output";
+
+// Helper to get styles from rendered spans
+function getSpanStyles(container: HTMLElement) {
+  const spans = container.querySelectorAll("span");
+  return Array.from(spans).map((span) => ({
+    text: span.textContent,
+    className: span.className,
+    style: span.getAttribute("style"),
+  }));
+}
+
+describe("AnsiOutput", () => {
+  describe("plain text", () => {
+    it("renders plain text without ANSI codes", () => {
+      render(<AnsiOutput>Hello, World!</AnsiOutput>);
+      expect(screen.getByText("Hello, World!")).toBeInTheDocument();
+    });
+
+    it("renders empty string as null", () => {
+      const { container } = render(<AnsiOutput>{""}</AnsiOutput>);
+      expect(container.querySelector("[data-slot='ansi-output']")).toBeNull();
+    });
+
+    it("handles whitespace and newlines", () => {
+      render(<AnsiOutput>{"line1\nline2\nline3"}</AnsiOutput>);
+      expect(screen.getByText(/line1/)).toBeInTheDocument();
+    });
+  });
+
+  describe("standard 16 colors", () => {
+    it("renders red foreground with CSS class", () => {
+      const { container } = render(
+        <AnsiOutput>{"\x1b[31mRed text\x1b[0m"}</AnsiOutput>
+      );
+      const spans = getSpanStyles(container);
+      const redSpan = spans.find((s) => s.text === "Red text");
+      expect(redSpan?.className).toContain("ansi-red-fg");
+    });
+
+    it("renders green foreground with CSS class", () => {
+      const { container } = render(
+        <AnsiOutput>{"\x1b[32mGreen text\x1b[0m"}</AnsiOutput>
+      );
+      const spans = getSpanStyles(container);
+      const greenSpan = spans.find((s) => s.text === "Green text");
+      expect(greenSpan?.className).toContain("ansi-green-fg");
+    });
+
+    it("renders yellow foreground with CSS class", () => {
+      const { container } = render(
+        <AnsiOutput>{"\x1b[33mYellow text\x1b[0m"}</AnsiOutput>
+      );
+      const spans = getSpanStyles(container);
+      const yellowSpan = spans.find((s) => s.text === "Yellow text");
+      expect(yellowSpan?.className).toContain("ansi-yellow-fg");
+    });
+
+    it("renders blue foreground with CSS class", () => {
+      const { container } = render(
+        <AnsiOutput>{"\x1b[34mBlue text\x1b[0m"}</AnsiOutput>
+      );
+      const spans = getSpanStyles(container);
+      const blueSpan = spans.find((s) => s.text === "Blue text");
+      expect(blueSpan?.className).toContain("ansi-blue-fg");
+    });
+
+    it("renders bright colors with CSS class", () => {
+      const { container } = render(
+        <AnsiOutput>{"\x1b[91mBright red\x1b[0m"}</AnsiOutput>
+      );
+      const spans = getSpanStyles(container);
+      const brightRedSpan = spans.find((s) => s.text === "Bright red");
+      expect(brightRedSpan?.className).toContain("ansi-bright-red-fg");
+    });
+
+    it("renders background colors with CSS class", () => {
+      const { container } = render(
+        <AnsiOutput>{"\x1b[41mRed background\x1b[0m"}</AnsiOutput>
+      );
+      const spans = getSpanStyles(container);
+      const bgSpan = spans.find((s) => s.text === "Red background");
+      expect(bgSpan?.className).toContain("ansi-red-bg");
+    });
+  });
+
+  describe("256-color palette", () => {
+    it("renders palette color 196 (red) as inline RGB", () => {
+      // Color 196 is in the 6x6x6 cube: r=5, g=0, b=0 -> rgb(255, 0, 0)
+      const { container } = render(
+        <AnsiOutput>{"\x1b[38;5;196mPalette 196\x1b[0m"}</AnsiOutput>
+      );
+      const spans = getSpanStyles(container);
+      const paletteSpan = spans.find((s) => s.text === "Palette 196");
+      expect(paletteSpan?.style).toContain("color:");
+      expect(paletteSpan?.style).toContain("rgb(");
+    });
+
+    it("renders grayscale palette color as inline RGB", () => {
+      // Color 240 is grayscale: (240-232)*10+8 = 88
+      const { container } = render(
+        <AnsiOutput>{"\x1b[38;5;240mGrayscale\x1b[0m"}</AnsiOutput>
+      );
+      const spans = getSpanStyles(container);
+      const graySpan = spans.find((s) => s.text === "Grayscale");
+      expect(graySpan?.style).toContain("color:");
+      expect(graySpan?.style).toContain("rgb(88, 88, 88)");
+    });
+
+    it("renders palette background color", () => {
+      const { container } = render(
+        <AnsiOutput>{"\x1b[48;5;21mBlue BG\x1b[0m"}</AnsiOutput>
+      );
+      const spans = getSpanStyles(container);
+      const bgSpan = spans.find((s) => s.text === "Blue BG");
+      expect(bgSpan?.style).toContain("background-color:");
+    });
+  });
+
+  describe("24-bit truecolor", () => {
+    it("renders truecolor foreground as inline RGB", () => {
+      const { container } = render(
+        <AnsiOutput>{"\x1b[38;2;255;128;0mOrange\x1b[0m"}</AnsiOutput>
+      );
+      const spans = getSpanStyles(container);
+      const truecolorSpan = spans.find((s) => s.text === "Orange");
+      expect(truecolorSpan?.style).toContain("color:");
+      expect(truecolorSpan?.style).toContain("rgb(255, 128, 0)");
+    });
+
+    it("renders truecolor background as inline RGB", () => {
+      const { container } = render(
+        <AnsiOutput>{"\x1b[48;2;50;100;150mTruecolor BG\x1b[0m"}</AnsiOutput>
+      );
+      const spans = getSpanStyles(container);
+      const bgSpan = spans.find((s) => s.text === "Truecolor BG");
+      expect(bgSpan?.style).toContain("background-color:");
+      expect(bgSpan?.style).toContain("rgb(50, 100, 150)");
+    });
+  });
+
+  describe("decorations", () => {
+    it("renders bold text", () => {
+      const { container } = render(
+        <AnsiOutput>{"\x1b[1mBold\x1b[0m"}</AnsiOutput>
+      );
+      const spans = getSpanStyles(container);
+      const boldSpan = spans.find((s) => s.text === "Bold");
+      expect(boldSpan?.style).toContain("font-weight: bold");
+    });
+
+    it("renders italic text", () => {
+      const { container } = render(
+        <AnsiOutput>{"\x1b[3mItalic\x1b[0m"}</AnsiOutput>
+      );
+      const spans = getSpanStyles(container);
+      const italicSpan = spans.find((s) => s.text === "Italic");
+      expect(italicSpan?.style).toContain("font-style: italic");
+    });
+
+    it("renders underline text", () => {
+      const { container } = render(
+        <AnsiOutput>{"\x1b[4mUnderline\x1b[0m"}</AnsiOutput>
+      );
+      const spans = getSpanStyles(container);
+      const underlineSpan = spans.find((s) => s.text === "Underline");
+      expect(underlineSpan?.style).toContain("text-decoration: underline");
+    });
+
+    it("renders strikethrough text", () => {
+      const { container } = render(
+        <AnsiOutput>{"\x1b[9mStrikethrough\x1b[0m"}</AnsiOutput>
+      );
+      const spans = getSpanStyles(container);
+      const strikeSpan = spans.find((s) => s.text === "Strikethrough");
+      expect(strikeSpan?.style).toContain("line-through");
+    });
+
+    it("renders dim text with reduced opacity", () => {
+      const { container } = render(
+        <AnsiOutput>{"\x1b[2mDim\x1b[0m"}</AnsiOutput>
+      );
+      const spans = getSpanStyles(container);
+      const dimSpan = spans.find((s) => s.text === "Dim");
+      expect(dimSpan?.style).toContain("opacity: 0.5");
+    });
+
+    it("combines multiple decorations", () => {
+      const { container } = render(
+        <AnsiOutput>{"\x1b[1;3;4mBold italic underline\x1b[0m"}</AnsiOutput>
+      );
+      const spans = getSpanStyles(container);
+      const combinedSpan = spans.find((s) => s.text === "Bold italic underline");
+      expect(combinedSpan?.style).toContain("font-weight: bold");
+      expect(combinedSpan?.style).toContain("font-style: italic");
+      expect(combinedSpan?.style).toContain("text-decoration: underline");
+    });
+  });
+
+  describe("terminal emulation", () => {
+    it("handles backspace characters", () => {
+      // "abc\b" should become "ab" (backspace removes 'c')
+      const { container } = render(
+        <AnsiOutput>{"abc\x08d"}</AnsiOutput>
+      );
+      // The result should be "abd" (c is replaced by backspace+d)
+      const text = container.textContent;
+      expect(text).toContain("abd");
+    });
+
+    it("handles carriage return", () => {
+      // Carriage return should work with escape-carriage package
+      const { container } = render(
+        <AnsiOutput>{"hello\rworld"}</AnsiOutput>
+      );
+      const text = container.textContent;
+      // escape-carriage handles \r by replacing content
+      expect(text).toBeDefined();
+    });
+  });
+
+  describe("combined styling", () => {
+    it("renders color with decoration", () => {
+      const { container } = render(
+        <AnsiOutput>{"\x1b[1;31mBold Red\x1b[0m"}</AnsiOutput>
+      );
+      const spans = getSpanStyles(container);
+      const styledSpan = spans.find((s) => s.text === "Bold Red");
+      expect(styledSpan?.className).toContain("ansi-red-fg");
+      expect(styledSpan?.style).toContain("font-weight: bold");
+    });
+
+    it("renders multiple styled segments", () => {
+      const { container } = render(
+        <AnsiOutput>
+          {"\x1b[31mRed\x1b[0m \x1b[32mGreen\x1b[0m \x1b[34mBlue\x1b[0m"}
+        </AnsiOutput>
+      );
+      const spans = getSpanStyles(container);
+      expect(spans.find((s) => s.text === "Red")?.className).toContain("ansi-red-fg");
+      expect(spans.find((s) => s.text === "Green")?.className).toContain("ansi-green-fg");
+      expect(spans.find((s) => s.text === "Blue")?.className).toContain("ansi-blue-fg");
+    });
+  });
+
+  describe("isError prop", () => {
+    it("applies error styling when isError is true", () => {
+      const { container } = render(
+        <AnsiOutput isError>Error message</AnsiOutput>
+      );
+      const output = container.querySelector("[data-slot='ansi-output']");
+      expect(output?.className).toContain("text-red");
+    });
+  });
+});
+
+describe("AnsiStreamOutput", () => {
+  it("renders stdout with appropriate styling", () => {
+    const { container } = render(
+      <AnsiStreamOutput text="stdout output" streamName="stdout" />
+    );
+    const output = container.querySelector("[data-slot='ansi-stream-output']");
+    expect(output).toBeInTheDocument();
+    expect(screen.getByText("stdout output")).toBeInTheDocument();
+  });
+
+  it("renders stderr with red styling", () => {
+    const { container } = render(
+      <AnsiStreamOutput text="stderr output" streamName="stderr" />
+    );
+    const output = container.querySelector("[data-slot='ansi-stream-output']");
+    expect(output?.className).toContain("text-red");
+  });
+
+  it("renders text content", () => {
+    render(
+      <AnsiStreamOutput text="Plain stream output" streamName="stdout" />
+    );
+    expect(screen.getByText("Plain stream output")).toBeInTheDocument();
+  });
+});
+
+describe("AnsiErrorOutput", () => {
+  it("renders error name and value", () => {
+    render(
+      <AnsiErrorOutput
+        ename="TypeError"
+        evalue="cannot read property 'foo' of undefined"
+      />
+    );
+    expect(screen.getByText(/TypeError/)).toBeInTheDocument();
+    expect(screen.getByText(/cannot read property/)).toBeInTheDocument();
+  });
+
+  it("renders traceback as array", () => {
+    render(
+      <AnsiErrorOutput
+        ename="Error"
+        evalue="test"
+        traceback={["line 1", "line 2", "line 3"]}
+      />
+    );
+    expect(screen.getByText(/line 1/)).toBeInTheDocument();
+    expect(screen.getByText(/line 2/)).toBeInTheDocument();
+  });
+
+  it("renders traceback as string", () => {
+    render(
+      <AnsiErrorOutput
+        ename="Error"
+        evalue="test"
+        traceback="single line traceback"
+      />
+    );
+    expect(screen.getByText(/single line traceback/)).toBeInTheDocument();
+  });
+
+  it("renders ANSI codes in traceback", () => {
+    const { container } = render(
+      <AnsiErrorOutput
+        ename="Error"
+        evalue="test"
+        traceback={["\x1b[31mRed error line\x1b[0m"]}
+      />
+    );
+    const spans = getSpanStyles(container);
+    const redSpan = spans.find((s) => s.text === "Red error line");
+    expect(redSpan?.className).toContain("ansi-red-fg");
+  });
+
+  it("has error-specific styling", () => {
+    const { container } = render(
+      <AnsiErrorOutput ename="Error" evalue="test" />
+    );
+    const output = container.querySelector("[data-slot='ansi-error-output']");
+    expect(output?.className).toContain("border-red");
+  });
+});

--- a/src/components/outputs/__tests__/media-router.test.ts
+++ b/src/components/outputs/__tests__/media-router.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Tests for media-router.tsx - MIME type selection and routing.
+ *
+ * These tests verify the MIME type selection logic that determines
+ * which renderer to use for Jupyter output data.
+ */
+
+import { describe, it, expect } from "vitest";
+import { getSelectedMimeType, DEFAULT_PRIORITY } from "../media-router";
+
+describe("getSelectedMimeType", () => {
+  describe("priority-based selection", () => {
+    it("returns highest priority MIME type when multiple available", () => {
+      const data = {
+        "text/plain": "Hello",
+        "text/html": "<b>Hello</b>",
+      };
+      // text/html has higher priority than text/plain in DEFAULT_PRIORITY
+      expect(getSelectedMimeType(data)).toBe("text/html");
+    });
+
+    it("returns widget MIME type over others", () => {
+      const data = {
+        "text/plain": "Widget fallback",
+        "text/html": "<div>widget</div>",
+        "application/vnd.jupyter.widget-view+json": { model_id: "abc" },
+      };
+      expect(getSelectedMimeType(data)).toBe(
+        "application/vnd.jupyter.widget-view+json"
+      );
+    });
+
+    it("returns image/png over text/plain", () => {
+      const data = {
+        "text/plain": "<Figure>",
+        "image/png": "iVBORw0KGgo...",
+      };
+      expect(getSelectedMimeType(data)).toBe("image/png");
+    });
+
+    it("returns application/json over text/plain", () => {
+      const data = {
+        "text/plain": '{"key": "value"}',
+        "application/json": { key: "value" },
+      };
+      expect(getSelectedMimeType(data)).toBe("application/json");
+    });
+
+    it("returns markdown over plain text", () => {
+      const data = {
+        "text/plain": "# Hello",
+        "text/markdown": "# Hello",
+      };
+      expect(getSelectedMimeType(data)).toBe("text/markdown");
+    });
+  });
+
+  describe("custom priority", () => {
+    it("respects custom priority order", () => {
+      const data = {
+        "text/plain": "Hello",
+        "text/html": "<b>Hello</b>",
+        "application/json": { greeting: "Hello" },
+      };
+      // Custom priority puts text/plain first
+      const customPriority = ["text/plain", "application/json", "text/html"];
+      expect(getSelectedMimeType(data, customPriority)).toBe("text/plain");
+    });
+
+    it("falls back to first available when no priority match", () => {
+      const data = {
+        "custom/mime-type": "custom data",
+      };
+      // DEFAULT_PRIORITY doesn't include custom/mime-type
+      expect(getSelectedMimeType(data)).toBe("custom/mime-type");
+    });
+
+    it("uses DEFAULT_PRIORITY when no custom priority provided", () => {
+      const data = {
+        "text/plain": "plain",
+        "text/html": "html",
+      };
+      expect(getSelectedMimeType(data, DEFAULT_PRIORITY)).toBe("text/html");
+    });
+  });
+
+  describe("empty/null handling", () => {
+    it("returns null for empty data object", () => {
+      expect(getSelectedMimeType({})).toBeNull();
+    });
+
+    it("skips null values", () => {
+      const data = {
+        "text/html": null,
+        "text/plain": "fallback",
+      };
+      expect(getSelectedMimeType(data)).toBe("text/plain");
+    });
+
+    it("skips undefined values", () => {
+      const data: Record<string, unknown> = {
+        "text/html": undefined,
+        "text/plain": "fallback",
+      };
+      expect(getSelectedMimeType(data)).toBe("text/plain");
+    });
+
+    it("returns null when all values are null", () => {
+      const data = {
+        "text/html": null,
+        "text/plain": null,
+      };
+      expect(getSelectedMimeType(data)).toBeNull();
+    });
+
+    it("accepts empty string as valid value", () => {
+      const data = {
+        "text/plain": "",
+      };
+      // Empty string is falsy but not null/undefined
+      expect(getSelectedMimeType(data)).toBe("text/plain");
+    });
+
+    it("accepts zero as valid value", () => {
+      const data = {
+        "application/json": 0,
+      };
+      expect(getSelectedMimeType(data)).toBe("application/json");
+    });
+
+    it("accepts false as valid value", () => {
+      const data = {
+        "application/json": false,
+      };
+      expect(getSelectedMimeType(data)).toBe("application/json");
+    });
+  });
+
+  describe("various MIME types", () => {
+    it("selects SVG over PNG", () => {
+      const data = {
+        "image/png": "png data",
+        "image/svg+xml": "<svg>...</svg>",
+      };
+      expect(getSelectedMimeType(data)).toBe("image/svg+xml");
+    });
+
+    it("selects Plotly over HTML", () => {
+      const data = {
+        "text/html": "<div>plotly</div>",
+        "application/vnd.plotly.v1+json": { data: [], layout: {} },
+      };
+      expect(getSelectedMimeType(data)).toBe("application/vnd.plotly.v1+json");
+    });
+
+    it("selects Vega-Lite v5 over v4", () => {
+      const data = {
+        "application/vnd.vegalite.v4+json": { $schema: "v4" },
+        "application/vnd.vegalite.v5+json": { $schema: "v5" },
+      };
+      expect(getSelectedMimeType(data)).toBe("application/vnd.vegalite.v5+json");
+    });
+
+    it("handles GeoJSON", () => {
+      const data = {
+        "text/plain": "geojson",
+        "application/geo+json": { type: "Feature" },
+      };
+      expect(getSelectedMimeType(data)).toBe("application/geo+json");
+    });
+
+    it("handles image/gif", () => {
+      const data = {
+        "text/plain": "<animation>",
+        "image/gif": "R0lGODlh...",
+      };
+      expect(getSelectedMimeType(data)).toBe("image/gif");
+    });
+
+    it("handles image/webp", () => {
+      const data = {
+        "text/plain": "<image>",
+        "image/webp": "UklGRl4A...",
+      };
+      expect(getSelectedMimeType(data)).toBe("image/webp");
+    });
+
+    it("handles image/jpeg", () => {
+      const data = {
+        "text/plain": "<image>",
+        "image/jpeg": "/9j/4AAQ...",
+      };
+      expect(getSelectedMimeType(data)).toBe("image/jpeg");
+    });
+  });
+
+  describe("DEFAULT_PRIORITY constant", () => {
+    it("has widget as highest priority", () => {
+      expect(DEFAULT_PRIORITY[0]).toBe(
+        "application/vnd.jupyter.widget-view+json"
+      );
+    });
+
+    it("has text/plain as lowest priority", () => {
+      expect(DEFAULT_PRIORITY[DEFAULT_PRIORITY.length - 1]).toBe("text/plain");
+    });
+
+    it("includes all standard image types", () => {
+      expect(DEFAULT_PRIORITY).toContain("image/png");
+      expect(DEFAULT_PRIORITY).toContain("image/jpeg");
+      expect(DEFAULT_PRIORITY).toContain("image/gif");
+      expect(DEFAULT_PRIORITY).toContain("image/webp");
+      expect(DEFAULT_PRIORITY).toContain("image/svg+xml");
+    });
+
+    it("includes rich visualization types", () => {
+      expect(DEFAULT_PRIORITY).toContain("application/vnd.plotly.v1+json");
+      expect(DEFAULT_PRIORITY).toContain("application/vnd.vegalite.v5+json");
+      expect(DEFAULT_PRIORITY).toContain("application/vnd.vega.v5+json");
+    });
+  });
+});

--- a/src/components/widgets/__tests__/buffer-utils.test.ts
+++ b/src/components/widgets/__tests__/buffer-utils.test.ts
@@ -1,0 +1,436 @@
+/**
+ * Tests for buffer-utils.ts - Widget binary data handling utilities.
+ *
+ * These functions handle the Jupyter widget protocol's binary buffer transport,
+ * which is critical for widgets that work with images, audio, and other binary data.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  applyBufferPaths,
+  extractBuffers,
+  arrayBufferToBase64,
+  buildMediaSrc,
+  findBufferPaths,
+} from "../buffer-utils";
+
+describe("applyBufferPaths", () => {
+  it("returns original data when bufferPaths is undefined", () => {
+    const data = { foo: "bar" };
+    const result = applyBufferPaths(data, undefined, [new ArrayBuffer(8)]);
+    expect(result).toBe(data);
+    expect(result).toEqual({ foo: "bar" });
+  });
+
+  it("returns original data when buffers is undefined", () => {
+    const data = { foo: "bar" };
+    const result = applyBufferPaths(data, [["foo"]], undefined);
+    expect(result).toBe(data);
+    expect(result).toEqual({ foo: "bar" });
+  });
+
+  it("returns original data when bufferPaths is empty", () => {
+    const data = { foo: "bar" };
+    const result = applyBufferPaths(data, [], [new ArrayBuffer(8)]);
+    expect(result).toBe(data);
+  });
+
+  it("applies buffer at single-level path", () => {
+    const data = { value: null };
+    const buffer = new ArrayBuffer(8);
+    const result = applyBufferPaths(data, [["value"]], [buffer]);
+    expect(result.value).toBe(buffer);
+  });
+
+  it("applies buffer at nested path", () => {
+    const data = { nested: { deep: { value: null } } };
+    const buffer = new ArrayBuffer(8);
+    const result = applyBufferPaths(data, [["nested", "deep", "value"]], [buffer]);
+    expect((result.nested as Record<string, unknown>).deep).toEqual({ value: buffer });
+  });
+
+  it("creates intermediate objects for missing paths", () => {
+    const data: Record<string, unknown> = {};
+    const buffer = new ArrayBuffer(8);
+    const result = applyBufferPaths(data, [["a", "b", "c"]], [buffer]);
+    expect(result.a).toBeDefined();
+    expect((result.a as Record<string, unknown>).b).toBeDefined();
+    expect(((result.a as Record<string, unknown>).b as Record<string, unknown>).c).toBe(buffer);
+  });
+
+  it("applies multiple buffers to multiple paths", () => {
+    const data = { first: null, second: null };
+    const buffer1 = new ArrayBuffer(4);
+    const buffer2 = new ArrayBuffer(8);
+    const result = applyBufferPaths(
+      data,
+      [["first"], ["second"]],
+      [buffer1, buffer2]
+    );
+    expect(result.first).toBe(buffer1);
+    expect(result.second).toBe(buffer2);
+  });
+
+  it("handles mismatched buffer count (fewer buffers than paths)", () => {
+    const data = { first: null, second: null };
+    const buffer = new ArrayBuffer(4);
+    const result = applyBufferPaths(
+      data,
+      [["first"], ["second"]],
+      [buffer]
+    );
+    expect(result.first).toBe(buffer);
+    expect(result.second).toBeNull();
+  });
+
+  it("skips empty paths", () => {
+    const data = { value: "original" };
+    const buffer = new ArrayBuffer(8);
+    const result = applyBufferPaths(data, [[]], [buffer]);
+    expect(result).toEqual({ value: "original" });
+  });
+
+  it("overwrites existing values", () => {
+    const data = { value: "will be replaced" };
+    const buffer = new ArrayBuffer(8);
+    const result = applyBufferPaths(data, [["value"]], [buffer]);
+    expect(result.value).toBe(buffer);
+  });
+});
+
+describe("extractBuffers", () => {
+  it("returns empty array when bufferPaths is undefined", () => {
+    const data = { buffer: new ArrayBuffer(8) };
+    const result = extractBuffers(data, undefined);
+    expect(result).toEqual([]);
+  });
+
+  it("returns empty array when bufferPaths is empty", () => {
+    const data = { buffer: new ArrayBuffer(8) };
+    const result = extractBuffers(data, []);
+    expect(result).toEqual([]);
+  });
+
+  it("extracts ArrayBuffer from single-level path", () => {
+    const buffer = new ArrayBuffer(8);
+    const data: Record<string, unknown> = { value: buffer };
+    const result = extractBuffers(data, [["value"]]);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(buffer);
+    expect(data.value).toBeNull();
+  });
+
+  it("extracts ArrayBuffer from nested path", () => {
+    const buffer = new ArrayBuffer(8);
+    const data = { nested: { deep: { value: buffer } } };
+    const result = extractBuffers(data, [["nested", "deep", "value"]]);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(buffer);
+    expect((data.nested.deep as Record<string, unknown>).value).toBeNull();
+  });
+
+  it("handles Uint8Array by slicing its buffer", () => {
+    const originalBuffer = new ArrayBuffer(16);
+    const view = new Uint8Array(originalBuffer, 4, 8); // offset 4, length 8
+    view[0] = 42;
+    view[7] = 99;
+
+    const data: Record<string, unknown> = { value: view };
+    const result = extractBuffers(data, [["value"]]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].byteLength).toBe(8);
+    const extractedView = new Uint8Array(result[0]);
+    expect(extractedView[0]).toBe(42);
+    expect(extractedView[7]).toBe(99);
+    expect(data.value).toBeNull();
+  });
+
+  it("handles other typed arrays (Int32Array)", () => {
+    const buffer = new ArrayBuffer(16);
+    const view = new Int32Array(buffer);
+    view[0] = 12345;
+
+    const data: Record<string, unknown> = { value: view };
+    const result = extractBuffers(data, [["value"]]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].byteLength).toBe(16);
+    expect(data.value).toBeNull();
+  });
+
+  it("returns empty ArrayBuffer for path that does not exist", () => {
+    const data = { other: "value" };
+    const result = extractBuffers(data, [["missing"]]);
+    expect(result).toHaveLength(1);
+    expect(result[0].byteLength).toBe(0);
+  });
+
+  it("returns empty ArrayBuffer for path with non-buffer value", () => {
+    const data = { value: "not a buffer" };
+    const result = extractBuffers(data, [["value"]]);
+    expect(result).toHaveLength(1);
+    expect(result[0].byteLength).toBe(0);
+  });
+
+  it("returns empty ArrayBuffer for empty path", () => {
+    const data = { value: new ArrayBuffer(8) };
+    const result = extractBuffers(data, [[]]);
+    expect(result).toHaveLength(1);
+    expect(result[0].byteLength).toBe(0);
+  });
+
+  it("extracts multiple buffers from multiple paths", () => {
+    const buffer1 = new ArrayBuffer(4);
+    const buffer2 = new ArrayBuffer(8);
+    const data: Record<string, unknown> = { first: buffer1, second: buffer2 };
+
+    const result = extractBuffers(data, [["first"], ["second"]]);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toBe(buffer1);
+    expect(result[1]).toBe(buffer2);
+    expect(data.first).toBeNull();
+    expect(data.second).toBeNull();
+  });
+
+  it("handles intermediate null in path", () => {
+    const data = { nested: null };
+    const result = extractBuffers(data, [["nested", "deep", "value"]]);
+    expect(result).toHaveLength(1);
+    expect(result[0].byteLength).toBe(0);
+  });
+
+  it("handles intermediate non-object in path", () => {
+    const data = { nested: "string" };
+    const result = extractBuffers(data, [["nested", "deep", "value"]]);
+    expect(result).toHaveLength(1);
+    expect(result[0].byteLength).toBe(0);
+  });
+});
+
+describe("arrayBufferToBase64", () => {
+  it("returns empty string for empty ArrayBuffer", () => {
+    const buffer = new ArrayBuffer(0);
+    expect(arrayBufferToBase64(buffer)).toBe("");
+  });
+
+  it("converts known bytes to correct base64", () => {
+    // "Hello" in ASCII is [72, 101, 108, 108, 111]
+    const buffer = new ArrayBuffer(5);
+    const view = new Uint8Array(buffer);
+    view.set([72, 101, 108, 108, 111]);
+
+    expect(arrayBufferToBase64(buffer)).toBe("SGVsbG8=");
+  });
+
+  it("handles Uint8Array input directly", () => {
+    const view = new Uint8Array([72, 101, 108, 108, 111]);
+    expect(arrayBufferToBase64(view)).toBe("SGVsbG8=");
+  });
+
+  it("handles binary data with all byte values", () => {
+    const buffer = new ArrayBuffer(3);
+    const view = new Uint8Array(buffer);
+    view.set([0, 255, 128]);
+
+    const result = arrayBufferToBase64(buffer);
+    expect(result).toBe("AP+A");
+  });
+
+  it("produces correct base64 for single byte", () => {
+    const view = new Uint8Array([65]); // 'A'
+    expect(arrayBufferToBase64(view)).toBe("QQ==");
+  });
+
+  it("produces correct base64 for two bytes", () => {
+    const view = new Uint8Array([65, 66]); // 'AB'
+    expect(arrayBufferToBase64(view)).toBe("QUI=");
+  });
+
+  it("produces correct base64 for three bytes (no padding)", () => {
+    const view = new Uint8Array([65, 66, 67]); // 'ABC'
+    expect(arrayBufferToBase64(view)).toBe("QUJD");
+  });
+});
+
+describe("buildMediaSrc", () => {
+  it("returns undefined for null value", () => {
+    expect(buildMediaSrc(null, "image", "png")).toBeUndefined();
+  });
+
+  it("returns undefined for undefined value", () => {
+    expect(buildMediaSrc(undefined, "image", "png")).toBeUndefined();
+  });
+
+  it("returns undefined for empty string", () => {
+    expect(buildMediaSrc("", "image", "png")).toBeUndefined();
+  });
+
+  it("converts ArrayBuffer to data URL", () => {
+    const buffer = new ArrayBuffer(5);
+    const view = new Uint8Array(buffer);
+    view.set([72, 101, 108, 108, 111]);
+
+    const result = buildMediaSrc(buffer, "image", "png");
+    expect(result).toBe("data:image/png;base64,SGVsbG8=");
+  });
+
+  it("converts Uint8Array to data URL", () => {
+    const view = new Uint8Array([72, 101, 108, 108, 111]);
+
+    const result = buildMediaSrc(view, "audio", "wav");
+    expect(result).toBe("data:audio/wav;base64,SGVsbG8=");
+  });
+
+  it("passes through data URLs unchanged", () => {
+    const dataUrl = "data:image/png;base64,ABC123";
+    expect(buildMediaSrc(dataUrl, "image", "jpeg")).toBe(dataUrl);
+  });
+
+  it("passes through http URLs unchanged", () => {
+    const url = "http://example.com/image.png";
+    expect(buildMediaSrc(url, "image", "png")).toBe(url);
+  });
+
+  it("passes through https URLs unchanged", () => {
+    const url = "https://example.com/image.png";
+    expect(buildMediaSrc(url, "image", "png")).toBe(url);
+  });
+
+  it("passes through absolute paths unchanged", () => {
+    const path = "/assets/image.png";
+    expect(buildMediaSrc(path, "image", "png")).toBe(path);
+  });
+
+  it("wraps plain base64 string in data URL", () => {
+    const base64 = "SGVsbG8=";
+    const result = buildMediaSrc(base64, "image", "gif");
+    expect(result).toBe("data:image/gif;base64,SGVsbG8=");
+  });
+
+  it("uses correct media type and format in data URL", () => {
+    const view = new Uint8Array([1, 2, 3]);
+    const result = buildMediaSrc(view, "video", "mp4");
+    expect(result).toMatch(/^data:video\/mp4;base64,/);
+  });
+});
+
+describe("findBufferPaths", () => {
+  it("returns empty array for object with no buffers", () => {
+    const data = { foo: "bar", num: 42, nested: { value: true } };
+    expect(findBufferPaths(data)).toEqual([]);
+  });
+
+  it("finds ArrayBuffer at top level", () => {
+    const data = { buffer: new ArrayBuffer(8), other: "value" };
+    const paths = findBufferPaths(data);
+    expect(paths).toEqual([["buffer"]]);
+  });
+
+  it("finds Uint8Array at top level", () => {
+    const data = { buffer: new Uint8Array(8), other: "value" };
+    const paths = findBufferPaths(data);
+    expect(paths).toEqual([["buffer"]]);
+  });
+
+  it("finds other typed arrays (Int32Array)", () => {
+    const data = { buffer: new Int32Array(4) };
+    const paths = findBufferPaths(data);
+    expect(paths).toEqual([["buffer"]]);
+  });
+
+  it("finds ArrayBuffer in nested object", () => {
+    const data = { nested: { deep: { buffer: new ArrayBuffer(8) } } };
+    const paths = findBufferPaths(data);
+    expect(paths).toEqual([["nested", "deep", "buffer"]]);
+  });
+
+  it("finds multiple buffers at various depths", () => {
+    const data = {
+      top: new ArrayBuffer(4),
+      nested: {
+        middle: new Uint8Array(8),
+        deeper: {
+          bottom: new ArrayBuffer(16),
+        },
+      },
+    };
+    const paths = findBufferPaths(data);
+    expect(paths).toHaveLength(3);
+    expect(paths).toContainEqual(["top"]);
+    expect(paths).toContainEqual(["nested", "middle"]);
+    expect(paths).toContainEqual(["nested", "deeper", "bottom"]);
+  });
+
+  it("does not recurse into arrays", () => {
+    const data = {
+      array: [new ArrayBuffer(8)],
+      buffer: new ArrayBuffer(4),
+    };
+    const paths = findBufferPaths(data);
+    // Should only find 'buffer', not the one inside the array
+    expect(paths).toEqual([["buffer"]]);
+  });
+
+  it("handles empty object", () => {
+    expect(findBufferPaths({})).toEqual([]);
+  });
+
+  it("ignores null values", () => {
+    const data = { nullValue: null, buffer: new ArrayBuffer(8) };
+    const paths = findBufferPaths(data);
+    expect(paths).toEqual([["buffer"]]);
+  });
+
+  it("uses provided prefix for paths", () => {
+    const data = { buffer: new ArrayBuffer(8) };
+    const paths = findBufferPaths(data, ["prefix", "path"]);
+    expect(paths).toEqual([["prefix", "path", "buffer"]]);
+  });
+});
+
+describe("roundtrip: applyBufferPaths and extractBuffers", () => {
+  it("extracting then applying restores original structure", () => {
+    const buffer = new ArrayBuffer(8);
+    const view = new Uint8Array(buffer);
+    view.set([1, 2, 3, 4, 5, 6, 7, 8]);
+
+    const original: Record<string, unknown> = {
+      nested: { data: buffer },
+      other: "value",
+    };
+    const paths = [["nested", "data"]];
+
+    // Extract (mutates original, sets to null)
+    const extractedBuffers = extractBuffers(original, paths);
+    expect(original.nested).toEqual({ data: null });
+
+    // Apply to restore
+    const restored = applyBufferPaths(original, paths, extractedBuffers);
+    expect(restored.nested).toEqual({ data: extractedBuffers[0] });
+
+    // Verify buffer contents preserved
+    const restoredView = new Uint8Array(
+      (restored.nested as Record<string, ArrayBuffer>).data
+    );
+    expect(Array.from(restoredView)).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
+  });
+
+  it("findBufferPaths produces paths usable by extractBuffers", () => {
+    const data: Record<string, unknown> = {
+      image: new ArrayBuffer(100),
+      nested: {
+        audio: new Uint8Array(50),
+      },
+    };
+
+    const paths = findBufferPaths(data);
+    expect(paths).toHaveLength(2);
+
+    const buffers = extractBuffers(data, paths);
+    expect(buffers).toHaveLength(2);
+    expect(data.image).toBeNull();
+    expect((data.nested as Record<string, unknown>).audio).toBeNull();
+  });
+});

--- a/src/components/widgets/__tests__/widget-store.test.ts
+++ b/src/components/widgets/__tests__/widget-store.test.ts
@@ -1,0 +1,614 @@
+/**
+ * Tests for widget-store.ts - Widget state management for Jupyter widgets.
+ *
+ * The widget store manages the lifecycle of widget models (comm_open/comm_msg/comm_close)
+ * and provides reactive subscriptions for UI updates.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import {
+  createWidgetStore,
+  isModelRef,
+  parseModelRef,
+  resolveModelRef,
+  type WidgetModel,
+} from "../widget-store";
+
+describe("isModelRef", () => {
+  it("returns true for valid IPY_MODEL_ reference", () => {
+    expect(isModelRef("IPY_MODEL_abc123")).toBe(true);
+  });
+
+  it("returns true for IPY_MODEL_ with UUID", () => {
+    expect(isModelRef("IPY_MODEL_550e8400-e29b-41d4-a716-446655440000")).toBe(true);
+  });
+
+  it("returns false for string without prefix", () => {
+    expect(isModelRef("abc123")).toBe(false);
+  });
+
+  it("returns false for empty string", () => {
+    expect(isModelRef("")).toBe(false);
+  });
+
+  it("returns false for null", () => {
+    expect(isModelRef(null)).toBe(false);
+  });
+
+  it("returns false for undefined", () => {
+    expect(isModelRef(undefined)).toBe(false);
+  });
+
+  it("returns false for number", () => {
+    expect(isModelRef(123)).toBe(false);
+  });
+
+  it("returns false for object", () => {
+    expect(isModelRef({ id: "IPY_MODEL_abc" })).toBe(false);
+  });
+
+  it("returns false for case mismatch", () => {
+    expect(isModelRef("ipy_model_abc")).toBe(false);
+    expect(isModelRef("IPY_model_abc")).toBe(false);
+  });
+});
+
+describe("parseModelRef", () => {
+  it("extracts model ID from valid reference", () => {
+    expect(parseModelRef("IPY_MODEL_abc123")).toBe("abc123");
+  });
+
+  it("extracts UUID from reference", () => {
+    const uuid = "550e8400-e29b-41d4-a716-446655440000";
+    expect(parseModelRef(`IPY_MODEL_${uuid}`)).toBe(uuid);
+  });
+
+  it("returns null for string without prefix", () => {
+    expect(parseModelRef("abc123")).toBeNull();
+  });
+
+  it("returns empty string for IPY_MODEL_ with no ID", () => {
+    expect(parseModelRef("IPY_MODEL_")).toBe("");
+  });
+
+  it("handles prefix only (edge case)", () => {
+    expect(parseModelRef("IPY_MODEL_")).toBe("");
+  });
+});
+
+describe("resolveModelRef", () => {
+  it("resolves reference to model using getModel", () => {
+    const mockModel: WidgetModel = {
+      id: "abc123",
+      state: { value: 42 },
+      buffers: [],
+      modelName: "IntSliderModel",
+      modelModule: "@jupyter-widgets/controls",
+    };
+    const getModel = vi.fn().mockReturnValue(mockModel);
+
+    const result = resolveModelRef("IPY_MODEL_abc123", getModel);
+
+    expect(getModel).toHaveBeenCalledWith("abc123");
+    expect(result).toBe(mockModel);
+  });
+
+  it("returns original value for non-reference string", () => {
+    const getModel = vi.fn();
+    const result = resolveModelRef("plain string", getModel);
+
+    expect(getModel).not.toHaveBeenCalled();
+    expect(result).toBe("plain string");
+  });
+
+  it("returns original value for number", () => {
+    const getModel = vi.fn();
+    expect(resolveModelRef(42, getModel)).toBe(42);
+    expect(getModel).not.toHaveBeenCalled();
+  });
+
+  it("returns original value for object", () => {
+    const getModel = vi.fn();
+    const obj = { foo: "bar" };
+    expect(resolveModelRef(obj, getModel)).toBe(obj);
+  });
+
+  it("returns original value for null", () => {
+    const getModel = vi.fn();
+    expect(resolveModelRef(null, getModel)).toBeNull();
+  });
+
+  it("returns undefined from getModel if model not found", () => {
+    const getModel = vi.fn().mockReturnValue(undefined);
+    const result = resolveModelRef("IPY_MODEL_missing", getModel);
+
+    expect(getModel).toHaveBeenCalledWith("missing");
+    expect(result).toBeUndefined();
+  });
+});
+
+describe("createWidgetStore", () => {
+  describe("basic store operations", () => {
+    it("returns a store with all required methods", () => {
+      const store = createWidgetStore();
+
+      expect(store.subscribe).toBeTypeOf("function");
+      expect(store.getSnapshot).toBeTypeOf("function");
+      expect(store.getModel).toBeTypeOf("function");
+      expect(store.createModel).toBeTypeOf("function");
+      expect(store.updateModel).toBeTypeOf("function");
+      expect(store.deleteModel).toBeTypeOf("function");
+      expect(store.wasModelClosed).toBeTypeOf("function");
+      expect(store.subscribeToKey).toBeTypeOf("function");
+      expect(store.emitCustomMessage).toBeTypeOf("function");
+      expect(store.subscribeToCustomMessage).toBeTypeOf("function");
+    });
+
+    it("starts with empty models", () => {
+      const store = createWidgetStore();
+      expect(store.getSnapshot().size).toBe(0);
+    });
+  });
+
+  describe("createModel", () => {
+    it("creates a model with correct metadata extraction", () => {
+      const store = createWidgetStore();
+
+      store.createModel("comm-1", {
+        _model_name: "IntSliderModel",
+        _model_module: "@jupyter-widgets/controls",
+        value: 50,
+        min: 0,
+        max: 100,
+      });
+
+      const model = store.getModel("comm-1");
+      expect(model).toBeDefined();
+      expect(model?.id).toBe("comm-1");
+      expect(model?.modelName).toBe("IntSliderModel");
+      expect(model?.modelModule).toBe("@jupyter-widgets/controls");
+      expect(model?.state.value).toBe(50);
+      expect(model?.buffers).toEqual([]);
+    });
+
+    it("uses default values when metadata missing", () => {
+      const store = createWidgetStore();
+
+      store.createModel("comm-1", { value: 42 });
+
+      const model = store.getModel("comm-1");
+      expect(model?.modelName).toBe("UnknownModel");
+      expect(model?.modelModule).toBe("");
+    });
+
+    it("stores buffers with the model", () => {
+      const store = createWidgetStore();
+      const buffer = new ArrayBuffer(8);
+
+      store.createModel("comm-1", { value: null }, [buffer]);
+
+      const model = store.getModel("comm-1");
+      expect(model?.buffers).toHaveLength(1);
+      expect(model?.buffers[0]).toBe(buffer);
+    });
+
+    it("notifies subscribers on create", () => {
+      const store = createWidgetStore();
+      const listener = vi.fn();
+
+      store.subscribe(listener);
+      store.createModel("comm-1", { value: 42 });
+
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it("updates getSnapshot after create", () => {
+      const store = createWidgetStore();
+
+      const before = store.getSnapshot();
+      store.createModel("comm-1", { value: 42 });
+      const after = store.getSnapshot();
+
+      expect(before.size).toBe(0);
+      expect(after.size).toBe(1);
+      expect(before).not.toBe(after); // New Map reference
+    });
+  });
+
+  describe("updateModel", () => {
+    it("merges state patch into existing model", () => {
+      const store = createWidgetStore();
+
+      store.createModel("comm-1", { value: 50, min: 0, max: 100 });
+      store.updateModel("comm-1", { value: 75 });
+
+      const model = store.getModel("comm-1");
+      expect(model?.state.value).toBe(75);
+      expect(model?.state.min).toBe(0);
+      expect(model?.state.max).toBe(100);
+    });
+
+    it("replaces buffers when provided", () => {
+      const store = createWidgetStore();
+      const buffer1 = new ArrayBuffer(4);
+      const buffer2 = new ArrayBuffer(8);
+
+      store.createModel("comm-1", { value: null }, [buffer1]);
+      store.updateModel("comm-1", {}, [buffer2]);
+
+      const model = store.getModel("comm-1");
+      expect(model?.buffers).toHaveLength(1);
+      expect(model?.buffers[0]).toBe(buffer2);
+    });
+
+    it("preserves buffers when not provided", () => {
+      const store = createWidgetStore();
+      const buffer = new ArrayBuffer(8);
+
+      store.createModel("comm-1", { value: null }, [buffer]);
+      store.updateModel("comm-1", { value: 42 });
+
+      const model = store.getModel("comm-1");
+      expect(model?.buffers[0]).toBe(buffer);
+    });
+
+    it("does nothing for non-existent model", () => {
+      const store = createWidgetStore();
+      const listener = vi.fn();
+
+      store.subscribe(listener);
+      store.updateModel("missing", { value: 42 });
+
+      expect(listener).not.toHaveBeenCalled();
+      expect(store.getModel("missing")).toBeUndefined();
+    });
+
+    it("notifies global listeners on update", () => {
+      const store = createWidgetStore();
+      const listener = vi.fn();
+
+      store.createModel("comm-1", { value: 50 });
+      store.subscribe(listener);
+      store.updateModel("comm-1", { value: 75 });
+
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it("creates new Map reference on update", () => {
+      const store = createWidgetStore();
+
+      store.createModel("comm-1", { value: 50 });
+      const before = store.getSnapshot();
+      store.updateModel("comm-1", { value: 75 });
+      const after = store.getSnapshot();
+
+      expect(before).not.toBe(after);
+    });
+  });
+
+  describe("deleteModel", () => {
+    it("removes model from store", () => {
+      const store = createWidgetStore();
+
+      store.createModel("comm-1", { value: 42 });
+      expect(store.getModel("comm-1")).toBeDefined();
+
+      store.deleteModel("comm-1");
+      expect(store.getModel("comm-1")).toBeUndefined();
+    });
+
+    it("notifies listeners on delete", () => {
+      const store = createWidgetStore();
+      const listener = vi.fn();
+
+      store.createModel("comm-1", { value: 42 });
+      store.subscribe(listener);
+      store.deleteModel("comm-1");
+
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it("does nothing for non-existent model", () => {
+      const store = createWidgetStore();
+      const listener = vi.fn();
+
+      store.subscribe(listener);
+      store.deleteModel("missing");
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it("marks model as closed", () => {
+      const store = createWidgetStore();
+
+      store.createModel("comm-1", { value: 42 });
+      store.deleteModel("comm-1");
+
+      expect(store.wasModelClosed("comm-1")).toBe(true);
+    });
+  });
+
+  describe("wasModelClosed", () => {
+    it("returns false for model that never existed", () => {
+      const store = createWidgetStore();
+      expect(store.wasModelClosed("never-existed")).toBe(false);
+    });
+
+    it("returns false for existing model", () => {
+      const store = createWidgetStore();
+
+      store.createModel("comm-1", { value: 42 });
+
+      expect(store.wasModelClosed("comm-1")).toBe(false);
+    });
+
+    it("returns true after model deleted", () => {
+      const store = createWidgetStore();
+
+      store.createModel("comm-1", { value: 42 });
+      store.deleteModel("comm-1");
+
+      expect(store.wasModelClosed("comm-1")).toBe(true);
+    });
+
+    it("returns false after model re-opened", () => {
+      const store = createWidgetStore();
+
+      store.createModel("comm-1", { value: 42 });
+      store.deleteModel("comm-1");
+      expect(store.wasModelClosed("comm-1")).toBe(true);
+
+      store.createModel("comm-1", { value: 100 });
+      expect(store.wasModelClosed("comm-1")).toBe(false);
+    });
+  });
+
+  describe("subscribe / unsubscribe", () => {
+    it("returns unsubscribe function", () => {
+      const store = createWidgetStore();
+      const listener = vi.fn();
+
+      const unsubscribe = store.subscribe(listener);
+      expect(unsubscribe).toBeTypeOf("function");
+    });
+
+    it("unsubscribe removes listener", () => {
+      const store = createWidgetStore();
+      const listener = vi.fn();
+
+      const unsubscribe = store.subscribe(listener);
+      store.createModel("comm-1", { value: 42 });
+      expect(listener).toHaveBeenCalledTimes(1);
+
+      unsubscribe();
+      store.createModel("comm-2", { value: 100 });
+      expect(listener).toHaveBeenCalledTimes(1); // Not called again
+    });
+
+    it("multiple listeners all notified", () => {
+      const store = createWidgetStore();
+      const listener1 = vi.fn();
+      const listener2 = vi.fn();
+
+      store.subscribe(listener1);
+      store.subscribe(listener2);
+      store.createModel("comm-1", { value: 42 });
+
+      expect(listener1).toHaveBeenCalledTimes(1);
+      expect(listener2).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("subscribeToKey", () => {
+    it("notifies callback when specific key changes", () => {
+      const store = createWidgetStore();
+      const callback = vi.fn();
+
+      store.createModel("comm-1", { value: 50, other: "data" });
+      store.subscribeToKey("comm-1", "value", callback);
+      store.updateModel("comm-1", { value: 75 });
+
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(callback).toHaveBeenCalledWith(75);
+    });
+
+    it("does not notify when different key changes", () => {
+      const store = createWidgetStore();
+      const callback = vi.fn();
+
+      store.createModel("comm-1", { value: 50, other: "data" });
+      store.subscribeToKey("comm-1", "value", callback);
+      store.updateModel("comm-1", { other: "changed" });
+
+      expect(callback).not.toHaveBeenCalled();
+    });
+
+    it("returns unsubscribe function", () => {
+      const store = createWidgetStore();
+      const callback = vi.fn();
+
+      store.createModel("comm-1", { value: 50 });
+      const unsubscribe = store.subscribeToKey("comm-1", "value", callback);
+
+      store.updateModel("comm-1", { value: 60 });
+      expect(callback).toHaveBeenCalledTimes(1);
+
+      unsubscribe();
+      store.updateModel("comm-1", { value: 70 });
+      expect(callback).toHaveBeenCalledTimes(1); // Not called again
+    });
+
+    it("multiple callbacks for same key all notified", () => {
+      const store = createWidgetStore();
+      const callback1 = vi.fn();
+      const callback2 = vi.fn();
+
+      store.createModel("comm-1", { value: 50 });
+      store.subscribeToKey("comm-1", "value", callback1);
+      store.subscribeToKey("comm-1", "value", callback2);
+      store.updateModel("comm-1", { value: 75 });
+
+      expect(callback1).toHaveBeenCalledWith(75);
+      expect(callback2).toHaveBeenCalledWith(75);
+    });
+
+    it("can subscribe before model exists", () => {
+      const store = createWidgetStore();
+      const callback = vi.fn();
+
+      store.subscribeToKey("comm-1", "value", callback);
+      store.createModel("comm-1", { value: 50 });
+      // Create doesn't trigger key listeners
+      store.updateModel("comm-1", { value: 75 });
+
+      expect(callback).toHaveBeenCalledWith(75);
+    });
+
+    it("cleans up listener maps on unsubscribe", () => {
+      const store = createWidgetStore();
+      const callback = vi.fn();
+
+      store.createModel("comm-1", { value: 50 });
+      const unsubscribe = store.subscribeToKey("comm-1", "value", callback);
+      unsubscribe();
+
+      // Should not throw when updating after cleanup
+      store.updateModel("comm-1", { value: 60 });
+      expect(callback).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("emitCustomMessage / subscribeToCustomMessage", () => {
+    it("delivers message to subscriber", () => {
+      const store = createWidgetStore();
+      const callback = vi.fn();
+
+      store.createModel("comm-1", { value: 42 });
+      store.subscribeToCustomMessage("comm-1", callback);
+      store.emitCustomMessage("comm-1", { action: "draw", x: 10 });
+
+      expect(callback).toHaveBeenCalledTimes(1);
+      expect(callback).toHaveBeenCalledWith(
+        { action: "draw", x: 10 },
+        undefined
+      );
+    });
+
+    it("converts ArrayBuffer to DataView for anywidget compatibility", () => {
+      const store = createWidgetStore();
+      const callback = vi.fn();
+      const buffer = new ArrayBuffer(8);
+
+      store.createModel("comm-1", { value: 42 });
+      store.subscribeToCustomMessage("comm-1", callback);
+      store.emitCustomMessage("comm-1", { action: "data" }, [buffer]);
+
+      expect(callback).toHaveBeenCalledTimes(1);
+      const [, buffers] = callback.mock.calls[0];
+      expect(buffers).toHaveLength(1);
+      expect(buffers[0]).toBeInstanceOf(DataView);
+      expect(buffers[0].buffer).toBe(buffer);
+    });
+
+    it("buffers messages before subscriber exists", () => {
+      const store = createWidgetStore();
+      const callback = vi.fn();
+
+      store.createModel("comm-1", { value: 42 });
+      store.emitCustomMessage("comm-1", { action: "first" });
+      store.emitCustomMessage("comm-1", { action: "second" });
+
+      // Subscribe after messages emitted
+      store.subscribeToCustomMessage("comm-1", callback);
+
+      // Should receive buffered messages
+      expect(callback).toHaveBeenCalledTimes(2);
+      expect(callback).toHaveBeenNthCalledWith(1, { action: "first" }, undefined);
+      expect(callback).toHaveBeenNthCalledWith(2, { action: "second" }, undefined);
+    });
+
+    it("multiple subscribers to same comm receive messages", () => {
+      const store = createWidgetStore();
+      const callback1 = vi.fn();
+      const callback2 = vi.fn();
+
+      store.createModel("comm-1", { value: 42 });
+      store.subscribeToCustomMessage("comm-1", callback1);
+      store.subscribeToCustomMessage("comm-1", callback2);
+      store.emitCustomMessage("comm-1", { action: "test" });
+
+      expect(callback1).toHaveBeenCalledWith({ action: "test" }, undefined);
+      expect(callback2).toHaveBeenCalledWith({ action: "test" }, undefined);
+    });
+
+    it("second subscriber also receives buffered history", () => {
+      const store = createWidgetStore();
+      const callback1 = vi.fn();
+      const callback2 = vi.fn();
+
+      store.createModel("comm-1", { value: 42 });
+      store.subscribeToCustomMessage("comm-1", callback1);
+      store.emitCustomMessage("comm-1", { action: "history" });
+
+      // Second subscriber should also get buffered messages
+      store.subscribeToCustomMessage("comm-1", callback2);
+
+      expect(callback1).toHaveBeenCalledTimes(1); // Live message only
+      expect(callback2).toHaveBeenCalledTimes(1); // Buffer flush
+      expect(callback2).toHaveBeenCalledWith({ action: "history" }, undefined);
+    });
+
+    it("returns unsubscribe function", () => {
+      const store = createWidgetStore();
+      const callback = vi.fn();
+
+      store.createModel("comm-1", { value: 42 });
+      const unsubscribe = store.subscribeToCustomMessage("comm-1", callback);
+
+      store.emitCustomMessage("comm-1", { action: "first" });
+      expect(callback).toHaveBeenCalledTimes(1);
+
+      unsubscribe();
+      store.emitCustomMessage("comm-1", { action: "second" });
+      expect(callback).toHaveBeenCalledTimes(1); // Not called again
+    });
+
+    it("cleans up buffer when model deleted", () => {
+      const store = createWidgetStore();
+      const callback = vi.fn();
+
+      store.createModel("comm-1", { value: 42 });
+      store.emitCustomMessage("comm-1", { action: "buffered" });
+      store.deleteModel("comm-1");
+
+      // Re-create and subscribe - should not receive old buffer
+      store.createModel("comm-1", { value: 100 });
+      store.subscribeToCustomMessage("comm-1", callback);
+
+      expect(callback).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("getSnapshot immutability", () => {
+    it("returns same reference when no changes", () => {
+      const store = createWidgetStore();
+      store.createModel("comm-1", { value: 42 });
+
+      const snapshot1 = store.getSnapshot();
+      const snapshot2 = store.getSnapshot();
+
+      expect(snapshot1).toBe(snapshot2);
+    });
+
+    it("returns new reference after change", () => {
+      const store = createWidgetStore();
+      store.createModel("comm-1", { value: 42 });
+
+      const snapshot1 = store.getSnapshot();
+      store.updateModel("comm-1", { value: 50 });
+      const snapshot2 = store.getSnapshot();
+
+      expect(snapshot1).not.toBe(snapshot2);
+    });
+  });
+});

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest";

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,8 +4,9 @@ import path from "path";
 export default defineConfig({
   test: {
     environment: "jsdom",
-    include: ["src/**/__tests__/**/*.test.ts"],
+    include: ["src/**/__tests__/**/*.test.{ts,tsx}"],
     globals: true,
+    setupFiles: ["./src/test-setup.ts"],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary

Add comprehensive unit test coverage for critical TypeScript modules handling widget binary data, state management, and MIME type rendering. Includes 170 new tests covering buffer utilities, widget store, media router, and ANSI output rendering.

**New tests:**
- **buffer-utils.test.ts** (52 tests): Binary data handling for widget protocol - applyBufferPaths, extractBuffers, buildMediaSrc, arrayBufferToBase64, findBufferPaths
- **widget-store.test.ts** (59 tests): Widget state management - model CRUD, subscriptions, key listeners, custom messages, IPY_MODEL_ references
- **media-router.test.ts** (26 tests): MIME type selection and priority handling
- **ansi-output.test.tsx** (33 tests): ANSI escape sequence rendering with standard colors, 256-color palette, 24-bit truecolor, decorations, and terminal emulation

**Test infrastructure improvements:**
- Added @testing-library/react and @testing-library/jest-dom for component testing
- Extended vitest config to support .tsx test files
- Created test setup file with jest-dom matchers