### PR TITLE
feat(runtimed-py): add dependency management and kernel restart

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5665,6 +5665,7 @@ name = "runtimed-py"
 version = "0.1.0"
 dependencies = [
  "log",
+ "notebook-doc",
  "pyo3",
  "pyo3-async-runtimes",
  "reqwest 0.12.28",

--- a/crates/runtimed-py/Cargo.toml
+++ b/crates/runtimed-py/Cargo.toml
@@ -15,6 +15,7 @@ crate-type = ["cdylib"]
 pyo3 = { version = "0.28", features = ["extension-module", "abi3-py39"] }
 pyo3-async-runtimes = { version = "0.28", features = ["tokio-runtime"] }
 runtimed = { path = "../runtimed" }
+notebook-doc = { path = "../notebook-doc" }
 tokio = { version = "1", features = ["full"] }
 serde_json = { workspace = true }
 uuid = { workspace = true }

--- a/crates/runtimed-py/src/async_session.rs
+++ b/crates/runtimed-py/src/async_session.rs
@@ -16,9 +16,13 @@ use runtimed::protocol::{NotebookBroadcast, NotebookRequest, NotebookResponse};
 
 use crate::error::to_py_err;
 use crate::event_stream::ExecutionEventStream;
-use crate::output::{Cell, ExecutionEvent, ExecutionResult, Output};
+use crate::output::{Cell, ExecutionEvent, ExecutionResult, Output, SyncEnvironmentResult};
 use crate::output_resolver;
 use crate::subscription::EventSubscription;
+
+use notebook_doc::metadata::{
+    CondaInlineMetadata, NotebookMetadataSnapshot, RuntMetadata, UvInlineMetadata,
+};
 
 /// An async session for executing code via the runtimed daemon.
 ///
@@ -590,6 +594,243 @@ impl AsyncSession {
                 NotebookResponse::Error { error } => Err(to_py_err(error)),
                 other => Err(to_py_err(format!("Unexpected response: {:?}", other))),
             }
+        })
+    }
+
+    // =========================================================================
+    // Metadata Operations (synced via automerge doc)
+    // =========================================================================
+
+    /// Set a metadata value in the automerge document.
+    ///
+    /// The value is synced to the daemon and all connected clients.
+    /// Use the key "notebook_metadata" to set the NotebookMetadataSnapshot
+    /// (JSON-encoded kernelspec, language_info, and runt config).
+    ///
+    /// Args:
+    ///     key: The metadata key.
+    ///     value: The metadata value (typically JSON).
+    ///
+    /// Returns a coroutine.
+    fn set_metadata<'py>(
+        &self,
+        py: Python<'py>,
+        key: &str,
+        value: &str,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let state = Arc::clone(&self.state);
+        let key = key.to_string();
+        let value = value.to_string();
+
+        future_into_py(py, async move {
+            let state_guard = state.lock().await;
+            let handle = state_guard
+                .handle
+                .as_ref()
+                .ok_or_else(|| to_py_err("Not connected"))?;
+
+            handle.set_metadata(&key, &value).await.map_err(to_py_err)
+        })
+    }
+
+    /// Get a metadata value from the automerge document.
+    ///
+    /// Reads from the local replica of the automerge doc.
+    ///
+    /// Args:
+    ///     key: The metadata key.
+    ///
+    /// Returns a coroutine that resolves to the metadata value (str) or None.
+    fn get_metadata<'py>(&self, py: Python<'py>, key: &str) -> PyResult<Bound<'py, PyAny>> {
+        let state = Arc::clone(&self.state);
+        let key = key.to_string();
+
+        future_into_py(py, async move {
+            let state_guard = state.lock().await;
+            let handle = state_guard
+                .handle
+                .as_ref()
+                .ok_or_else(|| to_py_err("Not connected"))?;
+
+            handle.get_metadata(&key).await.map_err(to_py_err)
+        })
+    }
+
+    // =========================================================================
+    // Dependency Management (convenience methods for notebook_metadata)
+    // =========================================================================
+
+    /// Get current UV dependencies.
+    ///
+    /// Returns a coroutine that resolves to list of UV dependency specifiers.
+    fn get_uv_dependencies<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let state = Arc::clone(&self.state);
+
+        future_into_py(py, async move {
+            let snapshot = get_notebook_metadata_async(&state).await?;
+            Ok(snapshot
+                .runt
+                .uv
+                .map(|uv| uv.dependencies)
+                .unwrap_or_default())
+        })
+    }
+
+    /// Add a UV dependency to the notebook.
+    ///
+    /// Args:
+    ///     package: PEP 508 dependency specifier (e.g., "pandas>=2.0", "requests").
+    ///
+    /// Returns a coroutine that resolves to the updated list of dependencies.
+    fn add_uv_dependency<'py>(
+        &self,
+        py: Python<'py>,
+        package: &str,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let state = Arc::clone(&self.state);
+        let package = package.to_string();
+
+        future_into_py(py, async move {
+            let mut snapshot = get_notebook_metadata_async(&state).await?;
+
+            let mut deps = snapshot
+                .runt
+                .uv
+                .map(|uv| uv.dependencies)
+                .unwrap_or_default();
+            deps.push(package);
+
+            snapshot.runt.uv = Some(UvInlineMetadata {
+                dependencies: deps.clone(),
+                requires_python: None,
+            });
+
+            set_notebook_metadata_async(&state, &snapshot).await?;
+            Ok(deps)
+        })
+    }
+
+    /// Remove a UV dependency by exact match.
+    ///
+    /// Args:
+    ///     package: Exact dependency string to remove.
+    ///
+    /// Returns a coroutine that resolves to the updated list of dependencies.
+    fn remove_uv_dependency<'py>(
+        &self,
+        py: Python<'py>,
+        package: &str,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let state = Arc::clone(&self.state);
+        let package = package.to_string();
+
+        future_into_py(py, async move {
+            let mut snapshot = get_notebook_metadata_async(&state).await?;
+
+            let mut deps = snapshot
+                .runt
+                .uv
+                .map(|uv| uv.dependencies)
+                .unwrap_or_default();
+            deps.retain(|dep| dep != &package);
+
+            snapshot.runt.uv = Some(UvInlineMetadata {
+                dependencies: deps.clone(),
+                requires_python: None,
+            });
+
+            set_notebook_metadata_async(&state, &snapshot).await?;
+            Ok(deps)
+        })
+    }
+
+    /// Get current Conda dependencies.
+    ///
+    /// Returns a coroutine that resolves to list of Conda package names.
+    fn get_conda_dependencies<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let state = Arc::clone(&self.state);
+
+        future_into_py(py, async move {
+            let snapshot = get_notebook_metadata_async(&state).await?;
+            Ok(snapshot
+                .runt
+                .conda
+                .map(|c| c.dependencies)
+                .unwrap_or_default())
+        })
+    }
+
+    /// Add a Conda dependency to the notebook.
+    ///
+    /// Args:
+    ///     package: Conda package specifier (e.g., "numpy", "scipy>=1.0").
+    ///
+    /// Returns a coroutine that resolves to the updated list of dependencies.
+    fn add_conda_dependency<'py>(
+        &self,
+        py: Python<'py>,
+        package: &str,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let state = Arc::clone(&self.state);
+        let package = package.to_string();
+
+        future_into_py(py, async move {
+            let mut snapshot = get_notebook_metadata_async(&state).await?;
+
+            let existing = snapshot.runt.conda.unwrap_or(CondaInlineMetadata {
+                dependencies: vec![],
+                channels: vec!["conda-forge".to_string()],
+                python: None,
+            });
+
+            let mut deps = existing.dependencies;
+            deps.push(package);
+
+            snapshot.runt.conda = Some(CondaInlineMetadata {
+                dependencies: deps.clone(),
+                channels: existing.channels,
+                python: existing.python,
+            });
+
+            set_notebook_metadata_async(&state, &snapshot).await?;
+            Ok(deps)
+        })
+    }
+
+    /// Remove a Conda dependency by exact match.
+    ///
+    /// Args:
+    ///     package: Exact dependency string to remove.
+    ///
+    /// Returns a coroutine that resolves to the updated list of dependencies.
+    fn remove_conda_dependency<'py>(
+        &self,
+        py: Python<'py>,
+        package: &str,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let state = Arc::clone(&self.state);
+        let package = package.to_string();
+
+        future_into_py(py, async move {
+            let mut snapshot = get_notebook_metadata_async(&state).await?;
+
+            let existing = snapshot.runt.conda.unwrap_or(CondaInlineMetadata {
+                dependencies: vec![],
+                channels: vec!["conda-forge".to_string()],
+                python: None,
+            });
+
+            let mut deps = existing.dependencies;
+            deps.retain(|dep| dep != &package);
+
+            snapshot.runt.conda = Some(CondaInlineMetadata {
+                dependencies: deps.clone(),
+                channels: existing.channels,
+                python: existing.python,
+            });
+
+            set_notebook_metadata_async(&state, &snapshot).await?;
+            Ok(deps)
         })
     }
 
@@ -1218,6 +1459,204 @@ impl AsyncSession {
         })
     }
 
+    /// Restart the kernel.
+    ///
+    /// Shuts down the current kernel and starts a new one. This is useful after
+    /// modifying dependencies to apply the changes.
+    ///
+    /// The new kernel will use env_source="auto" to pick up any inline
+    /// dependencies from the notebook metadata.
+    ///
+    /// Args:
+    ///     wait_for_ready: If True (default), wait for kernel to be idle.
+    ///
+    /// Note: This currently does shutdown + start. A daemon-side RestartKernel
+    /// command would be cleaner but doesn't exist yet.
+    ///
+    /// Returns a coroutine.
+    #[pyo3(signature = (wait_for_ready=true))]
+    fn restart_kernel<'py>(
+        &self,
+        py: Python<'py>,
+        wait_for_ready: bool,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let state = Arc::clone(&self.state);
+        let notebook_id = self.notebook_id.clone();
+
+        future_into_py(py, async move {
+            // TODO: Consider adding NotebookRequest::RestartKernel to the daemon
+            // Shutdown existing kernel
+            {
+                let mut state_guard = state.lock().await;
+                let handle = state_guard
+                    .handle
+                    .as_ref()
+                    .ok_or_else(|| to_py_err("Not connected"))?;
+
+                let response = handle
+                    .send_request(NotebookRequest::ShutdownKernel {})
+                    .await
+                    .map_err(to_py_err)?;
+
+                match response {
+                    NotebookResponse::KernelShuttingDown {} | NotebookResponse::NoKernel {} => {
+                        state_guard.kernel_started = false;
+                        state_guard.env_source = None;
+                    }
+                    NotebookResponse::Error { error } => return Err(to_py_err(error)),
+                    _ => {}
+                }
+            }
+
+            // Start new kernel with auto env detection
+            {
+                let mut state_guard = state.lock().await;
+                let handle = state_guard
+                    .handle
+                    .as_ref()
+                    .ok_or_else(|| to_py_err("Not connected"))?;
+
+                let response = handle
+                    .send_request(NotebookRequest::LaunchKernel {
+                        kernel_type: "python".to_string(),
+                        env_source: "auto".to_string(),
+                        notebook_path: Some(notebook_id.clone()),
+                    })
+                    .await
+                    .map_err(to_py_err)?;
+
+                match response {
+                    NotebookResponse::KernelLaunched { env_source, .. }
+                    | NotebookResponse::KernelAlreadyRunning { env_source, .. } => {
+                        state_guard.kernel_started = true;
+                        state_guard.env_source = Some(env_source);
+                    }
+                    NotebookResponse::Error { error } => return Err(to_py_err(error)),
+                    other => return Err(to_py_err(format!("Unexpected response: {:?}", other))),
+                }
+            }
+
+            // Wait for kernel ready if requested
+            if wait_for_ready {
+                let mut state_guard = state.lock().await;
+                if let Some(rx) = state_guard.broadcast_rx.as_mut() {
+                    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+                    while std::time::Instant::now() < deadline {
+                        match tokio::time::timeout(std::time::Duration::from_millis(100), rx.recv())
+                            .await
+                        {
+                            Ok(Some(NotebookBroadcast::KernelStatus { status, .. }))
+                                if status == "idle" =>
+                            {
+                                return Ok(());
+                            }
+                            Ok(Some(_)) => continue,
+                            Ok(None) => return Err(to_py_err("Broadcast channel closed")),
+                            Err(_) => continue,
+                        }
+                    }
+                }
+            }
+
+            Ok(())
+        })
+    }
+
+    /// Sync environment with current metadata (hot-install new packages).
+    ///
+    /// This attempts to install new packages without restarting the kernel.
+    /// Only supported for UV inline dependencies with additions only.
+    ///
+    /// For removals, conda dependencies, or other cases, this will return
+    /// an error with needs_restart=True indicating a kernel restart is required.
+    ///
+    /// Returns a coroutine that resolves to SyncEnvironmentResult.
+    fn sync_environment<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let state = Arc::clone(&self.state);
+
+        future_into_py(py, async move {
+            let response = {
+                let state_guard = state.lock().await;
+                let handle = state_guard
+                    .handle
+                    .as_ref()
+                    .ok_or_else(|| to_py_err("Not connected"))?;
+
+                handle
+                    .send_request(NotebookRequest::SyncEnvironment {})
+                    .await
+                    .map_err(to_py_err)?
+            };
+
+            match response {
+                NotebookResponse::SyncEnvironmentStarted { packages } => {
+                    // Wait for completion
+                    let mut state_guard = state.lock().await;
+                    if let Some(rx) = state_guard.broadcast_rx.as_mut() {
+                        let deadline =
+                            std::time::Instant::now() + std::time::Duration::from_secs(300);
+                        while std::time::Instant::now() < deadline {
+                            match tokio::time::timeout(std::time::Duration::from_secs(1), rx.recv())
+                                .await
+                            {
+                                Ok(Some(NotebookBroadcast::EnvSyncState {
+                                    in_sync: true, ..
+                                })) => {
+                                    return Ok(SyncEnvironmentResult {
+                                        success: true,
+                                        synced_packages: packages,
+                                        error: None,
+                                        needs_restart: false,
+                                    });
+                                }
+                                Ok(Some(_)) => continue,
+                                Ok(None) => break,
+                                Err(_) => continue,
+                            }
+                        }
+                    }
+                    // Assume success if we got SyncEnvironmentStarted
+                    Ok(SyncEnvironmentResult {
+                        success: true,
+                        synced_packages: packages,
+                        error: None,
+                        needs_restart: false,
+                    })
+                }
+                NotebookResponse::SyncEnvironmentComplete { synced_packages } => {
+                    Ok(SyncEnvironmentResult {
+                        success: true,
+                        synced_packages,
+                        error: None,
+                        needs_restart: false,
+                    })
+                }
+                NotebookResponse::SyncEnvironmentFailed {
+                    error,
+                    needs_restart,
+                } => Ok(SyncEnvironmentResult {
+                    success: false,
+                    synced_packages: vec![],
+                    error: Some(error),
+                    needs_restart,
+                }),
+                NotebookResponse::NoKernel {} => Ok(SyncEnvironmentResult {
+                    success: false,
+                    synced_packages: vec![],
+                    error: Some("No kernel running".to_string()),
+                    needs_restart: true,
+                }),
+                NotebookResponse::Error { error } => Ok(SyncEnvironmentResult {
+                    success: false,
+                    synced_packages: vec![],
+                    error: Some(error),
+                    needs_restart: true,
+                }),
+                other => Err(to_py_err(format!("Unexpected response: {:?}", other))),
+            }
+        })
+    }
+
     // =========================================================================
     // Kernel Introspection (completion, history, queue state)
     // =========================================================================
@@ -1711,4 +2150,59 @@ async fn collect_events_async(
     }
 
     Ok(events)
+}
+
+/// Get the notebook metadata snapshot asynchronously.
+async fn get_notebook_metadata_async(
+    state: &Arc<Mutex<AsyncSessionState>>,
+) -> PyResult<NotebookMetadataSnapshot> {
+    let state_guard = state.lock().await;
+    let handle = state_guard
+        .handle
+        .as_ref()
+        .ok_or_else(|| to_py_err("Not connected"))?;
+
+    let json_str = handle
+        .get_metadata("notebook_metadata")
+        .await
+        .map_err(to_py_err)?;
+
+    match json_str {
+        Some(s) => {
+            serde_json::from_str(&s).map_err(|e| to_py_err(format!("Invalid metadata JSON: {}", e)))
+        }
+        None => Ok(NotebookMetadataSnapshot {
+            kernelspec: None,
+            language_info: None,
+            runt: RuntMetadata {
+                schema_version: "1".to_string(),
+                env_id: None,
+                uv: None,
+                conda: None,
+                deno: None,
+                trust_signature: None,
+                trust_timestamp: None,
+            },
+        }),
+    }
+}
+
+/// Set the notebook metadata snapshot asynchronously.
+async fn set_notebook_metadata_async(
+    state: &Arc<Mutex<AsyncSessionState>>,
+    snapshot: &NotebookMetadataSnapshot,
+) -> PyResult<()> {
+    let json_str = serde_json::to_string(snapshot)
+        .map_err(|e| to_py_err(format!("Failed to serialize metadata: {}", e)))?;
+
+    let state_guard = state.lock().await;
+    let handle = state_guard
+        .handle
+        .as_ref()
+        .ok_or_else(|| to_py_err("Not connected"))?;
+
+    handle
+        .set_metadata("notebook_metadata", &json_str)
+        .await
+        .map_err(to_py_err)
 }

--- a/crates/runtimed-py/src/lib.rs
+++ b/crates/runtimed-py/src/lib.rs
@@ -26,7 +26,7 @@ use error::RuntimedError;
 use event_stream::{ExecutionEventIterator, ExecutionEventStream};
 use output::{
     Cell, CompletionItem, CompletionResult, ExecutionEvent, ExecutionResult, HistoryEntry, Output,
-    QueueState,
+    QueueState, SyncEnvironmentResult,
 };
 use session::Session;
 use subscription::{EventIteratorSubscription, EventSubscription};
@@ -54,6 +54,7 @@ fn runtimed(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<ExecutionResult>()?;
     m.add_class::<ExecutionEvent>()?;
     m.add_class::<Output>()?;
+    m.add_class::<SyncEnvironmentResult>()?;
 
     // Completion and queue types
     m.add_class::<CompletionItem>()?;

--- a/crates/runtimed-py/src/output.rs
+++ b/crates/runtimed-py/src/output.rs
@@ -444,6 +444,37 @@ impl HistoryEntry {
     }
 }
 
+/// Result of syncing environment with metadata.
+#[pyclass(get_all, skip_from_py_object)]
+#[derive(Clone, Debug)]
+pub struct SyncEnvironmentResult {
+    /// Whether the sync completed successfully
+    pub success: bool,
+    /// Packages that were installed (only if success=true)
+    pub synced_packages: Vec<String>,
+    /// Error message (only if success=false)
+    pub error: Option<String>,
+    /// Whether user should restart kernel instead (only if success=false)
+    pub needs_restart: bool,
+}
+
+#[pymethods]
+impl SyncEnvironmentResult {
+    fn __repr__(&self) -> String {
+        if self.success {
+            format!(
+                "SyncEnvironmentResult(success, packages={:?})",
+                self.synced_packages
+            )
+        } else {
+            format!(
+                "SyncEnvironmentResult(failed, error={:?}, needs_restart={})",
+                self.error, self.needs_restart
+            )
+        }
+    }
+}
+
 /// Result of executing code.
 #[pyclass(skip_from_py_object)]
 #[derive(Clone, Debug)]

--- a/crates/runtimed-py/src/session.rs
+++ b/crates/runtimed-py/src/session.rs
@@ -15,9 +15,13 @@ use runtimed::protocol::{NotebookBroadcast, NotebookRequest, NotebookResponse};
 
 use crate::error::to_py_err;
 use crate::event_stream::ExecutionEventIterator;
-use crate::output::{Cell, ExecutionEvent, ExecutionResult, Output};
+use crate::output::{Cell, ExecutionEvent, ExecutionResult, Output, SyncEnvironmentResult};
 use crate::output_resolver;
 use crate::subscription::EventIteratorSubscription;
+
+use notebook_doc::metadata::{
+    CondaInlineMetadata, NotebookMetadataSnapshot, RuntMetadata, UvInlineMetadata,
+};
 
 /// A session for executing code via the runtimed daemon.
 ///
@@ -534,6 +538,147 @@ impl Session {
     }
 
     // =========================================================================
+    // Dependency Management (convenience methods for notebook_metadata)
+    // =========================================================================
+
+    /// Get current UV dependencies.
+    ///
+    /// Returns:
+    ///     List of UV dependency specifiers (e.g., ["pandas>=2.0", "numpy"]).
+    fn get_uv_dependencies(&self) -> PyResult<Vec<String>> {
+        let snapshot = self.get_notebook_metadata()?;
+        Ok(snapshot
+            .runt
+            .uv
+            .map(|uv| uv.dependencies)
+            .unwrap_or_default())
+    }
+
+    /// Add a UV dependency to the notebook.
+    ///
+    /// Args:
+    ///     package: PEP 508 dependency specifier (e.g., "pandas>=2.0", "requests").
+    ///
+    /// Returns:
+    ///     Updated list of dependencies.
+    fn add_uv_dependency(&self, package: &str) -> PyResult<Vec<String>> {
+        let mut snapshot = self.get_notebook_metadata()?;
+
+        let mut deps = snapshot
+            .runt
+            .uv
+            .map(|uv| uv.dependencies)
+            .unwrap_or_default();
+
+        deps.push(package.to_string());
+
+        snapshot.runt.uv = Some(UvInlineMetadata {
+            dependencies: deps.clone(),
+            requires_python: None,
+        });
+
+        self.set_notebook_metadata(&snapshot)?;
+        Ok(deps)
+    }
+
+    /// Remove a UV dependency by exact match.
+    ///
+    /// Args:
+    ///     package: Exact dependency string to remove.
+    ///
+    /// Returns:
+    ///     Updated list of dependencies.
+    fn remove_uv_dependency(&self, package: &str) -> PyResult<Vec<String>> {
+        let mut snapshot = self.get_notebook_metadata()?;
+
+        let mut deps = snapshot
+            .runt
+            .uv
+            .map(|uv| uv.dependencies)
+            .unwrap_or_default();
+        deps.retain(|dep| dep != package);
+
+        snapshot.runt.uv = Some(UvInlineMetadata {
+            dependencies: deps.clone(),
+            requires_python: None,
+        });
+
+        self.set_notebook_metadata(&snapshot)?;
+        Ok(deps)
+    }
+
+    /// Get current Conda dependencies.
+    ///
+    /// Returns:
+    ///     List of Conda package names.
+    fn get_conda_dependencies(&self) -> PyResult<Vec<String>> {
+        let snapshot = self.get_notebook_metadata()?;
+        Ok(snapshot
+            .runt
+            .conda
+            .map(|c| c.dependencies)
+            .unwrap_or_default())
+    }
+
+    /// Add a Conda dependency to the notebook.
+    ///
+    /// Args:
+    ///     package: Conda package specifier (e.g., "numpy", "scipy>=1.0").
+    ///
+    /// Returns:
+    ///     Updated list of dependencies.
+    fn add_conda_dependency(&self, package: &str) -> PyResult<Vec<String>> {
+        let mut snapshot = self.get_notebook_metadata()?;
+
+        let existing = snapshot.runt.conda.unwrap_or(CondaInlineMetadata {
+            dependencies: vec![],
+            channels: vec!["conda-forge".to_string()],
+            python: None,
+        });
+
+        let mut deps = existing.dependencies;
+        deps.push(package.to_string());
+
+        snapshot.runt.conda = Some(CondaInlineMetadata {
+            dependencies: deps.clone(),
+            channels: existing.channels,
+            python: existing.python,
+        });
+
+        self.set_notebook_metadata(&snapshot)?;
+        Ok(deps)
+    }
+
+    /// Remove a Conda dependency by exact match.
+    ///
+    /// Args:
+    ///     package: Exact dependency string to remove.
+    ///
+    /// Returns:
+    ///     Updated list of dependencies.
+    fn remove_conda_dependency(&self, package: &str) -> PyResult<Vec<String>> {
+        let mut snapshot = self.get_notebook_metadata()?;
+
+        let existing = snapshot.runt.conda.unwrap_or(CondaInlineMetadata {
+            dependencies: vec![],
+            channels: vec!["conda-forge".to_string()],
+            python: None,
+        });
+
+        let mut deps = existing.dependencies;
+        deps.retain(|dep| dep != package);
+
+        snapshot.runt.conda = Some(CondaInlineMetadata {
+            dependencies: deps.clone(),
+            channels: existing.channels,
+            python: existing.python,
+        });
+
+        self.set_notebook_metadata(&snapshot)?;
+        Ok(deps)
+    }
+
+    // =========================================================================
     // Execution (document-first: reads source from automerge doc)
     // =========================================================================
 
@@ -862,6 +1007,155 @@ impl Session {
                     Ok(())
                 }
                 NotebookResponse::Error { error } => Err(to_py_err(error)),
+                other => Err(to_py_err(format!("Unexpected response: {:?}", other))),
+            }
+        })
+    }
+
+    /// Restart the kernel.
+    ///
+    /// Shuts down the current kernel and starts a new one. This is useful after
+    /// modifying dependencies to apply the changes.
+    ///
+    /// The new kernel will use env_source="auto" to pick up any inline
+    /// dependencies from the notebook metadata.
+    ///
+    /// Args:
+    ///     wait_for_ready: If True (default), wait for kernel to be idle.
+    ///
+    /// Note: This currently does shutdown + start. A daemon-side RestartKernel
+    /// command would be cleaner but doesn't exist yet.
+    #[pyo3(signature = (wait_for_ready=true))]
+    fn restart_kernel(&self, wait_for_ready: bool) -> PyResult<()> {
+        // TODO: Consider adding NotebookRequest::RestartKernel to the daemon
+        // Shutdown existing kernel
+        self.shutdown_kernel()?;
+
+        // Start new kernel with auto env detection
+        self.start_kernel("python", "auto", None)?;
+
+        if wait_for_ready {
+            // Wait briefly for kernel to become ready
+            // The kernel reports idle status via broadcasts after startup
+            self.runtime.block_on(async {
+                let mut state = self.state.lock().await;
+                let broadcast_rx = state.broadcast_rx.as_mut();
+                if let Some(rx) = broadcast_rx {
+                    // Wait up to 30 seconds for kernel ready
+                    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+                    while std::time::Instant::now() < deadline {
+                        match tokio::time::timeout(std::time::Duration::from_millis(100), rx.recv())
+                            .await
+                        {
+                            Ok(Some(NotebookBroadcast::KernelStatus { status, .. }))
+                                if status == "idle" =>
+                            {
+                                return Ok(());
+                            }
+                            Ok(Some(_)) => continue, // Other broadcasts, keep waiting
+                            Ok(None) => return Err(to_py_err("Broadcast channel closed")),
+                            Err(_) => continue, // Timeout, keep waiting
+                        }
+                    }
+                }
+                Ok(()) // Timeout waiting for ready, but kernel was launched
+            })
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Sync environment with current metadata (hot-install new packages).
+    ///
+    /// This attempts to install new packages without restarting the kernel.
+    /// Only supported for UV inline dependencies with additions only.
+    ///
+    /// For removals, conda dependencies, or other cases, this will return
+    /// an error with needs_restart=True indicating a kernel restart is required.
+    ///
+    /// Returns:
+    ///     SyncEnvironmentResult with success status and installed packages.
+    fn sync_environment(&self) -> PyResult<SyncEnvironmentResult> {
+        self.runtime.block_on(async {
+            let state = self.state.lock().await;
+
+            let handle = state
+                .handle
+                .as_ref()
+                .ok_or_else(|| to_py_err("Not connected"))?;
+
+            let response = handle
+                .send_request(NotebookRequest::SyncEnvironment {})
+                .await
+                .map_err(to_py_err)?;
+
+            drop(state); // Release lock before waiting for follow-up responses
+
+            match response {
+                NotebookResponse::SyncEnvironmentStarted { packages } => {
+                    // Wait for completion
+                    let mut state = self.state.lock().await;
+                    let broadcast_rx = state.broadcast_rx.as_mut();
+                    if let Some(rx) = broadcast_rx {
+                        let deadline =
+                            std::time::Instant::now() + std::time::Duration::from_secs(300);
+                        while std::time::Instant::now() < deadline {
+                            match tokio::time::timeout(std::time::Duration::from_secs(1), rx.recv())
+                                .await
+                            {
+                                Ok(Some(NotebookBroadcast::EnvSyncState {
+                                    in_sync: true, ..
+                                })) => {
+                                    return Ok(SyncEnvironmentResult {
+                                        success: true,
+                                        synced_packages: packages,
+                                        error: None,
+                                        needs_restart: false,
+                                    });
+                                }
+                                Ok(Some(_)) => continue,
+                                Ok(None) => break,
+                                Err(_) => continue,
+                            }
+                        }
+                    }
+                    // Assume success if we got SyncEnvironmentStarted
+                    Ok(SyncEnvironmentResult {
+                        success: true,
+                        synced_packages: packages,
+                        error: None,
+                        needs_restart: false,
+                    })
+                }
+                NotebookResponse::SyncEnvironmentComplete { synced_packages } => {
+                    Ok(SyncEnvironmentResult {
+                        success: true,
+                        synced_packages,
+                        error: None,
+                        needs_restart: false,
+                    })
+                }
+                NotebookResponse::SyncEnvironmentFailed {
+                    error,
+                    needs_restart,
+                } => Ok(SyncEnvironmentResult {
+                    success: false,
+                    synced_packages: vec![],
+                    error: Some(error),
+                    needs_restart,
+                }),
+                NotebookResponse::NoKernel {} => Ok(SyncEnvironmentResult {
+                    success: false,
+                    synced_packages: vec![],
+                    error: Some("No kernel running".to_string()),
+                    needs_restart: true,
+                }),
+                NotebookResponse::Error { error } => Ok(SyncEnvironmentResult {
+                    success: false,
+                    synced_packages: vec![],
+                    error: Some(error),
+                    needs_restart: true,
+                }),
                 other => Err(to_py_err(format!("Unexpected response: {:?}", other))),
             }
         })
@@ -1338,5 +1632,40 @@ impl Session {
         }
 
         Ok(events)
+    }
+}
+
+// =========================================================================
+// Internal helper methods (not exposed to Python)
+// =========================================================================
+
+impl Session {
+    /// Get the current notebook metadata snapshot.
+    fn get_notebook_metadata(&self) -> PyResult<NotebookMetadataSnapshot> {
+        let json_str = self.get_metadata("notebook_metadata")?;
+        match json_str {
+            Some(s) => serde_json::from_str(&s)
+                .map_err(|e| to_py_err(format!("Invalid metadata JSON: {}", e))),
+            None => Ok(NotebookMetadataSnapshot {
+                kernelspec: None,
+                language_info: None,
+                runt: RuntMetadata {
+                    schema_version: "1".to_string(),
+                    env_id: None,
+                    uv: None,
+                    conda: None,
+                    deno: None,
+                    trust_signature: None,
+                    trust_timestamp: None,
+                },
+            }),
+        }
+    }
+
+    /// Set the notebook metadata snapshot.
+    fn set_notebook_metadata(&self, snapshot: &NotebookMetadataSnapshot) -> PyResult<()> {
+        let json_str = serde_json::to_string(snapshot)
+            .map_err(|e| to_py_err(format!("Failed to serialize metadata: {}", e)))?;
+        self.set_metadata("notebook_metadata", &json_str)
     }
 }


### PR DESCRIPTION
## Summary

Add comprehensive dependency management to the runtimed-py Python bindings, enabling agents to programmatically manage notebook environments just like the frontend does.

**New capabilities:**
- Get/add/remove UV and Conda dependencies from notebook metadata
- Restart kernel with new environment configuration  
- Hot-install UV packages via `sync_environment()` (UV additions only, no restart needed)

## Changes

### New Output Type
- `SyncEnvironmentResult`: Represents outcome of environment sync operation with `success`, `synced_packages`, `error`, and `needs_restart` fields

### New Methods on Session and AsyncSession (8 methods each)
1. `get_uv_dependencies()` - Get current UV dependency list
2. `add_uv_dependency(package)` - Add UV dependency (exact match), returns updated list
3. `remove_uv_dependency(package)` - Remove UV dependency (exact match), returns updated list
4. `get_conda_dependencies()` - Get current Conda dependency list
5. `add_conda_dependency(package)` - Add Conda dependency (exact match), returns updated list
6. `remove_conda_dependency(package)` - Remove Conda dependency (exact match), returns updated list
7. `restart_kernel(wait_for_ready=true)` - Shutdown kernel and start new one with "auto" environment detection (picks up inline deps)
8. `sync_environment()` - Hot-install UV packages via daemon sync protocol, returns `SyncEnvironmentResult`

### Implementation Details

**Dependency management:**
- Reads/writes notebook metadata via the daemon's metadata system
- Dependencies stored in `metadata.runt.uv.dependencies` and `metadata.runt.conda.dependencies` 
- Uses exact string matching for add/remove (accepts full PEP 508 specs from user)

**Kernel restart:**
- Calls `shutdown_kernel()` then `start_kernel()` with "auto" env_source
- "auto" mode triggers daemon environment detection to pick up inline deps
- Optionally waits for kernel to reach "idle" status (30s timeout)

**Sync environment:**
- Implements daemon protocol for hot-installing UV packages without restart
- Returns success/failure with detailed error and needs_restart flag
- Only works for UV inline additions (removals/conda require full restart)

### Dependencies
Added `notebook-doc` crate for `NotebookMetadataSnapshot` types needed to read/write metadata.

## API Example

```python
from runtimed import Session

# Add dependencies and restart
with Session() as session:
    session.start_kernel()
    session.add_uv_dependency("pandas>=2.0")
    session.add_uv_dependency("matplotlib")
    session.restart_kernel()
    result = session.run("import pandas; import matplotlib")

# Hot-install (UV only, no restart)
with Session() as session:
    session.start_kernel()
    session.add_uv_dependency("requests")
    sync_result = session.sync_environment()
    if sync_result.success:
        session.run("import requests")
    elif sync_result.needs_restart:
        session.restart_kernel()
```

## Test Plan

- [x] Code compiles with `cargo check -p runtimed-py`
- [x] Code is formatted with `cargo fmt -p runtimed-py`
- [ ] Manual verification in Python: call get/add/remove methods and verify metadata changes
- [ ] Manual verification: restart_kernel() shuts down and starts new kernel
- [ ] Manual verification: sync_environment() works for UV additions