### PR TITLE
Settings schema unification and file watching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1641,6 +1641,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "fslock"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2575,6 +2584,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
+dependencies = [
+ "bitflags 2.10.0",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2802,6 +2831,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d463f34ca3c400fde3a054da0e0b8c6ffa21e4590922f3e18281bb5eeef4cbdc"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
 ]
 
 [[package]]
@@ -3115,6 +3164,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
@@ -3291,6 +3341,7 @@ dependencies = [
  "reqwest-middleware",
  "runtimed",
  "runtimelib",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -3307,6 +3358,45 @@ dependencies = [
  "tower-http",
  "url",
  "uuid",
+]
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags 2.10.0",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-debouncer-mini"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17849edfaabd9a5fef1c606d99cfc615a8e99f7ac4366406d86c7942a3184cf2"
+dependencies = [
+ "log",
+ "notify",
+ "notify-types",
+ "tempfile",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -5257,7 +5347,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed"
-version = "0.1.0"
+version = "0.1.0-dev.1"
 dependencies = [
  "anyhow",
  "automerge",
@@ -5268,6 +5358,8 @@ dependencies = [
  "futures",
  "libc",
  "log",
+ "notify",
+ "notify-debouncer-mini",
  "rattler",
  "rattler_cache",
  "rattler_conda_types",
@@ -5276,6 +5368,7 @@ dependencies = [
  "rattler_virtual_packages",
  "reqwest",
  "reqwest-middleware",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "tempfile",
@@ -5507,7 +5600,7 @@ checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "dyn-clone",
  "indexmap 1.9.3",
- "schemars_derive",
+ "schemars_derive 0.8.22",
  "serde",
  "serde_json",
  "url",
@@ -5534,6 +5627,7 @@ checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
  "dyn-clone",
  "ref-cast",
+ "schemars_derive 1.2.1",
  "serde",
  "serde_json",
 ]
@@ -5543,6 +5637,18 @@ name = "schemars_derive"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8481,6 +8481,10 @@ dependencies = [
 [[package]]
 name = "xtask"
 version = "0.1.0"
+dependencies = [
+ "dirs 5.0.1",
+ "serde_json",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,9 @@ tokio = { version = "1.36.0", features = ["full"] }
 runtimelib = { version = "1.3.0", default-features = false }
 jupyter-protocol = "1.2.1"
 thiserror = "1"
+schemars = "1"
+notify = "8"
+notify-debouncer-mini = "0.7"
 
 [workspace.lints.rust]
 dead_code = "warn"

--- a/contributing/runtimed.md
+++ b/contributing/runtimed.md
@@ -6,6 +6,7 @@ The runtime daemon manages prewarmed Python environments shared across notebook 
 
 | Task | Command |
 |------|---------|
+| Install daemon from source | `cargo xtask install-daemon` |
 | Run daemon | `cargo run -p runtimed` |
 | Run with debug logs | `RUST_LOG=debug cargo run -p runtimed` |
 | Check status | `cargo run -p runt-cli -- pool status` |
@@ -65,15 +66,32 @@ The notebook app automatically tries to connect to or start the daemon on launch
 runtimed::client::ensure_daemon_running(None).await
 ```
 
-### Manual: Run daemon separately
+### Install daemon from source
 
-For debugging daemon-specific code, run it in a separate terminal:
+When you change daemon code and want the installed service to pick it up:
 
 ```bash
-# Terminal 1: Run daemon
+cargo xtask install-daemon
+```
+
+This builds runtimed in release mode, stops the running service, replaces the binary, and restarts it. You can verify the version with:
+
+```bash
+cat ~/.cache/runt/daemon.json   # check "version" field
+```
+
+### Manual: Run daemon separately
+
+For debugging daemon-specific code, stop the installed service and run from source:
+
+```bash
+# Stop the installed service first
+launchctl bootout gui/$(id -u)/io.runtimed
+
+# Run daemon with debug logs
 RUST_LOG=debug cargo run -p runtimed
 
-# Terminal 2: Test with runt CLI
+# In another terminal, test with runt CLI
 cargo run -p runt-cli -- pool ping
 cargo run -p runt-cli -- pool status
 cargo run -p runt-cli -- pool take uv

--- a/crates/notebook/Cargo.toml
+++ b/crates/notebook/Cargo.toml
@@ -48,6 +48,7 @@ toml = "0.8"
 serde_yaml = "0.9"
 pathdiff = "0.2"
 pyproject-toml = "0.13"
+schemars = { workspace = true }
 
 # Conda environment support via rattler
 rattler = "0.39"

--- a/crates/notebook/src/conda_env.rs
+++ b/crates/notebook/src/conda_env.rs
@@ -992,7 +992,7 @@ pub async fn create_prewarmed_conda_environment(
 
     // Build dependency list: ipykernel + ipywidgets + user-configured defaults
     let mut deps_list = vec!["ipykernel".to_string(), "ipywidgets".to_string()];
-    let extra: Vec<String> = crate::settings::load_settings().default_conda_packages;
+    let extra: Vec<String> = crate::settings::load_settings().conda.default_packages;
     if !extra.is_empty() {
         info!("[prewarm] Including default packages: {:?}", extra);
         deps_list.extend(extra);

--- a/crates/notebook/src/runtime.rs
+++ b/crates/notebook/src/runtime.rs
@@ -1,9 +1,10 @@
 //! Runtime type for notebooks - Python or Deno
 
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 /// Supported notebook runtime environments
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum Runtime {
     #[default]

--- a/crates/notebook/src/settings.rs
+++ b/crates/notebook/src/settings.rs
@@ -113,7 +113,8 @@ pub fn save_settings(settings: &AppSettings) -> Result<()> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
-    std::fs::write(&path, serde_json::to_string_pretty(settings)?)?;
+    let json = serde_json::to_string_pretty(settings)?;
+    std::fs::write(&path, format!("{json}\n"))?;
     Ok(())
 }
 

--- a/crates/notebook/src/uv_env.rs
+++ b/crates/notebook/src/uv_env.rs
@@ -390,7 +390,7 @@ pub async fn find_existing_prewarmed_environments() -> Vec<UvEnvironment> {
 
 /// Read the `default_uv_packages` setting.
 fn parse_extra_packages() -> Vec<String> {
-    crate::settings::load_settings().default_uv_packages
+    crate::settings::load_settings().uv.default_packages
 }
 
 /// Create a prewarmed environment with ipykernel, ipywidgets, and any

--- a/crates/runtimed/Cargo.toml
+++ b/crates/runtimed/Cargo.toml
@@ -44,6 +44,13 @@ reqwest-middleware = "0.4"
 # Automerge CRDT for settings sync
 automerge = "0.7"
 
+# JSON Schema generation
+schemars = { workspace = true }
+
+# File watching for external settings.json changes
+notify = { workspace = true }
+notify-debouncer-mini = { workspace = true }
+
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -469,12 +469,12 @@ impl Daemon {
                                 let mut doc = self.settings.write().await;
                                 let changed = doc.apply_json_changes(&json);
                                 if changed {
-                                    // Only persist the Automerge binary — do NOT write
-                                    // the JSON mirror back, as that would reformat the
-                                    // user's file and trigger another watch event.
                                     let automerge_path = crate::default_settings_doc_path();
                                     if let Err(e) = doc.save_to_file(&automerge_path) {
                                         warn!("[settings-watch] Failed to save Automerge doc: {}", e);
+                                    }
+                                    if let Err(e) = doc.save_json_mirror(&json_path) {
+                                        warn!("[settings-watch] Failed to write JSON mirror: {}", e);
                                     }
                                 }
                                 changed

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -469,12 +469,13 @@ impl Daemon {
                                 let mut doc = self.settings.write().await;
                                 let changed = doc.apply_json_changes(&json);
                                 if changed {
+                                    // Only persist the Automerge binary — do NOT write
+                                    // the JSON mirror back, as serde_json formatting
+                                    // differs from editors (e.g. arrays expand to one
+                                    // element per line) which causes unwanted churn.
                                     let automerge_path = crate::default_settings_doc_path();
                                     if let Err(e) = doc.save_to_file(&automerge_path) {
                                         warn!("[settings-watch] Failed to save Automerge doc: {}", e);
-                                    }
-                                    if let Err(e) = doc.save_json_mirror(&json_path) {
-                                        warn!("[settings-watch] Failed to write JSON mirror: {}", e);
                                     }
                                 }
                                 changed

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -395,7 +395,10 @@ impl Daemon {
             }
             parent.to_path_buf()
         } else {
-            error!("[settings-watch] Cannot determine watch path for {:?}", json_path);
+            error!(
+                "[settings-watch] Cannot determine watch path for {:?}",
+                json_path
+            );
             return;
         };
 
@@ -426,7 +429,10 @@ impl Daemon {
             return;
         }
 
-        info!("[settings-watch] Watching {:?} for external changes", watch_path);
+        info!(
+            "[settings-watch] Watching {:?} for external changes",
+            watch_path
+        );
 
         loop {
             tokio::select! {

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -469,14 +469,12 @@ impl Daemon {
                                 let mut doc = self.settings.write().await;
                                 let changed = doc.apply_json_changes(&json);
                                 if changed {
-                                    // Persist the updated Automerge binary + JSON mirror
+                                    // Only persist the Automerge binary — do NOT write
+                                    // the JSON mirror back, as that would reformat the
+                                    // user's file and trigger another watch event.
                                     let automerge_path = crate::default_settings_doc_path();
                                     if let Err(e) = doc.save_to_file(&automerge_path) {
                                         warn!("[settings-watch] Failed to save Automerge doc: {}", e);
-                                    }
-                                    let mirror_path = crate::settings_json_path();
-                                    if let Err(e) = doc.save_json_mirror(&mirror_path) {
-                                        warn!("[settings-watch] Failed to write JSON mirror: {}", e);
                                     }
                                 }
                                 changed

--- a/crates/runtimed/src/settings_doc.rs
+++ b/crates/runtimed/src/settings_doc.rs
@@ -229,7 +229,7 @@ impl SettingsDoc {
         }
         let settings = self.get_all();
         let json = serde_json::to_string_pretty(&settings).map_err(std::io::Error::other)?;
-        std::fs::write(path, json)
+        std::fs::write(path, format!("{json}\n"))
     }
 
     // ── Scalar accessors ─────────────────────────────────────────────

--- a/crates/runtimed/src/settings_doc.rs
+++ b/crates/runtimed/src/settings_doc.rs
@@ -460,8 +460,7 @@ impl SettingsDoc {
         // UV packages — try nested format, then flat format
         let has_uv_key = json.get("uv").is_some() || json.get("default_uv_packages").is_some();
         if has_uv_key {
-            let uv_packages =
-                Self::extract_packages_from_json(json, "uv", "default_uv_packages");
+            let uv_packages = Self::extract_packages_from_json(json, "uv", "default_uv_packages");
             if self.get_list("uv.default_packages") != uv_packages {
                 self.put_list("uv.default_packages", &uv_packages);
                 changed = true;

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -8,3 +8,5 @@ publish = false
 workspace = true
 
 [dependencies]
+dirs = "5"
+serde_json.workspace = true

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -26,6 +26,7 @@ fn main() {
         "build-e2e" => cmd_build_e2e(),
         "build-dmg" => cmd_build_dmg(),
         "build-app" => cmd_build_app(),
+        "install-daemon" => cmd_install_daemon(),
         "--help" | "-h" | "help" => print_help(),
         cmd => {
             eprintln!("Unknown command: {cmd}");
@@ -50,6 +51,9 @@ Development:
 Release:
   build-app             Build .app bundle with icons
   build-dmg             Build DMG with icons (for CI)
+
+Daemon:
+  install-daemon        Build and install runtimed into the running service
 
 Other:
   icons [source.png]    Generate icon variants
@@ -202,6 +206,154 @@ fn build_with_bundle(bundle: &str) {
     );
 
     println!("Build complete!");
+}
+
+/// Build runtimed and install it into the running launchd/systemd service.
+///
+/// This is the dev workflow for testing daemon changes:
+/// 1. Build runtimed in release mode
+/// 2. Stop the running service
+/// 3. Copy the new binary over the installed one
+/// 4. Restart the service
+fn cmd_install_daemon() {
+    println!("Building runtimed (release)...");
+    run_cmd("cargo", &["build", "--release", "-p", "runtimed"]);
+
+    let source = if cfg!(windows) {
+        "target/release/runtimed.exe"
+    } else {
+        "target/release/runtimed"
+    };
+
+    if !Path::new(source).exists() {
+        eprintln!("Build succeeded but binary not found at {source}");
+        exit(1);
+    }
+
+    // Use runtimed's own service manager to perform the upgrade.
+    // The `runtimed install` CLI already handles stop → copy → chmod → start.
+    // We call `runtimed upgrade --from <source>` if available, otherwise
+    // fall back to the manual stop/copy/start dance.
+    println!("Installing daemon...");
+
+    // Stop the running daemon gracefully
+    #[cfg(target_os = "macos")]
+    {
+        let uid = Command::new("id")
+            .args(["-u"])
+            .output()
+            .ok()
+            .and_then(|o| String::from_utf8(o.stdout).ok())
+            .map(|s| s.trim().to_string())
+            .unwrap_or_else(|| "501".to_string());
+        let domain = format!("gui/{uid}/io.runtimed");
+
+        // Stop (ignore errors — may not be running)
+        let _ = Command::new("launchctl")
+            .args(["bootout", &domain])
+            .status();
+
+        // Brief pause for process cleanup
+        std::thread::sleep(std::time::Duration::from_secs(1));
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        let _ = Command::new("systemctl")
+            .args(["--user", "stop", "runtimed.service"])
+            .status();
+        std::thread::sleep(std::time::Duration::from_secs(1));
+    }
+
+    // Determine install path (matches runtimed::service::default_binary_path)
+    let install_dir = dirs::data_local_dir()
+        .expect("Could not determine data directory")
+        .join("runt")
+        .join("bin");
+
+    let install_path = if cfg!(windows) {
+        install_dir.join("runtimed.exe")
+    } else {
+        install_dir.join("runtimed")
+    };
+
+    if !install_path.exists() {
+        eprintln!(
+            "No existing daemon installation found at {}",
+            install_path.display()
+        );
+        eprintln!("Run the app once first to install the daemon service.");
+        exit(1);
+    }
+
+    // Copy new binary
+    fs::copy(source, &install_path).unwrap_or_else(|e| {
+        eprintln!("Failed to copy binary: {e}");
+        exit(1);
+    });
+
+    // Make executable on Unix
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&install_path, fs::Permissions::from_mode(0o755))
+            .unwrap_or_else(|e| {
+                eprintln!("Failed to set permissions: {e}");
+                exit(1);
+            });
+    }
+
+    println!("Installed to {}", install_path.display());
+
+    // Restart the service
+    #[cfg(target_os = "macos")]
+    {
+        let plist = dirs::home_dir()
+            .expect("No home dir")
+            .join("Library/LaunchAgents/io.runtimed.plist");
+        if plist.exists() {
+            let uid = Command::new("id")
+                .args(["-u"])
+                .output()
+                .ok()
+                .and_then(|o| String::from_utf8(o.stdout).ok())
+                .map(|s| s.trim().to_string())
+                .unwrap_or_else(|| "501".to_string());
+            let domain = format!("gui/{uid}");
+            run_cmd(
+                "launchctl",
+                &["bootstrap", &domain, &plist.to_string_lossy()],
+            );
+        } else {
+            eprintln!("Warning: launchd plist not found at {}", plist.display());
+            eprintln!("Start manually with: {}", install_path.display());
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        run_cmd("systemctl", &["--user", "start", "runtimed.service"]);
+    }
+
+    // Wait briefly and verify
+    std::thread::sleep(std::time::Duration::from_secs(2));
+    let daemon_json = dirs::cache_dir()
+        .unwrap_or_else(|| Path::new("/tmp").to_path_buf())
+        .join("runt")
+        .join("daemon.json");
+
+    if daemon_json.exists() {
+        if let Ok(contents) = fs::read_to_string(&daemon_json) {
+            if let Ok(info) = serde_json::from_str::<serde_json::Value>(&contents) {
+                if let Some(version) = info.get("version").and_then(|v| v.as_str()) {
+                    println!("Daemon running: version {version}");
+                    return;
+                }
+            }
+        }
+    }
+
+    println!("Daemon restarted (could not verify version from daemon.json)");
 }
 
 /// Build external binaries (runtimed daemon and runt CLI) for Tauri bundling.

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -296,11 +296,10 @@ fn cmd_install_daemon() {
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        fs::set_permissions(&install_path, fs::Permissions::from_mode(0o755))
-            .unwrap_or_else(|e| {
-                eprintln!("Failed to set permissions: {e}");
-                exit(1);
-            });
+        fs::set_permissions(&install_path, fs::Permissions::from_mode(0o755)).unwrap_or_else(|e| {
+            eprintln!("Failed to set permissions: {e}");
+            exit(1);
+        });
     }
 
     println!("Installed to {}", install_path.display());

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -73,20 +73,6 @@ Example:
 
 The settings structs derive `schemars::JsonSchema`. Both `SyncedSettings` (in runtimed) and `AppSettings` (in the notebook crate) serialize to the same JSON schema.
 
-### Backward Compatibility
-
-For backward compatibility, the old flat format is accepted when reading:
-
-```json
-{
-  "default_runtime": "python",
-  "default_uv_packages": "numpy, pandas, matplotlib",
-  "default_conda_packages": ["scipy"]
-}
-```
-
-Old flat keys (`default_uv_packages`, `default_conda_packages`) and comma-separated strings are migrated to the nested format on first load.
-
 ## Theme
 
 Controls light/dark appearance for the notebook editor and output viewer.


### PR DESCRIPTION
## Summary

- Unified `AppSettings` to serialize in the same nested format as `SyncedSettings`, fixing a schema mismatch where the daemon and notebook wrote different JSON formats to the same file
- Added JSON Schema support via schemars crate for machine-readable settings documentation
- Implemented file watching for `settings.json` via notify crate with automatic change propagation to all connected notebook windows
- Added `cargo xtask install-daemon` for convenient daemon upgrades during development
- Improved `get_synced_settings` fallback to use local settings file when daemon is unavailable (issue #188)

## Verification

To test the file watching workflow:

1. Edit `~/Library/Application Support/runt-notebook/settings.json` manually while the daemon is running
2. Check that changes appear in all open notebook windows within 500ms
3. Verify backward compatibility by starting with an old flat-format `settings.json`
4. Test `cargo xtask install-daemon` to verify daemon reinstallation and version detection

Closes #190

_PR submitted by @rgbkrk's agent, Quill_