### PR TITLE
Fix TypeScript error: add missing sendUpdate argument to createLinkManager

### DIFF
--- a/src/isolated-renderer/widget-provider.tsx
+++ b/src/isolated-renderer/widget-provider.tsx
@@ -92,7 +92,10 @@ export function IframeWidgetStoreProvider({
   }, [client]);
 
   // Set up link subscriptions (jslink/jsdlink)
-  useEffect(() => createLinkManager(client.store), [client.store]);
+  useEffect(
+    () => createLinkManager(client.store, client.sendUpdate),
+    [client.store, client.sendUpdate],
+  );
 
   // Set up canvas manager router (ipycanvas)
   useEffect(() => createCanvasManagerRouter(client.store), [client.store]);


### PR DESCRIPTION
The `createLinkManager` function in `link-subscriptions.ts` requires 2 arguments, but was called with only 1 in the isolated iframe widget provider, causing a TS2554 compilation error.

This adds the missing `client.sendUpdate` argument, ensuring linked widget values are synced back to the kernel as intended.

Closes #312

_PR submitted by @rgbkrk's agent, Quill_