### PR TITLE
docs: fix references to non-existent files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -262,7 +262,7 @@ Follow the pattern established by `environment_yml.rs` and `pixi.rs`:
 1. Create `crates/notebook/src/{format}.rs` with `find_{format}()` (directory walk) and `parse_{format}()` functions
 2. Add Tauri commands in `lib.rs`: `detect_{format}`, `get_{format}_dependencies`, `import_{format}_dependencies`
 3. Wire detection into `start_default_python_kernel_impl` at the correct priority position
-4. Add frontend detection in `useKernel.ts` auto-launch and `useCondaDependencies.ts` or `useDependencies.ts`
+4. Add frontend detection in `App.tsx` auto-launch and `useCondaDependencies.ts` or `useDependencies.ts`
 5. Add test fixture in `crates/notebook/fixtures/audit-test/`
 
 ### Trust System
@@ -289,6 +289,6 @@ Dependencies are signed with HMAC-SHA256 using a per-machine key at `~/.config/r
 | `crates/notebook/src/environment_yml.rs` | environment.yml discovery and parsing |
 | `crates/notebook/src/deno_env.rs` | Deno config detection and version checking |
 | `crates/notebook/src/trust.rs` | HMAC trust verification |
-| `apps/notebook/src/hooks/useKernel.ts` | Frontend kernel lifecycle and auto-launch |
+| `apps/notebook/src/hooks/useDaemonKernel.ts` | Daemon-owned kernel execution, status broadcasts, environment sync |
 | `apps/notebook/src/hooks/useDependencies.ts` | Frontend UV dependency management |
 | `apps/notebook/src/hooks/useCondaDependencies.ts` | Frontend conda dependency management |

--- a/contributing/environments.md
+++ b/contributing/environments.md
@@ -57,7 +57,7 @@ This ensures the app works standalone without requiring users to install Python 
 ```mermaid
 graph TB
     subgraph Frontend ["Frontend (TypeScript)"]
-        UK[useKernel.ts]
+        UK[useDaemonKernel.ts]
         UD[useDependencies.ts]
         UCD[useCondaDependencies.ts]
         DH[DependencyHeader.tsx]
@@ -228,7 +228,7 @@ graph TB
 
 ```mermaid
 sequenceDiagram
-    participant FE as Frontend<br/>useKernel.ts
+    participant FE as Frontend<br/>useDaemonKernel.ts
     participant TC as Tauri Backend<br/>lib.rs
     participant PF as Project File<br/>Detection
     participant EP as env_pool.rs
@@ -388,7 +388,7 @@ graph TB
 
 The diagrams show three main layers and a separate daemon process:
 
-1. **Frontend** (blue) — React hooks that invoke Tauri commands and listen for `kernel:lifecycle` events. `useKernel.ts` handles inline deps and Deno detection locally, then defers to the backend for project file detection via `startDefaultKernel()`.
+1. **Frontend** (blue) — React hooks that invoke Tauri commands and listen for daemon broadcasts. `useDaemonKernel.ts` handles kernel status, execution queue, and environment sync state, while `App.tsx` orchestrates launch logic.
 
 2. **Tauri Backend** (orange) — `start_default_python_kernel_impl` runs the detection priority chain: inline deps first, then closest project file, then prewarmed pool. Each path delegates to a kernel start method.
 
@@ -566,10 +566,12 @@ Two parallel UI components manage dependencies:
 | `DependencyHeader.tsx` | `useDependencies.ts` | UV deps, pyproject.toml detection |
 | `CondaDependencyHeader.tsx` | `useCondaDependencies.ts` | Conda deps, environment.yml and pixi.toml detection |
 
-The kernel lifecycle is managed by `useKernel.ts`, which:
-- Listens for `kernel:lifecycle` events from the backend
-- Captures the `env_source` string (e.g. `"uv:pyproject"`, `"conda:pixi"`)
-- Runs auto-launch detection on notebook open
+The kernel lifecycle is managed by `useDaemonKernel.ts`, which:
+- Listens for daemon broadcasts (`kernel_status`, `execution_*`, `env_sync_state`, etc.)
+- Tracks kernel status and execution queue
+- Provides `launchKernel()`, `executeCell()`, `syncEnvironment()` methods
+
+Launch orchestration lives in `App.tsx`, which handles trust verification and auto-launch.
 
 ## Testing
 
@@ -625,7 +627,7 @@ The kernel lifecycle is managed by `useKernel.ts`, which:
 
 | File | Role |
 |------|------|
-| `apps/notebook/src/hooks/useKernel.ts` | Frontend kernel lifecycle and auto-launch |
+| `apps/notebook/src/hooks/useDaemonKernel.ts` | Daemon-owned kernel execution, status broadcasts, environment sync |
 | `apps/notebook/src/hooks/useDependencies.ts` | Frontend UV dep management |
 | `apps/notebook/src/hooks/useCondaDependencies.ts` | Frontend conda dep management |
 | `apps/notebook/src/components/DependencyHeader.tsx` | UV dependency UI panel |

--- a/contributing/ui.md
+++ b/contributing/ui.md
@@ -1,22 +1,37 @@
 # UI Components (Shadcn + nteract)
 
-This repository maintains shared UI components in `packages/ui` using the shadcn CLI and the `@nteract` registry.
+This repository maintains shared UI components at the repo root using the shadcn CLI and the `@nteract` registry.
 
 ## Quick Start
 
-Run the following commands from the `packages/ui` directory:
+Run the following commands from the **repository root**:
 
 ```bash
-cd packages/ui
 pnpm dlx shadcn@latest registry add @nteract
 pnpm dlx shadcn@latest add @nteract/all -yo
 pnpm dlx shadcn@latest add @nteract/ipycanvas -yo
 pnpm dlx shadcn@latest add dialog -yo
 ```
 
+## Project Structure
+
+```
+/
+├── components.json          # shadcn configuration
+├── tailwind.config.js       # Tailwind config (covers src/ and apps/)
+├── src/
+│   ├── components/ui/       # 23 shared shadcn components
+│   └── lib/utils.ts         # cn() utility
+└── apps/
+    ├── notebook/            # Uses @/components/ui/* via path alias
+    └── sidecar/             # Uses @/components/ui/* via path alias
+```
+
+Both apps access shared components via the `@/` path alias, which resolves to `../../src/` in their tsconfig.json files.
+
 ## Key Points
 
-- The `components.json` file in `packages/ui` serves as the configuration source for shadcn.
+- The `components.json` file at the repo root configures shadcn.
 - Running certain commands may generate a `deno.lock` file, though the cause remains undiagnosed.
 - The `--overwrite` flag can force refresh of generated files when needed.
 


### PR DESCRIPTION
## Summary

- Update `useKernel.ts` references to `useDaemonKernel.ts` in AGENTS.md and contributing/environments.md (the hook was renamed/never existed)
- Rewrite contributing/ui.md to reflect actual project structure: shadcn config is at repo root with shared components in `src/components/ui/`, not in a non-existent `packages/ui` directory

## Test plan

- [x] Verify no remaining `useKernel.ts` references in markdown: `rg "useKernel.ts" --type md`
- [x] Verify no remaining `packages/ui` references in markdown: `rg "packages/ui" --type md`
- [x] Verify referenced files exist: `useDaemonKernel.ts`, `components.json`, `src/components/ui/`