### PR TITLE
fix(ci): tolerate missing macos updater artifacts

### DIFF
--- a/.github/workflows/weekly-preview.yml
+++ b/.github/workflows/weekly-preview.yml
@@ -284,17 +284,30 @@ jobs:
           fi
 
       - name: Collect artifacts
+        shell: bash
         run: |
           mkdir -p artifacts
-          DMG_PATH=$(find target/release/bundle/dmg -name "*.dmg" | head -1)
-          cp "$DMG_PATH" artifacts/nteract-darwin-arm64.dmg
-          # Updater bundle (.tar.gz and .sig)
-          for f in target/release/bundle/macos/*.tar.gz; do
-            [ -f "$f" ] && cp "$f" artifacts/nteract-darwin-arm64.app.tar.gz
-          done
-          for f in target/release/bundle/macos/*.tar.gz.sig; do
-            [ -f "$f" ] && cp "$f" artifacts/nteract-darwin-arm64.app.tar.gz.sig
-          done
+
+          shopt -s nullglob
+          DMG_BINARIES=(target/release/bundle/dmg/*.dmg)
+          TAR_GZ_BINARIES=(target/release/bundle/macos/*.tar.gz)
+          TAR_GZ_SIG_BINARIES=(target/release/bundle/macos/*.tar.gz.sig)
+          shopt -u nullglob
+
+          if [ ${#DMG_BINARIES[@]} -eq 0 ]; then
+            echo "::error::No macOS installer (.dmg) found in target/release/bundle/dmg"
+            exit 1
+          fi
+
+          cp "${DMG_BINARIES[0]}" artifacts/nteract-darwin-arm64.dmg
+
+          # Optional updater bundle (.tar.gz and .sig) for channels that publish updater artifacts.
+          if [ ${#TAR_GZ_BINARIES[@]} -gt 0 ]; then
+            cp "${TAR_GZ_BINARIES[0]}" artifacts/nteract-darwin-arm64.app.tar.gz
+          fi
+          if [ ${#TAR_GZ_SIG_BINARIES[@]} -gt 0 ]; then
+            cp "${TAR_GZ_SIG_BINARIES[0]}" artifacts/nteract-darwin-arm64.app.tar.gz.sig
+          fi
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Fix macOS weekly preview artifact collection to tolerate missing updater bundles.

The original script failed when only a `.dmg` was produced because the `for` loop for `*.tar.gz` updater files would exit non-zero under `bash -e` if no matching files were found. This PR updates the logic to make the collection of updater `.tar.gz` and `.sig` files optional, preventing the workflow from failing when they are not present.

---
<p><a href="https://cursor.com/agents/bc-bcbc592a-378a-4162-8b62-a93a3e64324e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bcbc592a-378a-4162-8b62-a93a3e64324e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

