### PR TITLE
refactor(notebook): eliminate empty notebook flash with eager WASM init

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -99,6 +99,7 @@ function AppContent() {
 
   const {
     cells,
+    isLoading,
     focusedCellId,
     setFocusedCellId,
     updateCellSource,
@@ -1086,6 +1087,7 @@ function AppContent() {
       />
       <NotebookView
         cells={cells}
+        isLoading={isLoading}
         focusedCellId={focusedCellId}
         executingCellIds={executingCellIds}
         pagePayloads={pagePayloads}

--- a/apps/notebook/src/components/CellSkeleton.tsx
+++ b/apps/notebook/src/components/CellSkeleton.tsx
@@ -1,0 +1,20 @@
+/**
+ * Skeleton placeholder shown while the notebook is loading.
+ * Mimics the visual structure of a code cell with AddCellButtons spacing.
+ */
+export function CellSkeleton() {
+  return (
+    <div className="flex py-4">
+      {/* Gutter area — matches CellContainer's w-10 gutter */}
+      <div className="w-10 flex-shrink-0" />
+
+      {/* Ribbon — self-stretch to fill container height */}
+      <div className="w-1 self-stretch bg-gray-200 dark:bg-gray-700" />
+
+      {/* Editor area placeholder */}
+      <div className="min-w-0 flex-1 py-3 pl-6 pr-3">
+        <div className="min-h-[2rem] rounded bg-muted/50 animate-pulse" />
+      </div>
+    </div>
+  );
+}

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -10,11 +10,13 @@ import {
 } from "../hooks/useEditorRegistry";
 import type { FindMatch } from "../hooks/useGlobalFind";
 import type { NotebookCell } from "../types";
+import { CellSkeleton } from "./CellSkeleton";
 import { CodeCell } from "./CodeCell";
 import { MarkdownCell } from "./MarkdownCell";
 
 interface NotebookViewProps {
   cells: NotebookCell[];
+  isLoading?: boolean;
   focusedCellId: string | null;
   executingCellIds: Set<string>;
   pagePayloads: Map<string, CellPagePayload>;
@@ -125,6 +127,7 @@ function CellErrorFallback({
 
 function NotebookViewContent({
   cells,
+  isLoading = false,
   focusedCellId,
   executingCellIds,
   pagePayloads,
@@ -293,30 +296,34 @@ function NotebookViewContent({
       style={{ contain: "paint" }}
     >
       {cells.length === 0 ? (
-        <div className="flex flex-col items-center justify-center py-20 text-muted-foreground">
-          <p className="text-sm">Empty notebook</p>
-          <p className="text-xs mt-1">Add a cell to get started</p>
-          <div className="mt-4 flex gap-2">
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => onAddCell("code")}
-              className="gap-1"
-            >
-              <Plus className="h-3 w-3" />
-              Code Cell
-            </Button>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => onAddCell("markdown")}
-              className="gap-1"
-            >
-              <Plus className="h-3 w-3" />
-              Markdown Cell
-            </Button>
+        isLoading ? (
+          <CellSkeleton />
+        ) : (
+          <div className="flex flex-col items-center justify-center py-20 text-muted-foreground">
+            <p className="text-sm">Empty notebook</p>
+            <p className="text-xs mt-1">Add a cell to get started</p>
+            <div className="mt-4 flex gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => onAddCell("code")}
+                className="gap-1"
+              >
+                <Plus className="h-3 w-3" />
+                Code Cell
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => onAddCell("markdown")}
+                className="gap-1"
+              >
+                <Plus className="h-3 w-3" />
+                Markdown Cell
+              </Button>
+            </div>
           </div>
-        </div>
+        )
       ) : (
         // biome-ignore lint/complexity/noUselessFragments: ternary else branch requires single expression
         <>

--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -14,18 +14,13 @@ import type { JupyterOutput, NotebookCell } from "../types";
 import init, { NotebookHandle } from "../wasm/runtimed-wasm/runtimed_wasm.js";
 
 // ---------------------------------------------------------------------------
-// Module-level WASM initialization — runs once per page load.
+// Module-level WASM initialization — starts loading immediately when module
+// is imported. This runs before React renders, eliminating WASM init latency
+// from the critical path that causes the "empty notebook" flash.
 // ---------------------------------------------------------------------------
-let wasmReady: Promise<void> | null = null;
-
-function ensureWasmInit(): Promise<void> {
-  if (!wasmReady) {
-    wasmReady = init().then(() => {
-      logger.info("[automerge-notebook] WASM initialized");
-    });
-  }
-  return wasmReady;
-}
+const wasmReady: Promise<void> = init().then(() => {
+  logger.info("[automerge-notebook] WASM initialized");
+});
 
 // ---------------------------------------------------------------------------
 // Hook
@@ -43,6 +38,7 @@ export function useAutomergeNotebook() {
   const [cells, setCells] = useState<NotebookCell[]>([]);
   const [focusedCellId, setFocusedCellId] = useState<string | null>(null);
   const [dirty, setDirty] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
 
   // The WASM handle is mutated in place — must live in a ref.
   const handleRef = useRef<NotebookHandle | null>(null);
@@ -117,7 +113,7 @@ export function useAutomergeNotebook() {
    * trigger the first sync exchange, not the load itself.
    */
   const bootstrap = useCallback(async () => {
-    await ensureWasmInit();
+    await wasmReady;
     try {
       const bytes = await invoke<number[]>("get_automerge_doc_bytes");
       const handle = NotebookHandle.load(new Uint8Array(bytes));
@@ -127,6 +123,7 @@ export function useAutomergeNotebook() {
       handleRef.current = handle;
 
       await materializeCells(handle);
+      setIsLoading(false);
       logger.info(
         `[automerge-notebook] Bootstrap complete — ${handle.cell_count()} cells`,
       );
@@ -483,6 +480,7 @@ export function useAutomergeNotebook() {
 
   return {
     cells,
+    isLoading,
     setCells,
     focusedCellId,
     setFocusedCellId,


### PR DESCRIPTION
## Summary

Eliminates the jarring visual flicker (4-5 distinct frames) when opening a notebook by:
- Moving WASM initialization to module import time (before React renders), shaving ~50-100ms from the critical path
- Adding `isLoading` state to distinguish "cells haven't loaded yet" from "genuinely empty notebook"
- Showing a skeleton placeholder instead of the "Empty notebook" UI during loading

## Changes

- **useAutomergeNotebook**: Eager `wasmReady` promise at module top level, `isLoading` state tracks bootstrap completion
- **CellSkeleton**: New placeholder component matching cell layout with animated input area
- **NotebookView**: Renders skeleton when `cells.length === 0 && isLoading`, preserving "Empty notebook" UI as safety net for edge cases
- **App.tsx**: Wires `isLoading` from hook through to view

## Verification

- [x] Open existing notebook: verify skeleton appears briefly, then cells (no "Empty notebook" flash)
- [x] New notebook: verify skeleton appears then default cell (currently created by `NotebookState::new_empty()`)
- [x] Slow daemon: kill daemon and open notebook, skeleton persists during retry without flashing empty state

_PR submitted by @rgbkrk's agent, Quill_