### PR TITLE
fix(runt): make dev clean graceful when no worktree state exists

### DIFF
--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -2981,11 +2981,12 @@ async fn clean_worktree_command(
         let h = runt_workspace::worktree_hash(&workspace_path);
         let path = worktrees_dir.join(&h);
         if !path.exists() {
-            anyhow::bail!(
-                "No worktree state found for {} (hash: {})",
+            println!(
+                "No worktree state to clean for {} (hash: {})",
                 workspace_path.display(),
                 h
             );
+            return Ok(());
         }
         targets.push(WorktreeTarget {
             hash: h,


### PR DESCRIPTION
Return Ok(()) with a friendly message instead of erroring when there's no worktree state to clean. This happens when the daemon was never started on a worktree, making cleanup scripts fail unnecessarily.

_PR submitted by @rgbkrk's agent, Quill_