### PR TITLE
Add zoom controls (Cmd+/Cmd--/Cmd-0)

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState, useRef } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
+import { getCurrentWebview } from "@tauri-apps/api/webview";
 import { NotebookToolbar } from "./components/NotebookToolbar";
 import { NotebookView } from "./components/NotebookView";
 import { DependencyHeader } from "./components/DependencyHeader";
@@ -318,6 +319,37 @@ onKernelStarted: loadCondaDependencies,
       unlistenPromise.then((unlisten) => unlisten());
     };
   }, [openNotebook]);
+
+  // Zoom controls via native menu
+  useEffect(() => {
+    const webview = getCurrentWebview();
+    let currentZoom = 1.0;
+
+    const handleZoomIn = () => {
+      currentZoom = Math.min(3.0, currentZoom + 0.1);
+      webview.setZoom(currentZoom);
+    };
+
+    const handleZoomOut = () => {
+      currentZoom = Math.max(0.5, currentZoom - 0.1);
+      webview.setZoom(currentZoom);
+    };
+
+    const handleZoomReset = () => {
+      currentZoom = 1.0;
+      webview.setZoom(1.0);
+    };
+
+    const unlistenIn = listen("menu:zoom-in", handleZoomIn);
+    const unlistenOut = listen("menu:zoom-out", handleZoomOut);
+    const unlistenReset = listen("menu:zoom-reset", handleZoomReset);
+
+    return () => {
+      unlistenIn.then((u) => u());
+      unlistenOut.then((u) => u());
+      unlistenReset.then((u) => u());
+    };
+  }, []);
 
   // Cmd+Shift+I to toggle isolation test panel (dev only)
   useEffect(() => {

--- a/crates/notebook/capabilities/default.json
+++ b/crates/notebook/capabilities/default.json
@@ -6,6 +6,7 @@
   "permissions": [
     "core:default",
     "core:event:default",
+    "core:webview:allow-set-webview-zoom",
     "dialog:default"
   ]
 }

--- a/crates/notebook/gen/schemas/capabilities.json
+++ b/crates/notebook/gen/schemas/capabilities.json
@@ -1,1 +1,1 @@
-{"default":{"identifier":"default","description":"Default capabilities for the notebook window","local":true,"windows":["main"],"permissions":["core:default","core:event:default","dialog:default"]}}
+{"default":{"identifier":"default","description":"Default capabilities for the notebook window","local":true,"windows":["main"],"permissions":["core:default","core:event:default","core:webview:allow-set-webview-zoom","dialog:default"]}}

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -1503,6 +1503,21 @@ pub fn run(notebook_path: Option<PathBuf>, runtime: Runtime) -> anyhow::Result<(
                         let _ = window.emit("menu:save", ());
                     }
                 }
+                crate::menu::MENU_ZOOM_IN => {
+                    if let Some(window) = app.get_webview_window("main") {
+                        let _ = window.emit("menu:zoom-in", ());
+                    }
+                }
+                crate::menu::MENU_ZOOM_OUT => {
+                    if let Some(window) = app.get_webview_window("main") {
+                        let _ = window.emit("menu:zoom-out", ());
+                    }
+                }
+                crate::menu::MENU_ZOOM_RESET => {
+                    if let Some(window) = app.get_webview_window("main") {
+                        let _ = window.emit("menu:zoom-reset", ());
+                    }
+                }
                 _ => {}
             }
         })

--- a/crates/notebook/src/menu.rs
+++ b/crates/notebook/src/menu.rs
@@ -7,6 +7,11 @@ pub const MENU_NEW_DENO_NOTEBOOK: &str = "new_deno_notebook";
 pub const MENU_OPEN: &str = "open";
 pub const MENU_SAVE: &str = "save";
 
+// Menu item IDs for zoom
+pub const MENU_ZOOM_IN: &str = "zoom_in";
+pub const MENU_ZOOM_OUT: &str = "zoom_out";
+pub const MENU_ZOOM_RESET: &str = "zoom_reset";
+
 /// Build the application menu bar
 pub fn create_menu(app: &AppHandle) -> tauri::Result<Menu<Wry>> {
     let menu = Menu::new(app)?;
@@ -72,6 +77,31 @@ pub fn create_menu(app: &AppHandle) -> tauri::Result<Menu<Wry>> {
     edit_menu.append(&PredefinedMenuItem::paste(app, None)?)?;
     edit_menu.append(&PredefinedMenuItem::select_all(app, None)?)?;
     menu.append(&edit_menu)?;
+
+    // View menu
+    let view_menu = Submenu::new(app, "View", true)?;
+    view_menu.append(&MenuItem::with_id(
+        app,
+        MENU_ZOOM_IN,
+        "Zoom In",
+        true,
+        Some("CmdOrCtrl+="),
+    )?)?;
+    view_menu.append(&MenuItem::with_id(
+        app,
+        MENU_ZOOM_OUT,
+        "Zoom Out",
+        true,
+        Some("CmdOrCtrl+-"),
+    )?)?;
+    view_menu.append(&MenuItem::with_id(
+        app,
+        MENU_ZOOM_RESET,
+        "Actual Size",
+        true,
+        Some("CmdOrCtrl+0"),
+    )?)?;
+    menu.append(&view_menu)?;
 
     // Window menu
     let window_menu = Submenu::new(app, "Window", true)?;


### PR DESCRIPTION
## Summary
Adds a View menu with zoom in, zoom out, and actual size options. Uses Tauri's webview setZoom API to handle zoom at 10% increments between 50%-300%.

## Changes
- **Menu**: New View menu with three zoom items and keyboard shortcuts
- **Backend**: Menu event handlers that emit zoom events to the frontend
- **Frontend**: Zoom state management and webview zoom control

## Screenshot

<img width="1212" height="862" alt="image" src="https://github.com/user-attachments/assets/b3c160be-71ab-4e8e-948c-c6f92781ecf2" />


## Test Plan
- [x] View menu displays with Zoom In, Zoom Out, and Actual Size items
- [x] Cmd-+ (or Cmd-=) zooms in by 10%
- [x] Cmd-- zooms out by 10%
- [x] Cmd-0 resets zoom to 100%
- [x] Zoom respects bounds (50% minimum, 300% maximum)