### PR TITLE
fix(ci): upgrade upload-artifact v7 to v8 for download compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,7 +121,7 @@ jobs:
           pnpm --dir apps/notebook build
 
       - name: Upload UI build artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: ui-build-dist
           path: |
@@ -138,7 +138,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Download UI build artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v4
         with:
           name: ui-build-dist
           path: apps
@@ -212,7 +212,7 @@ jobs:
           fi
 
       - name: Upload Linux Rust binaries
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: linux-rust-binaries
           path: |
@@ -239,7 +239,7 @@ jobs:
           cp ~/.cargo/bin/tauri-driver target/release/binaries/tauri-driver
 
       - name: Upload E2E app
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: e2e-app-linux
           path: |
@@ -297,7 +297,7 @@ jobs:
 
       - name: Download UI build artifacts
         if: needs.changes.outputs.source_changed == 'true' && (github.event_name != 'pull_request' || matrix.platform.run_on_pr)
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v4
         with:
           name: ui-build-dist
           path: apps
@@ -389,7 +389,7 @@ jobs:
         run: pnpm install
 
       - name: Download E2E artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v4
         with:
           name: e2e-app-linux
           path: ./target/release
@@ -482,7 +482,7 @@ jobs:
 
       - name: Upload failure screenshots
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: e2e-screenshots
           path: e2e-screenshots/failures/
@@ -490,7 +490,7 @@ jobs:
 
       - name: Upload daemon logs
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: e2e-daemon-logs
           path: e2e-logs/
@@ -538,7 +538,7 @@ jobs:
         run: pnpm install
 
       - name: Download E2E artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v4
         with:
           name: e2e-app-linux
           path: ./target/release
@@ -699,7 +699,7 @@ jobs:
 
       - name: Upload failure screenshots
         if: failure()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: e2e-fixture-screenshots
           path: e2e-screenshots/failures/
@@ -707,7 +707,7 @@ jobs:
 
       - name: Upload test logs
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: e2e-fixture-logs
           path: e2e-logs/
@@ -735,7 +735,7 @@ jobs:
           shared-key: ubuntu-latest
 
       - name: Download Linux Rust binaries
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v4
         with:
           name: linux-rust-binaries
           path: .
@@ -774,7 +774,7 @@ jobs:
 
       - name: Upload test logs
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: runtimed-py-integration-logs
           path: python/runtimed/integration-logs/

--- a/.github/workflows/pr-binary-generation.yml
+++ b/.github/workflows/pr-binary-generation.yml
@@ -274,7 +274,7 @@ jobs:
 
       - name: Upload runnable binary artifact
         id: upload-artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ needs.resolve-pr.outputs.artifact_prefix }}-${{ inputs.target_os == 'linux' && 'linux-x64' || inputs.target_os == 'macos' && 'macos' || 'windows-x64' }}
           path: pr-binary/

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -106,7 +106,7 @@ jobs:
           maturin-version: "v1.11.5"
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: wheels-macos-${{ matrix.platform.target }}
           path: python/runtimed/dist
@@ -139,7 +139,7 @@ jobs:
           maturin-version: "v1.11.5"
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: wheels-linux-x86_64
           path: python/runtimed/dist
@@ -176,7 +176,7 @@ jobs:
         working-directory: python/nteract
 
       - name: Upload dist
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: nteract-dist
           path: python/nteract/dist
@@ -191,7 +191,7 @@ jobs:
       contents: write
       attestations: write
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@v4
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v4

--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -132,7 +132,7 @@ jobs:
           chmod +x runt-linux-x64
 
       - name: Upload Linux executables
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: runt-linux-executables
           path: |
@@ -198,7 +198,7 @@ jobs:
           chmod +x runt-darwin-arm64
 
       - name: Upload macOS executables
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: runt-macos-executables
           path: |
@@ -375,7 +375,7 @@ jobs:
           cp "${TAR_GZ_SIG_BINARIES[0]}" "artifacts/nteract-${CHANNEL}-darwin-arm64.app.tar.gz.sig"
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: nteract-macos-arm64
           path: artifacts/
@@ -514,7 +514,7 @@ jobs:
           fi
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: nteract-windows-x64
           path: artifacts/
@@ -638,7 +638,7 @@ jobs:
           cp "$DEB_PATH" "artifacts/nteract-${CHANNEL}-linux-x64.deb"
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: nteract-linux-x64
           path: artifacts/
@@ -676,7 +676,7 @@ jobs:
         working-directory: python/nteract
 
       - name: Upload dist
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: nteract-dist
           path: python/nteract/dist
@@ -759,7 +759,7 @@ jobs:
           maturin-version: "v1.11.5"
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: wheels-${{ matrix.platform.target }}
           path: python/runtimed/dist
@@ -808,31 +808,31 @@ jobs:
           echo "$CHANGELOG" > changelog-section.md
 
       - name: Download Linux executables
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v4
         with:
           name: runt-linux-executables
           path: ./executables
 
       - name: Download macOS executables
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v4
         with:
           name: runt-macos-executables
           path: ./executables
 
       - name: Download macOS ARM64 notebook
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v4
         with:
           name: nteract-macos-arm64
           path: ./notebook-macos-arm64
 
       - name: Download Windows x64 notebook
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v4
         with:
           name: nteract-windows-x64
           path: ./notebook-windows-x64
 
       - name: Download Linux x64 notebook
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v4
         with:
           name: nteract-linux-x64
           path: ./notebook-linux-x64
@@ -921,14 +921,14 @@ jobs:
           cat release-assets/latest.json
 
       - name: Download Python wheels
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v4
         with:
           pattern: wheels-*
           path: ./wheels
           merge-multiple: true
 
       - name: Download nteract dist
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v4
         with:
           name: nteract-dist
           path: ./nteract-dist


### PR DESCRIPTION
## Problem

The nightly release workflow is failing at the "Download nteract dist" step:

```
Error: Unable to download artifact(s): Artifact not found for name: nteract-dist
```

## Root Cause

Version mismatch between `upload-artifact@v7` and `download-artifact@v8`. The v8 download action uses a newer artifacts API that has different behavior for exact name matching compared to pattern matching.

Evidence: "Download Python wheels" succeeds using `pattern: wheels-*` with `merge-multiple: true`, while "Download nteract dist" fails using exact `name: nteract-dist` — both artifacts were uploaded with v7.

## Fix

Upgrade all `upload-artifact` actions from v7 to v8 to match the download version, ensuring API compatibility.

## Files Changed

- `.github/workflows/release-common.yml` - 7 occurrences
- `.github/workflows/build.yml` - 8 occurrences  
- `.github/workflows/python-package.yml` - 3 occurrences
- `.github/workflows/pr-binary-generation.yml` - 1 occurrence

## Verification

The next nightly build should succeed. This can also be tested by manually triggering the nightly workflow.