### PR TITLE
feat(menu): list and focus open windows

### DIFF
--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -1415,6 +1415,8 @@ fn create_notebook_window_with_label(
         }
     });
 
+    refresh_native_menu(app);
+
     Ok(label)
 }
 
@@ -3130,6 +3132,19 @@ fn focused_window(app: &tauri::AppHandle) -> Option<tauri::WebviewWindow> {
         .find(|window| window.is_focused().ok() == Some(true))
 }
 
+fn refresh_native_menu(app: &tauri::AppHandle) {
+    match crate::menu::create_menu(app) {
+        Ok(menu) => {
+            if let Err(error) = app.set_menu(menu) {
+                warn!("[menu] Failed to update native menu: {}", error);
+            }
+        }
+        Err(error) => {
+            warn!("[menu] Failed to rebuild native menu: {}", error);
+        }
+    }
+}
+
 /// Create a new notebook window with the specified runtime.
 fn spawn_new_notebook(
     app: &tauri::AppHandle,
@@ -3794,6 +3809,19 @@ pub fn run(
         })
         .on_menu_event(|app, event| {
             let menu_id = event.id().as_ref();
+            if let Some(window_label) = crate::menu::window_label_for_menu_item_id(menu_id) {
+                if let Some(window) = app.get_webview_window(window_label) {
+                    if let Err(error) = window.set_focus() {
+                        warn!(
+                            "[menu] Failed to focus selected window '{}': {}",
+                            window_label, error
+                        );
+                    }
+                } else {
+                    warn!("[menu] Selected window '{}' is no longer available", window_label);
+                }
+                return;
+            }
             let registry = app.state::<WindowNotebookRegistry>();
             match menu_id {
                 crate::menu::MENU_NEW_NOTEBOOK => {
@@ -3942,6 +3970,7 @@ pub fn run(
                     }
                 }
             }
+            refresh_native_menu(app_handle);
         }
 
         // Save session state when app is about to exit

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -1247,7 +1247,7 @@ async fn save_notebook_as(
         nb.path = Some(save_path);
         nb.dirty = false;
     }
-    refresh_native_menu(&window.app_handle(), registry.inner());
+    refresh_native_menu(window.app_handle(), registry.inner());
 
     // Reconnect to the daemon with the new path-based room ID.
     // This ensures realtime sync uses the correct file path as the room identifier.

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -1247,6 +1247,7 @@ async fn save_notebook_as(
         nb.path = Some(save_path);
         nb.dirty = false;
     }
+    refresh_native_menu(&window.app_handle(), registry.inner());
 
     // Reconnect to the daemon with the new path-based room ID.
     // This ensures realtime sync uses the correct file path as the room identifier.
@@ -1415,7 +1416,7 @@ fn create_notebook_window_with_label(
         }
     });
 
-    refresh_native_menu(app);
+    refresh_native_menu(app, registry);
 
     Ok(label)
 }
@@ -3132,8 +3133,45 @@ fn focused_window(app: &tauri::AppHandle) -> Option<tauri::WebviewWindow> {
         .find(|window| window.is_focused().ok() == Some(true))
 }
 
-fn refresh_native_menu(app: &tauri::AppHandle) {
-    match crate::menu::create_menu(app) {
+fn window_menu_display_name(
+    app: &tauri::AppHandle,
+    registry: &WindowNotebookRegistry,
+    window_label: &str,
+) -> String {
+    if let Ok(context) = registry.get(window_label) {
+        if let Ok(state) = context.notebook_state.lock() {
+            return state
+                .path
+                .as_ref()
+                .and_then(|path| path.file_name())
+                .and_then(|name| name.to_str())
+                .unwrap_or("Untitled.ipynb")
+                .to_string();
+        }
+    }
+
+    app.get_webview_window(window_label)
+        .and_then(|window| window.title().ok())
+        .filter(|title| !title.trim().is_empty())
+        .unwrap_or_else(|| window_label.to_string())
+}
+
+fn window_menu_display_names(
+    app: &tauri::AppHandle,
+    registry: &WindowNotebookRegistry,
+) -> HashMap<String, String> {
+    app.webview_windows()
+        .into_keys()
+        .map(|window_label| {
+            let display_name = window_menu_display_name(app, registry, &window_label);
+            (window_label, display_name)
+        })
+        .collect()
+}
+
+fn refresh_native_menu(app: &tauri::AppHandle, registry: &WindowNotebookRegistry) {
+    let window_display_names = window_menu_display_names(app, registry);
+    match crate::menu::create_menu(app, &window_display_names) {
         Ok(menu) => {
             if let Err(error) = app.set_menu(menu) {
                 warn!("[menu] Failed to update native menu: {}", error);
@@ -3581,6 +3619,10 @@ pub fn run(
                 // Normal startup - just set the title on the main window
                 if let Some(window) = app.get_webview_window("main") {
                     let _ = window.set_title(&window_title);
+                    refresh_native_menu(
+                        app.handle(),
+                        app.state::<WindowNotebookRegistry>().inner(),
+                    );
                 }
             }
 
@@ -3603,7 +3645,9 @@ pub fn run(
             }
 
             // Set up native menu bar
-            let menu = crate::menu::create_menu(app.handle())?;
+            let window_display_names =
+                window_menu_display_names(app.handle(), app.state::<WindowNotebookRegistry>().inner());
+            let menu = crate::menu::create_menu(app.handle(), &window_display_names)?;
             app.set_menu(menu)?;
 
             // Restore additional windows from session (main window already restored above)
@@ -3970,7 +4014,7 @@ pub fn run(
                     }
                 }
             }
-            refresh_native_menu(app_handle);
+            refresh_native_menu(app_handle, &registry_for_window_close);
         }
 
         // Save session state when app is about to exit
@@ -4027,6 +4071,7 @@ pub fn run(
                                     .and_then(|n| n.to_str())
                                     .unwrap_or("Untitled.ipynb");
                                 let _ = window.set_title(title);
+                                refresh_native_menu(app_handle, &registry_for_open);
                                 let _ = emit_to_label::<_, _, _>(
                                     &window,
                                     window.label(),

--- a/crates/notebook/src/menu.rs
+++ b/crates/notebook/src/menu.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use tauri::menu::{
     AboutMetadata, AboutMetadataBuilder, Menu, MenuItem, PredefinedMenuItem, Submenu,
 };
@@ -88,7 +89,10 @@ fn build_about_metadata() -> AboutMetadata<'static> {
 }
 
 /// Build the application menu bar
-pub fn create_menu(app: &AppHandle) -> tauri::Result<Menu<Wry>> {
+pub fn create_menu(
+    app: &AppHandle,
+    window_display_names: &HashMap<String, String>,
+) -> tauri::Result<Menu<Wry>> {
     let menu = Menu::new(app)?;
     let about_metadata = build_about_metadata();
 
@@ -244,15 +248,27 @@ pub fn create_menu(app: &AppHandle) -> tauri::Result<Menu<Wry>> {
     let window_menu = Submenu::new(app, "Window", true)?;
     window_menu.append(&PredefinedMenuItem::minimize(app, None)?)?;
     window_menu.append(&PredefinedMenuItem::close_window(app, None)?)?;
-    let mut window_labels: Vec<_> = app.webview_windows().into_keys().collect();
-    window_labels.sort();
-    if !window_labels.is_empty() {
+    let mut window_entries: Vec<_> = app
+        .webview_windows()
+        .into_keys()
+        .map(|window_label| {
+            let display_name = window_display_names
+                .get(&window_label)
+                .cloned()
+                .unwrap_or_else(|| window_label.clone());
+            (window_label, display_name)
+        })
+        .collect();
+    window_entries.sort_by(|(label_a, title_a), (label_b, title_b)| {
+        title_a.cmp(title_b).then_with(|| label_a.cmp(label_b))
+    });
+    if !window_entries.is_empty() {
         window_menu.append(&PredefinedMenuItem::separator(app)?)?;
-        for window_label in window_labels {
+        for (window_label, display_name) in window_entries {
             window_menu.append(&MenuItem::with_id(
                 app,
                 window_menu_item_id(&window_label),
-                window_label,
+                display_name,
                 true,
                 None::<&str>,
             )?)?;

--- a/crates/notebook/src/menu.rs
+++ b/crates/notebook/src/menu.rs
@@ -1,7 +1,7 @@
 use tauri::menu::{
     AboutMetadata, AboutMetadataBuilder, Menu, MenuItem, PredefinedMenuItem, Submenu,
 };
-use tauri::{AppHandle, Wry};
+use tauri::{AppHandle, Manager, Wry};
 
 pub struct BundledSampleNotebook {
     pub id: &'static str,
@@ -18,6 +18,7 @@ pub const MENU_OPEN: &str = "open";
 pub const MENU_OPEN_SAMPLE_PREFIX: &str = "open_sample:";
 pub const MENU_SAVE: &str = "save";
 pub const MENU_CLONE_NOTEBOOK: &str = "clone_notebook";
+pub const MENU_WINDOW_FOCUS_PREFIX: &str = "focus_window:";
 
 // Menu item IDs for zoom
 pub const MENU_ZOOM_IN: &str = "zoom_in";
@@ -66,6 +67,14 @@ pub fn sample_for_menu_item_id(menu_id: &str) -> Option<&'static BundledSampleNo
     BUNDLED_SAMPLE_NOTEBOOKS
         .iter()
         .find(|sample| sample.id == sample_id)
+}
+
+pub fn window_menu_item_id(window_label: &str) -> String {
+    format!("{MENU_WINDOW_FOCUS_PREFIX}{window_label}")
+}
+
+pub fn window_label_for_menu_item_id(menu_id: &str) -> Option<&str> {
+    menu_id.strip_prefix(MENU_WINDOW_FOCUS_PREFIX)
 }
 
 fn build_about_metadata() -> AboutMetadata<'static> {
@@ -235,6 +244,20 @@ pub fn create_menu(app: &AppHandle) -> tauri::Result<Menu<Wry>> {
     let window_menu = Submenu::new(app, "Window", true)?;
     window_menu.append(&PredefinedMenuItem::minimize(app, None)?)?;
     window_menu.append(&PredefinedMenuItem::close_window(app, None)?)?;
+    let mut window_labels: Vec<_> = app.webview_windows().into_keys().collect();
+    window_labels.sort();
+    if !window_labels.is_empty() {
+        window_menu.append(&PredefinedMenuItem::separator(app)?)?;
+        for window_label in window_labels {
+            window_menu.append(&MenuItem::with_id(
+                app,
+                window_menu_item_id(&window_label),
+                window_label,
+                true,
+                None::<&str>,
+            )?)?;
+        }
+    }
     menu.append(&window_menu)?;
 
     Ok(menu)
@@ -243,8 +266,9 @@ pub fn create_menu(app: &AppHandle) -> tauri::Result<Menu<Wry>> {
 #[cfg(test)]
 mod tests {
     use super::{
-        build_about_metadata, sample_for_menu_item_id, sample_menu_item_id, APP_COMMIT_SHA,
-        APP_NAME, APP_RELEASE_DATE, APP_VERSION, BUNDLED_SAMPLE_NOTEBOOKS, MENU_ABOUT_NTERACT,
+        build_about_metadata, sample_for_menu_item_id, sample_menu_item_id,
+        window_label_for_menu_item_id, window_menu_item_id, APP_COMMIT_SHA, APP_NAME,
+        APP_RELEASE_DATE, APP_VERSION, BUNDLED_SAMPLE_NOTEBOOKS, MENU_ABOUT_NTERACT,
     };
     use std::collections::HashSet;
 
@@ -276,6 +300,16 @@ mod tests {
             let resolved = sample_for_menu_item_id(&menu_id).expect("sample should resolve");
             assert_eq!(resolved.id, sample.id);
         }
+    }
+
+    #[test]
+    fn window_menu_ids_round_trip() {
+        for label in ["main", "onboarding", "notebook-123"] {
+            let menu_id = window_menu_item_id(label);
+            let resolved = window_label_for_menu_item_id(&menu_id).expect("window should resolve");
+            assert_eq!(resolved, label);
+        }
+        assert!(window_label_for_menu_item_id("new_notebook").is_none());
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add dynamic listing of open application windows to the Window menu and enable focusing them on selection.

---
<p><a href="https://cursor.com/agents/bc-981ea99e-692e-406e-827b-0f008cf80d0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-981ea99e-692e-406e-827b-0f008cf80d0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->