### PR TITLE
feat(onboarding,daemon): dedicated onboarding window and daemon auto-upgrade

### DIFF
--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -3435,7 +3435,11 @@ pub fn run(
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
-        .plugin(tauri_plugin_window_state::Builder::default().build())
+        .plugin(
+            tauri_plugin_window_state::Builder::default()
+                .with_denylist(&["onboarding"])
+                .build(),
+        )
         .manage(window_registry.clone())
         .manage(reconnect_in_progress)
         .manage(daemon_status_state)
@@ -3535,8 +3539,30 @@ pub fn run(
                 .map_err(Box::<dyn std::error::Error>::from)?;
             log::info!("[startup] Notebooks directory: {}", notebooks_dir.display());
 
-            if let Some(window) = app.get_webview_window("main") {
-                let _ = window.set_title(&window_title);
+            if needs_onboarding {
+                // Close the default main window - we'll create an onboarding-specific one
+                if let Some(window) = app.get_webview_window("main") {
+                    let _ = window.close();
+                }
+
+                // Create dedicated onboarding window with fixed size appropriate for content
+                let _onboarding_window = tauri::WebviewWindowBuilder::new(
+                    app,
+                    "onboarding",
+                    tauri::WebviewUrl::default(),
+                )
+                .title("Welcome to nteract")
+                .inner_size(550.0, 650.0)
+                .resizable(false)
+                .center()
+                .build()?;
+
+                log::info!("[startup] Created dedicated onboarding window");
+            } else {
+                // Normal startup - just set the title on the main window
+                if let Some(window) = app.get_webview_window("main") {
+                    let _ = window.set_title(&window_title);
+                }
             }
 
             // Start WebDriver server for native E2E testing (if enabled)


### PR DESCRIPTION
## Summary

- Replace overlay-based onboarding with dedicated first-launch window
- After onboarding, opens fresh notebook with proper working directory instead of broken temp directory notebook
- Auto-detect daemon version mismatch after app updates and upgrade running daemon to match bundled version
- Fix runtimed install to support upgrading already-installed service

## Changes

**Onboarding Window (Phase 1)**
- Check `onboarding_completed` setting early before setting up notebook state
- Skip "main" window creation when onboarding is needed
- Add `complete_onboarding` Tauri command that creates fresh notebook and closes onboarding window
- Update App.tsx to call complete_onboarding instead of hiding overlay
- Remove `app:first_launch` event (no longer needed)

**Daemon Auto-Upgrade (Phase 2)**
- Add version comparison after successful daemon ping
- Implement `upgrade_daemon_via_sidecar()` to upgrade running daemon via sidecar
- Graceful handling for auto-update scenarios

**Bug Fix**
- `runtimed install` now calls `upgrade()` if service already installed instead of exiting with error
- Makes daemon install/upgrade idempotent for smooth updates

## Verification

Reviewers should verify:
- [ ] Fresh install triggers onboarding window (not overlay)
- [ ] After onboarding, new notebook opens with proper working directory
- [ ] Second launch restores previous session correctly
- [ ] Daemon upgrade works smoothly on app version changes

_PR submitted by @rgbkrk's agent, Quill_