### PR TITLE
feat(notebook): show native error dialog for notebook load failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1268,6 +1268,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dlib"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
+dependencies = [
+ "libloading 0.7.4",
+]
+
+[[package]]
 name = "dlopen2"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1289,6 +1298,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "dpi"
@@ -3504,6 +3519,7 @@ dependencies = [
  "rattler_virtual_packages",
  "reqwest 0.12.28",
  "reqwest-middleware",
+ "rfd 0.17.2",
  "runt-trust",
  "runt-workspace",
  "runtimed",
@@ -4368,6 +4384,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pollster"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4642,6 +4664,15 @@ name = "quick-xml"
 version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.39.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
 dependencies = [
  "memchr",
 ]
@@ -5440,6 +5471,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfd"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20dafead71c16a34e1ff357ddefc8afc11e7d51d6d2b9fbd07eaa48e3e540220"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "js-sys",
+ "libc",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "percent-encoding",
+ "pollster",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "web-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5907,6 +5965,12 @@ dependencies = [
  "serde_derive_internals",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -6873,7 +6937,7 @@ checksum = "9204b425d9be8d12aa60c2a83a289cf7d1caae40f57f336ed1155b3a5c0e359b"
 dependencies = [
  "log",
  "raw-window-handle",
- "rfd",
+ "rfd 0.16.0",
  "serde",
  "serde_json",
  "tauri",
@@ -8013,6 +8077,66 @@ dependencies = [
  "pin-utils",
  "slab",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "wayland-backend"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa75f400b7f719bcd68b3f47cd939ba654cedeef690f486db71331eec4c6a406"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix 1.1.3",
+ "scoped-tls",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab51d9f7c071abeee76007e2b742499e535148035bb835f97aaed1338cf516c3"
+dependencies = [
+ "bitflags 2.11.0",
+ "rustix 1.1.3",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b23b5df31ceff1328f06ac607591d5ba360cf58f90c8fad4ac8d3a55a3c4aec7"
+dependencies = [
+ "bitflags 2.11.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c86287151a309799b821ca709b7345a048a2956af05957c89cb824ab919fa4e3"
+dependencies = [
+ "proc-macro2",
+ "quick-xml 0.39.2",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "374f6b70e8e0d6bf9461a32988fd553b59ff630964924dad6e4a4eb6bd538d17"
+dependencies = [
+ "dlib",
+ "log",
+ "pkg-config",
 ]
 
 [[package]]

--- a/crates/notebook/Cargo.toml
+++ b/crates/notebook/Cargo.toml
@@ -68,6 +68,7 @@ rattler_solve = { version = "4.2", features = ["resolvo"] }
 rattler_virtual_packages = "2.3"
 reqwest = { version = "0.12", default-features = false, features = ["native-tls"] }
 reqwest-middleware = "0.4"
+rfd = "0.17"  # Native dialogs for pre-window error display
 url = "2.5"
 
 # WebDriver test server (native E2E testing without Docker)

--- a/crates/notebook/src/main.rs
+++ b/crates/notebook/src/main.rs
@@ -27,5 +27,20 @@ fn main() {
     #[cfg(not(feature = "webdriver-test"))]
     let webdriver_port: Option<u16> = None;
 
-    notebook::run(args.path, args.runtime, webdriver_port).expect("notebook app failed");
+    if let Err(e) = notebook::run(args.path.clone(), args.runtime, webdriver_port) {
+        // Show native error dialog before exiting
+        let title = "Cannot Open Notebook";
+        let message = match &args.path {
+            Some(path) => format!("Failed to open '{}':\n\n{}", path.display(), e),
+            None => format!("Failed to start notebook:\n\n{}", e),
+        };
+
+        rfd::MessageDialog::new()
+            .set_title(title)
+            .set_description(&message)
+            .set_level(rfd::MessageLevel::Error)
+            .show();
+
+        std::process::exit(1);
+    }
 }


### PR DESCRIPTION
## Summary

When notebook loading fails (invalid file, parsing errors, permission denied), the app now displays a native error dialog instead of silently crashing. Users see a clear message with the file path and error details.

## Example

**Before:** App crashes silently, stderr shows "notebook app failed". Users probably don't see stderr.
**After:** Native macOS error dialog appears with "Cannot Open Notebook" and the specific error

<img width="372" height="344" alt="image" src="https://github.com/user-attachments/assets/0d3cd829-75a0-472c-80ff-ef54a0c10ff0" />

## Implementation

- Added `rfd` dependency for native dialogs
- Modified `main.rs` to catch errors before process exit
- Replaces `.expect()` panic with user-friendly error message

_PR submitted by @rgbkrk's agent, Quill_