### PR TITLE
fix(daemon): add HOME env var to launchd plist and early startup logging

### DIFF
--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -1687,6 +1687,8 @@ async fn doctor_command(
     struct DoctorReport {
         installed_binary: CheckResult,
         service_config: CheckResult,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        plist_home_env: Option<CheckResult>,
         socket_file: CheckResult,
         daemon_state: CheckResult,
         daemon_running: CheckResult,
@@ -1728,6 +1730,39 @@ async fn doctor_command(
             status: if config_exists { "ok" } else { "missing" }.to_string(),
             detail: None,
         };
+
+        // Check 2b: On macOS, verify plist has HOME environment variable
+        #[cfg(target_os = "macos")]
+        let plist_home_env = if config_exists {
+            match std::fs::read_to_string(&service_config_path) {
+                Ok(content) => {
+                    if content.contains("<key>HOME</key>") {
+                        Some(CheckResult {
+                            path: "HOME env in plist".to_string(),
+                            status: "ok".to_string(),
+                            detail: None,
+                        })
+                    } else {
+                        Some(CheckResult {
+                            path: "HOME env in plist".to_string(),
+                            status: "missing".to_string(),
+                            detail: Some(
+                                "plist missing HOME - daemon may fail to start".to_string(),
+                            ),
+                        })
+                    }
+                }
+                Err(_) => Some(CheckResult {
+                    path: "HOME env in plist".to_string(),
+                    status: "error".to_string(),
+                    detail: Some("could not read plist".to_string()),
+                }),
+            }
+        } else {
+            None
+        };
+        #[cfg(not(target_os = "macos"))]
+        let plist_home_env: Option<CheckResult> = None;
 
         // Check 3: Socket file
         let socket_exists = socket_path.exists();
@@ -1802,6 +1837,7 @@ async fn doctor_command(
         DoctorReport {
             installed_binary,
             service_config,
+            plist_home_env,
             socket_file,
             daemon_state,
             daemon_running,
@@ -1821,6 +1857,15 @@ async fn doctor_command(
     let binary_exists = binary_path.exists();
     let config_exists = service_config_path.exists();
     let socket_exists = socket_path.exists();
+
+    // On macOS, check if plist is missing HOME env var
+    #[cfg(target_os = "macos")]
+    let plist_home_missing = config_exists
+        && std::fs::read_to_string(&service_config_path)
+            .map(|content| !content.contains("<key>HOME</key>"))
+            .unwrap_or(false);
+    #[cfg(not(target_os = "macos"))]
+    let plist_home_missing = false;
 
     // Check daemon state for fix operations
     let daemon_state_status = if let Some(info) = daemon_info {
@@ -1859,6 +1904,23 @@ async fn doctor_command(
                     }
                 } else {
                     actions_taken.push("Removed stale socket file".to_string());
+                }
+            }
+        }
+
+        // Fix plist missing HOME env var (causes daemon to fail on startup)
+        if plist_home_missing && binary_exists {
+            // Stop daemon first if running
+            if daemon_running_before {
+                let _ = manager.stop();
+            }
+            // Regenerate plist with HOME by calling upgrade with the existing binary
+            match manager.upgrade(&binary_path) {
+                Ok(()) => {
+                    actions_taken.push("Regenerated plist with HOME env var".to_string());
+                }
+                Err(e) => {
+                    eprintln!("Failed to regenerate plist: {}", e);
                 }
             }
         }
@@ -1942,6 +2004,17 @@ async fn doctor_command(
             report.service_config.path,
             status_icon(&report.service_config.status)
         );
+        if let Some(ref plist_check) = report.plist_home_env {
+            println!(
+                "Plist HOME env:     {}{}",
+                status_icon(&plist_check.status),
+                plist_check
+                    .detail
+                    .as_ref()
+                    .map(|d| format!(" ({})", d))
+                    .unwrap_or_default()
+            );
+        }
         println!(
             "Socket file:        {} {}",
             report.socket_file.path,

--- a/crates/runtimed/src/main.rs
+++ b/crates/runtimed/src/main.rs
@@ -103,14 +103,58 @@ enum Commands {
     FlushPool,
 }
 
+/// Get a log path that works even when HOME is not set.
+/// Falls back to /tmp if the normal cache directory is unavailable.
+fn early_log_path() -> PathBuf {
+    // Try the standard location first
+    if let Some(cache) = dirs::cache_dir() {
+        let path = cache
+            .join(runt_workspace::cache_namespace())
+            .join("runtimed.log");
+        if let Some(parent) = path.parent() {
+            if std::fs::create_dir_all(parent).is_ok() {
+                return path;
+            }
+        }
+    }
+    // Fallback to /tmp which should always be writable
+    PathBuf::from("/tmp/runtimed-startup.log")
+}
+
+/// Write an early diagnostic message before logging is initialized.
+/// This ensures we capture startup failures even when HOME is not set.
+fn early_log(msg: &str) {
+    use std::io::Write;
+    let path = early_log_path();
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    if let Ok(mut file) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+    {
+        let timestamp = chrono::Local::now().format("%Y-%m-%d %H:%M:%S");
+        let _ = writeln!(file, "{} [STARTUP] {}", timestamp, msg);
+    }
+}
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    // Log startup diagnostics BEFORE anything else - helps debug launchd issues
+    early_log(&format!(
+        "runtimed starting: pid={}, HOME={:?}, USER={:?}",
+        std::process::id(),
+        std::env::var("HOME").ok(),
+        std::env::var("USER").ok()
+    ));
+
     // Install panic hook to ensure panics are logged to the daemon log file.
-    // This runs before logging is initialized, so we write directly to the file.
+    // Uses early_log_path() which falls back to /tmp if HOME is not set.
     std::panic::set_hook(Box::new(|panic_info| {
         use std::io::Write;
 
-        let log_path = runtimed::default_log_path();
+        let log_path = early_log_path();
         let timestamp = chrono::Local::now().format("%Y-%m-%d %H:%M:%S");
         let msg = format!("{} [PANIC] runtimed: {}", timestamp, panic_info);
 
@@ -118,7 +162,6 @@ async fn main() -> anyhow::Result<()> {
         eprintln!("{}", msg);
 
         // Also append to log file so it's captured for debugging.
-        // Create the directory first in case this is first run.
         if let Some(parent) = log_path.parent() {
             let _ = std::fs::create_dir_all(parent);
         }

--- a/crates/runtimed/src/service.rs
+++ b/crates/runtimed/src/service.rs
@@ -97,6 +97,9 @@ pub enum ServiceError {
     #[error("Failed to stop service: {0}")]
     StopFailed(String),
 
+    #[error("Failed to install service: {0}")]
+    InstallFailed(String),
+
     #[error("Unsupported platform")]
     UnsupportedPlatform,
 }
@@ -348,16 +351,25 @@ impl ServiceManager {
     // macOS-specific implementations
     #[cfg(target_os = "macos")]
     fn create_macos_plist(&self) -> ServiceResult<()> {
+        // Get home directory at plist generation time - launchd doesn't expand ~
+        let home = dirs::home_dir().ok_or_else(|| {
+            ServiceError::InstallFailed(
+                "Cannot determine home directory for service install".into(),
+            )
+        })?;
+        let home_str = home.to_string_lossy();
+        let user = std::env::var("USER").unwrap_or_else(|_| "unknown".into());
+
         let plist_content = format!(
             r#"<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
     <key>Label</key>
-    <string>{}</string>
+    <string>{label}</string>
     <key>ProgramArguments</key>
     <array>
-        <string>{}</string>
+        <string>{binary}</string>
     </array>
     <key>RunAtLoad</key>
     <true/>
@@ -367,21 +379,26 @@ impl ServiceManager {
         <true/>
     </dict>
     <key>StandardOutPath</key>
-    <string>{}</string>
+    <string>{log}</string>
     <key>StandardErrorPath</key>
-    <string>{}</string>
+    <string>{log}</string>
     <key>EnvironmentVariables</key>
     <dict>
+        <key>HOME</key>
+        <string>{home}</string>
+        <key>USER</key>
+        <string>{user}</string>
         <key>PATH</key>
-        <string>~/.local/bin:/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin</string>
+        <string>{home}/.local/bin:/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin</string>
     </dict>
 </dict>
 </plist>
 "#,
-            daemon_launchd_label(),
-            self.config.binary_path.display(),
-            self.config.log_path.display(),
-            self.config.log_path.display(),
+            label = daemon_launchd_label(),
+            binary = self.config.binary_path.display(),
+            log = self.config.log_path.display(),
+            home = home_str,
+            user = user,
         );
 
         let plist_path = plist_path();
@@ -436,24 +453,34 @@ impl ServiceManager {
     // Linux-specific implementations
     #[cfg(target_os = "linux")]
     fn create_linux_systemd(&self) -> ServiceResult<()> {
+        // Get home directory at service generation time - systemd doesn't expand ~
+        let home = dirs::home_dir().ok_or_else(|| {
+            ServiceError::InstallFailed(
+                "Cannot determine home directory for service install".into(),
+            )
+        })?;
+        let home_str = home.to_string_lossy();
+
         let service_name = daemon_service_basename();
         let service_content = format!(
             r#"[Unit]
-Description={} - Jupyter Runtime Daemon
+Description={name} - Jupyter Runtime Daemon
 After=network.target
 
 [Service]
 Type=simple
-ExecStart={}
+ExecStart={binary}
 Restart=on-failure
 RestartSec=5
-Environment=PATH=~/.local/bin:/usr/local/bin:/usr/bin:/bin
+Environment=HOME={home}
+Environment=PATH={home}/.local/bin:/usr/local/bin:/usr/bin:/bin
 
 [Install]
 WantedBy=default.target
 "#,
-            service_name,
-            self.config.binary_path.display(),
+            name = service_name,
+            binary = self.config.binary_path.display(),
+            home = home_str,
         );
 
         let service_file_path = systemd_service_path();

--- a/crates/runtimed/src/service.rs
+++ b/crates/runtimed/src/service.rs
@@ -206,7 +206,10 @@ impl ServiceManager {
             std::fs::set_permissions(&self.config.binary_path, perms)?;
         }
 
-        // Service config already exists, just restart.
+        // Recreate service config to apply any template changes (e.g., new env vars)
+        self.create_service_config()?;
+        info!("[service] Updated service config");
+
         self.start()?;
 
         info!("[service] Upgrade completed successfully");
@@ -673,5 +676,48 @@ mod tests {
         let manager = ServiceManager::default();
         // Just verify it doesn't panic
         let _ = manager.is_installed();
+    }
+
+    /// Verify the macOS plist template includes HOME env var (prevents startup failures)
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn test_plist_template_contains_home_env() {
+        // Verify that dirs::home_dir() returns Some (prerequisite for the template)
+        assert!(
+            dirs::home_dir().is_some(),
+            "HOME must be available for plist generation"
+        );
+
+        // Check the actual plist file if it exists (from a previous install)
+        let plist_path = plist_path();
+        if plist_path.exists() {
+            let content = std::fs::read_to_string(&plist_path).unwrap();
+            assert!(
+                content.contains("<key>HOME</key>"),
+                "Installed plist should contain HOME env var. \
+                 If this fails, run 'runt daemon doctor --fix' to update the plist."
+            );
+        }
+    }
+
+    /// Verify the Linux systemd template includes HOME env var
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn test_systemd_template_contains_home_env() {
+        // Verify that dirs::home_dir() returns Some (prerequisite for the template)
+        assert!(
+            dirs::home_dir().is_some(),
+            "HOME must be available for systemd service generation"
+        );
+
+        // Check the actual service file if it exists
+        let service_path = systemd_service_path();
+        if service_path.exists() {
+            let content = std::fs::read_to_string(&service_path).unwrap();
+            assert!(
+                content.contains("Environment=HOME="),
+                "Installed systemd service should contain HOME env var"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fixed daemon startup failures on systems without HOME env var by:
1. Adding HOME and USER environment variables to launchd plist and systemd service
2. Expanding tilde (~) to absolute paths in PATH (launchd/systemd don't expand ~ automatically)
3. Adding early startup diagnostics that fall back to /tmp when normal logging fails
4. Enhanced `runt daemon doctor` to detect missing HOME in plist and auto-fix with `--fix`

## What Changed

**Daemon Installation** (`crates/runtimed/src/service.rs`):
- macOS plist now includes `HOME` and `USER` environment variables
- Paths in plist no longer use literal `~` - expanded to user's home directory at generation time
- Same fixes applied to Linux systemd service file

**Daemon Startup** (`crates/runtimed/src/main.rs`):
- Added early logging before any operations that could fail
- Fallback to `/tmp/runtimed-startup.log` if standard cache directory unavailable
- Panic hook now uses the same fallback path for capture

**Diagnostic Tool** (`crates/runt/src/main.rs`):
- `runt daemon doctor` now checks if plist has HOME env var
- `runt daemon doctor --fix` can regenerate plist if HOME is missing

## Verification

- ✓ Rust tests and clippy pass
- ✓ `runt daemon doctor` shows plist HOME env check
- ✓ Early logging captures startup diagnostics in ~/.cache/runt/runtimed.log
- ✓ Fallback logging works to /tmp/runtimed-startup.log when needed

_PR submitted by @rgbkrk's agent, Quill_