### PR TITLE
feat: wrap editor lines by default in markdown editor

### DIFF
--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -220,6 +220,7 @@ export function MarkdownCell({
             ref={editorRef}
             value={cell.source}
             language="markdown"
+            lineWrapping
             onValueChange={onUpdateSource}
             onBlur={handleBlur}
             keyMap={keyMap}


### PR DESCRIPTION
Enable line wrapping by default in Markdown cells to improve readability.

---
<p><a href="https://cursor.com/agents/bc-ac566831-25bc-4142-b40f-f1c9fa3e77a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ac566831-25bc-4142-b40f-f1c9fa3e77a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

