### PR TITLE
Support Ctrl+Enter to run cell and stay in same cell

### DIFF
--- a/apps/notebook/src/hooks/useCellKeyboardNavigation.ts
+++ b/apps/notebook/src/hooks/useCellKeyboardNavigation.ts
@@ -71,7 +71,6 @@ export function useCellKeyboardNavigation({
             key: "Mod-Enter",
             run: () => {
               onExecute();
-              onFocusNext("start");
               return true;
             },
           },

--- a/apps/notebook/src/hooks/useCellKeyboardNavigation.ts
+++ b/apps/notebook/src/hooks/useCellKeyboardNavigation.ts
@@ -74,6 +74,13 @@ export function useCellKeyboardNavigation({
               return true;
             },
           },
+          {
+            key: "Ctrl-Enter",
+            run: () => {
+              onExecute();
+              return true;
+            },
+          },
         ]
       : []),
     ...(onExecuteAndInsert


### PR DESCRIPTION
Add support for Ctrl+Enter (and Cmd+Enter on Mac) keyboard shortcut to run a cell without advancing to the next one, matching standard Jupyter notebook behavior.

Changes:
- Modified Mod-Enter to execute without focus change (Ctrl+Enter on Windows/Linux, Cmd+Enter on Mac)
- Added explicit Ctrl-Enter binding for Mac users who press physical Control key

This improves the notebook UX by allowing users to iterate on a cell multiple times without manually navigating back to it.