### PR TITLE
fix(ci): improve release social preview and version sorting

### DIFF
--- a/.github/workflows/releases/nightly.yml
+++ b/.github/workflows/releases/nightly.yml
@@ -18,7 +18,6 @@ jobs:
       release_title: "Nightly Release"
       version_suffix: "nightly"
       manifest_notes_prefix: "Nightly release"
-      release_heading: "Nightly Release"
       release_intro: "Automated nightly release from `main`."
       github_release_prerelease: true
       updater_channel_tag: "nightly-latest"

--- a/.github/workflows/releases/release-common.yml
+++ b/.github/workflows/releases/release-common.yml
@@ -15,10 +15,6 @@ on:
         description: Prefix for latest.json notes field
         required: true
         type: string
-      release_heading:
-        description: Markdown heading for the GitHub release body
-        required: true
-        type: string
       release_intro:
         description: Intro sentence in the GitHub release body
         required: true
@@ -52,11 +48,28 @@ env:
   TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
 
 jobs:
+  compute-version:
+    name: Compute Version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.VERSION }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Compute version
+        id: version
+        run: |
+          CURRENT_VERSION=$(grep '^version' crates/runt/Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+          TIMESTAMP=$(date -u +%Y%m%d%H%M)
+          VERSION="${CURRENT_VERSION}-${{ inputs.version_suffix }}.${TIMESTAMP}"
+          echo "Setting version to: ${VERSION}"
+          echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
+
   build-linux:
     name: Build Linux Executables
     runs-on: ubuntu-22.04
-    outputs:
-      version: ${{ steps.version.outputs.VERSION }}
+    needs: compute-version
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -101,16 +114,10 @@ jobs:
       - name: Build sidecar UI
         run: pnpm build
 
-      - name: Set version
-        id: version
+      - name: Set version in Cargo.toml
         run: |
-          CURRENT_VERSION=$(grep '^version' crates/runt/Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
-          COMMIT_SHA=${GITHUB_SHA::7}
-          VERSION="${CURRENT_VERSION}-${{ inputs.version_suffix }}.${COMMIT_SHA}"
+          VERSION="${{ needs.compute-version.outputs.version }}"
           echo "Setting version to: ${VERSION}"
-          echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
-
-          # Update version in Cargo.toml
           sed -i "s/^version = .*/version = \"${VERSION}\"/" crates/runt/Cargo.toml
 
       - name: Build for Linux x64
@@ -131,8 +138,7 @@ jobs:
   build-macos:
     name: Build macOS ARM64 Executables
     runs-on: macos-latest
-    outputs:
-      version: ${{ steps.version.outputs.VERSION }}
+    needs: compute-version
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -175,13 +181,9 @@ jobs:
         run: pnpm build
 
       - name: Set version in Cargo.toml
-        id: version
         run: |
-          CURRENT_VERSION=$(grep '^version' crates/runt/Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
-          COMMIT_SHA=${GITHUB_SHA::7}
-          VERSION="${CURRENT_VERSION}-${{ inputs.version_suffix }}.${COMMIT_SHA}"
+          VERSION="${{ needs.compute-version.outputs.version }}"
           echo "Setting version to: ${VERSION}"
-          echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
           sed -i '' "s/^version = .*/version = \"${VERSION}\"/" crates/runt/Cargo.toml
 
       - name: Build for macOS ARM64
@@ -202,6 +204,7 @@ jobs:
   build-notebook-macos-arm64:
     name: Build macOS ARM64 Notebook
     runs-on: macos-latest
+    needs: compute-version
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -284,9 +287,7 @@ jobs:
 
       - name: Set version in tauri.conf.json
         run: |
-          CURRENT_VERSION=$(grep '^version' crates/runt/Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
-          COMMIT_SHA=${GITHUB_SHA::7}
-          VERSION="${CURRENT_VERSION}-${{ inputs.version_suffix }}.${COMMIT_SHA}"
+          VERSION="${{ needs.compute-version.outputs.version }}"
           echo "Setting version to: ${VERSION}"
           sed -i '' "s/\"version\": \"[^\"]*\"/\"version\": \"${VERSION}\"/" crates/notebook/tauri.conf.json
           sed -i '' "s#https://github.com/nteract/desktop/releases/download/preview-latest/latest.json#https://github.com/nteract/desktop/releases/download/${{ inputs.updater_channel_tag }}/latest.json#" crates/notebook/tauri.conf.json
@@ -361,6 +362,7 @@ jobs:
   build-notebook-windows-x64:
     name: Build Windows x64 Notebook
     runs-on: windows-latest
+    needs: compute-version
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -414,12 +416,7 @@ jobs:
       - name: Set version in tauri.conf.json
         shell: pwsh
         run: |
-          $content = Get-Content crates/runt/Cargo.toml -Raw
-          if ($content -match 'version = "([^"]+)"') {
-            $currentVersion = $matches[1]
-          }
-          $commitSha = "$env:GITHUB_SHA".Substring(0, 7)
-          $version = "$currentVersion-${{ inputs.version_suffix }}.$commitSha"
+          $version = "${{ needs.compute-version.outputs.version }}"
           Write-Host "Setting version to: $version"
           $tauriConf = Get-Content crates/notebook/tauri.conf.json -Raw
           $tauriConf = $tauriConf -replace '"version": "[^"]+"', "`"version`": `"$version`""
@@ -480,6 +477,7 @@ jobs:
   build-notebook-linux-x64:
     name: Build Linux x64 Notebook
     runs-on: ubuntu-22.04
+    needs: compute-version
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -540,9 +538,7 @@ jobs:
 
       - name: Set version in tauri.conf.json
         run: |
-          CURRENT_VERSION=$(grep '^version' crates/runt/Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
-          COMMIT_SHA=${GITHUB_SHA::7}
-          VERSION="${CURRENT_VERSION}-${{ inputs.version_suffix }}.${COMMIT_SHA}"
+          VERSION="${{ needs.compute-version.outputs.version }}"
           echo "Setting version to: ${VERSION}"
           sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"${VERSION}\"/" crates/notebook/tauri.conf.json
           sed -i "s#https://github.com/nteract/desktop/releases/download/preview-latest/latest.json#https://github.com/nteract/desktop/releases/download/${{ inputs.updater_channel_tag }}/latest.json#" crates/notebook/tauri.conf.json
@@ -656,6 +652,7 @@ jobs:
       id-token: write
     needs:
       [
+        compute-version,
         build-linux,
         build-macos,
         build-notebook-macos-arm64,
@@ -717,8 +714,8 @@ jobs:
 
       - name: Generate updater manifest (latest.json)
         env:
-          VERSION: ${{ needs.build-linux.outputs.version }}
-          TAG_NAME: v${{ needs.build-linux.outputs.version }}
+          VERSION: ${{ needs.compute-version.outputs.version }}
+          TAG_NAME: v${{ needs.compute-version.outputs.version }}
           REPO: ${{ github.repository }}
         run: |
           RELEASE_BASE="https://github.com/${REPO}/releases/download/${TAG_NAME}"
@@ -794,14 +791,16 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: v${{ needs.build-linux.outputs.version }}
-          name: nteract v${{ needs.build-linux.outputs.version }}
+          tag_name: v${{ needs.compute-version.outputs.version }}
+          name: nteract v${{ needs.compute-version.outputs.version }}
           body: |
-            ## ${{ inputs.release_heading }}
+            ${{ inputs.release_intro }}
 
-            ${{ inputs.release_intro }} **Commit:** ${{ github.sha }}
+            ---
 
-            ### nteract (desktop app)
+            **Commit:** `${{ github.sha }}`
+
+            ## nteract (desktop app)
 
             | Platform | Architecture | Download |
             |----------|--------------|----------|
@@ -813,7 +812,7 @@ jobs:
 
             This release includes auto-update support. Existing installations will be notified of this update automatically.
 
-            ### runt (CLI)
+            ## runt (CLI)
 
             Also bundled inside the desktop app. Standalone binaries:
 
@@ -822,7 +821,7 @@ jobs:
             | Linux | x64 | `runt-linux-x64` |
             | macOS | ARM64 | `runt-darwin-arm64` |
 
-            ### runtimed (Python — macOS, Linux, Windows)
+            ## runtimed (Python — macOS, Linux, Windows)
 
             ```bash
             pip install runtimed --pre

--- a/.github/workflows/releases/weekly.yml
+++ b/.github/workflows/releases/weekly.yml
@@ -18,8 +18,7 @@ jobs:
       release_title: "Preview Release"
       version_suffix: "preview"
       manifest_notes_prefix: "Preview release"
-      release_heading: "Weekly Preview Release"
-      release_intro: "Automated preview from `main`."
+      release_intro: "It's runtime funtime! Grab the latest nteract preview for macOS, Windows, or Linux. Signed, notarized, and ready to run your notebooks."
       github_release_prerelease: false
       updater_channel_tag: "preview-latest"
       updater_channel_title: "Preview Update Channel"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3338,7 +3338,7 @@ dependencies = [
 
 [[package]]
 name = "notebook"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -5335,7 +5335,7 @@ dependencies = [
 
 [[package]]
 name = "runt-cli"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6113,7 +6113,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "sidecar"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/notebook/Cargo.toml
+++ b/crates/notebook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notebook"
-version = "1.4.0"
+version = "1.4.1"
 edition = "2021"
 description = "Tauri-based notebook UI for Jupyter kernels"
 repository = "https://github.com/nteract/desktop"

--- a/crates/notebook/tauri.conf.json
+++ b/crates/notebook/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "nteract",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "identifier": "org.nteract.desktop",
   "build": {
     "devUrl": "http://localhost:5174",

--- a/crates/runt/Cargo.toml
+++ b/crates/runt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runt-cli"
-version = "1.4.0"
+version = "1.4.1"
 edition.workspace = true
 description = "CLI for Jupyter Runtimes — install via GitHub Releases or `pip install runtimed`, not crates.io"
 repository.workspace = true

--- a/crates/sidecar/Cargo.toml
+++ b/crates/sidecar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sidecar"
-version = "1.4.0"
+version = "1.4.1"
 edition.workspace = true
 description = "Sidecar jupyter outputs — install via GitHub Releases or `pip install runtimed`, not crates.io"
 repository.workspace = true


### PR DESCRIPTION
Improves weekly preview releases in two ways:

1. **Social preview**: Lead release body with a friendly intro ("It's runtime funtime!") so GitHub's Open Graph metadata shows that instead of table gibberish.
2. **Version sorting**: Switch from commit hashes to YYYYMMDDHHmm UTC timestamps (e.g., `1.4.1-preview.202603011453`) so Tauri's semver updater properly compares and sorts releases.

Also bumps base version to 1.4.1 because semver treats numeric prerelease identifiers (timestamps) as lower precedence than alphanumeric ones (hashes), so this ensures proper upgrade paths.

**Verification**:
- [ ] Trigger GitHub Actions → Weekly Preview Release → Run workflow
- [ ] Check the generated release and verify social preview shows the intro text, not tables
- [ ] Confirm version has the timestamp format (YYYYMMDDHHmm)

_PR submitted by @rgbkrk's agent, Quill_