### PR TITLE
docs: post-migration audit for local-first Automerge architecture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ crates/notebook/icons/android/
 crates/notebook/icons/ios/
 crates/notebook/icons/icon.icns
 apps/notebook/package-lock.json
+deno.lock

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,6 +198,22 @@ To check which daemon version is running:
 runt daemon status
 ```
 
+## Notebook Document Architecture (Local-First)
+
+The notebook uses a local-first CRDT architecture. The frontend owns its own Automerge document via WASM, making cell mutations instant. Three Automerge peers participate:
+
+- **Frontend (WASM)** — `NotebookHandle` from `crates/runtimed-wasm`, loaded in the webview. Cell mutations (add, delete, edit source) execute locally in WASM. React state is derived from the WASM doc via `handle.get_cells_json()`.
+- **Tauri relay** — `NotebookSyncClient` in `crates/runtimed/src/notebook_sync_client.rs`. Forwards binary Automerge sync messages between frontend and daemon. Maintains its own doc replica (transitional — will be simplified to pure relay).
+- **Daemon** — `NotebookDoc` in `crates/runtimed/src/notebook_doc.rs`. Canonical doc for kernel execution, output writing, and persistence.
+
+Mutation flow: React → WASM `handle.add_cell()` → `handle.generate_sync_message()` → `invoke("send_automerge_sync")` → Tauri relay → daemon.
+
+Incoming sync: daemon → relay → `automerge:from-daemon` event → WASM `handle.receive_sync_message()` → `materializeCells()` → React state.
+
+The `runtimed-wasm` crate compiles from the same `automerge = "0.7"` as the daemon. This is critical — the JS `@automerge/automerge` package creates `Object(Text)` CRDTs for all string fields, but Rust uses scalar `Str` for metadata fields (`id`, `cell_type`, `execution_count`). Using the same Rust code in WASM guarantees schema compatibility.
+
+**Important:** Like the daemon binary, `runtimed-wasm` is a separate build artifact. Changes to `crates/runtimed-wasm/` require rebuilding with `wasm-pack build crates/runtimed-wasm --target web --out-dir ../../apps/notebook/src/wasm/runtimed-wasm` and committing the output. The WASM artifacts are committed to the repo so developers don't need wasm-pack installed for normal development.
+
 ## Environment Management
 
 Runt supports multiple environment backends (UV, Conda) and project file formats (pyproject.toml, environment.yml, pixi.toml). See `contributing/environments.md` for the full architecture and `docs/environments.md` for the user-facing guide.
@@ -277,7 +293,7 @@ Dependencies are signed with HMAC-SHA256 using a per-machine key at `~/.config/r
 | `crates/runtimed/src/notebook_sync_server.rs` | `auto_launch_kernel()` — runtime detection and environment resolution |
 | `crates/runtimed/src/kernel_manager.rs` | `RoomKernel::launch()` — spawns Python or Deno kernel processes |
 | `crates/runtimed/src/inline_env.rs` | Cached environment creation for inline deps (UV and Conda) |
-| `crates/notebook/src/lib.rs` | Tauri commands, kernel launch orchestration |
+| `crates/notebook/src/lib.rs` | Tauri commands (save, format, kernel, env), Automerge sync relay. Cell mutation commands removed — mutations go through WASM. |
 | `crates/notebook/src/project_file.rs` | Unified closest-wins project file detection |
 | `crates/notebook/src/uv_env.rs` | UV environment creation and caching |
 | `crates/notebook/src/conda_env.rs` | Conda environment creation via rattler |
@@ -286,6 +302,10 @@ Dependencies are signed with HMAC-SHA256 using a per-machine key at `~/.config/r
 | `crates/notebook/src/environment_yml.rs` | environment.yml discovery and parsing |
 | `crates/notebook/src/deno_env.rs` | Deno config detection and version checking |
 | `crates/notebook/src/trust.rs` | HMAC trust verification |
+| `crates/runtimed-wasm/src/lib.rs` | WASM bindings for NotebookDoc — cell mutations, sync messages |
+| `crates/runtimed-wasm/src/notebook_doc.rs` | Automerge document operations (copy of daemon's NotebookDoc, trimmed for WASM) |
+| `apps/notebook/src/hooks/useAutomergeNotebook.ts` | Local-first notebook hook — owns NotebookHandle WASM, drives React cell state |
 | `apps/notebook/src/hooks/useDaemonKernel.ts` | Daemon-owned kernel execution, status broadcasts, environment sync |
 | `apps/notebook/src/hooks/useDependencies.ts` | Frontend UV dependency management |
 | `apps/notebook/src/hooks/useCondaDependencies.ts` | Frontend conda dependency management |
+| `apps/notebook/src/lib/materialize-cells.ts` | Converts CellSnapshot[] from WASM/sync to NotebookCell[] for React (resolves blob manifests) |

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ nteract/desktop
 │   ├── runt/              # CLI binary
 │   ├── runtimed/          # Background daemon
 │   ├── runtimed-py/       # Python bindings for the daemon
+│   ├── runtimed-wasm/     # WASM Automerge bindings for frontend (same automerge crate as daemon)
 │   ├── notebook/          # Notebook Tauri app
 │   ├── sidecar/           # Sidecar wry/tao app
 │   ├── tauri-jupyter/     # Shared Tauri/Jupyter utilities

--- a/apps/notebook/src/hooks/useDaemonKernel.ts
+++ b/apps/notebook/src/hooks/useDaemonKernel.ts
@@ -399,7 +399,7 @@ export function useDaemonKernel({
 
           case "file_changed": {
             // External file changes detected and merged into Automerge doc.
-            // The actual cell data comes through notebook:updated (Automerge sync).
+            // The actual cell data comes through `automerge:from-daemon` (Automerge sync relay).
             // This broadcast is for notification purposes.
             const fileBroadcast = broadcast as {
               cells: unknown[];

--- a/contributing/architecture.md
+++ b/contributing/architecture.md
@@ -108,13 +108,13 @@ We are working toward full conformance with these principles.
 | Principle | Status |
 |-----------|--------|
 | Daemon as source of truth | Conformant |
-| Automerge as canonical state | Mostly Conformant |
+| Automerge as canonical state | Conformant |
 | On-disk as checkpoint | Conformant |
-| Local-first editing, synced execution | Mostly Conformant |
+| Local-first editing, synced execution | Conformant |
 | Binary separation | Conformant |
 | Daemon manages resources | Conformant |
 
-`ExecuteCell` is implemented and reads from the synced document. The deprecated `QueueCell` (which accepts code as a parameter) is retained only for `runtimed-py` backwards compatibility.
+The frontend now owns a local Automerge doc via `runtimed-wasm` WASM bindings, making it fully conformant with the canonical-state principle. Cell mutations (edits, reorders, deletes) are applied instantly in WASM with no RPC round-trip, satisfying local-first editing. `ExecuteCell` reads from the synced document. The deprecated `QueueCell` (which accepts code as a parameter) is retained only for `runtimed-py` backwards compatibility.
 
 ## References
 

--- a/contributing/build-dependencies.md
+++ b/contributing/build-dependencies.md
@@ -26,6 +26,7 @@ graph TD
         RC["runt-cli (bin: runt)<br/><i>CLI</i>"]
         NB["notebook (Tauri app)<br/><i>main app</i>"]
         XT["xtask<br/><i>build orchestrator</i>"]
+        RWASM["runtimed-wasm<br/><i>WASM notebook doc ops</i>"]
     end
 
     subgraph "Bundled Artifacts"
@@ -36,6 +37,7 @@ graph TD
     %% Frontend → Rust compile-time dependencies
     SUI -->|"build.rs panics<br/>if dist/ missing"| SC
     NUI -->|"tauri beforeBuildCommand"| NB
+    RWASM -->|"wasm-pack output in<br/>apps/notebook/src/wasm/"| NUI
 
     %% Rust crate dependencies (path deps in Cargo.toml)
     TJ -->|"path dep"| SC
@@ -63,7 +65,7 @@ graph TD
     classDef artifact fill:#e8f5e9,stroke:#2e7d32
 
     class SUI,NUI frontend
-    class TJ,RD,SC,RC,NB,XT rust
+    class TJ,RD,SC,RC,NB,XT,RWASM rust
     class APP,PY artifact
 ```
 
@@ -75,14 +77,15 @@ here is what happens under the hood:
 ```mermaid
 graph LR
     A["1. pnpm install"] --> B["2. pnpm --dir apps/sidecar build"]
-    A --> C["3. pnpm --dir apps/notebook build<br/>(includes isolated-renderer)"]
-    B --> D["4. cargo build --release<br/>-p runtimed -p runt-cli"]
+    A --> W["3. wasm-pack build<br/>crates/runtimed-wasm"]
+    W --> C["4. pnpm --dir apps/notebook build<br/>(includes isolated-renderer)"]
+    B --> D["5. cargo build --release<br/>-p runtimed -p runt-cli"]
     C --> D
-    D --> E["5. Copy binaries to<br/>crates/notebook/binaries/"]
-    E --> F["6. cargo tauri build"]
+    D --> E["6. Copy binaries to<br/>crates/notebook/binaries/"]
+    E --> F["7. cargo tauri build"]
 
     classDef step fill:#f3e5f5,stroke:#7b1fa2
-    class A,B,C,D,E,F step
+    class A,B,W,C,D,E,F step
 ```
 
 ## Rust Crate Dependency Graph
@@ -102,6 +105,7 @@ graph BT
     RT["runt-trust"]
     RW["runt-workspace"]
     RDPY["runtimed-py"]
+    RWASM["runtimed-wasm"]
 
     SC -->|"depends on"| TJ
     NB -->|"depends on"| TJ
@@ -119,7 +123,7 @@ graph BT
     classDef leaf fill:#c8e6c9,stroke:#388e3c
     classDef shared fill:#e3f2fd,stroke:#1976d2
 
-    class TJ,KL,KE,RT,RW standalone
+    class TJ,KL,KE,RT,RW,RWASM standalone
     class XT standalone
     class NB,RC,RDPY leaf
     class RD shared
@@ -134,4 +138,5 @@ graph BT
 | `runtimed` + `runt` binaries must exist in `crates/notebook/binaries/` | `tauri.conf.json` lists them in `bundle.externalBin` — Tauri bundles them into the .app/.dmg/.exe |
 | `isolated-renderer` built inline | The notebook-ui Vite plugin builds the isolated renderer and embeds it as a virtual module — no separate build step needed |
 | `xtask` has no Cargo deps | It shells out to `cargo build`, `pnpm`, and `cargo tauri` to orchestrate the full build |
+| `runtimed-wasm` must build before `notebook-ui` | wasm-pack output lands in `apps/notebook/src/wasm/runtimed-wasm/`; Vite imports it at build time. Artifacts are committed to the repo, so this step is only needed when changing `crates/runtimed-wasm/`. |
 | Python wheel uses maturin | `python/runtimed/pyproject.toml` points `maturin` at `crates/runt/Cargo.toml` with `bindings = "bin"` |

--- a/contributing/development.md
+++ b/contributing/development.md
@@ -96,6 +96,10 @@ pnpm build          # Build all UIs (sidecar, notebook — isolated-renderer bui
 cargo build         # Build Rust
 ```
 
+> **Note:** If you've changed `crates/runtimed-wasm/`, you need to run
+> `wasm-pack build crates/runtimed-wasm --target web --out-dir ../../apps/notebook/src/wasm/runtimed-wasm`
+> before `pnpm build`. `cargo xtask build` handles this automatically.
+
 ## Test Notebooks
 
 The `notebooks/` directory has test files:

--- a/contributing/runtimed.md
+++ b/contributing/runtimed.md
@@ -129,6 +129,8 @@ crates/runtimed/
 │   ├── sync_server.rs           # Settings sync handler
 │   ├── sync_client.rs           # Settings sync client library
 │   ├── notebook_doc.rs          # Notebook Automerge document, cell CRUD, text editing
+│   │                            # ⚠ Shared: copied to crates/runtimed-wasm/src/notebook_doc.rs
+│   │                            #   (WASM subset, daemon-only methods removed). Keep in sync.
 │   ├── notebook_sync_server.rs  # Room-based notebook sync, peer management, eviction
 │   ├── notebook_sync_client.rs  # Notebook sync client library
 │   ├── blob_store.rs            # Content-addressed blob store with metadata sidecars

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -65,10 +65,9 @@ localStorage.removeItem('runt:debug');
 ### Log Prefixes
 
 Logs are prefixed by component:
-- `[daemon-kernel]` - Kernel communication
-- `[notebook-sync]` - Document sync
-- `[manifest-resolver]` - Output blob resolution
-- `[App]` - Main app lifecycle
+- `[daemon-kernel]` - Kernel communication (`useDaemonKernel.ts`)
+- `[automerge-notebook]` - Document sync and WASM lifecycle (`useAutomergeNotebook.ts`)
+- `[manifest-resolver]` - Output blob resolution (`useManifestResolver.ts`)
 
 ## Troubleshooting
 

--- a/docs/python-bindings.md
+++ b/docs/python-bindings.md
@@ -119,6 +119,22 @@ cells = session.get_cells()
 session.delete_cell(cell_id)
 ```
 
+### Saving Notebooks
+
+Save the notebook document to disk. The daemon handles serialization.
+
+```python
+# Save to the current notebook path (daemon resolves it)
+path = session.save()
+print(path)  # "/Users/you/notebooks/analysis.ipynb"
+
+# Save-as to a specific path
+path = session.save(path="/tmp/copy.ipynb")
+print(path)  # "/tmp/copy.ipynb"
+```
+
+Returns the absolute path where the file was written.
+
 ### Streaming Execution
 
 Process outputs incrementally as they arrive from the kernel:
@@ -240,6 +256,16 @@ cells = await session.get_cells()
 
 # Delete a cell
 await session.delete_cell(cell_id)
+```
+
+### Saving Notebooks
+
+```python
+# Save to the current notebook path
+path = await session.save()
+
+# Save-as to a specific path
+path = await session.save(path="/tmp/copy.ipynb")
 ```
 
 ### Streaming Execution

--- a/docs/runtimed.md
+++ b/docs/runtimed.md
@@ -42,7 +42,7 @@ The architecture has two core ideas:
 │  │ - HTTP read server on localhost         │    │
 │  └─────────────────────────────────────────┘    │
 │  ┌─────────────────────────────────────────┐    │
-│  │ Kernel manager (future)                 │    │
+│  │ Kernel manager                          │    │
 │  │ - Owns kernel processes                 │    │
 │  │ - Subscribes to iopub                   │    │
 │  │ - Writes outputs to store               │    │
@@ -404,101 +404,82 @@ pub enum BlobResponse {
 
 ---
 
-## Phase 5: Tauri <-> daemon notebook sync
+## Phase 5: Local-first Automerge notebook sync
 
-> **Implemented** (PR #238 for cell/source sync, PR #241 for output/execution_count sync)
+> **Implemented** — Frontend owns a local Automerge doc via WASM. Cell state syncs bidirectionally with the daemon over binary Automerge messages.
 
-Wire the Tauri app and React frontend to use the daemon's automerge doc as the source of truth for notebook state. This gives us multi-window sync immediately. Outputs still flow as inline JSON strings through the CRDT for now — Phase 6 makes them efficient.
+The frontend runs `runtimed-wasm` (compiled from `crates/runtimed-wasm/`) as a WASM module, giving it a local Automerge `NotebookHandle`. All cell mutations (source edits, add/delete, reorder) happen locally in WASM and propagate to the daemon via binary sync messages relayed through Tauri. The daemon's copy is authoritative for outputs and execution state.
 
-**Known limitations** (tracked in issues):
-- Output clearing on re-execution uses frontend-driven approach; atomic clearing would be cleaner (#244)
-- Stream outputs sync individually without merging consecutive outputs (#243)
-- Widget-captured outputs are correctly excluded from sync (handled in App.tsx after widget routing)
-
-### Current state (what changes)
-
-Today the Tauri process holds notebook state in-memory:
-
-```rust
-pub struct NotebookState {
-    pub notebook: Notebook,      // nbformat v4 — cells, outputs, metadata
-    pub path: Option<PathBuf>,
-    pub dirty: bool,
-}
-```
-
-Cell mutations (`update_cell_source`, `add_cell`, `delete_cell`) modify this struct directly. Outputs flow as events from the kernel iopub listener through Tauri events to React state — they never touch `NotebookState` during execution. On save, the frontend's current state is serialized to `.ipynb`.
+### Architecture
 
 ```
-kernel -> iopub -> Tauri event "kernel:iopub" -> React state -> render
-                                                     | (on save)
-                                                 .ipynb file
+┌─────────────────────────────────────────────────────────┐
+│ Frontend (React)                                        │
+│                                                         │
+│  useAutomergeNotebook.ts                                │
+│    ├── NotebookHandle (runtimed-wasm, local Automerge)  │
+│    ├── materialize-cells.ts (doc → React cell state)    │
+│    └── Tauri event listeners                            │
+│                                                         │
+│  Cell edits ──► WASM mutates local doc                  │
+│                   │                                     │
+│                   ▼                                     │
+│              Binary sync message                        │
+│                   │                                     │
+│                   ▼                                     │
+│  Tauri relay (automerge:to-daemon / automerge:from-daemon) │
+│                   │                                     │
+│                   ▼                                     │
+│  Daemon (NotebookRoom)                                  │
+│    ├── Merges changes into canonical doc                │
+│    ├── Writes kernel outputs to doc                     │
+│    └── Syncs to all connected peers                     │
+└─────────────────────────────────────────────────────────┘
 ```
 
-### Target state
+### How cell mutations work
 
-Replace `NotebookState` with a `NotebookSyncClient` connected to the daemon. The automerge doc becomes the single source of truth.
+The frontend calls methods on the WASM `NotebookHandle` directly — no Tauri commands for cell source, add, or delete. The WASM module mutates its local Automerge doc and produces a binary sync message. Tauri relays that message to the daemon via the notebook sync connection.
 
-```
-kernel -> iopub -> Tauri writes to automerge doc -> daemon syncs to all peers
-                                                        |
-frontend <- Tauri event "notebook:updated" <- Tauri recv_changes()
-    |
-render
-```
+Character-level source edits use Automerge's `update_text` for CRDT-friendly merging across windows.
 
-### Tauri backend changes
+### How outputs arrive
 
-**On notebook open** (`load_notebook`):
-1. Determine notebook_id (derive from file path, or from notebook metadata)
-2. Connect `NotebookSyncClient` to daemon with that notebook_id
-3. If opening an .ipynb from disk: populate the automerge doc from the file contents (cells, source, metadata, outputs as JSON strings)
-4. If reconnecting to existing room (another window already has it open): sync from the daemon's canonical doc
-5. Spawn background task: `sync_client.recv_changes()` loop -> emit Tauri event `notebook:updated` with cell snapshots
+Outputs flow through the Automerge doc, not Tauri events:
 
-**Cell mutations** — existing Tauri commands change to write through automerge:
-- `update_cell_source(cell_id, source)` -> `sync_client.update_source(cell_id, source)` (character-level patch via `update_text`)
-- `add_cell(cell_type, after_cell_id)` -> `sync_client.add_cell(index, cell_id, cell_type)`
-- `delete_cell(cell_id)` -> `sync_client.delete_cell(cell_id)`
+1. Kernel emits iopub message → daemon's `kernel_manager` receives it
+2. Daemon writes output to the notebook's Automerge doc (cell outputs array)
+3. Daemon produces a sync message → Tauri relay forwards it to the frontend
+4. Frontend receives `automerge:from-daemon` → WASM merges into local doc
+5. `materialize-cells.ts` converts the updated doc into React cell state
 
-**Kernel outputs** — the iopub listener writes to automerge instead of just emitting events:
-- `stream` -> `sync_client.append_output(cell_id, json_output_string)`
-- `display_data` / `execute_result` -> same
-- `error` -> same
-- `execute_cell` clears outputs first: `sync_client.clear_outputs(cell_id)`
+The legacy `onOutput` broadcast path is no-opped to avoid duplicate outputs (no dedup IDs yet). See #557 for the output streaming improvement plan.
 
-The Tauri event `kernel:iopub` still fires for low-latency display (the frontend can render immediately from the event, then reconcile when the automerge update arrives). This is the same data, two delivery paths — event for speed, automerge for durability and sync.
+### Save and format-on-save
 
-**On save** (`save_notebook`):
-1. Read cell state from the sync client's local replica
-2. Serialize to nbformat `.ipynb` (same as today, but source of truth is automerge doc, not `NotebookState`)
-
-### Frontend changes
-
-**`useNotebook.ts`** — the hook's public API stays the same. Internally:
-- `cells` state populated from `notebook:updated` Tauri events (instead of only `load_notebook`)
-- `appendOutput` / `clearCellOutputs` / `setExecutionCount` still update local React state for immediate rendering
-- When `notebook:updated` arrives from Tauri (triggered by automerge sync), reconcile local state
-
-The frontend doesn't know about automerge. It still calls Tauri commands and receives Tauri events. The sync layer is invisible.
-
-**`OutputArea.tsx`** — no changes in this phase. Outputs are still `JupyterOutput[]` objects parsed from JSON strings. Phase 6 changes this.
+Save is delegated to the daemon via `NotebookRequest::SaveNotebook`. The daemon:
+1. Reads the canonical Automerge doc
+2. Runs format-on-save if enabled (ruff for Python, deno fmt for TypeScript)
+3. Serializes to nbformat `.ipynb` and writes to disk
+4. Syncs any formatter changes back to all peers
 
 ### What multi-window sync gives us
 
-- Two windows open the same notebook -> both see the same cells, source, and outputs
-- Edit source in window A -> window B sees the change (character-level merge via Automerge Text CRDT)
-- Execute cell in window A -> outputs appear in window B (JSON strings synced through automerge)
-- Both windows save -> same `.ipynb` content (both read from the same automerge doc)
+- Two windows open the same notebook → both have local Automerge docs synced through the daemon
+- Edit source in window A → binary sync message → daemon → window B sees the change
+- Execute cell in window A → daemon writes outputs → both windows materialize them
+- Save from either window → daemon writes the same canonical `.ipynb`
 
 ### Key files
 
 | File | Role |
 |------|------|
-| `crates/notebook/src/lib.rs` | Tauri commands using sync client |
-| `crates/notebook/src/notebook_state.rs` | Notebook metadata and state |
-| `crates/runtimed/src/kernel_manager.rs` | Daemon-side kernel and iopub handling |
-| `apps/notebook/src/hooks/useNotebook.ts` | Listen to `notebook:updated` events |
+| `crates/runtimed-wasm/` | WASM module exposing `NotebookHandle` to the frontend |
+| `apps/notebook/src/hooks/useAutomergeNotebook.ts` | Frontend hook owning the local Automerge doc and sync lifecycle |
+| `apps/notebook/src/lib/materialize-cells.ts` | Converts Automerge doc state into React cell arrays |
+| `crates/runtimed/src/notebook_sync_server.rs` | Daemon-side notebook room management and sync |
+| `crates/runtimed/src/kernel_manager.rs` | Daemon-side kernel process and iopub → Automerge output writing |
+| `crates/notebook/src/lib.rs` | Tauri commands and relay plumbing |
 
 ---
 
@@ -842,21 +823,13 @@ For output manifests, the `output_type` field provides structural versioning. Ne
 
 ## Known Limitations
 
-### Sync Race Condition During Execution
+### Output Flow and Deduplication
 
-When a cell executes, there's a brief window where daemon sync updates may conflict with local output updates. The flow is:
+Outputs arrive at the frontend exclusively through Automerge sync: the daemon writes outputs to the notebook doc, produces a sync message, and the Tauri relay forwards it to the frontend WASM where `materialize-cells.ts` renders them.
 
-1. Frontend clears outputs and marks cell as executing
-2. Kernel outputs arrive via iopub → frontend updates local state
-3. Frontend calls `sync_append_output` (async to daemon)
-4. Daemon may send `notebook:updated` before our append arrives
-5. Frontend must decide: trust daemon state or preserve local outputs?
+The `onOutput` broadcast path is no-opped to avoid showing duplicate outputs — there are no dedup IDs to correlate broadcast outputs with Automerge-synced outputs. This means output latency is bounded by the Automerge sync round-trip rather than direct event delivery.
 
-**Current workaround**: The frontend tracks "executing cells" in `executingCellsRef` and preserves local outputs for those cells during `notebook:updated`. When execution completes (`markExecutionComplete`), the cell trusts daemon state again.
-
-**Limitation**: This is imperfect. There's no correlation between the kernel's `msg_id` and outputs in the CRDT. If the daemon sends stale state, we might briefly show wrong outputs.
-
-**Proper fix (future)**: Store `parent_header.msg_id` in cell metadata to correlate execution requests with outputs. Only accept daemon outputs that match the expected `msg_id`.
+See #557 for the output streaming improvement plan.
 
 ### Multi-Window Widget Sync (#276)
 
@@ -881,13 +854,7 @@ Widgets only render in the window that was active when the widget was created. S
 | **2** | CRDT sync (settings + notebooks) | Implemented (PR #220, #223) |
 | **3** | Blob store (on-disk CAS + HTTP server) | Implemented (PR #220) |
 | **4** | Protocol consolidation (single socket) | Implemented (PR #220, #223) |
-| **5** | Tauri <-> daemon notebook sync (multi-window) | Implemented (PR #238, #241) |
+| **5** | Local-first Automerge notebook sync | Implemented — frontend owns local Automerge doc via `runtimed-wasm` WASM, cell mutations happen in WASM, sync to daemon via binary messages |
 | **6** | Output store (manifests, ContentRef, inlining) | Implemented (PR #237) |
 | **7** | ipynb round-tripping | Future (outputs already persist in nbformat) |
-| **8** | Daemon-owned kernels | Implemented (PRs #258, #259, #267, #271, #275) — behind `daemon_execution` flag, widgets work single-window |
-
-### Remaining for daemon_execution default-on
-
-1. **Widget multi-window sync (#276)** — widgets work in single window, but secondary windows show "Loading widget" due to missing `comm_open` history
-2. ~~**Inline deps detection**~~ ✅ — daemon now reads `metadata.uv.dependencies`/`metadata.conda.dependencies` from .ipynb file
-3. **Testing** — verify project file detection works across fixture notebooks
+| **8** | Daemon-owned kernels | Implemented (PRs #258, #259, #267, #271, #275) — widgets work single-window |

--- a/python/runtimed/README.md
+++ b/python/runtimed/README.md
@@ -61,6 +61,10 @@ result = session.execute_cell(cell_id)
 print(result.success)
 print(result.stdout)
 print(result.error)
+
+# Save the notebook to disk
+path = session.save()                       # Save to current path
+path = session.save(path="/tmp/copy.ipynb")  # Save-as
 ```
 
 ## AsyncSession API
@@ -73,6 +77,10 @@ async with runtimed.AsyncSession(notebook_id="my-notebook") as session:
     # Or document-first pattern
     cell_id = await session.create_cell("print(x)")
     result = await session.execute_cell(cell_id)
+
+    # Save the notebook to disk
+    path = await session.save()                       # Save to current path
+    path = await session.save(path="/tmp/copy.ipynb")  # Save-as
 ```
 
 ## DaemonClient API


### PR DESCRIPTION
Post-migration documentation audit. Updates 12 files to reflect the local-first Automerge architecture from PRs #542–#554.

## Changes

**AGENTS.md / CLAUDE.md:**
- New "Notebook Document Architecture (Local-First)" section — three Automerge peers, mutation/sync flows, WASM schema compatibility note
- Key files table updated with `runtimed-wasm`, `useAutomergeNotebook.ts`, `materialize-cells.ts`
- `crates/notebook/src/lib.rs` description updated (cell mutation commands removed)
- Build note for `runtimed-wasm` (same pattern as daemon separate-binary warning)

**README.md:** Added `runtimed-wasm` to project structure.

**contributing/architecture.md:** Conformance table: "Mostly Conformant" → "Conformant" for Automerge and local-first editing.

**contributing/build-dependencies.md:** Added `runtimed-wasm` to all three Mermaid diagrams and key points table.

**contributing/development.md:** Added wasm-pack manual build note.

**contributing/runtimed.md:** Cross-reference to `runtimed-wasm` shared `notebook_doc.rs`.

**docs/runtimed.md:** Rewrote Phase 5 section (was pervasively stale — referenced deleted files, deleted events, deleted commands, wrong architecture). Fixed Known Limitations sync race section. Updated summary table.

**docs/python-bindings.md + python/runtimed/README.md:** Added `session.save(path=None)` documentation.

**docs/logging.md:** Fixed stale log prefixes (`[notebook-sync]` → `[automerge-notebook]`).

**useDaemonKernel.ts:** Fixed stale comment (`notebook:updated` → `automerge:from-daemon`).

Closes the documentation gap from #540.