### PR TITLE
fix(notebook): close trust dialog immediately after approval

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -527,9 +527,11 @@ function AppContent() {
     const success = await approveTrust();
     if (success && pendingKernelStartRef.current) {
       pendingKernelStartRef.current = false;
-      // Now start the kernel since trust was approved
+      // Fire and forget - dialog closes immediately, kernel starts in background
       // Use "auto" for both - daemon detects from Automerge doc
-      await launchKernel("auto", "auto");
+      launchKernel("auto", "auto").catch((e) => {
+        logger.error("[App] kernel launch after trust approval failed:", e);
+      });
     }
     return success;
   }, [approveTrust, launchKernel]);

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -910,7 +910,12 @@ function AppContent() {
         }}
       />
       {needsApproval && kernelStatus === KERNEL_STATUS.NOT_STARTED && (
-        <UntrustedBanner onReviewClick={() => setTrustDialogOpen(true)} />
+        <UntrustedBanner
+          onReviewClick={() => {
+            pendingKernelStartRef.current = true;
+            setTrustDialogOpen(true);
+          }}
+        />
       )}
       <NotebookToolbar
         kernelStatus={kernelStatus}

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -23,6 +23,7 @@ import { GlobalFindBar } from "./components/GlobalFindBar";
 import { NotebookToolbar } from "./components/NotebookToolbar";
 import { NotebookView } from "./components/NotebookView";
 import { TrustDialog } from "./components/TrustDialog";
+import { UntrustedBanner } from "./components/UntrustedBanner";
 import { useCondaDependencies } from "./hooks/useCondaDependencies";
 import { useDaemonKernel } from "./hooks/useDaemonKernel";
 import { useDenoDependencies } from "./hooks/useDenoDependencies";
@@ -133,6 +134,7 @@ function AppContent() {
     trustInfo,
     typosquatWarnings,
     loading: trustLoading,
+    needsApproval,
     checkTrust,
     approveTrust,
   } = useTrust();
@@ -907,6 +909,9 @@ function AppContent() {
             });
         }}
       />
+      {needsApproval && kernelStatus === KERNEL_STATUS.NOT_STARTED && (
+        <UntrustedBanner onReviewClick={() => setTrustDialogOpen(true)} />
+      )}
       <NotebookToolbar
         kernelStatus={kernelStatus}
         envSource={envSource}

--- a/apps/notebook/src/components/UntrustedBanner.tsx
+++ b/apps/notebook/src/components/UntrustedBanner.tsx
@@ -1,0 +1,26 @@
+import { ShieldAlert } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+interface UntrustedBannerProps {
+  onReviewClick: () => void;
+}
+
+export function UntrustedBanner({ onReviewClick }: UntrustedBannerProps) {
+  return (
+    <div className="flex items-center justify-center gap-3 bg-amber-500/90 px-3 py-1.5 text-xs text-amber-950">
+      <ShieldAlert className="h-4 w-4" />
+      <span>
+        This notebook has dependencies that need approval before the kernel can
+        start.
+      </span>
+      <Button
+        size="sm"
+        variant="secondary"
+        className="h-6 px-2 text-xs bg-amber-100 hover:bg-amber-200 text-amber-900"
+        onClick={onReviewClick}
+      >
+        Review Dependencies
+      </Button>
+    </div>
+  );
+}

--- a/e2e/dev.sh
+++ b/e2e/dev.sh
@@ -275,9 +275,40 @@ case "${1:-help}" in
     ;;
 
   test-fixtures)
-    # Placeholder - tests need to be added back
-    echo "No fixture tests defined yet."
-    echo "Run individual tests with: ./e2e/dev.sh test-fixture <notebook> <spec>"
+    # Run all fixture tests (each gets a fresh app instance)
+    FAIL=0
+
+    $0 test-fixture \
+      crates/notebook/fixtures/audit-test/1-vanilla.ipynb \
+      e2e/specs/prewarmed-uv.spec.js || FAIL=1
+
+    $0 test-fixture \
+      crates/notebook/fixtures/audit-test/2-uv-inline.ipynb \
+      e2e/specs/uv-inline.spec.js || FAIL=1
+
+    $0 test-fixture \
+      crates/notebook/fixtures/audit-test/2-uv-inline.ipynb \
+      e2e/specs/trust-dialog-dismiss.spec.js || FAIL=1
+
+    $0 test-fixture \
+      crates/notebook/fixtures/audit-test/3-conda-inline.ipynb \
+      e2e/specs/conda-inline.spec.js || FAIL=1
+
+    $0 test-fixture \
+      crates/notebook/fixtures/audit-test/10-deno.ipynb \
+      e2e/specs/deno.spec.js || FAIL=1
+
+    $0 test-fixture \
+      crates/notebook/fixtures/audit-test/pyproject-project/5-pyproject.ipynb \
+      e2e/specs/uv-pyproject.spec.js || FAIL=1
+
+    if [ $FAIL -eq 1 ]; then
+      echo ""
+      echo "Some fixture tests failed"
+      exit 1
+    fi
+    echo ""
+    echo "All fixture tests passed"
     exit 0
     ;;
 

--- a/e2e/dev.sh
+++ b/e2e/dev.sh
@@ -282,13 +282,15 @@ case "${1:-help}" in
       crates/notebook/fixtures/audit-test/1-vanilla.ipynb \
       e2e/specs/prewarmed-uv.spec.js || FAIL=1
 
-    $0 test-fixture \
-      crates/notebook/fixtures/audit-test/2-uv-inline.ipynb \
-      e2e/specs/uv-inline.spec.js || FAIL=1
-
+    # Run trust-dialog-dismiss BEFORE uv-inline on same notebook
+    # so it runs against untrusted state (trust signature persists on disk)
     $0 test-fixture \
       crates/notebook/fixtures/audit-test/2-uv-inline.ipynb \
       e2e/specs/trust-dialog-dismiss.spec.js || FAIL=1
+
+    $0 test-fixture \
+      crates/notebook/fixtures/audit-test/2-uv-inline.ipynb \
+      e2e/specs/uv-inline.spec.js || FAIL=1
 
     $0 test-fixture \
       crates/notebook/fixtures/audit-test/3-conda-inline.ipynb \

--- a/e2e/specs/trust-dialog-dismiss.spec.js
+++ b/e2e/specs/trust-dialog-dismiss.spec.js
@@ -9,8 +9,12 @@
  * Requires: NOTEBOOK_PATH=crates/notebook/fixtures/audit-test/2-uv-inline.ipynb
  */
 
-import { browser } from "@wdio/globals";
-import { getKernelStatus, waitForAppReady } from "../helpers.js";
+import { browser, expect } from "@wdio/globals";
+import {
+  executeFirstCell,
+  getKernelStatus,
+  waitForAppReady,
+} from "../helpers.js";
 
 describe("Trust Dialog Dismiss", () => {
   before(async () => {
@@ -18,20 +22,19 @@ describe("Trust Dialog Dismiss", () => {
   });
 
   it("should close trust dialog on single click without waiting for kernel", async () => {
+    // Execute a cell to trigger kernel start (which requires trust approval)
+    // This is how other trust-related specs trigger the dialog
+    await executeFirstCell();
+
     // Wait for the trust dialog to appear (notebook has untrusted deps)
     const dialog = await $('[data-testid="trust-dialog"]');
 
-    // Give the dialog time to appear (first startup with deps)
-    try {
-      await dialog.waitForExist({ timeout: 30000 });
-    } catch {
-      // If dialog doesn't appear, kernel may have auto-started with trusted deps
-      // This can happen if the test ran before and the notebook was trusted
-      console.log(
-        "Trust dialog did not appear - notebook may already be trusted",
-      );
-      return;
-    }
+    // Dialog MUST appear for this fixture - fail if it doesn't
+    await dialog.waitForExist({
+      timeout: 30000,
+      timeoutMsg:
+        "Trust dialog did not appear - fixture notebook should have untrusted deps",
+    });
 
     // Record current kernel status before clicking
     const statusBefore = await getKernelStatus();
@@ -41,7 +44,6 @@ describe("Trust Dialog Dismiss", () => {
     const approveButton = await $('[data-testid="trust-approve-button"]');
     await approveButton.waitForClickable({ timeout: 5000 });
 
-    // Record time before click
     const clickTime = Date.now();
     await approveButton.click();
 
@@ -51,23 +53,16 @@ describe("Trust Dialog Dismiss", () => {
       timeout: 3000,
       interval: 100,
       timeoutMsg:
-        "Trust dialog did not close within 3s - may be waiting for kernel launch",
+        "Trust dialog did not close within 3s - may be waiting for kernel launch (regression #515)",
     });
 
     const closeTime = Date.now();
     const dismissTime = closeTime - clickTime;
     console.log(`Dialog dismissed in ${dismissTime}ms`);
 
-    // Verify dialog closed quickly (under 2 seconds)
-    expect(dismissTime).toBeLessThan(2000);
-
-    // Check kernel status - it should be starting (not yet idle)
-    // This proves the dialog didn't wait for kernel launch
+    // Check kernel status - should be starting or have quickly reached idle
     const statusAfter = await getKernelStatus();
     console.log(`Kernel status after dialog closed: ${statusAfter}`);
-
-    // The kernel should either be "starting" or have quickly reached "idle"
-    // We don't strictly assert "starting" because fast machines might launch quickly
     expect(["starting", "idle", "busy"]).toContain(statusAfter);
   });
 });

--- a/e2e/specs/trust-dialog-dismiss.spec.js
+++ b/e2e/specs/trust-dialog-dismiss.spec.js
@@ -1,0 +1,73 @@
+/**
+ * E2E Test: Trust Dialog Single-Click Dismiss
+ *
+ * Verifies that clicking "Trust & Start" closes the dialog immediately,
+ * without waiting for kernel launch to complete.
+ *
+ * Regression test for: https://github.com/nteract/desktop/issues/515
+ *
+ * Requires: NOTEBOOK_PATH=crates/notebook/fixtures/audit-test/2-uv-inline.ipynb
+ */
+
+import { browser } from "@wdio/globals";
+import { getKernelStatus, waitForAppReady } from "../helpers.js";
+
+describe("Trust Dialog Dismiss", () => {
+  before(async () => {
+    await waitForAppReady();
+  });
+
+  it("should close trust dialog on single click without waiting for kernel", async () => {
+    // Wait for the trust dialog to appear (notebook has untrusted deps)
+    const dialog = await $('[data-testid="trust-dialog"]');
+
+    // Give the dialog time to appear (first startup with deps)
+    try {
+      await dialog.waitForExist({ timeout: 30000 });
+    } catch {
+      // If dialog doesn't appear, kernel may have auto-started with trusted deps
+      // This can happen if the test ran before and the notebook was trusted
+      console.log(
+        "Trust dialog did not appear - notebook may already be trusted",
+      );
+      return;
+    }
+
+    // Record current kernel status before clicking
+    const statusBefore = await getKernelStatus();
+    console.log(`Kernel status before trust approval: ${statusBefore}`);
+
+    // Find and click the approve button
+    const approveButton = await $('[data-testid="trust-approve-button"]');
+    await approveButton.waitForClickable({ timeout: 5000 });
+
+    // Record time before click
+    const clickTime = Date.now();
+    await approveButton.click();
+
+    // Dialog should close QUICKLY (within 3 seconds) - this is the key assertion
+    // If it waited for kernel launch, this would timeout
+    await browser.waitUntil(async () => !(await dialog.isExisting()), {
+      timeout: 3000,
+      interval: 100,
+      timeoutMsg:
+        "Trust dialog did not close within 3s - may be waiting for kernel launch",
+    });
+
+    const closeTime = Date.now();
+    const dismissTime = closeTime - clickTime;
+    console.log(`Dialog dismissed in ${dismissTime}ms`);
+
+    // Verify dialog closed quickly (under 2 seconds)
+    expect(dismissTime).toBeLessThan(2000);
+
+    // Check kernel status - it should be starting (not yet idle)
+    // This proves the dialog didn't wait for kernel launch
+    const statusAfter = await getKernelStatus();
+    console.log(`Kernel status after dialog closed: ${statusAfter}`);
+
+    // The kernel should either be "starting" or have quickly reached "idle"
+    // We don't strictly assert "starting" because fast machines might launch quickly
+    expect(["starting", "idle", "busy"]).toContain(statusAfter);
+  });
+});

--- a/e2e/wdio.conf.js
+++ b/e2e/wdio.conf.js
@@ -33,6 +33,7 @@ const FIXTURE_SPECS = [
   "conda-inline.spec.js",
   "deno.spec.js",
   "prewarmed-uv.spec.js",
+  "trust-dialog-dismiss.spec.js",
   "untitled-pyproject.spec.js", // Requires working dir to be pyproject fixture directory
   "uv-inline.spec.js",
   "uv-pyproject.spec.js",


### PR DESCRIPTION
Don't await kernel launch in handleTrustApprove - close the dialog as soon as trust is approved. The kernel launch continues in the background.

This fixes the issue where the "Trust & Start" dialog required two clicks to dismiss because it was waiting for the kernel to finish launching.

Also adds:
- An e2e regression test (`trust-dialog-dismiss.spec.js`) that verifies the dialog closes within 3 seconds
- A yellow banner that appears when the kernel hasn't started because dependencies need approval

<!-- placeholder: screenshot of yellow untrusted banner -->

## Verification

- [x] Open a notebook with untrusted dependencies
- [x] Verify yellow banner appears explaining why kernel hasn't started
- [x] Click "Review Dependencies" button on banner or "Trust & Start" on dialog
- [x] Verify dialog closes immediately on first click
- [x] Verify kernel starts in the background and completes successfully
- [x] Run a cell to confirm kernel is functional

<img width="1105" height="616" alt="image" src="https://github.com/user-attachments/assets/a5918525-4dac-4076-a311-5ce870ee5394" />


Closes #515

_PR submitted by @rgbkrk's agent, Quill_