### PR TITLE
Reduce environment panel saturation

### DIFF
--- a/apps/notebook/src/components/CondaDependencyHeader.tsx
+++ b/apps/notebook/src/components/CondaDependencyHeader.tsx
@@ -122,7 +122,7 @@ export function CondaDependencyHeader({
 
   return (
     <div
-      className="border-b bg-emerald-50/50 dark:bg-emerald-950/20"
+      className="border-b bg-emerald-50/30 dark:bg-emerald-950/10"
       data-testid="conda-deps-panel"
     >
       <div className="px-3 py-3">
@@ -135,9 +135,9 @@ export function CondaDependencyHeader({
 
         {/* Environment preparation progress */}
         {envProgress?.isActive && (
-          <div className="mb-3 rounded bg-emerald-500/10 px-2 py-2">
+          <div className="mb-3 rounded bg-muted/80 px-2 py-2">
             <div className="flex items-center justify-between mb-1">
-              <span className="text-xs text-emerald-700 dark:text-emerald-400 truncate">
+              <span className="text-xs text-muted-foreground truncate">
                 {envProgress.statusText}
               </span>
               {envProgress.progress && (
@@ -182,7 +182,7 @@ export function CondaDependencyHeader({
 
         {/* Sync notice */}
         {syncedWhileRunning && (
-          <div className="mb-3 flex items-start gap-2 rounded bg-blue-500/10 px-2 py-1.5 text-xs text-blue-700 dark:text-blue-400">
+          <div className="mb-3 flex items-start gap-2 rounded bg-muted/80 px-2 py-1.5 text-xs text-muted-foreground">
             <Info className="h-3.5 w-3.5 mt-0.5 shrink-0" />
             <span>
               Dependencies synced to environment. New packages can be imported
@@ -204,12 +204,12 @@ export function CondaDependencyHeader({
 
         {/* environment.yml detected banner */}
         {environmentYmlInfo?.has_dependencies && (
-          <div className="mb-3 rounded bg-emerald-500/10 px-2 py-1.5 text-xs text-emerald-700 dark:text-emerald-400">
+          <div className="mb-3 rounded bg-muted/80 px-2 py-1.5 text-xs text-muted-foreground">
             <div className="flex items-center gap-2">
               <FileText className="h-3.5 w-3.5 shrink-0" />
               <span>
                 Using deps from{" "}
-                <code className="rounded bg-emerald-500/20 px-1">
+                <code className="rounded bg-muted px-1">
                   {environmentYmlInfo.relative_path}
                 </code>
                 {environmentYmlInfo.name && (
@@ -222,13 +222,13 @@ export function CondaDependencyHeader({
             {environmentYmlDeps &&
               (environmentYmlDeps.dependencies.length > 0 ||
                 environmentYmlDeps.pip_dependencies.length > 0) && (
-                <div className="mt-2 text-xs text-emerald-700/80 dark:text-emerald-400/80">
+                <div className="mt-2 text-xs text-muted-foreground">
                   {environmentYmlDeps.dependencies.length > 0 && (
                     <div className="flex flex-wrap gap-1 mb-1">
                       {environmentYmlDeps.dependencies.map((dep) => (
                         <span
                           key={dep}
-                          className="rounded bg-emerald-500/20 px-1.5 py-0.5 font-mono"
+                          className="rounded bg-muted px-1.5 py-0.5 font-mono"
                         >
                           {dep}
                         </span>
@@ -241,7 +241,7 @@ export function CondaDependencyHeader({
                       {environmentYmlDeps.pip_dependencies.map((dep) => (
                         <span
                           key={dep}
-                          className="rounded bg-emerald-500/10 px-1.5 py-0.5 font-mono"
+                          className="rounded bg-muted px-1.5 py-0.5 font-mono"
                         >
                           {dep}
                         </span>
@@ -278,12 +278,12 @@ export function CondaDependencyHeader({
 
         {/* pixi.toml detected banner */}
         {pixiInfo?.has_dependencies && (
-          <div className="mb-3 rounded bg-emerald-500/10 px-2 py-1.5 text-xs text-emerald-700 dark:text-emerald-400">
+          <div className="mb-3 rounded bg-muted/80 px-2 py-1.5 text-xs text-muted-foreground">
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-2">
                 <FileText className="h-3.5 w-3.5 shrink-0" />
                 <span>
-                  <code className="rounded bg-emerald-500/20 px-1">
+                  <code className="rounded bg-muted px-1">
                     {pixiInfo.relative_path}
                   </code>
                   {pixiInfo.workspace_name && (

--- a/apps/notebook/src/components/DenoDependencyHeader.tsx
+++ b/apps/notebook/src/components/DenoDependencyHeader.tsx
@@ -17,7 +17,7 @@ export function DenoDependencyHeader({
   onSetFlexibleNpmImports,
 }: DenoDependencyHeaderProps) {
   return (
-    <div className="border-b bg-emerald-500/5 dark:bg-emerald-500/10">
+    <div className="border-b bg-emerald-50/30 dark:bg-emerald-950/10">
       <div className="px-3 py-3">
         {/* Deno badge */}
         <div className="mb-2 flex items-center gap-2">
@@ -39,12 +39,12 @@ export function DenoDependencyHeader({
 
         {/* deno.json detected banner */}
         {denoConfigInfo && (
-          <div className="mb-3 rounded bg-emerald-500/10 px-2 py-1.5 text-xs text-emerald-600 dark:text-emerald-400">
+          <div className="mb-3 rounded bg-muted/80 px-2 py-1.5 text-xs text-muted-foreground">
             <div className="flex items-center gap-2">
               <FileText className="h-3.5 w-3.5 shrink-0" />
               <span>
                 Using{" "}
-                <code className="rounded bg-emerald-500/20 px-1">
+                <code className="rounded bg-muted px-1">
                   {denoConfigInfo.relative_path}
                 </code>
                 {denoConfigInfo.name && (
@@ -55,16 +55,14 @@ export function DenoDependencyHeader({
               </span>
             </div>
             {(denoConfigInfo.has_imports || denoConfigInfo.has_tasks) && (
-              <div className="mt-1.5 flex gap-2 text-emerald-500/80">
+              <div className="mt-1.5 flex gap-2 text-muted-foreground">
                 {denoConfigInfo.has_imports && (
-                  <span className="rounded bg-emerald-500/10 px-1.5 py-0.5">
+                  <span className="rounded bg-muted px-1.5 py-0.5">
                     imports
                   </span>
                 )}
                 {denoConfigInfo.has_tasks && (
-                  <span className="rounded bg-emerald-500/10 px-1.5 py-0.5">
-                    tasks
-                  </span>
+                  <span className="rounded bg-muted px-1.5 py-0.5">tasks</span>
                 )}
               </div>
             )}

--- a/apps/notebook/src/components/DependencyHeader.tsx
+++ b/apps/notebook/src/components/DependencyHeader.tsx
@@ -66,7 +66,10 @@ export function DependencyHeader({
   );
 
   return (
-    <div className="border-b bg-uv/5 dark:bg-uv/10" data-testid="deps-panel">
+    <div
+      className="border-b bg-uv/[0.02] dark:bg-uv/[0.04]"
+      data-testid="deps-panel"
+    >
       <div className="px-3 py-3">
         {/* uv badge */}
         <div className="mb-2 flex items-center gap-2">
@@ -77,7 +80,7 @@ export function DependencyHeader({
 
         {/* Sync notice */}
         {syncedWhileRunning && (
-          <div className="mb-3 flex items-start gap-2 rounded bg-uv/10 px-2 py-1.5 text-xs text-uv">
+          <div className="mb-3 flex items-start gap-2 rounded bg-muted/80 px-2 py-1.5 text-xs text-muted-foreground">
             <Info className="h-3.5 w-3.5 mt-0.5 shrink-0" />
             <span>
               Dependencies synced to environment. New packages can be imported
@@ -136,11 +139,11 @@ export function DependencyHeader({
 
         {/* UV availability notice */}
         {uvAvailable === false && (
-          <div className="mb-3 flex items-start gap-2 rounded bg-uv/10 px-2 py-1.5 text-xs text-uv">
+          <div className="mb-3 flex items-start gap-2 rounded bg-muted/80 px-2 py-1.5 text-xs text-muted-foreground">
             <Info className="h-3.5 w-3.5 mt-0.5 shrink-0" />
             <span>
               <span className="font-medium">uv not found.</span> Install it with{" "}
-              <code className="rounded bg-uv/20 px-1">
+              <code className="rounded bg-muted px-1">
                 curl -LsSf https://astral.sh/uv/install.sh | sh
               </code>
             </span>
@@ -149,12 +152,12 @@ export function DependencyHeader({
 
         {/* pyproject.toml detected banner */}
         {pyprojectInfo?.has_dependencies && (
-          <div className="mb-3 rounded bg-uv/10 px-2 py-1.5 text-xs text-uv">
+          <div className="mb-3 rounded bg-muted/80 px-2 py-1.5 text-xs text-muted-foreground">
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-2">
                 <FileText className="h-3.5 w-3.5 shrink-0" />
                 <span>
-                  <code className="rounded bg-uv/20 px-1">
+                  <code className="rounded bg-muted px-1">
                     {pyprojectInfo.relative_path}
                   </code>
                   {pyprojectInfo.project_name && (
@@ -198,13 +201,13 @@ export function DependencyHeader({
             {pyprojectDeps &&
               (pyprojectDeps.dependencies.length > 0 ||
                 pyprojectDeps.dev_dependencies.length > 0) && (
-                <div className="mt-2 text-xs text-uv/80">
+                <div className="mt-2 text-xs text-muted-foreground">
                   {pyprojectDeps.dependencies.length > 0 && (
                     <div className="flex flex-wrap gap-1 mb-1">
                       {pyprojectDeps.dependencies.map((dep) => (
                         <span
                           key={dep}
-                          className="rounded bg-uv/20 px-1.5 py-0.5 font-mono"
+                          className="rounded bg-muted px-1.5 py-0.5 font-mono"
                         >
                           {dep}
                         </span>
@@ -217,7 +220,7 @@ export function DependencyHeader({
                       {pyprojectDeps.dev_dependencies.map((dep) => (
                         <span
                           key={dep}
-                          className="rounded bg-uv/10 px-1.5 py-0.5 font-mono"
+                          className="rounded bg-muted px-1.5 py-0.5 font-mono"
                         >
                           {dep}
                         </span>
@@ -231,11 +234,11 @@ export function DependencyHeader({
 
         {/* Project-managed state: read-only view when using uv run */}
         {isUsingProjectEnv && (
-          <div className="mb-3 flex items-start gap-2 rounded bg-uv/10 px-2 py-1.5 text-xs text-uv">
+          <div className="mb-3 flex items-start gap-2 rounded bg-muted/80 px-2 py-1.5 text-xs text-muted-foreground">
             <Info className="h-3.5 w-3.5 mt-0.5 shrink-0" />
             <span>
               Managed by{" "}
-              <code className="rounded bg-uv/20 px-1">
+              <code className="rounded bg-muted px-1">
                 {pyprojectInfo?.relative_path ?? "pyproject.toml"}
               </code>{" "}
               — restart kernel to pick up dependency changes.


### PR DESCRIPTION
## Summary

Tone down the colored backgrounds in the UV, Conda, and Deno dependency panels to read as configuration drawers rather than alert banners. Panel containers now have reduced tint opacity, and inner notices (sync status, configuration detected, etc.) use neutral backgrounds instead of vendor colors.

_PR submitted by @rgbkrk's agent, Quill_