### PR TITLE
Reduce markdown cell flicker on mode transitions

### DIFF
--- a/e2e/specs/markdown-cell.spec.js
+++ b/e2e/specs/markdown-cell.spec.js
@@ -46,19 +46,27 @@ describe("Markdown Cell", () => {
   }
 
   /**
-   * Helper to check if cell is in edit mode (has CodeMirror editor)
+   * Helper to check if cell is in edit mode (editor is visible)
+   * Note: Both editor and iframe are always rendered, but hidden via CSS
    */
   async function isInEditMode(cell) {
     const editor = await cell.$('.cm-content[contenteditable="true"]');
-    return editor.isExisting();
+    if (!(await editor.isExisting())) {
+      return false;
+    }
+    return editor.isDisplayed();
   }
 
   /**
-   * Helper to check if cell has an iframe (rendered mode with isolation)
+   * Helper to check if cell has a visible iframe (rendered mode with isolation)
+   * Note: Both editor and iframe are always rendered, but hidden via CSS
    */
   async function hasIsolatedFrame(cell) {
     const iframe = await cell.$("iframe");
-    return iframe.isExisting();
+    if (!(await iframe.isExisting())) {
+      return false;
+    }
+    return iframe.isDisplayed();
   }
 
   describe("Creating and editing markdown cells", () => {


### PR DESCRIPTION
## Summary

Keep the IsolatedFrame alive across edit/view mode transitions instead of destroying and recreating it. This eliminates the expensive iframe bootstrap process (blob URL creation, React bundle fetch/eval) that occurs on each mode switch, resulting in smooth, flicker-free transitions.

## Changes

- Always render both editor and view sections, using CSS visibility (`hidden`/`block`) to control which is shown
- Clear rendered content before re-rendering to prevent content from being appended
- Add focus management for the editor when entering edit mode

## Testing

- All unit tests pass (272 tests)
- All builds succeed (JS, Rust)
- Manual verification shows smooth mode transitions with no flickering
- Content is correctly replaced instead of appended on subsequent edits