### PR TITLE
Expand cell highlight background to full width

### DIFF
--- a/src/components/cell/CellContainer.tsx
+++ b/src/components/cell/CellContainer.tsx
@@ -53,6 +53,7 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
         className={cn(
           "cell-container group flex transition-colors duration-150",
           bgColor,
+          isFocused && "-mx-16 px-16",
           className,
         )}
         onMouseDown={onFocus}


### PR DESCRIPTION
## Summary

Expanded the focused cell's background highlight to stretch across the full viewport width using negative margins. The highlight now covers both the left and right edges, providing better visual emphasis for the selected cell.

<img width="1212" height="862" alt="image" src="https://github.com/user-attachments/assets/43e6c079-c7f6-4865-a7a6-5f5f46bacb0c" />


## Testing

- [x] Click on a cell to focus it and verify the highlight extends to both edges
- [x] Verify unfocused cells remain unchanged
- [x] Verify cell content alignment is preserved (gutter, ribbon, content align correctly)