### PR TITLE
ci(build): add pull request path filters 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,27 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    paths:
+      - ".github/workflows/build.yml"
+      - "apps/**"
+      - "bin/**"
+      - "crates/**"
+      - "e2e/**"
+      - "python/**"
+      - "scripts/**"
+      - "src/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "rust-toolchain.toml"
+      - "package.json"
+      - "package-lock.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - "biome.json"
+      - "components.json"
+      - "tailwind.config.js"
+      - "tsconfig.json"
+      - "vitest.config.ts"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
Add a path filter to the `build.yml` workflow to skip builds for PRs with only documentation or non-material YAML changes.

This reduces unnecessary CI resource consumption by ensuring the build workflow only triggers when code or build configuration files are modified.

---
<p><a href="https://cursor.com/agents/bc-93e274b0-a6e3-48c1-a892-05304254dfc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-93e274b0-a6e3-48c1-a892-05304254dfc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

