### PR TITLE
fix(runtimed-py): query kernel status on connect

### DIFF
--- a/crates/runtimed-py/src/async_session.rs
+++ b/crates/runtimed-py/src/async_session.rs
@@ -192,8 +192,8 @@ impl AsyncSession {
             let connection_info = NotebookConnectionInfo::from_protocol(info);
             let (blob_base_url, blob_store_path) = get_blob_paths_async(&socket_path).await;
 
-            let state = AsyncSessionState {
-                handle: Some(handle),
+            let mut state = AsyncSessionState {
+                handle: Some(handle.clone()),
                 sync_rx: Some(sync_rx),
                 broadcast_rx: Some(broadcast_rx),
                 kernel_started: false,
@@ -203,6 +203,9 @@ impl AsyncSession {
                 connection_info: Some(connection_info),
                 notebook_path: Some(path),
             };
+
+            // Sync kernel state (handles connecting to already-running kernels)
+            sync_kernel_state_from_daemon(&handle, &mut state).await;
 
             Ok(AsyncSession {
                 state: Arc::new(Mutex::new(state)),
@@ -272,8 +275,8 @@ impl AsyncSession {
             let connection_info = NotebookConnectionInfo::from_protocol(info);
             let (blob_base_url, blob_store_path) = get_blob_paths_async(&socket_path).await;
 
-            let state = AsyncSessionState {
-                handle: Some(handle),
+            let mut state = AsyncSessionState {
+                handle: Some(handle.clone()),
                 sync_rx: Some(sync_rx),
                 broadcast_rx: Some(broadcast_rx),
                 kernel_started: false,
@@ -283,6 +286,9 @@ impl AsyncSession {
                 connection_info: Some(connection_info),
                 notebook_path: working_dir_str,
             };
+
+            // Sync kernel state (handles connecting to already-running kernels)
+            sync_kernel_state_from_daemon(&handle, &mut state).await;
 
             Ok(AsyncSession {
                 state: Arc::new(Mutex::new(state)),

--- a/crates/runtimed-py/src/async_session.rs
+++ b/crates/runtimed-py/src/async_session.rs
@@ -17,6 +17,7 @@ use runtimed::protocol::{NotebookBroadcast, NotebookRequest, NotebookResponse};
 use crate::daemon_paths::{get_blob_paths_async, get_socket_path};
 use crate::error::to_py_err;
 use crate::event_stream::ExecutionEventStream;
+use crate::kernel_state::{query_kernel_status, sync_kernel_state_from_daemon, KernelState};
 use crate::output::{Cell, ExecutionResult, NotebookConnectionInfo, Output, SyncEnvironmentResult};
 use crate::output_resolver;
 use crate::subscription::EventSubscription;
@@ -73,6 +74,16 @@ impl AsyncSessionState {
             connection_info: None,
             notebook_path: None,
         }
+    }
+}
+
+impl KernelState for AsyncSessionState {
+    fn set_kernel_started(&mut self, started: bool) {
+        self.kernel_started = started;
+    }
+
+    fn set_env_source(&mut self, source: Option<String>) {
+        self.env_source = source;
     }
 }
 
@@ -311,23 +322,31 @@ impl AsyncSession {
             state.blob_base_url = blob_base_url;
             state.blob_store_path = blob_store_path;
 
-            // Query daemon for current kernel state (handles connecting to already-running kernels)
-            if let Some(ref handle) = state.handle {
-                if let Ok(response) = handle.send_request(NotebookRequest::GetKernelInfo {}).await {
-                    if let NotebookResponse::KernelInfo {
-                        env_source, status, ..
-                    } = response
-                    {
-                        let is_running = matches!(status.as_str(), "idle" | "busy" | "starting");
-                        state.kernel_started = is_running;
-                        if is_running {
-                            state.env_source = env_source;
-                        }
-                    }
-                }
+            // Sync kernel state from daemon (handles connecting to already-running kernels)
+            if let Some(handle) = state.handle.clone() {
+                sync_kernel_state_from_daemon(&handle, &mut *state).await;
             }
 
             Ok(())
+        })
+    }
+
+    /// Get the current kernel status string.
+    ///
+    /// Queries the daemon for real-time kernel status. Returns the status
+    /// string ("idle", "busy", "starting", "not_started", etc.) or None
+    /// if the query fails or no kernel is running.
+    ///
+    /// Returns a coroutine that resolves to Optional[str].
+    fn kernel_status<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let state = Arc::clone(&self.state);
+        future_into_py(py, async move {
+            let state = state.lock().await;
+            if let Some(ref handle) = state.handle {
+                Ok(query_kernel_status(handle).await)
+            } else {
+                Ok(None)
+            }
         })
     }
 

--- a/crates/runtimed-py/src/async_session.rs
+++ b/crates/runtimed-py/src/async_session.rs
@@ -311,6 +311,22 @@ impl AsyncSession {
             state.blob_base_url = blob_base_url;
             state.blob_store_path = blob_store_path;
 
+            // Query daemon for current kernel state (handles connecting to already-running kernels)
+            if let Some(ref handle) = state.handle {
+                if let Ok(response) = handle.send_request(NotebookRequest::GetKernelInfo {}).await {
+                    if let NotebookResponse::KernelInfo {
+                        env_source, status, ..
+                    } = response
+                    {
+                        let is_running = matches!(status.as_str(), "idle" | "busy" | "starting");
+                        state.kernel_started = is_running;
+                        if is_running {
+                            state.env_source = env_source;
+                        }
+                    }
+                }
+            }
+
             Ok(())
         })
     }

--- a/crates/runtimed-py/src/kernel_state.rs
+++ b/crates/runtimed-py/src/kernel_state.rs
@@ -1,0 +1,49 @@
+//! Shared kernel state management for Session and AsyncSession.
+//!
+//! Provides a trait and helper function to sync kernel state from the daemon,
+//! avoiding code duplication between sync and async session implementations.
+
+use runtimed::notebook_sync_client::NotebookSyncHandle;
+use runtimed::protocol::{NotebookRequest, NotebookResponse};
+
+/// Trait for session state types that track kernel status.
+///
+/// Both `SessionState` and `AsyncSessionState` implement this trait,
+/// allowing shared helper functions to update kernel state.
+pub trait KernelState {
+    fn set_kernel_started(&mut self, started: bool);
+    fn set_env_source(&mut self, source: Option<String>);
+}
+
+/// Sync kernel state from daemon after connecting.
+///
+/// Queries `GetKernelInfo` to check if a kernel is already running
+/// (e.g., started by the desktop app) and updates local state accordingly.
+pub async fn sync_kernel_state_from_daemon<S: KernelState>(
+    handle: &NotebookSyncHandle,
+    state: &mut S,
+) {
+    if let Ok(NotebookResponse::KernelInfo {
+        env_source, status, ..
+    }) = handle.send_request(NotebookRequest::GetKernelInfo {}).await
+    {
+        let is_running = matches!(status.as_str(), "idle" | "busy" | "starting");
+        state.set_kernel_started(is_running);
+        if is_running {
+            state.set_env_source(env_source);
+        }
+    }
+}
+
+/// Query the daemon for current kernel status string.
+///
+/// Returns the status string ("idle", "busy", "starting", "not_started", etc.)
+/// or None if the query fails.
+pub async fn query_kernel_status(handle: &NotebookSyncHandle) -> Option<String> {
+    if let Ok(NotebookResponse::KernelInfo { status, .. }) =
+        handle.send_request(NotebookRequest::GetKernelInfo {}).await
+    {
+        return Some(status);
+    }
+    None
+}

--- a/crates/runtimed-py/src/kernel_state.rs
+++ b/crates/runtimed-py/src/kernel_state.rs
@@ -27,10 +27,14 @@ pub async fn sync_kernel_state_from_daemon<S: KernelState>(
         env_source, status, ..
     }) = handle.send_request(NotebookRequest::GetKernelInfo {}).await
     {
-        let is_running = matches!(status.as_str(), "idle" | "busy" | "starting");
+        // Any status other than "not_started" means a kernel exists
+        let is_running = status.as_str() != "not_started";
         state.set_kernel_started(is_running);
         if is_running {
             state.set_env_source(env_source);
+        } else {
+            // Clear stale env_source when kernel not running
+            state.set_env_source(None);
         }
     }
 }

--- a/crates/runtimed-py/src/lib.rs
+++ b/crates/runtimed-py/src/lib.rs
@@ -16,6 +16,7 @@ mod client;
 mod daemon_paths;
 mod error;
 mod event_stream;
+mod kernel_state;
 mod output;
 mod output_resolver;
 mod session;

--- a/crates/runtimed-py/src/session.rs
+++ b/crates/runtimed-py/src/session.rs
@@ -16,6 +16,7 @@ use runtimed::protocol::{NotebookBroadcast, NotebookRequest, NotebookResponse};
 use crate::daemon_paths::{get_blob_paths_sync, get_socket_path};
 use crate::error::to_py_err;
 use crate::event_stream::ExecutionEventIterator;
+use crate::kernel_state::{query_kernel_status, sync_kernel_state_from_daemon, KernelState};
 use crate::output::{Cell, ExecutionResult, NotebookConnectionInfo, Output, SyncEnvironmentResult};
 use crate::output_resolver;
 use crate::subscription::EventIteratorSubscription;
@@ -72,6 +73,16 @@ impl SessionState {
             connection_info: None,
             notebook_path: None,
         }
+    }
+}
+
+impl KernelState for SessionState {
+    fn set_kernel_started(&mut self, started: bool) {
+        self.kernel_started = started;
+    }
+
+    fn set_env_source(&mut self, source: Option<String>) {
+        self.env_source = source;
     }
 }
 
@@ -299,23 +310,29 @@ impl Session {
             state.blob_base_url = blob_base_url;
             state.blob_store_path = blob_store_path;
 
-            // Query daemon for current kernel state (handles connecting to already-running kernels)
-            if let Some(ref handle) = state.handle {
-                if let Ok(response) = handle.send_request(NotebookRequest::GetKernelInfo {}).await {
-                    if let NotebookResponse::KernelInfo {
-                        env_source, status, ..
-                    } = response
-                    {
-                        let is_running = matches!(status.as_str(), "idle" | "busy" | "starting");
-                        state.kernel_started = is_running;
-                        if is_running {
-                            state.env_source = env_source;
-                        }
-                    }
-                }
+            // Sync kernel state from daemon (handles connecting to already-running kernels)
+            if let Some(handle) = state.handle.clone() {
+                sync_kernel_state_from_daemon(&handle, &mut *state).await;
             }
 
             Ok(())
+        })
+    }
+
+    /// Get the current kernel status string.
+    ///
+    /// Queries the daemon for real-time kernel status. Returns the status
+    /// string ("idle", "busy", "starting", "not_started", etc.) or None
+    /// if the query fails or no kernel is running.
+    #[getter]
+    fn kernel_status(&self) -> Option<String> {
+        self.runtime.block_on(async {
+            let state = self.state.lock().await;
+            if let Some(ref handle) = state.handle {
+                query_kernel_status(handle).await
+            } else {
+                None
+            }
         })
     }
 

--- a/crates/runtimed-py/src/session.rs
+++ b/crates/runtimed-py/src/session.rs
@@ -181,8 +181,8 @@ impl Session {
             let connection_info = NotebookConnectionInfo::from_protocol(info);
             let (blob_base_url, blob_store_path) = get_blob_paths_sync(&socket_path);
 
-            let state = SessionState {
-                handle: Some(handle),
+            let mut state = SessionState {
+                handle: Some(handle.clone()),
                 sync_rx: Some(sync_rx),
                 broadcast_rx: Some(broadcast_rx),
                 kernel_started: false,
@@ -192,6 +192,9 @@ impl Session {
                 connection_info: Some(connection_info),
                 notebook_path: Some(path_str),
             };
+
+            // Sync kernel state (handles connecting to already-running kernels)
+            sync_kernel_state_from_daemon(&handle, &mut state).await;
 
             Ok((notebook_id, state))
         })?;
@@ -262,8 +265,8 @@ impl Session {
             let connection_info = NotebookConnectionInfo::from_protocol(info);
             let (blob_base_url, blob_store_path) = get_blob_paths_sync(&socket_path);
 
-            let state = SessionState {
-                handle: Some(handle),
+            let mut state = SessionState {
+                handle: Some(handle.clone()),
                 sync_rx: Some(sync_rx),
                 broadcast_rx: Some(broadcast_rx),
                 kernel_started: false,
@@ -273,6 +276,9 @@ impl Session {
                 connection_info: Some(connection_info),
                 notebook_path: working_dir_str,
             };
+
+            // Sync kernel state (handles connecting to already-running kernels)
+            sync_kernel_state_from_daemon(&handle, &mut state).await;
 
             Ok((notebook_id, state))
         })?;

--- a/crates/runtimed-py/src/session.rs
+++ b/crates/runtimed-py/src/session.rs
@@ -299,6 +299,22 @@ impl Session {
             state.blob_base_url = blob_base_url;
             state.blob_store_path = blob_store_path;
 
+            // Query daemon for current kernel state (handles connecting to already-running kernels)
+            if let Some(ref handle) = state.handle {
+                if let Ok(response) = handle.send_request(NotebookRequest::GetKernelInfo {}).await {
+                    if let NotebookResponse::KernelInfo {
+                        env_source, status, ..
+                    } = response
+                    {
+                        let is_running = matches!(status.as_str(), "idle" | "busy" | "starting");
+                        state.kernel_started = is_running;
+                        if is_running {
+                            state.env_source = env_source;
+                        }
+                    }
+                }
+            }
+
             Ok(())
         })
     }


### PR DESCRIPTION
## Summary

Fixes MCP kernel status mismatch when connecting to notebooks that already have running kernels. The AsyncSession and Session objects now query GetKernelInfo after establishing connection, ensuring they report accurate kernel state regardless of when/how the kernel was started.

## Problem

When connecting to a notebook that already has a running kernel (e.g., started by the desktop app), MCP clients would see `kernel_started: false` because the Python session objects never queried the daemon for current state.

## Solution

Both AsyncSession and Session now call `NotebookRequest::GetKernelInfo` after connecting and update their local `kernel_started` and `env_source` fields from the response. This ensures they have current kernel state on connect.

## Verification

* [ ] Connect via nteract MCP to a notebook with a running kernel — verify `kernel_started()` returns true
* [ ] Connect to a notebook with no kernel — verify `kernel_started()` returns false

_PR submitted by @rgbkrk's agent, Quill_