### PR TITLE
feat(runtimed-py): introduce Python bindings for daemon client

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -507,3 +507,58 @@ jobs:
           name: e2e-fixture-logs
           path: e2e-logs/
           retention-days: 7
+
+  # Python daemon integration tests
+  runtimed-py-integration:
+    name: runtimed-py Integration Tests
+    runs-on: ubuntu-latest
+    needs: [build]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libxdo-dev
+
+      - name: Install rust
+        uses: dsherret/rust-toolchain-file@v1
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ubuntu-latest
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Build runtimed binary
+        run: cargo build --release -p runtimed
+
+      - name: Build runtimed-py
+        working-directory: python/runtimed
+        run: uv run maturin develop --manifest-path ../../crates/runtimed-py/Cargo.toml
+
+      - name: Run integration tests
+        timeout-minutes: 10
+        working-directory: python/runtimed
+        run: |
+          mkdir -p integration-logs
+
+          # Set environment for CI mode
+          export RUNTIMED_INTEGRATION_TEST=1
+          export RUNTIMED_BINARY="${GITHUB_WORKSPACE}/target/release/runtimed"
+          export RUNTIMED_LOG_LEVEL=debug
+          export CONDUCTOR_WORKSPACE_PATH="${GITHUB_WORKSPACE}"
+
+          # Run tests (daemon is spawned by the test fixture)
+          uv run pytest tests/test_daemon_integration.py -v --tb=short 2>&1 | tee integration-logs/test-output.log || FAIL=1
+
+          exit ${FAIL:-0}
+
+      - name: Upload test logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: runtimed-py-integration-logs
+          path: python/runtimed/integration-logs/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ __pycache__/
 **/__pycache__/
 *.pyc
 *.pyo
+*.so
 *.egg-info/
 **/*.egg-info/
 .venv/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -647,7 +647,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02"
 dependencies = [
  "smallvec",
- "target-lexicon",
+ "target-lexicon 0.12.16",
 ]
 
 [[package]]
@@ -4164,6 +4164,78 @@ dependencies = [
 ]
 
 [[package]]
+name = "pyo3"
+version = "0.28.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf85e27e86080aafd5a22eae58a162e133a589551542b3e5cee4beb27e54f8e1"
+dependencies = [
+ "libc",
+ "once_cell",
+ "portable-atomic",
+ "pyo3-build-config",
+ "pyo3-ffi",
+ "pyo3-macros",
+]
+
+[[package]]
+name = "pyo3-async-runtimes"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e7364a95bf00e8377bbf9b0f09d7ff9715a29d8fcf93b47d1a967363b973178"
+dependencies = [
+ "futures-channel",
+ "futures-util",
+ "once_cell",
+ "pin-project-lite",
+ "pyo3",
+ "tokio",
+]
+
+[[package]]
+name = "pyo3-build-config"
+version = "0.28.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bf94ee265674bf76c09fa430b0e99c26e319c945d96ca0d5a8215f31bf81cf7"
+dependencies = [
+ "target-lexicon 0.13.5",
+]
+
+[[package]]
+name = "pyo3-ffi"
+version = "0.28.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "491aa5fc66d8059dd44a75f4580a2962c1862a1c2945359db36f6c2818b748dc"
+dependencies = [
+ "libc",
+ "pyo3-build-config",
+]
+
+[[package]]
+name = "pyo3-macros"
+version = "0.28.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5d671734e9d7a43449f8480f8b38115df67bef8d21f76837fa75ee7aaa5e52e"
+dependencies = [
+ "proc-macro2",
+ "pyo3-macros-backend",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "pyo3-macros-backend"
+version = "0.28.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22faaa1ce6c430a1f71658760497291065e6450d7b5dc2bcf254d49f66ee700a"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "pyo3-build-config",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "pyproject-toml"
 version = "0.13.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5197,6 +5269,21 @@ dependencies = [
  "ts-rs",
  "uuid",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "runtimed-py"
+version = "0.1.0"
+dependencies = [
+ "log",
+ "pyo3",
+ "pyo3-async-runtimes",
+ "reqwest 0.12.28",
+ "runtimed",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "uuid",
 ]
 
 [[package]]
@@ -6250,6 +6337,12 @@ name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
+name = "target-lexicon"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tauri"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "crates/tauri-jupyter",
     "crates/xtask",
     "crates/runtimed",
+    "crates/runtimed-py",
 ]
 default-members = ["crates/notebook"]
 resolver = "2"

--- a/crates/runtimed-py/Cargo.toml
+++ b/crates/runtimed-py/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "runtimed-py"
+version = "0.1.0"
+edition = "2021"
+description = "Python bindings for runtimed daemon client"
+repository.workspace = true
+license.workspace = true
+publish = false
+
+[lib]
+name = "runtimed"
+crate-type = ["cdylib"]
+
+[dependencies]
+pyo3 = { version = "0.28", features = ["extension-module"] }
+pyo3-async-runtimes = { version = "0.28", features = ["tokio-runtime"] }
+runtimed = { path = "../runtimed" }
+tokio = { version = "1", features = ["full"] }
+serde_json = { workspace = true }
+uuid = { workspace = true }
+log = "0.4"
+thiserror = { workspace = true }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }

--- a/crates/runtimed-py/src/client.rs
+++ b/crates/runtimed-py/src/client.rs
@@ -1,0 +1,136 @@
+//! DaemonClient for pool operations.
+//!
+//! Provides access to daemon status, pool information, and room listing.
+
+use pyo3::prelude::*;
+use pyo3::types::PyDict;
+use tokio::runtime::Runtime;
+
+use crate::error::to_py_err;
+
+/// Client for communicating with the runtimed daemon.
+///
+/// Provides synchronous access to daemon operations. Uses an internal
+/// tokio runtime to execute async operations.
+///
+/// Example:
+///     client = DaemonClient()
+///     if client.ping():
+///         status = client.status()
+///         print(f"UV available: {status['uv_available']}")
+#[pyclass]
+pub struct DaemonClient {
+    runtime: Runtime,
+    client: runtimed::client::PoolClient,
+}
+
+#[pymethods]
+impl DaemonClient {
+    /// Create a new daemon client.
+    ///
+    /// Connects to the daemon at the default socket path, which is
+    /// automatically determined based on environment variables
+    /// (CONDUCTOR_WORKSPACE_PATH for dev mode).
+    #[new]
+    fn new() -> PyResult<Self> {
+        let runtime = Runtime::new().map_err(to_py_err)?;
+        let client = runtimed::client::PoolClient::default();
+        Ok(Self { runtime, client })
+    }
+
+    /// Ping the daemon to check if it's alive.
+    ///
+    /// Returns True if the daemon responded, False otherwise.
+    fn ping(&self) -> bool {
+        self.runtime.block_on(self.client.ping()).is_ok()
+    }
+
+    /// Check if the daemon is running.
+    fn is_running(&self) -> bool {
+        self.runtime.block_on(self.client.is_daemon_running())
+    }
+
+    /// Get pool statistics.
+    ///
+    /// Returns a dictionary with pool status:
+    ///   - uv_available: number of prewarmed UV environments
+    ///   - conda_available: number of prewarmed Conda environments
+    ///   - uv_warming: number of UV environments being created
+    ///   - conda_warming: number of Conda environments being created
+    fn status<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let stats = self
+            .runtime
+            .block_on(self.client.status())
+            .map_err(to_py_err)?;
+
+        let dict = PyDict::new(py);
+        dict.set_item("uv_available", stats.uv_available)?;
+        dict.set_item("conda_available", stats.conda_available)?;
+        dict.set_item("uv_warming", stats.uv_warming)?;
+        dict.set_item("conda_warming", stats.conda_warming)?;
+        Ok(dict)
+    }
+
+    /// List all active notebook rooms.
+    ///
+    /// Returns a list of dictionaries with room information:
+    ///   - notebook_id: the notebook's identifier (file path or virtual ID)
+    ///   - active_peers: number of connected peers
+    ///   - has_kernel: whether a kernel is running
+    ///   - kernel_type: kernel type if running (e.g., "python", "deno")
+    ///   - kernel_status: current kernel status (if any)
+    fn list_rooms<'py>(&self, py: Python<'py>) -> PyResult<Vec<Bound<'py, PyDict>>> {
+        let rooms = self
+            .runtime
+            .block_on(self.client.list_rooms())
+            .map_err(to_py_err)?;
+
+        let mut result = Vec::with_capacity(rooms.len());
+        for room in rooms {
+            let dict = PyDict::new(py);
+            dict.set_item("notebook_id", &room.notebook_id)?;
+            dict.set_item("active_peers", room.active_peers)?;
+            dict.set_item("has_kernel", room.has_kernel)?;
+            if let Some(kernel_type) = &room.kernel_type {
+                dict.set_item("kernel_type", kernel_type)?;
+            }
+            if let Some(kernel_status) = &room.kernel_status {
+                dict.set_item("kernel_status", kernel_status)?;
+            }
+            if let Some(env_source) = &room.env_source {
+                dict.set_item("env_source", env_source)?;
+            }
+            result.push(dict);
+        }
+        Ok(result)
+    }
+
+    /// Flush all pooled environments and rebuild.
+    ///
+    /// This clears the prewarmed environment pool and triggers
+    /// creation of new environments with current settings.
+    fn flush_pool(&self) -> PyResult<()> {
+        self.runtime
+            .block_on(self.client.flush_pool())
+            .map_err(to_py_err)
+    }
+
+    /// Request daemon shutdown.
+    ///
+    /// Note: In development mode, this will stop the worktree daemon.
+    /// In production, this will stop the system daemon service.
+    fn shutdown(&self) -> PyResult<()> {
+        self.runtime
+            .block_on(self.client.shutdown())
+            .map_err(to_py_err)
+    }
+
+    fn __repr__(&self) -> String {
+        let status = if self.ping() {
+            "connected"
+        } else {
+            "disconnected"
+        };
+        format!("DaemonClient({})", status)
+    }
+}

--- a/crates/runtimed-py/src/error.rs
+++ b/crates/runtimed-py/src/error.rs
@@ -1,0 +1,11 @@
+//! Error types for Python bindings.
+
+use pyo3::exceptions::PyException;
+use pyo3::prelude::*;
+
+pyo3::create_exception!(runtimed, RuntimedError, PyException);
+
+/// Convert runtimed errors to Python exceptions.
+pub fn to_py_err(err: impl std::fmt::Display) -> PyErr {
+    RuntimedError::new_err(err.to_string())
+}

--- a/crates/runtimed-py/src/lib.rs
+++ b/crates/runtimed-py/src/lib.rs
@@ -15,7 +15,7 @@ mod session;
 
 use client::DaemonClient;
 use error::RuntimedError;
-use output::{ExecutionResult, Output};
+use output::{Cell, ExecutionResult, Output};
 use session::Session;
 
 /// Python module for runtimed daemon client.
@@ -26,6 +26,7 @@ fn runtimed(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<Session>()?;
 
     // Output types
+    m.add_class::<Cell>()?;
     m.add_class::<ExecutionResult>()?;
     m.add_class::<Output>()?;
 

--- a/crates/runtimed-py/src/lib.rs
+++ b/crates/runtimed-py/src/lib.rs
@@ -1,0 +1,36 @@
+//! Python bindings for runtimed daemon client.
+//!
+//! Provides Python classes for:
+//! - `DaemonClient`: Low-level daemon operations (status, ping, list rooms)
+//! - `Session`: High-level code execution with kernel management
+//!
+//! Both sync and async APIs are provided.
+
+use pyo3::prelude::*;
+
+mod client;
+mod error;
+mod output;
+mod session;
+
+use client::DaemonClient;
+use error::RuntimedError;
+use output::{ExecutionResult, Output};
+use session::Session;
+
+/// Python module for runtimed daemon client.
+#[pymodule]
+fn runtimed(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    // Core classes
+    m.add_class::<DaemonClient>()?;
+    m.add_class::<Session>()?;
+
+    // Output types
+    m.add_class::<ExecutionResult>()?;
+    m.add_class::<Output>()?;
+
+    // Error type
+    m.add("RuntimedError", m.py().get_type::<RuntimedError>())?;
+
+    Ok(())
+}

--- a/crates/runtimed-py/src/output.rs
+++ b/crates/runtimed-py/src/output.rs
@@ -1,0 +1,201 @@
+//! Output types for execution results.
+
+use pyo3::prelude::*;
+use std::collections::HashMap;
+
+/// A single output from cell execution.
+#[pyclass(skip_from_py_object)]
+#[derive(Clone, Debug)]
+pub struct Output {
+    /// Output type: "stream", "display_data", "execute_result", "error"
+    #[pyo3(get)]
+    pub output_type: String,
+
+    /// For stream outputs: "stdout" or "stderr"
+    #[pyo3(get)]
+    pub name: Option<String>,
+
+    /// For stream outputs: the text content
+    #[pyo3(get)]
+    pub text: Option<String>,
+
+    /// For display_data/execute_result: mime type -> content
+    #[pyo3(get)]
+    pub data: Option<HashMap<String, String>>,
+
+    /// For errors: exception name
+    #[pyo3(get)]
+    pub ename: Option<String>,
+
+    /// For errors: exception value
+    #[pyo3(get)]
+    pub evalue: Option<String>,
+
+    /// For errors: traceback lines
+    #[pyo3(get)]
+    pub traceback: Option<Vec<String>>,
+
+    /// For execute_result: execution count
+    #[pyo3(get)]
+    pub execution_count: Option<i64>,
+}
+
+#[pymethods]
+impl Output {
+    fn __repr__(&self) -> String {
+        match self.output_type.as_str() {
+            "stream" => format!(
+                "Output(stream, {}: {:?})",
+                self.name.as_deref().unwrap_or("?"),
+                self.text.as_deref().unwrap_or("")
+            ),
+            "display_data" | "execute_result" => {
+                let mime_types: Vec<&str> = self
+                    .data
+                    .as_ref()
+                    .map(|d| d.keys().map(|s| s.as_str()).collect())
+                    .unwrap_or_default();
+                format!("Output({}, {:?})", self.output_type, mime_types)
+            }
+            "error" => format!(
+                "Output(error, {}: {})",
+                self.ename.as_deref().unwrap_or("?"),
+                self.evalue.as_deref().unwrap_or("")
+            ),
+            _ => format!("Output({})", self.output_type),
+        }
+    }
+}
+
+impl Output {
+    /// Create a stream output.
+    pub fn stream(name: &str, text: &str) -> Self {
+        Self {
+            output_type: "stream".to_string(),
+            name: Some(name.to_string()),
+            text: Some(text.to_string()),
+            data: None,
+            ename: None,
+            evalue: None,
+            traceback: None,
+            execution_count: None,
+        }
+    }
+
+    /// Create a display_data output.
+    pub fn display_data(data: HashMap<String, String>) -> Self {
+        Self {
+            output_type: "display_data".to_string(),
+            name: None,
+            text: None,
+            data: Some(data),
+            ename: None,
+            evalue: None,
+            traceback: None,
+            execution_count: None,
+        }
+    }
+
+    /// Create an execute_result output.
+    pub fn execute_result(data: HashMap<String, String>, execution_count: i64) -> Self {
+        Self {
+            output_type: "execute_result".to_string(),
+            name: None,
+            text: None,
+            data: Some(data),
+            ename: None,
+            evalue: None,
+            traceback: None,
+            execution_count: Some(execution_count),
+        }
+    }
+
+    /// Create an error output.
+    pub fn error(ename: &str, evalue: &str, traceback: Vec<String>) -> Self {
+        Self {
+            output_type: "error".to_string(),
+            name: None,
+            text: None,
+            data: None,
+            ename: Some(ename.to_string()),
+            evalue: Some(evalue.to_string()),
+            traceback: Some(traceback),
+            execution_count: None,
+        }
+    }
+}
+
+/// Result of executing code.
+#[pyclass(skip_from_py_object)]
+#[derive(Clone, Debug)]
+pub struct ExecutionResult {
+    /// Cell ID that was executed
+    #[pyo3(get)]
+    pub cell_id: String,
+
+    /// All outputs from execution
+    #[pyo3(get)]
+    pub outputs: Vec<Output>,
+
+    /// Whether execution completed successfully (no error output)
+    #[pyo3(get)]
+    pub success: bool,
+
+    /// Execution count (if available)
+    #[pyo3(get)]
+    pub execution_count: Option<i64>,
+}
+
+#[pymethods]
+impl ExecutionResult {
+    /// Get combined stdout text.
+    #[getter]
+    fn stdout(&self) -> String {
+        self.outputs
+            .iter()
+            .filter(|o| o.output_type == "stream" && o.name.as_deref() == Some("stdout"))
+            .filter_map(|o| o.text.as_deref())
+            .collect::<Vec<_>>()
+            .join("")
+    }
+
+    /// Get combined stderr text.
+    #[getter]
+    fn stderr(&self) -> String {
+        self.outputs
+            .iter()
+            .filter(|o| o.output_type == "stream" && o.name.as_deref() == Some("stderr"))
+            .filter_map(|o| o.text.as_deref())
+            .collect::<Vec<_>>()
+            .join("")
+    }
+
+    /// Get display data outputs (display_data and execute_result).
+    #[getter]
+    fn display_data(&self) -> Vec<Output> {
+        self.outputs
+            .iter()
+            .filter(|o| o.output_type == "display_data" || o.output_type == "execute_result")
+            .cloned()
+            .collect()
+    }
+
+    /// Get error output if any.
+    #[getter]
+    fn error(&self) -> Option<Output> {
+        self.outputs
+            .iter()
+            .find(|o| o.output_type == "error")
+            .cloned()
+    }
+
+    fn __repr__(&self) -> String {
+        let status = if self.success { "ok" } else { "error" };
+        format!(
+            "ExecutionResult(cell={}, status={}, outputs={})",
+            self.cell_id,
+            status,
+            self.outputs.len()
+        )
+    }
+}

--- a/crates/runtimed-py/src/output.rs
+++ b/crates/runtimed-py/src/output.rs
@@ -125,6 +125,54 @@ impl Output {
     }
 }
 
+/// A cell from the automerge document.
+#[pyclass(skip_from_py_object)]
+#[derive(Clone, Debug)]
+pub struct Cell {
+    /// Cell ID
+    #[pyo3(get)]
+    pub id: String,
+
+    /// Cell type: "code", "markdown", or "raw"
+    #[pyo3(get)]
+    pub cell_type: String,
+
+    /// Cell source code/content
+    #[pyo3(get)]
+    pub source: String,
+
+    /// Execution count (None if not executed)
+    #[pyo3(get)]
+    pub execution_count: Option<i64>,
+}
+
+#[pymethods]
+impl Cell {
+    fn __repr__(&self) -> String {
+        let preview: String = self.source.chars().take(30).collect();
+        let ellipsis = if self.source.len() > 30 { "..." } else { "" };
+        format!(
+            "Cell(id={}, type={}, source={:?}{})",
+            self.id, self.cell_type, preview, ellipsis
+        )
+    }
+}
+
+impl Cell {
+    /// Create a Cell from a CellSnapshot.
+    pub fn from_snapshot(snapshot: runtimed::notebook_doc::CellSnapshot) -> Self {
+        // Parse execution_count from JSON string ("5" or "null")
+        let execution_count = snapshot.execution_count.parse::<i64>().ok();
+
+        Self {
+            id: snapshot.id,
+            cell_type: snapshot.cell_type,
+            source: snapshot.source,
+            execution_count,
+        }
+    }
+}
+
 /// Result of executing code.
 #[pyclass(skip_from_py_object)]
 #[derive(Clone, Debug)]

--- a/crates/runtimed-py/src/session.rs
+++ b/crates/runtimed-py/src/session.rs
@@ -1,0 +1,739 @@
+//! Session for code execution.
+//!
+//! Provides a high-level interface for executing code via the daemon's kernel.
+
+use pyo3::prelude::*;
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+use tokio::runtime::Runtime;
+use tokio::sync::Mutex;
+
+use runtimed::notebook_sync_client::{
+    NotebookBroadcastReceiver, NotebookSyncClient, NotebookSyncHandle,
+};
+use runtimed::protocol::{NotebookBroadcast, NotebookRequest, NotebookResponse};
+
+use crate::error::to_py_err;
+use crate::output::{ExecutionResult, Output};
+
+/// A session for executing code via the runtimed daemon.
+///
+/// Each session connects to a unique "virtual notebook" room in the daemon
+/// and can launch a kernel and execute code. Sessions are isolated from
+/// each other but multiple sessions can share the same kernel if they
+/// use the same notebook_id.
+///
+/// Example:
+///     session = Session()
+///     session.start_kernel()
+///     result = session.execute("print('hello')")
+///     print(result.stdout)  # "hello\n"
+#[pyclass]
+pub struct Session {
+    runtime: Runtime,
+    state: Arc<Mutex<SessionState>>,
+    notebook_id: String,
+}
+
+struct SessionState {
+    handle: Option<NotebookSyncHandle>,
+    broadcast_rx: Option<NotebookBroadcastReceiver>,
+    kernel_started: bool,
+    env_source: Option<String>,
+    /// Base URL for blob server (for resolving blob hashes)
+    blob_base_url: Option<String>,
+    /// Path to blob store directory (fallback for direct disk access)
+    blob_store_path: Option<PathBuf>,
+}
+
+impl SessionState {
+    fn new() -> Self {
+        Self {
+            handle: None,
+            broadcast_rx: None,
+            kernel_started: false,
+            env_source: None,
+            blob_base_url: None,
+            blob_store_path: None,
+        }
+    }
+}
+
+#[pymethods]
+impl Session {
+    /// Create a new session.
+    ///
+    /// Args:
+    ///     notebook_id: Optional unique identifier for this session.
+    ///                  If not provided, a random UUID is generated.
+    ///                  Multiple Session objects with the same notebook_id
+    ///                  will share the same kernel.
+    #[new]
+    #[pyo3(signature = (notebook_id=None))]
+    fn new(notebook_id: Option<String>) -> PyResult<Self> {
+        let runtime = Runtime::new().map_err(to_py_err)?;
+        let notebook_id =
+            notebook_id.unwrap_or_else(|| format!("agent-session-{}", uuid::Uuid::new_v4()));
+
+        Ok(Self {
+            runtime,
+            state: Arc::new(Mutex::new(SessionState::new())),
+            notebook_id,
+        })
+    }
+
+    /// Get the notebook ID for this session.
+    #[getter]
+    fn notebook_id(&self) -> &str {
+        &self.notebook_id
+    }
+
+    /// Check if the session is connected to the daemon.
+    #[getter]
+    fn is_connected(&self) -> bool {
+        let state = self.runtime.block_on(self.state.lock());
+        state.handle.is_some()
+    }
+
+    /// Check if a kernel has been started.
+    #[getter]
+    fn kernel_started(&self) -> bool {
+        let state = self.runtime.block_on(self.state.lock());
+        state.kernel_started
+    }
+
+    /// Get the environment source (e.g., "uv:prewarmed") if kernel is running.
+    #[getter]
+    fn env_source(&self) -> Option<String> {
+        let state = self.runtime.block_on(self.state.lock());
+        state.env_source.clone()
+    }
+
+    /// Connect to the daemon.
+    ///
+    /// This is called automatically by start_kernel() if not already connected.
+    fn connect(&self) -> PyResult<()> {
+        self.runtime.block_on(async {
+            let mut state = self.state.lock().await;
+            if state.handle.is_some() {
+                return Ok(()); // Already connected
+            }
+
+            let socket_path = runtimed::default_socket_path();
+
+            let (handle, _sync_rx, broadcast_rx, _cells, _notebook_path) =
+                NotebookSyncClient::connect_split(socket_path.clone(), self.notebook_id.clone())
+                    .await
+                    .map_err(to_py_err)?;
+
+            // Determine blob server URL and blob store path based on socket path
+            // In dev mode, blob server runs on a per-worktree port
+            let (blob_base_url, blob_store_path) = if let Some(parent) = socket_path.parent() {
+                // Read daemon.json to get blob port
+                let daemon_json = parent.join("daemon.json");
+                let base_url = if daemon_json.exists() {
+                    std::fs::read_to_string(&daemon_json)
+                        .ok()
+                        .and_then(|contents| {
+                            serde_json::from_str::<serde_json::Value>(&contents).ok()
+                        })
+                        .and_then(|info| info.get("blob_port").and_then(|p| p.as_u64()))
+                        .map(|port| format!("http://127.0.0.1:{}", port))
+                } else {
+                    None
+                };
+
+                // Blob store is at {daemon_dir}/blobs/
+                let store_path = parent.join("blobs");
+                let store_path = if store_path.exists() {
+                    Some(store_path)
+                } else {
+                    None
+                };
+
+                (base_url, store_path)
+            } else {
+                (None, None)
+            };
+
+            state.handle = Some(handle);
+            state.broadcast_rx = Some(broadcast_rx);
+            state.blob_base_url = blob_base_url;
+            state.blob_store_path = blob_store_path;
+
+            Ok(())
+        })
+    }
+
+    /// Start a kernel for this session.
+    ///
+    /// Args:
+    ///     kernel_type: Type of kernel ("python" or "deno"). Defaults to "python".
+    ///     env_source: Environment source. Defaults to "uv:prewarmed".
+    ///
+    /// If a kernel is already running for this session's notebook_id,
+    /// this returns immediately without starting a new one.
+    #[pyo3(signature = (kernel_type="python", env_source="uv:prewarmed"))]
+    fn start_kernel(&self, kernel_type: &str, env_source: &str) -> PyResult<()> {
+        // Ensure connected first
+        self.connect()?;
+
+        self.runtime.block_on(async {
+            let mut state = self.state.lock().await;
+
+            let handle = state
+                .handle
+                .as_ref()
+                .ok_or_else(|| to_py_err("Not connected"))?;
+
+            let response = handle
+                .send_request(NotebookRequest::LaunchKernel {
+                    kernel_type: kernel_type.to_string(),
+                    env_source: env_source.to_string(),
+                    notebook_path: None,
+                })
+                .await
+                .map_err(to_py_err)?;
+
+            match response {
+                NotebookResponse::KernelLaunched {
+                    env_source: actual_env,
+                    ..
+                } => {
+                    state.kernel_started = true;
+                    state.env_source = Some(actual_env);
+                    Ok(())
+                }
+                NotebookResponse::KernelAlreadyRunning {
+                    env_source: actual_env,
+                    ..
+                } => {
+                    state.kernel_started = true;
+                    state.env_source = Some(actual_env);
+                    Ok(())
+                }
+                NotebookResponse::Error { error } => Err(to_py_err(error)),
+                other => Err(to_py_err(format!("Unexpected response: {:?}", other))),
+            }
+        })
+    }
+
+    /// Execute code and return the result.
+    ///
+    /// Args:
+    ///     code: The code to execute.
+    ///     timeout_secs: Maximum time to wait for execution (default: 60).
+    ///
+    /// Returns:
+    ///     ExecutionResult with outputs, success status, and execution count.
+    ///
+    /// Raises:
+    ///     RuntimedError: If not connected, kernel not started, or timeout.
+    #[pyo3(signature = (code, timeout_secs=60.0))]
+    fn execute(&self, code: &str, timeout_secs: f64) -> PyResult<ExecutionResult> {
+        let cell_id = format!("cell-{}", uuid::Uuid::new_v4());
+
+        self.runtime.block_on(async {
+            let state = self.state.lock().await;
+
+            if !state.kernel_started {
+                return Err(to_py_err("Kernel not started. Call start_kernel() first."));
+            }
+
+            let handle = state
+                .handle
+                .as_ref()
+                .ok_or_else(|| to_py_err("Not connected"))?;
+
+            let blob_base_url = state.blob_base_url.clone();
+            let blob_store_path = state.blob_store_path.clone();
+
+            // Queue the cell
+            let response = handle
+                .send_request(NotebookRequest::QueueCell {
+                    cell_id: cell_id.clone(),
+                    code: code.to_string(),
+                })
+                .await
+                .map_err(to_py_err)?;
+
+            match response {
+                NotebookResponse::CellQueued { .. } => {}
+                NotebookResponse::Error { error } => return Err(to_py_err(error)),
+                other => return Err(to_py_err(format!("Unexpected response: {:?}", other))),
+            }
+
+            drop(state); // Release lock before waiting for broadcasts
+
+            // Wait for outputs
+            let timeout = std::time::Duration::from_secs_f64(timeout_secs);
+            let result = tokio::time::timeout(
+                timeout,
+                self.collect_outputs(&cell_id, blob_base_url, blob_store_path),
+            )
+            .await;
+
+            match result {
+                Ok(Ok(exec_result)) => Ok(exec_result),
+                Ok(Err(e)) => Err(e),
+                Err(_) => Err(to_py_err(format!(
+                    "Execution timed out after {} seconds",
+                    timeout_secs
+                ))),
+            }
+        })
+    }
+
+    /// Interrupt the currently executing cell.
+    fn interrupt(&self) -> PyResult<()> {
+        self.runtime.block_on(async {
+            let state = self.state.lock().await;
+
+            let handle = state
+                .handle
+                .as_ref()
+                .ok_or_else(|| to_py_err("Not connected"))?;
+
+            let response = handle
+                .send_request(NotebookRequest::InterruptExecution {})
+                .await
+                .map_err(to_py_err)?;
+
+            match response {
+                NotebookResponse::InterruptSent {} => Ok(()),
+                NotebookResponse::NoKernel {} => Err(to_py_err("No kernel running")),
+                NotebookResponse::Error { error } => Err(to_py_err(error)),
+                other => Err(to_py_err(format!("Unexpected response: {:?}", other))),
+            }
+        })
+    }
+
+    /// Shutdown the kernel.
+    fn shutdown_kernel(&self) -> PyResult<()> {
+        self.runtime.block_on(async {
+            let mut state = self.state.lock().await;
+
+            let handle = state
+                .handle
+                .as_ref()
+                .ok_or_else(|| to_py_err("Not connected"))?;
+
+            let response = handle
+                .send_request(NotebookRequest::ShutdownKernel {})
+                .await
+                .map_err(to_py_err)?;
+
+            match response {
+                NotebookResponse::KernelShuttingDown {} => {
+                    state.kernel_started = false;
+                    state.env_source = None;
+                    Ok(())
+                }
+                NotebookResponse::NoKernel {} => {
+                    state.kernel_started = false;
+                    state.env_source = None;
+                    Ok(())
+                }
+                NotebookResponse::Error { error } => Err(to_py_err(error)),
+                other => Err(to_py_err(format!("Unexpected response: {:?}", other))),
+            }
+        })
+    }
+
+    fn __repr__(&self) -> String {
+        let state = self.runtime.block_on(self.state.lock());
+        let status = if state.kernel_started {
+            "kernel_running"
+        } else if state.handle.is_some() {
+            "connected"
+        } else {
+            "disconnected"
+        };
+        format!("Session(id={}, status={})", self.notebook_id, status)
+    }
+
+    fn __enter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        slf
+    }
+
+    #[pyo3(signature = (_exc_type=None, _exc_val=None, _exc_tb=None))]
+    fn __exit__(
+        &self,
+        _exc_type: Option<&Bound<'_, PyAny>>,
+        _exc_val: Option<&Bound<'_, PyAny>>,
+        _exc_tb: Option<&Bound<'_, PyAny>>,
+    ) -> PyResult<bool> {
+        // Shutdown kernel on exit if running
+        let state = self.runtime.block_on(self.state.lock());
+        if state.kernel_started {
+            drop(state);
+            let _ = self.shutdown_kernel();
+        }
+        Ok(false) // Don't suppress exceptions
+    }
+
+    /// Close the session and shutdown the kernel if running.
+    ///
+    /// This is equivalent to using the session as a context manager
+    /// and exiting the context.
+    fn close(&self) -> PyResult<()> {
+        let state = self.runtime.block_on(self.state.lock());
+        if state.kernel_started {
+            drop(state);
+            let _ = self.shutdown_kernel();
+        }
+        Ok(())
+    }
+}
+
+impl Session {
+    /// Collect outputs for a cell until ExecutionDone is received.
+    ///
+    /// Note: Due to the Jupyter shell/iopub race condition, error outputs
+    /// may arrive AFTER ExecutionDone. We continue draining for a short
+    /// time after ExecutionDone to catch straggling outputs.
+    async fn collect_outputs(
+        &self,
+        cell_id: &str,
+        blob_base_url: Option<String>,
+        blob_store_path: Option<PathBuf>,
+    ) -> PyResult<ExecutionResult> {
+        let mut outputs = Vec::new();
+        let mut execution_count = None;
+        let mut success = true;
+        let mut done_received = false;
+
+        loop {
+            let mut state = self.state.lock().await;
+            let broadcast_rx = state
+                .broadcast_rx
+                .as_mut()
+                .ok_or_else(|| to_py_err("Not connected"))?;
+
+            // Use a short timeout - shorter after done to drain quickly
+            let timeout_ms = if done_received { 50 } else { 100 };
+            let broadcast = tokio::time::timeout(
+                std::time::Duration::from_millis(timeout_ms),
+                broadcast_rx.recv(),
+            )
+            .await;
+
+            match broadcast {
+                Ok(Some(msg)) => {
+                    drop(state); // Release lock while processing
+                    log::debug!("[session] Received broadcast: {:?}", msg);
+
+                    match msg {
+                        NotebookBroadcast::ExecutionStarted {
+                            cell_id: msg_cell_id,
+                            execution_count: count,
+                        } => {
+                            if msg_cell_id == cell_id {
+                                execution_count = Some(count);
+                            }
+                        }
+                        NotebookBroadcast::Output {
+                            cell_id: msg_cell_id,
+                            output_type,
+                            output_json,
+                        } => {
+                            log::debug!(
+                                "[session] Output broadcast: type={}, cell_id={}",
+                                output_type,
+                                msg_cell_id
+                            );
+                            if msg_cell_id == cell_id {
+                                if let Some(output) = self
+                                    .parse_output(
+                                        &output_type,
+                                        &output_json,
+                                        &blob_base_url,
+                                        &blob_store_path,
+                                    )
+                                    .await
+                                {
+                                    log::debug!(
+                                        "[session] Parsed output: type={}",
+                                        output.output_type
+                                    );
+                                    if output.output_type == "error" {
+                                        success = false;
+                                    }
+                                    outputs.push(output);
+                                } else {
+                                    log::debug!("[session] Failed to parse output");
+                                }
+                            }
+                        }
+                        NotebookBroadcast::ExecutionDone {
+                            cell_id: msg_cell_id,
+                        } => {
+                            if msg_cell_id == cell_id {
+                                // Don't break immediately - drain for a bit to catch
+                                // straggling outputs due to shell/iopub race condition
+                                log::debug!(
+                                    "[session] ExecutionDone received, starting drain phase"
+                                );
+                                done_received = true;
+                            }
+                        }
+                        NotebookBroadcast::KernelError { error } => {
+                            success = false;
+                            outputs.push(Output::error("KernelError", &error, vec![]));
+                            done_received = true;
+                        }
+                        _ => {
+                            // Ignore other broadcasts (KernelStatus, QueueChanged, etc.)
+                        }
+                    }
+                }
+                Ok(None) => {
+                    // Channel closed
+                    return Err(to_py_err("Broadcast channel closed"));
+                }
+                Err(_) => {
+                    // Timeout - if we've seen ExecutionDone, we're done draining
+                    if done_received {
+                        log::debug!(
+                            "[session] Drain timeout, finishing with {} outputs",
+                            outputs.len()
+                        );
+                        break;
+                    }
+                    // Otherwise continue waiting
+                }
+            }
+        }
+
+        Ok(ExecutionResult {
+            cell_id: cell_id.to_string(),
+            outputs,
+            success,
+            execution_count,
+        })
+    }
+
+    /// Parse an output from the daemon broadcast.
+    ///
+    /// The output_json field may be:
+    /// 1. A blob hash (SHA-256) that needs to be fetched from the blob server
+    /// 2. Inline JSON content
+    async fn parse_output(
+        &self,
+        output_type: &str,
+        output_json: &str,
+        blob_base_url: &Option<String>,
+        blob_store_path: &Option<PathBuf>,
+    ) -> Option<Output> {
+        // Try to parse output_json directly first
+        if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(output_json) {
+            return self.output_from_json(output_type, &parsed);
+        }
+
+        // If it looks like a blob hash (64 hex chars), try to resolve it
+        if output_json.len() == 64 && output_json.chars().all(|c| c.is_ascii_hexdigit()) {
+            log::debug!("[session] Detected blob hash: {}", output_json);
+            log::debug!("[session] blob_store_path: {:?}", blob_store_path);
+            log::debug!("[session] blob_base_url: {:?}", blob_base_url);
+            // First try: read directly from disk (most reliable)
+            if let Some(store_path) = blob_store_path {
+                // Blob path is {store}/{prefix}/{rest} where prefix is first 2 chars
+                let prefix = &output_json[..2];
+                let rest = &output_json[2..];
+                let blob_path = store_path.join(prefix).join(rest);
+                log::debug!("[session] Trying blob path: {:?}", blob_path);
+
+                match std::fs::read_to_string(&blob_path) {
+                    Ok(contents) => {
+                        log::debug!("[session] Read blob file, contents len: {}", contents.len());
+                        if let Ok(manifest) = serde_json::from_str::<serde_json::Value>(&contents) {
+                            return self
+                                .output_from_manifest(output_type, &manifest, blob_store_path)
+                                .await;
+                        } else {
+                            log::debug!("[session] Failed to parse manifest JSON");
+                        }
+                    }
+                    Err(e) => {
+                        log::debug!("[session] Failed to read blob file: {}", e);
+                    }
+                }
+            }
+
+            // Second try: fetch from blob server (may fail due to server issues)
+            if let Some(base_url) = blob_base_url {
+                let url = format!("{}/blobs/{}", base_url, output_json);
+                if let Ok(response) = reqwest::get(&url).await {
+                    if response.status().is_success() {
+                        if let Ok(manifest) = response.json::<serde_json::Value>().await {
+                            return self
+                                .output_from_manifest(output_type, &manifest, blob_store_path)
+                                .await;
+                        }
+                    }
+                }
+            }
+        }
+
+        // Fallback: create a minimal output
+        Some(Output::stream(
+            "stderr",
+            &format!("Failed to parse output: {}", output_json),
+        ))
+    }
+
+    /// Convert a parsed JSON value to an Output.
+    fn output_from_json(&self, output_type: &str, json: &serde_json::Value) -> Option<Output> {
+        match output_type {
+            "stream" => {
+                let name = json.get("name")?.as_str()?;
+                let text = json.get("text")?.as_str()?;
+                Some(Output::stream(name, text))
+            }
+            "display_data" => {
+                let data = json.get("data")?.as_object()?;
+                let mut output_data = HashMap::new();
+                for (key, value) in data {
+                    if let Some(s) = value.as_str() {
+                        output_data.insert(key.clone(), s.to_string());
+                    } else {
+                        output_data.insert(key.clone(), value.to_string());
+                    }
+                }
+                Some(Output::display_data(output_data))
+            }
+            "execute_result" => {
+                let data = json.get("data")?.as_object()?;
+                let execution_count = json.get("execution_count")?.as_i64()?;
+                let mut output_data = HashMap::new();
+                for (key, value) in data {
+                    if let Some(s) = value.as_str() {
+                        output_data.insert(key.clone(), s.to_string());
+                    } else {
+                        output_data.insert(key.clone(), value.to_string());
+                    }
+                }
+                Some(Output::execute_result(output_data, execution_count))
+            }
+            "error" => {
+                let ename = json.get("ename")?.as_str()?.to_string();
+                let evalue = json.get("evalue")?.as_str()?.to_string();
+                let traceback = json
+                    .get("traceback")?
+                    .as_array()?
+                    .iter()
+                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                    .collect();
+                Some(Output::error(&ename, &evalue, traceback))
+            }
+            _ => None,
+        }
+    }
+
+    /// Convert a blob manifest to an Output.
+    ///
+    /// The manifest has a format like:
+    /// {"output_type": "stream", "name": "stdout", "text": {"inline": "..."}}
+    async fn output_from_manifest(
+        &self,
+        output_type: &str,
+        manifest: &serde_json::Value,
+        blob_store_path: &Option<PathBuf>,
+    ) -> Option<Output> {
+        match output_type {
+            "stream" => {
+                let name = manifest.get("name")?.as_str()?;
+                let text_ref = manifest.get("text")?;
+                let text = self.resolve_content_ref(text_ref, blob_store_path).await?;
+                Some(Output::stream(name, &text))
+            }
+            "display_data" | "execute_result" => {
+                let data_map = manifest.get("data")?.as_object()?;
+                let mut output_data = HashMap::new();
+
+                for (mime_type, content_ref) in data_map {
+                    if let Some(content) =
+                        self.resolve_content_ref(content_ref, blob_store_path).await
+                    {
+                        output_data.insert(mime_type.clone(), content);
+                    }
+                }
+
+                if output_type == "execute_result" {
+                    let execution_count = manifest.get("execution_count")?.as_i64()?;
+                    Some(Output::execute_result(output_data, execution_count))
+                } else {
+                    Some(Output::display_data(output_data))
+                }
+            }
+            "error" => {
+                let ename = manifest.get("ename")?.as_str()?.to_string();
+                let evalue = manifest.get("evalue")?.as_str()?.to_string();
+
+                // Traceback can be a content ref ({"inline": "[...]"}) or a direct array
+                let traceback_val = manifest.get("traceback")?;
+                let traceback = if let Some(arr) = traceback_val.as_array() {
+                    // Direct array
+                    arr.iter()
+                        .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                        .collect()
+                } else {
+                    // Content reference - resolve it and parse as JSON array
+                    let tb_str = self
+                        .resolve_content_ref(traceback_val, blob_store_path)
+                        .await?;
+                    serde_json::from_str::<Vec<String>>(&tb_str).ok()?
+                };
+
+                Some(Output::error(&ename, &evalue, traceback))
+            }
+            _ => None,
+        }
+    }
+
+    /// Resolve a content reference from a blob manifest.
+    ///
+    /// Content refs can be:
+    /// - {"inline": "actual content"} - content is inline
+    /// - {"blob": "hash"} - content is in blob store
+    async fn resolve_content_ref(
+        &self,
+        content_ref: &serde_json::Value,
+        blob_store_path: &Option<PathBuf>,
+    ) -> Option<String> {
+        if let Some(inline) = content_ref.get("inline") {
+            return inline.as_str().map(|s| s.to_string());
+        }
+
+        if let Some(blob_hash) = content_ref.get("blob").and_then(|v| v.as_str()) {
+            // First try: read directly from disk
+            if let Some(store_path) = blob_store_path {
+                if blob_hash.len() >= 2 {
+                    let prefix = &blob_hash[..2];
+                    let rest = &blob_hash[2..];
+                    let blob_path = store_path.join(prefix).join(rest);
+
+                    if let Ok(contents) = std::fs::read_to_string(&blob_path) {
+                        return Some(contents);
+                    }
+                }
+            }
+
+            // Second try: fetch from server
+            let state = self.state.lock().await;
+            if let Some(base_url) = &state.blob_base_url {
+                let url = format!("{}/blobs/{}", base_url, blob_hash);
+                drop(state);
+
+                if let Ok(response) = reqwest::get(&url).await {
+                    if response.status().is_success() {
+                        return response.text().await.ok();
+                    }
+                }
+            }
+        }
+
+        None
+    }
+}

--- a/docs/python-bindings.md
+++ b/docs/python-bindings.md
@@ -1,0 +1,280 @@
+# Python Bindings (runtimed)
+
+The `runtimed` Python package provides programmatic access to the notebook daemon. Use it to execute code, manage kernels, and interact with notebooks from Python scripts, agents, or automation workflows.
+
+## Installation
+
+```bash
+# From PyPI (when published)
+pip install runtimed
+
+# From source
+cd python/runtimed
+uv run maturin develop
+```
+
+## Quick Start
+
+```python
+import runtimed
+
+# Execute code with automatic kernel management
+with runtimed.Session() as session:
+    session.start_kernel()
+    result = session.run("print('hello')")
+    print(result.stdout)  # "hello\n"
+```
+
+## Session API
+
+The `Session` class is the primary interface for executing code. Each session connects to a notebook room in the daemon.
+
+### Creating a Session
+
+```python
+# Auto-generated notebook ID
+session = runtimed.Session()
+
+# Explicit notebook ID (allows sharing between sessions)
+session = runtimed.Session(notebook_id="my-notebook")
+```
+
+### Kernel Lifecycle
+
+```python
+session.connect()                    # Connect to daemon (auto-called by start_kernel)
+session.start_kernel()               # Launch Python kernel
+session.start_kernel(kernel_type="deno")  # Launch Deno kernel
+session.interrupt()                  # Interrupt running execution
+session.shutdown_kernel()            # Stop the kernel
+```
+
+### Code Execution
+
+```python
+# Simple execution (creates ephemeral cell, executes, returns result)
+result = session.run("x = 42")
+result = session.run("print(x)")
+
+# Check results
+print(result.success)         # True if no error
+print(result.stdout)          # Captured stdout
+print(result.stderr)          # Captured stderr
+print(result.execution_count) # Execution counter
+print(result.error)           # Error output if failed
+```
+
+### Document-First Execution
+
+The session uses a document-first model where cells are stored in an automerge document. This enables multi-client synchronization.
+
+```python
+# Create a cell in the document
+cell_id = session.create_cell("x = 10")
+
+# Update cell source
+session.set_source(cell_id, "x = 20")
+
+# Execute by cell ID (daemon reads source from document)
+result = session.execute_cell(cell_id)
+
+# Read cell state
+cell = session.get_cell(cell_id)
+print(cell.source)           # "x = 20"
+print(cell.execution_count)  # 1
+
+# List all cells
+cells = session.get_cells()
+
+# Delete a cell
+session.delete_cell(cell_id)
+```
+
+### Context Manager
+
+Sessions work as context managers for automatic cleanup:
+
+```python
+with runtimed.Session() as session:
+    session.start_kernel()
+    result = session.run("1 + 1")
+# Kernel automatically shut down on exit
+```
+
+### Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `notebook_id` | `str` | Unique identifier for this notebook |
+| `is_connected` | `bool` | Whether connected to daemon |
+| `kernel_started` | `bool` | Whether kernel is running |
+| `env_source` | `str \| None` | Environment source (e.g., "uv:prewarmed") |
+
+## DaemonClient API
+
+The `DaemonClient` class provides low-level access to daemon operations.
+
+```python
+client = runtimed.DaemonClient()
+
+# Health checks
+client.ping()         # True if daemon responding
+client.is_running()   # True if daemon process exists
+
+# Pool status
+stats = client.status()
+# {
+#   'uv_available': 2,
+#   'conda_available': 0,
+#   'uv_warming': 1,
+#   'conda_warming': 0
+# }
+
+# Active notebook rooms
+rooms = client.list_rooms()
+# [
+#   {
+#     'notebook_id': 'my-notebook',
+#     'active_peers': 2,
+#     'has_kernel': True,
+#     'kernel_type': 'python',
+#     'kernel_status': 'idle',
+#     'env_source': 'uv:prewarmed'
+#   }
+# ]
+
+# Operations
+client.flush_pool()   # Clear and rebuild environment pool
+client.shutdown()     # Stop the daemon
+```
+
+## Result Types
+
+### ExecutionResult
+
+Returned by `run()` and `execute_cell()`:
+
+```python
+result = session.run("print('hello')")
+
+result.cell_id          # Cell that was executed
+result.success          # True if no error
+result.execution_count  # Execution counter value
+result.outputs          # List of Output objects
+result.stdout           # Combined stdout text
+result.stderr           # Combined stderr text
+result.display_data     # List of display_data/execute_result outputs
+result.error            # First error output, or None
+```
+
+### Output
+
+Individual outputs from execution:
+
+```python
+for output in result.outputs:
+    print(output.output_type)  # "stream", "display_data", "execute_result", "error"
+
+    # For streams
+    print(output.name)  # "stdout" or "stderr"
+    print(output.text)  # The text content
+
+    # For display_data/execute_result
+    print(output.data)  # Dict[str, str] of MIME type -> content
+
+    # For errors
+    print(output.ename)      # Exception class name
+    print(output.evalue)     # Exception message
+    print(output.traceback)  # List of traceback lines
+```
+
+### Cell
+
+Cell from the automerge document:
+
+```python
+cell = session.get_cell(cell_id)
+
+cell.id              # Cell identifier
+cell.cell_type       # "code", "markdown", or "raw"
+cell.source          # Cell source content
+cell.execution_count # Execution count if executed
+```
+
+## Multi-Client Scenarios
+
+Two sessions with the same `notebook_id` share the same kernel and document:
+
+```python
+# Session 1 creates a cell
+s1 = runtimed.Session(notebook_id="shared")
+s1.connect()
+s1.start_kernel()
+cell_id = s1.create_cell("x = 42")
+
+# Session 2 sees the cell and shares the kernel
+s2 = runtimed.Session(notebook_id="shared")
+s2.connect()
+s2.start_kernel()  # Reuses existing kernel
+
+cells = s2.get_cells()
+assert any(c.id == cell_id for c in cells)
+
+# Execute in s2, result visible to s1
+s2.run("print(x)")  # Uses x=42 from s1's execution
+```
+
+This enables:
+- Multiple Python processes sharing a notebook
+- Python scripts interacting with notebooks open in the app
+- Agent workflows with parallel execution
+
+## Error Handling
+
+All errors raise `RuntimedError`:
+
+```python
+try:
+    session.execute_cell("nonexistent-cell-id")
+except runtimed.RuntimedError as e:
+    print(f"Error: {e}")  # "Cell not found: nonexistent-cell-id"
+```
+
+Common error scenarios:
+- Connection to daemon fails
+- Kernel not started before execution
+- Cell not found
+- Execution timeout
+- Kernel errors
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `CONDUCTOR_WORKSPACE_PATH` | Use dev daemon for this worktree |
+| `RUNTIMED_SOCKET_PATH` | Override daemon socket path |
+
+## Sidecar (Rich Output Viewer)
+
+The package also includes a sidecar launcher for rich output display:
+
+```python
+from runtimed import sidecar
+
+# In a Jupyter kernel - auto-detects connection file
+s = sidecar()
+
+# In terminal IPython - creates IOPub bridge
+s = sidecar()
+
+# Explicit connection file
+s = sidecar("/path/to/kernel-123.json")
+
+# Check status
+print(s.running)  # True if sidecar process is alive
+
+# Cleanup
+s.close()
+```
+
+The sidecar provides a GUI window that displays rich outputs (plots, HTML, images) from kernel execution.

--- a/python/runtimed/.gitignore
+++ b/python/runtimed/.gitignore
@@ -1,0 +1,16 @@
+# Compiled extension modules
+*.so
+*.pyd
+*.dylib
+
+# Build artifacts
+target/
+dist/
+*.egg-info/
+
+# Virtual environments
+.venv/
+
+# Python cache
+__pycache__/
+*.pyc

--- a/python/runtimed/README.md
+++ b/python/runtimed/README.md
@@ -1,0 +1,64 @@
+# runtimed
+
+Python bindings for the runtimed notebook daemon. Execute code, manage kernels, and interact with notebooks programmatically.
+
+## Installation
+
+```bash
+pip install runtimed
+```
+
+## Quick Start
+
+```python
+import runtimed
+
+with runtimed.Session() as session:
+    session.start_kernel()
+    result = session.run("print('hello')")
+    print(result.stdout)  # "hello\n"
+```
+
+## Features
+
+- **Code execution** via daemon-managed kernels
+- **Document-first model** with automerge sync
+- **Multi-client support** for shared notebooks
+- **Rich output capture** (stdout, stderr, display_data, errors)
+
+## Session API
+
+```python
+session = runtimed.Session(notebook_id="my-notebook")
+session.start_kernel()
+
+# Simple execution
+result = session.run("x = 42")
+
+# Document operations
+cell_id = session.create_cell("print(x)")
+result = session.execute_cell(cell_id)
+
+# Inspect results
+print(result.success)
+print(result.stdout)
+print(result.error)
+```
+
+## DaemonClient API
+
+```python
+client = runtimed.DaemonClient()
+client.ping()        # Health check
+client.status()      # Pool statistics
+client.list_rooms()  # Active notebooks
+```
+
+## Requirements
+
+- runtimed daemon running (`runt daemon start`)
+- Python 3.9+
+
+## Documentation
+
+See [docs/python-bindings.md](https://github.com/nteract/desktop/blob/main/docs/python-bindings.md) for full documentation.

--- a/python/runtimed/pyproject.toml
+++ b/python/runtimed/pyproject.toml
@@ -19,9 +19,9 @@ requires = ["maturin>=1.0,<2.0"]
 build-backend = "maturin"
 
 [tool.maturin]
-manifest-path = "../../crates/runt/Cargo.toml"
+manifest-path = "../../crates/runtimed-py/Cargo.toml"
 python-source = "src"
-bindings = "bin"
+bindings = "pyo3"
 
 [dependency-groups]
 dev = [

--- a/python/runtimed/src/runtimed/__init__.py
+++ b/python/runtimed/src/runtimed/__init__.py
@@ -2,9 +2,31 @@
 
 from importlib.metadata import PackageNotFoundError, version
 
+# Existing sidecar functionality
 from runtimed._sidecar import BridgedSidecar, Sidecar, sidecar
 
-__all__ = ["BridgedSidecar", "Sidecar", "sidecar"]
+# Native daemon client (PyO3 bindings)
+from runtimed.runtimed import (
+    DaemonClient,
+    ExecutionResult,
+    Output,
+    RuntimedError,
+    Session,
+)
+
+__all__ = [
+    # Existing
+    "BridgedSidecar",
+    "Sidecar",
+    "sidecar",
+    # Daemon client API
+    "DaemonClient",
+    "Session",
+    "ExecutionResult",
+    "Output",
+    "RuntimedError",
+]
+
 try:
     __version__ = version("runtimed")
 except PackageNotFoundError:

--- a/python/runtimed/tests/conftest.py
+++ b/python/runtimed/tests/conftest.py
@@ -1,0 +1,56 @@
+"""Pytest configuration for runtimed tests.
+
+This file contains shared fixtures and configuration.
+"""
+
+import os
+import sys
+
+
+def pytest_configure(config):
+    """Configure pytest for runtimed tests."""
+    # Add markers for different test categories
+    config.addinivalue_line(
+        "markers", "integration: marks tests as integration tests (may need daemon)"
+    )
+    config.addinivalue_line(
+        "markers", "slow: marks tests as slow running"
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    """Modify test collection based on environment."""
+    # Auto-mark integration tests
+    for item in items:
+        if "daemon_integration" in item.nodeid:
+            item.add_marker("integration")
+
+    # Skip integration tests unless explicitly enabled or daemon is available
+    skip_integration = False
+
+    if os.environ.get("SKIP_INTEGRATION_TESTS", "0") == "1":
+        skip_integration = True
+
+    if skip_integration:
+        import pytest
+        skip_marker = pytest.mark.skip(reason="Integration tests disabled")
+        for item in items:
+            if "integration" in item.keywords:
+                item.add_marker(skip_marker)
+
+
+def pytest_report_header(config):
+    """Add useful info to test report header."""
+    lines = []
+
+    # Check for daemon mode
+    if os.environ.get("RUNTIMED_INTEGRATION_TEST") == "1":
+        lines.append("runtimed: CI mode (will spawn daemon)")
+    else:
+        lines.append("runtimed: dev mode (expects running daemon)")
+
+    # Check for custom socket path
+    if "RUNTIMED_SOCKET_PATH" in os.environ:
+        lines.append(f"runtimed socket: {os.environ['RUNTIMED_SOCKET_PATH']}")
+
+    return lines

--- a/python/runtimed/tests/run-integration.sh
+++ b/python/runtimed/tests/run-integration.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+# Integration test runner for runtimed-py
+#
+# Usage:
+#   ./tests/run-integration.sh           # Run with existing dev daemon
+#   ./tests/run-integration.sh --ci      # CI mode: spawn own daemon
+#   ./tests/run-integration.sh --build   # Build first, then run
+#
+# Environment variables:
+#   RUNTIMED_LOG_LEVEL    - Daemon log level (default: info)
+#   RUNTIMED_BINARY       - Path to runtimed binary
+#   RUNTIMED_SOCKET_PATH  - Custom socket path (dev mode only)
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PYTHON_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+PROJECT_ROOT="$(cd "$PYTHON_DIR/../.." && pwd)"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+log() { echo -e "${GREEN}[test]${NC} $1"; }
+warn() { echo -e "${YELLOW}[test]${NC} $1"; }
+error() { echo -e "${RED}[test]${NC} $1"; }
+
+# Parse arguments
+CI_MODE=0
+BUILD_FIRST=0
+PYTEST_ARGS=""
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --ci)
+            CI_MODE=1
+            shift
+            ;;
+        --build)
+            BUILD_FIRST=1
+            shift
+            ;;
+        *)
+            PYTEST_ARGS="$PYTEST_ARGS $1"
+            shift
+            ;;
+    esac
+done
+
+# Enable worktree isolation (same as e2e tests)
+export CONDUCTOR_WORKSPACE_PATH="$PROJECT_ROOT"
+
+cd "$PYTHON_DIR"
+
+# Build if requested
+if [ "$BUILD_FIRST" = "1" ]; then
+    log "Building runtimed binary..."
+    cargo build -p runtimed --manifest-path "$PROJECT_ROOT/Cargo.toml"
+
+    log "Building runtimed-py..."
+    uv run maturin develop --manifest-path "$PROJECT_ROOT/crates/runtimed-py/Cargo.toml"
+fi
+
+# Check if binary exists for CI mode
+if [ "$CI_MODE" = "1" ]; then
+    BINARY="${RUNTIMED_BINARY:-$PROJECT_ROOT/target/debug/runtimed}"
+    if [ ! -f "$BINARY" ]; then
+        error "runtimed binary not found at $BINARY"
+        error "Build with: cargo build -p runtimed"
+        exit 1
+    fi
+    export RUNTIMED_BINARY="$BINARY"
+    export RUNTIMED_INTEGRATION_TEST=1
+    log "CI mode: will spawn daemon from $BINARY"
+else
+    # Dev mode: check if daemon is running
+    log "Dev mode: checking for running daemon..."
+
+    # Try to import runtimed and check socket
+    if ! uv run python -c "
+import runtimed
+import os
+path = runtimed.default_socket_path() if hasattr(runtimed, 'default_socket_path') else None
+if path and not os.path.exists(path):
+    print(f'Socket not found: {path}')
+    exit(1)
+print(f'Using socket: {path}')
+" 2>/dev/null; then
+        warn "Daemon may not be running. Start with: cargo xtask dev-daemon"
+        warn "Or run in CI mode: ./tests/run-integration.sh --ci"
+    fi
+fi
+
+# Run tests
+log "Running integration tests..."
+PYTEST_DEFAULT_ARGS="-v --tb=short"
+
+if [ -z "$PYTEST_ARGS" ]; then
+    # Default: run daemon integration tests
+    PYTEST_ARGS="tests/test_daemon_integration.py"
+fi
+
+exec uv run pytest $PYTEST_DEFAULT_ARGS $PYTEST_ARGS

--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -1,0 +1,560 @@
+"""Integration tests for runtimed daemon client.
+
+These tests exercise the full daemon integration, including:
+- Document-first execution (automerge sync)
+- Multi-client synchronization
+- Kernel lifecycle management
+
+Running locally (with dev daemon already running):
+    pytest tests/test_daemon_integration.py -v
+
+Running in CI (spawns its own daemon):
+    RUNTIMED_INTEGRATION_TEST=1 pytest tests/test_daemon_integration.py -v
+
+Environment variables:
+    RUNTIMED_INTEGRATION_TEST=1  - Enable daemon spawning for CI
+    RUNTIMED_SOCKET_PATH         - Override socket path
+    RUNTIMED_BINARY              - Path to runtimed binary (for CI)
+    RUNTIMED_LOG_LEVEL           - Daemon log level (default: info)
+"""
+
+import os
+import subprocess
+import sys
+import tempfile
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+
+# Skip all tests if runtimed module not available
+pytest.importorskip("runtimed")
+
+import runtimed
+
+
+# ============================================================================
+# Fixtures for daemon management
+# ============================================================================
+
+
+def _find_runtimed_binary():
+    """Find the runtimed binary, checking common locations."""
+    # Explicit override
+    if "RUNTIMED_BINARY" in os.environ:
+        return Path(os.environ["RUNTIMED_BINARY"])
+
+    # Check relative to this repo
+    repo_root = Path(__file__).parent.parent.parent.parent.parent
+    candidates = [
+        repo_root / "target" / "debug" / "runtimed",
+        repo_root / "target" / "release" / "runtimed",
+    ]
+
+    for path in candidates:
+        if path.exists():
+            return path
+
+    pytest.skip("runtimed binary not found - build with: cargo build -p runtimed")
+
+
+def _is_integration_test_mode():
+    """Check if we should spawn our own daemon (CI mode)."""
+    return os.environ.get("RUNTIMED_INTEGRATION_TEST", "0") == "1"
+
+
+def _get_socket_path():
+    """Get the socket path for tests."""
+    if "RUNTIMED_SOCKET_PATH" in os.environ:
+        return Path(os.environ["RUNTIMED_SOCKET_PATH"])
+
+    # In integration test mode, use a temp directory
+    if _is_integration_test_mode():
+        return None  # Will be set by the daemon fixture
+
+    # Otherwise, use default (assumes dev daemon is running)
+    return runtimed.default_socket_path() if hasattr(runtimed, "default_socket_path") else None
+
+
+@pytest.fixture(scope="module")
+def daemon_process():
+    """Fixture that ensures a daemon is running.
+
+    In CI mode (RUNTIMED_INTEGRATION_TEST=1), spawns a daemon process.
+    In dev mode, assumes daemon is already running via `cargo xtask dev-daemon`.
+
+    Yields:
+        tuple: (socket_path, process_or_none)
+    """
+    if not _is_integration_test_mode():
+        # Dev mode: assume daemon is already running
+        socket_path = _get_socket_path()
+        if socket_path is None:
+            # Try the default
+            import runtimed as rt
+            socket_path = rt.default_socket_path() if hasattr(rt, "default_socket_path") else None
+
+        if socket_path and not socket_path.exists():
+            pytest.skip(
+                f"Daemon socket not found at {socket_path}. "
+                "Start daemon with: cargo xtask dev-daemon"
+            )
+
+        yield socket_path, None
+        return
+
+    # CI mode: spawn our own daemon
+    binary = _find_runtimed_binary()
+    log_level = os.environ.get("RUNTIMED_LOG_LEVEL", "info")
+
+    # Create a temp directory for this test run
+    with tempfile.TemporaryDirectory(prefix="runtimed-test-") as tmpdir:
+        tmpdir = Path(tmpdir)
+        socket_path = tmpdir / "runtimed.sock"
+        cache_dir = tmpdir / "cache"
+        blob_dir = tmpdir / "blobs"
+        cache_dir.mkdir()
+        blob_dir.mkdir()
+
+        # Build command
+        cmd = [
+            str(binary),
+            "run",
+            "--socket", str(socket_path),
+            "--cache-dir", str(cache_dir),
+            "--blob-store-dir", str(blob_dir),
+            "--uv-pool-size", "1",  # Minimal pool for tests
+            "--conda-pool-size", "0",  # No conda for speed
+        ]
+
+        print(f"\n[test] Starting daemon: {' '.join(cmd)}", file=sys.stderr)
+        print(f"[test] Socket path: {socket_path}", file=sys.stderr)
+
+        # Start daemon, capturing logs
+        log_file = tmpdir / "daemon.log"
+        with open(log_file, "w") as log_f:
+            env = os.environ.copy()
+            env["RUST_LOG"] = log_level
+
+            proc = subprocess.Popen(
+                cmd,
+                stdout=log_f,
+                stderr=subprocess.STDOUT,
+                env=env,
+            )
+
+        # Wait for socket to appear
+        for i in range(30):
+            if socket_path.exists():
+                print(f"[test] Daemon ready after {i + 1}s", file=sys.stderr)
+                break
+            if proc.poll() is not None:
+                # Daemon died - print logs and fail
+                print(f"[test] Daemon died with code {proc.returncode}", file=sys.stderr)
+                print(f"[test] Daemon logs:\n{log_file.read_text()}", file=sys.stderr)
+                pytest.fail("Daemon process died during startup")
+            time.sleep(1)
+        else:
+            proc.terminate()
+            print(f"[test] Daemon logs:\n{log_file.read_text()}", file=sys.stderr)
+            pytest.fail("Daemon socket did not appear within 30s")
+
+        try:
+            yield socket_path, proc
+        finally:
+            # Cleanup
+            print(f"\n[test] Stopping daemon...", file=sys.stderr)
+            proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait()
+
+            # Print daemon logs for debugging
+            if log_file.exists():
+                logs = log_file.read_text()
+                if logs:
+                    print(f"[test] Daemon logs:\n{logs}", file=sys.stderr)
+
+
+@pytest.fixture
+def session(daemon_process):
+    """Create a fresh Session for each test."""
+    socket_path, _ = daemon_process
+
+    # Create session with unique notebook ID
+    notebook_id = f"test-{uuid.uuid4()}"
+    sess = runtimed.Session(notebook_id=notebook_id)
+
+    # If we have a custom socket path, we need to configure it
+    # For now, the Session uses default_socket_path() internally
+    # which should work with CONDUCTOR_WORKSPACE_PATH or dev mode
+
+    sess.connect()
+    yield sess
+
+    # Cleanup: shutdown kernel if running
+    try:
+        if sess.kernel_started:
+            sess.shutdown_kernel()
+    except Exception:
+        pass
+
+
+@pytest.fixture
+def two_sessions(daemon_process):
+    """Create two sessions connected to the same notebook (peer sync test)."""
+    socket_path, _ = daemon_process
+
+    # Both sessions share the same notebook ID
+    notebook_id = f"test-{uuid.uuid4()}"
+
+    session1 = runtimed.Session(notebook_id=notebook_id)
+    session1.connect()
+
+    session2 = runtimed.Session(notebook_id=notebook_id)
+    session2.connect()
+
+    yield session1, session2
+
+    # Cleanup
+    for sess in [session1, session2]:
+        try:
+            if sess.kernel_started:
+                sess.shutdown_kernel()
+        except Exception:
+            pass
+
+
+# ============================================================================
+# Basic connectivity tests
+# ============================================================================
+
+
+class TestBasicConnectivity:
+    """Test basic daemon connectivity."""
+
+    def test_session_connect(self, session):
+        """Session can connect to daemon."""
+        assert session.is_connected
+
+    def test_session_repr(self, session):
+        """Session has useful repr."""
+        r = repr(session)
+        assert "Session" in r
+        assert session.notebook_id in r
+
+
+# ============================================================================
+# Document-first execution tests
+# ============================================================================
+
+
+class TestDocumentFirstExecution:
+    """Test document-first execution pattern.
+
+    These tests verify the architectural principle that execution reads
+    from the automerge document rather than receiving code directly.
+    """
+
+    def test_create_cell(self, session):
+        """Can create a cell in the document."""
+        cell_id = session.create_cell("x = 1")
+
+        assert cell_id.startswith("cell-")
+
+        # Verify cell exists in document
+        cell = session.get_cell(cell_id)
+        assert cell.id == cell_id
+        assert cell.source == "x = 1"
+        assert cell.cell_type == "code"
+
+    def test_update_cell_source(self, session):
+        """Can update cell source in document."""
+        cell_id = session.create_cell("original")
+        session.set_source(cell_id, "updated")
+
+        cell = session.get_cell(cell_id)
+        assert cell.source == "updated"
+
+    def test_get_cells(self, session):
+        """Can list all cells in document."""
+        # Create a few cells
+        cell_ids = [
+            session.create_cell("a = 1"),
+            session.create_cell("b = 2"),
+            session.create_cell("c = 3"),
+        ]
+
+        cells = session.get_cells()
+        assert len(cells) >= 3
+
+        found_ids = {c.id for c in cells}
+        for cid in cell_ids:
+            assert cid in found_ids
+
+    def test_delete_cell(self, session):
+        """Can delete a cell from document."""
+        cell_id = session.create_cell("to_delete")
+        session.delete_cell(cell_id)
+
+        with pytest.raises(runtimed.RuntimedError, match="not found"):
+            session.get_cell(cell_id)
+
+    def test_execute_cell_reads_from_document(self, session):
+        """execute_cell reads source from the synced document.
+
+        This is the core architectural test: execution uses ExecuteCell
+        which reads from the automerge doc, not QueueCell which bypasses it.
+        """
+        session.start_kernel()
+
+        # Create cell with source in document
+        cell_id = session.create_cell("result = 2 + 2; print(result)")
+
+        # Execute - daemon reads from document
+        result = session.execute_cell(cell_id)
+
+        assert result.success
+        assert "4" in result.stdout
+        assert result.cell_id == cell_id
+        assert result.execution_count is not None
+
+    def test_run_convenience_method(self, session):
+        """run() is a shortcut for create_cell + execute_cell."""
+        session.start_kernel()
+
+        result = session.run("print('hello from run')")
+
+        assert result.success
+        assert "hello from run" in result.stdout
+
+    def test_execution_error_captured(self, session):
+        """Execution errors are captured in result."""
+        session.start_kernel()
+
+        result = session.run("raise ValueError('test error')")
+
+        assert not result.success
+        assert result.error is not None
+        assert "ValueError" in result.error.ename
+
+    def test_multiple_executions(self, session):
+        """Can execute multiple cells sequentially."""
+        session.start_kernel()
+
+        # Execute multiple cells, building up state
+        r1 = session.run("x = 10")
+        assert r1.success
+
+        r2 = session.run("y = x * 2")
+        assert r2.success
+
+        r3 = session.run("print(f'y = {y}')")
+        assert r3.success
+        assert "y = 20" in r3.stdout
+
+
+# ============================================================================
+# Multi-client synchronization tests
+# ============================================================================
+
+
+class TestMultiClientSync:
+    """Test multi-client scenarios where two sessions share a notebook.
+
+    These tests verify that automerge sync works correctly when multiple
+    clients are connected to the same notebook.
+    """
+
+    def test_two_sessions_same_notebook(self, two_sessions):
+        """Two sessions can connect to the same notebook."""
+        s1, s2 = two_sessions
+
+        assert s1.is_connected
+        assert s2.is_connected
+        assert s1.notebook_id == s2.notebook_id
+
+    def test_cell_created_by_one_visible_to_other(self, two_sessions):
+        """Cell created by session 1 is visible to session 2."""
+        s1, s2 = two_sessions
+
+        # Session 1 creates a cell
+        cell_id = s1.create_cell("shared_var = 42")
+
+        # Give sync time to propagate
+        time.sleep(0.5)
+
+        # Session 2 should see it
+        cells = s2.get_cells()
+        found = [c for c in cells if c.id == cell_id]
+        assert len(found) == 1
+        assert found[0].source == "shared_var = 42"
+
+    def test_source_update_syncs_between_peers(self, two_sessions):
+        """Source updates sync between peers."""
+        s1, s2 = two_sessions
+
+        # Session 1 creates cell
+        cell_id = s1.create_cell("original")
+        time.sleep(0.3)
+
+        # Session 2 updates it
+        s2.set_source(cell_id, "updated by s2")
+        time.sleep(0.3)
+
+        # Session 1 should see the update
+        cell = s1.get_cell(cell_id)
+        assert cell.source == "updated by s2"
+
+    def test_shared_kernel_execution(self, two_sessions):
+        """Both sessions share the same kernel and execution state.
+
+        When two sessions connect to the same notebook, they share the
+        daemon's kernel. However, each session tracks its own `kernel_started`
+        flag locally, so both need to call start_kernel() (the second call
+        is a no-op in the daemon but updates local state).
+        """
+        s1, s2 = two_sessions
+
+        # Both sessions need to call start_kernel to update their local state
+        # The daemon only starts one kernel for the notebook
+        s1.start_kernel()
+        s2.start_kernel()  # No-op in daemon, but updates s2.kernel_started
+        time.sleep(0.5)
+
+        # Session 1 sets a variable
+        r1 = s1.run("shared = 'from s1'")
+        assert r1.success
+
+        # Session 2 can access it (same kernel)
+        r2 = s2.run("print(shared)")
+        assert r2.success
+        assert "from s1" in r2.stdout
+
+
+# ============================================================================
+# Kernel lifecycle tests
+# ============================================================================
+
+
+class TestKernelLifecycle:
+    """Test kernel lifecycle management."""
+
+    def test_start_kernel(self, session):
+        """Can start a kernel."""
+        assert not session.kernel_started
+
+        session.start_kernel()
+
+        assert session.kernel_started
+        assert session.env_source is not None
+
+    def test_kernel_interrupt(self, session):
+        """Can interrupt a running kernel."""
+        session.start_kernel()
+
+        # Start a long-running execution in background
+        cell_id = session.create_cell("import time; time.sleep(30)")
+
+        # We can't easily test async interrupt without threading,
+        # but we can at least verify the interrupt call doesn't error
+        # when nothing is running
+        session.interrupt()  # Should not raise
+
+    def test_shutdown_kernel(self, session):
+        """Can shutdown the kernel."""
+        session.start_kernel()
+        assert session.kernel_started
+
+        session.shutdown_kernel()
+        assert not session.kernel_started
+
+
+# ============================================================================
+# Output type tests
+# ============================================================================
+
+
+class TestOutputTypes:
+    """Test different output types from execution."""
+
+    def test_stdout_output(self, session):
+        """Captures stdout output."""
+        session.start_kernel()
+
+        result = session.run("print('hello stdout')")
+
+        assert result.success
+        assert result.stdout == "hello stdout\n"
+
+    def test_stderr_output(self, session):
+        """Captures stderr output."""
+        session.start_kernel()
+
+        result = session.run("import sys; sys.stderr.write('hello stderr\\n')")
+
+        assert result.success
+        assert "hello stderr" in result.stderr
+
+    def test_return_value(self, session):
+        """Captures expression return value."""
+        session.start_kernel()
+
+        result = session.run("2 + 2")
+
+        assert result.success
+        # Return value should appear in display_data
+        display = result.display_data
+        assert len(display) > 0
+
+    def test_multiple_outputs(self, session):
+        """Captures multiple outputs from one cell."""
+        session.start_kernel()
+
+        result = session.run("""
+print('line 1')
+print('line 2')
+'final value'
+""")
+
+        assert result.success
+        assert "line 1" in result.stdout
+        assert "line 2" in result.stdout
+
+
+# ============================================================================
+# Error handling tests
+# ============================================================================
+
+
+class TestErrorHandling:
+    """Test error handling scenarios."""
+
+    def test_execute_without_kernel(self, session):
+        """Executing without kernel raises helpful error."""
+        cell_id = session.create_cell("x = 1")
+
+        with pytest.raises(runtimed.RuntimedError, match="[Kk]ernel"):
+            session.execute_cell(cell_id)
+
+    def test_get_nonexistent_cell(self, session):
+        """Getting nonexistent cell raises error."""
+        with pytest.raises(runtimed.RuntimedError, match="not found"):
+            session.get_cell("cell-does-not-exist")
+
+    def test_syntax_error(self, session):
+        """Syntax errors are captured."""
+        session.start_kernel()
+
+        result = session.run("def broken(")
+
+        assert not result.success
+        assert result.error is not None
+        assert "SyntaxError" in result.error.ename
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/python/runtimed/uv.lock
+++ b/python/runtimed/uv.lock
@@ -838,7 +838,7 @@ wheels = [
 
 [[package]]
 name = "runtimed"
-version = "0.1.1"
+version = "0.1.4"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

Introduces the `runtimed` Python package - PyO3 bindings that enable programmatic notebook execution from Python. This is the foundation for agent tooling, MCP integrations, and automation workflows.

**What's included:**
- PyO3 bindings exposing daemon operations to Python
- Document-first execution model (cells synced via automerge)
- Multi-client support (multiple sessions can share a notebook)
- Comprehensive integration test suite (24 tests)
- CI workflow for automated testing

## New Components

### Rust Crate: `crates/runtimed-py/`

| Class | Purpose |
|-------|---------|
| `DaemonClient` | Low-level daemon ops: ping, status, list_rooms, flush_pool, shutdown |
| `Session` | High-level notebook execution with kernel lifecycle |
| `Cell` | Cell from automerge document (id, type, source, execution_count) |
| `ExecutionResult` | Execution result with outputs, success flag, stdout/stderr helpers |
| `Output` | Single output (stream, display_data, execute_result, error) |
| `RuntimedError` | Exception type for daemon errors |

### Python Package: `python/runtimed/`

```
python/runtimed/
├── pyproject.toml           # Maturin build config
├── src/runtimed/
│   ├── __init__.py          # Public API exports
│   ├── _binary.py           # runt binary discovery
│   ├── _sidecar.py          # Sidecar launcher for rich output
│   └── _ipython_bridge.py   # IOPub bridge for terminal IPython
└── tests/
    ├── test_daemon_integration.py  # 24 integration tests
    ├── test_sidecar.py             # Sidecar unit tests
    ├── test_ipython_bridge.py      # Bridge unit tests
    └── conftest.py                 # Pytest config
```

## API Examples

### Session (code execution)

```python
import runtimed

# Basic execution
with runtimed.Session(notebook_id="my-notebook") as session:
    session.start_kernel()
    result = session.run("print('hello')")
    print(result.stdout)  # "hello\n"

# Document-first pattern
session = runtimed.Session()
session.connect()
session.start_kernel()

# Create cell in automerge doc (syncs to all clients)
cell_id = session.create_cell("x = 42")

# Execute reads from document, not passed code
result = session.execute_cell(cell_id)

# Document operations
session.set_source(cell_id, "x = 100")  # Update cell
cell = session.get_cell(cell_id)         # Get cell info
cells = session.get_cells()              # List all cells
session.delete_cell(cell_id)             # Remove cell
```

### DaemonClient (low-level ops)

```python
client = runtimed.DaemonClient()
client.ping()        # True if daemon responding
stats = client.status()  # Pool stats
rooms = client.list_rooms()  # Active notebook rooms
```

## Document-First Execution

The bindings implement the architectural principle that execution reads from the automerge document rather than receiving code directly:

1. `session.create_cell(source)` - Creates cell in automerge doc
2. `session.execute_cell(cell_id)` - Daemon reads source from doc
3. All connected clients see the same code being executed

This enables multi-client scenarios where two Python sessions (or a Python session + the notebook app) can share a notebook and see each other's changes.

## Integration Tests

24 tests covering:
- **Basic connectivity** (2 tests) - Session connect, repr
- **Document-first execution** (8 tests) - Cell CRUD, execute reads from doc
- **Multi-client sync** (4 tests) - Two sessions sharing a notebook
- **Kernel lifecycle** (3 tests) - Start, interrupt, shutdown
- **Output types** (4 tests) - stdout, stderr, display_data, errors
- **Error handling** (3 tests) - Execute without kernel, missing cells, syntax errors

## Test plan

- [x] All 24 integration tests pass locally
- [x] CI workflow added (`runtimed-py-integration` job)
- [x] Multi-client automerge sync verified
- [x] Document-first execution pattern verified