### PR TITLE
Preload output iframe for code cells to enable instant rendering

### DIFF
--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -241,9 +241,8 @@ export function CodeCell({
             )}
           </>
         }
-        outputContent={
-          cell.outputs.length > 0 ? <OutputArea outputs={cell.outputs} /> : undefined
-        }
+        outputContent={<OutputArea outputs={cell.outputs} preloadIframe />}
+        hideOutput={cell.outputs.length === 0}
       />
 
       {/* History Search Dialog (Ctrl+R) */}

--- a/src/components/cell/CellContainer.tsx
+++ b/src/components/cell/CellContainer.tsx
@@ -11,6 +11,8 @@ interface CellContainerProps {
   codeContent?: ReactNode;
   /** Content for the output section (renders with a different ribbon color) */
   outputContent?: ReactNode;
+  /** Hide the output section (useful for preloading content invisibly) */
+  hideOutput?: boolean;
   /** Legacy children prop - use codeContent/outputContent for segmented ribbon support */
   children?: ReactNode;
   /** Content to render in the left gutter action area (e.g., play button, execution count) */
@@ -34,6 +36,7 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
       onFocus,
       codeContent,
       outputContent,
+      hideOutput,
       children,
       gutterContent,
       rightGutterContent,
@@ -95,7 +98,7 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
             </div>
             {/* Output row - ribbon + content together */}
             {hasOutput && (
-              <div className="flex">
+              <div className={cn("flex", hideOutput && "hidden")}>
                 <div
                   className={cn(
                     "w-1 transition-colors duration-150",


### PR DESCRIPTION
## Summary

Pre-create the `IsolatedFrame` in code cells before outputs arrive, so the expensive bootstrap process (blob URL creation, HTML load, React bundle fetch/eval) happens ahead of time. When outputs do arrive, they render instantly into the already-ready iframe.

Closes #124

## Changes

- **OutputArea**: Add `preloadIframe` prop that creates a hidden iframe even when there are no outputs yet
- **CodeCell**: Always render OutputArea with `preloadIframe={true}`

## How it works

1. When a code cell mounts, OutputArea creates a hidden `IsolatedFrame`
2. The iframe bootstraps in the background (creates blob URL, loads HTML, fetches React bundle)
3. When the user executes code and outputs arrive that need isolation, the iframe is already ready
4. Outputs render instantly instead of waiting for the full bootstrap

Outputs that don't need isolation (plain text, streams, errors) still render in-DOM for optimal performance.

## Demo

<!-- Add before/after comparison showing instant output rendering -->