### PR TITLE
feat(toolbar): insert cells after focused cell

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -949,6 +949,8 @@ function AppContent() {
         onRestartKernel={handleRestartKernel}
         onRunAllCells={handleRunAllCells}
         onRestartAndRunAll={handleRestartAndRunAll}
+        focusedCellId={focusedCellId}
+        lastCellId={cells.length > 0 ? cells[cells.length - 1].id : null}
         onAddCell={handleAddCell}
         onToggleDependencies={() => setDependencyHeaderOpen((prev) => !prev)}
         isDepsOpen={dependencyHeaderOpen}

--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -161,7 +161,9 @@ interface NotebookToolbarProps {
   onRestartKernel: () => void;
   onRunAllCells: () => void;
   onRestartAndRunAll: () => void;
-  onAddCell: (type: "code" | "markdown") => void;
+  focusedCellId?: string | null;
+  lastCellId?: string | null;
+  onAddCell: (type: "code" | "markdown", afterCellId?: string | null) => void;
   onToggleDependencies: () => void;
   isDepsOpen?: boolean;
   listKernelspecs?: () => Promise<KernelspecInfo[]>;
@@ -291,6 +293,8 @@ export function NotebookToolbar({
   onRestartKernel,
   onRunAllCells,
   onRestartAndRunAll,
+  focusedCellId,
+  lastCellId,
   onAddCell,
   onToggleDependencies,
   isDepsOpen = false,
@@ -375,7 +379,7 @@ export function NotebookToolbar({
           {/* Add cells */}
           <button
             type="button"
-            onClick={() => onAddCell("code")}
+            onClick={() => onAddCell("code", focusedCellId ?? lastCellId)}
             className="flex items-center gap-1 rounded px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
             title="Add code cell"
             data-testid="add-code-cell-button"
@@ -385,7 +389,7 @@ export function NotebookToolbar({
           </button>
           <button
             type="button"
-            onClick={() => onAddCell("markdown")}
+            onClick={() => onAddCell("markdown", focusedCellId ?? lastCellId)}
             className="flex items-center gap-1 rounded px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
             title="Add markdown cell"
             data-testid="add-markdown-cell-button"


### PR DESCRIPTION
The toolbar's +Code and +Markdown buttons now insert new cells after the currently focused cell, instead of always prepending at the top. If no cell is focused, the new cell is inserted after the last cell (or at the top if the notebook is empty).

This matches the intuitive behavior of the inline "Add Cell" buttons that appear between cells.

## Verification

- [x] Focus a cell and click +Code — new cell appears below focused cell
- [x] Focus a cell and click +Markdown — new cell appears below focused cell
- [x] Click outside cells to unfocus, then click +Code — new cell appears at bottom
- [x] Create a new notebook and click +Code — cell is added

_PR submitted by @rgbkrk's agent, Quill_