### PR TITLE
refactor(runtimed): use watch channel for instant reads instead of command round-trip

### DIFF
--- a/crates/runtimed-py/src/async_session.rs
+++ b/crates/runtimed-py/src/async_session.rs
@@ -737,7 +737,7 @@ impl AsyncSession {
     /// Currently only supports the "notebook_metadata" key for instant reads.
     ///
     /// Args:
-    ///     key: The metadata key (must be "notebook_metadata").
+    ///     key: The metadata key.
     ///
     /// Returns a coroutine that resolves to the metadata value (str) or None.
     fn get_metadata<'py>(&self, py: Python<'py>, key: &str) -> PyResult<Bound<'py, PyAny>> {
@@ -745,21 +745,19 @@ impl AsyncSession {
         let key = key.to_string();
 
         future_into_py(py, async move {
-            if key != NOTEBOOK_METADATA_KEY {
-                return Err(to_py_err(format!(
-                    "get_metadata only supports '{}' key, got '{}'",
-                    NOTEBOOK_METADATA_KEY, key
-                )));
-            }
-
             let state_guard = state.lock().await;
             let handle = state_guard
                 .handle
                 .as_ref()
                 .ok_or_else(|| to_py_err("Not connected"))?;
 
-            // Instant read from watch channel - no async, no channel round-trip
-            Ok(handle.get_notebook_metadata())
+            // Fast path for notebook_metadata: instant read from watch channel
+            if key == NOTEBOOK_METADATA_KEY {
+                return Ok(handle.get_notebook_metadata());
+            }
+
+            // Fallback for other keys: async command round-trip
+            handle.get_metadata(&key).await.map_err(to_py_err)
         })
     }
 

--- a/crates/runtimed-py/src/async_session.rs
+++ b/crates/runtimed-py/src/async_session.rs
@@ -25,6 +25,7 @@ use crate::subscription::EventSubscription;
 
 use notebook_doc::metadata::{
     CondaInlineMetadata, NotebookMetadataSnapshot, RuntMetadata, UvInlineMetadata,
+    NOTEBOOK_METADATA_KEY,
 };
 
 /// An async session for executing code via the runtimed daemon.
@@ -458,7 +459,7 @@ impl AsyncSession {
                 .as_ref()
                 .ok_or_else(|| to_py_err("Not connected"))?;
 
-            let cells = handle.get_cells().await.map_err(to_py_err)?;
+            let cells = handle.get_cells();
             let insert_index = index.unwrap_or(cells.len());
 
             handle
@@ -572,7 +573,7 @@ impl AsyncSession {
                 let blob_base_url = state_guard.blob_base_url.clone();
                 let blob_store_path = state_guard.blob_store_path.clone();
 
-                let cells = handle.get_cells().await.map_err(to_py_err)?;
+                let cells = handle.get_cells();
                 let snapshot = cells
                     .into_iter()
                     .find(|c| c.id == cell_id)
@@ -611,7 +612,7 @@ impl AsyncSession {
                 let blob_base_url = state_guard.blob_base_url.clone();
                 let blob_store_path = state_guard.blob_store_path.clone();
 
-                let snapshots = handle.get_cells().await.map_err(to_py_err)?;
+                let snapshots = handle.get_cells();
                 (snapshots, blob_base_url, blob_store_path)
             }; // Lock released here
 
@@ -733,9 +734,10 @@ impl AsyncSession {
     /// Get a metadata value from the automerge document.
     ///
     /// Reads from the local replica of the automerge doc.
+    /// Currently only supports the "notebook_metadata" key for instant reads.
     ///
     /// Args:
-    ///     key: The metadata key.
+    ///     key: The metadata key (must be "notebook_metadata").
     ///
     /// Returns a coroutine that resolves to the metadata value (str) or None.
     fn get_metadata<'py>(&self, py: Python<'py>, key: &str) -> PyResult<Bound<'py, PyAny>> {
@@ -743,13 +745,21 @@ impl AsyncSession {
         let key = key.to_string();
 
         future_into_py(py, async move {
+            if key != NOTEBOOK_METADATA_KEY {
+                return Err(to_py_err(format!(
+                    "get_metadata only supports '{}' key, got '{}'",
+                    NOTEBOOK_METADATA_KEY, key
+                )));
+            }
+
             let state_guard = state.lock().await;
             let handle = state_guard
                 .handle
                 .as_ref()
                 .ok_or_else(|| to_py_err("Not connected"))?;
 
-            handle.get_metadata(&key).await.map_err(to_py_err)
+            // Instant read from watch channel - no async, no channel round-trip
+            Ok(handle.get_notebook_metadata())
         })
     }
 
@@ -1386,7 +1396,7 @@ impl AsyncSession {
                 let cell_id = format!("cell-{}", uuid::Uuid::new_v4());
 
                 // Get current cell count for append position
-                let cells = handle.get_cells().await.map_err(to_py_err)?;
+                let cells = handle.get_cells();
                 let insert_index = cells.len();
 
                 // Add cell to document
@@ -2259,14 +2269,12 @@ async fn get_notebook_metadata_async(
         .as_ref()
         .ok_or_else(|| to_py_err("Not connected"))?;
 
-    let json_str = handle
-        .get_metadata("notebook_metadata")
-        .await
-        .map_err(to_py_err)?;
+    // Instant read from watch channel - no async, no channel round-trip
+    let json_str = handle.get_notebook_metadata();
 
     match json_str {
-        Some(s) => {
-            serde_json::from_str(&s).map_err(|e| to_py_err(format!("Invalid metadata JSON: {}", e)))
+        Some(ref s) => {
+            serde_json::from_str(s).map_err(|e| to_py_err(format!("Invalid metadata JSON: {}", e)))
         }
         None => Ok(NotebookMetadataSnapshot {
             kernelspec: None,

--- a/crates/runtimed-py/src/session.rs
+++ b/crates/runtimed-py/src/session.rs
@@ -623,13 +623,7 @@ impl Session {
     ///     The metadata value (str) or None if not set.
     fn get_metadata(&self, key: &str) -> PyResult<Option<String>> {
         self.connect()?;
-
-        if key != NOTEBOOK_METADATA_KEY {
-            return Err(to_py_err(format!(
-                "get_metadata only supports '{}' key, got '{}'",
-                NOTEBOOK_METADATA_KEY, key
-            )));
-        }
+        let key = key.to_string();
 
         self.runtime.block_on(async {
             let state = self.state.lock().await;
@@ -638,8 +632,13 @@ impl Session {
                 .as_ref()
                 .ok_or_else(|| to_py_err("Not connected"))?;
 
-            // Instant read from watch channel - no async, no channel round-trip
-            Ok(handle.get_notebook_metadata())
+            // Fast path for notebook_metadata: instant read from watch channel
+            if key == NOTEBOOK_METADATA_KEY {
+                return Ok(handle.get_notebook_metadata());
+            }
+
+            // Fallback for other keys: async command round-trip
+            handle.get_metadata(&key).await.map_err(to_py_err)
         })
     }
 

--- a/crates/runtimed-py/src/session.rs
+++ b/crates/runtimed-py/src/session.rs
@@ -24,6 +24,7 @@ use crate::subscription::EventIteratorSubscription;
 
 use notebook_doc::metadata::{
     CondaInlineMetadata, NotebookMetadataSnapshot, RuntMetadata, UvInlineMetadata,
+    NOTEBOOK_METADATA_KEY,
 };
 
 /// A session for executing code via the runtimed daemon.
@@ -375,7 +376,7 @@ impl Session {
                 .ok_or_else(|| to_py_err("Not connected"))?;
 
             // Get current cell count to determine index
-            let cells = handle.get_cells().await.map_err(to_py_err)?;
+            let cells = handle.get_cells();
             let insert_index = index.unwrap_or(cells.len());
 
             // Add cell to document
@@ -464,7 +465,7 @@ impl Session {
                 let blob_base_url = state.blob_base_url.clone();
                 let blob_store_path = state.blob_store_path.clone();
 
-                let cells = handle.get_cells().await.map_err(to_py_err)?;
+                let cells = handle.get_cells();
                 let snapshot = cells
                     .into_iter()
                     .find(|c| c.id == cell_id)
@@ -502,7 +503,7 @@ impl Session {
                 let blob_base_url = state.blob_base_url.clone();
                 let blob_store_path = state.blob_store_path.clone();
 
-                let snapshots = handle.get_cells().await.map_err(to_py_err)?;
+                let snapshots = handle.get_cells();
                 (snapshots, blob_base_url, blob_store_path)
             }; // Lock released here
 
@@ -623,7 +624,12 @@ impl Session {
     fn get_metadata(&self, key: &str) -> PyResult<Option<String>> {
         self.connect()?;
 
-        let key = key.to_string();
+        if key != NOTEBOOK_METADATA_KEY {
+            return Err(to_py_err(format!(
+                "get_metadata only supports '{}' key, got '{}'",
+                NOTEBOOK_METADATA_KEY, key
+            )));
+        }
 
         self.runtime.block_on(async {
             let state = self.state.lock().await;
@@ -632,7 +638,8 @@ impl Session {
                 .as_ref()
                 .ok_or_else(|| to_py_err("Not connected"))?;
 
-            handle.get_metadata(&key).await.map_err(to_py_err)
+            // Instant read from watch channel - no async, no channel round-trip
+            Ok(handle.get_notebook_metadata())
         })
     }
 

--- a/crates/runtimed/src/notebook_sync_client.rs
+++ b/crates/runtimed/src/notebook_sync_client.rs
@@ -110,6 +110,11 @@ enum SyncCommand {
         value: String,
         reply: oneshot::Sender<Result<(), NotebookSyncError>>,
     },
+    /// Get a metadata value from the Automerge doc (async fallback for non-notebook_metadata keys).
+    GetMetadata {
+        key: String,
+        reply: oneshot::Sender<Option<String>>,
+    },
     /// Send a request to the daemon and wait for a response.
     SendRequest {
         request: NotebookRequest,
@@ -166,6 +171,22 @@ impl NotebookSyncHandle {
     /// no channel round-trip.
     pub fn get_notebook_metadata(&self) -> Option<String> {
         self.snapshot_rx.borrow().notebook_metadata.clone()
+    }
+
+    /// Get a metadata value by key from the local replica.
+    ///
+    /// For `notebook_metadata`, prefer `get_notebook_metadata()` which is instant.
+    /// This async method exists for arbitrary keys that aren't in the snapshot.
+    pub async fn get_metadata(&self, key: &str) -> Result<Option<String>, NotebookSyncError> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.tx
+            .send(SyncCommand::GetMetadata {
+                key: key.to_string(),
+                reply: reply_tx,
+            })
+            .await
+            .map_err(|_| NotebookSyncError::ChannelClosed)?;
+        reply_rx.await.map_err(|_| NotebookSyncError::ChannelClosed)
     }
 
     /// Subscribe to snapshot changes.
@@ -2144,6 +2165,10 @@ async fn run_sync_task<S>(
                             publish_snapshot(&client.doc, &snapshot_tx, "mutation");
                         }
                         let _ = reply.send(result);
+                    }
+                    SyncCommand::GetMetadata { key, reply } => {
+                        let value = get_metadata_from_doc(&client.doc, &key);
+                        let _ = reply.send(value);
                     }
                     SyncCommand::SendRequest {
                         request,

--- a/crates/runtimed/src/notebook_sync_client.rs
+++ b/crates/runtimed/src/notebook_sync_client.rs
@@ -12,6 +12,7 @@
 //! This design avoids holding locks during network I/O.
 
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::time::Duration;
 
 use automerge::sync::{self, SyncDoc};
@@ -21,7 +22,7 @@ use futures::FutureExt;
 use log::{debug, info, warn};
 use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncRead, AsyncWrite};
-use tokio::sync::{broadcast, mpsc, oneshot};
+use tokio::sync::{broadcast, mpsc, oneshot, watch};
 
 use crate::connection::{
     self, Handshake, NotebookConnectionInfo, NotebookFrameType, ProtocolCapabilities, PROTOCOL_V2,
@@ -52,6 +53,18 @@ pub enum NotebookSyncError {
 
     #[error("Channel closed")]
     ChannelClosed,
+}
+
+/// Pre-computed snapshot for instant reads via watch channel.
+///
+/// The sync task publishes a new snapshot after every doc mutation.
+/// Handles read from the watch channel without any async or locking.
+#[derive(Clone, Default, Debug)]
+pub struct NotebookSnapshot {
+    /// Current cell state.
+    pub cells: Vec<CellSnapshot>,
+    /// JSON-serialized notebook metadata (the primary metadata field readers need).
+    pub notebook_metadata: Option<String>,
 }
 
 /// Commands sent from handles to the sync task.
@@ -91,19 +104,11 @@ enum SyncCommand {
         count: String,
         reply: oneshot::Sender<Result<(), NotebookSyncError>>,
     },
-    GetCells {
-        reply: oneshot::Sender<Vec<CellSnapshot>>,
-    },
     /// Set a metadata value in the Automerge doc and sync to daemon.
     SetMetadata {
         key: String,
         value: String,
         reply: oneshot::Sender<Result<(), NotebookSyncError>>,
-    },
-    /// Read a metadata value from the local Automerge doc replica.
-    GetMetadata {
-        key: String,
-        reply: oneshot::Sender<Option<String>>,
     },
     /// Send a request to the daemon and wait for a response.
     SendRequest {
@@ -127,8 +132,15 @@ enum SyncCommand {
 ///
 /// This is clonable and can be shared across threads. Commands are sent
 /// through a channel and processed by the background sync task.
+///
+/// Read operations (get_cells, get_notebook_metadata) are instant via a watch
+/// channel - no async, no channel round-trip. The sync task publishes a new
+/// snapshot after every doc mutation.
 #[derive(Clone)]
 pub struct NotebookSyncHandle {
+    /// Watch receiver for instant reads of pre-computed snapshots.
+    snapshot_rx: watch::Receiver<Arc<NotebookSnapshot>>,
+    /// Command channel for write operations.
     tx: mpsc::Sender<SyncCommand>,
     notebook_id: String,
 }
@@ -140,13 +152,29 @@ impl NotebookSyncHandle {
     }
 
     /// Get all cells from the local replica.
-    pub async fn get_cells(&self) -> Result<Vec<CellSnapshot>, NotebookSyncError> {
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.tx
-            .send(SyncCommand::GetCells { reply: reply_tx })
-            .await
-            .map_err(|_| NotebookSyncError::ChannelClosed)?;
-        reply_rx.await.map_err(|_| NotebookSyncError::ChannelClosed)
+    ///
+    /// This is an instant read from the pre-computed snapshot - no async,
+    /// no channel round-trip. The sync task publishes a new snapshot after
+    /// every doc mutation.
+    pub fn get_cells(&self) -> Vec<CellSnapshot> {
+        self.snapshot_rx.borrow().cells.clone()
+    }
+
+    /// Get the notebook metadata JSON from the local replica.
+    ///
+    /// This is an instant read from the pre-computed snapshot - no async,
+    /// no channel round-trip.
+    pub fn get_notebook_metadata(&self) -> Option<String> {
+        self.snapshot_rx.borrow().notebook_metadata.clone()
+    }
+
+    /// Subscribe to snapshot changes.
+    ///
+    /// Returns a clone of the watch receiver. Use `changed().await` to wait
+    /// for updates, then `borrow()` to read the new snapshot. Useful for
+    /// the Tauri event bridge to push updates to the frontend.
+    pub fn subscribe(&self) -> watch::Receiver<Arc<NotebookSnapshot>> {
+        self.snapshot_rx.clone()
     }
 
     /// Add a new cell at the given index.
@@ -295,19 +323,6 @@ impl NotebookSyncHandle {
         reply_rx
             .await
             .map_err(|_| NotebookSyncError::ChannelClosed)?
-    }
-
-    /// Read a metadata value from the local Automerge doc replica.
-    pub async fn get_metadata(&self, key: &str) -> Result<Option<String>, NotebookSyncError> {
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.tx
-            .send(SyncCommand::GetMetadata {
-                key: key.to_string(),
-                reply: reply_tx,
-            })
-            .await
-            .map_err(|_| NotebookSyncError::ChannelClosed)?;
-        reply_rx.await.map_err(|_| NotebookSyncError::ChannelClosed)
     }
 
     /// Send a request to the daemon and wait for a response.
@@ -1879,6 +1894,14 @@ where
         let notebook_id = self.notebook_id.clone();
         let pending_broadcasts = self.pending_broadcasts.clone();
 
+        // Watch channel for instant reads - sync task publishes snapshots after
+        // every doc mutation, handles read via borrow() without async or locking.
+        let initial_snapshot = Arc::new(NotebookSnapshot {
+            cells: initial_cells.clone(),
+            notebook_metadata: initial_metadata.clone(),
+        });
+        let (snapshot_tx, snapshot_rx) = watch::channel(initial_snapshot);
+
         // Channel for commands from handles
         let (cmd_tx, cmd_rx) = mpsc::channel::<SyncCommand>(32);
 
@@ -1920,6 +1943,7 @@ where
                 changes_tx,
                 broadcast_tx,
                 raw_sync_tx,
+                snapshot_tx,
             ))
             .catch_unwind()
             .await;
@@ -1942,6 +1966,7 @@ where
         });
 
         let handle = NotebookSyncHandle {
+            snapshot_rx,
             tx: cmd_tx,
             notebook_id,
         };
@@ -1965,6 +1990,7 @@ async fn run_sync_task<S>(
     changes_tx: mpsc::Sender<SyncUpdate>,
     broadcast_tx: broadcast::Sender<NotebookBroadcast>,
     raw_sync_tx: Option<mpsc::UnboundedSender<Vec<u8>>>,
+    snapshot_tx: watch::Sender<Arc<NotebookSnapshot>>,
 ) where
     S: AsyncRead + AsyncWrite + Unpin,
 {
@@ -1988,6 +2014,24 @@ async fn run_sync_task<S>(
     let mut loop_count = 0u64;
     // Track last metadata to only send updates when it actually changes
     let mut last_metadata: Option<String> = client.get_metadata(NOTEBOOK_METADATA_KEY);
+
+    // Helper to publish current doc state to watch channel.
+    // Call this after every doc mutation so handles get instant reads.
+    let publish_snapshot =
+        |doc: &AutoCommit, tx: &watch::Sender<Arc<NotebookSnapshot>>, reason: &str| {
+            let cells = get_cells_from_doc(doc);
+            debug!(
+                "[notebook-sync-task] publish_snapshot ({}) for {}: {} cells",
+                reason,
+                notebook_id,
+                cells.len()
+            );
+            let snapshot = Arc::new(NotebookSnapshot {
+                cells,
+                notebook_metadata: get_metadata_from_doc(doc, NOTEBOOK_METADATA_KEY),
+            });
+            let _ = tx.send(snapshot);
+        };
 
     loop {
         loop_count += 1;
@@ -2031,10 +2075,16 @@ async fn run_sync_task<S>(
                         reply,
                     } => {
                         let result = client.add_cell(index, &cell_id, &cell_type).await;
+                        if result.is_ok() {
+                            publish_snapshot(&client.doc, &snapshot_tx, "mutation");
+                        }
                         let _ = reply.send(result);
                     }
                     SyncCommand::DeleteCell { cell_id, reply } => {
                         let result = client.delete_cell(&cell_id).await;
+                        if result.is_ok() {
+                            publish_snapshot(&client.doc, &snapshot_tx, "mutation");
+                        }
                         let _ = reply.send(result);
                     }
                     SyncCommand::UpdateSource {
@@ -2043,6 +2093,9 @@ async fn run_sync_task<S>(
                         reply,
                     } => {
                         let result = client.update_source(&cell_id, &source).await;
+                        if result.is_ok() {
+                            publish_snapshot(&client.doc, &snapshot_tx, "mutation");
+                        }
                         let _ = reply.send(result);
                     }
                     SyncCommand::AppendSource {
@@ -2051,10 +2104,16 @@ async fn run_sync_task<S>(
                         reply,
                     } => {
                         let result = client.append_source(&cell_id, &text).await;
+                        if result.is_ok() {
+                            publish_snapshot(&client.doc, &snapshot_tx, "mutation");
+                        }
                         let _ = reply.send(result);
                     }
                     SyncCommand::ClearOutputs { cell_id, reply } => {
                         let result = client.clear_outputs(&cell_id).await;
+                        if result.is_ok() {
+                            publish_snapshot(&client.doc, &snapshot_tx, "mutation");
+                        }
                         let _ = reply.send(result);
                     }
                     SyncCommand::AppendOutput {
@@ -2063,6 +2122,9 @@ async fn run_sync_task<S>(
                         reply,
                     } => {
                         let result = client.append_output(&cell_id, &output).await;
+                        if result.is_ok() {
+                            publish_snapshot(&client.doc, &snapshot_tx, "mutation");
+                        }
                         let _ = reply.send(result);
                     }
                     SyncCommand::SetExecutionCount {
@@ -2071,18 +2133,16 @@ async fn run_sync_task<S>(
                         reply,
                     } => {
                         let result = client.set_execution_count(&cell_id, &count).await;
+                        if result.is_ok() {
+                            publish_snapshot(&client.doc, &snapshot_tx, "mutation");
+                        }
                         let _ = reply.send(result);
-                    }
-                    SyncCommand::GetCells { reply } => {
-                        let cells = client.get_cells();
-                        let _ = reply.send(cells);
                     }
                     SyncCommand::SetMetadata { key, value, reply } => {
                         let result = client.set_metadata(&key, &value).await;
-                        let _ = reply.send(result);
-                    }
-                    SyncCommand::GetMetadata { key, reply } => {
-                        let result = client.get_metadata(&key);
+                        if result.is_ok() {
+                            publish_snapshot(&client.doc, &snapshot_tx, "mutation");
+                        }
                         let _ = reply.send(result);
                     }
                     SyncCommand::SendRequest {
@@ -2169,6 +2229,8 @@ async fn run_sync_task<S>(
                                         client.doc.sync().receive_sync_message(fe_state, msg);
                                     match recv_result {
                                         Ok(()) => {
+                                            // Publish snapshot for instant reads
+                                            publish_snapshot(&client.doc, &snapshot_tx, "mutation");
                                             // Relay the changes to the daemon
                                             client.sync_to_daemon().await
                                         }
@@ -2230,6 +2292,9 @@ async fn run_sync_task<S>(
                         } else {
                             match client.process_incoming_frame(frame).await {
                                 Ok(Some(ReceivedFrame::Changes(cells))) => {
+                                    // Full peer mode: publish snapshot for instant reads
+                                    publish_snapshot(&client.doc, &snapshot_tx, "mutation");
+
                                     // Full peer mode: metadata diffing and SyncUpdate
                                     let current_metadata =
                                         client.get_metadata(NOTEBOOK_METADATA_KEY);

--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -515,12 +515,16 @@ class TestMultiClientSync:
         # Session 1 creates cell
         cell_id = s1.create_cell("original")
 
-        # Wait for cell to sync to session 2
-        def cell_visible_to_s2():
+        # Wait for cell AND its content to sync to session 2.
+        # Automerge sync happens in rounds - the cell structure may arrive
+        # before the Text content is fully synced. We need to wait for the
+        # source content, not just cell existence, before s2 can modify it.
+        def cell_content_synced_to_s2():
             cells = s2.get_cells()
-            return any(c.id == cell_id for c in cells)
+            matching = [c for c in cells if c.id == cell_id]
+            return matching and matching[0].source == "original"
 
-        wait_for_sync(cell_visible_to_s2, description="cell visible to s2")
+        wait_for_sync(cell_content_synced_to_s2, description="cell content synced to s2")
 
         # Session 2 updates it
         s2.set_source(cell_id, "updated by s2")


### PR DESCRIPTION
## Summary

Replace command-channel round-trip for `get_cells()` and `get_metadata()` with `tokio::watch` for instant synchronous reads. This addresses the root cause of #606 where reads through the command channel were starving incoming sync frames.

- Add `NotebookSnapshot` struct for pre-computed cell + metadata snapshots
- Add watch channel: sync task publishes snapshot after every doc mutation
- Change `get_cells()` and `get_notebook_metadata()` to sync (non-async) methods
- Remove `GetCells` and `GetMetadata` commands from `SyncCommand` enum
- Add `subscribe()` method for Tauri event bridge to push updates

This follows the automerge-repo pattern where the doc owner (XState in their case, sync task in ours) serializes all mutations and publishes snapshots, while reads are instant from the latest snapshot.

## Test plan

- [x] All Rust tests pass (`cargo test -p runtimed`)
- [x] Multi-client sync tests pass (`TestMultiClientSync`)
- [x] Fixed `test_source_update_syncs_between_peers` to wait for content sync, not just cell existence (Automerge sync happens in rounds - cell structure may arrive before Text content is fully synced)

Closes #612