### PR TITLE
Fix cell-operations e2e test with fixture notebook

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -326,6 +326,11 @@ jobs:
             E2E_SPEC=e2e/specs/error-handling.spec.js \
             pnpm test:e2e || FAIL=1
 
+          start_driver
+          NOTEBOOK_PATH=crates/notebook/fixtures/audit-test/1-vanilla.ipynb \
+            E2E_SPEC=e2e/specs/cell-operations.spec.js \
+            pnpm test:e2e || FAIL=1
+
           # Cleanup
           kill $DRIVER_PID 2>/dev/null || true
           kill $RUNTIMED_PID 2>/dev/null || true

--- a/e2e/specs/cell-operations.spec.js
+++ b/e2e/specs/cell-operations.spec.js
@@ -7,6 +7,8 @@
  * - Delete cell (cannot delete last cell)
  * - Variables persist across cells
  * - Execution count increments
+ *
+ * Requires: NOTEBOOK_PATH=crates/notebook/fixtures/audit-test/1-vanilla.ipynb
  */
 
 import os from "node:os";
@@ -97,10 +99,7 @@ describe("Cell Operations", () => {
   }
 
   describe("Adding cells", () => {
-    // TODO: This test is flaky because it runs without a fixture notebook.
-    // When the app opens blank, auto-cell creation races with the initial count check.
-    // Fix: Add this spec to FIXTURE_SPECS with a dedicated fixture notebook.
-    it.skip("should add a new code cell", async () => {
+    it("should add a new code cell", async () => {
       const initialCount = await countCodeCells();
       console.log("Initial code cell count:", initialCount);
 

--- a/e2e/specs/cell-operations.spec.js
+++ b/e2e/specs/cell-operations.spec.js
@@ -100,6 +100,18 @@ describe("Cell Operations", () => {
 
   describe("Adding cells", () => {
     it("should add a new code cell", async () => {
+      // Wait for fixture cells to render (1-vanilla.ipynb has 2 code cells)
+      await browser.waitUntil(
+        async () => {
+          const count = await countCodeCells();
+          return count >= 1;
+        },
+        {
+          timeout: 10000,
+          timeoutMsg: "Expected at least 1 code cell to render from fixture",
+        },
+      );
+
       const initialCount = await countCodeCells();
       console.log("Initial code cell count:", initialCount);
 

--- a/e2e/specs/error-handling.spec.js
+++ b/e2e/specs/error-handling.spec.js
@@ -16,6 +16,18 @@ describe("Error Handling", () => {
   before(async () => {
     await waitForAppReady();
     console.log("Page title:", await browser.getTitle());
+
+    // Wait for all 5 error cells to render before running tests
+    await browser.waitUntil(
+      async () => {
+        const cells = await $$('[data-cell-type="code"]');
+        return cells.length >= 5;
+      },
+      {
+        timeout: 10000,
+        timeoutMsg: "Expected 5 code cells to render",
+      },
+    );
   });
 
   async function getCodeCells() {

--- a/e2e/wdio.conf.js
+++ b/e2e/wdio.conf.js
@@ -47,6 +47,7 @@ const FIXTURE_SPECS = [
   "save-dirty-state.spec.js",
   "rich-outputs.spec.js",
   "error-handling.spec.js",
+  "cell-operations.spec.js",
 ];
 
 export const config = {


### PR DESCRIPTION
## Summary

Fixes the flaky `cell-operations.spec.js` E2E test by integrating it into the fixture-based test suite. The test previously ran without a fixture notebook, causing a race condition when the app opened blank (auto-cell creation would race with the initial cell count check).

The test now uses the `1-vanilla.ipynb` fixture for deterministic initial state and is only run during fixture-specific CI invocations, eliminating the flakiness.

## Changes

- Register `cell-operations.spec.js` as a fixture spec (excluded from default test runs)
- Add CI workflow entry to run the spec with `1-vanilla.ipynb`
- Un-skip the "should add a new code cell" test now that it has stable starting conditions
- Add documentation explaining the fixture requirement

_PR submitted by @rgbkrk's agent, Quill_