### PR TITLE
Add CLI launch capability to notebook app

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,16 +71,18 @@ jobs:
           pnpm --dir apps/sidecar build
           pnpm --dir apps/notebook build
 
-      - name: Build runtimed daemon
+      - name: Build external binaries
         shell: bash
         run: |
-          cargo build --release -p runtimed
+          cargo build --release -p runtimed -p runt-cli
           TARGET=$(rustc --print host-tuple)
           mkdir -p crates/notebook/binaries
           if [[ "$RUNNER_OS" == "Windows" ]]; then
             cp target/release/runtimed.exe "crates/notebook/binaries/runtimed-$TARGET.exe"
+            cp target/release/runt.exe "crates/notebook/binaries/runt-$TARGET.exe"
           else
             cp target/release/runtimed "crates/notebook/binaries/runtimed-$TARGET"
+            cp target/release/runt "crates/notebook/binaries/runt-$TARGET"
           fi
 
       - name: Clippy
@@ -157,16 +159,18 @@ jobs:
             cargo install tauri-cli tauri-driver --locked
           fi
 
-      - name: Build runtimed daemon
+      - name: Build external binaries
         run: |
-          cargo build --release -p runtimed
+          cargo build --release -p runtimed -p runt-cli
           TARGET=$(rustc --print host-tuple)
           # Copy to crates/notebook/binaries/ for Tauri build validation
           mkdir -p crates/notebook/binaries
           cp target/release/runtimed "crates/notebook/binaries/runtimed-$TARGET"
+          cp target/release/runt "crates/notebook/binaries/runt-$TARGET"
           # Copy to target/release/binaries/ for runtime (no-bundle builds)
           mkdir -p target/release/binaries
           cp target/release/runtimed "target/release/binaries/runtimed-$TARGET"
+          cp target/release/runt "target/release/binaries/runt-$TARGET"
 
       - name: Build Tauri app
         run: cd crates/notebook && cargo tauri build --ci --no-bundle --config '{"build":{"beforeBuildCommand":""}}'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,6 +143,7 @@ jobs:
       - name: Build frontend
         run: |
           pnpm run isolated-renderer:build
+          pnpm --dir apps/sidecar build
           pnpm --dir apps/notebook build
 
       - name: Cache cargo bin

--- a/.github/workflows/weekly-preview.yml
+++ b/.github/workflows/weekly-preview.yml
@@ -256,12 +256,13 @@ jobs:
       - name: Generate Icons
         run: cargo xtask icons
 
-      - name: Build runtimed daemon
+      - name: Build external binaries
         run: |
-          cargo build --release -p runtimed
+          cargo build --release -p runtimed -p runt-cli
           TARGET=$(rustc --print host-tuple)
           mkdir -p crates/notebook/binaries
           cp target/release/runtimed "crates/notebook/binaries/runtimed-$TARGET"
+          cp target/release/runt "crates/notebook/binaries/runt-$TARGET"
 
       - name: Build and Sign DMG
         env:
@@ -387,11 +388,12 @@ jobs:
       - name: Generate Icons
         run: cargo xtask icons
 
-      - name: Build runtimed daemon
+      - name: Build external binaries
         run: |
-          cargo build --release -p runtimed --target x86_64-apple-darwin
+          cargo build --release -p runtimed -p runt-cli --target x86_64-apple-darwin
           mkdir -p crates/notebook/binaries
           cp target/x86_64-apple-darwin/release/runtimed "crates/notebook/binaries/runtimed-x86_64-apple-darwin"
+          cp target/x86_64-apple-darwin/release/runt "crates/notebook/binaries/runt-x86_64-apple-darwin"
 
       - name: Build and Sign DMG
         env:
@@ -490,13 +492,14 @@ jobs:
       - name: Generate Icons
         run: cargo xtask icons
 
-      - name: Build runtimed daemon
+      - name: Build external binaries
         shell: bash
         run: |
-          cargo build --release -p runtimed
+          cargo build --release -p runtimed -p runt-cli
           TARGET=$(rustc --print host-tuple)
           mkdir -p crates/notebook/binaries
           cp target/release/runtimed.exe "crates/notebook/binaries/runtimed-$TARGET.exe"
+          cp target/release/runt.exe "crates/notebook/binaries/runt-$TARGET.exe"
 
       - name: Build NSIS Installer
         run: cargo tauri build --ci --bundles nsis --config '{"build":{"beforeBuildCommand":""}}'
@@ -586,12 +589,13 @@ jobs:
       - name: Generate Icons
         run: cargo xtask icons
 
-      - name: Build runtimed daemon
+      - name: Build external binaries
         run: |
-          cargo build --release -p runtimed
+          cargo build --release -p runtimed -p runt-cli
           TARGET=$(rustc --print host-tuple)
           mkdir -p crates/notebook/binaries
           cp target/release/runtimed "crates/notebook/binaries/runtimed-$TARGET"
+          cp target/release/runt "crates/notebook/binaries/runt-$TARGET"
 
       - name: Build AppImage
         run: cargo tauri build --ci --bundles appimage --config '{"build":{"beforeBuildCommand":""}}'

--- a/crates/notebook/binaries/.gitignore
+++ b/crates/notebook/binaries/.gitignore
@@ -1,2 +1,3 @@
-# Ignore all runtimed binaries (built by xtask)
+# Ignore all external binaries (built by xtask)
 runtimed-*
+runt-*

--- a/crates/notebook/src/cli_install.rs
+++ b/crates/notebook/src/cli_install.rs
@@ -141,9 +141,9 @@ pub fn install_cli(app: &tauri::AppHandle) -> Result<(), String> {
 
 /// Try to install directly without admin privileges
 fn try_install_direct(
-    bundled_runt: &PathBuf,
-    runt_dest: &PathBuf,
-    nb_dest: &PathBuf,
+    bundled_runt: &std::path::Path,
+    runt_dest: &std::path::Path,
+    nb_dest: &std::path::Path,
 ) -> Result<(), String> {
     // Copy runt binary
     fs::copy(bundled_runt, runt_dest)
@@ -167,7 +167,7 @@ fn try_install_direct(
 }
 
 /// Create the nb wrapper script
-fn create_nb_wrapper(nb_dest: &PathBuf) -> Result<(), String> {
+fn create_nb_wrapper(nb_dest: &std::path::Path) -> Result<(), String> {
     let script = r#"#!/bin/bash
 # nb - Runt Notebook CLI (shorthand for 'runt notebook')
 # Installed by runt-notebook.app
@@ -197,9 +197,9 @@ exec runt notebook "$@"
 /// Install using macOS admin privileges via osascript
 #[cfg(target_os = "macos")]
 fn install_with_admin_privileges(
-    bundled_runt: &PathBuf,
-    runt_dest: &PathBuf,
-    nb_dest: &PathBuf,
+    bundled_runt: &std::path::Path,
+    runt_dest: &std::path::Path,
+    nb_dest: &std::path::Path,
 ) -> Result<(), String> {
     let nb_script = r#"#!/bin/bash
 # nb - Runt Notebook CLI (shorthand for 'runt notebook')

--- a/crates/notebook/src/cli_install.rs
+++ b/crates/notebook/src/cli_install.rs
@@ -1,0 +1,246 @@
+//! CLI installation module for copying the bundled `runt` binary to PATH
+//! and creating the `nb` wrapper script.
+
+use std::fs;
+use std::io::Write;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+use std::path::PathBuf;
+#[cfg(target_os = "macos")]
+use std::process::Command;
+use tauri::Manager;
+
+/// The directory where CLI tools are installed
+#[cfg(target_os = "macos")]
+const INSTALL_DIR: &str = "/usr/local/bin";
+
+#[cfg(target_os = "linux")]
+const INSTALL_DIR: &str = "/usr/local/bin";
+
+#[cfg(target_os = "windows")]
+const INSTALL_DIR: &str = ""; // Windows uses different mechanism
+
+/// Get the path to the bundled runt binary.
+pub fn get_bundled_runt_path(app: &tauri::AppHandle) -> Option<PathBuf> {
+    #[cfg(target_os = "macos")]
+    {
+        if let Ok(exe_dir) = app.path().resource_dir() {
+            // resource_dir on macOS points to Contents/Resources
+            // The binary is in Contents/MacOS, which is ../MacOS from Resources
+            let macos_dir = exe_dir.parent()?.join("MacOS");
+            let bundled_path = macos_dir.join("runt");
+            if bundled_path.exists() {
+                log::debug!("[cli_install] Found bundled runt at {:?}", bundled_path);
+                return Some(bundled_path);
+            }
+            log::debug!("[cli_install] Bundled runt not found at {:?}", bundled_path);
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        if let Ok(resource_dir) = app.path().resource_dir() {
+            let bundled_path = resource_dir.join("runt");
+            if bundled_path.exists() {
+                log::debug!("[cli_install] Found bundled runt at {:?}", bundled_path);
+                return Some(bundled_path);
+            }
+            log::debug!("[cli_install] Bundled runt not found at {:?}", bundled_path);
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        if let Ok(resource_dir) = app.path().resource_dir() {
+            let bundled_path = resource_dir.join("runt.exe");
+            if bundled_path.exists() {
+                log::debug!("[cli_install] Found bundled runt at {:?}", bundled_path);
+                return Some(bundled_path);
+            }
+            log::debug!("[cli_install] Bundled runt not found at {:?}", bundled_path);
+        }
+    }
+
+    // Fallback: try the development path (target/*/binaries/runt-{target})
+    let target = if cfg!(target_os = "macos") {
+        if cfg!(target_arch = "aarch64") {
+            "aarch64-apple-darwin"
+        } else {
+            "x86_64-apple-darwin"
+        }
+    } else if cfg!(target_os = "linux") {
+        if cfg!(target_arch = "aarch64") {
+            "aarch64-unknown-linux-gnu"
+        } else {
+            "x86_64-unknown-linux-gnu"
+        }
+    } else {
+        "x86_64-pc-windows-msvc"
+    };
+
+    let binary_name = if cfg!(windows) {
+        format!("runt-{}.exe", target)
+    } else {
+        format!("runt-{}", target)
+    };
+
+    // Try to find it relative to the executable (for no-bundle dev builds)
+    if let Ok(exe_path) = std::env::current_exe() {
+        if let Some(exe_dir) = exe_path.parent() {
+            let dev_path = exe_dir.join("binaries").join(&binary_name);
+            if dev_path.exists() {
+                log::debug!("[cli_install] Found dev runt at {:?}", dev_path);
+                return Some(dev_path);
+            }
+            log::debug!("[cli_install] Dev runt not found at {:?}", dev_path);
+        }
+    }
+
+    None
+}
+
+/// Check if the CLI is already installed
+pub fn is_cli_installed() -> bool {
+    let runt_path = PathBuf::from(INSTALL_DIR).join("runt");
+    let nb_path = PathBuf::from(INSTALL_DIR).join("nb");
+    runt_path.exists() && nb_path.exists()
+}
+
+/// Install the CLI to the system PATH
+/// Returns Ok(()) on success, Err with message on failure
+pub fn install_cli(app: &tauri::AppHandle) -> Result<(), String> {
+    let bundled_runt = get_bundled_runt_path(app)
+        .ok_or_else(|| "Could not find bundled runt binary".to_string())?;
+
+    let install_dir = PathBuf::from(INSTALL_DIR);
+    let runt_dest = install_dir.join("runt");
+    let nb_dest = install_dir.join("nb");
+
+    // Try direct copy first
+    match try_install_direct(&bundled_runt, &runt_dest, &nb_dest) {
+        Ok(()) => {
+            log::info!("[cli_install] CLI installed successfully via direct copy");
+            return Ok(());
+        }
+        Err(e) => {
+            log::debug!("[cli_install] Direct install failed: {}, trying with admin privileges", e);
+        }
+    }
+
+    // Fall back to admin privileges
+    #[cfg(target_os = "macos")]
+    {
+        install_with_admin_privileges(&bundled_runt, &runt_dest, &nb_dest)
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        Err("Permission denied. Please run with administrator privileges.".to_string())
+    }
+}
+
+/// Try to install directly without admin privileges
+fn try_install_direct(
+    bundled_runt: &PathBuf,
+    runt_dest: &PathBuf,
+    nb_dest: &PathBuf,
+) -> Result<(), String> {
+    // Copy runt binary
+    fs::copy(bundled_runt, runt_dest)
+        .map_err(|e| format!("Failed to copy runt: {}", e))?;
+
+    // Make it executable
+    #[cfg(unix)]
+    {
+        let mut perms = fs::metadata(runt_dest)
+            .map_err(|e| format!("Failed to get runt permissions: {}", e))?
+            .permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(runt_dest, perms)
+            .map_err(|e| format!("Failed to set runt permissions: {}", e))?;
+    }
+
+    // Create nb wrapper script
+    create_nb_wrapper(nb_dest)?;
+
+    Ok(())
+}
+
+/// Create the nb wrapper script
+fn create_nb_wrapper(nb_dest: &PathBuf) -> Result<(), String> {
+    let script = r#"#!/bin/bash
+# nb - Runt Notebook CLI (shorthand for 'runt notebook')
+# Installed by runt-notebook.app
+exec runt notebook "$@"
+"#;
+
+    let mut file = fs::File::create(nb_dest)
+        .map_err(|e| format!("Failed to create nb script: {}", e))?;
+
+    file.write_all(script.as_bytes())
+        .map_err(|e| format!("Failed to write nb script: {}", e))?;
+
+    // Make it executable
+    #[cfg(unix)]
+    {
+        let mut perms = fs::metadata(nb_dest)
+            .map_err(|e| format!("Failed to get nb permissions: {}", e))?
+            .permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(nb_dest, perms)
+            .map_err(|e| format!("Failed to set nb permissions: {}", e))?;
+    }
+
+    Ok(())
+}
+
+/// Install using macOS admin privileges via osascript
+#[cfg(target_os = "macos")]
+fn install_with_admin_privileges(
+    bundled_runt: &PathBuf,
+    runt_dest: &PathBuf,
+    nb_dest: &PathBuf,
+) -> Result<(), String> {
+    let nb_script = r#"#!/bin/bash
+# nb - Runt Notebook CLI (shorthand for 'runt notebook')
+# Installed by runt-notebook.app
+exec runt notebook \"$@\"
+"#;
+
+    // Build the shell commands to run with admin privileges
+    let commands = format!(
+        r#"
+        cp '{}' '{}' && \
+        chmod 755 '{}' && \
+        echo '{}' > '{}' && \
+        chmod 755 '{}'
+        "#,
+        bundled_runt.display(),
+        runt_dest.display(),
+        runt_dest.display(),
+        nb_script,
+        nb_dest.display(),
+        nb_dest.display()
+    );
+
+    let script = format!(
+        r#"do shell script "{}" with administrator privileges"#,
+        commands.replace('"', r#"\""#).replace('\n', " ")
+    );
+
+    let output = Command::new("osascript")
+        .args(["-e", &script])
+        .output()
+        .map_err(|e| format!("Failed to run osascript: {}", e))?;
+
+    if output.status.success() {
+        Ok(())
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if stderr.contains("User canceled") || stderr.contains("(-128)") {
+            Err("Installation cancelled by user.".to_string())
+        } else {
+            Err(format!("Installation failed: {}", stderr))
+        }
+    }
+}

--- a/crates/notebook/src/menu.rs
+++ b/crates/notebook/src/menu.rs
@@ -13,6 +13,9 @@ pub const MENU_ZOOM_IN: &str = "zoom_in";
 pub const MENU_ZOOM_OUT: &str = "zoom_out";
 pub const MENU_ZOOM_RESET: &str = "zoom_reset";
 
+// Menu item IDs for CLI installation
+pub const MENU_INSTALL_CLI: &str = "install_cli";
+
 /// Build the application menu bar
 pub fn create_menu(app: &AppHandle) -> tauri::Result<Menu<Wry>> {
     let menu = Menu::new(app)?;
@@ -20,6 +23,14 @@ pub fn create_menu(app: &AppHandle) -> tauri::Result<Menu<Wry>> {
     // App menu (macOS standard - shows app name)
     let app_menu = Submenu::new(app, "runt-notebook", true)?;
     app_menu.append(&PredefinedMenuItem::about(app, Some("runt-notebook"), None)?)?;
+    app_menu.append(&PredefinedMenuItem::separator(app)?)?;
+    app_menu.append(&MenuItem::with_id(
+        app,
+        MENU_INSTALL_CLI,
+        "Install 'runt' Command in PATH...",
+        true,
+        None::<&str>,
+    )?)?;
     app_menu.append(&PredefinedMenuItem::separator(app)?)?;
     app_menu.append(&PredefinedMenuItem::services(app, None)?)?;
     app_menu.append(&PredefinedMenuItem::separator(app)?)?;

--- a/crates/notebook/tauri.conf.json
+++ b/crates/notebook/tauri.conf.json
@@ -24,7 +24,7 @@
   },
   "bundle": {
     "active": true,
-    "externalBin": ["binaries/runtimed"],
+    "externalBin": ["binaries/runtimed", "binaries/runt"],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/crates/sidecar/src/lib.rs
+++ b/crates/sidecar/src/lib.rs
@@ -626,7 +626,8 @@ pub fn launch(file: &Path, quiet: bool, dump: Option<&Path>) -> Result<()> {
     #[cfg(target_os = "windows")]
     {
         use tao::platform::windows::WindowExtWindows;
-        menu_bar.init_for_hwnd(window.hwnd() as _).ok();
+        // SAFETY: window.hwnd() returns a valid HWND for the duration of the window's lifetime
+        unsafe { menu_bar.init_for_hwnd(window.hwnd() as _) }.ok();
     }
     // Linux: Menu bar initialization skipped - requires GTK integration
 


### PR DESCRIPTION
## Summary

Bundle the `runt` CLI with the app and add a `notebook` subcommand that allows users to launch the app from the terminal. Users can install `runt` and `nb` (shorthand wrapper) to `/usr/local/bin` via a menu item in the app.

## Changes

- Add `runt notebook [PATH]` subcommand with cross-platform app launching
- Bundle `runt` binary with app via Tauri `externalBin` configuration
- Add `cli_install` module to handle copying binaries to PATH with admin privilege support
- Add "Install 'runt' Command in PATH..." menu item to app menu
- Support both `runt notebook` and `nb` commands after installation

## Testing

After building with `cargo xtask build-app`, verify the feature works by:
- Opening the app and going to the app menu
- Click "Install 'runt' Command in PATH..." and authorize when prompted
- In terminal, verify both commands work: `which runt && which nb`
- Test various invocations: `nb`, `nb myfile.ipynb`, `nb .`, `nb --runtime deno`
- Verify existing CLI functionality still works: `runt ps`, `runt start python3`, etc.

Closes #157