### PR TITLE
feat(notebook): reactive metadata via useSyncExternalStore, migrate reads+writes to WASM doc

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -36,6 +36,7 @@ import { useTrust } from "./hooks/useTrust";
 import { useUpdater } from "./hooks/useUpdater";
 import { KERNEL_STATUS } from "./lib/kernel-status";
 import { logger } from "./lib/logger";
+import { useDetectRuntime } from "./lib/notebook-metadata";
 import type { JupyterMessage } from "./types";
 
 /** MIME bundle type for page payloads */
@@ -142,15 +143,10 @@ function AppContent() {
   // Track pending kernel start that was blocked by trust dialog
   const pendingKernelStartRef = useRef(false);
 
-  // Notebook runtime type (python or deno)
-  const [runtime, setRuntime] = useState<"python" | "deno">("python");
-
-  // Load runtime from notebook metadata on mount
-  useEffect(() => {
-    invoke<string>("get_notebook_runtime").then((r) => {
-      setRuntime(r as "python" | "deno");
-    });
-  }, []);
+  // Notebook runtime type — reactive read from WASM Automerge doc.
+  // Re-renders automatically when metadata changes (bootstrap, sync, writes).
+  const detectedRuntime = useDetectRuntime();
+  const runtime = detectedRuntime ?? "python";
 
   // Auto-clear justSynced after 3 seconds
   useEffect(() => {

--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -10,6 +10,10 @@ import {
   type CellSnapshot,
   cellSnapshotsToNotebookCells,
 } from "../lib/materialize-cells";
+import {
+  notifyMetadataChanged,
+  setNotebookHandle,
+} from "../lib/notebook-metadata";
 import type { JupyterOutput, NotebookCell } from "../types";
 import init, { NotebookHandle } from "../wasm/runtimed-wasm/runtimed_wasm.js";
 
@@ -121,6 +125,7 @@ export function useAutomergeNotebook() {
       // Dispose previous handle (WASM allocation).
       handleRef.current?.free();
       handleRef.current = handle;
+      setNotebookHandle(handle);
 
       await materializeCells(handle);
       setIsLoading(false);
@@ -182,6 +187,14 @@ export function useAutomergeNotebook() {
           const changed = handle.receive_sync_message(bytes);
           if (changed) {
             await materializeCells(handle);
+            // Notify metadata subscribers (useSyncExternalStore) that the
+            // doc changed. This covers metadata updates from the daemon
+            // (e.g. trust re-signing, dependency sync from other windows).
+            // Note: local cell mutations (add/delete/source) don't call
+            // notifyMetadataChanged() because they only touch cells, not
+            // the metadata key. If a future mutation affects metadata,
+            // add a notify call there.
+            notifyMetadataChanged();
           }
           // The sync protocol may need multiple roundtrips — always
           // check whether we have something to send back.
@@ -215,6 +228,7 @@ export function useAutomergeNotebook() {
       unlistenSync.then((fn) => fn());
       unlistenClearOutputs.then((fn) => fn());
       // Free WASM handle.
+      setNotebookHandle(null);
       handleRef.current?.free();
       handleRef.current = null;
     };

--- a/apps/notebook/src/hooks/useCondaDependencies.ts
+++ b/apps/notebook/src/hooks/useCondaDependencies.ts
@@ -1,7 +1,14 @@
 import { invoke } from "@tauri-apps/api/core";
-import { getCurrentWebview } from "@tauri-apps/api/webview";
 import { useCallback, useEffect, useState } from "react";
 import { logger } from "../lib/logger";
+import {
+  addCondaDependency as addCondaDepWasm,
+  clearCondaSection,
+  removeCondaDependency as removeCondaDepWasm,
+  setCondaChannels as setCondaChannelsWasm,
+  setCondaPython as setCondaPythonWasm,
+  useCondaDeps,
+} from "../lib/notebook-metadata";
 import type { PixiInfo } from "../types";
 
 export interface CondaDependencies {
@@ -42,9 +49,6 @@ export type CondaSyncState =
   | { status: "dirty" };
 
 export function useCondaDependencies() {
-  const [dependencies, setDependencies] = useState<CondaDependencies | null>(
-    null,
-  );
   const [loading, setLoading] = useState(false);
   // Track if deps were synced to a running kernel (user may need to restart for some changes)
   const [syncedWhileRunning, setSyncedWhileRunning] = useState(false);
@@ -63,16 +67,16 @@ export function useCondaDependencies() {
   const [environmentYmlDeps, setEnvironmentYmlDeps] =
     useState<EnvironmentYmlDeps | null>(null);
 
-  const loadDependencies = useCallback(async () => {
-    try {
-      const deps = await invoke<CondaDependencies | null>(
-        "get_conda_dependencies",
-      );
-      setDependencies(deps);
-    } catch (e) {
-      logger.error("Failed to load conda dependencies:", e);
-    }
-  }, []);
+  // Reactive read from the WASM Automerge doc via useSyncExternalStore.
+  // Re-renders automatically when the doc changes (bootstrap, sync, writes).
+  const condaDeps = useCondaDeps();
+  const dependencies = condaDeps
+    ? {
+        dependencies: condaDeps.dependencies,
+        channels: condaDeps.channels,
+        python: condaDeps.python,
+      }
+    : null;
 
   // Load full environment.yml dependencies
   const loadEnvironmentYmlDeps = useCallback(async () => {
@@ -86,25 +90,13 @@ export function useCondaDependencies() {
     }
   }, []);
 
-  // Load dependencies and detect environment.yml and pixi.toml on mount
+  // Detect environment.yml and pixi.toml on mount
   useEffect(() => {
-    loadDependencies();
     invoke<EnvironmentYmlInfo | null>("detect_environment_yml").then(
       setEnvironmentYmlInfo,
     );
     invoke<PixiInfo | null>("detect_pixi_toml").then(setPixiInfo);
-  }, [loadDependencies]);
-
-  // Re-load when metadata is synced from another window
-  useEffect(() => {
-    const webview = getCurrentWebview();
-    const unlisten = webview.listen("notebook:metadata_updated", () => {
-      loadDependencies();
-    });
-    return () => {
-      unlisten.then((fn) => fn());
-    };
-  }, [loadDependencies]);
+  }, []);
 
   // Load environment.yml deps when we detect one
   useEffect(() => {
@@ -159,11 +151,8 @@ export function useCondaDependencies() {
       if (!pkg.trim()) return;
       setLoading(true);
       try {
-        await invoke("add_conda_dependency", { package: pkg.trim() });
-        await loadDependencies();
-        // Re-sign to keep notebook trusted after user modification
+        await addCondaDepWasm(pkg.trim());
         await resignTrust();
-        // Check sync state — UI will show "Sync Now" if dirty
         await checkSyncState();
       } catch (e) {
         logger.error("Failed to add conda dependency:", e);
@@ -171,18 +160,15 @@ export function useCondaDependencies() {
         setLoading(false);
       }
     },
-    [loadDependencies, resignTrust, checkSyncState],
+    [resignTrust, checkSyncState],
   );
 
   const removeDependency = useCallback(
     async (pkg: string) => {
       setLoading(true);
       try {
-        await invoke("remove_conda_dependency", { package: pkg });
-        await loadDependencies();
-        // Re-sign to keep notebook trusted after user modification
+        await removeCondaDepWasm(pkg);
         await resignTrust();
-        // Check sync state — removing a dep doesn't uninstall from running kernel
         await checkSyncState();
       } catch (e) {
         logger.error("Failed to remove conda dependency:", e);
@@ -190,22 +176,21 @@ export function useCondaDependencies() {
         setLoading(false);
       }
     },
-    [loadDependencies, resignTrust, checkSyncState],
+    [resignTrust, checkSyncState],
   );
 
   // Remove the entire conda dependency section from notebook metadata
   const clearAllDependencies = useCallback(async () => {
     setLoading(true);
     try {
-      await invoke("clear_dependency_section", { section: "conda" });
-      await loadDependencies();
+      await clearCondaSection();
       await resignTrust();
     } catch (e) {
       logger.error("Failed to clear conda dependencies:", e);
     } finally {
       setLoading(false);
     }
-  }, [loadDependencies, resignTrust]);
+  }, [resignTrust]);
 
   // Clear the synced notice (e.g., when kernel restarts)
   const clearSyncNotice = useCallback(() => {
@@ -218,13 +203,7 @@ export function useCondaDependencies() {
     async (channels: string[]) => {
       setLoading(true);
       try {
-        await invoke("set_conda_dependencies", {
-          dependencies: dependencies?.dependencies ?? [],
-          channels,
-          python: dependencies?.python ?? null,
-        });
-        await loadDependencies();
-        // Re-sign to keep notebook trusted after user modification
+        await setCondaChannelsWasm(channels);
         await resignTrust();
       } catch (e) {
         logger.error("Failed to set channels:", e);
@@ -232,20 +211,14 @@ export function useCondaDependencies() {
         setLoading(false);
       }
     },
-    [dependencies, loadDependencies, resignTrust],
+    [resignTrust],
   );
 
   const setPython = useCallback(
     async (version: string | null) => {
       setLoading(true);
       try {
-        await invoke("set_conda_dependencies", {
-          dependencies: dependencies?.dependencies ?? [],
-          channels: dependencies?.channels ?? [],
-          python: version,
-        });
-        await loadDependencies();
-        // Re-sign to keep notebook trusted after user modification
+        await setCondaPythonWasm(version);
         await resignTrust();
       } catch (e) {
         logger.error("Failed to set python version:", e);
@@ -253,7 +226,7 @@ export function useCondaDependencies() {
         setLoading(false);
       }
     },
-    [dependencies, loadDependencies, resignTrust],
+    [resignTrust],
   );
 
   const hasDependencies =
@@ -267,14 +240,13 @@ export function useCondaDependencies() {
     setLoading(true);
     try {
       await invoke("import_pixi_dependencies");
-      await loadDependencies();
       await resignTrust();
     } catch (e) {
       logger.error("Failed to import pixi dependencies:", e);
     } finally {
       setLoading(false);
     }
-  }, [loadDependencies, resignTrust]);
+  }, [resignTrust]);
 
   return {
     dependencies,
@@ -286,7 +258,6 @@ export function useCondaDependencies() {
     syncedWhileRunning,
     needsKernelRestart,
     pixiInfo,
-    loadDependencies,
     addDependency,
     removeDependency,
     clearAllDependencies,

--- a/apps/notebook/src/hooks/useDenoDependencies.ts
+++ b/apps/notebook/src/hooks/useDenoDependencies.ts
@@ -1,7 +1,10 @@
 import { invoke } from "@tauri-apps/api/core";
-import { getCurrentWebview } from "@tauri-apps/api/webview";
 import { useCallback, useEffect, useState } from "react";
 import { logger } from "../lib/logger";
+import {
+  setDenoFlexibleNpmImports as setDenoFlexibleWasm,
+  useDenoFlexibleNpmImports,
+} from "../lib/notebook-metadata";
 
 export interface DenoConfigInfo {
   path: string;
@@ -16,54 +19,20 @@ export function useDenoDependencies() {
   const [denoConfigInfo, setDenoConfigInfo] = useState<DenoConfigInfo | null>(
     null,
   );
-  const [flexibleNpmImports, setFlexibleNpmImportsState] =
-    useState<boolean>(true);
+  // Reactive read from the WASM Automerge doc via useSyncExternalStore.
+  // Re-renders automatically when the doc changes (bootstrap, sync, writes).
+  const flexibleNpmImportsFromDoc = useDenoFlexibleNpmImports();
+  const flexibleNpmImports = flexibleNpmImportsFromDoc ?? true;
 
-  // Load the flexible npm imports setting from notebook metadata
-  const loadFlexibleNpmImports = useCallback(async () => {
-    try {
-      const flexible = await invoke<boolean>("get_deno_flexible_npm_imports");
-      setFlexibleNpmImportsState(flexible);
-    } catch (e) {
-      logger.error("Failed to load flexible npm imports:", e);
-    }
+  // Check Deno availability and detect config on mount
+  useEffect(() => {
+    invoke<boolean>("check_deno_available").then(setDenoAvailable);
+    invoke<DenoConfigInfo | null>("detect_deno_config").then(setDenoConfigInfo);
   }, []);
-
-  // Check Deno availability, detect config, and load settings on mount
-  useEffect(() => {
-    const init = async () => {
-      try {
-        const available = await invoke<boolean>("check_deno_available");
-        setDenoAvailable(available);
-
-        const config = await invoke<DenoConfigInfo | null>(
-          "detect_deno_config",
-        );
-        setDenoConfigInfo(config);
-
-        await loadFlexibleNpmImports();
-      } catch (e) {
-        logger.error("Failed to initialize Deno dependencies:", e);
-      }
-    };
-    init();
-  }, [loadFlexibleNpmImports]);
-
-  // Re-load when metadata is synced from another window
-  useEffect(() => {
-    const webview = getCurrentWebview();
-    const unlisten = webview.listen("notebook:metadata_updated", () => {
-      loadFlexibleNpmImports();
-    });
-    return () => {
-      unlisten.then((fn) => fn());
-    };
-  }, [loadFlexibleNpmImports]);
 
   const setFlexibleNpmImports = useCallback(async (enabled: boolean) => {
     try {
-      await invoke("set_deno_flexible_npm_imports", { enabled });
-      setFlexibleNpmImportsState(enabled);
+      await setDenoFlexibleWasm(enabled);
     } catch (e) {
       logger.error("Failed to set flexible npm imports:", e);
     }

--- a/apps/notebook/src/hooks/useDependencies.ts
+++ b/apps/notebook/src/hooks/useDependencies.ts
@@ -1,7 +1,13 @@
 import { invoke } from "@tauri-apps/api/core";
-import { getCurrentWebview } from "@tauri-apps/api/webview";
 import { useCallback, useEffect, useState } from "react";
 import { logger } from "../lib/logger";
+import {
+  addUvDependency,
+  clearUvSection,
+  removeUvDependency,
+  setUvRequiresPython,
+  useUvDependencies,
+} from "../lib/notebook-metadata";
 
 export interface NotebookDependencies {
   dependencies: string[];
@@ -39,9 +45,6 @@ export interface PyProjectInfo {
 }
 
 export function useDependencies() {
-  const [dependencies, setDependencies] = useState<NotebookDependencies | null>(
-    null,
-  );
   const [uvAvailable, setUvAvailable] = useState<boolean | null>(null);
   const [loading, setLoading] = useState(false);
   // Track if deps were synced to a running kernel (user may need to restart for some changes)
@@ -73,32 +76,15 @@ export function useDependencies() {
     invoke<PyProjectInfo | null>("detect_pyproject").then(setPyprojectInfo);
   }, []);
 
-  const loadDependencies = useCallback(async () => {
-    try {
-      const deps = await invoke<NotebookDependencies | null>(
-        "get_notebook_dependencies",
-      );
-      setDependencies(deps);
-    } catch (e) {
-      logger.error("Failed to load dependencies:", e);
-    }
-  }, []);
-
-  // Load dependencies on mount
-  useEffect(() => {
-    loadDependencies();
-  }, [loadDependencies]);
-
-  // Re-load when metadata is synced from another window
-  useEffect(() => {
-    const webview = getCurrentWebview();
-    const unlisten = webview.listen("notebook:metadata_updated", () => {
-      loadDependencies();
-    });
-    return () => {
-      unlisten.then((fn) => fn());
-    };
-  }, [loadDependencies]);
+  // Reactive read from the WASM Automerge doc via useSyncExternalStore.
+  // Re-renders automatically when the doc changes (bootstrap, sync, writes).
+  const uvDeps = useUvDependencies();
+  const dependencies = uvDeps
+    ? {
+        dependencies: uvDeps.dependencies,
+        requires_python: uvDeps.requiresPython,
+      }
+    : null;
 
   // Re-sign the notebook after user modifications to keep it trusted
   const resignTrust = useCallback(async () => {
@@ -142,11 +128,8 @@ export function useDependencies() {
       if (!pkg.trim()) return;
       setLoading(true);
       try {
-        await invoke("add_dependency", { package: pkg.trim() });
-        await loadDependencies();
-        // Re-sign to keep notebook trusted after user modification
+        await addUvDependency(pkg.trim());
         await resignTrust();
-        // Check sync state - UI will show "Sync Now" if dirty
         await checkSyncState();
       } catch (e) {
         logger.error("Failed to add dependency:", e);
@@ -154,19 +137,15 @@ export function useDependencies() {
         setLoading(false);
       }
     },
-    [loadDependencies, resignTrust, checkSyncState],
+    [resignTrust, checkSyncState],
   );
 
   const removeDependency = useCallback(
     async (pkg: string) => {
       setLoading(true);
       try {
-        await invoke("remove_dependency", { package: pkg });
-        await loadDependencies();
-        // Re-sign to keep notebook trusted after user modification
+        await removeUvDependency(pkg);
         await resignTrust();
-        // Check sync state - UI will show dirty state
-        // Note: removing a dep doesn't uninstall from running kernel
         await checkSyncState();
       } catch (e) {
         logger.error("Failed to remove dependency:", e);
@@ -174,22 +153,21 @@ export function useDependencies() {
         setLoading(false);
       }
     },
-    [loadDependencies, resignTrust, checkSyncState],
+    [resignTrust, checkSyncState],
   );
 
   // Remove the entire uv dependency section from notebook metadata
   const clearAllDependencies = useCallback(async () => {
     setLoading(true);
     try {
-      await invoke("clear_dependency_section", { section: "uv" });
-      await loadDependencies();
+      await clearUvSection();
       await resignTrust();
     } catch (e) {
       logger.error("Failed to clear UV dependencies:", e);
     } finally {
       setLoading(false);
     }
-  }, [loadDependencies, resignTrust]);
+  }, [resignTrust]);
 
   // Clear the synced notice (e.g., when kernel restarts)
   const clearSyncNotice = useCallback(() => {
@@ -201,12 +179,7 @@ export function useDependencies() {
     async (version: string | null) => {
       setLoading(true);
       try {
-        await invoke("set_notebook_dependencies", {
-          dependencies: dependencies?.dependencies ?? [],
-          requiresPython: version,
-        });
-        await loadDependencies();
-        // Re-sign to keep notebook trusted after user modification
+        await setUvRequiresPython(version);
         await resignTrust();
       } catch (e) {
         logger.error("Failed to set requires-python:", e);
@@ -214,7 +187,7 @@ export function useDependencies() {
         setLoading(false);
       }
     },
-    [dependencies, loadDependencies, resignTrust],
+    [resignTrust],
   );
 
   const hasDependencies =
@@ -247,7 +220,6 @@ export function useDependencies() {
     setLoading(true);
     try {
       await invoke("import_pyproject_dependencies");
-      await loadDependencies();
       // Re-sign to keep notebook trusted after user modification
       await resignTrust();
       logger.info("[deps] Imported dependencies from pyproject.toml");
@@ -256,7 +228,7 @@ export function useDependencies() {
     } finally {
       setLoading(false);
     }
-  }, [loadDependencies, resignTrust]);
+  }, [resignTrust]);
 
   // Refresh pyproject detection
   const refreshPyproject = useCallback(async () => {
@@ -277,7 +249,7 @@ export function useDependencies() {
     loading,
     syncedWhileRunning,
     needsKernelRestart,
-    loadDependencies,
+
     addDependency,
     removeDependency,
     clearAllDependencies,

--- a/apps/notebook/src/lib/notebook-metadata.ts
+++ b/apps/notebook/src/lib/notebook-metadata.ts
@@ -1,0 +1,478 @@
+import { invoke } from "@tauri-apps/api/core";
+import { useMemo, useSyncExternalStore } from "react";
+import type { NotebookHandle } from "../wasm/runtimed-wasm/runtimed_wasm.js";
+import { logger } from "./logger";
+
+// ---------------------------------------------------------------------------
+// Reactive metadata store backed by the WASM Automerge document.
+//
+// useAutomergeNotebook owns the WASM NotebookHandle and registers it here.
+// React hooks use useSyncExternalStore to subscribe — they re-render
+// automatically when the doc changes (bootstrap, sync, writes).
+//
+// One store per window. Safe because there's exactly one notebook
+// (one handle) per window.
+// ---------------------------------------------------------------------------
+
+let _handle: NotebookHandle | null = null;
+let _snapshotCache: string | null = null;
+const _subscribers = new Set<() => void>();
+
+/**
+ * Notify all useSyncExternalStore subscribers that the doc changed.
+ * Call this after any operation that mutates the Automerge document:
+ * - setNotebookHandle (bootstrap / reconnect)
+ * - receive_sync_message (incoming daemon sync)
+ * - set_metadata (local writes)
+ */
+export function notifyMetadataChanged(): void {
+  _snapshotCache = _handle?.get_metadata_snapshot_json() ?? null;
+  for (const cb of _subscribers) cb();
+}
+
+/**
+ * Register the active NotebookHandle. Called by useAutomergeNotebook
+ * after bootstrap and cleared on unmount.
+ */
+export function setNotebookHandle(handle: NotebookHandle | null): void {
+  _handle = handle;
+  notifyMetadataChanged();
+}
+
+/**
+ * Subscribe to metadata changes. Used by useSyncExternalStore.
+ */
+function subscribe(callback: () => void): () => void {
+  _subscribers.add(callback);
+  return () => _subscribers.delete(callback);
+}
+
+/**
+ * Get the current metadata snapshot as a JSON string.
+ * Used as the getSnapshot function for useSyncExternalStore.
+ * Returns the cached value — only updated when notifyMetadataChanged() fires.
+ */
+function getSnapshotJson(): string | null {
+  // _snapshotCache is always set by notifyMetadataChanged() before
+  // any subscriber fires. This lazy init handles the first read
+  // before any notification has occurred.
+  if (_snapshotCache === null) {
+    _snapshotCache = _handle?.get_metadata_snapshot_json() ?? null;
+  }
+  return _snapshotCache;
+}
+
+// ---------------------------------------------------------------------------
+// React hooks — reactive metadata reads via useSyncExternalStore.
+// ---------------------------------------------------------------------------
+
+/**
+ * React hook: subscribe to the full metadata snapshot.
+ * Re-renders when the Automerge doc changes (bootstrap, sync, writes).
+ */
+export function useNotebookMetadata(): NotebookMetadataSnapshot | null {
+  const json = useSyncExternalStore(subscribe, getSnapshotJson);
+  return useMemo(() => {
+    if (!json) return null;
+    try {
+      return JSON.parse(json) as NotebookMetadataSnapshot;
+    } catch {
+      return null;
+    }
+  }, [json]);
+}
+
+/**
+ * React hook: detect the notebook runtime from metadata.
+ * Returns "python", "deno", or null.
+ */
+export function useDetectRuntime(): "python" | "deno" | null {
+  const snapshot = useNotebookMetadata();
+  if (!snapshot) return null;
+
+  // Check kernelspec.name first
+  if (snapshot.kernelspec) {
+    const name = snapshot.kernelspec.name.toLowerCase();
+    if (name.includes("deno")) return "deno";
+    if (name.includes("python")) return "python";
+    // Check kernelspec.language
+    if (snapshot.kernelspec.language) {
+      const lang = snapshot.kernelspec.language.toLowerCase();
+      if (lang === "typescript" || lang === "javascript") return "deno";
+      if (lang === "python") return "python";
+    }
+  }
+
+  // Fall back to language_info.name
+  if (snapshot.language_info) {
+    const name = snapshot.language_info.name.toLowerCase();
+    if (name === "deno" || name === "typescript" || name === "javascript")
+      return "deno";
+    if (name === "python") return "python";
+  }
+
+  // Fall back to runt.deno existing (legacy notebooks without kernelspec)
+  if (snapshot.runt.deno) return "deno";
+
+  return null;
+}
+
+/**
+ * React hook: read UV inline dependencies.
+ * Returns a stable object reference (via useMemo) to avoid unnecessary
+ * re-renders in consumers that use the result as a dependency or prop.
+ */
+export function useUvDependencies(): {
+  dependencies: string[];
+  requiresPython: string | null;
+} | null {
+  const snapshot = useNotebookMetadata();
+  const deps = snapshot?.runt?.uv?.dependencies;
+  const requiresPython = snapshot?.runt?.uv?.["requires-python"] ?? null;
+  return useMemo(() => {
+    if (!deps) return null;
+    return { dependencies: deps, requiresPython };
+  }, [deps, requiresPython]);
+}
+
+/**
+ * React hook: read Conda inline dependencies.
+ * Returns a stable object reference (via useMemo).
+ */
+export function useCondaDeps(): {
+  dependencies: string[];
+  channels: string[];
+  python: string | null;
+} | null {
+  const snapshot = useNotebookMetadata();
+  const deps = snapshot?.runt?.conda?.dependencies;
+  const channels = snapshot?.runt?.conda?.channels;
+  const python = snapshot?.runt?.conda?.python ?? null;
+  return useMemo(() => {
+    if (!deps || !channels) return null;
+    return { dependencies: deps, channels, python };
+  }, [deps, channels, python]);
+}
+
+/**
+ * React hook: read the Deno flexible_npm_imports setting.
+ */
+export function useDenoFlexibleNpmImports(): boolean | null {
+  const snapshot = useNotebookMetadata();
+  if (!snapshot?.runt?.deno) return null;
+  return snapshot.runt.deno.flexible_npm_imports ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// TypeScript interface matching the Rust NotebookMetadataSnapshot serde shape.
+// Kept in sync with crates/notebook-doc/src/metadata.rs.
+// ---------------------------------------------------------------------------
+
+export interface KernelspecSnapshot {
+  name: string;
+  display_name: string;
+  language?: string;
+}
+
+export interface LanguageInfoSnapshot {
+  name: string;
+  version?: string;
+}
+
+export interface UvInlineMetadata {
+  dependencies: string[];
+  "requires-python"?: string;
+}
+
+export interface CondaInlineMetadata {
+  dependencies: string[];
+  channels: string[];
+  python?: string;
+}
+
+export interface DenoMetadata {
+  permissions: string[];
+  import_map?: string;
+  config?: string;
+  flexible_npm_imports?: boolean;
+}
+
+export interface RuntMetadata {
+  schema_version: string;
+  env_id?: string;
+  uv?: UvInlineMetadata;
+  conda?: CondaInlineMetadata;
+  deno?: DenoMetadata;
+  trust_signature?: string;
+  trust_timestamp?: string;
+}
+
+export interface NotebookMetadataSnapshot {
+  kernelspec?: KernelspecSnapshot;
+  language_info?: LanguageInfoSnapshot;
+  runt: RuntMetadata;
+}
+
+// ---------------------------------------------------------------------------
+// Imperative read — used by write helpers that need the current snapshot.
+// Prefer the React hooks (useNotebookMetadata, etc.) for component reads.
+// ---------------------------------------------------------------------------
+
+/**
+ * Read the full typed metadata snapshot imperatively.
+ * Used internally by write helpers. Components should use useNotebookMetadata().
+ */
+function getMetadataSnapshot(): NotebookMetadataSnapshot | null {
+  if (!_handle) return null;
+  const json = _handle.get_metadata_snapshot_json();
+  if (!json) return null;
+  try {
+    return JSON.parse(json) as NotebookMetadataSnapshot;
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Write functions — mutate the WASM doc and sync to the Tauri relay.
+// ---------------------------------------------------------------------------
+
+/**
+ * Write a metadata snapshot to the WASM doc and sync to the relay.
+ * After this returns, both the WASM doc and the relay's doc have the update.
+ */
+export async function setMetadataSnapshot(
+  snapshot: NotebookMetadataSnapshot,
+): Promise<boolean> {
+  if (!_handle) return false;
+  try {
+    const json = JSON.stringify(snapshot);
+    _handle.set_metadata("notebook_metadata", json);
+    await syncToRelay();
+    notifyMetadataChanged();
+    return true;
+  } catch (e) {
+    logger.error("[notebook-metadata] setMetadataSnapshot failed:", e);
+    return false;
+  }
+}
+
+/**
+ * Generate a sync message from the WASM doc and send it to the Tauri relay.
+ * After the invoke returns, the relay's Automerge doc has the update.
+ */
+async function syncToRelay(): Promise<void> {
+  if (!_handle) return;
+  const msg = _handle.generate_sync_message();
+  if (msg) {
+    await invoke("send_automerge_sync", {
+      syncMessage: Array.from(msg),
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Package name extraction for dedup (ported from Rust).
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract the base package name from a dependency specifier.
+ * "pandas>=2.0" → "pandas", "numpy" → "numpy", "requests[security]" → "requests"
+ */
+function extractPackageName(spec: string): string {
+  return spec.split(/[>=<!~[;@\s]/)[0].toLowerCase();
+}
+
+// ---------------------------------------------------------------------------
+// UV dependency write helpers.
+// ---------------------------------------------------------------------------
+
+/**
+ * Add a UV dependency, deduplicating by package name (case-insensitive).
+ * Returns the updated dependencies list, or null on failure.
+ */
+export async function addUvDependency(pkg: string): Promise<string[] | null> {
+  const snapshot = getMetadataSnapshot();
+  if (!snapshot) return null;
+
+  const uv = snapshot.runt.uv ?? { dependencies: [] };
+  const name = extractPackageName(pkg);
+
+  // Deduplicate: replace existing entry for the same package
+  const filtered = uv.dependencies.filter(
+    (d) => extractPackageName(d) !== name,
+  );
+  filtered.push(pkg);
+
+  snapshot.runt.uv = { ...uv, dependencies: filtered };
+  const ok = await setMetadataSnapshot(snapshot);
+  return ok ? filtered : null;
+}
+
+/**
+ * Remove a UV dependency by package name (case-insensitive match).
+ * Returns the updated dependencies list, or null on failure.
+ */
+export async function removeUvDependency(
+  pkg: string,
+): Promise<string[] | null> {
+  const snapshot = getMetadataSnapshot();
+  if (!snapshot?.runt?.uv) return null;
+
+  const name = extractPackageName(pkg);
+  const filtered = snapshot.runt.uv.dependencies.filter(
+    (d) => extractPackageName(d) !== name,
+  );
+
+  snapshot.runt.uv = { ...snapshot.runt.uv, dependencies: filtered };
+  const ok = await setMetadataSnapshot(snapshot);
+  return ok ? filtered : null;
+}
+
+/**
+ * Clear the UV dependency section entirely.
+ */
+export async function clearUvSection(): Promise<boolean> {
+  const snapshot = getMetadataSnapshot();
+  if (!snapshot) return false;
+
+  delete snapshot.runt.uv;
+  return setMetadataSnapshot(snapshot);
+}
+
+/**
+ * Set UV requires-python constraint.
+ */
+export async function setUvRequiresPython(
+  requiresPython: string | null,
+): Promise<boolean> {
+  const snapshot = getMetadataSnapshot();
+  if (!snapshot?.runt?.uv) return false;
+
+  if (requiresPython) {
+    snapshot.runt.uv["requires-python"] = requiresPython;
+  } else {
+    delete snapshot.runt.uv["requires-python"];
+  }
+  return setMetadataSnapshot(snapshot);
+}
+
+// ---------------------------------------------------------------------------
+// Conda dependency write helpers.
+// ---------------------------------------------------------------------------
+
+/**
+ * Add a Conda dependency, deduplicating by package name (case-insensitive).
+ */
+export async function addCondaDependency(
+  pkg: string,
+): Promise<string[] | null> {
+  const snapshot = getMetadataSnapshot();
+  if (!snapshot) return null;
+
+  const conda = snapshot.runt.conda ?? {
+    dependencies: [],
+    channels: ["conda-forge"],
+  };
+  const name = extractPackageName(pkg);
+
+  const filtered = conda.dependencies.filter(
+    (d) => extractPackageName(d) !== name,
+  );
+  filtered.push(pkg);
+
+  snapshot.runt.conda = { ...conda, dependencies: filtered };
+  const ok = await setMetadataSnapshot(snapshot);
+  return ok ? filtered : null;
+}
+
+/**
+ * Remove a Conda dependency by package name.
+ */
+export async function removeCondaDependency(
+  pkg: string,
+): Promise<string[] | null> {
+  const snapshot = getMetadataSnapshot();
+  if (!snapshot?.runt?.conda) return null;
+
+  const name = extractPackageName(pkg);
+  const filtered = snapshot.runt.conda.dependencies.filter(
+    (d) => extractPackageName(d) !== name,
+  );
+
+  snapshot.runt.conda = { ...snapshot.runt.conda, dependencies: filtered };
+  const ok = await setMetadataSnapshot(snapshot);
+  return ok ? filtered : null;
+}
+
+/**
+ * Clear the Conda dependency section entirely.
+ */
+export async function clearCondaSection(): Promise<boolean> {
+  const snapshot = getMetadataSnapshot();
+  if (!snapshot) return false;
+
+  delete snapshot.runt.conda;
+  return setMetadataSnapshot(snapshot);
+}
+
+/**
+ * Set Conda channels, preserving other conda fields.
+ * Creates the conda section if it doesn't exist yet.
+ */
+export async function setCondaChannels(channels: string[]): Promise<boolean> {
+  const snapshot = getMetadataSnapshot();
+  if (!snapshot) return false;
+
+  const conda = snapshot.runt.conda ?? {
+    dependencies: [],
+    channels: [],
+  };
+  snapshot.runt.conda = { ...conda, channels };
+  return setMetadataSnapshot(snapshot);
+}
+
+/**
+ * Set Conda python version, preserving other conda fields.
+ * Creates the conda section if it doesn't exist yet.
+ */
+export async function setCondaPython(python: string | null): Promise<boolean> {
+  const snapshot = getMetadataSnapshot();
+  if (!snapshot) return false;
+
+  const conda = snapshot.runt.conda ?? {
+    dependencies: [],
+    channels: ["conda-forge"],
+  };
+  if (python) {
+    conda.python = python;
+  } else {
+    delete conda.python;
+  }
+  snapshot.runt.conda = conda;
+  return setMetadataSnapshot(snapshot);
+}
+
+// ---------------------------------------------------------------------------
+// Deno config write helpers.
+// ---------------------------------------------------------------------------
+
+/**
+ * Set the flexible_npm_imports setting for Deno notebooks.
+ */
+export async function setDenoFlexibleNpmImports(
+  enabled: boolean,
+): Promise<boolean> {
+  const snapshot = getMetadataSnapshot();
+  if (!snapshot) return false;
+
+  if (!snapshot.runt.deno) {
+    snapshot.runt.deno = { permissions: [], flexible_npm_imports: enabled };
+  } else {
+    snapshot.runt.deno = {
+      ...snapshot.runt.deno,
+      flexible_npm_imports: enabled,
+    };
+  }
+  return setMetadataSnapshot(snapshot);
+}


### PR DESCRIPTION
Migrates metadata reads and writes from Tauri IPC to the frontend's local WASM Automerge document. Uses React 18's `useSyncExternalStore` for reactive metadata subscriptions — hooks re-render automatically when the doc changes.

## Architecture

The WASM `NotebookHandle` is the metadata store. Three events notify subscribers:
- `setNotebookHandle()` — bootstrap / reconnect
- `receive_sync_message()` — incoming daemon Automerge sync
- `setMetadataSnapshot()` — local writes (add/remove deps)

React hooks subscribe via `useSyncExternalStore(subscribe, getSnapshotJson)`.

## New reactive hooks (`notebook-metadata.ts`)

| Hook | Replaces |
|------|----------|
| `useNotebookMetadata()` | `invoke("get_notebook_dependencies")` + `invoke("get_conda_dependencies")` + event listeners |
| `useDetectRuntime()` | `invoke("get_notebook_runtime")` + event listeners |
| `useUvDependencies()` | `invoke("get_notebook_dependencies")` + `loadDependencies()` callback chain |
| `useCondaDeps()` | `invoke("get_conda_dependencies")` + `loadDependencies()` callback chain |
| `useDenoFlexibleNpmImports()` | `invoke("get_deno_flexible_npm_imports")` + `loadFlexibleNpmImports()` callback chain |

## Write path

Dependency mutations (add, remove, clear, set channels/python) go through WASM:
1. Read current metadata from WASM doc
2. Mutate in TypeScript (with case-insensitive package name dedup)
3. Write back via `handle.set_metadata()` + `generate_sync_message()` → `invoke("send_automerge_sync")`
4. `notifyMetadataChanged()` → subscribers re-render with new state
5. `invoke("approve_notebook_trust")` for HMAC re-signing (stays in Tauri — needs filesystem access)

## What was removed

- `onNotebookHandleReady` callback pattern (replaced by `useSyncExternalStore`)
- `loadDependencies()` / `loadFlexibleNpmImports()` imperative read functions
- `notebook:metadata_updated` event listeners in dependency hooks
- Manual re-read calls after every write operation
- Dead Tauri commands: `get_deno_permissions`, `set_deno_permissions`

## Review fixes

- Codex: `setCondaChannels`/`setCondaPython` now create the conda section if absent (was silently failing)
- Codex: Added `language_info.name == "deno"` fallback to runtime detection
- Opus: Derived hooks wrapped in `useMemo` for stable object identity
- Opus: Simplified `getSnapshotJson` defensive check
- Opus: Added comment about cell mutations not notifying metadata subscribers

## QA

### UV dependencies
- [x] New notebook: add UV dep → pillbox appears immediately
- [x] Add second dep → both pillboxes show
- [x] Remove a dep → pillbox disappears
- [ ] Clear all deps → "No inline dependencies" message returns
- [ ] Set requires-python version

### Existing notebooks
- [x] Open saved notebook with existing UV deps → pillboxes show on load
- [x] Open saved notebook with legacy `metadata.uv` format (pre-runt namespace) → deps show after trust approval

### Conda dependencies
- [x] Add conda dep → pillbox appears
- [x] Remove conda dep → pillbox disappears
- [x] Set channels on notebook without existing conda section → creates section
- [x] Set python version on notebook without existing conda section → creates section

### Runtime detection
- [x] File > New Notebook → shows "Python"
- [x] File > New Notebook As > Deno → shows "Deno"
- [x] Open existing Deno notebook → shows "Deno"

### Deno config
- [x] Toggle flexible npm imports on Deno notebook → setting persists

### Cross-window
- [x] Add dep in window A, window B updates via Automerge sync

### Import from project files
- [x] Import from pyproject.toml → deps appear (may have brief delay for sync round-trip)
- [x] Import from pixi.toml → deps appear

### Trust
- [x] Untrusted notebook shows trust banner
- [x] Trust & Start approves and launches kernel
- [x] Adding deps re-signs trust automatically

### Save / Clone
- [x] Save notebook with deps → deps persist in .ipynb
- [x] Clone notebook with deps → cloned notebook has deps