### PR TITLE
fix(notebook): sync python-created cells to NotebookState for deletion

### DIFF
--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -188,7 +188,9 @@ where
 /// Convert a CellSnapshot from Automerge to an nbformat Cell.
 /// Used when joining an existing room to update local state.
 fn cell_snapshot_to_nbformat(snap: &CellSnapshot) -> Cell {
-    let id = CellId::from(uuid::Uuid::parse_str(&snap.id).unwrap_or_else(|_| uuid::Uuid::new_v4()));
+    // Preserve the original cell ID string (handles both UUID and "cell-UUID" formats)
+    let id =
+        CellId::try_from(snap.id.as_str()).unwrap_or_else(|_| CellId::from(uuid::Uuid::new_v4()));
     let source: Vec<String> = if snap.source.is_empty() {
         Vec::new()
     } else {
@@ -415,6 +417,15 @@ async fn initialize_notebook_sync(
                 &update.cells,
             ) {
                 warn!("[notebook-sync] Failed to emit notebook:updated: {}", e);
+            }
+
+            // Sync cells to NotebookState (for save-to-disk and delete_cell operations)
+            if let Ok(mut state) = notebook_state_for_receiver.lock() {
+                state.notebook.cells = update.cells.iter().map(cell_snapshot_to_nbformat).collect();
+                info!(
+                    "[notebook-sync] Updated local state with {} cells from peer",
+                    state.notebook.cells.len()
+                );
             }
 
             // If metadata changed, merge into local state and notify frontend


### PR DESCRIPTION
## Summary

Cells created by Python bindings were visible in the UI but couldn't be deleted because:
1. The receiver loop synced cells to the frontend React state but not to the local NotebookState used by delete_cell command
2. Cell IDs with the "cell-" prefix were parsed as UUIDs, generating a new ID instead of preserving the original

## Changes

- Sync cells to NotebookState in the receiver loop (mirrors existing metadata sync pattern)
- Preserve original cell ID strings using CellId::try_from instead of UUID parsing

## Verification

- [x] Cell created via Python bindings now appears in UI
- [x] Cell can be deleted from UI (previously failed with "Cannot delete cell")
- [x] All existing tests pass
- [x] Clippy check passes with no warnings

## Test Plan

1. Start dev daemon: `cargo xtask dev-daemon`
2. Start app: `cargo xtask dev`
3. Open a notebook and note its ID
4. Connect via Python:
   ```python
   import runtimed
   s = runtimed.Session(notebook_id="<id>")
   s.connect()
   cell_id = s.create_cell("# Test\nprint('hello')")
   ```
5. Verify cell appears in UI
6. Delete cell from UI - should succeed

_PR submitted by @rgbkrk's agent, Quill_