### PR TITLE
chore: enforce no-panic lints to prevent crashes in user code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,12 @@ unused_variables = "warn"
 [workspace.lints.clippy]
 all = { level = "warn", priority = -1 }
 
+# Prevent panics in user-facing code - crashes are terrible UX.
+# CI runs `clippy -- -D warnings` so these become errors in CI.
+# Use #[allow(clippy::unwrap_used)] with a comment explaining why it's safe.
+unwrap_used = "warn"
+expect_used = "warn"
+
 [profile.release]
 opt-level = 'z'
 strip = true

--- a/crates/kernel-env/src/conda.rs
+++ b/crates/kernel-env/src/conda.rs
@@ -866,6 +866,7 @@ async fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/crates/kernel-env/src/progress.rs
+++ b/crates/kernel-env/src/progress.rs
@@ -1,3 +1,7 @@
+// RwLock::read/write only fail if another thread panicked while holding the lock.
+// In that case the program is already crashing, so unwrap is acceptable here.
+#![allow(clippy::unwrap_used)]
+
 //! Progress reporting for environment operations.
 //!
 //! Provides [`EnvProgressPhase`] events covering the full lifecycle of

--- a/crates/kernel-env/src/uv.rs
+++ b/crates/kernel-env/src/uv.rs
@@ -637,6 +637,7 @@ async fn copy_dir_recursive(src: &Path, dst: &Path) -> Result<()> {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/crates/kernel-launch/src/tools.rs
+++ b/crates/kernel-launch/src/tools.rs
@@ -818,6 +818,7 @@ pub async fn get_uv_path() -> Result<PathBuf> {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -965,6 +965,7 @@ pub fn get_cells_from_doc(doc: &AutoCommit) -> Vec<CellSnapshot> {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/crates/notebook-doc/src/metadata.rs
+++ b/crates/notebook-doc/src/metadata.rs
@@ -326,6 +326,7 @@ impl RuntMetadata {
 pub const NOTEBOOK_METADATA_KEY: &str = "notebook_metadata";
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/crates/notebook/src/conda_env.rs
+++ b/crates/notebook/src/conda_env.rs
@@ -199,6 +199,7 @@ pub async fn sync_dependencies(env: &CondaEnvironment, deps: &CondaDependencies)
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/crates/notebook/src/deno_env.rs
+++ b/crates/notebook/src/deno_env.rs
@@ -330,6 +330,7 @@ fn strip_jsonc_comments(content: &str) -> String {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use std::io::Write;

--- a/crates/notebook/src/environment_yml.rs
+++ b/crates/notebook/src/environment_yml.rs
@@ -258,6 +258,7 @@ pub fn get_all_dependencies(config: &EnvironmentYmlConfig) -> (Vec<String>, Vec<
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use std::io::Write;

--- a/crates/notebook/src/format.rs
+++ b/crates/notebook/src/format.rs
@@ -155,6 +155,7 @@ pub async fn format_deno(source: &str, language: &str) -> Result<FormatResult> {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -624,6 +624,7 @@ async fn initialize_notebook_sync(
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::next_available_sample_path;
     use tempfile::TempDir;

--- a/crates/notebook/src/menu.rs
+++ b/crates/notebook/src/menu.rs
@@ -295,6 +295,7 @@ pub fn create_menu(
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::{
         about_menu_label, app_name, build_about_metadata, sample_for_menu_item_id,

--- a/crates/notebook/src/notebook_state.rs
+++ b/crates/notebook/src/notebook_state.rs
@@ -598,6 +598,7 @@ fn empty_cell_metadata() -> CellMetadata {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/crates/notebook/src/pixi.rs
+++ b/crates/notebook/src/pixi.rs
@@ -320,6 +320,7 @@ impl PixiConfig {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use std::io::Write;

--- a/crates/notebook/src/project_file.rs
+++ b/crates/notebook/src/project_file.rs
@@ -91,6 +91,7 @@ pub fn find_nearest_project_file(
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use tempfile::TempDir;

--- a/crates/notebook/src/pyproject.rs
+++ b/crates/notebook/src/pyproject.rs
@@ -195,6 +195,7 @@ pub fn get_all_dependencies(config: &PyProjectConfig) -> Vec<String> {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use std::io::Write;

--- a/crates/notebook/src/settings.rs
+++ b/crates/notebook/src/settings.rs
@@ -84,6 +84,7 @@ pub fn load_settings() -> SyncedSettings {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/crates/notebook/src/shell_env.rs
+++ b/crates/notebook/src/shell_env.rs
@@ -177,6 +177,7 @@ fn apply_well_known_paths() {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/crates/notebook/src/typosquat.rs
+++ b/crates/notebook/src/typosquat.rs
@@ -249,7 +249,7 @@ pub fn check_typosquat(package: &str) -> Option<TyposquatWarning> {
         }
 
         // Check if within threshold and better than current best
-        if distance <= threshold && (best_match.is_none() || distance < best_match.unwrap().1) {
+        if distance <= threshold && best_match.as_ref().is_none_or(|(_, d)| distance < *d) {
             best_match = Some((popular, distance));
         }
     }
@@ -272,6 +272,7 @@ pub fn check_packages(packages: &[String]) -> Vec<TyposquatWarning> {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/crates/notebook/src/uv_env.rs
+++ b/crates/notebook/src/uv_env.rs
@@ -170,6 +170,7 @@ pub async fn sync_dependencies(env: &UvEnvironment, deps: &[String]) -> Result<(
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/crates/notebook/tests/env_fallback.rs
+++ b/crates/notebook/tests/env_fallback.rs
@@ -1,3 +1,6 @@
+// Tests can use unwrap/expect freely - panics are acceptable in test code
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
 //! Integration tests for UV support and Rattler conda fallback.
 //!
 //! These tests verify the happy paths for environment detection and creation:

--- a/crates/runt-trust/src/lib.rs
+++ b/crates/runt-trust/src/lib.rs
@@ -299,6 +299,7 @@ pub fn sign_notebook_dependencies(
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use serial_test::serial;

--- a/crates/runt-workspace/src/lib.rs
+++ b/crates/runt-workspace/src/lib.rs
@@ -308,6 +308,7 @@ fn ensure_dir_exists(dir: &Path) -> Result<(), String> {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -3303,6 +3303,7 @@ async fn debug_session(
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     /// Test that the shutdown command correctly identifies UUIDs vs file paths.
     /// This is critical for handling both saved notebooks (paths) and untitled

--- a/crates/runtimed/src/blob_server.rs
+++ b/crates/runtimed/src/blob_server.rs
@@ -112,6 +112,7 @@ async fn serve_blob(store: &BlobStore, hash: &str) -> Response<Full<Bytes>> {
 }
 
 /// Build a simple text response.
+#[allow(clippy::expect_used)] // Response::builder only fails with invalid StatusCode, we use valid enum values
 fn text_response(status: StatusCode, body: &str) -> Response<Full<Bytes>> {
     Response::builder()
         .status(status)
@@ -121,6 +122,7 @@ fn text_response(status: StatusCode, body: &str) -> Response<Full<Bytes>> {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use tempfile::TempDir;

--- a/crates/runtimed/src/blob_store.rs
+++ b/crates/runtimed/src/blob_store.rs
@@ -246,6 +246,7 @@ impl BlobStore {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use tempfile::TempDir;

--- a/crates/runtimed/src/client.rs
+++ b/crates/runtimed/src/client.rs
@@ -692,6 +692,7 @@ pub async fn subscribe_pool_state(
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/crates/runtimed/src/comm_state.rs
+++ b/crates/runtimed/src/comm_state.rs
@@ -302,6 +302,7 @@ impl Default for CommState {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/crates/runtimed/src/connection.rs
+++ b/crates/runtimed/src/connection.rs
@@ -247,6 +247,7 @@ pub async fn recv_json_frame<R: AsyncRead + Unpin, T: DeserializeOwned>(
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -2105,6 +2105,7 @@ print("warmup complete")
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use std::path::PathBuf;

--- a/crates/runtimed/src/kernel_manager.rs
+++ b/crates/runtimed/src/kernel_manager.rs
@@ -1,3 +1,8 @@
+// Mutex::lock only fails if another thread panicked while holding the lock.
+// In that case the program is already crashing, so unwrap is acceptable here.
+// The shell_writer unwrap at line 1713 is guarded by an early-return check at line 1681.
+#![allow(clippy::unwrap_used)]
+
 //! Daemon-owned kernel management for notebook rooms.
 //!
 //! Each notebook room can have one kernel. The daemon owns the kernel lifecycle

--- a/crates/runtimed/src/notebook_sync_client.rs
+++ b/crates/runtimed/src/notebook_sync_client.rs
@@ -2050,6 +2050,7 @@ enum ReceivedFrame {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -559,6 +559,7 @@ impl NotebookRoom {
     /// For normal operation, `new_fresh` is used to ensure the .ipynb file
     /// is the source of truth.
     #[cfg(test)]
+    #[allow(clippy::unwrap_used, clippy::expect_used)]
     pub fn load_or_create(notebook_id: &str, docs_dir: &Path, blob_store: Arc<BlobStore>) -> Self {
         let filename = notebook_doc_filename(notebook_id);
         let persist_path = docs_dir.join(filename);
@@ -3476,6 +3477,7 @@ pub(crate) fn spawn_notebook_file_watcher(
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/crates/runtimed/src/output_store.rs
+++ b/crates/runtimed/src/output_store.rs
@@ -563,6 +563,7 @@ fn value_to_string(value: &Value) -> String {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use tempfile::TempDir;

--- a/crates/runtimed/src/project_file.rs
+++ b/crates/runtimed/src/project_file.rs
@@ -112,6 +112,7 @@ pub fn detect_project_file(notebook_path: &Path) -> Option<DetectedProjectFile> 
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use tempfile::TempDir;

--- a/crates/runtimed/src/protocol.rs
+++ b/crates/runtimed/src/protocol.rs
@@ -529,6 +529,7 @@ pub enum DaemonBroadcast {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use std::path::PathBuf;

--- a/crates/runtimed/src/runtime.rs
+++ b/crates/runtimed/src/runtime.rs
@@ -76,6 +76,7 @@ impl std::str::FromStr for Runtime {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/crates/runtimed/src/service.rs
+++ b/crates/runtimed/src/service.rs
@@ -658,6 +658,7 @@ pub fn service_config_path() -> PathBuf {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/crates/runtimed/src/settings_doc.rs
+++ b/crates/runtimed/src/settings_doc.rs
@@ -638,6 +638,12 @@ impl SettingsDoc {
     }
 
     /// Get or create a nested Map at ROOT.
+    ///
+    /// # Panics
+    /// Panics if `put_object` fails, which only happens if the Automerge document
+    /// is in an invalid state. This would indicate a fundamental corruption that
+    /// would break all document operations - crashing is the correct response.
+    #[allow(clippy::expect_used)]
     fn ensure_map(&mut self, map_key: &str) -> ObjId {
         if let Some(id) = self.get_map_id(map_key) {
             return id;
@@ -856,6 +862,7 @@ pub fn read_nested_list(doc: &AutoCommit, map_key: &str, sub_key: &str) -> Vec<S
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use tempfile::TempDir;

--- a/crates/runtimed/src/singleton.rs
+++ b/crates/runtimed/src/singleton.rs
@@ -225,6 +225,7 @@ pub fn get_running_daemon_info() -> Option<DaemonInfo> {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/crates/runtimed/src/stream_terminal.rs
+++ b/crates/runtimed/src/stream_terminal.rs
@@ -405,6 +405,7 @@ fn color_to_ansi(color: &Color, is_foreground: bool) -> Option<String> {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/crates/runtimed/src/sync_client.rs
+++ b/crates/runtimed/src/sync_client.rs
@@ -455,6 +455,7 @@ pub async fn try_get_synced_settings() -> Result<SyncedSettings, SyncClientError
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use crate::runtime::Runtime;

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -1,3 +1,6 @@
+// Tests can use unwrap/expect freely - panics are acceptable in test code
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
 //! Integration tests for runtimed daemon and client.
 //!
 //! These tests spawn a real daemon and test client interactions.

--- a/crates/sidecar/src/lib.rs
+++ b/crates/sidecar/src/lib.rs
@@ -681,6 +681,7 @@ fn get_response(request: Request<Vec<u8>>) -> Result<Response<Vec<u8>>> {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/crates/tauri-jupyter/src/base64.rs
+++ b/crates/tauri-jupyter/src/base64.rs
@@ -43,6 +43,7 @@ where
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use serde::{Deserialize, Serialize};

--- a/crates/tauri-jupyter/src/message.rs
+++ b/crates/tauri-jupyter/src/message.rs
@@ -134,6 +134,7 @@ impl<'de> Deserialize<'de> for WebViewJupyterMessage {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 


### PR DESCRIPTION
## Summary

Add workspace-level Clippy lints (`unwrap_used` and `expect_used`) to prevent panics in user-facing code. These lints are enforced in CI as errors, catching new code that could crash without user-visible error messages.

## Changes

- Add `clippy::unwrap_used` and `clippy::expect_used` warnings to workspace Cargo.toml
- Exemptions for known-safe patterns (RwLock/Mutex poisoning, Response builders, corrupted Automerge docs) with documented justifications
- Allow these lints in all test modules where panics are acceptable
- Fix typosquat.rs to use `is_none_or` instead of unwrap

## How it works

CI runs `cargo clippy --all-targets -- -D warnings` which converts these warnings to errors, preventing panics in production code.

_PR submitted by @rgbkrk's agent, Quill_