### PR TITLE
Style environment badges with brand colors in toolbar

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -276,6 +276,17 @@ function AppContent() {
           ? "conda"
           : null;
 
+  // Pre-start hint for the env badge (more specific than envType: distinguishes pixi)
+  const envTypeHint = envSource
+    ? null // backend has spoken, no hint needed
+    : pixiInfo?.has_dependencies
+      ? ("pixi" as const)
+      : envType === "conda"
+        ? ("conda" as const)
+        : envType === "uv"
+          ? ("uv" as const)
+          : null;
+
   // Environment preparation progress
   const envProgress = useEnvProgress();
 
@@ -453,6 +464,7 @@ function AppContent() {
       <NotebookToolbar
         kernelStatus={kernelStatus}
         envSource={envSource}
+        envTypeHint={envTypeHint}
         dirty={dirty}
         hasDependencies={hasDependencies}
         theme={theme}

--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -55,26 +55,104 @@ function PythonIcon({ className }: { className?: string }) {
   );
 }
 
-/** Format an env source string for display in the toolbar. */
-function formatEnvSource(source: string | null): string | null {
+/** uv logo icon */
+function UvIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 41 41"
+      fill="currentColor"
+      className={className}
+    >
+      <path d="M-5.28619e-06 0.168629L0.0843098 20.1685L0.151762 36.1683C0.161075 38.3774 1.95947 40.1607 4.16859 40.1514L20.1684 40.084L30.1684 40.0418L31.1852 40.0375C33.3877 40.0282 35.1683 38.2026 35.1683 36V36L37.0003 36L37.0003 39.9992L40.1683 39.9996L39.9996 -9.94653e-07L21.5998 0.0775689L21.6774 16.0185L21.6774 25.9998L20.0774 25.9998L18.3998 25.9998L18.4774 16.032L18.3998 0.0910593L-5.28619e-06 0.168629Z" />
+    </svg>
+  );
+}
+
+/** Conda logo icon (from conda/conda repo) */
+function CondaIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 23.565 27.149"
+      fill="currentColor"
+      stroke="currentColor"
+      strokeWidth="0.25px"
+      className={className}
+    >
+      <path d="M47.3 23.46c-.69-1.27-2.08-3.82-4.51-6.25-.81 3.47-.81 6.48-.69 7.99-.12 0 2.2-1.16 5.2-1.74zM36.54 28.32c-1.27-1.04-3.7-2.89-7.28-4.4.92 3.82 2.43 6.6 3.24 7.99 0 .23 1.62-1.74 4.05-3.59zM50.67 20.08c.81-2.08 2.31-5.09 4.74-8.22-1.5-2.66-3.58-5.32-6.36-7.64-2.2 2.78-3.7 5.56-4.74 8.33 3.12 2.66 5.09 5.44 6.36 7.52zM29.15 36.66c-1.22-.22-2.56-.41-4-.52a40.19 40.19 0 0 0-5.77-.06c1.01 1.29 2.24 2.71 3.73 4.14A39.43 39.43 0 0 0 26.35 43c.35-1.03.77-2.12 1.28-3.28a43.76 43.76 0 0 1 1.51-3.06zM11.92 49.15c4.16-2.66 8.09-3.82 10.75-4.17-2.08-1.74-5.09-4.51-7.52-8.33-3.47.69-7.01 2.02-10.36 4.33 1.97 3.47 4.47 6.2 7.12 8.17zM25.21 48.11c-1.62.12-5.56.34-10.19 3.12 4.28 2.66 8.22 4.06 10.19 4.52-.35-2.55-.35-5.21 0-7.64zM39.21 14.02c-2.54-1.74-5.78-3.24-9.83-4.17-.81 3.47-.92 6.71-.69 9.49 3.93 1.27 6.94 3.12 9.02 4.63 0-2.31.35-5.9 1.5-9.95z" fillRule="evenodd" transform="matrix(.26458 0 0 .26458 -.189 -.253)" />
+      <path d="M14.22 17.73c1.52-.19 3.32-.3 5.35-.22 1.82.08 3.44.3 4.83.56.29-3.12.58-6.24.88-9.37a45.326 45.326 0 0 0-5.82 4.02 45.63 45.63 0 0 0-5.23 5z" fillRule="evenodd" strokeLinecap="round" transform="matrix(.26458 0 0 .26458 -.189 -.253)" />
+      <path d="M31.2 5.66c2.19.64 4.61 1.55 7.12 2.84.75.38 1.46.78 2.13 1.17a33.466 33.466 0 0 1 4.63-8.01c-2.15.36-4.53.88-7.08 1.62-2.53.73-4.8 1.55-6.8 2.38Z" transform="matrix(.26458 0 0 .26458 -.189 -.253)" />
+      <path d="M9.14 51.23c-2.66-2.2-5.32-5.09-7.4-8.68C.58 48.45.58 54.7 1.51 60.49c2.2-4.05 4.86-6.94 7.63-9.26ZM86.84 81.09c-7.28-6.94-8.79-11.46-14.91-6.71C55.17 87.57 31 79.7 25.91 59.22c-.92-.12-7.4-1.39-13.99-5.9-3.24 2.55-6.59 6.48-9.37 12.15h-.12c10.52 39.81 61.74 49.07 85.44 24.19 3.93-4.17.35-7.06-1.04-8.56zM69.26 6.58c-3.35 1.62-6.01 3.7-8.09 5.9 1.73 3.7 2.54 7.06 3.01 9.14 3.24-2.55 6.47-4.05 8.44-4.86-.23-2.31-1.04-6.6-3.35-10.18zM57.59 16.75a26.405 26.405 0 0 0-3.02 6.27c.8.04 1.66.12 2.56.23.82.1 1.6.23 2.32.38-.13-.88-.3-1.84-.55-2.86-.38-1.52-.84-2.87-1.32-4.02zM58.67 8.08c1.04-.98 2.3-2.05 3.78-3.1 1.32-.94 2.58-1.7 3.74-2.31-1.92-.46-4.1-.88-6.51-1.17-2.52-.3-4.83-.4-6.88-.38 2.42 2.21 4.38 4.64 5.87 6.96z" fillRule="evenodd" transform="matrix(.26458 0 0 .26458 -.189 -.253)" />
+      <path d="M74.58 5.55s3.24 9.95 3.35 15.04c-3.93.93-7.4 2.31-11.21 5.56 2.08 1.04 3.93 2.31 5.67 3.82 1.85 1.62 3.58 2.31 6.01 1.16 1.39-.93 9.13-8.91 9.94-9.95 1.85-1.97 1.39-5.21-.58-6.71-4.86-4.51-13.18-8.91-13.18-8.91ZM2.82 37.77c3.47-2.31 6.94-3.82 10.41-4.63-1.5-3.12-2.54-6.71-2.77-10.88C7.11 27 4.45 32.33 2.83 37.77zM28.59 32.72c-1.16-2.2-2.66-5.79-3.47-10.18-3.12-.69-6.59-1.04-10.64-.46.23 4.05 1.39 7.52 2.89 10.53 4.62-.69 8.56-.35 11.22.12z" fillRule="evenodd" transform="matrix(.26458 0 0 .26458 -.189 -.253)" />
+    </svg>
+  );
+}
+
+/** Prefix/Pixi logo icon (P mark from prefix.dev) */
+function PixiIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 27.4 40.2"
+      fill="currentColor"
+      className={className}
+    >
+      <path d="M27.116 3.67449C27.0374 1.63273 25.7268 0.270764 23.633 0.19141C16.9597-0.0609578 10.2854-0.0667476 3.61182 0.19175C1.56495 0.270764 0.211498 1.63273 0.128738 3.67449C0.0507459 5.60828 0.00647096 8.27738 0 9.98946C0 10.843 0.666168 11.488 1.56086 11.488C2.04414 11.488 2.46169 11.2956 2.74845 10.988C2.7539 10.985 2.76174 10.9846 2.76548 10.9802C3.03897 10.6791 3.2348 10.3079 3.50385 10.001C3.83217 9.62675 4.21021 9.28515 4.63219 9.0195C5.45945 8.49842 6.37151 8.20655 7.44535 8.20655C10.2694 8.20655 12.5673 10.2745 12.5673 13.3496C12.5673 16.4638 10.3297 18.5679 7.27779 18.5679C5.44514 18.5679 3.82195 17.7733 2.92351 16.2333C2.91193 16.2132 2.89695 16.1978 2.88469 16.1791C2.8789 16.1709 2.87311 16.1631 2.86732 16.1549C2.83019 16.1028 2.78932 16.0558 2.74505 16.0139C2.45862 15.7088 2.0421 15.518 1.5612 15.518C0.777537 15.518 0.169607 16.0132 0.0306519 16.7094C0.00919558 16.7714 0 16.8555 0.000340577 17.0162C0.00613038 18.7246 0.0527894 21.6614 0.129079 23.6953C0.166542 24.6952 0.572169 25.6696 1.34017 26.3269C2.21647 27.0772 3.21028 27.0776 4.28207 27.272C4.6516 27.3391 5.02215 27.4587 5.30585 27.7148C5.7159 28.0853 5.86712 28.6974 5.73531 29.2338C5.59125 29.8185 5.17268 30.2007 4.69996 30.5327C4.26232 30.8403 3.85874 31.1689 3.5168 31.5837C2.78694 32.4686 2.4089 33.5853 2.4089 34.7293C2.4089 37.8435 4.56986 40.0764 7.72326 40.0764C10.8375 40.0764 13.0836 37.9808 13.0836 35.0426C13.0836 33.8976 12.7699 32.7509 12.0912 31.8191C11.7683 31.376 11.3708 30.9935 10.9213 30.6809C10.47 30.3672 10.0136 30.1349 9.78409 29.5989C9.65433 29.2954 9.6104 28.9531 9.68362 28.6296C10.0068 27.1981 11.6052 27.3551 12.7233 27.3592C14.2909 27.365 15.8586 27.3579 17.426 27.3364C19.4956 27.3081 21.565 27.2557 23.6333 27.178C25.5899 27.1045 27.0377 25.6999 27.1164 23.695C27.3783 17.0217 27.3735 10.3474 27.1164 3.67381Z" />
+    </svg>
+  );
+}
+
+/** Badge color variant for environment sources */
+type EnvBadgeVariant = "uv" | "conda" | "pixi";
+
+interface EnvBadgeInfo {
+  label: string;
+  variant: EnvBadgeVariant;
+}
+
+/** Map raw env_source string to badge display info. */
+function getEnvBadgeInfo(source: string | null): EnvBadgeInfo | null {
   if (!source) return null;
   switch (source) {
-    case "uv:inline": return "uv";
-    case "uv:pyproject": return "pyproject.toml";
-    case "uv:prewarmed": return "uv";
-    case "uv:fresh": return "uv";
-    case "conda:inline": return "conda";
-    case "conda:pixi": return "pixi.toml";
-    case "conda:env_yml": return "environment.yml";
-    case "conda:prewarmed": return "conda";
-    case "conda:fresh": return "conda";
-    default: return source.split(":")[0] ?? source;
+    case "uv:inline":
+    case "uv:pyproject":
+    case "uv:prewarmed":
+    case "uv:fresh":
+      return { label: "uv", variant: "uv" };
+    case "conda:inline":
+    case "conda:env_yml":
+    case "conda:prewarmed":
+    case "conda:fresh":
+      return { label: "conda", variant: "conda" };
+    case "conda:pixi":
+      return { label: "pixi", variant: "pixi" };
+    default: {
+      const prefix = source.split(":")[0];
+      if (prefix === "uv") return { label: "uv", variant: "uv" };
+      if (prefix === "conda") return { label: "conda", variant: "conda" };
+      return { label: prefix ?? source, variant: "uv" };
+    }
+  }
+}
+
+/** Tailwind classes for an env badge variant */
+function envBadgeClasses(variant: EnvBadgeVariant): string {
+  switch (variant) {
+    case "uv":
+      return "bg-fuchsia-500/10 text-fuchsia-600 dark:text-fuchsia-400";
+    case "conda":
+      return "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400";
+    case "pixi":
+      return "bg-amber-500/10 text-amber-600 dark:text-amber-400";
   }
 }
 
 interface NotebookToolbarProps {
   kernelStatus: string;
   envSource: string | null;
+  /** Pre-start hint: "uv" | "conda" | "pixi" | null, derived from notebook metadata */
+  envTypeHint?: EnvBadgeVariant | null;
   dirty: boolean;
   hasDependencies: boolean;
   theme: ThemeMode;
@@ -99,6 +177,7 @@ const themeOptions: { value: ThemeMode; label: string; icon: typeof Sun }[] = [
 export function NotebookToolbar({
   kernelStatus,
   envSource,
+  envTypeHint,
   dirty,
   hasDependencies,
   theme,
@@ -135,6 +214,16 @@ export function NotebookToolbar({
     kernelStatus === "idle" ||
     kernelStatus === "busy" ||
     kernelStatus === "starting";
+
+  // Show env badge from backend source when kernel is running, or from metadata hint pre-start
+  const envBadgeInfo =
+    runtime === "python"
+      ? envSource && (kernelStatus === "idle" || kernelStatus === "busy")
+        ? getEnvBadgeInfo(envSource)
+        : envTypeHint
+          ? { label: envTypeHint, variant: envTypeHint }
+          : null
+      : null;
 
   return (
     <Collapsible open={settingsOpen} onOpenChange={setSettingsOpen}>
@@ -252,6 +341,21 @@ export function NotebookToolbar({
             )}
           </div>
 
+          {/* Env source badge — Python only */}
+          {envBadgeInfo && (
+            <div
+              className={cn(
+                "flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium",
+                envBadgeClasses(envBadgeInfo.variant)
+              )}
+              title={`Environment: ${envSource}`}
+            >
+              {envBadgeInfo.variant === "uv" && <UvIcon className="h-2 w-2" />}
+              {envBadgeInfo.variant === "conda" && <CondaIcon className="h-2.5 w-2.5" />}
+              {envBadgeInfo.variant === "pixi" && <PixiIcon className="h-2 w-2" />}
+            </div>
+          )}
+
           {/* Kernel status */}
           <div className="flex items-center gap-1.5">
             <div
@@ -266,12 +370,7 @@ export function NotebookToolbar({
             />
             <span className="text-xs text-muted-foreground">
               {envProgress?.isActive ? envProgress.statusText : (
-                <>
-                  <span className="capitalize">{kernelStatus}</span>
-                  {envSource && (kernelStatus === "idle" || kernelStatus === "busy") && (
-                    <span className="text-muted-foreground/70"> · {formatEnvSource(envSource)}</span>
-                  )}
-                </>
+                <span className="capitalize">{kernelStatus}</span>
               )}
             </span>
           </div>


### PR DESCRIPTION
Add branded environment indicator badges to the notebook toolbar.

The environment source (uv, conda, pixi) now displays as a small icon-only badge with per-environment brand colors (pink for uv, green for conda, yellow for pixi) positioned next to the Python/Deno language badge. Badges are displayed as soft translucent colored backgrounds.

Pre-start detection shows environment hints from notebook metadata (pixi.toml, pyproject.toml, environment.yml). Once the kernel starts and reports the actual environment source from the backend, the badge updates accordingly.

The kernel status text no longer includes the environment source suffix—just shows the state (Idle/Busy/etc.).

<img width="968" height="657" alt="image" src="https://github.com/user-attachments/assets/ff416efe-3fa7-4523-bbdf-33ccdb379a01" />

<img width="997" height="410" alt="image" src="https://github.com/user-attachments/assets/f321950c-d5eb-489d-80da-a6977563b314" />

<img width="910" height="414" alt="image" src="https://github.com/user-attachments/assets/bd5fed99-1835-4c20-9056-8ff2de1b2dc2" />


## Verification

- Open a notebook with pixi.toml, pyproject.toml, or environment.yml dependencies
- Verify the environment badge appears pre-start with correct color and icon
- Start kernel and confirm badge updates with backend-reported source (if different)
- Check Deno notebooks don't show environment badges
- Hover badge to see full `Environment: <source>` tooltip