### PR TITLE
refactor(settings): daemon is sole writer to settings.json

### DIFF
--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -2823,26 +2823,6 @@ async fn get_settings() -> runtimed::settings_doc::SyncedSettings {
     settings::load_settings()
 }
 
-/// Set the default runtime preference
-#[tauri::command]
-async fn set_default_runtime(runtime: Runtime) -> Result<(), String> {
-    let mut settings = settings::load_settings();
-    settings.default_runtime = runtime;
-    settings::save_settings(&settings).map_err(|e| e.to_string())
-}
-
-/// Set the default Python environment type (uv or conda)
-#[tauri::command]
-async fn set_default_python_env(env_type: String) -> Result<(), String> {
-    let python_env: settings::PythonEnvType = env_type
-        .parse()
-        .expect("FromStr for PythonEnvType is infallible");
-
-    let mut settings = settings::load_settings();
-    settings.default_python_env = python_env;
-    settings::save_settings(&settings).map_err(|e| e.to_string())
-}
-
 /// Get synced settings from the Automerge settings document via runtimed.
 /// Falls back to reading settings.json when the daemon is unavailable,
 /// so the frontend always gets real settings instead of hardcoded defaults.
@@ -2873,116 +2853,25 @@ async fn get_synced_settings() -> Result<runtimed::settings_doc::SyncedSettings,
     }
 }
 
-/// Persist a setting to local settings.json (for keys that have local representation).
-fn save_setting_locally(key: &str, value: &serde_json::Value) -> Result<(), String> {
-    match key {
-        "theme" => {
-            let value_str = value.as_str().ok_or("expected string")?;
-            let theme: runtimed::settings_doc::ThemeMode =
-                serde_json::from_str(&format!("\"{value_str}\"")).map_err(|e| e.to_string())?;
-            let mut s = settings::load_settings();
-            s.theme = theme;
-            settings::save_settings(&s).map_err(|e| e.to_string())
-        }
-        "default_runtime" => {
-            let value_str = value.as_str().ok_or("expected string")?;
-            let runtime: Runtime =
-                serde_json::from_str(&format!("\"{}\"", value_str)).map_err(|e| e.to_string())?;
-            let mut s = settings::load_settings();
-            s.default_runtime = runtime;
-            settings::save_settings(&s).map_err(|e| e.to_string())
-        }
-        "default_python_env" => {
-            let value_str = value.as_str().ok_or("expected string")?;
-            let env_type: settings::PythonEnvType = value_str
-                .parse()
-                .expect("FromStr for PythonEnvType is infallible");
-            let mut s = settings::load_settings();
-            s.default_python_env = env_type;
-            settings::save_settings(&s).map_err(|e| e.to_string())
-        }
-        "uv.default_packages" => {
-            let packages = json_value_to_string_vec(value);
-            let mut s = settings::load_settings();
-            s.uv.default_packages = packages;
-            settings::save_settings(&s).map_err(|e| e.to_string())
-        }
-        "conda.default_packages" => {
-            let packages = json_value_to_string_vec(value);
-            let mut s = settings::load_settings();
-            s.conda.default_packages = packages;
-            settings::save_settings(&s).map_err(|e| e.to_string())
-        }
-        "keep_alive_secs" => {
-            let secs = value.as_u64().ok_or("expected number")?;
-            let mut s = settings::load_settings();
-            s.keep_alive_secs = secs;
-            settings::save_settings(&s).map_err(|e| e.to_string())
-        }
-        _ => Ok(()),
-    }
-}
-
-/// Extract a Vec<String> from a JSON value (array of strings).
-fn json_value_to_string_vec(value: &serde_json::Value) -> Vec<String> {
-    match value {
-        serde_json::Value::Array(arr) => arr
-            .iter()
-            .filter_map(|v| v.as_str().map(String::from))
-            .collect(),
-        serde_json::Value::String(s) => runtimed::settings_doc::split_comma_list(s),
-        _ => vec![],
-    }
-}
-
-/// Update a synced setting via the daemon and persist locally.
+/// Update a synced setting via the daemon.
+///
+/// The daemon is the sole writer to settings.json to prevent race conditions
+/// when multiple notebook windows are open. The daemon persists settings to disk
+/// after receiving the sync message.
 #[tauri::command]
 async fn set_synced_setting(key: String, value: serde_json::Value) -> Result<(), String> {
-    // Always persist to local settings.json so the menu handler can read it synchronously
-    save_setting_locally(&key, &value)?;
+    let socket_path = runtimed::default_socket_path();
+    let mut client = runtimed::sync_client::SyncClient::connect_with_timeout(
+        socket_path,
+        std::time::Duration::from_millis(500),
+    )
+    .await
+    .map_err(|e| format!("Daemon unavailable: {}. Setting not persisted.", e))?;
 
-    // Best-effort sync via daemon — use a short timeout since local write already succeeded
-    #[cfg(unix)]
-    {
-        let socket_path = runtimed::default_socket_path();
-        match runtimed::sync_client::SyncClient::connect_with_timeout(
-            socket_path,
-            std::time::Duration::from_millis(500),
-        )
+    client
+        .put_value(&key, &value)
         .await
-        {
-            Ok(mut client) => {
-                client
-                    .put_value(&key, &value)
-                    .await
-                    .map_err(|e| format!("sync error: {}", e))?;
-            }
-            Err(e) => {
-                log::warn!("[settings] Sync daemon unavailable ({}), local-only", e);
-            }
-        }
-    }
-
-    #[cfg(windows)]
-    {
-        let socket_path = runtimed::default_socket_path();
-        match runtimed::sync_client::SyncClient::connect_with_timeout(
-            socket_path,
-            std::time::Duration::from_millis(500),
-        )
-        .await
-        {
-            Ok(mut client) => {
-                client
-                    .put_value(&key, &value)
-                    .await
-                    .map_err(|e| format!("sync error: {}", e))?;
-            }
-            Err(e) => {
-                log::warn!("[settings] Sync daemon unavailable ({}), local-only", e);
-            }
-        }
-    }
+        .map_err(|e| format!("sync error: {}", e))?;
 
     Ok(())
 }
@@ -3354,8 +3243,6 @@ pub fn run(
             check_formatter_available,
             // Settings
             get_settings,
-            set_default_runtime,
-            set_default_python_env,
             // Synced settings (via runtimed Automerge)
             get_synced_settings,
             set_synced_setting,

--- a/crates/notebook/src/settings.rs
+++ b/crates/notebook/src/settings.rs
@@ -5,9 +5,12 @@
 //! - Linux: ~/.config/nteract/settings.json
 //! - Windows: C:\Users\<User>\AppData\Roaming\nteract\settings.json
 //!
+//! The daemon (runtimed) is the sole writer to settings.json to prevent race
+//! conditions when multiple notebook windows are open. This module only reads
+//! settings for fallback when the daemon is unavailable.
+//!
 //! Uses `runtimed::settings_doc::SyncedSettings` as the canonical settings type.
 
-use anyhow::Result;
 use runtimed::settings_doc::SyncedSettings;
 use std::path::PathBuf;
 
@@ -72,27 +75,6 @@ pub fn load_settings() -> SyncedSettings {
             .and_then(|v| serde_json::from_value(v.clone()).ok())
             .unwrap_or(defaults.keep_alive_secs),
     }
-}
-
-/// Save settings to disk.
-///
-/// Injects a `$schema` key pointing to the companion schema file so editors
-/// can provide autocomplete and validation.
-pub fn save_settings(settings: &SyncedSettings) -> Result<()> {
-    let path = settings_path();
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
-    let mut json_value = serde_json::to_value(settings)?;
-    if let Some(obj) = json_value.as_object_mut() {
-        obj.insert(
-            "$schema".to_string(),
-            serde_json::Value::String("./settings.schema.json".to_string()),
-        );
-    }
-    let json = serde_json::to_string_pretty(&json_value)?;
-    std::fs::write(&path, format!("{json}\n"))?;
-    Ok(())
 }
 
 #[cfg(test)]

--- a/src/hooks/useSyncedSettings.ts
+++ b/src/hooks/useSyncedSettings.ts
@@ -174,8 +174,8 @@ export function useSyncedSettings() {
   const setTheme = useCallback((newTheme: ThemeMode) => {
     setThemeState(newTheme);
     setStoredTheme(newTheme);
-    invoke("set_synced_setting", { key: "theme", value: newTheme }).catch(
-      () => {},
+    invoke("set_synced_setting", { key: "theme", value: newTheme }).catch((e) =>
+      console.warn("[settings] Failed to persist theme:", e),
     );
   }, []);
 
@@ -184,7 +184,7 @@ export function useSyncedSettings() {
     invoke("set_synced_setting", {
       key: "default_runtime",
       value: newRuntime,
-    }).catch(() => {});
+    }).catch((e) => console.warn("[settings] Failed to persist runtime:", e));
   }, []);
 
   const setDefaultPythonEnv = useCallback((newEnv: string) => {
@@ -192,7 +192,9 @@ export function useSyncedSettings() {
     invoke("set_synced_setting", {
       key: "default_python_env",
       value: newEnv,
-    }).catch(() => {});
+    }).catch((e) =>
+      console.warn("[settings] Failed to persist python env:", e),
+    );
   }, []);
 
   const setDefaultUvPackages = useCallback((packages: string[]) => {
@@ -200,7 +202,9 @@ export function useSyncedSettings() {
     invoke("set_synced_setting", {
       key: "uv.default_packages",
       value: packages,
-    }).catch(() => {});
+    }).catch((e) =>
+      console.warn("[settings] Failed to persist uv packages:", e),
+    );
   }, []);
 
   const setDefaultCondaPackages = useCallback((packages: string[]) => {
@@ -208,7 +212,9 @@ export function useSyncedSettings() {
     invoke("set_synced_setting", {
       key: "conda.default_packages",
       value: packages,
-    }).catch(() => {});
+    }).catch((e) =>
+      console.warn("[settings] Failed to persist conda packages:", e),
+    );
   }, []);
 
   const setKeepAliveSecs = useCallback((secs: number) => {
@@ -216,7 +222,9 @@ export function useSyncedSettings() {
     invoke("set_synced_setting", {
       key: "keep_alive_secs",
       value: secs,
-    }).catch(() => {});
+    }).catch((e) =>
+      console.warn("[settings] Failed to persist keep_alive_secs:", e),
+    );
   }, []);
 
   return {


### PR DESCRIPTION
## Summary

- Fix race condition where multiple notebook windows could write to `settings.json` simultaneously
- The daemon already persists settings to disk via `persist_settings()` in `sync_server.rs` after receiving sync messages - we just needed to stop windows from also writing
- Return error when daemon unavailable so frontend knows setting wasn't persisted

## Changes

- Remove `save_setting_locally()` call from `set_synced_setting` command
- Remove `save_setting_locally()` and `json_value_to_string_vec()` helpers  
- Remove legacy `set_default_runtime` and `set_default_python_env` commands that bypassed sync
- Remove `save_settings()` from `settings.rs` (now a read-only fallback module)

## Test plan

- [ ] Open 2+ notebook windows
- [ ] Change settings rapidly in both windows
- [ ] Verify no file corruption in `~/.config/nteract/settings.json`
- [ ] Change default runtime, press Cmd+N, verify new notebook uses correct runtime
- [ ] Stop daemon, try to change setting, verify error is returned

Closes #452