### PR TITLE
Run All should stop on first error

### DIFF
--- a/crates/notebook/fixtures/audit-test/10-run-all-error.ipynb
+++ b/crates/notebook/fixtures/audit-test/10-run-all-error.ipynb
@@ -1,0 +1,37 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"before_error\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "raise ValueError(\"stop here\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"after_error\")"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/crates/notebook/src/kernel.rs
+++ b/crates/notebook/src/kernel.rs
@@ -385,6 +385,7 @@ impl NotebookKernel {
         let pending_hist = self.pending_history.clone();
         let shell_app = app.clone();
         let shell_cell_id_map = self.cell_id_map.clone();
+        let shell_queue_tx = self.queue_tx.clone();
         let shell_reader_task = tokio::spawn(async move {
             loop {
                 match shell_reader.read().await {
@@ -456,6 +457,19 @@ impl NotebookKernel {
                                             {
                                                 error!("Failed to emit page_payload: {}", e);
                                             }
+                                        }
+                                    }
+                                }
+
+                                // Fallback error detection via execute_reply status
+                                if reply.status != jupyter_protocol::ReplyStatus::Ok {
+                                    let cell_id = parent_msg_id.as_ref().and_then(|msg_id| {
+                                        shell_cell_id_map.lock().ok()?.get(msg_id).cloned()
+                                    });
+                                    if let Some(cell_id) = cell_id {
+                                        if let Some(ref tx) = shell_queue_tx {
+                                            let _ =
+                                                tx.try_send(QueueCommand::CellError { cell_id });
                                         }
                                     }
                                 }
@@ -671,6 +685,7 @@ impl NotebookKernel {
         let pending_hist = self.pending_history.clone();
         let shell_app = app.clone();
         let shell_cell_id_map = self.cell_id_map.clone();
+        let shell_queue_tx = self.queue_tx.clone();
         let shell_reader_task = tokio::spawn(async move {
             loop {
                 match shell_reader.read().await {
@@ -741,6 +756,19 @@ impl NotebookKernel {
                                             {
                                                 error!("Failed to emit page_payload: {}", e);
                                             }
+                                        }
+                                    }
+                                }
+
+                                // Fallback error detection via execute_reply status
+                                if reply.status != jupyter_protocol::ReplyStatus::Ok {
+                                    let cell_id = parent_msg_id.as_ref().and_then(|msg_id| {
+                                        shell_cell_id_map.lock().ok()?.get(msg_id).cloned()
+                                    });
+                                    if let Some(cell_id) = cell_id {
+                                        if let Some(ref tx) = shell_queue_tx {
+                                            let _ =
+                                                tx.try_send(QueueCommand::CellError { cell_id });
                                         }
                                     }
                                 }
@@ -952,6 +980,7 @@ impl NotebookKernel {
         let pending_hist = self.pending_history.clone();
         let shell_app = app.clone();
         let shell_cell_id_map = self.cell_id_map.clone();
+        let shell_queue_tx = self.queue_tx.clone();
         let shell_reader_task = tokio::spawn(async move {
             loop {
                 match shell_reader.read().await {
@@ -1022,6 +1051,19 @@ impl NotebookKernel {
                                             {
                                                 error!("Failed to emit page_payload: {}", e);
                                             }
+                                        }
+                                    }
+                                }
+
+                                // Fallback error detection via execute_reply status
+                                if reply.status != jupyter_protocol::ReplyStatus::Ok {
+                                    let cell_id = parent_msg_id.as_ref().and_then(|msg_id| {
+                                        shell_cell_id_map.lock().ok()?.get(msg_id).cloned()
+                                    });
+                                    if let Some(cell_id) = cell_id {
+                                        if let Some(ref tx) = shell_queue_tx {
+                                            let _ =
+                                                tx.try_send(QueueCommand::CellError { cell_id });
                                         }
                                     }
                                 }
@@ -1418,6 +1460,7 @@ impl NotebookKernel {
         let pending_hist = self.pending_history.clone();
         let shell_app = app.clone();
         let shell_cell_id_map = self.cell_id_map.clone();
+        let shell_queue_tx = self.queue_tx.clone();
         let shell_reader_task = tokio::spawn(async move {
             loop {
                 match shell_reader.read().await {
@@ -1488,6 +1531,19 @@ impl NotebookKernel {
                                             {
                                                 error!("Failed to emit page_payload: {}", e);
                                             }
+                                        }
+                                    }
+                                }
+
+                                // Fallback error detection via execute_reply status
+                                if reply.status != jupyter_protocol::ReplyStatus::Ok {
+                                    let cell_id = parent_msg_id.as_ref().and_then(|msg_id| {
+                                        shell_cell_id_map.lock().ok()?.get(msg_id).cloned()
+                                    });
+                                    if let Some(cell_id) = cell_id {
+                                        if let Some(ref tx) = shell_queue_tx {
+                                            let _ =
+                                                tx.try_send(QueueCommand::CellError { cell_id });
                                         }
                                     }
                                 }
@@ -1701,6 +1757,7 @@ impl NotebookKernel {
         let pending_hist = self.pending_history.clone();
         let shell_app = app.clone();
         let shell_cell_id_map = self.cell_id_map.clone();
+        let shell_queue_tx = self.queue_tx.clone();
         let shell_reader_task = tokio::spawn(async move {
             loop {
                 match shell_reader.read().await {
@@ -1771,6 +1828,19 @@ impl NotebookKernel {
                                             {
                                                 error!("Failed to emit page_payload: {}", e);
                                             }
+                                        }
+                                    }
+                                }
+
+                                // Fallback error detection via execute_reply status
+                                if reply.status != jupyter_protocol::ReplyStatus::Ok {
+                                    let cell_id = parent_msg_id.as_ref().and_then(|msg_id| {
+                                        shell_cell_id_map.lock().ok()?.get(msg_id).cloned()
+                                    });
+                                    if let Some(cell_id) = cell_id {
+                                        if let Some(ref tx) = shell_queue_tx {
+                                            let _ =
+                                                tx.try_send(QueueCommand::CellError { cell_id });
                                         }
                                     }
                                 }
@@ -2005,6 +2075,7 @@ impl NotebookKernel {
         let pending_hist = self.pending_history.clone();
         let shell_app = app.clone();
         let shell_cell_id_map = self.cell_id_map.clone();
+        let shell_queue_tx = self.queue_tx.clone();
         let shell_reader_task = tokio::spawn(async move {
             loop {
                 match shell_reader.read().await {
@@ -2075,6 +2146,19 @@ impl NotebookKernel {
                                             {
                                                 error!("Failed to emit page_payload: {}", e);
                                             }
+                                        }
+                                    }
+                                }
+
+                                // Fallback error detection via execute_reply status
+                                if reply.status != jupyter_protocol::ReplyStatus::Ok {
+                                    let cell_id = parent_msg_id.as_ref().and_then(|msg_id| {
+                                        shell_cell_id_map.lock().ok()?.get(msg_id).cloned()
+                                    });
+                                    if let Some(cell_id) = cell_id {
+                                        if let Some(ref tx) = shell_queue_tx {
+                                            let _ =
+                                                tx.try_send(QueueCommand::CellError { cell_id });
                                         }
                                     }
                                 }
@@ -2315,6 +2399,7 @@ impl NotebookKernel {
         let pending_hist = self.pending_history.clone();
         let shell_app = app.clone();
         let shell_cell_id_map = self.cell_id_map.clone();
+        let shell_queue_tx = self.queue_tx.clone();
         let shell_reader_task = tokio::spawn(async move {
             loop {
                 match shell_reader.read().await {
@@ -2392,6 +2477,19 @@ impl NotebookKernel {
                                                     }
                                                 }
                                             }
+                                        }
+                                    }
+                                }
+
+                                // Fallback error detection via execute_reply status
+                                if reply.status != jupyter_protocol::ReplyStatus::Ok {
+                                    let cell_id = parent_msg_id.as_ref().and_then(|msg_id| {
+                                        shell_cell_id_map.lock().ok()?.get(msg_id).cloned()
+                                    });
+                                    if let Some(cell_id) = cell_id {
+                                        if let Some(ref tx) = shell_queue_tx {
+                                            let _ =
+                                                tx.try_send(QueueCommand::CellError { cell_id });
                                         }
                                     }
                                 }

--- a/crates/notebook/src/kernel.rs
+++ b/crates/notebook/src/kernel.rs
@@ -316,6 +316,17 @@ impl NotebookKernel {
                             }
                         }
 
+                        // Check for error output to signal stop-on-error
+                        if let JupyterMessageContent::ErrorOutput(_) = &message.content {
+                            if let Some(ref cid) = cell_id {
+                                if let Some(ref tx) = queue_tx {
+                                    let _ = tx.try_send(QueueCommand::CellError {
+                                        cell_id: cid.clone(),
+                                    });
+                                }
+                            }
+                        }
+
                         let tauri_msg = TauriJupyterMessage {
                             header: message.header,
                             parent_header: message.parent_header,
@@ -591,6 +602,17 @@ impl NotebookKernel {
                             }
                         }
 
+                        // Check for error output to signal stop-on-error
+                        if let JupyterMessageContent::ErrorOutput(_) = &message.content {
+                            if let Some(ref cid) = cell_id {
+                                if let Some(ref tx) = queue_tx {
+                                    let _ = tx.try_send(QueueCommand::CellError {
+                                        cell_id: cid.clone(),
+                                    });
+                                }
+                            }
+                        }
+
                         let tauri_msg = TauriJupyterMessage {
                             header: message.header,
                             parent_header: message.parent_header,
@@ -857,6 +879,17 @@ impl NotebookKernel {
                                             cell_id: cid.clone(),
                                         });
                                     }
+                                }
+                            }
+                        }
+
+                        // Check for error output to signal stop-on-error
+                        if let JupyterMessageContent::ErrorOutput(_) = &message.content {
+                            if let Some(ref cid) = cell_id {
+                                if let Some(ref tx) = queue_tx {
+                                    let _ = tx.try_send(QueueCommand::CellError {
+                                        cell_id: cid.clone(),
+                                    });
                                 }
                             }
                         }
@@ -1344,6 +1377,17 @@ impl NotebookKernel {
                             }
                         }
 
+                        // Check for error output to signal stop-on-error
+                        if let JupyterMessageContent::ErrorOutput(_) = &message.content {
+                            if let Some(ref cid) = cell_id {
+                                if let Some(ref tx) = queue_tx {
+                                    let _ = tx.try_send(QueueCommand::CellError {
+                                        cell_id: cid.clone(),
+                                    });
+                                }
+                            }
+                        }
+
                         let tauri_msg = TauriJupyterMessage {
                             header: message.header,
                             parent_header: message.parent_header,
@@ -1584,6 +1628,17 @@ impl NotebookKernel {
                                             cell_id: cid.clone(),
                                         });
                                     }
+                                }
+                            }
+                        }
+
+                        // Check for error output to signal stop-on-error
+                        if let JupyterMessageContent::ErrorOutput(_) = &message.content {
+                            if let Some(ref cid) = cell_id {
+                                if let Some(ref tx) = queue_tx {
+                                    let _ = tx.try_send(QueueCommand::CellError {
+                                        cell_id: cid.clone(),
+                                    });
                                 }
                             }
                         }
@@ -1862,6 +1917,17 @@ impl NotebookKernel {
                                             cell_id: cid.clone(),
                                         });
                                     }
+                                }
+                            }
+                        }
+
+                        // Check for error output to signal stop-on-error
+                        if let JupyterMessageContent::ErrorOutput(_) = &message.content {
+                            if let Some(ref cid) = cell_id {
+                                if let Some(ref tx) = queue_tx {
+                                    let _ = tx.try_send(QueueCommand::CellError {
+                                        cell_id: cid.clone(),
+                                    });
                                 }
                             }
                         }
@@ -2176,6 +2242,17 @@ impl NotebookKernel {
                                             cell_id: cid.clone(),
                                         });
                                     }
+                                }
+                            }
+                        }
+
+                        // Check for error output to signal stop-on-error
+                        if let JupyterMessageContent::ErrorOutput(_) = &message.content {
+                            if let Some(ref cid) = cell_id {
+                                if let Some(ref tx) = queue_tx {
+                                    let _ = tx.try_send(QueueCommand::CellError {
+                                        cell_id: cid.clone(),
+                                    });
                                 }
                             }
                         }

--- a/e2e/dev.sh
+++ b/e2e/dev.sh
@@ -248,6 +248,9 @@ case "${1:-help}" in
     run_fixture crates/notebook/fixtures/audit-test/8-multi-cell.ipynb \
                 e2e/specs/run-all-cells.spec.js
 
+    run_fixture crates/notebook/fixtures/audit-test/10-run-all-error.ipynb \
+                e2e/specs/run-all-error-stops.spec.js
+
     run_fixture crates/notebook/fixtures/audit-test/9-html-output.ipynb \
                 e2e/specs/iframe-isolation.spec.js
 

--- a/e2e/specs/run-all-error-stops.spec.js
+++ b/e2e/specs/run-all-error-stops.spec.js
@@ -1,0 +1,105 @@
+/**
+ * E2E Test: Run All Stops on First Error (Fixture)
+ *
+ * Opens a notebook with 3 code cells (10-run-all-error.ipynb):
+ *   1. print("before_error")  — succeeds
+ *   2. raise ValueError(...)  — errors
+ *   3. print("after_error")   — should NOT execute
+ *
+ * Verifies that "Run All" stops execution after the first cell error
+ * and does not execute subsequent cells.
+ *
+ * Requires: NOTEBOOK_PATH=crates/notebook/fixtures/audit-test/10-run-all-error.ipynb
+ */
+
+import { browser, expect } from "@wdio/globals";
+import {
+  waitForAppReady,
+  waitForErrorOutput,
+  waitForKernelReady,
+} from "../helpers.js";
+
+/**
+ * Wait for a specific cell (by index) to have stream output containing the expected text.
+ */
+async function waitForCellStreamOutput(
+  cellIndex,
+  expectedText,
+  timeout = 120000,
+) {
+  const cells = await $$('[data-cell-type="code"]');
+  const cell = cells[cellIndex];
+
+  await browser.waitUntil(
+    async () => {
+      const output = await cell.$('[data-slot="ansi-stream-output"]');
+      if (!(await output.isExisting())) return false;
+      const text = await output.getText();
+      return text.includes(expectedText);
+    },
+    {
+      timeout,
+      interval: 500,
+      timeoutMsg: `Cell ${cellIndex} did not produce output containing "${expectedText}"`,
+    },
+  );
+
+  const output = await cell.$('[data-slot="ansi-stream-output"]');
+  return await output.getText();
+}
+
+describe("Run All Stops on First Error", () => {
+  before(async () => {
+    await waitForAppReady();
+    console.log("Page title:", await browser.getTitle());
+  });
+
+  it("should have 3 pre-populated code cells", async () => {
+    const cells = await $$('[data-cell-type="code"]');
+    console.log("Code cells found:", cells.length);
+    expect(cells.length).toBe(3);
+  });
+
+  it("should stop execution on first error and skip remaining cells", async () => {
+    // Start the kernel explicitly if it hasn't auto-launched yet
+    const startButton = await $('[data-testid="start-kernel-button"]');
+    if (await startButton.isExisting()) {
+      await startButton.click();
+      console.log("Clicked Start Kernel");
+    }
+    await waitForKernelReady();
+    console.log("Kernel ready");
+
+    const runAllButton = await $('[data-testid="run-all-button"]');
+    await runAllButton.waitForClickable({ timeout: 5000 });
+    await runAllButton.click();
+    console.log("Clicked Run All");
+
+    // Cell 1 should execute successfully
+    const output1 = await waitForCellStreamOutput(0, "before_error");
+    console.log("Cell 1 output:", output1);
+    expect(output1).toContain("before_error");
+
+    // Cell 2 should produce an error
+    const cells = await $$('[data-cell-type="code"]');
+    await waitForErrorOutput(cells[1]);
+    console.log("Cell 2 produced error output");
+
+    // Wait a moment for the queue to settle
+    await browser.pause(2000);
+
+    // Cell 3 should NOT have any output (execution stopped)
+    const cell3 = cells[2];
+    const streamOutput = await cell3.$('[data-slot="ansi-stream-output"]');
+    const errorOutput = await cell3.$('[data-slot="ansi-error-output"]');
+
+    const hasStreamOutput = await streamOutput.isExisting();
+    const hasErrorOutput = await errorOutput.isExisting();
+
+    console.log("Cell 3 has stream output:", hasStreamOutput);
+    console.log("Cell 3 has error output:", hasErrorOutput);
+
+    expect(hasStreamOutput).toBe(false);
+    expect(hasErrorOutput).toBe(false);
+  });
+});

--- a/e2e/wdio.conf.js
+++ b/e2e/wdio.conf.js
@@ -40,6 +40,7 @@ const FIXTURE_SPECS = [
   "conda-deps-panel.spec.js",
   "trust-decline.spec.js",
   "run-all-cells.spec.js",
+  "run-all-error-stops.spec.js",
   "iframe-isolation.spec.js",
   "settings-panel.spec.js",
   "deno-runtime.spec.js",


### PR DESCRIPTION
Implement stop-on-error behavior for Run All execution. When running all cells,
if a cell produces an error output, the queue stops and remaining cells are not
executed. This matches standard notebook behavior.

**Changes:**
- Add `QueueCommand::CellError` and `had_error` flag to execution queue
- Detect `ErrorOutput` messages in all 7 iopub listeners
- When `ExecutionDone` arrives with `had_error=true`, clear pending cells instead of advancing
- Add 5 unit tests for error flag behavior
- Add fixture notebook and e2e test to verify stop-on-error

**Verification:**
- [x] Run `e2e/dev.sh` and verify `run-all-error-stops.spec.js` passes
- [x] Manually test: create notebook with 3 cells, second one errors, Run All should skip cell 3

Closes #221

_PR submitted by @rgbkrk's agent, Quill_