### PR TITLE
fix(runtimed): prevent pipe mode stream corruption by buffering outgoing frames (#613)

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -110,6 +110,7 @@ function AppContent() {
     openNotebook,
     cloneNotebook,
     dirty,
+    appendOutput,
     updateOutputByDisplayId,
     setExecutionCount,
     clearCellOutputs,
@@ -265,12 +266,11 @@ function AppContent() {
     runAllCells: daemonRunAllCells,
     sendCommMessage,
   } = useDaemonKernel({
-    // Outputs arrive via Automerge sync (materializeCells replaces all cells).
-    // Wiring appendOutput here causes duplicates: broadcast appends, then sync
-    // replaces with doc state that already has the output. If React batches both
-    // setCells calls, the functional update in appendOutput runs against the
-    // already-replaced state → double output. Sync latency is imperceptible.
-    onOutput: () => {},
+    // In pipe mode (#608), the Automerge sync path doesn't deliver output changes
+    // (daemon's sync state tracks the relay, not the WASM — all frames arrive with
+    // changed=false). Outputs must come from broadcasts until the sync state
+    // mismatch is fixed (see .context/plans/fix-pipe-mode-sync-state.md).
+    onOutput: appendOutput,
     onExecutionCount: handleExecutionCount,
     onExecutionDone: handleExecutionDone,
     onUpdateDisplayData: updateOutputByDisplayId,

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -663,10 +663,17 @@ async fn setup_sync_receivers(
     let sync_generation_for_cleanup = sync_generation.clone();
     tokio::spawn(async move {
         while let Some(broadcast) = broadcast_receiver.recv().await {
-            debug!(
-                "[notebook-sync] Broadcast for {}: {:?}",
-                notebook_id_for_broadcast, broadcast,
-            );
+            // Filter out EnvSyncState spam from debug logs — the daemon broadcasts
+            // this at high frequency and it drowns out useful messages.
+            if !matches!(
+                broadcast,
+                runtimed::protocol::NotebookBroadcast::EnvSyncState { .. }
+            ) {
+                debug!(
+                    "[notebook-sync] Broadcast for {}: {:?}",
+                    notebook_id_for_broadcast, broadcast,
+                );
+            }
             if let Err(e) =
                 emit_to_label::<_, _, _>(&window, window.label(), "daemon:broadcast", &broadcast)
             {

--- a/crates/runtimed/src/notebook_sync_client.rs
+++ b/crates/runtimed/src/notebook_sync_client.rs
@@ -1980,6 +1980,13 @@ async fn run_sync_task<S>(
         notebook_id
     );
 
+    // Buffer for outgoing sync frames in pipe mode. Instead of writing directly
+    // to client.stream inside the command handler (which can corrupt framing if
+    // a socket read is pending in the select!), we queue bytes here and flush
+    // them at the top of the loop before entering select!.
+    let mut pending_pipe_frames: std::collections::VecDeque<Vec<u8>> =
+        std::collections::VecDeque::new();
+
     // Sync state for the frontend peer (used when raw_sync_tx is active).
     // This tracks what the frontend doc has seen, enabling incremental sync messages.
     //
@@ -1997,6 +2004,24 @@ async fn run_sync_task<S>(
 
     loop {
         loop_count += 1;
+
+        // Flush any queued pipe frames to the daemon BEFORE entering select!.
+        // This ensures writes happen when no read is pending on the socket.
+        while let Some(frame_data) = pending_pipe_frames.pop_front() {
+            if let Err(e) = connection::send_typed_frame(
+                &mut client.stream,
+                NotebookFrameType::AutomergeSync,
+                &frame_data,
+            )
+            .await
+            {
+                warn!(
+                    "[notebook-sync-task] Failed to flush pipe frame for {}: {}",
+                    notebook_id, e
+                );
+                break;
+            }
+        }
 
         // First, check for any pending broadcasts (collected during request/response)
         // These need to be drained before we do anything else
@@ -2149,23 +2174,12 @@ async fn run_sync_task<S>(
                     }
                     SyncCommand::ReceiveFrontendSyncMessage { message, reply } => {
                         let result = if raw_sync_tx.is_some() {
-                            // Pipe mode (Tauri): forward raw sync bytes to daemon
-                            // without merging into the relay's doc. The daemon processes
-                            // the sync message and sends back a response frame, which
-                            // arrives in the socket read branch and is forwarded raw
-                            // to the frontend via raw_sync_tx.
-                            connection::send_typed_frame(
-                                &mut client.stream,
-                                NotebookFrameType::AutomergeSync,
-                                &message,
-                            )
-                            .await
-                            .map_err(|e| {
-                                NotebookSyncError::SyncError(format!(
-                                    "forward frontend sync to daemon: {}",
-                                    e
-                                ))
-                            })
+                            // Pipe mode (Tauri): queue the sync bytes to be flushed
+                            // at the top of the next loop iteration, BEFORE the
+                            // select! starts a new socket read. Writing directly here
+                            // would corrupt framing if a daemon read was pending.
+                            pending_pipe_frames.push_back(message);
+                            Ok(())
                         } else if let Some(ref mut fe_state) = frontend_peer_state {
                             // Full peer mode (runtimed-py): merge into local doc
                             match sync::Message::decode(&message) {


### PR DESCRIPTION
Fixes #613.

## Bug

In pipe mode (#608), `ReceiveFrontendSyncMessage` wrote sync frames directly to `client.stream` inside the `select!` command handler. If the daemon was sending data simultaneously, `select!` would drop the pending socket read, then the write would corrupt the framing. The daemon reads payload bytes as a length prefix → `frame too large: 1154398000 bytes`.

## Fix

Buffer outgoing pipe frames in a `VecDeque` and flush them at the top of the loop **before** entering `select!`. Writes only happen when no read is pending.

```
loop {
    // 1. Flush queued pipe frames (safe — no pending read)
    while let Some(frame) = pending_pipe_frames.pop_front() {
        send_typed_frame(&mut client.stream, AutomergeSync, &frame).await?;
    }

    // 2. Drain pending broadcasts
    // 3. select! { commands, socket read }
    //    - Commands queue frames instead of writing directly
    //    - Socket reads are uninterrupted
}
```

Full peer mode (runtimed-py) is unaffected — its writes go through `sync_to_daemon()` which owns the read/write sequence.

## Test plan

- [x] `cargo test -p runtimed --lib` — 234 passed
- [x] `cargo test -p runtimed --test '*'` — 15 integration tests
- [x] `cargo test -p notebook --lib` — 126 passed
- [ ] Run All on notebook with matplotlib output — outputs appear
- [ ] Individual cell execution — still works
- [ ] Session restore — no connection errors