### PR TITLE
perf(sync): skip Output broadcast blob resolution when onOutput is omitted

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -266,9 +266,6 @@ function AppContent() {
     runAllCells: daemonRunAllCells,
     sendCommMessage,
   } = useDaemonKernel({
-    // Sync now delivers outputs correctly (#617 fix: skip do_initial_sync in pipe
-    // mode). The broadcast callback is disabled to prevent duplicates.
-    onOutput: () => {},
     onExecutionCount: handleExecutionCount,
     onExecutionDone: handleExecutionDone,
     onUpdateDisplayData: updateOutputByDisplayId,

--- a/apps/notebook/src/hooks/useDaemonKernel.ts
+++ b/apps/notebook/src/hooks/useDaemonKernel.ts
@@ -36,8 +36,11 @@ export interface DaemonQueueState {
 }
 
 interface UseDaemonKernelOptions {
-  /** Called when an output is produced for a cell */
-  onOutput: (cellId: string, output: JupyterOutput) => void;
+  /** Called when an output is produced for a cell.
+   * Optional — when omitted, Output broadcast processing (including blob
+   * resolution) is skipped entirely. Sync delivers outputs via materializeCells.
+   * Provide a callback for OutputWidget capture or low-latency streaming. */
+  onOutput?: (cellId: string, output: JupyterOutput) => void;
   /** Called when execution count is set for a cell */
   onExecutionCount: (cellId: string, count: number) => void;
   /** Called when execution completes for a cell */
@@ -214,6 +217,11 @@ export function useDaemonKernel({
           }
 
           case "output": {
+            // Skip blob resolution entirely when no onOutput callback is
+            // registered. Sync delivers outputs via materializeCells; the
+            // broadcast path is only needed for OutputWidget capture.
+            if (!callbacksRef.current.onOutput) break;
+
             // Resolve output (may be blob hash or raw JSON)
             const cellId = broadcast.cell_id;
             const outputJson = broadcast.output_json;
@@ -238,7 +246,7 @@ export function useDaemonKernel({
               const output = await resolveOutputString(outputJson, port);
               if (cancelled) return;
               if (output) {
-                callbacksRef.current.onOutput(cellId, output);
+                callbacksRef.current.onOutput?.(cellId, output);
               } else if (!retried) {
                 // Resolution failed - port may be stale, refresh and retry once
                 logger.debug(


### PR DESCRIPTION
Outputs are rendered via Automerge sync (`materializeCells`). The daemon still sends `Output` broadcasts and `useDaemonKernel.ts` was processing them — resolving blob manifests via HTTP, then calling `onOutput()` which was a no-op (`() => {}`). Every output was fetched from the blob server twice: once for the discarded broadcast, once for the sync-driven render.

Fix: make `onOutput` optional. When omitted, the `case "output"` handler early-returns before blob resolution. Zero wasted HTTP fetches.

The broadcast pipeline stays active for callers that provide `onOutput` (OutputWidget capture needs it — the Output widget receives cell outputs via this path for real-time widget rendering).

```diff
 // App.tsx — no longer passes a no-op
 } = useDaemonKernel({
-    onOutput: () => {},
     onExecutionCount: handleExecutionCount,
```

```diff
 // useDaemonKernel.ts — early return when no callback
 case "output": {
+    if (!callbacksRef.current.onOutput) break;
     // Resolve output (may be blob hash or raw JSON)
```