### PR TITLE
Bootstrap deno via rattler when not on PATH

### DIFF
--- a/crates/notebook/src/format.rs
+++ b/crates/notebook/src/format.rs
@@ -2,7 +2,7 @@
 //!
 //! Supports:
 //! - Python via `ruff format` (auto-bootstrapped via rattler if not on PATH)
-//! - TypeScript/JavaScript via `deno fmt`
+//! - TypeScript/JavaScript via `deno fmt` (auto-bootstrapped via rattler if not on PATH)
 
 use crate::tools;
 use anyhow::{anyhow, Result};
@@ -84,6 +84,8 @@ pub async fn format_python(source: &str) -> Result<FormatResult> {
 }
 
 /// Format TypeScript/JavaScript code using deno fmt
+///
+/// Deno is auto-bootstrapped via rattler if not found on PATH.
 pub async fn format_deno(source: &str, language: &str) -> Result<FormatResult> {
     // Skip formatting for empty or whitespace-only source
     if source.trim().is_empty() {
@@ -102,7 +104,10 @@ pub async fn format_deno(source: &str, language: &str) -> Result<FormatResult> {
         _ => "ts", // default to TypeScript for Deno notebooks
     };
 
-    let mut child = tokio::process::Command::new("deno")
+    // Get deno path (from PATH or bootstrapped via rattler)
+    let deno_path = tools::get_deno_path().await?;
+
+    let mut child = tokio::process::Command::new(&deno_path)
         .args(["fmt", &format!("--ext={}", ext), "-"])
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())

--- a/crates/notebook/src/kernel.rs
+++ b/crates/notebook/src/kernel.rs
@@ -1,5 +1,6 @@
 use crate::conda_env::{CondaDependencies, CondaEnvironment};
 use crate::execution_queue::QueueCommand;
+use crate::tools;
 use crate::uv_env::{NotebookDependencies, UvEnvironment};
 use anyhow::Result;
 use bytes::Bytes;
@@ -1883,8 +1884,13 @@ impl NotebookKernel {
             connection_file_path
         );
 
+        // Get deno path (from PATH or bootstrapped via rattler)
+        let deno_path = tools::get_deno_path()
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to get deno path: {}", e))?;
+
         // Build the deno command
-        let mut cmd = tokio::process::Command::new("deno");
+        let mut cmd = tokio::process::Command::new(&deno_path);
         cmd.arg("jupyter")
             .arg("--kernel")
             .arg("--conn")


### PR DESCRIPTION
Extends the tool bootstrapping pattern from ruff to deno. When deno is not found on PATH, it's automatically installed from conda-forge and cached in ~/.cache/runt/tools/. 

Users with a newer system deno continue to use their version (PATH is checked first). This ensures Deno notebooks work out of the box for all users.

Updated call sites: deno_env.rs, format.rs, kernel.rs.

Co-Authored-By: QuillAid <261289082+quillaid@users.noreply.github.com>