### PR TITLE
fix(ci): restore execute permission on runtimed after artifact download

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -777,6 +777,9 @@ jobs:
           name: linux-rust-binaries
           path: .
 
+      - name: Make binaries executable
+        run: chmod +x target/release/runtimed target/release/runt
+
       - name: Install uv
         uses: astral-sh/setup-uv@v5
 


### PR DESCRIPTION
## Summary

- Add `chmod +x` step in the `runtimed-py-integration` job after downloading artifacts
- Fixes the permission error introduced in #646 where `actions/upload-artifact` doesn't preserve Unix file permissions

The `e2e` and `e2e-fixtures` jobs already had this step, but it was missing from the Python integration tests.

## Test plan

- CI passes on this PR