### PR TITLE
chore(zed): derive unique vite port from worktree root hash

### DIFF
--- a/.zed/tasks.json
+++ b/.zed/tasks.json
@@ -6,12 +6,12 @@
       "RUNTIMED_DEV": "1",
       "RUNTIMED_WORKSPACE_PATH": "$ZED_WORKTREE_ROOT",
       "RUNTIMED_WORKSPACE_NAME": "desktop",
-      "RUNTIMED_VITE_PORT": "5174"
+      "RUNTIMED_VITE_PORT": "5174",
     },
     "use_new_terminal": true,
     "allow_concurrent_runs": false,
     "reveal": "always",
-    "reveal_target": "dock"
+    "reveal_target": "dock",
   },
   {
     "label": "Dev App",
@@ -20,12 +20,12 @@
       "RUNTIMED_DEV": "1",
       "RUNTIMED_WORKSPACE_PATH": "$ZED_WORKTREE_ROOT",
       "RUNTIMED_WORKSPACE_NAME": "desktop",
-      "RUNTIMED_VITE_PORT": "5174"
+      "RUNTIMED_VITE_PORT": "5174",
     },
     "use_new_terminal": true,
     "allow_concurrent_runs": false,
     "reveal": "always",
-    "reveal_target": "dock"
+    "reveal_target": "dock",
   },
   {
     "label": "Setup",
@@ -33,37 +33,37 @@
     "use_new_terminal": false,
     "allow_concurrent_runs": false,
     "reveal": "always",
-    "hide": "on_success"
+    "hide": "on_success",
   },
   {
     "label": "Daemon Status",
     "command": "./target/debug/runt daemon status",
     "env": {
       "RUNTIMED_DEV": "1",
-      "RUNTIMED_WORKSPACE_PATH": "$ZED_WORKTREE_ROOT"
+      "RUNTIMED_WORKSPACE_PATH": "$ZED_WORKTREE_ROOT",
     },
     "use_new_terminal": false,
     "allow_concurrent_runs": false,
-    "reveal": "always"
+    "reveal": "always",
   },
   {
     "label": "Daemon Logs",
     "command": "./target/debug/runt daemon logs -f",
     "env": {
       "RUNTIMED_DEV": "1",
-      "RUNTIMED_WORKSPACE_PATH": "$ZED_WORKTREE_ROOT"
+      "RUNTIMED_WORKSPACE_PATH": "$ZED_WORKTREE_ROOT",
     },
     "use_new_terminal": true,
     "allow_concurrent_runs": false,
     "reveal": "always",
-    "reveal_target": "dock"
+    "reveal_target": "dock",
   },
   {
     "label": "Test (notebook crate)",
     "command": "cargo test -p notebook",
     "use_new_terminal": false,
     "allow_concurrent_runs": false,
-    "reveal": "always"
+    "reveal": "always",
   },
   {
     "label": "Format",
@@ -71,6 +71,38 @@
     "use_new_terminal": false,
     "allow_concurrent_runs": false,
     "reveal": "always",
-    "hide": "on_success"
-  }
+    "hide": "on_success",
+  },
+  {
+    "label": "E2E Build",
+    "command": "./e2e/dev.sh build",
+    "env": {
+      "RUNTIMED_WORKSPACE_PATH": "$ZED_WORKTREE_ROOT",
+    },
+    "use_new_terminal": false,
+    "allow_concurrent_runs": false,
+    "reveal": "always",
+  },
+  {
+    "label": "E2E Fixture Tests",
+    "command": "./e2e/dev.sh test-fixtures",
+    "env": {
+      "RUNTIMED_WORKSPACE_PATH": "$ZED_WORKTREE_ROOT",
+    },
+    "use_new_terminal": true,
+    "allow_concurrent_runs": false,
+    "reveal": "always",
+    "reveal_target": "dock",
+  },
+  {
+    "label": "E2E All Tests",
+    "command": "./e2e/dev.sh cycle",
+    "env": {
+      "RUNTIMED_WORKSPACE_PATH": "$ZED_WORKTREE_ROOT",
+    },
+    "use_new_terminal": true,
+    "allow_concurrent_runs": false,
+    "reveal": "always",
+    "reveal_target": "dock",
+  },
 ]

--- a/.zed/tasks.json
+++ b/.zed/tasks.json
@@ -6,7 +6,6 @@
       "RUNTIMED_DEV": "1",
       "RUNTIMED_WORKSPACE_PATH": "$ZED_WORKTREE_ROOT",
       "RUNTIMED_WORKSPACE_NAME": "desktop",
-      "RUNTIMED_VITE_PORT": "5174",
     },
     "use_new_terminal": true,
     "allow_concurrent_runs": false,
@@ -15,12 +14,11 @@
   },
   {
     "label": "Dev App",
-    "command": "cargo xtask dev",
+    "command": "export RUNTIMED_VITE_PORT=$((5100 + $(echo -n \"$ZED_WORKTREE_ROOT\" | cksum | cut -d' ' -f1) % 4900)); echo \"Vite port: $RUNTIMED_VITE_PORT\"; cargo xtask dev",
     "env": {
       "RUNTIMED_DEV": "1",
       "RUNTIMED_WORKSPACE_PATH": "$ZED_WORKTREE_ROOT",
       "RUNTIMED_WORKSPACE_NAME": "desktop",
-      "RUNTIMED_VITE_PORT": "5174",
     },
     "use_new_terminal": true,
     "allow_concurrent_runs": false,


### PR DESCRIPTION
Derive `RUNTIMED_VITE_PORT` from a hash of `ZED_WORKTREE_ROOT` so each worktree gets a unique port (range 5100–9999). Drop `RUNTIMED_VITE_PORT` from the Dev Daemon task since `dev-daemon` doesn't use it.