### PR TITLE
feat(runtimed): add signal handlers and panic logging for daemon exit visibility

### DIFF
--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -377,6 +377,13 @@ impl Daemon {
         }))
     }
 
+    /// Get a handle to the shutdown notifier.
+    ///
+    /// Signal handlers can use this to trigger graceful shutdown.
+    pub fn shutdown_notify(&self) -> Arc<Notify> {
+        self.shutdown_notify.clone()
+    }
+
     /// Run the daemon server.
     pub async fn run(self: Arc<Self>) -> anyhow::Result<()> {
         // Platform-specific setup

--- a/crates/runtimed/src/main.rs
+++ b/crates/runtimed/src/main.rs
@@ -6,7 +6,7 @@
 use std::path::PathBuf;
 
 use clap::{Parser, Subcommand};
-use log::info;
+use log::{error, info};
 use runtimed::client::PoolClient;
 use runtimed::daemon::{Daemon, DaemonConfig};
 use runtimed::service::ServiceManager;
@@ -93,6 +93,28 @@ enum Commands {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    // Install panic hook to ensure panics are logged to the daemon log file.
+    // This runs before logging is initialized, so we write directly to the file.
+    std::panic::set_hook(Box::new(|panic_info| {
+        use std::io::Write;
+
+        let log_path = runtimed::default_log_path();
+        let timestamp = chrono::Local::now().format("%Y-%m-%d %H:%M:%S");
+        let msg = format!("{} [PANIC] runtimed: {}", timestamp, panic_info);
+
+        // Write to stderr (visible in terminal)
+        eprintln!("{}", msg);
+
+        // Also append to log file so it's captured for debugging
+        if let Ok(mut file) = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&log_path)
+        {
+            let _ = writeln!(file, "{}", msg);
+        }
+    }));
+
     let cli = Cli::parse();
 
     // Set dev mode environment variable if flag is used
@@ -244,6 +266,10 @@ async fn run_daemon(
     let daemon = match Daemon::new(config) {
         Ok(d) => d,
         Err(e) => {
+            error!(
+                "Daemon already running: pid={}, endpoint={}",
+                e.info.pid, e.info.endpoint
+            );
             eprintln!("Error: {}", e);
             eprintln!(
                 "Running daemon: pid={}, endpoint={}",
@@ -252,6 +278,29 @@ async fn run_daemon(
             std::process::exit(1);
         }
     };
+
+    // Set up signal handlers for graceful shutdown with logging
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{signal, SignalKind};
+        let shutdown = daemon.shutdown_notify();
+
+        tokio::spawn(async move {
+            let mut sigterm = signal(SignalKind::terminate()).expect("failed to register SIGTERM");
+            let mut sigint = signal(SignalKind::interrupt()).expect("failed to register SIGINT");
+
+            tokio::select! {
+                _ = sigterm.recv() => {
+                    info!("[runtimed] Received SIGTERM");
+                }
+                _ = sigint.recv() => {
+                    info!("[runtimed] Received SIGINT");
+                }
+            }
+            shutdown.notify_one();
+        });
+    }
+
     daemon.run().await
 }
 


### PR DESCRIPTION
## Summary

When the daemon crashes or is terminated, users see "[Process exited with code 1]" in their terminal with no explanation in the logs. This makes debugging impossible. Added signal handlers for SIGTERM/SIGINT that log before gracefully shutting down, a panic hook that captures panics to the log file, and logging for startup errors.

## Changes

- Signal handlers for SIGTERM/SIGINT that trigger graceful shutdown with logging
- Panic hook that writes panics to the log file even if logging infrastructure fails
- Log "Daemon already running" errors to the file for better visibility
- Exposes `shutdown_notify()` method on `Daemon` for signal handlers to use

## Verification

Test the following scenarios to verify daemon exit logging:

- [x] Start dev daemon: `cargo xtask dev-daemon`
- [x] Send SIGTERM: `kill -TERM $(pgrep -f "target/debug/runtimed")` and verify logs show "Received SIGTERM" followed by "Shutting down"
- [x] Start daemon again, press Ctrl+C and verify logs show "Received SIGINT" followed by "Shutting down"
- [x] Verify existing daemon check still works: try starting a second daemon while one is running and verify "Daemon already running" appears in logs

_PR submitted by @rgbkrk's agent, Quill_