### PR TITLE
docs(daemon): recommend cargo xtask dev-daemon for development

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,9 +160,6 @@ For production use, install the daemon as a system service:
 ```bash
 # Reinstall daemon with your changes (builds release, stops old, copies, restarts)
 cargo xtask install-daemon
-
-# Or manually:
-runt daemon stop && runt daemon uninstall && runt daemon install
 ```
 
 `cargo xtask dev` and `cargo xtask build` do **not** reinstall the daemon. If you're changing daemon code (settings, sync, environments), you must run `cargo xtask install-daemon` separately to test your changes.

--- a/contributing/runtimed.md
+++ b/contributing/runtimed.md
@@ -97,22 +97,6 @@ cargo xtask run                   # Run the bundled binary
 
 The `--rust-only` flag skips `pnpm build`, reusing the existing frontend assets in `apps/notebook/dist/`. This is much faster when you're only changing Rust code.
 
-### Manual: Run daemon separately
-
-For debugging daemon-specific code, stop the installed service and run from source:
-
-```bash
-# Stop the installed service first
-cargo run -p runt-cli -- daemon stop
-
-# Run daemon with debug logs
-RUST_LOG=debug cargo run -p runtimed
-
-# In another terminal, test with runt CLI
-cargo run -p runt-cli -- daemon ping
-cargo run -p runt-cli -- daemon status
-```
-
 ### Testing
 
 ```bash
@@ -232,19 +216,17 @@ When shipped as a release build, the daemon installs as a system service that st
 - **Linux**: systemd user service in `~/.config/systemd/user/`
 - **Windows**: Startup folder script
 
-### Managing the Installed Service (for developers)
+### Managing the System Daemon
 
-If you have the app installed and want to run a development version of the daemon instead, you'll need to stop the installed service first.
+These commands manage the **system daemon** (production). For development, use `cargo xtask dev-daemon` instead — it provides per-worktree isolation and doesn't interfere with the system daemon.
 
-**Cross-platform (recommended):**
+**Cross-platform:**
 ```bash
-# Stop the installed daemon
-runt daemon stop
-
 # Check status
 runt daemon status
 
-# Start it later
+# Stop/start the system daemon
+runt daemon stop
 runt daemon start
 
 # View logs

--- a/docs/runtimed.md
+++ b/docs/runtimed.md
@@ -134,9 +134,11 @@ runt daemon start      # Start the daemon service
 runt daemon stop       # Stop the daemon service
 runt daemon restart    # Restart the daemon
 runt daemon logs -f    # Tail daemon logs
-runt daemon install    # Install as system service
-runt daemon uninstall  # Uninstall system service
+runt daemon install    # Install as system service (system daemon only)
+runt daemon uninstall  # Uninstall system service (system daemon only)
 ```
+
+Most commands work with both the system daemon and dev worktree daemons. The `install`/`uninstall` commands are system-only — don't run these in a worktree context.
 
 Auto-upgrade: the client detects version mismatches and replaces the binary.
 


### PR DESCRIPTION
Replace direct `runt daemon` command instructions with the xtask workflow.

Now that worktree support exists, `cargo xtask dev-daemon` provides better isolation and a more cohesive development experience. This removes the manual daemon commands that could interfere with worktree setup.

Also clarifies that most `runt daemon` commands work with both system and worktree daemons, but `install`/`uninstall` are system-only and shouldn't be run from a worktree context.

## Verification

- [x] Formatting and linting checks pass
- [x] Tests pass
- [x] No clippy warnings

_PR submitted by @rgbkrk's agent, Quill_