### PR TITLE
feat(notebook): add tab completion to code cells

### DIFF
--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -24,6 +24,7 @@ import type { CellPagePayload, MimeBundle } from "../App";
 import { useCellKeyboardNavigation } from "../hooks/useCellKeyboardNavigation";
 import { useEditorRegistry } from "../hooks/useEditorRegistry";
 import { kernelCompletionExtension } from "../lib/kernel-completion";
+import { tabCompletionKeymap } from "../lib/tab-completion";
 import type { CodeCell as CodeCellType } from "../types";
 
 // Lazy load HistorySearchDialog - it pulls in react-syntax-highlighter (~800KB)
@@ -207,10 +208,11 @@ export function CodeCell({
     [navigationKeyMap, historyKeyBinding],
   );
 
-  // CodeMirror extensions: kernel completion + search highlighting
+  // CodeMirror extensions: kernel completion + tab completion + search highlighting
   const editorExtensions = useMemo(
     () => [
       kernelCompletionExtension,
+      tabCompletionKeymap,
       ...searchHighlight(searchQuery || "", searchActiveOffset),
     ],
     [searchQuery, searchActiveOffset],

--- a/apps/notebook/src/lib/tab-completion.ts
+++ b/apps/notebook/src/lib/tab-completion.ts
@@ -1,0 +1,57 @@
+import {
+  acceptCompletion,
+  completionStatus,
+  startCompletion,
+} from "@codemirror/autocomplete";
+import { indentLess, indentMore } from "@codemirror/commands";
+import { type Extension, Prec } from "@codemirror/state";
+import { type EditorView, keymap } from "@codemirror/view";
+
+/**
+ * Check if cursor is after code where completion makes sense.
+ * Returns true if cursor follows a word character or dot.
+ */
+function shouldTriggerCompletion(view: EditorView): boolean {
+  const { state } = view;
+  const { from, to } = state.selection.main;
+
+  // Don't trigger with active selection (user might want to indent selection)
+  if (from !== to) return false;
+
+  const line = state.doc.lineAt(from);
+  const textBefore = state.sliceDoc(line.from, from);
+
+  // Trigger if cursor is directly after word character or dot
+  return /[\w.]$/.test(textBefore);
+}
+
+/**
+ * VS Code-like tab completion keymap:
+ * - Tab after text: triggers completion
+ * - Tab with completion open: accepts selection
+ * - Tab on empty/whitespace: indents
+ * - Shift+Tab: always dedent
+ */
+export const tabCompletionKeymap: Extension = Prec.high(
+  keymap.of([
+    {
+      key: "Tab",
+      run: (view) => {
+        // If completion is active, accept it
+        if (completionStatus(view.state) === "active") {
+          return acceptCompletion(view);
+        }
+        // If after code, trigger completion
+        if (shouldTriggerCompletion(view)) {
+          return startCompletion(view);
+        }
+        // Otherwise indent
+        return indentMore(view);
+      },
+    },
+    {
+      key: "Shift-Tab",
+      run: indentLess,
+    },
+  ]),
+);

--- a/apps/notebook/src/lib/tab-completion.ts
+++ b/apps/notebook/src/lib/tab-completion.ts
@@ -37,9 +37,13 @@ export const tabCompletionKeymap: Extension = Prec.high(
     {
       key: "Tab",
       run: (view) => {
-        // If completion is active, accept it
-        if (completionStatus(view.state) === "active") {
-          return acceptCompletion(view);
+        const status = completionStatus(view.state);
+        // If completion is active or pending, always consume Tab to prevent focus escape.
+        // acceptCompletion can return false during interactionDelay (~75ms), but we
+        // still want Tab captured so it doesn't bubble out of the editor.
+        if (status === "active" || status === "pending") {
+          acceptCompletion(view);
+          return true;
         }
         // If after code, trigger completion
         if (shouldTriggerCompletion(view)) {

--- a/e2e/specs/tab-completion.spec.js
+++ b/e2e/specs/tab-completion.spec.js
@@ -1,0 +1,169 @@
+/**
+ * E2E Tab Completion Test
+ *
+ * Verifies VS Code-like tab completion behavior in code cells:
+ * 1. Tab after identifier triggers completion
+ * 2. Tab accepts completion when popup is open
+ * 3. Tab on whitespace indents
+ * 4. Focus stays in editor (Tab doesn't escape)
+ */
+
+import { browser } from "@wdio/globals";
+import { typeSlowly, waitForAppReady, waitForKernelReady } from "../helpers.js";
+
+describe("Tab Completion", () => {
+  const modKey = process.platform === "darwin" ? "Meta" : "Control";
+
+  before(async () => {
+    await waitForAppReady();
+    // Wait for kernel so completions work
+    await waitForKernelReady(90000);
+  });
+
+  it("should trigger completion on Tab after identifier", async () => {
+    const codeCell = await $('[data-cell-type="code"]');
+    await codeCell.waitForExist({ timeout: 5000 });
+
+    const editor = await codeCell.$('.cm-content[contenteditable="true"]');
+    await editor.waitForExist({ timeout: 5000 });
+    await editor.click();
+    await browser.pause(200);
+
+    // Clear and type a variable assignment
+    await browser.keys([modKey, "a"]);
+    await browser.pause(100);
+    await typeSlowly("x = 123");
+    await browser.keys(["Shift", "Enter"]);
+
+    // Wait for execution to complete
+    await browser.waitUntil(
+      async () => {
+        const status = await browser.execute(() => {
+          const el = document.querySelector(
+            '[data-testid="notebook-toolbar"] .capitalize',
+          );
+          return el ? el.textContent.trim().toLowerCase() : "";
+        });
+        return status === "idle";
+      },
+      { timeout: 30000, interval: 300 },
+    );
+
+    // Now type 'x' and press Tab to trigger completion
+    await browser.pause(300);
+    await editor.click();
+    await browser.pause(200);
+    await browser.keys([modKey, "a"]);
+    await browser.pause(100);
+    await typeSlowly("x");
+    await browser.pause(100);
+
+    // Press Tab - should trigger completion popup
+    await browser.keys("Tab");
+    await browser.pause(500);
+
+    // Check that completion popup appeared
+    const completionPopup = await browser.execute(() => {
+      return !!document.querySelector(".cm-tooltip-autocomplete");
+    });
+
+    expect(completionPopup).toBe(true);
+
+    // Escape to close completion
+    await browser.keys("Escape");
+  });
+
+  it("should indent on Tab when on empty/whitespace line", async () => {
+    const codeCell = await $('[data-cell-type="code"]');
+    const editor = await codeCell.$('.cm-content[contenteditable="true"]');
+    await editor.click();
+    await browser.pause(200);
+
+    // Clear the cell
+    await browser.keys([modKey, "a"]);
+    await browser.pause(100);
+    await browser.keys("Backspace");
+    await browser.pause(100);
+
+    // Press Tab on empty line - should indent
+    await browser.keys("Tab");
+    await browser.pause(200);
+
+    // Get the content - should have indentation (spaces or tab)
+    const content = await browser.execute(() => {
+      const editor = document.querySelector(".cm-content");
+      return editor ? editor.textContent : "";
+    });
+
+    // Content should have some whitespace (indent)
+    expect(content.length).toBeGreaterThan(0);
+    expect(content.trim()).toBe(""); // Only whitespace
+  });
+
+  it("should keep focus in editor after Tab (not escape to page)", async () => {
+    const codeCell = await $('[data-cell-type="code"]');
+    const editor = await codeCell.$('.cm-content[contenteditable="true"]');
+    await editor.click();
+    await browser.pause(200);
+
+    // Clear and type something
+    await browser.keys([modKey, "a"]);
+    await browser.pause(100);
+    await typeSlowly("test");
+    await browser.pause(100);
+
+    // Press Tab
+    await browser.keys("Tab");
+    await browser.pause(300);
+
+    // Verify CodeMirror editor is still focused
+    const editorFocused = await browser.execute(() => {
+      const cmEditor = document.querySelector(".cm-editor.cm-focused");
+      return !!cmEditor;
+    });
+
+    expect(editorFocused).toBe(true);
+
+    // Clean up - close any completion popup
+    await browser.keys("Escape");
+  });
+
+  it("should accept completion with Tab when popup is open", async () => {
+    const codeCell = await $('[data-cell-type="code"]');
+    const editor = await codeCell.$('.cm-content[contenteditable="true"]');
+    await editor.click();
+    await browser.pause(200);
+
+    // Type 'x.' to trigger completion (dot trigger)
+    await browser.keys([modKey, "a"]);
+    await browser.pause(100);
+    await typeSlowly("x.");
+    await browser.pause(800); // Wait for completion to appear
+
+    // Check popup is open
+    const popupOpen = await browser.execute(() => {
+      return !!document.querySelector(".cm-tooltip-autocomplete");
+    });
+
+    if (popupOpen) {
+      // Press Tab to accept completion
+      await browser.keys("Tab");
+      await browser.pause(300);
+
+      // Get the content - should have something after 'x.'
+      const content = await browser.execute(() => {
+        const editor = document.querySelector(".cm-content");
+        return editor ? editor.textContent : "";
+      });
+
+      // Content should be longer than just 'x.'
+      expect(content.length).toBeGreaterThan(2);
+
+      // Editor should still be focused
+      const stillFocused = await browser.execute(() => {
+        return !!document.querySelector(".cm-editor.cm-focused");
+      });
+      expect(stillFocused).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
Enable VS Code-like tab completion in CodeMirror code cells:

**Changes:**
- Tab after code (e.g., `foo.` or `foo`) now triggers completion request instead of escaping the editor
- Tab with completion open accepts the selected item
- Tab on empty lines or pure whitespace indents (standard behavior)
- Shift+Tab dedents
- Completion can also be dismissed with Escape

**Why:** Previously Tab would break editor focus by navigating to other page elements, and completions could only be triggered via Ctrl+Space or automatically after `.`. This makes completion discovery difficult and breaks the native app's keyboard navigation model (using arrow keys to move between cells).

**Verification:**
- [ ] Type code like `x = 1` then `x` and press Tab → completion popup appears
- [ ] With completion open, press Tab or Enter → selection is accepted
- [ ] Empty line, press Tab → indentation is inserted
- [ ] Focus remains in editor (Tab doesn't escape to page elements)
- [ ] Escape closes completion popup

_PR submitted by @rgbkrk's agent, Quill_