### PR TITLE
Add configurable npm: imports for Deno notebooks

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -127,8 +127,13 @@ function AppContent() {
     setPython: setCondaPython,
   } = useCondaDependencies();
 
-  // Deno config detection
-  const { denoAvailable, denoConfigInfo } = useDenoDependencies();
+  // Deno config detection and settings
+  const {
+    denoAvailable,
+    denoConfigInfo,
+    flexibleNpmImports,
+    setFlexibleNpmImports,
+  } = useDenoDependencies();
 
   // Auto-detect environment type based on what's configured
   // uv takes priority if metadata exists (even with empty deps)
@@ -360,6 +365,8 @@ onKernelStarted: loadCondaDependencies,
         <DenoDependencyHeader
           denoAvailable={denoAvailable}
           denoConfigInfo={denoConfigInfo}
+          flexibleNpmImports={flexibleNpmImports}
+          onSetFlexibleNpmImports={setFlexibleNpmImports}
         />
       )}
       {dependencyHeaderOpen && runtime === "python" && envType === "conda" && (

--- a/apps/notebook/src/components/DenoDependencyHeader.tsx
+++ b/apps/notebook/src/components/DenoDependencyHeader.tsx
@@ -1,14 +1,20 @@
 import { Info, FileText, Package, ExternalLink } from "lucide-react";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
 import type { DenoConfigInfo } from "../hooks/useDenoDependencies";
 
 interface DenoDependencyHeaderProps {
   denoAvailable: boolean | null;
   denoConfigInfo: DenoConfigInfo | null;
+  flexibleNpmImports: boolean;
+  onSetFlexibleNpmImports: (enabled: boolean) => void;
 }
 
 export function DenoDependencyHeader({
   denoAvailable,
   denoConfigInfo,
+  flexibleNpmImports,
+  onSetFlexibleNpmImports,
 }: DenoDependencyHeaderProps) {
   return (
     <div className="border-b bg-emerald-500/5 dark:bg-emerald-500/10">
@@ -73,6 +79,32 @@ export function DenoDependencyHeader({
               No <code className="rounded bg-muted px-1">deno.json</code> found.
               Deno can import modules directly without configuration.
             </span>
+          </div>
+        )}
+
+        {/* Auto-install npm packages setting */}
+        {denoAvailable !== false && (
+          <div className="mb-3 flex items-start gap-2.5">
+            <Checkbox
+              id="flexible-npm-imports"
+              checked={flexibleNpmImports}
+              onCheckedChange={(checked) =>
+                onSetFlexibleNpmImports(checked === true)
+              }
+              className="mt-0.5"
+            />
+            <Label
+              htmlFor="flexible-npm-imports"
+              className="flex-1 flex-col items-start gap-1 cursor-pointer"
+            >
+              <span className="text-xs font-medium text-foreground">
+                Auto-install npm packages
+              </span>
+              <p className="text-xs text-muted-foreground font-normal">
+                Packages download automatically when you import them. Disable to
+                use your project&apos;s node_modules instead.
+              </p>
+            </Label>
           </div>
         )}
 


### PR DESCRIPTION
## Summary

Add a checkbox in the Deno dependencies panel to control whether npm: specifiers auto-install packages or use the project's node_modules. When Deno detects node_modules and package.json, it switches to Node compatibility mode which breaks auto-installation—this setting lets users toggle the behavior via the `DENO_NO_PACKAGE_JSON` environment variable.

Default is enabled to restore the intuitive notebook experience where `import * as Plot from "npm:@observablehq/plot"` just works.

## Changes

**Backend:**
- `deno_env.rs`: Added `flexible_npm_imports` boolean field to `DenoDependencies` struct
- `kernel.rs`: Set `DENO_NO_PACKAGE_JSON=1` when launching Deno kernels if setting is enabled
- `lib.rs`: Added `get_deno_flexible_npm_imports` and `set_deno_flexible_npm_imports` Tauri commands

**Frontend:**
- `useDenoDependencies.ts`: Added state and setter for the setting, synced with backend via Tauri
- `DenoDependencyHeader.tsx`: Added shadcn checkbox with label showing "Auto-install npm packages"
- `App.tsx`: Wired props through to component

## Screenshot

<img width="1840" height="1191" alt="image" src="https://github.com/user-attachments/assets/d75150b1-f4a1-4259-b8a6-70bc83bf02d7" />


_Checkbox UI showing in Deno dependencies panel (to be added)_

## Test plan

- [x] Open notebook in a directory with node_modules and package.json
- [x] Verify checkbox appears in Deno dependencies panel, checked by default
- [x] Run `import * as Plot from "npm:@observablehq/plot"` — should work
- [x] Uncheck the box, restart kernel
- [x] Run same import — should fail with "Could not find matching package" error
- [x] Check box again, restart kernel — should work