### PR TITLE
fix(notebook): show full kernel status in toolbar

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -33,6 +33,7 @@ import { useGlobalFind } from "./hooks/useGlobalFind";
 import { useNotebook } from "./hooks/useNotebook";
 import { useTrust } from "./hooks/useTrust";
 import { useUpdater } from "./hooks/useUpdater";
+import { KERNEL_STATUS } from "./lib/kernel-status";
 import { logger } from "./lib/logger";
 import type { JupyterMessage } from "./types";
 
@@ -563,7 +564,7 @@ function AppContent() {
       await clearOutputs(cellId);
 
       // Start kernel via daemon if not running, then queue cell.
-      if (kernelStatus === "not_started") {
+      if (kernelStatus === KERNEL_STATUS.NOT_STARTED) {
         const started = await tryStartKernel();
         // Only block execution when trust approval is pending.
         // For startup races (e.g. daemon already auto-starting), still try execute.
@@ -621,7 +622,7 @@ function AppContent() {
     await Promise.all(codeCells.map((cell) => clearOutputs(cell.id)));
 
     // Start kernel via daemon if not running
-    if (kernelStatus === "not_started") {
+    if (kernelStatus === KERNEL_STATUS.NOT_STARTED) {
       const started = await tryStartKernel();
       if (!started) {
         logger.debug("[App] handleRunAllCells: kernel not started, skipping");
@@ -999,7 +1000,7 @@ function AppContent() {
           flexibleNpmImports={flexibleNpmImports}
           onSetFlexibleNpmImports={setFlexibleNpmImports}
           syncState={denoDerivedSyncState}
-          syncing={kernelStatus === "starting"}
+          syncing={kernelStatus === KERNEL_STATUS.STARTING}
           onSyncNow={handleSyncDeps}
           justSynced={justSynced}
         />

--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -433,6 +433,9 @@ export function NotebookToolbar({
     kernelStatus === "idle" ||
     kernelStatus === "busy" ||
     kernelStatus === "starting";
+  const kernelStatusText = kernelStatus.replace(/_/g, " ");
+  const isKernelNotStarted =
+    kernelStatus === "not_started" || kernelStatus === "not started";
 
   // Derive env manager label for the runtime pill (e.g. "uv", "conda", "pixi")
   const envManager: EnvBadgeVariant | null =
@@ -647,7 +650,7 @@ export function NotebookToolbar({
 
           {/* Kernel status */}
           <div
-            className="flex w-[3rem] items-center gap-1.5"
+            className="flex items-center gap-1.5 whitespace-nowrap"
             role="status"
             aria-label={`Kernel: ${
               envProgress?.isActive
@@ -656,7 +659,7 @@ export function NotebookToolbar({
                   ? envProgress.statusText
                   : kernelStatus === "error" && kernelErrorMessage
                     ? `Error \u2014 ${kernelErrorMessage}`
-                    : kernelStatus
+                    : kernelStatusText
             }`}
             title={
               envProgress?.isActive
@@ -665,7 +668,7 @@ export function NotebookToolbar({
                   ? envProgress.error
                   : kernelStatus === "error" && kernelErrorMessage
                     ? `Error \u2014 ${kernelErrorMessage}`
-                    : kernelStatus
+                    : kernelStatusText
             }
           >
             <div
@@ -674,12 +677,11 @@ export function NotebookToolbar({
                 kernelStatus === "idle" && "bg-green-500",
                 kernelStatus === "busy" && "bg-amber-500",
                 kernelStatus === "starting" && "bg-blue-500 animate-pulse",
-                kernelStatus === "not started" &&
-                  "bg-gray-400 dark:bg-gray-500",
+                isKernelNotStarted && "bg-gray-400 dark:bg-gray-500",
                 kernelStatus === "error" && "bg-red-500",
               )}
             />
-            <span className="text-xs text-muted-foreground truncate">
+            <span className="text-xs text-muted-foreground whitespace-nowrap">
               {envProgress?.isActive ? (
                 envProgress.statusText
               ) : envProgress?.error ? (
@@ -694,11 +696,7 @@ export function NotebookToolbar({
                       "text-red-600 dark:text-red-400",
                   )}
                 >
-                  {kernelStatus === "not started"
-                    ? "off"
-                    : kernelStatus === "starting"
-                      ? "init"
-                      : kernelStatus}
+                  {kernelStatusText}
                 </span>
               )}
             </span>

--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -26,6 +26,11 @@ import { isKnownPythonEnv, isKnownRuntime } from "@/hooks/useSyncedSettings";
 import { cn } from "@/lib/utils";
 import type { EnvProgressState } from "../hooks/useEnvProgress";
 import type { UpdateStatus } from "../hooks/useUpdater";
+import {
+  getKernelStatusLabel,
+  KERNEL_STATUS,
+  type KernelStatus,
+} from "../lib/kernel-status";
 import type { KernelspecInfo } from "../types";
 
 /** Format seconds into human-readable duration */
@@ -238,7 +243,7 @@ function PixiIcon({ className }: { className?: string }) {
 type EnvBadgeVariant = "uv" | "conda" | "pixi";
 
 interface NotebookToolbarProps {
-  kernelStatus: string;
+  kernelStatus: KernelStatus;
   kernelErrorMessage?: string | null;
   envSource: string | null;
   /** Pre-start hint: "uv" | "conda" | "pixi" | null, derived from notebook metadata */
@@ -430,17 +435,20 @@ export function NotebookToolbar({
   }, [kernelspecs, onStartKernel, listKernelspecs]);
 
   const isKernelRunning =
-    kernelStatus === "idle" ||
-    kernelStatus === "busy" ||
-    kernelStatus === "starting";
-  const kernelStatusText = kernelStatus.replace(/_/g, " ");
+    kernelStatus === KERNEL_STATUS.IDLE ||
+    kernelStatus === KERNEL_STATUS.BUSY ||
+    kernelStatus === KERNEL_STATUS.STARTING;
+  const kernelStatusText = getKernelStatusLabel(kernelStatus);
   const isKernelNotStarted =
-    kernelStatus === "not_started" || kernelStatus === "not started";
+    kernelStatus === KERNEL_STATUS.NOT_STARTED ||
+    kernelStatus === KERNEL_STATUS.SHUTDOWN;
 
   // Derive env manager label for the runtime pill (e.g. "uv", "conda", "pixi")
   const envManager: EnvBadgeVariant | null =
     runtime === "python"
-      ? envSource && (kernelStatus === "idle" || kernelStatus === "busy")
+      ? envSource &&
+        (kernelStatus === KERNEL_STATUS.IDLE ||
+          kernelStatus === KERNEL_STATUS.BUSY)
         ? envSource.startsWith("conda:pixi")
           ? "pixi"
           : envSource.startsWith("conda")
@@ -547,7 +555,7 @@ export function NotebookToolbar({
               onClick={onInterruptKernel}
               className={cn(
                 "flex items-center gap-1 rounded px-2 py-1 text-xs transition-colors",
-                kernelStatus === "busy"
+                kernelStatus === KERNEL_STATUS.BUSY
                   ? "text-destructive hover:bg-destructive/10"
                   : "text-foreground hover:bg-muted",
               )}
@@ -556,7 +564,9 @@ export function NotebookToolbar({
             >
               <Square
                 className="h-3 w-3"
-                fill={kernelStatus === "busy" ? "currentColor" : "none"}
+                fill={
+                  kernelStatus === KERNEL_STATUS.BUSY ? "currentColor" : "none"
+                }
               />
               Interrupt
             </button>
@@ -657,7 +667,7 @@ export function NotebookToolbar({
                 ? envProgress.statusText
                 : envProgress?.error
                   ? envProgress.statusText
-                  : kernelStatus === "error" && kernelErrorMessage
+                  : kernelStatus === KERNEL_STATUS.ERROR && kernelErrorMessage
                     ? `Error \u2014 ${kernelErrorMessage}`
                     : kernelStatusText
             }`}
@@ -666,7 +676,7 @@ export function NotebookToolbar({
                 ? envProgress.statusText
                 : envProgress?.error
                   ? envProgress.error
-                  : kernelStatus === "error" && kernelErrorMessage
+                  : kernelStatus === KERNEL_STATUS.ERROR && kernelErrorMessage
                     ? `Error \u2014 ${kernelErrorMessage}`
                     : kernelStatusText
             }
@@ -674,11 +684,12 @@ export function NotebookToolbar({
             <div
               className={cn(
                 "h-2 w-2 shrink-0 rounded-full",
-                kernelStatus === "idle" && "bg-green-500",
-                kernelStatus === "busy" && "bg-amber-500",
-                kernelStatus === "starting" && "bg-blue-500 animate-pulse",
+                kernelStatus === KERNEL_STATUS.IDLE && "bg-green-500",
+                kernelStatus === KERNEL_STATUS.BUSY && "bg-amber-500",
+                kernelStatus === KERNEL_STATUS.STARTING &&
+                  "bg-blue-500 animate-pulse",
                 isKernelNotStarted && "bg-gray-400 dark:bg-gray-500",
-                kernelStatus === "error" && "bg-red-500",
+                kernelStatus === KERNEL_STATUS.ERROR && "bg-red-500",
               )}
             />
             <span className="text-xs text-muted-foreground whitespace-nowrap">
@@ -692,7 +703,7 @@ export function NotebookToolbar({
                 <span
                   className={cn(
                     "capitalize",
-                    kernelStatus === "error" &&
+                    kernelStatus === KERNEL_STATUS.ERROR &&
                       "text-red-600 dark:text-red-400",
                   )}
                 >
@@ -721,7 +732,7 @@ export function NotebookToolbar({
 
         {/* Deno install prompt */}
         {runtime === "deno" &&
-          kernelStatus === "error" &&
+          kernelStatus === KERNEL_STATUS.ERROR &&
           kernelErrorMessage && (
             <div className="border-t px-3 py-2">
               <div className="flex items-start gap-2 text-xs text-amber-700 dark:text-amber-400">

--- a/apps/notebook/src/hooks/useDaemonKernel.ts
+++ b/apps/notebook/src/hooks/useDaemonKernel.ts
@@ -9,6 +9,11 @@
 import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWebview } from "@tauri-apps/api/webview";
 import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  isKernelStatus,
+  KERNEL_STATUS,
+  type KernelStatus,
+} from "../lib/kernel-status";
 import { logger } from "../lib/logger";
 import type {
   DaemonBroadcast,
@@ -22,13 +27,7 @@ import {
 } from "./useManifestResolver";
 
 /** Kernel status from daemon */
-export type DaemonKernelStatus =
-  | "not_started"
-  | "starting"
-  | "idle"
-  | "busy"
-  | "error"
-  | "shutdown";
+export type DaemonKernelStatus = KernelStatus;
 
 /** Queue state from daemon */
 export interface DaemonQueueState {
@@ -72,8 +71,9 @@ export function useDaemonKernel({
   onClearOutputs,
   onCommMessage,
 }: UseDaemonKernelOptions) {
-  const [kernelStatus, setKernelStatus] =
-    useState<DaemonKernelStatus>("not_started");
+  const [kernelStatus, setKernelStatus] = useState<DaemonKernelStatus>(
+    KERNEL_STATUS.NOT_STARTED,
+  );
   const [queueState, setQueueState] = useState<DaemonQueueState>({
     executing: null,
     queued: [],
@@ -151,22 +151,29 @@ export function useDaemonKernel({
 
         switch (broadcast.event) {
           case "kernel_status": {
-            const status = broadcast.status as DaemonKernelStatus;
+            const rawStatus = broadcast.status;
+            if (!isKernelStatus(rawStatus)) {
+              logger.warn(
+                `[daemon-kernel] Ignoring unknown kernel status: ${rawStatus}`,
+              );
+              break;
+            }
+            const status: DaemonKernelStatus = rawStatus;
 
-            if (status === "busy") {
+            if (status === KERNEL_STATUS.BUSY) {
               // Throttle busy: only show if it persists past threshold
               // This ignores transient busy states from completions
               if (busyTimerRef.current === null) {
                 busyTimerRef.current = window.setTimeout(() => {
                   busyTimerRef.current = null;
-                  setKernelStatus("busy");
+                  setKernelStatus(KERNEL_STATUS.BUSY);
                   callbacksRef.current.onStatusChange?.(
-                    "busy",
+                    KERNEL_STATUS.BUSY,
                     broadcast.cell_id,
                   );
                 }, 60);
               }
-            } else if (status === "idle") {
+            } else if (status === KERNEL_STATUS.IDLE) {
               // Cancel pending busy transition if idle arrives quickly
               if (busyTimerRef.current !== null) {
                 clearTimeout(busyTimerRef.current);
@@ -191,7 +198,7 @@ export function useDaemonKernel({
               callbacksRef.current.onStatusChange?.(status, broadcast.cell_id);
 
               // Clear sync state when kernel shuts down
-              if (status === "shutdown") {
+              if (status === KERNEL_STATUS.SHUTDOWN) {
                 setEnvSyncState(null);
               }
             }
@@ -282,7 +289,7 @@ export function useDaemonKernel({
           }
 
           case "kernel_error": {
-            setKernelStatus("error");
+            setKernelStatus(KERNEL_STATUS.ERROR);
             callbacksRef.current.onKernelError?.(broadcast.error);
             break;
           }
@@ -407,9 +414,17 @@ export function useDaemonKernel({
         .then((response) => {
           if (cancelled) return;
           if (response.result === "kernel_info") {
+            if (!isKernelStatus(response.status)) {
+              logger.warn(
+                `[daemon-kernel] Ignoring unknown kernel_info status: ${response.status}`,
+              );
+              return;
+            }
+            const status: DaemonKernelStatus = response.status;
+
             // If kernel is not started and we haven't retried too many times,
             // wait a bit and try again (kernel may be auto-launching)
-            if (response.status === "not_started" && retryCount < 5) {
+            if (status === KERNEL_STATUS.NOT_STARTED && retryCount < 5) {
               setTimeout(() => {
                 if (!cancelled) fetchKernelInfo(retryCount + 1);
               }, 500);
@@ -425,7 +440,7 @@ export function useDaemonKernel({
               kernelType: response.kernel_type,
               envSource: response.env_source,
             });
-            setKernelStatus(response.status as DaemonKernelStatus);
+            setKernelStatus(status);
           }
         })
         .catch(() => {
@@ -439,7 +454,7 @@ export function useDaemonKernel({
       async () => {
         if (cancelled) return;
         logger.warn("[daemon-kernel] Daemon disconnected, resetting state");
-        setKernelStatus("not_started");
+        setKernelStatus(KERNEL_STATUS.NOT_STARTED);
         setKernelInfo({});
         setQueueState({ executing: null, queued: [] });
         setEnvSyncState(null);
@@ -492,7 +507,7 @@ export function useDaemonKernel({
       notebookPath?: string,
     ): Promise<DaemonNotebookResponse> => {
       logger.debug("[daemon-kernel] Launching kernel:", kernelType, envSource);
-      setKernelStatus("starting");
+      setKernelStatus(KERNEL_STATUS.STARTING);
 
       try {
         const response = await invoke<DaemonNotebookResponse>(
@@ -508,15 +523,15 @@ export function useDaemonKernel({
             kernelType: response.kernel_type,
             envSource: response.env_source,
           });
-          setKernelStatus("idle");
+          setKernelStatus(KERNEL_STATUS.IDLE);
         } else if (response.result === "error") {
-          setKernelStatus("error");
+          setKernelStatus(KERNEL_STATUS.ERROR);
         }
 
         return response;
       } catch (e) {
         logger.error("[daemon-kernel] Launch failed:", e);
-        setKernelStatus("error");
+        setKernelStatus(KERNEL_STATUS.ERROR);
         throw e;
       }
     },
@@ -578,7 +593,7 @@ export function useDaemonKernel({
         const response = await invoke<DaemonNotebookResponse>(
           "shutdown_kernel_via_daemon",
         );
-        setKernelStatus("not_started");
+        setKernelStatus(KERNEL_STATUS.NOT_STARTED);
         setKernelInfo({});
         return response;
       } catch (e) {

--- a/apps/notebook/src/lib/kernel-status.ts
+++ b/apps/notebook/src/lib/kernel-status.ts
@@ -1,0 +1,31 @@
+export const KERNEL_STATUS = {
+  NOT_STARTED: "not_started",
+  STARTING: "starting",
+  IDLE: "idle",
+  BUSY: "busy",
+  ERROR: "error",
+  SHUTDOWN: "shutdown",
+} as const;
+
+export type KernelStatus = (typeof KERNEL_STATUS)[keyof typeof KERNEL_STATUS];
+
+const KERNEL_STATUS_SET: ReadonlySet<KernelStatus> = new Set(
+  Object.values(KERNEL_STATUS),
+);
+
+export const KERNEL_STATUS_LABELS: Record<KernelStatus, string> = {
+  [KERNEL_STATUS.NOT_STARTED]: "not started",
+  [KERNEL_STATUS.STARTING]: "starting",
+  [KERNEL_STATUS.IDLE]: "idle",
+  [KERNEL_STATUS.BUSY]: "busy",
+  [KERNEL_STATUS.ERROR]: "error",
+  [KERNEL_STATUS.SHUTDOWN]: "shutdown",
+};
+
+export function isKernelStatus(value: string): value is KernelStatus {
+  return KERNEL_STATUS_SET.has(value as KernelStatus);
+}
+
+export function getKernelStatusLabel(status: KernelStatus): string {
+  return KERNEL_STATUS_LABELS[status];
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Display the full kernel status in the Notebook toolbar and format it for readability to prevent truncation.

### Walkthrough
<video src="/opt/cursor/artifacts/kernel_status_toolbar_visibility_fix_demo.mp4" controls></video>  
Kernel status text is fully visible in the right toolbar (`Not Started`) with no truncation.

<img src="/opt/cursor/artifacts/kernel_status_toolbar_full_label.webp" alt="kernel-status-full-label" />
<img src="/opt/cursor/artifacts/kernel_status_toolbar_full_label_tooltip.webp" alt="kernel-status-full-label-tooltip" />

---
<p><a href="https://cursor.com/agents/bc-df0c6e69-4630-47e5-abd1-dd385dedec37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-df0c6e69-4630-47e5-abd1-dd385dedec37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->