### PR TITLE
feat(markdown): resolve relative image paths via daemon and blob store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1921,6 +1921,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "getopts"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
+dependencies = [
+ "unicode-width 0.2.2",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4602,6 +4611,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83c41efbf8f90ac44de7f3a868f0867851d261b56291732d0cbf7cceaaeb55a6"
+dependencies = [
+ "bitflags 2.11.0",
+ "getopts",
+ "memchr",
+ "pulldown-cmark-escape",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-escape"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
+
+[[package]]
 name = "purl"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5709,6 +5737,7 @@ dependencies = [
  "notify",
  "notify-debouncer-mini",
  "petname",
+ "pulldown-cmark",
  "rattler",
  "rattler_cache",
  "rattler_conda_types",

--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -12,9 +12,35 @@ import { isDarkMode as detectDarkMode } from "@/lib/dark-mode";
 import { cn } from "@/lib/utils";
 import { useCellKeyboardNavigation } from "../hooks/useCellKeyboardNavigation";
 import { useEditorRegistry } from "../hooks/useEditorRegistry";
+import { fetchBlobPortWithRetry } from "../hooks/useManifestResolver";
 import { logger } from "../lib/logger";
 import { openUrl } from "../lib/open-url";
 import type { MarkdownCell as MarkdownCellType } from "../types";
+
+/**
+ * Apply cell attachments to markdown source.
+ * Replaces relative image paths with blob URLs.
+ */
+function applyAttachments(
+  source: string,
+  attachments: Record<string, string> | undefined,
+  blobPort: number | null,
+): string {
+  if (!attachments || !blobPort || Object.keys(attachments).length === 0) {
+    return source;
+  }
+
+  let result = source;
+  for (const [path, hash] of Object.entries(attachments)) {
+    const blobUrl = `http://127.0.0.1:${blobPort}/blob/${hash}`;
+    // Escape special regex characters in the path
+    const escapedPath = path.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    // Replace ![...](path) with ![...](blobUrl)
+    const regex = new RegExp(`(!\\[[^\\]]*\\])\\(${escapedPath}\\)`, "g");
+    result = result.replace(regex, `$1(${blobUrl})`);
+  }
+  return result;
+}
 
 interface MarkdownCellProps {
   cell: MarkdownCellType;
@@ -140,6 +166,12 @@ export function MarkdownCell({
     return () => observer.disconnect();
   }, []);
 
+  // Fetch blob port for resolving attachments
+  const [blobPort, setBlobPort] = useState<number | null>(null);
+  useEffect(() => {
+    fetchBlobPortWithRetry().then(setBlobPort);
+  }, []);
+
   // Register editor with the registry for cross-cell navigation
   useEffect(() => {
     if (editing && editorRef.current) {
@@ -165,25 +197,35 @@ export function MarkdownCell({
   // Render markdown content when iframe is ready
   const handleFrameReady = useCallback(() => {
     if (!frameRef.current || !cell.source) return;
+    const processedSource = applyAttachments(
+      cell.source,
+      cell.attachments,
+      blobPort,
+    );
     frameRef.current.render({
       mimeType: "text/markdown",
-      data: cell.source,
+      data: processedSource,
       cellId: cell.id,
       replace: true,
     });
-  }, [cell.source, cell.id]);
+  }, [cell.source, cell.id, cell.attachments, blobPort]);
 
-  // Sync markdown to iframe whenever source changes (supports RTC updates)
+  // Sync markdown to iframe whenever source or attachments change (supports RTC updates)
   useEffect(() => {
     if (frameRef.current?.isReady && cell.source) {
+      const processedSource = applyAttachments(
+        cell.source,
+        cell.attachments,
+        blobPort,
+      );
       frameRef.current.render({
         mimeType: "text/markdown",
-        data: cell.source,
+        data: processedSource,
         cellId: cell.id,
         replace: true,
       });
     }
-  }, [cell.source, cell.id]);
+  }, [cell.source, cell.id, cell.attachments, blobPort]);
 
   // Handle link clicks from iframe - open in system browser
   const handleLinkClick = useCallback((url: string) => {

--- a/apps/notebook/src/lib/materialize-cells.ts
+++ b/apps/notebook/src/lib/materialize-cells.ts
@@ -25,6 +25,7 @@ export interface CellSnapshot {
   execution_count: string; // "5" or "null"
   outputs: string[]; // JSON-encoded Jupyter outputs or manifest hashes
   metadata: Record<string, unknown>; // Cell metadata (arbitrary JSON object)
+  attachments?: Record<string, string>; // path → blob hash (markdown cells)
 }
 
 /**
@@ -225,9 +226,19 @@ export async function cellSnapshotsToNotebookCells(
       }
 
       // markdown or raw
+      if (snap.cell_type === "markdown") {
+        return {
+          id: snap.id,
+          cell_type: "markdown" as const,
+          source: snap.source,
+          metadata,
+          attachments: snap.attachments,
+        };
+      }
+
       return {
         id: snap.id,
-        cell_type: snap.cell_type as "markdown" | "raw",
+        cell_type: "raw" as const,
         source: snap.source,
         metadata,
       };

--- a/apps/notebook/src/types.ts
+++ b/apps/notebook/src/types.ts
@@ -15,6 +15,8 @@ export interface MarkdownCell {
   id: string;
   source: string;
   metadata: CellMetadata;
+  /** Resolved image attachments: relative path → blob hash */
+  attachments?: Record<string, string>;
 }
 
 export interface RawCell {

--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -32,6 +32,8 @@
 
 pub mod metadata;
 
+use std::collections::HashMap;
+
 /// Current document schema version.
 ///
 /// Bump this when making incompatible changes to the Automerge document
@@ -80,6 +82,9 @@ pub struct CellSnapshot {
     /// Cell metadata (arbitrary JSON object, preserves unknown keys)
     #[serde(default = "default_empty_object")]
     pub metadata: serde_json::Value,
+    /// Attachments for markdown cells: relative path → blob hash
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub attachments: HashMap<String, String>,
 }
 
 fn default_empty_object() -> serde_json::Value {
@@ -632,6 +637,8 @@ impl NotebookDoc {
         self.doc.put(&cell_map, "execution_count", "null")?;
         self.doc.put_object(&cell_map, "outputs", ObjType::List)?;
         self.doc.put(&cell_map, "metadata", "{}")?;
+        self.doc
+            .put_object(&cell_map, "attachments", ObjType::Map)?;
 
         Ok(position_str)
     }
@@ -695,6 +702,9 @@ impl NotebookDoc {
         // Store metadata as JSON string
         let metadata_str = serde_json::to_string(metadata).unwrap_or_else(|_| "{}".to_string());
         self.doc.put(&cell_map, "metadata", metadata_str)?;
+
+        self.doc
+            .put_object(&cell_map, "attachments", ObjType::Map)?;
 
         Ok(())
     }
@@ -1225,6 +1235,82 @@ impl NotebookDoc {
         self.update_cell_metadata_at(cell_id, &["tags"], serde_json::json!(tags))
     }
 
+    // ── Attachments ───────────────────────────────────────────────────
+
+    /// Get all attachments for a cell (path → blob hash).
+    pub fn get_cell_attachments(&self, cell_id: &str) -> Option<HashMap<String, String>> {
+        let cells_id = self.cells_map_id()?;
+        let cell_obj = self.cell_obj_id(&cells_id, cell_id)?;
+        let attachments_id = self.map_id(&cell_obj, "attachments")?;
+
+        Some(
+            self.doc
+                .map_range(&attachments_id, ..)
+                .filter_map(|item| {
+                    if let automerge::ValueRef::Scalar(automerge::ScalarValueRef::Str(hash)) =
+                        item.value
+                    {
+                        return Some((item.key.to_string(), hash.to_string()));
+                    }
+                    None
+                })
+                .collect(),
+        )
+    }
+
+    /// Set a single attachment for a cell.
+    ///
+    /// Creates the attachments map if it doesn't exist.
+    pub fn set_cell_attachment(
+        &mut self,
+        cell_id: &str,
+        path: &str,
+        blob_hash: &str,
+    ) -> Result<bool, AutomergeError> {
+        let cells_id = match self.cells_map_id() {
+            Some(id) => id,
+            None => return Ok(false),
+        };
+        let cell_obj = match self.cell_obj_id(&cells_id, cell_id) {
+            Some(o) => o,
+            None => return Ok(false),
+        };
+
+        // Get or create attachments map
+        let attachments_id = match self.map_id(&cell_obj, "attachments") {
+            Some(id) => id,
+            None => self
+                .doc
+                .put_object(&cell_obj, "attachments", ObjType::Map)?,
+        };
+
+        self.doc.put(&attachments_id, path, blob_hash)?;
+        Ok(true)
+    }
+
+    /// Remove a single attachment from a cell.
+    pub fn remove_cell_attachment(
+        &mut self,
+        cell_id: &str,
+        path: &str,
+    ) -> Result<bool, AutomergeError> {
+        let cells_id = match self.cells_map_id() {
+            Some(id) => id,
+            None => return Ok(false),
+        };
+        let cell_obj = match self.cell_obj_id(&cells_id, cell_id) {
+            Some(o) => o,
+            None => return Ok(false),
+        };
+        let attachments_id = match self.map_id(&cell_obj, "attachments") {
+            Some(id) => id,
+            None => return Ok(false),
+        };
+
+        self.doc.delete(&attachments_id, path)?;
+        Ok(true)
+    }
+
     // ── Notebook metadata ──────────────────────────────────────────
 
     /// Read a metadata value.
@@ -1380,6 +1466,17 @@ impl NotebookDoc {
             })
     }
 
+    fn map_id(&self, parent: &ObjId, key: &str) -> Option<ObjId> {
+        self.doc
+            .get(parent, key)
+            .ok()
+            .flatten()
+            .and_then(|(value, id)| match value {
+                automerge::Value::Object(ObjType::Map) => Some(id),
+                _ => None,
+            })
+    }
+
     fn read_cell(&self, cell_obj: &ObjId) -> Option<CellSnapshot> {
         let id = read_str(&self.doc, cell_obj, "id")?;
         let cell_type = read_str(&self.doc, cell_obj, "cell_type").unwrap_or_default();
@@ -1410,6 +1507,23 @@ impl NotebookDoc {
             .and_then(|s| serde_json::from_str(&s).ok())
             .unwrap_or_else(|| serde_json::json!({}));
 
+        // Read attachments map
+        let attachments = match self.map_id(cell_obj, "attachments") {
+            Some(map_id) => self
+                .doc
+                .map_range(&map_id, ..)
+                .filter_map(|item| {
+                    if let automerge::ValueRef::Scalar(automerge::ScalarValueRef::Str(hash)) =
+                        item.value
+                    {
+                        return Some((item.key.to_string(), hash.to_string()));
+                    }
+                    None
+                })
+                .collect(),
+            None => HashMap::new(),
+        };
+
         Some(CellSnapshot {
             id,
             cell_type,
@@ -1418,6 +1532,7 @@ impl NotebookDoc {
             execution_count,
             outputs,
             metadata,
+            attachments,
         })
     }
 }
@@ -1557,6 +1672,22 @@ pub fn get_cells_from_doc(doc: &AutoCommit) -> Vec<CellSnapshot> {
                 .and_then(|s| serde_json::from_str(&s).ok())
                 .unwrap_or_else(|| serde_json::json!({}));
 
+            // Read attachments map
+            let attachments = match doc.get(&cell_obj, "attachments").ok().flatten() {
+                Some((automerge::Value::Object(ObjType::Map), map_id)) => doc
+                    .map_range(&map_id, ..)
+                    .filter_map(|item| {
+                        if let automerge::ValueRef::Scalar(automerge::ScalarValueRef::Str(hash)) =
+                            item.value
+                        {
+                            return Some((item.key.to_string(), hash.to_string()));
+                        }
+                        None
+                    })
+                    .collect(),
+                _ => HashMap::new(),
+            };
+
             Some(CellSnapshot {
                 id,
                 cell_type,
@@ -1565,6 +1696,7 @@ pub fn get_cells_from_doc(doc: &AutoCommit) -> Vec<CellSnapshot> {
                 execution_count,
                 outputs,
                 metadata,
+                attachments,
             })
         })
         .collect();

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -34,6 +34,7 @@ pub struct JsCell {
     execution_count: String,
     outputs: Vec<String>,
     metadata: serde_json::Value,
+    attachments: std::collections::HashMap<String, String>,
 }
 
 #[wasm_bindgen]
@@ -75,6 +76,12 @@ impl JsCell {
     pub fn metadata_json(&self) -> String {
         serde_json::to_string(&self.metadata).unwrap_or_else(|_| "{}".to_string())
     }
+
+    /// Get attachments as a JSON object string (path → blob hash).
+    #[wasm_bindgen(getter)]
+    pub fn attachments_json(&self) -> String {
+        serde_json::to_string(&self.attachments).unwrap_or_else(|_| "{}".to_string())
+    }
 }
 
 impl From<(usize, CellSnapshot)> for JsCell {
@@ -88,6 +95,7 @@ impl From<(usize, CellSnapshot)> for JsCell {
             execution_count: snap.execution_count,
             outputs: snap.outputs,
             metadata: snap.metadata,
+            attachments: snap.attachments,
         }
     }
 }

--- a/crates/runtimed/Cargo.toml
+++ b/crates/runtimed/Cargo.toml
@@ -58,6 +58,9 @@ alacritty_terminal = "0.25"
 # Error parsing
 regex = "1"
 
+# Markdown parsing for image extraction
+pulldown-cmark = "0.13"
+
 # HTTP blob server
 hyper = { version = "1", features = ["http1", "server"] }
 http-body-util = "0.1"

--- a/crates/runtimed/src/lib.rs
+++ b/crates/runtimed/src/lib.rs
@@ -19,6 +19,7 @@ pub mod connection;
 pub mod daemon;
 pub mod inline_env;
 pub mod kernel_manager;
+pub mod markdown_images;
 pub use notebook_doc;
 pub use notebook_doc::metadata as notebook_metadata;
 pub mod notebook_sync_client;

--- a/crates/runtimed/src/markdown_images.rs
+++ b/crates/runtimed/src/markdown_images.rs
@@ -1,0 +1,208 @@
+//! Markdown image extraction for resolving relative image paths.
+//!
+//! This module provides utilities for extracting image references from markdown
+//! content and determining which ones need to be resolved from disk.
+
+use pulldown_cmark::{Event, Parser, Tag, TagEnd};
+
+/// Extract relative image paths from markdown source.
+///
+/// Returns a list of image paths that:
+/// - Are relative (not absolute, not URLs, not data URIs)
+/// - Are not already using Jupyter's attachment syntax
+///
+/// These paths need to be resolved against the notebook directory and stored
+/// in the blob store.
+pub fn extract_relative_images(source: &str) -> Vec<String> {
+    let parser = Parser::new(source);
+    let mut paths = Vec::new();
+    let mut in_image = false;
+    let mut current_dest: Option<String> = None;
+
+    for event in parser {
+        match event {
+            Event::Start(Tag::Image { dest_url, .. }) => {
+                in_image = true;
+                current_dest = Some(dest_url.to_string());
+            }
+            Event::End(TagEnd::Image) => {
+                if in_image {
+                    if let Some(dest) = current_dest.take() {
+                        if is_relative_path(&dest) {
+                            paths.push(dest);
+                        }
+                    }
+                }
+                in_image = false;
+            }
+            _ => {}
+        }
+    }
+
+    paths
+}
+
+/// Check if a path is relative and needs resolution.
+///
+/// Returns false for:
+/// - Absolute paths (starting with /)
+/// - HTTP/HTTPS URLs
+/// - Data URIs
+/// - Blob URLs
+/// - Jupyter attachment references (attachment:filename.png)
+fn is_relative_path(path: &str) -> bool {
+    let path = path.trim();
+
+    // Empty paths
+    if path.is_empty() {
+        return false;
+    }
+
+    // Absolute URLs
+    if path.starts_with("http://") || path.starts_with("https://") {
+        return false;
+    }
+
+    // Data URIs
+    if path.starts_with("data:") {
+        return false;
+    }
+
+    // Blob URLs
+    if path.starts_with("blob:") {
+        return false;
+    }
+
+    // Absolute file paths
+    if path.starts_with('/') {
+        return false;
+    }
+
+    // Windows absolute paths
+    if path.len() >= 2 && path.chars().nth(1) == Some(':') {
+        return false;
+    }
+
+    // Jupyter attachment references
+    if path.starts_with("attachment:") {
+        return false;
+    }
+
+    true
+}
+
+/// Determine the media type from a file extension.
+pub fn media_type_from_extension(path: &str) -> &'static str {
+    let ext = path
+        .rsplit('.')
+        .next()
+        .map(|e| e.to_lowercase())
+        .unwrap_or_default();
+
+    match ext.as_str() {
+        "png" => "image/png",
+        "jpg" | "jpeg" => "image/jpeg",
+        "gif" => "image/gif",
+        "webp" => "image/webp",
+        "svg" => "image/svg+xml",
+        "bmp" => "image/bmp",
+        "ico" => "image/x-icon",
+        "tiff" | "tif" => "image/tiff",
+        "avif" => "image/avif",
+        _ => "application/octet-stream",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_simple_image() {
+        let md = "![alt](image.png)";
+        let paths = extract_relative_images(md);
+        assert_eq!(paths, vec!["image.png"]);
+    }
+
+    #[test]
+    fn test_extract_relative_path() {
+        let md = "![diagram](assets/diagram.png)";
+        let paths = extract_relative_images(md);
+        assert_eq!(paths, vec!["assets/diagram.png"]);
+    }
+
+    #[test]
+    fn test_extract_multiple_images() {
+        let md = r#"
+# Header
+
+![first](img1.png)
+
+Some text
+
+![second](images/img2.jpg)
+"#;
+        let paths = extract_relative_images(md);
+        assert_eq!(paths, vec!["img1.png", "images/img2.jpg"]);
+    }
+
+    #[test]
+    fn test_ignore_http_url() {
+        let md = "![remote](https://example.com/image.png)";
+        let paths = extract_relative_images(md);
+        assert!(paths.is_empty());
+    }
+
+    #[test]
+    fn test_ignore_data_uri() {
+        let md = "![inline](data:image/png;base64,iVBORw0KGgo=)";
+        let paths = extract_relative_images(md);
+        assert!(paths.is_empty());
+    }
+
+    #[test]
+    fn test_ignore_absolute_path() {
+        let md = "![absolute](/usr/share/image.png)";
+        let paths = extract_relative_images(md);
+        assert!(paths.is_empty());
+    }
+
+    #[test]
+    fn test_ignore_attachment_syntax() {
+        let md = "![attached](attachment:image.png)";
+        let paths = extract_relative_images(md);
+        assert!(paths.is_empty());
+    }
+
+    #[test]
+    fn test_ignore_blob_url() {
+        let md = "![blob](blob:abc123)";
+        let paths = extract_relative_images(md);
+        assert!(paths.is_empty());
+    }
+
+    #[test]
+    fn test_media_type_png() {
+        assert_eq!(media_type_from_extension("image.png"), "image/png");
+        assert_eq!(media_type_from_extension("IMAGE.PNG"), "image/png");
+    }
+
+    #[test]
+    fn test_media_type_jpeg() {
+        assert_eq!(media_type_from_extension("photo.jpg"), "image/jpeg");
+        assert_eq!(media_type_from_extension("photo.jpeg"), "image/jpeg");
+    }
+
+    #[test]
+    fn test_media_type_svg() {
+        assert_eq!(media_type_from_extension("icon.svg"), "image/svg+xml");
+    }
+
+    #[test]
+    fn test_media_type_unknown() {
+        assert_eq!(
+            media_type_from_extension("file.xyz"),
+            "application/octet-stream"
+        );
+    }
+}

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -40,6 +40,7 @@ use crate::blob_store::BlobStore;
 use crate::comm_state::CommState;
 use crate::connection::{self, NotebookFrameType};
 use crate::kernel_manager::{DenoLaunchedConfig, LaunchedEnvConfig, RoomKernel};
+use crate::markdown_images::{extract_relative_images, media_type_from_extension};
 use crate::notebook_doc::{notebook_doc_filename, CellSnapshot, NotebookDoc};
 use crate::notebook_metadata::{NotebookMetadataSnapshot, NOTEBOOK_METADATA_KEY};
 use crate::protocol::{EnvSyncDiff, NotebookBroadcast, NotebookRequest, NotebookResponse};
@@ -257,6 +258,116 @@ fn compute_env_sync_diff(
             channels_changed,
             deno_changed,
         })
+    }
+}
+
+/// Process markdown cells to resolve relative image paths.
+///
+/// For each markdown cell with relative image paths (e.g., `![](assets/image.png)`),
+/// this function:
+/// 1. Extracts relative image paths from the markdown source
+/// 2. Resolves each path against the notebook directory
+/// 3. Reads the file and stores it in the blob store
+/// 4. Updates the cell's attachments map with the path → blob hash mapping
+///
+/// Security: Paths are canonicalized and validated to stay within the notebook's
+/// directory, preventing directory traversal attacks.
+async fn process_markdown_attachments(room: &NotebookRoom) {
+    // Only process if notebook has a valid file path (not untitled)
+    let notebook_dir = match room.notebook_path.parent() {
+        Some(dir) if room.notebook_path.exists() => dir,
+        _ => return,
+    };
+
+    // Canonicalize notebook directory for security checks
+    let canonical_dir = match notebook_dir.canonicalize() {
+        Ok(dir) => dir,
+        Err(_) => return,
+    };
+
+    // Get all markdown cells
+    let markdown_cells: Vec<(String, String, HashMap<String, String>)> = {
+        let doc = room.doc.read().await;
+        doc.get_cells()
+            .into_iter()
+            .filter(|cell| cell.cell_type == "markdown")
+            .map(|cell| (cell.id, cell.source, cell.attachments))
+            .collect()
+    };
+
+    for (cell_id, source, existing_attachments) in markdown_cells {
+        let relative_paths = extract_relative_images(&source);
+        if relative_paths.is_empty() {
+            continue;
+        }
+
+        let mut new_attachments = false;
+
+        for rel_path in relative_paths {
+            // Skip if already resolved
+            if existing_attachments.contains_key(&rel_path) {
+                continue;
+            }
+
+            // Resolve path against notebook directory
+            let resolved = notebook_dir.join(&rel_path);
+            let canonical = match resolved.canonicalize() {
+                Ok(p) => p,
+                Err(_) => {
+                    // File doesn't exist, skip
+                    continue;
+                }
+            };
+
+            // Security: ensure path stays within notebook directory
+            if !canonical.starts_with(&canonical_dir) {
+                warn!(
+                    "[notebook-sync] Blocked path traversal attempt: {} -> {:?}",
+                    rel_path, canonical
+                );
+                continue;
+            }
+
+            // Read file and store in blob store
+            let data = match tokio::fs::read(&canonical).await {
+                Ok(d) => d,
+                Err(e) => {
+                    debug!("[notebook-sync] Failed to read image {}: {}", rel_path, e);
+                    continue;
+                }
+            };
+
+            let media_type = media_type_from_extension(&rel_path);
+            let hash = match room.blob_store.put(&data, media_type).await {
+                Ok(h) => h,
+                Err(e) => {
+                    warn!("[notebook-sync] Failed to store image in blob store: {}", e);
+                    continue;
+                }
+            };
+
+            // Update cell attachment
+            {
+                let mut doc = room.doc.write().await;
+                if let Err(e) = doc.set_cell_attachment(&cell_id, &rel_path, &hash) {
+                    warn!(
+                        "[notebook-sync] Failed to set attachment for {}: {}",
+                        rel_path, e
+                    );
+                } else {
+                    debug!(
+                        "[notebook-sync] Resolved image {} -> blob:{}",
+                        rel_path, hash
+                    );
+                    new_attachments = true;
+                }
+            }
+        }
+
+        // If we added new attachments, notify peers
+        if new_attachments {
+            let _ = room.changed_tx.send(());
+        }
     }
 }
 
@@ -1005,6 +1116,9 @@ where
 
                                 // Check if metadata changed and kernel is running - broadcast sync state
                                 check_and_broadcast_sync_state(room).await;
+
+                                // Process markdown cells to resolve relative images
+                                process_markdown_attachments(room).await;
                             }
 
                             NotebookFrameType::Request => {
@@ -3197,6 +3311,7 @@ fn parse_cells_from_ipynb(json: &serde_json::Value) -> Option<Vec<CellSnapshot>>
                 execution_count,
                 outputs,
                 metadata,
+                attachments: std::collections::HashMap::new(),
             }
         })
         .collect();
@@ -4876,6 +4991,7 @@ mod tests {
             execution_count: "42".to_string(),
             outputs: vec![],
             metadata: serde_json::json!({}),
+            attachments: std::collections::HashMap::new(),
         }];
 
         let changed = apply_ipynb_changes(&room, &external_cells, false).await;
@@ -4911,6 +5027,7 @@ mod tests {
             execution_count: "5".to_string(),
             outputs: vec![r#"{"output_type":"error"}"#.to_string()],
             metadata: serde_json::json!({}),
+            attachments: std::collections::HashMap::new(),
         }];
 
         let changed = apply_ipynb_changes(&room, &external_cells, true).await;
@@ -4950,6 +5067,7 @@ mod tests {
                 execution_count: "null".to_string(),
                 outputs: vec![],
                 metadata: serde_json::json!({}),
+                attachments: std::collections::HashMap::new(),
             },
             CellSnapshot {
                 id: "new-cell".to_string(),
@@ -4959,6 +5077,7 @@ mod tests {
                 execution_count: "42".to_string(),
                 outputs: vec![r#"{"output_type":"execute_result"}"#.to_string()],
                 metadata: serde_json::json!({}),
+                attachments: std::collections::HashMap::new(),
             },
         ];
 


### PR DESCRIPTION
Adds support for markdown cells with relative image paths like `![](assets/diagram.png)`. The daemon resolves these paths against the notebook directory, stores resolved images in the blob store, and provides path → hash mappings to the frontend. Images are rendered by rewriting their paths to blob URLs before iframe display.

## Changes

**Backend (Rust):**
- `crates/notebook-doc`: Added `attachments` field to cells with getter/setter methods
- `crates/runtimed/src/markdown_images.rs` (new): Extracts relative image paths from markdown using pulldown-cmark
- `crates/runtimed/src/notebook_sync_server.rs`: `process_markdown_attachments()` validates paths (canonicalization, directory containment), stores in blob store, updates cell attachments
- `crates/runtimed-wasm`: Expose `attachments` in WASM bindings

**Frontend (TypeScript):**
- `apps/notebook/src/types.ts`: Added `attachments` to `MarkdownCell` interface
- `apps/notebook/src/lib/materialize-cells.ts`: Pass through attachments from sync
- `apps/notebook/src/components/MarkdownCell.tsx`: Apply attachments during render by rewriting paths to blob URLs

## Verification

* [ ] Create notebook with image directory (e.g., `assets/`)
* [ ] Add markdown cell with relative path: `![test](assets/test.png)`
* [ ] Verify image renders in preview mode
* [ ] Verify path traversal is blocked (`../../../etc/passwd`)
* [ ] Verify attachments persist in notebook document
* [ ] Test on different machine (images resolve from blob store)

Closes #683

_PR submitted by @rgbkrk's agent, Quill_