### PR TITLE
Emit kernel:lifecycle on shutdown, handle 'not started' in frontend

### DIFF
--- a/apps/notebook/src/hooks/useKernel.ts
+++ b/apps/notebook/src/hooks/useKernel.ts
@@ -128,6 +128,11 @@ export function useKernel({
         } else if (event.payload.state === "error") {
           setKernelStatus("error");
           setKernelErrorMessage(event.payload.error_message ?? null);
+        } else if (event.payload.state === "not started") {
+          setKernelStatus("not started");
+          setEnvSource(null);
+          setKernelErrorMessage(null);
+          startingRef.current = false;
         }
       }
     );

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -627,10 +627,21 @@ async fn interrupt_kernel(
 
 #[tauri::command]
 async fn shutdown_kernel(
+    app: tauri::AppHandle,
     kernel_state: tauri::State<'_, Arc<tokio::sync::Mutex<NotebookKernel>>>,
 ) -> Result<(), String> {
     let mut kernel = kernel_state.lock().await;
-    kernel.shutdown().await.map_err(|e| e.to_string())
+    kernel.shutdown().await.map_err(|e| e.to_string())?;
+
+    let event = KernelLifecycleEvent {
+        state: "not started".to_string(),
+        runtime: String::new(),
+        env_source: None,
+        error_message: None,
+    };
+    let _ = app.emit("kernel:lifecycle", &event);
+
+    Ok(())
 }
 
 #[tauri::command]


### PR DESCRIPTION
## Summary

- **Backend** (`lib.rs`): `shutdown_kernel` now emits `kernel:lifecycle` with `state: "not started"` after shutting down the kernel, so the frontend is notified of backend-initiated shutdowns
- **Frontend** (`useKernel.ts`): The lifecycle listener now handles `"not started"` state by resetting `kernelStatus`, `envSource`, error message, and the starting ref

Closes #179, closes #180

## Test plan

- [x] Verify kernel shutdown from UI still works (toolbar stop button)
- [x] Verify frontend status resets to "not started" after shutdown
- [x] Verify no regression in auto-launch lifecycle flow