### PR TITLE
docs(agents): add missing contributing docs to index

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,13 +63,20 @@ The `.context/` directory is gitignored and used for per-worktree state that sho
 
 See the `contributing/` directory for detailed guides:
 - `contributing/architecture.md` - Runtime architecture principles (daemon, state, sync)
+- `contributing/build-dependencies.md` - Build dependency graph
 - `contributing/development.md` - Development workflow and build commands
 - `contributing/e2e.md` - End-to-end testing guide
 - `contributing/environments.md` - Environment management architecture
+- `contributing/frontend-architecture.md` - Frontend code organization (src/ vs apps/)
 - `contributing/iframe-isolation.md` - Security architecture for output isolation
+- `contributing/logging.md` - Logging conventions
 - `contributing/nteract-elements.md` - Working with nteract/elements registry
 - `contributing/protocol.md` - Wire protocol between clients and daemon
+- `contributing/runtimed.md` - Daemon development guide
+- `contributing/testing.md` - Testing guide (Vitest, Rust, Hone, Python, E2E)
+- `contributing/typescript-bindings.md` - ts-rs type generation from Rust
 - `contributing/ui.md` - UI components and shadcn setup
+- `contributing/widget-development.md` - Widget system internals
 
 ## Runtime Daemon (`runtimed`)
 


### PR DESCRIPTION
## Summary

AGENTS.md was missing 7 of 15 contributing docs in its Contributing Guidelines section. This made those docs undiscoverable to agents/developers using AGENTS.md as their entry point.

Added the missing docs:
- build-dependencies.md
- frontend-architecture.md
- logging.md
- runtimed.md
- testing.md
- typescript-bindings.md
- widget-development.md

## Verification

* [ ] Verify the list matches `ls contributing/*.md` (should be 15 files)
* [ ] Confirm AGENTS.md and CLAUDE.md are now in sync

_PR submitted by @rgbkrk's agent, Quill_