### PR TITLE
Add per-worktree daemon isolation for development

### DIFF
--- a/contributing/development.md
+++ b/contributing/development.md
@@ -77,14 +77,64 @@ cargo xtask build
 
 The notebook app connects to a background daemon (`runtimed`) that manages prewarmed environments and notebook document sync. **Important:** The daemon is a separate process. When you change code in `crates/runtimed/`, the running daemon still uses the old binary until you reinstall it.
 
-### Reinstalling the daemon
+### Development Mode (Per-Worktree Isolation)
+
+In production, the Tauri app auto-installs and manages the system daemon. In development, you control the daemon yourself, which gives you:
+
+- Isolated state per worktree (no conflicts when testing across branches)
+- Your code changes take effect immediately on daemon restart
+- No interference with the system daemon
+
+**Two-terminal workflow:**
 
 ```bash
-# Rebuild and reinstall (builds release, stops old, copies, restarts)
+# Terminal 1: Start the dev daemon (stays running)
+cargo xtask dev-daemon
+
+# Terminal 2: Run the notebook app
+cargo xtask dev              # Hot-reload mode
+# or
+cargo xtask build && ./target/debug/notebook   # Debug build
+```
+
+The app detects dev mode and connects to the per-worktree daemon instead of installing/starting the system daemon.
+
+**Conductor users:** Dev mode is automatic when `CONDUCTOR_WORKSPACE_PATH` is set.
+
+**Non-Conductor users:** Set `RUNTIMED_DEV=1`:
+
+```bash
+# Terminal 1
+RUNTIMED_DEV=1 cargo xtask dev-daemon
+
+# Terminal 2
+RUNTIMED_DEV=1 cargo xtask dev
+```
+
+**Useful commands:**
+
+```bash
+runt daemon status           # Shows dev mode, worktree path, version
+runt daemon list-worktrees   # List all running dev daemons
+runt daemon logs -f          # Tail logs (uses correct log path in dev mode)
+```
+
+Per-worktree state is stored in `~/.cache/runt/worktrees/{hash}/`.
+
+### Testing Against System Daemon (Production Mode)
+
+When you need to test the full production flow (daemon auto-install, upgrades, etc.):
+
+```bash
+# Make sure dev mode is NOT set
+unset RUNTIMED_DEV
+unset CONDUCTOR_WORKSPACE_PATH
+
+# Rebuild and reinstall system daemon
 cargo xtask install-daemon
 
-# Verify version
-cat ~/Library/Caches/runt/daemon.json
+# Run the app (it will connect to system daemon)
+cargo xtask dev
 ```
 
 ### Daemon logs
@@ -96,14 +146,19 @@ runt daemon logs -n 100
 # Watch logs in real-time
 runt daemon logs -f
 
-# Filter for specific topics (can combine with grep)
+# Filter for specific topics
 runt daemon logs -f | grep -i "kernel\|auto-detect"
 ```
 
-### Common gotcha
+### Common gotchas
 
 If your daemon code changes aren't taking effect:
-1. Did you run `cargo xtask install-daemon`? (`cargo xtask build` doesn't reinstall the daemon)
-2. Is the daemon running the right version? Check `runt daemon status`
+1. **In dev mode:** Did you restart `cargo xtask dev-daemon`?
+2. **In production mode:** Did you run `cargo xtask install-daemon`?
+3. Check which daemon is running: `runt daemon status`
+
+If the app says "Dev daemon not running":
+- You're in dev mode but haven't started the dev daemon
+- Run `cargo xtask dev-daemon` in another terminal first
 
 See [contributing/runtimed.md](./runtimed.md) for full daemon development docs.

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -477,7 +477,8 @@ pub struct DaemonInfoForBanner {
 async fn get_daemon_info() -> Option<DaemonInfoForBanner> {
     #[cfg(debug_assertions)]
     {
-        let info_path = dirs::cache_dir()?.join("runt").join("daemon.json");
+        // Use runtimed's path resolution which handles dev mode (per-worktree) paths
+        let info_path = runtimed::singleton::daemon_info_path();
         let contents = std::fs::read_to_string(info_path).ok()?;
         let json: serde_json::Value = serde_json::from_str(&contents).ok()?;
         let version = json.get("version")?.as_str()?.to_string();

--- a/crates/runtimed/src/service.rs
+++ b/crates/runtimed/src/service.rs
@@ -58,6 +58,9 @@ pub fn default_binary_path() -> PathBuf {
 }
 
 /// Get the default path for the daemon log file.
+///
+/// Note: This is the system service log path (always ~/.cache/runt/runtimed.log).
+/// For dev mode, use `crate::default_log_path()` which handles per-worktree paths.
 pub fn default_log_path() -> PathBuf {
     dirs::cache_dir()
         .unwrap_or_else(|| PathBuf::from("/tmp"))


### PR DESCRIPTION
## Summary

Implement dev mode that enables each git worktree to run its own isolated daemon instance, preventing conflicts when developing across multiple branches. This solves the problem where the Tauri app's auto-install behavior makes it painful to test daemon changes across multiple worktrees—the system daemon would be relaunched by agents or other worktrees, making it unclear which version of the daemon was actually running.

## Changes

**Core dev mode detection** (`crates/runtimed/src/lib.rs`):
- `is_dev_mode()` - Checks `RUNTIMED_DEV=1` or `CONDUCTOR_WORKSPACE_PATH` (automatic for Conductor users)
- `get_workspace_path()` / `get_workspace_name()` - Retrieves workspace metadata
- `daemon_base_dir()` - Returns per-worktree directory in dev mode (`~/.cache/runt/worktrees/{hash}/`)
- All path functions now derive from `daemon_base_dir()` for automatic isolation

**App behavior** (`crates/runtimed/src/client.rs`):
- In dev mode: Skip service installation/upgrade, only check if daemon is running
- If dev daemon not running: Return helpful error message directing users to `cargo xtask dev-daemon`
- Production mode unchanged: Full service management

**New tooling**:
- `cargo xtask dev-daemon` - Build and run daemon in dev mode
- `runt daemon list-worktrees` - List all running dev worktree daemons
- `runtimed --dev run` - CLI flag for dev mode

**Metadata** (`crates/runtimed/src/singleton.rs`):
- Extended `DaemonInfo` with `worktree_path` and `workspace_description` fields
- `runt daemon status` now shows dev mode, worktree path, and workspace description

**Documentation** (`contributing/development.md`, `AGENTS.md`):
- Clear two-terminal workflow for dev: `cargo xtask dev-daemon` + `cargo xtask dev`
- Explains automatic Conductor detection vs manual `RUNTIMED_DEV=1`
- Shows how to test against system daemon (production mode)

## Verification

- [x] Build succeeds with no clippy warnings
- [x] Code formatted with `cargo fmt`
- Manual testing:
  1. `cargo xtask dev-daemon` starts isolated daemon
  2. App detects dev mode and connects to per-worktree socket
  3. Per-worktree state isolated in `~/.cache/runt/worktrees/{hash}/`
  4. `runt daemon list-worktrees` shows all dev daemons
  5. `runt daemon status` shows workspace info in dev mode
  6. System daemon mode still works when `RUNTIMED_DEV` unset

## Development Workflow

**With Conductor (automatic):**
```bash
# Terminal 1
cargo xtask dev-daemon

# Terminal 2
cargo xtask dev
```

**Without Conductor (manual):**
```bash
# Terminal 1
RUNTIMED_DEV=1 cargo xtask dev-daemon

# Terminal 2
RUNTIMED_DEV=1 cargo xtask dev
```

_PR submitted by @rgbkrk's agent, Quill_