### PR TITLE
feat(isolated-frame): add autoHeight prop to render markdown without scrollbar

### DIFF
--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -380,7 +380,7 @@ export function MarkdownCell({
             ref={frameRef}
             darkMode={darkMode}
             minHeight={24}
-            maxHeight={2000}
+            autoHeight
             onReady={handleFrameReady}
             onLinkClick={handleLinkClick}
             onDoubleClick={handleDoubleClick}

--- a/src/components/isolated/isolated-frame.tsx
+++ b/src/components/isolated/isolated-frame.tsx
@@ -44,6 +44,14 @@ export interface IsolatedFrameProps {
   maxHeight?: number;
 
   /**
+   * When true, iframe grows to fit content without maxHeight cap.
+   * Use for content that should render fully (e.g., markdown cells).
+   * Takes precedence over maxHeight when enabled.
+   * @default false
+   */
+  autoHeight?: boolean;
+
+  /**
    * Additional CSS classes for the iframe container.
    */
   className?: string;
@@ -192,6 +200,7 @@ export const IsolatedFrame = forwardRef<
     darkMode = true,
     minHeight = 24,
     maxHeight = 2000,
+    autoHeight = false,
     className = "",
     onReady,
     onResize,
@@ -329,10 +338,9 @@ export const IsolatedFrame = forwardRef<
 
         case "resize":
           if (data.payload?.height != null) {
-            const newHeight = Math.max(
-              minHeight,
-              Math.min(maxHeight, data.payload.height),
-            );
+            const newHeight = autoHeight
+              ? Math.max(minHeight, data.payload.height)
+              : Math.max(minHeight, Math.min(maxHeight, data.payload.height));
             setHeight(newHeight);
             onResize?.(newHeight);
           }
@@ -379,6 +387,7 @@ export const IsolatedFrame = forwardRef<
     initialContent,
     minHeight,
     maxHeight,
+    autoHeight,
     onReady,
     onResize,
     onLinkClick,

--- a/src/components/isolated/isolated-frame.tsx
+++ b/src/components/isolated/isolated-frame.tsx
@@ -39,6 +39,7 @@ export interface IsolatedFrameProps {
 
   /**
    * Maximum height of the iframe in pixels.
+   * Ignored when `autoHeight` is `true`.
    * @default 2000
    */
   maxHeight?: number;


### PR DESCRIPTION
Markdown cells should render at their natural height without scrollbar overflow. This PR adds an `autoHeight` prop to `IsolatedFrame` that bypasses the `maxHeight` cap, allowing full content rendering.

When enabled, `autoHeight` takes precedence over `maxHeight`, allowing markdown cells and other content to expand to their natural size instead of capping at 2000px.

## Changes
- Add `autoHeight` prop to `IsolatedFrame` component
- Update `MarkdownCell` to use `autoHeight` instead of `maxHeight={2000}`
- Resize handler now respects `autoHeight` when calculating frame height

## Verification
- [x] Open a notebook with a markdown cell containing long content
- [x] Switch between edit and view mode
- [x] Verify markdown renders without scrollbar
- [x] Verify code cell outputs still scroll correctly (use OutputArea with maxHeight)

_PR submitted by @rgbkrk's agent, Quill_