### PR TITLE
ci: fix weekly preview linux build by installing libxdo

### DIFF
--- a/.github/workflows/weekly-preview.yml
+++ b/.github/workflows/weekly-preview.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libxdo-dev
 
       - name: Set up Rust
         uses: dsherret/rust-toolchain-file@v1


### PR DESCRIPTION
## Summary
- add missing Linux system package `libxdo-dev` in weekly preview workflow
- align weekly preview dependency install with existing Linux CI workflows

## Why
The weekly preview Linux job fails at link time with:

`rust-lld: error: unable to find library -lxdo`

Installing `libxdo-dev` provides `-lxdo` and resolves the build failure.
