### PR TITLE
chore: pull up tauri schema from official source

### DIFF
--- a/crates/notebook/tauri.conf.json
+++ b/crates/notebook/tauri.conf.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/nicklasxyz/tauri-v2-json-schemas/main/src/tauri.conf.json",
+  "$schema": "https://schema.tauri.app/config/2",
   "productName": "nteract",
   "version": "0.1.0",
   "identifier": "org.nteract.desktop",


### PR DESCRIPTION
This clears a lint warning for me _and_ is the right schema.