### PR TITLE
fix(ci): correct nteract-dist artifact path after uv workspace migration

### DIFF
--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -679,7 +679,8 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: nteract-dist
-          path: python/nteract/dist
+          path: python/dist
+          if-no-files-found: error
 
   build-python-wheels:
     name: Build Python Wheels (${{ matrix.platform.target }})


### PR DESCRIPTION
## Summary

PR #731 introduced uv workspaces at `python/`. This changed where `uv build` outputs files — it now outputs to the workspace root (`python/dist/`) rather than the package directory (`python/nteract/dist/`).

The nightly release was failing because the upload step still looked for `python/nteract/dist`. This change updates the path and adds `if-no-files-found: error` to fail fast if the build produces no output.

## Verification

- [ ] Trigger nightly workflow via `workflow_dispatch`
- [ ] Verify `build-nteract-package` job completes successfully
- [ ] Verify `nteract-dist` artifact is uploaded
- [ ] Verify `prerelease` job completes and publishes to PyPI

_PR submitted by @rgbkrk's agent, Quill_