### PR TITLE
Show conda UI when uv is not found

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -137,10 +137,11 @@ function AppContent() {
   } = useDenoDependencies();
 
   // Auto-detect environment type based on what's configured
-  // uv takes priority if metadata exists (even with empty deps)
-  const envType = isUvConfigured
+  // uv takes priority if metadata exists AND uv is available
+  // Falls back to conda if uv is not available
+  const envType = isUvConfigured && uvAvailable !== false
     ? "uv"
-    : isCondaConfigured
+    : isCondaConfigured || uvAvailable === false
       ? "conda"
       : null;
 

--- a/apps/notebook/src/components/DependencyHeader.tsx
+++ b/apps/notebook/src/components/DependencyHeader.tsx
@@ -83,11 +83,14 @@ export function DependencyHeader({
 
           {/* UV availability notice */}
           {uvAvailable === false && (
-            <div className="mb-3 rounded bg-amber-500/10 px-2 py-1.5 text-xs text-amber-700 dark:text-amber-400">
-              <span className="font-medium">uv not found.</span> Install it with{" "}
-              <code className="rounded bg-amber-500/20 px-1">
-                curl -LsSf https://astral.sh/uv/install.sh | sh
-              </code>
+            <div className="mb-3 flex items-start gap-2 rounded bg-uv/10 px-2 py-1.5 text-xs text-uv">
+              <Info className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+              <span>
+                <span className="font-medium">uv not found.</span> Install it with{" "}
+                <code className="rounded bg-uv/20 px-1">
+                  curl -LsSf https://astral.sh/uv/install.sh | sh
+                </code>
+              </span>
             </div>
           )}
 


### PR DESCRIPTION
## Summary

When uv is unavailable, the app now shows the conda dependency header instead of a uv header with an error warning. This provides a clearer experience since the code will run normally using conda/rattler as a fallback.

Also improved the "uv not found" banner styling with an Info icon and uv-themed colors for consistency with other notices in the app.

## Changes

- **App.tsx**: Updated `envType` logic to check `uvAvailable` and fall back to conda when uv is not available
- **DependencyHeader.tsx**: Improved "uv not found" banner with Info icon and uv color theme

## Before

<img width="1212" height="862" alt="image" src="https://github.com/user-attachments/assets/a320d851-9c3f-4754-9474-055fec8a6941" />

## After  

<img width="1212" height="862" alt="image" src="https://github.com/user-attachments/assets/a920b546-0af6-4bcf-817b-cb11108492bf" />