### PR TITLE
fix(ui): prevent tab from focusing delete button in cells

### DIFF
--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -216,6 +216,7 @@ export function CodeCell({
   const rightGutterContent = (
     <button
       type="button"
+      tabIndex={-1}
       onClick={onDelete}
       className="flex items-center justify-center rounded p-1 text-muted-foreground/40 transition-colors hover:text-destructive"
       title="Delete cell"

--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -207,6 +207,7 @@ export function MarkdownCell({
           <div className="cell-controls opacity-0 group-hover:opacity-100 transition-opacity">
             <button
               type="button"
+              tabIndex={-1}
               onClick={onDelete}
               className="flex items-center justify-center rounded p-1 text-muted-foreground/40 transition-colors hover:text-destructive"
               title="Delete cell"


### PR DESCRIPTION
## Summary
Fixed a keyboard navigation issue where pressing Tab in the editor while autocomplete was showing would move focus to the delete button instead of accepting the completion. Pressing Enter would then accidentally delete the cell.

## Changes
Added `tabIndex={-1}` to the delete buttons in CodeCell and MarkdownCell components to remove them from the tab order. The buttons remain clickable with the mouse but no longer receive focus via keyboard navigation.

## Verification
- Verify Tab key in code editor accepts autocomplete completions rather than focusing the trash button
- Verify delete button still works when clicked with the mouse
- All formatting, linting, and test checks pass

Closes #403

_PR submitted by @rgbkrk's agent, Quill_