### PR TITLE
fix(runtimed): support nested Output widget capture contexts

### DIFF
--- a/src/components/outputs/media-router.tsx
+++ b/src/components/outputs/media-router.tsx
@@ -344,6 +344,19 @@ export function MediaRouter({
       return <AnsiOutput className={className}>{String(content)}</AnsiOutput>;
     }
 
+    // Widget view JSON - when rendered in-DOM without a widget renderer,
+    // show a helpful message instead of raw JSON. This typically happens
+    // when a widget is displayed inside an Output widget.
+    if (mimeType === "application/vnd.jupyter.widget-view+json") {
+      return (
+        <div className="py-2 px-3 text-sm text-muted-foreground bg-muted/50 rounded border border-border">
+          <span className="font-medium">Nested widget</span>
+          <span className="mx-1">·</span>
+          <span>Widgets inside Output widgets are not yet supported</span>
+        </div>
+      );
+    }
+
     // Unknown +json types without custom renderer - show as JSON
     if (mimeType.includes("+json")) {
       return (


### PR DESCRIPTION
## Summary

- Fixes edge case where nested Output widgets (e.g., nested `with out:` blocks) would overwrite each other's capture context
- Capture contexts now use a stack per msg_id instead of a single value
- Most recently activated widget receives outputs; when it exits, the previous widget resumes capturing
- Shows friendly "Nested widget" message instead of raw JSON when widgets are displayed inside Output widgets

## Screenshots

### Before

<img width="978" height="723" alt="image" src="https://github.com/user-attachments/assets/38a29bc5-b433-44ed-9928-463d719d2877" />

### After

<img width="840" height="388" alt="image" src="https://github.com/user-attachments/assets/018de49b-2307-40d1-8f76-8889f28af2a7" />


## Verification

- [x] Run `cargo test -p runtimed comm_state` - all 12 tests should pass including new nested capture tests
- [x] Manual test with nested Output widgets:
  ```python
  import ipywidgets as widgets
  outer = widgets.Output()
  inner = widgets.Output()
  display(outer)
  with outer:
      print("outer 1")
      display(inner)
      with inner:
          print("inner")
      print("outer 2")
  ```

Closes #421

_PR submitted by @rgbkrk's agent, Quill_