### PR TITLE
Add React error boundaries for resilient error handling

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -24,6 +24,7 @@ import { WidgetStoreProvider, useWidgetStoreRequired } from "@/components/widget
 import { MediaProvider } from "@/components/outputs/media-provider";
 import { WidgetView } from "@/components/widgets/widget-view";
 import { IsolationTest } from "@/components/outputs/isolated";
+import { ErrorBoundary } from "@/components/ErrorBoundary";
 import type { JupyterOutput, JupyterMessage } from "./types";
 
 /** Page payload data for a cell */
@@ -637,19 +638,52 @@ function AppContent() {
   );
 }
 
+function AppErrorFallback(_error: Error, resetErrorBoundary: () => void) {
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-4 bg-background p-8">
+      <div className="text-center">
+        <h1 className="text-lg font-semibold text-foreground">
+          Something went wrong
+        </h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          The notebook encountered an unexpected error.
+        </p>
+      </div>
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={resetErrorBoundary}
+          className="rounded-md border border-border bg-background px-4 py-2 text-sm font-medium text-foreground hover:bg-muted transition-colors"
+        >
+          Try again
+        </button>
+        <button
+          type="button"
+          onClick={() => window.location.reload()}
+          className="rounded-md bg-foreground px-4 py-2 text-sm font-medium text-background hover:opacity-90 transition-opacity"
+        >
+          Reload
+        </button>
+      </div>
+    </div>
+  );
+}
+
 export default function App() {
   return (
-    <WidgetStoreProvider sendMessage={sendMessage}>
-      <MediaProvider
-        renderers={{
-          "application/vnd.jupyter.widget-view+json": ({ data }) => {
-            const { model_id } = data as { model_id: string };
-            return <WidgetView modelId={model_id} />;
-          },
-        }}
-      >
-        <AppContent />
-      </MediaProvider>
-    </WidgetStoreProvider>
+    <ErrorBoundary fallback={AppErrorFallback}>
+      <WidgetStoreProvider sendMessage={sendMessage}>
+        <MediaProvider
+          renderers={{
+            "application/vnd.jupyter.widget-view+json": ({ data }) => {
+              const { model_id } = data as { model_id: string };
+              return <WidgetView modelId={model_id} />;
+            },
+          }}
+        >
+          <AppContent />
+        </MediaProvider>
+      </WidgetStoreProvider>
+    </ErrorBoundary>
   );
 }

--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -243,6 +243,7 @@ export function CodeCell({
             {pagePayload && (
               <div className="px-2 py-1">
                 <ErrorBoundary
+                  resetKeys={[pagePayload.data]}
                   fallback={() => (
                     <div className="text-xs text-muted-foreground italic px-1 py-2">
                       Failed to render documentation

--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -4,6 +4,7 @@ import { CellContainer } from "@/components/cell/CellContainer";
 import { CompactExecutionButton } from "@/components/cell/CompactExecutionButton";
 import { OutputArea } from "@/components/cell/OutputArea";
 import { AnsiOutput } from "@/components/outputs/ansi-output";
+import { ErrorBoundary } from "@/components/ErrorBoundary";
 import {
   CodeMirrorEditor,
   type CodeMirrorEditorRef,
@@ -241,10 +242,18 @@ export function CodeCell({
             {/* Page Payload (documentation from ? or ??) */}
             {pagePayload && (
               <div className="px-2 py-1">
-                <PagePayloadDisplay
-                  data={pagePayload.data}
-                  onDismiss={() => onClearPagePayload?.()}
-                />
+                <ErrorBoundary
+                  fallback={() => (
+                    <div className="text-xs text-muted-foreground italic px-1 py-2">
+                      Failed to render documentation
+                    </div>
+                  )}
+                >
+                  <PagePayloadDisplay
+                    data={pagePayload.data}
+                    onDismiss={() => onClearPagePayload?.()}
+                  />
+                </ErrorBoundary>
               </div>
             )}
           </>

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useRef, useMemo } from "react";
-import { Plus } from "lucide-react";
+import { Plus, RotateCcw, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { CodeCell } from "./CodeCell";
 import { MarkdownCell } from "./MarkdownCell";
 import { EditorRegistryProvider, useEditorRegistry } from "../hooks/useEditorRegistry";
@@ -61,6 +62,53 @@ function AddCellButtons({
           >
             <Plus className="h-3 w-3" />
             Markdown
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function CellErrorFallback({
+  error,
+  onRetry,
+  onDelete,
+}: {
+  error: Error;
+  onRetry: () => void;
+  onDelete: () => void;
+}) {
+  return (
+    <div className="mx-4 my-2 rounded-md border border-destructive/50 bg-destructive/5 p-3">
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <p className="text-sm font-medium text-destructive">
+            This cell encountered an error
+          </p>
+          <p className="mt-1 truncate text-xs text-muted-foreground">
+            {error.message}
+          </p>
+        </div>
+        <div className="flex shrink-0 items-center gap-1">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onRetry}
+            className="h-7 gap-1 px-2 text-xs"
+            title="Retry rendering"
+          >
+            <RotateCcw className="h-3 w-3" />
+            Retry
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onDelete}
+            className="h-7 gap-1 px-2 text-xs text-destructive hover:text-destructive"
+            title="Delete cell"
+          >
+            <X className="h-3 w-3" />
+            Delete
           </Button>
         </div>
       </div>
@@ -220,7 +268,17 @@ function NotebookViewContent({
               {index === 0 && (
                 <AddCellButtons afterCellId={null} onAdd={onAddCell} />
               )}
-              {renderCell(cell, index)}
+              <ErrorBoundary
+                fallback={(error, resetErrorBoundary) => (
+                  <CellErrorFallback
+                    error={error}
+                    onRetry={resetErrorBoundary}
+                    onDelete={() => onDeleteCell(cell.id)}
+                  />
+                )}
+              >
+                {renderCell(cell, index)}
+              </ErrorBoundary>
               <AddCellButtons afterCellId={cell.id} onAdd={onAddCell} />
             </div>
           ))}

--- a/e2e/helpers.js
+++ b/e2e/helpers.js
@@ -194,7 +194,13 @@ export async function waitForKernelStatus(status, timeout = 30000) {
  */
 export async function typeSlowly(text, delay = 30) {
   for (const char of text) {
-    await browser.keys(char);
+    // Newline characters must be sent as the Enter key — browser.keys('\n')
+    // doesn't produce Enter in all WebDriver environments (e.g. Linux/WRY).
+    if (char === "\n") {
+      await browser.keys("Enter");
+    } else {
+      await browser.keys(char);
+    }
     await browser.pause(delay);
   }
 }

--- a/e2e/specs/kernel-lifecycle.spec.js
+++ b/e2e/specs/kernel-lifecycle.spec.js
@@ -120,8 +120,8 @@ describe("Kernel Lifecycle", () => {
       console.log("Found restart button, clicking...");
       await restartButton.click();
 
-      // Wait for kernel to restart
-      await waitForKernelStatus("idle", 15000);
+      // Wait for kernel to restart (full startup cycle, same as initial boot)
+      await waitForKernelStatus("idle", KERNEL_STARTUP_TIMEOUT);
 
       // Try to access the variable — should get NameError
       codeCell = await setupCodeCell();

--- a/e2e/specs/settings-panel.spec.js
+++ b/e2e/specs/settings-panel.spec.js
@@ -189,7 +189,32 @@ describe("Settings Panel", () => {
 
   describe("Active button states", () => {
     it("should highlight the active theme button", async () => {
-      // After the previous test, "Light" should be the active theme
+      // After the previous test, "Light" should be the active theme.
+      // Wait for React re-render to propagate to button classes — on CI Linux
+      // the HTML class update and button re-render can happen in separate frames.
+      await browser.waitUntil(
+        async () => {
+          return await browser.execute(() => {
+            const group = document.querySelector(
+              '[data-testid="settings-theme-group"]'
+            );
+            const buttons = group?.querySelectorAll("button");
+            for (const btn of buttons || []) {
+              if (btn.textContent?.includes("Light")) {
+                return btn.className.includes("shadow-sm");
+              }
+            }
+            return false;
+          });
+        },
+        {
+          timeout: 3000,
+          interval: 100,
+          timeoutMsg:
+            "Light button did not get active styling (shadow-sm) after theme switch",
+        }
+      );
+
       const activeClass = await browser.execute(() => {
         const group = document.querySelector(
           '[data-testid="settings-theme-group"]'
@@ -233,7 +258,25 @@ describe("Settings Panel", () => {
         { timeout: 2000, interval: 100 }
       );
 
-      // Dark button should now be active
+      // Wait for Dark button to get active styling
+      await browser.waitUntil(
+        async () => {
+          return await browser.execute(() => {
+            const group = document.querySelector(
+              '[data-testid="settings-theme-group"]'
+            );
+            const buttons = group?.querySelectorAll("button");
+            for (const btn of buttons || []) {
+              if (btn.textContent?.includes("Dark")) {
+                return btn.className.includes("shadow-sm");
+              }
+            }
+            return false;
+          });
+        },
+        { timeout: 3000, interval: 100 }
+      );
+
       const darkClass = await browser.execute(() => {
         const group = document.querySelector(
           '[data-testid="settings-theme-group"]'

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -6,10 +6,18 @@ interface ErrorBoundaryProps {
   fallback: (error: Error, resetErrorBoundary: () => void) => ReactNode;
   /** Optional callback when an error is caught. */
   onError?: (error: Error, errorInfo: ErrorInfo) => void;
+  /**
+   * When any value in this array changes, the error state is automatically
+   * cleared and the children are re-rendered. Use this to recover from
+   * errors when the underlying data changes (e.g., cell re-execution,
+   * new output data, widget state update).
+   */
+  resetKeys?: readonly unknown[];
 }
 
 interface ErrorBoundaryState {
   error: Error | null;
+  prevResetKeys: readonly unknown[] | undefined;
 }
 
 /**
@@ -18,6 +26,9 @@ interface ErrorBoundaryState {
  * Catches render errors in child components and displays a fallback UI
  * via the `fallback` render prop. Provides a `resetErrorBoundary` function
  * to retry rendering.
+ *
+ * Supports automatic recovery via `resetKeys` — when any key changes,
+ * the error state is cleared and children re-render.
  *
  * @example
  * ```tsx
@@ -28,6 +39,7 @@ interface ErrorBoundaryState {
  *       <button onClick={reset}>Retry</button>
  *     </div>
  *   )}
+ *   resetKeys={[executionCount]}
  * >
  *   <MyComponent />
  * </ErrorBoundary>
@@ -39,11 +51,30 @@ export class ErrorBoundary extends Component<
 > {
   constructor(props: ErrorBoundaryProps) {
     super(props);
-    this.state = { error: null };
+    this.state = { error: null, prevResetKeys: props.resetKeys };
   }
 
-  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+  static getDerivedStateFromError(error: Error): Partial<ErrorBoundaryState> {
     return { error };
+  }
+
+  static getDerivedStateFromProps(
+    props: ErrorBoundaryProps,
+    state: ErrorBoundaryState,
+  ): Partial<ErrorBoundaryState> | null {
+    if (state.error && state.prevResetKeys !== undefined && props.resetKeys !== undefined) {
+      const changed =
+        props.resetKeys.length !== state.prevResetKeys.length ||
+        props.resetKeys.some((key, i) => !Object.is(key, state.prevResetKeys![i]));
+      if (changed) {
+        return { error: null, prevResetKeys: props.resetKeys };
+      }
+    }
+    // Always track latest resetKeys even when not in error state
+    if (props.resetKeys !== state.prevResetKeys) {
+      return { prevResetKeys: props.resetKeys };
+    }
+    return null;
   }
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,64 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  /** Render prop called when an error is caught. Return the fallback UI. */
+  fallback: (error: Error, resetErrorBoundary: () => void) => ReactNode;
+  /** Optional callback when an error is caught. */
+  onError?: (error: Error, errorInfo: ErrorInfo) => void;
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+}
+
+/**
+ * Reusable React error boundary.
+ *
+ * Catches render errors in child components and displays a fallback UI
+ * via the `fallback` render prop. Provides a `resetErrorBoundary` function
+ * to retry rendering.
+ *
+ * @example
+ * ```tsx
+ * <ErrorBoundary
+ *   fallback={(error, reset) => (
+ *     <div>
+ *       <p>Something went wrong: {error.message}</p>
+ *       <button onClick={reset}>Retry</button>
+ *     </div>
+ *   )}
+ * >
+ *   <MyComponent />
+ * </ErrorBoundary>
+ * ```
+ */
+export class ErrorBoundary extends Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error("[ErrorBoundary]", error, errorInfo.componentStack);
+    this.props.onError?.(error, errorInfo);
+  }
+
+  resetErrorBoundary = () => {
+    this.setState({ error: null });
+  };
+
+  render() {
+    if (this.state.error) {
+      return this.props.fallback(this.state.error, this.resetErrorBoundary);
+    }
+    return this.props.children;
+  }
+}

--- a/src/components/__tests__/ErrorBoundary.test.tsx
+++ b/src/components/__tests__/ErrorBoundary.test.tsx
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { useState } from "react";
+import { ErrorBoundary } from "../ErrorBoundary";
+
+// Suppress React's noisy error boundary console output during tests
+beforeEach(() => {
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+function ThrowingChild({ shouldThrow }: { shouldThrow: boolean }) {
+  if (shouldThrow) {
+    throw new Error("render failure");
+  }
+  return <div>child content</div>;
+}
+
+describe("ErrorBoundary", () => {
+  it("renders children when no error occurs", () => {
+    render(
+      <ErrorBoundary fallback={(error) => <div>{error.message}</div>}>
+        <div>hello</div>
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText("hello")).toBeInTheDocument();
+  });
+
+  it("renders fallback when a child throws", () => {
+    render(
+      <ErrorBoundary fallback={(error) => <div>error: {error.message}</div>}>
+        <ThrowingChild shouldThrow />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText("error: render failure")).toBeInTheDocument();
+  });
+
+  it("calls onError when a child throws", () => {
+    const onError = vi.fn();
+    render(
+      <ErrorBoundary
+        onError={onError}
+        fallback={(error) => <div>{error.message}</div>}
+      >
+        <ThrowingChild shouldThrow />
+      </ErrorBoundary>,
+    );
+    expect(onError).toHaveBeenCalledOnce();
+    expect(onError.mock.calls[0][0].message).toBe("render failure");
+  });
+
+  it("recovers when resetErrorBoundary is called", () => {
+    function Wrapper() {
+      const [shouldThrow, setShouldThrow] = useState(true);
+      return (
+        <ErrorBoundary
+          fallback={(_error, reset) => (
+            <button
+              onClick={() => {
+                setShouldThrow(false);
+                reset();
+              }}
+            >
+              retry
+            </button>
+          )}
+        >
+          <ThrowingChild shouldThrow={shouldThrow} />
+        </ErrorBoundary>
+      );
+    }
+
+    render(<Wrapper />);
+    expect(screen.getByText("retry")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("retry"));
+    expect(screen.getByText("child content")).toBeInTheDocument();
+  });
+
+  describe("resetKeys", () => {
+    it("auto-resets error state when resetKeys change", () => {
+      function Wrapper() {
+        const [key, setKey] = useState(0);
+        return (
+          <>
+            <button onClick={() => setKey((k) => k + 1)}>bump</button>
+            <ErrorBoundary
+              resetKeys={[key]}
+              fallback={(error) => <div>error: {error.message}</div>}
+            >
+              {/* Only throws on initial render (key=0) */}
+              <ThrowingChild shouldThrow={key === 0} />
+            </ErrorBoundary>
+          </>
+        );
+      }
+
+      render(<Wrapper />);
+      // Initially in error state
+      expect(screen.getByText("error: render failure")).toBeInTheDocument();
+
+      // Bump resetKeys — error should clear and children re-render
+      fireEvent.click(screen.getByText("bump"));
+      expect(screen.getByText("child content")).toBeInTheDocument();
+    });
+
+    it("stays in error state when resetKeys do not change", () => {
+      function Wrapper() {
+        const [, setCounter] = useState(0);
+        return (
+          <>
+            <button onClick={() => setCounter((c) => c + 1)}>rerender</button>
+            <ErrorBoundary
+              resetKeys={["stable"]}
+              fallback={(error) => <div>error: {error.message}</div>}
+            >
+              <ThrowingChild shouldThrow />
+            </ErrorBoundary>
+          </>
+        );
+      }
+
+      render(<Wrapper />);
+      expect(screen.getByText("error: render failure")).toBeInTheDocument();
+
+      // Parent re-render without changing resetKeys — still in error
+      fireEvent.click(screen.getByText("rerender"));
+      expect(screen.getByText("error: render failure")).toBeInTheDocument();
+    });
+
+    it("resets when output object reference changes", () => {
+      function Wrapper() {
+        const [output, setOutput] = useState<{ data: string }>({ data: "bad" });
+        return (
+          <>
+            <button onClick={() => setOutput({ data: "good" })}>new-output</button>
+            <ErrorBoundary
+              resetKeys={[output]}
+              fallback={(error) => <div>error: {error.message}</div>}
+            >
+              <ThrowingChild shouldThrow={output.data === "bad"} />
+            </ErrorBoundary>
+          </>
+        );
+      }
+
+      render(<Wrapper />);
+      expect(screen.getByText("error: render failure")).toBeInTheDocument();
+
+      // New output object — boundary should reset
+      fireEvent.click(screen.getByText("new-output"));
+      expect(screen.getByText("child content")).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -3,6 +3,7 @@
 import { ChevronDown, ChevronRight } from "lucide-react";
 import { useCallback, useEffect, useId, useRef, useState, type ReactNode } from "react";
 import { cn } from "@/lib/utils";
+import { ErrorBoundary } from "@/components/ErrorBoundary";
 import {
   AnsiErrorOutput,
   AnsiStreamOutput,
@@ -242,6 +243,20 @@ function renderOutput(
   }
 }
 
+function OutputErrorFallback({
+  error,
+  outputIndex,
+}: {
+  error: Error;
+  outputIndex: number;
+}) {
+  return (
+    <div className="rounded border border-dashed border-destructive/30 px-3 py-2 text-xs text-destructive/80">
+      Output {outputIndex + 1} failed to render: {error.message}
+    </div>
+  );
+}
+
 /**
  * OutputArea renders multiple Jupyter outputs with proper layout.
  *
@@ -463,9 +478,16 @@ export function OutputArea({
 
           {/* In-DOM outputs (when not using isolation) */}
           {!shouldIsolate &&
-            outputs.map((output, index) =>
-              renderOutput(output, index, renderers, priority, unsafe),
-            )}
+            outputs.map((output, index) => (
+              <ErrorBoundary
+                key={`error-boundary-${index}`}
+                fallback={(error) => (
+                  <OutputErrorFallback error={error} outputIndex={index} />
+                )}
+              >
+                {renderOutput(output, index, renderers, priority, unsafe)}
+              </ErrorBoundary>
+            ))}
         </div>
       )}
     </div>

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -480,7 +480,8 @@ export function OutputArea({
           {!shouldIsolate &&
             outputs.map((output, index) => (
               <ErrorBoundary
-                key={`error-boundary-${index}`}
+                key={`output-${index}`}
+                resetKeys={[output]}
                 fallback={(error) => (
                   <OutputErrorFallback error={error} outputIndex={index} />
                 )}

--- a/src/components/widgets/widget-view.tsx
+++ b/src/components/widgets/widget-view.tsx
@@ -143,9 +143,11 @@ export function WidgetView({ modelId, className }: WidgetViewProps) {
     }
   }
 
-  // Wrap in error boundary to catch render failures in built-in widgets
+  // Wrap in error boundary to catch render failures in built-in widgets.
+  // resetKeys tracks the model state so the boundary auto-recovers on updates.
   const wrappedWidget = (
     <ErrorBoundary
+      resetKeys={[model.state]}
       fallback={(error) => (
         <WidgetErrorFallback
           error={error}


### PR DESCRIPTION
## Summary

Implements a layered error boundary strategy to contain failures at the most granular level and prevent app crashes from malformed outputs or rendering errors.

- **Shared ErrorBoundary component** with render-prop fallback pattern and reset capability
- **App-level boundary** as last-resort safety net; shows "Something went wrong" with reload option
- **Cell-level boundaries** to isolate individual cell failures; shows error card with retry + delete actions
- **Output-level boundaries** to catch rendering errors in individual outputs; shows compact inline error
- **Widget-level boundaries** for built-in widget render failures; shows error matching UnsupportedWidget style
- **PagePayload boundary** for documentation rendering via `dangerouslySetInnerHTML`

Each boundary has a tailored fallback UI that follows the app's design language and provides actionable recovery options.