### PR TITLE
Sync markdown rendering on every source change for RTC support (#125)

### DIFF
--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -89,16 +89,16 @@ export function MarkdownCell({
     });
   }, [cell.source]);
 
-  // Re-render when source changes and not editing
+  // Sync markdown to iframe whenever source changes (supports RTC updates)
   useEffect(() => {
-    if (!editing && frameRef.current?.isReady && cell.source) {
+    if (frameRef.current?.isReady && cell.source) {
       frameRef.current.clear();
       frameRef.current.render({
         mimeType: "text/markdown",
         data: cell.source,
       });
     }
-  }, [editing, cell.source]);
+  }, [cell.source]);
 
   // Handle link clicks from iframe
   const handleLinkClick = useCallback((url: string) => {


### PR DESCRIPTION
## Summary

Removes the `!editing` condition from the markdown sync effect so iframe content updates whenever `cell.source` changes, regardless of edit mode. This enables Real-Time Collaboration (RTC) where external source changes need to be reflected immediately.

## Changes

- Remove `!editing` condition from the markdown rendering effect
- Remove `editing` from the dependency array
- Update comment to reflect RTC support purpose

## Benefits

- **RTC support**: External source changes render immediately
- **Live preview**: View stays in sync even while editing (though hidden)
- **No flickering**: Content already rendered when switching to view mode

## Testing

- [x] All unit tests pass
- [x] Isolated renderer builds successfully
- [x] Sidecar and notebook apps build successfully
- [x] Cargo clippy and build release succeed
- [x] Cargo tests pass