### PR TITLE
Update jupyter-protocol, runtimelib, and nbformat dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2704,9 +2704,9 @@ dependencies = [
 
 [[package]]
 name = "jupyter-protocol"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c75a69caf8b8e781224badfb76c4a8da4d49856de36ce72ae3cf5d4a1c94e42"
+checksum = "45cd3027b79a835a8ac9bae08f772b2cb192dd6a52a5d5455f1219861e47e8eb"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3144,9 +3144,9 @@ dependencies = [
 
 [[package]]
 name = "nbformat"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b10a89a2d910233ec3fca4de359b16ebe95e833c8b2162643ef98c6053a0549d"
+checksum = "d4983a40792c45e8639f77ef8e4461c55679cbc618f4b9e83830e8c7e79c8383"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5160,9 +5160,9 @@ dependencies = [
 
 [[package]]
 name = "runtimelib"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0bbbbda0bde4637a502077c169fc0b70aef6f6cb7d828327aa2faf46448157d"
+checksum = "fa84884e45ed4a1e663120cef3fc11f14d1a2a1933776e1c31599f7bd2dd0c9e"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -5776,7 +5776,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b1fdf65dd6331831494dd616b30351c38e96e45921a27745cf98490458b90bb"
 dependencies = [
- "dirs 5.0.1",
+ "dirs 6.0.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,8 @@ futures = "0.3"
 bytes = "1"
 base64 = "0.22"
 tokio = { version = "1.36.0", features = ["full"] }
-runtimelib = { version = "1.3.0", default-features = false }
-jupyter-protocol = "1.2.1"
+runtimelib = { version = "1.4.0", default-features = false }
+jupyter-protocol = "1.3.0"
 thiserror = "1"
 schemars = "1"
 notify = "8"

--- a/crates/notebook/Cargo.toml
+++ b/crates/notebook/Cargo.toml
@@ -33,7 +33,7 @@ jupyter-protocol = { workspace = true }
 runtimelib = { workspace = true, features = ["tokio-runtime", "ring"] }
 tauri-jupyter = { path = "../tauri-jupyter" }
 runtimed = { path = "../runtimed" }
-nbformat = "1.1.0"
+nbformat = "1.2.0"
 petname = "2"
 log = "0.4"
 env_logger = "0.11"

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -3866,6 +3866,7 @@ pub fn run(
             let nb_v4 = match nb {
                 nbformat::Notebook::V4(nb) => nb,
                 nbformat::Notebook::Legacy(legacy) => nbformat::upgrade_legacy_notebook(legacy)?,
+                nbformat::Notebook::V3(v3) => nbformat::upgrade_v3_notebook(v3)?,
             };
             NotebookState::from_notebook(nb_v4, path.clone())
         }
@@ -4452,6 +4453,15 @@ pub fn run(
                                     nbformat::Notebook::V4(nb) => nb,
                                     nbformat::Notebook::Legacy(legacy) => {
                                         match nbformat::upgrade_legacy_notebook(legacy) {
+                                            Ok(nb) => nb,
+                                            Err(e) => {
+                                                log::error!("Failed to upgrade notebook: {}", e);
+                                                continue;
+                                            }
+                                        }
+                                    }
+                                    nbformat::Notebook::V3(v3) => {
+                                        match nbformat::upgrade_v3_notebook(v3) {
                                             Ok(nb) => nb,
                                             Err(e) => {
                                                 log::error!("Failed to upgrade notebook: {}", e);


### PR DESCRIPTION
## Summary

Updated Jupyter-related dependencies to latest versions:
- jupyter-protocol: 1.2.1 → 1.3.0
- runtimelib: 1.3.0 → 1.4.0
- nbformat: 1.1.0 → 1.2.0

## Changes

The nbformat 1.2.0 update introduces support for V3 notebook format. Updated the notebook parsing code to handle the new `V3` variant by upgrading to V4 format, consistent with how Legacy notebooks are handled.

_PR submitted by @rgbkrk's agent, Quill_