### PR TITLE
Support dynamic E2E WebDriver port via CONDUCTOR_PORT

### DIFF
--- a/e2e/dev.sh
+++ b/e2e/dev.sh
@@ -11,7 +11,7 @@ if [ -f "$PROJECT_ROOT/e2e/.env" ]; then
   set -a; source "$PROJECT_ROOT/e2e/.env"; set +a
 fi
 
-PORT="${WEBDRIVER_PORT:-4444}"
+PORT="${WEBDRIVER_PORT:-${CONDUCTOR_PORT:-${PORT:-4444}}}"
 
 case "${1:-help}" in
   build)

--- a/e2e/wdio.conf.js
+++ b/e2e/wdio.conf.js
@@ -7,7 +7,7 @@
  *
  *   2. Native mode (macOS): Connects to the app's built-in WebDriver server
  *      - Build: cargo build --features webdriver-test -p notebook
- *      - Run:   ./target/debug/notebook --webdriver-port 4444
+ *      - Run:   ./target/debug/notebook --webdriver-port $PORT
  *      - Test:  pnpm test:e2e:native
  */
 
@@ -67,7 +67,7 @@ export const config = {
 
   // WebDriver connection settings
   hostname: process.env.WEBDRIVER_HOST || "localhost",
-  port: parseInt(process.env.WEBDRIVER_PORT || "4444", 10),
+  port: parseInt(process.env.WEBDRIVER_PORT || process.env.CONDUCTOR_PORT || process.env.PORT || "4444", 10),
 
   logLevel: "warn",
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:run": "vitest run",
     "test:e2e": "wdio run e2e/wdio.conf.js",
     "test:e2e:docker": "docker compose run --rm tauri-e2e",
-    "test:e2e:native": "WEBDRIVER_PORT=4444 wdio run e2e/wdio.conf.js",
+    "test:e2e:native": "wdio run e2e/wdio.conf.js",
     "e2e:docker:build": "docker compose build tauri-e2e",
     "e2e:docker:shell": "docker compose --profile dev run --rm tauri-e2e-shell"
   },


### PR DESCRIPTION
Add support for CONDUCTOR_PORT and PORT environment variables in the E2E test setup. This allows parallel test runs in different Conductor workspaces without port conflicts.

The port resolution order is: WEBDRIVER_PORT > CONDUCTOR_PORT > PORT > 4444 (default). Changes include:
- e2e/wdio.conf.js: Add CONDUCTOR_PORT and PORT to fallback chain
- e2e/dev.sh: Add CONDUCTOR_PORT and PORT to fallback chain  
- package.json: Remove hardcoded WEBDRIVER_PORT from test:e2e:native script

## Verification
- Run `./e2e/dev.sh start` — confirms it picks up `$CONDUCTOR_PORT` when set
- Run `CONDUCTOR_PORT=9876 ./e2e/dev.sh start` — confirms it starts on the dynamic port