### PR TITLE
fix(ui): prevent horizontal scroll drift and make UI chrome non-selectable

### DIFF
--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -352,7 +352,7 @@ export function NotebookToolbar({
     <Collapsible open={settingsOpen} onOpenChange={setSettingsOpen}>
       <header
         data-testid="notebook-toolbar"
-        className="sticky top-0 z-10 border-b bg-background/95 backdrop-blur supports-backdrop-filter:bg-background/60"
+        className="sticky top-0 z-10 border-b bg-background/95 backdrop-blur supports-backdrop-filter:bg-background/60 select-none"
       >
         <div className="flex h-10 items-center gap-2 px-3">
           {/* Save */}

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -40,7 +40,7 @@ function AddCellButtons({
   onAdd: (type: "code" | "markdown", afterCellId?: string | null) => void;
 }) {
   return (
-    <div className="group/betweener flex h-4 w-full items-center">
+    <div className="group/betweener flex h-4 w-full items-center select-none">
       {/* Gutter spacer - matches cell gutter: action area + ribbon */}
       <div className="flex h-full flex-shrink-0">
         <div className="w-10" />
@@ -51,11 +51,11 @@ function AddCellButtons({
         {/* Thin line appears on hover */}
         <div className="absolute inset-x-0 h-px bg-transparent group-hover/betweener:bg-border transition-colors" />
         {/* Buttons appear on hover */}
-        <div className="flex items-center gap-1 opacity-0 group-hover/betweener:opacity-100 transition-opacity z-10 bg-background px-2">
+        <div className="flex items-center gap-1 opacity-0 group-hover/betweener:opacity-100 transition-opacity z-10 bg-background px-2 select-none">
           <Button
             variant="ghost"
             size="sm"
-            className="h-5 gap-1 px-2 text-xs text-muted-foreground hover:text-foreground"
+            className="h-5 gap-1 px-2 text-xs text-muted-foreground hover:text-foreground select-none"
             onClick={() => onAdd("code", afterCellId)}
           >
             <Plus className="h-3 w-3" />
@@ -64,7 +64,7 @@ function AddCellButtons({
           <Button
             variant="ghost"
             size="sm"
-            className="h-5 gap-1 px-2 text-xs text-muted-foreground hover:text-foreground"
+            className="h-5 gap-1 px-2 text-xs text-muted-foreground hover:text-foreground select-none"
             onClick={() => onAdd("markdown", afterCellId)}
           >
             <Plus className="h-3 w-3" />
@@ -146,6 +146,22 @@ function NotebookViewContent({
 
   // Memoize cell IDs array
   const cellIds = useMemo(() => cells.map((c) => c.id), [cells]);
+
+  // Prevent horizontal scroll drift (can happen during text selection)
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const preventHorizontalScroll = () => {
+      if (container.scrollLeft !== 0) {
+        container.scrollLeft = 0;
+      }
+    };
+
+    container.addEventListener("scroll", preventHorizontalScroll);
+    return () =>
+      container.removeEventListener("scroll", preventHorizontalScroll);
+  }, []);
 
   // Scroll the current search match cell into view
   useEffect(() => {
@@ -273,7 +289,8 @@ function NotebookViewContent({
   return (
     <div
       ref={containerRef}
-      className="flex-1 overflow-y-auto overflow-x-hidden py-4 pl-8 pr-4"
+      className="flex-1 overflow-y-auto overflow-x-clip overscroll-x-contain py-4 pl-8 pr-4"
+      style={{ contain: "paint" }}
     >
       {cells.length === 0 ? (
         <div className="flex flex-col items-center justify-center py-20 text-muted-foreground">

--- a/src/components/cell/CellContainer.tsx
+++ b/src/components/cell/CellContainer.tsx
@@ -80,7 +80,7 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
         onDrop={onDrop}
       >
         {/* Gutter area - action content only (ribbon moves to content rows for segmented) */}
-        <div className="flex w-10 flex-shrink-0 flex-col items-end justify-start gap-0.5 pr-1 pt-3">
+        <div className="flex w-10 flex-shrink-0 flex-col items-end justify-start gap-0.5 pr-1 pt-3 select-none">
           {gutterContent}
         </div>
         {/* Cell content with ribbon */}
@@ -132,7 +132,7 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
         {rightGutterContent && (
           <div
             className={cn(
-              "flex w-10 flex-shrink-0 flex-col items-center gap-1 pt-3",
+              "flex w-10 flex-shrink-0 flex-col items-center gap-1 pt-3 select-none",
               "opacity-100 transition-opacity duration-150",
               "sm:opacity-0 sm:group-hover:opacity-100 sm:focus-within:opacity-100",
               isFocused && "sm:opacity-100",


### PR DESCRIPTION
## Summary
Fixes two related UI issues:
1. **Horizontal scroll drift** - The notebook window could scroll horizontally during text selection, cutting off execution count indicators. Now uses a scroll event handler to force scrollLeft back to 0 and CSS containment to isolate the scroll context.
2. **Non-selectable UI chrome** - Made toolbar, add-cell buttons, and cell gutters non-selectable while keeping user content (code, outputs) and informational banners selectable for copying error messages.

## Test Plan
- [x] Drag to select text across multiple cells - verify no horizontal scroll occurs and execution counts stay visible
- [x] Try to select toolbar buttons - should not be selectable
- [x] Try to select add-cell buttons between cells - should not be selectable
- [x] Try to select execution count indicators - should not be selectable
- [x] Verify code in cells remains selectable
- [x] Verify error messages in banners can still be selected and copied

_PR submitted by @rgbkrk's agent, Quill_