### PR TITLE
docs: address review feedback on architecture audit

### DIFF
--- a/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.d.ts
+++ b/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.d.ts
@@ -59,7 +59,7 @@ export class NotebookHandle {
      */
     detect_runtime(): string | undefined;
     /**
-     * Generate a sync message to send to the relay peer.
+     * Generate a sync message to send to the daemon (via the Tauri relay pipe).
      *
      * Returns the message as a byte array, or undefined if already in sync.
      * The caller should send these bytes via `invoke("send_automerge_sync", { syncMessage })`.
@@ -97,13 +97,13 @@ export class NotebookHandle {
      */
     constructor(notebook_id: string);
     /**
-     * Receive and apply a sync message from the relay peer.
+     * Receive and apply a sync message from the daemon (via the Tauri relay pipe).
      *
      * Returns true if the document changed (caller should re-read cells).
      */
     receive_sync_message(message: Uint8Array): boolean;
     /**
-     * Reset the sync state. Call this when reconnecting to a new relay session.
+     * Reset the sync state. Call this when reconnecting to a new daemon session.
      */
     reset_sync_state(): void;
     /**

--- a/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.js
+++ b/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.js
@@ -264,7 +264,7 @@ export class NotebookHandle {
         }
     }
     /**
-     * Generate a sync message to send to the relay peer.
+     * Generate a sync message to send to the daemon (via the Tauri relay pipe).
      *
      * Returns the message as a byte array, or undefined if already in sync.
      * The caller should send these bytes via `invoke("send_automerge_sync", { syncMessage })`.
@@ -415,7 +415,7 @@ export class NotebookHandle {
         return this;
     }
     /**
-     * Receive and apply a sync message from the relay peer.
+     * Receive and apply a sync message from the daemon (via the Tauri relay pipe).
      *
      * Returns true if the document changed (caller should re-read cells).
      * @param {Uint8Array} message
@@ -439,7 +439,7 @@ export class NotebookHandle {
         }
     }
     /**
-     * Reset the sync state. Call this when reconnecting to a new relay session.
+     * Reset the sync state. Call this when reconnecting to a new daemon session.
      */
     reset_sync_state() {
         wasm.notebookhandle_reset_sync_state(this.__wbg_ptr);

--- a/contributing/environments.md
+++ b/contributing/environments.md
@@ -295,7 +295,7 @@ graph TB
 
 The diagrams show two main layers:
 
-1. **Frontend** (blue) — React hooks that invoke Tauri commands and listen for `daemon:broadcast` events (kernel status, execution lifecycle) and `automerge:from-daemon` events (outputs and document state via Automerge sync). `useDaemonKernel.ts` handles kernel lifecycle via the daemon. Outputs arrive exclusively through Automerge sync, not broadcasts.
+1. **Frontend** (blue) — React hooks that invoke Tauri commands and listen for `daemon:broadcast` events (kernel status, execution lifecycle) and `automerge:from-daemon` events (document state including outputs via Automerge sync). `useDaemonKernel.ts` handles kernel lifecycle via the daemon. The daemon sends `Output` broadcasts and `useDaemonKernel.ts` processes them (blob resolution), but the `onOutput` rendering callback is a no-op — output **rendering** is driven by Automerge sync (`materializeCells`).
 
 2. **runtimed Daemon** (indigo) — A singleton background process that owns kernel processes and manages prewarmed UV and Conda environment pools. The daemon runs the detection priority chain: inline deps first, then closest project file, then prewarmed pool. Communicates via length-prefixed JSON over Unix domain sockets (or Windows named pipes). Also runs an Automerge CRDT sync server for cross-window settings and notebook state.
 

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -2041,7 +2041,7 @@ async fn get_automerge_doc_bytes(
     let guard = notebook_sync.lock().await;
     let handle = guard.as_ref().ok_or("Not connected to daemon")?;
 
-    // Fetch doc bytes from the daemon's canonical Automerge doc (not the relay's local replica).
+    // Fetch doc bytes from the daemon's canonical Automerge doc.
     match handle.send_request(NotebookRequest::GetDocBytes {}).await {
         Ok(NotebookResponse::DocBytes { bytes }) => Ok(bytes),
         Ok(NotebookResponse::Error { error }) => Err(error),

--- a/docs/runtimed.md
+++ b/docs/runtimed.md
@@ -453,7 +453,7 @@ Outputs flow through the Automerge doc, not Tauri events:
 4. Frontend receives `automerge:from-daemon` → WASM merges into local doc
 5. `materialize-cells.ts` converts the updated doc into React cell state
 
-The legacy `onOutput` broadcast path is no-opped — outputs arrive exclusively via Automerge sync.
+The `onOutput` callback in `App.tsx` is set to a no-op (`() => {}`) — outputs are rendered from Automerge sync, not broadcasts. The daemon still sends `Output` broadcasts and `useDaemonKernel.ts` still processes them (resolves blob manifests), but the resolved output is discarded by the no-op callback.
 
 ### Save and format-on-save
 
@@ -716,12 +716,12 @@ runtimed (daemon)
 
 Broadcast types:
 - `KernelStatus { status }` — idle/busy/starting
-- `Output { cell_id, output }` — **no-opped**; outputs arrive exclusively via Automerge sync
+- `Output { cell_id, output }` — daemon sends these and `useDaemonKernel.ts` processes them, but the `onOutput` rendering callback is a no-op; outputs are rendered from Automerge sync instead
 - `ExecutionStarted { cell_id, execution_count }` — clear outputs, show spinner
 - `ClearOutputs { cell_id }` — explicit clear request
 - `DisplayUpdate { cell_id, output }` — update_display_data (widget progress bars)
 
-> **Note:** `Output` broadcasts were originally intended for sub-50ms streaming, but are currently no-opped to avoid duplicates with Automerge-synced outputs (no dedup IDs). All output data arrives via the Automerge sync channel (`automerge:from-daemon` events). Issue #557 was resolved by making sync the sole output delivery channel.
+> **Note:** `Output` broadcasts are still sent by the daemon and processed by `useDaemonKernel.ts` (blob resolution runs), but the `onOutput` rendering callback in `App.tsx` is a no-op to avoid duplicates with Automerge-synced outputs (no dedup IDs). All output **rendering** is driven by the Automerge sync channel (`automerge:from-daemon` → `materializeCells`). Issue #557 was resolved by making sync the sole output rendering path.
 
 ### Project file auto-detection
 
@@ -827,9 +827,9 @@ For output manifests, the `output_type` field provides structural versioning. Ne
 
 ### Output Flow
 
-Outputs arrive at the frontend exclusively through Automerge sync: the daemon writes outputs to the notebook doc, produces a sync message, and the Tauri relay forwards raw bytes to the frontend WASM where `materialize-cells.ts` renders them.
+Output **rendering** is driven exclusively by Automerge sync: the daemon writes outputs to the notebook doc, produces a sync message, and the Tauri relay forwards raw bytes to the frontend WASM where `materialize-cells.ts` renders them. The daemon still sends `Output` broadcasts (and `useDaemonKernel.ts` processes them), but the `onOutput` rendering callback is a no-op.
 
-The `onOutput` broadcast path is no-opped — sync is the sole output delivery channel. Output latency is bounded by the Automerge sync round-trip rather than direct event delivery. Issue #557 was resolved by making sync the sole output delivery channel.
+Output latency is bounded by the Automerge sync round-trip rather than direct broadcast delivery. Re-enabling `onOutput` for lower-latency streaming would require dedup IDs to prevent duplicates with sync-delivered outputs. Issue #557 was resolved by making sync the sole output rendering path.
 
 ### Multi-Window Widget Sync (#276)
 


### PR DESCRIPTION
Follow-up to #625. Addresses three issues from review:

1. **Output broadcast wording** — The daemon still sends `Output` broadcasts and `useDaemonKernel.ts` processes them (blob resolution runs). What's no-opped is the `onOutput` *rendering callback* in `App.tsx`, not the broadcast itself. Fixed in `docs/runtimed.md` and `contributing/environments.md`.

2. **WASM .d.ts regeneration** — Rust doc comments were updated from "relay peer" to "daemon" in #625 but the generated TypeScript definitions weren't regenerated. Now consistent.

3. **Stale comment** — Removed "not the relay's local replica" parenthetical in `lib.rs:2044` (in pipe mode the relay has no local replica).