### PR TITLE
refactor: extract notebook-protocol crate for shared wire types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3506,13 +3506,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "notebook-protocol"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "kernel-env",
+ "log",
+ "notebook-doc",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "notebook-sync"
 version = "0.1.0"
 dependencies = [
  "automerge",
  "log",
  "notebook-doc",
- "runtimed",
+ "notebook-protocol",
  "serde",
  "serde_json",
  "thiserror 1.0.69",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3511,7 +3511,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "kernel-env",
- "log",
  "notebook-doc",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3526,6 +3526,7 @@ dependencies = [
  "log",
  "notebook-doc",
  "notebook-protocol",
+ "runtimed",
  "serde",
  "serde_json",
  "thiserror 1.0.69",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5648,6 +5648,7 @@ version = "0.1.0"
 dependencies = [
  "log",
  "notebook-doc",
+ "notebook-protocol",
  "notebook-sync",
  "pyo3",
  "pyo3-async-runtimes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/kernel-env",
     "crates/notebook",
     "crates/notebook-doc",
+    "crates/notebook-protocol",
     "crates/notebook-sync",
     "crates/tauri-jupyter",
     "crates/xtask",

--- a/crates/notebook-protocol/Cargo.toml
+++ b/crates/notebook-protocol/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-name = "notebook-sync"
+name = "notebook-protocol"
 version = "0.1.0"
 edition = "2021"
-description = "Automerge-based notebook sync client with direct document access"
+description = "Shared wire protocol types for notebook sync (client and server)"
 repository = "https://github.com/nteract/desktop"
 license = "BSD-3-Clause"
 
@@ -10,13 +10,10 @@ license = "BSD-3-Clause"
 workspace = true
 
 [dependencies]
-automerge = "0.7"
+anyhow = { workspace = true }
+kernel-env = { path = "../kernel-env" }
 notebook-doc = { path = "../notebook-doc" }
-notebook-protocol = { path = "../notebook-protocol" }
-tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-thiserror = { workspace = true }
-
-uuid = { workspace = true }
+tokio = { workspace = true }
 log = "0.4"

--- a/crates/notebook-protocol/Cargo.toml
+++ b/crates/notebook-protocol/Cargo.toml
@@ -16,4 +16,3 @@ notebook-doc = { path = "../notebook-doc" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
-log = "0.4"

--- a/crates/notebook-protocol/src/connection.rs
+++ b/crates/notebook-protocol/src/connection.rs
@@ -1,0 +1,760 @@
+//! Unified connection framing and handshake for the runtimed socket.
+//!
+//! Every connection begins with a 5-byte preamble:
+//!
+//! ```text
+//! [4 bytes: magic 0xC0DE01AC] [1 byte: protocol version]
+//! ```
+//!
+//! Followed by length-prefixed binary framing:
+//!
+//! ```text
+//! [4 bytes: payload length (big-endian u32)] [payload bytes]
+//! ```
+//!
+//! The first frame after the preamble is a JSON handshake declaring the
+//! channel. After the handshake, the daemon routes the connection to the
+//! appropriate handler.
+//!
+//! ## Notebook Sync Frame Types (Phase 8)
+//!
+//! Notebook sync connections use a typed frame format where the first byte
+//! of the payload indicates the frame type:
+//!
+//! - `0x00`: Automerge sync message (binary)
+//! - `0x01`: NotebookRequest (JSON)
+//! - `0x02`: NotebookResponse (JSON)
+//! - `0x03`: NotebookBroadcast (JSON)
+
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+
+/// Maximum frame size for data frames: 100 MiB (matches blob size limit).
+const MAX_FRAME_SIZE: usize = 100 * 1024 * 1024;
+
+/// Maximum frame size for control/handshake frames: 64 KiB.
+/// Applied to the initial handshake and JSON request/response traffic
+/// so that oversized frames can't force large allocations before channel
+/// routing has occurred.
+const MAX_CONTROL_FRAME_SIZE: usize = 64 * 1024;
+
+/// Channel handshake — the first frame on every connection.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "channel", rename_all = "snake_case")]
+pub enum Handshake {
+    /// Pool IPC: environment take/return/status/ping.
+    Pool,
+    /// Automerge settings sync.
+    SettingsSync,
+    /// Automerge notebook sync (per-notebook room).
+    ///
+    /// The optional `protocol` field is accepted for future version negotiation.
+    /// Currently only v2 (typed frames) is supported. After handshake, the server
+    /// sends a `ProtocolCapabilities` response before starting sync.
+    NotebookSync {
+        notebook_id: String,
+        /// Protocol version requested by client. Currently only v2 is supported.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        protocol: Option<String>,
+        /// Working directory for untitled notebooks (used for project file detection).
+        /// When a notebook_id is a UUID (untitled), this provides the directory context
+        /// for finding pyproject.toml, pixi.toml, or environment.yaml.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        working_dir: Option<String>,
+        /// Serialized NotebookMetadataSnapshot JSON, sent with the initial handshake
+        /// so the daemon can read kernelspec before auto-launching a kernel.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        initial_metadata: Option<String>,
+    },
+    /// Blob store: write blobs, query port.
+    Blob,
+    /// Pool state subscription: receive broadcasts when pool errors occur/clear.
+    /// Read-only channel - server pushes DaemonBroadcast messages to client.
+    PoolStateSubscribe,
+
+    /// Open an existing notebook file. Daemon loads from disk, derives notebook_id.
+    ///
+    /// The daemon returns `NotebookConnectionInfo` before starting sync.
+    /// After that, the connection becomes a normal notebook sync connection.
+    OpenNotebook {
+        /// Path to the .ipynb file.
+        path: String,
+    },
+
+    /// Create a new untitled notebook. Daemon creates empty room, generates env_id.
+    ///
+    /// The daemon returns `NotebookConnectionInfo` before starting sync.
+    /// After that, the connection becomes a normal notebook sync connection.
+    CreateNotebook {
+        /// Runtime type: "python" or "deno".
+        runtime: String,
+        /// Working directory for project file detection (pyproject.toml, pixi.toml, environment.yml).
+        /// Used since untitled notebooks have no path to derive working_dir from.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        working_dir: Option<String>,
+        /// Optional notebook_id hint for restoring an untitled notebook from a previous session.
+        /// If provided and the daemon has a persisted Automerge doc for this ID, the room is
+        /// reused instead of creating a fresh empty notebook. If the persisted doc doesn't exist,
+        /// a new notebook is created and this ID is used as the notebook_id/env_id.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        notebook_id: Option<String>,
+    },
+}
+
+/// Protocol version constant (string for backwards compatibility).
+pub const PROTOCOL_V2: &str = "v2";
+
+/// Numeric protocol version for version negotiation.
+/// Increment this when making breaking protocol changes.
+pub const PROTOCOL_VERSION: u32 = 2;
+
+/// Magic bytes identifying the runtimed protocol.
+/// Sent as the first 4 bytes of every connection, before the handshake frame.
+pub const MAGIC: [u8; 4] = [0xC0, 0xDE, 0x01, 0xAC];
+
+/// Total preamble size: 4-byte magic + 1-byte protocol version.
+pub const PREAMBLE_LEN: usize = 5;
+
+/// Send the connection preamble (magic bytes + protocol version).
+///
+/// Must be called once at the start of every connection, before
+/// the handshake frame.
+pub async fn send_preamble<W: AsyncWrite + Unpin>(writer: &mut W) -> std::io::Result<()> {
+    let mut buf = [0u8; PREAMBLE_LEN];
+    buf[..4].copy_from_slice(&MAGIC);
+    buf[4] = PROTOCOL_VERSION as u8;
+    writer.write_all(&buf).await?;
+    writer.flush().await?;
+    Ok(())
+}
+
+/// Receive and validate the connection preamble.
+///
+/// Returns the protocol version byte. Returns an error if the magic bytes
+/// don't match or the protocol version is incompatible.
+pub async fn recv_preamble<R: AsyncRead + Unpin>(reader: &mut R) -> std::io::Result<u8> {
+    let mut buf = [0u8; PREAMBLE_LEN];
+    match reader.read_exact(&mut buf).await {
+        Ok(_) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "connection closed before preamble",
+            ));
+        }
+        Err(e) => return Err(e),
+    }
+
+    if buf[..4] != MAGIC {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "invalid magic bytes: expected {:02X?}, got {:02X?}",
+                MAGIC,
+                &buf[..4]
+            ),
+        ));
+    }
+
+    let version = buf[4];
+    if version != PROTOCOL_VERSION as u8 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!(
+                "protocol version mismatch: expected {}, got {}",
+                PROTOCOL_VERSION, version
+            ),
+        ));
+    }
+
+    Ok(version)
+}
+
+/// Server response indicating protocol capabilities.
+///
+/// Sent immediately after handshake, before starting sync.
+/// Used by the `NotebookSync` handshake variant.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProtocolCapabilities {
+    /// Protocol version string (currently always "v2").
+    pub protocol: String,
+    /// Numeric protocol version for explicit version checking.
+    /// Clients can compare this against their expected version.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub protocol_version: Option<u32>,
+    /// Daemon version string (e.g., "2.0.0+abc123").
+    /// Useful for debugging version mismatches.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub daemon_version: Option<String>,
+}
+
+/// Server response for `OpenNotebook` and `CreateNotebook` handshakes.
+///
+/// Sent immediately after handshake, before starting sync.
+/// Contains notebook_id derived by the daemon (from path or generated env_id).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NotebookConnectionInfo {
+    /// Protocol version string (currently always "v2").
+    pub protocol: String,
+    /// Numeric protocol version for explicit version checking.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub protocol_version: Option<u32>,
+    /// Daemon version string (e.g., "2.0.0+abc123").
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub daemon_version: Option<String>,
+    /// Notebook identifier derived by the daemon.
+    /// For existing files: canonical path.
+    /// For new notebooks: generated UUID (env_id).
+    pub notebook_id: String,
+    /// Number of cells in the notebook (for progress indication).
+    pub cell_count: usize,
+    /// True if the notebook has untrusted dependencies requiring user approval.
+    pub needs_trust_approval: bool,
+    /// Error message if the notebook could not be opened/created.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// Frame types for notebook sync connections.
+///
+/// The first byte of each frame payload indicates the type of message.
+/// The byte values are defined in `notebook_doc::frame_types` so all
+/// consumers (daemon, WASM, Python) share one source of truth.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum NotebookFrameType {
+    /// Automerge sync message (binary).
+    AutomergeSync = notebook_doc::frame_types::AUTOMERGE_SYNC,
+    /// NotebookRequest (JSON).
+    Request = notebook_doc::frame_types::REQUEST,
+    /// NotebookResponse (JSON).
+    Response = notebook_doc::frame_types::RESPONSE,
+    /// NotebookBroadcast (JSON).
+    Broadcast = notebook_doc::frame_types::BROADCAST,
+    /// Presence (CBOR, see notebook_doc::presence).
+    Presence = notebook_doc::frame_types::PRESENCE,
+}
+
+impl TryFrom<u8> for NotebookFrameType {
+    type Error = std::io::Error;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        use notebook_doc::frame_types;
+        match value {
+            frame_types::AUTOMERGE_SYNC => Ok(Self::AutomergeSync),
+            frame_types::REQUEST => Ok(Self::Request),
+            frame_types::RESPONSE => Ok(Self::Response),
+            frame_types::BROADCAST => Ok(Self::Broadcast),
+            frame_types::PRESENCE => Ok(Self::Presence),
+            _ => Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("unknown notebook frame type: 0x{:02x}", value),
+            )),
+        }
+    }
+}
+
+/// A typed notebook frame with its type and payload.
+#[derive(Debug)]
+pub struct TypedNotebookFrame {
+    pub frame_type: NotebookFrameType,
+    pub payload: Vec<u8>,
+}
+
+/// Send a typed notebook frame.
+pub async fn send_typed_frame<W: AsyncWrite + Unpin>(
+    writer: &mut W,
+    frame_type: NotebookFrameType,
+    payload: &[u8],
+) -> std::io::Result<()> {
+    let mut data = Vec::with_capacity(1 + payload.len());
+    data.push(frame_type as u8);
+    data.extend_from_slice(payload);
+    send_frame(writer, &data).await
+}
+
+/// Send a typed notebook frame with JSON payload.
+pub async fn send_typed_json_frame<W: AsyncWrite + Unpin, T: Serialize>(
+    writer: &mut W,
+    frame_type: NotebookFrameType,
+    value: &T,
+) -> anyhow::Result<()> {
+    let json_bytes = serde_json::to_vec(value)?;
+    send_typed_frame(writer, frame_type, &json_bytes).await?;
+    Ok(())
+}
+
+/// Receive a typed notebook frame.
+/// Returns `None` on clean disconnect (EOF).
+pub async fn recv_typed_frame<R: AsyncRead + Unpin>(
+    reader: &mut R,
+) -> std::io::Result<Option<TypedNotebookFrame>> {
+    let Some(data) = recv_frame(reader).await? else {
+        return Ok(None);
+    };
+
+    if data.is_empty() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "empty frame",
+        ));
+    }
+
+    let frame_type = NotebookFrameType::try_from(data[0])?;
+    let payload = data[1..].to_vec();
+
+    Ok(Some(TypedNotebookFrame {
+        frame_type,
+        payload,
+    }))
+}
+
+/// Send a length-prefixed frame.
+///
+/// Returns an error if the payload exceeds `MAX_FRAME_SIZE` (100 MiB).
+/// This prevents silent truncation of the 4-byte length field at the u32
+/// boundary and keeps send/receive limits symmetric.
+pub async fn send_frame<W: AsyncWrite + Unpin>(writer: &mut W, data: &[u8]) -> std::io::Result<()> {
+    if data.len() > MAX_FRAME_SIZE {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!(
+                "frame too large to send: {} bytes (max {})",
+                data.len(),
+                MAX_FRAME_SIZE
+            ),
+        ));
+    }
+    let len = (data.len() as u32).to_be_bytes();
+    writer.write_all(&len).await?;
+    writer.write_all(data).await?;
+    writer.flush().await?;
+    Ok(())
+}
+
+/// Receive a length-prefixed frame with a caller-specified size limit.
+/// Returns `None` on clean disconnect (EOF).
+async fn recv_frame_with_limit<R: AsyncRead + Unpin>(
+    reader: &mut R,
+    max_size: usize,
+) -> std::io::Result<Option<Vec<u8>>> {
+    let mut len_buf = [0u8; 4];
+    match reader.read_exact(&mut len_buf).await {
+        Ok(_) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(None),
+        Err(e) => return Err(e),
+    }
+    let len = u32::from_be_bytes(len_buf) as usize;
+
+    if len > max_size {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("frame too large: {} bytes (max {})", len, max_size),
+        ));
+    }
+
+    let mut buf = vec![0u8; len];
+    reader.read_exact(&mut buf).await?;
+    Ok(Some(buf))
+}
+
+/// Receive a length-prefixed frame (up to 100 MiB for data payloads).
+/// Returns `None` on clean disconnect (EOF).
+pub async fn recv_frame<R: AsyncRead + Unpin>(reader: &mut R) -> std::io::Result<Option<Vec<u8>>> {
+    recv_frame_with_limit(reader, MAX_FRAME_SIZE).await
+}
+
+/// Receive a length-prefixed frame with the control/handshake size limit
+/// (64 KiB). Use this for handshake and JSON request/response traffic to
+/// prevent oversized frames from forcing large allocations.
+pub async fn recv_control_frame<R: AsyncRead + Unpin>(
+    reader: &mut R,
+) -> std::io::Result<Option<Vec<u8>>> {
+    recv_frame_with_limit(reader, MAX_CONTROL_FRAME_SIZE).await
+}
+
+/// Send a value as a JSON-encoded length-prefixed frame.
+pub async fn send_json_frame<W: AsyncWrite + Unpin, T: Serialize>(
+    writer: &mut W,
+    value: &T,
+) -> anyhow::Result<()> {
+    let data = serde_json::to_vec(value)?;
+    send_frame(writer, &data).await?;
+    Ok(())
+}
+
+/// Receive and deserialize a JSON-encoded length-prefixed frame.
+/// Returns `None` on clean disconnect (EOF).
+pub async fn recv_json_frame<R: AsyncRead + Unpin, T: DeserializeOwned>(
+    reader: &mut R,
+) -> anyhow::Result<Option<T>> {
+    match recv_frame(reader).await? {
+        Some(data) => {
+            let value = serde_json::from_slice(&data)?;
+            Ok(Some(value))
+        }
+        None => Ok(None),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_frame_roundtrip() {
+        let data = b"hello world";
+
+        let mut buf = Vec::new();
+        send_frame(&mut buf, data).await.unwrap();
+        assert_eq!(buf.len(), 4 + data.len());
+
+        let mut cursor = std::io::Cursor::new(buf);
+        let received = recv_frame(&mut cursor).await.unwrap().unwrap();
+        assert_eq!(received, data);
+    }
+
+    #[tokio::test]
+    async fn test_frame_eof() {
+        let buf: &[u8] = &[];
+        let mut cursor = std::io::Cursor::new(buf);
+        let result = recv_frame(&mut cursor).await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_frame_too_large_recv() {
+        let len_bytes = (MAX_FRAME_SIZE as u32 + 1).to_be_bytes();
+        let mut cursor = std::io::Cursor::new(len_bytes.to_vec());
+        let result = recv_frame(&mut cursor).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_frame_too_large_send() {
+        let data = vec![0u8; MAX_FRAME_SIZE + 1];
+        let mut buf = Vec::new();
+        let result = send_frame(&mut buf, &data).await;
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().kind(), std::io::ErrorKind::InvalidInput);
+    }
+
+    #[tokio::test]
+    async fn test_control_frame_rejects_oversized() {
+        // A frame larger than 64 KiB should be rejected by recv_control_frame
+        let oversized_len = (MAX_CONTROL_FRAME_SIZE as u32 + 1).to_be_bytes();
+        let mut cursor = std::io::Cursor::new(oversized_len.to_vec());
+        let result = recv_control_frame(&mut cursor).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_control_frame_accepts_small() {
+        let data = b"small control payload";
+        let mut buf = Vec::new();
+        send_frame(&mut buf, data).await.unwrap();
+
+        let mut cursor = std::io::Cursor::new(buf);
+        let received = recv_control_frame(&mut cursor).await.unwrap().unwrap();
+        assert_eq!(received, data);
+    }
+
+    #[tokio::test]
+    async fn test_json_frame_roundtrip() {
+        let handshake = Handshake::Pool;
+
+        let mut buf = Vec::new();
+        send_json_frame(&mut buf, &handshake).await.unwrap();
+
+        let mut cursor = std::io::Cursor::new(buf);
+        let received: Handshake = recv_json_frame(&mut cursor).await.unwrap().unwrap();
+        assert!(matches!(received, Handshake::Pool));
+    }
+
+    #[tokio::test]
+    async fn test_preamble_roundtrip() {
+        let mut buf = Vec::new();
+        send_preamble(&mut buf).await.unwrap();
+        assert_eq!(buf.len(), PREAMBLE_LEN);
+        assert_eq!(&buf[..4], &MAGIC);
+        assert_eq!(buf[4], PROTOCOL_VERSION as u8);
+
+        let mut cursor = std::io::Cursor::new(buf);
+        let version = recv_preamble(&mut cursor).await.unwrap();
+        assert_eq!(version, PROTOCOL_VERSION as u8);
+    }
+
+    #[tokio::test]
+    async fn test_preamble_bad_magic() {
+        let buf = [0xFF, 0xFF, 0xFF, 0xFF, PROTOCOL_VERSION as u8];
+        let mut cursor = std::io::Cursor::new(buf.to_vec());
+        let result = recv_preamble(&mut cursor).await;
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().kind(), std::io::ErrorKind::InvalidData);
+    }
+
+    #[tokio::test]
+    async fn test_preamble_version_mismatch() {
+        let mut buf = [0u8; PREAMBLE_LEN];
+        buf[..4].copy_from_slice(&MAGIC);
+        buf[4] = 99; // wrong version
+        let mut cursor = std::io::Cursor::new(buf.to_vec());
+        let result = recv_preamble(&mut cursor).await;
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().kind(), std::io::ErrorKind::InvalidData);
+    }
+
+    #[tokio::test]
+    async fn test_preamble_eof() {
+        let buf: &[u8] = &[0xC0, 0xDE]; // incomplete
+        let mut cursor = std::io::Cursor::new(buf);
+        let result = recv_preamble(&mut cursor).await;
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err().kind(),
+            std::io::ErrorKind::UnexpectedEof
+        );
+    }
+
+    #[tokio::test]
+    async fn test_handshake_serialization() {
+        // Pool
+        let json = serde_json::to_string(&Handshake::Pool).unwrap();
+        assert_eq!(json, r#"{"channel":"pool"}"#);
+
+        // SettingsSync
+        let json = serde_json::to_string(&Handshake::SettingsSync).unwrap();
+        assert_eq!(json, r#"{"channel":"settings_sync"}"#);
+
+        // NotebookSync (without protocol - should omit the field)
+        let json = serde_json::to_string(&Handshake::NotebookSync {
+            notebook_id: "abc".into(),
+            protocol: None,
+            working_dir: None,
+            initial_metadata: None,
+        })
+        .unwrap();
+        assert_eq!(json, r#"{"channel":"notebook_sync","notebook_id":"abc"}"#);
+
+        // NotebookSync with v2 protocol
+        let json = serde_json::to_string(&Handshake::NotebookSync {
+            notebook_id: "abc".into(),
+            protocol: Some("v2".into()),
+            working_dir: None,
+            initial_metadata: None,
+        })
+        .unwrap();
+        assert_eq!(
+            json,
+            r#"{"channel":"notebook_sync","notebook_id":"abc","protocol":"v2"}"#
+        );
+
+        // NotebookSync with working_dir for untitled notebook
+        let json = serde_json::to_string(&Handshake::NotebookSync {
+            notebook_id: "550e8400-e29b-41d4-a716-446655440000".into(),
+            protocol: Some("v2".into()),
+            working_dir: Some("/home/user/project".into()),
+            initial_metadata: None,
+        })
+        .unwrap();
+        assert_eq!(
+            json,
+            r#"{"channel":"notebook_sync","notebook_id":"550e8400-e29b-41d4-a716-446655440000","protocol":"v2","working_dir":"/home/user/project"}"#
+        );
+
+        // Blob
+        let json = serde_json::to_string(&Handshake::Blob).unwrap();
+        assert_eq!(json, r#"{"channel":"blob"}"#);
+
+        // OpenNotebook
+        let json = serde_json::to_string(&Handshake::OpenNotebook {
+            path: "/home/user/notebook.ipynb".into(),
+        })
+        .unwrap();
+        assert_eq!(
+            json,
+            r#"{"channel":"open_notebook","path":"/home/user/notebook.ipynb"}"#
+        );
+
+        // CreateNotebook without working_dir
+        let json = serde_json::to_string(&Handshake::CreateNotebook {
+            runtime: "python".into(),
+            working_dir: None,
+            notebook_id: None,
+        })
+        .unwrap();
+        assert_eq!(json, r#"{"channel":"create_notebook","runtime":"python"}"#);
+
+        // CreateNotebook with working_dir
+        let json = serde_json::to_string(&Handshake::CreateNotebook {
+            runtime: "deno".into(),
+            working_dir: Some("/home/user/project".into()),
+            notebook_id: None,
+        })
+        .unwrap();
+        assert_eq!(
+            json,
+            r#"{"channel":"create_notebook","runtime":"deno","working_dir":"/home/user/project"}"#
+        );
+
+        // CreateNotebook with notebook_id hint (session restore)
+        let json = serde_json::to_string(&Handshake::CreateNotebook {
+            runtime: "python".into(),
+            working_dir: None,
+            notebook_id: Some("550e8400-e29b-41d4-a716-446655440000".into()),
+        })
+        .unwrap();
+        assert_eq!(
+            json,
+            r#"{"channel":"create_notebook","runtime":"python","notebook_id":"550e8400-e29b-41d4-a716-446655440000"}"#
+        );
+    }
+
+    #[test]
+    fn test_notebook_connection_info_serialization() {
+        // Success case (minimal - no optional fields)
+        let info = NotebookConnectionInfo {
+            protocol: "v2".into(),
+            protocol_version: None,
+            daemon_version: None,
+            notebook_id: "/home/user/notebook.ipynb".into(),
+            cell_count: 5,
+            needs_trust_approval: false,
+            error: None,
+        };
+        let json = serde_json::to_string(&info).unwrap();
+        assert_eq!(
+            json,
+            r#"{"protocol":"v2","notebook_id":"/home/user/notebook.ipynb","cell_count":5,"needs_trust_approval":false}"#
+        );
+
+        // With version info
+        let info = NotebookConnectionInfo {
+            protocol: PROTOCOL_V2.into(),
+            protocol_version: Some(PROTOCOL_VERSION),
+            daemon_version: Some("0.1.0+abc123".into()),
+            notebook_id: "/home/user/notebook.ipynb".into(),
+            cell_count: 5,
+            needs_trust_approval: false,
+            error: None,
+        };
+        let json = serde_json::to_string(&info).unwrap();
+        assert!(json.contains(&format!(r#""protocol_version":{}"#, PROTOCOL_VERSION)));
+        assert!(json.contains(r#""daemon_version":"0.1.0+abc123""#));
+
+        // With trust approval needed
+        let info = NotebookConnectionInfo {
+            protocol: "v2".into(),
+            protocol_version: None,
+            daemon_version: None,
+            notebook_id: "550e8400-e29b-41d4-a716-446655440000".into(),
+            cell_count: 1,
+            needs_trust_approval: true,
+            error: None,
+        };
+        let json = serde_json::to_string(&info).unwrap();
+        assert!(json.contains(r#""needs_trust_approval":true"#));
+
+        // Error case
+        let info = NotebookConnectionInfo {
+            protocol: "v2".into(),
+            protocol_version: None,
+            daemon_version: None,
+            notebook_id: String::new(),
+            cell_count: 0,
+            needs_trust_approval: false,
+            error: Some("File not found".into()),
+        };
+        let json = serde_json::to_string(&info).unwrap();
+        assert!(json.contains(r#""error":"File not found""#));
+    }
+
+    #[tokio::test]
+    async fn test_multiple_frames_on_same_stream() {
+        let mut buf = Vec::new();
+        send_frame(&mut buf, b"first").await.unwrap();
+        send_frame(&mut buf, b"second").await.unwrap();
+        send_frame(&mut buf, b"third").await.unwrap();
+
+        let mut cursor = std::io::Cursor::new(buf);
+        assert_eq!(recv_frame(&mut cursor).await.unwrap().unwrap(), b"first");
+        assert_eq!(recv_frame(&mut cursor).await.unwrap().unwrap(), b"second");
+        assert_eq!(recv_frame(&mut cursor).await.unwrap().unwrap(), b"third");
+        // EOF
+        assert!(recv_frame(&mut cursor).await.unwrap().is_none());
+    }
+
+    #[test]
+    fn test_notebook_frame_type_conversion() {
+        assert_eq!(
+            NotebookFrameType::try_from(0x00).unwrap(),
+            NotebookFrameType::AutomergeSync
+        );
+        assert_eq!(
+            NotebookFrameType::try_from(0x01).unwrap(),
+            NotebookFrameType::Request
+        );
+        assert_eq!(
+            NotebookFrameType::try_from(0x02).unwrap(),
+            NotebookFrameType::Response
+        );
+        assert_eq!(
+            NotebookFrameType::try_from(0x03).unwrap(),
+            NotebookFrameType::Broadcast
+        );
+        assert!(NotebookFrameType::try_from(0xFF).is_err());
+    }
+
+    #[tokio::test]
+    async fn test_typed_frame_roundtrip() {
+        let payload = b"test payload";
+
+        let mut buf = Vec::new();
+        send_typed_frame(&mut buf, NotebookFrameType::Request, payload)
+            .await
+            .unwrap();
+
+        let mut cursor = std::io::Cursor::new(buf);
+        let frame = recv_typed_frame(&mut cursor).await.unwrap().unwrap();
+        assert_eq!(frame.frame_type, NotebookFrameType::Request);
+        assert_eq!(frame.payload, payload);
+    }
+
+    #[tokio::test]
+    async fn test_typed_frame_automerge_sync() {
+        let sync_data = b"\x00binary automerge data";
+
+        let mut buf = Vec::new();
+        send_typed_frame(&mut buf, NotebookFrameType::AutomergeSync, sync_data)
+            .await
+            .unwrap();
+
+        let mut cursor = std::io::Cursor::new(buf);
+        let frame = recv_typed_frame(&mut cursor).await.unwrap().unwrap();
+        assert_eq!(frame.frame_type, NotebookFrameType::AutomergeSync);
+        assert_eq!(frame.payload, sync_data);
+    }
+
+    #[tokio::test]
+    async fn test_typed_json_frame() {
+        #[derive(Debug, PartialEq, Serialize, Deserialize)]
+        struct TestMsg {
+            value: i32,
+        }
+
+        let msg = TestMsg { value: 42 };
+
+        let mut buf = Vec::new();
+        send_typed_json_frame(&mut buf, NotebookFrameType::Request, &msg)
+            .await
+            .unwrap();
+
+        let mut cursor = std::io::Cursor::new(buf);
+        let frame = recv_typed_frame(&mut cursor).await.unwrap().unwrap();
+        assert_eq!(frame.frame_type, NotebookFrameType::Request);
+
+        let parsed: TestMsg = serde_json::from_slice(&frame.payload).unwrap();
+        assert_eq!(parsed, msg);
+    }
+}

--- a/crates/notebook-protocol/src/connection.rs
+++ b/crates/notebook-protocol/src/connection.rs
@@ -120,6 +120,10 @@ pub const PREAMBLE_LEN: usize = 5;
 /// Must be called once at the start of every connection, before
 /// the handshake frame.
 pub async fn send_preamble<W: AsyncWrite + Unpin>(writer: &mut W) -> std::io::Result<()> {
+    const _: () = assert!(
+        PROTOCOL_VERSION <= u8::MAX as u32,
+        "PROTOCOL_VERSION must fit in a single byte for the wire preamble"
+    );
     let mut buf = [0u8; PREAMBLE_LEN];
     buf[..4].copy_from_slice(&MAGIC);
     buf[4] = PROTOCOL_VERSION as u8;

--- a/crates/notebook-protocol/src/lib.rs
+++ b/crates/notebook-protocol/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod connection;
+pub mod protocol;

--- a/crates/notebook-protocol/src/protocol.rs
+++ b/crates/notebook-protocol/src/protocol.rs
@@ -1,0 +1,514 @@
+//! Notebook-specific protocol types extracted from runtimed.
+//!
+//! Pure data definitions (structs and enums) for the notebook sync protocol.
+//! No `impl` blocks — just shapes + serde derives.
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+use notebook_doc::CellSnapshot;
+
+// ── Data structs referenced by protocol enums ───────────────────────────────
+
+/// A snapshot of a comm channel's state.
+///
+/// Stored in the daemon and sent to newly connected clients so they can
+/// reconstruct widget models that were created before they connected.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CommSnapshot {
+    /// The comm_id (unique identifier for this comm channel).
+    pub comm_id: String,
+
+    /// Target name (e.g., "jupyter.widget", "jupyter.widget.version").
+    pub target_name: String,
+
+    /// Current state snapshot (merged from all updates).
+    /// For widgets, this contains the full model state.
+    pub state: serde_json::Value,
+
+    /// Model module (e.g., "@jupyter-widgets/controls", "anywidget").
+    /// Extracted from `_model_module` in state for convenience.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model_module: Option<String>,
+
+    /// Model name (e.g., "IntSliderModel", "AnyModel").
+    /// Extracted from `_model_name` in state for convenience.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model_name: Option<String>,
+
+    /// Binary buffers associated with this comm (e.g., for images, arrays).
+    /// Stored inline for simplicity; large buffers could be moved to blob store.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub buffers: Vec<Vec<u8>>,
+}
+
+/// Environment configuration captured at kernel launch time.
+/// Used to detect when notebook metadata has drifted from the running kernel.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub struct LaunchedEnvConfig {
+    /// UV inline deps (if env_source is "uv:inline")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub uv_deps: Option<Vec<String>>,
+
+    /// Conda inline deps (if env_source is "conda:inline")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub conda_deps: Option<Vec<String>>,
+
+    /// Conda channels (if env_source is "conda:inline")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub conda_channels: Option<Vec<String>>,
+
+    /// Deno config (if kernel_type is "deno")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deno_config: Option<DenoLaunchedConfig>,
+
+    /// Path to the venv used by the kernel (for hot-sync into running env)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub venv_path: Option<PathBuf>,
+
+    /// Path to python executable (for hot-sync, avoids hardcoding bin/python vs Scripts/python.exe)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub python_path: Option<PathBuf>,
+
+    /// Unique identifier for this kernel launch session.
+    /// Used to detect if kernel was swapped during async operations (e.g., hot-sync).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub launch_id: Option<String>,
+}
+
+/// Deno configuration captured at kernel launch time.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub struct DenoLaunchedConfig {
+    /// Deno permission flags
+    #[serde(default)]
+    pub permissions: Vec<String>,
+
+    /// Path to import_map.json
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub import_map: Option<String>,
+
+    /// Path to deno.json config
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub config: Option<String>,
+
+    /// Whether npm: imports auto-install packages
+    #[serde(default = "default_flexible_npm")]
+    pub flexible_npm_imports: bool,
+}
+
+fn default_flexible_npm() -> bool {
+    true
+}
+
+/// Error information for a pool that is failing to warm.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PoolError {
+    /// Human-readable error message.
+    pub message: String,
+    /// Package that failed to install (if identified).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failed_package: Option<String>,
+    /// Number of consecutive failures.
+    pub consecutive_failures: u32,
+    /// Seconds until next retry (0 if retry is imminent).
+    pub retry_in_secs: u64,
+}
+
+// ── Helper structs ──────────────────────────────────────────────────────────
+
+/// A single entry from kernel input history.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HistoryEntry {
+    /// Session number (0 for current session)
+    pub session: i32,
+    /// Line number within the session
+    pub line: i32,
+    /// The source code that was executed
+    pub source: String,
+}
+
+/// A single completion item (LSP-ready structure).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CompletionItem {
+    /// The completion text
+    pub label: String,
+    /// Kind: "function", "variable", "class", "module", etc.
+    /// Populated by LSP later; kernel completions leave this as None.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    /// Short type annotation (e.g. "def read_csv(filepath_or_buffer, ...)")
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+    /// Source: "kernel" now, "ruff"/"basedpyright" later.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+}
+
+/// Difference between launched environment config and current metadata.
+/// Used to show the user what packages would be added/removed on restart.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EnvSyncDiff {
+    /// Packages to add (in current metadata but not in launched config).
+    #[serde(default)]
+    pub added: Vec<String>,
+    /// Packages to remove (in launched config but not in current metadata).
+    #[serde(default)]
+    pub removed: Vec<String>,
+    /// Conda channels changed (requires restart to use new channels).
+    #[serde(default)]
+    pub channels_changed: bool,
+    /// Deno config changed (permissions, import_map, etc.)
+    #[serde(default)]
+    pub deno_changed: bool,
+}
+
+// ── Notebook protocol enums ─────────────────────────────────────────────────
+
+/// Requests sent from notebook app to daemon for notebook operations.
+///
+/// These are sent as JSON over the notebook sync connection alongside
+/// Automerge sync messages. The daemon handles kernel lifecycle and
+/// execution, becoming the single source of truth for outputs.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "action", rename_all = "snake_case")]
+pub enum NotebookRequest {
+    /// Launch a kernel for this notebook room.
+    /// If a kernel is already running, returns info about the existing kernel.
+    LaunchKernel {
+        /// Kernel type: "python" or "deno"
+        kernel_type: String,
+        /// Environment source: "uv:inline", "conda:prewarmed", etc.
+        env_source: String,
+        /// Path to the notebook file (for working directory)
+        notebook_path: Option<String>,
+    },
+
+    /// Queue a cell for execution.
+    /// Daemon adds to queue and executes when previous cells complete.
+    #[deprecated(
+        since = "0.1.0",
+        note = "Use ExecuteCell instead - reads source from synced document"
+    )]
+    QueueCell { cell_id: String, code: String },
+
+    /// Execute a cell by reading its source from the automerge doc.
+    /// This is the preferred method - ensures execution matches synced document state.
+    ExecuteCell { cell_id: String },
+
+    /// Clear outputs for a cell (before re-execution).
+    ClearOutputs { cell_id: String },
+
+    /// Interrupt the currently executing cell.
+    InterruptExecution {},
+
+    /// Shutdown the kernel for this room.
+    ShutdownKernel {},
+
+    /// Get info about the current kernel (if any).
+    GetKernelInfo {},
+
+    /// Get the execution queue state.
+    GetQueueState {},
+
+    /// Run all code cells from the synced document.
+    /// Daemon reads cell sources from the Automerge doc and queues them.
+    RunAllCells {},
+
+    /// Send a comm message to the kernel (widget interactions).
+    /// Accepts the full Jupyter message envelope to preserve header/session.
+    SendComm {
+        /// The full Jupyter message (header, content, buffers, etc.)
+        /// Preserves frontend session/msg_id for proper widget protocol.
+        message: serde_json::Value,
+    },
+
+    /// Search the kernel's input history.
+    /// Returns matching history entries via HistoryResult response.
+    GetHistory {
+        /// Pattern to search for (glob-style, optional)
+        pattern: Option<String>,
+        /// Maximum number of entries to return
+        n: i32,
+        /// Only return unique entries (deduplicate)
+        unique: bool,
+    },
+
+    /// Request code completions from the kernel.
+    /// Returns matching completions via CompletionResult response.
+    Complete {
+        /// The code to complete
+        code: String,
+        /// Cursor position in the code
+        cursor_pos: usize,
+    },
+
+    /// Save the notebook to disk.
+    /// The daemon reads cells and metadata from the Automerge doc, merges
+    /// with any existing .ipynb on disk (to preserve unknown metadata keys),
+    /// and writes the result.
+    ///
+    /// If `path` is provided, saves to that path (with .ipynb appended if needed).
+    /// If `path` is None, saves to the room's notebook_path (original file location).
+    SaveNotebook {
+        /// If true, format code cells before saving (e.g., with ruff).
+        format_cells: bool,
+        /// Optional target path. If None, uses the room's notebook_path.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        path: Option<String>,
+    },
+
+    /// Clone the notebook to a new path with fresh env_id and cleared outputs.
+    /// Used for "Save As Copy" functionality - creates a new independent notebook
+    /// without affecting the current document.
+    CloneNotebook {
+        /// Target path for the cloned notebook (absolute, .ipynb appended if needed).
+        path: String,
+    },
+
+    /// Sync environment with current metadata (hot-install new packages).
+    /// Only supported for UV inline deps. Falls back to restart for removals/conda.
+    SyncEnvironment {},
+
+    /// Get the full Automerge document bytes from the daemon's canonical doc.
+    /// Used by the frontend to bootstrap its WASM Automerge peer.
+    GetDocBytes {},
+
+    /// Get raw metadata JSON from the daemon's Automerge doc.
+    /// Returns the value stored at the given key (e.g., "notebook_metadata").
+    GetRawMetadata {
+        /// Metadata key to read (e.g., "notebook_metadata").
+        key: String,
+    },
+
+    /// Set raw metadata JSON in the daemon's Automerge doc.
+    /// Writes the JSON string at the given key, then syncs to all peers.
+    SetRawMetadata {
+        /// Metadata key to write (e.g., "notebook_metadata").
+        key: String,
+        /// JSON string value to store.
+        value: String,
+    },
+}
+
+/// Responses from daemon to notebook app.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "result", rename_all = "snake_case")]
+pub enum NotebookResponse {
+    /// Kernel launched successfully.
+    KernelLaunched {
+        kernel_type: String,
+        env_source: String,
+        /// Environment config used at launch (for sync detection).
+        launched_config: LaunchedEnvConfig,
+    },
+
+    /// Kernel was already running (returned existing info).
+    KernelAlreadyRunning {
+        kernel_type: String,
+        env_source: String,
+        /// Environment config used at launch (for sync detection).
+        launched_config: LaunchedEnvConfig,
+    },
+
+    /// Cell queued for execution.
+    CellQueued { cell_id: String },
+
+    /// Outputs cleared.
+    OutputsCleared { cell_id: String },
+
+    /// Interrupt sent to kernel.
+    InterruptSent {},
+
+    /// Kernel shutdown initiated.
+    KernelShuttingDown {},
+
+    /// No kernel is running.
+    NoKernel {},
+
+    /// Kernel info response.
+    KernelInfo {
+        kernel_type: Option<String>,
+        env_source: Option<String>,
+        status: String, // "idle", "busy", "not_started"
+    },
+
+    /// Queue state response.
+    QueueState {
+        executing: Option<String>, // cell_id currently executing
+        queued: Vec<String>,       // cell_ids waiting
+    },
+
+    /// All cells queued for execution.
+    AllCellsQueued {
+        count: usize, // number of code cells queued
+    },
+
+    /// Notebook saved successfully to disk.
+    NotebookSaved {
+        /// The absolute path where the notebook was written.
+        path: String,
+    },
+
+    /// Notebook cloned successfully to a new file.
+    NotebookCloned {
+        /// The absolute path where the cloned notebook was written.
+        path: String,
+    },
+
+    /// Generic success.
+    Ok {},
+
+    /// Error response.
+    Error { error: String },
+
+    /// History search result.
+    HistoryResult { entries: Vec<HistoryEntry> },
+
+    /// Code completion result.
+    CompletionResult {
+        items: Vec<CompletionItem>,
+        cursor_start: usize,
+        cursor_end: usize,
+    },
+
+    /// Environment sync started (installing new packages).
+    SyncEnvironmentStarted {
+        /// Packages being installed
+        packages: Vec<String>,
+    },
+
+    /// Environment sync completed successfully.
+    SyncEnvironmentComplete {
+        /// Packages that were installed
+        synced_packages: Vec<String>,
+    },
+
+    /// Environment sync failed (fall back to restart).
+    SyncEnvironmentFailed {
+        /// Error message explaining why sync failed
+        error: String,
+        /// Whether the user should restart instead
+        needs_restart: bool,
+    },
+
+    /// Full Automerge document bytes from the daemon's canonical doc.
+    DocBytes {
+        /// Raw Automerge document bytes, encoded as a Vec for JSON transport.
+        bytes: Vec<u8>,
+    },
+
+    /// Raw metadata JSON value from the daemon's Automerge doc.
+    RawMetadata {
+        /// The metadata JSON string, or None if the key doesn't exist.
+        value: Option<String>,
+    },
+
+    /// Metadata was set successfully.
+    MetadataSet {},
+}
+
+/// Broadcast messages from daemon to all peers in a room.
+///
+/// These are sent proactively when kernel events occur, not as responses
+/// to specific requests. All connected windows receive these.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "event", rename_all = "snake_case")]
+pub enum NotebookBroadcast {
+    /// Kernel status changed.
+    KernelStatus {
+        status: String,          // "starting", "idle", "busy", "error", "shutdown"
+        cell_id: Option<String>, // which cell triggered status change
+    },
+
+    /// Execution started for a cell.
+    ExecutionStarted {
+        cell_id: String,
+        execution_count: i64,
+    },
+
+    /// Output produced by a cell.
+    Output {
+        cell_id: String,
+        output_type: String, // "stream", "display_data", "execute_result", "error"
+        output_json: String, // Serialized Jupyter output content
+        /// If Some, this is an update to an existing output at the given index.
+        /// If None, this is a new output to append.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        output_index: Option<usize>,
+    },
+
+    /// Display output updated in place (update_display_data).
+    DisplayUpdate {
+        display_id: String,
+        data: serde_json::Value,
+        metadata: serde_json::Map<String, serde_json::Value>,
+    },
+
+    /// Execution completed for a cell.
+    ExecutionDone { cell_id: String },
+
+    /// Queue state changed.
+    QueueChanged {
+        executing: Option<String>,
+        queued: Vec<String>,
+    },
+
+    /// Kernel error (failed to launch, crashed, etc.)
+    KernelError { error: String },
+
+    /// Outputs cleared for a cell.
+    OutputsCleared { cell_id: String },
+
+    /// Comm message from kernel (ipywidgets protocol).
+    /// Broadcast to all connected peers so all windows can display widgets.
+    Comm {
+        /// Message type: "comm_open", "comm_msg", "comm_close"
+        msg_type: String,
+        /// Message content (comm_id, data, target_name, etc.)
+        content: serde_json::Value,
+        /// Binary buffers (base64-encoded when serialized to JSON)
+        #[serde(default)]
+        buffers: Vec<Vec<u8>>,
+    },
+
+    /// Initial comm state sync sent to newly connected clients.
+    /// Contains all active comm channels so new windows can reconstruct widgets.
+    CommSync {
+        /// All active comm snapshots
+        comms: Vec<CommSnapshot>,
+    },
+
+    /// External file changes were detected and merged into the Automerge doc.
+    /// Broadcast to all connected windows so they can update their UI.
+    FileChanged {
+        /// Updated cells from the merged .ipynb file.
+        cells: Vec<CellSnapshot>,
+        /// Updated notebook metadata JSON, if changed.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        metadata: Option<String>,
+    },
+
+    /// Environment progress update during kernel launch.
+    ///
+    /// Carries rich progress phases (repodata, solve, download, link)
+    /// from `kernel_env` so the frontend can display detailed status.
+    EnvProgress {
+        env_type: String,
+        #[serde(flatten)]
+        phase: kernel_env::EnvProgressPhase,
+    },
+
+    /// Environment sync state changed.
+    ///
+    /// Broadcast when notebook metadata changes and differs from the
+    /// kernel's launched configuration. All connected windows can show
+    /// the sync UI in response.
+    EnvSyncState {
+        /// Whether the current metadata matches the launched config.
+        in_sync: bool,
+        /// What's different (for UI display). None if in_sync is true.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        diff: Option<EnvSyncDiff>,
+    },
+}

--- a/crates/notebook-sync/Cargo.toml
+++ b/crates/notebook-sync/Cargo.toml
@@ -20,3 +20,6 @@ thiserror = { workspace = true }
 
 uuid = { workspace = true }
 log = "0.4"
+
+[dev-dependencies]
+runtimed = { path = "../runtimed" }

--- a/crates/notebook-sync/src/broadcast.rs
+++ b/crates/notebook-sync/src/broadcast.rs
@@ -5,7 +5,7 @@
 //! logging and continuing, matching the behavior of the old
 //! `NotebookBroadcastReceiver` in `notebook_sync_client.rs`.
 
-use runtimed::protocol::NotebookBroadcast;
+use notebook_protocol::protocol::NotebookBroadcast;
 use tokio::sync::broadcast;
 
 /// A receiver for kernel/execution broadcasts from the daemon.

--- a/crates/notebook-sync/src/connect.rs
+++ b/crates/notebook-sync/src/connect.rs
@@ -13,10 +13,10 @@ use automerge::AutoCommit;
 use log::{debug, info};
 use tokio::sync::{mpsc, watch};
 
-use runtimed::connection::{
+use notebook_protocol::connection::{
     self, Handshake, NotebookConnectionInfo, NotebookFrameType, ProtocolCapabilities, PROTOCOL_V2,
 };
-use runtimed::protocol::NotebookBroadcast;
+use notebook_protocol::protocol::NotebookBroadcast;
 
 use crate::error::SyncError;
 use crate::handle::DocHandle;

--- a/crates/notebook-sync/src/handle.rs
+++ b/crates/notebook-sync/src/handle.rs
@@ -34,7 +34,7 @@ use std::sync::{Arc, Mutex};
 use automerge::AutoCommit;
 use tokio::sync::{mpsc, oneshot, watch};
 
-use runtimed::protocol::{NotebookRequest, NotebookResponse};
+use notebook_protocol::protocol::{NotebookRequest, NotebookResponse};
 
 use crate::error::SyncError;
 use crate::shared::SharedDocState;
@@ -391,7 +391,7 @@ impl DocHandle {
     pub async fn send_request_with_broadcast(
         &self,
         request: NotebookRequest,
-        broadcast_tx: tokio::sync::broadcast::Sender<runtimed::protocol::NotebookBroadcast>,
+        broadcast_tx: tokio::sync::broadcast::Sender<notebook_protocol::protocol::NotebookBroadcast>,
     ) -> Result<NotebookResponse, SyncError> {
         let (reply_tx, reply_rx) = oneshot::channel();
         self.cmd_tx

--- a/crates/notebook-sync/src/handle.rs
+++ b/crates/notebook-sync/src/handle.rs
@@ -391,7 +391,9 @@ impl DocHandle {
     pub async fn send_request_with_broadcast(
         &self,
         request: NotebookRequest,
-        broadcast_tx: tokio::sync::broadcast::Sender<notebook_protocol::protocol::NotebookBroadcast>,
+        broadcast_tx: tokio::sync::broadcast::Sender<
+            notebook_protocol::protocol::NotebookBroadcast,
+        >,
     ) -> Result<NotebookResponse, SyncError> {
         let (reply_tx, reply_rx) = oneshot::channel();
         self.cmd_tx

--- a/crates/notebook-sync/src/sync_task.rs
+++ b/crates/notebook-sync/src/sync_task.rs
@@ -25,8 +25,8 @@ use log::{debug, info, warn};
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::sync::{broadcast, mpsc, oneshot};
 
-use runtimed::connection::{self, NotebookFrameType};
-use runtimed::protocol::{NotebookBroadcast, NotebookRequest, NotebookResponse};
+use notebook_protocol::connection::{self, NotebookFrameType};
+use notebook_protocol::protocol::{NotebookBroadcast, NotebookRequest, NotebookResponse};
 
 use crate::error::SyncError;
 use crate::shared::SharedDocState;

--- a/crates/notebook-sync/src/tests.rs
+++ b/crates/notebook-sync/src/tests.rs
@@ -567,7 +567,7 @@ mod integration_tests {
     use std::path::PathBuf;
     use std::time::Duration;
 
-    use runtimed::protocol::{NotebookBroadcast, NotebookRequest, NotebookResponse};
+    use notebook_protocol::protocol::{NotebookBroadcast, NotebookRequest, NotebookResponse};
 
     /// Get the daemon socket path for the current worktree.
     fn daemon_socket_path() -> PathBuf {

--- a/crates/runtimed-py/Cargo.toml
+++ b/crates/runtimed-py/Cargo.toml
@@ -16,6 +16,7 @@ pyo3 = { version = "0.28", features = ["extension-module", "abi3-py39"] }
 pyo3-async-runtimes = { version = "0.28", features = ["tokio-runtime"] }
 runtimed = { path = "../runtimed" }
 notebook-doc = { path = "../notebook-doc" }
+notebook-protocol = { path = "../notebook-protocol" }
 notebook-sync = { path = "../notebook-sync" }
 tokio = { version = "1", features = ["full"] }
 serde_json = { workspace = true }

--- a/crates/runtimed-py/src/async_session.rs
+++ b/crates/runtimed-py/src/async_session.rs
@@ -10,7 +10,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
-use runtimed::protocol::{NotebookBroadcast, NotebookRequest, NotebookResponse};
+use notebook_protocol::protocol::{NotebookBroadcast, NotebookRequest, NotebookResponse};
 
 use crate::daemon_paths::get_socket_path;
 use crate::error::to_py_err;

--- a/crates/runtimed-py/src/event_stream.rs
+++ b/crates/runtimed-py/src/event_stream.rs
@@ -11,8 +11,8 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::Mutex;
 
+use notebook_protocol::protocol::NotebookBroadcast;
 use notebook_sync::BroadcastReceiver;
-use runtimed::protocol::NotebookBroadcast;
 
 use crate::error::to_py_err;
 use crate::output::ExecutionEvent;

--- a/crates/runtimed-py/src/output.rs
+++ b/crates/runtimed-py/src/output.rs
@@ -423,7 +423,7 @@ impl CompletionItem {
 }
 
 impl CompletionItem {
-    pub fn from_protocol(item: runtimed::protocol::CompletionItem) -> Self {
+    pub fn from_protocol(item: notebook_protocol::protocol::CompletionItem) -> Self {
         Self {
             label: item.label,
             kind: item.kind,
@@ -506,7 +506,7 @@ impl HistoryEntry {
 }
 
 impl HistoryEntry {
-    pub fn from_protocol(entry: runtimed::protocol::HistoryEntry) -> Self {
+    pub fn from_protocol(entry: notebook_protocol::protocol::HistoryEntry) -> Self {
         Self {
             session: entry.session,
             line: entry.line,
@@ -582,7 +582,7 @@ impl NotebookConnectionInfo {
 
 impl NotebookConnectionInfo {
     /// Create from the Rust NotebookConnectionInfo type.
-    pub fn from_protocol(info: runtimed::connection::NotebookConnectionInfo) -> Self {
+    pub fn from_protocol(info: notebook_protocol::connection::NotebookConnectionInfo) -> Self {
         Self {
             protocol: info.protocol,
             protocol_version: info.protocol_version,

--- a/crates/runtimed-py/src/session.rs
+++ b/crates/runtimed-py/src/session.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use tokio::runtime::Runtime;
 use tokio::sync::Mutex;
 
-use runtimed::protocol::{NotebookBroadcast, NotebookRequest, NotebookResponse};
+use notebook_protocol::protocol::{NotebookBroadcast, NotebookRequest, NotebookResponse};
 
 use crate::daemon_paths::get_socket_path;
 use crate::error::to_py_err;

--- a/crates/runtimed-py/src/session_core.rs
+++ b/crates/runtimed-py/src/session_core.rs
@@ -10,8 +10,8 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
+use notebook_protocol::protocol::{NotebookBroadcast, NotebookRequest, NotebookResponse};
 use notebook_sync::{BroadcastReceiver, DocHandle};
-use runtimed::protocol::{NotebookBroadcast, NotebookRequest, NotebookResponse};
 
 use notebook_doc::metadata::NotebookMetadataSnapshot;
 

--- a/crates/runtimed-py/src/subscription.rs
+++ b/crates/runtimed-py/src/subscription.rs
@@ -11,8 +11,8 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
+use notebook_protocol::protocol::NotebookBroadcast;
 use notebook_sync::BroadcastReceiver;
-use runtimed::protocol::NotebookBroadcast;
 
 use crate::error::to_py_err;
 use crate::output::ExecutionEvent;


### PR DESCRIPTION
Extracts shared wire protocol types into a standalone `notebook-protocol` crate so `notebook-sync` (client) doesn't depend on `runtimed` (daemon).

### What's extracted

- `connection.rs`: frame protocol, handshake types, send/recv functions
- `protocol.rs`: `NotebookRequest`, `NotebookResponse`, `NotebookBroadcast` enums plus data structs they reference (`CommSnapshot`, `LaunchedEnvConfig`, `PoolError`, `CompletionItem`, etc.)

### Current state

- `notebook-protocol` compiles
- `notebook-sync` depends on `notebook-protocol` instead of `runtimed` (27 tests pass)
- `runtimed` still has its own copies of these types

### Remaining work

`runtimed` needs to depend on `notebook-protocol` and re-export the shared types, replacing its own copies. This causes a type mismatch in `runtimed-py` where `notebook-sync` returns `notebook_protocol::` types but callers expect `runtimed::` types. That's a larger migration of imports across the daemon codebase.

_PR submitted by @rgbkrk's agent Quill, via Zed_