### PR TITLE
fix(xtask): build sidecar UI before runt-cli to enable build-dmg

### DIFF
--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -485,7 +485,17 @@ fn cmd_dev_daemon() {
 /// If `release` is false, builds in debug mode (faster for development).
 fn build_runtimed_daemon(release: bool) {
     build_external_binary("runtimed", "runtimed", release);
+    ensure_sidecar_ui();
     build_external_binary("runt-cli", "runt", release);
+}
+
+/// Ensure sidecar UI assets exist (required before building runt-cli).
+fn ensure_sidecar_ui() {
+    let sidecar_dist = Path::new("apps/sidecar/dist/index.html");
+    if !sidecar_dist.exists() {
+        println!("Building sidecar UI (required for runt-cli)...");
+        run_cmd("pnpm", &["--dir", "apps/sidecar", "build"]);
+    }
 }
 
 /// Build a binary and copy to binaries/ with target triple suffix for Tauri bundling.


### PR DESCRIPTION
## Summary

Fixes `cargo xtask build-dmg` failing with "UI assets not found" error.

The sidecar crate embeds UI assets at compile time via rust_embed. Its build.rs checks that `apps/sidecar/dist/index.html` exists before compiling. Previously, `build_runtimed_daemon()` would build runt-cli immediately after runtimed, but before pnpm had built the sidecar assets, causing the build to fail.

This adds `ensure_sidecar_ui()` which builds the sidecar UI if the dist folder doesn't exist, called from `build_runtimed_daemon()` before building runt-cli.

## Verification

- Run `rm -rf apps/sidecar/dist && cargo xtask build-dmg` to verify it now succeeds