### PR TITLE
fix(ci): disable webkit sandbox for E2E, increase pool size and test timeout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -455,7 +455,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.cargo/bin/tauri-driver
-          key: cargo-bin-tauri-driver-v0.1
+          key: cargo-bin-tauri-driver-${{ hashFiles('rust-toolchain.toml') }}
           restore-keys: |
             cargo-bin-tauri-driver-
 
@@ -511,6 +511,8 @@ jobs:
           RUNTIMED_WORKSPACE_PATH: ${{ github.workspace }}
           NO_AT_BRIDGE: 1
           LIBGL_ALWAYS_SOFTWARE: 1
+          WEBKIT_DISABLE_SANDBOX_THIS_IS_DANGEROUS: 1
+          WEBKIT_DISABLE_COMPOSITING_MODE: 1
           RUST_LOG: info,notebook=debug,runtimed=debug
 
       - name: Collect daemon logs
@@ -596,7 +598,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.cargo/bin/tauri-driver
-          key: cargo-bin-tauri-driver-v0.1
+          key: cargo-bin-tauri-driver-${{ hashFiles('rust-toolchain.toml') }}
           restore-keys: |
             cargo-bin-tauri-driver-
 
@@ -725,6 +727,8 @@ jobs:
           RUNTIMED_WORKSPACE_PATH: ${{ github.workspace }}
           NO_AT_BRIDGE: 1
           LIBGL_ALWAYS_SOFTWARE: 1
+          WEBKIT_DISABLE_SANDBOX_THIS_IS_DANGEROUS: 1
+          WEBKIT_DISABLE_COMPOSITING_MODE: 1
           RUST_LOG: info,notebook=debug,runtimed=debug
 
       - name: Collect daemon logs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -455,9 +455,9 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.cargo/bin/tauri-driver
-          key: cargo-bin-tauri-driver-${{ hashFiles('rust-toolchain.toml') }}
+          key: cargo-bin-tauri-driver-v1-${{ hashFiles('rust-toolchain.toml') }}
           restore-keys: |
-            cargo-bin-tauri-driver-
+            cargo-bin-tauri-driver-v1-
 
       - name: Install tauri-driver
         run: |
@@ -598,9 +598,9 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.cargo/bin/tauri-driver
-          key: cargo-bin-tauri-driver-${{ hashFiles('rust-toolchain.toml') }}
+          key: cargo-bin-tauri-driver-v1-${{ hashFiles('rust-toolchain.toml') }}
           restore-keys: |
-            cargo-bin-tauri-driver-
+            cargo-bin-tauri-driver-v1-
 
       - name: Install tauri-driver
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -470,6 +470,14 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
 
+      - name: Pre-seed settings to skip onboarding
+        run: |
+          # The app shows an onboarding window on fresh installs, which has no
+          # notebook webview for WebDriver to interact with. Pre-seed settings
+          # so the app opens a notebook directly.
+          mkdir -p ~/.config/nteract-nightly
+          echo '{"onboarding_completed": true}' > ~/.config/nteract-nightly/settings.json
+
       - name: Start E2E daemon
         run: |
           TARGET=$(ls target/release/binaries/ | grep runtimed | head -1)
@@ -634,6 +642,10 @@ jobs:
 
             echo "=== Running $name ==="
 
+            # Pre-seed settings to skip onboarding
+            mkdir -p ~/.config/nteract-nightly
+            echo '{"onboarding_completed": true}' > ~/.config/nteract-nightly/settings.json
+
             # Start daemon fresh for each test
             TARGET=$(ls target/release/binaries/ | grep runtimed | head -1)
             RUNTIMED_WORKSPACE_PATH="${GITHUB_WORKSPACE}" \
@@ -669,6 +681,10 @@ jobs:
             local name="$3"
 
             echo "=== Running $name ==="
+
+            # Pre-seed settings to skip onboarding
+            mkdir -p ~/.config/nteract-nightly
+            echo '{"onboarding_completed": true}' > ~/.config/nteract-nightly/settings.json
 
             # Start daemon with fixture directory as workspace path
             TARGET=$(ls target/release/binaries/ | grep runtimed | head -1)

--- a/python/runtimed/pyproject.toml
+++ b/python/runtimed/pyproject.toml
@@ -37,5 +37,6 @@ asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 # Global timeout catches truly stuck tests. Must be high enough
 # to cover the daemon_process fixture startup (up to 150s for socket +
-# pool warmup on first test in the module).
-timeout = 300
+# pool warmup on first test in the module) and survive at least one
+# 300s LaunchKernel wire timeout with room for retries.
+timeout = 600

--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -252,7 +252,7 @@ def daemon_process():
             "--blob-store-dir",
             str(blob_dir),
             "--uv-pool-size",
-            "3",  # Pool for sequential tests (need headroom for replenishment)
+            "6",  # Pool for sequential tests (need headroom for replenishment)
             "--conda-pool-size",
             "3",  # Need headroom for conda project file tests + inline fallback
         ]
@@ -2572,7 +2572,9 @@ class TestOpenNotebook:
         assert info.cell_count == 0
         assert info.notebook_id == session.notebook_id
 
-    def test_open_nonexistent_file_creates_notebook(self, daemon_process, monkeypatch, tmp_path):
+    def test_open_nonexistent_file_creates_notebook(
+        self, daemon_process, monkeypatch, tmp_path
+    ):
         """Opening missing file creates a new notebook at that path."""
         socket_path, _ = daemon_process
         if socket_path is not None:
@@ -2590,7 +2592,9 @@ class TestOpenNotebook:
         finally:
             session.close()
 
-    def test_open_nonexistent_file_auto_appends_ipynb(self, daemon_process, monkeypatch, tmp_path):
+    def test_open_nonexistent_file_auto_appends_ipynb(
+        self, daemon_process, monkeypatch, tmp_path
+    ):
         """Opening missing file without .ipynb extension auto-appends it."""
         socket_path, _ = daemon_process
         if socket_path is not None:


### PR DESCRIPTION
Two CI reliability fixes.

**E2E on Linux** — all tests fail with "no such window: unknown error" because Ubuntu 24.04 (`ubuntu-latest`) restricts unprivileged user namespaces via AppArmor, breaking WebKit2GTK's bubblewrap sandbox. The webview never loads.

- `WEBKIT_DISABLE_SANDBOX_THIS_IS_DANGEROUS=1` on both `e2e` and `e2e-fixtures` jobs
- `WEBKIT_DISABLE_COMPOSITING_MODE=1` for headless stability
- Bust stale `tauri-driver` cache (was pinned to `v0.1` forever, now keys on toolchain hash)

**Python integration tests** — `test_kernel_interrupt` hits a 300s `LaunchKernel` wire timeout, which exactly equals the pytest global timeout, leaving zero room for retries.

- UV pool size 3 → 6 (sequential sync tests exhaust pool faster than replenishment)
- pytest timeout 300s → 600s (survive one wire timeout with room for retry)

_PR submitted by @rgbkrk's agent Quill, via Zed_