### PR TITLE
refactor(notebook): capture CWD directly instead of --cwd arg

### DIFF
--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -3175,16 +3175,24 @@ fn create_window_context(state: NotebookState) -> WindowNotebookContext {
 /// If `notebook_path` is Some, opens that file. If None, creates a new empty notebook.
 /// The `runtime` parameter specifies which runtime to use for new notebooks.
 /// If None, falls back to user's default runtime from settings.
-/// The `working_dir` parameter provides directory context for untitled notebooks,
-/// enabling project file detection (pyproject.toml, pixi.toml, environment.yaml).
+///
+/// For untitled notebooks, the current working directory is captured at startup
+/// for project file detection (pyproject.toml, pixi.toml, environment.yaml).
 pub fn run(
     notebook_path: Option<PathBuf>,
     runtime: Option<Runtime>,
-    working_dir: Option<PathBuf>,
     #[allow(unused_variables)] webdriver_port: Option<u16>,
 ) -> anyhow::Result<()> {
     env_logger::init();
     shell_env::load_shell_environment();
+
+    // Capture working directory early for untitled notebook project detection.
+    // This must happen before Tauri startup, which may change the CWD.
+    let working_dir = if notebook_path.is_none() {
+        std::env::current_dir().ok()
+    } else {
+        None
+    };
 
     // Use provided runtime or fall back to user's default from settings
     let runtime = runtime.unwrap_or_else(|| settings::load_settings().default_runtime);

--- a/crates/notebook/src/main.rs
+++ b/crates/notebook/src/main.rs
@@ -12,12 +12,6 @@ struct Args {
     #[arg(long, short)]
     runtime: Option<Runtime>,
 
-    /// Working directory for untitled notebooks (used for project file detection).
-    /// When opening an untitled notebook, this directory will be used to find
-    /// pyproject.toml, pixi.toml, or environment.yaml.
-    #[arg(long)]
-    cwd: Option<PathBuf>,
-
     /// Start a built-in WebDriver server on this port for E2E testing.
     /// Enables native E2E tests without Docker or tauri-driver.
     #[cfg(feature = "webdriver-test")]
@@ -33,5 +27,5 @@ fn main() {
     #[cfg(not(feature = "webdriver-test"))]
     let webdriver_port: Option<u16> = None;
 
-    notebook::run(args.path, args.runtime, args.cwd, webdriver_port).expect("notebook app failed");
+    notebook::run(args.path, args.runtime, webdriver_port).expect("notebook app failed");
 }

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -404,7 +404,10 @@ fn main() -> Result<()> {
     }
 }
 
-/// Open the notebook application with optional path and runtime arguments
+/// Open the notebook application with optional path and runtime arguments.
+///
+/// The app automatically captures its working directory at startup for untitled
+/// notebooks, so we don't need to pass --cwd explicitly.
 fn open_notebook(path: Option<PathBuf>, runtime: Option<String>) -> Result<()> {
     // Convert relative paths to absolute
     let abs_path = path.map(|p| {
@@ -415,19 +418,12 @@ fn open_notebook(path: Option<PathBuf>, runtime: Option<String>) -> Result<()> {
         }
     });
 
-    // For untitled notebooks, capture current working directory for project file detection
-    let cwd = if abs_path.is_none() {
-        std::env::current_dir().ok()
-    } else {
-        None
-    };
-
     #[cfg(target_os = "macos")]
     {
         let mut cmd = std::process::Command::new("open");
         cmd.arg("-a").arg("nteract");
 
-        if abs_path.is_some() || runtime.is_some() || cwd.is_some() {
+        if abs_path.is_some() || runtime.is_some() {
             cmd.arg("--args");
         }
         if let Some(p) = abs_path {
@@ -435,9 +431,6 @@ fn open_notebook(path: Option<PathBuf>, runtime: Option<String>) -> Result<()> {
         }
         if let Some(r) = runtime {
             cmd.arg("--runtime").arg(r);
-        }
-        if let Some(wd) = &cwd {
-            cmd.arg("--cwd").arg(wd);
         }
 
         cmd.spawn()
@@ -456,9 +449,6 @@ fn open_notebook(path: Option<PathBuf>, runtime: Option<String>) -> Result<()> {
         if let Some(r) = runtime {
             cmd.arg("--runtime").arg(r);
         }
-        if let Some(wd) = &cwd {
-            cmd.arg("--cwd").arg(wd);
-        }
 
         cmd.spawn()
             .map_err(|e| anyhow::anyhow!("Failed to launch nteract: {}", e))?;
@@ -475,9 +465,6 @@ fn open_notebook(path: Option<PathBuf>, runtime: Option<String>) -> Result<()> {
         }
         if let Some(r) = runtime {
             cmd.arg("--runtime").arg(r);
-        }
-        if let Some(wd) = &cwd {
-            cmd.arg("--cwd").arg(wd);
         }
 
         cmd.spawn()

--- a/e2e/dev.sh
+++ b/e2e/dev.sh
@@ -297,18 +297,19 @@ case "${1:-help}" in
     ;;
 
   test-untitled-pyproject)
-    # Test untitled notebook with pyproject.toml detection via --cwd
-    cd "$PROJECT_ROOT"
+    # Test untitled notebook with pyproject.toml detection
+    # The app captures CWD at startup, so we run it from the fixture directory
     require_binary
     $0 stop 2>/dev/null || true
     sleep 1
     start_daemon
 
-    # Use --cwd to set the working directory for untitled notebook project file detection
     FIXTURE_DIR="$PROJECT_ROOT/crates/notebook/fixtures/audit-test/pyproject-project"
 
-    echo "Starting untitled notebook with --cwd $FIXTURE_DIR"
-    RUST_LOG="${RUST_LOG:-info}" "$BINARY" --webdriver-port "$PORT" --cwd "$FIXTURE_DIR" &
+    echo "Starting untitled notebook from $FIXTURE_DIR (app will detect pyproject.toml)"
+    cd "$FIXTURE_DIR"
+    RUST_LOG="${RUST_LOG:-info}" "$BINARY" --webdriver-port "$PORT" &
+    cd "$PROJECT_ROOT"
     wait_for_server 30
     TEST_EXIT=0
     E2E_SPEC="e2e/specs/untitled-pyproject.spec.js" WEBDRIVER_PORT="$PORT" pnpm exec wdio run e2e/wdio.conf.js || TEST_EXIT=$?

--- a/e2e/specs/untitled-pyproject.spec.js
+++ b/e2e/specs/untitled-pyproject.spec.js
@@ -2,10 +2,11 @@
  * E2E Test: Untitled Notebook with pyproject.toml
  *
  * Verifies that untitled notebooks can detect pyproject.toml
- * when launched with --cwd pointing to a project directory.
+ * when launched from a project directory.
  *
- * This test opens a fresh untitled notebook with --cwd set to
- * a fixture directory containing pyproject.toml with pandas.
+ * The app captures its working directory at startup and uses it
+ * for project file detection. This test runs the app from a fixture
+ * directory containing pyproject.toml with pandas.
  *
  * Run with: ./e2e/dev.sh test-untitled-pyproject
  */


### PR DESCRIPTION
## Summary

Simplifies untitled notebook project detection by removing the `--cwd` argument. The app now captures `std::env::current_dir()` directly at startup.

**Before**: CLI captured CWD and passed `--cwd` to app
**After**: App captures CWD itself (child processes inherit CWD from parent)

## Changes

- Remove `--cwd` argument from notebook app (`crates/notebook/src/main.rs`)
- Capture `std::env::current_dir()` at startup for untitled notebooks (`crates/notebook/src/lib.rs`)
- Remove `--cwd` passing logic from CLI (`crates/runt/src/main.rs`)
- Update E2E test to run app from fixture directory instead of using `--cwd`

## Test plan

- [ ] Run `runt notebook` from a directory with `pyproject.toml` - should detect deps
- [ ] Run E2E test: `./e2e/dev.sh test-untitled-pyproject`
- [ ] Opening saved notebooks should still work normally

_PR submitted by @rgbkrk's agent, Quill_