### PR TITLE
refactor: consolidate manifest resolution and migrate console.* to logger

### DIFF
--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -9,6 +9,7 @@ import {
 import { searchHighlight } from "@/components/editor/search-highlight";
 import { IsolatedFrame, type IsolatedFrameHandle } from "@/components/isolated";
 import { isDarkMode as detectDarkMode } from "@/lib/dark-mode";
+import { logger } from "@/lib/logger";
 import { cn } from "@/lib/utils";
 import { useCellKeyboardNavigation } from "../hooks/useCellKeyboardNavigation";
 import { useEditorRegistry } from "../hooks/useEditorRegistry";
@@ -378,9 +379,7 @@ export function MarkdownCell({
             onReady={handleFrameReady}
             onLinkClick={handleLinkClick}
             onDoubleClick={handleDoubleClick}
-            onError={(err) =>
-              console.error("[MarkdownCell] iframe error:", err)
-            }
+            onError={(err) => logger.error("[MarkdownCell] iframe error:", err)}
             className="w-full"
           />
         ) : (

--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -9,10 +9,10 @@ import {
 import { searchHighlight } from "@/components/editor/search-highlight";
 import { IsolatedFrame, type IsolatedFrameHandle } from "@/components/isolated";
 import { isDarkMode as detectDarkMode } from "@/lib/dark-mode";
-import { logger } from "@/lib/logger";
 import { cn } from "@/lib/utils";
 import { useCellKeyboardNavigation } from "../hooks/useCellKeyboardNavigation";
 import { useEditorRegistry } from "../hooks/useEditorRegistry";
+import { logger } from "../lib/logger";
 import type { MarkdownCell as MarkdownCellType } from "../types";
 
 interface MarkdownCellProps {

--- a/apps/notebook/src/hooks/useCondaDependencies.ts
+++ b/apps/notebook/src/hooks/useCondaDependencies.ts
@@ -1,6 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWebview } from "@tauri-apps/api/webview";
 import { useCallback, useEffect, useState } from "react";
+import { logger } from "../lib/logger";
 import type { PixiInfo } from "../types";
 
 export interface CondaDependencies {
@@ -69,7 +70,7 @@ export function useCondaDependencies() {
       );
       setDependencies(deps);
     } catch (e) {
-      console.error("Failed to load conda dependencies:", e);
+      logger.error("Failed to load conda dependencies:", e);
     }
   }, []);
 
@@ -81,7 +82,7 @@ export function useCondaDependencies() {
       );
       setEnvironmentYmlDeps(deps);
     } catch (e) {
-      console.error("Failed to load environment.yml dependencies:", e);
+      logger.error("Failed to load environment.yml dependencies:", e);
     }
   }, []);
 
@@ -118,7 +119,7 @@ export function useCondaDependencies() {
       await invoke("approve_notebook_trust");
     } catch (e) {
       // Signing may fail if no trust key yet - that's okay
-      console.debug("[conda] Could not resign trust:", e);
+      logger.debug("[conda] Could not resign trust:", e);
     }
   }, []);
 
@@ -135,7 +136,7 @@ export function useCondaDependencies() {
   // In daemon mode, users need to restart the kernel to pick up new deps.
   const syncToKernel = useCallback(async (): Promise<boolean> => {
     // Hot-sync not available in daemon mode - kernel restart required
-    console.log(
+    logger.info(
       "[conda] Hot-sync not available in daemon mode, restart kernel to apply changes",
     );
     setNeedsKernelRestart(true);
@@ -165,7 +166,7 @@ export function useCondaDependencies() {
         // Check sync state — UI will show "Sync Now" if dirty
         await checkSyncState();
       } catch (e) {
-        console.error("Failed to add conda dependency:", e);
+        logger.error("Failed to add conda dependency:", e);
       } finally {
         setLoading(false);
       }
@@ -184,7 +185,7 @@ export function useCondaDependencies() {
         // Check sync state — removing a dep doesn't uninstall from running kernel
         await checkSyncState();
       } catch (e) {
-        console.error("Failed to remove conda dependency:", e);
+        logger.error("Failed to remove conda dependency:", e);
       } finally {
         setLoading(false);
       }
@@ -200,7 +201,7 @@ export function useCondaDependencies() {
       await loadDependencies();
       await resignTrust();
     } catch (e) {
-      console.error("Failed to clear conda dependencies:", e);
+      logger.error("Failed to clear conda dependencies:", e);
     } finally {
       setLoading(false);
     }
@@ -226,7 +227,7 @@ export function useCondaDependencies() {
         // Re-sign to keep notebook trusted after user modification
         await resignTrust();
       } catch (e) {
-        console.error("Failed to set channels:", e);
+        logger.error("Failed to set channels:", e);
       } finally {
         setLoading(false);
       }
@@ -247,7 +248,7 @@ export function useCondaDependencies() {
         // Re-sign to keep notebook trusted after user modification
         await resignTrust();
       } catch (e) {
-        console.error("Failed to set python version:", e);
+        logger.error("Failed to set python version:", e);
       } finally {
         setLoading(false);
       }
@@ -269,7 +270,7 @@ export function useCondaDependencies() {
       await loadDependencies();
       await resignTrust();
     } catch (e) {
-      console.error("Failed to import pixi dependencies:", e);
+      logger.error("Failed to import pixi dependencies:", e);
     } finally {
       setLoading(false);
     }

--- a/apps/notebook/src/hooks/useDenoDependencies.ts
+++ b/apps/notebook/src/hooks/useDenoDependencies.ts
@@ -1,6 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWebview } from "@tauri-apps/api/webview";
 import { useCallback, useEffect, useState } from "react";
+import { logger } from "../lib/logger";
 
 export interface DenoConfigInfo {
   path: string;
@@ -24,7 +25,7 @@ export function useDenoDependencies() {
       const flexible = await invoke<boolean>("get_deno_flexible_npm_imports");
       setFlexibleNpmImportsState(flexible);
     } catch (e) {
-      console.error("Failed to load flexible npm imports:", e);
+      logger.error("Failed to load flexible npm imports:", e);
     }
   }, []);
 
@@ -42,7 +43,7 @@ export function useDenoDependencies() {
 
         await loadFlexibleNpmImports();
       } catch (e) {
-        console.error("Failed to initialize Deno dependencies:", e);
+        logger.error("Failed to initialize Deno dependencies:", e);
       }
     };
     init();
@@ -64,7 +65,7 @@ export function useDenoDependencies() {
       await invoke("set_deno_flexible_npm_imports", { enabled });
       setFlexibleNpmImportsState(enabled);
     } catch (e) {
-      console.error("Failed to set flexible npm imports:", e);
+      logger.error("Failed to set flexible npm imports:", e);
     }
   }, []);
 

--- a/apps/notebook/src/hooks/useDependencies.ts
+++ b/apps/notebook/src/hooks/useDependencies.ts
@@ -1,6 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWebview } from "@tauri-apps/api/webview";
 import { useCallback, useEffect, useState } from "react";
+import { logger } from "../lib/logger";
 
 export interface NotebookDependencies {
   dependencies: string[];
@@ -79,7 +80,7 @@ export function useDependencies() {
       );
       setDependencies(deps);
     } catch (e) {
-      console.error("Failed to load dependencies:", e);
+      logger.error("Failed to load dependencies:", e);
     }
   }, []);
 
@@ -105,7 +106,7 @@ export function useDependencies() {
       await invoke("approve_notebook_trust");
     } catch (e) {
       // Signing may fail if no trust key yet - that's okay
-      console.debug("[deps] Could not resign trust:", e);
+      logger.debug("[deps] Could not resign trust:", e);
     }
   }, []);
 
@@ -114,7 +115,7 @@ export function useDependencies() {
   // In daemon mode, users need to restart the kernel to pick up new deps.
   const syncToKernel = useCallback(async (): Promise<boolean> => {
     // Hot-sync not available in daemon mode - kernel restart required
-    console.log(
+    logger.info(
       "[deps] Hot-sync not available in daemon mode, restart kernel to apply changes",
     );
     setNeedsKernelRestart(true);
@@ -148,7 +149,7 @@ export function useDependencies() {
         // Check sync state - UI will show "Sync Now" if dirty
         await checkSyncState();
       } catch (e) {
-        console.error("Failed to add dependency:", e);
+        logger.error("Failed to add dependency:", e);
       } finally {
         setLoading(false);
       }
@@ -168,7 +169,7 @@ export function useDependencies() {
         // Note: removing a dep doesn't uninstall from running kernel
         await checkSyncState();
       } catch (e) {
-        console.error("Failed to remove dependency:", e);
+        logger.error("Failed to remove dependency:", e);
       } finally {
         setLoading(false);
       }
@@ -184,7 +185,7 @@ export function useDependencies() {
       await loadDependencies();
       await resignTrust();
     } catch (e) {
-      console.error("Failed to clear UV dependencies:", e);
+      logger.error("Failed to clear UV dependencies:", e);
     } finally {
       setLoading(false);
     }
@@ -208,7 +209,7 @@ export function useDependencies() {
         // Re-sign to keep notebook trusted after user modification
         await resignTrust();
       } catch (e) {
-        console.error("Failed to set requires-python:", e);
+        logger.error("Failed to set requires-python:", e);
       } finally {
         setLoading(false);
       }
@@ -230,7 +231,7 @@ export function useDependencies() {
       );
       setPyprojectDeps(deps);
     } catch (e) {
-      console.error("Failed to load pyproject dependencies:", e);
+      logger.error("Failed to load pyproject dependencies:", e);
     }
   }, []);
 
@@ -249,9 +250,9 @@ export function useDependencies() {
       await loadDependencies();
       // Re-sign to keep notebook trusted after user modification
       await resignTrust();
-      console.log("[deps] Imported dependencies from pyproject.toml");
+      logger.info("[deps] Imported dependencies from pyproject.toml");
     } catch (e) {
-      console.error("Failed to import from pyproject.toml:", e);
+      logger.error("Failed to import from pyproject.toml:", e);
     } finally {
       setLoading(false);
     }

--- a/apps/notebook/src/hooks/useGitInfo.ts
+++ b/apps/notebook/src/hooks/useGitInfo.ts
@@ -1,5 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import { useEffect, useState } from "react";
+import { logger } from "../lib/logger";
 
 interface GitInfo {
   branch: string;
@@ -20,7 +21,7 @@ export function useGitInfo() {
     invoke<GitInfo | null>("get_git_info")
       .then(setGitInfo)
       .catch((e) => {
-        console.error("Failed to get git info:", e);
+        logger.error("Failed to get git info:", e);
       });
   }, []);
 
@@ -34,7 +35,7 @@ export function useDaemonInfo() {
     invoke<DaemonInfo | null>("get_daemon_info")
       .then(setDaemonInfo)
       .catch((e) => {
-        console.error("Failed to get daemon info:", e);
+        logger.error("Failed to get daemon info:", e);
       });
   }, []);
 

--- a/apps/notebook/src/hooks/useManifestResolver.ts
+++ b/apps/notebook/src/hooks/useManifestResolver.ts
@@ -1,161 +1,9 @@
 import { invoke } from "@tauri-apps/api/core";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { logger } from "../lib/logger";
+import type { OutputManifest } from "../lib/manifest-resolution";
+import { isManifestHash, resolveManifest } from "../lib/manifest-resolution";
 import type { JupyterOutput } from "../types";
-
-/**
- * ContentRef represents a reference to content that may be inlined or stored in the blob store.
- * Matches the Rust ContentRef type in output_store.rs.
- */
-type ContentRef = { inline: string } | { blob: string; size: number };
-
-/**
- * Output manifest types matching the Rust OutputManifest enum.
- */
-interface DisplayDataManifest {
-  output_type: "display_data";
-  data: Record<string, ContentRef>;
-  metadata?: Record<string, unknown>;
-  transient?: { display_id?: string };
-}
-
-interface ExecuteResultManifest {
-  output_type: "execute_result";
-  data: Record<string, ContentRef>;
-  metadata?: Record<string, unknown>;
-  execution_count?: number | null;
-  transient?: { display_id?: string };
-}
-
-interface StreamManifest {
-  output_type: "stream";
-  name: string;
-  text: ContentRef;
-}
-
-interface ErrorManifest {
-  output_type: "error";
-  ename: string;
-  evalue: string;
-  traceback: ContentRef;
-}
-
-type OutputManifest =
-  | DisplayDataManifest
-  | ExecuteResultManifest
-  | StreamManifest
-  | ErrorManifest;
-
-/**
- * Check if a string looks like a blob hash (hex string).
- */
-export function looksLikeBlobHash(s: string): boolean {
-  // Blob hashes are 64-char hex strings (SHA-256)
-  return /^[a-f0-9]{64}$/.test(s);
-}
-
-/**
- * Resolve a ContentRef to its string value.
- */
-async function resolveContentRef(
-  ref: ContentRef,
-  blobPort: number,
-): Promise<string> {
-  if ("inline" in ref) {
-    return ref.inline;
-  }
-  // Fetch from blob store
-  const response = await fetch(`http://127.0.0.1:${blobPort}/blob/${ref.blob}`);
-  if (!response.ok) {
-    throw new Error(`Failed to fetch blob ${ref.blob}: ${response.status}`);
-  }
-  return response.text();
-}
-
-/**
- * Resolve a data bundle (MIME type -> ContentRef) to resolved strings.
- */
-async function resolveDataBundle(
-  data: Record<string, ContentRef>,
-  blobPort: number,
-): Promise<Record<string, unknown>> {
-  const resolved: Record<string, unknown> = {};
-  for (const [mimeType, ref] of Object.entries(data)) {
-    const content = await resolveContentRef(ref, blobPort);
-    // For JSON MIME types, parse the content
-    if (mimeType.includes("json")) {
-      try {
-        resolved[mimeType] = JSON.parse(content);
-      } catch {
-        resolved[mimeType] = content;
-      }
-    } else {
-      resolved[mimeType] = content;
-    }
-  }
-  return resolved;
-}
-
-/**
- * Resolve an output manifest to a full Jupyter output.
- */
-export async function resolveManifest(
-  manifest: OutputManifest,
-  blobPort: number,
-): Promise<JupyterOutput> {
-  switch (manifest.output_type) {
-    case "display_data": {
-      const data = await resolveDataBundle(manifest.data, blobPort);
-      const output: JupyterOutput = {
-        output_type: "display_data",
-        data,
-        metadata: manifest.metadata ?? {},
-      };
-      // Preserve display_id for update_display_data targeting
-      if (manifest.transient?.display_id) {
-        (output as Record<string, unknown>).display_id =
-          manifest.transient.display_id;
-      }
-      return output;
-    }
-    case "execute_result": {
-      const data = await resolveDataBundle(manifest.data, blobPort);
-      const output: JupyterOutput = {
-        output_type: "execute_result",
-        data,
-        metadata: manifest.metadata ?? {},
-        execution_count: manifest.execution_count ?? null,
-      };
-      // Preserve display_id for update_display_data targeting
-      if (manifest.transient?.display_id) {
-        (output as Record<string, unknown>).display_id =
-          manifest.transient.display_id;
-      }
-      return output;
-    }
-    case "stream": {
-      const text = await resolveContentRef(manifest.text, blobPort);
-      return {
-        output_type: "stream",
-        name: manifest.name as "stdout" | "stderr",
-        text,
-      };
-    }
-    case "error": {
-      const tracebackJson = await resolveContentRef(
-        manifest.traceback,
-        blobPort,
-      );
-      const traceback = JSON.parse(tracebackJson) as string[];
-      return {
-        output_type: "error",
-        ename: manifest.ename,
-        evalue: manifest.evalue,
-        traceback,
-      };
-    }
-  }
-}
 
 /**
  * Fetch blob port with retry logic.
@@ -196,7 +44,7 @@ export async function resolveOutputString(
   blobPort: number,
 ): Promise<JupyterOutput | null> {
   // If it doesn't look like a blob hash, try parsing as raw JSON
-  if (!looksLikeBlobHash(outputStr)) {
+  if (!isManifestHash(outputStr)) {
     try {
       return JSON.parse(outputStr) as JupyterOutput;
     } catch {
@@ -271,7 +119,7 @@ export function useManifestResolver() {
       }
 
       // If it doesn't look like a blob hash, try parsing as raw JSON
-      if (!looksLikeBlobHash(outputStr)) {
+      if (!isManifestHash(outputStr)) {
         try {
           const output = JSON.parse(outputStr) as JupyterOutput;
           cacheRef.current.set(outputStr, output);

--- a/apps/notebook/src/hooks/useTrust.ts
+++ b/apps/notebook/src/hooks/useTrust.ts
@@ -1,5 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import { useCallback, useEffect, useState } from "react";
+import { logger } from "../lib/logger";
 
 /** Trust status from the backend */
 export type TrustStatusType =
@@ -52,7 +53,7 @@ export function useTrust() {
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
       setError(message);
-      console.error("Failed to check trust:", e);
+      logger.error("Failed to check trust:", e);
       return null;
     } finally {
       setLoading(false);
@@ -71,7 +72,7 @@ export function useTrust() {
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
       setError(message);
-      console.error("Failed to approve trust:", e);
+      logger.error("Failed to approve trust:", e);
       return false;
     } finally {
       setLoading(false);

--- a/apps/notebook/src/hooks/useUpdater.ts
+++ b/apps/notebook/src/hooks/useUpdater.ts
@@ -1,6 +1,7 @@
 import { relaunch } from "@tauri-apps/plugin-process";
 import { check, type Update } from "@tauri-apps/plugin-updater";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { logger } from "../lib/logger";
 
 export type UpdateStatus =
   | "idle"
@@ -41,7 +42,7 @@ export function useUpdater() {
         setState({ status: "idle", version: null, error: null });
       }
     } catch (e) {
-      console.warn("[updater] check failed:", e);
+      logger.warn("[updater] check failed:", e);
       setState((prev) => ({
         ...prev,
         status: "error",
@@ -59,7 +60,7 @@ export function useUpdater() {
       await update.downloadAndInstall();
       setState((prev) => ({ ...prev, status: "ready" }));
     } catch (e) {
-      console.error("[updater] download/install failed:", e);
+      logger.error("[updater] download/install failed:", e);
       setState((prev) => ({
         ...prev,
         status: "error",
@@ -72,7 +73,7 @@ export function useUpdater() {
     try {
       await relaunch();
     } catch (e) {
-      console.error("[updater] relaunch failed:", e);
+      logger.error("[updater] relaunch failed:", e);
     }
   }, []);
 

--- a/apps/notebook/src/lib/manifest-resolution.ts
+++ b/apps/notebook/src/lib/manifest-resolution.ts
@@ -1,0 +1,135 @@
+import type { JupyterOutput } from "../types";
+
+/**
+ * Check if a string looks like a manifest hash (64-char hex SHA-256).
+ */
+export function isManifestHash(s: string): boolean {
+  return /^[a-f0-9]{64}$/.test(s);
+}
+
+/**
+ * A content reference — either inlined data or a blob-store hash.
+ */
+export type ContentRef = { inline: string } | { blob: string; size: number };
+
+/**
+ * An output manifest with content refs that may need blob-store resolution.
+ */
+export type OutputManifest =
+  | {
+      output_type: "display_data";
+      data: Record<string, ContentRef>;
+      metadata?: Record<string, unknown>;
+      transient?: { display_id?: string };
+    }
+  | {
+      output_type: "execute_result";
+      data: Record<string, ContentRef>;
+      metadata?: Record<string, unknown>;
+      execution_count?: number | null;
+      transient?: { display_id?: string };
+    }
+  | {
+      output_type: "stream";
+      name: string;
+      text: ContentRef;
+    }
+  | {
+      output_type: "error";
+      ename: string;
+      evalue: string;
+      traceback: ContentRef;
+    };
+
+/**
+ * Resolve a content reference to its string value.
+ * Inlined refs return immediately; blob refs are fetched from the blob store.
+ */
+export async function resolveContentRef(
+  ref: ContentRef,
+  blobPort: number,
+): Promise<string> {
+  if ("inline" in ref) {
+    return ref.inline;
+  }
+  const response = await fetch(`http://127.0.0.1:${blobPort}/blob/${ref.blob}`);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch blob ${ref.blob}: ${response.status}`);
+  }
+  return response.text();
+}
+
+/**
+ * Resolve a MIME-type → ContentRef map to a fully hydrated data bundle.
+ * JSON MIME types are auto-parsed.
+ */
+export async function resolveDataBundle(
+  data: Record<string, ContentRef>,
+  blobPort: number,
+): Promise<Record<string, unknown>> {
+  const resolved: Record<string, unknown> = {};
+  for (const [mimeType, ref] of Object.entries(data)) {
+    const content = await resolveContentRef(ref, blobPort);
+    if (mimeType.includes("json")) {
+      try {
+        resolved[mimeType] = JSON.parse(content);
+      } catch {
+        resolved[mimeType] = content;
+      }
+    } else {
+      resolved[mimeType] = content;
+    }
+  }
+  return resolved;
+}
+
+/**
+ * Resolve an output manifest into a fully hydrated JupyterOutput.
+ */
+export async function resolveManifest(
+  manifest: OutputManifest,
+  blobPort: number,
+): Promise<JupyterOutput> {
+  switch (manifest.output_type) {
+    case "display_data": {
+      const data = await resolveDataBundle(manifest.data, blobPort);
+      return {
+        output_type: "display_data",
+        data,
+        metadata: manifest.metadata ?? {},
+        display_id: manifest.transient?.display_id,
+      };
+    }
+    case "execute_result": {
+      const data = await resolveDataBundle(manifest.data, blobPort);
+      return {
+        output_type: "execute_result",
+        data,
+        metadata: manifest.metadata ?? {},
+        execution_count: manifest.execution_count ?? null,
+        display_id: manifest.transient?.display_id,
+      };
+    }
+    case "stream": {
+      const text = await resolveContentRef(manifest.text, blobPort);
+      return {
+        output_type: "stream",
+        name: manifest.name as "stdout" | "stderr",
+        text,
+      };
+    }
+    case "error": {
+      const tracebackJson = await resolveContentRef(
+        manifest.traceback,
+        blobPort,
+      );
+      const traceback = JSON.parse(tracebackJson) as string[];
+      return {
+        output_type: "error",
+        ename: manifest.ename,
+        evalue: manifest.evalue,
+        traceback,
+      };
+    }
+  }
+}

--- a/apps/notebook/src/lib/materialize-cells.ts
+++ b/apps/notebook/src/lib/materialize-cells.ts
@@ -1,5 +1,16 @@
 import type { JupyterOutput, NotebookCell } from "../types";
 import { logger } from "./logger";
+import type { OutputManifest } from "./manifest-resolution";
+import { isManifestHash, resolveManifest } from "./manifest-resolution";
+
+export type { ContentRef, OutputManifest } from "./manifest-resolution";
+// Re-export shared manifest types and functions for downstream consumers
+export {
+  isManifestHash,
+  resolveContentRef,
+  resolveDataBundle,
+  resolveManifest,
+} from "./manifest-resolution";
 
 /**
  * Snapshot of a cell from the Automerge document.
@@ -12,140 +23,6 @@ export interface CellSnapshot {
   source: string;
   execution_count: string; // "5" or "null"
   outputs: string[]; // JSON-encoded Jupyter outputs or manifest hashes
-}
-
-/**
- * Check if a string looks like a manifest hash (64-char hex SHA-256).
- */
-export function isManifestHash(s: string): boolean {
-  return /^[a-f0-9]{64}$/.test(s);
-}
-
-/**
- * A content reference — either inlined data or a blob-store hash.
- */
-export type ContentRef = { inline: string } | { blob: string; size: number };
-
-/**
- * An output manifest with content refs that may need blob-store resolution.
- */
-export type OutputManifest =
-  | {
-      output_type: "display_data";
-      data: Record<string, ContentRef>;
-      metadata?: Record<string, unknown>;
-      transient?: { display_id?: string };
-    }
-  | {
-      output_type: "execute_result";
-      data: Record<string, ContentRef>;
-      metadata?: Record<string, unknown>;
-      execution_count?: number | null;
-      transient?: { display_id?: string };
-    }
-  | {
-      output_type: "stream";
-      name: string;
-      text: ContentRef;
-    }
-  | {
-      output_type: "error";
-      ename: string;
-      evalue: string;
-      traceback: ContentRef;
-    };
-
-/**
- * Resolve a content reference to its string value.
- * Inlined refs return immediately; blob refs are fetched from the blob store.
- */
-export async function resolveContentRef(
-  ref: ContentRef,
-  blobPort: number,
-): Promise<string> {
-  if ("inline" in ref) {
-    return ref.inline;
-  }
-  const response = await fetch(`http://127.0.0.1:${blobPort}/blob/${ref.blob}`);
-  if (!response.ok) {
-    throw new Error(`Failed to fetch blob ${ref.blob}: ${response.status}`);
-  }
-  return response.text();
-}
-
-/**
- * Resolve a MIME-type → ContentRef map to a fully hydrated data bundle.
- * JSON MIME types are auto-parsed.
- */
-export async function resolveDataBundle(
-  data: Record<string, ContentRef>,
-  blobPort: number,
-): Promise<Record<string, unknown>> {
-  const resolved: Record<string, unknown> = {};
-  for (const [mimeType, ref] of Object.entries(data)) {
-    const content = await resolveContentRef(ref, blobPort);
-    if (mimeType.includes("json")) {
-      try {
-        resolved[mimeType] = JSON.parse(content);
-      } catch {
-        resolved[mimeType] = content;
-      }
-    } else {
-      resolved[mimeType] = content;
-    }
-  }
-  return resolved;
-}
-
-/**
- * Resolve an output manifest into a fully hydrated JupyterOutput.
- */
-export async function resolveManifest(
-  manifest: OutputManifest,
-  blobPort: number,
-): Promise<JupyterOutput> {
-  switch (manifest.output_type) {
-    case "display_data": {
-      const data = await resolveDataBundle(manifest.data, blobPort);
-      return {
-        output_type: "display_data",
-        data,
-        metadata: manifest.metadata ?? {},
-        display_id: manifest.transient?.display_id,
-      };
-    }
-    case "execute_result": {
-      const data = await resolveDataBundle(manifest.data, blobPort);
-      return {
-        output_type: "execute_result",
-        data,
-        metadata: manifest.metadata ?? {},
-        execution_count: manifest.execution_count ?? null,
-        display_id: manifest.transient?.display_id,
-      };
-    }
-    case "stream": {
-      const text = await resolveContentRef(manifest.text, blobPort);
-      return {
-        output_type: "stream",
-        name: manifest.name as "stdout" | "stderr",
-        text,
-      };
-    }
-    case "error": {
-      const tracebackJson = await resolveContentRef(
-        manifest.traceback,
-        blobPort,
-      );
-      const traceback = JSON.parse(tracebackJson) as string[];
-      return {
-        output_type: "error",
-        ename: manifest.ename,
-        evalue: manifest.evalue,
-        traceback,
-      };
-    }
-  }
 }
 
 /**


### PR DESCRIPTION
Two cleanup items from a codebase audit.

**Manifest resolution deduplication** — `materialize-cells.ts` and `useManifestResolver.ts` had ~150 LOC of duplicated types and blob resolution logic. Extracted into a shared `lib/manifest-resolution.ts` module. This also removes an unsafe `as Record<string, unknown>` type cast for `display_id` — the shared `resolveManifest` handles it directly via the existing `JupyterOutput` type.

**Logger migration** — 7 files were using raw `console.*` calls, bypassing the `logger` abstraction that gates debug output in production. Migrated all of them: `useCondaDependencies`, `useDependencies`, `useDenoDependencies`, `useGitInfo`, `useTrust`, `useUpdater`, `MarkdownCell`.

Net: -135 lines, one fewer copy-paste surface, consistent logging.