### PR TITLE
Fix Valid widget always showing Invalid readout

### DIFF
--- a/src/components/widgets/controls/valid-widget.tsx
+++ b/src/components/widgets/controls/valid-widget.tsx
@@ -29,7 +29,7 @@ export function ValidWidget({ modelId, className }: WidgetComponentProps) {
       ) : (
         <XIcon className="size-4 text-red-500" />
       )}
-      {readout && (
+      {!value && readout && (
         <span className="text-sm text-muted-foreground">{readout}</span>
       )}
     </div>


### PR DESCRIPTION
## Summary
Fixed the Valid widget displaying the readout text unconditionally. Now it only shows the readout (e.g., "Invalid") when the validation state is false.

## Changes
Modified the conditional rendering in ValidWidget to check `!value` before displaying the readout text, ensuring it only appears in invalid state.

## Testing
- All JS tests pass (272 passed)
- Isolated renderer builds successfully
- Sidecar and notebook apps build successfully
- All Rust tests pass (158 passed)
- Cargo clippy passes with no warnings

## Example
- `widgets.Valid(value=True, description='Valid!')` → Shows green checkmark, no "Invalid" text
- `widgets.Valid(value=False, description='Valid!')` → Shows red X, displays "Invalid" text

Fixes #63