### PR TITLE
Make iframe background transparent for focused cell colors

### DIFF
--- a/src/components/outputs/isolated/frame-html.ts
+++ b/src/components/outputs/isolated/frame-html.ts
@@ -67,7 +67,7 @@ export function generateFrameHtml(options: FrameHtmlOptions = {}): string {
       font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
       font-size: 14px;
       line-height: 1.5;
-      background: var(--bg-primary);
+      background: transparent;
       color: var(--text-primary);
     }
 

--- a/src/isolated-renderer/index.tsx
+++ b/src/isolated-renderer/index.tsx
@@ -70,20 +70,18 @@ function updateDocumentTheme(isDark: boolean) {
   // Some widgets (like drawdata) use @media (prefers-color-scheme: dark)
   root.style.colorScheme = isDark ? "dark" : "light";
 
-  // Update CSS variables for base styles
+  // Update CSS variables for base styles (background kept transparent for cell focus colors to show through)
   if (isDark) {
     root.style.setProperty("--bg-primary", "#0a0a0a");
     root.style.setProperty("--bg-secondary", "#1a1a1a");
     root.style.setProperty("--text-primary", "#e0e0e0");
     root.style.setProperty("--text-secondary", "#a0a0a0");
-    root.style.setProperty("--background", "#0a0a0a");
     root.style.setProperty("--foreground", "#e0e0e0");
   } else {
     root.style.setProperty("--bg-primary", "#ffffff");
     root.style.setProperty("--bg-secondary", "#f5f5f5");
     root.style.setProperty("--text-primary", "#1a1a1a");
     root.style.setProperty("--text-secondary", "#666666");
-    root.style.setProperty("--background", "#ffffff");
     root.style.setProperty("--foreground", "#1a1a1a");
   }
 }

--- a/src/isolated-renderer/styles.css
+++ b/src/isolated-renderer/styles.css
@@ -102,7 +102,7 @@ html, body {
   font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   font-size: 14px;
   line-height: 1.5;
-  background: var(--background);
+  background: transparent;
   color: var(--foreground);
 }
 


### PR DESCRIPTION
## Summary

Allow the focused cell's signature background color (e.g., light blue for code cells) to show through the isolated output iframe by making the iframe body background transparent instead of opaque.

## Changes

- Made `html, body` background transparent in the bootstrap HTML template
- Made `html, body` background transparent in the isolated renderer styles  
- Removed hardcoded `--background` CSS variable assignments that were blocking transparency

Child elements like `pre` blocks and tables retain their secondary backgrounds for readability.

## Testing

✅ All unit tests pass (272 tests)  
✅ All builds successful (isolated renderer, sidecar, notebook)  
✅ Rust checks pass (clippy, release build, cargo test)