### PR TITLE
Fix flaky e2e tests by waiting for cells to load

### DIFF
--- a/e2e/helpers.js
+++ b/e2e/helpers.js
@@ -32,6 +32,27 @@ export async function waitForAppReady() {
 }
 
 /**
+ * Wait for a specific number of code cells to be loaded.
+ * Use this in fixture tests where the notebook has pre-populated cells.
+ */
+export async function waitForCodeCells(expectedCount, timeout = 15000) {
+  await waitForAppReady();
+  await browser.waitUntil(
+    async () => {
+      return await browser.execute((count) => {
+        const cells = document.querySelectorAll('[data-cell-type="code"]');
+        return cells.length >= count;
+      }, expectedCount);
+    },
+    {
+      timeout,
+      interval: 300,
+      timeoutMsg: `Expected ${expectedCount} code cells but they did not load within ${timeout / 1000}s`,
+    },
+  );
+}
+
+/**
  * Wait for the kernel to reach idle or busy state.
  * Use this in specs that execute code — replaces both the 5000ms before()
  * pause AND the first kernel startup wait.

--- a/e2e/specs/rich-outputs.spec.js
+++ b/e2e/specs/rich-outputs.spec.js
@@ -11,11 +11,12 @@
  */
 
 import { browser, expect } from "@wdio/globals";
-import { waitForAppReady } from "../helpers.js";
+import { waitForCodeCells } from "../helpers.js";
 
 describe("Rich Output Types", () => {
   before(async () => {
-    await waitForAppReady();
+    // Wait for the 6 pre-populated code cells to load
+    await waitForCodeCells(6);
     console.log("Page title:", await browser.getTitle());
   });
 

--- a/e2e/specs/run-all-cells.spec.js
+++ b/e2e/specs/run-all-cells.spec.js
@@ -9,7 +9,7 @@
  */
 
 import { browser, expect } from "@wdio/globals";
-import { waitForAppReady } from "../helpers.js";
+import { waitForCodeCells } from "../helpers.js";
 
 /**
  * Wait for a specific cell (by index) to have stream output containing the expected text.
@@ -42,7 +42,8 @@ async function waitForCellStreamOutput(
 
 describe("Run All Cells", () => {
   before(async () => {
-    await waitForAppReady();
+    // Wait for the 3 pre-populated code cells to load
+    await waitForCodeCells(3);
     console.log("Page title:", await browser.getTitle());
   });
 


### PR DESCRIPTION
The `run-all-cells` and `rich-outputs` tests were failing in CI due to a race condition where the toolbar rendered before cells finished loading. Added `waitForCodeCells()` helper to fixture tests that wait for a specific number of code cells to be present before proceeding.

## Changes

- Added `waitForCodeCells(expectedCount, timeout)` helper in `e2e/helpers.js`
- Updated `run-all-cells.spec.js` to wait for 3 pre-populated cells
- Updated `rich-outputs.spec.js` to wait for 6 pre-populated cells

## Verification

- Check that the two previously failing fixture tests now consistently pass in CI

_PR submitted by @rgbkrk's agent, Quill_