### PR TITLE
bump the daemon's version number

### DIFF
--- a/crates/runtimed/Cargo.toml
+++ b/crates/runtimed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed"
-version = "0.1.0"
+version = "0.1.0-dev.1"
 edition = "2021"
 description = "Central daemon for managing Jupyter runtimes and prewarmed environments"
 repository = "https://github.com/runtimed/runt"


### PR DESCRIPTION
With dev builds we upgrade the daemon in place because the version string is `CARGO_PKG_VERSION+GIT_COMMIT`, and the upgrade logic in `ensure_daemon_running` does an exact string comparison. Since the git commit hash changes every commit. For a release build, bumping the `CARGO_PKG_VERSION` ensures any previously installed `0.1.0` daemon gets replaced.