### PR TITLE
Sync native window theme with app preference

### DIFF
--- a/crates/notebook/capabilities/default.json
+++ b/crates/notebook/capabilities/default.json
@@ -7,6 +7,7 @@
     "core:default",
     "core:event:default",
     "core:webview:allow-set-webview-zoom",
+    "core:window:allow-set-theme",
     "dialog:default"
   ]
 }

--- a/crates/notebook/gen/schemas/capabilities.json
+++ b/crates/notebook/gen/schemas/capabilities.json
@@ -1,1 +1,1 @@
-{"default":{"identifier":"default","description":"Default capabilities for the notebook window","local":true,"windows":["main"],"permissions":["core:default","core:event:default","core:webview:allow-set-webview-zoom","dialog:default"]}}
+{"default":{"identifier":"default","description":"Default capabilities for the notebook window","local":true,"windows":["main"],"permissions":["core:default","core:event:default","core:webview:allow-set-webview-zoom","core:window:allow-set-theme","dialog:default"]}}

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "e2e:dev:shell": "docker compose --profile dev run --rm tauri-e2e-shell"
   },
   "dependencies": {
+    "@tauri-apps/api": "~2.5.0",
     "@codemirror/autocomplete": "^6.20.0",
     "@codemirror/commands": "^6.10.2",
     "@codemirror/lang-html": "^6.4.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       '@codemirror/view':
         specifier: ^6.39.12
         version: 6.39.13
+      '@tauri-apps/api':
+        specifier: ~2.5.0
+        version: 2.5.0
       '@uiw/codemirror-theme-github':
         specifier: ^4.25.4
         version: 4.25.4(@codemirror/language@6.12.1)(@codemirror/state@6.5.4)(@codemirror/view@6.39.13)
@@ -1993,6 +1996,9 @@ packages:
 
   '@tauri-apps/api@2.10.1':
     resolution: {integrity: sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw==}
+
+  '@tauri-apps/api@2.5.0':
+    resolution: {integrity: sha512-Ldux4ip+HGAcPUmuLT8EIkk6yafl5vK0P0c0byzAKzxJh7vxelVtdPONjfgTm96PbN24yjZNESY8CKo8qniluA==}
 
   '@tauri-apps/plugin-dialog@2.6.0':
     resolution: {integrity: sha512-q4Uq3eY87TdcYzXACiYSPhmpBA76shgmQswGkSVio4C82Sz2W4iehe9TnKYwbq7weHiL88Yw19XZm7v28+Micg==}
@@ -7312,6 +7318,8 @@ snapshots:
       vite: 6.4.1(@types/node@22.19.9)(jiti@2.6.1)(lightningcss@1.30.2)
 
   '@tauri-apps/api@2.10.1': {}
+
+  '@tauri-apps/api@2.5.0': {}
 
   '@tauri-apps/plugin-dialog@2.6.0':
     dependencies:


### PR DESCRIPTION
## Summary
Fixed a visual mismatch where the native window title bar would follow the macOS system theme while the app content followed the app's internal theme setting. Now both stay in sync.

## Changes
- Add Tauri window theme API integration using `getCurrentWindow().setTheme()`
- Explicitly set both `dark` and `light` classes on `<html>` so theme-aware components don't fall back to system detection
- Add Tauri API permission `core:window:allow-set-theme`

## Testing
- Toggle between Light/Dark/System themes while macOS is in different appearance modes
- Verify the title bar matches the app content
- When in "System" mode, changing macOS appearance should update both layers

## Before & After
[Theme sync comparison image could go here]