### PR TITLE
fix(runtimed-py): fix three AsyncSession bugs found during API audit

### DIFF
--- a/crates/runtimed-py/src/async_session.rs
+++ b/crates/runtimed-py/src/async_session.rs
@@ -502,16 +502,9 @@ impl AsyncSession {
             let insert_index = index.unwrap_or(cells.len());
 
             handle
-                .add_cell(insert_index, &cell_id, &cell_type)
+                .add_cell_with_source(insert_index, &cell_id, &cell_type, &source)
                 .await
                 .map_err(to_py_err)?;
-
-            if !source.is_empty() {
-                handle
-                    .update_source(&cell_id, &source)
-                    .await
-                    .map_err(to_py_err)?;
-            }
 
             Ok(cell_id)
         })
@@ -1153,7 +1146,7 @@ impl AsyncSession {
                     let response = handle
                         .send_request(NotebookRequest::LaunchKernel {
                             kernel_type: "python".to_string(),
-                            env_source: "uv:prewarmed".to_string(),
+                            env_source: "auto".to_string(),
                             notebook_path: None,
                         })
                         .await
@@ -1339,7 +1332,7 @@ impl AsyncSession {
                     let response = handle
                         .send_request(NotebookRequest::LaunchKernel {
                             kernel_type: "python".to_string(),
-                            env_source: "uv:prewarmed".to_string(),
+                            env_source: "auto".to_string(),
                             notebook_path: None,
                         })
                         .await
@@ -1706,7 +1699,6 @@ impl AsyncSession {
         wait_for_ready: bool,
     ) -> PyResult<Bound<'py, PyAny>> {
         let state = Arc::clone(&self.state);
-        let notebook_id = self.notebook_id.clone();
 
         future_into_py(py, async move {
             // TODO: Consider adding NotebookRequest::RestartKernel to the daemon
@@ -1745,7 +1737,7 @@ impl AsyncSession {
                     .send_request(NotebookRequest::LaunchKernel {
                         kernel_type: "python".to_string(),
                         env_source: "auto".to_string(),
-                        notebook_path: Some(notebook_id.clone()),
+                        notebook_path: None,
                     })
                     .await
                     .map_err(to_py_err)?;


### PR DESCRIPTION
Found during an API surface comparison between `Session` and `AsyncSession` (prep for unifying them). Three bugs where `AsyncSession` diverged from `Session`'s correct behavior:

1. **`create_cell` non-atomic**: Used two-step `add_cell` + `update_source` instead of atomic `add_cell_with_source`. Remote peers could briefly see an empty cell before the source arrived.

2. **`execute_cell`/`stream_execute` hardcoded `"uv:prewarmed"`**: Auto-start used `"uv:prewarmed"` instead of `"auto"`, bypassing the daemon's environment auto-detection (pyproject.toml, pixi.toml, etc). Session correctly uses `"auto"`.

3. **`restart_kernel` passed `notebook_id` as `notebook_path`**: The daemon would try to resolve a UUID string as a file path for environment detection.

_PR submitted by @rgbkrk's agent Quill, via Zed_