### PR TITLE
Sync font sizes between inline and isolated renderer outputs

### DIFF
--- a/src/components/outputs/isolated/frame-html.ts
+++ b/src/components/outputs/isolated/frame-html.ts
@@ -80,10 +80,10 @@ export function generateFrameHtml(options: FrameHtmlOptions = {}): string {
       min-height: 1px;
     }
 
-    /* Reset common elements */
+    /* Reset common elements - 0.875rem matches Tailwind's text-sm */
     pre, code {
       font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace;
-      font-size: 13px;
+      font-size: 0.875rem;
     }
 
     pre {
@@ -96,11 +96,11 @@ export function generateFrameHtml(options: FrameHtmlOptions = {}): string {
       word-wrap: break-word;
     }
 
-    /* Table styling for pandas DataFrames */
+    /* Table styling for pandas DataFrames - 0.875rem matches Tailwind's text-sm */
     table {
       border-collapse: collapse;
       margin: 8px 0;
-      font-size: 13px;
+      font-size: 0.875rem;
     }
 
     th, td {

--- a/src/isolated-renderer/styles.css
+++ b/src/isolated-renderer/styles.css
@@ -110,9 +110,9 @@ body {
   padding: 8px;
 }
 
-/* Code font */
+/* Code font - uses Tailwind's text-sm to match main app output styling */
 pre, code {
-  font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace;
+  @apply font-mono text-sm;
 }
 
 /* Output item spacing */


### PR DESCRIPTION
## Summary

Stream outputs use Tailwind's `text-sm` (0.875rem), but isolated iframe outputs hardcoded 13px, causing inconsistent font sizes. This fix synchronizes font sizing across both rendering paths.

**Changes:**
- React renderer now uses `@apply font-mono text-sm` to leverage Tailwind's typography
- Bootstrap HTML updated to match with explicit 0.875rem for `pre`, `code`, and `table` elements

## Testing
- All 269 tests pass
- Isolated renderer bundle rebuilds successfully
- Tested both React and inline renderer paths

**Before:** Stream outputs appeared larger than table/code in isolated outputs  
**After:** Consistent 0.875rem font size across all output types