### PR TITLE
fix(sync): address PR #347 review feedback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5171,6 +5171,7 @@ dependencies = [
  "kernel-launch",
  "libc",
  "log",
+ "nbformat",
  "nix",
  "notify",
  "notify-debouncer-mini",

--- a/crates/runtimed/Cargo.toml
+++ b/crates/runtimed/Cargo.toml
@@ -87,3 +87,4 @@ windows-sys = { version = "0.52", features = ["Win32_Storage_FileSystem", "Win32
 
 [dev-dependencies]
 tempfile = "3"
+nbformat = "1.2.0"

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -2161,14 +2161,14 @@ mod tests {
         pool.mark_warming(2);
         assert_eq!(pool.warming, 2);
 
-        pool.warming_failed();
+        pool.warming_failed_with_error(None);
         assert_eq!(pool.warming, 1);
 
-        pool.warming_failed();
+        pool.warming_failed_with_error(None);
         assert_eq!(pool.warming, 0);
 
         // Should not go negative
-        pool.warming_failed();
+        pool.warming_failed_with_error(None);
         assert_eq!(pool.warming, 0);
     }
 
@@ -2221,30 +2221,30 @@ mod tests {
         assert!(pool.should_retry());
 
         // First failure = 30s backoff
-        pool.warming_failed();
+        pool.warming_failed_with_error(None);
         assert_eq!(pool.backoff_delay(), std::time::Duration::from_secs(30));
         assert_eq!(pool.failure_state.consecutive_failures, 1);
 
         // Second failure = 60s
-        pool.warming_failed();
+        pool.warming_failed_with_error(None);
         assert_eq!(pool.backoff_delay(), std::time::Duration::from_secs(60));
         assert_eq!(pool.failure_state.consecutive_failures, 2);
 
         // Third = 120s
-        pool.warming_failed();
+        pool.warming_failed_with_error(None);
         assert_eq!(pool.backoff_delay(), std::time::Duration::from_secs(120));
 
         // Fourth = 240s
-        pool.warming_failed();
+        pool.warming_failed_with_error(None);
         assert_eq!(pool.backoff_delay(), std::time::Duration::from_secs(240));
 
         // Fifth and beyond = max 300s (5 min)
-        pool.warming_failed();
+        pool.warming_failed_with_error(None);
         assert_eq!(pool.backoff_delay(), std::time::Duration::from_secs(300));
 
         // Even more failures should stay at max
         for _ in 0..10 {
-            pool.warming_failed();
+            pool.warming_failed_with_error(None);
         }
         assert_eq!(pool.backoff_delay(), std::time::Duration::from_secs(300));
     }
@@ -2259,7 +2259,7 @@ mod tests {
             failed_package: Some("bad-pkg".to_string()),
             error_message: "not found".to_string(),
         }));
-        pool.warming_failed();
+        pool.warming_failed_with_error(None);
         assert_eq!(pool.failure_state.consecutive_failures, 2);
         assert!(pool.failure_state.last_error.is_some());
 

--- a/src/bindings/CondaDefaults.ts
+++ b/src/bindings/CondaDefaults.ts
@@ -3,4 +3,4 @@
 /**
  * Default packages for conda environments.
  */
-export type CondaDefaults = { default_packages: Array<string> };
+export type CondaDefaults = { default_packages: Array<string>, };

--- a/src/bindings/SyncedSettings.ts
+++ b/src/bindings/SyncedSettings.ts
@@ -8,25 +8,24 @@ import type { UvDefaults } from "./UvDefaults";
 /**
  * Snapshot of all synced settings.
  */
-export type SyncedSettings = {
-  /**
-   * UI theme
-   */
-  theme: ThemeMode;
-  /**
-   * Default runtime for new notebooks
-   */
-  default_runtime: Runtime;
-  /**
-   * Default Python environment type (uv or conda)
-   */
-  default_python_env: PythonEnvType;
-  /**
-   * UV environment defaults
-   */
-  uv: UvDefaults;
-  /**
-   * Conda environment defaults
-   */
-  conda: CondaDefaults;
-};
+export type SyncedSettings = { 
+/**
+ * UI theme
+ */
+theme: ThemeMode, 
+/**
+ * Default runtime for new notebooks
+ */
+default_runtime: Runtime, 
+/**
+ * Default Python environment type (uv or conda)
+ */
+default_python_env: PythonEnvType, 
+/**
+ * UV environment defaults
+ */
+uv: UvDefaults, 
+/**
+ * Conda environment defaults
+ */
+conda: CondaDefaults, };

--- a/src/bindings/UvDefaults.ts
+++ b/src/bindings/UvDefaults.ts
@@ -3,4 +3,4 @@
 /**
  * Default packages for uv environments.
  */
-export type UvDefaults = { default_packages: Array<string> };
+export type UvDefaults = { default_packages: Array<string>, };


### PR DESCRIPTION
## Summary

Addresses remaining code review feedback from PR #347 (metadata sync):

- Expand DenoMetadata to sync import_map, config, and flexible_npm_imports fields
- Deep-merge runt namespace to preserve unknown fields (e.g. trust_signature)
- Distinguish ENOENT from parse errors when reading existing notebooks
- Ensure nbformat_minor >= 5 when writing cell IDs (spec compliance)
- Return valid nbformat stream output for invalid JSON with TODO and warning
- Use NOTEBOOK_METADATA_KEY constant instead of hardcoded string
- Add integration tests for save_notebook_to_disk with nbformat v4 validation

## Verification

- [x] New tests pass: `cargo test -p runtimed notebook_sync_server::tests`
- [x] Verify round-trip preserves unknown metadata and trust signatures
- [x] Verify nbformat_minor is enforced when cell IDs are present
- [x] Manual test: create notebook with deno config, verify all fields sync

_PR submitted by @rgbkrk's agent, Quill_