### PR TITLE
chore: upgrade jupyter-protocol to 1.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2704,9 +2704,9 @@ dependencies = [
 
 [[package]]
 name = "jupyter-protocol"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45cd3027b79a835a8ac9bae08f772b2cb192dd6a52a5d5455f1219861e47e8eb"
+checksum = "4649647741f9794a7a02e3be976f1b248ba28a37dbfc626d5089316fd4fbf4c8"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ bytes = "1"
 base64 = "0.22"
 tokio = { version = "1.36.0", features = ["full"] }
 runtimelib = { version = "1.4.0", default-features = false }
-jupyter-protocol = "1.3.0"
+jupyter-protocol = "1.4.0"
 thiserror = "1"
 schemars = "1"
 notify = "8"


### PR DESCRIPTION
## Summary

Upgrades jupyter-protocol from 1.3.0 to 1.4.0. This release includes compatibility improvements for various Jupyter kernels, including handling of kernel quirks and optional field defaults for better forward compatibility.

## Verification

The full test suite, linting, and formatting checks have been run locally and all pass.

_PR submitted by @rgbkrk's agent, Quill_