### PR TITLE
Add ipywidgets to default runtime dependencies

### DIFF
--- a/crates/notebook/src/conda_env.rs
+++ b/crates/notebook/src/conda_env.rs
@@ -221,6 +221,8 @@ pub async fn prepare_environment(
 
     // Add ipykernel (required for Jupyter)
     specs.push(MatchSpec::from_str("ipykernel", match_spec_options)?);
+    // Add ipywidgets for interactive widget support
+    specs.push(MatchSpec::from_str("ipywidgets", match_spec_options)?);
 
     // Add user dependencies
     for dep in &deps.dependencies {

--- a/crates/notebook/src/uv_env.rs
+++ b/crates/notebook/src/uv_env.rs
@@ -165,13 +165,14 @@ pub async fn prepare_environment(
         return Err(anyhow!("Failed to create virtual environment"));
     }
 
-    // Install ipykernel and dependencies
+    // Install ipykernel, ipywidgets, and dependencies
     let mut install_args = vec![
         "pip".to_string(),
         "install".to_string(),
         "--python".to_string(),
         python_path.to_string_lossy().to_string(),
         "ipykernel".to_string(),
+        "ipywidgets".to_string(),
     ];
 
     for dep in &deps.dependencies {
@@ -414,7 +415,7 @@ pub async fn create_prewarmed_environment() -> Result<UvEnvironment> {
         return Err(anyhow!("Failed to create prewarmed virtual environment"));
     }
 
-    // Install only ipykernel (no other dependencies)
+    // Install ipykernel and ipywidgets (no other dependencies)
     let install_status = tokio::process::Command::new("uv")
         .args([
             "pip",
@@ -422,6 +423,7 @@ pub async fn create_prewarmed_environment() -> Result<UvEnvironment> {
             "--python",
             &python_path.to_string_lossy(),
             "ipykernel",
+            "ipywidgets",
         ])
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())


### PR DESCRIPTION
Enables interactive widgets (sliders, buttons, progress bars, etc.) in notebooks without requiring explicit dependency declarations. Adds ipywidgets alongside ipykernel in both uv and conda/rattler environments for a better out-of-the-box experience.

Changes:
- Add ipywidgets to uv environment installation
- Add ipywidgets to prewarmed environment pool
- Add ipywidgets to conda environment specs