### PR TITLE
feat(kernel-env): extract environment management into shared crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2719,6 +2719,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "kernel-env"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "dirs 5.0.1",
+ "hex",
+ "kernel-launch",
+ "log",
+ "rattler",
+ "rattler_cache",
+ "rattler_conda_types",
+ "rattler_repodata_gateway",
+ "rattler_solve",
+ "rattler_virtual_packages",
+ "reqwest 0.12.28",
+ "reqwest-middleware",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "tempfile",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
 name = "kernel-launch"
 version = "0.1.0"
 dependencies = [
@@ -3266,6 +3291,7 @@ dependencies = [
  "hex",
  "hmac",
  "jupyter-protocol",
+ "kernel-env",
  "kernel-launch",
  "log",
  "nbformat",
@@ -5168,6 +5194,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "jupyter-protocol",
+ "kernel-env",
  "kernel-launch",
  "libc",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/runt",
     "crates/runt-trust",
     "crates/kernel-launch",
+    "crates/kernel-env",
     "crates/notebook",
     "crates/tauri-jupyter",
     "crates/xtask",

--- a/apps/notebook/src/hooks/useDaemonKernel.ts
+++ b/apps/notebook/src/hooks/useDaemonKernel.ts
@@ -306,6 +306,10 @@ export function useDaemonKernel({
             break;
           }
 
+          case "env_progress":
+            // Handled by useEnvProgress hook's own daemon:broadcast listener
+            break;
+
           default: {
             // Log unknown events to help debug unexpected broadcast types
             console.log(

--- a/apps/notebook/src/types.ts
+++ b/apps/notebook/src/types.ts
@@ -95,6 +95,8 @@ export type EnvProgressPhase =
       current_package: string;
     }
   | { phase: "install_complete"; elapsed_ms: number }
+  | { phase: "creating_venv" }
+  | { phase: "installing_packages"; packages: string[] }
   | { phase: "ready"; env_path: string; python_path: string }
   | { phase: "error"; message: string };
 
@@ -192,7 +194,11 @@ export type DaemonBroadcast =
   | {
       event: "comm_sync";
       comms: CommSnapshot[]; // All active comms for widget reconstruction
-    };
+    }
+  | ({
+      event: "env_progress";
+      env_type: "conda" | "uv";
+    } & EnvProgressPhase);
 
 /** Response types from daemon notebook requests */
 export type DaemonNotebookResponse =

--- a/crates/kernel-env/Cargo.toml
+++ b/crates/kernel-env/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "kernel-env"
+version = "0.1.0"
+edition = "2021"
+description = "Python environment management (UV + Conda) with progress reporting"
+repository = "https://github.com/runtimed/runt"
+license = "BSD-3-Clause"
+
+[lints]
+workspace = true
+
+[dependencies]
+anyhow = { workspace = true }
+tokio = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+uuid = { workspace = true }
+log = "0.4"
+dirs = "5"
+sha2 = "0.10"
+hex = "0.4"
+
+# Tool bootstrapping (get_uv_path)
+kernel-launch = { path = "../kernel-launch" }
+
+# Conda environment support via rattler
+rattler = "0.39"
+rattler_cache = "0.6"
+rattler_conda_types = "0.43"
+rattler_repodata_gateway = { version = "0.25", features = ["gateway"] }
+rattler_solve = { version = "4.2", features = ["resolvo"] }
+rattler_virtual_packages = "2.3"
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
+reqwest-middleware = "0.4"
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/kernel-env/src/conda.rs
+++ b/crates/kernel-env/src/conda.rs
@@ -1,0 +1,961 @@
+//! Conda environment management via rattler.
+//!
+//! Creates, caches, and prewarms conda environments for Jupyter kernels.
+//! Environments are keyed by a SHA-256 hash of (dependencies + channels +
+//! python constraint + env_id) and stored under the cache directory.
+
+use anyhow::{anyhow, Result};
+use log::{info, warn};
+use rattler::{default_cache_dir, install::Installer, package_cache::PackageCache};
+use rattler_conda_types::{
+    Channel, ChannelConfig, GenericVirtualPackage, MatchSpec, ParseMatchSpecOptions, Platform,
+    PrefixRecord,
+};
+use rattler_repodata_gateway::Gateway;
+use rattler_solve::{resolvo, SolverImpl, SolverTask};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Instant;
+
+use crate::progress::{EnvProgressPhase, ProgressHandler, RattlerReporter};
+
+/// Conda dependency specification.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CondaDependencies {
+    pub dependencies: Vec<String>,
+    #[serde(default)]
+    pub channels: Vec<String>,
+    pub python: Option<String>,
+    /// Unique environment ID for per-notebook isolation.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub env_id: Option<String>,
+}
+
+/// A resolved conda environment on disk.
+#[derive(Debug, Clone)]
+pub struct CondaEnvironment {
+    pub env_path: PathBuf,
+    pub python_path: PathBuf,
+}
+
+/// Get the default cache directory for conda environments.
+pub fn default_cache_dir_conda() -> PathBuf {
+    dirs::cache_dir()
+        .unwrap_or_else(|| PathBuf::from("/tmp"))
+        .join("runt")
+        .join("conda-envs")
+}
+
+/// Compute a stable cache key for the given dependencies.
+///
+/// The hash includes sorted deps, sorted channels, python constraint,
+/// and env_id (for per-notebook isolation).
+pub fn compute_env_hash(deps: &CondaDependencies) -> String {
+    let mut hasher = Sha256::new();
+
+    let mut sorted_deps = deps.dependencies.clone();
+    sorted_deps.sort();
+    for dep in &sorted_deps {
+        hasher.update(dep.as_bytes());
+        hasher.update(b"\n");
+    }
+
+    let mut sorted_channels = deps.channels.clone();
+    sorted_channels.sort();
+    for channel in &sorted_channels {
+        hasher.update(b"channel:");
+        hasher.update(channel.as_bytes());
+        hasher.update(b"\n");
+    }
+
+    if let Some(ref py) = deps.python {
+        hasher.update(b"python:");
+        hasher.update(py.as_bytes());
+    }
+
+    if let Some(ref env_id) = deps.env_id {
+        hasher.update(b"env_id:");
+        hasher.update(env_id.as_bytes());
+    }
+
+    let hash = hasher.finalize();
+    format!("{:x}", hash)[..16].to_string()
+}
+
+/// Prepare a conda environment with the given dependencies.
+///
+/// Uses cached environments when possible (keyed by dependency hash).
+/// If the cache doesn't exist, creates a new environment using rattler
+/// (repodata fetch → solve → download → install).
+///
+/// Progress events are emitted via `handler` throughout the lifecycle.
+pub async fn prepare_environment(
+    deps: &CondaDependencies,
+    handler: Arc<dyn ProgressHandler>,
+) -> Result<CondaEnvironment> {
+    prepare_environment_in(deps, &default_cache_dir_conda(), handler).await
+}
+
+/// Like [`prepare_environment`] but with an explicit cache directory.
+pub async fn prepare_environment_in(
+    deps: &CondaDependencies,
+    cache_dir: &Path,
+    handler: Arc<dyn ProgressHandler>,
+) -> Result<CondaEnvironment> {
+    let hash = compute_env_hash(deps);
+    let env_path = cache_dir.join(&hash);
+
+    handler.on_progress(
+        "conda",
+        EnvProgressPhase::Starting {
+            env_hash: hash.clone(),
+        },
+    );
+
+    #[cfg(target_os = "windows")]
+    let python_path = env_path.join("python.exe");
+    #[cfg(not(target_os = "windows"))]
+    let python_path = env_path.join("bin").join("python");
+
+    // Cache hit
+    if env_path.exists() && python_path.exists() {
+        info!("Using cached conda environment at {:?}", env_path);
+        handler.on_progress(
+            "conda",
+            EnvProgressPhase::CacheHit {
+                env_path: env_path.to_string_lossy().to_string(),
+            },
+        );
+        handler.on_progress(
+            "conda",
+            EnvProgressPhase::Ready {
+                env_path: env_path.to_string_lossy().to_string(),
+                python_path: python_path.to_string_lossy().to_string(),
+            },
+        );
+        return Ok(CondaEnvironment {
+            env_path,
+            python_path,
+        });
+    }
+
+    info!("Creating new conda environment at {:?}", env_path);
+
+    tokio::fs::create_dir_all(cache_dir).await?;
+
+    // Remove partial environment
+    if env_path.exists() {
+        tokio::fs::remove_dir_all(&env_path).await?;
+    }
+
+    install_conda_env(&env_path, deps, handler.clone()).await?;
+
+    // Verify python exists
+    if !python_path.exists() {
+        tokio::fs::remove_dir_all(&env_path).await.ok();
+        return Err(anyhow!(
+            "Python not found at {:?} after conda install",
+            python_path
+        ));
+    }
+
+    handler.on_progress(
+        "conda",
+        EnvProgressPhase::Ready {
+            env_path: env_path.to_string_lossy().to_string(),
+            python_path: python_path.to_string_lossy().to_string(),
+        },
+    );
+
+    Ok(CondaEnvironment {
+        env_path,
+        python_path,
+    })
+}
+
+/// Core rattler solve + install logic, extracted for reuse by prepare and prewarm.
+async fn install_conda_env(
+    env_path: &Path,
+    deps: &CondaDependencies,
+    handler: Arc<dyn ProgressHandler>,
+) -> Result<()> {
+    let cache_dir = env_path
+        .parent()
+        .unwrap_or_else(|| Path::new("/tmp"))
+        .to_path_buf();
+    let channel_config = ChannelConfig::default_with_root_dir(cache_dir);
+
+    // Parse channels
+    let channels: Vec<Channel> = if deps.channels.is_empty() {
+        vec![Channel::from_str("conda-forge", &channel_config)?]
+    } else {
+        deps.channels
+            .iter()
+            .map(|c| Channel::from_str(c, &channel_config))
+            .collect::<std::result::Result<Vec<_>, _>>()?
+    };
+
+    let channel_names: Vec<String> = channels.iter().map(|c| c.name().to_string()).collect();
+
+    handler.on_progress(
+        "conda",
+        EnvProgressPhase::FetchingRepodata {
+            channels: channel_names,
+        },
+    );
+
+    // Build specs
+    let match_spec_options = ParseMatchSpecOptions::strict();
+    let mut specs: Vec<MatchSpec> = Vec::new();
+
+    if let Some(ref py) = deps.python {
+        specs.push(MatchSpec::from_str(
+            &format!("python={}", py),
+            match_spec_options,
+        )?);
+    } else {
+        specs.push(MatchSpec::from_str("python>=3.9", match_spec_options)?);
+    }
+
+    specs.push(MatchSpec::from_str("ipykernel", match_spec_options)?);
+    specs.push(MatchSpec::from_str("ipywidgets", match_spec_options)?);
+
+    for dep in &deps.dependencies {
+        if dep != "ipykernel" && dep != "ipywidgets" {
+            specs.push(MatchSpec::from_str(dep, match_spec_options)?);
+        }
+    }
+
+    // Rattler cache
+    let rattler_cache_dir = default_cache_dir()
+        .map_err(|e| anyhow!("could not determine rattler cache directory: {}", e))?;
+    rattler_cache::ensure_cache_dir(&rattler_cache_dir)
+        .map_err(|e| anyhow!("could not create rattler cache directory: {}", e))?;
+
+    // HTTP client
+    let download_client = reqwest::Client::builder().build()?;
+    let download_client = reqwest_middleware::ClientBuilder::new(download_client).build();
+
+    // Gateway
+    let gateway = Gateway::builder()
+        .with_cache_dir(rattler_cache_dir.join(rattler_cache::REPODATA_CACHE_DIR))
+        .with_package_cache(PackageCache::new(
+            rattler_cache_dir.join(rattler_cache::PACKAGE_CACHE_DIR),
+        ))
+        .with_client(download_client.clone())
+        .finish();
+
+    // Query repodata with retry
+    let install_platform = Platform::current();
+    let platforms = vec![install_platform, Platform::NoArch];
+
+    let repodata_start = Instant::now();
+    const MAX_RETRIES: u32 = 3;
+    const INITIAL_DELAY_MS: u64 = 1000;
+
+    let mut last_error = None;
+    let mut repo_data = None;
+
+    for attempt in 0..MAX_RETRIES {
+        if attempt > 0 {
+            let delay_ms = INITIAL_DELAY_MS * (1 << (attempt - 1));
+            info!(
+                "Retrying repodata fetch (attempt {}/{}) after {}ms...",
+                attempt + 1,
+                MAX_RETRIES,
+                delay_ms
+            );
+            tokio::time::sleep(tokio::time::Duration::from_millis(delay_ms)).await;
+        }
+
+        match gateway
+            .query(channels.clone(), platforms.clone(), specs.clone())
+            .recursive(true)
+            .await
+        {
+            Ok(data) => {
+                repo_data = Some(data);
+                break;
+            }
+            Err(e) => {
+                let error_str = e.to_string();
+                let is_retryable = error_str.contains("500")
+                    || error_str.contains("502")
+                    || error_str.contains("503")
+                    || error_str.contains("504")
+                    || error_str.contains("timeout")
+                    || error_str.contains("connection");
+
+                if is_retryable && attempt < MAX_RETRIES - 1 {
+                    info!(
+                        "Transient error fetching repodata (attempt {}): {}",
+                        attempt + 1,
+                        error_str
+                    );
+                    last_error = Some(e);
+                    continue;
+                }
+                let error_msg = format!("Failed to fetch package metadata: {}", e);
+                handler.on_progress(
+                    "conda",
+                    EnvProgressPhase::Error {
+                        message: error_msg.clone(),
+                    },
+                );
+                return Err(anyhow!(error_msg));
+            }
+        }
+    }
+
+    let repo_data = match repo_data {
+        Some(data) => data,
+        None => {
+            let error_msg = format!(
+                "Failed to fetch package metadata after {} retries: {}",
+                MAX_RETRIES,
+                last_error
+                    .map(|e| e.to_string())
+                    .unwrap_or_else(|| "unknown error".to_string())
+            );
+            handler.on_progress(
+                "conda",
+                EnvProgressPhase::Error {
+                    message: error_msg.clone(),
+                },
+            );
+            return Err(anyhow!(error_msg));
+        }
+    };
+
+    let total_records: usize = repo_data.iter().map(|r| r.len()).sum();
+    let repodata_elapsed = repodata_start.elapsed();
+    info!(
+        "Loaded {} package records in {:?}",
+        total_records, repodata_elapsed
+    );
+    handler.on_progress(
+        "conda",
+        EnvProgressPhase::RepodataComplete {
+            record_count: total_records,
+            elapsed_ms: repodata_elapsed.as_millis() as u64,
+        },
+    );
+
+    // Virtual packages
+    let virtual_packages = rattler_virtual_packages::VirtualPackage::detect(
+        &rattler_virtual_packages::VirtualPackageOverrides::default(),
+    )?
+    .iter()
+    .map(|vpkg| GenericVirtualPackage::from(vpkg.clone()))
+    .collect::<Vec<_>>();
+
+    // Solve
+    handler.on_progress(
+        "conda",
+        EnvProgressPhase::Solving {
+            spec_count: specs.len(),
+        },
+    );
+
+    let solve_start = Instant::now();
+    let solver_task = SolverTask {
+        virtual_packages,
+        specs,
+        ..SolverTask::from_iter(&repo_data)
+    };
+
+    let solver_result = match resolvo::Solver.solve(solver_task) {
+        Ok(result) => result,
+        Err(e) => {
+            let error_msg = format!("Failed to solve dependencies: {}", e);
+            handler.on_progress(
+                "conda",
+                EnvProgressPhase::Error {
+                    message: error_msg.clone(),
+                },
+            );
+            return Err(anyhow!(error_msg));
+        }
+    };
+    let required_packages = solver_result.records;
+    let solve_elapsed = solve_start.elapsed();
+
+    info!(
+        "Solved: {} packages to install in {:?}",
+        required_packages.len(),
+        solve_elapsed
+    );
+    handler.on_progress(
+        "conda",
+        EnvProgressPhase::SolveComplete {
+            package_count: required_packages.len(),
+            elapsed_ms: solve_elapsed.as_millis() as u64,
+        },
+    );
+
+    // Install
+    handler.on_progress(
+        "conda",
+        EnvProgressPhase::Installing {
+            total: required_packages.len(),
+        },
+    );
+
+    let reporter = RattlerReporter::new(handler.clone());
+    let install_start = Instant::now();
+
+    match Installer::new()
+        .with_download_client(download_client)
+        .with_target_platform(install_platform)
+        .with_reporter(reporter)
+        .install(env_path, required_packages)
+        .await
+    {
+        Ok(_) => {}
+        Err(e) => {
+            let error_msg = format!("Failed to install packages: {}", e);
+            handler.on_progress(
+                "conda",
+                EnvProgressPhase::Error {
+                    message: error_msg.clone(),
+                },
+            );
+            return Err(anyhow!(error_msg));
+        }
+    }
+
+    let install_elapsed = install_start.elapsed();
+    info!(
+        "Conda environment ready at {:?} (install took {:?})",
+        env_path, install_elapsed
+    );
+    handler.on_progress(
+        "conda",
+        EnvProgressPhase::InstallComplete {
+            elapsed_ms: install_elapsed.as_millis() as u64,
+        },
+    );
+
+    Ok(())
+}
+
+/// Create a prewarmed conda environment with ipykernel, ipywidgets,
+/// and any caller-supplied extra packages.
+///
+/// Returns an environment at `prewarm-{uuid}` that can later be claimed
+/// via [`claim_prewarmed_environment`].
+pub async fn create_prewarmed_environment(
+    extra_packages: &[String],
+    handler: Arc<dyn ProgressHandler>,
+) -> Result<CondaEnvironment> {
+    create_prewarmed_environment_in(&default_cache_dir_conda(), extra_packages, handler).await
+}
+
+/// Like [`create_prewarmed_environment`] but with an explicit cache directory.
+pub async fn create_prewarmed_environment_in(
+    cache_dir: &Path,
+    extra_packages: &[String],
+    handler: Arc<dyn ProgressHandler>,
+) -> Result<CondaEnvironment> {
+    let temp_id = format!("prewarm-{}", uuid::Uuid::new_v4());
+    let env_path = cache_dir.join(&temp_id);
+
+    #[cfg(target_os = "windows")]
+    let python_path = env_path.join("python.exe");
+    #[cfg(not(target_os = "windows"))]
+    let python_path = env_path.join("bin").join("python");
+
+    info!(
+        "[prewarm] Creating prewarmed conda environment at {:?}",
+        env_path
+    );
+
+    tokio::fs::create_dir_all(cache_dir).await?;
+
+    let mut deps_list = vec!["ipykernel".to_string(), "ipywidgets".to_string()];
+    if !extra_packages.is_empty() {
+        info!("[prewarm] Including extra packages: {:?}", extra_packages);
+        deps_list.extend(extra_packages.iter().cloned());
+    }
+    let deps = CondaDependencies {
+        dependencies: deps_list,
+        channels: vec!["conda-forge".to_string()],
+        python: None,
+        env_id: None,
+    };
+
+    install_conda_env(&env_path, &deps, handler.clone()).await?;
+
+    info!(
+        "[prewarm] Prewarmed conda environment created at {:?}",
+        env_path
+    );
+
+    let env = CondaEnvironment {
+        env_path,
+        python_path,
+    };
+
+    warmup_environment(&env).await?;
+
+    Ok(env)
+}
+
+/// Claim a prewarmed environment for a specific notebook.
+///
+/// Moves the prewarmed environment to the correct cache location based
+/// on `env_id`, so it will be found by [`prepare_environment`] later.
+pub async fn claim_prewarmed_environment(
+    prewarmed: CondaEnvironment,
+    env_id: &str,
+) -> Result<CondaEnvironment> {
+    claim_prewarmed_environment_in(prewarmed, env_id, &default_cache_dir_conda()).await
+}
+
+/// Like [`claim_prewarmed_environment`] but with an explicit cache directory.
+pub async fn claim_prewarmed_environment_in(
+    prewarmed: CondaEnvironment,
+    env_id: &str,
+    cache_dir: &Path,
+) -> Result<CondaEnvironment> {
+    let deps = CondaDependencies {
+        dependencies: vec!["ipykernel".to_string()],
+        channels: vec!["conda-forge".to_string()],
+        python: None,
+        env_id: Some(env_id.to_string()),
+    };
+    let hash = compute_env_hash(&deps);
+    let dest_path = cache_dir.join(&hash);
+
+    #[cfg(target_os = "windows")]
+    let python_path = dest_path.join("python.exe");
+    #[cfg(not(target_os = "windows"))]
+    let python_path = dest_path.join("bin").join("python");
+
+    if dest_path.exists() {
+        info!(
+            "[prewarm] Destination already exists, removing prewarmed conda env at {:?}",
+            prewarmed.env_path
+        );
+        tokio::fs::remove_dir_all(&prewarmed.env_path).await.ok();
+        return Ok(CondaEnvironment {
+            env_path: dest_path,
+            python_path,
+        });
+    }
+
+    info!(
+        "[prewarm] Claiming prewarmed conda environment: {:?} -> {:?}",
+        prewarmed.env_path, dest_path
+    );
+
+    match tokio::fs::rename(&prewarmed.env_path, &dest_path).await {
+        Ok(()) => {
+            info!("[prewarm] Conda environment claimed via rename");
+        }
+        Err(e) => {
+            info!("[prewarm] Rename failed ({}), falling back to copy", e);
+            copy_dir_recursive(&prewarmed.env_path, &dest_path).await?;
+            tokio::fs::remove_dir_all(&prewarmed.env_path).await.ok();
+            info!("[prewarm] Conda environment claimed via copy");
+        }
+    }
+
+    Ok(CondaEnvironment {
+        env_path: dest_path,
+        python_path,
+    })
+}
+
+/// Find existing prewarmed conda environments from previous sessions.
+///
+/// Scans the cache directory for `prewarm-*` directories and validates
+/// they have a working Python binary.
+pub async fn find_existing_prewarmed_environments() -> Vec<CondaEnvironment> {
+    find_existing_prewarmed_environments_in(&default_cache_dir_conda()).await
+}
+
+/// Like [`find_existing_prewarmed_environments`] but with an explicit cache directory.
+pub async fn find_existing_prewarmed_environments_in(cache_dir: &Path) -> Vec<CondaEnvironment> {
+    let mut found = Vec::new();
+
+    let Ok(mut entries) = tokio::fs::read_dir(cache_dir).await else {
+        return found;
+    };
+
+    while let Ok(Some(entry)) = entries.next_entry().await {
+        let name = entry.file_name().to_string_lossy().to_string();
+        if !name.starts_with("prewarm-") {
+            continue;
+        }
+
+        let env_path = entry.path();
+
+        #[cfg(target_os = "windows")]
+        let python_path = env_path.join("python.exe");
+        #[cfg(not(target_os = "windows"))]
+        let python_path = env_path.join("bin").join("python");
+
+        if !python_path.exists() {
+            info!(
+                "[prewarm] Skipping invalid conda env (no python): {:?}",
+                env_path
+            );
+            tokio::fs::remove_dir_all(&env_path).await.ok();
+            continue;
+        }
+
+        info!(
+            "[prewarm] Found existing prewarmed conda environment: {:?}",
+            env_path
+        );
+        found.push(CondaEnvironment {
+            env_path,
+            python_path,
+        });
+    }
+
+    found
+}
+
+/// Warm up a conda environment by running Python to trigger .pyc compilation.
+pub async fn warmup_environment(env: &CondaEnvironment) -> Result<()> {
+    let warmup_start = Instant::now();
+    info!(
+        "[prewarm] Warming up conda environment at {:?}",
+        env.env_path
+    );
+
+    let warmup_script = r#"
+import sys
+import ipykernel
+import IPython
+import ipywidgets
+import traitlets
+import zmq
+from ipykernel.kernelbase import Kernel
+from ipykernel.ipkernel import IPythonKernel
+from ipykernel.comm import CommManager
+print("warmup complete")
+"#;
+
+    let output = tokio::process::Command::new(&env.python_path)
+        .args(["-c", warmup_script])
+        .output()
+        .await?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        warn!("[prewarm] Warmup failed for {:?}: {}", env.env_path, stderr);
+        return Ok(());
+    }
+
+    let marker_path = env.env_path.join(".warmed");
+    tokio::fs::write(&marker_path, "").await.ok();
+
+    info!(
+        "[prewarm] Warmup complete for {:?} in {}ms",
+        env.env_path,
+        warmup_start.elapsed().as_millis()
+    );
+
+    Ok(())
+}
+
+/// Check if a conda environment has been warmed up.
+pub fn is_environment_warmed(env: &CondaEnvironment) -> bool {
+    env.env_path.join(".warmed").exists()
+}
+
+/// Install additional dependencies into an existing environment.
+///
+/// Solves and installs new packages into the existing prefix, considering
+/// already-installed packages as locked.
+pub async fn sync_dependencies(env: &CondaEnvironment, deps: &CondaDependencies) -> Result<()> {
+    if deps.dependencies.is_empty() {
+        return Ok(());
+    }
+
+    info!(
+        "Syncing {} dependencies to {:?}",
+        deps.dependencies.len(),
+        env.env_path
+    );
+
+    let cache_dir = env
+        .env_path
+        .parent()
+        .unwrap_or_else(|| Path::new("/tmp"))
+        .to_path_buf();
+    let channel_config = ChannelConfig::default_with_root_dir(cache_dir);
+
+    let channels: Vec<Channel> = if deps.channels.is_empty() {
+        vec![Channel::from_str("conda-forge", &channel_config)?]
+    } else {
+        deps.channels
+            .iter()
+            .map(|c| Channel::from_str(c, &channel_config))
+            .collect::<std::result::Result<Vec<_>, _>>()?
+    };
+
+    let match_spec_options = ParseMatchSpecOptions::strict();
+    let mut specs: Vec<MatchSpec> = Vec::new();
+    for dep in &deps.dependencies {
+        specs.push(MatchSpec::from_str(dep, match_spec_options)?);
+    }
+
+    let rattler_cache_dir = default_cache_dir()
+        .map_err(|e| anyhow!("could not determine rattler cache directory: {}", e))?;
+
+    let download_client = reqwest::Client::builder().build()?;
+    let download_client = reqwest_middleware::ClientBuilder::new(download_client).build();
+
+    let gateway = Gateway::builder()
+        .with_cache_dir(rattler_cache_dir.join(rattler_cache::REPODATA_CACHE_DIR))
+        .with_package_cache(PackageCache::new(
+            rattler_cache_dir.join(rattler_cache::PACKAGE_CACHE_DIR),
+        ))
+        .with_client(download_client.clone())
+        .finish();
+
+    let install_platform = Platform::current();
+    let platforms = vec![install_platform, Platform::NoArch];
+
+    const MAX_RETRIES: u32 = 3;
+    const INITIAL_DELAY_MS: u64 = 1000;
+
+    let mut last_error = None;
+    let mut repo_data = None;
+
+    for attempt in 0..MAX_RETRIES {
+        if attempt > 0 {
+            let delay_ms = INITIAL_DELAY_MS * (1 << (attempt - 1));
+            info!(
+                "Retrying repodata fetch for sync (attempt {}/{}) after {}ms...",
+                attempt + 1,
+                MAX_RETRIES,
+                delay_ms
+            );
+            tokio::time::sleep(tokio::time::Duration::from_millis(delay_ms)).await;
+        }
+
+        match gateway
+            .query(channels.clone(), platforms.clone(), specs.clone())
+            .recursive(true)
+            .await
+        {
+            Ok(data) => {
+                repo_data = Some(data);
+                break;
+            }
+            Err(e) => {
+                let error_str = e.to_string();
+                let is_retryable = error_str.contains("500")
+                    || error_str.contains("502")
+                    || error_str.contains("503")
+                    || error_str.contains("504")
+                    || error_str.contains("timeout")
+                    || error_str.contains("connection");
+
+                if is_retryable && attempt < MAX_RETRIES - 1 {
+                    last_error = Some(e);
+                    continue;
+                }
+                return Err(anyhow!("Failed to fetch package metadata: {}", e));
+            }
+        }
+    }
+
+    let repo_data = repo_data.ok_or_else(|| {
+        anyhow!(
+            "Failed to fetch package metadata after {} retries: {}",
+            MAX_RETRIES,
+            last_error
+                .map(|e| e.to_string())
+                .unwrap_or_else(|| "unknown error".to_string())
+        )
+    })?;
+
+    let virtual_packages = rattler_virtual_packages::VirtualPackage::detect(
+        &rattler_virtual_packages::VirtualPackageOverrides::default(),
+    )?
+    .iter()
+    .map(|vpkg| GenericVirtualPackage::from(vpkg.clone()))
+    .collect::<Vec<_>>();
+
+    let installed_packages = PrefixRecord::collect_from_prefix::<PrefixRecord>(&env.env_path)?;
+
+    let solver_task = SolverTask {
+        virtual_packages,
+        specs,
+        locked_packages: installed_packages
+            .iter()
+            .map(|r| r.repodata_record.clone())
+            .collect(),
+        ..SolverTask::from_iter(&repo_data)
+    };
+
+    let solver_result = resolvo::Solver.solve(solver_task)?;
+    let required_packages = solver_result.records;
+
+    info!("Installing {} packages for sync", required_packages.len());
+
+    Installer::new()
+        .with_download_client(download_client)
+        .with_target_platform(install_platform)
+        .with_installed_packages(installed_packages)
+        .install(&env.env_path, required_packages)
+        .await?;
+
+    info!("Conda dependencies synced successfully");
+    Ok(())
+}
+
+/// No-op cleanup (cached environments are kept for reuse).
+pub async fn cleanup_environment(_env: &CondaEnvironment) -> Result<()> {
+    Ok(())
+}
+
+/// Force remove a cached environment.
+#[allow(dead_code)]
+pub async fn remove_environment(env: &CondaEnvironment) -> Result<()> {
+    if env.env_path.exists() {
+        tokio::fs::remove_dir_all(&env.env_path).await?;
+    }
+    Ok(())
+}
+
+/// Clear all cached conda environments.
+#[allow(dead_code)]
+pub async fn clear_cache() -> Result<()> {
+    let cache_dir = default_cache_dir_conda();
+    if cache_dir.exists() {
+        tokio::fs::remove_dir_all(&cache_dir).await?;
+    }
+    Ok(())
+}
+
+/// Recursively copy a directory, preserving symlinks.
+async fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {
+    tokio::fs::create_dir_all(dst).await?;
+
+    let mut entries = tokio::fs::read_dir(src).await?;
+    while let Some(entry) = entries.next_entry().await? {
+        let ty = entry.file_type().await?;
+        let src_path = entry.path();
+        let dst_path = dst.join(entry.file_name());
+
+        if ty.is_dir() {
+            Box::pin(copy_dir_recursive(&src_path, &dst_path)).await?;
+        } else if ty.is_symlink() {
+            #[cfg(unix)]
+            {
+                let link_target = tokio::fs::read_link(&src_path).await?;
+                tokio::fs::symlink(&link_target, &dst_path).await?;
+            }
+            #[cfg(windows)]
+            tokio::fs::copy(&src_path, &dst_path).await?;
+        } else {
+            tokio::fs::copy(&src_path, &dst_path).await?;
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_compute_env_hash_stable() {
+        let deps = CondaDependencies {
+            dependencies: vec!["pandas".to_string(), "numpy".to_string()],
+            channels: vec!["conda-forge".to_string()],
+            python: Some("3.11".to_string()),
+            env_id: Some("test-env-id".to_string()),
+        };
+
+        let hash1 = compute_env_hash(&deps);
+        let hash2 = compute_env_hash(&deps);
+        assert_eq!(hash1, hash2);
+    }
+
+    #[test]
+    fn test_compute_env_hash_order_independent() {
+        let deps1 = CondaDependencies {
+            dependencies: vec!["pandas".to_string(), "numpy".to_string()],
+            channels: vec![],
+            python: None,
+            env_id: Some("test-env-1".to_string()),
+        };
+
+        let deps2 = CondaDependencies {
+            dependencies: vec!["numpy".to_string(), "pandas".to_string()],
+            channels: vec![],
+            python: None,
+            env_id: Some("test-env-1".to_string()),
+        };
+
+        assert_eq!(compute_env_hash(&deps1), compute_env_hash(&deps2));
+    }
+
+    #[test]
+    fn test_compute_env_hash_different_deps() {
+        let deps1 = CondaDependencies {
+            dependencies: vec!["pandas".to_string()],
+            channels: vec![],
+            python: None,
+            env_id: Some("test-env-1".to_string()),
+        };
+
+        let deps2 = CondaDependencies {
+            dependencies: vec!["numpy".to_string()],
+            channels: vec![],
+            python: None,
+            env_id: Some("test-env-1".to_string()),
+        };
+
+        assert_ne!(compute_env_hash(&deps1), compute_env_hash(&deps2));
+    }
+
+    #[test]
+    fn test_compute_env_hash_includes_channels() {
+        let deps1 = CondaDependencies {
+            dependencies: vec!["numpy".to_string()],
+            channels: vec!["conda-forge".to_string()],
+            python: None,
+            env_id: Some("test-env-1".to_string()),
+        };
+
+        let deps2 = CondaDependencies {
+            dependencies: vec!["numpy".to_string()],
+            channels: vec!["defaults".to_string()],
+            python: None,
+            env_id: Some("test-env-1".to_string()),
+        };
+
+        assert_ne!(compute_env_hash(&deps1), compute_env_hash(&deps2));
+    }
+
+    #[test]
+    fn test_compute_env_hash_different_env_id() {
+        let deps1 = CondaDependencies {
+            dependencies: vec!["numpy".to_string()],
+            channels: vec!["conda-forge".to_string()],
+            python: None,
+            env_id: Some("notebook-1".to_string()),
+        };
+
+        let deps2 = CondaDependencies {
+            dependencies: vec!["numpy".to_string()],
+            channels: vec!["conda-forge".to_string()],
+            python: None,
+            env_id: Some("notebook-2".to_string()),
+        };
+
+        assert_ne!(compute_env_hash(&deps1), compute_env_hash(&deps2));
+    }
+}

--- a/crates/kernel-env/src/lib.rs
+++ b/crates/kernel-env/src/lib.rs
@@ -1,0 +1,34 @@
+//! Python environment management (UV + Conda) with progress reporting.
+//!
+//! This crate provides the core environment creation, caching, and prewarming
+//! logic used by both the notebook app and the runtimed daemon. It includes:
+//!
+//! - A progress reporting trait for environment lifecycle events
+//! - UV virtual environment creation via `uv`
+//! - Conda environment creation via `rattler`
+//! - Hash-based caching for instant reuse
+//! - Prewarming support for fast kernel startup
+//!
+//! # Progress Reporting
+//!
+//! All environment operations accept a [`ProgressHandler`] to report phases
+//! like fetching repodata, solving, downloading, and linking. Consumers
+//! implement this trait to route progress to their UI (Tauri events, daemon
+//! broadcast channel, logs, etc.).
+//!
+//! ```ignore
+//! use kernel_env::progress::{LogHandler, ProgressHandler};
+//!
+//! // Log-only progress
+//! let handler = LogHandler;
+//! kernel_env::conda::prepare_environment(&deps, &handler).await?;
+//! ```
+
+pub mod conda;
+pub mod progress;
+pub mod uv;
+
+// Re-export key types
+pub use conda::{CondaDependencies, CondaEnvironment};
+pub use progress::{EnvProgressPhase, LogHandler, ProgressHandler};
+pub use uv::{UvDependencies, UvEnvironment};

--- a/crates/kernel-env/src/progress.rs
+++ b/crates/kernel-env/src/progress.rs
@@ -1,0 +1,379 @@
+//! Progress reporting for environment operations.
+//!
+//! Provides [`EnvProgressPhase`] events covering the full lifecycle of
+//! environment creation (fetching repodata, solving, downloading, linking)
+//! and a [`ProgressHandler`] trait that consumers implement to route events
+//! to their UI layer.
+
+use rattler::install::{Reporter, Transaction};
+use rattler_conda_types::{PrefixRecord, RepoDataRecord};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::{Arc, RwLock};
+use std::time::Instant;
+
+/// Progress phases during environment preparation.
+///
+/// These events cover the full lifecycle from cache check through
+/// ready-to-use. Serializable for transport over IPC / Tauri events.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "phase", rename_all = "snake_case")]
+pub enum EnvProgressPhase {
+    /// Starting environment preparation.
+    Starting { env_hash: String },
+    /// Using a cached environment (fast path).
+    CacheHit { env_path: String },
+    /// Fetching package metadata from channels.
+    FetchingRepodata { channels: Vec<String> },
+    /// Repodata fetch complete.
+    RepodataComplete {
+        record_count: usize,
+        elapsed_ms: u64,
+    },
+    /// Solving dependency graph.
+    Solving { spec_count: usize },
+    /// Solve complete.
+    SolveComplete {
+        package_count: usize,
+        elapsed_ms: u64,
+    },
+    /// Installing packages (aggregate phase).
+    Installing { total: usize },
+    /// Download progress for individual packages.
+    DownloadProgress {
+        /// Number of packages fully downloaded.
+        completed: usize,
+        /// Total number of packages to download.
+        total: usize,
+        /// Name of the package currently being downloaded.
+        current_package: String,
+        /// Total bytes downloaded so far.
+        bytes_downloaded: u64,
+        /// Total bytes to download (if known).
+        bytes_total: Option<u64>,
+        /// Current download speed in bytes per second.
+        bytes_per_second: f64,
+    },
+    /// Linking/installing packages into the environment.
+    LinkProgress {
+        /// Number of packages fully linked.
+        completed: usize,
+        /// Total number of packages to link.
+        total: usize,
+        /// Name of the package currently being linked.
+        current_package: String,
+    },
+    /// Installation complete.
+    InstallComplete { elapsed_ms: u64 },
+    /// Creating virtual environment (UV-specific).
+    CreatingVenv,
+    /// Installing pip packages (UV-specific).
+    InstallingPackages { packages: Vec<String> },
+    /// Environment is ready.
+    Ready {
+        env_path: String,
+        python_path: String,
+    },
+    /// An error occurred.
+    Error { message: String },
+}
+
+/// Trait for receiving environment progress events.
+///
+/// Implement this to route progress to your UI layer (Tauri events,
+/// daemon broadcast channel, logs, etc.).
+pub trait ProgressHandler: Send + Sync {
+    /// Called for each progress phase during environment creation.
+    ///
+    /// `env_type` is `"conda"` or `"uv"`.
+    fn on_progress(&self, env_type: &str, phase: EnvProgressPhase);
+}
+
+/// Log-only progress handler.
+///
+/// Writes progress phases to the `log` crate at info level.
+pub struct LogHandler;
+
+impl ProgressHandler for LogHandler {
+    fn on_progress(&self, env_type: &str, phase: EnvProgressPhase) {
+        match &phase {
+            EnvProgressPhase::Starting { env_hash } => {
+                log::info!("[{env_type}] Starting environment preparation (hash: {env_hash})");
+            }
+            EnvProgressPhase::CacheHit { env_path } => {
+                log::info!("[{env_type}] Cache hit: {env_path}");
+            }
+            EnvProgressPhase::FetchingRepodata { channels } => {
+                log::info!("[{env_type}] Fetching repodata from: {channels:?}");
+            }
+            EnvProgressPhase::RepodataComplete {
+                record_count,
+                elapsed_ms,
+            } => {
+                log::info!("[{env_type}] Loaded {record_count} package records in {elapsed_ms}ms");
+            }
+            EnvProgressPhase::Solving { spec_count } => {
+                log::info!("[{env_type}] Solving {spec_count} specs...");
+            }
+            EnvProgressPhase::SolveComplete {
+                package_count,
+                elapsed_ms,
+            } => {
+                log::info!("[{env_type}] Resolved {package_count} packages in {elapsed_ms}ms");
+            }
+            EnvProgressPhase::Installing { total } => {
+                log::info!("[{env_type}] Installing {total} packages...");
+            }
+            EnvProgressPhase::DownloadProgress {
+                completed, total, ..
+            } => {
+                log::debug!("[{env_type}] Download {completed}/{total}");
+            }
+            EnvProgressPhase::LinkProgress {
+                completed, total, ..
+            } => {
+                log::debug!("[{env_type}] Link {completed}/{total}");
+            }
+            EnvProgressPhase::InstallComplete { elapsed_ms } => {
+                log::info!("[{env_type}] Installation complete in {elapsed_ms}ms");
+            }
+            EnvProgressPhase::CreatingVenv => {
+                log::info!("[{env_type}] Creating virtual environment...");
+            }
+            EnvProgressPhase::InstallingPackages { packages } => {
+                log::info!("[{env_type}] Installing packages: {packages:?}");
+            }
+            EnvProgressPhase::Ready {
+                env_path,
+                python_path,
+            } => {
+                log::info!("[{env_type}] Ready: env={env_path} python={python_path}");
+            }
+            EnvProgressPhase::Error { message } => {
+                log::error!("[{env_type}] Error: {message}");
+            }
+        }
+    }
+}
+
+/// Rattler [`Reporter`] implementation that delegates to [`ProgressHandler`].
+///
+/// Tracks download/link progress atomically and emits throttled
+/// [`EnvProgressPhase::DownloadProgress`] / [`LinkProgress`] events.
+///
+/// Uses `Arc<dyn ProgressHandler>` for ownership since rattler's `Installer`
+/// requires `'static` reporters.
+pub struct RattlerReporter {
+    handler: Arc<dyn ProgressHandler>,
+    /// Total packages to download.
+    total_downloads: AtomicUsize,
+    /// Number of packages fully downloaded.
+    downloaded_packages: AtomicUsize,
+    /// Total bytes downloaded across all packages.
+    bytes_downloaded: AtomicU64,
+    /// Total bytes to download (if known).
+    bytes_total: AtomicU64,
+    /// When downloading started.
+    download_start: RwLock<Option<Instant>>,
+    /// Total packages to link.
+    total_to_link: AtomicUsize,
+    /// Number of packages fully linked.
+    linked_packages: AtomicUsize,
+    /// Package names indexed by operation/cache index.
+    package_names: RwLock<HashMap<usize, String>>,
+    /// Current package being downloaded.
+    current_download: RwLock<Option<String>>,
+    /// Last time we emitted a download progress event (throttling).
+    last_download_emit: RwLock<Option<Instant>>,
+}
+
+impl RattlerReporter {
+    /// Create a new reporter that delegates to the given handler.
+    pub fn new(handler: Arc<dyn ProgressHandler>) -> Self {
+        Self {
+            handler,
+            total_downloads: AtomicUsize::new(0),
+            downloaded_packages: AtomicUsize::new(0),
+            bytes_downloaded: AtomicU64::new(0),
+            bytes_total: AtomicU64::new(0),
+            download_start: RwLock::new(None),
+            total_to_link: AtomicUsize::new(0),
+            linked_packages: AtomicUsize::new(0),
+            package_names: RwLock::new(HashMap::new()),
+            current_download: RwLock::new(None),
+            last_download_emit: RwLock::new(None),
+        }
+    }
+
+    /// Emit download progress (throttled to at most once per 100ms).
+    fn emit_download_progress(&self) {
+        {
+            let mut last_emit = self.last_download_emit.write().unwrap();
+            if let Some(last) = *last_emit {
+                if last.elapsed().as_millis() < 100 {
+                    return;
+                }
+            }
+            *last_emit = Some(Instant::now());
+        }
+
+        let completed = self.downloaded_packages.load(Ordering::SeqCst);
+        let total = self.total_downloads.load(Ordering::SeqCst);
+        let bytes_downloaded = self.bytes_downloaded.load(Ordering::SeqCst);
+        let bytes_total = self.bytes_total.load(Ordering::SeqCst);
+
+        let current_package = self
+            .current_download
+            .read()
+            .unwrap()
+            .clone()
+            .unwrap_or_default();
+
+        let bytes_per_second = {
+            let start = self.download_start.read().unwrap();
+            match *start {
+                Some(s) => {
+                    let elapsed = s.elapsed().as_secs_f64();
+                    if elapsed > 0.0 {
+                        bytes_downloaded as f64 / elapsed
+                    } else {
+                        0.0
+                    }
+                }
+                None => 0.0,
+            }
+        };
+
+        self.handler.on_progress(
+            "conda",
+            EnvProgressPhase::DownloadProgress {
+                completed,
+                total,
+                current_package,
+                bytes_downloaded,
+                bytes_total: if bytes_total > 0 {
+                    Some(bytes_total)
+                } else {
+                    None
+                },
+                bytes_per_second,
+            },
+        );
+    }
+
+    /// Emit link progress.
+    fn emit_link_progress(&self, current_package: String) {
+        let completed = self.linked_packages.load(Ordering::SeqCst);
+        let total = self.total_to_link.load(Ordering::SeqCst);
+
+        self.handler.on_progress(
+            "conda",
+            EnvProgressPhase::LinkProgress {
+                completed,
+                total,
+                current_package,
+            },
+        );
+    }
+}
+
+impl Reporter for RattlerReporter {
+    fn on_transaction_start(&self, transaction: &Transaction<PrefixRecord, RepoDataRecord>) {
+        let total = transaction.operations.len();
+        self.total_to_link.store(total, Ordering::SeqCst);
+        self.total_downloads.store(total, Ordering::SeqCst);
+        *self.download_start.write().unwrap() = Some(Instant::now());
+    }
+
+    fn on_transaction_operation_start(&self, _operation: usize) {}
+
+    fn on_populate_cache_start(&self, cache_entry: usize, record: &RepoDataRecord) -> usize {
+        let name = record.package_record.name.as_source().to_string();
+        self.package_names
+            .write()
+            .unwrap()
+            .insert(cache_entry, name);
+        cache_entry
+    }
+
+    fn on_validate_start(&self, cache_entry: usize) -> usize {
+        cache_entry
+    }
+
+    fn on_validate_complete(&self, _validate_idx: usize) {}
+
+    fn on_download_start(&self, cache_entry: usize) -> usize {
+        let name = self
+            .package_names
+            .read()
+            .unwrap()
+            .get(&cache_entry)
+            .cloned()
+            .unwrap_or_default();
+        *self.current_download.write().unwrap() = Some(name);
+        cache_entry
+    }
+
+    fn on_download_progress(&self, _download_idx: usize, progress: u64, total: Option<u64>) {
+        self.bytes_downloaded.fetch_add(progress, Ordering::SeqCst);
+        if let Some(t) = total {
+            let current_total = self.bytes_total.load(Ordering::SeqCst);
+            if current_total == 0 {
+                self.bytes_total.store(t, Ordering::SeqCst);
+            }
+        }
+        self.emit_download_progress();
+    }
+
+    fn on_download_completed(&self, _download_idx: usize) {
+        self.downloaded_packages.fetch_add(1, Ordering::SeqCst);
+        self.emit_download_progress();
+    }
+
+    fn on_populate_cache_complete(&self, _cache_entry: usize) {}
+
+    fn on_unlink_start(&self, operation: usize, _record: &PrefixRecord) -> usize {
+        operation
+    }
+
+    fn on_unlink_complete(&self, _index: usize) {}
+
+    fn on_link_start(&self, operation: usize, record: &RepoDataRecord) -> usize {
+        let name = record.package_record.name.as_source().to_string();
+        self.package_names
+            .write()
+            .unwrap()
+            .insert(operation, name.clone());
+        self.emit_link_progress(name);
+        operation
+    }
+
+    fn on_link_complete(&self, index: usize) {
+        self.linked_packages.fetch_add(1, Ordering::SeqCst);
+        let name = self
+            .package_names
+            .read()
+            .unwrap()
+            .get(&index)
+            .cloned()
+            .unwrap_or_default();
+        self.emit_link_progress(name);
+    }
+
+    fn on_transaction_operation_complete(&self, _operation: usize) {}
+
+    fn on_transaction_complete(&self) {}
+
+    fn on_post_link_start(&self, _package_name: &str, _script_path: &str) -> usize {
+        0
+    }
+
+    fn on_post_link_complete(&self, _index: usize, _success: bool) {}
+
+    fn on_pre_unlink_start(&self, _package_name: &str, _script_path: &str) -> usize {
+        0
+    }
+
+    fn on_pre_unlink_complete(&self, _index: usize, _success: bool) {}
+}

--- a/crates/kernel-env/src/uv.rs
+++ b/crates/kernel-env/src/uv.rs
@@ -1,0 +1,713 @@
+//! UV-based virtual environment management.
+//!
+//! Creates, caches, and prewarms UV virtual environments for Jupyter kernels.
+//! Environments are keyed by a SHA-256 hash of (dependencies + requires-python
+//! + env_id) and stored under the cache directory. UV is auto-bootstrapped via
+//! rattler if not found on PATH.
+
+use anyhow::{anyhow, Result};
+use log::info;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::sync::Arc;
+
+use crate::progress::{EnvProgressPhase, ProgressHandler};
+
+/// UV dependency specification.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UvDependencies {
+    pub dependencies: Vec<String>,
+    #[serde(rename = "requires-python")]
+    pub requires_python: Option<String>,
+}
+
+/// A resolved UV virtual environment on disk.
+#[derive(Debug)]
+pub struct UvEnvironment {
+    pub venv_path: PathBuf,
+    pub python_path: PathBuf,
+}
+
+/// Get the default cache directory for UV environments.
+pub fn default_cache_dir_uv() -> PathBuf {
+    dirs::cache_dir()
+        .unwrap_or_else(|| PathBuf::from("/tmp"))
+        .join("runt")
+        .join("envs")
+}
+
+/// Check if uv is available (either on PATH or bootstrappable via rattler).
+pub async fn check_uv_available() -> bool {
+    kernel_launch::tools::get_uv_path().await.is_ok()
+}
+
+/// Compute a stable cache key for the given dependencies.
+///
+/// When deps are empty and env_id is provided, includes env_id in hash
+/// for per-notebook isolation.
+pub fn compute_env_hash(deps: &UvDependencies, env_id: Option<&str>) -> String {
+    let mut hasher = Sha256::new();
+
+    let mut sorted_deps = deps.dependencies.clone();
+    sorted_deps.sort();
+
+    // For empty deps, include env_id for per-notebook isolation
+    if sorted_deps.is_empty() {
+        if let Some(id) = env_id {
+            hasher.update(b"env_id:");
+            hasher.update(id.as_bytes());
+            hasher.update(b"\n");
+        }
+    }
+
+    for dep in &sorted_deps {
+        hasher.update(dep.as_bytes());
+        hasher.update(b"\n");
+    }
+
+    if let Some(ref py) = deps.requires_python {
+        hasher.update(b"requires-python:");
+        hasher.update(py.as_bytes());
+    }
+
+    let hash = hasher.finalize();
+    format!("{:x}", hash)[..16].to_string()
+}
+
+/// Prepare a virtual environment with the given dependencies.
+///
+/// Uses cached environments when possible (keyed by dependency hash).
+/// If the cache doesn't exist, creates a new environment with
+/// `uv venv` + `uv pip install`.
+///
+/// The `env_id` parameter enables per-notebook isolation for empty deps:
+/// - If deps are empty and env_id is provided, the env is unique to that notebook
+/// - If deps are non-empty, env_id is ignored and envs are shared by dep hash
+pub async fn prepare_environment(
+    deps: &UvDependencies,
+    env_id: Option<&str>,
+    handler: Arc<dyn ProgressHandler>,
+) -> Result<UvEnvironment> {
+    prepare_environment_in(deps, env_id, &default_cache_dir_uv(), handler).await
+}
+
+/// Like [`prepare_environment`] but with an explicit cache directory.
+pub async fn prepare_environment_in(
+    deps: &UvDependencies,
+    env_id: Option<&str>,
+    cache_dir: &Path,
+    handler: Arc<dyn ProgressHandler>,
+) -> Result<UvEnvironment> {
+    let hash = compute_env_hash(deps, env_id);
+    let venv_path = cache_dir.join(&hash);
+
+    handler.on_progress(
+        "uv",
+        EnvProgressPhase::Starting {
+            env_hash: hash.clone(),
+        },
+    );
+
+    #[cfg(target_os = "windows")]
+    let python_path = venv_path.join("Scripts").join("python.exe");
+    #[cfg(not(target_os = "windows"))]
+    let python_path = venv_path.join("bin").join("python");
+
+    // Cache hit
+    if venv_path.exists() && python_path.exists() {
+        info!("Using cached environment at {:?}", venv_path);
+        handler.on_progress(
+            "uv",
+            EnvProgressPhase::CacheHit {
+                env_path: venv_path.to_string_lossy().to_string(),
+            },
+        );
+        handler.on_progress(
+            "uv",
+            EnvProgressPhase::Ready {
+                env_path: venv_path.to_string_lossy().to_string(),
+                python_path: python_path.to_string_lossy().to_string(),
+            },
+        );
+        return Ok(UvEnvironment {
+            venv_path,
+            python_path,
+        });
+    }
+
+    info!("Creating new environment at {:?}", venv_path);
+
+    let uv_path = kernel_launch::tools::get_uv_path().await?;
+
+    tokio::fs::create_dir_all(cache_dir).await?;
+
+    // Remove partial environment
+    if venv_path.exists() {
+        tokio::fs::remove_dir_all(&venv_path).await?;
+    }
+
+    // Create venv
+    handler.on_progress("uv", EnvProgressPhase::CreatingVenv);
+
+    let mut venv_cmd = tokio::process::Command::new(&uv_path);
+    venv_cmd.arg("venv").arg(&venv_path);
+
+    if let Some(ref py_version) = deps.requires_python {
+        let version = py_version
+            .trim_start_matches(|c: char| !c.is_ascii_digit())
+            .to_string();
+        if !version.is_empty() {
+            venv_cmd.arg("--python").arg(&version);
+        }
+    }
+
+    let venv_output = venv_cmd
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .await?;
+
+    if !venv_output.status.success() {
+        let stderr = String::from_utf8_lossy(&venv_output.stderr);
+        let error_msg = format!("Failed to create virtual environment: {}", stderr);
+        handler.on_progress(
+            "uv",
+            EnvProgressPhase::Error {
+                message: error_msg.clone(),
+            },
+        );
+        return Err(anyhow!(error_msg));
+    }
+
+    // Install packages
+    let mut install_args = vec![
+        "pip".to_string(),
+        "install".to_string(),
+        "--python".to_string(),
+        python_path.to_string_lossy().to_string(),
+        "ipykernel".to_string(),
+        "ipywidgets".to_string(),
+    ];
+
+    for dep in &deps.dependencies {
+        install_args.push(dep.clone());
+    }
+
+    handler.on_progress(
+        "uv",
+        EnvProgressPhase::InstallingPackages {
+            packages: install_args[4..].to_vec(),
+        },
+    );
+
+    let install_output = tokio::process::Command::new(&uv_path)
+        .args(&install_args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .await?;
+
+    if !install_output.status.success() {
+        tokio::fs::remove_dir_all(&venv_path).await.ok();
+        let stderr = String::from_utf8_lossy(&install_output.stderr);
+        let error_msg = format!("Failed to install dependencies: {}", stderr);
+        handler.on_progress(
+            "uv",
+            EnvProgressPhase::Error {
+                message: error_msg.clone(),
+            },
+        );
+        return Err(anyhow!(error_msg));
+    }
+
+    info!("Environment ready at {:?}", venv_path);
+    handler.on_progress(
+        "uv",
+        EnvProgressPhase::Ready {
+            env_path: venv_path.to_string_lossy().to_string(),
+            python_path: python_path.to_string_lossy().to_string(),
+        },
+    );
+
+    Ok(UvEnvironment {
+        venv_path,
+        python_path,
+    })
+}
+
+/// Install additional dependencies into an existing environment.
+pub async fn sync_dependencies(env: &UvEnvironment, deps: &[String]) -> Result<()> {
+    if deps.is_empty() {
+        return Ok(());
+    }
+
+    info!("Syncing {} dependencies to {:?}", deps.len(), env.venv_path);
+
+    let uv_path = kernel_launch::tools::get_uv_path().await?;
+
+    let mut install_args = vec![
+        "pip".to_string(),
+        "install".to_string(),
+        "--python".to_string(),
+        env.python_path.to_string_lossy().to_string(),
+    ];
+
+    for dep in deps {
+        install_args.push(dep.clone());
+    }
+
+    let output = tokio::process::Command::new(&uv_path)
+        .args(&install_args)
+        .output()
+        .await?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(anyhow!("Failed to sync dependencies: {}", stderr));
+    }
+
+    info!("Dependencies synced successfully");
+    Ok(())
+}
+
+/// Create a prewarmed environment with ipykernel, ipywidgets, and
+/// any caller-supplied extra packages.
+///
+/// Returns an environment at `prewarm-{uuid}` that can later be claimed
+/// via [`claim_prewarmed_environment`].
+pub async fn create_prewarmed_environment(
+    extra_packages: &[String],
+    handler: Arc<dyn ProgressHandler>,
+) -> Result<UvEnvironment> {
+    create_prewarmed_environment_in(&default_cache_dir_uv(), extra_packages, handler).await
+}
+
+/// Like [`create_prewarmed_environment`] but with an explicit cache directory.
+pub async fn create_prewarmed_environment_in(
+    cache_dir: &Path,
+    extra_packages: &[String],
+    handler: Arc<dyn ProgressHandler>,
+) -> Result<UvEnvironment> {
+    let temp_id = format!("prewarm-{}", uuid::Uuid::new_v4());
+    let venv_path = cache_dir.join(&temp_id);
+
+    #[cfg(target_os = "windows")]
+    let python_path = venv_path.join("Scripts").join("python.exe");
+    #[cfg(not(target_os = "windows"))]
+    let python_path = venv_path.join("bin").join("python");
+
+    info!(
+        "[prewarm] Creating prewarmed environment at {:?}",
+        venv_path
+    );
+
+    let uv_path = kernel_launch::tools::get_uv_path().await?;
+
+    tokio::fs::create_dir_all(cache_dir).await?;
+
+    handler.on_progress("uv", EnvProgressPhase::CreatingVenv);
+
+    let venv_output = tokio::process::Command::new(&uv_path)
+        .arg("venv")
+        .arg(&venv_path)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .await?;
+
+    if !venv_output.status.success() {
+        let stderr = String::from_utf8_lossy(&venv_output.stderr);
+        return Err(anyhow!(
+            "Failed to create prewarmed virtual environment: {}",
+            stderr
+        ));
+    }
+
+    // Install ipykernel, ipywidgets, and any extra packages
+    let mut install_args = vec![
+        "pip".to_string(),
+        "install".to_string(),
+        "--python".to_string(),
+        python_path.to_string_lossy().to_string(),
+        "ipykernel".to_string(),
+        "ipywidgets".to_string(),
+    ];
+    if !extra_packages.is_empty() {
+        info!("[prewarm] Including extra packages: {:?}", extra_packages);
+        install_args.extend(extra_packages.iter().cloned());
+    }
+
+    handler.on_progress(
+        "uv",
+        EnvProgressPhase::InstallingPackages {
+            packages: install_args[4..].to_vec(),
+        },
+    );
+
+    let install_output = tokio::process::Command::new(&uv_path)
+        .args(&install_args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .await?;
+
+    if !install_output.status.success() {
+        tokio::fs::remove_dir_all(&venv_path).await.ok();
+        let stderr = String::from_utf8_lossy(&install_output.stderr);
+        return Err(anyhow!(
+            "Failed to install ipykernel in prewarmed environment: {}",
+            stderr
+        ));
+    }
+
+    info!("[prewarm] Prewarmed environment ready at {:?}", venv_path);
+
+    let env = UvEnvironment {
+        venv_path,
+        python_path,
+    };
+
+    warmup_environment(&env).await?;
+
+    handler.on_progress(
+        "uv",
+        EnvProgressPhase::Ready {
+            env_path: env.venv_path.to_string_lossy().to_string(),
+            python_path: env.python_path.to_string_lossy().to_string(),
+        },
+    );
+
+    Ok(env)
+}
+
+/// Claim a prewarmed environment for a specific notebook.
+///
+/// Moves the prewarmed environment to the correct cache location based
+/// on `env_id`, so it will be found by [`prepare_environment`] later.
+pub async fn claim_prewarmed_environment(
+    prewarmed: UvEnvironment,
+    env_id: &str,
+) -> Result<UvEnvironment> {
+    claim_prewarmed_environment_in(prewarmed, env_id, &default_cache_dir_uv()).await
+}
+
+/// Like [`claim_prewarmed_environment`] but with an explicit cache directory.
+pub async fn claim_prewarmed_environment_in(
+    prewarmed: UvEnvironment,
+    env_id: &str,
+    cache_dir: &Path,
+) -> Result<UvEnvironment> {
+    let deps = UvDependencies {
+        dependencies: vec![],
+        requires_python: None,
+    };
+    let hash = compute_env_hash(&deps, Some(env_id));
+    let dest_path = cache_dir.join(&hash);
+
+    #[cfg(target_os = "windows")]
+    let python_path = dest_path.join("Scripts").join("python.exe");
+    #[cfg(not(target_os = "windows"))]
+    let python_path = dest_path.join("bin").join("python");
+
+    if dest_path.exists() {
+        info!(
+            "[prewarm] Destination already exists, removing prewarmed env at {:?}",
+            prewarmed.venv_path
+        );
+        tokio::fs::remove_dir_all(&prewarmed.venv_path).await.ok();
+        return Ok(UvEnvironment {
+            venv_path: dest_path,
+            python_path,
+        });
+    }
+
+    info!(
+        "[prewarm] Claiming prewarmed environment: {:?} -> {:?}",
+        prewarmed.venv_path, dest_path
+    );
+
+    match tokio::fs::rename(&prewarmed.venv_path, &dest_path).await {
+        Ok(()) => {
+            info!("[prewarm] Environment claimed via rename");
+        }
+        Err(e) => {
+            info!("[prewarm] Rename failed ({}), falling back to copy", e);
+            copy_dir_recursive(&prewarmed.venv_path, &dest_path).await?;
+            tokio::fs::remove_dir_all(&prewarmed.venv_path).await.ok();
+            info!("[prewarm] Environment claimed via copy");
+        }
+    }
+
+    Ok(UvEnvironment {
+        venv_path: dest_path,
+        python_path,
+    })
+}
+
+/// Find existing prewarmed environments from previous sessions.
+pub async fn find_existing_prewarmed_environments() -> Vec<UvEnvironment> {
+    find_existing_prewarmed_environments_in(&default_cache_dir_uv()).await
+}
+
+/// Like [`find_existing_prewarmed_environments`] but with an explicit cache directory.
+pub async fn find_existing_prewarmed_environments_in(cache_dir: &Path) -> Vec<UvEnvironment> {
+    let mut found = Vec::new();
+
+    let Ok(mut entries) = tokio::fs::read_dir(cache_dir).await else {
+        return found;
+    };
+
+    while let Ok(Some(entry)) = entries.next_entry().await {
+        let name = entry.file_name().to_string_lossy().to_string();
+        if !name.starts_with("prewarm-") {
+            continue;
+        }
+
+        let venv_path = entry.path();
+
+        #[cfg(target_os = "windows")]
+        let python_path = venv_path.join("Scripts").join("python.exe");
+        #[cfg(not(target_os = "windows"))]
+        let python_path = venv_path.join("bin").join("python");
+
+        if !python_path.exists() {
+            info!(
+                "[prewarm] Removing invalid prewarmed env (no python): {:?}",
+                venv_path
+            );
+            tokio::fs::remove_dir_all(&venv_path).await.ok();
+            continue;
+        }
+
+        info!(
+            "[prewarm] Found existing prewarmed environment: {:?}",
+            venv_path
+        );
+        found.push(UvEnvironment {
+            venv_path,
+            python_path,
+        });
+    }
+
+    found
+}
+
+/// Warm up a UV environment by running Python to trigger .pyc compilation.
+pub async fn warmup_environment(env: &UvEnvironment) -> Result<()> {
+    let warmup_start = std::time::Instant::now();
+    info!("[prewarm] Warming up UV environment at {:?}", env.venv_path);
+
+    let warmup_script = r#"
+import sys
+import ipykernel
+import IPython
+import ipywidgets
+import traitlets
+import zmq
+from ipykernel.kernelbase import Kernel
+from ipykernel.ipkernel import IPythonKernel
+from ipykernel.comm import CommManager
+print("warmup complete")
+"#;
+
+    let output = tokio::process::Command::new(&env.python_path)
+        .args(["-c", warmup_script])
+        .output()
+        .await?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        log::warn!(
+            "[prewarm] UV warmup failed for {:?}: {}",
+            env.venv_path,
+            stderr
+        );
+        return Ok(());
+    }
+
+    let marker_path = env.venv_path.join(".warmed");
+    tokio::fs::write(&marker_path, "").await.ok();
+
+    info!(
+        "[prewarm] UV warmup complete for {:?} in {}ms",
+        env.venv_path,
+        warmup_start.elapsed().as_millis()
+    );
+
+    Ok(())
+}
+
+/// Check if a UV environment has been warmed up.
+pub fn is_environment_warmed(env: &UvEnvironment) -> bool {
+    env.venv_path.join(".warmed").exists()
+}
+
+/// Copy an existing UV environment to a new location.
+pub async fn copy_environment(source: &UvEnvironment, new_env_id: &str) -> Result<UvEnvironment> {
+    let cache_dir = default_cache_dir_uv();
+    let dest_path = cache_dir.join(new_env_id);
+
+    if dest_path.exists() {
+        info!("Clone environment already exists at {:?}", dest_path);
+        #[cfg(target_os = "windows")]
+        let python_path = dest_path.join("Scripts").join("python.exe");
+        #[cfg(not(target_os = "windows"))]
+        let python_path = dest_path.join("bin").join("python");
+
+        return Ok(UvEnvironment {
+            venv_path: dest_path,
+            python_path,
+        });
+    }
+
+    info!(
+        "Copying environment from {:?} to {:?}",
+        source.venv_path, dest_path
+    );
+
+    copy_dir_recursive(&source.venv_path, &dest_path).await?;
+
+    #[cfg(target_os = "windows")]
+    let python_path = dest_path.join("Scripts").join("python.exe");
+    #[cfg(not(target_os = "windows"))]
+    let python_path = dest_path.join("bin").join("python");
+
+    info!("Environment copied successfully");
+
+    Ok(UvEnvironment {
+        venv_path: dest_path,
+        python_path,
+    })
+}
+
+/// No-op cleanup (cached environments are kept for reuse).
+pub async fn cleanup_environment(_env: &UvEnvironment) -> Result<()> {
+    Ok(())
+}
+
+/// Force remove a cached environment.
+#[allow(dead_code)]
+pub async fn remove_environment(env: &UvEnvironment) -> Result<()> {
+    if env.venv_path.exists() {
+        tokio::fs::remove_dir_all(&env.venv_path).await?;
+    }
+    Ok(())
+}
+
+/// Clear all cached UV environments.
+#[allow(dead_code)]
+pub async fn clear_cache() -> Result<()> {
+    let cache_dir = default_cache_dir_uv();
+    if cache_dir.exists() {
+        tokio::fs::remove_dir_all(&cache_dir).await?;
+    }
+    Ok(())
+}
+
+/// Recursively copy a directory, preserving symlinks.
+async fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {
+    tokio::fs::create_dir_all(dst).await?;
+    let mut entries = tokio::fs::read_dir(src).await?;
+
+    while let Some(entry) = entries.next_entry().await? {
+        let ty = entry.file_type().await?;
+        let src_path = entry.path();
+        let dst_path = dst.join(entry.file_name());
+
+        if ty.is_dir() {
+            Box::pin(copy_dir_recursive(&src_path, &dst_path)).await?;
+        } else if ty.is_symlink() {
+            #[cfg(unix)]
+            {
+                let link_target = tokio::fs::read_link(&src_path).await?;
+                tokio::fs::symlink(&link_target, &dst_path).await?;
+            }
+            #[cfg(windows)]
+            tokio::fs::copy(&src_path, &dst_path).await?;
+        } else {
+            tokio::fs::copy(&src_path, &dst_path).await?;
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_compute_env_hash_stable() {
+        let deps = UvDependencies {
+            dependencies: vec!["pandas".to_string(), "numpy".to_string()],
+            requires_python: Some(">=3.10".to_string()),
+        };
+
+        let hash1 = compute_env_hash(&deps, None);
+        let hash2 = compute_env_hash(&deps, None);
+        assert_eq!(hash1, hash2);
+    }
+
+    #[test]
+    fn test_compute_env_hash_order_independent() {
+        let deps1 = UvDependencies {
+            dependencies: vec!["pandas".to_string(), "numpy".to_string()],
+            requires_python: None,
+        };
+
+        let deps2 = UvDependencies {
+            dependencies: vec!["numpy".to_string(), "pandas".to_string()],
+            requires_python: None,
+        };
+
+        assert_eq!(
+            compute_env_hash(&deps1, None),
+            compute_env_hash(&deps2, None)
+        );
+    }
+
+    #[test]
+    fn test_compute_env_hash_different_deps() {
+        let deps1 = UvDependencies {
+            dependencies: vec!["pandas".to_string()],
+            requires_python: None,
+        };
+
+        let deps2 = UvDependencies {
+            dependencies: vec!["numpy".to_string()],
+            requires_python: None,
+        };
+
+        assert_ne!(
+            compute_env_hash(&deps1, None),
+            compute_env_hash(&deps2, None)
+        );
+    }
+
+    #[test]
+    fn test_compute_env_hash_env_id_isolation() {
+        let deps = UvDependencies {
+            dependencies: vec![],
+            requires_python: None,
+        };
+
+        let hash1 = compute_env_hash(&deps, Some("notebook-1"));
+        let hash2 = compute_env_hash(&deps, Some("notebook-2"));
+        assert_ne!(hash1, hash2);
+    }
+
+    #[test]
+    fn test_compute_env_hash_env_id_ignored_with_deps() {
+        let deps = UvDependencies {
+            dependencies: vec!["pandas".to_string()],
+            requires_python: None,
+        };
+
+        let hash1 = compute_env_hash(&deps, Some("notebook-1"));
+        let hash2 = compute_env_hash(&deps, Some("notebook-2"));
+        // env_id is only included for empty deps
+        assert_eq!(hash1, hash2);
+    }
+}

--- a/crates/kernel-env/src/uv.rs
+++ b/crates/kernel-env/src/uv.rs
@@ -1,9 +1,9 @@
 //! UV-based virtual environment management.
 //!
 //! Creates, caches, and prewarms UV virtual environments for Jupyter kernels.
-//! Environments are keyed by a SHA-256 hash of (dependencies + requires-python
-//! + env_id) and stored under the cache directory. UV is auto-bootstrapped via
-//! rattler if not found on PATH.
+//! Environments are keyed by a SHA-256 hash of dependencies, requires-python,
+//! and env_id, then stored under the cache directory. UV is auto-bootstrapped
+//! via rattler if not found on PATH.
 
 use anyhow::{anyhow, Result};
 use log::info;

--- a/crates/notebook/Cargo.toml
+++ b/crates/notebook/Cargo.toml
@@ -35,6 +35,7 @@ tauri-jupyter = { path = "../tauri-jupyter" }
 runtimed = { path = "../runtimed" }
 runt-trust = { path = "../runt-trust" }
 kernel-launch = { path = "../kernel-launch" }
+kernel-env = { path = "../kernel-env" }
 nbformat = "1.2.0"
 petname = "2"
 log = "0.4"

--- a/crates/notebook/src/conda_env.rs
+++ b/crates/notebook/src/conda_env.rs
@@ -1,88 +1,52 @@
 //! Conda-based environment management for notebook dependencies.
 //!
-//! This module handles creating ephemeral conda environments using `rattler`
-//! for notebooks that declare inline dependencies in their metadata.
+//! This module provides notebook-specific metadata operations (extract, set,
+//! remove dependencies from `nbformat::Metadata`) and delegates environment
+//! creation to `kernel_env::conda`.
 
-use anyhow::{anyhow, Result};
-use log::{info, warn};
-use rattler::{
-    default_cache_dir,
-    install::{Installer, Reporter, Transaction},
-    package_cache::PackageCache,
-};
-use rattler_conda_types::{
-    Channel, ChannelConfig, GenericVirtualPackage, MatchSpec, ParseMatchSpecOptions, Platform,
-    PrefixRecord, RepoDataRecord,
-};
-use rattler_repodata_gateway::Gateway;
-use rattler_solve::{resolvo, SolverImpl, SolverTask};
+use anyhow::Result;
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
-use std::collections::HashMap;
-use std::path::PathBuf;
-use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
-use std::sync::RwLock;
-use std::time::Instant;
+use std::sync::Arc;
 use tauri::{AppHandle, Emitter};
 
-/// Progress phases during environment preparation.
-/// Emitted as Tauri events for frontend progress display.
-#[derive(Debug, Clone, Serialize)]
-#[serde(tag = "phase", rename_all = "snake_case")]
-pub enum EnvProgressPhase {
-    /// Starting environment preparation
-    Starting { env_hash: String },
-    /// Using a cached environment (fast path)
-    CacheHit { env_path: String },
-    /// Fetching package metadata from channels
-    FetchingRepodata { channels: Vec<String> },
-    /// Repodata fetch complete
-    RepodataComplete {
-        record_count: usize,
-        elapsed_ms: u64,
-    },
-    /// Solving dependency graph
-    Solving { spec_count: usize },
-    /// Solve complete
-    SolveComplete {
-        package_count: usize,
-        elapsed_ms: u64,
-    },
-    /// Installing packages (legacy phase, kept for backward compat)
-    Installing { total: usize },
-    /// Download progress for individual packages
-    DownloadProgress {
-        /// Number of packages fully downloaded
-        completed: usize,
-        /// Total number of packages to download
-        total: usize,
-        /// Name of the package currently being downloaded
-        current_package: String,
-        /// Total bytes downloaded so far
-        bytes_downloaded: u64,
-        /// Total bytes to download (if known)
-        bytes_total: Option<u64>,
-        /// Current download speed in bytes per second
-        bytes_per_second: f64,
-    },
-    /// Linking/installing packages into the environment
-    LinkProgress {
-        /// Number of packages fully linked
-        completed: usize,
-        /// Total number of packages to link
-        total: usize,
-        /// Name of the package currently being linked
-        current_package: String,
-    },
-    /// Installation complete
-    InstallComplete { elapsed_ms: u64 },
-    /// Environment is ready
-    Ready {
-        env_path: String,
-        python_path: String,
-    },
-    /// An error occurred
-    Error { message: String },
+// Re-export core types from kernel-env for backward compatibility
+pub use kernel_env::conda::CondaEnvironment;
+pub use kernel_env::progress::EnvProgressPhase;
+
+/// Dependencies extracted from notebook metadata (conda format).
+///
+/// This is the notebook-side type that includes env_id for per-notebook
+/// isolation. It converts to/from `kernel_env::CondaDependencies`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CondaDependencies {
+    pub dependencies: Vec<String>,
+    #[serde(default)]
+    pub channels: Vec<String>,
+    pub python: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub env_id: Option<String>,
+}
+
+impl From<CondaDependencies> for kernel_env::CondaDependencies {
+    fn from(deps: CondaDependencies) -> Self {
+        Self {
+            dependencies: deps.dependencies,
+            channels: deps.channels,
+            python: deps.python,
+            env_id: deps.env_id,
+        }
+    }
+}
+
+impl From<kernel_env::CondaDependencies> for CondaDependencies {
+    fn from(deps: kernel_env::CondaDependencies) -> Self {
+        Self {
+            dependencies: deps.dependencies,
+            channels: deps.channels,
+            python: deps.python,
+            env_id: deps.env_id,
+        }
+    }
 }
 
 /// Full progress event payload sent to frontend.
@@ -93,288 +57,34 @@ pub struct EnvProgressEvent {
     pub phase: EnvProgressPhase,
 }
 
-/// Emit a progress event to the frontend.
-fn emit_progress(app: Option<&AppHandle>, phase: EnvProgressPhase) {
-    if let Some(app) = app {
+/// Progress handler that emits Tauri events.
+pub struct TauriProgressHandler {
+    app: AppHandle,
+}
+
+impl TauriProgressHandler {
+    pub fn new(app: AppHandle) -> Self {
+        Self { app }
+    }
+}
+
+impl kernel_env::ProgressHandler for TauriProgressHandler {
+    fn on_progress(&self, env_type: &str, phase: EnvProgressPhase) {
         let event = EnvProgressEvent {
-            env_type: "conda".to_string(),
+            env_type: env_type.to_string(),
             phase,
         };
-        if let Err(e) = app.emit("env:progress", &event) {
+        if let Err(e) = self.app.emit("env:progress", &event) {
             log::warn!("Failed to emit env:progress event: {}", e);
         }
     }
 }
 
-/// Reporter implementation for tracking installation progress.
-///
-/// This implements the rattler Reporter trait to provide granular progress
-/// updates during package download and installation.
-pub struct ProgressReporter {
-    app: Option<AppHandle>,
-    /// Total packages to download
-    total_downloads: AtomicUsize,
-    /// Number of packages fully downloaded
-    downloaded_packages: AtomicUsize,
-    /// Total bytes downloaded across all packages
-    bytes_downloaded: AtomicU64,
-    /// Total bytes to download (if known)
-    bytes_total: AtomicU64,
-    /// When downloading started
-    download_start: RwLock<Option<Instant>>,
-    /// Total packages to link
-    total_to_link: AtomicUsize,
-    /// Number of packages fully linked
-    linked_packages: AtomicUsize,
-    /// Package names indexed by operation/cache index
-    package_names: RwLock<HashMap<usize, String>>,
-    /// Current package being downloaded
-    current_download: RwLock<Option<String>>,
-    /// Last time we emitted a download progress event (for throttling)
-    last_download_emit: RwLock<Option<Instant>>,
-}
-
-impl ProgressReporter {
-    /// Create a new progress reporter.
-    pub fn new(app: Option<AppHandle>) -> Self {
-        Self {
-            app,
-            total_downloads: AtomicUsize::new(0),
-            downloaded_packages: AtomicUsize::new(0),
-            bytes_downloaded: AtomicU64::new(0),
-            bytes_total: AtomicU64::new(0),
-            download_start: RwLock::new(None),
-            total_to_link: AtomicUsize::new(0),
-            linked_packages: AtomicUsize::new(0),
-            package_names: RwLock::new(HashMap::new()),
-            current_download: RwLock::new(None),
-            last_download_emit: RwLock::new(None),
-        }
-    }
-
-    /// Emit download progress (throttled to avoid flooding)
-    fn emit_download_progress(&self) {
-        // Throttle to at most once per 100ms
-        {
-            let mut last_emit = self.last_download_emit.write().unwrap();
-            if let Some(last) = *last_emit {
-                if last.elapsed().as_millis() < 100 {
-                    return;
-                }
-            }
-            *last_emit = Some(Instant::now());
-        }
-
-        let completed = self.downloaded_packages.load(Ordering::SeqCst);
-        let total = self.total_downloads.load(Ordering::SeqCst);
-        let bytes_downloaded = self.bytes_downloaded.load(Ordering::SeqCst);
-        let bytes_total = self.bytes_total.load(Ordering::SeqCst);
-
-        let current_package = self
-            .current_download
-            .read()
-            .unwrap()
-            .clone()
-            .unwrap_or_default();
-
-        // Calculate speed
-        let bytes_per_second = {
-            let start = self.download_start.read().unwrap();
-            match *start {
-                Some(s) => {
-                    let elapsed = s.elapsed().as_secs_f64();
-                    if elapsed > 0.0 {
-                        bytes_downloaded as f64 / elapsed
-                    } else {
-                        0.0
-                    }
-                }
-                None => 0.0,
-            }
-        };
-
-        emit_progress(
-            self.app.as_ref(),
-            EnvProgressPhase::DownloadProgress {
-                completed,
-                total,
-                current_package,
-                bytes_downloaded,
-                bytes_total: if bytes_total > 0 {
-                    Some(bytes_total)
-                } else {
-                    None
-                },
-                bytes_per_second,
-            },
-        );
-    }
-
-    /// Emit link progress
-    fn emit_link_progress(&self, current_package: String) {
-        let completed = self.linked_packages.load(Ordering::SeqCst);
-        let total = self.total_to_link.load(Ordering::SeqCst);
-
-        emit_progress(
-            self.app.as_ref(),
-            EnvProgressPhase::LinkProgress {
-                completed,
-                total,
-                current_package,
-            },
-        );
-    }
-}
-
-impl Reporter for ProgressReporter {
-    fn on_transaction_start(&self, transaction: &Transaction<PrefixRecord, RepoDataRecord>) {
-        let total = transaction.operations.len();
-        self.total_to_link.store(total, Ordering::SeqCst);
-
-        // Count how many packages need to be downloaded (rough estimate)
-        // The actual count may be less if packages are cached
-        self.total_downloads.store(total, Ordering::SeqCst);
-
-        // Initialize download start time
-        *self.download_start.write().unwrap() = Some(Instant::now());
-    }
-
-    fn on_transaction_operation_start(&self, _operation: usize) {
-        // Called when an operation (unlink or link) starts
-    }
-
-    fn on_populate_cache_start(&self, cache_entry: usize, record: &RepoDataRecord) -> usize {
-        // Store the package name for later reference
-        let name = record.package_record.name.as_source().to_string();
-        self.package_names
-            .write()
-            .unwrap()
-            .insert(cache_entry, name);
-        cache_entry
-    }
-
-    fn on_validate_start(&self, cache_entry: usize) -> usize {
-        cache_entry
-    }
-
-    fn on_validate_complete(&self, _validate_idx: usize) {
-        // Validation complete - package was already in cache
-    }
-
-    fn on_download_start(&self, cache_entry: usize) -> usize {
-        // Set current download package
-        let name = self
-            .package_names
-            .read()
-            .unwrap()
-            .get(&cache_entry)
-            .cloned()
-            .unwrap_or_default();
-        *self.current_download.write().unwrap() = Some(name);
-        cache_entry
-    }
-
-    fn on_download_progress(&self, _download_idx: usize, progress: u64, total: Option<u64>) {
-        self.bytes_downloaded.fetch_add(progress, Ordering::SeqCst);
-        if let Some(t) = total {
-            // Update total if provided (first call usually has it)
-            let current_total = self.bytes_total.load(Ordering::SeqCst);
-            if current_total == 0 {
-                self.bytes_total.store(t, Ordering::SeqCst);
-            }
-        }
-        self.emit_download_progress();
-    }
-
-    fn on_download_completed(&self, _download_idx: usize) {
-        self.downloaded_packages.fetch_add(1, Ordering::SeqCst);
-        self.emit_download_progress();
-    }
-
-    fn on_populate_cache_complete(&self, _cache_entry: usize) {
-        // Cache population complete (either validated or downloaded)
-    }
-
-    fn on_unlink_start(&self, operation: usize, _record: &PrefixRecord) -> usize {
-        operation
-    }
-
-    fn on_unlink_complete(&self, _index: usize) {
-        // Unlink complete
-    }
-
-    fn on_link_start(&self, operation: usize, record: &RepoDataRecord) -> usize {
-        let name = record.package_record.name.as_source().to_string();
-        self.package_names
-            .write()
-            .unwrap()
-            .insert(operation, name.clone());
-        self.emit_link_progress(name);
-        operation
-    }
-
-    fn on_link_complete(&self, index: usize) {
-        self.linked_packages.fetch_add(1, Ordering::SeqCst);
-        let name = self
-            .package_names
-            .read()
-            .unwrap()
-            .get(&index)
-            .cloned()
-            .unwrap_or_default();
-        self.emit_link_progress(name);
-    }
-
-    fn on_transaction_operation_complete(&self, _operation: usize) {
-        // Operation complete
-    }
-
-    fn on_transaction_complete(&self) {
-        // Transaction complete - all packages installed
-    }
-
-    fn on_post_link_start(&self, _package_name: &str, _script_path: &str) -> usize {
-        0
-    }
-
-    fn on_post_link_complete(&self, _index: usize, _success: bool) {
-        // Post-link script complete
-    }
-
-    fn on_pre_unlink_start(&self, _package_name: &str, _script_path: &str) -> usize {
-        0
-    }
-
-    fn on_pre_unlink_complete(&self, _index: usize, _success: bool) {
-        // Pre-unlink script complete
-    }
-}
-
-/// Dependencies extracted from notebook metadata (conda format).
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CondaDependencies {
-    pub dependencies: Vec<String>,
-    #[serde(default)]
-    pub channels: Vec<String>,
-    pub python: Option<String>,
-    /// Unique environment ID for per-notebook isolation.
-    /// If set, this ID is included in the environment hash to ensure
-    /// each notebook gets its own isolated environment.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub env_id: Option<String>,
-}
-
-/// Result of environment preparation.
-#[derive(Debug, Clone)]
-pub struct CondaEnvironment {
-    pub env_path: PathBuf,
-    pub python_path: PathBuf,
-}
+// =====================================================================
+// Metadata operations (notebook-specific, depend on nbformat)
+// =====================================================================
 
 /// Extract dependencies from notebook metadata.
-///
-/// Looks for conda config in the new nested path `runt.conda` first,
-/// then falls back to legacy `conda` for backward compatibility.
 pub fn extract_dependencies(metadata: &nbformat::v4::Metadata) -> Option<CondaDependencies> {
     // New format: metadata.runt.conda
     if let Some(runt_value) = metadata.additional.get("runt") {
@@ -384,14 +94,12 @@ pub fn extract_dependencies(metadata: &nbformat::v4::Metadata) -> Option<CondaDe
             }
         }
     }
-    // Legacy format: metadata.conda (fallback for unmigrated notebooks)
+    // Legacy format: metadata.conda
     let conda_value = metadata.additional.get("conda")?;
     serde_json::from_value(conda_value.clone()).ok()
 }
 
 /// Set conda dependencies in notebook metadata (nested under runt).
-///
-/// Creates the `runt.conda` path if it doesn't exist.
 pub fn set_dependencies(metadata: &mut nbformat::v4::Metadata, deps: &CondaDependencies) {
     let conda_value = serde_json::json!({
         "dependencies": deps.dependencies,
@@ -399,7 +107,6 @@ pub fn set_dependencies(metadata: &mut nbformat::v4::Metadata, deps: &CondaDepen
         "python": deps.python,
     });
 
-    // Get or create runt namespace
     let runt = metadata
         .additional
         .entry("runt".to_string())
@@ -412,1132 +119,100 @@ pub fn set_dependencies(metadata: &mut nbformat::v4::Metadata, deps: &CondaDepen
 
 /// Check if notebook has conda config (in new or legacy format).
 pub fn has_conda_config(metadata: &nbformat::v4::Metadata) -> bool {
-    // Check new format
     if let Some(runt) = metadata.additional.get("runt") {
         if runt.get("conda").is_some() {
             return true;
         }
     }
-    // Check legacy format
     metadata.additional.contains_key("conda")
 }
 
 /// Remove conda config from metadata (both new and legacy paths).
 pub fn remove_conda_config(metadata: &mut nbformat::v4::Metadata) {
-    // Remove from new format
     if let Some(runt) = metadata.additional.get_mut("runt") {
         if let Some(runt_obj) = runt.as_object_mut() {
             runt_obj.remove("conda");
         }
     }
-    // Remove legacy format
     metadata.additional.remove("conda");
 }
 
+// =====================================================================
+// Environment operations (delegating to kernel-env)
+// =====================================================================
+
 /// Compute a cache key for the given dependencies.
-fn compute_env_hash(deps: &CondaDependencies) -> String {
-    let mut hasher = Sha256::new();
-
-    // Sort dependencies for consistent hashing
-    let mut sorted_deps = deps.dependencies.clone();
-    sorted_deps.sort();
-
-    for dep in &sorted_deps {
-        hasher.update(dep.as_bytes());
-        hasher.update(b"\n");
-    }
-
-    // Include channels in the hash
-    let mut sorted_channels = deps.channels.clone();
-    sorted_channels.sort();
-    for channel in &sorted_channels {
-        hasher.update(b"channel:");
-        hasher.update(channel.as_bytes());
-        hasher.update(b"\n");
-    }
-
-    if let Some(ref py) = deps.python {
-        hasher.update(b"python:");
-        hasher.update(py.as_bytes());
-    }
-
-    // Include env_id for per-notebook isolation
-    if let Some(ref env_id) = deps.env_id {
-        hasher.update(b"env_id:");
-        hasher.update(env_id.as_bytes());
-    }
-
-    let hash = hasher.finalize();
-    format!("{:x}", hash)[..16].to_string()
-}
-
-/// Get the cache directory for runt conda environments.
-fn get_cache_dir() -> PathBuf {
-    dirs::cache_dir()
-        .unwrap_or_else(|| PathBuf::from("/tmp"))
-        .join("runt")
-        .join("conda-envs")
+pub fn compute_env_hash(deps: &CondaDependencies) -> String {
+    kernel_env::conda::compute_env_hash(&deps.clone().into())
 }
 
 /// Prepare a conda environment with the given dependencies.
-///
-/// Uses cached environments when possible (keyed by dependency hash).
-/// If the cache doesn't exist or is invalid, creates a new environment using rattler.
-///
-/// If `app` is provided, progress events will be emitted to the frontend.
 pub async fn prepare_environment(
     deps: &CondaDependencies,
     app: Option<&AppHandle>,
 ) -> Result<CondaEnvironment> {
-    let hash = compute_env_hash(deps);
-    let cache_dir = get_cache_dir();
-    let env_path = cache_dir.join(&hash);
-
-    emit_progress(
-        app,
-        EnvProgressPhase::Starting {
-            env_hash: hash.clone(),
-        },
-    );
-
-    // Determine python path based on platform
-    #[cfg(target_os = "windows")]
-    let python_path = env_path.join("python.exe");
-    #[cfg(not(target_os = "windows"))]
-    let python_path = env_path.join("bin").join("python");
-
-    // Check if cached environment exists and is valid
-    if env_path.exists() && python_path.exists() {
-        info!("Using cached conda environment at {:?}", env_path);
-        emit_progress(
-            app,
-            EnvProgressPhase::CacheHit {
-                env_path: env_path.to_string_lossy().to_string(),
-            },
-        );
-        emit_progress(
-            app,
-            EnvProgressPhase::Ready {
-                env_path: env_path.to_string_lossy().to_string(),
-                python_path: python_path.to_string_lossy().to_string(),
-            },
-        );
-        return Ok(CondaEnvironment {
-            env_path,
-            python_path,
-        });
-    }
-
-    info!("Creating new conda environment at {:?}", env_path);
-
-    // Ensure cache directory exists
-    tokio::fs::create_dir_all(&cache_dir).await?;
-
-    // Remove partial/invalid environment if it exists
-    if env_path.exists() {
-        tokio::fs::remove_dir_all(&env_path).await?;
-    }
-
-    // Setup channel configuration
-    let channel_config = ChannelConfig::default_with_root_dir(cache_dir.clone());
-
-    // Parse channels (default to conda-forge if none specified)
-    let channels: Vec<Channel> = if deps.channels.is_empty() {
-        vec![Channel::from_str("conda-forge", &channel_config)?]
-    } else {
-        deps.channels
-            .iter()
-            .map(|c| Channel::from_str(c, &channel_config))
-            .collect::<Result<Vec<_>, _>>()?
+    let handler: Arc<dyn kernel_env::ProgressHandler> = match app {
+        Some(a) => Arc::new(TauriProgressHandler::new(a.clone())),
+        None => Arc::new(kernel_env::LogHandler),
     };
-
-    let channel_names: Vec<String> = channels.iter().map(|c| c.name().to_string()).collect();
-
-    // Build specs: python + ipykernel + user dependencies
-    let match_spec_options = ParseMatchSpecOptions::strict();
-    let mut specs: Vec<MatchSpec> = Vec::new();
-
-    // Add python version constraint
-    if let Some(ref py) = deps.python {
-        specs.push(MatchSpec::from_str(
-            &format!("python={}", py),
-            match_spec_options,
-        )?);
-    } else {
-        specs.push(MatchSpec::from_str("python>=3.9", match_spec_options)?);
-    }
-
-    // Add ipykernel (required for Jupyter)
-    specs.push(MatchSpec::from_str("ipykernel", match_spec_options)?);
-    // Add ipywidgets for interactive widget support
-    specs.push(MatchSpec::from_str("ipywidgets", match_spec_options)?);
-
-    // Add user dependencies
-    for dep in &deps.dependencies {
-        specs.push(MatchSpec::from_str(dep, match_spec_options)?);
-    }
-
-    info!("Resolving conda packages: {:?}", specs);
-
-    // Find or create the rattler cache directory
-    let rattler_cache_dir = default_cache_dir()
-        .map_err(|e| anyhow!("could not determine rattler cache directory: {}", e))?;
-    rattler_cache::ensure_cache_dir(&rattler_cache_dir)
-        .map_err(|e| anyhow!("could not create rattler cache directory: {}", e))?;
-
-    // Create HTTP client for downloading
-    let download_client = reqwest::Client::builder().build()?;
-    let download_client = reqwest_middleware::ClientBuilder::new(download_client).build();
-
-    // Create gateway for fetching repodata
-    let gateway = Gateway::builder()
-        .with_cache_dir(rattler_cache_dir.join(rattler_cache::REPODATA_CACHE_DIR))
-        .with_package_cache(PackageCache::new(
-            rattler_cache_dir.join(rattler_cache::PACKAGE_CACHE_DIR),
-        ))
-        .with_client(download_client.clone())
-        .finish();
-
-    // Determine platforms to query
-    let install_platform = Platform::current();
-    let platforms = vec![install_platform, Platform::NoArch];
-
-    // Query repodata from channels with retry logic for transient failures
-    info!("Fetching repodata from channels: {:?}", channels);
-    emit_progress(
-        app,
-        EnvProgressPhase::FetchingRepodata {
-            channels: channel_names,
-        },
-    );
-
-    let repodata_start = Instant::now();
-
-    // Retry configuration for transient network errors (e.g., conda-forge 500 errors)
-    const MAX_RETRIES: u32 = 3;
-    const INITIAL_DELAY_MS: u64 = 1000;
-
-    let mut last_error = None;
-    let mut repo_data = None;
-
-    for attempt in 0..MAX_RETRIES {
-        if attempt > 0 {
-            let delay_ms = INITIAL_DELAY_MS * (1 << (attempt - 1)); // Exponential backoff
-            info!(
-                "Retrying repodata fetch (attempt {}/{}) after {}ms...",
-                attempt + 1,
-                MAX_RETRIES,
-                delay_ms
-            );
-            tokio::time::sleep(tokio::time::Duration::from_millis(delay_ms)).await;
-        }
-
-        match gateway
-            .query(channels.clone(), platforms.clone(), specs.clone())
-            .recursive(true)
-            .await
-        {
-            Ok(data) => {
-                repo_data = Some(data);
-                break;
-            }
-            Err(e) => {
-                let error_str = e.to_string();
-                // Check if it's a retryable error (server errors, timeouts)
-                let is_retryable = error_str.contains("500")
-                    || error_str.contains("502")
-                    || error_str.contains("503")
-                    || error_str.contains("504")
-                    || error_str.contains("timeout")
-                    || error_str.contains("connection");
-
-                if is_retryable && attempt < MAX_RETRIES - 1 {
-                    info!(
-                        "Transient error fetching repodata (attempt {}): {}",
-                        attempt + 1,
-                        error_str
-                    );
-                    last_error = Some(e);
-                    continue;
-                }
-
-                let error_msg = format!("Failed to fetch package metadata: {}", e);
-                emit_progress(
-                    app,
-                    EnvProgressPhase::Error {
-                        message: error_msg.clone(),
-                    },
-                );
-                return Err(anyhow!(error_msg));
-            }
-        }
-    }
-
-    let repo_data = match repo_data {
-        Some(data) => data,
-        None => {
-            let error_msg = format!(
-                "Failed to fetch package metadata after {} retries: {}",
-                MAX_RETRIES,
-                last_error
-                    .map(|e| e.to_string())
-                    .unwrap_or_else(|| "unknown error".to_string())
-            );
-            emit_progress(
-                app,
-                EnvProgressPhase::Error {
-                    message: error_msg.clone(),
-                },
-            );
-            return Err(anyhow!(error_msg));
-        }
-    };
-
-    let total_records: usize = repo_data.iter().map(|r| r.len()).sum();
-    let repodata_elapsed = repodata_start.elapsed();
-    info!(
-        "Loaded {} package records in {:?}",
-        total_records, repodata_elapsed
-    );
-    emit_progress(
-        app,
-        EnvProgressPhase::RepodataComplete {
-            record_count: total_records,
-            elapsed_ms: repodata_elapsed.as_millis() as u64,
-        },
-    );
-
-    // Detect virtual packages (system capabilities like __glibc, __cuda, etc.)
-    let virt_start = Instant::now();
-    let virtual_packages = rattler_virtual_packages::VirtualPackage::detect(
-        &rattler_virtual_packages::VirtualPackageOverrides::default(),
-    )?
-    .iter()
-    .map(|vpkg| GenericVirtualPackage::from(vpkg.clone()))
-    .collect::<Vec<_>>();
-
-    info!(
-        "Detected {} virtual packages in {:?}",
-        virtual_packages.len(),
-        virt_start.elapsed()
-    );
-
-    // Solve dependencies
-    info!("Solving dependencies...");
-    emit_progress(
-        app,
-        EnvProgressPhase::Solving {
-            spec_count: specs.len(),
-        },
-    );
-
-    let solve_start = Instant::now();
-    let solver_task = SolverTask {
-        virtual_packages,
-        specs,
-        ..SolverTask::from_iter(&repo_data)
-    };
-
-    let solver_result = match resolvo::Solver.solve(solver_task) {
-        Ok(result) => result,
-        Err(e) => {
-            let error_msg = format!("Failed to solve dependencies: {}", e);
-            emit_progress(
-                app,
-                EnvProgressPhase::Error {
-                    message: error_msg.clone(),
-                },
-            );
-            return Err(anyhow!(error_msg));
-        }
-    };
-    let required_packages = solver_result.records;
-    let solve_elapsed = solve_start.elapsed();
-
-    info!(
-        "Solved: {} packages to install in {:?}",
-        required_packages.len(),
-        solve_elapsed
-    );
-    emit_progress(
-        app,
-        EnvProgressPhase::SolveComplete {
-            package_count: required_packages.len(),
-            elapsed_ms: solve_elapsed.as_millis() as u64,
-        },
-    );
-
-    // Install packages to the environment prefix
-    info!("Installing packages to {:?}", env_path);
-    emit_progress(
-        app,
-        EnvProgressPhase::Installing {
-            total: required_packages.len(),
-        },
-    );
-
-    // Create progress reporter for granular progress updates
-    let reporter = ProgressReporter::new(app.cloned());
-
-    let install_start = Instant::now();
-    let _result = match Installer::new()
-        .with_download_client(download_client)
-        .with_target_platform(install_platform)
-        .with_reporter(reporter)
-        .install(&env_path, required_packages)
-        .await
-    {
-        Ok(result) => result,
-        Err(e) => {
-            let error_msg = format!("Failed to install packages: {}", e);
-            emit_progress(
-                app,
-                EnvProgressPhase::Error {
-                    message: error_msg.clone(),
-                },
-            );
-            return Err(anyhow!(error_msg));
-        }
-    };
-
-    let install_elapsed = install_start.elapsed();
-    info!(
-        "Conda environment ready at {:?} (install took {:?})",
-        env_path, install_elapsed
-    );
-    emit_progress(
-        app,
-        EnvProgressPhase::InstallComplete {
-            elapsed_ms: install_elapsed.as_millis() as u64,
-        },
-    );
-    emit_progress(
-        app,
-        EnvProgressPhase::Ready {
-            env_path: env_path.to_string_lossy().to_string(),
-            python_path: python_path.to_string_lossy().to_string(),
-        },
-    );
-
-    Ok(CondaEnvironment {
-        env_path,
-        python_path,
-    })
+    kernel_env::conda::prepare_environment(&deps.clone().into(), handler).await
 }
 
-/// Clean up an ephemeral environment.
-///
-/// Note: We don't actually remove cached environments since they can be reused.
-/// This is called on kernel shutdown but only cleans up if needed.
-pub async fn cleanup_environment(_env: &CondaEnvironment) -> Result<()> {
-    // For now, we keep cached environments for reuse.
-    // Could add LRU eviction or size-based cleanup later.
-    Ok(())
+/// Create a prewarmed conda environment.
+pub async fn create_prewarmed_conda_environment(
+    app: Option<&AppHandle>,
+) -> Result<CondaEnvironment> {
+    let extra: Vec<String> = crate::settings::load_settings().conda.default_packages;
+    let handler: Arc<dyn kernel_env::ProgressHandler> = match app {
+        Some(a) => Arc::new(TauriProgressHandler::new(a.clone())),
+        None => Arc::new(kernel_env::LogHandler),
+    };
+    kernel_env::conda::create_prewarmed_environment(&extra, handler).await
 }
 
-/// Force remove a cached environment (for manual cleanup).
-#[allow(dead_code)]
-pub async fn remove_environment(env: &CondaEnvironment) -> Result<()> {
-    if env.env_path.exists() {
-        tokio::fs::remove_dir_all(&env.env_path).await?;
-    }
-    Ok(())
+/// Warm up a conda environment by running Python to trigger .pyc compilation.
+pub async fn warmup_conda_environment(env: &CondaEnvironment) -> Result<()> {
+    kernel_env::conda::warmup_environment(env).await
+}
+
+/// Check if a conda environment has been warmed up.
+pub fn is_environment_warmed(env: &CondaEnvironment) -> bool {
+    kernel_env::conda::is_environment_warmed(env)
+}
+
+/// Claim a prewarmed conda environment for a specific notebook.
+pub async fn claim_prewarmed_conda_environment(
+    prewarmed: CondaEnvironment,
+    env_id: &str,
+) -> Result<CondaEnvironment> {
+    kernel_env::conda::claim_prewarmed_environment(prewarmed, env_id).await
+}
+
+/// Find existing prewarmed conda environments from previous sessions.
+pub async fn find_existing_prewarmed_conda_environments() -> Vec<CondaEnvironment> {
+    kernel_env::conda::find_existing_prewarmed_environments().await
 }
 
 /// Install additional dependencies into an existing environment.
-///
-/// This is used to sync new dependencies when the kernel is already running.
-/// Uses rattler to solve and install the new packages into the existing prefix.
 pub async fn sync_dependencies(env: &CondaEnvironment, deps: &CondaDependencies) -> Result<()> {
-    if deps.dependencies.is_empty() {
-        return Ok(());
-    }
+    kernel_env::conda::sync_dependencies(env, &deps.clone().into()).await
+}
 
-    info!(
-        "Syncing {} dependencies to {:?}",
-        deps.dependencies.len(),
-        env.env_path
-    );
+/// No-op cleanup (cached environments are kept for reuse).
+pub async fn cleanup_environment(env: &CondaEnvironment) -> Result<()> {
+    kernel_env::conda::cleanup_environment(env).await
+}
 
-    // Setup channel configuration
-    let cache_dir = get_cache_dir();
-    let channel_config = ChannelConfig::default_with_root_dir(cache_dir.clone());
-
-    // Parse channels (default to conda-forge if none specified)
-    let channels: Vec<Channel> = if deps.channels.is_empty() {
-        vec![Channel::from_str("conda-forge", &channel_config)?]
-    } else {
-        deps.channels
-            .iter()
-            .map(|c| Channel::from_str(c, &channel_config))
-            .collect::<Result<Vec<_>, _>>()?
-    };
-
-    // Build specs for all dependencies (including existing ones to ensure compatibility)
-    let match_spec_options = ParseMatchSpecOptions::strict();
-    let mut specs: Vec<MatchSpec> = Vec::new();
-
-    for dep in &deps.dependencies {
-        specs.push(MatchSpec::from_str(dep, match_spec_options)?);
-    }
-
-    info!("Resolving {} conda packages for sync", specs.len());
-
-    // Find rattler cache directory
-    let rattler_cache_dir = default_cache_dir()
-        .map_err(|e| anyhow!("could not determine rattler cache directory: {}", e))?;
-
-    // Create HTTP client
-    let download_client = reqwest::Client::builder().build()?;
-    let download_client = reqwest_middleware::ClientBuilder::new(download_client).build();
-
-    // Create gateway for fetching repodata
-    let gateway = Gateway::builder()
-        .with_cache_dir(rattler_cache_dir.join(rattler_cache::REPODATA_CACHE_DIR))
-        .with_package_cache(PackageCache::new(
-            rattler_cache_dir.join(rattler_cache::PACKAGE_CACHE_DIR),
-        ))
-        .with_client(download_client.clone())
-        .finish();
-
-    // Query repodata with retry logic
-    let install_platform = Platform::current();
-    let platforms = vec![install_platform, Platform::NoArch];
-
-    const MAX_RETRIES: u32 = 3;
-    const INITIAL_DELAY_MS: u64 = 1000;
-
-    let mut last_error = None;
-    let mut repo_data = None;
-
-    for attempt in 0..MAX_RETRIES {
-        if attempt > 0 {
-            let delay_ms = INITIAL_DELAY_MS * (1 << (attempt - 1));
-            info!(
-                "Retrying repodata fetch for sync (attempt {}/{}) after {}ms...",
-                attempt + 1,
-                MAX_RETRIES,
-                delay_ms
-            );
-            tokio::time::sleep(tokio::time::Duration::from_millis(delay_ms)).await;
-        }
-
-        match gateway
-            .query(channels.clone(), platforms.clone(), specs.clone())
-            .recursive(true)
-            .await
-        {
-            Ok(data) => {
-                repo_data = Some(data);
-                break;
-            }
-            Err(e) => {
-                let error_str = e.to_string();
-                let is_retryable = error_str.contains("500")
-                    || error_str.contains("502")
-                    || error_str.contains("503")
-                    || error_str.contains("504")
-                    || error_str.contains("timeout")
-                    || error_str.contains("connection");
-
-                if is_retryable && attempt < MAX_RETRIES - 1 {
-                    info!(
-                        "Transient error fetching repodata for sync (attempt {}): {}",
-                        attempt + 1,
-                        error_str
-                    );
-                    last_error = Some(e);
-                    continue;
-                }
-                return Err(anyhow!("Failed to fetch package metadata: {}", e));
-            }
-        }
-    }
-
-    let repo_data = repo_data.ok_or_else(|| {
-        anyhow!(
-            "Failed to fetch package metadata after {} retries: {}",
-            MAX_RETRIES,
-            last_error
-                .map(|e| e.to_string())
-                .unwrap_or_else(|| "unknown error".to_string())
-        )
-    })?;
-
-    // Detect virtual packages
-    let virtual_packages = rattler_virtual_packages::VirtualPackage::detect(
-        &rattler_virtual_packages::VirtualPackageOverrides::default(),
-    )?
-    .iter()
-    .map(|vpkg| GenericVirtualPackage::from(vpkg.clone()))
-    .collect::<Vec<_>>();
-
-    // Get currently installed packages
-    let installed_packages = PrefixRecord::collect_from_prefix::<PrefixRecord>(&env.env_path)?;
-
-    // Solve dependencies
-    info!("Solving dependencies for sync...");
-    let solver_task = SolverTask {
-        virtual_packages,
-        specs,
-        locked_packages: installed_packages
-            .iter()
-            .map(|r| r.repodata_record.clone())
-            .collect(),
-        ..SolverTask::from_iter(&repo_data)
-    };
-
-    let solver_result = resolvo::Solver.solve(solver_task)?;
-    let required_packages = solver_result.records;
-
-    info!("Installing {} packages for sync", required_packages.len());
-
-    // Install to the existing prefix
-    let _result = Installer::new()
-        .with_download_client(download_client)
-        .with_target_platform(install_platform)
-        .with_installed_packages(installed_packages)
-        .install(&env.env_path, required_packages)
-        .await?;
-
-    info!("Conda dependencies synced successfully");
-    Ok(())
+/// Force remove a cached environment.
+#[allow(dead_code)]
+pub async fn remove_environment(env: &CondaEnvironment) -> Result<()> {
+    kernel_env::conda::remove_environment(env).await
 }
 
 /// Clear all cached conda environments.
 #[allow(dead_code)]
 pub async fn clear_cache() -> Result<()> {
-    let cache_dir = get_cache_dir();
-    if cache_dir.exists() {
-        tokio::fs::remove_dir_all(&cache_dir).await?;
-    }
-    Ok(())
-}
-
-// =============================================================================
-// Prewarming support
-// =============================================================================
-
-/// Create a prewarmed conda environment with just ipykernel installed.
-///
-/// This creates a generic environment at a temporary path (`prewarm-{uuid}`)
-/// that can later be claimed by a notebook using `claim_prewarmed_conda_environment`.
-/// The environment has no `env_id` in its hash, allowing it to be reused by any notebook.
-pub async fn create_prewarmed_conda_environment(
-    app: Option<&AppHandle>,
-) -> Result<CondaEnvironment> {
-    let temp_id = format!("prewarm-{}", uuid::Uuid::new_v4());
-    let cache_dir = get_cache_dir();
-    let env_path = cache_dir.join(&temp_id);
-
-    // Determine python path based on platform
-    #[cfg(target_os = "windows")]
-    let python_path = env_path.join("python.exe");
-    #[cfg(not(target_os = "windows"))]
-    let python_path = env_path.join("bin").join("python");
-
-    info!(
-        "[prewarm] Creating prewarmed conda environment at {:?}",
-        env_path
-    );
-
-    // Ensure cache directory exists
-    tokio::fs::create_dir_all(&cache_dir).await?;
-
-    // Build dependency list: ipykernel + ipywidgets + user-configured defaults
-    let mut deps_list = vec!["ipykernel".to_string(), "ipywidgets".to_string()];
-    let extra: Vec<String> = crate::settings::load_settings().conda.default_packages;
-    if !extra.is_empty() {
-        info!("[prewarm] Including default packages: {:?}", extra);
-        deps_list.extend(extra);
-    }
-    let deps = CondaDependencies {
-        dependencies: deps_list,
-        channels: vec!["conda-forge".to_string()],
-        python: None, // Use default Python version
-        env_id: None, // No env_id for prewarmed envs
-    };
-
-    // Reuse the core environment creation logic
-    create_environment_at_path(&env_path, &deps, app).await?;
-
-    info!(
-        "[prewarm] Prewarmed conda environment created at {:?}",
-        env_path
-    );
-
-    let env = CondaEnvironment {
-        env_path,
-        python_path,
-    };
-
-    // Warm up the environment by running Python to trigger .pyc compilation
-    warmup_conda_environment(&env).await?;
-
-    Ok(env)
-}
-
-/// Warm up a conda environment by running Python to trigger initialization.
-///
-/// This compiles .pyc files and runs first-time setup for ipykernel,
-/// dramatically reducing kernel startup time on subsequent use.
-pub async fn warmup_conda_environment(env: &CondaEnvironment) -> Result<()> {
-    let warmup_start = std::time::Instant::now();
-    info!(
-        "[prewarm] Warming up conda environment at {:?}",
-        env.env_path
-    );
-
-    // Script that imports key packages to trigger .pyc compilation
-    let warmup_script = r#"
-# Warmup script - triggers .pyc compilation and initialization
-import sys
-import ipykernel
-import IPython
-import ipywidgets
-import traitlets
-import zmq
-
-# Force ipykernel to initialize key components
-from ipykernel.kernelbase import Kernel
-from ipykernel.ipkernel import IPythonKernel
-
-# Import comm for widget support
-from ipykernel.comm import CommManager
-
-print("warmup complete")
-"#;
-
-    let output = tokio::process::Command::new(&env.python_path)
-        .args(["-c", warmup_script])
-        .output()
-        .await?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        warn!("[prewarm] Warmup failed for {:?}: {}", env.env_path, stderr);
-        // Don't fail the whole operation - environment is still usable
-        return Ok(());
-    }
-
-    // Create marker file to indicate this env has been warmed
-    let marker_path = env.env_path.join(".warmed");
-    tokio::fs::write(&marker_path, "").await.ok();
-
-    info!(
-        "[prewarm] Warmup complete for {:?} in {}ms",
-        env.env_path,
-        warmup_start.elapsed().as_millis()
-    );
-
-    Ok(())
-}
-
-/// Internal function to create a conda environment at a specific path.
-///
-/// This is the core rattler solve/install logic extracted for reuse.
-async fn create_environment_at_path(
-    env_path: &std::path::Path,
-    deps: &CondaDependencies,
-    app: Option<&AppHandle>,
-) -> Result<()> {
-    // Setup channel configuration
-    let cache_dir = get_cache_dir();
-    let channel_config = ChannelConfig::default_with_root_dir(cache_dir.clone());
-
-    // Parse channels (default to conda-forge if none specified)
-    let channels: Vec<Channel> = if deps.channels.is_empty() {
-        vec![Channel::from_str("conda-forge", &channel_config)?]
-    } else {
-        deps.channels
-            .iter()
-            .map(|c| Channel::from_str(c, &channel_config))
-            .collect::<Result<Vec<_>, _>>()?
-    };
-
-    emit_progress(
-        app,
-        EnvProgressPhase::FetchingRepodata {
-            channels: deps.channels.clone(),
-        },
-    );
-
-    // Build specs: base packages plus dependencies
-    let match_spec_options = ParseMatchSpecOptions::strict();
-    let mut specs: Vec<MatchSpec> = vec![
-        MatchSpec::from_str("ipykernel", match_spec_options)?,
-        MatchSpec::from_str("ipywidgets", match_spec_options)?,
-    ];
-
-    // Add python version constraint if specified
-    if let Some(ref py_version) = deps.python {
-        let py_spec = format!("python>={}", py_version);
-        specs.push(MatchSpec::from_str(&py_spec, match_spec_options)?);
-    }
-
-    // Add user dependencies
-    for dep in &deps.dependencies {
-        if dep != "ipykernel" && dep != "ipywidgets" {
-            specs.push(MatchSpec::from_str(dep, match_spec_options)?);
-        }
-    }
-
-    emit_progress(
-        app,
-        EnvProgressPhase::Solving {
-            spec_count: specs.len(),
-        },
-    );
-
-    // Find rattler cache directory
-    let rattler_cache_dir = default_cache_dir()
-        .map_err(|e| anyhow!("could not determine rattler cache directory: {}", e))?;
-
-    // Create HTTP client
-    let download_client = reqwest::Client::builder().build()?;
-    let download_client = reqwest_middleware::ClientBuilder::new(download_client).build();
-
-    // Create gateway for fetching repodata
-    let gateway = Gateway::builder()
-        .with_cache_dir(rattler_cache_dir.join(rattler_cache::REPODATA_CACHE_DIR))
-        .with_package_cache(PackageCache::new(
-            rattler_cache_dir.join(rattler_cache::PACKAGE_CACHE_DIR),
-        ))
-        .with_client(download_client.clone())
-        .finish();
-
-    // Query repodata with retry logic
-    let install_platform = Platform::current();
-    let platforms = vec![install_platform, Platform::NoArch];
-
-    let repodata_start = std::time::Instant::now();
-    const MAX_RETRIES: u32 = 3;
-    const INITIAL_DELAY_MS: u64 = 1000;
-
-    let mut last_error = None;
-    let mut repo_data = None;
-
-    for attempt in 0..MAX_RETRIES {
-        if attempt > 0 {
-            let delay_ms = INITIAL_DELAY_MS * (1 << (attempt - 1));
-            info!(
-                "Retrying repodata fetch (attempt {}/{}) after {}ms...",
-                attempt + 1,
-                MAX_RETRIES,
-                delay_ms
-            );
-            tokio::time::sleep(tokio::time::Duration::from_millis(delay_ms)).await;
-        }
-
-        match gateway
-            .query(channels.clone(), platforms.clone(), specs.clone())
-            .recursive(true)
-            .await
-        {
-            Ok(data) => {
-                repo_data = Some(data);
-                break;
-            }
-            Err(e) => {
-                let error_str = e.to_string();
-                let is_retryable = error_str.contains("500")
-                    || error_str.contains("502")
-                    || error_str.contains("503")
-                    || error_str.contains("504")
-                    || error_str.contains("timeout")
-                    || error_str.contains("connection");
-
-                if is_retryable && attempt < MAX_RETRIES - 1 {
-                    info!(
-                        "Transient error fetching repodata (attempt {}): {}",
-                        attempt + 1,
-                        error_str
-                    );
-                    last_error = Some(e);
-                    continue;
-                }
-                emit_progress(
-                    app,
-                    EnvProgressPhase::Error {
-                        message: format!("Failed to fetch package metadata: {}", e),
-                    },
-                );
-                return Err(anyhow!("Failed to fetch package metadata: {}", e));
-            }
-        }
-    }
-
-    let repo_data = repo_data.ok_or_else(|| {
-        let msg = format!(
-            "Failed to fetch package metadata after {} retries: {}",
-            MAX_RETRIES,
-            last_error
-                .map(|e| e.to_string())
-                .unwrap_or_else(|| "unknown error".to_string())
-        );
-        emit_progress(
-            app,
-            EnvProgressPhase::Error {
-                message: msg.clone(),
-            },
-        );
-        anyhow!(msg)
-    })?;
-
-    let repodata_elapsed = repodata_start.elapsed();
-    let record_count: usize = repo_data.iter().map(|r| r.len()).sum();
-    info!(
-        "Fetched repodata with {} records in {:?}",
-        record_count, repodata_elapsed
-    );
-    emit_progress(
-        app,
-        EnvProgressPhase::RepodataComplete {
-            record_count,
-            elapsed_ms: repodata_elapsed.as_millis() as u64,
-        },
-    );
-
-    // Detect virtual packages
-    let virtual_packages = rattler_virtual_packages::VirtualPackage::detect(
-        &rattler_virtual_packages::VirtualPackageOverrides::default(),
-    )?
-    .iter()
-    .map(|vpkg| GenericVirtualPackage::from(vpkg.clone()))
-    .collect::<Vec<_>>();
-
-    // Solve dependencies
-    let solve_start = std::time::Instant::now();
-    info!("Solving dependencies for {} specs", specs.len());
-
-    let solver_task = SolverTask {
-        virtual_packages,
-        specs,
-        ..SolverTask::from_iter(&repo_data)
-    };
-
-    let solver_result = match resolvo::Solver.solve(solver_task) {
-        Ok(result) => result,
-        Err(e) => {
-            let msg = format!("Failed to solve dependencies: {}", e);
-            emit_progress(
-                app,
-                EnvProgressPhase::Error {
-                    message: msg.clone(),
-                },
-            );
-            return Err(anyhow!(msg));
-        }
-    };
-
-    let required_packages = solver_result.records;
-    let solve_elapsed = solve_start.elapsed();
-    info!(
-        "Solved {} packages in {:?}",
-        required_packages.len(),
-        solve_elapsed
-    );
-    emit_progress(
-        app,
-        EnvProgressPhase::SolveComplete {
-            package_count: required_packages.len(),
-            elapsed_ms: solve_elapsed.as_millis() as u64,
-        },
-    );
-
-    // Install packages
-    let install_start = std::time::Instant::now();
-    info!(
-        "Installing {} packages to {:?}",
-        required_packages.len(),
-        env_path
-    );
-    emit_progress(
-        app,
-        EnvProgressPhase::Installing {
-            total: required_packages.len(),
-        },
-    );
-
-    // Create progress reporter if we have an app handle
-    let reporter = app.map(|a| ProgressReporter::new(Some(a.clone())));
-
-    let installer = Installer::new()
-        .with_download_client(download_client)
-        .with_target_platform(install_platform);
-
-    let _result = if let Some(reporter) = reporter {
-        installer
-            .with_reporter(reporter)
-            .install(env_path, required_packages)
-            .await?
-    } else {
-        installer.install(env_path, required_packages).await?
-    };
-
-    let install_elapsed = install_start.elapsed();
-    info!(
-        "Conda environment ready at {:?} (install took {:?})",
-        env_path, install_elapsed
-    );
-    emit_progress(
-        app,
-        EnvProgressPhase::InstallComplete {
-            elapsed_ms: install_elapsed.as_millis() as u64,
-        },
-    );
-
-    Ok(())
-}
-
-/// Claim a prewarmed conda environment for a specific notebook.
-///
-/// This moves the prewarmed environment to the correct cache location based
-/// on the notebook's `env_id`, so it will be found by `prepare_environment` later.
-pub async fn claim_prewarmed_conda_environment(
-    prewarmed: CondaEnvironment,
-    env_id: &str,
-) -> Result<CondaEnvironment> {
-    // Compute the hash that would be used for empty deps with this env_id
-    let deps = CondaDependencies {
-        dependencies: vec!["ipykernel".to_string()],
-        channels: vec!["conda-forge".to_string()],
-        python: None,
-        env_id: Some(env_id.to_string()),
-    };
-    let hash = compute_env_hash(&deps);
-    let cache_dir = get_cache_dir();
-    let dest_path = cache_dir.join(&hash);
-
-    // Determine python path based on platform
-    #[cfg(target_os = "windows")]
-    let python_path = dest_path.join("python.exe");
-    #[cfg(not(target_os = "windows"))]
-    let python_path = dest_path.join("bin").join("python");
-
-    // If destination already exists, just use it (race condition safety)
-    if dest_path.exists() {
-        info!(
-            "[prewarm] Destination already exists, removing prewarmed conda env at {:?}",
-            prewarmed.env_path
-        );
-        tokio::fs::remove_dir_all(&prewarmed.env_path).await.ok();
-        return Ok(CondaEnvironment {
-            env_path: dest_path,
-            python_path,
-        });
-    }
-
-    info!(
-        "[prewarm] Claiming prewarmed conda environment: {:?} -> {:?}",
-        prewarmed.env_path, dest_path
-    );
-
-    // Try to rename (fast if same filesystem)
-    match tokio::fs::rename(&prewarmed.env_path, &dest_path).await {
-        Ok(()) => {
-            info!("[prewarm] Conda environment claimed via rename");
-        }
-        Err(e) => {
-            // Rename failed (possibly cross-filesystem), fall back to copy+delete
-            info!("[prewarm] Rename failed ({}), falling back to copy", e);
-            copy_dir_recursive(&prewarmed.env_path, &dest_path).await?;
-            tokio::fs::remove_dir_all(&prewarmed.env_path).await.ok();
-            info!("[prewarm] Conda environment claimed via copy");
-        }
-    }
-
-    Ok(CondaEnvironment {
-        env_path: dest_path,
-        python_path,
-    })
-}
-
-/// Recursively copy a directory, preserving symlinks.
-async fn copy_dir_recursive(src: &std::path::Path, dst: &std::path::Path) -> Result<()> {
-    tokio::fs::create_dir_all(dst).await?;
-
-    let mut entries = tokio::fs::read_dir(src).await?;
-    while let Some(entry) = entries.next_entry().await? {
-        let ty = entry.file_type().await?;
-        let src_path = entry.path();
-        let dst_path = dst.join(entry.file_name());
-
-        if ty.is_dir() {
-            Box::pin(copy_dir_recursive(&src_path, &dst_path)).await?;
-        } else if ty.is_symlink() {
-            // Preserve symlinks (important for conda env bin/ structure)
-            #[cfg(unix)]
-            {
-                let link_target = tokio::fs::read_link(&src_path).await?;
-                tokio::fs::symlink(&link_target, &dst_path).await?;
-            }
-            #[cfg(windows)]
-            tokio::fs::copy(&src_path, &dst_path).await?;
-        } else {
-            tokio::fs::copy(&src_path, &dst_path).await?;
-        }
-    }
-
-    Ok(())
-}
-
-/// Find existing prewarmed conda environments from previous sessions.
-///
-/// Scans the cache directory for `prewarm-*` directories and validates
-/// they have a working Python binary. Returns valid environments that
-/// can be added to the pool on startup.
-pub async fn find_existing_prewarmed_conda_environments() -> Vec<CondaEnvironment> {
-    let cache_dir = get_cache_dir();
-    let mut found = Vec::new();
-
-    let Ok(mut entries) = tokio::fs::read_dir(&cache_dir).await else {
-        return found;
-    };
-
-    while let Ok(Some(entry)) = entries.next_entry().await {
-        let name = entry.file_name().to_string_lossy().to_string();
-        if !name.starts_with("prewarm-") {
-            continue;
-        }
-
-        let env_path = entry.path();
-
-        // Determine python path based on platform
-        #[cfg(target_os = "windows")]
-        let python_path = env_path.join("python.exe");
-        #[cfg(not(target_os = "windows"))]
-        let python_path = env_path.join("bin").join("python");
-
-        // Validate Python exists
-        if !python_path.exists() {
-            info!(
-                "[prewarm] Skipping invalid conda env (no python): {:?}",
-                env_path
-            );
-            // Clean up invalid environment
-            tokio::fs::remove_dir_all(&env_path).await.ok();
-            continue;
-        }
-
-        info!(
-            "[prewarm] Found existing prewarmed conda environment: {:?}",
-            env_path
-        );
-        found.push(CondaEnvironment {
-            env_path,
-            python_path,
-        });
-    }
-
-    found
-}
-
-/// Check if a conda environment has been warmed up.
-///
-/// Looks for a `.warmed` marker file in the environment directory.
-pub fn is_environment_warmed(env: &CondaEnvironment) -> bool {
-    env.env_path.join(".warmed").exists()
+    kernel_env::conda::clear_cache().await
 }
 
 #[cfg(test)]
@@ -1555,7 +230,6 @@ mod tests {
 
         let hash1 = compute_env_hash(&deps);
         let hash2 = compute_env_hash(&deps);
-
         assert_eq!(hash1, hash2);
     }
 
@@ -1632,7 +306,6 @@ mod tests {
             env_id: Some("notebook-2".to_string()),
         };
 
-        // Different env_ids should produce different hashes (isolated environments)
         assert_ne!(compute_env_hash(&deps1), compute_env_hash(&deps2));
     }
 }

--- a/crates/notebook/src/uv_env.rs
+++ b/crates/notebook/src/uv_env.rs
@@ -1,18 +1,20 @@
 //! UV-based environment management for notebook dependencies.
 //!
-//! This module handles creating ephemeral virtual environments using `uv`
-//! for notebooks that declare inline dependencies in their metadata.
-//! UV is auto-bootstrapped via rattler if not found on PATH.
+//! This module provides notebook-specific metadata operations (extract, set,
+//! remove dependencies from `nbformat::Metadata`) and delegates environment
+//! creation to `kernel_env::uv`.
 
-use crate::tools;
-use anyhow::{anyhow, Result};
-use log::info;
+use anyhow::Result;
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
-use std::path::PathBuf;
-use std::process::Stdio;
+use std::sync::Arc;
 
-/// Dependencies extracted from notebook metadata.
+// Re-export core types from kernel-env for backward compatibility
+pub use kernel_env::uv::UvEnvironment;
+
+/// Dependencies extracted from notebook metadata (uv format).
+///
+/// This is the notebook-side type that includes serde rename for
+/// `requires-python`. It converts to/from `kernel_env::UvDependencies`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NotebookDependencies {
     pub dependencies: Vec<String>,
@@ -20,17 +22,27 @@ pub struct NotebookDependencies {
     pub requires_python: Option<String>,
 }
 
-/// Result of environment preparation.
-#[derive(Debug)]
-pub struct UvEnvironment {
-    pub venv_path: PathBuf,
-    pub python_path: PathBuf,
+impl From<NotebookDependencies> for kernel_env::UvDependencies {
+    fn from(deps: NotebookDependencies) -> Self {
+        Self {
+            dependencies: deps.dependencies,
+            requires_python: deps.requires_python,
+        }
+    }
 }
 
-/// Check if uv is available (either on PATH or bootstrappable via rattler).
-pub async fn check_uv_available() -> bool {
-    tools::get_uv_path().await.is_ok()
+impl From<kernel_env::UvDependencies> for NotebookDependencies {
+    fn from(deps: kernel_env::UvDependencies) -> Self {
+        Self {
+            dependencies: deps.dependencies,
+            requires_python: deps.requires_python,
+        }
+    }
 }
+
+// =====================================================================
+// Metadata operations (notebook-specific, depend on nbformat)
+// =====================================================================
 
 /// Extract dependencies from notebook metadata.
 ///
@@ -51,15 +63,12 @@ pub fn extract_dependencies(metadata: &nbformat::v4::Metadata) -> Option<Noteboo
 }
 
 /// Set uv dependencies in notebook metadata (nested under runt).
-///
-/// Creates the `runt.uv` path if it doesn't exist.
 pub fn set_dependencies(metadata: &mut nbformat::v4::Metadata, deps: &NotebookDependencies) {
     let uv_value = serde_json::json!({
         "dependencies": deps.dependencies,
         "requires-python": deps.requires_python,
     });
 
-    // Get or create runt namespace
     let runt = metadata
         .additional
         .entry("runt".to_string())
@@ -72,586 +81,109 @@ pub fn set_dependencies(metadata: &mut nbformat::v4::Metadata, deps: &NotebookDe
 
 /// Check if notebook has uv config (in new or legacy format).
 pub fn has_uv_config(metadata: &nbformat::v4::Metadata) -> bool {
-    // Check new format
     if let Some(runt) = metadata.additional.get("runt") {
         if runt.get("uv").is_some() {
             return true;
         }
     }
-    // Check legacy format
     metadata.additional.contains_key("uv")
 }
 
 /// Remove uv config from metadata (both new and legacy paths).
 pub fn remove_uv_config(metadata: &mut nbformat::v4::Metadata) {
-    // Remove from new format
     if let Some(runt) = metadata.additional.get_mut("runt") {
         if let Some(runt_obj) = runt.as_object_mut() {
             runt_obj.remove("uv");
         }
     }
-    // Remove legacy format
     metadata.additional.remove("uv");
 }
 
 /// Extract the env_id from notebook metadata.
-///
-/// Looks for the `runt.env_id` field in the metadata's additional fields.
 pub fn extract_env_id(metadata: &nbformat::v4::Metadata) -> Option<String> {
     let runt_value = metadata.additional.get("runt")?;
     runt_value.get("env_id")?.as_str().map(|s| s.to_string())
 }
 
-/// Compute a cache key for the given dependencies.
-///
-/// When deps are empty and env_id is provided, includes env_id in hash
-/// for per-notebook isolation. This ensures new notebooks get fresh
-/// environments while notebooks with dependencies can share cached envs.
-fn compute_env_hash(deps: &NotebookDependencies, env_id: Option<&str>) -> String {
-    let mut hasher = Sha256::new();
+// =====================================================================
+// Environment operations (delegating to kernel-env)
+// =====================================================================
 
-    // Sort dependencies for consistent hashing
-    let mut sorted_deps = deps.dependencies.clone();
-    sorted_deps.sort();
-
-    // For empty deps, include env_id for per-notebook isolation
-    // This ensures new notebooks get their own environment
-    if sorted_deps.is_empty() {
-        if let Some(id) = env_id {
-            hasher.update(b"env_id:");
-            hasher.update(id.as_bytes());
-            hasher.update(b"\n");
-        }
-    }
-
-    for dep in &sorted_deps {
-        hasher.update(dep.as_bytes());
-        hasher.update(b"\n");
-    }
-
-    if let Some(ref py) = deps.requires_python {
-        hasher.update(b"requires-python:");
-        hasher.update(py.as_bytes());
-    }
-
-    let hash = hasher.finalize();
-    format!("{:x}", hash)[..16].to_string()
+/// Check if uv is available (either on PATH or bootstrappable via rattler).
+pub async fn check_uv_available() -> bool {
+    kernel_env::uv::check_uv_available().await
 }
 
-/// Get the cache directory for runt environments.
-fn get_cache_dir() -> PathBuf {
-    dirs::cache_dir()
-        .unwrap_or_else(|| PathBuf::from("/tmp"))
-        .join("runt")
-        .join("envs")
+/// Compute a cache key for the given dependencies.
+pub fn compute_env_hash(deps: &NotebookDependencies, env_id: Option<&str>) -> String {
+    kernel_env::uv::compute_env_hash(&deps.clone().into(), env_id)
 }
 
 /// Prepare a virtual environment with the given dependencies.
-///
-/// Uses cached environments when possible (keyed by dependency hash).
-/// If the cache doesn't exist or is invalid, creates a new environment.
-///
-/// The `env_id` parameter enables per-notebook isolation for empty deps:
-/// - If deps are empty and env_id is provided, the env is unique to that notebook
-/// - If deps are non-empty, env_id is ignored and envs are shared by dep hash
 pub async fn prepare_environment(
     deps: &NotebookDependencies,
     env_id: Option<&str>,
 ) -> Result<UvEnvironment> {
-    let hash = compute_env_hash(deps, env_id);
-    let cache_dir = get_cache_dir();
-    let venv_path = cache_dir.join(&hash);
-
-    // Determine python path based on platform
-    #[cfg(target_os = "windows")]
-    let python_path = venv_path.join("Scripts").join("python.exe");
-    #[cfg(not(target_os = "windows"))]
-    let python_path = venv_path.join("bin").join("python");
-
-    // Check if cached environment exists and is valid
-    if venv_path.exists() && python_path.exists() {
-        info!("Using cached environment at {:?}", venv_path);
-        return Ok(UvEnvironment {
-            venv_path,
-            python_path,
-        });
-    }
-
-    info!("Creating new environment at {:?}", venv_path);
-
-    // Get uv path (from PATH or bootstrapped via rattler)
-    let uv_path = tools::get_uv_path().await?;
-
-    // Ensure cache directory exists
-    tokio::fs::create_dir_all(&cache_dir).await?;
-
-    // Remove partial/invalid environment if it exists
-    if venv_path.exists() {
-        tokio::fs::remove_dir_all(&venv_path).await?;
-    }
-
-    // Create virtual environment with uv
-    let mut venv_cmd = tokio::process::Command::new(&uv_path);
-    venv_cmd.arg("venv").arg(&venv_path);
-
-    // Add python version constraint if specified
-    if let Some(ref py_version) = deps.requires_python {
-        // Extract version number from constraint like ">=3.10" -> "3.10"
-        let version = py_version
-            .trim_start_matches(|c: char| !c.is_ascii_digit())
-            .to_string();
-        if !version.is_empty() {
-            venv_cmd.arg("--python").arg(&version);
-        }
-    }
-
-    let venv_status = venv_cmd
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .status()
-        .await?;
-
-    if !venv_status.success() {
-        return Err(anyhow!("Failed to create virtual environment"));
-    }
-
-    // Install ipykernel, ipywidgets, and dependencies
-    let mut install_args = vec![
-        "pip".to_string(),
-        "install".to_string(),
-        "--python".to_string(),
-        python_path.to_string_lossy().to_string(),
-        "ipykernel".to_string(),
-        "ipywidgets".to_string(),
-    ];
-
-    for dep in &deps.dependencies {
-        install_args.push(dep.clone());
-    }
-
-    let install_status = tokio::process::Command::new(&uv_path)
-        .args(&install_args)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .status()
-        .await?;
-
-    if !install_status.success() {
-        // Clean up failed environment
-        tokio::fs::remove_dir_all(&venv_path).await.ok();
-        return Err(anyhow!("Failed to install dependencies"));
-    }
-
-    info!("Environment ready at {:?}", venv_path);
-
-    Ok(UvEnvironment {
-        venv_path,
-        python_path,
-    })
+    let handler: Arc<dyn kernel_env::ProgressHandler> = Arc::new(kernel_env::LogHandler);
+    kernel_env::uv::prepare_environment(&deps.clone().into(), env_id, handler).await
 }
 
-/// Clean up an ephemeral environment.
-///
-/// Note: We don't actually remove cached environments since they can be reused.
-/// This is called on kernel shutdown but only cleans up if needed.
-pub async fn cleanup_environment(_env: &UvEnvironment) -> Result<()> {
-    // For now, we keep cached environments for reuse.
-    // Could add LRU eviction or size-based cleanup later.
-    Ok(())
+/// Create a prewarmed environment with ipykernel, ipywidgets, and
+/// user-configured default packages.
+pub async fn create_prewarmed_environment() -> Result<UvEnvironment> {
+    let extra: Vec<String> = crate::settings::load_settings().uv.default_packages;
+    let handler: Arc<dyn kernel_env::ProgressHandler> = Arc::new(kernel_env::LogHandler);
+    kernel_env::uv::create_prewarmed_environment(&extra, handler).await
 }
 
-/// Force remove a cached environment (for manual cleanup).
-#[allow(dead_code)]
-pub async fn remove_environment(env: &UvEnvironment) -> Result<()> {
-    if env.venv_path.exists() {
-        tokio::fs::remove_dir_all(&env.venv_path).await?;
-    }
-    Ok(())
+/// Claim a prewarmed environment for a specific notebook.
+pub async fn claim_prewarmed_environment(
+    prewarmed: UvEnvironment,
+    env_id: &str,
+) -> Result<UvEnvironment> {
+    kernel_env::uv::claim_prewarmed_environment(prewarmed, env_id).await
+}
+
+/// Find existing prewarmed environments from previous sessions.
+pub async fn find_existing_prewarmed_environments() -> Vec<UvEnvironment> {
+    kernel_env::uv::find_existing_prewarmed_environments().await
+}
+
+/// Warm up a UV environment by running Python to trigger .pyc compilation.
+pub async fn warmup_uv_environment(env: &UvEnvironment) -> Result<()> {
+    kernel_env::uv::warmup_environment(env).await
+}
+
+/// Check if a UV environment has been warmed up.
+pub fn is_environment_warmed(env: &UvEnvironment) -> bool {
+    kernel_env::uv::is_environment_warmed(env)
+}
+
+/// Copy an existing UV environment to a new location.
+pub async fn copy_environment(source: &UvEnvironment, new_env_id: &str) -> Result<UvEnvironment> {
+    kernel_env::uv::copy_environment(source, new_env_id).await
 }
 
 /// Install additional dependencies into an existing environment.
-///
-/// This is used to sync new dependencies when the kernel is already running.
-/// UV is auto-bootstrapped via rattler if not found on PATH.
 pub async fn sync_dependencies(env: &UvEnvironment, deps: &[String]) -> Result<()> {
-    if deps.is_empty() {
-        return Ok(());
-    }
-
-    info!("Syncing {} dependencies to {:?}", deps.len(), env.venv_path);
-
-    // Get uv path (from PATH or bootstrapped via rattler)
-    let uv_path = tools::get_uv_path().await?;
-
-    let mut install_args = vec![
-        "pip".to_string(),
-        "install".to_string(),
-        "--python".to_string(),
-        env.python_path.to_string_lossy().to_string(),
-    ];
-
-    for dep in deps {
-        install_args.push(dep.clone());
-    }
-
-    let output = tokio::process::Command::new(&uv_path)
-        .args(&install_args)
-        .output()
-        .await?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(anyhow!("Failed to sync dependencies: {}", stderr));
-    }
-
-    info!("Dependencies synced successfully");
-    Ok(())
+    kernel_env::uv::sync_dependencies(env, deps).await
 }
 
-/// Copy an existing UV environment to a new location for a cloned notebook.
-///
-/// This allows cloned notebooks to start with the source's environment
-/// already prepared, making kernel startup instant.
-pub async fn copy_environment(source: &UvEnvironment, new_env_id: &str) -> Result<UvEnvironment> {
-    let cache_dir = get_cache_dir();
-    let dest_path = cache_dir.join(new_env_id);
-
-    if dest_path.exists() {
-        // Already copied (shouldn't happen with UUIDs, but be safe)
-        info!("Clone environment already exists at {:?}", dest_path);
-        #[cfg(target_os = "windows")]
-        let python_path = dest_path.join("Scripts").join("python.exe");
-        #[cfg(not(target_os = "windows"))]
-        let python_path = dest_path.join("bin").join("python");
-
-        return Ok(UvEnvironment {
-            venv_path: dest_path,
-            python_path,
-        });
-    }
-
-    info!(
-        "Copying environment from {:?} to {:?}",
-        source.venv_path, dest_path
-    );
-
-    // Copy the entire venv directory
-    copy_dir_recursive(&source.venv_path, &dest_path).await?;
-
-    #[cfg(target_os = "windows")]
-    let python_path = dest_path.join("Scripts").join("python.exe");
-    #[cfg(not(target_os = "windows"))]
-    let python_path = dest_path.join("bin").join("python");
-
-    info!("Environment copied successfully");
-
-    Ok(UvEnvironment {
-        venv_path: dest_path,
-        python_path,
-    })
+/// No-op cleanup (cached environments are kept for reuse).
+pub async fn cleanup_environment(env: &UvEnvironment) -> Result<()> {
+    kernel_env::uv::cleanup_environment(env).await
 }
 
-/// Recursively copy a directory.
-async fn copy_dir_recursive(src: &std::path::Path, dst: &std::path::Path) -> Result<()> {
-    tokio::fs::create_dir_all(dst).await?;
-    let mut entries = tokio::fs::read_dir(src).await?;
-
-    while let Some(entry) = entries.next_entry().await? {
-        let ty = entry.file_type().await?;
-        let src_path = entry.path();
-        let dst_path = dst.join(entry.file_name());
-
-        if ty.is_dir() {
-            Box::pin(copy_dir_recursive(&src_path, &dst_path)).await?;
-        } else if ty.is_symlink() {
-            // Preserve symlinks (important for venv structure)
-            // On Unix, use symlink. On Windows, copy the file.
-            #[cfg(unix)]
-            {
-                let link_target = tokio::fs::read_link(&src_path).await?;
-                tokio::fs::symlink(&link_target, &dst_path).await?;
-            }
-            #[cfg(windows)]
-            tokio::fs::copy(&src_path, &dst_path).await?;
-        } else {
-            tokio::fs::copy(&src_path, &dst_path).await?;
-        }
-    }
-
-    Ok(())
+/// Force remove a cached environment.
+#[allow(dead_code)]
+pub async fn remove_environment(env: &UvEnvironment) -> Result<()> {
+    kernel_env::uv::remove_environment(env).await
 }
 
 /// Clear all cached environments.
 #[allow(dead_code)]
 pub async fn clear_cache() -> Result<()> {
-    let cache_dir = get_cache_dir();
-    if cache_dir.exists() {
-        tokio::fs::remove_dir_all(&cache_dir).await?;
-    }
-    Ok(())
-}
-
-/// Find existing prewarmed environments from previous sessions.
-///
-/// Scans the cache directory for `prewarm-*` directories and validates
-/// they have a working Python binary. Returns valid environments that
-/// can be added to the pool on startup.
-pub async fn find_existing_prewarmed_environments() -> Vec<UvEnvironment> {
-    let cache_dir = get_cache_dir();
-    let mut found = Vec::new();
-
-    let Ok(mut entries) = tokio::fs::read_dir(&cache_dir).await else {
-        return found;
-    };
-
-    while let Ok(Some(entry)) = entries.next_entry().await {
-        let name = entry.file_name().to_string_lossy().to_string();
-        if !name.starts_with("prewarm-") {
-            continue;
-        }
-
-        let venv_path = entry.path();
-
-        // Determine python path based on platform
-        #[cfg(target_os = "windows")]
-        let python_path = venv_path.join("Scripts").join("python.exe");
-        #[cfg(not(target_os = "windows"))]
-        let python_path = venv_path.join("bin").join("python");
-
-        // Validate the python binary exists
-        if !python_path.exists() {
-            info!(
-                "[prewarm] Removing invalid prewarmed env (no python): {:?}",
-                venv_path
-            );
-            tokio::fs::remove_dir_all(&venv_path).await.ok();
-            continue;
-        }
-
-        info!(
-            "[prewarm] Found existing prewarmed environment: {:?}",
-            venv_path
-        );
-        found.push(UvEnvironment {
-            venv_path,
-            python_path,
-        });
-    }
-
-    found
-}
-
-/// Read the `default_uv_packages` setting.
-fn parse_extra_packages() -> Vec<String> {
-    crate::settings::load_settings().uv.default_packages
-}
-
-/// Create a prewarmed environment with ipykernel, ipywidgets, and any
-/// user-configured default packages installed.
-///
-/// This creates an environment at a temporary path (prewarm-{uuid}) that can
-/// later be claimed by a notebook using `claim_prewarmed_environment`.
-/// UV is auto-bootstrapped via rattler if not found on PATH.
-pub async fn create_prewarmed_environment() -> Result<UvEnvironment> {
-    let temp_id = format!("prewarm-{}", uuid::Uuid::new_v4());
-    let cache_dir = get_cache_dir();
-    let venv_path = cache_dir.join(&temp_id);
-
-    // Determine python path based on platform
-    #[cfg(target_os = "windows")]
-    let python_path = venv_path.join("Scripts").join("python.exe");
-    #[cfg(not(target_os = "windows"))]
-    let python_path = venv_path.join("bin").join("python");
-
-    info!(
-        "[prewarm] Creating prewarmed environment at {:?}",
-        venv_path
-    );
-
-    // Get uv path (from PATH or bootstrapped via rattler)
-    let uv_path = tools::get_uv_path().await?;
-
-    // Ensure cache directory exists
-    tokio::fs::create_dir_all(&cache_dir).await?;
-
-    // Create virtual environment with uv
-    let venv_status = tokio::process::Command::new(&uv_path)
-        .arg("venv")
-        .arg(&venv_path)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .status()
-        .await?;
-
-    if !venv_status.success() {
-        return Err(anyhow!("Failed to create prewarmed virtual environment"));
-    }
-
-    // Install ipykernel, ipywidgets, and any user-configured default packages
-    let extra = parse_extra_packages();
-    let mut install_args = vec![
-        "pip".to_string(),
-        "install".to_string(),
-        "--python".to_string(),
-        python_path.to_string_lossy().to_string(),
-        "ipykernel".to_string(),
-        "ipywidgets".to_string(),
-    ];
-    if !extra.is_empty() {
-        info!("[prewarm] Including default packages: {:?}", extra);
-        install_args.extend(extra);
-    }
-    let install_status = tokio::process::Command::new(&uv_path)
-        .args(&install_args)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .status()
-        .await?;
-
-    if !install_status.success() {
-        // Clean up failed environment
-        tokio::fs::remove_dir_all(&venv_path).await.ok();
-        return Err(anyhow!(
-            "Failed to install ipykernel in prewarmed environment"
-        ));
-    }
-
-    info!("[prewarm] Prewarmed environment ready at {:?}", venv_path);
-
-    let env = UvEnvironment {
-        venv_path,
-        python_path,
-    };
-
-    // Warm up the environment by running Python to trigger .pyc compilation
-    warmup_uv_environment(&env).await?;
-
-    Ok(env)
-}
-
-/// Claim a prewarmed environment for a specific notebook.
-///
-/// This moves the prewarmed environment to the correct cache location based
-/// on the notebook's env_id, so it will be found by `prepare_environment`.
-pub async fn claim_prewarmed_environment(
-    prewarmed: UvEnvironment,
-    env_id: &str,
-) -> Result<UvEnvironment> {
-    // Compute the hash that would be used for empty deps with this env_id
-    let deps = NotebookDependencies {
-        dependencies: vec![],
-        requires_python: None,
-    };
-    let hash = compute_env_hash(&deps, Some(env_id));
-    let cache_dir = get_cache_dir();
-    let dest_path = cache_dir.join(&hash);
-
-    // Determine python path based on platform
-    #[cfg(target_os = "windows")]
-    let python_path = dest_path.join("Scripts").join("python.exe");
-    #[cfg(not(target_os = "windows"))]
-    let python_path = dest_path.join("bin").join("python");
-
-    // If destination already exists, just use it (race condition safety)
-    if dest_path.exists() {
-        info!(
-            "[prewarm] Destination already exists, removing prewarmed env at {:?}",
-            prewarmed.venv_path
-        );
-        tokio::fs::remove_dir_all(&prewarmed.venv_path).await.ok();
-        return Ok(UvEnvironment {
-            venv_path: dest_path,
-            python_path,
-        });
-    }
-
-    info!(
-        "[prewarm] Claiming prewarmed environment: {:?} -> {:?}",
-        prewarmed.venv_path, dest_path
-    );
-
-    // Try to rename (fast if same filesystem)
-    match tokio::fs::rename(&prewarmed.venv_path, &dest_path).await {
-        Ok(()) => {
-            info!("[prewarm] Environment claimed via rename");
-        }
-        Err(e) => {
-            // Rename failed (possibly cross-filesystem), fall back to copy+delete
-            info!("[prewarm] Rename failed ({}), falling back to copy", e);
-            copy_dir_recursive(&prewarmed.venv_path, &dest_path).await?;
-            tokio::fs::remove_dir_all(&prewarmed.venv_path).await.ok();
-            info!("[prewarm] Environment claimed via copy");
-        }
-    }
-
-    Ok(UvEnvironment {
-        venv_path: dest_path,
-        python_path,
-    })
-}
-
-/// Warm up a UV environment by running Python to trigger initialization.
-///
-/// This compiles .pyc files and runs first-time setup for ipykernel,
-/// dramatically reducing kernel startup time on subsequent use.
-pub async fn warmup_uv_environment(env: &UvEnvironment) -> Result<()> {
-    let warmup_start = std::time::Instant::now();
-    info!("[prewarm] Warming up UV environment at {:?}", env.venv_path);
-
-    // Script that imports key packages to trigger .pyc compilation
-    let warmup_script = r#"
-# Warmup script - triggers .pyc compilation and initialization
-import sys
-import ipykernel
-import IPython
-import ipywidgets
-import traitlets
-import zmq
-
-# Force ipykernel to initialize key components
-from ipykernel.kernelbase import Kernel
-from ipykernel.ipkernel import IPythonKernel
-
-# Import comm for widget support
-from ipykernel.comm import CommManager
-
-print("warmup complete")
-"#;
-
-    let output = tokio::process::Command::new(&env.python_path)
-        .args(["-c", warmup_script])
-        .output()
-        .await?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        log::warn!(
-            "[prewarm] UV warmup failed for {:?}: {}",
-            env.venv_path,
-            stderr
-        );
-        // Don't fail the whole operation - environment is still usable
-        return Ok(());
-    }
-
-    // Create marker file to indicate this env has been warmed
-    let marker_path = env.venv_path.join(".warmed");
-    tokio::fs::write(&marker_path, "").await.ok();
-
-    info!(
-        "[prewarm] UV warmup complete for {:?} in {}ms",
-        env.venv_path,
-        warmup_start.elapsed().as_millis()
-    );
-
-    Ok(())
-}
-
-/// Check if a UV environment has been warmed up.
-///
-/// Looks for a `.warmed` marker file in the environment directory.
-pub fn is_environment_warmed(env: &UvEnvironment) -> bool {
-    env.venv_path.join(".warmed").exists()
+    kernel_env::uv::clear_cache().await
 }
 
 #[cfg(test)]
@@ -667,7 +199,6 @@ mod tests {
 
         let hash1 = compute_env_hash(&deps, None);
         let hash2 = compute_env_hash(&deps, None);
-
         assert_eq!(hash1, hash2);
     }
 

--- a/crates/runtimed/Cargo.toml
+++ b/crates/runtimed/Cargo.toml
@@ -68,6 +68,9 @@ runt-trust = { path = "../runt-trust" }
 # Shared kernel launching and tool bootstrapping
 kernel-launch = { path = "../kernel-launch" }
 
+# Shared environment management (UV + Conda) with progress reporting
+kernel-env = { path = "../kernel-env" }
+
 # JSON Schema generation
 schemars = { workspace = true }
 

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -1033,6 +1033,11 @@ impl Daemon {
         env
     }
 
+    /// Get the user's default Python environment preference.
+    pub async fn default_python_env(&self) -> crate::settings_doc::PythonEnvType {
+        self.settings.read().await.get_all().default_python_env
+    }
+
     /// Handle a single request.
     async fn handle_request(self: Arc<Self>, request: Request) -> Response {
         match request {

--- a/crates/runtimed/src/inline_env.rs
+++ b/crates/runtimed/src/inline_env.rs
@@ -1,341 +1,112 @@
 //! Cached environment creation for inline dependencies.
 //!
-//! Creates and caches environments for notebooks with inline UV or Conda dependencies.
-//! Environments are cached by dependency hash for fast reuse.
+//! Delegates to `kernel_env` for the actual environment creation while
+//! providing a [`BroadcastProgressHandler`] that forwards progress events
+//! to connected notebook clients via the broadcast channel.
 
-use anyhow::{anyhow, Result};
-use log::info;
-use sha2::{Digest, Sha256};
-use std::path::PathBuf;
-use std::process::Stdio;
+use std::sync::Arc;
+
+use anyhow::Result;
+use kernel_env::progress::{EnvProgressPhase, ProgressHandler};
+use tokio::sync::broadcast;
+
+use crate::protocol::NotebookBroadcast;
+
+// Re-export the PreparedEnv-equivalent types for callers that still
+// use the old `inline_env::PreparedEnv` pattern.
+pub use kernel_env::conda::CondaEnvironment;
+pub use kernel_env::uv::UvEnvironment;
 
 /// Result of preparing an environment with inline deps.
 #[derive(Debug, Clone)]
 pub struct PreparedEnv {
-    pub env_path: PathBuf,
-    pub python_path: PathBuf,
+    pub env_path: std::path::PathBuf,
+    pub python_path: std::path::PathBuf,
+}
+
+/// Progress handler that broadcasts [`EnvProgressPhase`] events to all
+/// connected notebook clients via a [`broadcast::Sender`].
+pub struct BroadcastProgressHandler {
+    tx: broadcast::Sender<NotebookBroadcast>,
+}
+
+impl BroadcastProgressHandler {
+    pub fn new(tx: broadcast::Sender<NotebookBroadcast>) -> Self {
+        Self { tx }
+    }
+}
+
+impl ProgressHandler for BroadcastProgressHandler {
+    fn on_progress(&self, env_type: &str, phase: EnvProgressPhase) {
+        // Log all phases
+        kernel_env::LogHandler.on_progress(env_type, phase.clone());
+
+        // Broadcast to connected clients
+        let _ = self.tx.send(NotebookBroadcast::EnvProgress {
+            env_type: env_type.to_string(),
+            phase,
+        });
+    }
 }
 
 /// Get the cache directory for inline dependency environments.
-fn get_inline_cache_dir() -> PathBuf {
+fn get_inline_cache_dir() -> std::path::PathBuf {
     dirs::cache_dir()
-        .unwrap_or_else(|| PathBuf::from("/tmp"))
+        .unwrap_or_else(|| std::path::PathBuf::from("/tmp"))
         .join("runt")
         .join("inline-envs")
 }
 
-/// Compute a stable hash for the given dependencies.
-fn compute_deps_hash(deps: &[String]) -> String {
-    let mut hasher = Sha256::new();
-
-    // Sort dependencies for consistent hashing
-    let mut sorted_deps = deps.to_vec();
-    sorted_deps.sort();
-
-    for dep in &sorted_deps {
-        hasher.update(dep.as_bytes());
-        hasher.update(b"\n");
-    }
-
-    let result = hasher.finalize();
-    format!("inline-{}", hex::encode(&result[..8]))
-}
-
 /// Prepare a cached UV environment with the given inline dependencies.
 ///
-/// If a cached environment with the same deps already exists, returns it immediately.
-/// Otherwise creates a new environment with uv venv + uv pip install.
-pub async fn prepare_uv_inline_env(deps: &[String]) -> Result<PreparedEnv> {
-    let hash = compute_deps_hash(deps);
-    let cache_dir = get_inline_cache_dir();
-    let env_path = cache_dir.join(&hash);
+/// If a cached environment with the same deps already exists, returns it
+/// immediately. Otherwise creates a new environment with uv venv + uv pip install.
+pub async fn prepare_uv_inline_env(
+    deps: &[String],
+    handler: Arc<dyn ProgressHandler>,
+) -> Result<PreparedEnv> {
+    let uv_deps = kernel_env::UvDependencies {
+        dependencies: deps.to_vec(),
+        requires_python: None,
+    };
 
-    // Determine python path based on platform
-    #[cfg(target_os = "windows")]
-    let python_path = env_path.join("Scripts").join("python.exe");
-    #[cfg(not(target_os = "windows"))]
-    let python_path = env_path.join("bin").join("python");
-
-    // Check if cached environment exists and is valid
-    if env_path.exists() && python_path.exists() {
-        info!(
-            "[inline-env] Cache hit for UV inline deps {:?} at {:?}",
-            deps, env_path
-        );
-        return Ok(PreparedEnv {
-            env_path,
-            python_path,
-        });
-    }
-
-    info!(
-        "[inline-env] Creating new UV env for deps {:?} at {:?}",
-        deps, env_path
-    );
-
-    // Get uv path
-    let uv_path = kernel_launch::tools::get_uv_path().await?;
-
-    // Ensure cache directory exists
-    tokio::fs::create_dir_all(&cache_dir).await?;
-
-    // Remove partial/invalid environment if it exists
-    if env_path.exists() {
-        tokio::fs::remove_dir_all(&env_path).await?;
-    }
-
-    // Create virtual environment with uv
-    let venv_output = tokio::process::Command::new(&uv_path)
-        .args(["venv", &env_path.to_string_lossy()])
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .output()
-        .await?;
-
-    if !venv_output.status.success() {
-        let stderr = String::from_utf8_lossy(&venv_output.stderr);
-        return Err(anyhow!("Failed to create virtual environment: {}", stderr));
-    }
-
-    // Install ipykernel + dependencies
-    let mut install_args = vec![
-        "pip".to_string(),
-        "install".to_string(),
-        "--python".to_string(),
-        python_path.to_string_lossy().to_string(),
-        "ipykernel".to_string(),
-    ];
-
-    for dep in deps {
-        install_args.push(dep.clone());
-    }
-
-    info!("[inline-env] Installing: {:?}", install_args);
-
-    let install_output = tokio::process::Command::new(&uv_path)
-        .args(&install_args)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .output()
-        .await?;
-
-    if !install_output.status.success() {
-        // Clean up failed environment
-        tokio::fs::remove_dir_all(&env_path).await.ok();
-        let stderr = String::from_utf8_lossy(&install_output.stderr);
-        return Err(anyhow!("Failed to install dependencies: {}", stderr));
-    }
-
-    info!("[inline-env] UV environment ready at {:?}", env_path);
+    let env =
+        kernel_env::uv::prepare_environment_in(&uv_deps, None, &get_inline_cache_dir(), handler)
+            .await?;
 
     Ok(PreparedEnv {
-        env_path,
-        python_path,
+        env_path: env.venv_path,
+        python_path: env.python_path,
     })
-}
-
-/// Compute a stable hash for conda dependencies + channels.
-///
-/// Includes channels in the hash because the same package name from different
-/// channels can yield different packages.
-fn compute_conda_deps_hash(deps: &[String], channels: &[String]) -> String {
-    let mut hasher = Sha256::new();
-
-    // Hash channels first (sorted for stability)
-    let mut sorted_channels = channels.to_vec();
-    sorted_channels.sort();
-    for ch in &sorted_channels {
-        hasher.update(b"channel:");
-        hasher.update(ch.as_bytes());
-        hasher.update(b"\n");
-    }
-
-    // Then hash deps (sorted for stability)
-    let mut sorted_deps = deps.to_vec();
-    sorted_deps.sort();
-    for dep in &sorted_deps {
-        hasher.update(dep.as_bytes());
-        hasher.update(b"\n");
-    }
-
-    let result = hasher.finalize();
-    format!("conda-inline-{}", hex::encode(&result[..8]))
 }
 
 /// Prepare a cached Conda environment with the given inline dependencies.
 ///
-/// If a cached environment with the same deps+channels already exists, returns it
-/// immediately. Otherwise creates a new environment using rattler (solve + install).
-///
-/// This mirrors the pattern in `daemon.rs::create_conda_env` but for inline deps
-/// instead of the prewarmed pool.
-pub async fn prepare_conda_inline_env(deps: &[String], channels: &[String]) -> Result<PreparedEnv> {
-    use rattler::{default_cache_dir, install::Installer, package_cache::PackageCache};
-    use rattler_conda_types::{
-        Channel, ChannelConfig, GenericVirtualPackage, MatchSpec, ParseMatchSpecOptions, Platform,
-    };
-    use rattler_repodata_gateway::Gateway;
-    use rattler_solve::{resolvo, SolverImpl, SolverTask};
-
-    let hash = compute_conda_deps_hash(deps, channels);
-    let cache_dir = get_inline_cache_dir();
-    let env_path = cache_dir.join(&hash);
-
-    // Determine python path based on platform
-    #[cfg(target_os = "windows")]
-    let python_path = env_path.join("python.exe");
-    #[cfg(not(target_os = "windows"))]
-    let python_path = env_path.join("bin").join("python");
-
-    // Check if cached environment exists and is valid
-    if env_path.exists() && python_path.exists() {
-        info!(
-            "[inline-env] Cache hit for Conda inline deps {:?} at {:?}",
-            deps, env_path
-        );
-        return Ok(PreparedEnv {
-            env_path,
-            python_path,
-        });
-    }
-
-    info!(
-        "[inline-env] Creating new Conda env for deps {:?} (channels: {:?}) at {:?}",
-        deps, channels, env_path
-    );
-
-    // Ensure cache directory exists
-    tokio::fs::create_dir_all(&cache_dir).await?;
-
-    // Remove partial/invalid environment if it exists
-    if env_path.exists() {
-        tokio::fs::remove_dir_all(&env_path).await?;
-    }
-
-    // Setup channel configuration
-    let channel_config = ChannelConfig::default_with_root_dir(cache_dir.clone());
-
-    // Parse channels (default to conda-forge if none specified)
-    let channel_names = if channels.is_empty() {
-        vec!["conda-forge".to_string()]
-    } else {
-        channels.to_vec()
-    };
-    let parsed_channels: Vec<Channel> = channel_names
-        .iter()
-        .map(|ch| Channel::from_str(ch, &channel_config))
-        .collect::<std::result::Result<Vec<_>, _>>()
-        .map_err(|e| anyhow!("Failed to parse conda channel: {}", e))?;
-
-    // Build specs: python + ipykernel + user deps
-    let match_spec_options = ParseMatchSpecOptions::strict();
-    let mut specs = vec![
-        MatchSpec::from_str("python>=3.9", match_spec_options)
-            .map_err(|e| anyhow!("Failed to parse python spec: {}", e))?,
-        MatchSpec::from_str("ipykernel", match_spec_options)
-            .map_err(|e| anyhow!("Failed to parse ipykernel spec: {}", e))?,
-    ];
-    for dep in deps {
-        specs.push(
-            MatchSpec::from_str(dep, match_spec_options)
-                .map_err(|e| anyhow!("Failed to parse dep '{}': {}", dep, e))?,
-        );
-    }
-
-    // Find rattler cache directory
-    let rattler_cache_dir =
-        default_cache_dir().map_err(|e| anyhow!("Could not determine rattler cache dir: {}", e))?;
-    rattler_cache::ensure_cache_dir(&rattler_cache_dir)
-        .map_err(|e| anyhow!("Could not create rattler cache dir: {}", e))?;
-
-    // Create HTTP client
-    let download_client = reqwest_middleware::ClientBuilder::new(
-        reqwest::Client::builder()
-            .build()
-            .map_err(|e| anyhow!("Failed to create HTTP client: {}", e))?,
-    )
-    .build();
-
-    // Create gateway for fetching repodata
-    let gateway = Gateway::builder()
-        .with_cache_dir(rattler_cache_dir.join(rattler_cache::REPODATA_CACHE_DIR))
-        .with_package_cache(PackageCache::new(
-            rattler_cache_dir.join(rattler_cache::PACKAGE_CACHE_DIR),
-        ))
-        .with_client(download_client.clone())
-        .finish();
-
-    // Query repodata
-    let install_platform = Platform::current();
-    let platforms = vec![install_platform, Platform::NoArch];
-
-    info!("[inline-env] Fetching conda repodata for inline deps...");
-    let repo_data = gateway
-        .query(parsed_channels, platforms, specs.clone())
-        .recursive(true)
-        .await
-        .map_err(|e| anyhow!("Failed to fetch conda repodata: {}", e))?;
-
-    info!("[inline-env] Solving conda dependencies...");
-
-    // Detect virtual packages
-    let virtual_packages = rattler_virtual_packages::VirtualPackage::detect(
-        &rattler_virtual_packages::VirtualPackageOverrides::default(),
-    )
-    .map_err(|e| anyhow!("Failed to detect virtual packages: {}", e))?
-    .iter()
-    .map(|vpkg| GenericVirtualPackage::from(vpkg.clone()))
-    .collect::<Vec<_>>();
-
-    // Solve dependencies
-    let solver_task = SolverTask {
-        virtual_packages,
-        specs,
-        ..SolverTask::from_iter(&repo_data)
+/// If a cached environment with the same deps+channels already exists, returns
+/// it immediately. Otherwise creates a new environment using rattler.
+pub async fn prepare_conda_inline_env(
+    deps: &[String],
+    channels: &[String],
+    handler: Arc<dyn ProgressHandler>,
+) -> Result<PreparedEnv> {
+    let conda_deps = kernel_env::CondaDependencies {
+        dependencies: deps.to_vec(),
+        channels: if channels.is_empty() {
+            vec!["conda-forge".to_string()]
+        } else {
+            channels.to_vec()
+        },
+        python: None,
+        env_id: None,
     };
 
-    let required_packages = resolvo::Solver
-        .solve(solver_task)
-        .map_err(|e| anyhow!("Failed to solve conda dependencies: {}", e))?
-        .records;
-
-    info!(
-        "[inline-env] Solved: {} conda packages to install",
-        required_packages.len()
-    );
-
-    // Install packages
-    Installer::new()
-        .with_download_client(download_client)
-        .with_target_platform(install_platform)
-        .install(&env_path, required_packages)
-        .await
-        .map_err(|e| {
-            // Clean up failed environment
-            let env_path_clone = env_path.clone();
-            tokio::spawn(async move {
-                tokio::fs::remove_dir_all(&env_path_clone).await.ok();
-            });
-            anyhow!("Failed to install conda packages: {}", e)
-        })?;
-
-    // Verify python exists
-    if !python_path.exists() {
-        tokio::fs::remove_dir_all(&env_path).await.ok();
-        return Err(anyhow!(
-            "Python not found at {:?} after conda install",
-            python_path
-        ));
-    }
-
-    info!(
-        "[inline-env] Conda inline environment ready at {:?}",
-        env_path
-    );
+    let env =
+        kernel_env::conda::prepare_environment_in(&conda_deps, &get_inline_cache_dir(), handler)
+            .await?;
 
     Ok(PreparedEnv {
-        env_path,
-        python_path,
+        env_path: env.env_path,
+        python_path: env.python_path,
     })
 }
 

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -1265,10 +1265,17 @@ async fn handle_notebook_request(
                         );
                         detected.to_env_source().to_string()
                     }
-                    // Priority 3: Fall back to prewarmed
+                    // Priority 3: Fall back to prewarmed (respecting user's env preference)
                     else {
-                        info!("[notebook-sync] No project file detected, using prewarmed");
-                        "uv:prewarmed".to_string()
+                        let prewarmed = match daemon.default_python_env().await {
+                            crate::settings_doc::PythonEnvType::Conda => "conda:prewarmed",
+                            _ => "uv:prewarmed",
+                        };
+                        info!(
+                            "[notebook-sync] No project file detected, using prewarmed ({})",
+                            prewarmed
+                        );
+                        prewarmed.to_string()
                     }
                 } else {
                     // Use explicit env_source (e.g., "uv:inline", "conda:inline")

--- a/crates/runtimed/src/protocol.rs
+++ b/crates/runtimed/src/protocol.rs
@@ -367,6 +367,16 @@ pub enum NotebookBroadcast {
         /// All active comm snapshots
         comms: Vec<CommSnapshot>,
     },
+
+    /// Environment progress update during kernel launch.
+    ///
+    /// Carries rich progress phases (repodata, solve, download, link)
+    /// from `kernel_env` so the frontend can display detailed status.
+    EnvProgress {
+        env_type: String,
+        #[serde(flatten)]
+        phase: kernel_env::EnvProgressPhase,
+    },
 }
 
 // =============================================================================


### PR DESCRIPTION
Create a new `kernel-env` crate that encapsulates all Python environment management (UV + Conda) with a progress reporting trait. This enables rich progress feedback on the daemon path and makes the environment logic reusable across notebook, runtimed, and tauri-jupyter.

Key changes:
- New `kernel-env` crate with `ProgressHandler` trait, `EnvProgressPhase` enum, and `RattlerReporter` (rattler's `Reporter` impl)
- UV and Conda environment creation, caching, prewarming all moved to kernel-env with progress callbacks throughout
- `runtimed/inline_env.rs` now delegates to kernel-env with a `BroadcastProgressHandler` that forwards progress via broadcast channel
- `notebook/conda_env.rs` and `notebook/uv_env.rs` become thin wrappers keeping only notebook-specific metadata operations (nbformat)
- Added `EnvProgress` variant to `NotebookBroadcast` protocol for daemon-to-frontend progress events
- All environment functions accept `Arc<dyn ProgressHandler>` for flexible progress routing (Tauri events, broadcast, logs)

Co-Authored-By: Kyle Kelley <rgbkrk@gmail.com>
