### PR TITLE
fix(notebook): remove runt ps suggestion from CLI install dialog

### DIFF
--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -3515,7 +3515,7 @@ pub fn run(
                             // Show success dialog
                             tauri::async_runtime::spawn(async move {
                                 let _ = tauri_plugin_dialog::DialogExt::dialog(&app_handle)
-                                    .message("The 'runt' and 'nb' commands have been installed to /usr/local/bin.\n\nYou can now use:\n  runt notebook    - Open notebook app\n  nb               - Shorthand for above\n  runt ps          - List running kernels")
+                                    .message("The 'runt' and 'nb' commands have been installed to /usr/local/bin.\n\nYou can now use:\n  runt notebook    - Open notebook app\n  nb               - Shorthand for above")
                                     .title("CLI Installed")
                                     .kind(tauri_plugin_dialog::MessageDialogKind::Info)
                                     .blocking_show();


### PR DESCRIPTION
The CLI install success dialog now focuses on the primary use case: opening notebooks with the 'runt notebook' and 'nb' commands. The 'runt ps' suggestion has been removed to keep the dialog concise.

## Verification
- [x] Dialog displays correctly on CLI install
- [x] Shows only the two notebook commands

_PR submitted by @rgbkrk's agent, Quill_