### PR TITLE
fix(ci): use PEP 440 alpha versioning for Python pre-releases

### DIFF
--- a/.github/workflows/weekly-preview.yml
+++ b/.github/workflows/weekly-preview.yml
@@ -640,7 +640,11 @@ jobs:
         if: runner.os != 'Windows'
         run: |
           CURRENT_VERSION=$(grep '^version' python/runtimed/pyproject.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
-          DEV_VERSION="${CURRENT_VERSION}.dev$(date -u +%Y%m%d)"
+          # Bump patch and use alpha tag so it sorts after current stable (PEP 440)
+          MAJOR_MINOR=$(echo "$CURRENT_VERSION" | sed 's/\.[0-9]*$//')
+          PATCH=$(echo "$CURRENT_VERSION" | grep -o '[0-9]*$')
+          NEXT_PATCH=$((PATCH + 1))
+          DEV_VERSION="${MAJOR_MINOR}.${NEXT_PATCH}a$(date -u +%Y%m%d)"
           echo "Setting Python version to: ${DEV_VERSION}"
           sed -i.bak "s/^version = .*/version = \"${DEV_VERSION}\"/" python/runtimed/pyproject.toml
 
@@ -652,7 +656,11 @@ jobs:
           if ($content -match 'version = "([^"]+)"') {
             $currentVersion = $matches[1]
           }
-          $devVersion = "$currentVersion.dev$(Get-Date -Format 'yyyyMMdd' -AsUTC)"
+          # Bump patch and use alpha tag so it sorts after current stable (PEP 440)
+          $parts = $currentVersion.Split('.')
+          $parts[2] = [string]([int]$parts[2] + 1)
+          $nextVersion = $parts -join '.'
+          $devVersion = "${nextVersion}a$(Get-Date -Format 'yyyyMMdd' -AsUTC)"
           Write-Host "Setting Python version to: $devVersion"
           $content = $content -replace 'version = "[^"]+"', "version = `"$devVersion`""
           Set-Content python/runtimed/pyproject.toml $content -NoNewline


### PR DESCRIPTION
Fix Python pre-release versioning so `pip install --pre runtimed` actually picks up preview builds.

**Before:** `0.1.4.dev20260301` — PEP 440 `.devN` sorts *below* `0.1.4`, so `--pre` keeps the stable version.

**After:** `0.1.5a20260301` — PEP 440 alpha sorts above `0.1.4` and below `0.1.5`:

```
0.1.4 < 0.1.5a20260301 < 0.1.5
```

Bumps the patch version before appending the alpha tag so it always sorts after the current stable.