### PR TITLE
fix(runtimed): bootstrap uv and fix kernel CWD for fresh installs

### DIFF
--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -1302,13 +1302,24 @@ impl Daemon {
 
     /// UV warming loop - maintains the UV pool.
     async fn uv_warming_loop(&self) {
-        // Check if uv is available
-        if !self.check_uv_available().await {
-            warn!("[runtimed] uv not available, UV warming disabled");
-            return;
-        }
+        // Bootstrap uv via rattler if not on PATH (this is cached via OnceCell)
+        let uv_path = match kernel_launch::tools::get_uv_path().await {
+            Ok(path) => {
+                info!("[runtimed] UV warming using uv at: {:?}", path);
+                path
+            }
+            Err(e) => {
+                warn!(
+                    "[runtimed] Failed to bootstrap uv: {}, UV warming disabled",
+                    e
+                );
+                return;
+            }
+        };
 
         info!("[runtimed] Starting UV warming loop");
+        // Store uv_path for use in create_uv_env - it's cached so get_uv_path() is instant
+        let _ = uv_path;
 
         loop {
             if *self.shutdown.lock().await {
@@ -1828,20 +1839,25 @@ print("warmup complete")
         let _ = self.pool_state_changed.send(broadcast);
     }
 
-    /// Check if uv is available on PATH.
-    async fn check_uv_available(&self) -> bool {
-        tokio::process::Command::new("uv")
-            .arg("--version")
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status()
-            .await
-            .map(|s| s.success())
-            .unwrap_or(false)
-    }
-
     /// Create a single UV environment and add it to the pool.
     async fn create_uv_env(&self) {
+        // Get uv path (cached via OnceCell, so this is instant after initial bootstrap)
+        let uv_path = match kernel_launch::tools::get_uv_path().await {
+            Ok(path) => path,
+            Err(e) => {
+                error!("[runtimed] Failed to get uv path: {}", e);
+                self.uv_pool
+                    .lock()
+                    .await
+                    .warming_failed_with_error(Some(PackageInstallError {
+                        failed_package: None,
+                        error_message: format!("Failed to get uv path: {}", e),
+                    }));
+                self.broadcast_pool_state().await;
+                return;
+            }
+        };
+
         let temp_id = format!("runtimed-uv-{}", uuid::Uuid::new_v4());
         let venv_path = self.config.cache_dir.join(&temp_id);
 
@@ -1869,7 +1885,7 @@ print("warmup complete")
         // Create venv (60 second timeout)
         let venv_result = tokio::time::timeout(
             std::time::Duration::from_secs(60),
-            tokio::process::Command::new("uv")
+            tokio::process::Command::new(&uv_path)
                 .arg("venv")
                 .arg(&venv_path)
                 .stdout(Stdio::piped())
@@ -1949,7 +1965,7 @@ print("warmup complete")
 
         let install_result = tokio::time::timeout(
             std::time::Duration::from_secs(120),
-            tokio::process::Command::new("uv")
+            tokio::process::Command::new(&uv_path)
                 .args(&install_args)
                 .stdout(Stdio::piped())
                 .stderr(Stdio::piped())

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -1098,12 +1098,18 @@ async fn auto_launch_kernel(
         return;
     }
 
-    // notebook_path is only valid if it's a real file (not a UUID for new notebooks)
+    // notebook_path_opt is ONLY for saved notebooks (actual file paths).
+    // For untitled notebooks, kernel_manager will use default_notebooks_dir() for CWD.
     let notebook_path = PathBuf::from(notebook_id);
     let notebook_path_opt = if notebook_path.exists() {
         Some(notebook_path.clone())
-    } else if is_untitled_notebook(notebook_id) {
-        // For untitled notebooks, use the working_dir from the handshake for project file detection
+    } else {
+        None
+    };
+
+    // For untitled notebooks, get working_dir separately for project file detection.
+    // This is NOT passed to kernel.launch() - that would cause .parent() to give wrong CWD.
+    let working_dir_for_detection = if is_untitled_notebook(notebook_id) {
         let working_dir = room.working_dir.read().await;
         working_dir.clone().inspect(|p| {
             info!(
@@ -1162,8 +1168,11 @@ async fn auto_launch_kernel(
     let inline_source = metadata_snapshot.as_ref().and_then(check_inline_deps);
 
     // Step 3: Check project files (for Python environment resolution)
-    let project_source = notebook_path_opt
+    // Use notebook path for saved notebooks, or working_dir for untitled notebooks
+    let detection_path = notebook_path_opt
         .as_ref()
+        .or(working_dir_for_detection.as_ref());
+    let project_source = detection_path
         .and_then(|path| crate::project_file::detect_project_file(path))
         .map(|detected| {
             info!(


### PR DESCRIPTION
## Summary

Fixes two issues discovered during fresh Mac install testing (closes #490):

- **Tool bootstrap**: Daemon now uses `kernel_launch::tools::get_uv_path()` which auto-bootstraps uv via rattler from conda-forge if not on PATH, instead of just checking PATH and giving up
- **Kernel CWD**: For untitled notebooks, kernel now launches in `~/notebooks` instead of home directory, preventing macOS permission prompts for Music/Photos/Documents

## Verification

- [ ] Fresh install: daemon logs show "UV warming using uv at:" (bootstrap succeeded)
- [ ] First notebook from onboarding: `import os; os.getcwd()` returns `~/notebooks`
- [ ] No macOS permission dialogs triggered on kernel launch

_PR submitted by @rgbkrk's agent, Quill_