### PR TITLE
Kill kernel process groups to clean up subprocesses

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3106,6 +3106,7 @@ dependencies = [
  "jupyter-protocol",
  "log",
  "nbformat",
+ "nix",
  "pathdiff",
  "petname",
  "pyproject-toml",

--- a/crates/notebook/Cargo.toml
+++ b/crates/notebook/Cargo.toml
@@ -44,6 +44,10 @@ toml = "0.8"
 pathdiff = "0.2"
 pyproject-toml = "0.13"
 
+# Unix process group support for kernel cleanup
+[target.'cfg(unix)'.dependencies]
+nix = { version = "0.30", features = ["signal", "process"] }
+
 # Conda environment support via rattler
 rattler = "0.39"
 rattler_cache = "0.6"


### PR DESCRIPTION
## Summary

Ensures that when kernels shut down, all child processes spawned by user code are also terminated by using Unix process groups.

- Kernels now create their own process group on spawn (Unix platforms)
- `shutdown()` sends SIGTERM to the entire process group for graceful cleanup
- `Drop` trait sends SIGKILL to the entire process group as a fallback
- Prevents orphaned processes from user code like `subprocess.run()` or shell commands

This complements runtimed/runt#80 (window/app exit cleanup) to ensure comprehensive process cleanup including subprocesses.