### PR TITLE
Bump runtimelib, jupyter-protocol, and nbformat

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2621,9 +2621,9 @@ dependencies = [
 
 [[package]]
 name = "jupyter-protocol"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fecdcf39420574a8df6fa5758cecafa99a4af93a80ca2a9a96596f9b301e3a5"
+checksum = "8c75a69caf8b8e781224badfb76c4a8da4d49856de36ce72ae3cf5d4a1c94e42"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3011,9 +3011,9 @@ dependencies = [
 
 [[package]]
 name = "nbformat"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5903b59b1e05b1dda851281e3668ad3b6b32b1d6677d591563bc2091474d7d3c"
+checksum = "b10a89a2d910233ec3fca4de359b16ebe95e833c8b2162643ef98c6053a0549d"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5121,9 +5121,9 @@ dependencies = [
 
 [[package]]
 name = "runtimelib"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d80685459e1e5fa5603182058351ae91c98ca458dfef4e85f0a37be4f7cf1e6c"
+checksum = "e0bbbbda0bde4637a502077c169fc0b70aef6f6cb7d828327aa2faf46448157d"
 dependencies = [
  "base64 0.22.1",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,8 @@ futures = "0.3"
 bytes = "1"
 base64 = "0.22"
 tokio = { version = "1.36.0", features = ["full"] }
-runtimelib = { version = "1.2.0", default-features = false }
-jupyter-protocol = "1.2.0"
+runtimelib = { version = "1.3.0", default-features = false }
+jupyter-protocol = "1.2.1"
 thiserror = "1"
 
 [profile.release]

--- a/crates/notebook/Cargo.toml
+++ b/crates/notebook/Cargo.toml
@@ -30,7 +30,7 @@ jupyter-protocol = { workspace = true }
 runtimelib = { workspace = true, features = ["tokio-runtime", "ring"] }
 tauri-jupyter = { path = "../tauri-jupyter" }
 runtimed = { path = "../runtimed" }
-nbformat = "1.0.0"
+nbformat = "1.1.0"
 petname = "2"
 log = "0.4"
 env_logger = "0.11"


### PR DESCRIPTION
Updates the Jupyter ecosystem crates to their latest versions:

- `runtimelib` 1.2.0 → 1.3.0
- `jupyter-protocol` 1.2.0 → 1.2.1
- `nbformat` 1.0.0 → 1.1.0

The nbformat 1.1.0 update includes the upstream fix for `MultilineString::serialize` which had the same `source_to_lines` trailing-newline bug we fixed in #162, but for stream output text.