### PR TITLE
docs: comprehensive audit — fix stale URLs, add move_cell to API docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,12 +215,14 @@ runt daemon status
 
 The notebook uses a local-first CRDT architecture. The frontend owns its own Automerge document via WASM, making cell mutations instant. Two Automerge peers participate:
 
-- **Frontend (WASM)** — `NotebookHandle` from `crates/runtimed-wasm`, loaded in the webview. Cell mutations (add, delete, edit source) execute locally in WASM. React state is derived from the WASM doc via `handle.get_cells_json()`. The WASM starts with an empty doc (`create_empty()`); the sync protocol delivers all state from the daemon.
+- **Frontend (WASM)** — `NotebookHandle` from `crates/runtimed-wasm`, loaded in the webview. Cell mutations (add, delete, move, edit source) execute locally in WASM. React state is derived from the WASM doc via `handle.get_cells_json()`. The WASM starts with an empty doc (`create_empty()`); the sync protocol delivers all state from the daemon.
 - **Daemon** — `NotebookDoc` from `crates/notebook-doc/src/lib.rs` (re-exported by `crates/runtimed/src/lib.rs`). Canonical doc for kernel execution, output writing, and persistence.
 
 The **Tauri relay** (`NotebookSyncClient` in `crates/runtimed/src/notebook_sync_client.rs`) is a transparent byte pipe — it forwards raw Automerge sync frames between the WASM and the daemon without merging or maintaining its own doc replica. The daemon's `peer_state` tracks the WASM peer directly through the pipe. A non-pipe "full peer" mode exists for `runtimed-py` (Python bindings), where the relay does maintain a local doc replica — but this is not the Tauri path.
 
-Mutation flow: React → WASM `handle.add_cell()` → `handle.generate_sync_message()` → `invoke("send_automerge_sync")` → relay pipe → daemon.
+Cells are stored in an Automerge Map keyed by cell ID, with a `position` field (fractional index hex string) for ordering. `move_cell` updates only the position field — no delete/re-insert. `get_cells()` returns cells sorted by position with cell ID as tiebreaker.
+
+Mutation flow: React → WASM `handle.add_cell_after()` → `handle.generate_sync_message()` → `invoke("send_automerge_sync")` → relay pipe → daemon.
 
 Incoming sync: daemon → relay pipe → `automerge:from-daemon` event → WASM `handle.receive_sync_message()` → `materializeCells()` → React state.
 

--- a/contributing/build-dependencies.md
+++ b/contributing/build-dependencies.md
@@ -6,7 +6,7 @@ each other. The key insight: the Notebook app (Tauri) bundles `runtimed` and
 step. Similarly, frontend assets must be built before their consuming Rust crates
 compile.
 
-> **Note:** PR [#209](https://github.com/runtimed/runt/pull/209) improves the
+> **Note:** PR [#209](https://github.com/nteract/desktop/pull/209) improves the
 > dev workflow so `cargo xtask dev` handles the sidecar binary build
 > automatically, but for release builds the dependency chain below still applies.
 

--- a/contributing/runtimed.md
+++ b/contributing/runtimed.md
@@ -212,6 +212,12 @@ print(result.outputs)  # [Output(stream, stdout: "hello\n")]
 # Get cell with outputs (includes historical outputs from other clients)
 cell = session.get_cell(result.cell_id)
 print(cell.outputs)  # [Output(stream, stdout: "hello\n")]
+
+# Move a cell (updates fractional index position)
+new_position = session.move_cell("cell-id", after_cell_id="other-cell-id")
+
+# Cell objects include position
+print(cell.position)  # fractional index string e.g. "80", "C0"
 ```
 
 ### Socket Path Configuration

--- a/crates/sidecar/README.md
+++ b/crates/sidecar/README.md
@@ -15,7 +15,7 @@ TODO: Include updated demo!
 
 Sidecar is not published to crates.io (it embeds UI assets at compile time that live outside the crate directory). Install via one of:
 
-**Pre-built binaries** from [GitHub Releases](https://github.com/runtimed/runtimed/releases):
+**Pre-built binaries** from [GitHub Releases](https://github.com/nteract/desktop/releases):
 
 ```bash
 # Download the latest release for your platform

--- a/docs/python-bindings.md
+++ b/docs/python-bindings.md
@@ -5,7 +5,7 @@ The `runtimed` Python package provides programmatic access to the notebook daemo
 ## Installation
 
 ```bash
-# From PyPI (when published)
+# From PyPI
 pip install runtimed
 
 # From source
@@ -117,6 +117,9 @@ cells = session.get_cells()
 
 # Delete a cell
 session.delete_cell(cell_id)
+
+# Move a cell (returns new fractional position string)
+new_position = session.move_cell(cell_id, after_cell_id="other-cell-id")
 ```
 
 ### Saving Notebooks
@@ -256,6 +259,9 @@ cells = await session.get_cells()
 
 # Delete a cell
 await session.delete_cell(cell_id)
+
+# Move a cell
+new_position = await session.move_cell(cell_id, after_cell_id="other-cell-id")
 ```
 
 ### Saving Notebooks
@@ -414,6 +420,7 @@ cell = session.get_cell(cell_id)
 
 cell.id              # Cell identifier
 cell.cell_type       # "code", "markdown", or "raw"
+cell.position        # Fractional index string for ordering
 cell.source          # Cell source content
 cell.execution_count # Execution count if executed
 ```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -178,7 +178,7 @@ This creates a symlink to `/usr/local/bin/runt`, so you can run `runt doctor` di
 If you're still stuck:
 
 1. Check the logs for error messages: `runt daemon logs -n 50`
-2. [Open an issue on GitHub](https://github.com/nteract/nteract/issues) with:
+2. [Open an issue on GitHub](https://github.com/nteract/desktop/issues) with:
    - The output of `runt doctor`
    - Any relevant log messages
    - Your macOS/Linux version

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -171,6 +171,6 @@ Instead of `jupyterlab-sidecar`, use regular notebook outputs. Output appears in
 
 ## See Also
 
-- [GitHub Issue #44](https://github.com/runtimed/runt/issues/44) — Widget compatibility testing matrix
+- [GitHub Issue #44](https://github.com/nteract/desktop/issues/44) — Widget compatibility testing matrix
 - [anywidget documentation](https://anywidget.dev/)
 - `src/components/widgets/controls/` — Built-in widget implementations

--- a/python/runtimed/README.md
+++ b/python/runtimed/README.md
@@ -65,6 +65,9 @@ print(result.error)
 # Save the notebook to disk
 path = session.save()                       # Save to current path
 path = session.save(path="/tmp/copy.ipynb")  # Save-as
+
+# Reorder cells
+new_position = session.move_cell(cell_id, after_cell_id="other-id")
 ```
 
 ## AsyncSession API
@@ -81,6 +84,9 @@ async with runtimed.AsyncSession(notebook_id="my-notebook") as session:
     # Save the notebook to disk
     path = await session.save()                       # Save to current path
     path = await session.save(path="/tmp/copy.ipynb")  # Save-as
+
+    # Reorder cells
+    new_position = await session.move_cell(cell_id, after_cell_id="other-id")
 ```
 
 ## DaemonClient API


### PR DESCRIPTION
Full audit of all 32 markdown files in the repo. Fixes stale URLs from the org rename and adds `move_cell`/`position` documentation to Python API docs.

**URL fixes (4 files):**
- `docs/troubleshooting.md` — `nteract/nteract` → `nteract/desktop` issues link
- `docs/widgets.md` — `runtimed/runt` → `nteract/desktop` issue link
- `contributing/build-dependencies.md` — `runtimed/runt` → `nteract/desktop` PR link
- `crates/sidecar/README.md` — `runtimed/runtimed` → `nteract/desktop` releases link

**API docs (4 files):**
- `docs/python-bindings.md` — `Cell.position` field, `move_cell` on Session and AsyncSession, removed stale "(when published)" comment
- `python/runtimed/README.md` — `move_cell` in Session and AsyncSession examples
- `contributing/runtimed.md` — `move_cell` and `cell.position` in Python bindings section
- `AGENTS.md` — fractional indexing description, `move_cell` in mutation list, `add_cell_after` in mutation flow

**24 files confirmed clean** — no stale versions, no `--prerelease allow`, no old schema references.

_PR submitted by @rgbkrk's agent Quill, via Zed_