### PR TITLE
Fix pnpm cache path in CI workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Enable corepack
         run: corepack enable
 
+      - name: Set pnpm store directory
+        run: pnpm config set store-dir ~/.pnpm-store
+
       - name: Cache pnpm store
         uses: actions/cache@v4
         with:
@@ -105,6 +108,9 @@ jobs:
 
       - name: Enable corepack
         run: corepack enable
+
+      - name: Set pnpm store directory
+        run: pnpm config set store-dir ~/.pnpm-store
 
       - name: Cache pnpm store
         uses: actions/cache@v4

--- a/.github/workflows/weekly-preview.yml
+++ b/.github/workflows/weekly-preview.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Enable corepack
         run: corepack enable
 
+      - name: Set pnpm store directory
+        run: pnpm config set store-dir ~/.pnpm-store
+
       - name: Cache pnpm store
         uses: actions/cache@v4
         with:
@@ -112,6 +115,9 @@ jobs:
       - name: Enable corepack
         run: corepack enable
 
+      - name: Set pnpm store directory
+        run: pnpm config set store-dir ~/.pnpm-store
+
       - name: Cache pnpm store
         uses: actions/cache@v4
         with:
@@ -179,6 +185,9 @@ jobs:
 
       - name: Enable corepack
         run: corepack enable
+
+      - name: Set pnpm store directory
+        run: pnpm config set store-dir ~/.pnpm-store
 
       - name: Cache pnpm store
         uses: actions/cache@v4
@@ -300,6 +309,9 @@ jobs:
 
       - name: Enable corepack
         run: corepack enable
+
+      - name: Set pnpm store directory
+        run: pnpm config set store-dir ~/.pnpm-store
 
       - name: Cache pnpm store
         uses: actions/cache@v4
@@ -510,6 +522,9 @@ jobs:
 
       - name: Enable corepack
         run: corepack enable
+
+      - name: Set pnpm store directory
+        run: pnpm config set store-dir ~/.pnpm-store
 
       - name: Cache pnpm store
         uses: actions/cache@v4


### PR DESCRIPTION
Fix pnpm cache path validation errors in GitHub Actions workflows.

The workflows attempted to cache `~/.pnpm-store`, but pnpm uses platform-specific default paths (e.g., `~/Library/pnpm/store/v10` on macOS). This caused "Path does not exist" warnings during cache post-processing, preventing any cache from being saved between runs.

Fixed by explicitly configuring pnpm to use `~/.pnpm-store` before installation in all jobs (except Windows which already uses the correct path). This ensures the cache directory exists and persists between CI runs.