### PR TITLE
feat(notebook): keep previous cell output bright when focused

### DIFF
--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -94,6 +94,8 @@ interface CodeCellProps {
   onInsertCellAfter?: () => void;
   onClearPagePayload?: () => void;
   isLastCell?: boolean;
+  /** Whether this cell is immediately before the focused cell */
+  isPreviousCellFromFocused?: boolean;
 }
 
 export function CodeCell({
@@ -115,6 +117,7 @@ export function CodeCell({
   onInsertCellAfter,
   onClearPagePayload,
   isLastCell = false,
+  isPreviousCellFromFocused,
 }: CodeCellProps) {
   const editorRef = useRef<CodeMirrorEditorRef>(null);
   const { registerEditor, unregisterEditor } = useEditorRegistry();
@@ -246,6 +249,7 @@ export function CodeCell({
         id={cell.id}
         cellType="code"
         isFocused={isFocused}
+        isPreviousCellFromFocused={isPreviousCellFromFocused}
         onFocus={onFocus}
         gutterContent={gutterContent}
         rightGutterContent={rightGutterContent}

--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -26,6 +26,8 @@ interface MarkdownCellProps {
   onFocusNext?: (cursorPosition: "start" | "end") => void;
   onInsertCellAfter?: () => void;
   isLastCell?: boolean;
+  /** Whether this cell is immediately before the focused cell */
+  isPreviousCellFromFocused?: boolean;
 }
 
 export function MarkdownCell({
@@ -39,6 +41,7 @@ export function MarkdownCell({
   onFocusNext,
   onInsertCellAfter,
   isLastCell = false,
+  isPreviousCellFromFocused,
 }: MarkdownCellProps) {
   const applyInlineFormatting = useCallback(
     (prefix: string, suffix = prefix) =>
@@ -320,6 +323,7 @@ export function MarkdownCell({
       id={cell.id}
       cellType="markdown"
       isFocused={isFocused}
+      isPreviousCellFromFocused={isPreviousCellFromFocused}
       onFocus={onFocus}
     >
       {/* Editor section - hidden when not editing */}

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -148,6 +148,13 @@ function NotebookViewContent({
   // Memoize cell IDs array
   const cellIds = useMemo(() => cells.map((c) => c.id), [cells]);
 
+  // Compute the cell ID that precedes the focused cell (keeps its output bright)
+  const previousCellId = useMemo(() => {
+    if (!focusedCellId) return null;
+    const focusedIndex = cells.findIndex((c) => c.id === focusedCellId);
+    return focusedIndex > 0 ? cells[focusedIndex - 1].id : null;
+  }, [focusedCellId, cells]);
+
   // Prevent horizontal scroll drift (can happen during text selection)
   useEffect(() => {
     const container = containerRef.current;
@@ -214,6 +221,7 @@ function NotebookViewContent({
             cell={cell}
             language={language}
             isFocused={isFocused}
+            isPreviousCellFromFocused={cell.id === previousCellId}
             isExecuting={isExecuting}
             pagePayload={pagePayload}
             searchQuery={searchQuery}
@@ -243,6 +251,7 @@ function NotebookViewContent({
             key={cell.id}
             cell={cell}
             isFocused={isFocused}
+            isPreviousCellFromFocused={cell.id === previousCellId}
             searchQuery={searchQuery}
             onFocus={() => onFocusCell(cell.id)}
             onUpdateSource={(source) => onUpdateCellSource(cell.id, source)}
@@ -266,6 +275,7 @@ function NotebookViewContent({
     },
     [
       focusedCellId,
+      previousCellId,
       executingCellIds,
       pagePayloads,
       runtime,

--- a/src/components/cell/CellContainer.tsx
+++ b/src/components/cell/CellContainer.tsx
@@ -21,6 +21,8 @@ interface CellContainerProps {
   rightGutterContent?: ReactNode;
   /** Custom color configuration for cell types not in defaults */
   customGutterColors?: Record<string, GutterColorConfig>;
+  /** Whether this cell is immediately before the focused cell (keeps output bright) */
+  isPreviousCellFromFocused?: boolean;
   onDragStart?: (e: React.DragEvent) => void;
   onDragOver?: (e: React.DragEvent) => void;
   onDrop?: (e: React.DragEvent) => void;
@@ -41,6 +43,7 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
       gutterContent,
       rightGutterContent,
       customGutterColors,
+      isPreviousCellFromFocused = false,
       onDragStart,
       onDragOver,
       onDrop,
@@ -108,7 +111,7 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
                 <div
                   className={cn(
                     "min-w-0 flex-1 py-2 pl-6 pr-3 transition-opacity duration-150",
-                    !isFocused && "opacity-70",
+                    !isFocused && !isPreviousCellFromFocused && "opacity-70",
                   )}
                 >
                   {outputContent}


### PR DESCRIPTION
When a cell is focused, other cell outputs are dimmed to 70% opacity to reduce visual noise. However, this makes it harder to reference the previous cell's output when writing follow-up code—the most common workflow.

This change exempts the immediately preceding cell from dimming. The previous cell's output now stays at 100% opacity while other unfocused cells remain dimmed, improving readability and workflow efficiency.

## Verification

* [x] Focus different cells and observe that the previous cell's output is not dimmed
* [x] Click through multiple cells with outputs and verify smooth 150ms opacity transitions
* [x] Confirm other unfocused cell outputs (not the previous one) remain at 70% opacity

_PR submitted by @rgbkrk's agent, Quill_