### PR TITLE
Add automatic daemon upgrade on version mismatch

### DIFF
--- a/contributing/runtimed.md
+++ b/contributing/runtimed.md
@@ -166,4 +166,45 @@ When shipped as a release build, the daemon installs as a system service that st
 - **Linux**: systemd user service in `~/.config/systemd/user/`
 - **Windows**: Startup folder script
 
-See user-facing documentation for service management commands.
+### Managing the Installed Service (for developers)
+
+If you have the app installed and want to run a development version of the daemon instead, you'll need to stop the installed service first.
+
+**macOS:**
+```bash
+# Stop the installed daemon
+launchctl unload ~/Library/LaunchAgents/io.runtimed.plist
+
+# Check status
+launchctl list | grep io.runtimed
+
+# Restart it later
+launchctl load ~/Library/LaunchAgents/io.runtimed.plist
+
+# Full uninstall (removes binary and service config)
+~/Library/Application\ Support/runt/bin/runtimed uninstall
+```
+
+**Linux:**
+```bash
+# Stop the installed daemon
+systemctl --user stop runtimed.service
+
+# Check status
+systemctl --user status runtimed.service
+
+# Restart it later
+systemctl --user start runtimed.service
+
+# Full uninstall
+~/.local/share/runt/bin/runtimed uninstall
+```
+
+**Key paths (macOS):**
+| File | Path |
+|------|------|
+| Installed binary | `~/Library/Application Support/runt/bin/runtimed` |
+| Service config | `~/Library/LaunchAgents/io.runtimed.plist` |
+| Socket | `~/Library/Caches/runt/runtimed.sock` |
+| Daemon info | `~/Library/Caches/runt/daemon.json` |
+| Logs | `~/Library/Caches/runt/runtimed.log` |

--- a/crates/runtimed/src/client.rs
+++ b/crates/runtimed/src/client.rs
@@ -226,10 +226,11 @@ pub async fn try_get_pooled_env(_env_type: EnvType) -> Option<PooledEnv> {
 ///
 /// This function:
 /// 1. Checks if the daemon responds to ping
-/// 2. If not responding, checks if the service is installed
-/// 3. If not installed, installs the service using the provided binary path
-/// 4. Starts the service if not running
-/// 5. Waits for the daemon to be ready
+/// 2. If running, checks version - upgrades if bundled version differs
+/// 3. If not responding, checks if the service is installed
+/// 4. If not installed, installs the service using the provided binary path
+/// 5. Starts the service if not running
+/// 6. Waits for the daemon to be ready
 ///
 /// Returns Ok(endpoint) if daemon is running, Err if it couldn't be started.
 ///
@@ -242,18 +243,45 @@ pub async fn ensure_daemon_running(
     use crate::singleton::get_running_daemon_info;
 
     let client = PoolClient::default();
+    let manager = ServiceManager::default();
+
+    // Version of the bundled/calling binary
+    let bundled_version = env!("CARGO_PKG_VERSION");
 
     // First, try to ping the daemon
     if client.ping().await.is_ok() {
         if let Some(info) = get_running_daemon_info() {
+            // Check if we need to upgrade
+            if info.version != bundled_version {
+                info!(
+                    "[pool-client] Version mismatch: running={}, bundled={}",
+                    info.version, bundled_version
+                );
+
+                if let Some(binary_path) = &daemon_binary {
+                    if !binary_path.exists() {
+                        return Err(EnsureDaemonError::BinaryNotFound(binary_path.clone()));
+                    }
+
+                    info!("[pool-client] Upgrading daemon...");
+                    manager
+                        .upgrade(binary_path)
+                        .map_err(|e| EnsureDaemonError::UpgradeFailed(e.to_string()))?;
+
+                    // Wait for upgraded daemon to be ready
+                    return wait_for_daemon_ready(&client).await;
+                } else {
+                    // No binary path provided, can't upgrade - just use existing
+                    info!("[pool-client] No binary path provided, using existing daemon");
+                }
+            }
+
             info!("[pool-client] Daemon already running at {}", info.endpoint);
             return Ok(info.endpoint);
         }
     }
 
     info!("[pool-client] Daemon not responding, checking service...");
-
-    let manager = ServiceManager::default();
 
     // Install if not already installed
     if !manager.is_installed() {
@@ -276,7 +304,15 @@ pub async fn ensure_daemon_running(
         .start()
         .map_err(|e| EnsureDaemonError::StartFailed(e.to_string()))?;
 
-    // Wait for daemon to be ready (up to 10 seconds)
+    // Wait for daemon to be ready
+    wait_for_daemon_ready(&client).await
+}
+
+/// Wait for the daemon to become ready (up to 10 seconds).
+#[cfg(unix)]
+async fn wait_for_daemon_ready(client: &PoolClient) -> Result<String, EnsureDaemonError> {
+    use crate::singleton::get_running_daemon_info;
+
     info!("[pool-client] Waiting for daemon to be ready...");
     for i in 0..20 {
         tokio::time::sleep(Duration::from_millis(500)).await;
@@ -319,6 +355,9 @@ pub enum EnsureDaemonError {
 
     #[error("Failed to start daemon service: {0}")]
     StartFailed(String),
+
+    #[error("Failed to upgrade daemon service: {0}")]
+    UpgradeFailed(String),
 
     #[error("Daemon did not become ready within timeout")]
     Timeout,


### PR DESCRIPTION
## Summary

Implement automatic version detection and upgrade for the runtimed daemon when the notebook app detects a version mismatch. This enables seamless app upgrades without requiring manual daemon restart or uninstall.

The upgrade flow stops the old daemon, replaces the binary, and restarts the service. Also fixed the bundled binary path resolution to work correctly in both bundled macOS apps and development builds.

Added developer documentation for managing the installed service when running development builds locally.

## Testing

- Fresh DMG installation: daemon installs and starts as launchd service on first launch
- Upgrade scenario: version mismatch detected, daemon automatically upgraded, pools remain healthy
- Both bundled and development build paths verified