### PR TITLE
Phase 5: Wire notebook app to daemon Automerge sync

### DIFF
--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -182,6 +182,10 @@ async fn initialize_notebook_sync(
             "[notebook-sync] Joining existing room with {} cells",
             initial_cells.len()
         );
+        // Emit Automerge state to frontend to replace stale disk content
+        if let Err(e) = app.emit("notebook:updated", &initial_cells) {
+            warn!("[notebook-sync] Failed to emit initial cells: {}", e);
+        }
     }
 
     // Store the handle for commands to use

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -3649,7 +3649,8 @@ pub fn run(
                 };
 
                 // Start settings sync subscription (reconnects automatically)
-                run_settings_sync(app_for_sync).await;
+                // Spawn as separate task since it runs forever
+                tokio::spawn(run_settings_sync(app_for_sync));
 
                 // Initialize notebook sync if daemon is available
                 if daemon_available {


### PR DESCRIPTION
## Summary

Connects the Tauri notebook app to runtimed's notebook sync service, enabling real-time cross-window state synchronization via Automerge CRDTs.

**What syncs now:**
- Cell source edits
- Cell additions and deletions
- Output clearing (pre-execution)

**Not yet synced (follow-up work):**
- Output content (outputs only appear on executing window via iopub)
- Execution counts

**Key implementation choices:**
- **notebook_id derivation**: Canonical file path for saved notebooks, env_id UUID for unsaved
- **Split client pattern**: Separates handle (commands) from receiver (changes) to avoid blocking during network I/O
- **Graceful fallback**: Daemon unavailable = local-only mode (no crash)
- **Fire-and-forget sync errors**: Maintain UI responsiveness

## Changes

### Backend (`crates/notebook/src/lib.rs`)
- Add `SharedNotebookSync` type with Unix/Windows platform support
- `derive_notebook_id()`: Stable ID from canonical path or env_id
- `initialize_notebook_sync()`: Connect to daemon, populate doc if new room
- `cell_snapshot_to_nbformat()`: Convert Automerge state to local nbformat cells
- Spawn receiver loop for cross-window updates
- Rewire `update_cell_source`, `add_cell`, `delete_cell` to sync mutations
- Add `clear_outputs` call in `execute_cell`

### Backend (`crates/runtimed/src/notebook_sync_client.rs`)
- Split client into `NotebookSyncHandle` + `NotebookSyncReceiver`
- Channel-based command processing with `tokio::select!`
- Avoids holding locks during network I/O

### Frontend (`apps/notebook/src/hooks/useNotebook.ts`)
- `CellSnapshot` interface matching Rust struct
- `cellSnapshotToNotebookCell()` conversion with output JSON parsing
- `notebook:updated` listener with reconciliation logic

## Test plan

- [x] Build: `cargo build -p notebook`
- [x] Open same notebook in two windows
- [x] Edit source in window A → appears in window B
- [x] Add/delete cell in window A → reflected in window B
- [x] Execute cell → outputs clear in other windows (outputs themselves stay local)
- [x] Open second window → shows Automerge state (not stale disk)
- [x] Stop daemon → app continues working (local-only mode)
- [x] Save from either window → .ipynb has all changes

Closes #231