### PR TITLE
Clean up verbose logging in E2E tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,8 +125,8 @@ jobs:
 
       - name: Run E2E security tests
         run: |
-          # Start Xvfb
-          Xvfb :99 -screen 0 1920x1080x24 &
+          # Start Xvfb (suppress xkbcomp keysym warnings)
+          Xvfb :99 -screen 0 1920x1080x24 2>/dev/null &
           export DISPLAY=:99
           sleep 2
 
@@ -144,3 +144,7 @@ jobs:
           exit ${TEST_EXIT:-0}
         env:
           TAURI_APP_PATH: ./target/release/notebook
+          # Suppress accessibility bus warnings in headless CI
+          NO_AT_BRIDGE: 1
+          # Use software rendering to suppress GPU/EGL warnings
+          LIBGL_ALWAYS_SOFTWARE: 1

--- a/e2e/specs/backspace-delete-cell.spec.js
+++ b/e2e/specs/backspace-delete-cell.spec.js
@@ -13,12 +13,13 @@ import { browser, expect } from "@wdio/globals";
 async function takeScreenshot(name) {
   const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
   const safeName = name.replace(/[^a-zA-Z0-9]/g, "-");
-  const screenshotPath = `/app/e2e-screenshots/${safeName}-${timestamp}.png`;
+  const screenshotDir = process.env.E2E_SCREENSHOT_DIR || "./e2e-screenshots";
+  const screenshotPath = `${screenshotDir}/${safeName}-${timestamp}.png`;
   try {
     await browser.saveScreenshot(screenshotPath);
     console.log(`Screenshot saved: ${screenshotPath}`);
   } catch (error) {
-    console.error(`Failed to save screenshot "${name}":`, error.message);
+    console.log(`Screenshot skipped (${name}): ${error.message}`);
   }
 }
 

--- a/e2e/specs/notebook-execution.spec.js
+++ b/e2e/specs/notebook-execution.spec.js
@@ -13,12 +13,13 @@ import { browser, expect } from "@wdio/globals";
 async function takeScreenshot(name) {
   const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
   const safeName = name.replace(/[^a-zA-Z0-9]/g, "-");
-  const screenshotPath = `/app/e2e-screenshots/${safeName}-${timestamp}.png`;
+  const screenshotDir = process.env.E2E_SCREENSHOT_DIR || "./e2e-screenshots";
+  const screenshotPath = `${screenshotDir}/${safeName}-${timestamp}.png`;
   try {
     await browser.saveScreenshot(screenshotPath);
     console.log(`Screenshot saved: ${screenshotPath}`);
   } catch (error) {
-    console.error(`Failed to save screenshot "${name}":`, error.message);
+    console.log(`Screenshot skipped (${name}): ${error.message}`);
   }
 }
 

--- a/e2e/wdio.conf.js
+++ b/e2e/wdio.conf.js
@@ -2,11 +2,20 @@
  * WebDriverIO configuration for Tauri E2E testing
  */
 
+import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+
+// Screenshot directory: configurable via env, defaults to ./e2e-screenshots
+const SCREENSHOT_DIR =
+  process.env.E2E_SCREENSHOT_DIR || path.join(__dirname, "..", "e2e-screenshots");
+const SCREENSHOT_FAILURES_DIR = path.join(SCREENSHOT_DIR, "failures");
+
+// Ensure screenshot directories exist
+fs.mkdirSync(SCREENSHOT_FAILURES_DIR, { recursive: true });
 
 export const config = {
   runner: "local",
@@ -57,7 +66,10 @@ export const config = {
     if (error) {
       const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
       const safeName = test.title.replace(/[^a-zA-Z0-9]/g, "-").slice(0, 50);
-      const screenshotPath = `/app/e2e-screenshots/failures/${safeName}-${timestamp}.png`;
+      const screenshotPath = path.join(
+        SCREENSHOT_FAILURES_DIR,
+        `${safeName}-${timestamp}.png`
+      );
       try {
         const { browser } = await import("@wdio/globals");
         await browser.saveScreenshot(screenshotPath);


### PR DESCRIPTION
Suppress non-actionable warnings and fix root causes of repeated errors in E2E test output:

- Check uv availability before prewarming to avoid 3x ERROR messages per test
- Make screenshot directory configurable via `E2E_SCREENSHOT_DIR` env var and auto-create directories
- Suppress xkbcomp keysym warnings in CI by redirecting Xvfb stderr
- Suppress AT-SPI accessibility warnings and GPU/EGL warnings in headless CI environments

These changes make E2E test logs significantly more readable while maintaining full functionality.