### PR TITLE
feat(menu): add explicit about nteract metadata

### DIFF
--- a/crates/notebook/build.rs
+++ b/crates/notebook/build.rs
@@ -19,9 +19,19 @@ fn main() {
         .map(|s| s.trim().to_string())
         .unwrap_or_else(|| "unknown".to_string());
 
+    // Capture commit date (used as release date in About metadata)
+    let release_date = Command::new("git")
+        .args(["show", "-s", "--format=%cs", "HEAD"])
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+
     // Set environment variables for use in Rust code
     println!("cargo:rustc-env=GIT_BRANCH={}", branch);
     println!("cargo:rustc-env=GIT_COMMIT={}", commit);
+    println!("cargo:rustc-env=GIT_COMMIT_DATE={}", release_date);
 
     // Re-run if git HEAD changes (detects branch switches, commits)
     println!("cargo:rerun-if-changed=../../.git/HEAD");

--- a/crates/notebook/src/menu.rs
+++ b/crates/notebook/src/menu.rs
@@ -1,4 +1,6 @@
-use tauri::menu::{Menu, MenuItem, PredefinedMenuItem, Submenu};
+use tauri::menu::{
+    AboutMetadata, AboutMetadataBuilder, Menu, MenuItem, PredefinedMenuItem, Submenu,
+};
 use tauri::{AppHandle, Wry};
 
 pub struct BundledSampleNotebook {
@@ -28,6 +30,11 @@ pub const MENU_RESTART_AND_RUN_ALL: &str = "restart_and_run_all";
 
 // Menu item IDs for CLI installation
 pub const MENU_INSTALL_CLI: &str = "install_cli";
+pub const MENU_ABOUT_NTERACT: &str = "About nteract";
+pub const APP_NAME: &str = "nteract";
+pub const APP_VERSION: &str = env!("CARGO_PKG_VERSION");
+pub const APP_COMMIT_SHA: &str = env!("GIT_COMMIT");
+pub const APP_RELEASE_DATE: &str = env!("GIT_COMMIT_DATE");
 
 pub const BUNDLED_SAMPLE_NOTEBOOKS: &[BundledSampleNotebook] = &[
     BundledSampleNotebook {
@@ -61,13 +68,28 @@ pub fn sample_for_menu_item_id(menu_id: &str) -> Option<&'static BundledSampleNo
         .find(|sample| sample.id == sample_id)
 }
 
+fn build_about_metadata() -> AboutMetadata<'static> {
+    AboutMetadataBuilder::new()
+        .name(Some(APP_NAME))
+        .version(Some(APP_VERSION))
+        .comments(Some(format!(
+            "Commit SHA: {APP_COMMIT_SHA}\nRelease Date: {APP_RELEASE_DATE}"
+        )))
+        .build()
+}
+
 /// Build the application menu bar
 pub fn create_menu(app: &AppHandle) -> tauri::Result<Menu<Wry>> {
     let menu = Menu::new(app)?;
+    let about_metadata = build_about_metadata();
 
     // App menu (macOS standard - shows app name)
-    let app_menu = Submenu::new(app, "nteract", true)?;
-    app_menu.append(&PredefinedMenuItem::about(app, Some("nteract"), None)?)?;
+    let app_menu = Submenu::new(app, APP_NAME, true)?;
+    app_menu.append(&PredefinedMenuItem::about(
+        app,
+        Some(MENU_ABOUT_NTERACT),
+        Some(about_metadata),
+    )?)?;
     app_menu.append(&PredefinedMenuItem::separator(app)?)?;
     app_menu.append(&MenuItem::with_id(
         app,
@@ -220,7 +242,10 @@ pub fn create_menu(app: &AppHandle) -> tauri::Result<Menu<Wry>> {
 
 #[cfg(test)]
 mod tests {
-    use super::{sample_for_menu_item_id, sample_menu_item_id, BUNDLED_SAMPLE_NOTEBOOKS};
+    use super::{
+        build_about_metadata, sample_for_menu_item_id, sample_menu_item_id, APP_COMMIT_SHA,
+        APP_NAME, APP_RELEASE_DATE, APP_VERSION, BUNDLED_SAMPLE_NOTEBOOKS, MENU_ABOUT_NTERACT,
+    };
     use std::collections::HashSet;
 
     #[test]
@@ -259,5 +284,29 @@ mod tests {
             nbformat::parse_notebook(sample.contents)
                 .unwrap_or_else(|e| panic!("{} should parse: {}", sample.file_name, e));
         }
+    }
+
+    #[test]
+    fn about_menu_label_is_explicit() {
+        assert_eq!(MENU_ABOUT_NTERACT, "About nteract");
+    }
+
+    #[test]
+    fn about_metadata_includes_required_release_fields() {
+        let metadata = build_about_metadata();
+        assert_eq!(metadata.name.as_deref(), Some(APP_NAME));
+        assert_eq!(metadata.version.as_deref(), Some(APP_VERSION));
+        let comments = metadata
+            .comments
+            .as_deref()
+            .expect("about metadata should include comments");
+        assert!(
+            comments.contains(APP_COMMIT_SHA),
+            "comments should include commit SHA"
+        );
+        assert!(
+            comments.contains(APP_RELEASE_DATE),
+            "comments should include release date"
+        );
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add an explicit "About nteract" menu with detailed metadata including app name, version, commit SHA, and release date.

---
<p><a href="https://cursor.com/agents/bc-9f641630-7d03-44bb-a01a-9c65f48167e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9f641630-7d03-44bb-a01a-9c65f48167e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->