### PR TITLE
Fix project file detection: canonicalize paths, git boundaries, closest-wins

### DIFF
--- a/crates/notebook/src/deno_env.rs
+++ b/crates/notebook/src/deno_env.rs
@@ -161,11 +161,15 @@ pub fn find_deno_config(start_path: &Path) -> Option<PathBuf> {
             }
         }
 
-        // Stop at home directory
+        // Stop at home directory or git repo root — a project file above the
+        // repo root almost certainly belongs to a different project
         if let Some(ref home) = home_dir {
             if current == *home {
                 return None;
             }
+        }
+        if current.join(".git").exists() {
+            return None;
         }
 
         // Move to parent directory

--- a/crates/notebook/src/environment_yml.rs
+++ b/crates/notebook/src/environment_yml.rs
@@ -90,11 +90,15 @@ pub fn find_environment_yml(start_path: &Path) -> Option<PathBuf> {
             return Some(yaml_candidate);
         }
 
-        // Stop at home directory
+        // Stop at home directory or git repo root — a project file above the
+        // repo root almost certainly belongs to a different project
         if let Some(ref home) = home_dir {
             if current == *home {
                 return None;
             }
+        }
+        if current.join(".git").exists() {
+            return None;
         }
 
         // Move to parent directory

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -2550,12 +2550,13 @@ async fn start_deno_kernel_impl(
             .unwrap_or_default();
         let flexible = deps.map(|d| d.flexible_npm_imports).unwrap_or(true);
 
-        // Find workspace directory with deno.json
+        // Find workspace directory with deno.json (canonicalized so Deno gets an
+        // absolute working directory even when the notebook was opened with a relative path)
         let ws_dir = state
             .path
             .as_ref()
             .and_then(|p| deno_env::find_deno_config(p))
-            .and_then(|c| c.parent().map(|p| p.to_path_buf()));
+            .and_then(|c| c.parent().map(|p| p.canonicalize().unwrap_or_else(|_| p.to_path_buf())));
 
         (perms, ws_dir, flexible, state.path.clone())
     };

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -9,6 +9,7 @@ pub mod kernel;
 pub mod menu;
 pub mod notebook_state;
 pub mod pixi;
+pub mod project_file;
 pub mod pyproject;
 pub mod runtime;
 pub mod settings;
@@ -1405,123 +1406,130 @@ async fn start_default_python_kernel_impl(
             settings::PythonEnvType::Conda => false,
         }
     } else {
-        // Neither has inline deps - check for project files before falling back to prewarmed
-        // Detection priority: pyproject.toml → pixi.toml → (environment.yml) → prewarmed
+        // Neither has inline deps - check for project files before falling back to prewarmed.
+        // Uses "closest wins" detection: single walk-up from notebook, first match wins.
+        // Tiebreaker when multiple files at same level: pyproject > pixi > environment.yml.
         let notebook_path_for_detection = {
             let state = notebook_state.lock().map_err(|e| e.to_string())?;
             state.path.clone()
         };
 
-        // Priority 2: Check for pyproject.toml → use uv run
+        // Build the set of project file kinds to search for
+        let mut search_kinds = vec![
+            project_file::ProjectFileKind::PixiToml,
+            project_file::ProjectFileKind::EnvironmentYml,
+        ];
         if uv_available {
-            if let Some(ref nb_path) = notebook_path_for_detection {
-                if let Some(pyproject_path) = pyproject::find_pyproject(nb_path) {
-                    if let Ok(config) = pyproject::parse_pyproject(&pyproject_path) {
-                        let info = pyproject::create_pyproject_info(&config, nb_path);
-                        if info.has_dependencies || info.has_venv {
-                            let project_dir = pyproject_path.parent()
-                                .ok_or_else(|| "Invalid pyproject.toml path".to_string())?;
-
-                            info!(
-                                "Auto-detected pyproject.toml at {}, starting with uv run",
-                                info.relative_path
-                            );
-
-                            let mut kernel = kernel_state.lock().await;
-                            kernel.start_with_uv_run(app, project_dir).await
-                                .map_err(|e| e.to_string())?;
-
-                            info!(
-                                "[kernel-ready] Started UV kernel in {}ms | Source: pyproject.toml (auto-detected)",
-                                kernel_start.elapsed().as_millis()
-                            );
-                            return Ok("uv:pyproject".to_string());
-                        }
-                    }
-                }
-            }
+            // Only search for pyproject.toml when uv is available to handle it
+            search_kinds.insert(0, project_file::ProjectFileKind::PyprojectToml);
         }
 
-        // Priority 3: Check for pixi.toml → convert to conda deps
         if let Some(ref nb_path) = notebook_path_for_detection {
-            if let Some(pixi_path) = pixi::find_pixi_toml(nb_path) {
-                if let Ok(config) = pixi::parse_pixi_toml(&pixi_path) {
-                    if !config.dependencies.is_empty() {
-                        let pixi_info = pixi::create_pixi_info(&config, nb_path);
-                        info!(
-                            "Auto-detected pixi.toml at {} with {} dependencies, using conda/rattler path",
-                            pixi_info.relative_path,
-                            pixi_info.dependency_count
-                        );
+            if let Some(detected) = project_file::find_nearest_project_file(nb_path, &search_kinds) {
+                match detected.kind {
+                    project_file::ProjectFileKind::PyprojectToml => {
+                        if let Ok(config) = pyproject::parse_pyproject(&detected.path) {
+                            let info = pyproject::create_pyproject_info(&config, nb_path);
+                            if info.has_dependencies || info.has_venv {
+                                let project_dir = detected.path.parent()
+                                    .ok_or_else(|| "Invalid pyproject.toml path".to_string())?;
 
-                        let mut deps = pixi::convert_to_conda_dependencies(&config);
+                                info!(
+                                    "Auto-detected pyproject.toml at {} (closest project file), starting with uv run",
+                                    info.relative_path
+                                );
 
-                        // Get or create env_id for this notebook
-                        let env_id = {
-                            let mut state = notebook_state.lock().map_err(|e| e.to_string())?;
-                            let existing_id = state.notebook.metadata.additional
-                                .get("runt")
-                                .and_then(|v| v.get("env_id"))
-                                .and_then(|v| v.as_str())
-                                .map(|s| s.to_string());
-                            match existing_id {
-                                Some(id) => id,
-                                None => {
-                                    let new_id = uuid::Uuid::new_v4().to_string();
-                                    state.notebook.metadata.additional.insert(
-                                        "runt".to_string(),
-                                        serde_json::json!({ "env_id": new_id }),
-                                    );
-                                    state.dirty = true;
-                                    new_id
-                                }
+                                let mut kernel = kernel_state.lock().await;
+                                kernel.start_with_uv_run(app, project_dir).await
+                                    .map_err(|e| e.to_string())?;
+
+                                info!(
+                                    "[kernel-ready] Started UV kernel in {}ms | Source: pyproject.toml (auto-detected)",
+                                    kernel_start.elapsed().as_millis()
+                                );
+                                return Ok("uv:pyproject".to_string());
                             }
-                        };
-                        deps.env_id = Some(env_id);
+                        }
+                        // Closest project file has no usable deps — fall through to prewarmed
+                    }
+                    project_file::ProjectFileKind::PixiToml => {
+                        if let Ok(config) = pixi::parse_pixi_toml(&detected.path) {
+                            if !config.dependencies.is_empty() {
+                                let pixi_info = pixi::create_pixi_info(&config, nb_path);
+                                info!(
+                                    "Auto-detected pixi.toml at {} with {} deps (closest project file), using conda/rattler",
+                                    pixi_info.relative_path,
+                                    pixi_info.dependency_count
+                                );
 
-                        let mut kernel = kernel_state.lock().await;
-                        kernel.start_with_conda(app, &deps, notebook_path_for_detection.as_deref())
-                            .await
-                            .map_err(|e| e.to_string())?;
+                                let mut deps = pixi::convert_to_conda_dependencies(&config);
 
-                        info!(
-                            "[kernel-ready] Started Conda kernel in {}ms | Source: pixi.toml (auto-detected)",
-                            kernel_start.elapsed().as_millis()
-                        );
-                        return Ok("conda:pixi".to_string());
+                                // Get or create env_id for this notebook
+                                let env_id = {
+                                    let mut state = notebook_state.lock().map_err(|e| e.to_string())?;
+                                    let existing_id = state.notebook.metadata.additional
+                                        .get("runt")
+                                        .and_then(|v| v.get("env_id"))
+                                        .and_then(|v| v.as_str())
+                                        .map(|s| s.to_string());
+                                    match existing_id {
+                                        Some(id) => id,
+                                        None => {
+                                            let new_id = uuid::Uuid::new_v4().to_string();
+                                            state.notebook.metadata.additional.insert(
+                                                "runt".to_string(),
+                                                serde_json::json!({ "env_id": new_id }),
+                                            );
+                                            state.dirty = true;
+                                            new_id
+                                        }
+                                    }
+                                };
+                                deps.env_id = Some(env_id);
+
+                                let mut kernel = kernel_state.lock().await;
+                                kernel.start_with_conda(app, &deps, notebook_path_for_detection.as_deref())
+                                    .await
+                                    .map_err(|e| e.to_string())?;
+
+                                info!(
+                                    "[kernel-ready] Started Conda kernel in {}ms | Source: pixi.toml (auto-detected)",
+                                    kernel_start.elapsed().as_millis()
+                                );
+                                return Ok("conda:pixi".to_string());
+                            }
+                        }
+                        // Closest project file has no usable deps — fall through to prewarmed
+                    }
+                    project_file::ProjectFileKind::EnvironmentYml => {
+                        if let Ok(config) = environment_yml::parse_environment_yml(&detected.path) {
+                            if !config.dependencies.is_empty() {
+                                let deps = environment_yml::convert_to_conda_dependencies(&config);
+                                info!(
+                                    "Auto-detected environment.yml at {} with {} deps (closest project file)",
+                                    detected.path.display(),
+                                    deps.dependencies.len()
+                                );
+                                let mut kernel = kernel_state.lock().await;
+                                kernel
+                                    .start_with_conda(app, &deps, Some(nb_path))
+                                    .await
+                                    .map_err(|e| e.to_string())?;
+
+                                info!(
+                                    "[kernel-ready] Started conda kernel via environment.yml in {}ms",
+                                    kernel_start.elapsed().as_millis()
+                                );
+                                return Ok("conda:env_yml".to_string());
+                            }
+                        }
+                        // Closest project file has no usable deps — fall through to prewarmed
                     }
                 }
             }
         }
 
-        // Priority 4: Check for environment.yml → convert to conda deps
-        if let Some(ref nb_path) = notebook_path_for_detection {
-            if let Some(yml_path) = environment_yml::find_environment_yml(nb_path) {
-                if let Ok(config) = environment_yml::parse_environment_yml(&yml_path) {
-                    if !config.dependencies.is_empty() {
-                        let deps = environment_yml::convert_to_conda_dependencies(&config);
-                        info!(
-                            "Found environment.yml at {} with {} deps, starting conda kernel",
-                            yml_path.display(),
-                            deps.dependencies.len()
-                        );
-                        let mut kernel = kernel_state.lock().await;
-                        kernel
-                            .start_with_conda(app, &deps, Some(nb_path))
-                            .await
-                            .map_err(|e| e.to_string())?;
-
-                        info!(
-                            "[kernel-ready] Started conda kernel via environment.yml in {}ms",
-                            kernel_start.elapsed().as_millis()
-                        );
-                        return Ok("conda:env_yml".to_string());
-                    }
-                }
-            }
-        }
-
-        // No project file found - fall back to user preference (for prewarmed envs)
+        // No project file found (or closest had no usable deps) — fall back to user preference
         match preferred_env {
             settings::PythonEnvType::Uv => {
                 if uv_available {

--- a/crates/notebook/src/pixi.rs
+++ b/crates/notebook/src/pixi.rs
@@ -100,11 +100,15 @@ pub fn find_pixi_toml(start_path: &Path) -> Option<PathBuf> {
             return Some(candidate);
         }
 
-        // Stop at home directory
+        // Stop at home directory or git repo root — a project file above the
+        // repo root almost certainly belongs to a different project
         if let Some(ref home) = home_dir {
             if current == *home {
                 return None;
             }
+        }
+        if current.join(".git").exists() {
+            return None;
         }
 
         // Move to parent directory

--- a/crates/notebook/src/project_file.rs
+++ b/crates/notebook/src/project_file.rs
@@ -1,0 +1,316 @@
+//! Unified project file detection with "closest wins" semantics.
+//!
+//! Instead of checking for each project file type independently (which lets a
+//! distant pyproject.toml beat a nearby pixi.toml), this module does a single
+//! walk-up from the notebook directory, checking for ALL project file types at
+//! each level. The first (closest) match wins, with a tiebreaker order when
+//! multiple files exist at the same level.
+
+use std::path::{Path, PathBuf};
+
+/// The type of project file detected.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProjectFileKind {
+    PyprojectToml,
+    PixiToml,
+    EnvironmentYml,
+}
+
+/// A detected project file with its path and kind.
+#[derive(Debug, Clone)]
+pub struct DetectedProjectFile {
+    pub path: PathBuf,
+    pub kind: ProjectFileKind,
+}
+
+/// Mapping from filename to project file kind, in tiebreaker priority order.
+const ALL_CANDIDATES: &[(&str, ProjectFileKind)] = &[
+    ("pyproject.toml", ProjectFileKind::PyprojectToml),
+    ("pixi.toml", ProjectFileKind::PixiToml),
+    ("environment.yml", ProjectFileKind::EnvironmentYml),
+    ("environment.yaml", ProjectFileKind::EnvironmentYml),
+];
+
+/// Walk up from `start_path` checking each directory for project files.
+///
+/// Returns the first (closest) match. Within a single directory, tiebreaker
+/// order is: pyproject.toml > pixi.toml > environment.yml > environment.yaml.
+///
+/// The `kinds` parameter controls which file types to search for. Pass a subset
+/// to exclude types that can't be used (e.g., omit `PyprojectToml` when uv is
+/// not available so the search continues to find pixi or environment.yml).
+///
+/// Stops at home directory or `.git` boundary (same rules as the individual
+/// `find_*` functions).
+pub fn find_nearest_project_file(
+    start_path: &Path,
+    kinds: &[ProjectFileKind],
+) -> Option<DetectedProjectFile> {
+    let start_dir = if start_path.is_file() {
+        start_path.parent()?
+    } else {
+        start_path
+    };
+
+    let home_dir = dirs::home_dir();
+
+    let mut current = start_dir.to_path_buf();
+    loop {
+        // Check all requested project file types at this level, in tiebreaker order
+        for (filename, kind) in ALL_CANDIDATES {
+            if !kinds.contains(kind) {
+                continue;
+            }
+            let candidate = current.join(filename);
+            if candidate.exists() {
+                return Some(DetectedProjectFile {
+                    path: candidate,
+                    kind: kind.clone(),
+                });
+            }
+        }
+
+        // Stop at home directory or git repo root
+        if let Some(ref home) = home_dir {
+            if current == *home {
+                return None;
+            }
+        }
+        if current.join(".git").exists() {
+            return None;
+        }
+
+        // Move to parent directory
+        match current.parent() {
+            Some(parent) if parent != current => {
+                current = parent.to_path_buf();
+            }
+            _ => return None, // Reached filesystem root
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn write_file(dir: &Path, name: &str, content: &str) {
+        std::fs::write(dir.join(name), content).unwrap();
+    }
+
+    #[test]
+    fn test_closest_wins_pixi_over_distant_pyproject() {
+        let temp = TempDir::new().unwrap();
+        let project = temp.path().join("project");
+        let notebooks = project.join("notebooks");
+        std::fs::create_dir_all(&notebooks).unwrap();
+
+        // pyproject.toml at project root (farther)
+        write_file(&project, "pyproject.toml", "[project]\nname = \"test\"");
+        // pixi.toml next to notebooks (closer)
+        write_file(&notebooks, "pixi.toml", "[project]\nname = \"test\"");
+
+        let all_kinds = vec![
+            ProjectFileKind::PyprojectToml,
+            ProjectFileKind::PixiToml,
+            ProjectFileKind::EnvironmentYml,
+        ];
+
+        let found = find_nearest_project_file(&notebooks, &all_kinds);
+        assert!(found.is_some());
+        let found = found.unwrap();
+        assert_eq!(found.kind, ProjectFileKind::PixiToml);
+        assert_eq!(found.path, notebooks.join("pixi.toml"));
+    }
+
+    #[test]
+    fn test_closest_wins_env_yml_over_distant_pyproject() {
+        let temp = TempDir::new().unwrap();
+        let project = temp.path().join("project");
+        let sub = project.join("sub");
+        std::fs::create_dir_all(&sub).unwrap();
+
+        // pyproject.toml far away
+        write_file(&project, "pyproject.toml", "[project]\nname = \"test\"");
+        // environment.yml closer
+        write_file(&sub, "environment.yml", "name: test\ndependencies: []");
+
+        let all_kinds = vec![
+            ProjectFileKind::PyprojectToml,
+            ProjectFileKind::PixiToml,
+            ProjectFileKind::EnvironmentYml,
+        ];
+
+        let found = find_nearest_project_file(&sub, &all_kinds);
+        assert!(found.is_some());
+        let found = found.unwrap();
+        assert_eq!(found.kind, ProjectFileKind::EnvironmentYml);
+    }
+
+    #[test]
+    fn test_tiebreaker_same_dir_pyproject_wins() {
+        let temp = TempDir::new().unwrap();
+        write_file(temp.path(), "pyproject.toml", "[project]\nname = \"test\"");
+        write_file(temp.path(), "pixi.toml", "[project]\nname = \"test\"");
+
+        let all_kinds = vec![
+            ProjectFileKind::PyprojectToml,
+            ProjectFileKind::PixiToml,
+            ProjectFileKind::EnvironmentYml,
+        ];
+
+        let found = find_nearest_project_file(temp.path(), &all_kinds);
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().kind, ProjectFileKind::PyprojectToml);
+    }
+
+    #[test]
+    fn test_tiebreaker_same_dir_pixi_over_env_yml() {
+        let temp = TempDir::new().unwrap();
+        write_file(temp.path(), "pixi.toml", "[project]\nname = \"test\"");
+        write_file(temp.path(), "environment.yml", "name: test");
+
+        let all_kinds = vec![
+            ProjectFileKind::PyprojectToml,
+            ProjectFileKind::PixiToml,
+            ProjectFileKind::EnvironmentYml,
+        ];
+
+        let found = find_nearest_project_file(temp.path(), &all_kinds);
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().kind, ProjectFileKind::PixiToml);
+    }
+
+    #[test]
+    fn test_no_project_files() {
+        let temp = TempDir::new().unwrap();
+        let all_kinds = vec![
+            ProjectFileKind::PyprojectToml,
+            ProjectFileKind::PixiToml,
+            ProjectFileKind::EnvironmentYml,
+        ];
+
+        let found = find_nearest_project_file(temp.path(), &all_kinds);
+        assert!(found.is_none());
+    }
+
+    #[test]
+    fn test_kinds_filter_skips_pyproject() {
+        let temp = TempDir::new().unwrap();
+        let sub = temp.path().join("sub");
+        std::fs::create_dir_all(&sub).unwrap();
+
+        // pyproject.toml right next to notebook
+        write_file(&sub, "pyproject.toml", "[project]\nname = \"test\"");
+        // pixi.toml one level up
+        write_file(temp.path(), "pixi.toml", "[project]\nname = \"test\"");
+
+        // When pyproject is excluded (uv not available), pixi should be found
+        let no_pyproject = vec![
+            ProjectFileKind::PixiToml,
+            ProjectFileKind::EnvironmentYml,
+        ];
+
+        let found = find_nearest_project_file(&sub, &no_pyproject);
+        assert!(found.is_some());
+        let found = found.unwrap();
+        assert_eq!(found.kind, ProjectFileKind::PixiToml);
+        assert_eq!(found.path, temp.path().join("pixi.toml"));
+    }
+
+    #[test]
+    fn test_stops_at_git_root() {
+        let temp = TempDir::new().unwrap();
+        let outer = temp.path().join("org");
+        let repo = outer.join("my-repo");
+        let notebooks = repo.join("notebooks");
+        std::fs::create_dir_all(&notebooks).unwrap();
+
+        // pyproject.toml above git root
+        write_file(&outer, "pyproject.toml", "[project]\nname = \"org\"");
+        // .git at repo root
+        std::fs::create_dir(repo.join(".git")).unwrap();
+
+        let all_kinds = vec![
+            ProjectFileKind::PyprojectToml,
+            ProjectFileKind::PixiToml,
+            ProjectFileKind::EnvironmentYml,
+        ];
+
+        let found = find_nearest_project_file(&notebooks, &all_kinds);
+        assert!(found.is_none());
+    }
+
+    #[test]
+    fn test_finds_file_at_git_root() {
+        let temp = TempDir::new().unwrap();
+        let repo = temp.path().join("my-repo");
+        let notebooks = repo.join("notebooks");
+        std::fs::create_dir_all(&notebooks).unwrap();
+
+        write_file(&repo, "pixi.toml", "[project]\nname = \"test\"");
+        std::fs::create_dir(repo.join(".git")).unwrap();
+
+        let all_kinds = vec![
+            ProjectFileKind::PyprojectToml,
+            ProjectFileKind::PixiToml,
+            ProjectFileKind::EnvironmentYml,
+        ];
+
+        let found = find_nearest_project_file(&notebooks, &all_kinds);
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().kind, ProjectFileKind::PixiToml);
+    }
+
+    #[test]
+    fn test_environment_yaml_variant() {
+        let temp = TempDir::new().unwrap();
+        write_file(temp.path(), "environment.yaml", "name: test");
+
+        let all_kinds = vec![
+            ProjectFileKind::PyprojectToml,
+            ProjectFileKind::PixiToml,
+            ProjectFileKind::EnvironmentYml,
+        ];
+
+        let found = find_nearest_project_file(temp.path(), &all_kinds);
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().kind, ProjectFileKind::EnvironmentYml);
+    }
+
+    #[test]
+    fn test_yml_preferred_over_yaml() {
+        let temp = TempDir::new().unwrap();
+        write_file(temp.path(), "environment.yml", "name: yml");
+        write_file(temp.path(), "environment.yaml", "name: yaml");
+
+        let all_kinds = vec![
+            ProjectFileKind::PyprojectToml,
+            ProjectFileKind::PixiToml,
+            ProjectFileKind::EnvironmentYml,
+        ];
+
+        let found = find_nearest_project_file(temp.path(), &all_kinds);
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().path, temp.path().join("environment.yml"));
+    }
+
+    #[test]
+    fn test_from_file_path() {
+        let temp = TempDir::new().unwrap();
+        write_file(temp.path(), "pyproject.toml", "[project]\nname = \"test\"");
+        let notebook = temp.path().join("notebook.ipynb");
+        write_file(temp.path(), "notebook.ipynb", "{}");
+
+        let all_kinds = vec![
+            ProjectFileKind::PyprojectToml,
+            ProjectFileKind::PixiToml,
+            ProjectFileKind::EnvironmentYml,
+        ];
+
+        let found = find_nearest_project_file(&notebook, &all_kinds);
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().kind, ProjectFileKind::PyprojectToml);
+    }
+}


### PR DESCRIPTION
## Summary

Three fixes for project file detection that caused kernel launch failures and incorrect environment selection:

**1. Relative path canonicalization** — When notebooks are opened with relative paths (via Cmd-O or CLI), `kernel_cwd()` and Deno workspace dir now canonicalize before passing to child processes, fixing "No such file or directory" errors.

**2. Git repository boundary detection** — All detection functions (`find_pyproject`, `find_pixi_toml`, `find_environment_yml`, `find_deno_config`) now stop at `.git` boundaries. Previously they could escape above the repo root and find unrelated project files (e.g., an org-level `pyproject.toml` with a uv workspace was picked up for a pixi notebook).

**3. Closest-wins detection** — Replaces the fixed type-priority chain (pyproject → pixi → environment.yml) with a single walk-up that checks for ALL project file types at each directory level. The closest match wins, with a same-directory tiebreaker of pyproject > pixi > environment.yml. Also simplifies the frontend by removing duplicated project file detection from `ensureKernelStarted` (which was missing pixi entirely), deferring to the backend via `startDefaultKernel()`.

## Verification

- [ ] Open a pixi.toml notebook — should use conda/rattler path, not uv run
- [ ] Open a pyproject.toml notebook — should still detect and use uv run
- [ ] Open a notebook via Cmd-O with a relative path — kernel should start
- [ ] With pixi.toml near notebook and pyproject.toml further up — pixi wins
- [ ] Detection does NOT escape above the git repo root