### PR TITLE
Add blob store, HTTP server, and unify daemon sockets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5330,6 +5330,7 @@ name = "runt-cli"
 version = "1.3.0-dev.1"
 dependencies = [
  "anyhow",
+ "chrono",
  "clap",
  "dirs 5.0.1",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5327,7 +5327,7 @@ dependencies = [
 
 [[package]]
 name = "runt-cli"
-version = "1.2.0"
+version = "1.3.0-dev.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -5348,7 +5348,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed"
-version = "0.1.0-dev.1"
+version = "0.1.0-dev.2"
 dependencies = [
  "anyhow",
  "automerge",
@@ -5357,6 +5357,10 @@ dependencies = [
  "dirs 5.0.1",
  "env_logger",
  "futures",
+ "hex",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
  "libc",
  "log",
  "notify",
@@ -5372,6 +5376,7 @@ dependencies = [
  "schemars 1.2.1",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
@@ -6017,7 +6022,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "sidecar"
-version = "1.2.0"
+version = "1.3.0-dev.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/contributing/environments.md
+++ b/contributing/environments.md
@@ -307,8 +307,8 @@ graph TB
         4. Python warmup (.pyc)
         5. Write .warmed marker"]
 
-        SYNC["Settings Sync Server
-        ~/.cache/runt/runtimed-sync.sock
+        SYNC["Settings Sync
+        (multiplexed on runtimed.sock)
         Automerge CRDT"]
 
         UWL -->|add| UVPool

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -2997,7 +2997,7 @@ async fn set_synced_setting(key: String, value: serde_json::Value) -> Result<(),
     // Also sync via daemon when available
     #[cfg(unix)]
     {
-        let socket_path = runtimed::default_sync_socket_path();
+        let socket_path = runtimed::default_socket_path();
         match runtimed::sync_client::SyncClient::connect(socket_path).await {
             Ok(mut client) => {
                 client
@@ -3036,7 +3036,7 @@ fn spawn_new_notebook(runtime: Runtime) {
 async fn run_settings_sync(app: tauri::AppHandle) {
     use tauri::Emitter;
 
-    let socket_path = runtimed::default_sync_socket_path();
+    let socket_path = runtimed::default_socket_path();
 
     loop {
         match runtimed::sync_client::SyncClient::connect(socket_path.clone()).await {

--- a/crates/runt/Cargo.toml
+++ b/crates/runt/Cargo.toml
@@ -30,3 +30,4 @@ rpassword = "7"
 dirs = "5"
 tabled = "0.15"
 futures = "0.3"
+chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -953,9 +953,11 @@ async fn pool_command(command: PoolCommands) -> Result<()> {
 
             match get_running_daemon_info() {
                 Some(info) => {
-                    // Verify the daemon is actually responding, not just a stale
-                    // daemon.json left behind after a crash.
-                    let alive = client.ping().await.is_ok();
+                    // Ping the daemon at the endpoint recorded in daemon.json,
+                    // not the default socket path — the daemon may have been
+                    // started with a custom --socket.
+                    let info_client = PoolClient::new(std::path::PathBuf::from(&info.endpoint));
+                    let alive = info_client.ping().await.is_ok();
 
                     if json {
                         let mut val = serde_json::to_value(&info)?;

--- a/crates/runtimed/Cargo.toml
+++ b/crates/runtimed/Cargo.toml
@@ -41,6 +41,15 @@ rattler_virtual_packages = "2.3"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 reqwest-middleware = "0.4"
 
+# Content-addressed blob store
+sha2 = "0.10"
+hex = "0.4"
+
+# HTTP blob server
+hyper = { version = "1", features = ["http1", "server"] }
+http-body-util = "0.1"
+hyper-util = { version = "0.1", features = ["tokio"] }
+
 # Automerge CRDT for settings sync
 automerge = "0.7"
 

--- a/crates/runtimed/src/blob_server.rs
+++ b/crates/runtimed/src/blob_server.rs
@@ -1,0 +1,240 @@
+//! HTTP read server for the blob store.
+//!
+//! Serves blobs by hash over unauthenticated localhost HTTP. This is safe
+//! because blobs are content-addressed (256-bit hashes are not guessable),
+//! the endpoint is read-only, and the data is non-secret (notebook outputs
+//! the user produced locally).
+//!
+//! Endpoints:
+//! - `GET /blob/{hash}` — raw bytes with `Content-Type` from metadata
+//! - `GET /health` — 200 OK
+//!
+//! The server binds `127.0.0.1:0` (OS-assigned random port) and runs on
+//! the caller's tokio runtime.
+
+use std::convert::Infallible;
+use std::sync::Arc;
+
+use http_body_util::Full;
+use hyper::body::Bytes;
+use hyper::server::conn::http1;
+use hyper::service::service_fn;
+use hyper::{Method, Request, Response, StatusCode};
+use hyper_util::rt::TokioIo;
+use log::{error, info};
+use tokio::net::TcpListener;
+
+use crate::blob_store::BlobStore;
+
+/// Start the blob HTTP server on a random localhost port.
+///
+/// Returns the port the server is listening on. The server runs as a
+/// spawned task on the current tokio runtime.
+pub async fn start_blob_server(store: Arc<BlobStore>) -> std::io::Result<u16> {
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let port = listener.local_addr()?.port();
+
+    info!("[blob-server] Listening on http://127.0.0.1:{}", port);
+
+    tokio::spawn(async move {
+        loop {
+            match listener.accept().await {
+                Ok((stream, _)) => {
+                    let store = store.clone();
+                    let io = TokioIo::new(stream);
+                    tokio::spawn(async move {
+                        let service = service_fn(move |req| handle_request(req, store.clone()));
+                        if let Err(e) = http1::Builder::new().serve_connection(io, service).await {
+                            if !e.is_incomplete_message() && !e.is_canceled() {
+                                error!("[blob-server] Connection error: {}", e);
+                            }
+                        }
+                    });
+                }
+                Err(e) => {
+                    error!("[blob-server] Accept error: {}", e);
+                }
+            }
+        }
+    });
+
+    Ok(port)
+}
+
+/// Handle a single HTTP request.
+async fn handle_request(
+    req: Request<hyper::body::Incoming>,
+    store: Arc<BlobStore>,
+) -> Result<Response<Full<Bytes>>, Infallible> {
+    let path = req.uri().path();
+    let method = req.method();
+
+    let response = if method != Method::GET {
+        text_response(StatusCode::METHOD_NOT_ALLOWED, "Method Not Allowed")
+    } else if path == "/health" {
+        text_response(StatusCode::OK, "OK")
+    } else if let Some(hash) = path.strip_prefix("/blob/") {
+        serve_blob(&store, hash).await
+    } else {
+        text_response(StatusCode::NOT_FOUND, "Not Found")
+    };
+
+    Ok(response)
+}
+
+/// Serve a blob by hash with correct Content-Type.
+async fn serve_blob(store: &BlobStore, hash: &str) -> Response<Full<Bytes>> {
+    let (blob_result, meta_result) = tokio::join!(store.get(hash), store.get_meta(hash));
+
+    match blob_result {
+        Ok(Some(data)) => {
+            let content_type = meta_result
+                .ok()
+                .flatten()
+                .map(|m| m.media_type)
+                .unwrap_or_else(|| "application/octet-stream".to_string());
+
+            Response::builder()
+                .status(StatusCode::OK)
+                .header("Content-Type", content_type)
+                .header("Content-Length", data.len().to_string())
+                .header("Cache-Control", "public, max-age=31536000, immutable")
+                .header("Access-Control-Allow-Origin", "*")
+                .body(Full::new(Bytes::from(data)))
+                .unwrap_or_else(|_| {
+                    text_response(StatusCode::INTERNAL_SERVER_ERROR, "Internal Server Error")
+                })
+        }
+        Ok(None) => text_response(StatusCode::NOT_FOUND, "Not Found"),
+        Err(_) => text_response(StatusCode::INTERNAL_SERVER_ERROR, "Internal Server Error"),
+    }
+}
+
+/// Build a simple text response.
+fn text_response(status: StatusCode, body: &str) -> Response<Full<Bytes>> {
+    Response::builder()
+        .status(status)
+        .header("Access-Control-Allow-Origin", "*")
+        .body(Full::new(Bytes::from(body.to_string())))
+        .expect("response builder should not fail")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    async fn setup() -> (TempDir, Arc<BlobStore>, u16) {
+        let dir = TempDir::new().unwrap();
+        let store = Arc::new(BlobStore::new(dir.path().join("blobs")));
+        let port = start_blob_server(store.clone()).await.unwrap();
+        // Give the server a moment to start accepting
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        (dir, store, port)
+    }
+
+    async fn get(port: u16, path: &str) -> (StatusCode, Vec<(String, String)>, Vec<u8>) {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpStream;
+
+        let mut stream = TcpStream::connect(format!("127.0.0.1:{}", port))
+            .await
+            .unwrap();
+        let request = format!(
+            "GET {} HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n",
+            path
+        );
+        stream.write_all(request.as_bytes()).await.unwrap();
+
+        let mut buf = Vec::new();
+        stream.read_to_end(&mut buf).await.unwrap();
+
+        let response = String::from_utf8_lossy(&buf);
+        let (head, body) = response.split_once("\r\n\r\n").unwrap_or((&response, ""));
+
+        let mut lines = head.lines();
+        let status_line = lines.next().unwrap_or("");
+        let status_code = status_line
+            .split_whitespace()
+            .nth(1)
+            .unwrap_or("0")
+            .parse::<u16>()
+            .unwrap_or(0);
+
+        let headers: Vec<(String, String)> = lines
+            .filter_map(|line| {
+                let (key, value) = line.split_once(": ")?;
+                Some((key.to_lowercase(), value.to_string()))
+            })
+            .collect();
+
+        (
+            StatusCode::from_u16(status_code).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR),
+            headers,
+            body.as_bytes().to_vec(),
+        )
+    }
+
+    fn header_value(headers: &[(String, String)], name: &str) -> Option<String> {
+        headers
+            .iter()
+            .find(|(k, _)| k == name)
+            .map(|(_, v)| v.clone())
+    }
+
+    #[tokio::test]
+    async fn test_health_endpoint() {
+        let (_dir, _store, port) = setup().await;
+        let (status, _, body) = get(port, "/health").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body, b"OK");
+    }
+
+    #[tokio::test]
+    async fn test_blob_not_found() {
+        let (_dir, _store, port) = setup().await;
+        let fake_hash = "a".repeat(64);
+        let (status, _, _) = get(port, &format!("/blob/{}", fake_hash)).await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_serve_blob_with_content_type() {
+        let (_dir, store, port) = setup().await;
+
+        let data = b"fake png data";
+        let hash = store.put(data, "image/png").await.unwrap();
+
+        let (status, headers, body) = get(port, &format!("/blob/{}", hash)).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body, data);
+        assert_eq!(
+            header_value(&headers, "content-type"),
+            Some("image/png".into())
+        );
+        assert_eq!(
+            header_value(&headers, "cache-control"),
+            Some("public, max-age=31536000, immutable".into())
+        );
+        assert_eq!(
+            header_value(&headers, "access-control-allow-origin"),
+            Some("*".into())
+        );
+    }
+
+    #[tokio::test]
+    async fn test_unknown_path_returns_404() {
+        let (_dir, _store, port) = setup().await;
+        let (status, _, _) = get(port, "/unknown").await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_two_servers_get_different_ports() {
+        let dir = TempDir::new().unwrap();
+        let store = Arc::new(BlobStore::new(dir.path().join("blobs")));
+        let port1 = start_blob_server(store.clone()).await.unwrap();
+        let port2 = start_blob_server(store.clone()).await.unwrap();
+        assert_ne!(port1, port2);
+    }
+}

--- a/crates/runtimed/src/blob_server.rs
+++ b/crates/runtimed/src/blob_server.rs
@@ -10,7 +10,8 @@
 //! - `GET /health` — 200 OK
 //!
 //! The server binds `127.0.0.1:0` (OS-assigned random port) and runs on
-//! the caller's tokio runtime.
+//! the caller's tokio runtime. It shuts down when the process exits; no
+//! explicit cancellation is implemented yet.
 
 use std::convert::Infallible;
 use std::sync::Arc;

--- a/crates/runtimed/src/blob_store.rs
+++ b/crates/runtimed/src/blob_store.rs
@@ -1,0 +1,390 @@
+//! Content-addressed blob store for notebook outputs.
+//!
+//! Stores blobs (images, HTML, rich data) on disk at a configurable root
+//! directory. Each blob is identified by its SHA-256 hash (hex-encoded) and
+//! stored in a two-level shard directory:
+//!
+//! ```text
+//! <root>/
+//!   a1/
+//!     b2c3d4...       # raw bytes
+//!     b2c3d4....meta  # JSON metadata sidecar
+//! ```
+//!
+//! All writes are atomic: data is written to a temp file in the shard
+//! directory and renamed into place, so readers never see partial writes.
+
+use std::io;
+use std::path::PathBuf;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+/// Maximum blob size accepted by `put()` (100 MiB).
+const MAX_BLOB_SIZE: usize = 100 * 1024 * 1024;
+
+/// Metadata stored alongside each blob.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BlobMeta {
+    pub media_type: String,
+    pub size: u64,
+    pub created_at: DateTime<Utc>,
+}
+
+/// Content-addressed on-disk blob store.
+#[derive(Debug, Clone)]
+pub struct BlobStore {
+    root: PathBuf,
+}
+
+impl BlobStore {
+    /// Create a new BlobStore rooted at `root`.
+    ///
+    /// The directory is created lazily on first `put()`.
+    pub fn new(root: PathBuf) -> Self {
+        Self { root }
+    }
+
+    /// Store `data` with the given `media_type`.
+    ///
+    /// Returns the SHA-256 hex hash of the raw bytes.
+    /// Rejects data larger than 100 MiB.
+    /// Idempotent: if the blob already exists, returns the hash without writing.
+    pub async fn put(&self, data: &[u8], media_type: &str) -> io::Result<String> {
+        if data.len() > MAX_BLOB_SIZE {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "blob too large: {} bytes (max {})",
+                    data.len(),
+                    MAX_BLOB_SIZE
+                ),
+            ));
+        }
+
+        let hash = hex::encode(Sha256::digest(data));
+        let (shard_dir, blob_path, meta_path) = self.paths(&hash);
+
+        // Idempotent: skip if both files already exist
+        if blob_path.exists() && meta_path.exists() {
+            return Ok(hash);
+        }
+
+        tokio::fs::create_dir_all(&shard_dir).await?;
+
+        // Write blob to temp file, then atomic rename
+        let tmp_blob = shard_dir.join(format!(".tmp.{}", uuid::Uuid::new_v4()));
+        if let Err(e) = async {
+            tokio::fs::write(&tmp_blob, data).await?;
+            tokio::fs::rename(&tmp_blob, &blob_path).await
+        }
+        .await
+        {
+            tokio::fs::remove_file(&tmp_blob).await.ok();
+            return Err(e);
+        }
+
+        // Write metadata sidecar (also via temp + rename)
+        let meta = BlobMeta {
+            media_type: media_type.to_string(),
+            size: data.len() as u64,
+            created_at: Utc::now(),
+        };
+        let meta_json =
+            serde_json::to_string(&meta).map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+
+        let tmp_meta = shard_dir.join(format!(".tmp.{}.meta", uuid::Uuid::new_v4()));
+        if let Err(e) = async {
+            tokio::fs::write(&tmp_meta, meta_json).await?;
+            tokio::fs::rename(&tmp_meta, &meta_path).await
+        }
+        .await
+        {
+            tokio::fs::remove_file(&tmp_meta).await.ok();
+            return Err(e);
+        }
+
+        Ok(hash)
+    }
+
+    /// Retrieve blob bytes by hash. Returns `None` if not found.
+    pub async fn get(&self, hash: &str) -> io::Result<Option<Vec<u8>>> {
+        if !Self::validate_hash(hash) {
+            return Ok(None);
+        }
+        let (_, blob_path, _) = self.paths(hash);
+        match tokio::fs::read(&blob_path).await {
+            Ok(data) => Ok(Some(data)),
+            Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Retrieve blob metadata by hash. Returns `None` if not found.
+    pub async fn get_meta(&self, hash: &str) -> io::Result<Option<BlobMeta>> {
+        if !Self::validate_hash(hash) {
+            return Ok(None);
+        }
+        let (_, _, meta_path) = self.paths(hash);
+        match tokio::fs::read_to_string(&meta_path).await {
+            Ok(json) => {
+                let meta: BlobMeta = serde_json::from_str(&json)
+                    .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+                Ok(Some(meta))
+            }
+            Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Check if a blob exists (without reading it).
+    pub fn exists(&self, hash: &str) -> bool {
+        if !Self::validate_hash(hash) {
+            return false;
+        }
+        let (_, blob_path, _) = self.paths(hash);
+        blob_path.exists()
+    }
+
+    /// Delete a blob and its metadata. Returns `true` if the blob existed.
+    pub async fn delete(&self, hash: &str) -> io::Result<bool> {
+        if !Self::validate_hash(hash) {
+            return Ok(false);
+        }
+        let (_, blob_path, meta_path) = self.paths(hash);
+        let existed = blob_path.exists();
+        if existed {
+            tokio::fs::remove_file(&blob_path).await.ok();
+            tokio::fs::remove_file(&meta_path).await.ok();
+        }
+        Ok(existed)
+    }
+
+    /// List all blob hashes in the store.
+    pub async fn list(&self) -> io::Result<Vec<String>> {
+        let mut hashes = Vec::new();
+
+        if !self.root.exists() {
+            return Ok(hashes);
+        }
+
+        let mut shard_entries = tokio::fs::read_dir(&self.root).await?;
+        while let Some(shard) = shard_entries.next_entry().await? {
+            if !shard.path().is_dir() {
+                continue;
+            }
+            let shard_name = shard.file_name().to_string_lossy().to_string();
+            if shard_name.len() != 2 || !shard_name.chars().all(|c| c.is_ascii_hexdigit()) {
+                continue;
+            }
+
+            let mut blob_entries = match tokio::fs::read_dir(shard.path()).await {
+                Ok(e) => e,
+                Err(_) => continue,
+            };
+            while let Some(entry) = blob_entries.next_entry().await? {
+                let name = entry.file_name().to_string_lossy().to_string();
+                if name.ends_with(".meta") || name.starts_with(".tmp") {
+                    continue;
+                }
+                let full_hash = format!("{}{}", shard_name, name);
+                if Self::validate_hash(&full_hash) {
+                    hashes.push(full_hash);
+                }
+            }
+        }
+
+        Ok(hashes)
+    }
+
+    /// Compute shard dir, blob path, and meta path for a given hash.
+    fn paths(&self, hash: &str) -> (PathBuf, PathBuf, PathBuf) {
+        let shard = &hash[..2];
+        let rest = &hash[2..];
+        let shard_dir = self.root.join(shard);
+        let blob_path = shard_dir.join(rest);
+        let meta_path = shard_dir.join(format!("{}.meta", rest));
+        (shard_dir, blob_path, meta_path)
+    }
+
+    /// Validate that a hash looks like a 64-character hex string.
+    fn validate_hash(hash: &str) -> bool {
+        hash.len() == 64 && hash.chars().all(|c| c.is_ascii_hexdigit())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn test_store(dir: &TempDir) -> BlobStore {
+        BlobStore::new(dir.path().join("blobs"))
+    }
+
+    #[tokio::test]
+    async fn test_put_and_get() {
+        let dir = TempDir::new().unwrap();
+        let store = test_store(&dir);
+
+        let data = b"hello world";
+        let hash = store.put(data, "text/plain").await.unwrap();
+        assert_eq!(hash.len(), 64);
+
+        let retrieved = store.get(&hash).await.unwrap().unwrap();
+        assert_eq!(retrieved, data);
+    }
+
+    #[tokio::test]
+    async fn test_idempotent_put() {
+        let dir = TempDir::new().unwrap();
+        let store = test_store(&dir);
+
+        let data = b"same content";
+        let hash1 = store.put(data, "text/plain").await.unwrap();
+        let hash2 = store.put(data, "text/plain").await.unwrap();
+        assert_eq!(hash1, hash2);
+    }
+
+    #[tokio::test]
+    async fn test_same_bytes_different_media_type() {
+        let dir = TempDir::new().unwrap();
+        let store = test_store(&dir);
+
+        let data = b"same bytes";
+        let hash1 = store.put(data, "text/plain").await.unwrap();
+        let hash2 = store.put(data, "application/octet-stream").await.unwrap();
+        // Same bytes = same hash (media type doesn't affect hash)
+        assert_eq!(hash1, hash2);
+        // Metadata keeps the first media type (idempotent — didn't overwrite)
+        let meta = store.get_meta(&hash1).await.unwrap().unwrap();
+        assert_eq!(meta.media_type, "text/plain");
+    }
+
+    #[tokio::test]
+    async fn test_size_limit() {
+        let dir = TempDir::new().unwrap();
+        let store = test_store(&dir);
+
+        let data = vec![0u8; MAX_BLOB_SIZE + 1];
+        let result = store.put(&data, "application/octet-stream").await;
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().kind(), io::ErrorKind::InvalidInput);
+    }
+
+    #[tokio::test]
+    async fn test_get_not_found() {
+        let dir = TempDir::new().unwrap();
+        let store = test_store(&dir);
+
+        let fake_hash = "a".repeat(64);
+        let result = store.get(&fake_hash).await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_get_meta() {
+        let dir = TempDir::new().unwrap();
+        let store = test_store(&dir);
+
+        let data = b"png bytes";
+        let hash = store.put(data, "image/png").await.unwrap();
+
+        let meta = store.get_meta(&hash).await.unwrap().unwrap();
+        assert_eq!(meta.media_type, "image/png");
+        assert_eq!(meta.size, data.len() as u64);
+    }
+
+    #[tokio::test]
+    async fn test_exists() {
+        let dir = TempDir::new().unwrap();
+        let store = test_store(&dir);
+
+        let fake_hash = "b".repeat(64);
+        assert!(!store.exists(&fake_hash));
+
+        let hash = store.put(b"data", "text/plain").await.unwrap();
+        assert!(store.exists(&hash));
+    }
+
+    #[tokio::test]
+    async fn test_delete() {
+        let dir = TempDir::new().unwrap();
+        let store = test_store(&dir);
+
+        let hash = store.put(b"to delete", "text/plain").await.unwrap();
+        assert!(store.exists(&hash));
+
+        let deleted = store.delete(&hash).await.unwrap();
+        assert!(deleted);
+        assert!(!store.exists(&hash));
+        assert!(store.get(&hash).await.unwrap().is_none());
+        assert!(store.get_meta(&hash).await.unwrap().is_none());
+
+        // Deleting again returns false
+        let deleted_again = store.delete(&hash).await.unwrap();
+        assert!(!deleted_again);
+    }
+
+    #[tokio::test]
+    async fn test_list() {
+        let dir = TempDir::new().unwrap();
+        let store = test_store(&dir);
+
+        let hash1 = store.put(b"one", "text/plain").await.unwrap();
+        let hash2 = store.put(b"two", "text/plain").await.unwrap();
+        let hash3 = store.put(b"three", "text/plain").await.unwrap();
+
+        let mut hashes = store.list().await.unwrap();
+        hashes.sort();
+
+        let mut expected = vec![hash1, hash2, hash3];
+        expected.sort();
+
+        assert_eq!(hashes, expected);
+    }
+
+    #[tokio::test]
+    async fn test_list_empty_store() {
+        let dir = TempDir::new().unwrap();
+        let store = test_store(&dir);
+
+        let hashes = store.list().await.unwrap();
+        assert!(hashes.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_invalid_hash_returns_none() {
+        let dir = TempDir::new().unwrap();
+        let store = test_store(&dir);
+
+        // Too short
+        assert!(store.get("abc").await.unwrap().is_none());
+        assert!(store.get_meta("abc").await.unwrap().is_none());
+        assert!(!store.exists("abc"));
+        assert!(!store.delete("abc").await.unwrap());
+
+        // Non-hex characters
+        let bad = format!("{}z", "a".repeat(63));
+        assert!(store.get(&bad).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_puts_same_content() {
+        let dir = TempDir::new().unwrap();
+        let store = test_store(&dir);
+
+        let data = b"concurrent content";
+        let store1 = store.clone();
+        let store2 = store.clone();
+
+        let (hash1, hash2) = tokio::join!(
+            async { store1.put(data, "text/plain").await.unwrap() },
+            async { store2.put(data, "text/plain").await.unwrap() },
+        );
+
+        assert_eq!(hash1, hash2);
+        assert_eq!(store.get(&hash1).await.unwrap().unwrap(), data);
+    }
+}

--- a/crates/runtimed/src/connection.rs
+++ b/crates/runtimed/src/connection.rs
@@ -1,0 +1,169 @@
+//! Unified connection framing and handshake for the runtimed socket.
+//!
+//! All connections to the daemon use length-prefixed binary framing:
+//!
+//! ```text
+//! [4 bytes: payload length (big-endian u32)] [payload bytes]
+//! ```
+//!
+//! The first frame on every connection is a JSON handshake declaring the
+//! channel. After the handshake, the daemon routes the connection to the
+//! appropriate handler.
+
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+
+/// Maximum frame size: 100 MiB (matches blob size limit).
+const MAX_FRAME_SIZE: usize = 100 * 1024 * 1024;
+
+/// Channel handshake — the first frame on every connection.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "channel", rename_all = "snake_case")]
+pub enum Handshake {
+    /// Pool IPC: environment take/return/status/ping.
+    Pool,
+    /// Automerge settings sync.
+    SettingsSync,
+    /// Automerge notebook sync (per-notebook room).
+    NotebookSync { notebook_id: String },
+    /// Blob store: write blobs, query port.
+    Blob,
+}
+
+/// Send a length-prefixed frame.
+pub async fn send_frame<W: AsyncWrite + Unpin>(writer: &mut W, data: &[u8]) -> std::io::Result<()> {
+    let len = (data.len() as u32).to_be_bytes();
+    writer.write_all(&len).await?;
+    writer.write_all(data).await?;
+    writer.flush().await?;
+    Ok(())
+}
+
+/// Receive a length-prefixed frame. Returns `None` on clean disconnect (EOF).
+pub async fn recv_frame<R: AsyncRead + Unpin>(reader: &mut R) -> std::io::Result<Option<Vec<u8>>> {
+    let mut len_buf = [0u8; 4];
+    match reader.read_exact(&mut len_buf).await {
+        Ok(_) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(None),
+        Err(e) => return Err(e),
+    }
+    let len = u32::from_be_bytes(len_buf) as usize;
+
+    if len > MAX_FRAME_SIZE {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("frame too large: {} bytes (max {})", len, MAX_FRAME_SIZE),
+        ));
+    }
+
+    let mut buf = vec![0u8; len];
+    reader.read_exact(&mut buf).await?;
+    Ok(Some(buf))
+}
+
+/// Send a value as a JSON-encoded length-prefixed frame.
+pub async fn send_json_frame<W: AsyncWrite + Unpin, T: Serialize>(
+    writer: &mut W,
+    value: &T,
+) -> anyhow::Result<()> {
+    let data = serde_json::to_vec(value)?;
+    send_frame(writer, &data).await?;
+    Ok(())
+}
+
+/// Receive and deserialize a JSON-encoded length-prefixed frame.
+/// Returns `None` on clean disconnect (EOF).
+pub async fn recv_json_frame<R: AsyncRead + Unpin, T: DeserializeOwned>(
+    reader: &mut R,
+) -> anyhow::Result<Option<T>> {
+    match recv_frame(reader).await? {
+        Some(data) => {
+            let value = serde_json::from_slice(&data)?;
+            Ok(Some(value))
+        }
+        None => Ok(None),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_frame_roundtrip() {
+        let data = b"hello world";
+
+        let mut buf = Vec::new();
+        send_frame(&mut buf, data).await.unwrap();
+        assert_eq!(buf.len(), 4 + data.len());
+
+        let mut cursor = std::io::Cursor::new(buf);
+        let received = recv_frame(&mut cursor).await.unwrap().unwrap();
+        assert_eq!(received, data);
+    }
+
+    #[tokio::test]
+    async fn test_frame_eof() {
+        let buf: &[u8] = &[];
+        let mut cursor = std::io::Cursor::new(buf);
+        let result = recv_frame(&mut cursor).await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_frame_too_large() {
+        let len_bytes = (MAX_FRAME_SIZE as u32 + 1).to_be_bytes();
+        let mut cursor = std::io::Cursor::new(len_bytes.to_vec());
+        let result = recv_frame(&mut cursor).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_json_frame_roundtrip() {
+        let handshake = Handshake::Pool;
+
+        let mut buf = Vec::new();
+        send_json_frame(&mut buf, &handshake).await.unwrap();
+
+        let mut cursor = std::io::Cursor::new(buf);
+        let received: Handshake = recv_json_frame(&mut cursor).await.unwrap().unwrap();
+        assert!(matches!(received, Handshake::Pool));
+    }
+
+    #[tokio::test]
+    async fn test_handshake_serialization() {
+        // Pool
+        let json = serde_json::to_string(&Handshake::Pool).unwrap();
+        assert_eq!(json, r#"{"channel":"pool"}"#);
+
+        // SettingsSync
+        let json = serde_json::to_string(&Handshake::SettingsSync).unwrap();
+        assert_eq!(json, r#"{"channel":"settings_sync"}"#);
+
+        // NotebookSync
+        let json = serde_json::to_string(&Handshake::NotebookSync {
+            notebook_id: "abc".into(),
+        })
+        .unwrap();
+        assert_eq!(json, r#"{"channel":"notebook_sync","notebook_id":"abc"}"#);
+
+        // Blob
+        let json = serde_json::to_string(&Handshake::Blob).unwrap();
+        assert_eq!(json, r#"{"channel":"blob"}"#);
+    }
+
+    #[tokio::test]
+    async fn test_multiple_frames_on_same_stream() {
+        let mut buf = Vec::new();
+        send_frame(&mut buf, b"first").await.unwrap();
+        send_frame(&mut buf, b"second").await.unwrap();
+        send_frame(&mut buf, b"third").await.unwrap();
+
+        let mut cursor = std::io::Cursor::new(buf);
+        assert_eq!(recv_frame(&mut cursor).await.unwrap().unwrap(), b"first");
+        assert_eq!(recv_frame(&mut cursor).await.unwrap().unwrap(), b"second");
+        assert_eq!(recv_frame(&mut cursor).await.unwrap().unwrap(), b"third");
+        // EOF
+        assert!(recv_frame(&mut cursor).await.unwrap().is_none());
+    }
+}

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -231,6 +231,13 @@ impl Daemon {
             if self.config.socket_path.exists() {
                 tokio::fs::remove_file(&self.config.socket_path).await?;
             }
+
+            // Clean up obsolete sync socket from pre-unification daemons
+            let sync_sock = self.config.socket_path.with_file_name("runtimed-sync.sock");
+            if sync_sock.exists() {
+                info!("[runtimed] Removing obsolete sync socket: {:?}", sync_sock);
+                tokio::fs::remove_file(&sync_sock).await.ok();
+            }
         }
 
         // Start the blob HTTP server

--- a/crates/runtimed/src/main.rs
+++ b/crates/runtimed/src/main.rs
@@ -28,17 +28,17 @@ struct Cli {
 enum Commands {
     /// Run the daemon (default if no command specified)
     Run {
-        /// Socket path for pool IPC (default: ~/.cache/runt/runtimed.sock)
+        /// Socket path for the unified IPC socket (default: ~/.cache/runt/runtimed.sock)
         #[arg(long)]
         socket: Option<PathBuf>,
-
-        /// Socket path for settings sync (default: ~/.cache/runt/runtimed-sync.sock)
-        #[arg(long)]
-        sync_socket: Option<PathBuf>,
 
         /// Cache directory for environments (default: ~/.cache/runt/envs)
         #[arg(long)]
         cache_dir: Option<PathBuf>,
+
+        /// Directory for the content-addressed blob store (default: ~/.cache/runt/blobs)
+        #[arg(long)]
+        blob_store_dir: Option<PathBuf>,
 
         /// Number of UV environments to maintain
         #[arg(long, default_value = "3")]
@@ -87,28 +87,28 @@ async fn main() -> anyhow::Result<()> {
     match cli.command {
         None | Some(Commands::Run { .. }) => {
             // Extract run args from command or use defaults
-            let (socket, sync_socket, cache_dir, uv_pool_size, conda_pool_size) = match cli.command
-            {
-                Some(Commands::Run {
-                    socket,
-                    sync_socket,
-                    cache_dir,
-                    uv_pool_size,
-                    conda_pool_size,
-                }) => (
-                    socket,
-                    sync_socket,
-                    cache_dir,
-                    uv_pool_size,
-                    conda_pool_size,
-                ),
-                _ => (None, None, None, 3, 3),
-            };
+            let (socket, cache_dir, blob_store_dir, uv_pool_size, conda_pool_size) =
+                match cli.command {
+                    Some(Commands::Run {
+                        socket,
+                        cache_dir,
+                        blob_store_dir,
+                        uv_pool_size,
+                        conda_pool_size,
+                    }) => (
+                        socket,
+                        cache_dir,
+                        blob_store_dir,
+                        uv_pool_size,
+                        conda_pool_size,
+                    ),
+                    _ => (None, None, None, 3, 3),
+                };
 
             run_daemon(
                 socket,
-                sync_socket,
                 cache_dir,
+                blob_store_dir,
                 uv_pool_size,
                 conda_pool_size,
             )
@@ -125,8 +125,8 @@ async fn main() -> anyhow::Result<()> {
 
 async fn run_daemon(
     socket: Option<PathBuf>,
-    sync_socket: Option<PathBuf>,
     cache_dir: Option<PathBuf>,
+    blob_store_dir: Option<PathBuf>,
     uv_pool_size: usize,
     conda_pool_size: usize,
 ) -> anyhow::Result<()> {
@@ -134,17 +134,17 @@ async fn run_daemon(
 
     let config = DaemonConfig {
         socket_path: socket.unwrap_or_else(runtimed::default_socket_path),
-        sync_socket_path: sync_socket.unwrap_or_else(runtimed::default_sync_socket_path),
         cache_dir: cache_dir.unwrap_or_else(runtimed::default_cache_dir),
+        blob_store_dir: blob_store_dir.unwrap_or_else(runtimed::default_blob_store_dir),
         uv_pool_size,
         conda_pool_size,
         ..Default::default()
     };
 
     info!("Configuration:");
-    info!("  Pool socket: {:?}", config.socket_path);
-    info!("  Sync socket: {:?}", config.sync_socket_path);
+    info!("  Socket: {:?}", config.socket_path);
     info!("  Cache dir: {:?}", config.cache_dir);
+    info!("  Blob store: {:?}", config.blob_store_dir);
     info!("  UV pool size: {}", config.uv_pool_size);
     info!("  Conda pool size: {}", config.conda_pool_size);
 

--- a/crates/runtimed/src/singleton.rs
+++ b/crates/runtimed/src/singleton.rs
@@ -20,6 +20,9 @@ pub struct DaemonInfo {
     pub version: String,
     /// When the daemon started.
     pub started_at: DateTime<Utc>,
+    /// HTTP port for the blob server (if running).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub blob_port: Option<u16>,
 }
 
 /// A lock that ensures only one daemon instance runs.
@@ -69,6 +72,7 @@ impl DaemonLock {
                     pid: 0,
                     version: "unknown".to_string(),
                     started_at: Utc::now(),
+                    blob_port: None,
                 });
             }
         };
@@ -90,6 +94,7 @@ impl DaemonLock {
                     pid: 0,
                     version: "unknown".to_string(),
                     started_at: Utc::now(),
+                    blob_port: None,
                 });
             }
         }
@@ -125,6 +130,7 @@ impl DaemonLock {
                     pid: 0,
                     version: "unknown".to_string(),
                     started_at: Utc::now(),
+                    blob_port: None,
                 });
             }
         }
@@ -139,12 +145,13 @@ impl DaemonLock {
     }
 
     /// Write daemon info after successful startup.
-    pub fn write_info(&self, endpoint: &str) -> std::io::Result<()> {
+    pub fn write_info(&self, endpoint: &str, blob_port: Option<u16>) -> std::io::Result<()> {
         let info = DaemonInfo {
             endpoint: endpoint.to_string(),
             pid: std::process::id(),
             version: format!("{}+{}", env!("CARGO_PKG_VERSION"), env!("GIT_COMMIT")),
             started_at: Utc::now(),
+            blob_port,
         };
 
         let json = serde_json::to_string_pretty(&info).map_err(std::io::Error::other)?;

--- a/crates/runtimed/src/sync_client.rs
+++ b/crates/runtimed/src/sync_client.rs
@@ -11,8 +11,9 @@ use automerge::sync::{self, SyncDoc};
 use automerge::transaction::Transactable;
 use automerge::{AutoCommit, ObjType, ReadDoc};
 use log::info;
-use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use tokio::io::{AsyncRead, AsyncWrite};
 
+use crate::connection::{self, Handshake};
 use crate::settings_doc::{
     read_nested_list, split_comma_list, CondaDefaults, SyncedSettings, ThemeMode, UvDefaults,
 };
@@ -43,40 +44,9 @@ pub struct SyncClient<S> {
     stream: S,
 }
 
-/// Send a length-prefixed message.
-async fn send_framed<W: AsyncWrite + Unpin>(writer: &mut W, data: &[u8]) -> std::io::Result<()> {
-    let len = (data.len() as u32).to_be_bytes();
-    writer.write_all(&len).await?;
-    writer.write_all(data).await?;
-    writer.flush().await?;
-    Ok(())
-}
-
-/// Receive a length-prefixed message. Returns `None` on clean disconnect.
-async fn recv_framed<R: AsyncRead + Unpin>(reader: &mut R) -> std::io::Result<Option<Vec<u8>>> {
-    let mut len_buf = [0u8; 4];
-    match reader.read_exact(&mut len_buf).await {
-        Ok(_) => {}
-        Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(None),
-        Err(e) => return Err(e),
-    }
-    let len = u32::from_be_bytes(len_buf) as usize;
-
-    if len > 1_048_576 {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::InvalidData,
-            format!("sync message too large: {} bytes", len),
-        ));
-    }
-
-    let mut buf = vec![0u8; len];
-    reader.read_exact(&mut buf).await?;
-    Ok(Some(buf))
-}
-
 #[cfg(unix)]
 impl SyncClient<tokio::net::UnixStream> {
-    /// Connect to the daemon's sync socket and perform initial sync.
+    /// Connect to the daemon's unified socket and perform initial sync.
     pub async fn connect(socket_path: PathBuf) -> Result<Self, SyncClientError> {
         Self::connect_with_timeout(socket_path, Duration::from_secs(2)).await
     }
@@ -99,7 +69,7 @@ impl SyncClient<tokio::net::UnixStream> {
 
 #[cfg(windows)]
 impl SyncClient<tokio::net::windows::named_pipe::NamedPipeClient> {
-    /// Connect to the daemon's sync socket and perform initial sync.
+    /// Connect to the daemon's unified socket and perform initial sync.
     pub async fn connect(socket_path: PathBuf) -> Result<Self, SyncClientError> {
         let pipe_name = socket_path.to_string_lossy().to_string();
         let client = tokio::net::windows::named_pipe::ClientOptions::new()
@@ -113,13 +83,19 @@ impl<S> SyncClient<S>
 where
     S: AsyncRead + AsyncWrite + Unpin,
 {
-    /// Initialize the client by performing the initial sync exchange.
+    /// Initialize the client by sending the handshake and performing
+    /// the initial sync exchange.
     async fn init(mut stream: S) -> Result<Self, SyncClientError> {
+        // Send the channel handshake so the daemon routes us to settings sync
+        connection::send_json_frame(&mut stream, &Handshake::SettingsSync)
+            .await
+            .map_err(|e| SyncClientError::SyncError(format!("handshake: {}", e)))?;
+
         let mut doc = AutoCommit::new();
         let mut peer_state = sync::State::new();
 
-        // The server sends first — receive and apply
-        match recv_framed(&mut stream).await? {
+        // The server sends first -- receive and apply
+        match connection::recv_frame(&mut stream).await? {
             Some(data) => {
                 let message = sync::Message::decode(&data)
                     .map_err(|e| SyncClientError::SyncError(format!("decode: {}", e)))?;
@@ -132,13 +108,18 @@ where
 
         // Send our sync message back (to complete the handshake)
         if let Some(msg) = doc.sync().generate_sync_message(&mut peer_state) {
-            send_framed(&mut stream, &msg.encode()).await?;
+            connection::send_frame(&mut stream, &msg.encode()).await?;
         }
 
-        // There might be more rounds needed — keep going until no more messages
+        // There might be more rounds needed -- keep going until no more messages
         loop {
             // Try to receive with a short timeout (the server may not have more to say)
-            match tokio::time::timeout(Duration::from_millis(100), recv_framed(&mut stream)).await {
+            match tokio::time::timeout(
+                Duration::from_millis(100),
+                connection::recv_frame(&mut stream),
+            )
+            .await
+            {
                 Ok(Ok(Some(data))) => {
                     let message = sync::Message::decode(&data)
                         .map_err(|e| SyncClientError::SyncError(format!("decode: {}", e)))?;
@@ -147,12 +128,12 @@ where
                         .map_err(|e| SyncClientError::SyncError(format!("receive: {}", e)))?;
 
                     if let Some(msg) = doc.sync().generate_sync_message(&mut peer_state) {
-                        send_framed(&mut stream, &msg.encode()).await?;
+                        connection::send_frame(&mut stream, &msg.encode()).await?;
                     }
                 }
                 Ok(Ok(None)) => return Err(SyncClientError::Disconnected),
                 Ok(Err(e)) => return Err(SyncClientError::ConnectionFailed(e)),
-                Err(_) => break, // Timeout — initial sync is done
+                Err(_) => break, // Timeout -- initial sync is done
             }
         }
 
@@ -212,7 +193,7 @@ where
     ) -> Result<(), SyncClientError> {
         match value {
             serde_json::Value::String(s) => {
-                // Scalar write — delegate to put which handles dotted paths
+                // Scalar write -- delegate to put which handles dotted paths
                 if let Some((map_key, sub_key)) = key.split_once('.') {
                     let map_id = self.ensure_map(map_key)?;
                     self.doc
@@ -281,7 +262,7 @@ where
     /// Generate and send sync message to daemon.
     async fn sync_to_daemon(&mut self) -> Result<(), SyncClientError> {
         if let Some(msg) = self.doc.sync().generate_sync_message(&mut self.peer_state) {
-            send_framed(&mut self.stream, &msg.encode()).await?;
+            connection::send_frame(&mut self.stream, &msg.encode()).await?;
         }
         Ok(())
     }
@@ -291,7 +272,7 @@ where
     /// Blocks until a sync message arrives, applies it, and returns the
     /// updated settings snapshot.
     pub async fn recv_changes(&mut self) -> Result<SyncedSettings, SyncClientError> {
-        match recv_framed(&mut self.stream).await? {
+        match connection::recv_frame(&mut self.stream).await? {
             Some(data) => {
                 let message = sync::Message::decode(&data)
                     .map_err(|e| SyncClientError::SyncError(format!("decode: {}", e)))?;
@@ -302,7 +283,7 @@ where
 
                 // Send ack if needed
                 if let Some(msg) = self.doc.sync().generate_sync_message(&mut self.peer_state) {
-                    send_framed(&mut self.stream, &msg.encode()).await?;
+                    connection::send_frame(&mut self.stream, &msg.encode()).await?;
                 }
 
                 Ok(self.get_all())
@@ -383,7 +364,7 @@ fn get_all_from_doc(doc: &AutoCommit) -> SyncedSettings {
 pub async fn try_get_synced_settings() -> Result<SyncedSettings, SyncClientError> {
     #[cfg(unix)]
     {
-        let client = SyncClient::connect(crate::default_sync_socket_path()).await?;
+        let client = SyncClient::connect(crate::default_socket_path()).await?;
         let settings = client.get_all();
         info!("[sync-client] Got settings from daemon: {:?}", settings);
         Ok(settings)

--- a/crates/runtimed/src/sync_server.rs
+++ b/crates/runtimed/src/sync_server.rs
@@ -1,226 +1,21 @@
-//! Automerge sync socket server for settings synchronization.
+//! Automerge sync protocol handler for settings synchronization.
 //!
-//! Runs alongside the pool daemon on a separate Unix socket (named pipe on
-//! Windows). Each connected client exchanges Automerge sync messages to keep
-//! a shared settings document in sync across all notebook windows.
-//!
-//! Wire protocol: length-prefix framed binary.
-//! Each message is `[4-byte big-endian length][payload]` where payload is an
-//! encoded `automerge::sync::Message`.
+//! Handles a single client connection that has already been routed by the
+//! daemon's unified socket. Exchanges Automerge sync messages to keep a
+//! shared settings document in sync across all notebook windows.
 
-use std::path::PathBuf;
 use std::sync::Arc;
 
 use automerge::sync;
-use log::{error, info, warn};
-use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
-use tokio::sync::{broadcast, Mutex, RwLock};
+use log::{info, warn};
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::sync::{broadcast, RwLock};
 
-#[cfg(unix)]
-use tokio::net::UnixListener;
-
-#[cfg(windows)]
-use tokio::net::windows::named_pipe::ServerOptions;
-
+use crate::connection;
 use crate::settings_doc::SettingsDoc;
 
-/// Send a length-prefixed message over a writer.
-async fn send_framed<W: AsyncWrite + Unpin>(writer: &mut W, data: &[u8]) -> std::io::Result<()> {
-    let len = (data.len() as u32).to_be_bytes();
-    writer.write_all(&len).await?;
-    writer.write_all(data).await?;
-    writer.flush().await?;
-    Ok(())
-}
-
-/// Receive a length-prefixed message from a reader.
-/// Returns `None` on clean disconnect (EOF).
-async fn recv_framed<R: AsyncRead + Unpin>(reader: &mut R) -> std::io::Result<Option<Vec<u8>>> {
-    let mut len_buf = [0u8; 4];
-    match reader.read_exact(&mut len_buf).await {
-        Ok(_) => {}
-        Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(None),
-        Err(e) => return Err(e),
-    }
-    let len = u32::from_be_bytes(len_buf) as usize;
-
-    // Sanity check: reject messages larger than 1 MB
-    if len > 1_048_576 {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::InvalidData,
-            format!("sync message too large: {} bytes", len),
-        ));
-    }
-
-    let mut buf = vec![0u8; len];
-    reader.read_exact(&mut buf).await?;
-    Ok(Some(buf))
-}
-
-/// Run the settings sync server.
-///
-/// Binds to `socket_path`, accepts connections, and runs the Automerge sync
-/// protocol with each client. When any client makes a change, all other
-/// connected clients are notified via `settings_changed`.
-pub async fn run_sync_server(
-    socket_path: PathBuf,
-    settings: Arc<RwLock<SettingsDoc>>,
-    settings_changed: broadcast::Sender<()>,
-    shutdown: Arc<Mutex<bool>>,
-    shutdown_notify: Arc<tokio::sync::Notify>,
-) -> anyhow::Result<()> {
-    #[cfg(unix)]
-    {
-        run_unix_sync_server(
-            socket_path,
-            settings,
-            settings_changed,
-            shutdown,
-            shutdown_notify,
-        )
-        .await
-    }
-
-    #[cfg(windows)]
-    {
-        run_windows_sync_server(
-            socket_path,
-            settings,
-            settings_changed,
-            shutdown,
-            shutdown_notify,
-        )
-        .await
-    }
-}
-
-#[cfg(unix)]
-async fn run_unix_sync_server(
-    socket_path: PathBuf,
-    settings: Arc<RwLock<SettingsDoc>>,
-    settings_changed: broadcast::Sender<()>,
-    shutdown: Arc<Mutex<bool>>,
-    shutdown_notify: Arc<tokio::sync::Notify>,
-) -> anyhow::Result<()> {
-    // Ensure socket directory exists
-    if let Some(parent) = socket_path.parent() {
-        tokio::fs::create_dir_all(parent).await?;
-    }
-
-    // Remove stale socket file
-    if socket_path.exists() {
-        tokio::fs::remove_file(&socket_path).await?;
-    }
-
-    let listener = UnixListener::bind(&socket_path)?;
-    info!("[sync] Listening on {:?}", socket_path);
-
-    loop {
-        tokio::select! {
-            accept_result = listener.accept() => {
-                match accept_result {
-                    Ok((stream, _)) => {
-                        let settings = settings.clone();
-                        let changed_tx = settings_changed.clone();
-                        let changed_rx = settings_changed.subscribe();
-                        tokio::spawn(async move {
-                            let (reader, writer) = tokio::io::split(stream);
-                            if let Err(e) = handle_sync_connection(
-                                reader, writer, settings, changed_tx, changed_rx,
-                            ).await {
-                                if !is_connection_closed(&e) {
-                                    error!("[sync] Connection error: {}", e);
-                                }
-                            }
-                            info!("[sync] Client disconnected");
-                        });
-                    }
-                    Err(e) => {
-                        error!("[sync] Accept error: {}", e);
-                    }
-                }
-            }
-            _ = shutdown_notify.notified() => {
-                if *shutdown.lock().await {
-                    info!("[sync] Shutting down");
-                    break;
-                }
-            }
-        }
-    }
-
-    // Cleanup socket
-    tokio::fs::remove_file(&socket_path).await.ok();
-    Ok(())
-}
-
-#[cfg(windows)]
-async fn run_windows_sync_server(
-    socket_path: PathBuf,
-    settings: Arc<RwLock<SettingsDoc>>,
-    settings_changed: broadcast::Sender<()>,
-    shutdown: Arc<Mutex<bool>>,
-    shutdown_notify: Arc<tokio::sync::Notify>,
-) -> anyhow::Result<()> {
-    let pipe_name = socket_path.to_string_lossy().to_string();
-    info!("[sync] Listening on {}", pipe_name);
-
-    let mut server = ServerOptions::new()
-        .first_pipe_instance(true)
-        .create(&pipe_name)?;
-
-    loop {
-        tokio::select! {
-            connect_result = server.connect() => {
-                if let Err(e) = connect_result {
-                    error!("[sync] Pipe connect error: {}", e);
-                    continue;
-                }
-
-                let connected = server;
-                server = match ServerOptions::new().create(&pipe_name) {
-                    Ok(s) => s,
-                    Err(e) => {
-                        error!("[sync] Failed to create new pipe server: {}", e);
-                        match ServerOptions::new().first_pipe_instance(true).create(&pipe_name) {
-                            Ok(s) => s,
-                            Err(e) => {
-                                error!("[sync] Fatal: cannot create pipe server: {}", e);
-                                break;
-                            }
-                        }
-                    }
-                };
-
-                let settings = settings.clone();
-                let changed_tx = settings_changed.clone();
-                let changed_rx = settings_changed.subscribe();
-                tokio::spawn(async move {
-                    let (reader, writer) = tokio::io::split(connected);
-                    if let Err(e) = handle_sync_connection(
-                        reader, writer, settings, changed_tx, changed_rx,
-                    ).await {
-                        if !is_connection_closed(&e) {
-                            error!("[sync] Connection error: {}", e);
-                        }
-                    }
-                    info!("[sync] Client disconnected");
-                });
-            }
-            _ = shutdown_notify.notified() => {
-                if *shutdown.lock().await {
-                    info!("[sync] Shutting down");
-                    break;
-                }
-            }
-        }
-    }
-
-    Ok(())
-}
-
 /// Check if an error is just a normal connection close.
-fn is_connection_closed(e: &anyhow::Error) -> bool {
+pub(crate) fn is_connection_closed(e: &anyhow::Error) -> bool {
     if let Some(io_err) = e.downcast_ref::<std::io::Error>() {
         matches!(
             io_err.kind(),
@@ -233,13 +28,14 @@ fn is_connection_closed(e: &anyhow::Error) -> bool {
     }
 }
 
-/// Handle a single sync client connection.
+/// Handle a single settings sync client connection.
 ///
-/// Protocol flow:
+/// The caller has already consumed the handshake frame. This function
+/// runs the Automerge sync protocol:
 /// 1. Initial sync: exchange messages until both sides converge
 /// 2. Watch loop: wait for changes (from other peers or from this client),
 ///    exchange sync messages to propagate
-async fn handle_sync_connection<R, W>(
+pub async fn handle_settings_sync_connection<R, W>(
     mut reader: R,
     mut writer: W,
     settings: Arc<RwLock<SettingsDoc>>,
@@ -253,11 +49,11 @@ where
     let mut peer_state = sync::State::new();
     info!("[sync] New client connected, starting initial sync");
 
-    // Phase 1: Initial sync — server sends first
+    // Phase 1: Initial sync -- server sends first
     {
         let mut doc = settings.write().await;
         if let Some(msg) = doc.generate_sync_message(&mut peer_state) {
-            send_framed(&mut writer, &msg.encode()).await?;
+            connection::send_frame(&mut writer, &msg.encode()).await?;
         }
     }
 
@@ -265,7 +61,7 @@ where
     loop {
         tokio::select! {
             // Incoming message from this client
-            result = recv_framed(&mut reader) => {
+            result = connection::recv_frame(&mut reader) => {
                 match result? {
                     Some(data) => {
                         let message = sync::Message::decode(&data)
@@ -280,7 +76,7 @@ where
 
                         // Send our response
                         if let Some(reply) = doc.generate_sync_message(&mut peer_state) {
-                            send_framed(&mut writer, &reply.encode()).await?;
+                            connection::send_frame(&mut writer, &reply.encode()).await?;
                         }
                     }
                     None => {
@@ -290,11 +86,11 @@ where
                 }
             }
 
-            // Another peer changed settings — push update to this client
+            // Another peer changed settings -- push update to this client
             _ = changed_rx.recv() => {
                 let mut doc = settings.write().await;
                 if let Some(msg) = doc.generate_sync_message(&mut peer_state) {
-                    send_framed(&mut writer, &msg.encode()).await?;
+                    connection::send_frame(&mut writer, &msg.encode()).await?;
                 }
             }
         }
@@ -311,41 +107,5 @@ fn persist_settings(doc: &mut SettingsDoc) {
     }
     if let Err(e) = doc.save_json_mirror(&json_path) {
         warn!("[sync] Failed to write JSON mirror: {}", e);
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[tokio::test]
-    async fn test_framed_roundtrip() {
-        let data = b"hello world";
-
-        let mut buf = Vec::new();
-        send_framed(&mut buf, data).await.unwrap();
-
-        assert_eq!(buf.len(), 4 + data.len());
-
-        let mut cursor = std::io::Cursor::new(buf);
-        let received = recv_framed(&mut cursor).await.unwrap().unwrap();
-        assert_eq!(received, data);
-    }
-
-    #[tokio::test]
-    async fn test_framed_eof() {
-        let buf: &[u8] = &[];
-        let mut cursor = std::io::Cursor::new(buf);
-        let result = recv_framed(&mut cursor).await.unwrap();
-        assert!(result.is_none());
-    }
-
-    #[tokio::test]
-    async fn test_framed_too_large() {
-        // Craft a message claiming to be 2 MB
-        let len_bytes = (2_000_000u32).to_be_bytes();
-        let mut cursor = std::io::Cursor::new(len_bytes.to_vec());
-        let result = recv_framed(&mut cursor).await;
-        assert!(result.is_err());
     }
 }

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -14,8 +14,8 @@ use tokio::time::sleep;
 fn test_config(temp_dir: &TempDir) -> DaemonConfig {
     DaemonConfig {
         socket_path: temp_dir.path().join("test-runtimed.sock"),
-        sync_socket_path: temp_dir.path().join("test-runtimed-sync.sock"),
         cache_dir: temp_dir.path().join("envs"),
+        blob_store_dir: temp_dir.path().join("blobs"),
         uv_pool_size: 0, // Don't create real envs in tests
         conda_pool_size: 0,
         max_age_secs: 3600,
@@ -131,8 +131,8 @@ async fn test_singleton_prevents_second_daemon() {
     // Try to start second daemon with same paths - should fail
     let config2 = DaemonConfig {
         socket_path: socket_path.clone(),
-        sync_socket_path: temp_dir.path().join("test-runtimed-sync.sock"),
         cache_dir: temp_dir.path().join("envs"),
+        blob_store_dir: temp_dir.path().join("blobs"),
         uv_pool_size: 0,
         conda_pool_size: 0,
         max_age_secs: 3600,

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -198,3 +198,78 @@ async fn test_try_get_pooled_env_no_daemon() {
     let result = client.take(EnvType::Uv).await;
     assert!(result.is_err(), "should fail when daemon is not running");
 }
+
+#[tokio::test]
+async fn test_settings_sync_via_unified_socket() {
+    use runtimed::sync_client::SyncClient;
+
+    let temp_dir = TempDir::new().unwrap();
+    let config = test_config(&temp_dir);
+    let socket_path = config.socket_path.clone();
+
+    let daemon = Daemon::new(config).unwrap();
+    let daemon_handle = tokio::spawn(async move {
+        daemon.run().await.ok();
+    });
+
+    // Wait for daemon to be ready (via pool channel)
+    let pool_client = PoolClient::new(socket_path.clone());
+    assert!(wait_for_daemon(&pool_client, Duration::from_secs(5)).await);
+
+    // Connect a SyncClient through the unified socket
+    let sync_client = SyncClient::connect_with_timeout(socket_path, Duration::from_secs(2))
+        .await
+        .expect("SyncClient should connect via unified socket");
+
+    // Read settings — verifies the sync handshake completed and we have
+    // a valid local replica. Exact values depend on persisted state.
+    let settings = sync_client.get_all();
+    // Smoke check: theme field is populated (any valid variant)
+    let _ = serde_json::to_string(&settings.theme).unwrap();
+
+    // Shutdown
+    pool_client.shutdown().await.ok();
+    let _ = tokio::time::timeout(Duration::from_secs(2), daemon_handle).await;
+}
+
+#[tokio::test]
+async fn test_blob_server_health() {
+    let temp_dir = TempDir::new().unwrap();
+    let config = test_config(&temp_dir);
+    let socket_path = config.socket_path.clone();
+
+    let daemon = Daemon::new(config).unwrap();
+    let daemon_handle = tokio::spawn(async move {
+        daemon.run().await.ok();
+    });
+
+    let client = PoolClient::new(socket_path);
+    assert!(wait_for_daemon(&client, Duration::from_secs(5)).await);
+
+    // Read daemon info to find blob port
+    let info_path = temp_dir.path().join("daemon.json");
+    let info_json = tokio::fs::read_to_string(&info_path)
+        .await
+        .expect("daemon.json should exist");
+    let info: serde_json::Value = serde_json::from_str(&info_json).unwrap();
+    let blob_port = info["blob_port"].as_u64().expect("blob_port should be set");
+
+    // Hit the health endpoint
+    let resp = reqwest::get(format!("http://127.0.0.1:{}/health", blob_port))
+        .await
+        .expect("health request should succeed");
+    assert_eq!(resp.status(), 200);
+    let body = resp.text().await.unwrap();
+    assert_eq!(body, "OK");
+
+    // Hit a non-existent blob — should 404
+    let fake_hash = "a".repeat(64);
+    let resp = reqwest::get(format!("http://127.0.0.1:{}/blob/{}", blob_port, fake_hash))
+        .await
+        .expect("blob request should succeed");
+    assert_eq!(resp.status(), 404);
+
+    // Shutdown
+    client.shutdown().await.ok();
+    let _ = tokio::time::timeout(Duration::from_secs(2), daemon_handle).await;
+}

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -190,7 +190,11 @@ async fn test_multiple_client_connections() {
 
 #[tokio::test]
 async fn test_try_get_pooled_env_no_daemon() {
-    // When daemon is not running, should return None gracefully
-    let result = runtimed::client::try_get_pooled_env(EnvType::Uv).await;
-    assert!(result.is_none());
+    // Use a temp dir so we don't accidentally connect to a real running daemon
+    let temp_dir = TempDir::new().unwrap();
+    let socket_path = temp_dir.path().join("nonexistent.sock");
+
+    let client = PoolClient::new(socket_path);
+    let result = client.take(EnvType::Uv).await;
+    assert!(result.is_err(), "should fail when daemon is not running");
 }

--- a/src/bindings/SyncedSettings.ts
+++ b/src/bindings/SyncedSettings.ts
@@ -8,23 +8,23 @@ import type { UvDefaults } from "./UvDefaults";
 /**
  * Snapshot of all synced settings.
  */
-export type SyncedSettings = { 
+export type SyncedSettings = {
 /**
  * UI theme
  */
-theme: ThemeMode, 
+theme: ThemeMode,
 /**
  * Default runtime for new notebooks
  */
-default_runtime: Runtime, 
+default_runtime: Runtime,
 /**
  * Default Python environment type (uv or conda)
  */
-default_python_env: PythonEnvType, 
+default_python_env: PythonEnvType,
 /**
  * UV environment defaults
  */
-uv: UvDefaults, 
+uv: UvDefaults,
 /**
  * Conda environment defaults
  */


### PR DESCRIPTION
## Summary

- **Blob store** (`blob_store.rs`): Content-addressed on-disk storage using SHA-256, with two-level hex sharding, metadata sidecars, atomic writes, and concurrent-put safety.
- **Blob HTTP server** (`blob_server.rs`): Read-only hyper 1.x server on `127.0.0.1:0` serving `GET /blob/{hash}` with correct `Content-Type`, immutable cache headers, and CORS.
- **Socket consolidation**: Unifies the two separate daemon sockets (`runtimed.sock` for pool IPC, `runtimed-sync.sock` for settings sync) into a single multiplexed socket. Connections identify their channel via a JSON handshake as the first frame. The shared framing module (`connection.rs`) replaces duplicated length-prefixed code.
- **CLI tooling**: `runt pool info` (with liveness verification) and `runt pool flush` commands for daemon health checks.

This is the foundation for moving notebook outputs (images, HTML, rich data) out of the automerge CRDT document into content-addressed storage.

## What changed

The NDJSON line protocol between pool client and daemon is replaced with length-prefixed binary framing. The separate settings sync socket is removed — all IPC goes through the unified `runtimed.sock`. Both sockets were introduced earlier this week so there's no backward-compatibility concern.

The blob write path goes through the IPC socket (`BlobRequest::Store` + binary data frame), while the read path is HTTP (`GET /blob/{hash}`). The daemon writes `blob_port` into `daemon.json` so clients can discover it.

## Verification

- [x] `runt pool info` reports daemon version, PID, blob port, and uptime; shows "STALE" when daemon is down
- [x] `curl http://127.0.0.1:{blob_port}/health` returns `OK`
- [x] Store a blob via IPC, fetch via HTTP — correct bytes and `Content-Type`

_PR submitted by @rgbkrk's agent, Quill_