### PR TITLE
Add synced default_uv_packages and default_conda_packages

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -67,7 +67,7 @@ function AppContent() {
   } = useNotebook();
 
   const { theme, setTheme } = useSyncedTheme();
-  const { defaultRuntime, setDefaultRuntime, defaultPythonEnv, setDefaultPythonEnv } = useSyncedSettings();
+  const { defaultRuntime, setDefaultRuntime, defaultPythonEnv, setDefaultPythonEnv, defaultUvPackages, setDefaultUvPackages, defaultCondaPackages, setDefaultCondaPackages } = useSyncedSettings();
 
   // Execution queue - cells are queued and executed in FIFO order by the backend
   const { queueCell, runAllCells, queuedCellIds: executingCellIds } = useExecutionQueue();
@@ -517,6 +517,10 @@ function AppContent() {
         onDefaultRuntimeChange={setDefaultRuntime}
         defaultPythonEnv={defaultPythonEnv}
         onDefaultPythonEnvChange={setDefaultPythonEnv}
+        defaultUvPackages={defaultUvPackages}
+        onDefaultUvPackagesChange={setDefaultUvPackages}
+        defaultCondaPackages={defaultCondaPackages}
+        onDefaultCondaPackagesChange={setDefaultCondaPackages}
         onSave={save}
         onStartKernel={handleStartKernel}
         onInterruptKernel={interruptKernel}

--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -568,7 +568,7 @@ export function NotebookToolbar({
                     Python Defaults
                   </span>
                   <p className="text-[11px] text-muted-foreground/70 mt-0.5">
-                    Applied to new notebooks without project dependencies
+                    Applied to new notebooks without project-based dependencies
                   </p>
                 </div>
                 <div className="grid gap-2" style={{ gridTemplateColumns: "auto 1fr" }}>

--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -490,7 +490,8 @@ export function NotebookToolbar({
 
         {/* Collapsible settings panel */}
         <CollapsibleContent>
-          <div className="border-t bg-background px-4 py-3" data-testid="settings-panel">
+          <div className="border-t bg-background px-4 py-3 space-y-3" data-testid="settings-panel">
+            {/* Global settings */}
             <div className="flex flex-wrap items-center gap-x-6 gap-y-2">
               {/* Theme */}
               <div className="flex items-center gap-3">
@@ -557,95 +558,108 @@ export function NotebookToolbar({
                   </div>
                 </div>
               )}
-
-              {/* Default Python Environment */}
-              {onDefaultPythonEnvChange && (
-                <div className="flex items-center gap-3">
-                  <span className="text-xs font-medium text-muted-foreground">
-                    Default Python Env
-                  </span>
-                  <div className="flex items-center gap-1 rounded-md border bg-muted/50 p-0.5" data-testid="settings-python-env-group">
-                    <button
-                      type="button"
-                      onClick={() => onDefaultPythonEnvChange("uv")}
-                      className={cn(
-                        "flex items-center gap-1.5 rounded-sm px-2.5 py-1 text-xs transition-colors",
-                        defaultPythonEnv === "uv"
-                          ? "bg-background text-foreground shadow-sm"
-                          : "text-muted-foreground hover:text-foreground"
-                      )}
-                    >
-                      <UvIcon className="h-3 w-3" />
-                      uv
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => onDefaultPythonEnvChange("conda")}
-                      className={cn(
-                        "flex items-center gap-1.5 rounded-sm px-2.5 py-1 text-xs transition-colors",
-                        defaultPythonEnv === "conda"
-                          ? "bg-background text-foreground shadow-sm"
-                          : "text-muted-foreground hover:text-foreground"
-                      )}
-                    >
-                      <CondaIcon className="h-3 w-3" />
-                      Conda
-                    </button>
-                  </div>
-                </div>
-              )}
             </div>
-            {/* Default Packages — separate inputs for uv and conda */}
-            {onDefaultUvPackagesChange && (
-              <div className="flex items-center gap-3 mt-2">
-                <span className="text-xs font-medium text-muted-foreground whitespace-nowrap">
-                  Default uv Packages
+
+            {/* Python settings */}
+            {(onDefaultPythonEnvChange || onDefaultUvPackagesChange || onDefaultCondaPackagesChange) && (
+              <div className="space-y-2">
+                <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+                  Python
                 </span>
-                <input
-                  type="text"
-                  defaultValue={defaultUvPackages}
-                  placeholder="numpy, pandas, scikit-learn"
-                  autoComplete="off"
-                  autoCorrect="off"
-                  autoCapitalize="off"
-                  spellCheck={false}
-                  onBlur={(e) =>
-                    onDefaultUvPackagesChange(e.target.value)
-                  }
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter") {
-                      onDefaultUvPackagesChange(e.currentTarget.value);
-                      e.currentTarget.blur();
-                    }
-                  }}
-                  className="h-7 flex-1 max-w-md rounded-md border bg-muted/50 px-2 text-xs text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
-                />
-              </div>
-            )}
-            {onDefaultCondaPackagesChange && (
-              <div className="flex items-center gap-3 mt-1">
-                <span className="text-xs font-medium text-muted-foreground whitespace-nowrap">
-                  Default Conda Packages
-                </span>
-                <input
-                  type="text"
-                  defaultValue={defaultCondaPackages}
-                  placeholder="numpy, pandas, scikit-learn"
-                  autoComplete="off"
-                  autoCorrect="off"
-                  autoCapitalize="off"
-                  spellCheck={false}
-                  onBlur={(e) =>
-                    onDefaultCondaPackagesChange(e.target.value)
-                  }
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter") {
-                      onDefaultCondaPackagesChange(e.currentTarget.value);
-                      e.currentTarget.blur();
-                    }
-                  }}
-                  className="h-7 flex-1 max-w-md rounded-md border bg-muted/50 px-2 text-xs text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
-                />
+                <div className="grid gap-2" style={{ gridTemplateColumns: "auto 1fr" }}>
+                  {/* Default Python Env */}
+                  {onDefaultPythonEnvChange && (
+                    <>
+                      <span className="text-xs font-medium text-muted-foreground whitespace-nowrap self-center text-right">
+                        Environment
+                      </span>
+                      <div className="flex items-center gap-1 rounded-md border bg-muted/50 p-0.5 w-fit" data-testid="settings-python-env-group">
+                        <button
+                          type="button"
+                          onClick={() => onDefaultPythonEnvChange("uv")}
+                          className={cn(
+                            "flex items-center gap-1.5 rounded-sm px-2.5 py-1 text-xs transition-colors",
+                            defaultPythonEnv === "uv"
+                              ? "bg-background text-foreground shadow-sm"
+                              : "text-muted-foreground hover:text-foreground"
+                          )}
+                        >
+                          <UvIcon className="h-3 w-3" />
+                          uv
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => onDefaultPythonEnvChange("conda")}
+                          className={cn(
+                            "flex items-center gap-1.5 rounded-sm px-2.5 py-1 text-xs transition-colors",
+                            defaultPythonEnv === "conda"
+                              ? "bg-background text-foreground shadow-sm"
+                              : "text-muted-foreground hover:text-foreground"
+                          )}
+                        >
+                          <CondaIcon className="h-3 w-3" />
+                          Conda
+                        </button>
+                      </div>
+                    </>
+                  )}
+
+                  {/* Default uv Packages */}
+                  {onDefaultUvPackagesChange && (
+                    <>
+                      <span className="text-xs font-medium text-muted-foreground whitespace-nowrap self-center text-right">
+                        uv Packages
+                      </span>
+                      <input
+                        type="text"
+                        defaultValue={defaultUvPackages}
+                        placeholder="numpy, pandas, scikit-learn"
+                        autoComplete="off"
+                        autoCorrect="off"
+                        autoCapitalize="off"
+                        spellCheck={false}
+                        onBlur={(e) =>
+                          onDefaultUvPackagesChange(e.target.value)
+                        }
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter") {
+                            onDefaultUvPackagesChange(e.currentTarget.value);
+                            e.currentTarget.blur();
+                          }
+                        }}
+                        className="h-7 max-w-md rounded-md border bg-muted/50 px-2 text-xs text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+                      />
+                    </>
+                  )}
+
+                  {/* Default Conda Packages */}
+                  {onDefaultCondaPackagesChange && (
+                    <>
+                      <span className="text-xs font-medium text-muted-foreground whitespace-nowrap self-center text-right">
+                        Conda Packages
+                      </span>
+                      <input
+                        type="text"
+                        defaultValue={defaultCondaPackages}
+                        placeholder="numpy, pandas, scikit-learn"
+                        autoComplete="off"
+                        autoCorrect="off"
+                        autoCapitalize="off"
+                        spellCheck={false}
+                        onBlur={(e) =>
+                          onDefaultCondaPackagesChange(e.target.value)
+                        }
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter") {
+                            onDefaultCondaPackagesChange(e.currentTarget.value);
+                            e.currentTarget.blur();
+                          }
+                        }}
+                        className="h-7 max-w-md rounded-md border bg-muted/50 px-2 text-xs text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+                      />
+                    </>
+                  )}
+                </div>
               </div>
             )}
           </div>

--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -535,7 +535,7 @@ export function NotebookToolbar({
                       className={cn(
                         "flex items-center gap-1.5 rounded-sm px-2.5 py-1 text-xs transition-colors",
                         defaultRuntime === "python"
-                          ? "bg-background text-foreground shadow-sm"
+                          ? "bg-blue-500/15 text-blue-600 dark:text-blue-400 shadow-sm"
                           : "text-muted-foreground hover:text-foreground"
                       )}
                     >
@@ -548,7 +548,7 @@ export function NotebookToolbar({
                       className={cn(
                         "flex items-center gap-1.5 rounded-sm px-2.5 py-1 text-xs transition-colors",
                         defaultRuntime === "deno"
-                          ? "bg-background text-foreground shadow-sm"
+                          ? "bg-teal-500/15 text-teal-600 dark:text-teal-400 shadow-sm"
                           : "text-muted-foreground hover:text-foreground"
                       )}
                     >
@@ -564,7 +564,7 @@ export function NotebookToolbar({
             {(onDefaultPythonEnvChange || onDefaultUvPackagesChange || onDefaultCondaPackagesChange) && (
               <div className="space-y-2">
                 <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
-                  Python
+                  Python Defaults
                 </span>
                 <div className="grid gap-2" style={{ gridTemplateColumns: "auto 1fr" }}>
                   {/* Default Python Env */}
@@ -580,7 +580,7 @@ export function NotebookToolbar({
                           className={cn(
                             "flex items-center gap-1.5 rounded-sm px-2.5 py-1 text-xs transition-colors",
                             defaultPythonEnv === "uv"
-                              ? "bg-background text-foreground shadow-sm"
+                              ? "bg-fuchsia-500/15 text-fuchsia-600 dark:text-fuchsia-400 shadow-sm"
                               : "text-muted-foreground hover:text-foreground"
                           )}
                         >
@@ -593,7 +593,7 @@ export function NotebookToolbar({
                           className={cn(
                             "flex items-center gap-1.5 rounded-sm px-2.5 py-1 text-xs transition-colors",
                             defaultPythonEnv === "conda"
-                              ? "bg-background text-foreground shadow-sm"
+                              ? "bg-emerald-500/15 text-emerald-600 dark:text-emerald-400 shadow-sm"
                               : "text-muted-foreground hover:text-foreground"
                           )}
                         >

--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -164,6 +164,10 @@ interface NotebookToolbarProps {
   onDefaultRuntimeChange?: (runtime: RuntimeMode) => void;
   defaultPythonEnv?: PythonEnvMode;
   onDefaultPythonEnvChange?: (env: PythonEnvMode) => void;
+  defaultUvPackages?: string;
+  onDefaultUvPackagesChange?: (packages: string) => void;
+  defaultCondaPackages?: string;
+  onDefaultCondaPackagesChange?: (packages: string) => void;
   onSave: () => void;
   onStartKernel: (name: string) => void;
   onInterruptKernel: () => void;
@@ -196,6 +200,10 @@ export function NotebookToolbar({
   onDefaultRuntimeChange,
   defaultPythonEnv = "uv",
   onDefaultPythonEnvChange,
+  defaultUvPackages = "",
+  onDefaultUvPackagesChange,
+  defaultCondaPackages = "",
+  onDefaultCondaPackagesChange,
   onSave,
   onStartKernel,
   onInterruptKernel,
@@ -587,6 +595,59 @@ export function NotebookToolbar({
                 </div>
               )}
             </div>
+            {/* Default Packages — separate inputs for uv and conda */}
+            {onDefaultUvPackagesChange && (
+              <div className="flex items-center gap-3 mt-2">
+                <span className="text-xs font-medium text-muted-foreground whitespace-nowrap">
+                  Default uv Packages
+                </span>
+                <input
+                  type="text"
+                  defaultValue={defaultUvPackages}
+                  placeholder="numpy, pandas, scikit-learn"
+                  autoComplete="off"
+                  autoCorrect="off"
+                  autoCapitalize="off"
+                  spellCheck={false}
+                  onBlur={(e) =>
+                    onDefaultUvPackagesChange(e.target.value)
+                  }
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      onDefaultUvPackagesChange(e.currentTarget.value);
+                      e.currentTarget.blur();
+                    }
+                  }}
+                  className="h-7 flex-1 max-w-md rounded-md border bg-muted/50 px-2 text-xs text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+                />
+              </div>
+            )}
+            {onDefaultCondaPackagesChange && (
+              <div className="flex items-center gap-3 mt-1">
+                <span className="text-xs font-medium text-muted-foreground whitespace-nowrap">
+                  Default Conda Packages
+                </span>
+                <input
+                  type="text"
+                  defaultValue={defaultCondaPackages}
+                  placeholder="numpy, pandas, scikit-learn"
+                  autoComplete="off"
+                  autoCorrect="off"
+                  autoCapitalize="off"
+                  spellCheck={false}
+                  onBlur={(e) =>
+                    onDefaultCondaPackagesChange(e.target.value)
+                  }
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      onDefaultCondaPackagesChange(e.currentTarget.value);
+                      e.currentTarget.blur();
+                    }
+                  }}
+                  className="h-7 flex-1 max-w-md rounded-md border bg-muted/50 px-2 text-xs text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+                />
+              </div>
+            )}
           </div>
         </CollapsibleContent>
       </header>

--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -563,9 +563,14 @@ export function NotebookToolbar({
             {/* Python settings */}
             {(onDefaultPythonEnvChange || onDefaultUvPackagesChange || onDefaultCondaPackagesChange) && (
               <div className="space-y-2">
-                <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
-                  Python Defaults
-                </span>
+                <div>
+                  <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+                    Python Defaults
+                  </span>
+                  <p className="text-[11px] text-muted-foreground/70 mt-0.5">
+                    Applied to new notebooks without project dependencies
+                  </p>
+                </div>
                 <div className="grid gap-2" style={{ gridTemplateColumns: "auto 1fr" }}>
                   {/* Default Python Env */}
                   {onDefaultPythonEnvChange && (

--- a/crates/notebook/src/conda_env.rs
+++ b/crates/notebook/src/conda_env.rs
@@ -912,12 +912,7 @@ pub async fn create_prewarmed_conda_environment(
 
     // Build dependency list: ipykernel + ipywidgets + user-configured defaults
     let mut deps_list = vec!["ipykernel".to_string(), "ipywidgets".to_string()];
-    let extra: Vec<String> = crate::settings::load_settings()
-        .default_conda_packages
-        .split(',')
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
-        .collect();
+    let extra: Vec<String> = crate::settings::load_settings().default_conda_packages;
     if !extra.is_empty() {
         info!("[prewarm] Including default packages: {:?}", extra);
         deps_list.extend(extra);

--- a/crates/notebook/src/settings.rs
+++ b/crates/notebook/src/settings.rs
@@ -40,6 +40,14 @@ pub struct AppSettings {
     /// Default Python environment type (uv or conda)
     #[serde(default)]
     pub default_python_env: PythonEnvType,
+
+    /// Default packages for prewarmed uv environments (comma-separated)
+    #[serde(default)]
+    pub default_uv_packages: String,
+
+    /// Default packages for prewarmed conda environments (comma-separated)
+    #[serde(default)]
+    pub default_conda_packages: String,
 }
 
 impl Default for AppSettings {
@@ -47,6 +55,8 @@ impl Default for AppSettings {
         Self {
             default_runtime: Runtime::Python,
             default_python_env: PythonEnvType::Uv,
+            default_uv_packages: String::new(),
+            default_conda_packages: String::new(),
         }
     }
 }
@@ -98,6 +108,8 @@ mod tests {
         let settings = AppSettings {
             default_runtime: Runtime::Deno,
             default_python_env: PythonEnvType::Uv,
+            default_uv_packages: String::new(),
+            default_conda_packages: String::new(),
         };
 
         let json = serde_json::to_string(&settings).unwrap();

--- a/crates/notebook/src/settings.rs
+++ b/crates/notebook/src/settings.rs
@@ -7,7 +7,7 @@
 
 use crate::runtime::Runtime;
 use anyhow::Result;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use std::path::PathBuf;
 
 /// Python environment type for dependency management
@@ -41,13 +41,56 @@ pub struct AppSettings {
     #[serde(default)]
     pub default_python_env: PythonEnvType,
 
-    /// Default packages for prewarmed uv environments (comma-separated)
-    #[serde(default)]
-    pub default_uv_packages: String,
+    /// Default packages for prewarmed uv environments
+    #[serde(default, deserialize_with = "deserialize_package_list")]
+    pub default_uv_packages: Vec<String>,
 
-    /// Default packages for prewarmed conda environments (comma-separated)
-    #[serde(default)]
-    pub default_conda_packages: String,
+    /// Default packages for prewarmed conda environments
+    #[serde(default, deserialize_with = "deserialize_package_list")]
+    pub default_conda_packages: Vec<String>,
+}
+
+/// Deserialize a package list that accepts both:
+/// - Old format: `"numpy, pandas, matplotlib"` (comma-separated string)
+/// - New format: `["numpy", "pandas", "matplotlib"]` (JSON array)
+fn deserialize_package_list<'de, D>(deserializer: D) -> std::result::Result<Vec<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    use serde::de;
+
+    struct PackageListVisitor;
+
+    impl<'de> de::Visitor<'de> for PackageListVisitor {
+        type Value = Vec<String>;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("a string or array of strings")
+        }
+
+        fn visit_str<E: de::Error>(self, v: &str) -> std::result::Result<Vec<String>, E> {
+            Ok(v.split(',')
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect())
+        }
+
+        fn visit_seq<A: de::SeqAccess<'de>>(
+            self,
+            mut seq: A,
+        ) -> std::result::Result<Vec<String>, A::Error> {
+            let mut items = Vec::new();
+            while let Some(item) = seq.next_element::<String>()? {
+                let trimmed = item.trim().to_string();
+                if !trimmed.is_empty() {
+                    items.push(trimmed);
+                }
+            }
+            Ok(items)
+        }
+    }
+
+    deserializer.deserialize_any(PackageListVisitor)
 }
 
 impl Default for AppSettings {
@@ -55,8 +98,8 @@ impl Default for AppSettings {
         Self {
             default_runtime: Runtime::Python,
             default_python_env: PythonEnvType::Uv,
-            default_uv_packages: String::new(),
-            default_conda_packages: String::new(),
+            default_uv_packages: vec![],
+            default_conda_packages: vec![],
         }
     }
 }
@@ -101,6 +144,8 @@ mod tests {
         let settings = AppSettings::default();
         assert_eq!(settings.default_runtime, Runtime::Python);
         assert_eq!(settings.default_python_env, PythonEnvType::Uv);
+        assert!(settings.default_uv_packages.is_empty());
+        assert!(settings.default_conda_packages.is_empty());
     }
 
     #[test]
@@ -108,8 +153,8 @@ mod tests {
         let settings = AppSettings {
             default_runtime: Runtime::Deno,
             default_python_env: PythonEnvType::Uv,
-            default_uv_packages: String::new(),
-            default_conda_packages: String::new(),
+            default_uv_packages: vec!["numpy".into(), "pandas".into()],
+            default_conda_packages: vec![],
         };
 
         let json = serde_json::to_string(&settings).unwrap();
@@ -117,18 +162,57 @@ mod tests {
 
         assert_eq!(parsed.default_runtime, Runtime::Deno);
         assert_eq!(parsed.default_python_env, PythonEnvType::Uv);
+        assert_eq!(parsed.default_uv_packages, vec!["numpy", "pandas"]);
+    }
+
+    #[test]
+    fn test_deserialize_old_comma_format() {
+        let json = r#"{
+            "default_runtime": "python",
+            "default_python_env": "uv",
+            "default_uv_packages": "numpy, pandas, matplotlib",
+            "default_conda_packages": "scipy"
+        }"#;
+        let parsed: AppSettings = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            parsed.default_uv_packages,
+            vec!["numpy", "pandas", "matplotlib"]
+        );
+        assert_eq!(parsed.default_conda_packages, vec!["scipy"]);
+    }
+
+    #[test]
+    fn test_deserialize_new_array_format() {
+        let json = r#"{
+            "default_runtime": "python",
+            "default_python_env": "uv",
+            "default_uv_packages": ["numpy", "pandas"],
+            "default_conda_packages": ["scipy", "scikit-learn"]
+        }"#;
+        let parsed: AppSettings = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.default_uv_packages, vec!["numpy", "pandas"]);
+        assert_eq!(
+            parsed.default_conda_packages,
+            vec!["scipy", "scikit-learn"]
+        );
+    }
+
+    #[test]
+    fn test_deserialize_missing_packages() {
+        let json = r#"{"default_runtime": "python"}"#;
+        let parsed: AppSettings = serde_json::from_str(json).unwrap();
+        assert!(parsed.default_uv_packages.is_empty());
+        assert!(parsed.default_conda_packages.is_empty());
     }
 
     #[test]
     fn test_python_env_type_serde() {
-        // Test that the enum serializes to lowercase strings
         let uv = PythonEnvType::Uv;
         let conda = PythonEnvType::Conda;
 
         assert_eq!(serde_json::to_string(&uv).unwrap(), "\"uv\"");
         assert_eq!(serde_json::to_string(&conda).unwrap(), "\"conda\"");
 
-        // Test deserialization
         let parsed_uv: PythonEnvType = serde_json::from_str("\"uv\"").unwrap();
         let parsed_conda: PythonEnvType = serde_json::from_str("\"conda\"").unwrap();
 
@@ -139,7 +223,6 @@ mod tests {
     #[test]
     fn test_settings_path_is_valid() {
         let path = settings_path();
-        // Should end with the expected path components
         assert!(path.ends_with("runt-notebook/settings.json"));
     }
 }

--- a/crates/notebook/src/uv_env.rs
+++ b/crates/notebook/src/uv_env.rs
@@ -386,17 +386,9 @@ pub async fn find_existing_prewarmed_environments() -> Vec<UvEnvironment> {
     found
 }
 
-/// Parse the `default_uv_packages` setting into individual package names.
-///
-/// Splits on commas, trims whitespace, and filters out empty entries.
+/// Read the `default_uv_packages` setting.
 fn parse_extra_packages() -> Vec<String> {
-    let settings = crate::settings::load_settings();
-    settings
-        .default_uv_packages
-        .split(',')
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
-        .collect()
+    crate::settings::load_settings().default_uv_packages
 }
 
 /// Create a prewarmed environment with ipykernel, ipywidgets, and any

--- a/crates/notebook/src/uv_env.rs
+++ b/crates/notebook/src/uv_env.rs
@@ -386,7 +386,21 @@ pub async fn find_existing_prewarmed_environments() -> Vec<UvEnvironment> {
     found
 }
 
-/// Create a prewarmed environment with just ipykernel installed.
+/// Parse the `default_uv_packages` setting into individual package names.
+///
+/// Splits on commas, trims whitespace, and filters out empty entries.
+fn parse_extra_packages() -> Vec<String> {
+    let settings = crate::settings::load_settings();
+    settings
+        .default_uv_packages
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
+/// Create a prewarmed environment with ipykernel, ipywidgets, and any
+/// user-configured default packages installed.
 ///
 /// This creates an environment at a temporary path (prewarm-{uuid}) that can
 /// later be claimed by a notebook using `claim_prewarmed_environment`.
@@ -423,16 +437,22 @@ pub async fn create_prewarmed_environment() -> Result<UvEnvironment> {
         return Err(anyhow!("Failed to create prewarmed virtual environment"));
     }
 
-    // Install ipykernel and ipywidgets (no other dependencies)
+    // Install ipykernel, ipywidgets, and any user-configured default packages
+    let extra = parse_extra_packages();
+    let mut install_args = vec![
+        "pip".to_string(),
+        "install".to_string(),
+        "--python".to_string(),
+        python_path.to_string_lossy().to_string(),
+        "ipykernel".to_string(),
+        "ipywidgets".to_string(),
+    ];
+    if !extra.is_empty() {
+        info!("[prewarm] Including default packages: {:?}", extra);
+        install_args.extend(extra);
+    }
     let install_status = tokio::process::Command::new(&uv_path)
-        .args([
-            "pip",
-            "install",
-            "--python",
-            &python_path.to_string_lossy(),
-            "ipykernel",
-            "ipywidgets",
-        ])
+        .args(&install_args)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .status()

--- a/crates/runtimed/src/client.rs
+++ b/crates/runtimed/src/client.rs
@@ -120,6 +120,16 @@ impl PoolClient {
         }
     }
 
+    /// Flush all pooled environments and trigger rebuild with current settings.
+    pub async fn flush_pool(&self) -> Result<(), ClientError> {
+        let response = self.send_request(Request::FlushPool).await?;
+        match response {
+            Response::Flushed => Ok(()),
+            Response::Error { message } => Err(ClientError::DaemonError(message)),
+            _ => Err(ClientError::ProtocolError("Unexpected response".to_string())),
+        }
+    }
+
     /// Request daemon shutdown.
     pub async fn shutdown(&self) -> Result<(), ClientError> {
         let response = self.send_request(Request::Shutdown).await?;

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -733,12 +733,7 @@ impl Daemon {
         let extra_conda_packages: Vec<String> = {
             let settings = self.settings.read().await;
             let synced = settings.get_all();
-            synced
-                .default_conda_packages
-                .split(',')
-                .map(|s| s.trim().to_string())
-                .filter(|s| !s.is_empty())
-                .collect()
+            synced.conda.default_packages
         };
 
         if !extra_conda_packages.is_empty() {
@@ -1027,12 +1022,7 @@ print("warmup complete")
         {
             let settings = self.settings.read().await;
             let synced = settings.get_all();
-            let extra: Vec<String> = synced
-                .default_uv_packages
-                .split(',')
-                .map(|s| s.trim().to_string())
-                .filter(|s| !s.is_empty())
-                .collect();
+            let extra = synced.uv.default_packages;
             if !extra.is_empty() {
                 info!("[runtimed] Including default uv packages: {:?}", extra);
                 install_packages.extend(extra);

--- a/crates/runtimed/src/protocol.rs
+++ b/crates/runtimed/src/protocol.rs
@@ -25,6 +25,9 @@ pub enum Request {
 
     /// Request daemon shutdown (for clean termination).
     Shutdown,
+
+    /// Flush all pooled environments and rebuild with current settings.
+    FlushPool,
 }
 
 /// Responses from the daemon to clients.
@@ -48,6 +51,9 @@ pub enum Response {
 
     /// Shutdown acknowledged.
     ShuttingDown,
+
+    /// Pool flush acknowledged — environments will be rebuilt.
+    Flushed,
 
     /// An error occurred.
     Error { message: String },
@@ -249,6 +255,26 @@ mod tests {
 
         let parsed = Response::from_line(&line).unwrap();
         assert!(matches!(parsed, Response::ShuttingDown));
+    }
+
+    #[test]
+    fn test_request_flush_pool() {
+        let req = Request::FlushPool;
+        let line = req.to_line().unwrap();
+        assert!(line.contains("flush_pool"));
+
+        let parsed = Request::from_line(&line).unwrap();
+        assert!(matches!(parsed, Request::FlushPool));
+    }
+
+    #[test]
+    fn test_response_flushed() {
+        let resp = Response::Flushed;
+        let line = resp.to_line().unwrap();
+        assert!(line.contains("flushed"));
+
+        let parsed = Response::from_line(&line).unwrap();
+        assert!(matches!(parsed, Response::Flushed));
     }
 
     #[test]

--- a/crates/runtimed/src/settings_doc.rs
+++ b/crates/runtimed/src/settings_doc.rs
@@ -20,6 +20,8 @@ pub struct SyncedSettings {
     pub theme: String,
     pub default_runtime: String,
     pub default_python_env: String,
+    pub default_uv_packages: String,
+    pub default_conda_packages: String,
 }
 
 impl Default for SyncedSettings {
@@ -28,6 +30,8 @@ impl Default for SyncedSettings {
             theme: "system".to_string(),
             default_runtime: "python".to_string(),
             default_python_env: "uv".to_string(),
+            default_uv_packages: String::new(),
+            default_conda_packages: String::new(),
         }
     }
 }
@@ -51,6 +55,16 @@ impl SettingsDoc {
             automerge::ROOT,
             "default_python_env",
             defaults.default_python_env,
+        );
+        let _ = doc.put(
+            automerge::ROOT,
+            "default_uv_packages",
+            defaults.default_uv_packages,
+        );
+        let _ = doc.put(
+            automerge::ROOT,
+            "default_conda_packages",
+            defaults.default_conda_packages,
         );
         Self { doc }
     }
@@ -111,6 +125,18 @@ impl SettingsDoc {
             .and_then(|v| v.as_str())
         {
             settings.put("default_python_env", env);
+        }
+        if let Some(pkgs) = json
+            .get("default_uv_packages")
+            .and_then(|v| v.as_str())
+        {
+            settings.put("default_uv_packages", pkgs);
+        }
+        if let Some(pkgs) = json
+            .get("default_conda_packages")
+            .and_then(|v| v.as_str())
+        {
+            settings.put("default_conda_packages", pkgs);
         }
         // Theme was never in settings.json, so it stays at the default ("system").
 
@@ -177,6 +203,12 @@ impl SettingsDoc {
             default_python_env: self
                 .get("default_python_env")
                 .unwrap_or(defaults.default_python_env),
+            default_uv_packages: self
+                .get("default_uv_packages")
+                .unwrap_or(defaults.default_uv_packages),
+            default_conda_packages: self
+                .get("default_conda_packages")
+                .unwrap_or(defaults.default_conda_packages),
         }
     }
 

--- a/crates/runtimed/src/settings_doc.rs
+++ b/crates/runtimed/src/settings_doc.rs
@@ -4,15 +4,40 @@
 //! application settings. The daemon holds the canonical copy; each connected
 //! notebook window holds a local replica that syncs over the Automerge sync
 //! protocol.
+//!
+//! The document uses nested maps for environment-specific settings:
+//!
+//! ```text
+//! ROOT/
+//!   theme: "system"
+//!   default_runtime: "python"
+//!   default_python_env: "uv"
+//!   uv/                           ← nested Map
+//!     default_packages: List[…]   ← List of Str
+//!   conda/                        ← nested Map
+//!     default_packages: List[…]   ← List of Str
+//! ```
 
 use std::path::Path;
 
 use automerge::sync;
 use automerge::sync::SyncDoc;
 use automerge::transaction::Transactable;
-use automerge::{AutoCommit, AutomergeError, ReadDoc};
+use automerge::{AutoCommit, AutomergeError, ObjId, ObjType, ReadDoc};
 use log::info;
 use serde::{Deserialize, Serialize};
+
+/// Default packages for uv environments.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct UvDefaults {
+    pub default_packages: Vec<String>,
+}
+
+/// Default packages for conda environments.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CondaDefaults {
+    pub default_packages: Vec<String>,
+}
 
 /// Snapshot of all synced settings.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -20,8 +45,8 @@ pub struct SyncedSettings {
     pub theme: String,
     pub default_runtime: String,
     pub default_python_env: String,
-    pub default_uv_packages: String,
-    pub default_conda_packages: String,
+    pub uv: UvDefaults,
+    pub conda: CondaDefaults,
 }
 
 impl Default for SyncedSettings {
@@ -30,15 +55,16 @@ impl Default for SyncedSettings {
             theme: "system".to_string(),
             default_runtime: "python".to_string(),
             default_python_env: "uv".to_string(),
-            default_uv_packages: String::new(),
-            default_conda_packages: String::new(),
+            uv: UvDefaults::default(),
+            conda: CondaDefaults::default(),
         }
     }
 }
 
 /// Wrapper around an Automerge document storing application settings.
 ///
-/// The document is a flat map at the root with string keys and string values.
+/// The document uses a mix of root-level scalar strings and nested maps
+/// containing lists for environment-specific settings.
 pub struct SettingsDoc {
     doc: AutoCommit,
 }
@@ -48,7 +74,8 @@ impl SettingsDoc {
     pub fn new() -> Self {
         let mut doc = AutoCommit::new();
         let defaults = SyncedSettings::default();
-        // Ignore errors on initial setup — the doc is fresh.
+
+        // Root-level scalars
         let _ = doc.put(automerge::ROOT, "theme", defaults.theme);
         let _ = doc.put(automerge::ROOT, "default_runtime", defaults.default_runtime);
         let _ = doc.put(
@@ -56,16 +83,17 @@ impl SettingsDoc {
             "default_python_env",
             defaults.default_python_env,
         );
-        let _ = doc.put(
-            automerge::ROOT,
-            "default_uv_packages",
-            defaults.default_uv_packages,
-        );
-        let _ = doc.put(
-            automerge::ROOT,
-            "default_conda_packages",
-            defaults.default_conda_packages,
-        );
+
+        // Nested uv map with empty package list
+        if let Ok(uv_id) = doc.put_object(automerge::ROOT, "uv", ObjType::Map) {
+            let _ = doc.put_object(&uv_id, "default_packages", ObjType::List);
+        }
+
+        // Nested conda map with empty package list
+        if let Ok(conda_id) = doc.put_object(automerge::ROOT, "conda", ObjType::Map) {
+            let _ = doc.put_object(&conda_id, "default_packages", ObjType::List);
+        }
+
         Self { doc }
     }
 
@@ -74,19 +102,18 @@ impl SettingsDoc {
     ///
     /// If `settings_json_path` points to an existing `settings.json`, its values
     /// are migrated into the new Automerge document.
-    pub fn load_or_create(
-        automerge_path: &Path,
-        settings_json_path: Option<&Path>,
-    ) -> Self {
+    ///
+    /// Existing Automerge docs with old flat keys (`default_uv_packages`,
+    /// `default_conda_packages`) are migrated to the nested structure on load.
+    pub fn load_or_create(automerge_path: &Path, settings_json_path: Option<&Path>) -> Self {
         // Try loading existing Automerge document
         if automerge_path.exists() {
             if let Ok(data) = std::fs::read(automerge_path) {
                 if let Ok(doc) = AutoCommit::load(&data) {
-                    info!(
-                        "[settings] Loaded Automerge doc from {:?}",
-                        automerge_path
-                    );
-                    return Self { doc };
+                    info!("[settings] Loaded Automerge doc from {:?}", automerge_path);
+                    let mut settings = Self { doc };
+                    settings.migrate_flat_to_nested();
+                    return settings;
                 }
             }
         }
@@ -95,13 +122,8 @@ impl SettingsDoc {
         if let Some(json_path) = settings_json_path {
             if json_path.exists() {
                 if let Ok(contents) = std::fs::read_to_string(json_path) {
-                    if let Ok(json) =
-                        serde_json::from_str::<serde_json::Value>(&contents)
-                    {
-                        info!(
-                            "[settings] Migrating from {:?}",
-                            json_path
-                        );
+                    if let Ok(json) = serde_json::from_str::<serde_json::Value>(&contents) {
+                        info!("[settings] Migrating from {:?}", json_path);
                         return Self::from_json(&json);
                     }
                 }
@@ -114,33 +136,88 @@ impl SettingsDoc {
     }
 
     /// Create a settings document from parsed JSON (for migration from settings.json).
+    ///
+    /// Handles both old flat format (`default_uv_packages: "numpy, pandas"`)
+    /// and new nested format (`uv: { default_packages: ["numpy", "pandas"] }`).
     fn from_json(json: &serde_json::Value) -> Self {
         let mut settings = Self::new();
 
         if let Some(runtime) = json.get("default_runtime").and_then(|v| v.as_str()) {
             settings.put("default_runtime", runtime);
         }
-        if let Some(env) = json
-            .get("default_python_env")
-            .and_then(|v| v.as_str())
-        {
+        if let Some(env) = json.get("default_python_env").and_then(|v| v.as_str()) {
             settings.put("default_python_env", env);
         }
-        if let Some(pkgs) = json
-            .get("default_uv_packages")
-            .and_then(|v| v.as_str())
-        {
-            settings.put("default_uv_packages", pkgs);
-        }
-        if let Some(pkgs) = json
-            .get("default_conda_packages")
-            .and_then(|v| v.as_str())
-        {
-            settings.put("default_conda_packages", pkgs);
-        }
-        // Theme was never in settings.json, so it stays at the default ("system").
 
+        // Try new nested format first, then fall back to old flat format
+        let uv_packages = Self::extract_packages_from_json(json, "uv", "default_uv_packages");
+        if !uv_packages.is_empty() {
+            settings.put_list("uv.default_packages", &uv_packages);
+        }
+
+        let conda_packages =
+            Self::extract_packages_from_json(json, "conda", "default_conda_packages");
+        if !conda_packages.is_empty() {
+            settings.put_list("conda.default_packages", &conda_packages);
+        }
+
+        // Theme was never in settings.json, so it stays at the default ("system").
         settings
+    }
+
+    /// Extract packages from JSON, trying nested format then flat comma-separated.
+    fn extract_packages_from_json(
+        json: &serde_json::Value,
+        nested_key: &str,
+        flat_key: &str,
+    ) -> Vec<String> {
+        // Try nested: { "uv": { "default_packages": ["numpy", "pandas"] } }
+        if let Some(nested) = json.get(nested_key).and_then(|v| v.as_object()) {
+            if let Some(arr) = nested.get("default_packages").and_then(|v| v.as_array()) {
+                let pkgs: Vec<String> = arr
+                    .iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect();
+                if !pkgs.is_empty() {
+                    return pkgs;
+                }
+            }
+        }
+
+        // Fall back to flat: { "default_uv_packages": "numpy, pandas" }
+        if let Some(comma_str) = json.get(flat_key).and_then(|v| v.as_str()) {
+            return split_comma_list(comma_str);
+        }
+
+        vec![]
+    }
+
+    /// Migrate old flat keys to nested structure.
+    ///
+    /// Reads `default_uv_packages` and `default_conda_packages` from ROOT,
+    /// splits comma values, stores them as nested lists, and deletes the old keys.
+    fn migrate_flat_to_nested(&mut self) {
+        // Migrate default_uv_packages -> uv.default_packages
+        if let Some(val) = self.get_flat("default_uv_packages") {
+            let packages = split_comma_list(&val);
+            if !packages.is_empty() {
+                self.put_list("uv.default_packages", &packages);
+            }
+            let _ = self.doc.delete(automerge::ROOT, "default_uv_packages");
+            info!("[settings] Migrated default_uv_packages to uv.default_packages");
+        }
+
+        // Migrate default_conda_packages -> conda.default_packages
+        if let Some(val) = self.get_flat("default_conda_packages") {
+            let packages = split_comma_list(&val);
+            if !packages.is_empty() {
+                self.put_list("conda.default_packages", &packages);
+            }
+            let _ = self
+                .doc
+                .delete(automerge::ROOT, "default_conda_packages");
+            info!("[settings] Migrated default_conda_packages to conda.default_packages");
+        }
     }
 
     /// Load a settings document from raw bytes.
@@ -169,46 +246,177 @@ impl SettingsDoc {
             std::fs::create_dir_all(parent)?;
         }
         let settings = self.get_all();
-        let json = serde_json::to_string_pretty(&settings)
-            .map_err(std::io::Error::other)?;
+        let json = serde_json::to_string_pretty(&settings).map_err(std::io::Error::other)?;
         std::fs::write(path, json)
     }
 
-    /// Get a single setting value by key.
+    // ── Scalar accessors ─────────────────────────────────────────────
+
+    /// Read a scalar string from ROOT only (no dotted path support).
+    fn get_flat(&self, key: &str) -> Option<String> {
+        read_scalar_str(&self.doc, automerge::ROOT, key)
+    }
+
+    /// Get a scalar setting value, supporting dotted paths for nested maps.
+    ///
+    /// E.g. `"theme"` reads from ROOT, `"uv.some_key"` reads from the `uv` sub-map.
     pub fn get(&self, key: &str) -> Option<String> {
+        if let Some((map_key, sub_key)) = key.split_once('.') {
+            let map_id = self.get_map_id(map_key)?;
+            read_scalar_str(&self.doc, map_id, sub_key)
+        } else {
+            self.get_flat(key)
+        }
+    }
+
+    /// Set a scalar setting value, supporting dotted paths for nested maps.
+    pub fn put(&mut self, key: &str, value: &str) {
+        if let Some((map_key, sub_key)) = key.split_once('.') {
+            let map_id = self.ensure_map(map_key);
+            let _ = self.doc.put(&map_id, sub_key, value);
+        } else {
+            let _ = self.doc.put(automerge::ROOT, key, value);
+        }
+    }
+
+    // ── List accessors ───────────────────────────────────────────────
+
+    /// Read a list of strings at a dotted path (e.g. `"uv.default_packages"`).
+    pub fn get_list(&self, key: &str) -> Vec<String> {
+        let (map_key, sub_key) = match key.split_once('.') {
+            Some(pair) => pair,
+            None => return vec![],
+        };
+        let map_id = match self.get_map_id(map_key) {
+            Some(id) => id,
+            None => return vec![],
+        };
+        let list_id = match self.doc.get(&map_id, sub_key).ok().flatten() {
+            Some((automerge::Value::Object(ObjType::List), id)) => id,
+            _ => return vec![],
+        };
+        let len = self.doc.length(&list_id);
+        (0..len)
+            .filter_map(|i| {
+                self.doc.get(&list_id, i).ok().flatten().and_then(
+                    |(value, _)| match value {
+                        automerge::Value::Scalar(s) => match s.as_ref() {
+                            automerge::ScalarValue::Str(s) => Some(s.to_string()),
+                            _ => None,
+                        },
+                        _ => None,
+                    },
+                )
+            })
+            .collect()
+    }
+
+    /// Replace a list of strings at a dotted path.
+    ///
+    /// Deletes the existing list (if any) and creates a new one with the given items.
+    pub fn put_list(&mut self, key: &str, values: &[String]) {
+        let (map_key, sub_key) = match key.split_once('.') {
+            Some(pair) => pair,
+            None => return,
+        };
+        let map_id = self.ensure_map(map_key);
+
+        // Delete existing value at this key (list or otherwise)
+        let _ = self.doc.delete(&map_id, sub_key);
+
+        // Create new list and insert items
+        if let Ok(list_id) = self.doc.put_object(&map_id, sub_key, ObjType::List) {
+            for (i, item) in values.iter().enumerate() {
+                let _ = self.doc.insert(&list_id, i, item.as_str());
+            }
+        }
+    }
+
+    /// Set a value from a `serde_json::Value` — dispatches to `put` for strings
+    /// or `put_list` for arrays. Used by Tauri commands.
+    pub fn put_value(&mut self, key: &str, value: &serde_json::Value) {
+        match value {
+            serde_json::Value::String(s) => self.put(key, s),
+            serde_json::Value::Array(arr) => {
+                let items: Vec<String> = arr
+                    .iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect();
+                self.put_list(key, &items);
+            }
+            _ => {}
+        }
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────
+
+    /// Look up a nested Map object at ROOT.
+    fn get_map_id(&self, map_key: &str) -> Option<ObjId> {
         self.doc
-            .get(automerge::ROOT, key)
+            .get(automerge::ROOT, map_key)
             .ok()
             .flatten()
-            .and_then(|(value, _)| match value {
-                automerge::Value::Scalar(s) => match s.as_ref() {
-                    automerge::ScalarValue::Str(s) => Some(s.to_string()),
-                    _ => None,
-                },
+            .and_then(|(value, id)| match value {
+                automerge::Value::Object(ObjType::Map) => Some(id),
                 _ => None,
             })
     }
 
-    /// Set a single setting value.
-    pub fn put(&mut self, key: &str, value: &str) {
-        let _ = self.doc.put(automerge::ROOT, key, value);
+    /// Get or create a nested Map at ROOT.
+    fn ensure_map(&mut self, map_key: &str) -> ObjId {
+        if let Some(id) = self.get_map_id(map_key) {
+            return id;
+        }
+        self.doc
+            .put_object(automerge::ROOT, map_key, ObjType::Map)
+            .expect("failed to create nested map")
     }
 
+    // ── Aggregate accessor ───────────────────────────────────────────
+
     /// Get a snapshot of all settings.
+    ///
+    /// Reads from nested maps first, falling back to old flat keys for
+    /// backward compatibility during upgrades.
     pub fn get_all(&self) -> SyncedSettings {
         let defaults = SyncedSettings::default();
+
+        // Read uv packages: try nested list, fall back to flat comma string
+        let uv_packages = {
+            let nested = self.get_list("uv.default_packages");
+            if !nested.is_empty() {
+                nested
+            } else if let Some(flat) = self.get_flat("default_uv_packages") {
+                split_comma_list(&flat)
+            } else {
+                defaults.uv.default_packages.clone()
+            }
+        };
+
+        // Read conda packages: try nested list, fall back to flat comma string
+        let conda_packages = {
+            let nested = self.get_list("conda.default_packages");
+            if !nested.is_empty() {
+                nested
+            } else if let Some(flat) = self.get_flat("default_conda_packages") {
+                split_comma_list(&flat)
+            } else {
+                defaults.conda.default_packages.clone()
+            }
+        };
+
         SyncedSettings {
             theme: self.get("theme").unwrap_or(defaults.theme),
             default_runtime: self.get("default_runtime").unwrap_or(defaults.default_runtime),
             default_python_env: self
                 .get("default_python_env")
                 .unwrap_or(defaults.default_python_env),
-            default_uv_packages: self
-                .get("default_uv_packages")
-                .unwrap_or(defaults.default_uv_packages),
-            default_conda_packages: self
-                .get("default_conda_packages")
-                .unwrap_or(defaults.default_conda_packages),
+            uv: UvDefaults {
+                default_packages: uv_packages,
+            },
+            conda: CondaDefaults {
+                default_packages: conda_packages,
+            },
         }
     }
 
@@ -236,6 +444,63 @@ impl Default for SettingsDoc {
     }
 }
 
+// ── Free helpers ─────────────────────────────────────────────────────
+
+/// Read a scalar string value from any Automerge object.
+fn read_scalar_str<O: AsRef<ObjId>>(
+    doc: &AutoCommit,
+    obj: O,
+    key: &str,
+) -> Option<String> {
+    doc.get(obj, key)
+        .ok()
+        .flatten()
+        .and_then(|(value, _)| match value {
+            automerge::Value::Scalar(s) => match s.as_ref() {
+                automerge::ScalarValue::Str(s) => Some(s.to_string()),
+                _ => None,
+            },
+            _ => None,
+        })
+}
+
+/// Split a comma-separated string into a list of trimmed, non-empty strings.
+pub fn split_comma_list(s: &str) -> Vec<String> {
+    s.split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
+/// Read a list of strings from a nested Automerge map within a raw `AutoCommit`.
+///
+/// Used by `sync_client::get_all_from_doc` which operates on bare docs.
+pub fn read_nested_list(doc: &AutoCommit, map_key: &str, sub_key: &str) -> Vec<String> {
+    let map_id = match doc.get(automerge::ROOT, map_key).ok().flatten() {
+        Some((automerge::Value::Object(ObjType::Map), id)) => id,
+        _ => return vec![],
+    };
+    let list_id = match doc.get(&map_id, sub_key).ok().flatten() {
+        Some((automerge::Value::Object(ObjType::List), id)) => id,
+        _ => return vec![],
+    };
+    let len = doc.length(&list_id);
+    (0..len)
+        .filter_map(|i| {
+            doc.get(&list_id, i)
+                .ok()
+                .flatten()
+                .and_then(|(value, _)| match value {
+                    automerge::Value::Scalar(s) => match s.as_ref() {
+                        automerge::ScalarValue::Str(s) => Some(s.to_string()),
+                        _ => None,
+                    },
+                    _ => None,
+                })
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -248,10 +513,12 @@ mod tests {
         assert_eq!(settings.theme, "system");
         assert_eq!(settings.default_runtime, "python");
         assert_eq!(settings.default_python_env, "uv");
+        assert!(settings.uv.default_packages.is_empty());
+        assert!(settings.conda.default_packages.is_empty());
     }
 
     #[test]
-    fn test_put_and_get() {
+    fn test_put_and_get_scalar() {
         let mut doc = SettingsDoc::new();
         doc.put("theme", "dark");
         assert_eq!(doc.get("theme"), Some("dark".to_string()));
@@ -264,15 +531,83 @@ mod tests {
     }
 
     #[test]
+    fn test_put_and_get_list() {
+        let mut doc = SettingsDoc::new();
+        doc.put_list(
+            "uv.default_packages",
+            &["numpy".to_string(), "pandas".to_string()],
+        );
+
+        let packages = doc.get_list("uv.default_packages");
+        assert_eq!(packages, vec!["numpy", "pandas"]);
+    }
+
+    #[test]
+    fn test_put_list_replaces_existing() {
+        let mut doc = SettingsDoc::new();
+        doc.put_list("uv.default_packages", &["numpy".to_string()]);
+        doc.put_list(
+            "uv.default_packages",
+            &["pandas".to_string(), "scipy".to_string()],
+        );
+
+        let packages = doc.get_list("uv.default_packages");
+        assert_eq!(packages, vec!["pandas", "scipy"]);
+    }
+
+    #[test]
+    fn test_get_list_empty_by_default() {
+        let doc = SettingsDoc::new();
+        let packages = doc.get_list("uv.default_packages");
+        assert!(packages.is_empty());
+    }
+
+    #[test]
+    fn test_put_value_string() {
+        let mut doc = SettingsDoc::new();
+        doc.put_value("theme", &serde_json::json!("dark"));
+        assert_eq!(doc.get("theme"), Some("dark".to_string()));
+    }
+
+    #[test]
+    fn test_put_value_array() {
+        let mut doc = SettingsDoc::new();
+        doc.put_value(
+            "uv.default_packages",
+            &serde_json::json!(["numpy", "pandas"]),
+        );
+        assert_eq!(
+            doc.get_list("uv.default_packages"),
+            vec!["numpy", "pandas"]
+        );
+    }
+
+    #[test]
+    fn test_get_all_with_packages() {
+        let mut doc = SettingsDoc::new();
+        doc.put_list(
+            "uv.default_packages",
+            &["numpy".to_string(), "pandas".to_string()],
+        );
+        doc.put_list("conda.default_packages", &["scipy".to_string()]);
+
+        let settings = doc.get_all();
+        assert_eq!(settings.uv.default_packages, vec!["numpy", "pandas"]);
+        assert_eq!(settings.conda.default_packages, vec!["scipy"]);
+    }
+
+    #[test]
     fn test_save_and_load() {
         let mut doc = SettingsDoc::new();
         doc.put("theme", "light");
+        doc.put_list("uv.default_packages", &["numpy".to_string()]);
 
         let bytes = doc.save();
         let loaded = SettingsDoc::load(&bytes).unwrap();
 
         assert_eq!(loaded.get("theme"), Some("light".to_string()));
         assert_eq!(loaded.get("default_runtime"), Some("python".to_string()));
+        assert_eq!(loaded.get_list("uv.default_packages"), vec!["numpy"]);
     }
 
     #[test]
@@ -282,30 +617,100 @@ mod tests {
 
         let mut doc = SettingsDoc::new();
         doc.put("theme", "dark");
+        doc.put_list(
+            "conda.default_packages",
+            &["scipy".to_string(), "numpy".to_string()],
+        );
         doc.save_to_file(&path).unwrap();
 
         let loaded = SettingsDoc::load_or_create(&path, None);
         assert_eq!(loaded.get("theme"), Some("dark".to_string()));
+        assert_eq!(
+            loaded.get_list("conda.default_packages"),
+            vec!["scipy", "numpy"]
+        );
     }
 
     #[test]
-    fn test_migrate_from_json() {
+    fn test_migrate_flat_to_nested() {
+        // Simulate an old Automerge doc with flat comma-separated keys
+        let mut doc = AutoCommit::new();
+        let _ = doc.put(automerge::ROOT, "theme", "dark");
+        let _ = doc.put(automerge::ROOT, "default_runtime", "python");
+        let _ = doc.put(automerge::ROOT, "default_python_env", "uv");
+        let _ = doc.put(
+            automerge::ROOT,
+            "default_uv_packages",
+            "numpy, pandas, matplotlib",
+        );
+        let _ = doc.put(automerge::ROOT, "default_conda_packages", "scipy");
+
+        let bytes = doc.save();
+
+        // Load via load_or_create which triggers migration
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("settings.automerge");
+        std::fs::write(&path, bytes).unwrap();
+
+        let loaded = SettingsDoc::load_or_create(&path, None);
+        let settings = loaded.get_all();
+
+        assert_eq!(settings.theme, "dark");
+        assert_eq!(
+            settings.uv.default_packages,
+            vec!["numpy", "pandas", "matplotlib"]
+        );
+        assert_eq!(settings.conda.default_packages, vec!["scipy"]);
+
+        // Old flat keys should be gone
+        assert_eq!(loaded.get_flat("default_uv_packages"), None);
+        assert_eq!(loaded.get_flat("default_conda_packages"), None);
+    }
+
+    #[test]
+    fn test_migrate_from_json_flat_format() {
         let tmp = TempDir::new().unwrap();
         let automerge_path = tmp.path().join("settings.automerge");
         let json_path = tmp.path().join("settings.json");
 
-        // Write a settings.json with existing settings
+        // Write old-format settings.json
         std::fs::write(
             &json_path,
-            r#"{"default_runtime":"deno","default_python_env":"conda"}"#,
+            r#"{"default_runtime":"deno","default_python_env":"conda","default_uv_packages":"numpy, pandas","default_conda_packages":"scipy, scikit-learn"}"#,
         )
         .unwrap();
 
         let doc = SettingsDoc::load_or_create(&automerge_path, Some(&json_path));
-        assert_eq!(doc.get("default_runtime"), Some("deno".to_string()));
-        assert_eq!(doc.get("default_python_env"), Some("conda".to_string()));
-        // Theme was never in settings.json, should be default
-        assert_eq!(doc.get("theme"), Some("system".to_string()));
+        let settings = doc.get_all();
+
+        assert_eq!(settings.default_runtime, "deno");
+        assert_eq!(settings.default_python_env, "conda");
+        assert_eq!(settings.uv.default_packages, vec!["numpy", "pandas"]);
+        assert_eq!(
+            settings.conda.default_packages,
+            vec!["scipy", "scikit-learn"]
+        );
+        assert_eq!(settings.theme, "system"); // Theme was never in settings.json
+    }
+
+    #[test]
+    fn test_migrate_from_json_nested_format() {
+        let tmp = TempDir::new().unwrap();
+        let automerge_path = tmp.path().join("settings.automerge");
+        let json_path = tmp.path().join("settings.json");
+
+        // Write new-format settings.json
+        std::fs::write(
+            &json_path,
+            r#"{"default_runtime":"python","uv":{"default_packages":["numpy","pandas"]},"conda":{"default_packages":["scipy"]}}"#,
+        )
+        .unwrap();
+
+        let doc = SettingsDoc::load_or_create(&automerge_path, Some(&json_path));
+        let settings = doc.get_all();
+
+        assert_eq!(settings.uv.default_packages, vec!["numpy", "pandas"]);
+        assert_eq!(settings.conda.default_packages, vec!["scipy"]);
     }
 
     #[test]
@@ -313,7 +718,6 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let automerge_path = tmp.path().join("settings.automerge");
 
-        // Neither file exists — should get defaults
         let doc = SettingsDoc::load_or_create(&automerge_path, None);
         assert_eq!(doc.get_all(), SyncedSettings::default());
     }
@@ -325,42 +729,41 @@ mod tests {
 
         let mut doc = SettingsDoc::new();
         doc.put("theme", "dark");
+        doc.put_list(
+            "uv.default_packages",
+            &["numpy".to_string(), "pandas".to_string()],
+        );
         doc.save_json_mirror(&json_path).unwrap();
 
         let contents = std::fs::read_to_string(&json_path).unwrap();
-        let parsed: SyncedSettings = serde_json::from_str(&contents).unwrap();
-        assert_eq!(parsed.theme, "dark");
+        let parsed: serde_json::Value = serde_json::from_str(&contents).unwrap();
+        assert_eq!(parsed["theme"], "dark");
+        assert_eq!(parsed["uv"]["default_packages"][0], "numpy");
+        assert_eq!(parsed["uv"]["default_packages"][1], "pandas");
     }
 
     #[test]
     fn test_sync_between_two_docs() {
-        // Simulate the daemon-client sync protocol
         let mut server = SettingsDoc::new();
         server.put("theme", "dark");
+        server.put_list("uv.default_packages", &["numpy".to_string()]);
 
         let mut client = SettingsDoc::new();
-        // Client starts with defaults
 
         let mut server_state = sync::State::new();
         let mut client_state = sync::State::new();
 
-        // Run sync rounds until both are in sync
         for _ in 0..10 {
-            // Client generates a message for the server
             if let Some(msg) = client.generate_sync_message(&mut client_state) {
                 server
                     .receive_sync_message(&mut server_state, msg)
                     .unwrap();
             }
-
-            // Server generates a message for the client
             if let Some(msg) = server.generate_sync_message(&mut server_state) {
                 client
                     .receive_sync_message(&mut client_state, msg)
                     .unwrap();
             }
-
-            // Check if both are now in sync
             if client.get("theme") == Some("dark".to_string()) {
                 break;
             }
@@ -368,17 +771,18 @@ mod tests {
 
         assert_eq!(client.get("theme"), Some("dark".to_string()));
         assert_eq!(client.get("default_runtime"), Some("python".to_string()));
+        assert_eq!(client.get_list("uv.default_packages"), vec!["numpy"]);
     }
 
     #[test]
     fn test_concurrent_writes_merge() {
-        // Both sides make changes, sync should merge them
         let mut server = SettingsDoc::new();
         let mut client = SettingsDoc::new();
 
-        // Sync initial state first
         let mut server_state = sync::State::new();
         let mut client_state = sync::State::new();
+
+        // Sync initial state
         for _ in 0..10 {
             if let Some(msg) = client.generate_sync_message(&mut client_state) {
                 server
@@ -392,7 +796,7 @@ mod tests {
             }
         }
 
-        // Now both make different changes
+        // Both make different changes
         server.put("theme", "dark");
         client.put("default_runtime", "deno");
 
@@ -410,10 +814,39 @@ mod tests {
             }
         }
 
-        // Both should have both changes
         assert_eq!(server.get("theme"), Some("dark".to_string()));
         assert_eq!(server.get("default_runtime"), Some("deno".to_string()));
         assert_eq!(client.get("theme"), Some("dark".to_string()));
         assert_eq!(client.get("default_runtime"), Some("deno".to_string()));
+    }
+
+    #[test]
+    fn test_split_comma_list() {
+        assert_eq!(
+            split_comma_list("numpy, pandas, matplotlib"),
+            vec!["numpy", "pandas", "matplotlib"]
+        );
+        assert_eq!(split_comma_list(""), Vec::<String>::new());
+        assert_eq!(split_comma_list("  "), Vec::<String>::new());
+        assert_eq!(split_comma_list("numpy"), vec!["numpy"]);
+    }
+
+    #[test]
+    fn test_nested_scalar_in_map() {
+        let mut doc = SettingsDoc::new();
+        // Write a scalar into a nested map (for future settings like conda channels)
+        doc.put("uv.some_future_setting", "value");
+        assert_eq!(
+            doc.get("uv.some_future_setting"),
+            Some("value".to_string())
+        );
+    }
+
+    #[test]
+    fn test_ensure_map_creates_if_missing() {
+        let mut doc = SettingsDoc::new();
+        // Put into a map that doesn't exist yet
+        doc.put("new_section.key", "value");
+        assert_eq!(doc.get("new_section.key"), Some("value".to_string()));
     }
 }

--- a/crates/runtimed/src/sync_client.rs
+++ b/crates/runtimed/src/sync_client.rs
@@ -253,6 +253,10 @@ fn get_all_from_doc(doc: &AutoCommit) -> SyncedSettings {
         theme: get_str("theme").unwrap_or(defaults.theme),
         default_runtime: get_str("default_runtime").unwrap_or(defaults.default_runtime),
         default_python_env: get_str("default_python_env").unwrap_or(defaults.default_python_env),
+        default_uv_packages: get_str("default_uv_packages")
+            .unwrap_or(defaults.default_uv_packages),
+        default_conda_packages: get_str("default_conda_packages")
+            .unwrap_or(defaults.default_conda_packages),
     }
 }
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -6,13 +6,25 @@ Runt notebook settings control default behavior for new notebooks, appearance, a
 
 | Setting | Options | Default | Stored In |
 |---------|---------|---------|-----------|
-| Theme | light, dark, system | system | Browser localStorage (per window) |
-| Default runtime | python, deno | python | Settings file |
-| Default Python env | uv, conda | conda | Settings file |
+| Theme | light, dark, system | system | Synced (Automerge) + localStorage for FOUC |
+| Default runtime | python, deno | python | Synced (Automerge) + settings file |
+| Default Python env | uv, conda | uv | Synced (Automerge) + settings file |
+| Default uv packages | comma-separated list | (empty) | Synced (Automerge) + settings file |
+| Default conda packages | comma-separated list | (empty) | Synced (Automerge) + settings file |
+
+## How Settings Sync Works
+
+Settings are synced across all notebook windows via the runtimed daemon using Automerge. The daemon holds the canonical document; each notebook window maintains a local replica.
+
+- **Source of truth:** The Automerge document in the daemon
+- **Persistence:** Settings are also written to `settings.json` as a local fallback (for Cmd+N menu behavior and daemon-unavailable scenarios)
+- **Theme special case:** Theme also uses browser localStorage to prevent a flash of unstyled content on startup
+
+When you change a setting in any window, it propagates to all other open windows in real time.
 
 ## Settings File
 
-Most settings are stored in a JSON file that is shared across all notebook windows.
+Settings are persisted to a JSON file shared across all notebook windows.
 
 | Platform | Path |
 |----------|------|
@@ -27,7 +39,9 @@ Example:
 ```json
 {
   "default_runtime": "python",
-  "default_python_env": "conda"
+  "default_python_env": "uv",
+  "default_uv_packages": "numpy, pandas, matplotlib",
+  "default_conda_packages": "numpy, pandas, scikit-learn"
 }
 ```
 
@@ -41,8 +55,6 @@ Controls light/dark appearance for the notebook editor and output viewer.
 
 Change the theme by clicking the gear icon in the notebook toolbar, then selecting Light, Dark, or System.
 
-Theme is currently stored per window in browser localStorage. Changing the theme in one window does not affect other open windows.
-
 ## Default Runtime
 
 Determines which runtime is used when creating a new notebook with **Cmd+N** (or **Ctrl+N** on Windows/Linux).
@@ -55,11 +67,7 @@ Determines which runtime is used when creating a new notebook with **Cmd+N** (or
 
 Valid values: `"python"`, `"deno"`
 
-You can always create a notebook with a specific runtime regardless of this setting:
-
-- **Cmd+N** — new notebook with the default runtime
-- **Cmd+Shift+N** — new Deno (TypeScript) notebook
-- `runt notebook --runtime deno` — from the CLI
+You can always create a notebook with a specific runtime using the **File > New Notebook As...** submenu.
 
 ## Default Python Environment
 
@@ -67,15 +75,30 @@ Controls which package manager is used for Python notebooks when no project-leve
 
 ```json
 {
-  "default_python_env": "conda"
+  "default_python_env": "uv"
 }
 ```
 
 Valid values: `"uv"`, `"conda"`
 
-- **conda** — uses conda/rattler for package management (supports conda packages)
 - **uv** — uses uv for package management (fast, pip-compatible)
+- **conda** — uses conda/rattler for package management (supports conda packages)
 
 If the notebook directory contains a `pyproject.toml` or `environment.yml`, the environment type is determined by that file instead of this setting.
 
+## Default Packages
 
+Controls which packages are pre-installed in prewarmed environments. These packages are available immediately when you open a new notebook, without needing to add them as inline dependencies.
+
+Since uv and conda have different package ecosystems, packages are configured separately:
+
+```json
+{
+  "default_uv_packages": "numpy, pandas, matplotlib",
+  "default_conda_packages": "numpy, pandas, scikit-learn"
+}
+```
+
+Both fields accept a comma-separated list of package names. Changes take effect on the next pool replenishment cycle — existing prewarmed environments keep their original packages until replaced. Restarting the app clears the pool and rebuilds with the updated packages.
+
+The packages are installed alongside `ipykernel` and `ipywidgets` (which are always included).

--- a/src/hooks/useSyncedSettings.ts
+++ b/src/hooks/useSyncedSettings.ts
@@ -12,6 +12,8 @@ interface SyncedSettings {
   theme: string;
   default_runtime: string;
   default_python_env: string;
+  default_uv_packages: string;
+  default_conda_packages: string;
 }
 
 function resolveTheme(theme: ThemeMode): "light" | "dark" {
@@ -55,19 +57,26 @@ function isValidPythonEnv(value: string): value is PythonEnvMode {
   return value === "uv" || value === "conda";
 }
 
-function getStored<T extends string>(key: string, validate: (v: string) => v is T): T | null {
+/**
+ * Read a theme value from localStorage.
+ *
+ * localStorage is ONLY used for the theme setting to avoid a flash of
+ * unstyled content (FOUC) on startup. All other settings initialize from
+ * defaults and wait for the daemon to provide the authoritative value.
+ */
+function getStoredTheme(): ThemeMode {
   try {
-    const stored = localStorage.getItem(key);
-    if (stored && validate(stored)) return stored;
+    const stored = localStorage.getItem("notebook-theme");
+    if (stored && isValidTheme(stored)) return stored;
   } catch {
     // ignore
   }
-  return null;
+  return "system";
 }
 
-function setStored(key: string, value: string) {
+function setStoredTheme(value: ThemeMode) {
   try {
-    localStorage.setItem(key, value);
+    localStorage.setItem("notebook-theme", value);
   } catch {
     // ignore
   }
@@ -76,20 +85,22 @@ function setStored(key: string, value: string) {
 /**
  * Hook for all synced settings across notebook windows via runtimed.
  *
- * Reads from the Automerge-backed settings sync daemon on mount,
- * listens for cross-window changes, and falls back to localStorage
- * when the daemon is unavailable.
+ * The daemon (Automerge doc) is the source of truth. On mount, we fetch
+ * the current settings from the daemon and listen for cross-window changes.
+ *
+ * localStorage is only used for theme to avoid FOUC. All other settings
+ * initialize from defaults and are overwritten once the daemon responds.
  */
 export function useSyncedSettings() {
-  const [theme, setThemeState] = useState<ThemeMode>(
-    () => getStored("notebook-theme", isValidTheme) ?? "system",
-  );
-  const [defaultRuntime, setDefaultRuntimeState] = useState<RuntimeMode>(
-    () => getStored("notebook-default-runtime", isValidRuntime) ?? "python",
-  );
-  const [defaultPythonEnv, setDefaultPythonEnvState] = useState<PythonEnvMode>(
-    () => getStored("notebook-default-python-env", isValidPythonEnv) ?? "uv",
-  );
+  // Theme uses localStorage to avoid flash of wrong theme on startup
+  const [theme, setThemeState] = useState<ThemeMode>(getStoredTheme);
+  // All other settings use defaults — daemon is the source of truth
+  const [defaultRuntime, setDefaultRuntimeState] =
+    useState<RuntimeMode>("python");
+  const [defaultPythonEnv, setDefaultPythonEnvState] =
+    useState<PythonEnvMode>("uv");
+  const [defaultUvPackages, setDefaultUvPackagesState] = useState("");
+  const [defaultCondaPackages, setDefaultCondaPackagesState] = useState("");
 
   // Load initial settings from daemon
   useEffect(() => {
@@ -97,19 +108,23 @@ export function useSyncedSettings() {
       .then((settings) => {
         if (isValidTheme(settings.theme)) {
           setThemeState(settings.theme);
-          setStored("notebook-theme", settings.theme);
+          setStoredTheme(settings.theme);
         }
         if (isValidRuntime(settings.default_runtime)) {
           setDefaultRuntimeState(settings.default_runtime);
-          setStored("notebook-default-runtime", settings.default_runtime);
         }
         if (isValidPythonEnv(settings.default_python_env)) {
           setDefaultPythonEnvState(settings.default_python_env);
-          setStored("notebook-default-python-env", settings.default_python_env);
+        }
+        if (typeof settings.default_uv_packages === "string") {
+          setDefaultUvPackagesState(settings.default_uv_packages);
+        }
+        if (typeof settings.default_conda_packages === "string") {
+          setDefaultCondaPackagesState(settings.default_conda_packages);
         }
       })
       .catch(() => {
-        // Daemon unavailable, stick with localStorage values
+        // Daemon unavailable — defaults are fine
       });
   }, []);
 
@@ -120,15 +135,19 @@ export function useSyncedSettings() {
         event.payload;
       if (isValidTheme(newTheme)) {
         setThemeState(newTheme);
-        setStored("notebook-theme", newTheme);
+        setStoredTheme(newTheme);
       }
       if (isValidRuntime(default_runtime)) {
         setDefaultRuntimeState(default_runtime);
-        setStored("notebook-default-runtime", default_runtime);
       }
       if (isValidPythonEnv(default_python_env)) {
         setDefaultPythonEnvState(default_python_env);
-        setStored("notebook-default-python-env", default_python_env);
+      }
+      if (typeof event.payload.default_uv_packages === "string") {
+        setDefaultUvPackagesState(event.payload.default_uv_packages);
+      }
+      if (typeof event.payload.default_conda_packages === "string") {
+        setDefaultCondaPackagesState(event.payload.default_conda_packages);
       }
     });
     return () => {
@@ -138,7 +157,7 @@ export function useSyncedSettings() {
 
   const setTheme = useCallback((newTheme: ThemeMode) => {
     setThemeState(newTheme);
-    setStored("notebook-theme", newTheme);
+    setStoredTheme(newTheme);
     invoke("set_synced_setting", { key: "theme", value: newTheme }).catch(
       () => {},
     );
@@ -146,7 +165,6 @@ export function useSyncedSettings() {
 
   const setDefaultRuntime = useCallback((newRuntime: RuntimeMode) => {
     setDefaultRuntimeState(newRuntime);
-    setStored("notebook-default-runtime", newRuntime);
     invoke("set_synced_setting", {
       key: "default_runtime",
       value: newRuntime,
@@ -155,10 +173,25 @@ export function useSyncedSettings() {
 
   const setDefaultPythonEnv = useCallback((newEnv: PythonEnvMode) => {
     setDefaultPythonEnvState(newEnv);
-    setStored("notebook-default-python-env", newEnv);
     invoke("set_synced_setting", {
       key: "default_python_env",
       value: newEnv,
+    }).catch(() => {});
+  }, []);
+
+  const setDefaultUvPackages = useCallback((packages: string) => {
+    setDefaultUvPackagesState(packages);
+    invoke("set_synced_setting", {
+      key: "default_uv_packages",
+      value: packages,
+    }).catch(() => {});
+  }, []);
+
+  const setDefaultCondaPackages = useCallback((packages: string) => {
+    setDefaultCondaPackagesState(packages);
+    invoke("set_synced_setting", {
+      key: "default_conda_packages",
+      value: packages,
     }).catch(() => {});
   }, []);
 
@@ -169,6 +202,10 @@ export function useSyncedSettings() {
     setDefaultRuntime,
     defaultPythonEnv,
     setDefaultPythonEnv,
+    defaultUvPackages,
+    setDefaultUvPackages,
+    defaultCondaPackages,
+    setDefaultCondaPackages,
   };
 }
 

--- a/src/hooks/useSyncedSettings.ts
+++ b/src/hooks/useSyncedSettings.ts
@@ -82,19 +82,6 @@ function setStoredTheme(value: ThemeMode) {
   }
 }
 
-/** Join a string array into a comma-separated display string. */
-function joinPackages(packages: string[]): string {
-  return packages.join(", ");
-}
-
-/** Split a comma-separated string into a trimmed, non-empty array. */
-function splitPackages(str: string): string[] {
-  return str
-    .split(",")
-    .map((s) => s.trim())
-    .filter(Boolean);
-}
-
 /**
  * Hook for all synced settings across notebook windows via runtimed.
  *
@@ -112,8 +99,10 @@ export function useSyncedSettings() {
     useState<RuntimeMode>("python");
   const [defaultPythonEnv, setDefaultPythonEnvState] =
     useState<PythonEnvMode>("uv");
-  const [defaultUvPackages, setDefaultUvPackagesState] = useState("");
-  const [defaultCondaPackages, setDefaultCondaPackagesState] = useState("");
+  const [defaultUvPackages, setDefaultUvPackagesState] = useState<string[]>([]);
+  const [defaultCondaPackages, setDefaultCondaPackagesState] = useState<
+    string[]
+  >([]);
 
   // Load initial settings from daemon
   useEffect(() => {
@@ -130,12 +119,10 @@ export function useSyncedSettings() {
           setDefaultPythonEnvState(settings.default_python_env);
         }
         if (Array.isArray(settings.uv?.default_packages)) {
-          setDefaultUvPackagesState(joinPackages(settings.uv.default_packages));
+          setDefaultUvPackagesState(settings.uv.default_packages);
         }
         if (Array.isArray(settings.conda?.default_packages)) {
-          setDefaultCondaPackagesState(
-            joinPackages(settings.conda.default_packages),
-          );
+          setDefaultCondaPackagesState(settings.conda.default_packages);
         }
       })
       .catch(() => {
@@ -159,14 +146,10 @@ export function useSyncedSettings() {
         setDefaultPythonEnvState(default_python_env);
       }
       if (Array.isArray(event.payload.uv?.default_packages)) {
-        setDefaultUvPackagesState(
-          joinPackages(event.payload.uv.default_packages),
-        );
+        setDefaultUvPackagesState(event.payload.uv.default_packages);
       }
       if (Array.isArray(event.payload.conda?.default_packages)) {
-        setDefaultCondaPackagesState(
-          joinPackages(event.payload.conda.default_packages),
-        );
+        setDefaultCondaPackagesState(event.payload.conda.default_packages);
       }
     });
     return () => {
@@ -198,19 +181,19 @@ export function useSyncedSettings() {
     }).catch(() => {});
   }, []);
 
-  const setDefaultUvPackages = useCallback((packagesStr: string) => {
-    setDefaultUvPackagesState(packagesStr);
+  const setDefaultUvPackages = useCallback((packages: string[]) => {
+    setDefaultUvPackagesState(packages);
     invoke("set_synced_setting", {
       key: "uv.default_packages",
-      value: splitPackages(packagesStr),
+      value: packages,
     }).catch(() => {});
   }, []);
 
-  const setDefaultCondaPackages = useCallback((packagesStr: string) => {
-    setDefaultCondaPackagesState(packagesStr);
+  const setDefaultCondaPackages = useCallback((packages: string[]) => {
+    setDefaultCondaPackagesState(packages);
     invoke("set_synced_setting", {
       key: "conda.default_packages",
-      value: splitPackages(packagesStr),
+      value: packages,
     }).catch(() => {});
   }, []);
 


### PR DESCRIPTION
Split default Python packages into uv and conda variants synced via Automerge. Both settings are reflected in the daemon's prewarmed environment pool creation and in fallback (non-prewarmed) environment creation.

Added `runtimed flush-pool` CLI command to rebuild pooled environments with current settings. Package text inputs now disable system autocomplete and spellcheck.

Updated docs/settings.md to explain the new settings and when they take effect (on pool replenishment cycle).

## Verification

- Text inputs for default packages should not autocorrect (e.g., numpy should not become Numpy on macOS)
- Synced settings should update across multiple windows in real time
- Run `runtimed flush-pool` to force rebuild of prewarmed environments with configured packages