### PR TITLE
fix(runtimed): clear execution queue on interrupt

### DIFF
--- a/crates/runtimed/src/kernel_manager.rs
+++ b/crates/runtimed/src/kernel_manager.rs
@@ -1333,8 +1333,8 @@ impl RoomKernel {
         Ok(())
     }
 
-    /// Interrupt the currently executing cell.
-    pub async fn interrupt(&self) -> Result<()> {
+    /// Interrupt the currently executing cell and clear the execution queue.
+    pub async fn interrupt(&mut self) -> Result<()> {
         let connection_info = self
             .connection_info
             .as_ref()
@@ -1347,6 +1347,16 @@ impl RoomKernel {
         control.send(request).await?;
 
         info!("[kernel-manager] Sent interrupt_request");
+
+        // Clear the execution queue - interrupt semantically means "stop all pending work"
+        let cleared = self.clear_queue();
+        if !cleared.is_empty() {
+            info!(
+                "[kernel-manager] Cleared {} queued cells due to interrupt",
+                cleared.len()
+            );
+        }
+
         Ok(())
     }
 

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -1612,8 +1612,8 @@ async fn handle_notebook_request(
         }
 
         NotebookRequest::InterruptExecution {} => {
-            let kernel_guard = room.kernel.lock().await;
-            if let Some(ref kernel) = *kernel_guard {
+            let mut kernel_guard = room.kernel.lock().await;
+            if let Some(ref mut kernel) = *kernel_guard {
                 match kernel.interrupt().await {
                     Ok(()) => NotebookResponse::InterruptSent {},
                     Err(e) => NotebookResponse::Error {


### PR DESCRIPTION
When a user interrupts a running cell, queued cells that were pending execution are now properly cleared. Previously, these cells would still execute after the interrupt.

The fix adds queue clearing to the `interrupt()` method in kernel_manager, ensuring that all pending work stops when interrupt is called.

Closes #398

## Verification
- Queue multiple cells and run them while the first is executing
- Click interrupt on the running cell
- Verify that remaining queued cells do not execute

_PR submitted by @rgbkrk's agent, Quill_