### PR TITLE
Fix settings-panel E2E flakiness on CI

### DIFF
--- a/e2e/specs/settings-panel.spec.js
+++ b/e2e/specs/settings-panel.spec.js
@@ -189,7 +189,32 @@ describe("Settings Panel", () => {
 
   describe("Active button states", () => {
     it("should highlight the active theme button", async () => {
-      // After the previous test, "Light" should be the active theme
+      // After the previous test, "Light" should be the active theme.
+      // Wait for React re-render to propagate to button classes — on CI Linux
+      // the HTML class update and button re-render can happen in separate frames.
+      await browser.waitUntil(
+        async () => {
+          return await browser.execute(() => {
+            const group = document.querySelector(
+              '[data-testid="settings-theme-group"]'
+            );
+            const buttons = group?.querySelectorAll("button");
+            for (const btn of buttons || []) {
+              if (btn.textContent?.includes("Light")) {
+                return btn.className.includes("shadow-sm");
+              }
+            }
+            return false;
+          });
+        },
+        {
+          timeout: 3000,
+          interval: 100,
+          timeoutMsg:
+            "Light button did not get active styling (shadow-sm) after theme switch",
+        }
+      );
+
       const activeClass = await browser.execute(() => {
         const group = document.querySelector(
           '[data-testid="settings-theme-group"]'
@@ -233,7 +258,25 @@ describe("Settings Panel", () => {
         { timeout: 2000, interval: 100 }
       );
 
-      // Dark button should now be active
+      // Wait for Dark button to get active styling
+      await browser.waitUntil(
+        async () => {
+          return await browser.execute(() => {
+            const group = document.querySelector(
+              '[data-testid="settings-theme-group"]'
+            );
+            const buttons = group?.querySelectorAll("button");
+            for (const btn of buttons || []) {
+              if (btn.textContent?.includes("Dark")) {
+                return btn.className.includes("shadow-sm");
+              }
+            }
+            return false;
+          });
+        },
+        { timeout: 3000, interval: 100 }
+      );
+
       const darkClass = await browser.execute(() => {
         const group = document.querySelector(
           '[data-testid="settings-theme-group"]'


### PR DESCRIPTION
## Summary

Fixes the settings-panel E2E test that fails on CI Linux with:

```
Expected substring: "bg-background"
Received string:    "flex items-center gap-1.5 rounded-sm px-2.5 py-1 text-xs transition-colors text-muted-foreground hover:text-foreground"
```

The "should highlight the active theme button" test reads the button's `className` synchronously after the previous test switches the theme. On CI Linux, the `<html>` class update and the button's React re-render happen in separate frames, so the button still shows inactive classes when the assertion runs.

**Fix:** Add `waitUntil` polling for the button's `shadow-sm` class before asserting, in both active-state tests. Same pattern used everywhere else in the settings-panel spec — wait for the observable DOM effect rather than assuming synchronous rendering.