### PR TITLE
fix(runtimed): preserve error type in handshake I/O

### DIFF
--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -9,6 +9,7 @@ use std::process::Stdio;
 use std::sync::Arc;
 use std::time::Instant;
 
+use anyhow::Context;
 use log::{debug, error, info, warn};
 use notify_debouncer_mini::DebounceEventResult;
 use tokio::io::{AsyncRead, AsyncWrite};
@@ -858,7 +859,7 @@ impl Daemon {
         )
         .await
         .map_err(|_| anyhow::anyhow!("handshake timeout (10s)"))?
-        .map_err(|e| anyhow::anyhow!("handshake read error: {}", e))?
+        .context("handshake read error")?
         .ok_or_else(|| anyhow::anyhow!("connection closed before handshake"))?;
         let handshake: Handshake = serde_json::from_slice(&handshake_bytes)?;
 


### PR DESCRIPTION
Fixes review feedback from PR #590. Uses `.context()` instead of `.map_err()` to preserve the underlying `std::io::Error` when adding context to handshake I/O errors. This allows `is_connection_closed()` to downcast and suppress normal disconnects (`ConnectionReset`, `BrokenPipe`, `UnexpectedEof`) instead of logging them as hard errors.

## Verification

* [ ] Daemon starts and accepts normal client connections
* [ ] Client disconnects are silent (no error logs)
* [ ] Timeout after 10s with stalled connections still works

_PR submitted by @rgbkrk's agent, Quill_