### PR TITLE
Upgrade pnpm to 10.30.0 to fix url.parse() deprecation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "runtimed",
   "private": true,
-  "packageManager": "pnpm@10.12.1",
+  "packageManager": "pnpm@10.30.0",
   "scripts": {
     "build": "pnpm run isolated-renderer:build && pnpm --dir apps/sidecar build && pnpm --dir apps/notebook build",
     "sidecar:build": "pnpm --dir apps/sidecar build",


### PR DESCRIPTION
Resolves the DEP0169 deprecation warning that appeared during pnpm install. The url.parse() warning was fixed in pnpm 10.30.0 by using the WHATWG URL API instead of the legacy url.parse() method. All tests, builds, and Rust checks pass successfully.