### PR TITLE
refactor(notebook): use shared metadata ops from notebook-doc in TS frontend and Python bindings

### DIFF
--- a/apps/notebook/src/lib/notebook-metadata.ts
+++ b/apps/notebook/src/lib/notebook-metadata.ts
@@ -85,36 +85,16 @@ export function useNotebookMetadata(): NotebookMetadataSnapshot | null {
 /**
  * React hook: detect the notebook runtime from metadata.
  * Returns "python", "deno", or null.
+ *
+ * Delegates to the canonical Rust implementation via WASM
+ * (NotebookMetadataSnapshot::detect_runtime). The useSyncExternalStore
+ * subscription ensures React re-renders when metadata changes.
  */
 export function useDetectRuntime(): "python" | "deno" | null {
-  const snapshot = useNotebookMetadata();
-  if (!snapshot) return null;
-
-  // Check kernelspec.name first
-  if (snapshot.kernelspec) {
-    const name = snapshot.kernelspec.name.toLowerCase();
-    if (name.includes("deno")) return "deno";
-    if (name.includes("python")) return "python";
-    // Check kernelspec.language
-    if (snapshot.kernelspec.language) {
-      const lang = snapshot.kernelspec.language.toLowerCase();
-      if (lang === "typescript" || lang === "javascript") return "deno";
-      if (lang === "python") return "python";
-    }
-  }
-
-  // Fall back to language_info.name
-  if (snapshot.language_info) {
-    const name = snapshot.language_info.name.toLowerCase();
-    if (name === "deno" || name === "typescript" || name === "javascript")
-      return "deno";
-    if (name === "python") return "python";
-  }
-
-  // Fall back to runt.deno existing (legacy notebooks without kernelspec)
-  if (snapshot.runt.deno) return "deno";
-
-  return null;
+  // Subscribe to metadata changes so we re-render when the doc updates.
+  useSyncExternalStore(subscribe, getSnapshotJson);
+  if (!_handle) return null;
+  return (_handle.detect_runtime() as "python" | "deno") ?? null;
 }
 
 /**
@@ -214,32 +194,19 @@ export interface NotebookMetadataSnapshot {
 }
 
 // ---------------------------------------------------------------------------
-// Imperative read — used by write helpers that need the current snapshot.
-// Prefer the React hooks (useNotebookMetadata, etc.) for component reads.
-// ---------------------------------------------------------------------------
-
-/**
- * Read the full typed metadata snapshot imperatively.
- * Used internally by write helpers. Components should use useNotebookMetadata().
- */
-function getMetadataSnapshot(): NotebookMetadataSnapshot | null {
-  if (!_handle) return null;
-  const json = _handle.get_metadata_snapshot_json();
-  if (!json) return null;
-  try {
-    return JSON.parse(json) as NotebookMetadataSnapshot;
-  } catch {
-    return null;
-  }
-}
-
-// ---------------------------------------------------------------------------
 // Write functions — mutate the WASM doc and sync to the Tauri relay.
+//
+// Dependency mutations (add/remove/clear) delegate to the canonical Rust
+// implementations via WASM (NotebookMetadataSnapshot methods in notebook-doc).
+// The WASM handle mutates the local Automerge doc, then we sync + notify.
 // ---------------------------------------------------------------------------
 
 /**
  * Write a metadata snapshot to the WASM doc and sync to the daemon.
  * After this returns, the WASM doc has the update and a sync message has been sent to the daemon.
+ *
+ * Prefer the typed mutation functions below for dependency writes. This is
+ * still useful for bulk metadata writes (e.g. import flows).
  */
 export async function setMetadataSnapshot(
   snapshot: NotebookMetadataSnapshot,
@@ -271,72 +238,41 @@ async function syncToRelay(): Promise<void> {
 }
 
 // ---------------------------------------------------------------------------
-// Package name extraction for dedup (ported from Rust).
-// ---------------------------------------------------------------------------
-
-/**
- * Extract the base package name from a dependency specifier.
- * "pandas>=2.0" → "pandas", "numpy" → "numpy", "requests[security]" → "requests"
- */
-function extractPackageName(spec: string): string {
-  return spec.split(/[>=<!~[;@\s]/)[0].toLowerCase();
-}
-
-// ---------------------------------------------------------------------------
 // UV dependency write helpers.
+//
+// These delegate to the canonical Rust implementations in notebook-doc via
+// WASM. Dedup, case-insensitive matching, and field preservation are handled
+// in Rust — the TS layer just calls the WASM method, syncs, and notifies.
 // ---------------------------------------------------------------------------
 
 /**
  * Add a UV dependency, deduplicating by package name (case-insensitive).
- * Returns the updated dependencies list, or null on failure.
  */
-export async function addUvDependency(pkg: string): Promise<string[] | null> {
-  const snapshot = getMetadataSnapshot();
-  if (!snapshot) return null;
-
-  const uv = snapshot.runt.uv ?? { dependencies: [] };
-  const name = extractPackageName(pkg);
-
-  // Deduplicate: replace existing entry for the same package
-  const filtered = uv.dependencies.filter(
-    (d) => extractPackageName(d) !== name,
-  );
-  filtered.push(pkg);
-
-  snapshot.runt.uv = { ...uv, dependencies: filtered };
-  const ok = await setMetadataSnapshot(snapshot);
-  return ok ? filtered : null;
+export async function addUvDependency(pkg: string): Promise<void> {
+  if (!_handle) return;
+  _handle.add_uv_dependency(pkg);
+  await syncToRelay();
+  notifyMetadataChanged();
 }
 
 /**
  * Remove a UV dependency by package name (case-insensitive match).
- * Returns the updated dependencies list, or null on failure.
  */
-export async function removeUvDependency(
-  pkg: string,
-): Promise<string[] | null> {
-  const snapshot = getMetadataSnapshot();
-  if (!snapshot?.runt?.uv) return null;
-
-  const name = extractPackageName(pkg);
-  const filtered = snapshot.runt.uv.dependencies.filter(
-    (d) => extractPackageName(d) !== name,
-  );
-
-  snapshot.runt.uv = { ...snapshot.runt.uv, dependencies: filtered };
-  const ok = await setMetadataSnapshot(snapshot);
-  return ok ? filtered : null;
+export async function removeUvDependency(pkg: string): Promise<void> {
+  if (!_handle) return;
+  _handle.remove_uv_dependency(pkg);
+  await syncToRelay();
+  notifyMetadataChanged();
 }
 
 /**
  * Clear the UV dependency section entirely.
  */
-export async function clearUvSection(): Promise<boolean> {
-  const snapshot = getMetadataSnapshot();
-  if (!snapshot) return false;
-
-  delete snapshot.runt.uv;
-  return setMetadataSnapshot(snapshot);
+export async function clearUvSection(): Promise<void> {
+  if (!_handle) return;
+  _handle.clear_uv_section();
+  await syncToRelay();
+  notifyMetadataChanged();
 }
 
 /**
@@ -344,16 +280,11 @@ export async function clearUvSection(): Promise<boolean> {
  */
 export async function setUvRequiresPython(
   requiresPython: string | null,
-): Promise<boolean> {
-  const snapshot = getMetadataSnapshot();
-  if (!snapshot?.runt?.uv) return false;
-
-  if (requiresPython) {
-    snapshot.runt.uv["requires-python"] = requiresPython;
-  } else {
-    delete snapshot.runt.uv["requires-python"];
-  }
-  return setMetadataSnapshot(snapshot);
+): Promise<void> {
+  if (!_handle) return;
+  _handle.set_uv_requires_python(requiresPython ?? undefined);
+  await syncToRelay();
+  notifyMetadataChanged();
 }
 
 // ---------------------------------------------------------------------------
@@ -363,97 +294,60 @@ export async function setUvRequiresPython(
 /**
  * Add a Conda dependency, deduplicating by package name (case-insensitive).
  */
-export async function addCondaDependency(
-  pkg: string,
-): Promise<string[] | null> {
-  const snapshot = getMetadataSnapshot();
-  if (!snapshot) return null;
-
-  const conda = snapshot.runt.conda ?? {
-    dependencies: [],
-    channels: ["conda-forge"],
-  };
-  const name = extractPackageName(pkg);
-
-  const filtered = conda.dependencies.filter(
-    (d) => extractPackageName(d) !== name,
-  );
-  filtered.push(pkg);
-
-  snapshot.runt.conda = { ...conda, dependencies: filtered };
-  const ok = await setMetadataSnapshot(snapshot);
-  return ok ? filtered : null;
+export async function addCondaDependency(pkg: string): Promise<void> {
+  if (!_handle) return;
+  _handle.add_conda_dependency(pkg);
+  await syncToRelay();
+  notifyMetadataChanged();
 }
 
 /**
  * Remove a Conda dependency by package name.
  */
-export async function removeCondaDependency(
-  pkg: string,
-): Promise<string[] | null> {
-  const snapshot = getMetadataSnapshot();
-  if (!snapshot?.runt?.conda) return null;
-
-  const name = extractPackageName(pkg);
-  const filtered = snapshot.runt.conda.dependencies.filter(
-    (d) => extractPackageName(d) !== name,
-  );
-
-  snapshot.runt.conda = { ...snapshot.runt.conda, dependencies: filtered };
-  const ok = await setMetadataSnapshot(snapshot);
-  return ok ? filtered : null;
+export async function removeCondaDependency(pkg: string): Promise<void> {
+  if (!_handle) return;
+  _handle.remove_conda_dependency(pkg);
+  await syncToRelay();
+  notifyMetadataChanged();
 }
 
 /**
  * Clear the Conda dependency section entirely.
  */
-export async function clearCondaSection(): Promise<boolean> {
-  const snapshot = getMetadataSnapshot();
-  if (!snapshot) return false;
-
-  delete snapshot.runt.conda;
-  return setMetadataSnapshot(snapshot);
+export async function clearCondaSection(): Promise<void> {
+  if (!_handle) return;
+  _handle.clear_conda_section();
+  await syncToRelay();
+  notifyMetadataChanged();
 }
 
 /**
  * Set Conda channels, preserving other conda fields.
  * Creates the conda section if it doesn't exist yet.
  */
-export async function setCondaChannels(channels: string[]): Promise<boolean> {
-  const snapshot = getMetadataSnapshot();
-  if (!snapshot) return false;
-
-  const conda = snapshot.runt.conda ?? {
-    dependencies: [],
-    channels: [],
-  };
-  snapshot.runt.conda = { ...conda, channels };
-  return setMetadataSnapshot(snapshot);
+export async function setCondaChannels(channels: string[]): Promise<void> {
+  if (!_handle) return;
+  _handle.set_conda_channels(JSON.stringify(channels));
+  await syncToRelay();
+  notifyMetadataChanged();
 }
 
 /**
  * Set Conda python version, preserving other conda fields.
  * Creates the conda section if it doesn't exist yet.
  */
-export async function setCondaPython(python: string | null): Promise<boolean> {
-  const snapshot = getMetadataSnapshot();
-  if (!snapshot) return false;
-
-  const conda = snapshot.runt.conda ?? {
-    dependencies: [],
-    channels: ["conda-forge"],
-  };
-  if (python) {
-    conda.python = python;
-  } else {
-    delete conda.python;
-  }
-  snapshot.runt.conda = conda;
-  return setMetadataSnapshot(snapshot);
+export async function setCondaPython(python: string | null): Promise<void> {
+  if (!_handle) return;
+  _handle.set_conda_python(python ?? undefined);
+  await syncToRelay();
+  notifyMetadataChanged();
 }
 
 // ---------------------------------------------------------------------------
 // Deno config write helpers.
+//
+// setDenoFlexibleNpmImports still uses the bulk setMetadataSnapshot path
+// since there's no dedicated WASM method for it yet.
 // ---------------------------------------------------------------------------
 
 /**
@@ -462,16 +356,21 @@ export async function setCondaPython(python: string | null): Promise<boolean> {
 export async function setDenoFlexibleNpmImports(
   enabled: boolean,
 ): Promise<boolean> {
-  const snapshot = getMetadataSnapshot();
-  if (!snapshot) return false;
-
-  if (!snapshot.runt.deno) {
-    snapshot.runt.deno = { permissions: [], flexible_npm_imports: enabled };
-  } else {
-    snapshot.runt.deno = {
-      ...snapshot.runt.deno,
-      flexible_npm_imports: enabled,
-    };
+  if (!_handle) return false;
+  const json = _handle.get_metadata_snapshot_json();
+  if (!json) return false;
+  try {
+    const snapshot = JSON.parse(json) as NotebookMetadataSnapshot;
+    if (!snapshot.runt.deno) {
+      snapshot.runt.deno = { permissions: [], flexible_npm_imports: enabled };
+    } else {
+      snapshot.runt.deno = {
+        ...snapshot.runt.deno,
+        flexible_npm_imports: enabled,
+      };
+    }
+    return setMetadataSnapshot(snapshot);
+  } catch {
+    return false;
   }
-  return setMetadataSnapshot(snapshot);
 }

--- a/apps/notebook/src/lib/notebook-metadata.ts
+++ b/apps/notebook/src/lib/notebook-metadata.ts
@@ -260,7 +260,8 @@ export async function addUvDependency(pkg: string): Promise<void> {
  */
 export async function removeUvDependency(pkg: string): Promise<void> {
   if (!_handle) return;
-  _handle.remove_uv_dependency(pkg);
+  const removed = _handle.remove_uv_dependency(pkg);
+  if (!removed) return;
   await syncToRelay();
   notifyMetadataChanged();
 }
@@ -306,7 +307,8 @@ export async function addCondaDependency(pkg: string): Promise<void> {
  */
 export async function removeCondaDependency(pkg: string): Promise<void> {
   if (!_handle) return;
-  _handle.remove_conda_dependency(pkg);
+  const removed = _handle.remove_conda_dependency(pkg);
+  if (!removed) return;
   await syncToRelay();
   notifyMetadataChanged();
 }

--- a/crates/runtimed-py/src/async_session.rs
+++ b/crates/runtimed-py/src/async_session.rs
@@ -805,10 +805,14 @@ impl AsyncSession {
 
     /// Add a UV dependency to the notebook.
     ///
+    /// Deduplicates by package name (case-insensitive): if a dependency with the
+    /// same package name already exists, it is replaced with the new specifier.
+    ///
     /// Args:
     ///     package: PEP 508 dependency specifier (e.g., "pandas>=2.0", "requests").
     ///
-    /// Returns a coroutine that resolves to the updated list of dependencies.
+    /// Returns a coroutine that resolves to None. Callers should use
+    /// `get_uv_dependencies()` to read current state.
     fn add_uv_dependency<'py>(
         &self,
         py: Python<'py>,
@@ -825,12 +829,12 @@ impl AsyncSession {
         })
     }
 
-    /// Remove a UV dependency by exact match.
+    /// Remove a UV dependency by package name (case-insensitive, version-agnostic).
     ///
     /// Args:
-    ///     package: Exact dependency string to remove.
+    ///     package: Package name to remove (e.g., "pandas"). Version specifiers are ignored.
     ///
-    /// Returns a coroutine that resolves to the updated list of dependencies.
+    /// Returns a coroutine that resolves to bool indicating if a dependency was removed.
     fn remove_uv_dependency<'py>(
         &self,
         py: Python<'py>,
@@ -867,10 +871,14 @@ impl AsyncSession {
 
     /// Add a Conda dependency to the notebook.
     ///
+    /// Deduplicates by package name (case-insensitive): if a dependency with the
+    /// same package name already exists, it is replaced with the new specifier.
+    ///
     /// Args:
     ///     package: Conda package specifier (e.g., "numpy", "scipy>=1.0").
     ///
-    /// Returns a coroutine that resolves to the updated list of dependencies.
+    /// Returns a coroutine that resolves to None. Callers should use
+    /// `get_conda_dependencies()` to read current state.
     fn add_conda_dependency<'py>(
         &self,
         py: Python<'py>,
@@ -887,12 +895,12 @@ impl AsyncSession {
         })
     }
 
-    /// Remove a Conda dependency by exact match.
+    /// Remove a Conda dependency by package name (case-insensitive, version-agnostic).
     ///
     /// Args:
-    ///     package: Exact dependency string to remove.
+    ///     package: Package name to remove (e.g., "numpy"). Version specifiers are ignored.
     ///
-    /// Returns a coroutine that resolves to the updated list of dependencies.
+    /// Returns a coroutine that resolves to bool indicating if a dependency was removed.
     fn remove_conda_dependency<'py>(
         &self,
         py: Python<'py>,

--- a/crates/runtimed-py/src/async_session.rs
+++ b/crates/runtimed-py/src/async_session.rs
@@ -21,9 +21,7 @@ use crate::output::{Cell, ExecutionResult, NotebookConnectionInfo, Output, SyncE
 use crate::output_resolver;
 use crate::subscription::EventSubscription;
 
-use notebook_doc::metadata::{
-    CondaInlineMetadata, NotebookMetadataSnapshot, RuntMetadata, UvInlineMetadata,
-};
+use notebook_doc::metadata::NotebookMetadataSnapshot;
 
 /// An async session for executing code via the runtimed daemon.
 ///
@@ -821,21 +819,9 @@ impl AsyncSession {
 
         future_into_py(py, async move {
             let mut snapshot = get_notebook_metadata_async(&state).await?;
-
-            let mut deps = snapshot
-                .runt
-                .uv
-                .map(|uv| uv.dependencies)
-                .unwrap_or_default();
-            deps.push(package);
-
-            snapshot.runt.uv = Some(UvInlineMetadata {
-                dependencies: deps.clone(),
-                requires_python: None,
-            });
-
+            snapshot.add_uv_dependency(&package);
             set_notebook_metadata_async(&state, &snapshot).await?;
-            Ok(deps)
+            Ok(())
         })
     }
 
@@ -855,21 +841,11 @@ impl AsyncSession {
 
         future_into_py(py, async move {
             let mut snapshot = get_notebook_metadata_async(&state).await?;
-
-            let mut deps = snapshot
-                .runt
-                .uv
-                .map(|uv| uv.dependencies)
-                .unwrap_or_default();
-            deps.retain(|dep| dep != &package);
-
-            snapshot.runt.uv = Some(UvInlineMetadata {
-                dependencies: deps.clone(),
-                requires_python: None,
-            });
-
-            set_notebook_metadata_async(&state, &snapshot).await?;
-            Ok(deps)
+            let removed = snapshot.remove_uv_dependency(&package);
+            if removed {
+                set_notebook_metadata_async(&state, &snapshot).await?;
+            }
+            Ok(removed)
         })
     }
 
@@ -905,24 +881,9 @@ impl AsyncSession {
 
         future_into_py(py, async move {
             let mut snapshot = get_notebook_metadata_async(&state).await?;
-
-            let existing = snapshot.runt.conda.unwrap_or(CondaInlineMetadata {
-                dependencies: vec![],
-                channels: vec!["conda-forge".to_string()],
-                python: None,
-            });
-
-            let mut deps = existing.dependencies;
-            deps.push(package);
-
-            snapshot.runt.conda = Some(CondaInlineMetadata {
-                dependencies: deps.clone(),
-                channels: existing.channels,
-                python: existing.python,
-            });
-
+            snapshot.add_conda_dependency(&package);
             set_notebook_metadata_async(&state, &snapshot).await?;
-            Ok(deps)
+            Ok(())
         })
     }
 
@@ -942,24 +903,11 @@ impl AsyncSession {
 
         future_into_py(py, async move {
             let mut snapshot = get_notebook_metadata_async(&state).await?;
-
-            let existing = snapshot.runt.conda.unwrap_or(CondaInlineMetadata {
-                dependencies: vec![],
-                channels: vec!["conda-forge".to_string()],
-                python: None,
-            });
-
-            let mut deps = existing.dependencies;
-            deps.retain(|dep| dep != &package);
-
-            snapshot.runt.conda = Some(CondaInlineMetadata {
-                dependencies: deps.clone(),
-                channels: existing.channels,
-                python: existing.python,
-            });
-
-            set_notebook_metadata_async(&state, &snapshot).await?;
-            Ok(deps)
+            let removed = snapshot.remove_conda_dependency(&package);
+            if removed {
+                set_notebook_metadata_async(&state, &snapshot).await?;
+            }
+            Ok(removed)
         })
     }
 
@@ -2184,21 +2132,7 @@ async fn get_notebook_metadata_async(
         .as_ref()
         .ok_or_else(|| to_py_err("Not connected"))?;
 
-    Ok(handle
-        .get_notebook_metadata()
-        .unwrap_or_else(|| NotebookMetadataSnapshot {
-            kernelspec: None,
-            language_info: None,
-            runt: RuntMetadata {
-                schema_version: "1".to_string(),
-                env_id: None,
-                uv: None,
-                conda: None,
-                deno: None,
-                trust_signature: None,
-                trust_timestamp: None,
-            },
-        }))
+    Ok(handle.get_notebook_metadata().unwrap_or_default())
 }
 
 /// Set the notebook metadata snapshot asynchronously.

--- a/crates/runtimed-py/src/session.rs
+++ b/crates/runtimed-py/src/session.rs
@@ -20,9 +20,7 @@ use crate::output::{Cell, ExecutionResult, NotebookConnectionInfo, Output, SyncE
 use crate::output_resolver;
 use crate::subscription::EventIteratorSubscription;
 
-use notebook_doc::metadata::{
-    CondaInlineMetadata, NotebookMetadataSnapshot, RuntMetadata, UvInlineMetadata,
-};
+use notebook_doc::metadata::NotebookMetadataSnapshot;
 
 /// A session for executing code via the runtimed daemon.
 ///
@@ -683,24 +681,10 @@ impl Session {
     ///
     /// Returns:
     ///     Updated list of dependencies.
-    fn add_uv_dependency(&self, package: &str) -> PyResult<Vec<String>> {
+    fn add_uv_dependency(&self, package: &str) -> PyResult<()> {
         let mut snapshot = self.get_notebook_metadata()?;
-
-        let mut deps = snapshot
-            .runt
-            .uv
-            .map(|uv| uv.dependencies)
-            .unwrap_or_default();
-
-        deps.push(package.to_string());
-
-        snapshot.runt.uv = Some(UvInlineMetadata {
-            dependencies: deps.clone(),
-            requires_python: None,
-        });
-
-        self.set_notebook_metadata(&snapshot)?;
-        Ok(deps)
+        snapshot.add_uv_dependency(package);
+        self.set_notebook_metadata(&snapshot)
     }
 
     /// Remove a UV dependency by exact match.
@@ -710,23 +694,13 @@ impl Session {
     ///
     /// Returns:
     ///     Updated list of dependencies.
-    fn remove_uv_dependency(&self, package: &str) -> PyResult<Vec<String>> {
+    fn remove_uv_dependency(&self, package: &str) -> PyResult<bool> {
         let mut snapshot = self.get_notebook_metadata()?;
-
-        let mut deps = snapshot
-            .runt
-            .uv
-            .map(|uv| uv.dependencies)
-            .unwrap_or_default();
-        deps.retain(|dep| dep != package);
-
-        snapshot.runt.uv = Some(UvInlineMetadata {
-            dependencies: deps.clone(),
-            requires_python: None,
-        });
-
-        self.set_notebook_metadata(&snapshot)?;
-        Ok(deps)
+        let removed = snapshot.remove_uv_dependency(package);
+        if removed {
+            self.set_notebook_metadata(&snapshot)?;
+        }
+        Ok(removed)
     }
 
     /// Get current Conda dependencies.
@@ -749,26 +723,10 @@ impl Session {
     ///
     /// Returns:
     ///     Updated list of dependencies.
-    fn add_conda_dependency(&self, package: &str) -> PyResult<Vec<String>> {
+    fn add_conda_dependency(&self, package: &str) -> PyResult<()> {
         let mut snapshot = self.get_notebook_metadata()?;
-
-        let existing = snapshot.runt.conda.unwrap_or(CondaInlineMetadata {
-            dependencies: vec![],
-            channels: vec!["conda-forge".to_string()],
-            python: None,
-        });
-
-        let mut deps = existing.dependencies;
-        deps.push(package.to_string());
-
-        snapshot.runt.conda = Some(CondaInlineMetadata {
-            dependencies: deps.clone(),
-            channels: existing.channels,
-            python: existing.python,
-        });
-
-        self.set_notebook_metadata(&snapshot)?;
-        Ok(deps)
+        snapshot.add_conda_dependency(package);
+        self.set_notebook_metadata(&snapshot)
     }
 
     /// Remove a Conda dependency by exact match.
@@ -778,26 +736,13 @@ impl Session {
     ///
     /// Returns:
     ///     Updated list of dependencies.
-    fn remove_conda_dependency(&self, package: &str) -> PyResult<Vec<String>> {
+    fn remove_conda_dependency(&self, package: &str) -> PyResult<bool> {
         let mut snapshot = self.get_notebook_metadata()?;
-
-        let existing = snapshot.runt.conda.unwrap_or(CondaInlineMetadata {
-            dependencies: vec![],
-            channels: vec!["conda-forge".to_string()],
-            python: None,
-        });
-
-        let mut deps = existing.dependencies;
-        deps.retain(|dep| dep != package);
-
-        snapshot.runt.conda = Some(CondaInlineMetadata {
-            dependencies: deps.clone(),
-            channels: existing.channels,
-            python: existing.python,
-        });
-
-        self.set_notebook_metadata(&snapshot)?;
-        Ok(deps)
+        let removed = snapshot.remove_conda_dependency(package);
+        if removed {
+            self.set_notebook_metadata(&snapshot)?;
+        }
+        Ok(removed)
     }
 
     // =========================================================================
@@ -1682,21 +1627,7 @@ impl Session {
             .as_ref()
             .ok_or_else(|| to_py_err("Not connected"))?;
 
-        Ok(handle
-            .get_notebook_metadata()
-            .unwrap_or_else(|| NotebookMetadataSnapshot {
-                kernelspec: None,
-                language_info: None,
-                runt: RuntMetadata {
-                    schema_version: "1".to_string(),
-                    env_id: None,
-                    uv: None,
-                    conda: None,
-                    deno: None,
-                    trust_signature: None,
-                    trust_timestamp: None,
-                },
-            }))
+        Ok(handle.get_notebook_metadata().unwrap_or_default())
     }
 
     /// Set the notebook metadata snapshot.

--- a/crates/runtimed-py/src/session.rs
+++ b/crates/runtimed-py/src/session.rs
@@ -674,26 +674,29 @@ impl Session {
             .unwrap_or_default())
     }
 
-    /// Add a UV dependency to the notebook.
+    /// Add a UV dependency to the notebook. Deduplicates by package name
+    /// (case-insensitive): if the package already exists, its specifier is
+    /// replaced rather than appended.
     ///
     /// Args:
     ///     package: PEP 508 dependency specifier (e.g., "pandas>=2.0", "requests").
     ///
     /// Returns:
-    ///     Updated list of dependencies.
+    ///     None. Use `get_uv_dependencies()` to read the current state.
     fn add_uv_dependency(&self, package: &str) -> PyResult<()> {
         let mut snapshot = self.get_notebook_metadata()?;
         snapshot.add_uv_dependency(package);
         self.set_notebook_metadata(&snapshot)
     }
 
-    /// Remove a UV dependency by exact match.
+    /// Remove a UV dependency by package name (case-insensitive, version-agnostic).
     ///
     /// Args:
-    ///     package: Exact dependency string to remove.
+    ///     package: Package name to remove (e.g., "requests"). Version specifiers
+    ///         are ignored — any entry matching the package name is removed.
     ///
     /// Returns:
-    ///     Updated list of dependencies.
+    ///     bool: True if a dependency was removed, False if not found.
     fn remove_uv_dependency(&self, package: &str) -> PyResult<bool> {
         let mut snapshot = self.get_notebook_metadata()?;
         let removed = snapshot.remove_uv_dependency(package);
@@ -716,26 +719,29 @@ impl Session {
             .unwrap_or_default())
     }
 
-    /// Add a Conda dependency to the notebook.
+    /// Add a Conda dependency to the notebook. Deduplicates by package name
+    /// (case-insensitive): if the package already exists, its specifier is
+    /// replaced rather than appended.
     ///
     /// Args:
     ///     package: Conda package specifier (e.g., "numpy", "scipy>=1.0").
     ///
     /// Returns:
-    ///     Updated list of dependencies.
+    ///     None. Use `get_conda_dependencies()` to read the current state.
     fn add_conda_dependency(&self, package: &str) -> PyResult<()> {
         let mut snapshot = self.get_notebook_metadata()?;
         snapshot.add_conda_dependency(package);
         self.set_notebook_metadata(&snapshot)
     }
 
-    /// Remove a Conda dependency by exact match.
+    /// Remove a Conda dependency by package name (case-insensitive, version-agnostic).
     ///
     /// Args:
-    ///     package: Exact dependency string to remove.
+    ///     package: Package name to remove (e.g., "numpy"). Version specifiers
+    ///         are ignored — any entry matching the package name is removed.
     ///
     /// Returns:
-    ///     Updated list of dependencies.
+    ///     bool: True if a dependency was removed, False if not found.
     fn remove_conda_dependency(&self, package: &str) -> PyResult<bool> {
         let mut snapshot = self.get_notebook_metadata()?;
         let removed = snapshot.remove_conda_dependency(package);


### PR DESCRIPTION
Phases 3 and 4 of the metadata consolidation plan. Follow-up to #655.

## Phase 4: Fix Python bindings

Replaces manual dependency manipulation in `Session` and `AsyncSession` with the shared `NotebookMetadataSnapshot` methods from `notebook-doc`.

**Bug fixes:**
- `add_uv_dependency` no longer clobbers `requires_python` to `None`
- `add_*_dependency` now deduplicates by package name
- `remove_*_dependency` now matches by package name (case-insensitive) instead of exact string match

**Breaking:** `add_*` returns `None` instead of `list[str]`. Callers should use `get_uv_dependencies()` / `get_conda_dependencies()` to read current state.

Also simplifies `get_notebook_metadata` fallback to `unwrap_or_default()`.

-135 lines across `session.rs` and `async_session.rs`.

## Phase 3: Simplify TypeScript frontend

Dependency mutations in `notebook-metadata.ts` now delegate to the canonical Rust implementations via WASM instead of doing read-modify-write JSON manipulation in TypeScript.

**Deleted:**
- `extractPackageName` — dedup handled in Rust
- `getMetadataSnapshot` imperative read — no longer needed
- Manual JSON manipulation in all dep write functions

**Simplified:**
- `useDetectRuntime` delegates to `handle.detect_runtime()` via WASM
- All dep mutation functions are 3-line WASM call + sync + notify
- Return types changed from `Promise<string[] | null>` to `Promise<void>` (callers already ignored return values)

-101 lines in `notebook-metadata.ts`.

## QA plan

Same as #655:
- [x] WASM module loads — cells render, editing works
- [x] Python kernel auto-launches correctly
- [x] Deno kernel auto-launches correctly
- [x] UV dependency add/remove/dedup works
- [x] Conda dependency add/remove works
- [x] New untitled notebook falls through to default runtime

_PR submitted by @rgbkrk's agent, Quill via Zed_