### PR TITLE
feat(runtimed): add streaming JSON parser for notebook loading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2789,6 +2789,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "jiter"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020ba671987d7444d251d3ee5340be1bf4606cd6c0b53e6f4066b5a1ee376b22"
+dependencies = [
+ "ahash",
+ "bitvec",
+ "lexical-parse-float",
+ "num-bigint",
+ "num-traits",
+ "pyo3",
+ "smallvec",
+]
+
+[[package]]
 name = "jni"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3030,6 +3045,31 @@ name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "lexical-parse-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a9f232fbd6f550bc0137dcb5f99ab674071ac2d690ac69704593cb4abbea56"
+dependencies = [
+ "lexical-parse-integer",
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a7a039f8fb9c19c996cd7b2fcce303c1b2874fe1aca544edc85c4a5f8489b34"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-util"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2604dd126bb14f13fb5d1bd6a66155079cb9fa655b37f875b3a742c705dbed17"
 
 [[package]]
 name = "libappindicator"
@@ -3610,10 +3650,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -4559,6 +4618,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf85e27e86080aafd5a22eae58a162e133a589551542b3e5cee4beb27e54f8e1"
 dependencies = [
  "libc",
+ "num-bigint",
+ "num-traits",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
@@ -5624,6 +5685,7 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
+ "jiter",
  "jupyter-protocol",
  "kernel-env",
  "kernel-launch",

--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -372,6 +372,50 @@ impl NotebookDoc {
         Ok(())
     }
 
+    /// Add a cell with full content in a single operation.
+    ///
+    /// This is optimized for bulk loading - it avoids the O(n) cell lookup that
+    /// separate `update_source`/`set_outputs`/`set_execution_count` calls require.
+    /// Use this when loading notebooks to avoid O(n²) performance degradation.
+    pub fn add_cell_full(
+        &mut self,
+        index: usize,
+        cell_id: &str,
+        cell_type: &str,
+        source: &str,
+        outputs: &[String],
+        execution_count: &str,
+    ) -> Result<(), AutomergeError> {
+        let cells_id = self
+            .cells_list_id()
+            .ok_or_else(|| AutomergeError::InvalidObjId("cells list not found".into()))?;
+
+        // Clamp index to list length
+        let len = self.doc.length(&cells_id);
+        let index = index.min(len);
+
+        // Create cell object
+        let cell_map = self.doc.insert_object(&cells_id, index, ObjType::Map)?;
+        self.doc.put(&cell_map, "id", cell_id)?;
+        self.doc.put(&cell_map, "cell_type", cell_type)?;
+        self.doc
+            .put(&cell_map, "execution_count", execution_count)?;
+
+        // Set source text directly (no Myers diff needed for initial load)
+        let source_id = self.doc.put_object(&cell_map, "source", ObjType::Text)?;
+        if !source.is_empty() {
+            self.doc.splice_text(&source_id, 0, 0, source)?;
+        }
+
+        // Set outputs
+        let outputs_id = self.doc.put_object(&cell_map, "outputs", ObjType::List)?;
+        for (i, output) in outputs.iter().enumerate() {
+            self.doc.insert(&outputs_id, i, output.as_str())?;
+        }
+
+        Ok(())
+    }
+
     /// Delete a cell by ID. Returns `true` if the cell was found and deleted.
     pub fn delete_cell(&mut self, cell_id: &str) -> Result<bool, AutomergeError> {
         let cells_id = match self.cells_list_id() {
@@ -385,6 +429,22 @@ impl NotebookDoc {
             }
             None => Ok(false),
         }
+    }
+
+    /// Delete all cells from the document.
+    ///
+    /// Used to reset a partially loaded document on failure, allowing
+    /// another connection to retry loading from scratch.
+    pub fn clear_all_cells(&mut self) -> Result<(), AutomergeError> {
+        let cells_id = match self.cells_list_id() {
+            Some(id) => id,
+            None => return Ok(()),
+        };
+        // Delete from end to avoid index shifting issues
+        while self.doc.length(&cells_id) > 0 {
+            self.doc.delete(&cells_id, 0)?;
+        }
+        Ok(())
     }
 
     // ── Source editing ───────────────────────────────────────────────

--- a/crates/runtimed/Cargo.toml
+++ b/crates/runtimed/Cargo.toml
@@ -66,7 +66,8 @@ hyper-util = { version = "0.1", features = ["tokio"] }
 automerge = "0.7"
 
 # Fast streaming JSON parser for incremental notebook loading
-jiter = "0.13"
+# default-features = false avoids pyo3, but we need num-bigint for BigInt support
+jiter = { version = "0.13", default-features = false, features = ["num-bigint"] }
 
 # Shared notebook document types (cell CRUD, metadata, sync)
 notebook-doc = { path = "../notebook-doc", features = ["persistence"] }

--- a/crates/runtimed/Cargo.toml
+++ b/crates/runtimed/Cargo.toml
@@ -65,6 +65,9 @@ hyper-util = { version = "0.1", features = ["tokio"] }
 # Automerge CRDT for settings sync
 automerge = "0.7"
 
+# Fast streaming JSON parser for incremental notebook loading
+jiter = "0.13"
+
 # Shared notebook document types (cell CRUD, metadata, sync)
 notebook-doc = { path = "../notebook-doc", features = ["persistence"] }
 

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -1006,17 +1006,26 @@ impl Daemon {
 
         // Check if this is first connection (needs streaming load) or joining existing room.
         // For first connection, we defer loading to the sync loop for streaming.
+        // Use try_start_loading() to atomically claim loading rights and prevent
+        // duplicate loads when multiple connections race.
         let (cell_count, needs_streaming_load) = {
             let doc = room.doc.read().await;
             let existing_count = doc.cell_count();
-            if existing_count == 0 {
-                // First connection - will do streaming load in sync loop
+            if existing_count == 0 && room.try_start_loading() {
+                // First connection and we won the race - will do streaming load in sync loop
                 // Send cell_count=0 initially; cells will stream via sync messages
                 info!(
                     "[runtimed] First connection to {}, will stream-load cells",
                     path
                 );
                 (0, true)
+            } else if existing_count == 0 {
+                // Another connection is already loading
+                info!(
+                    "[runtimed] Room for {} is being loaded by another connection",
+                    path
+                );
+                (0, false)
             } else {
                 // Room already has cells from another connection
                 info!(

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -952,6 +952,7 @@ impl Daemon {
                     working_dir_path,
                     initial_metadata,
                     false, // Send ProtocolCapabilities for legacy NotebookSync handshake
+                    None,  // No streaming load for legacy handshake
                 )
                 .await
             }
@@ -1003,59 +1004,34 @@ impl Daemon {
             )
         };
 
-        // Check-and-load atomically under write lock to prevent race conditions.
-        // Two concurrent opens could both see cell_count == 0 if we check with
-        // read lock first, leading to duplicate cells.
-        let cell_count = {
-            let mut doc = room.doc.write().await;
+        // Check if this is first connection (needs streaming load) or joining existing room.
+        // For first connection, we defer loading to the sync loop for streaming.
+        let (cell_count, needs_streaming_load) = {
+            let doc = room.doc.read().await;
             let existing_count = doc.cell_count();
             if existing_count == 0 {
-                // First connection - load from disk
-                // Set loading flag to prevent persistence during load
-                room.set_loading(true);
-                let result =
-                    crate::notebook_sync_server::load_notebook_from_disk(&mut doc, &path_buf).await;
-                room.set_loading(false);
-
-                match result {
-                    Ok(count) => {
-                        info!("[runtimed] Loaded {} cells from {} into room", count, path);
-                        count
-                    }
-                    Err(e) => {
-                        // Drop the doc lock before removing room
-                        drop(doc);
-                        // Remove the room to prevent stale trust state on retry
-                        {
-                            let mut rooms = self.notebook_rooms.lock().await;
-                            rooms.remove(&notebook_id);
-                            info!("[runtimed] Removed room {} after load failure", notebook_id);
-                        }
-                        // Send error response and return
-                        let (mut reader, mut writer) = tokio::io::split(stream);
-                        let response = NotebookConnectionInfo {
-                            protocol: PROTOCOL_V2.to_string(),
-                            protocol_version: Some(PROTOCOL_VERSION),
-                            daemon_version: Some(crate::daemon_version().to_string()),
-                            notebook_id: String::new(),
-                            cell_count: 0,
-                            needs_trust_approval: false,
-                            error: Some(format!("Failed to load notebook: {}", e)),
-                        };
-                        send_json_frame(&mut writer, &response).await?;
-                        // Drain any remaining data from reader to avoid broken pipe
-                        let _ = tokio::io::copy(&mut reader, &mut tokio::io::sink()).await;
-                        return Ok(());
-                    }
-                }
+                // First connection - will do streaming load in sync loop
+                // Send cell_count=0 initially; cells will stream via sync messages
+                info!(
+                    "[runtimed] First connection to {}, will stream-load cells",
+                    path
+                );
+                (0, true)
             } else {
                 // Room already has cells from another connection
                 info!(
                     "[runtimed] Room for {} already has {} cells (joining existing)",
                     path, existing_count
                 );
-                existing_count
+                (existing_count, false)
             }
+        };
+
+        // Set load path for streaming (only if first connection to saved notebook)
+        let load_path = if needs_streaming_load {
+            Some(path_buf.clone())
+        } else {
+            None
         };
 
         // Get trust state (already verified during room creation)
@@ -1089,7 +1065,8 @@ impl Daemon {
         // Drop the trust_state lock before continuing
         drop(trust_state);
 
-        // Continue with normal notebook sync (handles auto-launch internally)
+        // Continue with notebook sync (handles auto-launch internally)
+        // If load_path is Some, the sync loop will stream-load cells from disk.
         crate::notebook_sync_server::handle_notebook_sync_connection(
             reader,
             writer,
@@ -1100,8 +1077,9 @@ impl Daemon {
             default_python_env,
             self.clone(),
             working_dir_path,
-            None, // No initial_metadata - doc is already populated
+            None, // No initial_metadata - will be set from streaming load
             true, // Skip ProtocolCapabilities - already sent in NotebookConnectionInfo
+            load_path,
         )
         .await
     }
@@ -1230,6 +1208,7 @@ impl Daemon {
             working_dir_path,
             None, // No initial_metadata - doc is already populated
             true, // Skip ProtocolCapabilities - already sent in NotebookConnectionInfo
+            None, // No streaming load - doc is already populated by create_empty_notebook
         )
         .await
     }

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -1011,9 +1011,13 @@ impl Daemon {
             let existing_count = doc.cell_count();
             if existing_count == 0 {
                 // First connection - load from disk
-                match crate::notebook_sync_server::load_notebook_from_disk(&mut doc, &path_buf)
-                    .await
-                {
+                // Set loading flag to prevent persistence during load
+                room.set_loading(true);
+                let result =
+                    crate::notebook_sync_server::load_notebook_from_disk(&mut doc, &path_buf).await;
+                room.set_loading(false);
+
+                match result {
                     Ok(count) => {
                         info!("[runtimed] Loaded {} cells from {} into room", count, path);
                         count

--- a/crates/runtimed/src/lib.rs
+++ b/crates/runtimed/src/lib.rs
@@ -31,6 +31,7 @@ pub mod service;
 pub mod settings_doc;
 pub mod singleton;
 pub mod stream_terminal;
+pub mod streaming_ipynb;
 pub mod sync_client;
 pub mod sync_server;
 pub mod terminal_size;

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -882,12 +882,42 @@ where
     // Load notebook cells incrementally, emitting sync messages after each batch.
     // This allows the frontend to render cells progressively during load.
     if let Some(path) = load_path {
+        // Parse first to get cell count for the broadcast
+        let data = tokio::fs::read(&path)
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to read notebook: {}", e))?;
+        let parsed = crate::streaming_ipynb::parse_notebook(&data)
+            .map_err(|e| anyhow::anyhow!("Failed to parse notebook: {}", e))?;
+        let total_cells = parsed.cells.len();
+
+        // Broadcast streaming load started
+        let _ = room
+            .kernel_broadcast_tx
+            .send(NotebookBroadcast::StreamingLoadStarted { total_cells });
+        connection::send_typed_json_frame(
+            writer,
+            NotebookFrameType::Broadcast,
+            &NotebookBroadcast::StreamingLoadStarted { total_cells },
+        )
+        .await?;
+
         room.set_loading(true);
         let mut doc = room.doc.write().await;
         let result =
-            load_notebook_streaming(&mut doc, &mut peer_state, reader, writer, &path).await;
+            load_notebook_streaming_parsed(&mut doc, &mut peer_state, reader, writer, parsed).await;
         drop(doc); // Release lock before setting loading=false
         room.set_loading(false);
+
+        // Broadcast streaming load complete
+        let _ = room
+            .kernel_broadcast_tx
+            .send(NotebookBroadcast::StreamingLoadComplete { total_cells });
+        connection::send_typed_json_frame(
+            writer,
+            NotebookFrameType::Broadcast,
+            &NotebookBroadcast::StreamingLoadComplete { total_cells },
+        )
+        .await?;
 
         if let Err(e) = result {
             error!("[notebook-sync] Streaming load failed: {}", e);
@@ -3233,7 +3263,8 @@ pub async fn load_notebook_from_disk(
 
 /// Batch size for streaming notebook load.
 /// After this many cells are added, a sync message is emitted.
-const STREAMING_BATCH_SIZE: usize = 10;
+/// Smaller batches = faster first render, larger batches = less overhead.
+const STREAMING_BATCH_SIZE: usize = 3;
 
 /// Load notebook cells from disk with streaming sync message emission.
 ///
@@ -3358,6 +3389,124 @@ where
     }
 
     // Set metadata after all cells (metadata goes in final sync message)
+    doc.set_metadata_snapshot(&parsed.metadata)
+        .map_err(|e| format!("Failed to set metadata: {}", e))?;
+
+    // Send final sync message with metadata
+    if let Some(msg) = doc.generate_sync_message(peer_state) {
+        let encoded = msg.encode();
+        connection::send_typed_frame(writer, NotebookFrameType::AutomergeSync, &encoded)
+            .await
+            .map_err(|e| format!("Failed to send final sync message: {}", e))?;
+    }
+
+    Ok(total_cells)
+}
+
+/// Load pre-parsed notebook cells with streaming sync message emission.
+///
+/// Same as `load_notebook_streaming` but takes already-parsed cells.
+/// Used when we need to know the cell count before starting (for broadcasts).
+async fn load_notebook_streaming_parsed<R, W>(
+    doc: &mut NotebookDoc,
+    peer_state: &mut sync::State,
+    reader: &mut R,
+    writer: &mut W,
+    parsed: crate::streaming_ipynb::ParsedNotebook,
+) -> Result<usize, String>
+where
+    R: tokio::io::AsyncRead + Unpin,
+    W: tokio::io::AsyncWrite + Unpin,
+{
+    let total_cells = parsed.cells.len();
+    info!(
+        "[notebook-sync] Streaming load of {} cells (pre-parsed)",
+        total_cells
+    );
+
+    // Add cells in batches, emitting sync messages between batches
+    let mut batch_start = std::time::Instant::now();
+    for (idx, cell) in parsed.cells.into_iter().enumerate() {
+        // Add cell to doc
+        doc.add_cell(idx, &cell.id, &cell.cell_type)
+            .map_err(|e| format!("Failed to add cell: {}", e))?;
+        doc.update_source(&cell.id, &cell.source)
+            .map_err(|e| format!("Failed to update source: {}", e))?;
+        if !cell.outputs.is_empty() {
+            doc.set_outputs(&cell.id, &cell.outputs)
+                .map_err(|e| format!("Failed to set outputs: {}", e))?;
+        }
+        doc.set_execution_count(&cell.id, &cell.execution_count)
+            .map_err(|e| format!("Failed to set execution count: {}", e))?;
+
+        // Emit sync message after each batch (or on last cell)
+        let is_batch_complete = (idx + 1) % STREAMING_BATCH_SIZE == 0;
+        let is_last_cell = idx + 1 == total_cells;
+
+        if is_batch_complete || is_last_cell {
+            let add_elapsed = batch_start.elapsed();
+
+            // Generate and send sync message with the new cells
+            let gen_start = std::time::Instant::now();
+            let sync_msg = doc.generate_sync_message(peer_state);
+            let gen_elapsed = gen_start.elapsed();
+
+            if let Some(msg) = sync_msg {
+                let encoded = msg.encode();
+                let msg_size = encoded.len();
+
+                let send_start = std::time::Instant::now();
+                connection::send_typed_frame(writer, NotebookFrameType::AutomergeSync, &encoded)
+                    .await
+                    .map_err(|e| format!("Failed to send sync message: {}", e))?;
+                let send_elapsed = send_start.elapsed();
+
+                // Drain any incoming frames to prevent buffer deadlock
+                let mut drained = 0;
+                loop {
+                    use tokio::time::{timeout, Duration};
+                    match timeout(
+                        Duration::from_millis(1),
+                        connection::recv_typed_frame(reader),
+                    )
+                    .await
+                    {
+                        Ok(Ok(Some(frame))) => {
+                            if frame.frame_type == NotebookFrameType::AutomergeSync {
+                                if let Ok(msg) = sync::Message::decode(&frame.payload) {
+                                    let _ = doc.receive_sync_message(peer_state, msg);
+                                }
+                            }
+                            drained += 1;
+                        }
+                        _ => break,
+                    }
+                }
+
+                info!(
+                    "[notebook-sync] Batch {}-{}/{}: add={:?} gen={:?} send={:?} size={}KB drained={}",
+                    idx + 1 - (idx % STREAMING_BATCH_SIZE),
+                    idx + 1,
+                    total_cells,
+                    add_elapsed,
+                    gen_elapsed,
+                    send_elapsed,
+                    msg_size / 1024,
+                    drained
+                );
+            } else {
+                warn!(
+                    "[notebook-sync] Batch {}-{}/{}: generate_sync_message returned None",
+                    idx + 1 - (idx % STREAMING_BATCH_SIZE),
+                    idx + 1,
+                    total_cells
+                );
+            }
+            batch_start = std::time::Instant::now();
+        }
+    }
+
+    // Set metadata after all cells
     doc.set_metadata_snapshot(&parsed.metadata)
         .map_err(|e| format!("Failed to set metadata: {}", e))?;
 

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -884,7 +884,8 @@ where
     if let Some(path) = load_path {
         room.set_loading(true);
         let mut doc = room.doc.write().await;
-        let result = load_notebook_streaming(&mut doc, &mut peer_state, writer, &path).await;
+        let result =
+            load_notebook_streaming(&mut doc, &mut peer_state, reader, writer, &path).await;
         drop(doc); // Release lock before setting loading=false
         room.set_loading(false);
 
@@ -3245,13 +3246,15 @@ const STREAMING_BATCH_SIZE: usize = 10;
 /// so calling generate_sync_message() after each batch sends just the new cells.
 ///
 /// Returns the cell count on success.
-pub async fn load_notebook_streaming<W>(
+pub async fn load_notebook_streaming<R, W>(
     doc: &mut NotebookDoc,
     peer_state: &mut sync::State,
+    reader: &mut R,
     writer: &mut W,
     path: &std::path::Path,
 ) -> Result<usize, String>
 where
+    R: tokio::io::AsyncRead + Unpin,
     W: tokio::io::AsyncWrite + Unpin,
 {
     // Read the file as bytes
@@ -3270,6 +3273,7 @@ where
     );
 
     // Add cells in batches, emitting sync messages between batches
+    let mut batch_start = std::time::Instant::now();
     for (idx, cell) in parsed.cells.into_iter().enumerate() {
         // Add cell to doc
         doc.add_cell(idx, &cell.id, &cell.cell_type)
@@ -3288,19 +3292,68 @@ where
         let is_last_cell = idx + 1 == total_cells;
 
         if is_batch_complete || is_last_cell {
+            let add_elapsed = batch_start.elapsed();
+
             // Generate and send sync message with the new cells
-            if let Some(msg) = doc.generate_sync_message(peer_state) {
+            let gen_start = std::time::Instant::now();
+            let sync_msg = doc.generate_sync_message(peer_state);
+            let gen_elapsed = gen_start.elapsed();
+
+            if let Some(msg) = sync_msg {
                 let encoded = msg.encode();
+                let msg_size = encoded.len();
+
+                let send_start = std::time::Instant::now();
                 connection::send_typed_frame(writer, NotebookFrameType::AutomergeSync, &encoded)
                     .await
                     .map_err(|e| format!("Failed to send sync message: {}", e))?;
+                let send_elapsed = send_start.elapsed();
 
-                debug!(
-                    "[notebook-sync] Streamed batch: cells 1-{} of {}",
+                // Drain any incoming frames to prevent buffer deadlock.
+                // The frontend sends sync replies that pile up while we're streaming.
+                // Without draining, the socket buffers fill and sends block.
+                let mut drained = 0;
+                loop {
+                    use tokio::time::{timeout, Duration};
+                    match timeout(
+                        Duration::from_millis(1),
+                        connection::recv_typed_frame(reader),
+                    )
+                    .await
+                    {
+                        Ok(Ok(Some(frame))) => {
+                            // Process sync replies to update peer_state
+                            if frame.frame_type == NotebookFrameType::AutomergeSync {
+                                if let Ok(msg) = sync::Message::decode(&frame.payload) {
+                                    let _ = doc.receive_sync_message(peer_state, msg);
+                                }
+                            }
+                            drained += 1;
+                        }
+                        _ => break, // Timeout or error/EOF - no more frames ready
+                    }
+                }
+
+                info!(
+                    "[notebook-sync] Batch {}-{}/{}: add={:?} gen={:?} send={:?} size={}KB drained={}",
+                    idx + 1 - (idx % STREAMING_BATCH_SIZE),
+                    idx + 1,
+                    total_cells,
+                    add_elapsed,
+                    gen_elapsed,
+                    send_elapsed,
+                    msg_size / 1024,
+                    drained
+                );
+            } else {
+                warn!(
+                    "[notebook-sync] Batch {}-{}/{}: generate_sync_message returned None",
+                    idx + 1 - (idx % STREAMING_BATCH_SIZE),
                     idx + 1,
                     total_cells
                 );
             }
+            batch_start = std::time::Instant::now();
         }
     }
 

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -674,6 +674,7 @@ pub async fn handle_notebook_sync_connection<R, W>(
     working_dir: Option<PathBuf>,
     initial_metadata: Option<String>,
     skip_capabilities: bool,
+    load_path: Option<PathBuf>,
 ) -> anyhow::Result<()>
 where
     R: AsyncRead + Unpin,
@@ -779,7 +780,7 @@ where
         connection::send_json_frame(&mut writer, &caps).await?;
     }
 
-    let result = run_sync_loop_v2(&mut reader, &mut writer, &room, daemon.clone()).await;
+    let result = run_sync_loop_v2(&mut reader, &mut writer, &room, daemon.clone(), load_path).await;
 
     // Peer disconnected — decrement and possibly evict the room
     let remaining = room.active_peers.fetch_sub(1, Ordering::Relaxed) - 1;
@@ -867,6 +868,7 @@ async fn run_sync_loop_v2<R, W>(
     writer: &mut W,
     room: &NotebookRoom,
     daemon: std::sync::Arc<crate::daemon::Daemon>,
+    load_path: Option<PathBuf>,
 ) -> anyhow::Result<()>
 where
     R: AsyncRead + Unpin,
@@ -876,9 +878,25 @@ where
     let mut changed_rx = room.changed_tx.subscribe();
     let mut kernel_broadcast_rx = room.kernel_broadcast_tx.subscribe();
 
+    // Phase 0: Streaming load (if needed)
+    // Load notebook cells incrementally, emitting sync messages after each batch.
+    // This allows the frontend to render cells progressively during load.
+    if let Some(path) = load_path {
+        room.set_loading(true);
+        let mut doc = room.doc.write().await;
+        let result = load_notebook_streaming(&mut doc, &mut peer_state, writer, &path).await;
+        drop(doc); // Release lock before setting loading=false
+        room.set_loading(false);
+
+        if let Err(e) = result {
+            error!("[notebook-sync] Streaming load failed: {}", e);
+            return Err(anyhow::anyhow!("Streaming load failed: {}", e));
+        }
+    }
+
     // Phase 1: Initial sync — server sends first (typed frame)
-    // Encode the sync message inside the lock, then send outside it
-    // to avoid holding the write lock across async I/O.
+    // For streaming loads, this may be empty (all data sent during Phase 0).
+    // For pre-loaded docs, this sends the full state.
     let initial_encoded = {
         let mut doc = room.doc.write().await;
         doc.generate_sync_message(&mut peer_state)
@@ -3210,6 +3228,95 @@ pub async fn load_notebook_from_disk(
         .map_err(|e| format!("Failed to set metadata: {}", e))?;
 
     Ok(result.cell_count)
+}
+
+/// Batch size for streaming notebook load.
+/// After this many cells are added, a sync message is emitted.
+const STREAMING_BATCH_SIZE: usize = 10;
+
+/// Load notebook cells from disk with streaming sync message emission.
+///
+/// This function loads a notebook incrementally, emitting Automerge sync
+/// messages after every batch of cells. This allows the frontend to render
+/// cells progressively as they're loaded rather than waiting for the entire
+/// notebook.
+///
+/// The sync protocol sends deltas (changes since last sync with this peer),
+/// so calling generate_sync_message() after each batch sends just the new cells.
+///
+/// Returns the cell count on success.
+pub async fn load_notebook_streaming<W>(
+    doc: &mut NotebookDoc,
+    peer_state: &mut sync::State,
+    writer: &mut W,
+    path: &std::path::Path,
+) -> Result<usize, String>
+where
+    W: tokio::io::AsyncWrite + Unpin,
+{
+    // Read the file as bytes
+    let data = tokio::fs::read(path)
+        .await
+        .map_err(|e| format!("Failed to read notebook: {}", e))?;
+
+    // Parse all cells (fast with jiter)
+    let parsed = crate::streaming_ipynb::parse_notebook(&data)
+        .map_err(|e| format!("Failed to parse notebook: {}", e))?;
+
+    let total_cells = parsed.cells.len();
+    info!(
+        "[notebook-sync] Streaming load of {} cells from {:?}",
+        total_cells, path
+    );
+
+    // Add cells in batches, emitting sync messages between batches
+    for (idx, cell) in parsed.cells.into_iter().enumerate() {
+        // Add cell to doc
+        doc.add_cell(idx, &cell.id, &cell.cell_type)
+            .map_err(|e| format!("Failed to add cell: {}", e))?;
+        doc.update_source(&cell.id, &cell.source)
+            .map_err(|e| format!("Failed to update source: {}", e))?;
+        if !cell.outputs.is_empty() {
+            doc.set_outputs(&cell.id, &cell.outputs)
+                .map_err(|e| format!("Failed to set outputs: {}", e))?;
+        }
+        doc.set_execution_count(&cell.id, &cell.execution_count)
+            .map_err(|e| format!("Failed to set execution count: {}", e))?;
+
+        // Emit sync message after each batch (or on last cell)
+        let is_batch_complete = (idx + 1) % STREAMING_BATCH_SIZE == 0;
+        let is_last_cell = idx + 1 == total_cells;
+
+        if is_batch_complete || is_last_cell {
+            // Generate and send sync message with the new cells
+            if let Some(msg) = doc.generate_sync_message(peer_state) {
+                let encoded = msg.encode();
+                connection::send_typed_frame(writer, NotebookFrameType::AutomergeSync, &encoded)
+                    .await
+                    .map_err(|e| format!("Failed to send sync message: {}", e))?;
+
+                debug!(
+                    "[notebook-sync] Streamed batch: cells 1-{} of {}",
+                    idx + 1,
+                    total_cells
+                );
+            }
+        }
+    }
+
+    // Set metadata after all cells (metadata goes in final sync message)
+    doc.set_metadata_snapshot(&parsed.metadata)
+        .map_err(|e| format!("Failed to set metadata: {}", e))?;
+
+    // Send final sync message with metadata
+    if let Some(msg) = doc.generate_sync_message(peer_state) {
+        let encoded = msg.encode();
+        connection::send_typed_frame(writer, NotebookFrameType::AutomergeSync, &encoded)
+            .await
+            .map_err(|e| format!("Failed to send final sync message: {}", e))?;
+    }
+
+    Ok(total_cells)
 }
 
 /// Create a new empty notebook with a single code cell.

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -26,7 +26,7 @@
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use automerge::sync;
@@ -451,6 +451,10 @@ pub struct NotebookRoom {
     /// Wrapped in Mutex to allow setting after Arc creation.
     /// Sent when the room is evicted to stop the watcher.
     watcher_shutdown_tx: Mutex<Option<oneshot::Sender<()>>>,
+    /// Flag indicating whether the notebook is currently being loaded from disk.
+    /// When true, persistence is disabled to prevent saving incomplete documents.
+    /// Set to true before streaming load, false after all cells and metadata are loaded.
+    is_loading: AtomicBool,
 }
 
 impl NotebookRoom {
@@ -522,7 +526,22 @@ impl NotebookRoom {
             comm_state: Arc::new(CommState::new()),
             last_self_write: Arc::new(AtomicU64::new(0)),
             watcher_shutdown_tx: Mutex::new(None),
+            is_loading: AtomicBool::new(false),
         }
+    }
+
+    /// Check if the notebook is currently being loaded from disk.
+    ///
+    /// When true, persistence should be skipped to avoid saving incomplete documents.
+    pub fn is_loading(&self) -> bool {
+        self.is_loading.load(Ordering::Acquire)
+    }
+
+    /// Set the loading state.
+    ///
+    /// Set to true before streaming load, false after all cells and metadata are loaded.
+    pub fn set_loading(&self, loading: bool) {
+        self.is_loading.store(loading, Ordering::Release);
     }
 
     /// Create a new room by loading a persisted document or creating a fresh one.
@@ -558,6 +577,7 @@ impl NotebookRoom {
             comm_state: Arc::new(CommState::new()),
             last_self_write: Arc::new(AtomicU64::new(0)),
             watcher_shutdown_tx: Mutex::new(None),
+            is_loading: AtomicBool::new(false),
         }
     }
 
@@ -928,8 +948,10 @@ where
                                     .await?;
                                 }
 
-                                // Send to debounced persistence task
-                                let _ = room.persist_tx.send(Some(persist_bytes));
+                                // Send to debounced persistence task (skip during load)
+                                if !room.is_loading() {
+                                    let _ = room.persist_tx.send(Some(persist_bytes));
+                                }
 
                                 // Check if metadata changed and kernel is running - broadcast sync state
                                 check_and_broadcast_sync_state(room).await;
@@ -1949,8 +1971,10 @@ async fn handle_notebook_request(
                 bytes
             };
 
-            // 2. Send to debounced persistence task
-            let _ = room.persist_tx.send(Some(persist_bytes));
+            // 2. Send to debounced persistence task (skip during load)
+            if !room.is_loading() {
+                let _ = room.persist_tx.send(Some(persist_bytes));
+            }
 
             // 3. Broadcast for cross-window UI sync (fast path)
             let _ = room
@@ -2161,9 +2185,11 @@ async fn handle_notebook_request(
                 Ok(()) => {
                     // Notify peers of the change
                     let _ = room.changed_tx.send(());
-                    // Persist
-                    let bytes = doc.save();
-                    let _ = room.persist_tx.send(Some(bytes));
+                    // Persist (skip during load)
+                    if !room.is_loading() {
+                        let bytes = doc.save();
+                        let _ = room.persist_tx.send(Some(bytes));
+                    }
                     NotebookResponse::MetadataSet {}
                 }
                 Err(e) => NotebookResponse::Error {
@@ -3129,15 +3155,6 @@ fn parse_cells_from_ipynb(json: &serde_json::Value) -> Option<Vec<CellSnapshot>>
     Some(parsed_cells)
 }
 
-/// Parse notebook metadata from a .ipynb JSON value.
-///
-/// Uses `NotebookMetadataSnapshot::from_metadata_value` which extracts
-/// kernelspec, language_info, and runt namespace from the metadata.
-fn parse_metadata_from_ipynb(json: &serde_json::Value) -> Option<NotebookMetadataSnapshot> {
-    let metadata = json.get("metadata")?;
-    Some(NotebookMetadataSnapshot::from_metadata_value(metadata))
-}
-
 /// Load notebook cells and metadata from a .ipynb file into a NotebookDoc.
 ///
 /// Called by daemon-owned notebook loading (`OpenNotebook` handshake).
@@ -4021,6 +4038,7 @@ mod tests {
             comm_state: Arc::new(crate::comm_state::CommState::new()),
             last_self_write: Arc::new(AtomicU64::new(0)),
             watcher_shutdown_tx: Mutex::new(None),
+            is_loading: AtomicBool::new(false),
         };
 
         (room, notebook_path)

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -906,8 +906,15 @@ where
 
         room.set_loading(true);
         let mut doc = room.doc.write().await;
-        let result =
-            load_notebook_streaming(&mut doc, &mut peer_state, reader, writer, &path).await;
+        let result = load_notebook_streaming(
+            &mut doc,
+            &mut peer_state,
+            reader,
+            writer,
+            &path,
+            &room.blob_store,
+        )
+        .await;
         drop(doc); // Release lock before setting loading=false
         room.set_loading(false);
 
@@ -3279,6 +3286,9 @@ const STREAMING_BATCH_SIZE: usize = 3;
 /// The sync protocol sends deltas (changes since last sync with this peer),
 /// so calling generate_sync_message() after each batch sends just the new cells.
 ///
+/// Outputs are stored in the blob store (like kernel execution) so only
+/// small hash references go into Automerge, not megabytes of base64 images.
+///
 /// Returns the cell count on success.
 pub async fn load_notebook_streaming<R, W>(
     doc: &mut NotebookDoc,
@@ -3286,6 +3296,7 @@ pub async fn load_notebook_streaming<R, W>(
     reader: &mut R,
     writer: &mut W,
     path: &std::path::Path,
+    blob_store: &BlobStore,
 ) -> Result<usize, String>
 where
     R: tokio::io::AsyncRead + Unpin,
@@ -3309,13 +3320,43 @@ where
     // Add cells in batches, emitting sync messages between batches
     let mut batch_start = std::time::Instant::now();
     for (idx, cell) in parsed.cells.into_iter().enumerate() {
-        // Add cell to doc with all content in one operation (avoids O(n²) lookups)
+        // Process outputs through blob store (like kernel execution does)
+        // This stores large base64 images in blobs, only small hashes go into Automerge
+        let mut output_refs = Vec::with_capacity(cell.outputs.len());
+        for output_json in &cell.outputs {
+            let output_ref = match serde_json::from_str::<serde_json::Value>(output_json) {
+                Ok(output_value) => {
+                    // Create manifest (blobs large data) and store it
+                    match crate::output_store::create_manifest(
+                        &output_value,
+                        blob_store,
+                        crate::output_store::DEFAULT_INLINE_THRESHOLD,
+                    )
+                    .await
+                    {
+                        Ok(manifest_json) => {
+                            match crate::output_store::store_manifest(&manifest_json, blob_store)
+                                .await
+                            {
+                                Ok(hash) => hash,
+                                Err(_) => output_json.clone(), // Fallback to raw JSON
+                            }
+                        }
+                        Err(_) => output_json.clone(), // Fallback to raw JSON
+                    }
+                }
+                Err(_) => output_json.clone(), // Invalid JSON, keep as-is
+            };
+            output_refs.push(output_ref);
+        }
+
+        // Add cell to doc with blob references instead of raw outputs
         doc.add_cell_full(
             idx,
             &cell.id,
             &cell.cell_type,
             &cell.source,
-            &cell.outputs,
+            &output_refs,
             &cell.execution_count,
         )
         .map_err(|e| format!("Failed to add cell: {}", e))?;

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -544,6 +544,17 @@ impl NotebookRoom {
         self.is_loading.store(loading, Ordering::Release);
     }
 
+    /// Atomically try to start loading. Returns true if this caller won the race
+    /// and should perform the load; false if another caller already started loading.
+    ///
+    /// Uses compare_exchange to prevent duplicate loads when multiple connections
+    /// try to load the same notebook simultaneously.
+    pub fn try_start_loading(&self) -> bool {
+        self.is_loading
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+    }
+
     /// Create a new room by loading a persisted document or creating a fresh one.
     ///
     /// Note: This method is kept for tests that verify persistence behavior.
@@ -882,46 +893,51 @@ where
     // Load notebook cells incrementally, emitting sync messages after each batch.
     // This allows the frontend to render cells progressively during load.
     if let Some(path) = load_path {
-        // Parse first to get cell count for the broadcast
-        let data = tokio::fs::read(&path)
-            .await
-            .map_err(|e| anyhow::anyhow!("Failed to read notebook: {}", e))?;
-        let parsed = crate::streaming_ipynb::parse_notebook(&data)
-            .map_err(|e| anyhow::anyhow!("Failed to parse notebook: {}", e))?;
-        let total_cells = parsed.cells.len();
-
-        // Broadcast streaming load started
+        // Broadcast streaming load started immediately (before parsing)
         let _ = room
             .kernel_broadcast_tx
-            .send(NotebookBroadcast::StreamingLoadStarted { total_cells });
+            .send(NotebookBroadcast::StreamingLoadStarted);
         connection::send_typed_json_frame(
             writer,
             NotebookFrameType::Broadcast,
-            &NotebookBroadcast::StreamingLoadStarted { total_cells },
+            &NotebookBroadcast::StreamingLoadStarted,
         )
         .await?;
 
         room.set_loading(true);
         let mut doc = room.doc.write().await;
         let result =
-            load_notebook_streaming_parsed(&mut doc, &mut peer_state, reader, writer, parsed).await;
+            load_notebook_streaming(&mut doc, &mut peer_state, reader, writer, &path).await;
         drop(doc); // Release lock before setting loading=false
         room.set_loading(false);
 
-        // Broadcast streaming load complete
-        let _ = room
-            .kernel_broadcast_tx
-            .send(NotebookBroadcast::StreamingLoadComplete { total_cells });
-        connection::send_typed_json_frame(
-            writer,
-            NotebookFrameType::Broadcast,
-            &NotebookBroadcast::StreamingLoadComplete { total_cells },
-        )
-        .await?;
-
-        if let Err(e) = result {
-            error!("[notebook-sync] Streaming load failed: {}", e);
-            return Err(anyhow::anyhow!("Streaming load failed: {}", e));
+        match result {
+            Ok(total_cells) => {
+                // Broadcast streaming load complete with final count
+                let _ = room
+                    .kernel_broadcast_tx
+                    .send(NotebookBroadcast::StreamingLoadComplete { total_cells });
+                connection::send_typed_json_frame(
+                    writer,
+                    NotebookFrameType::Broadcast,
+                    &NotebookBroadcast::StreamingLoadComplete { total_cells },
+                )
+                .await?;
+            }
+            Err(e) => {
+                error!("[notebook-sync] Streaming load failed: {}", e);
+                // Clear partial state so another connection can retry from scratch
+                {
+                    let mut doc = room.doc.write().await;
+                    if let Err(clear_err) = doc.clear_all_cells() {
+                        warn!(
+                            "[notebook-sync] Failed to clear partial cells: {}",
+                            clear_err
+                        );
+                    }
+                }
+                return Err(anyhow::anyhow!("Streaming load failed: {}", e));
+            }
         }
     }
 
@@ -3222,34 +3238,21 @@ pub async fn load_notebook_from_disk(
 
     // Use streaming parser to parse cells incrementally
     let result = crate::streaming_ipynb::stream_notebook_cells(&data, |cell, idx| {
-        // Add each cell to the doc as it's parsed
-        doc.add_cell(idx, &cell.id, &cell.cell_type).map_err(|e| {
+        // Add cell with all content in one operation (avoids O(n²) lookups)
+        doc.add_cell_full(
+            idx,
+            &cell.id,
+            &cell.cell_type,
+            &cell.source,
+            &cell.outputs,
+            &cell.execution_count,
+        )
+        .map_err(|e| {
             crate::streaming_ipynb::StreamError::CellProcessing(format!(
                 "Failed to add cell: {}",
                 e
             ))
         })?;
-        doc.update_source(&cell.id, &cell.source).map_err(|e| {
-            crate::streaming_ipynb::StreamError::CellProcessing(format!(
-                "Failed to update source: {}",
-                e
-            ))
-        })?;
-        if !cell.outputs.is_empty() {
-            doc.set_outputs(&cell.id, &cell.outputs).map_err(|e| {
-                crate::streaming_ipynb::StreamError::CellProcessing(format!(
-                    "Failed to set outputs: {}",
-                    e
-                ))
-            })?;
-        }
-        doc.set_execution_count(&cell.id, &cell.execution_count)
-            .map_err(|e| {
-                crate::streaming_ipynb::StreamError::CellProcessing(format!(
-                    "Failed to set execution count: {}",
-                    e
-                ))
-            })?;
         Ok(())
     })
     .map_err(|e| format!("Failed to parse notebook: {}", e))?;
@@ -3306,17 +3309,16 @@ where
     // Add cells in batches, emitting sync messages between batches
     let mut batch_start = std::time::Instant::now();
     for (idx, cell) in parsed.cells.into_iter().enumerate() {
-        // Add cell to doc
-        doc.add_cell(idx, &cell.id, &cell.cell_type)
-            .map_err(|e| format!("Failed to add cell: {}", e))?;
-        doc.update_source(&cell.id, &cell.source)
-            .map_err(|e| format!("Failed to update source: {}", e))?;
-        if !cell.outputs.is_empty() {
-            doc.set_outputs(&cell.id, &cell.outputs)
-                .map_err(|e| format!("Failed to set outputs: {}", e))?;
-        }
-        doc.set_execution_count(&cell.id, &cell.execution_count)
-            .map_err(|e| format!("Failed to set execution count: {}", e))?;
+        // Add cell to doc with all content in one operation (avoids O(n²) lookups)
+        doc.add_cell_full(
+            idx,
+            &cell.id,
+            &cell.cell_type,
+            &cell.source,
+            &cell.outputs,
+            &cell.execution_count,
+        )
+        .map_err(|e| format!("Failed to add cell: {}", e))?;
 
         // Emit sync message after each batch (or on last cell)
         let is_batch_complete = (idx + 1) % STREAMING_BATCH_SIZE == 0;
@@ -3389,124 +3391,6 @@ where
     }
 
     // Set metadata after all cells (metadata goes in final sync message)
-    doc.set_metadata_snapshot(&parsed.metadata)
-        .map_err(|e| format!("Failed to set metadata: {}", e))?;
-
-    // Send final sync message with metadata
-    if let Some(msg) = doc.generate_sync_message(peer_state) {
-        let encoded = msg.encode();
-        connection::send_typed_frame(writer, NotebookFrameType::AutomergeSync, &encoded)
-            .await
-            .map_err(|e| format!("Failed to send final sync message: {}", e))?;
-    }
-
-    Ok(total_cells)
-}
-
-/// Load pre-parsed notebook cells with streaming sync message emission.
-///
-/// Same as `load_notebook_streaming` but takes already-parsed cells.
-/// Used when we need to know the cell count before starting (for broadcasts).
-async fn load_notebook_streaming_parsed<R, W>(
-    doc: &mut NotebookDoc,
-    peer_state: &mut sync::State,
-    reader: &mut R,
-    writer: &mut W,
-    parsed: crate::streaming_ipynb::ParsedNotebook,
-) -> Result<usize, String>
-where
-    R: tokio::io::AsyncRead + Unpin,
-    W: tokio::io::AsyncWrite + Unpin,
-{
-    let total_cells = parsed.cells.len();
-    info!(
-        "[notebook-sync] Streaming load of {} cells (pre-parsed)",
-        total_cells
-    );
-
-    // Add cells in batches, emitting sync messages between batches
-    let mut batch_start = std::time::Instant::now();
-    for (idx, cell) in parsed.cells.into_iter().enumerate() {
-        // Add cell to doc
-        doc.add_cell(idx, &cell.id, &cell.cell_type)
-            .map_err(|e| format!("Failed to add cell: {}", e))?;
-        doc.update_source(&cell.id, &cell.source)
-            .map_err(|e| format!("Failed to update source: {}", e))?;
-        if !cell.outputs.is_empty() {
-            doc.set_outputs(&cell.id, &cell.outputs)
-                .map_err(|e| format!("Failed to set outputs: {}", e))?;
-        }
-        doc.set_execution_count(&cell.id, &cell.execution_count)
-            .map_err(|e| format!("Failed to set execution count: {}", e))?;
-
-        // Emit sync message after each batch (or on last cell)
-        let is_batch_complete = (idx + 1) % STREAMING_BATCH_SIZE == 0;
-        let is_last_cell = idx + 1 == total_cells;
-
-        if is_batch_complete || is_last_cell {
-            let add_elapsed = batch_start.elapsed();
-
-            // Generate and send sync message with the new cells
-            let gen_start = std::time::Instant::now();
-            let sync_msg = doc.generate_sync_message(peer_state);
-            let gen_elapsed = gen_start.elapsed();
-
-            if let Some(msg) = sync_msg {
-                let encoded = msg.encode();
-                let msg_size = encoded.len();
-
-                let send_start = std::time::Instant::now();
-                connection::send_typed_frame(writer, NotebookFrameType::AutomergeSync, &encoded)
-                    .await
-                    .map_err(|e| format!("Failed to send sync message: {}", e))?;
-                let send_elapsed = send_start.elapsed();
-
-                // Drain any incoming frames to prevent buffer deadlock
-                let mut drained = 0;
-                loop {
-                    use tokio::time::{timeout, Duration};
-                    match timeout(
-                        Duration::from_millis(1),
-                        connection::recv_typed_frame(reader),
-                    )
-                    .await
-                    {
-                        Ok(Ok(Some(frame))) => {
-                            if frame.frame_type == NotebookFrameType::AutomergeSync {
-                                if let Ok(msg) = sync::Message::decode(&frame.payload) {
-                                    let _ = doc.receive_sync_message(peer_state, msg);
-                                }
-                            }
-                            drained += 1;
-                        }
-                        _ => break,
-                    }
-                }
-
-                info!(
-                    "[notebook-sync] Batch {}-{}/{}: add={:?} gen={:?} send={:?} size={}KB drained={}",
-                    idx + 1 - (idx % STREAMING_BATCH_SIZE),
-                    idx + 1,
-                    total_cells,
-                    add_elapsed,
-                    gen_elapsed,
-                    send_elapsed,
-                    msg_size / 1024,
-                    drained
-                );
-            } else {
-                warn!(
-                    "[notebook-sync] Batch {}-{}/{}: generate_sync_message returned None",
-                    idx + 1 - (idx % STREAMING_BATCH_SIZE),
-                    idx + 1,
-                    total_cells
-                );
-            }
-            batch_start = std::time::Instant::now();
-        }
-    }
-
-    // Set metadata after all cells
     doc.set_metadata_snapshot(&parsed.metadata)
         .map_err(|e| format!("Failed to set metadata: {}", e))?;
 

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -3141,47 +3141,58 @@ fn parse_metadata_from_ipynb(json: &serde_json::Value) -> Option<NotebookMetadat
 /// Load notebook cells and metadata from a .ipynb file into a NotebookDoc.
 ///
 /// Called by daemon-owned notebook loading (`OpenNotebook` handshake).
-/// Parses the file and populates the Automerge doc with cells and metadata.
+/// Uses a streaming JSON parser (jiter) for faster parsing of large notebooks.
+/// Cells are added to the doc as they're parsed.
 ///
 /// Returns the cell count on success.
 pub async fn load_notebook_from_disk(
     doc: &mut NotebookDoc,
     path: &std::path::Path,
 ) -> Result<usize, String> {
-    // Read the file
-    let content = tokio::fs::read_to_string(path)
+    // Read the file as bytes (faster than read_to_string, no UTF-8 validation)
+    let data = tokio::fs::read(path)
         .await
         .map_err(|e| format!("Failed to read notebook: {}", e))?;
 
-    // Parse JSON
-    let json: serde_json::Value =
-        serde_json::from_str(&content).map_err(|e| format!("Invalid notebook JSON: {}", e))?;
-
-    // Parse cells
-    let cells = parse_cells_from_ipynb(&json)
-        .ok_or_else(|| "Failed to parse cells from notebook".to_string())?;
-
-    // Populate cells in the doc
-    for (i, cell) in cells.iter().enumerate() {
-        doc.add_cell(i, &cell.id, &cell.cell_type)
-            .map_err(|e| format!("Failed to add cell: {}", e))?;
-        doc.update_source(&cell.id, &cell.source)
-            .map_err(|e| format!("Failed to update source: {}", e))?;
+    // Use streaming parser to parse cells incrementally
+    let result = crate::streaming_ipynb::stream_notebook_cells(&data, |cell, idx| {
+        // Add each cell to the doc as it's parsed
+        doc.add_cell(idx, &cell.id, &cell.cell_type).map_err(|e| {
+            crate::streaming_ipynb::StreamError::CellProcessing(format!(
+                "Failed to add cell: {}",
+                e
+            ))
+        })?;
+        doc.update_source(&cell.id, &cell.source).map_err(|e| {
+            crate::streaming_ipynb::StreamError::CellProcessing(format!(
+                "Failed to update source: {}",
+                e
+            ))
+        })?;
         if !cell.outputs.is_empty() {
-            doc.set_outputs(&cell.id, &cell.outputs)
-                .map_err(|e| format!("Failed to set outputs: {}", e))?;
+            doc.set_outputs(&cell.id, &cell.outputs).map_err(|e| {
+                crate::streaming_ipynb::StreamError::CellProcessing(format!(
+                    "Failed to set outputs: {}",
+                    e
+                ))
+            })?;
         }
         doc.set_execution_count(&cell.id, &cell.execution_count)
-            .map_err(|e| format!("Failed to set execution count: {}", e))?;
-    }
+            .map_err(|e| {
+                crate::streaming_ipynb::StreamError::CellProcessing(format!(
+                    "Failed to set execution count: {}",
+                    e
+                ))
+            })?;
+        Ok(())
+    })
+    .map_err(|e| format!("Failed to parse notebook: {}", e))?;
 
-    // Parse and set metadata
-    if let Some(metadata_snapshot) = parse_metadata_from_ipynb(&json) {
-        doc.set_metadata_snapshot(&metadata_snapshot)
-            .map_err(|e| format!("Failed to set metadata: {}", e))?;
-    }
+    // Set metadata from the streaming result
+    doc.set_metadata_snapshot(&result.metadata)
+        .map_err(|e| format!("Failed to set metadata: {}", e))?;
 
-    Ok(cells.len())
+    Ok(result.cell_count)
 }
 
 /// Create a new empty notebook with a single code cell.

--- a/crates/runtimed/src/protocol.rs
+++ b/crates/runtimed/src/protocol.rs
@@ -523,6 +523,23 @@ pub enum NotebookBroadcast {
         #[serde(skip_serializing_if = "Option::is_none")]
         diff: Option<EnvSyncDiff>,
     },
+
+    /// Streaming notebook load started.
+    ///
+    /// Broadcast when a large notebook begins loading incrementally.
+    /// Cells will arrive via sync messages. Frontend should show loading UI.
+    StreamingLoadStarted {
+        /// Total number of cells to be loaded.
+        total_cells: usize,
+    },
+
+    /// Streaming notebook load completed.
+    ///
+    /// All cells have been loaded and synced. Frontend can hide loading UI.
+    StreamingLoadComplete {
+        /// Total cells loaded.
+        total_cells: usize,
+    },
 }
 
 /// Difference between launched environment config and current metadata.

--- a/crates/runtimed/src/protocol.rs
+++ b/crates/runtimed/src/protocol.rs
@@ -526,18 +526,16 @@ pub enum NotebookBroadcast {
 
     /// Streaming notebook load started.
     ///
-    /// Broadcast when a large notebook begins loading incrementally.
+    /// Broadcast when a notebook begins loading incrementally.
     /// Cells will arrive via sync messages. Frontend should show loading UI.
-    StreamingLoadStarted {
-        /// Total number of cells to be loaded.
-        total_cells: usize,
-    },
+    /// Total cell count is unknown until parsing completes.
+    StreamingLoadStarted,
 
     /// Streaming notebook load completed.
     ///
     /// All cells have been loaded and synced. Frontend can hide loading UI.
     StreamingLoadComplete {
-        /// Total cells loaded.
+        /// Total cells loaded (known after parsing completes).
         total_cells: usize,
     },
 }

--- a/crates/runtimed/src/streaming_ipynb.rs
+++ b/crates/runtimed/src/streaming_ipynb.rs
@@ -46,6 +46,33 @@ pub struct StreamParseResult {
     pub cell_count: usize,
 }
 
+/// Result of parsing all cells at once.
+pub struct ParsedNotebook {
+    pub metadata: NotebookMetadataSnapshot,
+    pub cells: Vec<CellSnapshot>,
+}
+
+/// Parse a notebook and return all cells as a Vec.
+///
+/// This is useful when you need to batch-process cells (e.g., add cells to
+/// an Automerge doc in batches and emit sync messages between batches).
+///
+/// For very large notebooks, consider using `stream_notebook_cells` with a
+/// callback if you need to process cells one at a time.
+pub fn parse_notebook(data: &[u8]) -> Result<ParsedNotebook, StreamError> {
+    let mut cells = Vec::new();
+
+    let result = stream_notebook_cells(data, |cell, _idx| {
+        cells.push(cell);
+        Ok(())
+    })?;
+
+    Ok(ParsedNotebook {
+        metadata: result.metadata,
+        cells,
+    })
+}
+
 /// Parse a .ipynb file incrementally, calling `on_cell` for each cell.
 ///
 /// This function uses jiter to parse the notebook JSON without building

--- a/crates/runtimed/src/streaming_ipynb.rs
+++ b/crates/runtimed/src/streaming_ipynb.rs
@@ -283,12 +283,13 @@ fn process_cell_field(
                     "null".to_string()
                 }
                 _ => {
-                    // Could be number
+                    // Could be number (execution_count must be integer or null per nbformat)
                     let val = jiter.next_value()?;
                     match val {
                         JsonValue::Int(n) => n.to_string(),
                         JsonValue::BigInt(n) => n.to_string(),
-                        JsonValue::Float(n) => (n as i64).to_string(),
+                        // Float is invalid for execution_count, treat as null
+                        JsonValue::Float(_) => "null".to_string(),
                         _ => "null".to_string(),
                     }
                 }

--- a/crates/runtimed/src/streaming_ipynb.rs
+++ b/crates/runtimed/src/streaming_ipynb.rs
@@ -1,0 +1,501 @@
+//! Streaming .ipynb parser using jiter for incremental notebook loading.
+//!
+//! This module provides a fast, streaming JSON parser for Jupyter notebook files.
+//! Instead of loading the entire file into a serde_json::Value tree, it parses
+//! cells incrementally and invokes a callback for each cell. This enables
+//! streaming cells to the frontend via Automerge sync messages during load.
+
+use jiter::{Jiter, JsonValue, Peek};
+use notebook_doc::{metadata::NotebookMetadataSnapshot, CellSnapshot};
+use thiserror::Error;
+
+/// Errors that can occur during streaming notebook parsing.
+#[derive(Debug, Error)]
+pub enum StreamError {
+    #[error("JSON parse error at byte {position}: {message}")]
+    JsonParse { position: usize, message: String },
+
+    #[error("Invalid notebook structure: {0}")]
+    InvalidStructure(String),
+
+    #[error("Cell processing error: {0}")]
+    CellProcessing(String),
+}
+
+impl From<jiter::JsonError> for StreamError {
+    fn from(e: jiter::JsonError) -> Self {
+        StreamError::JsonParse {
+            position: e.index,
+            message: e.error_type.to_string(),
+        }
+    }
+}
+
+impl From<jiter::JiterError> for StreamError {
+    fn from(e: jiter::JiterError) -> Self {
+        StreamError::JsonParse {
+            position: e.index,
+            message: e.error_type.to_string(),
+        }
+    }
+}
+
+/// Result of streaming notebook parse.
+pub struct StreamParseResult {
+    pub metadata: NotebookMetadataSnapshot,
+    pub cell_count: usize,
+}
+
+/// Parse a .ipynb file incrementally, calling `on_cell` for each cell.
+///
+/// This function uses jiter to parse the notebook JSON without building
+/// a full in-memory tree. Cells are emitted one at a time via the callback,
+/// allowing the caller to add them to the Automerge doc and send sync
+/// messages incrementally.
+///
+/// Returns the notebook metadata and total cell count on success.
+pub fn stream_notebook_cells<F>(
+    data: &[u8],
+    mut on_cell: F,
+) -> Result<StreamParseResult, StreamError>
+where
+    F: FnMut(CellSnapshot, usize) -> Result<(), StreamError>,
+{
+    let mut jiter = Jiter::new(data);
+    let mut metadata: Option<NotebookMetadataSnapshot> = None;
+    let mut cell_count = 0;
+
+    // next_object() returns Option<&str> for first key (or None if empty)
+    // Convert to owned String to release the borrow before using jiter again
+    let first_key = jiter.next_object()?.map(|s| s.to_string());
+
+    if let Some(key) = first_key {
+        process_notebook_key(
+            &key,
+            &mut jiter,
+            &mut cell_count,
+            &mut metadata,
+            &mut on_cell,
+        )?;
+
+        // Process remaining keys
+        loop {
+            let next_key = jiter.next_key()?.map(|s| s.to_string());
+            match next_key {
+                Some(key) => {
+                    process_notebook_key(
+                        &key,
+                        &mut jiter,
+                        &mut cell_count,
+                        &mut metadata,
+                        &mut on_cell,
+                    )?;
+                }
+                None => break,
+            }
+        }
+    }
+
+    Ok(StreamParseResult {
+        metadata: metadata.unwrap_or_default(),
+        cell_count,
+    })
+}
+
+/// Process a single notebook-level key-value pair.
+fn process_notebook_key<F>(
+    key: &str,
+    jiter: &mut Jiter,
+    cell_count: &mut usize,
+    metadata: &mut Option<NotebookMetadataSnapshot>,
+    on_cell: &mut F,
+) -> Result<(), StreamError>
+where
+    F: FnMut(CellSnapshot, usize) -> Result<(), StreamError>,
+{
+    match key {
+        "cells" => {
+            // Parse cells array incrementally
+            // next_array() returns Option<Peek> for first element (or None if empty)
+            if let Some(first_peek) = jiter.next_array()? {
+                if first_peek == Peek::Object {
+                    let cell = parse_cell(jiter, *cell_count)?;
+                    on_cell(cell, *cell_count)?;
+                    *cell_count += 1;
+
+                    // Continue with remaining elements
+                    while let Some(peek) = jiter.array_step()? {
+                        if peek == Peek::Object {
+                            let cell = parse_cell(jiter, *cell_count)?;
+                            on_cell(cell, *cell_count)?;
+                            *cell_count += 1;
+                        } else {
+                            jiter.next_skip()?;
+                        }
+                    }
+                } else {
+                    jiter.next_skip()?;
+                    // Handle remaining elements
+                    while jiter.array_step()?.is_some() {
+                        jiter.next_skip()?;
+                    }
+                }
+            }
+        }
+        "metadata" => {
+            // Parse metadata as JSON value, then convert
+            let metadata_value = jiter.next_value()?;
+            *metadata = Some(parse_metadata_from_value(&metadata_value)?);
+        }
+        _ => {
+            // Skip nbformat, nbformat_minor, etc.
+            jiter.next_skip()?;
+        }
+    }
+    Ok(())
+}
+
+/// Parse a single cell object from the jiter stream.
+fn parse_cell(jiter: &mut Jiter, index: usize) -> Result<CellSnapshot, StreamError> {
+    let mut id: Option<String> = None;
+    let mut cell_type: Option<String> = None;
+    let mut source: Option<String> = None;
+    let mut execution_count = "null".to_string();
+    let mut outputs: Vec<String> = Vec::new();
+
+    // next_object() returns the first key (or None if empty object)
+    // Convert to owned String to release the borrow
+    let first_key = jiter.next_object()?.map(|s| s.to_string());
+
+    if let Some(key) = first_key {
+        process_cell_field(
+            &key,
+            jiter,
+            &mut id,
+            &mut cell_type,
+            &mut source,
+            &mut execution_count,
+            &mut outputs,
+        )?;
+
+        // Process remaining fields
+        loop {
+            let next_key = jiter.next_key()?.map(|s| s.to_string());
+            match next_key {
+                Some(key) => {
+                    process_cell_field(
+                        &key,
+                        jiter,
+                        &mut id,
+                        &mut cell_type,
+                        &mut source,
+                        &mut execution_count,
+                        &mut outputs,
+                    )?;
+                }
+                None => break,
+            }
+        }
+    }
+
+    // Generate stable fallback ID for older notebooks without cell IDs
+    let id = id.unwrap_or_else(|| format!("__external_cell_{}", index));
+    let cell_type = cell_type.unwrap_or_else(|| "code".to_string());
+    let source = source.unwrap_or_default();
+
+    Ok(CellSnapshot {
+        id,
+        cell_type,
+        source,
+        execution_count,
+        outputs,
+    })
+}
+
+/// Process a single cell field.
+#[allow(clippy::too_many_arguments)]
+fn process_cell_field(
+    key: &str,
+    jiter: &mut Jiter,
+    id: &mut Option<String>,
+    cell_type: &mut Option<String>,
+    source: &mut Option<String>,
+    execution_count: &mut String,
+    outputs: &mut Vec<String>,
+) -> Result<(), StreamError> {
+    match key {
+        "id" => {
+            *id = match jiter.peek()? {
+                Peek::String => Some(jiter.next_str()?.to_string()),
+                _ => {
+                    jiter.next_skip()?;
+                    None
+                }
+            };
+        }
+        "cell_type" => {
+            *cell_type = match jiter.peek()? {
+                Peek::String => Some(jiter.next_str()?.to_string()),
+                _ => {
+                    jiter.next_skip()?;
+                    None
+                }
+            };
+        }
+        "source" => {
+            *source = Some(parse_source(jiter)?);
+        }
+        "execution_count" => {
+            *execution_count = match jiter.peek()? {
+                Peek::Null => {
+                    jiter.next_null()?;
+                    "null".to_string()
+                }
+                Peek::True | Peek::False => {
+                    jiter.next_skip()?;
+                    "null".to_string()
+                }
+                _ => {
+                    // Could be number
+                    let val = jiter.next_value()?;
+                    match val {
+                        JsonValue::Int(n) => n.to_string(),
+                        JsonValue::BigInt(n) => n.to_string(),
+                        JsonValue::Float(n) => (n as i64).to_string(),
+                        _ => "null".to_string(),
+                    }
+                }
+            };
+        }
+        "outputs" => {
+            *outputs = parse_outputs(jiter)?;
+        }
+        _ => {
+            // Skip metadata, attachments, etc.
+            jiter.next_skip()?;
+        }
+    }
+    Ok(())
+}
+
+/// Parse cell source which can be a string or array of strings.
+fn parse_source(jiter: &mut Jiter) -> Result<String, StreamError> {
+    match jiter.peek()? {
+        Peek::String => Ok(jiter.next_str()?.to_string()),
+        Peek::Array => {
+            let mut result = String::new();
+            // next_array() returns Option<Peek> for first element
+            if let Some(first_peek) = jiter.next_array()? {
+                if first_peek == Peek::String {
+                    result.push_str(jiter.next_str()?);
+                } else {
+                    jiter.next_skip()?;
+                }
+
+                // Process remaining elements
+                while let Some(peek) = jiter.array_step()? {
+                    if peek == Peek::String {
+                        result.push_str(jiter.next_str()?);
+                    } else {
+                        jiter.next_skip()?;
+                    }
+                }
+            }
+            Ok(result)
+        }
+        _ => {
+            jiter.next_skip()?;
+            Ok(String::new())
+        }
+    }
+}
+
+/// Parse outputs array, serializing each output as a JSON string.
+fn parse_outputs(jiter: &mut Jiter) -> Result<Vec<String>, StreamError> {
+    match jiter.peek()? {
+        Peek::Array => {
+            let mut outputs = Vec::new();
+            // next_array() returns Option<Peek> for first element
+            if let Some(first_peek) = jiter.next_array()? {
+                if first_peek == Peek::Object {
+                    let output_value = jiter.next_value()?;
+                    outputs.push(json_value_to_string(&output_value));
+                } else {
+                    jiter.next_skip()?;
+                }
+
+                // Process remaining elements
+                while let Some(peek) = jiter.array_step()? {
+                    if peek == Peek::Object {
+                        let output_value = jiter.next_value()?;
+                        outputs.push(json_value_to_string(&output_value));
+                    } else {
+                        jiter.next_skip()?;
+                    }
+                }
+            }
+            Ok(outputs)
+        }
+        _ => {
+            jiter.next_skip()?;
+            Ok(Vec::new())
+        }
+    }
+}
+
+/// Convert jiter JsonValue to JSON string.
+fn json_value_to_string(value: &JsonValue) -> String {
+    match value {
+        JsonValue::Null => "null".to_string(),
+        JsonValue::Bool(b) => b.to_string(),
+        JsonValue::Int(n) => n.to_string(),
+        JsonValue::BigInt(n) => n.to_string(),
+        JsonValue::Float(n) => n.to_string(),
+        JsonValue::Str(s) => format!("\"{}\"", escape_json_string(s)),
+        JsonValue::Array(arr) => {
+            let items: Vec<String> = arr.iter().map(json_value_to_string).collect();
+            format!("[{}]", items.join(","))
+        }
+        JsonValue::Object(obj) => {
+            let items: Vec<String> = obj
+                .iter()
+                .map(|(k, v)| format!("\"{}\":{}", escape_json_string(k), json_value_to_string(v)))
+                .collect();
+            format!("{{{}}}", items.join(","))
+        }
+    }
+}
+
+/// Escape special characters in a JSON string.
+fn escape_json_string(s: &str) -> String {
+    let mut result = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '"' => result.push_str("\\\""),
+            '\\' => result.push_str("\\\\"),
+            '\n' => result.push_str("\\n"),
+            '\r' => result.push_str("\\r"),
+            '\t' => result.push_str("\\t"),
+            c if c.is_control() => {
+                result.push_str(&format!("\\u{:04x}", c as u32));
+            }
+            c => result.push(c),
+        }
+    }
+    result
+}
+
+/// Parse notebook metadata from a jiter JsonValue.
+fn parse_metadata_from_value(value: &JsonValue) -> Result<NotebookMetadataSnapshot, StreamError> {
+    // Convert JsonValue to serde_json::Value for compatibility with existing code
+    let json_str = json_value_to_string(value);
+    let serde_value: serde_json::Value = serde_json::from_str(&json_str)
+        .map_err(|e| StreamError::InvalidStructure(format!("Failed to parse metadata: {}", e)))?;
+
+    Ok(NotebookMetadataSnapshot::from_metadata_value(&serde_value))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_simple_notebook() {
+        let notebook_json = r##"{
+            "nbformat": 4,
+            "nbformat_minor": 5,
+            "metadata": {
+                "kernelspec": {
+                    "name": "python3",
+                    "display_name": "Python 3"
+                }
+            },
+            "cells": [
+                {
+                    "id": "cell-1",
+                    "cell_type": "code",
+                    "source": "print('hello')",
+                    "execution_count": 1,
+                    "outputs": []
+                },
+                {
+                    "id": "cell-2",
+                    "cell_type": "markdown",
+                    "source": ["# Header\n", "Some text"],
+                    "outputs": []
+                }
+            ]
+        }"##;
+
+        let mut cells = Vec::new();
+        let result = stream_notebook_cells(notebook_json.as_bytes(), |cell, _idx| {
+            cells.push(cell);
+            Ok(())
+        })
+        .unwrap();
+
+        assert_eq!(result.cell_count, 2);
+        assert_eq!(cells.len(), 2);
+
+        assert_eq!(cells[0].id, "cell-1");
+        assert_eq!(cells[0].cell_type, "code");
+        assert_eq!(cells[0].source, "print('hello')");
+        assert_eq!(cells[0].execution_count, "1");
+
+        assert_eq!(cells[1].id, "cell-2");
+        assert_eq!(cells[1].cell_type, "markdown");
+        assert_eq!(cells[1].source, "# Header\nSome text");
+    }
+
+    #[test]
+    fn test_parse_cell_without_id() {
+        let notebook_json = r#"{
+            "cells": [
+                {
+                    "cell_type": "code",
+                    "source": "x = 1"
+                }
+            ]
+        }"#;
+
+        let mut cells = Vec::new();
+        stream_notebook_cells(notebook_json.as_bytes(), |cell, _idx| {
+            cells.push(cell);
+            Ok(())
+        })
+        .unwrap();
+
+        assert_eq!(cells[0].id, "__external_cell_0");
+    }
+
+    #[test]
+    fn test_parse_outputs() {
+        let notebook_json = r#"{
+            "cells": [
+                {
+                    "id": "cell-1",
+                    "cell_type": "code",
+                    "source": "1+1",
+                    "execution_count": 1,
+                    "outputs": [
+                        {
+                            "output_type": "execute_result",
+                            "data": {"text/plain": "2"},
+                            "execution_count": 1
+                        }
+                    ]
+                }
+            ]
+        }"#;
+
+        let mut cells = Vec::new();
+        stream_notebook_cells(notebook_json.as_bytes(), |cell, _idx| {
+            cells.push(cell);
+            Ok(())
+        })
+        .unwrap();
+
+        assert_eq!(cells[0].outputs.len(), 1);
+        assert!(cells[0].outputs[0].contains("execute_result"));
+    }
+}


### PR DESCRIPTION
## Summary

Implements streaming notebook loading to progressively render cells as they're parsed rather than waiting for the entire notebook to load.

## Changes

### Phase 1: Streaming JSON Parser
- New module: `crates/runtimed/src/streaming_ipynb.rs`
- Uses jiter (8x faster than serde_json) for incremental parsing
- `stream_notebook_cells()` - parses with callback per cell
- `parse_notebook()` - returns all cells as Vec for batch processing

### Phase 2: Loading Flag
- Added `is_loading` AtomicBool to NotebookRoom
- Added `is_loading()` and `set_loading()` helper methods  
- All `persist_tx.send()` calls guarded with `is_loading` check
- Prevents saving incomplete documents during streaming load

### Phase 3: Streaming Sync Messages
- New `load_notebook_streaming()` function adds cells in batches of 10
- Emits Automerge sync messages after each batch
- Modified `run_sync_loop_v2` to accept optional `load_path` parameter
- Updated daemon.rs to defer loading to sync loop for OpenNotebook

## How It Works

1. Client connects, receives `cell_count=0` initially
2. Sync loop starts and calls `load_notebook_streaming()`
3. Cells are parsed with jiter, then added in batches of 10
4. After each batch, sync message is generated and sent
5. Client receives cells progressively and renders them
6. Frontend uses `useSyncExternalStore` pattern - handles multiple sync messages naturally

## Testing

- 233 unit tests pass
- New tests for streaming parser (simple notebook, no ID, with outputs)
- Existing integration tests pass

## Future Work (Optional)

- Loading progress indicator in frontend
- Configurable batch size based on notebook size