### PR TITLE
feat(notebook-doc): native Automerge metadata (no more JSON string blobs)

### DIFF
--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -1998,10 +1998,18 @@ pub fn get_cells_from_doc(doc: &AutoCommit) -> Vec<CellSnapshot> {
                 _ => vec![],
             };
 
-            // Read metadata (JSON string -> Value)
-            let metadata = read_str(doc, &cell_obj, "metadata")
-                .and_then(|s| serde_json::from_str(&s).ok())
-                .unwrap_or_else(|| serde_json::json!({}));
+            // Read metadata: try native Automerge Map first, fall back to legacy JSON string
+            let metadata = match doc.get(&cell_obj, "metadata").ok().flatten() {
+                Some((automerge::Value::Object(ObjType::Map), map_id)) => {
+                    read_map_as_json_from_doc(doc, &map_id)
+                }
+                _ => {
+                    // Legacy: metadata stored as JSON string
+                    read_str(doc, &cell_obj, "metadata")
+                        .and_then(|s| serde_json::from_str(&s).ok())
+                        .unwrap_or_else(|| serde_json::json!({}))
+                }
+            };
 
             // Read resolved asset map
             let resolved_assets = match doc.get(&cell_obj, "resolved_assets").ok().flatten() {

--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -172,19 +172,68 @@ impl NotebookDoc {
 
 impl NotebookDoc {
     /// Read the notebook metadata as a typed snapshot.
+    ///
+    /// Assembles from individual native Automerge keys (`"kernelspec"`,
+    /// `"language_info"`, `"runt"`). Falls back to the legacy bundled
+    /// `"notebook_metadata"` JSON string for migration.
     pub fn get_metadata_snapshot(&self) -> Option<metadata::NotebookMetadataSnapshot> {
+        // Try native keys first
+        let kernelspec = self
+            .get_metadata_value("kernelspec")
+            .and_then(|v| serde_json::from_value(v).ok());
+        let language_info = self
+            .get_metadata_value("language_info")
+            .and_then(|v| serde_json::from_value(v).ok());
+        let runt: Option<metadata::RuntMetadata> = self
+            .get_metadata_value("runt")
+            .and_then(|v| serde_json::from_value(v).ok());
+
+        // If we found at least one native key, assemble from them
+        if kernelspec.is_some() || language_info.is_some() || runt.is_some() {
+            return Some(metadata::NotebookMetadataSnapshot {
+                kernelspec,
+                language_info,
+                runt: runt.unwrap_or_default(),
+            });
+        }
+
+        // Fallback: legacy bundled JSON string (for untitled notebooks from old daemon)
         let json = self.get_metadata(metadata::NOTEBOOK_METADATA_KEY)?;
         serde_json::from_str(&json).ok()
     }
 
-    /// Write a typed metadata snapshot to the document.
+    /// Write a typed metadata snapshot to the document as native Automerge.
+    ///
+    /// Writes `"kernelspec"`, `"language_info"`, and `"runt"` as separate
+    /// native Automerge maps/lists. Also writes the legacy `"notebook_metadata"`
+    /// string key for backward compatibility during migration.
     pub fn set_metadata_snapshot(
         &mut self,
         snapshot: &metadata::NotebookMetadataSnapshot,
     ) -> Result<(), AutomergeError> {
+        // Write individual native keys
+        if let Some(ref ks) = snapshot.kernelspec {
+            let value = serde_json::to_value(ks).map_err(|e| {
+                AutomergeError::InvalidObjId(format!("serialize kernelspec: {}", e))
+            })?;
+            self.set_metadata_value("kernelspec", &value)?;
+        }
+        if let Some(ref li) = snapshot.language_info {
+            let value = serde_json::to_value(li).map_err(|e| {
+                AutomergeError::InvalidObjId(format!("serialize language_info: {}", e))
+            })?;
+            self.set_metadata_value("language_info", &value)?;
+        }
+        let runt_value = serde_json::to_value(&snapshot.runt)
+            .map_err(|e| AutomergeError::InvalidObjId(format!("serialize runt: {}", e)))?;
+        self.set_metadata_value("runt", &runt_value)?;
+
+        // Also write legacy bundled key for backward compat (remove in Phase 2)
         let json = serde_json::to_string(snapshot)
             .map_err(|e| AutomergeError::InvalidObjId(format!("serialize metadata: {}", e)))?;
-        self.set_metadata(metadata::NOTEBOOK_METADATA_KEY, &json)
+        self.set_metadata(metadata::NOTEBOOK_METADATA_KEY, &json)?;
+
+        Ok(())
     }
 
     /// Detect the notebook runtime from metadata (kernelspec + language_info).
@@ -1765,8 +1814,85 @@ pub fn get_metadata_from_doc(doc: &AutoCommit, key: &str) -> Option<String> {
 pub fn get_metadata_snapshot_from_doc(
     doc: &AutoCommit,
 ) -> Option<metadata::NotebookMetadataSnapshot> {
+    let meta_id = doc
+        .get(automerge::ROOT, "metadata")
+        .ok()
+        .flatten()
+        .and_then(|(value, id)| match value {
+            automerge::Value::Object(ObjType::Map) => Some(id),
+            _ => None,
+        })?;
+
+    // Try native keys first
+    let kernelspec = get_json_value_from_doc(doc, &meta_id, "kernelspec")
+        .and_then(|v| serde_json::from_value(v).ok());
+    let language_info = get_json_value_from_doc(doc, &meta_id, "language_info")
+        .and_then(|v| serde_json::from_value(v).ok());
+    let runt: Option<metadata::RuntMetadata> = get_json_value_from_doc(doc, &meta_id, "runt")
+        .and_then(|v| serde_json::from_value(v).ok());
+
+    if kernelspec.is_some() || language_info.is_some() || runt.is_some() {
+        return Some(metadata::NotebookMetadataSnapshot {
+            kernelspec,
+            language_info,
+            runt: runt.unwrap_or_default(),
+        });
+    }
+
+    // Fallback: legacy bundled JSON string
     let json = get_metadata_from_doc(doc, metadata::NOTEBOOK_METADATA_KEY)?;
     serde_json::from_str(&json).ok()
+}
+
+/// Read an Automerge subtree as a `serde_json::Value` from a raw `AutoCommit`.
+///
+/// Free-function counterpart of `NotebookDoc::get_json_value`.
+fn get_json_value_from_doc(
+    doc: &AutoCommit,
+    parent: &ObjId,
+    key: &str,
+) -> Option<serde_json::Value> {
+    use automerge::Value;
+    match doc.get(parent, key).ok()?? {
+        (Value::Object(ObjType::Map), map_id) => Some(read_map_as_json_from_doc(doc, &map_id)),
+        (Value::Object(ObjType::List), list_id) => {
+            Some(read_list_as_json_from_doc(doc, &list_id))
+        }
+        (Value::Scalar(s), _) => Some(scalar_to_json(&s)),
+        _ => None,
+    }
+}
+
+/// Read an Automerge map as a JSON object from a raw `AutoCommit`.
+fn read_map_as_json_from_doc(doc: &AutoCommit, map_id: &ObjId) -> serde_json::Value {
+    let mut obj = serde_json::Map::new();
+    for key in doc.keys(map_id) {
+        if let Some(value) = get_json_value_from_doc(doc, map_id, &key) {
+            obj.insert(key, value);
+        }
+    }
+    serde_json::Value::Object(obj)
+}
+
+/// Read an Automerge list as a JSON array from a raw `AutoCommit`.
+fn read_list_as_json_from_doc(doc: &AutoCommit, list_id: &ObjId) -> serde_json::Value {
+    use automerge::Value;
+    let len = doc.length(list_id);
+    let mut arr = Vec::with_capacity(len);
+    for i in 0..len {
+        let val = match doc.get(list_id, i).ok().flatten() {
+            Some((Value::Object(ObjType::Map), nested_id)) => {
+                read_map_as_json_from_doc(doc, &nested_id)
+            }
+            Some((Value::Object(ObjType::List), nested_id)) => {
+                read_list_as_json_from_doc(doc, &nested_id)
+            }
+            Some((Value::Scalar(s), _)) => scalar_to_json(&s),
+            _ => serde_json::Value::Null,
+        };
+        arr.push(val);
+    }
+    serde_json::Value::Array(arr)
 }
 
 /// Set a metadata value in a raw `AutoCommit` document.

--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -1331,6 +1331,176 @@ impl NotebookDoc {
         Ok(())
     }
 
+    // ── Native JSON ↔ Automerge ─────────────────────────────────────
+    //
+    // These primitives convert between serde_json::Value and native
+    // Automerge objects. JSON objects become Maps, arrays become Lists,
+    // and scalars become scalars. No JSON-encoded string blobs.
+
+    /// Write a `serde_json::Value` into the Automerge doc as native types.
+    ///
+    /// - `Value::Object` → `ObjType::Map` with recursive children
+    /// - `Value::Array` → `ObjType::List` with recursive elements
+    /// - `Value::String` → string scalar
+    /// - `Value::Bool` → bool scalar (stored as string "true"/"false" for now)
+    /// - `Value::Number` → string representation (Automerge scalars)
+    /// - `Value::Null` → deletes the key
+    ///
+    /// If the key already exists, it is replaced (the old object is overwritten).
+    pub fn put_json_value(
+        &mut self,
+        parent: &ObjId,
+        key: &str,
+        value: &serde_json::Value,
+    ) -> Result<(), AutomergeError> {
+        match value {
+            serde_json::Value::Null => {
+                self.doc.delete(parent, key)?;
+            }
+            serde_json::Value::Bool(b) => {
+                self.doc.put(parent, key, *b)?;
+            }
+            serde_json::Value::Number(n) => {
+                if let Some(i) = n.as_i64() {
+                    self.doc.put(parent, key, i)?;
+                } else if let Some(f) = n.as_f64() {
+                    self.doc.put(parent, key, f)?;
+                }
+            }
+            serde_json::Value::String(s) => {
+                self.doc.put(parent, key, s.as_str())?;
+            }
+            serde_json::Value::Array(arr) => {
+                let list_id = self.doc.put_object(parent, key, ObjType::List)?;
+                for (i, elem) in arr.iter().enumerate() {
+                    self.insert_json_value_at(&list_id, i, elem)?;
+                }
+            }
+            serde_json::Value::Object(map) => {
+                let map_id = self.doc.put_object(parent, key, ObjType::Map)?;
+                for (k, v) in map {
+                    self.put_json_value(&map_id, k, v)?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Insert a `serde_json::Value` into an Automerge list at the given index.
+    fn insert_json_value_at(
+        &mut self,
+        list_id: &ObjId,
+        index: usize,
+        value: &serde_json::Value,
+    ) -> Result<(), AutomergeError> {
+        match value {
+            serde_json::Value::Null => {
+                // Insert empty string as placeholder for null in lists
+                self.doc.insert(list_id, index, "")?;
+            }
+            serde_json::Value::Bool(b) => {
+                self.doc.insert(list_id, index, *b)?;
+            }
+            serde_json::Value::Number(n) => {
+                if let Some(i) = n.as_i64() {
+                    self.doc.insert(list_id, index, i)?;
+                } else if let Some(f) = n.as_f64() {
+                    self.doc.insert(list_id, index, f)?;
+                }
+            }
+            serde_json::Value::String(s) => {
+                self.doc.insert(list_id, index, s.as_str())?;
+            }
+            serde_json::Value::Array(arr) => {
+                let nested_list = self.doc.insert_object(list_id, index, ObjType::List)?;
+                for (i, elem) in arr.iter().enumerate() {
+                    self.insert_json_value_at(&nested_list, i, elem)?;
+                }
+            }
+            serde_json::Value::Object(map) => {
+                let nested_map = self.doc.insert_object(list_id, index, ObjType::Map)?;
+                for (k, v) in map {
+                    self.put_json_value(&nested_map, k, v)?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Read an Automerge subtree as a `serde_json::Value`.
+    ///
+    /// Maps become `Value::Object`, Lists become `Value::Array`,
+    /// and scalars become the appropriate JSON type.
+    ///
+    /// Returns `None` if the key doesn't exist.
+    pub fn get_json_value(&self, parent: &ObjId, key: &str) -> Option<serde_json::Value> {
+        use automerge::Value;
+        match self.doc.get(parent, key).ok()?? {
+            (Value::Object(ObjType::Map), map_id) => Some(self.read_map_as_json(&map_id)),
+            (Value::Object(ObjType::List), list_id) => Some(self.read_list_as_json(&list_id)),
+            (Value::Scalar(s), _) => Some(scalar_to_json(&s)),
+            _ => None,
+        }
+    }
+
+    /// Read an Automerge map as a JSON object.
+    fn read_map_as_json(&self, map_id: &ObjId) -> serde_json::Value {
+        let mut obj = serde_json::Map::new();
+        for key in self.doc.keys(map_id) {
+            if let Some(value) = self.get_json_value(map_id, &key) {
+                obj.insert(key, value);
+            }
+        }
+        serde_json::Value::Object(obj)
+    }
+
+    /// Read an Automerge list as a JSON array.
+    fn read_list_as_json(&self, list_id: &ObjId) -> serde_json::Value {
+        use automerge::Value;
+        let len = self.doc.length(list_id);
+        let mut arr = Vec::with_capacity(len);
+        for i in 0..len {
+            let val = match self.doc.get(list_id, i).ok().flatten() {
+                Some((Value::Object(ObjType::Map), nested_id)) => self.read_map_as_json(&nested_id),
+                Some((Value::Object(ObjType::List), nested_id)) => {
+                    self.read_list_as_json(&nested_id)
+                }
+                Some((Value::Scalar(s), _)) => scalar_to_json(&s),
+                _ => serde_json::Value::Null,
+            };
+            arr.push(val);
+        }
+        serde_json::Value::Array(arr)
+    }
+
+    /// Set a top-level notebook metadata key as native Automerge.
+    ///
+    /// The value is stored as native Automerge types (maps, lists, scalars),
+    /// not as a JSON string. This enables per-field CRDT merging for
+    /// concurrent edits.
+    pub fn set_metadata_value(
+        &mut self,
+        key: &str,
+        value: &serde_json::Value,
+    ) -> Result<(), AutomergeError> {
+        let meta_id = match self.metadata_map_id() {
+            Some(id) => id,
+            None => self
+                .doc
+                .put_object(automerge::ROOT, "metadata", ObjType::Map)?,
+        };
+        self.put_json_value(&meta_id, key, value)
+    }
+
+    /// Get a top-level notebook metadata key as a JSON value.
+    ///
+    /// Reads the native Automerge subtree and reconstructs it as
+    /// `serde_json::Value`. Returns `None` if the key doesn't exist.
+    pub fn get_metadata_value(&self, key: &str) -> Option<serde_json::Value> {
+        let meta_id = self.metadata_map_id()?;
+        self.get_json_value(&meta_id, key)
+    }
+
     // ── Sync protocol ───────────────────────────────────────────────
 
     /// Generate a sync message to send to a peer.
@@ -1347,8 +1517,26 @@ impl NotebookDoc {
         self.doc.sync().receive_sync_message(peer_state, message)
     }
 
-    // ── Internal helpers ────────────────────────────────────────────
+    // ── Internal helpers ──────────────────────────────────────────────
+}
 
+/// Convert an Automerge scalar to a `serde_json::Value`.
+fn scalar_to_json(s: &automerge::ScalarValue) -> serde_json::Value {
+    match s {
+        automerge::ScalarValue::Str(s) => serde_json::Value::String(s.to_string()),
+        automerge::ScalarValue::Int(i) => serde_json::json!(*i),
+        automerge::ScalarValue::Uint(u) => serde_json::json!(*u),
+        automerge::ScalarValue::F64(f) => serde_json::json!(*f),
+        automerge::ScalarValue::Boolean(b) => serde_json::Value::Bool(*b),
+        automerge::ScalarValue::Null => serde_json::Value::Null,
+        automerge::ScalarValue::Timestamp(t) => serde_json::json!(*t),
+        automerge::ScalarValue::Counter(c) => serde_json::json!(i64::from(c)),
+        automerge::ScalarValue::Unknown { .. } => serde_json::Value::Null,
+        _ => serde_json::Value::Null,
+    }
+}
+
+impl NotebookDoc {
     /// Get the cells Map object ID.
     fn cells_map_id(&self) -> Option<ObjId> {
         self.doc

--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -689,7 +689,8 @@ impl NotebookDoc {
         self.doc.put_object(&cell_map, "source", ObjType::Text)?;
         self.doc.put(&cell_map, "execution_count", "null")?;
         self.doc.put_object(&cell_map, "outputs", ObjType::List)?;
-        self.doc.put(&cell_map, "metadata", "{}")?;
+        self.doc
+            .put_object(&cell_map, "metadata", ObjType::Map)?;
         self.doc
             .put_object(&cell_map, "resolved_assets", ObjType::Map)?;
 
@@ -752,9 +753,20 @@ impl NotebookDoc {
             self.doc.insert(&outputs_id, i, output.as_str())?;
         }
 
-        // Store metadata as JSON string
-        let metadata_str = serde_json::to_string(metadata).unwrap_or_else(|_| "{}".to_string());
-        self.doc.put(&cell_map, "metadata", metadata_str)?;
+        // Store metadata as native Automerge map
+        if metadata.is_object() && !metadata.as_object().map_or(true, |m| m.is_empty()) {
+            let meta_id = self
+                .doc
+                .put_object(&cell_map, "metadata", ObjType::Map)?;
+            if let serde_json::Value::Object(map) = metadata {
+                for (k, v) in map {
+                    self.put_json_value(&meta_id, k, v)?;
+                }
+            }
+        } else {
+            self.doc
+                .put_object(&cell_map, "metadata", ObjType::Map)?;
+        }
 
         self.doc
             .put_object(&cell_map, "resolved_assets", ObjType::Map)?;
@@ -1172,19 +1184,24 @@ impl NotebookDoc {
         let cells_id = self.cells_map_id()?;
         let cell_obj = self.cell_obj_id(&cells_id, cell_id)?;
 
-        // Cell exists - return its metadata or empty object if missing/invalid
-        Some(
-            read_str(&self.doc, &cell_obj, "metadata")
-                .and_then(|s| serde_json::from_str(&s).ok())
-                .unwrap_or_else(|| serde_json::json!({})),
-        )
+        // Try native Automerge Map first, fall back to legacy JSON string
+        match self.get_json_value(&cell_obj, "metadata") {
+            Some(serde_json::Value::Object(_)) => self.get_json_value(&cell_obj, "metadata"),
+            _ => {
+                // Legacy: metadata stored as JSON string
+                Some(
+                    read_str(&self.doc, &cell_obj, "metadata")
+                        .and_then(|s| serde_json::from_str(&s).ok())
+                        .unwrap_or_else(|| serde_json::json!({})),
+                )
+            }
+        }
     }
 
-    /// Set the entire metadata object for a cell.
+    /// Set the entire metadata object for a cell as native Automerge.
     ///
-    /// Note: Metadata is stored as a JSON-encoded string, not as a CRDT structure.
-    /// Concurrent edits from multiple peers will result in last-write-wins semantics.
-    /// Use `update_cell_metadata_at` for path-based updates when possible.
+    /// Metadata is stored as a native Automerge Map with per-field CRDT merging.
+    /// Concurrent edits to different metadata keys merge cleanly.
     pub fn set_cell_metadata(
         &mut self,
         cell_id: &str,
@@ -1199,20 +1216,26 @@ impl NotebookDoc {
             None => return Ok(false),
         };
 
-        let metadata_str = serde_json::to_string(metadata).unwrap_or_else(|_| "{}".to_string());
-        self.doc.put(&cell_obj, "metadata", metadata_str)?;
+        // Write as native Automerge Map
+        let meta_id = self
+            .doc
+            .put_object(&cell_obj, "metadata", ObjType::Map)?;
+        if let serde_json::Value::Object(map) = metadata {
+            for (k, v) in map {
+                self.put_json_value(&meta_id, k, v)?;
+            }
+        }
         Ok(true)
     }
 
-    /// Update a nested path within cell metadata.
+    /// Update a nested path within cell metadata using native Automerge.
     ///
-    /// Creates intermediate objects as needed. For example:
+    /// Creates intermediate Automerge Maps as needed. For example:
     /// `update_cell_metadata_at("cell-1", &["jupyter", "source_hidden"], json!(true))`
-    /// will create `{"jupyter": {"source_hidden": true}}` if metadata was `{}`.
+    /// will create `metadata.jupyter.source_hidden = true` as native Automerge objects.
     ///
-    /// Note: This performs a read-modify-write on the JSON string. Concurrent updates
-    /// to different paths may conflict (last-write-wins), but this is rare in practice
-    /// since metadata updates are typically user-initiated actions.
+    /// Concurrent updates to different paths merge cleanly since each path
+    /// segment is a separate Automerge Map key.
     pub fn update_cell_metadata_at(
         &mut self,
         cell_id: &str,
@@ -1223,34 +1246,39 @@ impl NotebookDoc {
             return self.set_cell_metadata(cell_id, &value);
         }
 
-        let mut metadata = self
-            .get_cell_metadata(cell_id)
-            .unwrap_or_else(|| serde_json::json!({}));
+        let cells_id = match self.cells_map_id() {
+            Some(id) => id,
+            None => return Ok(false),
+        };
+        let cell_obj = match self.cell_obj_id(&cells_id, cell_id) {
+            Some(o) => o,
+            None => return Ok(false),
+        };
 
-        // Navigate to the parent of the target key, creating objects as needed
-        let mut current = &mut metadata;
+        // Get or create the metadata Map
+        let meta_id = match self.map_id(&cell_obj, "metadata") {
+            Some(id) => id,
+            None => self
+                .doc
+                .put_object(&cell_obj, "metadata", ObjType::Map)?,
+        };
+
+        // Navigate to the parent, creating intermediate Maps as needed
+        let mut current_id = meta_id;
         for key in &path[..path.len() - 1] {
-            if !current.is_object() {
-                *current = serde_json::json!({});
-            }
-            let obj = current.as_object_mut().unwrap();
-            if !obj.contains_key(*key) {
-                obj.insert((*key).to_string(), serde_json::json!({}));
-            }
-            current = obj.get_mut(*key).unwrap();
+            current_id = match self.map_id(&current_id, key) {
+                Some(id) => id,
+                None => self
+                    .doc
+                    .put_object(&current_id, *key, ObjType::Map)?,
+            };
         }
 
-        // Set the final key
-        if !current.is_object() {
-            *current = serde_json::json!({});
-        }
+        // Set the final key as native Automerge
         let final_key = path[path.len() - 1];
-        current
-            .as_object_mut()
-            .unwrap()
-            .insert(final_key.to_string(), value);
+        self.put_json_value(&current_id, final_key, &value)?;
 
-        self.set_cell_metadata(cell_id, &metadata)
+        Ok(true)
     }
 
     /// Set whether the cell source should be hidden (JupyterLab convention).
@@ -1734,10 +1762,16 @@ impl NotebookDoc {
             None => vec![],
         };
 
-        // Read metadata (JSON string -> Value)
-        let metadata = read_str(&self.doc, cell_obj, "metadata")
-            .and_then(|s| serde_json::from_str(&s).ok())
-            .unwrap_or_else(|| serde_json::json!({}));
+        // Read metadata: try native Automerge Map first, fall back to legacy JSON string
+        let metadata = match self.get_json_value(cell_obj, "metadata") {
+            Some(v @ serde_json::Value::Object(_)) => v,
+            _ => {
+                // Legacy: metadata stored as JSON string
+                read_str(&self.doc, cell_obj, "metadata")
+                    .and_then(|s| serde_json::from_str(&s).ok())
+                    .unwrap_or_else(|| serde_json::json!({}))
+            }
+        };
 
         // Read resolved asset map
         let resolved_assets = match self.map_id(cell_obj, "resolved_assets") {

--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -753,7 +753,7 @@ impl NotebookDoc {
         }
 
         // Store metadata as native Automerge map
-        if metadata.is_object() && !metadata.as_object().map_or(true, |m| m.is_empty()) {
+        if metadata.as_object().is_some_and(|m| !m.is_empty()) {
             let meta_id = self.doc.put_object(&cell_map, "metadata", ObjType::Map)?;
             if let serde_json::Value::Object(map) = metadata {
                 for (k, v) in map {

--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -217,12 +217,16 @@ impl NotebookDoc {
                 AutomergeError::InvalidObjId(format!("serialize kernelspec: {}", e))
             })?;
             self.set_metadata_value("kernelspec", &value)?;
+        } else if let Some(meta_id) = self.metadata_map_id() {
+            let _ = self.doc.delete(&meta_id, "kernelspec");
         }
         if let Some(ref li) = snapshot.language_info {
             let value = serde_json::to_value(li).map_err(|e| {
                 AutomergeError::InvalidObjId(format!("serialize language_info: {}", e))
             })?;
             self.set_metadata_value("language_info", &value)?;
+        } else if let Some(meta_id) = self.metadata_map_id() {
+            let _ = self.doc.delete(&meta_id, "language_info");
         }
         let runt_value = serde_json::to_value(&snapshot.runt)
             .map_err(|e| AutomergeError::InvalidObjId(format!("serialize runt: {}", e)))?;
@@ -1182,7 +1186,7 @@ impl NotebookDoc {
 
         // Try native Automerge Map first, fall back to legacy JSON string
         match self.get_json_value(&cell_obj, "metadata") {
-            Some(serde_json::Value::Object(_)) => self.get_json_value(&cell_obj, "metadata"),
+            Some(v @ serde_json::Value::Object(_)) => Some(v),
             _ => {
                 // Legacy: metadata stored as JSON string
                 Some(
@@ -1212,12 +1216,16 @@ impl NotebookDoc {
             None => return Ok(false),
         };
 
+        // Only accept JSON objects as cell metadata
+        let map = match metadata {
+            serde_json::Value::Object(map) => map,
+            _ => return Ok(false),
+        };
+
         // Write as native Automerge Map
         let meta_id = self.doc.put_object(&cell_obj, "metadata", ObjType::Map)?;
-        if let serde_json::Value::Object(map) = metadata {
-            for (k, v) in map {
-                self.put_json_value(&meta_id, k, v)?;
-            }
+        for (k, v) in map {
+            self.put_json_value(&meta_id, k, v)?;
         }
         Ok(true)
     }
@@ -1409,9 +1417,9 @@ impl NotebookDoc {
     /// - `Value::Object` → `ObjType::Map` with recursive children
     /// - `Value::Array` → `ObjType::List` with recursive elements
     /// - `Value::String` → string scalar
-    /// - `Value::Bool` → bool scalar (stored as string "true"/"false" for now)
-    /// - `Value::Number` → string representation (Automerge scalars)
-    /// - `Value::Null` → deletes the key
+    /// - `Value::Bool` → native bool scalar
+    /// - `Value::Number` → i64 or f64 scalar (i64 preferred when lossless)
+    /// - `Value::Null` → null scalar
     ///
     /// If the key already exists, it is replaced (the old object is overwritten).
     pub fn put_json_value(
@@ -1422,7 +1430,7 @@ impl NotebookDoc {
     ) -> Result<(), AutomergeError> {
         match value {
             serde_json::Value::Null => {
-                self.doc.delete(parent, key)?;
+                self.doc.put(parent, key, automerge::ScalarValue::Null)?;
             }
             serde_json::Value::Bool(b) => {
                 self.doc.put(parent, key, *b)?;
@@ -1430,6 +1438,13 @@ impl NotebookDoc {
             serde_json::Value::Number(n) => {
                 if let Some(i) = n.as_i64() {
                     self.doc.put(parent, key, i)?;
+                } else if let Some(u) = n.as_u64() {
+                    // u64 that didn't fit in i64 — store as f64 if it won't fit
+                    if u <= i64::MAX as u64 {
+                        self.doc.put(parent, key, u as i64)?;
+                    } else {
+                        self.doc.put(parent, key, u as f64)?;
+                    }
                 } else if let Some(f) = n.as_f64() {
                     self.doc.put(parent, key, f)?;
                 }
@@ -1462,8 +1477,8 @@ impl NotebookDoc {
     ) -> Result<(), AutomergeError> {
         match value {
             serde_json::Value::Null => {
-                // Insert empty string as placeholder for null in lists
-                self.doc.insert(list_id, index, "")?;
+                self.doc
+                    .insert(list_id, index, automerge::ScalarValue::Null)?;
             }
             serde_json::Value::Bool(b) => {
                 self.doc.insert(list_id, index, *b)?;
@@ -1471,6 +1486,12 @@ impl NotebookDoc {
             serde_json::Value::Number(n) => {
                 if let Some(i) = n.as_i64() {
                     self.doc.insert(list_id, index, i)?;
+                } else if let Some(u) = n.as_u64() {
+                    if u <= i64::MAX as u64 {
+                        self.doc.insert(list_id, index, u as i64)?;
+                    } else {
+                        self.doc.insert(list_id, index, u as f64)?;
+                    }
                 } else if let Some(f) = n.as_f64() {
                     self.doc.insert(list_id, index, f)?;
                 }
@@ -3439,5 +3460,145 @@ mod tests {
         // Can delete after migration
         doc.delete_cell("new-cell").unwrap();
         assert_eq!(doc.cell_count(), 1);
+    }
+
+    #[test]
+    fn test_json_round_trip_nested() {
+        let mut doc = NotebookDoc::new("rt-nested");
+        let input = serde_json::json!({
+            "string_key": "hello",
+            "bool_true": true,
+            "bool_false": false,
+            "int_pos": 42,
+            "int_neg": -7,
+            "float_val": 3.14,
+            "null_val": null,
+            "nested_map": {
+                "inner": "value",
+                "deep": { "a": 1 }
+            },
+            "array": [1, "two", true, null, {"k": "v"}, [10, 20]]
+        });
+
+        // Write into a fresh metadata key, then read back
+        doc.set_metadata_value("test_blob", &input).unwrap();
+        let output = doc.get_metadata_value("test_blob").unwrap();
+
+        assert_eq!(input, output, "nested JSON did not round-trip");
+    }
+
+    #[test]
+    fn test_metadata_value_round_trip() {
+        let mut doc = NotebookDoc::new("rt-meta");
+        let value = serde_json::json!({
+            "display_name": "Python 3",
+            "language": "python",
+            "version": 3,
+            "features": ["repl", "notebook"],
+            "config": null
+        });
+
+        doc.set_metadata_value("my_key", &value).unwrap();
+        let got = doc.get_metadata_value("my_key").unwrap();
+        assert_eq!(value, got);
+    }
+
+    #[test]
+    fn test_cell_metadata_nested_round_trip() {
+        let mut doc = NotebookDoc::new("rt-cell-meta");
+        doc.add_cell(0, "c1", "code").unwrap();
+
+        let meta = serde_json::json!({
+            "jupyter": {
+                "source_hidden": true,
+                "outputs_hidden": false
+            },
+            "tags": ["parameters"],
+            "custom": null
+        });
+
+        doc.set_cell_metadata("c1", &meta).unwrap();
+        let got = doc.get_cell_metadata("c1").unwrap();
+        assert_eq!(meta, got);
+    }
+
+    #[test]
+    fn test_set_cell_metadata_rejects_non_object() {
+        let mut doc = NotebookDoc::new("rt-reject");
+        doc.add_cell(0, "c1", "code").unwrap();
+
+        // Passing a non-object should return Ok(false) without mutating
+        assert_eq!(
+            doc.set_cell_metadata("c1", &serde_json::json!("not an object"))
+                .unwrap(),
+            false
+        );
+        assert_eq!(
+            doc.set_cell_metadata("c1", &serde_json::json!(42)).unwrap(),
+            false
+        );
+        assert_eq!(
+            doc.set_cell_metadata("c1", &serde_json::json!(null))
+                .unwrap(),
+            false
+        );
+    }
+
+    #[test]
+    fn test_set_metadata_snapshot_none_deletes_stale() {
+        let mut doc = NotebookDoc::new("rt-snap-del");
+
+        // Set a full snapshot first
+        let snap = metadata::NotebookMetadataSnapshot {
+            kernelspec: Some(metadata::KernelspecSnapshot {
+                display_name: "Python 3".into(),
+                language: Some("python".into()),
+                name: "python3".into(),
+            }),
+            language_info: Some(metadata::LanguageInfoSnapshot {
+                name: "python".into(),
+                version: None,
+            }),
+            runt: metadata::RuntMetadata::default(),
+        };
+        doc.set_metadata_snapshot(&snap).unwrap();
+        assert!(doc.get_metadata_value("kernelspec").is_some());
+        assert!(doc.get_metadata_value("language_info").is_some());
+
+        // Now set a snapshot with None fields — stale keys should be removed
+        let snap2 = metadata::NotebookMetadataSnapshot {
+            kernelspec: None,
+            language_info: None,
+            runt: metadata::RuntMetadata::default(),
+        };
+        doc.set_metadata_snapshot(&snap2).unwrap();
+        assert!(
+            doc.get_metadata_value("kernelspec").is_none(),
+            "kernelspec should be deleted when snapshot.kernelspec is None"
+        );
+        assert!(
+            doc.get_metadata_value("language_info").is_none(),
+            "language_info should be deleted when snapshot.language_info is None"
+        );
+    }
+
+    #[test]
+    fn test_null_in_list_round_trips() {
+        let mut doc = NotebookDoc::new("rt-null-list");
+        let input = serde_json::json!([1, null, "three", null]);
+
+        doc.set_metadata_value("arr", &input).unwrap();
+        let output = doc.get_metadata_value("arr").unwrap();
+        assert_eq!(input, output);
+    }
+
+    #[test]
+    fn test_null_in_map_round_trips() {
+        let mut doc = NotebookDoc::new("rt-null-map");
+        let input = serde_json::json!({"a": null, "b": 2});
+
+        doc.set_metadata_value("obj", &input).unwrap();
+        let output = doc.get_metadata_value("obj").unwrap();
+        assert_eq!(input, output);
     }
 }

--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -689,8 +689,7 @@ impl NotebookDoc {
         self.doc.put_object(&cell_map, "source", ObjType::Text)?;
         self.doc.put(&cell_map, "execution_count", "null")?;
         self.doc.put_object(&cell_map, "outputs", ObjType::List)?;
-        self.doc
-            .put_object(&cell_map, "metadata", ObjType::Map)?;
+        self.doc.put_object(&cell_map, "metadata", ObjType::Map)?;
         self.doc
             .put_object(&cell_map, "resolved_assets", ObjType::Map)?;
 
@@ -755,17 +754,14 @@ impl NotebookDoc {
 
         // Store metadata as native Automerge map
         if metadata.is_object() && !metadata.as_object().map_or(true, |m| m.is_empty()) {
-            let meta_id = self
-                .doc
-                .put_object(&cell_map, "metadata", ObjType::Map)?;
+            let meta_id = self.doc.put_object(&cell_map, "metadata", ObjType::Map)?;
             if let serde_json::Value::Object(map) = metadata {
                 for (k, v) in map {
                     self.put_json_value(&meta_id, k, v)?;
                 }
             }
         } else {
-            self.doc
-                .put_object(&cell_map, "metadata", ObjType::Map)?;
+            self.doc.put_object(&cell_map, "metadata", ObjType::Map)?;
         }
 
         self.doc
@@ -1217,9 +1213,7 @@ impl NotebookDoc {
         };
 
         // Write as native Automerge Map
-        let meta_id = self
-            .doc
-            .put_object(&cell_obj, "metadata", ObjType::Map)?;
+        let meta_id = self.doc.put_object(&cell_obj, "metadata", ObjType::Map)?;
         if let serde_json::Value::Object(map) = metadata {
             for (k, v) in map {
                 self.put_json_value(&meta_id, k, v)?;
@@ -1258,9 +1252,7 @@ impl NotebookDoc {
         // Get or create the metadata Map
         let meta_id = match self.map_id(&cell_obj, "metadata") {
             Some(id) => id,
-            None => self
-                .doc
-                .put_object(&cell_obj, "metadata", ObjType::Map)?,
+            None => self.doc.put_object(&cell_obj, "metadata", ObjType::Map)?,
         };
 
         // Navigate to the parent, creating intermediate Maps as needed
@@ -1268,9 +1260,7 @@ impl NotebookDoc {
         for key in &path[..path.len() - 1] {
             current_id = match self.map_id(&current_id, key) {
                 Some(id) => id,
-                None => self
-                    .doc
-                    .put_object(&current_id, *key, ObjType::Map)?,
+                None => self.doc.put_object(&current_id, *key, ObjType::Map)?,
             };
         }
 
@@ -1862,8 +1852,8 @@ pub fn get_metadata_snapshot_from_doc(
         .and_then(|v| serde_json::from_value(v).ok());
     let language_info = get_json_value_from_doc(doc, &meta_id, "language_info")
         .and_then(|v| serde_json::from_value(v).ok());
-    let runt: Option<metadata::RuntMetadata> = get_json_value_from_doc(doc, &meta_id, "runt")
-        .and_then(|v| serde_json::from_value(v).ok());
+    let runt: Option<metadata::RuntMetadata> =
+        get_json_value_from_doc(doc, &meta_id, "runt").and_then(|v| serde_json::from_value(v).ok());
 
     if kernelspec.is_some() || language_info.is_some() || runt.is_some() {
         return Some(metadata::NotebookMetadataSnapshot {
@@ -1889,9 +1879,7 @@ fn get_json_value_from_doc(
     use automerge::Value;
     match doc.get(parent, key).ok()?? {
         (Value::Object(ObjType::Map), map_id) => Some(read_map_as_json_from_doc(doc, &map_id)),
-        (Value::Object(ObjType::List), list_id) => {
-            Some(read_list_as_json_from_doc(doc, &list_id))
-        }
+        (Value::Object(ObjType::List), list_id) => Some(read_list_as_json_from_doc(doc, &list_id)),
         (Value::Scalar(s), _) => Some(scalar_to_json(&s)),
         _ => None,
     }

--- a/crates/runtimed-py/src/session_core.rs
+++ b/crates/runtimed-py/src/session_core.rs
@@ -1005,6 +1005,10 @@ pub(crate) async fn get_notebook_metadata(
 }
 
 /// Set the notebook metadata snapshot.
+///
+/// Writes via the legacy `"notebook_metadata"` string key through the handle.
+/// The doc layer's `set_metadata_snapshot` (called by the daemon on save/seed)
+/// handles dual-write to both native Automerge keys and the legacy string.
 pub(crate) async fn set_notebook_metadata(
     state: &Arc<Mutex<SessionState>>,
     snapshot: &NotebookMetadataSnapshot,

--- a/crates/runtimed/src/notebook_sync_client.rs
+++ b/crates/runtimed/src/notebook_sync_client.rs
@@ -2924,9 +2924,15 @@ async fn run_sync_task<S>(
                                 let update = SyncUpdate {
                                     cells,
                                     notebook_metadata: if metadata_changed {
-                                        current_metadata
-                                            .as_ref()
-                                            .and_then(|m| serde_json::to_string(m).ok())
+                                        current_metadata.as_ref().map(|m| {
+                                            serde_json::to_string(m).unwrap_or_else(|e| {
+                                                log::warn!(
+                                                    "[notebook-sync-task] Failed to serialize metadata for {}: {}",
+                                                    notebook_id, e
+                                                );
+                                                "{}".to_string()
+                                            })
+                                        })
                                     } else {
                                         None
                                     },

--- a/crates/runtimed/src/notebook_sync_client.rs
+++ b/crates/runtimed/src/notebook_sync_client.rs
@@ -2465,7 +2465,7 @@ where
         Option<String>,
     ) {
         let initial_cells = self.get_cells();
-        let initial_metadata = self.get_metadata(NOTEBOOK_METADATA_KEY);
+        let initial_metadata = self.get_metadata(NOTEBOOK_METADATA_KEY); // Legacy string for handshake compat
         let notebook_id = self.notebook_id.clone();
         let pending_broadcasts = self.pending_broadcasts.clone();
 
@@ -2600,7 +2600,8 @@ async fn run_sync_task<S>(
 
     let mut loop_count = 0u64;
     // Track last metadata to only send updates when it actually changes
-    let mut last_metadata: Option<String> = client.get_metadata(NOTEBOOK_METADATA_KEY);
+    let mut last_metadata: Option<NotebookMetadataSnapshot> =
+        get_metadata_snapshot_from_doc(&client.doc);
 
     loop {
         loop_count += 1;
@@ -2915,7 +2916,7 @@ async fn run_sync_task<S>(
                             Ok(Some(ReceivedFrame::Changes(cells))) => {
                                 publish_snapshot(&client, &snapshot_tx);
                                 // Full peer mode: metadata diffing and SyncUpdate
-                                let current_metadata = client.get_metadata(NOTEBOOK_METADATA_KEY);
+                                let current_metadata = get_metadata_snapshot_from_doc(&client.doc);
                                 let metadata_changed = current_metadata != last_metadata;
                                 if metadata_changed {
                                     last_metadata = current_metadata.clone();
@@ -2924,6 +2925,8 @@ async fn run_sync_task<S>(
                                     cells,
                                     notebook_metadata: if metadata_changed {
                                         current_metadata
+                                            .as_ref()
+                                            .and_then(|m| serde_json::to_string(m).ok())
                                     } else {
                                         None
                                     },

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -42,7 +42,7 @@ use crate::connection::{self, NotebookFrameType};
 use crate::kernel_manager::{DenoLaunchedConfig, LaunchedEnvConfig, RoomKernel};
 use crate::markdown_assets::resolve_markdown_assets;
 use crate::notebook_doc::{notebook_doc_filename, CellSnapshot, NotebookDoc};
-use crate::notebook_metadata::{NotebookMetadataSnapshot, NOTEBOOK_METADATA_KEY};
+use crate::notebook_metadata::NotebookMetadataSnapshot;
 use crate::protocol::{EnvSyncDiff, NotebookBroadcast, NotebookRequest, NotebookResponse};
 use notebook_doc::presence::{self, PresenceState};
 
@@ -326,14 +326,10 @@ async fn process_markdown_assets(room: &NotebookRoom) {
 /// 1. Kernel launched with inline deps - track drift (additions/removals)
 /// 2. Kernel launched with prewarmed - detect when user adds inline deps (needs restart)
 async fn check_and_broadcast_sync_state(room: &NotebookRoom) {
-    // Get current metadata from doc
+    // Get current metadata from doc (reads native keys first, falls back to legacy)
     let current_metadata = {
         let doc = room.doc.read().await;
-        if let Some(meta_json) = doc.get_metadata(NOTEBOOK_METADATA_KEY) {
-            serde_json::from_str::<NotebookMetadataSnapshot>(&meta_json).ok()
-        } else {
-            None
-        }
+        doc.get_metadata_snapshot()
     };
 
     let Some(current_metadata) = current_metadata else {
@@ -403,11 +399,9 @@ async fn resolve_metadata_snapshot(
     // Try reading from the Automerge doc first
     {
         let doc = room.doc.read().await;
-        if let Some(meta_json) = doc.get_metadata(NOTEBOOK_METADATA_KEY) {
-            if let Ok(snapshot) = serde_json::from_str::<NotebookMetadataSnapshot>(&meta_json) {
-                debug!("[notebook-sync] Resolved metadata snapshot from Automerge doc");
-                return Some(snapshot);
-            }
+        if let Some(snapshot) = doc.get_metadata_snapshot() {
+            debug!("[notebook-sync] Resolved metadata snapshot from Automerge doc");
+            return Some(snapshot);
         }
     }
 
@@ -770,16 +764,21 @@ where
     // This ensures the kernelspec is available before auto-launch decides which kernel to use.
     if let Some(ref metadata_json) = initial_metadata {
         let mut doc = room.doc.write().await;
-        if doc.get_metadata(NOTEBOOK_METADATA_KEY).is_none() {
-            match doc.set_metadata(NOTEBOOK_METADATA_KEY, metadata_json) {
-                Ok(()) => {
-                    info!(
-                        "[notebook-sync] Seeded initial metadata from handshake for {}",
-                        notebook_id
-                    );
-                }
-                Err(e) => {
-                    warn!("[notebook-sync] Failed to seed initial metadata: {}", e);
+        if doc.get_metadata_snapshot().is_none() {
+            // Seed initial metadata: parse the JSON and write as native Automerge
+            // types via set_metadata_snapshot. Also writes the legacy string key
+            // for backward compat (dual-write inside set_metadata_snapshot).
+            if let Ok(snapshot) = serde_json::from_str::<NotebookMetadataSnapshot>(metadata_json) {
+                match doc.set_metadata_snapshot(&snapshot) {
+                    Ok(()) => {
+                        info!(
+                            "[notebook-sync] Seeded initial metadata from handshake for {}",
+                            notebook_id
+                        );
+                    }
+                    Err(e) => {
+                        warn!("[notebook-sync] Failed to seed initial metadata: {}", e);
+                    }
                 }
             }
         }
@@ -2969,13 +2968,8 @@ async fn format_source(source: &str, runtime: &str) -> Option<String> {
 
 /// Detect the runtime from room metadata, returning "python", "deno", or None.
 async fn detect_room_runtime(room: &NotebookRoom) -> Option<String> {
-    let metadata_json = {
-        let doc = room.doc.read().await;
-        doc.get_metadata(NOTEBOOK_METADATA_KEY)
-    };
-    metadata_json
-        .as_ref()
-        .and_then(|json| serde_json::from_str::<NotebookMetadataSnapshot>(json).ok())
+    let doc = room.doc.read().await;
+    doc.get_metadata_snapshot()
         .and_then(|snapshot| snapshot.detect_runtime())
 }
 
@@ -3097,11 +3091,11 @@ async fn save_notebook_to_disk(
     };
 
     // Read cells and metadata from the Automerge doc
-    let (cells, metadata_json) = {
+    let (cells, metadata_snapshot) = {
         let doc = room.doc.read().await;
         let cells = doc.get_cells();
-        let metadata_json = doc.get_metadata(NOTEBOOK_METADATA_KEY);
-        (cells, metadata_json)
+        let metadata_snapshot = doc.get_metadata_snapshot();
+        (cells, metadata_snapshot)
     };
     let nbformat_attachments = room.nbformat_attachments.read().await.clone();
 
@@ -3164,12 +3158,8 @@ async fn save_notebook_to_disk(
         .cloned()
         .unwrap_or(serde_json::json!({}));
 
-    if let Some(ref meta_json) = metadata_json {
-        if let Ok(snapshot) =
-            serde_json::from_str::<crate::notebook_metadata::NotebookMetadataSnapshot>(meta_json)
-        {
-            snapshot.merge_into_metadata_value(&mut metadata);
-        }
+    if let Some(ref snapshot) = metadata_snapshot {
+        snapshot.merge_into_metadata_value(&mut metadata);
     }
 
     // Build the final notebook JSON
@@ -3241,9 +3231,9 @@ async fn clone_notebook_to_disk(room: &NotebookRoom, target_path: &str) -> Resul
     };
 
     // Read cells and metadata from the Automerge doc
-    let (cells, metadata_json) = {
+    let (cells, metadata_snapshot) = {
         let doc = room.doc.read().await;
-        (doc.get_cells(), doc.get_metadata(NOTEBOOK_METADATA_KEY))
+        (doc.get_cells(), doc.get_metadata_snapshot())
     };
 
     let nbformat_attachments = room.nbformat_attachments.read().await.clone();
@@ -3302,18 +3292,14 @@ async fn clone_notebook_to_disk(room: &NotebookRoom, target_path: &str) -> Resul
         .cloned()
         .unwrap_or(serde_json::json!({}));
 
-    if let Some(ref meta_json) = metadata_json {
-        if let Ok(mut snapshot) =
-            serde_json::from_str::<crate::notebook_metadata::NotebookMetadataSnapshot>(meta_json)
-        {
-            // Update env_id in the snapshot
-            snapshot.runt.env_id = Some(new_env_id.clone());
-            // Clear trust signature since this is a new notebook
-            snapshot.runt.trust_signature = None;
-            snapshot.runt.trust_timestamp = None;
+    if let Some(mut snapshot) = metadata_snapshot {
+        // Update env_id in the snapshot
+        snapshot.runt.env_id = Some(new_env_id.clone());
+        // Clear trust signature since this is a new notebook
+        snapshot.runt.trust_signature = None;
+        snapshot.runt.trust_timestamp = None;
 
-            snapshot.merge_into_metadata_value(&mut metadata);
-        }
+        snapshot.merge_into_metadata_value(&mut metadata);
     }
 
     // Determine nbformat_minor from existing or default to 5 (for cell IDs)

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -768,8 +768,8 @@ where
             // Seed initial metadata: parse the JSON and write as native Automerge
             // types via set_metadata_snapshot. Also writes the legacy string key
             // for backward compat (dual-write inside set_metadata_snapshot).
-            if let Ok(snapshot) = serde_json::from_str::<NotebookMetadataSnapshot>(metadata_json) {
-                match doc.set_metadata_snapshot(&snapshot) {
+            match serde_json::from_str::<NotebookMetadataSnapshot>(metadata_json) {
+                Ok(snapshot) => match doc.set_metadata_snapshot(&snapshot) {
                     Ok(()) => {
                         info!(
                             "[notebook-sync] Seeded initial metadata from handshake for {}",
@@ -778,6 +778,16 @@ where
                     }
                     Err(e) => {
                         warn!("[notebook-sync] Failed to seed initial metadata: {}", e);
+                    }
+                },
+                Err(e) => {
+                    warn!(
+                        "[notebook-sync] Failed to parse handshake metadata for {}: {}",
+                        notebook_id, e
+                    );
+                    // Fall back to writing the raw string as legacy key
+                    if let Err(e) = doc.set_metadata("notebook_metadata", metadata_json) {
+                        warn!("[notebook-sync] Failed to write legacy metadata: {}", e);
                     }
                 }
             }


### PR DESCRIPTION
Migrates notebook metadata and cell metadata from JSON string blobs to native Automerge types. All JSON values become native Automerge objects — Maps, Lists, and scalars — enabling proper CRDT merging.

### What changed

**notebook-doc** (foundation):
- `put_json_value` / `get_json_value` — generic JSON ↔ Automerge conversion
- `set_metadata_snapshot` — dual-writes native keys (`kernelspec`, `language_info`, `runt`) + legacy `"notebook_metadata"` string
- `get_metadata_snapshot` — reads native keys first, falls back to legacy string
- Cell metadata stored as native Automerge Maps (was JSON string)
- `update_cell_metadata_at` navigates/creates Automerge Maps directly (no read-modify-write of JSON blob)
- 155 notebook-doc tests pass

**daemon (notebook_sync_server)**:
- All `NOTEBOOK_METADATA_KEY` reads replaced with typed `doc.get_metadata_snapshot()`
- Save/load uses typed snapshot directly
- Handshake seeding writes via `set_metadata_snapshot` (dual-write)

**sync client**:
- Metadata change tracking uses typed `NotebookMetadataSnapshot` comparison instead of raw string diff

### What this enables

Two clients adding different UV dependencies concurrently: both land (Automerge list merge). Two clients setting `source_hidden` on different cells: both land (separate Map keys). Extension metadata from unknown tools gets the same CRDT treatment automatically.

### Remaining work

- `notebook/src/lib.rs` (Tauri commands) — still uses legacy key via `GetRawMetadata`/`SetRawMetadata` protocol
- `apps/notebook/src/lib/notebook-metadata.ts` (frontend) — still writes legacy key string
- These can be migrated in follow-up PRs since the dual-write ensures backward compat

See #765 for the full plan.

_PR submitted by @rgbkrk's agent Quill, via Zed_