### PR TITLE
feat(presence): enable cell focus and editor selection broadcasting

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -24,6 +24,7 @@ import { NotebookToolbar } from "./components/NotebookToolbar";
 import { NotebookView } from "./components/NotebookView";
 import { TrustDialog } from "./components/TrustDialog";
 import { UntrustedBanner } from "./components/UntrustedBanner";
+import { PresenceProvider } from "./contexts/PresenceContext";
 import { useAutomergeNotebook } from "./hooks/useAutomergeNotebook";
 import { useCondaDependencies } from "./hooks/useCondaDependencies";
 import { useDaemonKernel } from "./hooks/useDaemonKernel";
@@ -900,218 +901,224 @@ function AppContent() {
   }, []);
 
   return (
-    <div className="flex h-full flex-col bg-background overflow-hidden">
-      {gitInfo && (
-        <DebugBanner
-          branch={gitInfo.branch}
-          commit={gitInfo.commit}
-          description={gitInfo.description}
-          daemonVersion={daemonInfo?.version}
-          socketPath={daemonInfo?.socket_path}
-          isDevMode={daemonInfo?.is_dev_mode}
-        />
-      )}
-      <DaemonStatusBanner
-        status={daemonStatus}
-        onDismiss={() => setDaemonStatus(null)}
-        onRetry={() => {
-          setDaemonStatus({ status: "checking" });
-          invoke("reconnect_to_daemon")
-            .then(() => {
-              // Success - daemon:ready event will clear the banner
-            })
-            .catch((e) => {
-              setDaemonStatus({
-                status: "failed",
-                error: `Reconnection failed: ${e}`,
+    <PresenceProvider peerId={peerIdRef.current}>
+      <div className="flex h-full flex-col bg-background overflow-hidden">
+        {gitInfo && (
+          <DebugBanner
+            branch={gitInfo.branch}
+            commit={gitInfo.commit}
+            description={gitInfo.description}
+            daemonVersion={daemonInfo?.version}
+            socketPath={daemonInfo?.socket_path}
+            isDevMode={daemonInfo?.is_dev_mode}
+          />
+        )}
+        <DaemonStatusBanner
+          status={daemonStatus}
+          onDismiss={() => setDaemonStatus(null)}
+          onRetry={() => {
+            setDaemonStatus({ status: "checking" });
+            invoke("reconnect_to_daemon")
+              .then(() => {
+                // Success - daemon:ready event will clear the banner
+              })
+              .catch((e) => {
+                setDaemonStatus({
+                  status: "failed",
+                  error: `Reconnection failed: ${e}`,
+                });
               });
-            });
-        }}
-      />
-      {needsApproval && kernelStatus === KERNEL_STATUS.NOT_STARTED && (
-        <UntrustedBanner
-          onReviewClick={() => {
-            pendingKernelStartRef.current = true;
-            setTrustDialogOpen(true);
           }}
         />
-      )}
-      <NotebookToolbar
-        kernelStatus={kernelStatus}
-        envSource={envSource}
-        envTypeHint={envTypeHint}
-        dirty={dirty}
-        envProgress={
-          envProgress.isActive || envProgress.error ? envProgress : null
-        }
-        runtime={runtime}
-        onSave={save}
-        onStartKernel={handleStartKernel}
-        onInterruptKernel={interruptKernel}
-        onRestartKernel={handleRestartKernel}
-        onRunAllCells={handleRunAllCells}
-        onRestartAndRunAll={handleRestartAndRunAll}
-        focusedCellId={focusedCellId}
-        lastCellId={cells.length > 0 ? cells[cells.length - 1].id : null}
-        onAddCell={handleAddCell}
-        onToggleDependencies={() => setDependencyHeaderOpen((prev) => !prev)}
-        isDepsOpen={dependencyHeaderOpen}
-        updateStatus={updateStatus}
-        updateVersion={updateVersion}
-        onRestartToUpdate={restartToUpdate}
-      />
-      {/* Dual-dependency choice: both UV and conda deps exist, let user pick */}
-      {dependencyHeaderOpen &&
-        runtime === "python" &&
-        hasUvDependencies &&
-        hasCondaDependencies && (
-          <div className="border-b bg-amber-50/50 dark:bg-amber-950/20 px-3 py-2">
-            <div className="flex items-center gap-2 text-xs text-amber-700 dark:text-amber-400">
-              <span className="shrink-0">&#9888;</span>
-              <span className="font-medium">
-                This notebook has both uv and conda dependencies.
-              </span>
-              <div className="flex gap-1.5 ml-auto shrink-0">
-                <button
-                  disabled={clearingDeps}
-                  onClick={async () => {
-                    setClearingDeps(true);
-                    try {
-                      await clearAllCondaDeps();
-                    } finally {
-                      setClearingDeps(false);
-                    }
-                  }}
-                  className="px-2 py-0.5 text-xs font-medium rounded bg-fuchsia-100 dark:bg-fuchsia-900/40 hover:bg-fuchsia-200 dark:hover:bg-fuchsia-800/50 text-fuchsia-800 dark:text-fuchsia-300 border border-fuchsia-300 dark:border-fuchsia-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                >
-                  Use uv ({dependencies?.dependencies?.length ?? 0}{" "}
-                  {(dependencies?.dependencies?.length ?? 0) === 1
-                    ? "package"
-                    : "packages"}
-                  )
-                </button>
-                <button
-                  disabled={clearingDeps}
-                  onClick={async () => {
-                    setClearingDeps(true);
-                    try {
-                      await clearAllUvDeps();
-                    } finally {
-                      setClearingDeps(false);
-                    }
-                  }}
-                  className="px-2 py-0.5 text-xs font-medium rounded bg-emerald-100 dark:bg-emerald-900/40 hover:bg-emerald-200 dark:hover:bg-emerald-800/50 text-emerald-800 dark:text-emerald-300 border border-emerald-300 dark:border-emerald-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                >
-                  Use conda ({condaDependencies?.dependencies?.length ?? 0}{" "}
-                  {(condaDependencies?.dependencies?.length ?? 0) === 1
-                    ? "package"
-                    : "packages"}
-                  )
-                </button>
+        {needsApproval && kernelStatus === KERNEL_STATUS.NOT_STARTED && (
+          <UntrustedBanner
+            onReviewClick={() => {
+              pendingKernelStartRef.current = true;
+              setTrustDialogOpen(true);
+            }}
+          />
+        )}
+        <NotebookToolbar
+          kernelStatus={kernelStatus}
+          envSource={envSource}
+          envTypeHint={envTypeHint}
+          dirty={dirty}
+          envProgress={
+            envProgress.isActive || envProgress.error ? envProgress : null
+          }
+          runtime={runtime}
+          onSave={save}
+          onStartKernel={handleStartKernel}
+          onInterruptKernel={interruptKernel}
+          onRestartKernel={handleRestartKernel}
+          onRunAllCells={handleRunAllCells}
+          onRestartAndRunAll={handleRestartAndRunAll}
+          focusedCellId={focusedCellId}
+          lastCellId={cells.length > 0 ? cells[cells.length - 1].id : null}
+          onAddCell={handleAddCell}
+          onToggleDependencies={() => setDependencyHeaderOpen((prev) => !prev)}
+          isDepsOpen={dependencyHeaderOpen}
+          updateStatus={updateStatus}
+          updateVersion={updateVersion}
+          onRestartToUpdate={restartToUpdate}
+        />
+        {/* Dual-dependency choice: both UV and conda deps exist, let user pick */}
+        {dependencyHeaderOpen &&
+          runtime === "python" &&
+          hasUvDependencies &&
+          hasCondaDependencies && (
+            <div className="border-b bg-amber-50/50 dark:bg-amber-950/20 px-3 py-2">
+              <div className="flex items-center gap-2 text-xs text-amber-700 dark:text-amber-400">
+                <span className="shrink-0">&#9888;</span>
+                <span className="font-medium">
+                  This notebook has both uv and conda dependencies.
+                </span>
+                <div className="flex gap-1.5 ml-auto shrink-0">
+                  <button
+                    disabled={clearingDeps}
+                    onClick={async () => {
+                      setClearingDeps(true);
+                      try {
+                        await clearAllCondaDeps();
+                      } finally {
+                        setClearingDeps(false);
+                      }
+                    }}
+                    className="px-2 py-0.5 text-xs font-medium rounded bg-fuchsia-100 dark:bg-fuchsia-900/40 hover:bg-fuchsia-200 dark:hover:bg-fuchsia-800/50 text-fuchsia-800 dark:text-fuchsia-300 border border-fuchsia-300 dark:border-fuchsia-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    Use uv ({dependencies?.dependencies?.length ?? 0}{" "}
+                    {(dependencies?.dependencies?.length ?? 0) === 1
+                      ? "package"
+                      : "packages"}
+                    )
+                  </button>
+                  <button
+                    disabled={clearingDeps}
+                    onClick={async () => {
+                      setClearingDeps(true);
+                      try {
+                        await clearAllUvDeps();
+                      } finally {
+                        setClearingDeps(false);
+                      }
+                    }}
+                    className="px-2 py-0.5 text-xs font-medium rounded bg-emerald-100 dark:bg-emerald-900/40 hover:bg-emerald-200 dark:hover:bg-emerald-800/50 text-emerald-800 dark:text-emerald-300 border border-emerald-300 dark:border-emerald-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    Use conda ({condaDependencies?.dependencies?.length ?? 0}{" "}
+                    {(condaDependencies?.dependencies?.length ?? 0) === 1
+                      ? "package"
+                      : "packages"}
+                    )
+                  </button>
+                </div>
               </div>
             </div>
-          </div>
+          )}
+        {dependencyHeaderOpen && runtime === "deno" && (
+          <DenoDependencyHeader
+            denoAvailable={denoAvailable}
+            denoConfigInfo={denoConfigInfo}
+            flexibleNpmImports={flexibleNpmImports}
+            onSetFlexibleNpmImports={setFlexibleNpmImports}
+            syncState={denoDerivedSyncState}
+            syncing={kernelStatus === KERNEL_STATUS.STARTING}
+            onSyncNow={handleSyncDeps}
+            justSynced={justSynced}
+          />
         )}
-      {dependencyHeaderOpen && runtime === "deno" && (
-        <DenoDependencyHeader
-          denoAvailable={denoAvailable}
-          denoConfigInfo={denoConfigInfo}
-          flexibleNpmImports={flexibleNpmImports}
-          onSetFlexibleNpmImports={setFlexibleNpmImports}
-          syncState={denoDerivedSyncState}
-          syncing={kernelStatus === KERNEL_STATUS.STARTING}
-          onSyncNow={handleSyncDeps}
-          justSynced={justSynced}
+        {dependencyHeaderOpen &&
+          runtime === "python" &&
+          envType === "conda" && (
+            <CondaDependencyHeader
+              dependencies={condaDependencies?.dependencies ?? []}
+              channels={condaDependencies?.channels ?? []}
+              python={condaDependencies?.python ?? null}
+              loading={condaDepsLoading}
+              syncing={condaSyncing}
+              syncState={condaDerivedSyncState ?? condaSyncState}
+              syncedWhileRunning={condaSyncedWhileRunning}
+              needsKernelRestart={condaNeedsKernelRestart}
+              onAdd={addCondaDependency}
+              onRemove={removeCondaDependency}
+              onSetChannels={setCondaChannels}
+              onSetPython={setCondaPython}
+              onSyncNow={condaDerivedSyncState ? handleSyncDeps : syncCondaNow}
+              envProgress={envProgress.envType === "conda" ? envProgress : null}
+              onResetProgress={envProgress.reset}
+              environmentYmlInfo={environmentYmlInfo}
+              environmentYmlDeps={environmentYmlDeps}
+              pixiInfo={pixiInfo}
+              onImportFromPixi={importFromPixi}
+              justSynced={justSynced}
+            />
+          )}
+        {dependencyHeaderOpen &&
+          runtime === "python" &&
+          envType !== "conda" && (
+            <DependencyHeader
+              dependencies={dependencies?.dependencies ?? []}
+              requiresPython={dependencies?.requires_python ?? null}
+              uvAvailable={uvAvailable}
+              loading={depsLoading}
+              syncedWhileRunning={syncedWhileRunning}
+              needsKernelRestart={needsKernelRestart}
+              onAdd={addDependency}
+              onRemove={removeDependency}
+              syncState={uvDerivedSyncState ?? syncState}
+              onSyncNow={uvDerivedSyncState ? handleSyncDeps : syncNow}
+              pyprojectInfo={pyprojectInfo}
+              pyprojectDeps={pyprojectDeps}
+              onImportFromPyproject={importFromPyproject}
+              onUseProjectEnv={handleStartKernelWithPyproject}
+              isUsingProjectEnv={envSource === "uv:pyproject"}
+              justSynced={justSynced}
+            />
+          )}
+        {globalFind.isOpen && (
+          <GlobalFindBar
+            query={globalFind.query}
+            matchCount={globalFind.matches.length}
+            currentMatchIndex={globalFind.currentMatchIndex}
+            onQueryChange={globalFind.setQuery}
+            onNextMatch={globalFind.nextMatch}
+            onPrevMatch={globalFind.prevMatch}
+            onClose={globalFind.close}
+          />
+        )}
+        {showIsolationTest && <IsolationTest />}
+        <TrustDialog
+          open={trustDialogOpen}
+          onOpenChange={setTrustDialogOpen}
+          trustInfo={trustInfo}
+          typosquatWarnings={typosquatWarnings}
+          onApprove={handleTrustApprove}
+          onDecline={handleTrustDecline}
+          loading={trustLoading}
+          daemonMode={true}
         />
-      )}
-      {dependencyHeaderOpen && runtime === "python" && envType === "conda" && (
-        <CondaDependencyHeader
-          dependencies={condaDependencies?.dependencies ?? []}
-          channels={condaDependencies?.channels ?? []}
-          python={condaDependencies?.python ?? null}
-          loading={condaDepsLoading}
-          syncing={condaSyncing}
-          syncState={condaDerivedSyncState ?? condaSyncState}
-          syncedWhileRunning={condaSyncedWhileRunning}
-          needsKernelRestart={condaNeedsKernelRestart}
-          onAdd={addCondaDependency}
-          onRemove={removeCondaDependency}
-          onSetChannels={setCondaChannels}
-          onSetPython={setCondaPython}
-          onSyncNow={condaDerivedSyncState ? handleSyncDeps : syncCondaNow}
-          envProgress={envProgress.envType === "conda" ? envProgress : null}
-          onResetProgress={envProgress.reset}
-          environmentYmlInfo={environmentYmlInfo}
-          environmentYmlDeps={environmentYmlDeps}
-          pixiInfo={pixiInfo}
-          onImportFromPixi={importFromPixi}
-          justSynced={justSynced}
+        <NotebookView
+          cells={cells}
+          isLoading={isLoading}
+          focusedCellId={focusedCellId}
+          executingCellIds={executingCellIds}
+          pagePayloads={pagePayloads}
+          runtime={runtime}
+          searchQuery={globalFind.query}
+          searchCurrentMatch={globalFind.currentMatch}
+          onFocusCell={setFocusedCellId}
+          onUpdateCellSource={updateCellSource}
+          onExecuteCell={handleExecuteCell}
+          onInterruptKernel={interruptKernel}
+          onDeleteCell={deleteCell}
+          onAddCell={handleAddCell}
+          onMoveCell={moveCell}
+          onClearPagePayload={clearPagePayload}
+          onReportOutputMatchCount={globalFind.reportOutputMatchCount}
+          onSetCellSourceHidden={setCellSourceHidden}
+          onSetCellOutputsHidden={setCellOutputsHidden}
         />
-      )}
-      {dependencyHeaderOpen && runtime === "python" && envType !== "conda" && (
-        <DependencyHeader
-          dependencies={dependencies?.dependencies ?? []}
-          requiresPython={dependencies?.requires_python ?? null}
-          uvAvailable={uvAvailable}
-          loading={depsLoading}
-          syncedWhileRunning={syncedWhileRunning}
-          needsKernelRestart={needsKernelRestart}
-          onAdd={addDependency}
-          onRemove={removeDependency}
-          syncState={uvDerivedSyncState ?? syncState}
-          onSyncNow={uvDerivedSyncState ? handleSyncDeps : syncNow}
-          pyprojectInfo={pyprojectInfo}
-          pyprojectDeps={pyprojectDeps}
-          onImportFromPyproject={importFromPyproject}
-          onUseProjectEnv={handleStartKernelWithPyproject}
-          isUsingProjectEnv={envSource === "uv:pyproject"}
-          justSynced={justSynced}
-        />
-      )}
-      {globalFind.isOpen && (
-        <GlobalFindBar
-          query={globalFind.query}
-          matchCount={globalFind.matches.length}
-          currentMatchIndex={globalFind.currentMatchIndex}
-          onQueryChange={globalFind.setQuery}
-          onNextMatch={globalFind.nextMatch}
-          onPrevMatch={globalFind.prevMatch}
-          onClose={globalFind.close}
-        />
-      )}
-      {showIsolationTest && <IsolationTest />}
-      <TrustDialog
-        open={trustDialogOpen}
-        onOpenChange={setTrustDialogOpen}
-        trustInfo={trustInfo}
-        typosquatWarnings={typosquatWarnings}
-        onApprove={handleTrustApprove}
-        onDecline={handleTrustDecline}
-        loading={trustLoading}
-        daemonMode={true}
-      />
-      <NotebookView
-        cells={cells}
-        isLoading={isLoading}
-        focusedCellId={focusedCellId}
-        executingCellIds={executingCellIds}
-        pagePayloads={pagePayloads}
-        runtime={runtime}
-        searchQuery={globalFind.query}
-        searchCurrentMatch={globalFind.currentMatch}
-        onFocusCell={setFocusedCellId}
-        onUpdateCellSource={updateCellSource}
-        onExecuteCell={handleExecuteCell}
-        onInterruptKernel={interruptKernel}
-        onDeleteCell={deleteCell}
-        onAddCell={handleAddCell}
-        onMoveCell={moveCell}
-        onClearPagePayload={clearPagePayload}
-        onReportOutputMatchCount={globalFind.reportOutputMatchCount}
-        onSetCellSourceHidden={setCellSourceHidden}
-        onSetCellOutputsHidden={setCellOutputsHidden}
-      />
-    </div>
+      </div>
+    </PresenceProvider>
   );
 }
 

--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -23,12 +23,15 @@ import { AnsiOutput } from "@/components/outputs/ansi-output";
 import { ErrorBoundary } from "@/lib/error-boundary";
 import { cn } from "@/lib/utils";
 import type { CellPagePayload, MimeBundle } from "../App";
+import { usePresenceContext } from "../contexts/PresenceContext";
 import { useCellKeyboardNavigation } from "../hooks/useCellKeyboardNavigation";
 import { registerEditor, unregisterEditor } from "../lib/cursor-registry";
 import { kernelCompletionExtension } from "../lib/kernel-completion";
 import { openUrl } from "../lib/open-url";
+import { presenceSenderExtension } from "../lib/presence-sender";
 import { tabCompletionKeymap } from "../lib/tab-completion";
 import type { CodeCell as CodeCellType } from "../types";
+import { CellPresenceIndicators } from "./cell/CellPresenceIndicators";
 
 // Lazy load HistorySearchDialog - it pulls in react-syntax-highlighter (~800KB)
 // Only loaded when user opens history search (Ctrl+R)
@@ -136,6 +139,7 @@ export function CodeCell({
 }: CodeCellProps) {
   const editorRef = useRef<CodeMirrorEditorRef>(null);
   const [historyDialogOpen, setHistoryDialogOpen] = useState(false);
+  const presence = usePresenceContext();
 
   // Check cell metadata for visibility (JupyterLab convention)
   const isSourceHidden =
@@ -267,15 +271,27 @@ export function CodeCell({
   // Remote cursors extension (stable — no deps that change)
   const remoteCursorsExt = useMemo(() => remoteCursorsExtension(), []);
 
-  // CodeMirror extensions: kernel completion + tab completion + search highlighting + remote cursors
+  // Presence sender extension — broadcasts local cursor/selection to other peers
+  const presenceSenderExt = useMemo(() => {
+    if (!presence) return [];
+    return [
+      presenceSenderExtension(cell.id, {
+        onCursor: presence.setCursor,
+        onSelection: presence.setSelection,
+      }),
+    ];
+  }, [cell.id, presence]);
+
+  // CodeMirror extensions: kernel completion + tab completion + search highlighting + remote cursors + presence sender
   const editorExtensions = useMemo(
     () => [
       kernelCompletionExtension,
       tabCompletionKeymap,
       ...searchHighlight(searchQuery || "", searchActiveOffset),
       ...remoteCursorsExt,
+      ...presenceSenderExt,
     ],
-    [searchQuery, searchActiveOffset, remoteCursorsExt],
+    [searchQuery, searchActiveOffset, remoteCursorsExt, presenceSenderExt],
   );
 
   const handleExecute = useCallback(() => {
@@ -333,6 +349,7 @@ export function CodeCell({
         onFocus={onFocus}
         gutterContent={gutterContent}
         rightGutterContent={rightGutterContent}
+        presenceIndicators={<CellPresenceIndicators cellId={cell.id} />}
         dragHandleProps={dragHandleProps}
         isDragging={isDragging}
         codeContent={

--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -11,13 +11,16 @@ import { searchHighlight } from "@/components/editor/search-highlight";
 import { IsolatedFrame, type IsolatedFrameHandle } from "@/components/isolated";
 import { isDarkMode as detectDarkMode } from "@/lib/dark-mode";
 import { cn } from "@/lib/utils";
+import { usePresenceContext } from "../contexts/PresenceContext";
 import { useCellKeyboardNavigation } from "../hooks/useCellKeyboardNavigation";
 import { useBlobPort } from "../hooks/useManifestResolver";
 import { registerEditor, unregisterEditor } from "../lib/cursor-registry";
 import { logger } from "../lib/logger";
 import { rewriteMarkdownAssetRefs } from "../lib/markdown-assets";
 import { openUrl } from "../lib/open-url";
+import { presenceSenderExtension } from "../lib/presence-sender";
 import type { MarkdownCell as MarkdownCellType } from "../types";
+import { CellPresenceIndicators } from "./cell/CellPresenceIndicators";
 
 interface MarkdownCellProps {
   cell: MarkdownCellType;
@@ -131,6 +134,7 @@ export function MarkdownCell({
 
   const [editing, setEditing] = useState(cell.source === "");
   const editorRef = useRef<CodeMirrorEditorRef>(null);
+  const presence = usePresenceContext();
   const frameRef = useRef<IsolatedFrameHandle>(null);
   const viewRef = useRef<HTMLDivElement>(null);
 
@@ -286,10 +290,25 @@ export function MarkdownCell({
   // Remote cursors extension (stable — no deps that change)
   const remoteCursorsExt = useMemo(() => remoteCursorsExtension(), []);
 
-  // Search highlight extension for edit mode + remote cursors
+  // Presence sender extension — broadcasts local cursor/selection to other peers
+  const presenceSenderExt = useMemo(() => {
+    if (!presence) return [];
+    return [
+      presenceSenderExtension(cell.id, {
+        onCursor: presence.setCursor,
+        onSelection: presence.setSelection,
+      }),
+    ];
+  }, [cell.id, presence]);
+
+  // Search highlight extension for edit mode + remote cursors + presence sender
   const searchExtensions = useMemo(
-    () => [...searchHighlight(searchQuery || ""), ...remoteCursorsExt],
-    [searchQuery, remoteCursorsExt],
+    () => [
+      ...searchHighlight(searchQuery || ""),
+      ...remoteCursorsExt,
+      ...presenceSenderExt,
+    ],
+    [searchQuery, remoteCursorsExt, presenceSenderExt],
   );
 
   // Get keyboard navigation bindings
@@ -385,6 +404,7 @@ export function MarkdownCell({
       isFocused={isFocused}
       isPreviousCellFromFocused={isPreviousCellFromFocused}
       onFocus={onFocus}
+      presenceIndicators={<CellPresenceIndicators cellId={cell.id} />}
       dragHandleProps={dragHandleProps}
       isDragging={isDragging}
     >

--- a/apps/notebook/src/components/RawCell.tsx
+++ b/apps/notebook/src/components/RawCell.tsx
@@ -8,10 +8,13 @@ import {
 } from "@/components/editor/codemirror-editor";
 import { remoteCursorsExtension } from "@/components/editor/remote-cursors";
 import { searchHighlight } from "@/components/editor/search-highlight";
+import { usePresenceContext } from "../contexts/PresenceContext";
 import { useCellKeyboardNavigation } from "../hooks/useCellKeyboardNavigation";
 import { registerEditor, unregisterEditor } from "../lib/cursor-registry";
 import { detectRawFormat } from "../lib/detect-raw-format";
+import { presenceSenderExtension } from "../lib/presence-sender";
 import type { RawCell as RawCellType } from "../types";
+import { CellPresenceIndicators } from "./cell/CellPresenceIndicators";
 
 interface RawCellProps {
   cell: RawCellType;
@@ -45,6 +48,7 @@ export function RawCell({
   isDragging,
 }: RawCellProps) {
   const editorRef = useRef<CodeMirrorEditorRef>(null);
+  const presence = usePresenceContext();
 
   // Register EditorView with the cursor registry for presence support
   const registeredViewRef = useRef<EditorView | null>(null);
@@ -120,10 +124,25 @@ export function RawCell({
   // Remote cursors extension (stable — no deps that change)
   const remoteCursorsExt = useMemo(() => remoteCursorsExtension(), []);
 
-  // Search highlight extension + remote cursors
+  // Presence sender extension — broadcasts local cursor/selection to other peers
+  const presenceSenderExt = useMemo(() => {
+    if (!presence) return [];
+    return [
+      presenceSenderExtension(cell.id, {
+        onCursor: presence.setCursor,
+        onSelection: presence.setSelection,
+      }),
+    ];
+  }, [cell.id, presence]);
+
+  // Search highlight extension + remote cursors + presence sender
   const searchExtensions = useMemo(
-    () => [...searchHighlight(searchQuery || ""), ...remoteCursorsExt],
-    [searchQuery, remoteCursorsExt],
+    () => [
+      ...searchHighlight(searchQuery || ""),
+      ...remoteCursorsExt,
+      ...presenceSenderExt,
+    ],
+    [searchQuery, remoteCursorsExt, presenceSenderExt],
   );
 
   // Get keyboard navigation bindings
@@ -157,6 +176,7 @@ export function RawCell({
       isFocused={isFocused}
       isPreviousCellFromFocused={isPreviousCellFromFocused}
       onFocus={onFocus}
+      presenceIndicators={<CellPresenceIndicators cellId={cell.id} />}
       dragHandleProps={dragHandleProps}
       isDragging={isDragging}
     >

--- a/apps/notebook/src/components/cell/CellPresenceIndicators.tsx
+++ b/apps/notebook/src/components/cell/CellPresenceIndicators.tsx
@@ -1,0 +1,91 @@
+/**
+ * Cell-level presence indicators.
+ *
+ * Shows colored dots for remote peers that have their cursor in this cell.
+ * Uses the cursor registry's subscription mechanism for efficient updates.
+ */
+
+import { useEffect, useState } from "react";
+import {
+  getPeersForCell,
+  type PeerCursorInfo,
+  subscribeToCell,
+} from "../../lib/cursor-registry";
+
+interface CellPresenceIndicatorsProps {
+  cellId: string;
+}
+
+/** Maximum visible indicators before showing overflow count */
+const MAX_VISIBLE = 3;
+
+export function CellPresenceIndicators({
+  cellId,
+}: CellPresenceIndicatorsProps) {
+  const [peers, setPeers] = useState<PeerCursorInfo[]>([]);
+
+  // Subscribe to presence changes for this cell
+  useEffect(() => {
+    // Initial fetch
+    setPeers(getPeersForCell(cellId));
+
+    // Subscribe to updates
+    const unsubscribe = subscribeToCell(cellId, () => {
+      setPeers(getPeersForCell(cellId));
+    });
+
+    return unsubscribe;
+  }, [cellId]);
+
+  if (peers.length === 0) {
+    return null;
+  }
+
+  const visiblePeers = peers.slice(0, MAX_VISIBLE);
+  const overflowCount = peers.length - MAX_VISIBLE;
+
+  return (
+    <div
+      className="flex flex-col items-center gap-0.5"
+      title={formatTooltip(peers)}
+    >
+      {visiblePeers.map((peer) => (
+        <PresenceDot key={peer.peerId} peer={peer} />
+      ))}
+      {overflowCount > 0 && (
+        <span className="text-[9px] font-medium text-muted-foreground leading-none">
+          +{overflowCount}
+        </span>
+      )}
+    </div>
+  );
+}
+
+interface PresenceDotProps {
+  peer: PeerCursorInfo;
+}
+
+function PresenceDot({ peer }: PresenceDotProps) {
+  return (
+    <div
+      className="w-2 h-2 rounded-full shrink-0 transition-colors"
+      style={{ backgroundColor: peer.color }}
+      title={peer.peerLabel || "Peer"}
+    />
+  );
+}
+
+function formatTooltip(peers: PeerCursorInfo[]): string {
+  if (peers.length === 0) return "";
+  if (peers.length === 1) {
+    return peers[0].peerLabel || "1 peer";
+  }
+  const labels = peers
+    .map((p) => p.peerLabel)
+    .filter(Boolean)
+    .join(", ");
+  if (labels) {
+    return labels;
+  }
+  return `${peers.length} peers`;
+}

--- a/apps/notebook/src/contexts/PresenceContext.tsx
+++ b/apps/notebook/src/contexts/PresenceContext.tsx
@@ -1,0 +1,100 @@
+/**
+ * React context for presence functionality.
+ *
+ * Provides cursor/selection sending methods to the component tree,
+ * wrapping the usePresence hook to avoid prop drilling.
+ */
+
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useMemo,
+} from "react";
+import { usePresence } from "../hooks/usePresence";
+
+export interface PresenceContextValue {
+  /** Send cursor position for a cell */
+  setCursor: (cellId: string, line: number, column: number) => void;
+  /** Send selection range for a cell */
+  setSelection: (
+    cellId: string,
+    anchorLine: number,
+    anchorCol: number,
+    headLine: number,
+    headCol: number,
+  ) => void;
+  /** The local peer's ID */
+  peerId: string | null;
+}
+
+const PresenceContext = createContext<PresenceContextValue | null>(null);
+
+interface PresenceProviderProps {
+  peerId: string;
+  children: ReactNode;
+}
+
+export function PresenceProvider({ peerId, children }: PresenceProviderProps) {
+  const presence = usePresence(peerId);
+
+  // Wrap the presence methods to match the interface we want to expose
+  // (the hook already has these, but we're making them explicit)
+  const setCursor = useCallback(
+    (cellId: string, line: number, column: number) => {
+      presence.setCursor(cellId, line, column);
+    },
+    [presence],
+  );
+
+  const setSelection = useCallback(
+    (
+      cellId: string,
+      anchorLine: number,
+      anchorCol: number,
+      headLine: number,
+      headCol: number,
+    ) => {
+      presence.setSelection(cellId, anchorLine, anchorCol, headLine, headCol);
+    },
+    [presence],
+  );
+
+  const value = useMemo<PresenceContextValue>(
+    () => ({
+      setCursor,
+      setSelection,
+      peerId,
+    }),
+    [setCursor, setSelection, peerId],
+  );
+
+  return (
+    <PresenceContext.Provider value={value}>
+      {children}
+    </PresenceContext.Provider>
+  );
+}
+
+/**
+ * Hook to access presence context.
+ * Returns null if used outside a PresenceProvider.
+ */
+export function usePresenceContext(): PresenceContextValue | null {
+  return useContext(PresenceContext);
+}
+
+/**
+ * Hook that throws if presence context is not available.
+ * Use this when you need presence and it's an error if it's missing.
+ */
+export function usePresenceContextRequired(): PresenceContextValue {
+  const ctx = useContext(PresenceContext);
+  if (!ctx) {
+    throw new Error(
+      "usePresenceContextRequired must be used within a PresenceProvider",
+    );
+  }
+  return ctx;
+}

--- a/apps/notebook/src/lib/__tests__/cursor-registry.test.ts
+++ b/apps/notebook/src/lib/__tests__/cursor-registry.test.ts
@@ -1,0 +1,225 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getPeersForCell,
+  startCursorDispatch,
+  subscribeToCell,
+} from "../cursor-registry";
+import * as frameBus from "../notebook-frame-bus";
+
+// Mock the frame bus
+vi.mock("../notebook-frame-bus", () => ({
+  subscribePresence: vi.fn(() => vi.fn()),
+}));
+
+// Mock remote-cursors to avoid DOM dependencies
+vi.mock("@/components/editor/remote-cursors", () => ({
+  peerColor: (peerId: string) => `#${peerId.slice(0, 6)}`,
+  setRemoteCursors: vi.fn(),
+  setRemoteSelections: vi.fn(),
+}));
+
+describe("cursor-registry cell-level functions", () => {
+  let cleanup: (() => void) | undefined;
+  let presenceHandler: ((payload: unknown) => void) | undefined;
+
+  beforeEach(() => {
+    // Capture the presence handler when startCursorDispatch is called
+    vi.mocked(frameBus.subscribePresence).mockImplementation((handler) => {
+      presenceHandler = handler;
+      return vi.fn();
+    });
+
+    cleanup = startCursorDispatch("local-peer");
+  });
+
+  afterEach(() => {
+    cleanup?.();
+    presenceHandler = undefined;
+    vi.clearAllMocks();
+  });
+
+  describe("getPeersForCell", () => {
+    it("returns empty array when no peers", () => {
+      const peers = getPeersForCell("cell-1");
+      expect(peers).toEqual([]);
+    });
+
+    it("returns peers with cursors in the specified cell", () => {
+      // Simulate a peer cursor update
+      presenceHandler?.({
+        type: "update",
+        peer_id: "peer-1",
+        peer_label: "Human",
+        channel: "cursor",
+        data: { cell_id: "cell-1", line: 0, column: 5 },
+      });
+
+      const peers = getPeersForCell("cell-1");
+      expect(peers).toHaveLength(1);
+      expect(peers[0].peerId).toBe("peer-1");
+      expect(peers[0].peerLabel).toBe("Human");
+      expect(peers[0].cursor?.cell_id).toBe("cell-1");
+    });
+
+    it("excludes peers in other cells", () => {
+      presenceHandler?.({
+        type: "update",
+        peer_id: "peer-1",
+        channel: "cursor",
+        data: { cell_id: "cell-1", line: 0, column: 0 },
+      });
+      presenceHandler?.({
+        type: "update",
+        peer_id: "peer-2",
+        channel: "cursor",
+        data: { cell_id: "cell-2", line: 0, column: 0 },
+      });
+
+      const peersCell1 = getPeersForCell("cell-1");
+      const peersCell2 = getPeersForCell("cell-2");
+
+      expect(peersCell1).toHaveLength(1);
+      expect(peersCell1[0].peerId).toBe("peer-1");
+
+      expect(peersCell2).toHaveLength(1);
+      expect(peersCell2[0].peerId).toBe("peer-2");
+    });
+
+    it("excludes local peer", () => {
+      // Simulate local peer's cursor (should be filtered out)
+      presenceHandler?.({
+        type: "update",
+        peer_id: "local-peer",
+        channel: "cursor",
+        data: { cell_id: "cell-1", line: 0, column: 0 },
+      });
+
+      const peers = getPeersForCell("cell-1");
+      expect(peers).toHaveLength(0);
+    });
+  });
+
+  describe("subscribeToCell", () => {
+    it("notifies subscriber when peer enters cell", () => {
+      const callback = vi.fn();
+      const unsubscribe = subscribeToCell("cell-1", callback);
+
+      presenceHandler?.({
+        type: "update",
+        peer_id: "peer-1",
+        channel: "cursor",
+        data: { cell_id: "cell-1", line: 0, column: 0 },
+      });
+
+      expect(callback).toHaveBeenCalledTimes(1);
+      unsubscribe();
+    });
+
+    it("notifies subscriber when peer leaves cell", () => {
+      // Peer enters cell-1
+      presenceHandler?.({
+        type: "update",
+        peer_id: "peer-1",
+        channel: "cursor",
+        data: { cell_id: "cell-1", line: 0, column: 0 },
+      });
+
+      const callback = vi.fn();
+      const unsubscribe = subscribeToCell("cell-1", callback);
+
+      // Peer moves to cell-2
+      presenceHandler?.({
+        type: "update",
+        peer_id: "peer-1",
+        channel: "cursor",
+        data: { cell_id: "cell-2", line: 0, column: 0 },
+      });
+
+      // Should notify cell-1 (peer left) and cell-2 (peer entered)
+      expect(callback).toHaveBeenCalled();
+      unsubscribe();
+    });
+
+    it("does not notify after unsubscribe", () => {
+      const callback = vi.fn();
+      const unsubscribe = subscribeToCell("cell-1", callback);
+      unsubscribe();
+
+      presenceHandler?.({
+        type: "update",
+        peer_id: "peer-1",
+        channel: "cursor",
+        data: { cell_id: "cell-1", line: 0, column: 0 },
+      });
+
+      expect(callback).not.toHaveBeenCalled();
+    });
+
+    it("handles multiple subscribers to the same cell", () => {
+      const callback1 = vi.fn();
+      const callback2 = vi.fn();
+      const unsub1 = subscribeToCell("cell-1", callback1);
+      const unsub2 = subscribeToCell("cell-1", callback2);
+
+      presenceHandler?.({
+        type: "update",
+        peer_id: "peer-1",
+        channel: "cursor",
+        data: { cell_id: "cell-1", line: 0, column: 0 },
+      });
+
+      expect(callback1).toHaveBeenCalledTimes(1);
+      expect(callback2).toHaveBeenCalledTimes(1);
+
+      unsub1();
+      unsub2();
+    });
+
+    it("notifies on snapshot message", () => {
+      const callback = vi.fn();
+      const unsubscribe = subscribeToCell("cell-1", callback);
+
+      presenceHandler?.({
+        type: "snapshot",
+        peer_id: "daemon",
+        peers: [
+          {
+            peer_id: "peer-1",
+            peer_label: "Human",
+            channels: [
+              {
+                channel: "cursor",
+                data: { cell_id: "cell-1", line: 0, column: 0 },
+              },
+            ],
+          },
+        ],
+      });
+
+      expect(callback).toHaveBeenCalled();
+      unsubscribe();
+    });
+
+    it("notifies on peer left message", () => {
+      // First, add a peer
+      presenceHandler?.({
+        type: "update",
+        peer_id: "peer-1",
+        channel: "cursor",
+        data: { cell_id: "cell-1", line: 0, column: 0 },
+      });
+
+      const callback = vi.fn();
+      const unsubscribe = subscribeToCell("cell-1", callback);
+
+      // Peer leaves
+      presenceHandler?.({
+        type: "left",
+        peer_id: "peer-1",
+      });
+
+      expect(callback).toHaveBeenCalled();
+      unsubscribe();
+    });
+  });
+});

--- a/apps/notebook/src/lib/__tests__/presence-sender.test.ts
+++ b/apps/notebook/src/lib/__tests__/presence-sender.test.ts
@@ -1,0 +1,124 @@
+import { EditorState } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { presenceSenderExtension } from "../presence-sender";
+
+describe("presenceSenderExtension", () => {
+  let view: EditorView;
+  let onCursor: ReturnType<typeof vi.fn>;
+  let onSelection: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    onCursor = vi.fn();
+    onSelection = vi.fn();
+  });
+
+  afterEach(() => {
+    view?.destroy();
+    vi.useRealTimers();
+  });
+
+  function createView(doc: string) {
+    const state = EditorState.create({
+      doc,
+      extensions: [
+        presenceSenderExtension("cell-1", {
+          onCursor,
+          onSelection,
+        }),
+      ],
+    });
+    return new EditorView({ state });
+  }
+
+  it("sends cursor position when selection changes to a point", () => {
+    view = createView("hello\nworld");
+
+    // Move cursor to line 1, column 3 (0-based: line 0, col 3)
+    view.dispatch({
+      selection: { anchor: 3 },
+    });
+
+    // Should send immediately
+    expect(onCursor).toHaveBeenCalledTimes(1);
+    expect(onCursor).toHaveBeenCalledWith("cell-1", 0, 3);
+    expect(onSelection).not.toHaveBeenCalled();
+  });
+
+  it("sends selection when anchor differs from head", () => {
+    view = createView("hello\nworld");
+
+    // Select "ell" (positions 1-4)
+    view.dispatch({
+      selection: { anchor: 1, head: 4 },
+    });
+
+    expect(onSelection).toHaveBeenCalledTimes(1);
+    expect(onSelection).toHaveBeenCalledWith("cell-1", 0, 1, 0, 4);
+    expect(onCursor).not.toHaveBeenCalled();
+  });
+
+  it("converts multi-line positions correctly", () => {
+    view = createView("hello\nworld\nfoo");
+
+    // Move cursor to "w" in "world" (line 1, col 0)
+    view.dispatch({
+      selection: { anchor: 6 },
+    });
+
+    expect(onCursor).toHaveBeenCalledWith("cell-1", 1, 0);
+  });
+
+  it("throttles rapid selection changes", () => {
+    view = createView("hello");
+
+    // First change - sent immediately
+    view.dispatch({ selection: { anchor: 1 } });
+    expect(onCursor).toHaveBeenCalledTimes(1);
+
+    // Second change within throttle window - not sent yet
+    view.dispatch({ selection: { anchor: 2 } });
+    expect(onCursor).toHaveBeenCalledTimes(1);
+
+    // Third change within throttle window - still not sent
+    view.dispatch({ selection: { anchor: 3 } });
+    expect(onCursor).toHaveBeenCalledTimes(1);
+
+    // Advance past throttle interval (75ms)
+    vi.advanceTimersByTime(75);
+
+    // Now the pending update is sent (the last position: 3)
+    expect(onCursor).toHaveBeenCalledTimes(2);
+    expect(onCursor).toHaveBeenLastCalledWith("cell-1", 0, 3);
+  });
+
+  it("does not call callbacks for non-selection transactions", () => {
+    view = createView("hello");
+
+    // Initial selection
+    view.dispatch({ selection: { anchor: 1 } });
+    expect(onCursor).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(100);
+
+    // Document change without selection change
+    view.dispatch({
+      changes: { from: 5, insert: "!" },
+    });
+
+    // No additional cursor call
+    expect(onCursor).toHaveBeenCalledTimes(1);
+  });
+
+  it("handles selection spanning multiple lines", () => {
+    view = createView("hello\nworld\nfoo");
+
+    // Select from "llo" to "wor" (crossing line boundary)
+    view.dispatch({
+      selection: { anchor: 2, head: 9 },
+    });
+
+    expect(onSelection).toHaveBeenCalledWith("cell-1", 0, 2, 1, 3);
+  });
+});

--- a/apps/notebook/src/lib/cursor-registry.ts
+++ b/apps/notebook/src/lib/cursor-registry.ts
@@ -79,7 +79,8 @@ type PresenceMessage =
 
 // ── Peer state ───────────────────────────────────────────────────────
 
-interface PeerCursorInfo {
+export interface PeerCursorInfo {
+  peerId: string;
   peerLabel: string;
   color: string;
   cursor?: CursorData;
@@ -161,6 +162,8 @@ function dispatchToAffectedCells(affectedCellIds: Set<string>): void {
   for (const cellId of affectedCellIds) {
     dispatchToCell(cellId);
   }
+  // Also notify any cell-level subscribers
+  notifyCellSubscribers(affectedCellIds);
 }
 
 // ── Presence event handler ───────────────────────────────────────────
@@ -174,6 +177,7 @@ function handlePresence(payload: unknown): void {
 
       const existing = peers.get(msg.peer_id);
       const peer: PeerCursorInfo = existing ?? {
+        peerId: msg.peer_id,
         peerLabel: msg.peer_label || "Peer",
         color: peerColor(msg.peer_id),
       };
@@ -223,6 +227,7 @@ function handlePresence(payload: unknown): void {
         if (snap.peer_id === localPeerId) continue;
 
         const peer: PeerCursorInfo = {
+          peerId: snap.peer_id,
           peerLabel: snap.peer_label,
           color: peerColor(snap.peer_id),
         };
@@ -290,5 +295,63 @@ export function startCursorDispatch(peerId: string): () => void {
       }
     }
     editors.clear();
+    // Clear cell subscriptions
+    cellSubscribers.clear();
   };
+}
+
+// ── Cell-level presence queries ───────────────────────────────────────
+
+/** Map of cellId → Set of subscriber callbacks */
+const cellSubscribers = new Map<string, Set<() => void>>();
+
+/**
+ * Get all remote peers that have a cursor in the given cell.
+ * Returns peer info for UI rendering (colored dots, labels, etc.)
+ */
+export function getPeersForCell(cellId: string): PeerCursorInfo[] {
+  const result: PeerCursorInfo[] = [];
+  for (const peer of peers.values()) {
+    if (peer.peerId === localPeerId) continue;
+    if (peer.cursor?.cell_id === cellId) {
+      result.push(peer);
+    }
+  }
+  return result;
+}
+
+/**
+ * Subscribe to presence changes for a specific cell.
+ * The callback is invoked whenever peers enter or leave the cell.
+ * Returns an unsubscribe function.
+ */
+export function subscribeToCell(
+  cellId: string,
+  callback: () => void,
+): () => void {
+  let subs = cellSubscribers.get(cellId);
+  if (!subs) {
+    subs = new Set();
+    cellSubscribers.set(cellId, subs);
+  }
+  subs.add(callback);
+
+  return () => {
+    subs?.delete(callback);
+    if (subs?.size === 0) {
+      cellSubscribers.delete(cellId);
+    }
+  };
+}
+
+/** Notify cell subscribers when presence changes. */
+function notifyCellSubscribers(cellIds: Set<string>): void {
+  for (const cellId of cellIds) {
+    const subs = cellSubscribers.get(cellId);
+    if (subs) {
+      for (const cb of subs) {
+        cb();
+      }
+    }
+  }
 }

--- a/apps/notebook/src/lib/cursor-registry.ts
+++ b/apps/notebook/src/lib/cursor-registry.ts
@@ -122,7 +122,10 @@ export function unregisterEditor(cellId: string): void {
 /** Collect all remote cursors for a cell and dispatch to its EditorView. */
 function dispatchToCell(cellId: string): void {
   const view = editors.get(cellId);
-  if (!view) return;
+  if (!view) {
+    console.log(`[cursor-registry] dispatchToCell: no view for ${cellId}`);
+    return;
+  }
 
   const cursors: RemoteCursorState[] = [];
   const selections: RemoteSelectionState[] = [];
@@ -153,6 +156,9 @@ function dispatchToCell(cellId: string): void {
     }
   }
 
+  console.log(
+    `[cursor-registry] dispatchToCell ${cellId}: ${cursors.length} cursors, ${selections.length} selections`,
+  );
   setRemoteCursors(view, cursors);
   setRemoteSelections(view, selections);
 }

--- a/apps/notebook/src/lib/presence-sender.ts
+++ b/apps/notebook/src/lib/presence-sender.ts
@@ -1,0 +1,89 @@
+/**
+ * CodeMirror extension that broadcasts local cursor/selection presence.
+ *
+ * Listens to selection changes via `EditorView.updateListener` and calls
+ * presence callbacks with throttling to prevent flooding during rapid typing.
+ *
+ * The extension is created per-cell with the cell ID baked in, so each
+ * CodeMirror instance knows which cell it belongs to.
+ */
+
+import type { Extension } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+
+export interface PresenceSenderCallbacks {
+  onCursor: (cellId: string, line: number, column: number) => void;
+  onSelection: (
+    cellId: string,
+    anchorLine: number,
+    anchorCol: number,
+    headLine: number,
+    headCol: number,
+  ) => void;
+}
+
+/** Throttle interval in ms (~13 updates/sec max) */
+const THROTTLE_MS = 75;
+
+/**
+ * Create a CodeMirror extension that sends presence updates on selection change.
+ *
+ * @param cellId The ID of the cell this editor belongs to
+ * @param callbacks Presence send functions (typically from PresenceContext)
+ */
+export function presenceSenderExtension(
+  cellId: string,
+  callbacks: PresenceSenderCallbacks,
+): Extension {
+  let throttleTimer: ReturnType<typeof setTimeout> | null = null;
+  let pendingUpdate = false;
+
+  return EditorView.updateListener.of((update) => {
+    // Only act on selection changes
+    if (!update.selectionSet) return;
+
+    // If a timer is pending, mark that we have a pending update
+    if (throttleTimer) {
+      pendingUpdate = true;
+      return;
+    }
+
+    // Send immediately, then start throttle window
+    sendPresence(update.view, cellId, callbacks);
+
+    throttleTimer = setTimeout(() => {
+      throttleTimer = null;
+      // If there was a pending update during the throttle window, send it now
+      if (pendingUpdate) {
+        pendingUpdate = false;
+        sendPresence(update.view, cellId, callbacks);
+      }
+    }, THROTTLE_MS);
+  });
+}
+
+function sendPresence(
+  view: EditorView,
+  cellId: string,
+  callbacks: PresenceSenderCallbacks,
+): void {
+  const sel = view.state.selection.main;
+  const doc = view.state.doc;
+
+  // Convert head position to line:column
+  const headLineObj = doc.lineAt(sel.head);
+  const headLine = headLineObj.number - 1; // 0-based
+  const headCol = sel.head - headLineObj.from;
+
+  if (sel.anchor === sel.head) {
+    // Cursor only (no selection)
+    callbacks.onCursor(cellId, headLine, headCol);
+  } else {
+    // Selection - also need anchor position
+    const anchorLineObj = doc.lineAt(sel.anchor);
+    const anchorLine = anchorLineObj.number - 1;
+    const anchorCol = sel.anchor - anchorLineObj.from;
+
+    callbacks.onSelection(cellId, anchorLine, anchorCol, headLine, headCol);
+  }
+}

--- a/python/runtimed/demos/presence_cursor.py
+++ b/python/runtimed/demos/presence_cursor.py
@@ -1,4 +1,10 @@
-"""Demo: animate a cursor across a cell in the desktop app via presence.
+"""Demo: animate cursor and selection across cells via presence.
+
+Showcases:
+- Cell focus indicators (colored dots appear when cursor enters a cell)
+- Cursor animation (cursor bar moves through code)
+- Selection highlighting (selected text is highlighted)
+- Multi-cell navigation (cursor jumps between cells)
 
 Usage (from python/runtimed/, with dev daemon running):
 
@@ -29,6 +35,78 @@ def get_socket_path():
     return path
 
 
+def demo_cell_focus(session, cells):
+    """Demo 1: Cell focus indicators - jump between cells to show colored dots."""
+    print("\n📍 Demo 1: Cell Focus Indicators")
+    print("   Watch the colored dots appear in the cell gutter as we switch cells...")
+
+    for i, cell in enumerate(cells[:4]):  # Show first 4 cells
+        print(f"   → Focusing cell {i + 1}: {cell.cell_type}")
+        session.set_cursor(cell.id, line=0, column=0)
+        time.sleep(1.0)
+
+
+def demo_cursor_animation(session, cell):
+    """Demo 2: Animate cursor across a cell."""
+    source = cell.source
+    lines = source.split("\n")
+    print(f"\n✏️  Demo 2: Cursor Animation")
+    print(f"   Sweeping cursor across {len(lines)} lines...")
+
+    # Sweep across each line
+    for line_num, line_text in enumerate(lines[:5]):  # Limit to 5 lines for demo
+        for col in range(len(line_text) + 1):
+            session.set_cursor(cell.id, line=line_num, column=col)
+            time.sleep(0.03)
+
+    # Sweep back across line 0
+    first_line = lines[0] if lines else ""
+    for col in range(len(first_line), -1, -1):
+        session.set_cursor(cell.id, line=0, column=col)
+        time.sleep(0.03)
+
+
+def demo_selection(session, cell):
+    """Demo 3: Selection highlighting - grow selection across the cell."""
+    source = cell.source
+    lines = source.split("\n")
+    print(f"\n🎨 Demo 3: Selection Highlighting")
+    print(f"   Growing selection across the code...")
+
+    # Start at beginning
+    anchor_line, anchor_col = 0, 0
+
+    # Grow selection line by line
+    for line_num, line_text in enumerate(lines[:5]):  # Limit to 5 lines
+        for col in range(0, len(line_text) + 1, 3):  # Skip every 3 cols for speed
+            session.set_selection(
+                cell.id,
+                anchor_line=anchor_line,
+                anchor_col=anchor_col,
+                head_line=line_num,
+                head_col=col,
+            )
+            time.sleep(0.05)
+
+    # Hold the full selection
+    time.sleep(1.0)
+
+    # Shrink selection back
+    print("   Shrinking selection...")
+    for line_num in range(min(4, len(lines) - 1), -1, -1):
+        session.set_selection(
+            cell.id,
+            anchor_line=anchor_line,
+            anchor_col=anchor_col,
+            head_line=line_num,
+            head_col=0,
+        )
+        time.sleep(0.15)
+
+    # Clear selection by setting cursor
+    session.set_cursor(cell.id, line=0, column=0)
+
+
 def main():
     get_socket_path()  # validate env var is set
 
@@ -44,7 +122,7 @@ def main():
         notebook_id = rooms[0]["notebook_id"]
         print(f"Auto-detected notebook: {notebook_id}")
 
-    session = runtimed.Session(notebook_id=notebook_id, peer_label="🦾")
+    session = runtimed.Session(notebook_id=notebook_id, peer_label="🤖 Agent")
     session.connect()
 
     cells = session.get_cells()
@@ -52,33 +130,29 @@ def main():
         print("No cells found in notebook", file=sys.stderr)
         sys.exit(1)
 
-    print("Cells:")
-    for c in cells:
-        print(f"  {c.id}: {c.cell_type} ({len(c.source)} chars) -> {c.source[:60]!r}")
+    print("=" * 50)
+    print("🎭 Presence Demo: Cell Focus & Selection")
+    print("=" * 50)
+    print(f"\nNotebook: {notebook_id}")
+    print(f"Found {len(cells)} cells:")
+    for i, c in enumerate(cells[:5]):
+        preview = c.source[:40].replace("\n", "↵") if c.source else "(empty)"
+        print(f"  [{i + 1}] {c.cell_type}: {preview}...")
 
-    # Pick the cell with the most content
+    # Run demos
+    demo_cell_focus(session, cells)
+
+    # Pick cell with most content for cursor/selection demos
     cell = max(cells, key=lambda c: len(c.source))
-    source = cell.source
-    lines = source.split("\n")
-    print(f"\nAnimating cursor across cell {cell.id} ({len(source)} chars, {len(lines)} lines)")
+    if len(cell.source) > 10:
+        demo_cursor_animation(session, cell)
+        demo_selection(session, cell)
 
-    # Sweep across each line
-    for line_num, line_text in enumerate(lines):
-        for col in range(len(line_text) + 1):
-            session.set_cursor(cell.id, line=line_num, column=col)
-            time.sleep(0.04)
-
-    # Sweep back across line 0
-    first_line = lines[0] if lines else ""
-    for col in range(len(first_line), -1, -1):
-        session.set_cursor(cell.id, line=0, column=col)
-        time.sleep(0.04)
-
-    # Hold at the beginning so you can see it
-    session.set_cursor(cell.id, line=0, column=0)
+    # Final: return to first cell
+    print("\n✅ Demo complete!")
+    print("   Cursor returning to first cell...")
+    session.set_cursor(cells[0].id, line=0, column=0)
     time.sleep(2)
-
-    print("Done.")
 
 
 if __name__ == "__main__":

--- a/src/components/cell/CellContainer.tsx
+++ b/src/components/cell/CellContainer.tsx
@@ -21,6 +21,8 @@ interface CellContainerProps {
   rightGutterContent?: ReactNode;
   /** Content to render in the right margin aligned with output row (e.g., output controls) */
   outputRightGutterContent?: ReactNode;
+  /** Remote peer presence indicators (colored dots showing who's on this cell) */
+  presenceIndicators?: ReactNode;
   /** Custom color configuration for cell types not in defaults */
   customGutterColors?: Record<string, GutterColorConfig>;
   /** Whether this cell is immediately before the focused cell (keeps output bright) */
@@ -46,6 +48,7 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
       gutterContent,
       rightGutterContent,
       outputRightGutterContent,
+      presenceIndicators,
       customGutterColors,
       isPreviousCellFromFocused = false,
       dragHandleProps,
@@ -85,6 +88,7 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
         {/* Gutter area - action content only (ribbon moves to content rows for segmented) */}
         <div className="flex w-10 flex-shrink-0 flex-col items-end justify-start gap-0.5 pr-1 pt-3 select-none">
           {gutterContent}
+          {presenceIndicators}
         </div>
         {/* Cell content with ribbon */}
         {useSegmentedRibbon ? (

--- a/src/components/editor/remote-cursors.ts
+++ b/src/components/editor/remote-cursors.ts
@@ -381,6 +381,11 @@ export function setRemoteCursors(
   cursors: RemoteCursorState[],
 ): void {
   view.dispatch({ effects: setCursorsEffect.of(cursors) });
+  // Force layer remeasure when clearing cursors - CM6 layer may not redraw
+  // with an empty markers() return without an explicit measure request
+  if (cursors.length === 0) {
+    view.requestMeasure();
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

Enable real-time presence collaboration by broadcasting cursor positions and selections from code editors to remote peers. Add visual cell-level indicators showing which peers are focused on each cell.

**Features:**
* Throttled cursor/selection broadcasting (75ms) when typing or selecting in CodeMirror
* Cell-level presence indicators (colored dots) in cell gutters for remote peers
* PresenceContext for providing presence methods without prop drilling
* Cell-level presence queries: `getPeersForCell()`, `subscribeToCell()`

**Implementation:**
* `presence-sender.ts`: CodeMirror extension detecting selection changes
* `PresenceContext.tsx`: React context wrapping usePresence hook
* `CellPresenceIndicators.tsx`: UI component rendering peer indicators
* Cursor registry extensions for cell-level presence subscriptions
* Support for all cell types: code, markdown, raw

**Protocol**: Uses existing CBOR-encoded presence frames (frame type 0x04) — no daemon changes needed.

## Verification

* [ ] Open the same notebook in two browser windows
* [ ] Type or select text in one window → cursor/selection appears in other window
* [ ] Move between cells → colored dot indicators move to new cell
* [ ] Verify peer labels display correctly ("Human", "Agent", etc.)
* [ ] Run app with Python MCP client to test agent presence broadcasting

_PR submitted by @rgbkrk's agent, Quill_