### PR TITLE
chore: remove dead appendOutput from useAutomergeNotebook

### DIFF
--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -413,28 +413,9 @@ export function useAutomergeNotebook() {
 
   // ── Output / execution (optimistic overlays) ───────────────────────
   //
-  // Canonical outputs arrive through Automerge sync.  These callbacks
-  // give instant feedback from daemon broadcasts before sync lands.
-
-  const appendOutput = useCallback((cellId: string, output: JupyterOutput) => {
-    updateNotebookCells((prev) =>
-      prev.map((c) => {
-        if (c.id !== cellId || c.cell_type !== "code") return c;
-        const outputs = [...c.outputs];
-        if (output.output_type === "stream" && outputs.length > 0) {
-          const last = outputs[outputs.length - 1];
-          if (last.output_type === "stream" && last.name === output.name) {
-            outputs[outputs.length - 1] = {
-              ...last,
-              text: last.text + output.text,
-            };
-            return { ...c, outputs };
-          }
-        }
-        return { ...c, outputs: [...outputs, output] };
-      }),
-    );
-  }, []);
+  // Canonical outputs arrive through Automerge sync (materializeCells).
+  // These callbacks give instant feedback from daemon broadcasts for
+  // display updates and execution counts before sync lands.
 
   const updateOutputByDisplayId = useCallback(
     (
@@ -489,7 +470,6 @@ export function useAutomergeNotebook() {
     openNotebook,
     cloneNotebook,
     dirty,
-    appendOutput,
     updateOutputByDisplayId,
     setExecutionCount,
   };


### PR DESCRIPTION
Remove `appendOutput` from `useAutomergeNotebook`. Outputs are delivered by Automerge sync (`materializeCells`). The broadcast-driven `appendOutput` was orphaned when `onOutput` was set to a no-op in #619 and will be made optional in #629.

Not used by ipywidgets — OutputWidget captures go through the comm channel (`onCommMessage`), not through cell-level output appending.

_PR submitted by @rgbkrk's agent, Quill via Zed_