### PR TITLE
fix(build): ensure frontend dist changes trigger rebuild

### DIFF
--- a/crates/notebook/build.rs
+++ b/crates/notebook/build.rs
@@ -37,5 +37,8 @@ fn main() {
     println!("cargo:rerun-if-changed=../../.git/HEAD");
     println!("cargo:rerun-if-changed=../../.git/index");
 
+    // Re-run if frontend dist changes (ensures fresh frontend is embedded)
+    println!("cargo:rerun-if-changed=../../apps/notebook/dist");
+
     tauri_build::build()
 }


### PR DESCRIPTION
## Summary

- Add `rerun-if-changed` directive for the frontend dist folder in the notebook build script
- Fixes CI cache issue where stale frontend was embedded in release builds

## Problem

The `v1.4.1-preview.202603030430` release was built from the correct commit (PR #465's merge commit), but the OnboardingScreen component was missing from the binary. Investigation revealed:

1. `rust-cache` restored cached `target/` artifacts from a previous build
2. Cargo's incremental compilation reused the cached notebook binary
3. The binary had stale frontend embedded from before PR #465

Verification:
```bash
strings ./nteract.app/Contents/MacOS/notebook | grep -c "Welcome to nteract"  # Returns 0
```

## Fix

Add `cargo:rerun-if-changed` for the frontend dist folder so Cargo knows to rebuild when frontend changes:

```rust
println!("cargo:rerun-if-changed=../../apps/notebook/dist");
```

## Test plan

- [ ] Merge this PR
- [ ] Trigger a new preview release via workflow_dispatch
- [ ] Verify the new build includes OnboardingScreen: `strings .../notebook | grep "Welcome to nteract"`
- [ ] Have Anil test fresh install - should show onboarding screen