### PR TITLE
Remove kernelspec dependencies and add on-demand environment creation

### DIFF
--- a/apps/notebook/src/types.ts
+++ b/apps/notebook/src/types.ts
@@ -40,12 +40,6 @@ export type JupyterOutput =
       traceback: string[];
     };
 
-export interface KernelspecInfo {
-  name: string;
-  display_name: string;
-  language: string;
-}
-
 export interface JupyterMessage {
   header: {
     msg_id: string;

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -49,13 +49,6 @@ use std::sync::{Arc, Mutex};
 use tauri::RunEvent;
 use tauri::{Emitter, Manager};
 
-#[derive(Serialize)]
-struct KernelspecInfo {
-    name: String,
-    display_name: String,
-    language: String,
-}
-
 /// Git information for debug banner display.
 #[derive(Serialize)]
 struct GitInfo {
@@ -1297,32 +1290,6 @@ fn debug_get_local_state(
         .collect();
 
     Ok(json_cells)
-}
-
-#[tauri::command]
-async fn get_preferred_kernelspec(
-    state: tauri::State<'_, Arc<Mutex<NotebookState>>>,
-) -> Result<Option<String>, String> {
-    let state = state.lock().map_err(|e| e.to_string())?;
-    Ok(state
-        .notebook
-        .metadata
-        .kernelspec
-        .as_ref()
-        .map(|k| k.name.clone()))
-}
-
-#[tauri::command]
-async fn list_kernelspecs() -> Result<Vec<KernelspecInfo>, String> {
-    let specs = runtimelib::list_kernelspecs().await;
-    Ok(specs
-        .into_iter()
-        .map(|s| KernelspecInfo {
-            name: s.kernel_name,
-            display_name: s.kernelspec.display_name,
-            language: s.kernelspec.language,
-        })
-        .collect())
 }
 
 // ============================================================================
@@ -2666,9 +2633,6 @@ pub fn run(
             refresh_from_automerge,
             debug_get_automerge_state,
             debug_get_local_state,
-            // Kernelspec discovery (used by UI)
-            get_preferred_kernelspec,
-            list_kernelspecs,
             // UV dependency management
             check_uv_available,
             get_notebook_dependencies,

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -48,7 +48,7 @@ The dependency panel shows pixi dependencies and offers an "Import to notebook" 
 
 ## Deno Notebooks
 
-For Deno/TypeScript notebooks, Runt detects `deno.json` or `deno.jsonc` configuration files. Deno manages its own dependencies through import maps and URL imports, so the environment setup is simpler — Runt just needs Deno installed.
+For Deno/TypeScript notebooks, Runt detects `deno.json` or `deno.jsonc` configuration files. Deno manages its own dependencies through import maps and URL imports, so the environment setup is simpler. If Deno is not found on your PATH, Runt automatically bootstraps it from conda-forge using rattler.
 
 ## User Preferences
 


### PR DESCRIPTION
## Summary

Remove all kernelspec dependencies from daemon kernel launching and replace with on-demand environment creation. The daemon now creates environments on-demand when the prewarmed pool is exhausted, ensuring kernel launches always succeed.

**Related audit**: Confirmed that tool bootstrapping (deno, uv, ruff) properly uses conda-forge via rattler with PATH fallback - no changes needed there.

## Changes

- **daemon.rs**: Add `create_uv_env_on_demand()` and `create_conda_env_on_demand()` methods for creating environments when pool is empty
- **kernel_manager.rs**: Change `launch()` to require `PooledEnv` (not `Option`); remove kernelspec fallback entirely
- **notebook_sync_server.rs**: Replace kernelspec fallback with on-demand env creation at 4 call sites (auto-launch + LaunchKernel for both UV and Conda)
- **lib.rs**: Remove dead `get_preferred_kernelspec` and `list_kernelspecs` Tauri commands
- **NotebookToolbar.tsx**: Remove unused `listKernelspecs` prop and simplify kernel start logic
- **types.ts**: Remove unused `KernelspecInfo` interface
- **environments.md**: Fix documentation - Deno auto-bootstraps from conda-forge via rattler, not manually installed

## Notes

- The CLI tool (`runt`) retains kernelspec support for advanced users and standalone operations
- On-demand environment creation may be slower than prewarmed, but guarantees kernel launch success
- This complements PR #332 (pool error UI) - users will see when prewarming fails and understand why, while kernel launches still work via on-demand creation

## Verification

- Rust code compiles with `cargo clippy --all-targets -- -D warnings`
- All unit tests pass (164 passed)
- TypeScript formatting validated with biome

_PR submitted by @rgbkrk's agent, Quill_