### PR TITLE
Show daemon type and socket path in debug banner

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -27,7 +27,6 @@ import { useExecutionQueue } from "./hooks/useExecutionQueue";
 import { useDaemonInfo, useGitInfo } from "./hooks/useGitInfo";
 import { type MimeBundle, useKernel } from "./hooks/useKernel";
 import { useNotebook } from "./hooks/useNotebook";
-import { usePrewarmStatus } from "./hooks/usePrewarmStatus";
 import { useTrust } from "./hooks/useTrust";
 import type { JupyterMessage, JupyterOutput } from "./types";
 
@@ -75,7 +74,6 @@ async function sendMessage(message: unknown): Promise<void> {
 function AppContent() {
   const gitInfo = useGitInfo();
   const daemonInfo = useDaemonInfo();
-  const prewarmStatus = usePrewarmStatus();
 
   const { theme, setTheme } = useSyncedTheme();
   const {
@@ -753,9 +751,9 @@ function AppContent() {
           branch={gitInfo.branch}
           commit={gitInfo.commit}
           description={gitInfo.description}
-          uvPoolStatus={prewarmStatus.uv}
-          condaPoolStatus={prewarmStatus.conda}
           daemonVersion={daemonInfo?.version}
+          socketPath={daemonInfo?.socket_path}
+          isDevMode={daemonInfo?.is_dev_mode}
         />
       )}
       <NotebookToolbar

--- a/apps/notebook/src/components/DebugBanner.tsx
+++ b/apps/notebook/src/components/DebugBanner.tsx
@@ -1,24 +1,23 @@
-import { GitBranch, Server, Zap } from "lucide-react";
-import type { PoolStatus } from "../hooks/usePrewarmStatus";
+import { GitBranch, Server } from "lucide-react";
 
 interface DebugBannerProps {
   branch: string;
   commit: string;
   description?: string | null;
-  uvPoolStatus?: PoolStatus | null;
-  condaPoolStatus?: PoolStatus | null;
   daemonVersion?: string | null;
+  socketPath?: string | null;
+  isDevMode?: boolean | null;
 }
 
 export function DebugBanner({
   branch,
   commit,
   description,
-  uvPoolStatus,
-  condaPoolStatus,
   daemonVersion,
+  socketPath,
+  isDevMode,
 }: DebugBannerProps) {
-  const hasPoolStatus = uvPoolStatus || condaPoolStatus;
+  const daemonLabel = isDevMode ? "Dev Daemon" : "System Daemon";
 
   return (
     <div className="flex items-center justify-center gap-2 bg-violet-600/90 px-3 py-1 text-xs text-white">
@@ -32,54 +31,34 @@ export function DebugBanner({
           <span className="text-violet-100">{description}</span>
         </>
       )}
-      {hasPoolStatus && (
-        <>
-          <span className="text-violet-300">|</span>
-          <Zap className="h-3 w-3 text-yellow-300" />
-          <span className="text-violet-100">
-            {uvPoolStatus && (
-              <>
-                UV: {uvPoolStatus.available}/{uvPoolStatus.target}
-                {uvPoolStatus.creating > 0 && (
-                  <span className="text-violet-300">
-                    {" "}
-                    (+{uvPoolStatus.creating})
-                  </span>
-                )}
-              </>
-            )}
-            {uvPoolStatus && condaPoolStatus && " "}
-            {condaPoolStatus && (
-              <>
-                Conda: {condaPoolStatus.available}/{condaPoolStatus.target}
-                {condaPoolStatus.creating > 0 && (
-                  <span className="text-violet-300">
-                    {" "}
-                    (+{condaPoolStatus.creating})
-                  </span>
-                )}
-              </>
-            )}
-          </span>
-        </>
-      )}
       {daemonVersion && (
         <>
           <span className="text-violet-300">|</span>
           <Server className="h-3 w-3 text-emerald-300" />
           <span className="text-violet-100">
-            Daemon:{" "}
-            <span className="font-mono">
-              {daemonVersion.includes("+")
-                ? daemonVersion.split("+")[1]
-                : daemonVersion}
-            </span>
+            {daemonLabel}
+            {socketPath && (
+              <span
+                className="ml-1 font-mono truncate max-w-[350px] inline-block align-bottom"
+                title={socketPath}
+              >
+                {socketPath}
+              </span>
+            )}
+            {daemonVersion && (
+              <span className="ml-1 text-violet-300">
+                (
+                <span className="font-mono">
+                  {daemonVersion.includes("+")
+                    ? daemonVersion.split("+")[1]
+                    : daemonVersion}
+                </span>
+                )
+              </span>
+            )}
           </span>
         </>
       )}
-      <span className="ml-2 rounded bg-violet-500/50 px-1.5 py-0.5 text-[10px] font-medium uppercase">
-        Dev
-      </span>
     </div>
   );
 }

--- a/apps/notebook/src/hooks/useGitInfo.ts
+++ b/apps/notebook/src/hooks/useGitInfo.ts
@@ -9,6 +9,8 @@ interface GitInfo {
 
 interface DaemonInfo {
   version: string;
+  socket_path: string;
+  is_dev_mode: boolean;
 }
 
 export function useGitInfo() {


### PR DESCRIPTION
Replace spawn pool status with daemon connection info in the debug banner. Shows "Dev Daemon" or "System Daemon" label with the socket path, making it easy to identify which daemon instance the app is connected to when running multiple worktrees.

## Changes

- Backend: Extended `DaemonInfoForBanner` struct with `socket_path` and `is_dev_mode` fields
- Backend: Replace home directory prefix with `~` for shorter display
- Frontend: Updated `DebugBanner` component to show daemon type and socket path instead of pool status
- Frontend: Widened socket path display to 350px and added hover tooltip for full path

## Verification

- [x] Run dev daemon: `cargo xtask dev-daemon`
- [x] Run app: `cargo xtask dev`
- [x] Verify debug banner shows "Dev Daemon" with socket path like `~/.cache/runt/worktrees/{hash}/runtimed.sock`
- [x] Hover over socket path to verify full path tooltip appears

_PR submitted by @rgbkrk's agent, Quill_