### PR TITLE
Widget support in daemon execution mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5349,7 +5349,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed"
-version = "0.1.0-dev.9"
+version = "0.1.0-dev.10"
 dependencies = [
  "anyhow",
  "automerge",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5349,10 +5349,11 @@ dependencies = [
 
 [[package]]
 name = "runtimed"
-version = "0.1.0-dev.7"
+version = "0.1.0-dev.9"
 dependencies = [
  "anyhow",
  "automerge",
+ "bytes",
  "chrono",
  "clap",
  "dirs 5.0.1",

--- a/apps/notebook/src/types.ts
+++ b/apps/notebook/src/types.ts
@@ -172,6 +172,12 @@ export type DaemonBroadcast =
   | {
       event: "outputs_cleared";
       cell_id: string;
+    }
+  | {
+      event: "comm";
+      msg_type: string; // "comm_open" | "comm_msg" | "comm_close"
+      content: Record<string, unknown>;
+      buffers: number[][]; // Binary buffers as byte arrays
     };
 
 /** Response types from daemon notebook requests */

--- a/crates/runtimed/Cargo.toml
+++ b/crates/runtimed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed"
-version = "0.1.0-dev.9"
+version = "0.1.0-dev.10"
 edition = "2021"
 description = "Central daemon for managing Jupyter runtimes and prewarmed environments"
 repository = "https://github.com/runtimed/runt"

--- a/crates/runtimed/Cargo.toml
+++ b/crates/runtimed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed"
-version = "0.1.0-dev.7"
+version = "0.1.0-dev.9"
 edition = "2021"
 description = "Central daemon for managing Jupyter runtimes and prewarmed environments"
 repository = "https://github.com/runtimed/runt"
@@ -22,6 +22,7 @@ tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }
+bytes = { workspace = true }
 thiserror = { workspace = true }
 uuid = { workspace = true }
 futures = { workspace = true }

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -704,14 +704,10 @@ async fn handle_notebook_request(
             }
         }
 
-        NotebookRequest::SendComm {
-            msg_type,
-            content,
-            buffers,
-        } => {
+        NotebookRequest::SendComm { message } => {
             let mut kernel_guard = room.kernel.lock().await;
             if let Some(ref mut kernel) = *kernel_guard {
-                match kernel.send_comm_message(&msg_type, content, buffers).await {
+                match kernel.send_comm_message(message).await {
                     Ok(()) => NotebookResponse::Ok {},
                     Err(e) => NotebookResponse::Error {
                         error: format!("Failed to send comm message: {}", e),

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -703,6 +703,24 @@ async fn handle_notebook_request(
                 NotebookResponse::NoKernel {}
             }
         }
+
+        NotebookRequest::SendComm {
+            msg_type,
+            content,
+            buffers,
+        } => {
+            let mut kernel_guard = room.kernel.lock().await;
+            if let Some(ref mut kernel) = *kernel_guard {
+                match kernel.send_comm_message(&msg_type, content, buffers).await {
+                    Ok(()) => NotebookResponse::Ok {},
+                    Err(e) => NotebookResponse::Error {
+                        error: format!("Failed to send comm message: {}", e),
+                    },
+                }
+            } else {
+                NotebookResponse::NoKernel {}
+            }
+        }
     }
 }
 

--- a/crates/runtimed/src/protocol.rs
+++ b/crates/runtimed/src/protocol.rs
@@ -169,15 +169,11 @@ pub enum NotebookRequest {
     RunAllCells {},
 
     /// Send a comm message to the kernel (widget interactions).
-    /// Used for frontend→kernel comm_msg and comm_close messages.
+    /// Accepts the full Jupyter message envelope to preserve header/session.
     SendComm {
-        /// Message type: "comm_msg" or "comm_close"
-        msg_type: String,
-        /// Message content (comm_id, data, etc.)
-        content: serde_json::Value,
-        /// Binary buffers
-        #[serde(default)]
-        buffers: Vec<Vec<u8>>,
+        /// The full Jupyter message (header, content, buffers, etc.)
+        /// Preserves frontend session/msg_id for proper widget protocol.
+        message: serde_json::Value,
     },
 }
 

--- a/crates/runtimed/src/protocol.rs
+++ b/crates/runtimed/src/protocol.rs
@@ -167,6 +167,18 @@ pub enum NotebookRequest {
     /// Run all code cells from the synced document.
     /// Daemon reads cell sources from the Automerge doc and queues them.
     RunAllCells {},
+
+    /// Send a comm message to the kernel (widget interactions).
+    /// Used for frontend→kernel comm_msg and comm_close messages.
+    SendComm {
+        /// Message type: "comm_msg" or "comm_close"
+        msg_type: String,
+        /// Message content (comm_id, data, etc.)
+        content: serde_json::Value,
+        /// Binary buffers
+        #[serde(default)]
+        buffers: Vec<Vec<u8>>,
+    },
 }
 
 /// Responses from daemon to notebook app.
@@ -272,6 +284,18 @@ pub enum NotebookBroadcast {
 
     /// Outputs cleared for a cell.
     OutputsCleared { cell_id: String },
+
+    /// Comm message from kernel (ipywidgets protocol).
+    /// Broadcast to all connected peers so all windows can display widgets.
+    Comm {
+        /// Message type: "comm_open", "comm_msg", "comm_close"
+        msg_type: String,
+        /// Message content (comm_id, data, target_name, etc.)
+        content: serde_json::Value,
+        /// Binary buffers (base64-encoded when serialized to JSON)
+        #[serde(default)]
+        buffers: Vec<Vec<u8>>,
+    },
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Enable ipywidgets and other comm-based outputs to work when daemon execution is enabled. Implements bidirectional comm message routing through the daemon so widgets appear in all windows and stay synchronized.

## Changes

**Protocol & Daemon:**
- Add `NotebookBroadcast::Comm` variant for broadcasting comm_open/msg/close from kernel
- Add `NotebookRequest::SendComm` for frontend→kernel comm messages
- Extend daemon's iopub handler to detect and broadcast comm messages
- Add `send_comm_message()` method to RoomKernel to send messages back to kernel

**Frontend:**
- Extend `useDaemonKernel` hook with `onCommMessage` callback and `sendCommMessage` function
- Wire daemon comm sending in App.tsx using module-level sender pattern
- Automatically switches between daemon and local kernel message routes

**Design:**
- All windows receive all comm messages (broadcast with sync)
- Widget state stays synchronized across windows
- Aligns with Runt's multi-window architecture

_PR submitted by @rgbkrk's agent, Quill_