### PR TITLE
chore(ci): update github actions to node 24 versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
     outputs:
       source_changed: ${{ steps.filter.outputs.source }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -58,7 +58,7 @@ jobs:
     if: needs.changes.outputs.source_changed == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install rust
         uses: dsherret/rust-toolchain-file@v1
@@ -67,7 +67,7 @@ jobs:
         run: cargo fmt --check
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
 
@@ -91,10 +91,10 @@ jobs:
     if: needs.changes.outputs.source_changed == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
 
@@ -105,7 +105,7 @@ jobs:
         run: pnpm config set store-dir ~/.pnpm-store
 
       - name: Cache pnpm store
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.pnpm-store
           key: pnpm-store-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -121,7 +121,7 @@ jobs:
           pnpm --dir apps/notebook build
 
       - name: Upload UI build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ui-build-dist
           path: |
@@ -135,10 +135,10 @@ jobs:
     if: needs.changes.outputs.source_changed == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Download UI build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ui-build-dist
           path: apps
@@ -149,7 +149,7 @@ jobs:
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libxdo-dev
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
 
       - name: Install rust
         uses: dsherret/rust-toolchain-file@v1
@@ -159,7 +159,7 @@ jobs:
           shared-key: ubuntu-latest
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
 
@@ -170,7 +170,7 @@ jobs:
         run: pnpm config set store-dir ~/.pnpm-store
 
       - name: Cache pnpm store
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.pnpm-store
           key: pnpm-store-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -198,7 +198,7 @@ jobs:
           fi
 
       - name: Upload Linux Rust binaries
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: linux-rust-binaries
           path: |
@@ -259,12 +259,12 @@ jobs:
         if: needs.changes.outputs.source_changed == 'true' && github.event_name == 'pull_request' && !matrix.platform.run_on_pr
         run: echo "Skipping this platform for pull_request events."
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         if: needs.changes.outputs.source_changed == 'true' && (github.event_name != 'pull_request' || matrix.platform.run_on_pr)
 
       - name: Download UI build artifacts
         if: needs.changes.outputs.source_changed == 'true' && (github.event_name != 'pull_request' || matrix.platform.run_on_pr)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ui-build-dist
           path: apps
@@ -275,7 +275,7 @@ jobs:
 
       - name: Install uv
         if: needs.changes.outputs.source_changed == 'true' && (github.event_name != 'pull_request' || matrix.platform.run_on_pr)
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
 
       - name: Install rust
         if: needs.changes.outputs.source_changed == 'true' && (github.event_name != 'pull_request' || matrix.platform.run_on_pr)
@@ -320,7 +320,7 @@ jobs:
     if: needs.changes.outputs.source_changed == 'true' && needs.build-linux.result == 'success'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install system dependencies
         run: |
@@ -335,7 +335,7 @@ jobs:
           shared-key: ubuntu-latest
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
 
@@ -346,7 +346,7 @@ jobs:
         run: pnpm config set store-dir ~/.pnpm-store
 
       - name: Cache pnpm store
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.pnpm-store
           key: pnpm-store-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -362,7 +362,7 @@ jobs:
           pnpm --dir apps/notebook build
 
       - name: Cache cargo bin
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cargo/bin
           key: cargo-bin-ubuntu-tauri-cli-tauri-driver-${{ hashFiles('rust-toolchain.toml') }}
@@ -376,7 +376,7 @@ jobs:
           fi
 
       - name: Download Linux Rust binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: linux-rust-binaries
           path: .
@@ -391,7 +391,7 @@ jobs:
         run: cd crates/notebook && cargo tauri build --ci --no-bundle --config '{"build":{"beforeBuildCommand":""}}'
 
       - name: Upload E2E artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-app-linux
           path: |
@@ -406,7 +406,7 @@ jobs:
     needs: [changes, build-e2e-app]
     if: needs.changes.outputs.source_changed == 'true'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install system dependencies
         run: |
@@ -419,7 +419,7 @@ jobs:
             webkit2gtk-driver
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
 
@@ -430,7 +430,7 @@ jobs:
         run: pnpm config set store-dir ~/.pnpm-store
 
       - name: Cache pnpm store
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.pnpm-store
           key: pnpm-store-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -441,7 +441,7 @@ jobs:
         run: pnpm install
 
       - name: Download E2E artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: e2e-app-linux
           path: ./target/release
@@ -452,7 +452,7 @@ jobs:
           chmod +x target/release/binaries/*
 
       - name: Cache tauri-driver
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cargo/bin/tauri-driver
           key: cargo-bin-tauri-driver-v0.1
@@ -468,7 +468,7 @@ jobs:
           fi
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
 
       - name: Start E2E daemon
         run: |
@@ -526,7 +526,7 @@ jobs:
 
       - name: Upload failure screenshots
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-screenshots
           path: e2e-screenshots/failures/
@@ -534,7 +534,7 @@ jobs:
 
       - name: Upload daemon logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-daemon-logs
           path: e2e-logs/
@@ -547,7 +547,7 @@ jobs:
     needs: [changes, build-e2e-app, e2e]
     if: needs.changes.outputs.source_changed == 'true'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install system dependencies
         run: |
@@ -560,7 +560,7 @@ jobs:
             webkit2gtk-driver
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
 
@@ -571,7 +571,7 @@ jobs:
         run: pnpm config set store-dir ~/.pnpm-store
 
       - name: Cache pnpm store
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.pnpm-store
           key: pnpm-store-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -582,7 +582,7 @@ jobs:
         run: pnpm install
 
       - name: Download E2E artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: e2e-app-linux
           path: ./target/release
@@ -593,7 +593,7 @@ jobs:
           chmod +x target/release/binaries/*
 
       - name: Cache tauri-driver
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cargo/bin/tauri-driver
           key: cargo-bin-tauri-driver-v0.1
@@ -609,7 +609,7 @@ jobs:
           fi
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
 
       - name: Run kernel launch fixture tests
         timeout-minutes: 15
@@ -736,7 +736,7 @@ jobs:
 
       - name: Upload failure screenshots
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-fixture-screenshots
           path: e2e-screenshots/failures/
@@ -744,7 +744,7 @@ jobs:
 
       - name: Upload test logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-fixture-logs
           path: e2e-logs/
@@ -757,7 +757,7 @@ jobs:
     needs: [changes, build-linux]
     if: needs.changes.outputs.source_changed == 'true'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install system dependencies
         run: |
@@ -772,7 +772,7 @@ jobs:
           shared-key: ubuntu-latest
 
       - name: Download Linux Rust binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: linux-rust-binaries
           path: .
@@ -781,7 +781,7 @@ jobs:
         run: chmod +x target/release/runtimed target/release/runt
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
 
       - name: Build runtimed-py
         working-directory: python/runtimed
@@ -811,7 +811,7 @@ jobs:
 
       - name: Upload test logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: runtimed-py-integration-logs
           path: python/runtimed/integration-logs/

--- a/.github/workflows/pr-binary-generation.yml
+++ b/.github/workflows/pr-binary-generation.yml
@@ -39,7 +39,7 @@ jobs:
     steps:
       - name: Resolve pull request head commit
         id: resolve
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const prNumber = Number(context.payload.inputs.pr_number);
@@ -72,7 +72,7 @@ jobs:
 
     steps:
       - name: Checkout pinned PR commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ needs.resolve-pr.outputs.head_sha }}
           fetch-depth: 1
@@ -91,7 +91,7 @@ jobs:
           shared-key: pr-binary-${{ inputs.target_os }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
 
@@ -104,7 +104,7 @@ jobs:
 
       - name: Cache pnpm store (Unix)
         if: runner.os != 'Windows'
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.pnpm-store
           key: pnpm-store-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -113,7 +113,7 @@ jobs:
 
       - name: Cache pnpm store (Windows)
         if: runner.os == 'Windows'
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~\AppData\Local\pnpm\store
           key: pnpm-store-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -128,7 +128,7 @@ jobs:
 
       - name: Cache tauri-cli binary (Unix)
         if: runner.os != 'Windows'
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cargo/bin
           key: cargo-bin-${{ inputs.target_os }}-tauri-cli-${{ hashFiles('rust-toolchain.toml') }}
@@ -137,7 +137,7 @@ jobs:
 
       - name: Cache tauri-cli binary (Windows)
         if: runner.os == 'Windows'
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~\.cargo\bin
           key: cargo-bin-${{ inputs.target_os }}-tauri-cli-${{ hashFiles('rust-toolchain.toml') }}
@@ -161,7 +161,7 @@ jobs:
 
       - name: Bake PR + commit into version
         id: version
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           PR_NUMBER: ${{ needs.resolve-pr.outputs.pr_number }}
           COMMIT_SHORT_SHA: ${{ needs.resolve-pr.outputs.head_short_sha }}
@@ -274,14 +274,14 @@ jobs:
 
       - name: Upload runnable binary artifact
         id: upload-artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ needs.resolve-pr.outputs.artifact_prefix }}-${{ inputs.target_os == 'linux' && 'linux-x64' || inputs.target_os == 'macos' && 'macos' || 'windows-x64' }}
           path: pr-binary/
           retention-days: 14
 
       - name: Comment on PR with artifact link
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           PR_NUMBER: ${{ needs.resolve-pr.outputs.pr_number }}
           TARGET_OS: ${{ inputs.target_os }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -40,7 +40,7 @@ jobs:
           - runner: macos-latest
             target: x86_64-apple-darwin
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Rust
         uses: dsherret/rust-toolchain-file@v1
@@ -69,7 +69,7 @@ jobs:
           maturin-version: "v1.11.5"
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wheels-macos-${{ matrix.platform.target }}
           path: python/runtimed/dist
@@ -77,7 +77,7 @@ jobs:
   linux:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Rust
         uses: dsherret/rust-toolchain-file@v1
@@ -102,7 +102,7 @@ jobs:
           maturin-version: "v1.11.5"
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wheels-linux-x86_64
           path: python/runtimed/dist
@@ -117,15 +117,15 @@ jobs:
       contents: write
       attestations: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
 
       - name: Generate artifact attestation
-        uses: actions/attest-build-provenance@v2
+        uses: actions/attest-build-provenance@v4
         with:
           subject-path: "wheels-*/*"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
 
       - name: Publish to PyPI
         run: uv publish --trusted-publishing always --check-url https://pypi.org/simple/runtimed/ 'wheels-*/*'

--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -57,7 +57,7 @@ jobs:
       timestamp: ${{ steps.version.outputs.TIMESTAMP }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Compute version
         id: version
@@ -75,7 +75,7 @@ jobs:
     needs: compute-version
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -93,7 +93,7 @@ jobs:
           shared-key: "linux-release"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
 
@@ -104,7 +104,7 @@ jobs:
         run: pnpm config set store-dir ~/.pnpm-store
 
       - name: Cache pnpm store
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.pnpm-store
           key: pnpm-store-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -132,7 +132,7 @@ jobs:
           chmod +x runt-linux-x64
 
       - name: Upload Linux executables
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: runt-linux-executables
           path: |
@@ -144,7 +144,7 @@ jobs:
     needs: compute-version
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -159,7 +159,7 @@ jobs:
           shared-key: "macos-release"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
 
@@ -170,7 +170,7 @@ jobs:
         run: pnpm config set store-dir ~/.pnpm-store
 
       - name: Cache pnpm store
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.pnpm-store
           key: pnpm-store-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -198,7 +198,7 @@ jobs:
           chmod +x runt-darwin-arm64
 
       - name: Upload macOS executables
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: runt-macos-executables
           path: |
@@ -210,7 +210,7 @@ jobs:
     needs: compute-version
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -222,7 +222,7 @@ jobs:
           shared-key: "macos-notebook-arm64"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
 
@@ -233,7 +233,7 @@ jobs:
         run: pnpm config set store-dir ~/.pnpm-store
 
       - name: Cache pnpm store
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.pnpm-store
           key: pnpm-store-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -247,7 +247,7 @@ jobs:
         run: pnpm build
 
       - name: Cache cargo bin
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cargo/bin
           key: cargo-bin-macos-arm64-tauri-cli-${{ hashFiles('rust-toolchain.toml') }}
@@ -375,7 +375,7 @@ jobs:
           cp "${TAR_GZ_SIG_BINARIES[0]}" "artifacts/nteract-${CHANNEL}-darwin-arm64.app.tar.gz.sig"
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: nteract-macos-arm64
           path: artifacts/
@@ -386,7 +386,7 @@ jobs:
     needs: compute-version
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -398,7 +398,7 @@ jobs:
           shared-key: "windows-notebook-x64"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
 
@@ -406,7 +406,7 @@ jobs:
         run: corepack enable
 
       - name: Cache pnpm store
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~\AppData\Local\pnpm\store
           key: pnpm-store-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -420,7 +420,7 @@ jobs:
         run: pnpm build
 
       - name: Cache cargo bin
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~\.cargo\bin
           key: cargo-bin-windows-x64-tauri-cli-${{ hashFiles('rust-toolchain.toml') }}
@@ -514,7 +514,7 @@ jobs:
           fi
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: nteract-windows-x64
           path: artifacts/
@@ -525,7 +525,7 @@ jobs:
     needs: compute-version
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -543,7 +543,7 @@ jobs:
           shared-key: "linux-notebook-x64"
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20"
 
@@ -554,7 +554,7 @@ jobs:
         run: pnpm config set store-dir ~/.pnpm-store
 
       - name: Cache pnpm store
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.pnpm-store
           key: pnpm-store-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -568,7 +568,7 @@ jobs:
         run: pnpm build
 
       - name: Cache cargo bin
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cargo/bin
           key: cargo-bin-linux-x64-tauri-cli-${{ hashFiles('rust-toolchain.toml') }}
@@ -638,7 +638,7 @@ jobs:
           cp "$DEB_PATH" "artifacts/nteract-${CHANNEL}-linux-x64.deb"
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: nteract-linux-x64
           path: artifacts/
@@ -657,7 +657,7 @@ jobs:
           - runner: windows-latest
             target: x86_64-pc-windows-msvc
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Rust
         uses: dsherret/rust-toolchain-file@v1
@@ -721,7 +721,7 @@ jobs:
           maturin-version: "v1.11.5"
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wheels-${{ matrix.platform.target }}
           path: python/runtimed/dist
@@ -744,7 +744,7 @@ jobs:
       ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -769,31 +769,31 @@ jobs:
           echo "$CHANGELOG" > changelog-section.md
 
       - name: Download Linux executables
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: runt-linux-executables
           path: ./executables
 
       - name: Download macOS executables
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: runt-macos-executables
           path: ./executables
 
       - name: Download macOS ARM64 notebook
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: nteract-macos-arm64
           path: ./notebook-macos-arm64
 
       - name: Download Windows x64 notebook
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: nteract-windows-x64
           path: ./notebook-windows-x64
 
       - name: Download Linux x64 notebook
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: nteract-linux-x64
           path: ./notebook-linux-x64
@@ -882,14 +882,14 @@ jobs:
           cat release-assets/latest.json
 
       - name: Download Python wheels
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: wheels-*
           path: ./wheels
           merge-multiple: true
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
 
       - name: Publish to PyPI
         continue-on-error: true


### PR DESCRIPTION
Node.js 20 actions are deprecated and will be forced to Node.js 24 starting June 2, 2026.

Updated:
- `actions/checkout` v4 → v6
- `actions/cache` v4 → v5
- `actions/upload-artifact` v4 → v7
- `actions/download-artifact` v4 → v8
- `actions/setup-node` v4 → v6
- `astral-sh/setup-uv` v5 → v7
- `actions/github-script` v7 → v8
- `actions/attest-build-provenance` v2 → v4

Not updated (no Node 24 major version available yet):
- `Swatinem/rust-cache@v2`
- `dsherret/rust-toolchain-file@v1`
- `PyO3/maturin-action@v1`
- `softprops/action-gh-release@v2`
- `tauri-apps/tauri-action@v0`
- `dorny/paths-filter@v3`
- `raven-actions/actionlint@v2`
- `denoland/setup-deno@v2`

_PR submitted by @rgbkrk's agent Quill, via Zed_