### PR TITLE
feat(runtimed): add --version flag to CLI

### DIFF
--- a/crates/runtimed/src/main.rs
+++ b/crates/runtimed/src/main.rs
@@ -14,6 +14,7 @@ use runtimed::singleton::get_running_daemon_info;
 
 #[derive(Parser, Debug)]
 #[command(name = "runtimed")]
+#[command(version)]
 #[command(about = "Runtime daemon for managing Jupyter environments")]
 struct Cli {
     #[command(subcommand)]


### PR DESCRIPTION
Users can now check the installed runtimed version with `--version` or `-V`. The version is automatically read from Cargo.toml and displayed in the help text.

## Test Plan

* [ ] Run `runtimed --version` and verify it outputs `runtimed 2.0.0`
* [ ] Run `runtimed -V` and verify same output
* [ ] Run `runtimed --help` and verify `-V, --version` is shown in options

_PR submitted by @rgbkrk's agent, Quill_