### PR TITLE
Add E2E tests for Run All and Restart & Run All cells

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -253,6 +253,11 @@ jobs:
             E2E_SPEC=e2e/specs/trust-decline.spec.js \
             pnpm test:e2e || FAIL=1
 
+          start_driver
+          NOTEBOOK_PATH=crates/notebook/fixtures/audit-test/8-multi-cell.ipynb \
+            E2E_SPEC=e2e/specs/run-all-cells.spec.js \
+            pnpm test:e2e || FAIL=1
+
           # Cleanup
           kill $DRIVER_PID 2>/dev/null || true
 

--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -309,6 +309,7 @@ export function NotebookToolbar({
                 onClick={onRunAllCells}
                 className="flex items-center gap-1 rounded px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
                 title="Run all cells"
+                data-testid="run-all-button"
               >
                 <ChevronsRight className="h-3.5 w-3.5" />
                 Run All
@@ -336,6 +337,7 @@ export function NotebookToolbar({
                 onClick={onRestartAndRunAll}
                 className="flex items-center gap-1 rounded px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
                 title="Restart kernel and run all cells"
+                data-testid="restart-run-all-button"
               >
                 <RotateCcw className="h-3 w-3" />
                 <ChevronsRight className="h-3 w-3 -ml-1" />

--- a/crates/notebook/fixtures/audit-test/8-multi-cell.ipynb
+++ b/crates/notebook/fixtures/audit-test/8-multi-cell.ipynb
@@ -1,0 +1,39 @@
+{
+  "cells": [
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "cell-1",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "x = 42\n",
+        "print(\"cell1:\", x)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "cell-2",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "y = x * 2\n",
+        "print(\"cell2:\", y)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "cell-3",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "print(\"cell3: done\")"
+      ]
+    }
+  ],
+  "metadata": {},
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/e2e/dev.sh
+++ b/e2e/dev.sh
@@ -177,6 +177,10 @@ case "${1:-help}" in
       crates/notebook/fixtures/audit-test/2-uv-inline.ipynb \
       e2e/specs/trust-decline.spec.js || FAIL=1
 
+    $0 test-fixture \
+      crates/notebook/fixtures/audit-test/8-multi-cell.ipynb \
+      e2e/specs/run-all-cells.spec.js || FAIL=1
+
     exit $FAIL
     ;;
 

--- a/e2e/specs/run-all-cells.spec.js
+++ b/e2e/specs/run-all-cells.spec.js
@@ -1,0 +1,108 @@
+/**
+ * E2E Test: Run All Cells and Restart & Run All (Fixture)
+ *
+ * Opens a notebook with 3 code cells and no dependencies (8-multi-cell.ipynb).
+ * Verifies "Run All" executes all cells in order, and "Restart & Run All"
+ * clears outputs and re-executes everything.
+ *
+ * Requires: NOTEBOOK_PATH=crates/notebook/fixtures/audit-test/8-multi-cell.ipynb
+ */
+
+import { browser, expect } from "@wdio/globals";
+import { waitForAppReady, waitForKernelReady } from "../helpers.js";
+
+/**
+ * Wait for a specific cell (by index) to have stream output containing the expected text.
+ */
+async function waitForCellStreamOutput(cellIndex, expectedText, timeout = 120000) {
+  const cells = await $$('[data-cell-type="code"]');
+  const cell = cells[cellIndex];
+
+  await browser.waitUntil(
+    async () => {
+      const output = await cell.$('[data-slot="ansi-stream-output"]');
+      if (!(await output.isExisting())) return false;
+      const text = await output.getText();
+      return text.includes(expectedText);
+    },
+    {
+      timeout,
+      interval: 500,
+      timeoutMsg: `Cell ${cellIndex} did not produce output containing "${expectedText}"`,
+    }
+  );
+
+  const output = await cell.$('[data-slot="ansi-stream-output"]');
+  return await output.getText();
+}
+
+describe("Run All Cells", () => {
+  before(async () => {
+    await waitForAppReady();
+    console.log("Page title:", await browser.getTitle());
+  });
+
+  it("should have 3 pre-populated code cells", async () => {
+    const cells = await $$('[data-cell-type="code"]');
+    console.log("Code cells found:", cells.length);
+    expect(cells.length).toBe(3);
+  });
+
+  it("should execute all cells with Run All", async () => {
+    // Kernel auto-launches for vanilla notebooks (no deps)
+    await waitForKernelReady();
+    console.log("Kernel ready");
+
+    const runAllButton = await $('[data-testid="run-all-button"]');
+    await runAllButton.waitForClickable({ timeout: 5000 });
+    await runAllButton.click();
+    console.log("Clicked Run All");
+
+    // Wait for all 3 cells to produce correct output
+    const output1 = await waitForCellStreamOutput(0, "cell1: 42");
+    console.log("Cell 1 output:", output1);
+    expect(output1).toContain("cell1: 42");
+
+    const output2 = await waitForCellStreamOutput(1, "cell2: 84");
+    console.log("Cell 2 output:", output2);
+    expect(output2).toContain("cell2: 84");
+
+    const output3 = await waitForCellStreamOutput(2, "cell3: done");
+    console.log("Cell 3 output:", output3);
+    expect(output3).toContain("cell3: done");
+  });
+
+  it("should restart and re-execute all cells", async () => {
+    const restartRunAllButton = await $('[data-testid="restart-run-all-button"]');
+    await restartRunAllButton.waitForClickable({ timeout: 5000 });
+    await restartRunAllButton.click();
+    console.log("Clicked Restart & Run All");
+
+    // Wait for outputs to clear (kernel restarts, outputs get wiped)
+    await browser.waitUntil(
+      async () => {
+        const cells = await $$('[data-cell-type="code"]');
+        for (const cell of cells) {
+          const output = await cell.$('[data-slot="ansi-stream-output"]');
+          if (await output.isExisting()) return false;
+        }
+        return true;
+      },
+      { timeout: 15000, interval: 300, timeoutMsg: "Outputs did not clear after Restart & Run All" }
+    );
+    console.log("Outputs cleared");
+
+    // Wait for all cells to re-execute with correct outputs
+    const output1 = await waitForCellStreamOutput(0, "cell1: 42");
+    console.log("Cell 1 re-executed:", output1);
+    expect(output1).toContain("cell1: 42");
+
+    const output2 = await waitForCellStreamOutput(1, "cell2: 84");
+    console.log("Cell 2 re-executed:", output2);
+    expect(output2).toContain("cell2: 84");
+
+    const output3 = await waitForCellStreamOutput(2, "cell3: done");
+    console.log("Cell 3 re-executed:", output3);
+    expect(output3).toContain("cell3: done");
+  });
+});

--- a/e2e/wdio.conf.js
+++ b/e2e/wdio.conf.js
@@ -38,6 +38,7 @@ const FIXTURE_SPECS = [
   "deps-panel.spec.js",
   "conda-deps-panel.spec.js",
   "trust-decline.spec.js",
+  "run-all-cells.spec.js",
   "iframe-isolation.spec.js",
 ];
 


### PR DESCRIPTION
## What

Adds E2E test coverage for the Run All Cells and Restart & Run All Cells features from #186, along with `data-testid` attributes needed for reliable test targeting.

- `data-testid="run-all-button"` and `data-testid="restart-run-all-button"` on the two new toolbar buttons in `NotebookToolbar`
- New fixture `8-multi-cell.ipynb`: 3 code cells with cross-cell variable dependency (no deps, kernel auto-launches)
- New `run-all-cells.spec.js`: verifies Run All executes all cells in order, and Restart & Run All clears outputs and re-executes with a fresh kernel

## Why

The "Run All" and "Restart & Run All" features involve backend coordination (interrupt → shutdown → clear → enqueue all) that's worth validating end-to-end. The cross-cell variable dependency (`y = x * 2`) in the fixture proves sequential execution order — if cells run out of order, cell 2 fails.

## Verification

- [x] Run All button executes all 3 cells in order with correct outputs
- [x] Restart & Run All clears outputs, restarts kernel, and re-executes all cells