### PR TITLE
Add UI for prewarm pool errors

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -21,6 +21,7 @@ import { DenoDependencyHeader } from "./components/DenoDependencyHeader";
 import { DependencyHeader } from "./components/DependencyHeader";
 import { NotebookToolbar } from "./components/NotebookToolbar";
 import { NotebookView } from "./components/NotebookView";
+import { PoolErrorBanner } from "./components/PoolErrorBanner";
 import { TrustDialog } from "./components/TrustDialog";
 import { useCondaDependencies } from "./hooks/useCondaDependencies";
 import { useDaemonKernel } from "./hooks/useDaemonKernel";
@@ -29,6 +30,7 @@ import { useDependencies } from "./hooks/useDependencies";
 import { useEnvProgress } from "./hooks/useEnvProgress";
 import { useDaemonInfo, useGitInfo } from "./hooks/useGitInfo";
 import { useNotebook } from "./hooks/useNotebook";
+import { usePoolState } from "./hooks/usePoolState";
 import { useTrust } from "./hooks/useTrust";
 import type { JupyterMessage } from "./types";
 
@@ -312,6 +314,9 @@ function AppContent() {
 
   // Environment preparation progress
   const envProgress = useEnvProgress();
+
+  // Prewarm pool state (errors from invalid default packages)
+  const poolState = usePoolState();
 
   // Check trust and start kernel if trusted, otherwise show dialog.
   // Returns true if kernel was started, false if trust dialog opened or error.
@@ -733,6 +738,11 @@ function AppContent() {
               });
             });
         }}
+      />
+      <PoolErrorBanner
+        uvError={poolState.uvError}
+        condaError={poolState.condaError}
+        onDismiss={poolState.dismiss}
       />
       <NotebookToolbar
         kernelStatus={kernelStatus}

--- a/apps/notebook/src/components/PoolErrorBanner.tsx
+++ b/apps/notebook/src/components/PoolErrorBanner.tsx
@@ -1,0 +1,85 @@
+import { AlertTriangle, RefreshCw, X } from "lucide-react";
+import type { PoolError } from "../types";
+
+interface PoolErrorBannerProps {
+  uvError: PoolError | null;
+  condaError: PoolError | null;
+  onDismiss?: () => void;
+}
+
+/**
+ * Banner showing prewarm pool errors (failed to prepare default environments).
+ *
+ * Helps users identify and fix invalid default packages in their settings.
+ */
+export function PoolErrorBanner({
+  uvError,
+  condaError,
+  onDismiss,
+}: PoolErrorBannerProps) {
+  // Don't show if no errors
+  if (!uvError && !condaError) {
+    return null;
+  }
+
+  // Combine errors for display
+  const errors: Array<{ type: "uv" | "conda"; error: PoolError }> = [];
+  if (uvError) errors.push({ type: "uv", error: uvError });
+  if (condaError) errors.push({ type: "conda", error: condaError });
+
+  return (
+    <div className="flex flex-col gap-1 bg-amber-600/90 px-3 py-2 text-xs text-white">
+      {errors.map(({ type, error }, index) => (
+        <div key={type} className="flex items-center justify-between gap-2">
+          <div className="flex items-center gap-2 min-w-0">
+            <AlertTriangle className="h-3 w-3 flex-shrink-0" />
+            <span className="font-medium flex-shrink-0">
+              {type === "uv" ? "UV" : "Conda"} pool error
+            </span>
+            <span className="text-amber-200 flex-shrink-0">—</span>
+            <span className="text-amber-100 truncate">
+              {error.failed_package
+                ? `Failed to install "${error.failed_package}"`
+                : error.message}
+            </span>
+            {error.retry_in_secs > 0 && (
+              <>
+                <span className="text-amber-200 flex-shrink-0">·</span>
+                <span className="text-amber-200 flex-shrink-0 flex items-center gap-1">
+                  <RefreshCw className="h-3 w-3" />
+                  Retry in {formatRetryTime(error.retry_in_secs)}
+                </span>
+              </>
+            )}
+          </div>
+          {index === 0 && onDismiss && (
+            <button
+              type="button"
+              onClick={onDismiss}
+              className="rounded p-0.5 hover:bg-amber-500/50 transition-colors flex-shrink-0"
+              aria-label="Dismiss"
+            >
+              <X className="h-3 w-3" />
+            </button>
+          )}
+        </div>
+      ))}
+      <div className="text-amber-200 text-[10px] mt-0.5">
+        Check your default packages in Settings. Invalid packages prevent
+        environment prewarming.
+      </div>
+    </div>
+  );
+}
+
+function formatRetryTime(seconds: number): string {
+  if (seconds < 60) {
+    return `${seconds}s`;
+  }
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+  if (remainingSeconds === 0) {
+    return `${minutes}m`;
+  }
+  return `${minutes}m ${remainingSeconds}s`;
+}

--- a/apps/notebook/src/hooks/usePoolState.ts
+++ b/apps/notebook/src/hooks/usePoolState.ts
@@ -1,0 +1,63 @@
+import { listen } from "@tauri-apps/api/event";
+import { useCallback, useEffect, useState } from "react";
+import type { PoolError, PoolStateEvent } from "../types";
+
+export interface PoolState {
+  /** UV pool error (null if healthy) */
+  uvError: PoolError | null;
+  /** Conda pool error (null if healthy) */
+  condaError: PoolError | null;
+  /** Whether there's any pool error */
+  hasError: boolean;
+}
+
+/**
+ * Hook to subscribe to daemon pool state broadcasts.
+ *
+ * Returns error information when the prewarm pool fails to create
+ * environments (e.g., due to invalid default packages in settings).
+ */
+export function usePoolState(): PoolState & { dismiss: () => void } {
+  const [uvError, setUvError] = useState<PoolError | null>(null);
+  const [condaError, setCondaError] = useState<PoolError | null>(null);
+  const [dismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const unlisten = listen<PoolStateEvent>("pool:state", (event) => {
+      if (cancelled) return;
+
+      const payload = event.payload;
+
+      // Update error states
+      setUvError(payload.uv_error ?? null);
+      setCondaError(payload.conda_error ?? null);
+
+      // If errors clear, reset dismissed state so future errors show
+      if (!payload.uv_error && !payload.conda_error) {
+        setDismissed(false);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+      unlisten.then((fn) => fn());
+    };
+  }, []);
+
+  const dismiss = useCallback(() => {
+    setDismissed(true);
+  }, []);
+
+  // Only show errors if not dismissed
+  const effectiveUvError = dismissed ? null : uvError;
+  const effectiveCondaError = dismissed ? null : condaError;
+
+  return {
+    uvError: effectiveUvError,
+    condaError: effectiveCondaError,
+    hasError: Boolean(effectiveUvError || effectiveCondaError),
+    dismiss,
+  };
+}

--- a/apps/notebook/src/types.ts
+++ b/apps/notebook/src/types.ts
@@ -102,6 +102,31 @@ export type EnvProgressEvent = EnvProgressPhase & {
   env_type: "conda" | "uv";
 };
 
+// =============================================================================
+// Pool State Types (prewarm pool error display)
+// =============================================================================
+
+/** Error information for a prewarm pool that is failing to create environments */
+export interface PoolError {
+  /** Human-readable error message */
+  message: string;
+  /** Package that failed to install (if identified from error output) */
+  failed_package?: string;
+  /** Number of consecutive failures */
+  consecutive_failures: number;
+  /** Seconds until next retry (0 if retry is imminent) */
+  retry_in_secs: number;
+}
+
+/** Pool state broadcast from daemon - sent when prewarm pool errors occur or clear */
+export interface PoolStateEvent {
+  event: "pool_state";
+  /** UV pool error (null if healthy) */
+  uv_error: PoolError | null;
+  /** Conda pool error (null if healthy) */
+  conda_error: PoolError | null;
+}
+
 // pixi.toml detection info
 export interface PixiInfo {
   path: string;


### PR DESCRIPTION
Display warnings when invalid packages in `uv.default_packages` or `conda.default_packages` settings prevent environment prewarming. The UI shows the failed package name, error message, and retry countdown with exponential backoff (30s → 60s → 120s → 240s → 300s max).

This adds a Tauri event bridge that subscribes to the daemon's `PoolState` broadcasts, a `usePoolState` hook for frontend state management, and a `PoolErrorBanner` component to display errors in the app header.

Closes #296

## Verification

- [ ] Set an invalid package: `echo '{"uv":{"default_packages":["scitkit-learn"]}}' > ~/.config/runt-notebook/settings.json`
- [ ] Start app with `cargo xtask dev`
- [ ] Verify amber banner appears showing failed package and retry countdown
- [ ] Fix the typo in settings
- [ ] Verify banner clears when pool recovers
- [ ] Test dismiss button (banner should reappear on new errors)

_PR submitted by @rgbkrk's agent, Quill_