### PR TITLE
fix: reopen a notebook window from the dock

### DIFF
--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -721,7 +721,7 @@ async fn setup_sync_receivers(
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
-    use super::next_available_sample_path;
+    use super::{next_available_sample_path, reopen_action, ReopenAction};
     use tempfile::TempDir;
 
     #[test]
@@ -740,6 +740,21 @@ mod tests {
         let path = next_available_sample_path(temp_dir.path(), "example.ipynb");
 
         assert_eq!(path, temp_dir.path().join("example-2.ipynb"));
+    }
+
+    #[test]
+    fn reopen_action_restores_hidden_windows_before_spawning() {
+        assert_eq!(reopen_action(false, 1), Some(ReopenAction::RestoreWindow));
+    }
+
+    #[test]
+    fn reopen_action_spawns_when_all_windows_are_closed() {
+        assert_eq!(reopen_action(false, 0), Some(ReopenAction::SpawnNotebook));
+    }
+
+    #[test]
+    fn reopen_action_ignores_reopen_events_when_a_window_is_visible() {
+        assert_eq!(reopen_action(true, 1), None);
     }
 }
 
@@ -3054,6 +3069,24 @@ fn focused_window(app: &tauri::AppHandle) -> Option<tauri::WebviewWindow> {
         .find(|window| window.is_focused().ok() == Some(true))
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReopenAction {
+    RestoreWindow,
+    SpawnNotebook,
+}
+
+fn reopen_action(has_visible_windows: bool, open_window_count: usize) -> Option<ReopenAction> {
+    if has_visible_windows {
+        return None;
+    }
+
+    if open_window_count == 0 {
+        Some(ReopenAction::SpawnNotebook)
+    } else {
+        Some(ReopenAction::RestoreWindow)
+    }
+}
+
 fn window_menu_display_name(
     app: &tauri::AppHandle,
     registry: &WindowNotebookRegistry,
@@ -4234,6 +4267,56 @@ pub fn run(
                 } else if let Err(e) = open_notebook_window(app_handle, &registry_for_open, &path) {
                     log::error!("Failed to open notebook in new window: {}", e);
                 }
+            }
+        }
+
+        #[cfg(target_os = "macos")]
+        if let RunEvent::Reopen {
+            has_visible_windows,
+            ..
+        } = &event
+        {
+            match reopen_action(*has_visible_windows, app_handle.webview_windows().len()) {
+                Some(ReopenAction::RestoreWindow) => {
+                    let window = app_handle
+                        .get_webview_window("main")
+                        .or_else(|| app_handle.webview_windows().into_values().next());
+
+                    if let Some(window) = window {
+                        if let Err(error) = window.show() {
+                            warn!(
+                                "[app] Failed to show reopened window '{}': {}",
+                                window.label(),
+                                error
+                            );
+                        }
+                        if let Err(error) = window.unminimize() {
+                            warn!(
+                                "[app] Failed to unminimize reopened window '{}': {}",
+                                window.label(),
+                                error
+                            );
+                        }
+                        if let Err(error) = window.set_focus() {
+                            warn!(
+                                "[app] Failed to focus reopened window '{}': {}",
+                                window.label(),
+                                error
+                            );
+                        }
+                    }
+                }
+                Some(ReopenAction::SpawnNotebook) => {
+                    let runtime = settings::load_settings().default_runtime;
+                    if let Err(error) = spawn_new_notebook(app_handle, &registry_for_open, runtime)
+                    {
+                        warn!(
+                            "[app] Failed to create notebook window on reopen: {}",
+                            error
+                        );
+                    }
+                }
+                None => {}
             }
         }
     });

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -3069,12 +3069,14 @@ fn focused_window(app: &tauri::AppHandle) -> Option<tauri::WebviewWindow> {
         .find(|window| window.is_focused().ok() == Some(true))
 }
 
+#[cfg(any(target_os = "macos", test))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ReopenAction {
     RestoreWindow,
     SpawnNotebook,
 }
 
+#[cfg(any(target_os = "macos", test))]
 fn reopen_action(has_visible_windows: bool, open_window_count: usize) -> Option<ReopenAction> {
     if has_visible_windows {
         return None;


### PR DESCRIPTION
Closes #767

## Summary
- handle macOS `RunEvent::Reopen` so dock-icon clicks restore an existing hidden window or create a fresh notebook window
- centralize the reopen decision in a small helper to keep the lifecycle logic explicit
- add focused unit coverage for the reopen behavior

## Testing
- pnpm --dir apps/notebook build
- cargo test -p notebook reopen_action -- --nocapture

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: macOS-only lifecycle handling changes plus small pure-function helper and unit tests; main risk is unintended window focus/visibility behavior on reopen.
> 
> **Overview**
> Fixes macOS dock-icon *reopen* behavior by handling `RunEvent::Reopen` to either **restore an existing hidden/minimized window** (show/unminimize/focus) or **spawn a new notebook window** when none are open.
> 
> Adds a small `reopen_action` helper (and `ReopenAction` enum) to centralize the decision logic, along with unit tests covering the reopen cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 45142275b5d8b9ef51af1178eaf12a59fdc2897b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->