### PR TITLE
fix(notebook): activate app before file dialog when no windows exist

### DIFF
--- a/crates/notebook/Cargo.toml
+++ b/crates/notebook/Cargo.toml
@@ -76,9 +76,9 @@ axum = { version = "0.7", optional = true }
 tower-http = { version = "0.6", features = ["cors"], optional = true }
 base64 = { workspace = true, optional = true }
 
-# macOS: prevent focus stealing in webdriver mode
+# macOS: app activation for file dialogs when no windows exist
 [target.'cfg(target_os = "macos")'.dependencies]
-cocoa = { version = "0.26", optional = true }
+cocoa = "0.26"
 
 # Unix process group support for kernel cleanup
 [target.'cfg(unix)'.dependencies]
@@ -86,7 +86,7 @@ nix = { version = "0.30", features = ["signal", "process"] }
 
 [features]
 default = []
-webdriver-test = ["axum", "tower-http", "base64", "cocoa"]
+webdriver-test = ["axum", "tower-http", "base64"]
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -2976,6 +2976,18 @@ fn open_notebook_from_menu_without_window(
 ) {
     use tauri_plugin_dialog::DialogExt;
 
+    log::info!("[menu] File > Open triggered with no windows open");
+
+    // On macOS, activate the app to ensure the file dialog is visible
+    // when the app has no windows but is still running
+    #[cfg(target_os = "macos")]
+    unsafe {
+        use cocoa::appkit::NSApplication;
+        use cocoa::base::nil;
+        let ns_app = NSApplication::sharedApplication(nil);
+        ns_app.activateIgnoringOtherApps_(true);
+    }
+
     let app_handle = app.clone();
     let registry = registry.clone();
 

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -2981,6 +2981,7 @@ fn open_notebook_from_menu_without_window(
     // On macOS, activate the app to ensure the file dialog is visible
     // when the app has no windows but is still running
     #[cfg(target_os = "macos")]
+    #[allow(deprecated)]
     unsafe {
         use cocoa::appkit::NSApplication;
         use cocoa::base::nil;


### PR DESCRIPTION
## Summary
Fixes the File > Open menu action when all windows are closed on macOS.

On macOS, when the last notebook window is closed, the app stays running due to the exit prevention logic. However, clicking File > Open from the menu bar wouldn't display the file picker dialog because macOS requires the app to be activated first when it has no windows.

The fix activates the app via `NSApplication.activateIgnoringOtherApps_(true)` before showing the native file dialog in the no-window fallback path.

## Test plan
* [x] Close all notebook windows (app stays running in dock on macOS)
* [x] Click File > Open from the menu bar
* [x] Verify the file picker dialog appears
* [x] Select a `.ipynb` file and verify it opens in a new window

Closes #481

---

_PR submitted by @rgbkrk's agent, Quill_