### PR TITLE
refactor(runtimed-py): deduplicate streaming methods in Session/AsyncSession

### DIFF
--- a/crates/runtimed-py/src/async_session.rs
+++ b/crates/runtimed-py/src/async_session.rs
@@ -10,12 +10,9 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
-use notebook_protocol::protocol::{NotebookBroadcast, NotebookRequest, NotebookResponse};
-
 use crate::daemon_paths::get_socket_path;
 use crate::error::to_py_err;
 use crate::event_stream::ExecutionEventStream;
-use crate::output::SyncEnvironmentResult;
 use crate::session_core::{self, SessionState};
 use crate::subscription::EventSubscription;
 
@@ -768,52 +765,11 @@ impl AsyncSession {
         let cell_id = cell_id.to_string();
 
         future_into_py(py, async move {
-            // Auto-start kernel if needed
-            {
-                let st = state.lock().await;
-                if !st.kernel_started {
-                    drop(st);
-                    session_core::connect(&state, &notebook_id).await?;
-                    session_core::start_kernel(&state, "python", "auto", None).await?;
-                }
-            }
-
-            let st = state.lock().await;
-
-            let handle = st
-                .handle
-                .as_ref()
-                .ok_or_else(|| to_py_err("Not connected"))?;
-
-            handle.confirm_sync().await.map_err(to_py_err)?;
-
-            let response = handle
-                .send_request(NotebookRequest::ExecuteCell {
-                    cell_id: cell_id.clone(),
-                })
-                .await
-                .map_err(to_py_err)?;
-
-            match response {
-                NotebookResponse::CellQueued { .. } => {}
-                NotebookResponse::Error { error } => return Err(to_py_err(error)),
-                other => return Err(to_py_err(format!("Unexpected response: {:?}", other))),
-            }
-
-            // Resubscribe for this stream — needs direct state access
-            let stream_broadcast_rx = st
-                .broadcast_rx
-                .as_ref()
-                .ok_or_else(|| to_py_err("No broadcast receiver"))?
-                .resubscribe();
-
-            let blob_base_url = st.blob_base_url.clone();
-            let blob_store_path = st.blob_store_path.clone();
-
-            drop(st);
+            let (broadcast_rx, blob_base_url, blob_store_path) =
+                session_core::prepare_stream_execute(&state, &notebook_id, &cell_id).await?;
 
             Ok(ExecutionEventStream::new(
-                stream_broadcast_rx,
+                broadcast_rx,
                 cell_id,
                 timeout_secs,
                 blob_base_url,
@@ -836,23 +792,13 @@ impl AsyncSession {
         cell_ids: Option<Vec<String>>,
         event_types: Option<Vec<String>>,
     ) -> PyResult<EventSubscription> {
-        // Needs direct state access for resubscribe — use a temporary block_on
-        // since this returns a sync object (the subscription) not a coroutine.
+        // Use a temporary runtime since this returns a sync object (the subscription)
+        // not a coroutine.
         let rt = tokio::runtime::Runtime::new()
             .map_err(|e| to_py_err(format!("Failed to create runtime: {}", e)))?;
 
-        let state = rt.block_on(self.state.lock());
-
-        let broadcast_rx = state
-            .broadcast_rx
-            .as_ref()
-            .ok_or_else(|| to_py_err("Not connected - call connect() or start_kernel() first"))?
-            .resubscribe();
-
-        let blob_base_url = state.blob_base_url.clone();
-        let blob_store_path = state.blob_store_path.clone();
-
-        drop(state);
+        let (broadcast_rx, blob_base_url, blob_store_path) =
+            rt.block_on(session_core::prepare_subscribe(&self.state))?;
 
         Ok(EventSubscription::new(
             broadcast_rx,
@@ -871,91 +817,10 @@ impl AsyncSession {
     ///
     /// Returns a coroutine that resolves to SyncEnvironmentResult.
     fn sync_environment<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
-        // sync_environment is complex — waits for follow-up broadcasts.
-        // Kept inline rather than in session_core due to broadcast polling.
         let state = Arc::clone(&self.state);
 
         future_into_py(py, async move {
-            let st = state.lock().await;
-
-            let handle = st
-                .handle
-                .as_ref()
-                .ok_or_else(|| to_py_err("Not connected"))?;
-
-            let response = handle
-                .send_request(NotebookRequest::SyncEnvironment {})
-                .await
-                .map_err(to_py_err)?;
-
-            drop(st);
-
-            match response {
-                NotebookResponse::SyncEnvironmentStarted { packages } => {
-                    // Wait for completion via broadcast
-                    let mut st = state.lock().await;
-                    let broadcast_rx = st.broadcast_rx.as_mut();
-                    if let Some(rx) = broadcast_rx {
-                        let deadline =
-                            std::time::Instant::now() + std::time::Duration::from_secs(300);
-                        while std::time::Instant::now() < deadline {
-                            match tokio::time::timeout(std::time::Duration::from_secs(1), rx.recv())
-                                .await
-                            {
-                                Ok(Some(NotebookBroadcast::EnvSyncState {
-                                    in_sync: true, ..
-                                })) => {
-                                    return Ok(SyncEnvironmentResult {
-                                        success: true,
-                                        synced_packages: packages,
-                                        error: None,
-                                        needs_restart: false,
-                                    });
-                                }
-                                Ok(Some(_)) => continue,
-                                Ok(None) => break,
-                                Err(_) => continue,
-                            }
-                        }
-                    }
-                    Ok(SyncEnvironmentResult {
-                        success: true,
-                        synced_packages: packages,
-                        error: None,
-                        needs_restart: false,
-                    })
-                }
-                NotebookResponse::SyncEnvironmentComplete { synced_packages } => {
-                    Ok(SyncEnvironmentResult {
-                        success: true,
-                        synced_packages,
-                        error: None,
-                        needs_restart: false,
-                    })
-                }
-                NotebookResponse::SyncEnvironmentFailed {
-                    error,
-                    needs_restart,
-                } => Ok(SyncEnvironmentResult {
-                    success: false,
-                    synced_packages: vec![],
-                    error: Some(error),
-                    needs_restart,
-                }),
-                NotebookResponse::NoKernel {} => Ok(SyncEnvironmentResult {
-                    success: false,
-                    synced_packages: vec![],
-                    error: Some("No kernel running".to_string()),
-                    needs_restart: true,
-                }),
-                NotebookResponse::Error { error } => Ok(SyncEnvironmentResult {
-                    success: false,
-                    synced_packages: vec![],
-                    error: Some(error),
-                    needs_restart: true,
-                }),
-                other => Err(to_py_err(format!("Unexpected response: {:?}", other))),
-            }
+            session_core::sync_environment_impl(&state).await
         })
     }
 

--- a/crates/runtimed-py/src/session.rs
+++ b/crates/runtimed-py/src/session.rs
@@ -10,8 +10,6 @@ use std::sync::Arc;
 use tokio::runtime::Runtime;
 use tokio::sync::Mutex;
 
-use notebook_protocol::protocol::{NotebookBroadcast, NotebookRequest, NotebookResponse};
-
 use crate::daemon_paths::get_socket_path;
 use crate::error::to_py_err;
 use crate::event_stream::ExecutionEventIterator;
@@ -578,61 +576,18 @@ impl Session {
         timeout_secs: f64,
         signal_only: bool,
     ) -> PyResult<ExecutionEventIterator> {
-        let cell_id = cell_id.to_string();
+        let (broadcast_rx, blob_base_url, blob_store_path) = self.runtime.block_on(
+            session_core::prepare_stream_execute(&self.state, &self.notebook_id, cell_id),
+        )?;
 
-        // Auto-start kernel if not running
-        {
-            let state = self.runtime.block_on(self.state.lock());
-            if !state.kernel_started {
-                drop(state);
-                self.start_kernel("python", "auto", None)?;
-            }
-        }
-
-        self.runtime.block_on(async {
-            let state = self.state.lock().await;
-
-            let handle = state
-                .handle
-                .as_ref()
-                .ok_or_else(|| to_py_err("Not connected"))?;
-
-            handle.confirm_sync().await.map_err(to_py_err)?;
-
-            let response = handle
-                .send_request(NotebookRequest::ExecuteCell {
-                    cell_id: cell_id.clone(),
-                })
-                .await
-                .map_err(to_py_err)?;
-
-            match response {
-                NotebookResponse::CellQueued { .. } => {}
-                NotebookResponse::Error { error } => return Err(to_py_err(error)),
-                other => return Err(to_py_err(format!("Unexpected response: {:?}", other))),
-            }
-
-            // Resubscribe for this stream — needs direct state access
-            let stream_broadcast_rx = state
-                .broadcast_rx
-                .as_ref()
-                .ok_or_else(|| to_py_err("No broadcast receiver"))?
-                .resubscribe();
-
-            let blob_base_url = state.blob_base_url.clone();
-            let blob_store_path = state.blob_store_path.clone();
-
-            drop(state);
-
-            ExecutionEventIterator::new(
-                stream_broadcast_rx,
-                cell_id,
-                timeout_secs,
-                blob_base_url,
-                blob_store_path,
-                signal_only,
-            )
-        })
+        ExecutionEventIterator::new(
+            broadcast_rx,
+            cell_id.to_string(),
+            timeout_secs,
+            blob_base_url,
+            blob_store_path,
+            signal_only,
+        )
     }
 
     /// Subscribe to execution events for specific cells or event types.
@@ -648,19 +603,9 @@ impl Session {
         cell_ids: Option<Vec<String>>,
         event_types: Option<Vec<String>>,
     ) -> PyResult<EventIteratorSubscription> {
-        // Needs direct state access for resubscribe
-        let state = self.runtime.block_on(self.state.lock());
-
-        let broadcast_rx = state
-            .broadcast_rx
-            .as_ref()
-            .ok_or_else(|| to_py_err("Not connected - call connect() or start_kernel() first"))?
-            .resubscribe();
-
-        let blob_base_url = state.blob_base_url.clone();
-        let blob_store_path = state.blob_store_path.clone();
-
-        drop(state);
+        let (broadcast_rx, blob_base_url, blob_store_path) = self
+            .runtime
+            .block_on(session_core::prepare_subscribe(&self.state))?;
 
         EventIteratorSubscription::new(
             broadcast_rx,
@@ -680,90 +625,8 @@ impl Session {
     /// Returns:
     ///     SyncEnvironmentResult with success status and installed packages.
     fn sync_environment(&self) -> PyResult<SyncEnvironmentResult> {
-        // sync_environment is complex — waits for follow-up broadcasts.
-        // Kept inline rather than in session_core due to broadcast polling.
-        self.runtime.block_on(async {
-            let state = self.state.lock().await;
-
-            let handle = state
-                .handle
-                .as_ref()
-                .ok_or_else(|| to_py_err("Not connected"))?;
-
-            let response = handle
-                .send_request(NotebookRequest::SyncEnvironment {})
-                .await
-                .map_err(to_py_err)?;
-
-            drop(state);
-
-            match response {
-                NotebookResponse::SyncEnvironmentStarted { packages } => {
-                    // Wait for completion via broadcast
-                    let mut state = self.state.lock().await;
-                    let broadcast_rx = state.broadcast_rx.as_mut();
-                    if let Some(rx) = broadcast_rx {
-                        let deadline =
-                            std::time::Instant::now() + std::time::Duration::from_secs(300);
-                        while std::time::Instant::now() < deadline {
-                            match tokio::time::timeout(std::time::Duration::from_secs(1), rx.recv())
-                                .await
-                            {
-                                Ok(Some(NotebookBroadcast::EnvSyncState {
-                                    in_sync: true, ..
-                                })) => {
-                                    return Ok(SyncEnvironmentResult {
-                                        success: true,
-                                        synced_packages: packages,
-                                        error: None,
-                                        needs_restart: false,
-                                    });
-                                }
-                                Ok(Some(_)) => continue,
-                                Ok(None) => break,
-                                Err(_) => continue,
-                            }
-                        }
-                    }
-                    Ok(SyncEnvironmentResult {
-                        success: true,
-                        synced_packages: packages,
-                        error: None,
-                        needs_restart: false,
-                    })
-                }
-                NotebookResponse::SyncEnvironmentComplete { synced_packages } => {
-                    Ok(SyncEnvironmentResult {
-                        success: true,
-                        synced_packages,
-                        error: None,
-                        needs_restart: false,
-                    })
-                }
-                NotebookResponse::SyncEnvironmentFailed {
-                    error,
-                    needs_restart,
-                } => Ok(SyncEnvironmentResult {
-                    success: false,
-                    synced_packages: vec![],
-                    error: Some(error),
-                    needs_restart,
-                }),
-                NotebookResponse::NoKernel {} => Ok(SyncEnvironmentResult {
-                    success: false,
-                    synced_packages: vec![],
-                    error: Some("No kernel running".to_string()),
-                    needs_restart: true,
-                }),
-                NotebookResponse::Error { error } => Ok(SyncEnvironmentResult {
-                    success: false,
-                    synced_packages: vec![],
-                    error: Some(error),
-                    needs_restart: true,
-                }),
-                other => Err(to_py_err(format!("Unexpected response: {:?}", other))),
-            }
-        })
+        self.runtime
+            .block_on(session_core::sync_environment_impl(&self.state))
     }
 
     // =========================================================================

--- a/crates/runtimed-py/src/session_core.rs
+++ b/crates/runtimed-py/src/session_core.rs
@@ -1020,33 +1020,130 @@ pub(crate) async fn set_notebook_metadata(
     Ok(())
 }
 
-/// Sync environment with current metadata.
+// =========================================================================
+// Streaming helpers
+// =========================================================================
+
+/// Prepare for streaming execution: auto-start kernel, confirm sync,
+/// queue the cell, and return a resubscribed broadcast receiver.
 ///
-/// NOTE: This simplified version returns immediately on `SyncEnvironmentStarted`
-/// without waiting for completion. The real implementations that poll the broadcast
-/// stream for completion live inline in `session.rs` and `async_session.rs`.
-#[allow(dead_code)]
-pub(crate) async fn sync_environment(
+/// The caller wraps the receiver in the appropriate iterator type
+/// (ExecutionEventIterator for sync, ExecutionEventStream for async).
+pub(crate) async fn prepare_stream_execute(
     state: &Arc<Mutex<SessionState>>,
-) -> PyResult<SyncEnvironmentResult> {
+    notebook_id: &str,
+    cell_id: &str,
+) -> PyResult<(BroadcastReceiver, Option<String>, Option<PathBuf>)> {
+    // Auto-start kernel if needed
+    {
+        let st = state.lock().await;
+        if !st.kernel_started {
+            drop(st);
+            ensure_kernel_started(state, notebook_id).await?;
+        }
+    }
+
     let st = state.lock().await;
     let handle = st
         .handle
         .as_ref()
         .ok_or_else(|| to_py_err("Not connected"))?;
 
+    handle.confirm_sync().await.map_err(to_py_err)?;
+
     let response = handle
-        .send_request(NotebookRequest::SyncEnvironment {})
+        .send_request(NotebookRequest::ExecuteCell {
+            cell_id: cell_id.to_string(),
+        })
         .await
         .map_err(to_py_err)?;
 
     match response {
-        NotebookResponse::SyncEnvironmentStarted { packages } => Ok(SyncEnvironmentResult {
-            success: true,
-            synced_packages: packages,
-            error: None,
-            needs_restart: false,
-        }),
+        NotebookResponse::CellQueued { .. } => {}
+        NotebookResponse::Error { error } => return Err(to_py_err(error)),
+        other => return Err(to_py_err(format!("Unexpected response: {:?}", other))),
+    }
+
+    // Resubscribe for this stream
+    let stream_broadcast_rx = st
+        .broadcast_rx
+        .as_ref()
+        .ok_or_else(|| to_py_err("No broadcast receiver"))?
+        .resubscribe();
+
+    let blob_base_url = st.blob_base_url.clone();
+    let blob_store_path = st.blob_store_path.clone();
+
+    Ok((stream_broadcast_rx, blob_base_url, blob_store_path))
+}
+
+/// Prepare a broadcast subscription with optional filters.
+///
+/// Returns a resubscribed broadcast receiver and blob config.
+pub(crate) async fn prepare_subscribe(
+    state: &Arc<Mutex<SessionState>>,
+) -> PyResult<(BroadcastReceiver, Option<String>, Option<PathBuf>)> {
+    let st = state.lock().await;
+
+    let broadcast_rx = st
+        .broadcast_rx
+        .as_ref()
+        .ok_or_else(|| to_py_err("Not connected - call connect() or start_kernel() first"))?
+        .resubscribe();
+
+    let blob_base_url = st.blob_base_url.clone();
+    let blob_store_path = st.blob_store_path.clone();
+
+    Ok((broadcast_rx, blob_base_url, blob_store_path))
+}
+
+/// Sync environment with current metadata and poll for completion.
+pub(crate) async fn sync_environment_impl(
+    state: &Arc<Mutex<SessionState>>,
+) -> PyResult<SyncEnvironmentResult> {
+    let response = {
+        let st = state.lock().await;
+        let handle = st
+            .handle
+            .as_ref()
+            .ok_or_else(|| to_py_err("Not connected"))?;
+
+        handle
+            .send_request(NotebookRequest::SyncEnvironment {})
+            .await
+            .map_err(to_py_err)?
+    };
+
+    match response {
+        NotebookResponse::SyncEnvironmentStarted { packages } => {
+            // Wait for completion via broadcast
+            let mut st = state.lock().await;
+            let broadcast_rx = st.broadcast_rx.as_mut();
+            if let Some(rx) = broadcast_rx {
+                let deadline = std::time::Instant::now() + std::time::Duration::from_secs(300);
+                while std::time::Instant::now() < deadline {
+                    match tokio::time::timeout(std::time::Duration::from_secs(1), rx.recv()).await {
+                        Ok(Some(NotebookBroadcast::EnvSyncState { in_sync: true, .. })) => {
+                            return Ok(SyncEnvironmentResult {
+                                success: true,
+                                synced_packages: packages,
+                                error: None,
+                                needs_restart: false,
+                            });
+                        }
+                        Ok(Some(_)) => continue,
+                        Ok(None) => break,
+                        Err(_) => continue,
+                    }
+                }
+            }
+            Ok(SyncEnvironmentResult {
+                success: true,
+                synced_packages: packages,
+                error: None,
+                needs_restart: false,
+            })
+        }
         NotebookResponse::SyncEnvironmentComplete { synced_packages } => {
             Ok(SyncEnvironmentResult {
                 success: true,


### PR DESCRIPTION
## Summary

Extract common logic for `stream_execute`, `subscribe`, and `sync_environment` into `session_core` helpers to eliminate code duplication between the sync `Session` and async `AsyncSession` implementations.

- **prepare_stream_execute**: handles kernel auto-start, sync confirmation, execute requests, and returns a resubscribed broadcast receiver
- **prepare_subscribe**: returns a resubscribed broadcast receiver for subscriptions
- **sync_environment_impl**: full implementation with broadcast polling for completion

Callers wrap the receiver in their respective iterator types (ExecutionEventIterator for sync, ExecutionEventStream for async).

This reduces ~175 lines of duplication while maintaining identical behavior.

## Test Plan

- Unit tests pass: `cd python/runtimed && uv run pytest tests/test_session_unit.py -v` (40 tests)
- Rust tests pass: `cargo test --verbose`
- Linting passes: `cargo clippy --all-targets -- -D warnings`

---

_PR submitted by @rgbkrk's agent, Quill_