### PR TITLE
Add comprehensive ipywidgets demo notebook

### DIFF
--- a/notebooks/ipywidgets-demo.ipynb
+++ b/notebooks/ipywidgets-demo.ipynb
@@ -1,0 +1,1324 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# ipywidgets Demo\n",
+    "\n",
+    "This notebook demonstrates every widget control available in the `ipywidgets` namespace."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ipywidgets as widgets\n",
+    "from IPython.display import display"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Text Input Widgets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Text - Single line text input\n",
+    "widgets.Text(\n",
+    "    value='Hello World',\n",
+    "    placeholder='Type something',\n",
+    "    description='Text:',\n",
+    "    disabled=False\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Textarea - Multi-line text input\n",
+    "widgets.Textarea(\n",
+    "    value='Hello\\nWorld',\n",
+    "    placeholder='Type something',\n",
+    "    description='Textarea:',\n",
+    "    disabled=False\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Password - Masked text input\n",
+    "widgets.Password(\n",
+    "    value='secret',\n",
+    "    placeholder='Enter password',\n",
+    "    description='Password:',\n",
+    "    disabled=False\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Combobox - Text input with suggestions\n",
+    "widgets.Combobox(\n",
+    "    value='',\n",
+    "    placeholder='Choose or type',\n",
+    "    options=['Apple', 'Banana', 'Cherry', 'Date'],\n",
+    "    description='Fruit:',\n",
+    "    ensure_option=False,\n",
+    "    disabled=False\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Numeric Input Widgets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# IntText - Integer text input\n",
+    "widgets.IntText(\n",
+    "    value=42,\n",
+    "    description='IntText:',\n",
+    "    disabled=False\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# FloatText - Float text input\n",
+    "widgets.FloatText(\n",
+    "    value=3.14159,\n",
+    "    description='FloatText:',\n",
+    "    disabled=False\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# BoundedIntText - Bounded integer text input\n",
+    "widgets.BoundedIntText(\n",
+    "    value=7,\n",
+    "    min=0,\n",
+    "    max=10,\n",
+    "    step=1,\n",
+    "    description='Bounded Int:',\n",
+    "    disabled=False\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# BoundedFloatText - Bounded float text input\n",
+    "widgets.BoundedFloatText(\n",
+    "    value=2.5,\n",
+    "    min=0.0,\n",
+    "    max=5.0,\n",
+    "    step=0.1,\n",
+    "    description='Bounded Float:',\n",
+    "    disabled=False\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Slider Widgets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# IntSlider - Integer slider\n",
+    "widgets.IntSlider(\n",
+    "    value=50,\n",
+    "    min=0,\n",
+    "    max=100,\n",
+    "    step=1,\n",
+    "    description='IntSlider:',\n",
+    "    continuous_update=False,\n",
+    "    orientation='horizontal',\n",
+    "    readout=True,\n",
+    "    readout_format='d'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# FloatSlider - Float slider\n",
+    "widgets.FloatSlider(\n",
+    "    value=0.5,\n",
+    "    min=0.0,\n",
+    "    max=1.0,\n",
+    "    step=0.01,\n",
+    "    description='FloatSlider:',\n",
+    "    continuous_update=False,\n",
+    "    orientation='horizontal',\n",
+    "    readout=True,\n",
+    "    readout_format='.2f'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# FloatLogSlider - Logarithmic float slider\n",
+    "widgets.FloatLogSlider(\n",
+    "    value=10,\n",
+    "    base=10,\n",
+    "    min=-2,\n",
+    "    max=4,\n",
+    "    step=0.2,\n",
+    "    description='Log Slider:'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# IntRangeSlider - Integer range slider\n",
+    "widgets.IntRangeSlider(\n",
+    "    value=[25, 75],\n",
+    "    min=0,\n",
+    "    max=100,\n",
+    "    step=1,\n",
+    "    description='Int Range:',\n",
+    "    continuous_update=False,\n",
+    "    orientation='horizontal',\n",
+    "    readout=True\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# FloatRangeSlider - Float range slider\n",
+    "widgets.FloatRangeSlider(\n",
+    "    value=[0.2, 0.8],\n",
+    "    min=0.0,\n",
+    "    max=1.0,\n",
+    "    step=0.01,\n",
+    "    description='Float Range:',\n",
+    "    continuous_update=False,\n",
+    "    orientation='horizontal',\n",
+    "    readout=True,\n",
+    "    readout_format='.2f'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Progress Widgets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# IntProgress - Integer progress bar\n",
+    "widgets.IntProgress(\n",
+    "    value=7,\n",
+    "    min=0,\n",
+    "    max=10,\n",
+    "    description='Loading:',\n",
+    "    bar_style='info',\n",
+    "    orientation='horizontal'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# FloatProgress - Float progress bar\n",
+    "widgets.FloatProgress(\n",
+    "    value=0.65,\n",
+    "    min=0.0,\n",
+    "    max=1.0,\n",
+    "    description='Progress:',\n",
+    "    bar_style='success',\n",
+    "    orientation='horizontal'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Selection Widgets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Dropdown - Single selection dropdown\n",
+    "widgets.Dropdown(\n",
+    "    options=['Linux', 'macOS', 'Windows'],\n",
+    "    value='macOS',\n",
+    "    description='OS:',\n",
+    "    disabled=False\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Select - Single selection list\n",
+    "widgets.Select(\n",
+    "    options=['Python', 'JavaScript', 'Rust', 'Go', 'Ruby'],\n",
+    "    value='Python',\n",
+    "    description='Language:',\n",
+    "    disabled=False\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# SelectMultiple - Multiple selection list\n",
+    "widgets.SelectMultiple(\n",
+    "    options=['Red', 'Orange', 'Yellow', 'Green', 'Blue', 'Indigo', 'Violet'],\n",
+    "    value=['Red', 'Blue'],\n",
+    "    description='Colors:',\n",
+    "    disabled=False\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# RadioButtons - Radio button selection\n",
+    "widgets.RadioButtons(\n",
+    "    options=['Small', 'Medium', 'Large'],\n",
+    "    value='Medium',\n",
+    "    description='Size:',\n",
+    "    disabled=False\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ToggleButtons - Toggle button selection\n",
+    "widgets.ToggleButtons(\n",
+    "    options=['Slow', 'Regular', 'Fast'],\n",
+    "    value='Regular',\n",
+    "    description='Speed:',\n",
+    "    disabled=False,\n",
+    "    button_style=''\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# SelectionSlider - Selection via slider\n",
+    "widgets.SelectionSlider(\n",
+    "    options=['Freezing', 'Cold', 'Warm', 'Hot', 'Boiling'],\n",
+    "    value='Warm',\n",
+    "    description='Temp:',\n",
+    "    continuous_update=False,\n",
+    "    orientation='horizontal',\n",
+    "    readout=True\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# SelectionRangeSlider - Selection range via slider\n",
+    "import datetime\n",
+    "dates = [datetime.date(2024, 1, i) for i in range(1, 32)]\n",
+    "options = [(d.strftime('%b %d'), d) for d in dates]\n",
+    "widgets.SelectionRangeSlider(\n",
+    "    options=options,\n",
+    "    index=(5, 15),\n",
+    "    description='Date Range:',\n",
+    "    orientation='horizontal',\n",
+    "    layout=widgets.Layout(width='500px')\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Boolean Widgets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Checkbox - Boolean checkbox\n",
+    "widgets.Checkbox(\n",
+    "    value=True,\n",
+    "    description='Subscribe:',\n",
+    "    disabled=False,\n",
+    "    indent=False\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ToggleButton - Boolean toggle button\n",
+    "widgets.ToggleButton(\n",
+    "    value=False,\n",
+    "    description='Click me',\n",
+    "    disabled=False,\n",
+    "    button_style='',\n",
+    "    icon='check'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Valid - Validity indicator\n",
+    "widgets.Valid(\n",
+    "    value=True,\n",
+    "    description='Valid!'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Button Widget"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Button - Clickable button\n",
+    "button = widgets.Button(\n",
+    "    description='Click me',\n",
+    "    disabled=False,\n",
+    "    button_style='primary',\n",
+    "    tooltip='Click to trigger action',\n",
+    "    icon='rocket'\n",
+    ")\n",
+    "\n",
+    "output = widgets.Output()\n",
+    "\n",
+    "def on_button_clicked(b):\n",
+    "    with output:\n",
+    "        print('Button clicked!')\n",
+    "\n",
+    "button.on_click(on_button_clicked)\n",
+    "\n",
+    "display(button, output)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Date and Time Widgets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# DatePicker - Date selection\n",
+    "import datetime\n",
+    "widgets.DatePicker(\n",
+    "    description='Pick a Date:',\n",
+    "    disabled=False,\n",
+    "    value=datetime.date.today()\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TimePicker - Time selection\n",
+    "widgets.TimePicker(\n",
+    "    description='Pick a Time:',\n",
+    "    disabled=False\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# DatetimePicker - DateTime selection (timezone-aware)\n",
+    "widgets.DatetimePicker(\n",
+    "    description='DateTime:',\n",
+    "    disabled=False\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# NaiveDatetimePicker - DateTime selection (timezone-naive)\n",
+    "widgets.NaiveDatetimePicker(\n",
+    "    description='Naive DT:',\n",
+    "    disabled=False\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Color Widgets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ColorPicker - Color selection\n",
+    "widgets.ColorPicker(\n",
+    "    concise=False,\n",
+    "    description='Pick a color:',\n",
+    "    value='#3498db',\n",
+    "    disabled=False\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ColorsInput - Multiple color input\n",
+    "widgets.ColorsInput(\n",
+    "    value=['#e74c3c', '#2ecc71', '#3498db'],\n",
+    "    description='Colors:'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Tags and Array Input Widgets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TagsInput - String tags input\n",
+    "widgets.TagsInput(\n",
+    "    value=['python', 'jupyter', 'widgets'],\n",
+    "    allowed_tags=['python', 'jupyter', 'widgets', 'notebook', 'data'],\n",
+    "    allow_duplicates=False,\n",
+    "    description='Tags:'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# IntsInput - Integer array input\n",
+    "widgets.IntsInput(\n",
+    "    value=[1, 2, 3, 5, 8],\n",
+    "    description='Fibonacci:'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# FloatsInput - Float array input\n",
+    "widgets.FloatsInput(\n",
+    "    value=[1.0, 1.5, 2.0, 2.5],\n",
+    "    description='Floats:'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Display Widgets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Label - Text label\n",
+    "widgets.Label(\n",
+    "    value='This is a Label widget'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# HTML - HTML display\n",
+    "widgets.HTML(\n",
+    "    value='<h3>HTML Widget</h3><p>This is <b>bold</b> and <i>italic</i> text.</p>',\n",
+    "    description='HTML:'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# HTMLMath - HTML with LaTeX math\n",
+    "widgets.HTMLMath(\n",
+    "    value=r'The quadratic formula: $x = \\frac{-b \\pm \\sqrt{b^2-4ac}}{2a}$',\n",
+    "    description='Math:'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Media Widgets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Image - Display image from bytes\n",
+    "# Create a simple 10x10 red PNG image\n",
+    "import struct\n",
+    "import zlib\n",
+    "\n",
+    "def create_png(width, height, r, g, b):\n",
+    "    def png_chunk(chunk_type, data):\n",
+    "        chunk_len = struct.pack('>I', len(data))\n",
+    "        chunk_crc = struct.pack('>I', zlib.crc32(chunk_type + data) & 0xffffffff)\n",
+    "        return chunk_len + chunk_type + data + chunk_crc\n",
+    "    \n",
+    "    # PNG signature\n",
+    "    signature = b'\\x89PNG\\r\\n\\x1a\\n'\n",
+    "    \n",
+    "    # IHDR chunk\n",
+    "    ihdr_data = struct.pack('>IIBBBBB', width, height, 8, 2, 0, 0, 0)\n",
+    "    ihdr = png_chunk(b'IHDR', ihdr_data)\n",
+    "    \n",
+    "    # IDAT chunk (image data)\n",
+    "    raw_data = b''\n",
+    "    for y in range(height):\n",
+    "        raw_data += b'\\x00'  # Filter byte\n",
+    "        for x in range(width):\n",
+    "            raw_data += bytes([r, g, b])\n",
+    "    \n",
+    "    compressed = zlib.compress(raw_data)\n",
+    "    idat = png_chunk(b'IDAT', compressed)\n",
+    "    \n",
+    "    # IEND chunk\n",
+    "    iend = png_chunk(b'IEND', b'')\n",
+    "    \n",
+    "    return signature + ihdr + idat + iend\n",
+    "\n",
+    "red_png = create_png(50, 50, 231, 76, 60)\n",
+    "\n",
+    "widgets.Image(\n",
+    "    value=red_png,\n",
+    "    format='png',\n",
+    "    width=50,\n",
+    "    height=50\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Audio - Display audio player\n",
+    "# Create a simple sine wave WAV file\n",
+    "import wave\n",
+    "import math\n",
+    "import io\n",
+    "\n",
+    "def create_wav(frequency=440, duration=1.0, sample_rate=44100):\n",
+    "    buffer = io.BytesIO()\n",
+    "    with wave.open(buffer, 'wb') as wav:\n",
+    "        wav.setnchannels(1)\n",
+    "        wav.setsampwidth(2)\n",
+    "        wav.setframerate(sample_rate)\n",
+    "        samples = []\n",
+    "        for i in range(int(sample_rate * duration)):\n",
+    "            t = i / sample_rate\n",
+    "            sample = int(32767 * math.sin(2 * math.pi * frequency * t))\n",
+    "            samples.append(struct.pack('<h', sample))\n",
+    "        wav.writeframes(b''.join(samples))\n",
+    "    return buffer.getvalue()\n",
+    "\n",
+    "audio_data = create_wav(440, 0.5)\n",
+    "\n",
+    "widgets.Audio(\n",
+    "    value=audio_data,\n",
+    "    format='wav',\n",
+    "    autoplay=False,\n",
+    "    loop=False\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Video - Display video player (placeholder - requires actual video data)\n",
+    "widgets.Video(\n",
+    "    value=b'',  # Would normally contain video bytes\n",
+    "    format='mp4',\n",
+    "    width=320,\n",
+    "    height=240\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## File Upload Widget"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# FileUpload - File upload widget\n",
+    "widgets.FileUpload(\n",
+    "    accept='',  # Accept all file types\n",
+    "    multiple=True,\n",
+    "    description='Upload:'\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Play Widget"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Play - Animation control widget\n",
+    "play = widgets.Play(\n",
+    "    value=50,\n",
+    "    min=0,\n",
+    "    max=100,\n",
+    "    step=1,\n",
+    "    interval=500,\n",
+    "    description='Press play:',\n",
+    "    disabled=False\n",
+    ")\n",
+    "\n",
+    "slider = widgets.IntSlider()\n",
+    "widgets.jslink((play, 'value'), (slider, 'value'))\n",
+    "\n",
+    "widgets.HBox([play, slider])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Controller Widget"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Controller - Gamepad controller (requires connected gamepad)\n",
+    "widgets.Controller(\n",
+    "    index=0  # First connected gamepad\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Output Widget"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Output - Capture output from code\n",
+    "out = widgets.Output(layout={'border': '1px solid black'})\n",
+    "\n",
+    "with out:\n",
+    "    for i in range(5):\n",
+    "        print(f'Output line {i}')\n",
+    "\n",
+    "out"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Layout Container Widgets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Box - Generic container\n",
+    "widgets.Box([\n",
+    "    widgets.Label('Item 1'),\n",
+    "    widgets.Label('Item 2'),\n",
+    "    widgets.Label('Item 3')\n",
+    "])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# HBox - Horizontal box\n",
+    "widgets.HBox([\n",
+    "    widgets.Button(description='Left'),\n",
+    "    widgets.Button(description='Center'),\n",
+    "    widgets.Button(description='Right')\n",
+    "])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# VBox - Vertical box\n",
+    "widgets.VBox([\n",
+    "    widgets.Button(description='Top'),\n",
+    "    widgets.Button(description='Middle'),\n",
+    "    widgets.Button(description='Bottom')\n",
+    "])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# GridBox - Grid layout\n",
+    "widgets.GridBox(\n",
+    "    children=[widgets.Button(description=str(i)) for i in range(9)],\n",
+    "    layout=widgets.Layout(\n",
+    "        width='50%',\n",
+    "        grid_template_columns='repeat(3, 1fr)',\n",
+    "        grid_gap='5px'\n",
+    "    )\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Accordion - Collapsible sections\n",
+    "accordion = widgets.Accordion(children=[\n",
+    "    widgets.IntSlider(description='Slider'),\n",
+    "    widgets.Text(description='Text'),\n",
+    "    widgets.Checkbox(description='Check')\n",
+    "])\n",
+    "accordion.set_title(0, 'Slider Section')\n",
+    "accordion.set_title(1, 'Text Section')\n",
+    "accordion.set_title(2, 'Checkbox Section')\n",
+    "accordion"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Tab - Tabbed interface\n",
+    "tab = widgets.Tab(children=[\n",
+    "    widgets.Text(description='Name:'),\n",
+    "    widgets.IntSlider(description='Age:'),\n",
+    "    widgets.Checkbox(description='Active:')\n",
+    "])\n",
+    "tab.set_title(0, 'Text')\n",
+    "tab.set_title(1, 'Slider')\n",
+    "tab.set_title(2, 'Checkbox')\n",
+    "tab"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Stack - Stacked widgets (only one visible at a time)\n",
+    "stack = widgets.Stack([\n",
+    "    widgets.Label('Page 1'),\n",
+    "    widgets.Label('Page 2'),\n",
+    "    widgets.Label('Page 3')\n",
+    "], selected_index=0)\n",
+    "\n",
+    "dropdown = widgets.Dropdown(options=['Page 1', 'Page 2', 'Page 3'], value='Page 1', description='Select:')\n",
+    "widgets.jslink((dropdown, 'index'), (stack, 'selected_index'))\n",
+    "\n",
+    "widgets.VBox([dropdown, stack])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Template Layout Widgets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# AppLayout - Application-style layout\n",
+    "widgets.AppLayout(\n",
+    "    header=widgets.HTML('<h2 style=\"background: #3498db; color: white; padding: 10px;\">Header</h2>'),\n",
+    "    left_sidebar=widgets.HTML('<div style=\"background: #ecf0f1; padding: 10px;\">Left Sidebar</div>'),\n",
+    "    center=widgets.HTML('<div style=\"background: #bdc3c7; padding: 10px;\">Main Content Area</div>'),\n",
+    "    right_sidebar=widgets.HTML('<div style=\"background: #ecf0f1; padding: 10px;\">Right Sidebar</div>'),\n",
+    "    footer=widgets.HTML('<div style=\"background: #2c3e50; color: white; padding: 10px;\">Footer</div>'),\n",
+    "    pane_heights=['50px', 1, '40px']\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# GridspecLayout - CSS Grid-based layout\n",
+    "grid = widgets.GridspecLayout(3, 3, height='200px')\n",
+    "grid[0, :] = widgets.Button(description='Top (spans 3 cols)')\n",
+    "grid[1, 0] = widgets.Button(description='Left')\n",
+    "grid[1, 1:] = widgets.Button(description='Right (spans 2 cols)')\n",
+    "grid[2, :2] = widgets.Button(description='Bottom Left (spans 2)')\n",
+    "grid[2, 2] = widgets.Button(description='BR')\n",
+    "grid"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TwoByTwoLayout - 2x2 grid layout\n",
+    "widgets.TwoByTwoLayout(\n",
+    "    top_left=widgets.Button(description='Top Left'),\n",
+    "    top_right=widgets.Button(description='Top Right'),\n",
+    "    bottom_left=widgets.Button(description='Bottom Left'),\n",
+    "    bottom_right=widgets.Button(description='Bottom Right')\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Style and Layout Objects"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Layout - Widget layout properties\n",
+    "layout = widgets.Layout(\n",
+    "    width='50%',\n",
+    "    height='40px',\n",
+    "    border='2px solid #3498db',\n",
+    "    margin='10px',\n",
+    "    padding='5px'\n",
+    ")\n",
+    "\n",
+    "widgets.Button(description='Styled Button', layout=layout)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ButtonStyle - Button-specific styling\n",
+    "style = widgets.ButtonStyle(\n",
+    "    button_color='#e74c3c',\n",
+    "    font_weight='bold'\n",
+    ")\n",
+    "\n",
+    "widgets.Button(description='Red Button', style=style)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# SliderStyle - Slider-specific styling\n",
+    "slider_style = widgets.SliderStyle(\n",
+    "    handle_color='#2ecc71'\n",
+    ")\n",
+    "\n",
+    "widgets.IntSlider(description='Green Handle:', style=slider_style)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ToggleButtonsStyle - ToggleButtons-specific styling\n",
+    "toggle_style = widgets.ToggleButtonsStyle(\n",
+    "    button_width='100px',\n",
+    "    font_weight='bold'\n",
+    ")\n",
+    "\n",
+    "widgets.ToggleButtons(\n",
+    "    options=['A', 'B', 'C'],\n",
+    "    description='Options:',\n",
+    "    style=toggle_style\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Interactive Functions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# interact - Automatic UI generation from function signature\n",
+    "from ipywidgets import interact\n",
+    "\n",
+    "@interact(x=(0, 10), y=(0.0, 1.0, 0.1), name='World')\n",
+    "def greet(x=5, y=0.5, name='World'):\n",
+    "    print(f'Hello {name}! x={x}, y={y:.1f}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# interactive - More control over interact\n",
+    "from ipywidgets import interactive\n",
+    "\n",
+    "def f(a, b):\n",
+    "    return a + b\n",
+    "\n",
+    "w = interactive(f, a=10, b=20)\n",
+    "display(w)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# interactive_output - Separate output widget\n",
+    "from ipywidgets import interactive_output\n",
+    "\n",
+    "a = widgets.IntSlider(description='a')\n",
+    "b = widgets.IntSlider(description='b')\n",
+    "\n",
+    "def calculator(a, b):\n",
+    "    print(f'{a} + {b} = {a + b}')\n",
+    "\n",
+    "out = interactive_output(calculator, {'a': a, 'b': b})\n",
+    "\n",
+    "widgets.VBox([a, b, out])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Widget Linking"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# link - Bidirectional Python-side linking\n",
+    "from ipywidgets import link\n",
+    "\n",
+    "slider1 = widgets.IntSlider(description='Slider 1:')\n",
+    "slider2 = widgets.IntSlider(description='Slider 2:')\n",
+    "\n",
+    "link((slider1, 'value'), (slider2, 'value'))\n",
+    "\n",
+    "widgets.VBox([slider1, slider2])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# dlink - Directional Python-side linking\n",
+    "from ipywidgets import dlink\n",
+    "\n",
+    "source = widgets.IntSlider(description='Source:')\n",
+    "target = widgets.IntSlider(description='Target:')\n",
+    "\n",
+    "dlink((source, 'value'), (target, 'value'))\n",
+    "\n",
+    "widgets.VBox([source, target])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# jslink - Bidirectional JavaScript-side linking (faster)\n",
+    "from ipywidgets import jslink\n",
+    "\n",
+    "js_slider1 = widgets.IntSlider(description='JS Slider 1:')\n",
+    "js_slider2 = widgets.IntSlider(description='JS Slider 2:')\n",
+    "\n",
+    "jslink((js_slider1, 'value'), (js_slider2, 'value'))\n",
+    "\n",
+    "widgets.VBox([js_slider1, js_slider2])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# jsdlink - Directional JavaScript-side linking\n",
+    "from ipywidgets import jsdlink\n",
+    "\n",
+    "js_source = widgets.IntSlider(description='JS Source:')\n",
+    "js_target = widgets.IntSlider(description='JS Target:')\n",
+    "\n",
+    "jsdlink((js_source, 'value'), (js_target, 'value'))\n",
+    "\n",
+    "widgets.VBox([js_source, js_target])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "\n",
+    "## Summary\n",
+    "\n",
+    "This notebook has demonstrated all major widget controls from the `ipywidgets` namespace:\n",
+    "\n",
+    "- **Text Inputs**: Text, Textarea, Password, Combobox\n",
+    "- **Numeric Inputs**: IntText, FloatText, BoundedIntText, BoundedFloatText\n",
+    "- **Sliders**: IntSlider, FloatSlider, FloatLogSlider, IntRangeSlider, FloatRangeSlider\n",
+    "- **Progress**: IntProgress, FloatProgress\n",
+    "- **Selection**: Dropdown, Select, SelectMultiple, RadioButtons, ToggleButtons, SelectionSlider, SelectionRangeSlider\n",
+    "- **Boolean**: Checkbox, ToggleButton, Valid\n",
+    "- **Button**: Button\n",
+    "- **Date/Time**: DatePicker, TimePicker, DatetimePicker, NaiveDatetimePicker\n",
+    "- **Color**: ColorPicker, ColorsInput\n",
+    "- **Tags/Arrays**: TagsInput, IntsInput, FloatsInput\n",
+    "- **Display**: Label, HTML, HTMLMath\n",
+    "- **Media**: Image, Audio, Video\n",
+    "- **File**: FileUpload\n",
+    "- **Animation**: Play\n",
+    "- **Controller**: Controller\n",
+    "- **Output**: Output\n",
+    "- **Layout**: Box, HBox, VBox, GridBox, Accordion, Tab, Stack\n",
+    "- **Templates**: AppLayout, GridspecLayout, TwoByTwoLayout\n",
+    "- **Styling**: Layout, ButtonStyle, SliderStyle, ToggleButtonsStyle\n",
+    "- **Interactive**: interact, interactive, interactive_output\n",
+    "- **Linking**: link, dlink, jslink, jsdlink"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## Summary

Adds a comprehensive demonstration notebook showcasing all ipywidgets controls available in the `ipywidgets` namespace, with 1,300+ lines of example code organized by widget category.

## Contents

Demonstrates 65+ widgets including:
- Input widgets (text, numeric, sliders, selections)
- Boolean controls (checkbox, toggle button, valid indicator)
- Date/time pickers
- Color selection
- Media widgets (image, audio, video)
- Container layouts (Box, HBox, VBox, GridBox, Accordion, Tab, Stack)
- Template layouts (AppLayout, GridspecLayout, TwoByTwoLayout)
- Interactive functions and widget linking

## Testing

Run all cells in `notebooks/ipywidgets-demo.ipynb` to verify rendering of all widgets and interactivity. This notebook served as a test fixture that helped identify several widget rendering bugs.