### PR TITLE
feat(python): bundle runtimed daemon binary in wheel

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,8 +1,7 @@
 # Build and publish the runtimed Python package.
 #
-# The package provides PyO3 bindings for the runtimed daemon client.
-# It does NOT bundle the runt CLI binary — users get that from the
-# nteract desktop app or GitHub Releases.
+# The package provides PyO3 bindings for the runtimed daemon client,
+# and bundles the runtimed daemon binary.
 #
 # To publish: push a tag matching `python-v*` (e.g. `python-v0.1.0`).
 
@@ -43,6 +42,23 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up Rust
+        uses: dsherret/rust-toolchain-file@v1
+
+      - name: Install cross-compilation target
+        if: matrix.platform.target == 'x86_64-apple-darwin'
+        run: rustup target add x86_64-apple-darwin
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "python-${{ matrix.platform.target }}"
+
+      - name: Build runtimed binary
+        run: |
+          cargo build --release --target ${{ matrix.platform.target }} -p runtimed
+          cp target/${{ matrix.platform.target }}/release/runtimed python/runtimed/src/runtimed/_bin/
+          chmod +x python/runtimed/src/runtimed/_bin/runtimed
+
       - name: Build wheels
         uses: PyO3/maturin-action@v1
         with:
@@ -62,6 +78,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set up Rust
+        uses: dsherret/rust-toolchain-file@v1
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "python-x86_64-unknown-linux-gnu"
+
+      - name: Build runtimed binary
+        run: |
+          cargo build --release --target x86_64-unknown-linux-gnu -p runtimed
+          cp target/x86_64-unknown-linux-gnu/release/runtimed python/runtimed/src/runtimed/_bin/
+          chmod +x python/runtimed/src/runtimed/_bin/runtimed
 
       - name: Build wheels
         uses: PyO3/maturin-action@v1

--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -676,6 +676,20 @@ jobs:
         with:
           shared-key: "python-${{ matrix.platform.target }}"
 
+      - name: Build runtimed binary (Unix)
+        if: runner.os != 'Windows'
+        run: |
+          cargo build --release --target ${{ matrix.platform.target }} -p runtimed
+          cp target/${{ matrix.platform.target }}/release/runtimed python/runtimed/src/runtimed/_bin/
+          chmod +x python/runtimed/src/runtimed/_bin/runtimed
+
+      - name: Build runtimed binary (Windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          cargo build --release --target ${{ matrix.platform.target }} -p runtimed
+          cp target/${{ matrix.platform.target }}/release/runtimed.exe python/runtimed/src/runtimed/_bin/
+
       - name: Set dev version (Unix)
         if: runner.os != 'Windows'
         run: |

--- a/python/runtimed/.gitignore
+++ b/python/runtimed/.gitignore
@@ -14,3 +14,7 @@ dist/
 # Python cache
 __pycache__/
 *.pyc
+
+# Staged binaries (CI copies these before wheel build)
+src/runtimed/_bin/runtimed
+src/runtimed/_bin/runtimed.exe

--- a/python/runtimed/src/runtimed/_binary.py
+++ b/python/runtimed/src/runtimed/_binary.py
@@ -52,17 +52,21 @@ def _well_known_paths(name: str) -> list[str]:
     return paths
 
 
+# Path to the _bin/ directory bundled inside this package.
+_BIN_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "_bin")
+
+
 def find_binary(name: str) -> str:
     """Find a runtimed binary by name.
 
     Search order:
     1. Environment variable override (RUNTIMED_RUNT_PATH, etc.)
-    2. Python scripts directory (where pip/maturin install binaries)
+    2. Bundled in package (_bin/ directory inside the installed wheel)
     3. System PATH
     4. Well-known install locations (nteract.app, manual installs)
 
     Args:
-        name: Binary name (e.g., "runt")
+        name: Binary name (e.g., "runt", "runtimed")
 
     Returns:
         Absolute path to the binary.
@@ -83,11 +87,11 @@ def find_binary(name: str) -> str:
     exe_suffix = sysconfig.get_config_var("EXE") or ""
     exe_name = name + exe_suffix
 
-    # 2. Python scripts directory (where maturin/pip install binaries)
-    scripts_path = os.path.join(sysconfig.get_path("scripts"), exe_name)
-    if os.path.isfile(scripts_path):
-        return scripts_path
-    searched.append(f"scripts: {scripts_path}")
+    # 2. Bundled in package
+    bundled = os.path.join(_BIN_DIR, exe_name)
+    if os.path.isfile(bundled):
+        return bundled
+    searched.append(f"bundled: {bundled}")
 
     # 3. System PATH
     which_result = shutil.which(name)


### PR DESCRIPTION
Bundle the `runtimed` daemon binary inside the `runtimed` Python wheel as package data.

The binary lives in `_bin/` inside the package — not on PATH — so it doesn't conflict with binaries installed by the nteract desktop app. `find_binary("runtimed")` returns the path for programmatic use.

`runt` CLI is not included — it pulls in the sidecar (`wry`/`tao`/`libwebkit2gtk`) which is heavy and unavailable on Linux. Users get `runt` from the desktop app.

Primary motivation: let `nteract-mcp` (and others) run integration tests with just `pip install runtimed`.