### PR TITLE
refactor(runtimed): remove v1 protocol support

### DIFF
--- a/crates/runtimed/src/connection.rs
+++ b/crates/runtimed/src/connection.rs
@@ -42,15 +42,14 @@ pub enum Handshake {
     SettingsSync,
     /// Automerge notebook sync (per-notebook room).
     ///
-    /// The optional `protocol` field enables version negotiation:
-    /// - Absent or "v1": Raw Automerge frames (legacy protocol)
-    /// - "v2": Typed frames with first-byte type indicator
+    /// The `protocol` field enables version negotiation for future evolution.
+    /// Currently the only supported version is "v2" (typed frames).
     ///
-    /// After handshake, new servers send a `ProtocolCapabilities` response
-    /// before starting sync. Old servers skip this and send raw Automerge frames.
+    /// After handshake, the server sends a `ProtocolCapabilities` response
+    /// confirming the negotiated protocol before starting sync.
     NotebookSync {
         notebook_id: String,
-        /// Protocol version requested by client. Default is "v1" (raw frames).
+        /// Protocol version requested by client (e.g. "v2").
         #[serde(default, skip_serializing_if = "Option::is_none")]
         protocol: Option<String>,
         /// Working directory for untitled notebooks (used for project file detection).
@@ -70,17 +69,15 @@ pub enum Handshake {
     PoolStateSubscribe,
 }
 
-/// Protocol version constants.
-pub const PROTOCOL_V1: &str = "v1";
+/// Protocol version constant.
 pub const PROTOCOL_V2: &str = "v2";
 
 /// Server response indicating negotiated protocol capabilities.
 ///
-/// Sent by new servers immediately after handshake, before starting sync.
-/// Old servers don't send this (they start sync immediately).
+/// Sent immediately after handshake, before starting sync.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProtocolCapabilities {
-    /// Negotiated protocol version: "v1" or "v2"
+    /// Negotiated protocol version (e.g. "v2").
     pub protocol: String,
 }
 

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -868,11 +868,10 @@ impl Daemon {
                 working_dir,
                 initial_metadata,
             } => {
-                let use_typed_frames = protocol.as_deref() == Some(connection::PROTOCOL_V2);
                 info!(
                     "[runtimed] NotebookSync requested for {} (protocol: {}, working_dir: {:?})",
                     notebook_id,
-                    protocol.as_deref().unwrap_or("v1"),
+                    protocol.as_deref().unwrap_or("unspecified"),
                     working_dir
                 );
                 let docs_dir = self.config.notebook_docs_dir.clone();
@@ -898,7 +897,6 @@ impl Daemon {
                     room,
                     self.notebook_rooms.clone(),
                     notebook_id,
-                    use_typed_frames,
                     default_runtime,
                     default_python_env,
                     self.clone(),

--- a/crates/runtimed/src/notebook_sync_client.rs
+++ b/crates/runtimed/src/notebook_sync_client.rs
@@ -104,7 +104,6 @@ enum SyncCommand {
         reply: oneshot::Sender<Option<String>>,
     },
     /// Send a request to the daemon and wait for a response.
-    /// Only works with v2 protocol; returns error on v1.
     SendRequest {
         request: NotebookRequest,
         reply: oneshot::Sender<Result<NotebookResponse, NotebookSyncError>>,
@@ -310,9 +309,6 @@ impl NotebookSyncHandle {
     }
 
     /// Send a request to the daemon and wait for a response.
-    ///
-    /// This only works with v2 protocol. If the daemon is running v1,
-    /// this will return an error.
     pub async fn send_request(
         &self,
         request: NotebookRequest,
@@ -475,9 +471,6 @@ pub struct NotebookSyncClient<S> {
     peer_state: sync::State,
     stream: S,
     notebook_id: String,
-    /// Whether to use typed frames (v2 protocol) or raw frames (v1).
-    /// Determined during connection based on server capabilities.
-    use_typed_frames: bool,
     /// Broadcasts received during initial sync (before split).
     /// These are delivered immediately after into_split creates the channels.
     pending_broadcasts: Vec<NotebookBroadcast>,
@@ -700,9 +693,8 @@ where
     /// Initialize the client by sending the handshake and performing initial sync.
     ///
     /// The client requests the v2 protocol (typed frames) in the handshake.
-    /// If the server supports v2, it responds with a ProtocolCapabilities frame.
-    /// Old servers (v1) ignore the protocol field and send raw Automerge frames.
-    /// The client detects which protocol to use based on the first response.
+    /// The server responds with a ProtocolCapabilities frame confirming v2,
+    /// then sends the initial Automerge sync message as a typed frame.
     ///
     /// The `working_dir` parameter is used for untitled notebooks to provide
     /// the directory context for project file detection (pyproject.toml, etc).
@@ -728,170 +720,127 @@ where
         let mut doc = AutoCommit::new();
         let mut peer_state = sync::State::new();
 
-        // Read first frame to detect protocol version
-        // v2 servers send ProtocolCapabilities JSON first
-        // v1 servers send raw Automerge sync message first
+        // Read capabilities frame — server must support v2 protocol
         let first_frame = connection::recv_frame(&mut stream)
             .await?
             .ok_or(NotebookSyncError::Disconnected)?;
 
-        // Try to parse as ProtocolCapabilities (v2 server)
-        let use_typed_frames = match serde_json::from_slice::<ProtocolCapabilities>(&first_frame) {
+        match serde_json::from_slice::<ProtocolCapabilities>(&first_frame) {
             Ok(caps) if caps.protocol == PROTOCOL_V2 => {
                 info!(
                     "[notebook-sync-client] Server supports v2 protocol for {}",
                     notebook_id
                 );
-                true
             }
-            _ => {
-                // Not valid capabilities JSON — this is a raw Automerge frame from v1 server
-                // Process it as the initial sync message
-                info!(
-                    "[notebook-sync-client] Server uses v1 protocol for {}",
-                    notebook_id
-                );
-                let message = sync::Message::decode(&first_frame)
+            Ok(caps) => {
+                return Err(NotebookSyncError::SyncError(format!(
+                    "unsupported protocol version: {}",
+                    caps.protocol
+                )));
+            }
+            Err(e) => {
+                return Err(NotebookSyncError::SyncError(format!(
+                    "expected ProtocolCapabilities, got invalid JSON: {}",
+                    e
+                )));
+            }
+        }
+
+        // Read the first typed frame (must be AutomergeSync)
+        match connection::recv_typed_frame(&mut stream).await? {
+            Some(frame) => {
+                if frame.frame_type != NotebookFrameType::AutomergeSync {
+                    return Err(NotebookSyncError::SyncError(format!(
+                        "expected AutomergeSync frame, got {:?}",
+                        frame.frame_type
+                    )));
+                }
+                let message = sync::Message::decode(&frame.payload)
                     .map_err(|e| NotebookSyncError::SyncError(format!("decode: {}", e)))?;
                 doc.sync()
                     .receive_sync_message(&mut peer_state, message)
                     .map_err(|e| NotebookSyncError::SyncError(format!("receive: {}", e)))?;
-                false
             }
-        };
-
-        // For v2 protocol, read the first typed frame (Automerge sync)
-        if use_typed_frames {
-            match connection::recv_typed_frame(&mut stream).await? {
-                Some(frame) => {
-                    if frame.frame_type != NotebookFrameType::AutomergeSync {
-                        return Err(NotebookSyncError::SyncError(format!(
-                            "expected AutomergeSync frame, got {:?}",
-                            frame.frame_type
-                        )));
-                    }
-                    let message = sync::Message::decode(&frame.payload)
-                        .map_err(|e| NotebookSyncError::SyncError(format!("decode: {}", e)))?;
-                    doc.sync()
-                        .receive_sync_message(&mut peer_state, message)
-                        .map_err(|e| NotebookSyncError::SyncError(format!("receive: {}", e)))?;
-                }
-                None => return Err(NotebookSyncError::Disconnected),
-            }
+            None => return Err(NotebookSyncError::Disconnected),
         }
 
-        // Send our sync message back using the negotiated protocol
+        // Send our sync message back
         if let Some(msg) = doc.sync().generate_sync_message(&mut peer_state) {
-            if use_typed_frames {
-                connection::send_typed_frame(
-                    &mut stream,
-                    NotebookFrameType::AutomergeSync,
-                    &msg.encode(),
-                )
-                .await?;
-            } else {
-                connection::send_frame(&mut stream, &msg.encode()).await?;
-            }
+            connection::send_typed_frame(
+                &mut stream,
+                NotebookFrameType::AutomergeSync,
+                &msg.encode(),
+            )
+            .await?;
         }
 
-        // Continue sync rounds until no more messages (short timeout)
-        // For v2 protocol, we may receive Broadcast frames during initial sync (e.g., from auto-launch).
-        // We need to handle these properly instead of treating them as Automerge sync messages.
+        // Continue sync rounds until no more messages (short timeout).
+        // We may receive Broadcast frames during initial sync (e.g., from auto-launch).
         let mut pending_broadcasts = Vec::new();
         loop {
-            if use_typed_frames {
-                // v2 protocol: receive typed frame and handle by type
-                match tokio::time::timeout(
-                    Duration::from_millis(100),
-                    connection::recv_typed_frame(&mut stream),
-                )
-                .await
-                {
-                    Ok(Ok(Some(frame))) => match frame.frame_type {
-                        NotebookFrameType::AutomergeSync => {
-                            let message = sync::Message::decode(&frame.payload).map_err(|e| {
-                                NotebookSyncError::SyncError(format!("decode: {}", e))
-                            })?;
-                            doc.sync()
-                                .receive_sync_message(&mut peer_state, message)
-                                .map_err(|e| {
-                                    NotebookSyncError::SyncError(format!("receive: {}", e))
-                                })?;
-
-                            if let Some(msg) = doc.sync().generate_sync_message(&mut peer_state) {
-                                connection::send_typed_frame(
-                                    &mut stream,
-                                    NotebookFrameType::AutomergeSync,
-                                    &msg.encode(),
-                                )
-                                .await?;
-                            }
-                        }
-                        NotebookFrameType::Broadcast => {
-                            // Queue broadcasts to deliver after sync completes
-                            match serde_json::from_slice::<NotebookBroadcast>(&frame.payload) {
-                                Ok(broadcast) => {
-                                    info!(
-                                        "[notebook-sync-client] Received broadcast during init: {:?}",
-                                        broadcast
-                                    );
-                                    pending_broadcasts.push(broadcast);
-                                }
-                                Err(e) => {
-                                    warn!(
-                                        "[notebook-sync-client] Failed to deserialize broadcast: {} (payload: {} bytes)",
-                                        e,
-                                        frame.payload.len()
-                                    );
-                                }
-                            }
-                        }
-                        NotebookFrameType::Response => {
-                            // Unexpected during init, ignore
-                            warn!("[notebook-sync-client] Unexpected Response frame during init");
-                        }
-                        NotebookFrameType::Request => {
-                            // Server shouldn't send requests, ignore
-                            warn!("[notebook-sync-client] Unexpected Request frame during init");
-                        }
-                    },
-                    Ok(Ok(None)) => return Err(NotebookSyncError::Disconnected),
-                    Ok(Err(e)) => return Err(NotebookSyncError::ConnectionFailed(e)),
-                    Err(_) => break, // Timeout — initial sync is done
-                }
-            } else {
-                // v1 protocol: raw Automerge frames
-                match tokio::time::timeout(
-                    Duration::from_millis(100),
-                    connection::recv_frame(&mut stream),
-                )
-                .await
-                {
-                    Ok(Ok(Some(data))) => {
-                        let message = sync::Message::decode(&data)
+            match tokio::time::timeout(
+                Duration::from_millis(100),
+                connection::recv_typed_frame(&mut stream),
+            )
+            .await
+            {
+                Ok(Ok(Some(frame))) => match frame.frame_type {
+                    NotebookFrameType::AutomergeSync => {
+                        let message = sync::Message::decode(&frame.payload)
                             .map_err(|e| NotebookSyncError::SyncError(format!("decode: {}", e)))?;
                         doc.sync()
                             .receive_sync_message(&mut peer_state, message)
                             .map_err(|e| NotebookSyncError::SyncError(format!("receive: {}", e)))?;
 
                         if let Some(msg) = doc.sync().generate_sync_message(&mut peer_state) {
-                            connection::send_frame(&mut stream, &msg.encode()).await?;
+                            connection::send_typed_frame(
+                                &mut stream,
+                                NotebookFrameType::AutomergeSync,
+                                &msg.encode(),
+                            )
+                            .await?;
                         }
                     }
-                    Ok(Ok(None)) => return Err(NotebookSyncError::Disconnected),
-                    Ok(Err(e)) => return Err(NotebookSyncError::ConnectionFailed(e)),
-                    Err(_) => break, // Timeout — initial sync is done
-                }
+                    NotebookFrameType::Broadcast => {
+                        // Queue broadcasts to deliver after sync completes
+                        match serde_json::from_slice::<NotebookBroadcast>(&frame.payload) {
+                            Ok(broadcast) => {
+                                info!(
+                                    "[notebook-sync-client] Received broadcast during init: {:?}",
+                                    broadcast
+                                );
+                                pending_broadcasts.push(broadcast);
+                            }
+                            Err(e) => {
+                                warn!(
+                                    "[notebook-sync-client] Failed to deserialize broadcast: {} (payload: {} bytes)",
+                                    e,
+                                    frame.payload.len()
+                                );
+                            }
+                        }
+                    }
+                    NotebookFrameType::Response => {
+                        // Unexpected during init, ignore
+                        warn!("[notebook-sync-client] Unexpected Response frame during init");
+                    }
+                    NotebookFrameType::Request => {
+                        // Server shouldn't send requests, ignore
+                        warn!("[notebook-sync-client] Unexpected Request frame during init");
+                    }
+                },
+                Ok(Ok(None)) => return Err(NotebookSyncError::Disconnected),
+                Ok(Err(e)) => return Err(NotebookSyncError::ConnectionFailed(e)),
+                Err(_) => break, // Timeout — initial sync is done
             }
         }
 
         let cells = get_cells_from_doc(&doc);
         info!(
-            "[notebook-sync-client] Initial sync complete for {}: {} cells, {} pending broadcasts (protocol {})",
+            "[notebook-sync-client] Initial sync complete for {}: {} cells, {} pending broadcasts",
             notebook_id,
             cells.len(),
             pending_broadcasts.len(),
-            if use_typed_frames { "v2" } else { "v1" }
         );
 
         Ok(Self {
@@ -899,7 +848,6 @@ where
             peer_state,
             stream,
             notebook_id,
-            use_typed_frames,
             pending_broadcasts,
         })
     }
@@ -1187,42 +1135,13 @@ where
 
     // ── Receiving changes ───────────────────────────────────────────
 
-    /// Wait for the next change from the daemon.
+    /// Receive the next typed frame containing document changes.
     ///
     /// Blocks until a sync message arrives, applies it, and returns
-    /// the updated cells. For v2 protocol, this also handles Broadcast frames.
+    /// the updated cells. Handles AutomergeSync frames (applies changes,
+    /// sends ack) and ignores broadcast frames (those are handled
+    /// separately by `recv_frame`).
     pub async fn recv_changes(&mut self) -> Result<Vec<CellSnapshot>, NotebookSyncError> {
-        if self.use_typed_frames {
-            self.recv_changes_v2().await
-        } else {
-            self.recv_changes_v1().await
-        }
-    }
-
-    /// v1 protocol: receive raw Automerge frame
-    async fn recv_changes_v1(&mut self) -> Result<Vec<CellSnapshot>, NotebookSyncError> {
-        match connection::recv_frame(&mut self.stream).await? {
-            Some(data) => {
-                let message = sync::Message::decode(&data)
-                    .map_err(|e| NotebookSyncError::SyncError(format!("decode: {}", e)))?;
-                self.doc
-                    .sync()
-                    .receive_sync_message(&mut self.peer_state, message)
-                    .map_err(|e| NotebookSyncError::SyncError(format!("receive: {}", e)))?;
-
-                // Send ack if needed
-                if let Some(msg) = self.doc.sync().generate_sync_message(&mut self.peer_state) {
-                    connection::send_frame(&mut self.stream, &msg.encode()).await?;
-                }
-
-                Ok(self.get_cells())
-            }
-            None => Err(NotebookSyncError::Disconnected),
-        }
-    }
-
-    /// v2 protocol: receive typed frame
-    async fn recv_changes_v2(&mut self) -> Result<Vec<CellSnapshot>, NotebookSyncError> {
         match connection::recv_typed_frame(&mut self.stream).await? {
             Some(frame) => match frame.frame_type {
                 NotebookFrameType::AutomergeSync => {
@@ -1246,12 +1165,10 @@ where
                     Ok(self.get_cells())
                 }
                 NotebookFrameType::Broadcast => {
-                    // For now, ignore broadcast frames - caller can handle separately
-                    // In the future, we could return them or emit events
+                    // Ignore broadcast frames — caller can handle separately
                     Ok(self.get_cells())
                 }
                 _ => {
-                    // Unexpected frame type
                     warn!(
                         "[notebook-sync-client] Unexpected frame type in recv_changes: {:?}",
                         frame.frame_type
@@ -1263,86 +1180,74 @@ where
         }
     }
 
-    /// Receive any frame type from the daemon.
+    /// Receive any typed frame from the daemon.
     ///
-    /// Returns `Ok(None)` if no frame is available (v1 protocol always returns None).
-    /// This is used by the background task to handle all frame types.
+    /// Returns `Ok(None)` if no frame is available within the timeout.
+    /// Used by the background sync task to handle all frame types.
     ///
-    /// Note: This also drains any broadcasts collected during wait_for_response(),
+    /// Also drains any pending broadcasts collected during wait_for_response(),
     /// ensuring they aren't lost when a request/response exchange occurs.
-    async fn recv_frame_any(&mut self) -> Result<Option<ReceivedFrame>, NotebookSyncError> {
+    async fn recv_frame(&mut self) -> Result<Option<ReceivedFrame>, NotebookSyncError> {
         // First, drain any pending broadcasts collected during wait_for_response()
         if !self.pending_broadcasts.is_empty() {
             let broadcast = self.pending_broadcasts.remove(0);
             return Ok(Some(ReceivedFrame::Broadcast(broadcast)));
         }
 
-        if !self.use_typed_frames {
-            // v1 protocol: fall back to recv_changes behavior
-            match self.recv_changes_v1().await {
-                Ok(cells) => Ok(Some(ReceivedFrame::Changes(cells))),
-                Err(NotebookSyncError::Disconnected) => Err(NotebookSyncError::Disconnected),
-                Err(e) => Err(e),
-            }
-        } else {
-            // v2 protocol: handle all frame types with timeout to avoid blocking
-            let frame_result = tokio::time::timeout(
-                Duration::from_millis(100),
-                connection::recv_typed_frame(&mut self.stream),
-            )
-            .await;
+        let frame_result = tokio::time::timeout(
+            Duration::from_millis(1),
+            connection::recv_typed_frame(&mut self.stream),
+        )
+        .await;
 
-            match frame_result {
-                Ok(Ok(Some(frame))) => match frame.frame_type {
-                    NotebookFrameType::AutomergeSync => {
-                        let message = sync::Message::decode(&frame.payload)
-                            .map_err(|e| NotebookSyncError::SyncError(format!("decode: {}", e)))?;
-                        self.doc
-                            .sync()
-                            .receive_sync_message(&mut self.peer_state, message)
-                            .map_err(|e| NotebookSyncError::SyncError(format!("receive: {}", e)))?;
+        match frame_result {
+            Ok(Ok(Some(frame))) => match frame.frame_type {
+                NotebookFrameType::AutomergeSync => {
+                    let message = sync::Message::decode(&frame.payload)
+                        .map_err(|e| NotebookSyncError::SyncError(format!("decode: {}", e)))?;
+                    self.doc
+                        .sync()
+                        .receive_sync_message(&mut self.peer_state, message)
+                        .map_err(|e| NotebookSyncError::SyncError(format!("receive: {}", e)))?;
 
-                        // Send ack if needed
-                        if let Some(msg) =
-                            self.doc.sync().generate_sync_message(&mut self.peer_state)
-                        {
-                            connection::send_typed_frame(
-                                &mut self.stream,
-                                NotebookFrameType::AutomergeSync,
-                                &msg.encode(),
-                            )
-                            .await?;
-                        }
-
-                        Ok(Some(ReceivedFrame::Changes(self.get_cells())))
+                    // Send ack if needed
+                    if let Some(msg) = self.doc.sync().generate_sync_message(&mut self.peer_state) {
+                        connection::send_typed_frame(
+                            &mut self.stream,
+                            NotebookFrameType::AutomergeSync,
+                            &msg.encode(),
+                        )
+                        .await?;
                     }
-                    NotebookFrameType::Broadcast => {
-                        let broadcast: NotebookBroadcast = serde_json::from_slice(&frame.payload)
-                            .map_err(|e| {
+
+                    Ok(Some(ReceivedFrame::Changes(self.get_cells())))
+                }
+                NotebookFrameType::Broadcast => {
+                    let broadcast: NotebookBroadcast = serde_json::from_slice(&frame.payload)
+                        .map_err(|e| {
                             NotebookSyncError::SyncError(format!("deserialize broadcast: {}", e))
                         })?;
-                        Ok(Some(ReceivedFrame::Broadcast(broadcast)))
-                    }
-                    NotebookFrameType::Response => {
-                        let response: NotebookResponse = serde_json::from_slice(&frame.payload)
-                            .map_err(|e| {
-                                NotebookSyncError::SyncError(format!("deserialize response: {}", e))
-                            })?;
-                        Ok(Some(ReceivedFrame::Response(response)))
-                    }
-                    NotebookFrameType::Request => {
-                        // Unexpected - server shouldn't send requests
-                        warn!("[notebook-sync-client] Unexpected Request frame from server");
-                        Ok(None)
-                    }
-                },
-                // EOF/disconnect
-                Ok(Ok(None)) => Err(NotebookSyncError::Disconnected),
-                // I/O error
-                Ok(Err(e)) => Err(NotebookSyncError::ConnectionFailed(e)),
-                // Timeout - no data available, return Ok(None) so caller can continue
-                Err(_) => Ok(None),
-            }
+                    Ok(Some(ReceivedFrame::Broadcast(broadcast)))
+                }
+                NotebookFrameType::Response => {
+                    let response: NotebookResponse = serde_json::from_slice(&frame.payload)
+                        .map_err(|e| {
+                            NotebookSyncError::SyncError(format!("deserialize response: {}", e))
+                        })?;
+                    Ok(Some(ReceivedFrame::Response(response)))
+                }
+                NotebookFrameType::Request => {
+                    // Unexpected - server shouldn't send requests
+                    warn!("[notebook-sync-client] Unexpected Request frame from server");
+                    Ok(None)
+                }
+            },
+            // EOF/disconnect
+            Ok(Ok(None)) => Err(NotebookSyncError::Disconnected),
+            // I/O error
+            Ok(Err(e)) => Err(NotebookSyncError::ConnectionFailed(e)),
+            // Timeout - no data available, return Ok(None) so caller can continue
+            Err(_) => Ok(None),
         }
     }
 
@@ -1371,56 +1276,14 @@ where
 
     // ── Internal helpers ────────────────────────────────────────────
 
-    /// Generate and send sync message to daemon, then wait for the
-    /// server's acknowledgment.
+    /// Generate and send a sync message to the daemon, then wait for
+    /// the server's acknowledgment.
     ///
     /// The Automerge sync protocol is bidirectional: after the server
     /// applies our changes, it sends back a sync message confirming
     /// what it now has. By waiting for this reply, callers know the
-    /// daemon has processed and persisted the change when the write
-    /// method returns.
+    /// daemon has processed and persisted the change.
     async fn sync_to_daemon(&mut self) -> Result<(), NotebookSyncError> {
-        if self.use_typed_frames {
-            self.sync_to_daemon_v2().await
-        } else {
-            self.sync_to_daemon_v1().await
-        }
-    }
-
-    /// v1 protocol: raw Automerge frames
-    async fn sync_to_daemon_v1(&mut self) -> Result<(), NotebookSyncError> {
-        let encoded = {
-            let msg = self.doc.sync().generate_sync_message(&mut self.peer_state);
-            msg.map(|m| m.encode())
-        };
-
-        if let Some(data) = encoded {
-            connection::send_frame(&mut self.stream, &data).await?;
-
-            match tokio::time::timeout(
-                Duration::from_millis(500),
-                connection::recv_frame(&mut self.stream),
-            )
-            .await
-            {
-                Ok(Ok(Some(data))) => {
-                    let message = sync::Message::decode(&data)
-                        .map_err(|e| NotebookSyncError::SyncError(format!("decode: {}", e)))?;
-                    self.doc
-                        .sync()
-                        .receive_sync_message(&mut self.peer_state, message)
-                        .map_err(|e| NotebookSyncError::SyncError(format!("receive: {}", e)))?;
-                }
-                Ok(Ok(None)) => return Err(NotebookSyncError::Disconnected),
-                Ok(Err(e)) => return Err(NotebookSyncError::ConnectionFailed(e)),
-                Err(_) => {} // Timeout — server had nothing to send back
-            }
-        }
-        Ok(())
-    }
-
-    /// v2 protocol: typed frames
-    async fn sync_to_daemon_v2(&mut self) -> Result<(), NotebookSyncError> {
         let encoded = {
             let msg = self.doc.sync().generate_sync_message(&mut self.peer_state);
             msg.map(|m| m.encode())
@@ -1459,8 +1322,8 @@ where
 
     /// Send a request to the daemon and wait for the response.
     ///
-    /// This only works with v2 protocol. The request is sent as a typed
-    /// Request frame, and we wait for a Response frame back.
+    /// The request is sent as a typed Request frame, and we wait for
+    /// a Response frame back.
     pub async fn send_request(
         &mut self,
         request: &NotebookRequest,
@@ -1478,12 +1341,6 @@ where
         request: &NotebookRequest,
         broadcast_tx: Option<&broadcast::Sender<NotebookBroadcast>>,
     ) -> Result<NotebookResponse, NotebookSyncError> {
-        if !self.use_typed_frames {
-            return Err(NotebookSyncError::SyncError(
-                "send_request requires v2 protocol".to_string(),
-            ));
-        }
-
         // Serialize and send the request
         let payload = serde_json::to_vec(request)
             .map_err(|e| NotebookSyncError::SyncError(format!("serialize request: {}", e)))?;
@@ -1566,11 +1423,6 @@ where
                 None => return Err(NotebookSyncError::Disconnected),
             }
         }
-    }
-
-    /// Check if this client is using the v2 typed frames protocol.
-    pub fn uses_typed_frames(&self) -> bool {
-        self.use_typed_frames
     }
 
     fn cells_list_id(&self) -> Option<automerge::ObjId> {
@@ -1956,10 +1808,9 @@ async fn run_sync_task<S>(
                 }
             }
 
-            // Check for incoming changes
-            // Note: recv_frame_any() has an internal 100ms timeout, so no outer timeout needed
+            // Check for incoming frames (changes, broadcasts, etc.)
             _ = poll_interval.tick() => {
-                match client.recv_frame_any().await {
+                match client.recv_frame().await {
                     Ok(Some(ReceivedFrame::Changes(cells))) => {
                         // Got changes from another peer — only include metadata if it changed
                         let current_metadata = client.get_metadata(NOTEBOOK_METADATA_KEY);

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -664,9 +664,8 @@ pub fn get_or_create_room(
 /// is decremented. If it reaches zero, the room is evicted and any pending
 /// doc bytes are flushed via debounced persistence.
 ///
-/// The `use_typed_frames` parameter determines the protocol version:
-/// - `false` (v1): Raw Automerge frames (legacy, for old clients)
-/// - `true` (v2): Typed frames with first-byte type indicator
+/// The connection uses typed frames with a first-byte type indicator,
+/// supporting both Automerge sync and daemon-owned kernel execution.
 #[allow(clippy::too_many_arguments)]
 pub async fn handle_notebook_sync_connection<R, W>(
     mut reader: R,
@@ -674,7 +673,6 @@ pub async fn handle_notebook_sync_connection<R, W>(
     room: Arc<NotebookRoom>,
     rooms: NotebookRooms,
     notebook_id: String,
-    use_typed_frames: bool,
     default_runtime: crate::runtime::Runtime,
     default_python_env: crate::settings_doc::PythonEnvType,
     daemon: std::sync::Arc<crate::daemon::Daemon>,
@@ -717,7 +715,7 @@ where
         notebook_id,
         peers,
         if peers == 1 { "" } else { "s" },
-        if use_typed_frames { "v2" } else { "v1" }
+        "v2"
     );
 
     // Auto-launch kernel if this is the first peer and notebook is trusted
@@ -776,19 +774,13 @@ where
         }
     }
 
-    // For v2 protocol, send capabilities response first
-    if use_typed_frames {
-        let caps = connection::ProtocolCapabilities {
-            protocol: connection::PROTOCOL_V2.to_string(),
-        };
-        connection::send_json_frame(&mut writer, &caps).await?;
-    }
-
-    let result = if use_typed_frames {
-        run_sync_loop_v2(&mut reader, &mut writer, &room, daemon.clone()).await
-    } else {
-        run_sync_loop_v1(&mut reader, &mut writer, &room).await
+    // Send capabilities response
+    let caps = connection::ProtocolCapabilities {
+        protocol: connection::PROTOCOL_V2.to_string(),
     };
+    connection::send_json_frame(&mut writer, &caps).await?;
+
+    let result = run_sync_loop(&mut reader, &mut writer, &room, daemon.clone()).await;
 
     // Peer disconnected — decrement and possibly evict the room
     let remaining = room.active_peers.fetch_sub(1, Ordering::Relaxed) - 1;
@@ -867,84 +859,11 @@ where
     result
 }
 
-/// Protocol v1: Raw Automerge frames (legacy, for backwards compatibility).
+/// Sync loop using typed frames with first-byte type indicator.
 ///
-/// This is the original sync protocol used by older clients. It only supports
-/// Automerge document sync, not kernel execution through the daemon.
-async fn run_sync_loop_v1<R, W>(
-    reader: &mut R,
-    writer: &mut W,
-    room: &NotebookRoom,
-) -> anyhow::Result<()>
-where
-    R: AsyncRead + Unpin,
-    W: AsyncWrite + Unpin,
-{
-    let mut peer_state = sync::State::new();
-    let mut changed_rx = room.changed_tx.subscribe();
-
-    // Phase 1: Initial sync — server sends first (raw frame)
-    {
-        let mut doc = room.doc.write().await;
-        if let Some(msg) = doc.generate_sync_message(&mut peer_state) {
-            connection::send_frame(writer, &msg.encode()).await?;
-        }
-    }
-
-    // Phase 2: Exchange messages until sync is complete, then watch for changes
-    loop {
-        tokio::select! {
-            // Incoming message from this client (raw frame)
-            result = connection::recv_frame(reader) => {
-                match result? {
-                    Some(data) => {
-                        let message = sync::Message::decode(&data)
-                            .map_err(|e| anyhow::anyhow!("decode error: {}", e))?;
-
-                        // Serialize bytes inside the lock, then persist outside it
-                        let persist_bytes = {
-                            let mut doc = room.doc.write().await;
-                            doc.receive_sync_message(&mut peer_state, message)?;
-
-                            let bytes = doc.save();
-
-                            // Notify other peers in this room
-                            let _ = room.changed_tx.send(());
-
-                            // Send our response while still holding the lock (raw frame)
-                            if let Some(reply) = doc.generate_sync_message(&mut peer_state) {
-                                connection::send_frame(writer, &reply.encode()).await?;
-                            }
-
-                            bytes
-                        };
-
-                        // Send to debounced persistence task
-                        let _ = room.persist_tx.send(Some(persist_bytes));
-                    }
-                    None => {
-                        // Client disconnected
-                        return Ok(());
-                    }
-                }
-            }
-
-            // Another peer changed the document — push update to this client
-            _ = changed_rx.recv() => {
-                let mut doc = room.doc.write().await;
-                if let Some(msg) = doc.generate_sync_message(&mut peer_state) {
-                    connection::send_frame(writer, &msg.encode()).await?;
-                }
-            }
-        }
-    }
-}
-
-/// Protocol v2: Typed frames with first-byte type indicator.
-///
-/// Handles both Automerge sync messages and NotebookRequest messages.
-/// This protocol supports daemon-owned kernel execution (Phase 8).
-async fn run_sync_loop_v2<R, W>(
+/// Handles both Automerge sync messages and NotebookRequest messages,
+/// including daemon-owned kernel execution.
+async fn run_sync_loop<R, W>(
     reader: &mut R,
     writer: &mut W,
     room: &NotebookRoom,


### PR DESCRIPTION
Remove legacy raw Automerge frame protocol (v1) from both client and server. All connections now use typed frames (v2) exclusively. -235 net lines.

**What changed:**

- **Server:** delete `run_sync_loop_v1`, remove `use_typed_frames` param from `handle_notebook_sync_connection`, rename `run_sync_loop_v2` → `run_sync_loop`
- **Client:** remove `use_typed_frames` field, delete `recv_changes_v1`/`sync_to_daemon_v1`/`recv_frame_any`/`uses_typed_frames`, inline v2 bodies into `recv_changes`/`sync_to_daemon`, rename `recv_frame_any` → `recv_frame`
- **Client init:** require v2 `ProtocolCapabilities` instead of falling back to raw frames
- **Connection:** remove `PROTOCOL_V1` constant, update docs
- **Daemon routing:** drop `use_typed_frames` computation

Protocol negotiation infra (`ProtocolCapabilities`, `Handshake::protocol` field, `PROTOCOL_V2`) is kept for future protocol evolution.

**Verification:**

- `cargo check -p runtimed -p runtimed-py -p notebook` ✅
- `cargo test -p runtimed` — 15/15 integration tests pass ✅
- Python integration tests — 78 passed, 5 skipped, 4 failed (pre-existing error propagation issue, unrelated)