### PR TITLE
fix(ci): mark weekly preview releases as prerelease

### DIFF
--- a/.github/workflows/weekly-preview.yml
+++ b/.github/workflows/weekly-preview.yml
@@ -787,7 +787,7 @@ jobs:
             pip install runtimed --pre
             ```
           draft: false
-          prerelease: false
+          prerelease: true
           files: |
             ./release-assets/runt-linux-x64
             ./release-assets/runt-darwin-arm64
@@ -805,12 +805,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Ensure the rolling preview-latest release exists as a normal release, then update latest.json
+          # Ensure the rolling preview-latest release exists as a pre-release, then update latest.json
           gh release create preview-latest \
             --title "Preview Update Channel" \
             --notes "Rolling release for the preview auto-update channel. This release always contains the latest updater manifest. Do not delete this release." \
+            --prerelease \
             --latest=false 2>/dev/null || true
 
-          gh release edit preview-latest --prerelease=false --latest=false >/dev/null 2>&1 || true
+          gh release edit preview-latest --prerelease=true --latest=false >/dev/null 2>&1 || true
 
           gh release upload preview-latest release-assets/latest.json --clobber


### PR DESCRIPTION
Mark weekly preview GitHub releases as pre-releases to reflect their development status.

---
<p><a href="https://cursor.com/agents/bc-75600152-5ac7-4773-ad1d-dde4b50756d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-75600152-5ac7-4773-ad1d-dde4b50756d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

