### PR TITLE
Default daemon execution mode to enabled

### DIFF
--- a/crates/runtimed/src/settings_doc.rs
+++ b/crates/runtimed/src/settings_doc.rs
@@ -134,8 +134,13 @@ pub struct CondaDefaults {
     pub default_packages: Vec<String>,
 }
 
+/// Default value for daemon_execution setting (enabled by default for new installs).
+fn default_daemon_execution() -> bool {
+    true
+}
+
 /// Snapshot of all synced settings.
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq, JsonSchema, TS)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, JsonSchema, TS)]
 #[ts(export)]
 pub struct SyncedSettings {
     /// UI theme
@@ -158,11 +163,24 @@ pub struct SyncedSettings {
     #[serde(default)]
     pub conda: CondaDefaults,
 
-    /// Enable daemon-owned kernel execution (experimental).
+    /// Enable daemon-owned kernel execution.
     /// When enabled, the daemon manages kernel lifecycle and execution queue,
     /// enabling multi-window kernel sharing.
-    #[serde(default)]
+    #[serde(default = "default_daemon_execution")]
     pub daemon_execution: bool,
+}
+
+impl Default for SyncedSettings {
+    fn default() -> Self {
+        Self {
+            theme: ThemeMode::default(),
+            default_runtime: Runtime::default(),
+            default_python_env: PythonEnvType::default(),
+            uv: UvDefaults::default(),
+            conda: CondaDefaults::default(),
+            daemon_execution: true, // Enabled by default for new installs
+        }
+    }
 }
 
 /// Generate a JSON Schema string for the settings file.

--- a/src/bindings/SyncedSettings.ts
+++ b/src/bindings/SyncedSettings.ts
@@ -30,7 +30,7 @@ uv: UvDefaults,
  */
 conda: CondaDefaults, 
 /**
- * Enable daemon-owned kernel execution (experimental).
+ * Enable daemon-owned kernel execution.
  * When enabled, the daemon manages kernel lifecycle and execution queue,
  * enabling multi-window kernel sharing.
  */

--- a/src/hooks/useSyncedSettings.ts
+++ b/src/hooks/useSyncedSettings.ts
@@ -102,8 +102,8 @@ export function useSyncedSettings() {
   const [defaultCondaPackages, setDefaultCondaPackagesState] = useState<
     string[]
   >([]);
-  // Daemon execution mode (experimental)
-  const [daemonExecution, setDaemonExecutionState] = useState<boolean>(false);
+  // Daemon execution mode (enabled by default)
+  const [daemonExecution, setDaemonExecutionState] = useState<boolean>(true);
 
   // Load initial settings from daemon
   useEffect(() => {


### PR DESCRIPTION
## Summary

Enable daemon-only mode by default for new notebook installations. Existing users retain their settings; only new installs or fresh settings configurations default to daemon mode enabled.

Changes:
- Custom `Default` impl for `SyncedSettings` sets `daemon_execution: true`
- Serde deserialization defaults missing field to `true`
- Frontend initial state updated to match backend default

## Verification

- [ ] Verify new installation defaults to daemon mode enabled
- [ ] Confirm existing `settings.json` preserves user's setting
- [ ] Toggle still works via settings panel

_PR submitted by @rgbkrk's agent, Quill_