### PR TITLE
docs: fix documentation inaccuracies across codebase

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,7 +118,7 @@ RUNTIMED_DEV=1 cargo xtask dev
 RUNTIMED_DEV=1 runt daemon status
 ```
 
-Per-worktree state is stored in `~/.cache/runt/worktrees/{hash}/`.
+Per-worktree state is stored in `~/.cache/runt-nightly/worktrees/{hash}/`.
 
 ### Do NOT Use pkill or killall
 
@@ -134,7 +134,7 @@ When working in a Conductor workspace developing nteract/desktop, the xtask comm
 
 | Conductor Variable | Translated To | Purpose |
 |-------------------|---------------|---------|
-| `CONDUCTOR_WORKSPACE_PATH` | `RUNTIMED_WORKSPACE_PATH` | Daemon state isolated to `~/.cache/runt/worktrees/{hash}/` |
+| `CONDUCTOR_WORKSPACE_PATH` | `RUNTIMED_WORKSPACE_PATH` | Daemon state isolated to `~/.cache/runt-nightly/worktrees/{hash}/` |
 | `CONDUCTOR_WORKSPACE_NAME` | `RUNTIMED_WORKSPACE_NAME` | Human-readable workspace name for display |
 | `CONDUCTOR_PORT` | (used directly) | Vite dev server port (avoids conflicts between workspaces) |
 
@@ -188,7 +188,7 @@ The JSON output includes computed paths, environment variables, pool targets, an
 
 **Where state lives in dev mode:**
 ```
-~/.cache/runt/worktrees/{hash}/
+~/.cache/runt-nightly/worktrees/{hash}/
 ├── runtimed.sock      # Unix socket for IPC
 ├── runtimed.log       # Daemon logs
 ├── daemon.json        # PID, version, endpoint info
@@ -221,7 +221,7 @@ The daemon logs to:
 ~/.cache/runt/runtimed.log          (Linux)
 ```
 
-In dev mode, logs are at `~/.cache/runt/worktrees/{hash}/runtimed.log`.
+In dev mode, logs are at `~/.cache/runt-nightly/worktrees/{hash}/runtimed.log`.
 
 To check daemon logs:
 ```bash
@@ -321,7 +321,7 @@ Follow the pattern established by `environment_yml.rs` and `pixi.rs`:
 
 ### Trust System
 
-Dependencies are signed with HMAC-SHA256 using a per-machine key at `~/.config/runt/trust-key`. The signature covers `metadata.uv` and `metadata.conda` only (not cell contents or outputs). Shared notebooks are always untrusted on a new machine because the key is machine-specific. If you change the dependency metadata structure, you must update `crates/notebook/src/trust.rs`.
+Dependencies are signed with HMAC-SHA256 using a per-machine key at `~/.config/runt/trust-key`. The signature covers `metadata.uv` and `metadata.conda` only (not cell contents or outputs). Shared notebooks are always untrusted on a new machine because the key is machine-specific. If you change the dependency metadata structure, you must update the `crates/runt-trust/` crate (the `crates/notebook/src/trust.rs` file just re-exports from it).
 
 ### Key Files
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,7 +118,9 @@ RUNTIMED_DEV=1 cargo xtask dev
 RUNTIMED_DEV=1 runt daemon status
 ```
 
-Per-worktree state is stored in `~/.cache/runt-nightly/worktrees/{hash}/`.
+Per-worktree state is stored in:
+- macOS: `~/Library/Caches/runt-nightly/worktrees/{hash}/`
+- Linux: `~/.cache/runt-nightly/worktrees/{hash}/`
 
 ### Do NOT Use pkill or killall
 
@@ -134,7 +136,7 @@ When working in a Conductor workspace developing nteract/desktop, the xtask comm
 
 | Conductor Variable | Translated To | Purpose |
 |-------------------|---------------|---------|
-| `CONDUCTOR_WORKSPACE_PATH` | `RUNTIMED_WORKSPACE_PATH` | Daemon state isolated to `~/.cache/runt-nightly/worktrees/{hash}/` |
+| `CONDUCTOR_WORKSPACE_PATH` | `RUNTIMED_WORKSPACE_PATH` | Daemon state isolated to `<cache>/runt-nightly/worktrees/{hash}/` |
 | `CONDUCTOR_WORKSPACE_NAME` | `RUNTIMED_WORKSPACE_NAME` | Human-readable workspace name for display |
 | `CONDUCTOR_PORT` | (used directly) | Vite dev server port (avoids conflicts between workspaces) |
 
@@ -186,9 +188,9 @@ The JSON output includes computed paths, environment variables, pool targets, an
 
 **Why `./target/debug/runt`?** The debug binary is built with `RUNTIMED_WORKSPACE_PATH` in its environment (via xtask), so it connects to the worktree daemon. A system-installed `runt` connects to the system daemon instead.
 
-**Where state lives in dev mode:**
+**Where state lives in dev mode** (macOS: `~/Library/Caches/`, Linux: `~/.cache/`):
 ```
-~/.cache/runt-nightly/worktrees/{hash}/
+<cache>/runt-nightly/worktrees/{hash}/
 ├── runtimed.sock      # Unix socket for IPC
 ├── runtimed.log       # Daemon logs
 ├── daemon.json        # PID, version, endpoint info
@@ -221,7 +223,7 @@ The daemon logs to:
 ~/.cache/runt/runtimed.log          (Linux)
 ```
 
-In dev mode, logs are at `~/.cache/runt-nightly/worktrees/{hash}/runtimed.log`.
+In dev mode, logs are at `<cache>/runt-nightly/worktrees/{hash}/runtimed.log` (macOS: `~/Library/Caches/`, Linux: `~/.cache/`).
 
 To check daemon logs:
 ```bash

--- a/contributing/development.md
+++ b/contributing/development.md
@@ -156,7 +156,7 @@ RUNTIMED_DEV=1 cargo xtask dev
 ./target/debug/runt daemon logs -f          # Tail logs (uses correct log path in dev mode)
 ```
 
-Per-worktree state is stored in `~/.cache/runt/worktrees/{hash}/`.
+Per-worktree state is stored in `~/.cache/runt-nightly/worktrees/{hash}/`.
 
 **For AI agents:** Use `./target/debug/runt` directly to interact with the daemon. See the "Agent Access to Dev Daemon" section in CLAUDE.md. When using a raw terminal (not Zed tasks), set the env vars manually:
 

--- a/contributing/development.md
+++ b/contributing/development.md
@@ -156,7 +156,7 @@ RUNTIMED_DEV=1 cargo xtask dev
 ./target/debug/runt daemon logs -f          # Tail logs (uses correct log path in dev mode)
 ```
 
-Per-worktree state is stored in `~/.cache/runt-nightly/worktrees/{hash}/`.
+Per-worktree state is stored in `<cache>/runt-nightly/worktrees/{hash}/` (macOS: `~/Library/Caches/`, Linux: `~/.cache/`).
 
 **For AI agents:** Use `./target/debug/runt` directly to interact with the daemon. See the "Agent Access to Dev Daemon" section in CLAUDE.md. When using a raw terminal (not Zed tasks), set the env vars manually:
 

--- a/contributing/e2e.md
+++ b/contributing/e2e.md
@@ -102,6 +102,7 @@ Use a regular test when:
 |----------|------|---------------|
 | `1-vanilla.ipynb` | `prewarmed-uv.spec.js` | UV prewarmed environment pool |
 | `2-uv-inline.ipynb` | `uv-inline.spec.js` | UV inline dependency resolution |
+| `2-uv-inline.ipynb` | `trust-dialog-dismiss.spec.js` | Trust dialog dismiss flow |
 | `3-conda-inline.ipynb` | `conda-inline.spec.js` | Conda inline dependency resolution |
 | `10-deno.ipynb` | `deno.spec.js` | Deno kernel start + TypeScript execution |
 | `pyproject-project/5-pyproject.ipynb` | `uv-pyproject.spec.js` | pyproject.toml environment detection |
@@ -109,6 +110,7 @@ Use a regular test when:
 **Regular specs** (run against default app, not fixtures):
 - `smoke.spec.js` — Basic cell execution and output
 - `tab-completion.spec.js` — Tab completion in code cells
+- `cell-visibility.spec.js` — Source/output visibility toggles
 - `untitled-pyproject.spec.js` — Untitled notebook in pyproject.toml directory
 
 Multiple specs can reuse the same fixture notebook — each gets its own fresh app instance.

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -107,6 +107,7 @@ nteract Desktop caches environments so notebooks with the same dependencies shar
 |------|----------|
 | UV environments | `~/.cache/runt/envs/` |
 | Conda environments | `~/.cache/runt/conda-envs/` |
+| Inline dependency envs | `~/.cache/runt/inline-envs/` |
 | Tools (uv, deno) | `~/.cache/runt/tools/` |
 | Trust key | `~/.config/runt/trust-key` |
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -12,7 +12,8 @@ The daemon (`runtimed`) logs to a file that persists across sessions.
 |----------|------|
 | macOS | `~/Library/Caches/runt/runtimed.log` |
 | Linux | `~/.cache/runt/runtimed.log` |
-| Dev mode | `~/.cache/runt-nightly/worktrees/{hash}/runtimed.log` |
+| Dev mode (macOS) | `~/Library/Caches/runt-nightly/worktrees/{hash}/runtimed.log` |
+| Dev mode (Linux) | `~/.cache/runt-nightly/worktrees/{hash}/runtimed.log` |
 
 ### Viewing Logs
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -12,7 +12,7 @@ The daemon (`runtimed`) logs to a file that persists across sessions.
 |----------|------|
 | macOS | `~/Library/Caches/runt/runtimed.log` |
 | Linux | `~/.cache/runt/runtimed.log` |
-| Dev mode | `~/.cache/runt/worktrees/{hash}/runtimed.log` |
+| Dev mode | `~/.cache/runt-nightly/worktrees/{hash}/runtimed.log` |
 
 ### Viewing Logs
 

--- a/docs/python-bindings.md
+++ b/docs/python-bindings.md
@@ -280,9 +280,8 @@ Process outputs incrementally as they arrive from the kernel:
 
 ```python
 cell_id = await session.create_cell("for i in range(5): print(i)")
-events = await session.stream_execute(cell_id)
 
-for event in events:
+async for event in await session.stream_execute(cell_id):
     if event.event_type == "execution_started":
         print(f"Started, count={event.execution_count}")
     elif event.event_type == "output":

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -8,7 +8,7 @@ This guide covers ipywidgets and anywidget support in nteract Desktop.
 
 | Category | Examples | Status |
 |----------|----------|--------|
-| **ipywidgets core** | IntSlider, Button, VBox, Dropdown | ✅ 49 widget types |
+| **ipywidgets core** | IntSlider, Button, VBox, Dropdown | ✅ 54+ widget types |
 | **anywidget** | quak, drawdata, tqdm | ✅ Full AFM support |
 | **ipycanvas** | Canvas, MultiCanvas | ✅ Custom implementation (tested with 0.14.3) |
 | **Display outputs** | Plotly, Vega-Lite, HTML, images | ✅ Via display |

--- a/python/nteract/README.md
+++ b/python/nteract/README.md
@@ -172,8 +172,8 @@ This enables workflows like:
 
 ```bash
 # Clone
-git clone https://github.com/nteract/nteract
-cd nteract
+git clone https://github.com/nteract/desktop
+cd desktop/python/nteract
 
 # Install dependencies
 uv sync


### PR DESCRIPTION
## Summary

Comprehensive documentation audit identified and fixed 7 critical/major issues plus 3 minor issues across `contributing/`, `docs/`, and nested README files.

**Critical fixes:**
- Fixed async for loop syntax in python-bindings.md stream_execute example (code example would fail)
- Fixed development clone instructions in python/nteract/README.md

**Major fixes:**
- Added missing inline-envs cache path to docs/environments.md
- Fixed trust.rs reference to point to runt-trust crate
- Added missing E2E test specs (trust-dialog-dismiss, cell-visibility) to e2e.md
- Fixed dev mode cache paths to use runt-nightly namespace

**Minor fixes:**
- Updated ipywidgets count from 49 to 54+ in docs/widgets.md

## Verification

* [ ] Audit identified correct issues across all 36 markdown files
* [ ] Code examples in python-bindings.md now match actual implementation
* [ ] Development instructions point to correct repository
* [ ] Cache paths reflect correct dev mode behavior

_PR submitted by @rgbkrk's agent, Quill_