### PR TITLE
Default CodeMirror indentation to 4 spaces for Python, 2 for others

### DIFF
--- a/src/components/editor/codemirror-editor.tsx
+++ b/src/components/editor/codemirror-editor.tsx
@@ -18,7 +18,11 @@ import {
 } from "react";
 
 import { defaultExtensions } from "./extensions";
-import { getLanguageExtension, type SupportedLanguage } from "./languages";
+import {
+  getIndentationExtension,
+  getLanguageExtension,
+  type SupportedLanguage,
+} from "./languages";
 import { darkTheme, isDarkMode, lightTheme, type ThemeMode } from "./themes";
 
 export interface CodeMirrorEditorRef {
@@ -144,6 +148,11 @@ export const CodeMirrorEditor = forwardRef<
       [language],
     );
 
+    const indentExtension = useMemo(
+      () => getIndentationExtension(language),
+      [language],
+    );
+
     // Determine which theme to use
     const themeExtension = useMemo(() => {
       if (theme === "light") return lightTheme;
@@ -156,6 +165,7 @@ export const CodeMirrorEditor = forwardRef<
       const exts: Extension[] = [
         ...baseExtensions,
         langExtension,
+        indentExtension,
         themeExtension,
       ];
 
@@ -183,6 +193,7 @@ export const CodeMirrorEditor = forwardRef<
     }, [
       baseExtensions,
       langExtension,
+      indentExtension,
       themeExtension,
       keyMap,
       placeholder,

--- a/src/components/editor/languages.ts
+++ b/src/components/editor/languages.ts
@@ -4,6 +4,7 @@ import { json } from "@codemirror/lang-json";
 import { markdown } from "@codemirror/lang-markdown";
 import { python } from "@codemirror/lang-python";
 import { sql } from "@codemirror/lang-sql";
+import { indentUnit } from "@codemirror/language";
 import type { Extension } from "@codemirror/state";
 
 /**
@@ -47,6 +48,17 @@ export function getLanguageExtension(language: SupportedLanguage): Extension {
     default:
       return [];
   }
+}
+
+/**
+ * Get the indentation extension for a given language
+ * Python uses 4 spaces (PEP 8), web languages use 2 spaces
+ */
+export function getIndentationExtension(language: SupportedLanguage): Extension {
+  if (language === "python") {
+    return indentUnit.of("    ");
+  }
+  return indentUnit.of("  ");
 }
 
 /**


### PR DESCRIPTION
Implements language-specific indentation following community standards.

- Python: 4 spaces per PEP 8
- TypeScript, JavaScript, JSX, TSX, JSON: 2 spaces
- Other languages: 2 spaces (sensible default)

All tests pass including JS tests (272 tests), isolated renderer build, sidecar build, notebook build, Rust clippy checks, release build, and Rust tests (169 tests).