### PR TITLE
fix(runtimed): loop for automerge sync ack in sync_to_daemon

### DIFF
--- a/crates/runtimed/src/notebook_sync_client.rs
+++ b/crates/runtimed/src/notebook_sync_client.rs
@@ -2048,26 +2048,51 @@ where
             connection::send_typed_frame(&mut self.stream, NotebookFrameType::AutomergeSync, &data)
                 .await?;
 
-            match tokio::time::timeout(
-                Duration::from_millis(500),
-                connection::recv_typed_frame(&mut self.stream),
-            )
-            .await
-            {
-                Ok(Ok(Some(frame))) => {
-                    // Only handle AutomergeSync frames; ignore broadcasts
-                    if frame.frame_type == NotebookFrameType::AutomergeSync {
-                        let message = sync::Message::decode(&frame.payload)
-                            .map_err(|e| NotebookSyncError::SyncError(format!("decode: {}", e)))?;
-                        self.doc
-                            .sync()
-                            .receive_sync_message(&mut self.peer_state, message)
-                            .map_err(|e| NotebookSyncError::SyncError(format!("receive: {}", e)))?;
-                    }
+            // Loop until we receive the AutomergeSync ack or the deadline
+            // expires. Previous code read exactly one frame, so a Broadcast
+            // arriving before the ack would be silently dropped and the ack
+            // left unprocessed in the buffer — leaving peer_state stale.
+            let deadline = tokio::time::Instant::now() + Duration::from_millis(500);
+            loop {
+                let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+                if remaining.is_zero() {
+                    break; // Timeout — server had nothing to send back
                 }
-                Ok(Ok(None)) => return Err(NotebookSyncError::Disconnected),
-                Ok(Err(e)) => return Err(NotebookSyncError::ConnectionFailed(e)),
-                Err(_) => {} // Timeout — server had nothing to send back
+
+                match tokio::time::timeout(
+                    remaining,
+                    connection::recv_typed_frame(&mut self.stream),
+                )
+                .await
+                {
+                    Ok(Ok(Some(frame))) => {
+                        if frame.frame_type == NotebookFrameType::AutomergeSync {
+                            let message = sync::Message::decode(&frame.payload).map_err(|e| {
+                                NotebookSyncError::SyncError(format!("decode: {}", e))
+                            })?;
+                            self.doc
+                                .sync()
+                                .receive_sync_message(&mut self.peer_state, message)
+                                .map_err(|e| {
+                                    NotebookSyncError::SyncError(format!("receive: {}", e))
+                                })?;
+                            break; // Got the ack
+                        }
+                        // Queue non-ack frames (broadcasts) for later delivery
+                        // instead of silently dropping them.
+                        if frame.frame_type == NotebookFrameType::Broadcast {
+                            if let Ok(broadcast) =
+                                serde_json::from_slice::<NotebookBroadcast>(&frame.payload)
+                            {
+                                self.pending_broadcasts.push(broadcast);
+                            }
+                        }
+                        // Continue looping to find the ack
+                    }
+                    Ok(Ok(None)) => return Err(NotebookSyncError::Disconnected),
+                    Ok(Err(e)) => return Err(NotebookSyncError::ConnectionFailed(e)),
+                    Err(_) => break, // Timeout — server had nothing to send back
+                }
             }
         }
         Ok(())

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -1956,6 +1956,15 @@ async fn handle_notebook_request(
                 match doc.get_cell(&cell_id) {
                     Some(c) => (c.source, c.cell_type),
                     None => {
+                        let cells = doc.get_cells();
+                        let cell_ids: Vec<&str> = cells.iter().map(|c| c.id.as_str()).collect();
+                        warn!(
+                            "[notebook-sync] ExecuteCell: cell {} not found in document \
+                             (doc has {} cells: {:?})",
+                            cell_id,
+                            cells.len(),
+                            cell_ids,
+                        );
                         return NotebookResponse::Error {
                             error: format!("Cell not found in document: {}", cell_id),
                         };


### PR DESCRIPTION
`sync_to_daemon` previously read exactly one frame after sending the sync message. If a Broadcast frame arrived before the AutomergeSync ack, the broadcast was silently dropped and the ack was left unprocessed in the stream buffer — leaving `peer_state` stale.

Now loops until the ack arrives (or the 500ms deadline expires), queuing any Broadcast frames in `pending_broadcasts` for later delivery.

Also adds diagnostic logging to `ExecuteCell` when a cell is not found, including the doc's cell count and IDs.

Addresses these flaky CI failures:
```
FAILED test_cell_created_by_one_visible_to_other - Timed out waiting for cell with source visible to s2
FAILED test_interleaved_stdout_stderr_separate - Cell not found in document
FAILED test_uv_inline_deps_trusted - uv:inline requires a prepared environment (was it created?)
```

All three share the same root cause: sync mutations not propagating because a Broadcast frame ate the AutomergeSync ack.

Supersedes #693 (same fix, rebased onto current main after fractional indexing landed).

_PR submitted by @rgbkrk's agent Quill, via Zed_