### PR TITLE
feat(workspace): dev-mode notebooks directory and runt-workspace crate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ target/
 .ipynb_checkpoints
 Untitled*.ipynb
 
+# Dev mode notebooks directory
+notebooks/
+
 # Local sqlite db files
 *.db
 *.db-wal

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3371,6 +3371,7 @@ dependencies = [
  "reqwest 0.12.28",
  "reqwest-middleware",
  "runt-trust",
+ "runt-workspace",
  "runtimed",
  "runtimelib",
  "schemars 1.2.1",
@@ -5371,6 +5372,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "runt-workspace"
+version = "0.1.0"
+dependencies = [
+ "dirs 5.0.1",
+ "hex",
+ "sha2 0.10.9",
+]
+
+[[package]]
 name = "runtimed"
 version = "0.1.0-dev.10"
 dependencies = [
@@ -5407,6 +5417,7 @@ dependencies = [
  "reqwest 0.12.28",
  "reqwest-middleware",
  "runt-trust",
+ "runt-workspace",
  "runtimelib",
  "schemars 1.2.1",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "crates/sidecar",
     "crates/runt",
     "crates/runt-trust",
+    "crates/runt-workspace",
     "crates/kernel-launch",
     "crates/kernel-env",
     "crates/notebook",

--- a/crates/notebook/Cargo.toml
+++ b/crates/notebook/Cargo.toml
@@ -37,6 +37,7 @@ runtimelib = { workspace = true, features = ["tokio-runtime", "ring"] }
 tauri-jupyter = { path = "../tauri-jupyter" }
 runtimed = { path = "../runtimed" }
 runt-trust = { path = "../runt-trust" }
+runt-workspace = { path = "../runt-workspace" }
 kernel-launch = { path = "../kernel-launch" }
 kernel-env = { path = "../kernel-env" }
 nbformat = "1.2.0"

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -2989,25 +2989,12 @@ fn spawn_new_notebook(
     create_notebook_window(app, registry, state).map(|_| ())
 }
 
-/// Ensure ~/notebooks directory exists and return its path.
+/// Ensure notebooks directory exists and return its path.
+///
+/// In dev mode with a workspace path, uses {workspace}/notebooks.
+/// Otherwise uses ~/notebooks.
 fn ensure_notebooks_directory() -> Result<PathBuf, String> {
-    let home = dirs::home_dir().ok_or("Could not determine home directory")?;
-    let notebooks_dir = home.join("notebooks");
-    match std::fs::create_dir(&notebooks_dir) {
-        Ok(()) => Ok(notebooks_dir),
-        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
-            // Only return the path if it's actually a directory
-            if notebooks_dir.is_dir() {
-                Ok(notebooks_dir)
-            } else {
-                Err(format!(
-                    "~/notebooks exists but is not a directory: {}",
-                    notebooks_dir.display()
-                ))
-            }
-        }
-        Err(e) => Err(format!("Failed to create ~/notebooks directory: {}", e)),
-    }
+    runt_workspace::default_notebooks_dir()
 }
 
 /// Get the default directory for saving new notebooks.

--- a/crates/runt-workspace/Cargo.toml
+++ b/crates/runt-workspace/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "runt-workspace"
+version = "0.1.0"
+edition = "2021"
+description = "Workspace and dev mode utilities for Runt"
+
+[dependencies]
+dirs = "5"
+hex = "0.4"
+sha2 = "0.10"

--- a/crates/runt-workspace/src/lib.rs
+++ b/crates/runt-workspace/src/lib.rs
@@ -1,0 +1,172 @@
+//! Workspace and dev mode utilities for Runt.
+//!
+//! This crate provides utilities for detecting development mode and managing
+//! workspace-specific paths, enabling per-worktree isolation during development.
+
+use sha2::{Digest, Sha256};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+// ============================================================================
+// Development Mode Detection
+// ============================================================================
+
+/// Check if development mode is enabled.
+///
+/// Dev mode enables per-worktree daemon isolation, allowing each git worktree
+/// to run its own daemon instance with separate state directories.
+///
+/// Returns true if:
+/// - `RUNTIMED_DEV=1` is set (explicit opt-in), OR
+/// - `CONDUCTOR_WORKSPACE_PATH` is set (automatic for Conductor users)
+pub fn is_dev_mode() -> bool {
+    // Explicit opt-in
+    if std::env::var("RUNTIMED_DEV")
+        .map(|v| v == "1")
+        .unwrap_or(false)
+    {
+        return true;
+    }
+    // Auto-detect Conductor workspace
+    std::env::var("CONDUCTOR_WORKSPACE_PATH").is_ok()
+}
+
+/// Get the workspace path for dev mode.
+///
+/// Uses `CONDUCTOR_WORKSPACE_PATH` if available, otherwise detects via git.
+pub fn get_workspace_path() -> Option<PathBuf> {
+    // Prefer Conductor's workspace path
+    if let Ok(path) = std::env::var("CONDUCTOR_WORKSPACE_PATH") {
+        return Some(PathBuf::from(path));
+    }
+    // Fallback to git detection
+    detect_worktree_root()
+}
+
+/// Get the workspace name for display.
+///
+/// Uses `CONDUCTOR_WORKSPACE_NAME` if available, otherwise reads from
+/// `.context/workspace-description` file in the worktree.
+pub fn get_workspace_name() -> Option<String> {
+    // Prefer Conductor's workspace name
+    if let Ok(name) = std::env::var("CONDUCTOR_WORKSPACE_NAME") {
+        return Some(name);
+    }
+    // Fallback: read .context/workspace-description
+    get_workspace_path()
+        .and_then(|p| std::fs::read_to_string(p.join(".context/workspace-description")).ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+/// Detect the current git worktree root.
+///
+/// Runs `git rev-parse --show-toplevel` to find the root directory.
+fn detect_worktree_root() -> Option<PathBuf> {
+    Command::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| PathBuf::from(s.trim()))
+        .filter(|p| p.exists())
+}
+
+/// Compute a short hash of a worktree path for directory naming.
+///
+/// Returns the first 12 hex characters of the SHA-256 hash.
+pub fn worktree_hash(path: &Path) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(path.to_string_lossy().as_bytes());
+    hex::encode(&hasher.finalize()[..6]) // 6 bytes = 12 hex chars
+}
+
+// ============================================================================
+// Directory Paths
+// ============================================================================
+
+/// Get the base directory for the current daemon context.
+///
+/// In dev mode: `~/.cache/runt/worktrees/{hash}/`
+/// Otherwise: `~/.cache/runt/`
+pub fn daemon_base_dir() -> PathBuf {
+    let base = dirs::cache_dir()
+        .unwrap_or_else(|| PathBuf::from("/tmp"))
+        .join("runt");
+
+    if is_dev_mode() {
+        if let Some(worktree) = get_workspace_path() {
+            let hash = worktree_hash(&worktree);
+            return base.join("worktrees").join(hash);
+        }
+    }
+    base
+}
+
+/// Get the default directory for saving notebooks.
+///
+/// In dev mode with a workspace path: `{workspace}/notebooks/`
+/// Otherwise: `~/notebooks/`
+///
+/// Creates the directory if it doesn't exist.
+pub fn default_notebooks_dir() -> Result<PathBuf, String> {
+    let notebooks_dir = if is_dev_mode() {
+        if let Some(workspace) = get_workspace_path() {
+            workspace.join("notebooks")
+        } else {
+            home_notebooks_dir()?
+        }
+    } else {
+        home_notebooks_dir()?
+    };
+
+    ensure_dir_exists(&notebooks_dir)?;
+    Ok(notebooks_dir)
+}
+
+/// Get the ~/notebooks directory path.
+fn home_notebooks_dir() -> Result<PathBuf, String> {
+    let home = dirs::home_dir().ok_or("Could not determine home directory")?;
+    Ok(home.join("notebooks"))
+}
+
+/// Ensure a directory exists, creating it if necessary.
+fn ensure_dir_exists(dir: &Path) -> Result<(), String> {
+    match std::fs::create_dir(dir) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+            if dir.is_dir() {
+                Ok(())
+            } else {
+                Err(format!("{} exists but is not a directory", dir.display()))
+            }
+        }
+        Err(e) => Err(format!(
+            "Failed to create directory {}: {}",
+            dir.display(),
+            e
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_worktree_hash_consistency() {
+        let path = Path::new("/some/path");
+        let hash1 = worktree_hash(path);
+        let hash2 = worktree_hash(path);
+        assert_eq!(hash1, hash2);
+        assert_eq!(hash1.len(), 12);
+    }
+
+    #[test]
+    fn test_worktree_hash_differs() {
+        let path1 = Path::new("/path/one");
+        let path2 = Path::new("/path/two");
+        assert_ne!(worktree_hash(path1), worktree_hash(path2));
+    }
+}

--- a/crates/runtimed/Cargo.toml
+++ b/crates/runtimed/Cargo.toml
@@ -68,6 +68,9 @@ automerge = "0.7"
 # Trust verification (shared with notebook crate)
 runt-trust = { path = "../runt-trust" }
 
+# Workspace and dev mode utilities
+runt-workspace = { path = "../runt-workspace" }
+
 # Shared kernel launching and tool bootstrapping
 kernel-launch = { path = "../kernel-launch" }
 

--- a/crates/runtimed/src/kernel_manager.rs
+++ b/crates/runtimed/src/kernel_manager.rs
@@ -527,25 +527,10 @@ impl RoomKernel {
                 .map(|p| p.to_path_buf())
                 .unwrap_or_else(std::env::temp_dir)
         } else {
-            // For untitled notebooks, use ~/notebooks to avoid macOS permission prompts
+            // For untitled notebooks, use default notebooks directory to avoid macOS permission prompts
             // (using $HOME triggers "allow access to Music/Documents/etc" popups)
-            if let Some(home) = dirs::home_dir() {
-                let notebooks_dir = home.join("notebooks");
-                // Create if needed (app setup should have done this, but be defensive)
-                match std::fs::create_dir(&notebooks_dir) {
-                    Ok(()) => notebooks_dir,
-                    Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
-                        if notebooks_dir.is_dir() {
-                            notebooks_dir
-                        } else {
-                            std::env::temp_dir()
-                        }
-                    }
-                    Err(_) => std::env::temp_dir(),
-                }
-            } else {
-                std::env::temp_dir()
-            }
+            // In dev mode, this will be {workspace}/notebooks instead of ~/notebooks
+            runt_workspace::default_notebooks_dir().unwrap_or_else(|_| std::env::temp_dir())
         };
 
         // Build kernel command based on kernel type

--- a/crates/runtimed/src/lib.rs
+++ b/crates/runtimed/src/lib.rs
@@ -8,10 +8,8 @@
 //! using length-prefixed binary framing with a channel-based handshake.
 
 use std::path::PathBuf;
-use std::process::Command;
 
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
 
 pub mod blob_server;
 pub mod blob_store;
@@ -41,94 +39,10 @@ pub mod terminal_size;
 // Development Mode and Worktree Isolation
 // ============================================================================
 
-/// Check if development mode is enabled.
-///
-/// Dev mode enables per-worktree daemon isolation, allowing each git worktree
-/// to run its own daemon instance with separate state directories.
-///
-/// Returns true if:
-/// - `RUNTIMED_DEV=1` is set (explicit opt-in), OR
-/// - `CONDUCTOR_WORKSPACE_PATH` is set (automatic for Conductor users)
-pub fn is_dev_mode() -> bool {
-    // Explicit opt-in
-    if std::env::var("RUNTIMED_DEV")
-        .map(|v| v == "1")
-        .unwrap_or(false)
-    {
-        return true;
-    }
-    // Auto-detect Conductor workspace
-    std::env::var("CONDUCTOR_WORKSPACE_PATH").is_ok()
-}
-
-/// Get the workspace path for dev mode.
-///
-/// Uses `CONDUCTOR_WORKSPACE_PATH` if available, otherwise detects via git.
-pub fn get_workspace_path() -> Option<PathBuf> {
-    // Prefer Conductor's workspace path
-    if let Ok(path) = std::env::var("CONDUCTOR_WORKSPACE_PATH") {
-        return Some(PathBuf::from(path));
-    }
-    // Fallback to git detection
-    detect_worktree_root()
-}
-
-/// Get the workspace name for display.
-///
-/// Uses `CONDUCTOR_WORKSPACE_NAME` if available, otherwise reads from
-/// `.context/workspace-description` file in the worktree.
-pub fn get_workspace_name() -> Option<String> {
-    // Prefer Conductor's workspace name
-    if let Ok(name) = std::env::var("CONDUCTOR_WORKSPACE_NAME") {
-        return Some(name);
-    }
-    // Fallback: read .context/workspace-description
-    get_workspace_path()
-        .and_then(|p| std::fs::read_to_string(p.join(".context/workspace-description")).ok())
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
-}
-
-/// Detect the current git worktree root.
-///
-/// Runs `git rev-parse --show-toplevel` to find the root directory.
-fn detect_worktree_root() -> Option<PathBuf> {
-    Command::new("git")
-        .args(["rev-parse", "--show-toplevel"])
-        .output()
-        .ok()
-        .filter(|o| o.status.success())
-        .and_then(|o| String::from_utf8(o.stdout).ok())
-        .map(|s| PathBuf::from(s.trim()))
-        .filter(|p| p.exists())
-}
-
-/// Compute a short hash of a worktree path for directory naming.
-///
-/// Returns the first 12 hex characters of the SHA-256 hash.
-pub fn worktree_hash(path: &std::path::Path) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(path.to_string_lossy().as_bytes());
-    hex::encode(&hasher.finalize()[..6]) // 6 bytes = 12 hex chars
-}
-
-/// Get the base directory for the current daemon context.
-///
-/// In dev mode: `~/.cache/runt/worktrees/{hash}/`
-/// Otherwise: `~/.cache/runt/`
-pub fn daemon_base_dir() -> PathBuf {
-    let base = dirs::cache_dir()
-        .unwrap_or_else(|| PathBuf::from("/tmp"))
-        .join("runt");
-
-    if is_dev_mode() {
-        if let Some(worktree) = get_workspace_path() {
-            let hash = worktree_hash(&worktree);
-            return base.join("worktrees").join(hash);
-        }
-    }
-    base
-}
+// Re-export from runt-workspace for backwards compatibility
+pub use runt_workspace::{
+    daemon_base_dir, get_workspace_name, get_workspace_path, is_dev_mode, worktree_hash,
+};
 
 /// Get the default log path for the daemon.
 pub fn default_log_path() -> PathBuf {


### PR DESCRIPTION
Create a new `runt-workspace` crate to centralize workspace and dev mode utilities, improving the dependency graph by removing the need for other crates to depend on runtimed just for workspace utilities.

Add `default_notebooks_dir()` function that returns `{workspace}/notebooks/` in dev mode (via `CONDUCTOR_WORKSPACE_PATH` or git detection) and `~/notebooks/` otherwise. Update notebook save dialogs and kernel working directory logic to use this function, so test notebooks stay organized within the workspace during development.

Update `runtimed` to re-export workspace functions for backwards compatibility, and add `notebooks/` to `.gitignore` so dev notebooks aren't accidentally committed.

## Verification
- Run `cargo xtask dev-daemon` in one terminal and `cargo xtask dev` in another
- Create and save a new notebook to verify the save dialog defaults to `{workspace}/notebooks/`
- Confirm the saved notebook appears in the workspace's `notebooks/` folder
- Run `git status` to verify the `notebooks/` folder is gitignored

_PR submitted by @rgbkrk's agent, Quill_