### PR TITLE
fix(runtimed): accept legacy clients without magic bytes preamble

### DIFF
--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -886,17 +886,78 @@ impl Daemon {
     {
         // Read preamble + handshake with a timeout so that idle/stalled
         // connections don't hold resources.
+        //
+        // Backward compatibility: old clients (pre-2.0.0) send a length-prefixed
+        // JSON handshake without the magic bytes preamble. We detect this by
+        // peeking at the first byte: 0xC0 = new protocol (magic preamble),
+        // 0x00 = old protocol (4-byte big-endian length prefix for any
+        // reasonable handshake size). This allows the daemon upgrade to succeed
+        // even when the old app is still verifying daemon health.
         let handshake_bytes = tokio::time::timeout(std::time::Duration::from_secs(10), async {
-            // Validate magic bytes + protocol version
-            connection::recv_preamble(&mut stream)
+            // Peek at first byte to detect protocol version
+            let mut first_byte = [0u8; 1];
+            tokio::io::AsyncReadExt::read_exact(&mut stream, &mut first_byte)
                 .await
-                .map_err(|e| anyhow::anyhow!("preamble: {}", e))?;
+                .map_err(|e| {
+                    if e.kind() == std::io::ErrorKind::UnexpectedEof {
+                        anyhow::anyhow!("connection closed before preamble")
+                    } else {
+                        anyhow::anyhow!("preamble read: {}", e)
+                    }
+                })?;
 
-            // Read the JSON handshake frame
-            connection::recv_control_frame(&mut stream)
-                .await
-                .context("handshake read error")?
-                .ok_or_else(|| anyhow::anyhow!("connection closed before handshake"))
+            if first_byte[0] == connection::MAGIC[0] {
+                // New protocol: read remaining 4 bytes of preamble (3 more magic + 1 version)
+                let mut rest = [0u8; 4];
+                tokio::io::AsyncReadExt::read_exact(&mut stream, &mut rest)
+                    .await
+                    .map_err(|e| anyhow::anyhow!("preamble: {}", e))?;
+
+                if rest[..3] != connection::MAGIC[1..] {
+                    anyhow::bail!(
+                        "invalid magic bytes: expected {:02X?}, got {:02X?}",
+                        connection::MAGIC,
+                        [&first_byte[..], &rest[..3]].concat()
+                    );
+                }
+
+                let version = rest[3];
+                if version != connection::PROTOCOL_VERSION as u8 {
+                    anyhow::bail!(
+                        "protocol version mismatch: expected {}, got {}",
+                        connection::PROTOCOL_VERSION,
+                        version
+                    );
+                }
+
+                // Read the JSON handshake frame
+                connection::recv_control_frame(&mut stream)
+                    .await
+                    .context("handshake read error")?
+                    .ok_or_else(|| anyhow::anyhow!("connection closed before handshake"))
+            } else {
+                // Legacy protocol (pre-2.0.0): first byte is part of a 4-byte
+                // big-endian length prefix. Read remaining 3 length bytes.
+                log::debug!("[runtimed] Legacy client detected (no magic preamble)");
+                let mut len_rest = [0u8; 3];
+                tokio::io::AsyncReadExt::read_exact(&mut stream, &mut len_rest)
+                    .await
+                    .map_err(|e| anyhow::anyhow!("legacy length read: {}", e))?;
+
+                let len_bytes = [first_byte[0], len_rest[0], len_rest[1], len_rest[2]];
+                let len = u32::from_be_bytes(len_bytes) as usize;
+
+                if len > 64 * 1024 {
+                    anyhow::bail!("legacy handshake frame too large: {} bytes", len);
+                }
+
+                let mut buf = vec![0u8; len];
+                tokio::io::AsyncReadExt::read_exact(&mut stream, &mut buf)
+                    .await
+                    .map_err(|e| anyhow::anyhow!("legacy handshake read: {}", e))?;
+
+                Ok(buf)
+            }
         })
         .await
         .map_err(|_| anyhow::anyhow!("handshake timeout (10s)"))??;

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -12,6 +12,7 @@ use runtimed::daemon::{Daemon, DaemonConfig};
 use runtimed::notebook_sync_client::NotebookSyncClient;
 use runtimed::EnvType;
 use tempfile::TempDir;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::time::sleep;
 
 /// Write a test .ipynb notebook file with the given cells.
@@ -948,5 +949,66 @@ async fn test_streaming_load_second_client_joins() {
     drop(handle2);
     let _ = info2; // suppress unused warning
     pool_client.shutdown().await.ok();
+    let _ = tokio::time::timeout(Duration::from_secs(2), daemon_handle).await;
+}
+
+/// Test that a legacy client (pre-2.0.0, no magic bytes preamble) can still
+/// connect to the daemon. This is critical for the upgrade path: the old app
+/// installs the new daemon binary, then pings it to verify it's running.
+/// Without backward compat, the upgrade fails with "daemon did not become ready."
+#[tokio::test]
+async fn test_legacy_client_no_preamble() {
+    let temp_dir = TempDir::new().unwrap();
+    let config = test_config(&temp_dir);
+    let socket_path = config.socket_path.clone();
+
+    let daemon = Daemon::new(config).unwrap();
+    let daemon_handle = tokio::spawn(async move {
+        daemon.run().await.ok();
+    });
+
+    // Wait for daemon with a modern client first
+    let client = PoolClient::new(socket_path.clone());
+    assert!(wait_for_daemon(&client, Duration::from_secs(5)).await);
+
+    // Now connect as a legacy client: send a raw length-prefixed JSON
+    // handshake WITHOUT the magic bytes preamble.
+    let mut stream = tokio::net::UnixStream::connect(&socket_path)
+        .await
+        .expect("legacy client should connect");
+
+    // Send Pool handshake as length-prefixed JSON (old protocol)
+    let handshake = br#"{"channel":"pool"}"#;
+    let len = (handshake.len() as u32).to_be_bytes();
+    stream.write_all(&len).await.unwrap();
+    stream.write_all(handshake).await.unwrap();
+    stream.flush().await.unwrap();
+
+    // Send a Ping request
+    let ping = br#"{"type":"ping"}"#;
+    let len = (ping.len() as u32).to_be_bytes();
+    stream.write_all(&len).await.unwrap();
+    stream.write_all(ping).await.unwrap();
+    stream.flush().await.unwrap();
+
+    // Read the response — should be a Pong
+    let mut resp_len = [0u8; 4];
+    stream.read_exact(&mut resp_len).await.unwrap();
+    let resp_size = u32::from_be_bytes(resp_len) as usize;
+    let mut resp_buf = vec![0u8; resp_size];
+    stream.read_exact(&mut resp_buf).await.unwrap();
+
+    let resp: serde_json::Value = serde_json::from_slice(&resp_buf).unwrap();
+    assert_eq!(
+        resp["type"], "pong",
+        "legacy client should get a Pong response"
+    );
+
+    // Also verify a modern client still works alongside
+    let result = client.ping().await;
+    assert!(result.is_ok(), "modern client should still work");
+
+    // Shutdown
+    client.shutdown().await.ok();
     let _ = tokio::time::timeout(Duration::from_secs(2), daemon_handle).await;
 }


### PR DESCRIPTION
The daemon now accepts connections from old clients (pre-2.0.0) that don't send the magic bytes preamble. This fixes the upgrade path where the old app installs the new daemon binary and pings it to verify it's running — without this, the upgrade fails with "daemon did not become ready within timeout."

Detection is simple: read the first byte. `0xC0` = new protocol (magic preamble follows). `0x00` = legacy protocol (4-byte big-endian length prefix, no preamble). Old client handshakes like `{"channel":"pool"}` are 18 bytes, so the length prefix starts with `0x00`.

Includes an integration test that sends a raw JSON handshake without preamble and verifies the daemon responds with Pong.

_PR submitted by @rgbkrk's agent Quill, via Zed_