### PR TITLE
Add daemon support for history search (Ctrl+R)

### DIFF
--- a/apps/notebook/src/hooks/useHistorySearch.ts
+++ b/apps/notebook/src/hooks/useHistorySearch.ts
@@ -7,10 +7,6 @@ export interface HistoryEntry {
   source: string;
 }
 
-interface HistoryResult {
-  entries: HistoryEntry[];
-}
-
 // MRU cache for search queries (pattern -> entries)
 // Uses Map iteration order: oldest at start, newest at end
 const MAX_CACHE_SIZE = 20;
@@ -74,16 +70,16 @@ export function useHistorySearch() {
     setError(null);
 
     try {
-      const result = await invoke<HistoryResult>("get_history", {
+      const entries = await invoke<HistoryEntry[]>("get_history_via_daemon", {
         pattern: pattern || null,
         n: 100,
       });
 
       // Only update if this is still the current search (avoid race conditions)
       if (currentSearchRef.current === pattern) {
-        setEntries(result.entries);
+        setEntries(entries);
         // Cache the result
-        setCacheResult(pattern, result.entries);
+        setCacheResult(pattern, entries);
       }
     } catch (e) {
       const errorMsg = e instanceof Error ? e.message : String(e);

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -24,7 +24,7 @@ pub use runtime::Runtime;
 use notebook_state::{FrontendCell, NotebookState};
 use runtimed::notebook_doc::CellSnapshot;
 use runtimed::notebook_sync_client::{NotebookSyncClient, NotebookSyncHandle};
-use runtimed::protocol::{NotebookRequest, NotebookResponse};
+use runtimed::protocol::{HistoryEntry, NotebookRequest, NotebookResponse};
 
 use log::{info, warn};
 use nbformat::v4::{Cell, CellId, CellMetadata};
@@ -34,6 +34,13 @@ use serde::{Deserialize, Serialize};
 /// The Option allows graceful fallback when daemon is unavailable.
 /// Uses the split handle pattern - the handle is clonable and doesn't block.
 type SharedNotebookSync = Arc<tokio::sync::Mutex<Option<NotebookSyncHandle>>>;
+
+/// Newtype wrapper for auto-launch-in-progress flag (distinguishes from other AtomicBool states).
+struct AutoLaunchInProgress(Arc<AtomicBool>);
+
+/// Newtype wrapper for reconnect-in-progress flag (distinguishes from other AtomicBool states).
+struct ReconnectInProgress(Arc<AtomicBool>);
+
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
@@ -1103,6 +1110,41 @@ async fn send_comm_via_daemon(
         .map_err(|e| format!("daemon request failed: {}", e))
 }
 
+/// Get kernel input history via daemon.
+///
+/// Searches the kernel's input history for matching entries.
+/// Returns an error if no kernel is running or the request times out.
+#[tauri::command]
+async fn get_history_via_daemon(
+    pattern: Option<String>,
+    n: i32,
+    notebook_sync: tauri::State<'_, SharedNotebookSync>,
+) -> Result<Vec<HistoryEntry>, String> {
+    info!(
+        "[daemon-kernel] get_history_via_daemon: pattern={:?}, n={}",
+        pattern, n
+    );
+
+    let guard = notebook_sync.lock().await;
+    let handle = guard.as_ref().ok_or("Not connected to daemon")?;
+
+    let response = handle
+        .send_request(NotebookRequest::GetHistory {
+            pattern,
+            n,
+            unique: true,
+        })
+        .await
+        .map_err(|e| format!("daemon request failed: {}", e))?;
+
+    match response {
+        NotebookResponse::HistoryResult { entries } => Ok(entries),
+        NotebookResponse::NoKernel {} => Err("No kernel running".to_string()),
+        NotebookResponse::Error { error } => Err(error),
+        _ => Err("Unexpected response from daemon".to_string()),
+    }
+}
+
 /// Reconnect to the daemon after a disconnection.
 ///
 /// Called by the frontend after receiving daemon:disconnected event.
@@ -1111,12 +1153,13 @@ async fn reconnect_to_daemon(
     app: tauri::AppHandle,
     notebook_state: tauri::State<'_, Arc<Mutex<NotebookState>>>,
     notebook_sync: tauri::State<'_, SharedNotebookSync>,
-    reconnect_in_progress: tauri::State<'_, Arc<AtomicBool>>,
+    reconnect_in_progress: tauri::State<'_, ReconnectInProgress>,
 ) -> Result<(), String> {
     info!("[daemon-kernel] reconnect_to_daemon");
 
     // Use atomic compare_exchange to ensure only one reconnect runs at a time
     if reconnect_in_progress
+        .0
         .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
         .is_err()
     {
@@ -1125,7 +1168,7 @@ async fn reconnect_to_daemon(
     }
 
     // Helper to reset flag on all exit paths
-    let reset_flag = || reconnect_in_progress.store(false, Ordering::SeqCst);
+    let reset_flag = || reconnect_in_progress.0.store(false, Ordering::SeqCst);
 
     // Check if already connected
     {
@@ -2549,10 +2592,10 @@ pub fn run(
     ));
 
     // Track auto-launch state for frontend to query
-    let auto_launch_in_progress = Arc::new(AtomicBool::new(false));
+    let auto_launch_in_progress = AutoLaunchInProgress(Arc::new(AtomicBool::new(false)));
 
     // Guard against concurrent reconnect attempts
-    let reconnect_in_progress = Arc::new(AtomicBool::new(false));
+    let reconnect_in_progress = ReconnectInProgress(Arc::new(AtomicBool::new(false)));
 
     // Notebook sync client for cross-window state synchronization
     let notebook_sync: SharedNotebookSync = Arc::new(tokio::sync::Mutex::new(None));
@@ -2617,6 +2660,7 @@ pub fn run(
             get_daemon_queue_state,
             run_all_cells_via_daemon,
             send_comm_via_daemon,
+            get_history_via_daemon,
             reconnect_to_daemon,
             refresh_from_automerge,
             debug_get_automerge_state,

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -36,6 +36,7 @@ use serde::{Deserialize, Serialize};
 type SharedNotebookSync = Arc<tokio::sync::Mutex<Option<NotebookSyncHandle>>>;
 
 /// Newtype wrapper for auto-launch-in-progress flag (distinguishes from other AtomicBool states).
+#[allow(dead_code)]
 struct AutoLaunchInProgress(Arc<AtomicBool>);
 
 /// Newtype wrapper for reconnect-in-progress flag (distinguishes from other AtomicBool states).

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -1115,6 +1115,20 @@ async fn handle_notebook_request(
                 NotebookResponse::NoKernel {}
             }
         }
+
+        NotebookRequest::GetHistory { pattern, n, unique } => {
+            let mut kernel_guard = room.kernel.lock().await;
+            if let Some(ref mut kernel) = *kernel_guard {
+                match kernel.get_history(pattern, n, unique).await {
+                    Ok(entries) => NotebookResponse::HistoryResult { entries },
+                    Err(e) => NotebookResponse::Error {
+                        error: format!("Failed to get history: {}", e),
+                    },
+                }
+            } else {
+                NotebookResponse::NoKernel {}
+            }
+        }
     }
 }
 

--- a/crates/runtimed/src/protocol.rs
+++ b/crates/runtimed/src/protocol.rs
@@ -185,6 +185,17 @@ pub enum NotebookRequest {
         /// Preserves frontend session/msg_id for proper widget protocol.
         message: serde_json::Value,
     },
+
+    /// Search the kernel's input history.
+    /// Returns matching history entries via HistoryResult response.
+    GetHistory {
+        /// Pattern to search for (glob-style, optional)
+        pattern: Option<String>,
+        /// Maximum number of entries to return
+        n: i32,
+        /// Only return unique entries (deduplicate)
+        unique: bool,
+    },
 }
 
 /// Responses from daemon to notebook app.
@@ -241,6 +252,20 @@ pub enum NotebookResponse {
 
     /// Error response.
     Error { error: String },
+
+    /// History search result.
+    HistoryResult { entries: Vec<HistoryEntry> },
+}
+
+/// A single entry from kernel input history.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HistoryEntry {
+    /// Session number (0 for current session)
+    pub session: i32,
+    /// Line number within the session
+    pub line: i32,
+    /// The source code that was executed
+    pub source: String,
 }
 
 /// Broadcast messages from daemon to all peers in a room.


### PR DESCRIPTION
## Summary

Implements history request/reply protocol to restore kernel history search functionality after local kernel mode removal in Phase 2. History search queries now route through the daemon via `HistoryRequest` shell messages, with responses returned to the frontend through a pending request tracking system using oneshot channels.

## Changes

- **Protocol**: Added `GetHistory` request and `HistoryResult` response types to daemon IPC
- **Kernel manager**: Pending history request tracking with msg_id correlation, shell reply handling, and 5-second timeout
- **Request handler**: Route history requests through notebook sync server
- **Tauri command**: New `get_history_via_daemon` command replacing removed local kernel backend
- **Frontend**: Updated history search hook to use daemon command
- **Bug fix**: Fixed Tauri state panic from duplicate `Arc<AtomicBool>` types using newtype wrappers

<img width="1212" height="862" alt="image" src="https://github.com/user-attachments/assets/024cad07-dbd0-4f6d-920f-b3f88713da07" />


_PR submitted by @rgbkrk's agent, Quill_