### PR TITLE
feat(settings): add configurable keep-alive setting for notebook rooms

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -91,6 +91,8 @@ function AppContent() {
     setDefaultUvPackages,
     defaultCondaPackages,
     setDefaultCondaPackages,
+    keepAliveSecs,
+    setKeepAliveSecs,
   } = useSyncedSettings();
 
   const {
@@ -922,6 +924,8 @@ function AppContent() {
         onDefaultUvPackagesChange={setDefaultUvPackages}
         defaultCondaPackages={defaultCondaPackages}
         onDefaultCondaPackagesChange={setDefaultCondaPackages}
+        keepAliveSecs={keepAliveSecs}
+        onKeepAliveSecsChange={setKeepAliveSecs}
         onSave={save}
         onStartKernel={handleStartKernel}
         onInterruptKernel={interruptKernel}

--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -160,6 +160,8 @@ interface NotebookToolbarProps {
   onDefaultUvPackagesChange?: (packages: string[]) => void;
   defaultCondaPackages?: string[];
   onDefaultCondaPackagesChange?: (packages: string[]) => void;
+  keepAliveSecs?: number;
+  onKeepAliveSecsChange?: (secs: number) => void;
   onSave: () => void;
   onStartKernel: (name: string) => void;
   onInterruptKernel: () => void;
@@ -288,6 +290,8 @@ export function NotebookToolbar({
   onDefaultUvPackagesChange,
   defaultCondaPackages = [],
   onDefaultCondaPackagesChange,
+  keepAliveSecs = 30,
+  onKeepAliveSecsChange,
   onSave,
   onStartKernel,
   onInterruptKernel,
@@ -838,6 +842,39 @@ export function NotebookToolbar({
                         />
                       </>
                     )}
+                </div>
+              </div>
+            )}
+
+            {/* Advanced settings */}
+            {onKeepAliveSecsChange && (
+              <div className="space-y-2 pt-2 border-t border-border/50">
+                <div>
+                  <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+                    Advanced
+                  </span>
+                </div>
+                <div className="flex items-center gap-3">
+                  <span className="text-xs font-medium text-muted-foreground">
+                    Keep Alive
+                  </span>
+                  <input
+                    type="number"
+                    min={0}
+                    max={3600}
+                    step={5}
+                    value={keepAliveSecs}
+                    onChange={(e) =>
+                      onKeepAliveSecsChange(
+                        Math.max(0, Math.min(3600, Number(e.target.value))),
+                      )
+                    }
+                    className="w-20 rounded-md border bg-muted/50 px-2 py-1 text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+                  />
+                  <span className="text-xs text-muted-foreground">seconds</span>
+                  <span className="text-[10px] text-muted-foreground/70 ml-2">
+                    Time to keep notebook room alive after closing
+                  </span>
                 </div>
               </div>
             )}

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -2897,6 +2897,12 @@ fn save_setting_locally(key: &str, value: &serde_json::Value) -> Result<(), Stri
             s.conda.default_packages = packages;
             settings::save_settings(&s).map_err(|e| e.to_string())
         }
+        "keep_alive_secs" => {
+            let secs = value.as_u64().ok_or("expected number")?;
+            let mut s = settings::load_settings();
+            s.keep_alive_secs = secs;
+            settings::save_settings(&s).map_err(|e| e.to_string())
+        }
         _ => Ok(()),
     }
 }

--- a/crates/notebook/src/settings.rs
+++ b/crates/notebook/src/settings.rs
@@ -119,6 +119,7 @@ mod tests {
                 default_packages: vec!["numpy".into(), "pandas".into()],
             },
             conda: CondaDefaults::default(),
+            keep_alive_secs: 30,
         };
 
         let json = serde_json::to_string(&settings).unwrap();
@@ -253,6 +254,10 @@ mod tests {
                 .get("conda")
                 .and_then(|v| serde_json::from_value(v.clone()).ok())
                 .unwrap_or(defaults.conda),
+            keep_alive_secs: json_val
+                .get("keep_alive_secs")
+                .and_then(|v| serde_json::from_value(v.clone()).ok())
+                .unwrap_or(defaults.keep_alive_secs),
         };
         // Valid fields are preserved
         assert_eq!(settings.theme, ThemeMode::Dark);

--- a/crates/notebook/src/settings.rs
+++ b/crates/notebook/src/settings.rs
@@ -67,6 +67,10 @@ pub fn load_settings() -> SyncedSettings {
             .get("conda")
             .and_then(|v| serde_json::from_value(v.clone()).ok())
             .unwrap_or(defaults.conda),
+        keep_alive_secs: json
+            .get("keep_alive_secs")
+            .and_then(|v| serde_json::from_value(v.clone()).ok())
+            .unwrap_or(defaults.keep_alive_secs),
     }
 }
 

--- a/crates/runtimed/examples/test_inline_deps.rs
+++ b/crates/runtimed/examples/test_inline_deps.rs
@@ -58,6 +58,7 @@ async fn main() -> anyhow::Result<()> {
         conda_pool_size: 0,
         max_age_secs: 3600,
         lock_dir: Some(temp_dir.path().to_path_buf()),
+        room_eviction_delay_ms: None,
     };
     let socket_path = config.socket_path.clone();
     println!("Socket path: {:?}", socket_path);

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -53,6 +53,9 @@ pub struct DaemonConfig {
     pub max_age_secs: u64,
     /// Optional custom directory for lock files (used in tests).
     pub lock_dir: Option<PathBuf>,
+    /// Override for room eviction delay (milliseconds). Used in tests.
+    /// If None, uses the user's `keep_alive_secs` setting.
+    pub room_eviction_delay_ms: Option<u64>,
 }
 
 impl Default for DaemonConfig {
@@ -66,6 +69,7 @@ impl Default for DaemonConfig {
             conda_pool_size: 3,
             max_age_secs: 172800, // 2 days
             lock_dir: None,
+            room_eviction_delay_ms: None,
         }
     }
 }
@@ -384,6 +388,21 @@ impl Daemon {
     pub async fn trigger_shutdown(&self) {
         *self.shutdown.lock().await = true;
         self.shutdown_notify.notify_waiters();
+    }
+
+    /// Get the room eviction delay.
+    ///
+    /// Uses the config override if set (for tests), otherwise reads from
+    /// the user's `keep_alive_secs` setting.
+    pub async fn room_eviction_delay(&self) -> std::time::Duration {
+        if let Some(ms) = self.config.room_eviction_delay_ms {
+            return std::time::Duration::from_millis(ms);
+        }
+        let settings = self.settings.read().await;
+        let secs = settings
+            .get_u64("keep_alive_secs")
+            .unwrap_or(crate::settings_doc::DEFAULT_KEEP_ALIVE_SECS);
+        std::time::Duration::from_secs(secs)
     }
 
     /// Run the daemon server.

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -711,7 +711,7 @@ where
     }
 
     let result = if use_typed_frames {
-        run_sync_loop_v2(&mut reader, &mut writer, &room, daemon).await
+        run_sync_loop_v2(&mut reader, &mut writer, &room, daemon.clone()).await
     } else {
         run_sync_loop_v1(&mut reader, &mut writer, &room).await
     };
@@ -723,15 +723,15 @@ where
         // 1. Grace period during auto-launch (client may reconnect)
         // 2. Kernel running with no peers (idle timeout)
         // Without this, rooms with kernels would leak forever.
-        let eviction_delay = std::time::Duration::from_secs(30);
+        let eviction_delay = daemon.room_eviction_delay().await;
         let rooms_for_eviction = rooms.clone();
         let room_for_eviction = room.clone();
         let notebook_id_for_eviction = notebook_id.clone();
 
         info!(
-            "[notebook-sync] All peers disconnected from room {}, scheduling eviction check in {}s",
+            "[notebook-sync] All peers disconnected from room {}, scheduling eviction check in {:?}",
             notebook_id,
-            eviction_delay.as_secs()
+            eviction_delay
         );
 
         tokio::spawn(async move {

--- a/crates/runtimed/src/settings_doc.rs
+++ b/crates/runtimed/src/settings_doc.rs
@@ -134,6 +134,10 @@ pub struct CondaDefaults {
     pub default_packages: Vec<String>,
 }
 
+/// Default keep-alive duration in seconds for notebook rooms.
+/// When all clients disconnect, the daemon waits this long before evicting the room.
+pub const DEFAULT_KEEP_ALIVE_SECS: u64 = 30;
+
 /// Snapshot of all synced settings.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq, JsonSchema, TS)]
 #[ts(export)]
@@ -157,6 +161,15 @@ pub struct SyncedSettings {
     /// Conda environment defaults
     #[serde(default)]
     pub conda: CondaDefaults,
+
+    /// How long (in seconds) to keep notebook rooms alive after all clients disconnect.
+    /// This allows you to close and reopen the window without losing your kernel state.
+    #[serde(default = "default_keep_alive_secs")]
+    pub keep_alive_secs: u64,
+}
+
+fn default_keep_alive_secs() -> u64 {
+    DEFAULT_KEEP_ALIVE_SECS
 }
 
 /// Generate a JSON Schema string for the settings file.
@@ -200,6 +213,11 @@ impl SettingsDoc {
             automerge::ROOT,
             "default_python_env",
             defaults.default_python_env.to_string(),
+        );
+        let _ = doc.put(
+            automerge::ROOT,
+            "keep_alive_secs",
+            defaults.keep_alive_secs as i64,
         );
 
         // Nested uv map with empty package list
@@ -420,6 +438,30 @@ impl SettingsDoc {
         let _ = self.doc.put(automerge::ROOT, key, value);
     }
 
+    /// Get a u64 setting value from the root.
+    pub fn get_u64(&self, key: &str) -> Option<u64> {
+        self.doc
+            .get(automerge::ROOT, key)
+            .ok()
+            .flatten()
+            .and_then(|(value, _)| match value {
+                automerge::Value::Scalar(s) => match s.as_ref() {
+                    automerge::ScalarValue::Int(i) => Some(*i as u64),
+                    automerge::ScalarValue::Uint(u) => Some(*u),
+                    // Also support string for migration/JSON compatibility
+                    automerge::ScalarValue::Str(s) => s.parse().ok(),
+                    _ => None,
+                },
+                _ => None,
+            })
+    }
+
+    /// Set a u64 setting value at the root.
+    pub fn put_u64(&mut self, key: &str, value: u64) {
+        // Store as i64 since Automerge's Int is more widely supported
+        let _ = self.doc.put(automerge::ROOT, key, value as i64);
+    }
+
     /// Set a scalar setting value, supporting dotted paths for nested maps.
     pub fn put(&mut self, key: &str, value: &str) {
         if let Some((map_key, sub_key)) = key.split_once('.') {
@@ -485,8 +527,9 @@ impl SettingsDoc {
         }
     }
 
-    ///// Set a value from a `serde_json::Value` — dispatches to `put` for strings,
-    /// `put_list` for arrays, or `put_bool` for booleans. Used by Tauri commands.
+    /// Set a value from a `serde_json::Value` — dispatches to `put` for strings,
+    /// `put_list` for arrays, `put_bool` for booleans, or `put_u64` for numbers.
+    /// Used by Tauri commands.
     pub fn put_value(&mut self, key: &str, value: &serde_json::Value) {
         match value {
             serde_json::Value::String(s) => self.put(key, s),
@@ -498,6 +541,11 @@ impl SettingsDoc {
                 self.put_list(key, &items);
             }
             serde_json::Value::Bool(b) => self.put_bool(key, *b),
+            serde_json::Value::Number(n) => {
+                if let Some(u) = n.as_u64() {
+                    self.put_u64(key, u);
+                }
+            }
             _ => {}
         }
     }
@@ -578,6 +626,9 @@ impl SettingsDoc {
             conda: CondaDefaults {
                 default_packages: conda_packages,
             },
+            keep_alive_secs: self
+                .get_u64("keep_alive_secs")
+                .unwrap_or(defaults.keep_alive_secs),
         }
     }
 
@@ -631,6 +682,19 @@ impl SettingsDoc {
             let conda_packages = Self::extract_packages_from_json(json, "conda");
             if self.get_list("conda.default_packages") != conda_packages {
                 self.put_list("conda.default_packages", &conda_packages);
+                changed = true;
+            }
+        }
+
+        // keep_alive_secs (numeric)
+        if let Some(value) = json.get("keep_alive_secs").and_then(|v| v.as_u64()) {
+            let current = self.get_u64("keep_alive_secs");
+            if current != Some(value) {
+                info!(
+                    "[settings] apply_json_changes: keep_alive_secs changed {:?} -> {value}",
+                    current
+                );
+                self.put_u64("keep_alive_secs", value);
                 changed = true;
             }
         }

--- a/crates/runtimed/src/settings_doc.rs
+++ b/crates/runtimed/src/settings_doc.rs
@@ -300,6 +300,9 @@ impl SettingsDoc {
         if let Some(env) = json.get("default_python_env").and_then(|v| v.as_str()) {
             settings.put("default_python_env", env);
         }
+        if let Some(secs) = json.get("keep_alive_secs").and_then(|v| v.as_u64()) {
+            settings.put_u64("keep_alive_secs", secs);
+        }
 
         let uv_packages = Self::extract_packages_from_json(json, "uv");
         if !uv_packages.is_empty() {
@@ -446,7 +449,8 @@ impl SettingsDoc {
             .flatten()
             .and_then(|(value, _)| match value {
                 automerge::Value::Scalar(s) => match s.as_ref() {
-                    automerge::ScalarValue::Int(i) => Some(*i as u64),
+                    // Use try_from to prevent negative values wrapping to huge u64
+                    automerge::ScalarValue::Int(i) => u64::try_from(*i).ok(),
                     automerge::ScalarValue::Uint(u) => Some(*u),
                     // Also support string for migration/JSON compatibility
                     automerge::ScalarValue::Str(s) => s.parse().ok(),

--- a/crates/runtimed/src/sync_client.rs
+++ b/crates/runtimed/src/sync_client.rs
@@ -238,6 +238,14 @@ where
                     .collect();
                 self.put_list(key, &items)?;
             }
+            serde_json::Value::Number(n) => {
+                if let Some(u) = n.as_u64() {
+                    // Store as i64 since Automerge's Int is more widely supported
+                    self.doc
+                        .put(automerge::ROOT, key, u as i64)
+                        .map_err(|e| SyncClientError::SyncError(format!("put u64: {}", e)))?;
+                }
+            }
             _ => {}
         }
 
@@ -345,7 +353,8 @@ fn get_all_from_doc(doc: &AutoCommit) -> SyncedSettings {
             .flatten()
             .and_then(|(value, _)| match value {
                 automerge::Value::Scalar(s) => match s.as_ref() {
-                    automerge::ScalarValue::Int(i) => Some(*i as u64),
+                    // Use try_from to prevent negative values wrapping to huge u64
+                    automerge::ScalarValue::Int(i) => u64::try_from(*i).ok(),
                     automerge::ScalarValue::Uint(u) => Some(*u),
                     automerge::ScalarValue::Str(s) => s.parse().ok(),
                     _ => None,

--- a/crates/runtimed/src/sync_client.rs
+++ b/crates/runtimed/src/sync_client.rs
@@ -339,6 +339,21 @@ fn get_all_from_doc(doc: &AutoCommit) -> SyncedSettings {
             })
     };
 
+    let get_u64 = |key: &str| -> Option<u64> {
+        doc.get(automerge::ROOT, key)
+            .ok()
+            .flatten()
+            .and_then(|(value, _)| match value {
+                automerge::Value::Scalar(s) => match s.as_ref() {
+                    automerge::ScalarValue::Int(i) => Some(*i as u64),
+                    automerge::ScalarValue::Uint(u) => Some(*u),
+                    automerge::ScalarValue::Str(s) => s.parse().ok(),
+                    _ => None,
+                },
+                _ => None,
+            })
+    };
+
     // Read uv packages: try nested list, fall back to flat comma string
     let uv_packages = {
         let nested = read_nested_list(doc, "uv", "default_packages");
@@ -379,6 +394,7 @@ fn get_all_from_doc(doc: &AutoCommit) -> SyncedSettings {
         conda: CondaDefaults {
             default_packages: conda_packages,
         },
+        keep_alive_secs: get_u64("keep_alive_secs").unwrap_or(defaults.keep_alive_secs),
     }
 }
 

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -22,6 +22,7 @@ fn test_config(temp_dir: &TempDir) -> DaemonConfig {
         conda_pool_size: 0,
         max_age_secs: 3600,
         lock_dir: Some(temp_dir.path().to_path_buf()),
+        room_eviction_delay_ms: Some(50), // Fast eviction for tests
     }
 }
 
@@ -140,6 +141,7 @@ async fn test_singleton_prevents_second_daemon() {
         conda_pool_size: 0,
         max_age_secs: 3600,
         lock_dir: Some(temp_dir.path().to_path_buf()),
+        room_eviction_delay_ms: Some(50),
     };
 
     let result = Daemon::new(config2);

--- a/src/bindings/SyncedSettings.ts
+++ b/src/bindings/SyncedSettings.ts
@@ -28,4 +28,9 @@ uv: UvDefaults,
 /**
  * Conda environment defaults
  */
-conda: CondaDefaults, };
+conda: CondaDefaults, 
+/**
+ * How long (in seconds) to keep notebook rooms alive after all clients disconnect.
+ * This allows you to close and reopen the window without losing your kernel state.
+ */
+keep_alive_secs: bigint, };

--- a/src/hooks/useSyncedSettings.ts
+++ b/src/hooks/useSyncedSettings.ts
@@ -102,6 +102,7 @@ export function useSyncedSettings() {
   const [defaultCondaPackages, setDefaultCondaPackagesState] = useState<
     string[]
   >([]);
+  const [keepAliveSecs, setKeepAliveSecsState] = useState<number>(30);
 
   // Load initial settings from daemon
   useEffect(() => {
@@ -123,6 +124,11 @@ export function useSyncedSettings() {
         if (Array.isArray(settings.conda?.default_packages)) {
           setDefaultCondaPackagesState(settings.conda.default_packages);
         }
+        if (typeof settings.keep_alive_secs === "bigint") {
+          setKeepAliveSecsState(Number(settings.keep_alive_secs));
+        } else if (typeof settings.keep_alive_secs === "number") {
+          setKeepAliveSecsState(settings.keep_alive_secs);
+        }
       })
       .catch(() => {
         // Daemon unavailable — defaults are fine
@@ -136,6 +142,7 @@ export function useSyncedSettings() {
         theme: newTheme,
         default_runtime,
         default_python_env,
+        keep_alive_secs,
       } = event.payload;
       if (isValidTheme(newTheme)) {
         setThemeState(newTheme);
@@ -152,6 +159,11 @@ export function useSyncedSettings() {
       }
       if (Array.isArray(event.payload.conda?.default_packages)) {
         setDefaultCondaPackagesState(event.payload.conda.default_packages);
+      }
+      if (typeof keep_alive_secs === "bigint") {
+        setKeepAliveSecsState(Number(keep_alive_secs));
+      } else if (typeof keep_alive_secs === "number") {
+        setKeepAliveSecsState(keep_alive_secs);
       }
     });
     return () => {
@@ -199,6 +211,14 @@ export function useSyncedSettings() {
     }).catch(() => {});
   }, []);
 
+  const setKeepAliveSecs = useCallback((secs: number) => {
+    setKeepAliveSecsState(secs);
+    invoke("set_synced_setting", {
+      key: "keep_alive_secs",
+      value: secs,
+    }).catch(() => {});
+  }, []);
+
   return {
     theme,
     setTheme,
@@ -210,6 +230,8 @@ export function useSyncedSettings() {
     setDefaultUvPackages,
     defaultCondaPackages,
     setDefaultCondaPackages,
+    keepAliveSecs,
+    setKeepAliveSecs,
   };
 }
 


### PR DESCRIPTION
## Summary

Add a user-facing "Keep Alive" setting that controls how long the daemon keeps notebook rooms alive after all clients disconnect. This allows users to close the app window and reconnect without losing kernel state.

### What Changed

- Add `keep_alive_secs` to `SyncedSettings` (default 30 seconds)
- Add numeric getter/setter methods (`get_u64`/`put_u64`) to `SettingsDoc` for numeric settings
- Make room eviction delay configurable in `DaemonConfig` with optional test override
- Use setting value in eviction logic via `daemon.room_eviction_delay()`
- Add test override for fast eviction (50ms) to fix `test_notebook_room_eviction_and_persistence`
- Add "Keep Alive" input to settings panel under "Advanced" section
- Sync setting across all notebook windows via daemon

### Why

This fixes `test_notebook_room_eviction_and_persistence` which was failing because tests waited 200ms but the eviction delay was hardcoded at 30 seconds. The room wasn't evicted in time, so reconnecting clients got stale state instead of a fresh room.

The user-facing setting allows customization of this behavior for different workflows — some may want longer timeouts to keep kernels alive through window switches, others may prefer faster cleanup.

## Verification

- [ ] `cargo test -p runtimed test_notebook_room_eviction_and_persistence` passes
- [ ] All integration tests pass
- [ ] Settings panel loads with new "Keep Alive" control in Advanced section
- [ ] Changing Keep Alive value syncs across multiple notebook windows
- [ ] Default value is 30 seconds

_PR submitted by @rgbkrk's agent, Quill_