### PR TITLE
Reduce e2e test log verbosity

### DIFF
--- a/e2e/wdio.conf.js
+++ b/e2e/wdio.conf.js
@@ -33,7 +33,7 @@ export const config = {
   hostname: process.env.WEBDRIVER_HOST || "localhost",
   port: parseInt(process.env.WEBDRIVER_PORT || "4444", 10),
 
-  logLevel: "info",
+  logLevel: "warn",
 
   // Timeouts
   waitforTimeout: 10000,


### PR DESCRIPTION
Reduce WebdriverIO log level from 'info' to 'warn' to suppress verbose webdriver command logging. This declutters test output by removing entries like COMMAND, POST request details, and RESULT logs while preserving warnings and errors for debugging.