### PR TITLE
Use settings for default notebook runtime

### DIFF
--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -1759,9 +1759,13 @@ fn spawn_new_notebook(runtime: Runtime) {
 ///
 /// If `notebook_path` is Some, opens that file. If None, creates a new empty notebook.
 /// The `runtime` parameter specifies which runtime to use for new notebooks.
-pub fn run(notebook_path: Option<PathBuf>, runtime: Runtime) -> anyhow::Result<()> {
+/// If None, falls back to user's default runtime from settings.
+pub fn run(notebook_path: Option<PathBuf>, runtime: Option<Runtime>) -> anyhow::Result<()> {
     env_logger::init();
     shell_env::load_shell_environment();
+
+    // Use provided runtime or fall back to user's default from settings
+    let runtime = runtime.unwrap_or_else(|| settings::load_settings().default_runtime);
 
     let initial_state = match notebook_path {
         Some(ref path) if path.exists() => {

--- a/crates/notebook/src/main.rs
+++ b/crates/notebook/src/main.rs
@@ -8,9 +8,9 @@ struct Args {
     /// Path to notebook file to open or create
     path: Option<PathBuf>,
 
-    /// Runtime for new notebooks (python, deno)
-    #[arg(long, short, default_value = "python")]
-    runtime: Runtime,
+    /// Runtime for new notebooks (python, deno). Falls back to user settings if not specified.
+    #[arg(long, short)]
+    runtime: Option<Runtime>,
 }
 
 fn main() {


### PR DESCRIPTION
When launching the notebook app without specifying a runtime, it now respects the user's default runtime setting from ~/.config/runt-notebook/settings.json instead of always defaulting to Python.

Users can set their default runtime to Deno by creating/updating their settings file with `"default_runtime": "deno"`, enabling faster startup for Deno notebooks from Spotlight/Raycast.

The explicit --runtime CLI flag still overrides settings, so scripted launches are unaffected.

Co-Authored-By: QuillAid <261289082+quillaid@users.noreply.github.com>