### PR TITLE
feat(menu): add check for updates menu item

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -329,6 +329,7 @@ function AppContent() {
   const {
     status: updateStatus,
     version: updateVersion,
+    checkForUpdate,
     downloadAndInstall: downloadUpdate,
     restartToUpdate,
   } = useUpdater();
@@ -739,6 +740,17 @@ function AppContent() {
       unlistenPromise.then((unlisten) => unlisten());
     };
   }, [handleRestartAndRunAll]);
+
+  // Check for updates via native menu
+  useEffect(() => {
+    const webview = getCurrentWebview();
+    const unlistenPromise = webview.listen("menu:check-for-updates", () => {
+      checkForUpdate();
+    });
+    return () => {
+      unlistenPromise.then((unlisten) => unlisten());
+    };
+  }, [checkForUpdate]);
 
   // Zoom controls via native menu
   useEffect(() => {

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -3842,6 +3842,16 @@ pub fn run(
                         );
                     }
                 }
+                crate::menu::MENU_CHECK_FOR_UPDATES => {
+                    if let Some(window) = focused_window(app) {
+                        let _ = emit_to_label::<_, _, _>(
+                            &window,
+                            window.label(),
+                            "menu:check-for-updates",
+                            (),
+                        );
+                    }
+                }
                 crate::menu::MENU_INSTALL_CLI => {
                     let app_handle = app.clone();
                     match crate::cli_install::install_cli(&app_handle) {

--- a/crates/notebook/src/menu.rs
+++ b/crates/notebook/src/menu.rs
@@ -32,6 +32,7 @@ pub const MENU_RESTART_AND_RUN_ALL: &str = "restart_and_run_all";
 
 // Menu item IDs for CLI installation
 pub const MENU_INSTALL_CLI: &str = "install_cli";
+pub const MENU_CHECK_FOR_UPDATES: &str = "check_for_updates";
 pub const APP_VERSION: &str = env!("CARGO_PKG_VERSION");
 pub const APP_COMMIT_SHA: &str = env!("GIT_COMMIT");
 pub const APP_RELEASE_DATE: &str = env!("GIT_COMMIT_DATE");
@@ -123,6 +124,13 @@ pub fn create_menu(
         app,
         MENU_INSTALL_CLI,
         install_cli_label.as_str(),
+        true,
+        None::<&str>,
+    )?)?;
+    app_menu.append(&MenuItem::with_id(
+        app,
+        MENU_CHECK_FOR_UPDATES,
+        "Check for Updates...",
         true,
         None::<&str>,
     )?)?;


### PR DESCRIPTION
Add "Check for Updates..." entry to the nteract app menu, allowing users to manually trigger an update check instead of waiting for the automatic 30-minute interval. This follows standard UX patterns in desktop applications.

## Testing
* [x] Open the app and verify the menu item appears in nteract → Check for Updates...
* [ ] Click the menu item and verify the toolbar shows "checking" state briefly
* [ ] Verify that the update status displays correctly (showing "Update vX.Y.Z" if available or returning to idle if not)
* [ ] Verify the update download/install flow still works when an update is available

_PR submitted by @rgbkrk's agent, Quill_