### PR TITLE
feat(xtask): add unified lint command for rust, js, and python

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,17 +4,17 @@ This document provides guidance for AI agents working in this repository.
 
 ## Code Formatting (Required Before Committing)
 
-Run these commands before every commit. CI will reject PRs that fail formatting checks.
+Run this command before every commit. CI will reject PRs that fail formatting checks.
 
 ```bash
-# Format Rust code
-cargo fmt
-
-# Format and lint TypeScript/JavaScript (auto-fixes issues)
-npx @biomejs/biome check --fix apps/notebook/src/ e2e/
+cargo xtask lint --fix
 ```
 
-Do not skip these. There are no pre-commit hooks — you must run them manually.
+This formats Rust, lints/formats TypeScript/JavaScript with Biome, and lints/formats Python with ruff.
+
+For CI-style check-only mode: `cargo xtask lint`
+
+Do not skip this. There are no pre-commit hooks — you must run it manually.
 
 ## Commit and PR Title Standard (Required)
 

--- a/contributing/development.md
+++ b/contributing/development.md
@@ -13,6 +13,8 @@
 | Run with notebook | `cargo xtask run path/to/notebook.ipynb` |
 | Build release .app | `cargo xtask build-app` |
 | Build release DMG | `cargo xtask build-dmg` |
+| Lint (check mode) | `cargo xtask lint` |
+| Lint (auto-fix) | `cargo xtask lint --fix` |
 
 ## Choosing a Workflow
 
@@ -210,15 +212,13 @@ See [contributing/runtimed.md](./runtimed.md) for full daemon development docs.
 
 ## Before You Commit
 
-CI rejects PRs that fail formatting. Run these before every commit:
+CI rejects PRs that fail formatting. Run this before every commit:
 
 ```bash
-# Format Rust
-cargo fmt
-
-# Format and lint TypeScript/JavaScript
-npx @biomejs/biome check --fix apps/notebook/src/ e2e/
+cargo xtask lint --fix
 ```
+
+This formats Rust, lints/formats TypeScript/JavaScript with Biome, and lints/formats Python with ruff.
 
 Use [conventional commits](https://www.conventionalcommits.org/) for commit messages and PR titles:
 

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -42,6 +42,10 @@ fn main() {
             let release = args.iter().any(|a| a == "--release");
             cmd_dev_daemon(release);
         }
+        "lint" => {
+            let fix = args.iter().any(|a| a == "--fix");
+            cmd_lint(fix);
+        }
         "--help" | "-h" | "help" => print_help(),
         cmd => {
             eprintln!("Unknown command: {cmd}");
@@ -72,6 +76,10 @@ Release:
 Daemon:
   install-daemon             Build and install runtimed into the running service
   dev-daemon [--release]     Build and run runtimed in per-worktree dev mode
+
+Linting:
+  lint                       Check formatting and linting (Rust, JS/TS, Python)
+  lint --fix                 Auto-fix formatting and linting issues
 
 Other:
   icons [source.png]         Generate icon variants
@@ -518,6 +526,137 @@ fn cmd_dev_daemon(release: bool) {
     if !status.success() {
         exit(status.code().unwrap_or(1));
     }
+}
+
+/// Run linting and formatting checks across all languages.
+///
+/// In check mode (default): exits non-zero if any issues are found.
+/// In fix mode (--fix): auto-fixes issues where possible.
+fn cmd_lint(fix: bool) {
+    let mode = if fix { "fix" } else { "check" };
+    println!("Running lint ({mode} mode)...");
+    println!();
+
+    // Track if any linter failed
+    let mut failed = false;
+
+    // Rust formatting
+    println!("=== Rust formatting ===");
+    if fix {
+        if !run_cmd_ok("cargo", &["fmt"]) {
+            failed = true;
+        }
+    } else if !run_cmd_ok("cargo", &["fmt", "--check"]) {
+        failed = true;
+    }
+    println!();
+
+    // Rust clippy (check-only, no auto-fix available)
+    if !fix {
+        println!("=== Rust clippy ===");
+        if !run_cmd_ok(
+            "cargo",
+            &[
+                "clippy",
+                "--workspace",
+                "--all-targets",
+                "--",
+                "-D",
+                "warnings",
+            ],
+        ) {
+            failed = true;
+        }
+        println!();
+    }
+
+    // JavaScript/TypeScript with Biome
+    println!("=== JavaScript/TypeScript (Biome) ===");
+    let biome_ok = if fix {
+        run_cmd_ok(
+            "npx",
+            &[
+                "@biomejs/biome",
+                "check",
+                "--fix",
+                "apps/notebook/src/",
+                "e2e/",
+            ],
+        )
+    } else {
+        run_cmd_ok(
+            "npx",
+            &["@biomejs/biome", "check", "apps/notebook/src/", "e2e/"],
+        )
+    };
+    if !biome_ok {
+        failed = true;
+    }
+    println!();
+
+    // Python with ruff (if uv is available)
+    let python_dir = Path::new("python");
+    if python_dir.exists() {
+        if Command::new("uv").arg("--version").output().is_ok() {
+            println!("=== Python (ruff) ===");
+
+            // ruff check
+            let check_args = if fix {
+                vec!["run", "ruff", "check", "--fix", "."]
+            } else {
+                vec!["run", "ruff", "check", "."]
+            };
+            let check_status = Command::new("uv")
+                .args(&check_args)
+                .current_dir(python_dir)
+                .status();
+            if !check_status.map(|s| s.success()).unwrap_or(false) {
+                failed = true;
+            }
+
+            // ruff format
+            let format_args = if fix {
+                vec!["run", "ruff", "format", "."]
+            } else {
+                vec!["run", "ruff", "format", "--check", "."]
+            };
+            let format_status = Command::new("uv")
+                .args(&format_args)
+                .current_dir(python_dir)
+                .status();
+            if !format_status.map(|s| s.success()).unwrap_or(false) {
+                failed = true;
+            }
+            println!();
+        } else {
+            println!("=== Python (ruff) ===");
+            println!("Skipping: uv not found in PATH");
+            println!();
+        }
+    }
+
+    if failed {
+        if fix {
+            eprintln!("Some issues could not be auto-fixed. See output above.");
+        } else {
+            eprintln!("Lint check failed. Run `cargo xtask lint --fix` to auto-fix.");
+        }
+        exit(1);
+    }
+
+    println!("All checks passed!");
+}
+
+/// Run a command and return true if it succeeded.
+fn run_cmd_ok(cmd: &str, args: &[&str]) -> bool {
+    Command::new(cmd)
+        .args(args)
+        .status()
+        .map(|s| s.success())
+        .unwrap_or_else(|e| {
+            eprintln!("Failed to run {cmd}: {e}");
+            false
+        })
 }
 
 /// Build external binaries (runtimed daemon and runt CLI) for Tauri bundling.

--- a/python/nteract/tests/test_editing.py
+++ b/python/nteract/tests/test_editing.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pytest
+
 from nteract._editing import (
     MAX_REGEX_SOURCE_LEN,
     EditSpan,

--- a/python/nteract/tests/test_mcp_integration.py
+++ b/python/nteract/tests/test_mcp_integration.py
@@ -25,6 +25,7 @@ from typing import Any
 import anyio
 import pytest
 from mcp import ClientSession
+
 from nteract._mcp_server import mcp
 
 

--- a/python/runtimed/demos/presence_cursor.py
+++ b/python/runtimed/demos/presence_cursor.py
@@ -50,7 +50,7 @@ def demo_cursor_animation(session, cell):
     """Demo 2: Animate cursor across a cell."""
     source = cell.source
     lines = source.split("\n")
-    print(f"\n✏️  Demo 2: Cursor Animation")
+    print("\n✏️  Demo 2: Cursor Animation")
     print(f"   Sweeping cursor across {len(lines)} lines...")
 
     # Sweep across each line
@@ -70,8 +70,8 @@ def demo_selection(session, cell):
     """Demo 3: Selection highlighting - grow selection across the cell."""
     source = cell.source
     lines = source.split("\n")
-    print(f"\n🎨 Demo 3: Selection Highlighting")
-    print(f"   Growing selection across the code...")
+    print("\n🎨 Demo 3: Selection Highlighting")
+    print("   Growing selection across the code...")
 
     # Start at beginning
     anchor_line, anchor_col = 0, 0


### PR DESCRIPTION
## Summary

Add `cargo xtask lint` and `cargo xtask lint --fix` commands to consolidate all language-specific linting and formatting into a single interface:
- **Rust**: `cargo fmt` + `cargo clippy`
- **TypeScript/JavaScript**: Biome
- **Python**: ruff

Check mode exits non-zero if issues found. Fix mode auto-fixes where possible. Gracefully skips Python linting if uv is unavailable.

## Changes

- `crates/xtask/src/main.rs` — New `cmd_lint()` function supporting both check and fix modes
- `AGENTS.md` — Updated code formatting instructions
- `contributing/development.md` — Updated Quick Reference table and "Before You Commit" section

## Test Plan

- [ ] Verify `cargo xtask lint` detects formatting issues
- [ ] Verify `cargo xtask lint --fix` auto-fixes issues
- [ ] Verify command works with projects missing Python/uv
- [ ] Check that help text shows new commands

_PR submitted by @rgbkrk's agent, Quill_