### PR TITLE
Add daemon log path to CLAUDE.md and show daemon version in debug banner

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,23 @@ cargo xtask install-daemon
 
 See `docs/runtimed.md` for service management and troubleshooting.
 
+### Daemon Logs
+
+The daemon logs to:
+```
+~/Library/Caches/runt/runtimed.log
+```
+
+To check daemon logs:
+```bash
+tail -100 ~/Library/Caches/runt/runtimed.log
+```
+
+To check which daemon version is running:
+```bash
+cat ~/Library/Caches/runt/daemon.json
+```
+
 ## Environment Management
 
 Runt supports multiple environment backends (UV, Conda) and project file formats (pyproject.toml, environment.yml, pixi.toml). See `contributing/environments.md` for the full architecture and `docs/environments.md` for the user-facing guide.

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -23,7 +23,7 @@ import { useDenoDependencies } from "./hooks/useDenoDependencies";
 import { useDependencies } from "./hooks/useDependencies";
 import { useEnvProgress } from "./hooks/useEnvProgress";
 import { useExecutionQueue } from "./hooks/useExecutionQueue";
-import { useGitInfo } from "./hooks/useGitInfo";
+import { useDaemonInfo, useGitInfo } from "./hooks/useGitInfo";
 import { type MimeBundle, useKernel } from "./hooks/useKernel";
 import { useNotebook } from "./hooks/useNotebook";
 import { usePrewarmStatus } from "./hooks/usePrewarmStatus";
@@ -50,6 +50,7 @@ async function sendMessage(message: unknown): Promise<void> {
 
 function AppContent() {
   const gitInfo = useGitInfo();
+  const daemonInfo = useDaemonInfo();
   const prewarmStatus = usePrewarmStatus();
 
   const {
@@ -529,6 +530,7 @@ function AppContent() {
           description={gitInfo.description}
           uvPoolStatus={prewarmStatus.uv}
           condaPoolStatus={prewarmStatus.conda}
+          daemonVersion={daemonInfo?.version}
         />
       )}
       <NotebookToolbar

--- a/apps/notebook/src/components/DebugBanner.tsx
+++ b/apps/notebook/src/components/DebugBanner.tsx
@@ -1,4 +1,4 @@
-import { GitBranch, Zap } from "lucide-react";
+import { GitBranch, Server, Zap } from "lucide-react";
 import type { PoolStatus } from "../hooks/usePrewarmStatus";
 
 interface DebugBannerProps {
@@ -7,6 +7,7 @@ interface DebugBannerProps {
   description?: string | null;
   uvPoolStatus?: PoolStatus | null;
   condaPoolStatus?: PoolStatus | null;
+  daemonVersion?: string | null;
 }
 
 export function DebugBanner({
@@ -15,6 +16,7 @@ export function DebugBanner({
   description,
   uvPoolStatus,
   condaPoolStatus,
+  daemonVersion,
 }: DebugBannerProps) {
   const hasPoolStatus = uvPoolStatus || condaPoolStatus;
 
@@ -58,6 +60,20 @@ export function DebugBanner({
                 )}
               </>
             )}
+          </span>
+        </>
+      )}
+      {daemonVersion && (
+        <>
+          <span className="text-violet-300">|</span>
+          <Server className="h-3 w-3 text-emerald-300" />
+          <span className="text-violet-100">
+            Daemon:{" "}
+            <span className="font-mono">
+              {daemonVersion.includes("+")
+                ? daemonVersion.split("+")[1]
+                : daemonVersion}
+            </span>
           </span>
         </>
       )}

--- a/apps/notebook/src/hooks/useGitInfo.ts
+++ b/apps/notebook/src/hooks/useGitInfo.ts
@@ -7,6 +7,10 @@ interface GitInfo {
   description: string | null;
 }
 
+interface DaemonInfo {
+  version: string;
+}
+
 export function useGitInfo() {
   const [gitInfo, setGitInfo] = useState<GitInfo | null>(null);
 
@@ -19,4 +23,18 @@ export function useGitInfo() {
   }, []);
 
   return gitInfo;
+}
+
+export function useDaemonInfo() {
+  const [daemonInfo, setDaemonInfo] = useState<DaemonInfo | null>(null);
+
+  useEffect(() => {
+    invoke<DaemonInfo | null>("get_daemon_info")
+      .then(setDaemonInfo)
+      .catch((e) => {
+        console.error("Failed to get daemon info:", e);
+      });
+  }, []);
+
+  return daemonInfo;
 }

--- a/e2e/specs/settings-panel.spec.js
+++ b/e2e/specs/settings-panel.spec.js
@@ -124,25 +124,24 @@ describe("Settings Panel", () => {
       });
       expect(darkButton).toBe(true);
 
-      // Wait for DOM class to update
+      // Wait for DOM class to update - check both conditions atomically to avoid race
       await browser.waitUntil(
         async () => {
           return await browser.execute(() => {
-            return document.documentElement.classList.contains("dark");
+            const html = document.documentElement;
+            return (
+              html.classList.contains("dark") &&
+              !html.classList.contains("light")
+            );
           });
         },
         {
           timeout: 2000,
           interval: 100,
-          timeoutMsg: "<html> did not get 'dark' class",
+          timeoutMsg:
+            "<html> did not get 'dark' class or still has 'light' class",
         },
       );
-
-      // Verify "light" is removed
-      const hasLight = await browser.execute(() => {
-        return document.documentElement.classList.contains("light");
-      });
-      expect(hasLight).toBe(false);
 
       console.log("Dark theme applied to <html>");
     });
@@ -163,23 +162,24 @@ describe("Settings Panel", () => {
       });
       expect(lightButton).toBe(true);
 
+      // Wait for DOM class to update - check both conditions atomically to avoid race
       await browser.waitUntil(
         async () => {
           return await browser.execute(() => {
-            return document.documentElement.classList.contains("light");
+            const html = document.documentElement;
+            return (
+              html.classList.contains("light") &&
+              !html.classList.contains("dark")
+            );
           });
         },
         {
           timeout: 2000,
           interval: 100,
-          timeoutMsg: "<html> did not get 'light' class",
+          timeoutMsg:
+            "<html> did not get 'light' class or still has 'dark' class",
         },
       );
-
-      const hasDark = await browser.execute(() => {
-        return document.documentElement.classList.contains("dark");
-      });
-      expect(hasDark).toBe(false);
 
       console.log("Light theme applied to <html>");
     });


### PR DESCRIPTION
## Summary

- Add "Daemon Logs" section to CLAUDE.md documenting the correct log path at `~/Library/Caches/runt/runtimed.log`
- Add `get_daemon_info` Tauri command that reads `daemon.json`
- Display daemon version/commit in debug banner with server icon
- Extract just the commit hash from version string (`0.1.0-dev.2+abc123` → `abc123`)

## Motivation

Agents consistently check `~/Library/Logs` before finding the actual daemon log location at `~/Library/Caches/runt/runtimed.log`. This wastes time on every session.

The debug banner now shows the daemon version, making it easy to verify which daemon is running without checking logs manually. This is especially helpful when testing daemon changes across worktrees.

## Test plan

- [x] Open notebook in dev mode
- [x] Verify debug banner shows "Daemon: <commit_hash>" with server icon
- [x] Check that CLAUDE.md has the new "Daemon Logs" section