### PR TITLE
fix(presence): sanitize peer_label server-side, add round-trip tests

### DIFF
--- a/crates/notebook-doc/src/presence.rs
+++ b/crates/notebook-doc/src/presence.rs
@@ -512,9 +512,62 @@ mod tests {
         let encoded = encode_cursor_update("peer-1", &pos);
         let msg = decode_message(&encoded).unwrap();
         match msg {
-            PresenceMessage::Update { peer_id, data, .. } => {
+            PresenceMessage::Update {
+                peer_id,
+                peer_label,
+                data,
+            } => {
                 assert_eq!(peer_id, "peer-1");
+                assert_eq!(peer_label, None);
                 assert_eq!(data, ChannelData::Cursor(pos));
+            }
+            _ => panic!("expected Update"),
+        }
+    }
+
+    #[test]
+    fn test_cursor_labeled_roundtrip() {
+        let pos = CursorPosition {
+            cell_id: "cell-abc".into(),
+            line: 10,
+            column: 3,
+        };
+        let encoded = encode_cursor_update_labeled("peer-1", Some("Codex"), &pos);
+        let msg = decode_message(&encoded).unwrap();
+        match msg {
+            PresenceMessage::Update {
+                peer_id,
+                peer_label,
+                data,
+            } => {
+                assert_eq!(peer_id, "peer-1");
+                assert_eq!(peer_label, Some("Codex".to_string()));
+                assert_eq!(data, ChannelData::Cursor(pos));
+            }
+            _ => panic!("expected Update"),
+        }
+    }
+
+    #[test]
+    fn test_selection_labeled_roundtrip() {
+        let sel = SelectionRange {
+            cell_id: "cell-xyz".into(),
+            anchor_line: 0,
+            anchor_col: 0,
+            head_line: 3,
+            head_col: 10,
+        };
+        let encoded = encode_selection_update_labeled("agent-1", Some("Claude"), &sel);
+        let msg = decode_message(&encoded).unwrap();
+        match msg {
+            PresenceMessage::Update {
+                peer_id,
+                peer_label,
+                data,
+            } => {
+                assert_eq!(peer_id, "agent-1");
+                assert_eq!(peer_label, Some("Claude".to_string()));
+                assert_eq!(data, ChannelData::Selection(sel));
             }
             _ => panic!("expected Update"),
         }
@@ -532,8 +585,13 @@ mod tests {
         let encoded = encode_selection_update("editor-2", &sel);
         let msg = decode_message(&encoded).unwrap();
         match msg {
-            PresenceMessage::Update { peer_id, data, .. } => {
+            PresenceMessage::Update {
+                peer_id,
+                peer_label,
+                data,
+            } => {
                 assert_eq!(peer_id, "editor-2");
+                assert_eq!(peer_label, None);
                 assert_eq!(data, ChannelData::Selection(sel));
             }
             _ => panic!("expected Update"),

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -962,6 +962,29 @@ where
 ///
 /// Handles both Automerge sync messages and NotebookRequest messages.
 /// This protocol supports daemon-owned kernel execution (Phase 8).
+/// Sanitize a peer label from the wire: trim, clamp to 64 chars, fall back to "peer".
+fn sanitize_peer_label(raw: Option<&str>) -> String {
+    const MAX_LABEL_LEN: usize = 64;
+    match raw {
+        Some(s) => {
+            let trimmed = s.trim();
+            if trimmed.is_empty() {
+                "peer".to_string()
+            } else if trimmed.len() > MAX_LABEL_LEN {
+                // Truncate at a char boundary
+                let mut end = MAX_LABEL_LEN;
+                while !trimmed.is_char_boundary(end) {
+                    end -= 1;
+                }
+                trimmed[..end].to_string()
+            } else {
+                trimmed.to_string()
+            }
+        }
+        None => "peer".to_string(),
+    }
+}
+
 async fn run_sync_loop_v2<R, W>(
     reader: &mut R,
     writer: &mut W,
@@ -1166,14 +1189,16 @@ where
                                             warn!("[notebook-sync] Client tried to publish KernelState presence, ignoring");
                                         } else {
                                             let data_for_relay = data.clone();
-                                            // Use peer_label from the message if provided,
-                                            // otherwise fall back to "peer".
-                                            let label = peer_label.as_deref().unwrap_or("peer");
+                                            // Sanitize peer_label: trim whitespace, clamp length,
+                                            // treat empty as fallback. Prevents UI/memory issues
+                                            // from malicious or buggy clients.
+                                            let label = sanitize_peer_label(peer_label.as_deref());
+                                            let sanitized_label = Some(label.clone());
                                             // Update the room's presence state (using our known peer_id,
                                             // not the one in the frame — clients don't know their peer_id).
                                             let is_new = room.presence.write().await.update_peer(
                                                 peer_id,
-                                                label,
+                                                &label,
                                                 data,
                                                 now_ms,
                                             );
@@ -1205,11 +1230,11 @@ where
                                                 }
                                             }
 
-                                            // Re-encode with server-assigned peer_id and relay
+                                            // Re-encode with server-assigned peer_id and sanitized label
                                             if let Ok(bytes) = presence::encode_message(
                                                 &presence::PresenceMessage::Update {
                                                     peer_id: peer_id.to_string(),
-                                                    peer_label: peer_label.clone(),
+                                                    peer_label: sanitized_label,
                                                     data: data_for_relay,
                                                 },
                                             ) {


### PR DESCRIPTION
Sanitize `peer_label` server-side before storing and relaying to other peers.

- Trim whitespace, clamp to 64 chars (at char boundary), treat empty/missing as "peer"
- Both `update_peer()` and the relay use the sanitized label, ensuring consistency between snapshots and updates
- Add round-trip tests for `encode_cursor_update_labeled` and `encode_selection_update_labeled`
- Existing tests now explicitly assert `peer_label: None` for unlabeled encoders

_PR submitted by @rgbkrk's agent Quill, via Zed_