### PR TITLE
fix(runtimed-py): widen shell/iopub drain window from 50ms to 500ms

### DIFF
--- a/crates/runtimed-py/src/async_session.rs
+++ b/crates/runtimed-py/src/async_session.rs
@@ -2169,9 +2169,23 @@ async fn collect_outputs_async(
             .ok_or_else(|| to_py_err("Not connected"))?;
 
         // Before ExecutionDone: 100ms poll interval.
-        // After ExecutionDone: 50ms polls but keep going until the
-        // drain deadline (500ms after done) expires.
-        let timeout_ms = if drain_deadline.is_some() { 50 } else { 100 };
+        // After ExecutionDone: poll for the lesser of 50ms or time remaining
+        // until drain deadline, so we exit promptly when the deadline arrives
+        // even if messages keep flowing.
+        let timeout_ms = match drain_deadline {
+            Some(deadline) => {
+                let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+                if remaining.is_zero() {
+                    log::debug!(
+                        "[async_session] Drain deadline reached (top of loop), finishing with {} outputs",
+                        outputs.len()
+                    );
+                    break;
+                }
+                remaining.as_millis().min(50) as u64
+            }
+            None => 100,
+        };
         let broadcast = tokio::time::timeout(
             std::time::Duration::from_millis(timeout_ms),
             broadcast_rx.recv(),
@@ -2240,11 +2254,12 @@ async fn collect_outputs_async(
                         }
                     }
                     NotebookBroadcast::KernelError { error } => {
+                        // KernelError is a hard failure (kernel/daemon died), not
+                        // the shell/iopub ordering race. Return immediately.
                         success = false;
                         outputs.push(Output::error("KernelError", &error, vec![]));
-                        drain_deadline = Some(
-                            tokio::time::Instant::now() + std::time::Duration::from_millis(500),
-                        );
+                        log::debug!("[async_session] KernelError received, returning immediately");
+                        break;
                     }
                     _ => {}
                 }

--- a/crates/runtimed-py/src/async_session.rs
+++ b/crates/runtimed-py/src/async_session.rs
@@ -2155,7 +2155,10 @@ async fn collect_outputs_async(
     let mut outputs = Vec::new();
     let mut execution_count = None;
     let mut success = true;
-    let mut done_received = false;
+    // Drain deadline: set when ExecutionDone arrives. We keep draining
+    // broadcasts until this deadline to catch straggling iopub messages
+    // that arrive after the shell reply (classic Jupyter race).
+    let mut drain_deadline: Option<tokio::time::Instant> = None;
 
     loop {
         let mut state_guard = state.lock().await;
@@ -2165,7 +2168,10 @@ async fn collect_outputs_async(
             .as_mut()
             .ok_or_else(|| to_py_err("Not connected"))?;
 
-        let timeout_ms = if done_received { 50 } else { 100 };
+        // Before ExecutionDone: 100ms poll interval.
+        // After ExecutionDone: 50ms polls but keep going until the
+        // drain deadline (500ms after done) expires.
+        let timeout_ms = if drain_deadline.is_some() { 50 } else { 100 };
         let broadcast = tokio::time::timeout(
             std::time::Duration::from_millis(timeout_ms),
             broadcast_rx.recv(),
@@ -2221,16 +2227,24 @@ async fn collect_outputs_async(
                         cell_id: msg_cell_id,
                     } => {
                         if msg_cell_id == cell_id {
+                            // Don't break immediately - set a drain deadline to catch
+                            // straggling outputs due to shell/iopub race condition.
+                            // 500ms is generous enough to catch late iopub messages
+                            // while not noticeably slowing down normal execution.
                             log::debug!(
-                                "[async_session] ExecutionDone received, starting drain phase"
+                                "[async_session] ExecutionDone received, draining for 500ms"
                             );
-                            done_received = true;
+                            drain_deadline = Some(
+                                tokio::time::Instant::now() + std::time::Duration::from_millis(500),
+                            );
                         }
                     }
                     NotebookBroadcast::KernelError { error } => {
                         success = false;
                         outputs.push(Output::error("KernelError", &error, vec![]));
-                        done_received = true;
+                        drain_deadline = Some(
+                            tokio::time::Instant::now() + std::time::Duration::from_millis(500),
+                        );
                     }
                     _ => {}
                 }
@@ -2239,13 +2253,18 @@ async fn collect_outputs_async(
                 return Err(to_py_err("Broadcast channel closed"));
             }
             Err(_) => {
-                if done_received {
-                    log::debug!(
-                        "[async_session] Drain timeout, finishing with {} outputs",
-                        outputs.len()
-                    );
-                    break;
+                // Timeout - if drain deadline has passed, we're done
+                if let Some(deadline) = drain_deadline {
+                    if tokio::time::Instant::now() >= deadline {
+                        log::debug!(
+                            "[async_session] Drain deadline reached, finishing with {} outputs",
+                            outputs.len()
+                        );
+                        break;
+                    }
+                    // Deadline not yet reached - keep draining
                 }
+                // Otherwise continue waiting for ExecutionDone
             }
         }
     }

--- a/crates/runtimed-py/src/session.rs
+++ b/crates/runtimed-py/src/session.rs
@@ -1751,9 +1751,23 @@ impl Session {
                 .ok_or_else(|| to_py_err("Not connected"))?;
 
             // Before ExecutionDone: 100ms poll interval.
-            // After ExecutionDone: 50ms polls but keep going until the
-            // drain deadline (500ms after done) expires.
-            let timeout_ms = if drain_deadline.is_some() { 50 } else { 100 };
+            // After ExecutionDone: poll for the lesser of 50ms or time remaining
+            // until drain deadline, so we exit promptly when the deadline arrives
+            // even if messages keep flowing.
+            let timeout_ms = match drain_deadline {
+                Some(deadline) => {
+                    let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+                    if remaining.is_zero() {
+                        log::debug!(
+                            "[session] Drain deadline reached (top of loop), finishing with {} outputs",
+                            outputs.len()
+                        );
+                        break;
+                    }
+                    remaining.as_millis().min(50) as u64
+                }
+                None => 100,
+            };
             let broadcast = tokio::time::timeout(
                 std::time::Duration::from_millis(timeout_ms),
                 broadcast_rx.recv(),
@@ -1833,11 +1847,12 @@ impl Session {
                             }
                         }
                         NotebookBroadcast::KernelError { error } => {
+                            // KernelError is a hard failure (kernel/daemon died), not
+                            // the shell/iopub ordering race. Return immediately.
                             success = false;
                             outputs.push(Output::error("KernelError", &error, vec![]));
-                            drain_deadline = Some(
-                                tokio::time::Instant::now() + std::time::Duration::from_millis(500),
-                            );
+                            log::debug!("[session] KernelError received, returning immediately");
+                            break;
                         }
                         _ => {
                             // Ignore other broadcasts (KernelStatus, QueueChanged, etc.)

--- a/crates/runtimed-py/src/session.rs
+++ b/crates/runtimed-py/src/session.rs
@@ -1737,7 +1737,10 @@ impl Session {
         let mut outputs = Vec::new();
         let mut execution_count = None;
         let mut success = true;
-        let mut done_received = false;
+        // Drain deadline: set when ExecutionDone arrives. We keep draining
+        // broadcasts until this deadline to catch straggling iopub messages
+        // that arrive after the shell reply (classic Jupyter race).
+        let mut drain_deadline: Option<tokio::time::Instant> = None;
 
         loop {
             let mut state = self.state.lock().await;
@@ -1747,8 +1750,10 @@ impl Session {
                 .as_mut()
                 .ok_or_else(|| to_py_err("Not connected"))?;
 
-            // Use a short timeout - shorter after done to drain quickly
-            let timeout_ms = if done_received { 50 } else { 100 };
+            // Before ExecutionDone: 100ms poll interval.
+            // After ExecutionDone: 50ms polls but keep going until the
+            // drain deadline (500ms after done) expires.
+            let timeout_ms = if drain_deadline.is_some() { 50 } else { 100 };
             let broadcast = tokio::time::timeout(
                 std::time::Duration::from_millis(timeout_ms),
                 broadcast_rx.recv(),
@@ -1816,18 +1821,23 @@ impl Session {
                             cell_id: msg_cell_id,
                         } => {
                             if msg_cell_id == cell_id {
-                                // Don't break immediately - drain for a bit to catch
-                                // straggling outputs due to shell/iopub race condition
-                                log::debug!(
-                                    "[session] ExecutionDone received, starting drain phase"
+                                // Don't break immediately - set a drain deadline to catch
+                                // straggling outputs due to shell/iopub race condition.
+                                // 500ms is generous enough to catch late iopub messages
+                                // while not noticeably slowing down normal execution.
+                                log::debug!("[session] ExecutionDone received, draining for 500ms");
+                                drain_deadline = Some(
+                                    tokio::time::Instant::now()
+                                        + std::time::Duration::from_millis(500),
                                 );
-                                done_received = true;
                             }
                         }
                         NotebookBroadcast::KernelError { error } => {
                             success = false;
                             outputs.push(Output::error("KernelError", &error, vec![]));
-                            done_received = true;
+                            drain_deadline = Some(
+                                tokio::time::Instant::now() + std::time::Duration::from_millis(500),
+                            );
                         }
                         _ => {
                             // Ignore other broadcasts (KernelStatus, QueueChanged, etc.)
@@ -1839,15 +1849,18 @@ impl Session {
                     return Err(to_py_err("Broadcast channel closed"));
                 }
                 Err(_) => {
-                    // Timeout - if we've seen ExecutionDone, we're done draining
-                    if done_received {
-                        log::debug!(
-                            "[session] Drain timeout, finishing with {} outputs",
-                            outputs.len()
-                        );
-                        break;
+                    // Timeout - if drain deadline has passed, we're done
+                    if let Some(deadline) = drain_deadline {
+                        if tokio::time::Instant::now() >= deadline {
+                            log::debug!(
+                                "[session] Drain deadline reached, finishing with {} outputs",
+                                outputs.len()
+                            );
+                            break;
+                        }
+                        // Deadline not yet reached - keep draining
                     }
-                    // Otherwise continue waiting
+                    // Otherwise continue waiting for ExecutionDone
                 }
             }
         }


### PR DESCRIPTION
**Superseded by #755** — which reads outputs from the Automerge doc instead of the broadcast stream, eliminating the drain window entirely.

Keeping this as a reference. The drain window fix is correct but addresses a symptom. #755 addresses the root cause: `collect_outputs` shouldn't accumulate data from an ephemeral broadcast channel when the Automerge doc is the source of truth.

---

<details>
<summary>Original description</summary>

The Jupyter protocol has a well-known race condition where shell replies (`ExecutionDone`) can arrive before the last iopub message (error output). `collect_outputs` used a single 50ms timeout after receiving `ExecutionDone` to drain straggling messages. If the error output hadn't arrived yet, the result silently reported `status=ok, outputs=0`.

Replace the single-shot drain with a 500ms deadline: after `ExecutionDone`, keep polling at 50ms intervals until the deadline expires. Worst case adds 500ms to completed executions (typically much less since outputs arrive quickly). Applied to both `Session` and `AsyncSession`.

Found via CI probing in #746 — hit `test_error_traceback_captured` returning `ExecutionResult(status=ok, outputs=0)` on 1 of 4 pre-fix runs.
</details>

_PR submitted by @rgbkrk's agent Quill, via Zed_