### PR TITLE
Daemon-owned kernel execution with multi-window sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5349,7 +5349,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed"
-version = "0.1.0-dev.6"
+version = "0.1.0-dev.7"
 dependencies = [
  "anyhow",
  "automerge",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5349,7 +5349,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed"
-version = "0.1.0-dev.3"
+version = "0.1.0-dev.5"
 dependencies = [
  "anyhow",
  "automerge",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5349,7 +5349,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed"
-version = "0.1.0-dev.5"
+version = "0.1.0-dev.6"
 dependencies = [
  "anyhow",
  "automerge",

--- a/apps/notebook/src/hooks/useDaemonKernel.ts
+++ b/apps/notebook/src/hooks/useDaemonKernel.ts
@@ -258,7 +258,7 @@ export function useDaemonKernel({
     );
 
     // Listen for daemon disconnection (e.g., daemon restarted)
-    const unlistenDisconnect = listen("daemon:disconnected", () => {
+    const unlistenDisconnect = listen("daemon:disconnected", async () => {
       if (cancelled) return;
       console.warn(
         "[daemon-kernel] Daemon disconnected, resetting kernel state",
@@ -266,6 +266,15 @@ export function useDaemonKernel({
       setKernelStatus("not_started");
       setKernelInfo({});
       setQueueState({ executing: null, queued: [] });
+
+      // Attempt to reconnect to the daemon
+      console.log("[daemon-kernel] Attempting to reconnect to daemon...");
+      try {
+        await invoke("reconnect_to_daemon");
+        console.log("[daemon-kernel] Reconnected to daemon");
+      } catch (e) {
+        console.error("[daemon-kernel] Failed to reconnect:", e);
+      }
     });
 
     // Get initial kernel info from daemon

--- a/apps/notebook/src/types.ts
+++ b/apps/notebook/src/types.ts
@@ -188,5 +188,6 @@ export type DaemonNotebookResponse =
       status: string;
     }
   | { result: "queue_state"; executing?: string; queued: string[] }
+  | { result: "all_cells_queued"; count: number }
   | { result: "ok" }
   | { result: "error"; error: string };

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -1117,8 +1117,8 @@ async fn inspect_notebook(path: &PathBuf, full_outputs: bool, json_output: bool)
                         serde_json::json!({
                             "id": c.id,
                             "cell_type": c.cell_type,
-                            "source_preview": if c.source.len() > 80 {
-                                format!("{}...", &c.source[..80])
+                            "source_preview": if c.source.chars().count() > 80 {
+                                format!("{}...", c.source.chars().take(80).collect::<String>())
                             } else {
                                 c.source.clone()
                             },

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -186,6 +186,23 @@ enum Commands {
         #[arg(long, short)]
         runtime: Option<String>,
     },
+    /// Inspect the Automerge state for a notebook (debug command)
+    Inspect {
+        /// Path to the notebook file
+        path: PathBuf,
+        /// Show full output JSON (otherwise just shows count)
+        #[arg(long)]
+        full_outputs: bool,
+        /// Output in JSON format
+        #[arg(long)]
+        json: bool,
+    },
+    /// List active notebook rooms in the daemon (debug command)
+    Rooms {
+        /// Output in JSON format
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -335,6 +352,12 @@ async fn async_main(command: Option<Commands>) -> Result<()> {
             .await?
         }
         Some(Commands::Pool { command }) => pool_command(command).await?,
+        Some(Commands::Inspect {
+            path,
+            full_outputs,
+            json,
+        }) => inspect_notebook(&path, full_outputs, json).await?,
+        Some(Commands::Rooms { json }) => list_rooms(json).await?,
         None => println!("No command specified. Use --help for usage information."),
     }
 
@@ -1037,6 +1060,170 @@ async fn pool_command(command: PoolCommands) -> Result<()> {
                 std::process::exit(1);
             }
         },
+    }
+
+    Ok(())
+}
+
+// =============================================================================
+// Notebook inspection commands (debug tools)
+// =============================================================================
+
+async fn inspect_notebook(path: &PathBuf, full_outputs: bool, json_output: bool) -> Result<()> {
+    use runtimed::client::PoolClient;
+
+    // Convert to absolute path (notebook_id is the absolute path)
+    let notebook_id = if path.is_absolute() {
+        path.to_string_lossy().to_string()
+    } else {
+        std::env::current_dir()?
+            .join(path)
+            .to_string_lossy()
+            .to_string()
+    };
+
+    let client = PoolClient::default();
+
+    match client.inspect_notebook(&notebook_id).await {
+        Ok(result) => {
+            if json_output {
+                // Full JSON output
+                let output = serde_json::json!({
+                    "notebook_id": result.notebook_id,
+                    "source": result.source,
+                    "kernel_info": result.kernel_info,
+                    "cells": result.cells.iter().map(|c| {
+                        let outputs_info: Vec<serde_json::Value> = if full_outputs {
+                            c.outputs.iter().map(|o| {
+                                serde_json::from_str(o).unwrap_or(serde_json::Value::String(o.clone()))
+                            }).collect()
+                        } else {
+                            c.outputs.iter().map(|o| {
+                                // Parse and summarize
+                                if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(o) {
+                                    if let Some(otype) = parsed.get("output_type").and_then(|v| v.as_str()) {
+                                        serde_json::json!({
+                                            "output_type": otype,
+                                            "size": o.len(),
+                                        })
+                                    } else {
+                                        serde_json::json!({ "size": o.len() })
+                                    }
+                                } else {
+                                    serde_json::json!({ "size": o.len(), "parse_error": true })
+                                }
+                            }).collect()
+                        };
+                        serde_json::json!({
+                            "id": c.id,
+                            "cell_type": c.cell_type,
+                            "source_preview": if c.source.len() > 80 {
+                                format!("{}...", &c.source[..80])
+                            } else {
+                                c.source.clone()
+                            },
+                            "source_len": c.source.len(),
+                            "execution_count": c.execution_count,
+                            "outputs": outputs_info,
+                        })
+                    }).collect::<Vec<_>>(),
+                });
+                println!("{}", serde_json::to_string_pretty(&output)?);
+            } else {
+                // Human-readable output
+                println!("Notebook: {}", result.notebook_id);
+                println!("Source: {}", result.source);
+                if let Some(kernel) = &result.kernel_info {
+                    println!(
+                        "Kernel: {} ({}) - {}",
+                        kernel.kernel_type, kernel.env_source, kernel.status
+                    );
+                } else {
+                    println!("Kernel: none");
+                }
+                println!();
+                println!("Cells ({}):", result.cells.len());
+                println!("{}", "-".repeat(60));
+
+                for (i, cell) in result.cells.iter().enumerate() {
+                    let source_preview = if cell.source.len() > 60 {
+                        format!("{}...", cell.source.chars().take(60).collect::<String>())
+                    } else {
+                        cell.source.replace('\n', "\\n")
+                    };
+
+                    let exec_count = if cell.execution_count == "null" {
+                        "   ".to_string()
+                    } else {
+                        format!("[{}]", cell.execution_count)
+                    };
+
+                    println!(
+                        "{:2}. {} {:8} | {} | outputs: {}",
+                        i + 1,
+                        exec_count,
+                        cell.cell_type,
+                        source_preview,
+                        cell.outputs.len()
+                    );
+
+                    if full_outputs && !cell.outputs.is_empty() {
+                        for (j, output) in cell.outputs.iter().enumerate() {
+                            // Pretty print the JSON
+                            if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(output) {
+                                println!(
+                                    "      output[{}]: {}",
+                                    j,
+                                    serde_json::to_string_pretty(&parsed)?
+                                );
+                            } else {
+                                println!("      output[{}]: {}", j, output);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        Err(e) => {
+            eprintln!("Failed to inspect notebook: {}", e);
+            std::process::exit(1);
+        }
+    }
+
+    Ok(())
+}
+
+async fn list_rooms(json_output: bool) -> Result<()> {
+    use runtimed::client::PoolClient;
+
+    let client = PoolClient::default();
+
+    match client.list_rooms().await {
+        Ok(rooms) => {
+            if json_output {
+                println!("{}", serde_json::to_string_pretty(&rooms)?);
+            } else {
+                if rooms.is_empty() {
+                    println!("No active notebook rooms.");
+                } else {
+                    println!("Active Notebook Rooms ({}):", rooms.len());
+                    println!("{}", "-".repeat(60));
+                    for room in rooms {
+                        println!(
+                            "  {} ({} peer{}, kernel: {})",
+                            shorten_path(&PathBuf::from(&room.notebook_id)),
+                            room.active_peers,
+                            if room.active_peers == 1 { "" } else { "s" },
+                            if room.has_kernel { "yes" } else { "no" }
+                        );
+                    }
+                }
+            }
+        }
+        Err(e) => {
+            eprintln!("Failed to list rooms: {}", e);
+            std::process::exit(1);
+        }
     }
 
     Ok(())

--- a/crates/runtimed/Cargo.toml
+++ b/crates/runtimed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed"
-version = "0.1.0-dev.6"
+version = "0.1.0-dev.7"
 edition = "2021"
 description = "Central daemon for managing Jupyter runtimes and prewarmed environments"
 repository = "https://github.com/runtimed/runt"

--- a/crates/runtimed/Cargo.toml
+++ b/crates/runtimed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed"
-version = "0.1.0-dev.3"
+version = "0.1.0-dev.4"
 edition = "2021"
 description = "Central daemon for managing Jupyter runtimes and prewarmed environments"
 repository = "https://github.com/runtimed/runt"

--- a/crates/runtimed/Cargo.toml
+++ b/crates/runtimed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed"
-version = "0.1.0-dev.4"
+version = "0.1.0-dev.5"
 edition = "2021"
 description = "Central daemon for managing Jupyter runtimes and prewarmed environments"
 repository = "https://github.com/runtimed/runt"

--- a/crates/runtimed/Cargo.toml
+++ b/crates/runtimed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed"
-version = "0.1.0-dev.5"
+version = "0.1.0-dev.6"
 edition = "2021"
 description = "Central daemon for managing Jupyter runtimes and prewarmed environments"
 repository = "https://github.com/runtimed/runt"

--- a/crates/runtimed/src/protocol.rs
+++ b/crates/runtimed/src/protocol.rs
@@ -29,6 +29,15 @@ pub enum Request {
 
     /// Flush all pooled environments and rebuild with current settings.
     FlushPool,
+
+    /// Inspect the Automerge state for a notebook.
+    InspectNotebook {
+        /// The notebook ID (file path used as identifier).
+        notebook_id: String,
+    },
+
+    /// List all active notebook rooms.
+    ListRooms,
 }
 
 /// Responses from the daemon to clients.
@@ -58,6 +67,37 @@ pub enum Response {
 
     /// An error occurred.
     Error { message: String },
+
+    /// Notebook state inspection result.
+    NotebookState {
+        /// The notebook ID.
+        notebook_id: String,
+        /// Cell snapshots from the Automerge doc.
+        cells: Vec<crate::notebook_doc::CellSnapshot>,
+        /// Whether this was loaded from a live room or from disk.
+        source: String,
+        /// Kernel info if a kernel is running.
+        kernel_info: Option<NotebookKernelInfo>,
+    },
+
+    /// List of active notebook rooms.
+    RoomsList { rooms: Vec<RoomInfo> },
+}
+
+/// Kernel info for a notebook room.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NotebookKernelInfo {
+    pub kernel_type: String,
+    pub env_source: String,
+    pub status: String,
+}
+
+/// Info about an active notebook room.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RoomInfo {
+    pub notebook_id: String,
+    pub active_peers: usize,
+    pub has_kernel: bool,
 }
 
 /// Blob channel request.

--- a/crates/runtimed/src/protocol.rs
+++ b/crates/runtimed/src/protocol.rs
@@ -123,6 +123,10 @@ pub enum NotebookRequest {
 
     /// Get the execution queue state.
     GetQueueState {},
+
+    /// Run all code cells from the synced document.
+    /// Daemon reads cell sources from the Automerge doc and queues them.
+    RunAllCells {},
 }
 
 /// Responses from daemon to notebook app.
@@ -167,6 +171,11 @@ pub enum NotebookResponse {
     QueueState {
         executing: Option<String>, // cell_id currently executing
         queued: Vec<String>,       // cell_ids waiting
+    },
+
+    /// All cells queued for execution.
+    AllCellsQueued {
+        count: usize, // number of code cells queued
     },
 
     /// Generic success.


### PR DESCRIPTION
## Summary

Implements Phase 8: daemon-owned kernel execution with full multi-window support. The daemon now manages kernel lifecycle and execution queues, becoming the single source of truth for outputs and execution state. All connected windows share the same kernel and receive real-time broadcast updates.

**Key Features:**
- Multi-window kernel sharing: same notebook open in multiple windows uses one kernel
- Output broadcasting: all windows see outputs in real-time from daemon
- Atomic RunAllCells: daemon reads cell sources from Automerge doc (no code transmission)
- Stop-on-error: Run All halts queue on execution errors (standard Jupyter behavior)
- Daemon disconnection handling: auto-reconnects after daemon restart
- Debug tooling: `runt inspect` and `runt rooms` CLI commands for state inspection

## What Changed

**Frontend (`useDaemonKernel.ts`):**
- Added runAllCells() for atomic execution from synced doc
- Disconnect handler with auto-reconnect to daemon
- Improved queue state tracking and broadcast handling

**Frontend (`useNotebook.ts`):**
- Daemon mode preserves live outputs during Automerge sync (prevents phantom output overwrites)

**Frontend (`App.tsx`):**
- Wired restartAndRunAll to use daemon RunAllCells when enabled
- Integrated daemon kernel hooks with proper error handling

**Daemon (`notebook_sync_server.rs`):**
- Added RunAllCells handler: queues all code cells from synced doc
- Implemented stop-on-error: clears queue on CellError
- Added disconnect notification for window reconnection

**Daemon (`kernel_manager.rs`):**
- Made queue_cell idempotent: prevents duplicate queueing when multiple windows trigger RunAll

**Protocol additions:**
- Request::RunAllCells, NotebookResponse::AllCellsQueued
- Request::InspectNotebook, Request::ListRooms
- Response::NotebookState, Response::RoomsList

**CLI (`runt inspect`, `runt rooms`):**
- Debug commands for inspecting Automerge notebook state
- Shows cell metadata, outputs, execution counts from daemon or persisted files
- Helps diagnose sync issues

## Testing Checklist

- [x] Single window: execute cells, see outputs update in real-time
- [x] Multi-window: open same notebook in 2+ windows, execute in one, see outputs in all
- [x] Restart & Run All: kernel relaunches, all cells execute in order, stops on error
- [x] Daemon restart: after daemon crash/restart, windows auto-reconnect and can launch new kernel
- [x] Vanilla mode (daemon_execution: false): local kernel execution unaffected
- [x] `runt inspect <path>`: shows Automerge cell state for debugging
- [x] `runt rooms`: lists active rooms with peer and kernel status

_PR submitted by @rgbkrk's agent, Quill_