### PR TITLE
Silence Tauri event unregister errors

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -29,6 +29,7 @@ import { type MimeBundle, useKernel } from "./hooks/useKernel";
 import { useNotebook } from "./hooks/useNotebook";
 import { usePrewarmStatus } from "./hooks/usePrewarmStatus";
 import { useTrust } from "./hooks/useTrust";
+import { safeUnlisten } from "./lib/tauri-event";
 import type { JupyterMessage, JupyterOutput } from "./types";
 
 /** Page payload data for a cell */
@@ -646,7 +647,7 @@ function AppContent() {
 
     return () => {
       window.removeEventListener("keydown", handleKeyDown);
-      unlistenPromise.then((unlisten) => unlisten());
+      safeUnlisten(unlistenPromise);
     };
   }, [save]);
 
@@ -668,7 +669,7 @@ function AppContent() {
 
     return () => {
       window.removeEventListener("keydown", handleKeyDown);
-      unlistenPromise.then((unlisten) => unlisten());
+      safeUnlisten(unlistenPromise);
     };
   }, [openNotebook]);
 
@@ -679,7 +680,7 @@ function AppContent() {
     });
 
     return () => {
-      unlistenPromise.then((unlisten) => unlisten());
+      safeUnlisten(unlistenPromise);
     };
   }, [cloneNotebook]);
 
@@ -689,7 +690,7 @@ function AppContent() {
       handleRunAllCells();
     });
     return () => {
-      unlistenPromise.then((unlisten) => unlisten());
+      safeUnlisten(unlistenPromise);
     };
   }, [handleRunAllCells]);
 
@@ -699,7 +700,7 @@ function AppContent() {
       handleRestartAndRunAll();
     });
     return () => {
-      unlistenPromise.then((unlisten) => unlisten());
+      safeUnlisten(unlistenPromise);
     };
   }, [handleRestartAndRunAll]);
 
@@ -728,9 +729,9 @@ function AppContent() {
     const unlistenReset = listen("menu:zoom-reset", handleZoomReset);
 
     return () => {
-      unlistenIn.then((u) => u());
-      unlistenOut.then((u) => u());
-      unlistenReset.then((u) => u());
+      safeUnlisten(unlistenIn);
+      safeUnlisten(unlistenOut);
+      safeUnlisten(unlistenReset);
     };
   }, []);
 

--- a/apps/notebook/src/hooks/useDaemonKernel.ts
+++ b/apps/notebook/src/hooks/useDaemonKernel.ts
@@ -12,6 +12,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { safeUnlisten } from "../lib/tauri-event";
 import type {
   DaemonBroadcast,
   DaemonNotebookResponse,
@@ -249,8 +250,8 @@ export function useDaemonKernel({
 
     return () => {
       cancelled = true;
-      unlistenBroadcast.then((fn) => fn());
-      unlistenDisconnect.then((fn) => fn());
+      safeUnlisten(unlistenBroadcast);
+      safeUnlisten(unlistenDisconnect);
     };
   }, []);
 

--- a/apps/notebook/src/hooks/useEnvProgress.ts
+++ b/apps/notebook/src/hooks/useEnvProgress.ts
@@ -1,5 +1,6 @@
 import { listen } from "@tauri-apps/api/event";
 import { useCallback, useEffect, useState } from "react";
+import { safeUnlisten } from "../lib/tauri-event";
 import type { EnvProgressEvent, EnvProgressPhase } from "../types";
 
 export interface EnvProgressState {
@@ -197,7 +198,7 @@ export function useEnvProgress() {
 
     return () => {
       cancelled = true;
-      unlisten.then((fn) => fn());
+      safeUnlisten(unlisten);
     };
   }, []);
 

--- a/apps/notebook/src/hooks/useExecutionQueue.ts
+++ b/apps/notebook/src/hooks/useExecutionQueue.ts
@@ -1,6 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { safeUnlisten } from "../lib/tauri-event";
 
 /** Status of a cell in the queue */
 export type CellQueueStatus = "pending" | "executing";
@@ -77,8 +78,8 @@ export function useExecutionQueue(options: UseExecutionQueueOptions = {}) {
 
     return () => {
       cancelled = true;
-      stateUnlisten.then((fn) => fn());
-      cancelUnlisten.then((fn) => fn());
+      safeUnlisten(stateUnlisten);
+      safeUnlisten(cancelUnlisten);
     };
   }, [options.onCellsCancelled]);
 

--- a/apps/notebook/src/hooks/useKernel.ts
+++ b/apps/notebook/src/hooks/useKernel.ts
@@ -1,6 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { safeUnlisten } from "../lib/tauri-event";
 import type { JupyterMessage, JupyterOutput, KernelspecInfo } from "../types";
 
 /** MIME bundle type for page payloads */
@@ -299,9 +300,9 @@ export function useKernel({
 
     return () => {
       cancelled = true;
-      unlisten.then((fn) => fn());
-      pageUnlisten.then((fn) => fn());
-      lifecycleUnlisten.then((fn) => fn());
+      safeUnlisten(unlisten);
+      safeUnlisten(pageUnlisten);
+      safeUnlisten(lifecycleUnlisten);
     };
   }, []); // Empty deps - callbacks accessed via ref
 

--- a/apps/notebook/src/hooks/useNotebook.ts
+++ b/apps/notebook/src/hooks/useNotebook.ts
@@ -5,6 +5,7 @@ import {
   save as saveDialog,
 } from "@tauri-apps/plugin-dialog";
 import { useCallback, useEffect, useState } from "react";
+import { safeUnlisten } from "../lib/tauri-event";
 import type { JupyterOutput, NotebookCell } from "../types";
 
 /**
@@ -85,7 +86,7 @@ export function useNotebook() {
       loadCells();
     });
     return () => {
-      unlisten.then((fn) => fn());
+      safeUnlisten(unlisten);
     };
   }, [loadCells]);
 
@@ -105,7 +106,7 @@ export function useNotebook() {
       },
     );
     return () => {
-      unlisten.then((fn) => fn());
+      safeUnlisten(unlisten);
     };
   }, []);
 
@@ -122,7 +123,7 @@ export function useNotebook() {
       );
     });
     return () => {
-      unlisten.then((fn) => fn());
+      safeUnlisten(unlisten);
     };
   }, []);
 
@@ -143,7 +144,7 @@ export function useNotebook() {
       setCells(newCells);
     });
     return () => {
-      unlisten.then((fn) => fn());
+      safeUnlisten(unlisten);
     };
   }, []);
 

--- a/apps/notebook/src/lib/tauri-event.ts
+++ b/apps/notebook/src/lib/tauri-event.ts
@@ -1,0 +1,17 @@
+/**
+ * Safely unregister a Tauri event listener.
+ *
+ * Catches errors that occur if the Tauri event plugin is destroyed
+ * before the cleanup runs (e.g., during app shutdown).
+ *
+ * In Tauri API 2.10+, the unlisten function makes a synchronous call to
+ * `window.__TAURI_EVENT_PLUGIN_INTERNALS__.unregisterListener()` which
+ * throws if the plugin internals have been torn down. This wrapper
+ * silently catches those errors since if the plugin is gone, the
+ * listener is already cleaned up.
+ */
+export function safeUnlisten(
+  unlistenPromise: Promise<() => void | Promise<void>>,
+): void {
+  unlistenPromise.then((fn) => fn()).catch(() => {});
+}

--- a/src/hooks/useSyncedSettings.ts
+++ b/src/hooks/useSyncedSettings.ts
@@ -9,6 +9,7 @@ import type {
   SyncedSettings,
   ThemeMode,
 } from "@/bindings";
+import { safeUnlisten } from "../../apps/notebook/src/lib/tauri-event";
 
 // Re-export generated types so consumers can import from this module.
 export type { ThemeMode, Runtime, PythonEnvType };
@@ -164,7 +165,7 @@ export function useSyncedSettings() {
       }
     });
     return () => {
-      unlisten.then((u) => u());
+      safeUnlisten(unlisten);
     };
   }, []);
 


### PR DESCRIPTION
## Summary

Wrap Tauri `unlisten` calls with error handling to prevent console noise when the event plugin is destroyed before cleanup runs. This occurs during app shutdown, React StrictMode double-effects, and hot module reloading.

In Tauri API 2.10+, the unlisten function makes a synchronous call to `window.__TAURI_EVENT_PLUGIN_INTERNALS__.unregisterListener()` which throws if the plugin internals have been torn down. Add a `safeUnlisten()` helper that silently catches these errors—if the plugin is already gone, the listener is already cleaned up.

## Verification

- All lints pass (biome, clippy)
- All tests pass (JavaScript, Rust)
- UI builds successfully

_PR submitted by @rgbkrk's agent, Quill_