### PR TITLE
feat(runtimed-py): true async streaming and multi-subscriber broadcasts

### DIFF
--- a/crates/runtimed-py/src/async_session.rs
+++ b/crates/runtimed-py/src/async_session.rs
@@ -15,8 +15,10 @@ use runtimed::notebook_sync_client::{
 use runtimed::protocol::{NotebookBroadcast, NotebookRequest, NotebookResponse};
 
 use crate::error::to_py_err;
-use crate::output::{Cell, ExecutionResult, Output};
+use crate::event_stream::ExecutionEventStream;
+use crate::output::{Cell, ExecutionEvent, ExecutionResult, Output};
 use crate::output_resolver;
+use crate::subscription::EventSubscription;
 
 /// An async session for executing code via the runtimed daemon.
 ///
@@ -407,6 +409,43 @@ impl AsyncSession {
         })
     }
 
+    /// Append text to a cell's source in the automerge document.
+    ///
+    /// Unlike set_source() which replaces the entire text (using Myers diff
+    /// internally), this directly inserts characters at the end of the source
+    /// Text CRDT. This is ideal for streaming/agentic use cases where an
+    /// external process is appending tokens incrementally — each append is
+    /// a minimal CRDT operation that syncs efficiently to all connected clients.
+    ///
+    /// Args:
+    ///     cell_id: The cell ID.
+    ///     text: The text to append to the cell's source.
+    ///
+    /// Returns a coroutine.
+    fn append_source<'py>(
+        &self,
+        py: Python<'py>,
+        cell_id: &str,
+        text: &str,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let state = Arc::clone(&self.state);
+        let cell_id = cell_id.to_string();
+        let text = text.to_string();
+
+        future_into_py(py, async move {
+            let state_guard = state.lock().await;
+            let handle = state_guard
+                .handle
+                .as_ref()
+                .ok_or_else(|| to_py_err("Not connected"))?;
+
+            handle
+                .append_source(&cell_id, &text)
+                .await
+                .map_err(to_py_err)
+        })
+    }
+
     /// Get a cell from the automerge document.
     ///
     /// Args:
@@ -688,6 +727,240 @@ impl AsyncSession {
                 ))),
             }
         })
+    }
+
+    /// Stream execution events for a cell as an async iterator.
+    ///
+    /// Unlike execute_cell() which blocks until completion and returns all
+    /// outputs at once, this returns an async iterator that yields ExecutionEvent
+    /// objects as they arrive from the kernel, enabling real-time processing.
+    ///
+    /// Example:
+    ///     ```python
+    ///     async for event in await session.stream_execute(cell_id):
+    ///         if event.event_type == "output":
+    ///             print(event.output.text)  # Process output immediately
+    ///     ```
+    ///
+    /// Args:
+    ///     cell_id: The cell ID to execute.
+    ///     timeout_secs: Maximum time to wait for each event (default: 60).
+    ///     signal_only: If True, output events contain only output_index, not
+    ///         the full output data. Use get_cell() to fetch the data.
+    ///
+    /// Returns a coroutine that resolves to ExecutionEventStream (async iterator).
+    #[pyo3(signature = (cell_id, timeout_secs=60.0, signal_only=false))]
+    fn stream_execute<'py>(
+        &self,
+        py: Python<'py>,
+        cell_id: &str,
+        timeout_secs: f64,
+        signal_only: bool,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let state = Arc::clone(&self.state);
+        let notebook_id = self.notebook_id.clone();
+        let cell_id = cell_id.to_string();
+
+        future_into_py(py, async move {
+            // Auto-start kernel if not running
+            {
+                let state_guard = state.lock().await;
+                if !state_guard.kernel_started {
+                    drop(state_guard);
+
+                    let state_guard = state.lock().await;
+                    if state_guard.handle.is_none() {
+                        drop(state_guard);
+
+                        let socket_path = if let Ok(path) = std::env::var("RUNTIMED_SOCKET_PATH") {
+                            std::path::PathBuf::from(path)
+                        } else {
+                            runtimed::default_socket_path()
+                        };
+
+                        let (handle, sync_rx, broadcast_rx, _cells, _notebook_path) =
+                            NotebookSyncClient::connect_split(
+                                socket_path.clone(),
+                                notebook_id.clone(),
+                            )
+                            .await
+                            .map_err(to_py_err)?;
+
+                        let (blob_base_url, blob_store_path) = if let Some(parent) =
+                            socket_path.parent()
+                        {
+                            let daemon_json = parent.join("daemon.json");
+                            let base_url = if daemon_json.exists() {
+                                tokio::fs::read_to_string(&daemon_json)
+                                    .await
+                                    .ok()
+                                    .and_then(|contents| {
+                                        serde_json::from_str::<serde_json::Value>(&contents).ok()
+                                    })
+                                    .and_then(|info| info.get("blob_port").and_then(|p| p.as_u64()))
+                                    .map(|port| format!("http://127.0.0.1:{}", port))
+                            } else {
+                                None
+                            };
+
+                            let store_path = parent.join("blobs");
+                            let store_path = if store_path.exists() {
+                                Some(store_path)
+                            } else {
+                                None
+                            };
+
+                            (base_url, store_path)
+                        } else {
+                            (None, None)
+                        };
+
+                        let mut state_guard = state.lock().await;
+                        state_guard.handle = Some(handle);
+                        state_guard.sync_rx = Some(sync_rx);
+                        state_guard.broadcast_rx = Some(broadcast_rx);
+                        state_guard.blob_base_url = blob_base_url;
+                        state_guard.blob_store_path = blob_store_path;
+                    }
+
+                    // Start kernel
+                    let mut state_guard = state.lock().await;
+                    let handle = state_guard
+                        .handle
+                        .as_ref()
+                        .ok_or_else(|| to_py_err("Not connected"))?;
+
+                    let response = handle
+                        .send_request(NotebookRequest::LaunchKernel {
+                            kernel_type: "python".to_string(),
+                            env_source: "uv:prewarmed".to_string(),
+                            notebook_path: None,
+                        })
+                        .await
+                        .map_err(to_py_err)?;
+
+                    match response {
+                        NotebookResponse::KernelLaunched {
+                            env_source: actual_env,
+                            ..
+                        } => {
+                            state_guard.kernel_started = true;
+                            state_guard.env_source = Some(actual_env);
+                        }
+                        NotebookResponse::KernelAlreadyRunning {
+                            env_source: actual_env,
+                            ..
+                        } => {
+                            state_guard.kernel_started = true;
+                            state_guard.env_source = Some(actual_env);
+                        }
+                        NotebookResponse::Error { error } => return Err(to_py_err(error)),
+                        other => {
+                            return Err(to_py_err(format!("Unexpected response: {:?}", other)))
+                        }
+                    }
+                }
+            }
+
+            // Queue execution and get broadcast receiver for streaming
+            let state_guard = state.lock().await;
+
+            let handle = state_guard
+                .handle
+                .as_ref()
+                .ok_or_else(|| to_py_err("Not connected"))?;
+
+            // Queue the cell for execution
+            let response = handle
+                .send_request(NotebookRequest::ExecuteCell {
+                    cell_id: cell_id.clone(),
+                })
+                .await
+                .map_err(to_py_err)?;
+
+            match response {
+                NotebookResponse::CellQueued { .. } => {}
+                NotebookResponse::Error { error } => return Err(to_py_err(error)),
+                other => return Err(to_py_err(format!("Unexpected response: {:?}", other))),
+            }
+
+            // Get a resubscribed broadcast receiver for this stream
+            let stream_broadcast_rx = state_guard
+                .broadcast_rx
+                .as_ref()
+                .ok_or_else(|| to_py_err("No broadcast receiver"))?
+                .resubscribe();
+
+            let blob_base_url = state_guard.blob_base_url.clone();
+            let blob_store_path = state_guard.blob_store_path.clone();
+
+            drop(state_guard);
+
+            // Return the async iterator
+            Ok(ExecutionEventStream::new(
+                stream_broadcast_rx,
+                cell_id,
+                timeout_secs,
+                blob_base_url,
+                blob_store_path,
+                signal_only,
+            ))
+        })
+    }
+
+    /// Subscribe to notebook broadcast events independently of execution.
+    ///
+    /// Returns an async iterator that yields all broadcast events from the
+    /// notebook, optionally filtered by cell IDs and event types. This
+    /// enables reactive patterns for agents that want to respond to any
+    /// document activity (including executions from other clients).
+    ///
+    /// Example:
+    ///     ```python
+    ///     # Subscribe to all events
+    ///     async for event in session.subscribe():
+    ///         print(f"Got: {event.event_type}")
+    ///
+    ///     # Subscribe with filters
+    ///     async for event in session.subscribe(event_types=["output", "done"]):
+    ///         if event.event_type == "output":
+    ///             print(event.output.text)
+    ///     ```
+    ///
+    /// Args:
+    ///     cell_ids: Optional list of cell IDs to filter events.
+    ///     event_types: Optional list of event types to filter. Valid types:
+    ///         "execution_started", "output", "done", "error", "kernel_status".
+    ///
+    /// Returns an EventSubscription async iterator.
+    #[pyo3(signature = (cell_ids=None, event_types=None))]
+    fn subscribe(
+        &self,
+        cell_ids: Option<Vec<String>>,
+        event_types: Option<Vec<String>>,
+    ) -> PyResult<EventSubscription> {
+        // Use a temporary runtime to access the state synchronously
+        let runtime = tokio::runtime::Runtime::new().map_err(to_py_err)?;
+        let state = runtime.block_on(self.state.lock());
+
+        let broadcast_rx = state
+            .broadcast_rx
+            .as_ref()
+            .ok_or_else(|| to_py_err("Not connected - call connect() or start_kernel() first"))?
+            .resubscribe();
+
+        let blob_base_url = state.blob_base_url.clone();
+        let blob_store_path = state.blob_store_path.clone();
+
+        drop(state);
+
+        Ok(EventSubscription::new(
+            broadcast_rx,
+            cell_ids,
+            event_types,
+            blob_base_url,
+            blob_store_path,
+        ))
     }
 
     /// Convenience method: create a cell, execute it, and return the result.
@@ -1071,4 +1344,95 @@ async fn collect_outputs_async(
         success,
         execution_count,
     })
+}
+
+/// Collect execution events for a cell, yielding each event as it arrives.
+///
+/// Returns a Vec of ExecutionEvent objects in arrival order. Unlike
+/// collect_outputs_async which accumulates outputs into a single result,
+/// this preserves the event stream for agents that want to process
+/// outputs incrementally.
+async fn collect_events_async(
+    state: &Arc<Mutex<AsyncSessionState>>,
+    cell_id: &str,
+    blob_base_url: Option<String>,
+    blob_store_path: Option<PathBuf>,
+) -> PyResult<Vec<ExecutionEvent>> {
+    let mut events = Vec::new();
+    let mut done_received = false;
+
+    loop {
+        let mut state_guard = state.lock().await;
+
+        let broadcast_rx = state_guard
+            .broadcast_rx
+            .as_mut()
+            .ok_or_else(|| to_py_err("Not connected"))?;
+
+        let timeout_ms = if done_received { 50 } else { 100 };
+        let broadcast = tokio::time::timeout(
+            std::time::Duration::from_millis(timeout_ms),
+            broadcast_rx.recv(),
+        )
+        .await;
+
+        match broadcast {
+            Ok(Some(msg)) => {
+                drop(state_guard);
+
+                match msg {
+                    NotebookBroadcast::ExecutionStarted {
+                        cell_id: msg_cell_id,
+                        execution_count: count,
+                    } => {
+                        if msg_cell_id == cell_id {
+                            events.push(ExecutionEvent::execution_started(cell_id, count));
+                        }
+                    }
+                    NotebookBroadcast::Output {
+                        cell_id: msg_cell_id,
+                        output_type,
+                        output_json,
+                        ..
+                    } => {
+                        if msg_cell_id == cell_id {
+                            if let Some(output) = output_resolver::resolve_output_with_type(
+                                &output_type,
+                                &output_json,
+                                &blob_base_url,
+                                &blob_store_path,
+                            )
+                            .await
+                            {
+                                events.push(ExecutionEvent::output(cell_id, output));
+                            }
+                        }
+                    }
+                    NotebookBroadcast::ExecutionDone {
+                        cell_id: msg_cell_id,
+                    } => {
+                        if msg_cell_id == cell_id {
+                            events.push(ExecutionEvent::done(cell_id));
+                            done_received = true;
+                        }
+                    }
+                    NotebookBroadcast::KernelError { error } => {
+                        events.push(ExecutionEvent::error(cell_id, &error));
+                        done_received = true;
+                    }
+                    _ => {}
+                }
+            }
+            Ok(None) => {
+                return Err(to_py_err("Broadcast channel closed"));
+            }
+            Err(_) => {
+                if done_received {
+                    break;
+                }
+            }
+        }
+    }
+
+    Ok(events)
 }

--- a/crates/runtimed-py/src/event_stream.rs
+++ b/crates/runtimed-py/src/event_stream.rs
@@ -1,0 +1,338 @@
+//! Async and sync iterators for execution events.
+//!
+//! Provides streaming access to execution events as they arrive from the kernel,
+//! enabling real-time processing of outputs during cell execution.
+
+use pyo3::exceptions::PyStopAsyncIteration;
+use pyo3::prelude::*;
+use pyo3_async_runtimes::tokio::future_into_py;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::Mutex;
+
+use runtimed::notebook_sync_client::NotebookBroadcastReceiver;
+use runtimed::protocol::NotebookBroadcast;
+
+use crate::error::to_py_err;
+use crate::output::ExecutionEvent;
+use crate::output_resolver;
+
+/// Async iterator over execution events for a cell.
+///
+/// Yields `ExecutionEvent` objects as they arrive from the kernel:
+/// - `execution_started`: Execution began (has `execution_count`)
+/// - `output`: An output was produced (has `output`)
+/// - `done`: Execution finished
+/// - `error`: Kernel error occurred (has `error_message`)
+///
+/// Example:
+///     ```python
+///     async for event in await session.stream_execute(cell_id):
+///         if event.event_type == "output":
+///             print(event.output.text)
+///     ```
+#[pyclass]
+pub struct ExecutionEventStream {
+    state: Arc<Mutex<EventStreamState>>,
+}
+
+struct EventStreamState {
+    /// Broadcast receiver for this stream (resubscribed from session)
+    broadcast_rx: NotebookBroadcastReceiver,
+    /// Cell ID we're streaming events for
+    cell_id: String,
+    /// Whether execution is done
+    done: bool,
+    /// Timeout for waiting on events
+    timeout_secs: f64,
+    /// For resolving blob outputs
+    blob_base_url: Option<String>,
+    blob_store_path: Option<PathBuf>,
+    /// Whether to include output data or just signal (signal_only mode)
+    signal_only: bool,
+}
+
+impl ExecutionEventStream {
+    /// Create a new execution event stream.
+    pub fn new(
+        broadcast_rx: NotebookBroadcastReceiver,
+        cell_id: String,
+        timeout_secs: f64,
+        blob_base_url: Option<String>,
+        blob_store_path: Option<PathBuf>,
+        signal_only: bool,
+    ) -> Self {
+        Self {
+            state: Arc::new(Mutex::new(EventStreamState {
+                broadcast_rx,
+                cell_id,
+                done: false,
+                timeout_secs,
+                blob_base_url,
+                blob_store_path,
+                signal_only,
+            })),
+        }
+    }
+}
+
+#[pymethods]
+impl ExecutionEventStream {
+    /// Return self as the async iterator.
+    fn __aiter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        slf
+    }
+
+    /// Get the next event asynchronously.
+    ///
+    /// Returns a coroutine that yields the next ExecutionEvent,
+    /// or raises StopAsyncIteration when execution is complete.
+    fn __anext__<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let state = Arc::clone(&self.state);
+
+        future_into_py(py, async move {
+            let mut state = state.lock().await;
+
+            // If already done, signal end of iteration
+            if state.done {
+                return Err(PyStopAsyncIteration::new_err("Execution complete"));
+            }
+
+            let timeout = Duration::from_secs_f64(state.timeout_secs);
+            let cell_id = state.cell_id.clone();
+            let blob_base_url = state.blob_base_url.clone();
+            let blob_store_path = state.blob_store_path.clone();
+            let signal_only = state.signal_only;
+
+            // Wait for next relevant broadcast
+            loop {
+                let recv_result = tokio::time::timeout(timeout, state.broadcast_rx.recv()).await;
+
+                match recv_result {
+                    Ok(Some(broadcast)) => {
+                        match broadcast {
+                            NotebookBroadcast::ExecutionStarted {
+                                cell_id: msg_cell_id,
+                                execution_count,
+                            } => {
+                                if msg_cell_id == cell_id {
+                                    return Ok(ExecutionEvent::execution_started(
+                                        &cell_id,
+                                        execution_count,
+                                    ));
+                                }
+                                // Not our cell, continue waiting
+                            }
+                            NotebookBroadcast::Output {
+                                cell_id: msg_cell_id,
+                                output_type,
+                                output_json,
+                                output_index,
+                            } => {
+                                if msg_cell_id == cell_id {
+                                    if signal_only {
+                                        // Signal-only mode: include index but not resolved output
+                                        return Ok(ExecutionEvent::output_signal(
+                                            &cell_id,
+                                            output_index,
+                                        ));
+                                    } else {
+                                        // Full mode: resolve and include the output
+                                        if let Some(output) =
+                                            output_resolver::resolve_output_with_type(
+                                                &output_type,
+                                                &output_json,
+                                                &blob_base_url,
+                                                &blob_store_path,
+                                            )
+                                            .await
+                                        {
+                                            return Ok(ExecutionEvent::output_with_index(
+                                                &cell_id,
+                                                output,
+                                                output_index,
+                                            ));
+                                        }
+                                    }
+                                }
+                            }
+                            NotebookBroadcast::ExecutionDone {
+                                cell_id: msg_cell_id,
+                            } => {
+                                if msg_cell_id == cell_id {
+                                    state.done = true;
+                                    return Ok(ExecutionEvent::done(&cell_id));
+                                }
+                            }
+                            NotebookBroadcast::KernelError { error } => {
+                                state.done = true;
+                                return Ok(ExecutionEvent::error(&cell_id, &error));
+                            }
+                            _ => {
+                                // Ignore other broadcasts (KernelStatus, QueueChanged, etc.)
+                                continue;
+                            }
+                        }
+                    }
+                    Ok(None) => {
+                        // Channel closed
+                        state.done = true;
+                        return Err(to_py_err("Broadcast channel closed"));
+                    }
+                    Err(_) => {
+                        // Timeout - execution might be hung
+                        state.done = true;
+                        return Err(to_py_err(format!(
+                            "Execution timed out after {} seconds",
+                            state.timeout_secs
+                        )));
+                    }
+                }
+            }
+        })
+    }
+
+    fn __repr__(&self) -> String {
+        "ExecutionEventStream(...)".to_string()
+    }
+}
+
+/// Sync iterator over execution events for a cell.
+///
+/// This is the synchronous equivalent of `ExecutionEventStream`.
+/// It blocks on each iteration until the next event arrives.
+#[pyclass]
+pub struct ExecutionEventIterator {
+    runtime: tokio::runtime::Runtime,
+    state: Arc<Mutex<EventStreamState>>,
+}
+
+impl ExecutionEventIterator {
+    /// Create a new execution event iterator.
+    pub fn new(
+        broadcast_rx: NotebookBroadcastReceiver,
+        cell_id: String,
+        timeout_secs: f64,
+        blob_base_url: Option<String>,
+        blob_store_path: Option<PathBuf>,
+        signal_only: bool,
+    ) -> PyResult<Self> {
+        let runtime = tokio::runtime::Runtime::new().map_err(to_py_err)?;
+        Ok(Self {
+            runtime,
+            state: Arc::new(Mutex::new(EventStreamState {
+                broadcast_rx,
+                cell_id,
+                done: false,
+                timeout_secs,
+                blob_base_url,
+                blob_store_path,
+                signal_only,
+            })),
+        })
+    }
+}
+
+#[pymethods]
+impl ExecutionEventIterator {
+    fn __iter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        slf
+    }
+
+    fn __next__(&self) -> PyResult<Option<ExecutionEvent>> {
+        let state = Arc::clone(&self.state);
+
+        self.runtime.block_on(async {
+            let mut state = state.lock().await;
+
+            if state.done {
+                return Ok(None);
+            }
+
+            let timeout = Duration::from_secs_f64(state.timeout_secs);
+            let cell_id = state.cell_id.clone();
+            let blob_base_url = state.blob_base_url.clone();
+            let blob_store_path = state.blob_store_path.clone();
+            let signal_only = state.signal_only;
+
+            loop {
+                let recv_result = tokio::time::timeout(timeout, state.broadcast_rx.recv()).await;
+
+                match recv_result {
+                    Ok(Some(broadcast)) => match broadcast {
+                        NotebookBroadcast::ExecutionStarted {
+                            cell_id: msg_cell_id,
+                            execution_count,
+                        } => {
+                            if msg_cell_id == cell_id {
+                                return Ok(Some(ExecutionEvent::execution_started(
+                                    &cell_id,
+                                    execution_count,
+                                )));
+                            }
+                        }
+                        NotebookBroadcast::Output {
+                            cell_id: msg_cell_id,
+                            output_type,
+                            output_json,
+                            output_index,
+                        } => {
+                            if msg_cell_id == cell_id {
+                                if signal_only {
+                                    return Ok(Some(ExecutionEvent::output_signal(
+                                        &cell_id,
+                                        output_index,
+                                    )));
+                                } else {
+                                    if let Some(output) = output_resolver::resolve_output_with_type(
+                                        &output_type,
+                                        &output_json,
+                                        &blob_base_url,
+                                        &blob_store_path,
+                                    )
+                                    .await
+                                    {
+                                        return Ok(Some(ExecutionEvent::output_with_index(
+                                            &cell_id,
+                                            output,
+                                            output_index,
+                                        )));
+                                    }
+                                }
+                            }
+                        }
+                        NotebookBroadcast::ExecutionDone {
+                            cell_id: msg_cell_id,
+                        } => {
+                            if msg_cell_id == cell_id {
+                                state.done = true;
+                                return Ok(Some(ExecutionEvent::done(&cell_id)));
+                            }
+                        }
+                        NotebookBroadcast::KernelError { error } => {
+                            state.done = true;
+                            return Ok(Some(ExecutionEvent::error(&cell_id, &error)));
+                        }
+                        _ => continue,
+                    },
+                    Ok(None) => {
+                        state.done = true;
+                        return Err(to_py_err("Broadcast channel closed"));
+                    }
+                    Err(_) => {
+                        state.done = true;
+                        return Err(to_py_err(format!(
+                            "Execution timed out after {} seconds",
+                            state.timeout_secs
+                        )));
+                    }
+                }
+            }
+        })
+    }
+
+    fn __repr__(&self) -> String {
+        "ExecutionEventIterator(...)".to_string()
+    }
+}

--- a/crates/runtimed-py/src/lib.rs
+++ b/crates/runtimed-py/src/lib.rs
@@ -4,6 +4,8 @@
 //! - `DaemonClient`: Low-level daemon operations (status, ping, list rooms)
 //! - `Session`: Synchronous code execution with kernel management
 //! - `AsyncSession`: Async code execution with kernel management
+//! - `ExecutionEventStream`: Async iterator over execution events
+//! - `ExecutionEventIterator`: Sync iterator over execution events
 //!
 //! Both sync and async APIs are provided with full feature parity.
 
@@ -12,15 +14,19 @@ use pyo3::prelude::*;
 mod async_session;
 mod client;
 mod error;
+mod event_stream;
 mod output;
 mod output_resolver;
 mod session;
+mod subscription;
 
 use async_session::AsyncSession;
 use client::DaemonClient;
 use error::RuntimedError;
-use output::{Cell, ExecutionResult, Output};
+use event_stream::{ExecutionEventIterator, ExecutionEventStream};
+use output::{Cell, ExecutionEvent, ExecutionResult, Output};
 use session::Session;
+use subscription::{EventIteratorSubscription, EventSubscription};
 
 /// Python module for runtimed daemon client.
 #[pymodule]
@@ -32,9 +38,18 @@ fn runtimed(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // Core classes - async API
     m.add_class::<AsyncSession>()?;
 
+    // Iterator types for streaming execution
+    m.add_class::<ExecutionEventStream>()?;
+    m.add_class::<ExecutionEventIterator>()?;
+
+    // Subscription types for independent event listening
+    m.add_class::<EventSubscription>()?;
+    m.add_class::<EventIteratorSubscription>()?;
+
     // Output types
     m.add_class::<Cell>()?;
     m.add_class::<ExecutionResult>()?;
+    m.add_class::<ExecutionEvent>()?;
     m.add_class::<Output>()?;
 
     // Error type

--- a/crates/runtimed-py/src/output.rs
+++ b/crates/runtimed-py/src/output.rs
@@ -199,6 +199,134 @@ impl Cell {
     }
 }
 
+/// An event from a streaming execution.
+///
+/// Events are yielded incrementally as a cell executes:
+/// - "execution_started": execution began (has execution_count)
+/// - "output": an output was produced (has output and optionally output_index)
+/// - "done": execution finished
+/// - "error": kernel error occurred (has error_message)
+///
+/// In signal-only mode, output events have output_index but no output data.
+/// Use session.get_cell(cell_id).outputs[output_index] to fetch the data.
+#[pyclass(skip_from_py_object)]
+#[derive(Clone, Debug)]
+pub struct ExecutionEvent {
+    /// Event type: "execution_started", "output", "done", "error"
+    #[pyo3(get)]
+    pub event_type: String,
+
+    /// The cell ID this event is for
+    #[pyo3(get)]
+    pub cell_id: String,
+
+    /// The output (only for "output" events, None in signal-only mode)
+    #[pyo3(get)]
+    pub output: Option<Output>,
+
+    /// Index of the output in the cell's outputs list (for "output" events)
+    #[pyo3(get)]
+    pub output_index: Option<usize>,
+
+    /// Execution count (only for "execution_started" events)
+    #[pyo3(get)]
+    pub execution_count: Option<i64>,
+
+    /// Error message (only for "error" events)
+    #[pyo3(get)]
+    pub error_message: Option<String>,
+}
+
+#[pymethods]
+impl ExecutionEvent {
+    fn __repr__(&self) -> String {
+        match self.event_type.as_str() {
+            "output" => format!("ExecutionEvent(output, cell={})", self.cell_id),
+            "execution_started" => format!(
+                "ExecutionEvent(execution_started, cell={}, count={:?})",
+                self.cell_id, self.execution_count
+            ),
+            "done" => format!("ExecutionEvent(done, cell={})", self.cell_id),
+            "error" => format!(
+                "ExecutionEvent(error, cell={}, msg={:?})",
+                self.cell_id, self.error_message
+            ),
+            _ => format!("ExecutionEvent({}, cell={})", self.event_type, self.cell_id),
+        }
+    }
+}
+
+impl ExecutionEvent {
+    pub fn execution_started(cell_id: &str, execution_count: i64) -> Self {
+        Self {
+            event_type: "execution_started".to_string(),
+            cell_id: cell_id.to_string(),
+            output: None,
+            output_index: None,
+            execution_count: Some(execution_count),
+            error_message: None,
+        }
+    }
+
+    pub fn output(cell_id: &str, output: Output) -> Self {
+        Self {
+            event_type: "output".to_string(),
+            cell_id: cell_id.to_string(),
+            output: Some(output),
+            output_index: None,
+            execution_count: None,
+            error_message: None,
+        }
+    }
+
+    /// Create an output event with the output index (for streaming).
+    pub fn output_with_index(cell_id: &str, output: Output, output_index: Option<usize>) -> Self {
+        Self {
+            event_type: "output".to_string(),
+            cell_id: cell_id.to_string(),
+            output: Some(output),
+            output_index,
+            execution_count: None,
+            error_message: None,
+        }
+    }
+
+    /// Create a signal-only output event (output_index but no data).
+    /// Used in signal_only mode where the consumer queries state for output data.
+    pub fn output_signal(cell_id: &str, output_index: Option<usize>) -> Self {
+        Self {
+            event_type: "output".to_string(),
+            cell_id: cell_id.to_string(),
+            output: None,
+            output_index,
+            execution_count: None,
+            error_message: None,
+        }
+    }
+
+    pub fn done(cell_id: &str) -> Self {
+        Self {
+            event_type: "done".to_string(),
+            cell_id: cell_id.to_string(),
+            output: None,
+            output_index: None,
+            execution_count: None,
+            error_message: None,
+        }
+    }
+
+    pub fn error(cell_id: &str, message: &str) -> Self {
+        Self {
+            event_type: "error".to_string(),
+            cell_id: cell_id.to_string(),
+            output: None,
+            output_index: None,
+            execution_count: None,
+            error_message: Some(message.to_string()),
+        }
+    }
+}
+
 /// Result of executing code.
 #[pyclass(skip_from_py_object)]
 #[derive(Clone, Debug)]

--- a/crates/runtimed-py/src/session.rs
+++ b/crates/runtimed-py/src/session.rs
@@ -14,8 +14,10 @@ use runtimed::notebook_sync_client::{
 use runtimed::protocol::{NotebookBroadcast, NotebookRequest, NotebookResponse};
 
 use crate::error::to_py_err;
-use crate::output::{Cell, ExecutionResult, Output};
+use crate::event_stream::ExecutionEventIterator;
+use crate::output::{Cell, ExecutionEvent, ExecutionResult, Output};
 use crate::output_resolver;
+use crate::subscription::EventIteratorSubscription;
 
 /// A session for executing code via the runtimed daemon.
 ///
@@ -313,6 +315,29 @@ impl Session {
         })
     }
 
+    /// Append text to a cell's source in the automerge document.
+    ///
+    /// Unlike set_source() which replaces the entire text (using Myers diff
+    /// internally), this directly inserts characters at the end of the source
+    /// Text CRDT. This is ideal for streaming/agentic use cases where an
+    /// external process is appending tokens incrementally — each append is
+    /// a minimal CRDT operation that syncs efficiently to all connected clients.
+    ///
+    /// Args:
+    ///     cell_id: The cell ID.
+    ///     text: The text to append to the cell's source.
+    fn append_source(&self, cell_id: &str, text: &str) -> PyResult<()> {
+        self.runtime.block_on(async {
+            let state = self.state.lock().await;
+            let handle = state
+                .handle
+                .as_ref()
+                .ok_or_else(|| to_py_err("Not connected"))?;
+
+            handle.append_source(cell_id, text).await.map_err(to_py_err)
+        })
+    }
+
     /// Get a cell from the automerge document.
     ///
     /// Args:
@@ -543,6 +568,144 @@ impl Session {
                 ))),
             }
         })
+    }
+
+    /// Stream execution events for a cell as an iterator.
+    ///
+    /// Unlike execute_cell() which blocks until completion and returns all
+    /// outputs at once, this returns an iterator that yields ExecutionEvent
+    /// objects as they arrive from the kernel, enabling real-time processing.
+    ///
+    /// Example:
+    ///     ```python
+    ///     for event in session.stream_execute(cell_id):
+    ///         if event.event_type == "output":
+    ///             print(event.output.text)  # Process output immediately
+    ///     ```
+    ///
+    /// Args:
+    ///     cell_id: The cell ID to execute.
+    ///     timeout_secs: Maximum time to wait for each event (default: 60).
+    ///     signal_only: If True, output events contain only output_index, not
+    ///         the full output data. Use get_cell() to fetch the data.
+    ///
+    /// Returns:
+    ///     ExecutionEventIterator that yields ExecutionEvent objects.
+    #[pyo3(signature = (cell_id, timeout_secs=60.0, signal_only=false))]
+    fn stream_execute(
+        &self,
+        cell_id: &str,
+        timeout_secs: f64,
+        signal_only: bool,
+    ) -> PyResult<ExecutionEventIterator> {
+        let cell_id = cell_id.to_string();
+
+        // Auto-start kernel if not running
+        {
+            let state = self.runtime.block_on(self.state.lock());
+            if !state.kernel_started {
+                drop(state);
+                self.start_kernel("python", "auto", None)?;
+            }
+        }
+
+        self.runtime.block_on(async {
+            let state = self.state.lock().await;
+
+            let handle = state
+                .handle
+                .as_ref()
+                .ok_or_else(|| to_py_err("Not connected"))?;
+
+            // Queue the cell for execution
+            let response = handle
+                .send_request(NotebookRequest::ExecuteCell {
+                    cell_id: cell_id.clone(),
+                })
+                .await
+                .map_err(to_py_err)?;
+
+            match response {
+                NotebookResponse::CellQueued { .. } => {}
+                NotebookResponse::Error { error } => return Err(to_py_err(error)),
+                other => return Err(to_py_err(format!("Unexpected response: {:?}", other))),
+            }
+
+            // Get a resubscribed broadcast receiver for this stream
+            let stream_broadcast_rx = state
+                .broadcast_rx
+                .as_ref()
+                .ok_or_else(|| to_py_err("No broadcast receiver"))?
+                .resubscribe();
+
+            let blob_base_url = state.blob_base_url.clone();
+            let blob_store_path = state.blob_store_path.clone();
+
+            drop(state);
+
+            // Return the sync iterator
+            ExecutionEventIterator::new(
+                stream_broadcast_rx,
+                cell_id,
+                timeout_secs,
+                blob_base_url,
+                blob_store_path,
+                signal_only,
+            )
+        })
+    }
+
+    /// Subscribe to notebook broadcast events independently of execution.
+    ///
+    /// Returns an iterator that yields all broadcast events from the
+    /// notebook, optionally filtered by cell IDs and event types. This
+    /// enables reactive patterns for agents that want to respond to any
+    /// document activity (including executions from other clients).
+    ///
+    /// Example:
+    ///     ```python
+    ///     # Subscribe to all events
+    ///     for event in session.subscribe():
+    ///         print(f"Got: {event.event_type}")
+    ///
+    ///     # Subscribe with filters
+    ///     for event in session.subscribe(event_types=["output", "done"]):
+    ///         if event.event_type == "output":
+    ///             print(event.output.text)
+    ///     ```
+    ///
+    /// Args:
+    ///     cell_ids: Optional list of cell IDs to filter events.
+    ///     event_types: Optional list of event types to filter. Valid types:
+    ///         "execution_started", "output", "done", "error", "kernel_status".
+    ///
+    /// Returns an EventIteratorSubscription iterator.
+    #[pyo3(signature = (cell_ids=None, event_types=None))]
+    fn subscribe(
+        &self,
+        cell_ids: Option<Vec<String>>,
+        event_types: Option<Vec<String>>,
+    ) -> PyResult<EventIteratorSubscription> {
+        let state = self.runtime.block_on(self.state.lock());
+
+        let broadcast_rx = state
+            .broadcast_rx
+            .as_ref()
+            .ok_or_else(|| to_py_err("Not connected - call connect() or start_kernel() first"))?
+            .resubscribe();
+
+        let blob_base_url = state.blob_base_url.clone();
+        let blob_store_path = state.blob_store_path.clone();
+
+        drop(state);
+
+        EventIteratorSubscription::new(
+            broadcast_rx,
+            cell_ids,
+            event_types,
+            blob_base_url,
+            blob_store_path,
+        )
     }
 
     /// Convenience method: create a cell, execute it, and return the result.
@@ -842,5 +1005,91 @@ impl Session {
             success,
             execution_count,
         })
+    }
+
+    /// Collect execution events for a cell, preserving event order.
+    async fn collect_events(
+        &self,
+        cell_id: &str,
+        blob_base_url: Option<String>,
+        blob_store_path: Option<PathBuf>,
+    ) -> PyResult<Vec<ExecutionEvent>> {
+        let mut events = Vec::new();
+        let mut done_received = false;
+
+        loop {
+            let mut state = self.state.lock().await;
+
+            let broadcast_rx = state
+                .broadcast_rx
+                .as_mut()
+                .ok_or_else(|| to_py_err("Not connected"))?;
+
+            let timeout_ms = if done_received { 50 } else { 100 };
+            let broadcast = tokio::time::timeout(
+                std::time::Duration::from_millis(timeout_ms),
+                broadcast_rx.recv(),
+            )
+            .await;
+
+            match broadcast {
+                Ok(Some(msg)) => {
+                    drop(state);
+
+                    match msg {
+                        NotebookBroadcast::ExecutionStarted {
+                            cell_id: msg_cell_id,
+                            execution_count: count,
+                        } => {
+                            if msg_cell_id == cell_id {
+                                events.push(ExecutionEvent::execution_started(cell_id, count));
+                            }
+                        }
+                        NotebookBroadcast::Output {
+                            cell_id: msg_cell_id,
+                            output_type,
+                            output_json,
+                            ..
+                        } => {
+                            if msg_cell_id == cell_id {
+                                if let Some(output) = output_resolver::resolve_output_with_type(
+                                    &output_type,
+                                    &output_json,
+                                    &blob_base_url,
+                                    &blob_store_path,
+                                )
+                                .await
+                                {
+                                    events.push(ExecutionEvent::output(cell_id, output));
+                                }
+                            }
+                        }
+                        NotebookBroadcast::ExecutionDone {
+                            cell_id: msg_cell_id,
+                        } => {
+                            if msg_cell_id == cell_id {
+                                events.push(ExecutionEvent::done(cell_id));
+                                done_received = true;
+                            }
+                        }
+                        NotebookBroadcast::KernelError { error } => {
+                            events.push(ExecutionEvent::error(cell_id, &error));
+                            done_received = true;
+                        }
+                        _ => {}
+                    }
+                }
+                Ok(None) => {
+                    return Err(to_py_err("Broadcast channel closed"));
+                }
+                Err(_) => {
+                    if done_received {
+                        break;
+                    }
+                }
+            }
+        }
+
+        Ok(events)
     }
 }

--- a/crates/runtimed-py/src/subscription.rs
+++ b/crates/runtimed-py/src/subscription.rs
@@ -1,0 +1,322 @@
+//! Event subscription for independent event listening.
+//!
+//! Allows subscribing to notebook broadcasts independently of execution,
+//! enabling reactive patterns for agents and UIs.
+
+use pyo3::exceptions::PyStopAsyncIteration;
+use pyo3::prelude::*;
+use pyo3_async_runtimes::tokio::future_into_py;
+use std::collections::HashSet;
+use std::path::PathBuf;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+use runtimed::notebook_sync_client::NotebookBroadcastReceiver;
+use runtimed::protocol::NotebookBroadcast;
+
+use crate::error::to_py_err;
+use crate::output::ExecutionEvent;
+use crate::output_resolver;
+
+/// Async subscription to notebook broadcasts.
+///
+/// Yields all broadcast events from the notebook, optionally filtered by
+/// cell IDs and event types. This enables reactive patterns for agents
+/// that want to respond to any document activity.
+///
+/// Example:
+///     ```python
+///     async for event in session.subscribe():
+///         print(f"Got event: {event.event_type}")
+///
+///     # With filters
+///     async for event in session.subscribe(event_types=["output", "done"]):
+///         if event.event_type == "output":
+///             print(event.output.text)
+///     ```
+#[pyclass]
+pub struct EventSubscription {
+    state: Arc<Mutex<SubscriptionState>>,
+}
+
+struct SubscriptionState {
+    broadcast_rx: NotebookBroadcastReceiver,
+    /// Filter to specific cell IDs (empty = all cells)
+    cell_ids: HashSet<String>,
+    /// Filter to specific event types (empty = all types)
+    event_types: HashSet<String>,
+    /// For resolving blob outputs
+    blob_base_url: Option<String>,
+    blob_store_path: Option<PathBuf>,
+    /// Whether subscription is closed
+    closed: bool,
+}
+
+impl EventSubscription {
+    pub fn new(
+        broadcast_rx: NotebookBroadcastReceiver,
+        cell_ids: Option<Vec<String>>,
+        event_types: Option<Vec<String>>,
+        blob_base_url: Option<String>,
+        blob_store_path: Option<PathBuf>,
+    ) -> Self {
+        Self {
+            state: Arc::new(Mutex::new(SubscriptionState {
+                broadcast_rx,
+                cell_ids: cell_ids
+                    .map(|v| v.into_iter().collect())
+                    .unwrap_or_default(),
+                event_types: event_types
+                    .map(|v| v.into_iter().collect())
+                    .unwrap_or_default(),
+                blob_base_url,
+                blob_store_path,
+                closed: false,
+            })),
+        }
+    }
+}
+
+#[pymethods]
+impl EventSubscription {
+    fn __aiter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        slf
+    }
+
+    fn __anext__<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let state = Arc::clone(&self.state);
+
+        future_into_py(py, async move {
+            let mut state = state.lock().await;
+
+            if state.closed {
+                return Err(PyStopAsyncIteration::new_err("Subscription closed"));
+            }
+
+            let cell_ids = state.cell_ids.clone();
+            let event_types = state.event_types.clone();
+            let blob_base_url = state.blob_base_url.clone();
+            let blob_store_path = state.blob_store_path.clone();
+
+            // Wait for next matching broadcast
+            loop {
+                match state.broadcast_rx.recv().await {
+                    Some(broadcast) => {
+                        if let Some(event) = broadcast_to_event(
+                            broadcast,
+                            &cell_ids,
+                            &event_types,
+                            &blob_base_url,
+                            &blob_store_path,
+                        )
+                        .await
+                        {
+                            return Ok(event);
+                        }
+                        // Didn't match filters, continue waiting
+                    }
+                    None => {
+                        state.closed = true;
+                        return Err(PyStopAsyncIteration::new_err("Broadcast channel closed"));
+                    }
+                }
+            }
+        })
+    }
+
+    /// Close the subscription.
+    fn close<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let state = Arc::clone(&self.state);
+        future_into_py(py, async move {
+            let mut state = state.lock().await;
+            state.closed = true;
+            Ok(())
+        })
+    }
+
+    fn __repr__(&self) -> String {
+        "EventSubscription(...)".to_string()
+    }
+}
+
+/// Sync subscription to notebook broadcasts.
+#[pyclass]
+pub struct EventIteratorSubscription {
+    runtime: tokio::runtime::Runtime,
+    state: Arc<Mutex<SubscriptionState>>,
+}
+
+impl EventIteratorSubscription {
+    pub fn new(
+        broadcast_rx: NotebookBroadcastReceiver,
+        cell_ids: Option<Vec<String>>,
+        event_types: Option<Vec<String>>,
+        blob_base_url: Option<String>,
+        blob_store_path: Option<PathBuf>,
+    ) -> PyResult<Self> {
+        let runtime = tokio::runtime::Runtime::new().map_err(to_py_err)?;
+        Ok(Self {
+            runtime,
+            state: Arc::new(Mutex::new(SubscriptionState {
+                broadcast_rx,
+                cell_ids: cell_ids
+                    .map(|v| v.into_iter().collect())
+                    .unwrap_or_default(),
+                event_types: event_types
+                    .map(|v| v.into_iter().collect())
+                    .unwrap_or_default(),
+                blob_base_url,
+                blob_store_path,
+                closed: false,
+            })),
+        })
+    }
+}
+
+#[pymethods]
+impl EventIteratorSubscription {
+    fn __iter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        slf
+    }
+
+    fn __next__(&self) -> PyResult<Option<ExecutionEvent>> {
+        let state = Arc::clone(&self.state);
+
+        self.runtime.block_on(async {
+            let mut state = state.lock().await;
+
+            if state.closed {
+                return Ok(None);
+            }
+
+            let cell_ids = state.cell_ids.clone();
+            let event_types = state.event_types.clone();
+            let blob_base_url = state.blob_base_url.clone();
+            let blob_store_path = state.blob_store_path.clone();
+
+            loop {
+                match state.broadcast_rx.recv().await {
+                    Some(broadcast) => {
+                        if let Some(event) = broadcast_to_event(
+                            broadcast,
+                            &cell_ids,
+                            &event_types,
+                            &blob_base_url,
+                            &blob_store_path,
+                        )
+                        .await
+                        {
+                            return Ok(Some(event));
+                        }
+                    }
+                    None => {
+                        state.closed = true;
+                        return Ok(None);
+                    }
+                }
+            }
+        })
+    }
+
+    /// Close the subscription.
+    fn close(&self) -> PyResult<()> {
+        self.runtime.block_on(async {
+            let mut state = self.state.lock().await;
+            state.closed = true;
+            Ok(())
+        })
+    }
+
+    fn __repr__(&self) -> String {
+        "EventIteratorSubscription(...)".to_string()
+    }
+}
+
+/// Convert a broadcast to an ExecutionEvent, applying filters.
+/// Returns None if the broadcast doesn't match the filters.
+async fn broadcast_to_event(
+    broadcast: NotebookBroadcast,
+    cell_ids: &HashSet<String>,
+    event_types: &HashSet<String>,
+    blob_base_url: &Option<String>,
+    blob_store_path: &Option<PathBuf>,
+) -> Option<ExecutionEvent> {
+    match broadcast {
+        NotebookBroadcast::ExecutionStarted {
+            cell_id,
+            execution_count,
+        } => {
+            if !cell_ids.is_empty() && !cell_ids.contains(&cell_id) {
+                return None;
+            }
+            if !event_types.is_empty() && !event_types.contains("execution_started") {
+                return None;
+            }
+            Some(ExecutionEvent::execution_started(&cell_id, execution_count))
+        }
+        NotebookBroadcast::Output {
+            cell_id,
+            output_type,
+            output_json,
+            output_index,
+        } => {
+            if !cell_ids.is_empty() && !cell_ids.contains(&cell_id) {
+                return None;
+            }
+            if !event_types.is_empty() && !event_types.contains("output") {
+                return None;
+            }
+            // Resolve and include the output
+            if let Some(output) = output_resolver::resolve_output_with_type(
+                &output_type,
+                &output_json,
+                blob_base_url,
+                blob_store_path,
+            )
+            .await
+            {
+                Some(ExecutionEvent::output_with_index(
+                    &cell_id,
+                    output,
+                    output_index,
+                ))
+            } else {
+                // Still return an event with output_index even if resolution failed
+                Some(ExecutionEvent::output_signal(&cell_id, output_index))
+            }
+        }
+        NotebookBroadcast::ExecutionDone { cell_id } => {
+            if !cell_ids.is_empty() && !cell_ids.contains(&cell_id) {
+                return None;
+            }
+            if !event_types.is_empty() && !event_types.contains("done") {
+                return None;
+            }
+            Some(ExecutionEvent::done(&cell_id))
+        }
+        NotebookBroadcast::KernelError { error } => {
+            if !event_types.is_empty() && !event_types.contains("error") {
+                return None;
+            }
+            Some(ExecutionEvent::error("", &error))
+        }
+        NotebookBroadcast::KernelStatus { status, cell_id } => {
+            if !event_types.is_empty() && !event_types.contains("kernel_status") {
+                return None;
+            }
+            // Create a special event for kernel status
+            Some(ExecutionEvent {
+                event_type: "kernel_status".to_string(),
+                cell_id: cell_id.unwrap_or_default(),
+                output: None,
+                output_index: None,
+                execution_count: None,
+                error_message: Some(status),
+            })
+        }
+        _ => {
+            // Ignore other broadcast types (QueueChanged, Comm, etc.)
+            None
+        }
+    }
+}

--- a/crates/runtimed/src/notebook_doc.rs
+++ b/crates/runtimed/src/notebook_doc.rs
@@ -259,6 +259,35 @@ impl NotebookDoc {
         Ok(true)
     }
 
+    /// Append text to a cell's source without diffing.
+    ///
+    /// Unlike `update_source` which replaces the entire text (using Myers diff
+    /// internally), this directly inserts characters at the end of the source
+    /// Text CRDT. This is ideal for streaming/agentic use cases where an
+    /// external process is appending tokens incrementally.
+    pub fn append_source(&mut self, cell_id: &str, text: &str) -> Result<bool, AutomergeError> {
+        let cells_id = match self.cells_list_id() {
+            Some(id) => id,
+            None => return Ok(false),
+        };
+        let idx = match self.find_cell_index(&cells_id, cell_id) {
+            Some(i) => i,
+            None => return Ok(false),
+        };
+        let cell_obj = match self.cell_at_index(&cells_id, idx) {
+            Some(o) => o,
+            None => return Ok(false),
+        };
+        let source_id = match self.text_id(&cell_obj, "source") {
+            Some(id) => id,
+            None => return Ok(false),
+        };
+
+        let len = self.doc.text(&source_id)?.len();
+        self.doc.splice_text(&source_id, len, 0, text)?;
+        Ok(true)
+    }
+
     // ── Output management ───────────────────────────────────────────
 
     /// Replace all outputs for a cell.

--- a/crates/runtimed/src/notebook_sync_client.rs
+++ b/crates/runtimed/src/notebook_sync_client.rs
@@ -21,7 +21,7 @@ use futures::FutureExt;
 use log::{info, warn};
 use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncRead, AsyncWrite};
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::{broadcast, mpsc, oneshot};
 
 use crate::connection::{self, Handshake, NotebookFrameType, ProtocolCapabilities, PROTOCOL_V2};
 use crate::notebook_doc::{
@@ -70,6 +70,11 @@ enum SyncCommand {
         source: String,
         reply: oneshot::Sender<Result<(), NotebookSyncError>>,
     },
+    AppendSource {
+        cell_id: String,
+        text: String,
+        reply: oneshot::Sender<Result<(), NotebookSyncError>>,
+    },
     ClearOutputs {
         cell_id: String,
         reply: oneshot::Sender<Result<(), NotebookSyncError>>,
@@ -106,7 +111,7 @@ enum SyncCommand {
         /// Optional broadcast sender for delivering broadcasts during long-running requests.
         /// If provided, broadcasts received while waiting for the response are sent immediately
         /// instead of being queued for later delivery.
-        broadcast_tx: Option<mpsc::Sender<NotebookBroadcast>>,
+        broadcast_tx: Option<broadcast::Sender<NotebookBroadcast>>,
     },
 }
 
@@ -184,6 +189,26 @@ impl NotebookSyncHandle {
             .send(SyncCommand::UpdateSource {
                 cell_id: cell_id.to_string(),
                 source: source.to_string(),
+                reply: reply_tx,
+            })
+            .await
+            .map_err(|_| NotebookSyncError::ChannelClosed)?;
+        reply_rx
+            .await
+            .map_err(|_| NotebookSyncError::ChannelClosed)?
+    }
+
+    /// Append text to a cell's source (no diff, direct CRDT insert at end).
+    ///
+    /// Unlike `update_source` which replaces the entire text, this appends
+    /// characters at the end of the source. Ideal for streaming/agentic use
+    /// cases where tokens are appended incrementally.
+    pub async fn append_source(&self, cell_id: &str, text: &str) -> Result<(), NotebookSyncError> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.tx
+            .send(SyncCommand::AppendSource {
+                cell_id: cell_id.to_string(),
+                text: text.to_string(),
                 reply: reply_tx,
             })
             .await
@@ -307,7 +332,7 @@ impl NotebookSyncHandle {
     pub async fn send_request_with_broadcast(
         &self,
         request: NotebookRequest,
-        broadcast_tx: mpsc::Sender<NotebookBroadcast>,
+        broadcast_tx: broadcast::Sender<NotebookBroadcast>,
     ) -> Result<NotebookResponse, NotebookSyncError> {
         let (reply_tx, reply_rx) = oneshot::channel();
         self.tx
@@ -357,16 +382,46 @@ impl NotebookSyncReceiver {
 ///
 /// These are events like kernel status changes, execution outputs, etc.
 /// that are broadcast to all clients connected to the same notebook room.
+///
+/// This receiver supports multiple subscribers - use `resubscribe()` to create
+/// additional receivers that will receive all future broadcasts.
 pub struct NotebookBroadcastReceiver {
-    rx: mpsc::Receiver<NotebookBroadcast>,
+    rx: broadcast::Receiver<NotebookBroadcast>,
 }
 
 impl NotebookBroadcastReceiver {
     /// Wait for the next broadcast event.
     ///
-    /// Returns `None` if the sync task has stopped.
+    /// Returns `None` if the sync task has stopped (channel closed).
+    /// If events were missed due to a slow consumer, they are skipped
+    /// and the next available event is returned.
     pub async fn recv(&mut self) -> Option<NotebookBroadcast> {
-        self.rx.recv().await
+        loop {
+            match self.rx.recv().await {
+                Ok(msg) => return Some(msg),
+                Err(broadcast::error::RecvError::Lagged(count)) => {
+                    // Consumer was too slow, some messages were dropped
+                    log::warn!(
+                        "[NotebookBroadcastReceiver] Lagged by {} messages, continuing",
+                        count
+                    );
+                    // Continue to get the next available message
+                    continue;
+                }
+                Err(broadcast::error::RecvError::Closed) => return None,
+            }
+        }
+    }
+
+    /// Create a new receiver that will receive all future broadcasts.
+    ///
+    /// The new receiver starts from the next message sent after this call.
+    /// This allows multiple consumers to independently receive the same
+    /// broadcast events (e.g., for streaming execution + independent subscription).
+    pub fn resubscribe(&self) -> Self {
+        Self {
+            rx: self.rx.resubscribe(),
+        }
     }
 }
 
@@ -864,6 +919,47 @@ where
         self.sync_to_daemon().await
     }
 
+    /// Append text to a cell's source and sync to daemon.
+    ///
+    /// Directly inserts at the end of the Text CRDT without diffing.
+    pub async fn append_source(
+        &mut self,
+        cell_id: &str,
+        text: &str,
+    ) -> Result<(), NotebookSyncError> {
+        let cells_id = match self.cells_list_id() {
+            Some(id) => id,
+            None => return Err(NotebookSyncError::CellNotFound(cell_id.to_string())),
+        };
+        let idx = match self.find_cell_index(&cells_id, cell_id) {
+            Some(i) => i,
+            None => return Err(NotebookSyncError::CellNotFound(cell_id.to_string())),
+        };
+        let cell_obj = match self.cell_at_index(&cells_id, idx) {
+            Some(o) => o,
+            None => return Err(NotebookSyncError::CellNotFound(cell_id.to_string())),
+        };
+        let source_id = match self.text_id(&cell_obj, "source") {
+            Some(id) => id,
+            None => {
+                return Err(NotebookSyncError::SyncError(
+                    "source Text not found".to_string(),
+                ))
+            }
+        };
+
+        let len = self
+            .doc
+            .text(&source_id)
+            .map_err(|e| NotebookSyncError::SyncError(format!("text read: {}", e)))?
+            .len();
+        self.doc
+            .splice_text(&source_id, len, 0, text)
+            .map_err(|e| NotebookSyncError::SyncError(format!("splice_text: {}", e)))?;
+
+        self.sync_to_daemon().await
+    }
+
     /// Set outputs for a cell and sync to daemon.
     pub async fn set_outputs(
         &mut self,
@@ -1251,7 +1347,7 @@ where
     pub async fn send_request_with_broadcast(
         &mut self,
         request: &NotebookRequest,
-        broadcast_tx: Option<&mpsc::Sender<NotebookBroadcast>>,
+        broadcast_tx: Option<&broadcast::Sender<NotebookBroadcast>>,
     ) -> Result<NotebookResponse, NotebookSyncError> {
         if !self.use_typed_frames {
             return Err(NotebookSyncError::SyncError(
@@ -1289,7 +1385,7 @@ where
     /// being queued. This enables real-time progress updates during long-running requests.
     async fn wait_for_response_with_broadcast(
         &mut self,
-        broadcast_tx: Option<&mpsc::Sender<NotebookBroadcast>>,
+        broadcast_tx: Option<&broadcast::Sender<NotebookBroadcast>>,
     ) -> Result<NotebookResponse, NotebookSyncError> {
         loop {
             match connection::recv_typed_frame(&mut self.stream).await? {
@@ -1319,13 +1415,10 @@ where
                             // If we have a broadcast sender, deliver immediately
                             // Otherwise queue for later delivery
                             if let Some(tx) = broadcast_tx {
-                                // Try non-blocking send first for real-time delivery
-                                if let Err(tokio::sync::mpsc::error::TrySendError::Full(b)) =
-                                    tx.try_send(broadcast)
-                                {
-                                    // Channel full - queue for later to avoid dropping
-                                    // Terminal events (ready, error) are especially important
-                                    self.pending_broadcasts.push(b);
+                                // broadcast::Sender::send is synchronous
+                                // Only fails if there are no receivers, in which case queue it
+                                if tx.send(broadcast.clone()).is_err() {
+                                    self.pending_broadcasts.push(broadcast);
                                 }
                             } else {
                                 self.pending_broadcasts.push(broadcast);
@@ -1465,26 +1558,22 @@ where
         // Channel for sync updates to receivers
         let (changes_tx, changes_rx) = mpsc::channel::<SyncUpdate>(32);
 
-        // Channel for kernel broadcasts
-        let (broadcast_tx, broadcast_rx) = mpsc::channel::<NotebookBroadcast>(64);
+        // Channel for kernel broadcasts (broadcast channel supports multiple subscribers)
+        let (broadcast_tx, broadcast_rx) = broadcast::channel::<NotebookBroadcast>(64);
 
         // Send pending broadcasts (received during init) before spawning the task
         // This ensures the broadcast receiver can get them immediately
-        let broadcast_tx_for_pending = broadcast_tx.clone();
         if !pending_broadcasts.is_empty() {
             info!(
                 "[notebook-sync-client] Sending {} pending broadcasts for {}",
                 pending_broadcasts.len(),
                 notebook_id
             );
-            tokio::spawn(async move {
-                for broadcast in pending_broadcasts {
-                    if broadcast_tx_for_pending.send(broadcast).await.is_err() {
-                        warn!("[notebook-sync-client] Failed to send pending broadcast");
-                        break;
-                    }
-                }
-            });
+            for broadcast in pending_broadcasts {
+                // broadcast::Sender::send is synchronous, no await needed
+                // Errors only if there are no receivers, which can't happen here
+                let _ = broadcast_tx.send(broadcast);
+            }
         }
 
         // Spawn background task with panic catching
@@ -1542,7 +1631,7 @@ async fn run_sync_task<S>(
     mut client: NotebookSyncClient<S>,
     mut cmd_rx: mpsc::Receiver<SyncCommand>,
     changes_tx: mpsc::Sender<SyncUpdate>,
-    broadcast_tx: mpsc::Sender<NotebookBroadcast>,
+    broadcast_tx: broadcast::Sender<NotebookBroadcast>,
 ) where
     S: AsyncRead + AsyncWrite + Unpin,
 {
@@ -1579,6 +1668,10 @@ async fn run_sync_task<S>(
                             }
                             SyncCommand::UpdateSource { cell_id, source, reply } => {
                                 let result = client.update_source(&cell_id, &source).await;
+                                let _ = reply.send(result);
+                            }
+                            SyncCommand::AppendSource { cell_id, text, reply } => {
+                                let result = client.append_source(&cell_id, &text).await;
                                 let _ = reply.send(result);
                             }
                             SyncCommand::ClearOutputs { cell_id, reply } => {
@@ -1659,10 +1752,11 @@ async fn run_sync_task<S>(
                     }
                     Ok(Some(ReceivedFrame::Broadcast(broadcast))) => {
                         // Got a broadcast from daemon
-                        let send_result = broadcast_tx.send(broadcast).await;
+                        // broadcast::Sender::send is synchronous, returns Err only if no receivers
+                        let send_result = broadcast_tx.send(broadcast);
                         if send_result.is_err() {
                             info!(
-                                "[notebook-sync-task] Broadcast receiver dropped for {}",
+                                "[notebook-sync-task] No broadcast receivers for {}",
                                 notebook_id
                             );
                             // Continue - broadcasts are optional

--- a/docs/python-bindings.md
+++ b/docs/python-bindings.md
@@ -98,15 +98,18 @@ The session uses a document-first model where cells are stored in an automerge d
 # Create a cell in the document
 cell_id = session.create_cell("x = 10")
 
-# Update cell source
+# Update cell source (full replacement, uses Myers diff internally)
 session.set_source(cell_id, "x = 20")
+
+# Append to cell source (direct CRDT insert, no diff — ideal for streaming)
+session.append_source(cell_id, "\ny = 30")
 
 # Execute by cell ID (daemon reads source from document)
 result = session.execute_cell(cell_id)
 
 # Read cell state
 cell = session.get_cell(cell_id)
-print(cell.source)           # "x = 20"
+print(cell.source)           # "x = 20\ny = 30"
 print(cell.execution_count)  # 1
 
 # List all cells
@@ -114,6 +117,23 @@ cells = session.get_cells()
 
 # Delete a cell
 session.delete_cell(cell_id)
+```
+
+### Streaming Execution
+
+Process outputs incrementally as they arrive from the kernel:
+
+```python
+cell_id = session.create_cell("for i in range(5): print(i)")
+events = session.stream_execute(cell_id)
+
+for event in events:
+    if event.event_type == "execution_started":
+        print(f"Started, count={event.execution_count}")
+    elif event.event_type == "output":
+        print(f"Output: {event.output}")
+    elif event.event_type == "done":
+        print("Done!")
 ```
 
 ### Context Manager
@@ -202,21 +222,41 @@ await session.queue_cell(cell_id)
 # Create a cell in the automerge document
 cell_id = await session.create_cell("x = 10")
 
-# Update cell source
+# Update cell source (full replacement, uses Myers diff internally)
 await session.set_source(cell_id, "x = 20")
+
+# Append to cell source (direct CRDT insert, no diff — ideal for streaming)
+await session.append_source(cell_id, "\ny = 30")
 
 # Execute by cell ID (daemon reads source from document)
 result = await session.execute_cell(cell_id)
 
 # Read cell state
 cell = await session.get_cell(cell_id)
-print(cell.source)  # "x = 20"
+print(cell.source)  # "x = 20\ny = 30"
 
 # List all cells
 cells = await session.get_cells()
 
 # Delete a cell
 await session.delete_cell(cell_id)
+```
+
+### Streaming Execution
+
+Process outputs incrementally as they arrive from the kernel:
+
+```python
+cell_id = await session.create_cell("for i in range(5): print(i)")
+events = await session.stream_execute(cell_id)
+
+for event in events:
+    if event.event_type == "execution_started":
+        print(f"Started, count={event.execution_count}")
+    elif event.event_type == "output":
+        print(f"Output: {event.output}")
+    elif event.event_type == "done":
+        print("Done!")
 ```
 
 ### Async Context Manager
@@ -303,6 +343,21 @@ result.display_data     # List of display_data/execute_result outputs
 result.error            # First error output, or None
 ```
 
+### ExecutionEvent
+
+Returned by `stream_execute()`:
+
+```python
+events = session.stream_execute(cell_id)  # or: await session.stream_execute(cell_id)
+
+for event in events:
+    event.event_type      # "execution_started", "output", "done", "error"
+    event.cell_id         # Cell this event is for
+    event.output          # Output object (only for "output" events)
+    event.execution_count # int (only for "execution_started" events)
+    event.error_message   # str (only for "error" events)
+```
+
 ### Output
 
 Individual outputs from execution:
@@ -366,6 +421,36 @@ This enables:
 - Multiple Python processes sharing a notebook
 - Python scripts interacting with notebooks open in the app
 - Agent workflows with parallel execution
+
+### Agentic Streaming
+
+An agent can stream text into a cell while other clients see it in real-time:
+
+```python
+import asyncio
+import runtimed
+
+async def agent_writes_code():
+    async with runtimed.AsyncSession(notebook_id="shared") as session:
+        await session.start_kernel()
+
+        # Create an empty cell
+        cell_id = await session.create_cell("")
+
+        # Stream tokens into the cell — each append is a CRDT op
+        # that syncs to all connected clients in real-time
+        for token in ["import ", "math\n", "print(", "math.pi", ")"]:
+            await session.append_source(cell_id, token)
+            await asyncio.sleep(0.05)  # Simulate LLM token delay
+
+        # Execute the completed cell and stream outputs
+        events = await session.stream_execute(cell_id)
+        for event in events:
+            if event.event_type == "output":
+                print(f"Result: {event.output.text}")
+
+asyncio.run(agent_writes_code())
+```
 
 ## Error Handling
 

--- a/python/runtimed/src/runtimed/__init__.py
+++ b/python/runtimed/src/runtimed/__init__.py
@@ -10,6 +10,7 @@ from runtimed.runtimed import (
     AsyncSession,
     Cell,
     DaemonClient,
+    ExecutionEvent,
     ExecutionResult,
     Output,
     RuntimedError,
@@ -28,6 +29,7 @@ __all__ = [
     "AsyncSession",
     # Output types
     "Cell",
+    "ExecutionEvent",
     "ExecutionResult",
     "Output",
     "RuntimedError",

--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -1861,5 +1861,318 @@ class TestAsyncContextManager:
             pass
 
 
+# ============================================================================
+# Streaming Execution Tests (stream_execute async iterator)
+# ============================================================================
+
+
+class TestStreamExecute:
+    """Test stream_execute() returns events as an async iterator."""
+
+    @pytest.mark.asyncio
+    async def test_stream_execute_yields_events(self, async_session):
+        """stream_execute() yields events as they arrive, not all at once."""
+        await async_session.start_kernel()
+
+        cell_id = await async_session.create_cell(
+            "for i in range(3): print(f'line {i}')"
+        )
+
+        events = []
+        async for event in await async_session.stream_execute(cell_id):
+            events.append(event)
+
+        # Should have received multiple events (outputs + done)
+        assert len(events) >= 2, f"Expected multiple events, got {len(events)}"
+
+        # Should have output events
+        output_events = [e for e in events if e.event_type == "output"]
+        assert len(output_events) >= 1, "Expected at least one output event"
+
+        # Should have a done event
+        done_events = [e for e in events if e.event_type == "done"]
+        assert len(done_events) == 1, "Expected exactly one done event"
+
+    @pytest.mark.asyncio
+    async def test_stream_execute_has_output_events(self, async_session):
+        """stream_execute() yields output events with output data."""
+        await async_session.start_kernel()
+
+        cell_id = await async_session.create_cell(
+            "print('first'); print('second')"
+        )
+
+        output_events = []
+        async for event in await async_session.stream_execute(cell_id):
+            if event.event_type == "output":
+                output_events.append(event)
+
+        # Should have output events
+        assert len(output_events) >= 1, "Expected at least one output event"
+
+        # Output events should have output data
+        for event in output_events:
+            assert event.output is not None, "Output event should have output data"
+
+    @pytest.mark.asyncio
+    async def test_stream_execute_error_in_output(self, async_session):
+        """stream_execute() captures execution errors as output events.
+
+        Python errors (ValueError, etc.) are broadcast as Output events
+        with output_type="error" and ename/evalue/traceback fields.
+        KernelError is only for kernel-level failures (crash, launch).
+        """
+        await async_session.start_kernel()
+
+        cell_id = await async_session.create_cell("raise ValueError('test error')")
+
+        events = []
+        async for event in await async_session.stream_execute(cell_id):
+            events.append(event)
+
+        # Should have output events (error comes through as output)
+        output_events = [e for e in events if e.event_type == "output"]
+        assert len(output_events) >= 1, "Expected at least one output event"
+
+        # The output should contain the error information
+        # Error outputs have output_type="error" with ename/evalue fields
+        error_found = False
+        for event in output_events:
+            if event.output and event.output.output_type == "error":
+                error_found = True
+                assert event.output.ename is not None
+                assert "ValueError" in event.output.ename
+                break
+
+        assert error_found, "Expected an error output with ValueError"
+
+
+class TestSyncStreamExecute:
+    """Test sync Session.stream_execute() returns events as an iterator."""
+
+    def test_sync_stream_execute_yields_events(self, session):
+        """Sync stream_execute() yields events via iterator."""
+        session.start_kernel()
+
+        cell_id = session.create_cell("for i in range(3): print(f'line {i}')")
+
+        events = list(session.stream_execute(cell_id))
+
+        # Should have received multiple events
+        assert len(events) >= 2, f"Expected multiple events, got {len(events)}"
+
+        # Should have output and done events
+        output_events = [e for e in events if e.event_type == "output"]
+        done_events = [e for e in events if e.event_type == "done"]
+        assert len(output_events) >= 1
+        assert len(done_events) == 1
+
+
+# ============================================================================
+# Append Source Tests (incremental code writing)
+# ============================================================================
+
+
+class TestAppendSource:
+    """Test append_source() for incremental code writing (agentic streaming)."""
+
+    @pytest.mark.asyncio
+    async def test_append_source_basic(self, async_session):
+        """append_source() adds text to end of cell source."""
+        await async_session.start_kernel()
+
+        cell_id = await async_session.create_cell("x = 1")
+
+        # Append more code
+        await async_session.append_source(cell_id, "\ny = 2")
+        await async_session.append_source(cell_id, "\nprint(x + y)")
+
+        # Verify source was appended
+        cell = await async_session.get_cell(cell_id)
+        assert "x = 1" in cell.source
+        assert "y = 2" in cell.source
+        assert "print(x + y)" in cell.source
+
+        # Execute and verify
+        result = await async_session.execute_cell(cell_id)
+        assert result.success
+        assert "3" in result.stdout
+
+    @pytest.mark.asyncio
+    async def test_append_source_streaming_tokens(self, async_session):
+        """append_source() can append tokens incrementally (LLM streaming)."""
+        await async_session.start_kernel()
+
+        cell_id = await async_session.create_cell("")
+
+        # Simulate LLM streaming tokens
+        tokens = ["print", "(", "'hello", " ", "world", "'", ")"]
+        for token in tokens:
+            await async_session.append_source(cell_id, token)
+
+        cell = await async_session.get_cell(cell_id)
+        assert cell.source == "print('hello world')"
+
+        result = await async_session.execute_cell(cell_id)
+        assert result.success
+        assert "hello world" in result.stdout
+
+    @pytest.mark.asyncio
+    async def test_append_source_syncs_between_peers(self, two_async_sessions):
+        """append_source() changes sync to other sessions."""
+        s1, s2 = two_async_sessions
+
+        # Create cell in session 1
+        cell_id = await s1.create_cell("a = 1")
+        time.sleep(0.3)  # Allow sync
+
+        # Append in session 1
+        await s1.append_source(cell_id, "\nb = 2")
+        time.sleep(0.3)
+
+        # Session 2 should see the appended source
+        cell = await s2.get_cell(cell_id)
+        assert "a = 1" in cell.source
+        assert "b = 2" in cell.source
+
+
+class TestSyncAppendSource:
+    """Test sync Session.append_source()."""
+
+    def test_sync_append_source_basic(self, session):
+        """Sync append_source() adds text to cell source."""
+        session.start_kernel()
+
+        cell_id = session.create_cell("x = 10")
+        session.append_source(cell_id, "\nprint(x * 2)")
+
+        cell = session.get_cell(cell_id)
+        assert "x = 10" in cell.source
+        assert "print(x * 2)" in cell.source
+
+        result = session.execute_cell(cell_id)
+        assert result.success
+        assert "20" in result.stdout
+
+
+# ============================================================================
+# Subscription Tests (independent event listening)
+# ============================================================================
+
+
+class TestSubscription:
+    """Test subscribe() for independent event listening."""
+
+    @pytest.mark.asyncio
+    async def test_subscribe_receives_execution_events(self, async_session):
+        """subscribe() receives events from cell execution."""
+        await async_session.start_kernel()
+
+        cell_id = await async_session.create_cell("print('subscribed')")
+
+        # Start subscription before execution
+        subscription = async_session.subscribe()
+        received_events = []
+
+        import asyncio
+
+        async def collect_events():
+            async for event in subscription:
+                received_events.append(event)
+                if event.event_type == "done":
+                    break
+
+        # Run collection with timeout
+        collect_task = asyncio.create_task(collect_events())
+
+        # Execute cell
+        await async_session.execute_cell(cell_id)
+
+        # Wait for events with timeout
+        try:
+            await asyncio.wait_for(collect_task, timeout=5.0)
+        except asyncio.TimeoutError:
+            pass  # May timeout if no done event, that's ok
+
+        # Should have received some events
+        assert len(received_events) >= 1, "Expected to receive events via subscription"
+
+    @pytest.mark.asyncio
+    async def test_subscribe_filters_by_event_type(self, async_session):
+        """subscribe(event_types=[...]) filters events."""
+        await async_session.start_kernel()
+
+        cell_id = await async_session.create_cell("print('filtered')")
+
+        # Subscribe only to output events
+        subscription = async_session.subscribe(event_types=["output"])
+
+        import asyncio
+
+        received_events = []
+
+        async def collect_outputs():
+            count = 0
+            async for event in subscription:
+                received_events.append(event)
+                count += 1
+                if count >= 1:  # Just get first output
+                    break
+
+        collect_task = asyncio.create_task(collect_outputs())
+
+        await async_session.execute_cell(cell_id)
+
+        try:
+            await asyncio.wait_for(collect_task, timeout=3.0)
+        except asyncio.TimeoutError:
+            pass
+
+        # All received events should be output type
+        for event in received_events:
+            assert event.event_type == "output", f"Expected only output events, got {event.event_type}"
+
+    @pytest.mark.asyncio
+    async def test_multiple_subscribers(self, async_session):
+        """Multiple subscribers can listen to same execution."""
+        await async_session.start_kernel()
+
+        cell_id = await async_session.create_cell("print('multi-sub')")
+
+        # Create two independent subscriptions
+        sub1 = async_session.subscribe()
+        sub2 = async_session.subscribe()
+
+        import asyncio
+
+        events1, events2 = [], []
+
+        async def collect1():
+            async for event in sub1:
+                events1.append(event)
+                if event.event_type == "done":
+                    break
+
+        async def collect2():
+            async for event in sub2:
+                events2.append(event)
+                if event.event_type == "done":
+                    break
+
+        # Start both collectors
+        task1 = asyncio.create_task(collect1())
+        task2 = asyncio.create_task(collect2())
+
+        # Execute
+        await async_session.execute_cell(cell_id)
+
+        # Wait for both
+        await asyncio.wait_for(asyncio.gather(task1, task2), timeout=5.0)
+
+        # Both should have received events
+        assert len(events1) >= 1, "Subscriber 1 should receive events"
+        assert len(events2) >= 1, "Subscriber 2 should receive events"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Improves the runtimed Python bindings for agentic workflows with true async streaming and multi-subscriber support:

- **stream_execute()** now returns an async iterator that yields events as they arrive (instead of collecting all results)
- **subscribe()** enables independent event listening with optional filters for cell_ids and event_types
- **append_source()** supports incremental code writing for LLM token streaming
- Changed internal broadcast channel from mpsc to broadcast for multi-subscriber support

## Verification

- [x] Run Python integration tests: `cd python/runtimed && uv run pytest tests/test_daemon_integration.py -v -k "StreamExecute or AppendSource or Subscription"`
- [x] Verify async iteration works: create a cell with multiple prints and confirm events stream in real-time
- [x] Test multi-subscriber: open two subscriptions and verify both receive events

_PR submitted by @rgbkrk's agent, Quill_