### PR TITLE
feat: PEP 723 inline script metadata for notebook dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3665,6 +3665,7 @@ dependencies = [
  "sha2 0.10.9",
  "tempfile",
  "thiserror 1.0.69",
+ "toml 0.8.2",
 ]
 
 [[package]]

--- a/crates/notebook-doc/Cargo.toml
+++ b/crates/notebook-doc/Cargo.toml
@@ -12,6 +12,7 @@ loro_fractional_index = { workspace = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "1"
+toml = "0.8"
 log = { version = "0.4", optional = true }
 sha2 = { version = "0.10", optional = true }
 hex = { version = "0.4", optional = true }

--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -33,6 +33,7 @@
 
 pub mod frame_types;
 pub mod metadata;
+pub mod pep723;
 pub mod presence;
 
 use std::collections::HashMap;

--- a/crates/notebook-doc/src/pep723.rs
+++ b/crates/notebook-doc/src/pep723.rs
@@ -1,0 +1,406 @@
+//! PEP 723 inline script metadata parser.
+//!
+//! Extracts `# /// script` blocks from Python source code per
+//! <https://peps.python.org/pep-0723/>. This module is pure computation
+//! with no I/O — it compiles to WASM, native, and PyO3 targets.
+//!
+//! ## Usage
+//!
+//! ```rust
+//! use notebook_doc::pep723::{find_pep723_in_sources, Pep723Metadata};
+//!
+//! // Scan cell sources for a PEP 723 script block
+//! let sources = vec!["# /// script\n# dependencies = [\"requests\"]\n# ///"];
+//! let meta = find_pep723_in_sources(&sources).unwrap().unwrap();
+//! assert_eq!(meta.dependencies, vec!["requests"]);
+//! ```
+
+use serde::Deserialize;
+
+/// Parsed PEP 723 inline script metadata.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Pep723Metadata {
+    /// PEP 508 dependency specifiers (e.g. `["pandas>=2.0", "numpy"]`).
+    pub dependencies: Vec<String>,
+    /// Python version constraint (e.g. `">=3.11"`).
+    pub requires_python: Option<String>,
+}
+
+/// Error returned when PEP 723 extraction fails.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Pep723Error {
+    /// Multiple `# /// script` blocks found. PEP 723 requires exactly one.
+    DuplicateScriptBlock,
+    /// The TOML content inside the block is malformed.
+    InvalidToml(String),
+}
+
+impl std::fmt::Display for Pep723Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Pep723Error::DuplicateScriptBlock => {
+                write!(
+                    f,
+                    "multiple # /// script blocks found (PEP 723 requires exactly one)"
+                )
+            }
+            Pep723Error::InvalidToml(msg) => write!(f, "invalid TOML in script block: {}", msg),
+        }
+    }
+}
+
+impl std::error::Error for Pep723Error {}
+
+// ── Internal TOML schema ────────────────────────────────────────────────
+
+/// TOML structure inside a `# /// script` block.
+#[derive(Deserialize)]
+struct ScriptToml {
+    #[serde(default)]
+    dependencies: Vec<String>,
+    #[serde(rename = "requires-python")]
+    requires_python: Option<String>,
+}
+
+// ── Block extraction ────────────────────────────────────────────────────
+
+/// Extract the raw TOML content from a `# /// script` block in Python source.
+///
+/// Returns `None` if no block is found. Returns `Err` if multiple blocks
+/// of type `script` are found (per PEP 723 spec, tools MUST error).
+///
+/// The parser is intentionally simple — line-by-line, no regex dependency.
+/// This keeps the WASM binary small.
+fn extract_script_block(source: &str) -> Result<Option<String>, Pep723Error> {
+    let mut found: Option<String> = None;
+    let mut in_block = false;
+    let mut content_lines: Vec<String> = Vec::new();
+
+    for line in source.lines() {
+        if !in_block {
+            // Check for start marker: exactly "# /// script"
+            let trimmed = line.trim_end();
+            if trimmed == "# /// script" {
+                if found.is_some() {
+                    return Err(Pep723Error::DuplicateScriptBlock);
+                }
+                in_block = true;
+                content_lines.clear();
+            }
+        } else {
+            let trimmed = line.trim_end();
+            // Check for end marker: exactly "# ///"
+            if trimmed == "# ///" {
+                in_block = false;
+                found = Some(content_lines.join("\n"));
+                content_lines.clear();
+            } else if let Some(rest) = trimmed.strip_prefix("# ") {
+                // Content line with text: strip "# " prefix
+                content_lines.push(rest.to_string());
+            } else if trimmed == "#" {
+                // Blank content line (lone #)
+                content_lines.push(String::new());
+            } else {
+                // Line doesn't start with # — malformed block, treat as unclosed
+                // Per spec: "If a line does not start with #, the block is not valid"
+                // We abandon this block (unclosed blocks are ignored)
+                in_block = false;
+                content_lines.clear();
+            }
+        }
+    }
+
+    // If we're still in_block at EOF, the block is unclosed → ignore it
+    Ok(found)
+}
+
+// ── Public API ──────────────────────────────────────────────────────────
+
+/// Extract PEP 723 metadata from a single Python source string.
+///
+/// Returns `None` if no `# /// script` block is found.
+pub fn parse_pep723(source: &str) -> Result<Option<Pep723Metadata>, Pep723Error> {
+    let toml_content = match extract_script_block(source)? {
+        Some(content) => content,
+        None => return Ok(None),
+    };
+
+    let script: ScriptToml =
+        toml::from_str(&toml_content).map_err(|e| Pep723Error::InvalidToml(e.to_string()))?;
+
+    Ok(Some(Pep723Metadata {
+        dependencies: script.dependencies,
+        requires_python: script.requires_python,
+    }))
+}
+
+/// Scan multiple cell sources for a PEP 723 `# /// script` block.
+///
+/// Only code cell sources should be passed — markdown/raw cells are the
+/// caller's responsibility to filter.
+///
+/// Returns:
+/// - `Ok(Some(meta))` if exactly one block is found across all cells
+/// - `Ok(None)` if no block is found
+/// - `Err(DuplicateScriptBlock)` if multiple blocks are found (across
+///   cells or within a single cell)
+pub fn find_pep723_in_sources(sources: &[&str]) -> Result<Option<Pep723Metadata>, Pep723Error> {
+    let mut result: Option<Pep723Metadata> = None;
+
+    for source in sources {
+        if let Some(meta) = parse_pep723(source)? {
+            if result.is_some() {
+                return Err(Pep723Error::DuplicateScriptBlock);
+            }
+            result = Some(meta);
+        }
+    }
+
+    Ok(result)
+}
+
+/// Convenience: scan `CellSnapshot` slices from an Automerge doc.
+///
+/// Filters to code cells automatically.
+pub fn find_pep723_in_cells(
+    cells: &[crate::CellSnapshot],
+) -> Result<Option<Pep723Metadata>, Pep723Error> {
+    let sources: Vec<&str> = cells
+        .iter()
+        .filter(|c| c.cell_type == "code")
+        .map(|c| c.source.as_str())
+        .collect();
+
+    find_pep723_in_sources(&sources)
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_basic_extraction() {
+        let source = r#"# /// script
+# dependencies = ["requests", "rich"]
+# requires-python = ">=3.11"
+# ///"#;
+
+        let meta = parse_pep723(source).unwrap().unwrap();
+        assert_eq!(meta.dependencies, vec!["requests", "rich"]);
+        assert_eq!(meta.requires_python, Some(">=3.11".to_string()));
+    }
+
+    #[test]
+    fn test_no_block() {
+        let source = "print('hello')\nx = 1 + 2\n";
+        assert_eq!(parse_pep723(source).unwrap(), None);
+    }
+
+    #[test]
+    fn test_empty_dependencies() {
+        let source = "# /// script\n# dependencies = []\n# ///\n";
+        let meta = parse_pep723(source).unwrap().unwrap();
+        assert!(meta.dependencies.is_empty());
+        assert_eq!(meta.requires_python, None);
+    }
+
+    #[test]
+    fn test_deps_only_no_requires_python() {
+        let source = "# /// script\n# dependencies = [\"httpx\"]\n# ///";
+        let meta = parse_pep723(source).unwrap().unwrap();
+        assert_eq!(meta.dependencies, vec!["httpx"]);
+        assert_eq!(meta.requires_python, None);
+    }
+
+    #[test]
+    fn test_block_with_surrounding_code() {
+        let source = r#"import os
+
+# /// script
+# dependencies = ["pandas>=2.0"]
+# ///
+
+print(os.getcwd())"#;
+
+        let meta = parse_pep723(source).unwrap().unwrap();
+        assert_eq!(meta.dependencies, vec!["pandas>=2.0"]);
+    }
+
+    #[test]
+    fn test_duplicate_blocks_in_single_source() {
+        let source = "# /// script\n# dependencies = [\"a\"]\n# ///\n# /// script\n# dependencies = [\"b\"]\n# ///\n";
+        let err = parse_pep723(source).unwrap_err();
+        assert_eq!(err, Pep723Error::DuplicateScriptBlock);
+    }
+
+    #[test]
+    fn test_duplicate_blocks_across_cells() {
+        let cell1 = "# /// script\n# dependencies = [\"a\"]\n# ///";
+        let cell2 = "# /// script\n# dependencies = [\"b\"]\n# ///";
+        let err = find_pep723_in_sources(&[cell1, cell2]).unwrap_err();
+        assert_eq!(err, Pep723Error::DuplicateScriptBlock);
+    }
+
+    #[test]
+    fn test_unclosed_block_ignored() {
+        let _source = "# /// script\n# dependencies = [\"a\"]\n# no closing marker\n";
+        // Unclosed block — the non-comment line breaks the block, then EOF
+        // Actually this line starts with #, so it's still in the block.
+        // Let's use a truly unclosed block (EOF without # ///):
+        let source2 = "# /// script\n# dependencies = [\"a\"]\n";
+        assert_eq!(parse_pep723(source2).unwrap(), None);
+    }
+
+    #[test]
+    fn test_non_comment_line_breaks_block() {
+        // A line that doesn't start with # inside a block makes it invalid
+        let source = "# /// script\n# dependencies = [\"a\"]\nprint('oops')\n# ///\n";
+        assert_eq!(parse_pep723(source).unwrap(), None);
+    }
+
+    #[test]
+    fn test_blank_lines_in_toml() {
+        let source = "# /// script\n# dependencies = [\n#   \"requests\",\n#   \"rich\",\n# ]\n#\n# requires-python = \">=3.11\"\n# ///";
+        let meta = parse_pep723(source).unwrap().unwrap();
+        assert_eq!(meta.dependencies, vec!["requests", "rich"]);
+        assert_eq!(meta.requires_python, Some(">=3.11".to_string()));
+    }
+
+    #[test]
+    fn test_non_script_type_ignored() {
+        // A block with a different type name should be ignored
+        let source = "# /// something-else\n# key = \"value\"\n# ///\n";
+        assert_eq!(parse_pep723(source).unwrap(), None);
+    }
+
+    #[test]
+    fn test_invalid_toml() {
+        let source = "# /// script\n# this is not valid toml {{{\n# ///";
+        let err = parse_pep723(source).unwrap_err();
+        assert!(matches!(err, Pep723Error::InvalidToml(_)));
+    }
+
+    #[test]
+    fn test_multiline_deps_with_version_specs() {
+        let source = r#"# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#   "requests<3",
+#   "rich>=13.0",
+#   "click~=8.0",
+# ]
+# ///"#;
+
+        let meta = parse_pep723(source).unwrap().unwrap();
+        assert_eq!(
+            meta.dependencies,
+            vec!["requests<3", "rich>=13.0", "click~=8.0"]
+        );
+        assert_eq!(meta.requires_python, Some(">=3.10".to_string()));
+    }
+
+    #[test]
+    fn test_tool_section_ignored() {
+        // [tool] is valid PEP 723 TOML but we don't parse it
+        let source =
+            "# /// script\n# dependencies = [\"httpx\"]\n# [tool.ruff]\n# line-length = 88\n# ///";
+        let meta = parse_pep723(source).unwrap().unwrap();
+        assert_eq!(meta.dependencies, vec!["httpx"]);
+    }
+
+    /// Helper to build a CellSnapshot for tests without boilerplate.
+    fn cell(id: &str, cell_type: &str, source: &str, position: &str) -> crate::CellSnapshot {
+        crate::CellSnapshot {
+            id: id.to_string(),
+            cell_type: cell_type.to_string(),
+            source: source.to_string(),
+            position: position.to_string(),
+            execution_count: "null".to_string(),
+            outputs: vec![],
+            metadata: serde_json::json!({}),
+            resolved_assets: std::collections::HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn test_find_in_cells() {
+        let cells = vec![
+            cell(
+                "1",
+                "code",
+                "# /// script\n# dependencies = [\"httpx\"]\n# ///",
+                "a",
+            ),
+            cell("2", "code", "print('hello')", "b"),
+        ];
+
+        let meta = find_pep723_in_cells(&cells).unwrap().unwrap();
+        assert_eq!(meta.dependencies, vec!["httpx"]);
+    }
+
+    #[test]
+    fn test_markdown_cells_skipped() {
+        let cells = vec![
+            cell(
+                "1",
+                "markdown",
+                "# /// script\n# dependencies = [\"httpx\"]\n# ///",
+                "a",
+            ),
+            cell("2", "code", "print('hello')", "b"),
+        ];
+
+        assert_eq!(find_pep723_in_cells(&cells).unwrap(), None);
+    }
+
+    #[test]
+    fn test_juv_style_hidden_cell() {
+        // juv convention: first code cell with source_hidden metadata
+        // We don't care about the metadata — just the source content
+        let source = "# /// script\n# requires-python = \">=3.11\"\n# dependencies = [\n#   \"requests<3\",\n#   \"rich\",\n# ]\n# ///";
+
+        let cells = vec![
+            cell("meta", "code", source, "a"),
+            cell(
+                "work",
+                "code",
+                "import requests\nprint(requests.get('https://example.com').status_code)",
+                "b",
+            ),
+        ];
+
+        let meta = find_pep723_in_cells(&cells).unwrap().unwrap();
+        assert_eq!(meta.dependencies, vec!["requests<3", "rich"]);
+        assert_eq!(meta.requires_python, Some(">=3.11".to_string()));
+    }
+
+    #[test]
+    fn test_empty_source() {
+        assert_eq!(parse_pep723("").unwrap(), None);
+    }
+
+    #[test]
+    fn test_only_start_marker() {
+        // Just the start marker, no end — unclosed, ignored
+        assert_eq!(parse_pep723("# /// script").unwrap(), None);
+    }
+
+    #[test]
+    fn test_empty_block() {
+        // Valid block with no content — empty TOML
+        let source = "# /// script\n# ///";
+        let meta = parse_pep723(source).unwrap().unwrap();
+        assert!(meta.dependencies.is_empty());
+        assert_eq!(meta.requires_python, None);
+    }
+
+    #[test]
+    fn test_trailing_whitespace_on_markers() {
+        // Markers with trailing spaces should still match (we trim_end)
+        let source = "# /// script   \n# dependencies = [\"a\"]\n# ///  \n";
+        let meta = parse_pep723(source).unwrap().unwrap();
+        assert_eq!(meta.dependencies, vec!["a"]);
+    }
+}

--- a/crates/notebook/fixtures/audit-test/13-pep723.ipynb
+++ b/crates/notebook/fixtures/audit-test/13-pep723.ipynb
@@ -1,0 +1,43 @@
+{
+ "metadata": {
+  "kernelspec": {
+   "name": "python3",
+   "display_name": "Python 3",
+   "language": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "cells": [
+  {
+   "cell_type": "code",
+   "id": "pep723-meta",
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    }
+   },
+   "source": [
+    "# /// script\n",
+    "# requires-python = \">=3.11\"\n",
+    "# dependencies = [\n",
+    "#   \"httpx\",\n",
+    "# ]\n",
+    "# ///"
+   ],
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "cell_type": "code",
+   "id": "work-cell",
+   "metadata": {},
+   "source": [
+    "import httpx\n",
+    "print(httpx.__version__)"
+   ],
+   "outputs": [],
+   "execution_count": null
+  }
+ ]
+}

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -129,7 +129,7 @@ fn build_launched_config(
     let mut config = LaunchedEnvConfig::default();
 
     match env_source {
-        "uv:inline" => {
+        "uv:inline" | "uv:pep723" => {
             config.uv_deps = inline_deps.map(|d| d.to_vec());
             config.venv_path = venv_path;
             config.python_path = python_path;
@@ -1485,6 +1485,27 @@ async fn auto_launch_kernel(
     // Step 2: Check inline deps (for environment source, and runt.deno override)
     let inline_source = metadata_snapshot.as_ref().and_then(check_inline_deps);
 
+    // Step 2b: If no metadata inline deps, check cell source for PEP 723 script blocks
+    let (inline_source, pep723_deps) = if inline_source.is_some() {
+        (inline_source, None)
+    } else {
+        let cells = room.doc.read().await.get_cells();
+        match notebook_doc::pep723::find_pep723_in_cells(&cells) {
+            Ok(Some(meta)) if !meta.dependencies.is_empty() => {
+                info!(
+                    "[notebook-sync] Auto-launch: found PEP 723 deps: {:?}",
+                    meta.dependencies
+                );
+                (Some("uv:pep723".to_string()), Some(meta.dependencies))
+            }
+            Ok(_) => (None, None),
+            Err(e) => {
+                warn!("[notebook-sync] PEP 723 parse error: {}", e);
+                (None, None)
+            }
+        }
+    };
+
     // Step 3: Check project files (for Python environment resolution)
     // Use notebook path for saved notebooks, or working_dir for untitled notebooks
     let detection_path = notebook_path_opt
@@ -1548,10 +1569,11 @@ async fn auto_launch_kernel(
                 );
                 prewarmed.to_string()
             };
-            // For uv:inline, uv:pyproject, and conda:inline we don't need a pooled env -
+            // For uv:inline, uv:pep723, uv:pyproject, and conda:inline we don't need a pooled env -
             // these sources prepare their own environments
             let pooled_env = if env_source == "uv:pyproject"
                 || env_source == "uv:inline"
+                || env_source == "uv:pep723"
                 || env_source == "conda:inline"
             {
                 info!(
@@ -1602,10 +1624,11 @@ async fn auto_launch_kernel(
                     );
                     prewarmed.to_string()
                 };
-                // For uv:inline, uv:pyproject, and conda:inline we don't need a pooled env -
+                // For uv:inline, uv:pep723, uv:pyproject, and conda:inline we don't need a pooled env -
                 // these sources prepare their own environments
                 let pooled_env = if env_source == "uv:pyproject"
                     || env_source == "uv:inline"
+                    || env_source == "uv:pep723"
                     || env_source == "conda:inline"
                 {
                     info!(
@@ -1645,7 +1668,41 @@ async fn auto_launch_kernel(
         crate::inline_env::BroadcastProgressHandler::new(room.kernel_broadcast_tx.clone()),
     );
 
-    let (pooled_env, inline_deps) = if env_source == "uv:inline" {
+    let (pooled_env, inline_deps) = if env_source == "uv:pep723" {
+        // PEP 723 deps were extracted from cell source in step 2b
+        if let Some(ref deps) = pep723_deps {
+            info!(
+                "[notebook-sync] Preparing cached UV env for PEP 723 deps: {:?}",
+                deps
+            );
+            match crate::inline_env::prepare_uv_inline_env(deps, progress_handler.clone()).await {
+                Ok(prepared) => {
+                    info!(
+                        "[notebook-sync] Using cached PEP 723 env at {:?}",
+                        prepared.python_path
+                    );
+                    let env = Some(crate::PooledEnv {
+                        env_type: crate::EnvType::Uv,
+                        venv_path: prepared.env_path,
+                        python_path: prepared.python_path,
+                    });
+                    (env, Some(deps.clone()))
+                }
+                Err(e) => {
+                    error!("[notebook-sync] Failed to prepare PEP 723 env: {}", e);
+                    let _ = room
+                        .kernel_broadcast_tx
+                        .send(NotebookBroadcast::KernelStatus {
+                            status: format!("error: Failed to prepare environment: {}", e),
+                            cell_id: None,
+                        });
+                    return;
+                }
+            }
+        } else {
+            (None, None)
+        }
+    } else if env_source == "uv:inline" {
         if let Some(deps) = metadata_snapshot.as_ref().and_then(get_inline_uv_deps) {
             info!(
                 "[notebook-sync] Preparing cached UV env for inline deps: {:?}",
@@ -1911,7 +1968,25 @@ async fn handle_notebook_request(
                     );
                     inline_source
                 }
-                // Priority 2: Detect project files near notebook path
+                // Priority 2: Check PEP 723 script blocks in cell source
+                else if {
+                    let cells = room.doc.read().await.get_cells();
+                    match notebook_doc::pep723::find_pep723_in_cells(&cells) {
+                        Ok(Some(ref m)) if !m.dependencies.is_empty() => true,
+                        Ok(_) => false,
+                        Err(e) => {
+                            warn!(
+                                "[notebook-sync] Failed to parse PEP 723 script blocks: {}",
+                                e
+                            );
+                            false
+                        }
+                    }
+                } {
+                    info!("[notebook-sync] Found PEP 723 deps in cell source");
+                    "uv:pep723".to_string()
+                }
+                // Priority 3: Detect project files near notebook path
                 else if let Some(detected) = notebook_path
                     .as_ref()
                     .and_then(|path| crate::project_file::detect_project_file(path))
@@ -1923,7 +1998,7 @@ async fn handle_notebook_request(
                     );
                     detected.to_env_source().to_string()
                 }
-                // Priority 3: Fall back to prewarmed
+                // Priority 4: Fall back to prewarmed
                 else {
                     info!("[notebook-sync] No project file detected, using prewarmed");
                     "uv:prewarmed".to_string()
@@ -1968,7 +2043,7 @@ async fn handle_notebook_request(
                             };
                         }
                     },
-                    "uv:pyproject" | "uv:inline" | "conda:inline" => {
+                    "uv:pyproject" | "uv:inline" | "uv:pep723" | "conda:inline" => {
                         // These sources prepare their own environments, no pooled env needed
                         info!(
                             "[notebook-sync] LaunchKernel: {} prepares its own env, no pool env",
@@ -2008,7 +2083,60 @@ async fn handle_notebook_request(
                     room.kernel_broadcast_tx.clone(),
                 ));
 
-            let (pooled_env, inline_deps) = if resolved_env_source == "uv:inline" {
+            let (pooled_env, inline_deps) = if resolved_env_source == "uv:pep723" {
+                // Extract PEP 723 deps from cell source
+                let cells = room.doc.read().await.get_cells();
+                let pep723_deps = match notebook_doc::pep723::find_pep723_in_cells(&cells) {
+                    Ok(Some(m)) if !m.dependencies.is_empty() => Some(m.dependencies),
+                    Ok(_) => None,
+                    Err(e) => {
+                        error!(
+                            "[notebook-sync] Invalid PEP 723 metadata in notebook: {}",
+                            e
+                        );
+                        return NotebookResponse::Error {
+                            error: format!("Invalid PEP 723 metadata in notebook: {}", e),
+                        };
+                    }
+                };
+
+                if let Some(deps) = pep723_deps {
+                    info!(
+                        "[notebook-sync] LaunchKernel: Preparing cached UV env for PEP 723 deps: {:?}",
+                        deps
+                    );
+                    match crate::inline_env::prepare_uv_inline_env(
+                        &deps,
+                        launch_progress_handler.clone(),
+                    )
+                    .await
+                    {
+                        Ok(prepared) => {
+                            info!(
+                                "[notebook-sync] LaunchKernel: Using cached PEP 723 env at {:?}",
+                                prepared.python_path
+                            );
+                            let env = Some(crate::PooledEnv {
+                                env_type: crate::EnvType::Uv,
+                                venv_path: prepared.env_path,
+                                python_path: prepared.python_path,
+                            });
+                            (env, Some(deps))
+                        }
+                        Err(e) => {
+                            error!("[notebook-sync] Failed to prepare PEP 723 env: {}", e);
+                            return NotebookResponse::Error {
+                                error: format!("Failed to prepare PEP 723 environment: {}", e),
+                            };
+                        }
+                    }
+                } else {
+                    return NotebookResponse::Error {
+                        error: "No PEP 723 dependencies found in notebook cells for requested env_source \"uv:pep723\""
+                            .to_string(),
+                    };
+                }
+            } else if resolved_env_source == "uv:inline" {
                 if let Some(deps) = metadata_snapshot.as_ref().and_then(get_inline_uv_deps) {
                     info!(
                         "[notebook-sync] LaunchKernel: Preparing cached UV env for inline deps: {:?}",

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -1960,52 +1960,56 @@ async fn handle_notebook_request(
             } else if env_source == "auto" || env_source.is_empty() || env_source == "prewarmed" {
                 // Auto-detect Python environment
 
-                // Check PEP 723 deps upfront (for priority 2)
-                let has_pep723_deps = {
-                    let cells = room.doc.read().await.get_cells();
-                    match notebook_doc::pep723::find_pep723_in_cells(&cells) {
-                        Ok(Some(ref m)) if !m.dependencies.is_empty() => true,
-                        Ok(_) => false,
-                        Err(e) => {
-                            warn!(
-                                "[notebook-sync] Failed to parse PEP 723 script blocks: {}",
-                                e
-                            );
-                            false
-                        }
-                    }
-                };
-
-                // Priority 1: Check inline deps in notebook metadata
-                if let Some(inline_source) = metadata_snapshot.as_ref().and_then(check_inline_deps)
+                // Priority 1: Check inline deps in notebook metadata (filter out "deno" - we're resolving Python env)
+                if let Some(inline_source) = metadata_snapshot
+                    .as_ref()
+                    .and_then(check_inline_deps)
+                    .filter(|s| s != "deno")
                 {
                     info!(
                         "[notebook-sync] Found inline deps in notebook metadata -> {}",
                         inline_source
                     );
                     inline_source
-                }
-                // Priority 2: Check PEP 723 script blocks in cell source
-                else if has_pep723_deps {
-                    info!("[notebook-sync] Found PEP 723 deps in cell source");
-                    "uv:pep723".to_string()
-                }
-                // Priority 3: Detect project files near notebook path
-                else if let Some(detected) = notebook_path
-                    .as_ref()
-                    .and_then(|path| crate::project_file::detect_project_file(path))
-                {
-                    info!(
-                        "[notebook-sync] Auto-detected project file: {:?} -> {}",
-                        detected.path,
-                        detected.to_env_source()
-                    );
-                    detected.to_env_source().to_string()
-                }
-                // Priority 4: Fall back to prewarmed
-                else {
-                    info!("[notebook-sync] No project file detected, using prewarmed");
-                    "uv:prewarmed".to_string()
+                } else {
+                    // Priority 2: Check PEP 723 script blocks in cell source
+                    // Only parsed if metadata check above didn't find inline deps (lazy evaluation).
+                    let has_pep723_deps = {
+                        let cells = room.doc.read().await.get_cells();
+                        match notebook_doc::pep723::find_pep723_in_cells(&cells) {
+                            Ok(Some(ref m)) if !m.dependencies.is_empty() => true,
+                            Ok(_) => false,
+                            Err(e) => {
+                                warn!(
+                                    "[notebook-sync] Failed to parse PEP 723 script blocks: {}",
+                                    e
+                                );
+                                false
+                            }
+                        }
+                    };
+
+                    if has_pep723_deps {
+                        info!("[notebook-sync] Found PEP 723 deps in cell source");
+                        "uv:pep723".to_string()
+                    }
+                    // Priority 3: Detect project files near notebook path
+                    else if let Some(detected) = notebook_path
+                        .as_ref()
+                        .and_then(|path| crate::project_file::detect_project_file(path))
+                    {
+                        info!(
+                            "[notebook-sync] Auto-detected project file: {:?} -> {}",
+                            detected.path,
+                            detected.to_env_source()
+                        );
+                        detected.to_env_source().to_string()
+                    }
+                    // Priority 4: Fall back to prewarmed
+                    else {
+                        info!("[notebook-sync] No project file detected, using prewarmed");
+                        "uv:prewarmed".to_string()
+                    }
                 }
             } else {
                 // Use explicit env_source (e.g., "uv:inline", "conda:inline")

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -1959,17 +1959,9 @@ async fn handle_notebook_request(
                 "deno".to_string()
             } else if env_source == "auto" || env_source.is_empty() || env_source == "prewarmed" {
                 // Auto-detect Python environment
-                // Priority 1: Check inline deps in notebook metadata
-                if let Some(inline_source) = metadata_snapshot.as_ref().and_then(check_inline_deps)
-                {
-                    info!(
-                        "[notebook-sync] Found inline deps in notebook metadata -> {}",
-                        inline_source
-                    );
-                    inline_source
-                }
-                // Priority 2: Check PEP 723 script blocks in cell source
-                else if {
+
+                // Check PEP 723 deps upfront (for priority 2)
+                let has_pep723_deps = {
                     let cells = room.doc.read().await.get_cells();
                     match notebook_doc::pep723::find_pep723_in_cells(&cells) {
                         Ok(Some(ref m)) if !m.dependencies.is_empty() => true,
@@ -1982,7 +1974,19 @@ async fn handle_notebook_request(
                             false
                         }
                     }
-                } {
+                };
+
+                // Priority 1: Check inline deps in notebook metadata
+                if let Some(inline_source) = metadata_snapshot.as_ref().and_then(check_inline_deps)
+                {
+                    info!(
+                        "[notebook-sync] Found inline deps in notebook metadata -> {}",
+                        inline_source
+                    );
+                    inline_source
+                }
+                // Priority 2: Check PEP 723 script blocks in cell source
+                else if has_pep723_deps {
                     info!("[notebook-sync] Found PEP 723 deps in cell source");
                     "uv:pep723".to_string()
                 }


### PR DESCRIPTION
Support reading [PEP 723](https://peps.python.org/pep-0723/) inline script metadata (`# /// script` blocks) as a dependency source for notebooks. This is the format [juv](https://github.com/manzt/juv) uses.

**Parser** (`crates/notebook-doc/src/pep723.rs`) — Pure computation, no I/O. Line-by-line extraction of `# /// script` blocks, TOML parsing for `dependencies` and `requires-python`. Errors on duplicate blocks per spec. 21 unit tests + 1 doctest.

**Daemon integration** — PEP 723 slots into the detection chain after metadata inline deps but before project files. Scans code cells, feeds extracted deps into the existing `prepare_uv_inline_env` pipeline. New `env_source` label: `uv:pep723`.

**Fixture** — `13-pep723.ipynb` with a juv-style hidden cell declaring httpx.

### What works

Open a notebook with a `# /// script` block → daemon detects deps → creates cached UV environment → kernel launches with those deps available. `uv run notebook.ipynb` and `juv` interop.

### What's deferred

- **Trust**: PEP 723 deps live in cell source, not metadata. The current trust system only signs `metadata.runt.uv` / `metadata.runt.conda`, so PEP 723 notebooks bypass the trust dialog. Fine for notebooks you create yourself; gap for shared notebooks. Needs its own design.
- **Frontend display**: `useDependencies` doesn't recognize `uv:pep723` yet. The dep panel won't show PEP 723 deps.
- **Writing PEP 723**: The dep panel continues to write `metadata.runt.uv`. No migration.
- **Restart on edit**: If the user edits the `# /// script` cell, the kernel doesn't automatically restart with updated deps.

Closes #670

_PR submitted by @rgbkrk's agent Quill, via Zed_