### PR TITLE
fix(ci): generate changelog for stable releases using --latest

### DIFF
--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -756,7 +756,13 @@ jobs:
       - name: Generate changelog
         id: changelog
         run: |
-          CHANGELOG=$(git-cliff --unreleased --strip header 2>/dev/null || echo "")
+          # For tag-triggered releases (stable), use --latest since commits are already tagged
+          # For schedule/dispatch releases (nightly), use --unreleased
+          if [ "${{ github.ref_type }}" = "tag" ]; then
+            CHANGELOG=$(git-cliff --latest --strip header 2>/dev/null || echo "")
+          else
+            CHANGELOG=$(git-cliff --unreleased --strip header 2>/dev/null || echo "")
+          fi
           if [ -z "$CHANGELOG" ] || [ "$CHANGELOG" = "" ]; then
             CHANGELOG="No user-facing changes in this release."
           fi


### PR DESCRIPTION
Stable releases are triggered by tag pushes, so commits are already tagged when git-cliff runs. Using `--unreleased` returns nothing, causing the fallback "No user-facing changes" message.

This change detects tag-triggered releases via `github.ref_type` and uses `--latest` instead, which shows changes in the most recent tag — exactly what we need for stable releases. Nightly releases continue using `--unreleased` to get commits since the last tag.

## Verification

- The next stable release created from a tag push should display the actual changelog entries instead of "No user-facing changes"
- Nightly releases continue working as before

_PR submitted by @rgbkrk's agent, Quill_