### PR TITLE
ci: enable workspace-wide clippy and tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -221,7 +221,7 @@ jobs:
           retention-days: 1
 
       - name: Clippy
-        run: cargo clippy --all-targets -- -D warnings
+        run: cargo clippy --workspace --all-targets -- -D warnings
 
       - name: Build
         run: cargo build --release
@@ -246,7 +246,7 @@ jobs:
           retention-days: 1
 
       - name: Run tests
-        run: cargo test --verbose
+        run: cargo test --workspace --verbose
 
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
@@ -334,7 +334,7 @@ jobs:
 
       - name: Clippy
         if: needs.changes.outputs.source_changed == 'true' && (github.event_name != 'pull_request' || matrix.platform.run_on_pr)
-        run: cargo clippy --all-targets -- -D warnings
+        run: cargo clippy --workspace --all-targets -- -D warnings
 
       - name: Build
         if: needs.changes.outputs.source_changed == 'true' && (github.event_name != 'pull_request' || matrix.platform.run_on_pr)
@@ -342,7 +342,7 @@ jobs:
 
       - name: Run tests
         if: needs.changes.outputs.source_changed == 'true' && (github.event_name != 'pull_request' || matrix.platform.run_on_pr)
-        run: cargo test --verbose
+        run: cargo test --workspace --verbose
 
   # Build Tauri app once and share with E2E shards
   # E2E smoke test - verifies basic app functionality

--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -3413,11 +3413,11 @@ mod tests {
         );
 
         // Float
-        doc.put_json_value(&meta_id, "float_val", &serde_json::json!(3.14))
+        doc.put_json_value(&meta_id, "float_val", &serde_json::json!(3.15))
             .unwrap();
         assert_eq!(
             doc.get_json_value(&meta_id, "float_val"),
-            Some(serde_json::json!(3.14))
+            Some(serde_json::json!(3.15))
         );
 
         // String

--- a/crates/notebook-sync/src/tests.rs
+++ b/crates/notebook-sync/src/tests.rs
@@ -4,7 +4,7 @@
 //! Integration tests (behind `#[ignore]`) connect to a running daemon.
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::module_inception)]
 mod tests {
     use std::sync::{Arc, Mutex};
 

--- a/crates/runt/src/kernel_client.rs
+++ b/crates/runt/src/kernel_client.rs
@@ -50,6 +50,7 @@ pub struct KernelClient {
 }
 
 impl KernelClient {
+    #[allow(clippy::expect_used)] // petname only returns None when word count is 0
     pub async fn start_from_kernelspec(kernelspec: KernelspecDir) -> Result<Self> {
         let kernel_id = petname(2, "-").expect("failed to generate petname");
         let session_id = Uuid::new_v4().to_string();
@@ -96,6 +97,7 @@ impl KernelClient {
     ///
     /// The command is split on whitespace and `{connection_file}` is replaced
     /// with the path to the generated connection file.
+    #[allow(clippy::expect_used)] // petname only returns None when word count is 0
     pub async fn start_from_command(cmd: &str) -> Result<Self> {
         let kernel_id = petname(2, "-").expect("failed to generate petname");
         let session_id = Uuid::new_v4().to_string();

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -2163,11 +2163,11 @@ async fn doctor_command(
             .map(|c| c.status == "quarantined")
             .unwrap_or(false);
         #[cfg(not(target_os = "macos"))]
-        let launchd_not_loaded = false;
+        let _launchd_not_loaded = false;
         #[cfg(not(target_os = "macos"))]
         let launchd_error = false;
         #[cfg(not(target_os = "macos"))]
-        let is_quarantined = false;
+        let _is_quarantined = false;
 
         // Determine diagnosis
         let diagnosis = if daemon_running_result {

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -1334,6 +1334,7 @@ async fn execute_code(id: &str, code: Option<&str>) -> Result<()> {
 // Pool daemon commands
 // =============================================================================
 
+#[allow(clippy::unwrap_used, clippy::expect_used)] // CLI binary; panics with context are acceptable
 async fn pool_command(command: PoolCommands) -> Result<()> {
     use runtimed::client::PoolClient;
     use runtimed::EnvType;
@@ -1488,6 +1489,7 @@ async fn pool_command(command: PoolCommands) -> Result<()> {
 // Daemon management commands
 // =============================================================================
 
+#[allow(clippy::unwrap_used, clippy::expect_used)] // CLI binary; panics with context are acceptable
 async fn daemon_command(command: DaemonCommands) -> Result<()> {
     use runtimed::client::PoolClient;
     use runtimed::service::ServiceManager;

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -2245,7 +2245,7 @@ async fn doctor_command(
         false
     };
     #[cfg(not(target_os = "macos"))]
-    let launchd_not_loaded = false;
+    let _launchd_not_loaded = false;
 
     // On macOS, check if binary has quarantine xattr
     #[cfg(target_os = "macos")]
@@ -2260,7 +2260,7 @@ async fn doctor_command(
         false
     };
     #[cfg(not(target_os = "macos"))]
-    let is_quarantined = false;
+    let _is_quarantined = false;
 
     // Check daemon state for fix operations
     let daemon_state_status = if let Some(info) = daemon_info {

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -2163,11 +2163,14 @@ async fn doctor_command(
             .map(|c| c.status == "quarantined")
             .unwrap_or(false);
         #[cfg(not(target_os = "macos"))]
-        let _launchd_not_loaded = false;
+        #[allow(unused_variables)]
+        let launchd_not_loaded = false;
         #[cfg(not(target_os = "macos"))]
+        #[allow(unused_variables)]
         let launchd_error = false;
         #[cfg(not(target_os = "macos"))]
-        let _is_quarantined = false;
+        #[allow(unused_variables)]
+        let is_quarantined = false;
 
         // Determine diagnosis
         let diagnosis = if daemon_running_result {
@@ -2245,7 +2248,8 @@ async fn doctor_command(
         false
     };
     #[cfg(not(target_os = "macos"))]
-    let _launchd_not_loaded = false;
+    #[allow(unused_variables)]
+    let launchd_not_loaded = false;
 
     // On macOS, check if binary has quarantine xattr
     #[cfg(target_os = "macos")]
@@ -2260,7 +2264,8 @@ async fn doctor_command(
         false
     };
     #[cfg(not(target_os = "macos"))]
-    let _is_quarantined = false;
+    #[allow(unused_variables)]
+    let is_quarantined = false;
 
     // Check daemon state for fix operations
     let daemon_state_status = if let Some(info) = daemon_info {

--- a/crates/runtimed-py/src/async_session.rs
+++ b/crates/runtimed-py/src/async_session.rs
@@ -15,7 +15,7 @@ use notebook_protocol::protocol::{NotebookBroadcast, NotebookRequest, NotebookRe
 use crate::daemon_paths::get_socket_path;
 use crate::error::to_py_err;
 use crate::event_stream::ExecutionEventStream;
-use crate::output::{Cell, ExecutionResult, NotebookConnectionInfo, SyncEnvironmentResult};
+use crate::output::SyncEnvironmentResult;
 use crate::session_core::{self, SessionState};
 use crate::subscription::EventSubscription;
 

--- a/crates/runtimed-py/src/daemon_paths.rs
+++ b/crates/runtimed-py/src/daemon_paths.rs
@@ -14,6 +14,7 @@ pub fn get_socket_path() -> PathBuf {
 /// Resolve blob server URL and blob store path from the daemon directory (sync).
 ///
 /// Returns (blob_base_url, blob_store_path).
+#[allow(dead_code)] // Public API surface — not yet called from Python bindings
 pub fn get_blob_paths_sync(socket_path: &Path) -> (Option<String>, Option<PathBuf>) {
     let Some(parent) = socket_path.parent() else {
         return (None, None);
@@ -43,6 +44,7 @@ pub fn get_blob_paths_sync(socket_path: &Path) -> (Option<String>, Option<PathBu
 /// Resolve blob server URL and blob store path from the daemon directory (async).
 ///
 /// Returns (blob_base_url, blob_store_path).
+#[allow(dead_code)] // Public API surface — not yet called from Python bindings
 pub async fn get_blob_paths_async(socket_path: &Path) -> (Option<String>, Option<PathBuf>) {
     let Some(parent) = socket_path.parent() else {
         return (None, None);

--- a/crates/runtimed-py/src/session_core.rs
+++ b/crates/runtimed-py/src/session_core.rs
@@ -6,7 +6,7 @@
 //! `future_into_py()`. This eliminates the duplication that previously
 //! existed between session.rs and async_session.rs.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
@@ -1120,7 +1120,7 @@ pub(crate) async fn get_history(
     let response = handle
         .send_request(NotebookRequest::GetHistory {
             pattern: pattern.map(|s| s.to_string()),
-            n: n as i32,
+            n,
             unique,
         })
         .await
@@ -1179,7 +1179,7 @@ async fn ensure_kernel_started(
 }
 
 /// Resolve blob server URL and store path from daemon info.
-async fn resolve_blob_paths(socket_path: &PathBuf) -> (Option<String>, Option<PathBuf>) {
+async fn resolve_blob_paths(socket_path: &Path) -> (Option<String>, Option<PathBuf>) {
     if let Some(parent) = socket_path.parent() {
         let daemon_json = parent.join("daemon.json");
         let base_url = if daemon_json.exists() {

--- a/crates/runtimed/src/markdown_assets.rs
+++ b/crates/runtimed/src/markdown_assets.rs
@@ -260,6 +260,7 @@ fn estimated_base64_decoded_len(payload: &str) -> usize {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
     use tempfile::TempDir;

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -4722,7 +4722,7 @@ mod tests {
     #[test]
     fn test_sanitize_peer_label_clamps_unicode() {
         // 70 emoji = 70 chars but 280 bytes
-        let emoji_label: String = std::iter::repeat('🦾').take(70).collect();
+        let emoji_label: String = "🦾".repeat(70);
         let result = sanitize_peer_label(Some(&emoji_label));
         assert_eq!(result.chars().count(), 64);
     }

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -1062,11 +1062,10 @@ async fn test_pipe_mode_forwards_sync_frames() {
 
     // Drain frames from the pipe
     let mut frames = Vec::new();
-    loop {
-        match tokio::time::timeout(Duration::from_millis(500), frame_rx.recv()).await {
-            Ok(Some(frame)) => frames.push(frame),
-            _ => break,
-        }
+    while let Ok(Some(frame)) =
+        tokio::time::timeout(Duration::from_millis(500), frame_rx.recv()).await
+    {
+        frames.push(frame);
     }
 
     assert!(!frames.is_empty(), "pipe should receive at least one frame");
@@ -1130,11 +1129,10 @@ async fn test_pipe_mode_only_pipes_allowed_frame_types() {
 
     // Drain all frames
     let mut frames = Vec::new();
-    loop {
-        match tokio::time::timeout(Duration::from_millis(500), frame_rx.recv()).await {
-            Ok(Some(frame)) => frames.push(frame),
-            _ => break,
-        }
+    while let Ok(Some(frame)) =
+        tokio::time::timeout(Duration::from_millis(500), frame_rx.recv()).await
+    {
+        frames.push(frame);
     }
 
     assert!(
@@ -1212,11 +1210,10 @@ async fn test_pipe_mode_does_not_forward_response_frames() {
 
     // Drain all frames from the pipe
     let mut frames = Vec::new();
-    loop {
-        match tokio::time::timeout(Duration::from_millis(500), frame_rx.recv()).await {
-            Ok(Some(frame)) => frames.push(frame),
-            _ => break,
-        }
+    while let Ok(Some(frame)) =
+        tokio::time::timeout(Duration::from_millis(500), frame_rx.recv()).await
+    {
+        frames.push(frame);
     }
 
     // None of the piped frames should be Response frames
@@ -1285,11 +1282,10 @@ async fn test_pipe_mode_preserves_frame_order() {
 
     // Collect all frames
     let mut frames = Vec::new();
-    loop {
-        match tokio::time::timeout(Duration::from_millis(500), frame_rx.recv()).await {
-            Ok(Some(frame)) => frames.push(frame),
-            _ => break,
-        }
+    while let Ok(Some(frame)) =
+        tokio::time::timeout(Duration::from_millis(500), frame_rx.recv()).await
+    {
+        frames.push(frame);
     }
 
     // Filter to sync frames only

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -306,6 +306,7 @@ fn build_with_bundle(bundle: &str) {
 /// 2. Stop the running service
 /// 3. Copy the new binary over the installed one
 /// 4. Restart the service
+#[allow(clippy::expect_used)] // xtask is a dev tool; panics with context are fine here
 fn cmd_install_daemon() {
     println!("Building runtimed (release)...");
     run_cmd("cargo", &["build", "--release", "-p", "runtimed"]);
@@ -583,6 +584,7 @@ fn build_external_binary(package: &str, binary_name: &str, release: bool) {
 }
 
 /// Get the host target triple (e.g., aarch64-apple-darwin).
+#[allow(clippy::expect_used)] // xtask is a dev tool; rustc must be available
 fn get_host_target() -> String {
     let output = Command::new("rustc")
         .args(["--print", "host-tuple"])


### PR DESCRIPTION
Previously CI only ran `cargo clippy` and `cargo test` on the default package. This meant clippy warnings in workspace crates (xtask, runt-cli, runtimed-py, notebook-sync, etc.) went undetected.

This PR:

- Fixes all clippy warnings across every workspace crate
- Updates both CI jobs (build-linux and matrix build) to pass `--workspace` to clippy and test

**Clippy fixes by crate:**

| Crate | Fix |
|---|---|
| `xtask` | `#[allow(clippy::expect_used)]` — dev tool, panics are acceptable |
| `runt-cli` | `#[allow(clippy::expect_used, clippy::unwrap_used)]` on CLI functions and `kernel_client` methods |
| `runtimed` | `while let` loops, `"🦾".repeat(70)`, `#[allow(clippy::unwrap_used)]` in test module |
| `runtimed-py` | Remove unused imports, `#[allow(dead_code)]` on not-yet-called pub helpers, fix unnecessary cast and `&PathBuf` → `&Path` |
| `notebook-doc` | Use `3.15` instead of `3.14` in test to avoid `approx_constant` |
| `notebook-sync` | `#[allow(clippy::module_inception)]` in `tests.rs` |

Closes #787

_PR submitted by @rgbkrk's agent Quill, via Zed_