### PR TITLE
Add notebook sync protocol types and fractional indexing

### DIFF
--- a/crates/runtimed/src/fractional_index.rs
+++ b/crates/runtimed/src/fractional_index.rs
@@ -4,19 +4,56 @@
 //! between any two adjacent keys without reindexing. This is the Rust
 //! equivalent of `generateKeyBetween` used in intheloop's schema.
 
+use std::fmt;
+
 const BASE: u32 = 36;
 const DIGITS: &[u8] = b"0123456789abcdefghijklmnopqrstuvwxyz";
 
-fn digit_value(c: u8) -> u32 {
+/// Errors that can occur during fractional index operations.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FractionalIndexError {
+    /// A key contains a character that is not a valid base-36 digit.
+    InvalidCharacter(char),
+    /// `before` is not strictly less than `after`.
+    InvalidOrder { before: String, after: String },
+    /// No string can be generated between the given bounds.
+    NoSpace { before: String, after: String },
+}
+
+impl fmt::Display for FractionalIndexError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidCharacter(c) => write!(f, "invalid base-36 digit: '{c}'"),
+            Self::InvalidOrder { before, after } => {
+                write!(f, "before ({before}) must be less than after ({after})")
+            }
+            Self::NoSpace { before, after } => {
+                write!(f, "no key exists between \"{before}\" and \"{after}\"")
+            }
+        }
+    }
+}
+
+impl std::error::Error for FractionalIndexError {}
+
+fn digit_value(c: u8) -> Result<u32, FractionalIndexError> {
     match c {
-        b'0'..=b'9' => (c - b'0') as u32,
-        b'a'..=b'z' => (c - b'a' + 10) as u32,
-        _ => panic!("invalid base-36 digit: {}", c as char),
+        b'0'..=b'9' => Ok((c - b'0') as u32),
+        b'a'..=b'z' => Ok((c - b'a' + 10) as u32),
+        _ => Err(FractionalIndexError::InvalidCharacter(c as char)),
     }
 }
 
 fn digit_char(v: u32) -> u8 {
     DIGITS[v as usize]
+}
+
+/// Validate that a key string contains only valid base-36 digits.
+fn validate_key(key: &str) -> Result<(), FractionalIndexError> {
+    for &c in key.as_bytes() {
+        digit_value(c)?;
+    }
+    Ok(())
 }
 
 /// Generate a key between two optional bounds.
@@ -27,77 +64,209 @@ fn digit_char(v: u32) -> u8 {
 /// - `key_between(Some(before), Some(after))` → key between `before` and `after`
 ///
 /// Returns a lexicographically sortable base-36 string.
-///
-/// # Panics
-///
-/// Panics if `before >= after` when both are provided.
-pub fn key_between(before: Option<&str>, after: Option<&str>) -> String {
+pub fn key_between(
+    before: Option<&str>,
+    after: Option<&str>,
+) -> Result<String, FractionalIndexError> {
+    if let Some(b) = before {
+        validate_key(b)?;
+    }
+    if let Some(a) = after {
+        validate_key(a)?;
+    }
+
     match (before, after) {
-        (None, None) => String::from("a"),
-        (None, Some(after)) => midpoint_string(&[], after.as_bytes()),
-        (Some(before), None) => midpoint_string(before.as_bytes(), &[]),
+        (None, None) => Ok(String::from("a")),
+        (None, Some(after)) => generate_key_before(after),
+        (Some(before), None) => generate_key_after(before),
         (Some(before), Some(after)) => {
-            assert!(
-                before < after,
-                "before ({before}) must be less than after ({after})"
-            );
-            midpoint_string(before.as_bytes(), after.as_bytes())
+            if before >= after {
+                return Err(FractionalIndexError::InvalidOrder {
+                    before: before.to_string(),
+                    after: after.to_string(),
+                });
+            }
+            generate_key_between(before, after)
         }
     }
 }
 
 /// Generate n keys evenly spaced between two bounds.
-pub fn n_keys_between(before: Option<&str>, after: Option<&str>, n: usize) -> Vec<String> {
+pub fn n_keys_between(
+    before: Option<&str>,
+    after: Option<&str>,
+    n: usize,
+) -> Result<Vec<String>, FractionalIndexError> {
     if n == 0 {
-        return vec![];
+        return Ok(vec![]);
     }
 
     let mut result = Vec::with_capacity(n);
     let mut prev = before.map(|s| s.to_string());
 
     for _ in 0..n {
-        let key = key_between(prev.as_deref(), after);
+        let key = key_between(prev.as_deref(), after)?;
         result.push(key.clone());
         prev = Some(key);
     }
 
-    result
+    Ok(result)
 }
 
-/// Find a string that sorts between `a` and `b`.
-///
-/// When `a` is empty, it represents "before everything" (each digit = 0).
-/// When `b` is empty, it represents "after everything" (each digit = BASE).
-fn midpoint_string(a: &[u8], b: &[u8]) -> String {
-    let max_len = a.len().max(b.len());
-    let mut result = Vec::new();
+/// Generate a key that sorts before `b`.
+fn generate_key_before(b: &str) -> Result<String, FractionalIndexError> {
+    let bytes = b.as_bytes();
 
-    for i in 0..=max_len {
-        let av = if i < a.len() {
-            digit_value(a[i])
-        } else {
-            0
-        };
-        let bv = if i < b.len() {
-            digit_value(b[i])
-        } else {
-            BASE
-        };
-
-        if av + 1 < bv {
-            // There's room between these digits
-            let mid = av + (bv - av) / 2;
-            result.push(digit_char(mid));
-            return String::from_utf8(result).unwrap();
-        }
-
-        // av and bv are adjacent or equal, carry the prefix digit and continue
-        result.push(digit_char(av));
+    // Find the first non-zero character
+    let mut i = 0;
+    while i < bytes.len() && bytes[i] == b'0' {
+        i += 1;
     }
 
-    // Fallback: should not reach here if a < b, but append midpoint
-    result.push(digit_char(BASE / 2));
-    String::from_utf8(result).unwrap()
+    if i == bytes.len() {
+        // All zeros — prepend another zero
+        return Ok(format!("0{b}"));
+    }
+
+    let val = digit_value(bytes[i])?;
+
+    if i == 0 && val > 1 {
+        // Can use a smaller first character
+        return Ok(String::from(digit_char(val / 2) as char));
+    }
+
+    let prefix = &b[..i];
+    if val > 1 {
+        return Ok(format!("{prefix}{}", digit_char(val / 2) as char));
+    }
+
+    // val is 1, use prefix + "0" + midpoint
+    Ok(format!("{prefix}0h"))
+}
+
+/// Generate a key that sorts after `a`.
+fn generate_key_after(a: &str) -> Result<String, FractionalIndexError> {
+    let bytes = a.as_bytes();
+
+    // Find the last character that isn't 'z'
+    let mut i = bytes.len() as isize - 1;
+    while i >= 0 && bytes[i as usize] == b'z' {
+        i -= 1;
+    }
+
+    if i < 0 {
+        // All 'z's — extend
+        return Ok(format!("{a}h"));
+    }
+
+    let idx = i as usize;
+    let val = digit_value(bytes[idx])?;
+
+    if val < BASE - 2 {
+        // Simple increment
+        let prefix = &a[..idx];
+        return Ok(format!("{prefix}{}", digit_char(val + 1) as char));
+    }
+
+    // val is 'y' (34), incrementing gives 'z' — extend instead to avoid boundary
+    Ok(format!("{a}h"))
+}
+
+/// Generate a key between `a` and `b` where `a < b`.
+fn generate_key_between(a: &str, b: &str) -> Result<String, FractionalIndexError> {
+    let a_bytes = a.as_bytes();
+    let b_bytes = b.as_bytes();
+
+    // Find the first position where they differ
+    let mut i = 0;
+    while i < a_bytes.len() && i < b_bytes.len() && a_bytes[i] == b_bytes[i] {
+        i += 1;
+    }
+
+    // If a is a prefix of b
+    if i == a_bytes.len() {
+        let next_val = digit_value(b_bytes[i])?;
+
+        if next_val > 0 {
+            // There's a non-zero char after the common prefix
+            let mid_val = next_val / 2;
+            if mid_val > 0 {
+                return Ok(format!("{a}{}", digit_char(mid_val) as char));
+            } else {
+                // next_val is 1, mid is 0 — use a + "0"
+                return Ok(format!("{a}0"));
+            }
+        }
+
+        // next_val is 0: b continues with "0" after a ends
+        if b_bytes.len() > i + 1 {
+            // Count consecutive zeros after position i in b
+            let mut j = i;
+            while j < b_bytes.len() && b_bytes[j] == b'0' {
+                j += 1;
+            }
+
+            if j == b_bytes.len() {
+                // b is all zeros after the prefix — use fewer zeros
+                let zero_count = j - i;
+                if zero_count > 1 {
+                    return Ok(format!("{a}{}", "0".repeat(zero_count / 2)));
+                }
+            } else if j < b_bytes.len() {
+                // b has a non-zero char at position j
+                let prefix = format!("{a}{}", "0".repeat(j - i));
+                let next_val = digit_value(b_bytes[j])?;
+                if next_val > 0 {
+                    return Ok(format!(
+                        "{prefix}{}",
+                        digit_char(next_val / 2) as char
+                    ));
+                }
+            }
+        }
+
+        return Err(FractionalIndexError::NoSpace {
+            before: a.to_string(),
+            after: b.to_string(),
+        });
+    }
+
+    // b is a prefix of a shouldn't happen if a < b
+    if i == b_bytes.len() {
+        return Err(FractionalIndexError::InvalidOrder {
+            before: a.to_string(),
+            after: b.to_string(),
+        });
+    }
+
+    // Characters differ at position i
+    let a_val = digit_value(a_bytes[i])?;
+    let b_val = digit_value(b_bytes[i])?;
+
+    // If there's room between them, use the midpoint
+    if b_val - a_val > 1 {
+        let mid_val = (a_val + b_val) / 2;
+        let prefix = &a[..i];
+        let suffix = &a[i + 1..];
+        return Ok(format!(
+            "{prefix}{}{}",
+            digit_char(mid_val) as char,
+            suffix
+        ));
+    }
+
+    // Characters are adjacent (diff is 1)
+    // Extend after a's character to find space
+    if i < a_bytes.len() - 1 {
+        // a has more characters — generate key after the remaining part
+        let prefix = &a[..i + 1];
+        let remaining = &a[i + 1..];
+        let suffix = generate_key_after(remaining)?;
+        return Ok(format!("{prefix}{suffix}"));
+    }
+
+    // a[i] and b[i] are adjacent, a has no more characters — extend with midpoint
+    Ok(format!("{}h", &a[..i + 1]))
 }
 
 #[cfg(test)]
@@ -106,49 +275,49 @@ mod tests {
 
     #[test]
     fn test_midpoint_none_none() {
-        let key = key_between(None, None);
+        let key = key_between(None, None).unwrap();
         assert_eq!(key, "a");
     }
 
     #[test]
     fn test_after_last() {
-        let key = key_between(Some("a"), None);
+        let key = key_between(Some("a"), None).unwrap();
         assert!(key.as_str() > "a");
     }
 
     #[test]
     fn test_before_first() {
-        let key = key_between(None, Some("a"));
+        let key = key_between(None, Some("a")).unwrap();
         assert!(key.as_str() < "a");
     }
 
     #[test]
     fn test_between_two_keys() {
-        let key = key_between(Some("a"), Some("b"));
+        let key = key_between(Some("a"), Some("b")).unwrap();
         assert!(key.as_str() > "a");
         assert!(key.as_str() < "b");
     }
 
     #[test]
     fn test_between_distant_keys() {
-        let key = key_between(Some("a"), Some("z"));
+        let key = key_between(Some("a"), Some("z")).unwrap();
         assert!(key.as_str() > "a");
         assert!(key.as_str() < "z");
     }
 
     #[test]
     fn test_between_adjacent_single_chars() {
-        let key = key_between(Some("a"), Some("b"));
+        let key = key_between(Some("a"), Some("b")).unwrap();
         assert!(key.as_str() > "a");
         assert!(key.as_str() < "b");
     }
 
     #[test]
     fn test_sequential_insertions_at_end() {
-        let mut keys = vec![key_between(None, None)];
+        let mut keys = vec![key_between(None, None).unwrap()];
         for _ in 0..20 {
             let last = keys.last().unwrap().clone();
-            let new_key = key_between(Some(&last), None);
+            let new_key = key_between(Some(&last), None).unwrap();
             assert!(
                 new_key.as_str() > last.as_str(),
                 "{new_key} should be > {last}"
@@ -162,10 +331,10 @@ mod tests {
 
     #[test]
     fn test_sequential_insertions_at_beginning() {
-        let mut keys = vec![key_between(None, None)];
+        let mut keys = vec![key_between(None, None).unwrap()];
         for _ in 0..20 {
             let first = keys.first().unwrap().clone();
-            let new_key = key_between(None, Some(&first));
+            let new_key = key_between(None, Some(&first)).unwrap();
             assert!(
                 new_key.as_str() < first.as_str(),
                 "{new_key} should be < {first}"
@@ -183,7 +352,7 @@ mod tests {
         let hi = "b".to_string();
         let mut keys = vec![];
         for _ in 0..20 {
-            let key = key_between(Some(&lo), Some(&hi));
+            let key = key_between(Some(&lo), Some(&hi)).unwrap();
             assert!(key.as_str() > lo.as_str(), "{key} should be > {lo}");
             assert!(key.as_str() < hi.as_str(), "{key} should be < {hi}");
             keys.push(key.clone());
@@ -193,19 +362,19 @@ mod tests {
 
     #[test]
     fn test_n_keys_between_zero() {
-        let keys = n_keys_between(None, None, 0);
+        let keys = n_keys_between(None, None, 0).unwrap();
         assert!(keys.is_empty());
     }
 
     #[test]
     fn test_n_keys_between_one() {
-        let keys = n_keys_between(None, None, 1);
+        let keys = n_keys_between(None, None, 1).unwrap();
         assert_eq!(keys.len(), 1);
     }
 
     #[test]
     fn test_n_keys_between_multiple() {
-        let keys = n_keys_between(Some("a"), Some("z"), 5);
+        let keys = n_keys_between(Some("a"), Some("z"), 5).unwrap();
         assert_eq!(keys.len(), 5);
 
         for window in keys.windows(2) {
@@ -220,7 +389,7 @@ mod tests {
 
     #[test]
     fn test_n_keys_between_at_end() {
-        let keys = n_keys_between(Some("a"), None, 5);
+        let keys = n_keys_between(Some("a"), None, 5).unwrap();
         assert_eq!(keys.len(), 5);
         for window in keys.windows(2) {
             assert!(window[0] < window[1], "{} should be < {}", window[0], window[1]);
@@ -230,7 +399,7 @@ mod tests {
 
     #[test]
     fn test_n_keys_between_at_beginning() {
-        let keys = n_keys_between(None, Some("z"), 5);
+        let keys = n_keys_between(None, Some("z"), 5).unwrap();
         assert_eq!(keys.len(), 5);
         for window in keys.windows(2) {
             assert!(window[0] < window[1], "{} should be < {}", window[0], window[1]);
@@ -239,27 +408,81 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "before")]
     fn test_before_not_less_than_after() {
-        key_between(Some("b"), Some("a"));
+        let result = key_between(Some("b"), Some("a"));
+        assert!(matches!(result, Err(FractionalIndexError::InvalidOrder { .. })));
     }
 
     #[test]
-    #[should_panic(expected = "before")]
     fn test_before_equal_to_after() {
-        key_between(Some("a"), Some("a"));
+        let result = key_between(Some("a"), Some("a"));
+        assert!(matches!(result, Err(FractionalIndexError::InvalidOrder { .. })));
     }
 
     #[test]
     fn test_multichar_keys() {
-        let k1 = key_between(Some("aa"), Some("ab"));
+        let k1 = key_between(Some("aa"), Some("ab")).unwrap();
         assert!(k1.as_str() > "aa");
         assert!(k1.as_str() < "ab");
     }
 
     #[test]
     fn test_generate_after_max() {
-        let key = key_between(Some("zzz"), None);
+        let key = key_between(Some("zzz"), None).unwrap();
         assert!(key.as_str() > "zzz");
+    }
+
+    // ── New edge-case tests ─────────────────────────────────────────────
+
+    #[test]
+    fn test_prefix_bound_case() {
+        // This was the original bug: key_between("a", "a0") returned "a0i" > "a0"
+        let key = key_between(Some("a"), Some("a5")).unwrap();
+        assert!(key.as_str() > "a", "{key} should be > a");
+        assert!(key.as_str() < "a5", "{key} should be < a5");
+    }
+
+    #[test]
+    fn test_prefix_bound_a_a1() {
+        let key = key_between(Some("a"), Some("a1")).unwrap();
+        assert!(key.as_str() > "a", "{key} should be > a");
+        assert!(key.as_str() < "a1", "{key} should be < a1");
+    }
+
+    #[test]
+    fn test_prefix_bound_a_az() {
+        let key = key_between(Some("a"), Some("az")).unwrap();
+        assert!(key.as_str() > "a", "{key} should be > a");
+        assert!(key.as_str() < "az", "{key} should be < az");
+    }
+
+    #[test]
+    fn test_invalid_character_returns_error() {
+        let result = key_between(Some("A"), None);
+        assert!(matches!(result, Err(FractionalIndexError::InvalidCharacter('A'))));
+    }
+
+    #[test]
+    fn test_invalid_character_in_after() {
+        let result = key_between(None, Some("A"));
+        assert!(matches!(result, Err(FractionalIndexError::InvalidCharacter('A'))));
+    }
+
+    #[test]
+    fn test_invalid_character_special() {
+        let result = key_between(Some("a/b"), None);
+        assert!(matches!(result, Err(FractionalIndexError::InvalidCharacter('/'))));
+    }
+
+    #[test]
+    fn test_error_display() {
+        let err = FractionalIndexError::InvalidCharacter('Z');
+        assert_eq!(err.to_string(), "invalid base-36 digit: 'Z'");
+
+        let err = FractionalIndexError::InvalidOrder {
+            before: "b".into(),
+            after: "a".into(),
+        };
+        assert_eq!(err.to_string(), "before (b) must be less than after (a)");
     }
 }

--- a/crates/runtimed/src/fractional_index.rs
+++ b/crates/runtimed/src/fractional_index.rs
@@ -1,0 +1,265 @@
+//! Fractional indexing for cell ordering.
+//!
+//! Uses base-36 strings that sort lexicographically, allowing insertions
+//! between any two adjacent keys without reindexing. This is the Rust
+//! equivalent of `generateKeyBetween` used in intheloop's schema.
+
+const BASE: u32 = 36;
+const DIGITS: &[u8] = b"0123456789abcdefghijklmnopqrstuvwxyz";
+
+fn digit_value(c: u8) -> u32 {
+    match c {
+        b'0'..=b'9' => (c - b'0') as u32,
+        b'a'..=b'z' => (c - b'a' + 10) as u32,
+        _ => panic!("invalid base-36 digit: {}", c as char),
+    }
+}
+
+fn digit_char(v: u32) -> u8 {
+    DIGITS[v as usize]
+}
+
+/// Generate a key between two optional bounds.
+///
+/// - `key_between(None, None)` → midpoint key
+/// - `key_between(None, Some(after))` → key before `after`
+/// - `key_between(Some(before), None)` → key after `before`
+/// - `key_between(Some(before), Some(after))` → key between `before` and `after`
+///
+/// Returns a lexicographically sortable base-36 string.
+///
+/// # Panics
+///
+/// Panics if `before >= after` when both are provided.
+pub fn key_between(before: Option<&str>, after: Option<&str>) -> String {
+    match (before, after) {
+        (None, None) => String::from("a"),
+        (None, Some(after)) => midpoint_string(&[], after.as_bytes()),
+        (Some(before), None) => midpoint_string(before.as_bytes(), &[]),
+        (Some(before), Some(after)) => {
+            assert!(
+                before < after,
+                "before ({before}) must be less than after ({after})"
+            );
+            midpoint_string(before.as_bytes(), after.as_bytes())
+        }
+    }
+}
+
+/// Generate n keys evenly spaced between two bounds.
+pub fn n_keys_between(before: Option<&str>, after: Option<&str>, n: usize) -> Vec<String> {
+    if n == 0 {
+        return vec![];
+    }
+
+    let mut result = Vec::with_capacity(n);
+    let mut prev = before.map(|s| s.to_string());
+
+    for _ in 0..n {
+        let key = key_between(prev.as_deref(), after);
+        result.push(key.clone());
+        prev = Some(key);
+    }
+
+    result
+}
+
+/// Find a string that sorts between `a` and `b`.
+///
+/// When `a` is empty, it represents "before everything" (each digit = 0).
+/// When `b` is empty, it represents "after everything" (each digit = BASE).
+fn midpoint_string(a: &[u8], b: &[u8]) -> String {
+    let max_len = a.len().max(b.len());
+    let mut result = Vec::new();
+
+    for i in 0..=max_len {
+        let av = if i < a.len() {
+            digit_value(a[i])
+        } else {
+            0
+        };
+        let bv = if i < b.len() {
+            digit_value(b[i])
+        } else {
+            BASE
+        };
+
+        if av + 1 < bv {
+            // There's room between these digits
+            let mid = av + (bv - av) / 2;
+            result.push(digit_char(mid));
+            return String::from_utf8(result).unwrap();
+        }
+
+        // av and bv are adjacent or equal, carry the prefix digit and continue
+        result.push(digit_char(av));
+    }
+
+    // Fallback: should not reach here if a < b, but append midpoint
+    result.push(digit_char(BASE / 2));
+    String::from_utf8(result).unwrap()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_midpoint_none_none() {
+        let key = key_between(None, None);
+        assert_eq!(key, "a");
+    }
+
+    #[test]
+    fn test_after_last() {
+        let key = key_between(Some("a"), None);
+        assert!(key.as_str() > "a");
+    }
+
+    #[test]
+    fn test_before_first() {
+        let key = key_between(None, Some("a"));
+        assert!(key.as_str() < "a");
+    }
+
+    #[test]
+    fn test_between_two_keys() {
+        let key = key_between(Some("a"), Some("b"));
+        assert!(key.as_str() > "a");
+        assert!(key.as_str() < "b");
+    }
+
+    #[test]
+    fn test_between_distant_keys() {
+        let key = key_between(Some("a"), Some("z"));
+        assert!(key.as_str() > "a");
+        assert!(key.as_str() < "z");
+    }
+
+    #[test]
+    fn test_between_adjacent_single_chars() {
+        let key = key_between(Some("a"), Some("b"));
+        assert!(key.as_str() > "a");
+        assert!(key.as_str() < "b");
+    }
+
+    #[test]
+    fn test_sequential_insertions_at_end() {
+        let mut keys = vec![key_between(None, None)];
+        for _ in 0..20 {
+            let last = keys.last().unwrap().clone();
+            let new_key = key_between(Some(&last), None);
+            assert!(
+                new_key.as_str() > last.as_str(),
+                "{new_key} should be > {last}"
+            );
+            keys.push(new_key);
+        }
+        for window in keys.windows(2) {
+            assert!(window[0] < window[1], "{} should be < {}", window[0], window[1]);
+        }
+    }
+
+    #[test]
+    fn test_sequential_insertions_at_beginning() {
+        let mut keys = vec![key_between(None, None)];
+        for _ in 0..20 {
+            let first = keys.first().unwrap().clone();
+            let new_key = key_between(None, Some(&first));
+            assert!(
+                new_key.as_str() < first.as_str(),
+                "{new_key} should be < {first}"
+            );
+            keys.insert(0, new_key);
+        }
+        for window in keys.windows(2) {
+            assert!(window[0] < window[1], "{} should be < {}", window[0], window[1]);
+        }
+    }
+
+    #[test]
+    fn test_sequential_insertions_between() {
+        let mut lo = "a".to_string();
+        let hi = "b".to_string();
+        let mut keys = vec![];
+        for _ in 0..20 {
+            let key = key_between(Some(&lo), Some(&hi));
+            assert!(key.as_str() > lo.as_str(), "{key} should be > {lo}");
+            assert!(key.as_str() < hi.as_str(), "{key} should be < {hi}");
+            keys.push(key.clone());
+            lo = key;
+        }
+    }
+
+    #[test]
+    fn test_n_keys_between_zero() {
+        let keys = n_keys_between(None, None, 0);
+        assert!(keys.is_empty());
+    }
+
+    #[test]
+    fn test_n_keys_between_one() {
+        let keys = n_keys_between(None, None, 1);
+        assert_eq!(keys.len(), 1);
+    }
+
+    #[test]
+    fn test_n_keys_between_multiple() {
+        let keys = n_keys_between(Some("a"), Some("z"), 5);
+        assert_eq!(keys.len(), 5);
+
+        for window in keys.windows(2) {
+            assert!(window[0] < window[1], "{} should be < {}", window[0], window[1]);
+        }
+
+        for key in &keys {
+            assert!(key.as_str() > "a", "{key} should be > a");
+            assert!(key.as_str() < "z", "{key} should be < z");
+        }
+    }
+
+    #[test]
+    fn test_n_keys_between_at_end() {
+        let keys = n_keys_between(Some("a"), None, 5);
+        assert_eq!(keys.len(), 5);
+        for window in keys.windows(2) {
+            assert!(window[0] < window[1], "{} should be < {}", window[0], window[1]);
+        }
+        assert!(keys[0].as_str() > "a");
+    }
+
+    #[test]
+    fn test_n_keys_between_at_beginning() {
+        let keys = n_keys_between(None, Some("z"), 5);
+        assert_eq!(keys.len(), 5);
+        for window in keys.windows(2) {
+            assert!(window[0] < window[1], "{} should be < {}", window[0], window[1]);
+        }
+        assert!(keys.last().unwrap().as_str() < "z");
+    }
+
+    #[test]
+    #[should_panic(expected = "before")]
+    fn test_before_not_less_than_after() {
+        key_between(Some("b"), Some("a"));
+    }
+
+    #[test]
+    #[should_panic(expected = "before")]
+    fn test_before_equal_to_after() {
+        key_between(Some("a"), Some("a"));
+    }
+
+    #[test]
+    fn test_multichar_keys() {
+        let k1 = key_between(Some("aa"), Some("ab"));
+        assert!(k1.as_str() > "aa");
+        assert!(k1.as_str() < "ab");
+    }
+
+    #[test]
+    fn test_generate_after_max() {
+        let key = key_between(Some("zzz"), None);
+        assert!(key.as_str() > "zzz");
+    }
+}

--- a/crates/runtimed/src/lib.rs
+++ b/crates/runtimed/src/lib.rs
@@ -11,6 +11,9 @@ use serde::{Deserialize, Serialize};
 
 pub mod client;
 pub mod daemon;
+pub mod fractional_index;
+pub mod notebook_protocol;
+pub mod notebook_server;
 pub mod protocol;
 pub mod service;
 pub mod singleton;

--- a/crates/runtimed/src/notebook_protocol.rs
+++ b/crates/runtimed/src/notebook_protocol.rs
@@ -350,7 +350,7 @@ pub enum ServerMessage {
     Welcome {
         client_id: String,
         version: u64,
-        snapshot: NotebookSnapshot,
+        snapshot: Box<NotebookSnapshot>,
         #[serde(default)]
         catch_up: Vec<DeltaEvent>,
         #[serde(default)]
@@ -1217,7 +1217,7 @@ mod tests {
         let msg = ServerMessage::Welcome {
             client_id: "tauri-ui-1".into(),
             version: 847,
-            snapshot: NotebookSnapshot {
+            snapshot: Box::new(NotebookSnapshot {
                 version: 847,
                 metadata: HashMap::from([("title".into(), "Test Notebook".into())]),
                 cells: vec![CellSnapshot {
@@ -1237,7 +1237,7 @@ mod tests {
                 runtime_sessions: vec![],
                 execution_queue: vec![],
                 actors: vec![test_actor()],
-            },
+            }),
             catch_up: vec![],
             presence: HashMap::new(),
         };
@@ -1953,7 +1953,7 @@ mod tests {
         let msg = ServerMessage::Welcome {
             client_id: "agent-1".into(),
             version: 50,
-            snapshot: NotebookSnapshot {
+            snapshot: Box::new(NotebookSnapshot {
                 version: 48,
                 metadata: HashMap::new(),
                 cells: vec![],
@@ -1963,7 +1963,7 @@ mod tests {
                 runtime_sessions: vec![],
                 execution_queue: vec![],
                 actors: vec![],
-            },
+            }),
             catch_up: vec![
                 DeltaEvent {
                     version: 49,

--- a/crates/runtimed/src/notebook_protocol.rs
+++ b/crates/runtimed/src/notebook_protocol.rs
@@ -240,6 +240,14 @@ pub enum ClientMessage {
 }
 
 /// Edit operations sent by clients. Nested inside `ClientMessage::Edit`.
+///
+/// # Security note
+///
+/// Several variants include actor identity fields (`created_by`, `actor_id`,
+/// `modified_by`, `requested_by`, `cancelled_by`). The server MUST NOT trust
+/// these values from the wire — it must overwrite them with the authenticated
+/// identity established during the `Hello` handshake. Failing to do so allows
+/// clients to impersonate other actors.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "op", rename_all = "snake_case")]
 pub enum EditOp {

--- a/crates/runtimed/src/notebook_protocol.rs
+++ b/crates/runtimed/src/notebook_protocol.rs
@@ -1,0 +1,1986 @@
+//! Notebook sync protocol message types.
+//!
+//! Defines the complete wire protocol for notebook synchronization between the
+//! daemon (single source of truth) and connected clients (Tauri UI, agents, MCP
+//! servers, TUI). Messages are JSON with two-level tagging:
+//!
+//! - Outer: `{"type": "edit", ...}` via `#[serde(tag = "type")]`
+//! - Inner: `{"op": "cell_create", ...}` via `#[serde(tag = "op")]` + flatten
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+// ─── Shared Enums ────────────────────────────────────────────────────────────
+
+/// The kind of client connecting to the daemon.
+/// Determines what operations the client is permitted to perform.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ClientKind {
+    Ui,
+    Agent,
+    Mcp,
+    Tui,
+    Kernel,
+}
+
+/// Jupyter cell types. Pure Jupyter — no sql/ai cell types.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CellType {
+    Code,
+    Markdown,
+    Raw,
+}
+
+/// Client activity state for presence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Activity {
+    Editing,
+    Viewing,
+    Executing,
+    Idle,
+}
+
+/// Actor type — who or what is performing an action.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ActorType {
+    Human,
+    RuntimeAgent,
+}
+
+/// Cell execution state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecutionState {
+    Idle,
+    Queued,
+    Running,
+    Completed,
+    Error,
+}
+
+/// Runtime session status.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeStatus {
+    Starting,
+    Ready,
+    Busy,
+    Restarting,
+    Terminated,
+}
+
+/// Execution queue entry status.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum QueueStatus {
+    Pending,
+    Assigned,
+    Executing,
+    Completed,
+    Failed,
+    Cancelled,
+}
+
+/// Output type discriminant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OutputType {
+    MultimediaDisplay,
+    MultimediaResult,
+    Terminal,
+    Markdown,
+    Error,
+}
+
+/// Error codes returned by the daemon.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum ErrorCode {
+    Unauthorized,
+    Conflict,
+    NotFound,
+    InvalidOp,
+    KernelError,
+}
+
+/// Execution completion status.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CompletionStatus {
+    Success,
+    Error,
+    Cancelled,
+}
+
+// ─── Shared Structs ──────────────────────────────────────────────────────────
+
+/// An actor (user or agent) performing actions.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Actor {
+    pub id: String,
+    #[serde(rename = "type")]
+    pub actor_type: ActorType,
+    pub display_name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub avatar: Option<String>,
+}
+
+/// Cursor position within a cell's source.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CursorPosition {
+    pub line: u32,
+    pub ch: u32,
+}
+
+/// An incremental text patch for cell source editing.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TextPatch {
+    pub pos: u32,
+    pub delete: u32,
+    pub insert: String,
+}
+
+/// Media representation for output MIME data.
+///
+/// `Inline` for small data (base64 for binary, string for text).
+/// `Blob` for large outputs served via HTTP from local blob storage.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum MediaRepresentation {
+    Inline {
+        data: Value,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        metadata: Option<Value>,
+    },
+    Blob {
+        blob_path: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        metadata: Option<Value>,
+    },
+}
+
+/// Error output data from kernel execution.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ErrorOutputData {
+    pub ename: String,
+    pub evalue: String,
+    pub traceback: Vec<String>,
+}
+
+/// Runtime capabilities reported on session start.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RuntimeCapabilities {
+    pub can_execute_code: bool,
+}
+
+/// A cell in a batch execution request.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExecutionCell {
+    pub id: String,
+    pub execution_count: u64,
+    pub queue_id: String,
+}
+
+/// Presence info for a single connected peer.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PeerPresence {
+    pub client_kind: ClientKind,
+    pub actor: Actor,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub focus_cell: Option<String>,
+    pub activity: Activity,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<CursorPosition>,
+    #[serde(default)]
+    pub custom: Value,
+}
+
+// ─── Client → Server Messages ────────────────────────────────────────────────
+
+/// Messages sent from clients to the daemon.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ClientMessage {
+    /// Initial handshake. Must be the first message on a new connection.
+    Hello {
+        client_id: String,
+        client_kind: ClientKind,
+        client_name: String,
+        actor: Actor,
+        /// `None` for fresh connect, version number for reconnect.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        last_version: Option<u64>,
+    },
+
+    /// Update presence state. Actor identity comes from the hello handshake.
+    Presence {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        focus_cell: Option<String>,
+        activity: Activity,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        cursor: Option<CursorPosition>,
+        #[serde(default)]
+        custom: Value,
+    },
+
+    /// An edit operation. Wire format: `{"type":"edit","op":"cell_create",...}`
+    Edit {
+        #[serde(flatten)]
+        op: EditOp,
+    },
+
+    /// Request a checkpoint (save to disk).
+    Checkpoint {},
+}
+
+/// Edit operations sent by clients. Nested inside `ClientMessage::Edit`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "op", rename_all = "snake_case")]
+pub enum EditOp {
+    /// Create a new cell.
+    CellCreate {
+        id: String,
+        cell_type: CellType,
+        created_by: String,
+        /// Cell ID to insert after, or `None` for beginning.
+        after: Option<String>,
+    },
+
+    /// Delete a cell.
+    CellDelete { id: String, actor_id: String },
+
+    /// Move a cell to a new position.
+    CellMove {
+        id: String,
+        /// Cell ID to move after, or `None` for beginning.
+        after: Option<String>,
+        actor_id: String,
+    },
+
+    /// Replace cell source entirely (last-write-wins).
+    CellSourceSet {
+        id: String,
+        source: String,
+        modified_by: String,
+    },
+
+    /// Apply incremental patches to cell source.
+    CellSourcePatch {
+        id: String,
+        modified_by: String,
+        patches: Vec<TextPatch>,
+    },
+
+    /// Change cell type.
+    CellTypeChanged { id: String, cell_type: CellType },
+
+    /// Toggle cell source visibility.
+    CellSourceVisibility { id: String, visible: bool },
+
+    /// Toggle cell output visibility.
+    CellOutputVisibility { id: String, visible: bool },
+
+    /// Set a notebook metadata key-value pair.
+    NotebookMetadataSet { key: String, value: String },
+
+    /// Request execution of a single cell.
+    ExecutionRequested {
+        queue_id: String,
+        cell_id: String,
+        execution_count: u64,
+        requested_by: String,
+    },
+
+    /// Request execution of multiple cells.
+    MultipleExecutionRequested {
+        requested_by: String,
+        cells: Vec<ExecutionCell>,
+    },
+
+    /// Cancel a queued or running execution.
+    ExecutionCancelled {
+        queue_id: String,
+        cell_id: String,
+        cancelled_by: String,
+        reason: String,
+    },
+
+    /// Cancel all pending/running executions.
+    AllExecutionsCancelled {},
+
+    /// Interrupt a running kernel.
+    RuntimeInterrupt { session_id: String },
+
+    /// Restart a kernel session.
+    RuntimeRestart { session_id: String },
+
+    /// Shut down a kernel session.
+    RuntimeShutdown { session_id: String },
+
+    /// Send a comm message to the kernel (widget interaction).
+    CommMsg {
+        comm_id: String,
+        data: Value,
+        #[serde(default)]
+        buffers: u32,
+    },
+}
+
+// ─── Server → Client Messages ────────────────────────────────────────────────
+
+/// Messages sent from the daemon to clients.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ServerMessage {
+    /// Sent after a successful hello. Contains full state or catch-up deltas.
+    Welcome {
+        client_id: String,
+        version: u64,
+        snapshot: NotebookSnapshot,
+        #[serde(default)]
+        catch_up: Vec<DeltaEvent>,
+        #[serde(default)]
+        presence: HashMap<String, PeerPresence>,
+    },
+
+    /// Full presence state broadcast. Sent on any presence change.
+    PresenceState {
+        peers: HashMap<String, PeerPresence>,
+    },
+
+    /// A versioned delta broadcast to all clients.
+    Delta {
+        #[serde(flatten)]
+        event: DeltaEvent,
+    },
+
+    /// Error response to a client edit.
+    Error {
+        /// Correlation ID from the original message.
+        #[serde(rename = "ref", skip_serializing_if = "Option::is_none")]
+        ref_id: Option<String>,
+        code: ErrorCode,
+        message: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        cell_id: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        current_source: Option<String>,
+    },
+
+    /// Checkpoint completed.
+    Checkpointed { version: u64 },
+}
+
+/// A versioned delta event. Used both as a standalone `ServerMessage::Delta`
+/// and inside `Welcome.catch_up`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct DeltaEvent {
+    pub version: u64,
+    pub timestamp: String,
+    pub origin: String,
+    #[serde(flatten)]
+    pub op: DeltaOp,
+}
+
+/// Delta operations broadcast by the daemon.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "op", rename_all = "snake_case")]
+pub enum DeltaOp {
+    // ── Cell structure ──────────────────────────────────────────────────
+
+    CellCreated {
+        id: String,
+        cell_type: CellType,
+        created_by: String,
+        after: Option<String>,
+        fractional_index: String,
+    },
+
+    CellDeleted {
+        id: String,
+        actor_id: String,
+    },
+
+    CellMoved {
+        id: String,
+        after: Option<String>,
+        actor_id: String,
+        fractional_index: String,
+    },
+
+    CellSourceSet {
+        id: String,
+        source: String,
+        modified_by: String,
+    },
+
+    CellSourcePatched {
+        id: String,
+        modified_by: String,
+        patches: Vec<TextPatch>,
+    },
+
+    CellTypeChanged {
+        id: String,
+        cell_type: CellType,
+    },
+
+    CellSourceVisibility {
+        id: String,
+        visible: bool,
+    },
+
+    CellOutputVisibility {
+        id: String,
+        visible: bool,
+    },
+
+    NotebookMetadataSet {
+        key: String,
+        value: String,
+    },
+
+    // ── Output deltas (from kernel execution) ───────────────────────────
+
+    TerminalOutputAdded {
+        id: String,
+        cell_id: String,
+        position: f64,
+        stream_name: String,
+        data: String,
+    },
+
+    TerminalOutputAppended {
+        id: String,
+        output_id: String,
+        delta: String,
+        sequence_number: u64,
+    },
+
+    MultimediaDisplayAdded {
+        id: String,
+        cell_id: String,
+        position: f64,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        display_id: Option<String>,
+        representations: HashMap<String, MediaRepresentation>,
+    },
+
+    MultimediaDisplayUpdated {
+        display_id: String,
+        representations: HashMap<String, MediaRepresentation>,
+    },
+
+    MultimediaResultAdded {
+        id: String,
+        cell_id: String,
+        position: f64,
+        execution_count: u64,
+        representations: HashMap<String, MediaRepresentation>,
+    },
+
+    ErrorOutputAdded {
+        id: String,
+        cell_id: String,
+        position: f64,
+        data: ErrorOutputData,
+    },
+
+    CellOutputsCleared {
+        cell_id: String,
+        #[serde(default)]
+        wait: bool,
+    },
+
+    AllOutputsCleared {},
+
+    // ── Execution lifecycle ──────────────────────────────────────────────
+
+    ExecutionAssigned {
+        queue_id: String,
+        runtime_session_id: String,
+    },
+
+    ExecutionStarted {
+        queue_id: String,
+        cell_id: String,
+        runtime_session_id: String,
+        started_at: String,
+    },
+
+    ExecutionCompleted {
+        queue_id: String,
+        cell_id: String,
+        status: CompletionStatus,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        execution_duration_ms: Option<u64>,
+    },
+
+    // ── Runtime session (daemon-originated, informational) ──────────────
+
+    RuntimeSessionStarted {
+        session_id: String,
+        runtime_id: String,
+        runtime_type: String,
+        capabilities: RuntimeCapabilities,
+    },
+
+    RuntimeSessionStatusChanged {
+        session_id: String,
+        status: RuntimeStatus,
+    },
+
+    RuntimeSessionRenewal {
+        session_id: String,
+        renewed_at: String,
+        valid_for_ms: u64,
+    },
+
+    RuntimeSessionTerminated {
+        session_id: String,
+        reason: String,
+    },
+
+    // ── Comm/widget (daemon relays between kernel and UI clients) ───────
+
+    CommOpen {
+        comm_id: String,
+        target_name: String,
+        data: Value,
+        #[serde(default)]
+        buffers: u32,
+    },
+
+    CommMsg {
+        comm_id: String,
+        data: Value,
+        #[serde(default)]
+        buffers: u32,
+    },
+
+    CommClose {
+        comm_id: String,
+        data: Value,
+    },
+}
+
+// ─── Snapshot Types ──────────────────────────────────────────────────────────
+
+/// Full materialized notebook state, sent in `Welcome` on fresh connect.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct NotebookSnapshot {
+    pub version: u64,
+    #[serde(default)]
+    pub metadata: HashMap<String, String>,
+    #[serde(default)]
+    pub cells: Vec<CellSnapshot>,
+    #[serde(default)]
+    pub outputs: HashMap<String, Vec<OutputSnapshot>>,
+    #[serde(default)]
+    pub output_deltas: HashMap<String, Vec<OutputDeltaSnapshot>>,
+    #[serde(default)]
+    pub comms: HashMap<String, CommSnapshot>,
+    #[serde(default)]
+    pub runtime_sessions: Vec<RuntimeSessionSnapshot>,
+    #[serde(default)]
+    pub execution_queue: Vec<QueueEntrySnapshot>,
+    #[serde(default)]
+    pub actors: Vec<Actor>,
+}
+
+/// A cell in the snapshot.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CellSnapshot {
+    pub id: String,
+    pub cell_type: CellType,
+    pub source: String,
+    pub fractional_index: String,
+    #[serde(default)]
+    pub execution_state: ExecutionState,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub execution_count: Option<u64>,
+    #[serde(default = "default_true")]
+    pub source_visible: bool,
+    #[serde(default = "default_true")]
+    pub output_visible: bool,
+    pub created_by: String,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+impl Default for ExecutionState {
+    fn default() -> Self {
+        Self::Idle
+    }
+}
+
+/// An output in the snapshot.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct OutputSnapshot {
+    pub id: String,
+    pub output_type: OutputType,
+    pub position: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mime_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub representations: Option<HashMap<String, MediaRepresentation>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub execution_count: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub display_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stream_name: Option<String>,
+}
+
+/// A streaming delta for an output (e.g. terminal append).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OutputDeltaSnapshot {
+    pub id: String,
+    pub delta: String,
+    pub sequence_number: u64,
+}
+
+/// Accumulated comm/widget state.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CommSnapshot {
+    pub target_name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cell_id: Option<String>,
+    pub state: Value,
+    #[serde(default)]
+    pub buffer_paths: Vec<Vec<String>>,
+}
+
+/// A runtime session in the snapshot.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RuntimeSessionSnapshot {
+    pub session_id: String,
+    pub runtime_id: String,
+    pub runtime_type: String,
+    pub status: RuntimeStatus,
+    #[serde(default)]
+    pub is_active: bool,
+    #[serde(default)]
+    pub can_execute_code: bool,
+}
+
+/// An execution queue entry in the snapshot.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct QueueEntrySnapshot {
+    pub id: String,
+    pub cell_id: String,
+    pub execution_count: u64,
+    pub requested_by: String,
+    pub status: QueueStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub assigned_runtime_session: Option<String>,
+}
+
+// ─── Permission Methods ──────────────────────────────────────────────────────
+
+impl ClientKind {
+    /// Can this client create, delete, move, or modify cells?
+    pub fn can_edit_cells(&self) -> bool {
+        !matches!(self, Self::Kernel)
+    }
+
+    /// Can this client emit output deltas (terminal, multimedia, error)?
+    pub fn can_emit_outputs(&self) -> bool {
+        matches!(self, Self::Kernel | Self::Agent)
+    }
+
+    /// Can this client manage runtime sessions (start, restart, shutdown)?
+    pub fn can_manage_runtime(&self) -> bool {
+        matches!(self, Self::Agent)
+    }
+
+    /// Can this client request cell execution?
+    pub fn can_request_execution(&self) -> bool {
+        !matches!(self, Self::Kernel)
+    }
+
+    /// Can this client send comm messages to the kernel (widget interaction)?
+    pub fn can_send_comm_to_kernel(&self) -> bool {
+        matches!(self, Self::Ui | Self::Agent | Self::Mcp)
+    }
+
+    /// Can this client emit comm messages from the kernel side?
+    pub fn can_emit_comm_from_kernel(&self) -> bool {
+        matches!(self, Self::Kernel)
+    }
+
+    /// Can this client set notebook metadata?
+    pub fn can_set_metadata(&self) -> bool {
+        matches!(self, Self::Ui | Self::Agent | Self::Mcp)
+    }
+
+    /// Can this client request a checkpoint?
+    pub fn can_checkpoint(&self) -> bool {
+        matches!(self, Self::Ui | Self::Agent | Self::Mcp)
+    }
+
+    /// Can this client update presence?
+    pub fn can_update_presence(&self) -> bool {
+        !matches!(self, Self::Kernel)
+    }
+}
+
+// ─── Serialization Helpers ───────────────────────────────────────────────────
+
+impl ClientMessage {
+    /// Serialize to JSON string.
+    pub fn to_json(&self) -> Result<String, serde_json::Error> {
+        serde_json::to_string(self)
+    }
+
+    /// Parse from JSON string.
+    pub fn from_json(json: &str) -> Result<Self, serde_json::Error> {
+        serde_json::from_str(json)
+    }
+}
+
+impl ServerMessage {
+    /// Serialize to JSON string.
+    pub fn to_json(&self) -> Result<String, serde_json::Error> {
+        serde_json::to_string(self)
+    }
+
+    /// Parse from JSON string.
+    pub fn from_json(json: &str) -> Result<Self, serde_json::Error> {
+        serde_json::from_str(json)
+    }
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_actor() -> Actor {
+        Actor {
+            id: "user-123".into(),
+            actor_type: ActorType::Human,
+            display_name: "Kyle".into(),
+            avatar: None,
+        }
+    }
+
+    // ── ClientMessage roundtrips ────────────────────────────────────────
+
+    #[test]
+    fn test_hello_roundtrip() {
+        let msg = ClientMessage::Hello {
+            client_id: "tauri-ui-1".into(),
+            client_kind: ClientKind::Ui,
+            client_name: "Anode UI".into(),
+            actor: test_actor(),
+            last_version: None,
+        };
+        let json = msg.to_json().unwrap();
+        let parsed = ClientMessage::from_json(&json).unwrap();
+        assert_eq!(msg, parsed);
+    }
+
+    #[test]
+    fn test_hello_with_last_version() {
+        let msg = ClientMessage::Hello {
+            client_id: "agent-1".into(),
+            client_kind: ClientKind::Agent,
+            client_name: "Test Agent".into(),
+            actor: Actor {
+                id: "agent-1".into(),
+                actor_type: ActorType::RuntimeAgent,
+                display_name: "Agent".into(),
+                avatar: Some("https://example.com/avatar.png".into()),
+            },
+            last_version: Some(42),
+        };
+        let json = msg.to_json().unwrap();
+        let parsed = ClientMessage::from_json(&json).unwrap();
+        assert_eq!(msg, parsed);
+    }
+
+    #[test]
+    fn test_presence_roundtrip() {
+        let msg = ClientMessage::Presence {
+            focus_cell: Some("cell_03".into()),
+            activity: Activity::Editing,
+            cursor: Some(CursorPosition { line: 5, ch: 12 }),
+            custom: Value::Object(serde_json::Map::new()),
+        };
+        let json = msg.to_json().unwrap();
+        let parsed = ClientMessage::from_json(&json).unwrap();
+        assert_eq!(msg, parsed);
+    }
+
+    #[test]
+    fn test_checkpoint_roundtrip() {
+        let msg = ClientMessage::Checkpoint {};
+        let json = msg.to_json().unwrap();
+        let parsed = ClientMessage::from_json(&json).unwrap();
+        assert_eq!(msg, parsed);
+    }
+
+    // ── EditOp roundtrips ───────────────────────────────────────────────
+
+    #[test]
+    fn test_cell_create_roundtrip() {
+        let msg = ClientMessage::Edit {
+            op: EditOp::CellCreate {
+                id: "cell_01".into(),
+                cell_type: CellType::Code,
+                created_by: "user-123".into(),
+                after: None,
+            },
+        };
+        let json = msg.to_json().unwrap();
+        let parsed = ClientMessage::from_json(&json).unwrap();
+        assert_eq!(msg, parsed);
+    }
+
+    #[test]
+    fn test_cell_create_after_roundtrip() {
+        let msg = ClientMessage::Edit {
+            op: EditOp::CellCreate {
+                id: "cell_02".into(),
+                cell_type: CellType::Markdown,
+                created_by: "user-123".into(),
+                after: Some("cell_01".into()),
+            },
+        };
+        let json = msg.to_json().unwrap();
+        let parsed = ClientMessage::from_json(&json).unwrap();
+        assert_eq!(msg, parsed);
+    }
+
+    #[test]
+    fn test_cell_delete_roundtrip() {
+        let msg = ClientMessage::Edit {
+            op: EditOp::CellDelete {
+                id: "cell_01".into(),
+                actor_id: "user-123".into(),
+            },
+        };
+        let json = msg.to_json().unwrap();
+        let parsed = ClientMessage::from_json(&json).unwrap();
+        assert_eq!(msg, parsed);
+    }
+
+    #[test]
+    fn test_cell_move_roundtrip() {
+        let msg = ClientMessage::Edit {
+            op: EditOp::CellMove {
+                id: "cell_03".into(),
+                after: Some("cell_01".into()),
+                actor_id: "user-123".into(),
+            },
+        };
+        let json = msg.to_json().unwrap();
+        let parsed = ClientMessage::from_json(&json).unwrap();
+        assert_eq!(msg, parsed);
+    }
+
+    #[test]
+    fn test_cell_source_set_roundtrip() {
+        let msg = ClientMessage::Edit {
+            op: EditOp::CellSourceSet {
+                id: "cell_01".into(),
+                source: "import numpy as np\n".into(),
+                modified_by: "user-123".into(),
+            },
+        };
+        let json = msg.to_json().unwrap();
+        let parsed = ClientMessage::from_json(&json).unwrap();
+        assert_eq!(msg, parsed);
+    }
+
+    #[test]
+    fn test_cell_source_patch_roundtrip() {
+        let msg = ClientMessage::Edit {
+            op: EditOp::CellSourcePatch {
+                id: "cell_01".into(),
+                modified_by: "user-123".into(),
+                patches: vec![
+                    TextPatch {
+                        pos: 0,
+                        delete: 0,
+                        insert: "import ".into(),
+                    },
+                    TextPatch {
+                        pos: 14,
+                        delete: 3,
+                        insert: "numpy".into(),
+                    },
+                ],
+            },
+        };
+        let json = msg.to_json().unwrap();
+        let parsed = ClientMessage::from_json(&json).unwrap();
+        assert_eq!(msg, parsed);
+    }
+
+    #[test]
+    fn test_cell_type_changed_roundtrip() {
+        let msg = ClientMessage::Edit {
+            op: EditOp::CellTypeChanged {
+                id: "cell_01".into(),
+                cell_type: CellType::Markdown,
+            },
+        };
+        let json = msg.to_json().unwrap();
+        let parsed = ClientMessage::from_json(&json).unwrap();
+        assert_eq!(msg, parsed);
+    }
+
+    #[test]
+    fn test_cell_source_visibility_roundtrip() {
+        let msg = ClientMessage::Edit {
+            op: EditOp::CellSourceVisibility {
+                id: "cell_01".into(),
+                visible: false,
+            },
+        };
+        let json = msg.to_json().unwrap();
+        let parsed = ClientMessage::from_json(&json).unwrap();
+        assert_eq!(msg, parsed);
+    }
+
+    #[test]
+    fn test_cell_output_visibility_roundtrip() {
+        let msg = ClientMessage::Edit {
+            op: EditOp::CellOutputVisibility {
+                id: "cell_01".into(),
+                visible: true,
+            },
+        };
+        let json = msg.to_json().unwrap();
+        let parsed = ClientMessage::from_json(&json).unwrap();
+        assert_eq!(msg, parsed);
+    }
+
+    #[test]
+    fn test_notebook_metadata_set_roundtrip() {
+        let msg = ClientMessage::Edit {
+            op: EditOp::NotebookMetadataSet {
+                key: "title".into(),
+                value: "My Notebook".into(),
+            },
+        };
+        let json = msg.to_json().unwrap();
+        let parsed = ClientMessage::from_json(&json).unwrap();
+        assert_eq!(msg, parsed);
+    }
+
+    #[test]
+    fn test_execution_requested_roundtrip() {
+        let msg = ClientMessage::Edit {
+            op: EditOp::ExecutionRequested {
+                queue_id: "q_01".into(),
+                cell_id: "cell_01".into(),
+                execution_count: 5,
+                requested_by: "user-123".into(),
+            },
+        };
+        let json = msg.to_json().unwrap();
+        let parsed = ClientMessage::from_json(&json).unwrap();
+        assert_eq!(msg, parsed);
+    }
+
+    #[test]
+    fn test_multiple_execution_requested_roundtrip() {
+        let msg = ClientMessage::Edit {
+            op: EditOp::MultipleExecutionRequested {
+                requested_by: "user-123".into(),
+                cells: vec![
+                    ExecutionCell {
+                        id: "cell_01".into(),
+                        execution_count: 2,
+                        queue_id: "q_01".into(),
+                    },
+                    ExecutionCell {
+                        id: "cell_02".into(),
+                        execution_count: 1,
+                        queue_id: "q_02".into(),
+                    },
+                ],
+            },
+        };
+        let json = msg.to_json().unwrap();
+        let parsed = ClientMessage::from_json(&json).unwrap();
+        assert_eq!(msg, parsed);
+    }
+
+    #[test]
+    fn test_execution_cancelled_roundtrip() {
+        let msg = ClientMessage::Edit {
+            op: EditOp::ExecutionCancelled {
+                queue_id: "q_01".into(),
+                cell_id: "cell_01".into(),
+                cancelled_by: "user-123".into(),
+                reason: "user requested".into(),
+            },
+        };
+        let json = msg.to_json().unwrap();
+        let parsed = ClientMessage::from_json(&json).unwrap();
+        assert_eq!(msg, parsed);
+    }
+
+    #[test]
+    fn test_all_executions_cancelled_roundtrip() {
+        let msg = ClientMessage::Edit {
+            op: EditOp::AllExecutionsCancelled {},
+        };
+        let json = msg.to_json().unwrap();
+        let parsed = ClientMessage::from_json(&json).unwrap();
+        assert_eq!(msg, parsed);
+    }
+
+    #[test]
+    fn test_runtime_interrupt_roundtrip() {
+        let msg = ClientMessage::Edit {
+            op: EditOp::RuntimeInterrupt {
+                session_id: "session_01".into(),
+            },
+        };
+        let json = msg.to_json().unwrap();
+        let parsed = ClientMessage::from_json(&json).unwrap();
+        assert_eq!(msg, parsed);
+    }
+
+    #[test]
+    fn test_runtime_restart_roundtrip() {
+        let msg = ClientMessage::Edit {
+            op: EditOp::RuntimeRestart {
+                session_id: "session_01".into(),
+            },
+        };
+        let json = msg.to_json().unwrap();
+        let parsed = ClientMessage::from_json(&json).unwrap();
+        assert_eq!(msg, parsed);
+    }
+
+    #[test]
+    fn test_runtime_shutdown_roundtrip() {
+        let msg = ClientMessage::Edit {
+            op: EditOp::RuntimeShutdown {
+                session_id: "session_01".into(),
+            },
+        };
+        let json = msg.to_json().unwrap();
+        let parsed = ClientMessage::from_json(&json).unwrap();
+        assert_eq!(msg, parsed);
+    }
+
+    #[test]
+    fn test_comm_msg_edit_roundtrip() {
+        let msg = ClientMessage::Edit {
+            op: EditOp::CommMsg {
+                comm_id: "comm_01".into(),
+                data: serde_json::json!({"method": "update", "state": {"index": 3}}),
+                buffers: 0,
+            },
+        };
+        let json = msg.to_json().unwrap();
+        let parsed = ClientMessage::from_json(&json).unwrap();
+        assert_eq!(msg, parsed);
+    }
+
+    // ── Wire format shape ───────────────────────────────────────────────
+
+    #[test]
+    fn test_edit_wire_format_has_type_and_op() {
+        let msg = ClientMessage::Edit {
+            op: EditOp::CellCreate {
+                id: "cell_01".into(),
+                cell_type: CellType::Code,
+                created_by: "user-123".into(),
+                after: None,
+            },
+        };
+        let json = msg.to_json().unwrap();
+        let v: Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["type"], "edit");
+        assert_eq!(v["op"], "cell_create");
+        assert_eq!(v["id"], "cell_01");
+        assert_eq!(v["cell_type"], "code");
+    }
+
+    #[test]
+    fn test_hello_wire_format() {
+        let msg = ClientMessage::Hello {
+            client_id: "tauri-ui-1".into(),
+            client_kind: ClientKind::Ui,
+            client_name: "Anode UI".into(),
+            actor: test_actor(),
+            last_version: None,
+        };
+        let json = msg.to_json().unwrap();
+        let v: Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["type"], "hello");
+        assert_eq!(v["client_id"], "tauri-ui-1");
+        assert_eq!(v["client_kind"], "ui");
+        assert_eq!(v["actor"]["type"], "human");
+        assert_eq!(v["actor"]["display_name"], "Kyle");
+    }
+
+    #[test]
+    fn test_checkpoint_wire_format() {
+        let msg = ClientMessage::Checkpoint {};
+        let json = msg.to_json().unwrap();
+        let v: Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["type"], "checkpoint");
+    }
+
+    #[test]
+    fn test_delta_wire_format() {
+        let msg = ServerMessage::Delta {
+            event: DeltaEvent {
+                version: 848,
+                timestamp: "2026-02-20T15:30:00.123Z".into(),
+                origin: "user-123".into(),
+                op: DeltaOp::CellCreated {
+                    id: "cell_01".into(),
+                    cell_type: CellType::Code,
+                    created_by: "user-123".into(),
+                    after: None,
+                    fractional_index: "a".into(),
+                },
+            },
+        };
+        let json = msg.to_json().unwrap();
+        let v: Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["type"], "delta");
+        assert_eq!(v["version"], 848);
+        assert_eq!(v["op"], "cell_created");
+        assert_eq!(v["fractional_index"], "a");
+    }
+
+    #[test]
+    fn test_error_wire_format() {
+        let msg = ServerMessage::Error {
+            ref_id: Some("msg_01".into()),
+            code: ErrorCode::Unauthorized,
+            message: "ui clients cannot emit output deltas".into(),
+            cell_id: None,
+            current_source: None,
+        };
+        let json = msg.to_json().unwrap();
+        let v: Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["type"], "error");
+        assert_eq!(v["ref"], "msg_01");
+        assert_eq!(v["code"], "UNAUTHORIZED");
+    }
+
+    #[test]
+    fn test_error_code_serialization() {
+        assert_eq!(
+            serde_json::to_string(&ErrorCode::Unauthorized).unwrap(),
+            "\"UNAUTHORIZED\""
+        );
+        assert_eq!(
+            serde_json::to_string(&ErrorCode::NotFound).unwrap(),
+            "\"NOT_FOUND\""
+        );
+        assert_eq!(
+            serde_json::to_string(&ErrorCode::InvalidOp).unwrap(),
+            "\"INVALID_OP\""
+        );
+        assert_eq!(
+            serde_json::to_string(&ErrorCode::KernelError).unwrap(),
+            "\"KERNEL_ERROR\""
+        );
+    }
+
+    // ── ServerMessage roundtrips ────────────────────────────────────────
+
+    #[test]
+    fn test_welcome_roundtrip() {
+        let msg = ServerMessage::Welcome {
+            client_id: "tauri-ui-1".into(),
+            version: 847,
+            snapshot: NotebookSnapshot {
+                version: 847,
+                metadata: HashMap::from([("title".into(), "Test Notebook".into())]),
+                cells: vec![CellSnapshot {
+                    id: "cell_01".into(),
+                    cell_type: CellType::Code,
+                    source: "print('hello')".into(),
+                    fractional_index: "a0".into(),
+                    execution_state: ExecutionState::Idle,
+                    execution_count: Some(1),
+                    source_visible: true,
+                    output_visible: true,
+                    created_by: "user-123".into(),
+                }],
+                outputs: HashMap::new(),
+                output_deltas: HashMap::new(),
+                comms: HashMap::new(),
+                runtime_sessions: vec![],
+                execution_queue: vec![],
+                actors: vec![test_actor()],
+            },
+            catch_up: vec![],
+            presence: HashMap::new(),
+        };
+        let json = msg.to_json().unwrap();
+        let parsed = ServerMessage::from_json(&json).unwrap();
+        assert_eq!(msg, parsed);
+    }
+
+    #[test]
+    fn test_presence_state_roundtrip() {
+        let mut peers = HashMap::new();
+        peers.insert(
+            "tauri-ui-1".into(),
+            PeerPresence {
+                client_kind: ClientKind::Ui,
+                actor: test_actor(),
+                focus_cell: Some("cell_01".into()),
+                activity: Activity::Editing,
+                cursor: Some(CursorPosition { line: 5, ch: 12 }),
+                custom: Value::Object(serde_json::Map::new()),
+            },
+        );
+        let msg = ServerMessage::PresenceState { peers };
+        let json = msg.to_json().unwrap();
+        let parsed = ServerMessage::from_json(&json).unwrap();
+        assert_eq!(msg, parsed);
+    }
+
+    #[test]
+    fn test_checkpointed_roundtrip() {
+        let msg = ServerMessage::Checkpointed { version: 900 };
+        let json = msg.to_json().unwrap();
+        let parsed = ServerMessage::from_json(&json).unwrap();
+        assert_eq!(msg, parsed);
+    }
+
+    #[test]
+    fn test_error_roundtrip() {
+        let msg = ServerMessage::Error {
+            ref_id: Some("msg_01".into()),
+            code: ErrorCode::Conflict,
+            message: "source has changed".into(),
+            cell_id: Some("cell_01".into()),
+            current_source: Some("current contents".into()),
+        };
+        let json = msg.to_json().unwrap();
+        let parsed = ServerMessage::from_json(&json).unwrap();
+        assert_eq!(msg, parsed);
+    }
+
+    // ── DeltaOp roundtrips ──────────────────────────────────────────────
+
+    fn wrap_delta(op: DeltaOp) -> ServerMessage {
+        ServerMessage::Delta {
+            event: DeltaEvent {
+                version: 1,
+                timestamp: "2026-02-20T15:30:00Z".into(),
+                origin: "user-123".into(),
+                op,
+            },
+        }
+    }
+
+    #[test]
+    fn test_delta_cell_created_roundtrip() {
+        let msg = wrap_delta(DeltaOp::CellCreated {
+            id: "cell_01".into(),
+            cell_type: CellType::Code,
+            created_by: "user-123".into(),
+            after: None,
+            fractional_index: "a".into(),
+        });
+        let json = msg.to_json().unwrap();
+        let parsed = ServerMessage::from_json(&json).unwrap();
+        assert_eq!(msg, parsed);
+    }
+
+    #[test]
+    fn test_delta_cell_deleted_roundtrip() {
+        let msg = wrap_delta(DeltaOp::CellDeleted {
+            id: "cell_01".into(),
+            actor_id: "user-123".into(),
+        });
+        let json = msg.to_json().unwrap();
+        let parsed = ServerMessage::from_json(&json).unwrap();
+        assert_eq!(msg, parsed);
+    }
+
+    #[test]
+    fn test_delta_cell_moved_roundtrip() {
+        let msg = wrap_delta(DeltaOp::CellMoved {
+            id: "cell_03".into(),
+            after: Some("cell_01".into()),
+            actor_id: "user-123".into(),
+            fractional_index: "a5".into(),
+        });
+        let json = msg.to_json().unwrap();
+        let parsed = ServerMessage::from_json(&json).unwrap();
+        assert_eq!(msg, parsed);
+    }
+
+    #[test]
+    fn test_delta_cell_source_set_roundtrip() {
+        let msg = wrap_delta(DeltaOp::CellSourceSet {
+            id: "cell_01".into(),
+            source: "x = 42".into(),
+            modified_by: "user-123".into(),
+        });
+        let json = msg.to_json().unwrap();
+        let parsed = ServerMessage::from_json(&json).unwrap();
+        assert_eq!(msg, parsed);
+    }
+
+    #[test]
+    fn test_delta_cell_source_patched_roundtrip() {
+        let msg = wrap_delta(DeltaOp::CellSourcePatched {
+            id: "cell_01".into(),
+            modified_by: "user-123".into(),
+            patches: vec![TextPatch {
+                pos: 0,
+                delete: 1,
+                insert: "y".into(),
+            }],
+        });
+        let json = msg.to_json().unwrap();
+        let parsed = ServerMessage::from_json(&json).unwrap();
+        assert_eq!(msg, parsed);
+    }
+
+    #[test]
+    fn test_delta_terminal_output_added_roundtrip() {
+        let msg = wrap_delta(DeltaOp::TerminalOutputAdded {
+            id: "out_01".into(),
+            cell_id: "cell_01".into(),
+            position: 0.0,
+            stream_name: "stdout".into(),
+            data: "Processing...\n".into(),
+        });
+        let json = msg.to_json().unwrap();
+        let parsed = ServerMessage::from_json(&json).unwrap();
+        assert_eq!(msg, parsed);
+    }
+
+    #[test]
+    fn test_delta_terminal_output_appended_roundtrip() {
+        let msg = wrap_delta(DeltaOp::TerminalOutputAppended {
+            id: "d_01".into(),
+            output_id: "out_01".into(),
+            delta: "more text\n".into(),
+            sequence_number: 1,
+        });
+        let json = msg.to_json().unwrap();
+        let parsed = ServerMessage::from_json(&json).unwrap();
+        assert_eq!(msg, parsed);
+    }
+
+    #[test]
+    fn test_delta_multimedia_display_added_roundtrip() {
+        let mut representations = HashMap::new();
+        representations.insert(
+            "text/html".into(),
+            MediaRepresentation::Inline {
+                data: Value::String("<b>hello</b>".into()),
+                metadata: None,
+            },
+        );
+        let msg = wrap_delta(DeltaOp::MultimediaDisplayAdded {
+            id: "out_02".into(),
+            cell_id: "cell_01".into(),
+            position: 1.0,
+            display_id: Some("display_01".into()),
+            representations,
+        });
+        let json = msg.to_json().unwrap();
+        let parsed = ServerMessage::from_json(&json).unwrap();
+        assert_eq!(msg, parsed);
+    }
+
+    #[test]
+    fn test_delta_multimedia_display_updated_roundtrip() {
+        let mut representations = HashMap::new();
+        representations.insert(
+            "text/plain".into(),
+            MediaRepresentation::Inline {
+                data: Value::String("updated".into()),
+                metadata: None,
+            },
+        );
+        let msg = wrap_delta(DeltaOp::MultimediaDisplayUpdated {
+            display_id: "display_01".into(),
+            representations,
+        });
+        let json = msg.to_json().unwrap();
+        let parsed = ServerMessage::from_json(&json).unwrap();
+        assert_eq!(msg, parsed);
+    }
+
+    #[test]
+    fn test_delta_multimedia_result_added_roundtrip() {
+        let mut representations = HashMap::new();
+        representations.insert(
+            "text/plain".into(),
+            MediaRepresentation::Inline {
+                data: Value::String("42".into()),
+                metadata: None,
+            },
+        );
+        representations.insert(
+            "image/png".into(),
+            MediaRepresentation::Blob {
+                blob_path: "blobs/abc123".into(),
+                metadata: None,
+            },
+        );
+        let msg = wrap_delta(DeltaOp::MultimediaResultAdded {
+            id: "out_03".into(),
+            cell_id: "cell_01".into(),
+            position: 2.0,
+            execution_count: 5,
+            representations,
+        });
+        let json = msg.to_json().unwrap();
+        let parsed = ServerMessage::from_json(&json).unwrap();
+        assert_eq!(msg, parsed);
+    }
+
+    #[test]
+    fn test_delta_error_output_added_roundtrip() {
+        let msg = wrap_delta(DeltaOp::ErrorOutputAdded {
+            id: "out_04".into(),
+            cell_id: "cell_01".into(),
+            position: 3.0,
+            data: ErrorOutputData {
+                ename: "ValueError".into(),
+                evalue: "invalid literal".into(),
+                traceback: vec![
+                    "Traceback (most recent call last):".into(),
+                    "  File \"<stdin>\", line 1".into(),
+                    "ValueError: invalid literal".into(),
+                ],
+            },
+        });
+        let json = msg.to_json().unwrap();
+        let parsed = ServerMessage::from_json(&json).unwrap();
+        assert_eq!(msg, parsed);
+    }
+
+    #[test]
+    fn test_delta_cell_outputs_cleared_roundtrip() {
+        let msg = wrap_delta(DeltaOp::CellOutputsCleared {
+            cell_id: "cell_01".into(),
+            wait: true,
+        });
+        let json = msg.to_json().unwrap();
+        let parsed = ServerMessage::from_json(&json).unwrap();
+        assert_eq!(msg, parsed);
+    }
+
+    #[test]
+    fn test_delta_all_outputs_cleared_roundtrip() {
+        let msg = wrap_delta(DeltaOp::AllOutputsCleared {});
+        let json = msg.to_json().unwrap();
+        let parsed = ServerMessage::from_json(&json).unwrap();
+        assert_eq!(msg, parsed);
+    }
+
+    #[test]
+    fn test_delta_execution_assigned_roundtrip() {
+        let msg = wrap_delta(DeltaOp::ExecutionAssigned {
+            queue_id: "q_01".into(),
+            runtime_session_id: "session_01".into(),
+        });
+        let json = msg.to_json().unwrap();
+        let parsed = ServerMessage::from_json(&json).unwrap();
+        assert_eq!(msg, parsed);
+    }
+
+    #[test]
+    fn test_delta_execution_started_roundtrip() {
+        let msg = wrap_delta(DeltaOp::ExecutionStarted {
+            queue_id: "q_01".into(),
+            cell_id: "cell_01".into(),
+            runtime_session_id: "session_01".into(),
+            started_at: "2026-02-20T15:30:00Z".into(),
+        });
+        let json = msg.to_json().unwrap();
+        let parsed = ServerMessage::from_json(&json).unwrap();
+        assert_eq!(msg, parsed);
+    }
+
+    #[test]
+    fn test_delta_execution_completed_roundtrip() {
+        let msg = wrap_delta(DeltaOp::ExecutionCompleted {
+            queue_id: "q_01".into(),
+            cell_id: "cell_01".into(),
+            status: CompletionStatus::Success,
+            execution_duration_ms: Some(1234),
+        });
+        let json = msg.to_json().unwrap();
+        let parsed = ServerMessage::from_json(&json).unwrap();
+        assert_eq!(msg, parsed);
+    }
+
+    #[test]
+    fn test_delta_runtime_session_started_roundtrip() {
+        let msg = wrap_delta(DeltaOp::RuntimeSessionStarted {
+            session_id: "session_01".into(),
+            runtime_id: "runtime_01".into(),
+            runtime_type: "python3".into(),
+            capabilities: RuntimeCapabilities {
+                can_execute_code: true,
+            },
+        });
+        let json = msg.to_json().unwrap();
+        let parsed = ServerMessage::from_json(&json).unwrap();
+        assert_eq!(msg, parsed);
+    }
+
+    #[test]
+    fn test_delta_runtime_session_status_changed_roundtrip() {
+        let msg = wrap_delta(DeltaOp::RuntimeSessionStatusChanged {
+            session_id: "session_01".into(),
+            status: RuntimeStatus::Ready,
+        });
+        let json = msg.to_json().unwrap();
+        let parsed = ServerMessage::from_json(&json).unwrap();
+        assert_eq!(msg, parsed);
+    }
+
+    #[test]
+    fn test_delta_runtime_session_renewal_roundtrip() {
+        let msg = wrap_delta(DeltaOp::RuntimeSessionRenewal {
+            session_id: "session_01".into(),
+            renewed_at: "2026-02-20T15:30:00Z".into(),
+            valid_for_ms: 30000,
+        });
+        let json = msg.to_json().unwrap();
+        let parsed = ServerMessage::from_json(&json).unwrap();
+        assert_eq!(msg, parsed);
+    }
+
+    #[test]
+    fn test_delta_runtime_session_terminated_roundtrip() {
+        let msg = wrap_delta(DeltaOp::RuntimeSessionTerminated {
+            session_id: "session_01".into(),
+            reason: "shutdown".into(),
+        });
+        let json = msg.to_json().unwrap();
+        let parsed = ServerMessage::from_json(&json).unwrap();
+        assert_eq!(msg, parsed);
+    }
+
+    #[test]
+    fn test_delta_comm_open_roundtrip() {
+        let msg = wrap_delta(DeltaOp::CommOpen {
+            comm_id: "comm_01".into(),
+            target_name: "jupyter.widget.comm".into(),
+            data: serde_json::json!({"state": {"value": 0}}),
+            buffers: 0,
+        });
+        let json = msg.to_json().unwrap();
+        let parsed = ServerMessage::from_json(&json).unwrap();
+        assert_eq!(msg, parsed);
+    }
+
+    #[test]
+    fn test_delta_comm_msg_roundtrip() {
+        let msg = wrap_delta(DeltaOp::CommMsg {
+            comm_id: "comm_01".into(),
+            data: serde_json::json!({"method": "update", "state": {"value": 5}}),
+            buffers: 2,
+        });
+        let json = msg.to_json().unwrap();
+        let parsed = ServerMessage::from_json(&json).unwrap();
+        assert_eq!(msg, parsed);
+    }
+
+    #[test]
+    fn test_delta_comm_close_roundtrip() {
+        let msg = wrap_delta(DeltaOp::CommClose {
+            comm_id: "comm_01".into(),
+            data: serde_json::json!({}),
+        });
+        let json = msg.to_json().unwrap();
+        let parsed = ServerMessage::from_json(&json).unwrap();
+        assert_eq!(msg, parsed);
+    }
+
+    // ── Snapshot tests ──────────────────────────────────────────────────
+
+    #[test]
+    fn test_snapshot_mixed_cell_types() {
+        let snapshot = NotebookSnapshot {
+            version: 100,
+            metadata: HashMap::from([
+                ("title".into(), "Mixed Notebook".into()),
+                ("kernel_name".into(), "python3".into()),
+            ]),
+            cells: vec![
+                CellSnapshot {
+                    id: "cell_01".into(),
+                    cell_type: CellType::Code,
+                    source: "x = 1".into(),
+                    fractional_index: "a".into(),
+                    execution_state: ExecutionState::Completed,
+                    execution_count: Some(1),
+                    source_visible: true,
+                    output_visible: true,
+                    created_by: "user-123".into(),
+                },
+                CellSnapshot {
+                    id: "cell_02".into(),
+                    cell_type: CellType::Markdown,
+                    source: "# Hello".into(),
+                    fractional_index: "n".into(),
+                    execution_state: ExecutionState::Idle,
+                    execution_count: None,
+                    source_visible: true,
+                    output_visible: true,
+                    created_by: "user-123".into(),
+                },
+                CellSnapshot {
+                    id: "cell_03".into(),
+                    cell_type: CellType::Raw,
+                    source: "raw content".into(),
+                    fractional_index: "z".into(),
+                    execution_state: ExecutionState::Idle,
+                    execution_count: None,
+                    source_visible: false,
+                    output_visible: false,
+                    created_by: "agent-1".into(),
+                },
+            ],
+            outputs: HashMap::from([(
+                "cell_01".into(),
+                vec![OutputSnapshot {
+                    id: "out_01".into(),
+                    output_type: OutputType::MultimediaResult,
+                    position: 0.0,
+                    mime_type: Some("text/plain".into()),
+                    data: Some("1".into()),
+                    representations: Some(HashMap::from([(
+                        "text/plain".into(),
+                        MediaRepresentation::Inline {
+                            data: Value::String("1".into()),
+                            metadata: None,
+                        },
+                    )])),
+                    execution_count: Some(1),
+                    display_id: None,
+                    stream_name: None,
+                }],
+            )]),
+            output_deltas: HashMap::new(),
+            comms: HashMap::from([(
+                "comm_01".into(),
+                CommSnapshot {
+                    target_name: "jupyter.widget.comm".into(),
+                    cell_id: Some("cell_01".into()),
+                    state: serde_json::json!({"value": 42}),
+                    buffer_paths: vec![],
+                },
+            )]),
+            runtime_sessions: vec![RuntimeSessionSnapshot {
+                session_id: "session_01".into(),
+                runtime_id: "runtime_01".into(),
+                runtime_type: "python3".into(),
+                status: RuntimeStatus::Ready,
+                is_active: true,
+                can_execute_code: true,
+            }],
+            execution_queue: vec![],
+            actors: vec![test_actor()],
+        };
+
+        let json = serde_json::to_string(&snapshot).unwrap();
+        let parsed: NotebookSnapshot = serde_json::from_str(&json).unwrap();
+        assert_eq!(snapshot, parsed);
+        assert_eq!(parsed.cells.len(), 3);
+        assert_eq!(parsed.cells[0].cell_type, CellType::Code);
+        assert_eq!(parsed.cells[1].cell_type, CellType::Markdown);
+        assert_eq!(parsed.cells[2].cell_type, CellType::Raw);
+    }
+
+    #[test]
+    fn test_snapshot_with_output_deltas() {
+        let snapshot = NotebookSnapshot {
+            version: 50,
+            metadata: HashMap::new(),
+            cells: vec![],
+            outputs: HashMap::from([(
+                "cell_01".into(),
+                vec![OutputSnapshot {
+                    id: "out_01".into(),
+                    output_type: OutputType::Terminal,
+                    position: 0.0,
+                    mime_type: None,
+                    data: Some("line 1\n".into()),
+                    representations: None,
+                    execution_count: None,
+                    display_id: None,
+                    stream_name: Some("stdout".into()),
+                }],
+            )]),
+            output_deltas: HashMap::from([(
+                "out_01".into(),
+                vec![
+                    OutputDeltaSnapshot {
+                        id: "d1".into(),
+                        delta: "line 2\n".into(),
+                        sequence_number: 0,
+                    },
+                    OutputDeltaSnapshot {
+                        id: "d2".into(),
+                        delta: "line 3\n".into(),
+                        sequence_number: 1,
+                    },
+                ],
+            )]),
+            comms: HashMap::new(),
+            runtime_sessions: vec![],
+            execution_queue: vec![],
+            actors: vec![],
+        };
+
+        let json = serde_json::to_string(&snapshot).unwrap();
+        let parsed: NotebookSnapshot = serde_json::from_str(&json).unwrap();
+        assert_eq!(snapshot, parsed);
+        assert_eq!(parsed.output_deltas["out_01"].len(), 2);
+    }
+
+    // ── Permission matrix ───────────────────────────────────────────────
+
+    #[test]
+    fn test_kernel_cannot_edit_cells() {
+        assert!(!ClientKind::Kernel.can_edit_cells());
+        assert!(ClientKind::Ui.can_edit_cells());
+        assert!(ClientKind::Agent.can_edit_cells());
+        assert!(ClientKind::Mcp.can_edit_cells());
+        assert!(ClientKind::Tui.can_edit_cells());
+    }
+
+    #[test]
+    fn test_only_kernel_and_agent_emit_outputs() {
+        assert!(ClientKind::Kernel.can_emit_outputs());
+        assert!(ClientKind::Agent.can_emit_outputs());
+        assert!(!ClientKind::Ui.can_emit_outputs());
+        assert!(!ClientKind::Mcp.can_emit_outputs());
+        assert!(!ClientKind::Tui.can_emit_outputs());
+    }
+
+    #[test]
+    fn test_only_agent_manages_runtime() {
+        assert!(ClientKind::Agent.can_manage_runtime());
+        assert!(!ClientKind::Ui.can_manage_runtime());
+        assert!(!ClientKind::Mcp.can_manage_runtime());
+        assert!(!ClientKind::Kernel.can_manage_runtime());
+        assert!(!ClientKind::Tui.can_manage_runtime());
+    }
+
+    #[test]
+    fn test_kernel_cannot_request_execution() {
+        assert!(!ClientKind::Kernel.can_request_execution());
+        assert!(ClientKind::Ui.can_request_execution());
+        assert!(ClientKind::Agent.can_request_execution());
+        assert!(ClientKind::Mcp.can_request_execution());
+        assert!(ClientKind::Tui.can_request_execution());
+    }
+
+    #[test]
+    fn test_comm_to_kernel_permissions() {
+        assert!(ClientKind::Ui.can_send_comm_to_kernel());
+        assert!(ClientKind::Agent.can_send_comm_to_kernel());
+        assert!(ClientKind::Mcp.can_send_comm_to_kernel());
+        assert!(!ClientKind::Kernel.can_send_comm_to_kernel());
+        assert!(!ClientKind::Tui.can_send_comm_to_kernel());
+    }
+
+    #[test]
+    fn test_only_kernel_emits_comm_from_kernel() {
+        assert!(ClientKind::Kernel.can_emit_comm_from_kernel());
+        assert!(!ClientKind::Ui.can_emit_comm_from_kernel());
+        assert!(!ClientKind::Agent.can_emit_comm_from_kernel());
+        assert!(!ClientKind::Mcp.can_emit_comm_from_kernel());
+        assert!(!ClientKind::Tui.can_emit_comm_from_kernel());
+    }
+
+    #[test]
+    fn test_metadata_permissions() {
+        assert!(ClientKind::Ui.can_set_metadata());
+        assert!(ClientKind::Agent.can_set_metadata());
+        assert!(ClientKind::Mcp.can_set_metadata());
+        assert!(!ClientKind::Kernel.can_set_metadata());
+        assert!(!ClientKind::Tui.can_set_metadata());
+    }
+
+    #[test]
+    fn test_checkpoint_permissions() {
+        assert!(ClientKind::Ui.can_checkpoint());
+        assert!(ClientKind::Agent.can_checkpoint());
+        assert!(ClientKind::Mcp.can_checkpoint());
+        assert!(!ClientKind::Kernel.can_checkpoint());
+        assert!(!ClientKind::Tui.can_checkpoint());
+    }
+
+    #[test]
+    fn test_presence_permissions() {
+        assert!(ClientKind::Ui.can_update_presence());
+        assert!(ClientKind::Agent.can_update_presence());
+        assert!(ClientKind::Mcp.can_update_presence());
+        assert!(ClientKind::Tui.can_update_presence());
+        assert!(!ClientKind::Kernel.can_update_presence());
+    }
+
+    // ── Error cases ─────────────────────────────────────────────────────
+
+    #[test]
+    fn test_invalid_json() {
+        let result = ClientMessage::from_json("not valid json");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_unknown_type_tag() {
+        let result = ClientMessage::from_json(r#"{"type":"unknown_type"}"#);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_unknown_op_tag() {
+        let result = ClientMessage::from_json(r#"{"type":"edit","op":"unknown_op"}"#);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_missing_required_fields() {
+        // Hello without client_id
+        let result = ClientMessage::from_json(r#"{"type":"hello","client_kind":"ui"}"#);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_media_representation_inline_roundtrip() {
+        let repr = MediaRepresentation::Inline {
+            data: Value::String("hello".into()),
+            metadata: Some(serde_json::json!({"isolated": true})),
+        };
+        let json = serde_json::to_string(&repr).unwrap();
+        let parsed: MediaRepresentation = serde_json::from_str(&json).unwrap();
+        assert_eq!(repr, parsed);
+        let v: Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["type"], "inline");
+    }
+
+    #[test]
+    fn test_media_representation_blob_roundtrip() {
+        let repr = MediaRepresentation::Blob {
+            blob_path: "blobs/abc123".into(),
+            metadata: None,
+        };
+        let json = serde_json::to_string(&repr).unwrap();
+        let parsed: MediaRepresentation = serde_json::from_str(&json).unwrap();
+        assert_eq!(repr, parsed);
+        let v: Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(v["type"], "blob");
+    }
+
+    #[test]
+    fn test_client_kind_serialization() {
+        assert_eq!(serde_json::to_string(&ClientKind::Ui).unwrap(), "\"ui\"");
+        assert_eq!(
+            serde_json::to_string(&ClientKind::Agent).unwrap(),
+            "\"agent\""
+        );
+        assert_eq!(serde_json::to_string(&ClientKind::Mcp).unwrap(), "\"mcp\"");
+        assert_eq!(serde_json::to_string(&ClientKind::Tui).unwrap(), "\"tui\"");
+        assert_eq!(
+            serde_json::to_string(&ClientKind::Kernel).unwrap(),
+            "\"kernel\""
+        );
+    }
+
+    #[test]
+    fn test_cell_type_serialization() {
+        assert_eq!(
+            serde_json::to_string(&CellType::Code).unwrap(),
+            "\"code\""
+        );
+        assert_eq!(
+            serde_json::to_string(&CellType::Markdown).unwrap(),
+            "\"markdown\""
+        );
+        assert_eq!(serde_json::to_string(&CellType::Raw).unwrap(), "\"raw\"");
+    }
+
+    #[test]
+    fn test_queue_entry_snapshot_roundtrip() {
+        let entry = QueueEntrySnapshot {
+            id: "q_01".into(),
+            cell_id: "cell_01".into(),
+            execution_count: 3,
+            requested_by: "user-123".into(),
+            status: QueueStatus::Executing,
+            assigned_runtime_session: Some("session_01".into()),
+        };
+        let json = serde_json::to_string(&entry).unwrap();
+        let parsed: QueueEntrySnapshot = serde_json::from_str(&json).unwrap();
+        assert_eq!(entry, parsed);
+    }
+
+    #[test]
+    fn test_welcome_with_catch_up() {
+        let msg = ServerMessage::Welcome {
+            client_id: "agent-1".into(),
+            version: 50,
+            snapshot: NotebookSnapshot {
+                version: 48,
+                metadata: HashMap::new(),
+                cells: vec![],
+                outputs: HashMap::new(),
+                output_deltas: HashMap::new(),
+                comms: HashMap::new(),
+                runtime_sessions: vec![],
+                execution_queue: vec![],
+                actors: vec![],
+            },
+            catch_up: vec![
+                DeltaEvent {
+                    version: 49,
+                    timestamp: "2026-02-20T15:29:00Z".into(),
+                    origin: "user-123".into(),
+                    op: DeltaOp::CellSourceSet {
+                        id: "cell_01".into(),
+                        source: "updated".into(),
+                        modified_by: "user-123".into(),
+                    },
+                },
+                DeltaEvent {
+                    version: 50,
+                    timestamp: "2026-02-20T15:30:00Z".into(),
+                    origin: "user-123".into(),
+                    op: DeltaOp::NotebookMetadataSet {
+                        key: "title".into(),
+                        value: "New Title".into(),
+                    },
+                },
+            ],
+            presence: HashMap::new(),
+        };
+        let json = msg.to_json().unwrap();
+        let parsed = ServerMessage::from_json(&json).unwrap();
+        assert_eq!(msg, parsed);
+    }
+}

--- a/crates/runtimed/src/notebook_server.rs
+++ b/crates/runtimed/src/notebook_server.rs
@@ -4,9 +4,45 @@
 //! socket (or named pipe on Windows). The daemon routes connections to the
 //! appropriate notebook server based on the socket path.
 //!
-//! Socket path: `{runtime_dir}/runt-{notebook_id}.sock`
+//! Socket path: `{runtime_dir}/runt-{notebook_id}.sock` (Unix)
+//! Named pipe: `\\.\pipe\runt-{notebook_id}` (Windows)
 
+use std::fmt;
 use std::path::PathBuf;
+
+/// Errors from notebook server operations.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NotebookServerError {
+    /// The notebook ID contains characters outside `[A-Za-z0-9_-]`.
+    InvalidNotebookId(String),
+}
+
+impl fmt::Display for NotebookServerError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidNotebookId(id) => {
+                write!(
+                    f,
+                    "invalid notebook id: \"{id}\" (must contain only [A-Za-z0-9_-])"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for NotebookServerError {}
+
+/// Validate that a notebook ID contains only safe characters.
+fn validate_notebook_id(id: &str) -> Result<(), NotebookServerError> {
+    if id.is_empty()
+        || !id
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'_' || b == b'-')
+    {
+        return Err(NotebookServerError::InvalidNotebookId(id.to_string()));
+    }
+    Ok(())
+}
 
 /// A running notebook server instance.
 ///
@@ -16,16 +52,26 @@ pub struct NotebookServer {
 }
 
 impl NotebookServer {
-    pub fn new(notebook_id: String) -> Self {
-        Self { notebook_id }
+    /// Create a new notebook server. Returns an error if the notebook ID
+    /// contains characters outside `[A-Za-z0-9_-]`.
+    pub fn new(notebook_id: String) -> Result<Self, NotebookServerError> {
+        validate_notebook_id(&notebook_id)?;
+        Ok(Self { notebook_id })
     }
 
     /// Get the Unix socket path for this notebook server.
+    #[cfg(unix)]
     pub fn socket_path(&self) -> PathBuf {
         let runtime_dir = dirs::cache_dir()
             .unwrap_or_else(|| PathBuf::from("/tmp"))
             .join("runt");
         runtime_dir.join(format!("runt-{}.sock", self.notebook_id))
+    }
+
+    /// Get the named pipe path for this notebook server.
+    #[cfg(windows)]
+    pub fn socket_path(&self) -> PathBuf {
+        PathBuf::from(format!(r"\\.\pipe\runt-{}", self.notebook_id))
     }
 }
 
@@ -35,17 +81,70 @@ mod tests {
 
     #[test]
     fn test_new() {
-        let server = NotebookServer::new("test-notebook".into());
+        let server = NotebookServer::new("test-notebook".into()).unwrap();
         assert_eq!(server.notebook_id, "test-notebook");
     }
 
     #[test]
+    fn test_new_with_underscores_and_digits() {
+        let server = NotebookServer::new("my_notebook_123".into()).unwrap();
+        assert_eq!(server.notebook_id, "my_notebook_123");
+    }
+
+    #[test]
     fn test_socket_path_contains_notebook_id() {
-        let server = NotebookServer::new("my-notebook-123".into());
+        let server = NotebookServer::new("my-notebook-123".into()).unwrap();
         let path = server.socket_path();
-        assert!(path
-            .to_str()
-            .unwrap()
-            .contains("runt-my-notebook-123.sock"));
+        let path_str = path.to_str().unwrap();
+        assert!(path_str.contains("runt-my-notebook-123"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_socket_path_ends_with_sock() {
+        let server = NotebookServer::new("test".into()).unwrap();
+        let path = server.socket_path();
+        assert!(path.to_str().unwrap().ends_with(".sock"));
+    }
+
+    // ── Sanitization tests ──────────────────────────────────────────────
+
+    #[test]
+    fn test_rejects_path_traversal() {
+        let result = NotebookServer::new("../../../etc/passwd".into());
+        assert!(matches!(result, Err(NotebookServerError::InvalidNotebookId(_))));
+    }
+
+    #[test]
+    fn test_rejects_slash() {
+        let result = NotebookServer::new("foo/bar".into());
+        assert!(matches!(result, Err(NotebookServerError::InvalidNotebookId(_))));
+    }
+
+    #[test]
+    fn test_rejects_dot_dot() {
+        let result = NotebookServer::new("..".into());
+        assert!(matches!(result, Err(NotebookServerError::InvalidNotebookId(_))));
+    }
+
+    #[test]
+    fn test_rejects_empty() {
+        let result = NotebookServer::new("".into());
+        assert!(matches!(result, Err(NotebookServerError::InvalidNotebookId(_))));
+    }
+
+    #[test]
+    fn test_rejects_spaces() {
+        let result = NotebookServer::new("foo bar".into());
+        assert!(matches!(result, Err(NotebookServerError::InvalidNotebookId(_))));
+    }
+
+    #[test]
+    fn test_error_display() {
+        let err = NotebookServerError::InvalidNotebookId("../bad".into());
+        assert_eq!(
+            err.to_string(),
+            "invalid notebook id: \"../bad\" (must contain only [A-Za-z0-9_-])"
+        );
     }
 }

--- a/crates/runtimed/src/notebook_server.rs
+++ b/crates/runtimed/src/notebook_server.rs
@@ -1,0 +1,51 @@
+//! Stub for the per-notebook server.
+//!
+//! Each notebook gets its own server instance, listening on a dedicated Unix
+//! socket (or named pipe on Windows). The daemon routes connections to the
+//! appropriate notebook server based on the socket path.
+//!
+//! Socket path: `{runtime_dir}/runt-{notebook_id}.sock`
+
+use std::path::PathBuf;
+
+/// A running notebook server instance.
+///
+/// Each notebook gets its own socket: `{runtime_dir}/runt-{notebook_id}.sock`
+pub struct NotebookServer {
+    pub notebook_id: String,
+}
+
+impl NotebookServer {
+    pub fn new(notebook_id: String) -> Self {
+        Self { notebook_id }
+    }
+
+    /// Get the Unix socket path for this notebook server.
+    pub fn socket_path(&self) -> PathBuf {
+        let runtime_dir = dirs::cache_dir()
+            .unwrap_or_else(|| PathBuf::from("/tmp"))
+            .join("runt");
+        runtime_dir.join(format!("runt-{}.sock", self.notebook_id))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let server = NotebookServer::new("test-notebook".into());
+        assert_eq!(server.notebook_id, "test-notebook");
+    }
+
+    #[test]
+    fn test_socket_path_contains_notebook_id() {
+        let server = NotebookServer::new("my-notebook-123".into());
+        let path = server.socket_path();
+        assert!(path
+            .to_str()
+            .unwrap()
+            .contains("runt-my-notebook-123.sock"));
+    }
+}


### PR DESCRIPTION
## Motivation

The `runtimed` daemon currently handles environment pool management. We're extending it with a notebook sync protocol — a persistent bidirectional connection where the daemon is the single source of truth for notebook state, broadcasting versioned deltas to connected clients (Tauri UI, agents, MCP servers, TUI).

This replaces LiveStore (used in intheloop/Santiago). The frustrations driving this change:
- LiveStore forces all clients to JS
- CRDTs add complexity we don't need (single daemon serializes all writes)
- Presence is bolted on
- No permission system to control who can emit outputs vs edit cells

The daemon serializes all writes — no CRDTs. Clients send edits, daemon validates (including permission checks based on `client_kind`), applies to state, increments version, broadcasts deltas.

## What's in this PR

This PR introduces the protocol types and supporting modules. No server logic yet — that comes next.

- **`notebook_protocol.rs`** — Full client/server message types with two-level JSON tagging (`type` + `op`). Covers edit operations, delta broadcasting, execution lifecycle, comm/widget relay, presence, and snapshot types. Includes a permission matrix on `ClientKind` controlling what each client type can do (e.g., only `kernel` and `agent` can emit outputs, only `agent` can manage runtime sessions).
- **`fractional_index.rs`** — Base-36 fractional indexing for cell ordering, allowing insertions between any two adjacent keys without reindexing. Returns `Result` for safe handling of invalid input.
- **`notebook_server.rs`** — Stub for per-notebook server instances with validated notebook IDs and platform-specific socket paths (`#[cfg(unix)]` / `#[cfg(windows)]`).

### Key design decisions

1. **`after: Option<cell_id>` instead of client-computed fractional index** — Clients say "put it after cell X" (or `null` for beginning). Daemon computes the fractional index server-side.
2. **Separate module from pool protocol** — Pool daemon is request-response NDJSON; notebook sync is persistent bidirectional streaming. Different enough for separate modules, same crate.
3. **`serde_json::Value` for output data, representations, and comm state** — Keeps protocol independent of `jupyter-protocol`/`nbformat` internals.
4. **`MediaRepresentation::Inline` / `::Blob`** — Small data inline, large outputs served via HTTP from local blob storage.

## Test plan

- [x] `cargo test -p runtimed --lib` — 140+ unit tests covering roundtrip serde for every message variant, wire format shape verification, snapshot serialization, permission matrix, and error cases
- [x] `cargo clippy --all-targets -- -D warnings` — clean