### PR TITLE
Add widget comm state sync for multi-window support

### DIFF
--- a/apps/notebook/src/hooks/useDaemonKernel.ts
+++ b/apps/notebook/src/hooks/useDaemonKernel.ts
@@ -212,9 +212,12 @@ export function useDaemonKernel({
             // Initial comm state sync from daemon for multi-window widget reconstruction
             // Replay all comms as comm_open messages to the widget store
             const { onCommMessage } = callbacksRef.current;
+            console.log(
+              `[daemon-kernel] Received comm_sync event with ${broadcast.comms?.length ?? 0} comms, handler=${!!onCommMessage}`,
+            );
             if (onCommMessage && broadcast.comms) {
               console.log(
-                `[daemon-kernel] Received comm_sync with ${broadcast.comms.length} comms`,
+                `[daemon-kernel] Processing comm_sync: replaying ${broadcast.comms.length} comms`,
               );
               for (const comm of broadcast.comms) {
                 // Synthesize a comm_open message for each active comm
@@ -243,8 +246,19 @@ export function useDaemonKernel({
                 };
                 onCommMessage(msg);
               }
+            } else if (!onCommMessage) {
+              console.warn(
+                "[daemon-kernel] comm_sync received but onCommMessage not set!",
+              );
             }
             break;
+          }
+
+          default: {
+            // Log unknown events to help debug unexpected broadcast types
+            console.log(
+              `[daemon-kernel] Unknown broadcast event: ${(broadcast as { event: string }).event}`,
+            );
           }
         }
       },

--- a/apps/notebook/src/types.ts
+++ b/apps/notebook/src/types.ts
@@ -132,6 +132,16 @@ export interface EnvironmentYmlInfo {
 // Daemon Broadcast Types (Phase 8: Daemon-owned kernel execution)
 // =============================================================================
 
+/** Snapshot of a comm channel's state for multi-window sync */
+export interface CommSnapshot {
+  comm_id: string;
+  target_name: string;
+  state: Record<string, unknown>;
+  model_module?: string;
+  model_name?: string;
+  buffers?: number[][];
+}
+
 /** Broadcast events from daemon for kernel operations */
 export type DaemonBroadcast =
   | {
@@ -178,6 +188,10 @@ export type DaemonBroadcast =
       msg_type: string; // "comm_open" | "comm_msg" | "comm_close"
       content: Record<string, unknown>;
       buffers: number[][]; // Binary buffers as byte arrays
+    }
+  | {
+      event: "comm_sync";
+      comms: CommSnapshot[]; // All active comms for widget reconstruction
     };
 
 /** Response types from daemon notebook requests */

--- a/crates/runtimed/src/comm_state.rs
+++ b/crates/runtimed/src/comm_state.rs
@@ -1,0 +1,293 @@
+//! Comm channel state tracking for widget synchronization.
+//!
+//! This module manages the state of active Jupyter comm channels (used by ipywidgets).
+//! When a new client connects to a notebook room, the stored comm state is sent to allow
+//! the client to reconstruct widget models that were created before it connected.
+//!
+//! ## Comm Protocol Overview
+//!
+//! The Jupyter comm protocol uses three message types:
+//! - `comm_open`: Creates a new comm channel with initial state
+//! - `comm_msg`: Sends updates or custom messages on the channel
+//! - `comm_close`: Closes the channel
+//!
+//! For widgets, the `comm_open` establishes the model with initial state, and
+//! `comm_msg` with `method: "update"` sends state deltas.
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use tokio::sync::RwLock;
+
+/// A snapshot of a comm channel's state.
+///
+/// This is stored in the daemon and sent to newly connected clients so they can
+/// reconstruct widget models that were created before they connected.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommSnapshot {
+    /// The comm_id (unique identifier for this comm channel).
+    pub comm_id: String,
+
+    /// Target name (e.g., "jupyter.widget", "jupyter.widget.version").
+    pub target_name: String,
+
+    /// Current state snapshot (merged from all updates).
+    /// For widgets, this contains the full model state.
+    pub state: serde_json::Value,
+
+    /// Model module (e.g., "@jupyter-widgets/controls", "anywidget").
+    /// Extracted from `_model_module` in state for convenience.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model_module: Option<String>,
+
+    /// Model name (e.g., "IntSliderModel", "AnyModel").
+    /// Extracted from `_model_name` in state for convenience.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model_name: Option<String>,
+
+    /// Binary buffers associated with this comm (e.g., for images, arrays).
+    /// Stored inline for simplicity; large buffers could be moved to blob store.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub buffers: Vec<Vec<u8>>,
+}
+
+/// Thread-safe storage for active comm channels.
+///
+/// Tracks all active comm channels in a notebook room, allowing new clients
+/// to receive the current state and reconstruct widget models.
+pub struct CommState {
+    /// Active comms: comm_id -> CommSnapshot
+    comms: RwLock<HashMap<String, CommSnapshot>>,
+}
+
+impl CommState {
+    /// Create a new empty comm state.
+    pub fn new() -> Self {
+        Self {
+            comms: RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// Handle a `comm_open` message: create new comm entry.
+    ///
+    /// Extracts model info from the data payload and stores the initial state.
+    pub async fn on_comm_open(
+        &self,
+        comm_id: &str,
+        target_name: &str,
+        data: &serde_json::Value,
+        buffers: Vec<Vec<u8>>,
+    ) {
+        // Extract state from the data object (ipywidgets puts state in data.state)
+        let state = data
+            .get("state")
+            .cloned()
+            .unwrap_or_else(|| serde_json::json!({}));
+
+        // Extract model info from state for convenience
+        let model_module = state
+            .get("_model_module")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+
+        let model_name = state
+            .get("_model_name")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+
+        let snapshot = CommSnapshot {
+            comm_id: comm_id.to_string(),
+            target_name: target_name.to_string(),
+            state,
+            model_module,
+            model_name,
+            buffers,
+        };
+
+        let mut comms = self.comms.write().await;
+        comms.insert(comm_id.to_string(), snapshot);
+    }
+
+    /// Handle a `comm_msg` with `method: "update"`: merge state delta.
+    ///
+    /// Updates only the keys present in the delta, preserving other state.
+    pub async fn on_comm_update(&self, comm_id: &str, state_delta: &serde_json::Value) {
+        let mut comms = self.comms.write().await;
+
+        if let Some(snapshot) = comms.get_mut(comm_id) {
+            // Merge delta into existing state
+            if let (Some(existing), Some(delta)) =
+                (snapshot.state.as_object_mut(), state_delta.as_object())
+            {
+                for (key, value) in delta {
+                    existing.insert(key.clone(), value.clone());
+                }
+            }
+        }
+        // If comm doesn't exist, ignore the update (might be out-of-order)
+    }
+
+    /// Handle a `comm_close` message: remove comm entry.
+    pub async fn on_comm_close(&self, comm_id: &str) {
+        let mut comms = self.comms.write().await;
+        comms.remove(comm_id);
+    }
+
+    /// Get all active comm snapshots.
+    ///
+    /// Used to send current state to newly connected clients.
+    pub async fn get_all(&self) -> Vec<CommSnapshot> {
+        let comms = self.comms.read().await;
+        comms.values().cloned().collect()
+    }
+
+    /// Clear all comm state.
+    ///
+    /// Called when the kernel shuts down, as all widgets become invalid.
+    pub async fn clear(&self) {
+        let mut comms = self.comms.write().await;
+        comms.clear();
+    }
+
+    /// Check if there are any active comms.
+    pub async fn is_empty(&self) -> bool {
+        let comms = self.comms.read().await;
+        comms.is_empty()
+    }
+}
+
+impl Default for CommState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_comm_open_creates_entry() {
+        let state = CommState::new();
+        let widget_state = serde_json::json!({
+            "state": {
+                "_model_name": "IntSliderModel",
+                "_model_module": "@jupyter-widgets/controls",
+                "value": 50,
+                "min": 0,
+                "max": 100
+            }
+        });
+
+        state
+            .on_comm_open("comm-1", "jupyter.widget", &widget_state, vec![])
+            .await;
+
+        let comms = state.get_all().await;
+        assert_eq!(comms.len(), 1);
+        assert_eq!(comms[0].comm_id, "comm-1");
+        assert_eq!(comms[0].target_name, "jupyter.widget");
+        assert_eq!(comms[0].model_name, Some("IntSliderModel".to_string()));
+        assert_eq!(
+            comms[0].model_module,
+            Some("@jupyter-widgets/controls".to_string())
+        );
+        assert_eq!(comms[0].state["value"], 50);
+    }
+
+    #[tokio::test]
+    async fn test_comm_update_merges_state() {
+        let state = CommState::new();
+        state
+            .on_comm_open(
+                "comm-1",
+                "jupyter.widget",
+                &serde_json::json!({
+                    "state": {"value": 0, "min": 0, "max": 100}
+                }),
+                vec![],
+            )
+            .await;
+
+        state
+            .on_comm_update("comm-1", &serde_json::json!({"value": 50}))
+            .await;
+
+        let comms = state.get_all().await;
+        assert_eq!(comms[0].state["value"], 50);
+        assert_eq!(comms[0].state["min"], 0); // preserved
+        assert_eq!(comms[0].state["max"], 100); // preserved
+    }
+
+    #[tokio::test]
+    async fn test_comm_close_removes_entry() {
+        let state = CommState::new();
+        state
+            .on_comm_open(
+                "comm-1",
+                "jupyter.widget",
+                &serde_json::json!({"state": {}}),
+                vec![],
+            )
+            .await;
+
+        assert!(!state.is_empty().await);
+        state.on_comm_close("comm-1").await;
+        assert!(state.is_empty().await);
+    }
+
+    #[tokio::test]
+    async fn test_clear_removes_all_entries() {
+        let state = CommState::new();
+        state
+            .on_comm_open(
+                "comm-1",
+                "jupyter.widget",
+                &serde_json::json!({"state": {}}),
+                vec![],
+            )
+            .await;
+        state
+            .on_comm_open(
+                "comm-2",
+                "jupyter.widget",
+                &serde_json::json!({"state": {}}),
+                vec![],
+            )
+            .await;
+
+        assert_eq!(state.get_all().await.len(), 2);
+        state.clear().await;
+        assert!(state.is_empty().await);
+    }
+
+    #[tokio::test]
+    async fn test_update_nonexistent_comm_is_ignored() {
+        let state = CommState::new();
+
+        // Update for a comm that doesn't exist should not panic
+        state
+            .on_comm_update("nonexistent", &serde_json::json!({"value": 42}))
+            .await;
+
+        assert!(state.is_empty().await);
+    }
+
+    #[tokio::test]
+    async fn test_buffers_are_stored() {
+        let state = CommState::new();
+        let buffers = vec![vec![1, 2, 3], vec![4, 5, 6]];
+
+        state
+            .on_comm_open(
+                "comm-1",
+                "jupyter.widget",
+                &serde_json::json!({"state": {}}),
+                buffers.clone(),
+            )
+            .await;
+
+        let comms = state.get_all().await;
+        assert_eq!(comms[0].buffers, buffers);
+    }
+}

--- a/crates/runtimed/src/lib.rs
+++ b/crates/runtimed/src/lib.rs
@@ -16,6 +16,7 @@ use sha2::{Digest, Sha256};
 pub mod blob_server;
 pub mod blob_store;
 pub mod client;
+pub mod comm_state;
 pub mod connection;
 pub mod daemon;
 pub mod kernel_manager;

--- a/crates/runtimed/src/notebook_sync_client.rs
+++ b/crates/runtimed/src/notebook_sync_client.rs
@@ -512,14 +512,21 @@ where
                         }
                         NotebookFrameType::Broadcast => {
                             // Queue broadcasts to deliver after sync completes
-                            if let Ok(broadcast) =
-                                serde_json::from_slice::<NotebookBroadcast>(&frame.payload)
-                            {
-                                info!(
-                                    "[notebook-sync-client] Received broadcast during init: {:?}",
-                                    broadcast
-                                );
-                                pending_broadcasts.push(broadcast);
+                            match serde_json::from_slice::<NotebookBroadcast>(&frame.payload) {
+                                Ok(broadcast) => {
+                                    info!(
+                                        "[notebook-sync-client] Received broadcast during init: {:?}",
+                                        broadcast
+                                    );
+                                    pending_broadcasts.push(broadcast);
+                                }
+                                Err(e) => {
+                                    warn!(
+                                        "[notebook-sync-client] Failed to deserialize broadcast: {} (payload: {} bytes)",
+                                        e,
+                                        frame.payload.len()
+                                    );
+                                }
                             }
                         }
                         NotebookFrameType::Response => {

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -693,6 +693,9 @@ async fn auto_launch_kernel(
         return;
     }
 
+    // Clear any stale comm state from a previous kernel (in case it crashed)
+    room.comm_state.clear().await;
+
     // Create new kernel
     let mut kernel = RoomKernel::new(
         room.kernel_broadcast_tx.clone(),
@@ -830,6 +833,9 @@ async fn handle_notebook_request(
                     };
                 }
             }
+
+            // Clear any stale comm state from a previous kernel (in case it crashed)
+            room.comm_state.clear().await;
 
             // Create new kernel
             let mut kernel = RoomKernel::new(


### PR DESCRIPTION
## Summary

Track active comm channels in daemon and send `CommSync` broadcast to newly connected clients, enabling widget reconstruction in secondary windows.

Fixes #276

## Changes

- Add `CommState` module for tracking `comm_open`/`msg`/`close` messages
- Wire `CommState` into `NotebookRoom` and kernel manager's iopub handler
- Send `CommSync` broadcast after initial Automerge sync on client connect
- Handle `comm_sync` in frontend to synthesize `comm_open` messages for widget store
- Clear comm state on kernel shutdown

## Known Limitations (WIP)

- Third window opened after execution may not receive `comm_sync` (needs investigation - may be timing issue with broadcast delivery)
- Widget state not synced in real-time between windows (by design - avoids feedback loops during slider drag)
- Buffer paths not fully reconstructed - binary widget state may not hydrate correctly
- Replay order nondeterministic (`HashMap` iteration) - model dependencies may not resolve correctly

## Test plan

- [x] Unit tests for CommState (open, update, close, clear, buffers)
- [x] Protocol test for CommSync serialization
- [x] Manual test: open notebook, create widget, open second window
- [ ] Manual test: open third window after widget creation
- [ ] E2E test for multi-window widget sync

Co-authored-by: QuillAid <261289082+quillaid@users.noreply.github.com>