### PR TITLE
Always show Run All, Restart, and Restart and Run All buttons

### DIFF
--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -388,7 +388,7 @@ export function NotebookToolbar({
           <div className="h-4 w-px bg-border" />
 
           {/* Kernel controls */}
-          {!isKernelRunning ? (
+          {!isKernelRunning && (
             <button
               type="button"
               onClick={handleStartKernel}
@@ -400,57 +400,56 @@ export function NotebookToolbar({
               <Play className="h-3 w-3" fill="currentColor" />
               Start Kernel
             </button>
-          ) : (
-            <>
-              <button
-                type="button"
-                onClick={onRunAllCells}
-                className="flex items-center gap-1 rounded px-2 py-1 text-xs text-foreground transition-colors hover:bg-muted"
-                title="Run all cells"
-                data-testid="run-all-button"
-              >
-                <ChevronsRight className="h-3.5 w-3.5" />
-                Run All
-              </button>
-              <button
-                type="button"
-                onClick={onRestartKernel}
-                className="flex items-center gap-1 rounded px-2 py-1 text-xs text-foreground transition-colors hover:bg-muted"
-                title="Restart kernel"
-                data-testid="restart-kernel-button"
-              >
-                <RotateCcw className="h-3 w-3" />
-                Restart
-              </button>
-              <button
-                type="button"
-                onClick={onRestartAndRunAll}
-                className="flex items-center gap-1 rounded px-2 py-1 text-xs text-foreground transition-colors hover:bg-muted"
-                title="Restart kernel and run all cells"
-                data-testid="restart-run-all-button"
-              >
-                <RotateCcw className="h-3 w-3" />
-                <ChevronsRight className="h-3 w-3 -ml-1" />
-              </button>
-              <button
-                type="button"
-                onClick={onInterruptKernel}
-                className={cn(
-                  "flex items-center gap-1 rounded px-2 py-1 text-xs transition-colors",
-                  kernelStatus === "busy"
-                    ? "text-destructive hover:bg-destructive/10"
-                    : "text-foreground hover:bg-muted",
-                )}
-                title="Interrupt kernel"
-                data-testid="interrupt-kernel-button"
-              >
-                <Square
-                  className="h-3 w-3"
-                  fill={kernelStatus === "busy" ? "currentColor" : "none"}
-                />
-                Interrupt
-              </button>
-            </>
+          )}
+          <button
+            type="button"
+            onClick={onRunAllCells}
+            className="flex items-center gap-1 rounded px-2 py-1 text-xs text-foreground transition-colors hover:bg-muted"
+            title="Run all cells"
+            data-testid="run-all-button"
+          >
+            <ChevronsRight className="h-3.5 w-3.5" />
+            Run All
+          </button>
+          <button
+            type="button"
+            onClick={onRestartKernel}
+            className="flex items-center gap-1 rounded px-2 py-1 text-xs text-foreground transition-colors hover:bg-muted"
+            title="Restart kernel"
+            data-testid="restart-kernel-button"
+          >
+            <RotateCcw className="h-3 w-3" />
+            Restart
+          </button>
+          <button
+            type="button"
+            onClick={onRestartAndRunAll}
+            className="flex items-center gap-1 rounded px-2 py-1 text-xs text-foreground transition-colors hover:bg-muted"
+            title="Restart kernel and run all cells"
+            data-testid="restart-run-all-button"
+          >
+            <RotateCcw className="h-3 w-3" />
+            <ChevronsRight className="h-3 w-3 -ml-1" />
+          </button>
+          {isKernelRunning && (
+            <button
+              type="button"
+              onClick={onInterruptKernel}
+              className={cn(
+                "flex items-center gap-1 rounded px-2 py-1 text-xs transition-colors",
+                kernelStatus === "busy"
+                  ? "text-destructive hover:bg-destructive/10"
+                  : "text-foreground hover:bg-muted",
+              )}
+              title="Interrupt kernel"
+              data-testid="interrupt-kernel-button"
+            >
+              <Square
+                className="h-3 w-3"
+                fill={kernelStatus === "busy" ? "currentColor" : "none"}
+              />
+              Interrupt
+            </button>
           )}
 
           <div className="flex-1" />


### PR DESCRIPTION
These buttons were previously hidden until a kernel was started, but their handlers already support auto-starting the kernel when invoked. This change makes them always visible in the toolbar for a more consistent UX.

## Changes

- "Run All", "Restart", and "Restart and Run All" buttons now always appear in the toolbar
- "Start Kernel" button still only shows when kernel is not running  
- "Interrupt" button still only shows when kernel is running (can only interrupt a running kernel)

## Verification

- Open a notebook without starting a kernel
- Verify that "Run All", "Restart", and "Restart and Run All" buttons are visible
- Click "Run All" to verify it auto-starts the kernel and runs all cells
- Click "Restart and Run All" to verify it restarts the kernel and runs all cells
- Verify "Interrupt" only appears when kernel is running
- Verify "Start Kernel" button only appears when kernel is not running

_PR submitted by @rgbkrk's agent, Quill_