### PR TITLE
fix(release): propagate preview version to bundled runt

### DIFF
--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -291,6 +291,7 @@ jobs:
           echo "Setting version to: ${VERSION}"
           sed -i '' "s/\"version\": \"[^\"]*\"/\"version\": \"${VERSION}\"/" crates/notebook/tauri.conf.json
           sed -i '' "s#https://github.com/nteract/desktop/releases/download/preview-latest/latest.json#https://github.com/nteract/desktop/releases/download/${{ inputs.updater_channel_tag }}/latest.json#" crates/notebook/tauri.conf.json
+          sed -i '' "s/^version = .*/version = \"${VERSION}\"/" crates/runt/Cargo.toml
 
       - name: Generate Icons
         run: cargo xtask icons
@@ -422,6 +423,9 @@ jobs:
           $tauriConf = $tauriConf -replace '"version": "[^"]+"', "`"version`": `"$version`""
           $tauriConf = $tauriConf -replace 'https://github.com/nteract/desktop/releases/download/preview-latest/latest.json', 'https://github.com/nteract/desktop/releases/download/${{ inputs.updater_channel_tag }}/latest.json'
           Set-Content crates/notebook/tauri.conf.json $tauriConf
+          $runtCargo = Get-Content crates/runt/Cargo.toml -Raw
+          $runtCargo = $runtCargo -replace '(?m)^version = ".*"$', "version = `"$version`""
+          Set-Content crates/runt/Cargo.toml $runtCargo
 
       - name: Generate Icons
         run: cargo xtask icons
@@ -542,6 +546,7 @@ jobs:
           echo "Setting version to: ${VERSION}"
           sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"${VERSION}\"/" crates/notebook/tauri.conf.json
           sed -i "s#https://github.com/nteract/desktop/releases/download/preview-latest/latest.json#https://github.com/nteract/desktop/releases/download/${{ inputs.updater_channel_tag }}/latest.json#" crates/notebook/tauri.conf.json
+          sed -i "s/^version = .*/version = \"${VERSION}\"/" crates/runt/Cargo.toml
 
       - name: Generate Icons
         run: cargo xtask icons


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Update release workflow to correctly version the `runt` CLI when bundled with preview desktop apps, ensuring `runt --version` reflects the full preview version string.

---
<p><a href="https://cursor.com/agents/bc-6a350767-1aa9-41f9-a4c5-a6ce103af4e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6a350767-1aa9-41f9-a4c5-a6ce103af4e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->