### PR TITLE
Add Automerge notebook document sync to runtimed

### DIFF
--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -42,6 +42,8 @@ pub struct DaemonConfig {
     pub cache_dir: PathBuf,
     /// Directory for the content-addressed blob store.
     pub blob_store_dir: PathBuf,
+    /// Directory for persisted notebook Automerge documents.
+    pub notebook_docs_dir: PathBuf,
     /// Target number of UV environments to maintain.
     pub uv_pool_size: usize,
     /// Target number of Conda environments to maintain.
@@ -58,6 +60,7 @@ impl Default for DaemonConfig {
             socket_path: default_socket_path(),
             cache_dir: default_cache_dir(),
             blob_store_dir: default_blob_store_dir(),
+            notebook_docs_dir: crate::default_notebook_docs_dir(),
             uv_pool_size: 3,
             conda_pool_size: 3,
             max_age_secs: 172800, // 2 days
@@ -641,7 +644,7 @@ impl Daemon {
             }
             Handshake::NotebookSync { notebook_id } => {
                 info!("[runtimed] NotebookSync requested for {}", notebook_id);
-                let docs_dir = crate::default_notebook_docs_dir();
+                let docs_dir = self.config.notebook_docs_dir.clone();
                 let room = {
                     let mut rooms = self.notebook_rooms.lock().await;
                     crate::notebook_sync_server::get_or_create_room(

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -654,8 +654,14 @@ impl Daemon {
                     )
                 };
                 let (reader, writer) = tokio::io::split(stream);
-                crate::notebook_sync_server::handle_notebook_sync_connection(reader, writer, room)
-                    .await
+                crate::notebook_sync_server::handle_notebook_sync_connection(
+                    reader,
+                    writer,
+                    room,
+                    self.notebook_rooms.clone(),
+                    notebook_id,
+                )
+                .await
             }
             Handshake::Blob => self.handle_blob_connection(stream).await,
         }

--- a/crates/runtimed/src/lib.rs
+++ b/crates/runtimed/src/lib.rs
@@ -16,6 +16,9 @@ pub mod blob_store;
 pub mod client;
 pub mod connection;
 pub mod daemon;
+pub mod notebook_doc;
+pub mod notebook_sync_client;
+pub mod notebook_sync_server;
 pub mod protocol;
 pub mod runtime;
 pub mod service;
@@ -118,4 +121,12 @@ pub fn settings_schema_path() -> PathBuf {
         .unwrap_or_else(|| PathBuf::from("."))
         .join("runt-notebook")
         .join("settings.schema.json")
+}
+
+/// Get the default directory for persisted notebook Automerge documents.
+pub fn default_notebook_docs_dir() -> PathBuf {
+    dirs::cache_dir()
+        .unwrap_or_else(|| PathBuf::from("/tmp"))
+        .join("runt")
+        .join("notebook-docs")
 }

--- a/crates/runtimed/src/notebook_doc.rs
+++ b/crates/runtimed/src/notebook_doc.rs
@@ -1,0 +1,872 @@
+//! Automerge-backed notebook document for cross-window sync.
+//!
+//! Wraps an Automerge `AutoCommit` document with typed accessors for
+//! notebook cells, outputs, and metadata. The daemon holds the canonical
+//! copy in a "room"; each connected notebook window holds a local replica
+//! that syncs via the Automerge sync protocol.
+//!
+//! ## Document schema
+//!
+//! ```text
+//! ROOT/
+//!   notebook_id: Str
+//!   cells/                        ← List of Map
+//!     [i]/
+//!       id: Str                   ← cell UUID
+//!       cell_type: Str            ← "code" | "markdown" | "raw"
+//!       source: Text              ← Automerge Text CRDT (character-level merging)
+//!       execution_count: Str      ← JSON-encoded i32 or "null"
+//!       outputs/                  ← List of Str
+//!         [j]: Str                ← JSON-encoded Jupyter output (Phase 5: manifest hash)
+//!   metadata/                     ← Map
+//!     runtime: Str
+//! ```
+
+use std::path::Path;
+
+use automerge::sync;
+use automerge::sync::SyncDoc;
+use automerge::transaction::Transactable;
+use automerge::{AutoCommit, AutomergeError, ObjId, ObjType, ReadDoc};
+use log::info;
+use serde::{Deserialize, Serialize};
+
+/// Snapshot of a single cell's state, suitable for serialization.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CellSnapshot {
+    pub id: String,
+    /// "code", "markdown", or "raw"
+    pub cell_type: String,
+    pub source: String,
+    /// JSON-encoded execution count: a number string like "5" or "null"
+    pub execution_count: String,
+    /// JSON-encoded Jupyter output objects (will become manifest hashes in Phase 5)
+    pub outputs: Vec<String>,
+}
+
+/// Wrapper around an Automerge document storing a notebook.
+pub struct NotebookDoc {
+    doc: AutoCommit,
+}
+
+impl NotebookDoc {
+    /// Create a new empty notebook document with the given ID.
+    pub fn new(notebook_id: &str) -> Self {
+        let mut doc = AutoCommit::new();
+
+        let _ = doc.put(automerge::ROOT, "notebook_id", notebook_id);
+
+        // cells: empty List
+        let _ = doc.put_object(automerge::ROOT, "cells", ObjType::List);
+
+        // metadata: Map with default runtime
+        if let Ok(meta_id) = doc.put_object(automerge::ROOT, "metadata", ObjType::Map) {
+            let _ = doc.put(&meta_id, "runtime", "python");
+        }
+
+        Self { doc }
+    }
+
+    /// Load a notebook document from saved bytes.
+    pub fn load(data: &[u8]) -> Result<Self, AutomergeError> {
+        let doc = AutoCommit::load(data)?;
+        Ok(Self { doc })
+    }
+
+    /// Load from file or create a new document if the file doesn't exist.
+    pub fn load_or_create(path: &Path, notebook_id: &str) -> Self {
+        if path.exists() {
+            if let Ok(data) = std::fs::read(path) {
+                if let Ok(doc) = AutoCommit::load(&data) {
+                    info!("[notebook-doc] Loaded from {:?} for {}", path, notebook_id);
+                    return Self { doc };
+                }
+            }
+        }
+
+        info!(
+            "[notebook-doc] Creating new doc for {} (path: {:?})",
+            notebook_id, path
+        );
+        Self::new(notebook_id)
+    }
+
+    /// Serialize the document to bytes.
+    pub fn save(&mut self) -> Vec<u8> {
+        self.doc.save()
+    }
+
+    /// Save the document to a file.
+    pub fn save_to_file(&mut self, path: &Path) -> std::io::Result<()> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let data = self.save();
+        std::fs::write(path, data)
+    }
+
+    // ── Notebook ID ─────────────────────────────────────────────────
+
+    /// Read the notebook ID from the document.
+    pub fn notebook_id(&self) -> Option<String> {
+        read_str(&self.doc, automerge::ROOT, "notebook_id")
+    }
+
+    // ── Cell CRUD ───────────────────────────────────────────────────
+
+    /// Number of cells in the notebook.
+    pub fn cell_count(&self) -> usize {
+        match self.cells_list_id() {
+            Some(id) => self.doc.length(&id),
+            None => 0,
+        }
+    }
+
+    /// Get all cells as snapshots, in order.
+    pub fn get_cells(&self) -> Vec<CellSnapshot> {
+        let cells_id = match self.cells_list_id() {
+            Some(id) => id,
+            None => return vec![],
+        };
+        let len = self.doc.length(&cells_id);
+        (0..len)
+            .filter_map(|i| {
+                let cell_obj = self.cell_at_index(&cells_id, i)?;
+                self.read_cell(&cell_obj)
+            })
+            .collect()
+    }
+
+    /// Get a single cell by ID.
+    pub fn get_cell(&self, cell_id: &str) -> Option<CellSnapshot> {
+        let cells_id = self.cells_list_id()?;
+        let idx = self.find_cell_index(&cells_id, cell_id)?;
+        let cell_obj = self.cell_at_index(&cells_id, idx)?;
+        self.read_cell(&cell_obj)
+    }
+
+    /// Insert a new cell at the given index.
+    ///
+    /// Returns `Ok(())` on success. The cell starts with empty source and no outputs.
+    pub fn add_cell(
+        &mut self,
+        index: usize,
+        cell_id: &str,
+        cell_type: &str,
+    ) -> Result<(), AutomergeError> {
+        let cells_id = self
+            .cells_list_id()
+            .ok_or_else(|| AutomergeError::InvalidObjId("cells list not found".into()))?;
+
+        // Clamp index to list length
+        let len = self.doc.length(&cells_id);
+        let index = index.min(len);
+
+        let cell_map = self.doc.insert_object(&cells_id, index, ObjType::Map)?;
+        self.doc.put(&cell_map, "id", cell_id)?;
+        self.doc.put(&cell_map, "cell_type", cell_type)?;
+        self.doc.put_object(&cell_map, "source", ObjType::Text)?;
+        self.doc.put(&cell_map, "execution_count", "null")?;
+        self.doc.put_object(&cell_map, "outputs", ObjType::List)?;
+        Ok(())
+    }
+
+    /// Delete a cell by ID. Returns `true` if the cell was found and deleted.
+    pub fn delete_cell(&mut self, cell_id: &str) -> Result<bool, AutomergeError> {
+        let cells_id = match self.cells_list_id() {
+            Some(id) => id,
+            None => return Ok(false),
+        };
+        match self.find_cell_index(&cells_id, cell_id) {
+            Some(idx) => {
+                self.doc.delete(&cells_id, idx)?;
+                Ok(true)
+            }
+            None => Ok(false),
+        }
+    }
+
+    // ── Source editing ───────────────────────────────────────────────
+
+    /// Replace a cell's source text.
+    ///
+    /// Uses `update_text` which performs a Myers diff internally, producing
+    /// minimal CRDT operations for better concurrent edit merging.
+    pub fn update_source(
+        &mut self,
+        cell_id: &str,
+        new_source: &str,
+    ) -> Result<bool, AutomergeError> {
+        let cells_id = match self.cells_list_id() {
+            Some(id) => id,
+            None => return Ok(false),
+        };
+        let idx = match self.find_cell_index(&cells_id, cell_id) {
+            Some(i) => i,
+            None => return Ok(false),
+        };
+        let cell_obj = match self.cell_at_index(&cells_id, idx) {
+            Some(o) => o,
+            None => return Ok(false),
+        };
+        let source_id = match self.text_id(&cell_obj, "source") {
+            Some(id) => id,
+            None => return Ok(false),
+        };
+
+        self.doc.update_text(&source_id, new_source)?;
+        Ok(true)
+    }
+
+    // ── Output management ───────────────────────────────────────────
+
+    /// Replace all outputs for a cell.
+    pub fn set_outputs(
+        &mut self,
+        cell_id: &str,
+        outputs: &[String],
+    ) -> Result<bool, AutomergeError> {
+        let cells_id = match self.cells_list_id() {
+            Some(id) => id,
+            None => return Ok(false),
+        };
+        let idx = match self.find_cell_index(&cells_id, cell_id) {
+            Some(i) => i,
+            None => return Ok(false),
+        };
+        let cell_obj = match self.cell_at_index(&cells_id, idx) {
+            Some(o) => o,
+            None => return Ok(false),
+        };
+
+        // Delete existing outputs and create fresh list
+        let _ = self.doc.delete(&cell_obj, "outputs");
+        let list_id = self.doc.put_object(&cell_obj, "outputs", ObjType::List)?;
+        for (i, output) in outputs.iter().enumerate() {
+            self.doc.insert(&list_id, i, output.as_str())?;
+        }
+        Ok(true)
+    }
+
+    /// Append a single output to a cell's output list.
+    pub fn append_output(&mut self, cell_id: &str, output: &str) -> Result<bool, AutomergeError> {
+        let cells_id = match self.cells_list_id() {
+            Some(id) => id,
+            None => return Ok(false),
+        };
+        let idx = match self.find_cell_index(&cells_id, cell_id) {
+            Some(i) => i,
+            None => return Ok(false),
+        };
+        let cell_obj = match self.cell_at_index(&cells_id, idx) {
+            Some(o) => o,
+            None => return Ok(false),
+        };
+        let outputs_id = match self.list_id(&cell_obj, "outputs") {
+            Some(id) => id,
+            None => return Ok(false),
+        };
+
+        let len = self.doc.length(&outputs_id);
+        self.doc.insert(&outputs_id, len, output)?;
+        Ok(true)
+    }
+
+    /// Clear all outputs from a cell.
+    pub fn clear_outputs(&mut self, cell_id: &str) -> Result<bool, AutomergeError> {
+        self.set_outputs(cell_id, &[])
+    }
+
+    // ── Execution count ─────────────────────────────────────────────
+
+    /// Set the execution count for a cell. Pass "null" or a number string like "5".
+    pub fn set_execution_count(
+        &mut self,
+        cell_id: &str,
+        count: &str,
+    ) -> Result<bool, AutomergeError> {
+        let cells_id = match self.cells_list_id() {
+            Some(id) => id,
+            None => return Ok(false),
+        };
+        let idx = match self.find_cell_index(&cells_id, cell_id) {
+            Some(i) => i,
+            None => return Ok(false),
+        };
+        let cell_obj = match self.cell_at_index(&cells_id, idx) {
+            Some(o) => o,
+            None => return Ok(false),
+        };
+
+        self.doc.put(&cell_obj, "execution_count", count)?;
+        Ok(true)
+    }
+
+    // ── Metadata ────────────────────────────────────────────────────
+
+    /// Read a metadata value.
+    pub fn get_metadata(&self, key: &str) -> Option<String> {
+        let meta_id = self.metadata_map_id()?;
+        read_str(&self.doc, meta_id, key)
+    }
+
+    /// Set a metadata value.
+    pub fn set_metadata(&mut self, key: &str, value: &str) -> Result<(), AutomergeError> {
+        let meta_id = match self.metadata_map_id() {
+            Some(id) => id,
+            None => {
+                // Create metadata map if missing
+                let id = self
+                    .doc
+                    .put_object(automerge::ROOT, "metadata", ObjType::Map)?;
+                self.doc.put(&id, key, value)?;
+                return Ok(());
+            }
+        };
+        self.doc.put(&meta_id, key, value)?;
+        Ok(())
+    }
+
+    // ── Sync protocol ───────────────────────────────────────────────
+
+    /// Generate a sync message to send to a peer.
+    pub fn generate_sync_message(&mut self, peer_state: &mut sync::State) -> Option<sync::Message> {
+        self.doc.sync().generate_sync_message(peer_state)
+    }
+
+    /// Receive and apply a sync message from a peer.
+    pub fn receive_sync_message(
+        &mut self,
+        peer_state: &mut sync::State,
+        message: sync::Message,
+    ) -> Result<(), AutomergeError> {
+        self.doc.sync().receive_sync_message(peer_state, message)
+    }
+
+    // ── Internal helpers ────────────────────────────────────────────
+
+    fn cells_list_id(&self) -> Option<ObjId> {
+        self.doc
+            .get(automerge::ROOT, "cells")
+            .ok()
+            .flatten()
+            .and_then(|(value, id)| match value {
+                automerge::Value::Object(ObjType::List) => Some(id),
+                _ => None,
+            })
+    }
+
+    fn metadata_map_id(&self) -> Option<ObjId> {
+        self.doc
+            .get(automerge::ROOT, "metadata")
+            .ok()
+            .flatten()
+            .and_then(|(value, id)| match value {
+                automerge::Value::Object(ObjType::Map) => Some(id),
+                _ => None,
+            })
+    }
+
+    fn cell_at_index(&self, cells_id: &ObjId, index: usize) -> Option<ObjId> {
+        self.doc
+            .get(cells_id, index)
+            .ok()
+            .flatten()
+            .and_then(|(value, id)| match value {
+                automerge::Value::Object(ObjType::Map) => Some(id),
+                _ => None,
+            })
+    }
+
+    fn find_cell_index(&self, cells_id: &ObjId, cell_id: &str) -> Option<usize> {
+        let len = self.doc.length(cells_id);
+        for i in 0..len {
+            if let Some(cell_obj) = self.cell_at_index(cells_id, i) {
+                if read_str(&self.doc, &cell_obj, "id").as_deref() == Some(cell_id) {
+                    return Some(i);
+                }
+            }
+        }
+        None
+    }
+
+    fn text_id(&self, parent: &ObjId, key: &str) -> Option<ObjId> {
+        self.doc
+            .get(parent, key)
+            .ok()
+            .flatten()
+            .and_then(|(value, id)| match value {
+                automerge::Value::Object(ObjType::Text) => Some(id),
+                _ => None,
+            })
+    }
+
+    fn list_id(&self, parent: &ObjId, key: &str) -> Option<ObjId> {
+        self.doc
+            .get(parent, key)
+            .ok()
+            .flatten()
+            .and_then(|(value, id)| match value {
+                automerge::Value::Object(ObjType::List) => Some(id),
+                _ => None,
+            })
+    }
+
+    fn read_cell(&self, cell_obj: &ObjId) -> Option<CellSnapshot> {
+        let id = read_str(&self.doc, cell_obj, "id")?;
+        let cell_type = read_str(&self.doc, cell_obj, "cell_type").unwrap_or_default();
+        let execution_count =
+            read_str(&self.doc, cell_obj, "execution_count").unwrap_or_else(|| "null".to_string());
+
+        // Read source from Text CRDT
+        let source = self
+            .text_id(cell_obj, "source")
+            .and_then(|text_id| self.doc.text(&text_id).ok())
+            .unwrap_or_default();
+
+        // Read outputs list
+        let outputs = match self.list_id(cell_obj, "outputs") {
+            Some(list_id) => {
+                let len = self.doc.length(&list_id);
+                (0..len)
+                    .filter_map(|i| read_str(&self.doc, &list_id, i))
+                    .collect()
+            }
+            None => vec![],
+        };
+
+        Some(CellSnapshot {
+            id,
+            cell_type,
+            source,
+            execution_count,
+            outputs,
+        })
+    }
+}
+
+// ── Free helpers ─────────────────────────────────────────────────────
+
+/// Read a scalar string from any Automerge object by key.
+fn read_str<O: AsRef<automerge::ObjId>, P: Into<automerge::Prop>>(
+    doc: &AutoCommit,
+    obj: O,
+    prop: P,
+) -> Option<String> {
+    doc.get(obj, prop)
+        .ok()
+        .flatten()
+        .and_then(|(value, _)| match value {
+            automerge::Value::Scalar(s) => match s.as_ref() {
+                automerge::ScalarValue::Str(s) => Some(s.to_string()),
+                _ => None,
+            },
+            _ => None,
+        })
+}
+
+/// Compute a safe filename for persisting a notebook document.
+///
+/// Hashes the notebook_id (which could be a file path with special characters)
+/// using SHA-256 to produce a safe, deterministic filename.
+pub fn notebook_doc_filename(notebook_id: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let hash = hex::encode(Sha256::digest(notebook_id.as_bytes()));
+    format!("{}.automerge", hash)
+}
+
+/// Read cells from a raw AutoCommit document (used by the sync client).
+pub fn get_cells_from_doc(doc: &AutoCommit) -> Vec<CellSnapshot> {
+    let cells_id = match doc.get(automerge::ROOT, "cells").ok().flatten() {
+        Some((automerge::Value::Object(ObjType::List), id)) => id,
+        _ => return vec![],
+    };
+
+    let len = doc.length(&cells_id);
+    (0..len)
+        .filter_map(|i| {
+            let cell_obj = match doc.get(&cells_id, i).ok().flatten() {
+                Some((automerge::Value::Object(ObjType::Map), id)) => id,
+                _ => return None,
+            };
+
+            let id = read_str(doc, &cell_obj, "id")?;
+            let cell_type = read_str(doc, &cell_obj, "cell_type").unwrap_or_default();
+            let execution_count =
+                read_str(doc, &cell_obj, "execution_count").unwrap_or_else(|| "null".to_string());
+
+            let source = doc
+                .get(&cell_obj, "source")
+                .ok()
+                .flatten()
+                .and_then(|(value, text_id)| match value {
+                    automerge::Value::Object(ObjType::Text) => doc.text(&text_id).ok(),
+                    _ => None,
+                })
+                .unwrap_or_default();
+
+            let outputs = match doc.get(&cell_obj, "outputs").ok().flatten() {
+                Some((automerge::Value::Object(ObjType::List), list_id)) => {
+                    let len = doc.length(&list_id);
+                    (0..len)
+                        .filter_map(|j| read_str(doc, &list_id, j))
+                        .collect()
+                }
+                _ => vec![],
+            };
+
+            Some(CellSnapshot {
+                id,
+                cell_type,
+                source,
+                execution_count,
+                outputs,
+            })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_has_empty_cells() {
+        let doc = NotebookDoc::new("test-notebook");
+        assert_eq!(doc.notebook_id(), Some("test-notebook".to_string()));
+        assert_eq!(doc.cell_count(), 0);
+        assert_eq!(doc.get_cells(), vec![]);
+        assert_eq!(doc.get_metadata("runtime"), Some("python".to_string()));
+    }
+
+    #[test]
+    fn test_add_and_get_cell() {
+        let mut doc = NotebookDoc::new("nb1");
+        doc.add_cell(0, "cell-1", "code").unwrap();
+
+        assert_eq!(doc.cell_count(), 1);
+        let cell = doc.get_cell("cell-1").unwrap();
+        assert_eq!(cell.id, "cell-1");
+        assert_eq!(cell.cell_type, "code");
+        assert_eq!(cell.source, "");
+        assert_eq!(cell.execution_count, "null");
+        assert!(cell.outputs.is_empty());
+    }
+
+    #[test]
+    fn test_add_multiple_cells_ordering() {
+        let mut doc = NotebookDoc::new("nb1");
+        doc.add_cell(0, "first", "code").unwrap();
+        doc.add_cell(1, "second", "markdown").unwrap();
+        doc.add_cell(1, "middle", "code").unwrap(); // insert between first and second
+
+        let cells = doc.get_cells();
+        assert_eq!(cells.len(), 3);
+        assert_eq!(cells[0].id, "first");
+        assert_eq!(cells[1].id, "middle");
+        assert_eq!(cells[2].id, "second");
+    }
+
+    #[test]
+    fn test_add_cell_clamps_index() {
+        let mut doc = NotebookDoc::new("nb1");
+        // Index 100 on empty list should work (clamped to 0)
+        doc.add_cell(100, "cell-1", "code").unwrap();
+        assert_eq!(doc.cell_count(), 1);
+        assert_eq!(doc.get_cells()[0].id, "cell-1");
+    }
+
+    #[test]
+    fn test_delete_cell() {
+        let mut doc = NotebookDoc::new("nb1");
+        doc.add_cell(0, "cell-1", "code").unwrap();
+        doc.add_cell(1, "cell-2", "markdown").unwrap();
+
+        let deleted = doc.delete_cell("cell-1").unwrap();
+        assert!(deleted);
+        assert_eq!(doc.cell_count(), 1);
+        assert_eq!(doc.get_cells()[0].id, "cell-2");
+    }
+
+    #[test]
+    fn test_delete_nonexistent_cell() {
+        let mut doc = NotebookDoc::new("nb1");
+        let deleted = doc.delete_cell("nope").unwrap();
+        assert!(!deleted);
+    }
+
+    #[test]
+    fn test_update_source() {
+        let mut doc = NotebookDoc::new("nb1");
+        doc.add_cell(0, "cell-1", "code").unwrap();
+
+        doc.update_source("cell-1", "print('hello')").unwrap();
+        let cell = doc.get_cell("cell-1").unwrap();
+        assert_eq!(cell.source, "print('hello')");
+
+        // Update again
+        doc.update_source("cell-1", "print('world')").unwrap();
+        let cell = doc.get_cell("cell-1").unwrap();
+        assert_eq!(cell.source, "print('world')");
+    }
+
+    #[test]
+    fn test_update_source_empty() {
+        let mut doc = NotebookDoc::new("nb1");
+        doc.add_cell(0, "cell-1", "code").unwrap();
+        doc.update_source("cell-1", "some code").unwrap();
+        doc.update_source("cell-1", "").unwrap();
+        let cell = doc.get_cell("cell-1").unwrap();
+        assert_eq!(cell.source, "");
+    }
+
+    #[test]
+    fn test_update_source_nonexistent_cell() {
+        let mut doc = NotebookDoc::new("nb1");
+        let result = doc.update_source("nope", "code").unwrap();
+        assert!(!result);
+    }
+
+    #[test]
+    fn test_set_outputs() {
+        let mut doc = NotebookDoc::new("nb1");
+        doc.add_cell(0, "cell-1", "code").unwrap();
+
+        let outputs = vec![
+            r#"{"output_type":"stream","name":"stdout","text":"hello\n"}"#.to_string(),
+            r#"{"output_type":"execute_result","data":{"text/plain":"42"}}"#.to_string(),
+        ];
+        doc.set_outputs("cell-1", &outputs).unwrap();
+
+        let cell = doc.get_cell("cell-1").unwrap();
+        assert_eq!(cell.outputs, outputs);
+    }
+
+    #[test]
+    fn test_append_output() {
+        let mut doc = NotebookDoc::new("nb1");
+        doc.add_cell(0, "cell-1", "code").unwrap();
+
+        doc.append_output("cell-1", r#"{"output_type":"stream"}"#)
+            .unwrap();
+        doc.append_output("cell-1", r#"{"output_type":"display_data"}"#)
+            .unwrap();
+
+        let cell = doc.get_cell("cell-1").unwrap();
+        assert_eq!(cell.outputs.len(), 2);
+        assert!(cell.outputs[0].contains("stream"));
+        assert!(cell.outputs[1].contains("display_data"));
+    }
+
+    #[test]
+    fn test_clear_outputs() {
+        let mut doc = NotebookDoc::new("nb1");
+        doc.add_cell(0, "cell-1", "code").unwrap();
+        doc.append_output("cell-1", "output1").unwrap();
+        doc.append_output("cell-1", "output2").unwrap();
+
+        doc.clear_outputs("cell-1").unwrap();
+        let cell = doc.get_cell("cell-1").unwrap();
+        assert!(cell.outputs.is_empty());
+    }
+
+    #[test]
+    fn test_set_execution_count() {
+        let mut doc = NotebookDoc::new("nb1");
+        doc.add_cell(0, "cell-1", "code").unwrap();
+
+        doc.set_execution_count("cell-1", "42").unwrap();
+        let cell = doc.get_cell("cell-1").unwrap();
+        assert_eq!(cell.execution_count, "42");
+
+        doc.set_execution_count("cell-1", "null").unwrap();
+        let cell = doc.get_cell("cell-1").unwrap();
+        assert_eq!(cell.execution_count, "null");
+    }
+
+    #[test]
+    fn test_metadata() {
+        let mut doc = NotebookDoc::new("nb1");
+        assert_eq!(doc.get_metadata("runtime"), Some("python".to_string()));
+
+        doc.set_metadata("runtime", "deno").unwrap();
+        assert_eq!(doc.get_metadata("runtime"), Some("deno".to_string()));
+
+        doc.set_metadata("custom_key", "custom_value").unwrap();
+        assert_eq!(
+            doc.get_metadata("custom_key"),
+            Some("custom_value".to_string())
+        );
+    }
+
+    #[test]
+    fn test_save_and_load() {
+        let mut doc = NotebookDoc::new("nb1");
+        doc.add_cell(0, "cell-1", "code").unwrap();
+        doc.update_source("cell-1", "x = 42").unwrap();
+        doc.set_execution_count("cell-1", "1").unwrap();
+        doc.append_output("cell-1", r#"{"output_type":"execute_result"}"#)
+            .unwrap();
+        doc.add_cell(1, "cell-2", "markdown").unwrap();
+        doc.update_source("cell-2", "# Hello").unwrap();
+
+        let bytes = doc.save();
+        let loaded = NotebookDoc::load(&bytes).unwrap();
+
+        assert_eq!(loaded.notebook_id(), Some("nb1".to_string()));
+        let cells = loaded.get_cells();
+        assert_eq!(cells.len(), 2);
+        assert_eq!(cells[0].id, "cell-1");
+        assert_eq!(cells[0].source, "x = 42");
+        assert_eq!(cells[0].execution_count, "1");
+        assert_eq!(cells[0].outputs.len(), 1);
+        assert_eq!(cells[1].id, "cell-2");
+        assert_eq!(cells[1].source, "# Hello");
+    }
+
+    #[test]
+    fn test_save_to_file_and_load_or_create() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("notebook.automerge");
+
+        let mut doc = NotebookDoc::new("file-test");
+        doc.add_cell(0, "c1", "code").unwrap();
+        doc.update_source("c1", "print(1)").unwrap();
+        doc.save_to_file(&path).unwrap();
+
+        let loaded = NotebookDoc::load_or_create(&path, "file-test");
+        assert_eq!(loaded.notebook_id(), Some("file-test".to_string()));
+        let cells = loaded.get_cells();
+        assert_eq!(cells.len(), 1);
+        assert_eq!(cells[0].source, "print(1)");
+    }
+
+    #[test]
+    fn test_load_or_create_missing_file() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("does-not-exist.automerge");
+
+        let doc = NotebookDoc::load_or_create(&path, "new-nb");
+        assert_eq!(doc.notebook_id(), Some("new-nb".to_string()));
+        assert_eq!(doc.cell_count(), 0);
+    }
+
+    #[test]
+    fn test_sync_between_two_docs() {
+        // Server creates a notebook with cells
+        let mut server = NotebookDoc::new("sync-test");
+        server.add_cell(0, "cell-1", "code").unwrap();
+        server.update_source("cell-1", "import numpy").unwrap();
+        server.set_execution_count("cell-1", "1").unwrap();
+        server
+            .append_output("cell-1", r#"{"output_type":"stream"}"#)
+            .unwrap();
+
+        // Client starts with an empty doc (like a new window joining)
+        let mut client = NotebookDoc {
+            doc: AutoCommit::new(),
+        };
+
+        let mut server_state = sync::State::new();
+        let mut client_state = sync::State::new();
+
+        // Exchange sync messages until convergence
+        for _ in 0..10 {
+            if let Some(msg) = client.generate_sync_message(&mut client_state) {
+                server.receive_sync_message(&mut server_state, msg).unwrap();
+            }
+            if let Some(msg) = server.generate_sync_message(&mut server_state) {
+                client.receive_sync_message(&mut client_state, msg).unwrap();
+            }
+        }
+
+        // Client should now have the same cells
+        assert_eq!(client.notebook_id(), Some("sync-test".to_string()));
+        let cells = client.get_cells();
+        assert_eq!(cells.len(), 1);
+        assert_eq!(cells[0].id, "cell-1");
+        assert_eq!(cells[0].source, "import numpy");
+        assert_eq!(cells[0].execution_count, "1");
+        assert_eq!(cells[0].outputs.len(), 1);
+    }
+
+    #[test]
+    fn test_concurrent_cell_adds_merge() {
+        let mut server = NotebookDoc::new("merge-test");
+        let mut client = NotebookDoc {
+            doc: AutoCommit::new(),
+        };
+
+        let mut server_state = sync::State::new();
+        let mut client_state = sync::State::new();
+
+        // Initial sync to share the base document
+        for _ in 0..10 {
+            if let Some(msg) = client.generate_sync_message(&mut client_state) {
+                server.receive_sync_message(&mut server_state, msg).unwrap();
+            }
+            if let Some(msg) = server.generate_sync_message(&mut server_state) {
+                client.receive_sync_message(&mut client_state, msg).unwrap();
+            }
+        }
+
+        // Both add different cells concurrently (before syncing)
+        server.add_cell(0, "server-cell", "code").unwrap();
+        server.update_source("server-cell", "# server").unwrap();
+
+        client.add_cell(0, "client-cell", "markdown").unwrap();
+        client.update_source("client-cell", "# client").unwrap();
+
+        // Sync again
+        for _ in 0..10 {
+            if let Some(msg) = client.generate_sync_message(&mut client_state) {
+                server.receive_sync_message(&mut server_state, msg).unwrap();
+            }
+            if let Some(msg) = server.generate_sync_message(&mut server_state) {
+                client.receive_sync_message(&mut client_state, msg).unwrap();
+            }
+        }
+
+        // Both should have both cells (order may vary due to CRDT resolution)
+        let server_cells = server.get_cells();
+        let client_cells = client.get_cells();
+        assert_eq!(server_cells.len(), 2);
+        assert_eq!(client_cells.len(), 2);
+
+        let server_ids: Vec<&str> = server_cells.iter().map(|c| c.id.as_str()).collect();
+        let client_ids: Vec<&str> = client_cells.iter().map(|c| c.id.as_str()).collect();
+        assert!(server_ids.contains(&"server-cell"));
+        assert!(server_ids.contains(&"client-cell"));
+        assert_eq!(server_ids, client_ids); // Same order after merge
+    }
+
+    #[test]
+    fn test_notebook_doc_filename_deterministic() {
+        let f1 = notebook_doc_filename("/path/to/notebook.ipynb");
+        let f2 = notebook_doc_filename("/path/to/notebook.ipynb");
+        assert_eq!(f1, f2);
+        assert!(f1.ends_with(".automerge"));
+        // Different paths produce different filenames
+        let f3 = notebook_doc_filename("/other/path.ipynb");
+        assert_ne!(f1, f3);
+    }
+
+    #[test]
+    fn test_get_cells_from_doc_helper() {
+        let mut doc = NotebookDoc::new("helper-test");
+        doc.add_cell(0, "c1", "code").unwrap();
+        doc.update_source("c1", "x = 1").unwrap();
+
+        let cells = get_cells_from_doc(&doc.doc);
+        assert_eq!(cells.len(), 1);
+        assert_eq!(cells[0].id, "c1");
+        assert_eq!(cells[0].source, "x = 1");
+    }
+
+    #[test]
+    fn test_get_cells_from_empty_doc() {
+        let doc = AutoCommit::new();
+        let cells = get_cells_from_doc(&doc);
+        assert!(cells.is_empty());
+    }
+}

--- a/crates/runtimed/src/notebook_sync_client.rs
+++ b/crates/runtimed/src/notebook_sync_client.rs
@@ -1,0 +1,7 @@
+//! Client for the notebook sync service.
+//!
+//! Each notebook window creates a `NotebookSyncClient` that maintains a local
+//! Automerge document replica of the notebook. Changes made locally are sent
+//! to the daemon, and changes from other peers arrive as sync messages.
+
+// Implementation coming in next commit.

--- a/crates/runtimed/src/notebook_sync_client.rs
+++ b/crates/runtimed/src/notebook_sync_client.rs
@@ -3,5 +3,481 @@
 //! Each notebook window creates a `NotebookSyncClient` that maintains a local
 //! Automerge document replica of the notebook. Changes made locally are sent
 //! to the daemon, and changes from other peers arrive as sync messages.
+//!
+//! Follows the same pattern as `sync_client.rs` (settings sync client).
 
-// Implementation coming in next commit.
+use std::path::PathBuf;
+use std::time::Duration;
+
+use automerge::sync::{self, SyncDoc};
+use automerge::transaction::Transactable;
+use automerge::{AutoCommit, ObjType, ReadDoc};
+use log::info;
+use tokio::io::{AsyncRead, AsyncWrite};
+
+use crate::connection::{self, Handshake};
+use crate::notebook_doc::{get_cells_from_doc, CellSnapshot};
+
+/// Error type for notebook sync client operations.
+#[derive(Debug, thiserror::Error)]
+pub enum NotebookSyncError {
+    #[error("Failed to connect: {0}")]
+    ConnectionFailed(#[from] std::io::Error),
+
+    #[error("Sync protocol error: {0}")]
+    SyncError(String),
+
+    #[error("Connection timeout")]
+    Timeout,
+
+    #[error("Disconnected")]
+    Disconnected,
+
+    #[error("Cell not found: {0}")]
+    CellNotFound(String),
+}
+
+/// Client for the notebook sync service.
+///
+/// Holds a local Automerge document replica that stays in sync with the
+/// daemon's canonical copy for a specific notebook.
+pub struct NotebookSyncClient<S> {
+    doc: AutoCommit,
+    peer_state: sync::State,
+    stream: S,
+    notebook_id: String,
+}
+
+#[cfg(unix)]
+impl NotebookSyncClient<tokio::net::UnixStream> {
+    /// Connect to the daemon and join the notebook room.
+    pub async fn connect(
+        socket_path: PathBuf,
+        notebook_id: String,
+    ) -> Result<Self, NotebookSyncError> {
+        Self::connect_with_timeout(socket_path, notebook_id, Duration::from_secs(2)).await
+    }
+
+    /// Connect with a custom timeout.
+    pub async fn connect_with_timeout(
+        socket_path: PathBuf,
+        notebook_id: String,
+        timeout: Duration,
+    ) -> Result<Self, NotebookSyncError> {
+        let stream = tokio::time::timeout(timeout, tokio::net::UnixStream::connect(&socket_path))
+            .await
+            .map_err(|_| NotebookSyncError::Timeout)?
+            .map_err(NotebookSyncError::ConnectionFailed)?;
+
+        info!(
+            "[notebook-sync-client] Connected to {:?} for {}",
+            socket_path, notebook_id
+        );
+
+        Self::init(stream, notebook_id).await
+    }
+}
+
+#[cfg(windows)]
+impl NotebookSyncClient<tokio::net::windows::named_pipe::NamedPipeClient> {
+    /// Connect to the daemon and join the notebook room.
+    pub async fn connect(
+        socket_path: PathBuf,
+        notebook_id: String,
+    ) -> Result<Self, NotebookSyncError> {
+        let pipe_name = socket_path.to_string_lossy().to_string();
+        let client = tokio::net::windows::named_pipe::ClientOptions::new()
+            .open(&pipe_name)
+            .map_err(NotebookSyncError::ConnectionFailed)?;
+        Self::init(client, notebook_id).await
+    }
+}
+
+impl<S> NotebookSyncClient<S>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    /// Initialize the client by sending the handshake and performing initial sync.
+    async fn init(mut stream: S, notebook_id: String) -> Result<Self, NotebookSyncError> {
+        // Send the channel handshake
+        connection::send_json_frame(
+            &mut stream,
+            &Handshake::NotebookSync {
+                notebook_id: notebook_id.clone(),
+            },
+        )
+        .await
+        .map_err(|e| NotebookSyncError::SyncError(format!("handshake: {}", e)))?;
+
+        let mut doc = AutoCommit::new();
+        let mut peer_state = sync::State::new();
+
+        // The server sends first — receive and apply
+        match connection::recv_frame(&mut stream).await? {
+            Some(data) => {
+                let message = sync::Message::decode(&data)
+                    .map_err(|e| NotebookSyncError::SyncError(format!("decode: {}", e)))?;
+                doc.sync()
+                    .receive_sync_message(&mut peer_state, message)
+                    .map_err(|e| NotebookSyncError::SyncError(format!("receive: {}", e)))?;
+            }
+            None => return Err(NotebookSyncError::Disconnected),
+        }
+
+        // Send our sync message back
+        if let Some(msg) = doc.sync().generate_sync_message(&mut peer_state) {
+            connection::send_frame(&mut stream, &msg.encode()).await?;
+        }
+
+        // Continue sync rounds until no more messages (short timeout)
+        loop {
+            match tokio::time::timeout(
+                Duration::from_millis(100),
+                connection::recv_frame(&mut stream),
+            )
+            .await
+            {
+                Ok(Ok(Some(data))) => {
+                    let message = sync::Message::decode(&data)
+                        .map_err(|e| NotebookSyncError::SyncError(format!("decode: {}", e)))?;
+                    doc.sync()
+                        .receive_sync_message(&mut peer_state, message)
+                        .map_err(|e| NotebookSyncError::SyncError(format!("receive: {}", e)))?;
+
+                    if let Some(msg) = doc.sync().generate_sync_message(&mut peer_state) {
+                        connection::send_frame(&mut stream, &msg.encode()).await?;
+                    }
+                }
+                Ok(Ok(None)) => return Err(NotebookSyncError::Disconnected),
+                Ok(Err(e)) => return Err(NotebookSyncError::ConnectionFailed(e)),
+                Err(_) => break, // Timeout — initial sync is done
+            }
+        }
+
+        let cells = get_cells_from_doc(&doc);
+        info!(
+            "[notebook-sync-client] Initial sync complete for {}: {} cells",
+            notebook_id,
+            cells.len()
+        );
+
+        Ok(Self {
+            doc,
+            peer_state,
+            stream,
+            notebook_id,
+        })
+    }
+
+    /// Get the notebook ID this client is syncing.
+    pub fn notebook_id(&self) -> &str {
+        &self.notebook_id
+    }
+
+    // ── Read operations ─────────────────────────────────────────────
+
+    /// Get all cells from the local replica.
+    pub fn get_cells(&self) -> Vec<CellSnapshot> {
+        get_cells_from_doc(&self.doc)
+    }
+
+    /// Get a single cell by ID from the local replica.
+    pub fn get_cell(&self, cell_id: &str) -> Option<CellSnapshot> {
+        self.get_cells().into_iter().find(|c| c.id == cell_id)
+    }
+
+    // ── Write operations (mutate local + sync) ──────────────────────
+
+    /// Add a new cell at the given index and sync to daemon.
+    pub async fn add_cell(
+        &mut self,
+        index: usize,
+        cell_id: &str,
+        cell_type: &str,
+    ) -> Result<(), NotebookSyncError> {
+        let cells_id = self
+            .ensure_cells_list()
+            .map_err(|e| NotebookSyncError::SyncError(format!("ensure cells: {}", e)))?;
+
+        let len = self.doc.length(&cells_id);
+        let index = index.min(len);
+
+        let cell_map = self
+            .doc
+            .insert_object(&cells_id, index, ObjType::Map)
+            .map_err(|e| NotebookSyncError::SyncError(format!("insert: {}", e)))?;
+        self.doc
+            .put(&cell_map, "id", cell_id)
+            .map_err(|e| NotebookSyncError::SyncError(format!("put id: {}", e)))?;
+        self.doc
+            .put(&cell_map, "cell_type", cell_type)
+            .map_err(|e| NotebookSyncError::SyncError(format!("put type: {}", e)))?;
+        self.doc
+            .put_object(&cell_map, "source", ObjType::Text)
+            .map_err(|e| NotebookSyncError::SyncError(format!("put source: {}", e)))?;
+        self.doc
+            .put(&cell_map, "execution_count", "null")
+            .map_err(|e| NotebookSyncError::SyncError(format!("put exec_count: {}", e)))?;
+        self.doc
+            .put_object(&cell_map, "outputs", ObjType::List)
+            .map_err(|e| NotebookSyncError::SyncError(format!("put outputs: {}", e)))?;
+
+        self.sync_to_daemon().await
+    }
+
+    /// Delete a cell by ID and sync to daemon.
+    pub async fn delete_cell(&mut self, cell_id: &str) -> Result<(), NotebookSyncError> {
+        let cells_id = match self.cells_list_id() {
+            Some(id) => id,
+            None => return Err(NotebookSyncError::CellNotFound(cell_id.to_string())),
+        };
+
+        let idx = match self.find_cell_index(&cells_id, cell_id) {
+            Some(i) => i,
+            None => return Err(NotebookSyncError::CellNotFound(cell_id.to_string())),
+        };
+
+        self.doc
+            .delete(&cells_id, idx)
+            .map_err(|e| NotebookSyncError::SyncError(format!("delete: {}", e)))?;
+
+        self.sync_to_daemon().await
+    }
+
+    /// Update a cell's source text and sync to daemon.
+    pub async fn update_source(
+        &mut self,
+        cell_id: &str,
+        source: &str,
+    ) -> Result<(), NotebookSyncError> {
+        let cells_id = match self.cells_list_id() {
+            Some(id) => id,
+            None => return Err(NotebookSyncError::CellNotFound(cell_id.to_string())),
+        };
+        let idx = match self.find_cell_index(&cells_id, cell_id) {
+            Some(i) => i,
+            None => return Err(NotebookSyncError::CellNotFound(cell_id.to_string())),
+        };
+        let cell_obj = match self.cell_at_index(&cells_id, idx) {
+            Some(o) => o,
+            None => return Err(NotebookSyncError::CellNotFound(cell_id.to_string())),
+        };
+        let source_id = match self.text_id(&cell_obj, "source") {
+            Some(id) => id,
+            None => {
+                return Err(NotebookSyncError::SyncError(
+                    "source Text not found".to_string(),
+                ))
+            }
+        };
+
+        self.doc
+            .update_text(&source_id, source)
+            .map_err(|e| NotebookSyncError::SyncError(format!("update_text: {}", e)))?;
+
+        self.sync_to_daemon().await
+    }
+
+    /// Set outputs for a cell and sync to daemon.
+    pub async fn set_outputs(
+        &mut self,
+        cell_id: &str,
+        outputs: &[String],
+    ) -> Result<(), NotebookSyncError> {
+        let cells_id = match self.cells_list_id() {
+            Some(id) => id,
+            None => return Err(NotebookSyncError::CellNotFound(cell_id.to_string())),
+        };
+        let idx = match self.find_cell_index(&cells_id, cell_id) {
+            Some(i) => i,
+            None => return Err(NotebookSyncError::CellNotFound(cell_id.to_string())),
+        };
+        let cell_obj = match self.cell_at_index(&cells_id, idx) {
+            Some(o) => o,
+            None => return Err(NotebookSyncError::CellNotFound(cell_id.to_string())),
+        };
+
+        let _ = self.doc.delete(&cell_obj, "outputs");
+        let list_id = self
+            .doc
+            .put_object(&cell_obj, "outputs", ObjType::List)
+            .map_err(|e| NotebookSyncError::SyncError(format!("put outputs: {}", e)))?;
+        for (i, output) in outputs.iter().enumerate() {
+            self.doc
+                .insert(&list_id, i, output.as_str())
+                .map_err(|e| NotebookSyncError::SyncError(format!("insert output: {}", e)))?;
+        }
+
+        self.sync_to_daemon().await
+    }
+
+    /// Set execution count for a cell and sync to daemon.
+    pub async fn set_execution_count(
+        &mut self,
+        cell_id: &str,
+        count: &str,
+    ) -> Result<(), NotebookSyncError> {
+        let cells_id = match self.cells_list_id() {
+            Some(id) => id,
+            None => return Err(NotebookSyncError::CellNotFound(cell_id.to_string())),
+        };
+        let idx = match self.find_cell_index(&cells_id, cell_id) {
+            Some(i) => i,
+            None => return Err(NotebookSyncError::CellNotFound(cell_id.to_string())),
+        };
+        let cell_obj = match self.cell_at_index(&cells_id, idx) {
+            Some(o) => o,
+            None => return Err(NotebookSyncError::CellNotFound(cell_id.to_string())),
+        };
+
+        self.doc
+            .put(&cell_obj, "execution_count", count)
+            .map_err(|e| NotebookSyncError::SyncError(format!("put: {}", e)))?;
+
+        self.sync_to_daemon().await
+    }
+
+    // ── Receiving changes ───────────────────────────────────────────
+
+    /// Wait for the next change from the daemon.
+    ///
+    /// Blocks until a sync message arrives, applies it, and returns
+    /// the updated cells.
+    pub async fn recv_changes(&mut self) -> Result<Vec<CellSnapshot>, NotebookSyncError> {
+        match connection::recv_frame(&mut self.stream).await? {
+            Some(data) => {
+                let message = sync::Message::decode(&data)
+                    .map_err(|e| NotebookSyncError::SyncError(format!("decode: {}", e)))?;
+                self.doc
+                    .sync()
+                    .receive_sync_message(&mut self.peer_state, message)
+                    .map_err(|e| NotebookSyncError::SyncError(format!("receive: {}", e)))?;
+
+                // Send ack if needed
+                if let Some(msg) = self.doc.sync().generate_sync_message(&mut self.peer_state) {
+                    connection::send_frame(&mut self.stream, &msg.encode()).await?;
+                }
+
+                Ok(self.get_cells())
+            }
+            None => Err(NotebookSyncError::Disconnected),
+        }
+    }
+
+    // ── Internal helpers ────────────────────────────────────────────
+
+    /// Generate and send sync message to daemon.
+    async fn sync_to_daemon(&mut self) -> Result<(), NotebookSyncError> {
+        if let Some(msg) = self.doc.sync().generate_sync_message(&mut self.peer_state) {
+            connection::send_frame(&mut self.stream, &msg.encode()).await?;
+        }
+        Ok(())
+    }
+
+    fn cells_list_id(&self) -> Option<automerge::ObjId> {
+        self.doc
+            .get(automerge::ROOT, "cells")
+            .ok()
+            .flatten()
+            .and_then(|(value, id)| match value {
+                automerge::Value::Object(ObjType::List) => Some(id),
+                _ => None,
+            })
+    }
+
+    fn ensure_cells_list(&mut self) -> Result<automerge::ObjId, automerge::AutomergeError> {
+        if let Some(id) = self.cells_list_id() {
+            return Ok(id);
+        }
+        self.doc.put_object(automerge::ROOT, "cells", ObjType::List)
+    }
+
+    fn cell_at_index(&self, cells_id: &automerge::ObjId, index: usize) -> Option<automerge::ObjId> {
+        self.doc
+            .get(cells_id, index)
+            .ok()
+            .flatten()
+            .and_then(|(value, id)| match value {
+                automerge::Value::Object(ObjType::Map) => Some(id),
+                _ => None,
+            })
+    }
+
+    fn find_cell_index(&self, cells_id: &automerge::ObjId, cell_id: &str) -> Option<usize> {
+        let len = self.doc.length(cells_id);
+        for i in 0..len {
+            if let Some(cell_obj) = self.cell_at_index(cells_id, i) {
+                if self
+                    .doc
+                    .get(&cell_obj, "id")
+                    .ok()
+                    .flatten()
+                    .and_then(|(v, _)| match v {
+                        automerge::Value::Scalar(s) => match s.as_ref() {
+                            automerge::ScalarValue::Str(s) => Some(s.to_string()),
+                            _ => None,
+                        },
+                        _ => None,
+                    })
+                    .as_deref()
+                    == Some(cell_id)
+                {
+                    return Some(i);
+                }
+            }
+        }
+        None
+    }
+
+    fn text_id(&self, parent: &automerge::ObjId, key: &str) -> Option<automerge::ObjId> {
+        self.doc
+            .get(parent, key)
+            .ok()
+            .flatten()
+            .and_then(|(value, id)| match value {
+                automerge::Value::Object(ObjType::Text) => Some(id),
+                _ => None,
+            })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_cells_from_empty_doc() {
+        let doc = AutoCommit::new();
+        let cells = get_cells_from_doc(&doc);
+        assert!(cells.is_empty());
+    }
+
+    #[test]
+    fn test_get_cells_from_populated_doc() {
+        // Manually build a notebook structure in an AutoCommit
+        let mut doc = AutoCommit::new();
+        doc.put(automerge::ROOT, "notebook_id", "test").unwrap();
+        let cells_id = doc
+            .put_object(automerge::ROOT, "cells", ObjType::List)
+            .unwrap();
+
+        // Add a code cell
+        let cell = doc.insert_object(&cells_id, 0, ObjType::Map).unwrap();
+        doc.put(&cell, "id", "c1").unwrap();
+        doc.put(&cell, "cell_type", "code").unwrap();
+        let source = doc.put_object(&cell, "source", ObjType::Text).unwrap();
+        doc.splice_text(&source, 0, 0, "x = 1").unwrap();
+        doc.put(&cell, "execution_count", "1").unwrap();
+        let outputs = doc.put_object(&cell, "outputs", ObjType::List).unwrap();
+        doc.insert(&outputs, 0, r#"{"output_type":"stream"}"#)
+            .unwrap();
+
+        let cells = get_cells_from_doc(&doc);
+        assert_eq!(cells.len(), 1);
+        assert_eq!(cells[0].id, "c1");
+        assert_eq!(cells[0].cell_type, "code");
+        assert_eq!(cells[0].source, "x = 1");
+        assert_eq!(cells[0].execution_count, "1");
+        assert_eq!(cells[0].outputs.len(), 1);
+    }
+}

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -1,0 +1,9 @@
+//! Room-based notebook synchronization server.
+//!
+//! Each open notebook gets a "room" in the daemon. Multiple windows editing
+//! the same notebook sync through the room's canonical Automerge document.
+//!
+//! Follows the same sync protocol pattern as `sync_server.rs` (settings sync)
+//! but with per-notebook state.
+
+// Implementation coming in next commit.

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -4,6 +4,213 @@
 //! the same notebook sync through the room's canonical Automerge document.
 //!
 //! Follows the same sync protocol pattern as `sync_server.rs` (settings sync)
-//! but with per-notebook state.
+//! but with per-notebook state managed through rooms.
+//!
+//! ## Room lifecycle
+//!
+//! 1. First window opens notebook → daemon creates room, loads persisted doc
+//! 2. Client exchanges Automerge sync messages with the room
+//! 3. Additional windows join the same room
+//! 4. Changes from any peer broadcast to all others in the room
+//! 5. Documents persist to `~/.cache/runt/notebook-docs/{hash}.automerge`
 
-// Implementation coming in next commit.
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use automerge::sync;
+use log::{info, warn};
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::sync::{broadcast, Mutex, RwLock};
+
+use crate::connection;
+use crate::notebook_doc::{notebook_doc_filename, NotebookDoc};
+
+/// A notebook sync room — holds the canonical document and a broadcast
+/// channel for notifying peers of changes.
+pub struct NotebookRoom {
+    /// The canonical Automerge notebook document.
+    pub doc: Arc<RwLock<NotebookDoc>>,
+    /// Broadcast channel to notify all peers in this room of changes.
+    pub changed_tx: broadcast::Sender<()>,
+    /// Persistence path for this room's document.
+    pub persist_path: PathBuf,
+}
+
+impl NotebookRoom {
+    /// Create a new room by loading a persisted document or creating a fresh one.
+    pub fn load_or_create(notebook_id: &str, docs_dir: &Path) -> Self {
+        let filename = notebook_doc_filename(notebook_id);
+        let persist_path = docs_dir.join(filename);
+        let doc = NotebookDoc::load_or_create(&persist_path, notebook_id);
+        let (changed_tx, _) = broadcast::channel(16);
+        Self {
+            doc: Arc::new(RwLock::new(doc)),
+            changed_tx,
+            persist_path,
+        }
+    }
+}
+
+/// Thread-safe map of notebook rooms, keyed by notebook_id.
+pub type NotebookRooms = Arc<Mutex<HashMap<String, Arc<NotebookRoom>>>>;
+
+/// Get or create a room for a notebook.
+///
+/// The caller must hold the rooms mutex. This function will create a new
+/// room (loading from disk if available) if one doesn't exist.
+pub fn get_or_create_room(
+    rooms: &mut HashMap<String, Arc<NotebookRoom>>,
+    notebook_id: &str,
+    docs_dir: &Path,
+) -> Arc<NotebookRoom> {
+    rooms
+        .entry(notebook_id.to_string())
+        .or_insert_with(|| {
+            info!("[notebook-sync] Creating room for {}", notebook_id);
+            Arc::new(NotebookRoom::load_or_create(notebook_id, docs_dir))
+        })
+        .clone()
+}
+
+/// Handle a single notebook sync client connection.
+///
+/// The caller has already consumed the handshake frame and resolved the room.
+/// This function runs the Automerge sync protocol:
+/// 1. Initial sync: server sends first message
+/// 2. Watch loop: wait for changes (from other peers or from this client),
+///    exchange sync messages to propagate
+///
+/// Structurally identical to `handle_settings_sync_connection` in sync_server.rs.
+pub async fn handle_notebook_sync_connection<R, W>(
+    mut reader: R,
+    mut writer: W,
+    room: Arc<NotebookRoom>,
+) -> anyhow::Result<()>
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    let mut peer_state = sync::State::new();
+    let mut changed_rx = room.changed_tx.subscribe();
+
+    info!("[notebook-sync] Client connected to room");
+
+    // Phase 1: Initial sync — server sends first
+    {
+        let mut doc = room.doc.write().await;
+        if let Some(msg) = doc.generate_sync_message(&mut peer_state) {
+            connection::send_frame(&mut writer, &msg.encode()).await?;
+        }
+    }
+
+    // Phase 2: Exchange messages until sync is complete, then watch for changes
+    loop {
+        tokio::select! {
+            // Incoming message from this client
+            result = connection::recv_frame(&mut reader) => {
+                match result? {
+                    Some(data) => {
+                        let message = sync::Message::decode(&data)
+                            .map_err(|e| anyhow::anyhow!("decode error: {}", e))?;
+
+                        let mut doc = room.doc.write().await;
+                        doc.receive_sync_message(&mut peer_state, message)?;
+
+                        // Persist and notify other peers in this room
+                        persist_notebook(&mut doc, &room.persist_path);
+                        let _ = room.changed_tx.send(());
+
+                        // Send our response
+                        if let Some(reply) = doc.generate_sync_message(&mut peer_state) {
+                            connection::send_frame(&mut writer, &reply.encode()).await?;
+                        }
+                    }
+                    None => {
+                        // Client disconnected
+                        info!("[notebook-sync] Client disconnected from room");
+                        return Ok(());
+                    }
+                }
+            }
+
+            // Another peer changed the document — push update to this client
+            _ = changed_rx.recv() => {
+                let mut doc = room.doc.write().await;
+                if let Some(msg) = doc.generate_sync_message(&mut peer_state) {
+                    connection::send_frame(&mut writer, &msg.encode()).await?;
+                }
+            }
+        }
+    }
+}
+
+/// Persist the notebook document to disk.
+fn persist_notebook(doc: &mut NotebookDoc, path: &Path) {
+    if let Err(e) = doc.save_to_file(path) {
+        warn!("[notebook-sync] Failed to save notebook doc: {}", e);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_room_load_or_create_new() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let room = NotebookRoom::load_or_create("test-nb", tmp.path());
+
+        let doc = room.doc.try_read().unwrap();
+        assert_eq!(doc.notebook_id(), Some("test-nb".to_string()));
+        assert_eq!(doc.cell_count(), 0);
+    }
+
+    #[test]
+    fn test_room_persists_and_reloads() {
+        let tmp = tempfile::TempDir::new().unwrap();
+
+        // Create room and add a cell
+        {
+            let room = NotebookRoom::load_or_create("persist-test", tmp.path());
+            let mut doc = room.doc.try_write().unwrap();
+            doc.add_cell(0, "c1", "code").unwrap();
+            doc.update_source("c1", "hello").unwrap();
+            persist_notebook(&mut doc, &room.persist_path);
+        }
+
+        // Load again — should have the cell
+        {
+            let room = NotebookRoom::load_or_create("persist-test", tmp.path());
+            let doc = room.doc.try_read().unwrap();
+            assert_eq!(doc.cell_count(), 1);
+            let cell = doc.get_cell("c1").unwrap();
+            assert_eq!(cell.source, "hello");
+        }
+    }
+
+    #[test]
+    fn test_get_or_create_room_reuses_existing() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let mut rooms = HashMap::new();
+
+        let room1 = get_or_create_room(&mut rooms, "nb1", tmp.path());
+        let room2 = get_or_create_room(&mut rooms, "nb1", tmp.path());
+
+        // Should be the same Arc (same room)
+        assert!(Arc::ptr_eq(&room1, &room2));
+    }
+
+    #[test]
+    fn test_get_or_create_room_different_notebooks() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let mut rooms = HashMap::new();
+
+        let room1 = get_or_create_room(&mut rooms, "nb1", tmp.path());
+        let room2 = get_or_create_room(&mut rooms, "nb2", tmp.path());
+
+        // Should be different rooms
+        assert!(!Arc::ptr_eq(&room1, &room2));
+        assert_eq!(rooms.len(), 2);
+    }
+}

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -12,10 +12,13 @@
 //! 2. Client exchanges Automerge sync messages with the room
 //! 3. Additional windows join the same room
 //! 4. Changes from any peer broadcast to all others in the room
-//! 5. Documents persist to `~/.cache/runt/notebook-docs/{hash}.automerge`
+//! 5. When the last peer disconnects, the room is evicted from memory
+//!    (the doc is already persisted on every change)
+//! 6. Documents persist to `~/.cache/runt/notebook-docs/{hash}.automerge`
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use automerge::sync;
@@ -35,6 +38,8 @@ pub struct NotebookRoom {
     pub changed_tx: broadcast::Sender<()>,
     /// Persistence path for this room's document.
     pub persist_path: PathBuf,
+    /// Number of active peer connections in this room.
+    pub active_peers: AtomicUsize,
 }
 
 impl NotebookRoom {
@@ -48,6 +53,7 @@ impl NotebookRoom {
             doc: Arc::new(RwLock::new(doc)),
             changed_tx,
             persist_path,
+            active_peers: AtomicUsize::new(0),
         }
     }
 }
@@ -81,11 +87,62 @@ pub fn get_or_create_room(
 /// 2. Watch loop: wait for changes (from other peers or from this client),
 ///    exchange sync messages to propagate
 ///
-/// Structurally identical to `handle_settings_sync_connection` in sync_server.rs.
+/// When the connection closes (client disconnect or error), the peer count
+/// is decremented. If it reaches zero, the room is evicted from the rooms
+/// map (the doc has already been persisted on every change).
 pub async fn handle_notebook_sync_connection<R, W>(
     mut reader: R,
     mut writer: W,
     room: Arc<NotebookRoom>,
+    rooms: NotebookRooms,
+    notebook_id: String,
+) -> anyhow::Result<()>
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    room.active_peers.fetch_add(1, Ordering::Relaxed);
+    let peers = room.active_peers.load(Ordering::Relaxed);
+    info!(
+        "[notebook-sync] Client connected to room {} ({} peer{})",
+        notebook_id,
+        peers,
+        if peers == 1 { "" } else { "s" }
+    );
+
+    let result = run_sync_loop(&mut reader, &mut writer, &room).await;
+
+    // Peer disconnected — decrement and possibly evict the room
+    let remaining = room.active_peers.fetch_sub(1, Ordering::Relaxed) - 1;
+    if remaining == 0 {
+        let mut rooms_guard = rooms.lock().await;
+        // Re-check under the lock — another peer may have joined between
+        // our decrement and acquiring the lock.
+        if room.active_peers.load(Ordering::Relaxed) == 0 {
+            rooms_guard.remove(&notebook_id);
+            info!(
+                "[notebook-sync] Evicted room {} (no remaining peers)",
+                notebook_id
+            );
+        }
+    } else {
+        info!(
+            "[notebook-sync] Client disconnected from room {} ({} peer{} remaining)",
+            notebook_id,
+            remaining,
+            if remaining == 1 { "" } else { "s" }
+        );
+    }
+
+    result
+}
+
+/// Inner sync protocol loop, factored out so the caller can handle
+/// peer-count bookkeeping around it.
+async fn run_sync_loop<R, W>(
+    reader: &mut R,
+    writer: &mut W,
+    room: &NotebookRoom,
 ) -> anyhow::Result<()>
 where
     R: AsyncRead + Unpin,
@@ -94,13 +151,11 @@ where
     let mut peer_state = sync::State::new();
     let mut changed_rx = room.changed_tx.subscribe();
 
-    info!("[notebook-sync] Client connected to room");
-
     // Phase 1: Initial sync — server sends first
     {
         let mut doc = room.doc.write().await;
         if let Some(msg) = doc.generate_sync_message(&mut peer_state) {
-            connection::send_frame(&mut writer, &msg.encode()).await?;
+            connection::send_frame(writer, &msg.encode()).await?;
         }
     }
 
@@ -108,27 +163,35 @@ where
     loop {
         tokio::select! {
             // Incoming message from this client
-            result = connection::recv_frame(&mut reader) => {
+            result = connection::recv_frame(reader) => {
                 match result? {
                     Some(data) => {
                         let message = sync::Message::decode(&data)
                             .map_err(|e| anyhow::anyhow!("decode error: {}", e))?;
 
-                        let mut doc = room.doc.write().await;
-                        doc.receive_sync_message(&mut peer_state, message)?;
+                        // Serialize bytes inside the lock, then persist outside it
+                        let persist_bytes = {
+                            let mut doc = room.doc.write().await;
+                            doc.receive_sync_message(&mut peer_state, message)?;
 
-                        // Persist and notify other peers in this room
-                        persist_notebook(&mut doc, &room.persist_path);
-                        let _ = room.changed_tx.send(());
+                            let bytes = doc.save();
 
-                        // Send our response
-                        if let Some(reply) = doc.generate_sync_message(&mut peer_state) {
-                            connection::send_frame(&mut writer, &reply.encode()).await?;
-                        }
+                            // Notify other peers in this room
+                            let _ = room.changed_tx.send(());
+
+                            // Send our response while still holding the lock
+                            if let Some(reply) = doc.generate_sync_message(&mut peer_state) {
+                                connection::send_frame(writer, &reply.encode()).await?;
+                            }
+
+                            bytes
+                        };
+
+                        // Persist outside the write lock
+                        persist_notebook_bytes(&persist_bytes, &room.persist_path);
                     }
                     None => {
                         // Client disconnected
-                        info!("[notebook-sync] Client disconnected from room");
                         return Ok(());
                     }
                 }
@@ -138,16 +201,25 @@ where
             _ = changed_rx.recv() => {
                 let mut doc = room.doc.write().await;
                 if let Some(msg) = doc.generate_sync_message(&mut peer_state) {
-                    connection::send_frame(&mut writer, &msg.encode()).await?;
+                    connection::send_frame(writer, &msg.encode()).await?;
                 }
             }
         }
     }
 }
 
-/// Persist the notebook document to disk.
-fn persist_notebook(doc: &mut NotebookDoc, path: &Path) {
-    if let Err(e) = doc.save_to_file(path) {
+/// Persist pre-serialized notebook bytes to disk.
+fn persist_notebook_bytes(data: &[u8], path: &Path) {
+    if let Some(parent) = path.parent() {
+        if let Err(e) = std::fs::create_dir_all(parent) {
+            warn!(
+                "[notebook-sync] Failed to create parent dir for {:?}: {}",
+                path, e
+            );
+            return;
+        }
+    }
+    if let Err(e) = std::fs::write(path, data) {
         warn!("[notebook-sync] Failed to save notebook doc: {}", e);
     }
 }
@@ -164,6 +236,7 @@ mod tests {
         let doc = room.doc.try_read().unwrap();
         assert_eq!(doc.notebook_id(), Some("test-nb".to_string()));
         assert_eq!(doc.cell_count(), 0);
+        assert_eq!(room.active_peers.load(Ordering::Relaxed), 0);
     }
 
     #[test]
@@ -176,7 +249,8 @@ mod tests {
             let mut doc = room.doc.try_write().unwrap();
             doc.add_cell(0, "c1", "code").unwrap();
             doc.update_source("c1", "hello").unwrap();
-            persist_notebook(&mut doc, &room.persist_path);
+            let bytes = doc.save();
+            persist_notebook_bytes(&bytes, &room.persist_path);
         }
 
         // Load again — should have the cell
@@ -212,5 +286,23 @@ mod tests {
         // Should be different rooms
         assert!(!Arc::ptr_eq(&room1, &room2));
         assert_eq!(rooms.len(), 2);
+    }
+
+    #[test]
+    fn test_room_peer_counting() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let room = NotebookRoom::load_or_create("peer-test", tmp.path());
+
+        assert_eq!(room.active_peers.load(Ordering::Relaxed), 0);
+
+        room.active_peers.fetch_add(1, Ordering::Relaxed);
+        room.active_peers.fetch_add(1, Ordering::Relaxed);
+        assert_eq!(room.active_peers.load(Ordering::Relaxed), 2);
+
+        room.active_peers.fetch_sub(1, Ordering::Relaxed);
+        assert_eq!(room.active_peers.load(Ordering::Relaxed), 1);
+
+        room.active_peers.fetch_sub(1, Ordering::Relaxed);
+        assert_eq!(room.active_peers.load(Ordering::Relaxed), 0);
     }
 }

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -17,6 +17,7 @@ fn test_config(temp_dir: &TempDir) -> DaemonConfig {
         socket_path: temp_dir.path().join("test-runtimed.sock"),
         cache_dir: temp_dir.path().join("envs"),
         blob_store_dir: temp_dir.path().join("blobs"),
+        notebook_docs_dir: temp_dir.path().join("notebook-docs"),
         uv_pool_size: 0, // Don't create real envs in tests
         conda_pool_size: 0,
         max_age_secs: 3600,
@@ -134,6 +135,7 @@ async fn test_singleton_prevents_second_daemon() {
         socket_path: socket_path.clone(),
         cache_dir: temp_dir.path().join("envs"),
         blob_store_dir: temp_dir.path().join("blobs"),
+        notebook_docs_dir: temp_dir.path().join("notebook-docs"),
         uv_pool_size: 0,
         conda_pool_size: 0,
         max_age_secs: 3600,


### PR DESCRIPTION
## Summary

Implements Phase 2 of the runtimed architecture: Automerge CRDT synchronization for notebook documents. Multiple windows editing the same notebook now share a single Automerge document in the daemon, with all changes synchronized via the existing unified socket protocol.

The implementation follows the pattern established by settings sync but uses per-notebook "rooms" for isolation. Cell source uses `ObjType::Text` for character-level concurrent edit merging. Documents persist to `~/.cache/runt/notebook-docs/` on every change.

Review findings have been addressed: room eviction when the last peer disconnects, corrupt persisted docs are renamed to `.corrupt` rather than silently discarded, and serialization happens inside the write lock while disk I/O happens outside it to prevent blocking sync traffic.

_PR submitted by @rgbkrk's agent, Quill_