### PR TITLE
Remove dead Disconnected variant and add workspace lint config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,14 @@ runtimelib = { version = "1.3.0", default-features = false }
 jupyter-protocol = "1.2.1"
 thiserror = "1"
 
+[workspace.lints.rust]
+dead_code = "warn"
+unused_imports = "warn"
+unused_variables = "warn"
+
+[workspace.lints.clippy]
+all = { level = "warn", priority = -1 }
+
 [profile.release]
 opt-level = 'z'
 strip = true

--- a/crates/notebook/Cargo.toml
+++ b/crates/notebook/Cargo.toml
@@ -6,6 +6,9 @@ description = "Tauri-based notebook UI for Jupyter kernels"
 repository = "https://github.com/runtimed/runt"
 license = "BSD-3-Clause"
 
+[lints]
+workspace = true
+
 [lib]
 name = "notebook"
 path = "src/lib.rs"

--- a/crates/runt/Cargo.toml
+++ b/crates/runt/Cargo.toml
@@ -7,6 +7,9 @@ repository.workspace = true
 license.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [[bin]]
 name = "runt"
 path = "src/main.rs"

--- a/crates/runtimed/Cargo.toml
+++ b/crates/runtimed/Cargo.toml
@@ -6,6 +6,9 @@ description = "Central daemon for managing Jupyter runtimes and prewarmed enviro
 repository = "https://github.com/runtimed/runt"
 license = "BSD-3-Clause"
 
+[lints]
+workspace = true
+
 [lib]
 name = "runtimed"
 path = "src/lib.rs"

--- a/crates/sidecar/Cargo.toml
+++ b/crates/sidecar/Cargo.toml
@@ -7,6 +7,9 @@ repository.workspace = true
 license.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = { workspace = true }
 chrono = { version = "0.4", features = ["serde"] }

--- a/crates/sidecar/src/lib.rs
+++ b/crates/sidecar/src/lib.rs
@@ -109,7 +109,6 @@ enum SidecarEvent {
 #[serde(rename_all = "snake_case")]
 enum KernelConnectionStatus {
     Connected,
-    Disconnected,
 }
 
 async fn run(

--- a/crates/tauri-jupyter/Cargo.toml
+++ b/crates/tauri-jupyter/Cargo.toml
@@ -6,6 +6,9 @@ description = "Shared Jupyter message types for Tauri/WebView applications"
 repository.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = { workspace = true }
 bytes = { workspace = true }

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -4,4 +4,7 @@ version = "0.1.0"
 edition.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]


### PR DESCRIPTION
## Summary

Removes the unused `KernelConnectionStatus::Disconnected` variant that triggered a dead_code warning after upgrading Rust. The variant was never constructed and the frontend doesn't handle kernel_status messages.

Adds `[workspace.lints]` configuration so local builds (`cargo check`, `cargo build`) surface the same lint warnings that CI enforces with `cargo clippy -- -D warnings`, catching issues during development rather than only in CI.

## Changes

- **crates/sidecar/src/lib.rs**: Remove `Disconnected` from `KernelConnectionStatus` enum
- **Cargo.toml**: Add workspace-level lint config for `rustc` (dead_code, unused_imports, unused_variables) and `clippy::all`
- **crate Cargo.toml files** (6 crates): Inherit workspace lints with `[lints] workspace = true`