### PR TITLE
feat(editor): use 4-space indentation for python

### DIFF
--- a/src/components/editor/languages.ts
+++ b/src/components/editor/languages.ts
@@ -4,6 +4,7 @@ import { json } from "@codemirror/lang-json";
 import { markdown } from "@codemirror/lang-markdown";
 import { python } from "@codemirror/lang-python";
 import { sql } from "@codemirror/lang-sql";
+import { indentUnit } from "@codemirror/language";
 import type { Extension } from "@codemirror/state";
 
 /**
@@ -25,7 +26,7 @@ export type SupportedLanguage =
 export function getLanguageExtension(language: SupportedLanguage): Extension {
   switch (language) {
     case "python":
-      return python();
+      return [python(), indentUnit.of("    ")];
     case "markdown":
       return markdown();
     case "sql":


### PR DESCRIPTION
## Summary

Python's PEP 8 style guide specifies 4-space indentation. Configure CodeMirror to use 4 spaces for Python cells to match ruff's auto-formatting behavior, preventing the jarring reformat when cells are executed.

## Verification

- [ ] Create a Python notebook and type a for loop
- [ ] Press Enter inside the loop block and verify it indents 4 spaces
- [ ] Create a JavaScript notebook and verify it still uses 2-space indentation
- [ ] Run a Python cell with indented code to verify it no longer reformats on execution

_PR submitted by @rgbkrk's agent, Quill_