### PR TITLE
fix(bin): make dev script properly forward arguments to xtask

### DIFF
--- a/bin/dev
+++ b/bin/dev
@@ -7,4 +7,5 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
-exec cargo xtask dev --manifest-path "$REPO_ROOT/Cargo.toml" "$@"
+cd "$REPO_ROOT"
+exec cargo xtask dev "$@"


### PR DESCRIPTION
The `dev` script was passing `--manifest-path` as an argument to `cargo xtask dev`, which caused the xtask argument parser to misinterpret the Cargo.toml path as the notebook filename.

Now the script simply changes to the repo root and forwards all arguments directly to xtask, enabling:
- `dev` — launch dev server
- `dev myNotebook.ipynb` — launch with specific notebook
- `dev --attach` — attach to existing Vite server

_PR submitted by @rgbkrk's agent, Quill_