### PR TITLE
Distinguish cell outputs with gradient ribbon and opacity

### DIFF
--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -213,39 +213,38 @@ export function CodeCell({
         onFocus={onFocus}
         gutterContent={gutterContent}
         rightGutterContent={rightGutterContent}
-      >
-        {/* Editor */}
-        <div>
-          <CodeMirrorEditor
-            ref={editorRef}
-            value={cell.source}
-            language={language}
-            onValueChange={onUpdateSource}
-            keyMap={keyMap}
-            extensions={[kernelCompletionExtension]}
-            placeholder="Enter code..."
-            className="min-h-[2rem]"
-            autoFocus={isFocused}
-          />
-        </div>
+        codeContent={
+          <>
+            {/* Editor */}
+            <div>
+              <CodeMirrorEditor
+                ref={editorRef}
+                value={cell.source}
+                language={language}
+                onValueChange={onUpdateSource}
+                keyMap={keyMap}
+                extensions={[kernelCompletionExtension]}
+                placeholder="Enter code..."
+                className="min-h-[2rem]"
+                autoFocus={isFocused}
+              />
+            </div>
 
-        {/* Page Payload (documentation from ? or ??) */}
-        {pagePayload && (
-          <div className="px-2 py-1">
-            <PagePayloadDisplay
-              data={pagePayload.data}
-              onDismiss={() => onClearPagePayload?.()}
-            />
-          </div>
-        )}
-
-        {/* Outputs */}
-        {cell.outputs.length > 0 && (
-          <div className="py-2">
-            <OutputArea outputs={cell.outputs} />
-          </div>
-        )}
-      </CellContainer>
+            {/* Page Payload (documentation from ? or ??) */}
+            {pagePayload && (
+              <div className="px-2 py-1">
+                <PagePayloadDisplay
+                  data={pagePayload.data}
+                  onDismiss={() => onClearPagePayload?.()}
+                />
+              </div>
+            )}
+          </>
+        }
+        outputContent={
+          cell.outputs.length > 0 ? <OutputArea outputs={cell.outputs} /> : undefined
+        }
+      />
 
       {/* History Search Dialog (Ctrl+R) */}
       <HistorySearchDialog

--- a/src/components/cell/gutter-colors.ts
+++ b/src/components/cell/gutter-colors.ts
@@ -3,6 +3,10 @@ export interface GutterColorConfig {
     default: string;
     focused: string;
   };
+  outputRibbon: {
+    default: string;
+    focused: string;
+  };
   background: {
     focused: string;
   };
@@ -18,6 +22,10 @@ export const defaultGutterColors: Record<string, GutterColorConfig> = {
       default: "bg-gray-200 dark:bg-gray-700",
       focused: "bg-sky-400 dark:bg-sky-600",
     },
+    outputRibbon: {
+      default: "bg-gradient-to-b from-gray-200/60 to-gray-200 dark:from-gray-700/60 dark:to-gray-700",
+      focused: "bg-gradient-to-b from-sky-400/60 to-sky-400 dark:from-sky-600/60 dark:to-sky-600",
+    },
     background: {
       focused: "bg-sky-50/20 dark:bg-sky-900/10",
     },
@@ -26,6 +34,10 @@ export const defaultGutterColors: Record<string, GutterColorConfig> = {
     ribbon: {
       default: "bg-gray-200 dark:bg-gray-700",
       focused: "bg-emerald-400 dark:bg-emerald-600",
+    },
+    outputRibbon: {
+      default: "bg-gradient-to-b from-gray-200/60 to-gray-200 dark:from-gray-700/60 dark:to-gray-700",
+      focused: "bg-gradient-to-b from-emerald-400/60 to-emerald-400 dark:from-emerald-600/60 dark:to-emerald-600",
     },
     background: {
       focused: "bg-emerald-50/20 dark:bg-emerald-900/10",
@@ -36,6 +48,10 @@ export const defaultGutterColors: Record<string, GutterColorConfig> = {
       default: "bg-blue-200 dark:bg-blue-800",
       focused: "bg-blue-400 dark:bg-blue-600",
     },
+    outputRibbon: {
+      default: "bg-gradient-to-b from-blue-200/60 to-blue-200 dark:from-blue-800/60 dark:to-blue-800",
+      focused: "bg-gradient-to-b from-blue-400/60 to-blue-400 dark:from-blue-600/60 dark:to-blue-600",
+    },
     background: {
       focused: "bg-blue-50/50 dark:bg-blue-900/30",
     },
@@ -45,6 +61,10 @@ export const defaultGutterColors: Record<string, GutterColorConfig> = {
       default: "bg-purple-200 dark:bg-purple-800",
       focused: "bg-purple-400 dark:bg-purple-600",
     },
+    outputRibbon: {
+      default: "bg-gradient-to-b from-purple-200/60 to-purple-200 dark:from-purple-800/60 dark:to-purple-800",
+      focused: "bg-gradient-to-b from-purple-400/60 to-purple-400 dark:from-purple-600/60 dark:to-purple-600",
+    },
     background: {
       focused: "bg-purple-50/50 dark:bg-purple-900/30",
     },
@@ -53,6 +73,10 @@ export const defaultGutterColors: Record<string, GutterColorConfig> = {
     ribbon: {
       default: "bg-rose-200 dark:bg-rose-800",
       focused: "bg-rose-400 dark:bg-rose-600",
+    },
+    outputRibbon: {
+      default: "bg-gradient-to-b from-rose-200/60 to-rose-200 dark:from-rose-800/60 dark:to-rose-800",
+      focused: "bg-gradient-to-b from-rose-400/60 to-rose-400 dark:from-rose-600/60 dark:to-rose-600",
     },
     background: {
       focused: "bg-rose-50/50 dark:bg-rose-900/30",
@@ -68,6 +92,10 @@ export const fallbackGutterColors: GutterColorConfig = {
   ribbon: {
     default: "bg-gray-200 dark:bg-gray-700",
     focused: "bg-gray-400 dark:bg-gray-500",
+  },
+  outputRibbon: {
+    default: "bg-gradient-to-b from-gray-200/60 to-gray-200 dark:from-gray-700/60 dark:to-gray-700",
+    focused: "bg-gradient-to-b from-gray-400/60 to-gray-400 dark:from-gray-500/60 dark:to-gray-500",
   },
   background: {
     focused: "bg-gray-50/50 dark:bg-gray-900/30",


### PR DESCRIPTION
## Summary

Adds visual distinction between code and output sections within cells:
- Output ribbon uses a gradient (60% opacity → solid) creating a subtle "crease" between sections
- Unfocused outputs fade to 70% opacity, making code the focus while outputs recede
- Ribbon heights match their content naturally instead of splitting equally

This reinforces the notebook-as-paper metaphor where code is primary and outputs are secondary results.

## Changes

- **CellContainer**: Restructured to inline ribbons with each content section for proper height matching; added opacity fade to unfocused outputs
- **gutter-colors**: Added `outputRibbon` config with gradient colors for all cell types
- **CodeCell**: Migrated from single `children` prop to `codeContent`/`outputContent` slots

## Screenshots!

<img width="1212" height="862" alt="image" src="https://github.com/user-attachments/assets/0a4dc6a7-eb01-45ad-b3b7-e278868d4395" />

<img width="1212" height="862" alt="image" src="https://github.com/user-attachments/assets/2a6165a0-1c6f-4364-8232-2cb12cf7e235" />


Co-Authored-By: QuillAid <261289082+quillaid@users.noreply.github.com>