### PR TITLE
ci(build): run ui checks only on linux 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,6 +112,15 @@ jobs:
           pnpm --dir apps/sidecar build
           pnpm --dir apps/notebook build
 
+      - name: Upload UI build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ui-build-dist
+          path: |
+            apps/notebook/dist/
+            apps/sidecar/dist/
+          retention-days: 1
+
       - name: Build external binaries
         shell: bash
         run: |
@@ -138,6 +147,7 @@ jobs:
   build:
     name: ${{ matrix.platform.name }}
     runs-on: ${{ matrix.platform.runner }}
+    needs: [build-linux]
     strategy:
       matrix:
         platform:
@@ -149,6 +159,12 @@ jobs:
             setup: echo "No extra deps needed on Windows"
     steps:
       - uses: actions/checkout@v4
+
+      - name: Download UI build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: ui-build-dist
+          path: .
 
       - name: Install system dependencies
         run: ${{ matrix.platform.setup }}
@@ -162,36 +178,6 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: ${{ matrix.platform.runner }}
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-
-      - name: Enable corepack
-        run: corepack enable
-
-      - name: Set pnpm store directory
-        run: pnpm config set store-dir ~/.pnpm-store
-
-      - name: Cache pnpm store
-        uses: actions/cache@v4
-        with:
-          path: ~/.pnpm-store
-          key: pnpm-store-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            pnpm-store-${{ runner.os }}-
-
-      - name: Install JS dependencies
-        run: pnpm install
-
-      - name: Run JS tests
-        run: pnpm test:run
-
-      - name: Build UIs
-        run: |
-          pnpm --dir apps/sidecar build
-          pnpm --dir apps/notebook build
 
       - name: Build external binaries
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -164,7 +164,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ui-build-dist
-          path: .
+          path: apps
 
       - name: Install system dependencies
         run: ${{ matrix.platform.setup }}


### PR DESCRIPTION
Refactor `build.yml` to centralize UI validation on Linux and eliminate redundant UI build steps in macOS/Windows jobs.

Previously, macOS and Windows CI jobs duplicated Node setup, JS dependency installation, UI test execution, and frontend builds. This PR modifies the workflow so that Linux builds and uploads UI artifacts, which are then consumed by macOS/Windows jobs, allowing them to skip these UI-related steps and focus solely on platform-specific Rust validation.

---
<p><a href="https://cursor.com/agents/bc-cb1255c7-d48a-4d15-9062-866ea20b3549"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cb1255c7-d48a-4d15-9062-866ea20b3549"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

