### PR TITLE
Add settings panel E2E test as daemon-independent fixture

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -263,6 +263,11 @@ jobs:
             E2E_SPEC=e2e/specs/iframe-isolation.spec.js \
             pnpm test:e2e || FAIL=1
 
+          start_driver
+          NOTEBOOK_PATH=crates/notebook/fixtures/audit-test/1-vanilla.ipynb \
+            E2E_SPEC=e2e/specs/settings-panel.spec.js \
+            pnpm test:e2e || FAIL=1
+
           # Cleanup
           kill $DRIVER_PID 2>/dev/null || true
 

--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -460,14 +460,14 @@ export function NotebookToolbar({
 
         {/* Collapsible settings panel */}
         <CollapsibleContent>
-          <div className="border-t bg-background px-4 py-3">
+          <div className="border-t bg-background px-4 py-3" data-testid="settings-panel">
             <div className="flex flex-wrap items-center gap-x-6 gap-y-2">
               {/* Theme */}
               <div className="flex items-center gap-3">
                 <span className="text-xs font-medium text-muted-foreground">
                   Theme
                 </span>
-                <div className="flex items-center gap-1 rounded-md border bg-muted/50 p-0.5">
+                <div className="flex items-center gap-1 rounded-md border bg-muted/50 p-0.5" data-testid="settings-theme-group">
                   {themeOptions.map((option) => {
                     const Icon = option.icon;
                     const isActive = theme === option.value;
@@ -497,7 +497,7 @@ export function NotebookToolbar({
                   <span className="text-xs font-medium text-muted-foreground">
                     Default Runtime
                   </span>
-                  <div className="flex items-center gap-1 rounded-md border bg-muted/50 p-0.5">
+                  <div className="flex items-center gap-1 rounded-md border bg-muted/50 p-0.5" data-testid="settings-runtime-group">
                     <button
                       type="button"
                       onClick={() => onDefaultRuntimeChange("python")}
@@ -534,7 +534,7 @@ export function NotebookToolbar({
                   <span className="text-xs font-medium text-muted-foreground">
                     Default Python Env
                   </span>
-                  <div className="flex items-center gap-1 rounded-md border bg-muted/50 p-0.5">
+                  <div className="flex items-center gap-1 rounded-md border bg-muted/50 p-0.5" data-testid="settings-python-env-group">
                     <button
                       type="button"
                       onClick={() => onDefaultPythonEnvChange("uv")}

--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -252,6 +252,7 @@ export function NotebookToolbar({
               dirty ? "text-foreground" : "text-muted-foreground"
             )}
             title="Save (Cmd+S)"
+            data-testid="save-button"
           >
             <Save className="h-3.5 w-3.5" />
             {dirty && <span className="text-[10px]">&bull;</span>}
@@ -265,6 +266,7 @@ export function NotebookToolbar({
             onClick={() => onAddCell("code")}
             className="flex items-center gap-1 rounded px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
             title="Add code cell"
+            data-testid="add-code-cell-button"
           >
             <Plus className="h-3 w-3" />
             Code
@@ -274,6 +276,7 @@ export function NotebookToolbar({
             onClick={() => onAddCell("markdown")}
             className="flex items-center gap-1 rounded px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
             title="Add markdown cell"
+            data-testid="add-markdown-cell-button"
           >
             <Plus className="h-3 w-3" />
             Markdown
@@ -289,6 +292,7 @@ export function NotebookToolbar({
               disabled={kernelspecs.length === 0}
               className="flex items-center gap-1 rounded px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:opacity-50"
               title="Start kernel"
+              data-testid="start-kernel-button"
             >
               <Play className="h-3 w-3" fill="currentColor" />
               Start Kernel
@@ -310,6 +314,7 @@ export function NotebookToolbar({
                 onClick={onRestartKernel}
                 className="flex items-center gap-1 rounded px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
                 title="Restart kernel"
+                data-testid="restart-kernel-button"
               >
                 <RotateCcw className="h-3 w-3" />
                 Restart
@@ -329,6 +334,7 @@ export function NotebookToolbar({
                 onClick={onInterruptKernel}
                 className="flex items-center gap-1 rounded px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
                 title="Interrupt kernel"
+                data-testid="interrupt-kernel-button"
               >
                 <Square className="h-3 w-3" />
                 Interrupt

--- a/e2e/dev.sh
+++ b/e2e/dev.sh
@@ -185,6 +185,10 @@ case "${1:-help}" in
       crates/notebook/fixtures/audit-test/9-html-output.ipynb \
       e2e/specs/iframe-isolation.spec.js || FAIL=1
 
+    $0 test-fixture \
+      crates/notebook/fixtures/audit-test/1-vanilla.ipynb \
+      e2e/specs/settings-panel.spec.js || FAIL=1
+
     exit $FAIL
     ;;
 

--- a/e2e/helpers.js
+++ b/e2e/helpers.js
@@ -226,7 +226,7 @@ export async function setupCodeCell() {
   const cellExists = await codeCell.isExisting();
 
   if (!cellExists) {
-    const addCodeButton = await $("button*=Code");
+    const addCodeButton = await $('[data-testid="add-code-cell-button"]');
     await addCodeButton.waitForClickable({ timeout: 5000 });
     await addCodeButton.click();
     await browser.pause(500);

--- a/e2e/specs/backspace-delete-cell.spec.js
+++ b/e2e/specs/backspace-delete-cell.spec.js
@@ -74,7 +74,7 @@ describe("Backspace Delete Cell", () => {
     if (initialCellCount === 0) {
       // Add first cell
       console.log("No code cell found, adding one...");
-      const addCodeButton = await $("button*=Code");
+      const addCodeButton = await $('[data-testid="add-code-cell-button"]');
       await addCodeButton.waitForClickable({ timeout: 5000 });
       await addCodeButton.click();
       await browser.pause(500);
@@ -141,7 +141,7 @@ describe("Backspace Delete Cell", () => {
     // If Alt+Enter didn't create a cell, try clicking the add button
     if (cellCount < 2) {
       console.log("Alt+Enter didn't create cell, trying button...");
-      const addButtons = await $$("button*=Code");
+      const addButtons = await $$('[data-testid="add-code-cell-button"]');
       if (addButtons.length > 0) {
         // Scroll the last button into view and click
         const lastAddButton = addButtons[addButtons.length - 1];

--- a/e2e/specs/cell-operations.spec.js
+++ b/e2e/specs/cell-operations.spec.js
@@ -102,7 +102,7 @@ describe("Cell Operations", () => {
       console.log("Initial code cell count:", initialCount);
 
       // Click the "Code" button to add a new code cell
-      const addCodeButton = await $("button*=Code");
+      const addCodeButton = await $('[data-testid="add-code-cell-button"]');
       const buttonExists = await addCodeButton.isExisting();
 
       if (buttonExists) {
@@ -132,7 +132,7 @@ describe("Cell Operations", () => {
       console.log("Initial markdown cell count:", initialMdCount);
 
       // Click the "Markdown" button
-      const addMdButton = await $("button*=Markdown");
+      const addMdButton = await $('[data-testid="add-markdown-cell-button"]');
       const buttonExists = await addMdButton.isExisting();
 
       if (buttonExists) {
@@ -154,7 +154,7 @@ describe("Cell Operations", () => {
   describe("Deleting cells", () => {
     it("should delete a cell when multiple cells exist", async () => {
       // First ensure we have multiple cells
-      const addCodeButton = await $("button*=Code");
+      const addCodeButton = await $('[data-testid="add-code-cell-button"]');
       if (await addCodeButton.isExisting()) {
         await addCodeButton.click();
         await browser.pause(300);
@@ -273,7 +273,7 @@ describe("Cell Operations", () => {
   describe("Cross-cell state", () => {
     it("should persist variables across cells", async () => {
       // Add a fresh code cell
-      const addCodeButton = await $("button*=Code");
+      const addCodeButton = await $('[data-testid="add-code-cell-button"]');
       if (await addCodeButton.isExisting()) {
         await addCodeButton.click();
         await browser.pause(300);

--- a/e2e/specs/error-handling.spec.js
+++ b/e2e/specs/error-handling.spec.js
@@ -63,7 +63,7 @@ describe("Error Handling", () => {
 
     if (!cellExists) {
       console.log("No code cell found, adding one...");
-      const addCodeButton = await $("button*=Code");
+      const addCodeButton = await $('[data-testid="add-code-cell-button"]');
       await addCodeButton.waitForClickable({ timeout: 5000 });
       await addCodeButton.click();
       await browser.pause(500);

--- a/e2e/specs/kernel-lifecycle.spec.js
+++ b/e2e/specs/kernel-lifecycle.spec.js
@@ -71,9 +71,9 @@ describe("Kernel Lifecycle", () => {
 
     // If keyboard shortcut didn't work, try the interrupt button
     const interruptButton = await findButton([
+      '[data-testid="interrupt-kernel-button"]',
       'button[aria-label*="interrupt"]',
       'button[aria-label*="Interrupt"]',
-      "button*=Interrupt",
     ]);
     if (interruptButton) {
       console.log("Clicking interrupt button");
@@ -111,10 +111,9 @@ describe("Kernel Lifecycle", () => {
 
     // Find and click the restart button
     const restartButton = await findButton([
+      '[data-testid="restart-kernel-button"]',
       'button[title="Restart kernel"]',
       'button[aria-label*="restart"]',
-      'button[aria-label*="Restart"]',
-      "button*=Restart",
     ]);
 
     if (restartButton) {

--- a/e2e/specs/markdown-cell.spec.js
+++ b/e2e/specs/markdown-cell.spec.js
@@ -75,7 +75,7 @@ describe("Markdown Cell", () => {
       console.log("Initial markdown cell count:", initialCount);
 
       // Click the "Markdown" button to add a new markdown cell
-      const addMdButton = await $("button*=Markdown");
+      const addMdButton = await $('[data-testid="add-markdown-cell-button"]');
       const buttonExists = await addMdButton.isExisting();
 
       if (buttonExists) {
@@ -188,7 +188,7 @@ describe("Markdown Cell", () => {
 
       if (!targetCell) {
         // Create a markdown cell and add content
-        const addMdButton = await $("button*=Markdown");
+        const addMdButton = await $('[data-testid="add-markdown-cell-button"]');
         if (await addMdButton.isExisting()) {
           await addMdButton.click();
           await browser.pause(500);
@@ -299,7 +299,7 @@ describe("Markdown Cell", () => {
 
       if (!targetCell) {
         // Create or enter edit mode on a cell
-        const addMdButton = await $("button*=Markdown");
+        const addMdButton = await $('[data-testid="add-markdown-cell-button"]');
         if (await addMdButton.isExisting()) {
           await addMdButton.click();
           await browser.pause(500);

--- a/e2e/specs/notebook-execution.spec.js
+++ b/e2e/specs/notebook-execution.spec.js
@@ -92,7 +92,7 @@ describe("Notebook Execution Happy Path", () => {
     if (!cellExists) {
       // Notebook is empty - click "Code Cell" button to add first cell
       console.log("No code cell found, adding one...");
-      const addCodeButton = await $("button*=Code");
+      const addCodeButton = await $('[data-testid="add-code-cell-button"]');
       await addCodeButton.waitForClickable({ timeout: 5000 });
       await addCodeButton.click();
       await browser.pause(500);

--- a/e2e/specs/rich-outputs.spec.js
+++ b/e2e/specs/rich-outputs.spec.js
@@ -46,7 +46,7 @@ describe("Rich Output Types", () => {
 
     if (!cellExists) {
       console.log("No code cell found, adding one...");
-      const addCodeButton = await $("button*=Code");
+      const addCodeButton = await $('[data-testid="add-code-cell-button"]');
       await addCodeButton.waitForClickable({ timeout: 5000 });
       await addCodeButton.click();
       await browser.pause(500);

--- a/e2e/specs/run-all-cells.spec.js
+++ b/e2e/specs/run-all-cells.spec.js
@@ -49,12 +49,14 @@ describe("Run All Cells", () => {
   });
 
   it("should execute all cells with Run All", async () => {
-    // Start the kernel explicitly (auto-launch may be slow in CI)
-    const startButton = await $("button*=Start Kernel");
-    if (await startButton.isExisting()) {
-      await startButton.click();
-      console.log("Clicked Start Kernel");
-    }
+    // Start the kernel explicitly if it hasn't auto-launched yet.
+    // Use browser.execute() — wry's WebDriver returns broken element refs for text selectors.
+    const clicked = await browser.execute(() => {
+      const btn = document.querySelector('button[title="Start kernel"]');
+      if (btn) { btn.click(); return true; }
+      return false;
+    });
+    if (clicked) console.log("Clicked Start Kernel");
     await waitForKernelReady();
     console.log("Kernel ready");
 

--- a/e2e/specs/run-all-cells.spec.js
+++ b/e2e/specs/run-all-cells.spec.js
@@ -49,14 +49,12 @@ describe("Run All Cells", () => {
   });
 
   it("should execute all cells with Run All", async () => {
-    // Start the kernel explicitly if it hasn't auto-launched yet.
-    // Use browser.execute() — wry's WebDriver returns broken element refs for text selectors.
-    const clicked = await browser.execute(() => {
-      const btn = document.querySelector('button[title="Start kernel"]');
-      if (btn) { btn.click(); return true; }
-      return false;
-    });
-    if (clicked) console.log("Clicked Start Kernel");
+    // Start the kernel explicitly if it hasn't auto-launched yet
+    const startButton = await $('[data-testid="start-kernel-button"]');
+    if (await startButton.isExisting()) {
+      await startButton.click();
+      console.log("Clicked Start Kernel");
+    }
     await waitForKernelReady();
     console.log("Kernel ready");
 

--- a/e2e/specs/settings-panel.spec.js
+++ b/e2e/specs/settings-panel.spec.js
@@ -1,0 +1,293 @@
+/**
+ * E2E Test: Settings Panel (Fixture)
+ *
+ * Opens a vanilla notebook and tests the settings panel UI:
+ * toggling the panel, switching themes (observing <html> class changes),
+ * and verifying active button states for runtime and Python env settings.
+ *
+ * Daemon-independent: tests only observable DOM effects, not localStorage
+ * or settings.json persistence. Works whether or not runtimed is running.
+ *
+ * Requires: NOTEBOOK_PATH=crates/notebook/fixtures/audit-test/1-vanilla.ipynb
+ */
+
+import { browser, expect } from "@wdio/globals";
+import { waitForAppReady } from "../helpers.js";
+
+describe("Settings Panel", () => {
+  before(async () => {
+    await waitForAppReady();
+    console.log("Page title:", await browser.getTitle());
+  });
+
+  describe("Panel toggle", () => {
+    it("should open settings panel when clicking gear button", async () => {
+      // Settings panel should not be in DOM initially (Radix Collapsible unmounts content)
+      const panelBefore = await browser.execute(() => {
+        return !!document.querySelector('[data-testid="settings-panel"]');
+      });
+      expect(panelBefore).toBe(false);
+
+      // Click the gear button
+      const gearButton = await $('[aria-label="Settings"]');
+      await gearButton.waitForClickable({ timeout: 5000 });
+      await gearButton.click();
+
+      // Wait for panel to mount in DOM
+      await browser.waitUntil(
+        async () => {
+          return await browser.execute(() => {
+            return !!document.querySelector('[data-testid="settings-panel"]');
+          });
+        },
+        {
+          timeout: 3000,
+          interval: 100,
+          timeoutMsg: "Settings panel did not open",
+        }
+      );
+
+      console.log("Settings panel opened");
+    });
+
+    it("should show all three setting groups", async () => {
+      const themeGroup = await $('[data-testid="settings-theme-group"]');
+      expect(await themeGroup.isExisting()).toBe(true);
+
+      const runtimeGroup = await $('[data-testid="settings-runtime-group"]');
+      expect(await runtimeGroup.isExisting()).toBe(true);
+
+      const pythonEnvGroup = await $(
+        '[data-testid="settings-python-env-group"]'
+      );
+      expect(await pythonEnvGroup.isExisting()).toBe(true);
+
+      console.log("All three setting groups visible");
+    });
+
+    it("should close settings panel when clicking gear again", async () => {
+      const gearButton = await $('[aria-label="Settings"]');
+      await gearButton.click();
+
+      // Wait for panel to unmount from DOM
+      await browser.waitUntil(
+        async () => {
+          return await browser.execute(() => {
+            return !document.querySelector('[data-testid="settings-panel"]');
+          });
+        },
+        {
+          timeout: 3000,
+          interval: 100,
+          timeoutMsg: "Settings panel did not close",
+        }
+      );
+
+      console.log("Settings panel closed");
+    });
+  });
+
+  describe("Theme switching", () => {
+    before(async () => {
+      // Ensure panel is open for theme tests
+      const panelExists = await browser.execute(() => {
+        return !!document.querySelector('[data-testid="settings-panel"]');
+      });
+      if (!panelExists) {
+        const gearButton = await $('[aria-label="Settings"]');
+        await gearButton.click();
+        await browser.waitUntil(
+          async () => {
+            return await browser.execute(() => {
+              return !!document.querySelector(
+                '[data-testid="settings-panel"]'
+              );
+            });
+          },
+          { timeout: 3000, interval: 100 }
+        );
+      }
+    });
+
+    it("should apply 'dark' class to <html> when clicking Dark", async () => {
+      // Find and click the Dark button within the theme group
+      const darkButton = await browser.execute(() => {
+        const group = document.querySelector(
+          '[data-testid="settings-theme-group"]'
+        );
+        const buttons = group?.querySelectorAll("button");
+        for (const btn of buttons || []) {
+          if (btn.textContent?.includes("Dark")) {
+            btn.click();
+            return true;
+          }
+        }
+        return false;
+      });
+      expect(darkButton).toBe(true);
+
+      // Wait for DOM class to update
+      await browser.waitUntil(
+        async () => {
+          return await browser.execute(() => {
+            return document.documentElement.classList.contains("dark");
+          });
+        },
+        {
+          timeout: 2000,
+          interval: 100,
+          timeoutMsg: "<html> did not get 'dark' class",
+        }
+      );
+
+      // Verify "light" is removed
+      const hasLight = await browser.execute(() => {
+        return document.documentElement.classList.contains("light");
+      });
+      expect(hasLight).toBe(false);
+
+      console.log("Dark theme applied to <html>");
+    });
+
+    it("should apply 'light' class to <html> when clicking Light", async () => {
+      const lightButton = await browser.execute(() => {
+        const group = document.querySelector(
+          '[data-testid="settings-theme-group"]'
+        );
+        const buttons = group?.querySelectorAll("button");
+        for (const btn of buttons || []) {
+          if (btn.textContent?.includes("Light")) {
+            btn.click();
+            return true;
+          }
+        }
+        return false;
+      });
+      expect(lightButton).toBe(true);
+
+      await browser.waitUntil(
+        async () => {
+          return await browser.execute(() => {
+            return document.documentElement.classList.contains("light");
+          });
+        },
+        {
+          timeout: 2000,
+          interval: 100,
+          timeoutMsg: "<html> did not get 'light' class",
+        }
+      );
+
+      const hasDark = await browser.execute(() => {
+        return document.documentElement.classList.contains("dark");
+      });
+      expect(hasDark).toBe(false);
+
+      console.log("Light theme applied to <html>");
+    });
+  });
+
+  describe("Active button states", () => {
+    it("should highlight the active theme button", async () => {
+      // After the previous test, "Light" should be the active theme
+      const activeClass = await browser.execute(() => {
+        const group = document.querySelector(
+          '[data-testid="settings-theme-group"]'
+        );
+        const buttons = group?.querySelectorAll("button");
+        for (const btn of buttons || []) {
+          if (btn.textContent?.includes("Light")) {
+            return btn.className;
+          }
+        }
+        return "";
+      });
+
+      expect(activeClass).toContain("bg-background");
+      expect(activeClass).toContain("shadow-sm");
+      console.log("Active theme button has correct styling");
+    });
+
+    it("should update active state when switching theme", async () => {
+      // Click Dark
+      await browser.execute(() => {
+        const group = document.querySelector(
+          '[data-testid="settings-theme-group"]'
+        );
+        const buttons = group?.querySelectorAll("button");
+        for (const btn of buttons || []) {
+          if (btn.textContent?.includes("Dark")) {
+            btn.click();
+            break;
+          }
+        }
+      });
+
+      // Wait for React re-render
+      await browser.waitUntil(
+        async () => {
+          return await browser.execute(() => {
+            return document.documentElement.classList.contains("dark");
+          });
+        },
+        { timeout: 2000, interval: 100 }
+      );
+
+      // Dark button should now be active
+      const darkClass = await browser.execute(() => {
+        const group = document.querySelector(
+          '[data-testid="settings-theme-group"]'
+        );
+        const buttons = group?.querySelectorAll("button");
+        for (const btn of buttons || []) {
+          if (btn.textContent?.includes("Dark")) return btn.className;
+        }
+        return "";
+      });
+      expect(darkClass).toContain("shadow-sm");
+
+      // Light button should now be inactive
+      const lightClass = await browser.execute(() => {
+        const group = document.querySelector(
+          '[data-testid="settings-theme-group"]'
+        );
+        const buttons = group?.querySelectorAll("button");
+        for (const btn of buttons || []) {
+          if (btn.textContent?.includes("Light")) return btn.className;
+        }
+        return "";
+      });
+      expect(lightClass).not.toContain("shadow-sm");
+
+      console.log("Active button state switches correctly");
+    });
+
+    it("should show default runtime and python env selections", async () => {
+      // Verify at least one runtime button is active (don't assert which — daemon may set it)
+      const hasActiveRuntime = await browser.execute(() => {
+        const group = document.querySelector(
+          '[data-testid="settings-runtime-group"]'
+        );
+        const buttons = group?.querySelectorAll("button");
+        return Array.from(buttons || []).some((btn) =>
+          btn.className.includes("shadow-sm")
+        );
+      });
+      expect(hasActiveRuntime).toBe(true);
+
+      // Verify at least one python env button is active
+      const hasActivePythonEnv = await browser.execute(() => {
+        const group = document.querySelector(
+          '[data-testid="settings-python-env-group"]'
+        );
+        const buttons = group?.querySelectorAll("button");
+        return Array.from(buttons || []).some((btn) =>
+          btn.className.includes("shadow-sm")
+        );
+      });
+      expect(hasActivePythonEnv).toBe(true);
+
+      console.log("Runtime and Python env groups have active selections");
+    });
+  });
+});

--- a/e2e/wdio.conf.js
+++ b/e2e/wdio.conf.js
@@ -40,6 +40,7 @@ const FIXTURE_SPECS = [
   "trust-decline.spec.js",
   "run-all-cells.spec.js",
   "iframe-isolation.spec.js",
+  "settings-panel.spec.js",
 ];
 
 export const config = {


### PR DESCRIPTION
## Summary
- Adds E2E fixture test for the settings panel (`settings-panel.spec.js`, 8 test cases)
- Tests panel toggle, theme switching (Dark/Light DOM class changes), and active button state management
- Daemon-independent: tests only observable DOM effects, never asserts on initial state (which may be overridden by runtimed), so the test passes identically whether or not the daemon is running
- Adds 4 `data-testid` attributes to `NotebookToolbar.tsx` for settings panel selectors: `settings-panel`, `settings-theme-group`, `settings-runtime-group`, `settings-python-env-group`
- Reuses existing `1-vanilla.ipynb` fixture (no new notebook needed — testing toolbar UI, not cell output)