### PR TITLE
Fix formatting in Deno E2E specs for Biome CI

### DIFF
--- a/e2e/specs/alt-enter-execute-insert.spec.js
+++ b/e2e/specs/alt-enter-execute-insert.spec.js
@@ -7,7 +7,7 @@
  */
 
 import { browser, expect } from "@wdio/globals";
-import { waitForAppReady, typeSlowly, setupCodeCell } from "../helpers.js";
+import { setupCodeCell, typeSlowly, waitForAppReady } from "../helpers.js";
 
 describe("Alt+Enter Execute and Insert", () => {
   before(async () => {

--- a/e2e/specs/deno-runtime.spec.js
+++ b/e2e/specs/deno-runtime.spec.js
@@ -12,8 +12,8 @@
 
 import { browser, expect } from "@wdio/globals";
 import {
-  waitForAppReady,
   executeFirstCell,
+  waitForAppReady,
   waitForOutputContaining,
 } from "../helpers.js";
 

--- a/e2e/specs/keyboard-navigation.spec.js
+++ b/e2e/specs/keyboard-navigation.spec.js
@@ -11,9 +11,9 @@
  * .cm-focused CSS class may not update.
  */
 
-import { browser, expect } from "@wdio/globals";
 import os from "node:os";
-import { waitForAppReady, typeSlowly } from "../helpers.js";
+import { browser, expect } from "@wdio/globals";
+import { typeSlowly, waitForAppReady } from "../helpers.js";
 
 const MOD_KEY = os.platform() === "darwin" ? "Meta" : "Control";
 
@@ -54,7 +54,9 @@ describe("Keyboard Navigation", () => {
 
     // Type known content in cell 1
     const cells1 = await $$('[data-cell-type="code"]');
-    const editor1 = await cells1[cell1Index].$('.cm-content[contenteditable="true"]');
+    const editor1 = await cells1[cell1Index].$(
+      '.cm-content[contenteditable="true"]',
+    );
     await editor1.waitForExist({ timeout: 5000 });
     await editor1.click();
     await browser.pause(200);
@@ -65,7 +67,9 @@ describe("Keyboard Navigation", () => {
 
     // Type known content in cell 2
     const cells2 = await $$('[data-cell-type="code"]');
-    const editor2 = await cells2[cell2Index].$('.cm-content[contenteditable="true"]');
+    const editor2 = await cells2[cell2Index].$(
+      '.cm-content[contenteditable="true"]',
+    );
     await editor2.waitForExist({ timeout: 5000 });
     await editor2.click();
     await browser.pause(200);
@@ -76,13 +80,20 @@ describe("Keyboard Navigation", () => {
 
     const text1 = await getCellEditorText(cell1Index);
     const text2 = await getCellEditorText(cell2Index);
-    console.log("Cell 1 text:", JSON.stringify(text1), "Cell 2 text:", JSON.stringify(text2));
+    console.log(
+      "Cell 1 text:",
+      JSON.stringify(text1),
+      "Cell 2 text:",
+      JSON.stringify(text2),
+    );
   });
 
   it("should navigate down from cell 1 to cell 2 with ArrowDown at end", async () => {
     // Focus cell 1, move cursor to end
     const cells = await $$('[data-cell-type="code"]');
-    const editor1 = await cells[cell1Index].$('.cm-content[contenteditable="true"]');
+    const editor1 = await cells[cell1Index].$(
+      '.cm-content[contenteditable="true"]',
+    );
     await editor1.click();
     await browser.pause(200);
     await browser.keys([MOD_KEY, "a"]);
@@ -101,7 +112,12 @@ describe("Keyboard Navigation", () => {
     // Cell 2 should now contain the marker
     const text2 = await getCellEditorText(cell2Index);
     const text1 = await getCellEditorText(cell1Index);
-    console.log("After ArrowDown+X: cell1:", JSON.stringify(text1), "cell2:", JSON.stringify(text2));
+    console.log(
+      "After ArrowDown+X: cell1:",
+      JSON.stringify(text1),
+      "cell2:",
+      JSON.stringify(text2),
+    );
     expect(text2).toContain("X");
     expect(text1).not.toContain("X");
 
@@ -113,7 +129,9 @@ describe("Keyboard Navigation", () => {
   it("should navigate up from cell 2 to cell 1 with ArrowUp at start", async () => {
     // Focus cell 2, move cursor to start
     const cells = await $$('[data-cell-type="code"]');
-    const editor2 = await cells[cell2Index].$('.cm-content[contenteditable="true"]');
+    const editor2 = await cells[cell2Index].$(
+      '.cm-content[contenteditable="true"]',
+    );
     await editor2.click();
     await browser.pause(200);
     await browser.keys([MOD_KEY, "a"]);
@@ -132,7 +150,12 @@ describe("Keyboard Navigation", () => {
     // Cell 1 should now contain the marker
     const text1 = await getCellEditorText(cell1Index);
     const text2 = await getCellEditorText(cell2Index);
-    console.log("After ArrowUp+Y: cell1:", JSON.stringify(text1), "cell2:", JSON.stringify(text2));
+    console.log(
+      "After ArrowUp+Y: cell1:",
+      JSON.stringify(text1),
+      "cell2:",
+      JSON.stringify(text2),
+    );
     expect(text1).toContain("Y");
     expect(text2).not.toContain("Y");
 
@@ -144,7 +167,9 @@ describe("Keyboard Navigation", () => {
   it("should NOT navigate when cursor is in the middle of content", async () => {
     // Focus cell 1, move cursor to middle (between first and second char)
     const cells = await $$('[data-cell-type="code"]');
-    const editor1 = await cells[cell1Index].$('.cm-content[contenteditable="true"]');
+    const editor1 = await cells[cell1Index].$(
+      '.cm-content[contenteditable="true"]',
+    );
     await editor1.click();
     await browser.pause(200);
     await browser.keys([MOD_KEY, "a"]);
@@ -164,7 +189,12 @@ describe("Keyboard Navigation", () => {
 
     const text1 = await getCellEditorText(cell1Index);
     const text2 = await getCellEditorText(cell2Index);
-    console.log("After mid-content ArrowDown+Z: cell1:", JSON.stringify(text1), "cell2:", JSON.stringify(text2));
+    console.log(
+      "After mid-content ArrowDown+Z: cell1:",
+      JSON.stringify(text1),
+      "cell2:",
+      JSON.stringify(text2),
+    );
     expect(text1).toContain("Z");
     expect(text2).not.toContain("Z");
 

--- a/e2e/specs/save-dirty-state.spec.js
+++ b/e2e/specs/save-dirty-state.spec.js
@@ -12,9 +12,9 @@
  * Requires: NOTEBOOK_PATH=crates/notebook/fixtures/audit-test/1-vanilla.ipynb
  */
 
-import { browser, expect } from "@wdio/globals";
 import os from "node:os";
-import { waitForAppReady, typeSlowly } from "../helpers.js";
+import { browser } from "@wdio/globals";
+import { typeSlowly, waitForAppReady } from "../helpers.js";
 
 const MOD_KEY = os.platform() === "darwin" ? "Meta" : "Control";
 


### PR DESCRIPTION
## Summary
- Fix import ordering in 3 specs added by #205 (deno-runtime, alt-enter, keyboard-navigation, save-dirty-state)
- Remove unused `expect` import from save-dirty-state.spec.js
- Apply Biome formatting to keyboard-navigation.spec.js

These specs merged after the formatting enforcement PR (#206) and didn't have the Biome check yet.