### PR TITLE
Implement conda:inline support with rattler-based environment caching

### DIFF
--- a/crates/notebook/fixtures/audit-test/3-conda-inline.ipynb
+++ b/crates/notebook/fixtures/audit-test/3-conda-inline.ipynb
@@ -13,6 +13,11 @@
     }
   ],
   "metadata": {
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3",
+      "language": "python"
+    },
     "conda": {
       "dependencies": [
         "numpy"

--- a/crates/runtimed/src/inline_env.rs
+++ b/crates/runtimed/src/inline_env.rs
@@ -1,6 +1,6 @@
 //! Cached environment creation for inline dependencies.
 //!
-//! Creates and caches environments for notebooks with inline UV dependencies.
+//! Creates and caches environments for notebooks with inline UV or Conda dependencies.
 //! Environments are cached by dependency hash for fast reuse.
 
 use anyhow::{anyhow, Result};
@@ -134,6 +134,244 @@ pub async fn prepare_uv_inline_env(deps: &[String]) -> Result<PreparedEnv> {
     })
 }
 
-// TODO: Implement prepare_conda_inline_env using rattler
-// For now, conda:inline falls back to prewarmed pool (deps not installed)
-// The implementation would mirror daemon.rs create_conda_env but with custom specs
+/// Compute a stable hash for conda dependencies + channels.
+///
+/// Includes channels in the hash because the same package name from different
+/// channels can yield different packages.
+fn compute_conda_deps_hash(deps: &[String], channels: &[String]) -> String {
+    let mut hasher = Sha256::new();
+
+    // Hash channels first (sorted for stability)
+    let mut sorted_channels = channels.to_vec();
+    sorted_channels.sort();
+    for ch in &sorted_channels {
+        hasher.update(b"channel:");
+        hasher.update(ch.as_bytes());
+        hasher.update(b"\n");
+    }
+
+    // Then hash deps (sorted for stability)
+    let mut sorted_deps = deps.to_vec();
+    sorted_deps.sort();
+    for dep in &sorted_deps {
+        hasher.update(dep.as_bytes());
+        hasher.update(b"\n");
+    }
+
+    let result = hasher.finalize();
+    format!("conda-inline-{}", hex::encode(&result[..8]))
+}
+
+/// Prepare a cached Conda environment with the given inline dependencies.
+///
+/// If a cached environment with the same deps+channels already exists, returns it
+/// immediately. Otherwise creates a new environment using rattler (solve + install).
+///
+/// This mirrors the pattern in `daemon.rs::create_conda_env` but for inline deps
+/// instead of the prewarmed pool.
+pub async fn prepare_conda_inline_env(deps: &[String], channels: &[String]) -> Result<PreparedEnv> {
+    use rattler::{default_cache_dir, install::Installer, package_cache::PackageCache};
+    use rattler_conda_types::{
+        Channel, ChannelConfig, GenericVirtualPackage, MatchSpec, ParseMatchSpecOptions, Platform,
+    };
+    use rattler_repodata_gateway::Gateway;
+    use rattler_solve::{resolvo, SolverImpl, SolverTask};
+
+    let hash = compute_conda_deps_hash(deps, channels);
+    let cache_dir = get_inline_cache_dir();
+    let env_path = cache_dir.join(&hash);
+
+    // Determine python path based on platform
+    #[cfg(target_os = "windows")]
+    let python_path = env_path.join("python.exe");
+    #[cfg(not(target_os = "windows"))]
+    let python_path = env_path.join("bin").join("python");
+
+    // Check if cached environment exists and is valid
+    if env_path.exists() && python_path.exists() {
+        info!(
+            "[inline-env] Cache hit for Conda inline deps {:?} at {:?}",
+            deps, env_path
+        );
+        return Ok(PreparedEnv {
+            env_path,
+            python_path,
+        });
+    }
+
+    info!(
+        "[inline-env] Creating new Conda env for deps {:?} (channels: {:?}) at {:?}",
+        deps, channels, env_path
+    );
+
+    // Ensure cache directory exists
+    tokio::fs::create_dir_all(&cache_dir).await?;
+
+    // Remove partial/invalid environment if it exists
+    if env_path.exists() {
+        tokio::fs::remove_dir_all(&env_path).await?;
+    }
+
+    // Setup channel configuration
+    let channel_config = ChannelConfig::default_with_root_dir(cache_dir.clone());
+
+    // Parse channels (default to conda-forge if none specified)
+    let channel_names = if channels.is_empty() {
+        vec!["conda-forge".to_string()]
+    } else {
+        channels.to_vec()
+    };
+    let parsed_channels: Vec<Channel> = channel_names
+        .iter()
+        .map(|ch| Channel::from_str(ch, &channel_config))
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .map_err(|e| anyhow!("Failed to parse conda channel: {}", e))?;
+
+    // Build specs: python + ipykernel + user deps
+    let match_spec_options = ParseMatchSpecOptions::strict();
+    let mut specs = vec![
+        MatchSpec::from_str("python>=3.9", match_spec_options)
+            .map_err(|e| anyhow!("Failed to parse python spec: {}", e))?,
+        MatchSpec::from_str("ipykernel", match_spec_options)
+            .map_err(|e| anyhow!("Failed to parse ipykernel spec: {}", e))?,
+    ];
+    for dep in deps {
+        specs.push(
+            MatchSpec::from_str(dep, match_spec_options)
+                .map_err(|e| anyhow!("Failed to parse dep '{}': {}", dep, e))?,
+        );
+    }
+
+    // Find rattler cache directory
+    let rattler_cache_dir =
+        default_cache_dir().map_err(|e| anyhow!("Could not determine rattler cache dir: {}", e))?;
+    rattler_cache::ensure_cache_dir(&rattler_cache_dir)
+        .map_err(|e| anyhow!("Could not create rattler cache dir: {}", e))?;
+
+    // Create HTTP client
+    let download_client = reqwest_middleware::ClientBuilder::new(
+        reqwest::Client::builder()
+            .build()
+            .map_err(|e| anyhow!("Failed to create HTTP client: {}", e))?,
+    )
+    .build();
+
+    // Create gateway for fetching repodata
+    let gateway = Gateway::builder()
+        .with_cache_dir(rattler_cache_dir.join(rattler_cache::REPODATA_CACHE_DIR))
+        .with_package_cache(PackageCache::new(
+            rattler_cache_dir.join(rattler_cache::PACKAGE_CACHE_DIR),
+        ))
+        .with_client(download_client.clone())
+        .finish();
+
+    // Query repodata
+    let install_platform = Platform::current();
+    let platforms = vec![install_platform, Platform::NoArch];
+
+    info!("[inline-env] Fetching conda repodata for inline deps...");
+    let repo_data = gateway
+        .query(parsed_channels, platforms, specs.clone())
+        .recursive(true)
+        .await
+        .map_err(|e| anyhow!("Failed to fetch conda repodata: {}", e))?;
+
+    info!("[inline-env] Solving conda dependencies...");
+
+    // Detect virtual packages
+    let virtual_packages = rattler_virtual_packages::VirtualPackage::detect(
+        &rattler_virtual_packages::VirtualPackageOverrides::default(),
+    )
+    .map_err(|e| anyhow!("Failed to detect virtual packages: {}", e))?
+    .iter()
+    .map(|vpkg| GenericVirtualPackage::from(vpkg.clone()))
+    .collect::<Vec<_>>();
+
+    // Solve dependencies
+    let solver_task = SolverTask {
+        virtual_packages,
+        specs,
+        ..SolverTask::from_iter(&repo_data)
+    };
+
+    let required_packages = resolvo::Solver
+        .solve(solver_task)
+        .map_err(|e| anyhow!("Failed to solve conda dependencies: {}", e))?
+        .records;
+
+    info!(
+        "[inline-env] Solved: {} conda packages to install",
+        required_packages.len()
+    );
+
+    // Install packages
+    Installer::new()
+        .with_download_client(download_client)
+        .with_target_platform(install_platform)
+        .install(&env_path, required_packages)
+        .await
+        .map_err(|e| {
+            // Clean up failed environment
+            let env_path_clone = env_path.clone();
+            tokio::spawn(async move {
+                tokio::fs::remove_dir_all(&env_path_clone).await.ok();
+            });
+            anyhow!("Failed to install conda packages: {}", e)
+        })?;
+
+    // Verify python exists
+    if !python_path.exists() {
+        tokio::fs::remove_dir_all(&env_path).await.ok();
+        return Err(anyhow!(
+            "Python not found at {:?} after conda install",
+            python_path
+        ));
+    }
+
+    info!(
+        "[inline-env] Conda inline environment ready at {:?}",
+        env_path
+    );
+
+    Ok(PreparedEnv {
+        env_path,
+        python_path,
+    })
+}
+
+/// Extract channels from conda metadata in a notebook file.
+/// Returns the list of channel strings, or defaults to ["conda-forge"].
+pub fn get_inline_conda_channels(notebook_path: &std::path::Path) -> Vec<String> {
+    let content = match std::fs::read_to_string(notebook_path) {
+        Ok(c) => c,
+        Err(_) => return vec!["conda-forge".to_string()],
+    };
+    let nb: serde_json::Value = match serde_json::from_str(&content) {
+        Ok(v) => v,
+        Err(_) => return vec!["conda-forge".to_string()],
+    };
+    let metadata_value = match nb.get("metadata") {
+        Some(m) => m,
+        None => return vec!["conda-forge".to_string()],
+    };
+
+    let metadata: std::collections::HashMap<String, serde_json::Value> =
+        match serde_json::from_value(metadata_value.clone()) {
+            Ok(m) => m,
+            Err(_) => return vec!["conda-forge".to_string()],
+        };
+
+    if let Some(conda) = runt_trust::get_conda_metadata(&metadata) {
+        if let Some(channels) = conda.get("channels").and_then(|c| c.as_array()) {
+            let ch: Vec<String> = channels
+                .iter()
+                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                .collect();
+            if !ch.is_empty() {
+                return ch;
+            }
+        }
+    }
+
+    vec!["conda-forge".to_string()]
+}

--- a/crates/runtimed/src/kernel_manager.rs
+++ b/crates/runtimed/src/kernel_manager.rs
@@ -483,6 +483,24 @@ impl RoomKernel {
                         cmd.stderr(Stdio::null());
                         cmd
                     }
+                    "conda:inline" => {
+                        // Use prepared cached conda environment with inline deps
+                        let pooled_env = env.ok_or_else(|| {
+                            anyhow::anyhow!(
+                                "conda:inline requires a prepared environment (was it created?)"
+                            )
+                        })?;
+                        info!(
+                            "[kernel-manager] Starting Python kernel with cached conda inline env at {:?}",
+                            pooled_env.python_path
+                        );
+                        let mut cmd = tokio::process::Command::new(&pooled_env.python_path);
+                        cmd.args(["-Xfrozen_modules=off", "-m", "ipykernel_launcher", "-f"]);
+                        cmd.arg(&connection_file_path);
+                        cmd.stdout(Stdio::null());
+                        cmd.stderr(Stdio::null());
+                        cmd
+                    }
                     _ => {
                         // Prewarmed - use pooled environment
                         let pooled_env = env.ok_or_else(|| {

--- a/e2e/specs/conda-inline.spec.js
+++ b/e2e/specs/conda-inline.spec.js
@@ -1,0 +1,67 @@
+/**
+ * E2E Test: Conda Inline Dependencies
+ *
+ * Verifies that notebooks with inline conda dependencies get a cached
+ * environment with those deps installed (via rattler, not the prewarmed pool).
+ *
+ * Fixture: 3-conda-inline.ipynb (has numpy dependency via conda)
+ */
+
+import { browser } from "@wdio/globals";
+import {
+  approveTrustDialog,
+  executeFirstCell,
+  typeSlowly,
+  waitForCellOutput,
+  waitForKernelReady,
+} from "../helpers.js";
+
+describe("Conda Inline Dependencies", () => {
+  it("should auto-launch kernel (may need trust approval)", async () => {
+    // Wait for kernel or trust dialog (120s for first startup + conda env creation)
+    await waitForKernelReady(180000);
+  });
+
+  it("should have inline deps available after trust", async () => {
+    // Execute the first cell (prints sys.executable)
+    const cell = await executeFirstCell();
+
+    // May need to approve trust dialog for inline deps
+    const approved = await approveTrustDialog(15000);
+    if (approved) {
+      // If trust dialog appeared, wait for kernel to restart with deps
+      await waitForKernelReady(180000);
+      // Re-execute after kernel restart
+      await browser.keys(["Shift", "Enter"]);
+    }
+
+    // Wait for output
+    const output = await waitForCellOutput(cell, 120000);
+
+    // Should be a cached conda inline env (conda-inline-* path)
+    expect(output).toContain("conda-inline-");
+  });
+
+  it("should be able to import inline dependency", async () => {
+    // Find a cell and type import test
+    const cells = await $$('[data-cell-type="code"]');
+    const cell = cells.length > 1 ? cells[1] : cells[0];
+
+    const editor = await cell.$('.cm-content[contenteditable="true"]');
+    await editor.click();
+    await browser.pause(200);
+
+    // Select all and type import
+    const modKey = process.platform === "darwin" ? "Meta" : "Control";
+    await browser.keys([modKey, "a"]);
+    await browser.pause(100);
+
+    await typeSlowly("import numpy; print(numpy.__version__)");
+    await browser.keys(["Shift", "Enter"]);
+
+    // Wait for version output
+    const output = await waitForCellOutput(cell, 30000);
+    // Should show a version number (e.g., "1.26.4")
+    expect(output).toMatch(/^\d+\.\d+/);
+  });
+});

--- a/e2e/wdio.conf.js
+++ b/e2e/wdio.conf.js
@@ -30,6 +30,7 @@ fs.mkdirSync(SCREENSHOT_FAILURES_DIR, { recursive: true });
 // Fixture specs require NOTEBOOK_PATH to be set and are excluded from the default run.
 // Use ./e2e/dev.sh test-fixture <notebook> <spec> to run them individually.
 const FIXTURE_SPECS = [
+  "conda-inline.spec.js",
   "deno.spec.js",
   "prewarmed-uv.spec.js",
   "uv-inline.spec.js",


### PR DESCRIPTION
## Summary
This PR implements full support for `conda:inline` dependencies in notebooks, mirroring the existing `uv:inline` functionality. Notebooks can now specify conda dependencies inline with optional custom channels, and runtimed will create and cache conda environments using rattler.

## Key Changes

- **Added `prepare_conda_inline_env()` function** in `inline_env.rs`: Implements conda environment creation using rattler for dependency solving and installation, with caching by dependency+channel hash
- **Added `compute_conda_deps_hash()` function**: Generates stable cache keys for conda environments, including channels in the hash since the same package from different channels can differ
- **Added `get_inline_conda_channels()` function**: Extracts conda channel configuration from notebook metadata, defaulting to `conda-forge`
- **Updated `notebook_sync_server.rs`**: 
  - Integrated `conda:inline` handling in both `auto_launch_kernel()` and `handle_notebook_request()` paths
  - Extracts inline conda deps and channels, prepares cached environment, and broadcasts installation progress
  - Treats `conda:inline` like `uv:inline` and `uv:pyproject` (no pooled env needed)
- **Updated `kernel_manager.rs`**: Added `conda:inline` case to use prepared cached conda environment directly
- **Updated test fixture**: Added kernelspec metadata to `3-conda-inline.ipynb` for proper notebook configuration
- **Added E2E test**: New `conda-inline.spec.js` test verifies inline conda deps are available and importable

## Implementation Details

- Conda environment caching uses the same pattern as UV inline: hash-based cache directory with validation
- Channels are included in the hash computation to ensure different channel sources don't collide
- Uses rattler's `Gateway` for repodata fetching, `Solver` for dependency resolution, and `Installer` for package installation
- Automatically detects virtual packages and includes `python>=3.9` and `ipykernel` in all conda inline environments
- Failed environment creation is cleaned up to prevent partial/invalid cache entries
- Installation progress is broadcast to the frontend via `KernelStatus` messages
