### PR TITLE
Improve runt ps output with language detection and prettier formatting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -453,6 +453,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
+
+[[package]]
 name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3653,6 +3659,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "papergrid"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ad43c07024ef767f9160710b3a6773976194758c7919b17e63b863db0bdf7fb"
+dependencies = [
+ "bytecount",
+ "fnv",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3710,7 +3727,7 @@ checksum = "31095ca1f396e3de32745f42b20deef7bc09077f918b085307e8eab6ddd8fb9c"
 dependencies = [
  "once_cell",
  "serde",
- "unicode-width",
+ "unicode-width 0.2.2",
  "unscanny",
  "version-ranges",
 ]
@@ -3731,7 +3748,7 @@ dependencies = [
  "serde",
  "smallvec",
  "thiserror 1.0.69",
- "unicode-width",
+ "unicode-width 0.2.2",
  "url",
  "urlencoding",
  "version-ranges",
@@ -5057,6 +5074,7 @@ dependencies = [
  "anyhow",
  "clap",
  "dirs 5.0.1",
+ "futures",
  "jupyter-protocol",
  "petname",
  "rpassword",
@@ -5064,6 +5082,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sidecar",
+ "tabled",
  "tokio",
  "uuid",
 ]
@@ -5986,6 +6005,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "tabled"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c998b0c8b921495196a48aabaf1901ff28be0760136e31604f7967b0792050e"
+dependencies = [
+ "papergrid",
+ "tabled_derive",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "tabled_derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c138f99377e5d653a371cdad263615634cfc8467685dfe8e73e2b8e98f44b17"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "tao"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6875,6 +6918,12 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"

--- a/crates/runt/Cargo.toml
+++ b/crates/runt/Cargo.toml
@@ -24,3 +24,5 @@ tokio = { version = "1", features = ["full"] }
 petname = "2"
 rpassword = "7"
 dirs = "5"
+tabled = "0.15"
+futures = "0.3"


### PR DESCRIPTION
Replaces the hard-to-read port number table with a clean, informative display showing kernel language, version, and connection file path. The output now uses the `tabled` crate for prettier box-drawing formatting.

**Changes:**
- Query kernel_info on shell channel to detect language and version
- Show kernel status (alive/unresponsive) via heartbeat check
- Parallelize kernel queries to avoid timeouts on many kernels
- Add `--verbose` flag to show port details when needed
- Update JSON output to include new fields for programmatic use


```
╭──────────────────────┬────────────┬─────────┬────────┬─────────────────────────────────────────────────────────────────────────────────╮
│ NAME                 │ LANGUAGE   │ VERSION │ STATUS │ CONNECTION FILE                                                                 │
├──────────────────────┼────────────┼─────────┼────────┼─────────────────────────────────────────────────────────────────────────────────┤
│ tasty-lizardfish     │ typescript │ 5.8.3   │ alive  │ ~/Library/Jupyter/runtime/runt-kernel-tasty-lizardfish.json     │
│ amenable-rattlesnake │ typescript │ 5.8.3   │ alive  │ ~/Library/Jupyter/runtime/runt-kernel-amenable-rattlesnake.json │
│ closing-pewee        │ typescript │ 5.8.3   │ alive  │ ~/Library/Jupyter/runtime/runt-kernel-closing-pewee.json        │
│ dedicated-tinamou    │ typescript │ 5.8.3   │ alive  │ ~/Library/Jupyter/runtime/runt-kernel-dedicated-tinamou.json    │
│ shining-longspur     │ typescript │ 5.8.3   │ alive  │ ~/Library/Jupyter/runtime/runt-kernel-shining-longspur.json     │
│ sincere-pig          │ typescript │ 5.8.3   │ alive  │ ~/Library/Jupyter/runtime/runt-kernel-sincere-pig.json          │
╰──────────────────────┴────────────┴─────────┴────────┴─────────────────────────────────────────────────────────────────────────────────╯
%                
```