### PR TITLE
feat(xtask): show actual worktree hash in dev-daemon output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8682,6 +8682,7 @@ name = "xtask"
 version = "0.1.0"
 dependencies = [
  "dirs 5.0.1",
+ "runt-workspace",
  "serde_json",
 ]
 

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -9,4 +9,5 @@ workspace = true
 
 [dependencies]
 dirs = "5"
+runt-workspace = { path = "../runt-workspace" }
 serde_json.workspace = true

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -459,9 +459,14 @@ fn cmd_dev_daemon() {
         .join("runt")
         .join("worktrees");
 
+    let state_dir = match runt_workspace::get_workspace_path() {
+        Some(path) => cache_base.join(runt_workspace::worktree_hash(&path)),
+        None => cache_base.join("<unknown>"),
+    };
+
     println!();
     println!("Starting development daemon for this worktree...");
-    println!("State will be stored in {}/<hash>/", cache_base.display());
+    println!("State will be stored in {}/", state_dir.display());
     println!("Press Ctrl+C to stop.");
     println!();
 


### PR DESCRIPTION
Display the computed 12-character worktree hash instead of a placeholder in the dev-daemon startup message, making it easier to locate the daemon's state directory and cross-reference with `runt daemon status` output.

## Verification

- Output now shows full path with actual hash: `/Users/.../.cache/runt/worktrees/a1b2c3d4e5f6/`
- Tested build and all unit tests pass

_PR submitted by @rgbkrk's agent, Quill_