### PR TITLE
Fix E2E tests for daemon mode with worktree isolation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -210,8 +210,10 @@ jobs:
           # Start runtimed early so the pool fills while the Tauri app builds (~90s).
           # uv-pool-size 6 gives headroom for sequential fixture tests.
           # conda-pool-size 0 because conda fixture tests create inline environments.
-          # Explicitly pass PATH so the background process can find uv.
-          env PATH="$PATH" ./target/release/runtimed run --uv-pool-size 6 --conda-pool-size 0 &
+          # Use --dev mode with CONDUCTOR_WORKSPACE_PATH for isolated worktree paths.
+          # This ensures daemon and app use the same isolated socket/settings.
+          env PATH="$PATH" CONDUCTOR_WORKSPACE_PATH="${GITHUB_WORKSPACE}" \
+            ./target/release/runtimed --dev run --uv-pool-size 6 --conda-pool-size 0 &
           echo "RUNTIMED_PID=$!" >> $GITHUB_ENV
 
       - name: Build Tauri app
@@ -338,6 +340,8 @@ jobs:
           exit $FAIL
         env:
           TAURI_APP_PATH: ./target/release/notebook
+          # Enable worktree isolation so daemon and app use same isolated paths
+          CONDUCTOR_WORKSPACE_PATH: ${{ github.workspace }}
           # Suppress accessibility bus warnings in headless CI
           NO_AT_BRIDGE: 1
           # Use software rendering to suppress GPU/EGL warnings

--- a/apps/notebook/src/components/DaemonUnavailableBanner.tsx
+++ b/apps/notebook/src/components/DaemonUnavailableBanner.tsx
@@ -1,0 +1,32 @@
+import { AlertTriangle, X } from "lucide-react";
+
+interface DaemonUnavailableBannerProps {
+  message: string;
+  guidance: string;
+  onDismiss: () => void;
+}
+
+export function DaemonUnavailableBanner({
+  message,
+  guidance,
+  onDismiss,
+}: DaemonUnavailableBannerProps) {
+  return (
+    <div className="flex items-center justify-between gap-3 bg-red-600/90 px-3 py-2 text-sm text-white">
+      <div className="flex items-center gap-2">
+        <AlertTriangle className="h-4 w-4 flex-shrink-0" />
+        <span className="font-medium">{message}</span>
+        <span className="text-red-200">—</span>
+        <span className="text-red-100">{guidance}</span>
+      </div>
+      <button
+        type="button"
+        onClick={onDismiss}
+        className="rounded p-1 hover:bg-red-500/50 transition-colors"
+        aria-label="Dismiss"
+      >
+        <X className="h-4 w-4" />
+      </button>
+    </div>
+  );
+}

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -4018,6 +4018,11 @@ pub fn run(
     let uv_recovery_complete = Arc::new(AtomicBool::new(false));
     let conda_recovery_complete = Arc::new(AtomicBool::new(false));
 
+    // Daemon sync completion flag - set when notebook sync initialization completes
+    // Used to coordinate auto-launch decision with daemon connection status
+    let daemon_sync_complete = Arc::new(AtomicBool::new(false));
+    let daemon_sync_success = Arc::new(AtomicBool::new(false));
+
     // Clone for setup closure
     let queue_for_processor = queue.clone();
     let notebook_for_processor = notebook_state.clone();
@@ -4045,6 +4050,12 @@ pub fn run(
     // Clone for notebook sync initialization
     let notebook_for_sync = notebook_state.clone();
     let notebook_sync_for_init = notebook_sync.clone();
+    let daemon_sync_complete_for_init = daemon_sync_complete.clone();
+    let daemon_sync_success_for_init = daemon_sync_success.clone();
+
+    // Clone for auto-launch coordination
+    let daemon_sync_complete_for_autolaunch = daemon_sync_complete.clone();
+    let daemon_sync_success_for_autolaunch = daemon_sync_success.clone();
 
     let app = tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
@@ -4240,16 +4251,24 @@ pub fn run(
 
                 // Initialize notebook sync if daemon is available
                 if daemon_available {
-                    if let Err(e) = initialize_notebook_sync(
+                    match initialize_notebook_sync(
                         app_for_notebook_sync,
                         notebook_for_sync,
                         notebook_sync_for_init,
                     )
                     .await
                     {
-                        log::warn!("[startup] Notebook sync initialization failed: {}", e);
+                        Ok(()) => {
+                            log::info!("[startup] Notebook sync initialized successfully");
+                            daemon_sync_success_for_init.store(true, Ordering::SeqCst);
+                        }
+                        Err(e) => {
+                            log::warn!("[startup] Notebook sync initialization failed: {}", e);
+                        }
                     }
                 }
+                // Signal that daemon sync attempt is complete (success or failure)
+                daemon_sync_complete_for_init.store(true, Ordering::SeqCst);
             });
 
             // Spawn the UV environment prewarming loop
@@ -4264,7 +4283,7 @@ pub fn run(
             });
 
             // Auto-launch kernel for faster startup (only if trusted)
-            // Skip if daemon_execution is enabled - the daemon handles auto-launch
+            // Skip if daemon_execution is enabled AND daemon sync succeeded
             log::info!("[startup] Setup complete in {}ms, spawning auto-launch task", setup_start.elapsed().as_millis());
             let app_for_autolaunch = app.handle().clone();
             tauri::async_runtime::spawn(async move {
@@ -4273,11 +4292,45 @@ pub fn run(
                 // Load user's preferred Python environment type
                 let app_settings = settings::load_settings();
 
-                // Skip local auto-launch if daemon execution is enabled
-                // The daemon handles auto-launch when daemon_execution is true
+                // If daemon_execution is enabled, wait for daemon sync to complete (with timeout)
+                // before deciding whether to skip local auto-launch
                 if app_settings.daemon_execution {
-                    log::info!("[autolaunch] Skipping local auto-launch (daemon_execution enabled)");
-                    return;
+                    log::info!("[autolaunch] Daemon execution enabled, waiting for daemon sync...");
+
+                    // Wait up to 5 seconds for daemon sync to complete
+                    let sync_timeout = tokio::time::timeout(
+                        std::time::Duration::from_secs(5),
+                        async {
+                            while !daemon_sync_complete_for_autolaunch.load(Ordering::SeqCst) {
+                                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                            }
+                        },
+                    )
+                    .await;
+
+                    let sync_wait_ms = autolaunch_start.elapsed().as_millis();
+
+                    if sync_timeout.is_err() {
+                        log::warn!(
+                            "[autolaunch] Daemon sync timed out after {}ms, falling back to local auto-launch",
+                            sync_wait_ms
+                        );
+                        // Continue to local auto-launch
+                    } else if daemon_sync_success_for_autolaunch.load(Ordering::SeqCst) {
+                        // Daemon sync succeeded - let daemon handle auto-launch
+                        log::info!(
+                            "[autolaunch] Daemon sync succeeded in {}ms, daemon handles auto-launch",
+                            sync_wait_ms
+                        );
+                        return;
+                    } else {
+                        // Daemon sync completed but failed - fall back to local auto-launch
+                        log::warn!(
+                            "[autolaunch] Daemon sync failed after {}ms, falling back to local auto-launch",
+                            sync_wait_ms
+                        );
+                        // Continue to local auto-launch
+                    }
                 }
 
                 let prefer_conda = matches!(app_settings.default_python_env, settings::PythonEnvType::Conda);

--- a/e2e/dev.sh
+++ b/e2e/dev.sh
@@ -6,6 +6,12 @@ set -e
 PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 BINARY="$PROJECT_ROOT/target/debug/notebook"
 
+# Enable worktree isolation for E2E tests
+# This ensures the daemon and app use isolated paths (socket, settings, envs)
+# so E2E tests don't interfere with your regular development environment.
+# The daemon and app will use ~/.cache/runt/worktrees/{hash}/ instead of ~/.cache/runt/
+export CONDUCTOR_WORKSPACE_PATH="$PROJECT_ROOT"
+
 # Source .env for default config (port, etc.)
 if [ -f "$PROJECT_ROOT/e2e/.env" ]; then
   set -a; source "$PROJECT_ROOT/e2e/.env"; set +a


### PR DESCRIPTION
## Summary

- Enable worktree isolation in CI using `CONDUCTOR_WORKSPACE_PATH` so daemon and app use the same isolated paths
- Fix race condition between daemon sync and auto-launch tasks by waiting for sync completion before deciding
- Add worktree isolation to local E2E script (`e2e/dev.sh`) for consistent behavior

## Background

With daemon_execution defaulting to true (#291), E2E tests were failing because the auto-launch task could skip local auto-launch before daemon sync completed, leaving no kernel running.

## Changes

**CI Isolation** (`.github/workflows/build.yml`)
- Set `CONDUCTOR_WORKSPACE_PATH=${{ github.workspace }}` for daemon and E2E tests
- Use `--dev` mode for daemon to enable worktree isolation

**Race Condition Fix** (`crates/notebook/src/lib.rs`)
- Add `daemon_sync_complete` and `daemon_sync_success` flags
- Auto-launch task waits up to 5s for daemon sync before deciding
- Falls back to local auto-launch if daemon sync fails or times out

**Local E2E Isolation** (`e2e/dev.sh`)
- Set `CONDUCTOR_WORKSPACE_PATH` for local E2E testing
- Tests use isolated paths, won't interfere with development environment

## Verification

- [ ] E2E tests pass in CI with daemon mode enabled
- [ ] Local E2E tests work with `./e2e/dev.sh test-fixtures`
- [ ] Check logs for expected daemon sync messages

_PR submitted by @rgbkrk's agent, Quill_