### PR TITLE
chore(bin): add dev shortcut for cargo xtask dev

### DIFF
--- a/bin/dev
+++ b/bin/dev
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Dev shortcut — runs `cargo xtask dev` from anywhere in the repo.
+#
+# Activated automatically via .envrc (direnv) which prepends bin/ to PATH.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+exec cargo xtask dev --manifest-path "$REPO_ROOT/Cargo.toml" "$@"


### PR DESCRIPTION
Adds a convenient `dev` command that can be run from anywhere in the repo to start the dev environment. Complements the existing `runt` wrapper for ergonomic local development workflows.

The script:
- Can be invoked as just `dev` when direnv is active (via `.envrc` PATH prepend)
- Resolves to the local `cargo xtask dev` command
- Accepts additional arguments passed through to xtask

_PR submitted by @rgbkrk's agent, Quill_