### PR TITLE
Add deps panel E2E test and modernize existing specs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -238,6 +238,11 @@ jobs:
             E2E_SPEC=e2e/specs/environment-yml-detection.spec.js \
             pnpm test:e2e || FAIL=1
 
+          start_driver
+          NOTEBOOK_PATH=crates/notebook/fixtures/audit-test/2-uv-inline.ipynb \
+            E2E_SPEC=e2e/specs/deps-panel.spec.js \
+            pnpm test:e2e || FAIL=1
+
           # Cleanup
           kill $DRIVER_PID 2>/dev/null || true
 

--- a/apps/notebook/src/components/DependencyHeader.tsx
+++ b/apps/notebook/src/components/DependencyHeader.tsx
@@ -62,7 +62,7 @@ export function DependencyHeader({
   );
 
   return (
-    <div className="border-b bg-uv/5 dark:bg-uv/10">
+    <div className="border-b bg-uv/5 dark:bg-uv/10" data-testid="deps-panel">
       <div className="px-3 py-3">
         {/* uv badge */}
         <div className="mb-2 flex items-center gap-2">
@@ -112,6 +112,7 @@ export function DependencyHeader({
                 type="button"
                 onClick={onSyncNow}
                 disabled={loading}
+                data-testid="deps-sync-button"
                 className="flex items-center gap-1 rounded bg-amber-600 px-2 py-0.5 text-white text-xs font-medium hover:bg-amber-700 transition-colors disabled:opacity-50"
               >
                 <RefreshCw className={`h-3 w-3 ${loading ? "animate-spin" : ""}`} />
@@ -264,6 +265,7 @@ export function DependencyHeader({
               onChange={(e) => setNewDep(e.target.value)}
               onKeyDown={handleKeyDown}
               placeholder="package or package>=version"
+              data-testid="deps-add-input"
               className="flex-1 rounded border bg-background px-2 py-1 text-xs placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
               disabled={loading}
               autoComplete="off"
@@ -273,6 +275,7 @@ export function DependencyHeader({
               type="button"
               onClick={handleAdd}
               disabled={loading || !newDep.trim()}
+              data-testid="deps-add-button"
               className="flex items-center gap-1 rounded bg-uv px-2 py-1 text-xs text-white transition-colors hover:bg-uv/90 disabled:opacity-50"
             >
               <Plus className="h-3 w-3" />

--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -273,6 +273,7 @@ export function NotebookToolbar({
           <button
             type="button"
             onClick={onToggleDependencies}
+            data-testid="deps-toggle"
             className={cn(
               "flex items-center gap-1 rounded px-2 py-1 text-xs transition-colors hover:bg-muted",
               hasDependencies ? "text-foreground" : "text-muted-foreground"

--- a/e2e/dev.sh
+++ b/e2e/dev.sh
@@ -165,6 +165,10 @@ case "${1:-help}" in
       crates/notebook/fixtures/audit-test/conda-env-project/7-environment-yml.ipynb \
       e2e/specs/environment-yml-detection.spec.js || FAIL=1
 
+    $0 test-fixture \
+      crates/notebook/fixtures/audit-test/2-uv-inline.ipynb \
+      e2e/specs/deps-panel.spec.js || FAIL=1
+
     exit $FAIL
     ;;
 

--- a/e2e/specs/deps-panel.spec.js
+++ b/e2e/specs/deps-panel.spec.js
@@ -1,0 +1,127 @@
+/**
+ * E2E Test: Dependencies Panel (Fixture)
+ *
+ * Opens a notebook with UV inline deps (2-uv-inline.ipynb).
+ * Verifies the dependencies panel UI: opening it, viewing existing deps,
+ * adding a new dependency, and removing it.
+ *
+ * Requires: NOTEBOOK_PATH=crates/notebook/fixtures/audit-test/2-uv-inline.ipynb
+ */
+
+import { browser, expect } from "@wdio/globals";
+import {
+  waitForAppReady,
+  executeFirstCell,
+  waitForCellOutput,
+  approveTrustDialog,
+  typeSlowly,
+} from "../helpers.js";
+
+describe("Dependencies Panel", () => {
+  before(async () => {
+    await waitForAppReady();
+    console.log("Page title:", await browser.getTitle());
+  });
+
+  it("should start kernel with trust approval", async () => {
+    const codeCell = await executeFirstCell();
+    console.log("Triggered execution — expecting trust dialog");
+
+    await approveTrustDialog();
+    console.log("Trust dialog approved");
+
+    const outputText = await waitForCellOutput(codeCell, 120000);
+    console.log("Python executable:", outputText);
+
+    expect(outputText).toContain("runt/envs");
+  });
+
+  it("should open deps panel from toolbar", async () => {
+    const depsToggle = await $('[data-testid="deps-toggle"]');
+    await depsToggle.waitForClickable({ timeout: 5000 });
+    await depsToggle.click();
+
+    const depsPanel = await $('[data-testid="deps-panel"]');
+    await depsPanel.waitForExist({ timeout: 5000 });
+    console.log("Deps panel opened");
+  });
+
+  it("should show existing dependency from notebook metadata", async () => {
+    // The 2-uv-inline fixture has "requests" as an inline dep
+    const depsPanel = await $('[data-testid="deps-panel"]');
+
+    const depText = await depsPanel.getText();
+    console.log("Deps panel text:", depText);
+
+    expect(depText).toContain("requests");
+    console.log("Existing dependency 'requests' found in panel");
+  });
+
+  it("should add a new dependency", async () => {
+    const addInput = await $('[data-testid="deps-add-input"]');
+    await addInput.waitForExist({ timeout: 5000 });
+    await addInput.click();
+    await browser.pause(200);
+    await typeSlowly("httpx");
+
+    const addButton = await $('[data-testid="deps-add-button"]');
+    await addButton.waitForClickable({ timeout: 5000 });
+    await addButton.click();
+
+    // Wait for the dep to appear in the panel
+    await browser.waitUntil(
+      async () => {
+        const panelText = await $('[data-testid="deps-panel"]').getText();
+        return panelText.includes("httpx");
+      },
+      { timeout: 10000, interval: 500, timeoutMsg: "httpx did not appear in deps panel" }
+    );
+
+    console.log("Added dependency 'httpx'");
+  });
+
+  it("should remove the added dependency", async () => {
+    // Find the remove button for httpx (X button next to the dep badge)
+    const removeButton = await browser.execute(() => {
+      const badges = document.querySelectorAll('[data-testid="deps-panel"] .font-mono');
+      for (const badge of badges) {
+        if (badge.textContent.trim() === "httpx") {
+          // The X button is a sibling of the text span
+          const container = badge.closest("div");
+          const btn = container?.querySelector("button");
+          return btn ? true : false;
+        }
+      }
+      return false;
+    });
+
+    expect(removeButton).toBe(true);
+
+    // Click the remove button via execute to target the right one
+    await browser.execute(() => {
+      const badges = document.querySelectorAll('[data-testid="deps-panel"] .font-mono');
+      for (const badge of badges) {
+        if (badge.textContent.trim() === "httpx") {
+          const container = badge.closest("div");
+          const btn = container?.querySelector("button");
+          if (btn) btn.click();
+          break;
+        }
+      }
+    });
+
+    // Wait for httpx to disappear
+    await browser.waitUntil(
+      async () => {
+        const panelText = await $('[data-testid="deps-panel"]').getText();
+        return !panelText.includes("httpx");
+      },
+      { timeout: 10000, interval: 500, timeoutMsg: "httpx was not removed from deps panel" }
+    );
+
+    // requests should still be there
+    const panelText = await $('[data-testid="deps-panel"]').getText();
+    expect(panelText).toContain("requests");
+    console.log("Removed 'httpx', 'requests' still present");
+  });
+});

--- a/e2e/specs/env-detection.spec.js
+++ b/e2e/specs/env-detection.spec.js
@@ -10,14 +10,15 @@
  */
 
 import { browser, expect } from "@wdio/globals";
-import os from "node:os";
-import { waitForAppReady } from "../helpers.js";
-
-// macOS uses Cmd (Meta) for shortcuts, Linux uses Ctrl
-const MOD_KEY = os.platform() === "darwin" ? "Meta" : "Control";
+import {
+  waitForAppReady,
+  setupCodeCell,
+  typeSlowly,
+  waitForCellOutput,
+  waitForOutputContaining,
+} from "../helpers.js";
 
 describe("Environment Detection", () => {
-  // Allow extra time for environment creation on first run
   const KERNEL_STARTUP_TIMEOUT = 120000;
   const EXECUTION_TIMEOUT = 15000;
 
@@ -25,98 +26,23 @@ describe("Environment Detection", () => {
 
   before(async () => {
     await waitForAppReady();
-
-    const title = await browser.getTitle();
-    console.log("Page title:", title);
+    console.log("Page title:", await browser.getTitle());
   });
 
-  /**
-   * Helper to type text character by character with delay to avoid dropped keys
-   */
-  async function typeSlowly(text, delay = 30) {
-    for (const char of text) {
-      await browser.keys(char);
-      await browser.pause(delay);
-    }
-  }
-
-  /**
-   * Helper to wait for output containing specific text
-   */
-  async function waitForOutput(expectedText, timeout) {
-    await browser.waitUntil(
-      async () => {
-        const streamOutput = await codeCell.$('[data-slot="ansi-stream-output"]');
-        if (!(await streamOutput.isExisting())) {
-          return false;
-        }
-        const text = await streamOutput.getText();
-        console.log("Current output:", JSON.stringify(text));
-        return text.includes(expectedText);
-      },
-      {
-        timeout,
-        timeoutMsg: `Output "${expectedText}" did not appear within timeout.`,
-        interval: 500,
-      }
-    );
-  }
-
   it("should detect environment type and start kernel successfully", async () => {
-    // Step 1: Ensure we have a code cell
-    codeCell = await $('[data-cell-type="code"]');
-    const cellExists = await codeCell.isExisting();
+    codeCell = await setupCodeCell();
 
-    if (!cellExists) {
-      console.log("No code cell found, adding one...");
-      const addCodeButton = await $("button*=Code");
-      await addCodeButton.waitForClickable({ timeout: 5000 });
-      await addCodeButton.click();
-      await browser.pause(500);
-
-      codeCell = await $('[data-cell-type="code"]');
-      await codeCell.waitForExist({ timeout: 5000 });
-    }
-
-    console.log("Code cell found");
-
-    // Step 2: Focus the CodeMirror editor
-    const editor = await codeCell.$('.cm-content[contenteditable="true"]');
-    await editor.waitForExist({ timeout: 5000 });
-    await editor.click();
-    await browser.pause(200);
-
-    // Clear any existing content
-    await browser.keys([MOD_KEY, "a"]);
-    await browser.pause(100);
-
-    // Step 3: Type code to print the Python executable path
     const testCode = "import sys; print(sys.executable)";
     console.log("Typing code:", testCode);
     await typeSlowly(testCode);
     await browser.pause(300);
 
-    // Step 4: Execute the cell
+    // Execute
     await browser.keys(["Shift", "Enter"]);
     console.log("Triggered execution (kernel will start)");
 
-    // Step 5: Wait for output (longer timeout for kernel startup)
-    await browser.waitUntil(
-      async () => {
-        const output = await codeCell.$('[data-slot="ansi-stream-output"]');
-        return await output.isExisting();
-      },
-      {
-        timeout: KERNEL_STARTUP_TIMEOUT,
-        timeoutMsg: "Kernel did not start - no output appeared",
-        interval: 1000,
-      }
-    );
-
-    // Step 6: Verify the Python path is from a managed environment
-    const outputText = await codeCell
-      .$('[data-slot="ansi-stream-output"]')
-      .getText();
+    // Wait for output (longer timeout for kernel startup)
+    const outputText = await waitForCellOutput(codeCell, KERNEL_STARTUP_TIMEOUT);
     console.log("Python executable:", outputText);
 
     // Should be from either runt/envs (uv) or runt/conda-envs (conda)
@@ -127,51 +53,27 @@ describe("Environment Detection", () => {
 
     const envType = isUvEnv ? "uv" : "conda";
     console.log(`Environment type detected: ${envType}`);
-    console.log("Test passed: Kernel started with managed environment");
   });
 
   it("should have ipykernel available in the environment", async () => {
-    // This test depends on the previous test having started the kernel
-
-    // Focus editor and type code to check ipykernel
-    const editor = await codeCell.$('.cm-content[contenteditable="true"]');
-    await editor.click();
-    await browser.pause(200);
-
-    // Clear and type new code
-    await browser.keys([MOD_KEY, "a"]);
-    await browser.pause(100);
+    codeCell = await setupCodeCell();
 
     const testCode = 'import ipykernel; print(f"ipykernel {ipykernel.__version__}")';
     console.log("Typing code:", testCode);
     await typeSlowly(testCode);
     await browser.pause(300);
 
-    // Execute
     await browser.keys(["Shift", "Enter"]);
     console.log("Triggered execution");
 
-    // Wait for ipykernel output
-    await waitForOutput("ipykernel", EXECUTION_TIMEOUT);
-
-    const outputText = await codeCell
-      .$('[data-slot="ansi-stream-output"]')
-      .getText();
+    const outputText = await waitForOutputContaining(codeCell, "ipykernel", EXECUTION_TIMEOUT);
     expect(outputText).toContain("ipykernel");
     console.log("ipykernel check passed:", outputText);
   });
 
   it("should be able to execute Python code in the environment", async () => {
-    // Verify the environment is fully functional by running some code
+    codeCell = await setupCodeCell();
 
-    const editor = await codeCell.$('.cm-content[contenteditable="true"]');
-    await editor.click();
-    await browser.pause(200);
-
-    await browser.keys([MOD_KEY, "a"]);
-    await browser.pause(100);
-
-    // Simple computation to verify the kernel is working
     const testCode = "print(2 + 2)";
     console.log("Typing code:", testCode);
     await typeSlowly(testCode);
@@ -179,11 +81,7 @@ describe("Environment Detection", () => {
 
     await browser.keys(["Shift", "Enter"]);
 
-    await waitForOutput("4", EXECUTION_TIMEOUT);
-
-    const outputText = await codeCell
-      .$('[data-slot="ansi-stream-output"]')
-      .getText();
+    const outputText = await waitForOutputContaining(codeCell, "4", EXECUTION_TIMEOUT);
     expect(outputText).toContain("4");
     console.log("Computation test passed");
   });

--- a/e2e/wdio.conf.js
+++ b/e2e/wdio.conf.js
@@ -35,6 +35,7 @@ const FIXTURE_SPECS = [
   "pyproject-startup.spec.js",
   "pixi-env-detection.spec.js",
   "environment-yml-detection.spec.js",
+  "deps-panel.spec.js",
   "iframe-isolation.spec.js",
 ];
 


### PR DESCRIPTION
## Summary

- **New deps panel E2E test** (`deps-panel.spec.js`): Opens the UV inline deps fixture, approves trust, opens the deps panel, verifies `requests` is listed, adds `httpx`, removes it, and confirms `requests` is still there. First test coverage for the dependency management UI.
- **data-testid attributes**: Added `deps-panel`, `deps-add-input`, `deps-add-button`, `deps-sync-button` to `DependencyHeader.tsx` and `deps-toggle` to the toolbar Deps button
- **Modernized specs**: `env-detection.spec.js` and `kernel-lifecycle.spec.js` now use shared helpers from `e2e/helpers.js` instead of duplicating `typeSlowly`, `waitForOutput`, `findButton`, etc. in each file
- **Shared helpers expanded**: Added `typeSlowly`, `waitForOutputContaining`, `waitForErrorOutput`, `getKernelStatus`, `waitForKernelStatus`, `findButton`, `setupCodeCell` to `e2e/helpers.js`

## Test plan

- [x] All 9 non-fixture specs pass (`./e2e/dev.sh test all`)
- [x] deps-panel fixture test passes