### PR TITLE
refactor(runt): CLI consolidation with top-level aliases and dev commands

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -2,6 +2,9 @@
 #
 # This makes `runt` resolve to the local debug build (bin/runt wrapper)
 # instead of the system-wide /usr/local/bin/runt install.
+# Same with `notebook` and `runtimed`.
 PATH_add bin
 
-export CONDUCTOR_WORKSPACE_PATH="$(expand_path .)"
+export RUNTIMED_WORKSPACE_PATH="$(expand_path .)"
+export RUNTIMED_WORKSPACE_NAME="$(basename $(expand_path .))"
+export RUNTIMED_VITE_PORT="${CONDUCTOR_PORT:-5174}"

--- a/.envrc
+++ b/.envrc
@@ -8,3 +8,4 @@ PATH_add bin
 export RUNTIMED_WORKSPACE_PATH="$(expand_path .)"
 export RUNTIMED_WORKSPACE_NAME="$(basename $(expand_path .))"
 export RUNTIMED_VITE_PORT="${CONDUCTOR_PORT:-5174}"
+export RUNTIMED_DEV=1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5467,6 +5467,7 @@ dependencies = [
  "tabled",
  "tokio",
  "uuid",
+ "walkdir",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -825,6 +825,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "colored"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5451,6 +5461,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
+ "colored",
  "dirs 5.0.1",
  "futures",
  "jupyter-protocol",

--- a/apps/notebook/vite.config.ts
+++ b/apps/notebook/vite.config.ts
@@ -1,8 +1,8 @@
-import { defineConfig } from "vite";
-import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
-import { visualizer } from "rollup-plugin-visualizer";
+import react from "@vitejs/plugin-react";
 import path from "path";
+import { visualizer } from "rollup-plugin-visualizer";
+import { defineConfig } from "vite";
 import { isolatedRendererPlugin } from "./vite-plugin-isolated-renderer";
 
 export default defineConfig({
@@ -39,7 +39,9 @@ export default defineConfig({
     },
   },
   server: {
-    port: parseInt(process.env.CONDUCTOR_PORT || "5174"),
+    port: parseInt(
+      process.env.RUNTIMED_VITE_PORT || process.env.CONDUCTOR_PORT || "5174",
+    ),
     strictPort: true,
   },
   base: "/",

--- a/crates/runt/Cargo.toml
+++ b/crates/runt/Cargo.toml
@@ -2,7 +2,7 @@
 name = "runt-cli"
 version = "1.4.1"
 edition.workspace = true
-description = "CLI for Jupyter Runtimes — install via GitHub Releases or `pip install runtimed`, not crates.io"
+description = "CLI for Jupyter Runtimes — bundled with nteract"
 repository.workspace = true
 license.workspace = true
 publish = false

--- a/crates/runt/Cargo.toml
+++ b/crates/runt/Cargo.toml
@@ -25,6 +25,7 @@ sidecar = { path = "../sidecar" }
 runtimed = { path = "../runtimed" }
 runt-workspace = { path = "../runt-workspace" }
 clap = { version = "4.5.1", features = ["derive", "color"] }
+colored = "2"
 tokio = { version = "1", features = ["full"] }
 petname = "2"
 rpassword = "7"

--- a/crates/runt/Cargo.toml
+++ b/crates/runt/Cargo.toml
@@ -24,7 +24,7 @@ runtimelib = { workspace = true, features = ["tokio-runtime", "aws-lc-rs"] }
 sidecar = { path = "../sidecar" }
 runtimed = { path = "../runtimed" }
 runt-workspace = { path = "../runt-workspace" }
-clap = { version = "4.5.1", features = ["derive"] }
+clap = { version = "4.5.1", features = ["derive", "color"] }
 tokio = { version = "1", features = ["full"] }
 petname = "2"
 rpassword = "7"

--- a/crates/runt/Cargo.toml
+++ b/crates/runt/Cargo.toml
@@ -33,6 +33,7 @@ tabled = "0.15"
 futures = "0.3"
 chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
 notify = "8"
+walkdir = "2"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -120,6 +120,11 @@ struct Cli {
     command: Option<Commands>,
 }
 
+/// Check if dev mode is enabled via RUNTIMED_DEV environment variable
+fn is_dev_mode() -> bool {
+    std::env::var("RUNTIMED_DEV").is_ok()
+}
+
 #[derive(Subcommand)]
 enum Commands {
     /// Open the notebook application
@@ -152,6 +157,41 @@ enum Commands {
         /// Path to the notebook file, or notebook ID (UUID) for untitled notebooks
         path: PathBuf,
     },
+
+    // =========================================================================
+    // Top-level convenience aliases
+    // =========================================================================
+    /// Show daemon status (alias for `daemon status`)
+    Status {
+        /// Output in JSON format
+        #[arg(long)]
+        json: bool,
+    },
+    /// Diagnose daemon installation issues (alias for `daemon doctor`)
+    Doctor {
+        /// Attempt to fix issues automatically
+        #[arg(long)]
+        fix: bool,
+        /// Output in JSON format
+        #[arg(long)]
+        json: bool,
+    },
+    /// Tail daemon log file (alias for `daemon logs`)
+    Logs {
+        /// Follow the log (like tail -f)
+        #[arg(short, long)]
+        follow: bool,
+        /// Number of lines to show
+        #[arg(short = 'n', long, default_value = "50")]
+        lines: usize,
+    },
+
+    // =========================================================================
+    // Development utilities (only shown when RUNTIMED_DEV=1)
+    // =========================================================================
+    /// Development utilities for runtimed contributors
+    #[command(subcommand, hide = true)]
+    Dev(DevCommands),
     /// Inspect the Automerge state for a notebook (debug command)
     #[command(hide = true)]
     Inspect {
@@ -359,14 +399,19 @@ enum DaemonCommands {
     Shutdown,
     /// Check if the daemon is running (returns exit code)
     Ping,
+}
+
+/// Development commands (only shown when RUNTIMED_DEV=1)
+#[derive(Subcommand)]
+enum DevCommands {
     /// List all running dev worktree daemons
-    ListWorktrees {
+    Worktrees {
         /// Output in JSON format
         #[arg(long)]
         json: bool,
     },
     /// Clean up worktree daemon state directories
-    CleanWorktree {
+    Clean {
         /// Clean a specific worktree by its hash
         #[arg(long)]
         hash: Option<String>,
@@ -584,6 +629,27 @@ async fn async_main(command: Option<Commands>) -> Result<()> {
                 wait,
             )
             .await?
+        }
+
+        // Top-level convenience aliases
+        Some(Commands::Status { json }) => daemon_command(DaemonCommands::Status { json }).await?,
+        Some(Commands::Doctor { fix, json }) => {
+            daemon_command(DaemonCommands::Doctor { fix, json }).await?
+        }
+        Some(Commands::Logs { follow, lines }) => {
+            daemon_command(DaemonCommands::Logs { follow, lines }).await?
+        }
+
+        // Development commands (requires RUNTIMED_DEV=1)
+        Some(Commands::Dev(dev_cmd)) => {
+            if !is_dev_mode() {
+                eprintln!(
+                    "Error: 'runt dev' commands require RUNTIMED_DEV=1 environment variable."
+                );
+                eprintln!("These commands are intended for runtimed development only.");
+                std::process::exit(1);
+            }
+            dev_command(dev_cmd).await?
         }
 
         // Deprecated aliases (with warnings)
@@ -1686,10 +1752,18 @@ async fn daemon_command(command: DaemonCommands) -> Result<()> {
                 std::process::exit(1);
             }
         },
-        DaemonCommands::ListWorktrees { json } => {
+    }
+
+    Ok(())
+}
+
+/// Handle development commands (requires RUNTIMED_DEV=1)
+async fn dev_command(command: DevCommands) -> Result<()> {
+    match command {
+        DevCommands::Worktrees { json } => {
             list_worktree_daemons(json).await?;
         }
-        DaemonCommands::CleanWorktree {
+        DevCommands::Clean {
             hash,
             all,
             stale,

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -126,10 +126,11 @@ const TAGLINES: &[&str] = &[
 ];
 
 fn random_tagline() -> String {
+    use colored::Colorize;
     use std::collections::hash_map::RandomState;
     use std::hash::{BuildHasher, Hasher};
     let index = RandomState::new().build_hasher().finish() as usize % TAGLINES.len();
-    format!("Runt: {}", TAGLINES[index])
+    format!("{} {}", "Runt:".cyan().bold(), TAGLINES[index])
 }
 
 #[derive(Parser)]

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -693,7 +693,10 @@ async fn async_main(command: Option<Commands>) -> Result<()> {
             list_notebooks(json).await?
         }
 
-        None => println!("No command specified. Use --help for usage information."),
+        None => {
+            use clap::CommandFactory;
+            Cli::command().print_help()?;
+        }
     }
 
     Ok(())

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -138,7 +138,7 @@ fn random_tagline() -> String {
 }
 
 #[derive(Parser)]
-#[command(author, version, about = "CLI for Jupyter Runtimes", long_about = None)]
+#[command(name = "runt", author, version, about = "CLI for Jupyter Runtimes", long_about = None)]
 struct Cli {
     #[command(subcommand)]
     command: Option<Commands>,

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -12,7 +12,7 @@ use runtimelib::{
     create_client_heartbeat_connection, create_client_shell_connection_with_identity,
     find_kernelspec, peer_identity_for_session, runtime_dir, ConnectionInfo,
 };
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tokio::fs;
 use uuid::Uuid;
 
@@ -364,6 +364,27 @@ enum DaemonCommands {
         /// Output in JSON format
         #[arg(long)]
         json: bool,
+    },
+    /// Clean up worktree daemon state directories
+    CleanWorktree {
+        /// Clean a specific worktree by its hash
+        #[arg(long)]
+        hash: Option<String>,
+        /// Clean all worktree daemons (does not affect system daemon)
+        #[arg(long)]
+        all: bool,
+        /// Clean only stale worktrees (where original path no longer exists)
+        #[arg(long)]
+        stale: bool,
+        /// Stop running daemon before cleaning (otherwise refuses if running)
+        #[arg(long)]
+        force: bool,
+        /// Skip confirmation prompt
+        #[arg(short, long)]
+        yes: bool,
+        /// Show what would be deleted without actually deleting
+        #[arg(long)]
+        dry_run: bool,
     },
 }
 
@@ -1668,6 +1689,16 @@ async fn daemon_command(command: DaemonCommands) -> Result<()> {
         DaemonCommands::ListWorktrees { json } => {
             list_worktree_daemons(json).await?;
         }
+        DaemonCommands::CleanWorktree {
+            hash,
+            all,
+            stale,
+            force,
+            yes,
+            dry_run,
+        } => {
+            clean_worktree_command(hash, all, stale, force, yes, dry_run).await?;
+        }
     }
 
     Ok(())
@@ -2288,6 +2319,297 @@ async fn list_worktree_daemons(json_output: bool) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Clean up worktree daemon state directories
+async fn clean_worktree_command(
+    hash: Option<String>,
+    all: bool,
+    stale: bool,
+    force: bool,
+    yes: bool,
+    dry_run: bool,
+) -> Result<()> {
+    use runtimed::client::PoolClient;
+    use runtimed::singleton::read_daemon_info;
+    use std::io::{self, Write};
+
+    let worktrees_dir = dirs::cache_dir()
+        .unwrap_or_else(|| PathBuf::from("/tmp"))
+        .join("runt")
+        .join("worktrees");
+
+    if !worktrees_dir.exists() {
+        println!("No worktree state directories found.");
+        return Ok(());
+    }
+
+    // Collect worktree targets
+    struct WorktreeTarget {
+        hash: String,
+        path: PathBuf,
+        worktree_path: Option<String>,
+        is_running: bool,
+        is_stale: bool,
+        size_bytes: u64,
+    }
+
+    let mut targets: Vec<WorktreeTarget> = Vec::new();
+
+    if let Some(h) = hash {
+        // Specific hash
+        let path = worktrees_dir.join(&h);
+        if !path.exists() {
+            anyhow::bail!("No worktree state found for hash: {}", h);
+        }
+        targets.push(WorktreeTarget {
+            hash: h,
+            path,
+            worktree_path: None,
+            is_running: false,
+            is_stale: false,
+            size_bytes: 0,
+        });
+    } else if all || stale {
+        // All or stale worktrees
+        let mut entries = fs::read_dir(&worktrees_dir).await?;
+        while let Some(entry) = entries.next_entry().await? {
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+            let h = path
+                .file_name()
+                .and_then(|s| s.to_str())
+                .unwrap_or("unknown")
+                .to_string();
+            targets.push(WorktreeTarget {
+                hash: h,
+                path,
+                worktree_path: None,
+                is_running: false,
+                is_stale: false,
+                size_bytes: 0,
+            });
+        }
+    } else {
+        // Current worktree (default)
+        let workspace_path = runt_workspace::get_workspace_path().ok_or_else(|| {
+            anyhow::anyhow!("Not in a git worktree and RUNTIMED_WORKSPACE_PATH not set.\nUse --hash <hash> or --all to specify which worktree to clean.")
+        })?;
+        let h = runt_workspace::worktree_hash(&workspace_path);
+        let path = worktrees_dir.join(&h);
+        if !path.exists() {
+            anyhow::bail!(
+                "No worktree state found for {} (hash: {})",
+                workspace_path.display(),
+                h
+            );
+        }
+        targets.push(WorktreeTarget {
+            hash: h,
+            path,
+            worktree_path: Some(workspace_path.to_string_lossy().to_string()),
+            is_running: false,
+            is_stale: false,
+            size_bytes: 0,
+        });
+    }
+
+    if targets.is_empty() {
+        println!("No worktree state directories found.");
+        return Ok(());
+    }
+
+    // Check daemon status and calculate sizes for each target
+    for target in &mut targets {
+        // Read daemon info
+        let info_path = target.path.join("daemon.json");
+        if let Some(info) = read_daemon_info(&info_path) {
+            target.worktree_path = info.worktree_path.clone();
+
+            // Try to ping the daemon
+            let client = PoolClient::new(PathBuf::from(&info.endpoint));
+            target.is_running =
+                tokio::time::timeout(std::time::Duration::from_secs(2), client.ping())
+                    .await
+                    .map(|r| r.is_ok())
+                    .unwrap_or(false);
+
+            // Check if stale (original path no longer exists)
+            if let Some(ref wt_path) = target.worktree_path {
+                target.is_stale = !PathBuf::from(wt_path).exists();
+            }
+        }
+
+        // Calculate directory size
+        target.size_bytes = calculate_dir_size(&target.path);
+    }
+
+    // Filter to stale only if requested
+    if stale {
+        targets.retain(|t| t.is_stale);
+        if targets.is_empty() {
+            println!("No stale worktree state directories found.");
+            return Ok(());
+        }
+    }
+
+    // Check for running daemons
+    let running: Vec<_> = targets.iter().filter(|t| t.is_running).collect();
+    if !running.is_empty() && !force {
+        eprintln!("The following worktree daemons are still running:");
+        for t in &running {
+            eprintln!(
+                "  {} ({})",
+                t.hash,
+                t.worktree_path.as_deref().unwrap_or("unknown")
+            );
+        }
+        eprintln!();
+        eprintln!("Use --force to stop them first, or stop manually with:");
+        eprintln!("  runt daemon stop");
+        std::process::exit(1);
+    }
+
+    // Stop running daemons if --force
+    if force {
+        for target in &targets {
+            if target.is_running {
+                let info_path = target.path.join("daemon.json");
+                if let Some(info) = read_daemon_info(&info_path) {
+                    let client = PoolClient::new(PathBuf::from(&info.endpoint));
+                    print!("Stopping daemon {}... ", target.hash);
+                    io::stdout().flush()?;
+                    match client.shutdown().await {
+                        Ok(_) => {
+                            println!("done");
+                            // Brief wait for shutdown
+                            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+                        }
+                        Err(e) => {
+                            println!("warning: {}", e);
+                        }
+                    }
+                }
+            }
+        }
+        println!();
+    }
+
+    // Calculate total size
+    let total_size: u64 = targets.iter().map(|t| t.size_bytes).sum();
+
+    // Display summary
+    #[derive(Tabled)]
+    struct CleanupRow {
+        #[tabled(rename = "HASH")]
+        hash: String,
+        #[tabled(rename = "WORKTREE")]
+        worktree: String,
+        #[tabled(rename = "STATUS")]
+        status: String,
+        #[tabled(rename = "SIZE")]
+        size: String,
+    }
+
+    let rows: Vec<CleanupRow> = targets
+        .iter()
+        .map(|t| CleanupRow {
+            hash: t.hash.clone(),
+            worktree: t
+                .worktree_path
+                .as_ref()
+                .map(|p| shorten_path(&PathBuf::from(p)))
+                .unwrap_or_else(|| "-".to_string()),
+            status: if t.is_stale {
+                "stale".to_string()
+            } else if t.is_running {
+                "running".to_string()
+            } else {
+                "stopped".to_string()
+            },
+            size: format_size(t.size_bytes),
+        })
+        .collect();
+
+    let table = Table::new(&rows).with(Style::rounded()).to_string();
+    println!("{}", table);
+    println!();
+    println!(
+        "Will delete {} worktree state director{} ({})",
+        targets.len(),
+        if targets.len() == 1 { "y" } else { "ies" },
+        format_size(total_size)
+    );
+
+    if dry_run {
+        println!();
+        println!("(dry-run mode - no files deleted)");
+        return Ok(());
+    }
+
+    // Confirm unless --yes
+    if !yes {
+        print!("Continue? [y/N] ");
+        io::stdout().flush()?;
+        let mut input = String::new();
+        io::stdin().read_line(&mut input)?;
+        if !input.trim().eq_ignore_ascii_case("y") {
+            println!("Aborted.");
+            return Ok(());
+        }
+    }
+
+    // Perform deletion
+    let mut success_count = 0;
+    let mut failure_count = 0;
+
+    for target in &targets {
+        match std::fs::remove_dir_all(&target.path) {
+            Ok(()) => {
+                println!("Deleted {}", target.hash);
+                success_count += 1;
+            }
+            Err(e) => {
+                eprintln!("Failed to delete {}: {}", target.hash, e);
+                failure_count += 1;
+            }
+        }
+    }
+
+    println!();
+    println!("Cleaned {} worktree(s)", success_count);
+    if failure_count > 0 {
+        eprintln!("{} failed (check permissions)", failure_count);
+        std::process::exit(1);
+    }
+
+    Ok(())
+}
+
+/// Calculate total size of a directory
+fn calculate_dir_size(path: &Path) -> u64 {
+    walkdir::WalkDir::new(path)
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .filter_map(|e| e.metadata().ok())
+        .filter(|m| m.is_file())
+        .map(|m| m.len())
+        .sum()
+}
+
+/// Format bytes into human-readable size
+fn format_size(bytes: u64) -> String {
+    if bytes >= 1_000_000_000 {
+        format!("{:.1} GB", bytes as f64 / 1_000_000_000.0)
+    } else if bytes >= 1_000_000 {
+        format!("{:.1} MB", bytes as f64 / 1_000_000.0)
+    } else if bytes >= 1_000 {
+        format!("{:.1} KB", bytes as f64 / 1_000.0)
+    } else {
+        format!("{} B", bytes)
+    }
 }
 
 // =============================================================================

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -130,7 +130,11 @@ fn random_tagline() -> String {
     use std::collections::hash_map::RandomState;
     use std::hash::{BuildHasher, Hasher};
     let index = RandomState::new().build_hasher().finish() as usize % TAGLINES.len();
-    format!("{} {}", "Runt:".cyan().bold(), TAGLINES[index])
+
+    // ASCII art with colored brackets like notebook cells
+    let cells = format!("{}{}{}", "[*]".magenta(), "[ ]".blue(), "[▶]".green(),);
+
+    format!("{} {} {}", cells, "Runt:".purple().bold(), TAGLINES[index])
 }
 
 #[derive(Parser)]

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -125,11 +125,11 @@ const TAGLINES: &[&str] = &[
     "The CLI that makes notebooks go brrr",
 ];
 
-fn random_tagline() -> &'static str {
+fn random_tagline() -> String {
     use std::collections::hash_map::RandomState;
     use std::hash::{BuildHasher, Hasher};
     let index = RandomState::new().build_hasher().finish() as usize % TAGLINES.len();
-    TAGLINES[index]
+    format!("Runt: {}", TAGLINES[index])
 }
 
 #[derive(Parser)]

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -131,10 +131,15 @@ fn random_tagline() -> String {
     use std::hash::{BuildHasher, Hasher};
     let index = RandomState::new().build_hasher().finish() as usize % TAGLINES.len();
 
-    // ASCII art with colored brackets like notebook cells
-    let cells = format!("{}{}{}", "[*]".magenta(), "[ ]".blue(), "[▶]".green(),);
-
-    format!("{} {} {}", cells, "Runt:".purple().bold(), TAGLINES[index])
+    // 3-line purple bracket with tagline on middle row
+    format!(
+        "{}\n{} {} {}\n{}",
+        "╭─".purple(),
+        "│".purple(),
+        "Runt:".purple().bold(),
+        TAGLINES[index],
+        "╰─".purple()
+    )
 }
 
 #[derive(Parser)]

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -113,8 +113,27 @@ fn truncate_error(msg: &str, max_len: usize) -> String {
     }
 }
 
+/// Random taglines for the CLI help
+const TAGLINES: &[&str] = &[
+    "It's Runtime Funtime",
+    "When Untitled229.ipynb just hits different",
+    "You can change these messages with one cool trick (make a PR)",
+    "While you're wrangling data, we're wrangling environments",
+    "Wrangling Jupyter runtimes so you don't have to",
+    "Your trusty Jupyter runtime companion",
+    "Notebooks, kernels, environments — all from your terminal",
+    "The CLI that makes notebooks go brrr",
+];
+
+fn random_tagline() -> &'static str {
+    use std::collections::hash_map::RandomState;
+    use std::hash::{BuildHasher, Hasher};
+    let index = RandomState::new().build_hasher().finish() as usize % TAGLINES.len();
+    TAGLINES[index]
+}
+
 #[derive(Parser)]
-#[command(author, version, about, long_about = None)]
+#[command(author, version, about = "CLI for Jupyter Runtimes", long_about = None)]
 struct Cli {
     #[command(subcommand)]
     command: Option<Commands>,
@@ -695,7 +714,7 @@ async fn async_main(command: Option<Commands>) -> Result<()> {
 
         None => {
             use clap::CommandFactory;
-            Cli::command().print_help()?;
+            Cli::command().about(random_tagline()).print_help()?;
         }
     }
 

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -85,8 +85,10 @@ fn cmd_dev(notebook: Option<&str>, attach: bool) {
     if attach {
         println!("Attaching to existing Vite server...");
 
-        // Use CONDUCTOR_PORT if set, otherwise default to 5174 (Vite's default)
-        let port = env::var("CONDUCTOR_PORT").unwrap_or_else(|_| "5174".to_string());
+        // Use RUNTIMED_VITE_PORT, fall back to CONDUCTOR_PORT, then default
+        let port = env::var("RUNTIMED_VITE_PORT")
+            .or_else(|_| env::var("CONDUCTOR_PORT"))
+            .unwrap_or_else(|_| "5174".to_string());
         println!("Connecting to Vite at http://localhost:{port}");
 
         // Skip beforeDevCommand (Vite is already running) and set devUrl
@@ -102,11 +104,15 @@ fn cmd_dev(notebook: Option<&str>, attach: bool) {
     } else {
         println!("Starting dev server with hot reload...");
 
-        // Check if CONDUCTOR_PORT is set and override devUrl accordingly
-        let config_override = env::var("CONDUCTOR_PORT").ok().map(|port| {
-            println!("Using CONDUCTOR_PORT={port}");
-            format!(r#"{{"build":{{"devUrl":"http://localhost:{port}"}}}}"#)
-        });
+        // Check for port override: RUNTIMED_VITE_PORT > CONDUCTOR_PORT
+        let config_override = env::var("RUNTIMED_VITE_PORT")
+            .map(|port| ("RUNTIMED_VITE_PORT", port))
+            .or_else(|_| env::var("CONDUCTOR_PORT").map(|port| ("CONDUCTOR_PORT", port)))
+            .ok()
+            .map(|(var, port)| {
+                println!("Using {var}={port}");
+                format!(r#"{{"build":{{"devUrl":"http://localhost:{port}"}}}}"#)
+            });
 
         let mut args = vec!["tauri", "dev"];
         if let Some(ref config) = config_override {
@@ -127,8 +133,10 @@ fn cmd_vite() {
     println!("Use `cargo xtask dev --attach` in another terminal to connect.");
     println!();
 
-    // Use CONDUCTOR_PORT if set
-    if let Ok(port) = env::var("CONDUCTOR_PORT") {
+    // Check for port override: RUNTIMED_VITE_PORT > CONDUCTOR_PORT
+    if let Ok(port) = env::var("RUNTIMED_VITE_PORT") {
+        println!("Using RUNTIMED_VITE_PORT={port}");
+    } else if let Ok(port) = env::var("CONDUCTOR_PORT") {
         println!("Using CONDUCTOR_PORT={port}");
     }
 


### PR DESCRIPTION
## Summary

Consolidates the `runt` CLI for better ergonomics:

- **Top-level shortcuts** for common operations:
  - `runt status` → `runt daemon status`
  - `runt doctor` → `runt daemon doctor`
  - `runt logs` → `runt daemon logs`

- **New `runt dev` subcommand** for development utilities (hidden from help, requires `RUNTIMED_DEV=1`):
  - `runt dev worktrees` - list worktree daemons
  - `runt dev clean` - clean worktree state directories

- **New `RUNTIMED_VITE_PORT` env var** for custom Vite dev server port (falls back to `CONDUCTOR_PORT`)

## Changes

1. **`crates/runt/src/main.rs`** - Add top-level aliases, create `DevCommands` enum, move worktree commands from `DaemonCommands`
2. **`crates/runt/Cargo.toml`** - Add `walkdir` dependency for directory size calculation
3. **`crates/xtask/src/main.rs`** - Support `RUNTIMED_VITE_PORT` env var
4. **`apps/notebook/vite.config.ts`** - Check `RUNTIMED_VITE_PORT` before `CONDUCTOR_PORT`

## Verification

- [x] `runt status` shows daemon status
- [x] `runt doctor` runs diagnostics
- [x] `runt logs -f` tails logs
- [x] `runt --help` does NOT show `dev` command
- [x] `RUNTIMED_DEV=1 runt dev worktrees` lists worktree daemons
- [x] `RUNTIMED_DEV=1 runt dev clean --dry-run` shows cleanup preview
- [x] Without `RUNTIMED_DEV`, `runt dev` errors with helpful message

<img width="639" height="350" alt="image" src="https://github.com/user-attachments/assets/ec72ef5a-36e5-49c4-85f9-a665cb1f0b99" />



_PR submitted by @rgbkrk's agent, Quill_