### PR TITLE
refactor(notebook): remove redundant optimistic updates from cell mutations

### DIFF
--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -274,20 +274,24 @@ export function useAutomergeNotebook() {
   const updateCellSource = useCallback(
     (cellId: string, source: string) => {
       const handle = handleRef.current;
-      if (!handle) return;
+      if (!handle || awaitingInitialSyncRef.current) return;
 
       // Mutate WASM (instant, local-first)
-      handle.update_source(cellId, source);
+      const updated = handle.update_source(cellId, source);
+      if (!updated) return;
 
-      // Re-read from WASM (single source of truth)
-      rematerializeCellsSync(handle);
+      // Fast-path: update only the affected cell in the store (avoids full
+      // rematerialization on every keystroke, which would cause typing lag)
+      updateNotebookCells((prev) =>
+        prev.map((c) => (c.id === cellId ? { ...c, source } : c)),
+      );
 
       // Sync to daemon (fire-and-forget)
       syncToRelay(handle);
 
       setDirty(true);
     },
-    [rematerializeCellsSync, syncToRelay],
+    [syncToRelay],
   );
 
   const clearCellOutputs = useCallback((cellId: string) => {
@@ -302,19 +306,39 @@ export function useAutomergeNotebook() {
 
   const addCell = useCallback(
     (cellType: "code" | "markdown", afterCellId?: string | null) => {
-      const cellId = crypto.randomUUID();
       const handle = handleRef.current;
 
-      if (handle) {
-        // Mutate WASM (instant, local-first)
-        handle.add_cell_after(cellId, cellType, afterCellId ?? null);
-
-        // Re-read from WASM (single source of truth)
-        rematerializeCellsSync(handle);
-
-        // Sync to daemon (fire-and-forget)
-        syncToRelay(handle);
+      // Don't allow adding cells while bootstrapping or if no handle
+      if (!handle || awaitingInitialSyncRef.current) {
+        // Return a placeholder cell without mutating state
+        const placeholderId = crypto.randomUUID();
+        return cellType === "code"
+          ? {
+              cell_type: "code" as const,
+              id: placeholderId,
+              source: "",
+              outputs: [],
+              execution_count: null,
+              metadata: {},
+            }
+          : {
+              cell_type: cellType,
+              id: placeholderId,
+              source: "",
+              metadata: {},
+            };
       }
+
+      const cellId = crypto.randomUUID();
+
+      // Mutate WASM (instant, local-first)
+      handle.add_cell_after(cellId, cellType, afterCellId ?? null);
+
+      // Re-read from WASM (single source of truth)
+      rematerializeCellsSync(handle);
+
+      // Sync to daemon (fire-and-forget)
+      syncToRelay(handle);
 
       setFocusedCellId(cellId);
       setDirty(true);
@@ -339,7 +363,7 @@ export function useAutomergeNotebook() {
   const moveCell = useCallback(
     (cellId: string, afterCellId?: string | null) => {
       const handle = handleRef.current;
-      if (!handle) return;
+      if (!handle || awaitingInitialSyncRef.current) return;
 
       // Mutate WASM (instant, local-first)
       handle.move_cell(cellId, afterCellId ?? null);
@@ -358,13 +382,14 @@ export function useAutomergeNotebook() {
   const deleteCell = useCallback(
     (cellId: string) => {
       const handle = handleRef.current;
-      if (!handle) return;
+      if (!handle || awaitingInitialSyncRef.current) return;
 
       // Guard: never delete the last cell
       if (handle.cell_count() <= 1) return;
 
       // Mutate WASM (instant, local-first)
-      handle.delete_cell(cellId);
+      const deleted = handle.delete_cell(cellId);
+      if (!deleted) return;
 
       // Re-read from WASM (single source of truth)
       rematerializeCellsSync(handle);

--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -9,8 +9,10 @@ import { logger } from "../lib/logger";
 import {
   type CellSnapshot,
   cellSnapshotsToNotebookCells,
+  cellSnapshotsToNotebookCellsSync,
 } from "../lib/materialize-cells";
 import {
+  getNotebookCellsSnapshot,
   replaceNotebookCells,
   resetNotebookCells,
   updateNotebookCells,
@@ -20,7 +22,7 @@ import {
   notifyMetadataChanged,
   setNotebookHandle,
 } from "../lib/notebook-metadata";
-import type { JupyterOutput, NotebookCell } from "../types";
+import type { JupyterOutput } from "../types";
 import init, { NotebookHandle } from "../wasm/runtimed-wasm/runtimed_wasm.js";
 
 // ---------------------------------------------------------------------------
@@ -104,6 +106,20 @@ export function useAutomergeNotebook() {
         logger.warn("[automerge-notebook] sync to relay failed:", e),
       );
     }
+  }, []);
+
+  /**
+   * Synchronously re-read cells from WASM after a local mutation.
+   * Uses cache-only output resolution (no blob fetches).
+   */
+  const rematerializeCellsSync = useCallback((handle: NotebookHandle) => {
+    const json = handle.get_cells_json();
+    const snapshots: CellSnapshot[] = JSON.parse(json);
+    const newCells = cellSnapshotsToNotebookCellsSync(
+      snapshots,
+      outputCacheRef.current,
+    );
+    replaceNotebookCells(newCells);
   }, []);
 
   // ── Bootstrap ──────────────────────────────────────────────────────
@@ -257,18 +273,21 @@ export function useAutomergeNotebook() {
 
   const updateCellSource = useCallback(
     (cellId: string, source: string) => {
-      // Optimistic store update (instant keystroke feedback).
-      updateNotebookCells((prev) =>
-        prev.map((c) => (c.id === cellId ? { ...c, source } : c)),
-      );
-      setDirty(true);
-
       const handle = handleRef.current;
       if (!handle) return;
+
+      // Mutate WASM (instant, local-first)
       handle.update_source(cellId, source);
+
+      // Re-read from WASM (single source of truth)
+      rematerializeCellsSync(handle);
+
+      // Sync to daemon (fire-and-forget)
       syncToRelay(handle);
+
+      setDirty(true);
     },
-    [syncToRelay],
+    [rematerializeCellsSync, syncToRelay],
   );
 
   const clearCellOutputs = useCallback((cellId: string) => {
@@ -284,85 +303,78 @@ export function useAutomergeNotebook() {
   const addCell = useCallback(
     (cellType: "code" | "markdown", afterCellId?: string | null) => {
       const cellId = crypto.randomUUID();
-      const newCell: NotebookCell =
-        cellType === "code"
-          ? {
-              cell_type: "code",
-              id: cellId,
-              source: "",
-              outputs: [],
-              execution_count: null,
-              metadata: {},
-            }
-          : { cell_type: "markdown", id: cellId, source: "", metadata: {} };
-
-      // Mutate the WASM doc first — this is the source of truth.
-      // Uses fractional indexing: afterCellId=null inserts at start.
       const handle = handleRef.current;
+
       if (handle) {
+        // Mutate WASM (instant, local-first)
         handle.add_cell_after(cellId, cellType, afterCellId ?? null);
+
+        // Re-read from WASM (single source of truth)
+        rematerializeCellsSync(handle);
+
+        // Sync to daemon (fire-and-forget)
         syncToRelay(handle);
       }
 
-      // Optimistic store update.
-      updateNotebookCells((prev) => {
-        if (!afterCellId) return [newCell, ...prev];
-        const i = prev.findIndex((c) => c.id === afterCellId);
-        if (i === -1) return [newCell, ...prev];
-        const next = [...prev];
-        next.splice(i + 1, 0, newCell);
-        return next;
-      });
-
       setFocusedCellId(cellId);
       setDirty(true);
-      return newCell;
+
+      // Return the cell from the store (derived from WASM)
+      const cell = getNotebookCellsSnapshot().find((c) => c.id === cellId);
+      return (
+        cell ?? {
+          cell_type: cellType,
+          id: cellId,
+          source: "",
+          ...(cellType === "code"
+            ? { outputs: [], execution_count: null }
+            : {}),
+          metadata: {},
+        }
+      );
     },
-    [syncToRelay],
+    [rematerializeCellsSync, syncToRelay],
   );
 
   const moveCell = useCallback(
     (cellId: string, afterCellId?: string | null) => {
       const handle = handleRef.current;
-      if (handle) {
-        handle.move_cell(cellId, afterCellId ?? null);
-        syncToRelay(handle);
-      }
+      if (!handle) return;
 
-      // Optimistic store update: remove cell from old position, insert after target.
-      updateNotebookCells((prev) => {
-        const cellIdx = prev.findIndex((c) => c.id === cellId);
-        if (cellIdx === -1) return prev;
-        const cell = prev[cellIdx];
-        const without = prev.filter((c) => c.id !== cellId);
-        if (!afterCellId) return [cell, ...without];
-        const targetIdx = without.findIndex((c) => c.id === afterCellId);
-        if (targetIdx === -1) return [cell, ...without];
-        const next = [...without];
-        next.splice(targetIdx + 1, 0, cell);
-        return next;
-      });
+      // Mutate WASM (instant, local-first)
+      handle.move_cell(cellId, afterCellId ?? null);
+
+      // Re-read from WASM (single source of truth)
+      rematerializeCellsSync(handle);
+
+      // Sync to daemon (fire-and-forget)
+      syncToRelay(handle);
 
       setDirty(true);
     },
-    [syncToRelay],
+    [rematerializeCellsSync, syncToRelay],
   );
 
   const deleteCell = useCallback(
     (cellId: string) => {
-      // Guard: never delete the last cell.
-      updateNotebookCells((prev) => {
-        if (prev.length <= 1) return prev;
-        return prev.filter((c) => c.id !== cellId);
-      });
-      setDirty(true);
-
       const handle = handleRef.current;
       if (!handle) return;
+
+      // Guard: never delete the last cell
+      if (handle.cell_count() <= 1) return;
+
+      // Mutate WASM (instant, local-first)
       handle.delete_cell(cellId);
+
+      // Re-read from WASM (single source of truth)
+      rematerializeCellsSync(handle);
+
+      // Sync to daemon (fire-and-forget)
       syncToRelay(handle);
+
+      setDirty(true);
     },
-    [syncToRelay],
+    [rematerializeCellsSync, syncToRelay],
   );
 
   // ── Save / Open / Clone ────────────────────────────────────────────

--- a/apps/notebook/src/lib/materialize-cells.ts
+++ b/apps/notebook/src/lib/materialize-cells.ts
@@ -111,6 +111,73 @@ export function mergeConsecutiveStreams(
 }
 
 /**
+ * Synchronous cell materialization for local mutations.
+ *
+ * Uses cache-only output resolution (no blob fetches). Safe to call when:
+ * - Adding new cells (outputs are empty)
+ * - Deleting cells (no new outputs)
+ * - Moving cells (no new outputs)
+ * - Updating source (outputs unchanged)
+ *
+ * For daemon sync with potentially new blob hashes, use cellSnapshotsToNotebookCells().
+ */
+export function cellSnapshotsToNotebookCellsSync(
+  snapshots: CellSnapshot[],
+  cache: Map<string, JupyterOutput>,
+): NotebookCell[] {
+  return snapshots.map((snap) => {
+    const executionCount =
+      snap.execution_count === "null"
+        ? null
+        : Number.parseInt(snap.execution_count, 10);
+
+    const metadata = snap.metadata ?? {};
+
+    if (snap.cell_type === "code") {
+      // Resolve outputs from cache only — skip blob fetches
+      const resolvedOutputs = snap.outputs
+        .map((outputStr) => {
+          const cached = cache.get(outputStr);
+          if (cached) return cached;
+
+          // If not a manifest hash, parse as JSON
+          if (!isManifestHash(outputStr)) {
+            try {
+              const output = JSON.parse(outputStr) as JupyterOutput;
+              cache.set(outputStr, output);
+              return output;
+            } catch {
+              return null;
+            }
+          }
+
+          // Manifest hash but not cached — return null (will resolve on daemon sync)
+          return null;
+        })
+        .filter((o): o is JupyterOutput => o !== null);
+
+      const outputs = mergeConsecutiveStreams(resolvedOutputs);
+
+      return {
+        id: snap.id,
+        cell_type: "code" as const,
+        source: snap.source,
+        execution_count: Number.isNaN(executionCount) ? null : executionCount,
+        outputs,
+        metadata,
+      };
+    }
+
+    return {
+      id: snap.id,
+      cell_type: snap.cell_type as "markdown" | "raw",
+      source: snap.source,
+      metadata,
+    };
+  });
+}
+
+/**
  * Convert CellSnapshots to NotebookCells, resolving manifest hashes.
  *
  * This is the primary materialization function shared between `useNotebook`

--- a/apps/notebook/src/lib/materialize-cells.ts
+++ b/apps/notebook/src/lib/materialize-cells.ts
@@ -152,6 +152,10 @@ export function cellSnapshotsToNotebookCellsSync(
           }
 
           // Manifest hash but not cached — return null (will resolve on daemon sync)
+          logger.debug(
+            "[materialize-cells] Manifest hash not in cache during sync materialization:",
+            outputStr.slice(0, 16),
+          );
           return null;
         })
         .filter((o): o is JupyterOutput => o !== null);


### PR DESCRIPTION
## Summary

Removes redundant optimistic updates from the frontend's cell mutation handlers. The notebook now relies on the local-first WASM Automerge document as the single source of truth for cell state, eliminating duplicate state management.

## Changes

- Added `cellSnapshotsToNotebookCellsSync()` for synchronous materialization of cells from WASM (uses cache-only output resolution, no blob fetches)
- Refactored `addCell`, `moveCell`, `deleteCell` to use WASM → rematerialize → sync pattern
- **Kept fast-path for `updateCellSource`**: Single-cell store update to avoid typing lag from full rematerialization on every keystroke
- Added bootstrap guards (`awaitingInitialSyncRef`) to prevent mutations during document sync
- Check WASM mutation return values before rematerializing to avoid race conditions

Output overlay functions (`clearCellOutputs`, `updateOutputByDisplayId`, `setExecutionCount`) remain unchanged as they provide instant feedback from daemon broadcasts.

## Verification

* [x] Add cell and verify it appears instantly
* [x] Delete cell and verify it's removed instantly  
* [x] Move cells and verify correct ordering
* [x] Type in a cell and verify no lag
* [x] Run a cell and verify outputs appear
* [x] Run all cells and verify outputs clear and reappear
* [x] Delete all but one cell and verify the last cell cannot be deleted

_PR submitted by @rgbkrk's agent, Quill_