### PR TITLE
Fix phantom and duplicate outputs in daemon mode

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -313,9 +313,12 @@ function AppContent() {
     shutdownKernel: daemonShutdownKernel,
     runAllCells: daemonRunAllCells,
   } = useDaemonKernel({
-    onOutput: (cellId, output) => {
-      appendOutput(cellId, output);
-    },
+    // Daemon execution: Automerge is the source of truth for outputs.
+    // The daemon writes outputs to Automerge, then broadcasts for immediate UI.
+    // We skip broadcast handling to avoid race conditions - Automerge sync
+    // arrives shortly after and provides the canonical state.
+    // This prevents duplicate outputs when Automerge sync and broadcast race.
+    onOutput: () => {},
     onExecutionCount: handleExecutionCount,
     onExecutionDone: handleExecutionDone,
     onUpdateDisplayData: updateOutputByDisplayId,


### PR DESCRIPTION
## Summary

Fixes two related output accumulation bugs in daemon execution mode:

1. **Phantom outputs from persistence**: When reopening notebooks, stale outputs from persisted Automerge docs were merged with new execution results. Fixed by using `NotebookRoom::new_fresh()` to start rooms fresh—`.ipynb` is now the canonical source of truth.

2. **Duplicate outputs from async race**: Daemon broadcasts outputs and also writes them to Automerge. Both paths reached the frontend asynchronously, causing duplicate appends. Fixed by disabling broadcast-based output handling in daemon mode—outputs now come solely via Automerge sync.

## Verification

- [x] Run `cargo test --verbose` (230 tests pass)
- [x] Run `cargo clippy --all-targets -- -D warnings`
- [x] Run `pnpm test:run` (279 tests pass)
- [x] Integration tests confirm fresh room creation behavior

## Changes

- `NotebookRoom::new_fresh()`: Creates rooms with empty Automerge docs, deletes stale persisted state
- `get_or_create_room()`: Uses `new_fresh` instead of `load_or_create` for new rooms
- Frontend daemon kernel handler: Disables broadcast output handling (empty `onOutput`)
- Test: Updated `test_notebook_room_eviction_and_persistence` to verify fresh state behavior

_PR submitted by @rgbkrk's agent, Quill_