### PR TITLE
Add conda environment prewarming for instant kernel startup

### DIFF
--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -246,7 +246,7 @@ export function NotebookToolbar({
               )}
             />
             <span className="text-xs text-muted-foreground">
-              {envProgress ? envProgress.statusText : (
+              {envProgress?.isActive ? envProgress.statusText : (
                 <span className="capitalize">{kernelStatus}</span>
               )}
             </span>

--- a/crates/notebook/src/conda_env.rs
+++ b/crates/notebook/src/conda_env.rs
@@ -883,6 +883,408 @@ pub async fn clear_cache() -> Result<()> {
     Ok(())
 }
 
+// =============================================================================
+// Prewarming support
+// =============================================================================
+
+/// Create a prewarmed conda environment with just ipykernel installed.
+///
+/// This creates a generic environment at a temporary path (`prewarm-{uuid}`)
+/// that can later be claimed by a notebook using `claim_prewarmed_conda_environment`.
+/// The environment has no `env_id` in its hash, allowing it to be reused by any notebook.
+pub async fn create_prewarmed_conda_environment(
+    app: Option<&AppHandle>,
+) -> Result<CondaEnvironment> {
+    let temp_id = format!("prewarm-{}", uuid::Uuid::new_v4());
+    let cache_dir = get_cache_dir();
+    let env_path = cache_dir.join(&temp_id);
+
+    // Determine python path based on platform
+    #[cfg(target_os = "windows")]
+    let python_path = env_path.join("python.exe");
+    #[cfg(not(target_os = "windows"))]
+    let python_path = env_path.join("bin").join("python");
+
+    info!("[prewarm] Creating prewarmed conda environment at {:?}", env_path);
+
+    // Ensure cache directory exists
+    tokio::fs::create_dir_all(&cache_dir).await?;
+
+    // Create minimal dependencies (just ipykernel)
+    let deps = CondaDependencies {
+        dependencies: vec!["ipykernel".to_string(), "ipywidgets".to_string()],
+        channels: vec!["conda-forge".to_string()],
+        python: None, // Use default Python version
+        env_id: None, // No env_id for prewarmed envs
+    };
+
+    // Reuse the core environment creation logic
+    create_environment_at_path(&env_path, &deps, app).await?;
+
+    info!("[prewarm] Prewarmed conda environment created at {:?}", env_path);
+
+    Ok(CondaEnvironment {
+        env_path,
+        python_path,
+    })
+}
+
+/// Internal function to create a conda environment at a specific path.
+///
+/// This is the core rattler solve/install logic extracted for reuse.
+async fn create_environment_at_path(
+    env_path: &std::path::Path,
+    deps: &CondaDependencies,
+    app: Option<&AppHandle>,
+) -> Result<()> {
+    // Setup channel configuration
+    let cache_dir = get_cache_dir();
+    let channel_config = ChannelConfig::default_with_root_dir(cache_dir.clone());
+
+    // Parse channels (default to conda-forge if none specified)
+    let channels: Vec<Channel> = if deps.channels.is_empty() {
+        vec![Channel::from_str("conda-forge", &channel_config)?]
+    } else {
+        deps.channels
+            .iter()
+            .map(|c| Channel::from_str(c, &channel_config))
+            .collect::<Result<Vec<_>, _>>()?
+    };
+
+    emit_progress(app, EnvProgressPhase::FetchingRepodata {
+        channels: deps.channels.clone(),
+    });
+
+    // Build specs: base packages plus dependencies
+    let match_spec_options = ParseMatchSpecOptions::strict();
+    let mut specs: Vec<MatchSpec> = vec![
+        MatchSpec::from_str("ipykernel", match_spec_options)?,
+        MatchSpec::from_str("ipywidgets", match_spec_options)?,
+    ];
+
+    // Add python version constraint if specified
+    if let Some(ref py_version) = deps.python {
+        let py_spec = format!("python>={}", py_version);
+        specs.push(MatchSpec::from_str(&py_spec, match_spec_options)?);
+    }
+
+    // Add user dependencies
+    for dep in &deps.dependencies {
+        if dep != "ipykernel" && dep != "ipywidgets" {
+            specs.push(MatchSpec::from_str(dep, match_spec_options)?);
+        }
+    }
+
+    emit_progress(app, EnvProgressPhase::Solving { spec_count: specs.len() });
+
+    // Find rattler cache directory
+    let rattler_cache_dir = default_cache_dir()
+        .map_err(|e| anyhow!("could not determine rattler cache directory: {}", e))?;
+
+    // Create HTTP client
+    let download_client = reqwest::Client::builder().build()?;
+    let download_client = reqwest_middleware::ClientBuilder::new(download_client).build();
+
+    // Create gateway for fetching repodata
+    let gateway = Gateway::builder()
+        .with_cache_dir(rattler_cache_dir.join(rattler_cache::REPODATA_CACHE_DIR))
+        .with_package_cache(PackageCache::new(
+            rattler_cache_dir.join(rattler_cache::PACKAGE_CACHE_DIR),
+        ))
+        .with_client(download_client.clone())
+        .finish();
+
+    // Query repodata with retry logic
+    let install_platform = Platform::current();
+    let platforms = vec![install_platform, Platform::NoArch];
+
+    let repodata_start = std::time::Instant::now();
+    const MAX_RETRIES: u32 = 3;
+    const INITIAL_DELAY_MS: u64 = 1000;
+
+    let mut last_error = None;
+    let mut repo_data = None;
+
+    for attempt in 0..MAX_RETRIES {
+        if attempt > 0 {
+            let delay_ms = INITIAL_DELAY_MS * (1 << (attempt - 1));
+            info!(
+                "Retrying repodata fetch (attempt {}/{}) after {}ms...",
+                attempt + 1,
+                MAX_RETRIES,
+                delay_ms
+            );
+            tokio::time::sleep(tokio::time::Duration::from_millis(delay_ms)).await;
+        }
+
+        match gateway
+            .query(channels.clone(), platforms.clone(), specs.clone())
+            .recursive(true)
+            .await
+        {
+            Ok(data) => {
+                repo_data = Some(data);
+                break;
+            }
+            Err(e) => {
+                let error_str = e.to_string();
+                let is_retryable = error_str.contains("500")
+                    || error_str.contains("502")
+                    || error_str.contains("503")
+                    || error_str.contains("504")
+                    || error_str.contains("timeout")
+                    || error_str.contains("connection");
+
+                if is_retryable && attempt < MAX_RETRIES - 1 {
+                    info!(
+                        "Transient error fetching repodata (attempt {}): {}",
+                        attempt + 1,
+                        error_str
+                    );
+                    last_error = Some(e);
+                    continue;
+                }
+                emit_progress(app, EnvProgressPhase::Error {
+                    message: format!("Failed to fetch package metadata: {}", e),
+                });
+                return Err(anyhow!("Failed to fetch package metadata: {}", e));
+            }
+        }
+    }
+
+    let repo_data = repo_data.ok_or_else(|| {
+        let msg = format!(
+            "Failed to fetch package metadata after {} retries: {}",
+            MAX_RETRIES,
+            last_error.map(|e| e.to_string()).unwrap_or_else(|| "unknown error".to_string())
+        );
+        emit_progress(app, EnvProgressPhase::Error { message: msg.clone() });
+        anyhow!(msg)
+    })?;
+
+    let repodata_elapsed = repodata_start.elapsed();
+    let record_count: usize = repo_data.iter().map(|r| r.len()).sum();
+    info!(
+        "Fetched repodata with {} records in {:?}",
+        record_count, repodata_elapsed
+    );
+    emit_progress(app, EnvProgressPhase::RepodataComplete {
+        record_count,
+        elapsed_ms: repodata_elapsed.as_millis() as u64,
+    });
+
+    // Detect virtual packages
+    let virtual_packages = rattler_virtual_packages::VirtualPackage::detect(
+        &rattler_virtual_packages::VirtualPackageOverrides::default(),
+    )?
+    .iter()
+    .map(|vpkg| GenericVirtualPackage::from(vpkg.clone()))
+    .collect::<Vec<_>>();
+
+    // Solve dependencies
+    let solve_start = std::time::Instant::now();
+    info!("Solving dependencies for {} specs", specs.len());
+
+    let solver_task = SolverTask {
+        virtual_packages,
+        specs,
+        ..SolverTask::from_iter(&repo_data)
+    };
+
+    let solver_result = match resolvo::Solver.solve(solver_task) {
+        Ok(result) => result,
+        Err(e) => {
+            let msg = format!("Failed to solve dependencies: {}", e);
+            emit_progress(app, EnvProgressPhase::Error { message: msg.clone() });
+            return Err(anyhow!(msg));
+        }
+    };
+
+    let required_packages = solver_result.records;
+    let solve_elapsed = solve_start.elapsed();
+    info!(
+        "Solved {} packages in {:?}",
+        required_packages.len(),
+        solve_elapsed
+    );
+    emit_progress(app, EnvProgressPhase::SolveComplete {
+        package_count: required_packages.len(),
+        elapsed_ms: solve_elapsed.as_millis() as u64,
+    });
+
+    // Install packages
+    let install_start = std::time::Instant::now();
+    info!(
+        "Installing {} packages to {:?}",
+        required_packages.len(),
+        env_path
+    );
+    emit_progress(app, EnvProgressPhase::Installing {
+        total: required_packages.len(),
+    });
+
+    // Create progress reporter if we have an app handle
+    let reporter = app.map(|a| ProgressReporter::new(Some(a.clone())));
+
+    let installer = Installer::new()
+        .with_download_client(download_client)
+        .with_target_platform(install_platform);
+
+    let _result = if let Some(reporter) = reporter {
+        installer
+            .with_reporter(reporter)
+            .install(env_path, required_packages)
+            .await?
+    } else {
+        installer.install(env_path, required_packages).await?
+    };
+
+    let install_elapsed = install_start.elapsed();
+    info!(
+        "Conda environment ready at {:?} (install took {:?})",
+        env_path,
+        install_elapsed
+    );
+    emit_progress(app, EnvProgressPhase::InstallComplete {
+        elapsed_ms: install_elapsed.as_millis() as u64,
+    });
+
+    Ok(())
+}
+
+/// Claim a prewarmed conda environment for a specific notebook.
+///
+/// This moves the prewarmed environment to the correct cache location based
+/// on the notebook's `env_id`, so it will be found by `prepare_environment` later.
+pub async fn claim_prewarmed_conda_environment(
+    prewarmed: CondaEnvironment,
+    env_id: &str,
+) -> Result<CondaEnvironment> {
+    // Compute the hash that would be used for empty deps with this env_id
+    let deps = CondaDependencies {
+        dependencies: vec!["ipykernel".to_string()],
+        channels: vec!["conda-forge".to_string()],
+        python: None,
+        env_id: Some(env_id.to_string()),
+    };
+    let hash = compute_env_hash(&deps);
+    let cache_dir = get_cache_dir();
+    let dest_path = cache_dir.join(&hash);
+
+    // Determine python path based on platform
+    #[cfg(target_os = "windows")]
+    let python_path = dest_path.join("python.exe");
+    #[cfg(not(target_os = "windows"))]
+    let python_path = dest_path.join("bin").join("python");
+
+    // If destination already exists, just use it (race condition safety)
+    if dest_path.exists() {
+        info!(
+            "[prewarm] Destination already exists, removing prewarmed conda env at {:?}",
+            prewarmed.env_path
+        );
+        tokio::fs::remove_dir_all(&prewarmed.env_path).await.ok();
+        return Ok(CondaEnvironment {
+            env_path: dest_path,
+            python_path,
+        });
+    }
+
+    info!(
+        "[prewarm] Claiming prewarmed conda environment: {:?} -> {:?}",
+        prewarmed.env_path, dest_path
+    );
+
+    // Try to rename (fast if same filesystem)
+    match tokio::fs::rename(&prewarmed.env_path, &dest_path).await {
+        Ok(()) => {
+            info!("[prewarm] Conda environment claimed via rename");
+        }
+        Err(e) => {
+            // Rename failed (possibly cross-filesystem), fall back to copy+delete
+            info!(
+                "[prewarm] Rename failed ({}), falling back to copy",
+                e
+            );
+            copy_dir_recursive(&prewarmed.env_path, &dest_path).await?;
+            tokio::fs::remove_dir_all(&prewarmed.env_path).await.ok();
+            info!("[prewarm] Conda environment claimed via copy");
+        }
+    }
+
+    Ok(CondaEnvironment {
+        env_path: dest_path,
+        python_path,
+    })
+}
+
+/// Recursively copy a directory.
+async fn copy_dir_recursive(src: &std::path::Path, dst: &std::path::Path) -> Result<()> {
+    tokio::fs::create_dir_all(dst).await?;
+
+    let mut entries = tokio::fs::read_dir(src).await?;
+    while let Some(entry) = entries.next_entry().await? {
+        let src_path = entry.path();
+        let dst_path = dst.join(entry.file_name());
+
+        if entry.file_type().await?.is_dir() {
+            Box::pin(copy_dir_recursive(&src_path, &dst_path)).await?;
+        } else {
+            tokio::fs::copy(&src_path, &dst_path).await?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Find existing prewarmed conda environments from previous sessions.
+///
+/// Scans the cache directory for `prewarm-*` directories and validates
+/// they have a working Python binary. Returns valid environments that
+/// can be added to the pool on startup.
+pub async fn find_existing_prewarmed_conda_environments() -> Vec<CondaEnvironment> {
+    let cache_dir = get_cache_dir();
+    let mut found = Vec::new();
+
+    let Ok(mut entries) = tokio::fs::read_dir(&cache_dir).await else {
+        return found;
+    };
+
+    while let Ok(Some(entry)) = entries.next_entry().await {
+        let name = entry.file_name().to_string_lossy().to_string();
+        if !name.starts_with("prewarm-") {
+            continue;
+        }
+
+        let env_path = entry.path();
+
+        // Determine python path based on platform
+        #[cfg(target_os = "windows")]
+        let python_path = env_path.join("python.exe");
+        #[cfg(not(target_os = "windows"))]
+        let python_path = env_path.join("bin").join("python");
+
+        // Validate Python exists
+        if !python_path.exists() {
+            info!(
+                "[prewarm] Skipping invalid conda env (no python): {:?}",
+                env_path
+            );
+            // Clean up invalid environment
+            tokio::fs::remove_dir_all(&env_path).await.ok();
+            continue;
+        }
+
+        info!("[prewarm] Found existing prewarmed conda environment: {:?}", env_path);
+        found.push(CondaEnvironment {
+            env_path,
+            python_path,
+        });
+    }
+
+    found
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/notebook/src/env_pool.rs
+++ b/crates/notebook/src/env_pool.rs
@@ -450,7 +450,7 @@ impl CondaEnvPool {
 }
 
 /// Spawn a background task to replenish the conda pool after taking an environment.
-pub fn spawn_conda_replenishment(pool: SharedCondaEnvPool, app: AppHandle) {
+pub fn spawn_conda_replenishment(pool: SharedCondaEnvPool) {
     tokio::spawn(async move {
         // Check if we actually need to create one
         let should_create = {
@@ -468,7 +468,7 @@ pub fn spawn_conda_replenishment(pool: SharedCondaEnvPool, app: AppHandle) {
         }
 
         info!("[prewarm] Spawning immediate conda replenishment");
-        match crate::conda_env::create_prewarmed_conda_environment(Some(&app)).await {
+        match crate::conda_env::create_prewarmed_conda_environment(None).await {
             Ok(env) => {
                 let prewarmed = PrewarmedCondaEnv {
                     env_path: env.env_path,
@@ -531,7 +531,7 @@ pub async fn recover_existing_prewarmed_conda(pool: &SharedCondaEnvPool) {
 ///
 /// This function runs indefinitely, periodically checking the pool
 /// and creating new environments as needed to maintain the target size.
-pub async fn run_conda_prewarming_loop(pool: SharedCondaEnvPool, app: AppHandle) {
+pub async fn run_conda_prewarming_loop(pool: SharedCondaEnvPool) {
     // First, recover any existing prewarmed environments from disk
     recover_existing_prewarmed_conda(&pool).await;
 
@@ -557,7 +557,7 @@ pub async fn run_conda_prewarming_loop(pool: SharedCondaEnvPool, app: AppHandle)
             // Create environments sequentially (conda/rattler is resource-intensive)
             for i in 0..deficit {
                 info!("[prewarm] Creating conda env {}/{}", i + 1, deficit);
-                match crate::conda_env::create_prewarmed_conda_environment(Some(&app)).await {
+                match crate::conda_env::create_prewarmed_conda_environment(None).await {
                     Ok(env) => {
                         let prewarmed = PrewarmedCondaEnv {
                             env_path: env.env_path,

--- a/crates/notebook/src/env_pool.rs
+++ b/crates/notebook/src/env_pool.rs
@@ -47,7 +47,7 @@ impl Default for PoolConfig {
     fn default() -> Self {
         Self {
             pool_size: 3,
-            max_age_secs: 3600, // 1 hour
+            max_age_secs: 172800, // 2 days (ipykernel doesn't change often)
         }
     }
 }
@@ -333,6 +333,260 @@ pub async fn run_prewarming_loop(pool: SharedEnvPool, app: AppHandle) {
 fn emit_progress(app: &AppHandle, progress: PrewarmProgress) {
     if let Err(e) = app.emit("prewarm:progress", &progress) {
         error!("[prewarm] Failed to emit progress: {}", e);
+    }
+}
+
+// =============================================================================
+// Conda environment pool
+// =============================================================================
+
+use crate::conda_env::CondaEnvironment;
+
+/// A prewarmed conda environment ready for assignment to a notebook.
+#[derive(Debug, Clone)]
+pub struct PrewarmedCondaEnv {
+    /// Path to the conda environment directory.
+    pub env_path: PathBuf,
+    /// Path to the Python executable within the env.
+    pub python_path: PathBuf,
+    /// When this environment was created.
+    pub created_at: Instant,
+}
+
+impl PrewarmedCondaEnv {
+    /// Convert to a CondaEnvironment for kernel startup.
+    pub fn into_conda_environment(self) -> CondaEnvironment {
+        CondaEnvironment {
+            env_path: self.env_path,
+            python_path: self.python_path,
+        }
+    }
+}
+
+/// State of the conda prewarming pool.
+pub struct CondaEnvPool {
+    /// Available prewarmed conda environments.
+    pool: Vec<PrewarmedCondaEnv>,
+    /// Configuration.
+    config: PoolConfig,
+    /// Number of environments currently being created.
+    creating: usize,
+}
+
+/// Shared conda pool type for Tauri state management.
+pub type SharedCondaEnvPool = Arc<Mutex<CondaEnvPool>>;
+
+/// Current status of the conda pool for debugging/UI.
+#[derive(Debug, Clone, Serialize)]
+pub struct CondaPoolStatus {
+    /// Number of conda environments ready to use.
+    pub available: usize,
+    /// Number of conda environments currently being created.
+    pub creating: usize,
+    /// Target pool size.
+    pub target: usize,
+}
+
+impl CondaEnvPool {
+    /// Create a new conda environment pool with the given configuration.
+    pub fn new(config: PoolConfig) -> Self {
+        Self {
+            pool: Vec::with_capacity(config.pool_size),
+            config,
+            creating: 0,
+        }
+    }
+
+    /// Take a prewarmed conda environment from the pool.
+    ///
+    /// Returns `None` if no environments are available.
+    /// Automatically prunes stale environments before returning.
+    pub fn take(&mut self) -> Option<PrewarmedCondaEnv> {
+        self.prune_stale();
+        self.pool.pop()
+    }
+
+    /// Add a newly created prewarmed conda environment to the pool.
+    pub fn add(&mut self, env: PrewarmedCondaEnv) {
+        self.pool.push(env);
+        self.creating = self.creating.saturating_sub(1);
+    }
+
+    /// Mark that environment creation failed.
+    pub fn creation_failed(&mut self) {
+        self.creating = self.creating.saturating_sub(1);
+    }
+
+    /// Calculate how many environments need to be created to reach the target.
+    pub fn deficit(&self) -> usize {
+        let current = self.pool.len() + self.creating;
+        self.config.pool_size.saturating_sub(current)
+    }
+
+    /// Mark that we're starting to create N environments.
+    pub fn mark_creating(&mut self, count: usize) {
+        self.creating += count;
+    }
+
+    /// Remove environments that are older than the maximum age.
+    fn prune_stale(&mut self) {
+        let max_age = Duration::from_secs(self.config.max_age_secs);
+        let before = self.pool.len();
+        self.pool.retain(|e| e.created_at.elapsed() < max_age);
+        let removed = before - self.pool.len();
+        if removed > 0 {
+            info!("[prewarm] Pruned {} stale conda environments", removed);
+        }
+    }
+
+    /// Get the current status of the pool.
+    pub fn status(&self) -> CondaPoolStatus {
+        CondaPoolStatus {
+            available: self.pool.len(),
+            creating: self.creating,
+            target: self.config.pool_size,
+        }
+    }
+}
+
+/// Spawn a background task to replenish the conda pool after taking an environment.
+pub fn spawn_conda_replenishment(pool: SharedCondaEnvPool, app: AppHandle) {
+    tokio::spawn(async move {
+        // Check if we actually need to create one
+        let should_create = {
+            let mut p = pool.lock().await;
+            if p.deficit() > 0 {
+                p.mark_creating(1);
+                true
+            } else {
+                false
+            }
+        };
+
+        if !should_create {
+            return;
+        }
+
+        info!("[prewarm] Spawning immediate conda replenishment");
+        match crate::conda_env::create_prewarmed_conda_environment(Some(&app)).await {
+            Ok(env) => {
+                let prewarmed = PrewarmedCondaEnv {
+                    env_path: env.env_path,
+                    python_path: env.python_path,
+                    created_at: Instant::now(),
+                };
+                pool.lock().await.add(prewarmed);
+                info!("[prewarm] Conda replenishment complete");
+            }
+            Err(e) => {
+                error!("[prewarm] Conda replenishment failed: {}", e);
+                pool.lock().await.creation_failed();
+            }
+        }
+    });
+}
+
+/// Recover any existing prewarmed conda environments from disk.
+pub async fn recover_existing_prewarmed_conda(pool: &SharedCondaEnvPool) {
+    let recovered = crate::conda_env::find_existing_prewarmed_conda_environments().await;
+
+    if recovered.is_empty() {
+        info!("[prewarm] No existing prewarmed conda environments found");
+        return;
+    }
+
+    info!(
+        "[prewarm] Recovered {} existing prewarmed conda environments",
+        recovered.len()
+    );
+
+    let mut p = pool.lock().await;
+    for env in recovered {
+        // Only add up to the pool size
+        if p.pool.len() >= p.config.pool_size {
+            // Clean up extras we don't need
+            info!(
+                "[prewarm] Conda pool full, removing extra prewarmed env: {:?}",
+                env.env_path
+            );
+            tokio::fs::remove_dir_all(&env.env_path).await.ok();
+            continue;
+        }
+
+        let prewarmed = PrewarmedCondaEnv {
+            env_path: env.env_path,
+            python_path: env.python_path,
+            created_at: Instant::now(), // Treat as freshly created
+        };
+        p.pool.push(prewarmed);
+    }
+
+    info!(
+        "[prewarm] Conda pool initialized with {} environments",
+        p.pool.len()
+    );
+}
+
+/// Run the background conda prewarming loop.
+///
+/// This function runs indefinitely, periodically checking the pool
+/// and creating new environments as needed to maintain the target size.
+pub async fn run_conda_prewarming_loop(pool: SharedCondaEnvPool, app: AppHandle) {
+    // First, recover any existing prewarmed environments from disk
+    recover_existing_prewarmed_conda(&pool).await;
+
+    // Small delay to let the app finish startup before creating new envs
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    info!("[prewarm] Starting conda prewarming loop");
+
+    loop {
+        // Check what needs to be created
+        let deficit = {
+            let mut p = pool.lock().await;
+            let d = p.deficit();
+            if d > 0 {
+                p.mark_creating(d);
+            }
+            d
+        };
+
+        if deficit > 0 {
+            info!("[prewarm] Creating {} conda environments", deficit);
+
+            // Create environments sequentially (conda/rattler is resource-intensive)
+            for i in 0..deficit {
+                info!("[prewarm] Creating conda env {}/{}", i + 1, deficit);
+                match crate::conda_env::create_prewarmed_conda_environment(Some(&app)).await {
+                    Ok(env) => {
+                        let prewarmed = PrewarmedCondaEnv {
+                            env_path: env.env_path,
+                            python_path: env.python_path,
+                            created_at: Instant::now(),
+                        };
+                        pool.lock().await.add(prewarmed);
+                        info!("[prewarm] Created prewarmed conda environment");
+                    }
+                    Err(e) => {
+                        error!("[prewarm] Failed to create conda environment: {}", e);
+                        pool.lock().await.creation_failed();
+                    }
+                }
+            }
+        }
+
+        // Log status
+        {
+            let p = pool.lock().await;
+            let status = p.status();
+            info!(
+                "[prewarm] Conda pool status: {}/{} ready, {} creating",
+                status.available, status.target, status.creating
+            );
+        }
+
+        // Sleep before next check (longer interval for conda since it's expensive)
+        tokio::time::sleep(Duration::from_secs(60)).await;
     }
 }
 

--- a/crates/notebook/src/kernel.rs
+++ b/crates/notebook/src/kernel.rs
@@ -1555,6 +1555,277 @@ impl NotebookKernel {
         Ok(())
     }
 
+    /// Start a kernel using a prewarmed conda environment.
+    ///
+    /// This is similar to `start_with_conda` but skips environment preparation
+    /// since the environment is already ready from the prewarming pool.
+    pub async fn start_with_prewarmed_conda(
+        &mut self,
+        app: AppHandle,
+        env: CondaEnvironment,
+        notebook_path: Option<&std::path::Path>,
+    ) -> Result<()> {
+        // Shutdown existing kernel if any
+        self.shutdown().await.ok();
+
+        info!(
+            "Starting kernel with prewarmed conda environment at {:?}",
+            env.env_path
+        );
+
+        // Reserve ports
+        let ip = std::net::IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
+        let ports = runtimelib::peek_ports(ip, 5).await?;
+
+        let connection_info = ConnectionInfo {
+            transport: jupyter_protocol::connection_info::Transport::TCP,
+            ip: ip.to_string(),
+            stdin_port: ports[0],
+            control_port: ports[1],
+            hb_port: ports[2],
+            shell_port: ports[3],
+            iopub_port: ports[4],
+            signature_scheme: "hmac-sha256".to_string(),
+            key: Uuid::new_v4().to_string(),
+            kernel_name: Some("python3".to_string()),
+        };
+
+        let runtime_dir = runtimelib::dirs::runtime_dir();
+        tokio::fs::create_dir_all(&runtime_dir).await?;
+
+        let kernel_id: String =
+            petname::petname(2, "-").unwrap_or_else(|| Uuid::new_v4().to_string());
+        let connection_file_path = runtime_dir.join(format!("runt-kernel-{}.json", kernel_id));
+
+        tokio::fs::write(
+            &connection_file_path,
+            serde_json::to_string_pretty(&connection_info)?,
+        )
+        .await?;
+
+        info!(
+            "Starting prewarmed conda kernel at {:?} with python {:?}",
+            connection_file_path, env.python_path
+        );
+
+        // Spawn kernel using python from the prewarmed environment
+        let mut cmd = tokio::process::Command::new(&env.python_path);
+        cmd.args(["-m", "ipykernel_launcher", "-f"])
+            .arg(&connection_file_path)
+            .current_dir(kernel_cwd(notebook_path))
+            .stdout(Stdio::null())
+            .stderr(Stdio::null());
+        #[cfg(unix)]
+        cmd.process_group(0); // Create new process group for kernel and children
+        let process = cmd.kill_on_drop(true).spawn()?;
+
+        // Store process group ID for cleanup
+        #[cfg(unix)]
+        {
+            self.process_group_id = process.id().map(|pid| pid as i32);
+        }
+
+        // Small delay to let the kernel start
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
+        self.session_id = Uuid::new_v4().to_string();
+
+        // Create iopub connection and spawn listener
+        let mut iopub = runtimelib::create_client_iopub_connection(
+            &connection_info,
+            "",
+            &self.session_id,
+        )
+        .await?;
+
+        let app_handle = app.clone();
+        let cell_id_map = self.cell_id_map.clone();
+        let queue_tx = self.queue_tx.clone();
+        let iopub_task = tokio::spawn(async move {
+            loop {
+                match iopub.read().await {
+                    Ok(message) => {
+                        debug!(
+                            "iopub: type={} parent_msg_id={:?}",
+                            message.header.msg_type,
+                            message.parent_header.as_ref().map(|h| &h.msg_id)
+                        );
+
+                        // Look up cell_id from the msg_id → cell_id map
+                        let cell_id = message
+                            .parent_header
+                            .as_ref()
+                            .and_then(|h| cell_id_map.lock().ok()?.get(&h.msg_id).cloned());
+
+                        // Check for status: idle to signal execution completion
+                        if let JupyterMessageContent::Status(ref status) = message.content {
+                            if status.execution_state == jupyter_protocol::ExecutionState::Idle {
+                                if let Some(ref cid) = cell_id {
+                                    if let Some(ref tx) = queue_tx {
+                                        let _ = tx.try_send(QueueCommand::ExecutionDone {
+                                            cell_id: cid.clone(),
+                                        });
+                                    }
+                                }
+                            }
+                        }
+
+                        let tauri_msg = TauriJupyterMessage {
+                            header: message.header,
+                            parent_header: message.parent_header,
+                            metadata: message.metadata,
+                            content: message.content,
+                            buffers: message.buffers,
+                            channel: message.channel,
+                            cell_id,
+                        };
+
+                        if let Err(e) = app_handle.emit("kernel:iopub", &tauri_msg) {
+                            error!("Failed to emit kernel:iopub: {}", e);
+                            break;
+                        }
+                    }
+                    Err(e) => {
+                        error!("iopub read error: {}", e);
+                        break;
+                    }
+                }
+            }
+        });
+
+        // Create persistent shell connection
+        let identity = runtimelib::peer_identity_for_session(&self.session_id)?;
+        let mut shell = runtimelib::create_client_shell_connection_with_identity(
+            &connection_info,
+            &self.session_id,
+            identity,
+        )
+        .await?;
+
+        // Verify kernel is alive with kernel_info handshake
+        let request: JupyterMessage = KernelInfoRequest::default().into();
+        shell.send(request).await?;
+
+        let reply = tokio::time::timeout(std::time::Duration::from_secs(30), shell.read()).await;
+        match reply {
+            Ok(Ok(msg)) => {
+                info!("Prewarmed conda kernel alive: got {} reply", msg.header.msg_type);
+            }
+            Ok(Err(e)) => {
+                error!("Error reading kernel_info_reply: {}", e);
+                return Err(anyhow::anyhow!("Kernel did not respond: {}", e));
+            }
+            Err(_) => {
+                error!("Timeout waiting for kernel_info_reply");
+                return Err(anyhow::anyhow!("Kernel did not respond within 30s"));
+            }
+        }
+
+        // Split shell into persistent writer + reader
+        let (shell_writer, mut shell_reader) = shell.split();
+
+        let pending = self.pending_completions.clone();
+        let pending_hist = self.pending_history.clone();
+        let shell_app = app.clone();
+        let shell_cell_id_map = self.cell_id_map.clone();
+        let shell_reader_task = tokio::spawn(async move {
+            loop {
+                match shell_reader.read().await {
+                    Ok(msg) => {
+                        let parent_msg_id = msg.parent_header.as_ref().map(|h| h.msg_id.clone());
+
+                        match msg.content {
+                            JupyterMessageContent::CompleteReply(reply) => {
+                                if let Some(ref msg_id) = parent_msg_id {
+                                    if let Some(sender) = pending.lock().unwrap().remove(msg_id) {
+                                        let _ = sender.send(CompletionResult {
+                                            matches: reply.matches,
+                                            cursor_start: reply.cursor_start,
+                                            cursor_end: reply.cursor_end,
+                                        });
+                                    }
+                                }
+                            }
+                            JupyterMessageContent::HistoryReply(reply) => {
+                                if let Some(ref msg_id) = parent_msg_id {
+                                    if let Some(sender) = pending_hist.lock().unwrap().remove(msg_id)
+                                    {
+                                        let entries = reply
+                                            .history
+                                            .into_iter()
+                                            .map(|entry| match entry {
+                                                jupyter_protocol::HistoryEntry::Input(
+                                                    session,
+                                                    line,
+                                                    source,
+                                                ) => HistoryEntryData {
+                                                    session,
+                                                    line,
+                                                    source,
+                                                },
+                                                jupyter_protocol::HistoryEntry::InputOutput(
+                                                    session,
+                                                    line,
+                                                    (source, _),
+                                                ) => HistoryEntryData {
+                                                    session,
+                                                    line,
+                                                    source,
+                                                },
+                                            })
+                                            .collect();
+                                        let _ = sender.send(HistoryResult { entries });
+                                    }
+                                }
+                            }
+                            JupyterMessageContent::ExecuteReply(ref reply) => {
+                                // Handle page payloads from introspection (? and ??)
+                                for payload in &reply.payload {
+                                    if let Payload::Page { data, start } = payload {
+                                        let cell_id = parent_msg_id.as_ref().and_then(|msg_id| {
+                                            shell_cell_id_map.lock().ok()?.get(msg_id).cloned()
+                                        });
+
+                                        if let Some(cell_id) = cell_id {
+                                            let event = PagePayloadEvent {
+                                                cell_id,
+                                                data: data.clone(),
+                                                start: *start,
+                                            };
+                                            if let Err(e) =
+                                                shell_app.emit("kernel:page_payload", &event)
+                                            {
+                                                error!("Failed to emit page_payload: {}", e);
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                            _ => {
+                                debug!("shell reply: type={}", msg.header.msg_type);
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        error!("shell read error: {}", e);
+                        break;
+                    }
+                }
+            }
+        });
+
+        self.connection_info = Some(connection_info);
+        self.connection_file = Some(connection_file_path);
+        self.iopub_task = Some(iopub_task);
+        self.shell_reader_task = Some(shell_reader_task);
+        self.shell_writer = Some(shell_writer);
+        self._process = Some(process);
+        self.conda_environment = Some(env);
+
+        info!("Prewarmed conda kernel started: {}", kernel_id);
+        Ok(())
+    }
+
     /// Start a Deno kernel.
     ///
     /// Uses the system `deno jupyter` command to launch a Deno/TypeScript kernel.

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -20,7 +20,7 @@ use execution_queue::{ExecutionQueue, ExecutionQueueState, QueueCommand, SharedE
 use kernel::{CompletionResult, HistoryResult, NotebookKernel};
 use notebook_state::{FrontendCell, NotebookState};
 
-use log::info;
+use log::{error, info};
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::path::PathBuf;
@@ -1121,6 +1121,7 @@ async fn start_default_python_kernel_impl(
     notebook_state: &Arc<Mutex<NotebookState>>,
     kernel_state: &Arc<tokio::sync::Mutex<NotebookKernel>>,
     pool: &env_pool::SharedEnvPool,
+    conda_pool: &env_pool::SharedCondaEnvPool,
 ) -> Result<String, String> {
     // Load user's preferred Python environment type from settings
     let app_settings = settings::load_settings();
@@ -1321,6 +1322,53 @@ async fn start_default_python_kernel_impl(
             (env_id, state.path.clone())
         };
 
+        // Try to use a prewarmed conda environment from the pool
+        let prewarmed = conda_pool.lock().await.take();
+        if let Some(prewarmed_env) = prewarmed {
+            info!("[prewarm] Using prewarmed conda environment for notebook");
+
+            // Try to claim and use the prewarmed env, but fall back gracefully on error
+            match conda_env::claim_prewarmed_conda_environment(
+                prewarmed_env.into_conda_environment(),
+                &env_id,
+            )
+            .await
+            {
+                Ok(env) => {
+                    if env.python_path.exists() {
+                        let mut kernel = kernel_state.lock().await;
+                        match kernel.start_with_prewarmed_conda(app.clone(), env, notebook_path.as_deref()).await {
+                            Ok(()) => {
+                                // Trigger replenishment of the pool
+                                env_pool::spawn_conda_replenishment(conda_pool.clone(), app);
+                                return Ok("conda".to_string());
+                            }
+                            Err(e) => {
+                                error!(
+                                    "[prewarm] Failed to start kernel with prewarmed conda env, falling back: {}",
+                                    e
+                                );
+                            }
+                        }
+                    } else {
+                        info!(
+                            "[prewarm] Claimed conda env has invalid python path: {:?}, falling back",
+                            env.python_path
+                        );
+                    }
+                }
+                Err(e) => {
+                    error!(
+                        "[prewarm] Failed to claim prewarmed conda env, falling back: {}",
+                        e
+                    );
+                }
+            }
+        }
+
+        // No prewarmed env available (or prewarmed failed), create one normally
+        info!("No prewarmed conda environment available, creating fresh");
+
         // Create minimal deps with just ipykernel and the unique env_id
         let deps = conda_env::CondaDependencies {
             dependencies: vec!["ipykernel".to_string()],
@@ -1348,8 +1396,9 @@ async fn start_default_kernel(
     notebook_state: tauri::State<'_, Arc<Mutex<NotebookState>>>,
     kernel_state: tauri::State<'_, Arc<tokio::sync::Mutex<NotebookKernel>>>,
     pool: tauri::State<'_, env_pool::SharedEnvPool>,
+    conda_pool: tauri::State<'_, env_pool::SharedCondaEnvPool>,
 ) -> Result<String, String> {
-    start_default_python_kernel_impl(app, &notebook_state, &kernel_state, &pool).await
+    start_default_python_kernel_impl(app, &notebook_state, &kernel_state, &pool, &conda_pool).await
 }
 
 /// Check if the running kernel has a conda-managed environment.
@@ -1972,9 +2021,11 @@ pub fn run(notebook_path: Option<PathBuf>, runtime: Option<Runtime>) -> anyhow::
     let notebook_state = Arc::new(Mutex::new(initial_state));
     let kernel_state = Arc::new(tokio::sync::Mutex::new(NotebookKernel::default()));
 
-    // Create the prewarming environment pool
+    // Create the prewarming environment pools (UV and Conda)
     let env_pool: env_pool::SharedEnvPool =
         Arc::new(tokio::sync::Mutex::new(env_pool::EnvPool::new(env_pool::PoolConfig::default())));
+    let conda_env_pool: env_pool::SharedCondaEnvPool =
+        Arc::new(tokio::sync::Mutex::new(env_pool::CondaEnvPool::new(env_pool::PoolConfig::default())));
 
     // Track auto-launch state for frontend to query
     let auto_launch_in_progress = Arc::new(AtomicBool::new(false));
@@ -1984,11 +2035,13 @@ pub fn run(notebook_path: Option<PathBuf>, runtime: Option<Runtime>) -> anyhow::
     let notebook_for_processor = notebook_state.clone();
     let kernel_for_processor = kernel_state.clone();
     let pool_for_prewarm = env_pool.clone();
+    let conda_pool_for_prewarm = conda_env_pool.clone();
 
     // Clone for auto-launch kernel task
     let notebook_for_autolaunch = notebook_state.clone();
     let kernel_for_autolaunch = kernel_state.clone();
     let pool_for_autolaunch = env_pool.clone();
+    let conda_pool_for_autolaunch = conda_env_pool.clone();
     let auto_launch_flag = auto_launch_in_progress.clone();
 
     // Clone for lifecycle event handlers
@@ -2003,6 +2056,7 @@ pub fn run(notebook_path: Option<PathBuf>, runtime: Option<Runtime>) -> anyhow::
         .manage(kernel_state)
         .manage(queue)
         .manage(env_pool)
+        .manage(conda_env_pool)
         .manage(auto_launch_in_progress)
         .invoke_handler(tauri::generate_handler![
             load_notebook,
@@ -2108,10 +2162,16 @@ pub fn run(notebook_path: Option<PathBuf>, runtime: Option<Runtime>) -> anyhow::
                 kernel.set_queue_tx(tx_for_kernel);
             });
 
-            // Spawn the environment prewarming loop
+            // Spawn the UV environment prewarming loop
             let app_for_prewarm = app.handle().clone();
             tauri::async_runtime::spawn(async move {
                 env_pool::run_prewarming_loop(pool_for_prewarm, app_for_prewarm).await;
+            });
+
+            // Spawn the conda environment prewarming loop
+            let app_for_conda_prewarm = app.handle().clone();
+            tauri::async_runtime::spawn(async move {
+                env_pool::run_conda_prewarming_loop(conda_pool_for_prewarm, app_for_conda_prewarm).await;
             });
 
             // Auto-launch kernel for faster startup (only if trusted)
@@ -2175,6 +2235,7 @@ pub fn run(notebook_path: Option<PathBuf>, runtime: Option<Runtime>) -> anyhow::
                             &notebook_for_autolaunch,
                             &kernel_for_autolaunch,
                             &pool_for_autolaunch,
+                            &conda_pool_for_autolaunch,
                         )
                         .await
                         {

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -1340,7 +1340,7 @@ async fn start_default_python_kernel_impl(
                         match kernel.start_with_prewarmed_conda(app.clone(), env, notebook_path.as_deref()).await {
                             Ok(()) => {
                                 // Trigger replenishment of the pool
-                                env_pool::spawn_conda_replenishment(conda_pool.clone(), app);
+                                env_pool::spawn_conda_replenishment(conda_pool.clone());
                                 return Ok("conda".to_string());
                             }
                             Err(e) => {
@@ -2169,9 +2169,8 @@ pub fn run(notebook_path: Option<PathBuf>, runtime: Option<Runtime>) -> anyhow::
             });
 
             // Spawn the conda environment prewarming loop
-            let app_for_conda_prewarm = app.handle().clone();
             tauri::async_runtime::spawn(async move {
-                env_pool::run_conda_prewarming_loop(conda_pool_for_prewarm, app_for_conda_prewarm).await;
+                env_pool::run_conda_prewarming_loop(conda_pool_for_prewarm).await;
             });
 
             // Auto-launch kernel for faster startup (only if trusted)


### PR DESCRIPTION
## Summary

- Add conda environment prewarming, mirroring the existing UV prewarming pattern
- Pre-create conda environments with ipykernel in background so they're ready when opening notebooks
- Recover existing prewarmed environments on app startup for persistent caching
- Increase prewarmed environment max age from 1 hour to 2 days (ipykernel rarely changes)
- Fix progress events from background prewarming leaking to all notebook windows

## Test plan

- [x] Run `cargo xtask run` and open a new Python notebook - should see "[prewarm] Using prewarmed conda environment" in logs and kernel starts instantly (no solve progress)
- [x] After using a prewarmed env, verify pool replenishes in background via logs
- [x] Restart app and verify recovery of existing prewarmed environments

<!-- Placeholder for UI screenshots showing instant kernel startup -->