### PR TITLE
ci: eliminate build-e2e-app job, parallelize E2E tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -197,6 +197,20 @@ jobs:
             cp target/release/runt "crates/notebook/binaries/runt-$TARGET"
           fi
 
+      - name: Cache cargo bin
+        uses: actions/cache@v5
+        with:
+          path: ~/.cargo/bin
+          key: cargo-bin-ubuntu-tauri-cli-tauri-driver-${{ hashFiles('rust-toolchain.toml') }}
+          restore-keys: |
+            cargo-bin-ubuntu-tauri-cli-tauri-driver-
+
+      - name: Install tauri-cli and tauri-driver
+        run: |
+          if ! command -v cargo-tauri &> /dev/null || ! command -v tauri-driver &> /dev/null; then
+            cargo install tauri-cli tauri-driver --locked
+          fi
+
       - name: Upload Linux Rust binaries
         uses: actions/upload-artifact@v7
         with:
@@ -213,6 +227,25 @@ jobs:
 
       - name: Build
         run: cargo build --release
+
+      - name: Build Tauri E2E app
+        run: cd crates/notebook && cargo tauri build --ci --no-bundle --config '{"build":{"beforeBuildCommand":""}}'
+
+      - name: Stage E2E artifacts
+        run: |
+          mkdir -p target/release/binaries
+          cp crates/notebook/binaries/runtimed-* target/release/binaries/
+          cp crates/notebook/binaries/runt-* target/release/binaries/
+          cp ~/.cargo/bin/tauri-driver target/release/binaries/tauri-driver
+
+      - name: Upload E2E app
+        uses: actions/upload-artifact@v7
+        with:
+          name: e2e-app-linux
+          path: |
+            target/release/notebook
+            target/release/binaries/
+          retention-days: 1
 
       - name: Run tests
         run: cargo test --verbose
@@ -314,96 +347,11 @@ jobs:
         run: cargo test --verbose
 
   # Build Tauri app once and share with E2E shards
-  build-e2e-app:
-    name: Build E2E Test App
-    needs: [changes, build-linux]
-    if: needs.changes.outputs.source_changed == 'true' && needs.build-linux.result == 'success'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libxdo-dev
-
-      - name: Install rust
-        uses: dsherret/rust-toolchain-file@v1
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: ubuntu-latest
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: "20"
-
-      - name: Enable corepack
-        run: corepack enable
-
-      - name: Set pnpm store directory
-        run: pnpm config set store-dir ~/.pnpm-store
-
-      - name: Cache pnpm store
-        uses: actions/cache@v5
-        with:
-          path: ~/.pnpm-store
-          key: pnpm-store-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            pnpm-store-${{ runner.os }}-
-
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Build frontend
-        run: |
-          pnpm --dir apps/sidecar build
-          pnpm --dir apps/notebook build
-
-      - name: Cache cargo bin
-        uses: actions/cache@v5
-        with:
-          path: ~/.cargo/bin
-          key: cargo-bin-ubuntu-tauri-cli-tauri-driver-${{ hashFiles('rust-toolchain.toml') }}
-          restore-keys: |
-            cargo-bin-ubuntu-tauri-cli-tauri-driver-
-
-      - name: Install tauri-cli and tauri-driver
-        run: |
-          if ! command -v cargo-tauri &> /dev/null || ! command -v tauri-driver &> /dev/null; then
-            cargo install tauri-cli tauri-driver --locked
-          fi
-
-      - name: Download Linux Rust binaries
-        uses: actions/download-artifact@v8
-        with:
-          name: linux-rust-binaries
-          path: .
-
-      - name: Prepare external binaries for E2E jobs
-        run: |
-          mkdir -p target/release/binaries
-          cp crates/notebook/binaries/runtimed-* target/release/binaries/
-          cp crates/notebook/binaries/runt-* target/release/binaries/
-
-      - name: Build Tauri app
-        run: cd crates/notebook && cargo tauri build --ci --no-bundle --config '{"build":{"beforeBuildCommand":""}}'
-
-      - name: Upload E2E artifacts
-        uses: actions/upload-artifact@v7
-        with:
-          name: e2e-app-linux
-          path: |
-            target/release/notebook
-            target/release/binaries/
-          retention-days: 1
-
   # E2E smoke test - verifies basic app functionality
   e2e:
     name: E2E Smoke Test
     runs-on: ubuntu-latest
-    needs: [changes, build-e2e-app]
+    needs: [changes, build-linux]
     if: needs.changes.outputs.source_changed == 'true'
     steps:
       - uses: actions/checkout@v6
@@ -451,17 +399,15 @@ jobs:
           chmod +x target/release/notebook
           chmod +x target/release/binaries/*
 
-      - name: Cache tauri-driver
-        uses: actions/cache@v5
-        with:
-          path: ~/.cargo/bin/tauri-driver
-          key: cargo-bin-tauri-driver-v1-${{ hashFiles('rust-toolchain.toml') }}
-          restore-keys: |
-            cargo-bin-tauri-driver-v1-
-
-      - name: Install tauri-driver
+      - name: Install tauri-driver from artifact
         run: |
-          if ! command -v tauri-driver &> /dev/null; then
+          # tauri-driver is bundled in the e2e-app-linux artifact from build-linux
+          if [ -f ./target/release/binaries/tauri-driver ]; then
+            mkdir -p ~/.cargo/bin
+            cp ./target/release/binaries/tauri-driver ~/.cargo/bin/tauri-driver
+            chmod +x ~/.cargo/bin/tauri-driver
+          else
+            echo "tauri-driver not found in artifact, installing from source"
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
             source ~/.cargo/env
             cargo install tauri-driver --locked
@@ -554,7 +500,7 @@ jobs:
   e2e-fixtures:
     name: E2E Kernel Launch Tests
     runs-on: ubuntu-latest
-    needs: [changes, build-e2e-app, e2e]
+    needs: [changes, build-linux]
     if: needs.changes.outputs.source_changed == 'true'
     steps:
       - uses: actions/checkout@v6
@@ -602,17 +548,14 @@ jobs:
           chmod +x target/release/notebook
           chmod +x target/release/binaries/*
 
-      - name: Cache tauri-driver
-        uses: actions/cache@v5
-        with:
-          path: ~/.cargo/bin/tauri-driver
-          key: cargo-bin-tauri-driver-v1-${{ hashFiles('rust-toolchain.toml') }}
-          restore-keys: |
-            cargo-bin-tauri-driver-v1-
-
-      - name: Install tauri-driver
+      - name: Install tauri-driver from artifact
         run: |
-          if ! command -v tauri-driver &> /dev/null; then
+          if [ -f ./target/release/binaries/tauri-driver ]; then
+            mkdir -p ~/.cargo/bin
+            cp ./target/release/binaries/tauri-driver ~/.cargo/bin/tauri-driver
+            chmod +x ~/.cargo/bin/tauri-driver
+          else
+            echo "tauri-driver not found in artifact, installing from source"
             curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
             source ~/.cargo/env
             cargo install tauri-driver --locked


### PR DESCRIPTION
Three changes to cut ~15-20 min from the CI critical path:

**Eliminate `build-e2e-app` job.** The `build-linux` job already runs `cargo build --release` which compiles everything. Adding `cargo tauri build` after it reuses the warm cache. The separate `build-e2e-app` job was rebuilding the frontend from scratch and recompiling Rust on a cold cache — ~12 min of duplicated work.

**Parallelize E2E tests.** `e2e` and `e2e-fixtures` both only need the artifact from `build-linux`. Previously `e2e-fixtures` waited for `e2e` to finish first (~7-10 min gate).

**Bundle tauri-driver.** Built once in `build-linux`, downloaded by both E2E jobs. No more compiling from source in each job.

```
Before: changes → build-ui → build-linux → build-e2e-app → e2e → e2e-fixtures
After:  changes → build-ui → build-linux → e2e (parallel with e2e-fixtures)
```

_PR submitted by @rgbkrk's agent Quill, via Zed_