### PR TITLE
Add UI for prewarm pool errors

### DIFF
--- a/apps/notebook/src/components/DaemonStatusBanner.tsx
+++ b/apps/notebook/src/components/DaemonStatusBanner.tsx
@@ -1,6 +1,24 @@
 import { AlertTriangle, Loader2, RefreshCw, X } from "lucide-react";
 
 /**
+ * Error information for a prewarm pool that is failing to create environments.
+ */
+export interface PoolError {
+  message: string;
+  failed_package?: string;
+  consecutive_failures: number;
+  retry_in_secs: number;
+}
+
+/**
+ * Pool state broadcast from daemon.
+ */
+export interface PoolState {
+  uv_error: PoolError | null;
+  conda_error: PoolError | null;
+}
+
+/**
  * Status of the daemon during startup or operation.
  * Matches the DaemonProgress enum from Rust.
  */
@@ -16,8 +34,10 @@ export type DaemonStatus =
 
 interface DaemonStatusBannerProps {
   status: DaemonStatus;
+  poolState?: PoolState | null;
   onDismiss?: () => void;
   onRetry?: () => void;
+  onDismissPoolError?: () => void;
 }
 
 /**
@@ -26,20 +46,24 @@ interface DaemonStatusBannerProps {
  * Shows different visual states:
  * - Blue/info with spinner: Installing, upgrading, starting, waiting
  * - Amber/warning: Failed state with retry button
+ * - Amber/warning: Pool errors (invalid packages in settings)
  * - Hidden: Ready state or null
  */
 export function DaemonStatusBanner({
   status,
+  poolState,
   onDismiss,
   onRetry,
+  onDismissPoolError,
 }: DaemonStatusBannerProps) {
-  // Don't show banner for ready or null state
-  if (!status || status.status === "ready") {
-    return null;
-  }
+  // Check for pool errors (show even when daemon is ready)
+  const hasPoolError = poolState?.uv_error || poolState?.conda_error;
 
-  // Failed state - amber banner with error message and retry button
-  if (status.status === "failed") {
+  // Determine what to show based on status and pool errors
+  // Priority: failed > progress > pool_error > nothing
+
+  // 1. Failed state takes priority - show error with retry
+  if (status?.status === "failed") {
     return (
       <div className="flex items-center justify-between gap-2 bg-amber-600/90 px-3 py-1 text-xs text-white">
         <div className="flex items-center gap-2 min-w-0">
@@ -74,22 +98,81 @@ export function DaemonStatusBanner({
     );
   }
 
-  // Progress states - soft blue banner with spinner
-  const message = getProgressMessage(status);
+  // 2. Progress states - show spinner
+  if (status && status.status !== "ready") {
+    return (
+      <div className="flex items-center gap-2 bg-sky-600/90 px-3 py-1 text-xs text-white">
+        <Loader2 className="h-3 w-3 animate-spin flex-shrink-0" />
+        <span>{getProgressMessage(status)}</span>
+      </div>
+    );
+  }
 
-  return (
-    <div className="flex items-center gap-2 bg-sky-600/90 px-3 py-1 text-xs text-white">
-      <Loader2 className="h-3 w-3 animate-spin flex-shrink-0" />
-      <span>{message}</span>
-    </div>
-  );
+  // 3. Pool errors - show when daemon is ready but pool has issues
+  if (hasPoolError) {
+    const errors: Array<{ type: "uv" | "conda"; error: PoolError }> = [];
+    if (poolState?.uv_error) {
+      errors.push({ type: "uv", error: poolState.uv_error });
+    }
+    if (poolState?.conda_error) {
+      errors.push({ type: "conda", error: poolState.conda_error });
+    }
+
+    return (
+      <div className="flex flex-col gap-1 bg-amber-600/90 px-3 py-1.5 text-xs text-white">
+        {errors.map(({ type, error }, index) => (
+          <div key={type} className="flex items-center justify-between gap-2">
+            <div className="flex items-center gap-2 min-w-0">
+              <AlertTriangle className="h-3 w-3 flex-shrink-0" />
+              <span className="font-medium flex-shrink-0">
+                {type === "uv" ? "UV" : "Conda"} pool error
+              </span>
+              <span className="text-amber-200 flex-shrink-0">—</span>
+              <span className="text-amber-100 truncate">
+                {error.failed_package
+                  ? `Failed to install "${error.failed_package}"`
+                  : error.message}
+              </span>
+              {error.retry_in_secs > 0 && (
+                <>
+                  <span className="text-amber-200 flex-shrink-0">·</span>
+                  <span className="text-amber-200 flex-shrink-0">
+                    Retry in {formatRetryTime(error.retry_in_secs)}
+                  </span>
+                </>
+              )}
+            </div>
+            {index === 0 && onDismissPoolError && (
+              <button
+                type="button"
+                onClick={onDismissPoolError}
+                className="rounded p-0.5 hover:bg-amber-500/50 transition-colors flex-shrink-0"
+                aria-label="Dismiss"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            )}
+          </div>
+        ))}
+        <div className="text-amber-200 text-[10px]">
+          Check your default packages in Settings. Invalid packages prevent
+          environment prewarming.
+        </div>
+      </div>
+    );
+  }
+
+  // 4. Nothing to show (status is null or ready, no pool errors)
+  return null;
 }
 
 function getProgressMessage(
-  status: Exclude<
-    DaemonStatus,
-    null | { status: "ready" } | { status: "failed" }
-  >,
+  status:
+    | { status: "checking" }
+    | { status: "installing" }
+    | { status: "upgrading" }
+    | { status: "starting" }
+    | { status: "waiting_for_ready"; attempt: number; max_attempts: number },
 ): string {
   switch (status.status) {
     case "checking":
@@ -103,4 +186,16 @@ function getProgressMessage(
     case "waiting_for_ready":
       return `Starting runtime (${status.attempt}/${status.max_attempts})...`;
   }
+}
+
+function formatRetryTime(seconds: number): string {
+  if (seconds < 60) {
+    return `${seconds}s`;
+  }
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+  if (remainingSeconds === 0) {
+    return `${minutes}m`;
+  }
+  return `${minutes}m ${remainingSeconds}s`;
 }


### PR DESCRIPTION
Display warnings when invalid packages in `uv.default_packages` or `conda.default_packages` settings prevent environment prewarming. The UI shows the failed package name, error message, and retry countdown with exponential backoff (30s → 60s → 120s → 240s → 300s max).

This integrates pool error display directly into the existing `DaemonStatusBanner` component by adding a Tauri event bridge that subscribes to the daemon's `PoolState` broadcasts.

Closes #296

## Verification

- [ ] Set an invalid package: `echo '{"uv":{"default_packages":["scitkit-learn"]}}' > ~/.config/runt-notebook/settings.json`
- [ ] Start app with `cargo xtask dev`
- [ ] Verify amber banner appears showing failed package and retry countdown
- [ ] Fix the typo in settings
- [ ] Verify banner clears when pool recovers
- [ ] Test dismiss button (banner should reappear on new errors)

_PR submitted by @rgbkrk's agent, Quill_