### PR TITLE
Fix pyproject.toml environment support and error diagnostics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,9 @@ __pycache__/
 .venv/
 **/.venv/
 
+# Fixture artifacts from test runs
+crates/notebook/fixtures/**/uv.lock
+
 # Agent workspace context (per-worktree state)
 .context/
 

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -247,6 +247,7 @@ function AppContent() {
 
   const {
     kernelStatus,
+    kernelErrorMessage,
     envSource,
     ensureKernelStarted,
     startKernelWithPyproject,
@@ -463,12 +464,13 @@ function AppContent() {
       )}
       <NotebookToolbar
         kernelStatus={kernelStatus}
+        kernelErrorMessage={kernelErrorMessage}
         envSource={envSource}
         envTypeHint={envTypeHint}
         dirty={dirty}
         hasDependencies={hasDependencies}
         theme={theme}
-        envProgress={envProgress.isActive ? envProgress : null}
+        envProgress={envProgress.isActive || envProgress.error ? envProgress : null}
         runtime={runtime}
         onThemeChange={setTheme}
         onSave={save}

--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -150,6 +150,7 @@ function envBadgeClasses(variant: EnvBadgeVariant): string {
 
 interface NotebookToolbarProps {
   kernelStatus: string;
+  kernelErrorMessage: string | null;
   envSource: string | null;
   /** Pre-start hint: "uv" | "conda" | "pixi" | null, derived from notebook metadata */
   envTypeHint?: EnvBadgeVariant | null;
@@ -176,6 +177,7 @@ const themeOptions: { value: ThemeMode; label: string; icon: typeof Sun }[] = [
 
 export function NotebookToolbar({
   kernelStatus,
+  kernelErrorMessage,
   envSource,
   envTypeHint,
   dirty,
@@ -369,8 +371,24 @@ export function NotebookToolbar({
               )}
             />
             <span className="text-xs text-muted-foreground">
-              {envProgress?.isActive ? envProgress.statusText : (
-                <span className="capitalize">{kernelStatus}</span>
+              {envProgress?.isActive ? envProgress.statusText : envProgress?.error ? (
+                <span className="text-red-600 dark:text-red-400" title={envProgress.error}>
+                  {envProgress.statusText}
+                </span>
+              ) : (
+                <>
+                  <span className="capitalize">{kernelStatus}</span>
+                  {kernelStatus === "error" && kernelErrorMessage && (
+                    <span
+                      className="text-red-600 dark:text-red-400"
+                      title={kernelErrorMessage}
+                    >
+                      {" "}&mdash; {kernelErrorMessage.length > 80
+                        ? `${kernelErrorMessage.substring(0, 80)}...`
+                        : kernelErrorMessage}
+                    </span>
+                  )}
+                </>
               )}
             </span>
           </div>

--- a/crates/notebook/src/kernel.rs
+++ b/crates/notebook/src/kernel.rs
@@ -1030,6 +1030,14 @@ impl NotebookKernel {
         // Shutdown existing kernel if any
         self.shutdown().await.ok();
 
+        // Canonicalize project_dir so uv gets an absolute path
+        let project_dir = project_dir.canonicalize().map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to resolve project directory {:?}: {}",
+                project_dir,
+                e
+            )
+        })?;
         info!("Starting kernel with uv run in project {:?}", project_dir);
 
         // Reserve ports
@@ -1085,7 +1093,7 @@ impl NotebookKernel {
             "-f",
         ])
         .arg(&connection_file_path)
-        .current_dir(project_dir)
+        .current_dir(&project_dir)
         .stdout(Stdio::null())
         .stderr(Stdio::piped());
         #[cfg(unix)]

--- a/crates/notebook/src/kernel.rs
+++ b/crates/notebook/src/kernel.rs
@@ -1068,7 +1068,7 @@ impl NotebookKernel {
         );
 
         // Use `uv run` to launch the kernel - this lets uv handle the environment
-        // --with ipykernel adds it transiently without modifying pyproject.toml
+        // --with adds ipykernel and ipywidgets transiently without modifying pyproject.toml
         let uv_path = tools::get_uv_path().await?;
         let mut cmd = tokio::process::Command::new(&uv_path);
         cmd.args([
@@ -1077,6 +1077,8 @@ impl NotebookKernel {
             &project_dir.to_string_lossy(),
             "--with",
             "ipykernel",
+            "--with",
+            "ipywidgets",
             "python",
             "-m",
             "ipykernel_launcher",
@@ -1101,9 +1103,11 @@ impl NotebookKernel {
             env_hash: "pyproject".to_string(),
         });
 
-        // Spawn a task to read stderr and emit progress events from uv output
+        // Spawn a task to read stderr, emit progress events, and buffer lines for error reporting
         let stderr = process.stderr.take();
         let stderr_app = app.clone();
+        let stderr_lines = std::sync::Arc::new(tokio::sync::Mutex::new(Vec::<String>::new()));
+        let stderr_lines_writer = stderr_lines.clone();
         let _stderr_task = tokio::spawn(async move {
             if let Some(stderr) = stderr {
                 use tokio::io::{AsyncBufReadExt, BufReader};
@@ -1111,6 +1115,16 @@ impl NotebookKernel {
                 let mut lines = reader.lines();
                 while let Ok(Some(line)) = lines.next_line().await {
                     debug!("uv stderr: {}", line);
+
+                    // Buffer line for error reporting (keep last 20 lines)
+                    {
+                        let mut buf = stderr_lines_writer.lock().await;
+                        buf.push(line.clone());
+                        if buf.len() > 20 {
+                            buf.remove(0);
+                        }
+                    }
+
                     let line_lower = line.to_lowercase();
                     if line_lower.contains("resolved") && line_lower.contains("package") {
                         emit_uv_progress(&stderr_app, EnvProgressPhase::Solving { spec_count: 0 });
@@ -1141,10 +1155,19 @@ impl NotebookKernel {
 
             // Check if uv run process already exited (error case)
             if let Ok(Some(status)) = process.try_wait() {
+                // Give stderr reader a moment to drain remaining output
+                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                let captured = stderr_lines.lock().await;
+                let stderr_detail = if captured.is_empty() {
+                    String::new()
+                } else {
+                    format!("\n{}", captured.join("\n"))
+                };
+                let msg = format!("uv run exited with {}{}", status, stderr_detail);
                 emit_uv_progress(&app, EnvProgressPhase::Error {
-                    message: format!("uv run exited with {}", status),
+                    message: msg.clone(),
                 });
-                return Err(anyhow::anyhow!("uv run exited with {}", status));
+                return Err(anyhow::anyhow!(msg));
             }
 
             // Try iopub connection
@@ -1218,10 +1241,19 @@ impl NotebookKernel {
         }
 
         if !connected {
+            let captured = stderr_lines.lock().await;
+            let stderr_hint = if captured.is_empty() {
+                String::new()
+            } else {
+                let last_lines: Vec<&str> = captured.iter().rev().take(5)
+                    .map(|s| s.as_str()).collect::<Vec<_>>().into_iter().rev().collect();
+                format!("\nLast stderr: {}", last_lines.join("\n"))
+            };
             let msg = format!(
-                "Kernel did not respond after {} attempts (last: {})",
+                "Kernel did not respond after {} attempts (last: {}){}",
                 delays_ms.len(),
-                last_error.unwrap_or_else(|| "unknown".to_string())
+                last_error.unwrap_or_else(|| "unknown".to_string()),
+                stderr_hint
             );
             emit_uv_progress(&app, EnvProgressPhase::Error { message: msg.clone() });
             return Err(anyhow::anyhow!(msg));


### PR DESCRIPTION
## Summary

Fixes pyproject.toml kernel launch failures that were failing silently with no user-visible error. Adds comprehensive error message propagation from kernel launch failures through to the UI.

**Root causes fixed:**
- Error messages from auto-launch failures were logged but not sent to frontend
- Stderr output from `uv run` was not captured for inclusion in error messages
- `--with ipywidgets` was missing from uv run args (inconsistent with other env paths)
- Progress error state was gated out of the toolbar display

**Changes made:**
- Add `error_message` field to `KernelLifecycleEvent` for transmitting diagnostics
- Buffer last 20 lines of stderr in `start_with_uv_run` for error reporting
- Include stderr details in error messages when uv run exits or kernel is unresponsive
- Add `--with ipywidgets` to uv run args (matches conda and uv inline paths)
- Wire `kernelErrorMessage` through frontend hooks and display truncated message in toolbar with full text in hover tooltip
- Fix envProgress gating so error state reaches the toolbar