### PR TITLE
Add update_display_data support for in-place display updates

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -60,6 +60,7 @@ function AppContent() {
     cloneNotebook,
     dirty,
     appendOutput,
+    updateOutputByDisplayId,
     setExecutionCount,
     clearCellOutputs,
   } = useNotebook();
@@ -256,8 +257,9 @@ function AppContent() {
     onExecutionCount: handleExecutionCount,
     onExecutionDone: handleExecutionDone,
     onCommMessage: handleCommMessage,
-onKernelStarted: loadCondaDependencies,
+    onKernelStarted: loadCondaDependencies,
     onPagePayload: handlePagePayload,
+    onUpdateDisplayData: updateOutputByDisplayId,
   });
 
   // Environment preparation progress

--- a/apps/notebook/src/hooks/useNotebook.ts
+++ b/apps/notebook/src/hooks/useNotebook.ts
@@ -207,6 +207,30 @@ export function useNotebook() {
     []
   );
 
+  const updateOutputByDisplayId = useCallback(
+    (displayId: string, newData: Record<string, unknown>, newMetadata?: Record<string, unknown>) => {
+      setCells((prev) =>
+        prev.map((c) => {
+          if (c.cell_type !== "code") return c;
+          let changed = false;
+          const updatedOutputs = c.outputs.map((output) => {
+            if (
+              (output.output_type === "display_data" ||
+                output.output_type === "execute_result") &&
+              output.display_id === displayId
+            ) {
+              changed = true;
+              return { ...output, data: newData, metadata: newMetadata };
+            }
+            return output;
+          });
+          return changed ? { ...c, outputs: updatedOutputs } : c;
+        })
+      );
+    },
+    []
+  );
+
   const setExecutionCount = useCallback(
     (cellId: string, count: number) => {
       setCells((prev) =>
@@ -235,6 +259,7 @@ export function useNotebook() {
     cloneNotebook,
     dirty,
     appendOutput,
+    updateOutputByDisplayId,
     setExecutionCount,
   };
 }

--- a/apps/notebook/src/types.ts
+++ b/apps/notebook/src/types.ts
@@ -26,6 +26,7 @@ export type JupyterOutput =
       data: Record<string, unknown>;
       metadata?: Record<string, unknown>;
       execution_count?: number | null;
+      display_id?: string;
     }
   | {
       output_type: "stream";


### PR DESCRIPTION
## Summary

Enable IPython's display update mechanism where `display(obj, display_id=True)` followed by `handle.update(new_value)` updates the output in place. Previously these `update_display_data` messages were ignored by the notebook app.

## Changes

- Added `display_id` field to `JupyterOutput` type to track displayable outputs
- Implemented `updateOutputByDisplayId` callback in notebook hook for updating outputs by display ID
- Added handler for `update_display_data` messages in kernel message router
- Capture `display_id` from `display_data` messages when creating outputs
- Wired up display update callback to kernel message handler in App component

## Testing

All tests and builds pass:
- ✓ JS tests (272 tests)
- ✓ Isolated renderer build
- ✓ Sidecar build
- ✓ Notebook build
- ✓ Cargo clippy
- ✓ Cargo release build
- ✓ Cargo tests (158 passed)