### PR TITLE
feat(cli): enrich daemon status --json with dev-mode fields

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,6 +161,29 @@ Use `./target/debug/runt` to interact with the worktree daemon. When started via
 ./target/debug/runt daemon flush
 ```
 
+### Machine-Readable Status (`--json`)
+
+For scripts that need daemon configuration programmatically:
+
+```bash
+# Get socket path for RUNTIMED_SOCKET_PATH
+./target/debug/runt daemon status --json | jq -r .socket_path
+
+# Get blob server URL (when daemon is running)
+./target/debug/runt daemon status --json | jq -r .blob_url
+
+# Get all computed paths
+./target/debug/runt daemon status --json | jq '.paths'
+
+# Get environment variables
+./target/debug/runt daemon status --json | jq '.env'
+
+# Check if daemon is running
+./target/debug/runt daemon status --json | jq -r .running
+```
+
+The JSON output includes computed paths, environment variables, pool targets, and blob server URL — everything needed to configure dev scripts without manual computation.
+
 **Why `./target/debug/runt`?** The debug binary is built with `RUNTIMED_WORKSPACE_PATH` in its environment (via xtask), so it connects to the worktree daemon. A system-installed `runt` connects to the system daemon instead.
 
 **Where state lives in dev mode:**

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -1534,6 +1534,7 @@ async fn daemon_command(command: DaemonCommands) -> Result<()> {
                 });
 
             if json {
+                let base_dir = runt_workspace::daemon_base_dir();
                 let output = serde_json::json!({
                     "channel": runt_workspace::channel_display_name(),
                     "socket_path": socket_path,
@@ -1542,6 +1543,23 @@ async fn daemon_command(command: DaemonCommands) -> Result<()> {
                     "dev_mode": is_dev,
                     "daemon_info": daemon_info,
                     "pool_stats": stats,
+                    "paths": {
+                        "base_dir": base_dir,
+                        "log_path": base_dir.join("runtimed.log"),
+                        "envs_dir": base_dir.join("envs"),
+                        "blobs_dir": base_dir.join("blobs"),
+                        "notebooks_dir": runt_workspace::default_notebooks_dir().ok(),
+                    },
+                    "env": {
+                        "RUNTIMED_DEV": std::env::var("RUNTIMED_DEV").ok(),
+                        "RUNTIMED_WORKSPACE_PATH": std::env::var("RUNTIMED_WORKSPACE_PATH").ok(),
+                        "RUNTIMED_WORKSPACE_NAME": std::env::var("RUNTIMED_WORKSPACE_NAME").ok(),
+                        "RUNTIMED_VITE_PORT": std::env::var("RUNTIMED_VITE_PORT").ok(),
+                    },
+                    "blob_url": daemon_info.as_ref()
+                        .and_then(|i| i.blob_port.map(|p| format!("http://127.0.0.1:{}", p))),
+                    "worktree_hash": runt_workspace::get_workspace_path()
+                        .map(|p| runt_workspace::worktree_hash(&p)),
                 });
                 println!("{}", serde_json::to_string_pretty(&output)?);
             } else {

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -1631,8 +1631,10 @@ impl Daemon {
                     stats: PoolStats {
                         uv_available,
                         uv_warming,
+                        uv_target: self.config.uv_pool_size,
                         conda_available,
                         conda_warming,
+                        conda_target: self.config.conda_pool_size,
                         uv_error,
                         conda_error,
                     },

--- a/crates/runtimed/src/lib.rs
+++ b/crates/runtimed/src/lib.rs
@@ -94,8 +94,10 @@ pub struct PooledEnv {
 pub struct PoolStats {
     pub uv_available: usize,
     pub uv_warming: usize,
+    pub uv_target: usize,
     pub conda_available: usize,
     pub conda_warming: usize,
+    pub conda_target: usize,
     /// Error info for UV pool (if warming is failing).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub uv_error: Option<PoolError>,

--- a/docs/runtimed.md
+++ b/docs/runtimed.md
@@ -138,6 +138,24 @@ runt daemon install    # Install as system service (system daemon only)
 runt daemon uninstall  # Uninstall system service (system daemon only)
 ```
 
+**Machine-readable output** (`--json`):
+
+```bash
+runt daemon status --json
+```
+
+Returns structured JSON with:
+- `socket_path` — Unix socket or named pipe path
+- `running` — boolean daemon status
+- `daemon_info` — PID, version, blob_port, worktree_path (when running)
+- `pool_stats` — environment pool counts including `uv_target`/`conda_target`
+- `paths` — computed dev paths (base_dir, log_path, envs_dir, blobs_dir)
+- `env` — environment variables (RUNTIMED_DEV, RUNTIMED_WORKSPACE_PATH, etc.)
+- `blob_url` — HTTP blob server URL (when running)
+- `worktree_hash` — 12-char hash for dev mode isolation
+
+Useful for scripts that need to discover daemon configuration without parsing human-readable output.
+
 Most commands work with both the system daemon and dev worktree daemons. The `install`/`uninstall` commands are system-only — don't run these in a worktree context.
 
 Auto-upgrade: the client detects version mismatches and replaces the binary.


### PR DESCRIPTION
## Summary

- Add computed paths, environment variables, pool targets, and blob_url to the JSON output of `runt daemon status --json`
- Enables dev scripts to discover all daemon configuration from a single command without manual computation
- Documents the `--json` flag in AGENTS.md and docs/runtimed.md

## New JSON fields

```json
{
  "paths": {
    "base_dir": "~/.cache/runt-nightly/worktrees/af6062a01a24/",
    "log_path": "~/.cache/runt-nightly/worktrees/af6062a01a24/runtimed.log",
    "envs_dir": "~/.cache/runt-nightly/worktrees/af6062a01a24/envs/",
    "blobs_dir": "~/.cache/runt-nightly/worktrees/af6062a01a24/blobs/",
    "notebooks_dir": "/Users/.../desktop/notebooks/"
  },
  "env": {
    "RUNTIMED_DEV": "1",
    "RUNTIMED_WORKSPACE_PATH": "/Users/.../desktop",
    "RUNTIMED_WORKSPACE_NAME": "prague-v3",
    "RUNTIMED_VITE_PORT": "55080"
  },
  "blob_url": "http://127.0.0.1:60429",
  "worktree_hash": "af6062a01a24",
  "pool_stats": {
    "uv_target": 3,
    "conda_target": 3
  }
}
```

## Test plan

- [x] `./target/debug/runt daemon status --json | jq '.paths'` shows computed paths
- [x] `./target/debug/runt daemon status --json | jq '.env'` shows environment variables
- [x] `./target/debug/runt daemon status --json | jq -r .socket_path` works for scripts
- [x] Build succeeds with `cargo build -p runt-cli -p runtimed`

Closes #728