### PR TITLE
feat(runtimed): wire ExecuteCell to frontend for document-first execution

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -239,7 +239,7 @@ function AppContent() {
     kernelInfo,
     queueState,
     launchKernel,
-    queueCell,
+    executeCell,
     clearOutputs,
     interruptKernel,
     shutdownKernel,
@@ -411,16 +411,19 @@ function AppContent() {
       // Clear outputs immediately so user sees feedback
       clearCellOutputs(cellId);
 
-      // Broadcast clear to other windows, then queue
+      // Broadcast clear to other windows
       await clearOutputs(cellId);
+
+      // Check if cell is code (early exit before daemon call)
       const cell = cells.find((c) => c.id === cellId);
       if (!cell || cell.cell_type !== "code") return;
 
-      // Start kernel via daemon if not running, then queue cell
+      // Start kernel via daemon if not running, then execute cell
+      // ExecuteCell reads source from the synced document (document-first execution)
       if (kernelStatus === "not_started") {
         await tryStartKernel();
       }
-      queueCell(cellId, cell.source);
+      executeCell(cellId);
     },
     [
       clearCellOutputs,
@@ -428,7 +431,7 @@ function AppContent() {
       cells,
       kernelStatus,
       tryStartKernel,
-      queueCell,
+      executeCell,
     ],
   );
 

--- a/apps/notebook/src/hooks/useDaemonKernel.ts
+++ b/apps/notebook/src/hooks/useDaemonKernel.ts
@@ -461,6 +461,22 @@ export function useDaemonKernel({
     [],
   );
 
+  /** Execute a cell via the daemon (reads source from synced document) */
+  const executeCell = useCallback(
+    async (cellId: string): Promise<DaemonNotebookResponse> => {
+      console.log("[daemon-kernel] executing cell:", cellId);
+      try {
+        return await invoke<DaemonNotebookResponse>("execute_cell_via_daemon", {
+          cellId,
+        });
+      } catch (e) {
+        console.error("[daemon-kernel] execute failed:", e);
+        throw e;
+      }
+    },
+    [],
+  );
+
   /** Clear outputs for a cell via the daemon */
   const clearOutputs = useCallback(
     async (cellId: string): Promise<DaemonNotebookResponse> => {
@@ -594,6 +610,8 @@ export function useDaemonKernel({
     launchKernel,
     /** Queue a cell for execution */
     queueCell,
+    /** Execute a cell (reads source from synced document) */
+    executeCell,
     /** Clear outputs for a cell */
     clearOutputs,
     /** Interrupt kernel execution */

--- a/crates/runtimed/src/protocol.rs
+++ b/crates/runtimed/src/protocol.rs
@@ -660,6 +660,24 @@ mod tests {
     }
 
     #[test]
+    fn test_notebook_request_execute_cell() {
+        let req = NotebookRequest::ExecuteCell {
+            cell_id: "cell-456".into(),
+        };
+        let json = serde_json::to_string(&req).unwrap();
+        assert!(json.contains("execute_cell"));
+        assert!(json.contains("cell-456"));
+
+        let parsed: NotebookRequest = serde_json::from_str(&json).unwrap();
+        match parsed {
+            NotebookRequest::ExecuteCell { cell_id } => {
+                assert_eq!(cell_id, "cell-456");
+            }
+            _ => panic!("unexpected request type"),
+        }
+    }
+
+    #[test]
     fn test_notebook_response_kernel_launched() {
         let resp = NotebookResponse::KernelLaunched {
             kernel_type: "python".into(),


### PR DESCRIPTION
## Summary

Complete the ExecuteCell migration (follow-up to #350) by connecting the frontend to the new document-first execution path. Addresses findings from Codex review.

**Changes:**
- Fix lock ordering in ExecuteCell handler: read doc first, then lock kernel (prevents contention)
- Add `execute_cell_via_daemon` Tauri command
- Add `executeCell` function to `useDaemonKernel` hook  
- Switch `handleExecuteCell` in App.tsx to use `executeCell` instead of `queueCell`
- Add JSON round-trip test for `ExecuteCell` protocol

The frontend now uses `ExecuteCell` which reads cell source from the synced Automerge document, ensuring all connected clients execute the same code.

## Verification

- [ ] Execute a cell in a notebook - verify outputs appear correctly
- [ ] Multi-window: edit cell in one window, execute from another - verify synced source is executed
- [ ] Execute non-code cell (markdown) - verify error handling

_PR submitted by @rgbkrk's agent, Quill_