### PR TITLE
Optimize E2E tests: pre-warm pool, fixture-based rendering tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -212,7 +212,8 @@ jobs:
           # Start runtimed early so the pool fills while the Tauri app builds (~90s).
           # uv-pool-size 6 gives headroom for sequential fixture tests.
           # conda-pool-size 0 because conda fixture tests create inline environments.
-          ./target/release/runtimed run --uv-pool-size 6 --conda-pool-size 0 &
+          # Explicitly pass PATH so the background process can find uv.
+          env PATH="$PATH" ./target/release/runtimed run --uv-pool-size 6 --conda-pool-size 0 &
           echo "RUNTIMED_PID=$!" >> $GITHUB_ENV
 
       - name: Build Tauri app

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -207,6 +207,14 @@ jobs:
           cp target/release/runtimed "target/release/binaries/runtimed-$TARGET"
           cp target/release/runt "target/release/binaries/runt-$TARGET"
 
+      - name: Pre-warm environment pool
+        run: |
+          # Start runtimed early so the pool fills while the Tauri app builds (~90s).
+          # uv-pool-size 6 gives headroom for sequential fixture tests.
+          # conda-pool-size 0 because conda fixture tests create inline environments.
+          ./target/release/runtimed run --uv-pool-size 6 --conda-pool-size 0 &
+          echo "RUNTIMED_PID=$!" >> $GITHUB_ENV
+
       - name: Build Tauri app
         run: cd crates/notebook && cargo tauri build --ci --no-bundle --config '{"build":{"beforeBuildCommand":""}}'
 
@@ -309,8 +317,19 @@ jobs:
             E2E_SPEC=e2e/specs/save-dirty-state.spec.js \
             pnpm test:e2e || FAIL=1
 
+          start_driver
+          NOTEBOOK_PATH=crates/notebook/fixtures/audit-test/11-rich-outputs.ipynb \
+            E2E_SPEC=e2e/specs/rich-outputs.spec.js \
+            pnpm test:e2e || FAIL=1
+
+          start_driver
+          NOTEBOOK_PATH=crates/notebook/fixtures/audit-test/12-error-outputs.ipynb \
+            E2E_SPEC=e2e/specs/error-handling.spec.js \
+            pnpm test:e2e || FAIL=1
+
           # Cleanup
           kill $DRIVER_PID 2>/dev/null || true
+          kill $RUNTIMED_PID 2>/dev/null || true
 
           exit $FAIL
         env:

--- a/contributing/e2e.md
+++ b/contributing/e2e.md
@@ -115,6 +115,8 @@ Use a regular test when:
 | `9-html-output.ipynb` | `iframe-isolation.spec.js` | Iframe sandbox security |
 | `10-deno.ipynb` | `deno-runtime.spec.js` | Deno kernel start + TypeScript execution |
 | `1-vanilla.ipynb` | `save-dirty-state.spec.js` | Save button dirty state indicator |
+| `11-rich-outputs.ipynb` | `rich-outputs.spec.js` | Rich output rendering (PNG, HTML, DataFrame, ANSI) |
+| `12-error-outputs.ipynb` | `error-handling.spec.js` | Error traceback rendering |
 
 Multiple specs can reuse the same fixture notebook — each gets its own fresh app instance.
 

--- a/crates/notebook/fixtures/audit-test/11-rich-outputs.ipynb
+++ b/crates/notebook/fixtures/audit-test/11-rich-outputs.ipynb
@@ -1,0 +1,153 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "id": "cell-png",
+   "metadata": {},
+   "source": [
+    "from IPython.display import display, Image\n",
+    "import base64\n",
+    "\n",
+    "red_pixel = base64.b64decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==')\n",
+    "display(Image(data=red_pixel, format='png'))"
+   ],
+   "outputs": [
+    {
+     "output_type": "display_data",
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==",
+      "text/plain": "<IPython.core.display.Image object>"
+     },
+     "metadata": {}
+    }
+   ],
+   "execution_count": 1
+  },
+  {
+   "cell_type": "code",
+   "id": "cell-html",
+   "metadata": {},
+   "source": [
+    "from IPython.display import display, HTML\n",
+    "display(HTML('<div style=\"color: blue; font-size: 20px;\">Hello from HTML</div>'))"
+   ],
+   "outputs": [
+    {
+     "output_type": "display_data",
+     "data": {
+      "text/html": "<div style=\"color: blue; font-size: 20px;\">Hello from HTML</div>",
+      "text/plain": "<IPython.core.display.HTML object>"
+     },
+     "metadata": {}
+    }
+   ],
+   "execution_count": 2
+  },
+  {
+   "cell_type": "code",
+   "id": "cell-dataframe",
+   "metadata": {},
+   "source": [
+    "import pandas as pd\n",
+    "df = pd.DataFrame({\n",
+    "    'Name': ['Alice', 'Bob', 'Charlie'],\n",
+    "    'Age': [25, 30, 35],\n",
+    "    'City': ['NYC', 'LA', 'Chicago']\n",
+    "})\n",
+    "df"
+   ],
+   "outputs": [
+    {
+     "output_type": "execute_result",
+     "data": {
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>Name</th>\n      <th>Age</th>\n      <th>City</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>Alice</td>\n      <td>25</td>\n      <td>NYC</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>Bob</td>\n      <td>30</td>\n      <td>LA</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>Charlie</td>\n      <td>35</td>\n      <td>Chicago</td>\n    </tr>\n  </tbody>\n</table>\n</div>",
+      "text/plain": "      Name  Age     City\n0    Alice   25      NYC\n1      Bob   30       LA\n2  Charlie   35  Chicago"
+     },
+     "metadata": {},
+     "execution_count": 3
+    }
+   ],
+   "execution_count": 3
+  },
+  {
+   "cell_type": "code",
+   "id": "cell-multiprint",
+   "metadata": {},
+   "source": [
+    "print(\"First output\")\n",
+    "print(\"Second output\")\n",
+    "print(\"Third output\")"
+   ],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "First output\nSecond output\nThird output\n"
+    }
+   ],
+   "execution_count": 4
+  },
+  {
+   "cell_type": "code",
+   "id": "cell-mixed",
+   "metadata": {},
+   "source": [
+    "from IPython.display import display, Markdown\n",
+    "\n",
+    "print(\"This is stdout\")\n",
+    "display(Markdown(\"**This is bold markdown**\"))\n",
+    "print(\"More stdout\")"
+   ],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "This is stdout\n"
+    },
+    {
+     "output_type": "display_data",
+     "data": {
+      "text/markdown": "**This is bold markdown**",
+      "text/plain": "<IPython.core.display.Markdown object>"
+     },
+     "metadata": {}
+    },
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "More stdout\n"
+    }
+   ],
+   "execution_count": 5
+  },
+  {
+   "cell_type": "code",
+   "id": "cell-ansi",
+   "metadata": {},
+   "source": [
+    "print(\"\\033[31mRed\\033[0m \\033[32mGreen\\033[0m \\033[34mBlue\\033[0m\")"
+   ],
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": "\u001b[31mRed\u001b[0m \u001b[32mGreen\u001b[0m \u001b[34mBlue\u001b[0m\n"
+    }
+   ],
+   "execution_count": 6
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/crates/notebook/fixtures/audit-test/12-error-outputs.ipynb
+++ b/crates/notebook/fixtures/audit-test/12-error-outputs.ipynb
@@ -1,0 +1,124 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "id": "cell-syntax-error",
+   "metadata": {},
+   "source": [
+    "exec(\"print(1 +\")"
+   ],
+   "outputs": [
+    {
+     "output_type": "error",
+     "ename": "SyntaxError",
+     "evalue": "'(' was never closed (<string>, line 1)",
+     "traceback": [
+      "\u001b[0;36m  File \u001b[0;32m\"<string>\"\u001b[0;36m, line \u001b[0;32m1\u001b[0m\n\u001b[0;31m    print(1 +\u001b[0m\n\u001b[0m         ^\u001b[0m\n\u001b[0;31mSyntaxError\u001b[0m\u001b[0;31m:\u001b[0m '(' was never closed"
+     ]
+    }
+   ],
+   "execution_count": 1
+  },
+  {
+   "cell_type": "code",
+   "id": "cell-zero-div",
+   "metadata": {},
+   "source": [
+    "1 / 0"
+   ],
+   "outputs": [
+    {
+     "output_type": "error",
+     "ename": "ZeroDivisionError",
+     "evalue": "division by zero",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mZeroDivisionError\u001b[0m                         Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[2], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[38;5;241;43m1\u001b[39;49m \u001b[38;5;241;43m/\u001b[39;49m \u001b[38;5;241;43m0\u001b[39;49m\n",
+      "\u001b[0;31mZeroDivisionError\u001b[0m: division by zero"
+     ]
+    }
+   ],
+   "execution_count": 2
+  },
+  {
+   "cell_type": "code",
+   "id": "cell-import-error",
+   "metadata": {},
+   "source": [
+    "import nonexistent_package_xyz123"
+   ],
+   "outputs": [
+    {
+     "output_type": "error",
+     "ename": "ModuleNotFoundError",
+     "evalue": "No module named 'nonexistent_package_xyz123'",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mModuleNotFoundError\u001b[0m                       Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[3], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[38;5;28;01mimport\u001b[39;00m \u001b[38;5;21;01mnonexistent_package_xyz123\u001b[39;00m\n",
+      "\u001b[0;31mModuleNotFoundError\u001b[0m: No module named 'nonexistent_package_xyz123'"
+     ]
+    }
+   ],
+   "execution_count": 3
+  },
+  {
+   "cell_type": "code",
+   "id": "cell-name-error",
+   "metadata": {},
+   "source": [
+    "undefined_variable_xyz"
+   ],
+   "outputs": [
+    {
+     "output_type": "error",
+     "ename": "NameError",
+     "evalue": "name 'undefined_variable_xyz' is not defined",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[4], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m undefined_variable_xyz\n",
+      "\u001b[0;31mNameError\u001b[0m: name 'undefined_variable_xyz' is not defined"
+     ]
+    }
+   ],
+   "execution_count": 4
+  },
+  {
+   "cell_type": "code",
+   "id": "cell-type-error",
+   "metadata": {},
+   "source": [
+    "\"hello\" + 5"
+   ],
+   "outputs": [
+    {
+     "output_type": "error",
+     "ename": "TypeError",
+     "evalue": "can only concatenate str (not \"int\") to str",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[5], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m \u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mhello\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m \u001b[38;5;241;43m+\u001b[39;49m \u001b[38;5;241;43m5\u001b[39;49m\n",
+      "\u001b[0;31mTypeError\u001b[0m: can only concatenate str (not \"int\") to str"
+     ]
+    }
+   ],
+   "execution_count": 5
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/e2e/dev.sh
+++ b/e2e/dev.sh
@@ -257,6 +257,12 @@ case "${1:-help}" in
     run_fixture crates/notebook/fixtures/audit-test/1-vanilla.ipynb \
                 e2e/specs/settings-panel.spec.js
 
+    run_fixture crates/notebook/fixtures/audit-test/11-rich-outputs.ipynb \
+                e2e/specs/rich-outputs.spec.js
+
+    run_fixture crates/notebook/fixtures/audit-test/12-error-outputs.ipynb \
+                e2e/specs/error-handling.spec.js
+
     # Summary
     echo ""
     echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"

--- a/e2e/specs/error-handling.spec.js
+++ b/e2e/specs/error-handling.spec.js
@@ -1,222 +1,80 @@
 /**
- * E2E Test: Error Handling
+ * E2E Test: Error Handling (Fixture)
  *
- * Tests that errors are properly displayed:
- * - Syntax errors show traceback
- * - Runtime exceptions (ZeroDivisionError) show formatted output
- * - ImportError for missing packages shows helpful message
+ * Opens a notebook with pre-populated error outputs (12-error-outputs.ipynb) and
+ * verifies that error tracebacks render correctly without needing a kernel.
+ *
+ * Tests: SyntaxError, ZeroDivisionError, ModuleNotFoundError, NameError, TypeError.
+ *
+ * Requires: NOTEBOOK_PATH=crates/notebook/fixtures/audit-test/12-error-outputs.ipynb
  */
 
-import os from "node:os";
 import { browser, expect } from "@wdio/globals";
 import { waitForAppReady } from "../helpers.js";
 
-// macOS uses Cmd (Meta) for shortcuts, Linux uses Ctrl
-const MOD_KEY = os.platform() === "darwin" ? "Meta" : "Control";
-
 describe("Error Handling", () => {
-  const KERNEL_STARTUP_TIMEOUT = 90000;
-  const EXECUTION_TIMEOUT = 30000;
-
-  let codeCell;
-
   before(async () => {
     await waitForAppReady();
-
-    const title = await browser.getTitle();
-    console.log("Page title:", title);
+    console.log("Page title:", await browser.getTitle());
   });
 
-  /**
-   * Helper to type text character by character with delay
-   */
-  async function typeSlowly(text, delay = 30) {
-    for (const char of text) {
-      await browser.keys(char);
-      await browser.pause(delay);
-    }
+  async function getCodeCells() {
+    return await $$('[data-cell-type="code"]');
   }
 
-  /**
-   * Helper to wait for error output to appear
-   */
-  async function waitForError(timeout) {
-    await browser.waitUntil(
-      async () => {
-        const errorOutput = await codeCell.$('[data-slot="ansi-error-output"]');
-        return await errorOutput.isExisting();
-      },
-      {
-        timeout,
-        timeoutMsg: "Error output did not appear within timeout.",
-        interval: 500,
-      },
-    );
-  }
-
-  /**
-   * Helper to ensure we have a code cell and focus the editor
-   */
-  async function setupCodeCell() {
-    codeCell = await $('[data-cell-type="code"]');
-    const cellExists = await codeCell.isExisting();
-
-    if (!cellExists) {
-      console.log("No code cell found, adding one...");
-      const addCodeButton = await $('[data-testid="add-code-cell-button"]');
-      await addCodeButton.waitForClickable({ timeout: 5000 });
-      await addCodeButton.click();
-      await browser.pause(500);
-
-      codeCell = await $('[data-cell-type="code"]');
-      await codeCell.waitForExist({ timeout: 5000 });
-    }
-
-    const editor = await codeCell.$('.cm-content[contenteditable="true"]');
-    await editor.waitForExist({ timeout: 5000 });
-    await editor.click();
-    await browser.pause(200);
-
-    // Clear any existing content
-    await browser.keys([MOD_KEY, "a"]);
-    await browser.pause(100);
+  async function getErrorText(cell) {
+    const errorOutput = await cell.$('[data-slot="ansi-error-output"]');
+    await errorOutput.waitForExist({ timeout: 10000 });
+    return await errorOutput.getText();
   }
 
   it("should display syntax error traceback", async () => {
-    await setupCodeCell();
-
-    // Use exec() to force syntax error at runtime rather than parse time
-    // This ensures IPython reports it as an error output
-    const testCode = 'exec("print(1 +")';
-    console.log("Typing code with syntax error:", testCode);
-    await typeSlowly(testCode);
-    await browser.pause(300);
-
-    // Execute
-    await browser.keys(["Shift", "Enter"]);
-    console.log("Triggered execution");
-
-    // Wait for error output
-    await waitForError(KERNEL_STARTUP_TIMEOUT);
-
-    // Verify error content
-    const errorOutput = await codeCell.$('[data-slot="ansi-error-output"]');
-    const errorText = await errorOutput.getText();
+    const cells = await getCodeCells();
+    const errorText = await getErrorText(cells[0]);
     console.log("Error output:", errorText);
 
-    // Should contain SyntaxError indication
     expect(
       errorText.includes("SyntaxError") || errorText.includes("syntax"),
     ).toBe(true);
-
     console.log("Syntax error test passed");
   });
 
   it("should display ZeroDivisionError", async () => {
-    await setupCodeCell();
-
-    // Type code that causes division by zero
-    const testCode = "1 / 0";
-    console.log("Typing code:", testCode);
-    await typeSlowly(testCode);
-    await browser.pause(300);
-
-    // Execute
-    await browser.keys(["Shift", "Enter"]);
-    console.log("Triggered execution");
-
-    // Wait for error output
-    await waitForError(EXECUTION_TIMEOUT);
-
-    // Verify error content
-    const errorOutput = await codeCell.$('[data-slot="ansi-error-output"]');
-    const errorText = await errorOutput.getText();
+    const cells = await getCodeCells();
+    const errorText = await getErrorText(cells[1]);
     console.log("Error output:", errorText);
 
     expect(errorText).toContain("ZeroDivisionError");
-
     console.log("ZeroDivisionError test passed");
   });
 
   it("should display ImportError for missing packages", async () => {
-    await setupCodeCell();
-
-    // Import a package that doesn't exist
-    const testCode = "import nonexistent_package_xyz123";
-    console.log("Typing code:", testCode);
-    await typeSlowly(testCode);
-    await browser.pause(300);
-
-    // Execute
-    await browser.keys(["Shift", "Enter"]);
-    console.log("Triggered execution");
-
-    // Wait for error output
-    await waitForError(EXECUTION_TIMEOUT);
-
-    // Verify error content
-    const errorOutput = await codeCell.$('[data-slot="ansi-error-output"]');
-    const errorText = await errorOutput.getText();
+    const cells = await getCodeCells();
+    const errorText = await getErrorText(cells[2]);
     console.log("Error output:", errorText);
 
-    // Should contain ModuleNotFoundError or ImportError
     expect(
       errorText.includes("ModuleNotFoundError") ||
         errorText.includes("ImportError"),
     ).toBe(true);
-
     console.log("ImportError test passed");
   });
 
   it("should display NameError for undefined variables", async () => {
-    await setupCodeCell();
-
-    // Reference undefined variable
-    const testCode = "undefined_variable_xyz";
-    console.log("Typing code:", testCode);
-    await typeSlowly(testCode);
-    await browser.pause(300);
-
-    // Execute
-    await browser.keys(["Shift", "Enter"]);
-    console.log("Triggered execution");
-
-    // Wait for error output
-    await waitForError(EXECUTION_TIMEOUT);
-
-    // Verify error content
-    const errorOutput = await codeCell.$('[data-slot="ansi-error-output"]');
-    const errorText = await errorOutput.getText();
+    const cells = await getCodeCells();
+    const errorText = await getErrorText(cells[3]);
     console.log("Error output:", errorText);
 
     expect(errorText).toContain("NameError");
-
     console.log("NameError test passed");
   });
 
   it("should display TypeError for invalid operations", async () => {
-    await setupCodeCell();
-
-    // Type code that causes TypeError
-    const testCode = '"hello" + 5';
-    console.log("Typing code:", testCode);
-    await typeSlowly(testCode);
-    await browser.pause(300);
-
-    // Execute
-    await browser.keys(["Shift", "Enter"]);
-    console.log("Triggered execution");
-
-    // Wait for error output
-    await waitForError(EXECUTION_TIMEOUT);
-
-    // Verify error content
-    const errorOutput = await codeCell.$('[data-slot="ansi-error-output"]');
-    const errorText = await errorOutput.getText();
+    const cells = await getCodeCells();
+    const errorText = await getErrorText(cells[4]);
     console.log("Error output:", errorText);
 
     expect(errorText).toContain("TypeError");
-
     console.log("TypeError test passed");
   });
 });

--- a/e2e/specs/rich-outputs.spec.js
+++ b/e2e/specs/rich-outputs.spec.js
@@ -1,320 +1,147 @@
 /**
- * E2E Test: Rich Output Types
+ * E2E Test: Rich Output Types (Fixture)
  *
- * Tests that various output types render correctly:
- * - Image outputs (PNG, matplotlib)
- * - HTML outputs (rendered in isolated iframe)
- * - Multiple outputs in a single cell
+ * Opens a notebook with pre-populated outputs (11-rich-outputs.ipynb) and
+ * verifies that various output types render correctly without needing a kernel.
+ *
+ * Tests: PNG images, HTML in iframe, pandas DataFrame, multiple stream outputs,
+ * mixed output types, and ANSI color codes.
+ *
+ * Requires: NOTEBOOK_PATH=crates/notebook/fixtures/audit-test/11-rich-outputs.ipynb
  */
 
-import os from "node:os";
 import { browser, expect } from "@wdio/globals";
 import { waitForAppReady } from "../helpers.js";
 
-// macOS uses Cmd (Meta) for shortcuts, Linux uses Ctrl
-const MOD_KEY = os.platform() === "darwin" ? "Meta" : "Control";
-
 describe("Rich Output Types", () => {
-  const KERNEL_STARTUP_TIMEOUT = 90000;
-  const EXECUTION_TIMEOUT = 45000; // Longer for matplotlib and pandas
-
-  let codeCell;
-
   before(async () => {
     await waitForAppReady();
-
-    const title = await browser.getTitle();
-    console.log("Page title:", title);
+    console.log("Page title:", await browser.getTitle());
   });
 
-  /**
-   * Helper to type text character by character with delay
-   */
-  async function typeSlowly(text, delay = 30) {
-    for (const char of text) {
-      await browser.keys(char);
-      await browser.pause(delay);
-    }
-  }
-
-  /**
-   * Helper to ensure we have a code cell and focus the editor
-   */
-  async function setupCodeCell() {
-    codeCell = await $('[data-cell-type="code"]');
-    const cellExists = await codeCell.isExisting();
-
-    if (!cellExists) {
-      console.log("No code cell found, adding one...");
-      const addCodeButton = await $('[data-testid="add-code-cell-button"]');
-      await addCodeButton.waitForClickable({ timeout: 5000 });
-      await addCodeButton.click();
-      await browser.pause(500);
-
-      codeCell = await $('[data-cell-type="code"]');
-      await codeCell.waitForExist({ timeout: 5000 });
-    }
-
-    const editor = await codeCell.$('.cm-content[contenteditable="true"]');
-    await editor.waitForExist({ timeout: 5000 });
-    await editor.click();
-    await browser.pause(200);
-
-    // Clear any existing content
-    await browser.keys([MOD_KEY, "a"]);
-    await browser.pause(100);
-  }
-
-  /**
-   * Helper to wait for any output to appear
-   */
-  async function waitForAnyOutput(timeout) {
-    await browser.waitUntil(
-      async () => {
-        // Check for various output types
-        const streamOutput = await codeCell.$(
-          '[data-slot="ansi-stream-output"]',
-        );
-        const imageOutput = await codeCell.$("img");
-        const iframeOutput = await codeCell.$("iframe");
-        const displayData = await codeCell.$('[data-slot*="output"]');
-
-        return (
-          (await streamOutput.isExisting()) ||
-          (await imageOutput.isExisting()) ||
-          (await iframeOutput.isExisting()) ||
-          (await displayData.isExisting())
-        );
-      },
-      {
-        timeout,
-        timeoutMsg: "No output appeared within timeout.",
-        interval: 500,
-      },
-    );
-  }
-
-  /**
-   * Helper to wait for stream output containing text
-   */
-  async function waitForStreamOutput(expectedText, timeout) {
-    await browser.waitUntil(
-      async () => {
-        const output = await codeCell.$('[data-slot="ansi-stream-output"]');
-        if (!(await output.isExisting())) return false;
-        const text = await output.getText();
-        return text.includes(expectedText);
-      },
-      {
-        timeout,
-        timeoutMsg: `Stream output containing "${expectedText}" did not appear within timeout.`,
-        interval: 500,
-      },
-    );
+  async function getCodeCells() {
+    return await $$('[data-cell-type="code"]');
   }
 
   describe("Image outputs", () => {
     it("should render PNG images from matplotlib", async () => {
-      await setupCodeCell();
+      const cells = await getCodeCells();
+      const cell = cells[0];
 
-      // Create a simple matplotlib plot
-      // Note: matplotlib might need to be installed in the environment
-      const testCode = `import matplotlib
-matplotlib.use('Agg')
-import matplotlib.pyplot as plt
-plt.figure(figsize=(4, 3))
-plt.plot([1, 2, 3, 4], [1, 4, 2, 3])
-plt.title('Test Plot')
-plt.show()`;
+      // PNG display_data should render as an <img> tag
+      // Images may render in the main DOM or inside an IsolatedFrame
+      await browser.waitUntil(
+        async () => {
+          const img = await cell.$("img");
+          return await img.isExisting();
+        },
+        {
+          timeout: 15000,
+          interval: 500,
+          timeoutMsg: "PNG image did not render",
+        },
+      );
 
-      console.log("Typing matplotlib code");
-      await typeSlowly(testCode, 30); // Faster typing for longer code
-      await browser.pause(300);
-
-      // Execute
-      await browser.keys(["Shift", "Enter"]);
-      console.log("Triggered matplotlib execution");
-
-      try {
-        // Wait for image output
-        await browser.waitUntil(
-          async () => {
-            const img = await codeCell.$("img");
-            return await img.isExisting();
-          },
-          {
-            timeout: EXECUTION_TIMEOUT,
-            interval: 1000,
-          },
-        );
-
-        // Verify image exists
-        const img = await codeCell.$("img");
-        const imgExists = await img.isExisting();
-        expect(imgExists).toBe(true);
-
-        // Check image has valid src
-        const src = await img.getAttribute("src");
-        console.log(
-          "Image src type:",
-          src ? `${src.substring(0, 50)}...` : "none",
-        );
-        expect(src).toBeTruthy();
-
-        // Image should be either a data URL or blob URL
-        expect(src.startsWith("data:") || src.startsWith("blob:")).toBe(true);
-
-        console.log("Matplotlib image test passed");
-      } catch (e) {
-        // matplotlib might not be available
-        console.log(
-          "matplotlib test skipped - may not be installed:",
-          e.message,
-        );
-      }
+      const img = await cell.$("img");
+      const src = await img.getAttribute("src");
+      console.log(
+        "Image src type:",
+        src ? `${src.substring(0, 50)}...` : "none",
+      );
+      expect(src.startsWith("data:") || src.startsWith("blob:")).toBe(true);
+      console.log("PNG image test passed");
     });
 
     it("should render display(Image()) output", async () => {
-      await setupCodeCell();
-
-      // Create a simple base64 PNG (1x1 red pixel)
-      const testCode = `from IPython.display import display, Image
-import base64
-
-# 1x1 red PNG pixel
-red_pixel = base64.b64decode('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==')
-display(Image(data=red_pixel, format='png'))`;
-
-      console.log("Typing IPython Image display code");
-      await typeSlowly(testCode, 30);
-      await browser.pause(300);
-
-      await browser.keys(["Shift", "Enter"]);
-
-      try {
-        await waitForAnyOutput(KERNEL_STARTUP_TIMEOUT);
-
-        // Check for image
-        const img = await codeCell.$("img");
-        if (await img.isExisting()) {
-          console.log("IPython Image display test passed");
-        } else {
-          console.log(
-            "Image not rendered as img tag, checking alternative formats",
-          );
-        }
-      } catch (e) {
-        console.log("IPython Image test result:", e.message);
-      }
+      // Same cell as matplotlib — the fixture has a single PNG cell
+      // This test verifies the img element has a valid source
+      const cells = await getCodeCells();
+      const cell = cells[0];
+      const img = await cell.$("img");
+      expect(await img.isExisting()).toBe(true);
     });
   });
 
   describe("HTML outputs", () => {
     it("should render HTML in isolated iframe", async () => {
-      await setupCodeCell();
+      const cells = await getCodeCells();
+      const cell = cells[1];
 
-      // Display HTML content
-      const testCode = `from IPython.display import display, HTML
-display(HTML('<div style="color: blue; font-size: 20px;">Hello from HTML</div>'))`;
+      await browser.waitUntil(
+        async () => {
+          const iframe = await cell.$("iframe");
+          return await iframe.isExisting();
+        },
+        {
+          timeout: 15000,
+          interval: 500,
+          timeoutMsg: "HTML iframe did not appear",
+        },
+      );
 
-      console.log("Typing HTML display code");
-      await typeSlowly(testCode, 30);
-      await browser.pause(300);
+      const iframe = await cell.$("iframe");
+      console.log("HTML rendered in iframe - isolation working");
 
-      await browser.keys(["Shift", "Enter"]);
-
-      try {
-        await waitForAnyOutput(KERNEL_STARTUP_TIMEOUT);
-
-        // HTML should be rendered in an iframe for isolation
-        const iframe = await codeCell.$("iframe");
-        const iframeExists = await iframe.isExisting();
-
-        if (iframeExists) {
-          console.log("HTML rendered in iframe - isolation working");
-
-          // Verify iframe has sandbox attribute (security)
-          const sandbox = await iframe.getAttribute("sandbox");
-          console.log("Iframe sandbox:", sandbox);
-
-          // Should not have allow-same-origin for security
-          if (sandbox) {
-            expect(sandbox).not.toContain("allow-same-origin");
-          }
-        } else {
-          // HTML might be rendered directly if simple enough
-          const htmlContent = await codeCell.getHTML();
-          console.log(
-            "Cell HTML contains 'Hello':",
-            htmlContent.includes("Hello"),
-          );
-        }
-
-        console.log("HTML output test passed");
-      } catch (e) {
-        console.log("HTML output test result:", e.message);
+      const sandbox = await iframe.getAttribute("sandbox");
+      console.log("Iframe sandbox:", sandbox);
+      if (sandbox) {
+        expect(sandbox).not.toContain("allow-same-origin");
       }
+      console.log("HTML output test passed");
     });
 
     it("should render pandas DataFrame as HTML", async () => {
-      await setupCodeCell();
+      const cells = await getCodeCells();
+      const cell = cells[2];
 
-      // Create and display a pandas DataFrame
-      const testCode = `import pandas as pd
-df = pd.DataFrame({
-    'Name': ['Alice', 'Bob', 'Charlie'],
-    'Age': [25, 30, 35],
-    'City': ['NYC', 'LA', 'Chicago']
-})
-df`;
+      // DataFrame renders as HTML table — may be in iframe or direct DOM
+      await browser.waitUntil(
+        async () => {
+          const html = await cell.getHTML();
+          return (
+            html.includes("Alice") ||
+            html.includes("dataframe") ||
+            html.includes("iframe")
+          );
+        },
+        {
+          timeout: 15000,
+          interval: 500,
+          timeoutMsg: "DataFrame did not render",
+        },
+      );
 
-      console.log("Typing pandas DataFrame code");
-      await typeSlowly(testCode, 30);
-      await browser.pause(300);
-
-      await browser.keys(["Shift", "Enter"]);
-
-      try {
-        await waitForAnyOutput(EXECUTION_TIMEOUT);
-
-        // DataFrame should render as HTML table
-        // Check for table elements or iframe containing table
-        const cellHtml = await codeCell.getHTML();
-        const hasTable =
-          cellHtml.includes("<table") ||
-          cellHtml.includes("dataframe") ||
-          cellHtml.includes("Alice"); // Data should be visible
-
-        console.log("DataFrame rendered:", hasTable);
-
-        if (hasTable) {
-          console.log("pandas DataFrame test passed");
-        }
-      } catch (e) {
-        // pandas might not be available
-        console.log("pandas test skipped - may not be installed:", e.message);
-      }
+      const cellHtml = await cell.getHTML();
+      const hasTable =
+        cellHtml.includes("<table") ||
+        cellHtml.includes("dataframe") ||
+        cellHtml.includes("Alice");
+      console.log("DataFrame rendered:", hasTable);
+      expect(hasTable).toBe(true);
+      console.log("pandas DataFrame test passed");
     });
   });
 
   describe("Multiple outputs", () => {
     it("should display multiple outputs from a single cell", async () => {
-      await setupCodeCell();
+      const cells = await getCodeCells();
+      const cell = cells[3];
 
-      // Generate multiple outputs - use a simple test that works reliably
-      const testCode =
-        'print("First output"); print("Second output"); print("Third output")';
+      await browser.waitUntil(
+        async () => {
+          const output = await cell.$('[data-slot="ansi-stream-output"]');
+          if (!(await output.isExisting())) return false;
+          const text = await output.getText();
+          return text.includes("Third output");
+        },
+        {
+          timeout: 15000,
+          interval: 500,
+          timeoutMsg: "Stream outputs did not render",
+        },
+      );
 
-      console.log("Typing multiple print statements");
-      await typeSlowly(testCode, 30);
-      await browser.pause(300);
-
-      await browser.keys(["Shift", "Enter"]);
-
-      await waitForStreamOutput("Third output", KERNEL_STARTUP_TIMEOUT);
-
-      // All outputs should be visible
-      const outputText = await codeCell
+      const outputText = await cell
         .$('[data-slot="ansi-stream-output"]')
         .getText();
       console.log("Output text:", outputText);
@@ -322,60 +149,54 @@ df`;
       expect(outputText).toContain("First output");
       expect(outputText).toContain("Second output");
       expect(outputText).toContain("Third output");
-
       console.log("Multiple outputs test passed");
     });
 
     it("should display mixed output types", async () => {
-      await setupCodeCell();
+      const cells = await getCodeCells();
+      const cell = cells[4];
 
-      // Generate different output types
-      const testCode = `from IPython.display import display, Markdown
+      // Mixed cell has stream + display_data + stream
+      // All outputs go to iframe when any output needs isolation (markdown does)
+      await browser.waitUntil(
+        async () => {
+          const html = await cell.getHTML();
+          return (
+            html.includes("stdout") ||
+            html.includes("iframe") ||
+            html.includes("output")
+          );
+        },
+        {
+          timeout: 15000,
+          interval: 500,
+          timeoutMsg: "Mixed outputs did not render",
+        },
+      );
 
-print("This is stdout")
-display(Markdown("**This is bold markdown**"))
-print("More stdout")`;
-
-      console.log("Typing mixed output code");
-      await typeSlowly(testCode, 30);
-      await browser.pause(300);
-
-      await browser.keys(["Shift", "Enter"]);
-
-      try {
-        await waitForAnyOutput(KERNEL_STARTUP_TIMEOUT);
-
-        // Check that we have output
-        const cellHtml = await codeCell.getHTML();
-        const hasStdout =
-          cellHtml.includes("stdout") || cellHtml.includes("This is");
-
-        console.log("Mixed outputs rendered:", hasStdout);
-        console.log("Mixed output types test passed");
-      } catch (e) {
-        console.log("Mixed output test result:", e.message);
-      }
+      console.log("Mixed outputs rendered: true");
+      console.log("Mixed output types test passed");
     });
   });
 
   describe("ANSI colors in output", () => {
     it("should render ANSI color codes", async () => {
-      await setupCodeCell();
+      const cells = await getCodeCells();
+      const cell = cells[5];
 
-      // Print colored output - use single line for reliability
-      const testCode =
-        'print("\\033[31mRed\\033[0m \\033[32mGreen\\033[0m \\033[34mBlue\\033[0m")';
+      await browser.waitUntil(
+        async () => {
+          const output = await cell.$('[data-slot="ansi-stream-output"]');
+          return await output.isExisting();
+        },
+        {
+          timeout: 15000,
+          interval: 500,
+          timeoutMsg: "ANSI output did not render",
+        },
+      );
 
-      console.log("Typing ANSI color code");
-      await typeSlowly(testCode, 30);
-      await browser.pause(300);
-
-      await browser.keys(["Shift", "Enter"]);
-
-      await waitForStreamOutput("Blue", KERNEL_STARTUP_TIMEOUT);
-
-      // Check that ANSI spans are rendered with color classes
-      const outputHtml = await codeCell
+      const outputHtml = await cell
         .$('[data-slot="ansi-stream-output"]')
         .getHTML();
       console.log(
@@ -383,7 +204,6 @@ print("More stdout")`;
         outputHtml.includes("ansi-"),
       );
 
-      // Should have ANSI color classes applied
       const hasColorClasses =
         outputHtml.includes("ansi-red") ||
         outputHtml.includes("ansi-green") ||
@@ -391,6 +211,7 @@ print("More stdout")`;
         outputHtml.includes("color:");
 
       console.log("ANSI colors rendered:", hasColorClasses);
+      expect(hasColorClasses).toBe(true);
       console.log("ANSI color test passed");
     });
   });

--- a/e2e/wdio.conf.js
+++ b/e2e/wdio.conf.js
@@ -45,6 +45,8 @@ const FIXTURE_SPECS = [
   "settings-panel.spec.js",
   "deno-runtime.spec.js",
   "save-dirty-state.spec.js",
+  "rich-outputs.spec.js",
+  "error-handling.spec.js",
 ];
 
 export const config = {


### PR DESCRIPTION
## Summary
- Pre-warm the environment pool in CI by starting `runtimed` with `--uv-pool-size 6` during the Tauri app build window (~90s)
- Convert `rich-outputs.spec.js` from a 2:07 execution test to a ~10s fixture test with pre-populated outputs (PNG, HTML, DataFrame, stream, ANSI)
- Convert `error-handling.spec.js` from a 13.6s execution test to a ~5s fixture test with pre-populated error tracebacks
- Both tests moved from the default group (shared kernel) to fixture tests, removing 12 execution cycles

## Why
The `rich-outputs` and `error-handling` tests were typing code and starting kernels to test output *rendering* — not the execution pipeline. Pre-populating the fixture notebooks with saved outputs tests the same rendering paths without the kernel overhead. The pool prewarming eliminates the cold-start penalty for the first kernel-needing test.

Estimated savings: ~3-4 minutes off the ~17 minute E2E suite.