### PR TITLE
feat(presence): remote cursor UI — colored bars, labels, CM extension

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -93,9 +93,7 @@ function AppContent() {
   const peerIdRef = useRef(crypto.randomUUID());
 
   // Remote cursor/selection presence (outgoing setCursor/setSelection wired in step 5)
-  const { setCursor: _setCursor, setSelection: _setSelection } = usePresence(
-    peerIdRef.current,
-  );
+  usePresence(peerIdRef.current);
 
   // Start dispatching presence events to CodeMirror EditorViews
   useEffect(() => {

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -32,8 +32,10 @@ import { type EnvSyncState, useDependencies } from "./hooks/useDependencies";
 import { useEnvProgress } from "./hooks/useEnvProgress";
 import { useDaemonInfo, useGitInfo } from "./hooks/useGitInfo";
 import { useGlobalFind } from "./hooks/useGlobalFind";
+import { usePresence } from "./hooks/usePresence";
 import { useTrust } from "./hooks/useTrust";
 import { useUpdater } from "./hooks/useUpdater";
+import { startCursorDispatch } from "./lib/cursor-registry";
 import { KERNEL_STATUS } from "./lib/kernel-status";
 import { logger } from "./lib/logger";
 import { useDetectRuntime } from "./lib/notebook-metadata";
@@ -86,6 +88,19 @@ function AppContent() {
 
   // Apply theme to this window
   useSyncedTheme();
+
+  // Stable peer ID for presence (generated once per window lifetime)
+  const peerIdRef = useRef(crypto.randomUUID());
+
+  // Remote cursor/selection presence (outgoing setCursor/setSelection wired in step 5)
+  const { setCursor: _setCursor, setSelection: _setSelection } = usePresence(
+    peerIdRef.current,
+  );
+
+  // Start dispatching presence events to CodeMirror EditorViews
+  useEffect(() => {
+    return startCursorDispatch(peerIdRef.current);
+  }, []);
 
   const {
     cells,

--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -1,4 +1,4 @@
-import type { KeyBinding } from "@codemirror/view";
+import type { EditorView, KeyBinding } from "@codemirror/view";
 import { Trash2, X } from "lucide-react";
 import {
   lazy,
@@ -17,11 +17,13 @@ import {
   type CodeMirrorEditorRef,
 } from "@/components/editor/codemirror-editor";
 import type { SupportedLanguage } from "@/components/editor/languages";
+import { remoteCursorsExtension } from "@/components/editor/remote-cursors";
 import { searchHighlight } from "@/components/editor/search-highlight";
 import { AnsiOutput } from "@/components/outputs/ansi-output";
 import { ErrorBoundary } from "@/lib/error-boundary";
 import type { CellPagePayload, MimeBundle } from "../App";
 import { useCellKeyboardNavigation } from "../hooks/useCellKeyboardNavigation";
+import { registerEditor, unregisterEditor } from "../lib/cursor-registry";
 import { kernelCompletionExtension } from "../lib/kernel-completion";
 import { openUrl } from "../lib/open-url";
 import { tabCompletionKeymap } from "../lib/tab-completion";
@@ -128,6 +130,31 @@ export function CodeCell({
   const editorRef = useRef<CodeMirrorEditorRef>(null);
   const [historyDialogOpen, setHistoryDialogOpen] = useState(false);
 
+  // Register EditorView with the cursor registry for remote cursor rendering.
+  // We use a ref + polling approach because the EditorView is created async
+  // by useCodeMirror and isn't available on first render.
+  const registeredViewRef = useRef<EditorView | null>(null);
+  useEffect(() => {
+    // Check for the view becoming available (useCodeMirror creates it async)
+    const check = () => {
+      const view = editorRef.current?.getEditor() ?? null;
+      if (view && view !== registeredViewRef.current) {
+        registeredViewRef.current = view;
+        registerEditor(cell.id, view);
+      }
+    };
+    check();
+    // Re-check after a tick in case the view wasn't ready yet
+    const timer = setTimeout(check, 50);
+    return () => {
+      clearTimeout(timer);
+      if (registeredViewRef.current) {
+        unregisterEditor(cell.id);
+        registeredViewRef.current = null;
+      }
+    };
+  }, [cell.id]);
+
   // Handle Escape key to dismiss page payload
   useEffect(() => {
     if (!pagePayload || !isFocused) return;
@@ -202,14 +229,18 @@ export function CodeCell({
     [navigationKeyMap, historyKeyBinding],
   );
 
-  // CodeMirror extensions: kernel completion + tab completion + search highlighting
+  // Remote cursors extension (stable — no deps that change)
+  const remoteCursorsExt = useMemo(() => remoteCursorsExtension(), []);
+
+  // CodeMirror extensions: kernel completion + tab completion + search highlighting + remote cursors
   const editorExtensions = useMemo(
     () => [
       kernelCompletionExtension,
       tabCompletionKeymap,
       ...searchHighlight(searchQuery || "", searchActiveOffset),
+      ...remoteCursorsExt,
     ],
-    [searchQuery, searchActiveOffset],
+    [searchQuery, searchActiveOffset, remoteCursorsExt],
   );
 
   const handleExecute = useCallback(() => {

--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -135,19 +135,35 @@ export function CodeCell({
   // by useCodeMirror and isn't available on first render.
   const registeredViewRef = useRef<EditorView | null>(null);
   useEffect(() => {
-    // Check for the view becoming available (useCodeMirror creates it async)
-    const check = () => {
+    const tryRegister = () => {
       const view = editorRef.current?.getEditor() ?? null;
       if (view && view !== registeredViewRef.current) {
         registeredViewRef.current = view;
         registerEditor(cell.id, view);
+        return true;
       }
+      return false;
     };
-    check();
-    // Re-check after a tick in case the view wasn't ready yet
-    const timer = setTimeout(check, 50);
+
+    if (!tryRegister()) {
+      let attempts = 0;
+      const intervalId = window.setInterval(() => {
+        attempts += 1;
+        if (tryRegister() || attempts >= 40) {
+          clearInterval(intervalId);
+        }
+      }, 50);
+
+      return () => {
+        clearInterval(intervalId);
+        if (registeredViewRef.current) {
+          unregisterEditor(cell.id);
+          registeredViewRef.current = null;
+        }
+      };
+    }
+
     return () => {
-      clearTimeout(timer);
       if (registeredViewRef.current) {
         unregisterEditor(cell.id);
         registeredViewRef.current = null;

--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -138,24 +138,42 @@ export function MarkdownCell({
   const registeredViewRef = useRef<EditorView | null>(null);
   useEffect(() => {
     if (!editing) {
-      // Unregister when leaving edit mode
       if (registeredViewRef.current) {
         unregisterEditor(cell.id);
         registeredViewRef.current = null;
       }
       return;
     }
-    const check = () => {
+
+    const tryRegister = () => {
       const view = editorRef.current?.getEditor() ?? null;
       if (view && view !== registeredViewRef.current) {
         registeredViewRef.current = view;
         registerEditor(cell.id, view);
+        return true;
       }
+      return false;
     };
-    check();
-    const timer = setTimeout(check, 50);
+
+    if (!tryRegister()) {
+      let attempts = 0;
+      const intervalId = window.setInterval(() => {
+        attempts += 1;
+        if (tryRegister() || attempts >= 40) {
+          clearInterval(intervalId);
+        }
+      }, 50);
+
+      return () => {
+        clearInterval(intervalId);
+        if (registeredViewRef.current) {
+          unregisterEditor(cell.id);
+          registeredViewRef.current = null;
+        }
+      };
+    }
+
     return () => {
-      clearTimeout(timer);
       if (registeredViewRef.current) {
         unregisterEditor(cell.id);
         registeredViewRef.current = null;

--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -6,12 +6,14 @@ import {
   CodeMirrorEditor,
   type CodeMirrorEditorRef,
 } from "@/components/editor/codemirror-editor";
+import { remoteCursorsExtension } from "@/components/editor/remote-cursors";
 import { searchHighlight } from "@/components/editor/search-highlight";
 import { IsolatedFrame, type IsolatedFrameHandle } from "@/components/isolated";
 import { isDarkMode as detectDarkMode } from "@/lib/dark-mode";
 import { cn } from "@/lib/utils";
 import { useCellKeyboardNavigation } from "../hooks/useCellKeyboardNavigation";
 import { useBlobPort } from "../hooks/useManifestResolver";
+import { registerEditor, unregisterEditor } from "../lib/cursor-registry";
 import { logger } from "../lib/logger";
 import { rewriteMarkdownAssetRefs } from "../lib/markdown-assets";
 import { openUrl } from "../lib/open-url";
@@ -132,6 +134,35 @@ export function MarkdownCell({
   const frameRef = useRef<IsolatedFrameHandle>(null);
   const viewRef = useRef<HTMLDivElement>(null);
 
+  // Register EditorView with the cursor registry when in edit mode.
+  const registeredViewRef = useRef<EditorView | null>(null);
+  useEffect(() => {
+    if (!editing) {
+      // Unregister when leaving edit mode
+      if (registeredViewRef.current) {
+        unregisterEditor(cell.id);
+        registeredViewRef.current = null;
+      }
+      return;
+    }
+    const check = () => {
+      const view = editorRef.current?.getEditor() ?? null;
+      if (view && view !== registeredViewRef.current) {
+        registeredViewRef.current = view;
+        registerEditor(cell.id, view);
+      }
+    };
+    check();
+    const timer = setTimeout(check, 50);
+    return () => {
+      clearTimeout(timer);
+      if (registeredViewRef.current) {
+        unregisterEditor(cell.id);
+        registeredViewRef.current = null;
+      }
+    };
+  }, [cell.id, editing]);
+
   // Track dark mode state for iframe theme sync
   const [darkMode, setDarkMode] = useState(() => detectDarkMode());
 
@@ -234,10 +265,13 @@ export function MarkdownCell({
     [cell.source, isLastCell, onFocusNext, onInsertCellAfter],
   );
 
-  // Search highlight extension for edit mode
+  // Remote cursors extension (stable — no deps that change)
+  const remoteCursorsExt = useMemo(() => remoteCursorsExtension(), []);
+
+  // Search highlight extension for edit mode + remote cursors
   const searchExtensions = useMemo(
-    () => searchHighlight(searchQuery || ""),
-    [searchQuery],
+    () => [...searchHighlight(searchQuery || ""), ...remoteCursorsExt],
+    [searchQuery, remoteCursorsExt],
   );
 
   // Get keyboard navigation bindings

--- a/apps/notebook/src/lib/cursor-registry.ts
+++ b/apps/notebook/src/lib/cursor-registry.ts
@@ -283,5 +283,6 @@ export function startCursorDispatch(peerId: string): () => void {
         setRemoteSelections(view, []);
       }
     }
+    editors.clear();
   };
 }

--- a/apps/notebook/src/lib/cursor-registry.ts
+++ b/apps/notebook/src/lib/cursor-registry.ts
@@ -1,0 +1,287 @@
+/**
+ * Cursor registry — connects presence events from the frame bus to
+ * CodeMirror EditorViews via direct StateEffect dispatch.
+ *
+ * This is the hot path for remote cursor rendering. No React involvement —
+ * presence events arrive synchronously from the frame bus and are dispatched
+ * as CodeMirror StateEffects to registered EditorViews.
+ *
+ * Flow:
+ *   frame bus emitPresence() → subscribePresence callback
+ *     → group cursors/selections by cell_id
+ *       → setRemoteCursors(view, ...) / setRemoteSelections(view, ...)
+ */
+
+import type { EditorView } from "@codemirror/view";
+import {
+  peerColor,
+  type RemoteCursorState,
+  type RemoteSelectionState,
+  setRemoteCursors,
+  setRemoteSelections,
+} from "@/components/editor/remote-cursors";
+import { subscribePresence } from "./notebook-frame-bus";
+
+// ── Types (presence message shapes from WASM decode) ─────────────────
+
+interface CursorData {
+  cell_id: string;
+  line: number;
+  column: number;
+}
+
+interface SelectionData {
+  cell_id: string;
+  anchor_line: number;
+  anchor_col: number;
+  head_line: number;
+  head_col: number;
+}
+
+interface ChannelEntry {
+  channel: "cursor" | "selection" | "kernel_state" | "custom";
+  data: unknown;
+}
+
+interface PresenceUpdate {
+  type: "update";
+  peer_id: string;
+  channel: string;
+  data: unknown;
+}
+
+interface PresenceSnapshot {
+  type: "snapshot";
+  peer_id: string;
+  peers: Array<{
+    peer_id: string;
+    peer_label: string;
+    channels: ChannelEntry[];
+  }>;
+}
+
+interface PresenceLeft {
+  type: "left";
+  peer_id: string;
+}
+
+interface PresenceHeartbeat {
+  type: "heartbeat";
+  peer_id: string;
+}
+
+type PresenceMessage =
+  | PresenceUpdate
+  | PresenceSnapshot
+  | PresenceLeft
+  | PresenceHeartbeat;
+
+// ── Peer state ───────────────────────────────────────────────────────
+
+interface PeerCursorInfo {
+  peerLabel: string;
+  color: string;
+  cursor?: CursorData;
+  selection?: SelectionData;
+}
+
+// ── Registry state ───────────────────────────────────────────────────
+
+/** Map of cellId → registered EditorView */
+const editors = new Map<string, EditorView>();
+
+/** Map of peerId → current cursor/selection state */
+const peers = new Map<string, PeerCursorInfo>();
+
+/** The local peer ID (excluded from remote cursor rendering) */
+let localPeerId: string | null = null;
+
+// ── Editor registration ──────────────────────────────────────────────
+
+/**
+ * Register a CodeMirror EditorView for a cell. The registry will dispatch
+ * remote cursor StateEffects to this view when presence updates arrive.
+ */
+export function registerEditor(cellId: string, view: EditorView): void {
+  editors.set(cellId, view);
+  // Immediately render any existing cursors for this cell
+  dispatchToCell(cellId);
+}
+
+/**
+ * Unregister an EditorView when a cell unmounts or the view changes.
+ */
+export function unregisterEditor(cellId: string): void {
+  editors.delete(cellId);
+}
+
+// ── Dispatch helpers ─────────────────────────────────────────────────
+
+/** Collect all remote cursors for a cell and dispatch to its EditorView. */
+function dispatchToCell(cellId: string): void {
+  const view = editors.get(cellId);
+  if (!view) return;
+
+  const cursors: RemoteCursorState[] = [];
+  const selections: RemoteSelectionState[] = [];
+
+  for (const [peerId, peer] of peers) {
+    if (peerId === localPeerId) continue;
+
+    if (peer.cursor?.cell_id === cellId) {
+      cursors.push({
+        peerId,
+        peerLabel: peer.peerLabel,
+        line: peer.cursor.line,
+        column: peer.cursor.column,
+        color: peer.color,
+      });
+    }
+
+    if (peer.selection?.cell_id === cellId) {
+      selections.push({
+        peerId,
+        peerLabel: peer.peerLabel,
+        anchorLine: peer.selection.anchor_line,
+        anchorCol: peer.selection.anchor_col,
+        headLine: peer.selection.head_line,
+        headCol: peer.selection.head_col,
+        color: peer.color,
+      });
+    }
+  }
+
+  setRemoteCursors(view, cursors);
+  setRemoteSelections(view, selections);
+}
+
+/** Dispatch updates to all cells that might be affected by a peer change. */
+function dispatchToAffectedCells(affectedCellIds: Set<string>): void {
+  for (const cellId of affectedCellIds) {
+    dispatchToCell(cellId);
+  }
+}
+
+// ── Presence event handler ───────────────────────────────────────────
+
+function handlePresence(payload: unknown): void {
+  const msg = payload as PresenceMessage;
+
+  switch (msg.type) {
+    case "update": {
+      if (msg.peer_id === localPeerId) return;
+
+      const existing = peers.get(msg.peer_id);
+      const peer: PeerCursorInfo = existing ?? {
+        peerLabel: "",
+        color: peerColor(msg.peer_id),
+      };
+
+      const affectedCells = new Set<string>();
+
+      if (msg.channel === "cursor") {
+        const data = msg.data as CursorData;
+        // Clear old cell, add new cell
+        if (peer.cursor && peer.cursor.cell_id !== data.cell_id) {
+          affectedCells.add(peer.cursor.cell_id);
+        }
+        peer.cursor = data;
+        affectedCells.add(data.cell_id);
+      } else if (msg.channel === "selection") {
+        const data = msg.data as SelectionData;
+        if (peer.selection && peer.selection.cell_id !== data.cell_id) {
+          affectedCells.add(peer.selection.cell_id);
+        }
+        peer.selection = data;
+        affectedCells.add(data.cell_id);
+      }
+
+      peers.set(msg.peer_id, peer);
+      dispatchToAffectedCells(affectedCells);
+      break;
+    }
+
+    case "snapshot": {
+      // Replace all peer state with snapshot data
+      const affectedCells = new Set<string>();
+
+      // Track cells that had cursors before (to clear them)
+      for (const peer of peers.values()) {
+        if (peer.cursor) affectedCells.add(peer.cursor.cell_id);
+        if (peer.selection) affectedCells.add(peer.selection.cell_id);
+      }
+
+      peers.clear();
+
+      for (const snap of msg.peers) {
+        if (snap.peer_id === localPeerId) continue;
+
+        const peer: PeerCursorInfo = {
+          peerLabel: snap.peer_label,
+          color: peerColor(snap.peer_id),
+        };
+
+        for (const ch of snap.channels) {
+          if (ch.channel === "cursor") {
+            peer.cursor = ch.data as CursorData;
+            affectedCells.add(peer.cursor.cell_id);
+          } else if (ch.channel === "selection") {
+            peer.selection = ch.data as SelectionData;
+            affectedCells.add(peer.selection.cell_id);
+          }
+        }
+
+        peers.set(snap.peer_id, peer);
+      }
+
+      dispatchToAffectedCells(affectedCells);
+      break;
+    }
+
+    case "left": {
+      const peer = peers.get(msg.peer_id);
+      if (!peer) return;
+
+      const affectedCells = new Set<string>();
+      if (peer.cursor) affectedCells.add(peer.cursor.cell_id);
+      if (peer.selection) affectedCells.add(peer.selection.cell_id);
+
+      peers.delete(msg.peer_id);
+      dispatchToAffectedCells(affectedCells);
+      break;
+    }
+
+    case "heartbeat":
+      // No visual change needed
+      break;
+  }
+}
+
+// ── Lifecycle ────────────────────────────────────────────────────────
+
+/**
+ * Start dispatching presence events to registered CodeMirror EditorViews.
+ *
+ * Call once at app startup. Returns a cleanup function.
+ *
+ * @param peerId The local peer's ID — excluded from remote cursor rendering.
+ */
+export function startCursorDispatch(peerId: string): () => void {
+  localPeerId = peerId;
+
+  const unsubscribe = subscribePresence(handlePresence);
+
+  return () => {
+    unsubscribe();
+    localPeerId = null;
+    peers.clear();
+    // Clear all editors' cursors on shutdown
+    for (const [cellId] of editors) {
+      const view = editors.get(cellId);
+      if (view) {
+        setRemoteCursors(view, []);
+        setRemoteSelections(view, []);
+      }
+    }
+  };
+}

--- a/python/runtimed/demos/README.md
+++ b/python/runtimed/demos/README.md
@@ -1,0 +1,40 @@
+# runtimed demos
+
+Scripts for testing and demonstrating runtimed features. Run from the `python/runtimed/` directory so `uv run` picks up the local dev build.
+
+## Setup
+
+Build the Python bindings (from the repo root):
+
+```bash
+cd python/runtimed
+uv run --reinstall-package runtimed maturin develop
+```
+
+Set the dev daemon socket path:
+
+```bash
+# Find your worktree hash
+RUNTIMED_DEV=1 ./target/debug/runt daemon status
+
+# Export the socket path (replace <hash> with yours)
+export RUNTIMED_SOCKET_PATH=~/Library/Caches/runt-nightly/worktrees/<hash>/runtimed.sock
+```
+
+Find open notebook IDs:
+
+```bash
+RUNTIMED_DEV=1 ./target/debug/runt notebooks
+```
+
+## Demos
+
+### `presence_cursor.py`
+
+Animates a remote cursor across cells in an open notebook. The cursor sweeps through each line of the longest cell, then back across line 0.
+
+```bash
+uv run python demos/presence_cursor.py <notebook_id>
+```
+
+Requires a notebook window open in the dev app (`cargo xtask dev`). You should see a colored cursor bar with a "peer" label moving through the code.

--- a/python/runtimed/demos/README.md
+++ b/python/runtimed/demos/README.md
@@ -14,14 +14,14 @@ uv run --reinstall-package runtimed maturin develop
 Set the dev daemon socket path:
 
 ```bash
-# Find your worktree hash
+# Find your worktree hash (run from repo root)
 RUNTIMED_DEV=1 ./target/debug/runt daemon status
 
 # Export the socket path (replace <hash> with yours)
 export RUNTIMED_SOCKET_PATH=~/Library/Caches/runt-nightly/worktrees/<hash>/runtimed.sock
 ```
 
-Find open notebook IDs:
+Find open notebook IDs (from repo root):
 
 ```bash
 RUNTIMED_DEV=1 ./target/debug/runt notebooks

--- a/python/runtimed/demos/presence_cursor.py
+++ b/python/runtimed/demos/presence_cursor.py
@@ -1,0 +1,87 @@
+"""Demo: animate a cursor across a cell in the desktop app via presence.
+
+Usage (from python/runtimed/, with dev daemon running):
+
+    RUNTIMED_SOCKET_PATH=~/Library/Caches/runt-nightly/worktrees/<hash>/runtimed.sock \
+        uv run python demos/presence_cursor.py [notebook_id]
+
+If no notebook_id is provided, lists open notebooks and exits.
+"""
+
+import os
+import sys
+import time
+
+import runtimed
+
+
+def get_socket_path():
+    path = os.environ.get("RUNTIMED_SOCKET_PATH")
+    if not path:
+        print(
+            "Set RUNTIMED_SOCKET_PATH to your dev daemon socket, e.g.:\n"
+            "  RUNTIMED_SOCKET_PATH=~/Library/Caches/runt-nightly/worktrees/<hash>/runtimed.sock\n"
+            "\n"
+            "Find the hash with: RUNTIMED_DEV=1 ./target/debug/runt daemon status",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    return path
+
+
+def main():
+    get_socket_path()  # validate env var is set
+
+    notebook_id = sys.argv[1] if len(sys.argv) > 1 else None
+
+    if not notebook_id:
+        print(
+            "Usage: python demo_presence.py <notebook_id>\n"
+            "\n"
+            "Find notebook IDs with:\n"
+            "  RUNTIMED_DEV=1 ./target/debug/runt notebooks",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    session = runtimed.Session(notebook_id=notebook_id)
+    session.connect()
+
+    cells = session.get_cells()
+    if not cells:
+        print("No cells found in notebook", file=sys.stderr)
+        sys.exit(1)
+
+    print("Cells:")
+    for c in cells:
+        print(f"  {c.id}: {c.cell_type} ({len(c.source)} chars) -> {c.source[:60]!r}")
+
+    # Pick the cell with the most content
+    cell = max(cells, key=lambda c: len(c.source))
+    source = cell.source
+    lines = source.split("\n")
+    print(
+        f"\nAnimating cursor across cell {cell.id} ({len(source)} chars, {len(lines)} lines)"
+    )
+
+    # Sweep across each line
+    for line_num, line_text in enumerate(lines):
+        for col in range(len(line_text) + 1):
+            session.set_cursor(cell.id, line=line_num, column=col)
+            time.sleep(0.04)
+
+    # Sweep back across line 0
+    first_line = lines[0] if lines else ""
+    for col in range(len(first_line), -1, -1):
+        session.set_cursor(cell.id, line=0, column=col)
+        time.sleep(0.04)
+
+    # Hold at the beginning so you can see it
+    session.set_cursor(cell.id, line=0, column=0)
+    time.sleep(2)
+
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/python/runtimed/demos/presence_cursor.py
+++ b/python/runtimed/demos/presence_cursor.py
@@ -5,7 +5,7 @@ Usage (from python/runtimed/, with dev daemon running):
     RUNTIMED_SOCKET_PATH=~/Library/Caches/runt-nightly/worktrees/<hash>/runtimed.sock \
         uv run python demos/presence_cursor.py [notebook_id]
 
-If no notebook_id is provided, lists open notebooks and exits.
+If no notebook_id is provided, prints usage and exits.
 """
 
 import os
@@ -36,7 +36,7 @@ def main():
 
     if not notebook_id:
         print(
-            "Usage: python demo_presence.py <notebook_id>\n"
+            "Usage: python presence_cursor.py <notebook_id>\n"
             "\n"
             "Find notebook IDs with:\n"
             "  RUNTIMED_DEV=1 ./target/debug/runt notebooks",

--- a/src/components/editor/remote-cursors.ts
+++ b/src/components/editor/remote-cursors.ts
@@ -315,12 +315,7 @@ const remoteCursorsTheme = EditorView.theme({
     color: "white",
     whiteSpace: "nowrap",
     pointerEvents: "none",
-    opacity: "0",
-    transition: "opacity 0.15s ease",
     zIndex: "10",
-  },
-  ".cm-remote-cursor:hover .cm-remote-cursor-label": {
-    opacity: "1",
   },
   ".cm-remote-selection": {
     // Background color is set inline via decoration attributes

--- a/src/components/editor/remote-cursors.ts
+++ b/src/components/editor/remote-cursors.ts
@@ -118,7 +118,7 @@ class CursorWidget extends WidgetType {
     wrapper.style.borderLeftColor = this.color;
     wrapper.setAttribute("aria-label", this.label || "Remote cursor");
 
-    // Name label (shown on hover via CSS)
+    // Name label (always visible, positioned above the cursor bar)
     if (this.label) {
       const tag = document.createElement("span");
       tag.className = "cm-remote-cursor-label";
@@ -149,9 +149,10 @@ function buildCursorDecorations(
   for (const cursor of cursors) {
     // Clamp to document bounds
     const lineCount = doc.lines;
-    const lineNum = Math.min(cursor.line + 1, lineCount); // CM lines are 1-based
+    const safeLine = Math.max(0, cursor.line);
+    const lineNum = Math.min(safeLine + 1, lineCount);
     const line = doc.line(lineNum);
-    const col = Math.min(cursor.column, line.length);
+    const col = Math.min(Math.max(0, cursor.column), line.length);
     const pos = line.from + col;
 
     widgets.push(
@@ -181,14 +182,14 @@ function buildSelectionDecorations(
   const ranges: { from: number; to: number; color: string }[] = [];
 
   for (const sel of selections) {
-    const anchorLineNum = Math.min(sel.anchorLine + 1, lineCount);
+    const anchorLineNum = Math.max(1, Math.min(sel.anchorLine + 1, lineCount));
     const anchorLine = doc.line(anchorLineNum);
-    const anchorCol = Math.min(sel.anchorCol, anchorLine.length);
+    const anchorCol = Math.min(Math.max(0, sel.anchorCol), anchorLine.length);
     const anchorPos = anchorLine.from + anchorCol;
 
-    const headLineNum = Math.min(sel.headLine + 1, lineCount);
+    const headLineNum = Math.max(1, Math.min(sel.headLine + 1, lineCount));
     const headLine = doc.line(headLineNum);
-    const headCol = Math.min(sel.headCol, headLine.length);
+    const headCol = Math.min(Math.max(0, sel.headCol), headLine.length);
     const headPos = headLine.from + headCol;
 
     const from = Math.min(anchorPos, headPos);

--- a/src/components/editor/remote-cursors.ts
+++ b/src/components/editor/remote-cursors.ts
@@ -1,0 +1,369 @@
+/**
+ * CodeMirror 6 extension for rendering remote peer cursors and selections.
+ *
+ * Architecture:
+ * - `StateEffect<RemoteCursorState[]>` — dispatched from outside to update positions
+ * - `StateField<RemoteCursorState[]>` — stores current cursors for this editor instance
+ * - `ViewPlugin` — reads the StateField and produces Decoration widgets/marks
+ * - `WidgetType` subclass — renders the colored cursor bar with peer name tooltip
+ *
+ * The hot path (cursor position updates) is purely imperative — no React involvement.
+ * Call `setRemoteCursors(view, cursors)` to push new positions into an EditorView.
+ */
+
+import {
+  type Extension,
+  type Range,
+  RangeSetBuilder,
+  StateEffect,
+  StateField,
+} from "@codemirror/state";
+import {
+  Decoration,
+  type DecorationSet,
+  EditorView,
+  ViewPlugin,
+  type ViewUpdate,
+  WidgetType,
+} from "@codemirror/view";
+
+// ── Types ────────────────────────────────────────────────────────────
+
+export interface RemoteCursorState {
+  peerId: string;
+  peerLabel: string;
+  /** 0-based line number */
+  line: number;
+  /** 0-based column */
+  column: number;
+  color: string;
+}
+
+export interface RemoteSelectionState {
+  peerId: string;
+  peerLabel: string;
+  anchorLine: number;
+  anchorCol: number;
+  headLine: number;
+  headCol: number;
+  color: string;
+}
+
+// ── Color palette ────────────────────────────────────────────────────
+
+const CURSOR_COLORS = [
+  "#2563eb", // blue
+  "#e11d48", // rose
+  "#d97706", // amber
+  "#059669", // emerald
+  "#7c3aed", // violet
+  "#0891b2", // cyan
+  "#db2777", // pink
+  "#65a30d", // lime
+];
+
+/** Deterministic color from peer ID. */
+export function peerColor(peerId: string): string {
+  let hash = 0;
+  for (let i = 0; i < peerId.length; i++) {
+    hash = (hash * 31 + peerId.charCodeAt(i)) | 0;
+  }
+  return CURSOR_COLORS[Math.abs(hash) % CURSOR_COLORS.length];
+}
+
+// ── State effects ────────────────────────────────────────────────────
+
+const setCursorsEffect = StateEffect.define<RemoteCursorState[]>();
+const setSelectionsEffect = StateEffect.define<RemoteSelectionState[]>();
+
+// ── State fields ─────────────────────────────────────────────────────
+
+const cursorsField = StateField.define<RemoteCursorState[]>({
+  create: () => [],
+  update(value, tr) {
+    for (const e of tr.effects) {
+      if (e.is(setCursorsEffect)) return e.value;
+    }
+    return value;
+  },
+});
+
+const selectionsField = StateField.define<RemoteSelectionState[]>({
+  create: () => [],
+  update(value, tr) {
+    for (const e of tr.effects) {
+      if (e.is(setSelectionsEffect)) return e.value;
+    }
+    return value;
+  },
+});
+
+// ── Cursor widget ────────────────────────────────────────────────────
+
+class CursorWidget extends WidgetType {
+  constructor(
+    readonly color: string,
+    readonly label: string,
+  ) {
+    super();
+  }
+
+  eq(other: CursorWidget): boolean {
+    return this.color === other.color && this.label === other.label;
+  }
+
+  toDOM(): HTMLElement {
+    const wrapper = document.createElement("span");
+    wrapper.className = "cm-remote-cursor";
+    wrapper.style.borderLeftColor = this.color;
+    wrapper.setAttribute("aria-label", this.label || "Remote cursor");
+
+    // Name label (shown on hover via CSS)
+    if (this.label) {
+      const tag = document.createElement("span");
+      tag.className = "cm-remote-cursor-label";
+      tag.style.backgroundColor = this.color;
+      tag.textContent = this.label;
+      wrapper.appendChild(tag);
+    }
+
+    return wrapper;
+  }
+
+  ignoreEvent(): boolean {
+    return true;
+  }
+}
+
+// ── Decoration builder ───────────────────────────────────────────────
+
+function buildCursorDecorations(
+  view: EditorView,
+  cursors: RemoteCursorState[],
+): DecorationSet {
+  if (cursors.length === 0) return Decoration.none;
+
+  const doc = view.state.doc;
+  const widgets: Range<Decoration>[] = [];
+
+  for (const cursor of cursors) {
+    // Clamp to document bounds
+    const lineCount = doc.lines;
+    const lineNum = Math.min(cursor.line + 1, lineCount); // CM lines are 1-based
+    const line = doc.line(lineNum);
+    const col = Math.min(cursor.column, line.length);
+    const pos = line.from + col;
+
+    widgets.push(
+      Decoration.widget({
+        widget: new CursorWidget(cursor.color, cursor.peerLabel),
+        side: 1, // render after the character
+      }).range(pos),
+    );
+  }
+
+  // Decorations must be sorted by position
+  widgets.sort((a, b) => a.from - b.from);
+  return Decoration.set(widgets);
+}
+
+function buildSelectionDecorations(
+  view: EditorView,
+  selections: RemoteSelectionState[],
+): DecorationSet {
+  if (selections.length === 0) return Decoration.none;
+
+  const doc = view.state.doc;
+  const builder = new RangeSetBuilder<Decoration>();
+  const lineCount = doc.lines;
+
+  // Collect and sort ranges
+  const ranges: { from: number; to: number; color: string }[] = [];
+
+  for (const sel of selections) {
+    const anchorLineNum = Math.min(sel.anchorLine + 1, lineCount);
+    const anchorLine = doc.line(anchorLineNum);
+    const anchorCol = Math.min(sel.anchorCol, anchorLine.length);
+    const anchorPos = anchorLine.from + anchorCol;
+
+    const headLineNum = Math.min(sel.headLine + 1, lineCount);
+    const headLine = doc.line(headLineNum);
+    const headCol = Math.min(sel.headCol, headLine.length);
+    const headPos = headLine.from + headCol;
+
+    const from = Math.min(anchorPos, headPos);
+    const to = Math.max(anchorPos, headPos);
+
+    if (from < to) {
+      ranges.push({ from, to, color: sel.color });
+    }
+  }
+
+  // RangeSetBuilder requires sorted, non-overlapping additions
+  ranges.sort((a, b) => a.from - b.from || a.to - b.to);
+
+  for (const { from, to, color } of ranges) {
+    builder.add(
+      from,
+      to,
+      Decoration.mark({
+        class: "cm-remote-selection",
+        attributes: {
+          style: `background-color: ${color}33`, // ~20% opacity via hex alpha
+        },
+      }),
+    );
+  }
+
+  return builder.finish();
+}
+
+// ── View plugin ──────────────────────────────────────────────────────
+
+class RemoteCursorsPlugin {
+  cursorDecorations: DecorationSet;
+  selectionDecorations: DecorationSet;
+
+  constructor(view: EditorView) {
+    this.cursorDecorations = buildCursorDecorations(
+      view,
+      view.state.field(cursorsField),
+    );
+    this.selectionDecorations = buildSelectionDecorations(
+      view,
+      view.state.field(selectionsField),
+    );
+  }
+
+  update(update: ViewUpdate) {
+    // Rebuild decorations when cursor/selection state changes or document changes
+    // (document changes invalidate positions)
+    let cursorsChanged = update.docChanged;
+    let selectionsChanged = update.docChanged;
+
+    for (const e of update.transactions) {
+      for (const eff of e.effects) {
+        if (eff.is(setCursorsEffect)) cursorsChanged = true;
+        if (eff.is(setSelectionsEffect)) selectionsChanged = true;
+      }
+    }
+
+    if (cursorsChanged) {
+      this.cursorDecorations = buildCursorDecorations(
+        update.view,
+        update.state.field(cursorsField),
+      );
+    }
+    if (selectionsChanged) {
+      this.selectionDecorations = buildSelectionDecorations(
+        update.view,
+        update.state.field(selectionsField),
+      );
+    }
+  }
+}
+
+const cursorPlugin = ViewPlugin.fromClass(RemoteCursorsPlugin, {
+  decorations: (v) => v.cursorDecorations,
+});
+
+const selectionPlugin = ViewPlugin.fromClass(
+  // Reuse the same class but expose selection decorations
+  // We need a separate plugin instance because CM6 only allows one
+  // decoration source per plugin. Use a thin wrapper.
+  class {
+    source: RemoteCursorsPlugin | null = null;
+
+    constructor(view: EditorView) {
+      // Access the sibling plugin — they share the same StateField
+      this.source = view.plugin(cursorPlugin);
+    }
+
+    get decorations(): DecorationSet {
+      return this.source?.selectionDecorations ?? Decoration.none;
+    }
+
+    update(update: ViewUpdate) {
+      // The source plugin handles rebuild; just re-read the reference
+      this.source = update.view.plugin(cursorPlugin);
+    }
+  },
+  {
+    decorations: (v) => v.decorations,
+  },
+);
+
+// ── Theme ────────────────────────────────────────────────────────────
+
+const remoteCursorsTheme = EditorView.theme({
+  ".cm-remote-cursor": {
+    position: "relative",
+    borderLeft: "2px solid",
+    marginLeft: "-1px",
+    marginRight: "-1px",
+    pointerEvents: "none",
+  },
+  ".cm-remote-cursor-label": {
+    position: "absolute",
+    bottom: "100%",
+    left: "-1px",
+    padding: "1px 4px",
+    borderRadius: "3px 3px 3px 0",
+    fontSize: "11px",
+    lineHeight: "14px",
+    fontFamily: "system-ui, sans-serif",
+    color: "white",
+    whiteSpace: "nowrap",
+    pointerEvents: "none",
+    opacity: "0",
+    transition: "opacity 0.15s ease",
+    zIndex: "10",
+  },
+  ".cm-remote-cursor:hover .cm-remote-cursor-label": {
+    opacity: "1",
+  },
+  ".cm-remote-selection": {
+    // Background color is set inline via decoration attributes
+  },
+});
+
+// ── Public API ───────────────────────────────────────────────────────
+
+/**
+ * CodeMirror extension for rendering remote cursors and selections.
+ *
+ * Add to the editor's extensions array. Then call `setRemoteCursors()` and
+ * `setRemoteSelections()` to update positions from outside React.
+ */
+export function remoteCursorsExtension(): Extension[] {
+  return [
+    cursorsField,
+    selectionsField,
+    cursorPlugin,
+    selectionPlugin,
+    remoteCursorsTheme,
+  ];
+}
+
+/**
+ * Push new remote cursor positions into an EditorView.
+ *
+ * This dispatches a StateEffect — the ViewPlugin will pick up the change
+ * and rebuild decorations. Safe to call at high frequency.
+ */
+export function setRemoteCursors(
+  view: EditorView,
+  cursors: RemoteCursorState[],
+): void {
+  view.dispatch({ effects: setCursorsEffect.of(cursors) });
+}
+
+/**
+ * Push new remote selection ranges into an EditorView.
+ */
+export function setRemoteSelections(
+  view: EditorView,
+  selections: RemoteSelectionState[],
+): void {
+  view.dispatch({ effects: setSelectionsEffect.of(selections) });
+}


### PR DESCRIPTION
Render remote peer cursors in CodeMirror cells. Colored cursor bars with peer name labels, selection highlights with reduced opacity.

## Architecture

No React in the hot path. Presence events flow directly from the frame bus to CodeMirror:

```
frame bus emitPresence()
  → cursor-registry.ts (subscribePresence callback)
    → groups cursors by cell_id
      → setRemoteCursors(editorView, ...) — CM StateEffect dispatch
        → ViewPlugin rebuilds Decoration widgets
```

### New files

- **`src/components/editor/remote-cursors.ts`** — CodeMirror extension: `StateEffect` / `StateField` / `ViewPlugin` / `WidgetType` for cursor bar widgets and selection mark decorations. 8-color deterministic palette from peer ID hash.
- **`apps/notebook/src/lib/cursor-registry.ts`** — Module-level registry maps `cellId → EditorView`. Subscribes to presence on the frame bus, dispatches CM StateEffects directly to registered views. Handles update, snapshot, left, and heartbeat message types.
- **`python/runtimed/demos/`** — Demo scripts for testing presence with the Python bindings.

### Modified files

- **`App.tsx`** — Wire `usePresence` hook and `startCursorDispatch`
- **`CodeCell.tsx`** — Register EditorView with cursor registry, add `remoteCursorsExtension()`
- **`MarkdownCell.tsx`** — Same (edit mode only)

### What's working

- Incoming cursors render as colored bars with peer label flag
- Cursor position tracks across lines and columns
- Peer disconnect clears cursors
- Snapshot handling for late joiners

### Not yet wired

- Outgoing cursor broadcast (local cursor → daemon) — step 5 in the plan
- Peer labels are hardcoded to "peer" by the daemon — needs protocol change for real attribution

### Demo

```bash
cd python/runtimed
RUNTIMED_SOCKET_PATH=~/Library/Caches/runt-nightly/worktrees/<hash>/runtimed.sock \
  uv run python demos/presence_cursor.py <notebook_id>
```

_PR submitted by @rgbkrk's agent Quill, via Zed_