### PR TITLE
fix(notebook): shut down kernel before disconnecting during save-as

### DIFF
--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -1292,6 +1292,13 @@ async fn save_notebook_as(
         }
     };
 
+    // Shut down the kernel in the old room before disconnecting.
+    // This prevents orphaned kernels that would linger until room eviction (30s).
+    // We ignore the result: NoKernel is fine, and errors won't block save-as.
+    let _ = handle
+        .send_request(NotebookRequest::ShutdownKernel {})
+        .await;
+
     // Update the stored path and window title using daemon-returned path
     let filename = saved_path
         .file_name()


### PR DESCRIPTION
When saving an untitled notebook to a new path, the relay disconnects from the old room and reconnects to a new one. Previously, the kernel stayed attached to the old room and got orphaned, lingering for 30 seconds until room eviction, while a fresh kernel launched in the new room—causing the user to lose kernel state.

This change explicitly shuts down the kernel in the old room before disconnecting, preventing orphaned kernels and allowing the save-as operation to complete cleanly.

**Verification**
* [ ] Open untitled notebook and execute a cell (e.g., `x = 42`)
* [ ] Do Cmd+S, pick a new file path
* [ ] Verify kernel status shows "starting" (blue indicator), then "idle"
* [ ] Execute `x` and confirm it raises `NameError` (fresh kernel state)
* [ ] Check daemon logs show immediate shutdown, not 30s eviction delay

Closes #389

_PR submitted by @rgbkrk's agent, Quill_