### PR TITLE
Use project .venv for pyproject.toml-backed uv setups

### DIFF
--- a/apps/notebook/src/hooks/useDependencies.ts
+++ b/apps/notebook/src/hooks/useDependencies.ts
@@ -33,6 +33,7 @@ export interface PyProjectInfo {
   dependency_count: number;
   has_dev_dependencies: boolean;
   requires_python: string | null;
+  has_venv: boolean;
 }
 
 export function useDependencies() {

--- a/apps/notebook/src/hooks/useKernel.ts
+++ b/apps/notebook/src/hooks/useKernel.ts
@@ -38,6 +38,7 @@ export interface PyProjectInfo {
   dependency_count: number;
   has_dev_dependencies: boolean;
   requires_python: string | null;
+  has_venv: boolean;
 }
 
 /** Info about a detected deno.json/deno.jsonc */
@@ -434,11 +435,12 @@ export function useKernel({
         }
 
         // Check for pyproject.toml (auto-detect if present)
+        // Use pyproject.toml path if it has dependencies OR a .venv exists in the project
         const uvAvailable = await invoke<boolean>("check_uv_available");
         if (uvAvailable) {
           const pyprojectInfo = await invoke<PyProjectInfo | null>("detect_pyproject");
-          if (pyprojectInfo?.has_dependencies) {
-            console.log("[kernel] detected pyproject.toml:", pyprojectInfo.relative_path);
+          if (pyprojectInfo?.has_dependencies || pyprojectInfo?.has_venv) {
+            console.log("[kernel] detected pyproject.toml:", pyprojectInfo.relative_path, "has_venv:", pyprojectInfo.has_venv);
             await startKernelWithPyproject();
             return;
           }

--- a/apps/notebook/src/hooks/useKernel.ts
+++ b/apps/notebook/src/hooks/useKernel.ts
@@ -434,13 +434,14 @@ export function useKernel({
           return;
         }
 
-        // Check for pyproject.toml (auto-detect if present)
-        // Use pyproject.toml path if it has dependencies OR a .venv exists in the project
+        // Check for pyproject.toml (auto-detect if present).
+        // Pyproject-backed environments are preferred over notebook-level dependency
+        // configuration when both are present.
         const uvAvailable = await invoke<boolean>("check_uv_available");
         if (uvAvailable) {
           const pyprojectInfo = await invoke<PyProjectInfo | null>("detect_pyproject");
           if (pyprojectInfo?.has_dependencies || pyprojectInfo?.has_venv) {
-            console.log("[kernel] detected pyproject.toml:", pyprojectInfo.relative_path, "has_venv:", pyprojectInfo.has_venv);
+            console.log("[kernel] detected pyproject.toml (preferred backend):", pyprojectInfo.relative_path, "has_venv:", pyprojectInfo.has_venv);
             await startKernelWithPyproject();
             return;
           }

--- a/crates/notebook/src/pyproject.rs
+++ b/crates/notebook/src/pyproject.rs
@@ -45,6 +45,8 @@ pub struct PyProjectInfo {
     pub has_dev_dependencies: bool,
     /// Python version constraint if specified.
     pub requires_python: Option<String>,
+    /// Whether a .venv directory exists in the project.
+    pub has_venv: bool,
 }
 
 // [tool.uv] section - not covered by pyproject-toml crate
@@ -163,6 +165,13 @@ pub fn create_pyproject_info(config: &PyProjectConfig, notebook_path: &Path) -> 
             .map(|p| p.display().to_string())
             .unwrap_or_else(|| config.path.display().to_string());
 
+    // Check if .venv exists in the project directory
+    let has_venv = config
+        .path
+        .parent()
+        .map(|dir| dir.join(".venv").is_dir())
+        .unwrap_or(false);
+
     PyProjectInfo {
         path: config.path.display().to_string(),
         relative_path,
@@ -171,6 +180,7 @@ pub fn create_pyproject_info(config: &PyProjectConfig, notebook_path: &Path) -> 
         dependency_count: config.dependencies.len(),
         has_dev_dependencies: !config.dev_dependencies.is_empty(),
         requires_python: config.requires_python.clone(),
+        has_venv,
     }
 }
 


### PR DESCRIPTION
When a pyproject.toml project has a .venv directory, the app now uses that existing environment instead of creating ephemeral cached environments in ~/.cache/runt/envs/. This prevents repeated downloads of large packages like spacy models that are installed locally.

The fix detects .venv in the project directory and triggers the uv run --directory path when found, even if pyproject.toml has no declared dependencies. This allows users to maintain persistent .venv directories with side-loaded data and models while still supporting the standard pyproject.toml workflow.

## Testing
- Open a notebook in a project with pyproject.toml and an existing .venv
- Verify the kernel uses the project environment (check sys.prefix in a cell)
- Confirm the environment persists across kernel restarts