### PR TITLE
Enable conda environment support on Windows

### DIFF
--- a/crates/notebook/Cargo.toml
+++ b/crates/notebook/Cargo.toml
@@ -44,10 +44,6 @@ toml = "0.8"
 pathdiff = "0.2"
 pyproject-toml = "0.13"
 
-# Unix process group support for kernel cleanup
-[target.'cfg(unix)'.dependencies]
-nix = { version = "0.30", features = ["signal", "process"] }
-
 # Conda environment support via rattler
 rattler = "0.39"
 rattler_cache = "0.6"
@@ -58,6 +54,10 @@ rattler_virtual_packages = "2.3"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 reqwest-middleware = "0.4"
 url = "2.5"
+
+# Unix process group support for kernel cleanup
+[target.'cfg(unix)'.dependencies]
+nix = { version = "0.30", features = ["signal", "process"] }
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
Fixes the Windows build by moving rattler crate dependencies from the Unix-only configuration to the main dependencies section. The rattler crates were accidentally placed under `[target.'cfg(unix)'.dependencies']`, which excluded them from Windows builds while the `conda_env` module was unconditionally compiled, causing 36 compilation errors.

This change enables conda environment support on Windows, where it was already partially implemented. The `conda_env.rs` code already has Windows-aware path handling for Python executables and other platform-specific concerns.