### PR TITLE
Eliminate dark mode flash on app boot

### DIFF
--- a/apps/notebook/index.html
+++ b/apps/notebook/index.html
@@ -3,7 +3,31 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="dark light" />
     <title>notebook</title>
+    <script>
+      // Apply theme immediately to prevent flash of wrong color on boot
+      (function() {
+        var STORAGE_KEY = 'notebook-theme';
+        var theme;
+        try {
+          theme = localStorage.getItem(STORAGE_KEY);
+        } catch (e) {}
+
+        if (theme !== 'light' && theme !== 'dark' && theme !== 'system') {
+          theme = 'system';
+        }
+
+        var resolved = theme;
+        if (theme === 'system') {
+          resolved = window.matchMedia('(prefers-color-scheme: dark)').matches
+            ? 'dark'
+            : 'light';
+        }
+
+        document.documentElement.classList.add(resolved);
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/apps/notebook/src/index.css
+++ b/apps/notebook/src/index.css
@@ -83,6 +83,31 @@
   --ring: oklch(0.556 0 0);
 }
 
+/* Fallback: apply dark theme when system prefers dark and no explicit light class */
+@media (prefers-color-scheme: dark) {
+  :root:not(.light) {
+    --background: oklch(0.145 0 0);
+    --foreground: oklch(0.985 0 0);
+    --card: oklch(0.205 0 0);
+    --card-foreground: oklch(0.985 0 0);
+    --popover: oklch(0.205 0 0);
+    --popover-foreground: oklch(0.985 0 0);
+    --primary: oklch(0.922 0 0);
+    --primary-foreground: oklch(0.205 0 0);
+    --secondary: oklch(0.269 0 0);
+    --secondary-foreground: oklch(0.985 0 0);
+    --muted: oklch(0.269 0 0);
+    --muted-foreground: oklch(0.708 0 0);
+    --accent: oklch(0.269 0 0);
+    --accent-foreground: oklch(0.985 0 0);
+    --destructive: oklch(0.704 0.191 22.216);
+    --destructive-foreground: oklch(0.637 0.237 25.331);
+    --border: oklch(1 0 0 / 10%);
+    --input: oklch(1 0 0 / 15%);
+    --ring: oklch(0.556 0 0);
+  }
+}
+
 * {
   @apply border-border;
 }


### PR DESCRIPTION
Add inline theme script to HTML that synchronously applies the correct theme class before CSS renders, matching the user's stored preference or system setting. Also adds a CSS media query fallback to ensure dark colors apply even if JavaScript fails.

This eliminates the white flash visible when booting the app in dark mode.