### PR TITLE
feat(runtimed): add ExecuteCell request for document-first execution

### DIFF
--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -1198,6 +1198,7 @@ async fn launch_kernel_via_daemon(
 ///
 /// The daemon manages the execution queue and broadcasts outputs to all windows.
 #[tauri::command]
+#[allow(deprecated)]
 async fn queue_cell_via_daemon(
     cell_id: String,
     code: String,

--- a/crates/runtimed/src/protocol.rs
+++ b/crates/runtimed/src/protocol.rs
@@ -157,7 +157,15 @@ pub enum NotebookRequest {
 
     /// Queue a cell for execution.
     /// Daemon adds to queue and executes when previous cells complete.
+    #[deprecated(
+        since = "0.1.0",
+        note = "Use ExecuteCell instead - reads source from synced document"
+    )]
     QueueCell { cell_id: String, code: String },
+
+    /// Execute a cell by reading its source from the automerge doc.
+    /// This is the preferred method - ensures execution matches synced document state.
+    ExecuteCell { cell_id: String },
 
     /// Clear outputs for a cell (before re-execution).
     ClearOutputs { cell_id: String },
@@ -631,6 +639,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(deprecated)]
     fn test_notebook_request_queue_cell() {
         let req = NotebookRequest::QueueCell {
             cell_id: "abc-123".into(),


### PR DESCRIPTION
## Summary

Implement `ExecuteCell` request variant that reads cell source from the automerge document before queueing for execution. This enforces the architectural principle that the automerge document is the canonical source of truth for notebook content.

- Add `ExecuteCell { cell_id }` request variant to `NotebookRequest`
- Implement handler in `notebook_sync_server` that reads source from the document
- Validate cell exists and is a code cell before execution
- Deprecate `QueueCell` in favor of document-first approach
- All connected clients see consistent cell source and execution state

## Verification

- Build passes without warnings (`cargo clippy --all-targets -- -D warnings`)
- Protocol tests pass
- Frontend `queue_cell_via_daemon` still uses deprecated `QueueCell` for backward compatibility (separate migration PR to follow)

_PR submitted by @rgbkrk's agent, Quill_