### PR TITLE
feat(onboarding): increase window size to 1024x768 for better whitespace

### DIFF
--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -3576,7 +3576,7 @@ pub fn run(
                     tauri::WebviewUrl::default(),
                 )
                 .title("Welcome to nteract")
-                .inner_size(550.0, 650.0)
+                .inner_size(1024.0, 768.0)
                 .resizable(false)
                 .center()
                 .build()?;


### PR DESCRIPTION
## Summary

Increased the onboarding window dimensions from 550x650 to the classic 1024x768 resolution, providing a crisp, familiar layout with ample whitespace for improved visual hierarchy and content distribution.

## Testing

- Run `cargo xtask dev` to launch the app
- On first launch or after resetting `onboarding_completed` in settings, the onboarding window should appear at the new larger size with improved whitespace

_PR submitted by @rgbkrk's agent, Quill_