### PR TITLE
set the CONDUCTOR_WORKSPACE_PATH via direnv

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -3,3 +3,5 @@
 # This makes `runt` resolve to the local debug build (bin/runt wrapper)
 # instead of the system-wide /usr/local/bin/runt install.
 PATH_add bin
+
+export CONDUCTOR_WORKSPACE_PATH="$(expand_path .)"


### PR DESCRIPTION
For helping non-AI development workflows have a nice local runtime daemon.