### PR TITLE
refactor(runtimed): use watch channel for instant reads instead of command round-trip

### DIFF
--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -875,6 +875,26 @@ pub fn get_metadata_from_doc(doc: &AutoCommit, key: &str) -> Option<String> {
     read_str(doc, meta_id, key)
 }
 
+/// Read all metadata key-value pairs from a raw `AutoCommit` document.
+///
+/// Returns an empty map if the metadata object doesn't exist.
+pub fn get_all_metadata_from_doc(doc: &AutoCommit) -> std::collections::HashMap<String, String> {
+    let meta_id = match doc.get(automerge::ROOT, "metadata").ok().flatten() {
+        Some((automerge::Value::Object(ObjType::Map), id)) => id,
+        _ => return std::collections::HashMap::new(),
+    };
+    doc.map_range(&meta_id, ..)
+        .filter_map(|item| {
+            if let automerge::ValueRef::Scalar(s) = &item.value {
+                if let automerge::ScalarValueRef::Str(v) = s {
+                    return Some((item.key.to_string(), v.to_string()));
+                }
+            }
+            None
+        })
+        .collect()
+}
+
 /// Set a metadata value in a raw `AutoCommit` document.
 ///
 /// Creates the metadata map if it doesn't exist. This is the free-function

--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -875,24 +875,16 @@ pub fn get_metadata_from_doc(doc: &AutoCommit, key: &str) -> Option<String> {
     read_str(doc, meta_id, key)
 }
 
-/// Read all metadata key-value pairs from a raw `AutoCommit` document.
+/// Read the typed notebook metadata snapshot from a raw `AutoCommit` document.
 ///
-/// Returns an empty map if the metadata object doesn't exist.
-pub fn get_all_metadata_from_doc(doc: &AutoCommit) -> std::collections::HashMap<String, String> {
-    let meta_id = match doc.get(automerge::ROOT, "metadata").ok().flatten() {
-        Some((automerge::Value::Object(ObjType::Map), id)) => id,
-        _ => return std::collections::HashMap::new(),
-    };
-    doc.map_range(&meta_id, ..)
-        .filter_map(|item| {
-            if let automerge::ValueRef::Scalar(s) = &item.value {
-                if let automerge::ScalarValueRef::Str(v) = s {
-                    return Some((item.key.to_string(), v.to_string()));
-                }
-            }
-            None
-        })
-        .collect()
+/// This is the free-function counterpart of `NotebookDoc::get_metadata_snapshot`,
+/// for use by the sync client which holds a raw `AutoCommit` instead of a
+/// `NotebookDoc`.
+pub fn get_metadata_snapshot_from_doc(
+    doc: &AutoCommit,
+) -> Option<metadata::NotebookMetadataSnapshot> {
+    let json = get_metadata_from_doc(doc, metadata::NOTEBOOK_METADATA_KEY)?;
+    serde_json::from_str(&json).ok()
 }
 
 /// Set a metadata value in a raw `AutoCommit` document.

--- a/crates/runtimed-py/src/async_session.rs
+++ b/crates/runtimed-py/src/async_session.rs
@@ -473,7 +473,7 @@ impl AsyncSession {
                 .as_ref()
                 .ok_or_else(|| to_py_err("Not connected"))?;
 
-            let cells = handle.get_cells().await.map_err(to_py_err)?;
+            let cells = handle.get_cells();
             let insert_index = index.unwrap_or(cells.len());
 
             handle
@@ -587,7 +587,7 @@ impl AsyncSession {
                 let blob_base_url = state_guard.blob_base_url.clone();
                 let blob_store_path = state_guard.blob_store_path.clone();
 
-                let cells = handle.get_cells().await.map_err(to_py_err)?;
+                let cells = handle.get_cells();
                 let snapshot = cells
                     .into_iter()
                     .find(|c| c.id == cell_id)
@@ -626,7 +626,7 @@ impl AsyncSession {
                 let blob_base_url = state_guard.blob_base_url.clone();
                 let blob_store_path = state_guard.blob_store_path.clone();
 
-                let snapshots = handle.get_cells().await.map_err(to_py_err)?;
+                let snapshots = handle.get_cells();
                 (snapshots, blob_base_url, blob_store_path)
             }; // Lock released here
 
@@ -764,7 +764,7 @@ impl AsyncSession {
                 .as_ref()
                 .ok_or_else(|| to_py_err("Not connected"))?;
 
-            handle.get_metadata(&key).await.map_err(to_py_err)
+            Ok(handle.get_metadata(&key))
         })
     }
 
@@ -1401,7 +1401,7 @@ impl AsyncSession {
                 let cell_id = format!("cell-{}", uuid::Uuid::new_v4());
 
                 // Get current cell count for append position
-                let cells = handle.get_cells().await.map_err(to_py_err)?;
+                let cells = handle.get_cells();
                 let insert_index = cells.len();
 
                 // Add cell to document
@@ -2167,10 +2167,7 @@ async fn get_notebook_metadata_async(
         .as_ref()
         .ok_or_else(|| to_py_err("Not connected"))?;
 
-    let json_str = handle
-        .get_metadata("notebook_metadata")
-        .await
-        .map_err(to_py_err)?;
+    let json_str = handle.get_metadata("notebook_metadata");
 
     match json_str {
         Some(s) => {

--- a/crates/runtimed-py/src/async_session.rs
+++ b/crates/runtimed-py/src/async_session.rs
@@ -2167,13 +2167,9 @@ async fn get_notebook_metadata_async(
         .as_ref()
         .ok_or_else(|| to_py_err("Not connected"))?;
 
-    let json_str = handle.get_metadata("notebook_metadata");
-
-    match json_str {
-        Some(s) => {
-            serde_json::from_str(&s).map_err(|e| to_py_err(format!("Invalid metadata JSON: {}", e)))
-        }
-        None => Ok(NotebookMetadataSnapshot {
+    Ok(handle
+        .get_notebook_metadata()
+        .unwrap_or_else(|| NotebookMetadataSnapshot {
             kernelspec: None,
             language_info: None,
             runt: RuntMetadata {
@@ -2185,8 +2181,7 @@ async fn get_notebook_metadata_async(
                 trust_signature: None,
                 trust_timestamp: None,
             },
-        }),
-    }
+        }))
 }
 
 /// Set the notebook metadata snapshot asynchronously.

--- a/crates/runtimed-py/src/session.rs
+++ b/crates/runtimed-py/src/session.rs
@@ -387,7 +387,7 @@ impl Session {
                 .ok_or_else(|| to_py_err("Not connected"))?;
 
             // Get current cell count to determine index
-            let cells = handle.get_cells().await.map_err(to_py_err)?;
+            let cells = handle.get_cells();
             let insert_index = index.unwrap_or(cells.len());
 
             // Add cell to document
@@ -476,7 +476,7 @@ impl Session {
                 let blob_base_url = state.blob_base_url.clone();
                 let blob_store_path = state.blob_store_path.clone();
 
-                let cells = handle.get_cells().await.map_err(to_py_err)?;
+                let cells = handle.get_cells();
                 let snapshot = cells
                     .into_iter()
                     .find(|c| c.id == cell_id)
@@ -514,7 +514,7 @@ impl Session {
                 let blob_base_url = state.blob_base_url.clone();
                 let blob_store_path = state.blob_store_path.clone();
 
-                let snapshots = handle.get_cells().await.map_err(to_py_err)?;
+                let snapshots = handle.get_cells();
                 (snapshots, blob_base_url, blob_store_path)
             }; // Lock released here
 
@@ -644,7 +644,7 @@ impl Session {
                 .as_ref()
                 .ok_or_else(|| to_py_err("Not connected"))?;
 
-            handle.get_metadata(&key).await.map_err(to_py_err)
+            Ok(handle.get_metadata(&key))
         })
     }
 

--- a/crates/runtimed-py/src/session.rs
+++ b/crates/runtimed-py/src/session.rs
@@ -1664,11 +1664,16 @@ impl Session {
 impl Session {
     /// Get the current notebook metadata snapshot.
     fn get_notebook_metadata(&self) -> PyResult<NotebookMetadataSnapshot> {
-        let json_str = self.get_metadata("notebook_metadata")?;
-        match json_str {
-            Some(s) => serde_json::from_str(&s)
-                .map_err(|e| to_py_err(format!("Invalid metadata JSON: {}", e))),
-            None => Ok(NotebookMetadataSnapshot {
+        self.connect()?;
+        let state = self.state.blocking_lock();
+        let handle = state
+            .handle
+            .as_ref()
+            .ok_or_else(|| to_py_err("Not connected"))?;
+
+        Ok(handle
+            .get_notebook_metadata()
+            .unwrap_or_else(|| NotebookMetadataSnapshot {
                 kernelspec: None,
                 language_info: None,
                 runt: RuntMetadata {
@@ -1680,8 +1685,7 @@ impl Session {
                     trust_signature: None,
                     trust_timestamp: None,
                 },
-            }),
-        }
+            }))
     }
 
     /// Set the notebook metadata snapshot.

--- a/crates/runtimed/src/notebook_sync_client.rs
+++ b/crates/runtimed/src/notebook_sync_client.rs
@@ -27,10 +27,10 @@ use crate::connection::{
     self, Handshake, NotebookConnectionInfo, NotebookFrameType, ProtocolCapabilities, PROTOCOL_V2,
 };
 use crate::notebook_doc::{
-    get_all_metadata_from_doc, get_cells_from_doc, get_metadata_from_doc, set_metadata_in_doc,
+    get_cells_from_doc, get_metadata_from_doc, get_metadata_snapshot_from_doc, set_metadata_in_doc,
     CellSnapshot,
 };
-use crate::notebook_metadata::NOTEBOOK_METADATA_KEY;
+use crate::notebook_metadata::{NotebookMetadataSnapshot, NOTEBOOK_METADATA_KEY};
 use crate::protocol::{NotebookBroadcast, NotebookRequest, NotebookResponse};
 
 /// Error type for notebook sync client operations.
@@ -292,9 +292,26 @@ impl NotebookSyncHandle {
 
     /// Read a metadata value from the local Automerge doc replica.
     ///
-    /// Instant synchronous read from the latest snapshot.
+    /// Instant synchronous read from the latest snapshot. For the
+    /// `"notebook_metadata"` key this serializes the typed snapshot back to
+    /// JSON; other keys are not tracked and return `None`.
     pub fn get_metadata(&self, key: &str) -> Option<String> {
-        self.snapshot_rx.borrow().metadata.get(key).cloned()
+        if key == NOTEBOOK_METADATA_KEY {
+            let snap = self.snapshot_rx.borrow();
+            snap.notebook_metadata
+                .as_ref()
+                .and_then(|m| serde_json::to_string(m).ok())
+        } else {
+            None
+        }
+    }
+
+    /// Get the typed notebook metadata snapshot.
+    ///
+    /// Prefer this over `get_metadata("notebook_metadata")` followed by
+    /// `serde_json::from_str` — the snapshot is already parsed.
+    pub fn get_notebook_metadata(&self) -> Option<NotebookMetadataSnapshot> {
+        self.snapshot_rx.borrow().notebook_metadata.clone()
     }
 
     /// Send a request to the daemon and wait for a response.
@@ -398,19 +415,14 @@ pub struct SyncUpdate {
 /// Modeled after automerge-repo's `DocHandle.doc()` pattern: the sync task is
 /// the single owner/writer of the Automerge doc, and publishes snapshots for
 /// consumers.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct NotebookSnapshot {
     pub cells: std::sync::Arc<Vec<CellSnapshot>>,
-    pub metadata: std::sync::Arc<std::collections::HashMap<String, String>>,
-}
-
-impl Default for NotebookSnapshot {
-    fn default() -> Self {
-        Self {
-            cells: std::sync::Arc::new(Vec::new()),
-            metadata: std::sync::Arc::new(std::collections::HashMap::new()),
-        }
-    }
+    /// Typed notebook metadata (kernelspec, language_info, runt deps/trust).
+    ///
+    /// `None` when the doc has no `metadata.notebook_metadata` key yet (e.g.
+    /// freshly created notebooks before the daemon seeds metadata).
+    pub notebook_metadata: Option<NotebookMetadataSnapshot>,
 }
 
 /// This is separate from the handle to allow receiving changes independently
@@ -1900,7 +1912,7 @@ where
         // This is the Rust equivalent of automerge-repo's DocHandle.doc() pattern.
         let initial_snapshot = NotebookSnapshot {
             cells: std::sync::Arc::new(initial_cells.clone()),
-            metadata: std::sync::Arc::new(get_all_metadata_from_doc(&self.doc)),
+            notebook_metadata: get_metadata_snapshot_from_doc(&self.doc),
         };
         let (snapshot_tx, snapshot_rx) = watch::channel(initial_snapshot);
 
@@ -1997,7 +2009,7 @@ fn publish_snapshot<S: AsyncRead + AsyncWrite + Unpin>(
 ) {
     let snapshot = NotebookSnapshot {
         cells: std::sync::Arc::new(get_cells_from_doc(&client.doc)),
-        metadata: std::sync::Arc::new(get_all_metadata_from_doc(&client.doc)),
+        notebook_metadata: get_metadata_snapshot_from_doc(&client.doc),
     };
     let _ = snapshot_tx.send(snapshot);
 }

--- a/crates/runtimed/src/notebook_sync_client.rs
+++ b/crates/runtimed/src/notebook_sync_client.rs
@@ -2155,6 +2155,11 @@ async fn run_sync_task<S>(
                         let result = client
                             .send_request_with_broadcast(&request, Some(tx_to_use))
                             .await;
+                        // AutomergeSync frames may have been applied to client.doc
+                        // during wait_for_response_with_broadcast — refresh snapshot
+                        // so readers see daemon-driven mutations (outputs, execution
+                        // counts, etc.) immediately.
+                        publish_snapshot(&client, &snapshot_tx);
                         let _ = reply.send(result);
                     }
                     SyncCommand::GetDocBytes { reply } => {

--- a/crates/runtimed/src/notebook_sync_client.rs
+++ b/crates/runtimed/src/notebook_sync_client.rs
@@ -21,13 +21,14 @@ use futures::FutureExt;
 use log::{debug, info, warn};
 use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncRead, AsyncWrite};
-use tokio::sync::{broadcast, mpsc, oneshot};
+use tokio::sync::{broadcast, mpsc, oneshot, watch};
 
 use crate::connection::{
     self, Handshake, NotebookConnectionInfo, NotebookFrameType, ProtocolCapabilities, PROTOCOL_V2,
 };
 use crate::notebook_doc::{
-    get_cells_from_doc, get_metadata_from_doc, set_metadata_in_doc, CellSnapshot,
+    get_all_metadata_from_doc, get_cells_from_doc, get_metadata_from_doc, set_metadata_in_doc,
+    CellSnapshot,
 };
 use crate::notebook_metadata::NOTEBOOK_METADATA_KEY;
 use crate::protocol::{NotebookBroadcast, NotebookRequest, NotebookResponse};
@@ -91,19 +92,11 @@ enum SyncCommand {
         count: String,
         reply: oneshot::Sender<Result<(), NotebookSyncError>>,
     },
-    GetCells {
-        reply: oneshot::Sender<Vec<CellSnapshot>>,
-    },
     /// Set a metadata value in the Automerge doc and sync to daemon.
     SetMetadata {
         key: String,
         value: String,
         reply: oneshot::Sender<Result<(), NotebookSyncError>>,
-    },
-    /// Read a metadata value from the local Automerge doc replica.
-    GetMetadata {
-        key: String,
-        reply: oneshot::Sender<Option<String>>,
     },
     /// Send a request to the daemon and wait for a response.
     SendRequest {
@@ -131,6 +124,7 @@ enum SyncCommand {
 pub struct NotebookSyncHandle {
     tx: mpsc::Sender<SyncCommand>,
     notebook_id: String,
+    snapshot_rx: watch::Receiver<NotebookSnapshot>,
 }
 
 impl NotebookSyncHandle {
@@ -140,13 +134,12 @@ impl NotebookSyncHandle {
     }
 
     /// Get all cells from the local replica.
-    pub async fn get_cells(&self) -> Result<Vec<CellSnapshot>, NotebookSyncError> {
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.tx
-            .send(SyncCommand::GetCells { reply: reply_tx })
-            .await
-            .map_err(|_| NotebookSyncError::ChannelClosed)?;
-        reply_rx.await.map_err(|_| NotebookSyncError::ChannelClosed)
+    ///
+    /// Instant synchronous read from the latest snapshot published by the sync
+    /// task — no channel round-trip, no async. Modeled after automerge-repo's
+    /// `DocHandle.doc()` pattern.
+    pub fn get_cells(&self) -> Vec<CellSnapshot> {
+        self.snapshot_rx.borrow().cells.as_ref().clone()
     }
 
     /// Add a new cell at the given index.
@@ -298,16 +291,10 @@ impl NotebookSyncHandle {
     }
 
     /// Read a metadata value from the local Automerge doc replica.
-    pub async fn get_metadata(&self, key: &str) -> Result<Option<String>, NotebookSyncError> {
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.tx
-            .send(SyncCommand::GetMetadata {
-                key: key.to_string(),
-                reply: reply_tx,
-            })
-            .await
-            .map_err(|_| NotebookSyncError::ChannelClosed)?;
-        reply_rx.await.map_err(|_| NotebookSyncError::ChannelClosed)
+    ///
+    /// Instant synchronous read from the latest snapshot.
+    pub fn get_metadata(&self, key: &str) -> Option<String> {
+        self.snapshot_rx.borrow().metadata.get(key).cloned()
     }
 
     /// Send a request to the daemon and wait for a response.
@@ -400,6 +387,30 @@ pub struct SyncUpdate {
     pub cells: Vec<CellSnapshot>,
     /// JSON-serialized `NotebookMetadataSnapshot`, present when metadata changed.
     pub notebook_metadata: Option<String>,
+}
+
+/// Materialized read-only snapshot of the notebook state.
+///
+/// Published via `tokio::watch` channel after every doc mutation in the sync
+/// task. Readers (via `NotebookSyncHandle`) get instant access without any
+/// channel round-trip or locking.
+///
+/// Modeled after automerge-repo's `DocHandle.doc()` pattern: the sync task is
+/// the single owner/writer of the Automerge doc, and publishes snapshots for
+/// consumers.
+#[derive(Clone, Debug)]
+pub struct NotebookSnapshot {
+    pub cells: std::sync::Arc<Vec<CellSnapshot>>,
+    pub metadata: std::sync::Arc<std::collections::HashMap<String, String>>,
+}
+
+impl Default for NotebookSnapshot {
+    fn default() -> Self {
+        Self {
+            cells: std::sync::Arc::new(Vec::new()),
+            metadata: std::sync::Arc::new(std::collections::HashMap::new()),
+        }
+    }
 }
 
 /// This is separate from the handle to allow receiving changes independently
@@ -1885,6 +1896,14 @@ where
         let notebook_id = self.notebook_id.clone();
         let pending_broadcasts = self.pending_broadcasts.clone();
 
+        // Watch channel: sync task publishes snapshots, handle reads instantly.
+        // This is the Rust equivalent of automerge-repo's DocHandle.doc() pattern.
+        let initial_snapshot = NotebookSnapshot {
+            cells: std::sync::Arc::new(initial_cells.clone()),
+            metadata: std::sync::Arc::new(get_all_metadata_from_doc(&self.doc)),
+        };
+        let (snapshot_tx, snapshot_rx) = watch::channel(initial_snapshot);
+
         // Channel for commands from handles
         let (cmd_tx, cmd_rx) = mpsc::channel::<SyncCommand>(32);
 
@@ -1926,6 +1945,7 @@ where
                 changes_tx,
                 broadcast_tx,
                 raw_sync_tx,
+                snapshot_tx,
             ))
             .catch_unwind()
             .await;
@@ -1950,6 +1970,7 @@ where
         let handle = NotebookSyncHandle {
             tx: cmd_tx,
             notebook_id,
+            snapshot_rx,
         };
         let receiver = NotebookSyncReceiver { rx: changes_rx };
         let broadcast_receiver = NotebookBroadcastReceiver { rx: broadcast_rx };
@@ -1965,12 +1986,29 @@ where
 }
 
 /// Background task that owns the client and processes commands/changes.
+/// Publish a materialized snapshot of the current doc state via the watch channel.
+///
+/// Called after every successful doc mutation (local write or incoming sync frame)
+/// so that `NotebookSyncHandle` readers always see the latest state without any
+/// channel round-trip.
+fn publish_snapshot<S: AsyncRead + AsyncWrite + Unpin>(
+    client: &NotebookSyncClient<S>,
+    snapshot_tx: &watch::Sender<NotebookSnapshot>,
+) {
+    let snapshot = NotebookSnapshot {
+        cells: std::sync::Arc::new(get_cells_from_doc(&client.doc)),
+        metadata: std::sync::Arc::new(get_all_metadata_from_doc(&client.doc)),
+    };
+    let _ = snapshot_tx.send(snapshot);
+}
+
 async fn run_sync_task<S>(
     mut client: NotebookSyncClient<S>,
     mut cmd_rx: mpsc::Receiver<SyncCommand>,
     changes_tx: mpsc::Sender<SyncUpdate>,
     broadcast_tx: broadcast::Sender<NotebookBroadcast>,
     raw_sync_tx: Option<mpsc::UnboundedSender<Vec<u8>>>,
+    snapshot_tx: watch::Sender<NotebookSnapshot>,
 ) where
     S: AsyncRead + AsyncWrite + Unpin,
 {
@@ -2036,10 +2074,16 @@ async fn run_sync_task<S>(
                         reply,
                     } => {
                         let result = client.add_cell(index, &cell_id, &cell_type).await;
+                        if result.is_ok() {
+                            publish_snapshot(&client, &snapshot_tx);
+                        }
                         let _ = reply.send(result);
                     }
                     SyncCommand::DeleteCell { cell_id, reply } => {
                         let result = client.delete_cell(&cell_id).await;
+                        if result.is_ok() {
+                            publish_snapshot(&client, &snapshot_tx);
+                        }
                         let _ = reply.send(result);
                     }
                     SyncCommand::UpdateSource {
@@ -2048,6 +2092,9 @@ async fn run_sync_task<S>(
                         reply,
                     } => {
                         let result = client.update_source(&cell_id, &source).await;
+                        if result.is_ok() {
+                            publish_snapshot(&client, &snapshot_tx);
+                        }
                         let _ = reply.send(result);
                     }
                     SyncCommand::AppendSource {
@@ -2056,10 +2103,16 @@ async fn run_sync_task<S>(
                         reply,
                     } => {
                         let result = client.append_source(&cell_id, &text).await;
+                        if result.is_ok() {
+                            publish_snapshot(&client, &snapshot_tx);
+                        }
                         let _ = reply.send(result);
                     }
                     SyncCommand::ClearOutputs { cell_id, reply } => {
                         let result = client.clear_outputs(&cell_id).await;
+                        if result.is_ok() {
+                            publish_snapshot(&client, &snapshot_tx);
+                        }
                         let _ = reply.send(result);
                     }
                     SyncCommand::AppendOutput {
@@ -2068,6 +2121,9 @@ async fn run_sync_task<S>(
                         reply,
                     } => {
                         let result = client.append_output(&cell_id, &output).await;
+                        if result.is_ok() {
+                            publish_snapshot(&client, &snapshot_tx);
+                        }
                         let _ = reply.send(result);
                     }
                     SyncCommand::SetExecutionCount {
@@ -2076,18 +2132,16 @@ async fn run_sync_task<S>(
                         reply,
                     } => {
                         let result = client.set_execution_count(&cell_id, &count).await;
+                        if result.is_ok() {
+                            publish_snapshot(&client, &snapshot_tx);
+                        }
                         let _ = reply.send(result);
-                    }
-                    SyncCommand::GetCells { reply } => {
-                        let cells = client.get_cells();
-                        let _ = reply.send(cells);
                     }
                     SyncCommand::SetMetadata { key, value, reply } => {
                         let result = client.set_metadata(&key, &value).await;
-                        let _ = reply.send(result);
-                    }
-                    SyncCommand::GetMetadata { key, reply } => {
-                        let result = client.get_metadata(&key);
+                        if result.is_ok() {
+                            publish_snapshot(&client, &snapshot_tx);
+                        }
                         let _ = reply.send(result);
                     }
                     SyncCommand::SendRequest {
@@ -2204,6 +2258,9 @@ async fn run_sync_task<S>(
                                 }
                             }
                         }
+                        if result.is_ok() {
+                            publish_snapshot(&client, &snapshot_tx);
+                        }
                         let _ = reply.send(result);
                     }
                 },
@@ -2235,6 +2292,7 @@ async fn run_sync_task<S>(
                         } else {
                             match client.process_incoming_frame(frame).await {
                                 Ok(Some(ReceivedFrame::Changes(cells))) => {
+                                    publish_snapshot(&client, &snapshot_tx);
                                     // Full peer mode: metadata diffing and SyncUpdate
                                     let current_metadata =
                                         client.get_metadata(NOTEBOOK_METADATA_KEY);


### PR DESCRIPTION
Replace the async command round-trip for reads (`get_cells`, `get_metadata`) with a `tokio::watch` channel that publishes materialized snapshots after every doc mutation.

## Why

After `into_split()`, reads on `NotebookSyncHandle` send a `SyncCommand` over mpsc and await a oneshot reply — pure overhead for a local Automerge doc read. This caused starvation (#606) and is the wrong concurrency model for single-writer/multi-reader.

## How automerge-repo does it

automerge-repo's `DocHandle` uses single-owner + event-driven snapshots: the XState machine serializes all writes, `handle.doc()` is a synchronous snapshot read, and `change` events push the new doc to subscribers. No locks, no shared mutable state.

`tokio::watch` is the direct Rust translation: single-producer, multi-consumer, always holds the latest value, readers never block the writer.

## Changes

- `NotebookSnapshot` — new type with `Arc`-wrapped cells and metadata, published via `watch` after every doc mutation
- `get_all_metadata_from_doc` — bulk metadata reader in `notebook-doc`
- `publish_snapshot()` called after every write command and incoming sync frame in `run_sync_task`
- `NotebookSyncHandle::get_cells()` and `get_metadata()` are now **sync** — instant reads from the watch receiver
- `SyncCommand::GetCells` and `SyncCommand::GetMetadata` removed
- All `runtimed-py` call sites updated (removed `.await` and error mapping)

Closes #612