### PR TITLE
refactor(runtimed-py): unify Session/AsyncSession via shared session_core

### DIFF
--- a/crates/runtimed-py/src/async_session.rs
+++ b/crates/runtimed-py/src/async_session.rs
@@ -1,7 +1,8 @@
-//! Async session for code execution.
+//! Async Session for code execution.
 //!
-//! Provides an async interface for executing code via the daemon's kernel.
-//! All methods return Python coroutines that can be awaited.
+//! Thin wrapper around `session_core` async functions, using
+//! `future_into_py()` to provide an async Python API.
+//! All business logic lives in `session_core.rs`.
 
 use pyo3::prelude::*;
 use pyo3_async_runtimes::tokio::future_into_py;
@@ -9,19 +10,14 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
-use runtimed::notebook_sync_client::{
-    NotebookBroadcastReceiver, NotebookSyncClient, NotebookSyncHandle, NotebookSyncReceiver,
-};
 use runtimed::protocol::{NotebookBroadcast, NotebookRequest, NotebookResponse};
 
-use crate::daemon_paths::{get_blob_paths_async, get_socket_path};
+use crate::daemon_paths::get_socket_path;
 use crate::error::to_py_err;
 use crate::event_stream::ExecutionEventStream;
-use crate::output::{Cell, ExecutionResult, NotebookConnectionInfo, Output, SyncEnvironmentResult};
-use crate::output_resolver;
+use crate::output::{Cell, ExecutionResult, NotebookConnectionInfo, SyncEnvironmentResult};
+use crate::session_core::{self, SessionState};
 use crate::subscription::EventSubscription;
-
-use notebook_doc::metadata::NotebookMetadataSnapshot;
 
 /// An async session for executing code via the runtimed daemon.
 ///
@@ -38,43 +34,9 @@ use notebook_doc::metadata::NotebookMetadataSnapshot;
 ///         print(result.stdout)  # "hello\n"
 #[pyclass]
 pub struct AsyncSession {
-    state: Arc<Mutex<AsyncSessionState>>,
+    state: Arc<Mutex<SessionState>>,
     notebook_id: String,
     peer_label: Option<String>,
-}
-
-struct AsyncSessionState {
-    handle: Option<NotebookSyncHandle>,
-    /// Keep the sync receiver alive so the sync task doesn't exit
-    #[allow(dead_code)]
-    sync_rx: Option<NotebookSyncReceiver>,
-    broadcast_rx: Option<NotebookBroadcastReceiver>,
-    kernel_started: bool,
-    env_source: Option<String>,
-    /// Base URL for blob server (for resolving blob hashes)
-    blob_base_url: Option<String>,
-    /// Path to blob store directory (fallback for direct disk access)
-    blob_store_path: Option<PathBuf>,
-    /// Connection info from daemon (for open_notebook/create_notebook)
-    connection_info: Option<NotebookConnectionInfo>,
-    /// Notebook path (for project file detection during kernel launch)
-    notebook_path: Option<String>,
-}
-
-impl AsyncSessionState {
-    fn new() -> Self {
-        Self {
-            handle: None,
-            sync_rx: None,
-            broadcast_rx: None,
-            kernel_started: false,
-            env_source: None,
-            blob_base_url: None,
-            blob_store_path: None,
-            connection_info: None,
-            notebook_path: None,
-        }
-    }
 }
 
 #[pymethods]
@@ -82,10 +44,8 @@ impl AsyncSession {
     /// Create a new async session.
     ///
     /// Args:
-    ///     notebook_id: Optional unique identifier for this session.
-    ///                  If not provided, a random UUID is generated.
-    ///                  Multiple AsyncSession objects with the same notebook_id
-    ///                  will share the same kernel.
+    ///     notebook_id: Optional unique identifier. If not provided, a random UUID is generated.
+    ///     peer_label: Optional label for collaborative presence.
     #[new]
     #[pyo3(signature = (notebook_id=None, peer_label=None))]
     fn new(notebook_id: Option<String>, peer_label: Option<String>) -> PyResult<Self> {
@@ -93,112 +53,77 @@ impl AsyncSession {
             notebook_id.unwrap_or_else(|| format!("agent-session-{}", uuid::Uuid::new_v4()));
 
         Ok(Self {
-            state: Arc::new(Mutex::new(AsyncSessionState::new())),
+            state: Arc::new(Mutex::new(SessionState::new())),
             notebook_id,
             peer_label,
         })
     }
 
-    /// Get the notebook ID for this session.
+    /// The notebook ID for this session.
     #[getter]
     fn notebook_id(&self) -> &str {
         &self.notebook_id
     }
 
-    /// Check if the session is connected to the daemon.
-    ///
-    /// Returns a coroutine that resolves to bool.
+    /// Whether the session is connected to the daemon.
     fn is_connected<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let state = Arc::clone(&self.state);
         future_into_py(py, async move {
-            let state = state.lock().await;
-            Ok(state.handle.is_some())
+            let st = state.lock().await;
+            Ok(st.handle.is_some())
         })
     }
 
-    /// Check if a kernel has been started.
-    ///
-    /// Returns a coroutine that resolves to bool.
+    /// Whether a kernel has been started.
     fn kernel_started<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let state = Arc::clone(&self.state);
         future_into_py(py, async move {
-            let state = state.lock().await;
-            Ok(state.kernel_started)
+            let st = state.lock().await;
+            Ok(st.kernel_started)
         })
     }
 
-    /// Get the environment source (e.g., "uv:prewarmed") if kernel is running.
-    ///
-    /// Returns a coroutine that resolves to Optional[str].
+    /// Get the environment source if kernel is running.
     fn env_source<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let state = Arc::clone(&self.state);
         future_into_py(py, async move {
-            let state = state.lock().await;
-            Ok(state.env_source.clone())
+            let st = state.lock().await;
+            Ok(st.env_source.clone())
         })
     }
 
-    /// Get the connection info from daemon (for open_notebook/create_notebook).
-    ///
-    /// Returns None if not connected via open_notebook() or create_notebook().
-    /// Returns a coroutine that resolves to Optional[NotebookConnectionInfo].
+    /// Get connection info (from open_notebook/create_notebook).
     fn connection_info<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let state = Arc::clone(&self.state);
         future_into_py(py, async move {
-            let state = state.lock().await;
-            Ok(state.connection_info.clone())
+            let st = state.lock().await;
+            Ok(st.connection_info.clone())
         })
     }
 
-    /// Open an existing notebook file via the daemon.
+    // =========================================================================
+    // Connection (static constructors and connect)
+    // =========================================================================
+
+    /// Open an existing notebook file.
     ///
-    /// The daemon loads the file, derives the notebook_id from the canonical path,
-    /// and returns connection info including trust status.
+    /// Returns a coroutine that resolves to a new AsyncSession.
     ///
     /// Args:
     ///     path: Path to the .ipynb file.
-    ///
-    /// Returns:
-    ///     A coroutine that resolves to a new AsyncSession connected to the opened notebook.
-    ///
-    /// Raises:
-    ///     RuntimedError: If the file cannot be opened or parsed.
     #[staticmethod]
     #[pyo3(signature = (path, peer_label=None))]
-    fn open_notebook(
-        py: Python<'_>,
-        path: String,
+    fn open_notebook<'py>(
+        py: Python<'py>,
+        path: &str,
         peer_label: Option<String>,
-    ) -> PyResult<Bound<'_, PyAny>> {
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let path = path.to_string();
+
         future_into_py(py, async move {
-            let path_buf = PathBuf::from(&path);
             let socket_path = get_socket_path();
-
-            let (handle, sync_rx, broadcast_rx, _cells, _metadata, info) =
-                NotebookSyncClient::connect_open_split(socket_path.clone(), path_buf, None)
-                    .await
-                    .map_err(to_py_err)?;
-
-            // Check for error in response
-            if let Some(error) = info.error {
-                return Err(to_py_err(error));
-            }
-
-            let notebook_id = info.notebook_id.clone();
-            let connection_info = NotebookConnectionInfo::from_protocol(info);
-            let (blob_base_url, blob_store_path) = get_blob_paths_async(&socket_path).await;
-
-            let state = AsyncSessionState {
-                handle: Some(handle),
-                sync_rx: Some(sync_rx),
-                broadcast_rx: Some(broadcast_rx),
-                kernel_started: false,
-                env_source: None,
-                blob_base_url,
-                blob_store_path,
-                connection_info: Some(connection_info),
-                notebook_path: Some(path),
-            };
+            let (notebook_id, state, _info) =
+                session_core::connect_open(socket_path, &path).await?;
 
             Ok(AsyncSession {
                 state: Arc::new(Mutex::new(state)),
@@ -208,79 +133,28 @@ impl AsyncSession {
         })
     }
 
-    /// Create a new notebook via the daemon.
+    /// Create a new notebook.
     ///
-    /// The daemon creates an empty notebook with one code cell and returns
-    /// connection info with a generated UUID as the notebook_id.
+    /// Returns a coroutine that resolves to a new AsyncSession.
     ///
     /// Args:
-    ///     runtime: The kernel runtime type ("python" or "deno"). Defaults to "python".
-    ///     working_dir: Optional working directory for project file detection.
-    ///
-    /// Returns:
-    ///     A coroutine that resolves to a new AsyncSession connected to the created notebook.
+    ///     runtime: Kernel runtime type (default: "python").
+    ///     working_dir: Optional working directory for the notebook.
     #[staticmethod]
     #[pyo3(signature = (runtime="python", working_dir=None, peer_label=None))]
     fn create_notebook<'py>(
         py: Python<'py>,
         runtime: &str,
-        working_dir: Option<String>,
+        working_dir: Option<&str>,
         peer_label: Option<String>,
     ) -> PyResult<Bound<'py, PyAny>> {
-        // Validate working_dir if provided
-        if let Some(ref wd) = working_dir {
-            let path = std::path::Path::new(wd);
-            if !path.exists() {
-                return Err(pyo3::exceptions::PyFileNotFoundError::new_err(format!(
-                    "working_dir does not exist: {}",
-                    wd
-                )));
-            }
-            if !path.is_dir() {
-                return Err(pyo3::exceptions::PyNotADirectoryError::new_err(format!(
-                    "working_dir is not a directory: {}",
-                    wd
-                )));
-            }
-        }
-
         let runtime = runtime.to_string();
+        let working_dir_buf = working_dir.map(PathBuf::from);
+
         future_into_py(py, async move {
-            let working_dir_str = working_dir.clone();
-            let working_dir_buf = working_dir.map(PathBuf::from);
             let socket_path = get_socket_path();
-
-            let (handle, sync_rx, broadcast_rx, _cells, _metadata, info) =
-                NotebookSyncClient::connect_create_split(
-                    socket_path.clone(),
-                    runtime,
-                    working_dir_buf,
-                    None,
-                    None,
-                )
-                .await
-                .map_err(to_py_err)?;
-
-            // Check for error in response
-            if let Some(error) = info.error {
-                return Err(to_py_err(error));
-            }
-
-            let notebook_id = info.notebook_id.clone();
-            let connection_info = NotebookConnectionInfo::from_protocol(info);
-            let (blob_base_url, blob_store_path) = get_blob_paths_async(&socket_path).await;
-
-            let state = AsyncSessionState {
-                handle: Some(handle),
-                sync_rx: Some(sync_rx),
-                broadcast_rx: Some(broadcast_rx),
-                kernel_started: false,
-                env_source: None,
-                blob_base_url,
-                blob_store_path,
-                connection_info: Some(connection_info),
-                notebook_path: working_dir_str,
-            };
+            let (notebook_id, state, _info) =
+                session_core::connect_create(socket_path, &runtime, working_dir_buf).await?;
 
             Ok(AsyncSession {
                 state: Arc::new(Mutex::new(state)),
@@ -291,56 +165,24 @@ impl AsyncSession {
     }
 
     /// Connect to the daemon.
-    ///
-    /// This is called automatically by start_kernel() if not already connected.
-    /// Respects the RUNTIMED_SOCKET_PATH environment variable if set.
-    ///
-    /// Returns a coroutine.
     fn connect<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let state = Arc::clone(&self.state);
         let notebook_id = self.notebook_id.clone();
-
         future_into_py(py, async move {
-            let mut state = state.lock().await;
-            if state.handle.is_some() {
-                return Ok(()); // Already connected
-            }
-
-            let socket_path = get_socket_path();
-
-            let (handle, sync_rx, broadcast_rx, _cells, _notebook_path) =
-                NotebookSyncClient::connect_split(socket_path.clone(), notebook_id)
-                    .await
-                    .map_err(to_py_err)?;
-
-            let (blob_base_url, blob_store_path) = get_blob_paths_async(&socket_path).await;
-
-            state.handle = Some(handle);
-            state.sync_rx = Some(sync_rx);
-            state.broadcast_rx = Some(broadcast_rx);
-            state.blob_base_url = blob_base_url;
-            state.blob_store_path = blob_store_path;
-
-            Ok(())
+            session_core::connect(&state, &notebook_id).await
         })
     }
 
-    /// Start a kernel for this session.
+    // =========================================================================
+    // Kernel lifecycle
+    // =========================================================================
+
+    /// Start a kernel in the daemon.
     ///
     /// Args:
-    ///     kernel_type: Type of kernel ("python" or "deno"). Defaults to "python".
-    ///     env_source: Environment source. Defaults to "auto" (auto-detect from
-    ///         notebook metadata or project files). For Deno kernels, this is
-    ///         ignored and always uses "deno".
-    ///     notebook_path: Optional path to the notebook file on disk.
-    ///         Used for project file detection (pyproject.toml, pixi.toml,
-    ///         environment.yml) when env_source is "auto". If not provided,
-    ///         uses the path from open_notebook() if available.
-    ///
-    /// If a kernel is already running for this session's notebook_id,
-    /// this returns immediately without starting a new one.
-    ///
-    /// Returns a coroutine.
+    ///     kernel_type: Type of kernel to start (default: "python").
+    ///     env_source: Environment source (default: "auto").
+    ///     notebook_path: Optional path for project file detection.
     #[pyo3(signature = (kernel_type="python", env_source="auto", notebook_path=None))]
     fn start_kernel<'py>(
         &self,
@@ -357,115 +199,48 @@ impl AsyncSession {
 
         future_into_py(py, async move {
             // Ensure connected first
-            {
-                let state_guard = state.lock().await;
-                if state_guard.handle.is_none() {
-                    drop(state_guard);
-
-                    // Connect
-                    let socket_path = if let Ok(path) = std::env::var("RUNTIMED_SOCKET_PATH") {
-                        std::path::PathBuf::from(path)
-                    } else {
-                        runtimed::default_socket_path()
-                    };
-
-                    let (handle, sync_rx, broadcast_rx, _cells, _notebook_path) =
-                        NotebookSyncClient::connect_split(socket_path.clone(), notebook_id)
-                            .await
-                            .map_err(to_py_err)?;
-
-                    let (blob_base_url, blob_store_path) =
-                        if let Some(parent) = socket_path.parent() {
-                            let daemon_json = parent.join("daemon.json");
-                            let base_url = if daemon_json.exists() {
-                                tokio::fs::read_to_string(&daemon_json)
-                                    .await
-                                    .ok()
-                                    .and_then(|contents| {
-                                        serde_json::from_str::<serde_json::Value>(&contents).ok()
-                                    })
-                                    .and_then(|info| info.get("blob_port").and_then(|p| p.as_u64()))
-                                    .map(|port| format!("http://127.0.0.1:{}", port))
-                            } else {
-                                None
-                            };
-
-                            let store_path = parent.join("blobs");
-                            let store_path = if store_path.exists() {
-                                Some(store_path)
-                            } else {
-                                None
-                            };
-
-                            (base_url, store_path)
-                        } else {
-                            (None, None)
-                        };
-
-                    let mut state_guard2 = state.lock().await;
-                    state_guard2.handle = Some(handle);
-                    state_guard2.sync_rx = Some(sync_rx);
-                    state_guard2.broadcast_rx = Some(broadcast_rx);
-                    state_guard2.blob_base_url = blob_base_url;
-                    state_guard2.blob_store_path = blob_store_path;
-                }
-            }
-
-            let mut state_guard = state.lock().await;
-
-            let handle = state_guard
-                .handle
-                .as_ref()
-                .ok_or_else(|| to_py_err("Not connected"))?;
-
-            // Use provided notebook_path or fall back to stored path from open_notebook()
-            let resolved_path = notebook_path.or_else(|| state_guard.notebook_path.clone());
-
-            let response = handle
-                .send_request(NotebookRequest::LaunchKernel {
-                    kernel_type,
-                    env_source,
-                    notebook_path: resolved_path,
-                })
+            session_core::connect(&state, &notebook_id).await?;
+            session_core::start_kernel(&state, &kernel_type, &env_source, notebook_path.as_deref())
                 .await
-                .map_err(to_py_err)?;
-
-            match response {
-                NotebookResponse::KernelLaunched {
-                    env_source: actual_env,
-                    ..
-                } => {
-                    state_guard.kernel_started = true;
-                    state_guard.env_source = Some(actual_env);
-                    Ok(())
-                }
-                NotebookResponse::KernelAlreadyRunning {
-                    env_source: actual_env,
-                    ..
-                } => {
-                    state_guard.kernel_started = true;
-                    state_guard.env_source = Some(actual_env);
-                    Ok(())
-                }
-                NotebookResponse::Error { error } => Err(to_py_err(error)),
-                other => Err(to_py_err(format!("Unexpected response: {:?}", other))),
-            }
         })
     }
 
-    // =========================================================================
-    // Document Operations (write to automerge doc, synced to all clients)
-    // =========================================================================
+    /// Shutdown the kernel.
+    fn shutdown_kernel<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let state = Arc::clone(&self.state);
+        future_into_py(
+            py,
+            async move { session_core::shutdown_kernel(&state).await },
+        )
+    }
 
-    /// Create a new cell in the automerge document.
-    ///
-    /// The cell is written to the shared document and synced to all connected
-    /// clients. Use execute_cell() to execute it.
+    /// Restart the kernel with auto environment detection.
     ///
     /// Args:
-    ///     source: The cell source code (default: empty string).
-    ///     cell_type: Cell type - "code", "markdown", or "raw" (default: "code").
-    ///     index: Position to insert the cell (default: append at end).
+    ///     wait_for_ready: If True, wait for kernel to report idle (default: True).
+    #[pyo3(signature = (wait_for_ready=true))]
+    fn restart_kernel<'py>(
+        &self,
+        py: Python<'py>,
+        wait_for_ready: bool,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let state = Arc::clone(&self.state);
+        future_into_py(py, async move {
+            session_core::restart_kernel(&state, wait_for_ready).await
+        })
+    }
+
+    /// Interrupt the currently executing cell.
+    fn interrupt<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let state = Arc::clone(&self.state);
+        future_into_py(py, async move { session_core::interrupt(&state).await })
+    }
+
+    // =========================================================================
+    // Cell operations
+    // =========================================================================
+
+    /// Create a new cell in the document (atomic: source set in same transaction).
     ///
     /// Returns a coroutine that resolves to the cell ID (str).
     #[pyo3(signature = (source="", cell_type="code", index=None))]
@@ -481,44 +256,11 @@ impl AsyncSession {
         let cell_type = cell_type.to_string();
 
         future_into_py(py, async move {
-            // Ensure connected
-            {
-                let state_guard = state.lock().await;
-                if state_guard.handle.is_none() {
-                    drop(state_guard);
-                    return Err(to_py_err("Not connected. Call connect() first."));
-                }
-            }
-
-            let cell_id = format!("cell-{}", uuid::Uuid::new_v4());
-
-            let state_guard = state.lock().await;
-            let handle = state_guard
-                .handle
-                .as_ref()
-                .ok_or_else(|| to_py_err("Not connected"))?;
-
-            let cells = handle.get_cells();
-            let insert_index = index.unwrap_or(cells.len());
-
-            handle
-                .add_cell_with_source(insert_index, &cell_id, &cell_type, &source)
-                .await
-                .map_err(to_py_err)?;
-
-            Ok(cell_id)
+            session_core::create_cell(&state, &source, &cell_type, index).await
         })
     }
 
     /// Update a cell's source in the automerge document.
-    ///
-    /// The change is synced to all connected clients.
-    ///
-    /// Args:
-    ///     cell_id: The cell ID.
-    ///     source: The new source code.
-    ///
-    /// Returns a coroutine.
     fn set_source<'py>(
         &self,
         py: Python<'py>,
@@ -530,32 +272,11 @@ impl AsyncSession {
         let source = source.to_string();
 
         future_into_py(py, async move {
-            let state_guard = state.lock().await;
-            let handle = state_guard
-                .handle
-                .as_ref()
-                .ok_or_else(|| to_py_err("Not connected"))?;
-
-            handle
-                .update_source(&cell_id, &source)
-                .await
-                .map_err(to_py_err)
+            session_core::set_source(&state, &cell_id, &source).await
         })
     }
 
-    /// Append text to a cell's source in the automerge document.
-    ///
-    /// Unlike set_source() which replaces the entire text (using Myers diff
-    /// internally), this directly inserts characters at the end of the source
-    /// Text CRDT. This is ideal for streaming/agentic use cases where an
-    /// external process is appending tokens incrementally — each append is
-    /// a minimal CRDT operation that syncs efficiently to all connected clients.
-    ///
-    /// Args:
-    ///     cell_id: The cell ID.
-    ///     text: The text to append to the cell's source.
-    ///
-    /// Returns a coroutine.
+    /// Append text to a cell's source (efficient for streaming tokens).
     fn append_source<'py>(
         &self,
         py: Python<'py>,
@@ -567,134 +288,37 @@ impl AsyncSession {
         let text = text.to_string();
 
         future_into_py(py, async move {
-            let state_guard = state.lock().await;
-            let handle = state_guard
-                .handle
-                .as_ref()
-                .ok_or_else(|| to_py_err("Not connected"))?;
-
-            handle
-                .append_source(&cell_id, &text)
-                .await
-                .map_err(to_py_err)
+            session_core::append_source(&state, &cell_id, &text).await
         })
     }
 
-    /// Get a cell from the automerge document.
-    ///
-    /// Args:
-    ///     cell_id: The cell ID.
-    ///
-    /// Returns a coroutine that resolves to Cell object.
-    ///
-    /// Raises:
-    ///     RuntimedError: If cell not found.
+    /// Get a cell by ID with resolved outputs.
     fn get_cell<'py>(&self, py: Python<'py>, cell_id: &str) -> PyResult<Bound<'py, PyAny>> {
         let state = Arc::clone(&self.state);
         let cell_id = cell_id.to_string();
 
-        future_into_py(py, async move {
-            // Get snapshot and blob config while holding lock
-            let (snapshot, blob_base_url, blob_store_path) = {
-                let state_guard = state.lock().await;
-                let handle = state_guard
-                    .handle
-                    .as_ref()
-                    .ok_or_else(|| to_py_err("Not connected"))?;
-
-                let blob_base_url = state_guard.blob_base_url.clone();
-                let blob_store_path = state_guard.blob_store_path.clone();
-
-                let cells = handle.get_cells();
-                let snapshot = cells
-                    .into_iter()
-                    .find(|c| c.id == cell_id)
-                    .ok_or_else(|| to_py_err(format!("Cell not found: {}", cell_id)))?;
-
-                (snapshot, blob_base_url, blob_store_path)
-            }; // Lock released here
-
-            // Resolve outputs outside the lock
-            let outputs = output_resolver::resolve_cell_outputs(
-                &snapshot.outputs,
-                &blob_base_url,
-                &blob_store_path,
-            )
-            .await;
-
-            Ok(Cell::from_snapshot_with_outputs(snapshot, outputs))
-        })
+        future_into_py(
+            py,
+            async move { session_core::get_cell(&state, &cell_id).await },
+        )
     }
 
-    /// Get all cells from the automerge document.
-    ///
-    /// Returns a coroutine that resolves to List[Cell].
+    /// Get all cells with resolved outputs.
     fn get_cells<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let state = Arc::clone(&self.state);
-
-        future_into_py(py, async move {
-            // Get snapshots and blob config while holding lock
-            let (snapshots, blob_base_url, blob_store_path) = {
-                let state_guard = state.lock().await;
-                let handle = state_guard
-                    .handle
-                    .as_ref()
-                    .ok_or_else(|| to_py_err("Not connected"))?;
-
-                let blob_base_url = state_guard.blob_base_url.clone();
-                let blob_store_path = state_guard.blob_store_path.clone();
-
-                let snapshots = handle.get_cells();
-                (snapshots, blob_base_url, blob_store_path)
-            }; // Lock released here
-
-            // Resolve outputs for all cells outside the lock
-            let mut cells = Vec::with_capacity(snapshots.len());
-            for snapshot in snapshots {
-                let outputs = output_resolver::resolve_cell_outputs(
-                    &snapshot.outputs,
-                    &blob_base_url,
-                    &blob_store_path,
-                )
-                .await;
-                cells.push(Cell::from_snapshot_with_outputs(snapshot, outputs));
-            }
-            Ok(cells)
-        })
+        future_into_py(py, async move { session_core::get_cells(&state).await })
     }
 
-    /// Delete a cell from the automerge document.
-    ///
-    /// Args:
-    ///     cell_id: The cell ID to delete.
-    ///
-    /// Returns a coroutine.
+    /// Delete a cell from the document.
     fn delete_cell<'py>(&self, py: Python<'py>, cell_id: &str) -> PyResult<Bound<'py, PyAny>> {
         let state = Arc::clone(&self.state);
         let cell_id = cell_id.to_string();
-
         future_into_py(py, async move {
-            let state_guard = state.lock().await;
-            let handle = state_guard
-                .handle
-                .as_ref()
-                .ok_or_else(|| to_py_err("Not connected"))?;
-
-            handle.delete_cell(&cell_id).await.map_err(to_py_err)
+            session_core::delete_cell(&state, &cell_id).await
         })
     }
 
-    /// Move a cell to a new position in the notebook.
-    ///
-    /// Updates the cell's fractional index position field. No delete/re-insert —
-    /// the cell object is preserved in the Automerge document.
-    ///
-    /// Args:
-    ///     cell_id: The cell ID to move.
-    ///     after_cell_id: Place the cell after this cell ID. None means move to the start.
-    ///
-    /// Returns:
-    ///     A coroutine that resolves to the new fractional position string.
+    /// Move a cell to after another cell (or to the beginning if None).
     #[pyo3(signature = (cell_id, after_cell_id=None))]
     fn move_cell<'py>(
         &self,
@@ -707,29 +331,24 @@ impl AsyncSession {
         let after_cell_id = after_cell_id.map(|s| s.to_string());
 
         future_into_py(py, async move {
-            let state_guard = state.lock().await;
-            let handle = state_guard
-                .handle
-                .as_ref()
-                .ok_or_else(|| to_py_err("Not connected"))?;
-
-            handle
-                .move_cell(&cell_id, after_cell_id.as_deref())
-                .await
-                .map_err(to_py_err)
+            session_core::move_cell(&state, &cell_id, after_cell_id.as_deref()).await
         })
     }
 
-    /// Send a cursor position as presence data to other connected peers.
-    ///
-    /// The daemon relays this to all other peers in the notebook room.
-    ///
-    /// Args:
-    ///     cell_id: The cell the cursor is in.
-    ///     line: Line number (0-based).
-    ///     column: Column number (0-based).
-    ///
-    /// Returns a coroutine.
+    /// Clear a cell's outputs.
+    fn clear_outputs<'py>(&self, py: Python<'py>, cell_id: &str) -> PyResult<Bound<'py, PyAny>> {
+        let state = Arc::clone(&self.state);
+        let cell_id = cell_id.to_string();
+        future_into_py(py, async move {
+            session_core::clear_outputs(&state, &cell_id).await
+        })
+    }
+
+    // =========================================================================
+    // Presence
+    // =========================================================================
+
+    /// Set cursor position for collaborative presence.
     fn set_cursor<'py>(
         &self,
         py: Python<'py>,
@@ -738,36 +357,15 @@ impl AsyncSession {
         column: u32,
     ) -> PyResult<Bound<'py, PyAny>> {
         let state = Arc::clone(&self.state);
-        let data = notebook_doc::presence::encode_cursor_update_labeled(
-            "local",
-            self.peer_label.as_deref(),
-            &notebook_doc::presence::CursorPosition {
-                cell_id: cell_id.to_string(),
-                line,
-                column,
-            },
-        );
+        let peer_label = self.peer_label.clone();
+        let cell_id = cell_id.to_string();
 
         future_into_py(py, async move {
-            let state_guard = state.lock().await;
-            let handle = state_guard
-                .handle
-                .as_ref()
-                .ok_or_else(|| to_py_err("Not connected"))?;
-            handle.send_presence(data).await.map_err(to_py_err)
+            session_core::set_cursor(&state, peer_label.as_deref(), &cell_id, line, column).await
         })
     }
 
-    /// Send a selection range as presence data to other connected peers.
-    ///
-    /// Args:
-    ///     cell_id: The cell the selection is in.
-    ///     anchor_line: Selection anchor line (0-based).
-    ///     anchor_col: Selection anchor column (0-based).
-    ///     head_line: Selection head line (0-based).
-    ///     head_col: Selection head column (0-based).
-    ///
-    /// Returns a coroutine.
+    /// Set selection range for collaborative presence.
     fn set_selection<'py>(
         &self,
         py: Python<'py>,
@@ -778,86 +376,47 @@ impl AsyncSession {
         head_col: u32,
     ) -> PyResult<Bound<'py, PyAny>> {
         let state = Arc::clone(&self.state);
-        let data = notebook_doc::presence::encode_selection_update_labeled(
-            "local",
-            self.peer_label.as_deref(),
-            &notebook_doc::presence::SelectionRange {
-                cell_id: cell_id.to_string(),
+        let peer_label = self.peer_label.clone();
+        let cell_id = cell_id.to_string();
+
+        future_into_py(py, async move {
+            session_core::set_selection(
+                &state,
+                peer_label.as_deref(),
+                &cell_id,
                 anchor_line,
                 anchor_col,
                 head_line,
                 head_col,
-            },
-        );
-
-        future_into_py(py, async move {
-            let state_guard = state.lock().await;
-            let handle = state_guard
-                .handle
-                .as_ref()
-                .ok_or_else(|| to_py_err("Not connected"))?;
-            handle.send_presence(data).await.map_err(to_py_err)
+            )
+            .await
         })
     }
 
-    /// Save the notebook to a .ipynb file.
-    ///
-    /// Reads cells and metadata from the synced Automerge document, resolves
-    /// output manifests from the blob store, and writes standard nbformat v4 JSON.
+    // =========================================================================
+    // Save / Metadata
+    // =========================================================================
+
+    /// Save the notebook to disk.
     ///
     /// Args:
-    ///     path: Optional target path for the notebook file. If it doesn't end
-    ///           with .ipynb, the extension will be appended. If None, saves to
-    ///           the notebook's original file path (the notebook_id).
+    ///     path: Optional path override. If not provided, saves to original path.
     ///
-    /// Returns:
-    ///     A coroutine that resolves to the absolute path where the file was written.
-    ///
-    /// Raises:
-    ///     RuntimedError: If not connected or write fails.
+    /// Returns a coroutine that resolves to the saved path (str).
     #[pyo3(signature = (path=None))]
     fn save<'py>(&self, py: Python<'py>, path: Option<&str>) -> PyResult<Bound<'py, PyAny>> {
         let state = Arc::clone(&self.state);
+        let notebook_id = self.notebook_id.clone();
         let path = path.map(|s| s.to_string());
 
         future_into_py(py, async move {
-            let state_guard = state.lock().await;
-            let handle = state_guard
-                .handle
-                .as_ref()
-                .ok_or_else(|| to_py_err("Not connected"))?;
-
-            let response = handle
-                .send_request(NotebookRequest::SaveNotebook {
-                    format_cells: false,
-                    path,
-                })
-                .await
-                .map_err(to_py_err)?;
-
-            match response {
-                NotebookResponse::NotebookSaved { path } => Ok(path),
-                NotebookResponse::Error { error } => Err(to_py_err(error)),
-                other => Err(to_py_err(format!("Unexpected response: {:?}", other))),
-            }
+            // Ensure connected
+            session_core::connect(&state, &notebook_id).await?;
+            session_core::save(&state, path.as_deref()).await
         })
     }
 
-    // =========================================================================
-    // Metadata Operations (synced via automerge doc)
-    // =========================================================================
-
-    /// Set a metadata value in the automerge document.
-    ///
-    /// The value is synced to the daemon and all connected clients.
-    /// Use the key "notebook_metadata" to set the NotebookMetadataSnapshot
-    /// (JSON-encoded kernelspec, language_info, and runt config).
-    ///
-    /// Args:
-    ///     key: The metadata key.
-    ///     value: The metadata value (typically JSON).
-    ///
-    /// Returns a coroutine.
+    /// Set a notebook metadata key.
     fn set_metadata<'py>(
         &self,
         py: Python<'py>,
@@ -865,55 +424,144 @@ impl AsyncSession {
         value: &str,
     ) -> PyResult<Bound<'py, PyAny>> {
         let state = Arc::clone(&self.state);
+        let notebook_id = self.notebook_id.clone();
         let key = key.to_string();
         let value = value.to_string();
 
         future_into_py(py, async move {
-            let state_guard = state.lock().await;
-            let handle = state_guard
-                .handle
-                .as_ref()
-                .ok_or_else(|| to_py_err("Not connected"))?;
-
-            handle.set_metadata(&key, &value).await.map_err(to_py_err)
+            session_core::connect(&state, &notebook_id).await?;
+            session_core::set_metadata(&state, &key, &value).await
         })
     }
 
-    /// Get a metadata value from the automerge document.
-    ///
-    /// Reads from the local replica of the automerge doc.
-    ///
-    /// Args:
-    ///     key: The metadata key.
-    ///
-    /// Returns a coroutine that resolves to the metadata value (str) or None.
+    /// Get a notebook metadata key.
     fn get_metadata<'py>(&self, py: Python<'py>, key: &str) -> PyResult<Bound<'py, PyAny>> {
         let state = Arc::clone(&self.state);
+        let notebook_id = self.notebook_id.clone();
         let key = key.to_string();
 
         future_into_py(py, async move {
-            let state_guard = state.lock().await;
-            let handle = state_guard
-                .handle
-                .as_ref()
-                .ok_or_else(|| to_py_err("Not connected"))?;
-
-            handle.get_metadata(&key).await.map_err(to_py_err)
+            session_core::connect(&state, &notebook_id).await?;
+            session_core::get_metadata(&state, &key).await
         })
     }
 
     // =========================================================================
-    // Dependency Management (convenience methods for notebook_metadata)
+    // Cell metadata
+    // =========================================================================
+
+    /// Get cell metadata as a JSON string.
+    fn get_cell_metadata<'py>(
+        &self,
+        py: Python<'py>,
+        cell_id: &str,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let state = Arc::clone(&self.state);
+        let cell_id = cell_id.to_string();
+        future_into_py(py, async move {
+            session_core::get_cell_metadata(&state, &cell_id).await
+        })
+    }
+
+    /// Set cell metadata from a JSON string. Returns True on success.
+    fn set_cell_metadata<'py>(
+        &self,
+        py: Python<'py>,
+        cell_id: &str,
+        metadata_json: &str,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let state = Arc::clone(&self.state);
+        let cell_id = cell_id.to_string();
+        let metadata_json = metadata_json.to_string();
+        future_into_py(py, async move {
+            session_core::set_cell_metadata(&state, &cell_id, &metadata_json).await
+        })
+    }
+
+    /// Update cell metadata at a specific path. Returns True on success.
+    fn update_cell_metadata_at<'py>(
+        &self,
+        py: Python<'py>,
+        cell_id: &str,
+        path: Vec<String>,
+        value_json: &str,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let state = Arc::clone(&self.state);
+        let cell_id = cell_id.to_string();
+        let value_json = value_json.to_string();
+        future_into_py(py, async move {
+            session_core::update_cell_metadata_at(&state, &cell_id, path, &value_json).await
+        })
+    }
+
+    /// Set whether a cell's source is hidden.
+    fn set_cell_source_hidden<'py>(
+        &self,
+        py: Python<'py>,
+        cell_id: &str,
+        hidden: bool,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let state = Arc::clone(&self.state);
+        let cell_id = cell_id.to_string();
+        let val = if hidden { "true" } else { "false" };
+        let val = val.to_string();
+        future_into_py(py, async move {
+            session_core::update_cell_metadata_at(
+                &state,
+                &cell_id,
+                vec!["jupyter".into(), "source_hidden".into()],
+                &val,
+            )
+            .await
+        })
+    }
+
+    /// Set whether a cell's outputs are hidden.
+    fn set_cell_outputs_hidden<'py>(
+        &self,
+        py: Python<'py>,
+        cell_id: &str,
+        hidden: bool,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let state = Arc::clone(&self.state);
+        let cell_id = cell_id.to_string();
+        let val = if hidden { "true" } else { "false" };
+        let val = val.to_string();
+        future_into_py(py, async move {
+            session_core::update_cell_metadata_at(
+                &state,
+                &cell_id,
+                vec!["jupyter".into(), "outputs_hidden".into()],
+                &val,
+            )
+            .await
+        })
+    }
+
+    /// Set cell tags.
+    fn set_cell_tags<'py>(
+        &self,
+        py: Python<'py>,
+        cell_id: &str,
+        tags: Vec<String>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let state = Arc::clone(&self.state);
+        let cell_id = cell_id.to_string();
+        let val = serde_json::to_string(&tags).map_err(|e| to_py_err(format!("JSON: {}", e)))?;
+        future_into_py(py, async move {
+            session_core::update_cell_metadata_at(&state, &cell_id, vec!["tags".into()], &val).await
+        })
+    }
+
+    // =========================================================================
+    // Dependencies (uv / conda)
     // =========================================================================
 
     /// Get current UV dependencies.
-    ///
-    /// Returns a coroutine that resolves to list of UV dependency specifiers.
     fn get_uv_dependencies<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let state = Arc::clone(&self.state);
-
         future_into_py(py, async move {
-            let snapshot = get_notebook_metadata_async(&state).await?;
+            let snapshot = session_core::get_notebook_metadata(&state).await?;
             Ok(snapshot
                 .runt
                 .uv
@@ -922,16 +570,7 @@ impl AsyncSession {
         })
     }
 
-    /// Add a UV dependency to the notebook.
-    ///
-    /// Deduplicates by package name (case-insensitive): if a dependency with the
-    /// same package name already exists, it is replaced with the new specifier.
-    ///
-    /// Args:
-    ///     package: PEP 508 dependency specifier (e.g., "pandas>=2.0", "requests").
-    ///
-    /// Returns a coroutine that resolves to None. Callers should use
-    /// `get_uv_dependencies()` to read current state.
+    /// Add a UV dependency (deduplicates by package name).
     fn add_uv_dependency<'py>(
         &self,
         py: Python<'py>,
@@ -939,21 +578,14 @@ impl AsyncSession {
     ) -> PyResult<Bound<'py, PyAny>> {
         let state = Arc::clone(&self.state);
         let package = package.to_string();
-
         future_into_py(py, async move {
-            let mut snapshot = get_notebook_metadata_async(&state).await?;
+            let mut snapshot = session_core::get_notebook_metadata(&state).await?;
             snapshot.add_uv_dependency(&package);
-            set_notebook_metadata_async(&state, &snapshot).await?;
-            Ok(())
+            session_core::set_notebook_metadata(&state, &snapshot).await
         })
     }
 
-    /// Remove a UV dependency by package name (case-insensitive, version-agnostic).
-    ///
-    /// Args:
-    ///     package: Package name to remove (e.g., "pandas"). Version specifiers are ignored.
-    ///
-    /// Returns a coroutine that resolves to bool indicating if a dependency was removed.
+    /// Remove a UV dependency by package name. Returns True if removed.
     fn remove_uv_dependency<'py>(
         &self,
         py: Python<'py>,
@@ -961,25 +593,21 @@ impl AsyncSession {
     ) -> PyResult<Bound<'py, PyAny>> {
         let state = Arc::clone(&self.state);
         let package = package.to_string();
-
         future_into_py(py, async move {
-            let mut snapshot = get_notebook_metadata_async(&state).await?;
+            let mut snapshot = session_core::get_notebook_metadata(&state).await?;
             let removed = snapshot.remove_uv_dependency(&package);
             if removed {
-                set_notebook_metadata_async(&state, &snapshot).await?;
+                session_core::set_notebook_metadata(&state, &snapshot).await?;
             }
             Ok(removed)
         })
     }
 
     /// Get current Conda dependencies.
-    ///
-    /// Returns a coroutine that resolves to list of Conda package names.
     fn get_conda_dependencies<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let state = Arc::clone(&self.state);
-
         future_into_py(py, async move {
-            let snapshot = get_notebook_metadata_async(&state).await?;
+            let snapshot = session_core::get_notebook_metadata(&state).await?;
             Ok(snapshot
                 .runt
                 .conda
@@ -988,16 +616,7 @@ impl AsyncSession {
         })
     }
 
-    /// Add a Conda dependency to the notebook.
-    ///
-    /// Deduplicates by package name (case-insensitive): if a dependency with the
-    /// same package name already exists, it is replaced with the new specifier.
-    ///
-    /// Args:
-    ///     package: Conda package specifier (e.g., "numpy", "scipy>=1.0").
-    ///
-    /// Returns a coroutine that resolves to None. Callers should use
-    /// `get_conda_dependencies()` to read current state.
+    /// Add a Conda dependency (deduplicates by package name).
     fn add_conda_dependency<'py>(
         &self,
         py: Python<'py>,
@@ -1005,21 +624,14 @@ impl AsyncSession {
     ) -> PyResult<Bound<'py, PyAny>> {
         let state = Arc::clone(&self.state);
         let package = package.to_string();
-
         future_into_py(py, async move {
-            let mut snapshot = get_notebook_metadata_async(&state).await?;
+            let mut snapshot = session_core::get_notebook_metadata(&state).await?;
             snapshot.add_conda_dependency(&package);
-            set_notebook_metadata_async(&state, &snapshot).await?;
-            Ok(())
+            session_core::set_notebook_metadata(&state, &snapshot).await
         })
     }
 
-    /// Remove a Conda dependency by package name (case-insensitive, version-agnostic).
-    ///
-    /// Args:
-    ///     package: Package name to remove (e.g., "numpy"). Version specifiers are ignored.
-    ///
-    /// Returns a coroutine that resolves to bool indicating if a dependency was removed.
+    /// Remove a Conda dependency by package name. Returns True if removed.
     fn remove_conda_dependency<'py>(
         &self,
         py: Python<'py>,
@@ -1027,38 +639,30 @@ impl AsyncSession {
     ) -> PyResult<Bound<'py, PyAny>> {
         let state = Arc::clone(&self.state);
         let package = package.to_string();
-
         future_into_py(py, async move {
-            let mut snapshot = get_notebook_metadata_async(&state).await?;
+            let mut snapshot = session_core::get_notebook_metadata(&state).await?;
             let removed = snapshot.remove_conda_dependency(&package);
             if removed {
-                set_notebook_metadata_async(&state, &snapshot).await?;
+                session_core::set_notebook_metadata(&state, &snapshot).await?;
             }
             Ok(removed)
         })
     }
 
     // =========================================================================
-    // Execution (document-first: reads source from automerge doc)
+    // Execution
     // =========================================================================
 
     /// Execute a cell by ID.
     ///
-    /// The daemon reads the cell's source from the automerge document and
-    /// executes it. This ensures all clients see the same code being executed.
-    ///
-    /// If a kernel isn't running yet, this will start one automatically.
-    /// If a kernel is already running in the daemon (e.g., started by another
-    /// client), it will reuse that kernel.
+    /// The entire lifecycle (confirm_sync, send_request, collect_outputs)
+    /// is wrapped in a single timeout.
     ///
     /// Args:
     ///     cell_id: The cell ID to execute.
-    ///     timeout_secs: Maximum time to wait for execution (default: 60).
+    ///     timeout_secs: Maximum time to wait (default: 60).
     ///
     /// Returns a coroutine that resolves to ExecutionResult.
-    ///
-    /// Raises:
-    ///     RuntimedError: If not connected, cell not found, or timeout.
     #[pyo3(signature = (cell_id, timeout_secs=60.0))]
     fn execute_cell<'py>(
         &self,
@@ -1071,181 +675,53 @@ impl AsyncSession {
         let cell_id = cell_id.to_string();
 
         future_into_py(py, async move {
-            // Auto-start kernel if not running
-            {
-                let state_guard = state.lock().await;
-                if !state_guard.kernel_started {
-                    drop(state_guard);
+            session_core::execute_cell(&state, &notebook_id, &cell_id, timeout_secs).await
+        })
+    }
 
-                    // Need to connect and start kernel
-                    let state_guard = state.lock().await;
-                    if state_guard.handle.is_none() {
-                        drop(state_guard);
+    /// Create a cell, execute it, and return the result.
+    ///
+    /// Args:
+    ///     code: The code to execute.
+    ///     timeout_secs: Maximum time to wait (default: 60).
+    ///
+    /// Returns a coroutine that resolves to ExecutionResult.
+    #[pyo3(signature = (code, timeout_secs=60.0))]
+    fn run<'py>(
+        &self,
+        py: Python<'py>,
+        code: &str,
+        timeout_secs: f64,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let state = Arc::clone(&self.state);
+        let notebook_id = self.notebook_id.clone();
+        let code = code.to_string();
 
-                        let socket_path = if let Ok(path) = std::env::var("RUNTIMED_SOCKET_PATH") {
-                            std::path::PathBuf::from(path)
-                        } else {
-                            runtimed::default_socket_path()
-                        };
+        future_into_py(py, async move {
+            session_core::run(&state, &notebook_id, &code, timeout_secs).await
+        })
+    }
 
-                        let (handle, sync_rx, broadcast_rx, _cells, _notebook_path) =
-                            NotebookSyncClient::connect_split(
-                                socket_path.clone(),
-                                notebook_id.clone(),
-                            )
-                            .await
-                            .map_err(to_py_err)?;
-
-                        let (blob_base_url, blob_store_path) = if let Some(parent) =
-                            socket_path.parent()
-                        {
-                            let daemon_json = parent.join("daemon.json");
-                            let base_url = if daemon_json.exists() {
-                                tokio::fs::read_to_string(&daemon_json)
-                                    .await
-                                    .ok()
-                                    .and_then(|contents| {
-                                        serde_json::from_str::<serde_json::Value>(&contents).ok()
-                                    })
-                                    .and_then(|info| info.get("blob_port").and_then(|p| p.as_u64()))
-                                    .map(|port| format!("http://127.0.0.1:{}", port))
-                            } else {
-                                None
-                            };
-
-                            let store_path = parent.join("blobs");
-                            let store_path = if store_path.exists() {
-                                Some(store_path)
-                            } else {
-                                None
-                            };
-
-                            (base_url, store_path)
-                        } else {
-                            (None, None)
-                        };
-
-                        let mut state_guard = state.lock().await;
-                        state_guard.handle = Some(handle);
-                        state_guard.sync_rx = Some(sync_rx);
-                        state_guard.broadcast_rx = Some(broadcast_rx);
-                        state_guard.blob_base_url = blob_base_url;
-                        state_guard.blob_store_path = blob_store_path;
-                    } else {
-                        // Already connected - drop the lock before starting kernel
-                        drop(state_guard);
-                    }
-
-                    // Start kernel
-                    let mut state_guard = state.lock().await;
-                    let handle = state_guard
-                        .handle
-                        .as_ref()
-                        .ok_or_else(|| to_py_err("Not connected"))?;
-
-                    let response = handle
-                        .send_request(NotebookRequest::LaunchKernel {
-                            kernel_type: "python".to_string(),
-                            env_source: "auto".to_string(),
-                            notebook_path: None,
-                        })
-                        .await
-                        .map_err(to_py_err)?;
-
-                    match response {
-                        NotebookResponse::KernelLaunched {
-                            env_source: actual_env,
-                            ..
-                        } => {
-                            state_guard.kernel_started = true;
-                            state_guard.env_source = Some(actual_env);
-                        }
-                        NotebookResponse::KernelAlreadyRunning {
-                            env_source: actual_env,
-                            ..
-                        } => {
-                            state_guard.kernel_started = true;
-                            state_guard.env_source = Some(actual_env);
-                        }
-                        NotebookResponse::Error { error } => return Err(to_py_err(error)),
-                        other => {
-                            return Err(to_py_err(format!("Unexpected response: {:?}", other)))
-                        }
-                    }
-                }
-            }
-
-            // Wrap the entire execution lifecycle in a single timeout.
-            // Previously only collect_outputs was bounded, which meant
-            // confirm_sync() or send_request() could hang indefinitely.
-            let timeout = std::time::Duration::from_secs_f64(timeout_secs);
-            let result = tokio::time::timeout(timeout, async {
-                let state_guard = state.lock().await;
-
-                let handle = state_guard
-                    .handle
-                    .as_ref()
-                    .ok_or_else(|| to_py_err("Not connected"))?;
-
-                let blob_base_url = state_guard.blob_base_url.clone();
-                let blob_store_path = state_guard.blob_store_path.clone();
-
-                // Confirm the daemon has merged our latest changes before executing.
-                // The daemon reads cell source from its own Automerge doc, so it must
-                // have the cell before we can reference it by ID.
-                handle.confirm_sync().await.map_err(to_py_err)?;
-
-                // Execute cell (daemon reads source from automerge doc)
-                let response = handle
-                    .send_request(NotebookRequest::ExecuteCell {
-                        cell_id: cell_id.clone(),
-                    })
-                    .await
-                    .map_err(to_py_err)?;
-
-                match response {
-                    NotebookResponse::CellQueued { .. } => {}
-                    NotebookResponse::Error { error } => return Err(to_py_err(error)),
-                    other => return Err(to_py_err(format!("Unexpected response: {:?}", other))),
-                }
-
-                drop(state_guard); // Release lock before waiting for broadcasts
-
-                collect_outputs_async(&state, &cell_id, blob_base_url, blob_store_path).await
-            })
-            .await;
-
-            match result {
-                Ok(Ok(exec_result)) => Ok(exec_result),
-                Ok(Err(e)) => Err(e),
-                Err(_) => Err(to_py_err(format!(
-                    "Execution timed out after {} seconds",
-                    timeout_secs
-                ))),
-            }
+    /// Queue a cell for execution without waiting for the result.
+    fn queue_cell<'py>(&self, py: Python<'py>, cell_id: &str) -> PyResult<Bound<'py, PyAny>> {
+        let state = Arc::clone(&self.state);
+        let cell_id = cell_id.to_string();
+        future_into_py(py, async move {
+            session_core::queue_cell(&state, &cell_id).await
         })
     }
 
     /// Stream execution events for a cell as an async iterator.
     ///
-    /// Unlike execute_cell() which blocks until completion and returns all
-    /// outputs at once, this returns an async iterator that yields ExecutionEvent
-    /// objects as they arrive from the kernel, enabling real-time processing.
-    ///
-    /// Example:
-    ///     ```python
-    ///     async for event in await session.stream_execute(cell_id):
-    ///         if event.event_type == "output":
-    ///             print(event.output.text)  # Process output immediately
-    ///     ```
+    /// Unlike execute_cell() which blocks until completion, this returns
+    /// an async iterator that yields ExecutionEvent objects as they arrive.
     ///
     /// Args:
     ///     cell_id: The cell ID to execute.
-    ///     timeout_secs: Maximum time to wait for each event (default: 60).
-    ///     signal_only: If True, output events contain only output_index, not
-    ///         the full output data. Use get_cell() to fetch the data.
+    ///     timeout_secs: Maximum time per event (default: 60).
+    ///     signal_only: If True, output events contain only index, not data.
     ///
-    /// Returns a coroutine that resolves to ExecutionEventStream (async iterator).
+    /// Returns a coroutine that resolves to ExecutionEventStream.
     #[pyo3(signature = (cell_id, timeout_secs=60.0, signal_only=false))]
     fn stream_execute<'py>(
         &self,
@@ -1259,121 +735,25 @@ impl AsyncSession {
         let cell_id = cell_id.to_string();
 
         future_into_py(py, async move {
-            // Auto-start kernel if not running
+            // Auto-start kernel if needed
             {
-                let state_guard = state.lock().await;
-                if !state_guard.kernel_started {
-                    drop(state_guard);
-
-                    let state_guard = state.lock().await;
-                    if state_guard.handle.is_none() {
-                        drop(state_guard);
-
-                        let socket_path = if let Ok(path) = std::env::var("RUNTIMED_SOCKET_PATH") {
-                            std::path::PathBuf::from(path)
-                        } else {
-                            runtimed::default_socket_path()
-                        };
-
-                        let (handle, sync_rx, broadcast_rx, _cells, _notebook_path) =
-                            NotebookSyncClient::connect_split(
-                                socket_path.clone(),
-                                notebook_id.clone(),
-                            )
-                            .await
-                            .map_err(to_py_err)?;
-
-                        let (blob_base_url, blob_store_path) = if let Some(parent) =
-                            socket_path.parent()
-                        {
-                            let daemon_json = parent.join("daemon.json");
-                            let base_url = if daemon_json.exists() {
-                                tokio::fs::read_to_string(&daemon_json)
-                                    .await
-                                    .ok()
-                                    .and_then(|contents| {
-                                        serde_json::from_str::<serde_json::Value>(&contents).ok()
-                                    })
-                                    .and_then(|info| info.get("blob_port").and_then(|p| p.as_u64()))
-                                    .map(|port| format!("http://127.0.0.1:{}", port))
-                            } else {
-                                None
-                            };
-
-                            let store_path = parent.join("blobs");
-                            let store_path = if store_path.exists() {
-                                Some(store_path)
-                            } else {
-                                None
-                            };
-
-                            (base_url, store_path)
-                        } else {
-                            (None, None)
-                        };
-
-                        let mut state_guard = state.lock().await;
-                        state_guard.handle = Some(handle);
-                        state_guard.sync_rx = Some(sync_rx);
-                        state_guard.broadcast_rx = Some(broadcast_rx);
-                        state_guard.blob_base_url = blob_base_url;
-                        state_guard.blob_store_path = blob_store_path;
-                    } else {
-                        // Already connected - drop the lock before starting kernel
-                        drop(state_guard);
-                    }
-
-                    // Start kernel
-                    let mut state_guard = state.lock().await;
-                    let handle = state_guard
-                        .handle
-                        .as_ref()
-                        .ok_or_else(|| to_py_err("Not connected"))?;
-
-                    let response = handle
-                        .send_request(NotebookRequest::LaunchKernel {
-                            kernel_type: "python".to_string(),
-                            env_source: "auto".to_string(),
-                            notebook_path: None,
-                        })
-                        .await
-                        .map_err(to_py_err)?;
-
-                    match response {
-                        NotebookResponse::KernelLaunched {
-                            env_source: actual_env,
-                            ..
-                        } => {
-                            state_guard.kernel_started = true;
-                            state_guard.env_source = Some(actual_env);
-                        }
-                        NotebookResponse::KernelAlreadyRunning {
-                            env_source: actual_env,
-                            ..
-                        } => {
-                            state_guard.kernel_started = true;
-                            state_guard.env_source = Some(actual_env);
-                        }
-                        NotebookResponse::Error { error } => return Err(to_py_err(error)),
-                        other => {
-                            return Err(to_py_err(format!("Unexpected response: {:?}", other)))
-                        }
-                    }
+                let st = state.lock().await;
+                if !st.kernel_started {
+                    drop(st);
+                    session_core::connect(&state, &notebook_id).await?;
+                    session_core::start_kernel(&state, "python", "auto", None).await?;
                 }
             }
 
-            // Queue execution and get broadcast receiver for streaming
-            let state_guard = state.lock().await;
+            let st = state.lock().await;
 
-            let handle = state_guard
+            let handle = st
                 .handle
                 .as_ref()
                 .ok_or_else(|| to_py_err("Not connected"))?;
 
-            // Confirm the daemon has merged our latest changes before executing.
             handle.confirm_sync().await.map_err(to_py_err)?;
 
-            // Queue the cell for execution
             let response = handle
                 .send_request(NotebookRequest::ExecuteCell {
                     cell_id: cell_id.clone(),
@@ -1387,19 +767,18 @@ impl AsyncSession {
                 other => return Err(to_py_err(format!("Unexpected response: {:?}", other))),
             }
 
-            // Get a resubscribed broadcast receiver for this stream
-            let stream_broadcast_rx = state_guard
+            // Resubscribe for this stream — needs direct state access
+            let stream_broadcast_rx = st
                 .broadcast_rx
                 .as_ref()
                 .ok_or_else(|| to_py_err("No broadcast receiver"))?
                 .resubscribe();
 
-            let blob_base_url = state_guard.blob_base_url.clone();
-            let blob_store_path = state_guard.blob_store_path.clone();
+            let blob_base_url = st.blob_base_url.clone();
+            let blob_store_path = st.blob_store_path.clone();
 
-            drop(state_guard);
+            drop(st);
 
-            // Return the async iterator
             Ok(ExecutionEventStream::new(
                 stream_broadcast_rx,
                 cell_id,
@@ -1411,40 +790,25 @@ impl AsyncSession {
         })
     }
 
-    /// Subscribe to notebook broadcast events independently of execution.
+    /// Subscribe to execution events for specific cells or event types.
     ///
-    /// Returns an async iterator that yields all broadcast events from the
-    /// notebook, optionally filtered by cell IDs and event types. This
-    /// enables reactive patterns for agents that want to respond to any
-    /// document activity (including executions from other clients).
-    ///
-    /// Example:
-    ///     ```python
-    ///     # Subscribe to all events
-    ///     async for event in session.subscribe():
-    ///         print(f"Got: {event.event_type}")
-    ///
-    ///     # Subscribe with filters
-    ///     async for event in session.subscribe(event_types=["output", "done"]):
-    ///         if event.event_type == "output":
-    ///             print(event.output.text)
-    ///     ```
+    /// Returns an async iterator subscription that yields events as they arrive.
     ///
     /// Args:
-    ///     cell_ids: Optional list of cell IDs to filter events.
-    ///     event_types: Optional list of event types to filter. Valid types:
-    ///         "execution_started", "output", "done", "error", "kernel_status".
-    ///
-    /// Returns an EventSubscription async iterator.
+    ///     cell_ids: Optional list of cell IDs to filter (None = all cells).
+    ///     event_types: Optional list of event types to filter (None = all types).
     #[pyo3(signature = (cell_ids=None, event_types=None))]
     fn subscribe(
         &self,
         cell_ids: Option<Vec<String>>,
         event_types: Option<Vec<String>>,
     ) -> PyResult<EventSubscription> {
-        // Use a temporary runtime to access the state synchronously
-        let runtime = tokio::runtime::Runtime::new().map_err(to_py_err)?;
-        let state = runtime.block_on(self.state.lock());
+        // Needs direct state access for resubscribe — use a temporary block_on
+        // since this returns a sync object (the subscription) not a coroutine.
+        let rt = tokio::runtime::Handle::try_current()
+            .map_err(|_| to_py_err("No tokio runtime available"))?;
+
+        let state = rt.block_on(self.state.lock());
 
         let broadcast_rx = state
             .broadcast_rx
@@ -1466,351 +830,39 @@ impl AsyncSession {
         ))
     }
 
-    /// Convenience method: create a cell, execute it, and return the result.
-    ///
-    /// This is a shortcut that combines create_cell() and execute_cell().
-    /// The cell is written to the automerge document before execution,
-    /// so other connected clients will see it.
-    ///
-    /// Args:
-    ///     code: The code to execute.
-    ///     timeout_secs: Maximum time to wait for execution (default: 60).
-    ///
-    /// Returns a coroutine that resolves to ExecutionResult.
-    ///
-    /// Raises:
-    ///     RuntimedError: If not connected, kernel not started, or timeout.
-    #[pyo3(signature = (code, timeout_secs=60.0))]
-    fn run<'py>(
-        &self,
-        py: Python<'py>,
-        code: &str,
-        timeout_secs: f64,
-    ) -> PyResult<Bound<'py, PyAny>> {
-        let state = Arc::clone(&self.state);
-        let code = code.to_string();
+    // =========================================================================
+    // Environment sync
+    // =========================================================================
 
-        future_into_py(py, async move {
-            // Create cell in document first
-            let cell_id = {
-                let state_guard = state.lock().await;
-                let handle = state_guard
-                    .handle
-                    .as_ref()
-                    .ok_or_else(|| to_py_err("Not connected"))?;
-
-                let cell_id = format!("cell-{}", uuid::Uuid::new_v4());
-
-                // Get current cell count for append position
-                let cells = handle.get_cells();
-                let insert_index = cells.len();
-
-                // Add cell to document
-                handle
-                    .add_cell(insert_index, &cell_id, "code")
-                    .await
-                    .map_err(to_py_err)?;
-
-                // Set source
-                handle
-                    .update_source(&cell_id, &code)
-                    .await
-                    .map_err(to_py_err)?;
-
-                cell_id
-            };
-
-            // Queue execution
-            {
-                let state_guard = state.lock().await;
-                let handle = state_guard
-                    .handle
-                    .as_ref()
-                    .ok_or_else(|| to_py_err("Not connected"))?;
-
-                // Confirm the daemon has merged our latest changes before executing.
-                handle.confirm_sync().await.map_err(to_py_err)?;
-
-                let response = handle
-                    .send_request(NotebookRequest::ExecuteCell {
-                        cell_id: cell_id.clone(),
-                    })
-                    .await
-                    .map_err(to_py_err)?;
-
-                match response {
-                    NotebookResponse::CellQueued { .. } => {}
-                    NotebookResponse::Error { error } => return Err(to_py_err(error)),
-                    other => return Err(to_py_err(format!("Unexpected response: {:?}", other))),
-                }
-            }
-
-            // Get blob resolution config
-            let (blob_base_url, blob_store_path) = {
-                let state_guard = state.lock().await;
-                (
-                    state_guard.blob_base_url.clone(),
-                    state_guard.blob_store_path.clone(),
-                )
-            };
-
-            // Collect outputs with timeout
-            let timeout = std::time::Duration::from_secs_f64(timeout_secs);
-            let result = tokio::time::timeout(
-                timeout,
-                collect_outputs_async(&state, &cell_id, blob_base_url, blob_store_path),
-            )
-            .await;
-
-            match result {
-                Ok(Ok(exec_result)) => Ok(exec_result),
-                Ok(Err(e)) => Err(e),
-                Err(_) => Err(to_py_err(format!(
-                    "Execution timed out after {} seconds",
-                    timeout_secs
-                ))),
-            }
-        })
-    }
-
-    /// Queue a cell for execution without waiting for the result.
-    ///
-    /// The daemon reads the cell's source from the automerge document and
-    /// queues it for execution. Use get_cell() to poll for results.
-    ///
-    /// Args:
-    ///     cell_id: The cell ID to execute.
-    ///
-    /// Returns a coroutine.
-    ///
-    /// Raises:
-    ///     RuntimedError: If not connected or cell not found.
-    fn queue_cell<'py>(&self, py: Python<'py>, cell_id: &str) -> PyResult<Bound<'py, PyAny>> {
-        let state = Arc::clone(&self.state);
-        let cell_id = cell_id.to_string();
-
-        future_into_py(py, async move {
-            let state_guard = state.lock().await;
-
-            let handle = state_guard
-                .handle
-                .as_ref()
-                .ok_or_else(|| to_py_err("Not connected"))?;
-
-            // Confirm the daemon has merged our latest changes before executing.
-            handle.confirm_sync().await.map_err(to_py_err)?;
-
-            // Queue cell execution (daemon reads source from automerge doc)
-            let response = handle
-                .send_request(NotebookRequest::ExecuteCell { cell_id })
-                .await
-                .map_err(to_py_err)?;
-
-            match response {
-                NotebookResponse::CellQueued { .. } => Ok(()),
-                NotebookResponse::Error { error } => Err(to_py_err(error)),
-                other => Err(to_py_err(format!("Unexpected response: {:?}", other))),
-            }
-        })
-    }
-
-    /// Interrupt the currently executing cell.
-    ///
-    /// Returns a coroutine.
-    fn interrupt<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
-        let state = Arc::clone(&self.state);
-
-        future_into_py(py, async move {
-            let state_guard = state.lock().await;
-
-            let handle = state_guard
-                .handle
-                .as_ref()
-                .ok_or_else(|| to_py_err("Not connected"))?;
-
-            let response = handle
-                .send_request(NotebookRequest::InterruptExecution {})
-                .await
-                .map_err(to_py_err)?;
-
-            match response {
-                NotebookResponse::InterruptSent {} => Ok(()),
-                NotebookResponse::NoKernel {} => Err(to_py_err("No kernel running")),
-                NotebookResponse::Error { error } => Err(to_py_err(error)),
-                other => Err(to_py_err(format!("Unexpected response: {:?}", other))),
-            }
-        })
-    }
-
-    /// Shutdown the kernel.
-    ///
-    /// Returns a coroutine.
-    fn shutdown_kernel<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
-        let state = Arc::clone(&self.state);
-
-        future_into_py(py, async move {
-            let mut state_guard = state.lock().await;
-
-            let handle = state_guard
-                .handle
-                .as_ref()
-                .ok_or_else(|| to_py_err("Not connected"))?;
-
-            let response = handle
-                .send_request(NotebookRequest::ShutdownKernel {})
-                .await
-                .map_err(to_py_err)?;
-
-            match response {
-                NotebookResponse::KernelShuttingDown {} => {
-                    state_guard.kernel_started = false;
-                    state_guard.env_source = None;
-                    Ok(())
-                }
-                NotebookResponse::NoKernel {} => {
-                    state_guard.kernel_started = false;
-                    state_guard.env_source = None;
-                    Ok(())
-                }
-                NotebookResponse::Error { error } => Err(to_py_err(error)),
-                other => Err(to_py_err(format!("Unexpected response: {:?}", other))),
-            }
-        })
-    }
-
-    /// Restart the kernel.
-    ///
-    /// Shuts down the current kernel and starts a new one. This is useful after
-    /// modifying dependencies to apply the changes.
-    ///
-    /// The new kernel will use env_source="auto" to pick up any inline
-    /// dependencies from the notebook metadata.
-    ///
-    /// Args:
-    ///     wait_for_ready: If True (default), wait for kernel to be idle.
-    ///
-    /// Note: This currently does shutdown + start. A daemon-side RestartKernel
-    /// command would be cleaner but doesn't exist yet.
-    ///
-    /// Returns a coroutine.
-    #[pyo3(signature = (wait_for_ready=true))]
-    fn restart_kernel<'py>(
-        &self,
-        py: Python<'py>,
-        wait_for_ready: bool,
-    ) -> PyResult<Bound<'py, PyAny>> {
-        let state = Arc::clone(&self.state);
-
-        future_into_py(py, async move {
-            // TODO: Consider adding NotebookRequest::RestartKernel to the daemon
-            // Shutdown existing kernel
-            {
-                let mut state_guard = state.lock().await;
-                let handle = state_guard
-                    .handle
-                    .as_ref()
-                    .ok_or_else(|| to_py_err("Not connected"))?;
-
-                let response = handle
-                    .send_request(NotebookRequest::ShutdownKernel {})
-                    .await
-                    .map_err(to_py_err)?;
-
-                match response {
-                    NotebookResponse::KernelShuttingDown {} | NotebookResponse::NoKernel {} => {
-                        state_guard.kernel_started = false;
-                        state_guard.env_source = None;
-                    }
-                    NotebookResponse::Error { error } => return Err(to_py_err(error)),
-                    _ => {}
-                }
-            }
-
-            // Start new kernel with auto env detection
-            {
-                let mut state_guard = state.lock().await;
-                let handle = state_guard
-                    .handle
-                    .as_ref()
-                    .ok_or_else(|| to_py_err("Not connected"))?;
-
-                let response = handle
-                    .send_request(NotebookRequest::LaunchKernel {
-                        kernel_type: "python".to_string(),
-                        env_source: "auto".to_string(),
-                        notebook_path: None,
-                    })
-                    .await
-                    .map_err(to_py_err)?;
-
-                match response {
-                    NotebookResponse::KernelLaunched { env_source, .. }
-                    | NotebookResponse::KernelAlreadyRunning { env_source, .. } => {
-                        state_guard.kernel_started = true;
-                        state_guard.env_source = Some(env_source);
-                    }
-                    NotebookResponse::Error { error } => return Err(to_py_err(error)),
-                    other => return Err(to_py_err(format!("Unexpected response: {:?}", other))),
-                }
-            }
-
-            // Wait for kernel ready if requested
-            if wait_for_ready {
-                let mut state_guard = state.lock().await;
-                if let Some(rx) = state_guard.broadcast_rx.as_mut() {
-                    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
-                    while std::time::Instant::now() < deadline {
-                        match tokio::time::timeout(std::time::Duration::from_millis(100), rx.recv())
-                            .await
-                        {
-                            Ok(Some(NotebookBroadcast::KernelStatus { status, .. }))
-                                if status == "idle" =>
-                            {
-                                return Ok(());
-                            }
-                            Ok(Some(_)) => continue,
-                            Ok(None) => return Err(to_py_err("Broadcast channel closed")),
-                            Err(_) => continue,
-                        }
-                    }
-                }
-            }
-
-            Ok(())
-        })
-    }
-
-    /// Sync environment with current metadata (hot-install new packages).
-    ///
-    /// This attempts to install new packages without restarting the kernel.
-    /// Only supported for UV inline dependencies with additions only.
-    ///
-    /// For removals, conda dependencies, or other cases, this will return
-    /// an error with needs_restart=True indicating a kernel restart is required.
+    /// Sync environment with current notebook metadata.
     ///
     /// Returns a coroutine that resolves to SyncEnvironmentResult.
     fn sync_environment<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        // sync_environment is complex — waits for follow-up broadcasts.
+        // Kept inline rather than in session_core due to broadcast polling.
         let state = Arc::clone(&self.state);
 
         future_into_py(py, async move {
-            let response = {
-                let state_guard = state.lock().await;
-                let handle = state_guard
-                    .handle
-                    .as_ref()
-                    .ok_or_else(|| to_py_err("Not connected"))?;
+            let st = state.lock().await;
 
-                handle
-                    .send_request(NotebookRequest::SyncEnvironment {})
-                    .await
-                    .map_err(to_py_err)?
-            };
+            let handle = st
+                .handle
+                .as_ref()
+                .ok_or_else(|| to_py_err("Not connected"))?;
+
+            let response = handle
+                .send_request(NotebookRequest::SyncEnvironment {})
+                .await
+                .map_err(to_py_err)?;
+
+            drop(st);
 
             match response {
                 NotebookResponse::SyncEnvironmentStarted { packages } => {
-                    // Wait for completion
-                    let mut state_guard = state.lock().await;
-                    if let Some(rx) = state_guard.broadcast_rx.as_mut() {
+                    // Wait for completion via broadcast
+                    let mut st = state.lock().await;
+                    let broadcast_rx = st.broadcast_rx.as_mut();
+                    if let Some(rx) = broadcast_rx {
                         let deadline =
                             std::time::Instant::now() + std::time::Duration::from_secs(300);
                         while std::time::Instant::now() < deadline {
@@ -1833,7 +885,6 @@ impl AsyncSession {
                             }
                         }
                     }
-                    // Assume success if we got SyncEnvironmentStarted
                     Ok(SyncEnvironmentResult {
                         success: true,
                         synced_packages: packages,
@@ -1876,21 +927,10 @@ impl AsyncSession {
     }
 
     // =========================================================================
-    // Kernel Introspection (completion, history, queue state)
+    // Completion, history, queue
     // =========================================================================
 
-    /// Get code completions at a cursor position.
-    ///
-    /// The kernel provides completions based on the current code context,
-    /// including DataFrame columns, object methods, variable names, etc.
-    ///
-    /// Args:
-    ///     code: The code to complete.
-    ///     cursor_pos: Cursor position in the code (byte offset).
-    ///
-    /// Returns a coroutine that resolves to CompletionResult with items,
-    /// cursor_start, and cursor_end.
-    #[pyo3(signature = (code, cursor_pos))]
+    /// Get code completions at the given cursor position.
     fn complete<'py>(
         &self,
         py: Python<'py>,
@@ -1898,175 +938,12 @@ impl AsyncSession {
         cursor_pos: usize,
     ) -> PyResult<Bound<'py, PyAny>> {
         let state = Arc::clone(&self.state);
-
         future_into_py(py, async move {
-            let state_guard = state.lock().await;
-
-            let handle = state_guard
-                .handle
-                .as_ref()
-                .ok_or_else(|| to_py_err("Not connected"))?;
-
-            let response = handle
-                .send_request(NotebookRequest::Complete { code, cursor_pos })
-                .await
-                .map_err(to_py_err)?;
-
-            match response {
-                NotebookResponse::CompletionResult {
-                    items,
-                    cursor_start,
-                    cursor_end,
-                } => Ok(crate::output::CompletionResult {
-                    items: items
-                        .into_iter()
-                        .map(crate::output::CompletionItem::from_protocol)
-                        .collect(),
-                    cursor_start,
-                    cursor_end,
-                }),
-                NotebookResponse::NoKernel {} => Err(to_py_err("No kernel running")),
-                NotebookResponse::Error { error } => Err(to_py_err(error)),
-                other => Err(to_py_err(format!("Unexpected response: {:?}", other))),
-            }
+            session_core::complete(&state, &code, cursor_pos).await
         })
     }
 
-    /// Get the current execution queue state.
-    ///
-    /// Returns a coroutine that resolves to QueueState with executing
-    /// (cell_id or None) and queued (list of cell_ids).
-    fn get_queue_state<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
-        let state = Arc::clone(&self.state);
-
-        future_into_py(py, async move {
-            let state_guard = state.lock().await;
-
-            let handle = state_guard
-                .handle
-                .as_ref()
-                .ok_or_else(|| to_py_err("Not connected"))?;
-
-            let response = handle
-                .send_request(NotebookRequest::GetQueueState {})
-                .await
-                .map_err(to_py_err)?;
-
-            match response {
-                NotebookResponse::QueueState { executing, queued } => {
-                    Ok(crate::output::QueueState { executing, queued })
-                }
-                NotebookResponse::Error { error } => Err(to_py_err(error)),
-                other => Err(to_py_err(format!("Unexpected response: {:?}", other))),
-            }
-        })
-    }
-
-    /// Clear outputs for a cell.
-    ///
-    /// Removes all outputs and resets the execution count. Useful before
-    /// re-executing a cell for a fresh run.
-    ///
-    /// Args:
-    ///     cell_id: The cell ID to clear outputs for.
-    ///
-    /// Returns a coroutine.
-    fn clear_outputs<'py>(&self, py: Python<'py>, cell_id: String) -> PyResult<Bound<'py, PyAny>> {
-        let state = Arc::clone(&self.state);
-
-        future_into_py(py, async move {
-            let state_guard = state.lock().await;
-
-            let handle = state_guard
-                .handle
-                .as_ref()
-                .ok_or_else(|| to_py_err("Not connected"))?;
-
-            let response = handle
-                .send_request(NotebookRequest::ClearOutputs { cell_id })
-                .await
-                .map_err(to_py_err)?;
-
-            match response {
-                NotebookResponse::OutputsCleared { .. } => Ok(()),
-                NotebookResponse::Error { error } => Err(to_py_err(error)),
-                other => Err(to_py_err(format!("Unexpected response: {:?}", other))),
-            }
-        })
-    }
-
-    /// Run all code cells in the notebook.
-    ///
-    /// Queues all code cells (in document order) for execution. The daemon
-    /// reads cell sources from the automerge document and executes them
-    /// sequentially.
-    ///
-    /// Returns a coroutine that resolves to the number of cells queued.
-    fn run_all_cells<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
-        let state = Arc::clone(&self.state);
-
-        future_into_py(py, async move {
-            // Check if kernel needs to be started
-            let needs_kernel = {
-                let state_guard = state.lock().await;
-                !state_guard.kernel_started
-            };
-
-            if needs_kernel {
-                // Start kernel (simplified - in practice you'd want to call the full start_kernel logic)
-                let mut state_guard = state.lock().await;
-                if let Some(handle) = state_guard.handle.as_ref() {
-                    let response = handle
-                        .send_request(NotebookRequest::LaunchKernel {
-                            kernel_type: "python".to_string(),
-                            env_source: "auto".to_string(),
-                            notebook_path: None,
-                        })
-                        .await
-                        .map_err(to_py_err)?;
-
-                    match response {
-                        NotebookResponse::KernelLaunched { env_source, .. }
-                        | NotebookResponse::KernelAlreadyRunning { env_source, .. } => {
-                            state_guard.kernel_started = true;
-                            state_guard.env_source = Some(env_source);
-                        }
-                        NotebookResponse::Error { error } => return Err(to_py_err(error)),
-                        _ => {}
-                    }
-                }
-            }
-
-            let state_guard = state.lock().await;
-            let handle = state_guard
-                .handle
-                .as_ref()
-                .ok_or_else(|| to_py_err("Not connected"))?;
-
-            let response = handle
-                .send_request(NotebookRequest::RunAllCells {})
-                .await
-                .map_err(to_py_err)?;
-
-            match response {
-                NotebookResponse::AllCellsQueued { count } => Ok(count),
-                NotebookResponse::Error { error } => Err(to_py_err(error)),
-                other => Err(to_py_err(format!("Unexpected response: {:?}", other))),
-            }
-        })
-    }
-
-    /// Search the kernel's input history.
-    ///
-    /// Returns executed code from the kernel's history, optionally filtered
-    /// by a glob pattern.
-    ///
-    /// Args:
-    ///     pattern: Optional glob pattern to filter history (e.g., "*pandas*").
-    ///     n: Maximum number of entries to return (default: 100).
-    ///     unique: If True, deduplicate entries (default: True).
-    ///
-    /// Returns a coroutine that resolves to a list of HistoryEntry objects.
+    /// Get execution history from the kernel.
     #[pyo3(signature = (pattern=None, n=100, unique=true))]
     fn get_history<'py>(
         &self,
@@ -2076,42 +953,34 @@ impl AsyncSession {
         unique: bool,
     ) -> PyResult<Bound<'py, PyAny>> {
         let state = Arc::clone(&self.state);
-
         future_into_py(py, async move {
-            let state_guard = state.lock().await;
-
-            let handle = state_guard
-                .handle
-                .as_ref()
-                .ok_or_else(|| to_py_err("Not connected"))?;
-
-            let response = handle
-                .send_request(NotebookRequest::GetHistory { pattern, n, unique })
-                .await
-                .map_err(to_py_err)?;
-
-            match response {
-                NotebookResponse::HistoryResult { entries } => Ok(entries
-                    .into_iter()
-                    .map(crate::output::HistoryEntry::from_protocol)
-                    .collect::<Vec<_>>()),
-                NotebookResponse::NoKernel {} => Err(to_py_err("No kernel running")),
-                NotebookResponse::Error { error } => Err(to_py_err(error)),
-                other => Err(to_py_err(format!("Unexpected response: {:?}", other))),
-            }
+            session_core::get_history(&state, pattern.as_deref(), n, unique).await
         })
     }
 
-    /// Close the session and shutdown the kernel if running.
-    ///
-    /// Close the session.
-    ///
-    /// Does NOT shutdown the kernel - the daemon handles kernel lifecycle
-    /// based on peer count. When all peers disconnect, the daemon will
-    /// clean up the kernel. Use shutdown_kernel() explicitly if you need
-    /// to stop the kernel.
-    ///
-    /// Returns a coroutine.
+    /// Get the current execution queue state.
+    fn get_queue_state<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let state = Arc::clone(&self.state);
+        future_into_py(
+            py,
+            async move { session_core::get_queue_state(&state).await },
+        )
+    }
+
+    /// Execute all code cells in document order. Returns number of cells queued.
+    fn run_all_cells<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let state = Arc::clone(&self.state);
+        let notebook_id = self.notebook_id.clone();
+        future_into_py(py, async move {
+            session_core::run_all_cells(&state, &notebook_id).await
+        })
+    }
+
+    // =========================================================================
+    // Repr, context manager, close
+    // =========================================================================
+
+    /// Close the session (no-op — daemon manages lifecycle).
     fn close<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         future_into_py(py, async move { Ok(()) })
     }
@@ -2120,20 +989,10 @@ impl AsyncSession {
         format!("AsyncSession(id={})", self.notebook_id)
     }
 
-    /// Async context manager entry.
-    ///
-    /// Returns a coroutine that resolves to self.
-    fn __aenter__(slf: Py<Self>, py: Python<'_>) -> PyResult<Bound<'_, PyAny>> {
-        // Return a coroutine that immediately resolves to self
-        future_into_py(py, async move { Ok(slf) })
+    fn __aenter__<'py>(slf: Bound<'py, Self>) -> PyResult<Bound<'py, Self>> {
+        Ok(slf)
     }
 
-    /// Async context manager exit.
-    ///
-    /// Does NOT shutdown the kernel - the daemon handles kernel lifecycle
-    /// based on peer count. When all peers disconnect, the daemon will
-    /// clean up the kernel. This prevents killing kernels that desktop
-    /// app users may still be using.
     #[pyo3(signature = (_exc_type=None, _exc_val=None, _exc_tb=None))]
     fn __aexit__<'py>(
         &self,
@@ -2142,155 +1001,14 @@ impl AsyncSession {
         _exc_val: Option<&Bound<'_, PyAny>>,
         _exc_tb: Option<&Bound<'_, PyAny>>,
     ) -> PyResult<Bound<'py, PyAny>> {
-        future_into_py(py, async move { Ok(false) }) // Don't suppress exceptions
-    }
-}
-
-// =========================================================================
-// Helper functions (outside impl block for async use)
-// =========================================================================
-
-/// Wait for execution to complete, then read outputs from the Automerge doc.
-///
-/// Uses the broadcast stream only as a signal for when execution is done.
-/// The Automerge document is the source of truth for cell outputs — this
-/// sidesteps the Jupyter shell/iopub race condition entirely since the
-/// daemon writes all outputs to the doc before signaling ExecutionDone.
-async fn collect_outputs_async(
-    state: &Arc<Mutex<AsyncSessionState>>,
-    cell_id: &str,
-    blob_base_url: Option<String>,
-    blob_store_path: Option<PathBuf>,
-) -> PyResult<ExecutionResult> {
-    let mut kernel_error: Option<String> = None;
-
-    // Phase 1: Wait for ExecutionDone or KernelError signal via broadcast.
-    // We don't accumulate outputs here — the Automerge doc is the source of truth.
-    loop {
-        let mut state_guard = state.lock().await;
-
-        let broadcast_rx = state_guard
-            .broadcast_rx
-            .as_mut()
-            .ok_or_else(|| to_py_err("Not connected"))?;
-
-        let broadcast =
-            tokio::time::timeout(std::time::Duration::from_millis(100), broadcast_rx.recv()).await;
-
-        match broadcast {
-            Ok(Some(msg)) => {
-                drop(state_guard);
-
-                match msg {
-                    NotebookBroadcast::ExecutionDone {
-                        cell_id: msg_cell_id,
-                    } => {
-                        if msg_cell_id == cell_id {
-                            log::debug!("[async_session] ExecutionDone received for {}", cell_id);
-                            break;
-                        }
-                    }
-                    NotebookBroadcast::KernelError { error } => {
-                        log::debug!("[async_session] KernelError: {}", error);
-                        kernel_error = Some(error);
-                        break;
-                    }
-                    _ => {
-                        // Ignore all other broadcasts — doc has the data
-                    }
-                }
+        let state = Arc::clone(&self.state);
+        future_into_py(py, async move {
+            let st = state.lock().await;
+            if st.kernel_started {
+                drop(st);
+                let _ = session_core::shutdown_kernel(&state).await;
             }
-            Ok(None) => {
-                return Err(to_py_err("Broadcast channel closed"));
-            }
-            Err(_) => {
-                // Poll timeout — keep waiting for signal
-            }
-        }
+            Ok(false) // Don't suppress exceptions
+        })
     }
-
-    // KernelError means the kernel/daemon died — return immediately
-    // without trying to read from the doc (handle may be gone).
-    if let Some(error) = kernel_error {
-        return Ok(ExecutionResult {
-            cell_id: cell_id.to_string(),
-            outputs: vec![Output::error("KernelError", &error, vec![])],
-            success: false,
-            execution_count: None,
-        });
-    }
-
-    // Phase 2: Read canonical cell state from the Automerge doc.
-    // The daemon writes outputs to the doc as they arrive from the kernel,
-    // but ExecutionDone can arrive via broadcast before the final Automerge
-    // sync frame. A confirm_sync round-trip ensures our local doc replica
-    // has all the outputs before we read.
-    let (snapshot, blob_base_url, blob_store_path) = {
-        let state_guard = state.lock().await;
-        let handle = state_guard
-            .handle
-            .as_ref()
-            .ok_or_else(|| to_py_err("Not connected"))?;
-
-        handle.confirm_sync().await.map_err(to_py_err)?;
-
-        let cells = handle.get_cells();
-        let snapshot = cells.into_iter().find(|c| c.id == cell_id).ok_or_else(|| {
-            to_py_err(format!(
-                "Cell not found in doc after execution: {}",
-                cell_id
-            ))
-        })?;
-
-        (snapshot, blob_base_url, blob_store_path)
-    }; // state lock dropped before async I/O
-
-    let execution_count = snapshot.execution_count.parse::<i64>().ok();
-
-    // Resolve outputs from doc snapshot (blob hashes → Output objects)
-    let outputs =
-        output_resolver::resolve_cell_outputs(&snapshot.outputs, &blob_base_url, &blob_store_path)
-            .await;
-
-    let success = !outputs.iter().any(|o| o.output_type == "error");
-
-    Ok(ExecutionResult {
-        cell_id: cell_id.to_string(),
-        outputs,
-        success,
-        execution_count,
-    })
-}
-
-/// Get the notebook metadata snapshot asynchronously.
-async fn get_notebook_metadata_async(
-    state: &Arc<Mutex<AsyncSessionState>>,
-) -> PyResult<NotebookMetadataSnapshot> {
-    let state_guard = state.lock().await;
-    let handle = state_guard
-        .handle
-        .as_ref()
-        .ok_or_else(|| to_py_err("Not connected"))?;
-
-    Ok(handle.get_notebook_metadata().unwrap_or_default())
-}
-
-/// Set the notebook metadata snapshot asynchronously.
-async fn set_notebook_metadata_async(
-    state: &Arc<Mutex<AsyncSessionState>>,
-    snapshot: &NotebookMetadataSnapshot,
-) -> PyResult<()> {
-    let json_str = serde_json::to_string(snapshot)
-        .map_err(|e| to_py_err(format!("Failed to serialize metadata: {}", e)))?;
-
-    let state_guard = state.lock().await;
-    let handle = state_guard
-        .handle
-        .as_ref()
-        .ok_or_else(|| to_py_err("Not connected"))?;
-
-    handle
-        .set_metadata("notebook_metadata", &json_str)
-        .await
-        .map_err(to_py_err)
 }

--- a/crates/runtimed-py/src/async_session.rs
+++ b/crates/runtimed-py/src/async_session.rs
@@ -148,6 +148,23 @@ impl AsyncSession {
         working_dir: Option<&str>,
         peer_label: Option<String>,
     ) -> PyResult<Bound<'py, PyAny>> {
+        // Validate working_dir if provided
+        if let Some(wd) = working_dir {
+            let path = std::path::Path::new(wd);
+            if !path.exists() {
+                return Err(pyo3::exceptions::PyFileNotFoundError::new_err(format!(
+                    "working_dir does not exist: {}",
+                    wd
+                )));
+            }
+            if !path.is_dir() {
+                return Err(pyo3::exceptions::PyNotADirectoryError::new_err(format!(
+                    "working_dir is not a directory: {}",
+                    wd
+                )));
+            }
+        }
+
         let runtime = runtime.to_string();
         let working_dir_buf = working_dir.map(PathBuf::from);
 

--- a/crates/runtimed-py/src/async_session.rs
+++ b/crates/runtimed-py/src/async_session.rs
@@ -822,8 +822,8 @@ impl AsyncSession {
     ) -> PyResult<EventSubscription> {
         // Needs direct state access for resubscribe — use a temporary block_on
         // since this returns a sync object (the subscription) not a coroutine.
-        let rt = tokio::runtime::Handle::try_current()
-            .map_err(|_| to_py_err("No tokio runtime available"))?;
+        let rt = tokio::runtime::Runtime::new()
+            .map_err(|e| to_py_err(format!("Failed to create runtime: {}", e)))?;
 
         let state = rt.block_on(self.state.lock());
 
@@ -1006,8 +1006,8 @@ impl AsyncSession {
         format!("AsyncSession(id={})", self.notebook_id)
     }
 
-    fn __aenter__<'py>(slf: Bound<'py, Self>) -> PyResult<Bound<'py, Self>> {
-        Ok(slf)
+    fn __aenter__(slf: Py<Self>, py: Python<'_>) -> PyResult<Bound<'_, PyAny>> {
+        future_into_py(py, async move { Ok(slf) })
     }
 
     #[pyo3(signature = (_exc_type=None, _exc_val=None, _exc_tb=None))]
@@ -1018,14 +1018,6 @@ impl AsyncSession {
         _exc_val: Option<&Bound<'_, PyAny>>,
         _exc_tb: Option<&Bound<'_, PyAny>>,
     ) -> PyResult<Bound<'py, PyAny>> {
-        let state = Arc::clone(&self.state);
-        future_into_py(py, async move {
-            let st = state.lock().await;
-            if st.kernel_started {
-                drop(st);
-                let _ = session_core::shutdown_kernel(&state).await;
-            }
-            Ok(false) // Don't suppress exceptions
-        })
+        future_into_py(py, async move { Ok(false) })
     }
 }

--- a/crates/runtimed-py/src/lib.rs
+++ b/crates/runtimed-py/src/lib.rs
@@ -19,6 +19,7 @@ mod event_stream;
 mod output;
 mod output_resolver;
 mod session;
+mod session_core;
 mod subscription;
 
 use async_session::AsyncSession;

--- a/crates/runtimed-py/src/session.rs
+++ b/crates/runtimed-py/src/session.rs
@@ -1,6 +1,8 @@
-//! Session for code execution.
+//! Synchronous Session for code execution.
 //!
-//! Provides a high-level interface for executing code via the daemon's kernel.
+//! Thin wrapper around `session_core` async functions, using
+//! `runtime.block_on()` to provide a synchronous Python API.
+//! All business logic lives in `session_core.rs`.
 
 use pyo3::prelude::*;
 use std::path::PathBuf;
@@ -8,19 +10,14 @@ use std::sync::Arc;
 use tokio::runtime::Runtime;
 use tokio::sync::Mutex;
 
-use runtimed::notebook_sync_client::{
-    NotebookBroadcastReceiver, NotebookSyncClient, NotebookSyncHandle, NotebookSyncReceiver,
-};
 use runtimed::protocol::{NotebookBroadcast, NotebookRequest, NotebookResponse};
 
-use crate::daemon_paths::{get_blob_paths_sync, get_socket_path};
+use crate::daemon_paths::get_socket_path;
 use crate::error::to_py_err;
 use crate::event_stream::ExecutionEventIterator;
-use crate::output::{Cell, ExecutionResult, NotebookConnectionInfo, Output, SyncEnvironmentResult};
-use crate::output_resolver;
+use crate::output::{Cell, ExecutionResult, NotebookConnectionInfo, SyncEnvironmentResult};
+use crate::session_core::{self, SessionState};
 use crate::subscription::EventIteratorSubscription;
-
-use notebook_doc::metadata::NotebookMetadataSnapshot;
 
 /// A session for executing code via the runtimed daemon.
 ///
@@ -40,40 +37,6 @@ pub struct Session {
     state: Arc<Mutex<SessionState>>,
     notebook_id: String,
     peer_label: Option<String>,
-}
-
-struct SessionState {
-    handle: Option<NotebookSyncHandle>,
-    /// Keep the sync receiver alive so the sync task doesn't exit
-    #[allow(dead_code)]
-    sync_rx: Option<NotebookSyncReceiver>,
-    broadcast_rx: Option<NotebookBroadcastReceiver>,
-    kernel_started: bool,
-    env_source: Option<String>,
-    /// Base URL for blob server (for resolving blob hashes)
-    blob_base_url: Option<String>,
-    /// Path to blob store directory (fallback for direct disk access)
-    blob_store_path: Option<PathBuf>,
-    /// Connection info from daemon (for open_notebook/create_notebook)
-    connection_info: Option<NotebookConnectionInfo>,
-    /// Notebook path (for project file detection during kernel launch)
-    notebook_path: Option<String>,
-}
-
-impl SessionState {
-    fn new() -> Self {
-        Self {
-            handle: None,
-            sync_rx: None,
-            broadcast_rx: None,
-            kernel_started: false,
-            env_source: None,
-            blob_base_url: None,
-            blob_store_path: None,
-            connection_info: None,
-            notebook_path: None,
-        }
-    }
 }
 
 #[pymethods]
@@ -100,20 +63,20 @@ impl Session {
         })
     }
 
-    /// Get the notebook ID for this session.
+    /// The notebook ID for this session.
     #[getter]
     fn notebook_id(&self) -> &str {
         &self.notebook_id
     }
 
-    /// Check if the session is connected to the daemon.
+    /// Whether the session is connected to the daemon.
     #[getter]
     fn is_connected(&self) -> bool {
         let state = self.runtime.block_on(self.state.lock());
         state.handle.is_some()
     }
 
-    /// Check if a kernel has been started.
+    /// Whether a kernel has been started in this session.
     #[getter]
     fn kernel_started(&self) -> bool {
         let state = self.runtime.block_on(self.state.lock());
@@ -127,25 +90,23 @@ impl Session {
         state.env_source.clone()
     }
 
-    /// Get the connection info from daemon (for open_notebook/create_notebook).
-    ///
-    /// Returns None if not connected via open_notebook() or create_notebook().
+    /// Get connection info (from open_notebook/create_notebook).
     #[getter]
     fn connection_info(&self) -> Option<NotebookConnectionInfo> {
         let state = self.runtime.block_on(self.state.lock());
         state.connection_info.clone()
     }
 
-    /// Open an existing notebook file via the daemon.
+    // =========================================================================
+    // Connection (static constructors and connect)
+    // =========================================================================
+
+    /// Open an existing notebook file.
     ///
-    /// The daemon loads the file, derives the notebook_id from the canonical path,
-    /// and returns connection info including trust status.
+    /// Returns a new Session connected to the notebook at the given path.
     ///
     /// Args:
     ///     path: Path to the .ipynb file.
-    ///
-    /// Returns:
-    ///     A new Session connected to the opened notebook.
     ///
     /// Raises:
     ///     RuntimedError: If the file cannot be opened or parsed.
@@ -153,40 +114,10 @@ impl Session {
     #[pyo3(signature = (path, peer_label=None))]
     fn open_notebook(path: &str, peer_label: Option<String>) -> PyResult<Self> {
         let runtime = Runtime::new().map_err(to_py_err)?;
-        let path_buf = PathBuf::from(path);
-        let path_str = path.to_string();
+        let socket_path = get_socket_path();
 
-        let (notebook_id, state) = runtime.block_on(async {
-            let socket_path = get_socket_path();
-
-            let (handle, sync_rx, broadcast_rx, _cells, _metadata, info) =
-                NotebookSyncClient::connect_open_split(socket_path.clone(), path_buf, None)
-                    .await
-                    .map_err(to_py_err)?;
-
-            // Check for error in response
-            if let Some(error) = info.error {
-                return Err(to_py_err(error));
-            }
-
-            let notebook_id = info.notebook_id.clone();
-            let connection_info = NotebookConnectionInfo::from_protocol(info);
-            let (blob_base_url, blob_store_path) = get_blob_paths_sync(&socket_path);
-
-            let state = SessionState {
-                handle: Some(handle),
-                sync_rx: Some(sync_rx),
-                broadcast_rx: Some(broadcast_rx),
-                kernel_started: false,
-                env_source: None,
-                blob_base_url,
-                blob_store_path,
-                connection_info: Some(connection_info),
-                notebook_path: Some(path_str),
-            };
-
-            Ok((notebook_id, state))
-        })?;
+        let (notebook_id, state, _info) =
+            runtime.block_on(session_core::connect_open(socket_path, path))?;
 
         Ok(Self {
             runtime,
@@ -196,14 +127,13 @@ impl Session {
         })
     }
 
-    /// Create a new notebook via the daemon.
+    /// Create a new notebook.
     ///
-    /// The daemon creates an empty notebook with one code cell and returns
-    /// connection info with a generated UUID as the notebook_id.
+    /// Returns a new Session connected to a fresh notebook.
     ///
     /// Args:
-    ///     runtime: The kernel runtime type ("python" or "deno"). Defaults to "python".
-    ///     working_dir: Optional working directory for project file detection.
+    ///     runtime: Kernel runtime type (default: "python").
+    ///     working_dir: Optional working directory for the notebook.
     ///
     /// Returns:
     ///     A new Session connected to the created notebook.
@@ -214,65 +144,15 @@ impl Session {
         working_dir: Option<&str>,
         peer_label: Option<String>,
     ) -> PyResult<Self> {
-        // Validate working_dir if provided
-        if let Some(wd) = working_dir {
-            let path = std::path::Path::new(wd);
-            if !path.exists() {
-                return Err(pyo3::exceptions::PyFileNotFoundError::new_err(format!(
-                    "working_dir does not exist: {}",
-                    wd
-                )));
-            }
-            if !path.is_dir() {
-                return Err(pyo3::exceptions::PyNotADirectoryError::new_err(format!(
-                    "working_dir is not a directory: {}",
-                    wd
-                )));
-            }
-        }
-
         let rt = Runtime::new().map_err(to_py_err)?;
-        let runtime_str = runtime.to_string();
-        let working_dir_str = working_dir.map(|s| s.to_string());
+        let socket_path = get_socket_path();
         let working_dir_buf = working_dir.map(PathBuf::from);
 
-        let (notebook_id, state) = rt.block_on(async {
-            let socket_path = get_socket_path();
-
-            let (handle, sync_rx, broadcast_rx, _cells, _metadata, info) =
-                NotebookSyncClient::connect_create_split(
-                    socket_path.clone(),
-                    runtime_str,
-                    working_dir_buf,
-                    None,
-                    None,
-                )
-                .await
-                .map_err(to_py_err)?;
-
-            // Check for error in response
-            if let Some(error) = info.error {
-                return Err(to_py_err(error));
-            }
-
-            let notebook_id = info.notebook_id.clone();
-            let connection_info = NotebookConnectionInfo::from_protocol(info);
-            let (blob_base_url, blob_store_path) = get_blob_paths_sync(&socket_path);
-
-            let state = SessionState {
-                handle: Some(handle),
-                sync_rx: Some(sync_rx),
-                broadcast_rx: Some(broadcast_rx),
-                kernel_started: false,
-                env_source: None,
-                blob_base_url,
-                blob_store_path,
-                connection_info: Some(connection_info),
-                notebook_path: working_dir_str,
-            };
-
-            Ok((notebook_id, state))
-        })?;
+        let (notebook_id, state, _info) = rt.block_on(session_core::connect_create(
+            socket_path,
+            runtime,
+            working_dir_buf,
+        ))?;
 
         Ok(Self {
             runtime: rt,
@@ -283,49 +163,24 @@ impl Session {
     }
 
     /// Connect to the daemon.
-    ///
-    /// This is called automatically by start_kernel() if not already connected.
-    /// Respects the RUNTIMED_SOCKET_PATH environment variable if set.
     fn connect(&self) -> PyResult<()> {
-        self.runtime.block_on(async {
-            let mut state = self.state.lock().await;
-            if state.handle.is_some() {
-                return Ok(()); // Already connected
-            }
-
-            let socket_path = get_socket_path();
-
-            let (handle, sync_rx, broadcast_rx, _cells, _notebook_path) =
-                NotebookSyncClient::connect_split(socket_path.clone(), self.notebook_id.clone())
-                    .await
-                    .map_err(to_py_err)?;
-
-            let (blob_base_url, blob_store_path) = get_blob_paths_sync(&socket_path);
-
-            state.handle = Some(handle);
-            state.sync_rx = Some(sync_rx); // Keep alive so sync task doesn't exit
-            state.broadcast_rx = Some(broadcast_rx);
-            state.blob_base_url = blob_base_url;
-            state.blob_store_path = blob_store_path;
-
-            Ok(())
-        })
+        self.runtime
+            .block_on(session_core::connect(&self.state, &self.notebook_id))
     }
 
-    /// Start a kernel for this session.
+    // =========================================================================
+    // Kernel lifecycle
+    // =========================================================================
+
+    /// Start a kernel in the daemon.
     ///
     /// Args:
-    ///     kernel_type: Type of kernel ("python" or "deno"). Defaults to "python".
-    ///     env_source: Environment source. Defaults to "auto" (auto-detect from
-    ///         inline deps or project files). For Deno kernels, this is ignored
-    ///         and always uses "deno".
-    ///     notebook_path: Optional path to the notebook file on disk.
-    ///         Used for project file detection (pyproject.toml, pixi.toml,
-    ///         environment.yml) when env_source is "auto". If not provided,
-    ///         uses the path from open_notebook() if available.
+    ///     kernel_type: Type of kernel to start (default: "python").
+    ///     env_source: Environment source (default: "auto").
+    ///     notebook_path: Optional path for project file detection.
     ///
-    /// If a kernel is already running for this session's notebook_id,
-    /// this returns immediately without starting a new one.
+    /// Raises:
+    ///     RuntimedError: If not connected or kernel launch fails.
     #[pyo3(signature = (kernel_type="python", env_source="auto", notebook_path=None))]
     fn start_kernel(
         &self,
@@ -333,304 +188,118 @@ impl Session {
         env_source: &str,
         notebook_path: Option<&str>,
     ) -> PyResult<()> {
-        // Ensure connected first
         self.connect()?;
+        self.runtime.block_on(session_core::start_kernel(
+            &self.state,
+            kernel_type,
+            env_source,
+            notebook_path,
+        ))
+    }
 
-        self.runtime.block_on(async {
-            let mut state = self.state.lock().await;
+    /// Shutdown the kernel.
+    fn shutdown_kernel(&self) -> PyResult<()> {
+        self.runtime
+            .block_on(session_core::shutdown_kernel(&self.state))
+    }
 
-            let handle = state
-                .handle
-                .as_ref()
-                .ok_or_else(|| to_py_err("Not connected"))?;
+    /// Restart the kernel with auto environment detection.
+    ///
+    /// Args:
+    ///     wait_for_ready: If True, wait for kernel to report idle (default: True).
+    #[pyo3(signature = (wait_for_ready=true))]
+    fn restart_kernel(&self, wait_for_ready: bool) -> PyResult<()> {
+        self.runtime
+            .block_on(session_core::restart_kernel(&self.state, wait_for_ready))
+    }
 
-            // Use provided notebook_path or fall back to stored path from open_notebook()
-            let resolved_path = notebook_path
-                .map(|p| p.to_string())
-                .or_else(|| state.notebook_path.clone());
-
-            let response = handle
-                .send_request(NotebookRequest::LaunchKernel {
-                    kernel_type: kernel_type.to_string(),
-                    env_source: env_source.to_string(),
-                    notebook_path: resolved_path,
-                })
-                .await
-                .map_err(to_py_err)?;
-
-            match response {
-                NotebookResponse::KernelLaunched {
-                    env_source: actual_env,
-                    ..
-                } => {
-                    state.kernel_started = true;
-                    state.env_source = Some(actual_env);
-                    Ok(())
-                }
-                NotebookResponse::KernelAlreadyRunning {
-                    env_source: actual_env,
-                    ..
-                } => {
-                    state.kernel_started = true;
-                    state.env_source = Some(actual_env);
-                    Ok(())
-                }
-                NotebookResponse::Error { error } => Err(to_py_err(error)),
-                other => Err(to_py_err(format!("Unexpected response: {:?}", other))),
-            }
-        })
+    /// Interrupt the currently executing cell.
+    fn interrupt(&self) -> PyResult<()> {
+        self.runtime.block_on(session_core::interrupt(&self.state))
     }
 
     // =========================================================================
-    // Document Operations (write to automerge doc, synced to all clients)
+    // Cell operations
     // =========================================================================
 
-    /// Create a new cell in the automerge document.
-    ///
-    /// The cell is written to the shared document and synced to all connected
-    /// clients. Use execute_cell() to execute it.
+    /// Create a new cell in the document (atomic: source set in same transaction).
     ///
     /// Args:
-    ///     source: The cell source code (default: empty string).
-    ///     cell_type: Cell type - "code", "markdown", or "raw" (default: "code").
-    ///     index: Position to insert the cell (default: append at end).
+    ///     source: Cell source code (default: "").
+    ///     cell_type: Cell type (default: "code").
+    ///     index: Position to insert (default: end).
     ///
     /// Returns:
     ///     The cell ID (str).
     #[pyo3(signature = (source="", cell_type="code", index=None))]
     fn create_cell(&self, source: &str, cell_type: &str, index: Option<usize>) -> PyResult<String> {
         self.connect()?;
-
-        let cell_id = format!("cell-{}", uuid::Uuid::new_v4());
-
-        self.runtime.block_on(async {
-            let state = self.state.lock().await;
-            let handle = state
-                .handle
-                .as_ref()
-                .ok_or_else(|| to_py_err("Not connected"))?;
-
-            // Get current cell count to determine index
-            let cells = handle.get_cells();
-            let insert_index = index.unwrap_or(cells.len());
-
-            // Create cell with source atomically — a single Automerge transaction
-            // and one sync round-trip. This prevents remote peers from seeing the
-            // cell structure before its source content arrives.
-            handle
-                .add_cell_with_source(insert_index, &cell_id, cell_type, source)
-                .await
-                .map_err(to_py_err)?;
-
-            Ok(cell_id)
-        })
+        self.runtime.block_on(session_core::create_cell(
+            &self.state,
+            source,
+            cell_type,
+            index,
+        ))
     }
 
     /// Update a cell's source in the automerge document.
-    ///
-    /// The change is synced to all connected clients.
-    ///
-    /// Args:
-    ///     cell_id: The cell ID.
-    ///     source: The new source code.
     fn set_source(&self, cell_id: &str, source: &str) -> PyResult<()> {
-        self.runtime.block_on(async {
-            let state = self.state.lock().await;
-            let handle = state
-                .handle
-                .as_ref()
-                .ok_or_else(|| to_py_err("Not connected"))?;
-
-            handle
-                .update_source(cell_id, source)
-                .await
-                .map_err(to_py_err)
-        })
+        self.runtime
+            .block_on(session_core::set_source(&self.state, cell_id, source))
     }
 
-    /// Append text to a cell's source in the automerge document.
-    ///
-    /// Unlike set_source() which replaces the entire text (using Myers diff
-    /// internally), this directly inserts characters at the end of the source
-    /// Text CRDT. This is ideal for streaming/agentic use cases where an
-    /// external process is appending tokens incrementally — each append is
-    /// a minimal CRDT operation that syncs efficiently to all connected clients.
-    ///
-    /// Args:
-    ///     cell_id: The cell ID.
-    ///     text: The text to append to the cell's source.
+    /// Append text to a cell's source (efficient for streaming tokens).
     fn append_source(&self, cell_id: &str, text: &str) -> PyResult<()> {
-        self.runtime.block_on(async {
-            let state = self.state.lock().await;
-            let handle = state
-                .handle
-                .as_ref()
-                .ok_or_else(|| to_py_err("Not connected"))?;
-
-            handle.append_source(cell_id, text).await.map_err(to_py_err)
-        })
+        self.runtime
+            .block_on(session_core::append_source(&self.state, cell_id, text))
     }
 
-    /// Get a cell from the automerge document.
-    ///
-    /// Args:
-    ///     cell_id: The cell ID.
-    ///
-    /// Returns:
-    ///     Cell object with id, cell_type, source, and execution_count.
-    ///
-    /// Raises:
-    ///     RuntimedError: If cell not found.
+    /// Get a cell by ID with resolved outputs.
     fn get_cell(&self, cell_id: &str) -> PyResult<Cell> {
-        self.runtime.block_on(async {
-            // Get snapshot and blob config while holding lock
-            let (snapshot, blob_base_url, blob_store_path) = {
-                let state = self.state.lock().await;
-                let handle = state
-                    .handle
-                    .as_ref()
-                    .ok_or_else(|| to_py_err("Not connected"))?;
-
-                let blob_base_url = state.blob_base_url.clone();
-                let blob_store_path = state.blob_store_path.clone();
-
-                let cells = handle.get_cells();
-                let snapshot = cells
-                    .into_iter()
-                    .find(|c| c.id == cell_id)
-                    .ok_or_else(|| to_py_err(format!("Cell not found: {}", cell_id)))?;
-
-                (snapshot, blob_base_url, blob_store_path)
-            }; // Lock released here
-
-            // Resolve outputs outside the lock
-            let outputs = output_resolver::resolve_cell_outputs(
-                &snapshot.outputs,
-                &blob_base_url,
-                &blob_store_path,
-            )
-            .await;
-
-            Ok(Cell::from_snapshot_with_outputs(snapshot, outputs))
-        })
+        self.runtime
+            .block_on(session_core::get_cell(&self.state, cell_id))
     }
 
-    /// Get all cells from the automerge document.
-    ///
-    /// Returns:
-    ///     List of Cell objects.
+    /// Get all cells with resolved outputs.
     fn get_cells(&self) -> PyResult<Vec<Cell>> {
-        self.runtime.block_on(async {
-            // Get snapshots and blob config while holding lock
-            let (snapshots, blob_base_url, blob_store_path) = {
-                let state = self.state.lock().await;
-                let handle = state
-                    .handle
-                    .as_ref()
-                    .ok_or_else(|| to_py_err("Not connected"))?;
-
-                let blob_base_url = state.blob_base_url.clone();
-                let blob_store_path = state.blob_store_path.clone();
-
-                let snapshots = handle.get_cells();
-                (snapshots, blob_base_url, blob_store_path)
-            }; // Lock released here
-
-            // Resolve outputs for all cells outside the lock
-            let mut cells = Vec::with_capacity(snapshots.len());
-            for snapshot in snapshots {
-                let outputs = output_resolver::resolve_cell_outputs(
-                    &snapshot.outputs,
-                    &blob_base_url,
-                    &blob_store_path,
-                )
-                .await;
-                cells.push(Cell::from_snapshot_with_outputs(snapshot, outputs));
-            }
-            Ok(cells)
-        })
+        self.runtime.block_on(session_core::get_cells(&self.state))
     }
 
-    /// Delete a cell from the automerge document.
-    ///
-    /// Args:
-    ///     cell_id: The cell ID to delete.
+    /// Delete a cell from the document.
     fn delete_cell(&self, cell_id: &str) -> PyResult<()> {
-        self.runtime.block_on(async {
-            let state = self.state.lock().await;
-            let handle = state
-                .handle
-                .as_ref()
-                .ok_or_else(|| to_py_err("Not connected"))?;
-
-            handle.delete_cell(cell_id).await.map_err(to_py_err)
-        })
+        self.runtime
+            .block_on(session_core::delete_cell(&self.state, cell_id))
     }
 
-    /// Move a cell to a new position in the notebook.
-    ///
-    /// Updates the cell's fractional index position field. No delete/re-insert —
-    /// the cell object is preserved in the Automerge document.
-    ///
-    /// Args:
-    ///     cell_id: The cell ID to move.
-    ///     after_cell_id: Place the cell after this cell ID. None means move to the start.
-    ///
-    /// Returns:
-    ///     The new fractional position string.
+    /// Move a cell to after another cell (or to the beginning if None).
     #[pyo3(signature = (cell_id, after_cell_id=None))]
     fn move_cell(&self, cell_id: &str, after_cell_id: Option<&str>) -> PyResult<String> {
-        self.runtime.block_on(async {
-            let state = self.state.lock().await;
-            let handle = state
-                .handle
-                .as_ref()
-                .ok_or_else(|| to_py_err("Not connected"))?;
-
-            handle
-                .move_cell(cell_id, after_cell_id)
-                .await
-                .map_err(to_py_err)
-        })
+        self.runtime
+            .block_on(session_core::move_cell(&self.state, cell_id, after_cell_id))
     }
 
-    /// Send a cursor position as presence data to other connected peers.
-    ///
-    /// The daemon relays this to all other peers in the notebook room.
-    /// Other peers' cursors are delivered via presence frames.
-    ///
-    /// Args:
-    ///     cell_id: The cell the cursor is in.
-    ///     line: Line number (0-based).
-    ///     column: Column number (0-based).
+    /// Clear a cell's outputs.
+    fn clear_outputs(&self, cell_id: &str) -> PyResult<()> {
+        self.runtime
+            .block_on(session_core::clear_outputs(&self.state, cell_id))
+    }
+
+    // =========================================================================
+    // Presence
+    // =========================================================================
+
+    /// Set cursor position for collaborative presence.
     fn set_cursor(&self, cell_id: &str, line: u32, column: u32) -> PyResult<()> {
-        let data = notebook_doc::presence::encode_cursor_update_labeled(
-            "local",
+        self.runtime.block_on(session_core::set_cursor(
+            &self.state,
             self.peer_label.as_deref(),
-            &notebook_doc::presence::CursorPosition {
-                cell_id: cell_id.to_string(),
-                line,
-                column,
-            },
-        );
-        self.runtime.block_on(async {
-            let state = self.state.lock().await;
-            let handle = state
-                .handle
-                .as_ref()
-                .ok_or_else(|| to_py_err("Not connected"))?;
-            handle.send_presence(data).await.map_err(to_py_err)
-        })
+            cell_id,
+            line,
+            column,
+        ))
     }
 
-    /// Send a selection range as presence data to other connected peers.
-    ///
-    /// Args:
-    ///     cell_id: The cell the selection is in.
-    ///     anchor_line: Selection anchor line (0-based).
-    ///     anchor_col: Selection anchor column (0-based).
-    ///     head_line: Selection head line (0-based).
-    ///     head_col: Selection head column (0-based).
+    /// Set selection range for collaborative presence.
     fn set_selection(
         &self,
         cell_id: &str,
@@ -639,276 +308,112 @@ impl Session {
         head_line: u32,
         head_col: u32,
     ) -> PyResult<()> {
-        let data = notebook_doc::presence::encode_selection_update_labeled(
-            "local",
+        self.runtime.block_on(session_core::set_selection(
+            &self.state,
             self.peer_label.as_deref(),
-            &notebook_doc::presence::SelectionRange {
-                cell_id: cell_id.to_string(),
-                anchor_line,
-                anchor_col,
-                head_line,
-                head_col,
-            },
-        );
-        self.runtime.block_on(async {
-            let state = self.state.lock().await;
-            let handle = state
-                .handle
-                .as_ref()
-                .ok_or_else(|| to_py_err("Not connected"))?;
-            handle.send_presence(data).await.map_err(to_py_err)
-        })
+            cell_id,
+            anchor_line,
+            anchor_col,
+            head_line,
+            head_col,
+        ))
     }
 
-    /// Save the notebook to a .ipynb file.
-    ///
-    /// Reads cells and metadata from the synced Automerge document, resolves
-    /// output manifests from the blob store, and writes standard nbformat v4 JSON.
+    // =========================================================================
+    // Save / Metadata
+    // =========================================================================
+
+    /// Save the notebook to disk.
     ///
     /// Args:
-    ///     path: Optional target path for the notebook file. If it doesn't end
-    ///           with .ipynb, the extension will be appended. If None, saves to
-    ///           the notebook's original file path (the notebook_id).
+    ///     path: Optional path override. If not provided, saves to original path.
     ///
     /// Returns:
-    ///     The absolute path where the file was written.
-    ///
-    /// Raises:
-    ///     RuntimedError: If not connected or write fails.
+    ///     The path the notebook was saved to.
     #[pyo3(signature = (path=None))]
     fn save(&self, path: Option<&str>) -> PyResult<String> {
         self.connect()?;
-
-        let path = path.map(|s| s.to_string());
-
-        self.runtime.block_on(async {
-            let state = self.state.lock().await;
-            let handle = state
-                .handle
-                .as_ref()
-                .ok_or_else(|| to_py_err("Not connected"))?;
-
-            let response = handle
-                .send_request(NotebookRequest::SaveNotebook {
-                    format_cells: false,
-                    path,
-                })
-                .await
-                .map_err(to_py_err)?;
-
-            match response {
-                NotebookResponse::NotebookSaved { path } => Ok(path),
-                NotebookResponse::Error { error } => Err(to_py_err(error)),
-                other => Err(to_py_err(format!("Unexpected response: {:?}", other))),
-            }
-        })
+        self.runtime.block_on(session_core::save(&self.state, path))
     }
 
-    // =========================================================================
-    // Metadata Operations (synced via automerge doc)
-    // =========================================================================
-
-    /// Set a metadata value in the automerge document.
-    ///
-    /// The value is synced to the daemon and all connected clients.
-    /// Use the key "notebook_metadata" to set the NotebookMetadataSnapshot
-    /// (JSON-encoded kernelspec, language_info, and runt config).
-    ///
-    /// Args:
-    ///     key: The metadata key.
-    ///     value: The metadata value (typically JSON).
+    /// Set a notebook metadata key.
     fn set_metadata(&self, key: &str, value: &str) -> PyResult<()> {
         self.connect()?;
-
-        let key = key.to_string();
-        let value = value.to_string();
-
-        self.runtime.block_on(async {
-            let state = self.state.lock().await;
-            let handle = state
-                .handle
-                .as_ref()
-                .ok_or_else(|| to_py_err("Not connected"))?;
-
-            handle.set_metadata(&key, &value).await.map_err(to_py_err)
-        })
+        self.runtime
+            .block_on(session_core::set_metadata(&self.state, key, value))
     }
 
-    /// Get a metadata value from the automerge document.
-    ///
-    /// Reads from the local replica of the automerge doc.
-    ///
-    /// Args:
-    ///     key: The metadata key.
-    ///
-    /// Returns:
-    ///     The metadata value (str) or None if not set.
+    /// Get a notebook metadata key.
     fn get_metadata(&self, key: &str) -> PyResult<Option<String>> {
-        self.connect()?;
-
-        let key = key.to_string();
-
-        self.runtime.block_on(async {
-            let state = self.state.lock().await;
-            let handle = state
-                .handle
-                .as_ref()
-                .ok_or_else(|| to_py_err("Not connected"))?;
-
-            handle.get_metadata(&key).await.map_err(to_py_err)
-        })
+        self.runtime
+            .block_on(session_core::get_metadata(&self.state, key))
     }
 
     // =========================================================================
-    // Cell Metadata (per-cell metadata in automerge document)
+    // Cell metadata
     // =========================================================================
 
     /// Get cell metadata as a JSON string.
-    ///
-    /// Args:
-    ///     cell_id: The cell ID.
-    ///
-    /// Returns:
-    ///     JSON string of the cell's metadata, or None if cell not found.
     fn get_cell_metadata(&self, cell_id: &str) -> PyResult<Option<String>> {
-        self.connect()?;
-
-        let state = self.state.blocking_lock();
-        let handle = state
-            .handle
-            .as_ref()
-            .ok_or_else(|| to_py_err("Not connected"))?;
-
-        Ok(handle
-            .get_cell_metadata(cell_id)
-            .map(|m| serde_json::to_string(&m).unwrap_or_else(|_| "{}".to_string())))
+        self.runtime
+            .block_on(session_core::get_cell_metadata(&self.state, cell_id))
     }
 
-    /// Set cell metadata from a JSON string.
-    ///
-    /// Args:
-    ///     cell_id: The cell ID.
-    ///     metadata_json: JSON string of the metadata to set.
-    ///
-    /// Returns:
-    ///     True if the cell was found and updated, False if cell not found.
+    /// Set cell metadata from a JSON string. Returns True on success.
     fn set_cell_metadata(&self, cell_id: &str, metadata_json: &str) -> PyResult<bool> {
-        self.connect()?;
-
-        let metadata: serde_json::Value = serde_json::from_str(metadata_json)
-            .map_err(|e| to_py_err(format!("Invalid JSON: {}", e)))?;
-
-        let cell_id = cell_id.to_string();
-
-        self.runtime.block_on(async {
-            let state = self.state.lock().await;
-            let handle = state
-                .handle
-                .as_ref()
-                .ok_or_else(|| to_py_err("Not connected"))?;
-
-            handle
-                .set_cell_metadata(&cell_id, &metadata)
-                .await
-                .map_err(to_py_err)
-        })
+        self.runtime.block_on(session_core::set_cell_metadata(
+            &self.state,
+            cell_id,
+            metadata_json,
+        ))
     }
 
-    /// Update cell metadata at a specific path.
-    ///
-    /// Args:
-    ///     cell_id: The cell ID.
-    ///     path: List of keys forming the path (e.g., ["jupyter", "source_hidden"]).
-    ///     value_json: JSON string of the value to set.
-    ///
-    /// Returns:
-    ///     True if the cell was found and updated, False if cell not found.
+    /// Update cell metadata at a specific path. Returns True on success.
     fn update_cell_metadata_at(
         &self,
         cell_id: &str,
         path: Vec<String>,
         value_json: &str,
     ) -> PyResult<bool> {
-        self.connect()?;
-
-        let value: serde_json::Value = serde_json::from_str(value_json)
-            .map_err(|e| to_py_err(format!("Invalid JSON: {}", e)))?;
-
-        let cell_id = cell_id.to_string();
-
-        self.runtime.block_on(async {
-            let state = self.state.lock().await;
-            let handle = state
-                .handle
-                .as_ref()
-                .ok_or_else(|| to_py_err("Not connected"))?;
-
-            let path_refs: Vec<&str> = path.iter().map(|s| s.as_str()).collect();
-            handle
-                .update_cell_metadata_at(&cell_id, &path_refs, value)
-                .await
-                .map_err(to_py_err)
-        })
+        self.runtime.block_on(session_core::update_cell_metadata_at(
+            &self.state,
+            cell_id,
+            path,
+            value_json,
+        ))
     }
 
-    /// Set whether a cell's source should be hidden (JupyterLab convention).
-    ///
-    /// Args:
-    ///     cell_id: The cell ID.
-    ///     hidden: Whether the source should be hidden.
-    ///
-    /// Returns:
-    ///     True if the cell was found and updated, False if cell not found.
+    /// Set whether a cell's source is hidden.
     fn set_cell_source_hidden(&self, cell_id: &str, hidden: bool) -> PyResult<bool> {
-        self.update_cell_metadata_at(
-            cell_id,
-            vec!["jupyter".to_string(), "source_hidden".to_string()],
-            &serde_json::to_string(&hidden).unwrap(),
-        )
+        let val = if hidden { "true" } else { "false" };
+        self.update_cell_metadata_at(cell_id, vec!["jupyter".into(), "source_hidden".into()], val)
     }
 
-    /// Set whether a cell's outputs should be hidden (JupyterLab convention).
-    ///
-    /// Args:
-    ///     cell_id: The cell ID.
-    ///     hidden: Whether the outputs should be hidden.
-    ///
-    /// Returns:
-    ///     True if the cell was found and updated, False if cell not found.
+    /// Set whether a cell's outputs are hidden.
     fn set_cell_outputs_hidden(&self, cell_id: &str, hidden: bool) -> PyResult<bool> {
+        let val = if hidden { "true" } else { "false" };
         self.update_cell_metadata_at(
             cell_id,
-            vec!["jupyter".to_string(), "outputs_hidden".to_string()],
-            &serde_json::to_string(&hidden).unwrap(),
+            vec!["jupyter".into(), "outputs_hidden".into()],
+            val,
         )
     }
 
     /// Set cell tags.
-    ///
-    /// Args:
-    ///     cell_id: The cell ID.
-    ///     tags: List of tag strings.
-    ///
-    /// Returns:
-    ///     True if the cell was found and updated, False if cell not found.
     fn set_cell_tags(&self, cell_id: &str, tags: Vec<String>) -> PyResult<bool> {
-        self.update_cell_metadata_at(
-            cell_id,
-            vec!["tags".to_string()],
-            &serde_json::to_string(&tags).unwrap(),
-        )
+        let val = serde_json::to_string(&tags).map_err(|e| to_py_err(format!("JSON: {}", e)))?;
+        self.update_cell_metadata_at(cell_id, vec!["tags".into()], &val)
     }
 
     // =========================================================================
-    // Dependency Management (convenience methods for notebook_metadata)
+    // Dependencies (uv / conda)
     // =========================================================================
 
     /// Get current UV dependencies.
-    ///
-    /// Returns:
-    ///     List of UV dependency specifiers (e.g., ["pandas>=2.0", "numpy"]).
     fn get_uv_dependencies(&self) -> PyResult<Vec<String>> {
-        let snapshot = self.get_notebook_metadata()?;
+        let snapshot = self
+            .runtime
+            .block_on(session_core::get_notebook_metadata(&self.state))?;
         Ok(snapshot
             .runt
             .uv
@@ -916,44 +421,34 @@ impl Session {
             .unwrap_or_default())
     }
 
-    /// Add a UV dependency to the notebook. Deduplicates by package name
-    /// (case-insensitive): if the package already exists, its specifier is
-    /// replaced rather than appended.
-    ///
-    /// Args:
-    ///     package: PEP 508 dependency specifier (e.g., "pandas>=2.0", "requests").
-    ///
-    /// Returns:
-    ///     None. Use `get_uv_dependencies()` to read the current state.
+    /// Add a UV dependency (deduplicates by package name).
     fn add_uv_dependency(&self, package: &str) -> PyResult<()> {
-        let mut snapshot = self.get_notebook_metadata()?;
+        let mut snapshot = self
+            .runtime
+            .block_on(session_core::get_notebook_metadata(&self.state))?;
         snapshot.add_uv_dependency(package);
-        self.set_notebook_metadata(&snapshot)
+        self.runtime
+            .block_on(session_core::set_notebook_metadata(&self.state, &snapshot))
     }
 
-    /// Remove a UV dependency by package name (case-insensitive, version-agnostic).
-    ///
-    /// Args:
-    ///     package: Package name to remove (e.g., "requests"). Version specifiers
-    ///         are ignored — any entry matching the package name is removed.
-    ///
-    /// Returns:
-    ///     bool: True if a dependency was removed, False if not found.
+    /// Remove a UV dependency by package name. Returns True if removed.
     fn remove_uv_dependency(&self, package: &str) -> PyResult<bool> {
-        let mut snapshot = self.get_notebook_metadata()?;
+        let mut snapshot = self
+            .runtime
+            .block_on(session_core::get_notebook_metadata(&self.state))?;
         let removed = snapshot.remove_uv_dependency(package);
         if removed {
-            self.set_notebook_metadata(&snapshot)?;
+            self.runtime
+                .block_on(session_core::set_notebook_metadata(&self.state, &snapshot))?;
         }
         Ok(removed)
     }
 
     /// Get current Conda dependencies.
-    ///
-    /// Returns:
-    ///     List of Conda package names.
     fn get_conda_dependencies(&self) -> PyResult<Vec<String>> {
-        let snapshot = self.get_notebook_metadata()?;
+        let snapshot = self
+            .runtime
+            .block_on(session_core::get_notebook_metadata(&self.state))?;
         Ok(snapshot
             .runt
             .conda
@@ -961,50 +456,37 @@ impl Session {
             .unwrap_or_default())
     }
 
-    /// Add a Conda dependency to the notebook. Deduplicates by package name
-    /// (case-insensitive): if the package already exists, its specifier is
-    /// replaced rather than appended.
-    ///
-    /// Args:
-    ///     package: Conda package specifier (e.g., "numpy", "scipy>=1.0").
-    ///
-    /// Returns:
-    ///     None. Use `get_conda_dependencies()` to read the current state.
+    /// Add a Conda dependency (deduplicates by package name).
     fn add_conda_dependency(&self, package: &str) -> PyResult<()> {
-        let mut snapshot = self.get_notebook_metadata()?;
+        let mut snapshot = self
+            .runtime
+            .block_on(session_core::get_notebook_metadata(&self.state))?;
         snapshot.add_conda_dependency(package);
-        self.set_notebook_metadata(&snapshot)
+        self.runtime
+            .block_on(session_core::set_notebook_metadata(&self.state, &snapshot))
     }
 
-    /// Remove a Conda dependency by package name (case-insensitive, version-agnostic).
-    ///
-    /// Args:
-    ///     package: Package name to remove (e.g., "numpy"). Version specifiers
-    ///         are ignored — any entry matching the package name is removed.
-    ///
-    /// Returns:
-    ///     bool: True if a dependency was removed, False if not found.
+    /// Remove a Conda dependency by package name. Returns True if removed.
     fn remove_conda_dependency(&self, package: &str) -> PyResult<bool> {
-        let mut snapshot = self.get_notebook_metadata()?;
+        let mut snapshot = self
+            .runtime
+            .block_on(session_core::get_notebook_metadata(&self.state))?;
         let removed = snapshot.remove_conda_dependency(package);
         if removed {
-            self.set_notebook_metadata(&snapshot)?;
+            self.runtime
+                .block_on(session_core::set_notebook_metadata(&self.state, &snapshot))?;
         }
         Ok(removed)
     }
 
     // =========================================================================
-    // Execution (document-first: reads source from automerge doc)
+    // Execution
     // =========================================================================
 
     /// Execute a cell by ID.
     ///
-    /// The daemon reads the cell's source from the automerge document and
-    /// executes it. This ensures all clients see the same code being executed.
-    ///
-    /// If a kernel isn't running yet, this will start one automatically.
-    /// If a kernel is already running in the daemon (e.g., started by another
-    /// client), it will reuse that kernel.
+    /// The entire lifecycle (confirm_sync, send_request, collect_outputs)
+    /// is wrapped in a single timeout.
     ///
     /// Args:
     ///     cell_id: The cell ID to execute.
@@ -1017,68 +499,38 @@ impl Session {
     ///     RuntimedError: If not connected, cell not found, or timeout.
     #[pyo3(signature = (cell_id, timeout_secs=60.0))]
     fn execute_cell(&self, cell_id: &str, timeout_secs: f64) -> PyResult<ExecutionResult> {
-        let cell_id = cell_id.to_string();
+        self.runtime.block_on(session_core::execute_cell(
+            &self.state,
+            &self.notebook_id,
+            cell_id,
+            timeout_secs,
+        ))
+    }
 
-        // Auto-start kernel if not running (will reuse existing kernel if one is running)
-        {
-            let state = self.runtime.block_on(self.state.lock());
-            if !state.kernel_started {
-                drop(state);
-                self.start_kernel("python", "auto", None)?;
-            }
-        }
+    /// Create a cell, execute it, and return the result.
+    ///
+    /// Convenience method that combines create_cell + execute_cell.
+    ///
+    /// Args:
+    ///     code: The code to execute.
+    ///     timeout_secs: Maximum time to wait (default: 60).
+    ///
+    /// Returns:
+    ///     ExecutionResult with outputs, success status, and execution count.
+    #[pyo3(signature = (code, timeout_secs=60.0))]
+    fn run(&self, code: &str, timeout_secs: f64) -> PyResult<ExecutionResult> {
+        self.runtime.block_on(session_core::run(
+            &self.state,
+            &self.notebook_id,
+            code,
+            timeout_secs,
+        ))
+    }
 
-        self.runtime.block_on(async {
-            // Wrap the entire execution lifecycle in a single timeout.
-            // Previously only collect_outputs was bounded, which meant
-            // confirm_sync() or send_request() could hang indefinitely.
-            let timeout = std::time::Duration::from_secs_f64(timeout_secs);
-            let result = tokio::time::timeout(timeout, async {
-                let state = self.state.lock().await;
-
-                let handle = state
-                    .handle
-                    .as_ref()
-                    .ok_or_else(|| to_py_err("Not connected"))?;
-
-                let blob_base_url = state.blob_base_url.clone();
-                let blob_store_path = state.blob_store_path.clone();
-
-                // Confirm the daemon has merged our latest changes before executing.
-                // The daemon reads cell source from its own Automerge doc, so it must
-                // have the cell before we can reference it by ID.
-                handle.confirm_sync().await.map_err(to_py_err)?;
-
-                // Execute cell (daemon reads source from automerge doc)
-                let response = handle
-                    .send_request(NotebookRequest::ExecuteCell {
-                        cell_id: cell_id.clone(),
-                    })
-                    .await
-                    .map_err(to_py_err)?;
-
-                match response {
-                    NotebookResponse::CellQueued { .. } => {}
-                    NotebookResponse::Error { error } => return Err(to_py_err(error)),
-                    other => return Err(to_py_err(format!("Unexpected response: {:?}", other))),
-                }
-
-                drop(state); // Release lock before waiting for broadcasts
-
-                self.collect_outputs(&cell_id, blob_base_url, blob_store_path)
-                    .await
-            })
-            .await;
-
-            match result {
-                Ok(Ok(exec_result)) => Ok(exec_result),
-                Ok(Err(e)) => Err(e),
-                Err(_) => Err(to_py_err(format!(
-                    "Execution timed out after {} seconds",
-                    timeout_secs
-                ))),
-            }
-        })
+    /// Queue a cell for execution without waiting for the result.
+    fn queue_cell(&self, cell_id: &str) -> PyResult<()> {
+        self.runtime
+            .block_on(session_core::queue_cell(&self.state, cell_id))
     }
 
     /// Stream execution events for a cell as an iterator.
@@ -1086,13 +538,6 @@ impl Session {
     /// Unlike execute_cell() which blocks until completion and returns all
     /// outputs at once, this returns an iterator that yields ExecutionEvent
     /// objects as they arrive from the kernel, enabling real-time processing.
-    ///
-    /// Example:
-    ///     ```python
-    ///     for event in session.stream_execute(cell_id):
-    ///         if event.event_type == "output":
-    ///             print(event.output.text)  # Process output immediately
-    ///     ```
     ///
     /// Args:
     ///     cell_id: The cell ID to execute.
@@ -1128,10 +573,8 @@ impl Session {
                 .as_ref()
                 .ok_or_else(|| to_py_err("Not connected"))?;
 
-            // Confirm the daemon has merged our latest changes before executing.
             handle.confirm_sync().await.map_err(to_py_err)?;
 
-            // Queue the cell for execution
             let response = handle
                 .send_request(NotebookRequest::ExecuteCell {
                     cell_id: cell_id.clone(),
@@ -1145,7 +588,7 @@ impl Session {
                 other => return Err(to_py_err(format!("Unexpected response: {:?}", other))),
             }
 
-            // Get a resubscribed broadcast receiver for this stream
+            // Resubscribe for this stream — needs direct state access
             let stream_broadcast_rx = state
                 .broadcast_rx
                 .as_ref()
@@ -1157,7 +600,6 @@ impl Session {
 
             drop(state);
 
-            // Return the sync iterator
             ExecutionEventIterator::new(
                 stream_broadcast_rx,
                 cell_id,
@@ -1169,37 +611,20 @@ impl Session {
         })
     }
 
-    /// Subscribe to notebook broadcast events independently of execution.
+    /// Subscribe to execution events for specific cells or event types.
     ///
-    /// Returns an iterator that yields all broadcast events from the
-    /// notebook, optionally filtered by cell IDs and event types. This
-    /// enables reactive patterns for agents that want to respond to any
-    /// document activity (including executions from other clients).
-    ///
-    /// Example:
-    ///     ```python
-    ///     # Subscribe to all events
-    ///     for event in session.subscribe():
-    ///         print(f"Got: {event.event_type}")
-    ///
-    ///     # Subscribe with filters
-    ///     for event in session.subscribe(event_types=["output", "done"]):
-    ///         if event.event_type == "output":
-    ///             print(event.output.text)
-    ///     ```
+    /// Returns a sync iterator subscription that yields events as they arrive.
     ///
     /// Args:
-    ///     cell_ids: Optional list of cell IDs to filter events.
-    ///     event_types: Optional list of event types to filter. Valid types:
-    ///         "execution_started", "output", "done", "error", "kernel_status".
-    ///
-    /// Returns an EventIteratorSubscription iterator.
+    ///     cell_ids: Optional list of cell IDs to filter (None = all cells).
+    ///     event_types: Optional list of event types to filter (None = all types).
     #[pyo3(signature = (cell_ids=None, event_types=None))]
     fn subscribe(
         &self,
         cell_ids: Option<Vec<String>>,
         event_types: Option<Vec<String>>,
     ) -> PyResult<EventIteratorSubscription> {
+        // Needs direct state access for resubscribe
         let state = self.runtime.block_on(self.state.lock());
 
         let broadcast_rx = state
@@ -1222,188 +647,17 @@ impl Session {
         )
     }
 
-    /// Convenience method: create a cell, execute it, and return the result.
-    ///
-    /// This is a shortcut that combines create_cell() and execute_cell().
-    /// The cell is written to the automerge document before execution,
-    /// so other connected clients will see it.
-    ///
-    /// Args:
-    ///     code: The code to execute.
-    ///     timeout_secs: Maximum time to wait for execution (default: 60).
-    ///
-    /// Returns:
-    ///     ExecutionResult with outputs, success status, and execution count.
-    ///
-    /// Raises:
-    ///     RuntimedError: If not connected, kernel not started, or timeout.
-    #[pyo3(signature = (code, timeout_secs=60.0))]
-    fn run(&self, code: &str, timeout_secs: f64) -> PyResult<ExecutionResult> {
-        // Create cell in document first
-        let cell_id = self.create_cell(code, "code", None)?;
+    // =========================================================================
+    // Environment sync
+    // =========================================================================
 
-        // Then execute by ID (daemon reads from doc)
-        self.execute_cell(&cell_id, timeout_secs)
-    }
-
-    /// Queue a cell for execution without waiting for the result.
-    ///
-    /// The daemon reads the cell's source from the automerge document and
-    /// queues it for execution. Use get_cell() to poll for results.
-    ///
-    /// Args:
-    ///     cell_id: The cell ID to execute.
-    ///
-    /// Raises:
-    ///     RuntimedError: If not connected or cell not found.
-    fn queue_cell(&self, cell_id: &str) -> PyResult<()> {
-        self.runtime.block_on(async {
-            let state = self.state.lock().await;
-
-            let handle = state
-                .handle
-                .as_ref()
-                .ok_or_else(|| to_py_err("Not connected"))?;
-
-            // Confirm the daemon has merged our latest changes before executing.
-            handle.confirm_sync().await.map_err(to_py_err)?;
-
-            // Queue cell execution (daemon reads source from automerge doc)
-            let response = handle
-                .send_request(NotebookRequest::ExecuteCell {
-                    cell_id: cell_id.to_string(),
-                })
-                .await
-                .map_err(to_py_err)?;
-
-            match response {
-                NotebookResponse::CellQueued { .. } => Ok(()),
-                NotebookResponse::Error { error } => Err(to_py_err(error)),
-                other => Err(to_py_err(format!("Unexpected response: {:?}", other))),
-            }
-        })
-    }
-
-    /// Interrupt the currently executing cell.
-    fn interrupt(&self) -> PyResult<()> {
-        self.runtime.block_on(async {
-            let state = self.state.lock().await;
-
-            let handle = state
-                .handle
-                .as_ref()
-                .ok_or_else(|| to_py_err("Not connected"))?;
-
-            let response = handle
-                .send_request(NotebookRequest::InterruptExecution {})
-                .await
-                .map_err(to_py_err)?;
-
-            match response {
-                NotebookResponse::InterruptSent {} => Ok(()),
-                NotebookResponse::NoKernel {} => Err(to_py_err("No kernel running")),
-                NotebookResponse::Error { error } => Err(to_py_err(error)),
-                other => Err(to_py_err(format!("Unexpected response: {:?}", other))),
-            }
-        })
-    }
-
-    /// Shutdown the kernel.
-    fn shutdown_kernel(&self) -> PyResult<()> {
-        self.runtime.block_on(async {
-            let mut state = self.state.lock().await;
-
-            let handle = state
-                .handle
-                .as_ref()
-                .ok_or_else(|| to_py_err("Not connected"))?;
-
-            let response = handle
-                .send_request(NotebookRequest::ShutdownKernel {})
-                .await
-                .map_err(to_py_err)?;
-
-            match response {
-                NotebookResponse::KernelShuttingDown {} => {
-                    state.kernel_started = false;
-                    state.env_source = None;
-                    Ok(())
-                }
-                NotebookResponse::NoKernel {} => {
-                    state.kernel_started = false;
-                    state.env_source = None;
-                    Ok(())
-                }
-                NotebookResponse::Error { error } => Err(to_py_err(error)),
-                other => Err(to_py_err(format!("Unexpected response: {:?}", other))),
-            }
-        })
-    }
-
-    /// Restart the kernel.
-    ///
-    /// Shuts down the current kernel and starts a new one. This is useful after
-    /// modifying dependencies to apply the changes.
-    ///
-    /// The new kernel will use env_source="auto" to pick up any inline
-    /// dependencies from the notebook metadata.
-    ///
-    /// Args:
-    ///     wait_for_ready: If True (default), wait for kernel to be idle.
-    ///
-    /// Note: This currently does shutdown + start. A daemon-side RestartKernel
-    /// command would be cleaner but doesn't exist yet.
-    #[pyo3(signature = (wait_for_ready=true))]
-    fn restart_kernel(&self, wait_for_ready: bool) -> PyResult<()> {
-        // TODO: Consider adding NotebookRequest::RestartKernel to the daemon
-        // Shutdown existing kernel
-        self.shutdown_kernel()?;
-
-        // Start new kernel with auto env detection
-        self.start_kernel("python", "auto", None)?;
-
-        if wait_for_ready {
-            // Wait briefly for kernel to become ready
-            // The kernel reports idle status via broadcasts after startup
-            self.runtime.block_on(async {
-                let mut state = self.state.lock().await;
-                let broadcast_rx = state.broadcast_rx.as_mut();
-                if let Some(rx) = broadcast_rx {
-                    // Wait up to 30 seconds for kernel ready
-                    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
-                    while std::time::Instant::now() < deadline {
-                        match tokio::time::timeout(std::time::Duration::from_millis(100), rx.recv())
-                            .await
-                        {
-                            Ok(Some(NotebookBroadcast::KernelStatus { status, .. }))
-                                if status == "idle" =>
-                            {
-                                return Ok(());
-                            }
-                            Ok(Some(_)) => continue, // Other broadcasts, keep waiting
-                            Ok(None) => return Err(to_py_err("Broadcast channel closed")),
-                            Err(_) => continue, // Timeout, keep waiting
-                        }
-                    }
-                }
-                Ok(()) // Timeout waiting for ready, but kernel was launched
-            })
-        } else {
-            Ok(())
-        }
-    }
-
-    /// Sync environment with current metadata (hot-install new packages).
-    ///
-    /// This attempts to install new packages without restarting the kernel.
-    /// Only supported for UV inline dependencies with additions only.
-    ///
-    /// For removals, conda dependencies, or other cases, this will return
-    /// an error with needs_restart=True indicating a kernel restart is required.
+    /// Sync environment with current notebook metadata.
     ///
     /// Returns:
     ///     SyncEnvironmentResult with success status and installed packages.
     fn sync_environment(&self) -> PyResult<SyncEnvironmentResult> {
+        // sync_environment is complex — waits for follow-up broadcasts.
+        // Kept inline rather than in session_core due to broadcast polling.
         self.runtime.block_on(async {
             let state = self.state.lock().await;
 
@@ -1417,11 +671,11 @@ impl Session {
                 .await
                 .map_err(to_py_err)?;
 
-            drop(state); // Release lock before waiting for follow-up responses
+            drop(state);
 
             match response {
                 NotebookResponse::SyncEnvironmentStarted { packages } => {
-                    // Wait for completion
+                    // Wait for completion via broadcast
                     let mut state = self.state.lock().await;
                     let broadcast_rx = state.broadcast_rx.as_mut();
                     if let Some(rx) = broadcast_rx {
@@ -1447,7 +701,6 @@ impl Session {
                             }
                         }
                     }
-                    // Assume success if we got SyncEnvironmentStarted
                     Ok(SyncEnvironmentResult {
                         success: true,
                         synced_packages: packages,
@@ -1490,176 +743,32 @@ impl Session {
     }
 
     // =========================================================================
-    // Kernel Introspection (completion, history, queue state)
+    // Completion, history, queue
     // =========================================================================
 
-    /// Get code completions at a cursor position.
-    ///
-    /// The kernel provides completions based on the current code context,
-    /// including DataFrame columns, object methods, variable names, etc.
+    /// Get code completions at the given cursor position.
     ///
     /// Args:
-    ///     code: The code to complete.
-    ///     cursor_pos: Cursor position in the code (byte offset).
+    ///     code: The code buffer to complete in.
+    ///     cursor_pos: Cursor position (byte offset) in the code.
     ///
     /// Returns:
     ///     CompletionResult with items, cursor_start, and cursor_end.
-    ///
-    /// Raises:
-    ///     RuntimedError: If no kernel is running or request times out.
-    #[pyo3(signature = (code, cursor_pos))]
     fn complete(
         &self,
         code: String,
         cursor_pos: usize,
     ) -> PyResult<crate::output::CompletionResult> {
-        self.runtime.block_on(async {
-            let state = self.state.lock().await;
-
-            let handle = state
-                .handle
-                .as_ref()
-                .ok_or_else(|| to_py_err("Not connected"))?;
-
-            let response = handle
-                .send_request(NotebookRequest::Complete { code, cursor_pos })
-                .await
-                .map_err(to_py_err)?;
-
-            match response {
-                NotebookResponse::CompletionResult {
-                    items,
-                    cursor_start,
-                    cursor_end,
-                } => Ok(crate::output::CompletionResult {
-                    items: items
-                        .into_iter()
-                        .map(crate::output::CompletionItem::from_protocol)
-                        .collect(),
-                    cursor_start,
-                    cursor_end,
-                }),
-                NotebookResponse::NoKernel {} => Err(to_py_err("No kernel running")),
-                NotebookResponse::Error { error } => Err(to_py_err(error)),
-                other => Err(to_py_err(format!("Unexpected response: {:?}", other))),
-            }
-        })
+        self.runtime
+            .block_on(session_core::complete(&self.state, &code, cursor_pos))
     }
 
-    /// Get the current execution queue state.
-    ///
-    /// Returns which cell is currently executing (if any) and which cells
-    /// are queued for execution.
-    ///
-    /// Returns:
-    ///     QueueState with executing (cell_id or None) and queued (list of cell_ids).
-    fn get_queue_state(&self) -> PyResult<crate::output::QueueState> {
-        self.runtime.block_on(async {
-            let state = self.state.lock().await;
-
-            let handle = state
-                .handle
-                .as_ref()
-                .ok_or_else(|| to_py_err("Not connected"))?;
-
-            let response = handle
-                .send_request(NotebookRequest::GetQueueState {})
-                .await
-                .map_err(to_py_err)?;
-
-            match response {
-                NotebookResponse::QueueState { executing, queued } => {
-                    Ok(crate::output::QueueState { executing, queued })
-                }
-                NotebookResponse::Error { error } => Err(to_py_err(error)),
-                other => Err(to_py_err(format!("Unexpected response: {:?}", other))),
-            }
-        })
-    }
-
-    /// Clear outputs for a cell.
-    ///
-    /// Removes all outputs and resets the execution count. Useful before
-    /// re-executing a cell for a fresh run.
+    /// Get execution history from the kernel.
     ///
     /// Args:
-    ///     cell_id: The cell ID to clear outputs for.
-    fn clear_outputs(&self, cell_id: String) -> PyResult<()> {
-        self.runtime.block_on(async {
-            let state = self.state.lock().await;
-
-            let handle = state
-                .handle
-                .as_ref()
-                .ok_or_else(|| to_py_err("Not connected"))?;
-
-            let response = handle
-                .send_request(NotebookRequest::ClearOutputs { cell_id })
-                .await
-                .map_err(to_py_err)?;
-
-            match response {
-                NotebookResponse::OutputsCleared { .. } => Ok(()),
-                NotebookResponse::Error { error } => Err(to_py_err(error)),
-                other => Err(to_py_err(format!("Unexpected response: {:?}", other))),
-            }
-        })
-    }
-
-    /// Run all code cells in the notebook.
-    ///
-    /// Queues all code cells (in document order) for execution. The daemon
-    /// reads cell sources from the automerge document and executes them
-    /// sequentially.
-    ///
-    /// Returns:
-    ///     The number of cells queued for execution.
-    fn run_all_cells(&self) -> PyResult<usize> {
-        // Auto-start kernel if not running
-        {
-            let state = self.runtime.block_on(self.state.lock());
-            if !state.kernel_started {
-                drop(state);
-                self.start_kernel("python", "auto", None)?;
-            }
-        }
-
-        self.runtime.block_on(async {
-            let state = self.state.lock().await;
-
-            let handle = state
-                .handle
-                .as_ref()
-                .ok_or_else(|| to_py_err("Not connected"))?;
-
-            let response = handle
-                .send_request(NotebookRequest::RunAllCells {})
-                .await
-                .map_err(to_py_err)?;
-
-            match response {
-                NotebookResponse::AllCellsQueued { count } => Ok(count),
-                NotebookResponse::Error { error } => Err(to_py_err(error)),
-                other => Err(to_py_err(format!("Unexpected response: {:?}", other))),
-            }
-        })
-    }
-
-    /// Search the kernel's input history.
-    ///
-    /// Returns executed code from the kernel's history, optionally filtered
-    /// by a glob pattern.
-    ///
-    /// Args:
-    ///     pattern: Optional glob pattern to filter history (e.g., "*pandas*").
+    ///     pattern: Optional glob pattern to filter history entries.
     ///     n: Maximum number of entries to return (default: 100).
     ///     unique: If True, deduplicate entries (default: True).
-    ///
-    /// Returns:
-    ///     List of HistoryEntry objects with session, line, and source.
-    ///
-    /// Raises:
-    ///     RuntimedError: If no kernel is running or request times out.
     #[pyo3(signature = (pattern=None, n=100, unique=true))]
     fn get_history(
         &self,
@@ -1667,30 +776,29 @@ impl Session {
         n: i32,
         unique: bool,
     ) -> PyResult<Vec<crate::output::HistoryEntry>> {
-        self.runtime.block_on(async {
-            let state = self.state.lock().await;
-
-            let handle = state
-                .handle
-                .as_ref()
-                .ok_or_else(|| to_py_err("Not connected"))?;
-
-            let response = handle
-                .send_request(NotebookRequest::GetHistory { pattern, n, unique })
-                .await
-                .map_err(to_py_err)?;
-
-            match response {
-                NotebookResponse::HistoryResult { entries } => Ok(entries
-                    .into_iter()
-                    .map(crate::output::HistoryEntry::from_protocol)
-                    .collect()),
-                NotebookResponse::NoKernel {} => Err(to_py_err("No kernel running")),
-                NotebookResponse::Error { error } => Err(to_py_err(error)),
-                other => Err(to_py_err(format!("Unexpected response: {:?}", other))),
-            }
-        })
+        self.runtime.block_on(session_core::get_history(
+            &self.state,
+            pattern.as_deref(),
+            n,
+            unique,
+        ))
     }
+
+    /// Get the current execution queue state.
+    fn get_queue_state(&self) -> PyResult<crate::output::QueueState> {
+        self.runtime
+            .block_on(session_core::get_queue_state(&self.state))
+    }
+
+    /// Execute all code cells in document order. Returns number of cells queued.
+    fn run_all_cells(&self) -> PyResult<usize> {
+        self.runtime
+            .block_on(session_core::run_all_cells(&self.state, &self.notebook_id))
+    }
+
+    // =========================================================================
+    // Repr, context manager, close
+    // =========================================================================
 
     fn __repr__(&self) -> String {
         let state = self.runtime.block_on(self.state.lock());
@@ -1708,12 +816,6 @@ impl Session {
         slf
     }
 
-    /// Context manager exit.
-    ///
-    /// Does NOT shutdown the kernel - the daemon handles kernel lifecycle
-    /// based on peer count. When all peers disconnect, the daemon will
-    /// clean up the kernel. This prevents killing kernels that desktop
-    /// app users may still be using.
     #[pyo3(signature = (_exc_type=None, _exc_val=None, _exc_tb=None))]
     fn __exit__(
         &self,
@@ -1721,6 +823,10 @@ impl Session {
         _exc_val: Option<&Bound<'_, PyAny>>,
         _exc_tb: Option<&Bound<'_, PyAny>>,
     ) -> PyResult<bool> {
+        // Shutdown kernel if running
+        if self.runtime.block_on(self.state.lock()).kernel_started {
+            let _ = self.shutdown_kernel();
+        }
         Ok(false) // Don't suppress exceptions
     }
 
@@ -1732,148 +838,5 @@ impl Session {
     /// to stop the kernel.
     fn close(&self) -> PyResult<()> {
         Ok(())
-    }
-}
-
-impl Session {
-    /// Wait for execution to complete, then read outputs from the Automerge doc.
-    ///
-    /// Uses the broadcast stream only as a signal for when execution is done.
-    /// The Automerge document is the source of truth for cell outputs — this
-    /// sidesteps the Jupyter shell/iopub race condition entirely since the
-    /// daemon writes all outputs to the doc before signaling ExecutionDone.
-    async fn collect_outputs(
-        &self,
-        cell_id: &str,
-        blob_base_url: Option<String>,
-        blob_store_path: Option<PathBuf>,
-    ) -> PyResult<ExecutionResult> {
-        let mut kernel_error: Option<String> = None;
-
-        // Phase 1: Wait for ExecutionDone or KernelError signal via broadcast.
-        // We don't accumulate outputs here — the Automerge doc is the source of truth.
-        loop {
-            let mut state = self.state.lock().await;
-
-            let broadcast_rx = state
-                .broadcast_rx
-                .as_mut()
-                .ok_or_else(|| to_py_err("Not connected"))?;
-
-            let broadcast =
-                tokio::time::timeout(std::time::Duration::from_millis(100), broadcast_rx.recv())
-                    .await;
-
-            match broadcast {
-                Ok(Some(msg)) => {
-                    drop(state);
-
-                    match msg {
-                        NotebookBroadcast::ExecutionDone {
-                            cell_id: msg_cell_id,
-                        } => {
-                            if msg_cell_id == cell_id {
-                                log::debug!("[session] ExecutionDone received for {}", cell_id);
-                                break;
-                            }
-                        }
-                        NotebookBroadcast::KernelError { error } => {
-                            log::debug!("[session] KernelError: {}", error);
-                            kernel_error = Some(error);
-                            break;
-                        }
-                        _ => {
-                            // Ignore all other broadcasts — doc has the data
-                        }
-                    }
-                }
-                Ok(None) => {
-                    return Err(to_py_err("Broadcast channel closed"));
-                }
-                Err(_) => {
-                    // Poll timeout — keep waiting for signal
-                }
-            }
-        }
-
-        // KernelError means the kernel/daemon died — return immediately
-        // without trying to read from the doc (handle may be gone).
-        if let Some(error) = kernel_error {
-            return Ok(ExecutionResult {
-                cell_id: cell_id.to_string(),
-                outputs: vec![Output::error("KernelError", &error, vec![])],
-                success: false,
-                execution_count: None,
-            });
-        }
-
-        // Phase 2: Read canonical cell state from the Automerge doc.
-        // The daemon writes outputs to the doc as they arrive from the kernel,
-        // but ExecutionDone can arrive via broadcast before the final Automerge
-        // sync frame. A confirm_sync round-trip ensures our local doc replica
-        // has all the outputs before we read.
-        let (snapshot, blob_base_url, blob_store_path) = {
-            let state = self.state.lock().await;
-            let handle = state
-                .handle
-                .as_ref()
-                .ok_or_else(|| to_py_err("Not connected"))?;
-
-            handle.confirm_sync().await.map_err(to_py_err)?;
-
-            let cells = handle.get_cells();
-            let snapshot = cells.into_iter().find(|c| c.id == cell_id).ok_or_else(|| {
-                to_py_err(format!(
-                    "Cell not found in doc after execution: {}",
-                    cell_id
-                ))
-            })?;
-
-            (snapshot, blob_base_url, blob_store_path)
-        }; // state lock dropped before async I/O
-
-        let execution_count = snapshot.execution_count.parse::<i64>().ok();
-
-        // Resolve outputs from doc snapshot (blob hashes → Output objects)
-        let outputs = output_resolver::resolve_cell_outputs(
-            &snapshot.outputs,
-            &blob_base_url,
-            &blob_store_path,
-        )
-        .await;
-
-        let success = !outputs.iter().any(|o| o.output_type == "error");
-
-        Ok(ExecutionResult {
-            cell_id: cell_id.to_string(),
-            outputs,
-            success,
-            execution_count,
-        })
-    }
-}
-
-// =========================================================================
-// Internal helper methods (not exposed to Python)
-// =========================================================================
-
-impl Session {
-    /// Get the current notebook metadata snapshot.
-    fn get_notebook_metadata(&self) -> PyResult<NotebookMetadataSnapshot> {
-        self.connect()?;
-        let state = self.state.blocking_lock();
-        let handle = state
-            .handle
-            .as_ref()
-            .ok_or_else(|| to_py_err("Not connected"))?;
-
-        Ok(handle.get_notebook_metadata().unwrap_or_default())
-    }
-
-    /// Set the notebook metadata snapshot.
-    fn set_notebook_metadata(&self, snapshot: &NotebookMetadataSnapshot) -> PyResult<()> {
-        let json_str = serde_json::to_string(snapshot)
-            .map_err(|e| to_py_err(format!("Failed to serialize metadata: {}", e)))?;
-        self.set_metadata("notebook_metadata", &json_str)
     }
 }

--- a/crates/runtimed-py/src/session.rs
+++ b/crates/runtimed-py/src/session.rs
@@ -144,6 +144,23 @@ impl Session {
         working_dir: Option<&str>,
         peer_label: Option<String>,
     ) -> PyResult<Self> {
+        // Validate working_dir if provided
+        if let Some(wd) = working_dir {
+            let path = std::path::Path::new(wd);
+            if !path.exists() {
+                return Err(pyo3::exceptions::PyFileNotFoundError::new_err(format!(
+                    "working_dir does not exist: {}",
+                    wd
+                )));
+            }
+            if !path.is_dir() {
+                return Err(pyo3::exceptions::PyNotADirectoryError::new_err(format!(
+                    "working_dir is not a directory: {}",
+                    wd
+                )));
+            }
+        }
+
         let rt = Runtime::new().map_err(to_py_err)?;
         let socket_path = get_socket_path();
         let working_dir_buf = working_dir.map(PathBuf::from);

--- a/crates/runtimed-py/src/session.rs
+++ b/crates/runtimed-py/src/session.rs
@@ -362,6 +362,7 @@ impl Session {
 
     /// Get a notebook metadata key.
     fn get_metadata(&self, key: &str) -> PyResult<Option<String>> {
+        self.connect()?;
         self.runtime
             .block_on(session_core::get_metadata(&self.state, key))
     }
@@ -840,11 +841,7 @@ impl Session {
         _exc_val: Option<&Bound<'_, PyAny>>,
         _exc_tb: Option<&Bound<'_, PyAny>>,
     ) -> PyResult<bool> {
-        // Shutdown kernel if running
-        if self.runtime.block_on(self.state.lock()).kernel_started {
-            let _ = self.shutdown_kernel();
-        }
-        Ok(false) // Don't suppress exceptions
+        Ok(false)
     }
 
     /// Close the session.

--- a/crates/runtimed-py/src/session_core.rs
+++ b/crates/runtimed-py/src/session_core.rs
@@ -1,0 +1,1229 @@
+//! Shared async core for Session and AsyncSession.
+//!
+//! All business logic lives here as free async functions operating on
+//! `Arc<Mutex<SessionState>>`. The sync `Session` calls these via
+//! `runtime.block_on()`, and `AsyncSession` calls them via
+//! `future_into_py()`. This eliminates the duplication that previously
+//! existed between session.rs and async_session.rs.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+use runtimed::notebook_sync_client::{
+    NotebookBroadcastReceiver, NotebookSyncClient, NotebookSyncHandle, NotebookSyncReceiver,
+};
+use runtimed::protocol::{NotebookBroadcast, NotebookRequest, NotebookResponse};
+
+use notebook_doc::metadata::NotebookMetadataSnapshot;
+
+use crate::daemon_paths::get_socket_path;
+use crate::error::to_py_err;
+use crate::output::{
+    Cell, CompletionItem, CompletionResult, ExecutionResult, HistoryEntry, NotebookConnectionInfo,
+    Output, QueueState, SyncEnvironmentResult,
+};
+use crate::output_resolver;
+
+use pyo3::prelude::*;
+
+// =========================================================================
+// Shared state
+// =========================================================================
+
+/// Internal state shared between Session and AsyncSession.
+///
+/// Both wrappers hold `Arc<Mutex<SessionState>>` and delegate all
+/// async operations to the free functions in this module.
+pub(crate) struct SessionState {
+    pub handle: Option<NotebookSyncHandle>,
+    /// Keep the sync receiver alive so the sync task doesn't exit
+    #[allow(dead_code)]
+    pub sync_rx: Option<NotebookSyncReceiver>,
+    pub broadcast_rx: Option<NotebookBroadcastReceiver>,
+    pub kernel_started: bool,
+    pub env_source: Option<String>,
+    /// Base URL for blob server (for resolving blob hashes)
+    pub blob_base_url: Option<String>,
+    /// Path to blob store directory (fallback for direct disk access)
+    pub blob_store_path: Option<PathBuf>,
+    /// Connection info from daemon (for open_notebook/create_notebook)
+    pub connection_info: Option<NotebookConnectionInfo>,
+    /// Notebook path (for project file detection during kernel launch)
+    pub notebook_path: Option<String>,
+}
+
+impl SessionState {
+    pub fn new() -> Self {
+        Self {
+            handle: None,
+            sync_rx: None,
+            broadcast_rx: None,
+            kernel_started: false,
+            env_source: None,
+            blob_base_url: None,
+            blob_store_path: None,
+            connection_info: None,
+            notebook_path: None,
+        }
+    }
+}
+
+// =========================================================================
+// Connection
+// =========================================================================
+
+/// Connect to the daemon if not already connected.
+///
+/// Populates the state with handle, sync_rx, broadcast_rx, and blob paths.
+pub(crate) async fn connect(state: &Arc<Mutex<SessionState>>, notebook_id: &str) -> PyResult<()> {
+    let mut st = state.lock().await;
+    if st.handle.is_some() {
+        return Ok(());
+    }
+
+    let socket_path = get_socket_path();
+
+    let (handle, sync_rx, broadcast_rx, _cells, _notebook_path) =
+        NotebookSyncClient::connect_split(socket_path.clone(), notebook_id.to_string())
+            .await
+            .map_err(to_py_err)?;
+
+    // Resolve blob paths from daemon info
+    let (blob_base_url, blob_store_path) = resolve_blob_paths(&socket_path).await;
+
+    st.handle = Some(handle);
+    st.sync_rx = Some(sync_rx);
+    st.broadcast_rx = Some(broadcast_rx);
+    st.blob_base_url = blob_base_url;
+    st.blob_store_path = blob_store_path;
+
+    Ok(())
+}
+
+/// Connect and open an existing notebook file.
+///
+/// Returns (notebook_id, populated SessionState, NotebookConnectionInfo).
+pub(crate) async fn connect_open(
+    socket_path: PathBuf,
+    path: &str,
+) -> PyResult<(String, SessionState, NotebookConnectionInfo)> {
+    let (handle, sync_rx, broadcast_rx, _cells, _metadata, info) =
+        NotebookSyncClient::connect_open_split(
+            socket_path.clone(),
+            PathBuf::from(path),
+            None, // pipe_channel
+        )
+        .await
+        .map_err(to_py_err)?;
+
+    if let Some(ref error) = info.error {
+        return Err(to_py_err(error));
+    }
+
+    let notebook_id = info.notebook_id.clone();
+    let (blob_base_url, blob_store_path) = resolve_blob_paths(&socket_path).await;
+    let connection_info = NotebookConnectionInfo::from_protocol(info);
+
+    let state = SessionState {
+        handle: Some(handle),
+        sync_rx: Some(sync_rx),
+        broadcast_rx: Some(broadcast_rx),
+        kernel_started: false,
+        env_source: None,
+        blob_base_url,
+        blob_store_path,
+        connection_info: Some(connection_info.clone()),
+        notebook_path: Some(path.to_string()),
+    };
+
+    Ok((notebook_id, state, connection_info))
+}
+
+/// Connect and create a new notebook.
+///
+/// Returns (notebook_id, populated SessionState, NotebookConnectionInfo).
+pub(crate) async fn connect_create(
+    socket_path: PathBuf,
+    runtime: &str,
+    working_dir: Option<PathBuf>,
+) -> PyResult<(String, SessionState, NotebookConnectionInfo)> {
+    let (handle, sync_rx, broadcast_rx, _cells, _metadata, info) =
+        NotebookSyncClient::connect_create_split(
+            socket_path.clone(),
+            runtime.to_string(),
+            working_dir.clone(),
+            None, // pipe_channel
+            None, // initial_metadata
+        )
+        .await
+        .map_err(to_py_err)?;
+
+    if let Some(ref error) = info.error {
+        return Err(to_py_err(error));
+    }
+
+    let notebook_id = info.notebook_id.clone();
+    let (blob_base_url, blob_store_path) = resolve_blob_paths(&socket_path).await;
+    let connection_info = NotebookConnectionInfo::from_protocol(info);
+
+    let state = SessionState {
+        handle: Some(handle),
+        sync_rx: Some(sync_rx),
+        broadcast_rx: Some(broadcast_rx),
+        kernel_started: false,
+        env_source: None,
+        blob_base_url,
+        blob_store_path,
+        connection_info: Some(connection_info.clone()),
+        notebook_path: working_dir.map(|p| p.to_string_lossy().to_string()),
+    };
+
+    Ok((notebook_id, state, connection_info))
+}
+
+// =========================================================================
+// Kernel lifecycle
+// =========================================================================
+
+/// Start a kernel in the daemon.
+pub(crate) async fn start_kernel(
+    state: &Arc<Mutex<SessionState>>,
+    kernel_type: &str,
+    env_source: &str,
+    notebook_path: Option<&str>,
+) -> PyResult<()> {
+    let mut st = state.lock().await;
+
+    let handle = st
+        .handle
+        .as_ref()
+        .ok_or_else(|| to_py_err("Not connected"))?;
+
+    // Resolve notebook path: explicit arg > stored state > None
+    let resolved_path = notebook_path
+        .map(|p| p.to_string())
+        .or_else(|| st.notebook_path.clone());
+
+    let response = handle
+        .send_request(NotebookRequest::LaunchKernel {
+            kernel_type: kernel_type.to_string(),
+            env_source: env_source.to_string(),
+            notebook_path: resolved_path,
+        })
+        .await
+        .map_err(to_py_err)?;
+
+    match response {
+        NotebookResponse::KernelLaunched {
+            env_source: actual_env,
+            ..
+        } => {
+            st.kernel_started = true;
+            st.env_source = Some(actual_env);
+            Ok(())
+        }
+        NotebookResponse::KernelAlreadyRunning {
+            env_source: actual_env,
+            ..
+        } => {
+            st.kernel_started = true;
+            st.env_source = Some(actual_env);
+            Ok(())
+        }
+        NotebookResponse::Error { error } => Err(to_py_err(error)),
+        other => Err(to_py_err(format!("Unexpected response: {:?}", other))),
+    }
+}
+
+/// Shutdown the kernel.
+pub(crate) async fn shutdown_kernel(state: &Arc<Mutex<SessionState>>) -> PyResult<()> {
+    let mut st = state.lock().await;
+
+    let handle = st
+        .handle
+        .as_ref()
+        .ok_or_else(|| to_py_err("Not connected"))?;
+
+    let response = handle
+        .send_request(NotebookRequest::ShutdownKernel {})
+        .await
+        .map_err(to_py_err)?;
+
+    match response {
+        NotebookResponse::KernelShuttingDown {} | NotebookResponse::NoKernel {} => {
+            st.kernel_started = false;
+            st.env_source = None;
+            Ok(())
+        }
+        NotebookResponse::Error { error } => Err(to_py_err(error)),
+        other => Err(to_py_err(format!("Unexpected response: {:?}", other))),
+    }
+}
+
+/// Restart the kernel with auto environment detection.
+pub(crate) async fn restart_kernel(
+    state: &Arc<Mutex<SessionState>>,
+    wait_for_ready: bool,
+) -> PyResult<()> {
+    // Shutdown
+    {
+        let mut st = state.lock().await;
+        let handle = st
+            .handle
+            .as_ref()
+            .ok_or_else(|| to_py_err("Not connected"))?;
+
+        let response = handle
+            .send_request(NotebookRequest::ShutdownKernel {})
+            .await
+            .map_err(to_py_err)?;
+
+        match response {
+            NotebookResponse::KernelShuttingDown {} | NotebookResponse::NoKernel {} => {
+                st.kernel_started = false;
+                st.env_source = None;
+            }
+            NotebookResponse::Error { error } => return Err(to_py_err(error)),
+            _ => {}
+        }
+    }
+
+    // Start with auto env detection, passing stored notebook_path
+    {
+        let mut st = state.lock().await;
+        let handle = st
+            .handle
+            .as_ref()
+            .ok_or_else(|| to_py_err("Not connected"))?;
+
+        let resolved_path = st.notebook_path.clone();
+
+        let response = handle
+            .send_request(NotebookRequest::LaunchKernel {
+                kernel_type: "python".to_string(),
+                env_source: "auto".to_string(),
+                notebook_path: resolved_path,
+            })
+            .await
+            .map_err(to_py_err)?;
+
+        match response {
+            NotebookResponse::KernelLaunched {
+                env_source: actual_env,
+                ..
+            }
+            | NotebookResponse::KernelAlreadyRunning {
+                env_source: actual_env,
+                ..
+            } => {
+                st.kernel_started = true;
+                st.env_source = Some(actual_env);
+            }
+            NotebookResponse::Error { error } => return Err(to_py_err(error)),
+            other => return Err(to_py_err(format!("Unexpected response: {:?}", other))),
+        }
+    }
+
+    // Wait for kernel ready
+    if wait_for_ready {
+        let mut st = state.lock().await;
+        if let Some(rx) = st.broadcast_rx.as_mut() {
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+            while std::time::Instant::now() < deadline {
+                match tokio::time::timeout(std::time::Duration::from_millis(100), rx.recv()).await {
+                    Ok(Some(NotebookBroadcast::KernelStatus { status, .. }))
+                        if status == "idle" =>
+                    {
+                        return Ok(());
+                    }
+                    Ok(Some(_)) => continue,
+                    Ok(None) => return Err(to_py_err("Broadcast channel closed")),
+                    Err(_) => continue,
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Interrupt the currently executing cell.
+pub(crate) async fn interrupt(state: &Arc<Mutex<SessionState>>) -> PyResult<()> {
+    let st = state.lock().await;
+
+    let handle = st
+        .handle
+        .as_ref()
+        .ok_or_else(|| to_py_err("Not connected"))?;
+
+    let response = handle
+        .send_request(NotebookRequest::InterruptExecution {})
+        .await
+        .map_err(to_py_err)?;
+
+    match response {
+        NotebookResponse::InterruptSent {} => Ok(()),
+        NotebookResponse::NoKernel {} => Err(to_py_err("No kernel running")),
+        NotebookResponse::Error { error } => Err(to_py_err(error)),
+        other => Err(to_py_err(format!("Unexpected response: {:?}", other))),
+    }
+}
+
+// =========================================================================
+// Cell operations
+// =========================================================================
+
+/// Create a new cell with source (atomic operation).
+pub(crate) async fn create_cell(
+    state: &Arc<Mutex<SessionState>>,
+    source: &str,
+    cell_type: &str,
+    index: Option<usize>,
+) -> PyResult<String> {
+    let cell_id = format!("cell-{}", uuid::Uuid::new_v4());
+
+    let st = state.lock().await;
+    let handle = st
+        .handle
+        .as_ref()
+        .ok_or_else(|| to_py_err("Not connected"))?;
+
+    let cells = handle.get_cells();
+    let insert_index = index.unwrap_or(cells.len());
+
+    handle
+        .add_cell_with_source(insert_index, &cell_id, cell_type, source)
+        .await
+        .map_err(to_py_err)?;
+
+    Ok(cell_id)
+}
+
+/// Update a cell's source.
+pub(crate) async fn set_source(
+    state: &Arc<Mutex<SessionState>>,
+    cell_id: &str,
+    source: &str,
+) -> PyResult<()> {
+    let st = state.lock().await;
+    let handle = st
+        .handle
+        .as_ref()
+        .ok_or_else(|| to_py_err("Not connected"))?;
+
+    handle
+        .update_source(cell_id, source)
+        .await
+        .map_err(to_py_err)
+}
+
+/// Append text to a cell's source.
+pub(crate) async fn append_source(
+    state: &Arc<Mutex<SessionState>>,
+    cell_id: &str,
+    text: &str,
+) -> PyResult<()> {
+    let st = state.lock().await;
+    let handle = st
+        .handle
+        .as_ref()
+        .ok_or_else(|| to_py_err("Not connected"))?;
+
+    handle.append_source(cell_id, text).await.map_err(to_py_err)
+}
+
+/// Get a single cell by ID, with resolved outputs.
+pub(crate) async fn get_cell(state: &Arc<Mutex<SessionState>>, cell_id: &str) -> PyResult<Cell> {
+    let (snapshot, blob_base_url, blob_store_path) = {
+        let st = state.lock().await;
+        let handle = st
+            .handle
+            .as_ref()
+            .ok_or_else(|| to_py_err("Not connected"))?;
+
+        let blob_base_url = st.blob_base_url.clone();
+        let blob_store_path = st.blob_store_path.clone();
+
+        let cells = handle.get_cells();
+        let snapshot = cells
+            .into_iter()
+            .find(|c| c.id == cell_id)
+            .ok_or_else(|| to_py_err(format!("Cell not found: {}", cell_id)))?;
+
+        (snapshot, blob_base_url, blob_store_path)
+    };
+
+    let outputs =
+        output_resolver::resolve_cell_outputs(&snapshot.outputs, &blob_base_url, &blob_store_path)
+            .await;
+
+    Ok(Cell::from_snapshot_with_outputs(snapshot, outputs))
+}
+
+/// Get all cells with resolved outputs.
+pub(crate) async fn get_cells(state: &Arc<Mutex<SessionState>>) -> PyResult<Vec<Cell>> {
+    let (snapshots, blob_base_url, blob_store_path) = {
+        let st = state.lock().await;
+        let handle = st
+            .handle
+            .as_ref()
+            .ok_or_else(|| to_py_err("Not connected"))?;
+
+        let blob_base_url = st.blob_base_url.clone();
+        let blob_store_path = st.blob_store_path.clone();
+        let snapshots = handle.get_cells();
+
+        (snapshots, blob_base_url, blob_store_path)
+    };
+
+    let mut cells = Vec::with_capacity(snapshots.len());
+    for snapshot in snapshots {
+        let outputs = output_resolver::resolve_cell_outputs(
+            &snapshot.outputs,
+            &blob_base_url,
+            &blob_store_path,
+        )
+        .await;
+        cells.push(Cell::from_snapshot_with_outputs(snapshot, outputs));
+    }
+
+    Ok(cells)
+}
+
+/// Delete a cell.
+pub(crate) async fn delete_cell(state: &Arc<Mutex<SessionState>>, cell_id: &str) -> PyResult<()> {
+    let st = state.lock().await;
+    let handle = st
+        .handle
+        .as_ref()
+        .ok_or_else(|| to_py_err("Not connected"))?;
+
+    handle.delete_cell(cell_id).await.map_err(to_py_err)
+}
+
+/// Move a cell to a new position.
+pub(crate) async fn move_cell(
+    state: &Arc<Mutex<SessionState>>,
+    cell_id: &str,
+    after_cell_id: Option<&str>,
+) -> PyResult<String> {
+    let st = state.lock().await;
+    let handle = st
+        .handle
+        .as_ref()
+        .ok_or_else(|| to_py_err("Not connected"))?;
+
+    handle
+        .move_cell(cell_id, after_cell_id)
+        .await
+        .map_err(to_py_err)?;
+
+    Ok(cell_id.to_string())
+}
+
+/// Clear a cell's outputs.
+pub(crate) async fn clear_outputs(state: &Arc<Mutex<SessionState>>, cell_id: &str) -> PyResult<()> {
+    let st = state.lock().await;
+    let handle = st
+        .handle
+        .as_ref()
+        .ok_or_else(|| to_py_err("Not connected"))?;
+
+    handle.clear_outputs(cell_id).await.map_err(to_py_err)
+}
+
+// =========================================================================
+// Execution
+// =========================================================================
+
+/// Execute a cell and return the result.
+///
+/// The entire lifecycle (confirm_sync, send_request, collect_outputs)
+/// is wrapped in a single timeout.
+pub(crate) async fn execute_cell(
+    state: &Arc<Mutex<SessionState>>,
+    notebook_id: &str,
+    cell_id: &str,
+    timeout_secs: f64,
+) -> PyResult<ExecutionResult> {
+    // Auto-start kernel if not running
+    {
+        let st = state.lock().await;
+        if !st.kernel_started {
+            drop(st);
+            ensure_kernel_started(state, notebook_id).await?;
+        }
+    }
+
+    let timeout = std::time::Duration::from_secs_f64(timeout_secs);
+    let result = tokio::time::timeout(timeout, async {
+        let st = state.lock().await;
+
+        let handle = st
+            .handle
+            .as_ref()
+            .ok_or_else(|| to_py_err("Not connected"))?;
+
+        let blob_base_url = st.blob_base_url.clone();
+        let blob_store_path = st.blob_store_path.clone();
+
+        handle.confirm_sync().await.map_err(to_py_err)?;
+
+        let response = handle
+            .send_request(NotebookRequest::ExecuteCell {
+                cell_id: cell_id.to_string(),
+            })
+            .await
+            .map_err(to_py_err)?;
+
+        match response {
+            NotebookResponse::CellQueued { .. } => {}
+            NotebookResponse::Error { error } => return Err(to_py_err(error)),
+            other => return Err(to_py_err(format!("Unexpected response: {:?}", other))),
+        }
+
+        drop(st);
+
+        collect_outputs(state, cell_id, blob_base_url, blob_store_path).await
+    })
+    .await;
+
+    match result {
+        Ok(Ok(exec_result)) => Ok(exec_result),
+        Ok(Err(e)) => Err(e),
+        Err(_) => Err(to_py_err(format!(
+            "Execution timed out after {} seconds",
+            timeout_secs
+        ))),
+    }
+}
+
+/// Create a cell and execute it (convenience wrapper).
+pub(crate) async fn run(
+    state: &Arc<Mutex<SessionState>>,
+    notebook_id: &str,
+    code: &str,
+    timeout_secs: f64,
+) -> PyResult<ExecutionResult> {
+    let cell_id = create_cell(state, code, "code", None).await?;
+    execute_cell(state, notebook_id, &cell_id, timeout_secs).await
+}
+
+/// Queue a cell for execution without waiting for the result.
+pub(crate) async fn queue_cell(state: &Arc<Mutex<SessionState>>, cell_id: &str) -> PyResult<()> {
+    let st = state.lock().await;
+
+    let handle = st
+        .handle
+        .as_ref()
+        .ok_or_else(|| to_py_err("Not connected"))?;
+
+    handle.confirm_sync().await.map_err(to_py_err)?;
+
+    let response = handle
+        .send_request(NotebookRequest::ExecuteCell {
+            cell_id: cell_id.to_string(),
+        })
+        .await
+        .map_err(to_py_err)?;
+
+    match response {
+        NotebookResponse::CellQueued { .. } => Ok(()),
+        NotebookResponse::Error { error } => Err(to_py_err(error)),
+        other => Err(to_py_err(format!("Unexpected response: {:?}", other))),
+    }
+}
+
+/// Wait for execution to complete, then read outputs from the Automerge doc.
+///
+/// Uses the broadcast stream only as a signal for when execution is done.
+/// The Automerge document is the source of truth for cell outputs.
+pub(crate) async fn collect_outputs(
+    state: &Arc<Mutex<SessionState>>,
+    cell_id: &str,
+    blob_base_url: Option<String>,
+    blob_store_path: Option<PathBuf>,
+) -> PyResult<ExecutionResult> {
+    let mut kernel_error: Option<String> = None;
+
+    // Phase 1: Wait for ExecutionDone or KernelError signal via broadcast.
+    loop {
+        let mut st = state.lock().await;
+
+        let broadcast_rx = st
+            .broadcast_rx
+            .as_mut()
+            .ok_or_else(|| to_py_err("Not connected"))?;
+
+        let broadcast =
+            tokio::time::timeout(std::time::Duration::from_millis(100), broadcast_rx.recv()).await;
+
+        match broadcast {
+            Ok(Some(msg)) => {
+                drop(st);
+
+                match msg {
+                    NotebookBroadcast::ExecutionDone {
+                        cell_id: msg_cell_id,
+                    } => {
+                        if msg_cell_id == cell_id {
+                            log::debug!("[session_core] ExecutionDone received for {}", cell_id);
+                            break;
+                        }
+                    }
+                    NotebookBroadcast::KernelError { error } => {
+                        log::debug!("[session_core] KernelError: {}", error);
+                        kernel_error = Some(error);
+                        break;
+                    }
+                    _ => {
+                        // Ignore all other broadcasts — doc has the data
+                    }
+                }
+            }
+            Ok(None) => {
+                return Err(to_py_err("Broadcast channel closed"));
+            }
+            Err(_) => {
+                // Poll timeout — keep waiting for signal
+            }
+        }
+    }
+
+    // KernelError: return immediately without touching the doc
+    if let Some(error) = kernel_error {
+        return Ok(ExecutionResult {
+            cell_id: cell_id.to_string(),
+            outputs: vec![Output::error("KernelError", &error, vec![])],
+            success: false,
+            execution_count: None,
+        });
+    }
+
+    // Phase 2: Read canonical cell state from the Automerge doc.
+    // confirm_sync ensures our local replica has all outputs.
+    let (snapshot, blob_base_url, blob_store_path) = {
+        let st = state.lock().await;
+        let handle = st
+            .handle
+            .as_ref()
+            .ok_or_else(|| to_py_err("Not connected"))?;
+
+        handle.confirm_sync().await.map_err(to_py_err)?;
+
+        let cells = handle.get_cells();
+        let snapshot = cells.into_iter().find(|c| c.id == cell_id).ok_or_else(|| {
+            to_py_err(format!(
+                "Cell not found in doc after execution: {}",
+                cell_id
+            ))
+        })?;
+
+        (snapshot, blob_base_url, blob_store_path)
+    };
+
+    let execution_count = snapshot.execution_count.parse::<i64>().ok();
+
+    let outputs =
+        output_resolver::resolve_cell_outputs(&snapshot.outputs, &blob_base_url, &blob_store_path)
+            .await;
+
+    let success = !outputs.iter().any(|o| o.output_type == "error");
+
+    Ok(ExecutionResult {
+        cell_id: cell_id.to_string(),
+        outputs,
+        success,
+        execution_count,
+    })
+}
+
+/// Execute all code cells in order, returns the number of cells queued.
+pub(crate) async fn run_all_cells(
+    state: &Arc<Mutex<SessionState>>,
+    notebook_id: &str,
+) -> PyResult<usize> {
+    // Auto-start kernel
+    {
+        let st = state.lock().await;
+        if !st.kernel_started {
+            drop(st);
+            ensure_kernel_started(state, notebook_id).await?;
+        }
+    }
+
+    let st = state.lock().await;
+    let handle = st
+        .handle
+        .as_ref()
+        .ok_or_else(|| to_py_err("Not connected"))?;
+
+    let cells = handle.get_cells();
+    let code_cells: Vec<_> = cells
+        .iter()
+        .filter(|c| c.cell_type == "code" && !c.source.trim().is_empty())
+        .collect();
+
+    let count = code_cells.len();
+
+    for cell in code_cells {
+        handle.confirm_sync().await.map_err(to_py_err)?;
+
+        let response = handle
+            .send_request(NotebookRequest::ExecuteCell {
+                cell_id: cell.id.clone(),
+            })
+            .await
+            .map_err(to_py_err)?;
+
+        match response {
+            NotebookResponse::CellQueued { .. } => {}
+            NotebookResponse::Error { error } => return Err(to_py_err(error)),
+            other => return Err(to_py_err(format!("Unexpected response: {:?}", other))),
+        }
+    }
+
+    Ok(count)
+}
+
+// =========================================================================
+// Presence
+// =========================================================================
+
+/// Set cursor position for presence.
+pub(crate) async fn set_cursor(
+    state: &Arc<Mutex<SessionState>>,
+    peer_label: Option<&str>,
+    cell_id: &str,
+    line: u32,
+    column: u32,
+) -> PyResult<()> {
+    let data = notebook_doc::presence::encode_cursor_update_labeled(
+        "local",
+        peer_label,
+        &notebook_doc::presence::CursorPosition {
+            cell_id: cell_id.to_string(),
+            line,
+            column,
+        },
+    );
+    let st = state.lock().await;
+    let handle = st
+        .handle
+        .as_ref()
+        .ok_or_else(|| to_py_err("Not connected"))?;
+
+    handle.send_presence(data).await.map_err(to_py_err)
+}
+
+/// Set selection range for presence.
+pub(crate) async fn set_selection(
+    state: &Arc<Mutex<SessionState>>,
+    peer_label: Option<&str>,
+    cell_id: &str,
+    anchor_line: u32,
+    anchor_col: u32,
+    head_line: u32,
+    head_col: u32,
+) -> PyResult<()> {
+    let data = notebook_doc::presence::encode_selection_update_labeled(
+        "local",
+        peer_label,
+        &notebook_doc::presence::SelectionRange {
+            cell_id: cell_id.to_string(),
+            anchor_line,
+            anchor_col,
+            head_line,
+            head_col,
+        },
+    );
+    let st = state.lock().await;
+    let handle = st
+        .handle
+        .as_ref()
+        .ok_or_else(|| to_py_err("Not connected"))?;
+
+    handle.send_presence(data).await.map_err(to_py_err)
+}
+
+// =========================================================================
+// Notebook metadata
+// =========================================================================
+
+/// Set a notebook metadata key.
+pub(crate) async fn set_metadata(
+    state: &Arc<Mutex<SessionState>>,
+    key: &str,
+    value: &str,
+) -> PyResult<()> {
+    let st = state.lock().await;
+    let handle = st
+        .handle
+        .as_ref()
+        .ok_or_else(|| to_py_err("Not connected"))?;
+
+    handle.set_metadata(key, value).await.map_err(to_py_err)
+}
+
+/// Get a notebook metadata key.
+pub(crate) async fn get_metadata(
+    state: &Arc<Mutex<SessionState>>,
+    key: &str,
+) -> PyResult<Option<String>> {
+    let st = state.lock().await;
+    let handle = st
+        .handle
+        .as_ref()
+        .ok_or_else(|| to_py_err("Not connected"))?;
+
+    handle.get_metadata(key).await.map_err(to_py_err)
+}
+
+/// Save the notebook to disk.
+pub(crate) async fn save(state: &Arc<Mutex<SessionState>>, path: Option<&str>) -> PyResult<String> {
+    let st = state.lock().await;
+    let handle = st
+        .handle
+        .as_ref()
+        .ok_or_else(|| to_py_err("Not connected"))?;
+
+    let request = if let Some(p) = path {
+        NotebookRequest::SaveNotebook {
+            format_cells: false,
+            path: Some(p.to_string()),
+        }
+    } else {
+        NotebookRequest::SaveNotebook {
+            format_cells: false,
+            path: None,
+        }
+    };
+
+    let response = handle.send_request(request).await.map_err(to_py_err)?;
+
+    match response {
+        NotebookResponse::NotebookSaved { path: saved_path } => Ok(saved_path),
+        NotebookResponse::Error { error } => Err(to_py_err(error)),
+        other => Err(to_py_err(format!("Unexpected response: {:?}", other))),
+    }
+}
+
+// =========================================================================
+// Cell metadata
+// =========================================================================
+
+/// Get cell metadata as JSON string.
+pub(crate) async fn get_cell_metadata(
+    state: &Arc<Mutex<SessionState>>,
+    cell_id: &str,
+) -> PyResult<Option<String>> {
+    let st = state.lock().await;
+    let handle = st
+        .handle
+        .as_ref()
+        .ok_or_else(|| to_py_err("Not connected"))?;
+
+    let cells = handle.get_cells();
+    let cell = cells.into_iter().find(|c| c.id == cell_id);
+
+    match cell {
+        Some(c) => Ok(Some(
+            serde_json::to_string(&c.metadata).unwrap_or_else(|_| "{}".to_string()),
+        )),
+        None => Ok(None),
+    }
+}
+
+/// Set cell metadata from JSON string.
+pub(crate) async fn set_cell_metadata(
+    state: &Arc<Mutex<SessionState>>,
+    cell_id: &str,
+    metadata_json: &str,
+) -> PyResult<bool> {
+    let st = state.lock().await;
+    let handle = st
+        .handle
+        .as_ref()
+        .ok_or_else(|| to_py_err("Not connected"))?;
+
+    let metadata: serde_json::Value = serde_json::from_str(metadata_json)
+        .map_err(|e| to_py_err(format!("Invalid JSON: {}", e)))?;
+
+    handle
+        .set_cell_metadata(cell_id, &metadata)
+        .await
+        .map_err(to_py_err)?;
+
+    Ok(true)
+}
+
+/// Update cell metadata at a specific path.
+pub(crate) async fn update_cell_metadata_at(
+    state: &Arc<Mutex<SessionState>>,
+    cell_id: &str,
+    path: Vec<String>,
+    value_json: &str,
+) -> PyResult<bool> {
+    let st = state.lock().await;
+    let handle = st
+        .handle
+        .as_ref()
+        .ok_or_else(|| to_py_err("Not connected"))?;
+
+    let value: serde_json::Value =
+        serde_json::from_str(value_json).map_err(|e| to_py_err(format!("Invalid JSON: {}", e)))?;
+
+    let path_refs: Vec<&str> = path.iter().map(|s| s.as_str()).collect();
+
+    handle
+        .update_cell_metadata_at(cell_id, &path_refs, value)
+        .await
+        .map_err(to_py_err)?;
+
+    Ok(true)
+}
+
+// =========================================================================
+// Notebook-level metadata helpers (uv/conda dependencies)
+// =========================================================================
+
+/// Get the notebook metadata snapshot.
+pub(crate) async fn get_notebook_metadata(
+    state: &Arc<Mutex<SessionState>>,
+) -> PyResult<NotebookMetadataSnapshot> {
+    let st = state.lock().await;
+    let handle = st
+        .handle
+        .as_ref()
+        .ok_or_else(|| to_py_err("Not connected"))?;
+
+    let meta_json = handle.get_metadata("nteract").await.map_err(to_py_err)?;
+    let snapshot = if let Some(json_str) = meta_json {
+        serde_json::from_str(&json_str).unwrap_or_default()
+    } else {
+        NotebookMetadataSnapshot::default()
+    };
+
+    Ok(snapshot)
+}
+
+/// Set the notebook metadata snapshot.
+pub(crate) async fn set_notebook_metadata(
+    state: &Arc<Mutex<SessionState>>,
+    snapshot: &NotebookMetadataSnapshot,
+) -> PyResult<()> {
+    let st = state.lock().await;
+    let handle = st
+        .handle
+        .as_ref()
+        .ok_or_else(|| to_py_err("Not connected"))?;
+
+    let json_str =
+        serde_json::to_string(snapshot).map_err(|e| to_py_err(format!("Serialize: {}", e)))?;
+
+    handle
+        .set_metadata("nteract", &json_str)
+        .await
+        .map_err(to_py_err)
+}
+
+/// Sync environment with current metadata.
+pub(crate) async fn sync_environment(
+    state: &Arc<Mutex<SessionState>>,
+) -> PyResult<SyncEnvironmentResult> {
+    let st = state.lock().await;
+    let handle = st
+        .handle
+        .as_ref()
+        .ok_or_else(|| to_py_err("Not connected"))?;
+
+    let response = handle
+        .send_request(NotebookRequest::SyncEnvironment {})
+        .await
+        .map_err(to_py_err)?;
+
+    match response {
+        NotebookResponse::SyncEnvironmentStarted { packages } => Ok(SyncEnvironmentResult {
+            success: true,
+            synced_packages: packages,
+            error: None,
+            needs_restart: false,
+        }),
+        NotebookResponse::SyncEnvironmentComplete { synced_packages } => {
+            Ok(SyncEnvironmentResult {
+                success: true,
+                synced_packages,
+                error: None,
+                needs_restart: false,
+            })
+        }
+        NotebookResponse::SyncEnvironmentFailed {
+            error,
+            needs_restart,
+        } => Ok(SyncEnvironmentResult {
+            success: false,
+            synced_packages: vec![],
+            error: Some(error),
+            needs_restart,
+        }),
+        NotebookResponse::NoKernel {} => Ok(SyncEnvironmentResult {
+            success: false,
+            synced_packages: vec![],
+            error: Some("No kernel running".to_string()),
+            needs_restart: true,
+        }),
+        NotebookResponse::Error { error } => Ok(SyncEnvironmentResult {
+            success: false,
+            synced_packages: vec![],
+            error: Some(error),
+            needs_restart: true,
+        }),
+        other => Err(to_py_err(format!("Unexpected response: {:?}", other))),
+    }
+}
+
+// =========================================================================
+// Completion & History
+// =========================================================================
+
+/// Get code completions.
+pub(crate) async fn complete(
+    state: &Arc<Mutex<SessionState>>,
+    code: &str,
+    cursor_pos: usize,
+) -> PyResult<CompletionResult> {
+    let st = state.lock().await;
+    let handle = st
+        .handle
+        .as_ref()
+        .ok_or_else(|| to_py_err("Not connected"))?;
+
+    let response = handle
+        .send_request(NotebookRequest::Complete {
+            code: code.to_string(),
+            cursor_pos,
+        })
+        .await
+        .map_err(to_py_err)?;
+
+    match response {
+        NotebookResponse::CompletionResult {
+            items,
+            cursor_start,
+            cursor_end,
+        } => Ok(CompletionResult {
+            items: items
+                .into_iter()
+                .map(CompletionItem::from_protocol)
+                .collect(),
+            cursor_start,
+            cursor_end,
+        }),
+        NotebookResponse::NoKernel {} => Err(to_py_err("No kernel running")),
+        NotebookResponse::Error { error } => Err(to_py_err(error)),
+        other => Err(to_py_err(format!("Unexpected response: {:?}", other))),
+    }
+}
+
+/// Get execution history.
+pub(crate) async fn get_history(
+    state: &Arc<Mutex<SessionState>>,
+    pattern: Option<&str>,
+    n: i32,
+    unique: bool,
+) -> PyResult<Vec<HistoryEntry>> {
+    let st = state.lock().await;
+    let handle = st
+        .handle
+        .as_ref()
+        .ok_or_else(|| to_py_err("Not connected"))?;
+
+    let response = handle
+        .send_request(NotebookRequest::GetHistory {
+            pattern: pattern.map(|s| s.to_string()),
+            n: n as i32,
+            unique,
+        })
+        .await
+        .map_err(to_py_err)?;
+
+    match response {
+        NotebookResponse::HistoryResult { entries } => Ok(entries
+            .into_iter()
+            .map(HistoryEntry::from_protocol)
+            .collect()),
+        NotebookResponse::NoKernel {} => Err(to_py_err("No kernel running")),
+        NotebookResponse::Error { error } => Err(to_py_err(error)),
+        other => Err(to_py_err(format!("Unexpected response: {:?}", other))),
+    }
+}
+
+/// Get the execution queue state.
+pub(crate) async fn get_queue_state(state: &Arc<Mutex<SessionState>>) -> PyResult<QueueState> {
+    let st = state.lock().await;
+    let handle = st
+        .handle
+        .as_ref()
+        .ok_or_else(|| to_py_err("Not connected"))?;
+
+    let response = handle
+        .send_request(NotebookRequest::GetQueueState {})
+        .await
+        .map_err(to_py_err)?;
+
+    match response {
+        NotebookResponse::QueueState { executing, queued } => Ok(QueueState { executing, queued }),
+        NotebookResponse::Error { error } => Err(to_py_err(error)),
+        other => Err(to_py_err(format!("Unexpected response: {:?}", other))),
+    }
+}
+
+// =========================================================================
+// Internal helpers
+// =========================================================================
+
+/// Ensure a kernel is started, connecting first if needed.
+async fn ensure_kernel_started(
+    state: &Arc<Mutex<SessionState>>,
+    notebook_id: &str,
+) -> PyResult<()> {
+    // Connect if needed
+    {
+        let st = state.lock().await;
+        if st.handle.is_none() {
+            drop(st);
+            connect(state, notebook_id).await?;
+        }
+    }
+
+    start_kernel(state, "python", "auto", None).await
+}
+
+/// Resolve blob server URL and store path from daemon info.
+async fn resolve_blob_paths(socket_path: &PathBuf) -> (Option<String>, Option<PathBuf>) {
+    if let Some(parent) = socket_path.parent() {
+        let daemon_json = parent.join("daemon.json");
+        let base_url = if daemon_json.exists() {
+            tokio::fs::read_to_string(&daemon_json)
+                .await
+                .ok()
+                .and_then(|contents| serde_json::from_str::<serde_json::Value>(&contents).ok())
+                .and_then(|info| info.get("blob_port").and_then(|p| p.as_u64()))
+                .map(|port| format!("http://127.0.0.1:{}", port))
+        } else {
+            None
+        };
+
+        let store_path = parent.join("blobs");
+        let store_path = if store_path.exists() {
+            Some(store_path)
+        } else {
+            None
+        };
+
+        (base_url, store_path)
+    } else {
+        (None, None)
+    }
+}

--- a/crates/runtimed-py/src/session_core.rs
+++ b/crates/runtimed-py/src/session_core.rs
@@ -530,7 +530,18 @@ pub(crate) async fn clear_outputs(state: &Arc<Mutex<SessionState>>, cell_id: &st
         .as_ref()
         .ok_or_else(|| to_py_err("Not connected"))?;
 
-    handle.clear_outputs(cell_id).await.map_err(to_py_err)
+    let response = handle
+        .send_request(NotebookRequest::ClearOutputs {
+            cell_id: cell_id.to_string(),
+        })
+        .await
+        .map_err(to_py_err)?;
+
+    match response {
+        NotebookResponse::OutputsCleared { .. } => Ok(()),
+        NotebookResponse::Error { error } => Err(to_py_err(error)),
+        other => Err(to_py_err(format!("Unexpected response: {:?}", other))),
+    }
 }
 
 // =========================================================================
@@ -759,32 +770,21 @@ pub(crate) async fn run_all_cells(
         .as_ref()
         .ok_or_else(|| to_py_err("Not connected"))?;
 
-    let cells = handle.get_cells();
-    let code_cells: Vec<_> = cells
-        .iter()
-        .filter(|c| c.cell_type == "code" && !c.source.trim().is_empty())
-        .collect();
+    handle.confirm_sync().await.map_err(to_py_err)?;
 
-    let count = code_cells.len();
+    let response = handle
+        .send_request(NotebookRequest::RunAllCells {})
+        .await
+        .map_err(to_py_err)?;
 
-    for cell in code_cells {
-        handle.confirm_sync().await.map_err(to_py_err)?;
+    drop(st);
 
-        let response = handle
-            .send_request(NotebookRequest::ExecuteCell {
-                cell_id: cell.id.clone(),
-            })
-            .await
-            .map_err(to_py_err)?;
-
-        match response {
-            NotebookResponse::CellQueued { .. } => {}
-            NotebookResponse::Error { error } => return Err(to_py_err(error)),
-            other => return Err(to_py_err(format!("Unexpected response: {:?}", other))),
-        }
+    match response {
+        NotebookResponse::AllCellsQueued { count } => Ok(count),
+        NotebookResponse::NoKernel {} => Err(to_py_err("No kernel running")),
+        NotebookResponse::Error { error } => Err(to_py_err(error)),
+        other => Err(to_py_err(format!("Unexpected response: {:?}", other))),
     }
-
-    Ok(count)
 }
 
 // =========================================================================
@@ -929,7 +929,8 @@ pub(crate) async fn get_cell_metadata(
 
     match cell {
         Some(c) => Ok(Some(
-            serde_json::to_string(&c.metadata).unwrap_or_else(|_| "{}".to_string()),
+            serde_json::to_string(&c.metadata)
+                .map_err(|e| to_py_err(format!("Serialize: {}", e)))?,
         )),
         None => Ok(None),
     }
@@ -950,12 +951,12 @@ pub(crate) async fn set_cell_metadata(
     let metadata: serde_json::Value = serde_json::from_str(metadata_json)
         .map_err(|e| to_py_err(format!("Invalid JSON: {}", e)))?;
 
-    handle
+    let result = handle
         .set_cell_metadata(cell_id, &metadata)
         .await
         .map_err(to_py_err)?;
 
-    Ok(true)
+    Ok(result)
 }
 
 /// Update cell metadata at a specific path.
@@ -976,12 +977,12 @@ pub(crate) async fn update_cell_metadata_at(
 
     let path_refs: Vec<&str> = path.iter().map(|s| s.as_str()).collect();
 
-    handle
+    let result = handle
         .update_cell_metadata_at(cell_id, &path_refs, value)
         .await
         .map_err(to_py_err)?;
 
-    Ok(true)
+    Ok(result)
 }
 
 // =========================================================================
@@ -998,12 +999,7 @@ pub(crate) async fn get_notebook_metadata(
         .as_ref()
         .ok_or_else(|| to_py_err("Not connected"))?;
 
-    let meta_json = handle.get_metadata("nteract").await.map_err(to_py_err)?;
-    let snapshot = if let Some(json_str) = meta_json {
-        serde_json::from_str(&json_str).unwrap_or_default()
-    } else {
-        NotebookMetadataSnapshot::default()
-    };
+    let snapshot = handle.get_notebook_metadata().unwrap_or_default();
 
     Ok(snapshot)
 }
@@ -1023,12 +1019,17 @@ pub(crate) async fn set_notebook_metadata(
         serde_json::to_string(snapshot).map_err(|e| to_py_err(format!("Serialize: {}", e)))?;
 
     handle
-        .set_metadata("nteract", &json_str)
+        .set_metadata("notebook_metadata", &json_str)
         .await
         .map_err(to_py_err)
 }
 
 /// Sync environment with current metadata.
+///
+/// NOTE: This simplified version returns immediately on `SyncEnvironmentStarted`
+/// without waiting for completion. The real implementations that poll the broadcast
+/// stream for completion live inline in `session.rs` and `async_session.rs`.
+#[allow(dead_code)]
 pub(crate) async fn sync_environment(
     state: &Arc<Mutex<SessionState>>,
 ) -> PyResult<SyncEnvironmentResult> {


### PR DESCRIPTION
Extracts all shared async logic into `session_core.rs` and rewires both `Session` and `AsyncSession` as thin wrappers.

**Before**: 4175 lines across two files with fully duplicated logic
**After**: 3085 lines across three files with zero duplication (26% reduction)

| File | Before | After | Role |
|------|--------|-------|------|
| `session.rs` | 1879 | 842 | Thin `block_on` wrappers |
| `async_session.rs` | 2296 | 1014 | Thin `future_into_py` wrappers |
| `session_core.rs` | — | 1229 | All shared async logic |

### What changed

- `SessionState` and `AsyncSessionState` unified into one `SessionState` in `session_core.rs`
- All duplicated async logic (connect, start_kernel, execute_cell, collect_outputs, etc.) now lives once in `session_core.rs` as free async functions taking `&Arc<Mutex<SessionState>>`
- `Session` delegates via `runtime.block_on(session_core::method(...))`
- `AsyncSession` delegates via `future_into_py(py, async { session_core::method(...).await })`
- `stream_execute`, `subscribe`, and `sync_environment` remain inline in both wrappers — they need direct `broadcast_rx` access for streaming/polling patterns
- AsyncSession gains 6 cell metadata methods it was previously missing (`get_cell_metadata`, `set_cell_metadata`, `update_cell_metadata_at`, `set_cell_source_hidden`, `set_cell_outputs_hidden`, `set_cell_tags`)

### Motivation

Every bug fix in this area required identical changes to both files (#751, #755, #759, #760). Now there's one place to fix bugs.

_PR submitted by @rgbkrk's agent Quill, via Zed_