### PR TITLE
chore(deps): upgrade runtimelib to 1.5.0 and nbformat to 1.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3385,9 +3385,9 @@ dependencies = [
 
 [[package]]
 name = "nbformat"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4983a40792c45e8639f77ef8e4461c55679cbc618f4b9e83830e8c7e79c8383"
+checksum = "fb4717d82ad8b09135fb2a2a65460786a8410fcca25cebe266990a8e9646b65d"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5635,9 +5635,9 @@ dependencies = [
 
 [[package]]
 name = "runtimelib"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa84884e45ed4a1e663120cef3fc11f14d1a2a1933776e1c31599f7bd2dd0c9e"
+checksum = "524187cd923df8c146810a9f09be45fcaf4e5ba168f22f5f85598ca3c08c9202"
 dependencies = [
  "aws-lc-rs",
  "base64 0.22.1",
@@ -8990,9 +8990,9 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zeromq"
-version = "0.5.0"
+version = "0.6.0-pre.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b32e1e46c4e278efd0c1153f2db0113924b9bc5fff9f9221853d035e2d26fadf"
+checksum = "f06ccf13d2d6709a7463d175b88598c88a5dc63c8907ffb6f32a8a16baf77c1f"
 dependencies = [
  "async-trait",
  "asynchronous-codec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ futures = "0.3"
 bytes = "1"
 base64 = "0.22"
 tokio = { version = "1.36.0", features = ["full"] }
-runtimelib = { version = "1.4.0", default-features = false }
+runtimelib = { version = "1.5.0", default-features = false }
 jupyter-protocol = "1.4.0"
 thiserror = "1"
 schemars = "1"

--- a/crates/notebook/Cargo.toml
+++ b/crates/notebook/Cargo.toml
@@ -41,7 +41,7 @@ runt-trust = { path = "../runt-trust" }
 runt-workspace = { path = "../runt-workspace" }
 kernel-launch = { path = "../kernel-launch" }
 kernel-env = { path = "../kernel-env" }
-nbformat = "1.2.0"
+nbformat = "1.2.1"
 petname = "2"
 log = "0.4"
 env_logger = "0.11"

--- a/crates/runtimed/Cargo.toml
+++ b/crates/runtimed/Cargo.toml
@@ -99,5 +99,5 @@ windows-sys = { version = "0.52", features = ["Win32_Storage_FileSystem", "Win32
 
 [dev-dependencies]
 tempfile = "3"
-nbformat = "1.2.0"
+nbformat = "1.2.1"
 tokio = { version = "1.36.0", features = ["full", "test-util"] }


### PR DESCRIPTION
## Summary

Upgrades runtimelib from 1.4.0 to 1.5.0, nbformat from 1.2.0 to 1.2.1, and zeromq dependency. The nbformat 1.2.1 release includes a fix for deserialization crashes when loading pre-nbformat 4.5 notebooks that lack cell IDs.

## Verification

- [x] Clippy checks pass with `-D warnings`
- [x] All unit and integration tests pass
- [x] Rust and TypeScript formatting verified

_PR submitted by @rgbkrk's agent, Quill_