### PR TITLE
fix(mcp): make mcp required and pin httpx to stable

### DIFF
--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -4,16 +4,24 @@ The `runtimed` package includes an MCP (Model Context Protocol) server that enab
 
 ## Installation
 
-Install with the MCP extra:
+Install runtimed (MCP support is included by default):
 
 ```bash
-pip install runtimed[mcp]
+pip install runtimed
 ```
 
 Or with uv:
 
 ```bash
-uv pip install "runtimed[mcp]"
+uv pip install runtimed
+```
+
+**Note:** While runtimed is in pre-release, you may need to allow pre-releases:
+
+```bash
+pip install --pre runtimed
+# or
+uv pip install --prerelease=allow runtimed
 ```
 
 ## Running the Server
@@ -30,19 +38,27 @@ python -m runtimed._mcp_server
 
 ## Claude Code Configuration
 
-Add to your Claude Code MCP configuration:
+Add the MCP server using the Claude CLI:
+
+```bash
+# Using uvx (recommended for pre-release)
+claude mcp add --scope user runtimed-mcp -- uvx --prerelease=allow runtimed-mcp
+```
+
+Or add to your Claude Code MCP configuration manually:
 
 ```json
 {
   "mcpServers": {
     "runtimed-mcp": {
-      "command": "runtimed-mcp"
+      "command": "uvx",
+      "args": ["--prerelease=allow", "runtimed-mcp"]
     }
   }
 }
 ```
 
-Or if using uv in a development environment:
+For development with local source:
 
 ```json
 {

--- a/python/runtimed/pyproject.toml
+++ b/python/runtimed/pyproject.toml
@@ -8,12 +8,14 @@ authors = [
     { name = "Kyle Kelley", email = "rgbkrk@gmail.com" }
 ]
 requires-python = ">=3.10"
-dependencies = []
+dependencies = [
+    "mcp>=1.26.0",
+    "httpx>=0.27.0,<1.0",  # Pin to stable, avoid 1.0 dev releases
+]
 
 [project.optional-dependencies]
 kernel = ["ipykernel>=6.0"]
 bridge = ["pyzmq>=25.0"]
-mcp = ["mcp>=1.26.0"]
 
 [project.scripts]
 runtimed-mcp = "runtimed._mcp_server:main"

--- a/python/runtimed/src/runtimed/_mcp_server.py
+++ b/python/runtimed/src/runtimed/_mcp_server.py
@@ -20,39 +20,14 @@ import logging
 import sys
 from typing import Any
 
-try:
-    from mcp.server.fastmcp import FastMCP
-
-    _MCP_AVAILABLE = True
-except ImportError:
-    _MCP_AVAILABLE = False
-    FastMCP = None  # type: ignore[misc, assignment]
+from mcp.server.fastmcp import FastMCP
 
 import runtimed
 
 logger = logging.getLogger(__name__)
 
-# Create the MCP server (only if mcp package is available)
-if _MCP_AVAILABLE:
-    mcp = FastMCP("runtimed-mcp")
-else:
-    # Create a stub so decorators don't fail at import time
-    class _StubMCP:
-        """Stub MCP server for when mcp package isn't installed."""
-
-        def tool(self):
-            def decorator(func):
-                return func
-
-            return decorator
-
-        def resource(self, uri: str):
-            def decorator(func):
-                return func
-
-            return decorator
-
-    mcp = _StubMCP()  # type: ignore[assignment]
+# Create the MCP server
+mcp = FastMCP("runtimed-mcp")
 
 # Session state - single active session at a time
 _session: runtimed.AsyncSession | None = None
@@ -489,14 +464,6 @@ async def resource_rooms() -> str:
 
 def main():
     """Run the MCP server."""
-    if not _MCP_AVAILABLE:
-        print(
-            "Error: MCP server requires the 'mcp' package.\n"
-            "Install with: pip install runtimed[mcp]",
-            file=sys.stderr,
-        )
-        sys.exit(1)
-
     logging.basicConfig(
         level=logging.INFO,
         format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",

--- a/python/runtimed/tests/test_mcp.py
+++ b/python/runtimed/tests/test_mcp.py
@@ -9,19 +9,10 @@ class TestMcpServerImports:
 
     def test_import_mcp_server(self):
         """Verify the MCP server module can be imported."""
-        # This will fail if mcp isn't installed, which is expected
-        # for the base package without the [mcp] extra
-        try:
-            from runtimed import _mcp_server
+        from runtimed import _mcp_server
 
-            assert hasattr(_mcp_server, "mcp")
-            assert hasattr(_mcp_server, "main")
-        except ImportError as e:
-            if "mcp" in str(e):
-                pytest.skip(
-                    "mcp package not installed (install with: pip install runtimed[mcp])"
-                )
-            raise
+        assert hasattr(_mcp_server, "mcp")
+        assert hasattr(_mcp_server, "main")
 
 
 class TestHelperFunctions:
@@ -65,15 +56,12 @@ class TestMcpServerIntegration:
     @pytest.mark.asyncio
     async def test_connect_and_run_code(self, daemon_running):
         """Test connecting and running code via MCP tools."""
-        try:
-            from runtimed._mcp_server import (
-                connect_notebook,
-                start_kernel,
-                run_code,
-                disconnect_notebook,
-            )
-        except ImportError:
-            pytest.skip("mcp package not installed")
+        from runtimed._mcp_server import (
+            connect_notebook,
+            start_kernel,
+            run_code,
+            disconnect_notebook,
+        )
 
         # Connect
         result = await connect_notebook()
@@ -87,7 +75,16 @@ class TestMcpServerIntegration:
             # Run some code
             result = await run_code("x = 42\nprint(x)")
             assert result["success"] is True
-            assert "42" in result["stdout"]
+            # Output comes through the outputs list
+            assert len(result["outputs"]) > 0
+            # Find the stream output with stdout
+            stdout_output = None
+            for output in result["outputs"]:
+                if output.get("output_type") == "stream" and output.get("name") == "stdout":
+                    stdout_output = output
+                    break
+            assert stdout_output is not None, f"No stdout output found in {result['outputs']}"
+            assert "42" in stdout_output.get("text", ""), f"Expected '42' in output: {stdout_output}"
         finally:
             # Disconnect
             await disconnect_notebook()
@@ -95,18 +92,15 @@ class TestMcpServerIntegration:
     @pytest.mark.asyncio
     async def test_create_and_execute_cell(self, daemon_running):
         """Test creating and executing a cell."""
-        try:
-            from runtimed._mcp_server import (
-                connect_notebook,
-                start_kernel,
-                create_cell,
-                execute_cell,
-                get_cell,
-                delete_cell,
-                disconnect_notebook,
-            )
-        except ImportError:
-            pytest.skip("mcp package not installed")
+        from runtimed._mcp_server import (
+            connect_notebook,
+            start_kernel,
+            create_cell,
+            execute_cell,
+            get_cell,
+            delete_cell,
+            disconnect_notebook,
+        )
 
         # Connect
         await connect_notebook()
@@ -128,7 +122,16 @@ class TestMcpServerIntegration:
             # Execute it
             result = await execute_cell(cell_id)
             assert result["success"] is True
-            assert "hello from MCP" in result["stdout"]
+            # Output comes through the outputs list
+            assert len(result["outputs"]) > 0
+            # Find the stream output with stdout
+            stdout_output = None
+            for output in result["outputs"]:
+                if output.get("output_type") == "stream" and output.get("name") == "stdout":
+                    stdout_output = output
+                    break
+            assert stdout_output is not None, f"No stdout output found in {result['outputs']}"
+            assert "hello from MCP" in stdout_output.get("text", ""), f"Expected 'hello from MCP' in output: {stdout_output}"
 
             # Clean up
             await delete_cell(cell_id)
@@ -138,10 +141,7 @@ class TestMcpServerIntegration:
     @pytest.mark.asyncio
     async def test_list_notebooks(self, daemon_running):
         """Test listing notebook rooms."""
-        try:
-            from runtimed._mcp_server import list_notebooks
-        except ImportError:
-            pytest.skip("mcp package not installed")
+        from runtimed._mcp_server import list_notebooks
 
         rooms = await list_notebooks()
         assert isinstance(rooms, list)
@@ -165,10 +165,7 @@ class TestMcpResources:
     @pytest.mark.asyncio
     async def test_resource_status_no_session(self, daemon_running):
         """Test status resource without active session."""
-        try:
-            from runtimed._mcp_server import resource_status
-        except ImportError:
-            pytest.skip("mcp package not installed")
+        from runtimed._mcp_server import resource_status
 
         result = await resource_status()
         data = json.loads(result)
@@ -177,10 +174,7 @@ class TestMcpResources:
     @pytest.mark.asyncio
     async def test_resource_rooms(self, daemon_running):
         """Test rooms resource."""
-        try:
-            from runtimed._mcp_server import resource_rooms
-        except ImportError:
-            pytest.skip("mcp package not installed")
+        from runtimed._mcp_server import resource_rooms
 
         result = await resource_rooms()
         data = json.loads(result)

--- a/python/runtimed/uv.lock
+++ b/python/runtimed/uv.lock
@@ -289,7 +289,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1176,6 +1176,10 @@ wheels = [
 name = "runtimed"
 version = "0.1.4"
 source = { editable = "." }
+dependencies = [
+    { name = "httpx" },
+    { name = "mcp" },
+]
 
 [package.optional-dependencies]
 bridge = [
@@ -1183,9 +1187,6 @@ bridge = [
 ]
 kernel = [
     { name = "ipykernel" },
-]
-mcp = [
-    { name = "mcp" },
 ]
 
 [package.dev-dependencies]
@@ -1198,11 +1199,12 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "httpx", specifier = ">=0.27.0,<1.0" },
     { name = "ipykernel", marker = "extra == 'kernel'", specifier = ">=6.0" },
-    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.26.0" },
+    { name = "mcp", specifier = ">=1.26.0" },
     { name = "pyzmq", marker = "extra == 'bridge'", specifier = ">=25.0" },
 ]
-provides-extras = ["kernel", "bridge", "mcp"]
+provides-extras = ["kernel", "bridge"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

- Make `mcp>=1.26.0` a required dependency (was optional)
- Add `httpx>=0.27.0,<1.0` constraint to prevent dependency resolution issues
- Simplify MCP server by removing optional fallback stub
- Update tests to work with blob-based output format
- Update documentation with prerelease installation instructions

## Why

The MCP server was failing to start with `uvx --prerelease=allow` because:
- `--prerelease=allow` was pulling `httpx==1.0.dev3` 
- httpx 1.0.dev3 removed `TransportError`
- httpx-sse depends on `TransportError`, causing import failure

Making mcp required simplifies the codebase and reflects that the MCP server is a primary use case for the runtimed Python package.

## Verification

- [x] cargo fmt
- [x] cargo clippy --all-targets -- -D warnings
- [x] MCP server starts correctly
- [x] Server connects to daemon and shares kernel state with other clients

_PR submitted by @rgbkrk's agent, Quill_