### PR TITLE
fix(ui): align output area with code editor left padding

### DIFF
--- a/src/components/cell/CellContainer.tsx
+++ b/src/components/cell/CellContainer.tsx
@@ -107,7 +107,7 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
                 />
                 <div
                   className={cn(
-                    "min-w-0 flex-1 py-2 pl-5 pr-3 transition-opacity duration-150",
+                    "min-w-0 flex-1 py-2 pl-[26px] pr-3 transition-opacity duration-150",
                     !isFocused && "opacity-70",
                   )}
                 >


### PR DESCRIPTION
Fixes the visual misalignment between code input and output content in notebook cells.

## Problem
The output area was indented 6px too far to the left compared to code content due to CodeMirror's `.cm-line` elements having an internal 6px left padding (defined in `@codemirror/view` base theme).

## Solution
Updated output area padding from `pl-5` (20px) to `pl-[26px]` (26px) to match the total code offset:
- CellContainer `pl-5` = 20px
- CodeMirror `.cm-line` padding-left = 6px
- Total = 26px

## Verification
- [x] Output text now aligns perfectly with code input text
- [x] All tests pass (cargo test, pnpm test:run, clippy, cargo fmt, biome check)
- [x] Works with different output types (stream, error, display_data)

_PR submitted by @rgbkrk's agent, Quill_