### PR TITLE
Revive iframe-isolation E2E test as standalone fixture

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -258,6 +258,11 @@ jobs:
             E2E_SPEC=e2e/specs/run-all-cells.spec.js \
             pnpm test:e2e || FAIL=1
 
+          start_driver
+          NOTEBOOK_PATH=crates/notebook/fixtures/audit-test/9-html-output.ipynb \
+            E2E_SPEC=e2e/specs/iframe-isolation.spec.js \
+            pnpm test:e2e || FAIL=1
+
           # Cleanup
           kill $DRIVER_PID 2>/dev/null || true
 

--- a/crates/notebook/fixtures/audit-test/9-html-output.ipynb
+++ b/crates/notebook/fixtures/audit-test/9-html-output.ipynb
@@ -1,0 +1,27 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "id": "cell-1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from IPython.display import display, HTML\n",
+    "display(HTML(\"<div id='isolation-probe'>hello from iframe</div>\"))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/e2e/dev.sh
+++ b/e2e/dev.sh
@@ -181,6 +181,10 @@ case "${1:-help}" in
       crates/notebook/fixtures/audit-test/8-multi-cell.ipynb \
       e2e/specs/run-all-cells.spec.js || FAIL=1
 
+    $0 test-fixture \
+      crates/notebook/fixtures/audit-test/9-html-output.ipynb \
+      e2e/specs/iframe-isolation.spec.js || FAIL=1
+
     exit $FAIL
     ;;
 


### PR DESCRIPTION
## Summary

- Rewrites the orphaned `iframe-isolation.spec.js` as a proper fixture test with its own app instance
- Creates `9-html-output.ipynb` fixture that produces HTML output via `IPython.display`, triggering the production `IsolatedFrame` iframe
- Tests iframe sandbox security properties using the production postMessage eval channel (since `browser.switchToFrame()` doesn't work in wry's WebDriver)
- Wires the test into `dev.sh test-fixtures` and CI

## What changed

The old test tried to open a debug panel via `Ctrl+Shift+I` which doesn't work in headless wry. The new test takes a realistic approach: execute a cell that produces HTML output, wait for the `IsolatedFrame` iframe to appear, then verify security properties by sending eval messages through the iframe's postMessage bridge and checking the results.

Security properties verified:
- Sandbox attribute excludes `allow-same-origin`
- `window.__TAURI__` is undefined inside iframe
- `window.__TAURI_INTERNALS__` is undefined inside iframe
- Origin is opaque `"null"` (not `tauri://localhost`)
- Parent document access throws `SecurityError`
- `localStorage` access throws `SecurityError`

## Verification

- [x] `iframe-isolation.spec.js` passes with the `9-html-output.ipynb` fixture
- [x] All other fixture tests still pass (no regressions)
- [x] Security properties are actually tested inside the iframe (via postMessage eval), not in the parent frame