### PR TITLE
fix(notebook): rename kernel menu to runtime for clarity

### DIFF
--- a/crates/notebook/src/menu.rs
+++ b/crates/notebook/src/menu.rs
@@ -188,8 +188,8 @@ pub fn create_menu(app: &AppHandle) -> tauri::Result<Menu<Wry>> {
     edit_menu.append(&PredefinedMenuItem::select_all(app, None)?)?;
     menu.append(&edit_menu)?;
 
-    // Kernel menu
-    let kernel_menu = Submenu::new(app, "Kernel", true)?;
+    // Runtime menu
+    let kernel_menu = Submenu::new(app, "Runtime", true)?;
     kernel_menu.append(&MenuItem::with_id(
         app,
         MENU_RUN_ALL_CELLS,


### PR DESCRIPTION
Change the menu bar label from "Kernel" to "Runtime" for clearer terminology. This improves the consistency with how we refer to the execution context in the UI.

## Verification

- [x] cargo fmt and biome check pass
- [x] cargo xtask build completes successfully
- [x] pnpm test:run passes (279 tests)
- [x] cargo clippy passes with no warnings
- [x] cargo test passes (168 notebook tests)

_PR submitted by @rgbkrk's agent, Quill_