### PR TITLE
Add dev environment setup with direnv and cargo alias

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,6 @@
 [alias]
 xtask = "run --package xtask --"
+runt = "run --package runt-cli --"
 
 [env]
 TS_RS_EXPORT_DIR = { value = "src/bindings", relative = true }

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,5 @@
+# Dev environment — activated automatically by direnv (https://direnv.net)
+#
+# This makes `runt` resolve to the local debug build (bin/runt wrapper)
+# instead of the system-wide /usr/local/bin/runt install.
+PATH_add bin

--- a/bin/runt
+++ b/bin/runt
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Dev wrapper for runt — resolves to the local debug build instead of system install.
+#
+# Fast path: if target/debug/runt exists, exec it directly (instant).
+# Cold path: if it hasn't been built yet, build it first.
+#
+# Activated automatically via .envrc (direnv) which prepends bin/ to PATH.
+# For a build-if-stale experience, use `cargo runt` instead (cargo alias).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BINARY="$REPO_ROOT/target/debug/runt"
+
+if [ ! -f "$BINARY" ]; then
+    echo "runt not built yet — building..." >&2
+    cargo build --manifest-path "$REPO_ROOT/Cargo.toml" -p runt-cli
+fi
+
+exec "$BINARY" "$@"


### PR DESCRIPTION
## Summary
This PR adds developer experience improvements by introducing a local development wrapper and direnv configuration that allows developers to run the local debug build of `runt` directly, without needing a system-wide installation.

## Key Changes
- **bin/runt**: Added a bash wrapper script that:
  - Resolves to the local `target/debug/runt` build when available
  - Automatically builds the binary on first run if it doesn't exist yet
  - Passes all arguments through to the built binary
  
- **.envrc**: Added direnv configuration that prepends `bin/` to PATH, automatically activating the local wrapper when entering the repository directory

- **.cargo/config.toml**: Added `runt` cargo alias for convenient building with `cargo runt`, providing a build-if-stale experience

## Implementation Details
The wrapper uses a fast-path/cold-path approach:
- **Fast path**: If the binary exists, exec it directly (instant invocation)
- **Cold path**: If not built yet, run `cargo build` first, then exec

This setup is automatically activated via direnv (when installed), making the local development build the default `runt` command within the repository. The cargo alias provides an alternative for developers who prefer explicit build control.
