### PR TITLE
feat(ci): add Discord webhook notification for releases

### DIFF
--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -998,7 +998,7 @@ jobs:
           curl -H "Content-Type: application/json" -d "{
             \"embeds\": [{
               \"title\": \"${{ inputs.release_title }} succeeded\",
-              \"description\": \"Version \\\`v${VERSION}\\\` published successfully\",
+              \"description\": \"Version \`v${VERSION}\` published successfully\",
               \"url\": \"$RUN_URL\",
               \"color\": 3066993
             }]

--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -983,3 +983,23 @@ jobs:
           gh release edit "${{ inputs.updater_channel_tag }}" --prerelease=${{ inputs.updater_channel_prerelease }} --latest=false >/dev/null 2>&1 || true
 
           gh release upload "${{ inputs.updater_channel_tag }}" release-assets/latest.json --clobber
+
+      - name: Notify Discord
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          VERSION: ${{ needs.compute-version.outputs.version }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          if [ -z "$DISCORD_WEBHOOK" ]; then
+            echo "No Discord webhook configured, skipping notification"
+            exit 0
+          fi
+
+          curl -H "Content-Type: application/json" -d "{
+            \"embeds\": [{
+              \"title\": \"${{ inputs.release_title }} succeeded\",
+              \"description\": \"Version \\\`v${VERSION}\\\` published successfully\",
+              \"url\": \"$RUN_URL\",
+              \"color\": 3066993
+            }]
+          }" "$DISCORD_WEBHOOK"


### PR DESCRIPTION
Notifies the nteract Discord server when a release (nightly or stable) completes successfully.

## What changed
Added a final step to the `prerelease` job in the release workflow that posts a Discord embed with:
- Release title and success status
- Version number
- Link to the GitHub Actions run

The notification gracefully skips if the `DISCORD_WEBHOOK` secret is not configured.

## Setup
Create a Discord webhook in the nteract server and add it as the `DISCORD_WEBHOOK` repository secret in GitHub settings.

## Verification
- [x] Create the Discord webhook in the nteract server
- [x] Add webhook URL as `DISCORD_WEBHOOK` repository secret
- [ ] Manually trigger Nightly Release workflow to test notification appears in Discord
- [ ] Verify the embed contains version number and link to Actions run

_PR submitted by @rgbkrk's agent, Quill_