### PR TITLE
feat(runtimed): daemon-owned notebook loading infrastructure (#598)

### DIFF
--- a/crates/runtimed/src/connection.rs
+++ b/crates/runtimed/src/connection.rs
@@ -65,6 +65,28 @@ pub enum Handshake {
     /// Pool state subscription: receive broadcasts when pool errors occur/clear.
     /// Read-only channel - server pushes DaemonBroadcast messages to client.
     PoolStateSubscribe,
+
+    /// Open an existing notebook file. Daemon loads from disk, derives notebook_id.
+    ///
+    /// The daemon returns `NotebookConnectionInfo` before starting sync.
+    /// After that, the connection becomes a normal notebook sync connection.
+    OpenNotebook {
+        /// Path to the .ipynb file.
+        path: String,
+    },
+
+    /// Create a new untitled notebook. Daemon creates empty room, generates env_id.
+    ///
+    /// The daemon returns `NotebookConnectionInfo` before starting sync.
+    /// After that, the connection becomes a normal notebook sync connection.
+    CreateNotebook {
+        /// Runtime type: "python" or "deno".
+        runtime: String,
+        /// Working directory for project file detection (pyproject.toml, pixi.toml, environment.yml).
+        /// Used since untitled notebooks have no path to derive working_dir from.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        working_dir: Option<String>,
+    },
 }
 
 /// Protocol version constant.
@@ -73,10 +95,32 @@ pub const PROTOCOL_V2: &str = "v2";
 /// Server response indicating protocol capabilities.
 ///
 /// Sent immediately after handshake, before starting sync.
+/// Used by the `NotebookSync` handshake variant.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProtocolCapabilities {
     /// Protocol version (currently always "v2").
     pub protocol: String,
+}
+
+/// Server response for `OpenNotebook` and `CreateNotebook` handshakes.
+///
+/// Sent immediately after handshake, before starting sync.
+/// Contains notebook_id derived by the daemon (from path or generated env_id).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NotebookConnectionInfo {
+    /// Protocol version (currently always "v2").
+    pub protocol: String,
+    /// Notebook identifier derived by the daemon.
+    /// For existing files: canonical path.
+    /// For new notebooks: generated UUID (env_id).
+    pub notebook_id: String,
+    /// Number of cells in the notebook (for progress indication).
+    pub cell_count: usize,
+    /// True if the notebook has untrusted dependencies requiring user approval.
+    pub needs_trust_approval: bool,
+    /// Error message if the notebook could not be opened/created.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
 }
 
 /// Frame types for notebook sync connections.
@@ -379,6 +423,74 @@ mod tests {
         // Blob
         let json = serde_json::to_string(&Handshake::Blob).unwrap();
         assert_eq!(json, r#"{"channel":"blob"}"#);
+
+        // OpenNotebook
+        let json = serde_json::to_string(&Handshake::OpenNotebook {
+            path: "/home/user/notebook.ipynb".into(),
+        })
+        .unwrap();
+        assert_eq!(
+            json,
+            r#"{"channel":"open_notebook","path":"/home/user/notebook.ipynb"}"#
+        );
+
+        // CreateNotebook without working_dir
+        let json = serde_json::to_string(&Handshake::CreateNotebook {
+            runtime: "python".into(),
+            working_dir: None,
+        })
+        .unwrap();
+        assert_eq!(json, r#"{"channel":"create_notebook","runtime":"python"}"#);
+
+        // CreateNotebook with working_dir
+        let json = serde_json::to_string(&Handshake::CreateNotebook {
+            runtime: "deno".into(),
+            working_dir: Some("/home/user/project".into()),
+        })
+        .unwrap();
+        assert_eq!(
+            json,
+            r#"{"channel":"create_notebook","runtime":"deno","working_dir":"/home/user/project"}"#
+        );
+    }
+
+    #[test]
+    fn test_notebook_connection_info_serialization() {
+        // Success case
+        let info = NotebookConnectionInfo {
+            protocol: "v2".into(),
+            notebook_id: "/home/user/notebook.ipynb".into(),
+            cell_count: 5,
+            needs_trust_approval: false,
+            error: None,
+        };
+        let json = serde_json::to_string(&info).unwrap();
+        assert_eq!(
+            json,
+            r#"{"protocol":"v2","notebook_id":"/home/user/notebook.ipynb","cell_count":5,"needs_trust_approval":false}"#
+        );
+
+        // With trust approval needed
+        let info = NotebookConnectionInfo {
+            protocol: "v2".into(),
+            notebook_id: "550e8400-e29b-41d4-a716-446655440000".into(),
+            cell_count: 1,
+            needs_trust_approval: true,
+            error: None,
+        };
+        let json = serde_json::to_string(&info).unwrap();
+        assert!(json.contains(r#""needs_trust_approval":true"#));
+
+        // Error case
+        let info = NotebookConnectionInfo {
+            protocol: "v2".into(),
+            notebook_id: String::new(),
+            cell_count: 0,
+            needs_trust_approval: false,
+            error: Some("File not found".into()),
+        };
+        let json = serde_json::to_string(&info).unwrap();
+        assert!(json.contains(r#""error":"File not found""#));
     }
 
     #[tokio::test]

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -923,7 +923,77 @@ impl Daemon {
             }
             Handshake::Blob => self.handle_blob_connection(stream).await,
             Handshake::PoolStateSubscribe => self.handle_pool_state_subscription(stream).await,
+            Handshake::OpenNotebook { path } => self.handle_open_notebook(stream, path).await,
+            Handshake::CreateNotebook {
+                runtime,
+                working_dir,
+            } => {
+                self.handle_create_notebook(stream, runtime, working_dir)
+                    .await
+            }
         }
+    }
+
+    /// Handle an OpenNotebook connection.
+    ///
+    /// Daemon loads the .ipynb file, derives notebook_id, creates room, populates doc.
+    /// Returns NotebookConnectionInfo, then continues as normal notebook sync.
+    async fn handle_open_notebook<S>(
+        self: Arc<Self>,
+        mut stream: S,
+        path: String,
+    ) -> anyhow::Result<()>
+    where
+        S: AsyncRead + AsyncWrite + Unpin,
+    {
+        use crate::connection::{send_json_frame, NotebookConnectionInfo, PROTOCOL_V2};
+
+        info!("[runtimed] OpenNotebook requested for {}", path);
+
+        // TODO(#598): Implement daemon-owned loading
+        // For now, return an error to indicate this handshake is not yet implemented
+        let response = NotebookConnectionInfo {
+            protocol: PROTOCOL_V2.to_string(),
+            notebook_id: String::new(),
+            cell_count: 0,
+            needs_trust_approval: false,
+            error: Some("OpenNotebook handshake not yet implemented".to_string()),
+        };
+        send_json_frame(&mut stream, &response).await?;
+        Ok(())
+    }
+
+    /// Handle a CreateNotebook connection.
+    ///
+    /// Daemon creates empty room with one code cell, generates env_id as notebook_id.
+    /// Returns NotebookConnectionInfo, then continues as normal notebook sync.
+    async fn handle_create_notebook<S>(
+        self: Arc<Self>,
+        mut stream: S,
+        runtime: String,
+        working_dir: Option<String>,
+    ) -> anyhow::Result<()>
+    where
+        S: AsyncRead + AsyncWrite + Unpin,
+    {
+        use crate::connection::{send_json_frame, NotebookConnectionInfo, PROTOCOL_V2};
+
+        info!(
+            "[runtimed] CreateNotebook requested (runtime={}, working_dir={:?})",
+            runtime, working_dir
+        );
+
+        // TODO(#598): Implement daemon-owned creation
+        // For now, return an error to indicate this handshake is not yet implemented
+        let response = NotebookConnectionInfo {
+            protocol: PROTOCOL_V2.to_string(),
+            notebook_id: String::new(),
+            cell_count: 0,
+            needs_trust_approval: false,
+            error: Some("CreateNotebook handshake not yet implemented".to_string()),
+        };
+        send_json_frame(&mut stream, &response).await?;
+        Ok(())
     }
 
     /// Handle a pool state subscription connection.

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -938,11 +938,7 @@ impl Daemon {
     ///
     /// Daemon loads the .ipynb file, derives notebook_id, creates room, populates doc.
     /// Returns NotebookConnectionInfo, then continues as normal notebook sync.
-    async fn handle_open_notebook<S>(
-        self: Arc<Self>,
-        mut stream: S,
-        path: String,
-    ) -> anyhow::Result<()>
+    async fn handle_open_notebook<S>(self: Arc<Self>, stream: S, path: String) -> anyhow::Result<()>
     where
         S: AsyncRead + AsyncWrite + Unpin,
     {
@@ -950,17 +946,108 @@ impl Daemon {
 
         info!("[runtimed] OpenNotebook requested for {}", path);
 
-        // TODO(#598): Implement daemon-owned loading
-        // For now, return an error to indicate this handshake is not yet implemented
+        // Canonicalize path to derive notebook_id (stable across processes)
+        let path_buf = std::path::PathBuf::from(&path);
+        let notebook_id = path_buf
+            .canonicalize()
+            .unwrap_or_else(|_| path_buf.clone())
+            .to_string_lossy()
+            .to_string();
+
+        // Get or create room for this notebook
+        let docs_dir = self.config.notebook_docs_dir.clone();
+        let room = {
+            let mut rooms = self.notebook_rooms.lock().await;
+            crate::notebook_sync_server::get_or_create_room(
+                &mut rooms,
+                &notebook_id,
+                &docs_dir,
+                self.blob_store.clone(),
+            )
+        };
+
+        // Check if this is the first connection (doc is empty)
+        let cell_count = {
+            let doc = room.doc.read().await;
+            doc.cell_count()
+        };
+
+        // If doc is empty, load from disk (first connection to this notebook)
+        let cell_count = if cell_count == 0 {
+            let mut doc = room.doc.write().await;
+            match crate::notebook_sync_server::load_notebook_from_disk(&mut doc, &path_buf).await {
+                Ok(count) => {
+                    info!("[runtimed] Loaded {} cells from {} into room", count, path);
+                    count
+                }
+                Err(e) => {
+                    // Send error response and return
+                    let (mut reader, mut writer) = tokio::io::split(stream);
+                    let response = NotebookConnectionInfo {
+                        protocol: PROTOCOL_V2.to_string(),
+                        notebook_id: String::new(),
+                        cell_count: 0,
+                        needs_trust_approval: false,
+                        error: Some(format!("Failed to load notebook: {}", e)),
+                    };
+                    send_json_frame(&mut writer, &response).await?;
+                    // Drain any remaining data from reader to avoid broken pipe
+                    let _ = tokio::io::copy(&mut reader, &mut tokio::io::sink()).await;
+                    return Ok(());
+                }
+            }
+        } else {
+            // Room already has cells from another connection
+            info!(
+                "[runtimed] Room for {} already has {} cells (joining existing)",
+                path, cell_count
+            );
+            cell_count
+        };
+
+        // Get trust state (already verified during room creation)
+        let trust_state = room.trust_state.read().await;
+        let needs_trust_approval = !matches!(
+            trust_state.status,
+            runt_trust::TrustStatus::Trusted | runt_trust::TrustStatus::NoDependencies
+        );
+
+        // Send NotebookConnectionInfo response
+        let (reader, mut writer) = tokio::io::split(stream);
         let response = NotebookConnectionInfo {
             protocol: PROTOCOL_V2.to_string(),
-            notebook_id: String::new(),
-            cell_count: 0,
-            needs_trust_approval: false,
-            error: Some("OpenNotebook handshake not yet implemented".to_string()),
+            notebook_id: notebook_id.clone(),
+            cell_count,
+            needs_trust_approval,
+            error: None,
         };
-        send_json_frame(&mut stream, &response).await?;
-        Ok(())
+        send_json_frame(&mut writer, &response).await?;
+
+        // Get settings for sync and auto-launch
+        let settings = self.settings.read().await.get_all();
+        let default_runtime = settings.default_runtime;
+        let default_python_env = settings.default_python_env;
+
+        // working_dir derived from path's parent directory
+        let working_dir_path = path_buf.parent().map(|p| p.to_path_buf());
+
+        // Drop the trust_state lock before continuing
+        drop(trust_state);
+
+        // Continue with normal notebook sync (handles auto-launch internally)
+        crate::notebook_sync_server::handle_notebook_sync_connection(
+            reader,
+            writer,
+            room,
+            self.notebook_rooms.clone(),
+            notebook_id,
+            default_runtime,
+            default_python_env,
+            self.clone(),
+            working_dir_path,
+            None, // No initial_metadata - doc is already populated
+        )
+        .await
     }
 
     /// Handle a CreateNotebook connection.
@@ -969,7 +1056,7 @@ impl Daemon {
     /// Returns NotebookConnectionInfo, then continues as normal notebook sync.
     async fn handle_create_notebook<S>(
         self: Arc<Self>,
-        mut stream: S,
+        stream: S,
         runtime: String,
         working_dir: Option<String>,
     ) -> anyhow::Result<()>
@@ -983,17 +1070,81 @@ impl Daemon {
             runtime, working_dir
         );
 
-        // TODO(#598): Implement daemon-owned creation
-        // For now, return an error to indicate this handshake is not yet implemented
+        // Get settings for default Python env preference
+        let settings = self.settings.read().await.get_all();
+        let default_python_env = settings.default_python_env;
+        let default_runtime = settings.default_runtime;
+
+        // Generate notebook_id (env_id) upfront - UUID for untitled notebooks
+        let notebook_id = uuid::Uuid::new_v4().to_string();
+
+        // Create room for this notebook
+        let docs_dir = self.config.notebook_docs_dir.clone();
+        let room = {
+            let mut rooms = self.notebook_rooms.lock().await;
+            crate::notebook_sync_server::get_or_create_room(
+                &mut rooms,
+                &notebook_id,
+                &docs_dir,
+                self.blob_store.clone(),
+            )
+        };
+
+        // Populate the room's doc with the empty notebook content
+        let cell_count = {
+            let mut doc = room.doc.write().await;
+            match crate::notebook_sync_server::create_empty_notebook(
+                &mut doc,
+                &runtime,
+                default_python_env.clone(),
+                Some(&notebook_id),
+            ) {
+                Ok(_) => doc.cell_count(),
+                Err(e) => {
+                    let (mut reader, mut writer) = tokio::io::split(stream);
+                    let response = NotebookConnectionInfo {
+                        protocol: PROTOCOL_V2.to_string(),
+                        notebook_id: String::new(),
+                        cell_count: 0,
+                        needs_trust_approval: false,
+                        error: Some(format!("Failed to create notebook: {}", e)),
+                    };
+                    send_json_frame(&mut writer, &response).await?;
+                    let _ = tokio::io::copy(&mut reader, &mut tokio::io::sink()).await;
+                    return Ok(());
+                }
+            }
+        };
+
+        // Send NotebookConnectionInfo response
+        // New notebooks have no deps, so no trust approval needed
+        let (reader, mut writer) = tokio::io::split(stream);
         let response = NotebookConnectionInfo {
             protocol: PROTOCOL_V2.to_string(),
-            notebook_id: String::new(),
-            cell_count: 0,
+            notebook_id: notebook_id.clone(),
+            cell_count,
             needs_trust_approval: false,
-            error: Some("CreateNotebook handshake not yet implemented".to_string()),
+            error: None,
         };
-        send_json_frame(&mut stream, &response).await?;
-        Ok(())
+        send_json_frame(&mut writer, &response).await?;
+
+        // working_dir for untitled notebooks (used for project file detection)
+        let working_dir_path = working_dir.map(std::path::PathBuf::from);
+
+        // Continue with normal notebook sync
+        crate::notebook_sync_server::handle_notebook_sync_connection(
+            reader,
+            writer,
+            room,
+            self.notebook_rooms.clone(),
+            notebook_id,
+            default_runtime,
+            default_python_env,
+            self.clone(),
+            working_dir_path,
+            None, // No initial_metadata - doc is already populated
+        )
+        .await
     }
 
     /// Handle a pool state subscription connection.

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -1116,6 +1116,17 @@ impl Daemon {
             ) {
                 Ok(_) => doc.cell_count(),
                 Err(e) => {
+                    // Drop the doc lock before removing room
+                    drop(doc);
+                    // Remove the room to prevent stale state (consistency with OpenNotebook)
+                    {
+                        let mut rooms = self.notebook_rooms.lock().await;
+                        rooms.remove(&notebook_id);
+                        info!(
+                            "[runtimed] Removed room {} after create failure",
+                            notebook_id
+                        );
+                    }
                     let (mut reader, mut writer) = tokio::io::split(stream);
                     let response = NotebookConnectionInfo {
                         protocol: PROTOCOL_V2.to_string(),

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -918,6 +918,7 @@ impl Daemon {
                     self.clone(),
                     working_dir_path,
                     initial_metadata,
+                    false, // Send ProtocolCapabilities for legacy NotebookSync handshake
                 )
                 .await
             }
@@ -1059,6 +1060,7 @@ impl Daemon {
             self.clone(),
             working_dir_path,
             None, // No initial_metadata - doc is already populated
+            true, // Skip ProtocolCapabilities - already sent in NotebookConnectionInfo
         )
         .await
     }
@@ -1156,6 +1158,7 @@ impl Daemon {
             self.clone(),
             working_dir_path,
             None, // No initial_metadata - doc is already populated
+            true, // Skip ProtocolCapabilities - already sent in NotebookConnectionInfo
         )
         .await
     }

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -989,10 +989,7 @@ impl Daemon {
                         {
                             let mut rooms = self.notebook_rooms.lock().await;
                             rooms.remove(&notebook_id);
-                            info!(
-                                "[runtimed] Removed room {} after load failure",
-                                notebook_id
-                            );
+                            info!("[runtimed] Removed room {} after load failure", notebook_id);
                         }
                         // Send error response and return
                         let (mut reader, mut writer) = tokio::io::split(stream);

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -966,43 +966,56 @@ impl Daemon {
             )
         };
 
-        // Check if this is the first connection (doc is empty)
+        // Check-and-load atomically under write lock to prevent race conditions.
+        // Two concurrent opens could both see cell_count == 0 if we check with
+        // read lock first, leading to duplicate cells.
         let cell_count = {
-            let doc = room.doc.read().await;
-            doc.cell_count()
-        };
-
-        // If doc is empty, load from disk (first connection to this notebook)
-        let cell_count = if cell_count == 0 {
             let mut doc = room.doc.write().await;
-            match crate::notebook_sync_server::load_notebook_from_disk(&mut doc, &path_buf).await {
-                Ok(count) => {
-                    info!("[runtimed] Loaded {} cells from {} into room", count, path);
-                    count
+            let existing_count = doc.cell_count();
+            if existing_count == 0 {
+                // First connection - load from disk
+                match crate::notebook_sync_server::load_notebook_from_disk(&mut doc, &path_buf)
+                    .await
+                {
+                    Ok(count) => {
+                        info!("[runtimed] Loaded {} cells from {} into room", count, path);
+                        count
+                    }
+                    Err(e) => {
+                        // Drop the doc lock before removing room
+                        drop(doc);
+                        // Remove the room to prevent stale trust state on retry
+                        {
+                            let mut rooms = self.notebook_rooms.lock().await;
+                            rooms.remove(&notebook_id);
+                            info!(
+                                "[runtimed] Removed room {} after load failure",
+                                notebook_id
+                            );
+                        }
+                        // Send error response and return
+                        let (mut reader, mut writer) = tokio::io::split(stream);
+                        let response = NotebookConnectionInfo {
+                            protocol: PROTOCOL_V2.to_string(),
+                            notebook_id: String::new(),
+                            cell_count: 0,
+                            needs_trust_approval: false,
+                            error: Some(format!("Failed to load notebook: {}", e)),
+                        };
+                        send_json_frame(&mut writer, &response).await?;
+                        // Drain any remaining data from reader to avoid broken pipe
+                        let _ = tokio::io::copy(&mut reader, &mut tokio::io::sink()).await;
+                        return Ok(());
+                    }
                 }
-                Err(e) => {
-                    // Send error response and return
-                    let (mut reader, mut writer) = tokio::io::split(stream);
-                    let response = NotebookConnectionInfo {
-                        protocol: PROTOCOL_V2.to_string(),
-                        notebook_id: String::new(),
-                        cell_count: 0,
-                        needs_trust_approval: false,
-                        error: Some(format!("Failed to load notebook: {}", e)),
-                    };
-                    send_json_frame(&mut writer, &response).await?;
-                    // Drain any remaining data from reader to avoid broken pipe
-                    let _ = tokio::io::copy(&mut reader, &mut tokio::io::sink()).await;
-                    return Ok(());
-                }
+            } else {
+                // Room already has cells from another connection
+                info!(
+                    "[runtimed] Room for {} already has {} cells (joining existing)",
+                    path, existing_count
+                );
+                existing_count
             }
-        } else {
-            // Room already has cells from another connection
-            info!(
-                "[runtimed] Room for {} already has {} cells (joining existing)",
-                path, cell_count
-            );
-            cell_count
         };
 
         // Get trust state (already verified during room creation)

--- a/crates/runtimed/src/notebook_sync_client.rs
+++ b/crates/runtimed/src/notebook_sync_client.rs
@@ -23,7 +23,9 @@ use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::sync::{broadcast, mpsc, oneshot};
 
-use crate::connection::{self, Handshake, NotebookFrameType, ProtocolCapabilities, PROTOCOL_V2};
+use crate::connection::{
+    self, Handshake, NotebookConnectionInfo, NotebookFrameType, ProtocolCapabilities, PROTOCOL_V2,
+};
 use crate::notebook_doc::{
     get_cells_from_doc, get_metadata_from_doc, set_metadata_in_doc, CellSnapshot,
 };
@@ -599,6 +601,73 @@ impl NotebookSyncClient<tokio::net::UnixStream> {
         .await?;
         Ok(client.into_split_with_raw_sync(raw_sync_tx))
     }
+
+    /// Connect by opening an existing notebook file (daemon-owned loading).
+    ///
+    /// The daemon loads the file, derives the notebook_id, and returns it.
+    /// Returns NotebookConnectionInfo so caller can get notebook_id and trust status.
+    pub async fn connect_open_split(
+        socket_path: PathBuf,
+        path: PathBuf,
+        raw_sync_tx: Option<mpsc::UnboundedSender<Vec<u8>>>,
+    ) -> Result<
+        (
+            NotebookSyncHandle,
+            NotebookSyncReceiver,
+            NotebookBroadcastReceiver,
+            Vec<CellSnapshot>,
+            Option<String>,
+            NotebookConnectionInfo,
+        ),
+        NotebookSyncError,
+    > {
+        let stream = tokio::time::timeout(
+            Duration::from_secs(2),
+            tokio::net::UnixStream::connect(&socket_path),
+        )
+        .await
+        .map_err(|_| NotebookSyncError::Timeout)?
+        .map_err(NotebookSyncError::ConnectionFailed)?;
+
+        let (client, info) = Self::init_open_notebook(stream, path).await?;
+        let (handle, receiver, broadcast_rx, cells, metadata) =
+            client.into_split_with_raw_sync(raw_sync_tx);
+        Ok((handle, receiver, broadcast_rx, cells, metadata, info))
+    }
+
+    /// Connect by creating a new notebook (daemon-owned creation).
+    ///
+    /// The daemon creates an empty notebook with one cell and returns the notebook_id.
+    /// Returns NotebookConnectionInfo so caller can get notebook_id.
+    pub async fn connect_create_split(
+        socket_path: PathBuf,
+        runtime: String,
+        working_dir: Option<PathBuf>,
+        raw_sync_tx: Option<mpsc::UnboundedSender<Vec<u8>>>,
+    ) -> Result<
+        (
+            NotebookSyncHandle,
+            NotebookSyncReceiver,
+            NotebookBroadcastReceiver,
+            Vec<CellSnapshot>,
+            Option<String>,
+            NotebookConnectionInfo,
+        ),
+        NotebookSyncError,
+    > {
+        let stream = tokio::time::timeout(
+            Duration::from_secs(2),
+            tokio::net::UnixStream::connect(&socket_path),
+        )
+        .await
+        .map_err(|_| NotebookSyncError::Timeout)?
+        .map_err(NotebookSyncError::ConnectionFailed)?;
+
+        let (client, info) = Self::init_create_notebook(stream, runtime, working_dir).await?;
+        let (handle, receiver, broadcast_rx, cells, metadata) =
+            client.into_split_with_raw_sync(raw_sync_tx);
+        Ok((handle, receiver, broadcast_rx, cells, metadata, info))
+    }
 }
 
 #[cfg(windows)]
@@ -685,6 +754,61 @@ impl NotebookSyncClient<tokio::net::windows::named_pipe::NamedPipeClient> {
             Self::connect_with_options(socket_path, notebook_id, working_dir, initial_metadata)
                 .await?;
         Ok(client.into_split_with_raw_sync(raw_sync_tx))
+    }
+
+    /// Connect by opening an existing notebook file (daemon-owned loading).
+    pub async fn connect_open_split(
+        socket_path: PathBuf,
+        path: PathBuf,
+        raw_sync_tx: Option<mpsc::UnboundedSender<Vec<u8>>>,
+    ) -> Result<
+        (
+            NotebookSyncHandle,
+            NotebookSyncReceiver,
+            NotebookBroadcastReceiver,
+            Vec<CellSnapshot>,
+            Option<String>,
+            NotebookConnectionInfo,
+        ),
+        NotebookSyncError,
+    > {
+        let pipe_name = socket_path.to_string_lossy().to_string();
+        let stream = tokio::net::windows::named_pipe::ClientOptions::new()
+            .open(&pipe_name)
+            .map_err(NotebookSyncError::ConnectionFailed)?;
+
+        let (client, info) = Self::init_open_notebook(stream, path).await?;
+        let (handle, receiver, broadcast_rx, cells, metadata) =
+            client.into_split_with_raw_sync(raw_sync_tx);
+        Ok((handle, receiver, broadcast_rx, cells, metadata, info))
+    }
+
+    /// Connect by creating a new notebook (daemon-owned creation).
+    pub async fn connect_create_split(
+        socket_path: PathBuf,
+        runtime: String,
+        working_dir: Option<PathBuf>,
+        raw_sync_tx: Option<mpsc::UnboundedSender<Vec<u8>>>,
+    ) -> Result<
+        (
+            NotebookSyncHandle,
+            NotebookSyncReceiver,
+            NotebookBroadcastReceiver,
+            Vec<CellSnapshot>,
+            Option<String>,
+            NotebookConnectionInfo,
+        ),
+        NotebookSyncError,
+    > {
+        let pipe_name = socket_path.to_string_lossy().to_string();
+        let stream = tokio::net::windows::named_pipe::ClientOptions::new()
+            .open(&pipe_name)
+            .map_err(NotebookSyncError::ConnectionFailed)?;
+
+        let (client, info) = Self::init_create_notebook(stream, runtime, working_dir).await?;
+        let (handle, receiver, broadcast_rx, cells, metadata) =
+            client.into_split_with_raw_sync(raw_sync_tx);
+        Ok((handle, receiver, broadcast_rx, cells, metadata, info))
     }
 }
 
@@ -817,6 +941,208 @@ where
                                     "[notebook-sync-client] Failed to deserialize broadcast: {} (payload: {} bytes)",
                                     e,
                                     frame.payload.len()
+                                );
+                            }
+                        }
+                    }
+                    NotebookFrameType::Response => {
+                        warn!("[notebook-sync-client] Unexpected Response frame during init");
+                    }
+                    NotebookFrameType::Request => {
+                        warn!("[notebook-sync-client] Unexpected Request frame during init");
+                    }
+                },
+                Ok(Ok(None)) => return Err(NotebookSyncError::Disconnected),
+                Ok(Err(e)) => return Err(NotebookSyncError::ConnectionFailed(e)),
+                Err(_) => break, // Timeout — initial sync is done
+            }
+        }
+
+        let cells = get_cells_from_doc(&doc);
+        info!(
+            "[notebook-sync-client] Initial sync complete for {}: {} cells, {} pending broadcasts",
+            notebook_id,
+            cells.len(),
+            pending_broadcasts.len(),
+        );
+
+        Ok(Self {
+            doc,
+            peer_state,
+            stream,
+            notebook_id,
+            pending_broadcasts,
+        })
+    }
+
+    /// Initialize by opening an existing notebook file.
+    ///
+    /// The daemon loads the file, derives notebook_id, and returns NotebookConnectionInfo.
+    async fn init_open_notebook(
+        mut stream: S,
+        path: PathBuf,
+    ) -> Result<(Self, NotebookConnectionInfo), NotebookSyncError> {
+        let path_str = path.to_string_lossy().to_string();
+        info!(
+            "[notebook-sync-client] Opening notebook: {}",
+            path_str
+        );
+
+        // Send OpenNotebook handshake
+        connection::send_json_frame(&mut stream, &Handshake::OpenNotebook { path: path_str })
+            .await
+            .map_err(|e| NotebookSyncError::SyncError(format!("handshake: {}", e)))?;
+
+        // Receive NotebookConnectionInfo
+        let first_frame = connection::recv_frame(&mut stream)
+            .await?
+            .ok_or(NotebookSyncError::Disconnected)?;
+
+        let info: NotebookConnectionInfo = serde_json::from_slice(&first_frame)
+            .map_err(|e| NotebookSyncError::SyncError(format!("invalid response: {}", e)))?;
+
+        // Check for error in response
+        if let Some(ref error) = info.error {
+            return Err(NotebookSyncError::SyncError(error.clone()));
+        }
+
+        let notebook_id = info.notebook_id.clone();
+        info!(
+            "[notebook-sync-client] Daemon returned notebook_id: {} ({} cells, trust_approval: {})",
+            notebook_id, info.cell_count, info.needs_trust_approval
+        );
+
+        // Continue with Automerge sync (same as init)
+        let client = Self::do_initial_sync(stream, notebook_id).await?;
+        Ok((client, info))
+    }
+
+    /// Initialize by creating a new notebook.
+    ///
+    /// The daemon creates an empty notebook and returns NotebookConnectionInfo.
+    async fn init_create_notebook(
+        mut stream: S,
+        runtime: String,
+        working_dir: Option<PathBuf>,
+    ) -> Result<(Self, NotebookConnectionInfo), NotebookSyncError> {
+        info!(
+            "[notebook-sync-client] Creating new notebook (runtime: {}, working_dir: {:?})",
+            runtime, working_dir
+        );
+
+        // Send CreateNotebook handshake
+        connection::send_json_frame(
+            &mut stream,
+            &Handshake::CreateNotebook {
+                runtime,
+                working_dir: working_dir.map(|p| p.to_string_lossy().to_string()),
+            },
+        )
+        .await
+        .map_err(|e| NotebookSyncError::SyncError(format!("handshake: {}", e)))?;
+
+        // Receive NotebookConnectionInfo
+        let first_frame = connection::recv_frame(&mut stream)
+            .await?
+            .ok_or(NotebookSyncError::Disconnected)?;
+
+        let info: NotebookConnectionInfo = serde_json::from_slice(&first_frame)
+            .map_err(|e| NotebookSyncError::SyncError(format!("invalid response: {}", e)))?;
+
+        // Check for error in response
+        if let Some(ref error) = info.error {
+            return Err(NotebookSyncError::SyncError(error.clone()));
+        }
+
+        let notebook_id = info.notebook_id.clone();
+        info!(
+            "[notebook-sync-client] Daemon created notebook_id: {} ({} cells)",
+            notebook_id, info.cell_count
+        );
+
+        // Continue with Automerge sync (same as init)
+        let client = Self::do_initial_sync(stream, notebook_id).await?;
+        Ok((client, info))
+    }
+
+    /// Perform initial Automerge sync after handshake is complete.
+    ///
+    /// This is the common sync logic used by all init methods after the handshake
+    /// response has been received.
+    async fn do_initial_sync(
+        mut stream: S,
+        notebook_id: String,
+    ) -> Result<Self, NotebookSyncError> {
+        let mut doc = AutoCommit::new();
+        let mut peer_state = sync::State::new();
+        let mut pending_broadcasts = Vec::new();
+
+        // Read the first typed frame (Automerge sync)
+        match connection::recv_typed_frame(&mut stream).await? {
+            Some(frame) => {
+                if frame.frame_type != NotebookFrameType::AutomergeSync {
+                    return Err(NotebookSyncError::SyncError(format!(
+                        "expected AutomergeSync frame, got {:?}",
+                        frame.frame_type
+                    )));
+                }
+                let message = sync::Message::decode(&frame.payload)
+                    .map_err(|e| NotebookSyncError::SyncError(format!("decode: {}", e)))?;
+                doc.sync()
+                    .receive_sync_message(&mut peer_state, message)
+                    .map_err(|e| NotebookSyncError::SyncError(format!("receive: {}", e)))?;
+            }
+            None => return Err(NotebookSyncError::Disconnected),
+        }
+
+        // Send our sync message back
+        if let Some(msg) = doc.sync().generate_sync_message(&mut peer_state) {
+            connection::send_typed_frame(
+                &mut stream,
+                NotebookFrameType::AutomergeSync,
+                &msg.encode(),
+            )
+            .await?;
+        }
+
+        // Continue sync rounds until no more messages (short timeout)
+        loop {
+            match tokio::time::timeout(
+                Duration::from_millis(100),
+                connection::recv_typed_frame(&mut stream),
+            )
+            .await
+            {
+                Ok(Ok(Some(frame))) => match frame.frame_type {
+                    NotebookFrameType::AutomergeSync => {
+                        let message = sync::Message::decode(&frame.payload)
+                            .map_err(|e| NotebookSyncError::SyncError(format!("decode: {}", e)))?;
+                        doc.sync()
+                            .receive_sync_message(&mut peer_state, message)
+                            .map_err(|e| NotebookSyncError::SyncError(format!("receive: {}", e)))?;
+
+                        if let Some(msg) = doc.sync().generate_sync_message(&mut peer_state) {
+                            connection::send_typed_frame(
+                                &mut stream,
+                                NotebookFrameType::AutomergeSync,
+                                &msg.encode(),
+                            )
+                            .await?;
+                        }
+                    }
+                    NotebookFrameType::Broadcast => {
+                        match serde_json::from_slice::<NotebookBroadcast>(&frame.payload) {
+                            Ok(broadcast) => {
+                                info!(
+                                    "[notebook-sync-client] Received broadcast during init: {:?}",
+                                    broadcast
+                                );
+                                pending_broadcasts.push(broadcast);
+                            }
+                            Err(e) => {
+                                warn!(
+                                    "[notebook-sync-client] Failed to deserialize broadcast: {}",
+                                    e
                                 );
                             }
                         }

--- a/crates/runtimed/src/notebook_sync_client.rs
+++ b/crates/runtimed/src/notebook_sync_client.rs
@@ -1006,6 +1006,14 @@ where
             return Err(NotebookSyncError::SyncError(error.clone()));
         }
 
+        // Validate protocol version
+        if info.protocol != PROTOCOL_V2 {
+            return Err(NotebookSyncError::SyncError(format!(
+                "unsupported protocol version: {}",
+                info.protocol
+            )));
+        }
+
         let notebook_id = info.notebook_id.clone();
         info!(
             "[notebook-sync-client] Daemon returned notebook_id: {} ({} cells, trust_approval: {})",
@@ -1052,6 +1060,14 @@ where
         // Check for error in response
         if let Some(ref error) = info.error {
             return Err(NotebookSyncError::SyncError(error.clone()));
+        }
+
+        // Validate protocol version
+        if info.protocol != PROTOCOL_V2 {
+            return Err(NotebookSyncError::SyncError(format!(
+                "unsupported protocol version: {}",
+                info.protocol
+            )));
         }
 
         let notebook_id = info.notebook_id.clone();

--- a/crates/runtimed/src/notebook_sync_client.rs
+++ b/crates/runtimed/src/notebook_sync_client.rs
@@ -983,10 +983,7 @@ where
         path: PathBuf,
     ) -> Result<(Self, NotebookConnectionInfo), NotebookSyncError> {
         let path_str = path.to_string_lossy().to_string();
-        info!(
-            "[notebook-sync-client] Opening notebook: {}",
-            path_str
-        );
+        info!("[notebook-sync-client] Opening notebook: {}", path_str);
 
         // Send OpenNotebook handshake
         connection::send_json_frame(&mut stream, &Handshake::OpenNotebook { path: path_str })

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -3226,7 +3226,9 @@ fn build_new_notebook_metadata(
                     None,
                     Some(CondaInlineMetadata {
                         dependencies: vec![],
-                        channels: vec![],
+                        // Default to conda-forge to match launch logic normalization
+                        // (avoids false channel-drift detection)
+                        channels: vec!["conda-forge".to_string()],
                         python: None,
                     }),
                 ),

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -3101,6 +3101,172 @@ fn parse_cells_from_ipynb(json: &serde_json::Value) -> Option<Vec<CellSnapshot>>
     Some(parsed_cells)
 }
 
+/// Parse notebook metadata from a .ipynb JSON value.
+///
+/// Uses `NotebookMetadataSnapshot::from_metadata_value` which extracts
+/// kernelspec, language_info, and runt namespace from the metadata.
+fn parse_metadata_from_ipynb(json: &serde_json::Value) -> Option<NotebookMetadataSnapshot> {
+    let metadata = json.get("metadata")?;
+    Some(NotebookMetadataSnapshot::from_metadata_value(metadata))
+}
+
+/// Load notebook cells and metadata from a .ipynb file into a NotebookDoc.
+///
+/// Called by daemon-owned notebook loading (`OpenNotebook` handshake).
+/// Parses the file and populates the Automerge doc with cells and metadata.
+///
+/// Returns the cell count on success.
+pub async fn load_notebook_from_disk(
+    doc: &mut NotebookDoc,
+    path: &std::path::Path,
+) -> Result<usize, String> {
+    // Read the file
+    let content = tokio::fs::read_to_string(path)
+        .await
+        .map_err(|e| format!("Failed to read notebook: {}", e))?;
+
+    // Parse JSON
+    let json: serde_json::Value =
+        serde_json::from_str(&content).map_err(|e| format!("Invalid notebook JSON: {}", e))?;
+
+    // Parse cells
+    let cells = parse_cells_from_ipynb(&json)
+        .ok_or_else(|| "Failed to parse cells from notebook".to_string())?;
+
+    // Populate cells in the doc
+    for (i, cell) in cells.iter().enumerate() {
+        doc.add_cell(i, &cell.id, &cell.cell_type)
+            .map_err(|e| format!("Failed to add cell: {}", e))?;
+        doc.update_source(&cell.id, &cell.source)
+            .map_err(|e| format!("Failed to update source: {}", e))?;
+        if !cell.outputs.is_empty() {
+            doc.set_outputs(&cell.id, &cell.outputs)
+                .map_err(|e| format!("Failed to set outputs: {}", e))?;
+        }
+        doc.set_execution_count(&cell.id, &cell.execution_count)
+            .map_err(|e| format!("Failed to set execution count: {}", e))?;
+    }
+
+    // Parse and set metadata
+    if let Some(metadata_snapshot) = parse_metadata_from_ipynb(&json) {
+        doc.set_metadata_snapshot(&metadata_snapshot)
+            .map_err(|e| format!("Failed to set metadata: {}", e))?;
+    }
+
+    Ok(cells.len())
+}
+
+/// Create a new empty notebook with a single code cell.
+///
+/// Called by daemon-owned notebook creation (`CreateNotebook` handshake).
+/// Generates a new env_id and populates the doc with default metadata for
+/// the specified runtime.
+///
+/// Returns the generated env_id on success.
+pub fn create_empty_notebook(
+    doc: &mut NotebookDoc,
+    runtime: &str,
+    default_python_env: crate::settings_doc::PythonEnvType,
+) -> Result<String, String> {
+    let env_id = uuid::Uuid::new_v4().to_string();
+    let cell_id = uuid::Uuid::new_v4().to_string();
+
+    // Add a single empty code cell
+    doc.add_cell(0, &cell_id, "code")
+        .map_err(|e| format!("Failed to add cell: {}", e))?;
+
+    // Build metadata based on runtime
+    let metadata_snapshot = build_new_notebook_metadata(runtime, &env_id, default_python_env);
+
+    doc.set_metadata_snapshot(&metadata_snapshot)
+        .map_err(|e| format!("Failed to set metadata: {}", e))?;
+
+    Ok(env_id)
+}
+
+/// Build default metadata for a new notebook based on runtime.
+fn build_new_notebook_metadata(
+    runtime: &str,
+    env_id: &str,
+    default_python_env: crate::settings_doc::PythonEnvType,
+) -> NotebookMetadataSnapshot {
+    use crate::notebook_metadata::{
+        CondaInlineMetadata, KernelspecSnapshot, LanguageInfoSnapshot, RuntMetadata,
+        UvInlineMetadata,
+    };
+
+    let (kernelspec, language_info, runt) = match runtime {
+        "deno" => (
+            KernelspecSnapshot {
+                name: "deno".to_string(),
+                display_name: "Deno".to_string(),
+                language: Some("typescript".to_string()),
+            },
+            LanguageInfoSnapshot {
+                name: "typescript".to_string(),
+                version: None,
+            },
+            RuntMetadata {
+                schema_version: "1".to_string(),
+                env_id: Some(env_id.to_string()),
+                uv: None,
+                conda: None,
+                deno: None,
+                trust_signature: None,
+                trust_timestamp: None,
+            },
+        ),
+        _ => {
+            // Python (default)
+            let (uv, conda) = match default_python_env {
+                crate::settings_doc::PythonEnvType::Conda => (
+                    None,
+                    Some(CondaInlineMetadata {
+                        dependencies: vec![],
+                        channels: vec![],
+                        python: None,
+                    }),
+                ),
+                crate::settings_doc::PythonEnvType::Uv
+                | crate::settings_doc::PythonEnvType::Other(_) => (
+                    Some(UvInlineMetadata {
+                        dependencies: vec![],
+                        requires_python: None,
+                    }),
+                    None,
+                ),
+            };
+
+            (
+                KernelspecSnapshot {
+                    name: "python3".to_string(),
+                    display_name: "Python 3".to_string(),
+                    language: Some("python".to_string()),
+                },
+                LanguageInfoSnapshot {
+                    name: "python".to_string(),
+                    version: None,
+                },
+                RuntMetadata {
+                    schema_version: "1".to_string(),
+                    env_id: Some(env_id.to_string()),
+                    uv,
+                    conda,
+                    deno: None,
+                    trust_signature: None,
+                    trust_timestamp: None,
+                },
+            )
+        }
+    };
+
+    NotebookMetadataSnapshot {
+        kernelspec: Some(kernelspec),
+        language_info: Some(language_info),
+        runt,
+    }
+}
+
 /// Apply external .ipynb changes to the Automerge doc.
 ///
 /// Compares cells by ID and:

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -3159,16 +3159,19 @@ pub async fn load_notebook_from_disk(
 /// Create a new empty notebook with a single code cell.
 ///
 /// Called by daemon-owned notebook creation (`CreateNotebook` handshake).
-/// Generates a new env_id and populates the doc with default metadata for
-/// the specified runtime.
+/// Uses the provided env_id or generates a new one, and populates the doc
+/// with default metadata for the specified runtime.
 ///
-/// Returns the generated env_id on success.
+/// Returns the env_id used on success.
 pub fn create_empty_notebook(
     doc: &mut NotebookDoc,
     runtime: &str,
     default_python_env: crate::settings_doc::PythonEnvType,
+    env_id: Option<&str>,
 ) -> Result<String, String> {
-    let env_id = uuid::Uuid::new_v4().to_string();
+    let env_id = env_id
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
     let cell_id = uuid::Uuid::new_v4().to_string();
 
     // Add a single empty code cell

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -4620,4 +4620,137 @@ mod tests {
         };
         assert_eq!(cells[0].source, "x=1", "Source should remain unchanged");
     }
+
+    // ========================================================================
+    // Tests for daemon-owned notebook loading functions (Phase 2)
+    // ========================================================================
+
+    #[test]
+    fn test_build_new_notebook_metadata_deno() {
+        let metadata = build_new_notebook_metadata(
+            "deno",
+            "test-env-id",
+            crate::settings_doc::PythonEnvType::Uv,
+        );
+
+        assert_eq!(metadata.kernelspec.as_ref().unwrap().name, "deno");
+        assert_eq!(metadata.kernelspec.as_ref().unwrap().display_name, "Deno");
+        assert_eq!(
+            metadata.kernelspec.as_ref().unwrap().language,
+            Some("typescript".to_string())
+        );
+        assert_eq!(metadata.language_info.as_ref().unwrap().name, "typescript");
+        assert_eq!(metadata.runt.env_id, Some("test-env-id".to_string()));
+        assert!(metadata.runt.uv.is_none());
+        assert!(metadata.runt.conda.is_none());
+    }
+
+    #[test]
+    fn test_build_new_notebook_metadata_python_uv() {
+        let metadata = build_new_notebook_metadata(
+            "python",
+            "test-env-id",
+            crate::settings_doc::PythonEnvType::Uv,
+        );
+
+        assert_eq!(metadata.kernelspec.as_ref().unwrap().name, "python3");
+        assert_eq!(
+            metadata.kernelspec.as_ref().unwrap().display_name,
+            "Python 3"
+        );
+        assert_eq!(
+            metadata.kernelspec.as_ref().unwrap().language,
+            Some("python".to_string())
+        );
+        assert_eq!(metadata.language_info.as_ref().unwrap().name, "python");
+        assert_eq!(metadata.runt.env_id, Some("test-env-id".to_string()));
+        assert!(metadata.runt.uv.is_some());
+        assert!(metadata.runt.conda.is_none());
+        assert!(metadata.runt.uv.as_ref().unwrap().dependencies.is_empty());
+    }
+
+    #[test]
+    fn test_build_new_notebook_metadata_python_conda() {
+        let metadata = build_new_notebook_metadata(
+            "python",
+            "test-env-id",
+            crate::settings_doc::PythonEnvType::Conda,
+        );
+
+        assert_eq!(metadata.kernelspec.as_ref().unwrap().name, "python3");
+        assert_eq!(metadata.language_info.as_ref().unwrap().name, "python");
+        assert_eq!(metadata.runt.env_id, Some("test-env-id".to_string()));
+        assert!(metadata.runt.uv.is_none());
+        assert!(metadata.runt.conda.is_some());
+        assert!(metadata.runt.conda.as_ref().unwrap().dependencies.is_empty());
+        // Verify default channels to avoid false channel-drift detection
+        assert_eq!(
+            metadata.runt.conda.as_ref().unwrap().channels,
+            vec!["conda-forge".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_create_empty_notebook_python() {
+        let mut doc = NotebookDoc::new("test");
+        let result = create_empty_notebook(
+            &mut doc,
+            "python",
+            crate::settings_doc::PythonEnvType::Uv,
+            None,
+        );
+
+        assert!(result.is_ok());
+        let env_id = result.unwrap();
+        assert!(!env_id.is_empty(), "Should generate an env_id");
+
+        // Should have exactly one cell
+        assert_eq!(doc.cell_count(), 1);
+        let cells = doc.get_cells();
+        assert_eq!(cells[0].cell_type, "code");
+        assert!(cells[0].source.is_empty());
+    }
+
+    #[test]
+    fn test_create_empty_notebook_deno() {
+        let mut doc = NotebookDoc::new("test");
+        let result = create_empty_notebook(
+            &mut doc,
+            "deno",
+            crate::settings_doc::PythonEnvType::Uv, // Ignored for deno
+            None,
+        );
+
+        assert!(result.is_ok());
+        assert_eq!(doc.cell_count(), 1);
+
+        // Check metadata was set correctly
+        let metadata = doc.get_metadata_snapshot();
+        assert!(metadata.is_some());
+        let metadata = metadata.unwrap();
+        assert_eq!(metadata.kernelspec.as_ref().unwrap().name, "deno");
+    }
+
+    #[test]
+    fn test_create_empty_notebook_with_provided_env_id() {
+        let mut doc = NotebookDoc::new("test");
+        let provided_id = "my-custom-env-id";
+        let result = create_empty_notebook(
+            &mut doc,
+            "python",
+            crate::settings_doc::PythonEnvType::Uv,
+            Some(provided_id),
+        );
+
+        assert!(result.is_ok());
+        let env_id = result.unwrap();
+        assert_eq!(env_id, provided_id, "Should use provided env_id");
+
+        let metadata = doc.get_metadata_snapshot().unwrap();
+        assert_eq!(
+            metadata.runt.env_id,
+            Some(provided_id.to_string()),
+            "Metadata should have provided env_id"
+        );
+    }
 }

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -665,6 +665,10 @@ pub fn get_or_create_room(
 /// doc bytes are flushed via debounced persistence.
 ///
 /// Uses v2 typed frames protocol (with first-byte type indicator).
+///
+/// If `skip_capabilities` is true, the ProtocolCapabilities frame is not sent.
+/// This is used for OpenNotebook/CreateNotebook handshakes where the protocol
+/// is already communicated in the NotebookConnectionInfo response.
 #[allow(clippy::too_many_arguments)]
 pub async fn handle_notebook_sync_connection<R, W>(
     mut reader: R,
@@ -677,6 +681,7 @@ pub async fn handle_notebook_sync_connection<R, W>(
     daemon: std::sync::Arc<crate::daemon::Daemon>,
     working_dir: Option<PathBuf>,
     initial_metadata: Option<String>,
+    skip_capabilities: bool,
 ) -> anyhow::Result<()>
 where
     R: AsyncRead + Unpin,
@@ -772,11 +777,13 @@ where
         }
     }
 
-    // Send capabilities response (v2 protocol)
-    let caps = connection::ProtocolCapabilities {
-        protocol: connection::PROTOCOL_V2.to_string(),
-    };
-    connection::send_json_frame(&mut writer, &caps).await?;
+    // Send capabilities response (v2 protocol) unless already sent via NotebookConnectionInfo
+    if !skip_capabilities {
+        let caps = connection::ProtocolCapabilities {
+            protocol: connection::PROTOCOL_V2.to_string(),
+        };
+        connection::send_json_frame(&mut writer, &caps).await?;
+    }
 
     let result = run_sync_loop_v2(&mut reader, &mut writer, &room, daemon.clone()).await;
 

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -4682,7 +4682,13 @@ mod tests {
         assert_eq!(metadata.runt.env_id, Some("test-env-id".to_string()));
         assert!(metadata.runt.uv.is_none());
         assert!(metadata.runt.conda.is_some());
-        assert!(metadata.runt.conda.as_ref().unwrap().dependencies.is_empty());
+        assert!(metadata
+            .runt
+            .conda
+            .as_ref()
+            .unwrap()
+            .dependencies
+            .is_empty());
         // Verify default channels to avoid false channel-drift detection
         assert_eq!(
             metadata.runt.conda.as_ref().unwrap().channels,


### PR DESCRIPTION
## Summary

Implement the daemon-side infrastructure for daemon-owned notebook loading (issue #598). This PR completes Phases 1-3 and 5, providing all the building blocks for the Tauri integration in a follow-up PR.

**Phase 1: Protocol Extension**
- Add `OpenNotebook { path }` and `CreateNotebook { runtime, working_dir }` handshake variants
- Add `NotebookConnectionInfo` response with notebook_id, cell_count, needs_trust_approval, and error fields
- Protocol version included in response (no separate ProtocolCapabilities needed for new handshakes)

**Phase 2: Daemon-Side Loading Functions**
- `load_notebook_from_disk()` - parses .ipynb and populates NotebookDoc with cells and metadata
- `create_empty_notebook()` - creates new notebook with one code cell and runtime-specific metadata
- `build_new_notebook_metadata()` - generates metadata for Python (uv/conda) or Deno runtimes
- Reuses existing `parse_cells_from_ipynb()` for cell parsing

**Phase 3: Connection Handlers**
- `handle_open_notebook`: Canonicalizes path → derives notebook_id → creates room → loads from disk (if first connection) → checks trust → returns NotebookConnectionInfo → continues with sync
- `handle_create_notebook`: Generates UUID notebook_id → creates room → populates empty notebook → returns NotebookConnectionInfo → continues with sync
- Race condition prevention: check-and-load under single write lock
- Room cleanup on failure to prevent stale trust state

**Phase 5: NotebookSyncClient Extension**
- `connect_open_split()` - opens existing notebook via daemon, returns NotebookConnectionInfo
- `connect_create_split()` - creates new notebook via daemon, returns NotebookConnectionInfo
- `init_open_notebook()` / `init_create_notebook()` / `do_initial_sync()` - internal init helpers
- Protocol version validation on NotebookConnectionInfo

## What's Next

Phase 4-7 (Tauri integration) in a follow-up PR:
- Update window creation to use `connect_open_split`/`connect_create_split`
- Remove `NotebookState`-based loading
- Update session restore
- End-to-end integration tests

## Test Plan

- [x] cargo fmt
- [x] cargo clippy --all-targets -- -D warnings (clean)
- [x] cargo test -p runtimed (233 tests pass, +6 new unit tests)
- [x] Manual QA - no divergence noted

Closes #598 (daemon-side infrastructure complete; Tauri integration to follow)