### PR TITLE
chore(updater): fast-follow improvements from #635 review

### DIFF
--- a/apps/notebook/src/hooks/useUpdater.ts
+++ b/apps/notebook/src/hooks/useUpdater.ts
@@ -20,6 +20,17 @@ interface UpdaterState {
 }
 
 const CHECK_INTERVAL_MS = 30 * 60 * 1000; // 30 minutes
+const DAEMON_INSTALL_TIMEOUT_MS = 30 * 1000; // 30 seconds
+
+/** Run a promise with a timeout. Rejects with "timeout" if exceeded. */
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  return Promise.race([
+    promise,
+    new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error("timeout")), ms),
+    ),
+  ]);
+}
 
 export function useUpdater() {
   const [state, setState] = useState<UpdaterState>({
@@ -78,7 +89,10 @@ export function useUpdater() {
       // avoiding the "restart twice" problem.
       setState((prev) => ({ ...prev, status: "installing-daemon" }));
       try {
-        await invoke("install_daemon_for_update");
+        await withTimeout(
+          invoke("install_daemon_for_update"),
+          DAEMON_INSTALL_TIMEOUT_MS,
+        );
         logger.info("[updater] daemon installed, proceeding with relaunch");
       } catch (e) {
         // Log but don't block - worst case, app will upgrade daemon on next launch

--- a/crates/runtimed/src/notebook_sync_client.rs
+++ b/crates/runtimed/src/notebook_sync_client.rs
@@ -902,6 +902,9 @@ where
             .ok_or(NotebookSyncError::Disconnected)?;
 
         // Parse as ProtocolCapabilities - server must support v2
+        // TODO: Also validate caps.protocol_version if present, for explicit version mismatch detection.
+        // Currently only checks the string "v2", but protocol_version (u32) is more precise.
+        // See #635 for context on protocol version fields.
         match serde_json::from_slice::<ProtocolCapabilities>(&first_frame) {
             Ok(caps) if caps.protocol == PROTOCOL_V2 => {
                 info!(
@@ -1057,6 +1060,7 @@ where
         }
 
         // Validate protocol version
+        // TODO: Also validate info.protocol_version if present (#635)
         if info.protocol != PROTOCOL_V2 {
             return Err(NotebookSyncError::SyncError(format!(
                 "unsupported protocol version: {}",
@@ -1135,6 +1139,7 @@ where
         }
 
         // Validate protocol version
+        // TODO: Also validate info.protocol_version if present (#635)
         if info.protocol != PROTOCOL_V2 {
             return Err(NotebookSyncError::SyncError(format!(
                 "unsupported protocol version: {}",

--- a/crates/runtimed/src/singleton.rs
+++ b/crates/runtimed/src/singleton.rs
@@ -171,7 +171,7 @@ impl DaemonLock {
         let info = DaemonInfo {
             endpoint: endpoint.to_string(),
             pid: std::process::id(),
-            version: format!("{}+{}", env!("CARGO_PKG_VERSION"), env!("GIT_COMMIT")),
+            version: crate::daemon_version().to_string(),
             started_at: Utc::now(),
             blob_port,
             worktree_path,


### PR DESCRIPTION
## Summary

Fast-follow improvements from #635 review feedback:

- **Timeout on daemon install** — Wrap `invoke("install_daemon_for_update")` with a 30s timeout to prevent indefinite "Preparing..." state if the daemon install hangs
- **TODO for protocol_version validation** — Add TODO comments at all 3 protocol validation sites in `notebook_sync_client.rs` noting that `protocol_version` (u32) should be validated in addition to the legacy string
- **Deduplicate daemon_version()** — Use `crate::daemon_version()` in `singleton.rs` instead of duplicating the format string