### PR TITLE
Fix Dropdown widget not working in iframe

### DIFF
--- a/src/components/widgets/controls/dropdown-widget.tsx
+++ b/src/components/widgets/controls/dropdown-widget.tsx
@@ -1,19 +1,16 @@
 "use client";
 
 /**
- * Dropdown widget - renders a select/combobox dropdown.
+ * Dropdown widget - renders a native select dropdown.
  *
  * Maps to ipywidgets DropdownModel.
+ *
+ * Uses native HTML <select> instead of Radix UI Select because Radix
+ * uses Portal which doesn't work in sandboxed iframes (no allow-same-origin).
+ * See: https://github.com/runtimed/runt/issues/62
  */
 
 import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { cn } from "@/lib/utils";
 import type { WidgetComponentProps } from "../widget-registry";
 import {
@@ -31,14 +28,12 @@ export function DropdownWidget({ modelId, className }: WidgetComponentProps) {
   const description = useWidgetModelValue<string>(modelId, "description");
   const disabled = useWidgetModelValue<boolean>(modelId, "disabled") ?? false;
 
-  // Convert index to string value for Select (Radix Select uses string values)
+  // Convert index to string value for select
   const value =
-    index !== null && index !== undefined && index >= 0
-      ? String(index)
-      : undefined;
+    index !== null && index !== undefined && index >= 0 ? String(index) : "";
 
-  const handleValueChange = (newValue: string) => {
-    const newIndex = parseInt(newValue, 10);
+  const handleChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const newIndex = parseInt(event.target.value, 10);
     if (!Number.isNaN(newIndex)) {
       sendUpdate(modelId, { index: newIndex });
     }
@@ -51,22 +46,32 @@ export function DropdownWidget({ modelId, className }: WidgetComponentProps) {
       data-widget-type="Dropdown"
     >
       {description && <Label className="shrink-0 text-sm">{description}</Label>}
-      <Select
+      <select
         value={value}
-        onValueChange={handleValueChange}
+        onChange={handleChange}
         disabled={disabled}
+        className={cn(
+          // Base styles matching shadcn SelectTrigger
+          "h-9 w-48 appearance-none rounded-md border border-input px-3 py-2 text-sm",
+          "bg-transparent shadow-xs transition-[color,box-shadow] outline-none",
+          // Dark mode background
+          "dark:bg-input/30 dark:hover:bg-input/50",
+          // Focus styles
+          "focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50",
+          // Disabled state
+          "disabled:cursor-not-allowed disabled:opacity-50",
+          // Custom dropdown arrow using background image (chevron-down)
+          "bg-[length:16px_16px] bg-[right_8px_center] bg-no-repeat",
+          "bg-[url('data:image/svg+xml;charset=utf-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2224%22%20height%3D%2224%22%20viewBox%3D%220%200%2024%2024%22%20fill%3D%22none%22%20stroke%3D%22%239ca3af%22%20stroke-width%3D%222%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%3E%3Cpath%20d%3D%22m6%209%206%206%206-6%22%2F%3E%3C%2Fsvg%3E')]",
+          "pr-9", // Extra padding for the arrow
+        )}
       >
-        <SelectTrigger className="w-48">
-          <SelectValue placeholder="Select..." />
-        </SelectTrigger>
-        <SelectContent>
-          {options.map((option, idx) => (
-            <SelectItem key={idx} value={String(idx)}>
-              {option}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
+        {options.map((option, idx) => (
+          <option key={idx} value={String(idx)}>
+            {option}
+          </option>
+        ))}
+      </select>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Closes #62 

Fixes the Dropdown widget by replacing Radix UI Select with a native HTML `<select>` element. Radix uses a Portal that renders to `document.body`, causing focus management issues in the sandboxed iframe (opaque blob: origin without `allow-same-origin`).

## Changes

- Use native `<select>` instead of Radix UI Select component
- Style with `appearance-none` to match shadcn design system
- Add dark mode backgrounds and focus ring styling to match SelectTrigger
- Include custom chevron-down SVG icon

## Screenshots

<img width="239" height="136" alt="image" src="https://github.com/user-attachments/assets/c6b2eb6d-e7ae-45ef-8e73-ce5d386a5553" />

<img width="259" height="127" alt="image" src="https://github.com/user-attachments/assets/b13a677a-8178-46fc-8995-2b24c8f40743" />


## Testing

✅ All tests pass (272 tests)
✅ All builds succeed (isolated-renderer, sidecar, notebook)
✅ Cargo checks pass (clippy, release build, test suite)