### PR TITLE
Phase 5b: Sync outputs and execution counts via Automerge

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -226,6 +226,11 @@ function AppContent() {
       }
 
       appendOutput(cellId, output);
+      // Sync output to Automerge for cross-window sync (only if not captured by widget)
+      invoke("sync_append_output", {
+        cellId,
+        outputJson: JSON.stringify(output),
+      }).catch(() => {}); // Fire-and-forget
     },
     [appendOutput, sendWidgetUpdate, widgetStore],
   );

--- a/apps/notebook/src/hooks/useKernel.ts
+++ b/apps/notebook/src/hooks/useKernel.ts
@@ -231,54 +231,49 @@ export function useKernel({
 
       if (msgType === "stream") {
         const content = msg.content as { name: string; text: string };
-        const output = {
-          output_type: "stream" as const,
-          name: content.name as "stdout" | "stderr",
-          text: content.text,
-        };
-        onOutput(cellId, output, { parentMsgId: msg.parent_header?.msg_id });
-        // Sync output to Automerge for cross-window sync
-        invoke("sync_append_output", {
+        onOutput(
           cellId,
-          outputJson: JSON.stringify(output),
-        }).catch(() => {}); // Fire-and-forget
+          {
+            output_type: "stream",
+            name: content.name as "stdout" | "stderr",
+            text: content.text,
+          },
+          { parentMsgId: msg.parent_header?.msg_id },
+        );
       } else if (msgType === "display_data") {
         const content = msg.content as {
           data: Record<string, unknown>;
           metadata: Record<string, unknown>;
           transient?: { display_id?: string };
         };
-        const output = {
-          output_type: "display_data" as const,
-          data: content.data,
-          metadata: content.metadata,
-          display_id: content.transient?.display_id,
-        };
-        onOutput(cellId, output, { parentMsgId: msg.parent_header?.msg_id });
-        // Sync output to Automerge for cross-window sync
-        invoke("sync_append_output", {
+        onOutput(
           cellId,
-          outputJson: JSON.stringify(output),
-        }).catch(() => {}); // Fire-and-forget
+          {
+            output_type: "display_data",
+            data: content.data,
+            metadata: content.metadata,
+            display_id: content.transient?.display_id,
+          },
+          { parentMsgId: msg.parent_header?.msg_id },
+        );
       } else if (msgType === "execute_result") {
         const content = msg.content as {
           data: Record<string, unknown>;
           metadata: Record<string, unknown>;
           execution_count: number;
         };
-        const output = {
-          output_type: "execute_result" as const,
-          data: content.data,
-          metadata: content.metadata,
-          execution_count: content.execution_count,
-        };
-        onOutput(cellId, output, { parentMsgId: msg.parent_header?.msg_id });
-        onExecutionCount(cellId, content.execution_count);
-        // Sync output and execution count to Automerge for cross-window sync
-        invoke("sync_append_output", {
+        onOutput(
           cellId,
-          outputJson: JSON.stringify(output),
-        }).catch(() => {}); // Fire-and-forget
+          {
+            output_type: "execute_result",
+            data: content.data,
+            metadata: content.metadata,
+            execution_count: content.execution_count,
+          },
+          { parentMsgId: msg.parent_header?.msg_id },
+        );
+        onExecutionCount(cellId, content.execution_count);
+        // Sync execution count to Automerge for cross-window sync
         invoke("sync_execution_count", {
           cellId,
           count: content.execution_count,
@@ -289,18 +284,16 @@ export function useKernel({
           evalue: string;
           traceback: string[];
         };
-        const output = {
-          output_type: "error" as const,
-          ename: content.ename,
-          evalue: content.evalue,
-          traceback: content.traceback,
-        };
-        onOutput(cellId, output, { parentMsgId: msg.parent_header?.msg_id });
-        // Sync error output to Automerge for cross-window sync
-        invoke("sync_append_output", {
+        onOutput(
           cellId,
-          outputJson: JSON.stringify(output),
-        }).catch(() => {}); // Fire-and-forget
+          {
+            output_type: "error",
+            ename: content.ename,
+            evalue: content.evalue,
+            traceback: content.traceback,
+          },
+          { parentMsgId: msg.parent_header?.msg_id },
+        );
       }
     });
 

--- a/crates/notebook/fixtures/audit-test/1-vanilla.ipynb
+++ b/crates/notebook/fixtures/audit-test/1-vanilla.ipynb
@@ -1,18 +1,31 @@
 {
-  "cells": [
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "cell-1",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "import sys\n",
-        "print(sys.executable)"
-      ]
-    }
-  ],
-  "metadata": {},
-  "nbformat": 4,
-  "nbformat_minor": 5
+ "metadata": {
+  "uv": {
+   "dependencies": []
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "cells": [
+  {
+   "cell_type": "code",
+   "id": "8b5de5f8-9d57-4008-9c3e-349dc0904a90",
+   "metadata": {},
+   "execution_count": null,
+   "source": [
+    "import sys\n",
+    "\n",
+    "print(sys.executable)  # edited!"
+   ],
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "id": "d8535959-759a-4c53-af14-bfcb0e4a3345",
+   "metadata": {},
+   "execution_count": null,
+   "source": [],
+   "outputs": []
+  }
+ ]
 }

--- a/e2e/specs/settings-panel.spec.js
+++ b/e2e/specs/settings-panel.spec.js
@@ -186,8 +186,40 @@ describe("Settings Panel", () => {
   });
 
   describe("Active button states", () => {
+    before(async () => {
+      // Ensure panel is open for button state tests (sibling describe blocks don't share before hooks)
+      const panelExists = await browser.execute(() => {
+        return !!document.querySelector('[data-testid="settings-panel"]');
+      });
+      if (!panelExists) {
+        const gearButton = await $('[aria-label="Settings"]');
+        await gearButton.click();
+        await browser.waitUntil(
+          async () => {
+            return await browser.execute(() => {
+              return !!document.querySelector('[data-testid="settings-panel"]');
+            });
+          },
+          { timeout: 3000, interval: 100 },
+        );
+      }
+    });
+
     it("should highlight the active theme button", async () => {
-      // After the previous test, "Light" should be the active theme.
+      // Click Light to ensure theme is set (don't rely on state from previous describe block)
+      await browser.execute(() => {
+        const group = document.querySelector(
+          '[data-testid="settings-theme-group"]',
+        );
+        const buttons = group?.querySelectorAll("button");
+        for (const btn of buttons || []) {
+          if (btn.textContent?.includes("Light")) {
+            btn.click();
+            break;
+          }
+        }
+      });
+
       // Wait for React re-render to propagate to button classes — on CI Linux
       // the HTML class update and button re-render can happen in separate frames.
       await browser.waitUntil(


### PR DESCRIPTION
## Summary

Wire the frontend iopub listener to sync each output and execution count to the daemon's Automerge doc, enabling cross-window output synchronization. Execute a cell in window A and outputs now appear in window B.

**Backend**: Added `sync_append_output` and `sync_execution_count` Tauri commands that forward to the daemon's existing sync client methods.

**Frontend**: After processing each iopub message type (stream, display_data, execute_result, error, execute_input), the frontend now calls the corresponding sync command. Updated reconciliation logic to properly merge synced outputs with local state.

## Verification

- [x] Open same notebook in two windows
- [x] Execute `print("hello")` in window A
- [x] Output and execution count `[1]` appear in window B
- [x] Execute `import time; [print(i) or time.sleep(0.5) for i in range(5)]` - incremental outputs sync
- [x] Execute `raise ValueError("test")` - error traceback syncs

There be some bugs but they'll get addressed shortly.

Closes #240

_PR submitted by @rgbkrk's agent, Quill_