### PR TITLE
Menu bar error tooltips

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -123,6 +123,9 @@ function AppContent() {
   const [showIsolationTest, setShowIsolationTest] = useState(false);
   const [trustDialogOpen, setTrustDialogOpen] = useState(false);
   const [clearingDeps, setClearingDeps] = useState(false);
+  const [kernelErrorMessage, setKernelErrorMessage] = useState<string | null>(
+    null,
+  );
   // Track when sync/restart just completed for success feedback
   const [justSynced, setJustSynced] = useState(false);
 
@@ -271,6 +274,12 @@ function AppContent() {
     onUpdateDisplayData: updateOutputByDisplayId,
     onClearOutputs: clearCellOutputs, // Handle broadcast from other windows
     onCommMessage: handleCommMessage, // Route comm messages to widget store
+    onKernelError: setKernelErrorMessage,
+    onStatusChange: (status) => {
+      if (status !== KERNEL_STATUS.ERROR) {
+        setKernelErrorMessage(null);
+      }
+    },
   });
 
   // Derive values from daemon kernel
@@ -403,6 +412,7 @@ function AppContent() {
     if (info.status === "trusted" || info.status === "no_dependencies") {
       // Trusted - launch kernel via daemon
       // Both kernel_type and env_source use "auto" - daemon detects from Automerge doc
+      setKernelErrorMessage(null);
       const response = await launchKernel("auto", "auto");
       if (response.result === "error") {
         logger.error("[App] tryStartKernel: daemon error", response.error);
@@ -524,6 +534,7 @@ function AppContent() {
       pendingKernelStartRef.current = false;
       // Fire and forget - dialog closes immediately, kernel starts in background
       // Use "auto" for both - daemon detects from Automerge doc
+      setKernelErrorMessage(null);
       launchKernel("auto", "auto").catch((e) => {
         logger.error("[App] kernel launch after trust approval failed:", e);
       });
@@ -539,6 +550,7 @@ function AppContent() {
 
   // Start kernel explicitly with pyproject.toml (user action from DependencyHeader)
   const handleStartKernelWithPyproject = useCallback(async () => {
+    setKernelErrorMessage(null);
     const response = await launchKernel("python", "uv:pyproject");
     if (response.result === "error") {
       logger.error(
@@ -923,6 +935,7 @@ function AppContent() {
       )}
       <NotebookToolbar
         kernelStatus={kernelStatus}
+        kernelErrorMessage={kernelErrorMessage}
         envSource={envSource}
         envTypeHint={envTypeHint}
         dirty={dirty}

--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -20,6 +20,11 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@/components/ui/hover-card";
 import { Slider } from "@/components/ui/slider";
 import type { ThemeMode } from "@/hooks/useSyncedSettings";
 import { isKnownPythonEnv, isKnownRuntime } from "@/hooks/useSyncedSettings";
@@ -351,6 +356,61 @@ export function NotebookToolbar({
             : "uv"
         : (envTypeHint ?? null)
       : null;
+  const showKernelErrorTooltip =
+    !envProgress?.isActive &&
+    !envProgress?.error &&
+    kernelStatus === KERNEL_STATUS.ERROR &&
+    Boolean(kernelErrorMessage?.trim());
+  const kernelStatusAriaLabel = envProgress?.isActive
+    ? envProgress.statusText
+    : envProgress?.error
+      ? envProgress.statusText
+      : showKernelErrorTooltip
+        ? `Error \u2014 ${kernelErrorMessage}`
+        : kernelStatusText;
+  const kernelStatusTitle = envProgress?.isActive
+    ? envProgress.statusText
+    : envProgress?.error
+      ? envProgress.error
+      : showKernelErrorTooltip
+        ? undefined
+        : kernelStatusText;
+  const kernelStatusIndicator = (
+    <>
+      <div
+        className={cn(
+          "h-2 w-2 shrink-0 rounded-full",
+          kernelStatus === KERNEL_STATUS.IDLE && "bg-green-500",
+          kernelStatus === KERNEL_STATUS.BUSY && "bg-amber-500",
+          kernelStatus === KERNEL_STATUS.STARTING &&
+            "bg-blue-500 animate-pulse",
+          isKernelNotStarted && "bg-gray-400 dark:bg-gray-500",
+          kernelStatus === KERNEL_STATUS.ERROR && "bg-red-500",
+        )}
+      />
+      <span className="text-xs text-muted-foreground whitespace-nowrap">
+        {envProgress?.isActive ? (
+          envProgress.statusText
+        ) : envProgress?.error ? (
+          <span className="text-red-600 dark:text-red-400">
+            {envProgress.statusText}
+          </span>
+        ) : (
+          <span
+            className={cn(
+              "capitalize",
+              kernelStatus === KERNEL_STATUS.ERROR &&
+                "text-red-600 dark:text-red-400",
+              showKernelErrorTooltip &&
+                "cursor-help underline decoration-dotted underline-offset-2",
+            )}
+          >
+            {kernelStatusText}
+          </span>
+        )}
+      </span>
+    </>
+  );
 
   return (
     <Collapsible open={settingsOpen} onOpenChange={setSettingsOpen}>
@@ -554,59 +614,44 @@ export function NotebookToolbar({
           </button>
 
           {/* Kernel status */}
-          <div
-            className="flex items-center gap-1.5 whitespace-nowrap"
-            role="status"
-            aria-label={`Kernel: ${
-              envProgress?.isActive
-                ? envProgress.statusText
-                : envProgress?.error
-                  ? envProgress.statusText
-                  : kernelStatus === KERNEL_STATUS.ERROR && kernelErrorMessage
-                    ? `Error \u2014 ${kernelErrorMessage}`
-                    : kernelStatusText
-            }`}
-            title={
-              envProgress?.isActive
-                ? envProgress.statusText
-                : envProgress?.error
-                  ? envProgress.error
-                  : kernelStatus === KERNEL_STATUS.ERROR && kernelErrorMessage
-                    ? `Error \u2014 ${kernelErrorMessage}`
-                    : kernelStatusText
-            }
-          >
-            <div
-              className={cn(
-                "h-2 w-2 shrink-0 rounded-full",
-                kernelStatus === KERNEL_STATUS.IDLE && "bg-green-500",
-                kernelStatus === KERNEL_STATUS.BUSY && "bg-amber-500",
-                kernelStatus === KERNEL_STATUS.STARTING &&
-                  "bg-blue-500 animate-pulse",
-                isKernelNotStarted && "bg-gray-400 dark:bg-gray-500",
-                kernelStatus === KERNEL_STATUS.ERROR && "bg-red-500",
-              )}
-            />
-            <span className="text-xs text-muted-foreground whitespace-nowrap">
-              {envProgress?.isActive ? (
-                envProgress.statusText
-              ) : envProgress?.error ? (
-                <span className="text-red-600 dark:text-red-400">
-                  {envProgress.statusText}
-                </span>
-              ) : (
-                <span
-                  className={cn(
-                    "capitalize",
-                    kernelStatus === KERNEL_STATUS.ERROR &&
-                      "text-red-600 dark:text-red-400",
-                  )}
+          {showKernelErrorTooltip ? (
+            <div role="status" aria-label={`Kernel: ${kernelStatusAriaLabel}`}>
+              <HoverCard openDelay={0} closeDelay={0}>
+                <HoverCardTrigger asChild>
+                  <button
+                    type="button"
+                    aria-label={`Kernel: ${kernelStatusAriaLabel}`}
+                    className="flex items-center gap-1.5 whitespace-nowrap rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                    data-testid="kernel-error-status"
+                  >
+                    {kernelStatusIndicator}
+                  </button>
+                </HoverCardTrigger>
+                <HoverCardContent
+                  align="end"
+                  side="bottom"
+                  className="w-80 max-w-[min(24rem,calc(100vw-1rem))] space-y-1 p-3"
+                  data-testid="kernel-error-tooltip"
                 >
-                  {kernelStatusText}
-                </span>
-              )}
-            </span>
-          </div>
+                  <p className="text-xs font-medium text-red-600 dark:text-red-400">
+                    Kernel error
+                  </p>
+                  <p className="text-xs text-foreground whitespace-pre-wrap break-words">
+                    {kernelErrorMessage}
+                  </p>
+                </HoverCardContent>
+              </HoverCard>
+            </div>
+          ) : (
+            <div
+              className="flex items-center gap-1.5 whitespace-nowrap"
+              role="status"
+              aria-label={`Kernel: ${kernelStatusAriaLabel}`}
+              title={kernelStatusTitle}
+            >
+              {kernelStatusIndicator}
+            </div>
+          )}
 
           <div className="h-4 w-px bg-border" />
 

--- a/apps/notebook/src/components/__tests__/NotebookToolbar.test.tsx
+++ b/apps/notebook/src/components/__tests__/NotebookToolbar.test.tsx
@@ -1,0 +1,52 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { KERNEL_STATUS } from "../../lib/kernel-status";
+import { NotebookToolbar } from "../NotebookToolbar";
+
+const baseProps = {
+  envSource: null,
+  envTypeHint: null,
+  dirty: false,
+  hasDependencies: false,
+  theme: "system" as const,
+  envProgress: null,
+  runtime: "python",
+  onThemeChange: vi.fn(),
+  onSave: vi.fn(),
+  onStartKernel: vi.fn(),
+  onInterruptKernel: vi.fn(),
+  onRestartKernel: vi.fn(),
+  onRunAllCells: vi.fn(),
+  onRestartAndRunAll: vi.fn(),
+  onAddCell: vi.fn(),
+  onToggleDependencies: vi.fn(),
+};
+
+describe("NotebookToolbar kernel errors", () => {
+  it("shows the full kernel error only in a hover tooltip", async () => {
+    const errorMessage =
+      "Failed to start kernel: No such file or directory (os error 2)";
+
+    render(
+      <NotebookToolbar
+        {...baseProps}
+        kernelStatus={KERNEL_STATUS.ERROR}
+        kernelErrorMessage={errorMessage}
+      />,
+    );
+
+    const trigger = screen.getByTestId("kernel-error-status");
+
+    expect(trigger.getAttribute("aria-label")).toBe(
+      `Kernel: Error — ${errorMessage}`,
+    );
+    expect(screen.getByText("error")).toBeTruthy();
+    expect(screen.queryByText(errorMessage)).toBeNull();
+
+    fireEvent.focus(trigger);
+
+    await waitFor(() => {
+      expect(screen.queryByText(errorMessage)).toBeTruthy();
+    });
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Display detailed kernel error messages in a hover tooltip on the toolbar instead of inline, as requested in #578.

---
<p><a href="https://cursor.com/agents/bc-d59b25ed-aa7a-4128-82c5-ad9d6e42177f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d59b25ed-aa7a-4128-82c5-ad9d6e42177f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->