### PR TITLE
Optimize markdown rendering with replace semantics

### DIFF
--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -86,19 +86,22 @@ export function MarkdownCell({
     frameRef.current.render({
       mimeType: "text/markdown",
       data: cell.source,
+      cellId: cell.id,
+      replace: true,
     });
-  }, [cell.source]);
+  }, [cell.source, cell.id]);
 
   // Sync markdown to iframe whenever source changes (supports RTC updates)
   useEffect(() => {
     if (frameRef.current?.isReady && cell.source) {
-      frameRef.current.clear();
       frameRef.current.render({
         mimeType: "text/markdown",
         data: cell.source,
+        cellId: cell.id,
+        replace: true,
       });
     }
-  }, [cell.source]);
+  }, [cell.source, cell.id]);
 
   // Handle link clicks from iframe
   const handleLinkClick = useCallback((url: string) => {

--- a/src/components/outputs/isolated/frame-bridge.ts
+++ b/src/components/outputs/isolated/frame-bridge.ts
@@ -40,6 +40,8 @@ export interface RenderPayload {
   outputIndex?: number;
   /** If true, append to existing outputs instead of replacing */
   append?: boolean;
+  /** If true, replace all existing outputs with this single output */
+  replace?: boolean;
 }
 
 /**

--- a/src/isolated-renderer/index.tsx
+++ b/src/isolated-renderer/index.tsx
@@ -117,11 +117,20 @@ function IsolatedRendererApp() {
     switch (type) {
       case "render": {
         const renderPayload = payload as RenderPayload;
-        const id = `output-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-        setState((prev) => ({
-          ...prev,
-          outputs: [...prev.outputs, { id, payload: renderPayload }],
-        }));
+
+        // Generate stable ID when cellId is provided for better React reconciliation
+        const id = renderPayload.cellId
+          ? `${renderPayload.cellId}-${renderPayload.outputIndex ?? 0}`
+          : `output-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+        setState((prev) => {
+          if (renderPayload.replace) {
+            // Replace all outputs with this single new output
+            return { ...prev, outputs: [{ id, payload: renderPayload }] };
+          }
+          // Default: append to existing outputs
+          return { ...prev, outputs: [...prev.outputs, { id, payload: renderPayload }] };
+        });
 
         // Notify parent of render completion after next paint
         requestAnimationFrame(() => {


### PR DESCRIPTION
Replaces the inefficient clear+render pattern with a single replace operation for markdown cells, allowing React to reconcile efficiently and preserve component state during updates.

Changes:
- Add `replace` flag to `RenderPayload` interface
- Generate stable output IDs based on cellId+outputIndex for better React reconciliation
- Update MarkdownCell to use `replace: true` instead of separate clear() and render() calls

Closes #132