### PR TITLE
fix(runtimed-py): wrap entire execute_cell in timeout

### DIFF
--- a/crates/runtimed-py/src/async_session.rs
+++ b/crates/runtimed-py/src/async_session.rs
@@ -1182,43 +1182,44 @@ impl AsyncSession {
                 }
             }
 
-            let state_guard = state.lock().await;
-
-            let handle = state_guard
-                .handle
-                .as_ref()
-                .ok_or_else(|| to_py_err("Not connected"))?;
-
-            let blob_base_url = state_guard.blob_base_url.clone();
-            let blob_store_path = state_guard.blob_store_path.clone();
-
-            // Confirm the daemon has merged our latest changes before executing.
-            // The daemon reads cell source from its own Automerge doc, so it must
-            // have the cell before we can reference it by ID.
-            handle.confirm_sync().await.map_err(to_py_err)?;
-
-            // Execute cell (daemon reads source from automerge doc)
-            let response = handle
-                .send_request(NotebookRequest::ExecuteCell {
-                    cell_id: cell_id.clone(),
-                })
-                .await
-                .map_err(to_py_err)?;
-
-            match response {
-                NotebookResponse::CellQueued { .. } => {}
-                NotebookResponse::Error { error } => return Err(to_py_err(error)),
-                other => return Err(to_py_err(format!("Unexpected response: {:?}", other))),
-            }
-
-            drop(state_guard); // Release lock before waiting for broadcasts
-
-            // Wait for outputs
+            // Wrap the entire execution lifecycle in a single timeout.
+            // Previously only collect_outputs was bounded, which meant
+            // confirm_sync() or send_request() could hang indefinitely.
             let timeout = std::time::Duration::from_secs_f64(timeout_secs);
-            let result = tokio::time::timeout(
-                timeout,
-                collect_outputs_async(&state, &cell_id, blob_base_url, blob_store_path),
-            )
+            let result = tokio::time::timeout(timeout, async {
+                let state_guard = state.lock().await;
+
+                let handle = state_guard
+                    .handle
+                    .as_ref()
+                    .ok_or_else(|| to_py_err("Not connected"))?;
+
+                let blob_base_url = state_guard.blob_base_url.clone();
+                let blob_store_path = state_guard.blob_store_path.clone();
+
+                // Confirm the daemon has merged our latest changes before executing.
+                // The daemon reads cell source from its own Automerge doc, so it must
+                // have the cell before we can reference it by ID.
+                handle.confirm_sync().await.map_err(to_py_err)?;
+
+                // Execute cell (daemon reads source from automerge doc)
+                let response = handle
+                    .send_request(NotebookRequest::ExecuteCell {
+                        cell_id: cell_id.clone(),
+                    })
+                    .await
+                    .map_err(to_py_err)?;
+
+                match response {
+                    NotebookResponse::CellQueued { .. } => {}
+                    NotebookResponse::Error { error } => return Err(to_py_err(error)),
+                    other => return Err(to_py_err(format!("Unexpected response: {:?}", other))),
+                }
+
+                drop(state_guard); // Release lock before waiting for broadcasts
+
+                collect_outputs_async(&state, &cell_id, blob_base_url, blob_store_path).await
+            })
             .await;
 
             match result {

--- a/crates/runtimed-py/src/session.rs
+++ b/crates/runtimed-py/src/session.rs
@@ -1029,43 +1029,45 @@ impl Session {
         }
 
         self.runtime.block_on(async {
-            let state = self.state.lock().await;
-
-            let handle = state
-                .handle
-                .as_ref()
-                .ok_or_else(|| to_py_err("Not connected"))?;
-
-            let blob_base_url = state.blob_base_url.clone();
-            let blob_store_path = state.blob_store_path.clone();
-
-            // Confirm the daemon has merged our latest changes before executing.
-            // The daemon reads cell source from its own Automerge doc, so it must
-            // have the cell before we can reference it by ID.
-            handle.confirm_sync().await.map_err(to_py_err)?;
-
-            // Execute cell (daemon reads source from automerge doc)
-            let response = handle
-                .send_request(NotebookRequest::ExecuteCell {
-                    cell_id: cell_id.clone(),
-                })
-                .await
-                .map_err(to_py_err)?;
-
-            match response {
-                NotebookResponse::CellQueued { .. } => {}
-                NotebookResponse::Error { error } => return Err(to_py_err(error)),
-                other => return Err(to_py_err(format!("Unexpected response: {:?}", other))),
-            }
-
-            drop(state); // Release lock before waiting for broadcasts
-
-            // Wait for outputs
+            // Wrap the entire execution lifecycle in a single timeout.
+            // Previously only collect_outputs was bounded, which meant
+            // confirm_sync() or send_request() could hang indefinitely.
             let timeout = std::time::Duration::from_secs_f64(timeout_secs);
-            let result = tokio::time::timeout(
-                timeout,
-                self.collect_outputs(&cell_id, blob_base_url, blob_store_path),
-            )
+            let result = tokio::time::timeout(timeout, async {
+                let state = self.state.lock().await;
+
+                let handle = state
+                    .handle
+                    .as_ref()
+                    .ok_or_else(|| to_py_err("Not connected"))?;
+
+                let blob_base_url = state.blob_base_url.clone();
+                let blob_store_path = state.blob_store_path.clone();
+
+                // Confirm the daemon has merged our latest changes before executing.
+                // The daemon reads cell source from its own Automerge doc, so it must
+                // have the cell before we can reference it by ID.
+                handle.confirm_sync().await.map_err(to_py_err)?;
+
+                // Execute cell (daemon reads source from automerge doc)
+                let response = handle
+                    .send_request(NotebookRequest::ExecuteCell {
+                        cell_id: cell_id.clone(),
+                    })
+                    .await
+                    .map_err(to_py_err)?;
+
+                match response {
+                    NotebookResponse::CellQueued { .. } => {}
+                    NotebookResponse::Error { error } => return Err(to_py_err(error)),
+                    other => return Err(to_py_err(format!("Unexpected response: {:?}", other))),
+                }
+
+                drop(state); // Release lock before waiting for broadcasts
+
+                self.collect_outputs(&cell_id, blob_base_url, blob_store_path)
+                    .await
+            })
             .await;
 
             match result {


### PR DESCRIPTION
Previously, only `collect_outputs` was bounded by `timeout_secs`. The `confirm_sync()` and `send_request()` calls that precede it had no timeout — a stalled sync task or unresponsive daemon could hang the call forever.

This was observed in CI (PR #746 run 6): `test_execution_error_captured` hung for 600s (pytest timeout) instead of the expected 60s, because the hang occurred before the timeout wrapper was reached.

Now the entire execution lifecycle — `confirm_sync`, `send_request`, and `collect_outputs` — is wrapped in a single `tokio::time::timeout`. Applied to both `Session` and `AsyncSession`.

_PR submitted by @rgbkrk's agent Quill, via Zed_