### PR TITLE
feat(python): add nteract MCP server package to monorepo

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,7 +1,7 @@
-# Build and publish the runtimed Python package.
+# Build and publish Python packages (runtimed + nteract).
 #
-# The package provides PyO3 bindings for the runtimed daemon client,
-# and bundles the runtimed daemon binary.
+# runtimed: PyO3 bindings for the daemon client, bundles the runtimed binary.
+# nteract: Pure-Python MCP server that depends on runtimed.
 #
 # To publish: push a tag matching `python-v*` (e.g. `python-v0.1.0`).
 
@@ -14,6 +14,7 @@ on:
   pull_request:
     paths:
       - "python/runtimed/**"
+      - "python/nteract/**"
       - "crates/runtimed-py/**"
       - "crates/runtimed/**"
       - ".github/workflows/python-package.yml"
@@ -30,6 +31,48 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  nteract-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        run: uv sync --dev
+        working-directory: python/nteract
+
+      - name: Ruff check
+        run: uv run ruff check src/
+        working-directory: python/nteract
+
+      - name: Ruff format check
+        run: uv run ruff format --check src/
+        working-directory: python/nteract
+
+  nteract-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        run: uv sync --dev
+        working-directory: python/nteract
+
+      - name: Run smoke tests
+        run: uv run pytest --ignore=tests/test_mcp_integration.py
+        working-directory: python/nteract
+
   macos:
     runs-on: ${{ matrix.platform.runner }}
     strategy:
@@ -107,11 +150,48 @@ jobs:
           name: wheels-linux-x86_64
           path: python/runtimed/dist
 
+  nteract-build:
+    name: Build nteract sdist + wheel
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Set dev version
+        run: |
+          CURRENT_VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          MAJOR_MINOR=$(echo "$CURRENT_VERSION" | sed 's/\.[0-9]*$//')
+          PATCH=$(echo "$CURRENT_VERSION" | grep -o '[0-9]*$')
+          NEXT_PATCH=$((PATCH + 1))
+          TIMESTAMP=$(date -u +%Y%m%d%H%M)
+          DEV_VERSION="${MAJOR_MINOR}.${NEXT_PATCH}a${TIMESTAMP}"
+          echo "Setting nteract version to: ${DEV_VERSION}"
+          sed -i "s/^version = .*/version = \"${DEV_VERSION}\"/" pyproject.toml
+          # Pin runtimed dep to the same prerelease series
+          sed -i "s/runtimed>=2.0.1a0/runtimed>=${DEV_VERSION}/" pyproject.toml
+        working-directory: python/nteract
+
+      - name: Build
+        run: uv build
+        working-directory: python/nteract
+
+      - name: Upload dist
+        uses: actions/upload-artifact@v7
+        with:
+          name: nteract-dist
+          path: python/nteract/dist
+
   release:
     name: Release
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
-    needs: [macos, linux]
+    needs: [macos, linux, nteract-build]
     permissions:
       id-token: write
       contents: write
@@ -127,13 +207,18 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
 
-      - name: Publish to PyPI
+      - name: Publish runtimed to PyPI
         run: uv publish --trusted-publishing always --check-url https://pypi.org/simple/runtimed/ 'wheels-*/*'
+
+      - name: Publish nteract to PyPI
+        run: uv publish --trusted-publishing always --check-url https://pypi.org/simple/nteract/ 'nteract-dist/*'
 
       - name: Upload to GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref_name }}
-          files: "wheels-*/*"
+          files: |
+            wheels-*/*
+            nteract-dist/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -643,6 +643,44 @@ jobs:
           name: nteract-linux-x64
           path: artifacts/
 
+  build-nteract-package:
+    name: Build nteract Package
+    runs-on: ubuntu-latest
+    needs: compute-version
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Set dev version
+        if: inputs.github_release_prerelease
+        run: |
+          CURRENT_VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          MAJOR_MINOR=$(echo "$CURRENT_VERSION" | sed 's/\.[0-9]*$//')
+          PATCH=$(echo "$CURRENT_VERSION" | grep -o '[0-9]*$')
+          NEXT_PATCH=$((PATCH + 1))
+          TIMESTAMP="${{ needs.compute-version.outputs.timestamp }}"
+          DEV_VERSION="${MAJOR_MINOR}.${NEXT_PATCH}a${TIMESTAMP}"
+          echo "Setting nteract version to: ${DEV_VERSION}"
+          sed -i "s/^version = .*/version = \"${DEV_VERSION}\"/" pyproject.toml
+          # Pin runtimed dep to the same prerelease timestamp
+          sed -i "s/runtimed>=2.0.1a0/runtimed>=${DEV_VERSION}/" pyproject.toml
+        working-directory: python/nteract
+
+      - name: Build sdist + wheel
+        run: uv build
+        working-directory: python/nteract
+
+      - name: Upload dist
+        uses: actions/upload-artifact@v7
+        with:
+          name: nteract-dist
+          path: python/nteract/dist
+
   build-python-wheels:
     name: Build Python Wheels (${{ matrix.platform.target }})
     runs-on: ${{ matrix.platform.runner }}
@@ -741,6 +779,7 @@ jobs:
         build-notebook-windows-x64,
         build-notebook-linux-x64,
         build-python-wheels,
+        build-nteract-package,
       ]
     steps:
       - name: Checkout
@@ -888,12 +927,22 @@ jobs:
           path: ./wheels
           merge-multiple: true
 
+      - name: Download nteract dist
+        uses: actions/download-artifact@v8
+        with:
+          name: nteract-dist
+          path: ./nteract-dist
+
       - name: Install uv
         uses: astral-sh/setup-uv@v7
 
-      - name: Publish to PyPI
+      - name: Publish runtimed to PyPI
         continue-on-error: true
         run: uv publish --trusted-publishing always ./wheels/*.whl
+
+      - name: Publish nteract to PyPI
+        continue-on-error: true
+        run: uv publish --trusted-publishing always ./nteract-dist/*
 
       - name: Generate release body
         env:
@@ -968,6 +1017,7 @@ jobs:
             ./release-assets/nteract-${{ inputs.version_suffix }}-windows-x64.exe.sig
             ./release-assets/latest.json
             ./wheels/*.whl
+            ./nteract-dist/*
 
       - name: Update ${{ inputs.updater_channel_tag }} updater channel
         env:

--- a/python/nteract/.gitignore
+++ b/python/nteract/.gitignore
@@ -1,0 +1,22 @@
+# Python
+__pycache__/
+*.py[cod]
+*.egg-info/
+dist/
+build/
+
+# Virtual environments
+.venv/
+
+# Caches
+.ruff_cache/
+.pytest_cache/
+.mypy_cache/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+
+# Local Claude settings
+.claude/settings.local.json

--- a/python/nteract/CHANGELOG.md
+++ b/python/nteract/CHANGELOG.md
@@ -1,0 +1,8 @@
+## Changelog
+
+### v0.10.1
+- Update dependency versions.
+- Fixed bugs regarding data serialization.
+- Performance improvements related to the rendering.
+
+For a complete list of changes, please check the detailed changelog.

--- a/python/nteract/README.md
+++ b/python/nteract/README.md
@@ -1,0 +1,192 @@
+# nteract/nteract
+
+## What's going on?
+
+If you're here looking for the Electron-based nteract desktop app, you can view the source [in this repo](https://github.com/nteract/archived-desktop-app). **That desktop app is not actively maintained.**
+
+We're actively developing the spritual successor to the nteract desktop app in the [nteract/desktop repo](https://github.com/nteract/desktop).
+
+### The New Desktop App
+
+We're actively developing the spritual successor to the nteract desktop app in the [nteract/desktop repo](https://github.com/nteract/desktop).
+
+The new app is a native desktop app with instant startup and intelligent environment management.
+
+<img width="1100" height="750" alt="Screenshot 2026-02-27 at 8 33 13 AM" src="https://github.com/user-attachments/assets/06be5ab5-9390-43a9-993a-ccb07ec9139d" />
+
+## Bringing Agents in the Loop
+
+We're in the prelimiary stages of hooking up the realtime system from nteract/desktop to any agent of your choice. Collaborate with agents in notebooks, render interactive elements, and explore data together.
+
+### Quick Start
+
+#### Claude Code
+
+```bash
+# Stable desktop 1.4.x / stable MCP
+claude mcp add nteract -- uvx nteract
+```
+
+For desktop nightly / the upcoming 2.x transition, use the prerelease MCP package and nightly socket:
+
+```bash
+claude mcp add nteract-nightly -- env RUNTIMED_SOCKET_PATH="$HOME/Library/Caches/runt-nightly/runtimed.sock" uvx --prerelease allow nteract
+```
+
+That's it. Now Claude can execute Python code, create visualizations, and work with your data.
+
+## What is this?
+
+nteract is an MCP (Model Context Protocol) server that connects AI assistants like Claude to Jupyter notebooks. It enables:
+
+- **Code execution**: Run Python in a persistent kernel
+- **Real-time collaboration**: Watch the AI work in the nteract desktop app
+- **Shared state**: Multiple agents can work on the same notebook
+- **Environment management**: Automatic Python environment setup
+
+## Example
+
+Ask Claude:
+
+> "Help me visualize my log data"
+
+Claude will:
+1. Connect to a notebook session
+2. Write and execute code
+3. Generate visualizations
+4. Show you the results
+
+You can open the same notebook in the [nteract desktop app](https://github.com/nteract/desktop) to see changes in real-time and collaborate with the AI.
+
+## Installation
+
+Stable line for desktop `1.4.x`:
+
+```bash
+uvx nteract
+```
+
+Prerelease line for desktop nightly / 2.x transition:
+
+```bash
+uvx --prerelease allow nteract
+```
+
+## Claude Code Setup
+
+Add stable `nteract` as an MCP server:
+
+```bash
+claude mcp add nteract -- uvx nteract
+```
+
+Or manually add to your Claude configuration:
+
+```json
+{
+  "mcpServers": {
+    "nteract": {
+      "command": "uvx",
+      "args": ["nteract"]
+    }
+  }
+}
+```
+
+### Using with Nightly
+
+If you're using nteract desktop nightly builds, point at the nightly socket and allow prereleases:
+
+```bash
+claude mcp add nteract -- env RUNTIMED_SOCKET_PATH="$HOME/Library/Caches/runt-nightly/runtimed.sock" uvx --prerelease allow nteract
+```
+
+### Release Tracks
+
+- `main` publishes prerelease `nteract` builds for the 2.x transition and tracks `runtimed 2.x` prereleases.
+- `release/1.9.x` is the stable maintenance line for desktop `1.4.x` and stays on `runtimed 1.9.0`.
+
+## Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `connect_notebook` | Connect to a notebook by ID |
+| `open_notebook` | Open an existing .ipynb file |
+| `create_notebook` | Create a new notebook |
+| `save_notebook` | Save notebook to disk as .ipynb file |
+| `create_cell` | Add a cell to the notebook (use `and_run=True` to execute) |
+| `execute_cell` | Run a specific cell (returns partial results after timeout) |
+| `run_all_cells` | Queue all code cells for execution |
+| `append_source` | Stream tokens into a cell (ideal for LLM output) |
+| `get_cell` | Get a cell by ID with outputs |
+| `get_all_cells` | View all cells in the notebook |
+| `set_cell_source` | Update a cell's source code |
+| `move_cell` | Reorder a cell within the notebook |
+| `clear_outputs` | Clear a cell's outputs |
+| `delete_cell` | Remove a cell from the notebook |
+| `start_kernel` | Start a Python kernel |
+| `restart_kernel` | Restart kernel with updated dependencies |
+| `get_kernel_status` | Check kernel state |
+| `get_queue_state` | See what's executing and what's queued |
+| `complete_code` | Get code completions from the kernel |
+| `get_history` | Search kernel execution history |
+| `add_dependency` | Add a Python package dependency |
+| `remove_dependency` | Remove a dependency |
+| `get_dependencies` | List current dependencies |
+| `sync_environment` | Hot-install new deps without restart |
+
+## Architecture
+
+```
+┌─────────────┐     ┌─────────────┐     ┌─────────────┐
+│   Claude    │────▶│   nteract   │────▶│   runtimed  │
+│  (or other  │     │ MCP Server  │     │   daemon    │
+│     AI)     │     │             │     │             │
+└─────────────┘     └─────────────┘     └──────┬──────┘
+                                               │
+                    ┌─────────────┐             │
+                    │   nteract   │◀────────────┘
+                    │ Desktop App │  (real-time sync)
+                    └─────────────┘
+```
+
+- **nteract** (this package): MCP server for AI assistants
+- **runtimed**: Low-level daemon and Python bindings ([docs](https://github.com/nteract/desktop))
+- **nteract desktop**: Native app for humans to collaborate with AI
+
+## Real-time Collaboration
+
+The magic of nteract is that AI and humans share the same notebook:
+
+1. AI connects via MCP and runs code
+2. Human opens the same notebook in nteract desktop
+3. Changes sync instantly via CRDT
+4. Both see the same kernel state
+
+This enables workflows like:
+- AI does initial analysis, human refines
+- Human writes code, AI debugs errors
+- Multiple AI agents collaborate on complex tasks
+
+## Development
+
+```bash
+# Clone
+git clone https://github.com/nteract/nteract
+cd nteract
+
+# Install dependencies
+uv sync
+
+# Run tests
+uv run pytest
+```
+
+## Related Projects
+
+- [nteract/desktop](https://github.com/nteract/desktop) - Native desktop app
+- [runtimed on PyPI](https://pypi.org/project/runtimed/) - Low-level Python bindings
+
+## License
+
+BSD-3-Clause

--- a/python/nteract/pyproject.toml
+++ b/python/nteract/pyproject.toml
@@ -1,0 +1,59 @@
+[project]
+name = "nteract"
+version = "2.0.0"
+description = "Bring AI to Jupyter notebooks. MCP server for Claude, ChatGPT, Gemini, OpenCode and any agent."
+readme = "README.md"
+license = "BSD-3-Clause"
+authors = [
+    { name = "Kyle Kelley", email = "rgbkrk@gmail.com" }
+]
+requires-python = ">=3.10"
+dependencies = [
+    "mcp>=1.26.0",
+    "httpx>=0.27.0,<1.0",
+    "runtimed>=2.0.1a0,<3.0",
+]
+
+[project.scripts]
+nteract = "nteract._mcp_server:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/nteract"]
+
+[dependency-groups]
+dev = [
+    "anyio>=4.0",
+    "pytest>=8.0",
+    "pytest-asyncio>=0.23",
+    "ruff>=0.9",
+    "ty>=0.0.1a7",
+]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
+
+[tool.ruff]
+line-length = 100
+target-version = "py310"
+
+[tool.ruff.lint]
+select = [
+    "E",      # pycodestyle errors
+    "W",      # pycodestyle warnings
+    "F",      # pyflakes
+    "I",      # isort
+    "UP",     # pyupgrade
+    "B",      # flake8-bugbear
+    "SIM",    # flake8-simplify
+]
+
+[tool.ruff.format]
+quote-style = "double"
+
+[tool.ty.environment]
+python-version = "3.10"

--- a/python/nteract/src/nteract/__init__.py
+++ b/python/nteract/src/nteract/__init__.py
@@ -1,0 +1,5 @@
+"""nteract - AI-powered Jupyter notebooks."""
+
+from nteract._mcp_server import main
+
+__all__ = ["main"]

--- a/python/nteract/src/nteract/_mcp_server.py
+++ b/python/nteract/src/nteract/_mcp_server.py
@@ -1,0 +1,1163 @@
+"""nteract MCP server for AI-powered Jupyter notebooks.
+
+This server exposes notebook operations as MCP tools, allowing AI agents
+to create cells, execute code, and read outputs. For realtime sync with
+users, use the nteract desktop app connected to the same notebook.
+
+Usage:
+    python -m nteract._mcp_server
+
+Or via the entry point:
+    nteract
+
+Requires: pip install nteract
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+import re
+import sys
+from typing import Any
+
+import runtimed
+from mcp.server.fastmcp import FastMCP
+from mcp.types import ImageContent, TextContent, ToolAnnotations
+
+logger = logging.getLogger(__name__)
+
+# MCP content types for tool responses
+ContentItem = TextContent | ImageContent
+
+# Create the MCP server
+mcp = FastMCP("nteract")
+
+# Session state - single active session at a time
+_session: runtimed.AsyncSession | None = None
+_daemon_client: runtimed.DaemonClient | None = None
+
+
+def _get_daemon_client() -> runtimed.DaemonClient:
+    """Get or create the daemon client."""
+    global _daemon_client
+    if _daemon_client is None:
+        _daemon_client = runtimed.DaemonClient()
+    return _daemon_client
+
+
+async def _get_session() -> runtimed.AsyncSession:
+    """Get the current session, raising error if not connected."""
+    if _session is None:
+        raise RuntimeError("No active notebook session. Call connect_notebook first.")
+    return _session
+
+
+# Regex to strip ANSI escape sequences (terminal colors, cursor movement, etc.)
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]|\x1b\].*?\x07|\x1b\(B")
+
+
+def _strip_ansi(text: str) -> str:
+    """Strip ANSI escape sequences from text.
+
+    Kernel stream output (especially from pip/uv installs) often contains
+    terminal control codes for colors, progress bars, and cursor movement.
+    These waste LLM context and render as garbage in text responses.
+    """
+    return _ANSI_RE.sub("", text)
+
+
+# Maximum size for image data (base64-encoded). 1 MB is generous — a typical
+# matplotlib PNG is 50–100 KB. Images beyond this are silently dropped to
+# avoid blowing up the LLM's context window.
+_MAX_IMAGE_BASE64_BYTES = 1_000_000
+
+# Text mime type priority for LLM consumption.
+# text/llm+plain is from https://github.com/rgbkrk/repr_llm — a repr designed
+# specifically for language models. text/html is intentionally excluded: it's
+# often bulky embedded JS (e.g. Plotly) that wastes context window.
+_TEXT_MIME_PRIORITY = (
+    "text/llm+plain",
+    "text/markdown",
+    "text/plain",
+    "application/json",
+)
+
+
+def _format_output_text(output: runtimed.Output) -> str | None:
+    """Extract text representation from a single output.
+
+    Returns the best text representation, or None if no text available.
+    Priority: text/llm+plain > text/markdown > text/plain > application/json
+    """
+    if output.output_type == "stream":
+        return _strip_ansi(output.text) if output.text else None
+
+    if output.output_type == "error":
+        parts = []
+        if output.ename and output.evalue:
+            parts.append(f"{output.ename}: {output.evalue}")
+        elif output.evalue:
+            parts.append(output.evalue)
+        if output.traceback:
+            parts.append("\n".join(output.traceback))
+        return _strip_ansi("\n".join(parts)) if parts else None
+
+    if output.output_type in ("display_data", "execute_result"):
+        if output.data is None:
+            return None
+        for mime in _TEXT_MIME_PRIORITY:
+            if mime not in output.data:
+                continue
+            if mime == "application/json":
+                try:
+                    data = output.data[mime]
+                    if isinstance(data, str):
+                        return json.dumps(json.loads(data), indent=2)
+                    return json.dumps(data, indent=2)
+                except (json.JSONDecodeError, TypeError):
+                    return str(output.data[mime])
+            return output.data[mime]
+        return None
+
+    return None
+
+
+def _format_outputs_text(outputs: list[runtimed.Output]) -> str:
+    """Convert a list of outputs to readable text.
+
+    Extracts only text-based representations. Ignores images, HTML, and
+    other binary/bulky formats.
+    """
+    parts: list[str] = []
+    for output in outputs:
+        text = _format_output_text(output)
+        if text:
+            parts.append(text)
+    return "\n\n".join(parts)
+
+
+def _output_to_content(output: runtimed.Output) -> list[ContentItem]:
+    """Convert a single output to a list of MCP content items.
+
+    Returns the richest representation for each mime type:
+    - image/png, image/jpeg, image/gif, image/webp → ImageContent
+    - image/svg+xml → TextContent (XML text, not base64)
+    - text/llm+plain, text/markdown, text/plain, application/json → TextContent
+    - stream, error → TextContent
+
+    text/html is intentionally excluded — it's often bulky embedded JS
+    (e.g. Plotly, Bokeh) that wastes LLM context window.
+    """
+    items: list[ContentItem] = []
+
+    if output.output_type == "stream":
+        if output.text:
+            cleaned = _strip_ansi(output.text)
+            if cleaned.strip():
+                items.append(TextContent(type="text", text=cleaned))
+        return items
+
+    if output.output_type == "error":
+        parts = []
+        if output.ename and output.evalue:
+            parts.append(f"{output.ename}: {output.evalue}")
+        elif output.evalue:
+            parts.append(output.evalue)
+        if output.traceback:
+            parts.append("\n".join(output.traceback))
+        if parts:
+            items.append(TextContent(type="text", text=_strip_ansi("\n".join(parts))))
+        return items
+
+    if output.output_type in ("display_data", "execute_result"):
+        if output.data is None:
+            return items
+
+        # Images → ImageContent (base64 encoded by the kernel)
+        for mime in ("image/png", "image/jpeg", "image/gif", "image/webp"):
+            if mime in output.data:
+                data = output.data[mime]
+                if isinstance(data, str) and len(data) <= _MAX_IMAGE_BASE64_BYTES:
+                    items.append(ImageContent(type="image", data=data, mimeType=mime))
+
+        # SVG as text (it's XML, not base64)
+        if "image/svg+xml" in output.data:
+            items.append(TextContent(type="text", text=output.data["image/svg+xml"]))
+
+        # Best available text representation
+        for mime in _TEXT_MIME_PRIORITY:
+            if mime not in output.data:
+                continue
+            if mime == "application/json":
+                try:
+                    data = output.data[mime]
+                    if isinstance(data, str):
+                        text = json.dumps(json.loads(data), indent=2)
+                    else:
+                        text = json.dumps(data, indent=2)
+                    items.append(TextContent(type="text", text=text))
+                except (json.JSONDecodeError, TypeError):
+                    items.append(TextContent(type="text", text=str(output.data[mime])))
+            else:
+                items.append(TextContent(type="text", text=output.data[mime]))
+            break
+
+    return items
+
+
+def _outputs_to_content(outputs: list[runtimed.Output]) -> list[ContentItem]:
+    """Convert a list of outputs to MCP content items.
+
+    Each output may produce multiple items (e.g. an image + its text/plain alt).
+    """
+    items: list[ContentItem] = []
+    for output in outputs:
+        items.extend(_output_to_content(output))
+    return items
+
+
+def _format_header(
+    cell_id: str,
+    status: str | None = None,
+    execution_count: int | None = None,
+) -> str:
+    """Format a cell header line for terminal display.
+
+    Example: ━━━ cell-abc12345 ✓ idle [3] ━━━
+    """
+    icons = {"idle": "✓", "error": "✗", "running": "◐"}
+
+    parts = [f"━━━ {cell_id}"]
+
+    if status:
+        icon = icons.get(status, "?")
+        parts.append(f"{icon} {status}")
+
+    if execution_count is not None:
+        parts.append(f"[{execution_count}]")
+
+    parts.append("━━━")
+    return " ".join(parts)
+
+
+def _format_cell(cell: runtimed.Cell) -> str:
+    """Format a cell for terminal display (includes source).
+
+    Used by get_cell to show full cell state.
+    """
+    header = _format_header(cell.id, execution_count=cell.execution_count)
+    output_text = _format_outputs_text(cell.outputs)
+
+    if cell.source and output_text:
+        return f"{header}\n\n{cell.source}\n\n───────────────────\n\n{output_text}"
+    elif cell.source:
+        return f"{header}\n\n{cell.source}"
+    elif output_text:
+        return f"{header}\n\n{output_text}"
+    else:
+        return header
+
+
+def _cell_to_content(cell: runtimed.Cell) -> list[ContentItem]:
+    """Convert a cell to rich MCP content items.
+
+    Returns a header as TextContent, then each output as its richest type.
+    """
+    header = _format_header(cell.id, execution_count=cell.execution_count)
+    items: list[ContentItem] = []
+
+    if cell.source:
+        items.append(TextContent(type="text", text=f"{header}\n\n{cell.source}"))
+    else:
+        items.append(TextContent(type="text", text=header))
+
+    output_items = _outputs_to_content(cell.outputs)
+    if output_items:
+        items.extend(output_items)
+
+    return items
+
+
+def _format_execution_result(
+    cell_id: str,
+    events: list[Any],  # list[runtimed.ExecutionEvent]
+    complete: bool,
+) -> str:
+    """Format execution result for terminal display.
+
+    Status reflects execution outcome:
+    - "running": execution in progress (complete=false)
+    - "idle": completed successfully
+    - "error": execution raised an exception
+    """
+    outputs: list[runtimed.Output] = []
+    execution_count: int | None = None
+    status = "running"
+    has_error_output = False
+
+    for event in events:
+        if event.event_type == "execution_started":
+            execution_count = event.execution_count
+        elif event.event_type == "output":
+            outputs.append(event.output)
+            if event.output.output_type == "error":
+                has_error_output = True
+        elif event.event_type == "done":
+            status = "error" if has_error_output else "idle"
+        elif event.event_type == "error":
+            status = "error"
+
+    header = _format_header(cell_id, status=status, execution_count=execution_count)
+    output_text = _format_outputs_text(outputs)
+
+    if output_text:
+        return f"{header}\n\n{output_text}"
+    elif not complete:
+        return f"{header}\n\n(execution in progress...)"
+    else:
+        return header
+
+
+def _execution_result_to_content(
+    cell_id: str,
+    events: list[Any],  # list[runtimed.ExecutionEvent]
+    complete: bool,
+) -> list[ContentItem]:
+    """Convert execution result to rich MCP content items.
+
+    Returns a header TextContent, then each output as its richest type.
+    """
+    outputs: list[runtimed.Output] = []
+    execution_count: int | None = None
+    status = "running"
+    has_error_output = False
+
+    for event in events:
+        if event.event_type == "execution_started":
+            execution_count = event.execution_count
+        elif event.event_type == "output":
+            outputs.append(event.output)
+            if event.output.output_type == "error":
+                has_error_output = True
+        elif event.event_type == "done":
+            status = "error" if has_error_output else "idle"
+        elif event.event_type == "error":
+            status = "error"
+
+    header = _format_header(cell_id, status=status, execution_count=execution_count)
+    items: list[ContentItem] = [TextContent(type="text", text=header)]
+
+    output_items = _outputs_to_content(outputs)
+    if output_items:
+        items.extend(output_items)
+    elif not complete:
+        items.append(TextContent(type="text", text="(execution in progress...)"))
+
+    return items
+
+
+# =============================================================================
+# Session Management Tools
+# =============================================================================
+
+
+@mcp.tool(annotations=ToolAnnotations(destructiveHint=False))
+async def connect_notebook(
+    notebook_id: str | None = None,
+) -> dict[str, Any]:
+    """Connect to a notebook session.
+
+    Creates or connects to a notebook session in the daemon. Multiple calls
+    with the same notebook_id will share the same kernel.
+
+    Args:
+        notebook_id: Optional ID for the notebook. If not provided, generates
+            a unique ID. Use the same ID to reconnect to an existing session.
+
+    Returns:
+        Session info including the notebook_id.
+    """
+    global _session
+
+    # Close existing session if any
+    if _session is not None:
+        with contextlib.suppress(Exception):
+            await _session.close()
+
+    # Create new session
+    _session = runtimed.AsyncSession(notebook_id=notebook_id)
+    await _session.connect()
+
+    return {
+        "notebook_id": _session.notebook_id,
+        "connected": True,
+    }
+
+
+@mcp.tool(annotations=ToolAnnotations(destructiveHint=True))
+async def disconnect_notebook() -> dict[str, Any]:
+    """Disconnect from the current notebook session.
+
+    Closes the connection but does not shutdown the kernel (other clients
+    may still be using it).
+
+    Returns:
+        Confirmation of disconnection.
+    """
+    global _session
+
+    if _session is not None:
+        with contextlib.suppress(Exception):
+            await _session.close()
+        _session = None
+
+    return {"disconnected": True}
+
+
+@mcp.tool(annotations=ToolAnnotations(destructiveHint=False))
+async def open_notebook(path: str) -> dict[str, Any]:
+    """Open an existing .ipynb notebook file from disk.
+
+    Use this to open a notebook that already exists on the filesystem.
+    For creating a new notebook, use create_notebook() instead.
+
+    Args:
+        path: Absolute or relative path to the .ipynb file.
+
+    Returns:
+        Connection info including notebook_id and trust status.
+    """
+    global _session
+
+    if _session is not None:
+        with contextlib.suppress(Exception):
+            await _session.close()
+
+    _session = await runtimed.AsyncSession.open_notebook(path)
+    info = await _session.connection_info()
+    return {
+        "notebook_id": _session.notebook_id,
+        "path": path,
+        "cell_count": info.cell_count if info else 0,
+        "needs_trust_approval": info.needs_trust_approval if info else False,
+    }
+
+
+@mcp.tool(annotations=ToolAnnotations(destructiveHint=False))
+async def create_notebook(
+    runtime: str = "python",
+    working_dir: str | None = None,
+) -> dict[str, Any]:
+    """Create a new empty notebook in memory.
+
+    Creates an empty notebook with one code cell via the daemon. The notebook
+    exists only in memory until saved with save_notebook(path).
+
+    NOTE: This tool does NOT accept a path parameter. To save the notebook
+    to disk, call save_notebook(path) after creating it.
+
+    Args:
+        runtime: Kernel runtime type ("python" or "deno").
+        working_dir: Optional working directory for project detection.
+
+    Returns:
+        Connection info including notebook_id (a session identifier, not a file path).
+    """
+    global _session
+
+    if _session is not None:
+        with contextlib.suppress(Exception):
+            await _session.close()
+
+    _session = await runtimed.AsyncSession.create_notebook(runtime=runtime, working_dir=working_dir)
+    info = await _session.connection_info()
+    return {
+        "notebook_id": _session.notebook_id,
+        "runtime": runtime,
+        "cell_count": info.cell_count if info else 1,
+    }
+
+
+@mcp.tool(annotations=ToolAnnotations(destructiveHint=False))
+async def save_notebook(path: str | None = None) -> dict[str, Any]:
+    """Save the current notebook to disk as a .ipynb file.
+
+    Persists the current notebook state including cells, outputs, and metadata.
+
+    Args:
+        path: File path to save to. REQUIRED for notebooks created with
+            create_notebook(). Can be omitted for notebooks opened with
+            open_notebook() to save to the original location.
+
+    Returns:
+        The absolute path where the file was saved.
+    """
+    session = await _get_session()
+    try:
+        saved_path = await session.save(path)
+        return {"path": saved_path}
+    except Exception as e:
+        error_msg = str(e)
+        is_write_error = "Read-only" in error_msg or "Failed to write" in error_msg
+        if is_write_error and path is None:
+            raise RuntimeError(
+                "No path specified. For notebooks created with create_notebook(), "
+                "you must provide a path (e.g., save_notebook('/path/to/file.ipynb'))"
+            ) from e
+        raise
+
+
+def _format_notebook_list(rooms: list[dict[str, Any]]) -> str:
+    """Format notebook rooms for terminal display."""
+    if not rooms:
+        return "No active notebooks"
+
+    lines = [f"Notebooks ({len(rooms)}):"]
+    for room in rooms:
+        notebook_id = room.get("notebook_id", "unknown")
+        peers = room.get("active_peers", 0)
+        has_kernel = room.get("has_kernel", False)
+
+        # Build kernel info
+        if has_kernel:
+            kernel_type = room.get("kernel_type", "unknown")
+            kernel_status = room.get("kernel_status", "unknown")
+            env_source = room.get("env_source", "unknown")
+            kernel_info = f"{kernel_type} ({kernel_status}) | env: {env_source}"
+        else:
+            kernel_info = "no kernel"
+
+        lines.append(f"\n• {notebook_id}")
+        lines.append(f"  {kernel_info} | peers: {peers}")
+
+    return "\n".join(lines)
+
+
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+async def list_notebooks() -> list[ContentItem]:
+    """List all active notebook rooms in the daemon.
+
+    Returns:
+        List of notebook rooms with their status.
+    """
+    client = _get_daemon_client()
+    rooms = client.list_rooms()
+    return [TextContent(type="text", text=_format_notebook_list([dict(room) for room in rooms]))]
+
+
+# =============================================================================
+# Kernel Management Tools
+# =============================================================================
+
+
+@mcp.tool(annotations=ToolAnnotations(destructiveHint=False))
+async def start_kernel(
+    kernel_type: str = "python",
+    env_source: str = "auto",
+) -> dict[str, Any]:
+    """Start a kernel for the current session.
+
+    If a kernel is already running for this notebook_id (from any client),
+    it will be reused.
+
+    Args:
+        kernel_type: Type of kernel - "python" or "deno".
+        env_source: Environment source. Options:
+            - "auto" (default) - Auto-detect from notebook metadata/project files
+            - "uv:prewarmed" - Fast startup from UV pool
+            - "conda:prewarmed" - Conda environment from pool
+            - "uv:inline" - Use notebook's inline UV dependencies
+            - "conda:inline" - Use notebook's inline conda dependencies
+            For Deno kernels, this is ignored (always uses "deno").
+
+    Returns:
+        Kernel info including the actual env_source used.
+    """
+    session = await _get_session()
+    await session.start_kernel(kernel_type=kernel_type, env_source=env_source)
+
+    return {
+        "kernel_type": kernel_type,
+        "env_source": await session.env_source(),
+        "started": True,
+    }
+
+
+@mcp.tool(annotations=ToolAnnotations(destructiveHint=True))
+async def shutdown_kernel() -> dict[str, Any]:
+    """Shutdown the kernel for the current session.
+
+    Returns:
+        Confirmation of shutdown.
+    """
+    session = await _get_session()
+    await session.shutdown_kernel()
+
+    return {"shutdown": True}
+
+
+@mcp.tool(annotations=ToolAnnotations(destructiveHint=True))
+async def interrupt_kernel() -> dict[str, Any]:
+    """Interrupt the currently executing cell.
+
+    Use this to stop long-running or infinite loops.
+
+    Returns:
+        Confirmation of interrupt.
+    """
+    session = await _get_session()
+    await session.interrupt()
+
+    return {"interrupted": True}
+
+
+@mcp.tool(annotations=ToolAnnotations(destructiveHint=True))
+async def restart_kernel() -> dict[str, Any]:
+    """Restart the kernel with updated dependencies.
+
+    Clears all kernel state and reloads dependencies from notebook metadata.
+    Use this after adding/removing dependencies when sync_environment()
+    isn't sufficient.
+
+    Returns:
+        Confirmation of restart with the new env_source.
+    """
+    session = await _get_session()
+    await session.restart_kernel(wait_for_ready=True)
+    return {"restarted": True, "env_source": await session.env_source()}
+
+
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+async def get_kernel_status() -> dict[str, Any]:
+    """Get the kernel status for the current session.
+
+    Returns:
+        Kernel status including whether it's running and the env_source.
+    """
+    session = await _get_session()
+
+    return {
+        "connected": await session.is_connected(),
+        "kernel_started": await session.kernel_started(),
+        "env_source": await session.env_source(),
+    }
+
+
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+async def complete_code(code: str, cursor_pos: int) -> dict[str, Any]:
+    """Get code completions from the kernel.
+
+    Uses the kernel's introspection to provide context-aware completions.
+    Requires a running kernel.
+
+    Args:
+        code: The code to complete.
+        cursor_pos: Cursor position in the code (0-indexed byte offset).
+
+    Returns:
+        Completions including cursor_start, cursor_end, and items list.
+    """
+    session = await _get_session()
+    result = await session.complete(code, cursor_pos)
+    return {
+        "cursor_start": result.cursor_start,
+        "cursor_end": result.cursor_end,
+        "items": [
+            {"label": item.label, "kind": item.kind, "detail": item.detail} for item in result.items
+        ],
+    }
+
+
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+async def get_queue_state() -> dict[str, Any]:
+    """Get the current execution queue state.
+
+    Shows which cell is currently executing and which cells are queued.
+
+    Returns:
+        executing: Cell ID currently running (or null if idle).
+        queued: List of cell IDs waiting to run.
+    """
+    session = await _get_session()
+    state = await session.get_queue_state()
+    return {"executing": state.executing, "queued": state.queued}
+
+
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+async def get_history(
+    pattern: str | None = None,
+    n: int = 100,
+) -> dict[str, Any]:
+    """Search kernel execution history.
+
+    Returns previously executed code from this kernel session.
+
+    Args:
+        pattern: Optional glob pattern to filter results (e.g., "*import*").
+        n: Maximum entries to return (default 100).
+
+    Returns:
+        entries: List of history entries with session, line, and source.
+    """
+    session = await _get_session()
+    entries = await session.get_history(pattern=pattern, n=n, unique=True)
+    return {
+        "entries": [{"session": e.session, "line": e.line, "source": e.source} for e in entries]
+    }
+
+
+# =============================================================================
+# Dependency Management Tools
+# =============================================================================
+
+
+async def _get_package_manager(session: runtimed.AsyncSession) -> str:
+    """Detect which package manager the notebook is using.
+
+    Detection order:
+    1. If kernel is running, check env_source (most reliable)
+    2. Otherwise, check stored metadata for existing dependencies
+    3. Default to "uv" if no signal
+    """
+    # First check env_source if kernel is running
+    env = await session.env_source()
+    if env:
+        if env.startswith("conda:"):
+            return "conda"
+        return "uv"
+
+    # No kernel running - check stored metadata
+    # If notebook has conda deps, it's a conda notebook
+    conda_deps = await session.get_conda_dependencies()
+    if conda_deps:
+        return "conda"
+
+    return "uv"
+
+
+@mcp.tool(annotations=ToolAnnotations(destructiveHint=True))
+async def add_dependency(package: str) -> dict[str, Any]:
+    """Add a Python package dependency to the notebook.
+
+    Automatically uses the notebook's configured package manager (UV or Conda)
+    based on env_source. The package is added to the notebook's inline
+    dependency metadata.
+
+    Use sync_environment() to install without restart, or restart_kernel()
+    for a clean environment with the new dependency.
+
+    Args:
+        package: Package specifier (e.g., "pandas>=2.0", "requests").
+
+    Returns:
+        Updated list of dependencies and which package manager was used.
+    """
+    session = await _get_session()
+    pm = await _get_package_manager(session)
+    if pm == "conda":
+        await session.add_conda_dependency(package)
+        deps = await session.get_conda_dependencies()
+    else:
+        await session.add_uv_dependency(package)
+        deps = await session.get_uv_dependencies()
+    return {"dependencies": deps, "added": package, "package_manager": pm}
+
+
+@mcp.tool(annotations=ToolAnnotations(destructiveHint=True))
+async def remove_dependency(package: str) -> dict[str, Any]:
+    """Remove a dependency from the notebook.
+
+    Automatically uses the notebook's configured package manager (UV or Conda)
+    based on env_source. Requires kernel restart to take effect.
+
+    Args:
+        package: Exact dependency string to remove.
+
+    Returns:
+        Updated list of dependencies and which package manager was used.
+    """
+    session = await _get_session()
+    pm = await _get_package_manager(session)
+    if pm == "conda":
+        await session.remove_conda_dependency(package)
+        deps = await session.get_conda_dependencies()
+    else:
+        await session.remove_uv_dependency(package)
+        deps = await session.get_uv_dependencies()
+    return {"dependencies": deps, "removed": package, "package_manager": pm}
+
+
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+async def get_dependencies() -> dict[str, Any]:
+    """Get the notebook's current dependencies.
+
+    Returns dependencies from the notebook's configured package manager
+    (UV or Conda) based on env_source.
+
+    Returns:
+        List of dependency specifiers and which package manager is active.
+    """
+    session = await _get_session()
+    pm = await _get_package_manager(session)
+    if pm == "conda":
+        deps = await session.get_conda_dependencies()
+    else:
+        deps = await session.get_uv_dependencies()
+    return {"dependencies": deps, "package_manager": pm}
+
+
+@mcp.tool(annotations=ToolAnnotations(destructiveHint=True))
+async def sync_environment() -> dict[str, Any]:
+    """Hot-install new dependencies without restarting the kernel.
+
+    Only works for UV dependencies and only for additions.
+    If removals are needed or sync fails, use restart_kernel() instead.
+
+    Returns:
+        success: Whether sync completed.
+        synced_packages: Packages that were installed (if success).
+        needs_restart: If true, must restart kernel instead.
+    """
+    session = await _get_session()
+    result = await session.sync_environment()
+    return {
+        "success": result.success,
+        "synced_packages": result.synced_packages,
+        "error": result.error,
+        "needs_restart": result.needs_restart,
+    }
+
+
+# =============================================================================
+# Cell Operations Tools
+# =============================================================================
+
+
+@mcp.tool(annotations=ToolAnnotations(destructiveHint=False))
+async def create_cell(
+    source: str = "",
+    cell_type: str = "code",
+    index: int | None = None,
+    and_run: bool = False,
+    timeout_secs: float = 5.0,
+) -> list[ContentItem]:
+    """Create a new cell in the notebook, optionally executing it.
+
+    The cell is added to the shared document and synced to all connected
+    clients (including nteract if open with the same notebook).
+
+    Args:
+        source: Initial source code for the cell.
+        cell_type: Cell type - "code", "markdown", or "raw".
+        index: Position to insert the cell. None appends at the end.
+        and_run: If True, execute the cell after creating it.
+        timeout_secs: Max time to wait for execution (default 5s). If execution
+            takes longer, returns partial results with complete=False.
+
+    Returns:
+        If and_run=False: The cell_id.
+        If and_run=True: Cell with execution status and outputs.
+    """
+    session = await _get_session()
+    cell_id = await session.create_cell(
+        source=source,
+        cell_type=cell_type,
+        index=index,
+    )
+
+    if and_run and cell_type == "code":
+        return await _execute_cell_internal(cell_id, timeout_secs=timeout_secs)
+
+    return [TextContent(type="text", text=f"Created cell: {cell_id}")]
+
+
+@mcp.tool(annotations=ToolAnnotations(destructiveHint=True))
+async def set_cell_source(cell_id: str, source: str) -> dict[str, Any]:
+    """Update a cell's source code.
+
+    The change is synced to all connected clients.
+
+    Args:
+        cell_id: The cell ID to update.
+        source: The new source code.
+
+    Returns:
+        Confirmation of update.
+    """
+    session = await _get_session()
+    await session.set_source(cell_id=cell_id, source=source)
+
+    return {"cell_id": cell_id, "updated": True}
+
+
+@mcp.tool(annotations=ToolAnnotations(destructiveHint=False))
+async def append_source(cell_id: str, text: str) -> dict[str, Any]:
+    """Append text to a cell's source code.
+
+    Uses direct CRDT insertion (no diff) - ideal for streaming LLM tokens.
+    Changes sync to all connected clients in real-time.
+
+    Args:
+        cell_id: The cell ID to append to.
+        text: The text to append.
+
+    Returns:
+        Confirmation of append.
+    """
+    session = await _get_session()
+    await session.append_source(cell_id=cell_id, text=text)
+
+    return {"cell_id": cell_id, "appended": True}
+
+
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+async def get_cell(cell_id: str) -> list[ContentItem]:
+    """Get a cell by ID, including outputs if available.
+
+    Outputs are resolved from the Automerge document, so you can see
+    outputs from cells executed by other clients.
+
+    Args:
+        cell_id: The cell ID.
+
+    Returns:
+        Cell with source code and outputs (images returned as ImageContent).
+    """
+    session = await _get_session()
+    cell = await session.get_cell(cell_id=cell_id)
+    return _cell_to_content(cell)
+
+
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+async def get_all_cells() -> list[ContentItem]:
+    """Get all cells in the current notebook, including outputs.
+
+    Outputs are resolved from the Automerge document, so you can see
+    outputs from cells executed by other clients.
+
+    Returns:
+        All cells with source code and outputs (images returned as ImageContent).
+    """
+    session = await _get_session()
+    cells = await session.get_cells()
+    items: list[ContentItem] = []
+    for cell in cells:
+        items.extend(_cell_to_content(cell))
+    return items
+
+
+@mcp.tool(annotations=ToolAnnotations(destructiveHint=True))
+async def delete_cell(cell_id: str) -> dict[str, Any]:
+    """Delete a cell from the notebook.
+
+    The change is synced to all connected clients.
+
+    Args:
+        cell_id: The cell ID to delete.
+
+    Returns:
+        Confirmation of deletion.
+    """
+    session = await _get_session()
+    await session.delete_cell(cell_id=cell_id)
+
+    return {"cell_id": cell_id, "deleted": True}
+
+
+@mcp.tool(annotations=ToolAnnotations(destructiveHint=True))
+async def move_cell(cell_id: str, after_cell_id: str | None = None) -> dict[str, Any]:
+    """Move a cell to a new position in the notebook.
+
+    Reorders the shared document and syncs the change to all connected clients.
+
+    Args:
+        cell_id: The cell to move.
+        after_cell_id: Move after this cell. Use None to move to the start.
+
+    Returns:
+        Confirmation of the move, including the new internal position token.
+    """
+    session = await _get_session()
+    new_position = await session.move_cell(cell_id=cell_id, after_cell_id=after_cell_id)
+    return {
+        "cell_id": cell_id,
+        "after_cell_id": after_cell_id,
+        "new_position": new_position,
+        "moved": True,
+    }
+
+
+@mcp.tool(annotations=ToolAnnotations(destructiveHint=True))
+async def clear_outputs(cell_id: str) -> dict[str, Any]:
+    """Clear a cell's outputs.
+
+    Removes all outputs from the cell. Useful before re-running a cell
+    to get a clean slate.
+
+    Args:
+        cell_id: The cell ID to clear outputs from.
+
+    Returns:
+        Confirmation of clearing.
+    """
+    session = await _get_session()
+    await session.clear_outputs(cell_id)
+    return {"cell_id": cell_id, "cleared": True}
+
+
+# =============================================================================
+# Execution Tools
+# =============================================================================
+
+
+async def _execute_cell_internal(
+    cell_id: str,
+    timeout_secs: float = 5.0,
+) -> list[ContentItem]:
+    """Internal execution with streaming and partial results."""
+    session = await _get_session()
+    events: list[Any] = []  # list[runtimed.ExecutionEvent]
+    complete = False
+
+    async def collect_events() -> None:
+        nonlocal complete
+        async for event in await session.stream_execute(cell_id):
+            events.append(event)
+            if event.event_type in ("done", "error"):
+                complete = True
+                break
+
+    with contextlib.suppress(asyncio.TimeoutError):
+        await asyncio.wait_for(collect_events(), timeout=timeout_secs)
+
+    if complete:
+        # Prefer the synced document as the final source of truth once execution
+        # finishes. This is more robust across runtimed output transport changes.
+        session = await _get_session()
+        with contextlib.suppress(Exception):
+            cell = await session.get_cell(cell_id=cell_id)
+            has_error_output = any(output.output_type == "error" for output in cell.outputs)
+            status = "error" if has_error_output else "idle"
+            header = _format_header(cell.id, status=status, execution_count=cell.execution_count)
+            items: list[ContentItem] = [TextContent(type="text", text=header)]
+            items.extend(_outputs_to_content(cell.outputs))
+            return items
+
+    return _execution_result_to_content(cell_id, events, complete)
+
+
+@mcp.tool(annotations=ToolAnnotations(destructiveHint=True))
+async def execute_cell(
+    cell_id: str,
+    timeout_secs: float = 5.0,
+) -> list[ContentItem]:
+    """Execute a cell by ID.
+
+    Returns partial results after timeout_secs if still running.
+    If status shows "running", use get_cell() to poll for more outputs.
+
+    Args:
+        cell_id: The cell ID to execute.
+        timeout_secs: Maximum time to wait for execution (default: 5s).
+
+    Returns:
+        Cell with execution status and outputs (images returned as ImageContent).
+    """
+    return await _execute_cell_internal(cell_id, timeout_secs=timeout_secs)
+
+
+@mcp.tool(annotations=ToolAnnotations(destructiveHint=True))
+async def run_all_cells() -> dict[str, Any]:
+    """Queue all code cells for execution.
+
+    Queues all code cells in document order. Does not wait for completion.
+    Use get_queue_state() to monitor progress or get_all_cells() to see results.
+
+    Returns:
+        count: Number of cells queued for execution.
+    """
+    session = await _get_session()
+    count = await session.run_all_cells()
+    return {"status": "queued", "count": count}
+
+
+# =============================================================================
+# Resources
+# =============================================================================
+
+
+@mcp.resource("notebook://cells")
+async def resource_cells() -> str:
+    """Get all cells in the current notebook."""
+    if _session is None:
+        return "Error: No active session"
+
+    try:
+        cells = await _session.get_cells()
+        formatted = [
+            _format_cell(
+                cell,
+            )
+            for cell in cells
+        ]
+        return "\n\n".join(formatted)
+    except Exception as e:
+        return f"Error: {e}"
+
+
+@mcp.resource("notebook://status")
+async def resource_status() -> str:
+    """Get the current session and kernel status as JSON."""
+    if _session is None:
+        return json.dumps(
+            {
+                "connected": False,
+                "kernel_started": False,
+                "env_source": None,
+            }
+        )
+
+    try:
+        return json.dumps(
+            {
+                "notebook_id": _session.notebook_id,
+                "connected": await _session.is_connected(),
+                "kernel_started": await _session.kernel_started(),
+                "env_source": await _session.env_source(),
+            }
+        )
+    except Exception as e:
+        return json.dumps({"error": str(e)})
+
+
+@mcp.resource("notebook://rooms")
+async def resource_rooms() -> str:
+    """Get all active notebook rooms as JSON."""
+    try:
+        client = _get_daemon_client()
+        rooms = client.list_rooms()
+        return json.dumps([dict(room) for room in rooms])
+    except Exception as e:
+        return json.dumps({"error": str(e)})
+
+
+# =============================================================================
+# Entry Point
+# =============================================================================
+
+
+def main():
+    """Run the MCP server."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        stream=sys.stderr,
+    )
+    mcp.run(transport="stdio")
+
+
+if __name__ == "__main__":
+    main()

--- a/python/nteract/tests/test_mcp_integration.py
+++ b/python/nteract/tests/test_mcp_integration.py
@@ -1,0 +1,396 @@
+"""Integration tests for nteract MCP server.
+
+These tests require a running runtimed daemon. They use MCP's in-memory
+transport (anyio memory streams) to test the server without stdio.
+
+Run locally:
+    # Start runtimed daemon first
+    runtimed
+
+    # Run tests
+    uv run pytest tests/test_mcp_integration.py -v
+
+Skip in CI (requires daemon):
+    uv run pytest tests/ -v --ignore=tests/test_mcp_integration.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import re
+from typing import Any
+
+import anyio
+import pytest
+from mcp import ClientSession
+
+from nteract._mcp_server import mcp
+
+
+@pytest.fixture
+async def mcp_client():
+    """Create in-memory MCP client connected to our server.
+
+    Uses asyncio for task management to avoid anyio cancel scope
+    issues with pytest-asyncio fixture teardown.
+    """
+    # Bidirectional streams: client->server and server->client
+    client_send, server_recv = anyio.create_memory_object_stream[Any](0)
+    server_send, client_recv = anyio.create_memory_object_stream[Any](0)
+
+    # Start server as asyncio task (not anyio task group)
+    server_task = asyncio.create_task(
+        mcp._mcp_server.run(
+            server_recv,
+            server_send,
+            mcp._mcp_server.create_initialization_options(),
+            raise_exceptions=True,
+        )
+    )
+
+    # Give server a moment to start
+    await asyncio.sleep(0.01)
+
+    # Create client - use manual __aenter__/__aexit__ to control cleanup
+    client = ClientSession(client_recv, client_send)
+    await client.__aenter__()
+
+    try:
+        await client.initialize()
+        yield client
+    finally:
+        # Cancel server first
+        server_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await server_task
+
+        # Close streams to unblock any pending operations
+        await client_send.aclose()
+        await server_send.aclose()
+
+        # Best-effort client cleanup - suppress task context errors
+        with contextlib.suppress(RuntimeError):
+            await client.__aexit__(None, None, None)
+
+
+def _get_text(result: Any) -> str:
+    """Get all text content from MCP tool result.
+
+    Joins text from all TextContent items in the response, since tools
+    now return multiple content items (header, outputs, images, etc.).
+    """
+    if not hasattr(result, "content") or not result.content:
+        return ""
+    parts = []
+    for item in result.content:
+        if hasattr(item, "text"):
+            parts.append(item.text)
+    return "\n\n".join(parts)
+
+
+def _parse_json(result: Any) -> dict[str, Any]:
+    """Parse JSON from MCP tool result (for tools that return JSON)."""
+    text = _get_text(result)
+    if text:
+        return json.loads(text)
+    return {}
+
+
+def _extract_cell_id(text: str) -> str | None:
+    """Extract cell ID from 'Created cell: {id}' or header format."""
+    # Match "Created cell: cell-uuid"
+    match = re.search(r"Created cell: (cell-[\w-]+)", text)
+    if match:
+        return match.group(1)
+    # Match header format "━━━ cell-uuid" (full ID in header)
+    match = re.search(r"━━━ (cell-[\w-]+)", text)
+    if match:
+        return match.group(1)
+    return None
+
+
+@pytest.mark.asyncio
+async def test_list_tools(mcp_client: ClientSession):
+    """Verify all expected tools are exposed."""
+    tools = await mcp_client.list_tools()
+    tool_names = {t.name for t in tools.tools}
+
+    # Core tools should be present
+    assert "connect_notebook" in tool_names
+    assert "disconnect_notebook" in tool_names
+    assert "list_notebooks" in tool_names
+    assert "start_kernel" in tool_names
+    assert "shutdown_kernel" in tool_names
+    assert "interrupt_kernel" in tool_names
+    assert "get_kernel_status" in tool_names
+    assert "create_cell" in tool_names
+    assert "set_cell_source" in tool_names
+    assert "append_source" in tool_names
+    assert "get_cell" in tool_names
+    assert "get_all_cells" in tool_names
+    assert "delete_cell" in tool_names
+    assert "move_cell" in tool_names
+    assert "execute_cell" in tool_names
+
+    # run_code should be removed
+    assert "run_code" not in tool_names
+
+
+@pytest.mark.asyncio
+async def test_connect_and_create_cell(mcp_client: ClientSession):
+    """Connect to notebook and create a cell."""
+    # Connect
+    result = await mcp_client.call_tool("connect_notebook", {})
+    data = _parse_json(result)
+    assert data["connected"] is True
+    assert "notebook_id" in data
+
+    # Create cell (returns plain text)
+    result = await mcp_client.call_tool(
+        "create_cell",
+        {"source": "print('hello')", "cell_type": "code"},
+    )
+    text = _get_text(result)
+    assert "Created cell:" in text
+    cell_id = _extract_cell_id(text)
+    assert cell_id is not None
+
+    # Get cell (returns formatted string with source)
+    result = await mcp_client.call_tool("get_cell", {"cell_id": cell_id})
+    text = _get_text(result)
+    assert "print('hello')" in text
+
+
+@pytest.mark.asyncio
+async def test_append_source(mcp_client: ClientSession):
+    """Test streaming tokens into a cell."""
+    # Connect
+    await mcp_client.call_tool("connect_notebook", {})
+
+    # Create empty cell
+    result = await mcp_client.call_tool("create_cell", {"source": ""})
+    text = _get_text(result)
+    cell_id = _extract_cell_id(text)
+    assert cell_id is not None
+
+    # Stream tokens
+    tokens = ["print", "(", "'hello", " ", "world", "'", ")"]
+    for token in tokens:
+        result = await mcp_client.call_tool(
+            "append_source",
+            {"cell_id": cell_id, "text": token},
+        )
+        data = _parse_json(result)
+        assert data["appended"] is True
+
+    # Verify final source
+    result = await mcp_client.call_tool("get_cell", {"cell_id": cell_id})
+    text = _get_text(result)
+    assert "print('hello world')" in text
+
+
+@pytest.mark.asyncio
+async def test_execute_cell_basic(mcp_client: ClientSession):
+    """Test basic cell execution."""
+    # Connect and start kernel
+    await mcp_client.call_tool("connect_notebook", {})
+    await mcp_client.call_tool("start_kernel", {})
+
+    # Create and execute cell
+    result = await mcp_client.call_tool(
+        "create_cell",
+        {
+            "source": "print('hello from kernel')",
+            "and_run": True,
+            "timeout_secs": 30.0,  # Give enough time for kernel warmup
+        },
+    )
+    text = _get_text(result)
+
+    # Should have header with cell ID and output
+    assert "cell-" in text
+    assert "hello from kernel" in text
+
+
+@pytest.mark.asyncio
+async def test_execute_cell_partial_results(mcp_client: ClientSession):
+    """Execute long-running code, verify partial results returned."""
+    # Connect and start kernel
+    await mcp_client.call_tool("connect_notebook", {})
+    await mcp_client.call_tool("start_kernel", {})
+
+    # Create cell with slow code - print immediately, then sleep
+    result = await mcp_client.call_tool(
+        "create_cell",
+        {
+            "source": "import time; print('start'); time.sleep(10); print('done')",
+            "and_run": True,
+            "timeout_secs": 2.0,  # Short timeout to test partial results
+        },
+    )
+    text = _get_text(result)
+
+    # Should have partial output with "start" and running status
+    assert "running" in text
+    assert "start" in text
+
+
+@pytest.mark.asyncio
+async def test_poll_for_outputs(mcp_client: ClientSession):
+    """Create cell, execute, poll get_cell for updated outputs."""
+    # Connect and start kernel
+    await mcp_client.call_tool("connect_notebook", {})
+    await mcp_client.call_tool("start_kernel", {})
+
+    # Create cell with short delay
+    result = await mcp_client.call_tool(
+        "create_cell",
+        {
+            "source": "import time; time.sleep(1); print('done')",
+            "and_run": True,
+            "timeout_secs": 0.5,  # Return before completion
+        },
+    )
+    text = _get_text(result)
+    cell_id = _extract_cell_id(text)
+    assert cell_id is not None
+
+    # Should be incomplete (running status)
+    assert "running" in text
+
+    # Wait and poll
+    await anyio.sleep(2)
+    result = await mcp_client.call_tool("get_cell", {"cell_id": cell_id})
+    text = _get_text(result)
+
+    # Should now have the output
+    assert "done" in text
+
+
+@pytest.mark.asyncio
+async def test_output_ordering(mcp_client: ClientSession):
+    """Verify interleaved outputs maintain order."""
+    # Connect and start kernel
+    await mcp_client.call_tool("connect_notebook", {})
+    await mcp_client.call_tool("start_kernel", {})
+
+    # Code that produces interleaved outputs
+    code = """
+import sys
+print('a', flush=True)
+from IPython.display import display
+display('b')
+print('c', flush=True)
+"""
+    result = await mcp_client.call_tool(
+        "create_cell",
+        {
+            "source": code,
+            "and_run": True,
+            "timeout_secs": 30.0,
+        },
+    )
+    text = _get_text(result)
+
+    # Should contain a, b, c in that order
+    assert "a" in text, "Output should contain 'a'"
+    assert "b" in text, "Output should contain 'b'"
+    assert "c" in text, "Output should contain 'c'"
+
+    # Verify ordering: a comes before b, b comes before c
+    pos_a = text.find("\na\n")  # Look for 'a' on its own line
+    pos_b = text.find("'b'")  # display('b') shows as 'b'
+    pos_c = text.find("\nc\n")  # Look for 'c' on its own line
+    assert pos_a < pos_b < pos_c, (
+        f"Outputs should be in order a, b, c. Got positions: a={pos_a}, b={pos_b}, c={pos_c}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_kernel_status(mcp_client: ClientSession):
+    """Test kernel status reporting."""
+    # Connect
+    await mcp_client.call_tool("connect_notebook", {})
+
+    # Check status before starting kernel
+    result = await mcp_client.call_tool("get_kernel_status", {})
+    data = _parse_json(result)
+    assert data.get("kernel_started") is False
+
+    # Start kernel
+    await mcp_client.call_tool("start_kernel", {})
+
+    # Check status after starting
+    result = await mcp_client.call_tool("get_kernel_status", {})
+    data = _parse_json(result)
+    assert data.get("kernel_started") is True
+
+
+@pytest.mark.asyncio
+async def test_delete_cell(mcp_client: ClientSession):
+    """Test cell deletion."""
+    # Connect
+    await mcp_client.call_tool("connect_notebook", {})
+
+    # Create cell
+    result = await mcp_client.call_tool("create_cell", {"source": "x = 1"})
+    text = _get_text(result)
+    cell_id = _extract_cell_id(text)
+    assert cell_id is not None
+
+    # Delete cell
+    result = await mcp_client.call_tool("delete_cell", {"cell_id": cell_id})
+    data = _parse_json(result)
+    assert data["deleted"] is True
+
+    # Verify it's gone - get_all_cells returns formatted string
+    result = await mcp_client.call_tool("get_all_cells", {})
+    text = _get_text(result)
+    # The full cell_id shouldn't appear (we only show first 8 chars in header)
+    assert cell_id not in text
+
+
+@pytest.mark.asyncio
+async def test_move_cell(mcp_client: ClientSession):
+    """Test cell reordering."""
+    await mcp_client.call_tool("connect_notebook", {})
+
+    result = await mcp_client.call_tool("create_cell", {"source": "first"})
+    first_id = _extract_cell_id(_get_text(result))
+    assert first_id is not None
+
+    result = await mcp_client.call_tool("create_cell", {"source": "second"})
+    second_id = _extract_cell_id(_get_text(result))
+    assert second_id is not None
+
+    result = await mcp_client.call_tool("create_cell", {"source": "third"})
+    third_id = _extract_cell_id(_get_text(result))
+    assert third_id is not None
+
+    result = await mcp_client.call_tool(
+        "move_cell",
+        {"cell_id": third_id, "after_cell_id": first_id},
+    )
+    data = _parse_json(result)
+    assert data["moved"] is True
+    assert data["cell_id"] == third_id
+    assert data["after_cell_id"] == first_id
+
+    result = await mcp_client.call_tool("get_all_cells", {})
+    text = _get_text(result)
+    assert text.index("first") < text.index("third") < text.index("second")
+
+    result = await mcp_client.call_tool(
+        "move_cell",
+        {"cell_id": second_id, "after_cell_id": None},
+    )
+    data = _parse_json(result)
+    assert data["moved"] is True
+    assert data["cell_id"] == second_id
+    assert data["after_cell_id"] is None
+
+    result = await mcp_client.call_tool("get_all_cells", {})
+    text = _get_text(result)
+    assert text.index("second") < text.index("first") < text.index("third")

--- a/python/nteract/tests/test_smoke.py
+++ b/python/nteract/tests/test_smoke.py
@@ -1,0 +1,15 @@
+"""Smoke tests to verify the package can be imported."""
+
+
+def test_import():
+    """Verify the nteract package can be imported."""
+    import nteract
+
+    assert hasattr(nteract, "main")
+
+
+def test_mcp_server_import():
+    """Verify the MCP server module can be imported."""
+    from nteract._mcp_server import mcp
+
+    assert mcp.name == "nteract"


### PR DESCRIPTION
Brings the nteract MCP server package (from `nteract/nteract`) into `python/nteract/` so it builds and publishes alongside runtimed.

**What changed:**

- `python/nteract/` — source, tests, pyproject.toml, README
- Base version `2.0.0`, nightlies stamp `2.0.1a{timestamp}`
- Depends on `runtimed>=2.0.1a0,<3.0`
- `python-package.yml` — lint + test on PRs, build + publish on tag push
- `release-common.yml` — build nteract sdist/wheel, publish to PyPI alongside runtimed in nightlies
- PyPI trusted publisher configured for both `python-package.yml` and `release-common.yml`

_PR submitted by @rgbkrk's agent Quill, via Zed_