### PR TITLE
Fix dual deps UX: let users choose which environment

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -74,6 +74,7 @@ function AppContent() {
   const [dependencyHeaderOpen, setDependencyHeaderOpen] = useState(false);
   const [showIsolationTest, setShowIsolationTest] = useState(false);
   const [trustDialogOpen, setTrustDialogOpen] = useState(false);
+  const [clearingDeps, setClearingDeps] = useState(false);
 
   // Trust verification for notebook dependencies
   const {
@@ -113,6 +114,7 @@ function AppContent() {
     needsKernelRestart,
     addDependency,
     removeDependency,
+    clearAllDependencies: clearAllUvDeps,
     syncState,
     syncNow,
     pyprojectInfo,
@@ -133,6 +135,7 @@ function AppContent() {
     loadDependencies: loadCondaDependencies,
     addDependency: addCondaDependency,
     removeDependency: removeCondaDependency,
+    clearAllDependencies: clearAllCondaDeps,
     setChannels: setCondaChannels,
     setPython: setCondaPython,
     environmentYmlInfo,
@@ -481,15 +484,33 @@ function AppContent() {
         onToggleDependencies={() => setDependencyHeaderOpen((prev) => !prev)}
         listKernelspecs={listKernelspecs}
       />
-      {/* Dual-dependency warning: both UV and conda deps exist */}
+      {/* Dual-dependency choice: both UV and conda deps exist, let user pick */}
       {dependencyHeaderOpen && runtime === "python" && hasUvDependencies && hasCondaDependencies && (
         <div className="border-b bg-amber-50/50 dark:bg-amber-950/20 px-3 py-2">
-          <div className="flex items-start gap-2 text-xs text-amber-700 dark:text-amber-400">
-            <span className="shrink-0 mt-0.5">&#9888;</span>
-            <div>
-              <span className="font-medium">This notebook has both uv and conda dependencies.</span>
-              {" "}Using {envType === "conda" ? "conda" : "uv"} based on your preference.
-              Consider removing the unused {envType === "conda" ? "uv" : "conda"} dependencies to avoid confusion.
+          <div className="flex items-center gap-2 text-xs text-amber-700 dark:text-amber-400">
+            <span className="shrink-0">&#9888;</span>
+            <span className="font-medium">This notebook has both uv and conda dependencies.</span>
+            <div className="flex gap-1.5 ml-auto shrink-0">
+              <button
+                disabled={clearingDeps}
+                onClick={async () => {
+                  setClearingDeps(true);
+                  try { await clearAllCondaDeps(); } finally { setClearingDeps(false); }
+                }}
+                className="px-2 py-0.5 text-xs font-medium rounded bg-fuchsia-100 dark:bg-fuchsia-900/40 hover:bg-fuchsia-200 dark:hover:bg-fuchsia-800/50 text-fuchsia-800 dark:text-fuchsia-300 border border-fuchsia-300 dark:border-fuchsia-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                Use uv ({dependencies?.dependencies?.length ?? 0} {(dependencies?.dependencies?.length ?? 0) === 1 ? "package" : "packages"})
+              </button>
+              <button
+                disabled={clearingDeps}
+                onClick={async () => {
+                  setClearingDeps(true);
+                  try { await clearAllUvDeps(); } finally { setClearingDeps(false); }
+                }}
+                className="px-2 py-0.5 text-xs font-medium rounded bg-emerald-100 dark:bg-emerald-900/40 hover:bg-emerald-200 dark:hover:bg-emerald-800/50 text-emerald-800 dark:text-emerald-300 border border-emerald-300 dark:border-emerald-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                Use conda ({condaDependencies?.dependencies?.length ?? 0} {(condaDependencies?.dependencies?.length ?? 0) === 1 ? "package" : "packages"})
+              </button>
             </div>
           </div>
         </div>

--- a/apps/notebook/src/hooks/useCondaDependencies.ts
+++ b/apps/notebook/src/hooks/useCondaDependencies.ts
@@ -220,6 +220,20 @@ export function useCondaDependencies() {
     [loadDependencies, resignTrust, checkSyncState]
   );
 
+  // Remove the entire conda dependency section from notebook metadata
+  const clearAllDependencies = useCallback(async () => {
+    setLoading(true);
+    try {
+      await invoke("clear_dependency_section", { section: "conda" });
+      await loadDependencies();
+      await resignTrust();
+    } catch (e) {
+      console.error("Failed to clear conda dependencies:", e);
+    } finally {
+      setLoading(false);
+    }
+  }, [loadDependencies, resignTrust]);
+
   // Clear the synced notice (e.g., when kernel restarts)
   const clearSyncNotice = useCallback(() => {
     setSyncedWhileRunning(false);
@@ -302,6 +316,7 @@ export function useCondaDependencies() {
     loadDependencies,
     addDependency,
     removeDependency,
+    clearAllDependencies,
     setChannels,
     setPython,
     syncNow,

--- a/apps/notebook/src/hooks/useDependencies.ts
+++ b/apps/notebook/src/hooks/useDependencies.ts
@@ -183,6 +183,20 @@ export function useDependencies() {
     [loadDependencies, resignTrust, checkSyncState]
   );
 
+  // Remove the entire uv dependency section from notebook metadata
+  const clearAllDependencies = useCallback(async () => {
+    setLoading(true);
+    try {
+      await invoke("clear_dependency_section", { section: "uv" });
+      await loadDependencies();
+      await resignTrust();
+    } catch (e) {
+      console.error("Failed to clear UV dependencies:", e);
+    } finally {
+      setLoading(false);
+    }
+  }, [loadDependencies, resignTrust]);
+
   // Clear the synced notice (e.g., when kernel restarts)
   const clearSyncNotice = useCallback(() => {
     setSyncedWhileRunning(false);
@@ -270,6 +284,7 @@ export function useDependencies() {
     loadDependencies,
     addDependency,
     removeDependency,
+    clearAllDependencies,
     setRequiresPython,
     clearSyncNotice,
     // Environment sync state


### PR DESCRIPTION
When a notebook has both UV and conda inline dependencies, users now see a choice banner instead of a passive warning. The banner displays "Use uv (3)" and "Use conda (2)" buttons (showing package counts), letting users pick which environment they want. Clicking one removes the other dependency set and confirms the selection through a positive action rather than a destructive one.

**Changes:**
- Add `clear_dependency_section` Tauri command to remove entire metadata sections
- Add `clearAllDependencies()` hooks in useDependencies and useCondaDependencies  
- Replace passive warning text with actionable choice buttons
- Banner disappears after choosing, dependency panel naturally shows the selection
- Trust is automatically re-signed after clearing

## Verification

- [x] Dual deps fixture notebook shows choice banner with correct package counts
- [x] Clicking "Use uv" removes conda deps and banner disappears
- [x] Clicking "Use conda" removes uv deps and banner disappears
- [x] After choosing, notebook remains trusted (re-sign successful)
- [x] UX matches button colors to toolbar environment badges

## Screenshots

<img width="958" height="693" alt="image" src="https://github.com/user-attachments/assets/36b425fc-5961-4d6a-81d5-96025900cc12" />

<img width="958" height="693" alt="image" src="https://github.com/user-attachments/assets/917aeed2-ac1a-429d-9879-1dab966a018d" />