### PR TITLE
ci(workflows): add actionlint to validate workflow files on PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,6 +81,8 @@ jobs:
 
       - name: Lint GitHub Actions workflows
         uses: raven-actions/actionlint@v2
+        with:
+          shellcheck: false
 
   build-linux:
     name: Linux

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           filters: |
             source:
-              - ".github/workflows/build.yml"
+              - ".github/workflows/**"
               - "apps/**"
               - "bin/**"
               - "crates/**"
@@ -78,6 +78,9 @@ jobs:
 
       - name: Check Biome (format + lint + imports)
         run: npx @biomejs/biome check apps/notebook/src/ e2e/
+
+      - name: Lint GitHub Actions workflows
+        uses: raven-actions/actionlint@v2
 
   build-linux:
     name: Linux


### PR DESCRIPTION
## Summary

- Add `actionlint` CI step to catch workflow syntax errors before they land on main
- Update path filter to trigger linting on all workflow file changes (was only `build.yml`)

This prevents issues like the `matrix.target_os` error fixed in #413 from being merged.

## Test plan

- [ ] CI passes with the new actionlint step
- [ ] Verify actionlint catches errors by testing locally: `actionlint .github/workflows/*.yml`