### PR TITLE
feat(editor): add IPython magic and shell command highlighting

### DIFF
--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -182,8 +182,8 @@ function NotebookViewContent({
 
       if (cell.cell_type === "code") {
         const pagePayload = pagePayloads.get(cell.id) ?? null;
-        // Use TypeScript for Deno, Python otherwise
-        const language = runtime === "deno" ? "typescript" : "python";
+        // Use TypeScript for Deno, IPython otherwise (for magic/shell highlighting)
+        const language = runtime === "deno" ? "typescript" : "ipython";
         // Determine active match offset for this cell's source
         const activeSourceOffset =
           searchCurrentMatch &&

--- a/src/components/editor/codemirror-editor.tsx
+++ b/src/components/editor/codemirror-editor.tsx
@@ -17,7 +17,11 @@ import {
 
 import { cn } from "@/lib/utils";
 import { defaultExtensions } from "./extensions";
-import { getLanguageExtension, type SupportedLanguage } from "./languages";
+import {
+  getIPythonExtension,
+  getLanguageExtension,
+  type SupportedLanguage,
+} from "./languages";
 import { darkTheme, isDarkMode, lightTheme, type ThemeMode } from "./themes";
 
 export interface CodeMirrorEditorRef {
@@ -138,10 +142,13 @@ export const CodeMirrorEditor = forwardRef<
       };
     }, [theme]);
 
-    const langExtension = useMemo(
-      () => getLanguageExtension(language),
-      [language],
-    );
+    // For IPython, detect cell magics and switch to appropriate language mode
+    const langExtension = useMemo(() => {
+      if (language === "ipython") {
+        return getIPythonExtension(value).extension;
+      }
+      return getLanguageExtension(language);
+    }, [language, value]);
 
     // Determine which theme to use
     const themeExtension = useMemo(() => {

--- a/src/components/editor/index.ts
+++ b/src/components/editor/index.ts
@@ -11,12 +11,23 @@ export {
   notebookEditorTheme,
 } from "./extensions";
 export {
+  CELL_MAGIC_LANGUAGES,
+  detectCellMagic,
+  getCellMagicLanguage,
+  ipythonHighlighting,
+  ipythonIndent,
+  ipythonStyles,
+  ipythonStylesDark,
+} from "./ipython";
+export {
   detectLanguage,
   fileExtensionToLanguage,
+  getIPythonExtension,
   getLanguageExtension,
   languageDisplayNames,
   type SupportedLanguage,
 } from "./languages";
+export { searchHighlight } from "./search-highlight";
 export {
   darkTheme,
   documentHasDarkMode,

--- a/src/components/editor/ipython.ts
+++ b/src/components/editor/ipython.ts
@@ -1,0 +1,267 @@
+import { indentService } from "@codemirror/language";
+import { RangeSetBuilder } from "@codemirror/state";
+import type { DecorationSet, ViewUpdate } from "@codemirror/view";
+import { Decoration, EditorView, ViewPlugin } from "@codemirror/view";
+
+/**
+ * IPython syntax highlighting extension for CodeMirror 6
+ *
+ * Highlights IPython-specific syntax on top of standard Python:
+ * - Shell commands: !ls, !pip install
+ * - Line magics: %time, %run script.py
+ * - Cell magics: %%bash, %%javascript (first line only)
+ * - Help operators: object?, object??
+ *
+ * Note: For cell magics (%%), only the first line is decorated.
+ * The rest of the cell should use the appropriate language mode.
+ * Use detectCellMagic() and CELL_MAGIC_LANGUAGES to determine
+ * the correct language for cell magic content.
+ */
+
+// Decoration marks for IPython syntax
+const shellMark = Decoration.mark({ class: "cm-ipython-shell" });
+const magicMark = Decoration.mark({ class: "cm-ipython-magic" });
+const cellMagicMark = Decoration.mark({ class: "cm-ipython-cell-magic" });
+const helpMark = Decoration.mark({ class: "cm-ipython-help" });
+
+// Patterns for IPython syntax (applied to line content)
+const CELL_MAGIC_PATTERN = /^(%%[a-zA-Z_]\w*)/;
+const LINE_MAGIC_PATTERN = /^(%[a-zA-Z_]\w*)/;
+const SHELL_PATTERN = /^(!)/;
+const HELP_PATTERN = /(\?\??)$/;
+
+/**
+ * Custom indentation service for IPython.
+ *
+ * Prevents auto-indent after:
+ * - Line magics (%time, %matplotlib, etc.)
+ * - Shell commands (!pip, !ls, etc.)
+ * - Cell magic declarations (%%bash, %%html, etc.)
+ *
+ * These lines don't follow Python's indentation rules,
+ * so we reset to column 0 after them.
+ */
+export const ipythonIndent = indentService.of((context, pos) => {
+  // Get the previous line
+  const line = context.state.doc.lineAt(pos);
+  if (line.number <= 1) return null; // Let Python handle first line
+
+  const prevLine = context.state.doc.line(line.number - 1);
+  const prevText = prevLine.text.trim();
+
+  // After line magic, shell command, or cell magic - don't auto-indent
+  if (
+    LINE_MAGIC_PATTERN.test(prevText) ||
+    SHELL_PATTERN.test(prevText) ||
+    CELL_MAGIC_PATTERN.test(prevText)
+  ) {
+    return 0;
+  }
+
+  // Let Python's indentation handle everything else
+  return null;
+});
+
+/**
+ * Mapping of cell magic names to language identifiers.
+ * Use with getLanguageExtension() from languages.ts
+ */
+export const CELL_MAGIC_LANGUAGES: Record<string, string> = {
+  // HTML/SVG
+  html: "html",
+  HTML: "html",
+  svg: "html",
+  SVG: "html",
+  // JavaScript
+  javascript: "javascript",
+  js: "javascript",
+  // TypeScript
+  typescript: "typescript",
+  ts: "typescript",
+  // SQL
+  sql: "sql",
+  SQL: "sql",
+  // Markdown
+  markdown: "markdown",
+  md: "markdown",
+  // JSON
+  json: "json",
+  // Shell (falls back to plain since we don't have shell lang)
+  bash: "plain",
+  sh: "plain",
+  // Python (stays as Python)
+  python: "python",
+  python3: "python",
+  // Others without specific support fall back to plain
+};
+
+/**
+ * Detect cell magic from content.
+ * Cell magics must be on the first line.
+ *
+ * @param content - The editor content
+ * @returns The magic name (without %%) if found, null otherwise
+ *
+ * @example
+ * detectCellMagic("%%html\n<div>Hello</div>") // "html"
+ * detectCellMagic("%time x = 1") // null (line magic, not cell magic)
+ * detectCellMagic("print('hello')") // null
+ */
+export function detectCellMagic(content: string): string | null {
+  const firstLine = content.split("\n")[0].trim();
+  const match = firstLine.match(/^%%([a-zA-Z_]\w*)/);
+  return match ? match[1] : null;
+}
+
+/**
+ * Get the language identifier for a cell magic.
+ *
+ * @param magic - The cell magic name (without %%)
+ * @returns The language identifier to use with getLanguageExtension(),
+ *          or "plain" for unsupported magics
+ *
+ * @example
+ * getCellMagicLanguage("html") // "html"
+ * getCellMagicLanguage("bash") // "plain" (no shell support)
+ * getCellMagicLanguage("unknown") // "plain"
+ */
+export function getCellMagicLanguage(magic: string): string {
+  return CELL_MAGIC_LANGUAGES[magic] ?? "plain";
+}
+
+class IPythonHighlighter {
+  decorations: DecorationSet;
+
+  constructor(view: EditorView) {
+    this.decorations = this.buildDecorations(view);
+  }
+
+  update(update: ViewUpdate) {
+    if (update.docChanged || update.viewportChanged) {
+      this.decorations = this.buildDecorations(update.view);
+    }
+  }
+
+  buildDecorations(view: EditorView): DecorationSet {
+    const builder = new RangeSetBuilder<Decoration>();
+    const doc = view.state.doc;
+
+    // Check if we're in cell magic mode (first line is %%)
+    const firstLineText = doc.line(1).text.trim();
+    const isInCellMagicMode = CELL_MAGIC_PATTERN.test(firstLineText);
+
+    for (const { from, to } of view.visibleRanges) {
+      const startLine = doc.lineAt(from).number;
+      const endLine = doc.lineAt(to).number;
+
+      for (let lineNum = startLine; lineNum <= endLine; lineNum++) {
+        const line = doc.line(lineNum);
+        const lineText = line.text;
+        const trimmedText = lineText.trimStart();
+        const leadingSpaces = lineText.length - trimmedText.length;
+        const lineStart = line.from + leadingSpaces;
+
+        // Cell magic on first line - decorate it
+        if (lineNum === 1) {
+          const cellMagicMatch = trimmedText.match(CELL_MAGIC_PATTERN);
+          if (cellMagicMatch) {
+            builder.add(
+              lineStart,
+              lineStart + cellMagicMatch[1].length,
+              cellMagicMark,
+            );
+            continue;
+          }
+        }
+
+        // If we're in cell magic mode, don't apply IPython decorations
+        // to subsequent lines (they belong to the cell magic's language)
+        if (isInCellMagicMode && lineNum > 1) {
+          continue;
+        }
+
+        // Line magic (%magic)
+        const lineMagicMatch = trimmedText.match(LINE_MAGIC_PATTERN);
+        if (lineMagicMatch) {
+          builder.add(
+            lineStart,
+            lineStart + lineMagicMatch[1].length,
+            magicMark,
+          );
+          continue;
+        }
+
+        // Shell command (!command)
+        const shellMatch = trimmedText.match(SHELL_PATTERN);
+        if (shellMatch) {
+          builder.add(lineStart, line.to, shellMark);
+          continue;
+        }
+
+        // Help operator (object? or object??)
+        const helpMatch = lineText.match(HELP_PATTERN);
+        if (helpMatch && helpMatch.index !== undefined) {
+          const helpStart = line.from + helpMatch.index;
+          const helpEnd = helpStart + helpMatch[1].length;
+          builder.add(helpStart, helpEnd, helpMark);
+        }
+      }
+    }
+
+    return builder.finish();
+  }
+}
+
+/**
+ * CodeMirror extension that adds IPython syntax highlighting.
+ *
+ * For cells with cell magics (%%html, %%bash, etc.), only the first
+ * line is decorated. Use detectCellMagic() and getLanguageExtension()
+ * to set the appropriate language for the cell content.
+ */
+export function ipythonHighlighting() {
+  return ViewPlugin.fromClass(IPythonHighlighter, {
+    decorations: (v) => v.decorations,
+  });
+}
+
+/**
+ * Light theme styles for IPython syntax
+ */
+export const ipythonStyles = EditorView.theme({
+  ".cm-ipython-shell": {
+    color: "#0550ae",
+  },
+  ".cm-ipython-magic": {
+    color: "#6639ba",
+  },
+  ".cm-ipython-cell-magic": {
+    color: "#6639ba",
+    fontWeight: "bold",
+  },
+  ".cm-ipython-help": {
+    color: "#0969da",
+  },
+});
+
+/**
+ * Dark theme styles for IPython syntax
+ */
+export const ipythonStylesDark = EditorView.theme(
+  {
+    ".cm-ipython-shell": {
+      color: "#79c0ff",
+    },
+    ".cm-ipython-magic": {
+      color: "#d2a8ff",
+    },
+    ".cm-ipython-cell-magic": {
+      color: "#d2a8ff",
+      fontWeight: "bold",
+    },
+    ".cm-ipython-help": {
+      color: "#58a6ff",
+    },
+  },
+  { dark: true },
+);

--- a/src/components/editor/languages.ts
+++ b/src/components/editor/languages.ts
@@ -7,11 +7,22 @@ import { sql } from "@codemirror/lang-sql";
 import { indentUnit } from "@codemirror/language";
 import type { Extension } from "@codemirror/state";
 
+import {
+  CELL_MAGIC_LANGUAGES,
+  detectCellMagic,
+  getCellMagicLanguage,
+  ipythonHighlighting,
+  ipythonIndent,
+  ipythonStyles,
+  ipythonStylesDark,
+} from "./ipython";
+
 /**
  * Supported languages for the CodeMirror editor
  */
 export type SupportedLanguage =
   | "python"
+  | "ipython"
   | "markdown"
   | "sql"
   | "html"
@@ -23,10 +34,22 @@ export type SupportedLanguage =
 /**
  * Get the CodeMirror language extension for a given language
  */
+// PEP 8 specifies 4-space indentation for Python
+const pythonIndent = indentUnit.of("    ");
+
 export function getLanguageExtension(language: SupportedLanguage): Extension {
   switch (language) {
     case "python":
-      return [python(), indentUnit.of("    ")];
+      return [python(), pythonIndent];
+    case "ipython":
+      return [
+        python(),
+        pythonIndent,
+        ipythonIndent,
+        ipythonHighlighting(),
+        ipythonStyles,
+        ipythonStylesDark,
+      ];
     case "markdown":
       return markdown();
     case "sql":
@@ -45,10 +68,69 @@ export function getLanguageExtension(language: SupportedLanguage): Extension {
 }
 
 /**
+ * Get the language extension for IPython content, detecting cell magics.
+ *
+ * If the content starts with a cell magic (e.g., %%html, %%bash),
+ * returns the appropriate language extension for that magic.
+ * Otherwise returns the standard IPython extension.
+ *
+ * @param content - The editor content to analyze
+ * @returns Object with language extension and detected cell magic (if any)
+ *
+ * @example
+ * // Cell magic - returns HTML language
+ * getIPythonExtension("%%html\n<div>Hello</div>")
+ * // { extension: html(), cellMagic: "html", language: "html" }
+ *
+ * // No cell magic - returns IPython
+ * getIPythonExtension("%time x = sum(range(100))")
+ * // { extension: [python(), ...], cellMagic: null, language: "ipython" }
+ */
+export function getIPythonExtension(content: string): {
+  extension: Extension;
+  cellMagic: string | null;
+  language: SupportedLanguage;
+} {
+  const magic = detectCellMagic(content);
+
+  if (magic) {
+    const langId = getCellMagicLanguage(magic);
+    const language = (
+      langId in languageDisplayNames ? langId : "plain"
+    ) as SupportedLanguage;
+
+    // For cell magics, use the target language but add IPython decoration
+    // for the first line (the %%magic declaration)
+    const baseExtension = getLanguageExtension(language);
+    return {
+      extension: [
+        baseExtension,
+        ipythonHighlighting(),
+        ipythonStyles,
+        ipythonStylesDark,
+      ],
+      cellMagic: magic,
+      language,
+    };
+  }
+
+  // No cell magic - use standard IPython mode
+  return {
+    extension: getLanguageExtension("ipython"),
+    cellMagic: null,
+    language: "ipython",
+  };
+}
+
+// Re-export cell magic utilities for consumers
+export { CELL_MAGIC_LANGUAGES, detectCellMagic, getCellMagicLanguage };
+
+/**
  * Language display names for UI
  */
 export const languageDisplayNames: Record<SupportedLanguage, string> = {
   python: "Python",
+  ipython: "IPython",
   markdown: "Markdown",
   sql: "SQL",
   html: "HTML",
@@ -63,6 +145,7 @@ export const languageDisplayNames: Record<SupportedLanguage, string> = {
  */
 export const fileExtensionToLanguage: Record<string, SupportedLanguage> = {
   ".py": "python",
+  ".ipy": "ipython",
   ".md": "markdown",
   ".markdown": "markdown",
   ".sql": "sql",

--- a/src/components/editor/search-highlight.ts
+++ b/src/components/editor/search-highlight.ts
@@ -94,6 +94,17 @@ function createSearchHighlightPlugin(query: string, activeOffset: number) {
  * @param query - The search string to highlight (case-insensitive). Empty string = no highlights.
  * @param activeOffset - Character offset of the "active" match to highlight differently (-1 for none).
  * @returns A CodeMirror Extension array to pass to the editor.
+ *
+ * @example
+ * ```tsx
+ * import { searchHighlight } from "@/registry/editor/search-highlight";
+ *
+ * // Highlight all occurrences of "function"
+ * <CodeMirrorEditor extensions={[searchHighlight("function")]} />
+ *
+ * // Highlight with active match at character offset 100
+ * <CodeMirrorEditor extensions={[searchHighlight("function", 100)]} />
+ * ```
  */
 export function searchHighlight(query: string, activeOffset = -1): Extension[] {
   if (!query) return [];


### PR DESCRIPTION
Pull latest editor component from nteract/elements registry with IPython syntax highlighting support.

## What Changed
- Added IPython mode with syntax highlighting for:
  - Line magics: `%time`, `%matplotlib inline`, `%run script.py`
  - Cell magics: `%%html`, `%%bash`, `%%javascript` (with automatic language detection)
  - Shell commands: `!pip install`, `!ls -la`
  - Help operators: `object?`, `object??`
- Python notebook editor now uses "ipython" language mode by default
- New `ipython.ts` module provides cell magic detection and highlighting
- `getIPythonExtension()` analyzes cell content and applies appropriate language syntax highlighting

## Verification
- [x] Run the app and open a Python notebook
- [x] Test line magics: type `%time` and verify purple highlighting
- [x] Test cell magics: type `%%html` on first line, verify bold purple on first line and HTML highlighting on content
- [x] Test shell commands: type `!pip` and verify blue highlighting
- [x] Test help operators: type `x?` and verify blue highlighting
- [x] Run `cargo test` and `pnpm test:run` to verify no regressions

<img width="1142" height="854" alt="image" src="https://github.com/user-attachments/assets/25d44314-177e-48ba-bcdb-e0e56314147a" />


_PR submitted by @rgbkrk's agent, Quill_