### PR TITLE
Implement restart and run all cells

### DIFF
--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
-import { Save, Play, Square, Plus, Package, Settings, Sun, Moon, Monitor, RotateCcw } from "lucide-react";
+import { Save, Play, Square, Plus, Package, Settings, Sun, Moon, Monitor, RotateCcw, ChevronsRight } from "lucide-react";
 import { cn } from "@/lib/utils";
 import {
   Collapsible,
@@ -164,6 +164,8 @@ interface NotebookToolbarProps {
   onStartKernel: (name: string) => void;
   onInterruptKernel: () => void;
   onRestartKernel: () => void;
+  onRunAllCells: () => void;
+  onRestartAndRunAll: () => void;
   onAddCell: (type: "code" | "markdown") => void;
   onToggleDependencies: () => void;
   listKernelspecs: () => Promise<KernelspecInfo[]>;
@@ -190,6 +192,8 @@ export function NotebookToolbar({
   onStartKernel,
   onInterruptKernel,
   onRestartKernel,
+  onRunAllCells,
+  onRestartAndRunAll,
   onAddCell,
   onToggleDependencies,
   listKernelspecs,
@@ -301,6 +305,15 @@ export function NotebookToolbar({
             <>
               <button
                 type="button"
+                onClick={onRunAllCells}
+                className="flex items-center gap-1 rounded px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                title="Run all cells"
+              >
+                <ChevronsRight className="h-3.5 w-3.5" />
+                Run All
+              </button>
+              <button
+                type="button"
                 onClick={onInterruptKernel}
                 className="flex items-center gap-1 rounded px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
                 title="Interrupt kernel"
@@ -316,6 +329,15 @@ export function NotebookToolbar({
               >
                 <RotateCcw className="h-3 w-3" />
                 Restart
+              </button>
+              <button
+                type="button"
+                onClick={onRestartAndRunAll}
+                className="flex items-center gap-1 rounded px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                title="Restart kernel and run all cells"
+              >
+                <RotateCcw className="h-3 w-3" />
+                <ChevronsRight className="h-3 w-3 -ml-1" />
               </button>
             </>
           )}

--- a/apps/notebook/src/hooks/useExecutionQueue.ts
+++ b/apps/notebook/src/hooks/useExecutionQueue.ts
@@ -99,6 +99,17 @@ export function useExecutionQueue(options: UseExecutionQueueOptions = {}) {
     }
   }, []);
 
+  /** Queue all code cells for execution in notebook order */
+  const runAllCells = useCallback(async (): Promise<string[]> => {
+    console.log("[queue] run all cells");
+    try {
+      return await invoke<string[]>("run_all_cells");
+    } catch (e) {
+      console.error("[queue] run_all_cells failed:", e);
+      return [];
+    }
+  }, []);
+
   /** Check if a specific cell is in the queue (pending or executing) */
   const isCellQueued = useCallback(
     (cellId: string) => queueState.cells.some((c) => c.cell_id === cellId),
@@ -131,6 +142,8 @@ export function useExecutionQueue(options: UseExecutionQueueOptions = {}) {
     queueState,
     /** Queue a cell for execution */
     queueCell,
+    /** Queue all code cells for execution */
+    runAllCells,
     /** Clear all pending cells */
     clearQueue,
     /** Check if a cell is queued */

--- a/apps/notebook/src/hooks/useKernel.ts
+++ b/apps/notebook/src/hooks/useKernel.ts
@@ -522,6 +522,20 @@ export function useKernel({
     await ensureKernelStarted();
   }, [shutdownKernel, ensureKernelStarted]);
 
+  const restartAndRunAll = useCallback(async (): Promise<string[]> => {
+    console.log("[kernel] restart and run all");
+    try {
+      // Backend handles: interrupt → clear → shutdown → clear outputs → queue all
+      const cellIds = await invoke<string[]>("restart_and_run_all");
+      // Now start the kernel — queue processor retries until it's ready
+      await ensureKernelStarted();
+      return cellIds;
+    } catch (e) {
+      console.error("restart_and_run_all failed:", e);
+      return [];
+    }
+  }, [ensureKernelStarted]);
+
   return {
     kernelStatus,
     kernelErrorMessage,
@@ -539,6 +553,7 @@ export function useKernel({
     interruptKernel,
     shutdownKernel,
     restartKernel,
+    restartAndRunAll,
     listKernelspecs,
   };
 }

--- a/apps/notebook/src/hooks/useNotebook.ts
+++ b/apps/notebook/src/hooks/useNotebook.ts
@@ -54,6 +54,23 @@ export function useNotebook() {
     };
   }, []);
 
+  // Listen for backend-initiated bulk output clearing (run all / restart & run all)
+  useEffect(() => {
+    const unlisten = listen<string[]>("cells:outputs_cleared", (event) => {
+      const clearedIds = new Set(event.payload);
+      setCells((prev) =>
+        prev.map((c) =>
+          clearedIds.has(c.id) && c.cell_type === "code"
+            ? { ...c, outputs: [], execution_count: null }
+            : c
+        )
+      );
+    });
+    return () => {
+      unlisten.then((fn) => fn());
+    };
+  }, []);
+
   const updateCellSource = useCallback((cellId: string, source: string) => {
     setCells((prev) =>
       prev.map((c) => (c.id === cellId ? { ...c, source } : c))

--- a/crates/notebook/src/menu.rs
+++ b/crates/notebook/src/menu.rs
@@ -13,6 +13,10 @@ pub const MENU_ZOOM_IN: &str = "zoom_in";
 pub const MENU_ZOOM_OUT: &str = "zoom_out";
 pub const MENU_ZOOM_RESET: &str = "zoom_reset";
 
+// Menu item IDs for kernel operations
+pub const MENU_RUN_ALL_CELLS: &str = "run_all_cells";
+pub const MENU_RESTART_AND_RUN_ALL: &str = "restart_and_run_all";
+
 // Menu item IDs for CLI installation
 pub const MENU_INSTALL_CLI: &str = "install_cli";
 
@@ -96,6 +100,24 @@ pub fn create_menu(app: &AppHandle) -> tauri::Result<Menu<Wry>> {
     edit_menu.append(&PredefinedMenuItem::paste(app, None)?)?;
     edit_menu.append(&PredefinedMenuItem::select_all(app, None)?)?;
     menu.append(&edit_menu)?;
+
+    // Kernel menu
+    let kernel_menu = Submenu::new(app, "Kernel", true)?;
+    kernel_menu.append(&MenuItem::with_id(
+        app,
+        MENU_RUN_ALL_CELLS,
+        "Run All Cells",
+        true,
+        None::<&str>,
+    )?)?;
+    kernel_menu.append(&MenuItem::with_id(
+        app,
+        MENU_RESTART_AND_RUN_ALL,
+        "Restart & Run All Cells",
+        true,
+        None::<&str>,
+    )?)?;
+    menu.append(&kernel_menu)?;
 
     // View menu
     let view_menu = Submenu::new(app, "View", true)?;


### PR DESCRIPTION
## Summary

Add "Run All Cells" and "Restart & Run All Cells" features for executing all code cells in notebook order. Backend-coordinated orchestration ensures robust restart without fragile frontend timing: backend handles interrupt→clear→shutdown→queue, queue processor retries until kernel ready, then frontend starts kernel.

**Key changes:**
- Backend: `run_all_cells` and `restart_and_run_all` Tauri commands with `EnqueueAll` queue variant
- Timing fix: `cells:outputs_cleared` event emitted before queue updates, so UI shows clean cells immediately
- UI: "Run All" and "Restart & Run All" buttons on toolbar, plus Kernel menu

## Verification

Open a multi-cell notebook and verify:
- Click "Run All" button: all cells execute in order, outputs appear
- Click "Restart & Run All" button: kernel restarts, all cells execute, outputs appear
- Use Kernel menu items: same behavior as toolbar buttons