### PR TITLE
Fix prewarm pool doom loop on invalid default packages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5159,6 +5159,7 @@ dependencies = [
  "rattler_repodata_gateway",
  "rattler_solve",
  "rattler_virtual_packages",
+ "regex",
  "reqwest 0.12.28",
  "reqwest-middleware",
  "runt-trust",

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -98,12 +98,18 @@ fn shorten_path(path: &std::path::Path) -> String {
 }
 
 /// Truncate an error message for display, replacing newlines with spaces.
+/// Uses char boundaries to avoid panics on non-ASCII text.
 fn truncate_error(msg: &str, max_len: usize) -> String {
     let single_line = msg.replace('\n', " ");
-    if single_line.len() <= max_len {
+    if max_len < 4 {
+        return single_line.chars().take(max_len).collect();
+    }
+    let char_count = single_line.chars().count();
+    if char_count <= max_len {
         single_line
     } else {
-        format!("{}...", &single_line[..max_len - 3])
+        let truncated: String = single_line.chars().take(max_len - 3).collect();
+        format!("{}...", truncated)
     }
 }
 

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -97,6 +97,16 @@ fn shorten_path(path: &std::path::Path) -> String {
     path.display().to_string()
 }
 
+/// Truncate an error message for display, replacing newlines with spaces.
+fn truncate_error(msg: &str, max_len: usize) -> String {
+    let single_line = msg.replace('\n', " ");
+    if single_line.len() <= max_len {
+        single_line
+    } else {
+        format!("{}...", &single_line[..max_len - 3])
+    }
+}
+
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
 struct Cli {
@@ -1217,9 +1227,29 @@ async fn pool_command(command: PoolCommands) -> Result<()> {
                     println!("UV environments:");
                     println!("  Available: {}", stats.uv_available);
                     println!("  Warming:   {}", stats.uv_warming);
+                    if let Some(ref err) = stats.uv_error {
+                        println!("  ERROR:     {}", truncate_error(&err.message, 60));
+                        if let Some(ref pkg) = err.failed_package {
+                            println!("  Failed package: {}", pkg);
+                        }
+                        println!(
+                            "  Failures:  {} (retry in {}s)",
+                            err.consecutive_failures, err.retry_in_secs
+                        );
+                    }
                     println!("Conda environments:");
                     println!("  Available: {}", stats.conda_available);
                     println!("  Warming:   {}", stats.conda_warming);
+                    if let Some(ref err) = stats.conda_error {
+                        println!("  ERROR:     {}", truncate_error(&err.message, 60));
+                        if let Some(ref pkg) = err.failed_package {
+                            println!("  Failed package: {}", pkg);
+                        }
+                        println!(
+                            "  Failures:  {} (retry in {}s)",
+                            err.consecutive_failures, err.retry_in_secs
+                        );
+                    }
                 }
             }
             Err(e) => {

--- a/crates/runtimed/Cargo.toml
+++ b/crates/runtimed/Cargo.toml
@@ -51,6 +51,9 @@ reqwest-middleware = "0.4"
 sha2 = "0.10"
 hex = "0.4"
 
+# Error parsing
+regex = "1"
+
 # HTTP blob server
 hyper = { version = "1", features = ["http1", "server"] }
 http-body-util = "0.1"

--- a/crates/runtimed/src/client.rs
+++ b/crates/runtimed/src/client.rs
@@ -458,6 +458,109 @@ pub enum EnsureDaemonError {
     DevDaemonNotRunning(std::path::PathBuf),
 }
 
+// =============================================================================
+// Pool State Subscription
+// =============================================================================
+
+/// Subscribe to pool state changes from the daemon.
+///
+/// Returns a receiver that yields `DaemonBroadcast::PoolState` messages whenever
+/// the pool error state changes (new error, error cleared, etc.).
+///
+/// The first message is always the current state. Subsequent messages are sent
+/// when the state changes.
+///
+/// # Example
+///
+/// ```ignore
+/// let mut rx = subscribe_pool_state().await?;
+/// while let Some(broadcast) = rx.recv().await {
+///     match broadcast {
+///         DaemonBroadcast::PoolState { uv_error, conda_error } => {
+///             if let Some(err) = uv_error {
+///                 eprintln!("UV pool error: {}", err.message);
+///             }
+///         }
+///     }
+/// }
+/// ```
+pub async fn subscribe_pool_state(
+) -> Result<tokio::sync::mpsc::Receiver<crate::protocol::DaemonBroadcast>, ClientError> {
+    let socket_path = default_socket_path();
+    let connect_timeout = Duration::from_secs(2);
+
+    #[cfg(unix)]
+    let stream = {
+        let connect_result = tokio::time::timeout(
+            connect_timeout,
+            tokio::net::UnixStream::connect(&socket_path),
+        )
+        .await;
+
+        match connect_result {
+            Ok(Ok(s)) => s,
+            Ok(Err(e)) => return Err(ClientError::ConnectionFailed(e)),
+            Err(_) => return Err(ClientError::Timeout),
+        }
+    };
+
+    #[cfg(windows)]
+    let stream = {
+        let pipe_name = socket_path.to_string_lossy().to_string();
+        let connect_result = tokio::time::timeout(connect_timeout, async {
+            let mut attempts = 0;
+            loop {
+                match ClientOptions::new().open(&pipe_name) {
+                    Ok(client) => return Ok(client),
+                    Err(_) if attempts < 5 => {
+                        attempts += 1;
+                        tokio::time::sleep(Duration::from_millis(50)).await;
+                    }
+                    Err(e) => return Err(e),
+                }
+            }
+        })
+        .await;
+
+        match connect_result {
+            Ok(Ok(s)) => s,
+            Ok(Err(e)) => return Err(ClientError::ConnectionFailed(e)),
+            Err(_) => return Err(ClientError::Timeout),
+        }
+    };
+
+    // Send the handshake
+    let mut stream = stream;
+    connection::send_json_frame(&mut stream, &Handshake::PoolStateSubscribe)
+        .await
+        .map_err(|e| ClientError::ProtocolError(format!("handshake: {}", e)))?;
+
+    // Create a channel to forward broadcasts to the caller
+    let (tx, rx) = tokio::sync::mpsc::channel(16);
+
+    // Spawn a task to read broadcasts and forward them
+    tokio::spawn(async move {
+        loop {
+            match connection::recv_json_frame::<_, crate::protocol::DaemonBroadcast>(&mut stream)
+                .await
+            {
+                Ok(Some(broadcast)) => {
+                    if tx.send(broadcast).await.is_err() {
+                        break; // Receiver dropped
+                    }
+                }
+                Ok(None) => break, // Connection closed
+                Err(e) => {
+                    warn!("[pool-client] Error receiving pool state: {}", e);
+                    break;
+                }
+            }
+        }
+    });
+
+    Ok(rx)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/runtimed/src/connection.rs
+++ b/crates/runtimed/src/connection.rs
@@ -56,6 +56,9 @@ pub enum Handshake {
     },
     /// Blob store: write blobs, query port.
     Blob,
+    /// Pool state subscription: receive broadcasts when pool errors occur/clear.
+    /// Read-only channel - server pushes DaemonBroadcast messages to client.
+    PoolStateSubscribe,
 }
 
 /// Protocol version constants.

--- a/crates/runtimed/src/lib.rs
+++ b/crates/runtimed/src/lib.rs
@@ -166,6 +166,26 @@ pub struct PoolStats {
     pub uv_warming: usize,
     pub conda_available: usize,
     pub conda_warming: usize,
+    /// Error info for UV pool (if warming is failing).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub uv_error: Option<PoolError>,
+    /// Error info for Conda pool (if warming is failing).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub conda_error: Option<PoolError>,
+}
+
+/// Error information for a pool that is failing to warm.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PoolError {
+    /// Human-readable error message.
+    pub message: String,
+    /// Package that failed to install (if identified).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failed_package: Option<String>,
+    /// Number of consecutive failures.
+    pub consecutive_failures: u32,
+    /// Seconds until next retry (0 if retry is imminent).
+    pub retry_in_secs: u64,
 }
 
 /// Get the default endpoint path for runtimed.


### PR DESCRIPTION
## Summary

Fixes issue #264 where typos in `uv.default_packages` cause the daemon to enter a doom loop with misleading error messages and constant retries. The pool now fails fast with clear error identification and implements exponential backoff.

## Changes

- **Error Parsing**: Captures UV stderr and parses error output to identify the specific package that failed to resolve
- **Exponential Backoff**: Implements backoff strategy (30s → 60s → 120s → 240s → 300s max) to reduce log spam and resource waste
- **Settings Change Detection**: Resets backoff when settings.json changes, allowing users to fix typos and immediately retry
- **Live Broadcasting**: Broadcasts pool state changes to all connected clients for UI visibility
- **CLI Status**: `runt pool status` now displays error details and retry countdown

## Architecture

The solution adds three layers:
1. **Error Tracking**: `FailureState` struct in `Pool` tracks consecutive failures with exponential backoff calculation
2. **Broadcast Infrastructure**: `DaemonBroadcast::PoolState` subscription channel for real-time error visibility across clients
3. **User Feedback**: Error details available via `pool status` CLI and live broadcasts to connected notebook windows

## Verification

- Run `cargo xtask dev-daemon` and add a typo'd package to settings:
  ```bash
  echo '{"uv":{"default_packages":["scitkit-learn"]}}' > ~/.config/runt-notebook/settings.json
  ```
- Observe daemon logs show clear package name and exponential backoff (not constant 30s retries)
- Verify `runt pool status` displays error state with retry countdown
- Fix the typo and confirm backoff resets immediately

Closes #264

_PR submitted by @rgbkrk's agent, Quill_