### PR TITLE
Improve unknown settings warning UI with icon and actionable text

### DIFF
--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -1,4 +1,5 @@
 import {
+  AlertCircle,
   ChevronsRight,
   Info,
   Monitor,
@@ -678,9 +679,20 @@ export function NotebookToolbar({
                     </div>
                   </div>
                   {defaultRuntime && !isKnownRuntime(defaultRuntime) && (
-                    <p className="text-[11px] text-amber-600 dark:text-amber-400">
-                      Unknown runtime: &ldquo;{defaultRuntime}&rdquo;
-                    </p>
+                    <div className="flex items-start gap-2 text-xs text-amber-700 dark:text-amber-400 mt-1">
+                      <AlertCircle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+                      <span>
+                        <span className="font-medium">
+                          &ldquo;{defaultRuntime}&rdquo;
+                        </span>{" "}
+                        is not a recognized runtime. Click Python or Deno above,
+                        or edit{" "}
+                        <code className="rounded bg-amber-500/20 px-1">
+                          settings.json
+                        </code>
+                        .
+                      </span>
+                    </div>
                   )}
                 </div>
               )}
@@ -742,10 +754,20 @@ export function NotebookToolbar({
                       </div>
                       {defaultPythonEnv &&
                         !isKnownPythonEnv(defaultPythonEnv) && (
-                          <p className="text-[11px] text-amber-600 dark:text-amber-400 col-span-2">
-                            Unknown environment: &ldquo;{defaultPythonEnv}
-                            &rdquo;
-                          </p>
+                          <div className="flex items-start gap-2 text-xs text-amber-700 dark:text-amber-400 col-span-2 mt-1">
+                            <AlertCircle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+                            <span>
+                              <span className="font-medium">
+                                &ldquo;{defaultPythonEnv}&rdquo;
+                              </span>{" "}
+                              is not a recognized environment. Click uv or Conda
+                              above, or edit{" "}
+                              <code className="rounded bg-amber-500/20 px-1">
+                                settings.json
+                              </code>
+                              .
+                            </span>
+                          </div>
                         )}
                     </>
                   )}


### PR DESCRIPTION
Enhance the warnings shown when settings contain unknown values (e.g., `"julia"` for runtime or `"mamba"` for environment). Add an `AlertCircle` icon, bold the value, and provide clear guidance: click a button to fix it or edit `settings.json` directly.

This matches the existing Deno install prompt styling pattern and makes it obvious how to resolve the issue.

## Visual changes

[Screenshot placeholder: show unknown runtime warning with icon and text guidance]
[Screenshot placeholder: show unknown environment warning with icon and text guidance]

## Verification

- [x] Set `"default_runtime": "julia"` in `~/.config/runt/settings.json`, open app, verify warning displays with icon and actionable text
- [x] Click "Python" button, verify warning disappears and setting persists
- [x] Set `"default_python_env": "mamba"`, verify same pattern for environment warning
- [x] Click "uv" or "Conda", verify it clears
- [x] Check that styling matches Deno install prompt (icon, text color, code background)

_PR submitted by @rgbkrk's agent, Quill_