### PR TITLE
Fix crash when creating multiple notebooks rapidly (Cmd-N)

### DIFF
--- a/crates/notebook/src/conda_env.rs
+++ b/crates/notebook/src/conda_env.rs
@@ -1478,12 +1478,7 @@ pub async fn find_and_claim_prewarmed_conda_environments() -> Vec<CondaEnvironme
         })
         .await;
 
-        let lock_created = match claim_result {
-            Ok(Ok(_)) => true,
-            _ => false,
-        };
-
-        if !lock_created {
+        if !matches!(claim_result, Ok(Ok(_))) {
             // Another process already claimed this environment
             info!(
                 "[prewarm] Skipping already-claimed prewarmed conda env: {:?}",

--- a/crates/notebook/src/uv_env.rs
+++ b/crates/notebook/src/uv_env.rs
@@ -423,12 +423,7 @@ pub async fn find_and_claim_prewarmed_environments() -> Vec<UvEnvironment> {
         })
         .await;
 
-        let lock_created = match claim_result {
-            Ok(Ok(_)) => true,
-            _ => false,
-        };
-
-        if !lock_created {
+        if !matches!(claim_result, Ok(Ok(_))) {
             // Another process already claimed this environment
             info!(
                 "[prewarm] Skipping already-claimed prewarmed env: {:?}",


### PR DESCRIPTION
## Summary

Fixes the crash that occurs when rapidly creating multiple notebook windows using Cmd-N. Multiple windows are separate processes that share a prewarmed environment pool on disk, causing race conditions when they try to claim or use the same environments simultaneously.

## Changes

- **Path validation in take()**: Validates that environment paths still exist before returning them from the pool. If another process claimed/renamed an env, gracefully skip to the next one.
- **Warming locks**: Serialize environment creation across processes using atomic lock files (.warming.lock and .warming-conda.lock) to prevent resource contention.
- **Stale lock cleanup**: Automatically remove lock files older than 5 minutes to prevent stuck prewarming from crashed processes.
- **Shared pool model**: Multiple windows can have the same prewarmed environments in their pools. When one claims an env (renames it), others find it missing and skip it.