### PR TITLE
Add autoformat support for code cells (#71)

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -62,6 +62,7 @@ function AppContent() {
     appendOutput,
     setExecutionCount,
     clearCellOutputs,
+    formatCell,
   } = useNotebook();
 
   const { theme, setTheme } = useTheme("notebook-theme");
@@ -256,7 +257,7 @@ function AppContent() {
     onExecutionCount: handleExecutionCount,
     onExecutionDone: handleExecutionDone,
     onCommMessage: handleCommMessage,
-onKernelStarted: loadCondaDependencies,
+    onKernelStarted: loadCondaDependencies,
     onPagePayload: handlePagePayload,
   });
 
@@ -513,6 +514,7 @@ onKernelStarted: loadCondaDependencies,
         onDeleteCell={deleteCell}
         onAddCell={handleAddCell}
         onClearPagePayload={clearPagePayload}
+        onFormatCell={formatCell}
       />
     </div>
   );

--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -71,6 +71,7 @@ interface CodeCellProps {
   onFocusNext?: (cursorPosition: "start" | "end") => void;
   onInsertCellAfter?: () => void;
   onClearPagePayload?: () => void;
+  onFormat?: () => void;
   isLastCell?: boolean;
 }
 
@@ -89,6 +90,7 @@ export function CodeCell({
   onFocusNext,
   onInsertCellAfter,
   onClearPagePayload,
+  onFormat,
   isLastCell = false,
 }: CodeCellProps) {
   const editorRef = useRef<CodeMirrorEditorRef>(null);
@@ -152,6 +154,7 @@ export function CodeCell({
         }
       : undefined,
     onDelete,
+    onFormat,
   });
 
   // Ctrl+R to open history search

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -21,6 +21,7 @@ interface NotebookViewProps {
   onDeleteCell: (cellId: string) => void;
   onAddCell: (type: "code" | "markdown", afterCellId?: string | null) => void;
   onClearPagePayload: (cellId: string) => void;
+  onFormatCell?: (cellId: string) => void;
 }
 
 function AddCellButtons({
@@ -80,6 +81,7 @@ function NotebookViewContent({
   onDeleteCell,
   onAddCell,
   onClearPagePayload,
+  onFormatCell,
 }: NotebookViewProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const { focusCell } = useEditorRegistry();
@@ -130,6 +132,7 @@ function NotebookViewContent({
             onFocusNext={onFocusNext}
             onInsertCellAfter={() => onAddCell("code", cell.id)}
             onClearPagePayload={() => onClearPagePayload(cell.id)}
+            onFormat={onFormatCell ? () => onFormatCell(cell.id) : undefined}
             isLastCell={index === cells.length - 1}
           />
         );
@@ -178,6 +181,7 @@ function NotebookViewContent({
       onDeleteCell,
       onAddCell,
       onClearPagePayload,
+      onFormatCell,
       focusCell,
     ]
   );

--- a/apps/notebook/src/hooks/useCellKeyboardNavigation.ts
+++ b/apps/notebook/src/hooks/useCellKeyboardNavigation.ts
@@ -6,6 +6,7 @@ interface UseCellKeyboardNavigationOptions {
   onExecute?: () => void;
   onExecuteAndInsert?: () => void;
   onDelete?: () => void;
+  onFormat?: () => void;
 }
 
 export function useCellKeyboardNavigation({
@@ -14,6 +15,7 @@ export function useCellKeyboardNavigation({
   onExecute,
   onExecuteAndInsert,
   onDelete,
+  onFormat,
 }: UseCellKeyboardNavigationOptions): KeyBinding[] {
   return [
     {
@@ -89,6 +91,17 @@ export function useCellKeyboardNavigation({
             key: "Alt-Enter",
             run: () => {
               onExecuteAndInsert();
+              return true;
+            },
+          },
+        ]
+      : []),
+    ...(onFormat
+      ? [
+          {
+            key: "Mod-Shift-f",
+            run: () => {
+              onFormat();
               return true;
             },
           },

--- a/apps/notebook/src/hooks/useNotebook.ts
+++ b/apps/notebook/src/hooks/useNotebook.ts
@@ -34,6 +34,26 @@ export function useNotebook() {
     };
   }, [loadCells]);
 
+  // Listen for backend-initiated cell source updates (e.g., from formatting)
+  useEffect(() => {
+    const unlisten = listen<{ cell_id: string; source: string }>(
+      "cell:source_updated",
+      (event) => {
+        setCells((prev) =>
+          prev.map((c) =>
+            c.id === event.payload.cell_id
+              ? { ...c, source: event.payload.source }
+              : c
+          )
+        );
+        setDirty(true);
+      }
+    );
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, []);
+
   const updateCellSource = useCallback((cellId: string, source: string) => {
     setCells((prev) =>
       prev.map((c) => (c.id === cellId ? { ...c, source } : c))
@@ -220,6 +240,30 @@ export function useNotebook() {
     []
   );
 
+  /**
+   * Format a cell's source code using the appropriate formatter.
+   * The backend handles the formatting and emits a cell:source_updated event
+   * if the source changed, which updates the React state automatically.
+   */
+  const formatCell = useCallback(async (cellId: string) => {
+    try {
+      const result = await invoke<{
+        source: string;
+        changed: boolean;
+        error: string | null;
+      }>("format_cell", { cellId });
+
+      if (result.error) {
+        console.warn("[notebook] format_cell warning:", result.error);
+      }
+
+      return result;
+    } catch (e) {
+      console.error("[notebook] format_cell failed:", e);
+      return null;
+    }
+  }, []);
+
   return {
     cells,
     setCells,
@@ -236,5 +280,6 @@ export function useNotebook() {
     dirty,
     appendOutput,
     setExecutionCount,
+    formatCell,
   };
 }

--- a/crates/notebook/src/format.rs
+++ b/crates/notebook/src/format.rs
@@ -1,0 +1,188 @@
+//! Code formatting for notebook cells.
+//!
+//! Supports:
+//! - Python via `ruff format`
+//! - TypeScript/JavaScript via `deno fmt`
+
+use anyhow::{anyhow, Result};
+use serde::{Deserialize, Serialize};
+use std::process::Stdio;
+use tokio::io::AsyncWriteExt;
+
+/// Result of a format operation
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FormatResult {
+    /// The formatted source code
+    pub source: String,
+    /// Whether formatting changed the source
+    pub changed: bool,
+    /// Error message if formatting failed (source unchanged)
+    pub error: Option<String>,
+}
+
+/// Check if ruff is available on the system
+pub async fn check_ruff_available() -> bool {
+    tokio::process::Command::new("ruff")
+        .arg("--version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .await
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Format Python code using ruff
+pub async fn format_python(source: &str) -> Result<FormatResult> {
+    // Skip formatting for empty or whitespace-only source
+    if source.trim().is_empty() {
+        return Ok(FormatResult {
+            source: source.to_string(),
+            changed: false,
+            error: None,
+        });
+    }
+
+    let mut child = tokio::process::Command::new("ruff")
+        .args(["format", "--stdin-filename", "cell.py", "-"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| anyhow!("Failed to spawn ruff: {}", e))?;
+
+    // Write source to stdin
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin
+            .write_all(source.as_bytes())
+            .await
+            .map_err(|e| anyhow!("Failed to write to ruff stdin: {}", e))?;
+    }
+
+    let output = child
+        .wait_with_output()
+        .await
+        .map_err(|e| anyhow!("Failed to wait for ruff: {}", e))?;
+
+    if output.status.success() {
+        let formatted = String::from_utf8(output.stdout)
+            .map_err(|e| anyhow!("Invalid UTF-8 in ruff output: {}", e))?;
+        let changed = formatted != source;
+        Ok(FormatResult {
+            source: formatted,
+            changed,
+            error: None,
+        })
+    } else {
+        // Formatting failed (e.g., syntax error) - return original source with error
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        Ok(FormatResult {
+            source: source.to_string(),
+            changed: false,
+            error: Some(stderr.to_string()),
+        })
+    }
+}
+
+/// Format TypeScript/JavaScript code using deno fmt
+pub async fn format_deno(source: &str, language: &str) -> Result<FormatResult> {
+    // Skip formatting for empty or whitespace-only source
+    if source.trim().is_empty() {
+        return Ok(FormatResult {
+            source: source.to_string(),
+            changed: false,
+            error: None,
+        });
+    }
+
+    let ext = match language {
+        "typescript" | "ts" => "ts",
+        "javascript" | "js" => "js",
+        "tsx" => "tsx",
+        "jsx" => "jsx",
+        _ => "ts", // default to TypeScript for Deno notebooks
+    };
+
+    let mut child = tokio::process::Command::new("deno")
+        .args(["fmt", &format!("--ext={}", ext), "-"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| anyhow!("Failed to spawn deno fmt: {}", e))?;
+
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin
+            .write_all(source.as_bytes())
+            .await
+            .map_err(|e| anyhow!("Failed to write to deno fmt stdin: {}", e))?;
+    }
+
+    let output = child
+        .wait_with_output()
+        .await
+        .map_err(|e| anyhow!("Failed to wait for deno fmt: {}", e))?;
+
+    if output.status.success() {
+        let formatted = String::from_utf8(output.stdout)
+            .map_err(|e| anyhow!("Invalid UTF-8 in deno fmt output: {}", e))?;
+        let changed = formatted != source;
+        Ok(FormatResult {
+            source: formatted,
+            changed,
+            error: None,
+        })
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        Ok(FormatResult {
+            source: source.to_string(),
+            changed: false,
+            error: Some(stderr.to_string()),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_format_python_empty() {
+        let result = format_python("").await.unwrap();
+        assert!(!result.changed);
+        assert!(result.error.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_format_python_whitespace() {
+        let result = format_python("   \n\n  ").await.unwrap();
+        assert!(!result.changed);
+        assert!(result.error.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_format_deno_empty() {
+        let result = format_deno("", "ts").await.unwrap();
+        assert!(!result.changed);
+        assert!(result.error.is_none());
+    }
+
+    // Integration tests that require ruff/deno to be installed
+    #[tokio::test]
+    #[ignore] // Run with --ignored to test with actual formatters
+    async fn test_format_python_simple() {
+        let source = "x=1\ny  =  2";
+        let result = format_python(source).await.unwrap();
+        assert!(result.changed);
+        assert!(result.source.contains("x = 1"));
+    }
+
+    #[tokio::test]
+    #[ignore] // Run with --ignored to test with actual formatters
+    async fn test_format_deno_typescript() {
+        let source = "const x=1;const y  =  2";
+        let result = format_deno(source, "ts").await.unwrap();
+        assert!(result.changed);
+        assert!(result.source.contains("const x = 1"));
+    }
+}


### PR DESCRIPTION
## Summary

Implements automatic code formatting for code cells using ruff (Python) or deno fmt (TypeScript/JavaScript):
- **Format on execute**: Queue processor formats code before sending to kernel
- **Format on save**: All code cells formatted before writing to disk
- **Manual format**: Cmd+Shift+F formats the focused cell

## Architecture

Backend-driven architecture: formatting happens in Rust, frontend observes changes via `cell:source_updated` events. Formatting is best-effort - failures don't block execution or save.

## Test Plan

- [x] JS tests pass (`pnpm test:run`)
- [x] Isolated renderer builds (`pnpm run isolated-renderer:build`)
- [x] Sidecar app builds (`pnpm --dir apps/sidecar build`)
- [x] Notebook app builds (`pnpm --dir apps/notebook build`)
- [x] Cargo clippy passes (`cargo clippy --all-targets -- -D warnings`)
- [x] Release build succeeds (`cargo build --release`)
- [x] Tests pass (`cargo test --verbose`)