### PR TITLE
feat(stream-output): increase terminal width to 128 columns

### DIFF
--- a/crates/runtimed/src/stream_terminal.rs
+++ b/crates/runtimed/src/stream_terminal.rs
@@ -17,7 +17,7 @@ use alacritty_terminal::vte::ansi::{Color, NamedColor, Processor, Rgb};
 use alacritty_terminal::Term;
 
 /// Default terminal width in columns.
-const DEFAULT_COLUMNS: usize = 120;
+const DEFAULT_COLUMNS: usize = 128;
 
 /// Default terminal height in lines.
 /// We use a small height since we don't need scrollback for notebook outputs.


### PR DESCRIPTION
Bumps DEFAULT_COLUMNS from 120 to 128 for better display of ASCII art and terminal output. 128 is a power-of-2 width that provides more room while remaining reasonable for constrained layouts.

This change affects how the stream terminal emulator processes escape sequences and layouts content. Future work will include setting COLUMNS environment variable in kernel launchers to match this processing width, ensuring subprocesses (like IPython and shell commands) format output consistently.

## Verification

- [x] \`cargo test --verbose\` passes
- [x] \`cargo clippy --all-targets -- -D warnings\` passes
- [x] Formatting checks pass

_PR submitted by @rgbkrk's agent, Quill_