### PR TITLE
Fix E2E CI: install Python kernelspec for daemon kernel discovery

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -275,6 +275,20 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v5
 
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Setup Jupyter kernel
+        run: |
+          # Install ipykernel to create a system kernelspec
+          # The daemon's RoomKernel.launch() uses find_kernelspec() which needs this
+          pip install ipykernel
+          python -m ipykernel install --user --name python3
+          # Verify kernelspec was created
+          ls -la ~/.local/share/jupyter/kernels/
+
       - name: Start E2E daemon
         run: |
           TARGET=$(ls target/release/binaries/ | grep runtimed | head -1)


### PR DESCRIPTION
## Summary
- Fixes E2E smoke test failures in CI by installing a Python kernelspec
- The daemon's `RoomKernel.launch()` uses `find_kernelspec()` which requires a system kernelspec
- Adds `actions/setup-python` and `ipykernel install` to create the required kernelspec

## Root Cause
From the daemon logs in PR #318:
```
[notebook-sync] Auto-launch: new notebook, using prewarmed environment (uv:prewarmed)
[notebook-sync] Auto-launch failed: Kernel 'python3' not found. Available kernels: []
```

The daemon's UV pool creates prewarmed environments (2/2 available), but `RoomKernel.launch()` doesn't integrate with the pool - it just uses kernelspec discovery via `runtimelib::find_kernelspec("python3")`. On CI, no kernelspec was installed.

## Solution
Install Python and ipykernel in CI to create the `python3` kernelspec:
```yaml
- name: Setup Python
  uses: actions/setup-python@v5
  with:
    python-version: "3.12"

- name: Setup Jupyter kernel
  run: |
    pip install ipykernel
    python -m ipykernel install --user --name python3
```

## Notes
This is a workaround. The proper fix would be for `RoomKernel.launch()` to integrate with the daemon's prewarmed pool when `env_source` is `"uv:prewarmed"`. That's a larger change tracked separately.

## Test plan
- [x] E2E smoke tests pass locally (3/3)
- [ ] CI E2E smoke test passes