### PR TITLE
fix(markdown): eliminate dark mode flicker and speed up loading

### DIFF
--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -443,6 +443,7 @@ export function MarkdownCell({
             darkMode={darkMode}
             minHeight={24}
             autoHeight
+            revealOnRender
             onReady={handleFrameReady}
             onLinkClick={handleLinkClick}
             onDoubleClick={handleDoubleClick}

--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -436,7 +436,8 @@ export function MarkdownCell({
         onDoubleClick={handleDoubleClick}
         onKeyDown={handleViewKeyDown}
       >
-        {cell.source ? (
+        {/* Always render IsolatedFrame to preload it (hidden when no content) */}
+        <div className={cell.source ? undefined : "hidden"}>
           <IsolatedFrame
             ref={frameRef}
             darkMode={darkMode}
@@ -448,7 +449,8 @@ export function MarkdownCell({
             onError={(err) => logger.error("[MarkdownCell] iframe error:", err)}
             className="w-full"
           />
-        ) : (
+        </div>
+        {!cell.source && (
           <p className="text-muted-foreground italic">Double-click to edit</p>
         )}
         <button

--- a/src/components/isolated/__tests__/frame-html.test.ts
+++ b/src/components/isolated/__tests__/frame-html.test.ts
@@ -64,18 +64,23 @@ describe("generateFrameHtml", () => {
   });
 
   describe("dark mode", () => {
-    it("uses dark CSS variables when darkMode is true", () => {
+    it("uses transparent background to prevent flash", () => {
+      // Background is transparent initially; theme is applied via postMessage
       const darkHtml = generateFrameHtml({ darkMode: true });
-      // Dark mode uses #0a0a0a for background
-      expect(darkHtml).toContain("--bg-primary: #0a0a0a");
-      expect(darkHtml).toContain("--text-primary: #e0e0e0");
+      expect(darkHtml).toContain("--bg-primary: transparent");
+      expect(darkHtml).toContain("--bg-secondary: transparent");
     });
 
-    it("uses light CSS variables when darkMode is false", () => {
+    it("uses dark text colors when darkMode is true", () => {
+      const darkHtml = generateFrameHtml({ darkMode: true });
+      expect(darkHtml).toContain("--text-primary: #e0e0e0");
+      expect(darkHtml).toContain("--border-color: #333333");
+    });
+
+    it("uses light text colors when darkMode is false", () => {
       const lightHtml = generateFrameHtml({ darkMode: false });
-      // Light mode uses #ffffff for background
-      expect(lightHtml).toContain("--bg-primary: #ffffff");
       expect(lightHtml).toContain("--text-primary: #1a1a1a");
+      expect(lightHtml).toContain("--border-color: #e0e0e0");
     });
   });
 });

--- a/src/components/isolated/frame-html.ts
+++ b/src/components/isolated/frame-html.ts
@@ -32,6 +32,8 @@ export function generateFrameHtml(options: FrameHtmlOptions = {}): string {
     additionalScript = "",
   } = options;
 
+  // Start with transparent backgrounds to prevent flash while theme loads
+  // Parent will send theme message immediately after iframe is ready
   return `<!DOCTYPE html>
 <html>
 <head>
@@ -40,8 +42,8 @@ export function generateFrameHtml(options: FrameHtmlOptions = {}): string {
   <meta http-equiv="Content-Security-Policy" content="default-src 'self' blob: data:; script-src 'unsafe-inline' 'unsafe-eval' blob: https:; style-src 'unsafe-inline'; img-src * data: blob:; font-src * data:; connect-src *;">
   <style>
     :root {
-      --bg-primary: ${darkMode ? "#0a0a0a" : "#ffffff"};
-      --bg-secondary: ${darkMode ? "#1a1a1a" : "#f5f5f5"};
+      --bg-primary: transparent;
+      --bg-secondary: transparent;
       --text-primary: ${darkMode ? "#e0e0e0" : "#1a1a1a"};
       --text-secondary: ${darkMode ? "#a0a0a0" : "#666666"};
       --border-color: ${darkMode ? "#333333" : "#e0e0e0"};
@@ -360,6 +362,19 @@ export function generateFrameHtml(options: FrameHtmlOptions = {}): string {
         const rootEl = document.documentElement;
 
         if (isDark !== undefined) {
+          // Set class for Tailwind dark: variant and CSS selectors
+          if (isDark) {
+            rootEl.classList.add('dark');
+            rootEl.classList.remove('light');
+          } else {
+            rootEl.classList.add('light');
+            rootEl.classList.remove('dark');
+          }
+          // Set data-theme for components that check this attribute
+          rootEl.setAttribute('data-theme', isDark ? 'dark' : 'light');
+          // Set color-scheme for prefers-color-scheme media queries
+          rootEl.style.colorScheme = isDark ? 'dark' : 'light';
+          // Set CSS variables
           rootEl.style.setProperty('--bg-primary', isDark ? '#0a0a0a' : '#ffffff');
           rootEl.style.setProperty('--bg-secondary', isDark ? '#1a1a1a' : '#f5f5f5');
           rootEl.style.setProperty('--text-primary', isDark ? '#e0e0e0' : '#1a1a1a');

--- a/src/components/isolated/frame-html.ts
+++ b/src/components/isolated/frame-html.ts
@@ -63,6 +63,7 @@ export function generateFrameHtml(options: FrameHtmlOptions = {}): string {
       line-height: 1.5;
       background: transparent;
       color: var(--text-primary);
+      overflow: hidden;
     }
 
     /* Output container */

--- a/src/components/isolated/isolated-frame.tsx
+++ b/src/components/isolated/isolated-frame.tsx
@@ -248,15 +248,16 @@ export const IsolatedFrame = forwardRef<
     };
   }, []);
 
-  // Forward theme changes to iframe (without recreating the blob)
+  // Send theme as soon as iframe is ready (before renderer bootstrap)
+  // This prevents flash of wrong theme while React initializes
   useEffect(() => {
-    if (isReady && iframeRef.current?.contentWindow) {
+    if (isIframeReady && iframeRef.current?.contentWindow) {
       iframeRef.current.contentWindow.postMessage(
         { type: "theme", payload: { isDark: darkMode } },
         "*",
       );
     }
-  }, [darkMode, isReady]);
+  }, [darkMode, isIframeReady]);
 
   // Keep ref in sync with state (ref avoids stale closures in callbacks)
   useEffect(() => {
@@ -532,6 +533,8 @@ export const IsolatedFrame = forwardRef<
         height: `${height}px`,
         border: "none",
         display: "block",
+        background: "transparent",
+        colorScheme: darkMode ? "dark" : "light",
       }}
       title="Isolated output frame"
     />

--- a/src/components/isolated/isolated-frame.tsx
+++ b/src/components/isolated/isolated-frame.tsx
@@ -91,6 +91,14 @@ export interface IsolatedFrameProps {
    * Callback for all messages from the iframe (for debugging or custom handling).
    */
   onMessage?: (message: IframeToParentMessage) => void;
+
+  /**
+   * When true, iframe starts hidden (0 height, 0 opacity) and reveals
+   * with animation after content is rendered. Use for markdown cells
+   * to prevent flash of empty/unstyled content during bootstrap.
+   * @default false
+   */
+  revealOnRender?: boolean;
 }
 
 export interface IsolatedFrameHandle {
@@ -210,6 +218,7 @@ export const IsolatedFrame = forwardRef<
     onWidgetUpdate,
     onError,
     onMessage,
+    revealOnRender = false,
   },
   ref,
 ) {
@@ -229,6 +238,8 @@ export const IsolatedFrame = forwardRef<
   // Use ref to track ready state for send callback (avoids stale closure)
   const isReadyRef = useRef(false);
   const [height, setHeight] = useState(minHeight);
+  // Track if content has been rendered (for revealOnRender mode)
+  const [isContentRendered, setIsContentRendered] = useState(false);
 
   // Queue messages until iframe is ready
   const pendingMessagesRef = useRef<ParentToIframeMessage[]>([]);
@@ -341,6 +352,8 @@ export const IsolatedFrame = forwardRef<
             // them so they don't get delivered to the reloaded frame.
             pendingMessagesRef.current.length = 0;
             setIsReady(false);
+            // Reset content rendered state for revealOnRender mode
+            setIsContentRendered(false);
           }
 
           // Renderer injection is handled by a separate useEffect that depends
@@ -381,6 +394,18 @@ export const IsolatedFrame = forwardRef<
 
         case "resize":
           if (data.payload?.height != null) {
+            const newHeight = autoHeight
+              ? Math.max(minHeight, data.payload.height)
+              : Math.max(minHeight, Math.min(maxHeight, data.payload.height));
+            setHeight(newHeight);
+            onResize?.(newHeight);
+          }
+          break;
+
+        case "render_complete":
+          // Content has been rendered - reveal iframe if in revealOnRender mode
+          if (data.payload?.height != null) {
+            setIsContentRendered(true);
             const newHeight = autoHeight
               ? Math.max(minHeight, data.payload.height)
               : Math.max(minHeight, Math.min(maxHeight, data.payload.height));
@@ -520,6 +545,10 @@ export const IsolatedFrame = forwardRef<
     return null;
   }
 
+  // Compute display values for revealOnRender mode
+  const displayHeight = revealOnRender && !isContentRendered ? 0 : height;
+  const displayOpacity = revealOnRender && !isContentRendered ? 0 : 1;
+
   return (
     <iframe
       ref={iframeRef}
@@ -530,11 +559,15 @@ export const IsolatedFrame = forwardRef<
       data-slot="isolated-frame"
       style={{
         width: "100%",
-        height: `${height}px`,
+        height: `${displayHeight}px`,
+        opacity: displayOpacity,
         border: "none",
         display: "block",
         background: "transparent",
         colorScheme: darkMode ? "dark" : "light",
+        transition: revealOnRender
+          ? "height 150ms ease-out, opacity 150ms ease-out"
+          : undefined,
       }}
       title="Isolated output frame"
     />

--- a/src/isolated-renderer/index.tsx
+++ b/src/isolated-renderer/index.tsx
@@ -314,8 +314,8 @@ export function init() {
   // Set up message listener
   setupMessageListener();
 
-  // Initialize theme to dark (default) - will be updated by parent if needed
-  updateDocumentTheme(true);
+  // Theme is controlled by parent's theme message (sent when iframe is ready)
+  // Don't set a default here to avoid flash when parent sends different theme
 
   // Create root element if needed
   let rootEl = document.getElementById("root");


### PR DESCRIPTION
## Summary

Fixes two user-facing issues with markdown cell rendering:

1. **Dark mode flickering** - iframes started with baked-in background colors before theme message arrived, causing visible flash on load.
2. **Slow loading** - each markdown cell created its iframe lazily when viewed, causing noticeable delay.

## Changes

- Start iframes with transparent backgrounds (theme applied via postMessage)
- Send theme message immediately when iframe bootstrap completes (before React renderer)
- Always render markdown cell iframes (hidden when editing/empty) for preloading

## Verification

* [x] Open a notebook with markdown cells in dark mode - no white flash on load
* [x] Toggle theme while notebook is open - smooth transition without flicker
* [x] Create and edit new markdown cell - instant rendering after exiting edit mode
* [x] Load notebook with 10+ markdown cells - noticeably faster appearance

---

_PR submitted by @rgbkrk's agent, Quill_