### PR TITLE
Fix xtask and support CONDUCTOR_PORT for dev server

### DIFF
--- a/apps/notebook/package.json
+++ b/apps/notebook/package.json
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "type": "module",
   "scripts": {
-    "dev": "vite --port 5174",
+    "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview"
   },

--- a/apps/notebook/vite.config.ts
+++ b/apps/notebook/vite.config.ts
@@ -35,7 +35,7 @@ export default defineConfig({
     },
   },
   server: {
-    port: 5174,
+    port: parseInt(process.env.CONDUCTOR_PORT || "5174"),
     strictPort: true,
   },
   base: "/",

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -62,7 +62,20 @@ Other:
 
 fn cmd_dev() {
     println!("Starting dev server with hot reload...");
-    run_cmd("cargo", &["tauri", "dev", "--", "-p", "notebook"]);
+
+    // Check if CONDUCTOR_PORT is set and override devUrl accordingly
+    let config_override = env::var("CONDUCTOR_PORT").ok().map(|port| {
+        println!("Using CONDUCTOR_PORT={port}");
+        format!(r#"{{"build":{{"devUrl":"http://localhost:{port}"}}}}"#)
+    });
+
+    let mut args = vec!["tauri", "dev"];
+    if let Some(ref config) = config_override {
+        args.extend(["--config", config]);
+    }
+    args.extend(["--", "-p", "notebook"]);
+
+    run_cmd("cargo", &args);
 }
 
 fn cmd_build() {

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -18,7 +18,6 @@ fn main() {
             let notebook = args.get(1).map(String::as_str);
             cmd_run(notebook);
         }
-        "watch-isolated" => cmd_watch_isolated(),
         "icons" => {
             let source = args.get(1).map(String::as_str);
             cmd_icons(source);
@@ -46,7 +45,6 @@ Development:
   build                 Quick debug build (no DMG)
   build-e2e             Debug build with built-in WebDriver server
   run [notebook.ipynb]  Build and run debug app
-  watch-isolated        Watch and rebuild isolated renderer
 
 Release:
   build-app             Build .app bundle with icons
@@ -63,27 +61,8 @@ Other:
 }
 
 fn cmd_dev() {
-    // Build isolated renderer first (separate IIFE bundle, not part of Vite dev server)
-    println!("Building isolated renderer...");
-    run_cmd("pnpm", &["run", "isolated-renderer:build"]);
-
     println!("Starting dev server with hot reload...");
     run_cmd("cargo", &["tauri", "dev", "--", "-p", "notebook"]);
-}
-
-fn cmd_watch_isolated() {
-    println!("Watching isolated renderer for changes...");
-    println!("Reload app or open new notebook to see changes.");
-    run_cmd(
-        "pnpm",
-        &[
-            "vite",
-            "build",
-            "--watch",
-            "--config",
-            "src/isolated-renderer/vite.config.ts",
-        ],
-    );
 }
 
 fn cmd_build() {

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -49,8 +49,7 @@ RUN corepack enable && pnpm install --frozen-lockfile
 # Copy source code (this layer changes frequently — everything above is cached)
 COPY . .
 
-# Build frontend assets
-RUN pnpm run isolated-renderer:build
+# Build frontend assets (isolated-renderer built inline via Vite plugin)
 RUN pnpm --dir apps/notebook build
 
 # Generate icons (needed for bundling)


### PR DESCRIPTION
## Summary

- Remove obsolete `pnpm run isolated-renderer:build` from xtask and Dockerfile (the Vite plugin builds it inline now)
- Remove `watch-isolated` command that referenced a non-existent config file
- Add support for `CONDUCTOR_PORT` environment variable to set the Vite dev server port dynamically, enabling parallel development worktrees

## Changes

- **crates/xtask/src/main.rs**: Remove isolated-renderer build step from `cmd_dev()`, remove `watch-isolated` command entirely, add CONDUCTOR_PORT config override in `cmd_dev()`
- **apps/notebook/vite.config.ts**: Use `CONDUCTOR_PORT` env var (fallback to 5174) for dev server port
- **apps/notebook/package.json**: Remove hardcoded `--port 5174` from dev script (config handles it)
- **e2e/Dockerfile**: Remove obsolete `pnpm run isolated-renderer:build` step

## Test Plan

- [x] `cargo xtask dev` starts successfully with port from CONDUCTOR_PORT env var
- [x] All formatting checks pass (cargo fmt, biome)
- [x] All clippy lints pass
- [x] All Rust tests pass
- [x] All JS tests pass

_PR submitted by @rgbkrk's agent, Quill_