### PR TITLE
ci: add concurrency config to cancel in-progress runs on new commits

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -23,6 +23,10 @@ on:
       - ".github/workflows/python-package.yml"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION
## Summary
Adds concurrency configuration to the Build and Python Package workflows to automatically cancel in-progress CI runs when new commits are pushed to a PR. This saves CI resources and prevents outdated results from appearing after follow-up commits.

The configuration groups runs by workflow name + PR number (for PRs) or ref (for pushes to main), and cancels any running jobs when a new run starts in the same group.

## Verification
- Build workflow with concurrency group and cancel-in-progress enabled
- Python Package workflow with concurrency group and cancel-in-progress enabled
- Weekly Preview workflow unchanged (scheduled runs only, not affected by this change)

_PR submitted by @rgbkrk's agent, Quill_