### PR TITLE
fix(runtimed): preserve trailing newlines in stream terminal output

### DIFF
--- a/crates/runtimed/src/stream_terminal.rs
+++ b/crates/runtimed/src/stream_terminal.rs
@@ -176,6 +176,7 @@ impl StreamTerminals {
 fn serialize_to_ansi(term: &Term<VoidListener>) -> String {
     let grid = term.grid();
     let columns = grid.columns();
+    let cursor_line = grid.cursor.point.line.0;
 
     // First pass: find the last line with actual content (across full history)
     let topmost = grid.topmost_line();
@@ -358,7 +359,15 @@ fn serialize_to_ansi(term: &Term<VoidListener>) -> String {
         final_lines.pop();
     }
 
-    final_lines.join("\n")
+    let mut output = final_lines.join("\n");
+
+    // Preserve trailing newline if cursor is on a line after the last content.
+    // This happens when output ended with \n (e.g., print("hello") outputs "hello\n").
+    if cursor_line > max_line_with_content && !output.is_empty() {
+        output.push('\n');
+    }
+
+    output
 }
 
 /// Convert a Color to ANSI escape sequence.

--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -653,7 +653,6 @@ print()  # Final newline
         assert "Loading: 0%" not in result.stdout
         assert "Loading: 20%" not in result.stdout
 
-    @pytest.mark.skip(reason="Trailing newline stripped by stream_terminal.rs - see future work")
     def test_consecutive_prints_merged(self, session):
         """Consecutive print statements should be merged into one output."""
         session.start_kernel()
@@ -1662,7 +1661,6 @@ class TestAsyncKernelLifecycle:
 class TestAsyncOutputTypes:
     """Test different output types from execution with AsyncSession."""
 
-    @pytest.mark.skip(reason="Trailing newline stripped by stream_terminal.rs - see future work")
     @pytest.mark.asyncio
     async def test_async_stdout_output(self, async_session):
         """Captures stdout output."""


### PR DESCRIPTION
## Summary

Fixes trailing newlines being stripped from stream terminal output. The `serialize_to_ansi()` function was incorrectly removing trailing newlines when Python printed statements like `print("hello")` which output `"hello\n"`. This is now fixed by detecting when the cursor is on a line after the last content line.

## Testing

- `test_consecutive_prints_merged` now passes
- `test_async_stdout_output` now passes
- All 12 existing stream_terminal unit tests pass with no regressions

_PR submitted by @rgbkrk's agent, Quill_