### PR TITLE
chore: bump version to 1.4.0-alpha.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3338,7 +3338,7 @@ dependencies = [
 
 [[package]]
 name = "notebook"
-version = "1.0.0"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -5333,7 +5333,7 @@ dependencies = [
 
 [[package]]
 name = "runt-cli"
-version = "1.3.0-dev.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6101,7 +6101,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "sidecar"
-version = "1.3.0-dev.1"
+version = "1.4.0-alpha.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/notebook/Cargo.toml
+++ b/crates/notebook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notebook"
-version = "1.0.0"
+version = "1.4.0-alpha.1"
 edition = "2021"
 description = "Tauri-based notebook UI for Jupyter kernels"
 repository = "https://github.com/nteract/desktop"

--- a/crates/notebook/tauri.conf.json
+++ b/crates/notebook/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "nteract",
-  "version": "0.1.0",
+  "version": "1.4.0-alpha.1",
   "identifier": "org.nteract.desktop",
   "build": {
     "devUrl": "http://localhost:5174",

--- a/crates/runt/Cargo.toml
+++ b/crates/runt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runt-cli"
-version = "1.3.0-dev.1"
+version = "1.4.0-alpha.1"
 edition.workspace = true
 description = "CLI for Jupyter Runtimes — install via GitHub Releases or `pip install runtimed`, not crates.io"
 repository.workspace = true

--- a/crates/sidecar/Cargo.toml
+++ b/crates/sidecar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sidecar"
-version = "1.3.0-dev.1"
+version = "1.4.0-alpha.1"
 edition.workspace = true
 description = "Sidecar jupyter outputs — install via GitHub Releases or `pip install runtimed`, not crates.io"
 repository.workspace = true


### PR DESCRIPTION
Bump all app crate versions to `1.4.0-alpha.1`.

Old nteract (Electron) ended at `0.29.0`. This is a total rewrite. The preview releases have been shipping as `1.3.0-dev.1`, so `1.4.0-alpha.1` is the natural next step — the updater sees it as newer, and it signals we're heading toward a stable `1.4.0`.

| Crate | Before | After |
|-------|--------|-------|
| `runt-cli` | `1.3.0-dev.1` | `1.4.0-alpha.1` |
| `notebook` | `1.0.0` | `1.4.0-alpha.1` |
| `sidecar` | `1.3.0-dev.1` | `1.4.0-alpha.1` |
| `tauri.conf.json` | `0.1.0` | `1.4.0-alpha.1` |

Unchanged:
- `runtimed` crate: `0.1.0-dev.10` (internal daemon versioning)
- `runtimed` Python: `0.1.4` (independent PyPI versioning)

Preview releases will now tag as `v1.4.0-alpha.1-preview.{sha}`.