### PR TITLE
docs: Audit and align mermaid diagrams with current implementation

### DIFF
--- a/contributing/environments.md
+++ b/contributing/environments.md
@@ -82,7 +82,7 @@ graph TB
         CWL[Conda Warming Loop<br/>every 30s]
         SS[Settings Sync Server<br/>Automerge CRDT]
         PC[PoolClient<br/>IPC: Unix socket / Named pipe]
-        PROT[NDJSON Protocol<br/>Take / Return / Status / Ping]
+        PROT[Length-prefixed JSON<br/>Take / Return / Status / Ping]
 
         DM --> UWL
         DM --> CWL
@@ -359,7 +359,7 @@ The diagrams show three main layers and a separate daemon process:
 
 2. **Tauri Backend** (orange) — `start_default_python_kernel_impl` runs the detection priority chain: inline deps first, then closest project file, then prewarmed pool. Each path delegates to a kernel start method.
 
-3. **runtimed Daemon** (indigo) — A singleton background process managing prewarmed UV and Conda environment pools across all notebook windows. Communicates via NDJSON over Unix domain sockets (or Windows named pipes). Also runs an Automerge CRDT sync server for cross-window settings.
+3. **runtimed Daemon** (indigo) — A singleton background process managing prewarmed UV and Conda environment pools across all notebook windows. Communicates via length-prefixed JSON over Unix domain sockets (or Windows named pipes). Also runs an Automerge CRDT sync server for cross-window settings.
 
 4. **External Tools** (grey) — `uv` for pip-compatible package management, `rattler` for conda solving/installing, and `deno` for TypeScript notebooks.
 

--- a/docs/runtimed.md
+++ b/docs/runtimed.md
@@ -85,6 +85,8 @@ pub struct DaemonInfo {
     pub version: String,
     pub started_at: DateTime<Utc>,
     pub blob_port: Option<u16>,
+    pub worktree_path: Option<String>,        // dev mode only
+    pub workspace_description: Option<String>, // dev mode only
 }
 ```
 
@@ -110,6 +112,8 @@ Length-prefixed binary framing over a single Unix socket (Unix) or named pipe (W
 | `Ping` | `Pong` | Health check |
 | `Shutdown` | `ShuttingDown` | Graceful stop |
 | `FlushPool` | `Flushed` | Drain and rebuild all envs |
+| `InspectNotebook { notebook_id }` | `NotebookState { ... }` | Debug notebook sync state |
+| `ListRooms` | `RoomsList { rooms }` | List active notebook sync rooms |
 
 ### Settings.json file watcher
 


### PR DESCRIPTION
## Summary

Updated documentation to reflect the current codebase implementation and trajectory, with `docs/runtimed.md` as the authoritative source for architecture:

- Updated IPC protocol description from stale NDJSON to length-prefixed JSON in `contributing/environments.md`
- Added dev-mode fields to `DaemonInfo` struct in `docs/runtimed.md` 
- Added notebook sync protocol requests to IPC table

## Verification

- [x] cargo fmt
- [x] biome check (TS/JS)
- [x] clippy --all-targets
- [x] cargo test
- [x] pnpm test:run

_PR submitted by @rgbkrk's agent, Quill_