### PR TITLE
Use UV brand color for pyproject.toml active state badges

### DIFF
--- a/apps/notebook/src/components/DependencyHeader.tsx
+++ b/apps/notebook/src/components/DependencyHeader.tsx
@@ -163,7 +163,7 @@ export function DependencyHeader({
                     </button>
                   )}
                   {isUsingProjectEnv && (
-                    <span className="rounded bg-green-500/20 px-1.5 py-0.5 text-green-700 dark:text-green-400 text-xs font-medium">
+                    <span className="rounded bg-uv/20 px-1.5 py-0.5 text-uv text-xs font-medium">
                       Active
                     </span>
                   )}
@@ -209,10 +209,10 @@ export function DependencyHeader({
 
           {/* Project-managed state: read-only view when using uv run */}
           {isUsingProjectEnv && (
-            <div className="mb-3 flex items-start gap-2 rounded bg-green-500/10 px-2 py-1.5 text-xs text-green-700 dark:text-green-400">
+            <div className="mb-3 flex items-start gap-2 rounded bg-uv/10 px-2 py-1.5 text-xs text-uv">
               <Info className="h-3.5 w-3.5 mt-0.5 shrink-0" />
               <span>
-                Managed by <code className="rounded bg-green-500/20 px-1">{pyprojectInfo?.relative_path ?? "pyproject.toml"}</code> — restart kernel to pick up dependency changes.
+                Managed by <code className="rounded bg-uv/20 px-1">{pyprojectInfo?.relative_path ?? "pyproject.toml"}</code> — restart kernel to pick up dependency changes.
               </span>
             </div>
           )}


### PR DESCRIPTION
Replace jarring green colors with the UV brand color (#de5fe9) in the "Active" badge and "Managed by pyproject.toml" notice. These elements are now consistent with the rest of the UV-branded dependency panel, eliminating the visual clash between the fuchsia toolbar badge and the green status indicators.

<img width="1212" height="862" alt="image" src="https://github.com/user-attachments/assets/734ed706-13eb-43f7-ba39-c3701d60c1b2" />

## Verification

- Open a notebook with a pyproject.toml nearby
- Click "Use project env" to activate the project environment
- Confirm the "Active" badge is fuchsia instead of green
- Confirm the "Managed by pyproject.toml" notice uses the same brand color