### PR TITLE
feat(terminal): share terminal size constants across kernel and stream

### DIFF
--- a/crates/runtimed/src/kernel_manager.rs
+++ b/crates/runtimed/src/kernel_manager.rs
@@ -32,6 +32,7 @@ use crate::notebook_sync_server::persist_notebook_bytes;
 use crate::output_store::{self, DEFAULT_INLINE_THRESHOLD};
 use crate::protocol::{CompletionItem, HistoryEntry, NotebookBroadcast};
 use crate::stream_terminal::{StreamOutputState, StreamTerminals};
+use crate::terminal_size::{TERMINAL_COLUMNS_STR, TERMINAL_LINES_STR};
 use crate::PooledEnv;
 
 // ── Launched Environment Config ─────────────────────────────────────────────
@@ -623,6 +624,10 @@ impl RoomKernel {
             }
         };
         cmd.current_dir(&cwd);
+
+        // Set terminal size for consistent output formatting
+        cmd.env("COLUMNS", TERMINAL_COLUMNS_STR);
+        cmd.env("LINES", TERMINAL_LINES_STR);
 
         #[cfg(unix)]
         cmd.process_group(0);

--- a/crates/runtimed/src/lib.rs
+++ b/crates/runtimed/src/lib.rs
@@ -35,6 +35,7 @@ pub mod singleton;
 pub mod stream_terminal;
 pub mod sync_client;
 pub mod sync_server;
+pub mod terminal_size;
 
 // ============================================================================
 // Development Mode and Worktree Isolation

--- a/crates/runtimed/src/stream_terminal.rs
+++ b/crates/runtimed/src/stream_terminal.rs
@@ -16,12 +16,7 @@ use alacritty_terminal::term::Config;
 use alacritty_terminal::vte::ansi::{Color, NamedColor, Processor, Rgb};
 use alacritty_terminal::Term;
 
-/// Default terminal width in columns.
-const DEFAULT_COLUMNS: usize = 128;
-
-/// Default terminal height in lines.
-/// We use a small height since we don't need scrollback for notebook outputs.
-const DEFAULT_LINES: usize = 100;
+use crate::terminal_size::{TERMINAL_COLUMNS, TERMINAL_LINES};
 
 /// Maximum scrollback history.
 /// Keep minimal since notebook outputs don't need scrollback.
@@ -117,7 +112,7 @@ impl StreamTerminals {
                 scrolling_history: SCROLLBACK_HISTORY,
                 ..Config::default()
             };
-            let dimensions = TermDimensions::new(DEFAULT_COLUMNS, DEFAULT_LINES);
+            let dimensions = TermDimensions::new(TERMINAL_COLUMNS, TERMINAL_LINES);
             Term::new(config, &dimensions, VoidListener)
         });
 

--- a/crates/runtimed/src/terminal_size.rs
+++ b/crates/runtimed/src/terminal_size.rs
@@ -1,0 +1,28 @@
+//! Terminal size constants for kernel output.
+//!
+//! These constants define the terminal dimensions used for:
+//! 1. Kernel environment variables (COLUMNS, LINES) - what subprocesses see
+//! 2. Stream terminal emulation - how we process escape sequences
+//!
+//! Using 80 columns provides good compatibility with side-by-side window layouts
+//! on typical displays. Both values should match to ensure consistent output
+//! formatting between what the kernel produces and how we render it.
+
+/// Terminal width in columns.
+///
+/// This is passed to kernels via COLUMNS env var and used for stream terminal
+/// emulation. 80 is the classic terminal width that works well for side-by-side
+/// layouts and produces readable tracebacks.
+pub const TERMINAL_COLUMNS: usize = 80;
+
+/// Terminal height in lines.
+///
+/// Passed to kernels via LINES env var. The actual value matters less for
+/// notebooks since we don't have scrolling viewports, but some tools check it.
+pub const TERMINAL_LINES: usize = 100;
+
+/// String version of TERMINAL_COLUMNS for env var.
+pub const TERMINAL_COLUMNS_STR: &str = "80";
+
+/// String version of TERMINAL_LINES for env var.
+pub const TERMINAL_LINES_STR: &str = "100";


### PR DESCRIPTION
Creates a new `terminal_size` module with shared constants (TERMINAL_COLUMNS=80, TERMINAL_LINES=100) and sets COLUMNS/LINES environment variables on all kernel launches. This ensures subprocesses (IPython, shell commands, etc.) format output to match how the stream terminal emulator processes it.

Provides consistent output formatting across kernel and renderer, making notebooks easier to view side-by-side on typical displays with readable 80-column tracebacks.

## Verification

- Kernel environment variables (COLUMNS, LINES) are set on all Python and Deno kernels
- Stream terminal emulation uses the same constants
- All terminal width-dependent tools (htop, vim, less) will see 80 columns

_PR submitted by @rgbkrk's agent, Quill_