### PR TITLE
fix(runtimed-py): use abi3 stable ABI for cross-version wheel compatibility

### DIFF
--- a/crates/runtimed-py/Cargo.toml
+++ b/crates/runtimed-py/Cargo.toml
@@ -12,7 +12,7 @@ name = "runtimed"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.28", features = ["extension-module"] }
+pyo3 = { version = "0.28", features = ["extension-module", "abi3-py39"] }
 pyo3-async-runtimes = { version = "0.28", features = ["tokio-runtime"] }
 runtimed = { path = "../runtimed" }
 tokio = { version = "1", features = ["full"] }


### PR DESCRIPTION
The preview wheels published by #372 were version-specific (`cp314` on macOS, `cp312` on Linux/Windows), so `pip install runtimed --pre` fails on any other Python version (e.g. 3.13).

Enabling `abi3-py39` in PyO3 produces stable ABI wheels compatible with Python 3.9+, regardless of the build host's Python version.

One-line change in `crates/runtimed-py/Cargo.toml`. After merge, trigger a new preview release to publish compatible wheels.