### PR TITLE
fix(daemon): sync doc to peer before forwarding ExecutionDone

### DIFF
--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -1375,7 +1375,7 @@ where
                         // the outputs, causing clients to read empty outputs.
                         if matches!(&broadcast, NotebookBroadcast::ExecutionDone { .. }) {
                             send_doc_sync(
-                                &room,
+                                room,
                                 &mut peer_state,
                                 writer,
                             )
@@ -1398,7 +1398,7 @@ where
                         // The Automerge doc contains the persisted state, so send a
                         // sync message to catch the peer up on any missed output data.
                         send_doc_sync(
-                            &room,
+                            room,
                             &mut peer_state,
                             writer,
                         )

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -1373,20 +1373,13 @@ where
                         // ExecutionDone event. Without this, there's a race where
                         // the broadcast arrives before the sync frames carrying
                         // the outputs, causing clients to read empty outputs.
-                        if matches!(broadcast, NotebookBroadcast::ExecutionDone { .. }) {
-                            let encoded = {
-                                let mut doc = room.doc.write().await;
-                                doc.generate_sync_message(&mut peer_state)
-                                    .map(|msg| msg.encode())
-                            };
-                            if let Some(encoded) = encoded {
-                                connection::send_typed_frame(
-                                    writer,
-                                    NotebookFrameType::AutomergeSync,
-                                    &encoded,
-                                )
-                                .await?;
-                            }
+                        if matches!(&broadcast, NotebookBroadcast::ExecutionDone { .. }) {
+                            send_doc_sync(
+                                &room,
+                                &mut peer_state,
+                                writer,
+                            )
+                            .await?;
                         }
 
                         connection::send_typed_json_frame(
@@ -1404,20 +1397,12 @@ where
                         // The peer missed some broadcasts (outputs, status changes).
                         // The Automerge doc contains the persisted state, so send a
                         // sync message to catch the peer up on any missed output data.
-                        // Encode inside the lock, send outside it.
-                        let encoded = {
-                            let mut doc = room.doc.write().await;
-                            doc.generate_sync_message(&mut peer_state)
-                                .map(|msg| msg.encode())
-                        };
-                        if let Some(encoded) = encoded {
-                            connection::send_typed_frame(
-                                writer,
-                                NotebookFrameType::AutomergeSync,
-                                &encoded,
-                            )
-                            .await?;
-                        }
+                        send_doc_sync(
+                            &room,
+                            &mut peer_state,
+                            writer,
+                        )
+                        .await?;
                     }
                     Err(broadcast::error::RecvError::Closed) => {
                         // Broadcast channel closed — room is being evicted
@@ -1427,6 +1412,27 @@ where
             }
         }
     }
+}
+
+/// Send a doc sync message to a peer if there are pending changes.
+///
+/// Generates an Automerge sync message from the room's doc and sends it
+/// as a typed frame. Used before forwarding ExecutionDone (to ensure
+/// outputs are synced) and after broadcast lag recovery.
+async fn send_doc_sync<W: tokio::io::AsyncWrite + Unpin>(
+    room: &NotebookRoom,
+    peer_state: &mut automerge::sync::State,
+    writer: &mut W,
+) -> anyhow::Result<()> {
+    let encoded = {
+        let mut doc = room.doc.write().await;
+        doc.generate_sync_message(peer_state)
+            .map(|msg| msg.encode())
+    };
+    if let Some(encoded) = encoded {
+        connection::send_typed_frame(writer, NotebookFrameType::AutomergeSync, &encoded).await?;
+    }
+    Ok(())
 }
 
 /// Acquire a pooled environment from the appropriate pool based on env_source.

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -1367,6 +1367,28 @@ where
             result = kernel_broadcast_rx.recv() => {
                 match result {
                     Ok(broadcast) => {
+                        // For ExecutionDone, sync the Automerge doc to this peer
+                        // BEFORE forwarding the signal. This ensures the peer's
+                        // local doc has all cell outputs when it processes the
+                        // ExecutionDone event. Without this, there's a race where
+                        // the broadcast arrives before the sync frames carrying
+                        // the outputs, causing clients to read empty outputs.
+                        if matches!(broadcast, NotebookBroadcast::ExecutionDone { .. }) {
+                            let encoded = {
+                                let mut doc = room.doc.write().await;
+                                doc.generate_sync_message(&mut peer_state)
+                                    .map(|msg| msg.encode())
+                            };
+                            if let Some(encoded) = encoded {
+                                connection::send_typed_frame(
+                                    writer,
+                                    NotebookFrameType::AutomergeSync,
+                                    &encoded,
+                                )
+                                .await?;
+                            }
+                        }
+
                         connection::send_typed_json_frame(
                             writer,
                             NotebookFrameType::Broadcast,


### PR DESCRIPTION
Sync the Automerge doc to each peer BEFORE forwarding the `ExecutionDone` broadcast. This ensures the peer's local doc has all cell outputs when it processes the signal.

## The race condition

When a cell finishes executing:
1. Daemon writes outputs to its Automerge doc as iopub messages arrive
2. Daemon broadcasts `ExecutionDone` when `status: idle` arrives
3. Client receives `ExecutionDone`, reads cell from its local doc
4. **But the Automerge sync frames carrying the outputs may not have arrived yet**

The client reads empty outputs because the broadcast (lightweight JSON frame) travels faster than the sync frames (heavier Automerge binary data).

## The fix

In the per-connection handler (`run_sync_loop_v2`), when a `NotebookBroadcast::ExecutionDone` is about to be forwarded to a peer, first generate and send an Automerge sync message. This ensures the peer's doc is caught up before it sees the signal.

22 lines added, zero removed. The fix is in the broadcast forwarding path so it covers all `ExecutionDone` sources: normal completion, error replies (shell reader belt-and-suspenders), and auto-launched kernels.

## What this fixes

Root cause of intermittent CI failures across many test runs:
- `test_interleaved_stdout_stderr_separate`: `assert 'out1' in ''`
- `test_error_traceback_captured`: `status=ok, outputs=0`
- `test_execution_error_captured`: hung waiting for outputs
- Various other `outputs=0` flakes

These were first investigated in PR #746 and have been the most persistent CI instability issue.

_PR submitted by @rgbkrk's agent Quill, via Zed_