### PR TITLE
Add Deno installation prompt when kernel fails to initialize

### DIFF
--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
-import { Save, Play, Square, Plus, Package, Settings, Sun, Moon, Monitor, RotateCcw, ChevronsRight } from "lucide-react";
+import { Save, Play, Square, Plus, Package, Settings, Sun, Moon, Monitor, RotateCcw, ChevronsRight, Info } from "lucide-react";
 import { cn } from "@/lib/utils";
 import {
   Collapsible,
@@ -463,6 +463,22 @@ export function NotebookToolbar({
             </button>
           </CollapsibleTrigger>
         </div>
+
+        {/* Deno install prompt */}
+        {runtime === "deno" && kernelStatus === "error" && kernelErrorMessage && (
+          <div className="border-t px-3 py-2">
+            <div className="flex items-start gap-2 text-xs text-amber-700 dark:text-amber-400">
+              <Info className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+              <span>
+                <span className="font-medium">Deno not available.</span> Auto-install failed. Install manually with{" "}
+                <code className="rounded bg-amber-500/20 px-1">
+                  curl -fsSL https://deno.land/install.sh | sh
+                </code>{" "}
+                and restart.
+              </span>
+            </div>
+          </div>
+        )}
 
         {/* Collapsible settings panel */}
         <CollapsibleContent>

--- a/apps/notebook/src/hooks/useKernel.ts
+++ b/apps/notebook/src/hooks/useKernel.ts
@@ -459,7 +459,7 @@ export function useKernel({
           } else {
             console.warn("[kernel] Deno not available, notebook requires Deno runtime");
             setKernelStatus("error");
-            // TODO: Show install prompt
+            setKernelErrorMessage("Deno not available");
             return;
           }
         }


### PR DESCRIPTION
## Summary
This PR adds a user-friendly error message when the Deno runtime fails to initialize, guiding users to manually install Deno if auto-installation fails.

## Key Changes
- Added `Info` icon import from lucide-react for the error message UI
- Implemented a conditional error prompt in the NotebookToolbar that displays when:
  - Runtime is set to "deno"
  - Kernel status is "error"
  - An error message is present
- The prompt displays installation instructions with the curl command to install Deno
- Updated the kernel error handling to set `kernelErrorMessage` instead of just logging a TODO comment

## Implementation Details
- The error prompt is styled with amber/warning colors to indicate a non-critical issue
- Uses flexbox layout with proper spacing and icon sizing
- Includes the installation command in a code block for easy copying
- Positioned between the collapsible trigger and settings panel in the toolbar
- The message is dismissible by nature (appears only when conditions are met)