### PR TITLE
docs: update architecture docs for two-peer sync topology

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -200,15 +200,16 @@ runt daemon status
 
 ## Notebook Document Architecture (Local-First)
 
-The notebook uses a local-first CRDT architecture. The frontend owns its own Automerge document via WASM, making cell mutations instant. Three Automerge peers participate:
+The notebook uses a local-first CRDT architecture. The frontend owns its own Automerge document via WASM, making cell mutations instant. Two Automerge peers participate:
 
-- **Frontend (WASM)** — `NotebookHandle` from `crates/runtimed-wasm`, loaded in the webview. Cell mutations (add, delete, edit source) execute locally in WASM. React state is derived from the WASM doc via `handle.get_cells_json()`.
-- **Tauri relay** — `NotebookSyncClient` in `crates/runtimed/src/notebook_sync_client.rs`. Forwards binary Automerge sync messages between frontend and daemon. Maintains its own doc replica (transitional — will be simplified to pure relay).
+- **Frontend (WASM)** — `NotebookHandle` from `crates/runtimed-wasm`, loaded in the webview. Cell mutations (add, delete, edit source) execute locally in WASM. React state is derived from the WASM doc via `handle.get_cells_json()`. The WASM starts with an empty doc (`create_empty()`); the sync protocol delivers all state from the daemon.
 - **Daemon** — `NotebookDoc` in `crates/runtimed/src/notebook_doc.rs`. Canonical doc for kernel execution, output writing, and persistence.
 
-Mutation flow: React → WASM `handle.add_cell()` → `handle.generate_sync_message()` → `invoke("send_automerge_sync")` → Tauri relay → daemon.
+The **Tauri relay** (`NotebookSyncClient` in `crates/runtimed/src/notebook_sync_client.rs`) is a transparent byte pipe — it forwards raw Automerge sync frames between the WASM and the daemon without merging or maintaining its own doc replica. The daemon's `peer_state` tracks the WASM peer directly through the pipe. A non-pipe "full peer" mode exists for `runtimed-py` (Python bindings), where the relay does maintain a local doc replica — but this is not the Tauri path.
 
-Incoming sync: daemon → relay → `automerge:from-daemon` event → WASM `handle.receive_sync_message()` → `materializeCells()` → React state.
+Mutation flow: React → WASM `handle.add_cell()` → `handle.generate_sync_message()` → `invoke("send_automerge_sync")` → relay pipe → daemon.
+
+Incoming sync: daemon → relay pipe → `automerge:from-daemon` event → WASM `handle.receive_sync_message()` → `materializeCells()` → React state.
 
 The `runtimed-wasm` crate compiles from the same `automerge = "0.7"` as the daemon. This is critical — the JS `@automerge/automerge` package creates `Object(Text)` CRDTs for all string fields, but Rust uses scalar `Str` for metadata fields (`id`, `cell_type`, `execution_count`). Using the same Rust code in WASM guarantees schema compatibility.
 
@@ -293,7 +294,7 @@ Dependencies are signed with HMAC-SHA256 using a per-machine key at `~/.config/r
 | `crates/runtimed/src/notebook_sync_server.rs` | `auto_launch_kernel()` — runtime detection and environment resolution |
 | `crates/runtimed/src/kernel_manager.rs` | `RoomKernel::launch()` — spawns Python or Deno kernel processes |
 | `crates/runtimed/src/inline_env.rs` | Cached environment creation for inline deps (UV and Conda) |
-| `crates/notebook/src/lib.rs` | Tauri commands (save, format, kernel, env), Automerge sync relay. Cell mutation commands removed — mutations go through WASM. |
+| `crates/notebook/src/lib.rs` | Tauri commands (save, format, kernel, env), Automerge sync pipe (forwards raw frames between WASM and daemon). Cell mutation commands removed — mutations go through WASM. |
 | `crates/notebook/src/project_file.rs` | Unified closest-wins project file detection |
 | `crates/notebook/src/uv_env.rs` | UV environment creation and caching |
 | `crates/notebook/src/conda_env.rs` | Conda environment creation via rattler |
@@ -304,7 +305,7 @@ Dependencies are signed with HMAC-SHA256 using a per-machine key at `~/.config/r
 | `crates/notebook/src/trust.rs` | HMAC trust verification |
 | `crates/runtimed-wasm/src/lib.rs` | WASM bindings for NotebookDoc — cell mutations, sync messages |
 | `crates/runtimed-wasm/src/notebook_doc.rs` | Automerge document operations (copy of daemon's NotebookDoc, trimmed for WASM) |
-| `apps/notebook/src/hooks/useAutomergeNotebook.ts` | Local-first notebook hook — owns NotebookHandle WASM, drives React cell state |
+| `apps/notebook/src/hooks/useAutomergeNotebook.ts` | Local-first notebook hook — owns NotebookHandle WASM, drives React cell state, sync-only bootstrap (empty doc, no GetDocBytes) |
 | `apps/notebook/src/hooks/useDaemonKernel.ts` | Daemon-owned kernel execution, status broadcasts, environment sync |
 | `apps/notebook/src/hooks/useDependencies.ts` | Frontend UV dependency management |
 | `apps/notebook/src/hooks/useCondaDependencies.ts` | Frontend conda dependency management |

--- a/apps/notebook/src/lib/notebook-metadata.ts
+++ b/apps/notebook/src/lib/notebook-metadata.ts
@@ -238,8 +238,8 @@ function getMetadataSnapshot(): NotebookMetadataSnapshot | null {
 // ---------------------------------------------------------------------------
 
 /**
- * Write a metadata snapshot to the WASM doc and sync to the relay.
- * After this returns, both the WASM doc and the relay's doc have the update.
+ * Write a metadata snapshot to the WASM doc and sync to the daemon.
+ * After this returns, the WASM doc has the update and a sync message has been sent to the daemon.
  */
 export async function setMetadataSnapshot(
   snapshot: NotebookMetadataSnapshot,
@@ -258,8 +258,7 @@ export async function setMetadataSnapshot(
 }
 
 /**
- * Generate a sync message from the WASM doc and send it to the Tauri relay.
- * After the invoke returns, the relay's Automerge doc has the update.
+ * Generate a sync message from the WASM doc and send it to the daemon via the Tauri relay pipe.
  */
 async function syncToRelay(): Promise<void> {
   if (!_handle) return;

--- a/contributing/environments.md
+++ b/contributing/environments.md
@@ -130,7 +130,7 @@ graph TB
 
     %% Daemon broadcasts back to frontend
     NSS -.->|"daemon:broadcast {KernelLaunched, env_source}"| UDK
-    KM -.->|"daemon:broadcast {Output, KernelStatus}"| UDK
+    KM -.->|"daemon:broadcast {KernelStatus, ExecutionStarted, ExecutionDone}"| UDK
     VNT -.->|trust status| UD
 
     %% Environment creation → external tools
@@ -295,7 +295,7 @@ graph TB
 
 The diagrams show two main layers:
 
-1. **Frontend** (blue) — React hooks that invoke Tauri commands and listen for `daemon:broadcast` events. `useDaemonKernel.ts` handles kernel lifecycle via the daemon.
+1. **Frontend** (blue) — React hooks that invoke Tauri commands and listen for `daemon:broadcast` events (kernel status, execution lifecycle) and `automerge:from-daemon` events (outputs and document state via Automerge sync). `useDaemonKernel.ts` handles kernel lifecycle via the daemon. Outputs arrive exclusively through Automerge sync, not broadcasts.
 
 2. **runtimed Daemon** (indigo) — A singleton background process that owns kernel processes and manages prewarmed UV and Conda environment pools. The daemon runs the detection priority chain: inline deps first, then closest project file, then prewarmed pool. Communicates via length-prefixed JSON over Unix domain sockets (or Windows named pipes). Also runs an Automerge CRDT sync server for cross-window settings and notebook state.
 
@@ -520,7 +520,7 @@ The kernel lifecycle is managed by `useDaemonKernel.ts`, which:
 | `crates/notebook/src/pixi.rs` | pixi.toml discovery and parsing |
 | `crates/notebook/src/environment_yml.rs` | environment.yml discovery and parsing |
 | `crates/notebook/src/deno_env.rs` | Deno config detection |
-| `crates/notebook/src/notebook_state.rs` | Notebook metadata and new notebook creation |
+| `crates/notebook/src/lib.rs` | Tauri commands (save, format, kernel, env), sync pipe setup |
 | `crates/notebook/src/settings.rs` | User preferences (default runtime, env type) |
 | `crates/notebook/src/trust.rs` | HMAC trust verification |
 

--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -1,7 +1,7 @@
 //! Automerge-backed notebook document for cross-window sync.
 //!
 //! Also re-exports typed notebook metadata structs (`metadata` module) so all
-//! peers (daemon, Tauri relay, WASM frontend, Python bindings) share one
+//! peers (daemon, WASM frontend, Python bindings) share one
 //! definition of kernelspec, dependencies, and trust metadata.
 //!
 //! Wraps an Automerge `AutoCommit` document with typed accessors for

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -52,7 +52,7 @@ struct WindowNotebookContext {
     /// Updated on save_notebook_as when path changes.
     notebook_id: Arc<Mutex<String>>,
     /// Runtime type for this notebook (Python or Deno).
-    /// Used by session save so it doesn't need to read from NotebookState.
+    /// Used by session save so it doesn't need to query the daemon.
     runtime: Runtime,
 }
 

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -198,7 +198,7 @@ impl NotebookHandle {
             .map_err(|e| JsError::new(&format!("set_metadata failed: {}", e)))
     }
 
-    /// Generate a sync message to send to the relay peer.
+    /// Generate a sync message to send to the daemon (via the Tauri relay pipe).
     ///
     /// Returns the message as a byte array, or undefined if already in sync.
     /// The caller should send these bytes via `invoke("send_automerge_sync", { syncMessage })`.
@@ -208,7 +208,7 @@ impl NotebookHandle {
             .map(|msg| msg.encode())
     }
 
-    /// Receive and apply a sync message from the relay peer.
+    /// Receive and apply a sync message from the daemon (via the Tauri relay pipe).
     ///
     /// Returns true if the document changed (caller should re-read cells).
     pub fn receive_sync_message(&mut self, message: &[u8]) -> Result<bool, JsError> {
@@ -233,7 +233,7 @@ impl NotebookHandle {
         self.doc.save()
     }
 
-    /// Reset the sync state. Call this when reconnecting to a new relay session.
+    /// Reset the sync state. Call this when reconnecting to a new daemon session.
     pub fn reset_sync_state(&mut self) {
         self.sync_state = sync::State::new();
     }

--- a/docs/runtimed.md
+++ b/docs/runtimed.md
@@ -449,11 +449,11 @@ Outputs flow through the Automerge doc, not Tauri events:
 
 1. Kernel emits iopub message → daemon's `kernel_manager` receives it
 2. Daemon writes output to the notebook's Automerge doc (cell outputs array)
-3. Daemon produces a sync message → Tauri relay forwards it to the frontend
+3. Daemon produces a sync message → Tauri relay forwards raw bytes to the frontend (pipe mode — no Automerge processing in the relay)
 4. Frontend receives `automerge:from-daemon` → WASM merges into local doc
 5. `materialize-cells.ts` converts the updated doc into React cell state
 
-The legacy `onOutput` broadcast path is no-opped to avoid duplicate outputs (no dedup IDs yet). See #557 for the output streaming improvement plan.
+The legacy `onOutput` broadcast path is no-opped — outputs arrive exclusively via Automerge sync.
 
 ### Save and format-on-save
 
@@ -712,14 +712,16 @@ runtimed (daemon)
 | **Automerge Sync** | Document state (cells, source, outputs) | Yes |
 | **Broadcasts** | Real-time events | No |
 
-**Why both?** Automerge provides persistence and late-joiner sync. Broadcasts provide sub-50ms UI updates during execution.
+**Why both?** Automerge provides persistence and late-joiner sync. Broadcasts provide sub-50ms UI updates for kernel status during execution.
 
 Broadcast types:
 - `KernelStatus { status }` — idle/busy/starting
-- `Output { cell_id, output }` — stream/display_data/execute_result/error
+- `Output { cell_id, output }` — **no-opped**; outputs arrive exclusively via Automerge sync
 - `ExecutionStarted { cell_id, execution_count }` — clear outputs, show spinner
 - `ClearOutputs { cell_id }` — explicit clear request
 - `DisplayUpdate { cell_id, output }` — update_display_data (widget progress bars)
+
+> **Note:** `Output` broadcasts were originally intended for sub-50ms streaming, but are currently no-opped to avoid duplicates with Automerge-synced outputs (no dedup IDs). All output data arrives via the Automerge sync channel (`automerge:from-daemon` events). Issue #557 was resolved by making sync the sole output delivery channel.
 
 ### Project file auto-detection
 
@@ -785,7 +787,7 @@ Cross-cutting decisions that affect multiple phases. These are living answers �
 
 ### Acceptance criteria per phase
 
-**Phase 5**: Two windows open the same notebook, cell source edits propagate between them, and outputs from execution in window A appear in window B. Save from either window produces the same `.ipynb`. The existing `NotebookState` code path should remain as a fallback if the daemon isn't running — notebooks must still work standalone.
+**Phase 5**: Two windows open the same notebook, cell source edits propagate between them, and outputs from execution in window A appear in window B. Save from either window produces the same `.ipynb`. The daemon is required — all notebook operations go through the daemon connection.
 
 **Phase 6**: Outputs render from manifests + blob store. Images no longer bloat the CRDT. Re-opening a notebook with existing outputs renders them correctly from blobs, and new execution outputs use the manifest path.
 
@@ -823,13 +825,11 @@ For output manifests, the `output_type` field provides structural versioning. Ne
 
 ## Known Limitations
 
-### Output Flow and Deduplication
+### Output Flow
 
-Outputs arrive at the frontend exclusively through Automerge sync: the daemon writes outputs to the notebook doc, produces a sync message, and the Tauri relay forwards it to the frontend WASM where `materialize-cells.ts` renders them.
+Outputs arrive at the frontend exclusively through Automerge sync: the daemon writes outputs to the notebook doc, produces a sync message, and the Tauri relay forwards raw bytes to the frontend WASM where `materialize-cells.ts` renders them.
 
-The `onOutput` broadcast path is no-opped to avoid showing duplicate outputs — there are no dedup IDs to correlate broadcast outputs with Automerge-synced outputs. This means output latency is bounded by the Automerge sync round-trip rather than direct event delivery.
-
-See #557 for the output streaming improvement plan.
+The `onOutput` broadcast path is no-opped — sync is the sole output delivery channel. Output latency is bounded by the Automerge sync round-trip rather than direct event delivery. Issue #557 was resolved by making sync the sole output delivery channel.
 
 ### Multi-Window Widget Sync (#276)
 


### PR DESCRIPTION
Comprehensive documentation audit after the sync simplification work (#619, #622).

The relay is now a transparent byte pipe — two Automerge peers (WASM ↔ daemon) instead of three. These docs still described the old three-peer topology.

**Changes across 7 files:**

| File | What changed |
|------|-------------|
| `AGENTS.md` | Two peers instead of three, relay = byte pipe, sync-only bootstrap noted, key files table updated |
| `contributing/environments.md` | Removed ghost `notebook_state.rs` reference, Mermaid diagram updated (Output no longer broadcast), frontend description includes `automerge:from-daemon` |
| `docs/runtimed.md` | Removed `NotebookState` standalone fallback, Output broadcasts marked no-opped, pipe mode clarified in output flow, #557 resolution noted |
| `crates/runtimed-wasm/src/lib.rs` | "relay peer" → "daemon" in 3 doc comments |
| `apps/notebook/src/lib/notebook-metadata.ts` | "relay's doc" → "daemon" in 2 doc comments |
| `crates/notebook-doc/src/lib.rs` | Removed "Tauri relay" from peer list |
| `crates/notebook/src/lib.rs` | Removed stale `NotebookState` reference |