### PR TITLE
docs: update references for unified frame pipe

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -222,7 +222,7 @@ The **Tauri relay** (`NotebookSyncClient` in `crates/runtimed/src/notebook_sync_
 
 Cells are stored in an Automerge Map keyed by cell ID, with a `position` field (fractional index hex string) for ordering. `move_cell` updates only the position field — no delete/re-insert. `get_cells()` returns cells sorted by position with cell ID as tiebreaker.
 
-Mutation flow: React → WASM `handle.add_cell_after()` → `handle.generate_sync_message()` → prepend `0x00` type byte → `invoke("send_frame")` → relay pipe → daemon.
+Mutation flow: React → WASM `handle.add_cell_after()` → `handle.generate_sync_message()` → prepend `0x00` type byte → `invoke("send_frame", { frameData })` → relay pipe → daemon.
 
 Incoming sync: daemon → relay pipe → `notebook:frame` event → WASM `handle.receive_frame()` → demux by type byte → `materializeCells()` → React state. Broadcasts and presence are re-emitted as `notebook:broadcast` and `notebook:presence` webview events for downstream hooks.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -222,9 +222,9 @@ The **Tauri relay** (`NotebookSyncClient` in `crates/runtimed/src/notebook_sync_
 
 Cells are stored in an Automerge Map keyed by cell ID, with a `position` field (fractional index hex string) for ordering. `move_cell` updates only the position field — no delete/re-insert. `get_cells()` returns cells sorted by position with cell ID as tiebreaker.
 
-Mutation flow: React → WASM `handle.add_cell_after()` → `handle.generate_sync_message()` → `invoke("send_automerge_sync")` → relay pipe → daemon.
+Mutation flow: React → WASM `handle.add_cell_after()` → `handle.generate_sync_message()` → prepend `0x00` type byte → `invoke("send_frame")` → relay pipe → daemon.
 
-Incoming sync: daemon → relay pipe → `automerge:from-daemon` event → WASM `handle.receive_sync_message()` → `materializeCells()` → React state.
+Incoming sync: daemon → relay pipe → `notebook:frame` event → WASM `handle.receive_frame()` → demux by type byte → `materializeCells()` → React state. Broadcasts and presence are re-emitted as `notebook:broadcast` and `notebook:presence` webview events for downstream hooks.
 
 The `runtimed-wasm` crate compiles from the same `automerge = "0.7"` as the daemon. This is critical — the JS `@automerge/automerge` package creates `Object(Text)` CRDTs for all string fields, but Rust uses scalar `Str` for metadata fields (`id`, `cell_type`, `execution_count`). Using the same Rust code in WASM guarantees schema compatibility.
 
@@ -264,7 +264,7 @@ Deno kernels don't use environment pools. The daemon:
 
 ### Environment Source Labels
 
-The backend returns an `env_source` string with the `KernelLaunched` response (via `daemon:broadcast`) so the frontend can display the environment origin. Values:
+The backend returns an `env_source` string with the `KernelLaunched` response (via `notebook:broadcast`) so the frontend can display the environment origin.
 
 - `"uv:inline"` / `"uv:pyproject"` / `"uv:prewarmed"`
 - `"conda:inline"` / `"conda:env_yml"` / `"conda:pixi"` / `"conda:prewarmed"`

--- a/contributing/architecture.md
+++ b/contributing/architecture.md
@@ -9,7 +9,7 @@ This document defines the core architectural principles for the runtimed daemon 
 The runtimed daemon owns all runtime state. Clients (UI, agents, CLI) are views into daemon state, not independent state holders.
 
 **Implications:**
-- Clients subscribe to daemon state, they don't maintain parallel copies
+- Clients subscribe to daemon state via Automerge sync. The frontend maintains a local WASM doc for instant editing, but the daemon's doc is authoritative for execution and persistence
 - State changes flow through the daemon, not peer-to-peer between clients
 - If the daemon restarts, clients reconnect and resync
 
@@ -98,14 +98,15 @@ The principle of "automerge as canonical state" is violated when execution reque
 ```
 Client                              Daemon
   |                                   |
-  |-- [sync: update cell source] ---->|
-  |<-- [sync: ack] -------------------|
+  |-- [WASM mutates local doc] -------|  // Instant, no round-trip
+  |-- [sync frame 0x00] ------------>|  // invoke("send_frame")
+  |<-- [sync frame 0x00] ------------|  // "notebook:frame" event
   |                                   |
   |-- ExecuteCell { cell_id } ------->|  // No code parameter
   |<-- CellQueued --------------------|
   |                                   |
-  |<-- ExecutionStarted --------------|
-  |<-- Output -------------------------|
+  |<-- ExecutionStarted --------------|  // broadcast via notebook:frame
+  |<-- Output -------------------------|  // broadcast via notebook:frame
   |<-- ExecutionDone -----------------|
 ```
 
@@ -149,3 +150,8 @@ The frontend now owns a local Automerge doc via `runtimed-wasm` WASM bindings, m
 - `crates/notebook-doc/src/lib.rs` - Shared Automerge document operations (`NotebookDoc`) used by daemon and WASM
 - `crates/runtimed/src/notebook_sync_server.rs` - Sync protocol handling
 - `crates/runtimed/src/kernel_manager.rs` - Kernel lifecycle
+- `crates/runtimed/src/notebook_sync_client.rs` - Tauri relay: transparent byte pipe between WASM and daemon (`PipeChannel`)
+- `crates/runtimed-wasm/src/lib.rs` - WASM bindings: local Automerge peer, frame demux (`receive_frame`)
+- `crates/notebook/src/lib.rs` - Tauri commands and relay tasks (`send_frame`, `setup_sync_receivers`)
+- `crates/notebook-doc/src/frame_types.rs` - Shared frame type constants (0x00–0x04)
+- `apps/notebook/src/hooks/useAutomergeNotebook.ts` - Frontend sync hub: WASM handle, `notebook:frame` listener, cell materialization

--- a/contributing/environments.md
+++ b/contributing/environments.md
@@ -129,8 +129,8 @@ graph TB
     UCD -->|"invoke(detect_pixi_toml)"| DETP
 
     %% Daemon broadcasts back to frontend
-    NSS -.->|"daemon:broadcast {KernelLaunched, env_source}"| UDK
-    KM -.->|"daemon:broadcast {KernelStatus, ExecutionStarted, ExecutionDone}"| UDK
+    NSS -.->|"notebook:broadcast {KernelLaunched, env_source}"| UDK
+    KM -.->|"notebook:broadcast {KernelStatus, ExecutionStarted, ExecutionDone}"| UDK
     VNT -.->|trust status| UD
 
     %% Environment creation → external tools
@@ -210,7 +210,7 @@ sequenceDiagram
     KM-->>DM: Kernel ready
 
     DM-->>TC: KernelLaunched response
-    TC-->>FE: daemon:broadcast {KernelLaunched, env_source}
+    TC-->>FE: notebook:broadcast {KernelLaunched, env_source}
 ```
 
 ### Daemon Pool Architecture
@@ -295,7 +295,7 @@ graph TB
 
 The diagrams show two main layers:
 
-1. **Frontend** (blue) — React hooks that invoke Tauri commands and listen for `daemon:broadcast` events (kernel status, execution lifecycle) and `automerge:from-daemon` events (document state including outputs via Automerge sync). `useDaemonKernel.ts` handles kernel lifecycle via the daemon. The daemon sends `Output` broadcasts and `useDaemonKernel.ts` processes them (blob resolution), but the `onOutput` rendering callback is a no-op — output **rendering** is driven by Automerge sync (`materializeCells`).
+1. **Frontend** (blue) — React hooks that invoke Tauri commands and listen for `notebook:broadcast` events (kernel status, execution lifecycle) and `notebook:frame` events (document state including outputs via Automerge sync, demuxed by WASM). `useDaemonKernel.ts` handles kernel lifecycle via the daemon. The daemon sends `Output` broadcasts and `useDaemonKernel.ts` processes them (blob resolution), but the `onOutput` rendering callback is a no-op — output **rendering** is driven by Automerge sync (`materializeCells`).
 
 2. **runtimed Daemon** (indigo) — A singleton background process that owns kernel processes and manages prewarmed UV and Conda environment pools. The daemon runs the detection priority chain: inline deps first, then closest project file, then prewarmed pool. Communicates via length-prefixed JSON over Unix domain sockets (or Windows named pipes). Also runs an Automerge CRDT sync server for cross-window settings and notebook state.
 
@@ -470,7 +470,7 @@ Three UI components manage dependencies for different runtimes:
 | `DenoDependencyHeader.tsx` | — | Deno configuration and deno.json detection |
 
 The kernel lifecycle is managed by `useDaemonKernel.ts`, which:
-- Listens for `daemon:broadcast` events from the backend
+- Listens for `notebook:broadcast` events (re-emitted by `useAutomergeNotebook` after WASM frame demux)
 - Captures the `env_source` string (e.g. `"uv:pyproject"`, `"conda:pixi"`) from `KernelLaunched` responses
 - Tracks kernel status and execution queue
 - Provides `launchKernel()`, `executeCell()`, `syncEnvironment()` methods

--- a/contributing/environments.md
+++ b/contributing/environments.md
@@ -128,9 +128,9 @@ graph TB
     UD -->|"invoke(detect_pyproject)"| DETP
     UCD -->|"invoke(detect_pixi_toml)"| DETP
 
-    %% Daemon broadcasts back to frontend
-    NSS -.->|"notebook:broadcast {KernelLaunched, env_source}"| UDK
-    KM -.->|"notebook:broadcast {KernelStatus, ExecutionStarted, ExecutionDone}"| UDK
+    %% Daemon → relay → frontend (notebook:frame, re-emitted as notebook:broadcast after WASM demux)
+    NSS -.->|"notebook:frame → notebook:broadcast {KernelLaunched, env_source}"| UDK
+    KM -.->|"notebook:frame → notebook:broadcast {KernelStatus, ExecutionStarted, ExecutionDone}"| UDK
     VNT -.->|trust status| UD
 
     %% Environment creation → external tools
@@ -210,7 +210,8 @@ sequenceDiagram
     KM-->>DM: Kernel ready
 
     DM-->>TC: KernelLaunched response
-    TC-->>FE: notebook:broadcast {KernelLaunched, env_source}
+    TC-->>FE: notebook:frame {type 0x03, KernelLaunched, env_source}
+    FE->>FE: notebook:broadcast {KernelLaunched, env_source} (after WASM receive_frame() demux)
 ```
 
 ### Daemon Pool Architecture

--- a/contributing/frontend-architecture.md
+++ b/contributing/frontend-architecture.md
@@ -148,7 +148,7 @@ Security boundary for untrusted HTML/widget outputs. See [iframe-isolation.md](i
 3. **useDaemonKernel / useEnvProgress** — Consume `notebook:broadcast` events for kernel status, outputs, and environment progress
 4. **usePresence** — Consumes `notebook:presence` events for remote cursor/selection state
 
-Cell mutations (add, delete, edit) go through the WASM handle for instant response, then sync to the daemon via `invoke("send_frame")`. Execution requests go to the daemon via dedicated Tauri commands.
+Cell mutations (add, delete, edit) go through the WASM handle for instant response, then sync to the daemon via `invoke("send_frame", { frameData })` where `frameData` includes the type byte prefix. Execution requests go to the daemon via dedicated Tauri commands.
 
 ## Key Files
 

--- a/contributing/frontend-architecture.md
+++ b/contributing/frontend-architecture.md
@@ -104,6 +104,8 @@ Security boundary for untrusted HTML/widget outputs. See [iframe-isolation.md](i
 |------|------|
 | `useAutomergeNotebook` | Owns WASM NotebookHandle, drives cell state |
 | `useDaemonKernel` | Kernel execution, status broadcasts |
+| `usePresence` | Remote cursor/selection tracking via presence frames |
+| `useEnvProgress` | Environment setup progress tracking |
 | `useDependencies` | UV dependency management |
 | `useCondaDependencies` | Conda dependency management |
 | `useManifestResolver` | Resolves blob hashes to output data |
@@ -115,33 +117,38 @@ Security boundary for untrusted HTML/widget outputs. See [iframe-isolation.md](i
 ┌─────────────────────────────────────────────────────────────────┐
 │ Frontend                                                        │
 │                                                                 │
-│  ┌──────────────┐    sync     ┌──────────────────┐             │
-│  │ NotebookHandle│◄──────────►│ Daemon           │             │
-│  │ (WASM)       │             │ (notebook room)  │             │
-│  └──────┬───────┘             └────────┬─────────┘             │
-│         │                              │                        │
-│         │ get_cells_json()             │ kernel broadcasts      │
-│         ▼                              ▼                        │
-│  ┌──────────────┐             ┌──────────────────┐             │
-│  │ materialize- │             │ useDaemonKernel  │             │
-│  │ Cells()      │             │                  │             │
-│  └──────┬───────┘             └────────┬─────────┘             │
-│         │                              │                        │
-│         │ NotebookCell[]               │ outputs, status        │
-│         ▼                              ▼                        │
-│  ┌─────────────────────────────────────────────────┐           │
-│  │ React Components                                 │           │
-│  │ (CellContainer → CodeCell/MarkdownCell → Outputs)│           │
-│  └─────────────────────────────────────────────────┘           │
+│  Tauri relay ── "notebook:frame" ──► useAutomergeNotebook       │
+│                                      (WASM receive_frame demux) │
+│                                        │          │         │   │
+│                          sync_applied ─┘          │         │   │
+│                          ▼                        │         │   │
+│                   ┌──────────────┐                │         │   │
+│                   │ materialize- │    "notebook:   │  "notebook: │
+│                   │ Cells()      │    broadcast"   │  presence"  │
+│                   └──────┬───────┘        │         │       │   │
+│                          │                ▼         │       │   │
+│                          │        ┌──────────────┐  │       │   │
+│                          │        │useDaemonKernel│  │       │   │
+│                          │        │useEnvProgress │  │       │   │
+│                          │        └──────┬───────┘  │       │   │
+│                          │               │          ▼       │   │
+│                          │               │   ┌────────────┐ │   │
+│                          │               │   │usePresence │ │   │
+│                          │               │   └─────┬──────┘ │   │
+│                          ▼               ▼         ▼        │   │
+│  ┌─────────────────────────────────────────────────────────┐│   │
+│  │ React Components                                         ││   │
+│  │ (CellContainer → CodeCell/MarkdownCell → Outputs)        ││   │
+│  └─────────────────────────────────────────────────────────┘│   │
 └─────────────────────────────────────────────────────────────────┘
 ```
 
-1. **NotebookHandle (WASM)** — Local Automerge doc for instant cell edits
-2. **materializeCells()** — Converts WASM cell snapshots to React-friendly objects
-3. **useDaemonKernel** — Receives kernel outputs and status via daemon broadcasts
-4. **React components** — Render cells and outputs
+1. **useAutomergeNotebook** — Single ingress point. Listens for `notebook:frame`, demuxes via WASM `receive_frame()`, applies sync locally, re-emits `notebook:broadcast` and `notebook:presence` for downstream hooks
+2. **materializeCells()** — Converts WASM cell snapshots to React-friendly objects on sync changes
+3. **useDaemonKernel / useEnvProgress** — Consume `notebook:broadcast` events for kernel status, outputs, and environment progress
+4. **usePresence** — Consumes `notebook:presence` events for remote cursor/selection state
 
-Cell mutations (add, delete, edit) go through the WASM handle for instant response, then sync to the daemon. Execution requests go to the daemon, which reads from the synced document.
+Cell mutations (add, delete, edit) go through the WASM handle for instant response, then sync to the daemon via `invoke("send_frame")`. Execution requests go to the daemon via dedicated Tauri commands.
 
 ## Key Files
 
@@ -151,5 +158,7 @@ Cell mutations (add, delete, edit) go through the WASM handle for instant respon
 | `apps/notebook/src/App.tsx` | Root component, provider setup |
 | `apps/notebook/src/hooks/useAutomergeNotebook.ts` | WASM notebook sync |
 | `apps/notebook/src/lib/materialize-cells.ts` | WASM → React conversion |
+| `apps/notebook/src/hooks/usePresence.ts` | Remote presence tracking |
+| `apps/notebook/src/lib/frame-types.ts` | Frame type constants (mirrors Rust) |
 | `src/components/outputs/media-router.tsx` | Output type dispatch |
 | `src/components/editor/codemirror-editor.tsx` | Main editor |

--- a/contributing/protocol.md
+++ b/contributing/protocol.md
@@ -144,6 +144,7 @@ After the handshake, frames are typed by their first byte:
 | `0x01`    | NotebookRequest    | JSON |
 | `0x02`    | NotebookResponse   | JSON |
 | `0x03`    | NotebookBroadcast  | JSON |
+| `0x04`    | Presence           | Binary (CBOR, see `notebook_doc::presence`) |
 
 ## Automerge Sync
 
@@ -161,13 +162,15 @@ User types in cell
   → React calls WASM handle.update_source(cell_id, text)
   → WASM applies mutation locally (instant)
   → handle.generate_sync_message() → sync bytes
-  → Tauri invoke("send_automerge_sync", bytes)
-  → Relay pipes bytes to daemon socket (frame type 0x00)
+  → Frontend prepends 0x00 type byte → invoke("send_frame", { frameData })
+  → Tauri send_frame dispatches by type → relay pipes to daemon socket
   → Daemon applies sync, updates canonical doc
-  → Daemon generates response sync message
-  → Relay receives bytes, emits "automerge:from-daemon" event
-  → WASM handle.receive_sync_message(bytes)
-  → materializeCells() updates React state if doc changed
+  → Daemon generates response sync message → frame type 0x00
+  → Relay receives, emits "notebook:frame" Tauri event (raw typed bytes)
+  → Frontend useAutomergeNotebook listener → WASM handle.receive_frame(bytes)
+  → WASM demuxes by first byte, applies sync, returns FrameEvent[]
+  → sync_applied event → materializeCells() updates React state if doc changed
+  → sync_reply event → prepend 0x00, invoke("send_frame") back to daemon
 ```
 
 ## Request / Response
@@ -243,21 +246,26 @@ Kernel produces output
   → Daemon writes output to Automerge doc (as blob manifest)
   → Daemon sends NotebookBroadcast::Output on broadcast channel
   → Frame type 0x03 sent to all connected clients
-  → Relay receives, emits "daemon:broadcast" Tauri event
-  → Frontend useDaemonKernel hook processes the broadcast
+  → Relay receives, emits "notebook:frame" Tauri event
+  → WASM handle.receive_frame() demuxes → Broadcast event
+  → useAutomergeNotebook re-emits as "notebook:broadcast" webview event
+  → useDaemonKernel hook processes the broadcast
   → UI updates
 ```
 
 ## Tauri Event Bridge
 
-The relay emits these Tauri events to the frontend:
+The relay and frontend use these Tauri events:
 
-| Event | Payload | Purpose |
-|-------|---------|---------|
-| `automerge:from-daemon` | `Vec<u8>` | Raw Automerge sync bytes from daemon |
-| `daemon:broadcast` | JSON | Serialized `NotebookBroadcast` |
-| `daemon:ready` | — | Connection established, ready to bootstrap |
-| `daemon:disconnected` | — | Connection to daemon lost |
+| Event | Direction | Payload | Purpose |
+|-------|-----------|---------|---------|
+| `notebook:frame` | Relay → Frontend | `number[]` (typed frame bytes) | All daemon frames (sync, broadcast, presence) via unified pipe |
+| `notebook:broadcast` | Frontend → Frontend | JSON | Re-emitted by `useAutomergeNotebook` after WASM demux; consumed by `useDaemonKernel`, `useEnvProgress` |
+| `notebook:presence` | Frontend → Frontend | JSON | Re-emitted by `useAutomergeNotebook` after WASM CBOR decode; consumed by `usePresence` |
+| `daemon:ready` | Relay → Frontend | `DaemonReadyPayload` | Connection established, ready to bootstrap |
+| `daemon:disconnected` | Relay → Frontend | — | Connection to daemon lost |
+
+Outgoing frames from the frontend use `invoke("send_frame", { frameData })` where `frameData` is `number[]` with the first byte as the frame type. Only `0x00` (AutomergeSync) and `0x04` (Presence) are valid outgoing types.
 
 ## Output Storage
 
@@ -280,5 +288,7 @@ Cell outputs use a blob manifest system rather than inline data. When the daemon
 | `crates/notebook/src/lib.rs` | Tauri commands and relay tasks (pipes sync bytes, emits events) |
 | `crates/runtimed-wasm/src/lib.rs` | WASM bindings for local-first cell mutations |
 | `crates/notebook-doc/src/lib.rs` | Shared Automerge document schema and operations |
+| `crates/notebook-doc/src/frame_types.rs` | Shared frame type constants (0x00–0x04) |
+| `apps/notebook/src/lib/frame-types.ts` | TypeScript mirror of frame type constants |
 | `apps/notebook/src/hooks/useAutomergeNotebook.ts` | Frontend sync integration (WASM handle, sync loop, cell materialization) |
 | `apps/notebook/src/hooks/useDaemonKernel.ts` | Frontend broadcast handling (kernel status, outputs, environment) |

--- a/contributing/protocol.md
+++ b/contributing/protocol.md
@@ -170,7 +170,7 @@ User types in cell
   → Frontend useAutomergeNotebook listener → WASM handle.receive_frame(bytes)
   → WASM demuxes by first byte, applies sync, returns FrameEvent[]
   → sync_applied event → materializeCells() updates React state if doc changed
-  → sync_reply event → prepend 0x00, invoke("send_frame") back to daemon
+  → sync_reply event → prepend 0x00, invoke("send_frame", { frameData }) back to daemon
 ```
 
 ## Request / Response

--- a/docs/runtimed.md
+++ b/docs/runtimed.md
@@ -437,7 +437,7 @@ The frontend runs `runtimed-wasm` (compiled from `crates/runtimed-wasm/`) as a W
 │              Binary sync message                        │
 │                   │                                     │
 │                   ▼                                     │
-│  Tauri relay (automerge:to-daemon / automerge:from-daemon) │
+│  Tauri relay (send_frame / notebook:frame — unified pipe)  │
 │                   │                                     │
 │                   ▼                                     │
 │  Daemon (NotebookRoom)                                  │
@@ -460,7 +460,7 @@ Outputs flow through the Automerge doc, not Tauri events:
 1. Kernel emits iopub message → daemon's `kernel_manager` receives it
 2. Daemon writes output to the notebook's Automerge doc (cell outputs array)
 3. Daemon produces a sync message → Tauri relay forwards raw bytes to the frontend (pipe mode — no Automerge processing in the relay)
-4. Frontend receives `automerge:from-daemon` → WASM merges into local doc
+4. Frontend receives `notebook:frame` → WASM `receive_frame()` demuxes and merges into local doc
 5. `materialize-cells.ts` converts the updated doc into React cell state
 
 The `onOutput` callback in `App.tsx` is set to a no-op (`() => {}`) — outputs are rendered from Automerge sync, not broadcasts. The daemon still sends `Output` broadcasts and `useDaemonKernel.ts` still processes them (resolves blob manifests), but the resolved output is discarded by the no-op callback.
@@ -731,7 +731,7 @@ Broadcast types:
 - `ClearOutputs { cell_id }` — explicit clear request
 - `DisplayUpdate { cell_id, output }` — update_display_data (widget progress bars)
 
-> **Note:** `Output` broadcasts are still sent by the daemon and processed by `useDaemonKernel.ts` (blob resolution runs), but the `onOutput` rendering callback in `App.tsx` is a no-op to avoid duplicates with Automerge-synced outputs (no dedup IDs). All output **rendering** is driven by the Automerge sync channel (`automerge:from-daemon` → `materializeCells`). Issue #557 was resolved by making sync the sole output rendering path.
+> **Note:** `Output` broadcasts are still sent by the daemon and processed by `useDaemonKernel.ts` (blob resolution runs), but the `onOutput` rendering callback in `App.tsx` is a no-op to avoid duplicates with Automerge-synced outputs (no dedup IDs). All output **rendering** is driven by the Automerge sync channel (`notebook:frame` → WASM `receive_frame()` → `materializeCells`). Issue #557 was resolved by making sync the sole output rendering path.
 
 ### Project file auto-detection
 


### PR DESCRIPTION
Sweep through all markdown docs to replace stale event/command names from the pre-unified-frame-pipe era (PR #721).

### What changed

| Old | New | Notes |
|-----|-----|-------|
| `automerge:from-daemon` | `notebook:frame` | Unified typed frame event from Tauri relay |
| `automerge:to-daemon` | `invoke("send_frame")` | Tauri command, not event |
| `daemon:broadcast` | `notebook:broadcast` | Re-emitted by `useAutomergeNotebook` after WASM demux |
| `daemon:presence` | `notebook:presence` | Re-emitted after WASM CBOR decode |
| `send_automerge_sync` | `send_frame` | Type-byte-prefixed payload |
| `receive_sync_message()` | `receive_frame()` | WASM demuxes all frame types |

### Files touched

- **`AGENTS.md`** (+ symlinked `CLAUDE.md`) — mutation flow, incoming sync flow, env source labels
- **`contributing/protocol.md`** — added `0x04` Presence to typed frames table; rewrote sync flow, broadcast flow, Tauri Event Bridge section; added `frame_types.rs`/`frame-types.ts` to key files
- **`contributing/frontend-architecture.md`** — added `usePresence`/`useEnvProgress` to hooks table; replaced data flow diagram with unified pipe showing single ingress through `useAutomergeNotebook`
- **`contributing/architecture.md`** — nuanced Principle 1 for WASM local doc; replaced `[sync: ack]` diagram with typed frame flow; added missing key file references
- **`contributing/environments.md`** — 4 locations: mermaid diagrams, sequence diagram, prose
- **`docs/runtimed.md`** — Phase 5 architecture diagram, "How outputs arrive", Phase 8 dual-channel note

Verified zero remaining references to the old event names via grep.

_PR submitted by @rgbkrk's agent Quill, via Zed_