### PR TITLE
fix(notebook): scroll new cells into view

### DIFF
--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -302,7 +302,6 @@ export function CodeCell({
       if (!view) return;
 
       view.focus();
-      view.dom.scrollIntoView({ behavior: "smooth", block: "nearest" });
     });
 
     return () => cancelAnimationFrame(frameId);

--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -294,6 +294,20 @@ export function CodeCell({
     [searchQuery, searchActiveOffset, remoteCursorsExt, presenceSenderExt],
   );
 
+  useEffect(() => {
+    if (!isFocused || isSourceHidden) return;
+
+    const frameId = requestAnimationFrame(() => {
+      const view = editorRef.current?.getEditor();
+      if (!view) return;
+
+      view.focus();
+      view.dom.scrollIntoView({ behavior: "smooth", block: "nearest" });
+    });
+
+    return () => cancelAnimationFrame(frameId);
+  }, [isFocused, isSourceHidden]);
+
   const handleExecute = useCallback(() => {
     handleExecuteWithClear();
   }, [handleExecuteWithClear]);

--- a/apps/notebook/src/hooks/useEditorRegistry.tsx
+++ b/apps/notebook/src/hooks/useEditorRegistry.tsx
@@ -1,5 +1,6 @@
 import { EditorView } from "@codemirror/view";
 import { createContext, type ReactNode, useCallback, useContext } from "react";
+import { scrollElementIntoViewIfNeeded } from "@/components/cell/scroll-into-view-if-needed";
 import { logger } from "../lib/logger";
 
 interface EditorRegistryContextType {
@@ -51,8 +52,7 @@ export function EditorRegistryProvider({ children }: { children: ReactNode }) {
       });
       view.focus();
 
-      // Scroll cell into view
-      cellElement.scrollIntoView({ behavior: "smooth", block: "nearest" });
+      scrollElementIntoViewIfNeeded(cellElement as HTMLElement);
     },
     [],
   );

--- a/src/components/cell/CellContainer.tsx
+++ b/src/components/cell/CellContainer.tsx
@@ -1,6 +1,13 @@
-import { forwardRef, type ReactNode } from "react";
+import {
+  forwardRef,
+  type ReactNode,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+} from "react";
 import { cn } from "@/lib/utils";
 import { type GutterColorConfig, getGutterColors } from "./gutter-colors";
+import { scrollElementIntoViewIfNeeded } from "./scroll-into-view-if-needed";
 
 interface CellContainerProps {
   id: string;
@@ -57,6 +64,34 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
     },
     ref,
   ) => {
+    const cellRef = useRef<HTMLDivElement | null>(null);
+    const previousFocusedRef = useRef<boolean | undefined>(undefined);
+
+    useImperativeHandle(ref, () => cellRef.current as HTMLDivElement, []);
+
+    useEffect(() => {
+      const previouslyFocused = previousFocusedRef.current;
+      previousFocusedRef.current = isFocused;
+
+      if (!isFocused || previouslyFocused === isFocused) {
+        return;
+      }
+
+      const cellElement = cellRef.current;
+      const hovered =
+        cellElement?.parentElement?.querySelector(":hover") === cellElement;
+
+      if (!cellElement || hovered) {
+        return;
+      }
+
+      const frameId = requestAnimationFrame(() => {
+        scrollElementIntoViewIfNeeded(cellElement);
+      });
+
+      return () => cancelAnimationFrame(frameId);
+    }, [isFocused]);
+
     const colors = getGutterColors(cellType, customGutterColors);
     const ribbonColor = isFocused
       ? colors.ribbon.focused
@@ -72,7 +107,7 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
 
     return (
       <div
-        ref={ref}
+        ref={cellRef}
         data-slot="cell-container"
         data-cell-id={id}
         data-cell-type={cellType}

--- a/src/components/cell/__tests__/scroll-into-view-if-needed.test.ts
+++ b/src/components/cell/__tests__/scroll-into-view-if-needed.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { scrollElementIntoViewIfNeeded } from "../scroll-into-view-if-needed";
+
+function mockRect(rect: Partial<DOMRect>): DOMRect {
+  return {
+    x: 0,
+    y: 0,
+    width: 0,
+    height: 0,
+    top: 0,
+    right: 0,
+    bottom: 0,
+    left: 0,
+    toJSON: () => ({}),
+    ...rect,
+  } as DOMRect;
+}
+
+describe("scrollElementIntoViewIfNeeded", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+    vi.restoreAllMocks();
+  });
+
+  it("scrolls down when the element extends below the container", () => {
+    const container = document.createElement("div");
+    const element = document.createElement("div");
+    container.appendChild(element);
+    document.body.appendChild(container);
+
+    vi.spyOn(window, "getComputedStyle").mockReturnValue({
+      overflow: "auto",
+      overflowY: "auto",
+    } as CSSStyleDeclaration);
+
+    Object.defineProperty(container, "scrollTop", {
+      value: 100,
+      writable: true,
+    });
+    container.getBoundingClientRect = () =>
+      mockRect({ top: 100, bottom: 400, height: 300 });
+    element.getBoundingClientRect = () =>
+      mockRect({ top: 350, bottom: 460, height: 110 });
+
+    const scrollTo = vi.fn();
+    container.scrollTo = scrollTo;
+
+    scrollElementIntoViewIfNeeded(element);
+
+    expect(scrollTo).toHaveBeenCalledWith({
+      behavior: "smooth",
+      top: 160,
+    });
+  });
+
+  it("scrolls up when the element sits above the container viewport", () => {
+    const container = document.createElement("div");
+    const element = document.createElement("div");
+    container.appendChild(element);
+    document.body.appendChild(container);
+
+    vi.spyOn(window, "getComputedStyle").mockReturnValue({
+      overflow: "auto",
+      overflowY: "auto",
+    } as CSSStyleDeclaration);
+
+    Object.defineProperty(container, "scrollTop", {
+      value: 250,
+      writable: true,
+    });
+    container.getBoundingClientRect = () =>
+      mockRect({ top: 100, bottom: 400, height: 300 });
+    element.getBoundingClientRect = () =>
+      mockRect({ top: 60, bottom: 160, height: 100 });
+
+    const scrollTo = vi.fn();
+    container.scrollTo = scrollTo;
+
+    scrollElementIntoViewIfNeeded(element);
+
+    expect(scrollTo).toHaveBeenCalledWith({
+      behavior: "smooth",
+      top: 210,
+    });
+  });
+
+  it("does not scroll when the element is already visible", () => {
+    const container = document.createElement("div");
+    const element = document.createElement("div");
+    container.appendChild(element);
+    document.body.appendChild(container);
+
+    vi.spyOn(window, "getComputedStyle").mockReturnValue({
+      overflow: "auto",
+      overflowY: "auto",
+    } as CSSStyleDeclaration);
+
+    container.getBoundingClientRect = () =>
+      mockRect({ top: 100, bottom: 400, height: 300 });
+    element.getBoundingClientRect = () =>
+      mockRect({ top: 160, bottom: 260, height: 100 });
+
+    const scrollTo = vi.fn();
+    container.scrollTo = scrollTo;
+
+    scrollElementIntoViewIfNeeded(element);
+
+    expect(scrollTo).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/cell/scroll-into-view-if-needed.ts
+++ b/src/components/cell/scroll-into-view-if-needed.ts
@@ -1,0 +1,51 @@
+function isScrollable(overflowValue: string) {
+  return /(auto|scroll|overlay)/.test(overflowValue);
+}
+
+function findScrollContainer(element: HTMLElement): HTMLElement | null {
+  let current = element.parentElement;
+
+  while (current) {
+    const style = window.getComputedStyle(current);
+    if (isScrollable(style.overflowY) || isScrollable(style.overflow)) {
+      return current;
+    }
+    current = current.parentElement;
+  }
+
+  return null;
+}
+
+export function scrollElementIntoViewIfNeeded(element: HTMLElement) {
+  const scrollContainer = findScrollContainer(element);
+  if (!scrollContainer) {
+    element.scrollIntoView({
+      behavior: "smooth",
+      block: "nearest",
+      inline: "nearest",
+    });
+    return;
+  }
+
+  const elementRect = element.getBoundingClientRect();
+  const containerRect = scrollContainer.getBoundingClientRect();
+
+  if (
+    elementRect.top >= containerRect.top &&
+    elementRect.bottom <= containerRect.bottom
+  ) {
+    return;
+  }
+
+  const topOffset = elementRect.top - containerRect.top;
+  const bottomOffset = elementRect.bottom - containerRect.bottom;
+  const scrollTop =
+    topOffset < 0
+      ? scrollContainer.scrollTop + topOffset
+      : scrollContainer.scrollTop + bottomOffset;
+
+  scrollContainer.scrollTo({
+    top: scrollTop,
+    behavior: "smooth",
+  });
+}


### PR DESCRIPTION
## Summary
- focus newly inserted code cells after they mount
- scroll the new editor into view so typing can continue immediately

Closes #770