### PR TITLE
fix(ui): align isolated renderer styling with main app

### DIFF
--- a/src/components/isolated/frame-html.ts
+++ b/src/components/isolated/frame-html.ts
@@ -58,14 +58,9 @@ export function generateFrameHtml(options: FrameHtmlOptions = {}): string {
       margin: 0;
       padding: 0;
       font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-      font-size: 14px;
       line-height: 1.5;
       background: transparent;
       color: var(--text-primary);
-    }
-
-    body {
-      padding: 8px;
     }
 
     /* Output container */

--- a/src/isolated-renderer/styles.css
+++ b/src/isolated-renderer/styles.css
@@ -113,6 +113,20 @@ pre, code {
   @apply font-mono text-sm;
 }
 
+/* ANSI output styling - ensure consistent appearance with non-isolated outputs */
+[data-slot="ansi-output"] {
+  @apply font-mono text-sm whitespace-pre-wrap leading-relaxed;
+}
+
+[data-slot="ansi-stream-output"] {
+  @apply py-2 text-gray-700;
+}
+
+.dark [data-slot="ansi-stream-output"],
+[data-theme="dark"] [data-slot="ansi-stream-output"] {
+  @apply text-gray-300;
+}
+
 /* Output item spacing */
 .output-item {
   margin-bottom: 8px;

--- a/src/isolated-renderer/styles.css
+++ b/src/isolated-renderer/styles.css
@@ -101,30 +101,15 @@ html, body {
   margin: 0;
   padding: 0;
   font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-  font-size: 14px;
   line-height: 1.5;
   background: transparent;
   color: var(--foreground);
 }
 
 
-/* Code font - uses Tailwind's text-sm to match main app output styling */
+/* Code font */
 pre, code {
-  @apply font-mono text-sm;
-}
-
-/* ANSI output styling - ensure consistent appearance with non-isolated outputs */
-[data-slot="ansi-output"] {
-  @apply font-mono text-sm whitespace-pre-wrap leading-relaxed;
-}
-
-[data-slot="ansi-stream-output"] {
-  @apply py-2 text-gray-700;
-}
-
-.dark [data-slot="ansi-stream-output"],
-[data-theme="dark"] [data-slot="ansi-stream-output"] {
-  @apply text-gray-300;
+  @apply font-mono;
 }
 
 /* Output item spacing */

--- a/src/isolated-renderer/styles.css
+++ b/src/isolated-renderer/styles.css
@@ -4,6 +4,7 @@
  */
 
 @import "tailwindcss";
+@import "../styles/ansi.css";
 
 /* Source paths for Tailwind to scan for class names */
 @source "../components/outputs/**/*.{ts,tsx}";
@@ -106,9 +107,6 @@ html, body {
   color: var(--foreground);
 }
 
-body {
-  padding: 8px;
-}
 
 /* Code font - uses Tailwind's text-sm to match main app output styling */
 pre, code {

--- a/src/isolated-renderer/styles.css
+++ b/src/isolated-renderer/styles.css
@@ -107,16 +107,9 @@ html, body {
 }
 
 
-/* Code font - match main app's monospace font stack and size */
+/* Code font - match main app's monospace font stack */
 pre, code {
   font-family: "SF Mono", Consolas, Monaco, "Andale Mono", monospace;
-}
-
-/* ANSI output - override text-sm's rem-based size with explicit 14px to match main app */
-[data-slot="ansi-output"],
-[data-slot="ansi-output"] code {
-  font-size: 14px;
-  line-height: 1.625;
 }
 
 /* Output item spacing */

--- a/src/isolated-renderer/styles.css
+++ b/src/isolated-renderer/styles.css
@@ -107,9 +107,16 @@ html, body {
 }
 
 
-/* Code font - match main app's monospace font stack */
+/* Code font - match main app's monospace font stack and size */
 pre, code {
   font-family: "SF Mono", Consolas, Monaco, "Andale Mono", monospace;
+}
+
+/* ANSI output - override text-sm's rem-based size with explicit 14px to match main app */
+[data-slot="ansi-output"],
+[data-slot="ansi-output"] code {
+  font-size: 14px;
+  line-height: 1.625;
 }
 
 /* Output item spacing */

--- a/src/isolated-renderer/styles.css
+++ b/src/isolated-renderer/styles.css
@@ -107,9 +107,9 @@ html, body {
 }
 
 
-/* Code font */
+/* Code font - match main app's monospace font stack */
 pre, code {
-  @apply font-mono;
+  font-family: "SF Mono", Consolas, Monaco, "Andale Mono", monospace;
 }
 
 /* Output item spacing */


### PR DESCRIPTION
## Summary

Fixed styling inconsistencies between isolated iframe outputs and non-isolated outputs:

- **Removed hardcoded `font-size: 14px`** from bootstrap HTML and isolated renderer CSS. This was causing Tailwind's rem-based classes (like `text-sm`) to compute incorrectly (12.25px instead of 14px)
- **Removed extra `body { padding: 8px }`** that caused outputs to be indented further than non-isolated outputs  
- **Added missing ANSI CSS import** for terminal color support in isolated outputs
- **Matched monospace font stack** to main app (`"SF Mono", Consolas, Monaco, "Andale Mono", monospace`)

## Screenshots

Before:

<img width="976" height="652" alt="image" src="https://github.com/user-attachments/assets/e331267f-06d2-4e8b-94a9-264175b9bac6" />

After:

<img width="976" height="652" alt="image" src="https://github.com/user-attachments/assets/b5d1086c-9a0a-42ce-b29a-d1533c88bdc0" />


## Verification

- [x] Run `cargo xtask dev` and create a notebook
- [x] Compare `print('test')` output (non-isolated) with `print('test')` + `HTML("")` output (isolated) - text should now have identical font-size, font-family, and alignment

_PR submitted by @rgbkrk's agent, Quill_