### PR TITLE
fix(runtimed-py): validate working_dir in create_notebook

### DIFF
--- a/crates/runtimed-py/src/async_session.rs
+++ b/crates/runtimed-py/src/async_session.rs
@@ -220,6 +220,23 @@ impl AsyncSession {
         runtime: &str,
         working_dir: Option<String>,
     ) -> PyResult<Bound<'py, PyAny>> {
+        // Validate working_dir if provided
+        if let Some(ref wd) = working_dir {
+            let path = std::path::Path::new(wd);
+            if !path.exists() {
+                return Err(pyo3::exceptions::PyFileNotFoundError::new_err(format!(
+                    "working_dir does not exist: {}",
+                    wd
+                )));
+            }
+            if !path.is_dir() {
+                return Err(pyo3::exceptions::PyNotADirectoryError::new_err(format!(
+                    "working_dir is not a directory: {}",
+                    wd
+                )));
+            }
+        }
+
         let runtime = runtime.to_string();
         future_into_py(py, async move {
             let working_dir_str = working_dir.clone();

--- a/crates/runtimed-py/src/session.rs
+++ b/crates/runtimed-py/src/session.rs
@@ -208,6 +208,23 @@ impl Session {
     #[staticmethod]
     #[pyo3(signature = (runtime="python", working_dir=None))]
     fn create_notebook(runtime: &str, working_dir: Option<&str>) -> PyResult<Self> {
+        // Validate working_dir if provided
+        if let Some(wd) = working_dir {
+            let path = std::path::Path::new(wd);
+            if !path.exists() {
+                return Err(pyo3::exceptions::PyFileNotFoundError::new_err(format!(
+                    "working_dir does not exist: {}",
+                    wd
+                )));
+            }
+            if !path.is_dir() {
+                return Err(pyo3::exceptions::PyNotADirectoryError::new_err(format!(
+                    "working_dir is not a directory: {}",
+                    wd
+                )));
+            }
+        }
+
         let rt = Runtime::new().map_err(to_py_err)?;
         let runtime_str = runtime.to_string();
         let working_dir_str = working_dir.map(|s| s.to_string());

--- a/python/runtimed/tests/test_session_unit.py
+++ b/python/runtimed/tests/test_session_unit.py
@@ -225,6 +225,38 @@ class TestOutputTypes:
         assert hasattr(runtimed, "RuntimedError")
 
 
+class TestCreateNotebookValidation:
+    """Test create_notebook working_dir validation."""
+
+    def test_create_notebook_rejects_nonexistent_path(self):
+        """create_notebook raises FileNotFoundError for non-existent working_dir."""
+        with pytest.raises(FileNotFoundError, match="working_dir does not exist"):
+            runtimed.Session.create_notebook(working_dir="/sessions/fake-path")
+
+    def test_create_notebook_rejects_file_as_working_dir(self, tmp_path):
+        """create_notebook raises NotADirectoryError when working_dir is a file."""
+        test_file = tmp_path / "test_file.txt"
+        test_file.write_text("test")
+        with pytest.raises(NotADirectoryError, match="working_dir is not a directory"):
+            runtimed.Session.create_notebook(working_dir=str(test_file))
+
+
+class TestAsyncCreateNotebookValidation:
+    """Test AsyncSession.create_notebook working_dir validation."""
+
+    def test_async_create_notebook_rejects_nonexistent_path(self):
+        """AsyncSession.create_notebook raises FileNotFoundError for non-existent working_dir."""
+        with pytest.raises(FileNotFoundError, match="working_dir does not exist"):
+            runtimed.AsyncSession.create_notebook(working_dir="/sessions/fake-path")
+
+    def test_async_create_notebook_rejects_file_as_working_dir(self, tmp_path):
+        """AsyncSession.create_notebook raises NotADirectoryError when working_dir is a file."""
+        test_file = tmp_path / "test_file.txt"
+        test_file.write_text("test")
+        with pytest.raises(NotADirectoryError, match="working_dir is not a directory"):
+            runtimed.AsyncSession.create_notebook(working_dir=str(test_file))
+
+
 class TestModuleExports:
     """Test that all expected classes are exported."""
 


### PR DESCRIPTION
Validate that `working_dir` exists and is a directory when creating notebooks via the nteract MCP `create_notebook` method. Returns `FileNotFoundError` when the path doesn't exist or `NotADirectoryError` when the path points to a file.

This prevents Claude from silently ignoring invalid paths like Conductor session identifiers (e.g., `/sessions/sharp-confident-curie`) that it might mistakenly pass as filesystem paths. Now Claude gets explicit feedback to adjust its approach.

Added validation to both `Session.create_notebook()` and `AsyncSession.create_notebook()` in the Python bindings, plus comprehensive test coverage for both valid rejection cases.

## Verification

- [x] Python MCP bindings validate working_dir before daemon communication
- [x] Tests verify FileNotFoundError for non-existent paths
- [x] Tests verify NotADirectoryError for file paths
- [x] All existing tests pass

_PR submitted by @rgbkrk's agent, Quill_