### PR TITLE
test(e2e): add kernel launch E2E tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,9 @@ crates/notebook/fixtures/**/uv.lock
 # E2E test screenshots
 e2e-screenshots/
 
+# E2E daemon PID file
+.e2e-daemon.pid
+
 # Generated Tauri icons (keep source + build-required files)
 # Ignore platform-specific icons not needed for macOS/Linux/Windows build
 crates/notebook/icons/64x64.png

--- a/e2e/specs/deno.spec.js
+++ b/e2e/specs/deno.spec.js
@@ -1,0 +1,34 @@
+/**
+ * E2E Test: Deno Kernel
+ *
+ * Verifies that notebooks with Deno kernelspec are detected correctly
+ * and launch with the Deno runtime (not Python).
+ *
+ * Fixture: 10-deno.ipynb (has kernelspec.name = "deno")
+ */
+
+import { browser } from "@wdio/globals";
+import {
+  executeFirstCell,
+  waitForCellOutput,
+  waitForKernelReady,
+} from "../helpers.js";
+
+describe("Deno Kernel", () => {
+  it("should auto-launch Deno kernel", async () => {
+    // Wait for kernel to auto-launch (90s, includes deno bootstrap if needed)
+    await waitForKernelReady(90000);
+  });
+
+  it("should execute TypeScript and show output", async () => {
+    // Execute the first cell which logs "deno:ok" and version
+    const cell = await executeFirstCell();
+
+    // Wait for output
+    const output = await waitForCellOutput(cell, 30000);
+
+    // Verify Deno executed the code
+    expect(output).toContain("deno:ok");
+    expect(output).toContain("version:");
+  });
+});

--- a/e2e/specs/prewarmed-uv.spec.js
+++ b/e2e/specs/prewarmed-uv.spec.js
@@ -10,9 +10,9 @@
 import { browser } from "@wdio/globals";
 import {
   executeFirstCell,
+  isManagedEnv,
   waitForCellOutput,
   waitForKernelReady,
-  isManagedEnv,
 } from "../helpers.js";
 
 describe("Prewarmed Environment Pool", () => {

--- a/e2e/specs/prewarmed-uv.spec.js
+++ b/e2e/specs/prewarmed-uv.spec.js
@@ -1,0 +1,35 @@
+/**
+ * E2E Test: Prewarmed UV Pool
+ *
+ * Verifies that basic Python notebooks use prewarmed UV environments
+ * from the daemon's pool for fast startup.
+ *
+ * Fixture: 1-vanilla.ipynb (no inline deps, no project file)
+ */
+
+import { browser } from "@wdio/globals";
+import {
+  executeFirstCell,
+  waitForCellOutput,
+  waitForKernelReady,
+  isManagedEnv,
+} from "../helpers.js";
+
+describe("Prewarmed UV Pool", () => {
+  it("should auto-launch kernel from UV pool", async () => {
+    // Wait for kernel to auto-launch (90s for first startup)
+    await waitForKernelReady(90000);
+  });
+
+  it("should execute code and show managed env path", async () => {
+    // Execute the cell which prints sys.executable
+    const cell = await executeFirstCell();
+
+    // Wait for output
+    const output = await waitForCellOutput(cell, 30000);
+
+    // Verify it's a managed environment (runtimed-uv-* path)
+    expect(isManagedEnv(output)).toBe(true);
+    expect(output).toContain("runtimed-uv");
+  });
+});

--- a/e2e/specs/prewarmed-uv.spec.js
+++ b/e2e/specs/prewarmed-uv.spec.js
@@ -1,7 +1,7 @@
 /**
- * E2E Test: Prewarmed UV Pool
+ * E2E Test: Prewarmed Environment Pool
  *
- * Verifies that basic Python notebooks use prewarmed UV environments
+ * Verifies that basic Python notebooks use prewarmed environments
  * from the daemon's pool for fast startup.
  *
  * Fixture: 1-vanilla.ipynb (no inline deps, no project file)
@@ -15,8 +15,8 @@ import {
   isManagedEnv,
 } from "../helpers.js";
 
-describe("Prewarmed UV Pool", () => {
-  it("should auto-launch kernel from UV pool", async () => {
+describe("Prewarmed Environment Pool", () => {
+  it("should auto-launch kernel from pool", async () => {
     // Wait for kernel to auto-launch (90s for first startup)
     await waitForKernelReady(90000);
   });
@@ -26,10 +26,11 @@ describe("Prewarmed UV Pool", () => {
     const cell = await executeFirstCell();
 
     // Wait for output
-    const output = await waitForCellOutput(cell, 30000);
+    const output = await waitForCellOutput(cell, 60000);
 
-    // Verify it's a managed environment (runtimed-uv-* path)
+    // Verify it's a managed environment (runtimed-uv-* or runtimed-conda-*)
     expect(isManagedEnv(output)).toBe(true);
-    expect(output).toContain("runtimed-uv");
+    // Should be from daemon's prewarmed pool
+    expect(output).toMatch(/runtimed-(uv|conda)/);
   });
 });

--- a/e2e/specs/uv-inline.spec.js
+++ b/e2e/specs/uv-inline.spec.js
@@ -1,0 +1,67 @@
+/**
+ * E2E Test: UV Inline Dependencies
+ *
+ * Verifies that notebooks with inline UV dependencies get a cached
+ * environment with those deps installed (not the prewarmed pool).
+ *
+ * Fixture: 2-uv-inline.ipynb (has requests dependency)
+ */
+
+import { browser } from "@wdio/globals";
+import {
+  executeFirstCell,
+  waitForCellOutput,
+  waitForKernelReady,
+  approveTrustDialog,
+  typeSlowly,
+} from "../helpers.js";
+
+describe("UV Inline Dependencies", () => {
+  it("should auto-launch kernel (may need trust approval)", async () => {
+    // Wait for kernel or trust dialog (90s for first startup + env creation)
+    await waitForKernelReady(120000);
+  });
+
+  it("should have inline deps available after trust", async () => {
+    // Execute the first cell (prints sys.executable)
+    const cell = await executeFirstCell();
+
+    // May need to approve trust dialog for inline deps
+    const approved = await approveTrustDialog(15000);
+    if (approved) {
+      // If trust dialog appeared, wait for kernel to restart with deps
+      await waitForKernelReady(120000);
+      // Re-execute after kernel restart
+      await browser.keys(["Shift", "Enter"]);
+    }
+
+    // Wait for output
+    const output = await waitForCellOutput(cell, 60000);
+
+    // Should be a cached inline env (inline-* path)
+    expect(output).toContain("inline-");
+  });
+
+  it("should be able to import inline dependency", async () => {
+    // Find a cell and type import test
+    const cells = await $$('[data-cell-type="code"]');
+    const cell = cells.length > 1 ? cells[1] : cells[0];
+
+    const editor = await cell.$('.cm-content[contenteditable="true"]');
+    await editor.click();
+    await browser.pause(200);
+
+    // Select all and type import
+    const modKey = process.platform === "darwin" ? "Meta" : "Control";
+    await browser.keys([modKey, "a"]);
+    await browser.pause(100);
+
+    await typeSlowly("import requests; print(requests.__version__)");
+    await browser.keys(["Shift", "Enter"]);
+
+    // Wait for version output
+    const output = await waitForCellOutput(cell, 30000);
+    // Should show a version number (e.g., "2.31.0")
+    expect(output).toMatch(/^\d+\.\d+/);
+  });
+});

--- a/e2e/specs/uv-inline.spec.js
+++ b/e2e/specs/uv-inline.spec.js
@@ -9,11 +9,11 @@
 
 import { browser } from "@wdio/globals";
 import {
+  approveTrustDialog,
   executeFirstCell,
+  typeSlowly,
   waitForCellOutput,
   waitForKernelReady,
-  approveTrustDialog,
-  typeSlowly,
 } from "../helpers.js";
 
 describe("UV Inline Dependencies", () => {

--- a/e2e/specs/uv-pyproject.spec.js
+++ b/e2e/specs/uv-pyproject.spec.js
@@ -1,0 +1,58 @@
+/**
+ * E2E Test: UV pyproject.toml Detection
+ *
+ * Verifies that notebooks in directories with pyproject.toml use
+ * `uv run` to get project dependencies.
+ *
+ * Fixture: pyproject-project/5-pyproject.ipynb
+ *          pyproject-project/pyproject.toml (has pandas, numpy)
+ */
+
+import { browser } from "@wdio/globals";
+import {
+  executeFirstCell,
+  waitForCellOutput,
+  waitForKernelReady,
+  typeSlowly,
+} from "../helpers.js";
+
+describe("UV pyproject.toml Detection", () => {
+  it("should auto-launch kernel with project deps", async () => {
+    // Wait for kernel to auto-launch (120s, includes uv sync if needed)
+    await waitForKernelReady(120000);
+  });
+
+  it("should execute code", async () => {
+    // Execute the first cell which prints sys.executable
+    const cell = await executeFirstCell();
+
+    // Wait for output
+    const output = await waitForCellOutput(cell, 30000);
+
+    // Should show a Python path
+    expect(output).toContain("python");
+  });
+
+  it("should have project deps available (pandas)", async () => {
+    // Find a cell and type import test
+    const cells = await $$('[data-cell-type="code"]');
+    const cell = cells.length > 1 ? cells[1] : cells[0];
+
+    const editor = await cell.$('.cm-content[contenteditable="true"]');
+    await editor.click();
+    await browser.pause(200);
+
+    // Select all and type import
+    const modKey = process.platform === "darwin" ? "Meta" : "Control";
+    await browser.keys([modKey, "a"]);
+    await browser.pause(100);
+
+    await typeSlowly("import pandas; print(pandas.__version__)");
+    await browser.keys(["Shift", "Enter"]);
+
+    // Wait for version output
+    const output = await waitForCellOutput(cell, 60000);
+    // Should show pandas version (e.g., "2.1.0")
+    expect(output).toMatch(/^\d+\.\d+/);
+  });
+});

--- a/e2e/specs/uv-pyproject.spec.js
+++ b/e2e/specs/uv-pyproject.spec.js
@@ -11,9 +11,9 @@
 import { browser } from "@wdio/globals";
 import {
   executeFirstCell,
+  typeSlowly,
   waitForCellOutput,
   waitForKernelReady,
-  typeSlowly,
 } from "../helpers.js";
 
 describe("UV pyproject.toml Detection", () => {

--- a/e2e/wdio.conf.js
+++ b/e2e/wdio.conf.js
@@ -27,8 +27,14 @@ const SCREENSHOT_FAILURES_DIR = path.join(SCREENSHOT_DIR, "failures");
 // Ensure screenshot directories exist
 fs.mkdirSync(SCREENSHOT_FAILURES_DIR, { recursive: true });
 
-// Note: Previously had FIXTURE_SPECS exclusion list, but tests have been reset.
-// All specs now run by default. Use E2E_SPEC env var to run a specific spec.
+// Fixture specs require NOTEBOOK_PATH to be set and are excluded from the default run.
+// Use ./e2e/dev.sh test-fixture <notebook> <spec> to run them individually.
+const FIXTURE_SPECS = [
+  "deno.spec.js",
+  "prewarmed-uv.spec.js",
+  "uv-inline.spec.js",
+  "uv-pyproject.spec.js",
+];
 
 export const config = {
   runner: "local",
@@ -37,8 +43,10 @@ export const config = {
     ? [path.resolve(process.env.E2E_SPEC)]
     : [path.join(__dirname, "specs", "*.spec.js")],
 
-  // No exclusions - all specs run by default
-  exclude: [],
+  // Exclude fixture specs from default run (they require NOTEBOOK_PATH)
+  exclude: process.env.E2E_SPEC
+    ? []
+    : FIXTURE_SPECS.map((spec) => path.join(__dirname, "specs", spec)),
 
   // Don't run tests in parallel - we have one app instance
   maxInstances: 1,


### PR DESCRIPTION
## Summary

Add E2E tests for daemon-based kernel launching from PR #337. Tests verify:
- Prewarmed environment pool auto-launch
- Inline UV dependencies with trust dialog
- pyproject.toml project file detection
- Deno kernelspec detection and TypeScript execution

Also add `.e2e-daemon.pid` to gitignore to prevent committing the daemon PID file created during test runs.

## Tests

Reviewers can verify these tests by running:

```bash
./e2e/dev.sh build-full
./e2e/dev.sh test-fixture crates/notebook/fixtures/audit-test/1-vanilla.ipynb e2e/specs/prewarmed-uv.spec.js
./e2e/dev.sh test-fixture crates/notebook/fixtures/audit-test/2-uv-inline.ipynb e2e/specs/uv-inline.spec.js
./e2e/dev.sh test-fixture crates/notebook/fixtures/audit-test/pyproject-project/5-pyproject.ipynb e2e/specs/uv-pyproject.spec.js
./e2e/dev.sh test-fixture crates/notebook/fixtures/audit-test/10-deno.ipynb e2e/specs/deno.spec.js
```

_PR submitted by @rgbkrk's agent, Quill_