### PR TITLE
feat(runtimed-py): daemon-owned notebook loading bindings

### DIFF
--- a/crates/runtimed-py/src/async_session.rs
+++ b/crates/runtimed-py/src/async_session.rs
@@ -14,9 +14,12 @@ use runtimed::notebook_sync_client::{
 };
 use runtimed::protocol::{NotebookBroadcast, NotebookRequest, NotebookResponse};
 
+use crate::daemon_paths::{get_blob_paths_async, get_socket_path};
 use crate::error::to_py_err;
 use crate::event_stream::ExecutionEventStream;
-use crate::output::{Cell, ExecutionEvent, ExecutionResult, Output, SyncEnvironmentResult};
+use crate::output::{
+    Cell, ExecutionEvent, ExecutionResult, NotebookConnectionInfo, Output, SyncEnvironmentResult,
+};
 use crate::output_resolver;
 use crate::subscription::EventSubscription;
 
@@ -55,6 +58,8 @@ struct AsyncSessionState {
     blob_base_url: Option<String>,
     /// Path to blob store directory (fallback for direct disk access)
     blob_store_path: Option<PathBuf>,
+    /// Connection info from daemon (for open_notebook/create_notebook)
+    connection_info: Option<NotebookConnectionInfo>,
 }
 
 impl AsyncSessionState {
@@ -67,6 +72,7 @@ impl AsyncSessionState {
             env_source: None,
             blob_base_url: None,
             blob_store_path: None,
+            connection_info: None,
         }
     }
 }
@@ -131,6 +137,128 @@ impl AsyncSession {
         })
     }
 
+    /// Get the connection info from daemon (for open_notebook/create_notebook).
+    ///
+    /// Returns None if not connected via open_notebook() or create_notebook().
+    /// Returns a coroutine that resolves to Optional[NotebookConnectionInfo].
+    fn connection_info<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let state = Arc::clone(&self.state);
+        future_into_py(py, async move {
+            let state = state.lock().await;
+            Ok(state.connection_info.clone())
+        })
+    }
+
+    /// Open an existing notebook file via the daemon.
+    ///
+    /// The daemon loads the file, derives the notebook_id from the canonical path,
+    /// and returns connection info including trust status.
+    ///
+    /// Args:
+    ///     path: Path to the .ipynb file.
+    ///
+    /// Returns:
+    ///     A coroutine that resolves to a new AsyncSession connected to the opened notebook.
+    ///
+    /// Raises:
+    ///     RuntimedError: If the file cannot be opened or parsed.
+    #[staticmethod]
+    fn open_notebook(py: Python<'_>, path: String) -> PyResult<Bound<'_, PyAny>> {
+        future_into_py(py, async move {
+            let path_buf = PathBuf::from(&path);
+            let socket_path = get_socket_path();
+
+            let (handle, sync_rx, broadcast_rx, _cells, _metadata, info) =
+                NotebookSyncClient::connect_open_split(socket_path.clone(), path_buf, None)
+                    .await
+                    .map_err(to_py_err)?;
+
+            // Check for error in response
+            if let Some(error) = info.error {
+                return Err(to_py_err(error));
+            }
+
+            let notebook_id = info.notebook_id.clone();
+            let connection_info = NotebookConnectionInfo::from_protocol(info);
+            let (blob_base_url, blob_store_path) = get_blob_paths_async(&socket_path).await;
+
+            let state = AsyncSessionState {
+                handle: Some(handle),
+                sync_rx: Some(sync_rx),
+                broadcast_rx: Some(broadcast_rx),
+                kernel_started: false,
+                env_source: None,
+                blob_base_url,
+                blob_store_path,
+                connection_info: Some(connection_info),
+            };
+
+            Ok(AsyncSession {
+                state: Arc::new(Mutex::new(state)),
+                notebook_id,
+            })
+        })
+    }
+
+    /// Create a new notebook via the daemon.
+    ///
+    /// The daemon creates an empty notebook with one code cell and returns
+    /// connection info with a generated UUID as the notebook_id.
+    ///
+    /// Args:
+    ///     runtime: The kernel runtime type ("python" or "deno").
+    ///     working_dir: Optional working directory for project file detection.
+    ///
+    /// Returns:
+    ///     A coroutine that resolves to a new AsyncSession connected to the created notebook.
+    #[staticmethod]
+    #[pyo3(signature = (runtime, working_dir=None))]
+    fn create_notebook(
+        py: Python<'_>,
+        runtime: String,
+        working_dir: Option<String>,
+    ) -> PyResult<Bound<'_, PyAny>> {
+        future_into_py(py, async move {
+            let working_dir_buf = working_dir.map(PathBuf::from);
+            let socket_path = get_socket_path();
+
+            let (handle, sync_rx, broadcast_rx, _cells, _metadata, info) =
+                NotebookSyncClient::connect_create_split(
+                    socket_path.clone(),
+                    runtime,
+                    working_dir_buf,
+                    None,
+                )
+                .await
+                .map_err(to_py_err)?;
+
+            // Check for error in response
+            if let Some(error) = info.error {
+                return Err(to_py_err(error));
+            }
+
+            let notebook_id = info.notebook_id.clone();
+            let connection_info = NotebookConnectionInfo::from_protocol(info);
+            let (blob_base_url, blob_store_path) = get_blob_paths_async(&socket_path).await;
+
+            let state = AsyncSessionState {
+                handle: Some(handle),
+                sync_rx: Some(sync_rx),
+                broadcast_rx: Some(broadcast_rx),
+                kernel_started: false,
+                env_source: None,
+                blob_base_url,
+                blob_store_path,
+                connection_info: Some(connection_info),
+            };
+
+            Ok(AsyncSession {
+                state: Arc::new(Mutex::new(state)),
+                notebook_id,
+            })
+        })
+    }
+
     /// Connect to the daemon.
     ///
     /// This is called automatically by start_kernel() if not already connected.
@@ -147,45 +275,14 @@ impl AsyncSession {
                 return Ok(()); // Already connected
             }
 
-            // Check for socket path override via environment variable
-            let socket_path = if let Ok(path) = std::env::var("RUNTIMED_SOCKET_PATH") {
-                std::path::PathBuf::from(path)
-            } else {
-                runtimed::default_socket_path()
-            };
+            let socket_path = get_socket_path();
 
             let (handle, sync_rx, broadcast_rx, _cells, _notebook_path) =
                 NotebookSyncClient::connect_split(socket_path.clone(), notebook_id)
                     .await
                     .map_err(to_py_err)?;
 
-            // Determine blob server URL and blob store path based on socket path
-            let (blob_base_url, blob_store_path) = if let Some(parent) = socket_path.parent() {
-                let daemon_json = parent.join("daemon.json");
-                let base_url = if daemon_json.exists() {
-                    tokio::fs::read_to_string(&daemon_json)
-                        .await
-                        .ok()
-                        .and_then(|contents| {
-                            serde_json::from_str::<serde_json::Value>(&contents).ok()
-                        })
-                        .and_then(|info| info.get("blob_port").and_then(|p| p.as_u64()))
-                        .map(|port| format!("http://127.0.0.1:{}", port))
-                } else {
-                    None
-                };
-
-                let store_path = parent.join("blobs");
-                let store_path = if store_path.exists() {
-                    Some(store_path)
-                } else {
-                    None
-                };
-
-                (base_url, store_path)
-            } else {
-                (None, None)
-            };
+            let (blob_base_url, blob_store_path) = get_blob_paths_async(&socket_path).await;
 
             state.handle = Some(handle);
             state.sync_rx = Some(sync_rx);

--- a/crates/runtimed-py/src/daemon_paths.rs
+++ b/crates/runtimed-py/src/daemon_paths.rs
@@ -1,0 +1,71 @@
+//! Shared helpers for daemon socket and blob store paths.
+
+use std::path::PathBuf;
+
+/// Get the daemon socket path, respecting RUNTIMED_SOCKET_PATH env var.
+pub fn get_socket_path() -> PathBuf {
+    if let Ok(p) = std::env::var("RUNTIMED_SOCKET_PATH") {
+        PathBuf::from(p)
+    } else {
+        runtimed::default_socket_path()
+    }
+}
+
+/// Resolve blob server URL and blob store path from the daemon directory (sync).
+///
+/// Returns (blob_base_url, blob_store_path).
+pub fn get_blob_paths_sync(socket_path: &PathBuf) -> (Option<String>, Option<PathBuf>) {
+    let Some(parent) = socket_path.parent() else {
+        return (None, None);
+    };
+
+    let daemon_json = parent.join("daemon.json");
+    let base_url = if daemon_json.exists() {
+        std::fs::read_to_string(&daemon_json)
+            .ok()
+            .and_then(|contents| serde_json::from_str::<serde_json::Value>(&contents).ok())
+            .and_then(|info| info.get("blob_port").and_then(|p| p.as_u64()))
+            .map(|port| format!("http://127.0.0.1:{}", port))
+    } else {
+        None
+    };
+
+    let store_path = parent.join("blobs");
+    let store_path = if store_path.exists() {
+        Some(store_path)
+    } else {
+        None
+    };
+
+    (base_url, store_path)
+}
+
+/// Resolve blob server URL and blob store path from the daemon directory (async).
+///
+/// Returns (blob_base_url, blob_store_path).
+pub async fn get_blob_paths_async(socket_path: &PathBuf) -> (Option<String>, Option<PathBuf>) {
+    let Some(parent) = socket_path.parent() else {
+        return (None, None);
+    };
+
+    let daemon_json = parent.join("daemon.json");
+    let base_url = if daemon_json.exists() {
+        tokio::fs::read_to_string(&daemon_json)
+            .await
+            .ok()
+            .and_then(|contents| serde_json::from_str::<serde_json::Value>(&contents).ok())
+            .and_then(|info| info.get("blob_port").and_then(|p| p.as_u64()))
+            .map(|port| format!("http://127.0.0.1:{}", port))
+    } else {
+        None
+    };
+
+    let store_path = parent.join("blobs");
+    let store_path = if store_path.exists() {
+        Some(store_path)
+    } else {
+        None
+    };
+
+    (base_url, store_path)
+}

--- a/crates/runtimed-py/src/lib.rs
+++ b/crates/runtimed-py/src/lib.rs
@@ -13,6 +13,7 @@ use pyo3::prelude::*;
 
 mod async_session;
 mod client;
+mod daemon_paths;
 mod error;
 mod event_stream;
 mod output;
@@ -25,8 +26,8 @@ use client::DaemonClient;
 use error::RuntimedError;
 use event_stream::{ExecutionEventIterator, ExecutionEventStream};
 use output::{
-    Cell, CompletionItem, CompletionResult, ExecutionEvent, ExecutionResult, HistoryEntry, Output,
-    QueueState, SyncEnvironmentResult,
+    Cell, CompletionItem, CompletionResult, ExecutionEvent, ExecutionResult, HistoryEntry,
+    NotebookConnectionInfo, Output, QueueState, SyncEnvironmentResult,
 };
 use session::Session;
 use subscription::{EventIteratorSubscription, EventSubscription};
@@ -55,6 +56,7 @@ fn runtimed(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<ExecutionEvent>()?;
     m.add_class::<Output>()?;
     m.add_class::<SyncEnvironmentResult>()?;
+    m.add_class::<NotebookConnectionInfo>()?;
 
     // Completion and queue types
     m.add_class::<CompletionItem>()?;

--- a/crates/runtimed-py/src/output.rs
+++ b/crates/runtimed-py/src/output.rs
@@ -475,6 +475,47 @@ impl SyncEnvironmentResult {
     }
 }
 
+/// Connection info returned when opening or creating a notebook via daemon.
+///
+/// This is returned by `Session.open_notebook()` and `Session.create_notebook()`
+/// and provides information about the notebook that was opened or created.
+#[pyclass(get_all, skip_from_py_object)]
+#[derive(Clone, Debug)]
+pub struct NotebookConnectionInfo {
+    /// Protocol version (currently "v2").
+    pub protocol: String,
+    /// Notebook identifier derived by the daemon.
+    /// For existing files: canonical path.
+    /// For new notebooks: generated UUID.
+    pub notebook_id: String,
+    /// Number of cells in the notebook.
+    pub cell_count: usize,
+    /// True if the notebook has untrusted dependencies requiring user approval.
+    pub needs_trust_approval: bool,
+}
+
+#[pymethods]
+impl NotebookConnectionInfo {
+    fn __repr__(&self) -> String {
+        format!(
+            "NotebookConnectionInfo(notebook_id={}, cells={}, needs_trust={})",
+            self.notebook_id, self.cell_count, self.needs_trust_approval
+        )
+    }
+}
+
+impl NotebookConnectionInfo {
+    /// Create from the Rust NotebookConnectionInfo type.
+    pub fn from_protocol(info: runtimed::connection::NotebookConnectionInfo) -> Self {
+        Self {
+            protocol: info.protocol,
+            notebook_id: info.notebook_id,
+            cell_count: info.cell_count,
+            needs_trust_approval: info.needs_trust_approval,
+        }
+    }
+}
+
 /// Result of executing code.
 #[pyclass(skip_from_py_object)]
 #[derive(Clone, Debug)]

--- a/crates/runtimed-py/src/session.rs
+++ b/crates/runtimed-py/src/session.rs
@@ -13,9 +13,12 @@ use runtimed::notebook_sync_client::{
 };
 use runtimed::protocol::{NotebookBroadcast, NotebookRequest, NotebookResponse};
 
+use crate::daemon_paths::{get_blob_paths_sync, get_socket_path};
 use crate::error::to_py_err;
 use crate::event_stream::ExecutionEventIterator;
-use crate::output::{Cell, ExecutionEvent, ExecutionResult, Output, SyncEnvironmentResult};
+use crate::output::{
+    Cell, ExecutionEvent, ExecutionResult, NotebookConnectionInfo, Output, SyncEnvironmentResult,
+};
 use crate::output_resolver;
 use crate::subscription::EventIteratorSubscription;
 
@@ -54,6 +57,8 @@ struct SessionState {
     blob_base_url: Option<String>,
     /// Path to blob store directory (fallback for direct disk access)
     blob_store_path: Option<PathBuf>,
+    /// Connection info from daemon (for open_notebook/create_notebook)
+    connection_info: Option<NotebookConnectionInfo>,
 }
 
 impl SessionState {
@@ -66,6 +71,7 @@ impl SessionState {
             env_source: None,
             blob_base_url: None,
             blob_store_path: None,
+            connection_info: None,
         }
     }
 }
@@ -120,6 +126,132 @@ impl Session {
         state.env_source.clone()
     }
 
+    /// Get the connection info from daemon (for open_notebook/create_notebook).
+    ///
+    /// Returns None if not connected via open_notebook() or create_notebook().
+    #[getter]
+    fn connection_info(&self) -> Option<NotebookConnectionInfo> {
+        let state = self.runtime.block_on(self.state.lock());
+        state.connection_info.clone()
+    }
+
+    /// Open an existing notebook file via the daemon.
+    ///
+    /// The daemon loads the file, derives the notebook_id from the canonical path,
+    /// and returns connection info including trust status.
+    ///
+    /// Args:
+    ///     path: Path to the .ipynb file.
+    ///
+    /// Returns:
+    ///     A new Session connected to the opened notebook.
+    ///
+    /// Raises:
+    ///     RuntimedError: If the file cannot be opened or parsed.
+    #[staticmethod]
+    fn open_notebook(path: &str) -> PyResult<Self> {
+        let runtime = Runtime::new().map_err(to_py_err)?;
+        let path_buf = PathBuf::from(path);
+
+        let (notebook_id, state) = runtime.block_on(async {
+            let socket_path = get_socket_path();
+
+            let (handle, sync_rx, broadcast_rx, _cells, _metadata, info) =
+                NotebookSyncClient::connect_open_split(socket_path.clone(), path_buf, None)
+                    .await
+                    .map_err(to_py_err)?;
+
+            // Check for error in response
+            if let Some(error) = info.error {
+                return Err(to_py_err(error));
+            }
+
+            let notebook_id = info.notebook_id.clone();
+            let connection_info = NotebookConnectionInfo::from_protocol(info);
+            let (blob_base_url, blob_store_path) = get_blob_paths_sync(&socket_path);
+
+            let state = SessionState {
+                handle: Some(handle),
+                sync_rx: Some(sync_rx),
+                broadcast_rx: Some(broadcast_rx),
+                kernel_started: false,
+                env_source: None,
+                blob_base_url,
+                blob_store_path,
+                connection_info: Some(connection_info),
+            };
+
+            Ok((notebook_id, state))
+        })?;
+
+        Ok(Self {
+            runtime,
+            state: Arc::new(Mutex::new(state)),
+            notebook_id,
+        })
+    }
+
+    /// Create a new notebook via the daemon.
+    ///
+    /// The daemon creates an empty notebook with one code cell and returns
+    /// connection info with a generated UUID as the notebook_id.
+    ///
+    /// Args:
+    ///     runtime: The kernel runtime type ("python" or "deno"). Defaults to "python".
+    ///     working_dir: Optional working directory for project file detection.
+    ///
+    /// Returns:
+    ///     A new Session connected to the created notebook.
+    #[staticmethod]
+    #[pyo3(signature = (runtime="python", working_dir=None))]
+    fn create_notebook(runtime: &str, working_dir: Option<&str>) -> PyResult<Self> {
+        let rt = Runtime::new().map_err(to_py_err)?;
+        let runtime_str = runtime.to_string();
+        let working_dir_buf = working_dir.map(PathBuf::from);
+
+        let (notebook_id, state) = rt.block_on(async {
+            let socket_path = get_socket_path();
+
+            let (handle, sync_rx, broadcast_rx, _cells, _metadata, info) =
+                NotebookSyncClient::connect_create_split(
+                    socket_path.clone(),
+                    runtime_str,
+                    working_dir_buf,
+                    None,
+                )
+                .await
+                .map_err(to_py_err)?;
+
+            // Check for error in response
+            if let Some(error) = info.error {
+                return Err(to_py_err(error));
+            }
+
+            let notebook_id = info.notebook_id.clone();
+            let connection_info = NotebookConnectionInfo::from_protocol(info);
+            let (blob_base_url, blob_store_path) = get_blob_paths_sync(&socket_path);
+
+            let state = SessionState {
+                handle: Some(handle),
+                sync_rx: Some(sync_rx),
+                broadcast_rx: Some(broadcast_rx),
+                kernel_started: false,
+                env_source: None,
+                blob_base_url,
+                blob_store_path,
+                connection_info: Some(connection_info),
+            };
+
+            Ok((notebook_id, state))
+        })?;
+
+        Ok(Self {
+            runtime: rt,
+            state: Arc::new(Mutex::new(state)),
+            notebook_id,
+        })
+    }
+
     /// Connect to the daemon.
     ///
     /// This is called automatically by start_kernel() if not already connected.
@@ -131,47 +263,14 @@ impl Session {
                 return Ok(()); // Already connected
             }
 
-            // Check for socket path override via environment variable
-            let socket_path = if let Ok(path) = std::env::var("RUNTIMED_SOCKET_PATH") {
-                std::path::PathBuf::from(path)
-            } else {
-                runtimed::default_socket_path()
-            };
+            let socket_path = get_socket_path();
 
             let (handle, sync_rx, broadcast_rx, _cells, _notebook_path) =
                 NotebookSyncClient::connect_split(socket_path.clone(), self.notebook_id.clone())
                     .await
                     .map_err(to_py_err)?;
 
-            // Determine blob server URL and blob store path based on socket path
-            // In dev mode, blob server runs on a per-worktree port
-            let (blob_base_url, blob_store_path) = if let Some(parent) = socket_path.parent() {
-                // Read daemon.json to get blob port
-                let daemon_json = parent.join("daemon.json");
-                let base_url = if daemon_json.exists() {
-                    std::fs::read_to_string(&daemon_json)
-                        .ok()
-                        .and_then(|contents| {
-                            serde_json::from_str::<serde_json::Value>(&contents).ok()
-                        })
-                        .and_then(|info| info.get("blob_port").and_then(|p| p.as_u64()))
-                        .map(|port| format!("http://127.0.0.1:{}", port))
-                } else {
-                    None
-                };
-
-                // Blob store is at {daemon_dir}/blobs/
-                let store_path = parent.join("blobs");
-                let store_path = if store_path.exists() {
-                    Some(store_path)
-                } else {
-                    None
-                };
-
-                (base_url, store_path)
-            } else {
-                (None, None)
-            };
+            let (blob_base_url, blob_store_path) = get_blob_paths_sync(&socket_path);
 
             state.handle = Some(handle);
             state.sync_rx = Some(sync_rx); // Keep alive so sync task doesn't exit

--- a/python/runtimed/src/runtimed/__init__.py
+++ b/python/runtimed/src/runtimed/__init__.py
@@ -15,6 +15,7 @@ from runtimed.runtimed import (
     ExecutionEvent,
     ExecutionResult,
     HistoryEntry,
+    NotebookConnectionInfo,
     Output,
     QueueState,
     RuntimedError,
@@ -35,6 +36,7 @@ __all__ = [
     "Cell",
     "ExecutionEvent",
     "ExecutionResult",
+    "NotebookConnectionInfo",
     "Output",
     "RuntimedError",
     # Completion and queue types

--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -2174,5 +2174,314 @@ class TestSubscription:
         assert len(events2) >= 1, "Subscriber 2 should receive events"
 
 
+# ============================================================================
+# Open/Create Notebook Tests (daemon-owned loading)
+# ============================================================================
+
+
+class TestOpenNotebook:
+    """Test Session.open_notebook() - daemon-owned file loading."""
+
+    def test_open_existing_notebook(self, daemon_process, monkeypatch, tmp_path):
+        """Opening existing .ipynb loads cells via daemon."""
+        import json
+
+        socket_path, _ = daemon_process
+        if socket_path is not None:
+            monkeypatch.setenv("RUNTIMED_SOCKET_PATH", str(socket_path))
+
+        # Create test notebook
+        nb_path = tmp_path / "test.ipynb"
+        nb_path.write_text(
+            json.dumps(
+                {
+                    "nbformat": 4,
+                    "nbformat_minor": 5,
+                    "metadata": {
+                        "kernelspec": {"name": "python3", "display_name": "Python 3"}
+                    },
+                    "cells": [
+                        {
+                            "id": "cell-1",
+                            "cell_type": "code",
+                            "source": ["x = 1"],
+                            "metadata": {},
+                            "outputs": [],
+                        },
+                        {
+                            "id": "cell-2",
+                            "cell_type": "markdown",
+                            "source": ["# Hello"],
+                            "metadata": {},
+                        },
+                    ],
+                }
+            )
+        )
+
+        # Open via daemon
+        session = runtimed.Session.open_notebook(str(nb_path))
+        assert session.is_connected
+
+        # Verify daemon-derived notebook_id (should contain canonical path)
+        assert str(nb_path.resolve()) in session.notebook_id or nb_path.name in session.notebook_id
+
+        # Verify cells loaded
+        cells = session.get_cells()
+        assert len(cells) == 2
+        assert cells[0].source == "x = 1"
+        assert cells[1].cell_type == "markdown"
+
+    def test_open_notebook_returns_connection_info(self, daemon_process, monkeypatch, tmp_path):
+        """NotebookConnectionInfo includes cell_count."""
+        import json
+
+        socket_path, _ = daemon_process
+        if socket_path is not None:
+            monkeypatch.setenv("RUNTIMED_SOCKET_PATH", str(socket_path))
+
+        # Create notebook with 3 cells
+        nb_path = tmp_path / "three_cells.ipynb"
+        nb_path.write_text(
+            json.dumps(
+                {
+                    "nbformat": 4,
+                    "nbformat_minor": 5,
+                    "metadata": {},
+                    "cells": [
+                        {
+                            "id": "c1",
+                            "cell_type": "code",
+                            "source": [],
+                            "metadata": {},
+                            "outputs": [],
+                        },
+                        {
+                            "id": "c2",
+                            "cell_type": "code",
+                            "source": [],
+                            "metadata": {},
+                            "outputs": [],
+                        },
+                        {
+                            "id": "c3",
+                            "cell_type": "code",
+                            "source": [],
+                            "metadata": {},
+                            "outputs": [],
+                        },
+                    ],
+                }
+            )
+        )
+
+        session = runtimed.Session.open_notebook(str(nb_path))
+        info = session.connection_info
+        assert info is not None
+        assert info.cell_count == 3
+        assert info.notebook_id == session.notebook_id
+
+    def test_open_nonexistent_file_errors(self, daemon_process, monkeypatch, tmp_path):
+        """Opening missing file returns error."""
+        socket_path, _ = daemon_process
+        if socket_path is not None:
+            monkeypatch.setenv("RUNTIMED_SOCKET_PATH", str(socket_path))
+
+        with pytest.raises(runtimed.RuntimedError):
+            runtimed.Session.open_notebook(str(tmp_path / "missing.ipynb"))
+
+    def test_open_notebook_second_client_joins_room(
+        self, daemon_process, monkeypatch, tmp_path
+    ):
+        """Second client joining same notebook gets synced cells."""
+        import json
+
+        socket_path, _ = daemon_process
+        if socket_path is not None:
+            monkeypatch.setenv("RUNTIMED_SOCKET_PATH", str(socket_path))
+
+        nb_path = tmp_path / "shared.ipynb"
+        nb_path.write_text(
+            json.dumps(
+                {
+                    "nbformat": 4,
+                    "nbformat_minor": 5,
+                    "metadata": {},
+                    "cells": [
+                        {
+                            "id": "orig",
+                            "cell_type": "code",
+                            "source": ["a = 1"],
+                            "metadata": {},
+                            "outputs": [],
+                        }
+                    ],
+                }
+            )
+        )
+
+        session1 = runtimed.Session.open_notebook(str(nb_path))
+        session2 = runtimed.Session.open_notebook(str(nb_path))
+
+        # Both should have same notebook_id
+        assert session1.notebook_id == session2.notebook_id
+
+        # Add cell in session1
+        initial_count = len(session1.get_cells())
+        session1.create_cell("y = 2", index=initial_count)
+
+        # Should sync to session2
+        wait_for_sync(
+            lambda: len(session2.get_cells()) > initial_count, description="cell sync"
+        )
+
+        cells2 = session2.get_cells()
+        assert len(cells2) > initial_count
+
+
+class TestCreateNotebook:
+    """Test Session.create_notebook() - daemon-owned creation."""
+
+    def test_create_python_notebook(self, daemon_process, monkeypatch):
+        """Creating Python notebook returns session with one empty cell."""
+        socket_path, _ = daemon_process
+        if socket_path is not None:
+            monkeypatch.setenv("RUNTIMED_SOCKET_PATH", str(socket_path))
+
+        session = runtimed.Session.create_notebook(runtime="python")
+        assert session.is_connected
+
+        # notebook_id is UUID (not a path)
+        assert len(session.notebook_id) == 36  # UUID format
+
+        # Has one empty code cell
+        cells = session.get_cells()
+        assert len(cells) == 1
+        assert cells[0].cell_type == "code"
+        assert cells[0].source == ""
+
+    def test_create_notebook_returns_connection_info(self, daemon_process, monkeypatch):
+        """NotebookConnectionInfo is available for created notebooks."""
+        socket_path, _ = daemon_process
+        if socket_path is not None:
+            monkeypatch.setenv("RUNTIMED_SOCKET_PATH", str(socket_path))
+
+        session = runtimed.Session.create_notebook(runtime="python")
+        info = session.connection_info
+        assert info is not None
+        assert info.cell_count == 1
+        assert info.notebook_id == session.notebook_id
+        # New notebooks don't need trust approval
+        assert info.needs_trust_approval is False
+
+    def test_create_deno_notebook(self, daemon_process, monkeypatch):
+        """Creating Deno notebook sets correct runtime."""
+        socket_path, _ = daemon_process
+        if socket_path is not None:
+            monkeypatch.setenv("RUNTIMED_SOCKET_PATH", str(socket_path))
+
+        session = runtimed.Session.create_notebook(runtime="deno")
+        assert session.is_connected
+
+        # Has one empty code cell
+        cells = session.get_cells()
+        assert len(cells) == 1
+
+    def test_create_notebook_with_working_dir(self, daemon_process, monkeypatch, tmp_path):
+        """working_dir is used for project file detection."""
+        socket_path, _ = daemon_process
+        if socket_path is not None:
+            monkeypatch.setenv("RUNTIMED_SOCKET_PATH", str(socket_path))
+
+        # Create pyproject.toml in tmp_path
+        (tmp_path / "pyproject.toml").write_text("[project]\nname = 'test'")
+
+        session = runtimed.Session.create_notebook(
+            runtime="python", working_dir=str(tmp_path)
+        )
+
+        assert session.is_connected
+
+
+class TestTrustApproval:
+    """Test trust approval flow for notebooks with inline dependencies."""
+
+    def test_untrusted_notebook_needs_approval(
+        self, daemon_process, monkeypatch, tmp_path
+    ):
+        """Notebook with inline deps from unknown source needs trust."""
+        import json
+
+        socket_path, _ = daemon_process
+        if socket_path is not None:
+            monkeypatch.setenv("RUNTIMED_SOCKET_PATH", str(socket_path))
+
+        nb_path = tmp_path / "untrusted.ipynb"
+        nb_path.write_text(
+            json.dumps(
+                {
+                    "nbformat": 4,
+                    "nbformat_minor": 5,
+                    "metadata": {
+                        "runt": {
+                            "schema_version": "1",
+                            "uv": {"dependencies": ["requests"]},
+                            # No trust_signature - untrusted
+                        }
+                    },
+                    "cells": [
+                        {
+                            "id": "c1",
+                            "cell_type": "code",
+                            "source": [],
+                            "metadata": {},
+                            "outputs": [],
+                        }
+                    ],
+                }
+            )
+        )
+
+        session = runtimed.Session.open_notebook(str(nb_path))
+        info = session.connection_info
+        assert info is not None
+        assert info.needs_trust_approval is True
+
+    def test_notebook_without_deps_does_not_need_trust(
+        self, daemon_process, monkeypatch, tmp_path
+    ):
+        """Notebook without inline deps doesn't need trust approval."""
+        import json
+
+        socket_path, _ = daemon_process
+        if socket_path is not None:
+            monkeypatch.setenv("RUNTIMED_SOCKET_PATH", str(socket_path))
+
+        nb_path = tmp_path / "simple.ipynb"
+        nb_path.write_text(
+            json.dumps(
+                {
+                    "nbformat": 4,
+                    "nbformat_minor": 5,
+                    "metadata": {},
+                    "cells": [
+                        {
+                            "id": "c1",
+                            "cell_type": "code",
+                            "source": ["print('hello')"],
+                            "metadata": {},
+                            "outputs": [],
+                        }
+                    ],
+                }
+            )
+        )
+
+        session = runtimed.Session.open_notebook(str(nb_path))
+        info = session.connection_info
+        assert info is not None
+        assert info.needs_trust_approval is False
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Implement Python bindings for daemon-owned notebook loading (`Session.open_notebook()` and `Session.create_notebook()` class methods) to expose PR #601's new daemon-side infrastructure. Refactor socket path and blob store path computation into shared `daemon_paths` module to eliminate duplication across six different connection methods.

## Changes

- Add `Session.open_notebook()` and `Session.create_notebook()` static methods to expose daemon-side notebook file loading
- Add async variants `AsyncSession.open_notebook()` and `AsyncSession.create_notebook()`
- Create `crates/runtimed-py/src/daemon_paths.rs` with `get_socket_path()`, `get_blob_paths_sync()`, and `get_blob_paths_async()` helpers
- Expose `NotebookConnectionInfo` in Python wrapper's `__init__.py` to provide connection metadata (notebook_id, cell_count, trust status)
- Add 10 comprehensive integration tests covering open existing notebook, create new notebook, and trust approval workflows
- All new tests pass; cargo test, clippy, and fmt pass

---

_PR submitted by @rgbkrk's agent, Quill_