### PR TITLE
feat(mcp): improve agent notebook interface and cell type visibility

### DIFF
--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -1113,6 +1113,27 @@ impl NotebookDoc {
         Ok(true)
     }
 
+    // ── Cell type ───────────────────────────────────────────────────
+
+    /// Set the cell type for a cell. Valid values: "code", "markdown", "raw".
+    pub fn set_cell_type(
+        &mut self,
+        cell_id: &str,
+        cell_type: &str,
+    ) -> Result<bool, AutomergeError> {
+        let cells_id = match self.cells_map_id() {
+            Some(id) => id,
+            None => return Ok(false),
+        };
+        let cell_obj = match self.cell_obj_id(&cells_id, cell_id) {
+            Some(o) => o,
+            None => return Ok(false),
+        };
+
+        self.doc.put(&cell_obj, "cell_type", cell_type)?;
+        Ok(true)
+    }
+
     // ── Cell metadata ──────────────────────────────────────────────
 
     /// Get the raw metadata Value for a cell.

--- a/crates/notebook-sync/src/handle.rs
+++ b/crates/notebook-sync/src/handle.rs
@@ -268,6 +268,11 @@ impl DocHandle {
         self.with_notebook_doc(|nd| nd.append_source(cell_id, text))
     }
 
+    /// Set a cell's type. Valid values: "code", "markdown", "raw". Returns true if cell was found.
+    pub fn set_cell_type(&self, cell_id: &str, cell_type: &str) -> Result<bool, SyncError> {
+        self.with_notebook_doc(|nd| nd.set_cell_type(cell_id, cell_type))
+    }
+
     /// Set the full notebook metadata snapshot (kernelspec + language_info + runt).
     pub fn set_metadata_snapshot(
         &self,

--- a/crates/runtimed-py/src/async_session.rs
+++ b/crates/runtimed-py/src/async_session.rs
@@ -309,6 +309,22 @@ impl AsyncSession {
         })
     }
 
+    /// Set a cell's type (code, markdown, or raw).
+    fn set_cell_type<'py>(
+        &self,
+        py: Python<'py>,
+        cell_id: &str,
+        cell_type: &str,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let state = Arc::clone(&self.state);
+        let cell_id = cell_id.to_string();
+        let cell_type = cell_type.to_string();
+
+        future_into_py(py, async move {
+            session_core::set_cell_type(&state, &cell_id, &cell_type).await
+        })
+    }
+
     /// Get a cell by ID with resolved outputs.
     fn get_cell<'py>(&self, py: Python<'py>, cell_id: &str) -> PyResult<Bound<'py, PyAny>> {
         let state = Arc::clone(&self.state);

--- a/crates/runtimed-py/src/session.rs
+++ b/crates/runtimed-py/src/session.rs
@@ -271,6 +271,12 @@ impl Session {
             .block_on(session_core::append_source(&self.state, cell_id, text))
     }
 
+    /// Set a cell's type (code, markdown, or raw).
+    fn set_cell_type(&self, cell_id: &str, cell_type: &str) -> PyResult<()> {
+        self.runtime
+            .block_on(session_core::set_cell_type(&self.state, cell_id, cell_type))
+    }
+
     /// Get a cell by ID with resolved outputs.
     fn get_cell(&self, cell_id: &str) -> PyResult<Cell> {
         self.runtime

--- a/crates/runtimed-py/src/session_core.rs
+++ b/crates/runtimed-py/src/session_core.rs
@@ -413,6 +413,25 @@ pub(crate) async fn append_source(
     Ok(())
 }
 
+/// Set a cell's type.
+pub(crate) async fn set_cell_type(
+    state: &Arc<Mutex<SessionState>>,
+    cell_id: &str,
+    cell_type: &str,
+) -> PyResult<()> {
+    let st = state.lock().await;
+    let handle = st
+        .handle
+        .as_ref()
+        .ok_or_else(|| to_py_err("Not connected"))?;
+
+    // Synchronous — direct doc mutation via DocHandle
+    handle
+        .set_cell_type(cell_id, cell_type)
+        .map_err(to_py_err)?;
+    Ok(())
+}
+
 /// Get a single cell by ID, with resolved outputs.
 pub(crate) async fn get_cell(state: &Arc<Mutex<SessionState>>, cell_id: &str) -> PyResult<Cell> {
     let (snapshot, blob_base_url, blob_store_path) = {

--- a/python/nteract/src/nteract/_mcp_server.py
+++ b/python/nteract/src/nteract/_mcp_server.py
@@ -867,7 +867,7 @@ def _output_to_dict(output: runtimed.Output) -> dict[str, Any]:
 async def get_all_cells(
     format: Annotated[
         Literal["markdown", "json"],
-        Field(description="Output format: 'markdown' for visual display, 'json' for structured data"),
+        Field(description="'markdown' for visual display, 'json' for structured data"),
     ] = "markdown",
 ) -> list[ContentItem] | list[dict[str, Any]]:
     """Get all cells with source and outputs.

--- a/python/nteract/src/nteract/_mcp_server.py
+++ b/python/nteract/src/nteract/_mcp_server.py
@@ -252,16 +252,20 @@ def _outputs_to_content(outputs: list[runtimed.Output]) -> list[ContentItem]:
 
 def _format_header(
     cell_id: str,
+    cell_type: str | None = None,
     status: str | None = None,
     execution_count: int | None = None,
 ) -> str:
     """Format a cell header line for terminal display.
 
-    Example: ━━━ cell-abc12345 ✓ idle [3] ━━━
+    Example: ━━━ cell-abc12345 (code) ✓ idle [3] ━━━
     """
     icons = {"idle": "✓", "error": "✗", "running": "◐"}
 
     parts = [f"━━━ {cell_id}"]
+
+    if cell_type:
+        parts.append(f"({cell_type})")
 
     if status:
         icon = icons.get(status, "?")
@@ -279,7 +283,9 @@ def _format_cell(cell: runtimed.Cell) -> str:
 
     Used by get_cell to show full cell state.
     """
-    header = _format_header(cell.id, execution_count=cell.execution_count)
+    header = _format_header(
+        cell.id, cell_type=cell.cell_type, execution_count=cell.execution_count
+    )
     output_text = _format_outputs_text(cell.outputs)
 
     if cell.source and output_text:
@@ -297,7 +303,9 @@ def _cell_to_content(cell: runtimed.Cell) -> list[ContentItem]:
 
     Returns a header as TextContent, then each output as its richest type.
     """
-    header = _format_header(cell.id, execution_count=cell.execution_count)
+    header = _format_header(
+        cell.id, cell_type=cell.cell_type, execution_count=cell.execution_count
+    )
     items: list[ContentItem] = []
 
     if cell.source:
@@ -395,12 +403,37 @@ def _execution_result_to_content(
 # =============================================================================
 
 
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+async def list_notebooks() -> list[dict[str, Any]]:
+    """List all open notebook sessions.
+
+    Returns notebooks currently open by users or other agents.
+    Use join_notebook(notebook_id) to connect to one.
+    """
+    client = _get_daemon_client()
+    rooms = client.list_rooms()
+    return [
+        {
+            "notebook_id": room["notebook_id"],
+            "active_peers": room["active_peers"],
+            "has_kernel": room["has_kernel"],
+            "kernel_type": room.get("kernel_type"),
+            "kernel_status": room.get("kernel_status"),
+        }
+        for room in rooms
+    ]
+
+
 @mcp.tool(annotations=ToolAnnotations(destructiveHint=False))
-async def connect_notebook(
-    notebook_id: str | None = None,
+async def join_notebook(
+    notebook_id: str,
     ctx: Context | None = None,
 ) -> dict[str, Any]:
-    """Connect to a notebook by ID. Omit notebook_id to create a new session."""
+    """Join an existing notebook session by ID.
+
+    Use list_notebooks() to see available sessions. To open a file from disk,
+    use open_notebook(path). To create a new notebook, use create_notebook().
+    """
     global _session
     if ctx:
         _sniff_client_name(ctx)
@@ -410,7 +443,7 @@ async def connect_notebook(
         with contextlib.suppress(Exception):
             await _session.close()
 
-    # Create new session
+    # Join existing session
     _session = runtimed.AsyncSession(notebook_id=notebook_id, peer_label=_peer_label())
     await _session.connect()
 
@@ -469,11 +502,14 @@ async def create_notebook(
 
 @mcp.tool(annotations=ToolAnnotations(destructiveHint=False))
 async def save_notebook(path: str | None = None) -> dict[str, Any]:
-    """Save notebook to disk. Path is required for create_notebook() notebooks."""
+    """Save notebook to disk. Automatically reconnects to the saved file's session."""
+    global _session
     session = await _get_session()
+
+    old_notebook_id = session.notebook_id
+
     try:
         saved_path = await session.save(path)
-        return {"path": saved_path}
     except Exception as e:
         error_msg = str(e)
         is_write_error = "Read-only" in error_msg or "Failed to write" in error_msg
@@ -483,6 +519,24 @@ async def save_notebook(path: str | None = None) -> dict[str, Any]:
                 "you must provide a path (e.g., save_notebook('/path/to/file.ipynb'))"
             ) from e
         raise
+
+    # If notebook_id was UUID-based (ephemeral) and we saved to a path,
+    # reconnect to the path-based room so we're in sync with users who open the file
+    is_ephemeral = not old_notebook_id.startswith("/")
+    if is_ephemeral and saved_path:
+        with contextlib.suppress(Exception):
+            await session.close()
+
+        _session = await runtimed.AsyncSession.open_notebook(
+            saved_path, peer_label=_peer_label()
+        )
+        return {
+            "path": saved_path,
+            "reconnected": True,
+            "notebook_id": _session.notebook_id,
+        }
+
+    return {"path": saved_path}
 
 
 # =============================================================================
@@ -783,11 +837,59 @@ async def get_cell(
     return _cell_to_content(cell)
 
 
+def _output_to_dict(output: runtimed.Output) -> dict[str, Any]:
+    """Convert an output to a dictionary for JSON serialization."""
+    result: dict[str, Any] = {"output_type": output.output_type}
+
+    if output.output_type == "stream":
+        result["name"] = output.name
+        result["text"] = _strip_ansi(output.text) if output.text else ""
+    elif output.output_type == "error":
+        result["ename"] = output.ename or ""
+        result["evalue"] = output.evalue or ""
+        result["traceback"] = output.traceback or []
+    elif output.output_type in ("display_data", "execute_result"):
+        # Include text-based data, skip large binary data
+        result["data"] = {}
+        if output.data:
+            for mime in _TEXT_MIME_PRIORITY:
+                if mime in output.data:
+                    result["data"][mime] = output.data[mime]
+                    break
+        if output.output_type == "execute_result" and output.execution_count is not None:
+            result["execution_count"] = output.execution_count
+
+    return result
+
+
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
-async def get_all_cells() -> list[ContentItem]:
-    """Get all cells with source and outputs."""
+async def get_all_cells(
+    format: Annotated[
+        Literal["markdown", "json"],
+        Field(description="Output format: 'markdown' for visual display, 'json' for structured data"),
+    ] = "markdown",
+) -> list[ContentItem] | list[dict[str, Any]]:
+    """Get all cells with source and outputs.
+
+    Args:
+        format: "markdown" for visual display (default), "json" for structured data.
+    """
     session = await _get_session()
     cells = await session.get_cells()
+
+    if format == "json":
+        return [
+            {
+                "cell_id": cell.id,
+                "cell_type": cell.cell_type,
+                "execution_count": cell.execution_count,
+                "source": cell.source,
+                "outputs": [_output_to_dict(o) for o in cell.outputs],
+            }
+            for cell in cells
+        ]
+
+    # Default markdown format
     items: list[ContentItem] = []
     for cell in cells:
         items.extend(_cell_to_content(cell))
@@ -827,6 +929,17 @@ async def clear_outputs(cell_id: str) -> dict[str, Any]:
     session = await _get_session()
     await session.clear_outputs(cell_id)
     return {"cell_id": cell_id, "cleared": True}
+
+
+@mcp.tool(annotations=ToolAnnotations(destructiveHint=True))
+async def set_cell_type(
+    cell_id: str,
+    cell_type: Literal["code", "markdown", "raw"],
+) -> dict[str, Any]:
+    """Change a cell's type (code, markdown, or raw)."""
+    session = await _get_session()
+    await session.set_cell_type(cell_id=cell_id, cell_type=cell_type)
+    return {"cell_id": cell_id, "cell_type": cell_type}
 
 
 # =============================================================================

--- a/python/nteract/src/nteract/_mcp_server.py
+++ b/python/nteract/src/nteract/_mcp_server.py
@@ -284,9 +284,7 @@ def _format_cell(cell: runtimed.Cell) -> str:
 
     Used by get_cell to show full cell state.
     """
-    header = _format_header(
-        cell.id, cell_type=cell.cell_type, execution_count=cell.execution_count
-    )
+    header = _format_header(cell.id, cell_type=cell.cell_type, execution_count=cell.execution_count)
     output_text = _format_outputs_text(cell.outputs)
 
     if cell.source and output_text:
@@ -304,9 +302,7 @@ def _cell_to_content(cell: runtimed.Cell) -> list[ContentItem]:
 
     Returns a header as TextContent, then each output as its richest type.
     """
-    header = _format_header(
-        cell.id, cell_type=cell.cell_type, execution_count=cell.execution_count
-    )
+    header = _format_header(cell.id, cell_type=cell.cell_type, execution_count=cell.execution_count)
     items: list[ContentItem] = []
 
     if cell.source:
@@ -528,9 +524,7 @@ async def save_notebook(path: str | None = None) -> dict[str, Any]:
         with contextlib.suppress(Exception):
             await session.close()
 
-        _session = await runtimed.AsyncSession.open_notebook(
-            saved_path, peer_label=_peer_label()
-        )
+        _session = await runtimed.AsyncSession.open_notebook(saved_path, peer_label=_peer_label())
         return {
             "path": saved_path,
             "reconnected": True,

--- a/python/nteract/src/nteract/_mcp_server.py
+++ b/python/nteract/src/nteract/_mcp_server.py
@@ -20,6 +20,7 @@ import contextlib
 import difflib
 import json
 import logging
+import os
 import re
 import sys
 from typing import Annotated, Any, Literal
@@ -522,7 +523,7 @@ async def save_notebook(path: str | None = None) -> dict[str, Any]:
 
     # If notebook_id was UUID-based (ephemeral) and we saved to a path,
     # reconnect to the path-based room so we're in sync with users who open the file
-    is_ephemeral = not old_notebook_id.startswith("/")
+    is_ephemeral = not os.path.isabs(old_notebook_id)
     if is_ephemeral and saved_path:
         with contextlib.suppress(Exception):
             await session.close()

--- a/python/nteract/tests/test_mcp_integration.py
+++ b/python/nteract/tests/test_mcp_integration.py
@@ -117,7 +117,8 @@ async def test_list_tools(mcp_client: ClientSession):
     tool_names = {t.name for t in tools.tools}
 
     # Core tools should be present
-    assert "connect_notebook" in tool_names
+    assert "list_notebooks" in tool_names
+    assert "join_notebook" in tool_names
     assert "open_notebook" in tool_names
     assert "create_notebook" in tool_names
     assert "save_notebook" in tool_names
@@ -132,10 +133,13 @@ async def test_list_tools(mcp_client: ClientSession):
     assert "get_all_cells" in tool_names
     assert "delete_cell" in tool_names
     assert "move_cell" in tool_names
+    assert "clear_outputs" in tool_names
+    assert "set_cell_type" in tool_names
     assert "execute_cell" in tool_names
     assert "run_all_cells" in tool_names
 
     # Removed tools should not be present
+    assert "connect_notebook" not in tool_names  # replaced by join_notebook
     assert "disconnect_notebook" not in tool_names
     assert "start_kernel" not in tool_names
     assert "shutdown_kernel" not in tool_names
@@ -143,18 +147,17 @@ async def test_list_tools(mcp_client: ClientSession):
     assert "complete_code" not in tool_names
     assert "get_queue_state" not in tool_names
     assert "get_history" not in tool_names
-    assert "list_notebooks" not in tool_names
     assert "run_code" not in tool_names
 
 
 @pytest.mark.asyncio
-async def test_connect_and_create_cell(mcp_client: ClientSession):
-    """Connect to notebook and create a cell."""
-    # Connect
-    result = await mcp_client.call_tool("connect_notebook", {})
+async def test_create_notebook_and_cell(mcp_client: ClientSession):
+    """Create a notebook and add a cell."""
+    # Create notebook
+    result = await mcp_client.call_tool("create_notebook", {})
     data = _parse_json(result)
-    assert data["connected"] is True
     assert "notebook_id" in data
+    assert data["runtime"] == "python"
 
     # Create cell (returns plain text)
     result = await mcp_client.call_tool(
@@ -176,7 +179,7 @@ async def test_connect_and_create_cell(mcp_client: ClientSession):
 async def test_append_source(mcp_client: ClientSession):
     """Test streaming tokens into a cell."""
     # Connect
-    await mcp_client.call_tool("connect_notebook", {})
+    await mcp_client.call_tool("create_notebook", {})
 
     # Create empty cell
     result = await mcp_client.call_tool("create_cell", {"source": ""})
@@ -204,7 +207,7 @@ async def test_append_source(mcp_client: ClientSession):
 async def test_execute_cell_basic(mcp_client: ClientSession):
     """Test basic cell execution."""
     # Connect (daemon auto-launches kernel)
-    await mcp_client.call_tool("connect_notebook", {})
+    await mcp_client.call_tool("create_notebook", {})
 
     # Create and execute cell
     result = await mcp_client.call_tool(
@@ -226,7 +229,7 @@ async def test_execute_cell_basic(mcp_client: ClientSession):
 async def test_execute_cell_partial_results(mcp_client: ClientSession):
     """Execute long-running code, verify partial results returned."""
     # Connect (daemon auto-launches kernel)
-    await mcp_client.call_tool("connect_notebook", {})
+    await mcp_client.call_tool("create_notebook", {})
 
     # Create cell with slow code - print immediately, then sleep
     result = await mcp_client.call_tool(
@@ -248,7 +251,7 @@ async def test_execute_cell_partial_results(mcp_client: ClientSession):
 async def test_poll_for_outputs(mcp_client: ClientSession):
     """Create cell, execute, poll get_cell for updated outputs."""
     # Connect (daemon auto-launches kernel)
-    await mcp_client.call_tool("connect_notebook", {})
+    await mcp_client.call_tool("create_notebook", {})
 
     # Create cell with short delay
     result = await mcp_client.call_tool(
@@ -279,7 +282,7 @@ async def test_poll_for_outputs(mcp_client: ClientSession):
 async def test_output_ordering(mcp_client: ClientSession):
     """Verify interleaved outputs maintain order."""
     # Connect (daemon auto-launches kernel)
-    await mcp_client.call_tool("connect_notebook", {})
+    await mcp_client.call_tool("create_notebook", {})
 
     # Code that produces interleaved outputs
     code = """
@@ -317,7 +320,7 @@ print('c', flush=True)
 async def test_delete_cell(mcp_client: ClientSession):
     """Test cell deletion."""
     # Connect
-    await mcp_client.call_tool("connect_notebook", {})
+    await mcp_client.call_tool("create_notebook", {})
 
     # Create cell
     result = await mcp_client.call_tool("create_cell", {"source": "x = 1"})
@@ -340,7 +343,7 @@ async def test_delete_cell(mcp_client: ClientSession):
 @pytest.mark.asyncio
 async def test_move_cell(mcp_client: ClientSession):
     """Test cell reordering."""
-    await mcp_client.call_tool("connect_notebook", {})
+    await mcp_client.call_tool("create_notebook", {})
 
     result = await mcp_client.call_tool("create_cell", {"source": "first"})
     first_id = _extract_cell_id(_get_text(result))


### PR DESCRIPTION
## Summary

Improves the nteract MCP server interface to make agent workflows more discoverable and prevent accidental ephemeral notebook creation. Agents now see cell types in notebook representations and can change them on demand.

Closes #772, #773, #780

## Changes

**Tool API Redesign**: Replaced confusing `connect_notebook(notebook_id=None)` with separate, single-purpose tools:
- `list_notebooks()` discovers open sessions so agents can find the user's notebook instead of blindly creating new ones
- `join_notebook(notebook_id)` requires an ID, preventing accidental ephemeral session creation
- `create_notebook()` remains for intentional new notebook creation

**Better Cell Visibility**: Cell type now appears in headers alongside status/counts:
- Before: `━━━ cell-abc12345 ✓ idle [3] ━━━`
- After: `━━━ cell-abc12345 (code) ✓ idle [3] ━━━`

**Structured Data Option**: `get_all_cells(format="json")` returns cell data as structured JSON for agents that prefer programmatic access over formatted text.

**Auto-Reconnect on Save**: When an agent saves an ephemeral notebook, the session automatically switches to the saved file's room so agent and user stay in sync.

**Cell Type Mutation**: New `set_cell_type()` tool allows agents to convert cells between code/markdown/raw types. Wired through all Rust layers (notebook-doc, notebook-sync, runtimed-py).

## Verification

- [ ] Run `list_notebooks()` with a notebook open in the app—should see it listed
- [ ] Call `join_notebook(notebook_id)` to connect to an existing session
- [ ] Create cells and verify `get_all_cells()` shows cell types like `(code)`, `(markdown)`
- [ ] Try `get_all_cells(format="json")` to see structured output
- [ ] Create an ephemeral notebook with `create_notebook()`, add cells, call `save_notebook("/path/to/file.ipynb")`, verify response includes `reconnected: true`
- [ ] Use `set_cell_type(cell_id, "markdown")` to change cell type and verify in app

_PR submitted by @rgbkrk's agent, Quill_