### PR TITLE
feat(notebook): global find across code inputs and outputs

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -1055,6 +1055,7 @@ function AppContent() {
         onAddCell={handleAddCell}
         onClearPagePayload={clearPagePayload}
         onFormatCell={formatCell}
+        onReportOutputMatchCount={globalFind.reportOutputMatchCount}
       />
     </div>
   );

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -19,6 +19,7 @@ import {
 import { DebugBanner } from "./components/DebugBanner";
 import { DenoDependencyHeader } from "./components/DenoDependencyHeader";
 import { DependencyHeader } from "./components/DependencyHeader";
+import { GlobalFindBar } from "./components/GlobalFindBar";
 import { NotebookToolbar } from "./components/NotebookToolbar";
 import { NotebookView } from "./components/NotebookView";
 import { TrustDialog } from "./components/TrustDialog";
@@ -28,6 +29,7 @@ import { useDenoDependencies } from "./hooks/useDenoDependencies";
 import { type EnvSyncState, useDependencies } from "./hooks/useDependencies";
 import { useEnvProgress } from "./hooks/useEnvProgress";
 import { useDaemonInfo, useGitInfo } from "./hooks/useGitInfo";
+import { useGlobalFind } from "./hooks/useGlobalFind";
 import { useNotebook } from "./hooks/useNotebook";
 import { useTrust } from "./hooks/useTrust";
 import { useUpdater } from "./hooks/useUpdater";
@@ -106,6 +108,9 @@ function AppContent() {
     clearCellOutputs,
     formatCell,
   } = useNotebook();
+
+  // Global find (Cmd+F)
+  const globalFind = useGlobalFind(cells);
 
   const [dependencyHeaderOpen, setDependencyHeaderOpen] = useState(false);
   const [showIsolationTest, setShowIsolationTest] = useState(false);
@@ -643,6 +648,18 @@ function AppContent() {
     };
   }, [save]);
 
+  // Cmd+F to open global find
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === "f") {
+        e.preventDefault();
+        globalFind.open();
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [globalFind.open]);
+
   // Cmd+O to open (keyboard and native menu)
   useEffect(() => {
     const webview = getCurrentWebview();
@@ -1000,6 +1017,17 @@ function AppContent() {
           isUsingProjectEnv={envSource === "uv:pyproject"}
         />
       )}
+      {globalFind.isOpen && (
+        <GlobalFindBar
+          query={globalFind.query}
+          matchCount={globalFind.matches.length}
+          currentMatchIndex={globalFind.currentMatchIndex}
+          onQueryChange={globalFind.setQuery}
+          onNextMatch={globalFind.nextMatch}
+          onPrevMatch={globalFind.prevMatch}
+          onClose={globalFind.close}
+        />
+      )}
       {showIsolationTest && <IsolationTest />}
       <TrustDialog
         open={trustDialogOpen}
@@ -1017,6 +1045,8 @@ function AppContent() {
         executingCellIds={executingCellIds}
         pagePayloads={pagePayloads}
         runtime={runtime}
+        searchQuery={globalFind.query}
+        searchCurrentMatch={globalFind.currentMatch}
         onFocusCell={setFocusedCellId}
         onUpdateCellSource={updateCellSource}
         onExecuteCell={handleExecuteCell}

--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -17,6 +17,7 @@ import {
   type CodeMirrorEditorRef,
 } from "@/components/editor/codemirror-editor";
 import type { SupportedLanguage } from "@/components/editor/languages";
+import { searchHighlight } from "@/components/editor/search-highlight";
 import { AnsiOutput } from "@/components/outputs/ansi-output";
 import { ErrorBoundary } from "@/lib/error-boundary";
 import type { CellPagePayload, MimeBundle } from "../App";
@@ -79,6 +80,8 @@ interface CodeCellProps {
   isFocused: boolean;
   isExecuting: boolean;
   pagePayload: CellPagePayload | null;
+  searchQuery?: string;
+  searchActiveOffset?: number;
   onFocus: () => void;
   onUpdateSource: (source: string) => void;
   onExecute: () => void;
@@ -98,6 +101,8 @@ export function CodeCell({
   isFocused,
   isExecuting,
   pagePayload,
+  searchQuery,
+  searchActiveOffset = -1,
   onFocus,
   onUpdateSource,
   onExecute,
@@ -200,6 +205,15 @@ export function CodeCell({
     [navigationKeyMap, historyKeyBinding],
   );
 
+  // CodeMirror extensions: kernel completion + search highlighting
+  const editorExtensions = useMemo(
+    () => [
+      kernelCompletionExtension,
+      ...searchHighlight(searchQuery || "", searchActiveOffset),
+    ],
+    [searchQuery, searchActiveOffset],
+  );
+
   const handleExecute = useCallback(() => {
     handleExecuteWithClear();
   }, [handleExecuteWithClear]);
@@ -244,7 +258,7 @@ export function CodeCell({
                 language={language}
                 onValueChange={onUpdateSource}
                 keyMap={keyMap}
-                extensions={[kernelCompletionExtension]}
+                extensions={editorExtensions}
                 placeholder="Enter code..."
                 className="min-h-[2rem]"
                 autoFocus={isFocused}
@@ -271,7 +285,13 @@ export function CodeCell({
             )}
           </>
         }
-        outputContent={<OutputArea outputs={cell.outputs} preloadIframe />}
+        outputContent={
+          <OutputArea
+            outputs={cell.outputs}
+            preloadIframe
+            searchQuery={searchQuery}
+          />
+        }
         hideOutput={cell.outputs.length === 0}
       />
 

--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -82,6 +82,7 @@ interface CodeCellProps {
   pagePayload: CellPagePayload | null;
   searchQuery?: string;
   searchActiveOffset?: number;
+  onSearchMatchCount?: (count: number) => void;
   onFocus: () => void;
   onUpdateSource: (source: string) => void;
   onExecute: () => void;
@@ -103,6 +104,7 @@ export function CodeCell({
   pagePayload,
   searchQuery,
   searchActiveOffset = -1,
+  onSearchMatchCount,
   onFocus,
   onUpdateSource,
   onExecute,
@@ -290,6 +292,7 @@ export function CodeCell({
             outputs={cell.outputs}
             preloadIframe
             searchQuery={searchQuery}
+            onSearchMatchCount={onSearchMatchCount}
           />
         }
         hideOutput={cell.outputs.length === 0}

--- a/apps/notebook/src/components/GlobalFindBar.tsx
+++ b/apps/notebook/src/components/GlobalFindBar.tsx
@@ -63,6 +63,10 @@ export function GlobalFindBar({
           onChange={(e) => onQueryChange(e.target.value)}
           onKeyDown={handleKeyDown}
           placeholder="Find in notebook..."
+          autoComplete="off"
+          autoCorrect="off"
+          autoCapitalize="off"
+          spellCheck={false}
           className="h-7 w-full rounded border border-input bg-transparent px-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
           aria-label="Search notebook"
         />

--- a/apps/notebook/src/components/GlobalFindBar.tsx
+++ b/apps/notebook/src/components/GlobalFindBar.tsx
@@ -1,0 +1,104 @@
+import { ChevronDown, ChevronUp, X } from "lucide-react";
+import { useCallback, useEffect, useRef } from "react";
+
+interface GlobalFindBarProps {
+  query: string;
+  matchCount: number;
+  currentMatchIndex: number;
+  onQueryChange: (query: string) => void;
+  onNextMatch: () => void;
+  onPrevMatch: () => void;
+  onClose: () => void;
+}
+
+export function GlobalFindBar({
+  query,
+  matchCount,
+  currentMatchIndex,
+  onQueryChange,
+  onNextMatch,
+  onPrevMatch,
+  onClose,
+}: GlobalFindBarProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Focus input on mount
+  useEffect(() => {
+    requestAnimationFrame(() => {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    });
+  }, []);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onClose();
+      } else if (e.key === "Enter" && e.shiftKey) {
+        e.preventDefault();
+        onPrevMatch();
+      } else if (e.key === "Enter") {
+        e.preventDefault();
+        onNextMatch();
+      }
+    },
+    [onClose, onNextMatch, onPrevMatch],
+  );
+
+  const matchLabel =
+    query && matchCount > 0
+      ? `${currentMatchIndex + 1} of ${matchCount}`
+      : query
+        ? "No results"
+        : "";
+
+  return (
+    <div className="flex items-center gap-1.5 border-b bg-background px-3 py-1.5 shadow-sm">
+      <div className="relative flex-1 max-w-sm">
+        <input
+          ref={inputRef}
+          type="text"
+          value={query}
+          onChange={(e) => onQueryChange(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="Find in notebook..."
+          className="h-7 w-full rounded border border-input bg-transparent px-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+          aria-label="Search notebook"
+        />
+      </div>
+      <span className="text-xs text-muted-foreground min-w-[5rem] text-center tabular-nums">
+        {matchLabel}
+      </span>
+      <button
+        type="button"
+        onClick={onPrevMatch}
+        disabled={matchCount === 0}
+        className="flex h-6 w-6 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-muted disabled:opacity-30 disabled:pointer-events-none transition-colors"
+        title="Previous match (Shift+Enter)"
+        aria-label="Previous match"
+      >
+        <ChevronUp className="h-4 w-4" />
+      </button>
+      <button
+        type="button"
+        onClick={onNextMatch}
+        disabled={matchCount === 0}
+        className="flex h-6 w-6 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-muted disabled:opacity-30 disabled:pointer-events-none transition-colors"
+        title="Next match (Enter)"
+        aria-label="Next match"
+      >
+        <ChevronDown className="h-4 w-4" />
+      </button>
+      <button
+        type="button"
+        onClick={onClose}
+        className="flex h-6 w-6 items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+        title="Close (Escape)"
+        aria-label="Close find bar"
+      >
+        <X className="h-4 w-4" />
+      </button>
+    </div>
+  );
+}

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -151,7 +151,7 @@ function NotebookViewContent({
   useEffect(() => {
     if (!searchCurrentMatch) return;
     const cellEl = containerRef.current?.querySelector(
-      `[data-cell-id="${searchCurrentMatch.cellId}"]`,
+      `[data-cell-id="${CSS.escape(searchCurrentMatch.cellId)}"]`,
     );
     if (cellEl) {
       cellEl.scrollIntoView({ block: "nearest", behavior: "smooth" });

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -29,6 +29,7 @@ interface NotebookViewProps {
   onAddCell: (type: "code" | "markdown", afterCellId?: string | null) => void;
   onClearPagePayload: (cellId: string) => void;
   onFormatCell?: (cellId: string) => void;
+  onReportOutputMatchCount?: (cellId: string, count: number) => void;
 }
 
 function AddCellButtons({
@@ -138,6 +139,7 @@ function NotebookViewContent({
   onAddCell,
   onClearPagePayload,
   onFormatCell,
+  onReportOutputMatchCount,
 }: NotebookViewProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const { focusCell } = useEditorRegistry();
@@ -199,6 +201,11 @@ function NotebookViewContent({
             pagePayload={pagePayload}
             searchQuery={searchQuery}
             searchActiveOffset={activeSourceOffset}
+            onSearchMatchCount={
+              onReportOutputMatchCount
+                ? (count: number) => onReportOutputMatchCount(cell.id, count)
+                : undefined
+            }
             onFocus={() => onFocusCell(cell.id)}
             onUpdateSource={(source) => onUpdateCellSource(cell.id, source)}
             onExecute={() => onExecuteCell(cell.id)}
@@ -258,6 +265,7 @@ function NotebookViewContent({
       onAddCell,
       onClearPagePayload,
       onFormatCell,
+      onReportOutputMatchCount,
       focusCell,
     ],
   );

--- a/apps/notebook/src/hooks/useGlobalFind.ts
+++ b/apps/notebook/src/hooks/useGlobalFind.ts
@@ -1,0 +1,183 @@
+import { useCallback, useMemo, useState } from "react";
+import type { NotebookCell } from "../types";
+
+/** A single search match location. */
+export interface FindMatch {
+  /** Cell ID containing the match */
+  cellId: string;
+  /** Index of the cell in the notebook */
+  cellIndex: number;
+  /** Whether this match is in the cell source or output text */
+  type: "source" | "output";
+  /** Character offset within the searched text */
+  offset: number;
+  /** Length of the match */
+  length: number;
+}
+
+/** State and actions exposed by the useGlobalFind hook. */
+export interface GlobalFindState {
+  /** Whether the find bar is open */
+  isOpen: boolean;
+  /** Current search query */
+  query: string;
+  /** All matches found */
+  matches: FindMatch[];
+  /** Index of the currently active match */
+  currentMatchIndex: number;
+  /** The currently active match (or null) */
+  currentMatch: FindMatch | null;
+  /** Open the find bar */
+  open: () => void;
+  /** Close the find bar and clear search */
+  close: () => void;
+  /** Update the search query */
+  setQuery: (query: string) => void;
+  /** Navigate to the next match */
+  nextMatch: () => void;
+  /** Navigate to the previous match */
+  prevMatch: () => void;
+}
+
+/**
+ * Extract searchable text from a cell's outputs.
+ * Returns concatenated text from stream, error, and text/plain outputs.
+ */
+function extractOutputText(cell: NotebookCell): string {
+  if (cell.cell_type !== "code") return "";
+  const parts: string[] = [];
+  for (const output of cell.outputs) {
+    if (output.output_type === "stream") {
+      const text = typeof output.text === "string" ? output.text : output.text;
+      parts.push(text);
+    } else if (output.output_type === "error") {
+      parts.push(output.traceback.join("\n"));
+    } else if (
+      output.output_type === "execute_result" ||
+      output.output_type === "display_data"
+    ) {
+      // Search text/plain representation if available
+      const plain = output.data["text/plain"];
+      if (typeof plain === "string") {
+        parts.push(plain);
+      } else if (Array.isArray(plain)) {
+        parts.push(plain.join(""));
+      }
+    }
+  }
+  return parts.join("\n");
+}
+
+/**
+ * Find all occurrences of a query in text (case-insensitive).
+ */
+function findInText(
+  text: string,
+  query: string,
+): { offset: number; length: number }[] {
+  if (!query || !text) return [];
+  const matches: { offset: number; length: number }[] = [];
+  const lowerText = text.toLowerCase();
+  const lowerQuery = query.toLowerCase();
+  let pos = lowerText.indexOf(lowerQuery, 0);
+  while (pos !== -1) {
+    matches.push({ offset: pos, length: query.length });
+    pos = lowerText.indexOf(lowerQuery, pos + query.length);
+  }
+  return matches;
+}
+
+/**
+ * Hook for managing global find state across the notebook.
+ *
+ * Searches through cell sources and output text, providing
+ * match navigation and the current active match for highlighting.
+ */
+export function useGlobalFind(cells: NotebookCell[]): GlobalFindState {
+  const [isOpen, setIsOpen] = useState(false);
+  const [query, setQueryState] = useState("");
+  const [currentMatchIndex, setCurrentMatchIndex] = useState(0);
+
+  // Compute all matches whenever query or cells change
+  const matches = useMemo(() => {
+    if (!query) return [];
+    const allMatches: FindMatch[] = [];
+
+    for (let i = 0; i < cells.length; i++) {
+      const cell = cells[i];
+
+      // Search cell source
+      const sourceMatches = findInText(cell.source, query);
+      for (const m of sourceMatches) {
+        allMatches.push({
+          cellId: cell.id,
+          cellIndex: i,
+          type: "source",
+          offset: m.offset,
+          length: m.length,
+        });
+      }
+
+      // Search output text
+      const outputText = extractOutputText(cell);
+      const outputMatches = findInText(outputText, query);
+      for (const m of outputMatches) {
+        allMatches.push({
+          cellId: cell.id,
+          cellIndex: i,
+          type: "output",
+          offset: m.offset,
+          length: m.length,
+        });
+      }
+    }
+
+    return allMatches;
+  }, [query, cells]);
+
+  const currentMatch =
+    matches.length > 0 && currentMatchIndex >= 0
+      ? (matches[currentMatchIndex % matches.length] ?? null)
+      : null;
+
+  const open = useCallback(() => {
+    setIsOpen(true);
+  }, []);
+
+  const close = useCallback(() => {
+    setIsOpen(false);
+    setQueryState("");
+    setCurrentMatchIndex(0);
+  }, []);
+
+  const setQuery = useCallback((newQuery: string) => {
+    setQueryState(newQuery);
+    setCurrentMatchIndex(0);
+  }, []);
+
+  const nextMatch = useCallback(() => {
+    if (matches.length === 0) return;
+    setCurrentMatchIndex((prev) => (prev + 1) % matches.length);
+  }, [matches.length]);
+
+  const prevMatch = useCallback(() => {
+    if (matches.length === 0) return;
+    setCurrentMatchIndex(
+      (prev) => (prev - 1 + matches.length) % matches.length,
+    );
+  }, [matches.length]);
+
+  return {
+    isOpen,
+    query,
+    matches,
+    currentMatchIndex:
+      matches.length > 0 ? currentMatchIndex % matches.length : -1,
+    currentMatch,
+    open,
+    close,
+    setQuery,
+    nextMatch,
+    prevMatch,
+  };
+}

--- a/apps/notebook/src/hooks/useGlobalFind.ts
+++ b/apps/notebook/src/hooks/useGlobalFind.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import type { NotebookCell } from "../types";
 
 /** A single search match location. */
@@ -7,11 +7,11 @@ export interface FindMatch {
   cellId: string;
   /** Index of the cell in the notebook */
   cellIndex: number;
-  /** Whether this match is in the cell source or output text */
+  /** Whether this match is in the cell source or output */
   type: "source" | "output";
-  /** Character offset within the searched text */
+  /** For source matches: character offset within the source text. For output matches: local index within this cell's output matches. */
   offset: number;
-  /** Length of the match */
+  /** For source matches: length of the match. For output matches: 0. */
   length: number;
 }
 
@@ -37,35 +37,11 @@ export interface GlobalFindState {
   nextMatch: () => void;
   /** Navigate to the previous match */
   prevMatch: () => void;
-}
-
-/**
- * Extract searchable text from a cell's outputs.
- * Returns concatenated text from stream, error, and text/plain outputs.
- */
-function extractOutputText(cell: NotebookCell): string {
-  if (cell.cell_type !== "code") return "";
-  const parts: string[] = [];
-  for (const output of cell.outputs) {
-    if (output.output_type === "stream") {
-      const text = typeof output.text === "string" ? output.text : output.text;
-      parts.push(text);
-    } else if (output.output_type === "error") {
-      parts.push(output.traceback.join("\n"));
-    } else if (
-      output.output_type === "execute_result" ||
-      output.output_type === "display_data"
-    ) {
-      // Search text/plain representation if available
-      const plain = output.data["text/plain"];
-      if (typeof plain === "string") {
-        parts.push(plain);
-      } else if (Array.isArray(plain)) {
-        parts.push(plain.join(""));
-      }
-    }
-  }
-  return parts.join("\n");
+  /**
+   * Report the number of search matches found in a cell's output.
+   * Called by OutputArea when iframe reports search_results or in-DOM highlighting completes.
+   */
+  reportOutputMatchCount: (cellId: string, count: number) => void;
 }
 
 /**
@@ -90,15 +66,45 @@ function findInText(
 /**
  * Hook for managing global find state across the notebook.
  *
- * Searches through cell sources and output text, providing
- * match navigation and the current active match for highlighting.
+ * Source matches are computed directly from cell source text.
+ * Output matches are reported asynchronously by OutputArea components
+ * (via iframe postMessage search_results or in-DOM highlight counts).
  */
 export function useGlobalFind(cells: NotebookCell[]): GlobalFindState {
   const [isOpen, setIsOpen] = useState(false);
   const [query, setQueryState] = useState("");
   const [currentMatchIndex, setCurrentMatchIndex] = useState(0);
+  const [outputMatchCounts, setOutputMatchCounts] = useState<
+    Map<string, number>
+  >(new Map());
 
-  // Compute all matches whenever query or cells change
+  // Track previous query to reset output counts when query changes
+  const prevQueryRef = useRef(query);
+  if (prevQueryRef.current !== query) {
+    prevQueryRef.current = query;
+    // Clear stale output counts — OutputArea will re-report for the new query
+    if (outputMatchCounts.size > 0) {
+      setOutputMatchCounts(new Map());
+    }
+  }
+
+  const reportOutputMatchCount = useCallback(
+    (cellId: string, count: number) => {
+      setOutputMatchCounts((prev) => {
+        if (prev.get(cellId) === count) return prev;
+        const next = new Map(prev);
+        if (count === 0) {
+          next.delete(cellId);
+        } else {
+          next.set(cellId, count);
+        }
+        return next;
+      });
+    },
+    [],
+  );
+
+  // Compute all matches: source matches directly, output matches from reported counts
   const matches = useMemo(() => {
     if (!query) return [];
     const allMatches: FindMatch[] = [];
@@ -106,7 +112,7 @@ export function useGlobalFind(cells: NotebookCell[]): GlobalFindState {
     for (let i = 0; i < cells.length; i++) {
       const cell = cells[i];
 
-      // Search cell source
+      // Source matches (computed directly)
       const sourceMatches = findInText(cell.source, query);
       for (const m of sourceMatches) {
         allMatches.push({
@@ -118,22 +124,21 @@ export function useGlobalFind(cells: NotebookCell[]): GlobalFindState {
         });
       }
 
-      // Search output text
-      const outputText = extractOutputText(cell);
-      const outputMatches = findInText(outputText, query);
-      for (const m of outputMatches) {
+      // Output matches (from reported counts)
+      const outputCount = outputMatchCounts.get(cell.id) || 0;
+      for (let j = 0; j < outputCount; j++) {
         allMatches.push({
           cellId: cell.id,
           cellIndex: i,
           type: "output",
-          offset: m.offset,
-          length: m.length,
+          offset: j,
+          length: 0,
         });
       }
     }
 
     return allMatches;
-  }, [query, cells]);
+  }, [query, cells, outputMatchCounts]);
 
   const currentMatch =
     matches.length > 0 && currentMatchIndex >= 0
@@ -148,6 +153,7 @@ export function useGlobalFind(cells: NotebookCell[]): GlobalFindState {
     setIsOpen(false);
     setQueryState("");
     setCurrentMatchIndex(0);
+    setOutputMatchCounts(new Map());
   }, []);
 
   const setQuery = useCallback((newQuery: string) => {
@@ -179,5 +185,6 @@ export function useGlobalFind(cells: NotebookCell[]): GlobalFindState {
     setQuery,
     nextMatch,
     prevMatch,
+    reportOutputMatchCount,
   };
 }

--- a/apps/notebook/src/hooks/useGlobalFind.ts
+++ b/apps/notebook/src/hooks/useGlobalFind.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import type { NotebookCell } from "../types";
 
 /** A single search match location. */
@@ -78,19 +78,12 @@ export function useGlobalFind(cells: NotebookCell[]): GlobalFindState {
     Map<string, number>
   >(new Map());
 
-  // Track previous query to reset output counts when query changes
-  const prevQueryRef = useRef(query);
-  if (prevQueryRef.current !== query) {
-    prevQueryRef.current = query;
-    // Clear stale output counts — OutputArea will re-report for the new query
-    if (outputMatchCounts.size > 0) {
-      setOutputMatchCounts(new Map());
-    }
-  }
-
   const reportOutputMatchCount = useCallback(
     (cellId: string, count: number) => {
       setOutputMatchCounts((prev) => {
+        // Bail out when count is 0 and cellId isn't tracked — avoids creating
+        // a new Map on every output change when find is inactive (#1)
+        if (count === 0 && !prev.has(cellId)) return prev;
         if (prev.get(cellId) === count) return prev;
         const next = new Map(prev);
         if (count === 0) {
@@ -159,6 +152,8 @@ export function useGlobalFind(cells: NotebookCell[]): GlobalFindState {
   const setQuery = useCallback((newQuery: string) => {
     setQueryState(newQuery);
     setCurrentMatchIndex(0);
+    // Clear stale output counts — OutputArea will re-report for the new query
+    setOutputMatchCounts(new Map());
   }, []);
 
   const nextMatch = useCallback(() => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "runtimed",
+  "name": "nteract-desktop",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "runtimed",
+      "name": "nteract-desktop",
       "dependencies": {
         "@codemirror/autocomplete": "^6.20.0",
         "@codemirror/commands": "^6.10.2",
@@ -18,7 +18,24 @@
         "@codemirror/lint": "^6.9.3",
         "@codemirror/state": "^6.5.4",
         "@codemirror/view": "^6.39.12",
-        "@tauri-apps/api": "~2.5.0",
+        "@radix-ui/react-accordion": "^1.2.12",
+        "@radix-ui/react-avatar": "^1.1.11",
+        "@radix-ui/react-checkbox": "^1.3.3",
+        "@radix-ui/react-collapsible": "^1.1.12",
+        "@radix-ui/react-dialog": "^1.1.15",
+        "@radix-ui/react-dropdown-menu": "^2.1.16",
+        "@radix-ui/react-hover-card": "^1.1.15",
+        "@radix-ui/react-label": "^2.1.8",
+        "@radix-ui/react-popover": "^1.1.15",
+        "@radix-ui/react-progress": "^1.1.8",
+        "@radix-ui/react-radio-group": "^1.3.8",
+        "@radix-ui/react-select": "^2.2.6",
+        "@radix-ui/react-slider": "^1.3.6",
+        "@radix-ui/react-slot": "^1.2.4",
+        "@radix-ui/react-tabs": "^1.1.13",
+        "@radix-ui/react-toggle": "^1.1.10",
+        "@radix-ui/react-toggle-group": "^1.1.11",
+        "@tauri-apps/api": "^2.10.0",
         "@uiw/codemirror-theme-github": "^4.25.4",
         "@uiw/react-codemirror": "^4.25.4",
         "@uiw/react-json-view": "^2.0.0-alpha.41",
@@ -1683,6 +1700,24 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-accordion/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-alert-dialog": {
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.1.15.tgz",
@@ -1734,6 +1769,24 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-alert-dialog/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-arrow": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz",
@@ -1776,6 +1829,24 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-arrow/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -1826,14 +1897,32 @@
         }
       }
     },
-    "node_modules/@radix-ui/react-avatar": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.1.10.tgz",
-      "integrity": "sha512-V8piFfWapM5OmNCXTzVQY+E1rDa53zY+MQ4Y7356v4fFz6vqCyUtIz2rUD44ZEdwg78/jKmMJHj07+C/Z/rcog==",
+    "node_modules/@radix-ui/react-aspect-ratio/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-avatar": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.1.11.tgz",
+      "integrity": "sha512-0Qk603AHGV28BOBO34p7IgD5m+V5Sg/YovfayABkoDDBM5d3NCx0Mp4gGrjzLGes1jV5eNOE1r3itqOR33VC6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-context": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.4",
         "@radix-ui/react-use-callback-ref": "1.1.1",
         "@radix-ui/react-use-is-hydrated": "0.1.0",
         "@radix-ui/react-use-layout-effect": "1.1.1"
@@ -1853,25 +1942,17 @@
         }
       }
     },
-    "node_modules/@radix-ui/react-avatar/node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
-      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+    "node_modules/@radix-ui/react-avatar/node_modules/@radix-ui/react-context": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.3.tgz",
+      "integrity": "sha512-ieIFACdMpYfMEjF0rEf5KLvfVyIkOz6PDGyNnP+u+4xQ6jny3VCgA4OgXOwNx2aUkxn8zx9fiVcM8CfFYv9Lxw==",
       "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slot": "1.2.3"
-      },
       "peerDependencies": {
         "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
       },
       "peerDependenciesMeta": {
         "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
           "optional": true
         }
       }
@@ -1929,6 +2010,24 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-checkbox/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-collapsible": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.12.tgz",
@@ -1982,6 +2081,24 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-collapsible/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-collection": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
@@ -2027,6 +2144,24 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collection/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -2112,6 +2247,24 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-context-menu/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-dialog": {
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz",
@@ -2167,6 +2320,24 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -2236,6 +2407,24 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-dismissable-layer/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-dropdown-menu": {
       "version": "2.1.16",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.16.tgz",
@@ -2284,6 +2473,24 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dropdown-menu/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -2351,6 +2558,24 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-focus-scope/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-form": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-form/-/react-form-0.1.8.tgz",
@@ -2362,6 +2587,29 @@
         "@radix-ui/react-context": "1.1.2",
         "@radix-ui/react-id": "1.1.1",
         "@radix-ui/react-label": "2.1.7",
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-form/node_modules/@radix-ui/react-label": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.7.tgz",
+      "integrity": "sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ==",
+      "license": "MIT",
+      "dependencies": {
         "@radix-ui/react-primitive": "2.1.3"
       },
       "peerDependencies": {
@@ -2398,6 +2646,24 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-form/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -2456,6 +2722,24 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-hover-card/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-id": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
@@ -2475,35 +2759,12 @@
       }
     },
     "node_modules/@radix-ui/react-label": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.7.tgz",
-      "integrity": "sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.8.tgz",
+      "integrity": "sha512-FmXs37I6hSBVDlO4y764TNz1rLgKwjJMQ0EGte6F3Cb3f4bIuHB/iLa/8I9VKkmOy+gNHq8rql3j686ACVV21A==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-primitive": "2.1.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-label/node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
-      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slot": "1.2.3"
+        "@radix-ui/react-primitive": "2.1.4"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2583,6 +2844,24 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-menubar": {
       "version": "1.1.16",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-menubar/-/react-menubar-1.1.16.tgz",
@@ -2634,6 +2913,24 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menubar/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -2697,6 +2994,24 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-navigation-menu/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-one-time-password-field": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-one-time-password-field/-/react-one-time-password-field-0.1.8.tgz",
@@ -2754,6 +3069,24 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-one-time-password-field/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-password-toggle-field": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-password-toggle-field/-/react-password-toggle-field-0.1.3.tgz",
@@ -2803,6 +3136,24 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-password-toggle-field/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -2867,6 +3218,24 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-popper": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.8.tgz",
@@ -2922,6 +3291,24 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-popper/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-portal": {
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
@@ -2965,6 +3352,24 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -3016,67 +3421,41 @@
         }
       }
     },
-    "node_modules/@radix-ui/react-primitive/node_modules/@radix-ui/react-slot": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.4.tgz",
-      "integrity": "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==",
+    "node_modules/@radix-ui/react-progress": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-progress/-/react-progress-1.1.8.tgz",
+      "integrity": "sha512-+gISHcSPUJ7ktBy9RnTqbdKW78bcGke3t6taawyZ71pio1JewwGSJizycs7rLhGTvMJYCQB1DBK4KQsxs7U8dA==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
+        "@radix-ui/react-context": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.4"
       },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-progress/node_modules/@radix-ui/react-context": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.3.tgz",
+      "integrity": "sha512-ieIFACdMpYfMEjF0rEf5KLvfVyIkOz6PDGyNnP+u+4xQ6jny3VCgA4OgXOwNx2aUkxn8zx9fiVcM8CfFYv9Lxw==",
+      "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
       },
       "peerDependenciesMeta": {
         "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-progress": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-progress/-/react-progress-1.1.7.tgz",
-      "integrity": "sha512-vPdg/tF6YC/ynuBIJlk1mm7Le0VgW6ub6J2UWnTQ7/D23KXcPI1qy+0vBkgKgd38RCMJavBXpB83HPNFMTb0Fg==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-primitive": "2.1.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-progress/node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
-      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@radix-ui/react-slot": "1.2.3"
-      },
-      "peerDependencies": {
-        "@types/react": "*",
-        "@types/react-dom": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
-        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
           "optional": true
         }
       }
@@ -3136,6 +3515,24 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-radio-group/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-roving-focus": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz",
@@ -3190,6 +3587,24 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-roving-focus/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-scroll-area": {
       "version": "1.2.10",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.2.10.tgz",
@@ -3240,6 +3655,24 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-scroll-area/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -3310,6 +3743,24 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-separator": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.7.tgz",
@@ -3352,6 +3803,24 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-separator/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -3412,10 +3881,28 @@
         }
       }
     },
-    "node_modules/@radix-ui/react-slot": {
+    "node_modules/@radix-ui/react-slider/node_modules/@radix-ui/react-slot": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
       "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.4.tgz",
+      "integrity": "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.2"
@@ -3482,6 +3969,24 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-switch/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-tabs": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.13.tgz",
@@ -3531,6 +4036,24 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -3588,6 +4111,24 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toast/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -3669,6 +4210,24 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-toggle-group/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-toggle/node_modules/@radix-ui/react-primitive": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
@@ -3688,6 +4247,24 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toggle/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -3740,6 +4317,24 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toolbar/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -3797,6 +4392,24 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -3997,6 +4610,24 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -4670,9 +5301,9 @@
       }
     },
     "node_modules/@tauri-apps/api": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.5.0.tgz",
-      "integrity": "sha512-Ldux4ip+HGAcPUmuLT8EIkk6yafl5vK0P0c0byzAKzxJh7vxelVtdPONjfgTm96PbN24yjZNESY8CKo8qniluA==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.10.1.tgz",
+      "integrity": "sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw==",
       "license": "Apache-2.0 OR MIT",
       "funding": {
         "type": "opencollective",
@@ -12573,6 +13204,56 @@
         }
       }
     },
+    "node_modules/radix-ui/node_modules/@radix-ui/react-avatar": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.1.10.tgz",
+      "integrity": "sha512-V8piFfWapM5OmNCXTzVQY+E1rDa53zY+MQ4Y7356v4fFz6vqCyUtIz2rUD44ZEdwg78/jKmMJHj07+C/Z/rcog==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-is-hydrated": "0.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/radix-ui/node_modules/@radix-ui/react-label": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.7.tgz",
+      "integrity": "sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/radix-ui/node_modules/@radix-ui/react-primitive": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
@@ -12592,6 +13273,48 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/radix-ui/node_modules/@radix-ui/react-progress": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-progress/-/react-progress-1.1.7.tgz",
+      "integrity": "sha512-vPdg/tF6YC/ynuBIJlk1mm7Le0VgW6ub6J2UWnTQ7/D23KXcPI1qy+0vBkgKgd38RCMJavBXpB83HPNFMTb0Fg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/radix-ui/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -24,6 +24,7 @@ import {
 import { useWidgetStore } from "@/components/widgets/widget-store-context";
 import { isDarkMode as detectDarkMode } from "@/lib/dark-mode";
 import { ErrorBoundary } from "@/lib/error-boundary";
+import { highlightTextInDom } from "@/lib/highlight-text";
 import { OutputErrorFallback } from "@/lib/output-error-fallback";
 import { cn } from "@/lib/utils";
 
@@ -290,6 +291,7 @@ export function OutputArea({
   const id = useId();
   const frameRef = useRef<IsolatedFrameHandle>(null);
   const bridgeRef = useRef<CommBridgeManager | null>(null);
+  const inDomOutputRef = useRef<HTMLDivElement>(null);
 
   // Track dark mode state and observe changes
   const [darkMode, setDarkMode] = useState(() => detectDarkMode());
@@ -425,12 +427,19 @@ export function OutputArea({
     }
   }, [handleFrameReady]);
 
-  // Forward search query to the iframe
+  // Forward search query to the iframe (for isolated outputs)
   useEffect(() => {
-    if (frameRef.current?.isReady) {
+    if (frameRef.current?.isIframeReady) {
       frameRef.current.search(searchQuery || "");
     }
   }, [searchQuery]);
+
+  // Highlight search matches in in-DOM outputs
+  // Re-run when outputs change (outputCount tracks this) so new content gets highlighted
+  useEffect(() => {
+    if (!inDomOutputRef.current || shouldIsolate || outputCount === 0) return;
+    return highlightTextInDom(inDomOutputRef.current, searchQuery || "");
+  }, [searchQuery, shouldIsolate, outputCount]);
 
   // Empty state: render nothing (unless preloading iframe)
   if (outputs.length === 0 && !showPreloadedIframe) {
@@ -494,34 +503,37 @@ export function OutputArea({
           )}
 
           {/* In-DOM outputs (when not using isolation) */}
-          {!shouldIsolate &&
-            outputs.map((output, index) => (
-              <div
-                key={`output-${index}`}
-                data-slot="output-item"
-                data-output-index={index}
-              >
-                <ErrorBoundary
-                  resetKeys={[JSON.stringify(output)]}
-                  fallback={(error, reset) => (
-                    <OutputErrorFallback
-                      error={error}
-                      outputIndex={index}
-                      onRetry={reset}
-                    />
-                  )}
-                  onError={(error, errorInfo) => {
-                    console.error(
-                      `[OutputArea] Error rendering output ${index}:`,
-                      error,
-                      errorInfo.componentStack,
-                    );
-                  }}
+          {!shouldIsolate && (
+            <div ref={inDomOutputRef}>
+              {outputs.map((output, index) => (
+                <div
+                  key={`output-${index}`}
+                  data-slot="output-item"
+                  data-output-index={index}
                 >
-                  {renderOutput(output, index, renderers, priority)}
-                </ErrorBoundary>
-              </div>
-            ))}
+                  <ErrorBoundary
+                    resetKeys={[JSON.stringify(output)]}
+                    fallback={(error, reset) => (
+                      <OutputErrorFallback
+                        error={error}
+                        outputIndex={index}
+                        onRetry={reset}
+                      />
+                    )}
+                    onError={(error, errorInfo) => {
+                      console.error(
+                        `[OutputArea] Error rendering output ${index}:`,
+                        error,
+                        errorInfo.componentStack,
+                      );
+                    }}
+                  >
+                    {renderOutput(output, index, renderers, priority)}
+                  </ErrorBoundary>
+                </div>
+              ))}
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -108,6 +108,11 @@ interface OutputAreaProps {
    * @deprecated Use the comm bridge instead for full widget support
    */
   onWidgetUpdate?: (commId: string, state: Record<string, unknown>) => void;
+  /**
+   * Search query to highlight in iframe outputs.
+   * Empty string or undefined clears highlights.
+   */
+  searchQuery?: string;
 }
 
 /**
@@ -280,6 +285,7 @@ export function OutputArea({
   preloadIframe = false,
   onLinkClick,
   onWidgetUpdate,
+  searchQuery,
 }: OutputAreaProps) {
   const id = useId();
   const frameRef = useRef<IsolatedFrameHandle>(null);
@@ -418,6 +424,13 @@ export function OutputArea({
       handleFrameReady();
     }
   }, [handleFrameReady]);
+
+  // Forward search query to the iframe
+  useEffect(() => {
+    if (frameRef.current?.isReady) {
+      frameRef.current.search(searchQuery || "");
+    }
+  }, [searchQuery]);
 
   // Empty state: render nothing (unless preloading iframe)
   if (outputs.length === 0 && !showPreloadedIframe) {

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -455,14 +455,12 @@ export function OutputArea({
   // Re-run when outputs array ref changes so new content gets highlighted
   useEffect(() => {
     if (shouldIsolate) return; // iframe reports its own count via search_results
-    if (!inDomOutputRef.current || outputs.length === 0) {
-      onSearchMatchCount?.(0);
+    if (!searchQuery || !inDomOutputRef.current || outputs.length === 0) {
+      // Only report 0 if we were previously tracking matches for this cell
+      if (searchQuery) onSearchMatchCount?.(0);
       return;
     }
-    const cleanup = highlightTextInDom(
-      inDomOutputRef.current,
-      searchQuery || "",
-    );
+    const cleanup = highlightTextInDom(inDomOutputRef.current, searchQuery);
     const count =
       inDomOutputRef.current.querySelectorAll(".global-find-match").length;
     onSearchMatchCount?.(count);

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -114,6 +114,11 @@ interface OutputAreaProps {
    * Empty string or undefined clears highlights.
    */
   searchQuery?: string;
+  /**
+   * Callback reporting how many search matches were found in this cell's outputs.
+   * Called when iframe reports search_results or in-DOM highlighting completes.
+   */
+  onSearchMatchCount?: (count: number) => void;
 }
 
 /**
@@ -287,11 +292,14 @@ export function OutputArea({
   onLinkClick,
   onWidgetUpdate,
   searchQuery,
+  onSearchMatchCount,
 }: OutputAreaProps) {
   const id = useId();
   const frameRef = useRef<IsolatedFrameHandle>(null);
   const bridgeRef = useRef<CommBridgeManager | null>(null);
   const inDomOutputRef = useRef<HTMLDivElement>(null);
+  const searchQueryRef = useRef(searchQuery);
+  searchQueryRef.current = searchQuery;
 
   // Track dark mode state and observe changes
   const [darkMode, setDarkMode] = useState(() => detectDarkMode());
@@ -328,7 +336,6 @@ export function OutputArea({
   const shouldUseBridge = shouldIsolate && hasWidgets && widgetContext !== null;
 
   const hasCollapseControl = onToggleCollapse !== undefined;
-  const outputCount = outputs.length;
 
   // Handle messages from iframe, routing widget messages to comm bridge
   const handleIframeMessage = useCallback(
@@ -342,8 +349,13 @@ export function OutputArea({
       if (message.type === "widget_update" && onWidgetUpdate) {
         onWidgetUpdate(message.payload.commId, message.payload.state);
       }
+
+      // Capture search result count from iframe
+      if (message.type === "search_results") {
+        onSearchMatchCount?.(message.payload.count);
+      }
     },
-    [onWidgetUpdate],
+    [onWidgetUpdate, onSearchMatchCount],
   );
 
   // Callback when frame is ready - set up bridge and render outputs
@@ -408,6 +420,11 @@ export function OutputArea({
         });
       }
     });
+
+    // Re-apply search highlights after rendering new content
+    if (searchQueryRef.current) {
+      frameRef.current?.search(searchQueryRef.current);
+    }
   }, [outputs, priority, shouldUseBridge, widgetContext]);
 
   // Clean up bridge on unmount
@@ -435,11 +452,22 @@ export function OutputArea({
   }, [searchQuery]);
 
   // Highlight search matches in in-DOM outputs
-  // Re-run when outputs change (outputCount tracks this) so new content gets highlighted
+  // Re-run when outputs array ref changes so new content gets highlighted
   useEffect(() => {
-    if (!inDomOutputRef.current || shouldIsolate || outputCount === 0) return;
-    return highlightTextInDom(inDomOutputRef.current, searchQuery || "");
-  }, [searchQuery, shouldIsolate, outputCount]);
+    if (shouldIsolate) return; // iframe reports its own count via search_results
+    if (!inDomOutputRef.current || outputs.length === 0) {
+      onSearchMatchCount?.(0);
+      return;
+    }
+    const cleanup = highlightTextInDom(
+      inDomOutputRef.current,
+      searchQuery || "",
+    );
+    const count =
+      inDomOutputRef.current.querySelectorAll(".global-find-match").length;
+    onSearchMatchCount?.(count);
+    return cleanup;
+  }, [searchQuery, shouldIsolate, outputs, onSearchMatchCount]);
 
   // Empty state: render nothing (unless preloading iframe)
   if (outputs.length === 0 && !showPreloadedIframe) {
@@ -470,7 +498,7 @@ export function OutputArea({
           )}
           <span>
             {collapsed
-              ? `Show ${outputCount} output${outputCount > 1 ? "s" : ""}`
+              ? `Show ${outputs.length} output${outputs.length > 1 ? "s" : ""}`
               : "Hide outputs"}
           </span>
         </button>

--- a/src/components/editor/search-highlight.ts
+++ b/src/components/editor/search-highlight.ts
@@ -1,0 +1,104 @@
+import { type Extension, RangeSetBuilder } from "@codemirror/state";
+import {
+  Decoration,
+  type DecorationSet,
+  EditorView,
+  ViewPlugin,
+  type ViewUpdate,
+} from "@codemirror/view";
+
+const searchMatchMark = Decoration.mark({ class: "cm-global-find-match" });
+const activeMatchMark = Decoration.mark({
+  class: "cm-global-find-match-active",
+});
+
+const searchHighlightTheme = EditorView.theme({
+  ".cm-global-find-match": {
+    background: "#fbbf24",
+    color: "#000",
+    borderRadius: "2px",
+  },
+  ".cm-global-find-match-active": {
+    background: "#f97316",
+    color: "#000",
+    borderRadius: "2px",
+  },
+});
+
+/**
+ * Build decorations for all search matches in a document.
+ * @param doc - The CodeMirror document text
+ * @param query - Search query (case-insensitive)
+ * @param activeOffset - Character offset of the active match (-1 for none)
+ */
+function buildDecorations(
+  doc: string,
+  query: string,
+  activeOffset: number,
+): DecorationSet {
+  if (!query) return Decoration.none;
+
+  const builder = new RangeSetBuilder<Decoration>();
+  const lowerDoc = doc.toLowerCase();
+  const lowerQuery = query.toLowerCase();
+  let pos = lowerDoc.indexOf(lowerQuery, 0);
+
+  while (pos !== -1) {
+    const isActive = pos === activeOffset;
+    builder.add(
+      pos,
+      pos + query.length,
+      isActive ? activeMatchMark : searchMatchMark,
+    );
+    pos = lowerDoc.indexOf(lowerQuery, pos + query.length);
+  }
+
+  return builder.finish();
+}
+
+/**
+ * Create a search highlight ViewPlugin for a given query.
+ *
+ * Note: Since ViewPlugin instances are static (cannot update config),
+ * this returns a new extension each time the query changes. The parent
+ * component should replace extensions when the query changes, which
+ * is the standard pattern for react-codemirror.
+ */
+function createSearchHighlightPlugin(query: string, activeOffset: number) {
+  return ViewPlugin.define(
+    (view) => ({
+      decorations: buildDecorations(
+        view.state.doc.toString(),
+        query,
+        activeOffset,
+      ),
+      update(update: ViewUpdate) {
+        if (update.docChanged) {
+          this.decorations = buildDecorations(
+            update.state.doc.toString(),
+            query,
+            activeOffset,
+          );
+        }
+      },
+    }),
+    {
+      decorations: (v) => v.decorations,
+    },
+  );
+}
+
+/**
+ * Create a CodeMirror extension that highlights all matches of a search query.
+ *
+ * @param query - The search string to highlight (case-insensitive). Empty string = no highlights.
+ * @param activeOffset - Character offset of the "active" match to highlight differently (-1 for none).
+ * @returns A CodeMirror Extension array to pass to the editor.
+ */
+export function searchHighlight(query: string, activeOffset = -1): Extension[] {
+  if (!query) return [];
+  return [
+    searchHighlightTheme,
+    createSearchHighlightPlugin(query, activeOffset),
+  ];
+}

--- a/src/components/isolated/__tests__/comm-bridge-manager.test.ts
+++ b/src/components/isolated/__tests__/comm-bridge-manager.test.ts
@@ -76,6 +76,8 @@ function createMockFrame(): {
     eval: vi.fn(),
     setTheme: vi.fn(),
     clear: vi.fn(),
+    search: vi.fn(),
+    searchNavigate: vi.fn(),
     isReady: true,
     isIframeReady: true,
   };

--- a/src/components/isolated/frame-bridge.ts
+++ b/src/components/isolated/frame-bridge.ts
@@ -155,6 +155,33 @@ export interface BridgeReadyMessage {
   type: "bridge_ready";
 }
 
+// --- Global Find: Parent → Iframe ---
+
+/**
+ * Search for text within the iframe's rendered content.
+ * The iframe should highlight all matches and report the count.
+ */
+export interface SearchMessage {
+  type: "search";
+  payload: {
+    /** The search query string (empty string clears search) */
+    query: string;
+    /** Whether the search should be case-sensitive */
+    caseSensitive?: boolean;
+  };
+}
+
+/**
+ * Navigate to a specific match in the iframe's search results.
+ */
+export interface SearchNavigateMessage {
+  type: "search_navigate";
+  payload: {
+    /** The index of the match to navigate to (0-based) */
+    matchIndex: number;
+  };
+}
+
 /**
  * All message types that can be sent from parent to iframe.
  */
@@ -169,7 +196,9 @@ export type ParentToIframeMessage =
   | CommMsgMessage
   | CommCloseMessage
   | CommSyncMessage
-  | BridgeReadyMessage;
+  | BridgeReadyMessage
+  | SearchMessage
+  | SearchNavigateMessage;
 
 // --- Message Types: Iframe → Parent ---
 
@@ -324,6 +353,20 @@ export interface WidgetCommCloseMessage {
   };
 }
 
+// --- Global Find: Iframe → Parent ---
+
+/**
+ * Report search results from the iframe.
+ * Sent after processing a search message.
+ */
+export interface SearchResultsMessage {
+  type: "search_results";
+  payload: {
+    /** Number of matches found */
+    count: number;
+  };
+}
+
 /**
  * All message types that can be sent from iframe to parent.
  */
@@ -340,7 +383,8 @@ export type IframeToParentMessage =
   | RendererReadyMessage
   | WidgetReadyMessage
   | WidgetCommMsgMessage
-  | WidgetCommCloseMessage;
+  | WidgetCommCloseMessage
+  | SearchResultsMessage;
 
 // --- Utility Types ---
 
@@ -376,6 +420,7 @@ export function isIframeMessage(data: unknown): data is IframeToParentMessage {
       "widget_ready",
       "widget_comm_msg",
       "widget_comm_close",
+      "search_results",
     ].includes(msg.type)
   );
 }

--- a/src/components/isolated/isolated-frame.tsx
+++ b/src/components/isolated/isolated-frame.tsx
@@ -440,10 +440,24 @@ export const IsolatedFrame = forwardRef<
       setTheme: (isDark: boolean) =>
         send({ type: "theme", payload: { isDark } }),
       clear: () => send({ type: "clear" }),
-      search: (query: string, caseSensitive?: boolean) =>
-        send({ type: "search", payload: { query, caseSensitive } }),
-      searchNavigate: (matchIndex: number) =>
-        send({ type: "search_navigate", payload: { matchIndex } }),
+      search: (query: string, caseSensitive?: boolean) => {
+        // Search handler is in bootstrap HTML, so send directly when iframe is loaded
+        // (bypasses the isReady queue which waits for the React renderer)
+        if (iframeRef.current?.contentWindow) {
+          iframeRef.current.contentWindow.postMessage(
+            { type: "search", payload: { query, caseSensitive } },
+            "*",
+          );
+        }
+      },
+      searchNavigate: (matchIndex: number) => {
+        if (iframeRef.current?.contentWindow) {
+          iframeRef.current.contentWindow.postMessage(
+            { type: "search_navigate", payload: { matchIndex } },
+            "*",
+          );
+        }
+      },
       isReady,
       isIframeReady,
     }),

--- a/src/components/isolated/isolated-frame.tsx
+++ b/src/components/isolated/isolated-frame.tsx
@@ -111,6 +111,17 @@ export interface IsolatedFrameHandle {
   clear: () => void;
 
   /**
+   * Search for text within the iframe's rendered content.
+   * Pass empty string to clear search highlights.
+   */
+  search: (query: string, caseSensitive?: boolean) => void;
+
+  /**
+   * Navigate to a specific search match by index.
+   */
+  searchNavigate: (matchIndex: number) => void;
+
+  /**
    * Whether the iframe is ready to receive messages.
    * True after the React renderer bundle is initialized.
    */
@@ -429,6 +440,10 @@ export const IsolatedFrame = forwardRef<
       setTheme: (isDark: boolean) =>
         send({ type: "theme", payload: { isDark } }),
       clear: () => send({ type: "clear" }),
+      search: (query: string, caseSensitive?: boolean) =>
+        send({ type: "search", payload: { query, caseSensitive } }),
+      searchNavigate: (matchIndex: number) =>
+        send({ type: "search_navigate", payload: { matchIndex } }),
       isReady,
       isIframeReady,
     }),

--- a/src/lib/highlight-text.ts
+++ b/src/lib/highlight-text.ts
@@ -1,0 +1,66 @@
+/**
+ * Highlight all occurrences of a search query within a DOM container.
+ *
+ * Walks text nodes using TreeWalker, wraps matches in <mark> elements.
+ * Returns a cleanup function that removes all marks and restores text nodes.
+ */
+export function highlightTextInDom(
+  container: HTMLElement,
+  query: string,
+): () => void {
+  if (!query) return () => {};
+
+  const marks: HTMLElement[] = [];
+  const walker = document.createTreeWalker(
+    container,
+    NodeFilter.SHOW_TEXT,
+    null,
+  );
+  const lowerQuery = query.toLowerCase();
+
+  // Collect matches first (to avoid mutating DOM while walking)
+  const matches: { node: Text; offset: number; length: number }[] = [];
+  let node = walker.nextNode();
+  while (node) {
+    const text = node.nodeValue || "";
+    const lowerText = text.toLowerCase();
+    let pos = lowerText.indexOf(lowerQuery, 0);
+    while (pos !== -1) {
+      matches.push({ node: node as Text, offset: pos, length: query.length });
+      pos = lowerText.indexOf(lowerQuery, pos + query.length);
+    }
+    node = walker.nextNode();
+  }
+
+  // Apply highlights in reverse order to preserve offsets
+  for (let i = matches.length - 1; i >= 0; i--) {
+    const m = matches[i];
+    try {
+      const range = document.createRange();
+      range.setStart(m.node, m.offset);
+      range.setEnd(m.node, m.offset + m.length);
+      const mark = document.createElement("mark");
+      mark.className = "global-find-match";
+      mark.style.cssText =
+        "background: #fbbf24; color: #000; border-radius: 2px; padding: 0;";
+      range.surroundContents(mark);
+      marks.unshift(mark);
+    } catch {
+      // surroundContents can fail if range crosses element boundaries
+    }
+  }
+
+  // Return cleanup function
+  return () => {
+    for (const mark of marks) {
+      const parent = mark.parentNode;
+      if (parent) {
+        while (mark.firstChild) {
+          parent.insertBefore(mark.firstChild, mark);
+        }
+        parent.removeChild(mark);
+        parent.normalize();
+      }
+    }
+  };
+}


### PR DESCRIPTION
Cmd+F / Ctrl+F global find bar that searches across code cells, markdown cells, and outputs.

**How it works:**
- `useGlobalFind` hook computes source matches directly from cell text
- Output match counts are reported back from rendered content — iframes send `search_results` via postMessage, in-DOM outputs count `<mark>` elements after highlighting
- CodeMirror ViewPlugin highlights matches in editors (yellow for all, orange for active)
- `highlightTextInDom` walks DOM text nodes for in-DOM outputs (stream, error, text/plain)
- Iframe search protocol handles isolated outputs (HTML, widgets, plots)

**Known limitations / follow-up work:**
- No active match differentiation in output highlights (all same color, only CodeMirror editors show active vs inactive)
- `highlightTextInDom` mutates DOM outside React — worth exploring CSS Custom Highlight API or React-based highlighting as alternatives
- Output match navigation (scrolling to specific output match, sending `search_navigate` to iframes) not yet wired up

Closes #399