### PR TITLE
perf(runtimed): debounce notebook persistence to reduce disk I/O

### DIFF
--- a/crates/runtimed/src/kernel_manager.rs
+++ b/crates/runtimed/src/kernel_manager.rs
@@ -28,7 +28,6 @@ use uuid::Uuid;
 use crate::blob_store::BlobStore;
 use crate::comm_state::CommState;
 use crate::notebook_doc::NotebookDoc;
-use crate::notebook_sync_server::persist_notebook_bytes;
 use crate::output_store::{self, DEFAULT_INLINE_THRESHOLD};
 use crate::protocol::{CompletionItem, HistoryEntry, NotebookBroadcast};
 use crate::stream_terminal::{StreamOutputState, StreamTerminals};
@@ -320,8 +319,8 @@ pub struct RoomKernel {
     cmd_rx: Option<mpsc::Receiver<QueueCommand>>,
     /// Automerge document for persisting outputs
     doc: Arc<RwLock<NotebookDoc>>,
-    /// Path for persisting the document
-    persist_path: PathBuf,
+    /// Channel to send doc bytes to debounced persistence task
+    persist_tx: mpsc::Sender<Vec<u8>>,
     /// Channel to notify peers of document changes
     changed_tx: broadcast::Sender<()>,
     /// Blob store for output manifests
@@ -362,7 +361,7 @@ impl RoomKernel {
     pub fn new(
         broadcast_tx: broadcast::Sender<NotebookBroadcast>,
         doc: Arc<RwLock<NotebookDoc>>,
-        persist_path: PathBuf,
+        persist_tx: mpsc::Sender<Vec<u8>>,
         changed_tx: broadcast::Sender<()>,
         blob_store: Arc<BlobStore>,
         comm_state: Arc<CommState>,
@@ -388,7 +387,7 @@ impl RoomKernel {
             cmd_tx: None,
             cmd_rx: None,
             doc,
-            persist_path,
+            persist_tx,
             changed_tx,
             blob_store,
             comm_state,
@@ -692,7 +691,7 @@ impl RoomKernel {
         let cell_id_map = self.cell_id_map.clone();
         let iopub_cmd_tx = cmd_tx.clone();
         let doc = self.doc.clone();
-        let persist_path = self.persist_path.clone();
+        let persist_tx = self.persist_tx.clone();
         let changed_tx = self.changed_tx.clone();
         let blob_store = self.blob_store.clone();
         let comm_state = self.comm_state.clone();
@@ -761,7 +760,7 @@ impl RoomKernel {
                                         let _ = changed_tx.send(());
                                         bytes
                                     };
-                                    persist_notebook_bytes(&persist_bytes, &persist_path);
+                                    let _ = persist_tx.try_send(persist_bytes);
 
                                     let _ =
                                         broadcast_tx.send(NotebookBroadcast::ExecutionStarted {
@@ -901,7 +900,7 @@ impl RoomKernel {
                                         let _ = changed_tx.send(());
                                         bytes
                                     };
-                                    persist_notebook_bytes(&persist_bytes, &persist_path);
+                                    let _ = persist_tx.try_send(persist_bytes);
 
                                     let _ = broadcast_tx.send(NotebookBroadcast::Output {
                                         cell_id: cid.clone(),
@@ -1015,7 +1014,7 @@ impl RoomKernel {
                                             let _ = changed_tx.send(());
                                             bytes
                                         };
-                                        persist_notebook_bytes(&persist_bytes, &persist_path);
+                                        let _ = persist_tx.try_send(persist_bytes);
 
                                         let _ = broadcast_tx.send(NotebookBroadcast::Output {
                                             cell_id: cid.clone(),
@@ -1065,7 +1064,7 @@ impl RoomKernel {
                                         let _ = changed_tx.send(());
                                         bytes
                                     };
-                                    persist_notebook_bytes(&persist_bytes, &persist_path);
+                                    let _ = persist_tx.try_send(persist_bytes);
 
                                     // Broadcast for immediate UI update
                                     // Frontend will receive via Automerge sync, but broadcast for speed
@@ -1171,7 +1170,7 @@ impl RoomKernel {
                                             let _ = changed_tx.send(());
                                             bytes
                                         };
-                                        persist_notebook_bytes(&persist_bytes, &persist_path);
+                                        let _ = persist_tx.try_send(persist_bytes);
 
                                         let _ = broadcast_tx.send(NotebookBroadcast::Output {
                                             cell_id: cid.clone(),
@@ -1356,7 +1355,7 @@ impl RoomKernel {
         // Additional resources for handling page payloads (IPython ? and ?? help)
         let shell_doc = self.doc.clone();
         let shell_blob_store = self.blob_store.clone();
-        let shell_persist_path = self.persist_path.clone();
+        let shell_persist_tx = self.persist_tx.clone();
         let shell_changed_tx = self.changed_tx.clone();
 
         let shell_reader_task = tokio::spawn(async move {
@@ -1431,10 +1430,7 @@ impl RoomKernel {
                                                 let _ = shell_changed_tx.send(());
                                                 bytes
                                             };
-                                            persist_notebook_bytes(
-                                                &persist_bytes,
-                                                &shell_persist_path,
-                                            );
+                                            let _ = shell_persist_tx.try_send(persist_bytes);
 
                                             // Broadcast to all windows
                                             let _ = shell_broadcast_tx.send(
@@ -2053,11 +2049,11 @@ mod tests {
         let tmp = tempfile::TempDir::new().unwrap();
         let (tx, _rx) = broadcast::channel(16);
         let (changed_tx, _changed_rx) = broadcast::channel(16);
+        let (persist_tx, _persist_rx) = mpsc::channel::<Vec<u8>>(16);
         let doc = Arc::new(RwLock::new(NotebookDoc::new("test-notebook")));
-        let persist_path = PathBuf::from("/tmp/test.automerge");
         let blob_store = Arc::new(BlobStore::new(tmp.path().join("blobs")));
         let comm_state = Arc::new(CommState::new());
-        let kernel = RoomKernel::new(tx, doc, persist_path, changed_tx, blob_store, comm_state);
+        let kernel = RoomKernel::new(tx, doc, persist_tx, changed_tx, blob_store, comm_state);
 
         assert!(!kernel.is_running());
         assert!(kernel.executing_cell().is_none());

--- a/crates/runtimed/src/kernel_manager.rs
+++ b/crates/runtimed/src/kernel_manager.rs
@@ -22,7 +22,7 @@ use jupyter_protocol::{
 };
 use log::{debug, error, info, warn};
 use serde::{Deserialize, Serialize};
-use tokio::sync::{broadcast, mpsc, oneshot, RwLock};
+use tokio::sync::{broadcast, mpsc, oneshot, watch, RwLock};
 use uuid::Uuid;
 
 use crate::blob_store::BlobStore;
@@ -319,8 +319,8 @@ pub struct RoomKernel {
     cmd_rx: Option<mpsc::Receiver<QueueCommand>>,
     /// Automerge document for persisting outputs
     doc: Arc<RwLock<NotebookDoc>>,
-    /// Channel to send doc bytes to debounced persistence task
-    persist_tx: mpsc::Sender<Vec<u8>>,
+    /// Channel to send doc bytes to debounced persistence task (watch keeps latest)
+    persist_tx: watch::Sender<Option<Vec<u8>>>,
     /// Channel to notify peers of document changes
     changed_tx: broadcast::Sender<()>,
     /// Blob store for output manifests
@@ -361,7 +361,7 @@ impl RoomKernel {
     pub fn new(
         broadcast_tx: broadcast::Sender<NotebookBroadcast>,
         doc: Arc<RwLock<NotebookDoc>>,
-        persist_tx: mpsc::Sender<Vec<u8>>,
+        persist_tx: watch::Sender<Option<Vec<u8>>>,
         changed_tx: broadcast::Sender<()>,
         blob_store: Arc<BlobStore>,
         comm_state: Arc<CommState>,
@@ -760,7 +760,7 @@ impl RoomKernel {
                                         let _ = changed_tx.send(());
                                         bytes
                                     };
-                                    let _ = persist_tx.try_send(persist_bytes);
+                                    let _ = persist_tx.send(Some(persist_bytes));
 
                                     let _ =
                                         broadcast_tx.send(NotebookBroadcast::ExecutionStarted {
@@ -900,7 +900,7 @@ impl RoomKernel {
                                         let _ = changed_tx.send(());
                                         bytes
                                     };
-                                    let _ = persist_tx.try_send(persist_bytes);
+                                    let _ = persist_tx.send(Some(persist_bytes));
 
                                     let _ = broadcast_tx.send(NotebookBroadcast::Output {
                                         cell_id: cid.clone(),
@@ -1014,7 +1014,7 @@ impl RoomKernel {
                                             let _ = changed_tx.send(());
                                             bytes
                                         };
-                                        let _ = persist_tx.try_send(persist_bytes);
+                                        let _ = persist_tx.send(Some(persist_bytes));
 
                                         let _ = broadcast_tx.send(NotebookBroadcast::Output {
                                             cell_id: cid.clone(),
@@ -1064,7 +1064,7 @@ impl RoomKernel {
                                         let _ = changed_tx.send(());
                                         bytes
                                     };
-                                    let _ = persist_tx.try_send(persist_bytes);
+                                    let _ = persist_tx.send(Some(persist_bytes));
 
                                     // Broadcast for immediate UI update
                                     // Frontend will receive via Automerge sync, but broadcast for speed
@@ -1170,7 +1170,7 @@ impl RoomKernel {
                                             let _ = changed_tx.send(());
                                             bytes
                                         };
-                                        let _ = persist_tx.try_send(persist_bytes);
+                                        let _ = persist_tx.send(Some(persist_bytes));
 
                                         let _ = broadcast_tx.send(NotebookBroadcast::Output {
                                             cell_id: cid.clone(),
@@ -1430,7 +1430,7 @@ impl RoomKernel {
                                                 let _ = shell_changed_tx.send(());
                                                 bytes
                                             };
-                                            let _ = shell_persist_tx.try_send(persist_bytes);
+                                            let _ = shell_persist_tx.send(Some(persist_bytes));
 
                                             // Broadcast to all windows
                                             let _ = shell_broadcast_tx.send(
@@ -2049,7 +2049,7 @@ mod tests {
         let tmp = tempfile::TempDir::new().unwrap();
         let (tx, _rx) = broadcast::channel(16);
         let (changed_tx, _changed_rx) = broadcast::channel(16);
-        let (persist_tx, _persist_rx) = mpsc::channel::<Vec<u8>>(16);
+        let (persist_tx, _persist_rx) = watch::channel::<Option<Vec<u8>>>(None);
         let doc = Arc::new(RwLock::new(NotebookDoc::new("test-notebook")));
         let blob_store = Arc::new(BlobStore::new(tmp.path().join("blobs")));
         let comm_state = Arc::new(CommState::new());

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -13,7 +13,7 @@
 //! 3. Additional windows join the same room
 //! 4. Changes from any peer broadcast to all others in the room
 //! 5. When the last peer disconnects, the room is evicted from memory
-//!    (the doc is already persisted on every change)
+//!    (any pending doc bytes are flushed to disk via debounced persistence)
 //! 6. Documents persist to `~/.cache/runt/notebook-docs/{hash}.automerge`
 //!
 //! ## Phase 8: Daemon-owned kernel execution
@@ -32,7 +32,7 @@ use std::sync::Arc;
 use automerge::sync;
 use log::{debug, error, info, warn};
 use tokio::io::{AsyncRead, AsyncWrite};
-use tokio::sync::{broadcast, mpsc, Mutex, RwLock};
+use tokio::sync::{broadcast, watch, Mutex, RwLock};
 
 use crate::blob_store::BlobStore;
 use crate::comm_state::CommState;
@@ -455,7 +455,8 @@ pub struct NotebookRoom {
     /// Broadcast channel for kernel events (outputs, status changes).
     pub kernel_broadcast_tx: broadcast::Sender<NotebookBroadcast>,
     /// Channel to send doc bytes to the debounced persistence task.
-    pub persist_tx: mpsc::Sender<Vec<u8>>,
+    /// Uses watch for "latest value" semantics - always keeps most recent state.
+    pub persist_tx: watch::Sender<Option<Vec<u8>>>,
     /// Persistence path for this room's document.
     pub persist_path: PathBuf,
     /// Number of active peer connections in this room.
@@ -512,8 +513,8 @@ impl NotebookRoom {
         let (changed_tx, _) = broadcast::channel(16);
         let (kernel_broadcast_tx, _) = broadcast::channel(64);
 
-        // Spawn debounced persistence task
-        let (persist_tx, persist_rx) = mpsc::channel::<Vec<u8>>(16);
+        // Spawn debounced persistence task (watch channel keeps latest value only)
+        let (persist_tx, persist_rx) = watch::channel::<Option<Vec<u8>>>(None);
         spawn_persist_debouncer(persist_rx, persist_path.clone());
 
         // Verify trust from the notebook file
@@ -553,7 +554,7 @@ impl NotebookRoom {
         let doc = NotebookDoc::load_or_create(&persist_path, notebook_id);
         let (changed_tx, _) = broadcast::channel(16);
         let (kernel_broadcast_tx, _) = broadcast::channel(64);
-        let (persist_tx, persist_rx) = mpsc::channel::<Vec<u8>>(16);
+        let (persist_tx, persist_rx) = watch::channel::<Option<Vec<u8>>>(None);
         spawn_persist_debouncer(persist_rx, persist_path.clone());
         let notebook_path = PathBuf::from(notebook_id);
         let trust_state = verify_trust_from_file(&notebook_path);
@@ -630,8 +631,8 @@ pub fn get_or_create_room(
 ///    exchange sync messages to propagate
 ///
 /// When the connection closes (client disconnect or error), the peer count
-/// is decremented. If it reaches zero, the room is evicted from the rooms
-/// map (the doc has already been persisted on every change).
+/// is decremented. If it reaches zero, the room is evicted and any pending
+/// doc bytes are flushed via debounced persistence.
 ///
 /// The `use_typed_frames` parameter determines the protocol version:
 /// - `false` (v1): Raw Automerge frames (legacy, for old clients)
@@ -858,7 +859,7 @@ where
                         };
 
                         // Send to debounced persistence task
-                        let _ = room.persist_tx.try_send(persist_bytes);
+                        let _ = room.persist_tx.send(Some(persist_bytes));
                     }
                     None => {
                         // Client disconnected
@@ -960,7 +961,7 @@ where
                                 };
 
                                 // Send to debounced persistence task
-                                let _ = room.persist_tx.try_send(persist_bytes);
+                                let _ = room.persist_tx.send(Some(persist_bytes));
 
                                 // Check if metadata changed and kernel is running - broadcast sync state
                                 check_and_broadcast_sync_state(room).await;
@@ -1894,7 +1895,7 @@ async fn handle_notebook_request(
             };
 
             // 2. Send to debounced persistence task
-            let _ = room.persist_tx.try_send(persist_bytes);
+            let _ = room.persist_tx.send(Some(persist_bytes));
 
             // 3. Broadcast for cross-window UI sync (fast path)
             let _ = room
@@ -2484,47 +2485,58 @@ async fn resolve_cell_output(output_str: &str, blob_store: &BlobStore) -> serde_
 
 /// Spawn a debounced persistence task that coalesces writes.
 ///
-/// Instead of writing to disk on every iopub message, this task waits 500ms
-/// after the last update before persisting. This dramatically reduces disk I/O
-/// during rapid output (loops, progress bars) while ensuring data is eventually
-/// persisted.
-fn spawn_persist_debouncer(mut persist_rx: mpsc::Receiver<Vec<u8>>, persist_path: PathBuf) {
+/// Uses a `watch` channel for "latest value" semantics - new values replace old ones,
+/// so we always persist the most recent state. No backpressure issues.
+///
+/// Persistence strategy:
+/// - **Debounce (500ms)**: Wait 500ms after last update before writing
+/// - **Max interval (5s)**: During continuous output, flush at least every 5s
+/// - **Shutdown flush**: Persist any pending data when channel closes
+///
+/// This reduces disk I/O during rapid output while ensuring durability.
+fn spawn_persist_debouncer(
+    mut persist_rx: watch::Receiver<Option<Vec<u8>>>,
+    persist_path: PathBuf,
+) {
     tokio::spawn(async move {
         use std::time::Duration;
-        use tokio::time::{interval, Instant, MissedTickBehavior};
+        use tokio::time::Instant;
 
         let debounce_duration = Duration::from_millis(500);
-        let mut pending: Option<Vec<u8>> = None;
-        let mut last_receive: Option<Instant> = None;
+        let max_flush_interval = Duration::from_secs(5);
 
-        // Check every 100ms if we should flush
-        let mut check_interval = interval(Duration::from_millis(100));
-        check_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+        let mut last_receive: Option<Instant> = None;
+        let mut last_flush: Option<Instant> = None;
 
         loop {
+            // Wait for changes or timeout
+            let timeout = tokio::time::sleep(Duration::from_millis(100));
             tokio::select! {
-                // Receive new bytes to persist
-                result = persist_rx.recv() => {
-                    match result {
-                        Some(bytes) => {
-                            pending = Some(bytes);
-                            last_receive = Some(Instant::now());
+                result = persist_rx.changed() => {
+                    if result.is_err() {
+                        // Channel closed - flush any pending data and exit
+                        let bytes = persist_rx.borrow().clone();
+                        if let Some(data) = bytes {
+                            do_persist(&data, &persist_path);
                         }
-                        None => {
-                            // Channel closed - flush any pending data and exit
-                            if let Some(bytes) = pending.take() {
-                                persist_notebook_bytes(&bytes, &persist_path);
-                            }
-                            break;
-                        }
+                        break;
                     }
+                    last_receive = Some(Instant::now());
                 }
-                // Periodic check for debounce timeout
-                _ = check_interval.tick() => {
-                    if let (Some(bytes), Some(last)) = (pending.as_ref(), last_receive) {
-                        if last.elapsed() >= debounce_duration {
-                            persist_notebook_bytes(bytes, &persist_path);
-                            pending = None;
+                _ = timeout => {
+                    // Check if we should flush based on debounce or max interval
+                    let should_flush = match (last_receive, last_flush) {
+                        (Some(recv), _) if recv.elapsed() >= debounce_duration => true,
+                        (Some(_), Some(flush)) if flush.elapsed() >= max_flush_interval => true,
+                        (Some(_), None) if last_receive.map(|r| r.elapsed() >= max_flush_interval).unwrap_or(false) => true,
+                        _ => false,
+                    };
+
+                    if should_flush {
+                        let bytes = persist_rx.borrow().clone();
+                        if let Some(data) = bytes {
+                            do_persist(&data, &persist_path);
+                            last_flush = Some(Instant::now());
                             last_receive = None;
                         }
                     }
@@ -2532,6 +2544,19 @@ fn spawn_persist_debouncer(mut persist_rx: mpsc::Receiver<Vec<u8>>, persist_path
             }
         }
     });
+}
+
+/// Actually persist bytes to disk, logging if it takes too long.
+fn do_persist(data: &[u8], path: &Path) {
+    let start = std::time::Instant::now();
+    persist_notebook_bytes(data, path);
+    let elapsed = start.elapsed();
+    if elapsed > std::time::Duration::from_millis(500) {
+        warn!(
+            "[persist-debouncer] Slow write: {:?} took {:?}",
+            path, elapsed
+        );
+    }
 }
 
 /// Persist pre-serialized notebook bytes to disk.
@@ -2932,7 +2957,7 @@ mod tests {
         let (changed_tx, _) = broadcast::channel(16);
         let (kernel_broadcast_tx, _) = broadcast::channel(64);
         let persist_path = tmp.path().join("doc.automerge");
-        let (persist_tx, persist_rx) = mpsc::channel::<Vec<u8>>(16);
+        let (persist_tx, persist_rx) = watch::channel::<Option<Vec<u8>>>(None);
         spawn_persist_debouncer(persist_rx, persist_path.clone());
 
         let room = NotebookRoom {

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -32,7 +32,7 @@ use std::sync::Arc;
 use automerge::sync;
 use log::{debug, error, info, warn};
 use tokio::io::{AsyncRead, AsyncWrite};
-use tokio::sync::{broadcast, Mutex, RwLock};
+use tokio::sync::{broadcast, mpsc, Mutex, RwLock};
 
 use crate::blob_store::BlobStore;
 use crate::comm_state::CommState;
@@ -454,6 +454,8 @@ pub struct NotebookRoom {
     pub changed_tx: broadcast::Sender<()>,
     /// Broadcast channel for kernel events (outputs, status changes).
     pub kernel_broadcast_tx: broadcast::Sender<NotebookBroadcast>,
+    /// Channel to send doc bytes to the debounced persistence task.
+    pub persist_tx: mpsc::Sender<Vec<u8>>,
     /// Persistence path for this room's document.
     pub persist_path: PathBuf,
     /// Number of active peer connections in this room.
@@ -510,6 +512,10 @@ impl NotebookRoom {
         let (changed_tx, _) = broadcast::channel(16);
         let (kernel_broadcast_tx, _) = broadcast::channel(64);
 
+        // Spawn debounced persistence task
+        let (persist_tx, persist_rx) = mpsc::channel::<Vec<u8>>(16);
+        spawn_persist_debouncer(persist_rx, persist_path.clone());
+
         // Verify trust from the notebook file
         let notebook_path = PathBuf::from(notebook_id);
         let trust_state = verify_trust_from_file(&notebook_path);
@@ -522,6 +528,7 @@ impl NotebookRoom {
             doc: Arc::new(RwLock::new(doc)),
             changed_tx,
             kernel_broadcast_tx,
+            persist_tx,
             persist_path,
             active_peers: AtomicUsize::new(0),
             kernel: Arc::new(Mutex::new(None)),
@@ -546,12 +553,15 @@ impl NotebookRoom {
         let doc = NotebookDoc::load_or_create(&persist_path, notebook_id);
         let (changed_tx, _) = broadcast::channel(16);
         let (kernel_broadcast_tx, _) = broadcast::channel(64);
+        let (persist_tx, persist_rx) = mpsc::channel::<Vec<u8>>(16);
+        spawn_persist_debouncer(persist_rx, persist_path.clone());
         let notebook_path = PathBuf::from(notebook_id);
         let trust_state = verify_trust_from_file(&notebook_path);
         Self {
             doc: Arc::new(RwLock::new(doc)),
             changed_tx,
             kernel_broadcast_tx,
+            persist_tx,
             persist_path,
             active_peers: AtomicUsize::new(0),
             kernel: Arc::new(Mutex::new(None)),
@@ -847,8 +857,8 @@ where
                             bytes
                         };
 
-                        // Persist outside the write lock
-                        persist_notebook_bytes(&persist_bytes, &room.persist_path);
+                        // Send to debounced persistence task
+                        let _ = room.persist_tx.try_send(persist_bytes);
                     }
                     None => {
                         // Client disconnected
@@ -949,8 +959,8 @@ where
                                     bytes
                                 };
 
-                                // Persist outside the write lock
-                                persist_notebook_bytes(&persist_bytes, &room.persist_path);
+                                // Send to debounced persistence task
+                                let _ = room.persist_tx.try_send(persist_bytes);
 
                                 // Check if metadata changed and kernel is running - broadcast sync state
                                 check_and_broadcast_sync_state(room).await;
@@ -1130,7 +1140,7 @@ async fn auto_launch_kernel(
     let mut kernel = RoomKernel::new(
         room.kernel_broadcast_tx.clone(),
         room.doc.clone(),
-        room.persist_path.clone(),
+        room.persist_tx.clone(),
         room.changed_tx.clone(),
         room.blob_store.clone(),
         room.comm_state.clone(),
@@ -1499,7 +1509,7 @@ async fn handle_notebook_request(
             let mut kernel = RoomKernel::new(
                 room.kernel_broadcast_tx.clone(),
                 room.doc.clone(),
-                room.persist_path.clone(),
+                room.persist_tx.clone(),
                 room.changed_tx.clone(),
                 room.blob_store.clone(),
                 room.comm_state.clone(),
@@ -1883,8 +1893,8 @@ async fn handle_notebook_request(
                 bytes
             };
 
-            // 2. Persist outside the write lock
-            persist_notebook_bytes(&persist_bytes, &room.persist_path);
+            // 2. Send to debounced persistence task
+            let _ = room.persist_tx.try_send(persist_bytes);
 
             // 3. Broadcast for cross-window UI sync (fast path)
             let _ = room
@@ -2472,6 +2482,58 @@ async fn resolve_cell_output(output_str: &str, blob_store: &BlobStore) -> serde_
     }
 }
 
+/// Spawn a debounced persistence task that coalesces writes.
+///
+/// Instead of writing to disk on every iopub message, this task waits 500ms
+/// after the last update before persisting. This dramatically reduces disk I/O
+/// during rapid output (loops, progress bars) while ensuring data is eventually
+/// persisted.
+fn spawn_persist_debouncer(mut persist_rx: mpsc::Receiver<Vec<u8>>, persist_path: PathBuf) {
+    tokio::spawn(async move {
+        use std::time::Duration;
+        use tokio::time::{interval, Instant, MissedTickBehavior};
+
+        let debounce_duration = Duration::from_millis(500);
+        let mut pending: Option<Vec<u8>> = None;
+        let mut last_receive: Option<Instant> = None;
+
+        // Check every 100ms if we should flush
+        let mut check_interval = interval(Duration::from_millis(100));
+        check_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
+        loop {
+            tokio::select! {
+                // Receive new bytes to persist
+                result = persist_rx.recv() => {
+                    match result {
+                        Some(bytes) => {
+                            pending = Some(bytes);
+                            last_receive = Some(Instant::now());
+                        }
+                        None => {
+                            // Channel closed - flush any pending data and exit
+                            if let Some(bytes) = pending.take() {
+                                persist_notebook_bytes(&bytes, &persist_path);
+                            }
+                            break;
+                        }
+                    }
+                }
+                // Periodic check for debounce timeout
+                _ = check_interval.tick() => {
+                    if let (Some(bytes), Some(last)) = (pending.as_ref(), last_receive) {
+                        if last.elapsed() >= debounce_duration {
+                            persist_notebook_bytes(bytes, &persist_path);
+                            pending = None;
+                            last_receive = None;
+                        }
+                    }
+                }
+            }
+        }
+    });
+}
+
 /// Persist pre-serialized notebook bytes to disk.
 pub(crate) fn persist_notebook_bytes(data: &[u8], path: &Path) {
     if let Some(parent) = path.parent() {
@@ -2497,8 +2559,8 @@ mod tests {
         Arc::new(BlobStore::new(tmp.path().join("blobs")))
     }
 
-    #[test]
-    fn test_room_load_or_create_new() {
+    #[tokio::test]
+    async fn test_room_load_or_create_new() {
         let tmp = tempfile::TempDir::new().unwrap();
         let blob_store = test_blob_store(&tmp);
         let room = NotebookRoom::load_or_create("test-nb", tmp.path(), blob_store);
@@ -2509,8 +2571,8 @@ mod tests {
         assert_eq!(room.active_peers.load(Ordering::Relaxed), 0);
     }
 
-    #[test]
-    fn test_room_persists_and_reloads() {
+    #[tokio::test]
+    async fn test_room_persists_and_reloads() {
         let tmp = tempfile::TempDir::new().unwrap();
         let blob_store = test_blob_store(&tmp);
 
@@ -2534,8 +2596,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_get_or_create_room_reuses_existing() {
+    #[tokio::test]
+    async fn test_get_or_create_room_reuses_existing() {
         let tmp = tempfile::TempDir::new().unwrap();
         let blob_store = test_blob_store(&tmp);
         let mut rooms = HashMap::new();
@@ -2547,8 +2609,8 @@ mod tests {
         assert!(Arc::ptr_eq(&room1, &room2));
     }
 
-    #[test]
-    fn test_get_or_create_room_different_notebooks() {
+    #[tokio::test]
+    async fn test_get_or_create_room_different_notebooks() {
         let tmp = tempfile::TempDir::new().unwrap();
         let blob_store = test_blob_store(&tmp);
         let mut rooms = HashMap::new();
@@ -2561,8 +2623,8 @@ mod tests {
         assert_eq!(rooms.len(), 2);
     }
 
-    #[test]
-    fn test_room_peer_counting() {
+    #[tokio::test]
+    async fn test_room_peer_counting() {
         let tmp = tempfile::TempDir::new().unwrap();
         let blob_store = test_blob_store(&tmp);
         let room = NotebookRoom::load_or_create("peer-test", tmp.path(), blob_store);
@@ -2580,8 +2642,8 @@ mod tests {
         assert_eq!(room.active_peers.load(Ordering::Relaxed), 0);
     }
 
-    #[test]
-    fn test_new_fresh_creates_empty_doc() {
+    #[tokio::test]
+    async fn test_new_fresh_creates_empty_doc() {
         let tmp = tempfile::TempDir::new().unwrap();
         let blob_store = test_blob_store(&tmp);
         let room = NotebookRoom::new_fresh("fresh-test", tmp.path(), blob_store);
@@ -2591,8 +2653,8 @@ mod tests {
         assert_eq!(doc.cell_count(), 0);
     }
 
-    #[test]
-    fn test_new_fresh_deletes_stale_persisted_doc() {
+    #[tokio::test]
+    async fn test_new_fresh_deletes_stale_persisted_doc() {
         let tmp = tempfile::TempDir::new().unwrap();
         let blob_store = test_blob_store(&tmp);
 
@@ -2869,12 +2931,16 @@ mod tests {
         let doc = crate::notebook_doc::NotebookDoc::new(&notebook_id);
         let (changed_tx, _) = broadcast::channel(16);
         let (kernel_broadcast_tx, _) = broadcast::channel(64);
+        let persist_path = tmp.path().join("doc.automerge");
+        let (persist_tx, persist_rx) = mpsc::channel::<Vec<u8>>(16);
+        spawn_persist_debouncer(persist_rx, persist_path.clone());
 
         let room = NotebookRoom {
             doc: Arc::new(RwLock::new(doc)),
             changed_tx,
             kernel_broadcast_tx,
-            persist_path: tmp.path().join("doc.automerge"),
+            persist_tx,
+            persist_path,
             active_peers: AtomicUsize::new(0),
             kernel: Arc::new(Mutex::new(None)),
             blob_store,


### PR DESCRIPTION
## Summary

Reduces disk I/O during streaming output by debouncing notebook persistence writes. Instead of writing to disk on every iopub message (100s/sec during rapid output), the implementation coalesces writes into a single disk operation every 500ms.

## What Changed

- Added `persist_tx` channel to `NotebookRoom` for debounced writes
- Spawned background debouncer task with 500ms coalescing window (matches settings.json pattern)
- Replaced all direct `persist_notebook_bytes()` calls in kernel manager with channel sends
- Pending data flushes when channel closes (room eviction)

## Why This Matters

Rapid output (loops printing lines, progress bars, streaming data) previously caused 100s of synchronous disk writes per second. The in-memory Automerge document never loses data—only the on-disk snapshot lags by up to 500ms, a worthwhile tradeoff.

Closes #480

## Verification

- Run tests: `cargo test -p runtimed`
- Execute a cell with rapid output and observe reduced disk I/O
- Verify notebook persists correctly after cell execution completes

_PR submitted by @rgbkrk's agent, Quill_