### PR TITLE
fix: integrate prewarmed pool with kernel launching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -275,20 +275,6 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v5
 
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Setup Jupyter kernel
-        run: |
-          # Install ipykernel to create a system kernelspec
-          # The daemon's RoomKernel.launch() uses find_kernelspec() which needs this
-          pip install ipykernel
-          python -m ipykernel install --user --name python3
-          # Verify kernelspec was created
-          ls -la ~/.local/share/jupyter/kernels/
-
       - name: Start E2E daemon
         run: |
           TARGET=$(ls target/release/binaries/ | grep runtimed | head -1)

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -293,6 +293,7 @@ pub fn get_or_create_room(
 /// The `use_typed_frames` parameter determines the protocol version:
 /// - `false` (v1): Raw Automerge frames (legacy, for old clients)
 /// - `true` (v2): Typed frames with first-byte type indicator
+#[allow(clippy::too_many_arguments)]
 pub async fn handle_notebook_sync_connection<R, W>(
     mut reader: R,
     mut writer: W,

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -301,6 +301,7 @@ pub async fn handle_notebook_sync_connection<R, W>(
     notebook_id: String,
     use_typed_frames: bool,
     default_python_env: crate::settings_doc::PythonEnvType,
+    daemon: std::sync::Arc<crate::daemon::Daemon>,
 ) -> anyhow::Result<()>
 where
     R: AsyncRead + Unpin,
@@ -350,8 +351,15 @@ where
             // Spawn auto-launch in background so we don't block sync
             let room_clone = room.clone();
             let notebook_id_clone = notebook_id.clone();
+            let daemon_clone = daemon.clone();
             tokio::spawn(async move {
-                auto_launch_kernel(&room_clone, &notebook_id_clone, default_python_env).await;
+                auto_launch_kernel(
+                    &room_clone,
+                    &notebook_id_clone,
+                    default_python_env,
+                    daemon_clone,
+                )
+                .await;
             });
         } else if !matches!(
             trust_status,
@@ -373,7 +381,7 @@ where
     }
 
     let result = if use_typed_frames {
-        run_sync_loop_v2(&mut reader, &mut writer, &room).await
+        run_sync_loop_v2(&mut reader, &mut writer, &room, daemon).await
     } else {
         run_sync_loop_v1(&mut reader, &mut writer, &room).await
     };
@@ -525,6 +533,7 @@ async fn run_sync_loop_v2<R, W>(
     reader: &mut R,
     writer: &mut W,
     room: &NotebookRoom,
+    daemon: std::sync::Arc<crate::daemon::Daemon>,
 ) -> anyhow::Result<()>
 where
     R: AsyncRead + Unpin,
@@ -604,7 +613,8 @@ where
                             NotebookFrameType::Request => {
                                 // Handle NotebookRequest
                                 let request: NotebookRequest = serde_json::from_slice(&frame.payload)?;
-                                let response = handle_notebook_request(room, request).await;
+                                let response =
+                                    handle_notebook_request(room, request, daemon.clone()).await;
                                 connection::send_typed_json_frame(
                                     writer,
                                     NotebookFrameType::Response,
@@ -661,6 +671,7 @@ async fn auto_launch_kernel(
     room: &NotebookRoom,
     notebook_id: &str,
     default_python_env: crate::settings_doc::PythonEnvType,
+    daemon: std::sync::Arc<crate::daemon::Daemon>,
 ) {
     // Check if room still has peers (protect against race condition where client disconnects
     // before we finish launching)
@@ -747,10 +758,46 @@ async fn auto_launch_kernel(
         prewarmed.to_string()
     };
 
+    // Acquire prewarmed environment from pool if using prewarmed source
+    let pooled_env = match env_source.as_str() {
+        "uv:prewarmed" => match daemon.take_uv_env().await {
+            Some(env) => {
+                info!(
+                    "[notebook-sync] Auto-launch: acquired UV env from pool: {:?}",
+                    env.python_path
+                );
+                Some(env)
+            }
+            None => {
+                warn!("[notebook-sync] Auto-launch: UV pool empty, falling back to kernelspec");
+                None
+            }
+        },
+        "conda:prewarmed" => match daemon.take_conda_env().await {
+            Some(env) => {
+                info!(
+                    "[notebook-sync] Auto-launch: acquired Conda env from pool: {:?}",
+                    env.python_path
+                );
+                Some(env)
+            }
+            None => {
+                warn!("[notebook-sync] Auto-launch: Conda pool empty, falling back to kernelspec");
+                None
+            }
+        },
+        _ => None,
+    };
+
     // Launch kernel (default to python)
     let kernel_type = "python";
     match kernel
-        .launch(kernel_type, &env_source, notebook_path_opt.as_deref())
+        .launch(
+            kernel_type,
+            &env_source,
+            notebook_path_opt.as_deref(),
+            pooled_env,
+        )
         .await
     {
         Ok(()) => {
@@ -813,6 +860,7 @@ async fn auto_launch_kernel(
 async fn handle_notebook_request(
     room: &NotebookRoom,
     request: NotebookRequest,
+    daemon: std::sync::Arc<crate::daemon::Daemon>,
 ) -> NotebookResponse {
     info!("[notebook-sync] Handling request: {:?}", request);
 
@@ -883,8 +931,48 @@ async fn handle_notebook_request(
                     env_source.clone()
                 };
 
+            // Acquire prewarmed environment from pool if using prewarmed source
+            let pooled_env = match resolved_env_source.as_str() {
+                "uv:prewarmed" => match daemon.take_uv_env().await {
+                    Some(env) => {
+                        info!(
+                            "[notebook-sync] LaunchKernel: acquired UV env from pool: {:?}",
+                            env.python_path
+                        );
+                        Some(env)
+                    }
+                    None => {
+                        warn!(
+                                "[notebook-sync] LaunchKernel: UV pool empty, falling back to kernelspec"
+                            );
+                        None
+                    }
+                },
+                "conda:prewarmed" => match daemon.take_conda_env().await {
+                    Some(env) => {
+                        info!(
+                            "[notebook-sync] LaunchKernel: acquired Conda env from pool: {:?}",
+                            env.python_path
+                        );
+                        Some(env)
+                    }
+                    None => {
+                        warn!(
+                                "[notebook-sync] LaunchKernel: Conda pool empty, falling back to kernelspec"
+                            );
+                        None
+                    }
+                },
+                _ => None,
+            };
+
             match kernel
-                .launch(&kernel_type, &resolved_env_source, notebook_path.as_deref())
+                .launch(
+                    &kernel_type,
+                    &resolved_env_source,
+                    notebook_path.as_deref(),
+                    pooled_env,
+                )
                 .await
             {
                 Ok(()) => {


### PR DESCRIPTION
## Summary
- Properly integrates the daemon's prewarmed environment pool with kernel launching
- Removes the CI workaround from PR #324 (setup-python + ipykernel install)

## Background
PR #324 added a workaround that installed Python + ipykernel on CI to create a system kernelspec. This worked but was a band-aid - the daemon's prewarmed UV pool was being ignored.

## Solution
The daemon now properly uses prewarmed environments from the pool when `env_source` is `"uv:prewarmed"` or `"conda:prewarmed"`:

1. Added `take_uv_env()` and `take_conda_env()` methods to `Daemon`
2. Pass `Arc<Daemon>` to notebook sync server for pool access
3. Modified `RoomKernel.launch()` to accept optional `PooledEnv`
4. When env is provided, launch kernel using `env.python_path` directly via `python -m ipykernel_launcher` instead of kernelspec lookup
5. Updated `auto_launch_kernel` and `LaunchKernel` handler to acquire prewarmed envs from pool before launching
6. Removed CI workaround that installed Python + ipykernel globally

## Log output with pool integration
```
[runtimed] Took UV env for kernel launch: ".../envs/runtimed-uv-b7ffe5e5..."
[notebook-sync] Auto-launch: acquired UV env from pool: ".../bin/python"
[kernel-manager] Starting kernel from prewarmed env at ".../bin/python"
```

## Test plan
- [x] E2E smoke tests pass locally (3/3) using prewarmed pool
- [ ] CI E2E smoke test passes without Python/ipykernel installation