### PR TITLE
chore(ci): parallelize builds and make windows optional

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,13 +84,63 @@ jobs:
         with:
           shellcheck: false
 
-  build-linux:
-    name: Linux
+  build-ui:
+    name: Build shared UI artifacts
     needs: [changes]
     if: needs.changes.outputs.source_changed == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Set pnpm store directory
+        run: pnpm config set store-dir ~/.pnpm-store
+
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ~/.pnpm-store
+          key: pnpm-store-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            pnpm-store-${{ runner.os }}-
+
+      - name: Install JS dependencies
+        run: pnpm install
+
+      - name: Build UIs
+        run: |
+          pnpm --dir apps/sidecar build
+          pnpm --dir apps/notebook build
+
+      - name: Upload UI build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ui-build-dist
+          path: |
+            apps/notebook/dist/
+            apps/sidecar/dist/
+          retention-days: 1
+
+  build-linux:
+    name: Linux
+    needs: [changes, build-ui]
+    if: needs.changes.outputs.source_changed == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download UI build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: ui-build-dist
+          path: apps
 
       - name: Install system dependencies
         run: |
@@ -132,20 +182,6 @@ jobs:
       - name: Run JS tests
         run: pnpm test:run
 
-      - name: Build UIs
-        run: |
-          pnpm --dir apps/sidecar build
-          pnpm --dir apps/notebook build
-
-      - name: Upload UI build artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: ui-build-dist
-          path: |
-            apps/notebook/dist/
-            apps/sidecar/dist/
-          retention-days: 1
-
       - name: Build external binaries
         shell: bash
         run: |
@@ -171,8 +207,8 @@ jobs:
 
   build:
     name: ${{ matrix.platform.name }}
-    needs: [changes, build-linux]
-    if: ${{ always() && (needs.changes.outputs.source_changed != 'true' || needs.build-linux.result == 'success') }}
+    needs: [changes, build-ui]
+    if: ${{ always() && (needs.changes.outputs.source_changed != 'true' || needs.build-ui.result == 'success') }}
     runs-on: ${{ needs.changes.outputs.source_changed == 'true' && matrix.platform.runner || 'ubuntu-latest' }}
     strategy:
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -212,13 +212,7 @@ jobs:
     runs-on: ${{ needs.changes.outputs.source_changed == 'true' && matrix.platform.runner || 'ubuntu-latest' }}
     strategy:
       matrix:
-        platform:
-          - name: macOS
-            runner: macos-latest
-            setup: echo "No extra deps needed on macOS"
-          - name: Windows
-            runner: windows-latest
-            setup: echo "No extra deps needed on Windows"
+        platform: ${{ fromJSON(github.event_name == 'pull_request' && '[{"name":"macOS","runner":"macos-latest","setup":"echo No extra deps needed on macOS"}]' || '[{"name":"macOS","runner":"macos-latest","setup":"echo No extra deps needed on macOS"},{"name":"Windows","runner":"windows-latest","setup":"echo No extra deps needed on Windows"}]') }}
     steps:
       - name: Skip non-source changes
         if: needs.changes.outputs.source_changed != 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -209,50 +209,59 @@ jobs:
     name: ${{ matrix.platform.name }}
     needs: [changes, build-ui]
     if: ${{ always() && (needs.changes.outputs.source_changed != 'true' || needs.build-ui.result == 'success') }}
-    runs-on: ${{ needs.changes.outputs.source_changed == 'true' && matrix.platform.runner || 'ubuntu-latest' }}
+    continue-on-error: ${{ matrix.platform.non_blocking }}
+    runs-on: ${{ needs.changes.outputs.source_changed == 'true' && (github.event_name != 'pull_request' || matrix.platform.run_on_pr) && matrix.platform.runner || 'ubuntu-latest' }}
     strategy:
       matrix:
         platform:
           - name: macOS
             runner: macos-latest
             setup: echo "No extra deps needed on macOS"
+            run_on_pr: true
+            non_blocking: false
           - name: Windows
             runner: windows-latest
             setup: echo "No extra deps needed on Windows"
+            run_on_pr: false
+            non_blocking: true
     steps:
       - name: Skip non-source changes
         if: needs.changes.outputs.source_changed != 'true'
         run: echo "No source changes detected; skipping this platform leg."
 
+      - name: Skip this platform on pull requests
+        if: needs.changes.outputs.source_changed == 'true' && github.event_name == 'pull_request' && !matrix.platform.run_on_pr
+        run: echo "Skipping this platform for pull_request events."
+
       - uses: actions/checkout@v4
-        if: needs.changes.outputs.source_changed == 'true'
+        if: needs.changes.outputs.source_changed == 'true' && (github.event_name != 'pull_request' || matrix.platform.run_on_pr)
 
       - name: Download UI build artifacts
-        if: needs.changes.outputs.source_changed == 'true'
+        if: needs.changes.outputs.source_changed == 'true' && (github.event_name != 'pull_request' || matrix.platform.run_on_pr)
         uses: actions/download-artifact@v4
         with:
           name: ui-build-dist
           path: apps
 
       - name: Install system dependencies
-        if: needs.changes.outputs.source_changed == 'true'
+        if: needs.changes.outputs.source_changed == 'true' && (github.event_name != 'pull_request' || matrix.platform.run_on_pr)
         run: ${{ matrix.platform.setup }}
 
       - name: Install uv
-        if: needs.changes.outputs.source_changed == 'true'
+        if: needs.changes.outputs.source_changed == 'true' && (github.event_name != 'pull_request' || matrix.platform.run_on_pr)
         uses: astral-sh/setup-uv@v5
 
       - name: Install rust
-        if: needs.changes.outputs.source_changed == 'true'
+        if: needs.changes.outputs.source_changed == 'true' && (github.event_name != 'pull_request' || matrix.platform.run_on_pr)
         uses: dsherret/rust-toolchain-file@v1
 
       - uses: Swatinem/rust-cache@v2
-        if: needs.changes.outputs.source_changed == 'true'
+        if: needs.changes.outputs.source_changed == 'true' && (github.event_name != 'pull_request' || matrix.platform.run_on_pr)
         with:
           shared-key: ${{ matrix.platform.runner }}
 
       - name: Build external binaries
-        if: needs.changes.outputs.source_changed == 'true'
+        if: needs.changes.outputs.source_changed == 'true' && (github.event_name != 'pull_request' || matrix.platform.run_on_pr)
         shell: bash
         run: |
           cargo build --release -p runtimed -p runt-cli
@@ -267,15 +276,15 @@ jobs:
           fi
 
       - name: Clippy
-        if: needs.changes.outputs.source_changed == 'true'
+        if: needs.changes.outputs.source_changed == 'true' && (github.event_name != 'pull_request' || matrix.platform.run_on_pr)
         run: cargo clippy --all-targets -- -D warnings
 
       - name: Build
-        if: needs.changes.outputs.source_changed == 'true'
+        if: needs.changes.outputs.source_changed == 'true' && (github.event_name != 'pull_request' || matrix.platform.run_on_pr)
         run: cargo build --release
 
       - name: Run tests
-        if: needs.changes.outputs.source_changed == 'true'
+        if: needs.changes.outputs.source_changed == 'true' && (github.event_name != 'pull_request' || matrix.platform.run_on_pr)
         run: cargo test --verbose
 
   # Build Tauri app once and share with E2E shards

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -212,7 +212,13 @@ jobs:
     runs-on: ${{ needs.changes.outputs.source_changed == 'true' && matrix.platform.runner || 'ubuntu-latest' }}
     strategy:
       matrix:
-        platform: ${{ fromJSON(github.event_name == 'pull_request' && '[{"name":"macOS","runner":"macos-latest","setup":"echo No extra deps needed on macOS"}]' || '[{"name":"macOS","runner":"macos-latest","setup":"echo No extra deps needed on macOS"},{"name":"Windows","runner":"windows-latest","setup":"echo No extra deps needed on Windows"}]') }}
+        platform:
+          - name: macOS
+            runner: macos-latest
+            setup: echo "No extra deps needed on macOS"
+          - name: Windows
+            runner: windows-latest
+            setup: echo "No extra deps needed on Windows"
     steps:
       - name: Skip non-source changes
         if: needs.changes.outputs.source_changed != 'true'


### PR DESCRIPTION
Parallelize macOS and Windows builds in `build.yml` to improve CI efficiency.

Previously, macOS and Windows builds waited for `build-linux` to complete. This PR introduces a `build-ui` job to generate shared UI artifacts, allowing `build-linux` and the macOS/Windows matrix to run in parallel after the UI artifacts are ready.

---
<p><a href="https://cursor.com/agents/bc-a6416ad3-8318-4c34-a6df-b7755d50d01a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a6416ad3-8318-4c34-a6df-b7755d50d01a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

