### PR TITLE
fix(editor): restore python auto-indent by removing custom ipython indent service

### DIFF
--- a/src/components/editor/index.ts
+++ b/src/components/editor/index.ts
@@ -15,7 +15,6 @@ export {
   detectCellMagic,
   getCellMagicLanguage,
   ipythonHighlighting,
-  ipythonIndent,
   ipythonStyles,
   ipythonStylesDark,
 } from "./ipython";

--- a/src/components/editor/languages.ts
+++ b/src/components/editor/languages.ts
@@ -12,7 +12,6 @@ import {
   detectCellMagic,
   getCellMagicLanguage,
   ipythonHighlighting,
-  ipythonIndent,
   ipythonStyles,
   ipythonStylesDark,
 } from "./ipython";
@@ -45,7 +44,6 @@ export function getLanguageExtension(language: SupportedLanguage): Extension {
       return [
         python(),
         pythonIndent,
-        ipythonIndent,
         ipythonHighlighting(),
         ipythonStyles,
         ipythonStylesDark,


### PR DESCRIPTION
When IPython magic support (%%html, %%bash, etc.) was added, a custom indent service was included to prevent indentation after magic lines. However, this broke standard Python indentation — pressing Enter after "class Thing:" or "def foo():" no longer indented the next line.

The custom service attempted to fall back to CodeMirror's Python indentation by returning null, but this fallback wasn't working correctly. Rather than trying to calculate indentation manually (error-prone), we now rely entirely on CodeMirror's Python indentation logic.

Trade-off: Magic lines may now indent when they shouldn't, but this is preferable to breaking regular Python code indentation.

## Verification
* [ ] Type `class Thing:` + Enter → next line is indented 4 spaces
* [ ] Type `def foo():` + Enter → next line is indented 4 spaces
* [ ] Type `if True:` + Enter → next line is indented 4 spaces
* [ ] Test nested indentation: inside a function, type `for i in range(10):` + Enter → indents further

_PR submitted by @rgbkrk's agent, Quill_