### PR TITLE
Streamline development workflow with xtask commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,33 +92,30 @@ pnpm build
 cargo build --release
 ```
 
-### UI development
+### Development workflows
 
-Both apps share components from `src/`. Changes there are reflected in both.
+| Workflow | Command | Use when |
+|----------|---------|----------|
+| Hot reload | `cargo xtask dev` | Iterating on React UI |
+| Debug build | `cargo xtask build` | Testing without dev server |
+| Build and run | `cargo xtask run notebook.ipynb` | Quick manual testing |
+| Release .app | `cargo xtask build-app` | Testing app bundle locally |
+| Release DMG | `cargo xtask build-dmg` | Distribution (usually CI) |
+
+**Hot reload** connects to Vite dev server (port 5174) for instant UI updates.
+
+**Debug builds** skip DMG creation for fast iteration. Ideal when:
+- Working with multiple worktrees (avoids port conflicts)
+- Testing Rust changes
+- Don't need hot reload
+
+### Sidecar UI development
 
 ```bash
-# Notebook UI with hot reload (runs Vite dev server + Tauri)
-cargo tauri dev -- -p notebook
-
-# Sidecar UI dev server (for styling/component work)
 pnpm --dir apps/sidecar dev
 ```
 
-### Running without the dev server
-
-When working with multiple worktrees or when you don't need Vite hot reload, build the frontend and run a debug Tauri build:
-
-```bash
-pnpm notebook:build && cargo tauri build --debug && ./target/debug/notebook
-```
-
-This avoids port conflicts since `cargo tauri dev` binds to a fixed port (5174) for the Vite dev server. The debug build uses the pre-built assets from `apps/notebook/dist/` instead of connecting to a dev server.
-
-To open a specific notebook:
-
-```bash
-./target/debug/notebook path/to/notebook.ipynb
-```
+Both apps share components from `src/`. Changes there are reflected in both.
 
 ### Adding shadcn components
 

--- a/contributing/development.md
+++ b/contributing/development.md
@@ -1,0 +1,70 @@
+# Development Guide
+
+## Quick Reference
+
+| Task | Command |
+|------|---------|
+| Start dev server | `cargo xtask dev` |
+| Quick debug build | `cargo xtask build` |
+| Build and run | `cargo xtask run` |
+| Run with notebook | `cargo xtask run path/to/notebook.ipynb` |
+| Build release .app | `cargo xtask build-app` |
+| Build release DMG | `cargo xtask build-dmg` |
+
+## Choosing a Workflow
+
+### `cargo xtask dev` — Hot Reload
+
+Best for UI/React development. Uses Vite dev server on port 5174. Changes to React components hot-reload instantly.
+
+```bash
+cargo xtask dev
+```
+
+### `cargo xtask build` / `run` — Debug Build
+
+Best for:
+- Testing Rust changes
+- Multiple worktrees (avoids port 5174 conflicts)
+- Quick manual testing
+
+Builds a debug binary without DMG creation.
+
+```bash
+# Build only
+cargo xtask build
+
+# Build and run
+cargo xtask run
+
+# Build and run with a notebook
+cargo xtask run notebooks/test-isolation.ipynb
+```
+
+### `cargo xtask build-app` / `build-dmg` — Release Builds
+
+Mostly handled by CI for preview releases. Use locally only when testing:
+- App bundle structure
+- File associations
+- Icons
+
+## Build Order
+
+The UI must be built before Rust because:
+- `crates/sidecar` embeds assets from `apps/sidecar/dist/` at compile time via rust-embed
+- `crates/notebook` embeds assets from `apps/notebook/dist/` via Tauri
+
+The xtask commands handle this automatically. If building manually:
+
+```bash
+pnpm build          # Build all UIs (isolated-renderer, sidecar, notebook)
+cargo build         # Build Rust
+```
+
+## Test Notebooks
+
+The `notebooks/` directory has test files:
+
+```bash
+cargo xtask run notebooks/test-isolation.ipynb
+```


### PR DESCRIPTION
## Summary

Add four new xtask commands to provide a cleaner dev loop now that `cargo tauri build` creates DMGs by default.

- `cargo xtask dev` - Hot-reload dev server with isolated renderer pre-build
- `cargo xtask build` - Quick debug build without DMG (uses `--no-bundle --debug`)
- `cargo xtask run [notebook]` - Build and run debug app
- `cargo xtask watch-isolated` - Watch and auto-rebuild isolated renderer

Replaces confusing manual commands like `pnpm notebook:build && cargo tauri build --debug` with clear xtask wrappers that organize by use case.

Update README with workflow table and add `contributing/development.md` guide for day-to-day development.

## Changes

- **crates/xtask/src/main.rs** - Add dev, build, run, watch-isolated commands with organized help text
- **README.md** - Replace "Running without the dev server" section with clearer workflow table
- **contributing/development.md** - New guide explaining when to use each workflow

All tests pass, no breaking changes to existing commands.