### PR TITLE
Fix dev-daemon startup message to show platform-correct cache paths

### DIFF
--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -368,9 +368,14 @@ fn cmd_dev_daemon() {
         exit(1);
     }
 
+    let cache_base = dirs::cache_dir()
+        .unwrap_or_else(|| std::path::PathBuf::from("/tmp"))
+        .join("runt")
+        .join("worktrees");
+
     println!();
     println!("Starting development daemon for this worktree...");
-    println!("State will be stored in ~/.cache/runt/worktrees/<hash>/");
+    println!("State will be stored in {}/<hash>/", cache_base.display());
     println!("Press Ctrl+C to stop.");
     println!();
 


### PR DESCRIPTION
The dev-daemon startup message displayed a hardcoded Linux-style cache path (`~/.cache/runt/worktrees/<hash>/`), which is incorrect on macOS (`~/Library/Caches/runt/worktrees/<hash>/`) and Windows. This change computes and displays the correct platform-specific path using `dirs::cache_dir()`.

**What changed:**
- `crates/xtask/src/main.rs`: Compute platform-correct cache directory in `cmd_dev_daemon()` and display the actual path instead of a static string.

**Verification:**
- Run `cargo xtask dev-daemon` to see the correct cache path for your platform

_PR submitted by @rgbkrk's agent, Quill_