### PR TITLE
fix(notebook): detect project files for untitled notebooks via handshake

### DIFF
--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -255,6 +255,7 @@ async fn initialize_notebook_sync(
     notebook_state: Arc<Mutex<NotebookState>>,
     notebook_sync: SharedNotebookSync,
     sync_generation: Arc<AtomicU64>,
+    working_dir: Option<PathBuf>,
 ) -> Result<(), String> {
     // Increment generation to invalidate any stale cleanup from previous connections
     let current_generation = sync_generation.fetch_add(1, Ordering::SeqCst) + 1;
@@ -266,16 +267,22 @@ async fn initialize_notebook_sync(
 
     let socket_path = runtimed::default_socket_path();
     info!(
-        "[notebook-sync] Connecting to daemon for notebook: {} ({})",
+        "[notebook-sync] Connecting to daemon for notebook: {} ({}) (working_dir: {:?})",
         notebook_id,
-        socket_path.display()
+        socket_path.display(),
+        working_dir
     );
 
     // Connect using the split pattern - returns handle, receiver, broadcast receiver, initial cells, and initial metadata
+    // Pass working_dir for untitled notebooks so daemon can detect project files
     let (handle, mut receiver, mut broadcast_receiver, initial_cells, initial_metadata) =
-        NotebookSyncClient::connect_split(socket_path, notebook_id.clone())
-            .await
-            .map_err(|e| format!("sync connect: {}", e))?;
+        NotebookSyncClient::connect_split_with_options(
+            socket_path,
+            notebook_id.clone(),
+            working_dir,
+        )
+        .await
+        .map_err(|e| format!("sync connect: {}", e))?;
 
     // Populate Automerge doc if empty (new room or first window)
     if initial_cells.is_empty() {
@@ -1033,8 +1040,9 @@ async fn save_notebook_as(
         .app_handle()
         .get_webview_window(window.label())
         .ok_or_else(|| "Current webview window not found".to_string())?;
+    // Saved notebooks have a path, so no working_dir needed for project detection
     if let Err(e) =
-        initialize_notebook_sync(webview_window, state, notebook_sync, sync_generation).await
+        initialize_notebook_sync(webview_window, state, notebook_sync, sync_generation, None).await
     {
         warn!("[save-as] Daemon reconnect failed (save succeeded): {}", e);
     }
@@ -1164,11 +1172,13 @@ fn create_notebook_window_with_label(
 
     let context = registry.get(&label)?;
     tauri::async_runtime::spawn(async move {
+        // New windows opened from file have a path, so no working_dir needed
         if let Err(e) = initialize_notebook_sync(
             window,
             context.notebook_state,
             context.notebook_sync,
             context.sync_generation,
+            None,
         )
         .await
         {
@@ -1727,6 +1737,7 @@ async fn reconnect_to_daemon(
     }
 
     // Re-initialize notebook sync
+    // On reconnect, the room may already have working_dir stored if it was an untitled notebook
     let webview_window = window
         .app_handle()
         .get_webview_window(window.label())
@@ -1736,6 +1747,7 @@ async fn reconnect_to_daemon(
         notebook_state,
         notebook_sync,
         sync_generation,
+        None, // Room preserves working_dir from initial connection
     )
     .await;
 
@@ -3159,9 +3171,12 @@ fn create_window_context(state: NotebookState) -> WindowNotebookContext {
 /// If `notebook_path` is Some, opens that file. If None, creates a new empty notebook.
 /// The `runtime` parameter specifies which runtime to use for new notebooks.
 /// If None, falls back to user's default runtime from settings.
+/// The `working_dir` parameter provides directory context for untitled notebooks,
+/// enabling project file detection (pyproject.toml, pixi.toml, environment.yaml).
 pub fn run(
     notebook_path: Option<PathBuf>,
     runtime: Option<Runtime>,
+    working_dir: Option<PathBuf>,
     #[allow(unused_variables)] webdriver_port: Option<u16>,
 ) -> anyhow::Result<()> {
     env_logger::init();
@@ -3417,6 +3432,8 @@ pub fn run(
             let app_for_sync = app.handle().clone();
             let app_for_notebook_sync = app.handle().clone();
             let registry_for_notebook_sync = registry_for_sync.clone();
+            // Capture working_dir for untitled notebook project file detection
+            let working_dir_for_sync = working_dir.clone();
             tauri::async_runtime::spawn(async move {
                 // Get path to bundled runtimed binary (for auto-installation)
                 let binary_path = get_bundled_runtimed_path(&app_for_daemon);
@@ -3461,6 +3478,7 @@ pub fn run(
                                 context.notebook_state,
                                 context.notebook_sync,
                                 context.sync_generation,
+                                working_dir_for_sync,
                             )
                             .await
                             {

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -1737,7 +1737,11 @@ async fn reconnect_to_daemon(
     }
 
     // Re-initialize notebook sync
-    // On reconnect, the room may already have working_dir stored if it was an untitled notebook
+    // Get working_dir from notebook state to preserve on daemon restart
+    let working_dir = {
+        let state = notebook_state.lock().map_err(|e| e.to_string())?;
+        state.working_dir.clone()
+    };
     let webview_window = window
         .app_handle()
         .get_webview_window(window.label())
@@ -1747,7 +1751,7 @@ async fn reconnect_to_daemon(
         notebook_state,
         notebook_sync,
         sync_generation,
-        None, // Room preserves working_dir from initial connection
+        working_dir,
     )
     .await;
 
@@ -3193,7 +3197,7 @@ pub fn run(
     };
 
     // Determine initial state for main window
-    let initial_state = match notebook_path.as_ref() {
+    let mut initial_state = match notebook_path.as_ref() {
         Some(path) => load_notebook_state_for_path(path, runtime).map_err(anyhow::Error::msg)?,
         None => {
             // Try to restore from session
@@ -3217,6 +3221,10 @@ pub fn run(
             }
         }
     };
+    // Store working_dir in notebook state for untitled notebooks (used on daemon reconnect)
+    if initial_state.path.is_none() {
+        initial_state.working_dir = working_dir.clone();
+    }
 
     let window_title = match &initial_state.path {
         Some(path) => path

--- a/crates/notebook/src/main.rs
+++ b/crates/notebook/src/main.rs
@@ -12,6 +12,12 @@ struct Args {
     #[arg(long, short)]
     runtime: Option<Runtime>,
 
+    /// Working directory for untitled notebooks (used for project file detection).
+    /// When opening an untitled notebook, this directory will be used to find
+    /// pyproject.toml, pixi.toml, or environment.yaml.
+    #[arg(long)]
+    cwd: Option<PathBuf>,
+
     /// Start a built-in WebDriver server on this port for E2E testing.
     /// Enables native E2E tests without Docker or tauri-driver.
     #[cfg(feature = "webdriver-test")]
@@ -27,5 +33,5 @@ fn main() {
     #[cfg(not(feature = "webdriver-test"))]
     let webdriver_port: Option<u16> = None;
 
-    notebook::run(args.path, args.runtime, webdriver_port).expect("notebook app failed");
+    notebook::run(args.path, args.runtime, args.cwd, webdriver_port).expect("notebook app failed");
 }

--- a/crates/notebook/src/notebook_state.rs
+++ b/crates/notebook/src/notebook_state.rs
@@ -152,6 +152,9 @@ pub struct NotebookState {
     pub notebook: Notebook,
     pub path: Option<PathBuf>,
     pub dirty: bool,
+    /// Working directory for untitled notebooks (used for project file detection).
+    /// Set from --cwd CLI argument and preserved across daemon reconnects.
+    pub working_dir: Option<PathBuf>,
 }
 
 impl NotebookState {
@@ -216,6 +219,7 @@ impl NotebookState {
             },
             path: None,
             dirty: false,
+            working_dir: None,
         }
     }
 
@@ -319,6 +323,7 @@ impl NotebookState {
             },
             path: None,
             dirty: false,
+            working_dir: None,
         }
     }
 
@@ -378,6 +383,7 @@ impl NotebookState {
             },
             path: None,
             dirty: false,
+            working_dir: None,
         }
     }
 
@@ -429,6 +435,7 @@ impl NotebookState {
             },
             path: None,
             dirty: false,
+            working_dir: None,
         }
     }
 
@@ -437,6 +444,7 @@ impl NotebookState {
             notebook,
             path: Some(path),
             dirty: false,
+            working_dir: None, // Saved notebooks use path for project detection
         }
     }
 

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -415,12 +415,19 @@ fn open_notebook(path: Option<PathBuf>, runtime: Option<String>) -> Result<()> {
         }
     });
 
+    // For untitled notebooks, capture current working directory for project file detection
+    let cwd = if abs_path.is_none() {
+        std::env::current_dir().ok()
+    } else {
+        None
+    };
+
     #[cfg(target_os = "macos")]
     {
         let mut cmd = std::process::Command::new("open");
         cmd.arg("-a").arg("nteract");
 
-        if abs_path.is_some() || runtime.is_some() {
+        if abs_path.is_some() || runtime.is_some() || cwd.is_some() {
             cmd.arg("--args");
         }
         if let Some(p) = abs_path {
@@ -428,6 +435,9 @@ fn open_notebook(path: Option<PathBuf>, runtime: Option<String>) -> Result<()> {
         }
         if let Some(r) = runtime {
             cmd.arg("--runtime").arg(r);
+        }
+        if let Some(wd) = &cwd {
+            cmd.arg("--cwd").arg(wd);
         }
 
         cmd.spawn()
@@ -446,6 +456,9 @@ fn open_notebook(path: Option<PathBuf>, runtime: Option<String>) -> Result<()> {
         if let Some(r) = runtime {
             cmd.arg("--runtime").arg(r);
         }
+        if let Some(wd) = &cwd {
+            cmd.arg("--cwd").arg(wd);
+        }
 
         cmd.spawn()
             .map_err(|e| anyhow::anyhow!("Failed to launch nteract: {}", e))?;
@@ -462,6 +475,9 @@ fn open_notebook(path: Option<PathBuf>, runtime: Option<String>) -> Result<()> {
         }
         if let Some(r) = runtime {
             cmd.arg("--runtime").arg(r);
+        }
+        if let Some(wd) = &cwd {
+            cmd.arg("--cwd").arg(wd);
         }
 
         cmd.spawn()

--- a/crates/runtimed/src/connection.rs
+++ b/crates/runtimed/src/connection.rs
@@ -53,6 +53,11 @@ pub enum Handshake {
         /// Protocol version requested by client. Default is "v1" (raw frames).
         #[serde(default, skip_serializing_if = "Option::is_none")]
         protocol: Option<String>,
+        /// Working directory for untitled notebooks (used for project file detection).
+        /// When a notebook_id is a UUID (untitled), this provides the directory context
+        /// for finding pyproject.toml, pixi.toml, or environment.yaml.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        working_dir: Option<String>,
     },
     /// Blob store: write blobs, query port.
     Blob,
@@ -316,6 +321,7 @@ mod tests {
         let json = serde_json::to_string(&Handshake::NotebookSync {
             notebook_id: "abc".into(),
             protocol: None,
+            working_dir: None,
         })
         .unwrap();
         assert_eq!(json, r#"{"channel":"notebook_sync","notebook_id":"abc"}"#);
@@ -324,11 +330,24 @@ mod tests {
         let json = serde_json::to_string(&Handshake::NotebookSync {
             notebook_id: "abc".into(),
             protocol: Some("v2".into()),
+            working_dir: None,
         })
         .unwrap();
         assert_eq!(
             json,
             r#"{"channel":"notebook_sync","notebook_id":"abc","protocol":"v2"}"#
+        );
+
+        // NotebookSync with working_dir for untitled notebook
+        let json = serde_json::to_string(&Handshake::NotebookSync {
+            notebook_id: "550e8400-e29b-41d4-a716-446655440000".into(),
+            protocol: Some("v2".into()),
+            working_dir: Some("/home/user/project".into()),
+        })
+        .unwrap();
+        assert_eq!(
+            json,
+            r#"{"channel":"notebook_sync","notebook_id":"550e8400-e29b-41d4-a716-446655440000","protocol":"v2","working_dir":"/home/user/project"}"#
         );
 
         // Blob

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -838,12 +838,14 @@ impl Daemon {
             Handshake::NotebookSync {
                 notebook_id,
                 protocol,
+                working_dir,
             } => {
                 let use_typed_frames = protocol.as_deref() == Some(connection::PROTOCOL_V2);
                 info!(
-                    "[runtimed] NotebookSync requested for {} (protocol: {})",
+                    "[runtimed] NotebookSync requested for {} (protocol: {}, working_dir: {:?})",
                     notebook_id,
-                    protocol.as_deref().unwrap_or("v1")
+                    protocol.as_deref().unwrap_or("v1"),
+                    working_dir
                 );
                 let docs_dir = self.config.notebook_docs_dir.clone();
                 let room = {
@@ -860,6 +862,8 @@ impl Daemon {
                 let settings = self.settings.read().await.get_all();
                 let default_runtime = settings.default_runtime;
                 let default_python_env = settings.default_python_env;
+                // Convert working_dir String to PathBuf
+                let working_dir_path = working_dir.map(std::path::PathBuf::from);
                 crate::notebook_sync_server::handle_notebook_sync_connection(
                     reader,
                     writer,
@@ -870,6 +874,7 @@ impl Daemon {
                     default_runtime,
                     default_python_env,
                     self.clone(),
+                    working_dir_path,
                 )
                 .await
             }

--- a/crates/runtimed/src/notebook_sync_client.rs
+++ b/crates/runtimed/src/notebook_sync_client.rs
@@ -394,7 +394,7 @@ impl NotebookSyncClient<tokio::net::UnixStream> {
         socket_path: PathBuf,
         notebook_id: String,
     ) -> Result<Self, NotebookSyncError> {
-        Self::connect_with_timeout(socket_path, notebook_id, Duration::from_secs(2)).await
+        Self::connect_with_options(socket_path, notebook_id, Duration::from_secs(2), None).await
     }
 
     /// Connect with a custom timeout.
@@ -403,17 +403,27 @@ impl NotebookSyncClient<tokio::net::UnixStream> {
         notebook_id: String,
         timeout: Duration,
     ) -> Result<Self, NotebookSyncError> {
+        Self::connect_with_options(socket_path, notebook_id, timeout, None).await
+    }
+
+    /// Connect with custom timeout and working directory for untitled notebooks.
+    pub async fn connect_with_options(
+        socket_path: PathBuf,
+        notebook_id: String,
+        timeout: Duration,
+        working_dir: Option<PathBuf>,
+    ) -> Result<Self, NotebookSyncError> {
         let stream = tokio::time::timeout(timeout, tokio::net::UnixStream::connect(&socket_path))
             .await
             .map_err(|_| NotebookSyncError::Timeout)?
             .map_err(NotebookSyncError::ConnectionFailed)?;
 
         info!(
-            "[notebook-sync-client] Connected to {:?} for {}",
-            socket_path, notebook_id
+            "[notebook-sync-client] Connected to {:?} for {} (working_dir: {:?})",
+            socket_path, notebook_id, working_dir
         );
 
-        Self::init(stream, notebook_id).await
+        Self::init(stream, notebook_id, working_dir).await
     }
 
     /// Connect and return split handle/receiver for concurrent send/receive.
@@ -435,7 +445,31 @@ impl NotebookSyncClient<tokio::net::UnixStream> {
         ),
         NotebookSyncError,
     > {
-        let client = Self::connect(socket_path, notebook_id).await?;
+        Self::connect_split_with_options(socket_path, notebook_id, None).await
+    }
+
+    /// Connect and return split handle/receiver with working directory for untitled notebooks.
+    pub async fn connect_split_with_options(
+        socket_path: PathBuf,
+        notebook_id: String,
+        working_dir: Option<PathBuf>,
+    ) -> Result<
+        (
+            NotebookSyncHandle,
+            NotebookSyncReceiver,
+            NotebookBroadcastReceiver,
+            Vec<CellSnapshot>,
+            Option<String>,
+        ),
+        NotebookSyncError,
+    > {
+        let client = Self::connect_with_options(
+            socket_path,
+            notebook_id,
+            Duration::from_secs(2),
+            working_dir,
+        )
+        .await?;
         Ok(client.into_split())
     }
 }
@@ -447,11 +481,20 @@ impl NotebookSyncClient<tokio::net::windows::named_pipe::NamedPipeClient> {
         socket_path: PathBuf,
         notebook_id: String,
     ) -> Result<Self, NotebookSyncError> {
+        Self::connect_with_options(socket_path, notebook_id, None).await
+    }
+
+    /// Connect with working directory for untitled notebooks.
+    pub async fn connect_with_options(
+        socket_path: PathBuf,
+        notebook_id: String,
+        working_dir: Option<PathBuf>,
+    ) -> Result<Self, NotebookSyncError> {
         let pipe_name = socket_path.to_string_lossy().to_string();
         let client = tokio::net::windows::named_pipe::ClientOptions::new()
             .open(&pipe_name)
             .map_err(NotebookSyncError::ConnectionFailed)?;
-        Self::init(client, notebook_id).await
+        Self::init(client, notebook_id, working_dir).await
     }
 
     /// Connect and return split handle/receiver for concurrent send/receive.
@@ -468,7 +511,25 @@ impl NotebookSyncClient<tokio::net::windows::named_pipe::NamedPipeClient> {
         ),
         NotebookSyncError,
     > {
-        let client = Self::connect(socket_path, notebook_id).await?;
+        Self::connect_split_with_options(socket_path, notebook_id, None).await
+    }
+
+    /// Connect and return split handle/receiver with working directory for untitled notebooks.
+    pub async fn connect_split_with_options(
+        socket_path: PathBuf,
+        notebook_id: String,
+        working_dir: Option<PathBuf>,
+    ) -> Result<
+        (
+            NotebookSyncHandle,
+            NotebookSyncReceiver,
+            NotebookBroadcastReceiver,
+            Vec<CellSnapshot>,
+            Option<String>,
+        ),
+        NotebookSyncError,
+    > {
+        let client = Self::connect_with_options(socket_path, notebook_id, working_dir).await?;
         Ok(client.into_split())
     }
 }
@@ -483,13 +544,21 @@ where
     /// If the server supports v2, it responds with a ProtocolCapabilities frame.
     /// Old servers (v1) ignore the protocol field and send raw Automerge frames.
     /// The client detects which protocol to use based on the first response.
-    async fn init(mut stream: S, notebook_id: String) -> Result<Self, NotebookSyncError> {
+    ///
+    /// The `working_dir` parameter is used for untitled notebooks to provide
+    /// the directory context for project file detection (pyproject.toml, etc).
+    async fn init(
+        mut stream: S,
+        notebook_id: String,
+        working_dir: Option<PathBuf>,
+    ) -> Result<Self, NotebookSyncError> {
         // Send the channel handshake, requesting v2 protocol
         connection::send_json_frame(
             &mut stream,
             &Handshake::NotebookSync {
                 notebook_id: notebook_id.clone(),
                 protocol: Some(PROTOCOL_V2.to_string()),
+                working_dir: working_dir.map(|p| p.to_string_lossy().to_string()),
             },
         )
         .await

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -467,6 +467,10 @@ pub struct NotebookRoom {
     pub trust_state: Arc<RwLock<TrustState>>,
     /// The notebook file path (notebook_id is the path).
     pub notebook_path: PathBuf,
+    /// Working directory for untitled notebooks (used for project file detection).
+    /// When the notebook_id is a UUID (untitled), this provides the directory context
+    /// for finding pyproject.toml, pixi.toml, or environment.yaml.
+    pub working_dir: Arc<RwLock<Option<PathBuf>>>,
     /// Timestamp when auto-launch was triggered (for grace period on eviction).
     /// If set, the room won't be evicted for 30 seconds to allow client reconnect.
     pub auto_launch_at: Arc<RwLock<Option<std::time::Instant>>>,
@@ -524,6 +528,7 @@ impl NotebookRoom {
             blob_store,
             trust_state: Arc::new(RwLock::new(trust_state)),
             notebook_path,
+            working_dir: Arc::new(RwLock::new(None)),
             auto_launch_at: Arc::new(RwLock::new(None)),
             comm_state: Arc::new(CommState::new()),
         }
@@ -553,6 +558,7 @@ impl NotebookRoom {
             blob_store,
             trust_state: Arc::new(RwLock::new(trust_state)),
             notebook_path,
+            working_dir: Arc::new(RwLock::new(None)),
             auto_launch_at: Arc::new(RwLock::new(None)),
             comm_state: Arc::new(CommState::new()),
         }
@@ -631,11 +637,18 @@ pub async fn handle_notebook_sync_connection<R, W>(
     default_runtime: crate::runtime::Runtime,
     default_python_env: crate::settings_doc::PythonEnvType,
     daemon: std::sync::Arc<crate::daemon::Daemon>,
+    working_dir: Option<PathBuf>,
 ) -> anyhow::Result<()>
 where
     R: AsyncRead + Unpin,
     W: AsyncWrite + Unpin,
 {
+    // Set working_dir on the room if provided (for untitled notebook project detection)
+    if let Some(wd) = working_dir {
+        let mut room_wd = room.working_dir.write().await;
+        *room_wd = Some(wd);
+    }
+
     room.active_peers.fetch_add(1, Ordering::Relaxed);
     let peers = room.active_peers.load(Ordering::Relaxed);
     info!(
@@ -1079,17 +1092,14 @@ async fn auto_launch_kernel(
     let notebook_path_opt = if notebook_path.exists() {
         Some(notebook_path.clone())
     } else if is_untitled_notebook(notebook_id) {
-        // For untitled notebooks, check RUNTIMED_UNTITLED_BASE_PATH for project file detection
-        std::env::var("RUNTIMED_UNTITLED_BASE_PATH")
-            .ok()
-            .map(PathBuf::from)
-            .filter(|p| p.is_dir())
-            .inspect(|p| {
-                info!(
-                    "[notebook-sync] Using RUNTIMED_UNTITLED_BASE_PATH for untitled notebook: {}",
-                    p.display()
-                );
-            })
+        // For untitled notebooks, use the working_dir from the handshake for project file detection
+        let working_dir = room.working_dir.read().await;
+        working_dir.clone().inspect(|p| {
+            info!(
+                "[notebook-sync] Using working_dir for untitled notebook project detection: {}",
+                p.display()
+            );
+        })
     } else {
         None
     };
@@ -2879,6 +2889,7 @@ mod tests {
                 pending_launch: false,
             })),
             notebook_path: notebook_path.clone(),
+            working_dir: Arc::new(RwLock::new(None)),
             auto_launch_at: Arc::new(RwLock::new(None)),
             comm_state: Arc::new(crate::comm_state::CommState::new()),
         };

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -1050,6 +1050,11 @@ async fn acquire_pool_env_for_source(
     }
 }
 
+/// Check if a notebook_id is a UUID (untitled/unsaved notebook).
+fn is_untitled_notebook(notebook_id: &str) -> bool {
+    uuid::Uuid::parse_str(notebook_id).is_ok()
+}
+
 /// Auto-launch kernel for a trusted notebook when first peer connects.
 /// This is similar to handle_notebook_request(LaunchKernel) but without a request/response.
 ///
@@ -1073,6 +1078,19 @@ async fn auto_launch_kernel(
     let notebook_path = PathBuf::from(notebook_id);
     let notebook_path_opt = if notebook_path.exists() {
         Some(notebook_path.clone())
+    } else if is_untitled_notebook(notebook_id) {
+        // For untitled notebooks, check RUNTIMED_UNTITLED_BASE_PATH for project file detection
+        std::env::var("RUNTIMED_UNTITLED_BASE_PATH")
+            .ok()
+            .map(PathBuf::from)
+            .filter(|p| p.is_dir())
+            .map(|p| {
+                info!(
+                    "[notebook-sync] Using RUNTIMED_UNTITLED_BASE_PATH for untitled notebook: {}",
+                    p.display()
+                );
+                p
+            })
     } else {
         None
     };
@@ -3039,5 +3057,18 @@ mod tests {
         } else {
             panic!("Expected code cell");
         }
+    }
+
+    #[test]
+    fn test_is_untitled_notebook_with_uuid() {
+        assert!(is_untitled_notebook("550e8400-e29b-41d4-a716-446655440000"));
+        assert!(is_untitled_notebook("a1b2c3d4-e5f6-7890-abcd-ef1234567890"));
+    }
+
+    #[test]
+    fn test_is_untitled_notebook_with_path() {
+        assert!(!is_untitled_notebook("/home/user/notebook.ipynb"));
+        assert!(!is_untitled_notebook("./relative/path.ipynb"));
+        assert!(!is_untitled_notebook("notebook.ipynb"));
     }
 }

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -1084,12 +1084,11 @@ async fn auto_launch_kernel(
             .ok()
             .map(PathBuf::from)
             .filter(|p| p.is_dir())
-            .map(|p| {
+            .inspect(|p| {
                 info!(
                     "[notebook-sync] Using RUNTIMED_UNTITLED_BASE_PATH for untitled notebook: {}",
                     p.display()
                 );
-                p
             })
     } else {
         None

--- a/e2e/dev.sh
+++ b/e2e/dev.sh
@@ -297,18 +297,18 @@ case "${1:-help}" in
     ;;
 
   test-untitled-pyproject)
-    # Test untitled notebook with pyproject.toml detection via RUNTIMED_UNTITLED_BASE_PATH
+    # Test untitled notebook with pyproject.toml detection via --cwd
     cd "$PROJECT_ROOT"
     require_binary
     $0 stop 2>/dev/null || true
     sleep 1
     start_daemon
 
-    # Set the base path for untitled notebooks to use the pyproject fixture
-    export RUNTIMED_UNTITLED_BASE_PATH="$PROJECT_ROOT/crates/notebook/fixtures/audit-test/pyproject-project"
+    # Use --cwd to set the working directory for untitled notebook project file detection
+    FIXTURE_DIR="$PROJECT_ROOT/crates/notebook/fixtures/audit-test/pyproject-project"
 
-    echo "Starting untitled notebook with RUNTIMED_UNTITLED_BASE_PATH=$RUNTIMED_UNTITLED_BASE_PATH"
-    RUST_LOG="${RUST_LOG:-info}" "$BINARY" --webdriver-port "$PORT" &
+    echo "Starting untitled notebook with --cwd $FIXTURE_DIR"
+    RUST_LOG="${RUST_LOG:-info}" "$BINARY" --webdriver-port "$PORT" --cwd "$FIXTURE_DIR" &
     wait_for_server 30
     TEST_EXIT=0
     E2E_SPEC="e2e/specs/untitled-pyproject.spec.js" WEBDRIVER_PORT="$PORT" pnpm exec wdio run e2e/wdio.conf.js || TEST_EXIT=$?

--- a/e2e/dev.sh
+++ b/e2e/dev.sh
@@ -296,6 +296,28 @@ case "${1:-help}" in
     fi
     ;;
 
+  test-untitled-pyproject)
+    # Test untitled notebook with pyproject.toml detection via RUNTIMED_UNTITLED_BASE_PATH
+    cd "$PROJECT_ROOT"
+    require_binary
+    $0 stop 2>/dev/null || true
+    sleep 1
+    start_daemon
+
+    # Set the base path for untitled notebooks to use the pyproject fixture
+    export RUNTIMED_UNTITLED_BASE_PATH="$PROJECT_ROOT/crates/notebook/fixtures/audit-test/pyproject-project"
+
+    echo "Starting untitled notebook with RUNTIMED_UNTITLED_BASE_PATH=$RUNTIMED_UNTITLED_BASE_PATH"
+    RUST_LOG="${RUST_LOG:-info}" "$BINARY" --webdriver-port "$PORT" &
+    wait_for_server 30
+    TEST_EXIT=0
+    E2E_SPEC="e2e/specs/untitled-pyproject.spec.js" WEBDRIVER_PORT="$PORT" pnpm exec wdio run e2e/wdio.conf.js || TEST_EXIT=$?
+    # Stop app
+    PIDS=$(lsof -ti :"$PORT" 2>/dev/null || true)
+    [ -n "$PIDS" ] && echo "$PIDS" | xargs kill 2>/dev/null || true
+    exit $TEST_EXIT
+    ;;
+
   help|*)
     echo "Usage: ./e2e/dev.sh <command> [args...]"
     echo ""
@@ -316,6 +338,7 @@ case "${1:-help}" in
     echo "Test:"
     echo "  test [spec|all]    Run E2E tests (requires app already running)"
     echo "  test-fixture <nb> <spec>  Run a fixture test (starts fresh app)"
+    echo "  test-untitled-pyproject   Test untitled notebook with pyproject.toml"
     echo ""
     echo "Debug:"
     echo "  status             Check if WebDriver server is running"

--- a/e2e/specs/untitled-pyproject.spec.js
+++ b/e2e/specs/untitled-pyproject.spec.js
@@ -2,11 +2,10 @@
  * E2E Test: Untitled Notebook with pyproject.toml
  *
  * Verifies that untitled notebooks can detect pyproject.toml
- * when RUNTIMED_UNTITLED_BASE_PATH is set.
+ * when launched with --cwd pointing to a project directory.
  *
- * This test opens a fresh untitled notebook (no NOTEBOOK_PATH)
- * but sets RUNTIMED_UNTITLED_BASE_PATH to a fixture directory
- * containing pyproject.toml with pandas and numpy.
+ * This test opens a fresh untitled notebook with --cwd set to
+ * a fixture directory containing pyproject.toml with pandas.
  *
  * Run with: ./e2e/dev.sh test-untitled-pyproject
  */

--- a/e2e/specs/untitled-pyproject.spec.js
+++ b/e2e/specs/untitled-pyproject.spec.js
@@ -1,0 +1,38 @@
+/**
+ * E2E Test: Untitled Notebook with pyproject.toml
+ *
+ * Verifies that untitled notebooks can detect pyproject.toml
+ * when RUNTIMED_UNTITLED_BASE_PATH is set.
+ *
+ * This test opens a fresh untitled notebook (no NOTEBOOK_PATH)
+ * but sets RUNTIMED_UNTITLED_BASE_PATH to a fixture directory
+ * containing pyproject.toml with pandas and numpy.
+ *
+ * Run with: ./e2e/dev.sh test-untitled-pyproject
+ */
+
+import { browser } from "@wdio/globals";
+import {
+  setupCodeCell,
+  typeSlowly,
+  waitForCellOutput,
+  waitForKernelReady,
+} from "../helpers.js";
+
+describe("Untitled Notebook with pyproject.toml", () => {
+  it("should auto-launch kernel with project deps", async () => {
+    // Wait for kernel to auto-launch using pyproject deps (120s, includes uv sync)
+    await waitForKernelReady(120000);
+  });
+
+  it("should have project deps available (pandas from pyproject.toml)", async () => {
+    const cell = await setupCodeCell();
+    await typeSlowly("import pandas; print(pandas.__version__)");
+    await browser.keys(["Shift", "Enter"]);
+
+    // Wait for version output
+    const output = await waitForCellOutput(cell, 60000);
+    // Should show pandas version (e.g., "2.1.0")
+    expect(output).toMatch(/^\d+\.\d+/);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes issue #408: Untitled notebooks now detect project files (pyproject.toml, pixi.toml, environment.yaml) when opened from project directories.

Previously, untitled notebooks used a UUID as their notebook_id, which doesn't exist on disk, so project file detection was skipped entirely. Now the working directory is passed through the daemon handshake protocol.

## Implementation

**Flow:**
1. CLI captures CWD when launching untitled notebook (new `--cwd` flag)
2. App passes `working_dir` to daemon via handshake protocol
3. Daemon stores `working_dir` on the notebook room
4. `auto_launch_kernel()` uses `working_dir` for project file detection
5. Existing project detection logic handles the walk-up search for all project types

**Key changes:**
- Add `working_dir` field to `Handshake::NotebookSync`
- Add `--cwd` argument to CLI (`runt notebook`) and app
- Store `working_dir` on `NotebookRoom`
- Update sync client to support `working_dir` in connection

## Verification

- [ ] Test from directory with `pyproject.toml`: `cd ~/project && runt notebook`
- [ ] Test from directory with `pixi.toml`
- [ ] Test from directory with `environment.yaml`
- [ ] Test nested directories find parent project file
- [ ] Run E2E test: `./e2e/dev.sh test-untitled-pyproject`

## Notes

- Python bindings (`runtimed-py`) and MCP server not yet updated - can be addressed in follow-up
- E2E test now uses `--cwd` instead of environment variable

Closes #408

_PR submitted by @rgbkrk's agent, Quill_