### PR TITLE
fix: prettify product name formatting

### DIFF
--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -292,10 +292,10 @@ jobs:
           echo "Setting version to: ${VERSION}"
           CHANNEL="${RUNT_BUILD_CHANNEL:-stable}"
           if [ "$CHANNEL" = "preview" ]; then
-            PRODUCT_NAME="nteract-preview"
+            PRODUCT_NAME="nteract (Preview)"
             BUNDLE_ID="org.nteract.desktop.preview"
           elif [ "$CHANNEL" = "nightly" ]; then
-            PRODUCT_NAME="nteract-nightly"
+            PRODUCT_NAME="nteract (Nightly)"
             BUNDLE_ID="org.nteract.desktop.nightly"
           else
             PRODUCT_NAME="nteract"
@@ -442,11 +442,11 @@ jobs:
           $channel = "${{ env.RUNT_BUILD_CHANNEL }}".ToLowerInvariant()
           switch ($channel) {
             "preview" {
-              $productName = "nteract-preview"
+              $productName = "nteract (Preview)"
               $bundleId = "org.nteract.desktop.preview"
             }
             "nightly" {
-              $productName = "nteract-nightly"
+              $productName = "nteract (Nightly)"
               $bundleId = "org.nteract.desktop.nightly"
             }
             default {
@@ -592,10 +592,10 @@ jobs:
           echo "Setting version to: ${VERSION}"
           CHANNEL="${RUNT_BUILD_CHANNEL:-stable}"
           if [ "$CHANNEL" = "preview" ]; then
-            PRODUCT_NAME="nteract-preview"
+            PRODUCT_NAME="nteract (Preview)"
             BUNDLE_ID="org.nteract.desktop.preview"
           elif [ "$CHANNEL" = "nightly" ]; then
-            PRODUCT_NAME="nteract-nightly"
+            PRODUCT_NAME="nteract (Nightly)"
             BUNDLE_ID="org.nteract.desktop.nightly"
           else
             PRODUCT_NAME="nteract"

--- a/crates/runt-workspace/src/lib.rs
+++ b/crates/runt-workspace/src/lib.rs
@@ -47,8 +47,8 @@ fn desktop_product_name_for(channel: BuildChannel) -> &'static str {
 fn desktop_display_name_for(channel: BuildChannel) -> &'static str {
     match channel {
         BuildChannel::Stable => "nteract",
-        BuildChannel::Preview => "nteract Preview",
-        BuildChannel::Nightly => "nteract Nightly",
+        BuildChannel::Preview => "nteract (Preview)",
+        BuildChannel::Nightly => "nteract (Nightly)",
     }
 }
 
@@ -349,6 +349,15 @@ mod tests {
         assert_eq!(
             desktop_product_name_for(BuildChannel::Nightly),
             "nteract-nightly"
+        );
+        assert_eq!(desktop_display_name_for(BuildChannel::Stable), "nteract");
+        assert_eq!(
+            desktop_display_name_for(BuildChannel::Preview),
+            "nteract (Preview)"
+        );
+        assert_eq!(
+            desktop_display_name_for(BuildChannel::Nightly),
+            "nteract (Nightly)"
         );
 
         assert_eq!(cache_namespace_for(BuildChannel::Stable), "runt");

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -521,8 +521,18 @@ fn main() -> Result<()> {
 fn desktop_app_launch_candidates() -> &'static [&'static str] {
     match runt_workspace::build_channel() {
         runt_workspace::BuildChannel::Stable => &["nteract"],
-        runt_workspace::BuildChannel::Preview => &["nteract-preview", "nteract Preview", "nteract"],
-        runt_workspace::BuildChannel::Nightly => &["nteract-nightly", "nteract Nightly", "nteract"],
+        runt_workspace::BuildChannel::Preview => &[
+            "nteract (Preview)",
+            "nteract-preview",
+            "nteract Preview",
+            "nteract",
+        ],
+        runt_workspace::BuildChannel::Nightly => &[
+            "nteract (Nightly)",
+            "nteract-nightly",
+            "nteract Nightly",
+            "nteract",
+        ],
     }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Rename nightly and preview app display names to "nteract (Nightly)" and "nteract (Preview)".

---
<p><a href="https://cursor.com/agents/bc-abe93f51-e965-4203-9295-a60991fa9624"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-abe93f51-e965-4203-9295-a60991fa9624"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->