### PR TITLE
ci: build Python wheels for all platforms in preview

### DIFF
--- a/.github/workflows/weekly-preview.yml
+++ b/.github/workflows/weekly-preview.yml
@@ -613,51 +613,54 @@ jobs:
           path: nteract-linux-x64.AppImage
 
   build-python-wheels:
-    name: Build Python Wheels (${{ matrix.target }})
-    runs-on: macos-latest
+    name: Build Python Wheels (${{ matrix.platform.target }})
+    runs-on: ${{ matrix.platform.runner }}
     strategy:
       matrix:
-        target:
-          - aarch64-apple-darwin
-          - x86_64-apple-darwin
+        platform:
+          - runner: macos-latest
+            target: aarch64-apple-darwin
+          - runner: macos-latest
+            target: x86_64-apple-darwin
+          - runner: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - runner: windows-latest
+            target: x86_64-pc-windows-msvc
     steps:
       - uses: actions/checkout@v4
 
       - name: Set up Rust
         uses: dsherret/rust-toolchain-file@v1
 
-      - name: Install cross-compilation targets
-        run: rustup target add ${{ matrix.target }}
-
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "python-${{ matrix.target }}"
+          shared-key: "python-${{ matrix.platform.target }}"
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-
-      - name: Enable corepack
-        run: corepack enable
-
-      - name: Install JS dependencies
-        run: pnpm install
-
-      - name: Build sidecar UI
-        run: pnpm build
-
-      - name: Set dev version
+      - name: Set dev version (Unix)
+        if: runner.os != 'Windows'
         run: |
           CURRENT_VERSION=$(grep '^version' python/runtimed/pyproject.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
           DEV_VERSION="${CURRENT_VERSION}.dev$(date -u +%Y%m%d)"
           echo "Setting Python version to: ${DEV_VERSION}"
-          sed -i '' "s/^version = .*/version = \"${DEV_VERSION}\"/" python/runtimed/pyproject.toml
+          sed -i.bak "s/^version = .*/version = \"${DEV_VERSION}\"/" python/runtimed/pyproject.toml
+
+      - name: Set dev version (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $content = Get-Content python/runtimed/pyproject.toml -Raw
+          if ($content -match 'version = "([^"]+)"') {
+            $currentVersion = $matches[1]
+          }
+          $devVersion = "$currentVersion.dev$(Get-Date -Format 'yyyyMMdd' -AsUTC)"
+          Write-Host "Setting Python version to: $devVersion"
+          $content = $content -replace 'version = "[^"]+"', "version = `"$devVersion`""
+          Set-Content python/runtimed/pyproject.toml $content -NoNewline
 
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
-          target: ${{ matrix.target }}
+          target: ${{ matrix.platform.target }}
           args: --release --out dist
           working-directory: python/runtimed
           sccache: true
@@ -666,7 +669,7 @@ jobs:
       - name: Upload wheels
         uses: actions/upload-artifact@v4
         with:
-          name: wheels-${{ matrix.target }}
+          name: wheels-${{ matrix.platform.target }}
           path: python/runtimed/dist
 
   prerelease:
@@ -727,17 +730,12 @@ jobs:
           name: nteract-linux-x64
           path: ./executables
 
-      - name: Download Python wheels (macOS ARM64)
+      - name: Download Python wheels
         uses: actions/download-artifact@v4
         with:
-          name: wheels-aarch64-apple-darwin
+          pattern: wheels-*
           path: ./wheels
-
-      - name: Download Python wheels (macOS x64)
-        uses: actions/download-artifact@v4
-        with:
-          name: wheels-x86_64-apple-darwin
-          path: ./wheels
+          merge-multiple: true
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
@@ -779,7 +777,7 @@ jobs:
             | macOS | x64 | `runt-darwin-x64` |
             | macOS | ARM64 | `runt-darwin-arm64` |
 
-            ### runtimed (Python)
+            ### runtimed (Python — macOS, Linux, Windows)
 
             ```bash
             pip install runtimed --pre


### PR DESCRIPTION
Build Python wheels for all platforms in the preview release workflow.

## Changes

The `build-python-wheels` job now targets 4 platforms:

| Runner | Target | Wheel |
|--------|--------|-------|
| `macos-latest` | `aarch64-apple-darwin` | macOS ARM64 |
| `macos-latest` | `x86_64-apple-darwin` | macOS x64 |
| `ubuntu-latest` | `x86_64-unknown-linux-gnu` | Linux x64 (manylinux) |
| `windows-latest` | `x86_64-pc-windows-msvc` | Windows x64 |

Also:
- **Removed sidecar UI steps** (Node/pnpm/`pnpm build`) — not needed after #371 decoupled the runt binary from the wheel
- **Removed cross-compilation target step** — each matrix entry builds native on its own runner
- **Consolidated wheel downloads** — single `download-artifact` with `pattern: wheels-*` and `merge-multiple: true`
- **Cross-platform version patching** — Unix `sed -i.bak` and Windows PowerShell

## Trusted publishing

No config changes needed — the publish step still runs in the `prerelease` job of `weekly-preview.yml`, which is already registered as a trusted publisher on PyPI.

## Testing

After merge, trigger the preview workflow manually and watch the Actions run. The new Linux and Windows wheel builds should complete and the `uv publish` step should upload all 4 wheels to PyPI.