### PR TITLE
fix(kernel-manager): handle directory paths for untitled notebook cwd

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -633,6 +633,42 @@ jobs:
             return $exit_code
           }
 
+          # Helper function to run untitled notebook test from a specific directory
+          # This test requires the app to be launched from a directory containing pyproject.toml
+          run_untitled_test() {
+            local fixture_dir="$1"
+            local spec="$2"
+            local name="$3"
+
+            echo "=== Running $name ==="
+
+            # Start daemon with fixture directory as workspace path
+            TARGET=$(ls target/release/binaries/ | grep runtimed | head -1)
+            CONDUCTOR_WORKSPACE_PATH="$fixture_dir" \
+              ./target/release/binaries/$TARGET --dev run \
+              --uv-pool-size 2 --conda-pool-size 0 &
+            DAEMON_PID=$!
+            sleep 20
+
+            # Start tauri-driver from fixture directory so app inherits that CWD
+            (cd "$fixture_dir" && ~/.cargo/bin/tauri-driver --port 4444) &
+            DRIVER_PID=$!
+            sleep 3
+
+            # Run test WITHOUT NOTEBOOK_PATH (untitled notebook)
+            local exit_code=0
+            E2E_SPEC="$spec" CONDUCTOR_WORKSPACE_PATH="$fixture_dir" \
+              pnpm test:e2e 2>&1 | tee -a e2e-logs/fixtures-output.log || exit_code=$?
+
+            # Cleanup
+            kill $DRIVER_PID 2>/dev/null || true
+            kill $DAEMON_PID 2>/dev/null || true
+            sleep 2
+
+            echo "=== $name complete (exit: $exit_code) ==="
+            return $exit_code
+          }
+
           # Run each fixture test
           run_fixture_test \
             "crates/notebook/fixtures/audit-test/1-vanilla.ipynb" \
@@ -643,6 +679,12 @@ jobs:
             "crates/notebook/fixtures/audit-test/10-deno.ipynb" \
             "e2e/specs/deno.spec.js" \
             "Deno Kernel Test" || FAIL=1
+
+          # Run untitled notebook test from pyproject fixture directory
+          run_untitled_test \
+            "${GITHUB_WORKSPACE}/crates/notebook/fixtures/audit-test/pyproject-project" \
+            "e2e/specs/untitled-pyproject.spec.js" \
+            "Untitled Pyproject Test" || FAIL=1
 
           exit $FAIL
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -652,7 +652,10 @@ jobs:
 
             # Start tauri-driver from fixture directory so app inherits that CWD
             # Use absolute path for the app binary since we're changing directories
-            (cd "$fixture_dir" && TAURI_APP_PATH="${GITHUB_WORKSPACE}/target/release/notebook" \
+            # Set CONDUCTOR_WORKSPACE_PATH so app connects to the daemon we just started
+            (cd "$fixture_dir" && \
+              CONDUCTOR_WORKSPACE_PATH="$fixture_dir" \
+              TAURI_APP_PATH="${GITHUB_WORKSPACE}/target/release/notebook" \
               ~/.cargo/bin/tauri-driver --port 4444) &
             DRIVER_PID=$!
             sleep 3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -651,13 +651,17 @@ jobs:
             sleep 20
 
             # Start tauri-driver from fixture directory so app inherits that CWD
-            (cd "$fixture_dir" && ~/.cargo/bin/tauri-driver --port 4444) &
+            # Use absolute path for the app binary since we're changing directories
+            (cd "$fixture_dir" && TAURI_APP_PATH="${GITHUB_WORKSPACE}/target/release/notebook" \
+              ~/.cargo/bin/tauri-driver --port 4444) &
             DRIVER_PID=$!
             sleep 3
 
             # Run test WITHOUT NOTEBOOK_PATH (untitled notebook)
+            # Use absolute path for TAURI_APP_PATH since tauri-driver runs from fixture dir
             local exit_code=0
             E2E_SPEC="$spec" CONDUCTOR_WORKSPACE_PATH="$fixture_dir" \
+              TAURI_APP_PATH="${GITHUB_WORKSPACE}/target/release/notebook" \
               pnpm test:e2e 2>&1 | tee -a e2e-logs/fixtures-output.log || exit_code=$?
 
             # Cleanup

--- a/crates/runtimed/src/kernel_manager.rs
+++ b/crates/runtimed/src/kernel_manager.rs
@@ -522,11 +522,17 @@ impl RoomKernel {
 
         // Determine working directory
         let cwd = if let Some(path) = notebook_path {
-            path.parent()
-                .map(|p| p.to_path_buf())
-                .unwrap_or_else(std::env::temp_dir)
+            if path.is_dir() {
+                // For untitled notebooks, working_dir is already a directory
+                path.to_path_buf()
+            } else {
+                // For saved notebooks, get parent directory of the file
+                path.parent()
+                    .map(|p| p.to_path_buf())
+                    .unwrap_or_else(std::env::temp_dir)
+            }
         } else {
-            // For untitled notebooks, use default notebooks directory to avoid macOS permission prompts
+            // No path at all - use default notebooks directory to avoid macOS permission prompts
             // (using $HOME triggers "allow access to Music/Documents/etc" popups)
             // In dev mode, this will be {workspace}/notebooks instead of ~/notebooks
             runt_workspace::default_notebooks_dir().unwrap_or_else(|_| std::env::temp_dir())

--- a/e2e/specs/untitled-pyproject.spec.js
+++ b/e2e/specs/untitled-pyproject.spec.js
@@ -19,9 +19,7 @@ import {
   waitForKernelReady,
 } from "../helpers.js";
 
-// FIXME: pyproject.toml deps not being installed - pandas import fails
-// See: https://github.com/nteract/desktop/pull/487
-describe.skip("Untitled Notebook with pyproject.toml", () => {
+describe("Untitled Notebook with pyproject.toml", () => {
   it("should auto-launch kernel with project deps", async () => {
     // Wait for kernel to auto-launch using pyproject deps (120s, includes uv sync)
     await waitForKernelReady(120000);

--- a/e2e/wdio.conf.js
+++ b/e2e/wdio.conf.js
@@ -27,12 +27,13 @@ const SCREENSHOT_FAILURES_DIR = path.join(SCREENSHOT_DIR, "failures");
 // Ensure screenshot directories exist
 fs.mkdirSync(SCREENSHOT_FAILURES_DIR, { recursive: true });
 
-// Fixture specs require NOTEBOOK_PATH to be set and are excluded from the default run.
-// Use ./e2e/dev.sh test-fixture <notebook> <spec> to run them individually.
+// Fixture specs require special setup (NOTEBOOK_PATH or working directory) and are excluded
+// from the default run. Use ./e2e/dev.sh test-fixture or test-untitled-pyproject to run them.
 const FIXTURE_SPECS = [
   "conda-inline.spec.js",
   "deno.spec.js",
   "prewarmed-uv.spec.js",
+  "untitled-pyproject.spec.js", // Requires working dir to be pyproject fixture directory
   "uv-inline.spec.js",
   "uv-pyproject.spec.js",
 ];


### PR DESCRIPTION
## Summary

Fixed a bug where pyproject.toml dependencies weren't being installed for untitled notebooks. The kernel manager was unconditionally calling `path.parent()` on the notebook path, which broke project file detection for untitled notebooks where `notebook_path` is already a directory (used for CWD context).

## Changes

- Check if `notebook_path` is a directory and use it directly (untitled notebooks)
- Only call `parent()` for file paths (saved notebooks)
- Re-enabled e2e/specs/untitled-pyproject.spec.js which now passes

## Verification

- ✓ E2E test: untitled-pyproject.spec.js (both tests pass)
- ✓ Cargo tests: 168 tests passed
- ✓ Clippy: no warnings
- ✓ Formatting: cargo fmt + biome passed

_PR submitted by @rgbkrk's agent, Quill_