### PR TITLE
fix(workspace): graceful fallback for notebooks dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,8 +11,8 @@ target/
 .ipynb_checkpoints
 Untitled*.ipynb
 
-# Dev mode notebooks directory
-notebooks/
+# Dev mode notebooks directory (repo root only)
+/notebooks/
 
 # Local sqlite db files
 *.db

--- a/crates/runt-workspace/src/lib.rs
+++ b/crates/runt-workspace/src/lib.rs
@@ -106,23 +106,31 @@ pub fn daemon_base_dir() -> PathBuf {
 
 /// Get the default directory for saving notebooks.
 ///
-/// In dev mode with a workspace path: `{workspace}/notebooks/`
+/// In dev mode with a workspace path: tries `{workspace}/notebooks/` first,
+/// falling back to `~/notebooks/` if the workspace dir can't be created.
 /// Otherwise: `~/notebooks/`
 ///
 /// Creates the directory if it doesn't exist.
 pub fn default_notebooks_dir() -> Result<PathBuf, String> {
-    let notebooks_dir = if is_dev_mode() {
+    // In dev mode, try workspace notebooks first with fallback to home
+    if is_dev_mode() {
         if let Some(workspace) = get_workspace_path() {
-            workspace.join("notebooks")
-        } else {
-            home_notebooks_dir()?
+            let workspace_notebooks = workspace.join("notebooks");
+            if ensure_dir_exists(&workspace_notebooks).is_ok() {
+                return Ok(workspace_notebooks);
+            }
+            // Workspace dir failed (stale path, permissions, etc.) - fall back to ~/notebooks
+            eprintln!(
+                "Warning: Could not create {}, falling back to ~/notebooks",
+                workspace_notebooks.display()
+            );
         }
-    } else {
-        home_notebooks_dir()?
-    };
+    }
 
-    ensure_dir_exists(&notebooks_dir)?;
-    Ok(notebooks_dir)
+    // Default to ~/notebooks
+    let home_notebooks = home_notebooks_dir()?;
+    ensure_dir_exists(&home_notebooks)?;
+    Ok(home_notebooks)
 }
 
 /// Get the ~/notebooks directory path.


### PR DESCRIPTION
Address review feedback from Codex on #434:

**Issue 1 (Medium)**: If `CONDUCTOR_WORKSPACE_PATH` is stale/unwritable, app startup would abort instead of degrading gracefully.

**Fix**: `default_notebooks_dir()` now tries the workspace notebooks directory first, and if creation fails (stale path, permissions, etc.), it logs a warning and falls back to `~/notebooks`.

**Issue 2 (Low)**: The gitignore pattern `notebooks/` was unanchored and would ignore any directory named `notebooks` anywhere in the repo.

**Fix**: Changed to `/notebooks/` to scope the ignore to the repo root only.

## Verification
- [ ] With a valid workspace path, notebooks save to `{workspace}/notebooks/`
- [ ] With an invalid/unwritable workspace path, notebooks fall back to `~/notebooks/` with a warning
- [ ] Nested directories named `notebooks/` elsewhere in the repo are not ignored

_PR submitted by @rgbkrk's agent, Quill_