### PR TITLE
fix(security): restrict access to trust key and socket to user

### DIFF
--- a/crates/runt-trust/src/lib.rs
+++ b/crates/runt-trust/src/lib.rs
@@ -92,6 +92,15 @@ pub fn get_or_create_trust_key() -> Result<[u8; 32], String> {
 
         std::fs::write(&key_path, key).map_err(|e| format!("Failed to write trust key: {}", e))?;
 
+        // Restrict key file permissions to owner-only (0600) so other users cannot
+        // read the HMAC key and forge trust signatures.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&key_path, std::fs::Permissions::from_mode(0o600))
+                .map_err(|e| format!("Failed to set trust key permissions: {}", e))?;
+        }
+
         Ok(key)
     }
 }

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -499,6 +499,17 @@ impl Daemon {
     #[cfg(unix)]
     async fn run_unix_server(self: &Arc<Self>) -> anyhow::Result<()> {
         let listener = UnixListener::bind(&self.config.socket_path)?;
+
+        // Restrict socket permissions to owner-only (0600) so other users cannot
+        // connect to the daemon.
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(
+                &self.config.socket_path,
+                std::fs::Permissions::from_mode(0o600),
+            )?;
+        }
+
         info!("[runtimed] Listening on {:?}", self.config.socket_path);
 
         loop {


### PR DESCRIPTION
Restrict the unix socket and trust key to originating user.