### PR TITLE
fix(runtimed-py): widen shell/iopub drain window to fix flaky test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -750,6 +750,28 @@ jobs:
         working-directory: python/runtimed
         run: uv run maturin develop --manifest-path ../../crates/runtimed-py/Cargo.toml
 
+      - name: Inspect binary and Python module
+        working-directory: python/runtimed
+        run: |
+          echo "=== runtimed binary ==="
+          ls -la "${GITHUB_WORKSPACE}/target/release/runtimed"
+          file "${GITHUB_WORKSPACE}/target/release/runtimed"
+          sha256sum "${GITHUB_WORKSPACE}/target/release/runtimed" | cut -c1-16
+          "${GITHUB_WORKSPACE}/target/release/runtimed" --version || true
+
+          echo ""
+          echo "=== runtimed Python module ==="
+          uv run python -c "
+          import runtimed
+          print(f'module file: {runtimed.__file__}')
+          print(f'version:     {getattr(runtimed, \"__version__\", \"N/A\")}')
+          print(f'dir:         {sorted(d for d in dir(runtimed) if not d.startswith(\"_\"))}')
+          "
+
+          echo ""
+          echo "=== installed packages ==="
+          uv pip list 2>/dev/null | grep -i runtimed || uv run pip list | grep -i runtimed || true
+
       - name: Run unit tests
         working-directory: python/runtimed
         run: uv run pytest tests/test_session_unit.py -v --tb=short
@@ -768,7 +790,7 @@ jobs:
           export RUNTIMED_WORKSPACE_PATH="${GITHUB_WORKSPACE}"
 
           # Run tests (daemon is spawned by the test fixture)
-          uv run pytest tests/test_daemon_integration.py -v --tb=short 2>&1 | tee integration-logs/test-output.log || FAIL=1
+          uv run pytest tests/test_daemon_integration.py -v -s --tb=short 2>&1 | tee integration-logs/test-output.log || FAIL=1
 
           exit ${FAIL:-0}
 

--- a/crates/runtimed-py/src/async_session.rs
+++ b/crates/runtimed-py/src/async_session.rs
@@ -2155,7 +2155,10 @@ async fn collect_outputs_async(
     let mut outputs = Vec::new();
     let mut execution_count = None;
     let mut success = true;
-    let mut done_received = false;
+    // Drain deadline: set when ExecutionDone arrives. We keep draining
+    // broadcasts until this deadline to catch straggling iopub messages
+    // that arrive after the shell reply (classic Jupyter race).
+    let mut drain_deadline: Option<tokio::time::Instant> = None;
 
     loop {
         let mut state_guard = state.lock().await;
@@ -2165,7 +2168,10 @@ async fn collect_outputs_async(
             .as_mut()
             .ok_or_else(|| to_py_err("Not connected"))?;
 
-        let timeout_ms = if done_received { 50 } else { 100 };
+        // Before ExecutionDone: 100ms poll interval.
+        // After ExecutionDone: 50ms polls but keep going until the
+        // drain deadline (500ms after done) expires.
+        let timeout_ms = if drain_deadline.is_some() { 50 } else { 100 };
         let broadcast = tokio::time::timeout(
             std::time::Duration::from_millis(timeout_ms),
             broadcast_rx.recv(),
@@ -2221,16 +2227,24 @@ async fn collect_outputs_async(
                         cell_id: msg_cell_id,
                     } => {
                         if msg_cell_id == cell_id {
+                            // Don't break immediately - set a drain deadline to catch
+                            // straggling outputs due to shell/iopub race condition.
+                            // 500ms is generous enough to catch late iopub messages
+                            // while not noticeably slowing down normal execution.
                             log::debug!(
-                                "[async_session] ExecutionDone received, starting drain phase"
+                                "[async_session] ExecutionDone received, draining for 500ms"
                             );
-                            done_received = true;
+                            drain_deadline = Some(
+                                tokio::time::Instant::now() + std::time::Duration::from_millis(500),
+                            );
                         }
                     }
                     NotebookBroadcast::KernelError { error } => {
                         success = false;
                         outputs.push(Output::error("KernelError", &error, vec![]));
-                        done_received = true;
+                        drain_deadline = Some(
+                            tokio::time::Instant::now() + std::time::Duration::from_millis(500),
+                        );
                     }
                     _ => {}
                 }
@@ -2239,13 +2253,18 @@ async fn collect_outputs_async(
                 return Err(to_py_err("Broadcast channel closed"));
             }
             Err(_) => {
-                if done_received {
-                    log::debug!(
-                        "[async_session] Drain timeout, finishing with {} outputs",
-                        outputs.len()
-                    );
-                    break;
+                // Timeout - if drain deadline has passed, we're done
+                if let Some(deadline) = drain_deadline {
+                    if tokio::time::Instant::now() >= deadline {
+                        log::debug!(
+                            "[async_session] Drain deadline reached, finishing with {} outputs",
+                            outputs.len()
+                        );
+                        break;
+                    }
+                    // Deadline not yet reached - keep draining
                 }
+                // Otherwise continue waiting for ExecutionDone
             }
         }
     }

--- a/crates/runtimed-py/src/session.rs
+++ b/crates/runtimed-py/src/session.rs
@@ -1737,7 +1737,10 @@ impl Session {
         let mut outputs = Vec::new();
         let mut execution_count = None;
         let mut success = true;
-        let mut done_received = false;
+        // Drain deadline: set when ExecutionDone arrives. We keep draining
+        // broadcasts until this deadline to catch straggling iopub messages
+        // that arrive after the shell reply (classic Jupyter race).
+        let mut drain_deadline: Option<tokio::time::Instant> = None;
 
         loop {
             let mut state = self.state.lock().await;
@@ -1747,8 +1750,10 @@ impl Session {
                 .as_mut()
                 .ok_or_else(|| to_py_err("Not connected"))?;
 
-            // Use a short timeout - shorter after done to drain quickly
-            let timeout_ms = if done_received { 50 } else { 100 };
+            // Before ExecutionDone: 100ms poll interval.
+            // After ExecutionDone: 50ms polls but keep going until the
+            // drain deadline (500ms after done) expires.
+            let timeout_ms = if drain_deadline.is_some() { 50 } else { 100 };
             let broadcast = tokio::time::timeout(
                 std::time::Duration::from_millis(timeout_ms),
                 broadcast_rx.recv(),
@@ -1816,18 +1821,23 @@ impl Session {
                             cell_id: msg_cell_id,
                         } => {
                             if msg_cell_id == cell_id {
-                                // Don't break immediately - drain for a bit to catch
-                                // straggling outputs due to shell/iopub race condition
-                                log::debug!(
-                                    "[session] ExecutionDone received, starting drain phase"
+                                // Don't break immediately - set a drain deadline to catch
+                                // straggling outputs due to shell/iopub race condition.
+                                // 500ms is generous enough to catch late iopub messages
+                                // while not noticeably slowing down normal execution.
+                                log::debug!("[session] ExecutionDone received, draining for 500ms");
+                                drain_deadline = Some(
+                                    tokio::time::Instant::now()
+                                        + std::time::Duration::from_millis(500),
                                 );
-                                done_received = true;
                             }
                         }
                         NotebookBroadcast::KernelError { error } => {
                             success = false;
                             outputs.push(Output::error("KernelError", &error, vec![]));
-                            done_received = true;
+                            drain_deadline = Some(
+                                tokio::time::Instant::now() + std::time::Duration::from_millis(500),
+                            );
                         }
                         _ => {
                             // Ignore other broadcasts (KernelStatus, QueueChanged, etc.)
@@ -1839,15 +1849,18 @@ impl Session {
                     return Err(to_py_err("Broadcast channel closed"));
                 }
                 Err(_) => {
-                    // Timeout - if we've seen ExecutionDone, we're done draining
-                    if done_received {
-                        log::debug!(
-                            "[session] Drain timeout, finishing with {} outputs",
-                            outputs.len()
-                        );
-                        break;
+                    // Timeout - if drain deadline has passed, we're done
+                    if let Some(deadline) = drain_deadline {
+                        if tokio::time::Instant::now() >= deadline {
+                            log::debug!(
+                                "[session] Drain deadline reached, finishing with {} outputs",
+                                outputs.len()
+                            );
+                            break;
+                        }
+                        // Deadline not yet reached - keep draining
                     }
-                    // Otherwise continue waiting
+                    // Otherwise continue waiting for ExecutionDone
                 }
             }
         }

--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -19,6 +19,7 @@ Environment variables:
 """
 
 import asyncio
+import hashlib
 import inspect
 import os
 import subprocess
@@ -219,6 +220,26 @@ def daemon_process():
     # CI mode: spawn our own daemon
     binary = _find_runtimed_binary()
     log_level = os.environ.get("RUNTIMED_LOG_LEVEL", "info")
+
+    # Log binary diagnostics to help detect stale binaries in CI
+    print(f"[test] Binary path: {binary}", file=sys.stderr)
+    print(f"[test] Binary exists: {binary.exists()}", file=sys.stderr)
+    if binary.exists():
+        stat = binary.stat()
+        print(f"[test] Binary size: {stat.st_size} bytes", file=sys.stderr)
+        print(f"[test] Binary mtime: {stat.st_mtime}", file=sys.stderr)
+        sha = hashlib.sha256(binary.read_bytes()).hexdigest()[:16]
+        print(f"[test] Binary sha256 prefix: {sha}", file=sys.stderr)
+        try:
+            ver = subprocess.run(
+                [str(binary), "--version"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            print(f"[test] Binary version: {ver.stdout.strip()}", file=sys.stderr)
+        except Exception as e:
+            print(f"[test] Could not get binary version: {e}", file=sys.stderr)
 
     # Create a temp directory for this test run
     # ignore_cleanup_errors=True prevents OSError when ipykernel leaves behind

--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -1,4 +1,4 @@
-"""Integration tests for runtimed daemon client.  # CI probe run 3
+"""Integration tests for runtimed daemon client.  # CI probe run 4
 
 These tests exercise the full daemon integration, including:
 - Document-first execution (automerge sync)

--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -1,4 +1,4 @@
-"""Integration tests for runtimed daemon client.
+"""Integration tests for runtimed daemon client.  # CI probe run 3
 
 These tests exercise the full daemon integration, including:
 - Document-first execution (automerge sync)

--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -1,4 +1,4 @@
-"""Integration tests for runtimed daemon client.
+"""Integration tests for runtimed daemon client.  # CI probe run 6
 
 These tests exercise the full daemon integration, including:
 - Document-first execution (automerge sync)

--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -1,4 +1,4 @@
-"""Integration tests for runtimed daemon client.  # CI probe run 4
+"""Integration tests for runtimed daemon client.
 
 These tests exercise the full daemon integration, including:
 - Document-first execution (automerge sync)


### PR DESCRIPTION
Started as a CI probe to check whether the uv workspace changes (#731) caused stale binary issues — they didn't. Binary + Python module diagnostics confirmed everything builds fresh from the commit.

What we found: two distinct flakes in the integration tests, both in error-path execution:

### 1. Shell/iopub race — 50ms drain too short (FIXED)
`test_error_traceback_captured` gets `status=ok, outputs=0` because the error output arrives after `ExecutionDone` and the 50ms drain window misses it. Fixed by using a 500ms drain deadline.

### 2. `collect_outputs` deadlock (NOT YET FIXED)
`test_execution_error_captured` hangs for the full 600s pytest timeout. The 60s tokio timeout inside `execute_cell` doesn't fire — likely a `block_on` + signal interaction issue. The daemon may not be sending `ExecutionDone` for certain error cases, and the tokio timeout inside `runtime.block_on()` doesn't propagate correctly when pytest's signal-based timeout handler fires.

**CI results (runtimed-py integration):**

| Run | Result | Notes |
|-----|--------|-------|
| 1 | ✅ 115 passed | Pre-fix, no diagnostics |
| 2 | ❌ `test_error_traceback_captured` | Race: `status=ok, outputs=0` (50ms drain) |
| 3 | ✅ 115 passed | Pre-fix |
| 4 | ✅ 115 passed | Pre-fix |
| 5 | ✅ 115 passed | With drain fix |
| 6 | ❌ `test_execution_error_captured` | Hung 600s — `ExecutionDone` never received |

_PR submitted by @rgbkrk's agent Quill, via Zed_