### PR TITLE
docs(notebook): clarify daemon recovery is user-initiated via retry

### DIFF
--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -2415,7 +2415,10 @@ async fn reconnect_to_daemon(
             let client = runtimed::client::PoolClient::default();
             for attempt in 1..=20 {
                 if client.ping().await.is_ok() {
-                    info!("[daemon-kernel] Daemon ready after {} ping attempts", attempt);
+                    info!(
+                        "[daemon-kernel] Daemon ready after {} ping attempts",
+                        attempt
+                    );
                     break;
                 }
                 if attempt < 20 {

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -2275,7 +2275,7 @@ fn is_daemon_dead_error(error: &str) -> bool {
 ///
 /// If the socket doesn't exist (daemon dead), this will attempt to restart the daemon
 /// using `ensure_daemon_via_sidecar()` before retrying the connection.
-/// In dev mode, returns a helpful error instead of auto-restarting.
+/// In dev mode, returns a helpful error instead of attempting recovery.
 ///
 /// Called by the frontend after receiving daemon:disconnected event.
 #[tauri::command]
@@ -2370,7 +2370,7 @@ async fn reconnect_to_daemon(
         Err(ref e) if is_daemon_dead_error(e) => {
             info!("[daemon-kernel] Daemon appears dead: {}", e);
 
-            // In dev mode, don't auto-restart - show helpful guidance
+            // In dev mode, don't attempt recovery - show helpful guidance
             if runtimed::is_dev_mode() {
                 reset_flag();
                 return Err(


### PR DESCRIPTION
## Summary

Updated comments in reconnect_to_daemon to reflect that daemon recovery is initiated by the user clicking the Retry button, not automatic background behavior. Changes terminology from 'auto-restart' to 'recovery' for clarity.

## Changes

- Line 2278: Updated docstring to clarify recovery only happens when user retries
- Line 2373: Updated inline comment to remove 'auto-restart' language

## Testing

* [ ] Verify comments read correctly in IDE
* [ ] Confirm terminology aligns with UI "Retry" button behavior
* [ ] No functional changes - comments only

_PR submitted by @rgbkrk's agent, Quill_