### PR TITLE
Show daemon progress during first-launch setup

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -700,6 +700,19 @@ function AppContent() {
       <DaemonStatusBanner
         status={daemonStatus}
         onDismiss={() => setDaemonStatus(null)}
+        onRetry={() => {
+          setDaemonStatus({ status: "checking" });
+          invoke("reconnect_to_daemon")
+            .then(() => {
+              // Success - daemon:ready event will clear the banner
+            })
+            .catch((e) => {
+              setDaemonStatus({
+                status: "failed",
+                error: `Reconnection failed: ${e}`,
+              });
+            });
+        }}
       />
       <NotebookToolbar
         kernelStatus={kernelStatus}

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -640,8 +640,8 @@ function AppContent() {
 
     // Listen for daemon ready (reconnection success)
     const unlistenReady = listen("daemon:ready", () => {
-      // Clear any error banner when daemon reconnects
-      setDaemonStatus((prev) => (prev?.status === "failed" ? null : prev));
+      // Clear any status banner when daemon reconnects (failed, checking, etc.)
+      setDaemonStatus(null);
     });
 
     // Check daemon status on mount (in case events fired before React was ready)

--- a/apps/notebook/src/components/DaemonStatusBanner.tsx
+++ b/apps/notebook/src/components/DaemonStatusBanner.tsx
@@ -1,0 +1,92 @@
+import { AlertTriangle, Loader2, X } from "lucide-react";
+
+/**
+ * Status of the daemon during startup or operation.
+ * Matches the DaemonProgress enum from Rust.
+ */
+export type DaemonStatus =
+  | { status: "checking" }
+  | { status: "installing" }
+  | { status: "upgrading" }
+  | { status: "starting" }
+  | { status: "waiting_for_ready"; attempt: number; max_attempts: number }
+  | { status: "ready"; endpoint: string }
+  | { status: "failed"; error: string }
+  | null;
+
+interface DaemonStatusBannerProps {
+  status: DaemonStatus;
+  onDismiss?: () => void;
+}
+
+/**
+ * Banner component showing daemon startup progress or errors.
+ *
+ * Shows different visual states:
+ * - Blue/info with spinner: Installing, upgrading, starting, waiting
+ * - Red/error: Failed state with dismissible error message
+ * - Hidden: Ready state or null
+ */
+export function DaemonStatusBanner({
+  status,
+  onDismiss,
+}: DaemonStatusBannerProps) {
+  // Don't show banner for ready or null state
+  if (!status || status.status === "ready") {
+    return null;
+  }
+
+  // Failed state - red banner with error message
+  if (status.status === "failed") {
+    return (
+      <div className="flex items-center justify-between gap-3 bg-red-600/90 px-3 py-2 text-sm text-white">
+        <div className="flex items-center gap-2">
+          <AlertTriangle className="h-4 w-4 flex-shrink-0" />
+          <span className="font-medium">Runtime unavailable</span>
+          <span className="text-red-200">—</span>
+          <span className="text-red-100">{status.error}</span>
+        </div>
+        {onDismiss && (
+          <button
+            type="button"
+            onClick={onDismiss}
+            className="rounded p-1 hover:bg-red-500/50 transition-colors"
+            aria-label="Dismiss"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        )}
+      </div>
+    );
+  }
+
+  // Progress states - blue banner with spinner
+  const message = getProgressMessage(status);
+
+  return (
+    <div className="flex items-center gap-2 bg-blue-600/90 px-3 py-2 text-sm text-white">
+      <Loader2 className="h-4 w-4 animate-spin flex-shrink-0" />
+      <span>{message}</span>
+    </div>
+  );
+}
+
+function getProgressMessage(
+  status: Exclude<
+    DaemonStatus,
+    null | { status: "ready" } | { status: "failed" }
+  >,
+): string {
+  switch (status.status) {
+    case "checking":
+      return "Checking runtime status...";
+    case "installing":
+      return "Installing runtime (first launch)...";
+    case "upgrading":
+      return "Upgrading runtime...";
+    case "starting":
+      return "Starting runtime...";
+    case "waiting_for_ready":
+      return `Starting runtime (${status.attempt}/${status.max_attempts})...`;
+  }
+}

--- a/apps/notebook/src/components/DaemonStatusBanner.tsx
+++ b/apps/notebook/src/components/DaemonStatusBanner.tsx
@@ -1,4 +1,4 @@
-import { AlertTriangle, Loader2, X } from "lucide-react";
+import { AlertTriangle, Loader2, RefreshCw, X } from "lucide-react";
 
 /**
  * Status of the daemon during startup or operation.
@@ -17,6 +17,7 @@ export type DaemonStatus =
 interface DaemonStatusBannerProps {
   status: DaemonStatus;
   onDismiss?: () => void;
+  onRetry?: () => void;
 }
 
 /**
@@ -24,48 +25,61 @@ interface DaemonStatusBannerProps {
  *
  * Shows different visual states:
  * - Blue/info with spinner: Installing, upgrading, starting, waiting
- * - Red/error: Failed state with dismissible error message
+ * - Amber/warning: Failed state with retry button
  * - Hidden: Ready state or null
  */
 export function DaemonStatusBanner({
   status,
   onDismiss,
+  onRetry,
 }: DaemonStatusBannerProps) {
   // Don't show banner for ready or null state
   if (!status || status.status === "ready") {
     return null;
   }
 
-  // Failed state - red banner with error message
+  // Failed state - amber banner with error message and retry button
   if (status.status === "failed") {
     return (
-      <div className="flex items-center justify-between gap-3 bg-red-600/90 px-3 py-2 text-sm text-white">
-        <div className="flex items-center gap-2">
-          <AlertTriangle className="h-4 w-4 flex-shrink-0" />
-          <span className="font-medium">Runtime unavailable</span>
-          <span className="text-red-200">—</span>
-          <span className="text-red-100">{status.error}</span>
+      <div className="flex items-center justify-between gap-2 bg-amber-600/90 px-3 py-1 text-xs text-white">
+        <div className="flex items-center gap-2 min-w-0">
+          <AlertTriangle className="h-3 w-3 flex-shrink-0" />
+          <span className="font-medium flex-shrink-0">Runtime unavailable</span>
+          <span className="text-amber-200 flex-shrink-0">—</span>
+          <span className="text-amber-100 truncate">{status.error}</span>
         </div>
-        {onDismiss && (
-          <button
-            type="button"
-            onClick={onDismiss}
-            className="rounded p-1 hover:bg-red-500/50 transition-colors"
-            aria-label="Dismiss"
-          >
-            <X className="h-4 w-4" />
-          </button>
-        )}
+        <div className="flex items-center gap-1 flex-shrink-0">
+          {onRetry && (
+            <button
+              type="button"
+              onClick={onRetry}
+              className="flex items-center gap-1 rounded px-2 py-0.5 hover:bg-amber-500/50 transition-colors"
+            >
+              <RefreshCw className="h-3 w-3" />
+              <span>Retry</span>
+            </button>
+          )}
+          {onDismiss && (
+            <button
+              type="button"
+              onClick={onDismiss}
+              className="rounded p-0.5 hover:bg-amber-500/50 transition-colors"
+              aria-label="Dismiss"
+            >
+              <X className="h-3 w-3" />
+            </button>
+          )}
+        </div>
       </div>
     );
   }
 
-  // Progress states - blue banner with spinner
+  // Progress states - soft blue banner with spinner
   const message = getProgressMessage(status);
 
   return (
-    <div className="flex items-center gap-2 bg-blue-600/90 px-3 py-2 text-sm text-white">
-      <Loader2 className="h-4 w-4 animate-spin flex-shrink-0" />
+    <div className="flex items-center gap-2 bg-sky-600/90 px-3 py-1 text-xs text-white">
+      <Loader2 className="h-3 w-3 animate-spin flex-shrink-0" />
       <span>{message}</span>
     </div>
   );

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -1142,6 +1142,16 @@ async fn get_daemon_kernel_info(
         .map_err(|e| format!("daemon request failed: {}", e))
 }
 
+/// Check if daemon is connected.
+/// Returns true if notebook_sync handle exists (daemon available).
+#[tauri::command]
+async fn is_daemon_connected(
+    notebook_sync: tauri::State<'_, SharedNotebookSync>,
+) -> Result<bool, String> {
+    let guard = notebook_sync.lock().await;
+    Ok(guard.is_some())
+}
+
 /// Get execution queue state from the daemon.
 #[tauri::command]
 async fn get_daemon_queue_state(
@@ -4087,6 +4097,7 @@ pub fn run(
             interrupt_via_daemon,
             shutdown_kernel_via_daemon,
             get_daemon_kernel_info,
+            is_daemon_connected,
             get_daemon_queue_state,
             run_all_cells_via_daemon,
             send_comm_via_daemon,


### PR DESCRIPTION
## Summary

Adds daemon startup progress feedback on first app launch. Users now see "Installing runtime (first launch)..." instead of cryptic "Not..." status during daemon installation, addressing #311. The implementation emits progress events from `ensure_daemon_running()` through the Tauri event system, with a new `DaemonStatusBanner` component displaying real-time status.

## Changes

- **Backend**: Added `DaemonProgress` enum and optional progress callback to `ensure_daemon_running()` with events at each stage (Checking, Installing, Upgrading, Starting, WaitingForReady, Ready, Failed)
- **Frontend**: New `DaemonStatusBanner.tsx` component showing progress states (blue/info with spinner) and error states (red/dismissible)
- **Integration**: Wired progress callback in setup hook to emit `daemon:progress` Tauri events; App listens and renders banner

## Screenshots

<img width="1212" height="862" alt="image" src="https://github.com/user-attachments/assets/efcb4402-a0a4-4f4f-8332-032887d3ff74" />

<img width="1212" height="862" alt="image" src="https://github.com/user-attachments/assets/bbe03e41-d0dc-494e-9feb-5099be9d55bc" />


Closes #311

_PR submitted by @rgbkrk's agent, Quill_