### PR TITLE
docs: fix branding to use nteract Desktop instead of Runt

### DIFF
--- a/docs/environments.md
+++ b/docs/environments.md
@@ -1,14 +1,14 @@
 # Environments
 
-Runt automatically manages Python and Deno environments for your notebooks. You don't need to manually create virtual environments or install packages — Runt handles it based on what's in your notebook and what project files are nearby.
+nteract Desktop automatically manages Python and Deno environments for your notebooks. You don't need to manually create virtual environments or install packages — the app handles it based on what's in your notebook and what project files are nearby.
 
 ## How It Works
 
-When you open a notebook, Runt uses a two-stage detection:
+When you open a notebook, nteract Desktop uses a two-stage detection:
 
 ### Stage 1: Which runtime? (Python or Deno)
 
-Runt checks the notebook's stored kernel type:
+nteract Desktop checks the notebook's stored kernel type:
 - If the notebook says it's a **Deno notebook** → Deno kernel
 - If the notebook says it's a **Python notebook** → Python kernel (then proceeds to Stage 2)
 - New notebooks use your **default runtime** preference
@@ -17,10 +17,10 @@ This means Python and Deno notebooks can coexist in the same project directory �
 
 ### Stage 2: Which Python environment?
 
-For Python notebooks, Runt looks for dependencies in this order:
+For Python notebooks, nteract Desktop looks for dependencies in this order:
 
 1. **Inline dependencies** stored in the notebook itself
-2. **Closest project file** — Runt walks up from the notebook's directory looking for `pyproject.toml`, `pixi.toml`, or `environment.yml`. The closest match wins, regardless of file type. If the same directory has multiple project files, the tiebreaker is: pyproject.toml > pixi.toml > environment.yml
+2. **Closest project file** — nteract Desktop walks up from the notebook's directory looking for `pyproject.toml`, `pixi.toml`, or `environment.yml`. The closest match wins, regardless of file type. If the same directory has multiple project files, the tiebreaker is: pyproject.toml > pixi.toml > environment.yml
 3. If none found, a **prewarmed environment** with just the basics
 
 The search stops at git repository boundaries and your home directory, so project files from unrelated repos won't interfere.
@@ -37,7 +37,7 @@ The simplest way to manage packages. Dependencies are stored directly in the not
 
 ## Working with pyproject.toml
 
-If your notebook is in a directory with a `pyproject.toml`, Runt auto-detects it and uses `uv run` to start the kernel in the project's virtual environment.
+If your notebook is in a directory with a `pyproject.toml`, nteract Desktop auto-detects it and uses `uv run` to start the kernel in the project's virtual environment.
 
 - The project's `.venv/` is used directly — no separate cached environment
 - Dependencies stay in sync with the project
@@ -49,13 +49,13 @@ The dependency panel offers two actions:
 
 ## Working with environment.yml
 
-Conda `environment.yml` files are auto-detected. Runt parses the channels, conda dependencies, and pip dependencies from the file and creates a conda environment using rattler.
+Conda `environment.yml` files are auto-detected. nteract Desktop parses the channels, conda dependencies, and pip dependencies from the file and creates a conda environment using rattler.
 
 The dependency panel shows the environment.yml dependencies and offers an "Import to notebook" action to copy them into the notebook's conda metadata for portability.
 
 ## Working with pixi.toml
 
-Pixi project files are auto-detected. Runt converts pixi dependencies to conda format and creates the environment using rattler. Both `[dependencies]` (conda packages) and `[pypi-dependencies]` (pip packages) are supported.
+Pixi project files are auto-detected. nteract Desktop converts pixi dependencies to conda format and creates the environment using rattler. Both `[dependencies]` (conda packages) and `[pypi-dependencies]` (pip packages) are supported.
 
 The dependency panel shows pixi dependencies and offers an "Import to notebook" action.
 
@@ -64,8 +64,8 @@ The dependency panel shows pixi dependencies and offers an "Import to notebook" 
 Deno notebooks use the Deno runtime for TypeScript/JavaScript. Unlike Python, Deno manages its own dependencies through import maps and URL imports, so there's no separate environment to create.
 
 **How Deno is obtained:**
-- Runt first checks if `deno` is on your PATH
-- If not found, Runt automatically installs Deno from conda-forge (stored in `~/.cache/runt/tools/`)
+- nteract Desktop first checks if `deno` is on your PATH
+- If not found, nteract Desktop automatically installs Deno from conda-forge (stored in `~/.cache/runt/tools/`)
 
 This means Deno notebooks work out of the box — you don't need to install Deno manually.
 
@@ -85,23 +85,23 @@ Choose which package manager to use for Python notebooks:
 - **UV** (default) — fast, pip-compatible package management
 - **Conda** — supports conda packages (useful for non-Python dependencies like CUDA libraries)
 
-This preference is used when no project files are detected and the notebook has no inline dependencies. When a project file is present, Runt picks the appropriate backend automatically (UV for pyproject.toml, Conda for environment.yml and pixi.toml).
+This preference is used when no project files are detected and the notebook has no inline dependencies. When a project file is present, nteract Desktop picks the appropriate backend automatically (UV for pyproject.toml, Conda for environment.yml and pixi.toml).
 
 See [Settings](settings.md) for how to change these defaults.
 
 ## Trust Dialog
 
-When you open a notebook with dependencies for the first time, Runt may show a trust dialog asking you to approve the dependency installation. This happens because:
+When you open a notebook with dependencies for the first time, nteract Desktop may show a trust dialog asking you to approve the dependency installation. This happens because:
 
 - Dependencies are signed with a per-machine key
 - Notebooks from other machines (shared by a colleague, cloned from a repo) have a different signature
-- Runt asks you to verify the dependencies before installing anything
+- nteract Desktop asks you to verify the dependencies before installing anything
 
 After you approve, the notebook is re-signed with your machine's key and won't prompt again.
 
 ## Cache and Cleanup
 
-Runt caches environments so notebooks with the same dependencies share a single environment, making subsequent opens instant.
+nteract Desktop caches environments so notebooks with the same dependencies share a single environment, making subsequent opens instant.
 
 | What | Location |
 |------|----------|
@@ -110,7 +110,7 @@ Runt caches environments so notebooks with the same dependencies share a single 
 | Tools (uv, deno) | `~/.cache/runt/tools/` |
 | Trust key | `~/.config/runt/trust-key` |
 
-To reclaim disk space, delete the environment cache directories. Runt will recreate environments as needed.
+To reclaim disk space, delete the environment cache directories. nteract Desktop will recreate environments as needed.
 
 ## Troubleshooting
 
@@ -118,6 +118,6 @@ To reclaim disk space, delete the environment cache directories. Runt will recre
 
 **Wrong environment**: If the kernel started with a prewarmed environment instead of your project's dependencies, check that your project file (pyproject.toml, environment.yml, pixi.toml) is in the notebook's directory or a parent directory within the same git repository.
 
-**Slow first start**: The first time a notebook opens with dependencies, Runt needs to download and install packages. Subsequent opens with the same dependencies are instant due to caching.
+**Slow first start**: The first time a notebook opens with dependencies, nteract Desktop needs to download and install packages. Subsequent opens with the same dependencies are instant due to caching.
 
-**Trust dialog keeps appearing**: This happens when the notebook's dependency signature doesn't match your machine's key. Approve the dependencies once and Runt will re-sign the notebook.
+**Trust dialog keeps appearing**: This happens when the notebook's dependency signature doesn't match your machine's key. Approve the dependencies once and nteract Desktop will re-sign the notebook.

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,6 +1,6 @@
 # Logging and Debugging
 
-This guide explains how to access and enable verbose logging in Runt.
+This guide explains how to access and enable verbose logging in nteract Desktop.
 
 ## Daemon Logs
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -1,6 +1,6 @@
 # Settings
 
-Runt notebook settings control default behavior for new notebooks, appearance, and runtime configuration.
+nteract Desktop settings control default behavior for new notebooks, appearance, and runtime configuration.
 
 ## Quick Reference
 

--- a/docs/sharing.md
+++ b/docs/sharing.md
@@ -1,6 +1,6 @@
 # Sharing Notebooks
 
-Runt notebooks are standard `.ipynb` files that work with Jupyter and other notebook tools. This guide covers how to share notebooks so recipients get the right environment.
+Notebooks created with nteract Desktop are standard `.ipynb` files that work with Jupyter and other notebook tools. This guide covers how to share notebooks so recipients get the right environment.
 
 ## Two Sharing Models
 
@@ -14,11 +14,11 @@ Dependencies stored directly in the notebook metadata. The notebook is self-cont
 
 ### Project-Level Reference (Stays in Sync)
 
-The notebook lives alongside a project file (`pyproject.toml`, `environment.yml`, or `pixi.toml`). Runt auto-detects the project file and creates the environment from it.
+The notebook lives alongside a project file (`pyproject.toml`, `environment.yml`, or `pixi.toml`). nteract Desktop auto-detects the project file and creates the environment from it.
 
 **Best for**: Notebooks in a git repository where everyone clones the same project structure.
 
-**How to create**: Put your notebook in a directory with a project file. When the recipient clones the repo and opens the notebook, Runt detects the project file automatically.
+**How to create**: Put your notebook in a directory with a project file. When the recipient clones the repo and opens the notebook, nteract Desktop detects the project file automatically.
 
 ## What Happens on the Recipient's End
 
@@ -27,34 +27,34 @@ The notebook lives alongside a project file (`pyproject.toml`, `environment.yml`
 1. Recipient opens the notebook
 2. Trust dialog appears (dependencies are unsigned on a new machine)
 3. Recipient approves the dependencies
-4. Runt installs the packages and starts the kernel
+4. nteract Desktop installs the packages and starts the kernel
 5. Notebook is ready to use
 
 ### Notebook in a project (pyproject.toml, environment.yml, pixi.toml)
 
 1. Recipient clones the repository
-2. Opens the notebook in Runt
-3. Runt detects the project file and creates the environment automatically
+2. Opens the notebook in nteract Desktop
+3. nteract Desktop detects the project file and creates the environment automatically
 4. No trust dialog (project file deps don't require trust approval)
 5. Notebook is ready to use
 
 ### Notebook with no dependencies
 
 1. Recipient opens the notebook
-2. Runt starts a prewarmed environment with just the basics (ipykernel, ipywidgets)
+2. nteract Desktop starts a prewarmed environment with just the basics (ipykernel, ipywidgets)
 3. Recipient needs to add packages manually
 
 ## Making Sharing Seamless
 
 - **Include dependencies**: Always add your packages to the notebook or use a project file. A notebook with no dependency information forces the recipient to guess what's needed.
 - **Use inline deps for standalone notebooks**: If the notebook is meant to be shared without a project, use "Copy to notebook" to embed dependencies directly.
-- **Use project files for repositories**: If the notebook lives in a git repo, keep dependencies in `pyproject.toml` or `environment.yml` and let Runt auto-detect them.
+- **Use project files for repositories**: If the notebook lives in a git repo, keep dependencies in `pyproject.toml` or `environment.yml` and let nteract Desktop auto-detect them.
 - **Avoid mixing UV and conda deps**: A notebook with both UV and conda dependencies can cause confusion. Pick one backend for each notebook.
 
 ## The Trust Dialog
 
-When you open a notebook with inline dependencies from another machine, Runt shows a trust dialog. This is a security measure — it prevents notebooks from silently installing arbitrary packages.
+When you open a notebook with inline dependencies from another machine, nteract Desktop shows a trust dialog. This is a security measure — it prevents notebooks from silently installing arbitrary packages.
 
-The dialog shows what dependencies the notebook wants to install. After you approve, Runt signs the notebook with your machine's key and won't ask again for that notebook (unless the dependencies change).
+The dialog shows what dependencies the notebook wants to install. After you approve, nteract Desktop signs the notebook with your machine's key and won't ask again for that notebook (unless the dependencies change).
 
 Project-file-based environments (pyproject.toml, environment.yml, pixi.toml) don't trigger the trust dialog because the dependencies come from files you can inspect in the repository, not from embedded notebook metadata.

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -1,6 +1,6 @@
 # Widget Support
 
-This guide covers ipywidgets and anywidget support in Runt.
+This guide covers ipywidgets and anywidget support in nteract Desktop.
 
 ## Quick Reference
 
@@ -17,7 +17,7 @@ This guide covers ipywidgets and anywidget support in Runt.
 
 | Widget | Why | Alternative |
 |--------|-----|-------------|
-| JupyterLab extensions | Runt is not JupyterLab | — |
+| JupyterLab extensions | nteract Desktop is not JupyterLab | — |
 | jupyterlab-sidecar | JupyterLab extension | Use notebook outputs |
 | bqplot | Extends IPython's DOMWidget | Plotly, Altair, Vega-Lite |
 
@@ -66,7 +66,7 @@ ipycanvas has a custom implementation (tested with v0.14.3). This is a from-scra
 
 ### anywidget
 
-Runt fully implements the [AFM (AnyWidget Frontend Module) spec](https://anywidget.dev/en/afm/). Any widget following this spec will work.
+nteract Desktop fully implements the [AFM (AnyWidget Frontend Module) spec](https://anywidget.dev/en/afm/). Any widget following this spec will work.
 
 **Tested widgets:**
 - **quak** — DataFrame viewer (custom messages work)
@@ -91,7 +91,7 @@ Rich display outputs work via the display protocol (not as widgets):
 
 ### JupyterLab Extensions
 
-**Runt is NOT JupyterLab.** Anything requiring `@jupyterlab/*` APIs won't work:
+**nteract Desktop is NOT JupyterLab.** Anything requiring `@jupyterlab/*` APIs won't work:
 
 - `jupyterlab-sidecar` — Creates JupyterLab panels, requires `@jupyterlab/application`
 - Any widget that imports from `@jupyterlab/services`, `@jupyterlab/apputils`, etc.
@@ -106,7 +106,7 @@ Some widgets extend IPython's `DOMWidget` class instead of the standard `@jupyte
 
 ## Why These Limitations?
 
-Runt runs widgets in isolated iframes for security. The architecture is:
+nteract Desktop runs widgets in isolated iframes for security. The architecture is:
 
 ```
 Parent Window (Tauri app)


### PR DESCRIPTION
## Summary

Replace "Runt" and "Runt notebooks" with "nteract Desktop" or "the app" in user-facing documentation. The correct branding is:
- **nteract Desktop** — the desktop app
- **runtimed** — the runtime daemon
- **runt** — the CLI tool
- **runtimed (python)** — the Python bindings

"Runt" was being used as a generic product name, which was confusing since "runt" specifically refers to the CLI tool.

## Changes

- `docs/sharing.md` — 10 replacements
- `docs/settings.md` — 1 replacement
- `docs/logging.md` — 1 replacement
- `docs/environments.md` — 17 replacements
- `docs/widgets.md` — 5 replacements

## Verification

- Filesystem paths like `~/.cache/runt/` are preserved (these are actual directory names)
- Technical docs (`docs/runtimed.md`, `docs/python-bindings.md`) already use correct branding
- All "Runt" as product name has been replaced; remaining matches are section headers or Python class names

_PR submitted by @rgbkrk's agent, Quill_