### PR TITLE
feat(notebook): make addCell and deleteCell optimistic

### DIFF
--- a/apps/notebook/src/hooks/useNotebook.ts
+++ b/apps/notebook/src/hooks/useNotebook.ts
@@ -449,39 +449,50 @@ export function useNotebook() {
   }, []);
 
   const addCell = useCallback(
-    async (cellType: "code" | "markdown", afterCellId?: string | null) => {
-      try {
-        const newCell = await invoke<NotebookCell>("add_cell", {
-          cellType,
-          afterCellId: afterCellId ?? null,
-        });
-        setCells((prev) => {
-          if (!afterCellId) return [newCell, ...prev];
-          const idx = prev.findIndex((c) => c.id === afterCellId);
-          if (idx === -1) return [newCell, ...prev];
-          const next = [...prev];
-          next.splice(idx + 1, 0, newCell);
-          return next;
-        });
-        setFocusedCellId(newCell.id);
-        setDirty(true);
-        return newCell;
-      } catch (e) {
-        logger.error("[notebook] Add cell failed:", e);
-        return null;
-      }
+    (cellType: "code" | "markdown", afterCellId?: string | null) => {
+      const cellId = crypto.randomUUID();
+      const newCell: NotebookCell =
+        cellType === "code"
+          ? {
+              cell_type: "code",
+              id: cellId,
+              source: "",
+              outputs: [],
+              execution_count: null,
+            }
+          : { cell_type: "markdown", id: cellId, source: "" };
+      setCells((prev) => {
+        if (!afterCellId) return [newCell, ...prev];
+        const idx = prev.findIndex((c) => c.id === afterCellId);
+        if (idx === -1) return [newCell, ...prev];
+        const next = [...prev];
+        next.splice(idx + 1, 0, newCell);
+        return next;
+      });
+      setFocusedCellId(cellId);
+      setDirty(true);
+      // Fire-and-forget — backend uses the frontend-generated cellId
+      invoke("add_cell", {
+        cellId,
+        cellType,
+        afterCellId: afterCellId ?? null,
+      }).catch((e) => logger.error("[notebook] add_cell sync failed:", e));
+      return newCell;
     },
     [],
   );
 
-  const deleteCell = useCallback(async (cellId: string) => {
-    try {
-      await invoke("delete_cell", { cellId });
-      setCells((prev) => prev.filter((c) => c.id !== cellId));
-      setDirty(true);
-    } catch (e) {
-      logger.error("[notebook] Delete cell failed:", e);
-    }
+  const deleteCell = useCallback((cellId: string) => {
+    // Optimistic update — guard against deleting the last cell locally
+    setCells((prev) => {
+      if (prev.length <= 1) return prev;
+      return prev.filter((c) => c.id !== cellId);
+    });
+    setDirty(true);
+    // Fire-and-forget sync to backend
+    invoke("delete_cell", { cellId }).catch((e) =>
+      logger.error("[notebook] delete_cell sync failed:", e),
+    );
   }, []);
 
   const save = useCallback(async () => {

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -1541,6 +1541,7 @@ async fn update_cell_source(
 
 #[tauri::command]
 async fn add_cell(
+    cell_id: Option<String>,
     cell_type: String,
     after_cell_id: Option<String>,
     window: tauri::Window,
@@ -1559,7 +1560,7 @@ async fn add_cell(
         };
 
         let cell = s
-            .add_cell(&cell_type, after_cell_id.as_deref())
+            .add_cell(&cell_type, after_cell_id.as_deref(), cell_id.as_deref())
             .ok_or_else(|| format!("Invalid cell type: {}", cell_type))?;
 
         (cell, insert_index)
@@ -1595,11 +1596,16 @@ async fn delete_cell(
 ) -> Result<(), String> {
     let state = notebook_state_for_window(&window, registry.inner())?;
     let notebook_sync = notebook_sync_for_window(&window, registry.inner())?;
-    // Delete from local state first
+    // Delete from local state — frontend owns the "last cell" guard,
+    // so a false return here is a no-op rather than an error.
     {
         let mut s = state.lock().map_err(|e| e.to_string())?;
         if !s.delete_cell(&cell_id) {
-            return Err("Cannot delete cell (last cell or not found)".to_string());
+            info!(
+                "[notebook] delete_cell skipped for {}: last cell or not found",
+                cell_id
+            );
+            return Ok(());
         }
     }
 

--- a/crates/notebook/src/notebook_state.rs
+++ b/crates/notebook/src/notebook_state.rs
@@ -542,8 +542,12 @@ impl NotebookState {
         &mut self,
         cell_type: &str,
         after_cell_id: Option<&str>,
+        cell_id: Option<&str>,
     ) -> Option<FrontendCell> {
-        let new_id = CellId::from(Uuid::new_v4());
+        let new_id = match cell_id {
+            Some(id) => CellId::from(Uuid::parse_str(id).unwrap_or_else(|_| Uuid::new_v4())),
+            None => CellId::from(Uuid::new_v4()),
+        };
         let cell = match cell_type {
             "code" => Cell::Code {
                 id: new_id,
@@ -982,7 +986,7 @@ mod tests {
     fn test_add_cell_code() {
         let mut state = NotebookState::new_empty();
 
-        let result = state.add_cell("code", None);
+        let result = state.add_cell("code", None, None);
 
         assert!(result.is_some());
         assert!(matches!(result.unwrap(), FrontendCell::Code { .. }));
@@ -993,7 +997,7 @@ mod tests {
     fn test_add_cell_markdown() {
         let mut state = NotebookState::new_empty();
 
-        let result = state.add_cell("markdown", None);
+        let result = state.add_cell("markdown", None, None);
 
         assert!(result.is_some());
         assert!(matches!(result.unwrap(), FrontendCell::Markdown { .. }));
@@ -1003,7 +1007,7 @@ mod tests {
     fn test_add_cell_raw() {
         let mut state = NotebookState::new_empty();
 
-        let result = state.add_cell("raw", None);
+        let result = state.add_cell("raw", None, None);
 
         assert!(result.is_some());
         assert!(matches!(result.unwrap(), FrontendCell::Raw { .. }));
@@ -1013,7 +1017,7 @@ mod tests {
     fn test_add_cell_invalid_type_returns_none() {
         let mut state = NotebookState::new_empty();
 
-        let result = state.add_cell("invalid", None);
+        let result = state.add_cell("invalid", None, None);
 
         assert!(result.is_none());
         assert_eq!(state.notebook.cells.len(), 1);
@@ -1024,7 +1028,7 @@ mod tests {
         let mut state = NotebookState::new_empty();
         let first_cell_id = state.notebook.cells[0].id().to_string();
 
-        state.add_cell("code", Some(&first_cell_id));
+        state.add_cell("code", Some(&first_cell_id), None);
 
         assert_eq!(state.notebook.cells.len(), 2);
         // New cell should be at index 1 (after first cell)
@@ -1032,11 +1036,34 @@ mod tests {
     }
 
     #[test]
+    fn test_add_cell_with_provided_id() {
+        let mut state = NotebookState::new_empty();
+        let provided_id = "a1b2c3d4-e5f6-7890-abcd-ef1234567890";
+
+        let result = state.add_cell("code", None, Some(provided_id)).unwrap();
+
+        assert_eq!(result.id(), provided_id);
+        assert_eq!(state.notebook.cells[0].id().to_string(), provided_id);
+    }
+
+    #[test]
+    fn test_add_cell_with_provided_id_ignores_invalid_uuid() {
+        let mut state = NotebookState::new_empty();
+
+        // Invalid UUID should fall back to generating a new one
+        let result = state.add_cell("code", None, Some("not-a-uuid")).unwrap();
+
+        // Should still succeed — just with a generated UUID, not "not-a-uuid"
+        assert_ne!(result.id(), "not-a-uuid");
+        assert_eq!(state.notebook.cells.len(), 2);
+    }
+
+    #[test]
     fn test_add_cell_at_beginning_when_no_after() {
         let mut state = NotebookState::new_empty();
         let first_cell_id = state.notebook.cells[0].id().to_string();
 
-        let new_cell = state.add_cell("code", None).unwrap();
+        let new_cell = state.add_cell("code", None, None).unwrap();
 
         // New cell should be at index 0
         assert_eq!(state.notebook.cells[0].id().to_string(), new_cell.id());
@@ -1049,14 +1076,14 @@ mod tests {
         let mut state = NotebookState::new_empty();
 
         assert!(!state.dirty);
-        state.add_cell("code", None);
+        state.add_cell("code", None, None);
         assert!(state.dirty);
     }
 
     #[test]
     fn test_delete_cell_removes_cell() {
         let mut state = NotebookState::new_empty();
-        state.add_cell("code", None);
+        state.add_cell("code", None, None);
         let cell_to_delete = state.notebook.cells[0].id().to_string();
 
         let result = state.delete_cell(&cell_to_delete);
@@ -1079,7 +1106,7 @@ mod tests {
     #[test]
     fn test_delete_cell_returns_false_for_missing() {
         let mut state = NotebookState::new_empty();
-        state.add_cell("code", None);
+        state.add_cell("code", None, None);
 
         let result = state.delete_cell("nonexistent");
 
@@ -1090,7 +1117,7 @@ mod tests {
     #[test]
     fn test_delete_cell_sets_dirty_flag() {
         let mut state = NotebookState::new_empty();
-        state.add_cell("code", None);
+        state.add_cell("code", None, None);
         state.dirty = false;
         let cell_to_delete = state.notebook.cells[0].id().to_string();
 
@@ -1232,9 +1259,9 @@ mod tests {
         let first_code_id = state.notebook.cells[0].id().to_string();
 
         // Add markdown, then another code cell
-        state.add_cell("markdown", Some(&first_code_id));
+        state.add_cell("markdown", Some(&first_code_id), None);
         let md_id = state.notebook.cells[1].id().to_string();
-        state.add_cell("code", Some(&md_id));
+        state.add_cell("code", Some(&md_id), None);
         let second_code_id = state.notebook.cells[2].id().to_string();
 
         let code_ids = state.get_code_cell_ids();
@@ -1248,7 +1275,7 @@ mod tests {
         let mut state = NotebookState::new_empty();
         let first_id = state.notebook.cells[0].id().to_string();
         // Replace the only code cell with a markdown cell
-        state.add_cell("markdown", Some(&first_id));
+        state.add_cell("markdown", Some(&first_id), None);
         // Can't delete the last cell, so this test just checks with mixed cells
         let ids = state.get_code_cell_ids();
         assert_eq!(ids.len(), 1); // The original code cell


### PR DESCRIPTION
Phase 0 of the local-first Automerge migration: eliminate user-visible latency for cell mutations.

`addCell` and `deleteCell` now update React state immediately and fire-and-forget the backend sync. The existing `notebook:updated` Automerge broadcast acts as the convergence backstop.

### Changes

**`addCell`** — UUID generated on frontend via `crypto.randomUUID()`, cell constructed locally, `invoke` is fire-and-forget. Backend `add_cell` command accepts an optional `cell_id` parameter.

**`deleteCell`** — last-cell guard moved to frontend, `invoke` is fire-and-forget. Backend `delete_cell` returns `Ok(())` instead of `Err` when the cell can't be deleted.

### Testing

- Rapid add/delete feels instant
- Last-cell guard prevents deleting the only cell
- Frontend-generated UUIDs flow through to Automerge doc
- Second window sees cells appear/disappear via sync
- No console or daemon errors under normal operation