### PR TITLE
refactor(runtimed): remove v1 protocol support from server

### DIFF
--- a/crates/runtimed/src/connection.rs
+++ b/crates/runtimed/src/connection.rs
@@ -42,15 +42,12 @@ pub enum Handshake {
     SettingsSync,
     /// Automerge notebook sync (per-notebook room).
     ///
-    /// The optional `protocol` field enables version negotiation:
-    /// - Absent or "v1": Raw Automerge frames (legacy protocol)
-    /// - "v2": Typed frames with first-byte type indicator
-    ///
-    /// After handshake, new servers send a `ProtocolCapabilities` response
-    /// before starting sync. Old servers skip this and send raw Automerge frames.
+    /// The optional `protocol` field is accepted for future version negotiation.
+    /// Currently only v2 (typed frames) is supported. After handshake, the server
+    /// sends a `ProtocolCapabilities` response before starting sync.
     NotebookSync {
         notebook_id: String,
-        /// Protocol version requested by client. Default is "v1" (raw frames).
+        /// Protocol version requested by client. Currently only v2 is supported.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         protocol: Option<String>,
         /// Working directory for untitled notebooks (used for project file detection).
@@ -70,17 +67,15 @@ pub enum Handshake {
     PoolStateSubscribe,
 }
 
-/// Protocol version constants.
-pub const PROTOCOL_V1: &str = "v1";
+/// Protocol version constant.
 pub const PROTOCOL_V2: &str = "v2";
 
-/// Server response indicating negotiated protocol capabilities.
+/// Server response indicating protocol capabilities.
 ///
-/// Sent by new servers immediately after handshake, before starting sync.
-/// Old servers don't send this (they start sync immediately).
+/// Sent immediately after handshake, before starting sync.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProtocolCapabilities {
-    /// Negotiated protocol version: "v1" or "v2"
+    /// Protocol version (currently always "v2").
     pub protocol: String,
 }
 

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -868,11 +868,10 @@ impl Daemon {
                 working_dir,
                 initial_metadata,
             } => {
-                let use_typed_frames = protocol.as_deref() == Some(connection::PROTOCOL_V2);
                 info!(
                     "[runtimed] NotebookSync requested for {} (protocol: {}, working_dir: {:?})",
                     notebook_id,
-                    protocol.as_deref().unwrap_or("v1"),
+                    protocol.as_deref().unwrap_or("v2"),
                     working_dir
                 );
                 let docs_dir = self.config.notebook_docs_dir.clone();
@@ -898,7 +897,6 @@ impl Daemon {
                     room,
                     self.notebook_rooms.clone(),
                     notebook_id,
-                    use_typed_frames,
                     default_runtime,
                     default_python_env,
                     self.clone(),

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -664,9 +664,7 @@ pub fn get_or_create_room(
 /// is decremented. If it reaches zero, the room is evicted and any pending
 /// doc bytes are flushed via debounced persistence.
 ///
-/// The `use_typed_frames` parameter determines the protocol version:
-/// - `false` (v1): Raw Automerge frames (legacy, for old clients)
-/// - `true` (v2): Typed frames with first-byte type indicator
+/// Uses v2 typed frames protocol (with first-byte type indicator).
 #[allow(clippy::too_many_arguments)]
 pub async fn handle_notebook_sync_connection<R, W>(
     mut reader: R,
@@ -674,7 +672,6 @@ pub async fn handle_notebook_sync_connection<R, W>(
     room: Arc<NotebookRoom>,
     rooms: NotebookRooms,
     notebook_id: String,
-    use_typed_frames: bool,
     default_runtime: crate::runtime::Runtime,
     default_python_env: crate::settings_doc::PythonEnvType,
     daemon: std::sync::Arc<crate::daemon::Daemon>,
@@ -713,11 +710,10 @@ where
     room.active_peers.fetch_add(1, Ordering::Relaxed);
     let peers = room.active_peers.load(Ordering::Relaxed);
     info!(
-        "[notebook-sync] Client connected to room {} ({} peer{}, protocol {})",
+        "[notebook-sync] Client connected to room {} ({} peer{})",
         notebook_id,
         peers,
-        if peers == 1 { "" } else { "s" },
-        if use_typed_frames { "v2" } else { "v1" }
+        if peers == 1 { "" } else { "s" }
     );
 
     // Auto-launch kernel if this is the first peer and notebook is trusted
@@ -776,19 +772,13 @@ where
         }
     }
 
-    // For v2 protocol, send capabilities response first
-    if use_typed_frames {
-        let caps = connection::ProtocolCapabilities {
-            protocol: connection::PROTOCOL_V2.to_string(),
-        };
-        connection::send_json_frame(&mut writer, &caps).await?;
-    }
-
-    let result = if use_typed_frames {
-        run_sync_loop_v2(&mut reader, &mut writer, &room, daemon.clone()).await
-    } else {
-        run_sync_loop_v1(&mut reader, &mut writer, &room).await
+    // Send capabilities response (v2 protocol)
+    let caps = connection::ProtocolCapabilities {
+        protocol: connection::PROTOCOL_V2.to_string(),
     };
+    connection::send_json_frame(&mut writer, &caps).await?;
+
+    let result = run_sync_loop_v2(&mut reader, &mut writer, &room, daemon.clone()).await;
 
     // Peer disconnected — decrement and possibly evict the room
     let remaining = room.active_peers.fetch_sub(1, Ordering::Relaxed) - 1;
@@ -867,80 +857,7 @@ where
     result
 }
 
-/// Protocol v1: Raw Automerge frames (legacy, for backwards compatibility).
-///
-/// This is the original sync protocol used by older clients. It only supports
-/// Automerge document sync, not kernel execution through the daemon.
-async fn run_sync_loop_v1<R, W>(
-    reader: &mut R,
-    writer: &mut W,
-    room: &NotebookRoom,
-) -> anyhow::Result<()>
-where
-    R: AsyncRead + Unpin,
-    W: AsyncWrite + Unpin,
-{
-    let mut peer_state = sync::State::new();
-    let mut changed_rx = room.changed_tx.subscribe();
-
-    // Phase 1: Initial sync — server sends first (raw frame)
-    {
-        let mut doc = room.doc.write().await;
-        if let Some(msg) = doc.generate_sync_message(&mut peer_state) {
-            connection::send_frame(writer, &msg.encode()).await?;
-        }
-    }
-
-    // Phase 2: Exchange messages until sync is complete, then watch for changes
-    loop {
-        tokio::select! {
-            // Incoming message from this client (raw frame)
-            result = connection::recv_frame(reader) => {
-                match result? {
-                    Some(data) => {
-                        let message = sync::Message::decode(&data)
-                            .map_err(|e| anyhow::anyhow!("decode error: {}", e))?;
-
-                        // Serialize bytes inside the lock, then persist outside it
-                        let persist_bytes = {
-                            let mut doc = room.doc.write().await;
-                            doc.receive_sync_message(&mut peer_state, message)?;
-
-                            let bytes = doc.save();
-
-                            // Notify other peers in this room
-                            let _ = room.changed_tx.send(());
-
-                            // Send our response while still holding the lock (raw frame)
-                            if let Some(reply) = doc.generate_sync_message(&mut peer_state) {
-                                connection::send_frame(writer, &reply.encode()).await?;
-                            }
-
-                            bytes
-                        };
-
-                        // Send to debounced persistence task
-                        let _ = room.persist_tx.send(Some(persist_bytes));
-                    }
-                    None => {
-                        // Client disconnected
-                        return Ok(());
-                    }
-                }
-            }
-
-            // Another peer changed the document — push update to this client
-            _ = changed_rx.recv() => {
-                let mut doc = room.doc.write().await;
-                if let Some(msg) = doc.generate_sync_message(&mut peer_state) {
-                    connection::send_frame(writer, &msg.encode()).await?;
-                }
-            }
-        }
-    }
-}
-
-/// Protocol v2: Typed frames with first-byte type indicator.
+/// Typed frames sync loop with first-byte type indicator.
 ///
 /// Handles both Automerge sync messages and NotebookRequest messages.
 /// This protocol supports daemon-owned kernel execution (Phase 8).


### PR DESCRIPTION
Completes the v1 protocol removal started in PR #582 by removing v1 support from the notebook sync server.

**Changes:**
- Delete `run_sync_loop_v1` (~70 lines)
- Remove `use_typed_frames` parameter and conditional logic from `handle_notebook_sync_connection`
- Simplify daemon routing to always use v2
- Delete `PROTOCOL_V1` constant
- Update documentation to reflect v2-only support

The protocol negotiation infrastructure is preserved (protocol field in Handshake) to support future v3 negotiation if needed. The server now always uses v2 typed frames.

## Verification
- [x] Verify notebook sync still works end-to-end
- [x] Check that cell execution remains fast and responsive

_PR submitted by @rgbkrk's agent, Quill_