### PR TITLE
fix(runtimed): persist execution_count before executionstarted broadcast

### DIFF
--- a/crates/runtimed/src/kernel_manager.rs
+++ b/crates/runtimed/src/kernel_manager.rs
@@ -744,10 +744,29 @@ impl RoomKernel {
 
                             JupyterMessageContent::ExecuteInput(input) => {
                                 if let Some(ref cid) = cell_id {
+                                    // Persist execution count in Automerge before notifying clients
+                                    // so UI reads the updated value immediately.
+                                    let execution_count = input.execution_count.0 as i64;
+                                    let persist_bytes = {
+                                        let mut doc_guard = doc.write().await;
+                                        if let Err(e) = doc_guard
+                                            .set_execution_count(cid, &execution_count.to_string())
+                                        {
+                                            warn!(
+                                                "[kernel-manager] Failed to set execution_count in doc: {}",
+                                                e
+                                            );
+                                        }
+                                        let bytes = doc_guard.save();
+                                        let _ = changed_tx.send(());
+                                        bytes
+                                    };
+                                    persist_notebook_bytes(&persist_bytes, &persist_path);
+
                                     let _ =
                                         broadcast_tx.send(NotebookBroadcast::ExecutionStarted {
                                             cell_id: cid.clone(),
-                                            execution_count: input.execution_count.0 as i64,
+                                            execution_count,
                                         });
                                 }
                             }


### PR DESCRIPTION
### Motivation
- Clients sometimes receive `ExecutionStarted` before the notebook Automerge doc contains the updated `execution_count`, so the UI may not show the count immediately.
- Persisting the count into the Automerge doc before broadcasting ensures the frontend can read the updated value right away.

### Description
- Update the `ExecuteInput` iopub handler in `crates/runtimed/src/kernel_manager.rs` to write the `execution_count` into the Automerge document via `doc.set_execution_count` and call `doc.save()` before broadcasting.
- Immediately persist the updated bytes with `persist_notebook_bytes` and emit `changed_tx` so the sync pipeline sees the update.
- Keep the `NotebookBroadcast::ExecutionStarted` payload the same but use the locally persisted `execution_count` variable and log a warning if writing to the doc fails.

### Testing
- Ran `cargo fmt` successfully to apply Rust formatting checks.
- Ran `npx @biomejs/biome check --fix apps/notebook/src/ e2e/` successfully for frontend formatting/linting.
- Ran `cargo test -p runtimed kernel_manager::tests::test_room_kernel_new -- --exact --nocapture` and the unit test passed.
- Could not interactively run the full desktop GUI in this environment, so desktop verification (executing cells and observing execution counts in the app) was validated via code inspection and unit tests rather than a live UI session.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a67f1887448329bee3e5fa493065e1)