### PR TITLE
Add notebook path argument to cargo xtask dev

### DIFF
--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -12,7 +12,10 @@ fn main() {
     }
 
     match args[0].as_str() {
-        "dev" => cmd_dev(),
+        "dev" => {
+            let notebook = args.get(1).map(String::as_str);
+            cmd_dev(notebook);
+        }
         "build" => cmd_build(),
         "run" => {
             let notebook = args.get(1).map(String::as_str);
@@ -42,7 +45,7 @@ fn print_help() {
         "Usage: cargo xtask <COMMAND>
 
 Development:
-  dev                   Start hot-reload dev server
+  dev [notebook.ipynb]  Start hot-reload dev server
   build                 Quick debug build (no DMG)
   build-e2e             Debug build with built-in WebDriver server
   run [notebook.ipynb]  Build and run debug app
@@ -62,7 +65,7 @@ Other:
     );
 }
 
-fn cmd_dev() {
+fn cmd_dev(notebook: Option<&str>) {
     println!("Starting dev server with hot reload...");
 
     // Check if CONDUCTOR_PORT is set and override devUrl accordingly
@@ -76,6 +79,9 @@ fn cmd_dev() {
         args.extend(["--config", config]);
     }
     args.extend(["--", "-p", "notebook"]);
+    if let Some(path) = notebook {
+        args.extend(["--", path]);
+    }
 
     run_cmd("cargo", &args);
 }


### PR DESCRIPTION
Developers can now pass an optional notebook path to `cargo xtask dev` to open a specific notebook with hot-reload enabled, matching the capability of `cargo xtask run`.

## Changes
- `cargo xtask dev [notebook.ipynb]` now accepts an optional notebook path argument
- Arguments are passed through to the app using Tauri's `-- [appArgs]` syntax
- Help text updated to document the new argument

## Test Plan
- [ ] Run `cargo xtask dev` without arguments (existing behavior unchanged)
- [ ] Run `cargo xtask dev /path/to/notebook.ipynb` and verify the notebook opens
- [ ] Verify hot-reload works with the notebook path argument

_PR submitted by @rgbkrk's agent, Quill_