### PR TITLE
feat(runtimed): format-on-execute, remove Tauri format_cell command

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -111,7 +111,6 @@ function AppContent() {
     updateOutputByDisplayId,
     setExecutionCount,
     clearCellOutputs,
-    formatCell,
   } = useAutomergeNotebook();
 
   // Global find (Cmd+F)
@@ -1099,7 +1098,6 @@ function AppContent() {
         onDeleteCell={deleteCell}
         onAddCell={handleAddCell}
         onClearPagePayload={clearPagePayload}
-        onFormatCell={formatCell}
         onReportOutputMatchCount={globalFind.reportOutputMatchCount}
       />
     </div>

--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -93,7 +93,6 @@ interface CodeCellProps {
   onFocusNext?: (cursorPosition: "start" | "end") => void;
   onInsertCellAfter?: () => void;
   onClearPagePayload?: () => void;
-  onFormat?: () => void;
   isLastCell?: boolean;
 }
 
@@ -115,7 +114,6 @@ export function CodeCell({
   onFocusNext,
   onInsertCellAfter,
   onClearPagePayload,
-  onFormat,
   isLastCell = false,
 }: CodeCellProps) {
   const editorRef = useRef<CodeMirrorEditorRef>(null);
@@ -179,7 +177,6 @@ export function CodeCell({
         }
       : undefined,
     onDelete,
-    onFormat,
   });
 
   // Ctrl+R to open history search

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -28,7 +28,6 @@ interface NotebookViewProps {
   onDeleteCell: (cellId: string) => void;
   onAddCell: (type: "code" | "markdown", afterCellId?: string | null) => void;
   onClearPagePayload: (cellId: string) => void;
-  onFormatCell?: (cellId: string) => void;
   onReportOutputMatchCount?: (cellId: string, count: number) => void;
 }
 
@@ -138,7 +137,6 @@ function NotebookViewContent({
   onDeleteCell,
   onAddCell,
   onClearPagePayload,
-  onFormatCell,
   onReportOutputMatchCount,
 }: NotebookViewProps) {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -231,7 +229,6 @@ function NotebookViewContent({
             onFocusNext={onFocusNext}
             onInsertCellAfter={() => onAddCell("code", cell.id)}
             onClearPagePayload={() => onClearPagePayload(cell.id)}
-            onFormat={onFormatCell ? () => onFormatCell(cell.id) : undefined}
             isLastCell={index === cells.length - 1}
           />
         );
@@ -280,7 +277,6 @@ function NotebookViewContent({
       onDeleteCell,
       onAddCell,
       onClearPagePayload,
-      onFormatCell,
       onReportOutputMatchCount,
       focusCell,
     ],

--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -195,22 +195,6 @@ export function useAutomergeNotebook() {
       },
     );
 
-    // ── Backend-initiated cell source updates (e.g. formatting) ──────
-    const unlistenSourceUpdated = webview.listen<{
-      cell_id: string;
-      source: string;
-    }>("cell:source_updated", (event) => {
-      if (cancelled) return;
-      setCells((prev) =>
-        prev.map((c) =>
-          c.id === event.payload.cell_id
-            ? { ...c, source: event.payload.source }
-            : c,
-        ),
-      );
-      setDirty(true);
-    });
-
     // ── Bulk output clearing (run-all / restart-and-run-all) ─────────
     const unlistenClearOutputs = webview.listen<string[]>(
       "cells:outputs_cleared",
@@ -232,7 +216,6 @@ export function useAutomergeNotebook() {
       unlistenReady.then((fn) => fn());
       unlistenFileOpened.then((fn) => fn());
       unlistenSync.then((fn) => fn());
-      unlistenSourceUpdated.then((fn) => fn());
       unlistenClearOutputs.then((fn) => fn());
       // Free WASM handle.
       handleRef.current?.free();
@@ -460,25 +443,6 @@ export function useAutomergeNotebook() {
     );
   }, []);
 
-  const formatCell = useCallback(async (cellId: string) => {
-    try {
-      const result = await invoke<{
-        source: string;
-        changed: boolean;
-        error: string | null;
-      }>("format_cell", { cellId });
-
-      if (result.error) {
-        logger.warn("[automerge-notebook] Format cell warning:", result.error);
-      }
-
-      return result;
-    } catch (e) {
-      logger.error("[automerge-notebook] Format cell failed:", e);
-      return null;
-    }
-  }, []);
-
   // ── Public interface ───────────────────────────────────────────────
 
   return {
@@ -497,6 +461,5 @@ export function useAutomergeNotebook() {
     appendOutput,
     updateOutputByDisplayId,
     setExecutionCount,
-    formatCell,
   };
 }

--- a/apps/notebook/src/hooks/useCellKeyboardNavigation.ts
+++ b/apps/notebook/src/hooks/useCellKeyboardNavigation.ts
@@ -6,7 +6,6 @@ interface UseCellKeyboardNavigationOptions {
   onExecute?: () => void;
   onExecuteAndInsert?: () => void;
   onDelete?: () => void;
-  onFormat?: () => void;
 }
 
 export function useCellKeyboardNavigation({
@@ -15,7 +14,6 @@ export function useCellKeyboardNavigation({
   onExecute,
   onExecuteAndInsert,
   onDelete,
-  onFormat,
 }: UseCellKeyboardNavigationOptions): KeyBinding[] {
   return [
     {
@@ -91,17 +89,6 @@ export function useCellKeyboardNavigation({
             key: "Alt-Enter",
             run: () => {
               onExecuteAndInsert();
-              return true;
-            },
-          },
-        ]
-      : []),
-    ...(onFormat
-      ? [
-          {
-            key: "Mod-Shift-f",
-            run: () => {
-              onFormat();
               return true;
             },
           },

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -2983,113 +2983,6 @@ async fn set_deno_flexible_npm_imports(
     set_metadata_snapshot(handle, &new_snapshot).await
 }
 
-/// Format a cell's source code using the appropriate formatter (ruff for Python, deno fmt for TypeScript/JavaScript).
-/// Returns the formatted source and whether it changed. If formatting fails (e.g., syntax error),
-/// returns the original source with an error message.
-#[tauri::command]
-async fn format_cell(
-    cell_id: String,
-    window: tauri::Window,
-    registry: tauri::State<'_, WindowNotebookRegistry>,
-) -> Result<format::FormatResult, String> {
-    let notebook_sync = notebook_sync_for_window(&window, registry.inner())?;
-
-    // Get current source from sync handle and runtime from metadata
-    let (source, runtime) = {
-        let guard = notebook_sync.lock().await;
-        let handle = guard.as_ref().ok_or("Not connected to daemon")?;
-        let cells = handle
-            .get_cells()
-            .await
-            .map_err(|e| format!("get_cells: {}", e))?;
-        let cell = cells
-            .iter()
-            .find(|c| c.id == cell_id)
-            .ok_or_else(|| "Cell not found".to_string())?;
-        let source = cell.source.clone();
-
-        // Get runtime from metadata
-        let runtime = get_runtime_from_sync(handle).await;
-        (source, runtime)
-    };
-
-    // Skip formatting for empty cells
-    if source.trim().is_empty() {
-        return Ok(format::FormatResult {
-            source,
-            changed: false,
-            error: None,
-        });
-    }
-
-    // Format based on runtime
-    let mut result = match runtime {
-        Runtime::Python => format::format_python(&source)
-            .await
-            .map_err(|e| e.to_string())?,
-        Runtime::Deno => format::format_deno(&source, "typescript")
-            .await
-            .map_err(|e| e.to_string())?,
-        Runtime::Other(ref s) => {
-            return Err(format!("No formatter available for runtime: {s}"));
-        }
-    };
-
-    // Strip trailing newline that formatters always add (cells shouldn't end with \n)
-    result.source = result.source_for_cell().to_string();
-    result.changed = result.source != source;
-
-    // If formatting changed, update via sync handle
-    if result.changed {
-        let guard = notebook_sync.lock().await;
-        if let Some(handle) = guard.as_ref() {
-            if let Err(e) = handle.update_source(&cell_id, &result.source).await {
-                warn!("[notebook-sync] update_source for format failed: {}", e);
-            }
-        }
-        // Emit event to notify frontend
-        let _ = emit_to_label::<_, _, _>(
-            &window,
-            window.label(),
-            "cell:source_updated",
-            serde_json::json!({
-                "cell_id": cell_id,
-                "source": result.source.clone(),
-            }),
-        );
-    }
-
-    Ok(result)
-}
-
-/// Check if a formatter is available for the current notebook runtime.
-/// Returns true if ruff is available for Python notebooks or deno for TypeScript notebooks.
-#[tauri::command]
-async fn check_formatter_available(
-    window: tauri::Window,
-    registry: tauri::State<'_, WindowNotebookRegistry>,
-) -> Result<bool, String> {
-    let notebook_sync = notebook_sync_for_window(&window, registry.inner())?;
-    let runtime = {
-        let guard = notebook_sync.lock().await;
-        match guard.as_ref() {
-            Some(handle) => get_runtime_from_sync(handle).await,
-            None => {
-                // Fallback to NotebookState
-                let state = notebook_state_for_window(&window, registry.inner())?;
-                let nb = state.lock().map_err(|e| e.to_string())?;
-                nb.get_runtime()
-            }
-        }
-    };
-
-    match runtime {
-        Runtime::Python => Ok(format::check_ruff_available().await),
-        Runtime::Deno => Ok(deno_env::check_deno_available().await),
-        Runtime::Other(_) => Ok(false),
-    }
-}
-
 /// Get app settings (default runtime, etc.)
 #[tauri::command]
 async fn get_settings() -> runtimed::settings_doc::SyncedSettings {
@@ -3679,9 +3572,7 @@ pub fn run(
             set_deno_permissions,
             get_deno_flexible_npm_imports,
             set_deno_flexible_npm_imports,
-            // Code formatting
-            format_cell,
-            check_formatter_available,
+
             // Settings
             get_settings,
             // Synced settings (via runtimed Automerge)

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -1932,6 +1932,23 @@ async fn handle_notebook_request(
                 };
             }
 
+            // Format before execution (best-effort, non-blocking on failure)
+            let source = if let Some(runtime) = detect_room_runtime(room).await {
+                if let Some(formatted) = format_source(&source, &runtime).await {
+                    // Write formatted source back to the Automerge doc
+                    let mut doc = room.doc.write().await;
+                    if doc.update_source(&cell_id, &formatted).is_ok() {
+                        let _ = room.changed_tx.send(());
+                        debug!("[format] Formatted cell {} before execution", cell_id);
+                    }
+                    formatted
+                } else {
+                    source
+                }
+            } else {
+                source
+            };
+
             // NOW lock kernel for the queue operation
             let mut kernel_guard = room.kernel.lock().await;
             if let Some(ref mut kernel) = *kernel_guard {
@@ -2349,29 +2366,94 @@ async fn handle_sync_environment(room: &NotebookRoom) -> NotebookResponse {
     }
 }
 
+/// Format a single source string using ruff (Python) or deno fmt (Deno).
+///
+/// Returns the formatted source with trailing newline stripped (cells shouldn't
+/// end with \n), or None if formatting failed or wasn't applicable.
+async fn format_source(source: &str, runtime: &str) -> Option<String> {
+    use kernel_launch::tools;
+    use std::process::Stdio;
+    use tokio::io::AsyncWriteExt;
+
+    if source.trim().is_empty() {
+        return None;
+    }
+
+    let raw = match runtime {
+        "python" => {
+            let ruff_path = tools::get_ruff_path().await.ok()?;
+            let mut child = tokio::process::Command::new(&ruff_path)
+                .args(["format", "--stdin-filename", "cell.py", "-"])
+                .stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .spawn()
+                .ok()?;
+
+            if let Some(mut stdin) = child.stdin.take() {
+                stdin.write_all(source.as_bytes()).await.ok()?;
+            }
+
+            let output = child.wait_with_output().await.ok()?;
+            if output.status.success() {
+                String::from_utf8(output.stdout).ok()
+            } else {
+                None
+            }
+        }
+        "deno" => {
+            let deno_path = tools::get_deno_path().await.ok()?;
+            let mut child = tokio::process::Command::new(&deno_path)
+                .args(["fmt", "--ext=ts", "-"])
+                .stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .spawn()
+                .ok()?;
+
+            if let Some(mut stdin) = child.stdin.take() {
+                stdin.write_all(source.as_bytes()).await.ok()?;
+            }
+
+            let output = child.wait_with_output().await.ok()?;
+            if output.status.success() {
+                String::from_utf8(output.stdout).ok()
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }?;
+
+    // Strip trailing newline (formatters always add one, but cells shouldn't have it)
+    let formatted = raw.strip_suffix('\n').unwrap_or(&raw).to_string();
+
+    if formatted != source {
+        Some(formatted)
+    } else {
+        None
+    }
+}
+
+/// Detect the runtime from room metadata, returning "python", "deno", or None.
+async fn detect_room_runtime(room: &NotebookRoom) -> Option<String> {
+    let metadata_json = {
+        let doc = room.doc.read().await;
+        doc.get_metadata(NOTEBOOK_METADATA_KEY)
+    };
+    metadata_json
+        .as_ref()
+        .and_then(|json| serde_json::from_str::<NotebookMetadataSnapshot>(json).ok())
+        .and_then(|snapshot| detect_notebook_kernel_type(&snapshot))
+}
+
 /// Format all code cells in a notebook using ruff (Python) or deno fmt (Deno).
 ///
 /// Reads the runtime type from the notebook metadata and formats accordingly.
 /// Updates the Automerge doc with formatted sources and broadcasts changes.
 /// Formatting errors are logged but don't fail the operation (best-effort).
 async fn format_notebook_cells(room: &NotebookRoom) -> Result<usize, String> {
-    use kernel_launch::tools;
-    use std::process::Stdio;
-    use tokio::io::AsyncWriteExt;
-
-    // Get runtime type from metadata - only format for known runtimes (Python/Deno)
-    let metadata_json = {
-        let doc = room.doc.read().await;
-        doc.get_metadata(NOTEBOOK_METADATA_KEY)
-    };
-
-    let runtime = metadata_json
-        .as_ref()
-        .and_then(|json| serde_json::from_str::<NotebookMetadataSnapshot>(json).ok())
-        .and_then(|snapshot| detect_notebook_kernel_type(&snapshot));
-
-    // Skip formatting for unknown kernelspec to avoid incorrectly reformatting non-Python/Deno notebooks
-    let runtime = match runtime {
+    let runtime = match detect_room_runtime(room).await {
         Some(rt) => rt,
         None => {
             info!("[format] Skipping format: unknown kernelspec (no formatter available)");
@@ -2396,88 +2478,10 @@ async fn format_notebook_cells(room: &NotebookRoom) -> Result<usize, String> {
     let mut formatted_count = 0;
 
     for (cell_id, source) in cells {
-        let format_result = match runtime.as_str() {
-            "python" => {
-                // Format with ruff
-                match tools::get_ruff_path().await {
-                    Ok(ruff_path) => {
-                        let mut child = match tokio::process::Command::new(&ruff_path)
-                            .args(["format", "--stdin-filename", "cell.py", "-"])
-                            .stdin(Stdio::piped())
-                            .stdout(Stdio::piped())
-                            .stderr(Stdio::piped())
-                            .spawn()
-                        {
-                            Ok(c) => c,
-                            Err(e) => {
-                                warn!("[format] Failed to spawn ruff: {}", e);
-                                continue;
-                            }
-                        };
-
-                        if let Some(mut stdin) = child.stdin.take() {
-                            if stdin.write_all(source.as_bytes()).await.is_err() {
-                                continue;
-                            }
-                        }
-
-                        match child.wait_with_output().await {
-                            Ok(output) if output.status.success() => {
-                                String::from_utf8(output.stdout).ok()
-                            }
-                            _ => None,
-                        }
-                    }
-                    Err(_) => None,
-                }
-            }
-            "deno" => {
-                // Format with deno fmt
-                match tools::get_deno_path().await {
-                    Ok(deno_path) => {
-                        let mut child = match tokio::process::Command::new(&deno_path)
-                            .args(["fmt", "--ext=ts", "-"])
-                            .stdin(Stdio::piped())
-                            .stdout(Stdio::piped())
-                            .stderr(Stdio::piped())
-                            .spawn()
-                        {
-                            Ok(c) => c,
-                            Err(e) => {
-                                warn!("[format] Failed to spawn deno fmt: {}", e);
-                                continue;
-                            }
-                        };
-
-                        if let Some(mut stdin) = child.stdin.take() {
-                            if stdin.write_all(source.as_bytes()).await.is_err() {
-                                continue;
-                            }
-                        }
-
-                        match child.wait_with_output().await {
-                            Ok(output) if output.status.success() => {
-                                String::from_utf8(output.stdout).ok()
-                            }
-                            _ => None,
-                        }
-                    }
-                    Err(_) => None,
-                }
-            }
-            _ => None,
-        };
-
-        if let Some(formatted) = format_result {
-            // Strip trailing newline (formatters always add one, but cells shouldn't have it)
-            let formatted = formatted.strip_suffix('\n').unwrap_or(&formatted);
-
-            if formatted != source {
-                // Update Automerge doc
-                let mut doc = room.doc.write().await;
-                if doc.update_source(&cell_id, formatted).is_ok() {
-                    formatted_count += 1;
-                }
+        if let Some(formatted) = format_source(&source, &runtime).await {
+            let mut doc = room.doc.write().await;
+            if doc.update_source(&cell_id, &formatted).is_ok() {
+                formatted_count += 1;
             }
         }
     }


### PR DESCRIPTION
The daemon now formats cell source before execution, replacing the Tauri-mediated `format_cell` command. Formatting ownership is fully daemon-side.

## How it works

**Format-on-execute:** When a cell is executed (Shift+Enter), the daemon formats the source with ruff (Python) or deno fmt (Deno) before queuing it for the kernel. The formatted source is written back to the Automerge doc and syncs to all peers. Best-effort — if formatting fails (syntax error, formatter unavailable), the original source executes unchanged.

**Format-on-save:** Already daemon-owned since PR #545. No change here.

## QA

- [x] Python: `x=1+2` → Shift+Enter → source reformats to `x = 1 + 2`
- [x] Deno: verified formatting via deno fmt

## What was removed

**Tauri commands (−111 lines Rust):**

| Removed | Reason |
|---------|--------|
| `format_cell` command | Last consumer of `handle.get_cells()` + `handle.update_source()` — blocking relay simplification (#556) |
| `check_formatter_available` command | Zero frontend callers |
| `cell:source_updated` event emission | Only emitter was `format_cell` |

**Frontend (−25 lines TS):**

| Removed | Reason |
|---------|--------|
| `⌘⇧F` / `Ctrl+Shift+F` keybinding | Vestigial — no UI affordance, format-on-execute covers the use case |
| `onFormat` prop chain | `useCellKeyboardNavigation` → `CodeCell` → `NotebookView` → `App.tsx` |
| `formatCell` callback in `useAutomergeNotebook` | Was a no-op after command removal |
| `cell:source_updated` listener | Only consumer of the removed event |

## Daemon changes

- Extract `format_source()` helper from `format_notebook_cells()` — reusable for single-cell formatting
- Extract `detect_room_runtime()` helper — shared between format-on-execute and format-on-save
- Add format step in `ExecuteCell` handler before kernel queue

−164 net lines. Unblocks relay simplification by removing the last `handle.get_cells()` consumer in Tauri.