### PR TITLE
Add daemon support for code completions (Tab/Ctrl+Space)

### DIFF
--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -26,7 +26,7 @@ use runtimed::notebook_doc::CellSnapshot;
 use runtimed::notebook_sync_client::{NotebookSyncClient, NotebookSyncHandle};
 use runtimed::protocol::{CompletionItem, HistoryEntry, NotebookRequest, NotebookResponse};
 
-use log::{info, warn};
+use log::{debug, info, warn};
 use nbformat::v4::{Cell, CellId, CellMetadata};
 use serde::{Deserialize, Serialize};
 
@@ -1164,7 +1164,7 @@ async fn complete_via_daemon(
     cursor_pos: usize,
     notebook_sync: tauri::State<'_, SharedNotebookSync>,
 ) -> Result<CompletionResult, String> {
-    info!(
+    debug!(
         "[daemon-kernel] complete_via_daemon: cursor_pos={}",
         cursor_pos
     );

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -24,7 +24,7 @@ pub use runtime::Runtime;
 use notebook_state::{FrontendCell, NotebookState};
 use runtimed::notebook_doc::CellSnapshot;
 use runtimed::notebook_sync_client::{NotebookSyncClient, NotebookSyncHandle};
-use runtimed::protocol::{HistoryEntry, NotebookRequest, NotebookResponse};
+use runtimed::protocol::{CompletionItem, HistoryEntry, NotebookRequest, NotebookResponse};
 
 use log::{info, warn};
 use nbformat::v4::{Cell, CellId, CellMetadata};
@@ -1140,6 +1140,53 @@ async fn get_history_via_daemon(
 
     match response {
         NotebookResponse::HistoryResult { entries } => Ok(entries),
+        NotebookResponse::NoKernel {} => Err("No kernel running".to_string()),
+        NotebookResponse::Error { error } => Err(error),
+        _ => Err("Unexpected response from daemon".to_string()),
+    }
+}
+
+/// Result type for completion requests (matches frontend interface).
+#[derive(Serialize)]
+struct CompletionResult {
+    items: Vec<CompletionItem>,
+    cursor_start: usize,
+    cursor_end: usize,
+}
+
+/// Get code completions via daemon.
+///
+/// Requests completions from the kernel for the given code at cursor position.
+/// Returns an error if no kernel is running or the request times out.
+#[tauri::command]
+async fn complete_via_daemon(
+    code: String,
+    cursor_pos: usize,
+    notebook_sync: tauri::State<'_, SharedNotebookSync>,
+) -> Result<CompletionResult, String> {
+    info!(
+        "[daemon-kernel] complete_via_daemon: cursor_pos={}",
+        cursor_pos
+    );
+
+    let guard = notebook_sync.lock().await;
+    let handle = guard.as_ref().ok_or("Not connected to daemon")?;
+
+    let response = handle
+        .send_request(NotebookRequest::Complete { code, cursor_pos })
+        .await
+        .map_err(|e| format!("daemon request failed: {}", e))?;
+
+    match response {
+        NotebookResponse::CompletionResult {
+            items,
+            cursor_start,
+            cursor_end,
+        } => Ok(CompletionResult {
+            items,
+            cursor_start,
+            cursor_end,
+        }),
         NotebookResponse::NoKernel {} => Err("No kernel running".to_string()),
         NotebookResponse::Error { error } => Err(error),
         _ => Err("Unexpected response from daemon".to_string()),
@@ -2662,6 +2709,7 @@ pub fn run(
             run_all_cells_via_daemon,
             send_comm_via_daemon,
             get_history_via_daemon,
+            complete_via_daemon,
             reconnect_to_daemon,
             refresh_from_automerge,
             debug_get_automerge_state,

--- a/crates/runtimed/src/kernel_manager.rs
+++ b/crates/runtimed/src/kernel_manager.rs
@@ -17,8 +17,8 @@ use std::sync::{Arc, Mutex as StdMutex};
 use anyhow::Result;
 use bytes::Bytes;
 use jupyter_protocol::{
-    ConnectionInfo, ExecuteRequest, HistoryRequest, InterruptRequest, JupyterMessage,
-    JupyterMessageContent, KernelInfoRequest, ShutdownRequest,
+    CompleteRequest, ConnectionInfo, ExecuteRequest, HistoryRequest, InterruptRequest,
+    JupyterMessage, JupyterMessageContent, KernelInfoRequest, ShutdownRequest,
 };
 use log::{debug, error, info, warn};
 use serde::Serialize;
@@ -30,7 +30,7 @@ use crate::comm_state::CommState;
 use crate::notebook_doc::NotebookDoc;
 use crate::notebook_sync_server::persist_notebook_bytes;
 use crate::output_store::{self, DEFAULT_INLINE_THRESHOLD};
-use crate::protocol::{HistoryEntry, NotebookBroadcast};
+use crate::protocol::{CompletionItem, HistoryEntry, NotebookBroadcast};
 use crate::PooledEnv;
 
 /// Convert a JupyterMessageContent to nbformat-style JSON for storage in Automerge.
@@ -210,6 +210,10 @@ impl std::fmt::Display for KernelStatus {
 
 /// A kernel owned by the daemon for a notebook room.
 ///
+/// Type alias for pending completion response channels.
+type PendingCompletions =
+    Arc<StdMutex<HashMap<String, oneshot::Sender<(Vec<CompletionItem>, usize, usize)>>>>;
+
 /// Unlike the notebook app's `NotebookKernel`, this broadcasts outputs
 /// to all connected peers rather than emitting Tauri events.
 pub struct RoomKernel {
@@ -260,6 +264,8 @@ pub struct RoomKernel {
     comm_state: Arc<CommState>,
     /// Pending history requests: msg_id → response channel
     pending_history: Arc<StdMutex<HashMap<String, oneshot::Sender<Vec<HistoryEntry>>>>>,
+    /// Pending completion requests: msg_id → response channel
+    pending_completions: PendingCompletions,
 }
 
 /// Commands from iopub/shell handlers for queue state management.
@@ -309,6 +315,7 @@ impl RoomKernel {
             blob_store,
             comm_state,
             pending_history: Arc::new(StdMutex::new(HashMap::new())),
+            pending_completions: Arc::new(StdMutex::new(HashMap::new())),
         }
     }
 
@@ -876,6 +883,7 @@ impl RoomKernel {
         let shell_broadcast_tx = self.broadcast_tx.clone();
         let shell_cell_id_map = self.cell_id_map.clone();
         let shell_pending_history = self.pending_history.clone();
+        let shell_pending_completions = self.pending_completions.clone();
         // Additional resources for handling page payloads (IPython ? and ?? help)
         let shell_doc = self.doc.clone();
         let shell_blob_store = self.blob_store.clone();
@@ -1026,6 +1034,37 @@ impl RoomKernel {
                                                 entries.len()
                                             );
                                             let _ = tx.send(entries);
+                                        }
+                                    }
+                                }
+                            }
+                            JupyterMessageContent::CompleteReply(ref reply) => {
+                                // Get the parent msg_id to find the pending request
+                                if let Some(ref parent) = msg.parent_header {
+                                    let msg_id = &parent.msg_id;
+                                    if let Ok(mut pending) = shell_pending_completions.lock() {
+                                        if let Some(tx) = pending.remove(msg_id) {
+                                            // Convert kernel matches to CompletionItem (LSP-ready format)
+                                            let items: Vec<CompletionItem> = reply
+                                                .matches
+                                                .iter()
+                                                .map(|m| CompletionItem {
+                                                    label: m.clone(),
+                                                    kind: None,
+                                                    detail: None,
+                                                    source: Some("kernel".to_string()),
+                                                })
+                                                .collect();
+
+                                            debug!(
+                                                "[kernel-manager] Resolved completion request: {} items",
+                                                items.len()
+                                            );
+                                            let _ = tx.send((
+                                                items,
+                                                reply.cursor_start,
+                                                reply.cursor_end,
+                                            ));
                                         }
                                     }
                                 }
@@ -1349,6 +1388,56 @@ impl RoomKernel {
                     pending.remove(&msg_id);
                 }
                 Err(anyhow::anyhow!("History request timed out"))
+            }
+        }
+    }
+
+    /// Request code completions from the kernel.
+    ///
+    /// Sends a complete_request to the kernel and waits for the reply.
+    /// Returns an error if no kernel is running or the request times out.
+    pub async fn complete(
+        &mut self,
+        code: String,
+        cursor_pos: usize,
+    ) -> Result<(Vec<CompletionItem>, usize, usize)> {
+        let shell = self
+            .shell_writer
+            .as_mut()
+            .ok_or_else(|| anyhow::anyhow!("No kernel running"))?;
+
+        // Create completion request
+        let request = CompleteRequest { code, cursor_pos };
+
+        let message: JupyterMessage = request.into();
+        let msg_id = message.header.msg_id.clone();
+
+        // Create response channel
+        let (tx, rx) = oneshot::channel();
+
+        // Register pending request BEFORE sending
+        self.pending_completions
+            .lock()
+            .map_err(|_| anyhow::anyhow!("Lock poisoned"))?
+            .insert(msg_id.clone(), tx);
+
+        // Send request
+        shell.send(message).await?;
+        debug!("[kernel-manager] Sent complete_request: msg_id={}", msg_id);
+
+        // Wait for response with timeout
+        match tokio::time::timeout(std::time::Duration::from_secs(5), rx).await {
+            Ok(Ok(result)) => Ok(result),
+            Ok(Err(_)) => {
+                // Channel closed without response
+                Err(anyhow::anyhow!("Completion request cancelled"))
+            }
+            Err(_) => {
+                // Timeout - clean up pending request
+                if let Ok(mut pending) = self.pending_completions.lock() {
+                    pending.remove(&msg_id);
+                }
+                Err(anyhow::anyhow!("Completion request timed out"))
             }
         }
     }

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -1218,6 +1218,24 @@ async fn handle_notebook_request(
                 NotebookResponse::NoKernel {}
             }
         }
+
+        NotebookRequest::Complete { code, cursor_pos } => {
+            let mut kernel_guard = room.kernel.lock().await;
+            if let Some(ref mut kernel) = *kernel_guard {
+                match kernel.complete(code, cursor_pos).await {
+                    Ok((items, cursor_start, cursor_end)) => NotebookResponse::CompletionResult {
+                        items,
+                        cursor_start,
+                        cursor_end,
+                    },
+                    Err(e) => NotebookResponse::Error {
+                        error: format!("Failed to get completions: {}", e),
+                    },
+                }
+            } else {
+                NotebookResponse::NoKernel {}
+            }
+        }
     }
 }
 

--- a/crates/runtimed/src/protocol.rs
+++ b/crates/runtimed/src/protocol.rs
@@ -196,6 +196,15 @@ pub enum NotebookRequest {
         /// Only return unique entries (deduplicate)
         unique: bool,
     },
+
+    /// Request code completions from the kernel.
+    /// Returns matching completions via CompletionResult response.
+    Complete {
+        /// The code to complete
+        code: String,
+        /// Cursor position in the code
+        cursor_pos: usize,
+    },
 }
 
 /// Responses from daemon to notebook app.
@@ -255,6 +264,13 @@ pub enum NotebookResponse {
 
     /// History search result.
     HistoryResult { entries: Vec<HistoryEntry> },
+
+    /// Code completion result.
+    CompletionResult {
+        items: Vec<CompletionItem>,
+        cursor_start: usize,
+        cursor_end: usize,
+    },
 }
 
 /// A single entry from kernel input history.
@@ -266,6 +282,23 @@ pub struct HistoryEntry {
     pub line: i32,
     /// The source code that was executed
     pub source: String,
+}
+
+/// A single completion item (LSP-ready structure).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CompletionItem {
+    /// The completion text
+    pub label: String,
+    /// Kind: "function", "variable", "class", "module", etc.
+    /// Populated by LSP later; kernel completions leave this as None.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    /// Short type annotation (e.g. "def read_csv(filepath_or_buffer, ...)")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+    /// Source: "kernel" now, "ruff"/"basedpyright" later.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
 }
 
 /// Broadcast messages from daemon to all peers in a room.


### PR DESCRIPTION
## Summary

Implements code completion requests via the daemon using the Jupyter protocol's `complete_request`/`complete_reply` messages. Uses LSP-ready `CompletionItem` structure for future extensibility with additional completion sources (ruff, basedpyright). Follows the same request/response pattern as the history search feature (PR #320).

The frontend invokes `complete_via_daemon()` when the user triggers autocompletion (Ctrl+Space or after typing `.`), which sends a `Complete` request to the daemon. The kernel manager tracks pending requests and converts kernel matches to `CompletionItem` objects before returning results.

Closes #314

## Verification

- Completions appear when typing in code cells (Ctrl+Space or after `.`)
- Completion popup shows available symbols/functions from the kernel
- Timeout handling works if kernel doesn't respond (5-second timeout)
- No kernel case returns appropriate error

---

_PR submitted by @rgbkrk's agent, Quill_