### PR TITLE
feat!: bump all artifacts to v2.0.0, clean up release flow

### DIFF
--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -39,6 +39,11 @@ on:
         description: Whether the updater channel release is prerelease
         required: true
         type: boolean
+      publish_python_prerelease:
+        description: Whether to publish Python wheels to PyPI as pre-releases (only nightly should do this)
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -892,6 +897,7 @@ jobs:
         uses: astral-sh/setup-uv@v5
 
       - name: Publish to PyPI
+        if: inputs.publish_python_prerelease
         continue-on-error: true
         run: uv publish --trusted-publishing always ./wheels/*.whl
 

--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -39,11 +39,6 @@ on:
         description: Whether the updater channel release is prerelease
         required: true
         type: boolean
-      publish_python_prerelease:
-        description: Whether to publish Python wheels to PyPI as pre-releases (only nightly should do this)
-        required: false
-        type: boolean
-        default: false
 
 permissions:
   contents: write
@@ -686,7 +681,7 @@ jobs:
           cp target/${{ matrix.platform.target }}/release/runtimed.exe python/runtimed/src/runtimed/_bin/
 
       - name: Set dev version (Unix)
-        if: runner.os != 'Windows'
+        if: runner.os != 'Windows' && inputs.github_release_prerelease
         run: |
           CURRENT_VERSION=$(grep '^version' python/runtimed/pyproject.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
           # Bump patch and use alpha tag so it sorts after current stable (PEP 440)
@@ -699,7 +694,7 @@ jobs:
           sed -i.bak "s/^version = .*/version = \"${DEV_VERSION}\"/" python/runtimed/pyproject.toml
 
       - name: Set dev version (Windows)
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' && inputs.github_release_prerelease
         shell: pwsh
         run: |
           $content = Get-Content python/runtimed/pyproject.toml -Raw
@@ -897,7 +892,6 @@ jobs:
         uses: astral-sh/setup-uv@v5
 
       - name: Publish to PyPI
-        if: inputs.publish_python_prerelease
         continue-on-error: true
         run: uv publish --trusted-publishing always ./wheels/*.whl
 

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -24,4 +24,3 @@ jobs:
       updater_channel_title: "Nightly Update Channel"
       updater_channel_notes: "Rolling release for the nightly auto-update channel. This release always contains the latest updater manifest. Do not delete this release."
       updater_channel_prerelease: true
-      publish_python_prerelease: true

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -24,3 +24,4 @@ jobs:
       updater_channel_title: "Nightly Update Channel"
       updater_channel_notes: "Rolling release for the nightly auto-update channel. This release always contains the latest updater manifest. Do not delete this release."
       updater_channel_prerelease: true
+      publish_python_prerelease: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,7 @@ See the `contributing/` directory for detailed guides:
 - `contributing/logging.md` - Logging conventions
 - `contributing/nteract-elements.md` - Working with nteract/elements registry
 - `contributing/protocol.md` - Wire protocol between clients and daemon
+- `contributing/releasing.md` - Versioning scheme, release procedures, tag conventions
 - `contributing/runtimed.md` - Daemon development guide
 - `contributing/testing.md` - Testing guide (Vitest, Rust, Hone, Python, E2E)
 - `contributing/typescript-bindings.md` - ts-rs type generation from Rust

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3527,7 +3527,7 @@ dependencies = [
 
 [[package]]
 name = "notebook"
-version = "1.4.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -5620,7 +5620,7 @@ dependencies = [
 
 [[package]]
 name = "runt-cli"
-version = "1.4.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5670,7 +5670,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed"
-version = "0.1.0-dev.10"
+version = "2.0.0"
 dependencies = [
  "alacritty_terminal",
  "anyhow",
@@ -6407,7 +6407,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "sidecar"
-version = "1.4.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/contributing/protocol.md
+++ b/contributing/protocol.md
@@ -2,43 +2,39 @@
 
 This document describes the wire protocol between notebook clients (frontend WASM + Tauri relay) and the runtimed daemon.
 
-## Versioning Contract
+## Compatibility
 
-The protocol has a numeric version (`PROTOCOL_VERSION` in `connection.rs`) that governs compatibility between clients and the daemon. All published artifacts tie their major version to this protocol version:
+Two independent version numbers handle compatibility, separate from the artifact version:
 
-| Artifact | Version scheme | Example |
-|----------|---------------|---------|
-| `runtimed` (PyPI) | `{PROTOCOL_VERSION}.{minor}.{patch}` | `2.0.0`, `2.1.0` |
-| `runtimed` (Rust daemon) | `{PROTOCOL_VERSION}.{minor}.{patch}` | `2.0.0` |
-| `runt-cli` | `{PROTOCOL_VERSION}.{minor}.{patch}` | `2.0.0` |
-| nteract desktop app | `{PROTOCOL_VERSION}.{minor}.{patch}` | `2.0.0` |
+- **Protocol version** (`PROTOCOL_VERSION` in `connection.rs`, currently `2`) — governs wire compatibility. Validated by the 5-byte magic preamble (`0xC0DE01AC` + version byte) at the start of every connection. Bump when the framing, handshake shape, or message serialization format changes.
+- **Schema version** (`SCHEMA_VERSION` in `notebook-doc/src/lib.rs`, currently `1`) — governs Automerge document compatibility. Stored in the doc root as `schema_version`. Bump when the document structure changes (e.g., switching cells from ordered list to fractional-indexed map).
 
-**Rules:**
+These are just incrementing integers. They evolve independently from each other and from the artifact version. A protocol or schema bump doesn't automatically force a major version bump — that depends on whether the change is user-facing.
 
-- **Major version = protocol version.** A `PROTOCOL_VERSION` bump (breaking wire change) forces a new major version across all artifacts. Any `runtimed 2.x.y` client can talk to any `2.x.y` daemon.
-- **Minor version = new features.** Additive changes (new request/response/broadcast variants with serde defaults) bump the minor version. Old clients ignore unknown variants; new clients degrade gracefully against old daemons.
-- **Patch version = bug fixes.** No protocol changes.
+Artifact versions follow standard semver based on what users see.
 
 ### Release channels
 
-**Stable:** Pushing a `v*` tag publishes Python wheels to PyPI at the version in `pyproject.toml` (e.g., `2.0.0`). No separate `python-v*` tag needed — the desktop release ships the Python package too.
+**Stable:** Pushing a `v*` tag publishes Python wheels to PyPI at the version in `pyproject.toml`. No separate `python-v*` tag needed — the desktop release ships the Python package too.
 
-**Nightly:** Daily builds publish PEP 440 alpha pre-releases:
-
-```
-2.0.1a202507150900   (nightly from 2025-07-15)
-```
-
-These sort after the current stable (`2.0.0`) but before the next stable (`2.0.1`). Install with `pip install runtimed --pre`.
+**Nightly:** Daily builds publish PEP 440 alpha pre-releases (e.g., `2.0.1a202603100900`). Install with `pip install runtimed --pre`.
 
 **Python-only:** The `python-v*` tag path (`python-package.yml`) exists for Python-specific patches that don't need a full desktop release.
 
 See `contributing/releasing.md` for the full release procedures.
 
-### Version negotiation
+### Connection preamble
 
-- **Notebook sync** (`NotebookSync`, `OpenNotebook`, `CreateNotebook` handshakes): The daemon returns `protocol_version` and `daemon_version` in its capabilities response. The client hard-fails on mismatch.
-- **Pool IPC** (`Pool` handshake): The client sends `protocol_version` in the handshake. Old clients omit it (`None`); the daemon accepts them for backward compatibility. Future versions may reject mismatched clients with a clear error.
+Every connection starts with a 5-byte preamble before the JSON handshake frame:
+
+| Bytes | Content |
+|-------|---------|
+| 0–3 | Magic: `0xC0 0xDE 0x01 0xAC` |
+| 4 | Protocol version (currently `2`) |
+
+The daemon validates both before reading the handshake. Non-runtimed connections get a clear "invalid magic bytes" error. Protocol mismatches are rejected before any JSON parsing.
+
+After the preamble, the notebook sync path also returns `protocol_version` and `daemon_version` in its `ProtocolCapabilities` / `NotebookConnectionInfo` responses for informational purposes.
 
 ### Desktop app compatibility
 

--- a/contributing/protocol.md
+++ b/contributing/protocol.md
@@ -19,15 +19,21 @@ The protocol has a numeric version (`PROTOCOL_VERSION` in `connection.rs`) that 
 - **Minor version = new features.** Additive changes (new request/response/broadcast variants with serde defaults) bump the minor version. Old clients ignore unknown variants; new clients degrade gracefully against old daemons.
 - **Patch version = bug fixes.** No protocol changes.
 
-### Nightly pre-releases
+### Release channels
 
-Nightly builds publish Python wheels to PyPI as PEP 440 alpha pre-releases:
+**Stable:** Pushing a `v*` tag publishes Python wheels to PyPI at the version in `pyproject.toml` (e.g., `2.0.0`). No separate `python-v*` tag needed — the desktop release ships the Python package too.
+
+**Nightly:** Daily builds publish PEP 440 alpha pre-releases:
 
 ```
 2.0.1a202507150900   (nightly from 2025-07-15)
 ```
 
-These sort after the current stable (`2.0.0`) but before the next stable (`2.0.1`). Install with `pip install runtimed --pre`. Stable releases are published only via `python-v*` tags.
+These sort after the current stable (`2.0.0`) but before the next stable (`2.0.1`). Install with `pip install runtimed --pre`.
+
+**Python-only:** The `python-v*` tag path (`python-package.yml`) exists for Python-specific patches that don't need a full desktop release.
+
+See `contributing/releasing.md` for the full release procedures.
 
 ### Version negotiation
 

--- a/contributing/protocol.md
+++ b/contributing/protocol.md
@@ -2,6 +2,42 @@
 
 This document describes the wire protocol between notebook clients (frontend WASM + Tauri relay) and the runtimed daemon.
 
+## Versioning Contract
+
+The protocol has a numeric version (`PROTOCOL_VERSION` in `connection.rs`) that governs compatibility between clients and the daemon. All published artifacts tie their major version to this protocol version:
+
+| Artifact | Version scheme | Example |
+|----------|---------------|---------|
+| `runtimed` (PyPI) | `{PROTOCOL_VERSION}.{minor}.{patch}` | `2.0.0`, `2.1.0` |
+| `runtimed` (Rust daemon) | `{PROTOCOL_VERSION}.{minor}.{patch}` | `2.0.0` |
+| `runt-cli` | `{PROTOCOL_VERSION}.{minor}.{patch}` | `2.0.0` |
+| nteract desktop app | `{PROTOCOL_VERSION}.{minor}.{patch}` | `2.0.0` |
+
+**Rules:**
+
+- **Major version = protocol version.** A `PROTOCOL_VERSION` bump (breaking wire change) forces a new major version across all artifacts. Any `runtimed 2.x.y` client can talk to any `2.x.y` daemon.
+- **Minor version = new features.** Additive changes (new request/response/broadcast variants with serde defaults) bump the minor version. Old clients ignore unknown variants; new clients degrade gracefully against old daemons.
+- **Patch version = bug fixes.** No protocol changes.
+
+### Nightly pre-releases
+
+Nightly builds publish Python wheels to PyPI as PEP 440 alpha pre-releases:
+
+```
+2.0.1a202507150900   (nightly from 2025-07-15)
+```
+
+These sort after the current stable (`2.0.0`) but before the next stable (`2.0.1`). Install with `pip install runtimed --pre`. Stable releases are published only via `python-v*` tags.
+
+### Version negotiation
+
+- **Notebook sync** (`NotebookSync`, `OpenNotebook`, `CreateNotebook` handshakes): The daemon returns `protocol_version` and `daemon_version` in its capabilities response. The client hard-fails on mismatch.
+- **Pool IPC** (`Pool` handshake): The client sends `protocol_version` in the handshake. Old clients omit it (`None`); the daemon accepts them for backward compatibility. Future versions may reject mismatched clients with a clear error.
+
+### Desktop app compatibility
+
+The desktop app bundles its own daemon binary. Version-mismatch detection between the app and its bundled daemon compares git commit hashes (appended as `+{sha}` at build time), not semver. This is because both are always built from the same commit in CI.
+
 ## Overview
 
 The notebook app communicates with runtimed over a Unix socket (named pipe on Windows) using length-prefixed, typed frames. The protocol carries three kinds of traffic:
@@ -60,7 +96,7 @@ The daemon responds with a `NotebookConnectionInfo`:
 {
   "protocol": "v2",
   "protocol_version": 2,
-  "daemon_version": "0.1.0-dev.10+abc123",
+  "daemon_version": "2.0.0+abc123",
   "notebook_id": "derived-id",
   "cell_count": 5,
   "needs_trust_approval": false,

--- a/contributing/releasing.md
+++ b/contributing/releasing.md
@@ -14,11 +14,20 @@ All published artifacts share the same version and follow semver:
 | `runtimed` Python package | PyPI | `python/runtimed/pyproject.toml` |
 | `sidecar` | Bundled in Python wheel | `crates/sidecar/Cargo.toml` |
 
-**Major version = protocol version.** `PROTOCOL_VERSION` in `crates/runtimed/src/connection.rs` governs the major version. Any `runtimed 2.x.y` client can talk to any `2.x.y` daemon.
+Standard semver rules apply:
 
-- **Major** — breaking wire protocol change (`PROTOCOL_VERSION` bump)
-- **Minor** — new features (additive request/response/broadcast types)
-- **Patch** — bug fixes, no protocol changes
+- **Major** — breaking changes to user-facing APIs or behavior
+- **Minor** — new features, additive protocol/schema changes
+- **Patch** — bug fixes
+
+### Internal compatibility markers
+
+Two independent version numbers handle compatibility, separate from the artifact version:
+
+- **Protocol version** (`PROTOCOL_VERSION` in `connection.rs`) — governs wire compatibility. Validated by the magic bytes preamble at connection time. Bump when the framing, handshake shape, or message serialization format changes.
+- **Schema version** (`SCHEMA_VERSION` in `notebook-doc/src/lib.rs`) — governs Automerge document compatibility. Stored in the doc root. Bump when the document structure changes (e.g., switching cells from ordered list to fractional-indexed map).
+
+These are just incrementing integers. They evolve independently from each other and from the artifact version. A protocol bump doesn't force a major version bump — it depends on whether the change is user-facing.
 
 ## Bumping Versions
 
@@ -105,12 +114,21 @@ This builds macOS + Linux wheels and publishes to PyPI. Use this when you need t
 When making a breaking wire protocol change:
 
 1. Bump `PROTOCOL_VERSION` in `crates/runtimed/src/connection.rs`
-2. Bump the major version in all six version sources
-3. Update `PROTOCOL_V2` string constant if the version string changes
-4. Update `contributing/protocol.md` versioning table
-5. Tag as the new major version (e.g., `v3.0.0`)
+2. Update `PROTOCOL_V2` string constant if the version string changes
+3. Update `contributing/protocol.md`
+4. Decide whether this warrants a major, minor, or patch version bump based on user impact
 
-The notebook sync path hard-fails on protocol mismatch. The pool IPC path sends `protocol_version` in the handshake for forward compatibility.
+The magic bytes preamble rejects connections with mismatched protocol versions at the wire level, before any JSON parsing.
+
+## Schema Version Changes
+
+When changing the Automerge document structure:
+
+1. Bump `SCHEMA_VERSION` in `crates/notebook-doc/src/lib.rs`
+2. Add migration logic in the daemon's doc loading path (detect old schema, convert in-place)
+3. Update the document schema comment in `notebook-doc/src/lib.rs`
+
+Schema changes don't necessarily require a protocol bump — the wire format for sync frames stays the same, only the doc content changes.
 
 See `contributing/protocol.md` for the full versioning contract.
 
@@ -135,6 +153,6 @@ Before tagging a stable release:
 
 - [ ] All version sources bumped and in sync
 - [ ] `cargo check` passes (Cargo.lock updated)
-- [ ] `PROTOCOL_VERSION` matches major version
+- [ ] `PROTOCOL_VERSION` and `SCHEMA_VERSION` are correct for this release
 - [ ] CI is green on `main`
 - [ ] Changelog-worthy items use conventional commit prefixes (`feat`, `fix`, `perf`)

--- a/contributing/releasing.md
+++ b/contributing/releasing.md
@@ -1,0 +1,140 @@
+# Releasing
+
+How versioning, releases, and publishing work across the project.
+
+## Version Scheme
+
+All published artifacts share the same version and follow semver:
+
+| Artifact | Where | Version source |
+|---|---|---|
+| nteract desktop app | GitHub Releases | `crates/notebook/tauri.conf.json` |
+| `runt` CLI | GitHub Releases | `crates/runt/Cargo.toml` |
+| `runtimed` daemon | Bundled in app + Python wheel | `crates/runtimed/Cargo.toml` |
+| `runtimed` Python package | PyPI | `python/runtimed/pyproject.toml` |
+| `sidecar` | Bundled in Python wheel | `crates/sidecar/Cargo.toml` |
+
+**Major version = protocol version.** `PROTOCOL_VERSION` in `crates/runtimed/src/connection.rs` governs the major version. Any `runtimed 2.x.y` client can talk to any `2.x.y` daemon.
+
+- **Major** — breaking wire protocol change (`PROTOCOL_VERSION` bump)
+- **Minor** — new features (additive request/response/broadcast types)
+- **Patch** — bug fixes, no protocol changes
+
+## Bumping Versions
+
+All five version sources must stay in sync. When preparing a release:
+
+```bash
+# Update all of these to the same version:
+#   crates/runtimed/Cargo.toml
+#   crates/runt/Cargo.toml
+#   crates/notebook/Cargo.toml
+#   crates/notebook/tauri.conf.json
+#   crates/sidecar/Cargo.toml
+#   python/runtimed/pyproject.toml
+
+# Then let Cargo.lock catch up:
+cargo check
+```
+
+Commit the version bump, then tag to trigger the release.
+
+## Release Types
+
+### Stable Release
+
+Push a `v*` tag to `main`:
+
+```bash
+git tag v2.1.0
+git push origin v2.1.0
+```
+
+This triggers `release-stable.yml` → `release-common.yml`, which:
+
+1. Builds the desktop app (macOS, Windows, Linux)
+2. Builds `runt` CLI binaries
+3. Builds Python wheels at the version in `pyproject.toml` (no alpha stamp)
+4. Publishes wheels to PyPI (stable release)
+5. Creates a GitHub Release with all artifacts
+6. Updates the `stable-latest` Tauri updater channel
+7. Posts to Discord
+
+The stable release publishes the Python package to PyPI at the exact version from `pyproject.toml`. This means tagging `v2.1.0` also ships `runtimed==2.1.0` on PyPI — no separate Python tag needed.
+
+### Nightly Release
+
+Runs automatically at 9am UTC daily via `release-nightly.yml`, or manually via workflow dispatch.
+
+Same pipeline as stable, but:
+
+- Desktop version gets a `-nightly.{timestamp}` suffix
+- Python wheels get an alpha stamp: `2.0.1a202507150900` (PEP 440)
+- App is branded "nteract Nightly" with a separate bundle ID (side-by-side install)
+- GitHub Release is marked as prerelease
+- CLI binary is named `runt-nightly`
+
+Nightly Python wheels are installable with:
+
+```bash
+pip install runtimed --pre
+```
+
+### Python-Only Release
+
+For Python-specific fixes that don't need a full desktop release, use the dedicated `python-package.yml` workflow:
+
+```bash
+# Bump python/runtimed/pyproject.toml (and Cargo.tomls if Rust changed)
+git tag python-v2.1.1
+git push origin python-v2.1.1
+```
+
+This builds macOS + Linux wheels and publishes to PyPI. Use this when you need to ship a Python patch without cutting a new desktop release.
+
+## Tag Reference
+
+| Tag pattern | Workflow | What it publishes |
+|---|---|---|
+| `v*` | `release-stable.yml` | Desktop app + CLI + Python (stable) |
+| `python-v*` | `python-package.yml` | Python wheels only |
+| _(cron)_ | `release-nightly.yml` | Desktop app + CLI + Python (pre-release) |
+
+## Protocol Version Changes
+
+When making a breaking wire protocol change:
+
+1. Bump `PROTOCOL_VERSION` in `crates/runtimed/src/connection.rs`
+2. Bump the major version in all six version sources
+3. Update `PROTOCOL_V2` string constant if the version string changes
+4. Update `contributing/protocol.md` versioning table
+5. Tag as the new major version (e.g., `v3.0.0`)
+
+The notebook sync path hard-fails on protocol mismatch. The pool IPC path sends `protocol_version` in the handshake for forward compatibility.
+
+See `contributing/protocol.md` for the full versioning contract.
+
+## CI Internals
+
+The reusable `release-common.yml` accepts inputs from the nightly/stable callers:
+
+- `github_release_prerelease: true` → applies PEP 440 alpha stamp to Python version
+- `github_release_prerelease: false` → uses `pyproject.toml` version as-is
+
+Python wheels are always built (macOS arm64, Linux x64, Windows x64) and always published. `continue-on-error: true` on the PyPI step handles duplicate version conflicts (e.g., re-running a workflow).
+
+Desktop version is computed as `{runt-cli version}-{suffix}.{timestamp}` where suffix is `nightly` or `stable`. This is stamped into `tauri.conf.json` and `Cargo.toml` at build time — not committed.
+
+### Trusted Publishing
+
+PyPI publishing uses OIDC trusted publishing (no API tokens). The GitHub Actions workflow identity is registered as a trusted publisher on PyPI for the `runtimed` package. Both `release-common.yml` and `python-package.yml` use this.
+
+## Checklist
+
+Before tagging a stable release:
+
+- [ ] All version sources bumped and in sync
+- [ ] `cargo check` passes (Cargo.lock updated)
+- [ ] `PROTOCOL_VERSION` matches major version
+- [ ] CI is green on `main`
+- [ ] Changelog-worthy items use conventional commit prefixes (`feat`, `fix`, `perf`)

--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -13,6 +13,7 @@
 //!
 //! ```text
 //! ROOT/
+//!   schema_version: u64           ← Document schema version (1 = ordered list cells)
 //!   notebook_id: Str
 //!   cells/                        ← List of Map
 //!     [i]/
@@ -28,6 +29,14 @@
 //! ```
 
 pub mod metadata;
+
+/// Current document schema version.
+///
+/// Bump this when making incompatible changes to the Automerge document
+/// structure (e.g., switching cells from an ordered list to a fractional-indexed map).
+///
+/// - **1** — Original schema: `cells` is an ordered `List` of `Map`.
+pub const SCHEMA_VERSION: u64 = 1;
 
 use automerge::sync;
 use automerge::sync::SyncDoc;
@@ -202,6 +211,7 @@ impl NotebookDoc {
     pub fn new(notebook_id: &str) -> Self {
         let mut doc = AutoCommit::new();
 
+        let _ = doc.put(automerge::ROOT, "schema_version", SCHEMA_VERSION);
         let _ = doc.put(automerge::ROOT, "notebook_id", notebook_id);
 
         // cells: empty List
@@ -213,6 +223,21 @@ impl NotebookDoc {
         }
 
         Self { doc }
+    }
+
+    /// Read the schema version from the document, if present.
+    ///
+    /// Returns `None` for documents created before schema versioning was added.
+    /// Callers can treat `None` as schema version 1 (the original format).
+    pub fn schema_version(&self) -> Option<u64> {
+        match self.doc.get(automerge::ROOT, "schema_version").ok()?? {
+            (automerge::Value::Scalar(s), _) => match s.as_ref() {
+                automerge::ScalarValue::Uint(v) => Some(*v),
+                automerge::ScalarValue::Int(v) => Some(*v as u64),
+                _ => None,
+            },
+            _ => None,
+        }
     }
 
     /// Create a document with zero operations for sync-only bootstrap.

--- a/crates/notebook/Cargo.toml
+++ b/crates/notebook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notebook"
-version = "1.4.1"
+version = "2.0.0"
 edition = "2021"
 description = "Tauri-based notebook UI for Jupyter kernels"
 repository = "https://github.com/nteract/desktop"

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -1231,8 +1231,8 @@ where
         if !runtimed::is_dev_mode() {
             let bundled_version = bundled_daemon_version();
             if let Some(info) = runtimed::singleton::get_running_daemon_info() {
-                // Compare commit hashes only - package versions differ between crates
-                // (notebook has version like "1.4.1", runtimed has "0.1.0-dev.10")
+                // Compare commit hashes only - CI appends "+{git_sha}" to the version
+                // at build time, so commit hash is the precise compatibility check.
                 let running_commit = extract_commit_hash(&info.version);
                 let bundled_commit = extract_commit_hash(&bundled_version);
 

--- a/crates/notebook/tauri.conf.json
+++ b/crates/notebook/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "nteract",
-  "version": "1.4.1",
+  "version": "2.0.0",
   "identifier": "org.nteract.desktop",
   "build": {
     "devUrl": "http://localhost:5174",

--- a/crates/runt/Cargo.toml
+++ b/crates/runt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runt-cli"
-version = "1.4.1"
+version = "2.0.0"
 edition.workspace = true
 description = "CLI for Jupyter Runtimes — bundled with nteract"
 repository.workspace = true

--- a/crates/runtimed-py/src/output.rs
+++ b/crates/runtimed-py/src/output.rs
@@ -484,6 +484,10 @@ impl SyncEnvironmentResult {
 pub struct NotebookConnectionInfo {
     /// Protocol version (currently "v2").
     pub protocol: String,
+    /// Numeric protocol version for explicit version checking.
+    pub protocol_version: Option<u32>,
+    /// Daemon version string (e.g., "2.0.0+abc123").
+    pub daemon_version: Option<String>,
     /// Notebook identifier derived by the daemon.
     /// For existing files: canonical path.
     /// For new notebooks: generated UUID.
@@ -497,9 +501,10 @@ pub struct NotebookConnectionInfo {
 #[pymethods]
 impl NotebookConnectionInfo {
     fn __repr__(&self) -> String {
+        let daemon_ver = self.daemon_version.as_deref().unwrap_or("unknown");
         format!(
-            "NotebookConnectionInfo(notebook_id={}, cells={}, needs_trust={})",
-            self.notebook_id, self.cell_count, self.needs_trust_approval
+            "NotebookConnectionInfo(notebook_id={}, cells={}, protocol_version={:?}, daemon_version={})",
+            self.notebook_id, self.cell_count, self.protocol_version, daemon_ver
         )
     }
 }
@@ -509,6 +514,8 @@ impl NotebookConnectionInfo {
     pub fn from_protocol(info: runtimed::connection::NotebookConnectionInfo) -> Self {
         Self {
             protocol: info.protocol,
+            protocol_version: info.protocol_version,
+            daemon_version: info.daemon_version,
             notebook_id: info.notebook_id,
             cell_count: info.cell_count,
             needs_trust_approval: info.needs_trust_approval,

--- a/crates/runtimed/Cargo.toml
+++ b/crates/runtimed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed"
-version = "0.1.0-dev.10"
+version = "2.0.0"
 edition = "2021"
 description = "Central daemon for managing Jupyter runtimes and prewarmed environments"
 repository = "https://github.com/nteract/desktop"

--- a/crates/runtimed/src/client.rs
+++ b/crates/runtimed/src/client.rs
@@ -301,15 +301,15 @@ impl PoolClient {
     where
         S: AsyncRead + AsyncWrite + Unpin,
     {
+        // Send preamble (magic bytes + protocol version)
+        connection::send_preamble(&mut stream)
+            .await
+            .map_err(|e| ClientError::ProtocolError(format!("preamble: {}", e)))?;
+
         // Send the channel handshake
-        connection::send_json_frame(
-            &mut stream,
-            &Handshake::Pool {
-                protocol_version: Some(connection::PROTOCOL_VERSION),
-            },
-        )
-        .await
-        .map_err(|e| ClientError::ProtocolError(format!("handshake: {}", e)))?;
+        connection::send_json_frame(&mut stream, &Handshake::Pool)
+            .await
+            .map_err(|e| ClientError::ProtocolError(format!("handshake: {}", e)))?;
 
         // Send the request as a framed JSON message
         connection::send_json_frame(&mut stream, &request)
@@ -664,8 +664,11 @@ pub async fn subscribe_pool_state(
         }
     };
 
-    // Send the handshake
+    // Send preamble + handshake
     let mut stream = stream;
+    connection::send_preamble(&mut stream)
+        .await
+        .map_err(|e| ClientError::ProtocolError(format!("preamble: {}", e)))?;
     connection::send_json_frame(&mut stream, &Handshake::PoolStateSubscribe)
         .await
         .map_err(|e| ClientError::ProtocolError(format!("handshake: {}", e)))?;

--- a/crates/runtimed/src/client.rs
+++ b/crates/runtimed/src/client.rs
@@ -302,9 +302,14 @@ impl PoolClient {
         S: AsyncRead + AsyncWrite + Unpin,
     {
         // Send the channel handshake
-        connection::send_json_frame(&mut stream, &Handshake::Pool)
-            .await
-            .map_err(|e| ClientError::ProtocolError(format!("handshake: {}", e)))?;
+        connection::send_json_frame(
+            &mut stream,
+            &Handshake::Pool {
+                protocol_version: Some(connection::PROTOCOL_VERSION),
+            },
+        )
+        .await
+        .map_err(|e| ClientError::ProtocolError(format!("handshake: {}", e)))?;
 
         // Send the request as a framed JSON message
         connection::send_json_frame(&mut stream, &request)

--- a/crates/runtimed/src/connection.rs
+++ b/crates/runtimed/src/connection.rs
@@ -37,7 +37,12 @@ const MAX_CONTROL_FRAME_SIZE: usize = 64 * 1024;
 #[serde(tag = "channel", rename_all = "snake_case")]
 pub enum Handshake {
     /// Pool IPC: environment take/return/status/ping.
-    Pool,
+    Pool {
+        /// Numeric protocol version for version negotiation.
+        /// Old clients omit this; the daemon treats `None` as "legacy, accept anyway."
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        protocol_version: Option<u32>,
+    },
     /// Automerge settings sync.
     SettingsSync,
     /// Automerge notebook sync (per-notebook room).
@@ -388,21 +393,40 @@ mod tests {
 
     #[tokio::test]
     async fn test_json_frame_roundtrip() {
-        let handshake = Handshake::Pool;
+        let handshake = Handshake::Pool {
+            protocol_version: Some(PROTOCOL_VERSION),
+        };
 
         let mut buf = Vec::new();
         send_json_frame(&mut buf, &handshake).await.unwrap();
 
         let mut cursor = std::io::Cursor::new(buf);
         let received: Handshake = recv_json_frame(&mut cursor).await.unwrap().unwrap();
-        assert!(matches!(received, Handshake::Pool));
+        assert!(matches!(
+            received,
+            Handshake::Pool {
+                protocol_version: Some(PROTOCOL_VERSION)
+            }
+        ));
     }
 
     #[tokio::test]
     async fn test_handshake_serialization() {
-        // Pool
-        let json = serde_json::to_string(&Handshake::Pool).unwrap();
-        assert_eq!(json, r#"{"channel":"pool"}"#);
+        // Pool (with protocol_version)
+        let json = serde_json::to_string(&Handshake::Pool {
+            protocol_version: Some(PROTOCOL_VERSION),
+        })
+        .unwrap();
+        assert_eq!(json, r#"{"channel":"pool","protocol_version":2}"#);
+
+        // Pool (legacy, no protocol_version — still deserializes)
+        let legacy: Handshake = serde_json::from_str(r#"{"channel":"pool"}"#).unwrap();
+        assert!(matches!(
+            legacy,
+            Handshake::Pool {
+                protocol_version: None
+            }
+        ));
 
         // SettingsSync
         let json = serde_json::to_string(&Handshake::SettingsSync).unwrap();

--- a/crates/runtimed/src/connection.rs
+++ b/crates/runtimed/src/connection.rs
@@ -1,12 +1,18 @@
 //! Unified connection framing and handshake for the runtimed socket.
 //!
-//! All connections to the daemon use length-prefixed binary framing:
+//! Every connection begins with a 5-byte preamble:
+//!
+//! ```text
+//! [4 bytes: magic 0xC0DE01AC] [1 byte: protocol version]
+//! ```
+//!
+//! Followed by length-prefixed binary framing:
 //!
 //! ```text
 //! [4 bytes: payload length (big-endian u32)] [payload bytes]
 //! ```
 //!
-//! The first frame on every connection is a JSON handshake declaring the
+//! The first frame after the preamble is a JSON handshake declaring the
 //! channel. After the handshake, the daemon routes the connection to the
 //! appropriate handler.
 //!
@@ -37,12 +43,7 @@ const MAX_CONTROL_FRAME_SIZE: usize = 64 * 1024;
 #[serde(tag = "channel", rename_all = "snake_case")]
 pub enum Handshake {
     /// Pool IPC: environment take/return/status/ping.
-    Pool {
-        /// Numeric protocol version for version negotiation.
-        /// Old clients omit this; the daemon treats `None` as "legacy, accept anyway."
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        protocol_version: Option<u32>,
-    },
+    Pool,
     /// Automerge settings sync.
     SettingsSync,
     /// Automerge notebook sync (per-notebook room).
@@ -106,6 +107,68 @@ pub const PROTOCOL_V2: &str = "v2";
 /// Numeric protocol version for version negotiation.
 /// Increment this when making breaking protocol changes.
 pub const PROTOCOL_VERSION: u32 = 2;
+
+/// Magic bytes identifying the runtimed protocol.
+/// Sent as the first 4 bytes of every connection, before the handshake frame.
+pub const MAGIC: [u8; 4] = [0xC0, 0xDE, 0x01, 0xAC];
+
+/// Total preamble size: 4-byte magic + 1-byte protocol version.
+pub const PREAMBLE_LEN: usize = 5;
+
+/// Send the connection preamble (magic bytes + protocol version).
+///
+/// Must be called once at the start of every connection, before
+/// the handshake frame.
+pub async fn send_preamble<W: AsyncWrite + Unpin>(writer: &mut W) -> std::io::Result<()> {
+    let mut buf = [0u8; PREAMBLE_LEN];
+    buf[..4].copy_from_slice(&MAGIC);
+    buf[4] = PROTOCOL_VERSION as u8;
+    writer.write_all(&buf).await?;
+    writer.flush().await?;
+    Ok(())
+}
+
+/// Receive and validate the connection preamble.
+///
+/// Returns the protocol version byte. Returns an error if the magic bytes
+/// don't match or the protocol version is incompatible.
+pub async fn recv_preamble<R: AsyncRead + Unpin>(reader: &mut R) -> std::io::Result<u8> {
+    let mut buf = [0u8; PREAMBLE_LEN];
+    match reader.read_exact(&mut buf).await {
+        Ok(_) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "connection closed before preamble",
+            ));
+        }
+        Err(e) => return Err(e),
+    }
+
+    if buf[..4] != MAGIC {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "invalid magic bytes: expected {:02X?}, got {:02X?}",
+                MAGIC,
+                &buf[..4]
+            ),
+        ));
+    }
+
+    let version = buf[4];
+    if version != PROTOCOL_VERSION as u8 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "protocol version mismatch: expected {}, got {}",
+                PROTOCOL_VERSION, version
+            ),
+        ));
+    }
+
+    Ok(version)
+}
 
 /// Server response indicating protocol capabilities.
 ///
@@ -393,40 +456,66 @@ mod tests {
 
     #[tokio::test]
     async fn test_json_frame_roundtrip() {
-        let handshake = Handshake::Pool {
-            protocol_version: Some(PROTOCOL_VERSION),
-        };
+        let handshake = Handshake::Pool;
 
         let mut buf = Vec::new();
         send_json_frame(&mut buf, &handshake).await.unwrap();
 
         let mut cursor = std::io::Cursor::new(buf);
         let received: Handshake = recv_json_frame(&mut cursor).await.unwrap().unwrap();
-        assert!(matches!(
-            received,
-            Handshake::Pool {
-                protocol_version: Some(PROTOCOL_VERSION)
-            }
-        ));
+        assert!(matches!(received, Handshake::Pool));
+    }
+
+    #[tokio::test]
+    async fn test_preamble_roundtrip() {
+        let mut buf = Vec::new();
+        send_preamble(&mut buf).await.unwrap();
+        assert_eq!(buf.len(), PREAMBLE_LEN);
+        assert_eq!(&buf[..4], &MAGIC);
+        assert_eq!(buf[4], PROTOCOL_VERSION as u8);
+
+        let mut cursor = std::io::Cursor::new(buf);
+        let version = recv_preamble(&mut cursor).await.unwrap();
+        assert_eq!(version, PROTOCOL_VERSION as u8);
+    }
+
+    #[tokio::test]
+    async fn test_preamble_bad_magic() {
+        let buf = [0xFF, 0xFF, 0xFF, 0xFF, PROTOCOL_VERSION as u8];
+        let mut cursor = std::io::Cursor::new(buf.to_vec());
+        let result = recv_preamble(&mut cursor).await;
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().kind(), std::io::ErrorKind::InvalidData);
+    }
+
+    #[tokio::test]
+    async fn test_preamble_version_mismatch() {
+        let mut buf = [0u8; PREAMBLE_LEN];
+        buf[..4].copy_from_slice(&MAGIC);
+        buf[4] = 99; // wrong version
+        let mut cursor = std::io::Cursor::new(buf.to_vec());
+        let result = recv_preamble(&mut cursor).await;
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().kind(), std::io::ErrorKind::InvalidData);
+    }
+
+    #[tokio::test]
+    async fn test_preamble_eof() {
+        let buf: &[u8] = &[0xC0, 0xDE]; // incomplete
+        let mut cursor = std::io::Cursor::new(buf);
+        let result = recv_preamble(&mut cursor).await;
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().kind(),
+            std::io::ErrorKind::UnexpectedEof
+        );
     }
 
     #[tokio::test]
     async fn test_handshake_serialization() {
-        // Pool (with protocol_version)
-        let json = serde_json::to_string(&Handshake::Pool {
-            protocol_version: Some(PROTOCOL_VERSION),
-        })
-        .unwrap();
-        assert_eq!(json, r#"{"channel":"pool","protocol_version":2}"#);
-
-        // Pool (legacy, no protocol_version — still deserializes)
-        let legacy: Handshake = serde_json::from_str(r#"{"channel":"pool"}"#).unwrap();
-        assert!(matches!(
-            legacy,
-            Handshake::Pool {
-                protocol_version: None
-            }
-        ));
+        // Pool
+        let json = serde_json::to_string(&Handshake::Pool).unwrap();
+        assert_eq!(json, r#"{"channel":"pool"}"#);
 
         // SettingsSync
         let json = serde_json::to_string(&Handshake::SettingsSync).unwrap();

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -897,7 +897,7 @@ impl Daemon {
         let handshake: Handshake = serde_json::from_slice(&handshake_bytes)?;
 
         match handshake {
-            Handshake::Pool => self.handle_pool_connection(stream).await,
+            Handshake::Pool { .. } => self.handle_pool_connection(stream).await,
             Handshake::SettingsSync => {
                 let (reader, writer) = tokio::io::split(stream);
                 let changed_tx = self.settings_changed.clone();

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -884,20 +884,26 @@ impl Daemon {
     where
         S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
     {
-        // Read the handshake with the control frame limit (64 KiB) and a
-        // timeout so that idle/stalled connections don't hold resources.
-        let handshake_bytes = tokio::time::timeout(
-            std::time::Duration::from_secs(10),
-            connection::recv_control_frame(&mut stream),
-        )
+        // Read preamble + handshake with a timeout so that idle/stalled
+        // connections don't hold resources.
+        let handshake_bytes = tokio::time::timeout(std::time::Duration::from_secs(10), async {
+            // Validate magic bytes + protocol version
+            connection::recv_preamble(&mut stream)
+                .await
+                .map_err(|e| anyhow::anyhow!("preamble: {}", e))?;
+
+            // Read the JSON handshake frame
+            connection::recv_control_frame(&mut stream)
+                .await
+                .context("handshake read error")?
+                .ok_or_else(|| anyhow::anyhow!("connection closed before handshake"))
+        })
         .await
-        .map_err(|_| anyhow::anyhow!("handshake timeout (10s)"))?
-        .context("handshake read error")?
-        .ok_or_else(|| anyhow::anyhow!("connection closed before handshake"))?;
+        .map_err(|_| anyhow::anyhow!("handshake timeout (10s)"))??;
         let handshake: Handshake = serde_json::from_slice(&handshake_bytes)?;
 
         match handshake {
-            Handshake::Pool { .. } => self.handle_pool_connection(stream).await,
+            Handshake::Pool => self.handle_pool_connection(stream).await,
             Handshake::SettingsSync => {
                 let (reader, writer) = tokio::io::split(stream);
                 let changed_tx = self.settings_changed.clone();

--- a/crates/runtimed/src/notebook_sync_client.rs
+++ b/crates/runtimed/src/notebook_sync_client.rs
@@ -905,6 +905,11 @@ where
         working_dir: Option<PathBuf>,
         initial_metadata: Option<String>,
     ) -> Result<Self, NotebookSyncError> {
+        // Send preamble (magic bytes + protocol version)
+        connection::send_preamble(&mut stream)
+            .await
+            .map_err(|e| NotebookSyncError::SyncError(format!("preamble: {}", e)))?;
+
         // Send the channel handshake, requesting v2 protocol
         connection::send_json_frame(
             &mut stream,
@@ -1072,6 +1077,11 @@ where
         let path_str = path.to_string_lossy().to_string();
         info!("[notebook-sync-client] Opening notebook: {}", path_str);
 
+        // Send preamble (magic bytes + protocol version)
+        connection::send_preamble(&mut stream)
+            .await
+            .map_err(|e| NotebookSyncError::SyncError(format!("preamble: {}", e)))?;
+
         // Send OpenNotebook handshake
         connection::send_json_frame(&mut stream, &Handshake::OpenNotebook { path: path_str })
             .await
@@ -1151,6 +1161,11 @@ where
             "[notebook-sync-client] Creating new notebook (runtime: {}, working_dir: {:?}, notebook_id: {:?})",
             runtime, working_dir, notebook_id
         );
+
+        // Send preamble (magic bytes + protocol version)
+        connection::send_preamble(&mut stream)
+            .await
+            .map_err(|e| NotebookSyncError::SyncError(format!("preamble: {}", e)))?;
 
         // Send CreateNotebook handshake
         connection::send_json_frame(

--- a/crates/runtimed/src/sync_client.rs
+++ b/crates/runtimed/src/sync_client.rs
@@ -112,6 +112,11 @@ where
     /// Initialize the client by sending the handshake and performing
     /// the initial sync exchange.
     async fn init(mut stream: S) -> Result<Self, SyncClientError> {
+        // Send preamble (magic bytes + protocol version)
+        connection::send_preamble(&mut stream)
+            .await
+            .map_err(|e| SyncClientError::SyncError(format!("preamble: {}", e)))?;
+
         // Send the channel handshake so the daemon routes us to settings sync
         connection::send_json_frame(&mut stream, &Handshake::SettingsSync)
             .await

--- a/crates/sidecar/Cargo.toml
+++ b/crates/sidecar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sidecar"
-version = "1.4.1"
+version = "2.0.0"
 edition.workspace = true
 description = "Sidecar jupyter outputs — install via GitHub Releases or `pip install runtimed`, not crates.io"
 repository.workspace = true

--- a/python/runtimed/pyproject.toml
+++ b/python/runtimed/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "runtimed"
-version = "0.1.4"
+version = "2.0.0"
 description = "Python toolkit for Jupyter runtimes, powered by runtimed Rust binaries"
 readme = "README.md"
 license = "BSD-3-Clause"


### PR DESCRIPTION
All artifacts move to 2.0.0. Establishes a versioning contract, adds a magic bytes wire preamble, and cleans up the release flow — all ahead of fractional indexing for cell ordering.

## Version bumps (2.0.0 everywhere)

- `runtimed` Rust daemon (`0.1.0-dev.10` → `2.0.0`)
- `runtimed` PyPI package (`0.1.4` → `2.0.0`)
- `runt-cli` (`1.4.1` → `2.0.0`)
- `notebook` / `tauri.conf.json` (`1.4.1` → `2.0.0`)
- `sidecar` (`1.4.1` → `2.0.0`)

## Magic bytes preamble

Every connection now starts with a 5-byte preamble before the JSON handshake frame:

| Bytes | Content |
|-------|---------|
| 0–3 | `0xC0 0xDE 0x01 0xAC` |
| 4 | Protocol version (`2`) |

The daemon validates both before reading the handshake. Non-runtimed connections get a clear error instead of a serde parse failure. Protocol mismatches are rejected before any JSON parsing. This is the breaking wire change that justifies 2.0.0.

## Document schema version

Adds `schema_version` (u64, currently `1`) to the Automerge document root. This is the gate for the upcoming fractional indexing migration — schema version 2 will switch cells from an ordered `List` to a `Map` keyed by cell ID with fractional index positions. Independent from the wire protocol version.

## Release flow

- Stable desktop releases (`v*` tags) now also publish Python wheels to PyPI at the version from `pyproject.toml`. One tag ships everything.
- Nightly still applies the PEP 440 alpha stamp (`2.0.1a{timestamp}`).
- `python-v*` tag path kept for Python-only patches.

## Python bindings

`NotebookConnectionInfo` now exposes `protocol_version` and `daemon_version` (previously dropped during conversion from Rust).

## Versioning contract

Protocol version and schema version are independent internal compatibility markers — not tied to the artifact version. A protocol or schema bump doesn't force a major version bump; that depends on user impact. Documented in `contributing/releasing.md` and `contributing/protocol.md`.

_PR submitted by @rgbkrk's agent Quill, via Zed_