### PR TITLE
Respect default_python_env setting and add UV warmup

### DIFF
--- a/crates/notebook/src/conda_env.rs
+++ b/crates/notebook/src/conda_env.rs
@@ -948,6 +948,7 @@ pub async fn warmup_conda_environment(env: &CondaEnvironment) -> Result<()> {
 import sys
 import ipykernel
 import IPython
+import ipywidgets
 import traitlets
 import zmq
 


### PR DESCRIPTION
## Summary

- **Default env type**: New notebooks now respect the user's `default_python_env` setting (Conda vs UV) instead of hardcoding UV
- **UV warmup**: Add `warmup_uv_environment()` to compile bytecode for ipykernel, IPython, ipywidgets, traitlets, zmq
- **Both warmups**: Include ipywidgets bytecode compilation for faster startup
- **UV recovery**: Skip unwarmed environments during recovery, matching conda behavior

These changes ensure consistent environment configuration and improve kernel startup times across both environment managers.