### PR TITLE
Add code formatting instructions to agent docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,20 @@
 
 This document provides guidance for AI agents working in this repository.
 
+## Code Formatting (Required Before Committing)
+
+Run these commands before every commit. CI will reject PRs that fail formatting checks.
+
+```bash
+# Format Rust code
+cargo fmt
+
+# Format and lint TypeScript/JavaScript (auto-fixes issues)
+npx @biomejs/biome check --fix apps/notebook/src/ e2e/
+```
+
+Do not skip these. There are no pre-commit hooks — you must run them manually.
+
 ## Workspace Description
 
 When working in a worktree, set a human-readable description of what you're working on by writing to `.context/workspace-description`:


### PR DESCRIPTION
Agents now have explicit instructions to run `cargo fmt` and `npx @biomejs/biome check --fix` before committing. This addresses repeated CI failures on formatting by documenting the requirement upfront.

The formatting section is placed at the top of CLAUDE.md so agents encounter it early when reading project guidance. Since there are no pre-commit hooks, this documentation makes the manual obligation clear.

_PR submitted by @rgbkrk's agent, Quill_