### PR TITLE
Add daemon execution mode UI

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -86,6 +86,7 @@ function AppContent() {
     defaultCondaPackages,
     setDefaultCondaPackages,
     daemonExecution,
+    setDaemonExecution,
   } = useSyncedSettings();
 
   const {
@@ -777,6 +778,8 @@ function AppContent() {
         onDefaultUvPackagesChange={setDefaultUvPackages}
         defaultCondaPackages={defaultCondaPackages}
         onDefaultCondaPackagesChange={setDefaultCondaPackages}
+        daemonExecution={daemonExecution}
+        onDaemonExecutionChange={setDaemonExecution}
         onSave={save}
         onStartKernel={handleStartKernel}
         onInterruptKernel={interruptKernel}
@@ -899,6 +902,7 @@ function AppContent() {
         onApprove={handleTrustApprove}
         onDecline={handleTrustDecline}
         loading={trustLoading}
+        daemonMode={daemonExecution}
       />
       <NotebookView
         cells={cells}

--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -158,6 +158,9 @@ interface NotebookToolbarProps {
   onDefaultUvPackagesChange?: (packages: string[]) => void;
   defaultCondaPackages?: string[];
   onDefaultCondaPackagesChange?: (packages: string[]) => void;
+  /** Daemon execution mode (experimental) */
+  daemonExecution?: boolean;
+  onDaemonExecutionChange?: (enabled: boolean) => void;
   onSave: () => void;
   onStartKernel: (name: string) => void;
   onInterruptKernel: () => void;
@@ -293,6 +296,8 @@ export function NotebookToolbar({
   onDefaultUvPackagesChange,
   defaultCondaPackages = [],
   onDefaultCondaPackagesChange,
+  daemonExecution = false,
+  onDaemonExecutionChange,
   onSave,
   onStartKernel,
   onInterruptKernel,
@@ -798,6 +803,37 @@ export function NotebookToolbar({
                       </>
                     )}
                 </div>
+              </div>
+            )}
+
+            {/* Experimental settings */}
+            {onDaemonExecutionChange && (
+              <div className="space-y-2">
+                <div>
+                  <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+                    Experimental
+                  </span>
+                  <span className="ml-2 text-[10px] font-medium px-1.5 py-0.5 rounded bg-amber-500/15 text-amber-600 dark:text-amber-400">
+                    Beta
+                  </span>
+                </div>
+                <label className="flex items-start gap-3 cursor-pointer group">
+                  <input
+                    type="checkbox"
+                    checked={daemonExecution}
+                    onChange={(e) => onDaemonExecutionChange(e.target.checked)}
+                    className="mt-0.5 h-4 w-4 rounded border-muted-foreground/30 text-primary focus:ring-primary/50"
+                  />
+                  <div className="flex-1">
+                    <span className="text-xs font-medium text-foreground group-hover:text-primary transition-colors">
+                      Daemon Execution Mode
+                    </span>
+                    <p className="text-[11px] text-muted-foreground/70 mt-0.5">
+                      Kernel managed by daemon. Enables multi-window kernel
+                      sharing.
+                    </p>
+                  </div>
+                </label>
               </div>
             )}
           </div>

--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -14,6 +14,7 @@ import {
   X,
 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
   Collapsible,
   CollapsibleContent,
@@ -817,23 +818,28 @@ export function NotebookToolbar({
                     Beta
                   </span>
                 </div>
-                <label className="flex items-start gap-3 cursor-pointer group">
-                  <input
-                    type="checkbox"
+                <div className="flex items-start gap-3">
+                  <Checkbox
+                    id="daemon-execution-toggle"
                     checked={daemonExecution}
-                    onChange={(e) => onDaemonExecutionChange(e.target.checked)}
-                    className="mt-0.5 h-4 w-4 rounded border-muted-foreground/30 text-primary focus:ring-primary/50"
+                    onCheckedChange={(checked) =>
+                      onDaemonExecutionChange(checked === true)
+                    }
+                    className="mt-0.5"
                   />
-                  <div className="flex-1">
-                    <span className="text-xs font-medium text-foreground group-hover:text-primary transition-colors">
+                  <label
+                    htmlFor="daemon-execution-toggle"
+                    className="flex-1 cursor-pointer"
+                  >
+                    <span className="text-xs font-medium text-foreground hover:text-primary transition-colors">
                       Daemon Execution Mode
                     </span>
                     <p className="text-[11px] text-muted-foreground/70 mt-0.5">
                       Kernel managed by daemon. Enables multi-window kernel
                       sharing.
                     </p>
-                  </div>
-                </label>
+                  </label>
+                </div>
               </div>
             )}
           </div>

--- a/apps/notebook/src/components/TrustDialog.tsx
+++ b/apps/notebook/src/components/TrustDialog.tsx
@@ -19,6 +19,8 @@ interface TrustDialogProps {
   onApprove: () => Promise<boolean>;
   onDecline: () => void;
   loading?: boolean;
+  /** When true, shows daemon-specific messaging about auto-launch */
+  daemonMode?: boolean;
 }
 
 /** Package list item with optional typosquat warning */
@@ -51,6 +53,7 @@ export function TrustDialog({
   onApprove,
   onDecline,
   loading = false,
+  daemonMode = false,
 }: TrustDialogProps) {
   const handleApprove = useCallback(async () => {
     const success = await onApprove();
@@ -98,7 +101,9 @@ export function TrustDialog({
           <DialogDescription>
             {isSignatureInvalid
               ? "This notebook's dependencies have been modified since you last approved them. Review and approve to continue."
-              : "This notebook wants to install packages. Review them before running code."}
+              : daemonMode
+                ? "This notebook wants to install packages. Once approved, the kernel will start automatically."
+                : "This notebook wants to install packages. Review them before running code."}
           </DialogDescription>
         </DialogHeader>
 
@@ -167,7 +172,11 @@ export function TrustDialog({
             disabled={loading}
             data-testid="trust-approve-button"
           >
-            {loading ? "Approving..." : "Trust & Install"}
+            {loading
+              ? "Approving..."
+              : daemonMode
+                ? "Trust & Start"
+                : "Trust & Install"}
           </Button>
         </DialogFooter>
       </DialogContent>


### PR DESCRIPTION
## Summary

Add user-facing UI controls for daemon-only mode:
- Settings panel toggle to enable/disable daemon execution (experimental)
- Trust dialog shows daemon-specific context: "Once approved, kernel will start automatically"
- Button text updates: "Trust & Start" in daemon mode vs "Trust & Install" in local mode

This makes daemon-only mode discoverable and usable without manually editing settings.json.

## Verification

- [x] Toggle appears in Settings panel under "Experimental" section
- [x] Toggling updates daemon settings (persists across restart)
- [ ] Trust dialog shows appropriate text based on daemon mode
- [ ] Kernel auto-launches after trust approval in daemon mode
- [ ] Opening notebook in second window sees same setting

_PR submitted by @rgbkrk's agent, Quill_