### PR TITLE
refactor(runtimed): use explicit RUNTIMED_* env vars

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -447,7 +447,7 @@ jobs:
       - name: Start E2E daemon
         run: |
           TARGET=$(ls target/release/binaries/ | grep runtimed | head -1)
-          CONDUCTOR_WORKSPACE_PATH="${GITHUB_WORKSPACE}" \
+          RUNTIMED_WORKSPACE_PATH="${GITHUB_WORKSPACE}" \
             ./target/release/binaries/$TARGET --dev run \
             --uv-pool-size 2 --conda-pool-size 0 &
           echo "RUNTIMED_PID=$!" >> $GITHUB_ENV
@@ -482,7 +482,7 @@ jobs:
           exit ${FAIL:-0}
         env:
           TAURI_APP_PATH: ./target/release/notebook
-          CONDUCTOR_WORKSPACE_PATH: ${{ github.workspace }}
+          RUNTIMED_WORKSPACE_PATH: ${{ github.workspace }}
           NO_AT_BRIDGE: 1
           LIBGL_ALWAYS_SOFTWARE: 1
           RUST_LOG: info,notebook=debug,runtimed=debug
@@ -608,7 +608,7 @@ jobs:
 
             # Start daemon fresh for each test
             TARGET=$(ls target/release/binaries/ | grep runtimed | head -1)
-            CONDUCTOR_WORKSPACE_PATH="${GITHUB_WORKSPACE}" \
+            RUNTIMED_WORKSPACE_PATH="${GITHUB_WORKSPACE}" \
               ./target/release/binaries/$TARGET --dev run \
               --uv-pool-size 2 --conda-pool-size 0 &
             DAEMON_PID=$!
@@ -644,7 +644,7 @@ jobs:
 
             # Start daemon with fixture directory as workspace path
             TARGET=$(ls target/release/binaries/ | grep runtimed | head -1)
-            CONDUCTOR_WORKSPACE_PATH="$fixture_dir" \
+            RUNTIMED_WORKSPACE_PATH="$fixture_dir" \
               ./target/release/binaries/$TARGET --dev run \
               --uv-pool-size 2 --conda-pool-size 0 &
             DAEMON_PID=$!
@@ -652,9 +652,9 @@ jobs:
 
             # Start tauri-driver from fixture directory so app inherits that CWD
             # Use absolute path for the app binary since we're changing directories
-            # Set CONDUCTOR_WORKSPACE_PATH so app connects to the daemon we just started
+            # Set RUNTIMED_WORKSPACE_PATH so app connects to the daemon we just started
             (cd "$fixture_dir" && \
-              CONDUCTOR_WORKSPACE_PATH="$fixture_dir" \
+              RUNTIMED_WORKSPACE_PATH="$fixture_dir" \
               TAURI_APP_PATH="${GITHUB_WORKSPACE}/target/release/notebook" \
               ~/.cargo/bin/tauri-driver --port 4444) &
             DRIVER_PID=$!
@@ -663,7 +663,7 @@ jobs:
             # Run test WITHOUT NOTEBOOK_PATH (untitled notebook)
             # Use absolute path for TAURI_APP_PATH since tauri-driver runs from fixture dir
             local exit_code=0
-            E2E_SPEC="$spec" CONDUCTOR_WORKSPACE_PATH="$fixture_dir" \
+            E2E_SPEC="$spec" RUNTIMED_WORKSPACE_PATH="$fixture_dir" \
               TAURI_APP_PATH="${GITHUB_WORKSPACE}/target/release/notebook" \
               pnpm test:e2e 2>&1 | tee -a e2e-logs/fixtures-output.log || exit_code=$?
 
@@ -696,7 +696,7 @@ jobs:
           exit $FAIL
         env:
           TAURI_APP_PATH: ./target/release/notebook
-          CONDUCTOR_WORKSPACE_PATH: ${{ github.workspace }}
+          RUNTIMED_WORKSPACE_PATH: ${{ github.workspace }}
           NO_AT_BRIDGE: 1
           LIBGL_ALWAYS_SOFTWARE: 1
           RUST_LOG: info,notebook=debug,runtimed=debug
@@ -770,7 +770,7 @@ jobs:
           export RUNTIMED_INTEGRATION_TEST=1
           export RUNTIMED_BINARY="${GITHUB_WORKSPACE}/target/release/runtimed"
           export RUNTIMED_LOG_LEVEL=debug
-          export CONDUCTOR_WORKSPACE_PATH="${GITHUB_WORKSPACE}"
+          export RUNTIMED_WORKSPACE_PATH="${GITHUB_WORKSPACE}"
 
           # Run tests (daemon is spawned by the test fixture)
           uv run pytest tests/test_daemon_integration.py -v --tb=short 2>&1 | tee integration-logs/test-output.log || FAIL=1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,18 +117,19 @@ Use the proper commands instead:
 
 ### Agent Access to Dev Daemon (Conductor Workspaces)
 
-When working in a Conductor workspace, the following environment variables are set automatically:
+When working in a Conductor workspace developing nteract/desktop, the xtask commands translate Conductor's environment variables to runtimed-specific ones:
 
-| Variable | Purpose | Used By |
-|----------|---------|---------|
-| `CONDUCTOR_WORKSPACE_PATH` | Enables dev mode; daemon state isolated to `~/.cache/runt/worktrees/{hash}/` | `runtimed::is_dev_mode()`, `daemon_base_dir()` |
-| `CONDUCTOR_WORKSPACE_NAME` | Human-readable workspace name for display | `runtimed::get_workspace_name()` |
-| `CONDUCTOR_PORT` | Vite dev server port (avoids conflicts between workspaces) | `cargo xtask dev`, `cargo xtask vite` |
-| `CONDUCTOR_DEFAULT_BRANCH` | Target branch for PRs (usually `main`) | Agent workflows |
+| Conductor Variable | Translated To | Purpose |
+|-------------------|---------------|---------|
+| `CONDUCTOR_WORKSPACE_PATH` | `RUNTIMED_WORKSPACE_PATH` | Daemon state isolated to `~/.cache/runt/worktrees/{hash}/` |
+| `CONDUCTOR_WORKSPACE_NAME` | `RUNTIMED_WORKSPACE_NAME` | Human-readable workspace name for display |
+| `CONDUCTOR_PORT` | (used directly) | Vite dev server port (avoids conflicts between workspaces) |
+
+**Important:** The translation only happens when running `cargo xtask dev` or `cargo xtask dev-daemon`. This allows using Conductor for unrelated projects without interfering with the system daemon.
 
 **Interacting with the daemon:**
 
-Use `./target/debug/runt` to interact with the worktree daemon. This binary automatically connects to the correct daemon based on `CONDUCTOR_WORKSPACE_PATH`.
+Use `./target/debug/runt` to interact with the worktree daemon. When started via `cargo xtask dev-daemon`, the daemon receives `RUNTIMED_WORKSPACE_PATH` and uses per-worktree isolation.
 
 ```bash
 # Check daemon status and pool info
@@ -147,7 +148,7 @@ Use `./target/debug/runt` to interact with the worktree daemon. This binary auto
 ./target/debug/runt daemon flush
 ```
 
-**Why `./target/debug/runt`?** The debug binary is built for the current worktree and reads `CONDUCTOR_WORKSPACE_PATH` to connect to the correct daemon. A system-installed `runt` would connect to the system daemon instead.
+**Why `./target/debug/runt`?** The debug binary is built with `RUNTIMED_WORKSPACE_PATH` in its environment (via xtask), so it connects to the worktree daemon. A system-installed `runt` connects to the system daemon instead.
 
 **Where state lives in dev mode:**
 ```

--- a/contributing/development.md
+++ b/contributing/development.md
@@ -132,7 +132,7 @@ cargo xtask build --rust-only && cargo xtask run  # Fast iteration
 
 The app detects dev mode and connects to the per-worktree daemon instead of installing/starting the system daemon.
 
-**Conductor users:** Dev mode is automatic when `CONDUCTOR_WORKSPACE_PATH` is set.
+**Conductor users:** When using `cargo xtask dev` or `cargo xtask dev-daemon`, the xtask commands automatically translate `CONDUCTOR_WORKSPACE_PATH` to `RUNTIMED_WORKSPACE_PATH`, enabling dev mode.
 
 **Non-Conductor users:** Set `RUNTIMED_DEV=1`:
 
@@ -147,9 +147,9 @@ RUNTIMED_DEV=1 cargo xtask dev
 **Useful commands:**
 
 ```bash
-runt daemon status           # Shows dev mode, worktree path, version
-runt daemon list-worktrees   # List all running dev daemons
-runt daemon logs -f          # Tail logs (uses correct log path in dev mode)
+./target/debug/runt daemon status           # Shows dev mode, worktree path, version
+./target/debug/runt daemon list-worktrees   # List all running dev daemons
+./target/debug/runt daemon logs -f          # Tail logs (uses correct log path in dev mode)
 ```
 
 Per-worktree state is stored in `~/.cache/runt/worktrees/{hash}/`.
@@ -163,7 +163,7 @@ When you need to test the full production flow (daemon auto-install, upgrades, e
 ```bash
 # Make sure dev mode is NOT set
 unset RUNTIMED_DEV
-unset CONDUCTOR_WORKSPACE_PATH
+unset RUNTIMED_WORKSPACE_PATH
 
 # Rebuild and reinstall system daemon
 cargo xtask install-daemon

--- a/crates/runt-workspace/src/lib.rs
+++ b/crates/runt-workspace/src/lib.rs
@@ -18,7 +18,7 @@ use std::process::Command;
 ///
 /// Returns true if:
 /// - `RUNTIMED_DEV=1` is set (explicit opt-in), OR
-/// - `CONDUCTOR_WORKSPACE_PATH` is set (automatic for Conductor users)
+/// - `RUNTIMED_WORKSPACE_PATH` is set (explicit workspace isolation)
 pub fn is_dev_mode() -> bool {
     // Explicit opt-in
     if std::env::var("RUNTIMED_DEV")
@@ -27,16 +27,15 @@ pub fn is_dev_mode() -> bool {
     {
         return true;
     }
-    // Auto-detect Conductor workspace
-    std::env::var("CONDUCTOR_WORKSPACE_PATH").is_ok()
+    // Workspace path presence enables dev mode
+    std::env::var("RUNTIMED_WORKSPACE_PATH").is_ok()
 }
 
 /// Get the workspace path for dev mode.
 ///
-/// Uses `CONDUCTOR_WORKSPACE_PATH` if available, otherwise detects via git.
+/// Uses `RUNTIMED_WORKSPACE_PATH` if available, otherwise detects via git.
 pub fn get_workspace_path() -> Option<PathBuf> {
-    // Prefer Conductor's workspace path
-    if let Ok(path) = std::env::var("CONDUCTOR_WORKSPACE_PATH") {
+    if let Ok(path) = std::env::var("RUNTIMED_WORKSPACE_PATH") {
         return Some(PathBuf::from(path));
     }
     // Fallback to git detection
@@ -45,11 +44,10 @@ pub fn get_workspace_path() -> Option<PathBuf> {
 
 /// Get the workspace name for display.
 ///
-/// Uses `CONDUCTOR_WORKSPACE_NAME` if available, otherwise reads from
+/// Uses `RUNTIMED_WORKSPACE_NAME` if available, otherwise reads from
 /// `.context/workspace-description` file in the worktree.
 pub fn get_workspace_name() -> Option<String> {
-    // Prefer Conductor's workspace name
-    if let Ok(name) = std::env::var("CONDUCTOR_WORKSPACE_NAME") {
+    if let Ok(name) = std::env::var("RUNTIMED_WORKSPACE_NAME") {
         return Some(name);
     }
     // Fallback: read .context/workspace-description

--- a/crates/runtimed-py/src/client.rs
+++ b/crates/runtimed-py/src/client.rs
@@ -30,7 +30,7 @@ impl DaemonClient {
     ///
     /// Connects to the daemon at the default socket path, which is
     /// automatically determined based on environment variables
-    /// (CONDUCTOR_WORKSPACE_PATH for dev mode).
+    /// (RUNTIMED_WORKSPACE_PATH for dev mode).
     #[new]
     fn new() -> PyResult<Self> {
         let runtime = Runtime::new().map_err(to_py_err)?;

--- a/crates/runtimed/src/client.rs
+++ b/crates/runtimed/src/client.rs
@@ -359,7 +359,7 @@ pub async fn try_get_pooled_env(env_type: EnvType) -> Option<PooledEnv> {
 /// 5. Starts the service if not running
 /// 6. Waits for the daemon to be ready
 ///
-/// In development mode (RUNTIMED_DEV=1 or CONDUCTOR_WORKSPACE_PATH set):
+/// In development mode (RUNTIMED_DEV=1 or RUNTIMED_WORKSPACE_PATH set):
 /// - Skips service installation/upgrade
 /// - Only checks if the per-worktree daemon is running
 /// - Returns an error with guidance if not running

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -471,14 +471,22 @@ fn cmd_dev_daemon() {
     println!();
 
     // Run the daemon with --dev flag
-    let status = Command::new(binary)
-        .args(["--dev", "run"])
-        .env("RUNTIMED_DEV", "1") // Also set env var for consistency
-        .status()
-        .unwrap_or_else(|e| {
-            eprintln!("Failed to run runtimed: {e}");
-            exit(1);
-        });
+    let mut cmd = Command::new(binary);
+    cmd.args(["--dev", "run"]);
+    cmd.env("RUNTIMED_DEV", "1");
+
+    // Translate Conductor → Runtimed for Conductor workspace users
+    if let Ok(path) = env::var("CONDUCTOR_WORKSPACE_PATH") {
+        cmd.env("RUNTIMED_WORKSPACE_PATH", &path);
+    }
+    if let Ok(name) = env::var("CONDUCTOR_WORKSPACE_NAME") {
+        cmd.env("RUNTIMED_WORKSPACE_NAME", &name);
+    }
+
+    let status = cmd.status().unwrap_or_else(|e| {
+        eprintln!("Failed to run runtimed: {e}");
+        exit(1);
+    });
 
     if !status.success() {
         exit(status.code().unwrap_or(1));
@@ -585,17 +593,25 @@ fn run_cmd(cmd: &str, args: &[&str]) {
 
 /// Run a command with RUST_LOG set to enable info-level logging.
 /// This is useful for dev mode to see Rust logs from the notebook app.
+/// Also translates CONDUCTOR_* env vars to RUNTIMED_* for Conductor workspace users.
 fn run_cmd_with_rust_log(cmd: &str, args: &[&str]) {
     // Use existing RUST_LOG if set, otherwise default to info
     let rust_log = env::var("RUST_LOG").unwrap_or_else(|_| "info".to_string());
-    let status = Command::new(cmd)
-        .args(args)
-        .env("RUST_LOG", &rust_log)
-        .status()
-        .unwrap_or_else(|e| {
-            eprintln!("Failed to run {cmd}: {e}");
-            exit(1);
-        });
+    let mut command = Command::new(cmd);
+    command.args(args).env("RUST_LOG", &rust_log);
+
+    // Translate Conductor → Runtimed for Conductor workspace users
+    if let Ok(path) = env::var("CONDUCTOR_WORKSPACE_PATH") {
+        command.env("RUNTIMED_WORKSPACE_PATH", &path);
+    }
+    if let Ok(name) = env::var("CONDUCTOR_WORKSPACE_NAME") {
+        command.env("RUNTIMED_WORKSPACE_NAME", &name);
+    }
+
+    let status = command.status().unwrap_or_else(|e| {
+        eprintln!("Failed to run {cmd}: {e}");
+        exit(1);
+    });
 
     if !status.success() {
         eprintln!("Command failed: {cmd} {}", args.join(" "));

--- a/docs/python-bindings.md
+++ b/docs/python-bindings.md
@@ -389,7 +389,7 @@ Common error scenarios:
 
 | Variable | Description |
 |----------|-------------|
-| `CONDUCTOR_WORKSPACE_PATH` | Use dev daemon for this worktree |
+| `RUNTIMED_WORKSPACE_PATH` | Use dev daemon for this worktree |
 | `RUNTIMED_SOCKET_PATH` | Override daemon socket path |
 
 ## Sidecar (Rich Output Viewer)

--- a/e2e/dev.sh
+++ b/e2e/dev.sh
@@ -12,7 +12,7 @@ DAEMON_PID_FILE="$PROJECT_ROOT/.e2e-daemon.pid"
 # This ensures the daemon and app use isolated paths (socket, settings, envs)
 # so E2E tests don't interfere with your regular development environment.
 # The daemon and app will use ~/.cache/runt/worktrees/{hash}/ instead of ~/.cache/runt/
-export CONDUCTOR_WORKSPACE_PATH="$PROJECT_ROOT"
+export RUNTIMED_WORKSPACE_PATH="$PROJECT_ROOT"
 
 # Source .env for default config (port, etc.)
 if [ -f "$PROJECT_ROOT/e2e/.env" ]; then

--- a/python/runtimed/tests/run-integration.sh
+++ b/python/runtimed/tests/run-integration.sh
@@ -50,7 +50,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 # Enable worktree isolation (same as e2e tests)
-export CONDUCTOR_WORKSPACE_PATH="$PROJECT_ROOT"
+export RUNTIMED_WORKSPACE_PATH="$PROJECT_ROOT"
 
 cd "$PYTHON_DIR"
 

--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -74,9 +74,9 @@ def _find_runtimed_binary():
     if "RUNTIMED_BINARY" in os.environ:
         return Path(os.environ["RUNTIMED_BINARY"])
 
-    # Use CONDUCTOR_WORKSPACE_PATH if available (preferred in CI and worktrees)
-    if "CONDUCTOR_WORKSPACE_PATH" in os.environ:
-        repo_root = Path(os.environ["CONDUCTOR_WORKSPACE_PATH"])
+    # Use RUNTIMED_WORKSPACE_PATH if available (preferred in CI and worktrees)
+    if "RUNTIMED_WORKSPACE_PATH" in os.environ:
+        repo_root = Path(os.environ["RUNTIMED_WORKSPACE_PATH"])
     else:
         # Fallback: walk up from this file (python/runtimed/tests/test_*.py)
         repo_root = Path(__file__).parent.parent.parent.parent.parent


### PR DESCRIPTION
## Summary

Fixes a conflict where `CONDUCTOR_WORKSPACE_PATH` (set in ALL Conductor workspaces) was incorrectly triggering dev mode isolation even when not developing nteract/desktop.

Solution: Introduce `RUNTIMED_WORKSPACE_PATH` and `RUNTIMED_WORKSPACE_NAME` for explicit opt-in to dev mode. The xtask dev commands translate `CONDUCTOR_*` → `RUNTIMED_*` for convenience in Conductor workspaces, but system-installed `runt`/`nteract` binaries won't react to `CONDUCTOR_*`, allowing use of Conductor for unrelated projects without interfering with the system daemon.

## Changes

- **runt-workspace**: Check `RUNTIMED_WORKSPACE_PATH` instead of `CONDUCTOR_WORKSPACE_PATH` for dev mode detection
- **xtask dev/dev-daemon**: Translate Conductor env vars for Conductor workspace users
- **CI workflows**: Use explicit `RUNTIMED_WORKSPACE_PATH` (10 occurrences)
- **E2E and Python tests**: Use `RUNTIMED_WORKSPACE_PATH`
- **Documentation**: Updated to explain the translation behavior and when dev mode is activated

## Verification

- Conductor workspace, unrelated project → uses system daemon (no RUNTIMED_* set)
- Conductor workspace, `cargo xtask dev` → uses dev daemon (xtask translates CONDUCTOR_* → RUNTIMED_*)
- CI test runs → use dev daemon (explicit RUNTIMED_WORKSPACE_PATH)
- Manual `RUNTIMED_DEV=1` → uses dev daemon

_PR submitted by @rgbkrk's agent, Quill_