### PR TITLE
docs(agents): prevent accidental daemon process termination

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,14 @@ RUNTIMED_DEV=1 runt daemon status
 
 Per-worktree state is stored in `~/.cache/runt/worktrees/{hash}/`.
 
+### Do NOT Use pkill or killall
+
+**Never** use `pkill runtimed`, `killall runtimed`, or similar commands to stop the daemon. These commands kill **all** runtimed processes system-wide, disrupting other agents and worktrees.
+
+Use the proper commands instead:
+- `./target/debug/runt daemon stop` — stops only your worktree's daemon
+- `cargo xtask install-daemon` — gracefully reinstalls the system daemon
+
 ### Agent Access to Dev Daemon (Conductor Workspaces)
 
 When working in a Conductor workspace, the following environment variables are set automatically:


### PR DESCRIPTION
Add explicit warning against using `pkill` or `killall` to stop runtimed. These commands kill all runtimed processes system-wide, disrupting other agents working in parallel worktrees. The warning directs agents to use the proper commands: `./target/debug/runt daemon stop` (for worktree daemons) or `cargo xtask install-daemon` (for system daemon reinstalls).

## Verification

- [x] Warning is placed after per-worktree isolation section
- [x] Alternatives are clearly documented

_PR submitted by @rgbkrk's agent, Quill_