### PR TITLE
Fix scrollbar overflow in notebook layout

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -424,7 +424,7 @@ onKernelStarted: loadCondaDependencies,
   }, []);
 
   return (
-    <div className="min-h-screen bg-background">
+    <div className="flex h-full flex-col bg-background overflow-hidden">
       {gitInfo && (
         <DebugBanner
           branch={gitInfo.branch}

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -183,7 +183,7 @@ function NotebookViewContent({
   );
 
   return (
-    <div ref={containerRef} className="py-4 pl-8 pr-4">
+    <div ref={containerRef} className="flex-1 overflow-y-auto overflow-x-hidden py-4 pl-8 pr-4">
       {cells.length === 0 ? (
         <div className="flex flex-col items-center justify-center py-20 text-muted-foreground">
           <p className="text-sm">Empty notebook</p>

--- a/apps/notebook/src/index.css
+++ b/apps/notebook/src/index.css
@@ -118,6 +118,11 @@ body {
     Ubuntu, Cantarell, sans-serif;
 }
 
+html, body, #root {
+  height: 100%;
+  overflow: hidden;
+}
+
 ::-webkit-scrollbar {
   width: 8px;
   height: 8px;


### PR DESCRIPTION
## Summary

Fixes unwanted scrollbars appearing in the notebook app by converting the layout to a proper flexbox structure that constrains content within the viewport. The root container now fills the viewport exactly with no browser-managed scrolling, and the NotebookView becomes the scrollable region with `overflow-y-auto` and `overflow-x-hidden` to handle focused cell expansion.

## Changes

- Added `height: 100%; overflow: hidden;` to html/body/#root in index.css to prevent body-level scrollbars
- Converted App.tsx root container from `min-h-screen` to `flex h-full flex-col overflow-hidden`
- Made NotebookView scrollable with `flex-1 overflow-y-auto overflow-x-hidden`

## Test Plan

- Verify no body scrollbars appear when notebook content exceeds viewport
- Verify notebook content scrolls within its container
- Click cells to focus them - verify no horizontal scrollbar appears  
- Run ipywidgets outputs - verify widgets render correctly
- Open DependencyHeader - verify it stacks above the scrollable area
- Use zoom controls - verify no scrollbars introduced