### PR TITLE
feat(ui): add success feedback banner after sync/restart completes

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -333,6 +333,15 @@ function AppContent() {
   // Environment preparation progress
   const envProgress = useEnvProgress();
 
+  // Reset progress error when dependencies change (allows retry after fixing issues)
+  const progressError = envProgress.error;
+  const progressReset = envProgress.reset;
+  useEffect(() => {
+    if (envSyncState && !envSyncState.inSync && progressError) {
+      progressReset();
+    }
+  }, [envSyncState, progressError, progressReset]);
+
   // Derive sync state from daemon's envSyncState for inline environments
   // This overrides the disabled syncState from useDependencies/useCondaDependencies
   // Also shows for prewarmed kernels when user adds inline deps (prewarmed→inline drift)
@@ -406,6 +415,9 @@ function AppContent() {
   // Handler to sync deps - tries hot-sync for UV additions, falls back to restart
   // Always checks trust before any operation that installs packages
   const handleSyncDeps = useCallback(async (): Promise<boolean> => {
+    // Reset any previous error state before attempting
+    envProgress.reset();
+
     // Check trust first - required before any package installation (hot-sync or restart)
     const info = await checkTrust();
     if (!info) return false;
@@ -456,6 +468,7 @@ function AppContent() {
   }, [
     envSource,
     envSyncState,
+    envProgress,
     syncEnvironment,
     checkTrust,
     shutdownKernel,

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -111,6 +111,8 @@ function AppContent() {
   const [showIsolationTest, setShowIsolationTest] = useState(false);
   const [trustDialogOpen, setTrustDialogOpen] = useState(false);
   const [clearingDeps, setClearingDeps] = useState(false);
+  // Track when sync/restart just completed for success feedback
+  const [justSynced, setJustSynced] = useState(false);
 
   // Daemon startup status (installing, starting, failed, etc.)
   const [daemonStatus, setDaemonStatus] = useState<DaemonStatus>(null);
@@ -138,6 +140,13 @@ function AppContent() {
       setRuntime(r as "python" | "deno");
     });
   }, []);
+
+  // Auto-clear justSynced after 3 seconds
+  useEffect(() => {
+    if (!justSynced) return;
+    const timer = setTimeout(() => setJustSynced(false), 3000);
+    return () => clearTimeout(timer);
+  }, [justSynced]);
 
   // Page payload state: maps cell_id -> payload (transient, not saved)
   const [pagePayloads, setPagePayloads] = useState<
@@ -420,6 +429,7 @@ function AppContent() {
 
       if (response.result === "sync_environment_complete") {
         console.log("[App] Hot-sync succeeded:", response.synced_packages);
+        setJustSynced(true);
         return true;
       }
 
@@ -438,7 +448,11 @@ function AppContent() {
 
     // Restart flow - deps are already trusted from check above
     await shutdownKernel();
-    return tryStartKernel();
+    const started = await tryStartKernel();
+    if (started) {
+      setJustSynced(true);
+    }
+    return started;
   }, [
     envSource,
     envSyncState,
@@ -956,6 +970,7 @@ function AppContent() {
           syncState={denoDerivedSyncState}
           syncing={kernelStatus === "starting"}
           onSyncNow={handleSyncDeps}
+          justSynced={justSynced}
         />
       )}
       {dependencyHeaderOpen && runtime === "python" && envType === "conda" && (
@@ -979,6 +994,7 @@ function AppContent() {
           environmentYmlDeps={environmentYmlDeps}
           pixiInfo={pixiInfo}
           onImportFromPixi={importFromPixi}
+          justSynced={justSynced}
         />
       )}
       {dependencyHeaderOpen && runtime === "python" && envType !== "conda" && (
@@ -998,6 +1014,7 @@ function AppContent() {
           onImportFromPyproject={importFromPyproject}
           onUseProjectEnv={handleStartKernelWithPyproject}
           isUsingProjectEnv={envSource === "uv:pyproject"}
+          justSynced={justSynced}
         />
       )}
       {showIsolationTest && <IsolationTest />}

--- a/apps/notebook/src/components/CondaDependencyHeader.tsx
+++ b/apps/notebook/src/components/CondaDependencyHeader.tsx
@@ -1,5 +1,6 @@
 import {
   AlertCircle,
+  Check,
   Download,
   FileText,
   Info,
@@ -42,6 +43,8 @@ interface CondaDependencyHeaderProps {
   pixiInfo?: PixiInfo | null;
   /** Import pixi.toml deps into notebook conda metadata */
   onImportFromPixi?: () => Promise<void>;
+  /** Show success feedback after sync completed */
+  justSynced?: boolean;
 }
 
 export function CondaDependencyHeader({
@@ -64,6 +67,7 @@ export function CondaDependencyHeader({
   environmentYmlDeps,
   pixiInfo,
   onImportFromPixi,
+  justSynced,
 }: CondaDependencyHeaderProps) {
   const [newDep, setNewDep] = useState("");
   const [newChannel, setNewChannel] = useState("");
@@ -177,6 +181,14 @@ export function CondaDependencyHeader({
                 </button>
               )}
             </div>
+          </div>
+        )}
+
+        {/* Success feedback after sync completed */}
+        {justSynced && (
+          <div className="mb-3 flex items-center gap-2 rounded bg-emerald-500/10 px-2 py-1.5 text-xs text-emerald-700 dark:text-emerald-400">
+            <Check className="h-3.5 w-3.5 shrink-0" />
+            <span>Environment synced — dependencies are ready to use</span>
           </div>
         )}
 

--- a/apps/notebook/src/components/DenoDependencyHeader.tsx
+++ b/apps/notebook/src/components/DenoDependencyHeader.tsx
@@ -1,4 +1,11 @@
-import { ExternalLink, FileText, Info, Package, RefreshCw } from "lucide-react";
+import {
+  Check,
+  ExternalLink,
+  FileText,
+  Info,
+  Package,
+  RefreshCw,
+} from "lucide-react";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Label } from "@/components/ui/label";
 import type { DenoConfigInfo } from "../hooks/useDenoDependencies";
@@ -12,6 +19,8 @@ interface DenoDependencyHeaderProps {
   syncState?: { status: "synced" | "dirty" } | null;
   syncing?: boolean;
   onSyncNow?: () => Promise<boolean>;
+  /** Show success feedback after sync completed */
+  justSynced?: boolean;
 }
 
 export function DenoDependencyHeader({
@@ -22,6 +31,7 @@ export function DenoDependencyHeader({
   syncState,
   syncing,
   onSyncNow,
+  justSynced,
 }: DenoDependencyHeaderProps) {
   return (
     <div className="border-b bg-emerald-50/30 dark:bg-emerald-950/10">
@@ -33,6 +43,14 @@ export function DenoDependencyHeader({
           </span>
           <span className="text-xs text-muted-foreground">Dependencies</span>
         </div>
+
+        {/* Success feedback after sync completed */}
+        {justSynced && (
+          <div className="mb-3 flex items-center gap-2 rounded bg-emerald-500/10 px-2 py-1.5 text-xs text-emerald-700 dark:text-emerald-400">
+            <Check className="h-3.5 w-3.5 shrink-0" />
+            <span>Kernel restarted — configuration applied</span>
+          </div>
+        )}
 
         {/* Config drift notice - kernel restart needed */}
         {syncState?.status === "dirty" && onSyncNow && (

--- a/apps/notebook/src/components/DependencyHeader.tsx
+++ b/apps/notebook/src/components/DependencyHeader.tsx
@@ -1,4 +1,12 @@
-import { Download, FileText, Info, Plus, RefreshCw, X } from "lucide-react";
+import {
+  Check,
+  Download,
+  FileText,
+  Info,
+  Plus,
+  RefreshCw,
+  X,
+} from "lucide-react";
 import { type KeyboardEvent, useCallback, useState } from "react";
 import type {
   EnvSyncState,
@@ -27,6 +35,8 @@ interface DependencyHeaderProps {
   onUseProjectEnv?: () => Promise<void>;
   /** Whether the kernel is currently using the project environment */
   isUsingProjectEnv?: boolean;
+  /** Show success feedback after sync completed */
+  justSynced?: boolean;
 }
 
 export function DependencyHeader({
@@ -45,6 +55,7 @@ export function DependencyHeader({
   onImportFromPyproject,
   onUseProjectEnv,
   isUsingProjectEnv,
+  justSynced,
 }: DependencyHeaderProps) {
   const [newDep, setNewDep] = useState("");
 
@@ -77,6 +88,14 @@ export function DependencyHeader({
             uv
           </span>
         </div>
+
+        {/* Success feedback after sync completed */}
+        {justSynced && (
+          <div className="mb-3 flex items-center gap-2 rounded bg-emerald-500/10 px-2 py-1.5 text-xs text-emerald-700 dark:text-emerald-400">
+            <Check className="h-3.5 w-3.5 shrink-0" />
+            <span>Environment synced — dependencies are ready to use</span>
+          </div>
+        )}
 
         {/* Sync notice */}
         {syncedWhileRunning && (

--- a/apps/notebook/src/hooks/useEnvProgress.ts
+++ b/apps/notebook/src/hooks/useEnvProgress.ts
@@ -218,11 +218,18 @@ export function useEnvProgress() {
       "daemon:broadcast",
       (event) => {
         const broadcast = event.payload;
-        console.log("[useEnvProgress] daemon:broadcast received:", broadcast.event, broadcast);
+        console.log(
+          "[useEnvProgress] daemon:broadcast received:",
+          broadcast.event,
+          broadcast,
+        );
         if (broadcast.event === "env_progress") {
           // The daemon broadcast has the same shape as EnvProgressEvent
           // (env_type + flattened phase fields) plus the "event" tag
-          console.log("[useEnvProgress] Processing env_progress event:", broadcast);
+          console.log(
+            "[useEnvProgress] Processing env_progress event:",
+            broadcast,
+          );
           processEvent(broadcast as unknown as EnvProgressEvent);
         }
       },

--- a/apps/notebook/src/hooks/useEnvProgress.ts
+++ b/apps/notebook/src/hooks/useEnvProgress.ts
@@ -218,18 +218,9 @@ export function useEnvProgress() {
       "daemon:broadcast",
       (event) => {
         const broadcast = event.payload;
-        console.log(
-          "[useEnvProgress] daemon:broadcast received:",
-          broadcast.event,
-          broadcast,
-        );
         if (broadcast.event === "env_progress") {
           // The daemon broadcast has the same shape as EnvProgressEvent
           // (env_type + flattened phase fields) plus the "event" tag
-          console.log(
-            "[useEnvProgress] Processing env_progress event:",
-            broadcast,
-          );
           processEvent(broadcast as unknown as EnvProgressEvent);
         }
       },

--- a/apps/notebook/src/hooks/useEnvProgress.ts
+++ b/apps/notebook/src/hooks/useEnvProgress.ts
@@ -218,9 +218,11 @@ export function useEnvProgress() {
       "daemon:broadcast",
       (event) => {
         const broadcast = event.payload;
+        console.log("[useEnvProgress] daemon:broadcast received:", broadcast.event, broadcast);
         if (broadcast.event === "env_progress") {
           // The daemon broadcast has the same shape as EnvProgressEvent
           // (env_type + flattened phase fields) plus the "event" tag
+          console.log("[useEnvProgress] Processing env_progress event:", broadcast);
           processEvent(broadcast as unknown as EnvProgressEvent);
         }
       },

--- a/crates/runtimed/src/notebook_sync_client.rs
+++ b/crates/runtimed/src/notebook_sync_client.rs
@@ -103,6 +103,10 @@ enum SyncCommand {
     SendRequest {
         request: NotebookRequest,
         reply: oneshot::Sender<Result<NotebookResponse, NotebookSyncError>>,
+        /// Optional broadcast sender for delivering broadcasts during long-running requests.
+        /// If provided, broadcasts received while waiting for the response are sent immediately
+        /// instead of being queued for later delivery.
+        broadcast_tx: Option<mpsc::Sender<NotebookBroadcast>>,
     },
 }
 
@@ -286,6 +290,31 @@ impl NotebookSyncHandle {
             .send(SyncCommand::SendRequest {
                 request,
                 reply: reply_tx,
+                broadcast_tx: None,
+            })
+            .await
+            .map_err(|_| NotebookSyncError::ChannelClosed)?;
+        reply_rx
+            .await
+            .map_err(|_| NotebookSyncError::ChannelClosed)?
+    }
+
+    /// Send a request to the daemon, delivering broadcasts immediately as they arrive.
+    ///
+    /// This is useful for long-running requests (like `LaunchKernel`) where you want
+    /// progress updates delivered in real-time instead of being queued until the
+    /// response is received.
+    pub async fn send_request_with_broadcast(
+        &self,
+        request: NotebookRequest,
+        broadcast_tx: mpsc::Sender<NotebookBroadcast>,
+    ) -> Result<NotebookResponse, NotebookSyncError> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.tx
+            .send(SyncCommand::SendRequest {
+                request,
+                reply: reply_tx,
+                broadcast_tx: Some(broadcast_tx),
             })
             .await
             .map_err(|_| NotebookSyncError::ChannelClosed)?;
@@ -1142,6 +1171,19 @@ where
         &mut self,
         request: &NotebookRequest,
     ) -> Result<NotebookResponse, NotebookSyncError> {
+        self.send_request_with_broadcast(request, None).await
+    }
+
+    /// Send a request to the daemon, optionally delivering broadcasts immediately.
+    ///
+    /// If `broadcast_tx` is provided, broadcasts received while waiting for the response
+    /// are sent immediately instead of being queued. This is useful for long-running
+    /// requests like `LaunchKernel` where progress updates should be delivered in real-time.
+    pub async fn send_request_with_broadcast(
+        &mut self,
+        request: &NotebookRequest,
+        broadcast_tx: Option<&mpsc::Sender<NotebookBroadcast>>,
+    ) -> Result<NotebookResponse, NotebookSyncError> {
         if !self.use_typed_frames {
             return Err(NotebookSyncError::SyncError(
                 "send_request requires v2 protocol".to_string(),
@@ -1156,14 +1198,30 @@ where
             .await?;
 
         // Wait for a Response frame (with timeout)
-        match tokio::time::timeout(Duration::from_secs(30), self.wait_for_response()).await {
+        // Use longer timeout for requests that may create environments
+        let timeout_secs = match request {
+            NotebookRequest::LaunchKernel { .. } => 300, // 5 minutes for env creation
+            _ => 30,
+        };
+        match tokio::time::timeout(
+            Duration::from_secs(timeout_secs),
+            self.wait_for_response_with_broadcast(broadcast_tx),
+        )
+        .await
+        {
             Ok(result) => result,
             Err(_) => Err(NotebookSyncError::Timeout),
         }
     }
 
-    /// Wait for a Response frame, handling other frame types that may arrive first.
-    async fn wait_for_response(&mut self) -> Result<NotebookResponse, NotebookSyncError> {
+    /// Wait for a Response frame, optionally delivering broadcasts immediately.
+    ///
+    /// If `broadcast_tx` is provided, broadcasts are sent immediately instead of
+    /// being queued. This enables real-time progress updates during long-running requests.
+    async fn wait_for_response_with_broadcast(
+        &mut self,
+        broadcast_tx: Option<&mpsc::Sender<NotebookBroadcast>>,
+    ) -> Result<NotebookResponse, NotebookSyncError> {
         loop {
             match connection::recv_typed_frame(&mut self.stream).await? {
                 Some(frame) => match frame.frame_type {
@@ -1185,12 +1243,18 @@ where
                         // Continue waiting for Response
                     }
                     NotebookFrameType::Broadcast => {
-                        // Collect broadcasts received while waiting for response
-                        // They'll be delivered via recv_frame_any() later
+                        // Parse the broadcast
                         if let Ok(broadcast) =
                             serde_json::from_slice::<NotebookBroadcast>(&frame.payload)
                         {
-                            self.pending_broadcasts.push(broadcast);
+                            // If we have a broadcast sender, deliver immediately
+                            // Otherwise queue for later delivery
+                            if let Some(tx) = broadcast_tx {
+                                // Fire and forget - don't block on slow receivers
+                                let _ = tx.try_send(broadcast);
+                            } else {
+                                self.pending_broadcasts.push(broadcast);
+                            }
                         }
                         continue;
                     }
@@ -1466,8 +1530,11 @@ async fn run_sync_task<S>(
                                 let result = client.get_metadata(&key);
                                 let _ = reply.send(result);
                             }
-                            SyncCommand::SendRequest { request, reply } => {
-                                let result = client.send_request(&request).await;
+                            SyncCommand::SendRequest { request, reply, broadcast_tx: override_tx } => {
+                                // Use the override broadcast_tx if provided, otherwise use the task's broadcast_tx
+                                // This allows broadcasts to be delivered immediately during long-running requests
+                                let tx_to_use = override_tx.as_ref().unwrap_or(&broadcast_tx);
+                                let result = client.send_request_with_broadcast(&request, Some(tx_to_use)).await;
                                 let _ = reply.send(result);
                             }
                         }

--- a/crates/runtimed/src/notebook_sync_client.rs
+++ b/crates/runtimed/src/notebook_sync_client.rs
@@ -1250,8 +1250,14 @@ where
                             // If we have a broadcast sender, deliver immediately
                             // Otherwise queue for later delivery
                             if let Some(tx) = broadcast_tx {
-                                // Fire and forget - don't block on slow receivers
-                                let _ = tx.try_send(broadcast);
+                                // Try non-blocking send first for real-time delivery
+                                if let Err(tokio::sync::mpsc::error::TrySendError::Full(b)) =
+                                    tx.try_send(broadcast)
+                                {
+                                    // Channel full - queue for later to avoid dropping
+                                    // Terminal events (ready, error) are especially important
+                                    self.pending_broadcasts.push(b);
+                                }
                             } else {
                                 self.pending_broadcasts.push(broadcast);
                             }


### PR DESCRIPTION
## Summary

When users click "Restart" to apply dependency changes, there was no visual confirmation that it worked - the amber banner just disappeared silently.

- Adds a green success banner: "Environment synced — dependencies are ready to use"  
- Shows for 3 seconds then auto-dismisses
- Works for UV inline deps, Conda inline deps, and Deno config changes

## Screenshots

**Before**: Amber banner shows changes needed, then... nothing after restart
**After**: Amber banner → Green success banner for 3s → Clean state

## Test Plan

1. Create a notebook with conda inline deps
2. Add a new package while kernel is running
3. Click "Restart" button
4. **Expected**: Green success banner appears for 3 seconds
5. Verify same behavior works for UV and Deno

## Note on Rattler Progress

The rattler progress bars already exist and work correctly during *fresh* conda env creation. When an env is **cached** (common after first use), it shows `cache_hit` immediately and there's no progress to display - just instant kernel start. The success banner helps provide feedback in this case.