### PR TITLE
feat(keep-alive): add exponential slider (5s to 7 days) and shutdown command

### DIFF
--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -29,8 +29,17 @@ import type { UpdateStatus } from "../hooks/useUpdater";
 import type { KernelspecInfo } from "../types";
 
 /** Format seconds into human-readable duration */
-function formatDuration(secs: number | null): string {
-  if (secs === null) return "Forever";
+function formatDuration(secs: number): string {
+  if (secs >= 86400) {
+    const days = Math.floor(secs / 86400);
+    const hours = Math.floor((secs % 86400) / 3600);
+    return hours > 0 ? `${days}d ${hours}h` : `${days}d`;
+  }
+  if (secs >= 3600) {
+    const hours = Math.floor(secs / 3600);
+    const mins = Math.floor((secs % 3600) / 60);
+    return mins > 0 ? `${hours}h ${mins}m` : `${hours}h`;
+  }
   if (secs >= 60) {
     const mins = Math.floor(secs / 60);
     const remainingSecs = secs % 60;
@@ -39,24 +48,43 @@ function formatDuration(secs: number | null): string {
   return `${secs}s`;
 }
 
-/** Keep Alive slider - uses Radix Slider for consistency with widget controls */
+// Exponential slider constants
+const MIN_SECS = 5;
+const MAX_SECS = 604800; // 7 days
+const SLIDER_STEPS = 100;
+
+// Convert slider position (0-100) to seconds (exponential scale)
+function sliderToSeconds(position: number): number {
+  // Exponential: value = MIN * (MAX/MIN)^(position/100)
+  const ratio = MAX_SECS / MIN_SECS;
+  const secs = Math.round(MIN_SECS * ratio ** (position / SLIDER_STEPS));
+  return Math.max(MIN_SECS, Math.min(MAX_SECS, secs));
+}
+
+// Convert seconds to slider position (0-100)
+function secondsToSlider(secs: number): number {
+  // Inverse: position = 100 * log(value/MIN) / log(MAX/MIN)
+  const ratio = MAX_SECS / MIN_SECS;
+  const position = (SLIDER_STEPS * Math.log(secs / MIN_SECS)) / Math.log(ratio);
+  return Math.max(0, Math.min(SLIDER_STEPS, Math.round(position)));
+}
+
+/** Keep Alive slider - exponential scale from 5s to 7 days */
 function KeepAliveSlider({
   value,
   onChange,
 }: {
-  value: number | null;
-  onChange: (value: number | null) => void;
+  value: number;
+  onChange: (value: number) => void;
 }) {
-  // When forever mode is on, value is null; slider uses last known numeric value
-  const [localValue, setLocalValue] = useState(value ?? 30);
-  const isForever = value === null;
+  const [localValue, setLocalValue] = useState(value);
 
-  // Sync local value when prop changes externally (only for numeric values)
+  // Sync local value when prop changes externally
   useEffect(() => {
-    if (value !== null) {
-      setLocalValue(value);
-    }
+    setLocalValue(value);
   }, [value]);
+
+  const sliderPosition = secondsToSlider(localValue);
 
   return (
     <div className="space-y-3 pt-2 border-t border-border/50">
@@ -71,50 +99,27 @@ function KeepAliveSlider({
             Keep Alive
           </span>
           <span className="text-xs font-medium text-foreground tabular-nums">
-            {formatDuration(isForever ? null : localValue)}
+            {formatDuration(localValue)}
           </span>
         </div>
         <p className="text-[10px] text-muted-foreground/70">
           Time to keep notebook runtime alive after closing
         </p>
       </div>
-      {/* Forever checkbox */}
-      <label className="flex items-center gap-2 cursor-pointer">
-        <input
-          type="checkbox"
-          checked={isForever}
-          onChange={(e) => {
-            if (e.target.checked) {
-              onChange(null);
-            } else {
-              onChange(localValue);
-            }
-          }}
-          className="h-3.5 w-3.5 rounded border-muted-foreground/50 text-primary focus:ring-primary/50"
+      <div className="py-2">
+        <Slider
+          value={[sliderPosition]}
+          min={0}
+          max={SLIDER_STEPS}
+          step={1}
+          onValueChange={(v) => setLocalValue(sliderToSeconds(v[0]))}
+          onValueCommit={(v) => onChange(sliderToSeconds(v[0]))}
         />
-        <span className="text-xs text-muted-foreground">
-          Keep alive forever
-        </span>
-      </label>
-      {/* Slider - only shown when not in forever mode */}
-      {!isForever && (
-        <>
-          <div className="py-2">
-            <Slider
-              value={[localValue]}
-              min={5}
-              max={3600}
-              step={5}
-              onValueChange={(v) => setLocalValue(v[0])}
-              onValueCommit={(v) => onChange(v[0])}
-            />
-          </div>
-          <div className="flex justify-between text-[10px] text-muted-foreground/70">
-            <span>5s</span>
-            <span>1 hour</span>
-          </div>
-        </>
-      )}
+      </div>
+      <div className="flex justify-between text-[10px] text-muted-foreground/70">
+        <span>5s</span>
+        <span>7 days</span>
+      </div>
     </div>
   );
 }
@@ -252,8 +257,8 @@ interface NotebookToolbarProps {
   onDefaultUvPackagesChange?: (packages: string[]) => void;
   defaultCondaPackages?: string[];
   onDefaultCondaPackagesChange?: (packages: string[]) => void;
-  keepAliveSecs?: number | null;
-  onKeepAliveSecsChange?: (secs: number | null) => void;
+  keepAliveSecs?: number;
+  onKeepAliveSecsChange?: (secs: number) => void;
   onSave: () => void;
   onStartKernel: (name: string) => void;
   onInterruptKernel: () => void;

--- a/crates/notebook/src/settings.rs
+++ b/crates/notebook/src/settings.rs
@@ -101,7 +101,7 @@ mod tests {
                 default_packages: vec!["numpy".into(), "pandas".into()],
             },
             conda: CondaDefaults::default(),
-            keep_alive_secs: Some(30),
+            keep_alive_secs: 30,
         };
 
         let json = serde_json::to_string(&settings).unwrap();

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -395,8 +395,8 @@ impl Daemon {
     /// Returns the eviction delay duration.
     ///
     /// Uses the config override if set (for tests), otherwise reads from
-    /// the user's `keep_alive_secs` setting. Enforces a minimum of 5 seconds
-    /// to prevent accidental instant eviction from misconfigured settings.
+    /// the user's `keep_alive_secs` setting. Clamps to valid range (5s to 7 days)
+    /// to prevent accidental instant eviction or extreme values.
     pub async fn room_eviction_delay(&self) -> std::time::Duration {
         // Test override for predictable eviction in tests
         if let Some(ms) = self.config.room_eviction_delay_ms {
@@ -406,7 +406,10 @@ impl Daemon {
         let secs = settings
             .get_u64("keep_alive_secs")
             .unwrap_or(crate::settings_doc::DEFAULT_KEEP_ALIVE_SECS)
-            .max(crate::settings_doc::MIN_KEEP_ALIVE_SECS);
+            .clamp(
+                crate::settings_doc::MIN_KEEP_ALIVE_SECS,
+                crate::settings_doc::MAX_KEEP_ALIVE_SECS,
+            );
         std::time::Duration::from_secs(secs)
     }
 

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -392,31 +392,22 @@ impl Daemon {
 
     /// Get the room eviction delay.
     ///
-    /// Returns `None` for "forever" mode (no eviction), or `Some(Duration)`
-    /// for timed eviction.
+    /// Returns the eviction delay duration.
     ///
     /// Uses the config override if set (for tests), otherwise reads from
     /// the user's `keep_alive_secs` setting. Enforces a minimum of 5 seconds
     /// to prevent accidental instant eviction from misconfigured settings.
-    pub async fn room_eviction_delay(&self) -> Option<std::time::Duration> {
-        // Test override always returns Some (tests need predictable eviction)
+    pub async fn room_eviction_delay(&self) -> std::time::Duration {
+        // Test override for predictable eviction in tests
         if let Some(ms) = self.config.room_eviction_delay_ms {
-            return Some(std::time::Duration::from_millis(ms));
+            return std::time::Duration::from_millis(ms);
         }
         let settings = self.settings.read().await;
-        match settings.get_u64_option("keep_alive_secs") {
-            // Key is null -> forever mode, no eviction
-            Some(None) => None,
-            // Key has value -> use it (with minimum enforcement)
-            Some(Some(secs)) => {
-                let secs = secs.max(crate::settings_doc::MIN_KEEP_ALIVE_SECS);
-                Some(std::time::Duration::from_secs(secs))
-            }
-            // Key missing -> use default
-            None => Some(std::time::Duration::from_secs(
-                crate::settings_doc::DEFAULT_KEEP_ALIVE_SECS,
-            )),
-        }
+        let secs = settings
+            .get_u64("keep_alive_secs")
+            .unwrap_or(crate::settings_doc::DEFAULT_KEEP_ALIVE_SECS)
+            .max(crate::settings_doc::MIN_KEEP_ALIVE_SECS);
+        std::time::Duration::from_secs(secs)
     }
 
     /// Run the daemon server.

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -735,18 +735,8 @@ where
         // Schedule delayed eviction check. This handles:
         // 1. Grace period during auto-launch (client may reconnect)
         // 2. Kernel running with no peers (idle timeout)
-        // Without this, rooms with kernels would leak forever.
+        // Without this, rooms with kernels would leak indefinitely.
         let eviction_delay = daemon.room_eviction_delay().await;
-
-        // If keep-alive is "forever" (None), skip eviction scheduling
-        let Some(eviction_delay) = eviction_delay else {
-            info!(
-                "[notebook-sync] All peers disconnected from room {}, keep-alive forever (no eviction)",
-                notebook_id
-            );
-            return Ok(());
-        };
-
         let rooms_for_eviction = rooms.clone();
         let room_for_eviction = room.clone();
         let notebook_id_for_eviction = notebook_id.clone();

--- a/crates/runtimed/src/settings_doc.rs
+++ b/crates/runtimed/src/settings_doc.rs
@@ -24,7 +24,7 @@ use automerge::sync;
 use automerge::sync::SyncDoc;
 use automerge::transaction::Transactable;
 use automerge::{AutoCommit, AutomergeError, ObjId, ObjType, ReadDoc};
-use log::{info, warn};
+use log::info;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use ts_rs::TS;
@@ -141,6 +141,9 @@ pub const DEFAULT_KEEP_ALIVE_SECS: u64 = 30;
 /// Minimum keep-alive duration (5 seconds) to prevent accidental instant eviction.
 pub const MIN_KEEP_ALIVE_SECS: u64 = 5;
 
+/// Maximum keep-alive duration (7 days) for notebook rooms.
+pub const MAX_KEEP_ALIVE_SECS: u64 = 604800;
+
 /// Snapshot of all synced settings.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, JsonSchema, TS)]
 #[ts(export)]
@@ -167,10 +170,9 @@ pub struct SyncedSettings {
 
     /// How long (in seconds) to keep notebook rooms alive after all clients disconnect.
     /// This allows you to close and reopen the window without losing your kernel state.
-    /// `None` means keep alive forever (no automatic eviction).
-    /// When set to a value, minimum is 5 seconds to prevent accidental instant eviction.
+    /// Range: 5 seconds to 7 days (604800 seconds).
     #[serde(default = "default_keep_alive_secs")]
-    pub keep_alive_secs: Option<u64>,
+    pub keep_alive_secs: u64,
 }
 
 impl Default for SyncedSettings {
@@ -181,13 +183,13 @@ impl Default for SyncedSettings {
             default_python_env: PythonEnvType::default(),
             uv: UvDefaults::default(),
             conda: CondaDefaults::default(),
-            keep_alive_secs: Some(DEFAULT_KEEP_ALIVE_SECS),
+            keep_alive_secs: DEFAULT_KEEP_ALIVE_SECS,
         }
     }
 }
 
-fn default_keep_alive_secs() -> Option<u64> {
-    Some(DEFAULT_KEEP_ALIVE_SECS)
+fn default_keep_alive_secs() -> u64 {
+    DEFAULT_KEEP_ALIVE_SECS
 }
 
 /// Generate a JSON Schema string for the settings file.
@@ -232,19 +234,12 @@ impl SettingsDoc {
             "default_python_env",
             defaults.default_python_env.to_string(),
         );
-        // keep_alive_secs: Some(n) -> store n, None -> store null (forever)
-        match defaults.keep_alive_secs {
-            Some(secs) => {
-                let _ = doc.put(automerge::ROOT, "keep_alive_secs", secs as i64);
-            }
-            None => {
-                let _ = doc.put(
-                    automerge::ROOT,
-                    "keep_alive_secs",
-                    automerge::ScalarValue::Null,
-                );
-            }
-        }
+        // Store keep_alive_secs as i64 (Automerge's numeric type)
+        let _ = doc.put(
+            automerge::ROOT,
+            "keep_alive_secs",
+            defaults.keep_alive_secs as i64,
+        );
 
         // Nested uv map with empty package list
         if let Ok(uv_id) = doc.put_object(automerge::ROOT, "uv", ObjType::Map) {
@@ -326,13 +321,9 @@ impl SettingsDoc {
         if let Some(env) = json.get("default_python_env").and_then(|v| v.as_str()) {
             settings.put("default_python_env", env);
         }
-        // keep_alive_secs: null = forever, number = timeout in seconds
-        if let Some(value) = json.get("keep_alive_secs") {
-            if value.is_null() {
-                settings.put_null("keep_alive_secs");
-            } else if let Some(secs) = value.as_u64() {
-                settings.put_u64("keep_alive_secs", secs);
-            }
+        // keep_alive_secs: numeric value in seconds (5 to 604800)
+        if let Some(secs) = json.get("keep_alive_secs").and_then(|v| v.as_u64()) {
+            settings.put_u64("keep_alive_secs", secs);
         }
 
         let uv_packages = Self::extract_packages_from_json(json, "uv");
@@ -497,33 +488,6 @@ impl SettingsDoc {
         let _ = self.doc.put(automerge::ROOT, key, value as i64);
     }
 
-    /// Set a null value at the root (for optional fields like keep_alive_secs).
-    pub fn put_null(&mut self, key: &str) {
-        let _ = self
-            .doc
-            .put(automerge::ROOT, key, automerge::ScalarValue::Null);
-    }
-
-    /// Get an optional u64 setting value from the root.
-    /// Returns `Some(None)` if the key exists and is null (forever),
-    /// `Some(Some(value))` if the key exists with a valid numeric value,
-    /// `None` if the key doesn't exist or has an invalid value.
-    ///
-    /// Invalid values (negative numbers, unparseable strings) are treated as
-    /// "key not present" to avoid accidentally enabling forever mode.
-    pub fn get_u64_option(&self, key: &str) -> Option<Option<u64>> {
-        match self.doc.get(automerge::ROOT, key).ok().flatten() {
-            Some((automerge::Value::Scalar(s), _)) => match s.as_ref() {
-                automerge::ScalarValue::Null => Some(None), // Explicit null = forever
-                automerge::ScalarValue::Int(i) => u64::try_from(*i).ok().map(Some),
-                automerge::ScalarValue::Uint(u) => Some(Some(*u)),
-                automerge::ScalarValue::Str(s) => s.parse().ok().map(Some),
-                _ => None,
-            },
-            _ => None,
-        }
-    }
-
     /// Set a scalar setting value, supporting dotted paths for nested maps.
     pub fn put(&mut self, key: &str, value: &str) {
         if let Some((map_key, sub_key)) = key.split_once('.') {
@@ -608,7 +572,6 @@ impl SettingsDoc {
                     self.put_u64(key, u);
                 }
             }
-            serde_json::Value::Null => self.put_null(key),
             _ => {}
         }
     }
@@ -689,10 +652,9 @@ impl SettingsDoc {
             conda: CondaDefaults {
                 default_packages: conda_packages,
             },
-            keep_alive_secs: match self.get_u64_option("keep_alive_secs") {
-                Some(opt) => opt,                 // Use stored value (could be None = forever)
-                None => defaults.keep_alive_secs, // Key missing, use default
-            },
+            keep_alive_secs: self
+                .get_u64("keep_alive_secs")
+                .unwrap_or(defaults.keep_alive_secs),
         }
     }
 
@@ -751,34 +713,16 @@ impl SettingsDoc {
         }
 
         // keep_alive_secs (numeric or null for forever)
-        // Only explicit null means forever; invalid values are ignored
-        if let Some(json_value) = json.get("keep_alive_secs") {
-            let new_value: Option<Option<u64>> = if json_value.is_null() {
-                Some(None) // Explicit null = forever
-            } else if let Some(secs) = json_value.as_u64() {
-                Some(Some(secs)) // Valid numeric value
-            } else {
-                // Invalid value (negative, string, object, etc.) - ignore
-                warn!(
-                    "[settings] apply_json_changes: ignoring invalid keep_alive_secs value: {:?}",
-                    json_value
+        // keep_alive_secs: numeric value in seconds (invalid values are ignored)
+        if let Some(new_secs) = json.get("keep_alive_secs").and_then(|v| v.as_u64()) {
+            let current = self.get_u64("keep_alive_secs");
+            if current != Some(new_secs) {
+                info!(
+                    "[settings] apply_json_changes: keep_alive_secs changed {:?} -> {}",
+                    current, new_secs
                 );
-                None
-            };
-
-            if let Some(new_value) = new_value {
-                let current = self.get_u64_option("keep_alive_secs").flatten();
-                if current != new_value {
-                    info!(
-                        "[settings] apply_json_changes: keep_alive_secs changed {:?} -> {:?}",
-                        current, new_value
-                    );
-                    match new_value {
-                        Some(secs) => self.put_u64("keep_alive_secs", secs),
-                        None => self.put_null("keep_alive_secs"),
-                    }
-                    changed = true;
-                }
+                self.put_u64("keep_alive_secs", new_secs);
+                changed = true;
             }
         }
 
@@ -1273,29 +1217,15 @@ mod tests {
     }
 
     #[test]
-    fn test_keep_alive_secs_null_is_forever() {
-        let mut doc = SettingsDoc::new();
-        doc.put_null("keep_alive_secs");
-
-        // get_u64_option should return Some(None) for explicit null
-        let result = doc.get_u64_option("keep_alive_secs");
-        assert_eq!(result, Some(None));
-
-        // get_all should have None for forever mode
-        let settings = doc.get_all();
-        assert_eq!(settings.keep_alive_secs, None);
-    }
-
-    #[test]
     fn test_keep_alive_secs_valid_number() {
         let mut doc = SettingsDoc::new();
         doc.put_u64("keep_alive_secs", 60);
 
-        let result = doc.get_u64_option("keep_alive_secs");
-        assert_eq!(result, Some(Some(60)));
+        let result = doc.get_u64("keep_alive_secs");
+        assert_eq!(result, Some(60));
 
         let settings = doc.get_all();
-        assert_eq!(settings.keep_alive_secs, Some(60));
+        assert_eq!(settings.keep_alive_secs, 60);
     }
 
     #[test]
@@ -1303,23 +1233,8 @@ mod tests {
         let doc = SettingsDoc::new();
         let settings = doc.get_all();
 
-        // Default should be Some(30), not forever
-        assert_eq!(settings.keep_alive_secs, Some(DEFAULT_KEEP_ALIVE_SECS));
-    }
-
-    #[test]
-    fn test_apply_json_changes_keep_alive_explicit_null() {
-        let mut doc = SettingsDoc::new();
-
-        // Explicit null in JSON should set forever mode
-        let json = serde_json::json!({
-            "keep_alive_secs": null
-        });
-        let changed = doc.apply_json_changes(&json);
-        assert!(changed);
-
-        let settings = doc.get_all();
-        assert_eq!(settings.keep_alive_secs, None);
+        // Default should be 30 seconds
+        assert_eq!(settings.keep_alive_secs, DEFAULT_KEEP_ALIVE_SECS);
     }
 
     #[test]
@@ -1333,7 +1248,7 @@ mod tests {
         assert!(changed);
 
         let settings = doc.get_all();
-        assert_eq!(settings.keep_alive_secs, Some(120));
+        assert_eq!(settings.keep_alive_secs, 120);
     }
 
     #[test]
@@ -1342,7 +1257,7 @@ mod tests {
         // Set a known value first
         doc.put_u64("keep_alive_secs", 60);
 
-        // Invalid values should be ignored, not treated as forever
+        // Invalid values should be ignored
         // Test negative number (can't be represented as u64 in JSON)
         let json = serde_json::json!({
             "keep_alive_secs": -1
@@ -1351,7 +1266,7 @@ mod tests {
         assert!(!changed); // Should be no change
 
         let settings = doc.get_all();
-        assert_eq!(settings.keep_alive_secs, Some(60)); // Original preserved
+        assert_eq!(settings.keep_alive_secs, 60); // Original preserved
 
         // Test string value
         let json = serde_json::json!({
@@ -1361,22 +1276,22 @@ mod tests {
         assert!(!changed);
 
         let settings = doc.get_all();
-        assert_eq!(settings.keep_alive_secs, Some(60)); // Original preserved
+        assert_eq!(settings.keep_alive_secs, 60); // Original preserved
 
-        // Test object value
+        // Test null value (should be ignored, not treated specially)
         let json = serde_json::json!({
-            "keep_alive_secs": {}
+            "keep_alive_secs": null
         });
         let changed = doc.apply_json_changes(&json);
         assert!(!changed);
 
         let settings = doc.get_all();
-        assert_eq!(settings.keep_alive_secs, Some(60)); // Original preserved
+        assert_eq!(settings.keep_alive_secs, 60); // Original preserved
     }
 
     #[test]
-    fn test_get_u64_option_negative_int_not_forever() {
-        use automerge::{AutoCommit, ReadDoc};
+    fn test_get_u64_negative_int_returns_none() {
+        use automerge::AutoCommit;
 
         // Manually create a doc with a negative Int value
         let mut automerge_doc = AutoCommit::new();
@@ -1385,8 +1300,8 @@ mod tests {
         // Wrap in SettingsDoc
         let doc = SettingsDoc { doc: automerge_doc };
 
-        // Negative Int should return None (not present), not Some(None) (forever)
-        let result = doc.get_u64_option("keep_alive_secs");
+        // Negative Int should return None (invalid)
+        let result = doc.get_u64("keep_alive_secs");
         assert_eq!(result, None);
     }
 }

--- a/crates/runtimed/src/settings_doc.rs
+++ b/crates/runtimed/src/settings_doc.rs
@@ -270,6 +270,7 @@ impl SettingsDoc {
                     info!("[settings] Loaded Automerge doc from {:?}", automerge_path);
                     let mut settings = Self { doc };
                     settings.migrate_flat_to_nested();
+                    settings.migrate_null_keep_alive();
 
                     // Reconcile with settings.json so manual edits made while the
                     // daemon was stopped are picked up (the file watcher only
@@ -322,8 +323,14 @@ impl SettingsDoc {
             settings.put("default_python_env", env);
         }
         // keep_alive_secs: numeric value in seconds (5 to 604800)
-        if let Some(secs) = json.get("keep_alive_secs").and_then(|v| v.as_u64()) {
-            settings.put_u64("keep_alive_secs", secs);
+        // Legacy null means "forever", which we migrate to MAX_KEEP_ALIVE_SECS
+        if let Some(val) = json.get("keep_alive_secs") {
+            if val.is_null() {
+                // Migration: null (legacy "forever" mode) -> MAX_KEEP_ALIVE_SECS
+                settings.put_u64("keep_alive_secs", MAX_KEEP_ALIVE_SECS);
+            } else if let Some(secs) = val.as_u64() {
+                settings.put_u64("keep_alive_secs", secs);
+            }
         }
 
         let uv_packages = Self::extract_packages_from_json(json, "uv");
@@ -375,6 +382,21 @@ impl SettingsDoc {
             }
             let _ = self.doc.delete(automerge::ROOT, "default_conda_packages");
             info!("[settings] Migrated default_conda_packages to conda.default_packages");
+        }
+    }
+
+    /// Migrate legacy null keep_alive_secs (from "forever" mode) to MAX_KEEP_ALIVE_SECS.
+    ///
+    /// Previously, `null` meant "keep alive forever". Now we use a fixed maximum of 7 days.
+    /// This migration ensures users who had "forever" mode get the longest available duration
+    /// instead of silently falling back to the 30-second default.
+    fn migrate_null_keep_alive(&mut self) {
+        if self.is_null("keep_alive_secs") {
+            info!(
+                "[settings] Migrating null keep_alive_secs to MAX_KEEP_ALIVE_SECS ({})",
+                MAX_KEEP_ALIVE_SECS
+            );
+            self.put_u64("keep_alive_secs", MAX_KEEP_ALIVE_SECS);
         }
     }
 
@@ -483,9 +505,22 @@ impl SettingsDoc {
     }
 
     /// Set a u64 setting value at the root.
+    ///
+    /// Values are clamped to i64::MAX to prevent overflow during conversion.
     pub fn put_u64(&mut self, key: &str, value: u64) {
-        // Store as i64 since Automerge's Int is more widely supported
-        let _ = self.doc.put(automerge::ROOT, key, value as i64);
+        // Clamp to i64::MAX to prevent overflow (Automerge stores as signed int)
+        let clamped = value.min(i64::MAX as u64);
+        let _ = self.doc.put(automerge::ROOT, key, clamped as i64);
+    }
+
+    /// Check if a key exists in the document but has a null value.
+    fn is_null(&self, key: &str) -> bool {
+        self.doc
+            .get(automerge::ROOT, key)
+            .ok()
+            .flatten()
+            .map(|(value, _)| matches!(value, automerge::Value::Scalar(s) if matches!(s.as_ref(), automerge::ScalarValue::Null)))
+            .unwrap_or(false)
     }
 
     /// Set a scalar setting value, supporting dotted paths for nested maps.
@@ -1303,5 +1338,82 @@ mod tests {
         // Negative Int should return None (invalid)
         let result = doc.get_u64("keep_alive_secs");
         assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_migrate_null_keep_alive_to_max() {
+        use automerge::AutoCommit;
+
+        // Manually create a doc with null keep_alive_secs (legacy "forever" mode)
+        let mut automerge_doc = AutoCommit::new();
+        let _ = automerge_doc.put(
+            automerge::ROOT,
+            "keep_alive_secs",
+            automerge::ScalarValue::Null,
+        );
+
+        let mut doc = SettingsDoc { doc: automerge_doc };
+
+        // Verify it's detected as null
+        assert!(doc.is_null("keep_alive_secs"));
+        assert_eq!(doc.get_u64("keep_alive_secs"), None);
+
+        // Run migration
+        doc.migrate_null_keep_alive();
+
+        // Should now be MAX_KEEP_ALIVE_SECS
+        assert!(!doc.is_null("keep_alive_secs"));
+        assert_eq!(doc.get_u64("keep_alive_secs"), Some(MAX_KEEP_ALIVE_SECS));
+
+        let settings = doc.get_all();
+        assert_eq!(settings.keep_alive_secs, MAX_KEEP_ALIVE_SECS);
+    }
+
+    #[test]
+    fn test_from_json_null_keep_alive_migrates_to_max() {
+        // JSON with null keep_alive_secs (legacy "forever" mode)
+        let json = serde_json::json!({
+            "theme": "dark",
+            "keep_alive_secs": null
+        });
+
+        let doc = SettingsDoc::from_json(&json);
+        let settings = doc.get_all();
+
+        // Should be MAX_KEEP_ALIVE_SECS, not the default 30s
+        assert_eq!(settings.keep_alive_secs, MAX_KEEP_ALIVE_SECS);
+        assert_eq!(settings.theme, ThemeMode::Dark);
+    }
+
+    #[test]
+    fn test_put_u64_clamps_extreme_values() {
+        let mut doc = SettingsDoc::new();
+
+        // Very large value that would overflow i64
+        let extreme_value = u64::MAX;
+        doc.put_u64("keep_alive_secs", extreme_value);
+
+        // Should be clamped to i64::MAX
+        let result = doc.get_u64("keep_alive_secs");
+        assert_eq!(result, Some(i64::MAX as u64));
+    }
+
+    #[test]
+    fn test_is_null_returns_false_for_numeric() {
+        let doc = SettingsDoc::new();
+        // New doc has numeric keep_alive_secs (default 30)
+        assert!(!doc.is_null("keep_alive_secs"));
+    }
+
+    #[test]
+    fn test_is_null_returns_false_for_missing_key() {
+        use automerge::AutoCommit;
+
+        // Empty doc with no keep_alive_secs key
+        let automerge_doc = AutoCommit::new();
+        let doc = SettingsDoc { doc: automerge_doc };
+
+        // Missing key is not the same as null
+        assert!(!doc.is_null("keep_alive_secs"));
     }
 }

--- a/crates/runtimed/src/sync_client.rs
+++ b/crates/runtimed/src/sync_client.rs
@@ -246,11 +246,6 @@ where
                         .map_err(|e| SyncClientError::SyncError(format!("put u64: {}", e)))?;
                 }
             }
-            serde_json::Value::Null => {
-                self.doc
-                    .put(automerge::ROOT, key, automerge::ScalarValue::Null)
-                    .map_err(|e| SyncClientError::SyncError(format!("put null: {}", e)))?;
-            }
             _ => {}
         }
 
@@ -352,19 +347,13 @@ fn get_all_from_doc(doc: &AutoCommit) -> SyncedSettings {
             })
     };
 
-    // Returns Option<Option<u64>> to distinguish:
-    // - None = key doesn't exist or has invalid value
-    // - Some(None) = key exists with null value (forever)
-    // - Some(Some(u64)) = key exists with valid numeric value
-    // Invalid values (negative numbers, unparseable strings) are treated as
-    // "key not present" to avoid accidentally enabling forever mode.
-    let get_u64_option = |key: &str| -> Option<Option<u64>> {
+    // Get a u64 value from the doc
+    let get_u64 = |key: &str| -> Option<u64> {
         match doc.get(automerge::ROOT, key).ok().flatten() {
             Some((automerge::Value::Scalar(s), _)) => match s.as_ref() {
-                automerge::ScalarValue::Null => Some(None),
-                automerge::ScalarValue::Int(i) => u64::try_from(*i).ok().map(Some),
-                automerge::ScalarValue::Uint(u) => Some(Some(*u)),
-                automerge::ScalarValue::Str(s) => s.parse().ok().map(Some),
+                automerge::ScalarValue::Int(i) => u64::try_from(*i).ok(),
+                automerge::ScalarValue::Uint(u) => Some(*u),
+                automerge::ScalarValue::Str(s) => s.parse().ok(),
                 _ => None,
             },
             _ => None,
@@ -411,7 +400,7 @@ fn get_all_from_doc(doc: &AutoCommit) -> SyncedSettings {
         conda: CondaDefaults {
             default_packages: conda_packages,
         },
-        keep_alive_secs: get_u64_option("keep_alive_secs").unwrap_or(defaults.keep_alive_secs),
+        keep_alive_secs: get_u64("keep_alive_secs").unwrap_or(defaults.keep_alive_secs),
     }
 }
 

--- a/src/bindings/CondaDefaults.ts
+++ b/src/bindings/CondaDefaults.ts
@@ -3,4 +3,4 @@
 /**
  * Default packages for conda environments.
  */
-export type CondaDefaults = { default_packages: Array<string>, };
+export type CondaDefaults = { default_packages: Array<string> };

--- a/src/bindings/SyncedSettings.ts
+++ b/src/bindings/SyncedSettings.ts
@@ -8,31 +8,31 @@ import type { UvDefaults } from "./UvDefaults";
 /**
  * Snapshot of all synced settings.
  */
-export type SyncedSettings = { 
-/**
- * UI theme
- */
-theme: ThemeMode, 
-/**
- * Default runtime for new notebooks
- */
-default_runtime: Runtime, 
-/**
- * Default Python environment type (uv or conda)
- */
-default_python_env: PythonEnvType, 
-/**
- * UV environment defaults
- */
-uv: UvDefaults, 
-/**
- * Conda environment defaults
- */
-conda: CondaDefaults, 
-/**
- * How long (in seconds) to keep notebook rooms alive after all clients disconnect.
- * This allows you to close and reopen the window without losing your kernel state.
- * `None` means keep alive forever (no automatic eviction).
- * When set to a value, minimum is 5 seconds to prevent accidental instant eviction.
- */
-keep_alive_secs: bigint | null, };
+export type SyncedSettings = {
+  /**
+   * UI theme
+   */
+  theme: ThemeMode;
+  /**
+   * Default runtime for new notebooks
+   */
+  default_runtime: Runtime;
+  /**
+   * Default Python environment type (uv or conda)
+   */
+  default_python_env: PythonEnvType;
+  /**
+   * UV environment defaults
+   */
+  uv: UvDefaults;
+  /**
+   * Conda environment defaults
+   */
+  conda: CondaDefaults;
+  /**
+   * How long (in seconds) to keep notebook rooms alive after all clients disconnect.
+   * This allows you to close and reopen the window without losing your kernel state.
+   * Range: 5 seconds to 7 days (604800 seconds).
+   */
+  keep_alive_secs: bigint;
+};

--- a/src/bindings/UvDefaults.ts
+++ b/src/bindings/UvDefaults.ts
@@ -3,4 +3,4 @@
 /**
  * Default packages for uv environments.
  */
-export type UvDefaults = { default_packages: Array<string>, };
+export type UvDefaults = { default_packages: Array<string> };

--- a/src/hooks/useSyncedSettings.ts
+++ b/src/hooks/useSyncedSettings.ts
@@ -102,8 +102,8 @@ export function useSyncedSettings() {
   const [defaultCondaPackages, setDefaultCondaPackagesState] = useState<
     string[]
   >([]);
-  // null means "forever" (no automatic eviction)
-  const [keepAliveSecs, setKeepAliveSecsState] = useState<number | null>(30);
+  // Keep-alive duration in seconds (5s to 7 days)
+  const [keepAliveSecs, setKeepAliveSecsState] = useState<number>(30);
 
   // Load initial settings from daemon
   useEffect(() => {
@@ -125,10 +125,8 @@ export function useSyncedSettings() {
         if (Array.isArray(settings.conda?.default_packages)) {
           setDefaultCondaPackagesState(settings.conda.default_packages);
         }
-        // Handle keep_alive_secs: null means "forever", number means timeout
-        if (settings.keep_alive_secs === null) {
-          setKeepAliveSecsState(null);
-        } else if (typeof settings.keep_alive_secs === "bigint") {
+        // Handle keep_alive_secs: bigint from backend, convert to number
+        if (typeof settings.keep_alive_secs === "bigint") {
           setKeepAliveSecsState(Number(settings.keep_alive_secs));
         } else if (typeof settings.keep_alive_secs === "number") {
           setKeepAliveSecsState(settings.keep_alive_secs);
@@ -164,10 +162,8 @@ export function useSyncedSettings() {
       if (Array.isArray(event.payload.conda?.default_packages)) {
         setDefaultCondaPackagesState(event.payload.conda.default_packages);
       }
-      // Handle keep_alive_secs: null means "forever", number means timeout
-      if (keep_alive_secs === null) {
-        setKeepAliveSecsState(null);
-      } else if (typeof keep_alive_secs === "bigint") {
+      // Handle keep_alive_secs: bigint from backend, convert to number
+      if (typeof keep_alive_secs === "bigint") {
         setKeepAliveSecsState(Number(keep_alive_secs));
       } else if (typeof keep_alive_secs === "number") {
         setKeepAliveSecsState(keep_alive_secs);
@@ -224,7 +220,7 @@ export function useSyncedSettings() {
     );
   }, []);
 
-  const setKeepAliveSecs = useCallback((secs: number | null) => {
+  const setKeepAliveSecs = useCallback((secs: number) => {
     setKeepAliveSecsState(secs);
     invoke("set_synced_setting", {
       key: "keep_alive_secs",


### PR DESCRIPTION
## Summary

- Add configurable keep-alive duration with exponential slider (5 seconds to 7 days)
- Add `runt shutdown` command for manual room cleanup
- Exponential scale makes the slider intuitive across a wide range of durations

## Changes

### Keep-Alive Slider
- Range: 5 seconds to 604800 seconds (7 days)
- Uses exponential scale: dragging the slider increases time exponentially
- Format displays seconds, minutes, hours, or days appropriately

### Shutdown Command
```bash
# Shutdown by notebook path
runt shutdown /path/to/notebook.ipynb

# Shutdown by room UUID
runt shutdown a1b2c3d4-...
```

Useful for cleaning up rooms manually regardless of keep-alive settings.

## Test plan
- [x] Open settings, verify slider goes from 5s to 7d
- [x] Drag slider - values should increase exponentially
- [x] Set to various values, close notebook, verify eviction timing
- [x] Verify `runt shutdown` works with both paths and UUIDs