### PR TITLE
feat(ui): notebook loading skeleton for daemon-owned doc population (#599)

### DIFF
--- a/apps/notebook/src/components/CellSkeleton.tsx
+++ b/apps/notebook/src/components/CellSkeleton.tsx
@@ -1,20 +1,42 @@
 /**
- * Skeleton placeholder shown while the notebook is loading.
- * Mimics the visual structure of a code cell with AddCellButtons spacing.
+ * Skeleton placeholder shown while the notebook document is loading from the daemon.
+ *
+ * Renders several placeholder cells with varying heights to mimic a real notebook.
+ * The staggered animation delays give a subtle wave effect while loading.
  */
-export function CellSkeleton() {
+
+const skeletonCells = [
+  { height: "2.5rem", delay: "0ms" },
+  { height: "5rem", delay: "75ms" },
+  { height: "2rem", delay: "150ms" },
+];
+
+function SkeletonCell({ height, delay }: { height: string; delay: string }) {
   return (
     <div className="flex py-4">
       {/* Gutter area — matches CellContainer's w-10 gutter */}
       <div className="w-10 flex-shrink-0" />
 
       {/* Ribbon — self-stretch to fill container height */}
-      <div className="w-1 self-stretch bg-gray-200 dark:bg-gray-700" />
+      <div className="w-1 self-stretch rounded-sm bg-muted/40" />
 
       {/* Editor area placeholder */}
       <div className="min-w-0 flex-1 py-3 pl-6 pr-3">
-        <div className="min-h-[2rem] rounded bg-muted/50 animate-pulse" />
+        <div
+          className="rounded bg-muted/30 animate-pulse"
+          style={{ minHeight: height, animationDelay: delay }}
+        />
       </div>
+    </div>
+  );
+}
+
+export function CellSkeleton() {
+  return (
+    <div>
+      {skeletonCells.map((cell, i) => (
+        <SkeletonCell key={i} height={cell.height} delay={cell.delay} />
+      ))}
     </div>
   );
 }


### PR DESCRIPTION
Closes #599.

Builds on #607 (external store + `awaitingInitialSyncRef` loading detection).

## What changed

`CellSkeleton` now renders three skeleton cells with varying heights instead of one, giving a more realistic "notebook is loading" appearance. Staggered `animationDelay` on the pulse creates a subtle wave effect.

| Before | After |
|---|---|
| Single 2rem skeleton cell | Three cells: 2.5rem, 5rem, 2rem |
| Looks sparse during load | Looks like a notebook with cells |

## How loading works (from #607)

1. `isLoading` starts `true`
2. `bootstrap()` fetches doc bytes from daemon via `GetDocBytes` request
3. If doc has cells → `isLoading = false` immediately
4. If doc is empty (daemon still syncing) → stays loading until first `automerge:from-daemon` message
5. `NotebookViewContent` shows `<CellSkeleton />` when `cells.length === 0 && isLoading`
6. Once cells materialize via sync → external store updates → React re-renders with real cells

## Follow-ups

- `DaemonReadyPayload { cell_count }` is emitted but not consumed yet — could size the skeleton to match the actual notebook
- Per-cell output loading indicators (outputs arrive via broadcast after cells sync)