### PR TITLE
fix(notebook): prevent context loss when same file opened twice

### DIFF
--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -67,8 +67,12 @@ impl WindowNotebookRegistry {
         label: impl Into<String>,
         context: WindowNotebookContext,
     ) -> Result<(), String> {
+        let label = label.into();
         let mut contexts = self.contexts.lock().map_err(|e| e.to_string())?;
-        contexts.insert(label.into(), context);
+        if contexts.contains_key(&label) {
+            return Err(format!("Context already exists for window '{}'", label));
+        }
+        contexts.insert(label, context);
         Ok(())
     }
 
@@ -1773,6 +1777,14 @@ fn create_notebook_window_for_daemon(
             format!("notebook-{}", uuid::Uuid::new_v4())
         }
     });
+
+    // If a window with this label already exists, focus it instead of creating a duplicate.
+    // This prevents the race condition where opening the same file twice overwrites and then
+    // removes the context, leaving the original window in a broken state (#577).
+    if let Some(existing_window) = app.get_webview_window(&label) {
+        let _ = existing_window.set_focus();
+        return Ok(label);
+    }
 
     // Placeholder notebook_id — daemon will provide the canonical one.
     let placeholder_id = match &mode {


### PR DESCRIPTION
When the same notebook file is opened twice (issue #577), the second attempt would overwrite the first window's context in the registry, then fail to create a new window (duplicate label), then remove the context during error cleanup. This left the original window in a broken state where all commands failed with "No notebook context for window".

**Fix**: Check if a window with the generated label already exists before creating a context. If it does, focus the existing window and return early. Additionally, `registry.insert()` now rejects duplicate keys to prevent silent overwrites.

**Test plan**:
* [x] Open a notebook via `open /path/to/notebook.ipynb`
* [x] Run `open /path/to/notebook.ipynb` again  
* [x] Verify the existing window is focused (not a new broken one)
* [x] Verify cells can still execute normally

Closes #577

_PR submitted by @rgbkrk's agent, Quill_