### PR TITLE
Fix environment specification matching for notebooks with dependencies

### DIFF
--- a/contributing/development.md
+++ b/contributing/development.md
@@ -7,7 +7,7 @@
 | Start dev server | `cargo xtask dev` |
 | Quick debug build | `cargo xtask build` |
 | Build and run | `cargo xtask run` |
-| Run with notebook | `cargo xtask run path/to/notebook.ipynb` |
+| Run with notebook | `cargo xtask build && ./target/debug/notebook path/to/notebook.ipynb` |
 | Build release .app | `cargo xtask build-app` |
 | Build release DMG | `cargo xtask build-dmg` |
 
@@ -37,9 +37,12 @@ cargo xtask build
 # Build and run
 cargo xtask run
 
-# Build and run with a notebook
-cargo xtask run notebooks/test-isolation.ipynb
+# Build and open a specific notebook
+cargo xtask build
+./target/debug/notebook path/to/notebook.ipynb
 ```
+
+**Note:** Use `./target/debug/notebook` directly to open notebooks with file paths. The `cargo xtask run` command doesn't pass file arguments through correctly.
 
 ### `cargo xtask build-app` / `build-dmg` — Release Builds
 
@@ -66,5 +69,6 @@ cargo build         # Build Rust
 The `notebooks/` directory has test files:
 
 ```bash
-cargo xtask run notebooks/test-isolation.ipynb
+cargo xtask build
+./target/debug/notebook notebooks/test-isolation.ipynb
 ```


### PR DESCRIPTION
## Summary

When notebooks have dependencies (e.g., mlx-audio, spacy), they need to be resolved through `prepare_environment()` which finds/creates cached environments keyed by dependency hash. The daemon-based prewarming is only for blank notebooks. This fixes a regression from commit 936d465 where notebooks with existing cached environments weren't finding them.

## Changes

- Route notebooks WITH dependencies to `prepare_environment()` (finds cached envs)
- Use prewarmed envs only for notebooks WITHOUT dependencies (preserves fast startup)
- When both uv and conda metadata exist in notebook, pick the one with actual dependencies (fixes ambiguity when conda deps are empty but uv has packages)
- Updated development guide to correctly document `cargo xtask build` + `./target/debug/notebook` workflow

## Testing

Verify by opening a notebook with dependencies (like MLX audio demo with mlx-audio[tts]):
- Subsequent opens find cached environment (fast startup)
- Imports work correctly (packages are available)