### PR TITLE
Fix preview build by generating icons first

### DIFF
--- a/.github/workflows/weekly-preview.yml
+++ b/.github/workflows/weekly-preview.yml
@@ -243,6 +243,9 @@ jobs:
           echo "Setting version to: ${VERSION}"
           sed -i '' "s/\"version\": \"[^\"]*\"/\"version\": \"${VERSION}\"/" crates/notebook/tauri.conf.json
 
+      - name: Generate Icons
+        run: cargo xtask icons
+
       - name: Build and Sign DMG
         env:
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
@@ -360,6 +363,9 @@ jobs:
           VERSION="${CURRENT_VERSION}-preview.${COMMIT_SHA}"
           echo "Setting version to: ${VERSION}"
           sed -i '' "s/\"version\": \"[^\"]*\"/\"version\": \"${VERSION}\"/" crates/notebook/tauri.conf.json
+
+      - name: Generate Icons
+        run: cargo xtask icons
 
       - name: Build and Sign DMG
         env:


### PR DESCRIPTION
Adds icon generation step before DMG builds in the weekly preview workflow.

The macOS DMG builds were failing with "Failed to create app icon: resource path `icons/icon.icns` doesn't exist" because this file is gitignored and must be generated from source.png at build time. The workflow overrides `beforeBuildCommand` to skip redundant frontend builds, but this also skipped icon generation.

Uses `cargo xtask icons` to generate all icon variants before the tauri build step in both ARM64 and x64 jobs. All tests and build checks pass.