### PR TITLE
Add output store foundation: ContentRef, manifests, inlining threshold

### DIFF
--- a/crates/runtimed/src/lib.rs
+++ b/crates/runtimed/src/lib.rs
@@ -19,6 +19,7 @@ pub mod daemon;
 pub mod notebook_doc;
 pub mod notebook_sync_client;
 pub mod notebook_sync_server;
+pub mod output_store;
 pub mod protocol;
 pub mod runtime;
 pub mod service;

--- a/crates/runtimed/src/output_store.rs
+++ b/crates/runtimed/src/output_store.rs
@@ -1,0 +1,723 @@
+//! Output store: manifests, ContentRef, and inlining for notebook outputs.
+//!
+//! This module provides the foundation for Phase 6 output handling:
+//! - `ContentRef`: a reference to content that may be inlined or stored in the blob store
+//! - Output manifests: Jupyter output types with `ContentRef` for data fields
+//! - Inlining threshold: small data is inlined, large data goes to blob store
+//!
+//! ## Design
+//!
+//! Instead of storing full Jupyter outputs as JSON strings in the CRDT (which
+//! causes bloat for images and large outputs), we store output manifests that
+//! reference content via `ContentRef`. Small content (< 8KB by default) is
+//! inlined in the manifest. Large content is stored in the blob store.
+//!
+//! The manifest is itself stored in the blob store with media type
+//! `application/x-jupyter-output+json`, and its hash is stored in the CRDT.
+
+use std::collections::HashMap;
+use std::io;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::blob_store::BlobStore;
+
+/// Default inlining threshold: 8 KB.
+///
+/// Content smaller than this is inlined in the manifest.
+/// Content equal to or larger than this is stored in the blob store.
+pub const DEFAULT_INLINE_THRESHOLD: usize = 8 * 1024;
+
+/// Media type for output manifests stored in the blob store.
+pub const MANIFEST_MEDIA_TYPE: &str = "application/x-jupyter-output+json";
+
+/// A reference to content that may be inlined or stored in the blob store.
+///
+/// Serializes as an untagged enum:
+/// - `{"inline": "..."}`  — content is inlined
+/// - `{"blob": "hash...", "size": 12345}` — content is in blob store
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ContentRef {
+    /// Content is inlined in the manifest.
+    Inline { inline: String },
+    /// Content is stored in the blob store.
+    Blob { blob: String, size: u64 },
+}
+
+impl ContentRef {
+    /// Create a ContentRef from data, applying the inlining threshold.
+    ///
+    /// If the data is smaller than the threshold, it's inlined.
+    /// Otherwise, it's stored in the blob store.
+    pub async fn from_data(
+        data: &str,
+        media_type: &str,
+        blob_store: &BlobStore,
+        threshold: usize,
+    ) -> io::Result<Self> {
+        if data.len() < threshold {
+            Ok(ContentRef::Inline {
+                inline: data.to_string(),
+            })
+        } else {
+            let hash = blob_store.put(data.as_bytes(), media_type).await?;
+            Ok(ContentRef::Blob {
+                blob: hash,
+                size: data.len() as u64,
+            })
+        }
+    }
+
+    /// Resolve a ContentRef to its string content.
+    ///
+    /// For inline content, returns the content directly.
+    /// For blob content, fetches from the blob store.
+    pub async fn resolve(&self, blob_store: &BlobStore) -> io::Result<String> {
+        match self {
+            ContentRef::Inline { inline } => Ok(inline.clone()),
+            ContentRef::Blob { blob, .. } => {
+                let data = blob_store.get(blob).await?.ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::NotFound, format!("blob not found: {}", blob))
+                })?;
+                String::from_utf8(data).map_err(|e| {
+                    io::Error::new(io::ErrorKind::InvalidData, format!("invalid UTF-8: {}", e))
+                })
+            }
+        }
+    }
+
+    /// Returns true if the content is inlined.
+    pub fn is_inline(&self) -> bool {
+        matches!(self, ContentRef::Inline { .. })
+    }
+}
+
+// =============================================================================
+// Output manifest types
+// =============================================================================
+
+/// Manifest for display_data and execute_result outputs.
+///
+/// These are the most common output types, containing MIME-typed data bundles.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DisplayDataManifest {
+    /// Output type: "display_data" or "execute_result"
+    pub output_type: String,
+    /// MIME type -> content reference
+    pub data: HashMap<String, ContentRef>,
+    /// MIME type -> metadata (unchanged from Jupyter)
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub metadata: HashMap<String, Value>,
+    /// Execution count (only for execute_result)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub execution_count: Option<i32>,
+}
+
+/// Manifest for stream outputs (stdout/stderr).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StreamManifest {
+    /// Output type: always "stream"
+    pub output_type: String,
+    /// Stream name: "stdout" or "stderr"
+    pub name: String,
+    /// Stream text content
+    pub text: ContentRef,
+}
+
+/// Manifest for error outputs.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ErrorManifest {
+    /// Output type: always "error"
+    pub output_type: String,
+    /// Exception class name
+    pub ename: String,
+    /// Exception value/message
+    pub evalue: String,
+    /// Traceback lines (JSON array as string)
+    pub traceback: ContentRef,
+}
+
+/// A unified output manifest enum for serialization.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "output_type")]
+pub enum OutputManifest {
+    #[serde(rename = "display_data")]
+    DisplayData {
+        data: HashMap<String, ContentRef>,
+        #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+        metadata: HashMap<String, Value>,
+    },
+    #[serde(rename = "execute_result")]
+    ExecuteResult {
+        data: HashMap<String, ContentRef>,
+        #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+        metadata: HashMap<String, Value>,
+        execution_count: Option<i32>,
+    },
+    #[serde(rename = "stream")]
+    Stream { name: String, text: ContentRef },
+    #[serde(rename = "error")]
+    Error {
+        ename: String,
+        evalue: String,
+        traceback: ContentRef,
+    },
+}
+
+// =============================================================================
+// Manifest creation and resolution
+// =============================================================================
+
+/// Create an output manifest from a raw Jupyter output JSON value.
+///
+/// Applies the inlining threshold to data fields:
+/// - Data smaller than the threshold is inlined
+/// - Data larger than the threshold is stored in the blob store
+///
+/// Returns the manifest as a JSON string.
+pub async fn create_manifest(
+    output: &Value,
+    blob_store: &BlobStore,
+    threshold: usize,
+) -> io::Result<String> {
+    let output_type = output
+        .get("output_type")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "missing output_type"))?;
+
+    let manifest = match output_type {
+        "display_data" => {
+            let data = convert_data_bundle(output.get("data"), blob_store, threshold).await?;
+            let metadata = extract_metadata(output.get("metadata"));
+            OutputManifest::DisplayData { data, metadata }
+        }
+        "execute_result" => {
+            let data = convert_data_bundle(output.get("data"), blob_store, threshold).await?;
+            let metadata = extract_metadata(output.get("metadata"));
+            let execution_count = output
+                .get("execution_count")
+                .and_then(|v| v.as_i64())
+                .map(|n| n as i32);
+            OutputManifest::ExecuteResult {
+                data,
+                metadata,
+                execution_count,
+            }
+        }
+        "stream" => {
+            let name = output
+                .get("name")
+                .and_then(|v| v.as_str())
+                .unwrap_or("stdout")
+                .to_string();
+            let text_value = output
+                .get("text")
+                .cloned()
+                .unwrap_or(Value::String(String::new()));
+            let text_str = normalize_text(&text_value);
+            let text =
+                ContentRef::from_data(&text_str, "text/plain", blob_store, threshold).await?;
+            OutputManifest::Stream { name, text }
+        }
+        "error" => {
+            let ename = output
+                .get("ename")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let evalue = output
+                .get("evalue")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let traceback_value = output
+                .get("traceback")
+                .cloned()
+                .unwrap_or(Value::Array(vec![]));
+            let traceback_json = serde_json::to_string(&traceback_value)
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+            let traceback =
+                ContentRef::from_data(&traceback_json, "application/json", blob_store, threshold)
+                    .await?;
+            OutputManifest::Error {
+                ename,
+                evalue,
+                traceback,
+            }
+        }
+        _ => {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("unknown output_type: {}", output_type),
+            ))
+        }
+    };
+
+    serde_json::to_string(&manifest).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+}
+
+/// Store a manifest JSON string in the blob store.
+///
+/// Returns the blob hash that can be stored in the CRDT.
+pub async fn store_manifest(manifest_json: &str, blob_store: &BlobStore) -> io::Result<String> {
+    blob_store
+        .put(manifest_json.as_bytes(), MANIFEST_MEDIA_TYPE)
+        .await
+}
+
+/// Resolve a manifest back to a full Jupyter output JSON value.
+///
+/// Fetches any blob-referenced content and reconstructs the original format.
+pub async fn resolve_manifest(manifest_json: &str, blob_store: &BlobStore) -> io::Result<Value> {
+    let manifest: OutputManifest = serde_json::from_str(manifest_json)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+
+    match manifest {
+        OutputManifest::DisplayData { data, metadata } => {
+            let resolved_data = resolve_data_bundle(data, blob_store).await?;
+            let mut output = serde_json::json!({
+                "output_type": "display_data",
+                "data": resolved_data,
+            });
+            if !metadata.is_empty() {
+                output["metadata"] = Value::Object(metadata.into_iter().collect());
+            } else {
+                output["metadata"] = Value::Object(serde_json::Map::new());
+            }
+            Ok(output)
+        }
+        OutputManifest::ExecuteResult {
+            data,
+            metadata,
+            execution_count,
+        } => {
+            let resolved_data = resolve_data_bundle(data, blob_store).await?;
+            let mut output = serde_json::json!({
+                "output_type": "execute_result",
+                "data": resolved_data,
+                "execution_count": execution_count,
+            });
+            if !metadata.is_empty() {
+                output["metadata"] = Value::Object(metadata.into_iter().collect());
+            } else {
+                output["metadata"] = Value::Object(serde_json::Map::new());
+            }
+            Ok(output)
+        }
+        OutputManifest::Stream { name, text } => {
+            let resolved_text = text.resolve(blob_store).await?;
+            Ok(serde_json::json!({
+                "output_type": "stream",
+                "name": name,
+                "text": resolved_text,
+            }))
+        }
+        OutputManifest::Error {
+            ename,
+            evalue,
+            traceback,
+        } => {
+            let traceback_json = traceback.resolve(blob_store).await?;
+            let traceback_array: Value = serde_json::from_str(&traceback_json)
+                .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+            Ok(serde_json::json!({
+                "output_type": "error",
+                "ename": ename,
+                "evalue": evalue,
+                "traceback": traceback_array,
+            }))
+        }
+    }
+}
+
+// =============================================================================
+// Helper functions
+// =============================================================================
+
+/// Convert a Jupyter data bundle (MIME type -> content) to ContentRefs.
+async fn convert_data_bundle(
+    data: Option<&Value>,
+    blob_store: &BlobStore,
+    threshold: usize,
+) -> io::Result<HashMap<String, ContentRef>> {
+    let mut result = HashMap::new();
+
+    if let Some(Value::Object(map)) = data {
+        for (mime_type, value) in map {
+            let content_str = value_to_string(value);
+            // Use the MIME type as the blob media type
+            let content_ref =
+                ContentRef::from_data(&content_str, mime_type, blob_store, threshold).await?;
+            result.insert(mime_type.clone(), content_ref);
+        }
+    }
+
+    Ok(result)
+}
+
+/// Resolve a data bundle of ContentRefs back to string values.
+async fn resolve_data_bundle(
+    data: HashMap<String, ContentRef>,
+    blob_store: &BlobStore,
+) -> io::Result<HashMap<String, Value>> {
+    let mut result = HashMap::new();
+
+    for (mime_type, content_ref) in data {
+        let content = content_ref.resolve(blob_store).await?;
+        // Try to parse as JSON for structured MIME types, otherwise use as string
+        let value = if mime_type.ends_with("+json") || mime_type == "application/json" {
+            serde_json::from_str(&content).unwrap_or(Value::String(content))
+        } else {
+            Value::String(content)
+        };
+        result.insert(mime_type, value);
+    }
+
+    Ok(result)
+}
+
+/// Extract metadata from a Jupyter output, preserving as Value.
+fn extract_metadata(metadata: Option<&Value>) -> HashMap<String, Value> {
+    match metadata {
+        Some(Value::Object(map)) => map.clone().into_iter().collect(),
+        _ => HashMap::new(),
+    }
+}
+
+/// Normalize text that may be a string or array of strings (Jupyter format).
+fn normalize_text(value: &Value) -> String {
+    match value {
+        Value::String(s) => s.clone(),
+        Value::Array(arr) => arr
+            .iter()
+            .filter_map(|v| v.as_str())
+            .collect::<Vec<_>>()
+            .join(""),
+        _ => String::new(),
+    }
+}
+
+/// Convert a JSON value to a string for storage.
+///
+/// Strings are returned as-is. Other types are JSON-serialized.
+fn value_to_string(value: &Value) -> String {
+    match value {
+        Value::String(s) => s.clone(),
+        _ => serde_json::to_string(value).unwrap_or_default(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn test_store(dir: &TempDir) -> BlobStore {
+        BlobStore::new(dir.path().join("blobs"))
+    }
+
+    #[test]
+    fn test_content_ref_serialization() {
+        // Inline variant
+        let inline = ContentRef::Inline {
+            inline: "hello".to_string(),
+        };
+        let json = serde_json::to_string(&inline).unwrap();
+        assert_eq!(json, r#"{"inline":"hello"}"#);
+
+        // Blob variant
+        let blob = ContentRef::Blob {
+            blob: "abc123".to_string(),
+            size: 1000,
+        };
+        let json = serde_json::to_string(&blob).unwrap();
+        assert_eq!(json, r#"{"blob":"abc123","size":1000}"#);
+    }
+
+    #[test]
+    fn test_content_ref_deserialization() {
+        let inline: ContentRef = serde_json::from_str(r#"{"inline":"hello"}"#).unwrap();
+        assert!(matches!(inline, ContentRef::Inline { inline } if inline == "hello"));
+
+        let blob: ContentRef = serde_json::from_str(r#"{"blob":"abc123","size":1000}"#).unwrap();
+        assert!(
+            matches!(blob, ContentRef::Blob { blob, size } if blob == "abc123" && size == 1000)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_content_ref_from_data_inlines_small() {
+        let dir = TempDir::new().unwrap();
+        let store = test_store(&dir);
+
+        let small_data = "hello world";
+        let content_ref = ContentRef::from_data(small_data, "text/plain", &store, 100)
+            .await
+            .unwrap();
+
+        assert!(content_ref.is_inline());
+        assert!(matches!(content_ref, ContentRef::Inline { inline } if inline == small_data));
+    }
+
+    #[tokio::test]
+    async fn test_content_ref_from_data_blobs_large() {
+        let dir = TempDir::new().unwrap();
+        let store = test_store(&dir);
+
+        let large_data = "x".repeat(200);
+        let content_ref = ContentRef::from_data(&large_data, "text/plain", &store, 100)
+            .await
+            .unwrap();
+
+        assert!(!content_ref.is_inline());
+        assert!(matches!(content_ref, ContentRef::Blob { size, .. } if size == 200));
+    }
+
+    #[tokio::test]
+    async fn test_content_ref_resolve_inline() {
+        let dir = TempDir::new().unwrap();
+        let store = test_store(&dir);
+
+        let content_ref = ContentRef::Inline {
+            inline: "hello".to_string(),
+        };
+        let resolved = content_ref.resolve(&store).await.unwrap();
+        assert_eq!(resolved, "hello");
+    }
+
+    #[tokio::test]
+    async fn test_content_ref_resolve_blob() {
+        let dir = TempDir::new().unwrap();
+        let store = test_store(&dir);
+
+        let data = "blob content";
+        let hash = store.put(data.as_bytes(), "text/plain").await.unwrap();
+
+        let content_ref = ContentRef::Blob {
+            blob: hash,
+            size: data.len() as u64,
+        };
+        let resolved = content_ref.resolve(&store).await.unwrap();
+        assert_eq!(resolved, data);
+    }
+
+    #[tokio::test]
+    async fn test_create_manifest_display_data() {
+        let dir = TempDir::new().unwrap();
+        let store = test_store(&dir);
+
+        let output = serde_json::json!({
+            "output_type": "display_data",
+            "data": {
+                "text/plain": "hello",
+                "text/html": "<b>hello</b>"
+            },
+            "metadata": {}
+        });
+
+        let manifest_json = create_manifest(&output, &store, DEFAULT_INLINE_THRESHOLD)
+            .await
+            .unwrap();
+
+        let manifest: OutputManifest = serde_json::from_str(&manifest_json).unwrap();
+        assert!(matches!(manifest, OutputManifest::DisplayData { .. }));
+    }
+
+    #[tokio::test]
+    async fn test_create_manifest_stream() {
+        let dir = TempDir::new().unwrap();
+        let store = test_store(&dir);
+
+        let output = serde_json::json!({
+            "output_type": "stream",
+            "name": "stdout",
+            "text": "hello world\n"
+        });
+
+        let manifest_json = create_manifest(&output, &store, DEFAULT_INLINE_THRESHOLD)
+            .await
+            .unwrap();
+
+        let manifest: OutputManifest = serde_json::from_str(&manifest_json).unwrap();
+        assert!(matches!(manifest, OutputManifest::Stream { name, .. } if name == "stdout"));
+    }
+
+    #[tokio::test]
+    async fn test_create_manifest_error() {
+        let dir = TempDir::new().unwrap();
+        let store = test_store(&dir);
+
+        let output = serde_json::json!({
+            "output_type": "error",
+            "ename": "ValueError",
+            "evalue": "invalid value",
+            "traceback": ["line 1", "line 2"]
+        });
+
+        let manifest_json = create_manifest(&output, &store, DEFAULT_INLINE_THRESHOLD)
+            .await
+            .unwrap();
+
+        let manifest: OutputManifest = serde_json::from_str(&manifest_json).unwrap();
+        assert!(matches!(manifest, OutputManifest::Error { ename, .. } if ename == "ValueError"));
+    }
+
+    #[tokio::test]
+    async fn test_store_manifest() {
+        let dir = TempDir::new().unwrap();
+        let store = test_store(&dir);
+
+        let manifest = r#"{"output_type":"stream","name":"stdout","text":{"inline":"hello"}}"#;
+        let hash = store_manifest(manifest, &store).await.unwrap();
+
+        // Verify it's stored with correct media type
+        let meta = store.get_meta(&hash).await.unwrap().unwrap();
+        assert_eq!(meta.media_type, MANIFEST_MEDIA_TYPE);
+    }
+
+    #[tokio::test]
+    async fn test_round_trip_display_data() {
+        let dir = TempDir::new().unwrap();
+        let store = test_store(&dir);
+
+        let original = serde_json::json!({
+            "output_type": "display_data",
+            "data": {
+                "text/plain": "hello",
+                "text/html": "<b>hello</b>"
+            },
+            "metadata": {}
+        });
+
+        let manifest_json = create_manifest(&original, &store, DEFAULT_INLINE_THRESHOLD)
+            .await
+            .unwrap();
+        let resolved = resolve_manifest(&manifest_json, &store).await.unwrap();
+
+        assert_eq!(resolved["output_type"], "display_data");
+        assert_eq!(resolved["data"]["text/plain"], "hello");
+        assert_eq!(resolved["data"]["text/html"], "<b>hello</b>");
+    }
+
+    #[tokio::test]
+    async fn test_round_trip_execute_result() {
+        let dir = TempDir::new().unwrap();
+        let store = test_store(&dir);
+
+        let original = serde_json::json!({
+            "output_type": "execute_result",
+            "data": {
+                "text/plain": "42"
+            },
+            "metadata": {},
+            "execution_count": 5
+        });
+
+        let manifest_json = create_manifest(&original, &store, DEFAULT_INLINE_THRESHOLD)
+            .await
+            .unwrap();
+        let resolved = resolve_manifest(&manifest_json, &store).await.unwrap();
+
+        assert_eq!(resolved["output_type"], "execute_result");
+        assert_eq!(resolved["data"]["text/plain"], "42");
+        assert_eq!(resolved["execution_count"], 5);
+    }
+
+    #[tokio::test]
+    async fn test_round_trip_stream() {
+        let dir = TempDir::new().unwrap();
+        let store = test_store(&dir);
+
+        let original = serde_json::json!({
+            "output_type": "stream",
+            "name": "stderr",
+            "text": "error message\n"
+        });
+
+        let manifest_json = create_manifest(&original, &store, DEFAULT_INLINE_THRESHOLD)
+            .await
+            .unwrap();
+        let resolved = resolve_manifest(&manifest_json, &store).await.unwrap();
+
+        assert_eq!(resolved["output_type"], "stream");
+        assert_eq!(resolved["name"], "stderr");
+        assert_eq!(resolved["text"], "error message\n");
+    }
+
+    #[tokio::test]
+    async fn test_round_trip_error() {
+        let dir = TempDir::new().unwrap();
+        let store = test_store(&dir);
+
+        let original = serde_json::json!({
+            "output_type": "error",
+            "ename": "ZeroDivisionError",
+            "evalue": "division by zero",
+            "traceback": ["Traceback:", "  File \"test.py\"", "ZeroDivisionError"]
+        });
+
+        let manifest_json = create_manifest(&original, &store, DEFAULT_INLINE_THRESHOLD)
+            .await
+            .unwrap();
+        let resolved = resolve_manifest(&manifest_json, &store).await.unwrap();
+
+        assert_eq!(resolved["output_type"], "error");
+        assert_eq!(resolved["ename"], "ZeroDivisionError");
+        assert_eq!(resolved["evalue"], "division by zero");
+        assert!(resolved["traceback"].is_array());
+        assert_eq!(resolved["traceback"].as_array().unwrap().len(), 3);
+    }
+
+    #[tokio::test]
+    async fn test_large_data_uses_blob() {
+        let dir = TempDir::new().unwrap();
+        let store = test_store(&dir);
+
+        // Create output with data larger than threshold
+        let large_html = "<html>".to_string() + &"x".repeat(10000) + "</html>";
+        let output = serde_json::json!({
+            "output_type": "display_data",
+            "data": {
+                "text/plain": "small",
+                "text/html": large_html
+            },
+            "metadata": {}
+        });
+
+        let manifest_json = create_manifest(&output, &store, DEFAULT_INLINE_THRESHOLD)
+            .await
+            .unwrap();
+        let manifest: OutputManifest = serde_json::from_str(&manifest_json).unwrap();
+
+        if let OutputManifest::DisplayData { data, .. } = manifest {
+            // text/plain should be inlined (< 8KB)
+            assert!(data.get("text/plain").unwrap().is_inline());
+            // text/html should be a blob (> 8KB)
+            assert!(!data.get("text/html").unwrap().is_inline());
+        } else {
+            panic!("Expected DisplayData manifest");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_stream_text_array_normalization() {
+        let dir = TempDir::new().unwrap();
+        let store = test_store(&dir);
+
+        // Jupyter sometimes sends text as array of strings
+        let output = serde_json::json!({
+            "output_type": "stream",
+            "name": "stdout",
+            "text": ["line 1\n", "line 2\n"]
+        });
+
+        let manifest_json = create_manifest(&output, &store, DEFAULT_INLINE_THRESHOLD)
+            .await
+            .unwrap();
+        let resolved = resolve_manifest(&manifest_json, &store).await.unwrap();
+
+        assert_eq!(resolved["text"], "line 1\nline 2\n");
+    }
+}


### PR DESCRIPTION
## Summary

Implements Phase 6 foundation for notebook output handling (#230):

- **ContentRef enum** (untagged serde): `{"inline": "..."}` for <8KB, `{"blob": "hash", "size": N}` for larger
- **OutputManifest types**: display_data, execute_result, stream, error — mirrors Jupyter types but with ContentRef for data fields
- **create_manifest**: converts raw Jupyter output JSON to manifest, applying inlining threshold
- **store_manifest**: stores manifest in blob store with media type `application/x-jupyter-output+json`
- **resolve_manifest**: reconstructs full Jupyter output from manifest (fetches blobs as needed)

## Test plan

- [x] 16 unit tests covering:
  - ContentRef serialization/deserialization (untagged enum)
  - Inlining decisions (small data inlines, large data blobs)
  - Manifest construction for each output type
  - Round-trip tests: Jupyter output → manifest → resolve → same output
  - Stream text array normalization (Jupyter sends `["line 1\n", "line 2\n"]`)
  - Large data correctly stored in blob store