### PR TITLE
feat(runtimed-py): add AsyncSession and queue_cell() API

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -538,6 +538,10 @@ jobs:
         working-directory: python/runtimed
         run: uv run maturin develop --manifest-path ../../crates/runtimed-py/Cargo.toml
 
+      - name: Run unit tests
+        working-directory: python/runtimed
+        run: uv run pytest tests/test_session_unit.py -v --tb=short
+
       - name: Run integration tests
         timeout-minutes: 10
         working-directory: python/runtimed

--- a/crates/runtimed-py/src/async_session.rs
+++ b/crates/runtimed-py/src/async_session.rs
@@ -1,0 +1,1260 @@
+//! Async session for code execution.
+//!
+//! Provides an async interface for executing code via the daemon's kernel.
+//! All methods return Python coroutines that can be awaited.
+
+use pyo3::prelude::*;
+use pyo3_async_runtimes::tokio::future_into_py;
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+use runtimed::notebook_sync_client::{
+    NotebookBroadcastReceiver, NotebookSyncClient, NotebookSyncHandle, NotebookSyncReceiver,
+};
+use runtimed::protocol::{NotebookBroadcast, NotebookRequest, NotebookResponse};
+
+use crate::error::to_py_err;
+use crate::output::{Cell, ExecutionResult, Output};
+
+/// An async session for executing code via the runtimed daemon.
+///
+/// Each session connects to a unique "virtual notebook" room in the daemon
+/// and can launch a kernel and execute code. Sessions are isolated from
+/// each other but multiple sessions can share the same kernel if they
+/// use the same notebook_id.
+///
+/// Example:
+///     async with AsyncSession() as session:
+///         await session.start_kernel()
+///         result = await session.run("print('hello')")
+///         print(result.stdout)  # "hello\n"
+#[pyclass]
+pub struct AsyncSession {
+    state: Arc<Mutex<AsyncSessionState>>,
+    notebook_id: String,
+}
+
+struct AsyncSessionState {
+    handle: Option<NotebookSyncHandle>,
+    /// Keep the sync receiver alive so the sync task doesn't exit
+    #[allow(dead_code)]
+    sync_rx: Option<NotebookSyncReceiver>,
+    broadcast_rx: Option<NotebookBroadcastReceiver>,
+    kernel_started: bool,
+    env_source: Option<String>,
+    /// Base URL for blob server (for resolving blob hashes)
+    blob_base_url: Option<String>,
+    /// Path to blob store directory (fallback for direct disk access)
+    blob_store_path: Option<PathBuf>,
+}
+
+impl AsyncSessionState {
+    fn new() -> Self {
+        Self {
+            handle: None,
+            sync_rx: None,
+            broadcast_rx: None,
+            kernel_started: false,
+            env_source: None,
+            blob_base_url: None,
+            blob_store_path: None,
+        }
+    }
+}
+
+#[pymethods]
+impl AsyncSession {
+    /// Create a new async session.
+    ///
+    /// Args:
+    ///     notebook_id: Optional unique identifier for this session.
+    ///                  If not provided, a random UUID is generated.
+    ///                  Multiple AsyncSession objects with the same notebook_id
+    ///                  will share the same kernel.
+    #[new]
+    #[pyo3(signature = (notebook_id=None))]
+    fn new(notebook_id: Option<String>) -> PyResult<Self> {
+        let notebook_id =
+            notebook_id.unwrap_or_else(|| format!("agent-session-{}", uuid::Uuid::new_v4()));
+
+        Ok(Self {
+            state: Arc::new(Mutex::new(AsyncSessionState::new())),
+            notebook_id,
+        })
+    }
+
+    /// Get the notebook ID for this session.
+    #[getter]
+    fn notebook_id(&self) -> &str {
+        &self.notebook_id
+    }
+
+    /// Check if the session is connected to the daemon.
+    ///
+    /// Returns a coroutine that resolves to bool.
+    fn is_connected<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let state = Arc::clone(&self.state);
+        future_into_py(py, async move {
+            let state = state.lock().await;
+            Ok(state.handle.is_some())
+        })
+    }
+
+    /// Check if a kernel has been started.
+    ///
+    /// Returns a coroutine that resolves to bool.
+    fn kernel_started<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let state = Arc::clone(&self.state);
+        future_into_py(py, async move {
+            let state = state.lock().await;
+            Ok(state.kernel_started)
+        })
+    }
+
+    /// Get the environment source (e.g., "uv:prewarmed") if kernel is running.
+    ///
+    /// Returns a coroutine that resolves to Optional[str].
+    fn env_source<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let state = Arc::clone(&self.state);
+        future_into_py(py, async move {
+            let state = state.lock().await;
+            Ok(state.env_source.clone())
+        })
+    }
+
+    /// Connect to the daemon.
+    ///
+    /// This is called automatically by start_kernel() if not already connected.
+    /// Respects the RUNTIMED_SOCKET_PATH environment variable if set.
+    ///
+    /// Returns a coroutine.
+    fn connect<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let state = Arc::clone(&self.state);
+        let notebook_id = self.notebook_id.clone();
+
+        future_into_py(py, async move {
+            let mut state = state.lock().await;
+            if state.handle.is_some() {
+                return Ok(()); // Already connected
+            }
+
+            // Check for socket path override via environment variable
+            let socket_path = if let Ok(path) = std::env::var("RUNTIMED_SOCKET_PATH") {
+                std::path::PathBuf::from(path)
+            } else {
+                runtimed::default_socket_path()
+            };
+
+            let (handle, sync_rx, broadcast_rx, _cells, _notebook_path) =
+                NotebookSyncClient::connect_split(socket_path.clone(), notebook_id)
+                    .await
+                    .map_err(to_py_err)?;
+
+            // Determine blob server URL and blob store path based on socket path
+            let (blob_base_url, blob_store_path) = if let Some(parent) = socket_path.parent() {
+                let daemon_json = parent.join("daemon.json");
+                let base_url = if daemon_json.exists() {
+                    tokio::fs::read_to_string(&daemon_json)
+                        .await
+                        .ok()
+                        .and_then(|contents| {
+                            serde_json::from_str::<serde_json::Value>(&contents).ok()
+                        })
+                        .and_then(|info| info.get("blob_port").and_then(|p| p.as_u64()))
+                        .map(|port| format!("http://127.0.0.1:{}", port))
+                } else {
+                    None
+                };
+
+                let store_path = parent.join("blobs");
+                let store_path = if store_path.exists() {
+                    Some(store_path)
+                } else {
+                    None
+                };
+
+                (base_url, store_path)
+            } else {
+                (None, None)
+            };
+
+            state.handle = Some(handle);
+            state.sync_rx = Some(sync_rx);
+            state.broadcast_rx = Some(broadcast_rx);
+            state.blob_base_url = blob_base_url;
+            state.blob_store_path = blob_store_path;
+
+            Ok(())
+        })
+    }
+
+    /// Start a kernel for this session.
+    ///
+    /// Args:
+    ///     kernel_type: Type of kernel ("python" or "deno"). Defaults to "python".
+    ///     env_source: Environment source. Defaults to "uv:prewarmed".
+    ///
+    /// If a kernel is already running for this session's notebook_id,
+    /// this returns immediately without starting a new one.
+    ///
+    /// Returns a coroutine.
+    #[pyo3(signature = (kernel_type="python", env_source="uv:prewarmed"))]
+    fn start_kernel<'py>(
+        &self,
+        py: Python<'py>,
+        kernel_type: &str,
+        env_source: &str,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let state = Arc::clone(&self.state);
+        let notebook_id = self.notebook_id.clone();
+        let kernel_type = kernel_type.to_string();
+        let env_source = env_source.to_string();
+
+        future_into_py(py, async move {
+            // Ensure connected first
+            {
+                let state_guard = state.lock().await;
+                if state_guard.handle.is_none() {
+                    drop(state_guard);
+
+                    // Connect
+                    let socket_path = if let Ok(path) = std::env::var("RUNTIMED_SOCKET_PATH") {
+                        std::path::PathBuf::from(path)
+                    } else {
+                        runtimed::default_socket_path()
+                    };
+
+                    let (handle, sync_rx, broadcast_rx, _cells, _notebook_path) =
+                        NotebookSyncClient::connect_split(socket_path.clone(), notebook_id)
+                            .await
+                            .map_err(to_py_err)?;
+
+                    let (blob_base_url, blob_store_path) =
+                        if let Some(parent) = socket_path.parent() {
+                            let daemon_json = parent.join("daemon.json");
+                            let base_url = if daemon_json.exists() {
+                                tokio::fs::read_to_string(&daemon_json)
+                                    .await
+                                    .ok()
+                                    .and_then(|contents| {
+                                        serde_json::from_str::<serde_json::Value>(&contents).ok()
+                                    })
+                                    .and_then(|info| info.get("blob_port").and_then(|p| p.as_u64()))
+                                    .map(|port| format!("http://127.0.0.1:{}", port))
+                            } else {
+                                None
+                            };
+
+                            let store_path = parent.join("blobs");
+                            let store_path = if store_path.exists() {
+                                Some(store_path)
+                            } else {
+                                None
+                            };
+
+                            (base_url, store_path)
+                        } else {
+                            (None, None)
+                        };
+
+                    let mut state_guard2 = state.lock().await;
+                    state_guard2.handle = Some(handle);
+                    state_guard2.sync_rx = Some(sync_rx);
+                    state_guard2.broadcast_rx = Some(broadcast_rx);
+                    state_guard2.blob_base_url = blob_base_url;
+                    state_guard2.blob_store_path = blob_store_path;
+                }
+            }
+
+            let mut state_guard = state.lock().await;
+
+            let handle = state_guard
+                .handle
+                .as_ref()
+                .ok_or_else(|| to_py_err("Not connected"))?;
+
+            let response = handle
+                .send_request(NotebookRequest::LaunchKernel {
+                    kernel_type,
+                    env_source,
+                    notebook_path: None,
+                })
+                .await
+                .map_err(to_py_err)?;
+
+            match response {
+                NotebookResponse::KernelLaunched {
+                    env_source: actual_env,
+                    ..
+                } => {
+                    state_guard.kernel_started = true;
+                    state_guard.env_source = Some(actual_env);
+                    Ok(())
+                }
+                NotebookResponse::KernelAlreadyRunning {
+                    env_source: actual_env,
+                    ..
+                } => {
+                    state_guard.kernel_started = true;
+                    state_guard.env_source = Some(actual_env);
+                    Ok(())
+                }
+                NotebookResponse::Error { error } => Err(to_py_err(error)),
+                other => Err(to_py_err(format!("Unexpected response: {:?}", other))),
+            }
+        })
+    }
+
+    // =========================================================================
+    // Document Operations (write to automerge doc, synced to all clients)
+    // =========================================================================
+
+    /// Create a new cell in the automerge document.
+    ///
+    /// The cell is written to the shared document and synced to all connected
+    /// clients. Use execute_cell() to execute it.
+    ///
+    /// Args:
+    ///     source: The cell source code (default: empty string).
+    ///     cell_type: Cell type - "code", "markdown", or "raw" (default: "code").
+    ///     index: Position to insert the cell (default: append at end).
+    ///
+    /// Returns a coroutine that resolves to the cell ID (str).
+    #[pyo3(signature = (source="", cell_type="code", index=None))]
+    fn create_cell<'py>(
+        &self,
+        py: Python<'py>,
+        source: &str,
+        cell_type: &str,
+        index: Option<usize>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let state = Arc::clone(&self.state);
+        let source = source.to_string();
+        let cell_type = cell_type.to_string();
+
+        future_into_py(py, async move {
+            // Ensure connected
+            {
+                let state_guard = state.lock().await;
+                if state_guard.handle.is_none() {
+                    drop(state_guard);
+                    return Err(to_py_err("Not connected. Call connect() first."));
+                }
+            }
+
+            let cell_id = format!("cell-{}", uuid::Uuid::new_v4());
+
+            let state_guard = state.lock().await;
+            let handle = state_guard
+                .handle
+                .as_ref()
+                .ok_or_else(|| to_py_err("Not connected"))?;
+
+            let cells = handle.get_cells().await.map_err(to_py_err)?;
+            let insert_index = index.unwrap_or(cells.len());
+
+            handle
+                .add_cell(insert_index, &cell_id, &cell_type)
+                .await
+                .map_err(to_py_err)?;
+
+            if !source.is_empty() {
+                handle
+                    .update_source(&cell_id, &source)
+                    .await
+                    .map_err(to_py_err)?;
+            }
+
+            Ok(cell_id)
+        })
+    }
+
+    /// Update a cell's source in the automerge document.
+    ///
+    /// The change is synced to all connected clients.
+    ///
+    /// Args:
+    ///     cell_id: The cell ID.
+    ///     source: The new source code.
+    ///
+    /// Returns a coroutine.
+    fn set_source<'py>(
+        &self,
+        py: Python<'py>,
+        cell_id: &str,
+        source: &str,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let state = Arc::clone(&self.state);
+        let cell_id = cell_id.to_string();
+        let source = source.to_string();
+
+        future_into_py(py, async move {
+            let state_guard = state.lock().await;
+            let handle = state_guard
+                .handle
+                .as_ref()
+                .ok_or_else(|| to_py_err("Not connected"))?;
+
+            handle
+                .update_source(&cell_id, &source)
+                .await
+                .map_err(to_py_err)
+        })
+    }
+
+    /// Get a cell from the automerge document.
+    ///
+    /// Args:
+    ///     cell_id: The cell ID.
+    ///
+    /// Returns a coroutine that resolves to Cell object.
+    ///
+    /// Raises:
+    ///     RuntimedError: If cell not found.
+    fn get_cell<'py>(&self, py: Python<'py>, cell_id: &str) -> PyResult<Bound<'py, PyAny>> {
+        let state = Arc::clone(&self.state);
+        let cell_id = cell_id.to_string();
+
+        future_into_py(py, async move {
+            let state_guard = state.lock().await;
+            let handle = state_guard
+                .handle
+                .as_ref()
+                .ok_or_else(|| to_py_err("Not connected"))?;
+
+            let cells = handle.get_cells().await.map_err(to_py_err)?;
+            cells
+                .into_iter()
+                .find(|c| c.id == cell_id)
+                .map(Cell::from_snapshot)
+                .ok_or_else(|| to_py_err(format!("Cell not found: {}", cell_id)))
+        })
+    }
+
+    /// Get all cells from the automerge document.
+    ///
+    /// Returns a coroutine that resolves to List[Cell].
+    fn get_cells<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let state = Arc::clone(&self.state);
+
+        future_into_py(py, async move {
+            let state_guard = state.lock().await;
+            let handle = state_guard
+                .handle
+                .as_ref()
+                .ok_or_else(|| to_py_err("Not connected"))?;
+
+            let cells = handle.get_cells().await.map_err(to_py_err)?;
+            Ok(cells
+                .into_iter()
+                .map(Cell::from_snapshot)
+                .collect::<Vec<_>>())
+        })
+    }
+
+    /// Delete a cell from the automerge document.
+    ///
+    /// Args:
+    ///     cell_id: The cell ID to delete.
+    ///
+    /// Returns a coroutine.
+    fn delete_cell<'py>(&self, py: Python<'py>, cell_id: &str) -> PyResult<Bound<'py, PyAny>> {
+        let state = Arc::clone(&self.state);
+        let cell_id = cell_id.to_string();
+
+        future_into_py(py, async move {
+            let state_guard = state.lock().await;
+            let handle = state_guard
+                .handle
+                .as_ref()
+                .ok_or_else(|| to_py_err("Not connected"))?;
+
+            handle.delete_cell(&cell_id).await.map_err(to_py_err)
+        })
+    }
+
+    // =========================================================================
+    // Execution (document-first: reads source from automerge doc)
+    // =========================================================================
+
+    /// Execute a cell by ID.
+    ///
+    /// The daemon reads the cell's source from the automerge document and
+    /// executes it. This ensures all clients see the same code being executed.
+    ///
+    /// If a kernel isn't running yet, this will start one automatically.
+    /// If a kernel is already running in the daemon (e.g., started by another
+    /// client), it will reuse that kernel.
+    ///
+    /// Args:
+    ///     cell_id: The cell ID to execute.
+    ///     timeout_secs: Maximum time to wait for execution (default: 60).
+    ///
+    /// Returns a coroutine that resolves to ExecutionResult.
+    ///
+    /// Raises:
+    ///     RuntimedError: If not connected, cell not found, or timeout.
+    #[pyo3(signature = (cell_id, timeout_secs=60.0))]
+    fn execute_cell<'py>(
+        &self,
+        py: Python<'py>,
+        cell_id: &str,
+        timeout_secs: f64,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let state = Arc::clone(&self.state);
+        let notebook_id = self.notebook_id.clone();
+        let cell_id = cell_id.to_string();
+
+        future_into_py(py, async move {
+            // Auto-start kernel if not running
+            {
+                let state_guard = state.lock().await;
+                if !state_guard.kernel_started {
+                    drop(state_guard);
+
+                    // Need to connect and start kernel
+                    let state_guard = state.lock().await;
+                    if state_guard.handle.is_none() {
+                        drop(state_guard);
+
+                        let socket_path = if let Ok(path) = std::env::var("RUNTIMED_SOCKET_PATH") {
+                            std::path::PathBuf::from(path)
+                        } else {
+                            runtimed::default_socket_path()
+                        };
+
+                        let (handle, sync_rx, broadcast_rx, _cells, _notebook_path) =
+                            NotebookSyncClient::connect_split(
+                                socket_path.clone(),
+                                notebook_id.clone(),
+                            )
+                            .await
+                            .map_err(to_py_err)?;
+
+                        let (blob_base_url, blob_store_path) = if let Some(parent) =
+                            socket_path.parent()
+                        {
+                            let daemon_json = parent.join("daemon.json");
+                            let base_url = if daemon_json.exists() {
+                                tokio::fs::read_to_string(&daemon_json)
+                                    .await
+                                    .ok()
+                                    .and_then(|contents| {
+                                        serde_json::from_str::<serde_json::Value>(&contents).ok()
+                                    })
+                                    .and_then(|info| info.get("blob_port").and_then(|p| p.as_u64()))
+                                    .map(|port| format!("http://127.0.0.1:{}", port))
+                            } else {
+                                None
+                            };
+
+                            let store_path = parent.join("blobs");
+                            let store_path = if store_path.exists() {
+                                Some(store_path)
+                            } else {
+                                None
+                            };
+
+                            (base_url, store_path)
+                        } else {
+                            (None, None)
+                        };
+
+                        let mut state_guard = state.lock().await;
+                        state_guard.handle = Some(handle);
+                        state_guard.sync_rx = Some(sync_rx);
+                        state_guard.broadcast_rx = Some(broadcast_rx);
+                        state_guard.blob_base_url = blob_base_url;
+                        state_guard.blob_store_path = blob_store_path;
+                    }
+
+                    // Start kernel
+                    let mut state_guard = state.lock().await;
+                    let handle = state_guard
+                        .handle
+                        .as_ref()
+                        .ok_or_else(|| to_py_err("Not connected"))?;
+
+                    let response = handle
+                        .send_request(NotebookRequest::LaunchKernel {
+                            kernel_type: "python".to_string(),
+                            env_source: "uv:prewarmed".to_string(),
+                            notebook_path: None,
+                        })
+                        .await
+                        .map_err(to_py_err)?;
+
+                    match response {
+                        NotebookResponse::KernelLaunched {
+                            env_source: actual_env,
+                            ..
+                        } => {
+                            state_guard.kernel_started = true;
+                            state_guard.env_source = Some(actual_env);
+                        }
+                        NotebookResponse::KernelAlreadyRunning {
+                            env_source: actual_env,
+                            ..
+                        } => {
+                            state_guard.kernel_started = true;
+                            state_guard.env_source = Some(actual_env);
+                        }
+                        NotebookResponse::Error { error } => return Err(to_py_err(error)),
+                        other => {
+                            return Err(to_py_err(format!("Unexpected response: {:?}", other)))
+                        }
+                    }
+                }
+            }
+
+            let state_guard = state.lock().await;
+
+            let handle = state_guard
+                .handle
+                .as_ref()
+                .ok_or_else(|| to_py_err("Not connected"))?;
+
+            let blob_base_url = state_guard.blob_base_url.clone();
+            let blob_store_path = state_guard.blob_store_path.clone();
+
+            // Execute cell (daemon reads source from automerge doc)
+            let response = handle
+                .send_request(NotebookRequest::ExecuteCell {
+                    cell_id: cell_id.clone(),
+                })
+                .await
+                .map_err(to_py_err)?;
+
+            match response {
+                NotebookResponse::CellQueued { .. } => {}
+                NotebookResponse::Error { error } => return Err(to_py_err(error)),
+                other => return Err(to_py_err(format!("Unexpected response: {:?}", other))),
+            }
+
+            drop(state_guard); // Release lock before waiting for broadcasts
+
+            // Wait for outputs
+            let timeout = std::time::Duration::from_secs_f64(timeout_secs);
+            let result = tokio::time::timeout(
+                timeout,
+                collect_outputs_async(&state, &cell_id, blob_base_url, blob_store_path),
+            )
+            .await;
+
+            match result {
+                Ok(Ok(exec_result)) => Ok(exec_result),
+                Ok(Err(e)) => Err(e),
+                Err(_) => Err(to_py_err(format!(
+                    "Execution timed out after {} seconds",
+                    timeout_secs
+                ))),
+            }
+        })
+    }
+
+    /// Convenience method: create a cell, execute it, and return the result.
+    ///
+    /// This is a shortcut that combines create_cell() and execute_cell().
+    /// The cell is written to the automerge document before execution,
+    /// so other connected clients will see it.
+    ///
+    /// Args:
+    ///     code: The code to execute.
+    ///     timeout_secs: Maximum time to wait for execution (default: 60).
+    ///
+    /// Returns a coroutine that resolves to ExecutionResult.
+    ///
+    /// Raises:
+    ///     RuntimedError: If not connected, kernel not started, or timeout.
+    #[pyo3(signature = (code, timeout_secs=60.0))]
+    fn run<'py>(
+        &self,
+        py: Python<'py>,
+        code: &str,
+        timeout_secs: f64,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let state = Arc::clone(&self.state);
+        let notebook_id = self.notebook_id.clone();
+        let code = code.to_string();
+
+        future_into_py(py, async move {
+            // Ensure connected
+            {
+                let state_guard = state.lock().await;
+                if state_guard.handle.is_none() {
+                    drop(state_guard);
+
+                    let socket_path = if let Ok(path) = std::env::var("RUNTIMED_SOCKET_PATH") {
+                        std::path::PathBuf::from(path)
+                    } else {
+                        runtimed::default_socket_path()
+                    };
+
+                    let (handle, sync_rx, broadcast_rx, _cells, _notebook_path) =
+                        NotebookSyncClient::connect_split(socket_path.clone(), notebook_id.clone())
+                            .await
+                            .map_err(to_py_err)?;
+
+                    let (blob_base_url, blob_store_path) =
+                        if let Some(parent) = socket_path.parent() {
+                            let daemon_json = parent.join("daemon.json");
+                            let base_url = if daemon_json.exists() {
+                                tokio::fs::read_to_string(&daemon_json)
+                                    .await
+                                    .ok()
+                                    .and_then(|contents| {
+                                        serde_json::from_str::<serde_json::Value>(&contents).ok()
+                                    })
+                                    .and_then(|info| info.get("blob_port").and_then(|p| p.as_u64()))
+                                    .map(|port| format!("http://127.0.0.1:{}", port))
+                            } else {
+                                None
+                            };
+
+                            let store_path = parent.join("blobs");
+                            let store_path = if store_path.exists() {
+                                Some(store_path)
+                            } else {
+                                None
+                            };
+
+                            (base_url, store_path)
+                        } else {
+                            (None, None)
+                        };
+
+                    let mut state_guard = state.lock().await;
+                    state_guard.handle = Some(handle);
+                    state_guard.sync_rx = Some(sync_rx);
+                    state_guard.broadcast_rx = Some(broadcast_rx);
+                    state_guard.blob_base_url = blob_base_url;
+                    state_guard.blob_store_path = blob_store_path;
+                }
+            }
+
+            // Create cell in document
+            let cell_id = format!("cell-{}", uuid::Uuid::new_v4());
+            {
+                let state_guard = state.lock().await;
+                let handle = state_guard
+                    .handle
+                    .as_ref()
+                    .ok_or_else(|| to_py_err("Not connected"))?;
+
+                let cells = handle.get_cells().await.map_err(to_py_err)?;
+                let insert_index = cells.len();
+
+                handle
+                    .add_cell(insert_index, &cell_id, "code")
+                    .await
+                    .map_err(to_py_err)?;
+
+                handle
+                    .update_source(&cell_id, &code)
+                    .await
+                    .map_err(to_py_err)?;
+            }
+
+            // Auto-start kernel if needed
+            {
+                let state_guard = state.lock().await;
+                if !state_guard.kernel_started {
+                    drop(state_guard);
+
+                    let mut state_guard = state.lock().await;
+                    let handle = state_guard
+                        .handle
+                        .as_ref()
+                        .ok_or_else(|| to_py_err("Not connected"))?;
+
+                    let response = handle
+                        .send_request(NotebookRequest::LaunchKernel {
+                            kernel_type: "python".to_string(),
+                            env_source: "uv:prewarmed".to_string(),
+                            notebook_path: None,
+                        })
+                        .await
+                        .map_err(to_py_err)?;
+
+                    match response {
+                        NotebookResponse::KernelLaunched {
+                            env_source: actual_env,
+                            ..
+                        } => {
+                            state_guard.kernel_started = true;
+                            state_guard.env_source = Some(actual_env);
+                        }
+                        NotebookResponse::KernelAlreadyRunning {
+                            env_source: actual_env,
+                            ..
+                        } => {
+                            state_guard.kernel_started = true;
+                            state_guard.env_source = Some(actual_env);
+                        }
+                        NotebookResponse::Error { error } => return Err(to_py_err(error)),
+                        other => {
+                            return Err(to_py_err(format!("Unexpected response: {:?}", other)))
+                        }
+                    }
+                }
+            }
+
+            // Execute
+            let state_guard = state.lock().await;
+            let handle = state_guard
+                .handle
+                .as_ref()
+                .ok_or_else(|| to_py_err("Not connected"))?;
+
+            let blob_base_url = state_guard.blob_base_url.clone();
+            let blob_store_path = state_guard.blob_store_path.clone();
+
+            let response = handle
+                .send_request(NotebookRequest::ExecuteCell {
+                    cell_id: cell_id.clone(),
+                })
+                .await
+                .map_err(to_py_err)?;
+
+            match response {
+                NotebookResponse::CellQueued { .. } => {}
+                NotebookResponse::Error { error } => return Err(to_py_err(error)),
+                other => return Err(to_py_err(format!("Unexpected response: {:?}", other))),
+            }
+
+            drop(state_guard);
+
+            let timeout = std::time::Duration::from_secs_f64(timeout_secs);
+            let result = tokio::time::timeout(
+                timeout,
+                collect_outputs_async(&state, &cell_id, blob_base_url, blob_store_path),
+            )
+            .await;
+
+            match result {
+                Ok(Ok(exec_result)) => Ok(exec_result),
+                Ok(Err(e)) => Err(e),
+                Err(_) => Err(to_py_err(format!(
+                    "Execution timed out after {} seconds",
+                    timeout_secs
+                ))),
+            }
+        })
+    }
+
+    /// Interrupt the currently executing cell.
+    ///
+    /// Returns a coroutine.
+    fn interrupt<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let state = Arc::clone(&self.state);
+
+        future_into_py(py, async move {
+            let state_guard = state.lock().await;
+
+            let handle = state_guard
+                .handle
+                .as_ref()
+                .ok_or_else(|| to_py_err("Not connected"))?;
+
+            let response = handle
+                .send_request(NotebookRequest::InterruptExecution {})
+                .await
+                .map_err(to_py_err)?;
+
+            match response {
+                NotebookResponse::InterruptSent {} => Ok(()),
+                NotebookResponse::NoKernel {} => Err(to_py_err("No kernel running")),
+                NotebookResponse::Error { error } => Err(to_py_err(error)),
+                other => Err(to_py_err(format!("Unexpected response: {:?}", other))),
+            }
+        })
+    }
+
+    /// Shutdown the kernel.
+    ///
+    /// Returns a coroutine.
+    fn shutdown_kernel<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let state = Arc::clone(&self.state);
+
+        future_into_py(py, async move {
+            let mut state_guard = state.lock().await;
+
+            let handle = state_guard
+                .handle
+                .as_ref()
+                .ok_or_else(|| to_py_err("Not connected"))?;
+
+            let response = handle
+                .send_request(NotebookRequest::ShutdownKernel {})
+                .await
+                .map_err(to_py_err)?;
+
+            match response {
+                NotebookResponse::KernelShuttingDown {} => {
+                    state_guard.kernel_started = false;
+                    state_guard.env_source = None;
+                    Ok(())
+                }
+                NotebookResponse::NoKernel {} => {
+                    state_guard.kernel_started = false;
+                    state_guard.env_source = None;
+                    Ok(())
+                }
+                NotebookResponse::Error { error } => Err(to_py_err(error)),
+                other => Err(to_py_err(format!("Unexpected response: {:?}", other))),
+            }
+        })
+    }
+
+    /// Close the session and shutdown the kernel if running.
+    ///
+    /// Returns a coroutine.
+    fn close<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let state = Arc::clone(&self.state);
+
+        future_into_py(py, async move {
+            let mut state_guard = state.lock().await;
+            if state_guard.kernel_started {
+                if let Some(handle) = state_guard.handle.as_ref() {
+                    let _ = handle
+                        .send_request(NotebookRequest::ShutdownKernel {})
+                        .await;
+                }
+                state_guard.kernel_started = false;
+                state_guard.env_source = None;
+            }
+            Ok(())
+        })
+    }
+
+    fn __repr__(&self) -> String {
+        format!("AsyncSession(id={})", self.notebook_id)
+    }
+
+    /// Async context manager entry.
+    ///
+    /// Returns a coroutine that resolves to self.
+    fn __aenter__(slf: Py<Self>, py: Python<'_>) -> PyResult<Bound<'_, PyAny>> {
+        // Return a coroutine that immediately resolves to self
+        future_into_py(py, async move { Ok(slf) })
+    }
+
+    /// Async context manager exit.
+    #[pyo3(signature = (_exc_type=None, _exc_val=None, _exc_tb=None))]
+    fn __aexit__<'py>(
+        &self,
+        py: Python<'py>,
+        _exc_type: Option<&Bound<'_, PyAny>>,
+        _exc_val: Option<&Bound<'_, PyAny>>,
+        _exc_tb: Option<&Bound<'_, PyAny>>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let state = Arc::clone(&self.state);
+
+        future_into_py(py, async move {
+            let mut state_guard = state.lock().await;
+            if state_guard.kernel_started {
+                if let Some(handle) = state_guard.handle.as_ref() {
+                    let _ = handle
+                        .send_request(NotebookRequest::ShutdownKernel {})
+                        .await;
+                }
+                state_guard.kernel_started = false;
+                state_guard.env_source = None;
+            }
+            Ok(false) // Don't suppress exceptions
+        })
+    }
+}
+
+// =========================================================================
+// Helper functions (outside impl block for async use)
+// =========================================================================
+
+/// Collect outputs for a cell until ExecutionDone is received.
+async fn collect_outputs_async(
+    state: &Arc<Mutex<AsyncSessionState>>,
+    cell_id: &str,
+    blob_base_url: Option<String>,
+    blob_store_path: Option<PathBuf>,
+) -> PyResult<ExecutionResult> {
+    let mut outputs = Vec::new();
+    let mut execution_count = None;
+    let mut success = true;
+    let mut done_received = false;
+
+    loop {
+        let mut state_guard = state.lock().await;
+
+        let broadcast_rx = state_guard
+            .broadcast_rx
+            .as_mut()
+            .ok_or_else(|| to_py_err("Not connected"))?;
+
+        let timeout_ms = if done_received { 50 } else { 100 };
+        let broadcast = tokio::time::timeout(
+            std::time::Duration::from_millis(timeout_ms),
+            broadcast_rx.recv(),
+        )
+        .await;
+
+        match broadcast {
+            Ok(Some(msg)) => {
+                drop(state_guard);
+                log::debug!("[async_session] Received broadcast: {:?}", msg);
+
+                match msg {
+                    NotebookBroadcast::ExecutionStarted {
+                        cell_id: msg_cell_id,
+                        execution_count: count,
+                    } => {
+                        if msg_cell_id == cell_id {
+                            execution_count = Some(count);
+                        }
+                    }
+                    NotebookBroadcast::Output {
+                        cell_id: msg_cell_id,
+                        output_type,
+                        output_json,
+                    } => {
+                        if msg_cell_id == cell_id {
+                            if let Some(output) = parse_output_async(
+                                &output_type,
+                                &output_json,
+                                &blob_base_url,
+                                &blob_store_path,
+                            )
+                            .await
+                            {
+                                if output.output_type == "error" {
+                                    success = false;
+                                }
+                                outputs.push(output);
+                            }
+                        }
+                    }
+                    NotebookBroadcast::ExecutionDone {
+                        cell_id: msg_cell_id,
+                    } => {
+                        if msg_cell_id == cell_id {
+                            log::debug!(
+                                "[async_session] ExecutionDone received, starting drain phase"
+                            );
+                            done_received = true;
+                        }
+                    }
+                    NotebookBroadcast::KernelError { error } => {
+                        success = false;
+                        outputs.push(Output::error("KernelError", &error, vec![]));
+                        done_received = true;
+                    }
+                    _ => {}
+                }
+            }
+            Ok(None) => {
+                return Err(to_py_err("Broadcast channel closed"));
+            }
+            Err(_) => {
+                if done_received {
+                    log::debug!(
+                        "[async_session] Drain timeout, finishing with {} outputs",
+                        outputs.len()
+                    );
+                    break;
+                }
+            }
+        }
+    }
+
+    Ok(ExecutionResult {
+        cell_id: cell_id.to_string(),
+        outputs,
+        success,
+        execution_count,
+    })
+}
+
+/// Parse an output from the daemon broadcast.
+async fn parse_output_async(
+    output_type: &str,
+    output_json: &str,
+    blob_base_url: &Option<String>,
+    blob_store_path: &Option<PathBuf>,
+) -> Option<Output> {
+    // Try to parse output_json directly first
+    if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(output_json) {
+        return output_from_json(output_type, &parsed);
+    }
+
+    // If it looks like a blob hash (64 hex chars), try to resolve it
+    if output_json.len() == 64 && output_json.chars().all(|c| c.is_ascii_hexdigit()) {
+        log::debug!("[async_session] Detected blob hash: {}", output_json);
+
+        // First try: read directly from disk
+        if let Some(store_path) = blob_store_path {
+            let prefix = &output_json[..2];
+            let rest = &output_json[2..];
+            let blob_path = store_path.join(prefix).join(rest);
+
+            if let Ok(contents) = tokio::fs::read_to_string(&blob_path).await {
+                if let Ok(manifest) = serde_json::from_str::<serde_json::Value>(&contents) {
+                    return output_from_manifest_async(output_type, &manifest, blob_store_path)
+                        .await;
+                }
+            }
+        }
+
+        // Second try: fetch from blob server
+        if let Some(base_url) = blob_base_url {
+            let url = format!("{}/blobs/{}", base_url, output_json);
+            if let Ok(response) = reqwest::get(&url).await {
+                if response.status().is_success() {
+                    if let Ok(manifest) = response.json::<serde_json::Value>().await {
+                        return output_from_manifest_async(output_type, &manifest, blob_store_path)
+                            .await;
+                    }
+                }
+            }
+        }
+    }
+
+    // Fallback
+    if output_type == "error" {
+        Some(Output::error(
+            "OutputParseError",
+            &format!("Failed to parse error output: {}", output_json),
+            vec![],
+        ))
+    } else {
+        Some(Output::stream(
+            "stderr",
+            &format!("Failed to parse output: {}", output_json),
+        ))
+    }
+}
+
+/// Convert a parsed JSON value to an Output.
+fn output_from_json(output_type: &str, json: &serde_json::Value) -> Option<Output> {
+    match output_type {
+        "stream" => {
+            let name = json.get("name")?.as_str()?;
+            let text = json.get("text")?.as_str()?;
+            Some(Output::stream(name, text))
+        }
+        "display_data" => {
+            let data = json.get("data")?.as_object()?;
+            let mut output_data = HashMap::new();
+            for (key, value) in data {
+                if let Some(s) = value.as_str() {
+                    output_data.insert(key.clone(), s.to_string());
+                } else {
+                    output_data.insert(key.clone(), value.to_string());
+                }
+            }
+            Some(Output::display_data(output_data))
+        }
+        "execute_result" => {
+            let data = json.get("data")?.as_object()?;
+            let execution_count = json.get("execution_count")?.as_i64()?;
+            let mut output_data = HashMap::new();
+            for (key, value) in data {
+                if let Some(s) = value.as_str() {
+                    output_data.insert(key.clone(), s.to_string());
+                } else {
+                    output_data.insert(key.clone(), value.to_string());
+                }
+            }
+            Some(Output::execute_result(output_data, execution_count))
+        }
+        "error" => {
+            let ename = json.get("ename")?.as_str()?.to_string();
+            let evalue = json.get("evalue")?.as_str()?.to_string();
+            let traceback = json
+                .get("traceback")?
+                .as_array()?
+                .iter()
+                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                .collect();
+            Some(Output::error(&ename, &evalue, traceback))
+        }
+        _ => None,
+    }
+}
+
+/// Convert a blob manifest to an Output.
+async fn output_from_manifest_async(
+    output_type: &str,
+    manifest: &serde_json::Value,
+    blob_store_path: &Option<PathBuf>,
+) -> Option<Output> {
+    match output_type {
+        "stream" => {
+            let name = manifest.get("name")?.as_str()?;
+            let text_ref = manifest.get("text")?;
+            let text = resolve_content_ref_async(text_ref, blob_store_path).await?;
+            Some(Output::stream(name, &text))
+        }
+        "display_data" | "execute_result" => {
+            let data_map = manifest.get("data")?.as_object()?;
+            let mut output_data = HashMap::new();
+
+            for (mime_type, content_ref) in data_map {
+                if let Some(content) = resolve_content_ref_async(content_ref, blob_store_path).await
+                {
+                    output_data.insert(mime_type.clone(), content);
+                }
+            }
+
+            if output_type == "execute_result" {
+                let execution_count = manifest.get("execution_count")?.as_i64()?;
+                Some(Output::execute_result(output_data, execution_count))
+            } else {
+                Some(Output::display_data(output_data))
+            }
+        }
+        "error" => {
+            let ename = manifest.get("ename")?.as_str()?.to_string();
+            let evalue = manifest.get("evalue")?.as_str()?.to_string();
+
+            let traceback_val = manifest.get("traceback")?;
+            let traceback = if let Some(arr) = traceback_val.as_array() {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                    .collect()
+            } else {
+                let tb_str = resolve_content_ref_async(traceback_val, blob_store_path).await?;
+                serde_json::from_str::<Vec<String>>(&tb_str).ok()?
+            };
+
+            Some(Output::error(&ename, &evalue, traceback))
+        }
+        _ => None,
+    }
+}
+
+/// Resolve a content reference from a blob manifest.
+async fn resolve_content_ref_async(
+    content_ref: &serde_json::Value,
+    blob_store_path: &Option<PathBuf>,
+) -> Option<String> {
+    if let Some(inline) = content_ref.get("inline") {
+        return inline.as_str().map(|s| s.to_string());
+    }
+
+    if let Some(blob_hash) = content_ref.get("blob").and_then(|v| v.as_str()) {
+        if let Some(store_path) = blob_store_path {
+            if blob_hash.len() >= 2 {
+                let prefix = &blob_hash[..2];
+                let rest = &blob_hash[2..];
+                let blob_path = store_path.join(prefix).join(rest);
+
+                if let Ok(contents) = tokio::fs::read_to_string(&blob_path).await {
+                    return Some(contents);
+                }
+            }
+        }
+    }
+
+    None
+}

--- a/crates/runtimed-py/src/lib.rs
+++ b/crates/runtimed-py/src/lib.rs
@@ -2,17 +2,20 @@
 //!
 //! Provides Python classes for:
 //! - `DaemonClient`: Low-level daemon operations (status, ping, list rooms)
-//! - `Session`: High-level code execution with kernel management
+//! - `Session`: Synchronous code execution with kernel management
+//! - `AsyncSession`: Async code execution with kernel management
 //!
-//! Both sync and async APIs are provided.
+//! Both sync and async APIs are provided with full feature parity.
 
 use pyo3::prelude::*;
 
+mod async_session;
 mod client;
 mod error;
 mod output;
 mod session;
 
+use async_session::AsyncSession;
 use client::DaemonClient;
 use error::RuntimedError;
 use output::{Cell, ExecutionResult, Output};
@@ -21,9 +24,12 @@ use session::Session;
 /// Python module for runtimed daemon client.
 #[pymodule]
 fn runtimed(m: &Bound<'_, PyModule>) -> PyResult<()> {
-    // Core classes
+    // Core classes - sync API
     m.add_class::<DaemonClient>()?;
     m.add_class::<Session>()?;
+
+    // Core classes - async API
+    m.add_class::<AsyncSession>()?;
 
     // Output types
     m.add_class::<Cell>()?;

--- a/crates/runtimed-py/src/session.rs
+++ b/crates/runtimed-py/src/session.rs
@@ -508,6 +508,30 @@ impl Session {
         })
     }
 
+    /// Convenience method: create a cell, execute it, and return the result.
+    ///
+    /// This is a shortcut that combines create_cell() and execute_cell().
+    /// The cell is written to the automerge document before execution,
+    /// so other connected clients will see it.
+    ///
+    /// Args:
+    ///     code: The code to execute.
+    ///     timeout_secs: Maximum time to wait for execution (default: 60).
+    ///
+    /// Returns:
+    ///     ExecutionResult with outputs, success status, and execution count.
+    ///
+    /// Raises:
+    ///     RuntimedError: If not connected, kernel not started, or timeout.
+    #[pyo3(signature = (code, timeout_secs=60.0))]
+    fn run(&self, code: &str, timeout_secs: f64) -> PyResult<ExecutionResult> {
+        // Create cell in document first
+        let cell_id = self.create_cell(code, "code", None)?;
+
+        // Then execute by ID (daemon reads from doc)
+        self.execute_cell(&cell_id, timeout_secs)
+    }
+
     /// Queue a cell for execution without waiting for the result.
     ///
     /// The daemon reads the cell's source from the automerge document and

--- a/docs/python-bindings.md
+++ b/docs/python-bindings.md
@@ -23,8 +23,7 @@ import runtimed
 # Execute code with automatic kernel management
 with runtimed.Session() as session:
     session.start_kernel()
-    cell_id = session.create_cell("print('hello')")
-    result = session.execute_cell(cell_id)
+    result = session.run("print('hello')")
     print(result.stdout)  # "hello\n"
 ```
 
@@ -37,8 +36,7 @@ import runtimed
 async def main():
     async with runtimed.AsyncSession() as session:
         await session.start_kernel()
-        cell_id = await session.create_cell("print('hello async')")
-        result = await session.execute_cell(cell_id)
+        result = await session.run("print('hello async')")
         print(result.stdout)  # "hello async\n"
 
 asyncio.run(main())

--- a/docs/python-bindings.md
+++ b/docs/python-bindings.md
@@ -15,6 +15,8 @@ uv run maturin develop
 
 ## Quick Start
 
+### Synchronous API
+
 ```python
 import runtimed
 
@@ -23,6 +25,21 @@ with runtimed.Session() as session:
     session.start_kernel()
     result = session.run("print('hello')")
     print(result.stdout)  # "hello\n"
+```
+
+### Async API
+
+```python
+import asyncio
+import runtimed
+
+async def main():
+    async with runtimed.AsyncSession() as session:
+        await session.start_kernel()
+        result = await session.run("print('hello async')")
+        print(result.stdout)  # "hello async\n"
+
+asyncio.run(main())
 ```
 
 ## Session API
@@ -109,6 +126,106 @@ with runtimed.Session() as session:
 | `is_connected` | `bool` | Whether connected to daemon |
 | `kernel_started` | `bool` | Whether kernel is running |
 | `env_source` | `str \| None` | Environment source (e.g., "uv:prewarmed") |
+
+## AsyncSession API
+
+The `AsyncSession` class provides the same functionality as `Session` but with an async API for use in async Python code.
+
+### Quick Start
+
+```python
+import asyncio
+import runtimed
+
+async def main():
+    async with runtimed.AsyncSession() as session:
+        await session.start_kernel()
+        result = await session.run("print('hello async')")
+        print(result.stdout)  # "hello async\n"
+
+asyncio.run(main())
+```
+
+### Creating an AsyncSession
+
+```python
+# Auto-generated notebook ID
+session = runtimed.AsyncSession()
+
+# Explicit notebook ID (allows sharing between sessions)
+session = runtimed.AsyncSession(notebook_id="my-notebook")
+```
+
+### Kernel Lifecycle
+
+```python
+await session.connect()              # Connect to daemon
+await session.start_kernel()         # Launch Python kernel
+await session.start_kernel(kernel_type="deno")  # Launch Deno kernel
+await session.interrupt()            # Interrupt running execution
+await session.shutdown_kernel()      # Stop the kernel
+```
+
+### Code Execution
+
+```python
+# Simple execution
+result = await session.run("x = 42")
+result = await session.run("print(x)")
+
+# Check results
+print(result.success)         # True if no error
+print(result.stdout)          # Captured stdout
+print(result.stderr)          # Captured stderr
+```
+
+### Document-First Execution
+
+```python
+# Create a cell in the automerge document
+cell_id = await session.create_cell("x = 10")
+
+# Update cell source
+await session.set_source(cell_id, "x = 20")
+
+# Execute by cell ID (daemon reads source from document)
+result = await session.execute_cell(cell_id)
+
+# Read cell state
+cell = await session.get_cell(cell_id)
+print(cell.source)  # "x = 20"
+
+# List all cells
+cells = await session.get_cells()
+
+# Delete a cell
+await session.delete_cell(cell_id)
+```
+
+### Async Context Manager
+
+AsyncSession works as an async context manager for automatic cleanup:
+
+```python
+async with runtimed.AsyncSession() as session:
+    await session.start_kernel()
+    result = await session.run("1 + 1")
+# Kernel automatically shut down on exit
+```
+
+### Async Properties
+
+Note that property accessors are async methods in AsyncSession:
+
+```python
+# These are coroutines, not properties
+connected = await session.is_connected()     # bool
+kernel_running = await session.kernel_started()  # bool
+env = await session.env_source()             # str | None
+
+# Only notebook_id is a sync property
+notebook_id = session.notebook_id  # str
+```
 
 ## DaemonClient API
 

--- a/docs/python-bindings.md
+++ b/docs/python-bindings.md
@@ -23,7 +23,8 @@ import runtimed
 # Execute code with automatic kernel management
 with runtimed.Session() as session:
     session.start_kernel()
-    result = session.run("print('hello')")
+    cell_id = session.create_cell("print('hello')")
+    result = session.execute_cell(cell_id)
     print(result.stdout)  # "hello\n"
 ```
 
@@ -36,7 +37,8 @@ import runtimed
 async def main():
     async with runtimed.AsyncSession() as session:
         await session.start_kernel()
-        result = await session.run("print('hello async')")
+        cell_id = await session.create_cell("print('hello async')")
+        result = await session.execute_cell(cell_id)
         print(result.stdout)  # "hello async\n"
 
 asyncio.run(main())
@@ -69,9 +71,13 @@ session.shutdown_kernel()            # Stop the kernel
 ### Code Execution
 
 ```python
-# Simple execution (creates ephemeral cell, executes, returns result)
-result = session.run("x = 42")
-result = session.run("print(x)")
+# Create cells in the document, then execute (document-first pattern)
+cell_id = session.create_cell("x = 42")
+result = session.execute_cell(cell_id)
+
+# Execute another cell
+cell_id2 = session.create_cell("print(x)")
+result = session.execute_cell(cell_id2)
 
 # Check results
 print(result.success)         # True if no error
@@ -79,6 +85,11 @@ print(result.stdout)          # Captured stdout
 print(result.stderr)          # Captured stderr
 print(result.execution_count) # Execution counter
 print(result.error)           # Error output if failed
+
+# Queue execution without waiting (fire-and-forget)
+session.queue_cell(cell_id)
+# Poll for results later
+cell = session.get_cell(cell_id)
 ```
 
 ### Document-First Execution
@@ -114,7 +125,8 @@ Sessions work as context managers for automatic cleanup:
 ```python
 with runtimed.Session() as session:
     session.start_kernel()
-    result = session.run("1 + 1")
+    cell_id = session.create_cell("1 + 1")
+    result = session.execute_cell(cell_id)
 # Kernel automatically shut down on exit
 ```
 
@@ -140,7 +152,8 @@ import runtimed
 async def main():
     async with runtimed.AsyncSession() as session:
         await session.start_kernel()
-        result = await session.run("print('hello async')")
+        cell_id = await session.create_cell("print('hello async')")
+        result = await session.execute_cell(cell_id)
         print(result.stdout)  # "hello async\n"
 
 asyncio.run(main())
@@ -169,14 +182,20 @@ await session.shutdown_kernel()      # Stop the kernel
 ### Code Execution
 
 ```python
-# Simple execution
-result = await session.run("x = 42")
-result = await session.run("print(x)")
+# Create and execute cells (document-first pattern)
+cell_id = await session.create_cell("x = 42")
+result = await session.execute_cell(cell_id)
+
+cell_id2 = await session.create_cell("print(x)")
+result = await session.execute_cell(cell_id2)
 
 # Check results
 print(result.success)         # True if no error
 print(result.stdout)          # Captured stdout
 print(result.stderr)          # Captured stderr
+
+# Queue execution without waiting
+await session.queue_cell(cell_id)
 ```
 
 ### Document-First Execution
@@ -209,7 +228,8 @@ AsyncSession works as an async context manager for automatic cleanup:
 ```python
 async with runtimed.AsyncSession() as session:
     await session.start_kernel()
-    result = await session.run("1 + 1")
+    cell_id = await session.create_cell("1 + 1")
+    result = await session.execute_cell(cell_id)
 # Kernel automatically shut down on exit
 ```
 
@@ -269,10 +289,11 @@ client.shutdown()     # Stop the daemon
 
 ### ExecutionResult
 
-Returned by `run()` and `execute_cell()`:
+Returned by `execute_cell()`:
 
 ```python
-result = session.run("print('hello')")
+cell_id = session.create_cell("print('hello')")
+result = session.execute_cell(cell_id)
 
 result.cell_id          # Cell that was executed
 result.success          # True if no error
@@ -323,11 +344,12 @@ cell.execution_count # Execution count if executed
 Two sessions with the same `notebook_id` share the same kernel and document:
 
 ```python
-# Session 1 creates a cell
+# Session 1 creates a cell and executes
 s1 = runtimed.Session(notebook_id="shared")
 s1.connect()
 s1.start_kernel()
 cell_id = s1.create_cell("x = 42")
+s1.execute_cell(cell_id)
 
 # Session 2 sees the cell and shares the kernel
 s2 = runtimed.Session(notebook_id="shared")
@@ -338,7 +360,8 @@ cells = s2.get_cells()
 assert any(c.id == cell_id for c in cells)
 
 # Execute in s2, result visible to s1
-s2.run("print(x)")  # Uses x=42 from s1's execution
+cell_id2 = s2.create_cell("print(x)")
+s2.execute_cell(cell_id2)  # Uses x=42 from s1's execution
 ```
 
 This enables:

--- a/python/runtimed/README.md
+++ b/python/runtimed/README.md
@@ -17,7 +17,8 @@ import runtimed
 
 with runtimed.Session() as session:
     session.start_kernel()
-    result = session.run("print('hello')")
+    cell_id = session.create_cell("print('hello')")
+    result = session.execute_cell(cell_id)
     print(result.stdout)  # "hello\n"
 ```
 
@@ -30,7 +31,8 @@ import runtimed
 async def main():
     async with runtimed.AsyncSession() as session:
         await session.start_kernel()
-        result = await session.run("print('hello async')")
+        cell_id = await session.create_cell("print('hello async')")
+        result = await session.execute_cell(cell_id)
         print(result.stdout)
 
 asyncio.run(main())
@@ -48,14 +50,17 @@ asyncio.run(main())
 
 ```python
 session = runtimed.Session(notebook_id="my-notebook")
+session.connect()
 session.start_kernel()
 
-# Simple execution
-result = session.run("x = 42")
-
-# Document operations
-cell_id = session.create_cell("print(x)")
+# Create and execute cells (document-first pattern)
+cell_id = session.create_cell("x = 42")
 result = session.execute_cell(cell_id)
+
+# Queue execution without waiting (fire-and-forget)
+session.queue_cell(cell_id)
+# Poll for results
+cell = session.get_cell(cell_id)
 
 # Inspect results
 print(result.success)
@@ -68,9 +73,11 @@ print(result.error)
 ```python
 async with runtimed.AsyncSession(notebook_id="my-notebook") as session:
     await session.start_kernel()
-    result = await session.run("x = 42")
-    cell_id = await session.create_cell("print(x)")
+    cell_id = await session.create_cell("x = 42")
     result = await session.execute_cell(cell_id)
+
+    # Or queue without waiting
+    await session.queue_cell(cell_id)
 ```
 
 ## DaemonClient API

--- a/python/runtimed/README.md
+++ b/python/runtimed/README.md
@@ -10,6 +10,8 @@ pip install runtimed
 
 ## Quick Start
 
+### Synchronous API
+
 ```python
 import runtimed
 
@@ -19,9 +21,25 @@ with runtimed.Session() as session:
     print(result.stdout)  # "hello\n"
 ```
 
+### Async API
+
+```python
+import asyncio
+import runtimed
+
+async def main():
+    async with runtimed.AsyncSession() as session:
+        await session.start_kernel()
+        result = await session.run("print('hello async')")
+        print(result.stdout)
+
+asyncio.run(main())
+```
+
 ## Features
 
 - **Code execution** via daemon-managed kernels
+- **Sync and async APIs** for flexibility
 - **Document-first model** with automerge sync
 - **Multi-client support** for shared notebooks
 - **Rich output capture** (stdout, stderr, display_data, errors)
@@ -43,6 +61,16 @@ result = session.execute_cell(cell_id)
 print(result.success)
 print(result.stdout)
 print(result.error)
+```
+
+## AsyncSession API
+
+```python
+async with runtimed.AsyncSession(notebook_id="my-notebook") as session:
+    await session.start_kernel()
+    result = await session.run("x = 42")
+    cell_id = await session.create_cell("print(x)")
+    result = await session.execute_cell(cell_id)
 ```
 
 ## DaemonClient API

--- a/python/runtimed/README.md
+++ b/python/runtimed/README.md
@@ -17,8 +17,7 @@ import runtimed
 
 with runtimed.Session() as session:
     session.start_kernel()
-    cell_id = session.create_cell("print('hello')")
-    result = session.execute_cell(cell_id)
+    result = session.run("print('hello')")
     print(result.stdout)  # "hello\n"
 ```
 
@@ -31,8 +30,7 @@ import runtimed
 async def main():
     async with runtimed.AsyncSession() as session:
         await session.start_kernel()
-        cell_id = await session.create_cell("print('hello async')")
-        result = await session.execute_cell(cell_id)
+        result = await session.run("print('hello async')")
         print(result.stdout)
 
 asyncio.run(main())
@@ -50,17 +48,14 @@ asyncio.run(main())
 
 ```python
 session = runtimed.Session(notebook_id="my-notebook")
-session.connect()
 session.start_kernel()
 
-# Create and execute cells (document-first pattern)
-cell_id = session.create_cell("x = 42")
-result = session.execute_cell(cell_id)
+# Simple execution
+result = session.run("x = 42")
 
-# Queue execution without waiting (fire-and-forget)
-session.queue_cell(cell_id)
-# Poll for results
-cell = session.get_cell(cell_id)
+# Document-first pattern (for fine-grained control)
+cell_id = session.create_cell("print(x)")
+result = session.execute_cell(cell_id)
 
 # Inspect results
 print(result.success)
@@ -73,11 +68,11 @@ print(result.error)
 ```python
 async with runtimed.AsyncSession(notebook_id="my-notebook") as session:
     await session.start_kernel()
-    cell_id = await session.create_cell("x = 42")
-    result = await session.execute_cell(cell_id)
+    result = await session.run("x = 42")
 
-    # Or queue without waiting
-    await session.queue_cell(cell_id)
+    # Or document-first pattern
+    cell_id = await session.create_cell("print(x)")
+    result = await session.execute_cell(cell_id)
 ```
 
 ## DaemonClient API

--- a/python/runtimed/pyproject.toml
+++ b/python/runtimed/pyproject.toml
@@ -27,5 +27,10 @@ bindings = "pyo3"
 dev = [
     "maturin>=1.0,<2.0",
     "pytest>=8.0",
+    "pytest-asyncio>=0.23",
     "ipykernel>=6.0",
 ]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"

--- a/python/runtimed/src/runtimed/__init__.py
+++ b/python/runtimed/src/runtimed/__init__.py
@@ -7,6 +7,7 @@ from runtimed._sidecar import BridgedSidecar, Sidecar, sidecar
 
 # Native daemon client (PyO3 bindings)
 from runtimed.runtimed import (
+    AsyncSession,
     DaemonClient,
     ExecutionResult,
     Output,
@@ -19,9 +20,12 @@ __all__ = [
     "BridgedSidecar",
     "Sidecar",
     "sidecar",
-    # Daemon client API
+    # Daemon client API - sync
     "DaemonClient",
     "Session",
+    # Daemon client API - async
+    "AsyncSession",
+    # Output types
     "ExecutionResult",
     "Output",
     "RuntimedError",

--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -573,12 +573,16 @@ print('line 2')
 class TestErrorHandling:
     """Test error handling scenarios."""
 
-    def test_execute_without_kernel(self, session):
-        """Executing without kernel raises helpful error."""
-        cell_id = session.create_cell("x = 1")
+    def test_execute_auto_starts_kernel(self, session):
+        """execute_cell auto-starts kernel if not running."""
+        # Don't call start_kernel() - execute_cell should do it automatically
+        cell_id = session.create_cell("x = 42; print(x)")
 
-        with pytest.raises(runtimed.RuntimedError, match="[Kk]ernel"):
-            session.execute_cell(cell_id)
+        # Should work without explicit start_kernel()
+        result = session.execute_cell(cell_id)
+        assert result.success
+        assert "42" in result.stdout
+        assert session.kernel_started
 
     def test_get_nonexistent_cell(self, session):
         """Getting nonexistent cell raises error."""

--- a/python/runtimed/tests/test_session_unit.py
+++ b/python/runtimed/tests/test_session_unit.py
@@ -1,0 +1,245 @@
+"""Unit tests for Session and AsyncSession classes.
+
+These tests don't require a running daemon - they test construction,
+properties, and error handling for disconnected sessions.
+"""
+
+import pytest
+
+import runtimed
+
+
+class TestSessionConstruction:
+    """Test Session construction and properties."""
+
+    def test_session_with_auto_id(self):
+        """Session generates unique ID if not provided."""
+        session = runtimed.Session()
+        assert session.notebook_id.startswith("agent-session-")
+        assert len(session.notebook_id) > 20  # UUID adds significant length
+
+    def test_session_with_custom_id(self):
+        """Session uses provided notebook_id."""
+        session = runtimed.Session(notebook_id="my-custom-notebook")
+        assert session.notebook_id == "my-custom-notebook"
+
+    def test_session_unique_ids(self):
+        """Each Session gets a unique ID."""
+        s1 = runtimed.Session()
+        s2 = runtimed.Session()
+        assert s1.notebook_id != s2.notebook_id
+
+    def test_session_repr_disconnected(self):
+        """Session repr shows disconnected status."""
+        session = runtimed.Session(notebook_id="test-repr")
+        r = repr(session)
+        assert "Session" in r
+        assert "test-repr" in r
+        assert "disconnected" in r
+
+    def test_session_is_connected_initially_false(self):
+        """Session is not connected immediately after construction."""
+        session = runtimed.Session()
+        assert not session.is_connected
+
+    def test_session_kernel_started_initially_false(self):
+        """Kernel is not started immediately after construction."""
+        session = runtimed.Session()
+        assert not session.kernel_started
+
+    def test_session_env_source_initially_none(self):
+        """env_source is None when no kernel is running."""
+        session = runtimed.Session()
+        assert session.env_source is None
+
+
+class TestAsyncSessionConstruction:
+    """Test AsyncSession construction and properties."""
+
+    def test_async_session_with_auto_id(self):
+        """AsyncSession generates unique ID if not provided."""
+        session = runtimed.AsyncSession()
+        assert session.notebook_id.startswith("agent-session-")
+        assert len(session.notebook_id) > 20
+
+    def test_async_session_with_custom_id(self):
+        """AsyncSession uses provided notebook_id."""
+        session = runtimed.AsyncSession(notebook_id="my-async-notebook")
+        assert session.notebook_id == "my-async-notebook"
+
+    def test_async_session_unique_ids(self):
+        """Each AsyncSession gets a unique ID."""
+        s1 = runtimed.AsyncSession()
+        s2 = runtimed.AsyncSession()
+        assert s1.notebook_id != s2.notebook_id
+
+    def test_async_session_repr(self):
+        """AsyncSession repr shows notebook ID."""
+        session = runtimed.AsyncSession(notebook_id="test-async-repr")
+        r = repr(session)
+        assert "AsyncSession" in r
+        assert "test-async-repr" in r
+
+
+class TestAsyncSessionProperties:
+    """Test AsyncSession async property methods."""
+
+    @pytest.mark.asyncio
+    async def test_async_is_connected_initially_false(self):
+        """AsyncSession is not connected immediately after construction."""
+        session = runtimed.AsyncSession()
+        assert not await session.is_connected()
+
+    @pytest.mark.asyncio
+    async def test_async_kernel_started_initially_false(self):
+        """Kernel is not started immediately after construction."""
+        session = runtimed.AsyncSession()
+        assert not await session.kernel_started()
+
+    @pytest.mark.asyncio
+    async def test_async_env_source_initially_none(self):
+        """env_source is None when no kernel is running."""
+        session = runtimed.AsyncSession()
+        assert await session.env_source() is None
+
+
+class TestSessionErrorHandling:
+    """Test error handling for disconnected sessions."""
+
+    def test_set_source_without_connection(self):
+        """set_source raises error when not connected."""
+        session = runtimed.Session()
+        with pytest.raises(runtimed.RuntimedError, match="[Nn]ot connected"):
+            session.set_source("cell-123", "x = 1")
+
+    def test_get_cell_without_connection(self):
+        """get_cell raises error when not connected."""
+        session = runtimed.Session()
+        with pytest.raises(runtimed.RuntimedError, match="[Nn]ot connected"):
+            session.get_cell("cell-123")
+
+    def test_get_cells_without_connection(self):
+        """get_cells raises error when not connected."""
+        session = runtimed.Session()
+        with pytest.raises(runtimed.RuntimedError, match="[Nn]ot connected"):
+            session.get_cells()
+
+    def test_delete_cell_without_connection(self):
+        """delete_cell raises error when not connected."""
+        session = runtimed.Session()
+        with pytest.raises(runtimed.RuntimedError, match="[Nn]ot connected"):
+            session.delete_cell("cell-123")
+
+    def test_interrupt_without_connection(self):
+        """interrupt raises error when not connected."""
+        session = runtimed.Session()
+        with pytest.raises(runtimed.RuntimedError, match="[Nn]ot connected"):
+            session.interrupt()
+
+    def test_shutdown_kernel_without_connection(self):
+        """shutdown_kernel raises error when not connected."""
+        session = runtimed.Session()
+        with pytest.raises(runtimed.RuntimedError, match="[Nn]ot connected"):
+            session.shutdown_kernel()
+
+
+class TestAsyncSessionErrorHandling:
+    """Test error handling for disconnected async sessions."""
+
+    @pytest.mark.asyncio
+    async def test_async_set_source_without_connection(self):
+        """set_source raises error when not connected."""
+        session = runtimed.AsyncSession()
+        with pytest.raises(runtimed.RuntimedError, match="[Nn]ot connected"):
+            await session.set_source("cell-123", "x = 1")
+
+    @pytest.mark.asyncio
+    async def test_async_get_cell_without_connection(self):
+        """get_cell raises error when not connected."""
+        session = runtimed.AsyncSession()
+        with pytest.raises(runtimed.RuntimedError, match="[Nn]ot connected"):
+            await session.get_cell("cell-123")
+
+    @pytest.mark.asyncio
+    async def test_async_get_cells_without_connection(self):
+        """get_cells raises error when not connected."""
+        session = runtimed.AsyncSession()
+        with pytest.raises(runtimed.RuntimedError, match="[Nn]ot connected"):
+            await session.get_cells()
+
+    @pytest.mark.asyncio
+    async def test_async_delete_cell_without_connection(self):
+        """delete_cell raises error when not connected."""
+        session = runtimed.AsyncSession()
+        with pytest.raises(runtimed.RuntimedError, match="[Nn]ot connected"):
+            await session.delete_cell("cell-123")
+
+    @pytest.mark.asyncio
+    async def test_async_interrupt_without_connection(self):
+        """interrupt raises error when not connected."""
+        session = runtimed.AsyncSession()
+        with pytest.raises(runtimed.RuntimedError, match="[Nn]ot connected"):
+            await session.interrupt()
+
+    @pytest.mark.asyncio
+    async def test_async_shutdown_kernel_without_connection(self):
+        """shutdown_kernel raises error when not connected."""
+        session = runtimed.AsyncSession()
+        with pytest.raises(runtimed.RuntimedError, match="[Nn]ot connected"):
+            await session.shutdown_kernel()
+
+    @pytest.mark.asyncio
+    async def test_async_create_cell_without_connection(self):
+        """create_cell raises error when not connected."""
+        session = runtimed.AsyncSession()
+        with pytest.raises(runtimed.RuntimedError, match="[Nn]ot connected"):
+            await session.create_cell("x = 1")
+
+
+class TestOutputTypes:
+    """Test Output and ExecutionResult classes."""
+
+    def test_output_class_exists(self):
+        """Output class is exported."""
+        assert hasattr(runtimed, "Output")
+
+    def test_execution_result_class_exists(self):
+        """ExecutionResult class is exported."""
+        assert hasattr(runtimed, "ExecutionResult")
+
+    def test_runtimed_error_class_exists(self):
+        """RuntimedError class is exported."""
+        assert hasattr(runtimed, "RuntimedError")
+
+
+class TestModuleExports:
+    """Test that all expected classes are exported."""
+
+    def test_session_exported(self):
+        """Session is exported from runtimed."""
+        assert hasattr(runtimed, "Session")
+
+    def test_async_session_exported(self):
+        """AsyncSession is exported from runtimed."""
+        assert hasattr(runtimed, "AsyncSession")
+
+    def test_daemon_client_exported(self):
+        """DaemonClient is exported from runtimed."""
+        assert hasattr(runtimed, "DaemonClient")
+
+    def test_all_exports(self):
+        """Check __all__ exports the expected items."""
+        expected = [
+            "Session",
+            "AsyncSession",
+            "DaemonClient",
+            "ExecutionResult",
+            "Output",
+            "RuntimedError",
+        ]
+        for name in expected:
+            assert name in runtimed.__all__, f"{name} not in __all__"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/python/runtimed/tests/test_session_unit.py
+++ b/python/runtimed/tests/test_session_unit.py
@@ -142,6 +142,12 @@ class TestSessionErrorHandling:
         with pytest.raises(runtimed.RuntimedError, match="[Nn]ot connected"):
             session.shutdown_kernel()
 
+    def test_queue_cell_without_connection(self):
+        """queue_cell raises error when not connected."""
+        session = runtimed.Session()
+        with pytest.raises(runtimed.RuntimedError, match="[Nn]ot connected"):
+            session.queue_cell("cell-123")
+
 
 class TestAsyncSessionErrorHandling:
     """Test error handling for disconnected async sessions."""
@@ -194,6 +200,13 @@ class TestAsyncSessionErrorHandling:
         session = runtimed.AsyncSession()
         with pytest.raises(runtimed.RuntimedError, match="[Nn]ot connected"):
             await session.create_cell("x = 1")
+
+    @pytest.mark.asyncio
+    async def test_async_queue_cell_without_connection(self):
+        """queue_cell raises error when not connected."""
+        session = runtimed.AsyncSession()
+        with pytest.raises(runtimed.RuntimedError, match="[Nn]ot connected"):
+            await session.queue_cell("cell-123")
 
 
 class TestOutputTypes:

--- a/python/runtimed/uv.lock
+++ b/python/runtimed/uv.lock
@@ -26,6 +26,15 @@ wheels = [
 ]
 
 [[package]]
+name = "backports-asyncio-runner"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
+]
+
+[[package]]
 name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -712,6 +721,41 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-asyncio"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+dependencies = [
+    { name = "backports-asyncio-runner", marker = "python_full_version < '3.10'" },
+    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/86/9e3c5f48f7b7b638b216e4b9e645f54d199d7abbbab7a64a13b4e12ba10f/pytest_asyncio-1.2.0.tar.gz", hash = "sha256:c609a64a2a8768462d0c99811ddb8bd2583c33fd33cf7f21af1c142e824ffb57", size = 50119, upload-time = "2025-09-12T07:33:53.816Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/93/2fa34714b7a4ae72f2f8dad66ba17dd9a2c793220719e736dda28b7aec27/pytest_asyncio-1.2.0-py3-none-any.whl", hash = "sha256:8e17ae5e46d8e7efe51ab6494dd2010f4ca8dae51652aa3c8d55acf50bfb2e99", size = 15095, upload-time = "2025-09-12T07:33:52.639Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.11'",
+    "python_full_version == '3.10.*'",
+]
+dependencies = [
+    { name = "backports-asyncio-runner", marker = "python_full_version == '3.10.*'" },
+    { name = "pytest", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -857,6 +901,8 @@ dev = [
     { name = "maturin" },
     { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "pytest", version = "9.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "pytest-asyncio", version = "1.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pytest-asyncio", version = "1.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
 
 [package.metadata]
@@ -871,6 +917,7 @@ dev = [
     { name = "ipykernel", specifier = ">=6.0" },
     { name = "maturin", specifier = ">=1.0,<2.0" },
     { name = "pytest", specifier = ">=8.0" },
+    { name = "pytest-asyncio", specifier = ">=0.23" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds async Python API and refactors execution to a document-first model:

- **AsyncSession** - Full async/await API with feature parity to sync Session
- **queue_cell()** - Fire-and-forget execution (poll `get_cell()` for results)
- **Unit tests** - Adds test_session_unit.py for sync Session

## API Changes

**New: AsyncSession** - All methods return coroutines:
```python
async with runtimed.AsyncSession() as session:
    await session.start_kernel()
    cell_id = await session.create_cell("print('hello')")
    result = await session.execute_cell(cell_id)
```

**New: queue_cell()** - Non-blocking execution:
```python
session.queue_cell(cell_id)  # Fire without waiting
cell = session.get_cell(cell_id)  # Poll for results
```

**Removed: run()** - Was sugar over create_cell + execute_cell. Use the explicit pattern instead:
```python
cell_id = session.create_cell("code")
result = session.execute_cell(cell_id)
```

## Changes

| File | Change |
|------|--------|
| `crates/runtimed-py/src/async_session.rs` | New AsyncSession implementation |
| `crates/runtimed-py/src/session.rs` | Add queue_cell(), remove run() |
| `crates/runtimed-py/src/lib.rs` | Export AsyncSession |
| `python/runtimed/tests/test_session_unit.py` | Unit tests for Session |
| `python/runtimed/tests/test_daemon_integration.py` | Async integration tests |
| `docs/python-bindings.md` | AsyncSession documentation |

## Test Plan

- [x] Unit tests pass (`test_session_unit.py`)
- [x] Integration tests pass with daemon running
- [x] AsyncSession methods return proper coroutines
- [x] queue_cell() fires without blocking

_PR by @rgbkrk's agent, Quill_