### PR TITLE
fix(runtimed): add minimum keep-alive constraint and improve UX

### DIFF
--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -854,27 +854,35 @@ export function NotebookToolbar({
                     Advanced
                   </span>
                 </div>
-                <div className="flex items-center gap-3">
-                  <span className="text-xs font-medium text-muted-foreground">
-                    Keep Alive
-                  </span>
+                <div className="space-y-2">
+                  <div className="flex items-center justify-between">
+                    <span className="text-xs font-medium text-muted-foreground">
+                      Keep Alive
+                    </span>
+                    <span className="text-xs font-medium text-foreground tabular-nums">
+                      {keepAliveSecs >= 3600
+                        ? "Forever"
+                        : keepAliveSecs >= 60
+                          ? `${Math.floor(keepAliveSecs / 60)}m ${keepAliveSecs % 60}s`
+                          : `${keepAliveSecs}s`}
+                    </span>
+                  </div>
                   <input
-                    type="number"
-                    min={0}
+                    type="range"
+                    min={5}
                     max={3600}
                     step={5}
                     value={keepAliveSecs}
                     onChange={(e) =>
-                      onKeepAliveSecsChange(
-                        Math.max(0, Math.min(3600, Number(e.target.value))),
-                      )
+                      onKeepAliveSecsChange(Number(e.target.value))
                     }
-                    className="w-20 rounded-md border bg-muted/50 px-2 py-1 text-xs text-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+                    className="w-full h-1.5 rounded-full bg-muted appearance-none cursor-pointer accent-primary [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-3 [&::-webkit-slider-thumb]:h-3 [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-primary [&::-webkit-slider-thumb]:cursor-pointer [&::-moz-range-thumb]:w-3 [&::-moz-range-thumb]:h-3 [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:bg-primary [&::-moz-range-thumb]:border-0 [&::-moz-range-thumb]:cursor-pointer"
                   />
-                  <span className="text-xs text-muted-foreground">seconds</span>
-                  <span className="text-[10px] text-muted-foreground/70 ml-2">
-                    Time to keep notebook room alive after closing
-                  </span>
+                  <div className="flex justify-between text-[10px] text-muted-foreground/70">
+                    <span>5s</span>
+                    <span>Time to keep notebook room alive after closing</span>
+                    <span>Forever</span>
+                  </div>
                 </div>
               </div>
             )}

--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -27,6 +27,101 @@ import type { EnvProgressState } from "../hooks/useEnvProgress";
 import type { UpdateStatus } from "../hooks/useUpdater";
 import type { KernelspecInfo } from "../types";
 
+/** Format seconds into human-readable duration */
+function formatDuration(secs: number): string {
+  if (secs >= 3600) return "Forever";
+  if (secs >= 60) {
+    const mins = Math.floor(secs / 60);
+    const remainingSecs = secs % 60;
+    return remainingSecs > 0 ? `${mins}m ${remainingSecs}s` : `${mins}m`;
+  }
+  return `${secs}s`;
+}
+
+/** Keep Alive slider with fill effect - only emits on release */
+function KeepAliveSlider({
+  value,
+  onChange,
+}: {
+  value: number;
+  onChange: (value: number) => void;
+}) {
+  const [localValue, setLocalValue] = useState(value);
+  const isDragging = useRef(false);
+
+  // Sync local value when prop changes (but not during drag)
+  useEffect(() => {
+    if (!isDragging.current) {
+      setLocalValue(value);
+    }
+  }, [value]);
+
+  const min = 5;
+  const max = 3600;
+  const percentage = ((localValue - min) / (max - min)) * 100;
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    isDragging.current = true;
+    setLocalValue(Number(e.target.value));
+  };
+
+  const handleRelease = () => {
+    isDragging.current = false;
+    onChange(localValue);
+  };
+
+  return (
+    <div className="space-y-3 pt-2 border-t border-border/50">
+      <div>
+        <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+          Advanced
+        </span>
+      </div>
+      <div className="space-y-1">
+        <div className="flex items-center justify-between">
+          <span className="text-xs font-medium text-muted-foreground">
+            Keep Alive
+          </span>
+          <span className="text-xs font-medium text-foreground tabular-nums">
+            {formatDuration(localValue)}
+          </span>
+        </div>
+        <p className="text-[10px] text-muted-foreground/70">
+          Time to keep notebook runtime alive after closing
+        </p>
+      </div>
+      <div className="px-1 py-2">
+        <div className="relative h-2">
+          {/* Track background */}
+          <div className="absolute inset-0 rounded-full bg-muted" />
+          {/* Fill */}
+          <div
+            className="absolute inset-y-0 left-0 rounded-full bg-primary/80"
+            style={{ width: `${percentage}%` }}
+          />
+          {/* Input */}
+          <input
+            type="range"
+            min={min}
+            max={max}
+            step={5}
+            value={localValue}
+            onChange={handleChange}
+            onMouseUp={handleRelease}
+            onTouchEnd={handleRelease}
+            onKeyUp={handleRelease}
+            className="absolute inset-0 w-full h-full appearance-none bg-transparent cursor-pointer [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-3.5 [&::-webkit-slider-thumb]:h-3.5 [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-primary [&::-webkit-slider-thumb]:shadow-sm [&::-webkit-slider-thumb]:cursor-pointer [&::-webkit-slider-thumb]:border-2 [&::-webkit-slider-thumb]:border-background [&::-moz-range-thumb]:w-3.5 [&::-moz-range-thumb]:h-3.5 [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:bg-primary [&::-moz-range-thumb]:shadow-sm [&::-moz-range-thumb]:border-2 [&::-moz-range-thumb]:border-background [&::-moz-range-thumb]:cursor-pointer"
+          />
+        </div>
+      </div>
+      <div className="flex justify-between text-[10px] text-muted-foreground/70 px-1">
+        <span>5s</span>
+        <span>Forever</span>
+      </div>
+    </div>
+  );
+}
+
 /** Deno logo icon (from tabler icons) */
 function DenoIcon({ className }: { className?: string }) {
   return (
@@ -848,43 +943,10 @@ export function NotebookToolbar({
 
             {/* Advanced settings */}
             {onKeepAliveSecsChange && (
-              <div className="space-y-2 pt-2 border-t border-border/50">
-                <div>
-                  <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
-                    Advanced
-                  </span>
-                </div>
-                <div className="space-y-2">
-                  <div className="flex items-center justify-between">
-                    <span className="text-xs font-medium text-muted-foreground">
-                      Keep Alive
-                    </span>
-                    <span className="text-xs font-medium text-foreground tabular-nums">
-                      {keepAliveSecs >= 3600
-                        ? "Forever"
-                        : keepAliveSecs >= 60
-                          ? `${Math.floor(keepAliveSecs / 60)}m ${keepAliveSecs % 60}s`
-                          : `${keepAliveSecs}s`}
-                    </span>
-                  </div>
-                  <input
-                    type="range"
-                    min={5}
-                    max={3600}
-                    step={5}
-                    value={keepAliveSecs}
-                    onChange={(e) =>
-                      onKeepAliveSecsChange(Number(e.target.value))
-                    }
-                    className="w-full h-1.5 rounded-full bg-muted appearance-none cursor-pointer accent-primary [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-3 [&::-webkit-slider-thumb]:h-3 [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-primary [&::-webkit-slider-thumb]:cursor-pointer [&::-moz-range-thumb]:w-3 [&::-moz-range-thumb]:h-3 [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:bg-primary [&::-moz-range-thumb]:border-0 [&::-moz-range-thumb]:cursor-pointer"
-                  />
-                  <div className="flex justify-between text-[10px] text-muted-foreground/70">
-                    <span>5s</span>
-                    <span>Time to keep notebook room alive after closing</span>
-                    <span>Forever</span>
-                  </div>
-                </div>
-              </div>
+              <KeepAliveSlider
+                value={keepAliveSecs}
+                onChange={onKeepAliveSecsChange}
+              />
             )}
           </div>
         </CollapsibleContent>

--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -20,6 +20,7 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
+import { Slider } from "@/components/ui/slider";
 import type { ThemeMode } from "@/hooks/useSyncedSettings";
 import { isKnownPythonEnv, isKnownRuntime } from "@/hooks/useSyncedSettings";
 import { cn } from "@/lib/utils";
@@ -38,7 +39,7 @@ function formatDuration(secs: number): string {
   return `${secs}s`;
 }
 
-/** Keep Alive slider with fill effect - only emits on release */
+/** Keep Alive slider - uses Radix Slider for consistency with widget controls */
 function KeepAliveSlider({
   value,
   onChange,
@@ -47,28 +48,11 @@ function KeepAliveSlider({
   onChange: (value: number) => void;
 }) {
   const [localValue, setLocalValue] = useState(value);
-  const isDragging = useRef(false);
 
-  // Sync local value when prop changes (but not during drag)
+  // Sync local value when prop changes externally
   useEffect(() => {
-    if (!isDragging.current) {
-      setLocalValue(value);
-    }
+    setLocalValue(value);
   }, [value]);
-
-  const min = 5;
-  const max = 3600;
-  const percentage = ((localValue - min) / (max - min)) * 100;
-
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    isDragging.current = true;
-    setLocalValue(Number(e.target.value));
-  };
-
-  const handleRelease = () => {
-    isDragging.current = false;
-    onChange(localValue);
-  };
 
   return (
     <div className="space-y-3 pt-2 border-t border-border/50">
@@ -90,31 +74,17 @@ function KeepAliveSlider({
           Time to keep notebook runtime alive after closing
         </p>
       </div>
-      <div className="px-1 py-2">
-        <div className="relative h-2">
-          {/* Track background */}
-          <div className="absolute inset-0 rounded-full bg-muted" />
-          {/* Fill */}
-          <div
-            className="absolute inset-y-0 left-0 rounded-full bg-primary/80"
-            style={{ width: `${percentage}%` }}
-          />
-          {/* Input */}
-          <input
-            type="range"
-            min={min}
-            max={max}
-            step={5}
-            value={localValue}
-            onChange={handleChange}
-            onMouseUp={handleRelease}
-            onTouchEnd={handleRelease}
-            onKeyUp={handleRelease}
-            className="absolute inset-0 w-full h-full appearance-none bg-transparent cursor-pointer [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-3.5 [&::-webkit-slider-thumb]:h-3.5 [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-primary [&::-webkit-slider-thumb]:shadow-sm [&::-webkit-slider-thumb]:cursor-pointer [&::-webkit-slider-thumb]:border-2 [&::-webkit-slider-thumb]:border-background [&::-moz-range-thumb]:w-3.5 [&::-moz-range-thumb]:h-3.5 [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:bg-primary [&::-moz-range-thumb]:shadow-sm [&::-moz-range-thumb]:border-2 [&::-moz-range-thumb]:border-background [&::-moz-range-thumb]:cursor-pointer"
-          />
-        </div>
+      <div className="py-2">
+        <Slider
+          value={[localValue]}
+          min={5}
+          max={3600}
+          step={5}
+          onValueChange={(v) => setLocalValue(v[0])}
+          onValueCommit={(v) => onChange(v[0])}
+        />
       </div>
-      <div className="flex justify-between text-[10px] text-muted-foreground/70 px-1">
+      <div className="flex justify-between text-[10px] text-muted-foreground/70">
         <span>5s</span>
         <span>Forever</span>
       </div>

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -393,7 +393,8 @@ impl Daemon {
     /// Get the room eviction delay.
     ///
     /// Uses the config override if set (for tests), otherwise reads from
-    /// the user's `keep_alive_secs` setting.
+    /// the user's `keep_alive_secs` setting. Enforces a minimum of 5 seconds
+    /// to prevent accidental instant eviction from misconfigured settings.
     pub async fn room_eviction_delay(&self) -> std::time::Duration {
         if let Some(ms) = self.config.room_eviction_delay_ms {
             return std::time::Duration::from_millis(ms);
@@ -402,6 +403,8 @@ impl Daemon {
         let secs = settings
             .get_u64("keep_alive_secs")
             .unwrap_or(crate::settings_doc::DEFAULT_KEEP_ALIVE_SECS);
+        // Enforce minimum to prevent instant eviction from bad settings
+        let secs = secs.max(crate::settings_doc::MIN_KEEP_ALIVE_SECS);
         std::time::Duration::from_secs(secs)
     }
 

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -605,7 +605,7 @@ pub fn get_or_create_room(
     rooms
         .entry(notebook_id.to_string())
         .or_insert_with(|| {
-            debug!("[notebook-sync] Creating room for {}", notebook_id);
+            info!("[notebook-sync] Creating room for {}", notebook_id);
             Arc::new(NotebookRoom::new_fresh(notebook_id, docs_dir, blob_store))
         })
         .clone()

--- a/crates/runtimed/src/settings_doc.rs
+++ b/crates/runtimed/src/settings_doc.rs
@@ -138,8 +138,11 @@ pub struct CondaDefaults {
 /// When all clients disconnect, the daemon waits this long before evicting the room.
 pub const DEFAULT_KEEP_ALIVE_SECS: u64 = 30;
 
+/// Minimum keep-alive duration (5 seconds) to prevent accidental instant eviction.
+pub const MIN_KEEP_ALIVE_SECS: u64 = 5;
+
 /// Snapshot of all synced settings.
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq, JsonSchema, TS)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, JsonSchema, TS)]
 #[ts(export)]
 pub struct SyncedSettings {
     /// UI theme
@@ -164,8 +167,22 @@ pub struct SyncedSettings {
 
     /// How long (in seconds) to keep notebook rooms alive after all clients disconnect.
     /// This allows you to close and reopen the window without losing your kernel state.
+    /// Minimum is 5 seconds to prevent accidental instant eviction.
     #[serde(default = "default_keep_alive_secs")]
     pub keep_alive_secs: u64,
+}
+
+impl Default for SyncedSettings {
+    fn default() -> Self {
+        Self {
+            theme: ThemeMode::default(),
+            default_runtime: Runtime::default(),
+            default_python_env: PythonEnvType::default(),
+            uv: UvDefaults::default(),
+            conda: CondaDefaults::default(),
+            keep_alive_secs: DEFAULT_KEEP_ALIVE_SECS,
+        }
+    }
 }
 
 fn default_keep_alive_secs() -> u64 {


### PR DESCRIPTION
## Summary

- Fixed `keep_alive_secs` defaulting to 0 due to `#[derive(Default)]` using `u64::default()`
- Added `MIN_KEEP_ALIVE_SECS` (5s) to prevent accidental instant eviction
- Upgraded room creation logging from debug to info level
- Replaced number input with a slider (5s to "Forever")

## Changes

**Backend:**
- Implement `Default` manually for `SyncedSettings` with 30s keep-alive default
- Add minimum enforcement in `daemon.room_eviction_delay()`
- Log room creation at info level for better observability

**Frontend:**
- Replace number input with slider (min 5s, max 3600s)
- Show human-readable time format ("2m 30s", "Forever" at max)
- Display min/max labels on slider endpoints

## Verification

- [x] Test slider in settings panel
- [x] Verify minimum 5s enforced when setting low values
- [x] Check daemon logs show room creation at info level

_PR submitted by @rgbkrk's agent, Quill_