### PR TITLE
fix(sync): detect and merge external notebook file changes

### DIFF
--- a/apps/notebook/src/hooks/useDaemonKernel.ts
+++ b/apps/notebook/src/hooks/useDaemonKernel.ts
@@ -397,6 +397,20 @@ export function useDaemonKernel({
             break;
           }
 
+          case "file_changed": {
+            // External file changes detected and merged into Automerge doc.
+            // The actual cell data comes through notebook:updated (Automerge sync).
+            // This broadcast is for notification purposes.
+            const fileBroadcast = broadcast as {
+              cells: unknown[];
+              metadata?: string;
+            };
+            logger.info(
+              `[daemon-kernel] External file changes detected (${fileBroadcast.cells.length} cells)`,
+            );
+            break;
+          }
+
           default: {
             // Log unknown events to help debug unexpected broadcast types
             logger.debug(

--- a/apps/notebook/src/types.ts
+++ b/apps/notebook/src/types.ts
@@ -208,6 +208,17 @@ export type DaemonBroadcast =
         channels_changed: boolean;
         deno_changed: boolean;
       };
+    }
+  | {
+      event: "file_changed";
+      cells: {
+        id: string;
+        cell_type: string;
+        source: string;
+        execution_count: string;
+        outputs: string[];
+      }[];
+      metadata?: string;
     };
 
 /** Response types from daemon notebook requests */

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -2683,19 +2683,19 @@ const SELF_WRITE_SKIP_WINDOW_MS: u64 = 600;
 
 /// Parse cells from a Jupyter notebook JSON object.
 ///
+/// Returns `Some(cells)` if parsing succeeded (including empty `cells: []`),
+/// or `None` if the `cells` key is missing or invalid (parse failure).
+///
 /// The source field can be either a string or an array of strings (lines).
 /// We normalize it to a single string.
 ///
 /// For older notebooks (pre-nbformat 4.5) that don't have cell IDs, we generate
 /// stable fallback IDs based on the cell index. This prevents data loss when
 /// merging changes from externally-generated notebooks.
-fn parse_cells_from_ipynb(json: &serde_json::Value) -> Vec<CellSnapshot> {
-    let cells = match json.get("cells").and_then(|c| c.as_array()) {
-        Some(c) => c,
-        None => return vec![],
-    };
+fn parse_cells_from_ipynb(json: &serde_json::Value) -> Option<Vec<CellSnapshot>> {
+    let cells_json = json.get("cells").and_then(|c| c.as_array())?;
 
-    cells
+    let parsed_cells = cells_json
         .iter()
         .enumerate()
         .map(|(index, cell)| {
@@ -2749,7 +2749,9 @@ fn parse_cells_from_ipynb(json: &serde_json::Value) -> Vec<CellSnapshot> {
                 outputs,
             }
         })
-        .collect()
+        .collect();
+
+    Some(parsed_cells)
 }
 
 /// Apply external .ipynb changes to the Automerge doc.
@@ -2769,20 +2771,10 @@ async fn apply_ipynb_changes(
     external_cells: &[CellSnapshot],
     has_running_kernel: bool,
 ) -> bool {
-    // Guard: don't apply changes if external cells are empty but we have cells
-    // This prevents accidental data loss from parse failures or corrupt files
     let current_cells = {
         let doc = room.doc.read().await;
         doc.get_cells()
     };
-
-    if external_cells.is_empty() && !current_cells.is_empty() {
-        warn!(
-            "[notebook-watch] External file has no cells but current doc has {} cells - skipping merge to prevent data loss",
-            current_cells.len()
-        );
-        return false;
-    }
 
     let mut doc = room.doc.write().await;
 
@@ -2829,11 +2821,17 @@ async fn apply_ipynb_changes(
             {
                 let _ = doc.update_source(&ext_cell.id, &ext_cell.source);
 
-                // Preserve outputs/execution_count from current state if kernel running
+                // For existing cells with running kernel: preserve current outputs/execution_count
+                // For new cells: always use external values (they don't have in-progress state)
                 if has_running_kernel {
                     if let Some(current) = current_map.get(ext_cell.id.as_str()) {
+                        // Existing cell - preserve in-progress state
                         let _ = doc.set_outputs(&ext_cell.id, &current.outputs);
                         let _ = doc.set_execution_count(&ext_cell.id, &current.execution_count);
+                    } else {
+                        // New cell - use external values
+                        let _ = doc.set_outputs(&ext_cell.id, &ext_cell.outputs);
+                        let _ = doc.set_execution_count(&ext_cell.id, &ext_cell.execution_count);
                     }
                 } else {
                     let _ = doc.set_outputs(&ext_cell.id, &ext_cell.outputs);
@@ -2906,6 +2904,7 @@ async fn apply_ipynb_changes(
             }
         } else {
             // New cell - add it
+            // New cells don't have any in-progress state, so always use external values
             debug!(
                 "[notebook-watch] Adding new cell at index {}: {}",
                 index, ext_cell.id
@@ -2915,13 +2914,9 @@ async fn apply_ipynb_changes(
                 .is_ok()
             {
                 changed = true;
-                // Set the source
                 let _ = doc.update_source(&ext_cell.id, &ext_cell.source);
-                // Set outputs and execution_count (if no kernel running)
-                if !has_running_kernel {
-                    let _ = doc.set_outputs(&ext_cell.id, &ext_cell.outputs);
-                    let _ = doc.set_execution_count(&ext_cell.id, &ext_cell.execution_count);
-                }
+                let _ = doc.set_outputs(&ext_cell.id, &ext_cell.outputs);
+                let _ = doc.set_execution_count(&ext_cell.id, &ext_cell.execution_count);
             }
         }
     }
@@ -3047,7 +3042,17 @@ pub(crate) fn spawn_notebook_file_watcher(
                             };
 
                             // Parse cells from the .ipynb
-                            let external_cells = parse_cells_from_ipynb(&json);
+                            // None = parse failure (missing cells key), Some([]) = valid empty notebook
+                            let external_cells = match parse_cells_from_ipynb(&json) {
+                                Some(cells) => cells,
+                                None => {
+                                    warn!(
+                                        "[notebook-watch] Cannot parse cells from {:?} - skipping",
+                                        notebook_path
+                                    );
+                                    continue;
+                                }
+                            };
 
                             // Check if kernel is running (to preserve outputs)
                             let has_kernel = room.has_kernel().await;
@@ -3763,7 +3768,7 @@ mod tests {
             ]
         });
 
-        let cells = parse_cells_from_ipynb(&json);
+        let cells = parse_cells_from_ipynb(&json).expect("Should parse valid notebook");
         assert_eq!(cells.len(), 2);
         assert_eq!(cells[0].id, "cell-1");
         assert_eq!(cells[0].cell_type, "code");
@@ -3795,7 +3800,7 @@ mod tests {
             ]
         });
 
-        let cells = parse_cells_from_ipynb(&json);
+        let cells = parse_cells_from_ipynb(&json).expect("Should parse valid notebook");
         assert_eq!(cells.len(), 2);
         // Should generate fallback IDs based on index
         assert_eq!(cells[0].id, "__external_cell_0");
@@ -3806,24 +3811,29 @@ mod tests {
 
     #[test]
     fn test_parse_cells_from_ipynb_empty() {
+        // Valid notebook with empty cells array - should return Some([])
         let json = serde_json::json!({
             "cells": []
         });
-        let cells = parse_cells_from_ipynb(&json);
+        let cells = parse_cells_from_ipynb(&json).expect("Should parse valid empty notebook");
         assert!(cells.is_empty());
     }
 
     #[test]
     fn test_parse_cells_from_ipynb_no_cells_key() {
+        // Invalid notebook (missing cells key) - should return None
         let json = serde_json::json!({
             "metadata": {}
         });
-        let cells = parse_cells_from_ipynb(&json);
-        assert!(cells.is_empty());
+        assert!(
+            parse_cells_from_ipynb(&json).is_none(),
+            "Should return None for invalid notebook"
+        );
     }
 
     #[tokio::test]
-    async fn test_apply_ipynb_changes_guards_against_empty_cells() {
+    async fn test_apply_ipynb_changes_clears_all_cells() {
+        // Valid "delete all cells" case - empty cells array should clear the doc
         let tmp = tempfile::TempDir::new().unwrap();
         let (room, _) = test_room_with_path(&tmp, "test.ipynb");
 
@@ -3834,18 +3844,17 @@ mod tests {
             doc.update_source("cell-1", "x = 1").unwrap();
         }
 
-        // Try to apply empty external cells - should be rejected
+        // Apply empty external cells - should delete all cells
         let external_cells = vec![];
         let changed = apply_ipynb_changes(&room, &external_cells, false).await;
-        assert!(!changed, "Should not apply changes when external is empty");
+        assert!(changed, "Should apply changes to clear all cells");
 
-        // Verify cell is still there
+        // Verify all cells were deleted
         let cells = {
             let doc = room.doc.read().await;
             doc.get_cells()
         };
-        assert_eq!(cells.len(), 1);
-        assert_eq!(cells[0].id, "cell-1");
+        assert!(cells.is_empty(), "All cells should be deleted");
     }
 
     #[tokio::test]
@@ -3914,5 +3923,55 @@ mod tests {
         // But outputs and execution_count should be preserved
         assert_eq!(cells[0].outputs, vec![r#"{"output_type":"stream"}"#]);
         assert_eq!(cells[0].execution_count, "10");
+    }
+
+    #[tokio::test]
+    async fn test_apply_ipynb_changes_new_cell_with_outputs_while_kernel_running() {
+        // New external cells should get their external outputs even when kernel is running
+        // (they don't have any in-progress state to preserve)
+        let tmp = tempfile::TempDir::new().unwrap();
+        let (room, _) = test_room_with_path(&tmp, "test.ipynb");
+
+        // Start with one cell
+        {
+            let mut doc = room.doc.write().await;
+            doc.add_cell(0, "existing-cell", "code").unwrap();
+        }
+
+        // Add a new external cell with outputs while kernel is "running"
+        let external_cells = vec![
+            CellSnapshot {
+                id: "existing-cell".to_string(),
+                cell_type: "code".to_string(),
+                source: String::new(),
+                execution_count: "null".to_string(),
+                outputs: vec![],
+            },
+            CellSnapshot {
+                id: "new-cell".to_string(),
+                cell_type: "code".to_string(),
+                source: "print('new')".to_string(),
+                execution_count: "42".to_string(),
+                outputs: vec![r#"{"output_type":"execute_result"}"#.to_string()],
+            },
+        ];
+
+        let changed = apply_ipynb_changes(&room, &external_cells, true).await;
+        assert!(changed, "Should add new cell");
+
+        let cells = {
+            let doc = room.doc.read().await;
+            doc.get_cells()
+        };
+        assert_eq!(cells.len(), 2);
+
+        // New cell should have external outputs and execution_count
+        let new_cell = cells.iter().find(|c| c.id == "new-cell").unwrap();
+        assert_eq!(new_cell.source, "print('new')");
+        assert_eq!(new_cell.execution_count, "42");
+        assert_eq!(
+            new_cell.outputs,
+            vec![r#"{"output_type":"execute_result"}"#]
+        );
     }
 }

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -2678,12 +2678,17 @@ pub(crate) fn persist_notebook_bytes(data: &[u8], path: &Path) {
 // When changes are detected, merge them into the Automerge doc and broadcast.
 
 /// Time window (ms) to skip file change events after our own writes.
-const SELF_WRITE_SKIP_WINDOW_MS: u64 = 100;
+/// Must be larger than the debounce window (500ms) to reliably skip self-writes.
+const SELF_WRITE_SKIP_WINDOW_MS: u64 = 600;
 
 /// Parse cells from a Jupyter notebook JSON object.
 ///
 /// The source field can be either a string or an array of strings (lines).
 /// We normalize it to a single string.
+///
+/// For older notebooks (pre-nbformat 4.5) that don't have cell IDs, we generate
+/// stable fallback IDs based on the cell index. This prevents data loss when
+/// merging changes from externally-generated notebooks.
 fn parse_cells_from_ipynb(json: &serde_json::Value) -> Vec<CellSnapshot> {
     let cells = match json.get("cells").and_then(|c| c.as_array()) {
         Some(c) => c,
@@ -2692,8 +2697,16 @@ fn parse_cells_from_ipynb(json: &serde_json::Value) -> Vec<CellSnapshot> {
 
     cells
         .iter()
-        .filter_map(|cell| {
-            let id = cell.get("id").and_then(|v| v.as_str())?.to_string();
+        .enumerate()
+        .map(|(index, cell)| {
+            // Use existing ID or generate a stable fallback based on index
+            // This handles older notebooks (pre-nbformat 4.5) without cell IDs
+            let id = cell
+                .get("id")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string())
+                .unwrap_or_else(|| format!("__external_cell_{}", index));
+
             let cell_type = cell
                 .get("cell_type")
                 .and_then(|v| v.as_str())
@@ -2728,13 +2741,13 @@ fn parse_cells_from_ipynb(json: &serde_json::Value) -> Vec<CellSnapshot> {
                 })
                 .unwrap_or_default();
 
-            Some(CellSnapshot {
+            CellSnapshot {
                 id,
                 cell_type,
                 source,
                 execution_count,
                 outputs,
-            })
+            }
         })
         .collect()
 }
@@ -2744,7 +2757,11 @@ fn parse_cells_from_ipynb(json: &serde_json::Value) -> Vec<CellSnapshot> {
 /// Compares cells by ID and:
 /// - Adds new cells
 /// - Removes deleted cells
-/// - Updates source for modified cells (preserving outputs if kernel is running)
+/// - Updates source, execution_count, and outputs for modified cells
+/// - Handles cell reordering by rebuilding the cell list
+///
+/// When a kernel is running, outputs and execution counts are preserved
+/// to avoid losing in-progress execution results.
 ///
 /// Returns true if any changes were applied.
 async fn apply_ipynb_changes(
@@ -2752,8 +2769,22 @@ async fn apply_ipynb_changes(
     external_cells: &[CellSnapshot],
     has_running_kernel: bool,
 ) -> bool {
+    // Guard: don't apply changes if external cells are empty but we have cells
+    // This prevents accidental data loss from parse failures or corrupt files
+    let current_cells = {
+        let doc = room.doc.read().await;
+        doc.get_cells()
+    };
+
+    if external_cells.is_empty() && !current_cells.is_empty() {
+        warn!(
+            "[notebook-watch] External file has no cells but current doc has {} cells - skipping merge to prevent data loss",
+            current_cells.len()
+        );
+        return false;
+    }
+
     let mut doc = room.doc.write().await;
-    let current_cells = doc.get_cells();
 
     // Build maps for comparison
     let current_map: HashMap<&str, &CellSnapshot> =
@@ -2761,7 +2792,57 @@ async fn apply_ipynb_changes(
     let external_map: HashMap<&str, &CellSnapshot> =
         external_cells.iter().map(|c| (c.id.as_str(), c)).collect();
 
+    // Check if cell order changed
+    let current_ids: Vec<&str> = current_cells.iter().map(|c| c.id.as_str()).collect();
+    let external_ids: Vec<&str> = external_cells.iter().map(|c| c.id.as_str()).collect();
+    let order_changed = {
+        // Filter to only IDs that exist in both, then compare order
+        let common_current: Vec<&str> = current_ids
+            .iter()
+            .filter(|id| external_map.contains_key(*id))
+            .copied()
+            .collect();
+        let common_external: Vec<&str> = external_ids
+            .iter()
+            .filter(|id| current_map.contains_key(*id))
+            .copied()
+            .collect();
+        common_current != common_external
+    };
+
     let mut changed = false;
+
+    // If order changed, we need to rebuild the cell list
+    // This is expensive but necessary to match external order
+    if order_changed {
+        debug!("[notebook-watch] Cell order changed, rebuilding cell list");
+
+        // Delete all current cells and re-add in external order
+        for cell in &current_cells {
+            let _ = doc.delete_cell(&cell.id);
+        }
+
+        for (index, ext_cell) in external_cells.iter().enumerate() {
+            if doc
+                .add_cell(index, &ext_cell.id, &ext_cell.cell_type)
+                .is_ok()
+            {
+                let _ = doc.update_source(&ext_cell.id, &ext_cell.source);
+
+                // Preserve outputs/execution_count from current state if kernel running
+                if has_running_kernel {
+                    if let Some(current) = current_map.get(ext_cell.id.as_str()) {
+                        let _ = doc.set_outputs(&ext_cell.id, &current.outputs);
+                        let _ = doc.set_execution_count(&ext_cell.id, &current.execution_count);
+                    }
+                } else {
+                    let _ = doc.set_outputs(&ext_cell.id, &ext_cell.outputs);
+                    let _ = doc.set_execution_count(&ext_cell.id, &ext_cell.execution_count);
+                }
+            }
+        }
+        return true;
+    }
 
     // Find cells to delete (in current but not in external)
     let cells_to_delete: Vec<String> = current_cells
@@ -2798,14 +2879,29 @@ async fn apply_ipynb_changes(
                 // For now, just log - full support would need more work
             }
 
-            // Preserve outputs if kernel is running, otherwise sync from file
-            if !has_running_kernel && current_cell.outputs != ext_cell.outputs {
-                debug!(
-                    "[notebook-watch] Updating outputs for cell: {}",
-                    ext_cell.id
-                );
-                if let Ok(true) = doc.set_outputs(&ext_cell.id, &ext_cell.outputs) {
-                    changed = true;
+            // Preserve outputs and execution_count if kernel is running
+            if !has_running_kernel {
+                if current_cell.outputs != ext_cell.outputs {
+                    debug!(
+                        "[notebook-watch] Updating outputs for cell: {}",
+                        ext_cell.id
+                    );
+                    if let Ok(true) = doc.set_outputs(&ext_cell.id, &ext_cell.outputs) {
+                        changed = true;
+                    }
+                }
+
+                if current_cell.execution_count != ext_cell.execution_count {
+                    debug!(
+                        "[notebook-watch] Updating execution_count for cell: {} ({} -> {})",
+                        ext_cell.id, current_cell.execution_count, ext_cell.execution_count
+                    );
+                    if doc
+                        .set_execution_count(&ext_cell.id, &ext_cell.execution_count)
+                        .is_ok()
+                    {
+                        changed = true;
+                    }
                 }
             }
         } else {
@@ -2821,9 +2917,10 @@ async fn apply_ipynb_changes(
                 changed = true;
                 // Set the source
                 let _ = doc.update_source(&ext_cell.id, &ext_cell.source);
-                // Set outputs (if no kernel running)
+                // Set outputs and execution_count (if no kernel running)
                 if !has_running_kernel {
                     let _ = doc.set_outputs(&ext_cell.id, &ext_cell.outputs);
+                    let _ = doc.set_execution_count(&ext_cell.id, &ext_cell.execution_count);
                 }
             }
         }
@@ -3639,5 +3736,183 @@ mod tests {
             content_str.starts_with("update-"),
             "Content should be from an update"
         );
+    }
+
+    // ==========================================================================
+    // File watcher tests
+    // ==========================================================================
+
+    #[test]
+    fn test_parse_cells_from_ipynb_with_ids() {
+        let json = serde_json::json!({
+            "cells": [
+                {
+                    "id": "cell-1",
+                    "cell_type": "code",
+                    "source": "print('hello')",
+                    "execution_count": 5,
+                    "outputs": []
+                },
+                {
+                    "id": "cell-2",
+                    "cell_type": "markdown",
+                    "source": ["# Title\n", "Body"],
+                    "execution_count": null,
+                    "outputs": []
+                }
+            ]
+        });
+
+        let cells = parse_cells_from_ipynb(&json);
+        assert_eq!(cells.len(), 2);
+        assert_eq!(cells[0].id, "cell-1");
+        assert_eq!(cells[0].cell_type, "code");
+        assert_eq!(cells[0].source, "print('hello')");
+        assert_eq!(cells[0].execution_count, "5");
+        assert_eq!(cells[1].id, "cell-2");
+        assert_eq!(cells[1].cell_type, "markdown");
+        assert_eq!(cells[1].source, "# Title\nBody");
+        assert_eq!(cells[1].execution_count, "null");
+    }
+
+    #[test]
+    fn test_parse_cells_from_ipynb_missing_ids() {
+        // Older notebooks (pre-nbformat 4.5) don't have cell IDs
+        let json = serde_json::json!({
+            "cells": [
+                {
+                    "cell_type": "code",
+                    "source": "x = 1",
+                    "execution_count": null,
+                    "outputs": []
+                },
+                {
+                    "cell_type": "code",
+                    "source": "y = 2",
+                    "execution_count": null,
+                    "outputs": []
+                }
+            ]
+        });
+
+        let cells = parse_cells_from_ipynb(&json);
+        assert_eq!(cells.len(), 2);
+        // Should generate fallback IDs based on index
+        assert_eq!(cells[0].id, "__external_cell_0");
+        assert_eq!(cells[1].id, "__external_cell_1");
+        assert_eq!(cells[0].source, "x = 1");
+        assert_eq!(cells[1].source, "y = 2");
+    }
+
+    #[test]
+    fn test_parse_cells_from_ipynb_empty() {
+        let json = serde_json::json!({
+            "cells": []
+        });
+        let cells = parse_cells_from_ipynb(&json);
+        assert!(cells.is_empty());
+    }
+
+    #[test]
+    fn test_parse_cells_from_ipynb_no_cells_key() {
+        let json = serde_json::json!({
+            "metadata": {}
+        });
+        let cells = parse_cells_from_ipynb(&json);
+        assert!(cells.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_apply_ipynb_changes_guards_against_empty_cells() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let (room, _) = test_room_with_path(&tmp, "test.ipynb");
+
+        // Add cells to the doc
+        {
+            let mut doc = room.doc.write().await;
+            doc.add_cell(0, "cell-1", "code").unwrap();
+            doc.update_source("cell-1", "x = 1").unwrap();
+        }
+
+        // Try to apply empty external cells - should be rejected
+        let external_cells = vec![];
+        let changed = apply_ipynb_changes(&room, &external_cells, false).await;
+        assert!(!changed, "Should not apply changes when external is empty");
+
+        // Verify cell is still there
+        let cells = {
+            let doc = room.doc.read().await;
+            doc.get_cells()
+        };
+        assert_eq!(cells.len(), 1);
+        assert_eq!(cells[0].id, "cell-1");
+    }
+
+    #[tokio::test]
+    async fn test_apply_ipynb_changes_updates_execution_count() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let (room, _) = test_room_with_path(&tmp, "test.ipynb");
+
+        // Add cells to the doc
+        {
+            let mut doc = room.doc.write().await;
+            doc.add_cell(0, "cell-1", "code").unwrap();
+            doc.set_execution_count("cell-1", "null").unwrap();
+        }
+
+        // Apply external changes with execution_count
+        let external_cells = vec![CellSnapshot {
+            id: "cell-1".to_string(),
+            cell_type: "code".to_string(),
+            source: String::new(),
+            execution_count: "42".to_string(),
+            outputs: vec![],
+        }];
+
+        let changed = apply_ipynb_changes(&room, &external_cells, false).await;
+        assert!(changed, "Should detect execution_count change");
+
+        let cells = {
+            let doc = room.doc.read().await;
+            doc.get_cells()
+        };
+        assert_eq!(cells[0].execution_count, "42");
+    }
+
+    #[tokio::test]
+    async fn test_apply_ipynb_changes_preserves_outputs_when_kernel_running() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let (room, _) = test_room_with_path(&tmp, "test.ipynb");
+
+        // Add cells with outputs
+        {
+            let mut doc = room.doc.write().await;
+            doc.add_cell(0, "cell-1", "code").unwrap();
+            doc.set_outputs("cell-1", &[r#"{"output_type":"stream"}"#.to_string()])
+                .unwrap();
+            doc.set_execution_count("cell-1", "10").unwrap();
+        }
+
+        // Apply external changes (with different outputs) while kernel is "running"
+        let external_cells = vec![CellSnapshot {
+            id: "cell-1".to_string(),
+            cell_type: "code".to_string(),
+            source: "new source".to_string(),
+            execution_count: "5".to_string(),
+            outputs: vec![r#"{"output_type":"error"}"#.to_string()],
+        }];
+
+        let changed = apply_ipynb_changes(&room, &external_cells, true).await;
+        assert!(changed, "Should apply source change");
+
+        let cells = {
+            let doc = room.doc.read().await;
+            doc.get_cells()
+        };
+        // Source should be updated
+        assert_eq!(cells[0].source, "new source");
+        // But outputs and execution_count should be preserved
+        assert_eq!(cells[0].outputs, vec![r#"{"output_type":"stream"}"#]);
+        assert_eq!(cells[0].execution_count, "10");
     }
 }

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -26,19 +26,21 @@
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use automerge::sync;
 use log::{debug, error, info, warn};
 use tokio::io::{AsyncRead, AsyncWrite};
-use tokio::sync::{broadcast, watch, Mutex, RwLock};
+use tokio::sync::{broadcast, oneshot, watch, Mutex, RwLock};
+
+use notify_debouncer_mini::DebounceEventResult;
 
 use crate::blob_store::BlobStore;
 use crate::comm_state::CommState;
 use crate::connection::{self, NotebookFrameType};
 use crate::kernel_manager::{DenoLaunchedConfig, LaunchedEnvConfig, RoomKernel};
-use crate::notebook_doc::{notebook_doc_filename, NotebookDoc};
+use crate::notebook_doc::{notebook_doc_filename, CellSnapshot, NotebookDoc};
 use crate::notebook_metadata::{NotebookMetadataSnapshot, NOTEBOOK_METADATA_KEY};
 use crate::protocol::{EnvSyncDiff, NotebookBroadcast, NotebookRequest, NotebookResponse};
 
@@ -481,6 +483,13 @@ pub struct NotebookRoom {
     /// Stores active comms so new windows can sync widget models.
     /// Arc-wrapped so it can be shared with the kernel's iopub task.
     pub comm_state: Arc<CommState>,
+    /// Timestamp (ms since epoch) of last self-write to the .ipynb file.
+    /// Used to skip file watcher events triggered by our own saves.
+    pub last_self_write: Arc<AtomicU64>,
+    /// Shutdown signal for the file watcher task.
+    /// Wrapped in Mutex to allow setting after Arc creation.
+    /// Sent when the room is evicted to stop the watcher.
+    watcher_shutdown_tx: Mutex<Option<oneshot::Sender<()>>>,
 }
 
 impl NotebookRoom {
@@ -539,6 +548,8 @@ impl NotebookRoom {
             working_dir: Arc::new(RwLock::new(None)),
             auto_launch_at: Arc::new(RwLock::new(None)),
             comm_state: Arc::new(CommState::new()),
+            last_self_write: Arc::new(AtomicU64::new(0)),
+            watcher_shutdown_tx: Mutex::new(None),
         }
     }
 
@@ -572,6 +583,8 @@ impl NotebookRoom {
             working_dir: Arc::new(RwLock::new(None)),
             auto_launch_at: Arc::new(RwLock::new(None)),
             comm_state: Arc::new(CommState::new()),
+            last_self_write: Arc::new(AtomicU64::new(0)),
+            watcher_shutdown_tx: Mutex::new(None),
         }
     }
 
@@ -607,6 +620,8 @@ pub type NotebookRooms = Arc<Mutex<HashMap<String, Arc<NotebookRoom>>>>;
 /// fresh room if one doesn't exist. The .ipynb file is the source of truth -
 /// the first client to connect will populate the Automerge doc from their
 /// local file.
+///
+/// For .ipynb files, a file watcher is spawned to detect external changes.
 pub fn get_or_create_room(
     rooms: &mut HashMap<String, Arc<NotebookRoom>>,
     notebook_id: &str,
@@ -617,7 +632,21 @@ pub fn get_or_create_room(
         .entry(notebook_id.to_string())
         .or_insert_with(|| {
             info!("[notebook-sync] Creating room for {}", notebook_id);
-            Arc::new(NotebookRoom::new_fresh(notebook_id, docs_dir, blob_store))
+            let room = Arc::new(NotebookRoom::new_fresh(notebook_id, docs_dir, blob_store));
+
+            // Spawn file watcher for .ipynb files (not for untitled notebooks with UUID IDs)
+            if !is_untitled_notebook(notebook_id) {
+                let notebook_path = PathBuf::from(notebook_id);
+                if notebook_path.extension().is_some_and(|ext| ext == "ipynb") {
+                    let shutdown_tx = spawn_notebook_file_watcher(notebook_path, room.clone());
+                    // Store the shutdown sender (blocking lock is OK here, room is new)
+                    if let Ok(mut guard) = room.watcher_shutdown_tx.try_lock() {
+                        *guard = Some(shutdown_tx);
+                    }
+                }
+            }
+
+            room
         })
         .clone()
 }
@@ -787,6 +816,17 @@ where
                         );
                     }
                 }
+
+                // Stop file watcher if running
+                if let Some(shutdown_tx) = room_for_eviction.watcher_shutdown_tx.lock().await.take()
+                {
+                    let _ = shutdown_tx.send(());
+                    debug!(
+                        "[notebook-sync] Stopped file watcher for {}",
+                        notebook_id_for_eviction
+                    );
+                }
+
                 rooms_guard.remove(&notebook_id_for_eviction);
                 info!(
                     "[notebook-sync] Evicted room {} (idle timeout)",
@@ -2437,6 +2477,13 @@ async fn save_notebook_to_disk(room: &NotebookRoom) -> Result<(), String> {
         .await
         .map_err(|e| format!("Failed to write notebook: {e}"))?;
 
+    // Update last_self_write timestamp so file watcher skips this change
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0);
+    room.last_self_write.store(now, Ordering::Relaxed);
+
     info!(
         "[notebook-sync] Saved notebook to disk: {:?} ({} cells)",
         notebook_path, cell_count
@@ -2621,6 +2668,332 @@ pub(crate) fn persist_notebook_bytes(data: &[u8], path: &Path) {
     if let Err(e) = std::fs::write(path, data) {
         warn!("[notebook-sync] Failed to save notebook doc: {}", e);
     }
+}
+
+// =============================================================================
+// Notebook File Watching
+// =============================================================================
+//
+// Watch .ipynb files for external changes (git, VS Code, other editors).
+// When changes are detected, merge them into the Automerge doc and broadcast.
+
+/// Time window (ms) to skip file change events after our own writes.
+const SELF_WRITE_SKIP_WINDOW_MS: u64 = 100;
+
+/// Parse cells from a Jupyter notebook JSON object.
+///
+/// The source field can be either a string or an array of strings (lines).
+/// We normalize it to a single string.
+fn parse_cells_from_ipynb(json: &serde_json::Value) -> Vec<CellSnapshot> {
+    let cells = match json.get("cells").and_then(|c| c.as_array()) {
+        Some(c) => c,
+        None => return vec![],
+    };
+
+    cells
+        .iter()
+        .filter_map(|cell| {
+            let id = cell.get("id").and_then(|v| v.as_str())?.to_string();
+            let cell_type = cell
+                .get("cell_type")
+                .and_then(|v| v.as_str())
+                .unwrap_or("code")
+                .to_string();
+
+            // Source can be a string or array of strings
+            let source = match cell.get("source") {
+                Some(serde_json::Value::String(s)) => s.clone(),
+                Some(serde_json::Value::Array(arr)) => arr
+                    .iter()
+                    .filter_map(|v| v.as_str())
+                    .collect::<Vec<_>>()
+                    .join(""),
+                _ => String::new(),
+            };
+
+            // Execution count: number or null
+            let execution_count = match cell.get("execution_count") {
+                Some(serde_json::Value::Number(n)) => n.to_string(),
+                _ => "null".to_string(),
+            };
+
+            // Outputs: keep as JSON strings
+            let outputs = cell
+                .get("outputs")
+                .and_then(|v| v.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .map(|o| serde_json::to_string(o).unwrap_or_default())
+                        .collect()
+                })
+                .unwrap_or_default();
+
+            Some(CellSnapshot {
+                id,
+                cell_type,
+                source,
+                execution_count,
+                outputs,
+            })
+        })
+        .collect()
+}
+
+/// Apply external .ipynb changes to the Automerge doc.
+///
+/// Compares cells by ID and:
+/// - Adds new cells
+/// - Removes deleted cells
+/// - Updates source for modified cells (preserving outputs if kernel is running)
+///
+/// Returns true if any changes were applied.
+async fn apply_ipynb_changes(
+    room: &NotebookRoom,
+    external_cells: &[CellSnapshot],
+    has_running_kernel: bool,
+) -> bool {
+    let mut doc = room.doc.write().await;
+    let current_cells = doc.get_cells();
+
+    // Build maps for comparison
+    let current_map: HashMap<&str, &CellSnapshot> =
+        current_cells.iter().map(|c| (c.id.as_str(), c)).collect();
+    let external_map: HashMap<&str, &CellSnapshot> =
+        external_cells.iter().map(|c| (c.id.as_str(), c)).collect();
+
+    let mut changed = false;
+
+    // Find cells to delete (in current but not in external)
+    let cells_to_delete: Vec<String> = current_cells
+        .iter()
+        .filter(|c| !external_map.contains_key(c.id.as_str()))
+        .map(|c| c.id.clone())
+        .collect();
+
+    for cell_id in cells_to_delete {
+        debug!("[notebook-watch] Deleting cell: {}", cell_id);
+        if let Ok(true) = doc.delete_cell(&cell_id) {
+            changed = true;
+        }
+    }
+
+    // Process external cells in order (add new or update existing)
+    for (index, ext_cell) in external_cells.iter().enumerate() {
+        if let Some(current_cell) = current_map.get(ext_cell.id.as_str()) {
+            // Cell exists - check if source changed
+            if current_cell.source != ext_cell.source {
+                debug!("[notebook-watch] Updating source for cell: {}", ext_cell.id);
+                if let Ok(true) = doc.update_source(&ext_cell.id, &ext_cell.source) {
+                    changed = true;
+                }
+            }
+
+            // Update cell type if changed
+            if current_cell.cell_type != ext_cell.cell_type {
+                debug!(
+                    "[notebook-watch] Cell type changed for {}: {} -> {}",
+                    ext_cell.id, current_cell.cell_type, ext_cell.cell_type
+                );
+                // Cell type changes require recreating the cell (rare case)
+                // For now, just log - full support would need more work
+            }
+
+            // Preserve outputs if kernel is running, otherwise sync from file
+            if !has_running_kernel && current_cell.outputs != ext_cell.outputs {
+                debug!(
+                    "[notebook-watch] Updating outputs for cell: {}",
+                    ext_cell.id
+                );
+                if let Ok(true) = doc.set_outputs(&ext_cell.id, &ext_cell.outputs) {
+                    changed = true;
+                }
+            }
+        } else {
+            // New cell - add it
+            debug!(
+                "[notebook-watch] Adding new cell at index {}: {}",
+                index, ext_cell.id
+            );
+            if doc
+                .add_cell(index, &ext_cell.id, &ext_cell.cell_type)
+                .is_ok()
+            {
+                changed = true;
+                // Set the source
+                let _ = doc.update_source(&ext_cell.id, &ext_cell.source);
+                // Set outputs (if no kernel running)
+                if !has_running_kernel {
+                    let _ = doc.set_outputs(&ext_cell.id, &ext_cell.outputs);
+                }
+            }
+        }
+    }
+
+    changed
+}
+
+/// Spawn a file watcher for a notebook's .ipynb file.
+///
+/// Watches for external changes and merges them into the Automerge doc.
+/// Returns a shutdown sender to stop the watcher when the room is evicted.
+pub(crate) fn spawn_notebook_file_watcher(
+    notebook_path: PathBuf,
+    room: Arc<NotebookRoom>,
+) -> oneshot::Sender<()> {
+    let (shutdown_tx, mut shutdown_rx) = oneshot::channel();
+
+    tokio::spawn(async move {
+        // Determine what path to watch
+        let watch_path = if notebook_path.exists() {
+            notebook_path.clone()
+        } else if let Some(parent) = notebook_path.parent() {
+            // Watch parent directory if file doesn't exist yet
+            if !parent.exists() {
+                warn!(
+                    "[notebook-watch] Parent dir doesn't exist for {:?}",
+                    notebook_path
+                );
+                return;
+            }
+            parent.to_path_buf()
+        } else {
+            warn!(
+                "[notebook-watch] Cannot determine watch path for {:?}",
+                notebook_path
+            );
+            return;
+        };
+
+        // Create tokio mpsc channel to bridge from notify callback thread
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<DebounceEventResult>(16);
+
+        // Create debouncer with 500ms window (same as settings.json)
+        let debouncer_result = notify_debouncer_mini::new_debouncer(
+            std::time::Duration::from_millis(500),
+            move |res: DebounceEventResult| {
+                let _ = tx.blocking_send(res);
+            },
+        );
+
+        let mut debouncer = match debouncer_result {
+            Ok(d) => d,
+            Err(e) => {
+                error!(
+                    "[notebook-watch] Failed to create file watcher for {:?}: {}",
+                    notebook_path, e
+                );
+                return;
+            }
+        };
+
+        if let Err(e) = debouncer
+            .watcher()
+            .watch(&watch_path, notify::RecursiveMode::NonRecursive)
+        {
+            error!("[notebook-watch] Failed to watch {:?}: {}", watch_path, e);
+            return;
+        }
+
+        info!(
+            "[notebook-watch] Watching {:?} for external changes",
+            notebook_path
+        );
+
+        loop {
+            tokio::select! {
+                Some(result) = rx.recv() => {
+                    match result {
+                        Ok(events) => {
+                            // Check if any event is for our notebook file
+                            let relevant = events.iter().any(|e| e.path == notebook_path);
+                            if !relevant {
+                                continue;
+                            }
+
+                            // Check if this is a self-write (within skip window of our last save)
+                            let now = std::time::SystemTime::now()
+                                .duration_since(std::time::UNIX_EPOCH)
+                                .map(|d| d.as_millis() as u64)
+                                .unwrap_or(0);
+                            let last_write = room.last_self_write.load(Ordering::Relaxed);
+                            if now.saturating_sub(last_write) < SELF_WRITE_SKIP_WINDOW_MS {
+                                debug!(
+                                    "[notebook-watch] Skipping self-write event for {:?}",
+                                    notebook_path
+                                );
+                                continue;
+                            }
+
+                            // Read and parse the file
+                            let contents = match tokio::fs::read_to_string(&notebook_path).await {
+                                Ok(c) => c,
+                                Err(e) => {
+                                    // File may be deleted or being written
+                                    debug!(
+                                        "[notebook-watch] Cannot read {:?}: {}",
+                                        notebook_path, e
+                                    );
+                                    continue;
+                                }
+                            };
+
+                            let json: serde_json::Value = match serde_json::from_str(&contents) {
+                                Ok(j) => j,
+                                Err(e) => {
+                                    // Partial write or invalid JSON - try again next event
+                                    debug!(
+                                        "[notebook-watch] Cannot parse {:?}: {}",
+                                        notebook_path, e
+                                    );
+                                    continue;
+                                }
+                            };
+
+                            // Parse cells from the .ipynb
+                            let external_cells = parse_cells_from_ipynb(&json);
+
+                            // Check if kernel is running (to preserve outputs)
+                            let has_kernel = room.has_kernel().await;
+
+                            // Apply changes to Automerge doc
+                            let changed = apply_ipynb_changes(&room, &external_cells, has_kernel).await;
+
+                            if changed {
+                                info!(
+                                    "[notebook-watch] Applied external changes from {:?}",
+                                    notebook_path
+                                );
+
+                                // Notify peers of the change
+                                let _ = room.changed_tx.send(());
+
+                                // Broadcast FileChanged to all connected clients
+                                let cells = {
+                                    let doc = room.doc.read().await;
+                                    doc.get_cells()
+                                };
+                                let _ = room.kernel_broadcast_tx.send(
+                                    NotebookBroadcast::FileChanged {
+                                        cells,
+                                        metadata: None, // TODO: handle metadata changes
+                                    }
+                                );
+                            }
+                        }
+                        Err(errs) => {
+                            warn!("[notebook-watch] Watch error for {:?}: {:?}", notebook_path, errs);
+                        }
+                    }
+                }
+                _ = &mut shutdown_rx => {
+                    info!("[notebook-watch] Shutting down watcher for {:?}", notebook_path);
+                    break;
+                }
+            }
+        }
+    });
+
+    shutdown_tx
 }
 
 #[cfg(test)]
@@ -3031,6 +3404,8 @@ mod tests {
             working_dir: Arc::new(RwLock::new(None)),
             auto_launch_at: Arc::new(RwLock::new(None)),
             comm_state: Arc::new(crate::comm_state::CommState::new()),
+            last_self_write: Arc::new(AtomicU64::new(0)),
+            watcher_shutdown_tx: Mutex::new(None),
         };
 
         (room, notebook_path)

--- a/crates/runtimed/src/protocol.rs
+++ b/crates/runtimed/src/protocol.rs
@@ -433,6 +433,16 @@ pub enum NotebookBroadcast {
         comms: Vec<CommSnapshot>,
     },
 
+    /// External file changes were detected and merged into the Automerge doc.
+    /// Broadcast to all connected windows so they can update their UI.
+    FileChanged {
+        /// Updated cells from the merged .ipynb file.
+        cells: Vec<crate::notebook_doc::CellSnapshot>,
+        /// Updated notebook metadata JSON, if changed.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        metadata: Option<String>,
+    },
+
     /// Environment progress update during kernel launch.
     ///
     /// Carries rich progress phases (repodata, solve, download, link)


### PR DESCRIPTION
## Summary

Watch .ipynb files for external edits (git checkout, VS Code, other editors) while they are open in nteract. When changes are detected, merge them into the Automerge doc and broadcast to connected clients. This prevents reopening a notebook from showing stale state when the file has been modified outside the app.

The implementation follows the established `settings.json` file watcher pattern, using `notify_debouncer_mini` with a 500ms debounce window. Self-writes are detected via timestamp tracking to avoid reacting to our own persistence saves. In-memory outputs are preserved during active kernel execution.

Closes #526

## Verification

- [x] Open a notebook in nteract
- [x] Edit it externally (e.g., VS Code, git checkout, text editor)
- [x] Verify nteract updates to show the external changes
- [x] Confirm in-progress execution outputs are not lost
- [x] Check daemon logs for file watcher activity: `runt daemon logs -f | grep notebook-watch`

_PR submitted by @rgbkrk's agent, Quill_