### PR TITLE
Fix flaky iframe-isolation E2E test

### DIFF
--- a/crates/notebook/fixtures/audit-test/9-html-output.ipynb
+++ b/crates/notebook/fixtures/audit-test/9-html-output.ipynb
@@ -4,11 +4,21 @@
    "cell_type": "code",
    "id": "cell-1",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "output_type": "display_data",
+     "data": {
+      "text/html": "<div id='isolation-probe'>hello from iframe</div>",
+      "text/plain": "<IPython.core.display.HTML object>"
+     },
+     "metadata": {}
+    }
+   ],
    "source": [
     "from IPython.display import display, HTML\n",
     "display(HTML(\"<div id='isolation-probe'>hello from iframe</div>\"))"
-   ]
+   ],
+   "execution_count": 1
   }
  ],
  "metadata": {

--- a/e2e/specs/iframe-isolation.spec.js
+++ b/e2e/specs/iframe-isolation.spec.js
@@ -1,8 +1,8 @@
 /**
  * E2E Security Tests: Iframe Isolation (Fixture)
  *
- * Opens a notebook that produces HTML output (9-html-output.ipynb).
- * Executes the cell, which triggers an IsolatedFrame iframe, then verifies
+ * Opens a notebook with pre-populated HTML display_data output (9-html-output.ipynb).
+ * The IsolatedFrame renders on load without needing a kernel, then the tests verify
  * that the iframe sandbox properly blocks Tauri API leakage and cross-origin access.
  *
  * Note: browser.switchToFrame() and browser.executeAsync() are not supported in
@@ -15,11 +15,7 @@
  */
 
 import { browser, expect } from "@wdio/globals";
-import {
-  executeFirstCell,
-  waitForAppReady,
-  waitForKernelReady,
-} from "../helpers.js";
+import { waitForAppReady } from "../helpers.js";
 
 /**
  * Execute code inside the isolated iframe via postMessage eval channel.
@@ -82,24 +78,15 @@ describe("Iframe Isolation Security", () => {
     await waitForAppReady();
     console.log("Page title:", await browser.getTitle());
 
-    // Kernel auto-launches for vanilla notebooks (no deps)
-    await waitForKernelReady();
-    console.log("Kernel ready");
-
-    // Execute the cell — produces HTML display output via IPython.display
-    // When a cell has HTML output, ALL outputs (including stream) get routed
-    // to the IsolatedFrame iframe, so we wait for the iframe directly.
-    await executeFirstCell();
-    console.log("Triggered execution");
-
-    // Wait for the IsolatedFrame iframe to appear (HTML output triggers it)
+    // The fixture notebook has pre-populated HTML display_data output,
+    // so the IsolatedFrame renders on load without needing a kernel.
     await browser.waitUntil(
       async () => {
         const iframe = await $('iframe[title="Isolated output frame"]');
         return await iframe.isExisting();
       },
       {
-        timeout: 120000,
+        timeout: 30000,
         interval: 500,
         timeoutMsg: "Isolated output frame did not appear",
       },


### PR DESCRIPTION
## Summary
- Pre-populate `9-html-output.ipynb` fixture with HTML `display_data` output so the `IsolatedFrame` renders on load
- Remove kernel dependency from `iframe-isolation.spec.js` — no more `waitForKernelReady` or `executeFirstCell`
- Reduces timeout from 120s to 30s since we're only waiting for the iframe to appear, not a kernel to start

## Why
The iframe isolation test only checks sandbox attributes and cross-origin restrictions. It doesn't need a running kernel — it just needs an iframe with HTML content. Starting a kernel made the test flaky under CI resource pressure (the kernel sometimes didn't start within the 30s timeout).