### PR TITLE
fix(runtimed): add 10-second timeout on IPC handshake

### DIFF
--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -850,12 +850,16 @@ impl Daemon {
     where
         S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
     {
-        // Read the handshake with the control frame limit (64 KiB) so that
-        // an oversized first frame can't force a large allocation before we
-        // know which channel the connection belongs to.
-        let handshake_bytes = connection::recv_control_frame(&mut stream)
-            .await?
-            .ok_or_else(|| anyhow::anyhow!("connection closed before handshake"))?;
+        // Read the handshake with the control frame limit (64 KiB) and a
+        // timeout so that idle/stalled connections don't hold resources.
+        let handshake_bytes = tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            connection::recv_control_frame(&mut stream),
+        )
+        .await
+        .map_err(|_| anyhow::anyhow!("handshake timeout (10s)"))?
+        .map_err(|e| anyhow::anyhow!("handshake read error: {}", e))?
+        .ok_or_else(|| anyhow::anyhow!("connection closed before handshake"))?;
         let handshake: Handshake = serde_json::from_slice(&handshake_bytes)?;
 
         match handshake {


### PR DESCRIPTION
Adds a timeout to prevent idle client connections from holding daemon resources indefinitely. Without a timeout, a client that connects to the daemon socket but never sends a handshake frame leaves the connection open, wasting a tokio task and file descriptor.

Wraps the initial `recv_control_frame` call in `route_connection` with a 10-second timeout. Stalled connections are now dropped with a clear error message.

## Verification

* [x] Daemon starts normally and connects to clients
* [x] Verify timeout behavior: create a test client that connects but doesn't send handshake, confirm it's dropped after ~10s
* [x] Check daemon logs for "handshake timeout" errors

_PR submitted by @rgbkrk's agent, Quill_