### PR TITLE
fix(sync): skip do_initial_sync in pipe mode

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -110,7 +110,7 @@ function AppContent() {
     openNotebook,
     cloneNotebook,
     dirty,
-    appendOutput,
+
     updateOutputByDisplayId,
     setExecutionCount,
     clearCellOutputs,
@@ -266,11 +266,9 @@ function AppContent() {
     runAllCells: daemonRunAllCells,
     sendCommMessage,
   } = useDaemonKernel({
-    // In pipe mode (#608), the Automerge sync path doesn't deliver output changes
-    // (daemon's sync state tracks the relay, not the WASM — all frames arrive with
-    // changed=false). Outputs must come from broadcasts until the sync state
-    // mismatch is fixed (see .context/plans/fix-pipe-mode-sync-state.md).
-    onOutput: appendOutput,
+    // Sync now delivers outputs correctly (#617 fix: skip do_initial_sync in pipe
+    // mode). The broadcast callback is disabled to prevent duplicates.
+    onOutput: () => {},
     onExecutionCount: handleExecutionCount,
     onExecutionDone: handleExecutionDone,
     onUpdateDisplayData: updateOutputByDisplayId,

--- a/crates/runtimed/src/notebook_sync_client.rs
+++ b/crates/runtimed/src/notebook_sync_client.rs
@@ -652,7 +652,8 @@ impl NotebookSyncClient<tokio::net::UnixStream> {
         .map_err(|_| NotebookSyncError::Timeout)?
         .map_err(NotebookSyncError::ConnectionFailed)?;
 
-        let (client, info) = Self::init_open_notebook(stream, path).await?;
+        let pipe_mode = raw_sync_tx.is_some();
+        let (client, info) = Self::init_open_notebook(stream, path, pipe_mode).await?;
         let (handle, receiver, broadcast_rx, cells, metadata) =
             client.into_split_with_raw_sync(raw_sync_tx);
         Ok((handle, receiver, broadcast_rx, cells, metadata, info))
@@ -687,8 +688,10 @@ impl NotebookSyncClient<tokio::net::UnixStream> {
         .map_err(|_| NotebookSyncError::Timeout)?
         .map_err(NotebookSyncError::ConnectionFailed)?;
 
+        let pipe_mode = raw_sync_tx.is_some();
         let (client, info) =
-            Self::init_create_notebook(stream, runtime, working_dir, notebook_id).await?;
+            Self::init_create_notebook(stream, runtime, working_dir, notebook_id, pipe_mode)
+                .await?;
         let (handle, receiver, broadcast_rx, cells, metadata) =
             client.into_split_with_raw_sync(raw_sync_tx);
         Ok((handle, receiver, broadcast_rx, cells, metadata, info))
@@ -802,7 +805,8 @@ impl NotebookSyncClient<tokio::net::windows::named_pipe::NamedPipeClient> {
             .open(&pipe_name)
             .map_err(NotebookSyncError::ConnectionFailed)?;
 
-        let (client, info) = Self::init_open_notebook(stream, path).await?;
+        let pipe_mode = raw_sync_tx.is_some();
+        let (client, info) = Self::init_open_notebook(stream, path, pipe_mode).await?;
         let (handle, receiver, broadcast_rx, cells, metadata) =
             client.into_split_with_raw_sync(raw_sync_tx);
         Ok((handle, receiver, broadcast_rx, cells, metadata, info))
@@ -831,8 +835,10 @@ impl NotebookSyncClient<tokio::net::windows::named_pipe::NamedPipeClient> {
             .open(&pipe_name)
             .map_err(NotebookSyncError::ConnectionFailed)?;
 
+        let pipe_mode = raw_sync_tx.is_some();
         let (client, info) =
-            Self::init_create_notebook(stream, runtime, working_dir, notebook_id).await?;
+            Self::init_create_notebook(stream, runtime, working_dir, notebook_id, pipe_mode)
+                .await?;
         let (handle, receiver, broadcast_rx, cells, metadata) =
             client.into_split_with_raw_sync(raw_sync_tx);
         Ok((handle, receiver, broadcast_rx, cells, metadata, info))
@@ -1008,6 +1014,7 @@ where
     async fn init_open_notebook(
         mut stream: S,
         path: PathBuf,
+        pipe_mode: bool,
     ) -> Result<(Self, NotebookConnectionInfo), NotebookSyncError> {
         let path_str = path.to_string_lossy().to_string();
         info!("[notebook-sync-client] Opening notebook: {}", path_str);
@@ -1044,8 +1051,26 @@ where
             notebook_id, info.cell_count, info.needs_trust_approval
         );
 
-        // Continue with Automerge sync (same as init)
-        let client = Self::do_initial_sync(stream, notebook_id).await?;
+        // In pipe mode the relay is a transparent byte pipe — the frontend WASM
+        // handles the full Automerge sync protocol with the daemon directly.
+        // Skipping do_initial_sync means the daemon's peer_state tracks the WASM
+        // peer (through the pipe) instead of the relay, fixing the sync state
+        // mismatch that caused changed=false on every frame (#617).
+        let client = if pipe_mode {
+            info!(
+                "[notebook-sync-client] Pipe mode: skipping initial sync for {}",
+                notebook_id
+            );
+            Self {
+                doc: AutoCommit::new(),
+                peer_state: sync::State::new(),
+                stream,
+                notebook_id,
+                pending_broadcasts: Vec::new(),
+            }
+        } else {
+            Self::do_initial_sync(stream, notebook_id).await?
+        };
         Ok((client, info))
     }
 
@@ -1057,6 +1082,7 @@ where
         runtime: String,
         working_dir: Option<PathBuf>,
         notebook_id: Option<String>,
+        pipe_mode: bool,
     ) -> Result<(Self, NotebookConnectionInfo), NotebookSyncError> {
         info!(
             "[notebook-sync-client] Creating new notebook (runtime: {}, working_dir: {:?}, notebook_id: {:?})",
@@ -1102,8 +1128,22 @@ where
             notebook_id, info.cell_count
         );
 
-        // Continue with Automerge sync (same as init)
-        let client = Self::do_initial_sync(stream, notebook_id).await?;
+        // See init_open_notebook for explanation of the pipe_mode skip.
+        let client = if pipe_mode {
+            info!(
+                "[notebook-sync-client] Pipe mode: skipping initial sync for {}",
+                notebook_id
+            );
+            Self {
+                doc: AutoCommit::new(),
+                peer_state: sync::State::new(),
+                stream,
+                notebook_id,
+                pending_broadcasts: Vec::new(),
+            }
+        } else {
+            Self::do_initial_sync(stream, notebook_id).await?
+        };
         Ok((client, info))
     }
 


### PR DESCRIPTION
Fixes #617.

After the pure relay change (#608), the daemon's Automerge sync state tracked the relay peer (established during `do_initial_sync`), but the actual consumer of sync frames was the frontend WASM. Every `automerge:from-daemon` frame arrived with `changed=false` because the WASM's sync state didn't match the relay's.

The fix: when `raw_sync_tx` is provided (pipe mode), skip `do_initial_sync` entirely. The daemon's first sync message flows through the pipe to the WASM, which handles the full sync protocol directly. The daemon's `peer_state` now tracks the WASM peer instead of the relay.

**What changes:**
- `init_open_notebook` and `init_create_notebook` accept a `pipe_mode` flag
- When `pipe_mode`, create a minimal `NotebookSyncClient` with empty doc/peer_state instead of running `do_initial_sync`
- Both Unix and Windows `connect_open_split`/`connect_create_split` pass `raw_sync_tx.is_some()` as `pipe_mode`

**What doesn't change:**
- Non-pipe mode (runtimed-py, full peer) still uses `do_initial_sync`
- `GetDocBytes` bootstrap still works — it goes to the daemon (`NotebookRequest::GetDocBytes`), not the relay's local doc
- No WASM or frontend changes needed

**Why this works:**
The daemon proactively sends its first sync message (Phase 1 in `run_sync_loop_v2`) from a fresh `peer_state`. With `do_initial_sync` skipped, that message flows through the pipe to the WASM. The WASM merges it and responds. After this exchange, the daemon's `peer_state` correctly reflects the WASM's state, so subsequent output changes arrive with `changed=true` and trigger `materializeCells`.