### PR TITLE
feat(updater): install daemon before app restart to prevent version mismatch

### DIFF
--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -499,6 +499,15 @@ export function NotebookToolbar({
               <span>Restart to update</span>
             </button>
           )}
+          {updateStatus === "installing-daemon" && (
+            <div
+              className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium bg-green-500/15 text-green-500 dark:text-green-400"
+              title="Preparing runtime for update…"
+            >
+              <RotateCcw className="h-3 w-3 animate-spin" />
+              <span>Preparing…</span>
+            </div>
+          )}
 
           {/* Runtime / deps toggle */}
           <button

--- a/apps/notebook/src/hooks/useUpdater.ts
+++ b/apps/notebook/src/hooks/useUpdater.ts
@@ -1,3 +1,4 @@
+import { invoke } from "@tauri-apps/api/core";
 import { relaunch } from "@tauri-apps/plugin-process";
 import { check, type Update } from "@tauri-apps/plugin-updater";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -9,6 +10,7 @@ export type UpdateStatus =
   | "available"
   | "downloading"
   | "ready"
+  | "installing-daemon"
   | "error";
 
 interface UpdaterState {
@@ -71,6 +73,18 @@ export function useUpdater() {
 
   const restartToUpdate = useCallback(async () => {
     try {
+      // Install the new daemon BEFORE relaunch to prevent version mismatch.
+      // This ensures the new app launches with a compatible daemon already running,
+      // avoiding the "restart twice" problem.
+      setState((prev) => ({ ...prev, status: "installing-daemon" }));
+      try {
+        await invoke("install_daemon_for_update");
+        logger.info("[updater] daemon installed, proceeding with relaunch");
+      } catch (e) {
+        // Log but don't block - worst case, app will upgrade daemon on next launch
+        logger.warn("[updater] pre-restart daemon install failed:", e);
+      }
+
       await relaunch();
     } catch (e) {
       logger.error("[updater] relaunch failed:", e);

--- a/apps/notebook/src/hooks/useUpdater.ts
+++ b/apps/notebook/src/hooks/useUpdater.ts
@@ -88,6 +88,8 @@ export function useUpdater() {
       await relaunch();
     } catch (e) {
       logger.error("[updater] relaunch failed:", e);
+      // Revert to ready state so user can retry
+      setState((prev) => ({ ...prev, status: "ready" }));
     }
   }, []);
 

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -863,6 +863,26 @@ where
     Err(error)
 }
 
+/// Install/upgrade the daemon in preparation for app restart after update.
+///
+/// Called by the frontend before `relaunch()` to ensure the new app version
+/// launches with a compatible daemon. This prevents the "restart twice" problem
+/// where the new frontend connects to an old daemon with incompatible protocol.
+#[tauri::command]
+async fn install_daemon_for_update(app: tauri::AppHandle) -> Result<(), String> {
+    log::info!("[updater] Installing daemon before app restart...");
+
+    // Force upgrade regardless of version match - we're about to restart
+    // with a new app version that expects the new daemon
+    upgrade_daemon_via_sidecar(&app, |progress| {
+        log::info!("[updater] Daemon install progress: {:?}", progress);
+    })
+    .await?;
+
+    log::info!("[updater] Daemon installed successfully, ready for app restart");
+    Ok(())
+}
+
 /// Ensure the daemon is running using Tauri's sidecar API.
 ///
 /// This replaces the old `ensure_daemon_running` flow that used ServiceManager directly.
@@ -3072,6 +3092,8 @@ pub fn run(
             reconnect_to_daemon,
             get_automerge_doc_bytes,
             send_automerge_sync,
+            // App update support
+            install_daemon_for_update,
 
             // Kernelspec discovery (used by UI)
             list_kernelspecs,

--- a/crates/runtimed/src/connection.rs
+++ b/crates/runtimed/src/connection.rs
@@ -95,8 +95,12 @@ pub enum Handshake {
     },
 }
 
-/// Protocol version constant.
+/// Protocol version constant (string for backwards compatibility).
 pub const PROTOCOL_V2: &str = "v2";
+
+/// Numeric protocol version for version negotiation.
+/// Increment this when making breaking protocol changes.
+pub const PROTOCOL_VERSION: u32 = 2;
 
 /// Server response indicating protocol capabilities.
 ///
@@ -104,8 +108,16 @@ pub const PROTOCOL_V2: &str = "v2";
 /// Used by the `NotebookSync` handshake variant.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProtocolCapabilities {
-    /// Protocol version (currently always "v2").
+    /// Protocol version string (currently always "v2").
     pub protocol: String,
+    /// Numeric protocol version for explicit version checking.
+    /// Clients can compare this against their expected version.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub protocol_version: Option<u32>,
+    /// Daemon version string (e.g., "0.1.0-dev.10+abc123").
+    /// Useful for debugging version mismatches.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub daemon_version: Option<String>,
 }
 
 /// Server response for `OpenNotebook` and `CreateNotebook` handshakes.
@@ -114,8 +126,14 @@ pub struct ProtocolCapabilities {
 /// Contains notebook_id derived by the daemon (from path or generated env_id).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NotebookConnectionInfo {
-    /// Protocol version (currently always "v2").
+    /// Protocol version string (currently always "v2").
     pub protocol: String,
+    /// Numeric protocol version for explicit version checking.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub protocol_version: Option<u32>,
+    /// Daemon version string (e.g., "0.1.0-dev.10+abc123").
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub daemon_version: Option<String>,
     /// Notebook identifier derived by the daemon.
     /// For existing files: canonical path.
     /// For new notebooks: generated UUID (env_id).
@@ -476,9 +494,11 @@ mod tests {
 
     #[test]
     fn test_notebook_connection_info_serialization() {
-        // Success case
+        // Success case (minimal - no optional fields)
         let info = NotebookConnectionInfo {
             protocol: "v2".into(),
+            protocol_version: None,
+            daemon_version: None,
             notebook_id: "/home/user/notebook.ipynb".into(),
             cell_count: 5,
             needs_trust_approval: false,
@@ -490,9 +510,25 @@ mod tests {
             r#"{"protocol":"v2","notebook_id":"/home/user/notebook.ipynb","cell_count":5,"needs_trust_approval":false}"#
         );
 
+        // With version info
+        let info = NotebookConnectionInfo {
+            protocol: "v2".into(),
+            protocol_version: Some(2),
+            daemon_version: Some("0.1.0+abc123".into()),
+            notebook_id: "/home/user/notebook.ipynb".into(),
+            cell_count: 5,
+            needs_trust_approval: false,
+            error: None,
+        };
+        let json = serde_json::to_string(&info).unwrap();
+        assert!(json.contains(r#""protocol_version":2"#));
+        assert!(json.contains(r#""daemon_version":"0.1.0+abc123""#));
+
         // With trust approval needed
         let info = NotebookConnectionInfo {
             protocol: "v2".into(),
+            protocol_version: None,
+            daemon_version: None,
             notebook_id: "550e8400-e29b-41d4-a716-446655440000".into(),
             cell_count: 1,
             needs_trust_approval: true,
@@ -504,6 +540,8 @@ mod tests {
         // Error case
         let info = NotebookConnectionInfo {
             protocol: "v2".into(),
+            protocol_version: None,
+            daemon_version: None,
             notebook_id: String::new(),
             cell_count: 0,
             needs_trust_approval: false,

--- a/crates/runtimed/src/connection.rs
+++ b/crates/runtimed/src/connection.rs
@@ -512,8 +512,8 @@ mod tests {
 
         // With version info
         let info = NotebookConnectionInfo {
-            protocol: "v2".into(),
-            protocol_version: Some(2),
+            protocol: PROTOCOL_V2.into(),
+            protocol_version: Some(PROTOCOL_VERSION),
             daemon_version: Some("0.1.0+abc123".into()),
             notebook_id: "/home/user/notebook.ipynb".into(),
             cell_count: 5,
@@ -521,7 +521,7 @@ mod tests {
             error: None,
         };
         let json = serde_json::to_string(&info).unwrap();
-        assert!(json.contains(r#""protocol_version":2"#));
+        assert!(json.contains(&format!(r#""protocol_version":{}"#, PROTOCOL_VERSION)));
         assert!(json.contains(r#""daemon_version":"0.1.0+abc123""#));
 
         // With trust approval needed

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -999,7 +999,7 @@ impl Daemon {
                         let response = NotebookConnectionInfo {
                             protocol: PROTOCOL_V2.to_string(),
                             protocol_version: Some(PROTOCOL_VERSION),
-                            daemon_version: Some(crate::daemon_version()),
+                            daemon_version: Some(crate::daemon_version().to_string()),
                             notebook_id: String::new(),
                             cell_count: 0,
                             needs_trust_approval: false,
@@ -1033,7 +1033,7 @@ impl Daemon {
         let response = NotebookConnectionInfo {
             protocol: PROTOCOL_V2.to_string(),
             protocol_version: Some(PROTOCOL_VERSION),
-            daemon_version: Some(crate::daemon_version()),
+            daemon_version: Some(crate::daemon_version().to_string()),
             notebook_id: notebook_id.clone(),
             cell_count,
             needs_trust_approval,
@@ -1149,7 +1149,7 @@ impl Daemon {
                         let response = NotebookConnectionInfo {
                             protocol: PROTOCOL_V2.to_string(),
                             protocol_version: Some(PROTOCOL_VERSION),
-                            daemon_version: Some(crate::daemon_version()),
+                            daemon_version: Some(crate::daemon_version().to_string()),
                             notebook_id: String::new(),
                             cell_count: 0,
                             needs_trust_approval: false,
@@ -1169,7 +1169,7 @@ impl Daemon {
         let response = NotebookConnectionInfo {
             protocol: PROTOCOL_V2.to_string(),
             protocol_version: Some(PROTOCOL_VERSION),
-            daemon_version: Some(crate::daemon_version()),
+            daemon_version: Some(crate::daemon_version().to_string()),
             notebook_id: notebook_id.clone(),
             cell_count,
             needs_trust_approval: false,

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -944,7 +944,9 @@ impl Daemon {
     where
         S: AsyncRead + AsyncWrite + Unpin,
     {
-        use crate::connection::{send_json_frame, NotebookConnectionInfo, PROTOCOL_V2};
+        use crate::connection::{
+            send_json_frame, NotebookConnectionInfo, PROTOCOL_V2, PROTOCOL_VERSION,
+        };
 
         info!("[runtimed] OpenNotebook requested for {}", path);
 
@@ -996,6 +998,8 @@ impl Daemon {
                         let (mut reader, mut writer) = tokio::io::split(stream);
                         let response = NotebookConnectionInfo {
                             protocol: PROTOCOL_V2.to_string(),
+                            protocol_version: Some(PROTOCOL_VERSION),
+                            daemon_version: Some(crate::daemon_version()),
                             notebook_id: String::new(),
                             cell_count: 0,
                             needs_trust_approval: false,
@@ -1028,6 +1032,8 @@ impl Daemon {
         let (reader, mut writer) = tokio::io::split(stream);
         let response = NotebookConnectionInfo {
             protocol: PROTOCOL_V2.to_string(),
+            protocol_version: Some(PROTOCOL_VERSION),
+            daemon_version: Some(crate::daemon_version()),
             notebook_id: notebook_id.clone(),
             cell_count,
             needs_trust_approval,
@@ -1077,7 +1083,9 @@ impl Daemon {
     where
         S: AsyncRead + AsyncWrite + Unpin,
     {
-        use crate::connection::{send_json_frame, NotebookConnectionInfo, PROTOCOL_V2};
+        use crate::connection::{
+            send_json_frame, NotebookConnectionInfo, PROTOCOL_V2, PROTOCOL_VERSION,
+        };
 
         info!(
             "[runtimed] CreateNotebook requested (runtime={}, working_dir={:?}, notebook_id_hint={:?})",
@@ -1140,6 +1148,8 @@ impl Daemon {
                         let (mut reader, mut writer) = tokio::io::split(stream);
                         let response = NotebookConnectionInfo {
                             protocol: PROTOCOL_V2.to_string(),
+                            protocol_version: Some(PROTOCOL_VERSION),
+                            daemon_version: Some(crate::daemon_version()),
                             notebook_id: String::new(),
                             cell_count: 0,
                             needs_trust_approval: false,
@@ -1158,6 +1168,8 @@ impl Daemon {
         let (reader, mut writer) = tokio::io::split(stream);
         let response = NotebookConnectionInfo {
             protocol: PROTOCOL_V2.to_string(),
+            protocol_version: Some(PROTOCOL_VERSION),
+            daemon_version: Some(crate::daemon_version()),
             notebook_id: notebook_id.clone(),
             cell_count,
             needs_trust_approval: false,

--- a/crates/runtimed/src/lib.rs
+++ b/crates/runtimed/src/lib.rs
@@ -53,8 +53,10 @@ pub fn default_log_path() -> PathBuf {
 
 /// Get the daemon version string (e.g., "0.1.0-dev.10+abc123").
 /// Used for protocol version checking and debugging.
-pub fn daemon_version() -> String {
-    format!("{}+{}", env!("CARGO_PKG_VERSION"), env!("GIT_COMMIT"))
+/// Cached to avoid repeated allocations on hot paths.
+pub fn daemon_version() -> &'static str {
+    static VERSION: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+    VERSION.get_or_init(|| format!("{}+{}", env!("CARGO_PKG_VERSION"), env!("GIT_COMMIT")))
 }
 
 // ============================================================================

--- a/crates/runtimed/src/lib.rs
+++ b/crates/runtimed/src/lib.rs
@@ -51,6 +51,12 @@ pub fn default_log_path() -> PathBuf {
     daemon_base_dir().join("runtimed.log")
 }
 
+/// Get the daemon version string (e.g., "0.1.0-dev.10+abc123").
+/// Used for protocol version checking and debugging.
+pub fn daemon_version() -> String {
+    format!("{}+{}", env!("CARGO_PKG_VERSION"), env!("GIT_COMMIT"))
+}
+
 // ============================================================================
 // Types
 // ============================================================================

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -793,7 +793,7 @@ where
         let caps = connection::ProtocolCapabilities {
             protocol: connection::PROTOCOL_V2.to_string(),
             protocol_version: Some(connection::PROTOCOL_VERSION),
-            daemon_version: Some(crate::daemon_version()),
+            daemon_version: Some(crate::daemon_version().to_string()),
         };
         connection::send_json_frame(&mut writer, &caps).await?;
     }

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -792,6 +792,8 @@ where
     if !skip_capabilities {
         let caps = connection::ProtocolCapabilities {
             protocol: connection::PROTOCOL_V2.to_string(),
+            protocol_version: Some(connection::PROTOCOL_VERSION),
+            daemon_version: Some(crate::daemon_version()),
         };
         connection::send_json_frame(&mut writer, &caps).await?;
     }


### PR DESCRIPTION
## Summary

Fixes the "restart twice" problem during app updates.

**Before**: User clicks "Restart to update" → new app launches → old daemon still running → new frontend gets corrupted state from protocol mismatch → user must restart again

**After**: User clicks "Restart to update" → old app installs new daemon first → then relaunches → new app starts with compatible daemon → clean state

### Changes

**Pre-Restart Daemon Installation**
- Add `install_daemon_for_update` Tauri command that forces daemon upgrade before app restart
- Call this command from `restartToUpdate()` before `relaunch()`
- Add "installing-daemon" status with "Preparing…" spinner in toolbar
- Graceful fallback: if daemon install fails, still proceed with relaunch
- If relaunch fails, revert to "ready" status so user can retry

**Protocol Version Safety Net**
- Add `PROTOCOL_VERSION` constant (u32 = 2) for numeric version comparison
- Add `protocol_version` and `daemon_version` fields to `ProtocolCapabilities` and `NotebookConnectionInfo`
- Add `daemon_version()` helper (cached with `OnceLock` to avoid allocations)
- Fields are optional (backwards compatible) but allow explicit mismatch detection

## Test plan

- [ ] Manual test: trigger an update, click "Restart to update", verify "Preparing…" shows briefly
- [ ] Verify new app launches with new daemon running (`runt daemon status`)
- [ ] Test fallback: verify update still works if daemon install fails
- [ ] Verify `protocol_version` and `daemon_version` appear in daemon handshake responses