### PR TITLE
refactor(metadata): switch frontend reads from JSON strings to native WASM objects

### DIFF
--- a/apps/notebook/src/lib/notebook-metadata.ts
+++ b/apps/notebook/src/lib/notebook-metadata.ts
@@ -20,6 +20,17 @@ let _snapshotCache: NotebookMetadataSnapshot | null = null;
 const _subscribers = new Set<() => void>();
 
 /**
+ * Read the current metadata snapshot from the WASM handle as a typed object.
+ * Returns null if no handle is set or the WASM method returns a non-object.
+ */
+function readSnapshot(): NotebookMetadataSnapshot | null {
+  const raw = _handle?.get_metadata_snapshot();
+  return raw && typeof raw === "object"
+    ? (raw as NotebookMetadataSnapshot)
+    : null;
+}
+
+/**
  * Notify all useSyncExternalStore subscribers that the doc changed.
  * Call this after any operation that mutates the Automerge document:
  * - setNotebookHandle (bootstrap / reconnect)
@@ -27,9 +38,7 @@ const _subscribers = new Set<() => void>();
  * - set_metadata (local writes)
  */
 export function notifyMetadataChanged(): void {
-  const raw = _handle?.get_metadata_snapshot();
-  _snapshotCache =
-    raw && typeof raw === "object" ? (raw as NotebookMetadataSnapshot) : null;
+  _snapshotCache = readSnapshot();
   for (const cb of _subscribers) cb();
 }
 
@@ -60,9 +69,7 @@ function getSnapshot(): NotebookMetadataSnapshot | null {
   // any subscriber fires. This lazy init handles the first read
   // before any notification has occurred.
   if (_snapshotCache === null) {
-    const raw = _handle?.get_metadata_snapshot();
-    _snapshotCache =
-      raw && typeof raw === "object" ? (raw as NotebookMetadataSnapshot) : null;
+    _snapshotCache = readSnapshot();
   }
   return _snapshotCache;
 }
@@ -361,9 +368,7 @@ export async function setDenoFlexibleNpmImports(
   enabled: boolean,
 ): Promise<boolean> {
   if (!_handle) return false;
-  const snapshot = _handle.get_metadata_snapshot() as
-    | NotebookMetadataSnapshot
-    | undefined;
+  const snapshot = readSnapshot();
   if (!snapshot) return false;
   try {
     if (!snapshot.runt.deno) {

--- a/apps/notebook/src/lib/notebook-metadata.ts
+++ b/apps/notebook/src/lib/notebook-metadata.ts
@@ -29,9 +29,7 @@ const _subscribers = new Set<() => void>();
 export function notifyMetadataChanged(): void {
   const raw = _handle?.get_metadata_snapshot();
   _snapshotCache =
-    raw && typeof raw === "object"
-      ? (raw as NotebookMetadataSnapshot)
-      : null;
+    raw && typeof raw === "object" ? (raw as NotebookMetadataSnapshot) : null;
   for (const cb of _subscribers) cb();
 }
 
@@ -64,9 +62,7 @@ function getSnapshot(): NotebookMetadataSnapshot | null {
   if (_snapshotCache === null) {
     const raw = _handle?.get_metadata_snapshot();
     _snapshotCache =
-      raw && typeof raw === "object"
-        ? (raw as NotebookMetadataSnapshot)
-        : null;
+      raw && typeof raw === "object" ? (raw as NotebookMetadataSnapshot) : null;
   }
   return _snapshotCache;
 }

--- a/apps/notebook/src/lib/notebook-metadata.ts
+++ b/apps/notebook/src/lib/notebook-metadata.ts
@@ -16,7 +16,7 @@ import { logger } from "./logger";
 // ---------------------------------------------------------------------------
 
 let _handle: NotebookHandle | null = null;
-let _snapshotCache: string | null = null;
+let _snapshotCache: NotebookMetadataSnapshot | null = null;
 const _subscribers = new Set<() => void>();
 
 /**
@@ -27,7 +27,11 @@ const _subscribers = new Set<() => void>();
  * - set_metadata (local writes)
  */
 export function notifyMetadataChanged(): void {
-  _snapshotCache = _handle?.get_metadata_snapshot_json() ?? null;
+  const raw = _handle?.get_metadata_snapshot();
+  _snapshotCache =
+    raw && typeof raw === "object"
+      ? (raw as NotebookMetadataSnapshot)
+      : null;
   for (const cb of _subscribers) cb();
 }
 
@@ -49,16 +53,20 @@ function subscribe(callback: () => void): () => void {
 }
 
 /**
- * Get the current metadata snapshot as a JSON string.
+ * Get the current metadata snapshot as a native JS object.
  * Used as the getSnapshot function for useSyncExternalStore.
  * Returns the cached value — only updated when notifyMetadataChanged() fires.
  */
-function getSnapshotJson(): string | null {
+function getSnapshot(): NotebookMetadataSnapshot | null {
   // _snapshotCache is always set by notifyMetadataChanged() before
   // any subscriber fires. This lazy init handles the first read
   // before any notification has occurred.
   if (_snapshotCache === null) {
-    _snapshotCache = _handle?.get_metadata_snapshot_json() ?? null;
+    const raw = _handle?.get_metadata_snapshot();
+    _snapshotCache =
+      raw && typeof raw === "object"
+        ? (raw as NotebookMetadataSnapshot)
+        : null;
   }
   return _snapshotCache;
 }
@@ -72,15 +80,7 @@ function getSnapshotJson(): string | null {
  * Re-renders when the Automerge doc changes (bootstrap, sync, writes).
  */
 export function useNotebookMetadata(): NotebookMetadataSnapshot | null {
-  const json = useSyncExternalStore(subscribe, getSnapshotJson);
-  return useMemo(() => {
-    if (!json) return null;
-    try {
-      return JSON.parse(json) as NotebookMetadataSnapshot;
-    } catch {
-      return null;
-    }
-  }, [json]);
+  return useSyncExternalStore(subscribe, getSnapshot);
 }
 
 /**
@@ -93,7 +93,7 @@ export function useNotebookMetadata(): NotebookMetadataSnapshot | null {
  */
 export function useDetectRuntime(): "python" | "deno" | null {
   // Subscribe to metadata changes so we re-render when the doc updates.
-  useSyncExternalStore(subscribe, getSnapshotJson);
+  useSyncExternalStore(subscribe, getSnapshot);
   if (!_handle) return null;
   return (_handle.detect_runtime() as "python" | "deno") ?? null;
 }
@@ -365,10 +365,11 @@ export async function setDenoFlexibleNpmImports(
   enabled: boolean,
 ): Promise<boolean> {
   if (!_handle) return false;
-  const json = _handle.get_metadata_snapshot_json();
-  if (!json) return false;
+  const snapshot = _handle.get_metadata_snapshot() as
+    | NotebookMetadataSnapshot
+    | undefined;
+  if (!snapshot) return false;
   try {
-    const snapshot = JSON.parse(json) as NotebookMetadataSnapshot;
     if (!snapshot.runt.deno) {
       snapshot.runt.deno = { permissions: [], flexible_npm_imports: enabled };
     } else {


### PR DESCRIPTION
Switch the metadata read path from JSON strings to native JS objects, aligning it with the write path that already uses `set_metadata_snapshot_value()`.

## What changed

`apps/notebook/src/lib/notebook-metadata.ts`:

- **Cache**: `string | null` → `NotebookMetadataSnapshot | null`
- **`notifyMetadataChanged()`**: calls `get_metadata_snapshot()` (native JS object via `serde-wasm-bindgen`) instead of `get_metadata_snapshot_json()`
- **`getSnapshotJson()` → `getSnapshot()`**: returns the native object directly
- **`useNotebookMetadata()`**: returns `useSyncExternalStore` result directly — no `JSON.parse`/`useMemo` wrapper
- **`useDetectRuntime()`**: subscribes via `getSnapshot` instead of `getSnapshotJson`
- **`setDenoFlexibleNpmImports()`**: reads snapshot via `get_metadata_snapshot()` instead of JSON round-trip

## Why

PR #792 added `get_metadata_snapshot()` which returns JS objects directly from WASM via `serde-wasm-bindgen`. The old read path serialized to JSON in Rust, passed a string to JS, then parsed it back — an unnecessary round-trip now that the native method exists.

## `useSyncExternalStore` note

With the JSON string path, referential stability was free (`===` on strings). With objects, every `notifyMetadataChanged()` call creates a new object reference, causing a re-render. This is fine — metadata changes are infrequent (user-initiated dep adds, kernelspec changes) and the downstream renders are cheap.

## No other files affected

Grepped for `get_metadata_snapshot_json`, `getSnapshotJson`, and `JSON.parse.*metadata` across `apps/notebook/src/` — all references were in `notebook-metadata.ts` only. The hooks (`useAutomergeNotebook.ts`, `useDaemonKernel.ts`) don't touch the JSON read path.

_PR submitted by @rgbkrk's agent Quill, via Zed_