### PR TITLE
Add UV environment dirty state tracking and Sync Now button

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -109,6 +109,8 @@ function AppContent() {
     needsKernelRestart,
     addDependency,
     removeDependency,
+    syncState,
+    syncNow,
     pyprojectInfo,
     pyprojectDeps,
     importFromPyproject,
@@ -438,6 +440,8 @@ onKernelStarted: loadCondaDependencies,
           needsKernelRestart={needsKernelRestart}
           onAdd={addDependency}
           onRemove={removeDependency}
+          syncState={syncState}
+          onSyncNow={syncNow}
           pyprojectInfo={pyprojectInfo}
           pyprojectDeps={pyprojectDeps}
           onImportFromPyproject={importFromPyproject}

--- a/apps/notebook/src/components/DependencyHeader.tsx
+++ b/apps/notebook/src/components/DependencyHeader.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback, type KeyboardEvent } from "react";
-import { X, Plus, Info, FileText, Download } from "lucide-react";
-import type { PyProjectInfo, PyProjectDeps } from "../hooks/useDependencies";
+import { X, Plus, Info, FileText, Download, RefreshCw } from "lucide-react";
+import type { PyProjectInfo, PyProjectDeps, EnvSyncState } from "../hooks/useDependencies";
 
 interface DependencyHeaderProps {
   dependencies: string[];
@@ -11,6 +11,9 @@ interface DependencyHeaderProps {
   needsKernelRestart: boolean;
   onAdd: (pkg: string) => Promise<void>;
   onRemove: (pkg: string) => Promise<void>;
+  // Environment sync state
+  syncState?: EnvSyncState | null;
+  onSyncNow?: () => Promise<boolean>;
   // pyproject.toml support
   pyprojectInfo?: PyProjectInfo | null;
   pyprojectDeps?: PyProjectDeps | null;
@@ -26,6 +29,8 @@ export function DependencyHeader({
   needsKernelRestart,
   onAdd,
   onRemove,
+  syncState,
+  onSyncNow,
   pyprojectInfo,
   pyprojectDeps,
   onImportFromPyproject,
@@ -78,6 +83,33 @@ export function DependencyHeader({
                 Restart kernel to use these dependencies. The current kernel
                 wasn&apos;t started with dependency management.
               </span>
+            </div>
+          )}
+
+          {/* Sync Now notice for dirty environment */}
+          {syncState?.status === "dirty" && onSyncNow && (
+            <div className="mb-3 flex items-center justify-between rounded bg-amber-500/10 px-2 py-1.5 text-xs text-amber-700 dark:text-amber-400">
+              <div className="flex items-center gap-2">
+                <Info className="h-3.5 w-3.5 shrink-0" />
+                <span>
+                  {syncState.added.length > 0 && (
+                    <span>{syncState.added.length} package{syncState.added.length > 1 ? "s" : ""} to install</span>
+                  )}
+                  {syncState.added.length > 0 && syncState.removed.length > 0 && ", "}
+                  {syncState.removed.length > 0 && (
+                    <span>{syncState.removed.length} removed (restart to uninstall)</span>
+                  )}
+                </span>
+              </div>
+              <button
+                type="button"
+                onClick={onSyncNow}
+                disabled={loading}
+                className="flex items-center gap-1 rounded bg-amber-600 px-2 py-0.5 text-white text-xs font-medium hover:bg-amber-700 transition-colors disabled:opacity-50"
+              >
+                <RefreshCw className={`h-3 w-3 ${loading ? "animate-spin" : ""}`} />
+                Sync Now
+              </button>
             </div>
           )}
 

--- a/crates/notebook/src/kernel.rs
+++ b/crates/notebook/src/kernel.rs
@@ -90,6 +90,8 @@ pub struct NotebookKernel {
     conda_environment: Option<CondaEnvironment>,
     /// Optional sender to notify execution queue when a cell finishes
     queue_tx: Option<mpsc::Sender<QueueCommand>>,
+    /// Dependencies the kernel was started with (for dirty state detection)
+    synced_dependencies: Option<Vec<String>>,
 }
 
 impl Default for NotebookKernel {
@@ -108,6 +110,7 @@ impl Default for NotebookKernel {
             uv_environment: None,
             conda_environment: None,
             queue_tx: None,
+            synced_dependencies: None,
         }
     }
 }
@@ -374,10 +377,13 @@ impl NotebookKernel {
     ///
     /// Creates an ephemeral virtual environment using uv with the specified
     /// dependencies, installs ipykernel, and launches the kernel from that environment.
+    ///
+    /// The `env_id` parameter enables per-notebook isolation for empty deps.
     pub async fn start_with_uv(
         &mut self,
         app: AppHandle,
         deps: &NotebookDependencies,
+        env_id: Option<&str>,
     ) -> Result<()> {
         // Shutdown existing kernel if any
         self.shutdown().await.ok();
@@ -385,7 +391,7 @@ impl NotebookKernel {
         info!("Preparing uv environment with deps: {:?}", deps.dependencies);
 
         // Prepare the uv environment
-        let env = crate::uv_env::prepare_environment(deps).await?;
+        let env = crate::uv_env::prepare_environment(deps, env_id).await?;
 
         // Reserve ports
         let ip = std::net::IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
@@ -627,6 +633,7 @@ impl NotebookKernel {
         self.shell_writer = Some(shell_writer);
         self._process = Some(process);
         self.uv_environment = Some(env);
+        self.synced_dependencies = Some(deps.dependencies.clone());
 
         info!("UV-managed kernel started: {}", kernel_id);
         Ok(())
@@ -1641,6 +1648,16 @@ impl NotebookKernel {
     /// Get a reference to the uv environment, if this kernel was started with uv.
     pub fn uv_environment(&self) -> Option<&UvEnvironment> {
         self.uv_environment.as_ref()
+    }
+
+    /// Get the dependencies this kernel was started with (for dirty state detection).
+    pub fn synced_dependencies(&self) -> Option<&Vec<String>> {
+        self.synced_dependencies.as_ref()
+    }
+
+    /// Update the synced dependencies after a sync operation.
+    pub fn set_synced_dependencies(&mut self, deps: Vec<String>) {
+        self.synced_dependencies = Some(deps);
     }
 
     /// Check if this kernel is running with a conda-managed environment.

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -20,6 +20,7 @@ use notebook_state::{FrontendCell, NotebookState};
 
 use log::info;
 use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use tauri::{Emitter, Manager};
@@ -38,6 +39,29 @@ struct GitInfo {
     branch: String,
     commit: String,
     description: Option<String>,
+}
+
+/// Environment sync state for dirty detection.
+#[derive(Serialize)]
+#[serde(tag = "status")]
+pub enum EnvSyncState {
+    /// Kernel is not running
+    #[serde(rename = "not_running")]
+    NotRunning,
+    /// Kernel is running but not UV-managed
+    #[serde(rename = "not_uv_managed")]
+    NotUvManaged,
+    /// Environment is in sync with declared dependencies
+    #[serde(rename = "synced")]
+    Synced,
+    /// Environment differs from declared dependencies
+    #[serde(rename = "dirty")]
+    Dirty {
+        /// Dependencies declared but not synced
+        added: Vec<String>,
+        /// Dependencies synced but no longer declared
+        removed: Vec<String>,
+    },
 }
 
 /// Get git information for the debug banner.
@@ -129,43 +153,59 @@ async fn save_notebook_as(
 
 /// Clone the current notebook for saving as a new file.
 /// Generates a fresh env_id and clears outputs/execution counts.
+/// If the kernel is running with a UV environment, copies it for fast startup.
 #[tauri::command]
 async fn clone_notebook_to_path(
     path: String,
-    state: tauri::State<'_, Arc<Mutex<NotebookState>>>,
+    notebook_state: tauri::State<'_, Arc<Mutex<NotebookState>>>,
+    kernel_state: tauri::State<'_, Arc<tokio::sync::Mutex<NotebookKernel>>>,
 ) -> Result<(), String> {
-    let state = state.lock().map_err(|e| e.to_string())?;
-
-    // Clone the notebook structure
-    let mut cloned_notebook = state.notebook.clone();
-
-    // Generate fresh env_id
+    // Generate fresh env_id upfront
     let new_env_id = uuid::Uuid::new_v4().to_string();
 
-    // Update runt metadata with new env_id
-    if let Some(runt_value) = cloned_notebook.metadata.additional.get_mut("runt") {
-        if let Some(obj) = runt_value.as_object_mut() {
-            obj.insert("env_id".to_string(), serde_json::json!(new_env_id));
-        }
-    }
+    // Clone notebook structure while holding the lock
+    let cloned_notebook = {
+        let state = notebook_state.lock().map_err(|e| e.to_string())?;
+        let mut cloned = state.notebook.clone();
 
-    // Also update conda env_id if present
-    if let Some(conda_value) = cloned_notebook.metadata.additional.get_mut("conda") {
-        if let Some(obj) = conda_value.as_object_mut() {
-            obj.insert("env_id".to_string(), serde_json::json!(new_env_id));
+        // Update runt metadata with new env_id
+        if let Some(runt_value) = cloned.metadata.additional.get_mut("runt") {
+            if let Some(obj) = runt_value.as_object_mut() {
+                obj.insert("env_id".to_string(), serde_json::json!(new_env_id.clone()));
+            }
         }
-    }
 
-    // Clear outputs and execution counts from all code cells
-    for cell in &mut cloned_notebook.cells {
-        if let nbformat::v4::Cell::Code {
-            outputs,
-            execution_count,
-            ..
-        } = cell
-        {
-            outputs.clear();
-            *execution_count = None;
+        // Also update conda env_id if present
+        if let Some(conda_value) = cloned.metadata.additional.get_mut("conda") {
+            if let Some(obj) = conda_value.as_object_mut() {
+                obj.insert("env_id".to_string(), serde_json::json!(new_env_id.clone()));
+            }
+        }
+
+        // Clear outputs and execution counts from all code cells
+        for cell in &mut cloned.cells {
+            if let nbformat::v4::Cell::Code {
+                outputs,
+                execution_count,
+                ..
+            } = cell
+            {
+                outputs.clear();
+                *execution_count = None;
+            }
+        }
+
+        cloned
+    };
+
+    // If kernel is running with UV env, copy it for fast clone startup
+    {
+        let kernel = kernel_state.lock().await;
+        if let Some(source_env) = kernel.uv_environment() {
+            // Copy the environment - ignore errors, clone will just create fresh env on start
+            if let Err(e) = uv_env::copy_environment(source_env, &new_env_id).await {
+                info!("Failed to copy environment for clone (will create fresh): {}", e);
+            }
         }
     }
 
@@ -532,9 +572,12 @@ async fn start_kernel_with_uv(
     notebook_state: tauri::State<'_, Arc<Mutex<NotebookState>>>,
     kernel_state: tauri::State<'_, Arc<tokio::sync::Mutex<NotebookKernel>>>,
 ) -> Result<(), String> {
-    let deps = {
+    let (deps, env_id) = {
         let state = notebook_state.lock().map_err(|e| e.to_string())?;
-        uv_env::extract_dependencies(&state.notebook.metadata)
+        (
+            uv_env::extract_dependencies(&state.notebook.metadata),
+            uv_env::extract_env_id(&state.notebook.metadata),
+        )
     };
 
     let deps = deps.ok_or_else(|| "No dependencies in notebook metadata".to_string())?;
@@ -546,7 +589,7 @@ async fn start_kernel_with_uv(
 
     let mut kernel = kernel_state.lock().await;
     kernel
-        .start_with_uv(app, &deps)
+        .start_with_uv(app, &deps, env_id.as_deref())
         .await
         .map_err(|e| e.to_string())
 }
@@ -569,6 +612,51 @@ async fn kernel_has_uv_env(
     Ok(kernel.has_uv_environment())
 }
 
+/// Get the sync state between declared dependencies and the running kernel's environment.
+#[tauri::command]
+async fn get_env_sync_state(
+    notebook_state: tauri::State<'_, Arc<Mutex<NotebookState>>>,
+    kernel_state: tauri::State<'_, Arc<tokio::sync::Mutex<NotebookKernel>>>,
+) -> Result<EnvSyncState, String> {
+    let declared_deps = {
+        let state = notebook_state.lock().map_err(|e| e.to_string())?;
+        uv_env::extract_dependencies(&state.notebook.metadata)
+            .map(|d| d.dependencies)
+            .unwrap_or_default()
+    };
+
+    let kernel = kernel_state.lock().await;
+
+    if !kernel.is_running() {
+        return Ok(EnvSyncState::NotRunning);
+    }
+
+    if !kernel.has_uv_environment() {
+        return Ok(EnvSyncState::NotUvManaged);
+    }
+
+    let synced_deps = kernel.synced_dependencies().cloned().unwrap_or_default();
+
+    // Compare as sets
+    let declared_set: HashSet<_> = declared_deps.iter().collect();
+    let synced_set: HashSet<_> = synced_deps.iter().collect();
+
+    let added: Vec<_> = declared_set
+        .difference(&synced_set)
+        .map(|s| (*s).clone())
+        .collect();
+    let removed: Vec<_> = synced_set
+        .difference(&declared_set)
+        .map(|s| (*s).clone())
+        .collect();
+
+    if added.is_empty() && removed.is_empty() {
+        Ok(EnvSyncState::Synced)
+    } else {
+        Ok(EnvSyncState::Dirty { added, removed })
+    }
+}
+
 /// Sync dependencies to the running kernel's uv environment.
 ///
 /// Installs any new/changed dependencies into the existing venv.
@@ -587,7 +675,7 @@ async fn sync_kernel_dependencies(
         return Ok(false);
     };
 
-    let kernel = kernel_state.lock().await;
+    let mut kernel = kernel_state.lock().await;
     let Some(env) = kernel.uv_environment() else {
         return Ok(false);
     };
@@ -600,6 +688,9 @@ async fn sync_kernel_dependencies(
     uv_env::sync_dependencies(env, &deps.dependencies)
         .await
         .map_err(|e| e.to_string())?;
+
+    // Update tracked synced dependencies after successful sync
+    kernel.set_synced_dependencies(deps.dependencies.clone());
 
     Ok(true)
 }
@@ -814,7 +905,8 @@ async fn start_default_uv_kernel(
     kernel_state: tauri::State<'_, Arc<tokio::sync::Mutex<NotebookKernel>>>,
 ) -> Result<(), String> {
     // Ensure uv metadata exists in the notebook (for legacy notebooks)
-    {
+    // Also extract env_id for per-notebook isolation
+    let env_id = {
         let mut state = notebook_state.lock().map_err(|e| e.to_string())?;
 
         if !state.notebook.metadata.additional.contains_key("uv") {
@@ -826,7 +918,9 @@ async fn start_default_uv_kernel(
             );
             state.dirty = true;
         }
-    }
+
+        uv_env::extract_env_id(&state.notebook.metadata)
+    };
 
     // Create minimal deps with just ipykernel
     let deps = uv_env::NotebookDependencies {
@@ -838,7 +932,7 @@ async fn start_default_uv_kernel(
 
     let mut kernel = kernel_state.lock().await;
     kernel
-        .start_with_uv(app, &deps)
+        .start_with_uv(app, &deps, env_id.as_deref())
         .await
         .map_err(|e| e.to_string())
 }
@@ -927,7 +1021,8 @@ async fn start_default_kernel(
         info!("uv is available, using uv for default kernel");
 
         // Ensure uv metadata exists in the notebook (for legacy notebooks)
-        {
+        // Also extract env_id for per-notebook isolation
+        let env_id = {
             let mut state = notebook_state.lock().map_err(|e| e.to_string())?;
 
             if !state.notebook.metadata.additional.contains_key("uv") {
@@ -939,7 +1034,9 @@ async fn start_default_kernel(
                 );
                 state.dirty = true;
             }
-        }
+
+            uv_env::extract_env_id(&state.notebook.metadata)
+        };
 
         // Create minimal deps with just ipykernel
         let deps = uv_env::NotebookDependencies {
@@ -949,7 +1046,7 @@ async fn start_default_kernel(
 
         let mut kernel = kernel_state.lock().await;
         kernel
-            .start_with_uv(app, &deps)
+            .start_with_uv(app, &deps, env_id.as_deref())
             .await
             .map_err(|e| e.to_string())?;
 
@@ -1566,6 +1663,7 @@ pub fn run(notebook_path: Option<PathBuf>, runtime: Runtime) -> anyhow::Result<(
             start_default_uv_kernel,
             is_kernel_running,
             kernel_has_uv_env,
+            get_env_sync_state,
             sync_kernel_dependencies,
             // Conda dependency management
             get_conda_dependencies,

--- a/crates/notebook/src/uv_env.rs
+++ b/crates/notebook/src/uv_env.rs
@@ -345,8 +345,8 @@ mod tests {
             requires_python: Some(">=3.10".to_string()),
         };
 
-        let hash1 = compute_env_hash(&deps);
-        let hash2 = compute_env_hash(&deps);
+        let hash1 = compute_env_hash(&deps, None);
+        let hash2 = compute_env_hash(&deps, None);
 
         assert_eq!(hash1, hash2);
     }
@@ -363,7 +363,7 @@ mod tests {
             requires_python: None,
         };
 
-        assert_eq!(compute_env_hash(&deps1), compute_env_hash(&deps2));
+        assert_eq!(compute_env_hash(&deps1, None), compute_env_hash(&deps2, None));
     }
 
     #[test]
@@ -378,6 +378,6 @@ mod tests {
             requires_python: None,
         };
 
-        assert_ne!(compute_env_hash(&deps1), compute_env_hash(&deps2));
+        assert_ne!(compute_env_hash(&deps1, None), compute_env_hash(&deps2, None));
     }
 }

--- a/crates/notebook/src/uv_env.rs
+++ b/crates/notebook/src/uv_env.rs
@@ -47,13 +47,35 @@ pub fn extract_dependencies(metadata: &nbformat::v4::Metadata) -> Option<Noteboo
     serde_json::from_value(uv_value.clone()).ok()
 }
 
+/// Extract the env_id from notebook metadata.
+///
+/// Looks for the `runt.env_id` field in the metadata's additional fields.
+pub fn extract_env_id(metadata: &nbformat::v4::Metadata) -> Option<String> {
+    let runt_value = metadata.additional.get("runt")?;
+    runt_value.get("env_id")?.as_str().map(|s| s.to_string())
+}
+
 /// Compute a cache key for the given dependencies.
-fn compute_env_hash(deps: &NotebookDependencies) -> String {
+///
+/// When deps are empty and env_id is provided, includes env_id in hash
+/// for per-notebook isolation. This ensures new notebooks get fresh
+/// environments while notebooks with dependencies can share cached envs.
+fn compute_env_hash(deps: &NotebookDependencies, env_id: Option<&str>) -> String {
     let mut hasher = Sha256::new();
 
     // Sort dependencies for consistent hashing
     let mut sorted_deps = deps.dependencies.clone();
     sorted_deps.sort();
+
+    // For empty deps, include env_id for per-notebook isolation
+    // This ensures new notebooks get their own environment
+    if sorted_deps.is_empty() {
+        if let Some(id) = env_id {
+            hasher.update(b"env_id:");
+            hasher.update(id.as_bytes());
+            hasher.update(b"\n");
+        }
+    }
 
     for dep in &sorted_deps {
         hasher.update(dep.as_bytes());
@@ -81,8 +103,15 @@ fn get_cache_dir() -> PathBuf {
 ///
 /// Uses cached environments when possible (keyed by dependency hash).
 /// If the cache doesn't exist or is invalid, creates a new environment.
-pub async fn prepare_environment(deps: &NotebookDependencies) -> Result<UvEnvironment> {
-    let hash = compute_env_hash(deps);
+///
+/// The `env_id` parameter enables per-notebook isolation for empty deps:
+/// - If deps are empty and env_id is provided, the env is unique to that notebook
+/// - If deps are non-empty, env_id is ignored and envs are shared by dep hash
+pub async fn prepare_environment(
+    deps: &NotebookDependencies,
+    env_id: Option<&str>,
+) -> Result<UvEnvironment> {
+    let hash = compute_env_hash(deps, env_id);
     let cache_dir = get_cache_dir();
     let venv_path = cache_dir.join(&hash);
 
@@ -221,6 +250,77 @@ pub async fn sync_dependencies(env: &UvEnvironment, deps: &[String]) -> Result<(
     }
 
     info!("Dependencies synced successfully");
+    Ok(())
+}
+
+/// Copy an existing UV environment to a new location for a cloned notebook.
+///
+/// This allows cloned notebooks to start with the source's environment
+/// already prepared, making kernel startup instant.
+pub async fn copy_environment(source: &UvEnvironment, new_env_id: &str) -> Result<UvEnvironment> {
+    let cache_dir = get_cache_dir();
+    let dest_path = cache_dir.join(new_env_id);
+
+    if dest_path.exists() {
+        // Already copied (shouldn't happen with UUIDs, but be safe)
+        info!("Clone environment already exists at {:?}", dest_path);
+        #[cfg(target_os = "windows")]
+        let python_path = dest_path.join("Scripts").join("python.exe");
+        #[cfg(not(target_os = "windows"))]
+        let python_path = dest_path.join("bin").join("python");
+
+        return Ok(UvEnvironment {
+            venv_path: dest_path,
+            python_path,
+        });
+    }
+
+    info!(
+        "Copying environment from {:?} to {:?}",
+        source.venv_path, dest_path
+    );
+
+    // Copy the entire venv directory
+    copy_dir_recursive(&source.venv_path, &dest_path).await?;
+
+    #[cfg(target_os = "windows")]
+    let python_path = dest_path.join("Scripts").join("python.exe");
+    #[cfg(not(target_os = "windows"))]
+    let python_path = dest_path.join("bin").join("python");
+
+    info!("Environment copied successfully");
+
+    Ok(UvEnvironment {
+        venv_path: dest_path,
+        python_path,
+    })
+}
+
+/// Recursively copy a directory.
+async fn copy_dir_recursive(src: &std::path::Path, dst: &std::path::Path) -> Result<()> {
+    tokio::fs::create_dir_all(dst).await?;
+    let mut entries = tokio::fs::read_dir(src).await?;
+
+    while let Some(entry) = entries.next_entry().await? {
+        let ty = entry.file_type().await?;
+        let src_path = entry.path();
+        let dst_path = dst.join(entry.file_name());
+
+        if ty.is_dir() {
+            Box::pin(copy_dir_recursive(&src_path, &dst_path)).await?;
+        } else if ty.is_symlink() {
+            // Preserve symlinks (important for venv structure)
+            let link_target = tokio::fs::read_link(&src_path).await?;
+            // On Unix, use symlink. On Windows, copy the file.
+            #[cfg(unix)]
+            tokio::fs::symlink(&link_target, &dst_path).await?;
+            #[cfg(windows)]
+            tokio::fs::copy(&src_path, &dst_path).await?;
+        } else {
+            tokio::fs::copy(&src_path, &dst_path).await?;
+        }
+    }
+
     Ok(())
 }
 

--- a/crates/notebook/tests/env_fallback.rs
+++ b/crates/notebook/tests/env_fallback.rs
@@ -97,7 +97,7 @@ async fn test_uv_environment_creation_with_no_deps() {
         requires_python: None,
     };
 
-    let result = uv_env::prepare_environment(&deps).await;
+    let result = uv_env::prepare_environment(&deps, None).await;
 
     assert!(result.is_ok(), "prepare_environment should succeed: {:?}", result.err());
 
@@ -129,8 +129,8 @@ async fn test_uv_environment_uses_cache_correctly() {
     };
 
     // Create environment twice
-    let env1 = uv_env::prepare_environment(&deps).await.expect("First prepare should succeed");
-    let env2 = uv_env::prepare_environment(&deps).await.expect("Second prepare should succeed");
+    let env1 = uv_env::prepare_environment(&deps, None).await.expect("First prepare should succeed");
+    let env2 = uv_env::prepare_environment(&deps, None).await.expect("Second prepare should succeed");
 
     // Same dependencies should result in same cached environment
     assert_eq!(


### PR DESCRIPTION
## Summary
Implements environment synchronization state tracking for UV kernels, giving users explicit control over when to install new dependencies. Shows a "Sync Now" button when declared deps differ from the running kernel's environment.

**Key features:**
- Track what deps each kernel started with for accurate dirty detection
- Hybrid isolation: new empty notebooks get per-notebook envs, others share by dep hash
- "Sync Now" button appears when deps are out of sync (manual sync, not auto)
- Clone notebooks now copy the source UV environment for fast startup

## Feature Demo
[Placeholder: Screenshot of "Sync Now" button appearing when dependencies added to running kernel]

[Placeholder: Screenshot showing per-notebook isolation in different notebook instances]

## Technical Details
- `synced_dependencies` field tracks what kernel started with
- `get_env_sync_state` compares declared vs synced deps
- Empty deps include `env_id` in hash for isolation
- `copy_environment` enables fast clones

This gives users visibility and control while the hybrid isolation prevents environment pollution during development without sacrificing efficiency for real dependency sets.

Co-Authored-By: QuillAid <261289082+quillaid@users.noreply.github.com>