### PR TITLE
fix(kernel): resolve kernel type from automerge doc

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -321,11 +321,9 @@ function AppContent() {
     if (!info) return false;
 
     if (info.status === "trusted" || info.status === "no_dependencies") {
-      // Trusted - launch kernel via daemon ("auto" triggers project file detection)
-      const response = await launchKernel(
-        runtime === "deno" ? "deno" : "python",
-        "auto",
-      );
+      // Trusted - launch kernel via daemon
+      // Both kernel_type and env_source use "auto" - daemon detects from Automerge doc
+      const response = await launchKernel("auto", "auto");
       if (response.result === "error") {
         console.error("[App] tryStartKernel: daemon error", response.error);
         return false;
@@ -336,7 +334,7 @@ function AppContent() {
     pendingKernelStartRef.current = true;
     setTrustDialogOpen(true);
     return false;
-  }, [checkTrust, launchKernel, runtime]);
+  }, [checkTrust, launchKernel]);
 
   // Restart and run all cells
   const restartAndRunAll = useCallback(async () => {
@@ -384,10 +382,11 @@ function AppContent() {
     if (success && pendingKernelStartRef.current) {
       pendingKernelStartRef.current = false;
       // Now start the kernel since trust was approved
-      await launchKernel(runtime === "deno" ? "deno" : "python", "auto");
+      // Use "auto" for both - daemon detects from Automerge doc
+      await launchKernel("auto", "auto");
     }
     return success;
-  }, [approveTrust, launchKernel, runtime]);
+  }, [approveTrust, launchKernel]);
 
   // Handle trust decline from dialog
   const handleTrustDecline = useCallback(() => {

--- a/apps/notebook/src/hooks/useDaemonKernel.ts
+++ b/apps/notebook/src/hooks/useDaemonKernel.ts
@@ -452,23 +452,6 @@ export function useDaemonKernel({
     [],
   );
 
-  /** Queue a cell for execution via the daemon */
-  const queueCell = useCallback(
-    async (cellId: string, code: string): Promise<DaemonNotebookResponse> => {
-      console.log("[daemon-kernel] queueing cell:", cellId);
-      try {
-        return await invoke<DaemonNotebookResponse>("queue_cell_via_daemon", {
-          cellId,
-          code,
-        });
-      } catch (e) {
-        console.error("[daemon-kernel] queue failed:", e);
-        throw e;
-      }
-    },
-    [],
-  );
-
   /** Execute a cell via the daemon (reads source from synced document) */
   const executeCell = useCallback(
     async (cellId: string): Promise<DaemonNotebookResponse> => {
@@ -616,8 +599,6 @@ export function useDaemonKernel({
     kernelInfo,
     /** Launch a kernel via the daemon */
     launchKernel,
-    /** Queue a cell for execution */
-    queueCell,
     /** Execute a cell (reads source from synced document) */
     executeCell,
     /** Clear outputs for a cell */


### PR DESCRIPTION
Make the daemon the authoritative source for kernel type detection by supporting `kernel_type="auto"` in LaunchKernel requests. The daemon now detects kernel type from the notebook's metadata snapshot in the Automerge doc using the existing `detect_notebook_kernel_type()` function, preventing divergence between UI state and actual kernel configuration.

Also removes the unused `queueCell()` function which represented an anti-pattern of passing code directly to the daemon instead of having it read from the synced Automerge document via `executeCell()`.

This addresses the medium-severity "Runtime Detection Divergence" issue from the kernel architecture audit against `contributing/architecture.md`.

_PR submitted by @rgbkrk's agent, Quill_