### PR TITLE
feat(notebook): cell visibility UI (source/outputs)

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -117,6 +117,8 @@ function AppContent() {
     updateOutputByDisplayId,
     setExecutionCount,
     clearCellOutputs,
+    setCellSourceHidden,
+    setCellOutputsHidden,
   } = useAutomergeNotebook();
 
   // Global find (Cmd+F)
@@ -1106,6 +1108,8 @@ function AppContent() {
         onMoveCell={moveCell}
         onClearPagePayload={clearPagePayload}
         onReportOutputMatchCount={globalFind.reportOutputMatchCount}
+        onSetCellSourceHidden={setCellSourceHidden}
+        onSetCellOutputsHidden={setCellOutputsHidden}
       />
     </div>
   );

--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -1,5 +1,5 @@
 import type { EditorView, KeyBinding } from "@codemirror/view";
-import { Trash2, X } from "lucide-react";
+import { ChevronRight, Code2, EyeOff, Trash2, X } from "lucide-react";
 import {
   lazy,
   Suspense,
@@ -21,6 +21,7 @@ import { remoteCursorsExtension } from "@/components/editor/remote-cursors";
 import { searchHighlight } from "@/components/editor/search-highlight";
 import { AnsiOutput } from "@/components/outputs/ansi-output";
 import { ErrorBoundary } from "@/lib/error-boundary";
+import { cn } from "@/lib/utils";
 import type { CellPagePayload, MimeBundle } from "../App";
 import { useCellKeyboardNavigation } from "../hooks/useCellKeyboardNavigation";
 import { registerEditor, unregisterEditor } from "../lib/cursor-registry";
@@ -102,6 +103,10 @@ interface CodeCellProps {
   dragHandleProps?: Record<string, unknown>;
   /** Whether this cell is currently being dragged */
   isDragging?: boolean;
+  /** Callback to toggle source visibility (JupyterLab convention) */
+  onToggleSourceHidden?: (hidden: boolean) => void;
+  /** Callback to toggle outputs visibility (JupyterLab convention) */
+  onToggleOutputsHidden?: (hidden: boolean) => void;
 }
 
 export function CodeCell({
@@ -126,9 +131,23 @@ export function CodeCell({
   isPreviousCellFromFocused,
   dragHandleProps,
   isDragging,
+  onToggleSourceHidden,
+  onToggleOutputsHidden,
 }: CodeCellProps) {
   const editorRef = useRef<CodeMirrorEditorRef>(null);
   const [historyDialogOpen, setHistoryDialogOpen] = useState(false);
+
+  // Check cell metadata for visibility (JupyterLab convention)
+  const isSourceHidden =
+    (cell.metadata?.jupyter as { source_hidden?: boolean })?.source_hidden ===
+    true;
+  const isOutputsHidden =
+    (cell.metadata?.jupyter as { outputs_hidden?: boolean })?.outputs_hidden ===
+    true;
+
+  // When both are hidden, show a compact single-row layout with both badges side by side
+  const bothHidden =
+    isSourceHidden && isOutputsHidden && cell.outputs.length > 0;
 
   // Register EditorView with the cursor registry for remote cursor rendering.
   // We use a ref + polling approach because the EditorView is created async
@@ -273,15 +292,35 @@ export function CodeCell({
   );
 
   const rightGutterContent = (
-    <button
-      type="button"
-      tabIndex={-1}
-      onClick={onDelete}
-      className="flex items-center justify-center rounded p-1 text-muted-foreground/40 transition-colors hover:text-destructive"
-      title="Delete cell"
-    >
-      <Trash2 className="h-3.5 w-3.5" />
-    </button>
+    <div className="flex flex-col gap-0.5">
+      {/* Toggle source visibility (not shown when both hidden - badges handle it) */}
+      {onToggleSourceHidden && !bothHidden && (
+        <button
+          type="button"
+          tabIndex={-1}
+          onClick={() => onToggleSourceHidden(!isSourceHidden)}
+          className={cn(
+            "flex items-center justify-center rounded p-1 transition-colors hover:text-foreground",
+            isSourceHidden
+              ? "text-muted-foreground/70"
+              : "text-muted-foreground/40",
+          )}
+          title={isSourceHidden ? "Show source" : "Hide source"}
+        >
+          <Code2 className="h-3.5 w-3.5" />
+        </button>
+      )}
+      {/* Delete button */}
+      <button
+        type="button"
+        tabIndex={-1}
+        onClick={onDelete}
+        className="flex items-center justify-center rounded p-1 text-muted-foreground/40 transition-colors hover:text-destructive"
+        title="Delete cell"
+      >
+        <Trash2 className="h-3.5 w-3.5" />
+      </button>
+    </div>
   );
 
   return (
@@ -298,8 +337,51 @@ export function CodeCell({
         isDragging={isDragging}
         codeContent={
           <>
-            {/* Editor */}
-            <div>
+            {/* Source visibility toggle + Editor */}
+            {bothHidden ? (
+              /* Compact layout: both badges side by side when both hidden */
+              <div className="flex justify-end gap-2">
+                <button
+                  type="button"
+                  onClick={() => onToggleSourceHidden?.(false)}
+                  className="inline-flex items-center gap-1 px-2 py-0.5 text-xs text-muted-foreground hover:text-foreground bg-muted/50 hover:bg-muted rounded transition-colors"
+                  title="Show source"
+                >
+                  <Code2 className="h-3 w-3" />
+                  <span className="font-mono truncate max-w-32">
+                    {cell.source.split("\n")[0] || "source"}
+                  </span>
+                  <ChevronRight className="h-3 w-3" />
+                </button>
+                <button
+                  type="button"
+                  onClick={() => onToggleOutputsHidden?.(false)}
+                  className="inline-flex items-center gap-1 px-2 py-0.5 text-xs text-muted-foreground hover:text-foreground bg-muted/50 hover:bg-muted rounded transition-colors"
+                  title="Show outputs"
+                >
+                  <span>
+                    {cell.outputs.length} output
+                    {cell.outputs.length !== 1 ? "s" : ""}
+                  </span>
+                  <ChevronRight className="h-3 w-3" />
+                </button>
+              </div>
+            ) : isSourceHidden ? (
+              <div className="flex justify-end">
+                <button
+                  type="button"
+                  onClick={() => onToggleSourceHidden?.(false)}
+                  className="inline-flex items-center gap-1 px-2 py-0.5 text-xs text-muted-foreground hover:text-foreground bg-muted/50 hover:bg-muted rounded transition-colors"
+                  title="Show source"
+                >
+                  <Code2 className="h-3 w-3" />
+                  <span className="font-mono truncate max-w-48">
+                    {cell.source.split("\n")[0] || "source"}
+                  </span>
+                  <ChevronRight className="h-3 w-3" />
+                </button>
+              </div>
+            ) : (
               <CodeMirrorEditor
                 ref={editorRef}
                 value={cell.source}
@@ -311,7 +393,7 @@ export function CodeCell({
                 className="min-h-[2rem]"
                 autoFocus={isFocused}
               />
-            </div>
+            )}
 
             {/* Page Payload (documentation from ? or ??) */}
             {pagePayload && (
@@ -334,15 +416,47 @@ export function CodeCell({
           </>
         }
         outputContent={
-          <OutputArea
-            outputs={cell.outputs}
-            preloadIframe
-            searchQuery={searchQuery}
-            onSearchMatchCount={onSearchMatchCount}
-            onLinkClick={(url) => openUrl(url)}
-          />
+          isOutputsHidden && cell.outputs.length > 0 ? (
+            <div className="flex justify-end">
+              <button
+                type="button"
+                onClick={() => onToggleOutputsHidden?.(false)}
+                className="inline-flex items-center gap-1 px-2 py-0.5 text-xs text-muted-foreground hover:text-foreground bg-muted/50 hover:bg-muted rounded transition-colors"
+                title="Show outputs"
+              >
+                <span>
+                  {cell.outputs.length} output
+                  {cell.outputs.length !== 1 ? "s" : ""}
+                </span>
+                <ChevronRight className="h-3 w-3" />
+              </button>
+            </div>
+          ) : (
+            <OutputArea
+              outputs={cell.outputs}
+              preloadIframe
+              searchQuery={searchQuery}
+              onSearchMatchCount={onSearchMatchCount}
+              onLinkClick={(url) => openUrl(url)}
+            />
+          )
         }
-        hideOutput={cell.outputs.length === 0}
+        outputRightGutterContent={
+          onToggleOutputsHidden &&
+          cell.outputs.length > 0 &&
+          !isOutputsHidden ? (
+            <button
+              type="button"
+              tabIndex={-1}
+              onClick={() => onToggleOutputsHidden(true)}
+              className="flex items-center justify-center rounded p-1 text-muted-foreground/40 transition-colors hover:text-foreground"
+              title="Hide outputs"
+            >
+              <EyeOff className="h-3.5 w-3.5" />
+            </button>
+          ) : undefined
+        }
+        hideOutput={cell.outputs.length === 0 || bothHidden}
       />
 
       {/* History Search Dialog (Ctrl+R) - lazy loaded */}

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -53,6 +53,8 @@ interface NotebookViewProps {
   onMoveCell: (cellId: string, afterCellId?: string | null) => void;
   onClearPagePayload: (cellId: string) => void;
   onReportOutputMatchCount?: (cellId: string, count: number) => void;
+  onSetCellSourceHidden?: (cellId: string, hidden: boolean) => void;
+  onSetCellOutputsHidden?: (cellId: string, hidden: boolean) => void;
 }
 
 function AddCellButtons({
@@ -274,6 +276,8 @@ function NotebookViewContent({
   onMoveCell,
   onClearPagePayload,
   onReportOutputMatchCount,
+  onSetCellSourceHidden,
+  onSetCellOutputsHidden,
 }: NotebookViewProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const { focusCell } = useEditorRegistry();
@@ -442,6 +446,16 @@ function NotebookViewContent({
             isLastCell={index === cells.length - 1}
             dragHandleProps={dragHandleProps}
             isDragging={isDragging}
+            onToggleSourceHidden={
+              onSetCellSourceHidden
+                ? (hidden: boolean) => onSetCellSourceHidden(cell.id, hidden)
+                : undefined
+            }
+            onToggleOutputsHidden={
+              onSetCellOutputsHidden
+                ? (hidden: boolean) => onSetCellOutputsHidden(cell.id, hidden)
+                : undefined
+            }
           />
         );
       }
@@ -505,6 +519,8 @@ function NotebookViewContent({
       onAddCell,
       onClearPagePayload,
       onReportOutputMatchCount,
+      onSetCellSourceHidden,
+      onSetCellOutputsHidden,
       focusCell,
     ],
   );

--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -558,6 +558,48 @@ export function useAutomergeNotebook() {
     );
   }, []);
 
+  // ── Cell visibility ─────────────────────────────────────────────────
+
+  const setCellSourceHidden = useCallback(
+    (cellId: string, hidden: boolean) => {
+      const handle = handleRef.current;
+      if (!handle || awaitingInitialSyncRef.current) return;
+
+      // Mutate WASM (instant, local-first)
+      const updated = handle.set_cell_source_hidden(cellId, hidden);
+      if (!updated) return;
+
+      // Re-read from WASM (single source of truth)
+      rematerializeCellsSync(handle);
+
+      // Sync to daemon (fire-and-forget)
+      syncToRelay(handle);
+
+      setDirty(true);
+    },
+    [rematerializeCellsSync, syncToRelay],
+  );
+
+  const setCellOutputsHidden = useCallback(
+    (cellId: string, hidden: boolean) => {
+      const handle = handleRef.current;
+      if (!handle || awaitingInitialSyncRef.current) return;
+
+      // Mutate WASM (instant, local-first)
+      const updated = handle.set_cell_outputs_hidden(cellId, hidden);
+      if (!updated) return;
+
+      // Re-read from WASM (single source of truth)
+      rematerializeCellsSync(handle);
+
+      // Sync to daemon (fire-and-forget)
+      syncToRelay(handle);
+
+      setDirty(true);
+    },
+    [rematerializeCellsSync, syncToRelay],
+  );
+
   // ── Public interface ───────────────────────────────────────────────
 
   return {
@@ -576,5 +618,7 @@ export function useAutomergeNotebook() {
     dirty,
     updateOutputByDisplayId,
     setExecutionCount,
+    setCellSourceHidden,
+    setCellOutputsHidden,
   };
 }

--- a/src/components/cell/CellContainer.tsx
+++ b/src/components/cell/CellContainer.tsx
@@ -17,8 +17,10 @@ interface CellContainerProps {
   children?: ReactNode;
   /** Content to render in the left gutter action area (e.g., play button, execution count) */
   gutterContent?: ReactNode;
-  /** Content to render in the right margin (e.g., cell controls, kebab menu) */
+  /** Content to render in the right margin aligned with code row (e.g., cell controls) */
   rightGutterContent?: ReactNode;
+  /** Content to render in the right margin aligned with output row (e.g., output controls) */
+  outputRightGutterContent?: ReactNode;
   /** Custom color configuration for cell types not in defaults */
   customGutterColors?: Record<string, GutterColorConfig>;
   /** Whether this cell is immediately before the focused cell (keeps output bright) */
@@ -43,6 +45,7 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
       children,
       gutterContent,
       rightGutterContent,
+      outputRightGutterContent,
       customGutterColors,
       isPreviousCellFromFocused = false,
       dragHandleProps,
@@ -86,7 +89,7 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
         {/* Cell content with ribbon */}
         {useSegmentedRibbon ? (
           <div className="flex min-w-0 flex-1 flex-col">
-            {/* Code row - ribbon + content together so heights match */}
+            {/* Code row - ribbon + content + right gutter */}
             <div className="flex">
               <div
                 {...dragHandleProps}
@@ -99,8 +102,21 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
                 )}
               />
               <div className="min-w-0 flex-1 py-3 pl-6 pr-3">{codeContent}</div>
+              {/* Code row right gutter */}
+              {rightGutterContent && (
+                <div
+                  className={cn(
+                    "flex w-10 flex-shrink-0 flex-col items-center gap-1 pt-1 select-none",
+                    "opacity-100 transition-opacity duration-150",
+                    "sm:opacity-0 sm:group-hover:opacity-100 sm:focus-within:opacity-100",
+                    isFocused && "sm:opacity-100",
+                  )}
+                >
+                  {rightGutterContent}
+                </div>
+              )}
             </div>
-            {/* Output row - ribbon + content together */}
+            {/* Output row - ribbon + content + right gutter */}
             {hasOutput && (
               <div className={cn("flex", hideOutput && "hidden")}>
                 <div
@@ -117,37 +133,52 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
                 >
                   {outputContent}
                 </div>
+                {/* Output row right gutter */}
+                {outputRightGutterContent && (
+                  <div
+                    className={cn(
+                      "flex w-10 flex-shrink-0 flex-col items-center gap-1 pt-1 select-none",
+                      "opacity-100 transition-opacity duration-150",
+                      "sm:opacity-0 sm:group-hover:opacity-100 sm:focus-within:opacity-100",
+                      isFocused && "sm:opacity-100",
+                    )}
+                  >
+                    {outputRightGutterContent}
+                  </div>
+                )}
               </div>
             )}
           </div>
         ) : (
-          /* Legacy layout - ribbon + content side by side */
-          <div className="flex min-w-0 flex-1">
-            <div
-              {...dragHandleProps}
-              className={cn(
-                "w-1 self-stretch transition-colors duration-150",
-                ribbonColor,
-                dragHandleProps &&
-                  "cursor-grab hover:brightness-125 touch-none",
-                isDragging && "cursor-grabbing",
-              )}
-            />
-            <div className="min-w-0 flex-1 py-3 pl-6 pr-3">{children}</div>
-          </div>
-        )}
-        {/* Right margin - pt-3 aligns with left gutter, appears on hover/focus */}
-        {rightGutterContent && (
-          <div
-            className={cn(
-              "flex w-10 flex-shrink-0 flex-col items-center gap-1 pt-3 select-none",
-              "opacity-100 transition-opacity duration-150",
-              "sm:opacity-0 sm:group-hover:opacity-100 sm:focus-within:opacity-100",
-              isFocused && "sm:opacity-100",
+          <>
+            {/* Legacy layout - ribbon + content side by side */}
+            <div className="flex min-w-0 flex-1">
+              <div
+                {...dragHandleProps}
+                className={cn(
+                  "w-1 self-stretch transition-colors duration-150",
+                  ribbonColor,
+                  dragHandleProps &&
+                    "cursor-grab hover:brightness-125 touch-none",
+                  isDragging && "cursor-grabbing",
+                )}
+              />
+              <div className="min-w-0 flex-1 py-3 pl-6 pr-3">{children}</div>
+            </div>
+            {/* Right margin for legacy layout */}
+            {rightGutterContent && (
+              <div
+                className={cn(
+                  "flex w-10 flex-shrink-0 flex-col items-center gap-1 pt-3 select-none",
+                  "opacity-100 transition-opacity duration-150",
+                  "sm:opacity-0 sm:group-hover:opacity-100 sm:focus-within:opacity-100",
+                  isFocused && "sm:opacity-100",
+                )}
+              >
+                {rightGutterContent}
+              </div>
             )}
-          >
-            {rightGutterContent}
-          </div>
+          </>
         )}
       </div>
     );


### PR DESCRIPTION
## Summary

Add user-facing controls to show/hide cell source and outputs using JupyterLab metadata conventions (`metadata.jupyter.source_hidden`, `metadata.jupyter.outputs_hidden`). The UI integrates with the existing WASM bindings added in #739.

**Layout:**
- Source toggle + delete button in right gutter (aligned with code row)
- Output hide button in right gutter (aligned with output row, appears on hover)
- When both source and outputs are hidden: compact side-by-side badges with expand controls

**Key Changes:**
- Add `setCellSourceHidden` / `setCellOutputsHidden` callbacks to `useAutomergeNotebook`
- Thread visibility callbacks through `NotebookView` → `CodeCell`
- Add `outputRightGutterContent` prop to `CellContainer` for per-row gutter controls
- Visibility state indicated by button opacity and color

## Test Plan

* [ ] Hide cell source - verify metadata updates and UI shows badge with first line preview
* [ ] Show cell source - verify editor reappears and metadata clears
* [ ] Hide cell outputs - verify output area replaced with badge showing output count
* [ ] Show cell outputs - verify badge replaced with output content
* [ ] Hide both source and outputs - verify compact two-badge layout in single row
* [ ] Unhide from badges - verify correct row expands
* [ ] Output hide button appears on hover - verify visibility toggle works from both locations

---

_PR submitted by @rgbkrk's agent, Quill_