### PR TITLE
Add E2E tests for Deno runtime and keyboard interactions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,6 +126,11 @@ jobs:
         with:
           node-version: "20"
 
+      - name: Install Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
       - name: Enable corepack
         run: corepack enable
 
@@ -266,6 +271,16 @@ jobs:
           start_driver
           NOTEBOOK_PATH=crates/notebook/fixtures/audit-test/1-vanilla.ipynb \
             E2E_SPEC=e2e/specs/settings-panel.spec.js \
+            pnpm test:e2e || FAIL=1
+
+          start_driver
+          NOTEBOOK_PATH=crates/notebook/fixtures/audit-test/10-deno.ipynb \
+            E2E_SPEC=e2e/specs/deno-runtime.spec.js \
+            pnpm test:e2e || FAIL=1
+
+          start_driver
+          NOTEBOOK_PATH=crates/notebook/fixtures/audit-test/1-vanilla.ipynb \
+            E2E_SPEC=e2e/specs/save-dirty-state.spec.js \
             pnpm test:e2e || FAIL=1
 
           # Cleanup

--- a/contributing/e2e.md
+++ b/contributing/e2e.md
@@ -113,6 +113,8 @@ Use a regular test when:
 | `7-environment-yml.ipynb` | `environment-yml-detection.spec.js` | environment.yml detection |
 | `8-multi-cell.ipynb` | `run-all-cells.spec.js` | Run All / Restart & Run All |
 | `9-html-output.ipynb` | `iframe-isolation.spec.js` | Iframe sandbox security |
+| `10-deno.ipynb` | `deno-runtime.spec.js` | Deno kernel start + TypeScript execution |
+| `1-vanilla.ipynb` | `save-dirty-state.spec.js` | Save button dirty state indicator |
 
 Multiple specs can reuse the same fixture notebook — each gets its own fresh app instance.
 

--- a/crates/notebook/fixtures/audit-test/10-deno.ipynb
+++ b/crates/notebook/fixtures/audit-test/10-deno.ipynb
@@ -1,0 +1,22 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "console.log(\"deno:ok\");\n",
+    "console.log(`version:${Deno.version.deno}`);"
+   ]
+  }
+ ],
+ "metadata": {
+  "runt": {
+   "runtime": "deno"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/e2e/dev.sh
+++ b/e2e/dev.sh
@@ -265,6 +265,14 @@ case "${1:-help}" in
     fi
     echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
+    $0 test-fixture \
+      crates/notebook/fixtures/audit-test/10-deno.ipynb \
+      e2e/specs/deno-runtime.spec.js || FAIL=1
+
+    $0 test-fixture \
+      crates/notebook/fixtures/audit-test/1-vanilla.ipynb \
+      e2e/specs/save-dirty-state.spec.js || FAIL=1
+
     exit $FAIL
     ;;
 

--- a/e2e/specs/alt-enter-execute-insert.spec.js
+++ b/e2e/specs/alt-enter-execute-insert.spec.js
@@ -1,0 +1,74 @@
+/**
+ * E2E Test: Alt+Enter (Execute and Insert Cell)
+ *
+ * Tests that Alt+Enter in a code cell:
+ * 1. Executes the current cell
+ * 2. Inserts a new empty code cell below
+ */
+
+import { browser, expect } from "@wdio/globals";
+import { waitForAppReady, typeSlowly, setupCodeCell } from "../helpers.js";
+
+describe("Alt+Enter Execute and Insert", () => {
+  before(async () => {
+    await waitForAppReady();
+    console.log("Page title:", await browser.getTitle());
+  });
+
+  it("should execute cell and insert new cell below on Alt+Enter", async () => {
+    // Setup: get or create a code cell, clear its content
+    const codeCell = await setupCodeCell();
+
+    // Type code that produces output
+    await typeSlowly('print("alt-enter-test")');
+    await browser.pause(300);
+
+    // Count cells before
+    const cellsBefore = await $$('[data-cell-type="code"]');
+    const countBefore = cellsBefore.length;
+    console.log("Cells before Alt+Enter:", countBefore);
+
+    // Press Alt+Enter
+    await browser.keys(["Alt", "Enter"]);
+
+    // Wait for the new cell to be created
+    await browser.waitUntil(
+      async () => {
+        const cells = await $$('[data-cell-type="code"]');
+        return cells.length === countBefore + 1;
+      },
+      {
+        timeout: 5000,
+        interval: 200,
+        timeoutMsg: "New cell was not inserted after Alt+Enter",
+      },
+    );
+
+    const cellsAfter = await $$('[data-cell-type="code"]');
+    console.log("Cells after Alt+Enter:", cellsAfter.length);
+    expect(cellsAfter.length).toBe(countBefore + 1);
+
+    // Wait for execution output in the original cell (includes kernel startup time)
+    await browser.waitUntil(
+      async () => {
+        const output = await codeCell.$('[data-slot="ansi-stream-output"]');
+        if (!(await output.isExisting())) return false;
+        const text = await output.getText();
+        return text.includes("alt-enter-test");
+      },
+      {
+        timeout: 90000,
+        interval: 500,
+        timeoutMsg: "Cell did not produce output after Alt+Enter execution",
+      },
+    );
+
+    const outputText = await codeCell
+      .$('[data-slot="ansi-stream-output"]')
+      .getText();
+    console.log("Output:", outputText);
+    expect(outputText).toContain("alt-enter-test");
+
+    console.log("Alt+Enter: executed cell and inserted new cell");
+  });
+});

--- a/e2e/specs/deno-runtime.spec.js
+++ b/e2e/specs/deno-runtime.spec.js
@@ -1,0 +1,49 @@
+/**
+ * E2E Test: Deno Runtime (Fixture #10)
+ *
+ * Opens a notebook with runtime="deno" in metadata.
+ * Verifies:
+ *   - The app loads and shows the Deno runtime badge
+ *   - The Deno kernel starts successfully
+ *   - TypeScript code executes and produces output
+ *
+ * Requires: NOTEBOOK_PATH=crates/notebook/fixtures/audit-test/10-deno.ipynb
+ */
+
+import { browser, expect } from "@wdio/globals";
+import {
+  waitForAppReady,
+  executeFirstCell,
+  waitForOutputContaining,
+} from "../helpers.js";
+
+describe("Deno Runtime", () => {
+  before(async () => {
+    await waitForAppReady();
+    console.log("Page title:", await browser.getTitle());
+  });
+
+  it("should show the Deno runtime badge in the toolbar", async () => {
+    const isDenoBadge = await browser.execute(() => {
+      return !!document.querySelector('[title="Deno/TypeScript notebook"]');
+    });
+    expect(isDenoBadge).toBe(true);
+    console.log("Deno runtime badge visible");
+  });
+
+  it("should start Deno kernel and execute TypeScript code", async () => {
+    const codeCell = await executeFirstCell();
+    console.log("Triggered execution");
+
+    const outputText = await waitForOutputContaining(
+      codeCell,
+      "deno:ok",
+      120000,
+    );
+    console.log("Output:", outputText);
+
+    expect(outputText).toContain("deno:ok");
+    expect(outputText).toContain("version:");
+    console.log("Deno kernel execution verified");
+  });
+});

--- a/e2e/specs/keyboard-navigation.spec.js
+++ b/e2e/specs/keyboard-navigation.spec.js
@@ -1,0 +1,175 @@
+/**
+ * E2E Test: Keyboard Navigation Between Cells
+ *
+ * Tests ArrowUp/ArrowDown navigation between cells:
+ * - ArrowDown at end of content moves focus to the next cell (cursor at start)
+ * - ArrowUp at position 0 moves focus to the previous cell (cursor at end)
+ * - Arrow keys in the middle of content do NOT cross cell boundaries
+ *
+ * Focus detection: Types a unique marker character after navigation and checks
+ * which cell's editor contains it. This works reliably in wry where
+ * .cm-focused CSS class may not update.
+ */
+
+import { browser, expect } from "@wdio/globals";
+import os from "node:os";
+import { waitForAppReady, typeSlowly } from "../helpers.js";
+
+const MOD_KEY = os.platform() === "darwin" ? "Meta" : "Control";
+
+/**
+ * Get the text content of a cell's CodeMirror editor by index.
+ */
+async function getCellEditorText(cellIndex) {
+  return await browser.execute((idx) => {
+    const cells = document.querySelectorAll('[data-cell-type="code"]');
+    const cell = cells[idx];
+    if (!cell) return null;
+    const cmContent = cell.querySelector(".cm-content");
+    return cmContent ? cmContent.textContent : null;
+  }, cellIndex);
+}
+
+describe("Keyboard Navigation", () => {
+  let cell1Index;
+  let cell2Index;
+
+  before(async () => {
+    await waitForAppReady();
+    console.log("Page title:", await browser.getTitle());
+
+    // Count existing cells so we know our offset
+    const existingCells = await $$('[data-cell-type="code"]');
+    const offset = existingCells.length;
+
+    // Add 2 fresh code cells at the end
+    const addCodeButton = await $('[data-testid="add-code-cell-button"]');
+    await addCodeButton.click();
+    await browser.pause(300);
+    await addCodeButton.click();
+    await browser.pause(300);
+
+    cell1Index = offset;
+    cell2Index = offset + 1;
+
+    // Type known content in cell 1
+    const cells1 = await $$('[data-cell-type="code"]');
+    const editor1 = await cells1[cell1Index].$('.cm-content[contenteditable="true"]');
+    await editor1.waitForExist({ timeout: 5000 });
+    await editor1.click();
+    await browser.pause(200);
+    await browser.keys([MOD_KEY, "a"]);
+    await browser.pause(100);
+    await typeSlowly("AAA");
+    await browser.pause(200);
+
+    // Type known content in cell 2
+    const cells2 = await $$('[data-cell-type="code"]');
+    const editor2 = await cells2[cell2Index].$('.cm-content[contenteditable="true"]');
+    await editor2.waitForExist({ timeout: 5000 });
+    await editor2.click();
+    await browser.pause(200);
+    await browser.keys([MOD_KEY, "a"]);
+    await browser.pause(100);
+    await typeSlowly("BBB");
+    await browser.pause(200);
+
+    const text1 = await getCellEditorText(cell1Index);
+    const text2 = await getCellEditorText(cell2Index);
+    console.log("Cell 1 text:", JSON.stringify(text1), "Cell 2 text:", JSON.stringify(text2));
+  });
+
+  it("should navigate down from cell 1 to cell 2 with ArrowDown at end", async () => {
+    // Focus cell 1, move cursor to end
+    const cells = await $$('[data-cell-type="code"]');
+    const editor1 = await cells[cell1Index].$('.cm-content[contenteditable="true"]');
+    await editor1.click();
+    await browser.pause(200);
+    await browser.keys([MOD_KEY, "a"]);
+    await browser.pause(100);
+    await browser.keys(["ArrowRight"]); // deselect, cursor at end
+    await browser.pause(200);
+
+    // Press ArrowDown — should move focus to cell 2
+    await browser.keys(["ArrowDown"]);
+    await browser.pause(300);
+
+    // Type a marker to verify which cell has focus
+    await typeSlowly("X");
+    await browser.pause(200);
+
+    // Cell 2 should now contain the marker
+    const text2 = await getCellEditorText(cell2Index);
+    const text1 = await getCellEditorText(cell1Index);
+    console.log("After ArrowDown+X: cell1:", JSON.stringify(text1), "cell2:", JSON.stringify(text2));
+    expect(text2).toContain("X");
+    expect(text1).not.toContain("X");
+
+    // Clean up: remove the marker from cell 2
+    await browser.keys(["Backspace"]);
+    await browser.pause(100);
+  });
+
+  it("should navigate up from cell 2 to cell 1 with ArrowUp at start", async () => {
+    // Focus cell 2, move cursor to start
+    const cells = await $$('[data-cell-type="code"]');
+    const editor2 = await cells[cell2Index].$('.cm-content[contenteditable="true"]');
+    await editor2.click();
+    await browser.pause(200);
+    await browser.keys([MOD_KEY, "a"]);
+    await browser.pause(100);
+    await browser.keys(["ArrowLeft"]); // deselect, cursor at start (position 0)
+    await browser.pause(200);
+
+    // Press ArrowUp — should move focus to cell 1
+    await browser.keys(["ArrowUp"]);
+    await browser.pause(300);
+
+    // Type a marker to verify which cell has focus
+    await typeSlowly("Y");
+    await browser.pause(200);
+
+    // Cell 1 should now contain the marker
+    const text1 = await getCellEditorText(cell1Index);
+    const text2 = await getCellEditorText(cell2Index);
+    console.log("After ArrowUp+Y: cell1:", JSON.stringify(text1), "cell2:", JSON.stringify(text2));
+    expect(text1).toContain("Y");
+    expect(text2).not.toContain("Y");
+
+    // Clean up: remove the marker from cell 1
+    await browser.keys(["Backspace"]);
+    await browser.pause(100);
+  });
+
+  it("should NOT navigate when cursor is in the middle of content", async () => {
+    // Focus cell 1, move cursor to middle (between first and second char)
+    const cells = await $$('[data-cell-type="code"]');
+    const editor1 = await cells[cell1Index].$('.cm-content[contenteditable="true"]');
+    await editor1.click();
+    await browser.pause(200);
+    await browser.keys([MOD_KEY, "a"]);
+    await browser.pause(100);
+    await browser.keys(["ArrowLeft"]); // cursor at start
+    await browser.pause(100);
+    await browser.keys(["ArrowRight"]); // cursor at position 1 (middle)
+    await browser.pause(200);
+
+    // Press ArrowDown — should NOT move focus (cursor not at end)
+    await browser.keys(["ArrowDown"]);
+    await browser.pause(300);
+
+    // Type a marker — should go into cell 1 (focus stayed)
+    await typeSlowly("Z");
+    await browser.pause(200);
+
+    const text1 = await getCellEditorText(cell1Index);
+    const text2 = await getCellEditorText(cell2Index);
+    console.log("After mid-content ArrowDown+Z: cell1:", JSON.stringify(text1), "cell2:", JSON.stringify(text2));
+    expect(text1).toContain("Z");
+    expect(text2).not.toContain("Z");
+
+    // Clean up
+    await browser.keys(["Backspace"]);
+    await browser.pause(100);
+  });
+});

--- a/e2e/specs/save-dirty-state.spec.js
+++ b/e2e/specs/save-dirty-state.spec.js
@@ -1,0 +1,108 @@
+/**
+ * E2E Test: Save / Cmd+S and Dirty State (Fixture)
+ *
+ * Opens a vanilla notebook, edits a cell, verifies the dirty bullet
+ * appears on the save button, saves with Cmd+S, verifies the bullet clears.
+ *
+ * Daemon-independent: only tests observable DOM effects of actions.
+ *
+ * Note: Cmd+S writes the modified notebook to disk. In CI this is fine
+ * (fresh checkout each run). Locally, `git checkout` restores the fixture.
+ *
+ * Requires: NOTEBOOK_PATH=crates/notebook/fixtures/audit-test/1-vanilla.ipynb
+ */
+
+import { browser, expect } from "@wdio/globals";
+import os from "node:os";
+import { waitForAppReady, typeSlowly } from "../helpers.js";
+
+const MOD_KEY = os.platform() === "darwin" ? "Meta" : "Control";
+
+/**
+ * Check whether the dirty bullet is visible inside the save button.
+ * The bullet is rendered as <span class="text-[10px]">&bull;</span> (U+2022).
+ */
+async function isDirtyBulletVisible() {
+  return await browser.execute(() => {
+    const saveBtn = document.querySelector('[data-testid="save-button"]');
+    if (!saveBtn) return false;
+    const spans = saveBtn.querySelectorAll("span");
+    for (const span of spans) {
+      if (span.textContent === "\u2022") return true;
+    }
+    return false;
+  });
+}
+
+describe("Save and Dirty State", () => {
+  before(async () => {
+    await waitForAppReady();
+    console.log("Page title:", await browser.getTitle());
+  });
+
+  it("should show dirty bullet after editing a cell", async () => {
+    // Focus the first cell editor
+    const codeCell = await $('[data-cell-type="code"]');
+    await codeCell.waitForExist({ timeout: 5000 });
+    const editor = await codeCell.$('.cm-content[contenteditable="true"]');
+    await editor.waitForExist({ timeout: 5000 });
+    await editor.click();
+    await browser.pause(200);
+
+    // Move to end of content
+    await browser.keys([MOD_KEY, "a"]);
+    await browser.pause(100);
+    await browser.keys(["ArrowRight"]);
+    await browser.pause(100);
+
+    // Type something to make the notebook dirty
+    await typeSlowly(" # edited");
+    await browser.pause(300);
+
+    // Wait for the dirty bullet to appear
+    await browser.waitUntil(async () => await isDirtyBulletVisible(), {
+      timeout: 5000,
+      interval: 200,
+      timeoutMsg: "Dirty bullet did not appear after editing",
+    });
+
+    console.log("Dirty bullet visible after editing");
+  });
+
+  it("should clear dirty bullet after Cmd+S", async () => {
+    // Press Cmd+S / Ctrl+S
+    await browser.keys([MOD_KEY, "s"]);
+
+    // Wait for the dirty bullet to disappear
+    await browser.waitUntil(async () => !(await isDirtyBulletVisible()), {
+      timeout: 10000,
+      interval: 200,
+      timeoutMsg: "Dirty bullet did not clear after save",
+    });
+
+    console.log("Dirty bullet cleared after Cmd+S");
+  });
+
+  it("should show dirty bullet again after further edits", async () => {
+    // Edit again
+    const codeCell = await $('[data-cell-type="code"]');
+    const editor = await codeCell.$('.cm-content[contenteditable="true"]');
+    await editor.click();
+    await browser.pause(200);
+    await browser.keys([MOD_KEY, "a"]);
+    await browser.pause(100);
+    await browser.keys(["ArrowRight"]);
+    await browser.pause(100);
+    await typeSlowly("!");
+    await browser.pause(300);
+
+    // Verify dirty bullet reappears
+    await browser.waitUntil(async () => await isDirtyBulletVisible(), {
+      timeout: 5000,
+      interval: 200,
+      timeoutMsg: "Dirty bullet did not reappear after second edit",
+    });
+
+    console.log("Dirty state re-asserted after further edits");
+  });
+});

--- a/e2e/wdio.conf.js
+++ b/e2e/wdio.conf.js
@@ -41,6 +41,8 @@ const FIXTURE_SPECS = [
   "run-all-cells.spec.js",
   "iframe-isolation.spec.js",
   "settings-panel.spec.js",
+  "deno-runtime.spec.js",
+  "save-dirty-state.spec.js",
 ];
 
 export const config = {


### PR DESCRIPTION
Add comprehensive E2E test coverage for Deno runtime execution and critical user interactions. 

The test suite includes four new fixture and regular specs covering:
- **Deno runtime execution** (new fixture #10): Verifies kernel startup and TypeScript code execution, filling the largest coverage gap (zero Deno E2E tests existed)
- **Save button dirty state** (fixture test): Tests the dirty indicator bullet appearing on edit and clearing on Cmd+S
- **Keyboard cell navigation** (regular tests): Validates ArrowUp/Down cross-cell movement and mid-content cursor handling
- **Alt+Enter execute-and-insert** (regular test): Confirms execute + insert-below cell behavior

Also includes CI configuration to install Deno in the E2E job and updated documentation.

## Verification

Run the E2E test suite locally to validate:
- Deno fixture test: `./e2e/dev.sh test-fixture crates/notebook/fixtures/audit-test/10-deno.ipynb e2e/specs/deno-runtime.spec.js`
- Save fixture test: `./e2e/dev.sh test-fixture crates/notebook/fixtures/audit-test/1-vanilla.ipynb e2e/specs/save-dirty-state.spec.js`
- Regular tests: `./e2e/dev.sh test all` (now includes keyboard-navigation and alt-enter specs)

_PR submitted by @rgbkrk's agent, Quill_