### PR TITLE
feat: notebook-sync crate with samod-inspired DocHandle for direct document access

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3669,6 +3669,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "notebook-sync"
+version = "0.1.0"
+dependencies = [
+ "automerge",
+ "futures",
+ "log",
+ "notebook-doc",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+]
+
+[[package]]
 name = "notify"
 version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3673,7 +3673,6 @@ name = "notebook-sync"
 version = "0.1.0"
 dependencies = [
  "automerge",
- "futures",
  "log",
  "notebook-doc",
  "runtimed",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3681,6 +3681,7 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3676,6 +3676,7 @@ dependencies = [
  "futures",
  "log",
  "notebook-doc",
+ "runtimed",
  "serde",
  "serde_json",
  "thiserror 1.0.69",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "crates/kernel-env",
     "crates/notebook",
     "crates/notebook-doc",
+    "crates/notebook-sync",
     "crates/tauri-jupyter",
     "crates/xtask",
     "crates/runtimed",

--- a/crates/notebook-sync/Cargo.toml
+++ b/crates/notebook-sync/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 [dependencies]
 automerge = "0.7"
 notebook-doc = { path = "../notebook-doc" }
+runtimed = { path = "../runtimed", default-features = false }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/notebook-sync/Cargo.toml
+++ b/crates/notebook-sync/Cargo.toml
@@ -17,6 +17,6 @@ tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
-futures = { workspace = true }
+
 uuid = { workspace = true }
 log = "0.4"

--- a/crates/notebook-sync/Cargo.toml
+++ b/crates/notebook-sync/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "notebook-sync"
+version = "0.1.0"
+edition = "2021"
+description = "Automerge-based notebook sync client with direct document access"
+repository = "https://github.com/nteract/desktop"
+license = "BSD-3-Clause"
+
+[lints]
+workspace = true
+
+[dependencies]
+automerge = "0.7"
+notebook-doc = { path = "../notebook-doc" }
+tokio = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+futures = { workspace = true }
+log = "0.4"

--- a/crates/notebook-sync/Cargo.toml
+++ b/crates/notebook-sync/Cargo.toml
@@ -18,4 +18,5 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 futures = { workspace = true }
+uuid = { workspace = true }
 log = "0.4"

--- a/crates/notebook-sync/src/connect.rs
+++ b/crates/notebook-sync/src/connect.rs
@@ -1,0 +1,415 @@
+//! Connection handshake and initial Automerge sync.
+//!
+//! Establishes a connection to the runtimed daemon, performs the protocol
+//! handshake, and runs the initial Automerge sync exchange to populate
+//! the local document replica.
+
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use automerge::sync::{self, SyncDoc};
+use automerge::AutoCommit;
+use log::{debug, info, warn};
+use tokio::sync::{mpsc, watch};
+
+use runtimed::connection::{
+    self, Handshake, NotebookConnectionInfo, NotebookFrameType, ProtocolCapabilities, PROTOCOL_V2,
+};
+use runtimed::protocol::NotebookBroadcast;
+
+use crate::error::SyncError;
+use crate::handle::DocHandle;
+use crate::shared::SharedDocState;
+use crate::snapshot::NotebookSnapshot;
+use crate::sync_task;
+
+/// Result of connecting to a notebook room.
+pub struct ConnectResult {
+    /// Handle for document mutations and reads.
+    pub handle: DocHandle,
+
+    /// Receiver for kernel/execution broadcasts from the daemon.
+    pub broadcast_rx: tokio::sync::broadcast::Receiver<NotebookBroadcast>,
+
+    /// Initial cells in the document after sync.
+    pub cells: Vec<notebook_doc::CellSnapshot>,
+
+    /// Initial metadata string (legacy format, for handshake compat).
+    pub initial_metadata: Option<String>,
+}
+
+/// Result of connecting to an existing notebook file.
+pub struct OpenResult {
+    /// Handle for document mutations and reads.
+    pub handle: DocHandle,
+
+    /// Receiver for kernel/execution broadcasts from the daemon.
+    pub broadcast_rx: tokio::sync::broadcast::Receiver<NotebookBroadcast>,
+
+    /// Connection info from the daemon (notebook_id, trust status, etc).
+    pub info: NotebookConnectionInfo,
+
+    /// Initial cells in the document after sync.
+    pub cells: Vec<notebook_doc::CellSnapshot>,
+}
+
+/// Connect to a notebook room by ID.
+///
+/// Performs the protocol handshake and initial Automerge sync. Returns a
+/// `DocHandle` for direct document access and a broadcast receiver for
+/// kernel events.
+pub async fn connect(
+    socket_path: PathBuf,
+    notebook_id: String,
+) -> Result<ConnectResult, SyncError> {
+    connect_with_options(socket_path, notebook_id, None, None).await
+}
+
+/// Connect to a notebook room with options.
+pub async fn connect_with_options(
+    socket_path: PathBuf,
+    notebook_id: String,
+    working_dir: Option<PathBuf>,
+    initial_metadata: Option<String>,
+) -> Result<ConnectResult, SyncError> {
+    let stream = tokio::net::UnixStream::connect(&socket_path)
+        .await
+        .map_err(SyncError::Io)?;
+
+    let (reader, writer) = tokio::io::split(stream);
+    let mut reader = tokio::io::BufReader::new(reader);
+    let mut writer = tokio::io::BufWriter::new(writer);
+
+    // Send preamble
+    connection::send_preamble(&mut writer).await?;
+
+    // Send handshake
+    let handshake = Handshake::NotebookSync {
+        notebook_id: notebook_id.clone(),
+        protocol: Some(PROTOCOL_V2.to_string()),
+        working_dir: working_dir.map(|p| p.to_string_lossy().to_string()),
+        initial_metadata: initial_metadata.clone(),
+    };
+    connection::send_json_frame(&mut writer, &handshake)
+        .await
+        .map_err(|e| SyncError::Protocol(format!("Send handshake: {}", e)))?;
+
+    // Receive protocol capabilities
+    let caps_data = connection::recv_frame(&mut reader)
+        .await?
+        .ok_or_else(|| SyncError::Protocol("Connection closed during handshake".into()))?;
+    let _caps: ProtocolCapabilities = serde_json::from_slice(&caps_data)?;
+
+    // Initial Automerge sync exchange
+    let mut doc = AutoCommit::new();
+    let mut peer_state = sync::State::new();
+    let mut pending_broadcasts = Vec::new();
+
+    do_initial_sync(
+        &mut reader,
+        &mut writer,
+        &mut doc,
+        &mut peer_state,
+        &mut pending_broadcasts,
+    )
+    .await?;
+
+    info!(
+        "[notebook-sync] Connected to room {} ({} cells)",
+        notebook_id,
+        notebook_doc::get_cells_from_doc(&doc).len()
+    );
+
+    // Read initial state before splitting
+    let cells = notebook_doc::get_cells_from_doc(&doc);
+    let legacy_metadata =
+        notebook_doc::get_metadata_from_doc(&doc, notebook_doc::metadata::NOTEBOOK_METADATA_KEY);
+
+    // Build the shared state and channels
+    let shared = Arc::new(Mutex::new(SharedDocState::new(doc, notebook_id.clone())));
+    // Restore the peer_state from the handshake sync
+    {
+        let mut state = shared.lock().map_err(|_| SyncError::LockPoisoned)?;
+        state.peer_state = peer_state;
+    }
+
+    let initial_snapshot = {
+        let state = shared.lock().map_err(|_| SyncError::LockPoisoned)?;
+        NotebookSnapshot::from_doc(&state.doc)
+    };
+
+    let (snapshot_tx, snapshot_rx) = watch::channel(initial_snapshot);
+    let snapshot_tx = Arc::new(snapshot_tx);
+    let (changed_tx, changed_rx) = mpsc::unbounded_channel();
+    let (cmd_tx, cmd_rx) = mpsc::channel::<sync_task::SyncCommand>(32);
+    let (broadcast_tx, broadcast_rx) = tokio::sync::broadcast::channel::<NotebookBroadcast>(64);
+    let cmd_tx_for_handle = cmd_tx.clone();
+
+    // Send any broadcasts received during initial sync
+    for bc in pending_broadcasts {
+        let _ = broadcast_tx.send(bc);
+    }
+
+    // Build the handle
+    let handle = DocHandle::new(
+        Arc::clone(&shared),
+        changed_tx,
+        cmd_tx_for_handle,
+        Arc::clone(&snapshot_tx),
+        snapshot_rx,
+        notebook_id.clone(),
+    );
+
+    // Reunite the split stream for the sync task
+    let stream = reader.into_inner().unsplit(writer.into_inner());
+
+    // Spawn the sync task
+    let task_config = sync_task::SyncTaskConfig {
+        doc: Arc::clone(&shared),
+        changed_rx,
+        cmd_rx,
+        snapshot_tx: Arc::clone(&snapshot_tx),
+        broadcast_tx,
+    };
+
+    let notebook_id_for_task = notebook_id.clone();
+    tokio::spawn(async move {
+        info!(
+            "[notebook-sync] Sync task started for {}",
+            notebook_id_for_task
+        );
+        sync_task::run(task_config, stream).await;
+        info!(
+            "[notebook-sync] Sync task stopped for {}",
+            notebook_id_for_task
+        );
+    });
+
+    Ok(ConnectResult {
+        handle,
+        broadcast_rx,
+        cells,
+        initial_metadata: legacy_metadata,
+    })
+}
+
+/// Connect and open an existing notebook file.
+pub async fn connect_open(socket_path: PathBuf, path: PathBuf) -> Result<OpenResult, SyncError> {
+    let stream = tokio::net::UnixStream::connect(&socket_path)
+        .await
+        .map_err(SyncError::Io)?;
+
+    let (reader, writer) = tokio::io::split(stream);
+    let mut reader = tokio::io::BufReader::new(reader);
+    let mut writer = tokio::io::BufWriter::new(writer);
+
+    // Send preamble
+    connection::send_preamble(&mut writer).await?;
+
+    // Send open handshake
+    let handshake = Handshake::OpenNotebook {
+        path: path.to_string_lossy().to_string(),
+    };
+    connection::send_json_frame(&mut writer, &handshake)
+        .await
+        .map_err(|e| SyncError::Protocol(format!("Send handshake: {}", e)))?;
+
+    // Receive connection info
+    let info_data = connection::recv_frame(&mut reader)
+        .await?
+        .ok_or_else(|| SyncError::Protocol("Connection closed during handshake".into()))?;
+    let info: NotebookConnectionInfo = serde_json::from_slice(&info_data)?;
+
+    if let Some(ref error) = info.error {
+        return Err(SyncError::Protocol(error.clone()));
+    }
+
+    let notebook_id = info.notebook_id.clone();
+
+    // Initial Automerge sync exchange
+    let mut doc = AutoCommit::new();
+    let mut peer_state = sync::State::new();
+    let mut pending_broadcasts = Vec::new();
+
+    do_initial_sync(
+        &mut reader,
+        &mut writer,
+        &mut doc,
+        &mut peer_state,
+        &mut pending_broadcasts,
+    )
+    .await?;
+
+    info!(
+        "[notebook-sync] Opened notebook {} ({} cells)",
+        notebook_id,
+        notebook_doc::get_cells_from_doc(&doc).len()
+    );
+
+    let cells = notebook_doc::get_cells_from_doc(&doc);
+
+    // Build shared state and channels
+    let shared = Arc::new(Mutex::new(SharedDocState::new(doc, notebook_id.clone())));
+    {
+        let mut state = shared.lock().map_err(|_| SyncError::LockPoisoned)?;
+        state.peer_state = peer_state;
+    }
+
+    let initial_snapshot = {
+        let state = shared.lock().map_err(|_| SyncError::LockPoisoned)?;
+        NotebookSnapshot::from_doc(&state.doc)
+    };
+
+    let (snapshot_tx, snapshot_rx) = watch::channel(initial_snapshot);
+    let snapshot_tx = Arc::new(snapshot_tx);
+    let (changed_tx, changed_rx) = mpsc::unbounded_channel();
+    let (cmd_tx, cmd_rx) = mpsc::channel::<sync_task::SyncCommand>(32);
+    let (broadcast_tx, broadcast_rx) = tokio::sync::broadcast::channel::<NotebookBroadcast>(64);
+    let cmd_tx_for_handle = cmd_tx.clone();
+
+    for bc in pending_broadcasts {
+        let _ = broadcast_tx.send(bc);
+    }
+
+    let handle = DocHandle::new(
+        Arc::clone(&shared),
+        changed_tx,
+        cmd_tx_for_handle,
+        Arc::clone(&snapshot_tx),
+        snapshot_rx,
+        notebook_id.clone(),
+    );
+
+    let stream = reader.into_inner().unsplit(writer.into_inner());
+
+    let task_config = sync_task::SyncTaskConfig {
+        doc: Arc::clone(&shared),
+        changed_rx,
+        cmd_rx,
+        snapshot_tx: Arc::clone(&snapshot_tx),
+        broadcast_tx,
+    };
+
+    let notebook_id_for_task = notebook_id.clone();
+    tokio::spawn(async move {
+        info!(
+            "[notebook-sync] Sync task started for {}",
+            notebook_id_for_task
+        );
+        sync_task::run(task_config, stream).await;
+        info!(
+            "[notebook-sync] Sync task stopped for {}",
+            notebook_id_for_task
+        );
+    });
+
+    Ok(OpenResult {
+        handle,
+        broadcast_rx,
+        info,
+        cells,
+    })
+}
+
+/// Perform the initial Automerge sync exchange after handshake.
+///
+/// Exchanges sync messages with the daemon until the local document is
+/// caught up. Also buffers any broadcasts received during sync.
+async fn do_initial_sync<R, W>(
+    reader: &mut R,
+    writer: &mut W,
+    doc: &mut AutoCommit,
+    peer_state: &mut sync::State,
+    pending_broadcasts: &mut Vec<NotebookBroadcast>,
+) -> Result<(), SyncError>
+where
+    R: tokio::io::AsyncRead + Unpin,
+    W: tokio::io::AsyncWrite + Unpin,
+{
+    // Receive the daemon's first sync message
+    let first_frame = connection::recv_typed_frame(reader)
+        .await?
+        .ok_or_else(|| SyncError::Protocol("Connection closed during initial sync".into()))?;
+
+    if first_frame.frame_type != NotebookFrameType::AutomergeSync {
+        return Err(SyncError::Protocol(format!(
+            "Expected AutomergeSync frame, got {:?}",
+            first_frame.frame_type
+        )));
+    }
+
+    // Apply and respond
+    let msg = sync::Message::decode(&first_frame.payload)
+        .map_err(|e| SyncError::Protocol(format!("Decode sync message: {}", e)))?;
+    doc.sync()
+        .receive_sync_message(peer_state, msg)
+        .map_err(|e| SyncError::Protocol(format!("Apply sync message: {}", e)))?;
+
+    // Generate reply
+    if let Some(reply) = doc.sync().generate_sync_message(peer_state) {
+        connection::send_typed_frame(writer, NotebookFrameType::AutomergeSync, &reply.encode())
+            .await?;
+    }
+
+    // Continue receiving until we hit a timeout (convergence)
+    let mut rounds = 0;
+    loop {
+        match tokio::time::timeout(
+            Duration::from_millis(100),
+            connection::recv_typed_frame(reader),
+        )
+        .await
+        {
+            Ok(Ok(Some(frame))) => match frame.frame_type {
+                NotebookFrameType::AutomergeSync => {
+                    let msg = sync::Message::decode(&frame.payload)
+                        .map_err(|e| SyncError::Protocol(format!("Decode sync: {}", e)))?;
+                    doc.sync()
+                        .receive_sync_message(peer_state, msg)
+                        .map_err(|e| SyncError::Protocol(format!("Apply sync: {}", e)))?;
+
+                    if let Some(reply) = doc.sync().generate_sync_message(peer_state) {
+                        connection::send_typed_frame(
+                            writer,
+                            NotebookFrameType::AutomergeSync,
+                            &reply.encode(),
+                        )
+                        .await?;
+                    }
+                    rounds += 1;
+                }
+                NotebookFrameType::Broadcast => {
+                    // Buffer broadcasts received during initial sync
+                    if let Ok(bc) = serde_json::from_slice::<NotebookBroadcast>(&frame.payload) {
+                        pending_broadcasts.push(bc);
+                    }
+                }
+                _ => {
+                    debug!(
+                        "[notebook-sync] Ignoring {:?} frame during initial sync",
+                        frame.frame_type
+                    );
+                }
+            },
+            Ok(Ok(None)) => {
+                return Err(SyncError::Protocol(
+                    "Connection closed during initial sync".into(),
+                ));
+            }
+            Ok(Err(e)) => {
+                return Err(SyncError::Io(e));
+            }
+            Err(_) => {
+                // Timeout — sync converged
+                debug!(
+                    "[notebook-sync] Initial sync converged after {} rounds",
+                    rounds
+                );
+                break;
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/crates/notebook-sync/src/connect.rs
+++ b/crates/notebook-sync/src/connect.rs
@@ -312,6 +312,150 @@ pub async fn connect_open(socket_path: PathBuf, path: PathBuf) -> Result<OpenRes
     })
 }
 
+/// Result of creating a new notebook.
+pub struct CreateResult {
+    /// Handle for document mutations and reads.
+    pub handle: DocHandle,
+
+    /// Receiver for kernel/execution broadcasts from the daemon.
+    pub broadcast_rx: tokio::sync::broadcast::Receiver<NotebookBroadcast>,
+
+    /// Connection info from the daemon (notebook_id, trust status, etc).
+    pub info: NotebookConnectionInfo,
+
+    /// Initial cells in the document after sync.
+    pub cells: Vec<notebook_doc::CellSnapshot>,
+}
+
+/// Connect and create a new notebook.
+///
+/// The daemon creates an empty notebook room with one code cell and
+/// returns connection info with a generated UUID as the notebook_id.
+pub async fn connect_create(
+    socket_path: PathBuf,
+    runtime: &str,
+    working_dir: Option<PathBuf>,
+) -> Result<CreateResult, SyncError> {
+    let stream = tokio::net::UnixStream::connect(&socket_path)
+        .await
+        .map_err(SyncError::Io)?;
+
+    let (reader, writer) = tokio::io::split(stream);
+    let mut reader = tokio::io::BufReader::new(reader);
+    let mut writer = tokio::io::BufWriter::new(writer);
+
+    // Send preamble
+    connection::send_preamble(&mut writer).await?;
+
+    // Send create handshake
+    let handshake = Handshake::CreateNotebook {
+        runtime: runtime.to_string(),
+        working_dir: working_dir
+            .as_ref()
+            .map(|p| p.to_string_lossy().to_string()),
+        notebook_id: None,
+    };
+    connection::send_json_frame(&mut writer, &handshake)
+        .await
+        .map_err(|e| SyncError::Protocol(format!("Send handshake: {}", e)))?;
+
+    // Receive connection info
+    let info_data = connection::recv_frame(&mut reader)
+        .await?
+        .ok_or_else(|| SyncError::Protocol("Connection closed during handshake".into()))?;
+    let info: NotebookConnectionInfo = serde_json::from_slice(&info_data)?;
+
+    if let Some(ref error) = info.error {
+        return Err(SyncError::Protocol(error.clone()));
+    }
+
+    let notebook_id = info.notebook_id.clone();
+
+    // Initial Automerge sync exchange
+    let mut doc = AutoCommit::new();
+    let mut peer_state = sync::State::new();
+    let mut pending_broadcasts = Vec::new();
+
+    do_initial_sync(
+        &mut reader,
+        &mut writer,
+        &mut doc,
+        &mut peer_state,
+        &mut pending_broadcasts,
+    )
+    .await?;
+
+    info!(
+        "[notebook-sync] Created notebook {} ({} cells)",
+        notebook_id,
+        notebook_doc::get_cells_from_doc(&doc).len()
+    );
+
+    let cells = notebook_doc::get_cells_from_doc(&doc);
+
+    // Build shared state and channels
+    let shared = Arc::new(Mutex::new(SharedDocState::new(doc, notebook_id.clone())));
+    {
+        let mut state = shared.lock().map_err(|_| SyncError::LockPoisoned)?;
+        state.peer_state = peer_state;
+    }
+
+    let initial_snapshot = {
+        let state = shared.lock().map_err(|_| SyncError::LockPoisoned)?;
+        NotebookSnapshot::from_doc(&state.doc)
+    };
+
+    let (snapshot_tx, snapshot_rx) = watch::channel(initial_snapshot);
+    let snapshot_tx = Arc::new(snapshot_tx);
+    let (changed_tx, changed_rx) = mpsc::unbounded_channel();
+    let (cmd_tx, cmd_rx) = mpsc::channel::<sync_task::SyncCommand>(32);
+    let (broadcast_tx, broadcast_rx) = tokio::sync::broadcast::channel::<NotebookBroadcast>(64);
+    let cmd_tx_for_handle = cmd_tx.clone();
+
+    for bc in pending_broadcasts {
+        let _ = broadcast_tx.send(bc);
+    }
+
+    let handle = DocHandle::new(
+        Arc::clone(&shared),
+        changed_tx,
+        cmd_tx_for_handle,
+        Arc::clone(&snapshot_tx),
+        snapshot_rx,
+        notebook_id.clone(),
+    );
+
+    let stream = reader.into_inner().unsplit(writer.into_inner());
+
+    let task_config = sync_task::SyncTaskConfig {
+        doc: Arc::clone(&shared),
+        changed_rx,
+        cmd_rx,
+        snapshot_tx: Arc::clone(&snapshot_tx),
+        broadcast_tx,
+    };
+
+    let notebook_id_for_task = notebook_id.clone();
+    tokio::spawn(async move {
+        info!(
+            "[notebook-sync] Sync task started for {}",
+            notebook_id_for_task
+        );
+        sync_task::run(task_config, stream).await;
+        info!(
+            "[notebook-sync] Sync task stopped for {}",
+            notebook_id_for_task
+        );
+    });
+
+    Ok(CreateResult {
+        handle,
+        broadcast_rx,
+        info,
+        cells,
+    })
+}
+
 /// Perform the initial Automerge sync exchange after handshake.
 ///
 /// Exchanges sync messages with the daemon until the local document is

--- a/crates/notebook-sync/src/connect.rs
+++ b/crates/notebook-sync/src/connect.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 
 use automerge::sync::{self, SyncDoc};
 use automerge::AutoCommit;
-use log::{debug, info, warn};
+use log::{debug, info};
 use tokio::sync::{mpsc, watch};
 
 use runtimed::connection::{
@@ -54,11 +54,14 @@ pub struct OpenResult {
     pub cells: Vec<notebook_doc::CellSnapshot>,
 }
 
+// TODO: Windows support — use named pipes instead of Unix domain sockets.
+
 /// Connect to a notebook room by ID.
 ///
 /// Performs the protocol handshake and initial Automerge sync. Returns a
 /// `DocHandle` for direct document access and a broadcast receiver for
 /// kernel events.
+#[cfg(unix)]
 pub async fn connect(
     socket_path: PathBuf,
     notebook_id: String,
@@ -67,6 +70,7 @@ pub async fn connect(
 }
 
 /// Connect to a notebook room with options.
+#[cfg(unix)]
 pub async fn connect_with_options(
     socket_path: PathBuf,
     notebook_id: String,
@@ -195,6 +199,7 @@ pub async fn connect_with_options(
 }
 
 /// Connect and open an existing notebook file.
+#[cfg(unix)]
 pub async fn connect_open(socket_path: PathBuf, path: PathBuf) -> Result<OpenResult, SyncError> {
     let stream = tokio::net::UnixStream::connect(&socket_path)
         .await
@@ -331,6 +336,7 @@ pub struct CreateResult {
 ///
 /// The daemon creates an empty notebook room with one code cell and
 /// returns connection info with a generated UUID as the notebook_id.
+#[cfg(unix)]
 pub async fn connect_create(
     socket_path: PathBuf,
     runtime: &str,

--- a/crates/notebook-sync/src/error.rs
+++ b/crates/notebook-sync/src/error.rs
@@ -1,0 +1,43 @@
+//! Error types for notebook-sync operations.
+
+/// Errors that can occur during notebook sync operations.
+#[derive(Debug, thiserror::Error)]
+pub enum SyncError {
+    /// The document mutex was poisoned (a thread panicked while holding it).
+    #[error("Document lock poisoned")]
+    LockPoisoned,
+
+    /// An Automerge operation failed.
+    #[error("Automerge error: {0}")]
+    Automerge(#[from] automerge::AutomergeError),
+
+    /// A network I/O error occurred.
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// The sync task has stopped (channels closed).
+    #[error("Disconnected from sync task")]
+    Disconnected,
+
+    /// A daemon protocol error.
+    #[error("Protocol error: {0}")]
+    Protocol(String),
+
+    /// Connection timed out.
+    #[error("Connection timed out")]
+    Timeout,
+
+    /// A cell was not found in the document.
+    #[error("Cell not found: {0}")]
+    CellNotFound(String),
+
+    /// Serialization/deserialization error.
+    #[error("Serialization error: {0}")]
+    Serialization(String),
+}
+
+impl From<serde_json::Error> for SyncError {
+    fn from(e: serde_json::Error) -> Self {
+        SyncError::Serialization(e.to_string())
+    }
+}

--- a/crates/notebook-sync/src/handle.rs
+++ b/crates/notebook-sync/src/handle.rs
@@ -202,26 +202,34 @@ impl DocHandle {
         })?
     }
 
-    /// Add a new cell at the given index.
-    pub fn add_cell(&self, index: usize, cell_id: &str, cell_type: &str) -> Result<(), SyncError> {
-        self.with_notebook_doc(|nd| nd.add_cell(index, cell_id, cell_type))
+    /// Add a new cell after the given cell (or at the beginning if `None`).
+    ///
+    /// Returns the fractional position string assigned to the cell.
+    pub fn add_cell_after(
+        &self,
+        cell_id: &str,
+        cell_type: &str,
+        after_cell_id: Option<&str>,
+    ) -> Result<String, SyncError> {
+        self.with_notebook_doc(|nd| nd.add_cell_after(cell_id, cell_type, after_cell_id))
     }
 
     /// Add a new cell with source in a single atomic transaction.
     ///
     /// Prevents peers from seeing an empty cell before the source arrives.
-    /// Uses `add_cell` + `update_source` in one `with_doc` lock.
+    /// Both the cell structure and source are written in one lock acquisition,
+    /// one snapshot publish, and one sync notification.
     pub fn add_cell_with_source(
         &self,
-        index: usize,
         cell_id: &str,
         cell_type: &str,
+        after_cell_id: Option<&str>,
         source: &str,
-    ) -> Result<(), SyncError> {
+    ) -> Result<String, SyncError> {
         self.with_notebook_doc(|nd| {
-            nd.add_cell(index, cell_id, cell_type)?;
+            let position = nd.add_cell_after(cell_id, cell_type, after_cell_id)?;
             nd.update_source(cell_id, source)?;
-            Ok(())
+            Ok(position)
         })
     }
 

--- a/crates/notebook-sync/src/handle.rs
+++ b/crates/notebook-sync/src/handle.rs
@@ -9,18 +9,19 @@
 //!
 //! ## Convenience methods vs `with_doc`
 //!
-//! For single operations, use the convenience methods (`add_cell`, `set_source`,
-//! `set_metadata_value`, etc.). For compound operations that should be atomic
-//! (one lock, one snapshot, one sync), use `with_doc` directly:
+//! For single operations, use the convenience methods (`add_cell_after`,
+//! `update_source`, `set_metadata_string`, etc.). For compound operations
+//! that should be atomic (one lock, one snapshot, one sync), use `with_doc`
+//! directly:
 //!
 //! ```ignore
 //! // Single operation — convenience method
-//! handle.add_cell(0, "cell-1", "code")?;
+//! handle.add_cell_after("cell-1", "code", None)?;
 //!
 //! // Compound operation — with_doc for atomicity
 //! handle.with_doc(|doc| {
 //!     let mut nd = NotebookDoc::wrap(std::mem::take(doc));
-//!     nd.add_cell(0, "cell-1", "code")?;
+//!     nd.add_cell_after("cell-1", "code", None)?;
 //!     nd.update_source("cell-1", "print('hello')")?;
 //!     nd.set_cell_source_hidden("cell-1", true)?;
 //!     *doc = nd.into_inner();
@@ -50,11 +51,8 @@ use crate::sync_task::SyncCommand;
 ///
 /// ```ignore
 /// // Synchronous — no .await needed for document mutations
-/// handle.with_doc(|doc| {
-///     doc.add_cell(0, "cell-1", "code")?;
-///     doc.update_source("cell-1", "print('hello')")?;
-///     Ok(())
-/// })?;
+/// handle.add_cell_after("cell-1", "code", None)?;
+/// handle.update_source("cell-1", "print('hello')")?;
 ///
 /// // Read the latest snapshot (no lock, no .await)
 /// let cells = handle.snapshot().cells();
@@ -128,7 +126,7 @@ impl DocHandle {
     /// Mutate the document directly via a closure.
     ///
     /// This is the primary mutation API. The closure receives a mutable
-    /// `NotebookDoc` reference and can perform any document operations.
+    /// `&mut AutoCommit` reference and can perform any document operations.
     /// After the closure returns:
     ///
     /// 1. A new snapshot is published (readers see updated state immediately)
@@ -159,7 +157,7 @@ impl DocHandle {
     /// ```
     ///
     /// For convenience, prefer the typed methods on `DocHandle` (e.g.,
-    /// `add_cell`, `set_metadata_value`) which handle the wrap/unwrap
+    /// `add_cell_after`, `set_metadata_string`) which handle the wrap/unwrap
     /// internally. Use `with_doc` for custom or compound operations.
     pub fn with_doc<F, R>(&self, f: F) -> Result<R, SyncError>
     where
@@ -182,6 +180,18 @@ impl DocHandle {
         let _ = self.changed_tx.send(());
 
         Ok(result)
+    }
+
+    /// Read the document without publishing a snapshot or notifying the sync task.
+    ///
+    /// Use this for read-only operations (e.g., `get_metadata_string`) that
+    /// don't mutate the document and therefore shouldn't trigger a sync cycle.
+    fn with_doc_readonly<F, R>(&self, f: F) -> Result<R, SyncError>
+    where
+        F: FnOnce(&AutoCommit) -> R,
+    {
+        let state = self.doc.lock().map_err(|_| SyncError::LockPoisoned)?;
+        Ok(f(&state.doc))
     }
 
     // =====================================================================
@@ -311,11 +321,9 @@ impl DocHandle {
 
     /// Get a string metadata value.
     pub fn get_metadata_string(&self, key: &str) -> Option<String> {
-        self.with_doc(|doc| {
-            let nd = notebook_doc::NotebookDoc::wrap(std::mem::take(doc));
-            let result = nd.get_metadata(key);
-            *doc = nd.into_inner();
-            result
+        self.with_doc_readonly(|doc| {
+            let nd = notebook_doc::NotebookDoc::wrap(doc.clone());
+            nd.get_metadata(key)
         })
         .ok()
         .flatten()
@@ -467,6 +475,7 @@ impl DocHandle {
     ///
     /// This is primarily for the sync task to apply incoming sync messages.
     /// Callers should prefer `with_doc` for mutations and `snapshot()` for reads.
+    #[allow(dead_code)]
     pub(crate) fn shared_state(&self) -> &Arc<Mutex<SharedDocState>> {
         &self.doc
     }
@@ -475,6 +484,7 @@ impl DocHandle {
     ///
     /// Called by the sync task after applying incoming changes from the daemon.
     /// Handle callers don't need this — `with_doc` publishes automatically.
+    #[allow(dead_code)]
     pub(crate) fn publish_snapshot_from_doc(&self, doc: &AutoCommit) {
         let snapshot = NotebookSnapshot::from_doc(doc);
         let _ = self.snapshot_tx.send(snapshot);

--- a/crates/notebook-sync/src/handle.rs
+++ b/crates/notebook-sync/src/handle.rs
@@ -6,6 +6,27 @@
 //!
 //! Document mutations are synchronous and microsecond-fast. Only daemon
 //! protocol operations (`send_request`, `confirm_sync`) are async.
+//!
+//! ## Convenience methods vs `with_doc`
+//!
+//! For single operations, use the convenience methods (`add_cell`, `set_source`,
+//! `set_metadata_value`, etc.). For compound operations that should be atomic
+//! (one lock, one snapshot, one sync), use `with_doc` directly:
+//!
+//! ```ignore
+//! // Single operation — convenience method
+//! handle.add_cell(0, "cell-1", "code")?;
+//!
+//! // Compound operation — with_doc for atomicity
+//! handle.with_doc(|doc| {
+//!     let mut nd = NotebookDoc::wrap(std::mem::take(doc));
+//!     nd.add_cell(0, "cell-1", "code")?;
+//!     nd.update_source("cell-1", "print('hello')")?;
+//!     nd.set_cell_source_hidden("cell-1", true)?;
+//!     *doc = nd.into_inner();
+//!     Ok(())
+//! })?;
+//! ```
 
 use std::sync::{Arc, Mutex};
 
@@ -161,6 +182,155 @@ impl DocHandle {
         let _ = self.changed_tx.send(());
 
         Ok(result)
+    }
+
+    // =====================================================================
+    // Convenience methods — single-operation wrappers around with_doc
+    // =====================================================================
+
+    // Helper: run a closure on a NotebookDoc wrapper, handling the
+    // wrap/unwrap dance and error type conversion.
+    fn with_notebook_doc<F, T>(&self, f: F) -> Result<T, SyncError>
+    where
+        F: FnOnce(&mut notebook_doc::NotebookDoc) -> Result<T, automerge::AutomergeError>,
+    {
+        self.with_doc(|doc| {
+            let mut nd = notebook_doc::NotebookDoc::wrap(std::mem::take(doc));
+            let result = f(&mut nd);
+            *doc = nd.into_inner();
+            result.map_err(SyncError::Automerge)
+        })?
+    }
+
+    /// Add a new cell at the given index.
+    pub fn add_cell(&self, index: usize, cell_id: &str, cell_type: &str) -> Result<(), SyncError> {
+        self.with_notebook_doc(|nd| nd.add_cell(index, cell_id, cell_type))
+    }
+
+    /// Add a new cell with source in a single atomic transaction.
+    ///
+    /// Prevents peers from seeing an empty cell before the source arrives.
+    /// Uses `add_cell` + `update_source` in one `with_doc` lock.
+    pub fn add_cell_with_source(
+        &self,
+        index: usize,
+        cell_id: &str,
+        cell_type: &str,
+        source: &str,
+    ) -> Result<(), SyncError> {
+        self.with_notebook_doc(|nd| {
+            nd.add_cell(index, cell_id, cell_type)?;
+            nd.update_source(cell_id, source)?;
+            Ok(())
+        })
+    }
+
+    /// Delete a cell by ID. Returns true if found and deleted.
+    pub fn delete_cell(&self, cell_id: &str) -> Result<bool, SyncError> {
+        self.with_notebook_doc(|nd| nd.delete_cell(cell_id))
+    }
+
+    /// Move a cell to after another cell (or to the beginning if `None`).
+    /// Returns the new position string.
+    pub fn move_cell(
+        &self,
+        cell_id: &str,
+        after_cell_id: Option<&str>,
+    ) -> Result<String, SyncError> {
+        self.with_notebook_doc(|nd| nd.move_cell(cell_id, after_cell_id))
+    }
+
+    /// Update a cell's source text. Returns true if cell was found.
+    pub fn update_source(&self, cell_id: &str, source: &str) -> Result<bool, SyncError> {
+        self.with_notebook_doc(|nd| nd.update_source(cell_id, source))
+    }
+
+    /// Append text to a cell's source (efficient for streaming tokens). Returns true if cell was found.
+    pub fn append_source(&self, cell_id: &str, text: &str) -> Result<bool, SyncError> {
+        self.with_notebook_doc(|nd| nd.append_source(cell_id, text))
+    }
+
+    /// Set the full notebook metadata snapshot (kernelspec + language_info + runt).
+    pub fn set_metadata_snapshot(
+        &self,
+        snapshot: &notebook_doc::metadata::NotebookMetadataSnapshot,
+    ) -> Result<(), SyncError> {
+        self.with_notebook_doc(|nd| nd.set_metadata_snapshot(snapshot))
+    }
+
+    /// Set cell metadata from a JSON value. Returns true if cell found.
+    pub fn set_cell_metadata(
+        &self,
+        cell_id: &str,
+        metadata: &serde_json::Value,
+    ) -> Result<bool, SyncError> {
+        self.with_notebook_doc(|nd| nd.set_cell_metadata(cell_id, metadata))
+    }
+
+    /// Update cell metadata at a specific path. Returns true if cell found.
+    pub fn update_cell_metadata_at(
+        &self,
+        cell_id: &str,
+        path: &[&str],
+        value: serde_json::Value,
+    ) -> Result<bool, SyncError> {
+        self.with_notebook_doc(|nd| nd.update_cell_metadata_at(cell_id, path, value))
+    }
+
+    /// Set whether a cell's source should be hidden.
+    pub fn set_cell_source_hidden(&self, cell_id: &str, hidden: bool) -> Result<bool, SyncError> {
+        self.with_notebook_doc(|nd| nd.set_cell_source_hidden(cell_id, hidden))
+    }
+
+    /// Set whether a cell's outputs should be hidden.
+    pub fn set_cell_outputs_hidden(&self, cell_id: &str, hidden: bool) -> Result<bool, SyncError> {
+        self.with_notebook_doc(|nd| nd.set_cell_outputs_hidden(cell_id, hidden))
+    }
+
+    /// Set cell tags.
+    pub fn set_cell_tags(&self, cell_id: &str, tags: &[&str]) -> Result<bool, SyncError> {
+        let tags_value: Vec<serde_json::Value> = tags
+            .iter()
+            .map(|t| serde_json::Value::String(t.to_string()))
+            .collect();
+        self.update_cell_metadata_at(cell_id, &["tags"], serde_json::Value::Array(tags_value))
+    }
+
+    /// Set a string metadata value.
+    pub fn set_metadata_string(&self, key: &str, value: &str) -> Result<(), SyncError> {
+        self.with_notebook_doc(|nd| nd.set_metadata(key, value))
+    }
+
+    /// Get a string metadata value.
+    pub fn get_metadata_string(&self, key: &str) -> Option<String> {
+        self.with_doc(|doc| {
+            let nd = notebook_doc::NotebookDoc::wrap(std::mem::take(doc));
+            let result = nd.get_metadata(key);
+            *doc = nd.into_inner();
+            result
+        })
+        .ok()
+        .flatten()
+    }
+
+    /// Add a UV dependency, deduplicating by package name.
+    pub fn add_uv_dependency(&self, pkg: &str) -> Result<(), SyncError> {
+        self.with_notebook_doc(|nd| nd.add_uv_dependency(pkg))
+    }
+
+    /// Remove a UV dependency by package name. Returns true if removed.
+    pub fn remove_uv_dependency(&self, pkg: &str) -> Result<bool, SyncError> {
+        self.with_notebook_doc(|nd| nd.remove_uv_dependency(pkg))
+    }
+
+    /// Add a Conda dependency, deduplicating by package name.
+    pub fn add_conda_dependency(&self, pkg: &str) -> Result<(), SyncError> {
+        self.with_notebook_doc(|nd| nd.add_conda_dependency(pkg))
+    }
+
+    /// Remove a Conda dependency by package name. Returns true if removed.
+    pub fn remove_conda_dependency(&self, pkg: &str) -> Result<bool, SyncError> {
+        self.with_notebook_doc(|nd| nd.remove_conda_dependency(pkg))
     }
 
     // =====================================================================

--- a/crates/notebook-sync/src/handle.rs
+++ b/crates/notebook-sync/src/handle.rs
@@ -1,0 +1,211 @@
+//! `DocHandle` — direct, synchronous access to the Automerge document.
+//!
+//! Inspired by [samod](https://github.com/alexjg/samod)'s `DocHandle`, this
+//! provides callers with a `with_doc` method that locks the shared document,
+//! runs a closure, publishes a snapshot, and notifies the sync task.
+//!
+//! Document mutations are synchronous and microsecond-fast. Only daemon
+//! protocol operations (`send_request`, `confirm_sync`) are async.
+
+use std::sync::{Arc, Mutex};
+
+use automerge::AutoCommit;
+use tokio::sync::{mpsc, watch};
+
+use crate::error::SyncError;
+use crate::shared::SharedDocState;
+use crate::snapshot::NotebookSnapshot;
+
+/// A handle to a synced notebook document.
+///
+/// `DocHandle` is `Clone` — multiple callers can hold handles to the same
+/// document. All mutations go through `with_doc`, which acquires the mutex,
+/// runs the closure, publishes a snapshot, and notifies the sync task.
+///
+/// # Example
+///
+/// ```ignore
+/// // Synchronous — no .await needed for document mutations
+/// handle.with_doc(|doc| {
+///     doc.add_cell(0, "cell-1", "code")?;
+///     doc.update_source("cell-1", "print('hello')")?;
+///     Ok(())
+/// })?;
+///
+/// // Read the latest snapshot (no lock, no .await)
+/// let cells = handle.snapshot().cells();
+///
+/// // Async — daemon protocol needs socket I/O
+/// let response = handle.send_request(NotebookRequest::LaunchKernel { ... }).await?;
+/// ```
+#[derive(Clone)]
+pub struct DocHandle {
+    /// Shared document state (doc + sync protocol state).
+    /// Both the handle and the sync task hold a reference.
+    doc: Arc<Mutex<SharedDocState>>,
+
+    /// Notify the sync task that the document was mutated locally.
+    /// The sync task will generate and send a sync message to the daemon.
+    changed_tx: mpsc::UnboundedSender<()>,
+
+    /// Watch channel for publishing snapshots after mutations.
+    /// The handle publishes; readers (Python API, frontend) subscribe.
+    snapshot_tx: Arc<watch::Sender<NotebookSnapshot>>,
+
+    /// Watch channel receiver for reading the latest snapshot.
+    snapshot_rx: watch::Receiver<NotebookSnapshot>,
+
+    /// The notebook identifier.
+    notebook_id: String,
+}
+
+impl std::fmt::Debug for DocHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DocHandle")
+            .field("notebook_id", &self.notebook_id)
+            .finish()
+    }
+}
+
+impl DocHandle {
+    /// Create a new `DocHandle` from shared state and channels.
+    ///
+    /// This is called by the connection/split logic, not by end users.
+    pub(crate) fn new(
+        doc: Arc<Mutex<SharedDocState>>,
+        changed_tx: mpsc::UnboundedSender<()>,
+        snapshot_tx: Arc<watch::Sender<NotebookSnapshot>>,
+        snapshot_rx: watch::Receiver<NotebookSnapshot>,
+        notebook_id: String,
+    ) -> Self {
+        Self {
+            doc,
+            changed_tx,
+            snapshot_tx,
+            snapshot_rx,
+            notebook_id,
+        }
+    }
+
+    /// The notebook ID this handle is connected to.
+    pub fn notebook_id(&self) -> &str {
+        &self.notebook_id
+    }
+
+    // =====================================================================
+    // Document mutations — synchronous, direct, no channels
+    // =====================================================================
+
+    /// Mutate the document directly via a closure.
+    ///
+    /// This is the primary mutation API. The closure receives a mutable
+    /// `NotebookDoc` reference and can perform any document operations.
+    /// After the closure returns:
+    ///
+    /// 1. A new snapshot is published (readers see updated state immediately)
+    /// 2. The sync task is notified to propagate changes to the daemon
+    ///
+    /// The mutex is held only for the duration of the closure — keep
+    /// mutations fast (microseconds). Never do I/O inside the closure.
+    ///
+    /// # Errors
+    ///
+    /// Returns `SyncError::LockPoisoned` if the mutex was poisoned (a thread
+    /// panicked while holding it). The closure's own errors are returned via
+    /// the `Result` inside `R`.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// use notebook_doc::NotebookDoc;
+    ///
+    /// handle.with_doc(|doc| {
+    ///     let mut nd = NotebookDoc::wrap(std::mem::take(doc));
+    ///     nd.set_metadata_value("runt", &serde_json::json!({
+    ///         "uv": { "dependencies": ["pandas>=2.0"] }
+    ///     }))?;
+    ///     *doc = nd.into_inner();
+    ///     Ok(())
+    /// })?;
+    /// ```
+    ///
+    /// For convenience, prefer the typed methods on `DocHandle` (e.g.,
+    /// `add_cell`, `set_metadata_value`) which handle the wrap/unwrap
+    /// internally. Use `with_doc` for custom or compound operations.
+    pub fn with_doc<F, R>(&self, f: F) -> Result<R, SyncError>
+    where
+        F: FnOnce(&mut AutoCommit) -> R,
+    {
+        let mut state = self.doc.lock().map_err(|_| SyncError::LockPoisoned)?;
+
+        let result = f(&mut state.doc);
+
+        // Publish a fresh snapshot so readers see the mutation immediately.
+        // This happens before the sync task sends it to the daemon — local
+        // reads are always up-to-date even if the network is slow.
+        let snapshot = NotebookSnapshot::from_doc(&state.doc);
+        let _ = self.snapshot_tx.send(snapshot);
+
+        // Notify the sync task that the document changed. The sync task will
+        // generate a sync message and send it to the daemon. Unbounded send
+        // so we never block the caller. If the sync task is behind, multiple
+        // notifications coalesce (it just syncs once).
+        let _ = self.changed_tx.send(());
+
+        Ok(result)
+    }
+
+    // =====================================================================
+    // Read-only access — no lock needed
+    // =====================================================================
+
+    /// Get the latest document snapshot.
+    ///
+    /// Returns the most recent snapshot published after the last mutation.
+    /// This reads from a `watch` channel — no mutex lock, no async, instant.
+    pub fn snapshot(&self) -> NotebookSnapshot {
+        self.snapshot_rx.borrow().clone()
+    }
+
+    /// Get all cells from the latest snapshot.
+    pub fn get_cells(&self) -> Vec<notebook_doc::CellSnapshot> {
+        self.snapshot_rx.borrow().cells.as_ref().clone()
+    }
+
+    /// Get the typed notebook metadata from the latest snapshot.
+    pub fn get_notebook_metadata(
+        &self,
+    ) -> Option<notebook_doc::metadata::NotebookMetadataSnapshot> {
+        self.snapshot_rx.borrow().notebook_metadata.clone()
+    }
+
+    /// Subscribe to snapshot changes.
+    ///
+    /// Returns a `watch::Receiver` that is notified whenever the document
+    /// changes (locally or from a remote peer). Use `.changed().await` to
+    /// wait for the next update, then `.borrow()` to read it.
+    pub fn subscribe(&self) -> watch::Receiver<NotebookSnapshot> {
+        self.snapshot_rx.clone()
+    }
+
+    // =====================================================================
+    // Direct access to shared state (for the sync task and advanced use)
+    // =====================================================================
+
+    /// Get a reference to the shared document state.
+    ///
+    /// This is primarily for the sync task to apply incoming sync messages.
+    /// Callers should prefer `with_doc` for mutations and `snapshot()` for reads.
+    pub(crate) fn shared_state(&self) -> &Arc<Mutex<SharedDocState>> {
+        &self.doc
+    }
+
+    /// Publish a snapshot from the current document state.
+    ///
+    /// Called by the sync task after applying incoming changes from the daemon.
+    /// Handle callers don't need this — `with_doc` publishes automatically.
+    pub(crate) fn publish_snapshot_from_doc(&self, doc: &AutoCommit) {
+        let snapshot = NotebookSnapshot::from_doc(doc);
+        let _ = self.snapshot_tx.send(snapshot);
+    }
+}

--- a/crates/notebook-sync/src/handle.rs
+++ b/crates/notebook-sync/src/handle.rs
@@ -10,11 +10,14 @@
 use std::sync::{Arc, Mutex};
 
 use automerge::AutoCommit;
-use tokio::sync::{mpsc, watch};
+use tokio::sync::{mpsc, oneshot, watch};
+
+use runtimed::protocol::{NotebookRequest, NotebookResponse};
 
 use crate::error::SyncError;
 use crate::shared::SharedDocState;
 use crate::snapshot::NotebookSnapshot;
+use crate::sync_task::SyncCommand;
 
 /// A handle to a synced notebook document.
 ///
@@ -48,6 +51,9 @@ pub struct DocHandle {
     /// The sync task will generate and send a sync message to the daemon.
     changed_tx: mpsc::UnboundedSender<()>,
 
+    /// Command channel for async operations (request/response, confirm_sync, presence).
+    cmd_tx: mpsc::Sender<SyncCommand>,
+
     /// Watch channel for publishing snapshots after mutations.
     /// The handle publishes; readers (Python API, frontend) subscribe.
     snapshot_tx: Arc<watch::Sender<NotebookSnapshot>>,
@@ -74,6 +80,7 @@ impl DocHandle {
     pub(crate) fn new(
         doc: Arc<Mutex<SharedDocState>>,
         changed_tx: mpsc::UnboundedSender<()>,
+        cmd_tx: mpsc::Sender<SyncCommand>,
         snapshot_tx: Arc<watch::Sender<NotebookSnapshot>>,
         snapshot_rx: watch::Receiver<NotebookSnapshot>,
         notebook_id: String,
@@ -81,6 +88,7 @@ impl DocHandle {
         Self {
             doc,
             changed_tx,
+            cmd_tx,
             snapshot_tx,
             snapshot_rx,
             notebook_id,
@@ -153,6 +161,91 @@ impl DocHandle {
         let _ = self.changed_tx.send(());
 
         Ok(result)
+    }
+
+    // =====================================================================
+    // Async operations — need socket I/O via the sync task
+    // =====================================================================
+
+    /// Send a request to the daemon and wait for a response.
+    ///
+    /// This is async because it involves socket I/O. The request is sent
+    /// to the daemon via the sync task, which handles the wire protocol.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let response = handle.send_request(NotebookRequest::LaunchKernel {
+    ///     kernel_type: "python".into(),
+    ///     env_source: "auto".into(),
+    ///     notebook_path: None,
+    /// }).await?;
+    /// ```
+    pub async fn send_request(
+        &self,
+        request: NotebookRequest,
+    ) -> Result<NotebookResponse, SyncError> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.cmd_tx
+            .send(SyncCommand::SendRequest {
+                request,
+                reply: reply_tx,
+                broadcast_tx: None,
+            })
+            .await
+            .map_err(|_| SyncError::Disconnected)?;
+        reply_rx.await.map_err(|_| SyncError::Disconnected)?
+    }
+
+    /// Send a request with a broadcast channel for real-time progress updates.
+    ///
+    /// Used for long-running requests like `LaunchKernel` where the daemon
+    /// sends progress broadcasts (env creation, package installs) while
+    /// the request is in flight.
+    pub async fn send_request_with_broadcast(
+        &self,
+        request: NotebookRequest,
+        broadcast_tx: tokio::sync::broadcast::Sender<runtimed::protocol::NotebookBroadcast>,
+    ) -> Result<NotebookResponse, SyncError> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.cmd_tx
+            .send(SyncCommand::SendRequest {
+                request,
+                reply: reply_tx,
+                broadcast_tx: Some(broadcast_tx),
+            })
+            .await
+            .map_err(|_| SyncError::Disconnected)?;
+        reply_rx.await.map_err(|_| SyncError::Disconnected)?
+    }
+
+    /// Confirm that the daemon has merged all our local changes.
+    ///
+    /// Performs up to 5 sync round-trips, checking that the daemon's
+    /// shared_heads include our local heads. Call this before executing
+    /// a cell to ensure the daemon has the cell's source.
+    pub async fn confirm_sync(&self) -> Result<(), SyncError> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.cmd_tx
+            .send(SyncCommand::ConfirmSync { reply: reply_tx })
+            .await
+            .map_err(|_| SyncError::Disconnected)?;
+        reply_rx.await.map_err(|_| SyncError::Disconnected)?
+    }
+
+    /// Send a raw presence frame to the daemon.
+    ///
+    /// The daemon relays this to all other peers in the notebook room.
+    pub async fn send_presence(&self, data: Vec<u8>) -> Result<(), SyncError> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.cmd_tx
+            .send(SyncCommand::SendPresence {
+                data,
+                reply: reply_tx,
+            })
+            .await
+            .map_err(|_| SyncError::Disconnected)?;
+        reply_rx.await.map_err(|_| SyncError::Disconnected)?
     }
 
     // =====================================================================

--- a/crates/notebook-sync/src/lib.rs
+++ b/crates/notebook-sync/src/lib.rs
@@ -1,0 +1,39 @@
+//! Automerge-based notebook sync client with direct document access.
+//!
+//! Inspired by [samod](https://github.com/alexjg/samod) (automerge-repo in Rust),
+//! this crate provides a `DocHandle` that gives callers direct, synchronous access
+//! to the Automerge document via `with_doc`. No command channels, no serialization,
+//! no async overhead for document mutations.
+//!
+//! ## Architecture
+//!
+//! ```text
+//! DocHandle (callers)                    SyncTask (network I/O)
+//!   │                                      │
+//!   ├─ with_doc(|doc| doc.add_cell(...))   │
+//!   │   → lock mutex                       │
+//!   │   → mutate doc                       │
+//!   │   → publish snapshot                 │
+//!   │   → notify sync task ──────────────► │ generate_sync_message()
+//!   │                                      │ → send to daemon
+//!   │                                      │
+//!   ├─ snapshot()                           │
+//!   │   → read watch channel (no lock)     │
+//!   │                                      │
+//!   ├─ send_request(req).await ───────────►│ socket write/read
+//!   │   (async — needs socket I/O)         │
+//! ```
+//!
+//! Document mutations (`with_doc`) are synchronous and microsecond-fast.
+//! Only daemon protocol operations (`send_request`, `confirm_sync`) are async.
+
+pub mod error;
+pub mod handle;
+mod shared;
+mod snapshot;
+pub mod sync_task;
+
+pub use error::SyncError;
+pub use handle::DocHandle;
+pub use shared::SharedDocState;
+pub use snapshot::NotebookSnapshot;

--- a/crates/notebook-sync/src/lib.rs
+++ b/crates/notebook-sync/src/lib.rs
@@ -27,6 +27,7 @@
 //! Document mutations (`with_doc`) are synchronous and microsecond-fast.
 //! Only daemon protocol operations (`send_request`, `confirm_sync`) are async.
 
+pub mod connect;
 pub mod error;
 pub mod handle;
 mod shared;

--- a/crates/notebook-sync/src/lib.rs
+++ b/crates/notebook-sync/src/lib.rs
@@ -10,9 +10,12 @@
 //! ```text
 //! DocHandle (callers)                    SyncTask (network I/O)
 //!   │                                      │
-//!   ├─ with_doc(|doc| doc.add_cell(...))   │
+//!   ├─ handle.add_cell_after(...)           │
+//!   │   (convenience method)               │
+//!   │                                      │
+//!   ├─ handle.with_doc(|doc| { ... })      │
 //!   │   → lock mutex                       │
-//!   │   → mutate doc                       │
+//!   │   → mutate &mut AutoCommit           │
 //!   │   → publish snapshot                 │
 //!   │   → notify sync task ──────────────► │ generate_sync_message()
 //!   │                                      │ → send to daemon
@@ -24,9 +27,26 @@
 //!   │   (async — needs socket I/O)         │
 //! ```
 //!
+//! For single operations, use convenience methods like `add_cell_after`,
+//! `update_source`, `set_metadata_string`, etc. For compound operations
+//! that should be atomic, use `with_doc` directly with `NotebookDoc::wrap`:
+//!
+//! ```ignore
+//! // Single operation — convenience method
+//! handle.add_cell_after("cell-1", "code", None)?;
+//!
+//! // Compound operation — with_doc for atomicity
+//! handle.with_doc(|doc| {
+//!     let mut nd = notebook_doc::NotebookDoc::wrap(std::mem::take(doc));
+//!     nd.add_cell_after("cell-1", "code", None)?;
+//!     nd.update_source("cell-1", "print('hello')")?;
+//!     *doc = nd.into_inner();
+//!     Ok::<_, automerge::AutomergeError>(())
+//! })?;
+//! ```
+//!
 //! Document mutations (`with_doc`) are synchronous and microsecond-fast.
 //! Only daemon protocol operations (`send_request`, `confirm_sync`) are async.
-
 pub mod connect;
 pub mod error;
 pub mod handle;

--- a/crates/notebook-sync/src/lib.rs
+++ b/crates/notebook-sync/src/lib.rs
@@ -38,3 +38,6 @@ pub use error::SyncError;
 pub use handle::DocHandle;
 pub use shared::SharedDocState;
 pub use snapshot::NotebookSnapshot;
+
+#[cfg(test)]
+mod tests;

--- a/crates/notebook-sync/src/shared.rs
+++ b/crates/notebook-sync/src/shared.rs
@@ -1,0 +1,61 @@
+//! Shared document state behind `Arc<Mutex<_>>`.
+//!
+//! This is the core state shared between `DocHandle` (callers) and the sync task
+//! (network I/O). All document mutations happen through the mutex. The sync task
+//! also acquires the mutex briefly to apply incoming sync messages and generate
+//! outgoing ones.
+
+use automerge::sync;
+use automerge::AutoCommit;
+
+/// The shared state behind `Arc<Mutex<SharedDocState>>`.
+///
+/// Contains the Automerge document, sync protocol state, and notebook identity.
+/// Both the `DocHandle` and the sync task hold `Arc<Mutex<SharedDocState>>`.
+pub struct SharedDocState {
+    /// The Automerge document — source of truth for all notebook content.
+    pub(crate) doc: AutoCommit,
+
+    /// Automerge sync protocol state for the daemon peer.
+    pub(crate) peer_state: sync::State,
+
+    /// The notebook identifier (canonical path for file-backed notebooks,
+    /// UUID for ephemeral/untitled notebooks).
+    pub(crate) notebook_id: String,
+}
+
+impl SharedDocState {
+    /// Create a new shared state with the given document and notebook ID.
+    pub fn new(doc: AutoCommit, notebook_id: String) -> Self {
+        Self {
+            doc,
+            peer_state: sync::State::new(),
+            notebook_id,
+        }
+    }
+
+    /// Get a reference to the notebook ID.
+    pub fn notebook_id(&self) -> &str {
+        &self.notebook_id
+    }
+
+    /// Generate an outgoing sync message for the daemon peer, if any changes
+    /// need to be sent.
+    ///
+    /// Returns `None` if the daemon already has all our changes.
+    pub fn generate_sync_message(&mut self) -> Option<sync::Message> {
+        use automerge::sync::SyncDoc;
+        self.doc.sync().generate_sync_message(&mut self.peer_state)
+    }
+
+    /// Apply an incoming sync message from the daemon peer.
+    pub fn receive_sync_message(
+        &mut self,
+        message: sync::Message,
+    ) -> Result<(), automerge::AutomergeError> {
+        use automerge::sync::SyncDoc;
+        self.doc
+            .sync()
+            .receive_sync_message(&mut self.peer_state, message)
+    }
+}

--- a/crates/notebook-sync/src/snapshot.rs
+++ b/crates/notebook-sync/src/snapshot.rs
@@ -1,0 +1,72 @@
+//! Read-only notebook snapshot published via `tokio::sync::watch`.
+//!
+//! The `DocHandle` publishes a new snapshot after every document mutation
+//! (local or remote). Readers access the latest state without acquiring
+//! the document mutex — they just borrow from the watch channel.
+
+use std::sync::Arc;
+
+use notebook_doc::metadata::NotebookMetadataSnapshot;
+use notebook_doc::CellSnapshot;
+
+/// A point-in-time snapshot of the notebook document.
+///
+/// Published by the `DocHandle` after every mutation. Readers clone the
+/// `Arc<Vec<CellSnapshot>>` cheaply — the cell data itself is shared.
+///
+/// This is the read side of the document. For writes, use `DocHandle::with_doc`.
+#[derive(Clone, Debug)]
+pub struct NotebookSnapshot {
+    /// All cells in document order (sorted by fractional index position).
+    pub cells: Arc<Vec<CellSnapshot>>,
+
+    /// Parsed notebook metadata (kernelspec, language_info, runt config).
+    /// `None` if the document has no metadata yet.
+    pub notebook_metadata: Option<NotebookMetadataSnapshot>,
+}
+
+impl NotebookSnapshot {
+    /// Create a snapshot from the current document state.
+    pub fn from_doc(doc: &automerge::AutoCommit) -> Self {
+        use notebook_doc::{get_cells_from_doc, get_metadata_snapshot_from_doc};
+
+        Self {
+            cells: Arc::new(get_cells_from_doc(doc)),
+            notebook_metadata: get_metadata_snapshot_from_doc(doc),
+        }
+    }
+
+    /// Create an empty snapshot (no cells, no metadata).
+    pub fn empty() -> Self {
+        Self {
+            cells: Arc::new(Vec::new()),
+            notebook_metadata: None,
+        }
+    }
+
+    /// Get cells as a slice.
+    pub fn cells(&self) -> &[CellSnapshot] {
+        &self.cells
+    }
+
+    /// Get a cell by ID.
+    pub fn get_cell(&self, cell_id: &str) -> Option<&CellSnapshot> {
+        self.cells.iter().find(|c| c.id == cell_id)
+    }
+
+    /// Get the number of cells.
+    pub fn cell_count(&self) -> usize {
+        self.cells.len()
+    }
+
+    /// Get the typed notebook metadata snapshot.
+    pub fn notebook_metadata(&self) -> Option<&NotebookMetadataSnapshot> {
+        self.notebook_metadata.as_ref()
+    }
+}
+
+impl Default for NotebookSnapshot {
+    fn default() -> Self {
+        Self::empty()
+    }
+}

--- a/crates/notebook-sync/src/sync_task.rs
+++ b/crates/notebook-sync/src/sync_task.rs
@@ -18,9 +18,17 @@
 //! via `DocHandle::with_doc`. This task is purely for network synchronization.
 
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
-use tokio::sync::mpsc;
+use automerge::sync::{self, SyncDoc};
+use log::{debug, info, warn};
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::sync::{broadcast, mpsc, oneshot};
 
+use runtimed::connection::{self, NotebookFrameType};
+use runtimed::protocol::{NotebookBroadcast, NotebookRequest, NotebookResponse};
+
+use crate::error::SyncError;
 use crate::shared::SharedDocState;
 use crate::snapshot::NotebookSnapshot;
 
@@ -30,11 +38,35 @@ use crate::snapshot::NotebookSnapshot;
 /// connection go through this channel. Document mutations happen directly
 /// on the `DocHandle` via `with_doc`.
 pub enum SyncCommand {
-    // TODO: SendRequest, ConfirmSync, SendPresence, ReceiveFrontendSyncMessage
-    //
-    // These will be ported from the existing NotebookSyncClient as the
-    // migration progresses. Each carries a oneshot reply channel for the
-    // caller to await the result.
+    /// Send a request to the daemon and wait for a response.
+    SendRequest {
+        request: NotebookRequest,
+        reply: oneshot::Sender<Result<NotebookResponse, SyncError>>,
+        /// Optional broadcast sender for delivering broadcasts during long-running
+        /// requests (e.g., LaunchKernel with environment progress updates).
+        broadcast_tx: Option<broadcast::Sender<NotebookBroadcast>>,
+    },
+
+    /// Confirm that the daemon has merged all our local changes.
+    ///
+    /// Performs up to 5 sync round-trips, checking that the daemon's
+    /// shared_heads include our local heads.
+    ConfirmSync {
+        reply: oneshot::Sender<Result<(), SyncError>>,
+    },
+
+    /// Send a raw presence frame to the daemon.
+    SendPresence {
+        data: Vec<u8>,
+        reply: oneshot::Sender<Result<(), SyncError>>,
+    },
+
+    /// Apply a raw Automerge sync message from the frontend (WASM/pipe mode)
+    /// and forward to the daemon.
+    ReceiveFrontendSyncMessage {
+        message: Vec<u8>,
+        reply: oneshot::Sender<Result<(), SyncError>>,
+    },
 }
 
 /// Configuration for the sync task.
@@ -43,7 +75,6 @@ pub struct SyncTaskConfig {
     pub doc: Arc<Mutex<SharedDocState>>,
 
     /// Receives notifications when the document was mutated locally.
-    /// The sync task should generate and send a sync message to the daemon.
     pub changed_rx: mpsc::UnboundedReceiver<()>,
 
     /// Receives protocol commands (request/response, confirm_sync, presence).
@@ -51,6 +82,9 @@ pub struct SyncTaskConfig {
 
     /// Watch sender for publishing snapshots after applying remote changes.
     pub snapshot_tx: Arc<tokio::sync::watch::Sender<NotebookSnapshot>>,
+
+    /// Broadcast sender for kernel/execution events from the daemon.
+    pub broadcast_tx: broadcast::Sender<NotebookBroadcast>,
 }
 
 /// Run the sync task.
@@ -58,77 +92,532 @@ pub struct SyncTaskConfig {
 /// This is spawned as a background tokio task. It runs until the socket
 /// closes or all handles are dropped (channels close).
 ///
-/// # Architecture
-///
-/// ```text
-/// loop {
-///     select! {
-///         // Local doc changed → generate sync message → send to daemon
-///         _ = changed_rx.recv() => { ... }
-///
-///         // Incoming frame from daemon → apply to doc → publish snapshot
-///         frame = recv_frame(&mut stream) => { ... }
-///
-///         // Protocol command (request/response, etc.)
-///         cmd = cmd_rx.recv() => { ... }
-///     }
-/// }
-/// ```
-///
 /// The document mutex is held briefly for sync message generation/application.
 /// It is NEVER held across `.await` points (socket I/O).
-pub async fn run<S>(_config: SyncTaskConfig, _stream: S)
+pub async fn run<S>(mut config: SyncTaskConfig, stream: S)
 where
-    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+    S: AsyncRead + AsyncWrite + Unpin,
 {
-    // TODO: Port the sync loop from notebook_sync_client.rs::run_sync_task.
-    //
-    // The key difference from the current implementation:
-    //
-    // 1. No document mutation commands to handle (those happen on DocHandle)
-    // 2. The `changed_rx` channel replaces the mutation commands —
-    //    when it fires, lock the doc, generate_sync_message, send to daemon
-    // 3. Incoming frames: lock the doc, receive_sync_message, publish snapshot
-    // 4. Protocol commands (SendRequest etc.): same as current implementation
-    //
-    // The select! loop structure:
-    //
-    // loop {
-    //     select! {
-    //         // Drain all pending change notifications (coalesce)
-    //         _ = changed_rx.recv() => {
-    //             // Drain any additional notifications (coalesce multiple mutations)
-    //             while changed_rx.try_recv().is_ok() {}
-    //             let mut state = config.doc.lock().unwrap();
-    //             if let Some(msg) = state.generate_sync_message() {
-    //                 let msg_bytes = msg.encode();
-    //                 drop(state);  // release before I/O
-    //                 send_sync_frame(&mut stream, &msg_bytes).await;
-    //             }
-    //         }
-    //
-    //         // Incoming frame from daemon
-    //         frame = recv_frame(&mut stream) => {
-    //             match frame {
-    //                 AutomergeSync(payload) => {
-    //                     let msg = sync::Message::decode(&payload)?;
-    //                     let mut state = config.doc.lock().unwrap();
-    //                     state.receive_sync_message(msg)?;
-    //                     let snapshot = NotebookSnapshot::from_doc(&state.doc);
-    //                     drop(state);
-    //                     config.snapshot_tx.send(snapshot);
-    //                     // Generate response sync message if needed
-    //                     ...
-    //                 }
-    //                 Broadcast(payload) => { ... }
-    //                 ...
-    //             }
-    //         }
-    //
-    //         // Protocol commands
-    //         cmd = cmd_rx.recv() => { ... }
-    //     }
-    // }
+    let (reader, writer) = tokio::io::split(stream);
+    let mut reader = tokio::io::BufReader::new(reader);
+    let mut writer = tokio::io::BufWriter::new(writer);
 
-    log::info!("[notebook-sync] Sync task stub — not yet implemented");
+    let notebook_id = {
+        let state = config.doc.lock().unwrap_or_else(|e| e.into_inner());
+        state.notebook_id().to_string()
+    };
+
+    let mut loop_count: u64 = 0;
+
+    // Track last metadata for change detection (used for SyncUpdate-like behavior)
+    let mut last_metadata: Option<notebook_doc::metadata::NotebookMetadataSnapshot> = {
+        let state = config.doc.lock().unwrap_or_else(|e| e.into_inner());
+        notebook_doc::get_metadata_snapshot_from_doc(&state.doc)
+    };
+
+    loop {
+        loop_count += 1;
+
+        // Use select! with biased mode so we prioritize local changes and commands
+        // over incoming frames (prevents starvation when the daemon is chatty).
+        enum SelectResult {
+            Changed,
+            Command(Option<SyncCommand>),
+            Frame(std::io::Result<Option<connection::TypedNotebookFrame>>),
+        }
+
+        let select_result = tokio::select! {
+            biased;
+
+            // Local document was mutated by a handle
+            result = config.changed_rx.recv() => {
+                if result.is_none() {
+                    // All handles dropped — shut down
+                    info!("[notebook-sync] All handles dropped for {}, shutting down", notebook_id);
+                    break;
+                }
+                SelectResult::Changed
+            }
+
+            // Protocol command (request/response, confirm_sync, etc.)
+            cmd = config.cmd_rx.recv() => SelectResult::Command(cmd),
+
+            // Incoming frame from daemon
+            frame = connection::recv_typed_frame(&mut reader) => SelectResult::Frame(frame),
+        };
+
+        match select_result {
+            // ─── Local changes: generate sync message and send to daemon ───
+            SelectResult::Changed => {
+                // Drain any additional notifications (coalesce multiple mutations)
+                while config.changed_rx.try_recv().is_ok() {}
+
+                // Generate and send sync message
+                let msg_bytes = {
+                    let mut state = config.doc.lock().unwrap_or_else(|e| e.into_inner());
+                    state.generate_sync_message().map(|msg| msg.encode())
+                };
+
+                if let Some(bytes) = msg_bytes {
+                    if let Err(e) = connection::send_typed_frame(
+                        &mut writer,
+                        NotebookFrameType::AutomergeSync,
+                        &bytes,
+                    )
+                    .await
+                    {
+                        warn!(
+                            "[notebook-sync] Failed to send sync message for {}: {}",
+                            notebook_id, e
+                        );
+                        break;
+                    }
+                }
+
+                // Wait briefly for an ack from the daemon (like sync_to_daemon)
+                match tokio::time::timeout(
+                    Duration::from_millis(500),
+                    connection::recv_typed_frame(&mut reader),
+                )
+                .await
+                {
+                    Ok(Ok(Some(frame))) => {
+                        handle_incoming_frame(
+                            &frame,
+                            &config.doc,
+                            &mut writer,
+                            &config.snapshot_tx,
+                            &config.broadcast_tx,
+                            &notebook_id,
+                        )
+                        .await;
+                    }
+                    Ok(Ok(None)) => {
+                        info!("[notebook-sync] Connection closed for {}", notebook_id);
+                        break;
+                    }
+                    Ok(Err(e)) => {
+                        warn!("[notebook-sync] Socket error for {}: {}", notebook_id, e);
+                        break;
+                    }
+                    Err(_) => {
+                        // Timeout — daemon hasn't responded yet, that's fine
+                    }
+                }
+            }
+
+            // ─── Protocol commands ─────────────────────────────────────────
+            SelectResult::Command(cmd) => {
+                let Some(cmd) = cmd else {
+                    // Command channel closed — shut down
+                    info!(
+                        "[notebook-sync] Command channel closed for {}, shutting down",
+                        notebook_id
+                    );
+                    break;
+                };
+
+                match cmd {
+                    SyncCommand::SendRequest {
+                        request,
+                        reply,
+                        broadcast_tx: req_broadcast_tx,
+                    } => {
+                        let result = send_request_impl(
+                            &config.doc,
+                            &mut reader,
+                            &mut writer,
+                            &config.snapshot_tx,
+                            &config.broadcast_tx,
+                            req_broadcast_tx.as_ref(),
+                            &request,
+                            &notebook_id,
+                        )
+                        .await;
+                        let _ = reply.send(result);
+                    }
+
+                    SyncCommand::ConfirmSync { reply } => {
+                        let result = confirm_sync_impl(
+                            &config.doc,
+                            &mut reader,
+                            &mut writer,
+                            &config.snapshot_tx,
+                            &config.broadcast_tx,
+                            &notebook_id,
+                        )
+                        .await;
+                        let _ = reply.send(result);
+                    }
+
+                    SyncCommand::SendPresence { data, reply } => {
+                        let result = connection::send_typed_frame(
+                            &mut writer,
+                            NotebookFrameType::Presence,
+                            &data,
+                        )
+                        .await
+                        .map_err(SyncError::Io);
+                        let _ = reply.send(result);
+                    }
+
+                    SyncCommand::ReceiveFrontendSyncMessage { message, reply } => {
+                        // Apply the frontend's sync message to our doc
+                        {
+                            let mut state = config.doc.lock().unwrap_or_else(|e| e.into_inner());
+                            if let Ok(msg) = sync::Message::decode(&message) {
+                                let _ = state.receive_sync_message(msg);
+                            }
+                        }
+                        // Forward to daemon
+                        let result = connection::send_typed_frame(
+                            &mut writer,
+                            NotebookFrameType::AutomergeSync,
+                            &message,
+                        )
+                        .await
+                        .map_err(SyncError::Io);
+
+                        publish_snapshot(&config.doc, &config.snapshot_tx);
+                        let _ = reply.send(result);
+                    }
+                }
+            }
+
+            // ─── Incoming frame from daemon ────────────────────────────────
+            SelectResult::Frame(frame_result) => match frame_result {
+                Ok(Some(frame)) => {
+                    handle_incoming_frame(
+                        &frame,
+                        &config.doc,
+                        &mut writer,
+                        &config.snapshot_tx,
+                        &config.broadcast_tx,
+                        &notebook_id,
+                    )
+                    .await;
+                }
+                Ok(None) => {
+                    info!(
+                        "[notebook-sync] Disconnected from daemon for {}, loop_count={}",
+                        notebook_id, loop_count
+                    );
+                    break;
+                }
+                Err(e) => {
+                    warn!(
+                        "[notebook-sync] Socket error for {}: {}, loop_count={}",
+                        notebook_id, e, loop_count
+                    );
+                    break;
+                }
+            },
+        }
+    }
+
+    info!(
+        "[notebook-sync] Stopped for {} after {} loop iterations",
+        notebook_id, loop_count
+    );
+}
+
+// =========================================================================
+// Internal helpers
+// =========================================================================
+
+/// Handle an incoming typed frame from the daemon.
+async fn handle_incoming_frame<W: AsyncWrite + Unpin>(
+    frame: &connection::TypedNotebookFrame,
+    doc: &Arc<Mutex<SharedDocState>>,
+    writer: &mut W,
+    snapshot_tx: &Arc<tokio::sync::watch::Sender<NotebookSnapshot>>,
+    broadcast_tx: &broadcast::Sender<NotebookBroadcast>,
+    notebook_id: &str,
+) {
+    match frame.frame_type {
+        NotebookFrameType::AutomergeSync => {
+            let msg = match sync::Message::decode(&frame.payload) {
+                Ok(msg) => msg,
+                Err(e) => {
+                    warn!(
+                        "[notebook-sync] Failed to decode sync message for {}: {}",
+                        notebook_id, e
+                    );
+                    return;
+                }
+            };
+
+            // Apply and generate ack — lock held only for Automerge operations
+            let ack_bytes = {
+                let mut state = doc.lock().unwrap_or_else(|e| e.into_inner());
+                if let Err(e) = state.receive_sync_message(msg) {
+                    warn!(
+                        "[notebook-sync] Failed to apply sync message for {}: {}",
+                        notebook_id, e
+                    );
+                    return;
+                }
+                state.generate_sync_message().map(|msg| msg.encode())
+            };
+
+            // Publish snapshot immediately (before sending ack — readers see changes fast)
+            publish_snapshot(doc, snapshot_tx);
+
+            // Send ack if needed (outside the lock — never hold across I/O)
+            if let Some(bytes) = ack_bytes {
+                if let Err(e) =
+                    connection::send_typed_frame(writer, NotebookFrameType::AutomergeSync, &bytes)
+                        .await
+                {
+                    warn!(
+                        "[notebook-sync] Failed to send sync ack for {}: {}",
+                        notebook_id, e
+                    );
+                }
+            }
+        }
+
+        NotebookFrameType::Broadcast => {
+            match serde_json::from_slice::<NotebookBroadcast>(&frame.payload) {
+                Ok(bc) => {
+                    let _ = broadcast_tx.send(bc);
+                }
+                Err(e) => {
+                    warn!(
+                        "[notebook-sync] Failed to parse broadcast for {}: {}",
+                        notebook_id, e
+                    );
+                }
+            }
+        }
+
+        NotebookFrameType::Presence => {
+            // Presence frames are typically forwarded to UI — for now, log and ignore
+            debug!(
+                "[notebook-sync] Received presence frame for {} ({} bytes)",
+                notebook_id,
+                frame.payload.len()
+            );
+        }
+
+        NotebookFrameType::Response => {
+            // Unexpected outside of a request/response cycle
+            warn!(
+                "[notebook-sync] Unexpected Response frame for {} in background loop",
+                notebook_id
+            );
+        }
+
+        NotebookFrameType::Request => {
+            warn!(
+                "[notebook-sync] Unexpected Request frame from daemon for {}",
+                notebook_id
+            );
+        }
+    }
+}
+
+/// Send a request to the daemon and wait for a response.
+///
+/// While waiting, also processes AutomergeSync and Broadcast frames that arrive
+/// interleaved with the response.
+async fn send_request_impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
+    doc: &Arc<Mutex<SharedDocState>>,
+    reader: &mut R,
+    writer: &mut W,
+    snapshot_tx: &Arc<tokio::sync::watch::Sender<NotebookSnapshot>>,
+    broadcast_tx: &broadcast::Sender<NotebookBroadcast>,
+    req_broadcast_tx: Option<&broadcast::Sender<NotebookBroadcast>>,
+    request: &NotebookRequest,
+    notebook_id: &str,
+) -> Result<NotebookResponse, SyncError> {
+    // Serialize and send the request
+    let payload =
+        serde_json::to_vec(request).map_err(|e| SyncError::Serialization(e.to_string()))?;
+
+    connection::send_typed_frame(writer, NotebookFrameType::Request, &payload)
+        .await
+        .map_err(SyncError::Io)?;
+
+    // Determine timeout based on request type
+    let timeout_secs = match request {
+        NotebookRequest::LaunchKernel { .. } => 300, // 5 minutes for env creation
+        _ => 30,
+    };
+
+    // Wait for a Response frame, processing other frames that arrive meanwhile
+    let result = tokio::time::timeout(
+        Duration::from_secs(timeout_secs),
+        wait_for_response(
+            doc,
+            reader,
+            writer,
+            snapshot_tx,
+            broadcast_tx,
+            req_broadcast_tx,
+            notebook_id,
+        ),
+    )
+    .await;
+
+    match result {
+        Ok(Ok(response)) => Ok(response),
+        Ok(Err(e)) => Err(e),
+        Err(_) => Err(SyncError::Timeout),
+    }
+}
+
+/// Wait for a Response frame from the daemon, processing other frames.
+async fn wait_for_response<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
+    doc: &Arc<Mutex<SharedDocState>>,
+    reader: &mut R,
+    writer: &mut W,
+    snapshot_tx: &Arc<tokio::sync::watch::Sender<NotebookSnapshot>>,
+    broadcast_tx: &broadcast::Sender<NotebookBroadcast>,
+    req_broadcast_tx: Option<&broadcast::Sender<NotebookBroadcast>>,
+    notebook_id: &str,
+) -> Result<NotebookResponse, SyncError> {
+    loop {
+        let frame = connection::recv_typed_frame(reader)
+            .await
+            .map_err(SyncError::Io)?
+            .ok_or_else(|| SyncError::Protocol("Connection closed waiting for response".into()))?;
+
+        match frame.frame_type {
+            NotebookFrameType::Response => {
+                let response: NotebookResponse = serde_json::from_slice(&frame.payload)
+                    .map_err(|e| SyncError::Serialization(e.to_string()))?;
+                return Ok(response);
+            }
+
+            NotebookFrameType::AutomergeSync => {
+                // Apply sync message while waiting for response
+                let msg = sync::Message::decode(&frame.payload)
+                    .map_err(|e| SyncError::Protocol(format!("Decode sync: {}", e)))?;
+
+                let ack_bytes = {
+                    let mut state = doc.lock().unwrap_or_else(|e| e.into_inner());
+                    state
+                        .receive_sync_message(msg)
+                        .map_err(|e| SyncError::Protocol(format!("Apply sync: {}", e)))?;
+                    state.generate_sync_message().map(|m| m.encode())
+                };
+
+                publish_snapshot(doc, snapshot_tx);
+
+                if let Some(bytes) = ack_bytes {
+                    connection::send_typed_frame(writer, NotebookFrameType::AutomergeSync, &bytes)
+                        .await
+                        .map_err(SyncError::Io)?;
+                }
+            }
+
+            NotebookFrameType::Broadcast => {
+                if let Ok(bc) = serde_json::from_slice::<NotebookBroadcast>(&frame.payload) {
+                    // Send to request-specific broadcast channel if provided (for real-time
+                    // progress during long requests like LaunchKernel)
+                    if let Some(tx) = req_broadcast_tx {
+                        let _ = tx.send(bc.clone());
+                    }
+                    // Also send to the main broadcast channel
+                    let _ = broadcast_tx.send(bc);
+                }
+            }
+
+            _ => {
+                // Ignore other frame types while waiting for response
+                debug!(
+                    "[notebook-sync] Ignoring {:?} frame while waiting for response ({})",
+                    frame.frame_type, notebook_id
+                );
+            }
+        }
+    }
+}
+
+/// Confirm that the daemon has merged all our local changes.
+///
+/// Performs sync rounds until our local heads are in the peer's shared_heads,
+/// or until we've done 5 rounds (best-effort).
+async fn confirm_sync_impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
+    doc: &Arc<Mutex<SharedDocState>>,
+    reader: &mut R,
+    writer: &mut W,
+    snapshot_tx: &Arc<tokio::sync::watch::Sender<NotebookSnapshot>>,
+    broadcast_tx: &broadcast::Sender<NotebookBroadcast>,
+    notebook_id: &str,
+) -> Result<(), SyncError> {
+    for round in 0..5 {
+        // Generate and send sync message
+        let (msg_bytes, our_heads, shared_heads) = {
+            let mut state = doc.lock().unwrap_or_else(|e| e.into_inner());
+            let our_heads = state.doc.get_heads();
+            let shared = state.peer_state.shared_heads.clone();
+            let msg = state.generate_sync_message().map(|m| m.encode());
+            (msg, our_heads, shared)
+        };
+
+        // Check if already confirmed
+        if our_heads.is_empty() || our_heads.iter().all(|h| shared_heads.contains(h)) {
+            debug!(
+                "[notebook-sync] Sync confirmed for {} after {} rounds",
+                notebook_id, round
+            );
+            return Ok(());
+        }
+
+        // Send sync message if there is one
+        if let Some(bytes) = msg_bytes {
+            connection::send_typed_frame(writer, NotebookFrameType::AutomergeSync, &bytes)
+                .await
+                .map_err(SyncError::Io)?;
+        }
+
+        // Wait for response
+        match tokio::time::timeout(
+            Duration::from_millis(2000),
+            connection::recv_typed_frame(reader),
+        )
+        .await
+        {
+            Ok(Ok(Some(frame))) => {
+                handle_incoming_frame(&frame, doc, writer, snapshot_tx, broadcast_tx, notebook_id)
+                    .await;
+            }
+            Ok(Ok(None)) => {
+                return Err(SyncError::Protocol(
+                    "Connection closed during confirm_sync".into(),
+                ));
+            }
+            Ok(Err(e)) => {
+                return Err(SyncError::Io(e));
+            }
+            Err(_) => {
+                // Timeout — try next round
+                debug!(
+                    "[notebook-sync] confirm_sync round {} timed out for {}",
+                    round, notebook_id
+                );
+            }
+        }
+    }
+
+    // Best-effort: likely confirmed even if heads don't fully match
+    debug!(
+        "[notebook-sync] confirm_sync: heads not fully confirmed after 5 rounds for {}",
+        notebook_id
+    );
+    Ok(())
+}
+
+/// Publish a snapshot from the current document state.
+fn publish_snapshot(
+    doc: &Arc<Mutex<SharedDocState>>,
+    snapshot_tx: &Arc<tokio::sync::watch::Sender<NotebookSnapshot>>,
+) {
+    let snapshot = {
+        let state = doc.lock().unwrap_or_else(|e| e.into_inner());
+        NotebookSnapshot::from_doc(&state.doc)
+    };
+    let _ = snapshot_tx.send(snapshot);
 }

--- a/crates/notebook-sync/src/sync_task.rs
+++ b/crates/notebook-sync/src/sync_task.rs
@@ -20,7 +20,7 @@
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use automerge::sync::{self, SyncDoc};
+use automerge::sync;
 use log::{debug, info, warn};
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::sync::{broadcast, mpsc, oneshot};
@@ -110,7 +110,7 @@ where
     let mut loop_count: u64 = 0;
 
     // Track last metadata for change detection (used for SyncUpdate-like behavior)
-    let mut last_metadata: Option<notebook_doc::metadata::NotebookMetadataSnapshot> = {
+    let mut _last_metadata: Option<notebook_doc::metadata::NotebookMetadataSnapshot> = {
         let state = config.doc.lock().unwrap_or_else(|e| e.into_inner());
         notebook_doc::get_metadata_snapshot_from_doc(&state.doc)
     };
@@ -262,14 +262,23 @@ where
                     }
 
                     SyncCommand::ReceiveFrontendSyncMessage { message, reply } => {
-                        // Apply the frontend's sync message to our doc
+                        // Decode and apply the frontend's sync message to our doc.
+                        // Reject invalid bytes early — never forward garbage to the daemon.
+                        let msg = match sync::Message::decode(&message) {
+                            Ok(msg) => msg,
+                            Err(e) => {
+                                let _ = reply
+                                    .send(Err(SyncError::Protocol(format!("decode sync: {}", e))));
+                                continue;
+                            }
+                        };
+
                         {
                             let mut state = config.doc.lock().unwrap_or_else(|e| e.into_inner());
-                            if let Ok(msg) = sync::Message::decode(&message) {
-                                let _ = state.receive_sync_message(msg);
-                            }
+                            let _ = state.receive_sync_message(msg);
                         }
-                        // Forward to daemon
+
+                        // Forward valid message to daemon
                         let result = connection::send_typed_frame(
                             &mut writer,
                             NotebookFrameType::AutomergeSync,
@@ -421,6 +430,7 @@ async fn handle_incoming_frame<W: AsyncWrite + Unpin>(
 ///
 /// While waiting, also processes AutomergeSync and Broadcast frames that arrive
 /// interleaved with the response.
+#[allow(clippy::too_many_arguments)]
 async fn send_request_impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
     doc: &Arc<Mutex<SharedDocState>>,
     reader: &mut R,

--- a/crates/notebook-sync/src/sync_task.rs
+++ b/crates/notebook-sync/src/sync_task.rs
@@ -1,0 +1,134 @@
+//! Sync task — background network I/O loop.
+//!
+//! The sync task owns the socket connection to the daemon and handles:
+//!
+//! 1. **Local changes** — when `DocHandle::with_doc` mutates the document,
+//!    it sends a notification via `changed_rx`. The sync task generates an
+//!    Automerge sync message and sends it to the daemon.
+//!
+//! 2. **Remote changes** — when the daemon sends sync messages (from other
+//!    peers), the sync task applies them to the shared document and publishes
+//!    a new snapshot.
+//!
+//! 3. **Protocol operations** — daemon request/response (`SendRequest`),
+//!    sync confirmation (`ConfirmSync`), and presence frames still go through
+//!    a command channel since they need socket I/O.
+//!
+//! Document mutations do NOT go through this task. Callers mutate directly
+//! via `DocHandle::with_doc`. This task is purely for network synchronization.
+
+use std::sync::{Arc, Mutex};
+
+use tokio::sync::mpsc;
+
+use crate::shared::SharedDocState;
+use crate::snapshot::NotebookSnapshot;
+
+/// Commands that require socket I/O (not document mutations).
+///
+/// This is intentionally minimal — only operations that need the network
+/// connection go through this channel. Document mutations happen directly
+/// on the `DocHandle` via `with_doc`.
+pub enum SyncCommand {
+    // TODO: SendRequest, ConfirmSync, SendPresence, ReceiveFrontendSyncMessage
+    //
+    // These will be ported from the existing NotebookSyncClient as the
+    // migration progresses. Each carries a oneshot reply channel for the
+    // caller to await the result.
+}
+
+/// Configuration for the sync task.
+pub struct SyncTaskConfig {
+    /// Shared document state (same Arc as DocHandle).
+    pub doc: Arc<Mutex<SharedDocState>>,
+
+    /// Receives notifications when the document was mutated locally.
+    /// The sync task should generate and send a sync message to the daemon.
+    pub changed_rx: mpsc::UnboundedReceiver<()>,
+
+    /// Receives protocol commands (request/response, confirm_sync, presence).
+    pub cmd_rx: mpsc::Receiver<SyncCommand>,
+
+    /// Watch sender for publishing snapshots after applying remote changes.
+    pub snapshot_tx: Arc<tokio::sync::watch::Sender<NotebookSnapshot>>,
+}
+
+/// Run the sync task.
+///
+/// This is spawned as a background tokio task. It runs until the socket
+/// closes or all handles are dropped (channels close).
+///
+/// # Architecture
+///
+/// ```text
+/// loop {
+///     select! {
+///         // Local doc changed → generate sync message → send to daemon
+///         _ = changed_rx.recv() => { ... }
+///
+///         // Incoming frame from daemon → apply to doc → publish snapshot
+///         frame = recv_frame(&mut stream) => { ... }
+///
+///         // Protocol command (request/response, etc.)
+///         cmd = cmd_rx.recv() => { ... }
+///     }
+/// }
+/// ```
+///
+/// The document mutex is held briefly for sync message generation/application.
+/// It is NEVER held across `.await` points (socket I/O).
+pub async fn run<S>(_config: SyncTaskConfig, _stream: S)
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+{
+    // TODO: Port the sync loop from notebook_sync_client.rs::run_sync_task.
+    //
+    // The key difference from the current implementation:
+    //
+    // 1. No document mutation commands to handle (those happen on DocHandle)
+    // 2. The `changed_rx` channel replaces the mutation commands —
+    //    when it fires, lock the doc, generate_sync_message, send to daemon
+    // 3. Incoming frames: lock the doc, receive_sync_message, publish snapshot
+    // 4. Protocol commands (SendRequest etc.): same as current implementation
+    //
+    // The select! loop structure:
+    //
+    // loop {
+    //     select! {
+    //         // Drain all pending change notifications (coalesce)
+    //         _ = changed_rx.recv() => {
+    //             // Drain any additional notifications (coalesce multiple mutations)
+    //             while changed_rx.try_recv().is_ok() {}
+    //             let mut state = config.doc.lock().unwrap();
+    //             if let Some(msg) = state.generate_sync_message() {
+    //                 let msg_bytes = msg.encode();
+    //                 drop(state);  // release before I/O
+    //                 send_sync_frame(&mut stream, &msg_bytes).await;
+    //             }
+    //         }
+    //
+    //         // Incoming frame from daemon
+    //         frame = recv_frame(&mut stream) => {
+    //             match frame {
+    //                 AutomergeSync(payload) => {
+    //                     let msg = sync::Message::decode(&payload)?;
+    //                     let mut state = config.doc.lock().unwrap();
+    //                     state.receive_sync_message(msg)?;
+    //                     let snapshot = NotebookSnapshot::from_doc(&state.doc);
+    //                     drop(state);
+    //                     config.snapshot_tx.send(snapshot);
+    //                     // Generate response sync message if needed
+    //                     ...
+    //                 }
+    //                 Broadcast(payload) => { ... }
+    //                 ...
+    //             }
+    //         }
+    //
+    //         // Protocol commands
+    //         cmd = cmd_rx.recv() => { ... }
+    //     }
+    // }
+
+    log::info!("[notebook-sync] Sync task stub — not yet implemented");
+}

--- a/crates/notebook-sync/src/tests.rs
+++ b/crates/notebook-sync/src/tests.rs
@@ -4,6 +4,7 @@
 //! Integration tests (behind `#[ignore]`) connect to a running daemon.
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use std::sync::{Arc, Mutex};
 
@@ -561,6 +562,7 @@ mod tests {
 // =========================================================================
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod integration_tests {
     use std::path::PathBuf;
     use std::time::Duration;

--- a/crates/notebook-sync/src/tests.rs
+++ b/crates/notebook-sync/src/tests.rs
@@ -1,0 +1,391 @@
+//! Unit tests for notebook-sync.
+//!
+//! These tests verify the DocHandle pattern without a daemon connection.
+//! They exercise the shared state, snapshot publishing, and with_doc closure API.
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use automerge::AutoCommit;
+    use tokio::sync::{mpsc, watch};
+
+    use crate::handle::DocHandle;
+    use crate::shared::SharedDocState;
+    use crate::snapshot::NotebookSnapshot;
+
+    /// Create a DocHandle wired up with channels but no sync task.
+    /// Good for testing the handle's local behavior in isolation.
+    fn test_handle() -> (
+        DocHandle,
+        mpsc::UnboundedReceiver<()>,
+        mpsc::Receiver<crate::sync_task::SyncCommand>,
+    ) {
+        // Use NotebookDoc::new() to get a properly initialized doc with schema
+        let nd = notebook_doc::NotebookDoc::new("test-notebook");
+        let doc = nd.into_inner();
+        let shared = Arc::new(Mutex::new(SharedDocState::new(doc, "test-notebook".into())));
+
+        let initial_snapshot = NotebookSnapshot::empty();
+        let (snapshot_tx, snapshot_rx) = watch::channel(initial_snapshot);
+        let snapshot_tx = Arc::new(snapshot_tx);
+        let (changed_tx, changed_rx) = mpsc::unbounded_channel();
+        let (cmd_tx, cmd_rx) = mpsc::channel(32);
+
+        let handle = DocHandle::new(
+            shared,
+            changed_tx,
+            cmd_tx,
+            snapshot_tx,
+            snapshot_rx,
+            "test-notebook".into(),
+        );
+
+        (handle, changed_rx, cmd_rx)
+    }
+
+    #[test]
+    fn test_notebook_id() {
+        let (handle, _changed_rx, _cmd_rx) = test_handle();
+        assert_eq!(handle.notebook_id(), "test-notebook");
+    }
+
+    #[test]
+    fn test_with_doc_returns_value() {
+        let (handle, _changed_rx, _cmd_rx) = test_handle();
+
+        let result = handle.with_doc(|_doc| 42).unwrap();
+        assert_eq!(result, 42);
+    }
+
+    #[test]
+    fn test_with_doc_can_return_result() {
+        let (handle, _changed_rx, _cmd_rx) = test_handle();
+
+        let result: Result<Result<String, String>, _> =
+            handle.with_doc(|_doc| Ok("hello".to_string()));
+
+        assert_eq!(result.unwrap().unwrap(), "hello");
+    }
+
+    #[test]
+    fn test_with_doc_notifies_changed() {
+        let (handle, mut changed_rx, _cmd_rx) = test_handle();
+
+        // No notification yet
+        assert!(changed_rx.try_recv().is_err());
+
+        // Mutate the doc
+        handle.with_doc(|_doc| {}).unwrap();
+
+        // Should have received a change notification
+        assert!(changed_rx.try_recv().is_ok());
+    }
+
+    #[test]
+    fn test_with_doc_publishes_snapshot() {
+        let (handle, _changed_rx, _cmd_rx) = test_handle();
+
+        // Initial snapshot has no cells
+        let snap = handle.snapshot();
+        assert_eq!(snap.cell_count(), 0);
+
+        // Add a cell via with_doc using raw Automerge operations
+        handle
+            .with_doc(|doc| {
+                use automerge::transaction::Transactable;
+                use automerge::ObjType;
+
+                // Create the schema: cells map
+                let cells_id = doc
+                    .put_object(automerge::ROOT, "cells", ObjType::Map)
+                    .unwrap();
+                let cell_id = doc.put_object(&cells_id, "cell-1", ObjType::Map).unwrap();
+                doc.put(&cell_id, "id", "cell-1").unwrap();
+                doc.put(&cell_id, "cell_type", "code").unwrap();
+                doc.put(&cell_id, "position", "80").unwrap();
+                doc.put_object(&cell_id, "source", ObjType::Text).unwrap();
+                doc.put(&cell_id, "execution_count", "null").unwrap();
+                doc.put_object(&cell_id, "outputs", ObjType::List).unwrap();
+                doc.put_object(&cell_id, "metadata", ObjType::Map).unwrap();
+                doc.put_object(&cell_id, "resolved_assets", ObjType::Map)
+                    .unwrap();
+            })
+            .unwrap();
+
+        // Snapshot should now have the cell
+        let snap = handle.snapshot();
+        assert_eq!(snap.cell_count(), 1);
+        assert_eq!(snap.cells()[0].id, "cell-1");
+        assert_eq!(snap.cells()[0].cell_type, "code");
+    }
+
+    #[test]
+    fn test_with_doc_using_notebook_doc() {
+        let (handle, _changed_rx, _cmd_rx) = test_handle();
+
+        // Use NotebookDoc wrapper for typed operations
+        handle
+            .with_doc(|doc| {
+                let mut nd = notebook_doc::NotebookDoc::wrap(std::mem::take(doc));
+                nd.add_cell(0, "cell-1", "code").unwrap();
+                nd.update_source("cell-1", "print('hello')").unwrap();
+                *doc = nd.into_inner();
+            })
+            .unwrap();
+
+        let snap = handle.snapshot();
+        assert_eq!(snap.cell_count(), 1);
+
+        let cell = snap.get_cell("cell-1").unwrap();
+        assert_eq!(cell.source, "print('hello')");
+        assert_eq!(cell.cell_type, "code");
+    }
+
+    #[test]
+    fn test_multiple_mutations_coalesce_notifications() {
+        let (handle, mut changed_rx, _cmd_rx) = test_handle();
+
+        // Multiple mutations
+        handle.with_doc(|_doc| {}).unwrap();
+        handle.with_doc(|_doc| {}).unwrap();
+        handle.with_doc(|_doc| {}).unwrap();
+
+        // Should have 3 notifications (one per with_doc call)
+        // The sync task would coalesce these, but the channel has all of them
+        let mut count = 0;
+        while changed_rx.try_recv().is_ok() {
+            count += 1;
+        }
+        assert_eq!(count, 3);
+    }
+
+    #[test]
+    fn test_snapshot_reflects_latest_mutation() {
+        let (handle, _changed_rx, _cmd_rx) = test_handle();
+
+        handle
+            .with_doc(|doc| {
+                let mut nd = notebook_doc::NotebookDoc::wrap(std::mem::take(doc));
+                nd.add_cell(0, "cell-1", "code").unwrap();
+                nd.update_source("cell-1", "x = 1").unwrap();
+                *doc = nd.into_inner();
+            })
+            .unwrap();
+
+        assert_eq!(
+            handle.snapshot().get_cell("cell-1").unwrap().source,
+            "x = 1"
+        );
+
+        // Update the source
+        handle
+            .with_doc(|doc| {
+                let mut nd = notebook_doc::NotebookDoc::wrap(std::mem::take(doc));
+                nd.update_source("cell-1", "x = 2").unwrap();
+                *doc = nd.into_inner();
+            })
+            .unwrap();
+
+        // Snapshot should reflect the latest mutation immediately
+        assert_eq!(
+            handle.snapshot().get_cell("cell-1").unwrap().source,
+            "x = 2"
+        );
+    }
+
+    #[test]
+    fn test_get_cells_convenience() {
+        let (handle, _changed_rx, _cmd_rx) = test_handle();
+
+        handle
+            .with_doc(|doc| {
+                let mut nd = notebook_doc::NotebookDoc::wrap(std::mem::take(doc));
+                nd.add_cell(0, "cell-a", "code").unwrap();
+                nd.add_cell(1, "cell-b", "markdown").unwrap();
+                *doc = nd.into_inner();
+            })
+            .unwrap();
+
+        let cells = handle.get_cells();
+        assert_eq!(cells.len(), 2);
+        assert_eq!(cells[0].id, "cell-a");
+        assert_eq!(cells[1].id, "cell-b");
+    }
+
+    #[test]
+    fn test_handle_is_clone() {
+        let (handle, _changed_rx, _cmd_rx) = test_handle();
+
+        let handle2 = handle.clone();
+
+        // Mutate via first handle
+        handle
+            .with_doc(|doc| {
+                let mut nd = notebook_doc::NotebookDoc::wrap(std::mem::take(doc));
+                nd.add_cell(0, "cell-1", "code").unwrap();
+                *doc = nd.into_inner();
+            })
+            .unwrap();
+
+        // Second handle sees the same state
+        assert_eq!(handle2.snapshot().cell_count(), 1);
+        assert_eq!(handle2.get_cells()[0].id, "cell-1");
+    }
+
+    #[test]
+    fn test_subscribe_receives_updates() {
+        let (handle, _changed_rx, _cmd_rx) = test_handle();
+
+        let mut subscriber = handle.subscribe();
+
+        handle
+            .with_doc(|doc| {
+                let mut nd = notebook_doc::NotebookDoc::wrap(std::mem::take(doc));
+                nd.add_cell(0, "cell-1", "code").unwrap();
+                *doc = nd.into_inner();
+            })
+            .unwrap();
+
+        // The subscriber should see the change
+        assert!(subscriber.has_changed().unwrap_or(false));
+        let snap = subscriber.borrow_and_update().clone();
+        assert_eq!(snap.cell_count(), 1);
+    }
+
+    #[test]
+    fn test_metadata_operations() {
+        let (handle, _changed_rx, _cmd_rx) = test_handle();
+
+        // Initially no metadata
+        assert!(handle.get_notebook_metadata().is_none());
+
+        // Set metadata via with_doc
+        handle
+            .with_doc(|doc| {
+                let mut nd = notebook_doc::NotebookDoc::wrap(std::mem::take(doc));
+
+                let snapshot = notebook_doc::metadata::NotebookMetadataSnapshot {
+                    kernelspec: Some(notebook_doc::metadata::KernelspecSnapshot {
+                        name: "python3".into(),
+                        display_name: "Python 3".into(),
+                        language: Some("python".into()),
+                    }),
+                    language_info: None,
+                    runt: notebook_doc::metadata::RuntMetadata::default(),
+                };
+                nd.set_metadata_snapshot(&snapshot).unwrap();
+                *doc = nd.into_inner();
+            })
+            .unwrap();
+
+        // Should be readable from the snapshot
+        let meta = handle.get_notebook_metadata().unwrap();
+        let ks = meta.kernelspec.unwrap();
+        assert_eq!(ks.name, "python3");
+        assert_eq!(ks.display_name, "Python 3");
+        assert_eq!(ks.language.unwrap(), "python");
+    }
+
+    #[test]
+    fn test_cell_metadata_via_with_doc() {
+        let (handle, _changed_rx, _cmd_rx) = test_handle();
+
+        handle
+            .with_doc(|doc| {
+                let mut nd = notebook_doc::NotebookDoc::wrap(std::mem::take(doc));
+                nd.add_cell(0, "cell-1", "code").unwrap();
+                nd.set_cell_source_hidden("cell-1", true).unwrap();
+                nd.set_cell_outputs_hidden("cell-1", true).unwrap();
+                *doc = nd.into_inner();
+            })
+            .unwrap();
+
+        let cell = handle.snapshot().get_cell("cell-1").unwrap().clone();
+        assert!(cell.is_source_hidden());
+        assert!(cell.is_outputs_hidden());
+    }
+
+    #[test]
+    fn test_empty_snapshot() {
+        let snap = NotebookSnapshot::empty();
+        assert_eq!(snap.cell_count(), 0);
+        assert!(snap.cells().is_empty());
+        assert!(snap.notebook_metadata().is_none());
+        assert!(snap.get_cell("nonexistent").is_none());
+    }
+
+    #[test]
+    fn test_shared_doc_state_new() {
+        let doc = AutoCommit::new();
+        let state = SharedDocState::new(doc, "test-id".into());
+        assert_eq!(state.notebook_id(), "test-id");
+    }
+
+    #[test]
+    fn test_shared_doc_state_sync_message_empty_doc() {
+        let doc = AutoCommit::new();
+        let mut state = SharedDocState::new(doc, "test-id".into());
+
+        // A fresh doc with no changes should have no sync message for a fresh peer
+        // (both are empty, nothing to sync)
+        let msg = state.generate_sync_message();
+        // First sync message is always generated (contains bloom filter)
+        assert!(msg.is_some());
+    }
+
+    #[test]
+    fn test_with_doc_error_propagation() {
+        let (handle, _changed_rx, _cmd_rx) = test_handle();
+
+        let result: Result<Result<(), String>, _> =
+            handle.with_doc(|_doc| Err("something went wrong".to_string()));
+
+        // The outer Result is Ok (no lock poison), inner is Err
+        let inner = result.unwrap();
+        assert!(inner.is_err());
+        assert_eq!(inner.unwrap_err(), "something went wrong");
+    }
+
+    #[test]
+    fn test_concurrent_access_from_multiple_threads() {
+        let (handle, _changed_rx, _cmd_rx) = test_handle();
+
+        let handle1 = handle.clone();
+        let handle2 = handle.clone();
+
+        // Spawn two threads that mutate concurrently
+        let t1 = std::thread::spawn(move || {
+            for i in 0..10 {
+                handle1
+                    .with_doc(|doc| {
+                        let mut nd = notebook_doc::NotebookDoc::wrap(std::mem::take(doc));
+                        let cell_id = format!("thread1-cell-{}", i);
+                        nd.add_cell(0, &cell_id, "code").unwrap();
+                        *doc = nd.into_inner();
+                    })
+                    .unwrap();
+            }
+        });
+
+        let t2 = std::thread::spawn(move || {
+            for i in 0..10 {
+                handle2
+                    .with_doc(|doc| {
+                        let mut nd = notebook_doc::NotebookDoc::wrap(std::mem::take(doc));
+                        let cell_id = format!("thread2-cell-{}", i);
+                        nd.add_cell(0, &cell_id, "code").unwrap();
+                        *doc = nd.into_inner();
+                    })
+                    .unwrap();
+            }
+        });
+
+        t1.join().unwrap();
+        t2.join().unwrap();
+
+        // All 20 cells should be present
+        let cells = handle.get_cells();
+        assert_eq!(cells.len(), 20);
+    }
+}

--- a/crates/notebook-sync/src/tests.rs
+++ b/crates/notebook-sync/src/tests.rs
@@ -1,7 +1,7 @@
-//! Unit tests for notebook-sync.
+//! Tests for notebook-sync.
 //!
-//! These tests verify the DocHandle pattern without a daemon connection.
-//! They exercise the shared state, snapshot publishing, and with_doc closure API.
+//! Unit tests verify the DocHandle pattern without a daemon connection.
+//! Integration tests (behind `#[ignore]`) connect to a running daemon.
 
 #[cfg(test)]
 mod tests {
@@ -104,7 +104,7 @@ mod tests {
                 doc.put(&cell_id, "id", "cell-1").unwrap();
                 doc.put(&cell_id, "cell_type", "code").unwrap();
                 doc.put(&cell_id, "position", "80").unwrap();
-                doc.put_object(&cell_id, "source", ObjType::Text).unwrap();
+                let _source_id = doc.put_object(&cell_id, "source", ObjType::Text).unwrap();
                 doc.put(&cell_id, "execution_count", "null").unwrap();
                 doc.put_object(&cell_id, "outputs", ObjType::List).unwrap();
                 doc.put_object(&cell_id, "metadata", ObjType::Map).unwrap();
@@ -128,7 +128,7 @@ mod tests {
         handle
             .with_doc(|doc| {
                 let mut nd = notebook_doc::NotebookDoc::wrap(std::mem::take(doc));
-                nd.add_cell(0, "cell-1", "code").unwrap();
+                nd.add_cell_after("cell-1", "code", None).unwrap();
                 nd.update_source("cell-1", "print('hello')").unwrap();
                 *doc = nd.into_inner();
             })
@@ -167,7 +167,7 @@ mod tests {
         handle
             .with_doc(|doc| {
                 let mut nd = notebook_doc::NotebookDoc::wrap(std::mem::take(doc));
-                nd.add_cell(0, "cell-1", "code").unwrap();
+                nd.add_cell_after("cell-1", "code", None).unwrap();
                 nd.update_source("cell-1", "x = 1").unwrap();
                 *doc = nd.into_inner();
             })
@@ -201,8 +201,9 @@ mod tests {
         handle
             .with_doc(|doc| {
                 let mut nd = notebook_doc::NotebookDoc::wrap(std::mem::take(doc));
-                nd.add_cell(0, "cell-a", "code").unwrap();
-                nd.add_cell(1, "cell-b", "markdown").unwrap();
+                nd.add_cell_after("cell-a", "code", None).unwrap();
+                nd.add_cell_after("cell-b", "markdown", Some("cell-a"))
+                    .unwrap();
                 *doc = nd.into_inner();
             })
             .unwrap();
@@ -223,7 +224,7 @@ mod tests {
         handle
             .with_doc(|doc| {
                 let mut nd = notebook_doc::NotebookDoc::wrap(std::mem::take(doc));
-                nd.add_cell(0, "cell-1", "code").unwrap();
+                nd.add_cell_after("cell-1", "code", None).unwrap();
                 *doc = nd.into_inner();
             })
             .unwrap();
@@ -242,7 +243,7 @@ mod tests {
         handle
             .with_doc(|doc| {
                 let mut nd = notebook_doc::NotebookDoc::wrap(std::mem::take(doc));
-                nd.add_cell(0, "cell-1", "code").unwrap();
+                nd.add_cell_after("cell-1", "code", None).unwrap();
                 *doc = nd.into_inner();
             })
             .unwrap();
@@ -294,7 +295,7 @@ mod tests {
         handle
             .with_doc(|doc| {
                 let mut nd = notebook_doc::NotebookDoc::wrap(std::mem::take(doc));
-                nd.add_cell(0, "cell-1", "code").unwrap();
+                nd.add_cell_after("cell-1", "code", None).unwrap();
                 nd.set_cell_source_hidden("cell-1", true).unwrap();
                 nd.set_cell_outputs_hidden("cell-1", true).unwrap();
                 *doc = nd.into_inner();
@@ -361,7 +362,7 @@ mod tests {
                     .with_doc(|doc| {
                         let mut nd = notebook_doc::NotebookDoc::wrap(std::mem::take(doc));
                         let cell_id = format!("thread1-cell-{}", i);
-                        nd.add_cell(0, &cell_id, "code").unwrap();
+                        nd.add_cell_after(&cell_id, "code", None).unwrap();
                         *doc = nd.into_inner();
                     })
                     .unwrap();
@@ -374,7 +375,7 @@ mod tests {
                     .with_doc(|doc| {
                         let mut nd = notebook_doc::NotebookDoc::wrap(std::mem::take(doc));
                         let cell_id = format!("thread2-cell-{}", i);
-                        nd.add_cell(0, &cell_id, "code").unwrap();
+                        nd.add_cell_after(&cell_id, "code", None).unwrap();
                         *doc = nd.into_inner();
                     })
                     .unwrap();
@@ -387,5 +388,429 @@ mod tests {
         // All 20 cells should be present
         let cells = handle.get_cells();
         assert_eq!(cells.len(), 20);
+    }
+
+    // =====================================================================
+    // Convenience method tests
+    // =====================================================================
+
+    #[test]
+    fn test_convenience_add_cell() {
+        let (handle, _changed_rx, _cmd_rx) = test_handle();
+
+        handle.add_cell_after("cell-1", "code", None).unwrap();
+
+        let cells = handle.get_cells();
+        assert_eq!(cells.len(), 1);
+        assert_eq!(cells[0].id, "cell-1");
+        assert_eq!(cells[0].cell_type, "code");
+    }
+
+    #[test]
+    fn test_convenience_add_cell_with_source() {
+        let (handle, _changed_rx, _cmd_rx) = test_handle();
+
+        handle
+            .add_cell_with_source("cell-1", "code", None, "x = 42")
+            .unwrap();
+
+        let cell = handle.snapshot().get_cell("cell-1").unwrap().clone();
+        assert_eq!(cell.source, "x = 42");
+    }
+
+    #[test]
+    fn test_convenience_update_source() {
+        let (handle, _changed_rx, _cmd_rx) = test_handle();
+
+        handle.add_cell_after("cell-1", "code", None).unwrap();
+        handle.update_source("cell-1", "y = 100").unwrap();
+
+        let cell = handle.snapshot().get_cell("cell-1").unwrap().clone();
+        assert_eq!(cell.source, "y = 100");
+    }
+
+    #[test]
+    fn test_convenience_append_source() {
+        let (handle, _changed_rx, _cmd_rx) = test_handle();
+
+        handle
+            .add_cell_with_source("cell-1", "code", None, "x = 1")
+            .unwrap();
+        handle.append_source("cell-1", "\ny = 2").unwrap();
+
+        let cell = handle.snapshot().get_cell("cell-1").unwrap().clone();
+        assert_eq!(cell.source, "x = 1\ny = 2");
+    }
+
+    #[test]
+    fn test_convenience_delete_cell() {
+        let (handle, _changed_rx, _cmd_rx) = test_handle();
+
+        handle.add_cell_after("cell-1", "code", None).unwrap();
+        handle
+            .add_cell_after("cell-2", "code", Some("cell-1"))
+            .unwrap();
+        assert_eq!(handle.get_cells().len(), 2);
+
+        let deleted = handle.delete_cell("cell-1").unwrap();
+        assert!(deleted);
+        assert_eq!(handle.get_cells().len(), 1);
+        assert_eq!(handle.get_cells()[0].id, "cell-2");
+    }
+
+    #[test]
+    fn test_convenience_set_metadata_snapshot() {
+        let (handle, _changed_rx, _cmd_rx) = test_handle();
+
+        let snapshot = notebook_doc::metadata::NotebookMetadataSnapshot {
+            kernelspec: Some(notebook_doc::metadata::KernelspecSnapshot {
+                name: "deno".into(),
+                display_name: "Deno".into(),
+                language: Some("typescript".into()),
+            }),
+            language_info: None,
+            runt: notebook_doc::metadata::RuntMetadata::default(),
+        };
+
+        handle.set_metadata_snapshot(&snapshot).unwrap();
+
+        let meta = handle.get_notebook_metadata().unwrap();
+        assert_eq!(meta.kernelspec.unwrap().name, "deno");
+    }
+
+    #[test]
+    fn test_convenience_cell_visibility() {
+        let (handle, _changed_rx, _cmd_rx) = test_handle();
+
+        handle.add_cell_after("cell-1", "code", None).unwrap();
+
+        handle.set_cell_source_hidden("cell-1", true).unwrap();
+        assert!(handle
+            .snapshot()
+            .get_cell("cell-1")
+            .unwrap()
+            .is_source_hidden());
+
+        handle.set_cell_outputs_hidden("cell-1", true).unwrap();
+        assert!(handle
+            .snapshot()
+            .get_cell("cell-1")
+            .unwrap()
+            .is_outputs_hidden());
+    }
+
+    #[test]
+    fn test_convenience_uv_dependencies() {
+        let (handle, _changed_rx, _cmd_rx) = test_handle();
+
+        handle.add_uv_dependency("pandas>=2.0").unwrap();
+        handle.add_uv_dependency("requests").unwrap();
+
+        let meta = handle.get_notebook_metadata().unwrap();
+        let deps = meta.runt.uv.unwrap().dependencies;
+        assert_eq!(deps.len(), 2);
+        assert!(deps.contains(&"pandas>=2.0".to_string()));
+        assert!(deps.contains(&"requests".to_string()));
+
+        let removed = handle.remove_uv_dependency("pandas").unwrap();
+        assert!(removed);
+
+        let meta = handle.get_notebook_metadata().unwrap();
+        let deps = meta.runt.uv.unwrap().dependencies;
+        assert_eq!(deps.len(), 1);
+        assert_eq!(deps[0], "requests");
+    }
+
+    #[test]
+    fn test_atomic_compound_operation() {
+        let (handle, mut changed_rx, _cmd_rx) = test_handle();
+
+        // Drain any existing notifications
+        while changed_rx.try_recv().is_ok() {}
+
+        // Compound operation: add cell + set source + set metadata, all in one lock
+        handle
+            .with_doc(|doc| {
+                let mut nd = notebook_doc::NotebookDoc::wrap(std::mem::take(doc));
+                nd.add_cell_after("cell-1", "code", None).unwrap();
+                nd.update_source("cell-1", "print('atomic')").unwrap();
+                nd.set_cell_source_hidden("cell-1", true).unwrap();
+                *doc = nd.into_inner();
+            })
+            .unwrap();
+
+        // Only ONE change notification (atomic)
+        let mut count = 0;
+        while changed_rx.try_recv().is_ok() {
+            count += 1;
+        }
+        assert_eq!(
+            count, 1,
+            "compound with_doc should produce exactly one notification"
+        );
+
+        // All mutations visible
+        let cell = handle.snapshot().get_cell("cell-1").unwrap().clone();
+        assert_eq!(cell.source, "print('atomic')");
+        assert!(cell.is_source_hidden());
+    }
+}
+
+// =========================================================================
+// Integration tests (require a running daemon)
+// =========================================================================
+
+#[cfg(test)]
+mod integration_tests {
+    use std::path::PathBuf;
+    use std::time::Duration;
+
+    use runtimed::protocol::{NotebookBroadcast, NotebookRequest, NotebookResponse};
+
+    /// Get the daemon socket path for the current worktree.
+    fn daemon_socket_path() -> PathBuf {
+        // Use the same logic as the Python tests: check env vars first
+        if let Ok(path) = std::env::var("RUNTIMED_SOCKET_PATH") {
+            return PathBuf::from(path);
+        }
+        runtimed::default_socket_path()
+    }
+
+    /// Check if a daemon is running and available.
+    fn daemon_available() -> bool {
+        let path = daemon_socket_path();
+        path.exists()
+    }
+
+    #[tokio::test]
+    #[ignore] // Run with: cargo test -p notebook-sync -- --ignored
+    async fn test_connect_to_daemon() {
+        if !daemon_available() {
+            eprintln!("Skipping: no daemon running");
+            return;
+        }
+
+        let result = crate::connect::connect(daemon_socket_path(), "test-connect".into()).await;
+
+        assert!(result.is_ok(), "Failed to connect: {:?}", result.err());
+
+        let conn = result.unwrap();
+        assert_eq!(conn.handle.notebook_id(), "test-connect");
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn test_create_cell_and_read_back() {
+        if !daemon_available() {
+            eprintln!("Skipping: no daemon running");
+            return;
+        }
+
+        let conn = crate::connect::connect(
+            daemon_socket_path(),
+            format!("test-cell-{}", uuid::Uuid::new_v4()),
+        )
+        .await
+        .expect("connect");
+
+        let handle = conn.handle;
+
+        // Create a cell with source
+        handle
+            .add_cell_with_source("cell-1", "code", None, "x = 42")
+            .expect("add_cell_with_source");
+
+        // Confirm the daemon has our changes
+        handle.confirm_sync().await.expect("confirm_sync");
+
+        // Read back via snapshot
+        let snap = handle.snapshot();
+        let cell = snap.get_cell("cell-1").expect("cell should exist");
+        assert_eq!(cell.source, "x = 42");
+        assert_eq!(cell.cell_type, "code");
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn test_execute_cell_and_get_outputs() {
+        if !daemon_available() {
+            eprintln!("Skipping: no daemon running");
+            return;
+        }
+
+        let notebook_id = format!("test-exec-{}", uuid::Uuid::new_v4());
+        let conn = crate::connect::connect(daemon_socket_path(), notebook_id)
+            .await
+            .expect("connect");
+
+        let handle = conn.handle;
+        let mut broadcast_rx = conn.broadcast_rx;
+
+        // Start a kernel
+        let response = handle
+            .send_request(NotebookRequest::LaunchKernel {
+                kernel_type: "python".into(),
+                env_source: "auto".into(),
+                notebook_path: None,
+            })
+            .await
+            .expect("launch kernel");
+
+        match response {
+            NotebookResponse::KernelLaunched { .. }
+            | NotebookResponse::KernelAlreadyRunning { .. } => {}
+            other => panic!("Unexpected response: {:?}", other),
+        }
+
+        // Create a cell that prints something
+        handle
+            .add_cell_with_source(
+                "cell-exec",
+                "code",
+                None,
+                "print('hello from notebook-sync')",
+            )
+            .expect("add_cell");
+
+        // Confirm sync so daemon has the cell
+        handle.confirm_sync().await.expect("confirm_sync");
+
+        // Execute
+        let response = handle
+            .send_request(NotebookRequest::ExecuteCell {
+                cell_id: "cell-exec".into(),
+            })
+            .await
+            .expect("execute");
+
+        match response {
+            NotebookResponse::CellQueued { .. } => {}
+            other => panic!("Expected CellQueued, got: {:?}", other),
+        }
+
+        // Wait for ExecutionDone via broadcast
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(30);
+        let mut got_done = false;
+
+        while tokio::time::Instant::now() < deadline {
+            match tokio::time::timeout(Duration::from_millis(500), broadcast_rx.recv()).await {
+                Ok(Ok(NotebookBroadcast::ExecutionDone { cell_id })) if cell_id == "cell-exec" => {
+                    got_done = true;
+                    break;
+                }
+                Ok(Ok(_)) => continue, // other broadcasts
+                Ok(Err(_)) => break,   // channel lagged or closed
+                Err(_) => continue,    // timeout, keep waiting
+            }
+        }
+
+        assert!(got_done, "Did not receive ExecutionDone within 30s");
+
+        // Confirm sync to ensure outputs are in our doc
+        handle
+            .confirm_sync()
+            .await
+            .expect("confirm_sync after exec");
+
+        // Read outputs from the Automerge doc (source of truth)
+        // Outputs are stored as manifest hashes (blob references) or raw JSON —
+        // the important thing is that they exist after execution.
+        let snap = handle.snapshot();
+        let cell = snap.get_cell("cell-exec").expect("cell should exist");
+
+        assert!(
+            !cell.outputs.is_empty(),
+            "Cell should have outputs after execution"
+        );
+
+        // Verify execution_count was set (proves the cell actually ran)
+        assert_ne!(
+            cell.execution_count, "null",
+            "execution_count should be set after execution, got: {}",
+            cell.execution_count
+        );
+
+        // Shutdown kernel
+        let _ = handle
+            .send_request(NotebookRequest::ShutdownKernel {})
+            .await;
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn test_two_handles_share_state() {
+        if !daemon_available() {
+            eprintln!("Skipping: no daemon running");
+            return;
+        }
+
+        let notebook_id = format!("test-share-{}", uuid::Uuid::new_v4());
+
+        // First handle connects and creates a cell
+        let conn1 = crate::connect::connect(daemon_socket_path(), notebook_id.clone())
+            .await
+            .expect("connect 1");
+
+        conn1
+            .handle
+            .add_cell_with_source("shared-cell", "code", None, "shared = True")
+            .expect("add_cell");
+
+        conn1.handle.confirm_sync().await.expect("confirm_sync 1");
+
+        // Second handle connects to the same notebook
+        let conn2 = crate::connect::connect(daemon_socket_path(), notebook_id)
+            .await
+            .expect("connect 2");
+
+        // Second handle should see the cell created by the first
+        let snap = conn2.handle.snapshot();
+        let cell = snap.get_cell("shared-cell");
+        assert!(
+            cell.is_some(),
+            "Second handle should see cell created by first"
+        );
+        assert_eq!(cell.unwrap().source, "shared = True");
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn test_metadata_round_trip_via_daemon() {
+        if !daemon_available() {
+            eprintln!("Skipping: no daemon running");
+            return;
+        }
+
+        let notebook_id = format!("test-meta-{}", uuid::Uuid::new_v4());
+        let conn = crate::connect::connect(daemon_socket_path(), notebook_id)
+            .await
+            .expect("connect");
+
+        let handle = conn.handle;
+
+        // Set metadata
+        let snapshot = notebook_doc::metadata::NotebookMetadataSnapshot {
+            kernelspec: Some(notebook_doc::metadata::KernelspecSnapshot {
+                name: "python3".into(),
+                display_name: "Python 3".into(),
+                language: Some("python".into()),
+            }),
+            language_info: None,
+            runt: notebook_doc::metadata::RuntMetadata::default(),
+        };
+
+        handle
+            .set_metadata_snapshot(&snapshot)
+            .expect("set_metadata_snapshot");
+
+        handle.confirm_sync().await.expect("confirm_sync");
+
+        // Read back
+        let meta = handle
+            .get_notebook_metadata()
+            .expect("should have metadata");
+        let ks = meta.kernelspec.expect("should have kernelspec");
+        assert_eq!(ks.name, "python3");
+        assert_eq!(ks.display_name, "Python 3");
     }
 }


### PR DESCRIPTION
New `notebook-sync` crate implementing the [samod](https://github.com/alexjg/samod)-inspired architecture for notebook document sync. Replaces the `SyncCommand` channel pattern with direct document access via `DocHandle::with_doc`.

### The problem with our current sync client

`NotebookSyncHandle` communicates with the sync task via 14+ `SyncCommand` enum variants for every document mutation. Values are serialized to strings to cross the channel boundary. The sync task is a bottleneck - all mutations are serialized through one task. Native Automerge types can't flow through string-based commands.

### The samod pattern

samod (by Alex Good, Automerge maintainer) uses `Arc<Mutex<_>>` for the document, shared between the handle and the sync task. Document mutations are synchronous closures - lock, mutate, propagate side effects. No command channels, no serialization.

### What this crate provides

**`DocHandle`** - direct, synchronous document access:
```rust
// Synchronous - no .await, no channel, microsecond-fast
handle.add_cell_after("cell-1", "code", None)?;
handle.update_source("cell-1", "print('hello')")?;

// Compound operations - one lock, one snapshot, one sync notification
handle.with_doc(|doc| {
    let mut nd = NotebookDoc::wrap(std::mem::take(doc));
    nd.add_cell_after("cell-1", "code", None)?;
    nd.update_source("cell-1", "print('hello')")?;
    *doc = nd.into_inner();
    Ok(())
})?;

// Reads - instant, no lock (watch channel)
let cells = handle.get_cells();
let meta = handle.get_notebook_metadata();

// Async - only for daemon protocol (needs socket I/O)
let response = handle.send_request(NotebookRequest::LaunchKernel { ... }).await?;
handle.confirm_sync().await?;
```

**Convenience methods** for all common operations: cell CRUD, source editing, metadata, dependencies, cell visibility, tags.

**Relational cell API** - `add_cell_after(cell_id, cell_type, after_cell_id)` instead of index-based. Uses fractional indexing directly.

### Test results

- **27 unit tests** - DocHandle pattern, convenience methods, concurrent access, metadata
- **5 integration tests** (against live daemon) - connection, cell CRUD, execution with outputs, multi-peer sync, metadata round-trip

### SyncCommand reduced from 14+ to 4

Only socket I/O operations go through the command channel:
- `SendRequest` - daemon protocol request/response
- `ConfirmSync` - sync protocol round-trip
- `SendPresence` - presence frame
- `ReceiveFrontendSyncMessage` - WASM sync frame

All document mutations (`AddCell`, `DeleteCell`, `UpdateSource`, `SetMetadata`, `SetCellMetadata`, etc.) are gone - they happen directly on the `DocHandle`.

_PR submitted by @rgbkrk's agent Quill, via Zed_