### PR TITLE
Handle async metadata reads via notebook sync task

### DIFF
--- a/crates/runtimed-py/src/async_session.rs
+++ b/crates/runtimed-py/src/async_session.rs
@@ -764,7 +764,7 @@ impl AsyncSession {
                 .as_ref()
                 .ok_or_else(|| to_py_err("Not connected"))?;
 
-            Ok(handle.get_metadata(&key))
+            handle.get_metadata(&key).await.map_err(to_py_err)
         })
     }
 

--- a/crates/runtimed-py/src/session.rs
+++ b/crates/runtimed-py/src/session.rs
@@ -644,7 +644,7 @@ impl Session {
                 .as_ref()
                 .ok_or_else(|| to_py_err("Not connected"))?;
 
-            Ok(handle.get_metadata(&key))
+            handle.get_metadata(&key).await.map_err(to_py_err)
         })
     }
 

--- a/crates/runtimed/src/notebook_sync_client.rs
+++ b/crates/runtimed/src/notebook_sync_client.rs
@@ -98,6 +98,11 @@ enum SyncCommand {
         value: String,
         reply: oneshot::Sender<Result<(), NotebookSyncError>>,
     },
+    /// Read a metadata value from the local Automerge doc replica.
+    GetMetadata {
+        key: String,
+        reply: oneshot::Sender<Option<String>>,
+    },
     /// Send a request to the daemon and wait for a response.
     SendRequest {
         request: NotebookRequest,
@@ -292,18 +297,26 @@ impl NotebookSyncHandle {
 
     /// Read a metadata value from the local Automerge doc replica.
     ///
-    /// Instant synchronous read from the latest snapshot. For the
-    /// `"notebook_metadata"` key this serializes the typed snapshot back to
-    /// JSON; other keys are not tracked and return `None`.
-    pub fn get_metadata(&self, key: &str) -> Option<String> {
+    /// `notebook_metadata` uses the watch snapshot fast path. Other metadata
+    /// keys fall back to the sync task so callers keep the pre-watch behavior.
+    pub async fn get_metadata(&self, key: &str) -> Result<Option<String>, NotebookSyncError> {
         if key == NOTEBOOK_METADATA_KEY {
             let snap = self.snapshot_rx.borrow();
-            snap.notebook_metadata
+            return Ok(snap
+                .notebook_metadata
                 .as_ref()
-                .and_then(|m| serde_json::to_string(m).ok())
-        } else {
-            None
+                .and_then(|m| serde_json::to_string(m).ok()));
         }
+
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.tx
+            .send(SyncCommand::GetMetadata {
+                key: key.to_string(),
+                reply: reply_tx,
+            })
+            .await
+            .map_err(|_| NotebookSyncError::ChannelClosed)?;
+        reply_rx.await.map_err(|_| NotebookSyncError::ChannelClosed)
     }
 
     /// Get the typed notebook metadata snapshot.
@@ -2155,6 +2168,9 @@ async fn run_sync_task<S>(
                             publish_snapshot(&client, &snapshot_tx);
                         }
                         let _ = reply.send(result);
+                    }
+                    SyncCommand::GetMetadata { key, reply } => {
+                        let _ = reply.send(client.get_metadata(&key));
                     }
                     SyncCommand::SendRequest {
                         request,

--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -18,6 +18,7 @@ Environment variables:
     RUNTIMED_LOG_LEVEL           - Daemon log level (default: info)
 """
 
+import asyncio
 import os
 import subprocess
 import sys
@@ -1032,6 +1033,14 @@ class TestKernelLaunchMetadata:
         assert parsed["kernelspec"]["name"] == "python3"
         assert parsed["runt"]["schema_version"] == "1"
 
+    def test_custom_metadata_round_trip(self, session):
+        """Non-notebook metadata keys remain readable after the watch refactor."""
+        session.set_metadata("custom_key", "custom_value")
+        time.sleep(0.3)
+
+        raw = session.get_metadata("custom_key")
+        assert raw == "custom_value"
+
     def test_python_kernel_with_python_kernelspec(self, session):
         """A notebook with python kernelspec launches a Python kernel."""
         import json
@@ -1608,6 +1617,15 @@ class TestAsyncDocumentFirstExecution:
         found_ids = {c.id for c in cells}
         for cid in cell_ids:
             assert cid in found_ids
+
+    @pytest.mark.asyncio
+    async def test_async_custom_metadata_round_trip(self, async_session):
+        """Async sessions can still read metadata keys outside notebook_metadata."""
+        await async_session.set_metadata("custom_key", "custom_value")
+        await asyncio.sleep(0.3)
+
+        raw = await async_session.get_metadata("custom_key")
+        assert raw == "custom_value"
 
     @pytest.mark.asyncio
     async def test_async_delete_cell(self, async_session):


### PR DESCRIPTION
Summary:
- make `NotebookSyncHandle::get_metadata` async so non-`notebook_metadata` keys use the sync task fallback and add a `GetMetadata` command
- wire the async path through the notebook sync client and Python session helpers so they await the new method
- add sync and async Python integration tests that round-trip a custom metadata key

Testing:
- Not run (not requested)