### PR TITLE
fix(kernel): include cell_id in clear_outputs warning log

### DIFF
--- a/crates/runtimed/src/kernel_manager.rs
+++ b/crates/runtimed/src/kernel_manager.rs
@@ -828,8 +828,8 @@ impl RoomKernel {
                                         let mut doc_guard = doc.write().await;
                                         if let Err(e) = doc_guard.clear_outputs(cid) {
                                             warn!(
-                                                "[kernel-manager] Failed to clear outputs in doc: {}",
-                                                e
+                                                "[kernel-manager] Failed to clear outputs in doc for cell {}: {}",
+                                                cid, e
                                             );
                                         }
                                         if let Err(e) = doc_guard


### PR DESCRIPTION
## Summary

- Include the cell ID in the warning log when `clear_outputs` fails

Improves debuggability in multi-cell/multi-window sessions.

Follow-up to #736 based on copilot review feedback.