### PR TITLE
Add notebook-tui: A rich TUI for Jupyter notebooks powered by runtimed

### DIFF
--- a/python/notebook-tui/pyproject.toml
+++ b/python/notebook-tui/pyproject.toml
@@ -1,0 +1,20 @@
+[project]
+name = "notebook-tui"
+version = "0.1.0"
+description = "A rich notebook TUI powered by runtimed and Textual"
+requires-python = ">=3.10"
+dependencies = [
+    "runtimed>=0.1.4",
+    "textual>=3.0.0",
+    "rich>=13.0.0",
+]
+
+[project.scripts]
+notebook-tui = "notebook_tui:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.backends"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/notebook_tui"]

--- a/python/notebook-tui/pyproject.toml
+++ b/python/notebook-tui/pyproject.toml
@@ -4,17 +4,20 @@ version = "0.1.0"
 description = "A rich notebook TUI powered by runtimed and Textual"
 requires-python = ">=3.10"
 dependencies = [
-    "runtimed>=0.1.4",
+    "runtimed",
     "textual>=3.0.0",
     "rich>=13.0.0",
 ]
+
+[tool.uv.sources]
+runtimed = { path = "../runtimed", editable = true }
 
 [project.scripts]
 notebook-tui = "notebook_tui:main"
 
 [build-system]
 requires = ["hatchling"]
-build-backend = "hatchling.backends"
+build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/notebook_tui"]

--- a/python/notebook-tui/src/notebook_tui/__init__.py
+++ b/python/notebook-tui/src/notebook_tui/__init__.py
@@ -1,0 +1,8 @@
+"""notebook-tui - A rich notebook TUI powered by runtimed and Textual."""
+
+
+def main():
+    """Entry point for the notebook-tui command."""
+    from notebook_tui.app import run
+
+    run()

--- a/python/notebook-tui/src/notebook_tui/__main__.py
+++ b/python/notebook-tui/src/notebook_tui/__main__.py
@@ -1,0 +1,5 @@
+"""Allow running with: python -m notebook_tui"""
+
+from notebook_tui import main
+
+main()

--- a/python/notebook-tui/src/notebook_tui/app.py
+++ b/python/notebook-tui/src/notebook_tui/app.py
@@ -1,0 +1,841 @@
+"""Main Textual application for the notebook TUI."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from threading import Event as ThreadEvent
+
+import runtimed
+from textual import on, work
+from textual.app import App, ComposeResult
+from textual.binding import Binding
+from textual.containers import Horizontal, Vertical, VerticalScroll
+from textual.css.query import NoMatches
+from textual.reactive import reactive
+from textual.screen import ModalScreen
+from textual.widgets import (
+    Footer,
+    Header,
+    Input,
+    Label,
+    Static,
+    TextArea,
+)
+
+from notebook_tui.widgets import (
+    CellWidget,
+    KernelStatusBar,
+    NotebookTitle,
+)
+
+
+class OpenNotebookScreen(ModalScreen[str | None]):
+    """Modal screen to enter a notebook path."""
+
+    BINDINGS = [Binding("escape", "cancel", "Cancel")]
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="open-dialog"):
+            yield Label("Open Notebook", id="dialog-title")
+            yield Input(
+                placeholder="Path to .ipynb file (or leave empty for new notebook)",
+                id="notebook-path-input",
+            )
+
+    def on_mount(self) -> None:
+        self.query_one("#notebook-path-input", Input).focus()
+
+    @on(Input.Submitted, "#notebook-path-input")
+    def on_submit(self, event: Input.Submitted) -> None:
+        self.dismiss(event.value.strip() or None)
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)
+
+
+class ChangeCellTypeScreen(ModalScreen[str | None]):
+    """Modal to change cell type."""
+
+    BINDINGS = [Binding("escape", "cancel", "Cancel")]
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="cell-type-dialog"):
+            yield Label("Change Cell Type", id="dialog-title")
+            yield Static("[bold]c[/] Code  |  [bold]m[/] Markdown  |  [bold]r[/] Raw")
+
+    def key_c(self) -> None:
+        self.dismiss("code")
+
+    def key_m(self) -> None:
+        self.dismiss("markdown")
+
+    def key_r(self) -> None:
+        self.dismiss("raw")
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)
+
+
+class NotebookApp(App):
+    """A rich notebook TUI powered by runtimed and Textual."""
+
+    TITLE = "notebook-tui"
+    SUB_TITLE = "runtimed"
+
+    CSS = """
+    Screen {
+        background: $surface;
+    }
+
+    #notebook-container {
+        height: 1fr;
+        padding: 0 1;
+    }
+
+    #status-bar {
+        dock: bottom;
+        height: 1;
+        background: $primary-background;
+        color: $text;
+        padding: 0 1;
+    }
+
+    #kernel-status {
+        width: auto;
+        min-width: 20;
+        color: $text-muted;
+    }
+
+    #notebook-title {
+        width: 1fr;
+        text-align: center;
+        color: $text;
+    }
+
+    #cell-count {
+        width: auto;
+        min-width: 10;
+        text-align: right;
+        color: $text-muted;
+    }
+
+    .cell-widget {
+        margin: 0 0 1 0;
+        height: auto;
+        max-height: 100%;
+    }
+
+    .cell-widget.--focused {
+        border: heavy $accent;
+    }
+
+    .cell-widget.--not-focused {
+        border: tall $surface-lighten-2;
+    }
+
+    .cell-widget.--executing {
+        border: heavy $warning;
+    }
+
+    .cell-gutter {
+        width: 6;
+        height: auto;
+        min-height: 3;
+        padding: 0;
+        color: $text-muted;
+        text-align: right;
+    }
+
+    .cell-gutter.--executing {
+        color: $warning;
+    }
+
+    .cell-body {
+        width: 1fr;
+        height: auto;
+    }
+
+    .cell-source {
+        height: auto;
+        min-height: 3;
+        max-height: 30;
+    }
+
+    .cell-source TextArea {
+        height: auto;
+        min-height: 3;
+        max-height: 30;
+    }
+
+    .cell-output {
+        height: auto;
+        max-height: 40;
+        padding: 0 0 0 1;
+        margin: 0;
+    }
+
+    .cell-output-stream {
+        height: auto;
+        color: $text;
+    }
+
+    .cell-output-error {
+        height: auto;
+        color: $error;
+    }
+
+    .cell-output-result {
+        height: auto;
+        color: $success;
+    }
+
+    .cell-type-badge {
+        width: 4;
+        height: 1;
+        padding: 0;
+        text-align: center;
+        text-style: bold;
+    }
+
+    .cell-type-badge.--code {
+        color: $accent;
+    }
+
+    .cell-type-badge.--markdown {
+        color: $success;
+    }
+
+    .cell-type-badge.--raw {
+        color: $text-muted;
+    }
+
+    .empty-notebook {
+        text-align: center;
+        padding: 4;
+        color: $text-muted;
+    }
+
+    #open-dialog, #cell-type-dialog {
+        align: center middle;
+        width: 60;
+        height: auto;
+        max-height: 10;
+        border: thick $accent;
+        background: $surface;
+        padding: 1 2;
+    }
+
+    #dialog-title {
+        text-align: center;
+        text-style: bold;
+        margin-bottom: 1;
+    }
+
+    #notebook-path-input {
+        width: 100%;
+    }
+    """
+
+    BINDINGS = [
+        Binding("ctrl+q", "quit", "Quit", priority=True),
+        Binding("ctrl+s", "save", "Save"),
+        Binding("ctrl+o", "open_notebook", "Open"),
+        Binding("ctrl+n", "new_notebook", "New"),
+        Binding("a", "add_cell_above", "Add Above", show=False),
+        Binding("b", "add_cell_below", "Add Below", show=False),
+        Binding("d,d", "delete_cell", "Delete Cell", show=False),
+        Binding("shift+enter", "execute_cell", "Run Cell", priority=True),
+        Binding("ctrl+enter", "execute_and_next", "Run & Next", priority=True),
+        Binding("ctrl+shift+enter", "run_all", "Run All"),
+        Binding("j", "focus_next_cell", "Next Cell", show=False),
+        Binding("k", "focus_prev_cell", "Prev Cell", show=False),
+        Binding("down", "focus_next_cell", "Next Cell", show=False),
+        Binding("up", "focus_prev_cell", "Prev Cell", show=False),
+        Binding("enter", "enter_edit", "Edit Cell", show=False),
+        Binding("escape", "exit_edit", "Command Mode", priority=True),
+        Binding("ctrl+c", "interrupt_kernel", "Interrupt"),
+        Binding("t", "change_cell_type", "Cell Type", show=False),
+        Binding("ctrl+shift+h", "toggle_help", "Help"),
+    ]
+
+    kernel_status: reactive[str] = reactive("disconnected")
+    focused_cell_index: reactive[int] = reactive(0)
+    edit_mode: reactive[bool] = reactive(False)
+    notebook_path: reactive[str | None] = reactive(None)
+
+    def __init__(
+        self,
+        notebook_path: str | None = None,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self._notebook_path_arg = notebook_path
+        self._session: runtimed.Session | None = None
+        self._cell_ids: list[str] = []
+        self._executing_cells: set[str] = set()
+        self._kernel_ready = ThreadEvent()
+
+    def compose(self) -> ComposeResult:
+        yield Header()
+        with Horizontal(id="status-bar"):
+            yield KernelStatusBar(id="kernel-status")
+            yield NotebookTitle(id="notebook-title")
+            yield Static("0 cells", id="cell-count")
+        yield VerticalScroll(id="notebook-container")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        if self._notebook_path_arg:
+            self._open_notebook(self._notebook_path_arg)
+        else:
+            self._create_new_notebook()
+
+    @work(thread=True, group="session")
+    def _open_notebook(self, path: str) -> None:
+        """Open an existing notebook file."""
+        try:
+            self._session = runtimed.Session.open_notebook(path)
+            self.notebook_path = path
+            self._post_connect()
+        except runtimed.RuntimedError as e:
+            self.notify(f"Error opening notebook: {e}", severity="error")
+
+    @work(thread=True, group="session")
+    def _create_new_notebook(self) -> None:
+        """Create a new empty notebook."""
+        try:
+            self._session = runtimed.Session.create_notebook(runtime="python")
+            self.notebook_path = None
+            self._post_connect()
+        except runtimed.RuntimedError as e:
+            self.notify(f"Error creating notebook: {e}", severity="error")
+
+    def _post_connect(self) -> None:
+        """After connecting, load cells and start kernel."""
+        session = self._session
+        if session is None:
+            return
+
+        self.kernel_status = "connecting"
+        self.call_from_thread(self._update_kernel_status, "connecting")
+
+        # Load existing cells
+        try:
+            cells = session.get_cells()
+            self.call_from_thread(self._load_cells, cells)
+        except runtimed.RuntimedError:
+            pass
+
+        # Start kernel
+        try:
+            session.start_kernel()
+            self.kernel_status = "idle"
+            self.call_from_thread(self._update_kernel_status, "idle")
+            self._kernel_ready.set()
+        except runtimed.RuntimedError as e:
+            self.call_from_thread(self._update_kernel_status, "error")
+            self.call_from_thread(
+                self.notify, f"Kernel start failed: {e}", severity="error"
+            )
+
+        # Start listening for broadcasts
+        self._listen_for_broadcasts()
+
+    def _listen_for_broadcasts(self) -> None:
+        """Listen for daemon broadcasts in background thread."""
+        session = self._session
+        if session is None:
+            return
+
+        try:
+            for event in session.subscribe():
+                self._handle_broadcast(event)
+        except runtimed.RuntimedError:
+            self.call_from_thread(self._update_kernel_status, "disconnected")
+
+    def _handle_broadcast(self, event: runtimed.ExecutionEvent) -> None:
+        """Process a broadcast event from the daemon."""
+        if event.event_type == "execution_started":
+            cell_id = event.cell_id
+            self._executing_cells.add(cell_id)
+            self.call_from_thread(self._mark_cell_executing, cell_id, True)
+            self.call_from_thread(self._update_kernel_status, "busy")
+
+        elif event.event_type == "output":
+            cell_id = event.cell_id
+            output = event.output
+            self.call_from_thread(self._append_output, cell_id, output)
+
+        elif event.event_type == "done":
+            cell_id = event.cell_id
+            self._executing_cells.discard(cell_id)
+            self.call_from_thread(self._mark_cell_executing, cell_id, False)
+            # Refresh execution count
+            if self._session:
+                try:
+                    cell = self._session.get_cell(cell_id)
+                    self.call_from_thread(
+                        self._update_execution_count,
+                        cell_id,
+                        cell.execution_count,
+                    )
+                except runtimed.RuntimedError:
+                    pass
+            if not self._executing_cells:
+                self.call_from_thread(self._update_kernel_status, "idle")
+
+        elif event.event_type == "error":
+            cell_id = event.cell_id
+            if cell_id:
+                self._executing_cells.discard(cell_id)
+                self.call_from_thread(self._mark_cell_executing, cell_id, False)
+            self.call_from_thread(self._update_kernel_status, "idle")
+
+    def _load_cells(self, cells: list[runtimed.Cell]) -> None:
+        """Load cells into the UI."""
+        container = self.query_one("#notebook-container", VerticalScroll)
+        container.remove_children()
+        self._cell_ids.clear()
+
+        if not cells:
+            self._add_empty_placeholder()
+            return
+
+        for cell in cells:
+            self._cell_ids.append(cell.id)
+            widget = CellWidget(
+                cell_id=cell.id,
+                cell_type=cell.cell_type,
+                source=cell.source,
+                execution_count=cell.execution_count,
+                outputs=cell.outputs or [],
+            )
+            container.mount(widget)
+
+        self._update_cell_count()
+        if self._cell_ids:
+            self.focused_cell_index = 0
+            self._focus_cell(0)
+
+    def _add_empty_placeholder(self) -> None:
+        """Show placeholder when notebook is empty."""
+        container = self.query_one("#notebook-container", VerticalScroll)
+        container.mount(
+            Static(
+                "[bold]Empty Notebook[/]\n\n"
+                "Press [bold]b[/] to add a cell\n"
+                "Press [bold]Ctrl+O[/] to open a notebook",
+                classes="empty-notebook",
+            )
+        )
+
+    def _update_kernel_status(self, status: str) -> None:
+        """Update kernel status display."""
+        self.kernel_status = status
+        try:
+            bar = self.query_one("#kernel-status", KernelStatusBar)
+            bar.status = status
+        except NoMatches:
+            pass
+
+    def _update_cell_count(self) -> None:
+        """Update cell count display."""
+        count = len(self._cell_ids)
+        try:
+            label = self.query_one("#cell-count", Static)
+            label.update(f"{count} cell{'s' if count != 1 else ''}")
+        except NoMatches:
+            pass
+
+    def watch_notebook_path(self, path: str | None) -> None:
+        """Update title when notebook path changes."""
+        try:
+            title = self.query_one("#notebook-title", NotebookTitle)
+            if path:
+                title.update(Path(path).name)
+            else:
+                title.update("Untitled Notebook")
+        except NoMatches:
+            pass
+
+    # --- Cell focus management ---
+
+    def _focus_cell(self, index: int) -> None:
+        """Focus a cell by index."""
+        if not self._cell_ids:
+            return
+        index = max(0, min(index, len(self._cell_ids) - 1))
+        self.focused_cell_index = index
+
+        # Update visual focus
+        for i, cell_id in enumerate(self._cell_ids):
+            try:
+                widget = self.query_one(f"#cell-{cell_id}", CellWidget)
+                widget.is_focused_cell = i == index
+            except NoMatches:
+                pass
+
+        # Scroll into view
+        try:
+            cell_id = self._cell_ids[index]
+            widget = self.query_one(f"#cell-{cell_id}", CellWidget)
+            widget.scroll_visible()
+        except (NoMatches, IndexError):
+            pass
+
+    def _get_focused_cell_widget(self) -> CellWidget | None:
+        """Get the currently focused cell widget."""
+        if not self._cell_ids or self.focused_cell_index >= len(self._cell_ids):
+            return None
+        cell_id = self._cell_ids[self.focused_cell_index]
+        try:
+            return self.query_one(f"#cell-{cell_id}", CellWidget)
+        except NoMatches:
+            return None
+
+    def _mark_cell_executing(self, cell_id: str, executing: bool) -> None:
+        """Mark a cell as executing or not."""
+        try:
+            widget = self.query_one(f"#cell-{cell_id}", CellWidget)
+            widget.is_executing = executing
+        except NoMatches:
+            pass
+
+    def _append_output(self, cell_id: str, output: runtimed.Output) -> None:
+        """Append an output to a cell."""
+        try:
+            widget = self.query_one(f"#cell-{cell_id}", CellWidget)
+            widget.append_output(output)
+        except NoMatches:
+            pass
+
+    def _update_execution_count(
+        self, cell_id: str, count: int | None
+    ) -> None:
+        """Update a cell's execution count."""
+        try:
+            widget = self.query_one(f"#cell-{cell_id}", CellWidget)
+            widget.execution_count = count
+        except NoMatches:
+            pass
+
+    # --- Actions ---
+
+    def action_focus_next_cell(self) -> None:
+        if self.edit_mode:
+            return
+        self._focus_cell(self.focused_cell_index + 1)
+
+    def action_focus_prev_cell(self) -> None:
+        if self.edit_mode:
+            return
+        self._focus_cell(self.focused_cell_index - 1)
+
+    def action_enter_edit(self) -> None:
+        """Enter edit mode on the focused cell."""
+        widget = self._get_focused_cell_widget()
+        if widget:
+            self.edit_mode = True
+            widget.enter_edit_mode()
+
+    def action_exit_edit(self) -> None:
+        """Exit edit mode, sync source back to session."""
+        if not self.edit_mode:
+            return
+        self.edit_mode = False
+        widget = self._get_focused_cell_widget()
+        if widget:
+            widget.exit_edit_mode()
+            self._sync_cell_source(widget.cell_id, widget.get_source())
+
+    @work(thread=True)
+    def _sync_cell_source(self, cell_id: str, source: str) -> None:
+        """Sync cell source to daemon."""
+        if self._session:
+            try:
+                self._session.set_source(cell_id, source)
+            except runtimed.RuntimedError as e:
+                self.call_from_thread(
+                    self.notify, f"Sync error: {e}", severity="warning"
+                )
+
+    def action_add_cell_below(self) -> None:
+        """Add a new code cell below the focused cell."""
+        if self.edit_mode:
+            return
+        self._add_cell(self.focused_cell_index + 1)
+
+    def action_add_cell_above(self) -> None:
+        """Add a new code cell above the focused cell."""
+        if self.edit_mode:
+            return
+        self._add_cell(self.focused_cell_index)
+
+    @work(thread=True)
+    def _add_cell(self, index: int) -> None:
+        """Add a new cell at the given index."""
+        if not self._session:
+            return
+        try:
+            cell_id = self._session.create_cell(
+                source="", cell_type="code", index=index
+            )
+            self.call_from_thread(self._insert_cell_widget, cell_id, index, "code")
+        except runtimed.RuntimedError as e:
+            self.call_from_thread(
+                self.notify, f"Error adding cell: {e}", severity="error"
+            )
+
+    def _insert_cell_widget(
+        self, cell_id: str, index: int, cell_type: str
+    ) -> None:
+        """Insert a cell widget at the given index."""
+        container = self.query_one("#notebook-container", VerticalScroll)
+
+        # Remove empty placeholder if present
+        for child in container.children:
+            if "empty-notebook" in child.classes:
+                child.remove()
+                break
+
+        widget = CellWidget(
+            cell_id=cell_id,
+            cell_type=cell_type,
+            source="",
+            execution_count=None,
+            outputs=[],
+        )
+
+        if index >= len(self._cell_ids):
+            container.mount(widget)
+            self._cell_ids.append(cell_id)
+        else:
+            before_id = self._cell_ids[index]
+            try:
+                before_widget = self.query_one(
+                    f"#cell-{before_id}", CellWidget
+                )
+                container.mount(widget, before=before_widget)
+            except NoMatches:
+                container.mount(widget)
+            self._cell_ids.insert(index, cell_id)
+
+        self._update_cell_count()
+        self._focus_cell(index)
+        # Auto-enter edit mode on new cell
+        self.edit_mode = True
+        widget.enter_edit_mode()
+
+    def action_delete_cell(self) -> None:
+        """Delete the focused cell."""
+        if self.edit_mode or not self._cell_ids:
+            return
+        cell_id = self._cell_ids[self.focused_cell_index]
+        self._delete_cell(cell_id, self.focused_cell_index)
+
+    @work(thread=True)
+    def _delete_cell(self, cell_id: str, index: int) -> None:
+        """Delete a cell."""
+        if not self._session:
+            return
+        try:
+            self._session.delete_cell(cell_id)
+            self.call_from_thread(self._remove_cell_widget, cell_id, index)
+        except runtimed.RuntimedError as e:
+            self.call_from_thread(
+                self.notify, f"Error deleting cell: {e}", severity="error"
+            )
+
+    def _remove_cell_widget(self, cell_id: str, index: int) -> None:
+        """Remove a cell widget."""
+        try:
+            widget = self.query_one(f"#cell-{cell_id}", CellWidget)
+            widget.remove()
+        except NoMatches:
+            pass
+
+        if cell_id in self._cell_ids:
+            self._cell_ids.remove(cell_id)
+
+        self._update_cell_count()
+
+        if not self._cell_ids:
+            self._add_empty_placeholder()
+        else:
+            new_index = min(index, len(self._cell_ids) - 1)
+            self._focus_cell(new_index)
+
+    def action_execute_cell(self) -> None:
+        """Execute the focused cell."""
+        # Sync source if in edit mode
+        widget = self._get_focused_cell_widget()
+        if widget and widget.cell_type == "code":
+            if self.edit_mode:
+                widget.exit_edit_mode()
+                self.edit_mode = False
+            source = widget.get_source()
+            self._execute_cell(widget.cell_id, source)
+
+    def action_execute_and_next(self) -> None:
+        """Execute the focused cell and move to the next one."""
+        self.action_execute_cell()
+        # Move to next or create new cell
+        if self.focused_cell_index >= len(self._cell_ids) - 1:
+            self._add_cell(len(self._cell_ids))
+        else:
+            self._focus_cell(self.focused_cell_index + 1)
+
+    @work(thread=True)
+    def _execute_cell(self, cell_id: str, source: str) -> None:
+        """Execute a cell via the daemon."""
+        if not self._session:
+            return
+        try:
+            # Sync source first
+            self._session.set_source(cell_id, source)
+            # Clear previous outputs
+            self._session.clear_outputs(cell_id)
+            self.call_from_thread(self._clear_cell_outputs, cell_id)
+            # Queue for execution (outputs arrive via broadcast)
+            self._session.queue_cell(cell_id)
+        except runtimed.RuntimedError as e:
+            self.call_from_thread(
+                self.notify, f"Execution error: {e}", severity="error"
+            )
+
+    def _clear_cell_outputs(self, cell_id: str) -> None:
+        """Clear outputs for a cell widget."""
+        try:
+            widget = self.query_one(f"#cell-{cell_id}", CellWidget)
+            widget.clear_outputs()
+        except NoMatches:
+            pass
+
+    def action_run_all(self) -> None:
+        """Run all cells."""
+        self._run_all_cells()
+
+    @work(thread=True)
+    def _run_all_cells(self) -> None:
+        """Run all cells via the daemon."""
+        if not self._session:
+            return
+        try:
+            # Sync all sources first
+            for cell_id in self._cell_ids:
+                try:
+                    widget = self.query_one(f"#cell-{cell_id}", CellWidget)
+                    source = widget.get_source()
+                    self._session.set_source(cell_id, source)
+                except NoMatches:
+                    pass
+            self._session.run_all_cells()
+        except runtimed.RuntimedError as e:
+            self.call_from_thread(
+                self.notify, f"Error running all: {e}", severity="error"
+            )
+
+    def action_interrupt_kernel(self) -> None:
+        """Interrupt the running kernel."""
+        self._interrupt_kernel()
+
+    @work(thread=True)
+    def _interrupt_kernel(self) -> None:
+        if self._session:
+            try:
+                self._session.interrupt()
+                self.call_from_thread(
+                    self.notify, "Kernel interrupted", severity="information"
+                )
+            except runtimed.RuntimedError as e:
+                self.call_from_thread(
+                    self.notify, f"Interrupt failed: {e}", severity="error"
+                )
+
+    def action_save(self) -> None:
+        """Save the notebook."""
+        self._save_notebook()
+
+    @work(thread=True)
+    def _save_notebook(self) -> None:
+        if not self._session:
+            return
+        try:
+            # Sync all cell sources before saving
+            for cell_id in self._cell_ids:
+                try:
+                    widget = self.query_one(f"#cell-{cell_id}", CellWidget)
+                    source = widget.get_source()
+                    self._session.set_source(cell_id, source)
+                except NoMatches:
+                    pass
+            path = self._session.save()
+            self.call_from_thread(
+                self.notify, f"Saved: {path}", severity="information"
+            )
+        except runtimed.RuntimedError as e:
+            self.call_from_thread(
+                self.notify, f"Save error: {e}", severity="error"
+            )
+
+    def action_open_notebook(self) -> None:
+        """Open a notebook file."""
+
+        def on_path(path: str | None) -> None:
+            if path:
+                self._open_notebook(path)
+
+        self.push_screen(OpenNotebookScreen(), on_path)
+
+    def action_new_notebook(self) -> None:
+        """Create a new notebook."""
+        self._create_new_notebook()
+
+    def action_change_cell_type(self) -> None:
+        """Change the focused cell's type."""
+        if self.edit_mode:
+            return
+
+        def on_type(cell_type: str | None) -> None:
+            if cell_type:
+                widget = self._get_focused_cell_widget()
+                if widget:
+                    widget.cell_type = cell_type
+                    # TODO: sync cell type to daemon when API supports it
+
+        self.push_screen(ChangeCellTypeScreen(), on_type)
+
+    def action_toggle_help(self) -> None:
+        """Show/hide help."""
+        self.notify(
+            "[bold]Key Bindings[/]\n"
+            "Enter: Edit  |  Esc: Command mode\n"
+            "Shift+Enter: Run  |  Ctrl+Enter: Run & Next\n"
+            "a/b: Add above/below  |  dd: Delete\n"
+            "j/k: Navigate  |  t: Cell type\n"
+            "Ctrl+C: Interrupt  |  Ctrl+S: Save",
+            title="Help",
+            timeout=10,
+        )
+
+
+def run():
+    """CLI entry point with argument parsing."""
+    parser = argparse.ArgumentParser(
+        description="A rich notebook TUI powered by runtimed"
+    )
+    parser.add_argument(
+        "notebook",
+        nargs="?",
+        help="Path to .ipynb file to open",
+    )
+    args = parser.parse_args()
+
+    app = NotebookApp(notebook_path=args.notebook)
+    app.run()
+
+
+if __name__ == "__main__":
+    run()

--- a/python/notebook-tui/src/notebook_tui/app.py
+++ b/python/notebook-tui/src/notebook_tui/app.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import argparse
+import logging
 from pathlib import Path
 from threading import Event as ThreadEvent
 
 import runtimed
+
+log = logging.getLogger("notebook_tui")
 from textual import on, work
 from textual.app import App, ComposeResult
 from textual.binding import Binding
@@ -286,20 +289,59 @@ class NotebookApp(App):
         yield Footer()
 
     def on_mount(self) -> None:
+        # Show loading state immediately so the user doesn't see a blank screen
+        self._show_loading()
         if self._notebook_path_arg:
             self._open_notebook(self._notebook_path_arg)
         else:
             self._create_new_notebook()
+
+    def _show_loading(self) -> None:
+        """Show a loading message while connecting to daemon."""
+        try:
+            container = self.query_one("#notebook-container", VerticalScroll)
+            container.mount(
+                Static(
+                    "[bold]Connecting to runtimed...[/]\n\n"
+                    "[dim]Waiting for daemon connection.[/]",
+                    classes="empty-notebook",
+                    id="loading-message",
+                )
+            )
+        except NoMatches:
+            pass
+
+    def _remove_loading(self) -> None:
+        """Remove the loading message."""
+        try:
+            self.query_one("#loading-message").remove()
+        except (NoMatches, Exception):
+            pass
+
+    def _update_loading(self, message: str) -> None:
+        """Update the loading message text."""
+        try:
+            loading = self.query_one("#loading-message", Static)
+            loading.update(
+                f"[bold]{message}[/]\n\n"
+                "[dim]Waiting for daemon connection.[/]"
+            )
+        except (NoMatches, Exception):
+            pass
 
     @work(thread=True, group="session")
     def _open_notebook(self, path: str) -> None:
         """Open an existing notebook file."""
         try:
             resolved = str(Path(path).resolve())
+            log.info("Opening notebook: %s", resolved)
+            self.call_from_thread(self._update_loading, f"Opening {Path(path).name}...")
             self._session = runtimed.Session.open_notebook(resolved)
+            log.info("Session connected for: %s", resolved)
             self.call_from_thread(setattr, self, "notebook_path", resolved)
             self._post_connect()
         except Exception as e:
+            log.exception("Error opening notebook: %s", path)
             self.call_from_thread(self._show_error, f"Error opening notebook: {e}")
             self.call_from_thread(self._update_kernel_status, "error")
 
@@ -307,10 +349,14 @@ class NotebookApp(App):
     def _create_new_notebook(self) -> None:
         """Create a new empty notebook."""
         try:
+            log.info("Creating new notebook")
+            self.call_from_thread(self._update_loading, "Creating new notebook...")
             self._session = runtimed.Session.create_notebook(runtime="python")
+            log.info("New notebook session created")
             self.call_from_thread(setattr, self, "notebook_path", None)
             self._post_connect()
         except Exception as e:
+            log.exception("Error creating notebook")
             self.call_from_thread(self._show_error, f"Error creating notebook: {e}")
             self.call_from_thread(self._update_kernel_status, "error")
 
@@ -324,25 +370,33 @@ class NotebookApp(App):
 
         # Load existing cells
         try:
+            log.info("Loading cells from session")
             cells = session.get_cells()
+            log.info("Loaded %d cells", len(cells))
             self.call_from_thread(self._load_cells, cells)
         except Exception as e:
+            log.exception("Error loading cells")
             self.call_from_thread(
                 self.notify, f"Error loading cells: {e}", severity="error"
             )
 
         # Start kernel
         try:
+            log.info("Starting kernel")
+            self.call_from_thread(self._update_loading, "Starting kernel...")
             session.start_kernel()
+            log.info("Kernel started")
             self.call_from_thread(self._update_kernel_status, "idle")
             self._kernel_ready.set()
         except Exception as e:
+            log.exception("Kernel start failed")
             self.call_from_thread(self._update_kernel_status, "error")
             self.call_from_thread(
                 self.notify, f"Kernel start failed: {e}", severity="error"
             )
 
         # Start listening for broadcasts
+        log.info("Starting broadcast listener")
         self._listen_for_broadcasts()
 
     def _listen_for_broadcasts(self) -> None:
@@ -353,8 +407,10 @@ class NotebookApp(App):
 
         try:
             for event in session.subscribe():
+                log.debug("Broadcast: %s cell=%s", event.event_type, event.cell_id)
                 self._handle_broadcast(event)
         except Exception:
+            log.exception("Broadcast listener disconnected")
             self.call_from_thread(self._update_kernel_status, "disconnected")
 
     def _handle_broadcast(self, event: runtimed.ExecutionEvent) -> None:
@@ -397,6 +453,7 @@ class NotebookApp(App):
 
     def _load_cells(self, cells: list[runtimed.Cell]) -> None:
         """Load cells into the UI."""
+        self._remove_loading()
         container = self.query_one("#notebook-container", VerticalScroll)
         container.remove_children()
         self._cell_ids.clear()
@@ -435,6 +492,7 @@ class NotebookApp(App):
 
     def _show_error(self, message: str) -> None:
         """Show an error message in the content area and as a notification."""
+        self._remove_loading()
         self.notify(message, severity="error", timeout=10)
         try:
             container = self.query_one("#notebook-container", VerticalScroll)
@@ -853,6 +911,8 @@ def _find_dev_daemon_socket() -> str | None:
 
 def run():
     """CLI entry point with argument parsing."""
+    import os
+
     parser = argparse.ArgumentParser(
         description="A rich notebook TUI powered by runtimed"
     )
@@ -865,11 +925,23 @@ def run():
         "--socket",
         help="Path to runtimed socket (auto-detected if not set)",
     )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Enable debug logging to /tmp/notebook-tui.log",
+    )
     args = parser.parse_args()
 
-    # Set socket path: explicit flag > env var > auto-detect dev daemon
-    import os
+    # Set up logging if --debug is passed
+    if args.debug:
+        logging.basicConfig(
+            filename="/tmp/notebook-tui.log",
+            level=logging.DEBUG,
+            format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        )
+        log.info("Debug logging enabled")
 
+    # Set socket path: explicit flag > env var > auto-detect dev daemon
     if args.socket:
         os.environ["RUNTIMED_SOCKET_PATH"] = args.socket
     elif "RUNTIMED_SOCKET_PATH" not in os.environ:
@@ -879,6 +951,9 @@ def run():
             dev_sock = _find_dev_daemon_socket()
             if dev_sock:
                 os.environ["RUNTIMED_SOCKET_PATH"] = dev_sock
+
+    socket_path = os.environ.get("RUNTIMED_SOCKET_PATH", str(Path.home() / ".cache" / "runt" / "runtimed.sock"))
+    log.info("Using socket: %s (exists: %s)", socket_path, Path(socket_path).exists())
 
     app = NotebookApp(notebook_path=args.notebook)
     app.run()

--- a/python/notebook-tui/src/notebook_tui/app.py
+++ b/python/notebook-tui/src/notebook_tui/app.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import argparse
-import sys
 from pathlib import Path
 from threading import Event as ThreadEvent
 
@@ -296,21 +295,24 @@ class NotebookApp(App):
     def _open_notebook(self, path: str) -> None:
         """Open an existing notebook file."""
         try:
-            self._session = runtimed.Session.open_notebook(path)
-            self.notebook_path = path
+            resolved = str(Path(path).resolve())
+            self._session = runtimed.Session.open_notebook(resolved)
+            self.call_from_thread(setattr, self, "notebook_path", resolved)
             self._post_connect()
-        except runtimed.RuntimedError as e:
-            self.notify(f"Error opening notebook: {e}", severity="error")
+        except Exception as e:
+            self.call_from_thread(self._show_error, f"Error opening notebook: {e}")
+            self.call_from_thread(self._update_kernel_status, "error")
 
     @work(thread=True, group="session")
     def _create_new_notebook(self) -> None:
         """Create a new empty notebook."""
         try:
             self._session = runtimed.Session.create_notebook(runtime="python")
-            self.notebook_path = None
+            self.call_from_thread(setattr, self, "notebook_path", None)
             self._post_connect()
-        except runtimed.RuntimedError as e:
-            self.notify(f"Error creating notebook: {e}", severity="error")
+        except Exception as e:
+            self.call_from_thread(self._show_error, f"Error creating notebook: {e}")
+            self.call_from_thread(self._update_kernel_status, "error")
 
     def _post_connect(self) -> None:
         """After connecting, load cells and start kernel."""
@@ -318,23 +320,23 @@ class NotebookApp(App):
         if session is None:
             return
 
-        self.kernel_status = "connecting"
         self.call_from_thread(self._update_kernel_status, "connecting")
 
         # Load existing cells
         try:
             cells = session.get_cells()
             self.call_from_thread(self._load_cells, cells)
-        except runtimed.RuntimedError:
-            pass
+        except Exception as e:
+            self.call_from_thread(
+                self.notify, f"Error loading cells: {e}", severity="error"
+            )
 
         # Start kernel
         try:
             session.start_kernel()
-            self.kernel_status = "idle"
             self.call_from_thread(self._update_kernel_status, "idle")
             self._kernel_ready.set()
-        except runtimed.RuntimedError as e:
+        except Exception as e:
             self.call_from_thread(self._update_kernel_status, "error")
             self.call_from_thread(
                 self.notify, f"Kernel start failed: {e}", severity="error"
@@ -352,7 +354,7 @@ class NotebookApp(App):
         try:
             for event in session.subscribe():
                 self._handle_broadcast(event)
-        except runtimed.RuntimedError:
+        except Exception:
             self.call_from_thread(self._update_kernel_status, "disconnected")
 
     def _handle_broadcast(self, event: runtimed.ExecutionEvent) -> None:
@@ -381,7 +383,7 @@ class NotebookApp(App):
                         cell_id,
                         cell.execution_count,
                     )
-                except runtimed.RuntimedError:
+                except Exception:
                     pass
             if not self._executing_cells:
                 self.call_from_thread(self._update_kernel_status, "idle")
@@ -430,6 +432,22 @@ class NotebookApp(App):
                 classes="empty-notebook",
             )
         )
+
+    def _show_error(self, message: str) -> None:
+        """Show an error message in the content area and as a notification."""
+        self.notify(message, severity="error", timeout=10)
+        try:
+            container = self.query_one("#notebook-container", VerticalScroll)
+            container.remove_children()
+            container.mount(
+                Static(
+                    f"[bold red]Error[/]\n\n{message}\n\n"
+                    "[dim]Press Ctrl+O to open a notebook or Ctrl+Q to quit.[/]",
+                    classes="empty-notebook",
+                )
+            )
+        except NoMatches:
+            pass
 
     def _update_kernel_status(self, status: str) -> None:
         """Update kernel status display."""
@@ -556,7 +574,7 @@ class NotebookApp(App):
         if self._session:
             try:
                 self._session.set_source(cell_id, source)
-            except runtimed.RuntimedError as e:
+            except Exception as e:
                 self.call_from_thread(
                     self.notify, f"Sync error: {e}", severity="warning"
                 )
@@ -583,7 +601,7 @@ class NotebookApp(App):
                 source="", cell_type="code", index=index
             )
             self.call_from_thread(self._insert_cell_widget, cell_id, index, "code")
-        except runtimed.RuntimedError as e:
+        except Exception as e:
             self.call_from_thread(
                 self.notify, f"Error adding cell: {e}", severity="error"
             )
@@ -643,7 +661,7 @@ class NotebookApp(App):
         try:
             self._session.delete_cell(cell_id)
             self.call_from_thread(self._remove_cell_widget, cell_id, index)
-        except runtimed.RuntimedError as e:
+        except Exception as e:
             self.call_from_thread(
                 self.notify, f"Error deleting cell: {e}", severity="error"
             )
@@ -700,7 +718,7 @@ class NotebookApp(App):
             self.call_from_thread(self._clear_cell_outputs, cell_id)
             # Queue for execution (outputs arrive via broadcast)
             self._session.queue_cell(cell_id)
-        except runtimed.RuntimedError as e:
+        except Exception as e:
             self.call_from_thread(
                 self.notify, f"Execution error: {e}", severity="error"
             )
@@ -732,7 +750,7 @@ class NotebookApp(App):
                 except NoMatches:
                     pass
             self._session.run_all_cells()
-        except runtimed.RuntimedError as e:
+        except Exception as e:
             self.call_from_thread(
                 self.notify, f"Error running all: {e}", severity="error"
             )
@@ -749,7 +767,7 @@ class NotebookApp(App):
                 self.call_from_thread(
                     self.notify, "Kernel interrupted", severity="information"
                 )
-            except runtimed.RuntimedError as e:
+            except Exception as e:
                 self.call_from_thread(
                     self.notify, f"Interrupt failed: {e}", severity="error"
                 )
@@ -775,7 +793,7 @@ class NotebookApp(App):
             self.call_from_thread(
                 self.notify, f"Saved: {path}", severity="information"
             )
-        except runtimed.RuntimedError as e:
+        except Exception as e:
             self.call_from_thread(
                 self.notify, f"Save error: {e}", severity="error"
             )
@@ -821,6 +839,18 @@ class NotebookApp(App):
         )
 
 
+def _find_dev_daemon_socket() -> str | None:
+    """Try to find a dev daemon socket in worktree directories."""
+    cache_dir = Path.home() / ".cache" / "runt" / "worktrees"
+    if not cache_dir.exists():
+        return None
+    for worktree_dir in cache_dir.iterdir():
+        sock = worktree_dir / "runtimed.sock"
+        if sock.exists():
+            return str(sock)
+    return None
+
+
 def run():
     """CLI entry point with argument parsing."""
     parser = argparse.ArgumentParser(
@@ -831,7 +861,24 @@ def run():
         nargs="?",
         help="Path to .ipynb file to open",
     )
+    parser.add_argument(
+        "--socket",
+        help="Path to runtimed socket (auto-detected if not set)",
+    )
     args = parser.parse_args()
+
+    # Set socket path: explicit flag > env var > auto-detect dev daemon
+    import os
+
+    if args.socket:
+        os.environ["RUNTIMED_SOCKET_PATH"] = args.socket
+    elif "RUNTIMED_SOCKET_PATH" not in os.environ:
+        # Auto-detect: check default path first, then dev worktree sockets
+        default_sock = Path.home() / ".cache" / "runt" / "runtimed.sock"
+        if not default_sock.exists():
+            dev_sock = _find_dev_daemon_socket()
+            if dev_sock:
+                os.environ["RUNTIMED_SOCKET_PATH"] = dev_sock
 
     app = NotebookApp(notebook_path=args.notebook)
     app.run()

--- a/python/notebook-tui/src/notebook_tui/widgets.py
+++ b/python/notebook-tui/src/notebook_tui/widgets.py
@@ -1,0 +1,314 @@
+"""Textual widgets for the notebook TUI."""
+
+from __future__ import annotations
+
+import re
+
+import runtimed
+from rich.markup import escape
+from rich.text import Text
+from textual.containers import Horizontal, Vertical
+from textual.reactive import reactive
+from textual.widget import Widget
+from textual.widgets import Static, TextArea
+
+
+# ANSI escape code pattern for stripping from traceback text
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _strip_ansi(text: str) -> str:
+    """Remove ANSI escape codes from text."""
+    return _ANSI_RE.sub("", text)
+
+
+class KernelStatusBar(Static):
+    """Displays kernel connection status with an indicator."""
+
+    status: reactive[str] = reactive("disconnected")
+
+    _STATUS_DISPLAY = {
+        "disconnected": ("", "Disconnected"),
+        "connecting": ("", "Connecting..."),
+        "idle": ("", "Idle"),
+        "busy": ("", "Busy"),
+        "error": ("", "Error"),
+        "starting": ("", "Starting..."),
+        "shutdown": ("", "Shutdown"),
+    }
+
+    def render(self) -> str:
+        icon, label = self._STATUS_DISPLAY.get(
+            self.status, ("?", self.status)
+        )
+        return f" {icon} {label}"
+
+
+class NotebookTitle(Static):
+    """Displays the notebook filename."""
+
+    pass
+
+
+class OutputBlock(Static):
+    """A single output block within a cell."""
+
+    def __init__(
+        self,
+        output: runtimed.Output,
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+        self._output = output
+
+    def on_mount(self) -> None:
+        self._render_output()
+
+    def _render_output(self) -> None:
+        output = self._output
+
+        if output.output_type == "stream":
+            text = output.text or ""
+            css_class = (
+                "cell-output-error"
+                if output.name == "stderr"
+                else "cell-output-stream"
+            )
+            self.add_class(css_class)
+            self.update(escape(text.rstrip("\n")))
+
+        elif output.output_type == "execute_result":
+            self.add_class("cell-output-result")
+            self._render_display_data(output)
+
+        elif output.output_type == "display_data":
+            self.add_class("cell-output-result")
+            self._render_display_data(output)
+
+        elif output.output_type == "error":
+            self.add_class("cell-output-error")
+            ename = getattr(output, "ename", "Error") or "Error"
+            evalue = getattr(output, "evalue", "") or ""
+            tb_lines = getattr(output, "traceback", []) or []
+
+            parts = []
+            if tb_lines:
+                for line in tb_lines:
+                    parts.append(_strip_ansi(line))
+            else:
+                parts.append(f"{ename}: {evalue}")
+
+            self.update(escape("\n".join(parts)))
+
+    def _render_display_data(self, output: runtimed.Output) -> None:
+        """Render display_data or execute_result output."""
+        data = getattr(output, "data", None)
+        if not data:
+            return
+
+        # Prefer text representations for terminal
+        if "text/plain" in data:
+            self.update(escape(data["text/plain"]))
+        elif "text/markdown" in data:
+            self.update(data["text/markdown"])
+        elif "text/html" in data:
+            # Strip HTML tags for terminal display
+            html = data["text/html"]
+            clean = re.sub(r"<[^>]+>", "", html)
+            self.update(escape(clean.strip()))
+        elif "image/png" in data or "image/jpeg" in data:
+            self.update("[Image output - view in graphical notebook]")
+        elif "application/json" in data:
+            import json
+
+            try:
+                formatted = json.dumps(
+                    json.loads(data["application/json"]),
+                    indent=2,
+                )
+                self.update(escape(formatted))
+            except (json.JSONDecodeError, TypeError):
+                self.update(escape(str(data["application/json"])))
+        else:
+            # Show first available mime type
+            for mime, content in data.items():
+                self.update(escape(f"[{mime}]\n{str(content)[:500]}"))
+                break
+
+
+class CellWidget(Widget):
+    """A notebook cell with gutter, source editor, and output area."""
+
+    is_focused_cell: reactive[bool] = reactive(False)
+    is_executing: reactive[bool] = reactive(False)
+    execution_count: reactive[int | None] = reactive(None)
+    cell_type: reactive[str] = reactive("code")
+
+    def __init__(
+        self,
+        cell_id: str,
+        cell_type: str = "code",
+        source: str = "",
+        execution_count: int | None = None,
+        outputs: list[runtimed.Output] | None = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(id=f"cell-{cell_id}", classes="cell-widget --not-focused", **kwargs)
+        self.cell_id = cell_id
+        self.cell_type = cell_type
+        self._source = source
+        self.execution_count = execution_count
+        self._outputs = outputs or []
+        self._in_edit_mode = False
+
+    def compose(self):
+        with Horizontal():
+            # Gutter: execution count and cell type indicator
+            yield Static(self._gutter_text(), classes="cell-gutter")
+            with Vertical(classes="cell-body"):
+                # Source area
+                with Vertical(classes="cell-source"):
+                    yield TextArea(
+                        self._source,
+                        language="python" if self.cell_type == "code" else None,
+                        theme="monokai",
+                        id=f"source-{self.cell_id}",
+                        show_line_numbers=True,
+                        read_only=True,
+                        tab_behavior="indent",
+                        soft_wrap=True,
+                    )
+                # Output area
+                yield Vertical(
+                    *self._make_output_widgets(),
+                    classes="cell-output",
+                    id=f"output-{self.cell_id}",
+                )
+
+    def _gutter_text(self) -> str:
+        """Build gutter text with execution count."""
+        if self.cell_type == "code":
+            if self.is_executing:
+                return " [*]:"
+            if self.execution_count is not None:
+                return f"[{self.execution_count}]:"
+            return "[ ]:"
+        elif self.cell_type == "markdown":
+            return "  MD:"
+        return " RAW:"
+
+    def _make_output_widgets(self) -> list[OutputBlock]:
+        """Create output widgets from stored outputs."""
+        widgets = []
+        for i, output in enumerate(self._outputs):
+            widgets.append(
+                OutputBlock(
+                    output,
+                    id=f"out-{self.cell_id}-{i}",
+                )
+            )
+        return widgets
+
+    def _update_gutter(self) -> None:
+        """Refresh the gutter display."""
+        try:
+            gutter = self.query_one(".cell-gutter", Static)
+            gutter.update(self._gutter_text())
+            if self.is_executing:
+                gutter.add_class("--executing")
+            else:
+                gutter.remove_class("--executing")
+        except Exception:
+            pass
+
+    def watch_is_focused_cell(self, focused: bool) -> None:
+        if focused:
+            self.remove_class("--not-focused")
+            self.add_class("--focused")
+        else:
+            self.remove_class("--focused")
+            self.add_class("--not-focused")
+
+    def watch_is_executing(self, executing: bool) -> None:
+        if executing:
+            self.add_class("--executing")
+        else:
+            self.remove_class("--executing")
+        self._update_gutter()
+
+    def watch_execution_count(self, count: int | None) -> None:
+        self._update_gutter()
+
+    def watch_cell_type(self, cell_type: str) -> None:
+        self._update_gutter()
+        # Update syntax highlighting
+        try:
+            editor = self.query_one(f"#source-{self.cell_id}", TextArea)
+            editor.language = "python" if cell_type == "code" else None
+        except Exception:
+            pass
+
+    def enter_edit_mode(self) -> None:
+        """Enable editing in the source TextArea."""
+        self._in_edit_mode = True
+        try:
+            editor = self.query_one(f"#source-{self.cell_id}", TextArea)
+            editor.read_only = False
+            editor.focus()
+        except Exception:
+            pass
+
+    def exit_edit_mode(self) -> None:
+        """Disable editing in the source TextArea."""
+        self._in_edit_mode = False
+        try:
+            editor = self.query_one(f"#source-{self.cell_id}", TextArea)
+            self._source = editor.text
+            editor.read_only = True
+        except Exception:
+            pass
+
+    def get_source(self) -> str:
+        """Get the current source text."""
+        try:
+            editor = self.query_one(f"#source-{self.cell_id}", TextArea)
+            return editor.text
+        except Exception:
+            return self._source
+
+    def set_source(self, source: str) -> None:
+        """Set the source text."""
+        self._source = source
+        try:
+            editor = self.query_one(f"#source-{self.cell_id}", TextArea)
+            editor.load_text(source)
+        except Exception:
+            pass
+
+    def append_output(self, output: runtimed.Output) -> None:
+        """Append a new output to this cell."""
+        idx = len(self._outputs)
+        self._outputs.append(output)
+        try:
+            output_container = self.query_one(
+                f"#output-{self.cell_id}", Vertical
+            )
+            block = OutputBlock(
+                output,
+                id=f"out-{self.cell_id}-{idx}",
+            )
+            output_container.mount(block)
+        except Exception:
+            pass
+
+    def clear_outputs(self) -> None:
+        """Remove all outputs from this cell."""
+        self._outputs.clear()
+        self.execution_count = None
+        try:
+            output_container = self.query_one(
+                f"#output-{self.cell_id}", Vertical
+            )
+            output_container.remove_children()
+        except Exception:
+            pass

--- a/python/notebook-tui/uv.lock
+++ b/python/notebook-tui/uv.lock
@@ -1,0 +1,157 @@
+version = 1
+revision = 3
+requires-python = ">=3.10"
+
+[[package]]
+name = "linkify-it-py"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "uc-micro-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2e/c9/06ea13676ef354f0af6169587ae292d3e2406e212876a413bf9eece4eb23/linkify_it_py-2.1.0.tar.gz", hash = "sha256:43360231720999c10e9328dc3691160e27a718e280673d444c38d7d3aaa3b98b", size = 29158, upload-time = "2026-03-01T07:48:47.683Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/de/88b3be5c31b22333b3ca2f6ff1de4e863d8fe45aaea7485f591970ec1d3e/linkify_it_py-2.1.0-py3-none-any.whl", hash = "sha256:0d252c1594ecba2ecedc444053db5d3a9b7ec1b0dd929c8f1d74dce89f86c05e", size = 19878, upload-time = "2026-03-01T07:48:46.098Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[package.optional-dependencies]
+linkify = [
+    { name = "linkify-it-py" },
+]
+
+[[package]]
+name = "mdit-py-plugins"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b2/fd/a756d36c0bfba5f6e39a1cdbdbfdd448dc02692467d83816dff4592a1ebc/mdit_py_plugins-0.5.0.tar.gz", hash = "sha256:f4918cb50119f50446560513a8e311d574ff6aaed72606ddae6d35716fe809c6", size = 44655, upload-time = "2025-08-11T07:25:49.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl", hash = "sha256:07a08422fc1936a5d26d146759e9155ea466e842f5ab2f7d2266dd084c8dab1f", size = 57205, upload-time = "2025-08-11T07:25:47.597Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "notebook-tui"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "rich" },
+    { name = "runtimed" },
+    { name = "textual" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "rich", specifier = ">=13.0.0" },
+    { name = "runtimed", editable = "../runtimed" },
+    { name = "textual", specifier = ">=3.0.0" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.9.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/56/8d4c30c8a1d07013911a8fdbd8f89440ef9f08d07a1b50ab8ca8be5a20f9/platformdirs-4.9.4.tar.gz", hash = "sha256:1ec356301b7dc906d83f371c8f487070e99d3ccf9e501686456394622a01a934", size = 28737, upload-time = "2026-03-05T18:34:13.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/d7/97f7e3a6abb67d8080dd406fd4df842c2be0efaf712d1c899c32a075027c/platformdirs-4.9.4-py3-none-any.whl", hash = "sha256:68a9a4619a666ea6439f2ff250c12a853cd1cbd5158d258bd824a7df6be2f868", size = 21216, upload-time = "2026-03-05T18:34:12.172Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "rich"
+version = "14.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/c6/f3b320c27991c46f43ee9d856302c70dc2d0fb2dba4842ff739d5f46b393/rich-14.3.3.tar.gz", hash = "sha256:b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b", size = 230582, upload-time = "2026-02-19T17:23:12.474Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl", hash = "sha256:793431c1f8619afa7d3b52b2cdec859562b950ea0d4b6b505397612db8d5362d", size = 310458, upload-time = "2026-02-19T17:23:13.732Z" },
+]
+
+[[package]]
+name = "runtimed"
+version = "0.1.4"
+source = { editable = "../runtimed" }
+
+[package.metadata]
+requires-dist = [
+    { name = "ipykernel", marker = "extra == 'kernel'", specifier = ">=6.0" },
+    { name = "pyzmq", marker = "extra == 'bridge'", specifier = ">=25.0" },
+]
+provides-extras = ["kernel", "bridge"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "ipykernel", specifier = ">=6.0" },
+    { name = "maturin", specifier = ">=1.0,<2.0" },
+    { name = "pytest", specifier = ">=8.0" },
+    { name = "pytest-asyncio", specifier = ">=0.23" },
+    { name = "pytest-timeout", specifier = ">=2.0" },
+]
+
+[[package]]
+name = "textual"
+version = "8.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py", extra = ["linkify"] },
+    { name = "mdit-py-plugins" },
+    { name = "platformdirs" },
+    { name = "pygments" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/50/d46c43c02e80c67ead6ba72231c1bfa90f3c6105dc26aee92a782c5f10dd/textual-8.1.0.tar.gz", hash = "sha256:4aef2badb7b15db23c9d96002ac0b6307345fac62b6a37935fb9b483414e4071", size = 1842894, upload-time = "2026-03-10T03:01:11.664Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/e2/5ba08dc536ece4d0bd250bcf4aea9770c5078f559de15af0ad235a1a9eb2/textual-8.1.0-py3-none-any.whl", hash = "sha256:878c05fe1a1332bcbf1000a9d9fbdecccb52a683645107612ba2c838d803b7ad", size = 719618, upload-time = "2026-03-10T03:05:31.149Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "uc-micro-py"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/67/9a363818028526e2d4579334460df777115bdec1bb77c08f9db88f6389f2/uc_micro_py-2.0.0.tar.gz", hash = "sha256:c53691e495c8db60e16ffc4861a35469b0ba0821fe409a8a7a0a71864d33a811", size = 6611, upload-time = "2026-03-01T06:31:27.526Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/73/d21edf5b204d1467e06500080a50f79d49ef2b997c79123a536d4a17d97c/uc_micro_py-2.0.0-py3-none-any.whl", hash = "sha256:3603a3859af53e5a39bc7677713c78ea6589ff188d70f4fee165db88e22b242c", size = 6383, upload-time = "2026-03-01T06:31:26.257Z" },
+]


### PR DESCRIPTION
## Summary

This PR introduces `notebook-tui`, a new terminal user interface (TUI) application for working with Jupyter notebooks. Built on top of the `runtimed` daemon and the `Textual` framework, it provides an interactive notebook editing and execution experience in the terminal.

## Key Changes

- **Main Application (`app.py`)**: Implements the core `NotebookApp` class with:
  - Notebook lifecycle management (open, create, save)
  - Cell management (add, delete, navigate, edit)
  - Code execution with kernel status tracking
  - Real-time output streaming via daemon broadcasts
  - Modal dialogs for opening notebooks and changing cell types
  - Comprehensive keyboard bindings for Jupyter-like workflows (Vim-style navigation, Shift+Enter to run, etc.)

- **Widget Components (`widgets.py`)**: Provides reusable Textual widgets:
  - `CellWidget`: Main cell container with gutter, source editor, and output area
  - `OutputBlock`: Renders various output types (streams, errors, results, display data)
  - `KernelStatusBar`: Shows kernel connection status with visual indicator
  - `NotebookTitle`: Displays current notebook filename
  - Support for syntax highlighting and ANSI code stripping

- **Package Structure**: 
  - Entry points via `__init__.py` and `__main__.py` for CLI access
  - `pyproject.toml` with dependencies on `runtimed`, `textual`, and `rich`

## Notable Implementation Details

- **Threading Model**: Uses Textual's `@work` decorator for background operations (kernel communication, file I/O) to keep the UI responsive
- **Reactive State Management**: Leverages Textual's reactive properties for kernel status, cell focus, and edit mode
- **Broadcast Handling**: Listens to daemon events for execution status, outputs, and errors in real-time
- **Edit Mode Toggle**: Cells can be toggled between read-only and editable states with automatic source synchronization
- **Output Rendering**: Intelligently handles multiple MIME types (text/plain, markdown, HTML, JSON, images) with terminal-appropriate fallbacks
- **Keyboard Bindings**: Implements Jupyter-familiar shortcuts (j/k for navigation, dd for delete, a/b for add cells, Shift+Enter to execute)
