### PR TITLE
fix(upgrade): rename button to clarify preparation step

### DIFF
--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -497,10 +497,10 @@ export function NotebookToolbar({
               onClick={onRestartToUpdate}
               data-testid="update-restart-button"
               className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium bg-green-500/15 text-green-600 hover:bg-green-500/25 dark:text-green-400 transition-colors"
-              title={`Restart to install v${updateVersion}`}
+              title={`Prepare to install v${updateVersion}`}
             >
               <RotateCcw className="h-3 w-3" />
-              <span>Restart to update</span>
+              <span>Prepare for Update</span>
             </button>
           )}
 


### PR DESCRIPTION
## Summary
Rename the "Restart to update" toolbar button to "Prepare for Update" to better reflect its behavior. The button now opens the upgrade review panel (where users review notebooks and stop busy kernels) rather than directly restarting the app.

Closes #660

## Test Plan
* [ ] Verify the toolbar button displays "Prepare for Update" when an update is available
* [ ] Confirm the tooltip shows "Prepare to install vX.X.X"
* [ ] Click the button to confirm it opens the upgrade review panel

_PR submitted by @rgbkrk's agent, Quill_