### PR TITLE
docs: add frontend architecture, testing, bindings, and widget dev guides

### DIFF
--- a/contributing/architecture.md
+++ b/contributing/architecture.md
@@ -53,6 +53,33 @@ Cell outputs are stored as content-addressed blobs with manifest references. Thi
 - Manifest format allows lazy loading and deduplication
 - Large outputs don't block document sync
 
+**Implementation details:**
+
+The blob store uses content-addressed storage at `~/.cache/runt/blobs/`. Each blob is identified by its SHA-256 hash and stored in a two-level shard directory:
+
+```
+~/.cache/runt/blobs/
+  a1/
+    b2c3d4...       # raw bytes
+    b2c3d4....meta  # JSON metadata (media_type, size, created_at)
+```
+
+Data flow:
+1. Kernel produces output → daemon's `output_store.rs` receives it
+2. Large data (images, HTML) goes to `blob_store.rs` → returns hash
+3. Daemon broadcasts `OutputManifest` with `ContentRef` (either `{ inline: "..." }` or `{ blob: "hash", size: N }`)
+4. Frontend's `manifest-resolution.ts` checks `isManifestHash()` on output data
+5. Blob refs are fetched from `blob_server.rs` via `http://127.0.0.1:{port}/blob/{hash}`
+6. `materialize-cells.ts` converts resolved outputs to React-renderable `NotebookCell[]`
+
+Key files:
+- `crates/runtimed/src/blob_store.rs` — Content-addressed storage with atomic writes
+- `crates/runtimed/src/blob_server.rs` — HTTP server for blob retrieval
+- `crates/runtimed/src/output_store.rs` — Decides inline vs blob based on size threshold
+- `apps/notebook/src/lib/manifest-resolution.ts` — `resolveManifest()`, `resolveContentRef()`
+- `apps/notebook/src/lib/materialize-cells.ts` — Assembles cells with resolved outputs
+- `apps/notebook/src/hooks/useManifestResolver.ts` — React hook for lazy resolution
+
 ### 6. Daemon Manages Runtime Resources
 
 The daemon owns kernel lifecycle, environment pools, and tooling (ruff, deno, etc.).

--- a/contributing/frontend-architecture.md
+++ b/contributing/frontend-architecture.md
@@ -1,0 +1,155 @@
+# Frontend Architecture
+
+This guide explains the frontend code organization and how shared components relate to the notebook application.
+
+## Directory Layout
+
+```
+/
+├── src/                          ← Shared components (path alias @/)
+│   ├── bindings/                 ← TypeScript types generated from Rust (see typescript-bindings.md)
+│   ├── components/
+│   │   ├── cell/                 ← Cell container, controls, execution count
+│   │   ├── editor/               ← CodeMirror wrappers, extensions, themes
+│   │   ├── isolated/             ← Iframe security isolation (IsolatedFrame, CommBridge)
+│   │   ├── outputs/              ← Output renderers (MediaRouter, AnsiOutput, etc.)
+│   │   ├── widgets/              ← ipywidgets and anywidget implementations
+│   │   └── ui/                   ← shadcn components (Button, Dialog, etc.)
+│   ├── hooks/                    ← Shared hooks (useSyncedSettings, useTheme)
+│   ├── isolated-renderer/        ← Code that runs INSIDE isolated iframe
+│   ├── lib/                      ← Shared utilities (utils.ts with cn())
+│   └── styles/                   ← Global stylesheets
+│
+├── apps/
+│   ├── notebook/src/             ← Notebook app (path alias ~/)
+│   │   ├── components/           ← App-specific components (toolbar, banners)
+│   │   ├── hooks/                ← Notebook-specific hooks (useDaemonKernel, etc.)
+│   │   ├── lib/                  ← App-specific utilities (materialize-cells.ts)
+│   │   ├── wasm/                 ← WASM bindings (runtimed-wasm)
+│   │   ├── App.tsx               ← Root component
+│   │   └── types.ts              ← App types
+│   │
+│   └── sidecar/src/              ← Standalone output viewer for REPL use
+│                                   (embeds via rust-embed in crates/sidecar/)
+```
+
+## Path Aliases
+
+The notebook app uses two path aliases configured in `apps/notebook/tsconfig.json`:
+
+| Alias | Resolves To | Use For |
+|-------|-------------|---------|
+| `@/*` | `../../src/*` | Shared components, hooks, utilities |
+| `~/*` | `./src/*` | App-specific code |
+
+Example imports:
+```tsx
+import { CellContainer } from "@/components/cell";      // shared
+import { useDaemonKernel } from "~/hooks/useDaemonKernel";  // app-specific
+```
+
+## Shared vs App-Specific
+
+**Put code in `src/` (shared) when:**
+- It's a pure UI component with no Tauri/daemon dependencies
+- It could be reused by sidecar or future apps
+- It's a generic utility (cn(), theme helpers)
+
+**Put code in `apps/notebook/src/` when:**
+- It uses Tauri APIs (`@tauri-apps/api`)
+- It interacts with the daemon (kernel execution, notebook sync)
+- It's specific to the notebook editing experience
+
+## Key Shared Components
+
+### Cell Components (`src/components/cell/`)
+
+| Component | Role |
+|-----------|------|
+| `CellContainer` | Wrapper with selection, focus, drag handles |
+| `CellControls` | Play button, cell type indicator |
+| `CellHeader` | Execution count display |
+| `PlayButton` | Execute cell action |
+
+### Editor (`src/components/editor/`)
+
+CodeMirror integration with Jupyter-specific extensions:
+- `codemirror-editor.tsx` — Main editor component
+- `extensions/` — Keybindings, line numbers, bracket matching
+- `languages/` — Python, Markdown, SQL syntax
+- `themes/` — Light and dark themes
+
+### Outputs (`src/components/outputs/`)
+
+| Renderer | MIME Types |
+|----------|------------|
+| `AnsiOutput` | `text/plain` with ANSI codes |
+| `HtmlOutput` | `text/html` |
+| `ImageOutput` | `image/png`, `image/jpeg`, etc. |
+| `MarkdownOutput` | `text/markdown` |
+| `JsonOutput` | `application/json` |
+| `MediaRouter` | Dispatches to appropriate renderer |
+
+### Widgets (`src/components/widgets/`)
+
+See [widget-development.md](widget-development.md) for internals.
+
+### Isolated Renderer (`src/components/isolated/`)
+
+Security boundary for untrusted HTML/widget outputs. See [iframe-isolation.md](iframe-isolation.md).
+
+## Key App-Specific Hooks
+
+| Hook | Role |
+|------|------|
+| `useAutomergeNotebook` | Owns WASM NotebookHandle, drives cell state |
+| `useDaemonKernel` | Kernel execution, status broadcasts |
+| `useDependencies` | UV dependency management |
+| `useCondaDependencies` | Conda dependency management |
+| `useManifestResolver` | Resolves blob hashes to output data |
+| `useCellKeyboardNavigation` | Arrow keys, enter/escape modes |
+
+## Data Flow
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ Frontend                                                        │
+│                                                                 │
+│  ┌──────────────┐    sync     ┌──────────────────┐             │
+│  │ NotebookHandle│◄──────────►│ Daemon           │             │
+│  │ (WASM)       │             │ (notebook room)  │             │
+│  └──────┬───────┘             └────────┬─────────┘             │
+│         │                              │                        │
+│         │ get_cells_json()             │ kernel broadcasts      │
+│         ▼                              ▼                        │
+│  ┌──────────────┐             ┌──────────────────┐             │
+│  │ materialize- │             │ useDaemonKernel  │             │
+│  │ Cells()      │             │                  │             │
+│  └──────┬───────┘             └────────┬─────────┘             │
+│         │                              │                        │
+│         │ NotebookCell[]               │ outputs, status        │
+│         ▼                              ▼                        │
+│  ┌─────────────────────────────────────────────────┐           │
+│  │ React Components                                 │           │
+│  │ (CellContainer → CodeCell/MarkdownCell → Outputs)│           │
+│  └─────────────────────────────────────────────────┘           │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+1. **NotebookHandle (WASM)** — Local Automerge doc for instant cell edits
+2. **materializeCells()** — Converts WASM cell snapshots to React-friendly objects
+3. **useDaemonKernel** — Receives kernel outputs and status via daemon broadcasts
+4. **React components** — Render cells and outputs
+
+Cell mutations (add, delete, edit) go through the WASM handle for instant response, then sync to the daemon. Execution requests go to the daemon, which reads from the synced document.
+
+## Key Files
+
+| File | Role |
+|------|------|
+| `apps/notebook/tsconfig.json` | Path alias configuration |
+| `apps/notebook/src/App.tsx` | Root component, provider setup |
+| `apps/notebook/src/hooks/useAutomergeNotebook.ts` | WASM notebook sync |
+| `apps/notebook/src/lib/materialize-cells.ts` | WASM → React conversion |
+| `src/components/outputs/media-router.tsx` | Output type dispatch |
+| `src/components/editor/codemirror-editor.tsx` | Main editor |

--- a/contributing/testing.md
+++ b/contributing/testing.md
@@ -1,0 +1,232 @@
+# Testing Guide
+
+This guide covers all test types in the codebase. For E2E tests specifically, see [e2e.md](e2e.md).
+
+## Quick Reference
+
+| Type | Location | Command | Framework |
+|------|----------|---------|-----------|
+| E2E | `e2e/specs/` | `./e2e/dev.sh test` | WebdriverIO + Mocha |
+| Frontend unit | `src/**/__tests__/` | `pnpm test` | Vitest + jsdom |
+| Rust unit | inline `#[cfg(test)]` | `cargo test` | built-in |
+| CLI behavior | `crates/runt/tests/*.hone` | `cargo hone test` | Hone |
+| Python | `python/runtimed/tests/` | `pytest` | pytest |
+
+## Frontend Unit Tests (Vitest)
+
+Configuration: `vitest.config.ts`
+
+```ts
+test: {
+  environment: "jsdom",
+  include: ["src/**/__tests__/**/*.test.{ts,tsx}"],
+  globals: true,
+  setupFiles: ["./src/test-setup.ts"],
+}
+```
+
+**Running tests:**
+
+```bash
+pnpm test         # Watch mode
+pnpm test:run     # Run once
+```
+
+**Writing tests:**
+
+```tsx
+// src/components/outputs/__tests__/ansi-output.test.tsx
+import { render } from "@testing-library/react";
+import { AnsiOutput } from "../ansi-output";
+
+describe("AnsiOutput", () => {
+  it("renders plain text", () => {
+    const { container } = render(<AnsiOutput text="hello" />);
+    expect(container.textContent).toBe("hello");
+  });
+
+  it.each([
+    ["red", "\x1b[31mred\x1b[0m"],
+    ["green", "\x1b[32mgreen\x1b[0m"],
+  ])("renders %s ANSI color", (_, text) => {
+    const { container } = render(<AnsiOutput text={text} />);
+    expect(container.querySelector(".ansi-red")).toBeTruthy();
+  });
+});
+```
+
+**Test locations:**
+
+- `src/components/isolated/__tests__/` — Frame bridge, message protocol
+- `src/components/outputs/__tests__/` — Output renderers
+- `src/components/widgets/__tests__/` — Widget store, registry
+
+## Rust Unit Tests
+
+Rust tests are inline modules using `#[cfg(test)]`:
+
+```rust
+// crates/runtimed/src/runtime.rs
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_runtime_serialization() {
+        let runtime = Runtime::Python;
+        let json = serde_json::to_string(&runtime).unwrap();
+        assert_eq!(json, "\"python\"");
+    }
+}
+```
+
+**Running tests:**
+
+```bash
+cargo test                    # All workspace tests
+cargo test -p runtimed        # Specific crate
+cargo test -p notebook-doc    # Automerge doc tests
+cargo test -- --nocapture     # Show println! output
+```
+
+**Key test locations:**
+
+| Crate | Tests |
+|-------|-------|
+| `kernel-launch` | Tool hashing, path resolution |
+| `notebook-doc` | Automerge document operations |
+| `runtimed` | Settings, kernel manager, stream terminal |
+
+## Hone CLI Tests
+
+Hone is a bash-based declarative test framework for the `runt` CLI. Test files are in `crates/runt/tests/*.hone`.
+
+**File format:**
+
+```bash
+#! shell: /bin/bash
+#! timeout: 60s
+
+TEST "help flag displays usage"
+RUN runt --help
+ASSERT exit_code == 0
+ASSERT stdout contains "Usage: runt [COMMAND]"
+
+TEST "invalid command fails"
+RUN runt invalid_command
+ASSERT exit_code != 0
+ASSERT stderr contains "error: unrecognized subcommand"
+
+TEST "version matches regex"
+RUN runt --version
+ASSERT stdout matches /runt-cli \d+\.\d+\.\d+/
+```
+
+**Available assertions:**
+
+| Assertion | Example |
+|-----------|---------|
+| Exit code | `ASSERT exit_code == 0` |
+| Contains | `ASSERT stdout contains "text"` |
+| Regex match | `ASSERT stdout matches /pattern/` |
+| Not equal | `ASSERT exit_code != 0` |
+
+**Test files:**
+
+| File | Coverage |
+|------|----------|
+| `cli.hone` | Help, version, invalid commands |
+| `kernel_lifecycle.hone` | Start, execute, stop, interrupt |
+| `ps.hone` | Process listing |
+| `start_errors.hone` | Invalid kernel errors |
+| `exec_errors.hone` | Execution error handling |
+| `interrupt_errors.hone` | Interrupt signal handling |
+| `stop_errors.hone` | Stop command edge cases |
+
+**Running Hone tests:**
+
+```bash
+cargo hone test               # All hone tests
+cargo hone test cli.hone      # Specific file
+```
+
+## Python Tests (pytest)
+
+Location: `python/runtimed/tests/`
+
+Configuration in `conftest.py` defines markers and daemon detection.
+
+**Test categories:**
+
+| File | Type | Requires Daemon |
+|------|------|-----------------|
+| `test_session_unit.py` | Unit | No |
+| `test_daemon_integration.py` | Integration | Yes |
+| `test_ipython_bridge.py` | Integration | Yes |
+| `test_sidecar.py` | Integration | Yes |
+| `test_binary.py` | Binary/CLI | No |
+
+**Running tests:**
+
+```bash
+# Unit tests only (fast, no daemon)
+pytest python/runtimed/tests/test_session_unit.py -v
+
+# Skip integration tests
+SKIP_INTEGRATION_TESTS=1 pytest python/runtimed/tests/ -v
+
+# Integration tests (requires running dev daemon)
+pytest python/runtimed/tests/test_daemon_integration.py -v
+
+# CI mode (spawns its own daemon)
+RUNTIMED_INTEGRATION_TEST=1 pytest python/runtimed/tests/ -v
+```
+
+**Writing tests:**
+
+```python
+# Unit test (no daemon)
+class TestSessionConstruction:
+    def test_session_with_auto_id(self):
+        session = runtimed.Session()
+        assert session.notebook_id.startswith("agent-session-")
+        assert not session.is_connected
+
+# Integration test (needs daemon)
+@pytest.mark.asyncio
+async def test_kernel_execution(self):
+    session = runtimed.AsyncSession()
+    await session.connect()
+    result = await session.execute("1 + 1")
+    assert "2" in result
+```
+
+**Environment variables:**
+
+| Variable | Effect |
+|----------|--------|
+| `SKIP_INTEGRATION_TESTS=1` | Skip tests marked `@pytest.mark.integration` |
+| `RUNTIMED_INTEGRATION_TEST=1` | CI mode: spawns daemon automatically |
+| `RUNTIMED_SOCKET_PATH` | Override daemon socket location |
+
+## E2E Tests
+
+See [e2e.md](e2e.md) for the full guide.
+
+Quick start:
+
+```bash
+./e2e/dev.sh cycle          # Build + start + test
+./e2e/dev.sh test           # Smoke test only
+./e2e/dev.sh test all       # All non-fixture specs
+```
+
+## Test Philosophy
+
+From [architecture.md](architecture.md):
+
+- **E2E tests** (WebdriverIO): Slow but comprehensive, test full user journeys
+- **Integration tests** (Python bindings): Fast daemon interaction tests
+- **Unit tests**: Pure logic, no I/O, fast feedback
+
+Preference: Fast integration tests over slow E2E where possible. Use E2E for critical user journeys, integration tests for daemon behavior, unit tests for algorithms.

--- a/contributing/typescript-bindings.md
+++ b/contributing/typescript-bindings.md
@@ -1,0 +1,140 @@
+# TypeScript Bindings (ts-rs)
+
+TypeScript types in `src/bindings/` are auto-generated from Rust structs and enums. Do not edit them manually.
+
+## Overview
+
+The `ts-rs` crate generates TypeScript type definitions from Rust types annotated with `#[derive(TS)]`. This ensures type safety between the Rust daemon and TypeScript frontend.
+
+## Source Files
+
+| Rust File | Generated Types |
+|-----------|-----------------|
+| `crates/runtimed/src/settings_doc.rs` | `ThemeMode`, `PythonEnvType`, `UvDefaults`, `CondaDefaults`, `SyncedSettings` |
+| `crates/runtimed/src/runtime.rs` | `Runtime` |
+
+## How It Works
+
+Rust types use `#[derive(TS)]` and `#[ts(export)]` attributes:
+
+```rust
+use ts_rs::TS;
+
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+#[ts(export)]
+pub enum ThemeMode {
+    System,
+    Light,
+    Dark,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+#[ts(export)]
+pub struct SyncedSettings {
+    pub theme: ThemeMode,
+    pub default_runtime: Runtime,
+    pub default_python_env: PythonEnvType,
+    // ...
+}
+```
+
+This generates:
+
+```typescript
+// src/bindings/ThemeMode.ts
+export type ThemeMode = "system" | "light" | "dark";
+
+// src/bindings/SyncedSettings.ts
+export type SyncedSettings = {
+  theme: ThemeMode;
+  default_runtime: Runtime;
+  default_python_env: PythonEnvType;
+  // ...
+};
+```
+
+## Configuration
+
+The export directory is configured in `.cargo/config.toml`:
+
+```toml
+[env]
+TS_RS_EXPORT_DIR = { value = "src/bindings", relative = true }
+```
+
+## Regenerating Bindings
+
+Run `cargo test` to regenerate bindings:
+
+```bash
+cargo test
+```
+
+The ts-rs procedural macro exports types during test compilation. Generated files appear in `src/bindings/`.
+
+## Adding New Bindings
+
+1. Add the `ts-rs` dependency to your crate's `Cargo.toml`:
+   ```toml
+   [dependencies]
+   ts-rs = { version = "10", features = ["serde-compat"] }
+   ```
+
+2. Annotate your type:
+   ```rust
+   use ts_rs::TS;
+
+   #[derive(TS)]
+   #[ts(export)]
+   pub struct MyNewType {
+       pub field: String,
+   }
+   ```
+
+3. Run `cargo test` to generate the TypeScript file
+
+4. Import from `src/bindings/index.ts`:
+   ```typescript
+   import type { MyNewType } from "@/bindings";
+   ```
+
+## Generated Files
+
+```
+src/bindings/
+├── CondaDefaults.ts
+├── PythonEnvType.ts
+├── Runtime.ts
+├── SyncedSettings.ts
+├── ThemeMode.ts
+├── UvDefaults.ts
+└── index.ts          ← Re-exports all types
+```
+
+The `index.ts` file re-exports all generated types for convenient imports.
+
+## Usage in Frontend
+
+```typescript
+import type { SyncedSettings, ThemeMode } from "@/bindings";
+import { useSyncedSettings } from "@/hooks/useSyncedSettings";
+
+function Settings() {
+  const { settings, updateSettings } = useSyncedSettings();
+
+  const handleThemeChange = (theme: ThemeMode) => {
+    updateSettings({ theme });
+  };
+  // ...
+}
+```
+
+## Key Files
+
+| File | Role |
+|------|------|
+| `.cargo/config.toml` | Sets `TS_RS_EXPORT_DIR` |
+| `crates/runtimed/src/settings_doc.rs` | Main source of settings types |
+| `crates/runtimed/src/runtime.rs` | Runtime enum |
+| `src/bindings/index.ts` | Re-exports all generated types |
+| `src/hooks/useSyncedSettings.ts` | Consumes the generated types |

--- a/contributing/widget-development.md
+++ b/contributing/widget-development.md
@@ -1,0 +1,215 @@
+# Widget Development Guide
+
+This guide covers widget system internals for developers. For user-facing widget support info, see [docs/widgets.md](../docs/widgets.md).
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│ Parent Window                                                           │
+│                                                                         │
+│  ┌──────────────┐    comm_open/msg/close    ┌─────────────────────────┐│
+│  │ Kernel       │◄────────────────────────►│ WidgetStore             ││
+│  │ (via daemon) │                           │ (state management)      ││
+│  └──────────────┘                           └───────────┬─────────────┘│
+│                                                         │              │
+│                                            ┌────────────┴────────────┐ │
+│                                            │ CommBridgeManager       │ │
+│                                            │ (routes messages)       │ │
+│                                            └────────────┬────────────┘ │
+│                                                         │ postMessage  │
+└─────────────────────────────────────────────────────────┼──────────────┘
+                                                          │
+┌─────────────────────────────────────────────────────────┼──────────────┐
+│ Isolated Iframe (sandboxed, no Tauri access)            ▼              │
+│                                                                         │
+│  ┌─────────────────┐         ┌──────────────────┐                      │
+│  │ WidgetBridge    │◄───────►│ Widget Components │                      │
+│  │ (receives msgs) │         │ (React renders)   │                      │
+│  └─────────────────┘         └──────────────────┘                      │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+Widgets run inside a security-isolated iframe. The parent window owns the WidgetStore and proxies Jupyter comm messages through the CommBridgeManager.
+
+## Key Files
+
+| File | Role |
+|------|------|
+| `src/components/widgets/widget-store.ts` | Model state management (useSyncExternalStore pattern) |
+| `src/components/widgets/widget-registry.ts` | Maps model names to React components |
+| `src/components/widgets/controls/` | 54 built-in ipywidgets implementations |
+| `src/components/widgets/controls/index.ts` | Registration of all built-in widgets |
+| `src/components/widgets/anywidget-view.tsx` | AFM loader for anywidget ESM modules |
+| `src/components/widgets/widget-view.tsx` | Renders widgets by looking up registry |
+| `src/components/isolated/comm-bridge-manager.ts` | Routes comm messages between store and iframe |
+| `src/components/isolated/frame-bridge.ts` | Message protocol types and guards |
+| `src/isolated-renderer/widget-bridge-client.ts` | Iframe-side message handler |
+
+## WidgetStore API
+
+The store manages widget models using React's `useSyncExternalStore` pattern:
+
+```typescript
+interface WidgetStore {
+  // For useSyncExternalStore
+  subscribe(listener: () => void): () => void;
+  getSnapshot(): Map<string, WidgetModel>;
+
+  // Model operations
+  getModel(modelId: string): WidgetModel | undefined;
+  createModel(commId: string, state: Record<string, unknown>, buffers?: ArrayBuffer[]): void;
+  updateModel(commId: string, statePatch: Record<string, unknown>, buffers?: ArrayBuffer[]): void;
+  deleteModel(commId: string): void;
+
+  // Fine-grained subscriptions
+  subscribeToKey(modelId: string, key: string, callback: (value: unknown) => void): () => void;
+
+  // Custom messages (e.g., anywidget)
+  emitCustomMessage(commId: string, content: Record<string, unknown>, buffers?: ArrayBuffer[]): void;
+  subscribeToCustomMessage(commId: string, callback: CustomMessageCallback): () => void;
+}
+```
+
+Usage in components:
+
+```tsx
+import { useSyncExternalStore } from "react";
+
+function useWidgetValue(store: WidgetStore, modelId: string, key: string) {
+  return useSyncExternalStore(
+    (callback) => store.subscribeToKey(modelId, key, callback),
+    () => store.getModel(modelId)?.state[key]
+  );
+}
+```
+
+## Comm Bridge Protocol
+
+Widget communication follows the Jupyter Comm protocol:
+
+| Message | When | Data |
+|---------|------|------|
+| `comm_open` | Widget created | `{ comm_id, target_name, data: { state } }` |
+| `comm_msg` | State update | `{ comm_id, data: { method: "update", state } }` |
+| `comm_msg` | Custom message | `{ comm_id, data: { method: "custom", content } }` |
+| `comm_close` | Widget destroyed | `{ comm_id }` |
+
+The CommBridgeManager:
+1. Subscribes to WidgetStore changes
+2. Forwards model updates to the isolated iframe via postMessage
+3. Receives iframe messages and routes them to kernel or store
+
+## Adding a New Built-in Widget
+
+1. **Create the component** in `src/components/widgets/controls/`:
+
+```tsx
+// src/components/widgets/controls/my-widget.tsx
+import type { WidgetComponentProps } from "../widget-registry";
+
+export function MyWidget({ modelId }: WidgetComponentProps) {
+  // Access widget store via context or props
+  const value = useWidgetValue(modelId, "value");
+  const description = useWidgetValue(modelId, "description");
+
+  const handleChange = (newValue: number) => {
+    // Send update back to kernel
+    sendUpdate(modelId, { value: newValue });
+  };
+
+  return (
+    <div>
+      <label>{description}</label>
+      <input value={value} onChange={(e) => handleChange(Number(e.target.value))} />
+    </div>
+  );
+}
+```
+
+2. **Register the widget** in `src/components/widgets/controls/index.ts`:
+
+```typescript
+import { MyWidget } from "./my-widget";
+registerWidget("MyWidgetModel", MyWidget);
+```
+
+3. **Export the component** (optional, for direct use):
+
+```typescript
+export { MyWidget } from "./my-widget";
+```
+
+## Widget State Convention
+
+Widgets receive state from ipywidgets with these common fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `_model_name` | string | e.g., "IntSliderModel" |
+| `_model_module` | string | e.g., "@jupyter-widgets/controls" |
+| `value` | varies | Current widget value |
+| `description` | string | Label text |
+| `disabled` | boolean | Whether widget is interactive |
+| `layout` | string | IPY_MODEL_ reference to LayoutModel |
+
+## IPY_MODEL_ References
+
+Container widgets reference children via `IPY_MODEL_<comm_id>` strings:
+
+```typescript
+import { isModelRef, parseModelRef } from "../widget-store";
+
+// Check if value is a model reference
+if (isModelRef(child)) {
+  const childModelId = parseModelRef(child);
+  // Render child widget by its ID
+}
+```
+
+## Anywidget Support
+
+Anywidgets use ESM modules loaded at runtime. The `anywidget-view.tsx` component:
+
+1. Detects `_esm` field in model state
+2. Dynamically imports the ESM module
+3. Calls the module's `render` function with a model proxy
+
+## Testing Widgets
+
+**Unit tests:** `src/components/widgets/__tests__/`
+
+```typescript
+// widget-store.test.ts
+describe("WidgetStore", () => {
+  it("creates and updates models", () => {
+    const store = createWidgetStore();
+    store.createModel("test-id", { value: 42 });
+    expect(store.getModel("test-id")?.state.value).toBe(42);
+  });
+});
+```
+
+**Manual testing:**
+
+```python
+# In a notebook
+import ipywidgets as widgets
+slider = widgets.IntSlider(value=50, min=0, max=100)
+display(slider)
+```
+
+## Debugging
+
+Enable widget debug logging:
+
+```typescript
+// In browser console
+localStorage.setItem("DEBUG", "widgets:*");
+```
+
+Watch for comm messages in the daemon logs:
+
+```bash
+runt daemon logs -f | grep -i comm
+```


### PR DESCRIPTION
## Summary

Added four comprehensive developer guides addressing high-priority documentation gaps:

* **frontend-architecture.md** — Explains src/ (shared components) vs apps/notebook/src/ (app-specific), path aliases, component organization, and data flow
* **testing.md** — Unified guide covering Vitest (frontend), Rust unit tests, Hone CLI tests, Python integration tests, and E2E
* **typescript-bindings.md** — Documents the ts-rs workflow for auto-generating TypeScript types from Rust
* **widget-development.md** — Widget system internals, WidgetStore API, Comm bridge protocol, and adding new widgets

Also expanded contributing/architecture.md with blob store implementation details under Principle 5.

## Test Plan

* Review each new doc for accuracy and completeness against the codebase
* Verify all file paths and code references exist
* Cross-check internal links between docs work correctly

_PR submitted by @rgbkrk's agent, Quill_