### PR TITLE
fix(release): drop alpha postfix from weekly preview labels

### DIFF
--- a/.github/workflows/weekly-preview.yml
+++ b/.github/workflows/weekly-preview.yml
@@ -68,8 +68,7 @@ jobs:
         run: |
           CURRENT_VERSION=$(grep '^version' crates/runt/Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
           COMMIT_SHA=${GITHUB_SHA::7}
-          BASE_VERSION="${CURRENT_VERSION%-alpha.1}"
-          VERSION="${BASE_VERSION}-preview.${COMMIT_SHA}"
+          VERSION="${CURRENT_VERSION}-preview.${COMMIT_SHA}"
           echo "Setting version to: ${VERSION}"
           echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
 
@@ -142,8 +141,7 @@ jobs:
         run: |
           CURRENT_VERSION=$(grep '^version' crates/runt/Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
           COMMIT_SHA=${GITHUB_SHA::7}
-          BASE_VERSION="${CURRENT_VERSION%-alpha.1}"
-          VERSION="${BASE_VERSION}-preview.${COMMIT_SHA}"
+          VERSION="${CURRENT_VERSION}-preview.${COMMIT_SHA}"
           echo "Setting version to: ${VERSION}"
           echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
           sed -i '' "s/^version = .*/version = \"${VERSION}\"/" crates/runt/Cargo.toml
@@ -250,8 +248,7 @@ jobs:
         run: |
           CURRENT_VERSION=$(grep '^version' crates/runt/Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
           COMMIT_SHA=${GITHUB_SHA::7}
-          BASE_VERSION="${CURRENT_VERSION%-alpha.1}"
-          VERSION="${BASE_VERSION}-preview.${COMMIT_SHA}"
+          VERSION="${CURRENT_VERSION}-preview.${COMMIT_SHA}"
           echo "Setting version to: ${VERSION}"
           sed -i '' "s/\"version\": \"[^\"]*\"/\"version\": \"${VERSION}\"/" crates/notebook/tauri.conf.json
 
@@ -379,8 +376,7 @@ jobs:
             $currentVersion = $matches[1]
           }
           $commitSha = "$env:GITHUB_SHA".Substring(0, 7)
-          $baseVersion = $currentVersion -replace '-alpha\.1$', ''
-          $version = "$baseVersion-preview.$commitSha"
+          $version = "$currentVersion-preview.$commitSha"
           Write-Host "Setting version to: $version"
           $tauriConf = Get-Content crates/notebook/tauri.conf.json -Raw
           $tauriConf = $tauriConf -replace '"version": "[^"]+"', "`"version`": `"$version`""
@@ -502,8 +498,7 @@ jobs:
         run: |
           CURRENT_VERSION=$(grep '^version' crates/runt/Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
           COMMIT_SHA=${GITHUB_SHA::7}
-          BASE_VERSION="${CURRENT_VERSION%-alpha.1}"
-          VERSION="${BASE_VERSION}-preview.${COMMIT_SHA}"
+          VERSION="${CURRENT_VERSION}-preview.${COMMIT_SHA}"
           echo "Setting version to: ${VERSION}"
           sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"${VERSION}\"/" crates/notebook/tauri.conf.json
 
@@ -609,7 +604,7 @@ jobs:
           path: python/runtimed/dist
 
   prerelease:
-    name: Release
+    name: Preview Release
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/weekly-preview.yml
+++ b/.github/workflows/weekly-preview.yml
@@ -68,7 +68,8 @@ jobs:
         run: |
           CURRENT_VERSION=$(grep '^version' crates/runt/Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
           COMMIT_SHA=${GITHUB_SHA::7}
-          VERSION="${CURRENT_VERSION}-preview.${COMMIT_SHA}"
+          BASE_VERSION="${CURRENT_VERSION%-alpha.1}"
+          VERSION="${BASE_VERSION}-preview.${COMMIT_SHA}"
           echo "Setting version to: ${VERSION}"
           echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
 
@@ -141,7 +142,8 @@ jobs:
         run: |
           CURRENT_VERSION=$(grep '^version' crates/runt/Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
           COMMIT_SHA=${GITHUB_SHA::7}
-          VERSION="${CURRENT_VERSION}-preview.${COMMIT_SHA}"
+          BASE_VERSION="${CURRENT_VERSION%-alpha.1}"
+          VERSION="${BASE_VERSION}-preview.${COMMIT_SHA}"
           echo "Setting version to: ${VERSION}"
           echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
           sed -i '' "s/^version = .*/version = \"${VERSION}\"/" crates/runt/Cargo.toml
@@ -248,7 +250,8 @@ jobs:
         run: |
           CURRENT_VERSION=$(grep '^version' crates/runt/Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
           COMMIT_SHA=${GITHUB_SHA::7}
-          VERSION="${CURRENT_VERSION}-preview.${COMMIT_SHA}"
+          BASE_VERSION="${CURRENT_VERSION%-alpha.1}"
+          VERSION="${BASE_VERSION}-preview.${COMMIT_SHA}"
           echo "Setting version to: ${VERSION}"
           sed -i '' "s/\"version\": \"[^\"]*\"/\"version\": \"${VERSION}\"/" crates/notebook/tauri.conf.json
 
@@ -376,7 +379,8 @@ jobs:
             $currentVersion = $matches[1]
           }
           $commitSha = "$env:GITHUB_SHA".Substring(0, 7)
-          $version = "$currentVersion-preview.$commitSha"
+          $baseVersion = $currentVersion -replace '-alpha\.1$', ''
+          $version = "$baseVersion-preview.$commitSha"
           Write-Host "Setting version to: $version"
           $tauriConf = Get-Content crates/notebook/tauri.conf.json -Raw
           $tauriConf = $tauriConf -replace '"version": "[^"]+"', "`"version`": `"$version`""
@@ -498,7 +502,8 @@ jobs:
         run: |
           CURRENT_VERSION=$(grep '^version' crates/runt/Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
           COMMIT_SHA=${GITHUB_SHA::7}
-          VERSION="${CURRENT_VERSION}-preview.${COMMIT_SHA}"
+          BASE_VERSION="${CURRENT_VERSION%-alpha.1}"
+          VERSION="${BASE_VERSION}-preview.${COMMIT_SHA}"
           echo "Setting version to: ${VERSION}"
           sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"${VERSION}\"/" crates/notebook/tauri.conf.json
 
@@ -604,7 +609,7 @@ jobs:
           path: python/runtimed/dist
 
   prerelease:
-    name: Prerelease
+    name: Release
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -762,7 +767,7 @@ jobs:
             pip install runtimed --pre
             ```
           draft: false
-          prerelease: true
+          prerelease: false
           files: |
             ./release-assets/runt-linux-x64
             ./release-assets/runt-darwin-arm64
@@ -780,10 +785,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Ensure the rolling preview-latest release exists, then update latest.json
+          # Ensure the rolling preview-latest release exists as a normal release, then update latest.json
           gh release create preview-latest \
             --title "Preview Update Channel" \
             --notes "Rolling release for the preview auto-update channel. This release always contains the latest updater manifest. Do not delete this release." \
-            --prerelease 2>/dev/null || true
+            --latest=false 2>/dev/null || true
+
+          gh release edit preview-latest --prerelease=false --latest=false >/dev/null 2>&1 || true
 
           gh release upload preview-latest release-assets/latest.json --clobber

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3338,7 +3338,7 @@ dependencies = [
 
 [[package]]
 name = "notebook"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -5334,7 +5334,7 @@ dependencies = [
 
 [[package]]
 name = "runt-cli"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6102,7 +6102,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "sidecar"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,7 +4,7 @@
 
 | Stream | Tag | Trigger | Destination |
 |--------|-----|---------|-------------|
-| **Weekly preview** | `v{version}-preview.{sha}` | Cron (Monday 9am UTC) or manual | GitHub Releases (prerelease) |
+| **Weekly preview** | `v{version}-preview.{sha}` | Cron (Monday 9am UTC) or manual | GitHub Releases |
 | **Stable desktop** | `v{semver}` | Manual `workflow_dispatch` | GitHub Releases |
 | **Python package** | `python-v{semver}` | Manual tag push | PyPI + GitHub Releases |
 

--- a/crates/notebook/Cargo.toml
+++ b/crates/notebook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notebook"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 edition = "2021"
 description = "Tauri-based notebook UI for Jupyter kernels"
 repository = "https://github.com/nteract/desktop"

--- a/crates/notebook/tauri.conf.json
+++ b/crates/notebook/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "nteract",
-  "version": "1.4.0-alpha.1",
+  "version": "1.4.0",
   "identifier": "org.nteract.desktop",
   "build": {
     "devUrl": "http://localhost:5174",

--- a/crates/runt/Cargo.toml
+++ b/crates/runt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runt-cli"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 edition.workspace = true
 description = "CLI for Jupyter Runtimes — install via GitHub Releases or `pip install runtimed`, not crates.io"
 repository.workspace = true

--- a/crates/sidecar/Cargo.toml
+++ b/crates/sidecar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sidecar"
-version = "1.4.0-alpha.1"
+version = "1.4.0"
 edition.workspace = true
 description = "Sidecar jupyter outputs — install via GitHub Releases or `pip install runtimed`, not crates.io"
 repository.workspace = true


### PR DESCRIPTION
Update weekly preview version labels to drop the `alpha.1` postfix for non-Python artifacts and publish weekly previews as normal GitHub releases.

---
<p><a href="https://cursor.com/agents/bc-8b0b9836-822f-40b4-af0e-920fd5a6c427"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8b0b9836-822f-40b4-af0e-920fd5a6c427"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

