### PR TITLE
Unify runt CLI and runtimed daemon commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ The notebook app connects to a background daemon (`runtimed`) that manages prewa
 cargo xtask install-daemon
 
 # Or manually:
-./target/debug/runtimed stop && ./target/debug/runtimed uninstall && ./target/debug/runtimed install
+runt daemon stop && runt daemon uninstall && runt daemon install
 ```
 
 `cargo xtask dev` and `cargo xtask build` do **not** reinstall the daemon. If you're changing daemon code (settings, sync, environments), you must run `cargo xtask install-daemon` separately to test your changes.
@@ -66,16 +66,20 @@ See `docs/runtimed.md` for service management and troubleshooting.
 
 The daemon logs to:
 ```
-~/Library/Caches/runt/runtimed.log
+~/Library/Caches/runt/runtimed.log  (macOS)
+~/.cache/runt/runtimed.log          (Linux)
 ```
 
 To check daemon logs:
 ```bash
-tail -100 ~/Library/Caches/runt/runtimed.log
+runt daemon logs -n 100    # Last 100 lines
+runt daemon logs -f        # Follow/tail logs
 ```
 
 To check which daemon version is running:
 ```bash
+runt daemon status
+# or directly:
 cat ~/Library/Caches/runt/daemon.json
 ```
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5335,6 +5335,7 @@ dependencies = [
  "dirs 5.0.1",
  "futures",
  "jupyter-protocol",
+ "notify",
  "petname",
  "rpassword",
  "runtimed",

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -2,80 +2,74 @@
 
 This document provides context for continuing development on the `runtimed` daemon.
 
-## Current State
-
-**Branch:** `rgbkrk/pool-daemon-prototype`
-**PR:** #150 - "Fix crash when creating multiple notebooks rapidly (Cmd-N)"
-
-The daemon is fully functional and integrated with the notebook crate. All tests pass.
-
 ## What is runtimed?
 
-`runtimed` is a centralized daemon that manages prewarmed Python environments for Jupyter notebooks. It provides:
+`runtimed` is a background daemon that manages the stateful parts of the notebook experience:
 
-- **UV environments** - Fast Python venvs using uv
-- **Conda environments** - Full conda environments using rattler (no external mamba/conda needed)
-- **Instant notebook startup** - Notebooks get prewarmed environments immediately instead of waiting for creation
-- **Singleton pattern** - Only one daemon runs at a time via file locking
+- **Environment pools** - Prewarmed UV and Conda environments for instant notebook startup
+- **Notebook sync** - Real-time CRDT synchronization across multiple windows via Automerge
+- **Settings sync** - User preferences shared across all notebook windows
+- **Blob store** - Content-addressed storage for outputs with HTTP serving
+- **Kernel management** - Daemon-owned kernel execution (behind `daemon_execution` flag)
+
+The daemon runs as a system service (`io.runtimed` on macOS, `runtimed.service` on Linux) and communicates via Unix socket.
 
 ## Architecture
 
 ```
-┌─────────────────┐     Unix Socket (NDJSON)     ┌─────────────────┐
-│    Notebook     │ ───────────────────────────► │    runtimed     │
-│   (client)      │     GetEnv { env_type }      │    (daemon)     │
-│                 │ ◄─────────────────────────── │                 │
-│                 │     PooledEnv { ... }        │   UV Pool (3)   │
-│                 │                              │  Conda Pool (3) │
-└─────────────────┘                              └─────────────────┘
+┌──────────────────┐   ┌──────────────────┐   ┌──────────────────┐
+│  Notebook Win 1  │   │  Notebook Win 2  │   │  Notebook Win N  │
+│  (Tauri process) │   │  (Tauri process) │   │  (Tauri process) │
+└────────┬─────────┘   └────────┬─────────┘   └────────┬─────────┘
+         │                      │                      │
+         │     Unix Socket      │     Unix Socket      │
+         └──────────┬───────────┴───────────┬──────────┘
+                    │                       │
+                    ▼                       ▼
+              ┌─────────────────────────────────┐
+              │            runtimed             │
+              │      (singleton daemon)         │
+              │                                 │
+              │  ┌──────────┐  ┌──────────────┐ │
+              │  │ UV Pool  │  │  Conda Pool  │ │
+              │  │ (3 envs) │  │   (3 envs)   │ │
+              │  └──────────┘  └──────────────┘ │
+              │  ┌──────────────────────────┐   │
+              │  │ CRDT Sync (Automerge)    │   │
+              │  │ - Settings doc           │   │
+              │  │ - Notebook rooms         │   │
+              │  └──────────────────────────┘   │
+              │  ┌──────────────────────────┐   │
+              │  │ Blob Store + HTTP server │   │
+              │  └──────────────────────────┘   │
+              └─────────────────────────────────┘
 ```
 
 ## Key Files
 
 ### Daemon (crates/runtimed/)
-- `src/daemon.rs` - Core daemon: pool management, warming loops, socket server
-- `src/client.rs` - Client API: `try_get_pooled_env()` for notebooks
-- `src/singleton.rs` - File-based singleton locking
-- `src/pool.rs` - Pool state machine (Available/Warming counts)
-- `src/lib.rs` - Public exports: `EnvType`, `PooledEnv`, `PoolStatus`
+| File | Role |
+|------|------|
+| `daemon.rs` | Core daemon: pool management, warming loops, connection routing |
+| `client.rs` | Client API: `PoolClient` for pool operations |
+| `singleton.rs` | File-based singleton locking, DaemonInfo discovery |
+| `protocol.rs` | Request/Response enums, BlobRequest/BlobResponse |
+| `connection.rs` | Unified framing, handshake enum, send/recv helpers |
+| `settings_doc.rs` | Settings Automerge document, schema, migration |
+| `notebook_doc.rs` | Notebook Automerge document, cell CRUD, text editing |
+| `notebook_sync_server.rs` | Room-based notebook sync, peer management |
+| `blob_store.rs` | Content-addressed blob store with metadata sidecars |
+| `blob_server.rs` | HTTP read server for blobs |
+| `service.rs` | Platform-specific service installation |
 
-### Notebook Integration (crates/notebook/)
-- `src/env_pool.rs` - `take_uv_env()` and `take_conda_env()` helpers
-  - Try daemon first (fast, non-blocking)
-  - Fall back to in-process pool if daemon unavailable
-- `src/lib.rs` - Three locations call the take functions (~lines 1115, 1325, 1469)
+### CLI (crates/runt/)
+| File | Role |
+|------|------|
+| `main.rs` | Unified CLI: daemon management, kernel listing, notebook inspection |
 
 ### Documentation
 - `contributing/runtimed.md` - Developer guide
-- `docs/runtimed.md` - User-facing documentation
-
-## How It Works
-
-### Daemon Startup
-1. Acquires singleton lock (`~/.cache/runt/daemon.lock`)
-2. Scans cache dir for existing `runtimed-uv-*` and `runtimed-conda-*` directories
-3. Validates existing envs (checks python binary exists)
-4. Adds valid envs to pool immediately (instant 3/3 availability)
-5. Starts warming loops to replenish any missing envs
-
-### Environment Creation
-- **UV**: Uses `uv venv` + `uv pip install ipykernel ipywidgets`
-- **Conda**: Uses rattler (Rust-native conda) to create envs with python, ipykernel, ipywidgets
-
-### Notebook Takes Environment
-1. Notebook calls `take_uv_env()` or `take_conda_env()`
-2. Helper tries daemon first via Unix socket
-3. If daemon returns env, use it immediately
-4. If daemon unavailable/empty, fall back to in-process pool
-5. Daemon logs "Took conda env:" and starts replenishing
-
-## Environment Prefixes
-
-Important: The daemon uses different prefixes than the notebook's in-process pool:
-- Daemon: `runtimed-uv-*`, `runtimed-conda-*`
-- Notebook: `prewarm-*`
-
-This prevents collision - the notebook's cleanup won't delete daemon environments.
+- `docs/runtimed.md` - Full architecture documentation
 
 ## Running the Daemon
 
@@ -83,50 +77,56 @@ This prevents collision - the notebook's cleanup won't delete daemon environment
 # Development (with logging)
 RUST_LOG=info cargo run -p runtimed
 
-# Check status
-cargo run -p runtimed -- status
+# Check status via CLI
+runt daemon status
 
 # Stop daemon
-cargo run -p runtimed -- stop
+runt daemon stop
+
+# View logs
+runt daemon logs -f
 ```
 
 ## Running Tests
 
 ```bash
-# Stop daemon first (one test expects no daemon)
-cargo run -p runtimed -- stop
+# Stop daemon first (some tests expect no daemon)
+runt daemon stop
 
 # Run tests
 cargo test -p runtimed
 ```
 
-## Recent Changes (This Session)
+## CLI Commands
 
-1. **Rattler-based conda warming** - Uses rattler instead of CLI mamba/conda
-2. **Daemon-first environment fetching** - Notebook tries daemon before in-process pool
-3. **Environment reuse on startup** - Daemon finds and reuses existing runtimed-* directories
-4. **Prefix namespacing** - Changed from `prewarm-*` to `runtimed-*` to avoid collision
+The `runt` CLI is the unified interface for all daemon and kernel operations:
 
-## Known Working State
+```bash
+# Daemon management
+runt daemon status        # Service + pool + version info
+runt daemon start         # Start the daemon service
+runt daemon stop          # Stop the daemon service
+runt daemon restart       # Restart the daemon
+runt daemon logs -f       # Tail daemon logs
+runt daemon flush         # Flush pool and rebuild environments
+runt daemon install       # Install as system service
+runt daemon uninstall     # Uninstall system service
 
-Tested with daemon running and opening 3 notebooks:
-- All notebooks got conda environments from daemon
-- Daemon replenished pool back to 3/3
-- Warmup completed successfully for all replacement envs
-- UV pool stayed at 3/3 (notebooks used conda in this test)
+# Kernel and notebook inspection
+runt ps                   # List all kernels (connection-file + daemon-managed)
+runt notebooks            # List open notebooks with kernel/peer info
 
-## Potential Future Work
-
-- Automatic daemon startup (launchd/systemd service files)
-- Configurable package lists
-- Environment cleanup/garbage collection for old unused envs
-- Metrics/telemetry for environment usage patterns
-- Support for custom conda channels
+# Jupyter kernel utilities
+runt jupyter start <name> # Start a connection-file kernel
+runt jupyter stop --all   # Stop connection-file kernels
+runt jupyter console      # Interactive REPL
+```
 
 ## Log Location
 
 ```
-/Users/kylekelley/Library/Caches/runt/runtimed.log
+~/Library/Caches/runt/runtimed.log  (macOS)
+~/.cache/runt/runtimed.log          (Linux)
 ```
 
-Watch live: `tail -f /Users/kylekelley/Library/Caches/runt/runtimed.log`
+Watch live: `runt daemon logs -f`

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Runt
 
-CLI and desktop tools for [Jupyter runtimes](https://github.com/runtimed/runtimed), powered by [runtimelib](https://crates.io/crates/runtimelib) and [jupyter-protocol](https://crates.io/crates/jupyter-protocol).
+A fast, modern toolkit for Jupyter notebooks. Native desktop app with instant startup, real-time collaboration, and intelligent environment management.
+
+Built on [runtimelib](https://crates.io/crates/runtimelib) and [jupyter-protocol](https://crates.io/crates/jupyter-protocol).
 
 ## Install
 
@@ -18,34 +20,43 @@ pip install runtimed
 
 |  App  | Description |
 |-----------|-------------|
-| `runt` | CLI for managing and interacting with Jupyter kernels |
-| `sidecar` | Desktop viewer for Jupyter kernel outputs |
+| `runt` | CLI for managing kernels, notebooks, and the daemon |
+| `runtimed` | Background daemon managing environment pools, notebook sync, and kernel execution |
 | `notebook` | Desktop notebook editor (Tauri + React) |
+| `sidecar` | Desktop viewer for Jupyter kernel outputs |
 | `runtimed` (PyPI) | Python package bundling the `runt` binary |
 
 ## Usage
 
 ```bash
-# List running kernels
+# List all kernels (connection-file and daemon-managed)
 runt ps
 
-# Start a kernel
-runt start python3
+# Launch notebook editor
+runt notebook [path/to/notebook.ipynb]
 
 # Interactive console
 runt console
 
-# Launch sidecar output viewer
-runt sidecar <connection-file>
+# Daemon management
+runt daemon status     # Check daemon and pool status
+runt daemon start      # Start the daemon service
+runt daemon stop       # Stop the daemon service
+runt daemon logs -f    # Tail daemon logs
 
-# Launch notebook editor
-runt notebook
+# List open notebooks with kernel info
+runt notebooks
+
+# Jupyter kernel utilities
+runt jupyter start python3    # Start a connection-file kernel
+runt jupyter stop --all       # Stop all connection-file kernels
+runt jupyter sidecar <file>   # Launch sidecar output viewer
 ```
 
 ## Project structure
 
 ```
-sun-valley/
+runt/
 ├── src/                    # Shared UI code (React components, hooks, utilities)
 │   ├── components/
 │   │   ├── ui/            # shadcn primitives (button, dialog, etc.)
@@ -59,11 +70,13 @@ sun-valley/
 │   ├── notebook/          # Notebook Tauri frontend
 │   └── sidecar/           # Sidecar WebView frontend
 ├── crates/                 # Rust code
-│   ├── runt/              # Main CLI binary
+│   ├── runt/              # CLI binary
+│   ├── runtimed/          # Background daemon
 │   ├── notebook/          # Notebook Tauri app
 │   ├── sidecar/           # Sidecar wry/tao app
 │   └── tauri-jupyter/     # Shared Tauri/Jupyter utilities
-└── components.json         # shadcn config (run commands from repo root)
+├── docs/                   # Architecture documentation
+└── contributing/           # Developer guides
 ```
 
 ## Development

--- a/contributing/development.md
+++ b/contributing/development.md
@@ -91,19 +91,19 @@ cat ~/Library/Caches/runt/daemon.json
 
 ```bash
 # View recent logs
-tail -100 ~/Library/Caches/runt/runtimed.log
+runt daemon logs -n 100
 
 # Watch logs in real-time
-tail -f ~/Library/Caches/runt/runtimed.log
+runt daemon logs -f
 
-# Filter for specific topics
-tail -f ~/Library/Caches/runt/runtimed.log | grep -i "kernel\|auto-detect"
+# Filter for specific topics (can combine with grep)
+runt daemon logs -f | grep -i "kernel\|auto-detect"
 ```
 
 ### Common gotcha
 
 If your daemon code changes aren't taking effect:
 1. Did you run `cargo xtask install-daemon`? (`cargo xtask build` doesn't reinstall the daemon)
-2. Is the daemon running the right version? Check `cat ~/Library/Caches/runt/daemon.json`
+2. Is the daemon running the right version? Check `runt daemon status`
 
 See [contributing/runtimed.md](./runtimed.md) for full daemon development docs.

--- a/crates/runt/Cargo.toml
+++ b/crates/runt/Cargo.toml
@@ -31,3 +31,4 @@ dirs = "5"
 tabled = "0.15"
 futures = "0.3"
 chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
+notify = "8"

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -564,9 +564,9 @@ async fn list_kernels(json_output: bool, verbose: bool) -> Result<()> {
             connection_files.push(path);
         }
 
-        let kernel_futures = connection_files.into_iter().map(|path| {
-            async move { gather_kernel_info(path, timeout).await }
-        });
+        let kernel_futures = connection_files
+            .into_iter()
+            .map(|path| async move { gather_kernel_info(path, timeout).await });
 
         connection_file_kernels = join_all(kernel_futures)
             .await

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -43,31 +43,46 @@ struct KernelInfo {
     connection_info: ConnectionInfo,
 }
 
+/// Unified kernel entry (from connection file OR daemon)
+#[derive(Serialize, Clone)]
+struct UnifiedKernelInfo {
+    name: String,
+    language: Option<String>,
+    status: String,
+    source: String, // "jupyter" or "runtimed"
+    notebook: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    connection_file: Option<PathBuf>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    env_source: Option<String>,
+}
+
 #[derive(Tabled)]
 struct KernelTableRow {
     #[tabled(rename = "NAME")]
     name: String,
     #[tabled(rename = "LANGUAGE")]
     language: String,
-    #[tabled(rename = "VERSION")]
-    version: String,
     #[tabled(rename = "STATUS")]
     status: String,
-    #[tabled(rename = "CONNECTION FILE")]
-    connection_file: String,
+    #[tabled(rename = "SOURCE")]
+    source: String,
+    #[tabled(rename = "NOTEBOOK")]
+    notebook: String,
 }
 
-impl From<&KernelInfo> for KernelTableRow {
-    fn from(info: &KernelInfo) -> Self {
+impl From<&UnifiedKernelInfo> for KernelTableRow {
+    fn from(info: &UnifiedKernelInfo) -> Self {
         KernelTableRow {
             name: info.name.clone(),
             language: info.language.clone().unwrap_or_else(|| "-".to_string()),
-            version: info
-                .language_version
-                .clone()
+            status: info.status.clone(),
+            source: info.source.clone(),
+            notebook: info
+                .notebook
+                .as_ref()
+                .map(|p| shorten_path(&PathBuf::from(p)))
                 .unwrap_or_else(|| "-".to_string()),
-            status: info.status.to_string(),
-            connection_file: shorten_path(&info.connection_file),
         }
     }
 }
@@ -91,7 +106,7 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    /// List currently running kernels
+    /// List all running kernels (connection-file and daemon-managed)
     Ps {
         /// Output in JSON format
         #[arg(long)]
@@ -100,6 +115,123 @@ enum Commands {
         #[arg(short, long)]
         verbose: bool,
     },
+    /// Open the notebook application
+    Notebook {
+        /// Path to notebook file or directory to open
+        path: Option<PathBuf>,
+        /// Runtime for new notebooks (python, deno)
+        #[arg(long, short)]
+        runtime: Option<String>,
+    },
+    /// Jupyter kernel utilities
+    Jupyter {
+        #[command(subcommand)]
+        command: JupyterCommands,
+    },
+    /// Daemon management (service, pool, logs)
+    Daemon {
+        #[command(subcommand)]
+        command: DaemonCommands,
+    },
+    /// List open notebooks with kernel and peer info
+    Notebooks {
+        /// Output in JSON format
+        #[arg(long)]
+        json: bool,
+    },
+    /// Inspect the Automerge state for a notebook (debug command)
+    #[command(hide = true)]
+    Inspect {
+        /// Path to the notebook file
+        path: PathBuf,
+        /// Show full output JSON (otherwise just shows count)
+        #[arg(long)]
+        full_outputs: bool,
+        /// Output in JSON format
+        #[arg(long)]
+        json: bool,
+    },
+    /// Debug message passing between sidecar and kernel
+    #[command(hide = true)]
+    Debug {
+        /// The kernel to launch (e.g., python3, julia)
+        kernel: Option<String>,
+        /// Custom command to launch the kernel (use {connection_file} as placeholder)
+        #[arg(long)]
+        cmd: Option<String>,
+        /// Code to execute after kernel starts
+        #[arg(long)]
+        exec: Option<String>,
+        /// Path to dump all messages (defaults to temp file)
+        #[arg(long)]
+        dump: Option<PathBuf>,
+        /// Keep running after execution for manual interaction (Ctrl+C to exit)
+        #[arg(long, short)]
+        wait: bool,
+    },
+
+    // =========================================================================
+    // Hidden aliases for backwards compatibility (deprecated)
+    // =========================================================================
+    /// [DEPRECATED] Use 'runt jupyter start' instead
+    #[command(hide = true)]
+    Start { name: String },
+    /// [DEPRECATED] Use 'runt jupyter stop' instead
+    #[command(hide = true)]
+    Stop {
+        id: Option<String>,
+        #[arg(long)]
+        all: bool,
+    },
+    /// [DEPRECATED] Use 'runt jupyter interrupt' instead
+    #[command(hide = true)]
+    Interrupt { id: String },
+    /// [DEPRECATED] Use 'runt jupyter exec' instead
+    #[command(hide = true)]
+    Exec { id: String, code: Option<String> },
+    /// [DEPRECATED] Use 'runt jupyter sidecar' instead
+    #[command(hide = true)]
+    Sidecar {
+        file: PathBuf,
+        #[arg(short, long)]
+        quiet: bool,
+        #[arg(long)]
+        dump: Option<PathBuf>,
+    },
+    /// [DEPRECATED] Use 'runt jupyter console' instead
+    #[command(hide = true)]
+    Console {
+        kernel: Option<String>,
+        #[arg(long)]
+        cmd: Option<String>,
+        #[arg(short, long)]
+        verbose: bool,
+    },
+    /// [DEPRECATED] Use 'runt jupyter clean' instead
+    #[command(hide = true)]
+    Clean {
+        #[arg(long, default_value = "2")]
+        timeout: u64,
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// [DEPRECATED] Use 'runt daemon' instead
+    #[command(hide = true)]
+    Pool {
+        #[command(subcommand)]
+        command: PoolCommands,
+    },
+    /// [DEPRECATED] Use 'runt notebooks' instead
+    #[command(hide = true)]
+    Rooms {
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+/// Jupyter kernel management commands
+#[derive(Subcommand)]
+enum JupyterCommands {
     /// Start a kernel given a name
     Start {
         /// The name of the kernel to launch (e.g., python3, julia)
@@ -125,17 +257,6 @@ enum Commands {
         /// The code to execute (reads from stdin if not provided)
         code: Option<String>,
     },
-    /// Launch the sidecar viewer for a kernel
-    Sidecar {
-        /// Path to a kernel connection file
-        file: PathBuf,
-        /// Suppress output
-        #[arg(short, long)]
-        quiet: bool,
-        /// Dump all messages to a JSON file
-        #[arg(long)]
-        dump: Option<PathBuf>,
-    },
     /// Launch a kernel and open an interactive console
     Console {
         /// The kernel to launch (e.g., python3, julia)
@@ -156,55 +277,60 @@ enum Commands {
         #[arg(long)]
         dry_run: bool,
     },
-    /// Debug message passing between sidecar and kernel
-    Debug {
-        /// The kernel to launch (e.g., python3, julia)
-        kernel: Option<String>,
-        /// Custom command to launch the kernel (use {connection_file} as placeholder)
-        #[arg(long)]
-        cmd: Option<String>,
-        /// Code to execute after kernel starts
-        #[arg(long)]
-        exec: Option<String>,
-        /// Path to dump all messages (defaults to temp file)
+    /// Launch the sidecar viewer for a kernel
+    Sidecar {
+        /// Path to a kernel connection file
+        file: PathBuf,
+        /// Suppress output
+        #[arg(short, long)]
+        quiet: bool,
+        /// Dump all messages to a JSON file
         #[arg(long)]
         dump: Option<PathBuf>,
-        /// Keep running after execution for manual interaction (Ctrl+C to exit)
-        #[arg(long, short)]
-        wait: bool,
-    },
-    /// Interact with the pool daemon (prewarmed Python environments)
-    Pool {
-        #[command(subcommand)]
-        command: PoolCommands,
-    },
-    /// Open the notebook application
-    Notebook {
-        /// Path to notebook file or directory to open
-        path: Option<PathBuf>,
-        /// Runtime for new notebooks (python, deno)
-        #[arg(long, short)]
-        runtime: Option<String>,
-    },
-    /// Inspect the Automerge state for a notebook (debug command)
-    Inspect {
-        /// Path to the notebook file
-        path: PathBuf,
-        /// Show full output JSON (otherwise just shows count)
-        #[arg(long)]
-        full_outputs: bool,
-        /// Output in JSON format
-        #[arg(long)]
-        json: bool,
-    },
-    /// List active notebook rooms in the daemon (debug command)
-    Rooms {
-        /// Output in JSON format
-        #[arg(long)]
-        json: bool,
     },
 }
 
+/// Daemon management commands (replaces Pool + runtimed service commands)
+#[derive(Subcommand)]
+enum DaemonCommands {
+    /// Show daemon status (service, pool, version, uptime)
+    Status {
+        /// Output in JSON format
+        #[arg(long)]
+        json: bool,
+    },
+    /// Start the daemon service
+    Start,
+    /// Stop the daemon service
+    Stop,
+    /// Restart the daemon service (stop + start)
+    Restart,
+    /// Install daemon as a system service
+    Install {
+        /// Path to the daemon binary to install
+        #[arg(long)]
+        binary: Option<PathBuf>,
+    },
+    /// Uninstall daemon system service
+    Uninstall,
+    /// Tail daemon log file
+    Logs {
+        /// Follow the log (like tail -f)
+        #[arg(short, long)]
+        follow: bool,
+        /// Number of lines to show
+        #[arg(short = 'n', long, default_value = "50")]
+        lines: usize,
+    },
+    /// Flush all pooled environments and rebuild
+    Flush,
+    /// Request daemon shutdown (stops the daemon process)
+    Shutdown,
+    /// Check if the daemon is running (returns exit code)
+    Ping,
+}
+
+/// [DEPRECATED] Pool commands - use 'runt daemon' instead
 #[derive(Subcommand)]
 enum PoolCommands {
     /// Check if the pool daemon is running
@@ -237,16 +363,19 @@ fn main() -> Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
+        // Sidecar runs a tao event loop on the main thread (no tokio needed)
+        Some(Commands::Jupyter {
+            command: JupyterCommands::Sidecar { file, quiet, dump },
+        }) => sidecar::launch(&file, quiet, dump.as_deref()),
+        // Deprecated alias
         Some(Commands::Sidecar { file, quiet, dump }) => {
-            // Sidecar runs a tao event loop on the main thread (no tokio needed)
+            eprintln!("Warning: 'runt sidecar' is deprecated. Use 'runt jupyter sidecar' instead.");
             sidecar::launch(&file, quiet, dump.as_deref())
         }
-        Some(Commands::Notebook { path, runtime }) => {
-            // Notebook launches the desktop app (no tokio needed)
-            open_notebook(path, runtime)
-        }
+        // Notebook launches the desktop app (no tokio needed)
+        Some(Commands::Notebook { path, runtime }) => open_notebook(path, runtime),
+        // All other subcommands use tokio
         other => {
-            // All other subcommands use tokio
             let rt = tokio::runtime::Runtime::new()?;
             rt.block_on(async_main(other))
         }
@@ -322,19 +451,17 @@ fn open_notebook(path: Option<PathBuf>, runtime: Option<String>) -> Result<()> {
 
 async fn async_main(command: Option<Commands>) -> Result<()> {
     match command {
+        // Primary commands
         Some(Commands::Ps { json, verbose }) => list_kernels(json, verbose).await?,
-        Some(Commands::Start { name }) => start_kernel(&name).await?,
-        Some(Commands::Stop { id, all }) => stop_kernels(id.as_deref(), all).await?,
-        Some(Commands::Interrupt { id }) => interrupt_kernel(&id).await?,
-        Some(Commands::Exec { id, code }) => execute_code(&id, code.as_deref()).await?,
-        Some(Commands::Console {
-            kernel,
-            cmd,
-            verbose,
-        }) => console(kernel.as_deref(), cmd.as_deref(), verbose).await?,
-        Some(Commands::Sidecar { .. }) => unreachable!(),
-        Some(Commands::Notebook { .. }) => unreachable!(),
-        Some(Commands::Clean { timeout, dry_run }) => clean_kernels(timeout, dry_run).await?,
+        Some(Commands::Notebook { .. }) => unreachable!(), // handled in main()
+        Some(Commands::Jupyter { command }) => jupyter_command(command).await?,
+        Some(Commands::Daemon { command }) => daemon_command(command).await?,
+        Some(Commands::Notebooks { json }) => list_notebooks(json).await?,
+        Some(Commands::Inspect {
+            path,
+            full_outputs,
+            json,
+        }) => inspect_notebook(&path, full_outputs, json).await?,
         Some(Commands::Debug {
             kernel,
             cmd,
@@ -351,62 +478,197 @@ async fn async_main(command: Option<Commands>) -> Result<()> {
             )
             .await?
         }
-        Some(Commands::Pool { command }) => pool_command(command).await?,
-        Some(Commands::Inspect {
-            path,
-            full_outputs,
-            json,
-        }) => inspect_notebook(&path, full_outputs, json).await?,
-        Some(Commands::Rooms { json }) => list_rooms(json).await?,
+
+        // Deprecated aliases (with warnings)
+        Some(Commands::Start { name }) => {
+            eprintln!("Warning: 'runt start' is deprecated. Use 'runt jupyter start' instead.");
+            start_kernel(&name).await?
+        }
+        Some(Commands::Stop { id, all }) => {
+            eprintln!("Warning: 'runt stop' is deprecated. Use 'runt jupyter stop' instead.");
+            stop_kernels(id.as_deref(), all).await?
+        }
+        Some(Commands::Interrupt { id }) => {
+            eprintln!(
+                "Warning: 'runt interrupt' is deprecated. Use 'runt jupyter interrupt' instead."
+            );
+            interrupt_kernel(&id).await?
+        }
+        Some(Commands::Exec { id, code }) => {
+            eprintln!("Warning: 'runt exec' is deprecated. Use 'runt jupyter exec' instead.");
+            execute_code(&id, code.as_deref()).await?
+        }
+        Some(Commands::Console {
+            kernel,
+            cmd,
+            verbose,
+        }) => {
+            eprintln!("Warning: 'runt console' is deprecated. Use 'runt jupyter console' instead.");
+            console(kernel.as_deref(), cmd.as_deref(), verbose).await?
+        }
+        Some(Commands::Sidecar { .. }) => unreachable!(), // handled in main()
+        Some(Commands::Clean { timeout, dry_run }) => {
+            eprintln!("Warning: 'runt clean' is deprecated. Use 'runt jupyter clean' instead.");
+            clean_kernels(timeout, dry_run).await?
+        }
+        Some(Commands::Pool { command }) => {
+            eprintln!("Warning: 'runt pool' is deprecated. Use 'runt daemon' instead.");
+            pool_command(command).await?
+        }
+        Some(Commands::Rooms { json }) => {
+            eprintln!("Warning: 'runt rooms' is deprecated. Use 'runt notebooks' instead.");
+            list_notebooks(json).await?
+        }
+
         None => println!("No command specified. Use --help for usage information."),
     }
 
     Ok(())
 }
 
+async fn jupyter_command(command: JupyterCommands) -> Result<()> {
+    match command {
+        JupyterCommands::Start { name } => start_kernel(&name).await,
+        JupyterCommands::Stop { id, all } => stop_kernels(id.as_deref(), all).await,
+        JupyterCommands::Interrupt { id } => interrupt_kernel(&id).await,
+        JupyterCommands::Exec { id, code } => execute_code(&id, code.as_deref()).await,
+        JupyterCommands::Console {
+            kernel,
+            cmd,
+            verbose,
+        } => console(kernel.as_deref(), cmd.as_deref(), verbose).await,
+        JupyterCommands::Clean { timeout, dry_run } => clean_kernels(timeout, dry_run).await,
+        JupyterCommands::Sidecar { .. } => unreachable!(), // handled in main()
+    }
+}
+
 async fn list_kernels(json_output: bool, verbose: bool) -> Result<()> {
+    use runtimed::client::PoolClient;
+
     let runtime_dir = runtime_dir();
-    let mut entries = fs::read_dir(&runtime_dir).await?;
     let timeout = Duration::from_secs(2);
 
-    // Collect all connection file paths first
-    let mut connection_files: Vec<PathBuf> = Vec::new();
-    while let Some(entry) = entries.next_entry().await? {
-        let path = entry.path();
-        if path.extension().and_then(|s| s.to_str()) != Some("json") {
-            continue;
+    // 1. Gather connection-file kernels (standalone Jupyter kernels)
+    let mut connection_file_kernels = Vec::new();
+    if let Ok(mut entries) = fs::read_dir(&runtime_dir).await {
+        let mut connection_files: Vec<PathBuf> = Vec::new();
+        while let Some(entry) = entries.next_entry().await.ok().flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|s| s.to_str()) != Some("json") {
+                continue;
+            }
+            let file_name = path.file_name().and_then(|s| s.to_str()).unwrap_or("");
+            if !file_name.starts_with("runt-kernel-") {
+                continue;
+            }
+            connection_files.push(path);
         }
-        let file_name = path.file_name().and_then(|s| s.to_str()).unwrap_or("");
-        if !file_name.starts_with("runt-kernel-") {
-            continue;
-        }
-        connection_files.push(path);
+
+        let kernel_futures = connection_files.into_iter().map(|path| {
+            let timeout = timeout;
+            async move { gather_kernel_info(path, timeout).await }
+        });
+
+        connection_file_kernels = join_all(kernel_futures)
+            .await
+            .into_iter()
+            .flatten()
+            .collect();
     }
 
-    // Query all kernels in parallel
-    let kernel_futures = connection_files.into_iter().map(|path| {
-        let timeout = timeout;
-        async move { gather_kernel_info(path, timeout).await }
-    });
+    // 2. Gather daemon-managed kernels
+    let mut daemon_kernels: Vec<UnifiedKernelInfo> = Vec::new();
+    let client = PoolClient::default();
+    if let Ok(rooms) = client.list_rooms().await {
+        for room in rooms {
+            if room.has_kernel {
+                daemon_kernels.push(UnifiedKernelInfo {
+                    name: room
+                        .kernel_type
+                        .clone()
+                        .unwrap_or_else(|| "unknown".to_string()),
+                    language: room.kernel_type.clone(),
+                    status: room.kernel_status.unwrap_or_else(|| "unknown".to_string()),
+                    source: "runtimed".to_string(),
+                    notebook: Some(room.notebook_id.clone()),
+                    connection_file: None,
+                    env_source: room.env_source,
+                });
+            }
+        }
+    }
 
-    let mut kernels: Vec<KernelInfo> = join_all(kernel_futures)
-        .await
-        .into_iter()
-        .flatten()
+    // 3. Convert connection-file kernels to unified format
+    let mut unified_kernels: Vec<UnifiedKernelInfo> = connection_file_kernels
+        .iter()
+        .map(|k| UnifiedKernelInfo {
+            name: k.name.clone(),
+            language: k.language.clone(),
+            status: k.status.to_string(),
+            source: "jupyter".to_string(),
+            notebook: None,
+            connection_file: Some(k.connection_file.clone()),
+            env_source: None,
+        })
         .collect();
 
-    // Sort kernels by name for consistent display
-    kernels.sort_by(|a, b| a.name.cmp(&b.name));
+    // 4. Add daemon kernels (they take precedence for display)
+    unified_kernels.extend(daemon_kernels);
+
+    // Sort by source (runtimed first), then by name
+    unified_kernels.sort_by(|a, b| {
+        // runtimed comes before jupyter
+        let source_cmp = b.source.cmp(&a.source); // reverse to put runtimed first
+        if source_cmp != std::cmp::Ordering::Equal {
+            source_cmp
+        } else {
+            a.name.cmp(&b.name)
+        }
+    });
 
     if json_output {
-        println!("{}", serde_json::to_string_pretty(&kernels)?);
+        println!("{}", serde_json::to_string_pretty(&unified_kernels)?);
     } else if verbose {
-        print_verbose_kernel_table(&kernels);
+        // Verbose mode shows connection-file kernels with full details
+        if !connection_file_kernels.is_empty() {
+            println!("Connection-file kernels:");
+            print_verbose_kernel_table(&connection_file_kernels);
+        }
+        // Also show daemon-managed kernels
+        let daemon_rows: Vec<KernelTableRow> = unified_kernels
+            .iter()
+            .filter(|k| k.source == "runtimed")
+            .map(KernelTableRow::from)
+            .collect();
+        if !daemon_rows.is_empty() {
+            if !connection_file_kernels.is_empty() {
+                println!();
+            }
+            println!("Daemon-managed kernels:");
+            let table = Table::new(daemon_rows).with(Style::rounded()).to_string();
+            println!("{}", table);
+        }
+        if connection_file_kernels.is_empty()
+            && unified_kernels.iter().all(|k| k.source != "runtimed")
+        {
+            println!("No running kernels found.");
+        }
     } else {
-        print_kernel_table(&kernels);
+        print_unified_kernel_table(&unified_kernels);
     }
 
     Ok(())
+}
+
+fn print_unified_kernel_table(kernels: &[UnifiedKernelInfo]) {
+    if kernels.is_empty() {
+        println!("No running kernels found.");
+        return;
+    }
+
+    let rows: Vec<KernelTableRow> = kernels.iter().map(KernelTableRow::from).collect();
+    let table = Table::new(rows).with(Style::rounded()).to_string();
+    println!("{}", table);
 }
 
 async fn gather_kernel_info(path: PathBuf, timeout: Duration) -> Option<KernelInfo> {
@@ -484,17 +746,6 @@ async fn read_connection_info(path: &PathBuf) -> Result<ConnectionInfo> {
     let content = fs::read_to_string(path).await?;
     let info: ConnectionInfo = serde_json::from_str(&content)?;
     Ok(info)
-}
-
-fn print_kernel_table(kernels: &[KernelInfo]) {
-    if kernels.is_empty() {
-        println!("No running kernels found.");
-        return;
-    }
-
-    let rows: Vec<KernelTableRow> = kernels.iter().map(KernelTableRow::from).collect();
-    let table = Table::new(rows).with(Style::rounded()).to_string();
-    println!("{}", table);
 }
 
 fn print_verbose_kernel_table(kernels: &[KernelInfo]) {
@@ -1066,6 +1317,309 @@ async fn pool_command(command: PoolCommands) -> Result<()> {
 }
 
 // =============================================================================
+// Daemon management commands
+// =============================================================================
+
+async fn daemon_command(command: DaemonCommands) -> Result<()> {
+    use runtimed::client::PoolClient;
+    use runtimed::service::ServiceManager;
+    use runtimed::singleton::get_running_daemon_info;
+
+    let client = PoolClient::default();
+    let manager = ServiceManager::default();
+
+    match command {
+        DaemonCommands::Status { json } => {
+            let installed = manager.is_installed();
+            let daemon_info = get_running_daemon_info();
+            let running = if daemon_info.is_some() {
+                client.ping().await.is_ok()
+            } else {
+                false
+            };
+            let stats = if running {
+                client.status().await.ok()
+            } else {
+                None
+            };
+
+            if json {
+                let output = serde_json::json!({
+                    "installed": installed,
+                    "running": running,
+                    "daemon_info": daemon_info,
+                    "pool_stats": stats,
+                });
+                println!("{}", serde_json::to_string_pretty(&output)?);
+            } else {
+                println!("runtimed Daemon Status");
+                println!("======================");
+                println!(
+                    "Service installed: {}",
+                    if installed { "yes" } else { "no" }
+                );
+                println!("Daemon running:    {}", if running { "yes" } else { "no" });
+
+                if let Some(info) = &daemon_info {
+                    println!("PID:               {}", info.pid);
+                    println!("Version:           {}", info.version);
+                    if let Some(port) = info.blob_port {
+                        println!("Blob server:       http://127.0.0.1:{}", port);
+                    }
+                    let uptime = chrono::Utc::now() - info.started_at;
+                    let hours = uptime.num_hours();
+                    let mins = uptime.num_minutes() % 60;
+                    println!("Uptime:            {}h {}m", hours, mins);
+                }
+
+                if let Some(stats) = &stats {
+                    println!();
+                    println!("Pool:");
+                    println!(
+                        "  UV:    {}/{} ready{}",
+                        stats.uv_available,
+                        stats.uv_available + stats.uv_warming,
+                        if stats.uv_warming > 0 {
+                            format!(" ({} warming)", stats.uv_warming)
+                        } else {
+                            String::new()
+                        }
+                    );
+                    println!(
+                        "  Conda: {}/{} ready{}",
+                        stats.conda_available,
+                        stats.conda_available + stats.conda_warming,
+                        if stats.conda_warming > 0 {
+                            format!(" ({} warming)", stats.conda_warming)
+                        } else {
+                            String::new()
+                        }
+                    );
+                }
+            }
+        }
+        DaemonCommands::Start => {
+            if !manager.is_installed() {
+                eprintln!("Service not installed. Run 'runt daemon install' first.");
+                std::process::exit(1);
+            }
+            println!("Starting runtimed service...");
+            manager.start()?;
+            println!("Service started.");
+        }
+        DaemonCommands::Stop => {
+            if !manager.is_installed() {
+                eprintln!("Service not installed.");
+                std::process::exit(1);
+            }
+            println!("Stopping runtimed service...");
+            manager.stop()?;
+            println!("Service stopped.");
+        }
+        DaemonCommands::Restart => {
+            if !manager.is_installed() {
+                eprintln!("Service not installed. Run 'runt daemon install' first.");
+                std::process::exit(1);
+            }
+            println!("Restarting runtimed service...");
+            let _ = manager.stop(); // Ignore if not running
+            manager.start()?;
+            println!("Service restarted.");
+        }
+        DaemonCommands::Install { binary } => {
+            // Find runtimed binary: use provided path, or look for sibling binary
+            let source = binary.unwrap_or_else(|| {
+                let current_exe =
+                    std::env::current_exe().expect("Failed to get current executable path");
+                let exe_dir = current_exe.parent().unwrap();
+                exe_dir.join(if cfg!(windows) {
+                    "runtimed.exe"
+                } else {
+                    "runtimed"
+                })
+            });
+
+            if !source.exists() {
+                eprintln!("Daemon binary not found at: {}", source.display());
+                eprintln!("Build it with: cargo build -p runtimed");
+                std::process::exit(1);
+            }
+
+            if manager.is_installed() {
+                eprintln!("Service already installed. Use 'runt daemon uninstall' first.");
+                std::process::exit(1);
+            }
+
+            println!("Installing runtimed service...");
+            println!("Source binary: {}", source.display());
+            manager.install(&source)?;
+            println!("Service installed. Run 'runt daemon start' to start it.");
+        }
+        DaemonCommands::Uninstall => {
+            if !manager.is_installed() {
+                println!("Service not installed.");
+                return Ok(());
+            }
+            println!("Uninstalling runtimed service...");
+            manager.uninstall()?;
+            println!("Service uninstalled.");
+        }
+        DaemonCommands::Logs { follow, lines } => {
+            let log_path = dirs::cache_dir()
+                .unwrap_or_else(|| PathBuf::from("/tmp"))
+                .join("runt")
+                .join("runtimed.log");
+
+            if !log_path.exists() {
+                eprintln!("Log file not found: {}", log_path.display());
+                std::process::exit(1);
+            }
+
+            // Native Rust implementation for cross-platform support
+            tail_log_file(&log_path, lines, follow).await?;
+        }
+        DaemonCommands::Flush => match client.flush_pool().await {
+            Ok(()) => {
+                println!("Pool flushed — environments will be rebuilt");
+            }
+            Err(e) => {
+                eprintln!("Failed to flush pool: {}", e);
+                std::process::exit(1);
+            }
+        },
+        DaemonCommands::Shutdown => match client.shutdown().await {
+            Ok(()) => {
+                println!("Shutdown request sent");
+            }
+            Err(e) => {
+                eprintln!("Failed to shutdown daemon: {}", e);
+                std::process::exit(1);
+            }
+        },
+        DaemonCommands::Ping => match client.ping().await {
+            Ok(()) => {
+                println!("pong");
+            }
+            Err(e) => {
+                eprintln!("Daemon not running: {}", e);
+                std::process::exit(1);
+            }
+        },
+    }
+
+    Ok(())
+}
+
+/// Native log file tailing implementation
+async fn tail_log_file(path: &PathBuf, lines: usize, follow: bool) -> Result<()> {
+    use std::io::{BufRead, BufReader, Seek, SeekFrom};
+
+    // Read last N lines
+    let file = std::fs::File::open(path)?;
+    let reader = BufReader::new(&file);
+    let all_lines: Vec<String> = reader.lines().collect::<std::io::Result<Vec<_>>>()?;
+    let start = all_lines.len().saturating_sub(lines);
+    for line in &all_lines[start..] {
+        println!("{}", line);
+    }
+
+    if follow {
+        // Watch for new lines
+        use notify::{Config, RecommendedWatcher, RecursiveMode, Watcher};
+        use std::sync::mpsc::channel;
+
+        let (tx, rx) = channel();
+        let mut watcher = RecommendedWatcher::new(tx, Config::default())?;
+        watcher.watch(path.as_ref(), RecursiveMode::NonRecursive)?;
+
+        let mut file = std::fs::File::open(path)?;
+        file.seek(SeekFrom::End(0))?;
+        let mut reader = BufReader::new(file);
+        let mut line = String::new();
+
+        loop {
+            // Check for file changes
+            if let Ok(_event) = rx.recv_timeout(std::time::Duration::from_millis(100)) {
+                // Read any new lines
+                while reader.read_line(&mut line)? > 0 {
+                    print!("{}", line);
+                    line.clear();
+                }
+            }
+
+            // Check for Ctrl+C
+            if tokio::task::spawn_blocking(|| {
+                // Non-blocking check - we just rely on timeout
+                false
+            })
+            .await?
+            {
+                break;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+// =============================================================================
+// Notebook listing command
+// =============================================================================
+
+#[derive(Tabled)]
+struct NotebookTableRow {
+    #[tabled(rename = "NOTEBOOK")]
+    notebook: String,
+    #[tabled(rename = "KERNEL")]
+    kernel: String,
+    #[tabled(rename = "ENV")]
+    env: String,
+    #[tabled(rename = "STATUS")]
+    status: String,
+    #[tabled(rename = "PEERS")]
+    peers: String,
+}
+
+async fn list_notebooks(json_output: bool) -> Result<()> {
+    use runtimed::client::PoolClient;
+
+    let client = PoolClient::default();
+
+    match client.list_rooms().await {
+        Ok(rooms) => {
+            if json_output {
+                println!("{}", serde_json::to_string_pretty(&rooms)?);
+            } else {
+                if rooms.is_empty() {
+                    println!("No open notebooks.");
+                } else {
+                    let rows: Vec<NotebookTableRow> = rooms
+                        .iter()
+                        .map(|r| NotebookTableRow {
+                            notebook: shorten_path(&PathBuf::from(&r.notebook_id)),
+                            kernel: r.kernel_type.clone().unwrap_or_else(|| "-".to_string()),
+                            env: r.env_source.clone().unwrap_or_else(|| "-".to_string()),
+                            status: r.kernel_status.clone().unwrap_or_else(|| "-".to_string()),
+                            peers: r.active_peers.to_string(),
+                        })
+                        .collect();
+
+                    let table = Table::new(rows).with(Style::rounded()).to_string();
+                    println!("{}", table);
+                }
+            }
+        }
+        Err(e) => {
+            eprintln!("Failed to list notebooks: {}", e);
+            eprintln!("Is the daemon running? Try 'runt daemon status'");
+            std::process::exit(1);
+        }
+    }
+
+    Ok(())
+}
+
+// =============================================================================
 // Notebook inspection commands (debug tools)
 // =============================================================================
 
@@ -1186,42 +1740,6 @@ async fn inspect_notebook(path: &PathBuf, full_outputs: bool, json_output: bool)
         }
         Err(e) => {
             eprintln!("Failed to inspect notebook: {}", e);
-            std::process::exit(1);
-        }
-    }
-
-    Ok(())
-}
-
-async fn list_rooms(json_output: bool) -> Result<()> {
-    use runtimed::client::PoolClient;
-
-    let client = PoolClient::default();
-
-    match client.list_rooms().await {
-        Ok(rooms) => {
-            if json_output {
-                println!("{}", serde_json::to_string_pretty(&rooms)?);
-            } else {
-                if rooms.is_empty() {
-                    println!("No active notebook rooms.");
-                } else {
-                    println!("Active Notebook Rooms ({}):", rooms.len());
-                    println!("{}", "-".repeat(60));
-                    for room in rooms {
-                        println!(
-                            "  {} ({} peer{}, kernel: {})",
-                            shorten_path(&PathBuf::from(&room.notebook_id)),
-                            room.active_peers,
-                            if room.active_peers == 1 { "" } else { "s" },
-                            if room.has_kernel { "yes" } else { "no" }
-                        );
-                    }
-                }
-            }
-        }
-        Err(e) => {
-            eprintln!("Failed to list rooms: {}", e);
             std::process::exit(1);
         }
     }

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -918,10 +918,20 @@ impl Daemon {
                 let rooms = self.notebook_rooms.lock().await;
                 let mut room_infos = Vec::new();
                 for (notebook_id, room) in rooms.iter() {
+                    // Get kernel info if available
+                    let (kernel_type, env_source, kernel_status) = room
+                        .kernel_info()
+                        .await
+                        .map(|(kt, es, st)| (Some(kt), Some(es), Some(st)))
+                        .unwrap_or((None, None, None));
+
                     room_infos.push(crate::protocol::RoomInfo {
                         notebook_id: notebook_id.clone(),
                         active_peers: room.active_peers.load(std::sync::atomic::Ordering::Relaxed),
                         has_kernel: room.has_kernel().await,
+                        kernel_type,
+                        env_source,
+                        kernel_status,
                     });
                 }
                 Response::RoomsList { rooms: room_infos }

--- a/crates/runtimed/src/main.rs
+++ b/crates/runtimed/src/main.rs
@@ -56,23 +56,30 @@ enum Commands {
         binary: Option<PathBuf>,
     },
 
-    /// Uninstall daemon system service
+    // =========================================================================
+    // Deprecated commands - use 'runt daemon' instead
+    // =========================================================================
+    /// [DEPRECATED] Use 'runt daemon uninstall' instead
+    #[command(hide = true)]
     Uninstall,
 
-    /// Check daemon status
+    /// [DEPRECATED] Use 'runt daemon status' instead
+    #[command(hide = true)]
     Status {
-        /// Output in JSON format
         #[arg(long)]
         json: bool,
     },
 
-    /// Start the installed service
+    /// [DEPRECATED] Use 'runt daemon start' instead
+    #[command(hide = true)]
     Start,
 
-    /// Stop the installed service
+    /// [DEPRECATED] Use 'runt daemon stop' instead
+    #[command(hide = true)]
     Stop,
 
-    /// Flush all pooled environments and rebuild with current settings
+    /// [DEPRECATED] Use 'runt daemon flush' instead
+    #[command(hide = true)]
     FlushPool,
 }
 
@@ -115,11 +122,33 @@ async fn main() -> anyhow::Result<()> {
             .await
         }
         Some(Commands::Install { binary }) => install_service(binary),
-        Some(Commands::Uninstall) => uninstall_service(),
-        Some(Commands::Status { json }) => status(json).await,
-        Some(Commands::Start) => start_service(),
-        Some(Commands::Stop) => stop_service(),
-        Some(Commands::FlushPool) => flush_pool().await,
+        // Deprecated commands - still work but print warnings
+        Some(Commands::Uninstall) => {
+            eprintln!(
+                "Warning: 'runtimed uninstall' is deprecated. Use 'runt daemon uninstall' instead."
+            );
+            uninstall_service()
+        }
+        Some(Commands::Status { json }) => {
+            eprintln!(
+                "Warning: 'runtimed status' is deprecated. Use 'runt daemon status' instead."
+            );
+            status(json).await
+        }
+        Some(Commands::Start) => {
+            eprintln!("Warning: 'runtimed start' is deprecated. Use 'runt daemon start' instead.");
+            start_service()
+        }
+        Some(Commands::Stop) => {
+            eprintln!("Warning: 'runtimed stop' is deprecated. Use 'runt daemon stop' instead.");
+            stop_service()
+        }
+        Some(Commands::FlushPool) => {
+            eprintln!(
+                "Warning: 'runtimed flush-pool' is deprecated. Use 'runt daemon flush' instead."
+            );
+            flush_pool().await
+        }
     }
 }
 
@@ -182,9 +211,9 @@ fn install_service(binary: Option<PathBuf>) -> anyhow::Result<()> {
     println!("Service installed successfully!");
     println!("The daemon will start automatically at login.");
     println!();
-    println!("To start now: runtimed start");
-    println!("To check status: runtimed status");
-    println!("To uninstall: runtimed uninstall");
+    println!("To start now:    runt daemon start");
+    println!("To check status: runt daemon status");
+    println!("To uninstall:    runt daemon uninstall");
 
     Ok(())
 }

--- a/crates/runtimed/src/protocol.rs
+++ b/crates/runtimed/src/protocol.rs
@@ -98,6 +98,15 @@ pub struct RoomInfo {
     pub notebook_id: String,
     pub active_peers: usize,
     pub has_kernel: bool,
+    /// Kernel type if running (e.g., "python", "deno")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kernel_type: Option<String>,
+    /// Environment source if kernel is running (e.g., "uv:inline", "conda:prewarmed")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub env_source: Option<String>,
+    /// Kernel status if running (e.g., "idle", "busy", "starting")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kernel_status: Option<String>,
 }
 
 /// Blob channel request.

--- a/docs/runtimed.md
+++ b/docs/runtimed.md
@@ -123,6 +123,17 @@ The daemon watches `~/.config/runt-notebook/settings.json` for external edits. C
 | Linux | systemd user service (`~/.config/systemd/user/runtimed.service`) |
 | Windows | VBS script in Startup folder |
 
+**CLI commands** (cross-platform):
+```bash
+runt daemon status     # Check service and pool status
+runt daemon start      # Start the daemon service
+runt daemon stop       # Stop the daemon service
+runt daemon restart    # Restart the daemon
+runt daemon logs -f    # Tail daemon logs
+runt daemon install    # Install as system service
+runt daemon uninstall  # Uninstall system service
+```
+
 Auto-upgrade: the client detects version mismatches and replaces the binary.
 
 ### Key files


### PR DESCRIPTION
## Summary

Restructure the CLI to make `runt` the single interface for users. The `runtimed` binary is now minimal and only used for system service integration.

**New command structure:**
- `runt daemon` - Service management (status, start, stop, restart, install, uninstall, logs, flush, shutdown, ping)
- `runt jupyter` - Kernel utilities (start, stop, interrupt, exec, console, clean, sidecar)
- `runt ps` - Enhanced to show both connection-file and daemon-managed kernels with SOURCE and NOTEBOOK columns
- `runt notebooks` - List open notebooks with kernel/peer info
- `runtimed` - Only `run` and `install` visible; other commands hidden with deprecation warnings

**Implementation details:**
- Extended protocol `RoomInfo` with kernel_type, env_source, kernel_status fields
- Updated daemon `ListRooms` handler to populate kernel details from running kernels
- Native cross-platform log reading for `runt daemon logs` using notify crate
- Full backwards compatibility with deprecation warnings guiding users to new structure

## Verification

- [x] All tests pass (15 integration tests, 0 failures)
- [x] Clippy clean (no warnings)
- [x] Both `runt` and `runtimed` build successfully
- [x] New CLI structure verified with `--help` output
- [x] Backwards-compatible aliases work with deprecation messages

_PR submitted by @rgbkrk's agent, Quill_