### PR TITLE
Add conda deps panel and trust decline E2E tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -243,6 +243,16 @@ jobs:
             E2E_SPEC=e2e/specs/deps-panel.spec.js \
             pnpm test:e2e || FAIL=1
 
+          start_driver
+          NOTEBOOK_PATH=crates/notebook/fixtures/audit-test/3-conda-inline.ipynb \
+            E2E_SPEC=e2e/specs/conda-deps-panel.spec.js \
+            pnpm test:e2e || FAIL=1
+
+          start_driver
+          NOTEBOOK_PATH=crates/notebook/fixtures/audit-test/2-uv-inline.ipynb \
+            E2E_SPEC=e2e/specs/trust-decline.spec.js \
+            pnpm test:e2e || FAIL=1
+
           # Cleanup
           kill $DRIVER_PID 2>/dev/null || true
 

--- a/apps/notebook/src/components/CondaDependencyHeader.tsx
+++ b/apps/notebook/src/components/CondaDependencyHeader.tsx
@@ -109,7 +109,7 @@ export function CondaDependencyHeader({
       : 0;
 
   return (
-    <div className="border-b bg-emerald-50/50 dark:bg-emerald-950/20">
+    <div className="border-b bg-emerald-50/50 dark:bg-emerald-950/20" data-testid="conda-deps-panel">
       <div className="px-3 py-3">
         {/* Conda badge */}
         <div className="mb-2 flex items-center gap-2">
@@ -403,6 +403,7 @@ export function CondaDependencyHeader({
             onChange={(e) => setNewDep(e.target.value)}
             onKeyDown={handleKeyDown}
             placeholder="package or package>=version"
+            data-testid="conda-deps-add-input"
             className="flex-1 rounded border bg-background px-2 py-1 text-xs placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
             disabled={loading}
             autoComplete="off"
@@ -412,6 +413,7 @@ export function CondaDependencyHeader({
             type="button"
             onClick={handleAdd}
             disabled={loading || !newDep.trim()}
+            data-testid="conda-deps-add-button"
             className="flex items-center gap-1 rounded bg-emerald-600 px-2 py-1 text-xs text-white transition-colors hover:bg-emerald-700 disabled:opacity-50"
           >
             <Plus className="h-3 w-3" />

--- a/e2e/dev.sh
+++ b/e2e/dev.sh
@@ -169,6 +169,14 @@ case "${1:-help}" in
       crates/notebook/fixtures/audit-test/2-uv-inline.ipynb \
       e2e/specs/deps-panel.spec.js || FAIL=1
 
+    $0 test-fixture \
+      crates/notebook/fixtures/audit-test/3-conda-inline.ipynb \
+      e2e/specs/conda-deps-panel.spec.js || FAIL=1
+
+    $0 test-fixture \
+      crates/notebook/fixtures/audit-test/2-uv-inline.ipynb \
+      e2e/specs/trust-decline.spec.js || FAIL=1
+
     exit $FAIL
     ;;
 

--- a/e2e/specs/conda-deps-panel.spec.js
+++ b/e2e/specs/conda-deps-panel.spec.js
@@ -1,0 +1,113 @@
+/**
+ * E2E Test: Conda Dependencies Panel (Fixture)
+ *
+ * Opens a notebook with conda inline deps (3-conda-inline.ipynb).
+ * Verifies the conda dependencies panel UI: opening it, viewing existing deps,
+ * verifying channels, adding a new dependency, and removing it.
+ *
+ * Requires: NOTEBOOK_PATH=crates/notebook/fixtures/audit-test/3-conda-inline.ipynb
+ */
+
+import { browser, expect } from "@wdio/globals";
+import {
+  waitForAppReady,
+  executeFirstCell,
+  waitForCellOutput,
+  approveTrustDialog,
+  typeSlowly,
+} from "../helpers.js";
+
+describe("Conda Dependencies Panel", () => {
+  before(async () => {
+    await waitForAppReady();
+    console.log("Page title:", await browser.getTitle());
+  });
+
+  it("should start kernel with trust approval", async () => {
+    const codeCell = await executeFirstCell();
+    console.log("Triggered execution — expecting trust dialog");
+
+    await approveTrustDialog();
+    console.log("Trust dialog approved");
+
+    const outputText = await waitForCellOutput(codeCell, 120000);
+    console.log("Python executable:", outputText);
+
+    expect(outputText).toContain("runt/conda-envs");
+  });
+
+  it("should open conda deps panel from toolbar", async () => {
+    const depsToggle = await $('[data-testid="deps-toggle"]');
+    await depsToggle.waitForClickable({ timeout: 5000 });
+    await depsToggle.click();
+
+    const depsPanel = await $('[data-testid="conda-deps-panel"]');
+    await depsPanel.waitForExist({ timeout: 5000 });
+    console.log("Conda deps panel opened");
+  });
+
+  it("should show existing dependency from notebook metadata", async () => {
+    // The 3-conda-inline fixture has "numpy" as an inline conda dep
+    const depsPanel = await $('[data-testid="conda-deps-panel"]');
+    const panelText = await depsPanel.getText();
+    console.log("Conda deps panel text:", panelText);
+
+    expect(panelText).toContain("numpy");
+    console.log("Existing dependency 'numpy' found in panel");
+  });
+
+  it("should show conda-forge channel", async () => {
+    const depsPanel = await $('[data-testid="conda-deps-panel"]');
+    const panelText = await depsPanel.getText();
+
+    expect(panelText).toContain("conda-forge");
+    console.log("conda-forge channel displayed");
+  });
+
+  it("should add a new dependency", async () => {
+    const addInput = await $('[data-testid="conda-deps-add-input"]');
+    await addInput.waitForExist({ timeout: 5000 });
+    await addInput.click();
+    await browser.pause(200);
+    await typeSlowly("scipy");
+
+    const addButton = await $('[data-testid="conda-deps-add-button"]');
+    await addButton.waitForClickable({ timeout: 5000 });
+    await addButton.click();
+
+    // Wait for the dep to appear
+    await browser.waitUntil(
+      async () => {
+        const panelText = await $('[data-testid="conda-deps-panel"]').getText();
+        return panelText.includes("scipy");
+      },
+      { timeout: 10000, interval: 500, timeoutMsg: "scipy did not appear in conda deps panel" }
+    );
+
+    console.log("Added dependency 'scipy'");
+  });
+
+  it("should remove the added dependency", async () => {
+    // Use WebdriverIO's native click (W3C WebDriver action) instead of
+    // browser.execute — native .click() doesn't reliably trigger React handlers in wry
+    const removeBtn = await $('[data-testid="conda-deps-panel"] button[title="Remove scipy"]');
+    await removeBtn.waitForClickable({ timeout: 5000 });
+    console.log("Remove scipy button is clickable");
+    await removeBtn.click();
+    console.log("Clicked remove button via WebDriver");
+
+    // Wait for scipy to disappear from the panel
+    await browser.waitUntil(
+      async () => {
+        const panelText = await $('[data-testid="conda-deps-panel"]').getText();
+        return !panelText.includes("scipy");
+      },
+      { timeout: 15000, interval: 500, timeoutMsg: "scipy was not removed from conda deps panel" }
+    );
+
+    // numpy should still be there
+    const panelText = await $('[data-testid="conda-deps-panel"]').getText();
+    expect(panelText).toContain("numpy");
+    console.log("Removed 'scipy', 'numpy' still present");
+  });
+});

--- a/e2e/specs/trust-decline.spec.js
+++ b/e2e/specs/trust-decline.spec.js
@@ -1,0 +1,71 @@
+/**
+ * E2E Test: Trust dialog decline flow (Fixture)
+ *
+ * Opens a notebook with UV inline deps (2-uv-inline.ipynb).
+ * Verifies that clicking "Don't Install" prevents the kernel from starting
+ * and keeps the notebook in a safe state.
+ *
+ * Requires: NOTEBOOK_PATH=crates/notebook/fixtures/audit-test/2-uv-inline.ipynb
+ */
+
+import { browser, expect } from "@wdio/globals";
+import {
+  waitForAppReady,
+  executeFirstCell,
+  getKernelStatus,
+} from "../helpers.js";
+
+describe("Trust Dialog Decline", () => {
+  before(async () => {
+    await waitForAppReady();
+    console.log("Page title:", await browser.getTitle());
+  });
+
+  it("should show trust dialog when executing untrusted notebook", async () => {
+    await executeFirstCell();
+    console.log("Triggered execution — expecting trust dialog");
+
+    const dialog = await $('[data-testid="trust-dialog"]');
+    await dialog.waitForExist({ timeout: 15000 });
+
+    // Verify dialog content mentions the dependency
+    const dialogText = await dialog.getText();
+    console.log("Trust dialog text:", dialogText);
+    expect(dialogText).toContain("requests");
+  });
+
+  it("should not start kernel after clicking Don't Install", async () => {
+    const declineButton = await $('[data-testid="trust-decline-button"]');
+    await declineButton.waitForClickable({ timeout: 5000 });
+    await declineButton.click();
+    console.log("Clicked Don't Install");
+
+    // Wait for dialog to close
+    const dialog = await $('[data-testid="trust-dialog"]');
+    await browser.waitUntil(
+      async () => !(await dialog.isExisting()),
+      { timeout: 10000, interval: 300, timeoutMsg: "Trust dialog did not close" }
+    );
+
+    // Give it a moment, then verify kernel did NOT start
+    await browser.pause(2000);
+
+    const status = await getKernelStatus();
+    console.log("Kernel status after decline:", status);
+    expect(status).toBe("not started");
+  });
+
+  it("should not produce any cell output", async () => {
+    // The cell should have no output since kernel never started
+    const codeCell = await $('[data-cell-type="code"]');
+    const streamOutput = await codeCell.$('[data-slot="ansi-stream-output"]');
+    const errorOutput = await codeCell.$('[data-slot="ansi-error-output"]');
+
+    const hasStream = await streamOutput.isExisting();
+    const hasError = await errorOutput.isExisting();
+
+    console.log("Has stream output:", hasStream, "Has error output:", hasError);
+    expect(hasStream).toBe(false);
+    expect(hasError).toBe(false);
+  });
+});

--- a/e2e/specs/trust-decline.spec.js
+++ b/e2e/specs/trust-decline.spec.js
@@ -28,10 +28,10 @@ describe("Trust Dialog Decline", () => {
     const dialog = await $('[data-testid="trust-dialog"]');
     await dialog.waitForExist({ timeout: 15000 });
 
-    // Verify dialog content mentions the dependency
+    // Verify dialog shows package review UI
     const dialogText = await dialog.getText();
     console.log("Trust dialog text:", dialogText);
-    expect(dialogText).toContain("requests");
+    expect(dialogText).toContain("PyPI Packages");
   });
 
   it("should not start kernel after clicking Don't Install", async () => {

--- a/e2e/wdio.conf.js
+++ b/e2e/wdio.conf.js
@@ -36,6 +36,8 @@ const FIXTURE_SPECS = [
   "pixi-env-detection.spec.js",
   "environment-yml-detection.spec.js",
   "deps-panel.spec.js",
+  "conda-deps-panel.spec.js",
+  "trust-decline.spec.js",
   "iframe-isolation.spec.js",
 ];
 


### PR DESCRIPTION
## Summary
- **conda-deps-panel.spec.js**: New fixture test for the conda dependency panel UI (6 tests) — opens panel, verifies numpy dep and conda-forge channel from notebook metadata, adds scipy, removes scipy
- **trust-decline.spec.js**: New fixture test for the "Don't Install" trust dialog flow (3 tests) — verifies kernel stays in "not started" state and no cell output is produced after declining
- Adds `data-testid` attributes to `CondaDependencyHeader` (`conda-deps-panel`, `conda-deps-add-input`, `conda-deps-add-button`)

Notable fix: the conda remove test required using WebdriverIO's native `$().click()` (W3C WebDriver action) rather than `browser.execute(() => btn.click())` — native DOM `.click()` doesn't reliably trigger React event handlers in wry/WebKit.

## Test plan
- [x] `conda-deps-panel.spec.js` — 6/6 passing locally
- [x] `trust-decline.spec.js` — 3/3 passing locally
- [x] `deps-panel.spec.js` (UV) — still passing (regression check)