### PR TITLE
Add clone notebook feature (File > Clone Notebook...)

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -55,6 +55,7 @@ function AppContent() {
     deleteCell,
     save,
     openNotebook,
+    cloneNotebook,
     dirty,
     appendOutput,
     setExecutionCount,
@@ -325,6 +326,17 @@ onKernelStarted: loadCondaDependencies,
       unlistenPromise.then((unlisten) => unlisten());
     };
   }, [openNotebook]);
+
+  // Clone notebook via native menu
+  useEffect(() => {
+    const unlistenPromise = listen("menu:clone", () => {
+      cloneNotebook();
+    });
+
+    return () => {
+      unlistenPromise.then((unlisten) => unlisten());
+    };
+  }, [cloneNotebook]);
 
   // Zoom controls via native menu
   useEffect(() => {

--- a/apps/notebook/src/hooks/useNotebook.ts
+++ b/apps/notebook/src/hooks/useNotebook.ts
@@ -138,6 +138,28 @@ export function useNotebook() {
     }
   }, []);
 
+  const cloneNotebook = useCallback(async () => {
+    try {
+      // Show Save dialog for the clone
+      const filePath = await saveDialog({
+        filters: [{ name: "Jupyter Notebook", extensions: ["ipynb"] }],
+        defaultPath: "Untitled-Clone.ipynb",
+      });
+
+      if (!filePath) {
+        return; // User cancelled
+      }
+
+      // Clone notebook with fresh env_id and save to path
+      await invoke("clone_notebook_to_path", { path: filePath });
+
+      // Open the cloned notebook in a new window
+      await invoke("open_notebook_in_new_window", { path: filePath });
+    } catch (e) {
+      console.error("clone_notebook failed:", e);
+    }
+  }, []);
+
   const appendOutput = useCallback(
     (cellId: string, output: JupyterOutput) => {
       setCells((prev) =>
@@ -193,6 +215,7 @@ export function useNotebook() {
     deleteCell,
     save,
     openNotebook,
+    cloneNotebook,
     dirty,
     appendOutput,
     setExecutionCount,

--- a/crates/notebook/src/menu.rs
+++ b/crates/notebook/src/menu.rs
@@ -6,6 +6,7 @@ pub const MENU_NEW_PYTHON_NOTEBOOK: &str = "new_python_notebook";
 pub const MENU_NEW_DENO_NOTEBOOK: &str = "new_deno_notebook";
 pub const MENU_OPEN: &str = "open";
 pub const MENU_SAVE: &str = "save";
+pub const MENU_CLONE_NOTEBOOK: &str = "clone_notebook";
 
 // Menu item IDs for zoom
 pub const MENU_ZOOM_IN: &str = "zoom_in";
@@ -64,6 +65,13 @@ pub fn create_menu(app: &AppHandle) -> tauri::Result<Menu<Wry>> {
         "Save",
         true,
         Some("CmdOrCtrl+S"),
+    )?)?;
+    file_menu.append(&MenuItem::with_id(
+        app,
+        MENU_CLONE_NOTEBOOK,
+        "Clone Notebook...",
+        true,
+        None::<&str>,
     )?)?;
     menu.append(&file_menu)?;
 


### PR DESCRIPTION
## Summary
Adds a new "Clone Notebook..." option to the File menu that creates a copy of the current notebook with a fresh environment, preserving all code and dependencies.

- Generates fresh `env_id` for environment isolation
- Clears outputs and execution counts 
- Preserves all cells and dependency configuration
- Opens clone in new window

<img width="197" height="154" alt="image" src="https://github.com/user-attachments/assets/5f3dbbdd-2a92-4f2c-adfb-5c540cdd3eff" />


## Implementation Details
- Backend command `clone_notebook_to_path` handles cloning logic
- Menu event emits to frontend which shows save dialog
- Reuses existing `open_notebook_in_new_window` pattern