### PR TITLE
refactor(runtimed): reduce relay to pure byte pipe — two-peer Automerge sync (#600)

### DIFF
--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -215,44 +215,56 @@ where
     )
 }
 
-/// Read the notebook metadata from Automerge via the sync handle.
+/// Read the notebook metadata from the daemon's canonical Automerge doc.
 /// Returns the deserialized NotebookMetadataSnapshot, or None if not available.
 async fn get_metadata_snapshot(
     handle: &NotebookSyncHandle,
 ) -> Option<runtimed::notebook_metadata::NotebookMetadataSnapshot> {
-    handle
-        .get_metadata(runtimed::notebook_metadata::NOTEBOOK_METADATA_KEY)
+    let key = runtimed::notebook_metadata::NOTEBOOK_METADATA_KEY.to_string();
+    match handle
+        .send_request(NotebookRequest::GetRawMetadata { key })
         .await
-        .ok()
-        .flatten()
-        .and_then(|json| serde_json::from_str(&json).ok())
+    {
+        Ok(NotebookResponse::RawMetadata { value: Some(json) }) => serde_json::from_str(&json).ok(),
+        _ => None,
+    }
 }
 
-/// Write a NotebookMetadataSnapshot to Automerge via the sync handle.
+/// Write a NotebookMetadataSnapshot to the daemon's canonical Automerge doc.
 async fn set_metadata_snapshot(
     handle: &NotebookSyncHandle,
     snapshot: &runtimed::notebook_metadata::NotebookMetadataSnapshot,
 ) -> Result<(), String> {
-    let json = serde_json::to_string(snapshot).map_err(|e| format!("serialize metadata: {}", e))?;
-    handle
-        .set_metadata(runtimed::notebook_metadata::NOTEBOOK_METADATA_KEY, &json)
+    let value =
+        serde_json::to_string(snapshot).map_err(|e| format!("serialize metadata: {}", e))?;
+    let key = runtimed::notebook_metadata::NOTEBOOK_METADATA_KEY.to_string();
+    match handle
+        .send_request(NotebookRequest::SetRawMetadata { key, value })
         .await
-        .map_err(|e| format!("set_metadata: {}", e))
+    {
+        Ok(NotebookResponse::MetadataSet {}) => Ok(()),
+        Ok(NotebookResponse::Error { error }) => Err(error),
+        Ok(other) => Err(format!("Unexpected response: {:?}", other)),
+        Err(e) => Err(format!("set_metadata request failed: {}", e)),
+    }
 }
 
-/// Read the raw metadata `additional` fields from Automerge, preserving all
-/// unknown fields in `runt` (e.g. `trust_signature`, `trust_timestamp`).
+/// Read the raw metadata `additional` fields from the daemon's Automerge doc,
+/// preserving all unknown fields in `runt` (e.g. `trust_signature`, `trust_timestamp`).
 ///
 /// Unlike `get_metadata_snapshot` → `metadata_from_snapshot`, this does not
 /// go through the typed `RuntMetadata` struct which would strip unknown keys.
 async fn get_raw_metadata_additional(
     handle: &NotebookSyncHandle,
 ) -> Option<HashMap<String, serde_json::Value>> {
-    let json_str = handle
-        .get_metadata(runtimed::notebook_metadata::NOTEBOOK_METADATA_KEY)
+    let key = runtimed::notebook_metadata::NOTEBOOK_METADATA_KEY.to_string();
+    let json_str = match handle
+        .send_request(NotebookRequest::GetRawMetadata { key })
         .await
-        .ok()
-        .flatten()?;
+    {
+        Ok(NotebookResponse::RawMetadata { value: Some(json) }) => json,
+        _ => return None,
+    };
     let value: serde_json::Value = serde_json::from_str(&json_str).ok()?;
     let obj = value.as_object()?;
     let mut additional = HashMap::new();
@@ -262,19 +274,27 @@ async fn get_raw_metadata_additional(
     Some(additional)
 }
 
-/// Write trust fields into the Automerge metadata JSON without going through
-/// the typed `NotebookMetadataSnapshot` round-trip (which strips unknown `runt` keys
-/// like `trust_signature` that aren't modeled in `RuntMetadata`).
+/// Write trust fields into the daemon's Automerge metadata JSON without going
+/// through the typed `NotebookMetadataSnapshot` round-trip (which strips unknown
+/// `runt` keys like `trust_signature` that aren't modeled in `RuntMetadata`).
 async fn set_raw_trust_in_metadata(
     handle: &NotebookSyncHandle,
     signature: &str,
     timestamp: &str,
 ) -> Result<(), String> {
-    let json_str = handle
-        .get_metadata(runtimed::notebook_metadata::NOTEBOOK_METADATA_KEY)
+    let key = runtimed::notebook_metadata::NOTEBOOK_METADATA_KEY.to_string();
+    let json_str = match handle
+        .send_request(NotebookRequest::GetRawMetadata { key: key.clone() })
         .await
-        .map_err(|e| format!("get_metadata: {}", e))?
-        .ok_or("No metadata in Automerge doc")?;
+    {
+        Ok(NotebookResponse::RawMetadata { value: Some(json) }) => json,
+        Ok(NotebookResponse::RawMetadata { value: None }) => {
+            return Err("No metadata in Automerge doc".to_string())
+        }
+        Ok(NotebookResponse::Error { error }) => return Err(error),
+        Ok(other) => return Err(format!("Unexpected response: {:?}", other)),
+        Err(e) => return Err(format!("get_metadata request failed: {}", e)),
+    };
 
     let mut value: serde_json::Value =
         serde_json::from_str(&json_str).map_err(|e| format!("parse metadata: {}", e))?;
@@ -298,13 +318,18 @@ async fn set_raw_trust_in_metadata(
 
     let new_json =
         serde_json::to_string(&value).map_err(|e| format!("serialize metadata: {}", e))?;
-    handle
-        .set_metadata(
-            runtimed::notebook_metadata::NOTEBOOK_METADATA_KEY,
-            &new_json,
-        )
+    match handle
+        .send_request(NotebookRequest::SetRawMetadata {
+            key,
+            value: new_json,
+        })
         .await
-        .map_err(|e| format!("set_metadata: {}", e))
+    {
+        Ok(NotebookResponse::MetadataSet {}) => Ok(()),
+        Ok(NotebookResponse::Error { error }) => Err(error),
+        Ok(other) => Err(format!("Unexpected response: {:?}", other)),
+        Err(e) => Err(format!("set_metadata request failed: {}", e)),
+    }
 }
 
 /// Reconstruct an nbformat Metadata from a NotebookMetadataSnapshot.
@@ -2174,16 +2199,18 @@ async fn get_automerge_doc_bytes(
     let guard = notebook_sync.lock().await;
     let handle = guard.as_ref().ok_or("Not connected to daemon")?;
 
-    handle
-        .get_doc_bytes()
-        .await
-        .map_err(|e| format!("Failed to get doc bytes: {}", e))
+    // Fetch doc bytes from the daemon's canonical Automerge doc (not the relay's local replica).
+    match handle.send_request(NotebookRequest::GetDocBytes {}).await {
+        Ok(NotebookResponse::DocBytes { bytes }) => Ok(bytes),
+        Ok(NotebookResponse::Error { error }) => Err(error),
+        Ok(other) => Err(format!("Unexpected response: {:?}", other)),
+        Err(e) => Err(format!("Failed to get doc bytes: {}", e)),
+    }
 }
 
 /// Receive a raw Automerge sync message from the frontend.
 ///
-/// The message is applied to the local Automerge doc and relayed to the daemon.
-/// This enables the frontend to act as a full Automerge peer in Phase 2.
+/// The message is forwarded to the daemon via the relay.
 #[tauri::command]
 async fn send_automerge_sync(
     window: tauri::Window,

--- a/crates/runtimed/src/notebook_sync_client.rs
+++ b/crates/runtimed/src/notebook_sync_client.rs
@@ -2101,19 +2101,17 @@ async fn run_sync_task<S>(
                     SyncCommand::GetDocBytes { reply } => {
                         let bytes = client.doc.save();
 
-                        // Initialize frontend_peer_state now that the frontend
-                        // will have the doc bytes. Before this point, fe_state
-                        // is None so no sync messages are sent to the frontend
-                        // (preventing stale messages from causing phantom cells).
-                        //
-                        // We simulate a complete sync exchange with a mirror doc
-                        // loaded from the same bytes. After convergence, fe_state
-                        // knows exactly what the frontend has.
-                        if raw_sync_tx.is_some() {
+                        // In pipe mode (Tauri), the frontend gets doc bytes from the
+                        // daemon via send_request(GetDocBytes), not from this command.
+                        // But runtimed-py tests may still call this. Skip the virtual
+                        // sync handshake in pipe mode — the frontend and daemon sync
+                        // directly through the byte pipe, so no relay peer state needed.
+                        if raw_sync_tx.is_none() {
+                            // Full peer mode (runtimed-py): initialize frontend_peer_state
+                            // via virtual sync handshake so we know what the peer has seen.
                             let mut fe_state = sync::State::new();
                             if let Ok(mut mirror) = automerge::AutoCommit::load(&bytes) {
                                 let mut mirror_state = sync::State::new();
-                                // Exchange sync messages until both sides agree
                                 for _ in 0..10 {
                                     let our_msg =
                                         client.doc.sync().generate_sync_message(&mut fe_state);
@@ -2145,8 +2143,26 @@ async fn run_sync_task<S>(
                         let _ = reply.send(bytes);
                     }
                     SyncCommand::ReceiveFrontendSyncMessage { message, reply } => {
-                        let result = if let Some(ref mut fe_state) = frontend_peer_state {
-                            // Apply the frontend's sync message to our local doc
+                        let result = if raw_sync_tx.is_some() {
+                            // Pipe mode (Tauri): forward raw sync bytes to daemon
+                            // without merging into the relay's doc. The daemon processes
+                            // the sync message and sends back a response frame, which
+                            // arrives in the socket read branch and is forwarded raw
+                            // to the frontend via raw_sync_tx.
+                            connection::send_typed_frame(
+                                &mut client.stream,
+                                NotebookFrameType::AutomergeSync,
+                                &message,
+                            )
+                            .await
+                            .map_err(|e| {
+                                NotebookSyncError::SyncError(format!(
+                                    "forward frontend sync to daemon: {}",
+                                    e
+                                ))
+                            })
+                        } else if let Some(ref mut fe_state) = frontend_peer_state {
+                            // Full peer mode (runtimed-py): merge into local doc
                             match sync::Message::decode(&message) {
                                 Ok(msg) => {
                                     let recv_result =
@@ -2172,12 +2188,15 @@ async fn run_sync_task<S>(
                                 "frontend sync relay not active".to_string(),
                             ))
                         };
-                        // Send response sync message back to frontend
-                        if let (Some(ref tx), Some(ref mut fe_state)) =
-                            (&raw_sync_tx, &mut frontend_peer_state)
-                        {
-                            if let Some(msg) = client.doc.sync().generate_sync_message(fe_state) {
-                                let _ = tx.send(msg.encode());
+                        // In full peer mode, send response sync message back to frontend
+                        if raw_sync_tx.is_none() {
+                            if let (Some(ref tx), Some(ref mut fe_state)) =
+                                (&raw_sync_tx, &mut frontend_peer_state)
+                            {
+                                if let Some(msg) = client.doc.sync().generate_sync_message(fe_state)
+                                {
+                                    let _ = tx.send(msg.encode());
+                                }
                             }
                         }
                         let _ = reply.send(result);
@@ -2197,73 +2216,84 @@ async fn run_sync_task<S>(
                 // v2 protocol: direct socket read completed
                 match frame_result {
                     Ok(Some(frame)) => {
-                        match client.process_incoming_frame(frame).await {
-                            Ok(Some(ReceivedFrame::Changes(cells))) => {
-                                // Got changes from another peer — only include metadata if it changed
-                                let current_metadata = client.get_metadata(NOTEBOOK_METADATA_KEY);
-                                let metadata_changed = current_metadata != last_metadata;
-                                if metadata_changed {
-                                    last_metadata = current_metadata.clone();
-                                }
-                                let update = SyncUpdate {
-                                    cells,
-                                    notebook_metadata: if metadata_changed {
-                                        current_metadata
-                                    } else {
-                                        None
-                                    },
-                                };
-                                // Use try_send to avoid blocking if receiver isn't draining
-                                match changes_tx.try_send(update) {
-                                    Ok(()) => {}
-                                    Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
-                                        // Channel full - receiver not keeping up, skip this update
+                        // Pipe mode (Tauri): forward AutomergeSync frames raw to the
+                        // frontend without merging into the relay's doc. This makes
+                        // the relay a transparent byte pipe between frontend and daemon
+                        // — two Automerge peers instead of three.
+                        // Broadcast and Response frames still need normal processing.
+                        if raw_sync_tx.is_some()
+                            && frame.frame_type == NotebookFrameType::AutomergeSync
+                        {
+                            if let Some(ref tx) = raw_sync_tx {
+                                let _ = tx.send(frame.payload);
+                            }
+                        } else {
+                            match client.process_incoming_frame(frame).await {
+                                Ok(Some(ReceivedFrame::Changes(cells))) => {
+                                    // Full peer mode: metadata diffing and SyncUpdate
+                                    let current_metadata =
+                                        client.get_metadata(NOTEBOOK_METADATA_KEY);
+                                    let metadata_changed = current_metadata != last_metadata;
+                                    if metadata_changed {
+                                        last_metadata = current_metadata.clone();
                                     }
-                                    Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
-                                        info!(
+                                    let update = SyncUpdate {
+                                        cells,
+                                        notebook_metadata: if metadata_changed {
+                                            current_metadata
+                                        } else {
+                                            None
+                                        },
+                                    };
+                                    match changes_tx.try_send(update) {
+                                        Ok(()) => {}
+                                        Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {}
+                                        Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
+                                            info!(
                                             "[notebook-sync-task] Changes receiver dropped for {}, loop_count={}",
                                             notebook_id, loop_count
                                         );
-                                        break;
+                                            break;
+                                        }
                                     }
-                                }
-                                // Forward sync message to frontend if relay is active
-                                if let (Some(ref tx), Some(ref mut fe_state)) =
-                                    (&raw_sync_tx, &mut frontend_peer_state)
-                                {
-                                    if let Some(msg) =
-                                        client.doc.sync().generate_sync_message(fe_state)
+                                    // Forward sync message to frontend (full peer mode only)
+                                    if let (Some(ref tx), Some(ref mut fe_state)) =
+                                        (&raw_sync_tx, &mut frontend_peer_state)
                                     {
-                                        let _ = tx.send(msg.encode());
+                                        if let Some(msg) =
+                                            client.doc.sync().generate_sync_message(fe_state)
+                                        {
+                                            let _ = tx.send(msg.encode());
+                                        }
                                     }
                                 }
-                            }
-                            Ok(Some(ReceivedFrame::Broadcast(broadcast))) => {
-                                let send_result = broadcast_tx.send(broadcast);
-                                if send_result.is_err() {
-                                    info!(
-                                        "[notebook-sync-task] No broadcast receivers for {}",
+                                Ok(Some(ReceivedFrame::Broadcast(broadcast))) => {
+                                    let send_result = broadcast_tx.send(broadcast);
+                                    if send_result.is_err() {
+                                        info!(
+                                            "[notebook-sync-task] No broadcast receivers for {}",
+                                            notebook_id
+                                        );
+                                    }
+                                }
+                                Ok(Some(ReceivedFrame::Response(_))) => {
+                                    warn!(
+                                        "[notebook-sync-task] Unexpected response frame for {}",
                                         notebook_id
                                     );
                                 }
-                            }
-                            Ok(Some(ReceivedFrame::Response(_))) => {
-                                warn!(
-                                    "[notebook-sync-task] Unexpected response frame for {}",
-                                    notebook_id
-                                );
-                            }
-                            Ok(None) => {
-                                // Frame was handled internally (e.g., unexpected Request)
-                            }
-                            Err(e) => {
-                                warn!(
+                                Ok(None) => {
+                                    // Frame was handled internally (e.g., unexpected Request)
+                                }
+                                Err(e) => {
+                                    warn!(
                                     "[notebook-sync-task] Error processing frame for {}: {}, loop_count={}",
                                     notebook_id, e, loop_count
                                 );
-                                break;
+                                    break;
+                                }
                             }
-                        }
+                        } // end else (non-pipe mode)
                     }
                     Ok(None) => {
                         // Connection closed

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -2161,6 +2161,35 @@ async fn handle_notebook_request(
         }
 
         NotebookRequest::SyncEnvironment {} => handle_sync_environment(room).await,
+
+        NotebookRequest::GetDocBytes {} => {
+            let mut doc = room.doc.write().await;
+            let bytes = doc.save();
+            NotebookResponse::DocBytes { bytes }
+        }
+
+        NotebookRequest::GetRawMetadata { key } => {
+            let doc = room.doc.read().await;
+            let value = doc.get_metadata(&key);
+            NotebookResponse::RawMetadata { value }
+        }
+
+        NotebookRequest::SetRawMetadata { key, value } => {
+            let mut doc = room.doc.write().await;
+            match doc.set_metadata(&key, &value) {
+                Ok(()) => {
+                    // Notify peers of the change
+                    let _ = room.changed_tx.send(());
+                    // Persist
+                    let bytes = doc.save();
+                    let _ = room.persist_tx.send(Some(bytes));
+                    NotebookResponse::MetadataSet {}
+                }
+                Err(e) => NotebookResponse::Error {
+                    error: format!("Failed to set metadata: {e}"),
+                },
+            }
+        }
     }
 }
 

--- a/crates/runtimed/src/protocol.rs
+++ b/crates/runtimed/src/protocol.rs
@@ -253,6 +253,26 @@ pub enum NotebookRequest {
     /// Sync environment with current metadata (hot-install new packages).
     /// Only supported for UV inline deps. Falls back to restart for removals/conda.
     SyncEnvironment {},
+
+    /// Get the full Automerge document bytes from the daemon's canonical doc.
+    /// Used by the frontend to bootstrap its WASM Automerge peer.
+    GetDocBytes {},
+
+    /// Get raw metadata JSON from the daemon's Automerge doc.
+    /// Returns the value stored at the given key (e.g., "notebook_metadata").
+    GetRawMetadata {
+        /// Metadata key to read (e.g., "notebook_metadata").
+        key: String,
+    },
+
+    /// Set raw metadata JSON in the daemon's Automerge doc.
+    /// Writes the JSON string at the given key, then syncs to all peers.
+    SetRawMetadata {
+        /// Metadata key to write (e.g., "notebook_metadata").
+        key: String,
+        /// JSON string value to store.
+        value: String,
+    },
 }
 
 /// Responses from daemon to notebook app.
@@ -355,6 +375,21 @@ pub enum NotebookResponse {
         /// Whether the user should restart instead
         needs_restart: bool,
     },
+
+    /// Full Automerge document bytes from the daemon's canonical doc.
+    DocBytes {
+        /// Raw Automerge document bytes, encoded as a Vec for JSON transport.
+        bytes: Vec<u8>,
+    },
+
+    /// Raw metadata JSON value from the daemon's Automerge doc.
+    RawMetadata {
+        /// The metadata JSON string, or None if the key doesn't exist.
+        value: Option<String>,
+    },
+
+    /// Metadata was set successfully.
+    MetadataSet {},
 }
 
 /// A single entry from kernel input history.


### PR DESCRIPTION
Closes #600.

The Tauri relay (`NotebookSyncClient`) was a full Automerge peer — it maintained its own `AutoCommit` doc, merged sync messages from both frontend and daemon, and generated new sync messages for each peer. This created a three-peer topology (frontend ↔ relay ↔ daemon) that was the root cause of 6+ correctness findings from the protocol audit.

## What changed

### Step 1: Daemon requests for doc bytes and metadata
New `NotebookRequest` variants — `GetDocBytes`, `GetRawMetadata { key }`, `SetRawMetadata { key, value }` — let the Tauri app read/write the daemon's canonical Automerge doc directly via the request/response protocol, without going through the relay's local replica.

### Step 2: Reroute Tauri callers
`get_automerge_doc_bytes`, `get_metadata_snapshot`, `set_metadata_snapshot`, `get_raw_metadata_additional`, `set_raw_trust_in_metadata` — all now use `send_request()` instead of relay-local `get_metadata()`/`set_metadata()`/`get_doc_bytes()`.

### Step 3: Byte pipe in `run_sync_task`
When `raw_sync_tx` is present (Tauri mode), the relay is now a transparent byte forwarder:

| Operation | Before (3-peer) | After (2-peer pipe) |
|---|---|---|
| Frontend → daemon sync | decode → merge into relay doc → `sync_to_daemon()` → re-encode | forward raw bytes as `AutomergeSync` frame |
| Daemon → frontend sync | merge into relay doc → `generate_sync_message(fe_state)` | forward raw `AutomergeSync` frame payload |
| `GetDocBytes` | serialize relay's `AutoCommit` + virtual sync handshake | skipped in pipe mode (frontend uses daemon request) |
| Metadata diffing | read from relay doc, diff, emit `SyncUpdate` | skipped (frontend WASM drives metadata via `useSyncExternalStore`) |

`runtimed-py` retains the full peer mode (no `raw_sync_tx`) — unchanged behavior.

## Audit findings resolved

For the Tauri path, these protocol correctness findings are eliminated:

- **`sync_to_daemon()` drops broadcast frames during ack wait** — relay no longer calls `sync_to_daemon()`
- **Triple-merge divergence risk** — two peers (frontend ↔ daemon) instead of three
- **Virtual sync handshake 10-iteration limit** — no virtual handshake in pipe mode
- **`try_send` drops sync updates silently** — no `SyncUpdate`/`changes_tx` in pipe mode
- **`receive_and_relay_sync_message` uses wrong peer state** — no relay peer state in pipe mode

## Handle methods still used from Tauri

| Method | Purpose |
|---|---|
| `send_request()` | Daemon RPC (save, execute, kernel lifecycle, etc.) |
| `receive_frontend_sync_message()` | Raw byte forward to daemon |
| `notebook_id()` | ID accessor |

No relay-local doc methods (`get_metadata`, `set_metadata`, `get_doc_bytes`, `get_cells`, etc.) are called from `lib.rs`.

## Test plan

- [x] `cargo test -p runtimed --lib` — 234 passed
- [x] `cargo test -p runtimed --test '*'` — 15 integration tests passed
- [x] `cargo test -p notebook --lib` — 137 passed
- [ ] Open existing .ipynb — cells load, kernel auto-launches
- [ ] Cmd-N new notebook — kernel launches, execute works
- [ ] Save-as — reconnects to new room
- [ ] Session restore — windows restored
- [ ] Trust approval — prompt appears for untrusted notebooks
- [ ] Metadata writes (add dependency) — syncs to daemon and persists