### PR TITLE
feat(notebook): extract settings into separate window

### DIFF
--- a/apps/notebook/settings/App.tsx
+++ b/apps/notebook/settings/App.tsx
@@ -204,12 +204,12 @@ const themeOptions: { value: ThemeMode; label: string; icon: typeof Sun }[] = [
 ];
 
 export default function App() {
-  // Apply theme to window
-  useSyncedTheme();
+  // Apply theme to window and get theme controls
+  // IMPORTANT: Use theme/setTheme from useSyncedTheme, not a separate useSyncedSettings call,
+  // so that setTheme updates the same state instance that applies the DOM theme.
+  const { theme, setTheme } = useSyncedTheme();
 
   const {
-    theme,
-    setTheme,
     defaultRuntime,
     setDefaultRuntime,
     defaultPythonEnv,

--- a/apps/notebook/settings/App.tsx
+++ b/apps/notebook/settings/App.tsx
@@ -1,0 +1,416 @@
+import { AlertCircle, Monitor, Moon, Sun, X } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Slider } from "@/components/ui/slider";
+import {
+  isKnownPythonEnv,
+  isKnownRuntime,
+  type ThemeMode,
+  useSyncedSettings,
+  useSyncedTheme,
+} from "@/hooks/useSyncedSettings";
+import { cn } from "@/lib/utils";
+import {
+  CondaIcon,
+  DenoIcon,
+  PythonIcon,
+  UvIcon,
+} from "../src/components/icons";
+
+/** Format seconds into human-readable duration */
+function formatDuration(secs: number): string {
+  if (secs >= 86400) {
+    const days = Math.floor(secs / 86400);
+    const hours = Math.floor((secs % 86400) / 3600);
+    return hours > 0 ? `${days}d ${hours}h` : `${days}d`;
+  }
+  if (secs >= 3600) {
+    const hours = Math.floor(secs / 3600);
+    const mins = Math.floor((secs % 3600) / 60);
+    return mins > 0 ? `${hours}h ${mins}m` : `${hours}h`;
+  }
+  if (secs >= 60) {
+    const mins = Math.floor(secs / 60);
+    const remainingSecs = secs % 60;
+    return remainingSecs > 0 ? `${mins}m ${remainingSecs}s` : `${mins}m`;
+  }
+  return `${secs}s`;
+}
+
+// Exponential slider constants
+const MIN_SECS = 5;
+const MAX_SECS = 604800; // 7 days
+const SLIDER_STEPS = 100;
+
+// Convert slider position (0-100) to seconds (exponential scale)
+function sliderToSeconds(position: number): number {
+  const ratio = MAX_SECS / MIN_SECS;
+  const secs = Math.round(MIN_SECS * ratio ** (position / SLIDER_STEPS));
+  return Math.max(MIN_SECS, Math.min(MAX_SECS, secs));
+}
+
+// Convert seconds to slider position (0-100)
+function secondsToSlider(secs: number): number {
+  const ratio = MAX_SECS / MIN_SECS;
+  const position = (SLIDER_STEPS * Math.log(secs / MIN_SECS)) / Math.log(ratio);
+  return Math.max(0, Math.min(SLIDER_STEPS, Math.round(position)));
+}
+
+/** Keep Alive slider - exponential scale from 5s to 7 days */
+function KeepAliveSlider({
+  value,
+  onChange,
+}: {
+  value: number;
+  onChange: (value: number) => void;
+}) {
+  const [localValue, setLocalValue] = useState(value);
+
+  useEffect(() => {
+    setLocalValue(value);
+  }, [value]);
+
+  const sliderPosition = secondsToSlider(localValue);
+
+  return (
+    <div className="space-y-3 pt-4 border-t border-border/50">
+      <div>
+        <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+          Advanced
+        </span>
+      </div>
+      <div className="space-y-1">
+        <div className="flex items-center justify-between">
+          <span className="text-xs font-medium text-muted-foreground">
+            Keep Alive
+          </span>
+          <span className="text-xs font-medium text-foreground tabular-nums">
+            {formatDuration(localValue)}
+          </span>
+        </div>
+        <p className="text-[10px] text-muted-foreground/70">
+          Time to keep notebook runtime alive after closing
+        </p>
+      </div>
+      <div className="py-2">
+        <Slider
+          value={[sliderPosition]}
+          min={0}
+          max={SLIDER_STEPS}
+          step={1}
+          onValueChange={(v) => setLocalValue(sliderToSeconds(v[0]))}
+          onValueCommit={(v) => onChange(sliderToSeconds(v[0]))}
+        />
+      </div>
+      <div className="flex justify-between text-[10px] text-muted-foreground/70">
+        <span>5s</span>
+        <span>7 days</span>
+      </div>
+    </div>
+  );
+}
+
+/** Badge input for managing a list of package names */
+function PackageBadgeInput({
+  packages,
+  onChange,
+  placeholder,
+}: {
+  packages: string[];
+  onChange: (packages: string[]) => void;
+  placeholder?: string;
+}) {
+  const [inputValue, setInputValue] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const addPackage = useCallback(
+    (raw: string) => {
+      const name = raw.trim();
+      if (!name) return;
+      if (!packages.includes(name)) {
+        onChange([...packages, name]);
+      }
+      setInputValue("");
+    },
+    [packages, onChange],
+  );
+
+  const removePackage = useCallback(
+    (index: number) => {
+      onChange(packages.filter((_, i) => i !== index));
+    },
+    [packages, onChange],
+  );
+
+  return (
+    <div
+      className="flex flex-wrap items-center gap-1 min-h-7 rounded-md border bg-muted/50 px-1.5 py-1 cursor-text"
+      onClick={() => inputRef.current?.focus()}
+    >
+      {packages.map((pkg, i) => (
+        <span
+          key={`${pkg}-${i}`}
+          className="inline-flex items-center gap-0.5 rounded-md bg-secondary text-secondary-foreground pl-1.5 pr-0.5 py-0 text-xs leading-5"
+        >
+          {pkg}
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              removePackage(i);
+            }}
+            className="rounded-sm p-0 hover:bg-muted-foreground/20"
+          >
+            <X className="h-3 w-3" />
+          </button>
+        </span>
+      ))}
+      <input
+        ref={inputRef}
+        type="text"
+        value={inputValue}
+        onChange={(e) => setInputValue(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.preventDefault();
+            addPackage(inputValue);
+          } else if (
+            e.key === "Backspace" &&
+            inputValue === "" &&
+            packages.length > 0
+          ) {
+            removePackage(packages.length - 1);
+          }
+        }}
+        onBlur={() => {
+          if (inputValue.trim()) {
+            addPackage(inputValue);
+          }
+        }}
+        placeholder={packages.length === 0 ? placeholder : ""}
+        autoComplete="off"
+        autoCorrect="off"
+        autoCapitalize="off"
+        spellCheck={false}
+        className="flex-1 min-w-[80px] bg-transparent text-xs text-foreground placeholder:text-muted-foreground focus:outline-none h-5"
+      />
+    </div>
+  );
+}
+
+const themeOptions: { value: ThemeMode; label: string; icon: typeof Sun }[] = [
+  { value: "light", label: "Light", icon: Sun },
+  { value: "dark", label: "Dark", icon: Moon },
+  { value: "system", label: "System", icon: Monitor },
+];
+
+export default function App() {
+  // Apply theme to window
+  useSyncedTheme();
+
+  const {
+    theme,
+    setTheme,
+    defaultRuntime,
+    setDefaultRuntime,
+    defaultPythonEnv,
+    setDefaultPythonEnv,
+    defaultUvPackages,
+    setDefaultUvPackages,
+    defaultCondaPackages,
+    setDefaultCondaPackages,
+    keepAliveSecs,
+    setKeepAliveSecs,
+  } = useSyncedSettings();
+
+  return (
+    <div className="h-full overflow-auto">
+      <div className="p-6 space-y-6 max-w-lg mx-auto">
+        <h1 className="text-lg font-semibold">Settings</h1>
+
+        {/* Theme */}
+        <div className="space-y-2">
+          <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+            Appearance
+          </span>
+          <div className="flex items-center gap-3">
+            <span className="text-sm text-muted-foreground">Theme</span>
+            <div className="flex items-center gap-1 rounded-md border bg-muted/50 p-0.5">
+              {themeOptions.map((option) => {
+                const Icon = option.icon;
+                const isActive = theme === option.value;
+                return (
+                  <button
+                    key={option.value}
+                    type="button"
+                    onClick={() => setTheme(option.value)}
+                    className={cn(
+                      "flex items-center gap-1.5 rounded-sm px-2.5 py-1 text-xs transition-colors",
+                      isActive
+                        ? "bg-background text-foreground shadow-sm"
+                        : "text-muted-foreground hover:text-foreground",
+                    )}
+                  >
+                    <Icon className="h-3.5 w-3.5" />
+                    {option.label}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+
+        {/* Default Runtime */}
+        <div className="space-y-2">
+          <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+            New Notebooks
+          </span>
+          <div className="space-y-1">
+            <div className="flex items-center gap-3">
+              <span className="text-sm text-muted-foreground">
+                Default Runtime
+              </span>
+              <div className="flex items-center gap-1 rounded-md border bg-muted/50 p-0.5">
+                <button
+                  type="button"
+                  onClick={() => setDefaultRuntime("python")}
+                  className={cn(
+                    "flex items-center gap-1.5 rounded-sm px-2.5 py-1 text-xs transition-colors",
+                    defaultRuntime === "python"
+                      ? "bg-blue-500/15 text-blue-600 dark:text-blue-400 shadow-sm"
+                      : "text-muted-foreground hover:text-foreground",
+                  )}
+                >
+                  <PythonIcon className="h-3.5 w-3.5" />
+                  Python
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setDefaultRuntime("deno")}
+                  className={cn(
+                    "flex items-center gap-1.5 rounded-sm px-2.5 py-1 text-xs transition-colors",
+                    defaultRuntime === "deno"
+                      ? "bg-teal-500/15 text-teal-600 dark:text-teal-400 shadow-sm"
+                      : "text-muted-foreground hover:text-foreground",
+                  )}
+                >
+                  <DenoIcon className="h-3.5 w-3.5" />
+                  Deno
+                </button>
+              </div>
+            </div>
+            {defaultRuntime && !isKnownRuntime(defaultRuntime) && (
+              <div className="flex items-start gap-2 text-xs text-amber-700 dark:text-amber-400 mt-1">
+                <AlertCircle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+                <span>
+                  <span className="font-medium">
+                    &ldquo;{defaultRuntime}&rdquo;
+                  </span>{" "}
+                  is not a recognized runtime. Click Python or Deno above, or
+                  edit{" "}
+                  <code className="rounded bg-amber-500/20 px-1">
+                    settings.json
+                  </code>
+                  .
+                </span>
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Python Defaults */}
+        <div className="space-y-3">
+          <div>
+            <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+              Python Defaults
+            </span>
+            <p className="text-[11px] text-muted-foreground/70 mt-0.5">
+              Applied to new notebooks without project-based dependencies
+            </p>
+          </div>
+          <div
+            className="grid gap-3"
+            style={{ gridTemplateColumns: "auto 1fr" }}
+          >
+            {/* Default Python Env */}
+            <span className="text-sm text-muted-foreground whitespace-nowrap self-center text-right">
+              Environment
+            </span>
+            <div className="flex items-center gap-1 rounded-md border bg-muted/50 p-0.5 w-fit">
+              <button
+                type="button"
+                onClick={() => setDefaultPythonEnv("uv")}
+                className={cn(
+                  "flex items-center gap-1.5 rounded-sm px-2.5 py-1 text-xs transition-colors",
+                  defaultPythonEnv === "uv"
+                    ? "bg-fuchsia-500/15 text-fuchsia-600 dark:text-fuchsia-400 shadow-sm"
+                    : "text-muted-foreground hover:text-foreground",
+                )}
+              >
+                <UvIcon className="h-3 w-3" />
+                uv
+              </button>
+              <button
+                type="button"
+                onClick={() => setDefaultPythonEnv("conda")}
+                className={cn(
+                  "flex items-center gap-1.5 rounded-sm px-2.5 py-1 text-xs transition-colors",
+                  defaultPythonEnv === "conda"
+                    ? "bg-emerald-500/15 text-emerald-600 dark:text-emerald-400 shadow-sm"
+                    : "text-muted-foreground hover:text-foreground",
+                )}
+              >
+                <CondaIcon className="h-3 w-3" />
+                Conda
+              </button>
+            </div>
+            {defaultPythonEnv && !isKnownPythonEnv(defaultPythonEnv) && (
+              <div className="flex items-start gap-2 text-xs text-amber-700 dark:text-amber-400 col-span-2 mt-1">
+                <AlertCircle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+                <span>
+                  <span className="font-medium">
+                    &ldquo;{defaultPythonEnv}&rdquo;
+                  </span>{" "}
+                  is not a recognized environment. Click uv or Conda above, or
+                  edit{" "}
+                  <code className="rounded bg-amber-500/20 px-1">
+                    settings.json
+                  </code>
+                  .
+                </span>
+              </div>
+            )}
+
+            {/* Packages */}
+            {defaultPythonEnv === "uv" && (
+              <>
+                <span className="text-sm text-muted-foreground whitespace-nowrap self-center text-right">
+                  Packages
+                </span>
+                <PackageBadgeInput
+                  packages={defaultUvPackages}
+                  onChange={setDefaultUvPackages}
+                  placeholder="Add packages..."
+                />
+              </>
+            )}
+            {defaultPythonEnv === "conda" && (
+              <>
+                <span className="text-sm text-muted-foreground whitespace-nowrap self-center text-right">
+                  Packages
+                </span>
+                <PackageBadgeInput
+                  packages={defaultCondaPackages}
+                  onChange={setDefaultCondaPackages}
+                  placeholder="Add packages..."
+                />
+              </>
+            )}
+          </div>
+        </div>
+
+        {/* Advanced */}
+        <KeepAliveSlider value={keepAliveSecs} onChange={setKeepAliveSecs} />
+      </div>
+    </div>
+  );
+}

--- a/apps/notebook/settings/index.css
+++ b/apps/notebook/settings/index.css
@@ -1,0 +1,132 @@
+@config "../../../tailwind.config.js";
+@source "../src/components/**/*.{ts,tsx}";
+@source "./**/*.{ts,tsx}";
+
+@import "tailwindcss";
+@import "tw-animate-css";
+
+@custom-variant dark (&:is(.dark *));
+
+@theme inline {
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-destructive-foreground: var(--destructive-foreground);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+  --radius-2xl: calc(var(--radius) + 8px);
+  --radius-3xl: calc(var(--radius) + 12px);
+  --radius-4xl: calc(var(--radius) + 16px);
+}
+
+:root {
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.145 0 0);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.145 0 0);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.145 0 0);
+  --primary: oklch(0.205 0 0);
+  --primary-foreground: oklch(0.985 0 0);
+  --secondary: oklch(0.97 0 0);
+  --secondary-foreground: oklch(0.205 0 0);
+  --muted: oklch(0.97 0 0);
+  --muted-foreground: oklch(0.556 0 0);
+  --accent: oklch(0.97 0 0);
+  --accent-foreground: oklch(0.205 0 0);
+  --destructive: oklch(0.577 0.245 27.325);
+  --destructive-foreground: oklch(0.577 0.245 27.325);
+  --border: oklch(0.922 0 0);
+  --input: oklch(0.922 0 0);
+  --ring: oklch(0.708 0 0);
+  --radius: 0.625rem;
+}
+
+.dark {
+  --background: oklch(0.145 0 0);
+  --foreground: oklch(0.985 0 0);
+  --card: oklch(0.205 0 0);
+  --card-foreground: oklch(0.985 0 0);
+  --popover: oklch(0.205 0 0);
+  --popover-foreground: oklch(0.985 0 0);
+  --primary: oklch(0.922 0 0);
+  --primary-foreground: oklch(0.205 0 0);
+  --secondary: oklch(0.269 0 0);
+  --secondary-foreground: oklch(0.985 0 0);
+  --muted: oklch(0.269 0 0);
+  --muted-foreground: oklch(0.708 0 0);
+  --accent: oklch(0.269 0 0);
+  --accent-foreground: oklch(0.985 0 0);
+  --destructive: oklch(0.704 0.191 22.216);
+  --destructive-foreground: oklch(0.637 0.237 25.331);
+  --border: oklch(1 0 0 / 10%);
+  --input: oklch(1 0 0 / 15%);
+  --ring: oklch(0.556 0 0);
+}
+
+/* Fallback: apply dark theme when system prefers dark and no explicit light class */
+@media (prefers-color-scheme: dark) {
+  :root:not(.light) {
+    --background: oklch(0.145 0 0);
+    --foreground: oklch(0.985 0 0);
+    --card: oklch(0.205 0 0);
+    --card-foreground: oklch(0.985 0 0);
+    --popover: oklch(0.205 0 0);
+    --popover-foreground: oklch(0.985 0 0);
+    --primary: oklch(0.922 0 0);
+    --primary-foreground: oklch(0.205 0 0);
+    --secondary: oklch(0.269 0 0);
+    --secondary-foreground: oklch(0.985 0 0);
+    --muted: oklch(0.269 0 0);
+    --muted-foreground: oklch(0.708 0 0);
+    --accent: oklch(0.269 0 0);
+    --accent-foreground: oklch(0.985 0 0);
+    --destructive: oklch(0.704 0.191 22.216);
+    --destructive-foreground: oklch(0.637 0.237 25.331);
+    --border: oklch(1 0 0 / 10%);
+    --input: oklch(1 0 0 / 15%);
+    --ring: oklch(0.556 0 0);
+  }
+}
+
+* {
+  @apply border-border;
+}
+
+body {
+  @apply bg-background text-foreground;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen,
+    Ubuntu, Cantarell, sans-serif;
+}
+
+html, body, #root {
+  height: 100%;
+  overflow: hidden;
+}
+
+@layer base {
+  * {
+    @apply border-border outline-ring/50;
+  }
+  body {
+    @apply bg-background text-foreground;
+  }
+}

--- a/apps/notebook/settings/index.html
+++ b/apps/notebook/settings/index.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="dark light" />
+    <title>Settings</title>
+    <script>
+      // Apply theme immediately to prevent flash of wrong color on boot
+      (() => {
+        var STORAGE_KEY = 'notebook-theme';
+        var theme;
+        try {
+          theme = localStorage.getItem(STORAGE_KEY);
+        } catch (_e) {}
+
+        if (theme !== 'light' && theme !== 'dark' && theme !== 'system') {
+          theme = 'system';
+        }
+
+        var resolved = theme;
+        if (theme === 'system') {
+          resolved = window.matchMedia('(prefers-color-scheme: dark)').matches
+            ? 'dark'
+            : 'light';
+        }
+
+        document.documentElement.classList.add(resolved);
+      })();
+    </script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/apps/notebook/settings/main.tsx
+++ b/apps/notebook/settings/main.tsx
@@ -1,0 +1,10 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App";
+import "./index.css";
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -9,7 +9,7 @@ import {
   WidgetStoreProvider,
 } from "@/components/widgets/widget-store-context";
 import { WidgetView } from "@/components/widgets/widget-view";
-import { useSyncedSettings, useSyncedTheme } from "@/hooks/useSyncedSettings";
+import { useSyncedTheme } from "@/hooks/useSyncedSettings";
 import { ErrorBoundary } from "@/lib/error-boundary";
 import { CondaDependencyHeader } from "./components/CondaDependencyHeader";
 import {
@@ -84,19 +84,8 @@ function AppContent() {
   const gitInfo = useGitInfo();
   const daemonInfo = useDaemonInfo();
 
-  const { theme, setTheme } = useSyncedTheme();
-  const {
-    defaultRuntime,
-    setDefaultRuntime,
-    defaultPythonEnv,
-    setDefaultPythonEnv,
-    defaultUvPackages,
-    setDefaultUvPackages,
-    defaultCondaPackages,
-    setDefaultCondaPackages,
-    keepAliveSecs,
-    setKeepAliveSecs,
-  } = useSyncedSettings();
+  // Apply theme to this window
+  useSyncedTheme();
 
   const {
     cells,
@@ -209,15 +198,6 @@ function AppContent() {
     flexibleNpmImports,
     setFlexibleNpmImports,
   } = useDenoDependencies();
-
-  // Combine hasDependencies for toolbar badge
-  // For Deno, show badge if deno.json is found with imports
-  const hasDependencies =
-    runtime === "deno"
-      ? (denoConfigInfo?.has_imports ?? false)
-      : hasUvDependencies ||
-        hasCondaDependencies ||
-        (environmentYmlInfo?.has_dependencies ?? false);
 
   // Get widget store handler for routing comm messages
   const { handleMessage: handleWidgetMessage } = useWidgetStoreRequired();
@@ -926,23 +906,10 @@ function AppContent() {
         envSource={envSource}
         envTypeHint={envTypeHint}
         dirty={dirty}
-        hasDependencies={hasDependencies}
-        theme={theme}
         envProgress={
           envProgress.isActive || envProgress.error ? envProgress : null
         }
         runtime={runtime}
-        onThemeChange={setTheme}
-        defaultRuntime={defaultRuntime}
-        onDefaultRuntimeChange={setDefaultRuntime}
-        defaultPythonEnv={defaultPythonEnv}
-        onDefaultPythonEnvChange={setDefaultPythonEnv}
-        defaultUvPackages={defaultUvPackages}
-        onDefaultUvPackagesChange={setDefaultUvPackages}
-        defaultCondaPackages={defaultCondaPackages}
-        onDefaultCondaPackagesChange={setDefaultCondaPackages}
-        keepAliveSecs={keepAliveSecs}
-        onKeepAliveSecsChange={setKeepAliveSecs}
         onSave={save}
         onStartKernel={handleStartKernel}
         onInterruptKernel={interruptKernel}

--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -123,279 +123,279 @@ export function NotebookToolbar({
       : null;
 
   return (
-      <header
-        data-testid="notebook-toolbar"
-        className="sticky top-0 z-10 border-b bg-background/95 backdrop-blur supports-backdrop-filter:bg-background/60 select-none"
-      >
-        <div className="flex h-10 items-center gap-2 px-3">
-          {/* Save */}
+    <header
+      data-testid="notebook-toolbar"
+      className="sticky top-0 z-10 border-b bg-background/95 backdrop-blur supports-backdrop-filter:bg-background/60 select-none"
+    >
+      <div className="flex h-10 items-center gap-2 px-3">
+        {/* Save */}
+        <button
+          type="button"
+          onClick={onSave}
+          className={cn(
+            "flex items-center gap-1 rounded px-2 py-1 text-xs transition-colors hover:bg-muted",
+            dirty ? "text-foreground" : "text-muted-foreground",
+          )}
+          title="Save (Cmd+S)"
+          data-testid="save-button"
+        >
+          <Save className="h-3.5 w-3.5" />
+          {dirty && <span className="text-[10px]">&bull;</span>}
+        </button>
+
+        <div className="h-4 w-px bg-border" />
+
+        {/* Add cells */}
+        <button
+          type="button"
+          onClick={() => onAddCell("code", focusedCellId ?? lastCellId)}
+          className="flex items-center gap-1 rounded px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          title="Add code cell"
+          data-testid="add-code-cell-button"
+        >
+          <Plus className="h-3 w-3" />
+          Code
+        </button>
+        <button
+          type="button"
+          onClick={() => onAddCell("markdown", focusedCellId ?? lastCellId)}
+          className="flex items-center gap-1 rounded px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+          title="Add markdown cell"
+          data-testid="add-markdown-cell-button"
+        >
+          <Plus className="h-3 w-3" />
+          Markdown
+        </button>
+
+        <div className="h-4 w-px bg-border" />
+
+        {/* Kernel controls */}
+        {!isKernelRunning && (
           <button
             type="button"
-            onClick={onSave}
+            onClick={handleStartKernel}
+            disabled={listKernelspecs && kernelspecs.length === 0}
+            className="flex items-center gap-1 rounded px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:opacity-50"
+            title="Start kernel"
+            data-testid="start-kernel-button"
+          >
+            <Play className="h-3 w-3" fill="currentColor" />
+            Start Kernel
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={onRunAllCells}
+          className="flex items-center gap-1 rounded px-2 py-1 text-xs text-foreground transition-colors hover:bg-muted"
+          title="Run all cells"
+          data-testid="run-all-button"
+        >
+          <ChevronsRight className="h-3.5 w-3.5" />
+          Run All
+        </button>
+        <button
+          type="button"
+          onClick={onRestartKernel}
+          className="flex items-center gap-1 rounded px-2 py-1 text-xs text-foreground transition-colors hover:bg-muted"
+          title="Restart kernel"
+          data-testid="restart-kernel-button"
+        >
+          <RotateCcw className="h-3 w-3" />
+          Restart
+        </button>
+        <button
+          type="button"
+          onClick={onRestartAndRunAll}
+          className="flex items-center gap-1 rounded px-2 py-1 text-xs text-foreground transition-colors hover:bg-muted"
+          title="Restart kernel and run all cells"
+          data-testid="restart-run-all-button"
+        >
+          <RotateCcw className="h-3 w-3" />
+          <ChevronsRight className="h-3 w-3 -ml-1" />
+        </button>
+        {isKernelRunning && (
+          <button
+            type="button"
+            onClick={onInterruptKernel}
             className={cn(
-              "flex items-center gap-1 rounded px-2 py-1 text-xs transition-colors hover:bg-muted",
-              dirty ? "text-foreground" : "text-muted-foreground",
+              "flex items-center gap-1 rounded px-2 py-1 text-xs transition-colors",
+              kernelStatus === KERNEL_STATUS.BUSY
+                ? "text-destructive hover:bg-destructive/10"
+                : "text-foreground hover:bg-muted",
             )}
-            title="Save (Cmd+S)"
-            data-testid="save-button"
+            title="Interrupt kernel"
+            data-testid="interrupt-kernel-button"
           >
-            <Save className="h-3.5 w-3.5" />
-            {dirty && <span className="text-[10px]">&bull;</span>}
-          </button>
-
-          <div className="h-4 w-px bg-border" />
-
-          {/* Add cells */}
-          <button
-            type="button"
-            onClick={() => onAddCell("code", focusedCellId ?? lastCellId)}
-            className="flex items-center gap-1 rounded px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-            title="Add code cell"
-            data-testid="add-code-cell-button"
-          >
-            <Plus className="h-3 w-3" />
-            Code
-          </button>
-          <button
-            type="button"
-            onClick={() => onAddCell("markdown", focusedCellId ?? lastCellId)}
-            className="flex items-center gap-1 rounded px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-            title="Add markdown cell"
-            data-testid="add-markdown-cell-button"
-          >
-            <Plus className="h-3 w-3" />
-            Markdown
-          </button>
-
-          <div className="h-4 w-px bg-border" />
-
-          {/* Kernel controls */}
-          {!isKernelRunning && (
-            <button
-              type="button"
-              onClick={handleStartKernel}
-              disabled={listKernelspecs && kernelspecs.length === 0}
-              className="flex items-center gap-1 rounded px-2 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:opacity-50"
-              title="Start kernel"
-              data-testid="start-kernel-button"
-            >
-              <Play className="h-3 w-3" fill="currentColor" />
-              Start Kernel
-            </button>
-          )}
-          <button
-            type="button"
-            onClick={onRunAllCells}
-            className="flex items-center gap-1 rounded px-2 py-1 text-xs text-foreground transition-colors hover:bg-muted"
-            title="Run all cells"
-            data-testid="run-all-button"
-          >
-            <ChevronsRight className="h-3.5 w-3.5" />
-            Run All
-          </button>
-          <button
-            type="button"
-            onClick={onRestartKernel}
-            className="flex items-center gap-1 rounded px-2 py-1 text-xs text-foreground transition-colors hover:bg-muted"
-            title="Restart kernel"
-            data-testid="restart-kernel-button"
-          >
-            <RotateCcw className="h-3 w-3" />
-            Restart
-          </button>
-          <button
-            type="button"
-            onClick={onRestartAndRunAll}
-            className="flex items-center gap-1 rounded px-2 py-1 text-xs text-foreground transition-colors hover:bg-muted"
-            title="Restart kernel and run all cells"
-            data-testid="restart-run-all-button"
-          >
-            <RotateCcw className="h-3 w-3" />
-            <ChevronsRight className="h-3 w-3 -ml-1" />
-          </button>
-          {isKernelRunning && (
-            <button
-              type="button"
-              onClick={onInterruptKernel}
-              className={cn(
-                "flex items-center gap-1 rounded px-2 py-1 text-xs transition-colors",
-                kernelStatus === KERNEL_STATUS.BUSY
-                  ? "text-destructive hover:bg-destructive/10"
-                  : "text-foreground hover:bg-muted",
-              )}
-              title="Interrupt kernel"
-              data-testid="interrupt-kernel-button"
-            >
-              <Square
-                className="h-3 w-3"
-                fill={
-                  kernelStatus === KERNEL_STATUS.BUSY ? "currentColor" : "none"
-                }
-              />
-              Interrupt
-            </button>
-          )}
-
-          <div className="flex-1" />
-
-          {/* Update available */}
-          {updateStatus === "available" && onDownloadUpdate && (
-            <button
-              type="button"
-              onClick={onDownloadUpdate}
-              data-testid="update-download-button"
-              className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium bg-violet-500/10 text-violet-600 hover:bg-violet-500/20 dark:text-violet-400 transition-colors"
-              title={`Download update v${updateVersion}`}
-            >
-              <ArrowDownToLine className="h-3 w-3" />
-              <span>Update {updateVersion}</span>
-            </button>
-          )}
-          {updateStatus === "downloading" && (
-            <div
-              className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium bg-violet-500/10 text-violet-500 dark:text-violet-400"
-              title="Downloading update…"
-            >
-              <ArrowDownToLine className="h-3 w-3 animate-bounce" />
-              <span>Updating…</span>
-            </div>
-          )}
-          {updateStatus === "ready" && onRestartToUpdate && (
-            <button
-              type="button"
-              onClick={onRestartToUpdate}
-              data-testid="update-restart-button"
-              className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium bg-green-500/15 text-green-600 hover:bg-green-500/25 dark:text-green-400 transition-colors"
-              title={`Prepare to install v${updateVersion}`}
-            >
-              <RotateCcw className="h-3 w-3" />
-              <span>Prepare for Update</span>
-            </button>
-          )}
-
-          {/* Runtime / deps toggle */}
-          <button
-            type="button"
-            onClick={onToggleDependencies}
-            data-testid="deps-toggle"
-            data-runtime={runtime}
-            className={cn(
-              "flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium transition-colors",
-              runtime === "deno"
-                ? "bg-emerald-500/10 text-emerald-600 hover:bg-emerald-500/20 dark:text-emerald-400"
-                : "bg-blue-500/10 text-blue-600 hover:bg-blue-500/20 dark:text-blue-400",
-              isDepsOpen && "ring-1 ring-current/25",
-            )}
-            title={(() => {
-              const lang = runtime === "deno" ? "Deno/TypeScript" : "Python";
-              const mgr = envManager ? ` · ${envManager}` : "";
-              const action = isDepsOpen
-                ? "close environment panel"
-                : "open environment panel";
-              return `${lang}${mgr} — ${action}`;
-            })()}
-          >
-            {runtime === "deno" ? (
-              <>
-                <DenoIcon className="h-3 w-3" />
-                <span>Deno</span>
-              </>
-            ) : (
-              <>
-                <PythonIcon className="h-3 w-3" />
-                <span>Python</span>
-              </>
-            )}
-            {envManager && (
-              <>
-                <span className="opacity-40">·</span>
-                {envManager === "uv" && (
-                  <UvIcon className="h-2 w-2 text-fuchsia-600 dark:text-fuchsia-400" />
-                )}
-                {envManager === "conda" && (
-                  <CondaIcon className="h-2.5 w-2.5 text-emerald-600 dark:text-emerald-400" />
-                )}
-                {envManager === "pixi" && (
-                  <PixiIcon className="h-2.5 w-2.5 text-amber-600 dark:text-amber-400" />
-                )}
-              </>
-            )}
-          </button>
-
-          {/* Kernel status */}
-          <div
-            className="flex items-center gap-1.5 whitespace-nowrap"
-            role="status"
-            aria-label={`Kernel: ${
-              envProgress?.isActive
-                ? envProgress.statusText
-                : envProgress?.error
-                  ? envProgress.statusText
-                  : kernelStatus === KERNEL_STATUS.ERROR && kernelErrorMessage
-                    ? `Error \u2014 ${kernelErrorMessage}`
-                    : kernelStatusText
-            }`}
-            title={
-              envProgress?.isActive
-                ? envProgress.statusText
-                : envProgress?.error
-                  ? envProgress.error
-                  : kernelStatus === KERNEL_STATUS.ERROR && kernelErrorMessage
-                    ? `Error \u2014 ${kernelErrorMessage}`
-                    : kernelStatusText
-            }
-          >
-            <div
-              className={cn(
-                "h-2 w-2 shrink-0 rounded-full",
-                kernelStatus === KERNEL_STATUS.IDLE && "bg-green-500",
-                kernelStatus === KERNEL_STATUS.BUSY && "bg-amber-500",
-                kernelStatus === KERNEL_STATUS.STARTING &&
-                  "bg-blue-500 animate-pulse",
-                isKernelNotStarted && "bg-gray-400 dark:bg-gray-500",
-                kernelStatus === KERNEL_STATUS.ERROR && "bg-red-500",
-              )}
+            <Square
+              className="h-3 w-3"
+              fill={
+                kernelStatus === KERNEL_STATUS.BUSY ? "currentColor" : "none"
+              }
             />
-            <span className="text-xs text-muted-foreground whitespace-nowrap">
-              {envProgress?.isActive ? (
-                envProgress.statusText
-              ) : envProgress?.error ? (
-                <span className="text-red-600 dark:text-red-400">
-                  {envProgress.statusText}
-                </span>
-              ) : (
-                <span
-                  className={cn(
-                    "capitalize",
-                    kernelStatus === KERNEL_STATUS.ERROR &&
-                      "text-red-600 dark:text-red-400",
-                  )}
-                >
-                  {kernelStatusText}
-                </span>
-              )}
-            </span>
-          </div>
-        </div>
+            Interrupt
+          </button>
+        )}
 
-        {/* Deno install prompt */}
-        {runtime === "deno" &&
-          kernelStatus === KERNEL_STATUS.ERROR &&
-          kernelErrorMessage && (
-            <div className="border-t px-3 py-2">
-              <div className="flex items-start gap-2 text-xs text-amber-700 dark:text-amber-400">
-                <Info className="h-3.5 w-3.5 mt-0.5 shrink-0" />
-                <span>
-                  <span className="font-medium">Deno not available.</span>{" "}
-                  Auto-install failed. Install manually with{" "}
-                  <code className="rounded bg-amber-500/20 px-1">
-                    curl -fsSL https://deno.land/install.sh | sh
-                  </code>{" "}
-                  and restart.
-                </span>
-              </div>
-            </div>
+        <div className="flex-1" />
+
+        {/* Update available */}
+        {updateStatus === "available" && onDownloadUpdate && (
+          <button
+            type="button"
+            onClick={onDownloadUpdate}
+            data-testid="update-download-button"
+            className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium bg-violet-500/10 text-violet-600 hover:bg-violet-500/20 dark:text-violet-400 transition-colors"
+            title={`Download update v${updateVersion}`}
+          >
+            <ArrowDownToLine className="h-3 w-3" />
+            <span>Update {updateVersion}</span>
+          </button>
+        )}
+        {updateStatus === "downloading" && (
+          <div
+            className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium bg-violet-500/10 text-violet-500 dark:text-violet-400"
+            title="Downloading update…"
+          >
+            <ArrowDownToLine className="h-3 w-3 animate-bounce" />
+            <span>Updating…</span>
+          </div>
+        )}
+        {updateStatus === "ready" && onRestartToUpdate && (
+          <button
+            type="button"
+            onClick={onRestartToUpdate}
+            data-testid="update-restart-button"
+            className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium bg-green-500/15 text-green-600 hover:bg-green-500/25 dark:text-green-400 transition-colors"
+            title={`Prepare to install v${updateVersion}`}
+          >
+            <RotateCcw className="h-3 w-3" />
+            <span>Prepare for Update</span>
+          </button>
+        )}
+
+        {/* Runtime / deps toggle */}
+        <button
+          type="button"
+          onClick={onToggleDependencies}
+          data-testid="deps-toggle"
+          data-runtime={runtime}
+          className={cn(
+            "flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium transition-colors",
+            runtime === "deno"
+              ? "bg-emerald-500/10 text-emerald-600 hover:bg-emerald-500/20 dark:text-emerald-400"
+              : "bg-blue-500/10 text-blue-600 hover:bg-blue-500/20 dark:text-blue-400",
+            isDepsOpen && "ring-1 ring-current/25",
           )}
-      </header>
+          title={(() => {
+            const lang = runtime === "deno" ? "Deno/TypeScript" : "Python";
+            const mgr = envManager ? ` · ${envManager}` : "";
+            const action = isDepsOpen
+              ? "close environment panel"
+              : "open environment panel";
+            return `${lang}${mgr} — ${action}`;
+          })()}
+        >
+          {runtime === "deno" ? (
+            <>
+              <DenoIcon className="h-3 w-3" />
+              <span>Deno</span>
+            </>
+          ) : (
+            <>
+              <PythonIcon className="h-3 w-3" />
+              <span>Python</span>
+            </>
+          )}
+          {envManager && (
+            <>
+              <span className="opacity-40">·</span>
+              {envManager === "uv" && (
+                <UvIcon className="h-2 w-2 text-fuchsia-600 dark:text-fuchsia-400" />
+              )}
+              {envManager === "conda" && (
+                <CondaIcon className="h-2.5 w-2.5 text-emerald-600 dark:text-emerald-400" />
+              )}
+              {envManager === "pixi" && (
+                <PixiIcon className="h-2.5 w-2.5 text-amber-600 dark:text-amber-400" />
+              )}
+            </>
+          )}
+        </button>
+
+        {/* Kernel status */}
+        <div
+          className="flex items-center gap-1.5 whitespace-nowrap"
+          role="status"
+          aria-label={`Kernel: ${
+            envProgress?.isActive
+              ? envProgress.statusText
+              : envProgress?.error
+                ? envProgress.statusText
+                : kernelStatus === KERNEL_STATUS.ERROR && kernelErrorMessage
+                  ? `Error \u2014 ${kernelErrorMessage}`
+                  : kernelStatusText
+          }`}
+          title={
+            envProgress?.isActive
+              ? envProgress.statusText
+              : envProgress?.error
+                ? envProgress.error
+                : kernelStatus === KERNEL_STATUS.ERROR && kernelErrorMessage
+                  ? `Error \u2014 ${kernelErrorMessage}`
+                  : kernelStatusText
+          }
+        >
+          <div
+            className={cn(
+              "h-2 w-2 shrink-0 rounded-full",
+              kernelStatus === KERNEL_STATUS.IDLE && "bg-green-500",
+              kernelStatus === KERNEL_STATUS.BUSY && "bg-amber-500",
+              kernelStatus === KERNEL_STATUS.STARTING &&
+                "bg-blue-500 animate-pulse",
+              isKernelNotStarted && "bg-gray-400 dark:bg-gray-500",
+              kernelStatus === KERNEL_STATUS.ERROR && "bg-red-500",
+            )}
+          />
+          <span className="text-xs text-muted-foreground whitespace-nowrap">
+            {envProgress?.isActive ? (
+              envProgress.statusText
+            ) : envProgress?.error ? (
+              <span className="text-red-600 dark:text-red-400">
+                {envProgress.statusText}
+              </span>
+            ) : (
+              <span
+                className={cn(
+                  "capitalize",
+                  kernelStatus === KERNEL_STATUS.ERROR &&
+                    "text-red-600 dark:text-red-400",
+                )}
+              >
+                {kernelStatusText}
+              </span>
+            )}
+          </span>
+        </div>
+      </div>
+
+      {/* Deno install prompt */}
+      {runtime === "deno" &&
+        kernelStatus === KERNEL_STATUS.ERROR &&
+        kernelErrorMessage && (
+          <div className="border-t px-3 py-2">
+            <div className="flex items-start gap-2 text-xs text-amber-700 dark:text-amber-400">
+              <Info className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+              <span>
+                <span className="font-medium">Deno not available.</span>{" "}
+                Auto-install failed. Install manually with{" "}
+                <code className="rounded bg-amber-500/20 px-1">
+                  curl -fsSL https://deno.land/install.sh | sh
+                </code>{" "}
+                and restart.
+              </span>
+            </div>
+          </div>
+        )}
+    </header>
   );
 }

--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -1,28 +1,14 @@
 import {
-  AlertCircle,
   ArrowDownToLine,
   ChevronsRight,
   Info,
-  Monitor,
-  Moon,
   Play,
   Plus,
   RotateCcw,
   Save,
-  Settings,
   Square,
-  Sun,
-  X,
 } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from "@/components/ui/collapsible";
-import { Slider } from "@/components/ui/slider";
-import type { ThemeMode } from "@/hooks/useSyncedSettings";
-import { isKnownPythonEnv, isKnownRuntime } from "@/hooks/useSyncedSettings";
+import { useCallback, useEffect, useState } from "react";
 import { cn } from "@/lib/utils";
 import type { EnvProgressState } from "../hooks/useEnvProgress";
 import type { UpdateStatus } from "../hooks/useUpdater";
@@ -34,102 +20,6 @@ import {
 import type { KernelspecInfo } from "../types";
 import { CondaIcon, DenoIcon, PixiIcon, PythonIcon, UvIcon } from "./icons";
 
-/** Format seconds into human-readable duration */
-function formatDuration(secs: number): string {
-  if (secs >= 86400) {
-    const days = Math.floor(secs / 86400);
-    const hours = Math.floor((secs % 86400) / 3600);
-    return hours > 0 ? `${days}d ${hours}h` : `${days}d`;
-  }
-  if (secs >= 3600) {
-    const hours = Math.floor(secs / 3600);
-    const mins = Math.floor((secs % 3600) / 60);
-    return mins > 0 ? `${hours}h ${mins}m` : `${hours}h`;
-  }
-  if (secs >= 60) {
-    const mins = Math.floor(secs / 60);
-    const remainingSecs = secs % 60;
-    return remainingSecs > 0 ? `${mins}m ${remainingSecs}s` : `${mins}m`;
-  }
-  return `${secs}s`;
-}
-
-// Exponential slider constants
-const MIN_SECS = 5;
-const MAX_SECS = 604800; // 7 days
-const SLIDER_STEPS = 100;
-
-// Convert slider position (0-100) to seconds (exponential scale)
-function sliderToSeconds(position: number): number {
-  // Exponential: value = MIN * (MAX/MIN)^(position/100)
-  const ratio = MAX_SECS / MIN_SECS;
-  const secs = Math.round(MIN_SECS * ratio ** (position / SLIDER_STEPS));
-  return Math.max(MIN_SECS, Math.min(MAX_SECS, secs));
-}
-
-// Convert seconds to slider position (0-100)
-function secondsToSlider(secs: number): number {
-  // Inverse: position = 100 * log(value/MIN) / log(MAX/MIN)
-  const ratio = MAX_SECS / MIN_SECS;
-  const position = (SLIDER_STEPS * Math.log(secs / MIN_SECS)) / Math.log(ratio);
-  return Math.max(0, Math.min(SLIDER_STEPS, Math.round(position)));
-}
-
-/** Keep Alive slider - exponential scale from 5s to 7 days */
-function KeepAliveSlider({
-  value,
-  onChange,
-}: {
-  value: number;
-  onChange: (value: number) => void;
-}) {
-  const [localValue, setLocalValue] = useState(value);
-
-  // Sync local value when prop changes externally
-  useEffect(() => {
-    setLocalValue(value);
-  }, [value]);
-
-  const sliderPosition = secondsToSlider(localValue);
-
-  return (
-    <div className="space-y-3 pt-2 border-t border-border/50">
-      <div>
-        <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
-          Advanced
-        </span>
-      </div>
-      <div className="space-y-1">
-        <div className="flex items-center justify-between">
-          <span className="text-xs font-medium text-muted-foreground">
-            Keep Alive
-          </span>
-          <span className="text-xs font-medium text-foreground tabular-nums">
-            {formatDuration(localValue)}
-          </span>
-        </div>
-        <p className="text-[10px] text-muted-foreground/70">
-          Time to keep notebook runtime alive after closing
-        </p>
-      </div>
-      <div className="py-2">
-        <Slider
-          value={[sliderPosition]}
-          min={0}
-          max={SLIDER_STEPS}
-          step={1}
-          onValueChange={(v) => setLocalValue(sliderToSeconds(v[0]))}
-          onValueCommit={(v) => onChange(sliderToSeconds(v[0]))}
-        />
-      </div>
-      <div className="flex justify-between text-[10px] text-muted-foreground/70">
-        <span>5s</span>
-        <span>7 days</span>
-      </div>
-    </div>
-  );
-}
-
 /** Badge color variant for environment sources */
 type EnvBadgeVariant = "uv" | "conda" | "pixi";
 
@@ -140,21 +30,8 @@ interface NotebookToolbarProps {
   /** Pre-start hint: "uv" | "conda" | "pixi" | null, derived from notebook metadata */
   envTypeHint?: EnvBadgeVariant | null;
   dirty: boolean;
-  hasDependencies: boolean;
-  theme: ThemeMode;
   envProgress: EnvProgressState | null;
   runtime?: string;
-  onThemeChange: (theme: ThemeMode) => void;
-  defaultRuntime?: string;
-  onDefaultRuntimeChange?: (runtime: string) => void;
-  defaultPythonEnv?: string;
-  onDefaultPythonEnvChange?: (env: string) => void;
-  defaultUvPackages?: string[];
-  onDefaultUvPackagesChange?: (packages: string[]) => void;
-  defaultCondaPackages?: string[];
-  onDefaultCondaPackagesChange?: (packages: string[]) => void;
-  keepAliveSecs?: number;
-  onKeepAliveSecsChange?: (secs: number) => void;
   onSave: () => void;
   onStartKernel: (name: string) => void;
   onInterruptKernel: () => void;
@@ -173,120 +50,14 @@ interface NotebookToolbarProps {
   onRestartToUpdate?: () => void;
 }
 
-const themeOptions: { value: ThemeMode; label: string; icon: typeof Sun }[] = [
-  { value: "light", label: "Light", icon: Sun },
-  { value: "dark", label: "Dark", icon: Moon },
-  { value: "system", label: "System", icon: Monitor },
-];
-
-/** Badge input for managing a list of package names */
-function PackageBadgeInput({
-  packages,
-  onChange,
-  placeholder,
-}: {
-  packages: string[];
-  onChange: (packages: string[]) => void;
-  placeholder?: string;
-}) {
-  const [inputValue, setInputValue] = useState("");
-  const inputRef = useRef<HTMLInputElement>(null);
-
-  const addPackage = useCallback(
-    (raw: string) => {
-      const name = raw.trim();
-      if (!name) return;
-      if (!packages.includes(name)) {
-        onChange([...packages, name]);
-      }
-      setInputValue("");
-    },
-    [packages, onChange],
-  );
-
-  const removePackage = useCallback(
-    (index: number) => {
-      onChange(packages.filter((_, i) => i !== index));
-    },
-    [packages, onChange],
-  );
-
-  return (
-    <div
-      className="flex flex-wrap items-center gap-1 min-h-7 max-w-md rounded-md border bg-muted/50 px-1.5 py-1 cursor-text"
-      onClick={() => inputRef.current?.focus()}
-    >
-      {packages.map((pkg, i) => (
-        <span
-          key={`${pkg}-${i}`}
-          className="inline-flex items-center gap-0.5 rounded-md bg-secondary text-secondary-foreground pl-1.5 pr-0.5 py-0 text-xs leading-5"
-        >
-          {pkg}
-          <button
-            type="button"
-            onClick={(e) => {
-              e.stopPropagation();
-              removePackage(i);
-            }}
-            className="rounded-sm p-0 hover:bg-muted-foreground/20"
-          >
-            <X className="h-3 w-3" />
-          </button>
-        </span>
-      ))}
-      <input
-        ref={inputRef}
-        type="text"
-        value={inputValue}
-        onChange={(e) => setInputValue(e.target.value)}
-        onKeyDown={(e) => {
-          if (e.key === "Enter") {
-            e.preventDefault();
-            addPackage(inputValue);
-          } else if (
-            e.key === "Backspace" &&
-            inputValue === "" &&
-            packages.length > 0
-          ) {
-            removePackage(packages.length - 1);
-          }
-        }}
-        onBlur={() => {
-          if (inputValue.trim()) {
-            addPackage(inputValue);
-          }
-        }}
-        placeholder={packages.length === 0 ? placeholder : ""}
-        autoComplete="off"
-        autoCorrect="off"
-        autoCapitalize="off"
-        spellCheck={false}
-        className="flex-1 min-w-[80px] bg-transparent text-xs text-foreground placeholder:text-muted-foreground focus:outline-none h-5"
-      />
-    </div>
-  );
-}
-
 export function NotebookToolbar({
   kernelStatus,
   kernelErrorMessage,
   envSource,
   envTypeHint,
   dirty,
-  theme,
   envProgress,
   runtime = "python",
-  onThemeChange,
-  defaultRuntime = "python",
-  onDefaultRuntimeChange,
-  defaultPythonEnv = "uv",
-  onDefaultPythonEnvChange,
-  defaultUvPackages = [],
-  onDefaultUvPackagesChange,
-  defaultCondaPackages = [],
-  onDefaultCondaPackagesChange,
-  keepAliveSecs = 30,
-  onKeepAliveSecsChange,
   onSave,
   onStartKernel,
   onInterruptKernel,
@@ -305,7 +76,6 @@ export function NotebookToolbar({
   onRestartToUpdate,
 }: NotebookToolbarProps) {
   const [kernelspecs, setKernelspecs] = useState<KernelspecInfo[]>([]);
-  const [settingsOpen, setSettingsOpen] = useState(false);
 
   useEffect(() => {
     if (listKernelspecs) {
@@ -353,7 +123,6 @@ export function NotebookToolbar({
       : null;
 
   return (
-    <Collapsible open={settingsOpen} onOpenChange={setSettingsOpen}>
       <header
         data-testid="notebook-toolbar"
         className="sticky top-0 z-10 border-b bg-background/95 backdrop-blur supports-backdrop-filter:bg-background/60 select-none"
@@ -607,22 +376,6 @@ export function NotebookToolbar({
               )}
             </span>
           </div>
-
-          <div className="h-4 w-px bg-border" />
-
-          {/* Settings gear */}
-          <CollapsibleTrigger asChild>
-            <button
-              type="button"
-              className={cn(
-                "flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground",
-                settingsOpen && "bg-muted text-foreground",
-              )}
-              aria-label="Settings"
-            >
-              <Settings className="h-4 w-4" />
-            </button>
-          </CollapsibleTrigger>
         </div>
 
         {/* Deno install prompt */}
@@ -643,220 +396,6 @@ export function NotebookToolbar({
               </div>
             </div>
           )}
-
-        {/* Collapsible settings panel */}
-        <CollapsibleContent>
-          <div
-            className="border-t bg-background px-4 py-3 space-y-3"
-            data-testid="settings-panel"
-          >
-            {/* Global settings */}
-            <div className="flex flex-wrap items-center gap-x-6 gap-y-2">
-              {/* Theme */}
-              <div className="flex items-center gap-3">
-                <span className="text-xs font-medium text-muted-foreground">
-                  Theme
-                </span>
-                <div
-                  className="flex items-center gap-1 rounded-md border bg-muted/50 p-0.5"
-                  data-testid="settings-theme-group"
-                >
-                  {themeOptions.map((option) => {
-                    const Icon = option.icon;
-                    const isActive = theme === option.value;
-                    return (
-                      <button
-                        key={option.value}
-                        type="button"
-                        onClick={() => onThemeChange(option.value)}
-                        className={cn(
-                          "flex items-center gap-1.5 rounded-sm px-2.5 py-1 text-xs transition-colors",
-                          isActive
-                            ? "bg-background text-foreground shadow-sm"
-                            : "text-muted-foreground hover:text-foreground",
-                        )}
-                      >
-                        <Icon className="h-3.5 w-3.5" />
-                        {option.label}
-                      </button>
-                    );
-                  })}
-                </div>
-              </div>
-
-              {/* Default Runtime */}
-              {onDefaultRuntimeChange && (
-                <div className="space-y-1">
-                  <div className="flex items-center gap-3">
-                    <span className="text-xs font-medium text-muted-foreground">
-                      Default Runtime
-                    </span>
-                    <div
-                      className="flex items-center gap-1 rounded-md border bg-muted/50 p-0.5"
-                      data-testid="settings-runtime-group"
-                    >
-                      <button
-                        type="button"
-                        onClick={() => onDefaultRuntimeChange("python")}
-                        className={cn(
-                          "flex items-center gap-1.5 rounded-sm px-2.5 py-1 text-xs transition-colors",
-                          defaultRuntime === "python"
-                            ? "bg-blue-500/15 text-blue-600 dark:text-blue-400 shadow-sm"
-                            : "text-muted-foreground hover:text-foreground",
-                        )}
-                      >
-                        <PythonIcon className="h-3.5 w-3.5" />
-                        Python
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => onDefaultRuntimeChange("deno")}
-                        className={cn(
-                          "flex items-center gap-1.5 rounded-sm px-2.5 py-1 text-xs transition-colors",
-                          defaultRuntime === "deno"
-                            ? "bg-teal-500/15 text-teal-600 dark:text-teal-400 shadow-sm"
-                            : "text-muted-foreground hover:text-foreground",
-                        )}
-                      >
-                        <DenoIcon className="h-3.5 w-3.5" />
-                        Deno
-                      </button>
-                    </div>
-                  </div>
-                  {defaultRuntime && !isKnownRuntime(defaultRuntime) && (
-                    <div className="flex items-start gap-2 text-xs text-amber-700 dark:text-amber-400 mt-1">
-                      <AlertCircle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
-                      <span>
-                        <span className="font-medium">
-                          &ldquo;{defaultRuntime}&rdquo;
-                        </span>{" "}
-                        is not a recognized runtime. Click Python or Deno above,
-                        or edit{" "}
-                        <code className="rounded bg-amber-500/20 px-1">
-                          settings.json
-                        </code>
-                        .
-                      </span>
-                    </div>
-                  )}
-                </div>
-              )}
-            </div>
-
-            {/* Python settings */}
-            {(onDefaultPythonEnvChange ||
-              onDefaultUvPackagesChange ||
-              onDefaultCondaPackagesChange) && (
-              <div className="space-y-2">
-                <div>
-                  <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
-                    Python Defaults
-                  </span>
-                  <p className="text-[11px] text-muted-foreground/70 mt-0.5">
-                    Applied to new notebooks without project-based dependencies
-                  </p>
-                </div>
-                <div
-                  className="grid gap-2"
-                  style={{ gridTemplateColumns: "auto 1fr" }}
-                >
-                  {/* Default Python Env */}
-                  {onDefaultPythonEnvChange && (
-                    <>
-                      <span className="text-xs font-medium text-muted-foreground whitespace-nowrap self-center text-right">
-                        Environment
-                      </span>
-                      <div
-                        className="flex items-center gap-1 rounded-md border bg-muted/50 p-0.5 w-fit"
-                        data-testid="settings-python-env-group"
-                      >
-                        <button
-                          type="button"
-                          onClick={() => onDefaultPythonEnvChange("uv")}
-                          className={cn(
-                            "flex items-center gap-1.5 rounded-sm px-2.5 py-1 text-xs transition-colors",
-                            defaultPythonEnv === "uv"
-                              ? "bg-fuchsia-500/15 text-fuchsia-600 dark:text-fuchsia-400 shadow-sm"
-                              : "text-muted-foreground hover:text-foreground",
-                          )}
-                        >
-                          <UvIcon className="h-3 w-3" />
-                          uv
-                        </button>
-                        <button
-                          type="button"
-                          onClick={() => onDefaultPythonEnvChange("conda")}
-                          className={cn(
-                            "flex items-center gap-1.5 rounded-sm px-2.5 py-1 text-xs transition-colors",
-                            defaultPythonEnv === "conda"
-                              ? "bg-emerald-500/15 text-emerald-600 dark:text-emerald-400 shadow-sm"
-                              : "text-muted-foreground hover:text-foreground",
-                          )}
-                        >
-                          <CondaIcon className="h-3 w-3" />
-                          Conda
-                        </button>
-                      </div>
-                      {defaultPythonEnv &&
-                        !isKnownPythonEnv(defaultPythonEnv) && (
-                          <div className="flex items-start gap-2 text-xs text-amber-700 dark:text-amber-400 col-span-2 mt-1">
-                            <AlertCircle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
-                            <span>
-                              <span className="font-medium">
-                                &ldquo;{defaultPythonEnv}&rdquo;
-                              </span>{" "}
-                              is not a recognized environment. Click uv or Conda
-                              above, or edit{" "}
-                              <code className="rounded bg-amber-500/20 px-1">
-                                settings.json
-                              </code>
-                              .
-                            </span>
-                          </div>
-                        )}
-                    </>
-                  )}
-
-                  {/* Packages — show only the input matching the selected env */}
-                  {defaultPythonEnv === "uv" && onDefaultUvPackagesChange && (
-                    <>
-                      <span className="text-xs font-medium text-muted-foreground whitespace-nowrap self-center text-right">
-                        Packages
-                      </span>
-                      <PackageBadgeInput
-                        packages={defaultUvPackages}
-                        onChange={onDefaultUvPackagesChange}
-                        placeholder="Add packages…"
-                      />
-                    </>
-                  )}
-                  {defaultPythonEnv === "conda" &&
-                    onDefaultCondaPackagesChange && (
-                      <>
-                        <span className="text-xs font-medium text-muted-foreground whitespace-nowrap self-center text-right">
-                          Packages
-                        </span>
-                        <PackageBadgeInput
-                          packages={defaultCondaPackages}
-                          onChange={onDefaultCondaPackagesChange}
-                          placeholder="Add packages…"
-                        />
-                      </>
-                    )}
-                </div>
-              </div>
-            )}
-
-            {/* Advanced settings */}
-            {onKeepAliveSecsChange && (
-              <KeepAliveSlider
-                value={keepAliveSecs}
-                onChange={onKeepAliveSecsChange}
-              />
-            )}
-          </div>
-        </CollapsibleContent>
       </header>
-    </Collapsible>
   );
 }

--- a/apps/notebook/vite.config.ts
+++ b/apps/notebook/vite.config.ts
@@ -31,6 +31,7 @@ export default defineConfig({
         main: path.resolve(__dirname, "index.html"),
         onboarding: path.resolve(__dirname, "onboarding/index.html"),
         upgrade: path.resolve(__dirname, "upgrade/index.html"),
+        settings: path.resolve(__dirname, "settings/index.html"),
       },
       output: {
         entryFileNames: "assets/[name].js",

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -2916,6 +2916,39 @@ async fn set_synced_setting(key: String, value: serde_json::Value) -> Result<(),
     Ok(())
 }
 
+/// Open the settings window.
+///
+/// Uses singleton pattern - focuses existing window if present, otherwise creates new one.
+#[tauri::command]
+async fn open_settings_window(app: tauri::AppHandle) -> Result<(), String> {
+    // Singleton: focus existing window if present
+    if let Some(existing_window) = app.get_webview_window("settings") {
+        existing_window
+            .set_focus()
+            .map_err(|e| format!("Failed to focus settings window: {}", e))?;
+        return Ok(());
+    }
+
+    // Create settings window
+    tauri::WebviewWindowBuilder::new(
+        &app,
+        "settings",
+        tauri::WebviewUrl::App("settings/index.html".into()),
+    )
+    .title(format!(
+        "{} Settings",
+        runt_workspace::desktop_display_name()
+    ))
+    .inner_size(560.0, 580.0)
+    .min_inner_size(450.0, 400.0)
+    .resizable(true)
+    .center()
+    .build()
+    .map_err(|e| format!("Failed to create settings window: {}", e))?;
+
+    Ok(())
+}
+
 fn focused_window(app: &tauri::AppHandle) -> Option<tauri::WebviewWindow> {
     app.webview_windows()
         .into_values()
@@ -3468,6 +3501,7 @@ pub fn run(
             // Synced settings (via runtimed Automerge)
             get_synced_settings,
             set_synced_setting,
+            open_settings_window,
             // Onboarding
             complete_onboarding,
             // Debug info
@@ -3876,6 +3910,14 @@ pub fn run(
                             (),
                         );
                     }
+                }
+                crate::menu::MENU_SETTINGS => {
+                    let app_handle = app.clone();
+                    tauri::async_runtime::spawn(async move {
+                        if let Err(e) = open_settings_window(app_handle).await {
+                            log::error!("[menu] Failed to open settings window: {}", e);
+                        }
+                    });
                 }
                 crate::menu::MENU_INSTALL_CLI => {
                     let app_handle = app.clone();

--- a/crates/notebook/src/menu.rs
+++ b/crates/notebook/src/menu.rs
@@ -30,9 +30,10 @@ pub const MENU_ZOOM_RESET: &str = "zoom_reset";
 pub const MENU_RUN_ALL_CELLS: &str = "run_all_cells";
 pub const MENU_RESTART_AND_RUN_ALL: &str = "restart_and_run_all";
 
-// Menu item IDs for CLI installation
+// Menu item IDs for CLI installation and settings
 pub const MENU_INSTALL_CLI: &str = "install_cli";
 pub const MENU_CHECK_FOR_UPDATES: &str = "check_for_updates";
+pub const MENU_SETTINGS: &str = "settings";
 pub const APP_VERSION: &str = env!("CARGO_PKG_VERSION");
 pub const APP_COMMIT_SHA: &str = env!("GIT_COMMIT");
 pub const APP_RELEASE_DATE: &str = env!("GIT_COMMIT_DATE");
@@ -133,6 +134,14 @@ pub fn create_menu(
         "Check for Updates...",
         true,
         None::<&str>,
+    )?)?;
+    app_menu.append(&PredefinedMenuItem::separator(app)?)?;
+    app_menu.append(&MenuItem::with_id(
+        app,
+        MENU_SETTINGS,
+        "Settings...",
+        true,
+        Some("CmdOrCtrl+,"),
     )?)?;
     app_menu.append(&PredefinedMenuItem::separator(app)?)?;
     app_menu.append(&PredefinedMenuItem::services(app, None)?)?;


### PR DESCRIPTION
## Summary

Moves the settings panel from the notebook toolbar into a dedicated settings window. Settings are now accessed via **App menu > Settings...** or **Cmd+,** (macOS standard shortcut) instead of a collapsible panel in the toolbar.

This clarifies that settings control global app preferences, not notebook-specific configurations. The Python/Deno dependencies button remains in the toolbar since it manages notebook-level dependencies.

## Changes

- Create new settings window with theme, runtime, and Python environment controls
- Add Cmd+, menu shortcut for opening settings (singleton window pattern)
- Remove collapsible settings panel from NotebookToolbar
- Remove settings gear icon from toolbar
- Window size: 560×580 default, 450×400 minimum

## Verification

* [x] Open settings from App menu (Cmd+,) - window appears
* [x] Change theme in settings - all notebook windows update
* [x] Press Cmd+, while settings open - focuses existing window (no duplicates)
* [x] Python/Deno deps button in toolbar works for current notebook
* [x] Settings window is resizable and centered on first open

---

_PR submitted by @rgbkrk's agent, Quill_