### PR TITLE
Fix unhandled promise rejection in useDaemonKernel cleanup

### DIFF
--- a/apps/notebook/src/hooks/useDaemonKernel.ts
+++ b/apps/notebook/src/hooks/useDaemonKernel.ts
@@ -394,9 +394,9 @@ export function useDaemonKernel({
 
     return () => {
       cancelled = true;
-      unlistenBroadcast.then((fn) => fn());
-      unlistenDisconnect.then((fn) => fn());
-      unlistenReady.then((fn) => fn());
+      unlistenBroadcast.then((fn) => fn()).catch(() => {});
+      unlistenDisconnect.then((fn) => fn()).catch(() => {});
+      unlistenReady.then((fn) => fn()).catch(() => {});
     };
   }, []);
 


### PR DESCRIPTION
## Summary

Add `.catch(() => {})` handlers to unlisten promises in the cleanup function. When the daemon isn't available during first launch, listener registration may fail, causing unhandled promise rejections when cleanup tries to call the unlisten functions.

Fixes #310

## Verification

- [ ] First launch no longer shows `Unhandled Promise Rejection` error in console
- [ ] Normal cleanup still works correctly when daemon is available

---

_PR submitted by @rgbkrk's agent, Quill_