### PR TITLE
Sync notebook metadata (kernelspec, language_info, dependencies) via Automerge

### DIFF
--- a/apps/notebook/src/hooks/useCondaDependencies.ts
+++ b/apps/notebook/src/hooks/useCondaDependencies.ts
@@ -1,4 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
 import { useCallback, useEffect, useState } from "react";
 import type { PixiInfo } from "../types";
 
@@ -91,6 +92,16 @@ export function useCondaDependencies() {
       setEnvironmentYmlInfo,
     );
     invoke<PixiInfo | null>("detect_pixi_toml").then(setPixiInfo);
+  }, [loadDependencies]);
+
+  // Re-load when metadata is synced from another window
+  useEffect(() => {
+    const unlisten = listen("notebook:metadata_updated", () => {
+      loadDependencies();
+    });
+    return () => {
+      unlisten.then((fn) => fn());
+    };
   }, [loadDependencies]);
 
   // Load environment.yml deps when we detect one

--- a/apps/notebook/src/hooks/useDependencies.ts
+++ b/apps/notebook/src/hooks/useDependencies.ts
@@ -1,4 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
 import { useCallback, useEffect, useState } from "react";
 
 export interface NotebookDependencies {
@@ -85,6 +86,16 @@ export function useDependencies() {
   // Load dependencies on mount
   useEffect(() => {
     loadDependencies();
+  }, [loadDependencies]);
+
+  // Re-load when metadata is synced from another window
+  useEffect(() => {
+    const unlisten = listen("notebook:metadata_updated", () => {
+      loadDependencies();
+    });
+    return () => {
+      unlisten.then((fn) => fn());
+    };
   }, [loadDependencies]);
 
   // Re-sign the notebook after user modifications to keep it trusted

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -234,23 +234,22 @@ async fn initialize_notebook_sync(
         }
 
         // Also push notebook metadata to Automerge doc
-        {
+        let metadata_json = {
             let state = notebook_state.lock().map_err(|e| e.to_string())?;
             let snapshot = notebook_state::snapshot_from_nbformat(&state.notebook.metadata);
-            let metadata_json = serde_json::to_string(&snapshot)
-                .map_err(|e| format!("serialize metadata: {}", e))?;
-            info!(
-                "[notebook-sync] Pushing metadata to Automerge doc for {}",
-                notebook_id
-            );
-            handle
-                .set_metadata(
-                    runtimed::notebook_metadata::NOTEBOOK_METADATA_KEY,
-                    &metadata_json,
-                )
-                .await
-                .map_err(|e| format!("set_metadata: {}", e))?;
-        }
+            serde_json::to_string(&snapshot).map_err(|e| format!("serialize metadata: {}", e))?
+        };
+        info!(
+            "[notebook-sync] Pushing metadata to Automerge doc for {}",
+            notebook_id
+        );
+        handle
+            .set_metadata(
+                runtimed::notebook_metadata::NOTEBOOK_METADATA_KEY,
+                &metadata_json,
+            )
+            .await
+            .map_err(|e| format!("set_metadata: {}", e))?;
     } else {
         info!(
             "[notebook-sync] Joining existing room with {} cells",

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -203,8 +203,8 @@ async fn initialize_notebook_sync(
         socket_path.display()
     );
 
-    // Connect using the split pattern - returns handle, receiver, broadcast receiver, and initial cells
-    let (handle, mut receiver, mut broadcast_receiver, initial_cells) =
+    // Connect using the split pattern - returns handle, receiver, broadcast receiver, initial cells, and initial metadata
+    let (handle, mut receiver, mut broadcast_receiver, initial_cells, initial_metadata) =
         NotebookSyncClient::connect_split(socket_path, notebook_id.clone())
             .await
             .map_err(|e| format!("sync connect: {}", e))?;
@@ -232,6 +232,25 @@ async fn initialize_notebook_sync(
                     .map_err(|e| format!("update_source: {}", e))?;
             }
         }
+
+        // Also push notebook metadata to Automerge doc
+        {
+            let state = notebook_state.lock().map_err(|e| e.to_string())?;
+            let snapshot = notebook_state::snapshot_from_nbformat(&state.notebook.metadata);
+            let metadata_json = serde_json::to_string(&snapshot)
+                .map_err(|e| format!("serialize metadata: {}", e))?;
+            info!(
+                "[notebook-sync] Pushing metadata to Automerge doc for {}",
+                notebook_id
+            );
+            handle
+                .set_metadata(
+                    runtimed::notebook_metadata::NOTEBOOK_METADATA_KEY,
+                    &metadata_json,
+                )
+                .await
+                .map_err(|e| format!("set_metadata: {}", e))?;
+        }
     } else {
         info!(
             "[notebook-sync] Joining existing room with {} cells",
@@ -249,6 +268,30 @@ async fn initialize_notebook_sync(
                 "[notebook-sync] Updated local state with {} cells from Automerge",
                 state.notebook.cells.len()
             );
+
+            // Also merge metadata from Automerge doc into local state
+            if let Some(ref metadata_json) = initial_metadata {
+                match serde_json::from_str::<runtimed::notebook_metadata::NotebookMetadataSnapshot>(
+                    metadata_json,
+                ) {
+                    Ok(snapshot) => {
+                        notebook_state::merge_snapshot_into_nbformat(
+                            &snapshot,
+                            &mut state.notebook.metadata,
+                        );
+                        info!(
+                            "[notebook-sync] Merged metadata from Automerge for {}",
+                            notebook_id
+                        );
+                    }
+                    Err(e) => {
+                        warn!(
+                            "[notebook-sync] Failed to deserialize metadata from Automerge: {}",
+                            e
+                        );
+                    }
+                }
+            }
         }
         // Emit Automerge state to frontend (for immediate UI update)
         if let Err(e) = app.emit("notebook:updated", &initial_cells) {
@@ -272,20 +315,49 @@ async fn initialize_notebook_sync(
     // The receiver is separate from the handle, so it doesn't block commands
     let app_clone = app.clone();
     let notebook_id_for_receiver = notebook_id.clone();
+    let notebook_state_for_receiver = notebook_state.clone();
     tokio::spawn(async move {
         info!(
             "[notebook-sync] Starting receiver loop for {}",
             notebook_id_for_receiver
         );
-        while let Some(cells) = receiver.recv().await {
+        while let Some(update) = receiver.recv().await {
             info!(
                 "[notebook-sync] Received {} cells from peer for {}",
-                cells.len(),
+                update.cells.len(),
                 notebook_id_for_receiver
             );
-            // Emit event for frontend to reconcile state
-            if let Err(e) = app_clone.emit("notebook:updated", &cells) {
+            // Emit cell changes for frontend to reconcile state
+            if let Err(e) = app_clone.emit("notebook:updated", &update.cells) {
                 warn!("[notebook-sync] Failed to emit notebook:updated: {}", e);
+            }
+
+            // If metadata changed, merge into local state and notify frontend
+            if let Some(ref metadata_json) = update.notebook_metadata {
+                match serde_json::from_str::<runtimed::notebook_metadata::NotebookMetadataSnapshot>(
+                    metadata_json,
+                ) {
+                    Ok(snapshot) => {
+                        if let Ok(mut state) = notebook_state_for_receiver.lock() {
+                            notebook_state::merge_snapshot_into_nbformat(
+                                &snapshot,
+                                &mut state.notebook.metadata,
+                            );
+                        }
+                        if let Err(e) = app_clone.emit("notebook:metadata_updated", metadata_json) {
+                            warn!(
+                                "[notebook-sync] Failed to emit notebook:metadata_updated: {}",
+                                e
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        warn!(
+                            "[notebook-sync] Failed to deserialize metadata from peer: {}",
+                            e
+                        );
+                    }
+                }
             }
         }
         info!(
@@ -349,6 +421,54 @@ async fn initialize_notebook_sync(
     }
 
     Ok(())
+}
+
+/// Push the current notebook metadata to the Automerge doc via the sync handle.
+///
+/// Call this after any mutation to `notebook.metadata` so that the daemon
+/// and other windows receive the updated metadata through Automerge sync.
+async fn push_metadata_to_sync(
+    notebook_state: &Arc<Mutex<NotebookState>>,
+    notebook_sync: &SharedNotebookSync,
+) {
+    let metadata_json = {
+        let state = match notebook_state.lock() {
+            Ok(s) => s,
+            Err(e) => {
+                warn!(
+                    "[notebook-sync] Failed to lock state for metadata push: {}",
+                    e
+                );
+                return;
+            }
+        };
+        let snapshot = notebook_state::snapshot_from_nbformat(&state.notebook.metadata);
+        match serde_json::to_string(&snapshot) {
+            Ok(json) => json,
+            Err(e) => {
+                warn!(
+                    "[notebook-sync] Failed to serialize metadata snapshot: {}",
+                    e
+                );
+                return;
+            }
+        }
+    };
+
+    if let Some(handle) = notebook_sync.lock().await.as_ref() {
+        if let Err(e) = handle
+            .set_metadata(
+                runtimed::notebook_metadata::NOTEBOOK_METADATA_KEY,
+                &metadata_json,
+            )
+            .await
+        {
+            warn!(
+                "[notebook-sync] Failed to push metadata to Automerge: {}",
+                e
+            );
+        }
+    }
 }
 
 #[cfg(test)]
@@ -619,9 +739,13 @@ async fn get_notebook_path(
 
 /// Format all code cells in the notebook and save.
 /// Formatting is best-effort - cells that fail to format are saved as-is.
+///
+/// Save path: daemon writes .ipynb to disk (merging synced metadata with
+/// existing file content). Falls back to local save if daemon is unavailable.
 #[tauri::command]
 async fn save_notebook(
     state: tauri::State<'_, Arc<Mutex<NotebookState>>>,
+    notebook_sync: tauri::State<'_, SharedNotebookSync>,
     app: tauri::AppHandle,
 ) -> Result<(), String> {
     // First pass: collect cells to format (release lock for async formatting)
@@ -681,11 +805,56 @@ async fn save_notebook(
         // Formatting errors are silently ignored - save with original code
     }
 
-    // Now save
-    let mut nb = state.lock().map_err(|e| e.to_string())?;
-    let content = nb.serialize()?;
-    std::fs::write(&path, &content).map_err(|e| e.to_string())?;
-    nb.dirty = false;
+    // Ensure latest metadata is pushed to daemon before saving
+    push_metadata_to_sync(&state, &notebook_sync).await;
+
+    // Try daemon save first (daemon merges metadata + cells from Automerge doc)
+    let daemon_saved = {
+        let guard = notebook_sync.lock().await;
+        if let Some(ref handle) = *guard {
+            match handle
+                .send_request(NotebookRequest::SaveNotebook {
+                    format_cells: false, // Already formatted above
+                })
+                .await
+            {
+                Ok(NotebookResponse::NotebookSaved {}) => {
+                    info!("[save] Notebook saved via daemon");
+                    true
+                }
+                Ok(NotebookResponse::Error { error }) => {
+                    warn!(
+                        "[save] Daemon save failed: {}, falling back to local",
+                        error
+                    );
+                    false
+                }
+                Ok(_) => {
+                    warn!("[save] Unexpected daemon response, falling back to local");
+                    false
+                }
+                Err(e) => {
+                    warn!("[save] Daemon request failed: {}, falling back to local", e);
+                    false
+                }
+            }
+        } else {
+            false
+        }
+    };
+
+    // Fallback: save locally if daemon save didn't work
+    if !daemon_saved {
+        let nb = state.lock().map_err(|e| e.to_string())?;
+        let content = nb.serialize()?;
+        std::fs::write(&path, &content).map_err(|e| e.to_string())?;
+    }
+
+    // Mark as clean
+    {
+        let mut nb = state.lock().map_err(|e| e.to_string())?;
+        nb.dirty = false;
+    }
     Ok(())
 }
 
@@ -1489,16 +1658,18 @@ async fn set_notebook_dependencies(
     dependencies: Vec<String>,
     requires_python: Option<String>,
     state: tauri::State<'_, Arc<Mutex<NotebookState>>>,
+    notebook_sync: tauri::State<'_, SharedNotebookSync>,
 ) -> Result<(), String> {
-    let mut state = state.lock().map_err(|e| e.to_string())?;
-
-    let deps = uv_env::NotebookDependencies {
-        dependencies,
-        requires_python,
-    };
-    uv_env::set_dependencies(&mut state.notebook.metadata, &deps);
-    state.dirty = true;
-
+    {
+        let mut state = state.lock().map_err(|e| e.to_string())?;
+        let deps = uv_env::NotebookDependencies {
+            dependencies,
+            requires_python,
+        };
+        uv_env::set_dependencies(&mut state.notebook.metadata, &deps);
+        state.dirty = true;
+    }
+    push_metadata_to_sync(&state, &notebook_sync).await;
     Ok(())
 }
 
@@ -1507,41 +1678,48 @@ async fn set_notebook_dependencies(
 async fn add_dependency(
     package: String,
     state: tauri::State<'_, Arc<Mutex<NotebookState>>>,
+    notebook_sync: tauri::State<'_, SharedNotebookSync>,
 ) -> Result<(), String> {
-    let mut state = state.lock().map_err(|e| e.to_string())?;
+    let changed = {
+        let mut s = state.lock().map_err(|e| e.to_string())?;
 
-    // Get existing deps or create new
-    let existing = uv_env::extract_dependencies(&state.notebook.metadata);
-    let mut deps = existing
-        .as_ref()
-        .map(|d| d.dependencies.clone())
-        .unwrap_or_default();
+        // Get existing deps or create new
+        let existing = uv_env::extract_dependencies(&s.notebook.metadata);
+        let mut deps = existing
+            .as_ref()
+            .map(|d| d.dependencies.clone())
+            .unwrap_or_default();
 
-    // Check if already exists (by package name, ignoring version specifiers)
-    let pkg_name = package
-        .split(&['>', '<', '=', '!', '~', '['][..])
-        .next()
-        .unwrap_or(&package);
-    let already_exists = deps.iter().any(|d| {
-        let existing_name = d
+        // Check if already exists (by package name, ignoring version specifiers)
+        let pkg_name = package
             .split(&['>', '<', '=', '!', '~', '['][..])
             .next()
-            .unwrap_or(d);
-        existing_name.eq_ignore_ascii_case(pkg_name)
-    });
+            .unwrap_or(&package);
+        let already_exists = deps.iter().any(|d| {
+            let existing_name = d
+                .split(&['>', '<', '=', '!', '~', '['][..])
+                .next()
+                .unwrap_or(d);
+            existing_name.eq_ignore_ascii_case(pkg_name)
+        });
 
-    if !already_exists {
-        deps.push(package);
-
-        let requires_python = existing.and_then(|d| d.requires_python);
-        let new_deps = uv_env::NotebookDependencies {
-            dependencies: deps,
-            requires_python,
-        };
-        uv_env::set_dependencies(&mut state.notebook.metadata, &new_deps);
-        state.dirty = true;
+        if !already_exists {
+            deps.push(package);
+            let requires_python = existing.and_then(|d| d.requires_python);
+            let new_deps = uv_env::NotebookDependencies {
+                dependencies: deps,
+                requires_python,
+            };
+            uv_env::set_dependencies(&mut s.notebook.metadata, &new_deps);
+            s.dirty = true;
+            true
+        } else {
+            false
+        }
+    };
+    if changed {
+        push_metadata_to_sync(&state, &notebook_sync).await;
     }
-
     Ok(())
 }
 
@@ -1550,36 +1728,36 @@ async fn add_dependency(
 async fn remove_dependency(
     package: String,
     state: tauri::State<'_, Arc<Mutex<NotebookState>>>,
+    notebook_sync: tauri::State<'_, SharedNotebookSync>,
 ) -> Result<(), String> {
-    let mut state = state.lock().map_err(|e| e.to_string())?;
-
-    let existing = uv_env::extract_dependencies(&state.notebook.metadata);
-    if let Some(existing) = existing {
-        // Remove by package name (ignoring version specifiers)
-        let pkg_name = package
-            .split(&['>', '<', '=', '!', '~', '['][..])
-            .next()
-            .unwrap_or(&package);
-        let deps: Vec<String> = existing
-            .dependencies
-            .into_iter()
-            .filter(|d| {
-                let existing_name = d
-                    .split(&['>', '<', '=', '!', '~', '['][..])
-                    .next()
-                    .unwrap_or(d);
-                !existing_name.eq_ignore_ascii_case(pkg_name)
-            })
-            .collect();
-
-        let new_deps = uv_env::NotebookDependencies {
-            dependencies: deps,
-            requires_python: existing.requires_python,
-        };
-        uv_env::set_dependencies(&mut state.notebook.metadata, &new_deps);
-        state.dirty = true;
+    {
+        let mut s = state.lock().map_err(|e| e.to_string())?;
+        let existing = uv_env::extract_dependencies(&s.notebook.metadata);
+        if let Some(existing) = existing {
+            let pkg_name = package
+                .split(&['>', '<', '=', '!', '~', '['][..])
+                .next()
+                .unwrap_or(&package);
+            let deps: Vec<String> = existing
+                .dependencies
+                .into_iter()
+                .filter(|d| {
+                    let existing_name = d
+                        .split(&['>', '<', '=', '!', '~', '['][..])
+                        .next()
+                        .unwrap_or(d);
+                    !existing_name.eq_ignore_ascii_case(pkg_name)
+                })
+                .collect();
+            let new_deps = uv_env::NotebookDependencies {
+                dependencies: deps,
+                requires_python: existing.requires_python,
+            };
+            uv_env::set_dependencies(&mut s.notebook.metadata, &new_deps);
+            s.dirty = true;
+        }
     }
-
+    push_metadata_to_sync(&state, &notebook_sync).await;
     Ok(())
 }
 
@@ -1591,6 +1769,7 @@ async fn remove_dependency(
 async fn clear_dependency_section(
     section: String,
     state: tauri::State<'_, Arc<Mutex<NotebookState>>>,
+    notebook_sync: tauri::State<'_, SharedNotebookSync>,
 ) -> Result<(), String> {
     if section != "uv" && section != "conda" {
         return Err(format!(
@@ -1599,25 +1778,25 @@ async fn clear_dependency_section(
         ));
     }
 
-    let mut state = state.lock().map_err(|e| e.to_string())?;
-
-    // Remove from new nested path and legacy path
-    match section.as_str() {
-        "uv" => {
-            if uv_env::has_uv_config(&state.notebook.metadata) {
-                uv_env::remove_uv_config(&mut state.notebook.metadata);
-                state.dirty = true;
+    {
+        let mut s = state.lock().map_err(|e| e.to_string())?;
+        match section.as_str() {
+            "uv" => {
+                if uv_env::has_uv_config(&s.notebook.metadata) {
+                    uv_env::remove_uv_config(&mut s.notebook.metadata);
+                    s.dirty = true;
+                }
             }
-        }
-        "conda" => {
-            if conda_env::has_conda_config(&state.notebook.metadata) {
-                conda_env::remove_conda_config(&mut state.notebook.metadata);
-                state.dirty = true;
+            "conda" => {
+                if conda_env::has_conda_config(&s.notebook.metadata) {
+                    conda_env::remove_conda_config(&mut s.notebook.metadata);
+                    s.dirty = true;
+                }
             }
+            _ => {}
         }
-        _ => {}
     }
-
+    push_metadata_to_sync(&state, &notebook_sync).await;
     Ok(())
 }
 
@@ -1654,18 +1833,20 @@ async fn set_conda_dependencies(
     channels: Vec<String>,
     python: Option<String>,
     state: tauri::State<'_, Arc<Mutex<NotebookState>>>,
+    notebook_sync: tauri::State<'_, SharedNotebookSync>,
 ) -> Result<(), String> {
-    let mut state = state.lock().map_err(|e| e.to_string())?;
-
-    let deps = conda_env::CondaDependencies {
-        dependencies,
-        channels,
-        python,
-        env_id: None,
-    };
-    conda_env::set_dependencies(&mut state.notebook.metadata, &deps);
-    state.dirty = true;
-
+    {
+        let mut s = state.lock().map_err(|e| e.to_string())?;
+        let deps = conda_env::CondaDependencies {
+            dependencies,
+            channels,
+            python,
+            env_id: None,
+        };
+        conda_env::set_dependencies(&mut s.notebook.metadata, &deps);
+        s.dirty = true;
+    }
+    push_metadata_to_sync(&state, &notebook_sync).await;
     Ok(())
 }
 
@@ -1674,47 +1855,52 @@ async fn set_conda_dependencies(
 async fn add_conda_dependency(
     package: String,
     state: tauri::State<'_, Arc<Mutex<NotebookState>>>,
+    notebook_sync: tauri::State<'_, SharedNotebookSync>,
 ) -> Result<(), String> {
-    let mut state = state.lock().map_err(|e| e.to_string())?;
+    let changed = {
+        let mut s = state.lock().map_err(|e| e.to_string())?;
 
-    // Get existing deps or create new
-    let existing = conda_env::extract_dependencies(&state.notebook.metadata);
-    let mut deps = existing
-        .as_ref()
-        .map(|d| d.dependencies.clone())
-        .unwrap_or_default();
-    let channels = existing
-        .as_ref()
-        .map(|d| d.channels.clone())
-        .unwrap_or_default();
-    let python = existing.as_ref().and_then(|d| d.python.clone());
+        let existing = conda_env::extract_dependencies(&s.notebook.metadata);
+        let mut deps = existing
+            .as_ref()
+            .map(|d| d.dependencies.clone())
+            .unwrap_or_default();
+        let channels = existing
+            .as_ref()
+            .map(|d| d.channels.clone())
+            .unwrap_or_default();
+        let python = existing.as_ref().and_then(|d| d.python.clone());
 
-    // Check if already exists (by package name, ignoring version specifiers)
-    let pkg_name = package
-        .split(&['>', '<', '=', '!', '~', '['][..])
-        .next()
-        .unwrap_or(&package);
-    let already_exists = deps.iter().any(|d| {
-        let existing_name = d
+        let pkg_name = package
             .split(&['>', '<', '=', '!', '~', '['][..])
             .next()
-            .unwrap_or(d);
-        existing_name.eq_ignore_ascii_case(pkg_name)
-    });
+            .unwrap_or(&package);
+        let already_exists = deps.iter().any(|d| {
+            let existing_name = d
+                .split(&['>', '<', '=', '!', '~', '['][..])
+                .next()
+                .unwrap_or(d);
+            existing_name.eq_ignore_ascii_case(pkg_name)
+        });
 
-    if !already_exists {
-        deps.push(package);
-
-        let new_deps = conda_env::CondaDependencies {
-            dependencies: deps,
-            channels,
-            python,
-            env_id: None,
-        };
-        conda_env::set_dependencies(&mut state.notebook.metadata, &new_deps);
-        state.dirty = true;
+        if !already_exists {
+            deps.push(package);
+            let new_deps = conda_env::CondaDependencies {
+                dependencies: deps,
+                channels,
+                python,
+                env_id: None,
+            };
+            conda_env::set_dependencies(&mut s.notebook.metadata, &new_deps);
+            s.dirty = true;
+            true
+        } else {
+            false
+        }
+    };
+    if changed {
+        push_metadata_to_sync(&state, &notebook_sync).await;
     }
-
     Ok(())
 }
 
@@ -1723,38 +1909,38 @@ async fn add_conda_dependency(
 async fn remove_conda_dependency(
     package: String,
     state: tauri::State<'_, Arc<Mutex<NotebookState>>>,
+    notebook_sync: tauri::State<'_, SharedNotebookSync>,
 ) -> Result<(), String> {
-    let mut state = state.lock().map_err(|e| e.to_string())?;
-
-    let existing = conda_env::extract_dependencies(&state.notebook.metadata);
-    if let Some(existing) = existing {
-        // Remove by package name (ignoring version specifiers)
-        let pkg_name = package
-            .split(&['>', '<', '=', '!', '~', '['][..])
-            .next()
-            .unwrap_or(&package);
-        let deps: Vec<String> = existing
-            .dependencies
-            .into_iter()
-            .filter(|d| {
-                let existing_name = d
-                    .split(&['>', '<', '=', '!', '~', '['][..])
-                    .next()
-                    .unwrap_or(d);
-                !existing_name.eq_ignore_ascii_case(pkg_name)
-            })
-            .collect();
-
-        let new_deps = conda_env::CondaDependencies {
-            dependencies: deps,
-            channels: existing.channels,
-            python: existing.python,
-            env_id: existing.env_id,
-        };
-        conda_env::set_dependencies(&mut state.notebook.metadata, &new_deps);
-        state.dirty = true;
+    {
+        let mut s = state.lock().map_err(|e| e.to_string())?;
+        let existing = conda_env::extract_dependencies(&s.notebook.metadata);
+        if let Some(existing) = existing {
+            let pkg_name = package
+                .split(&['>', '<', '=', '!', '~', '['][..])
+                .next()
+                .unwrap_or(&package);
+            let deps: Vec<String> = existing
+                .dependencies
+                .into_iter()
+                .filter(|d| {
+                    let existing_name = d
+                        .split(&['>', '<', '=', '!', '~', '['][..])
+                        .next()
+                        .unwrap_or(d);
+                    !existing_name.eq_ignore_ascii_case(pkg_name)
+                })
+                .collect();
+            let new_deps = conda_env::CondaDependencies {
+                dependencies: deps,
+                channels: existing.channels,
+                python: existing.python,
+                env_id: existing.env_id,
+            };
+            conda_env::set_dependencies(&mut s.notebook.metadata, &new_deps);
+            s.dirty = true;
+        }
     }
-
+    push_metadata_to_sync(&state, &notebook_sync).await;
     Ok(())
 }
 
@@ -1849,10 +2035,11 @@ async fn get_pyproject_dependencies(
 #[tauri::command]
 async fn import_pyproject_dependencies(
     state: tauri::State<'_, Arc<Mutex<NotebookState>>>,
+    notebook_sync: tauri::State<'_, SharedNotebookSync>,
 ) -> Result<(), String> {
     let notebook_path = {
-        let state = state.lock().map_err(|e| e.to_string())?;
-        state.path.clone()
+        let s = state.lock().map_err(|e| e.to_string())?;
+        s.path.clone()
     };
 
     let Some(notebook_path) = notebook_path else {
@@ -1865,23 +2052,21 @@ async fn import_pyproject_dependencies(
 
     let config = pyproject::parse_pyproject(&pyproject_path).map_err(|e| e.to_string())?;
 
-    // Merge pyproject deps into notebook metadata
-    let mut state = state.lock().map_err(|e| e.to_string())?;
-
-    let all_deps = pyproject::get_all_dependencies(&config);
-
-    let deps = uv_env::NotebookDependencies {
-        dependencies: all_deps.clone(),
-        requires_python: config.requires_python,
-    };
-    uv_env::set_dependencies(&mut state.notebook.metadata, &deps);
-    state.dirty = true;
-
-    info!(
-        "Imported {} dependencies from pyproject.toml into notebook",
-        all_deps.len()
-    );
-
+    {
+        let mut s = state.lock().map_err(|e| e.to_string())?;
+        let all_deps = pyproject::get_all_dependencies(&config);
+        let deps = uv_env::NotebookDependencies {
+            dependencies: all_deps.clone(),
+            requires_python: config.requires_python,
+        };
+        uv_env::set_dependencies(&mut s.notebook.metadata, &deps);
+        s.dirty = true;
+        info!(
+            "Imported {} dependencies from pyproject.toml into notebook",
+            all_deps.len()
+        );
+    }
+    push_metadata_to_sync(&state, &notebook_sync).await;
     Ok(())
 }
 
@@ -1907,33 +2092,37 @@ async fn verify_notebook_trust(
 #[tauri::command]
 async fn approve_notebook_trust(
     state: tauri::State<'_, Arc<Mutex<NotebookState>>>,
+    notebook_sync: tauri::State<'_, SharedNotebookSync>,
 ) -> Result<(), String> {
-    let mut state = state.lock().map_err(|e| e.to_string())?;
+    {
+        let mut s = state.lock().map_err(|e| e.to_string())?;
 
-    // Compute signature over current dependencies
-    let signature = trust::sign_notebook_dependencies(&state.notebook.metadata.additional)?;
+        // Compute signature over current dependencies
+        let signature = trust::sign_notebook_dependencies(&s.notebook.metadata.additional)?;
 
-    // Get or create the runt metadata section
-    let runt_value = state
-        .notebook
-        .metadata
-        .additional
-        .entry("runt".to_string())
-        .or_insert_with(|| serde_json::json!({}));
+        // Get or create the runt metadata section
+        let runt_value = s
+            .notebook
+            .metadata
+            .additional
+            .entry("runt".to_string())
+            .or_insert_with(|| serde_json::json!({}));
 
-    // Add/update the trust signature
-    if let Some(obj) = runt_value.as_object_mut() {
-        obj.insert(
-            "trust_signature".to_string(),
-            serde_json::Value::String(signature),
-        );
-        obj.insert(
-            "trust_timestamp".to_string(),
-            serde_json::Value::String(chrono::Utc::now().to_rfc3339()),
-        );
+        // Add/update the trust signature
+        if let Some(obj) = runt_value.as_object_mut() {
+            obj.insert(
+                "trust_signature".to_string(),
+                serde_json::Value::String(signature),
+            );
+            obj.insert(
+                "trust_timestamp".to_string(),
+                serde_json::Value::String(chrono::Utc::now().to_rfc3339()),
+            );
+        }
+
+        s.dirty = true;
     }
-
-    state.dirty = true;
+    push_metadata_to_sync(&state, &notebook_sync).await;
     Ok(())
 }
 
@@ -2122,10 +2311,11 @@ async fn get_environment_yml_dependencies(
 #[tauri::command]
 async fn import_pixi_dependencies(
     state: tauri::State<'_, Arc<Mutex<NotebookState>>>,
+    notebook_sync: tauri::State<'_, SharedNotebookSync>,
 ) -> Result<(), String> {
     let notebook_path = {
-        let state = state.lock().map_err(|e| e.to_string())?;
-        state.path.clone()
+        let s = state.lock().map_err(|e| e.to_string())?;
+        s.path.clone()
     };
 
     let Some(notebook_path) = notebook_path else {
@@ -2139,23 +2329,22 @@ async fn import_pixi_dependencies(
     let config = pixi::parse_pixi_toml(&pixi_path).map_err(|e| e.to_string())?;
     let conda_deps = pixi::convert_to_conda_dependencies(&config);
 
-    // Merge pixi deps into notebook conda metadata
-    let mut state = state.lock().map_err(|e| e.to_string())?;
-
-    let deps = conda_env::CondaDependencies {
-        dependencies: conda_deps.dependencies.clone(),
-        channels: conda_deps.channels,
-        python: conda_deps.python,
-        env_id: None,
-    };
-    conda_env::set_dependencies(&mut state.notebook.metadata, &deps);
-    state.dirty = true;
-
-    info!(
-        "Imported {} dependencies from pixi.toml into notebook conda metadata",
-        conda_deps.dependencies.len()
-    );
-
+    {
+        let mut s = state.lock().map_err(|e| e.to_string())?;
+        let deps = conda_env::CondaDependencies {
+            dependencies: conda_deps.dependencies.clone(),
+            channels: conda_deps.channels,
+            python: conda_deps.python,
+            env_id: None,
+        };
+        conda_env::set_dependencies(&mut s.notebook.metadata, &deps);
+        s.dirty = true;
+        info!(
+            "Imported {} dependencies from pixi.toml into notebook conda metadata",
+            conda_deps.dependencies.len()
+        );
+    }
+    push_metadata_to_sync(&state, &notebook_sync).await;
     Ok(())
 }
 
@@ -2224,22 +2413,21 @@ async fn get_deno_permissions(
 async fn set_deno_permissions(
     permissions: Vec<String>,
     state: tauri::State<'_, Arc<Mutex<NotebookState>>>,
+    notebook_sync: tauri::State<'_, SharedNotebookSync>,
 ) -> Result<(), String> {
-    let mut state = state.lock().map_err(|e| e.to_string())?;
-
-    // Preserve existing settings when updating permissions
-    let mut deno_deps =
-        deno_env::extract_deno_metadata(&state.notebook.metadata).unwrap_or_default();
-    deno_deps.permissions = permissions;
-
-    let deno_value = serde_json::to_value(&deno_deps).map_err(|e| e.to_string())?;
-    state
-        .notebook
-        .metadata
-        .additional
-        .insert("deno".to_string(), deno_value);
-    state.dirty = true;
-
+    {
+        let mut s = state.lock().map_err(|e| e.to_string())?;
+        let mut deno_deps =
+            deno_env::extract_deno_metadata(&s.notebook.metadata).unwrap_or_default();
+        deno_deps.permissions = permissions;
+        let deno_value = serde_json::to_value(&deno_deps).map_err(|e| e.to_string())?;
+        s.notebook
+            .metadata
+            .additional
+            .insert("deno".to_string(), deno_value);
+        s.dirty = true;
+    }
+    push_metadata_to_sync(&state, &notebook_sync).await;
     Ok(())
 }
 
@@ -2258,22 +2446,21 @@ async fn get_deno_flexible_npm_imports(
 async fn set_deno_flexible_npm_imports(
     enabled: bool,
     state: tauri::State<'_, Arc<Mutex<NotebookState>>>,
+    notebook_sync: tauri::State<'_, SharedNotebookSync>,
 ) -> Result<(), String> {
-    let mut state = state.lock().map_err(|e| e.to_string())?;
-
-    // Preserve existing settings when updating flexible_npm_imports
-    let mut deno_deps =
-        deno_env::extract_deno_metadata(&state.notebook.metadata).unwrap_or_default();
-    deno_deps.flexible_npm_imports = enabled;
-
-    let deno_value = serde_json::to_value(&deno_deps).map_err(|e| e.to_string())?;
-    state
-        .notebook
-        .metadata
-        .additional
-        .insert("deno".to_string(), deno_value);
-    state.dirty = true;
-
+    {
+        let mut s = state.lock().map_err(|e| e.to_string())?;
+        let mut deno_deps =
+            deno_env::extract_deno_metadata(&s.notebook.metadata).unwrap_or_default();
+        deno_deps.flexible_npm_imports = enabled;
+        let deno_value = serde_json::to_value(&deno_deps).map_err(|e| e.to_string())?;
+        s.notebook
+            .metadata
+            .additional
+            .insert("deno".to_string(), deno_value);
+        s.dirty = true;
+    }
+    push_metadata_to_sync(&state, &notebook_sync).await;
     Ok(())
 }
 

--- a/crates/notebook/src/notebook_state.rs
+++ b/crates/notebook/src/notebook_state.rs
@@ -615,6 +615,111 @@ impl NotebookState {
     }
 }
 
+// ── Conversions between nbformat Metadata and NotebookMetadataSnapshot ──
+
+use runtimed::notebook_metadata::{
+    CondaInlineMetadata, DenoMetadata, KernelspecSnapshot, LanguageInfoSnapshot,
+    NotebookMetadataSnapshot, RuntMetadata, UvInlineMetadata,
+};
+
+/// Extract a `NotebookMetadataSnapshot` from nbformat metadata.
+///
+/// Reads `kernelspec`, `language_info`, and `runt` from the nbformat struct.
+/// Falls back to legacy `uv`/`conda` top-level keys if `runt` is absent.
+pub fn snapshot_from_nbformat(metadata: &nbformat::v4::Metadata) -> NotebookMetadataSnapshot {
+    let kernelspec = metadata.kernelspec.as_ref().map(|ks| KernelspecSnapshot {
+        name: ks.name.clone(),
+        display_name: ks.display_name.clone(),
+        language: ks.language.clone(),
+    });
+
+    let language_info = metadata
+        .language_info
+        .as_ref()
+        .map(|li| LanguageInfoSnapshot {
+            name: li.name.clone(),
+            version: None, // nbformat LanguageInfo doesn't always have version
+        });
+
+    let runt = if let Some(runt_value) = metadata.additional.get("runt") {
+        serde_json::from_value::<RuntMetadata>(runt_value.clone()).unwrap_or_else(|_| {
+            RuntMetadata {
+                schema_version: "1".to_string(),
+                env_id: None,
+                uv: None,
+                conda: None,
+                deno: None,
+            }
+        })
+    } else {
+        // Fallback: legacy top-level uv/conda keys
+        let uv = metadata
+            .additional
+            .get("uv")
+            .and_then(|v| serde_json::from_value::<UvInlineMetadata>(v.clone()).ok());
+        let conda = metadata
+            .additional
+            .get("conda")
+            .and_then(|v| serde_json::from_value::<CondaInlineMetadata>(v.clone()).ok());
+        let deno = metadata.additional.get("deno").and_then(|_| {
+            Some(DenoMetadata {
+                permissions: vec![],
+            })
+        });
+
+        RuntMetadata {
+            schema_version: "1".to_string(),
+            env_id: None,
+            uv,
+            conda,
+            deno,
+        }
+    };
+
+    NotebookMetadataSnapshot {
+        kernelspec,
+        language_info,
+        runt,
+    }
+}
+
+/// Merge a `NotebookMetadataSnapshot` back into nbformat metadata.
+///
+/// Replaces `kernelspec`, `language_info`, and `metadata.additional["runt"]`
+/// while preserving all other keys in `additional` (e.g. `jupyter`, `deno`
+/// top-level config, custom extensions).
+pub fn merge_snapshot_into_nbformat(
+    snapshot: &NotebookMetadataSnapshot,
+    metadata: &mut nbformat::v4::Metadata,
+) {
+    // Replace kernelspec
+    metadata.kernelspec = snapshot
+        .kernelspec
+        .as_ref()
+        .map(|ks| nbformat::v4::KernelSpec {
+            name: ks.name.clone(),
+            display_name: ks.display_name.clone(),
+            language: ks.language.clone(),
+            additional: std::collections::HashMap::new(),
+        });
+
+    // Replace language_info
+    metadata.language_info = snapshot
+        .language_info
+        .as_ref()
+        .map(|li| nbformat::v4::LanguageInfo {
+            name: li.name.clone(),
+            version: li.version.clone(),
+            codemirror_mode: None,
+            additional: std::collections::HashMap::new(),
+        });
+
+    // Replace runt namespace in additional
+    if let Ok(runt_value) = serde_json::to_value(&snapshot.runt) {
+        metadata.additional.insert("runt".to_string(), runt_value);
+    }
+}
+
 fn empty_cell_metadata() -> CellMetadata {
     CellMetadata {
         id: None,

--- a/crates/notebook/src/notebook_state.rs
+++ b/crates/notebook/src/notebook_state.rs
@@ -661,10 +661,8 @@ pub fn snapshot_from_nbformat(metadata: &nbformat::v4::Metadata) -> NotebookMeta
             .additional
             .get("conda")
             .and_then(|v| serde_json::from_value::<CondaInlineMetadata>(v.clone()).ok());
-        let deno = metadata.additional.get("deno").and_then(|_| {
-            Some(DenoMetadata {
-                permissions: vec![],
-            })
+        let deno = metadata.additional.get("deno").map(|_| DenoMetadata {
+            permissions: vec![],
         });
 
         RuntMetadata {

--- a/crates/runtimed/src/lib.rs
+++ b/crates/runtimed/src/lib.rs
@@ -22,6 +22,7 @@ pub mod daemon;
 pub mod inline_env;
 pub mod kernel_manager;
 pub mod notebook_doc;
+pub mod notebook_metadata;
 pub mod notebook_sync_client;
 pub mod notebook_sync_server;
 pub mod output_store;

--- a/crates/runtimed/src/notebook_metadata.rs
+++ b/crates/runtimed/src/notebook_metadata.rs
@@ -1,0 +1,437 @@
+//! Typed notebook metadata structs for Automerge sync.
+//!
+//! These types represent the notebook-level metadata that is synced between
+//! the daemon and all connected notebook windows via the Automerge document.
+//!
+//! The `NotebookMetadataSnapshot` is serialized as a JSON string and stored
+//! under the `metadata.notebook_metadata` key in the Automerge doc. When
+//! writing to disk, it is merged back into the full `.ipynb` metadata,
+//! preserving any fields we don't track (arbitrary Jupyter extensions, etc.).
+//!
+//! ## Merge semantics
+//!
+//! When saving to disk, the snapshot is merged into existing file metadata
+//! like `Object.assign({}, existingMetadata, { kernelspec, language_info, runt })`.
+//! This replaces `kernelspec`, `language_info`, and the `runt` key in
+//! `metadata.additional` while leaving everything else untouched.
+
+use serde::{Deserialize, Serialize};
+
+// ── Runt namespace ───────────────────────────────────────────────────
+
+/// Typed representation of the `metadata.runt` namespace in a notebook.
+///
+/// Contains environment configuration (uv, conda, deno), schema versioning,
+/// a per-notebook environment ID, and trust signatures.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RuntMetadata {
+    /// Schema version for migration support. Currently "1".
+    pub schema_version: String,
+
+    /// Unique environment ID for this notebook (UUID).
+    /// Used for per-notebook environment isolation when no dependencies are declared.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub env_id: Option<String>,
+
+    /// UV (pip-compatible) inline dependency configuration.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub uv: Option<UvInlineMetadata>,
+
+    /// Conda inline dependency configuration.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub conda: Option<CondaInlineMetadata>,
+
+    /// Deno runtime configuration.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deno: Option<DenoMetadata>,
+}
+
+/// UV inline dependency metadata (`metadata.runt.uv`).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct UvInlineMetadata {
+    /// PEP 508 dependency specifiers (e.g. `["pandas>=2.0", "numpy"]`).
+    #[serde(default)]
+    pub dependencies: Vec<String>,
+
+    /// Python version constraint (e.g. `">=3.10"`).
+    #[serde(
+        rename = "requires-python",
+        skip_serializing_if = "Option::is_none",
+        default
+    )]
+    pub requires_python: Option<String>,
+}
+
+/// Conda inline dependency metadata (`metadata.runt.conda`).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CondaInlineMetadata {
+    /// Conda package names (e.g. `["numpy", "scipy"]`).
+    #[serde(default)]
+    pub dependencies: Vec<String>,
+
+    /// Conda channels to search (e.g. `["conda-forge"]`).
+    #[serde(default)]
+    pub channels: Vec<String>,
+
+    /// Explicit Python version for the conda environment.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub python: Option<String>,
+}
+
+/// Deno runtime configuration (`metadata.runt.deno`).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct DenoMetadata {
+    /// Deno permission flags (e.g. `["--allow-read", "--allow-write"]`).
+    #[serde(default)]
+    pub permissions: Vec<String>,
+}
+
+// ── Notebook-level metadata snapshot ─────────────────────────────────
+
+/// Snapshot of notebook-level metadata for Automerge sync.
+///
+/// Covers kernelspec + language_info + runt namespace — everything needed for
+/// kernel detection and environment resolution. Serialized as JSON and stored
+/// in the Automerge document under `metadata.notebook_metadata`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct NotebookMetadataSnapshot {
+    /// Jupyter kernel specification (runtime type detection).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kernelspec: Option<KernelspecSnapshot>,
+
+    /// Language information (set by the kernel after startup).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub language_info: Option<LanguageInfoSnapshot>,
+
+    /// Runt-specific metadata (dependencies, trust, environment config).
+    pub runt: RuntMetadata,
+}
+
+/// Kernelspec snapshot for Automerge sync.
+///
+/// Mirrors the standard Jupyter `kernelspec` metadata fields.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct KernelspecSnapshot {
+    /// Kernel name (e.g. `"python3"`, `"deno"`).
+    pub name: String,
+    /// Human-readable display name (e.g. `"Python 3"`, `"Deno"`).
+    pub display_name: String,
+    /// Programming language (e.g. `"python"`, `"typescript"`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub language: Option<String>,
+}
+
+/// Language info snapshot for Automerge sync.
+///
+/// Mirrors the standard Jupyter `language_info` metadata fields (subset).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct LanguageInfoSnapshot {
+    /// Language name (e.g. `"python"`, `"typescript"`).
+    pub name: String,
+    /// Language version (e.g. `"3.11.5"`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+}
+
+// ── Conversions to/from serde_json::Value ────────────────────────────
+
+impl NotebookMetadataSnapshot {
+    /// Build a snapshot from a raw `serde_json::Value` representing the full
+    /// notebook-level metadata object (as read from an `.ipynb` file).
+    ///
+    /// Extracts `kernelspec`, `language_info`, and `runt` (with fallback to
+    /// legacy `uv`/`conda` top-level keys).
+    pub fn from_metadata_value(metadata: &serde_json::Value) -> Self {
+        let kernelspec = metadata
+            .get("kernelspec")
+            .and_then(|v| serde_json::from_value::<KernelspecSnapshot>(v.clone()).ok());
+
+        let language_info = metadata
+            .get("language_info")
+            .and_then(|v| serde_json::from_value::<LanguageInfoSnapshot>(v.clone()).ok());
+
+        let runt = metadata
+            .get("runt")
+            .and_then(|v| serde_json::from_value::<RuntMetadata>(v.clone()).ok())
+            .unwrap_or_else(|| {
+                // Fallback: try legacy top-level uv/conda keys
+                let uv = metadata
+                    .get("uv")
+                    .and_then(|v| serde_json::from_value::<UvInlineMetadata>(v.clone()).ok());
+                let conda = metadata
+                    .get("conda")
+                    .and_then(|v| serde_json::from_value::<CondaInlineMetadata>(v.clone()).ok());
+
+                RuntMetadata {
+                    schema_version: "1".to_string(),
+                    env_id: None,
+                    uv,
+                    conda,
+                    deno: None,
+                }
+            });
+
+        NotebookMetadataSnapshot {
+            kernelspec,
+            language_info,
+            runt,
+        }
+    }
+
+    /// Merge this snapshot into a mutable JSON object representing the full
+    /// notebook metadata. Replaces `kernelspec`, `language_info`, and `runt`
+    /// while preserving all other keys.
+    pub fn merge_into_metadata_value(&self, metadata: &mut serde_json::Value) {
+        let obj = match metadata.as_object_mut() {
+            Some(o) => o,
+            None => return,
+        };
+
+        // Replace kernelspec
+        match &self.kernelspec {
+            Some(ks) => {
+                if let Ok(v) = serde_json::to_value(ks) {
+                    obj.insert("kernelspec".to_string(), v);
+                }
+            }
+            None => {
+                obj.remove("kernelspec");
+            }
+        }
+
+        // Replace language_info
+        match &self.language_info {
+            Some(li) => {
+                if let Ok(v) = serde_json::to_value(li) {
+                    obj.insert("language_info".to_string(), v);
+                }
+            }
+            None => {
+                obj.remove("language_info");
+            }
+        }
+
+        // Replace runt namespace
+        if let Ok(v) = serde_json::to_value(&self.runt) {
+            obj.insert("runt".to_string(), v);
+        }
+    }
+}
+
+impl RuntMetadata {
+    /// Create a default RuntMetadata with UV configuration.
+    pub fn new_uv(env_id: String) -> Self {
+        RuntMetadata {
+            schema_version: "1".to_string(),
+            env_id: Some(env_id),
+            uv: Some(UvInlineMetadata {
+                dependencies: Vec::new(),
+                requires_python: None,
+            }),
+            conda: None,
+            deno: None,
+        }
+    }
+
+    /// Create a default RuntMetadata with Conda configuration.
+    pub fn new_conda(env_id: String) -> Self {
+        RuntMetadata {
+            schema_version: "1".to_string(),
+            env_id: Some(env_id),
+            uv: None,
+            conda: Some(CondaInlineMetadata {
+                dependencies: Vec::new(),
+                channels: vec!["conda-forge".to_string()],
+                python: None,
+            }),
+            deno: None,
+        }
+    }
+
+    /// Create a default RuntMetadata for Deno runtime.
+    pub fn new_deno(env_id: String) -> Self {
+        RuntMetadata {
+            schema_version: "1".to_string(),
+            env_id: Some(env_id),
+            uv: None,
+            conda: None,
+            deno: Some(DenoMetadata {
+                permissions: Vec::new(),
+            }),
+        }
+    }
+}
+
+// ── Automerge document key ───────────────────────────────────────────
+
+/// The key used to store the serialized `NotebookMetadataSnapshot` in the
+/// Automerge document's `metadata` map.
+pub const NOTEBOOK_METADATA_KEY: &str = "notebook_metadata";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_runt_metadata_uv_roundtrip() {
+        let meta = RuntMetadata::new_uv("test-env-id".to_string());
+        let json = serde_json::to_string(&meta).unwrap();
+        let parsed: RuntMetadata = serde_json::from_str(&json).unwrap();
+        assert_eq!(meta, parsed);
+        assert_eq!(parsed.uv.as_ref().unwrap().dependencies.len(), 0);
+    }
+
+    #[test]
+    fn test_runt_metadata_conda_roundtrip() {
+        let meta = RuntMetadata::new_conda("test-env-id".to_string());
+        let json = serde_json::to_string(&meta).unwrap();
+        let parsed: RuntMetadata = serde_json::from_str(&json).unwrap();
+        assert_eq!(meta, parsed);
+        assert_eq!(parsed.conda.as_ref().unwrap().channels, vec!["conda-forge"]);
+    }
+
+    #[test]
+    fn test_runt_metadata_deno_roundtrip() {
+        let meta = RuntMetadata::new_deno("test-env-id".to_string());
+        let json = serde_json::to_string(&meta).unwrap();
+        let parsed: RuntMetadata = serde_json::from_str(&json).unwrap();
+        assert_eq!(meta, parsed);
+        assert!(parsed.deno.is_some());
+    }
+
+    #[test]
+    fn test_snapshot_roundtrip() {
+        let snapshot = NotebookMetadataSnapshot {
+            kernelspec: Some(KernelspecSnapshot {
+                name: "python3".to_string(),
+                display_name: "Python 3".to_string(),
+                language: Some("python".to_string()),
+            }),
+            language_info: Some(LanguageInfoSnapshot {
+                name: "python".to_string(),
+                version: Some("3.11.5".to_string()),
+            }),
+            runt: RuntMetadata {
+                schema_version: "1".to_string(),
+                env_id: Some("abc-123".to_string()),
+                uv: Some(UvInlineMetadata {
+                    dependencies: vec!["pandas>=2.0".to_string(), "numpy".to_string()],
+                    requires_python: Some(">=3.10".to_string()),
+                }),
+                conda: None,
+                deno: None,
+            },
+        };
+
+        let json = serde_json::to_string(&snapshot).unwrap();
+        let parsed: NotebookMetadataSnapshot = serde_json::from_str(&json).unwrap();
+        assert_eq!(snapshot, parsed);
+    }
+
+    #[test]
+    fn test_snapshot_from_metadata_value() {
+        let metadata = serde_json::json!({
+            "kernelspec": {
+                "name": "python3",
+                "display_name": "Python 3",
+                "language": "python"
+            },
+            "runt": {
+                "schema_version": "1",
+                "env_id": "abc-123",
+                "uv": {
+                    "dependencies": ["pandas"],
+                    "requires-python": ">=3.10"
+                }
+            },
+            "jupyter": {
+                "some_custom_field": true
+            }
+        });
+
+        let snapshot = NotebookMetadataSnapshot::from_metadata_value(&metadata);
+        assert_eq!(snapshot.kernelspec.as_ref().unwrap().name, "python3");
+        assert_eq!(snapshot.runt.schema_version, "1");
+        assert_eq!(
+            snapshot.runt.uv.as_ref().unwrap().dependencies,
+            vec!["pandas"]
+        );
+    }
+
+    #[test]
+    fn test_snapshot_from_legacy_metadata() {
+        // Legacy format: uv at top level instead of inside runt
+        let metadata = serde_json::json!({
+            "kernelspec": {
+                "name": "python3",
+                "display_name": "Python 3"
+            },
+            "uv": {
+                "dependencies": ["requests"],
+                "requires-python": ">=3.9"
+            }
+        });
+
+        let snapshot = NotebookMetadataSnapshot::from_metadata_value(&metadata);
+        assert_eq!(
+            snapshot.runt.uv.as_ref().unwrap().dependencies,
+            vec!["requests"]
+        );
+        assert_eq!(snapshot.runt.schema_version, "1");
+    }
+
+    #[test]
+    fn test_merge_into_preserves_unknown_keys() {
+        let mut metadata = serde_json::json!({
+            "kernelspec": {
+                "name": "old_kernel",
+                "display_name": "Old"
+            },
+            "jupyter": {
+                "some_custom_field": true
+            },
+            "custom_extension": "preserved"
+        });
+
+        let snapshot = NotebookMetadataSnapshot {
+            kernelspec: Some(KernelspecSnapshot {
+                name: "python3".to_string(),
+                display_name: "Python 3".to_string(),
+                language: Some("python".to_string()),
+            }),
+            language_info: None,
+            runt: RuntMetadata::new_uv("env-1".to_string()),
+        };
+
+        snapshot.merge_into_metadata_value(&mut metadata);
+
+        // Kernelspec was replaced
+        assert_eq!(metadata["kernelspec"]["name"], "python3");
+        // language_info was removed (snapshot has None)
+        assert!(metadata.get("language_info").is_none());
+        // Unknown keys preserved
+        assert_eq!(metadata["jupyter"]["some_custom_field"], true);
+        assert_eq!(metadata["custom_extension"], "preserved");
+        // Runt was added
+        assert_eq!(metadata["runt"]["schema_version"], "1");
+    }
+
+    #[test]
+    fn test_skip_serializing_none_fields() {
+        let meta = RuntMetadata {
+            schema_version: "1".to_string(),
+            env_id: None,
+            uv: None,
+            conda: None,
+            deno: None,
+        };
+        let json = serde_json::to_value(&meta).unwrap();
+        // None fields should not appear in JSON
+        assert!(!json.as_object().unwrap().contains_key("env_id"));
+        assert!(!json.as_object().unwrap().contains_key("uv"));
+        assert!(!json.as_object().unwrap().contains_key("conda"));
+        assert!(!json.as_object().unwrap().contains_key("deno"));
+        // schema_version should always be present
+        assert!(json.as_object().unwrap().contains_key("schema_version"));
+    }
+}

--- a/crates/runtimed/src/notebook_sync_client.rs
+++ b/crates/runtimed/src/notebook_sync_client.rs
@@ -19,11 +19,15 @@ use automerge::transaction::Transactable;
 use automerge::{AutoCommit, ObjType, ReadDoc};
 use futures::FutureExt;
 use log::{info, warn};
+use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::sync::{mpsc, oneshot};
 
 use crate::connection::{self, Handshake, NotebookFrameType, ProtocolCapabilities, PROTOCOL_V2};
-use crate::notebook_doc::{get_cells_from_doc, CellSnapshot};
+use crate::notebook_doc::{
+    get_cells_from_doc, get_metadata_from_doc, set_metadata_in_doc, CellSnapshot,
+};
+use crate::notebook_metadata::NOTEBOOK_METADATA_KEY;
 use crate::protocol::{NotebookBroadcast, NotebookRequest, NotebookResponse};
 
 /// Error type for notebook sync client operations.
@@ -82,6 +86,17 @@ enum SyncCommand {
     },
     GetCells {
         reply: oneshot::Sender<Vec<CellSnapshot>>,
+    },
+    /// Set a metadata value in the Automerge doc and sync to daemon.
+    SetMetadata {
+        key: String,
+        value: String,
+        reply: oneshot::Sender<Result<(), NotebookSyncError>>,
+    },
+    /// Read a metadata value from the local Automerge doc replica.
+    GetMetadata {
+        key: String,
+        reply: oneshot::Sender<Option<String>>,
     },
     /// Send a request to the daemon and wait for a response.
     /// Only works with v2 protocol; returns error on v1.
@@ -229,6 +244,35 @@ impl NotebookSyncHandle {
             .map_err(|_| NotebookSyncError::ChannelClosed)?
     }
 
+    /// Set a metadata value in the Automerge doc and sync to daemon.
+    pub async fn set_metadata(&self, key: &str, value: &str) -> Result<(), NotebookSyncError> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.tx
+            .send(SyncCommand::SetMetadata {
+                key: key.to_string(),
+                value: value.to_string(),
+                reply: reply_tx,
+            })
+            .await
+            .map_err(|_| NotebookSyncError::ChannelClosed)?;
+        reply_rx
+            .await
+            .map_err(|_| NotebookSyncError::ChannelClosed)?
+    }
+
+    /// Read a metadata value from the local Automerge doc replica.
+    pub async fn get_metadata(&self, key: &str) -> Result<Option<String>, NotebookSyncError> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.tx
+            .send(SyncCommand::GetMetadata {
+                key: key.to_string(),
+                reply: reply_tx,
+            })
+            .await
+            .map_err(|_| NotebookSyncError::ChannelClosed)?;
+        reply_rx.await.map_err(|_| NotebookSyncError::ChannelClosed)
+    }
+
     /// Send a request to the daemon and wait for a response.
     ///
     /// This only works with v2 protocol. If the daemon is running v1,
@@ -253,17 +297,29 @@ impl NotebookSyncHandle {
 
 /// Receiver for incoming changes from other peers.
 ///
+/// An update received from the Automerge sync protocol.
+///
+/// Contains cells (always present after any sync) and optionally the
+/// notebook metadata snapshot if it changed.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SyncUpdate {
+    /// Current cell state after applying the sync message.
+    pub cells: Vec<CellSnapshot>,
+    /// JSON-serialized `NotebookMetadataSnapshot`, present when metadata changed.
+    pub notebook_metadata: Option<String>,
+}
+
 /// This is separate from the handle to allow receiving changes independently
 /// of sending commands. Call `recv()` to wait for the next batch of changes.
 pub struct NotebookSyncReceiver {
-    rx: mpsc::Receiver<Vec<CellSnapshot>>,
+    rx: mpsc::Receiver<SyncUpdate>,
 }
 
 impl NotebookSyncReceiver {
-    /// Wait for the next batch of changes from other peers.
+    /// Wait for the next sync update from other peers.
     ///
     /// Returns `None` if the sync task has stopped.
-    pub async fn recv(&mut self) -> Option<Vec<CellSnapshot>> {
+    pub async fn recv(&mut self) -> Option<SyncUpdate> {
         self.rx.recv().await
     }
 }
@@ -346,6 +402,7 @@ impl NotebookSyncClient<tokio::net::UnixStream> {
             NotebookSyncReceiver,
             NotebookBroadcastReceiver,
             Vec<CellSnapshot>,
+            Option<String>,
         ),
         NotebookSyncError,
     > {
@@ -378,6 +435,7 @@ impl NotebookSyncClient<tokio::net::windows::named_pipe::NamedPipeClient> {
             NotebookSyncReceiver,
             NotebookBroadcastReceiver,
             Vec<CellSnapshot>,
+            Option<String>,
         ),
         NotebookSyncError,
     > {
@@ -604,7 +662,19 @@ where
         self.get_cells().into_iter().find(|c| c.id == cell_id)
     }
 
+    /// Read a metadata value from the local Automerge doc replica.
+    pub fn get_metadata(&self, key: &str) -> Option<String> {
+        get_metadata_from_doc(&self.doc, key)
+    }
+
     // ── Write operations (mutate local + sync) ──────────────────────
+
+    /// Set a metadata value and sync to daemon.
+    pub async fn set_metadata(&mut self, key: &str, value: &str) -> Result<(), NotebookSyncError> {
+        set_metadata_in_doc(&mut self.doc, key, value)
+            .map_err(|e| NotebookSyncError::SyncError(format!("set_metadata: {}", e)))?;
+        self.sync_to_daemon().await
+    }
 
     /// Add a new cell at the given index and sync to daemon.
     pub async fn add_cell(
@@ -1204,9 +1274,10 @@ where
     ///
     /// Returns:
     /// - `NotebookSyncHandle`: Clonable handle for sending commands
-    /// - `NotebookSyncReceiver`: Receiver for changes from other peers
+    /// - `NotebookSyncReceiver`: Receiver for sync updates from other peers
     /// - `NotebookBroadcastReceiver`: Receiver for kernel broadcast events
     /// - `Vec<CellSnapshot>`: Initial cells after sync
+    /// - `Option<String>`: Initial notebook metadata JSON (if present)
     ///
     /// The client is consumed and a background task is spawned to process
     /// both commands and incoming changes concurrently.
@@ -1217,16 +1288,18 @@ where
         NotebookSyncReceiver,
         NotebookBroadcastReceiver,
         Vec<CellSnapshot>,
+        Option<String>,
     ) {
         let initial_cells = self.get_cells();
+        let initial_metadata = self.get_metadata(NOTEBOOK_METADATA_KEY);
         let notebook_id = self.notebook_id.clone();
         let pending_broadcasts = self.pending_broadcasts.clone();
 
         // Channel for commands from handles
         let (cmd_tx, cmd_rx) = mpsc::channel::<SyncCommand>(32);
 
-        // Channel for changes to receivers
-        let (changes_tx, changes_rx) = mpsc::channel::<Vec<CellSnapshot>>(32);
+        // Channel for sync updates to receivers
+        let (changes_tx, changes_rx) = mpsc::channel::<SyncUpdate>(32);
 
         // Channel for kernel broadcasts
         let (broadcast_tx, broadcast_rx) = mpsc::channel::<NotebookBroadcast>(64);
@@ -1290,7 +1363,13 @@ where
         let receiver = NotebookSyncReceiver { rx: changes_rx };
         let broadcast_receiver = NotebookBroadcastReceiver { rx: broadcast_rx };
 
-        (handle, receiver, broadcast_receiver, initial_cells)
+        (
+            handle,
+            receiver,
+            broadcast_receiver,
+            initial_cells,
+            initial_metadata,
+        )
     }
 }
 
@@ -1298,7 +1377,7 @@ where
 async fn run_sync_task<S>(
     mut client: NotebookSyncClient<S>,
     mut cmd_rx: mpsc::Receiver<SyncCommand>,
-    changes_tx: mpsc::Sender<Vec<CellSnapshot>>,
+    changes_tx: mpsc::Sender<SyncUpdate>,
     broadcast_tx: mpsc::Sender<NotebookBroadcast>,
 ) where
     S: AsyncRead + AsyncWrite + Unpin,
@@ -1351,6 +1430,14 @@ async fn run_sync_task<S>(
                                 let cells = client.get_cells();
                                 let _ = reply.send(cells);
                             }
+                            SyncCommand::SetMetadata { key, value, reply } => {
+                                let result = client.set_metadata(&key, &value).await;
+                                let _ = reply.send(result);
+                            }
+                            SyncCommand::GetMetadata { key, reply } => {
+                                let result = client.get_metadata(&key);
+                                let _ = reply.send(result);
+                            }
                             SyncCommand::SendRequest { request, reply } => {
                                 let result = client.send_request(&request).await;
                                 let _ = reply.send(result);
@@ -1376,8 +1463,13 @@ async fn run_sync_task<S>(
                     client.recv_frame_any()
                 ).await {
                     Ok(Ok(Some(ReceivedFrame::Changes(cells)))) => {
-                        // Got changes from another peer
-                        if changes_tx.send(cells).await.is_err() {
+                        // Got changes from another peer — include metadata
+                        let notebook_metadata = client.get_metadata(NOTEBOOK_METADATA_KEY);
+                        let update = SyncUpdate {
+                            cells,
+                            notebook_metadata,
+                        };
+                        if changes_tx.send(update).await.is_err() {
                             info!(
                                 "[notebook-sync-task] Changes receiver dropped for {}, loop_count={}",
                                 notebook_id, loop_count

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -1689,6 +1689,182 @@ async fn handle_notebook_request(
                 NotebookResponse::NoKernel {}
             }
         }
+
+        NotebookRequest::SaveNotebook { format_cells: _ } => {
+            // TODO: format_cells support (requires ruff/deno formatter access)
+            match save_notebook_to_disk(room).await {
+                Ok(()) => NotebookResponse::NotebookSaved {},
+                Err(e) => NotebookResponse::Error {
+                    error: format!("Failed to save notebook: {}", e),
+                },
+            }
+        }
+    }
+}
+
+/// Save the notebook from the Automerge doc to disk as .ipynb.
+///
+/// 1. Read existing .ipynb from disk (if it exists) to preserve unknown metadata
+/// 2. Read cells and metadata from the Automerge doc
+/// 3. Merge metadata: replace kernelspec, language_info, runt; preserve everything else
+/// 4. Reconstruct cells: source and outputs from Automerge, cell metadata from existing file
+/// 5. Write the merged notebook to disk
+async fn save_notebook_to_disk(room: &NotebookRoom) -> Result<(), String> {
+    let notebook_path = &room.notebook_path;
+
+    // Read existing .ipynb to preserve unknown metadata and cell metadata
+    let existing: Option<serde_json::Value> = std::fs::read_to_string(notebook_path)
+        .ok()
+        .and_then(|content| serde_json::from_str(&content).ok());
+
+    // Read cells and metadata from the Automerge doc
+    let (cells, metadata_json) = {
+        let doc = room.doc.read().await;
+        let cells = doc.get_cells();
+        let metadata_json = doc.get_metadata("notebook_metadata");
+        (cells, metadata_json)
+    };
+
+    // Build existing cell metadata index (cell_id -> cell metadata from .ipynb)
+    let existing_cell_metadata: HashMap<String, serde_json::Value> = existing
+        .as_ref()
+        .and_then(|nb| nb.get("cells"))
+        .and_then(|c| c.as_array())
+        .map(|cells_arr| {
+            cells_arr
+                .iter()
+                .filter_map(|cell| {
+                    let id = cell.get("id").and_then(|v| v.as_str())?;
+                    let meta = cell
+                        .get("metadata")
+                        .cloned()
+                        .unwrap_or(serde_json::json!({}));
+                    Some((id.to_string(), meta))
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    // Reconstruct cells as JSON
+    let mut nb_cells = Vec::new();
+    for cell in &cells {
+        let cell_meta = existing_cell_metadata
+            .get(&cell.id)
+            .cloned()
+            .unwrap_or(serde_json::json!({}));
+
+        // Parse source into multiline array format (split_inclusive('\n'))
+        let source_lines: Vec<String> = if cell.source.is_empty() {
+            vec![]
+        } else {
+            let mut lines = Vec::new();
+            let mut remaining = cell.source.as_str();
+            while let Some(pos) = remaining.find('\n') {
+                lines.push(remaining[..=pos].to_string());
+                remaining = &remaining[pos + 1..];
+            }
+            if !remaining.is_empty() {
+                lines.push(remaining.to_string());
+            }
+            lines
+        };
+
+        let mut cell_json = serde_json::json!({
+            "id": cell.id,
+            "cell_type": cell.cell_type,
+            "source": source_lines,
+            "metadata": cell_meta,
+        });
+
+        if cell.cell_type == "code" {
+            // Resolve outputs (may be manifest hashes or raw JSON)
+            let mut resolved_outputs = Vec::new();
+            for output_str in &cell.outputs {
+                let output_value = resolve_cell_output(output_str, &room.blob_store).await;
+                resolved_outputs.push(output_value);
+            }
+            cell_json["outputs"] = serde_json::Value::Array(resolved_outputs);
+
+            // Parse execution_count
+            let exec_count: serde_json::Value =
+                serde_json::from_str(&cell.execution_count).unwrap_or(serde_json::Value::Null);
+            cell_json["execution_count"] = exec_count;
+        }
+
+        nb_cells.push(cell_json);
+    }
+
+    // Build metadata by merging synced snapshot onto existing
+    let mut metadata = existing
+        .as_ref()
+        .and_then(|nb| nb.get("metadata"))
+        .cloned()
+        .unwrap_or(serde_json::json!({}));
+
+    if let Some(ref meta_json) = metadata_json {
+        if let Ok(snapshot) =
+            serde_json::from_str::<crate::notebook_metadata::NotebookMetadataSnapshot>(meta_json)
+        {
+            snapshot.merge_into_metadata_value(&mut metadata);
+        }
+    }
+
+    // Build the final notebook JSON
+    let nbformat_minor = existing
+        .as_ref()
+        .and_then(|nb| nb.get("nbformat_minor"))
+        .cloned()
+        .unwrap_or(serde_json::json!(5));
+
+    let notebook_json = serde_json::json!({
+        "nbformat": 4,
+        "nbformat_minor": nbformat_minor,
+        "metadata": metadata,
+        "cells": nb_cells,
+    });
+
+    // Serialize with trailing newline (nbformat convention)
+    let content = serde_json::to_string_pretty(&notebook_json)
+        .map_err(|e| format!("Failed to serialize notebook: {}", e))?;
+    let content_with_newline = format!("{}\n", content);
+
+    // Write to disk
+    std::fs::write(notebook_path, content_with_newline)
+        .map_err(|e| format!("Failed to write notebook: {}", e))?;
+
+    info!(
+        "[notebook-sync] Saved notebook to disk: {:?} ({} cells)",
+        notebook_path,
+        nb_cells.len()
+    );
+
+    Ok(())
+}
+
+/// Resolve a single cell output — handles both manifest hashes and raw JSON.
+async fn resolve_cell_output(output_str: &str, blob_store: &BlobStore) -> serde_json::Value {
+    // Check if it's a manifest hash (64-char hex string)
+    if output_str.len() == 64 && output_str.chars().all(|c| c.is_ascii_hexdigit()) {
+        // Try to fetch manifest from blob store
+        if let Ok(Some(manifest_bytes)) = blob_store.get(output_str).await {
+            if let Ok(manifest_json) = String::from_utf8(manifest_bytes) {
+                // Resolve the manifest to full Jupyter output
+                if let Ok(resolved) =
+                    crate::output_store::resolve_manifest(&manifest_json, blob_store).await
+                {
+                    return resolved;
+                }
+            }
+        }
+        // If resolution fails, return empty output
+        warn!(
+            "[notebook-sync] Failed to resolve output manifest: {}",
+            &output_str[..8]
+        );
+        serde_json::json!({"output_type": "stream", "name": "stderr", "text": ["[output could not be resolved]"]})
+    } else {
+        // Raw JSON output
+        serde_json::from_str(output_str).unwrap_or(serde_json::json!({}))
     }
 }
 

--- a/crates/runtimed/src/protocol.rs
+++ b/crates/runtimed/src/protocol.rs
@@ -205,6 +205,15 @@ pub enum NotebookRequest {
         /// Cursor position in the code
         cursor_pos: usize,
     },
+
+    /// Save the notebook to disk.
+    /// The daemon reads cells and metadata from the Automerge doc, merges
+    /// with any existing .ipynb on disk (to preserve unknown metadata keys),
+    /// and writes the result.
+    SaveNotebook {
+        /// If true, format code cells before saving (e.g., with ruff).
+        format_cells: bool,
+    },
 }
 
 /// Responses from daemon to notebook app.
@@ -255,6 +264,9 @@ pub enum NotebookResponse {
     AllCellsQueued {
         count: usize, // number of code cells queued
     },
+
+    /// Notebook saved successfully to disk.
+    NotebookSaved {},
 
     /// Generic success.
     Ok {},


### PR DESCRIPTION
## Summary

This PR extends the notebook sync system to include metadata synchronization alongside cell content. Notebook-level metadata (kernelspec, language_info, and environment configuration) is now synced through the Automerge document, ensuring all connected windows and the daemon stay in sync when dependencies or kernel settings change.

## Key Changes

- **New `notebook_metadata` module** (`crates/runtimed/src/notebook_metadata.rs`): Defines typed structs for syncing notebook metadata (`NotebookMetadataSnapshot`, `RuntMetadata`, `KernelspecSnapshot`, `LanguageInfoSnapshot`) with serialization/deserialization and merge semantics for preserving unknown metadata fields.

- **Metadata sync in client initialization** (`crates/notebook/src/lib.rs`):
  - `initialize_notebook_sync` now receives `initial_metadata` from the sync client
  - When creating a new room, metadata is pushed to the Automerge doc via `handle.set_metadata()`
  - When joining an existing room, metadata from the doc is merged into local state
  - Receiver loop now handles `SyncUpdate` (containing both cells and optional metadata) and emits `notebook:metadata_updated` events

- **New `push_metadata_to_sync()` helper**: Serializes current notebook metadata and pushes it to the daemon via the sync handle. Called after any metadata mutation (dependencies, kernelspec changes).

- **Dependency command updates**: All dependency-related commands (`set_notebook_dependencies`, `add_dependency`, `remove_dependency`, `clear_dependency_section`, `set_conda_dependencies`, `add_conda_dependency`, `remove_conda_dependency`) now call `push_metadata_to_sync()` after modifying metadata to ensure changes propagate to other windows.

- **Daemon-side save support** (`crates/runtimed/src/notebook_sync_server.rs`):
  - New `SaveNotebook` request type in protocol
  - `save_notebook_to_disk()` reads cells and metadata from Automerge doc, merges with existing .ipynb file (preserving unknown metadata), and writes to disk
  - Reconstructs cells with proper source formatting and resolves output manifests

- **Enhanced sync client** (`crates/runtimed/src/notebook_sync_client.rs`):
  - `SyncUpdate` struct now carries both cells and optional `notebook_metadata` JSON
  - New `set_metadata()` and `get_metadata()` methods on `NotebookSyncHandle`
  - Metadata changes are tracked and included in sync updates

- **Notebook save refactor** (`crates/notebook/src/lib.rs`):
  - `save_notebook()` now attempts daemon save first (which merges synced metadata with file content)
  - Falls back to local save if daemon is unavailable
  - Ensures metadata is pushed to sync before saving

- **Frontend event listeners** (`apps/notebook/src/hooks/useDependencies.ts`, `useCondaDependencies.ts`): Added listeners for `notebook:metadata_updated` event to refresh dependency state when metadata changes from other windows.

- **Conversion utilities** (`crates/notebook/src/notebook_state.rs`): New `snapshot_from_nbformat()` and `merge_snapshot_into_nbformat()` functions to convert between nbformat metadata and the sync snapshot format.

## Implementation Details

- Metadata is stored as a JSON string under the `metadata.notebook_metadata` key in the Automerge document
- Merge strategy preserves unknown metadata fields by reading existing .ipynb, extracting only kernelspec/language_info/runt, and merging back
- All metadata mutations are now lock-scoped to minimize contention before pushing to sync
- Daemon save is the primary path; local save is a fallback for robustness
