### PR TITLE
refactor(notebook): remove redundant runt.runtime field

### DIFF
--- a/contributing/environments.md
+++ b/contributing/environments.md
@@ -515,9 +515,14 @@ Dependencies and environment config are stored in notebook JSON metadata:
 ```json
 {
   "metadata": {
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3",
+      "language": "python"
+    },
     "runt": {
-      "env_id": "uuid",
-      "runtime": "python"
+      "schema_version": "1",
+      "env_id": "uuid"
     },
     "uv": {
       "dependencies": ["pandas", "numpy"],
@@ -535,6 +540,8 @@ Dependencies and environment config are stored in notebook JSON metadata:
   }
 }
 ```
+
+Note: The runtime type (Python vs Deno) is determined by `kernelspec.name`, not by a field in `runt`. The kernelspec is the standard Jupyter metadata field.
 
 `runt.env_id` is the canonical per-notebook identifier used for environment isolation.
 

--- a/crates/notebook/fixtures/audit-test/10-deno.ipynb
+++ b/crates/notebook/fixtures/audit-test/10-deno.ipynb
@@ -1,30 +1,30 @@
 {
-    "cells": [
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "id": "cell-1",
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "console.log(\"deno:ok\");\n",
-                "console.log(`version:${Deno.version.deno}`);"
-            ]
-        }
-    ],
-    "metadata": {
-        "kernelspec": {
-            "display_name": "Deno",
-            "language": "typescript",
-            "name": "deno"
-        },
-        "language_info": {
-            "name": "typescript"
-        },
-        "runt": {
-            "runtime": "deno"
-        }
+  "cells": [
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "cell-1",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "console.log(\"deno:ok\");\n",
+        "console.log(`version:${Deno.version.deno}`);"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Deno",
+      "language": "typescript",
+      "name": "deno"
     },
-    "nbformat": 4,
-    "nbformat_minor": 5
+    "language_info": {
+      "name": "typescript"
+    },
+    "runt": {
+      "schema_version": "1"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
 }

--- a/e2e/specs/deno.spec.js
+++ b/e2e/specs/deno.spec.js
@@ -7,7 +7,6 @@
  * Fixture: 10-deno.ipynb (has kernelspec.name = "deno")
  */
 
-import { browser } from "@wdio/globals";
 import {
   executeFirstCell,
   waitForCellOutput,

--- a/e2e/specs/prewarmed-uv.spec.js
+++ b/e2e/specs/prewarmed-uv.spec.js
@@ -7,7 +7,6 @@
  * Fixture: 1-vanilla.ipynb (no inline deps, no project file)
  */
 
-import { browser } from "@wdio/globals";
 import {
   executeFirstCell,
   isManagedEnv,

--- a/examples/deno-hello.ipynb
+++ b/examples/deno-hello.ipynb
@@ -13,10 +13,12 @@
       "codemirror_mode": "typescript"
     },
     "runt": {
-      "runtime": "deno"
+      "schema_version": "1"
     },
     "deno": {
-      "permissions": ["--allow-net"]
+      "permissions": [
+        "--allow-net"
+      ]
     }
   },
   "nbformat": 4,


### PR DESCRIPTION
Runtime type detection now uses `kernelspec.name` exclusively, matching how the daemon detects kernel type. The `runt.runtime` field was redundant with the standard Jupyter kernelspec.

## Changes

- Update `get_runtime()` to read from `kernelspec.name` instead of `runt.runtime`
- Remove `"runtime"` field from all notebook metadata JSON in `notebook_state.rs`
- Update notebook fixtures (`10-deno.ipynb`, `deno-hello.ipynb`) to remove `runt.runtime`
- Update documentation to clarify that `kernelspec` determines runtime type

## Verification

- [ ] All tests pass
- [ ] Notebooks with Python kernelspec are correctly detected as Python runtime
- [ ] Notebooks with Deno kernelspec are correctly detected as Deno runtime

_PR submitted by @rgbkrk's agent, Quill_