### PR TITLE
Fix pyproject.toml detection for new notebooks

### DIFF
--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -25,7 +25,7 @@ use notebook_state::{FrontendCell, NotebookState};
 use log::{error, info};
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use tauri::{Emitter, Manager, RunEvent};
@@ -2408,7 +2408,7 @@ fn spawn_new_notebook(runtime: Runtime) {
 }
 
 /// Create initial notebook state for a new notebook, detecting pyproject.toml for Python.
-fn create_new_notebook_state(path: &PathBuf, runtime: Runtime) -> NotebookState {
+fn create_new_notebook_state(path: &Path, runtime: Runtime) -> NotebookState {
     // Only check pyproject.toml for Python runtime
     if runtime == Runtime::Python {
         if let Some(pyproject_path) = pyproject::find_pyproject(path) {
@@ -2419,7 +2419,7 @@ fn create_new_notebook_state(path: &PathBuf, runtime: Runtime) -> NotebookState 
                     pyproject_path.display()
                 );
                 let mut state = NotebookState::new_empty_with_uv_from_pyproject(&config);
-                state.path = Some(path.clone());
+                state.path = Some(path.to_path_buf());
                 return state;
             }
         }
@@ -2427,7 +2427,7 @@ fn create_new_notebook_state(path: &PathBuf, runtime: Runtime) -> NotebookState 
 
     // No pyproject.toml found (or non-Python runtime) - use default
     let mut state = NotebookState::new_empty_with_runtime(runtime);
-    state.path = Some(path.clone());
+    state.path = Some(path.to_path_buf());
     state
 }
 

--- a/crates/notebook/src/notebook_state.rs
+++ b/crates/notebook/src/notebook_state.rs
@@ -217,6 +217,53 @@ impl NotebookState {
         }
     }
 
+    /// Create a new empty Python notebook with UV metadata from a pyproject.toml config.
+    /// Used when creating a new notebook in a directory with pyproject.toml.
+    pub fn new_empty_with_uv_from_pyproject(config: &crate::pyproject::PyProjectConfig) -> Self {
+        let env_id = Uuid::new_v4().to_string();
+        let mut additional = HashMap::new();
+
+        let all_deps = crate::pyproject::get_all_dependencies(config);
+
+        additional.insert(
+            "uv".to_string(),
+            serde_json::json!({
+                "dependencies": all_deps,
+                "requires-python": config.requires_python,
+            }),
+        );
+
+        additional.insert(
+            "runt".to_string(),
+            serde_json::json!({
+                "env_id": env_id,
+                "runtime": "python",
+            }),
+        );
+
+        NotebookState {
+            notebook: Notebook {
+                metadata: nbformat::v4::Metadata {
+                    kernelspec: None,
+                    language_info: None,
+                    authors: None,
+                    additional,
+                },
+                nbformat: 4,
+                nbformat_minor: 5,
+                cells: vec![Cell::Code {
+                    id: CellId::from(Uuid::new_v4()),
+                    metadata: empty_cell_metadata(),
+                    execution_count: None,
+                    source: Vec::new(),
+                    outputs: Vec::new(),
+                }],
+            },
+            path: None,
+            dirty: false,
+        }
+    }
+
     pub fn from_notebook(notebook: Notebook, path: PathBuf) -> Self {
         NotebookState {
             notebook,


### PR DESCRIPTION
When creating a new notebook in a directory with pyproject.toml, the app now detects it and uses UV environment instead of defaulting to conda. Previously, environment detection only ran after notebook metadata was already set to conda.

## Changes

- Added `new_empty_with_uv_from_pyproject()` constructor to create notebooks with UV metadata populated from pyproject.toml dependencies
- Added `create_new_notebook_state()` helper that detects pyproject.toml during notebook creation, before metadata is finalized
- Modified the notebook creation flow to use the new helper when creating notebooks at a specified path

## How to verify

Create a new notebook in a directory containing a pyproject.toml file with dependencies. The notebook UI should show the UV/pip environment picker instead of conda.