### PR TITLE
Enable Tab/Shift-Tab indentation in CodeMirror editor

### DIFF
--- a/src/components/editor/codemirror-editor.tsx
+++ b/src/components/editor/codemirror-editor.tsx
@@ -205,7 +205,7 @@ export const CodeMirrorEditor = forwardRef<
     const { setContainer, view } = useCodeMirror({
       container: editorRef.current,
       basicSetup: false,
-      indentWithTab: false,
+      indentWithTab: true,
       extensions,
       maxHeight,
       value,


### PR DESCRIPTION
Enables Tab and Shift-Tab keys to properly indent and dedent code in notebook cells. Previously these keys were navigating between UI controls instead of indenting.

**Change:** Set `indentWithTab: true` in the CodeMirror editor configuration to enable the built-in `@codemirror/commands` indentation keybindings.

Co-Authored-By: QuillAid <261289082+quillaid@users.noreply.github.com>