### PR TITLE
fix(test): fix flaky sync timing race in multi-client test

### DIFF
--- a/python/runtimed/tests/conftest.py
+++ b/python/runtimed/tests/conftest.py
@@ -13,9 +13,7 @@ def pytest_configure(config):
     config.addinivalue_line(
         "markers", "integration: marks tests as integration tests (may need daemon)"
     )
-    config.addinivalue_line(
-        "markers", "slow: marks tests as slow running"
-    )
+    config.addinivalue_line("markers", "slow: marks tests as slow running")
 
 
 def pytest_collection_modifyitems(config, items):
@@ -33,6 +31,7 @@ def pytest_collection_modifyitems(config, items):
 
     if skip_integration:
         import pytest
+
         skip_marker = pytest.mark.skip(reason="Integration tests disabled")
         for item in items:
             if "integration" in item.keywords:

--- a/python/runtimed/tests/test_binary.py
+++ b/python/runtimed/tests/test_binary.py
@@ -25,17 +25,27 @@ def test_find_binary_via_path(tmp_path):
     fake_bin.touch()
     fake_bin.chmod(0o755)
 
-    with patch("runtimed._binary.sysconfig.get_path", return_value=str(tmp_path / "no_scripts")), \
-         patch("shutil.which", return_value=str(fake_bin)):
+    with (
+        patch(
+            "runtimed._binary.sysconfig.get_path",
+            return_value=str(tmp_path / "no_scripts"),
+        ),
+        patch("shutil.which", return_value=str(fake_bin)),
+    ):
         result = find_binary("runt")
         assert result == str(fake_bin)
 
 
 def test_find_binary_not_found(tmp_path):
     """BinaryNotFoundError raised when binary not found anywhere."""
-    with patch.dict(os.environ, {}, clear=True), \
-         patch("runtimed._binary.sysconfig.get_path", return_value=str(tmp_path / "no_scripts")), \
-         patch("shutil.which", return_value=None):
+    with (
+        patch.dict(os.environ, {}, clear=True),
+        patch(
+            "runtimed._binary.sysconfig.get_path",
+            return_value=str(tmp_path / "no_scripts"),
+        ),
+        patch("shutil.which", return_value=None),
+    ):
         with pytest.raises(BinaryNotFoundError, match="runt"):
             find_binary("runt")
 
@@ -50,7 +60,9 @@ def test_env_var_takes_precedence(tmp_path):
     path_bin.touch()
     path_bin.chmod(0o755)
 
-    with patch.dict(os.environ, {"RUNTIMED_RUNT_PATH": str(env_bin)}), \
-         patch("shutil.which", return_value=str(path_bin)):
+    with (
+        patch.dict(os.environ, {"RUNTIMED_RUNT_PATH": str(env_bin)}),
+        patch("shutil.which", return_value=str(path_bin)),
+    ):
         result = find_binary("runt")
         assert result == str(env_bin)

--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -35,6 +35,35 @@ import runtimed
 
 
 # ============================================================================
+# Test utilities
+# ============================================================================
+
+
+def wait_for_sync(check_fn, *, timeout=3.0, interval=0.1, description="sync"):
+    """Poll until check_fn returns True or timeout.
+
+    Args:
+        check_fn: Callable that returns True when sync is complete
+        timeout: Maximum time to wait in seconds
+        interval: Initial polling interval (grows with backoff)
+        description: Description for error message
+
+    Returns:
+        True if sync completed within timeout
+
+    Raises:
+        AssertionError: If timeout exceeded
+    """
+    start = time.time()
+    while time.time() - start < timeout:
+        if check_fn():
+            return True
+        time.sleep(interval)
+        interval = min(interval * 1.5, 0.5)  # Backoff up to 0.5s
+    raise AssertionError(f"Timed out waiting for {description} after {timeout}s")
+
+
+# ============================================================================
 # Fixtures for daemon management
 # ============================================================================
 
@@ -79,7 +108,11 @@ def _get_socket_path():
         return None  # Will be set by the daemon fixture
 
     # Otherwise, use default (assumes dev daemon is running)
-    return runtimed.default_socket_path() if hasattr(runtimed, "default_socket_path") else None
+    return (
+        runtimed.default_socket_path()
+        if hasattr(runtimed, "default_socket_path")
+        else None
+    )
 
 
 @pytest.fixture(scope="module")
@@ -98,7 +131,10 @@ def daemon_process():
         if socket_path is None:
             # Try the default
             import runtimed as rt
-            socket_path = rt.default_socket_path() if hasattr(rt, "default_socket_path") else None
+
+            socket_path = (
+                rt.default_socket_path() if hasattr(rt, "default_socket_path") else None
+            )
 
         if socket_path and not socket_path.exists():
             pytest.skip(
@@ -128,11 +164,16 @@ def daemon_process():
         cmd = [
             str(binary),
             "run",
-            "--socket", str(socket_path),
-            "--cache-dir", str(cache_dir),
-            "--blob-store-dir", str(blob_dir),
-            "--uv-pool-size", "3",  # Pool for sequential tests (need headroom for replenishment)
-            "--conda-pool-size", "3",  # Need headroom for conda project file tests + inline fallback
+            "--socket",
+            str(socket_path),
+            "--cache-dir",
+            str(cache_dir),
+            "--blob-store-dir",
+            str(blob_dir),
+            "--uv-pool-size",
+            "3",  # Pool for sequential tests (need headroom for replenishment)
+            "--conda-pool-size",
+            "3",  # Need headroom for conda project file tests + inline fallback
         ]
 
         print(f"\n[test] Starting daemon: {' '.join(cmd)}", file=sys.stderr)
@@ -158,7 +199,9 @@ def daemon_process():
                 break
             if proc.poll() is not None:
                 # Daemon died - print logs and fail
-                print(f"[test] Daemon died with code {proc.returncode}", file=sys.stderr)
+                print(
+                    f"[test] Daemon died with code {proc.returncode}", file=sys.stderr
+                )
                 print(f"[test] Daemon logs:\n{log_file.read_text()}", file=sys.stderr)
                 pytest.fail("Daemon process died during startup")
             time.sleep(1)
@@ -174,6 +217,7 @@ def daemon_process():
         uv_ready = False
         conda_ready = False
         import re
+
         # Match "UV pool: N/M available" where N > 0 (works for any pool size)
         uv_pattern = re.compile(r"UV pool: (\d+)/\d+ available")
         conda_pattern = re.compile(r"Conda pool: (\d+)/\d+ available")
@@ -185,14 +229,19 @@ def daemon_process():
                         match = uv_pattern.search(line)
                         if match and int(match.group(1)) > 0:
                             uv_ready = True
-                            print(f"[test] UV pool ready after {i + 1}s", file=sys.stderr)
+                            print(
+                                f"[test] UV pool ready after {i + 1}s", file=sys.stderr
+                            )
                             break
                 if not conda_ready:
                     for line in log_contents.splitlines():
                         match = conda_pattern.search(line)
                         if match and int(match.group(1)) > 0:
                             conda_ready = True
-                            print(f"[test] Conda pool ready after {i + 1}s", file=sys.stderr)
+                            print(
+                                f"[test] Conda pool ready after {i + 1}s",
+                                file=sys.stderr,
+                            )
                             break
             except Exception:
                 pass
@@ -459,20 +508,31 @@ class TestMultiClientSync:
         assert len(found) == 1
         assert found[0].source == "shared_var = 42"
 
-    @pytest.mark.skip(reason="Flaky - sync timing race condition, needs longer delay or retry")
     def test_source_update_syncs_between_peers(self, two_sessions):
         """Source updates sync between peers."""
         s1, s2 = two_sessions
 
         # Session 1 creates cell
         cell_id = s1.create_cell("original")
-        time.sleep(0.3)
+
+        # Wait for cell to sync to session 2
+        def cell_visible_to_s2():
+            cells = s2.get_cells()
+            return any(c.id == cell_id for c in cells)
+
+        wait_for_sync(cell_visible_to_s2, description="cell visible to s2")
 
         # Session 2 updates it
         s2.set_source(cell_id, "updated by s2")
-        time.sleep(0.3)
 
-        # Session 1 should see the update
+        # Wait for update to sync back to session 1
+        def update_visible_to_s1():
+            cell = s1.get_cell(cell_id)
+            return cell.source == "updated by s2"
+
+        wait_for_sync(update_visible_to_s1, description="update visible to s1")
+
+        # Final assertion
         cell = s1.get_cell(cell_id)
         assert cell.source == "updated by s2"
 
@@ -619,11 +679,11 @@ class TestTerminalEmulation:
         """
         session.start_kernel()
 
-        cell_id = session.create_cell(r'''
+        cell_id = session.create_cell(r"""
 import sys
 sys.stdout.write("Progress: 50%\rProgress: 100%")
 sys.stdout.flush()
-''')
+""")
         result = session.execute_cell(cell_id)
 
         assert result.success
@@ -636,7 +696,7 @@ sys.stdout.flush()
         """Simulated progress bar should show only final state."""
         session.start_kernel()
 
-        cell_id = session.create_cell(r'''
+        cell_id = session.create_cell(r"""
 import sys
 import time
 for i in range(0, 101, 20):
@@ -644,7 +704,7 @@ for i in range(0, 101, 20):
     sys.stdout.flush()
     time.sleep(0.05)
 print()  # Final newline
-''')
+""")
         result = session.execute_cell(cell_id)
 
         assert result.success
@@ -658,11 +718,11 @@ print()  # Final newline
         """Consecutive print statements should be merged into one output."""
         session.start_kernel()
 
-        cell_id = session.create_cell('''
+        cell_id = session.create_cell("""
 print("line 1")
 print("line 2")
 print("line 3")
-''')
+""")
         result = session.execute_cell(cell_id)
 
         assert result.success
@@ -678,13 +738,13 @@ print("line 3")
         """Interleaved stdout and stderr should remain separate streams."""
         session.start_kernel()
 
-        cell_id = session.create_cell('''
+        cell_id = session.create_cell("""
 import sys
 print("out1")
 sys.stderr.write("err1\\n")
 sys.stderr.flush()
 print("out2")
-''')
+""")
         result = session.execute_cell(cell_id)
 
         assert result.success
@@ -701,10 +761,10 @@ print("out2")
         """ANSI color codes should be preserved in output."""
         session.start_kernel()
 
-        cell_id = session.create_cell(r'''
+        cell_id = session.create_cell(r"""
 # Print with ANSI red color
 print("\x1b[31mRed text\x1b[0m Normal text")
-''')
+""")
         result = session.execute_cell(cell_id)
 
         assert result.success
@@ -718,12 +778,12 @@ print("\x1b[31mRed text\x1b[0m Normal text")
         """Backspace character should delete previous character."""
         session.start_kernel()
 
-        cell_id = session.create_cell(r'''
+        cell_id = session.create_cell(r"""
 import sys
 sys.stdout.write("abc\b\bd")
 sys.stdout.flush()
 print()
-''')
+""")
         result = session.execute_cell(cell_id)
 
         assert result.success
@@ -735,12 +795,12 @@ print()
         """ANSI colors combined with carriage return work correctly."""
         session.start_kernel()
 
-        cell_id = session.create_cell(r'''
+        cell_id = session.create_cell(r"""
 import sys
 # Print colored text, then overwrite with different color
 sys.stdout.write("\x1b[31mRed\x1b[0m\r\x1b[32mGreen\x1b[0m")
 sys.stdout.flush()
-''')
+""")
         result = session.execute_cell(cell_id)
 
         assert result.success
@@ -858,9 +918,7 @@ class TestOutputHandling:
         session.start_kernel()
 
         result = session.run(
-            'import sys\n'
-            'print("to stdout")\n'
-            'sys.stderr.write("to stderr\\n")'
+            'import sys\nprint("to stdout")\nsys.stderr.write("to stderr\\n")'
         )
 
         assert result.success
@@ -884,11 +942,11 @@ class TestOutputHandling:
         session.start_kernel()
 
         result = session.run(
-            'def inner():\n'
+            "def inner():\n"
             '    raise RuntimeError("deep error")\n'
-            'def outer():\n'
-            '    inner()\n'
-            'outer()'
+            "def outer():\n"
+            "    inner()\n"
+            "outer()"
         )
 
         assert not result.success
@@ -908,8 +966,9 @@ class TestOutputHandling:
 NOTEBOOK_METADATA_KEY = "notebook_metadata"
 
 
-def _python_kernelspec_metadata(*, with_uv_deps=None, with_conda_deps=None,
-                                  with_conda_channels=None):
+def _python_kernelspec_metadata(
+    *, with_uv_deps=None, with_conda_deps=None, with_conda_channels=None
+):
     """Build a NotebookMetadataSnapshot JSON dict with a Python kernelspec."""
     snapshot = {
         "kernelspec": {
@@ -1036,8 +1095,7 @@ class TestKernelLaunchMetadata:
         assert env_source is not None
         # Should be one of the known env_source values
         assert any(
-            env_source.startswith(prefix)
-            for prefix in ("uv:", "conda:", "deno")
+            env_source.startswith(prefix) for prefix in ("uv:", "conda:", "deno")
         ), f"Unexpected env_source: {env_source}"
 
     @pytest.mark.skip(reason="Flaky - sync timing race condition in CI")
@@ -1275,7 +1333,13 @@ class TestCondaInlineDeps:
 
 
 # Fixture directory for project file tests
-FIXTURES_DIR = Path(__file__).parent.parent.parent.parent / "crates" / "notebook" / "fixtures" / "audit-test"
+FIXTURES_DIR = (
+    Path(__file__).parent.parent.parent.parent
+    / "crates"
+    / "notebook"
+    / "fixtures"
+    / "audit-test"
+)
 
 
 class TestProjectFileDetection:
@@ -1314,7 +1378,9 @@ class TestProjectFileDetection:
 
         # The fixture pyproject.toml declares numpy as a dependency
         result = session.run("import numpy; print(numpy.__version__)")
-        assert result.success, f"Failed to import numpy from pyproject env: {result.stderr}"
+        assert result.success, (
+            f"Failed to import numpy from pyproject env: {result.stderr}"
+        )
 
     def test_pixi_auto_detection(self, session):
         """notebook_path near pixi.toml auto-detects conda:pixi.
@@ -1350,7 +1416,9 @@ class TestProjectFileDetection:
         """
         import json
 
-        notebook_path = str(FIXTURES_DIR / "conda-env-project" / "7-environment-yml.ipynb")
+        notebook_path = str(
+            FIXTURES_DIR / "conda-env-project" / "7-environment-yml.ipynb"
+        )
 
         snapshot = _python_kernelspec_metadata()
         session.set_metadata(NOTEBOOK_METADATA_KEY, json.dumps(snapshot))
@@ -1556,7 +1624,9 @@ class TestAsyncDocumentFirstExecution:
         """Execution errors are captured in result."""
         await async_session.start_kernel()
 
-        cell_id = await async_session.create_cell("raise ValueError('async test error')")
+        cell_id = await async_session.create_cell(
+            "raise ValueError('async test error')"
+        )
         result = await async_session.execute_cell(cell_id)
 
         assert not result.success
@@ -1678,7 +1748,9 @@ class TestAsyncOutputTypes:
         """Captures stderr output."""
         await async_session.start_kernel()
 
-        cell_id = await async_session.create_cell("import sys; sys.stderr.write('async hello stderr\\n')")
+        cell_id = await async_session.create_cell(
+            "import sys; sys.stderr.write('async hello stderr\\n')"
+        )
         result = await async_session.execute_cell(cell_id)
 
         assert result.success
@@ -1743,7 +1815,7 @@ class TestAsyncContextManager:
 
         # After exit, kernel should be shut down
         # Verify by checking the room no longer has an active kernel
-        # Note: The daemon may be terminated by fixture teardown before we can verify,
+# Note: The daemon may be terminated by fixture teardown before we can verify,
         # which is fine - it means cleanup already completed
         try:
             client = runtimed.DaemonClient()

--- a/python/runtimed/tests/test_ipython_bridge.py
+++ b/python/runtimed/tests/test_ipython_bridge.py
@@ -26,8 +26,13 @@ class TestIPythonBridge:
             assert info["transport"] == "tcp"
             assert info["signature_scheme"] == "hmac-sha256"
             assert info["kernel_name"] == "python3"
-            for key in ("shell_port", "iopub_port", "stdin_port",
-                        "control_port", "hb_port"):
+            for key in (
+                "shell_port",
+                "iopub_port",
+                "stdin_port",
+                "control_port",
+                "hb_port",
+            ):
                 assert isinstance(info[key], int)
                 assert info[key] > 0
             assert len(info["key"]) == 32  # uuid4 hex
@@ -83,14 +88,17 @@ class TestIPythonBridge:
             # Build a kernel_info_request
             import hashlib
             import hmac as hmac_mod
-            header = json.dumps({
-                "msg_id": "test-123",
-                "msg_type": "kernel_info_request",
-                "username": "test",
-                "session": "test-session",
-                "date": "2025-01-01T00:00:00Z",
-                "version": "5.3",
-            }).encode()
+
+            header = json.dumps(
+                {
+                    "msg_id": "test-123",
+                    "msg_type": "kernel_info_request",
+                    "username": "test",
+                    "session": "test-session",
+                    "date": "2025-01-01T00:00:00Z",
+                    "version": "5.3",
+                }
+            ).encode()
             parent = b"{}"
             metadata = b"{}"
             content = b"{}"
@@ -102,9 +110,9 @@ class TestIPythonBridge:
             h.update(content)
             sig = h.hexdigest().encode()
 
-            dealer.send_multipart([
-                b"<IDS|MSG>", sig, header, parent, metadata, content
-            ])
+            dealer.send_multipart(
+                [b"<IDS|MSG>", sig, header, parent, metadata, content]
+            )
 
             # Wait for reply
             assert dealer.poll(3000)
@@ -134,24 +142,29 @@ class TestIPythonBridge:
 
             import hashlib
             import hmac as hmac_mod
-            header = json.dumps({
-                "msg_id": "test-456",
-                "msg_type": "execute_request",
-                "username": "test",
-                "session": "test-session",
-                "date": "2025-01-01T00:00:00Z",
-                "version": "5.3",
-            }).encode()
+
+            header = json.dumps(
+                {
+                    "msg_id": "test-456",
+                    "msg_type": "execute_request",
+                    "username": "test",
+                    "session": "test-session",
+                    "date": "2025-01-01T00:00:00Z",
+                    "version": "5.3",
+                }
+            ).encode()
             parent = b"{}"
             metadata = b"{}"
-            content = json.dumps({
-                "code": "",
-                "silent": True,
-                "store_history": False,
-                "user_expressions": {"cwd": "__import__('os').getcwd()"},
-                "allow_stdin": False,
-                "stop_on_error": False,
-            }).encode()
+            content = json.dumps(
+                {
+                    "code": "",
+                    "silent": True,
+                    "store_history": False,
+                    "user_expressions": {"cwd": "__import__('os').getcwd()"},
+                    "allow_stdin": False,
+                    "stop_on_error": False,
+                }
+            ).encode()
 
             h = hmac_mod.new(info["key"].encode(), digestmod=hashlib.sha256)
             h.update(header)
@@ -160,9 +173,9 @@ class TestIPythonBridge:
             h.update(content)
             sig = h.hexdigest().encode()
 
-            dealer.send_multipart([
-                b"<IDS|MSG>", sig, header, parent, metadata, content
-            ])
+            dealer.send_multipart(
+                [b"<IDS|MSG>", sig, header, parent, metadata, content]
+            )
 
             assert dealer.poll(3000)
             parts = dealer.recv_multipart()
@@ -210,9 +223,7 @@ class TestIPythonBridge:
             sub.connect(f"tcp://127.0.0.1:{info['iopub_port']}")
             time.sleep(0.1)
 
-            bridge.publish_execute_result(
-                {"text/plain": "42"}, {}, execution_count=1
-            )
+            bridge.publish_execute_result({"text/plain": "42"}, {}, execution_count=1)
 
             assert sub.poll(2000)
             parts = sub.recv_multipart()
@@ -353,13 +364,19 @@ class TestInstallBridge:
 
         bridge = install_bridge(ip)
         try:
-            ip.events.register.assert_called_once_with("post_run_cell", bridge._post_run_cell if hasattr(bridge, '_post_run_cell') else ip.events.register.call_args[0][1])
+            ip.events.register.assert_called_once_with(
+                "post_run_cell",
+                bridge._post_run_cell
+                if hasattr(bridge, "_post_run_cell")
+                else ip.events.register.call_args[0][1],
+            )
             assert bridge.connection_file.exists()
         finally:
             bridge.close()
 
     def test_install_wraps_stdout_stderr(self):
         import sys
+
         original_stdout = sys.stdout
         original_stderr = sys.stderr
         ip = MagicMock()

--- a/python/runtimed/tests/test_mcp.py
+++ b/python/runtimed/tests/test_mcp.py
@@ -18,7 +18,9 @@ class TestMcpServerImports:
             assert hasattr(_mcp_server, "main")
         except ImportError as e:
             if "mcp" in str(e):
-                pytest.skip("mcp package not installed (install with: pip install runtimed[mcp])")
+                pytest.skip(
+                    "mcp package not installed (install with: pip install runtimed[mcp])"
+                )
             raise
 
 

--- a/python/runtimed/tests/test_sidecar.py
+++ b/python/runtimed/tests/test_sidecar.py
@@ -14,8 +14,10 @@ def test_sidecar_with_explicit_connection_file(tmp_path):
 
     mock_popen = MagicMock()
     mock_popen.poll.return_value = None
-    with patch("runtimed._sidecar.find_binary", return_value="/usr/bin/runt"), \
-         patch("subprocess.Popen", return_value=mock_popen) as popen_call:
+    with (
+        patch("runtimed._sidecar.find_binary", return_value="/usr/bin/runt"),
+        patch("subprocess.Popen", return_value=mock_popen) as popen_call,
+    ):
         result = sidecar(str(conn_file))
 
         assert isinstance(result, Sidecar)
@@ -37,8 +39,10 @@ def test_sidecar_without_quiet(tmp_path):
     conn_file.write_text('{"key": "test"}')
 
     mock_popen = MagicMock()
-    with patch("runtimed._sidecar.find_binary", return_value="/usr/bin/runt"), \
-         patch("subprocess.Popen", return_value=mock_popen) as popen_call:
+    with (
+        patch("runtimed._sidecar.find_binary", return_value="/usr/bin/runt"),
+        patch("subprocess.Popen", return_value=mock_popen) as popen_call,
+    ):
         sidecar(str(conn_file), quiet=False)
 
         cmd = popen_call.call_args[0][0]
@@ -52,8 +56,10 @@ def test_sidecar_with_dump(tmp_path):
     dump_file = tmp_path / "dump.json"
 
     mock_popen = MagicMock()
-    with patch("runtimed._sidecar.find_binary", return_value="/usr/bin/runt"), \
-         patch("subprocess.Popen", return_value=mock_popen) as popen_call:
+    with (
+        patch("runtimed._sidecar.find_binary", return_value="/usr/bin/runt"),
+        patch("subprocess.Popen", return_value=mock_popen) as popen_call,
+    ):
         sidecar(str(conn_file), dump=str(dump_file))
 
         cmd = popen_call.call_args[0][0]
@@ -81,8 +87,10 @@ def test_sidecar_close(tmp_path):
     conn_file.write_text('{"key": "test"}')
 
     mock_popen = MagicMock()
-    with patch("runtimed._sidecar.find_binary", return_value="/usr/bin/runt"), \
-         patch("subprocess.Popen", return_value=mock_popen):
+    with (
+        patch("runtimed._sidecar.find_binary", return_value="/usr/bin/runt"),
+        patch("subprocess.Popen", return_value=mock_popen),
+    ):
         s = sidecar(str(conn_file))
         s.close()
         mock_popen.terminate.assert_called_once()
@@ -98,11 +106,14 @@ def test_sidecar_terminal_ipython_launches_bridge():
     mock_popen.poll.return_value = None
 
     import builtins
+
     original = getattr(builtins, "get_ipython", None)
     builtins.get_ipython = lambda: mock_shell
     try:
-        with patch("runtimed._sidecar.find_binary", return_value="/usr/bin/runt"), \
-             patch("subprocess.Popen", return_value=mock_popen):
+        with (
+            patch("runtimed._sidecar.find_binary", return_value="/usr/bin/runt"),
+            patch("subprocess.Popen", return_value=mock_popen),
+        ):
             result = sidecar()
             assert isinstance(result, BridgedSidecar)
             assert result.running is True
@@ -121,6 +132,7 @@ def test_sidecar_terminal_ipython_no_pyzmq():
     type(mock_shell).__name__ = "TerminalInteractiveShell"
 
     import builtins
+
     original = getattr(builtins, "get_ipython", None)
     builtins.get_ipython = lambda: mock_shell
     try:
@@ -138,6 +150,7 @@ def test_sidecar_terminal_ipython_no_pyzmq():
 
 def test_sidecar_auto_detect_catches_non_runtime_errors():
     """Catches exceptions like MultipleInstanceError from get_connection_file."""
+
     class MultipleInstanceError(Exception):
         pass
 
@@ -148,14 +161,18 @@ def test_sidecar_auto_detect_catches_non_runtime_errors():
 
     # Ensure get_ipython is not defined (skip the terminal check)
     import builtins
+
     original = getattr(builtins, "get_ipython", None)
     if hasattr(builtins, "get_ipython"):
         delattr(builtins, "get_ipython")
     try:
-        with patch.dict("sys.modules", {
-            "ipykernel": MagicMock(),
-            "ipykernel.connect": mock_module,
-        }):
+        with patch.dict(
+            "sys.modules",
+            {
+                "ipykernel": MagicMock(),
+                "ipykernel.connect": mock_module,
+            },
+        ):
             with pytest.raises(RuntimeError, match="MultipleInstanceError"):
                 sidecar()
     finally:
@@ -171,7 +188,9 @@ def test_sidecar_repr_exited(tmp_path):
     mock_popen = MagicMock()
     mock_popen.poll.return_value = 0
     mock_popen.returncode = 0
-    with patch("runtimed._sidecar.find_binary", return_value="/usr/bin/runt"), \
-         patch("subprocess.Popen", return_value=mock_popen):
+    with (
+        patch("runtimed._sidecar.find_binary", return_value="/usr/bin/runt"),
+        patch("subprocess.Popen", return_value=mock_popen),
+    ):
         s = sidecar(str(conn_file))
         assert "exited (0)" in repr(s)


### PR DESCRIPTION
## Summary

- Fixes flaky `test_source_update_syncs_between_peers` test caused by CRDT sync timing between two sessions
- Adds `wait_for_sync()` helper with exponential backoff to poll for sync completion instead of fixed delays
- Removes skip decorator from the test

## Test plan

- [x] Test passes reliably (verified 5+ consecutive runs)
- [x] All `TestMultiClientSync` tests pass