### PR TITLE
feat(runtimed): add RUNTIMED_SOCKET_PATH env var support

### DIFF
--- a/crates/runtimed/src/lib.rs
+++ b/crates/runtimed/src/lib.rs
@@ -127,6 +127,22 @@ pub struct PoolError {
 /// On Windows, this returns a named pipe path (e.g., \\.\pipe\runtimed).
 #[cfg(unix)]
 pub fn default_socket_path() -> PathBuf {
+    if let Ok(p) = std::env::var("RUNTIMED_SOCKET_PATH") {
+        let p = p.trim();
+        if !p.is_empty() {
+            let path = PathBuf::from(p);
+            // Validate parent directory exists (socket file may not exist yet)
+            if let Some(parent) = path.parent() {
+                if parent.exists() {
+                    return path;
+                }
+                panic!(
+                    "RUNTIMED_SOCKET_PATH directory does not exist: {}",
+                    parent.display()
+                );
+            }
+        }
+    }
     daemon_base_dir().join("runtimed.sock")
 }
 
@@ -137,6 +153,22 @@ pub fn default_socket_path() -> PathBuf {
 /// In dev mode on Windows, appends the worktree hash to the pipe name.
 #[cfg(windows)]
 pub fn default_socket_path() -> PathBuf {
+    if let Ok(p) = std::env::var("RUNTIMED_SOCKET_PATH") {
+        let p = p.trim();
+        if !p.is_empty() {
+            let path = PathBuf::from(p);
+            // Validate parent directory exists (socket file may not exist yet)
+            if let Some(parent) = path.parent() {
+                if parent.exists() {
+                    return path;
+                }
+                panic!(
+                    "RUNTIMED_SOCKET_PATH directory does not exist: {}",
+                    parent.display()
+                );
+            }
+        }
+    }
     let pipe_name = daemon_binary_basename();
     // Windows named pipes use the \\.\pipe\name format
     if is_dev_mode() {


### PR DESCRIPTION
## Summary

Adds support for the `RUNTIMED_SOCKET_PATH` environment variable to override the daemon socket path. This allows easily connecting to a different daemon (e.g., the system daemon from within a Conductor worktree).

## Usage

```bash
# Query system daemon from within a worktree
RUNTIMED_SOCKET_PATH=~/Library/Caches/runt/runtimed.sock runt daemon status
```

## Implementation

Modified `default_socket_path()` in `crates/runtimed/src/lib.rs` to check the env var first (both Unix and Windows versions). This automatically propagates to all `runt` CLI commands since they all use this function.

Consistent with the Python bindings (`runtimed-py`) which already respect this env var.

Closes #466