### PR TITLE
fix(kernel): clear outputs in automerge doc when execution starts

### DIFF
--- a/crates/runtimed/src/kernel_manager.rs
+++ b/crates/runtimed/src/kernel_manager.rs
@@ -812,11 +812,26 @@ impl RoomKernel {
 
                             JupyterMessageContent::ExecuteInput(input) => {
                                 if let Some(ref cid) = cell_id {
-                                    // Persist execution count in Automerge before notifying clients
-                                    // so UI reads the updated value immediately.
+                                    // Clear terminal emulator state for this cell before new execution
+                                    {
+                                        let mut terminals = stream_terminals.lock().await;
+                                        terminals.clear(cid);
+                                    }
+
+                                    // Clear outputs and set execution count in Automerge before
+                                    // notifying clients so UI reads the updated value immediately.
+                                    // Clearing outputs here (when execution truly starts) ensures
+                                    // a single source of truth - both frontend and MCP-triggered
+                                    // executions get outputs cleared authoritatively by the daemon.
                                     let execution_count = input.execution_count.0 as i64;
                                     let persist_bytes = {
                                         let mut doc_guard = doc.write().await;
+                                        if let Err(e) = doc_guard.clear_outputs(cid) {
+                                            warn!(
+                                                "[kernel-manager] Failed to clear outputs in doc: {}",
+                                                e
+                                            );
+                                        }
                                         if let Err(e) = doc_guard
                                             .set_execution_count(cid, &execution_count.to_string())
                                         {


### PR DESCRIPTION
## Summary

- Clear outputs in the Automerge document when execution truly starts (on `ExecuteInput` from kernel)
- Also clears terminal emulator state at the same point
- Creates a single source of truth - both frontend and MCP-triggered executions get outputs cleared authoritatively by the daemon

## Context

When an agent executes a cell via MCP, the frontend would show stale outputs from the previous execution. This happened because output clearing was a client-side optimistic effect, and MCP-triggered executions bypass the frontend entirely.

The fix makes the daemon the authority on output clearing. When the kernel sends `ExecuteInput` (execution truly begins), the daemon:
1. Clears the terminal emulator state
2. Clears outputs in the Automerge doc
3. Sets execution count (existing behavior)

The frontend receives the cleared outputs via normal Automerge sync.

Fixes #734

## Test plan

- [ ] User-initiated execution: Run a cell with output, modify and re-run - old output should clear immediately
- [ ] MCP-initiated execution: Use nteract MCP `execute_cell` on a cell with existing output - old output should clear
- [ ] Rapid re-execution: Click Execute rapidly on same cell - no duplicate outputs
- [ ] Cross-window sync: Open same notebook in two windows, execute in one - both windows see cleared outputs