### PR TITLE
fix(editor): route select all through codemirror

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -40,6 +40,7 @@ import { startCursorDispatch } from "./lib/cursor-registry";
 import { KERNEL_STATUS } from "./lib/kernel-status";
 import { logger } from "./lib/logger";
 import { useDetectRuntime } from "./lib/notebook-metadata";
+import { selectAllInActiveElement } from "./lib/select-all";
 import type { JupyterMessage } from "./types";
 
 /** MIME bundle type for page payloads */
@@ -714,6 +715,18 @@ function AppContent() {
       unlistenPromise.then((unlisten) => unlisten());
     };
   }, [cloneNotebook]);
+
+  // Edit menu: Select all
+  useEffect(() => {
+    const webview = getCurrentWebview();
+    const unlistenPromise = webview.listen("menu:select-all", () => {
+      selectAllInActiveElement();
+    });
+
+    return () => {
+      unlistenPromise.then((unlisten) => unlisten()).catch(() => {});
+    };
+  }, []);
 
   // Cell menu: Insert cell
   useEffect(() => {

--- a/apps/notebook/src/lib/__tests__/select-all.test.ts
+++ b/apps/notebook/src/lib/__tests__/select-all.test.ts
@@ -1,0 +1,39 @@
+import { EditorView } from "@codemirror/view";
+import { afterEach, describe, expect, it } from "vitest";
+import { selectAllInActiveElement } from "../select-all";
+
+describe("selectAllInActiveElement", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("selects the active CodeMirror document instead of the whole page", () => {
+    const parent = document.createElement("div");
+    document.body.appendChild(parent);
+
+    const view = new EditorView({
+      doc: "print('hello')",
+      parent,
+    });
+
+    view.focus();
+
+    expect(selectAllInActiveElement()).toBe(true);
+    expect(view.state.selection.main.from).toBe(0);
+    expect(view.state.selection.main.to).toBe(view.state.doc.length);
+
+    view.destroy();
+  });
+
+  it("falls back to selecting a standard input", () => {
+    const input = document.createElement("input");
+    input.value = "desktop";
+    document.body.appendChild(input);
+
+    input.focus();
+
+    expect(selectAllInActiveElement()).toBe(true);
+    expect(input.selectionStart).toBe(0);
+    expect(input.selectionEnd).toBe(input.value.length);
+  });
+});

--- a/apps/notebook/src/lib/select-all.ts
+++ b/apps/notebook/src/lib/select-all.ts
@@ -1,0 +1,56 @@
+import { EditorView } from "@codemirror/view";
+
+function selectAllInCodeMirror(activeElement: Element): boolean {
+  const cmContent =
+    activeElement.closest(".cm-content") ??
+    activeElement.closest(".cm-editor")?.querySelector(".cm-content");
+
+  if (!(cmContent instanceof HTMLElement)) return false;
+
+  const view = EditorView.findFromDOM(cmContent);
+  if (!view) return false;
+
+  const docLength = view.state.doc.length;
+  view.focus();
+  view.dispatch({
+    selection: { anchor: 0, head: docLength },
+    scrollIntoView: true,
+  });
+  return true;
+}
+
+function selectAllInContentEditable(activeElement: HTMLElement): boolean {
+  const selection = activeElement.ownerDocument.defaultView?.getSelection();
+  if (!selection) return false;
+
+  const range = activeElement.ownerDocument.createRange();
+  range.selectNodeContents(activeElement);
+  selection.removeAllRanges();
+  selection.addRange(range);
+  return true;
+}
+
+export function selectAllInActiveElement(doc: Document = document): boolean {
+  const activeElement = doc.activeElement;
+  if (!activeElement) {
+    return doc.execCommand?.("selectAll") ?? false;
+  }
+
+  if (selectAllInCodeMirror(activeElement)) {
+    return true;
+  }
+
+  if (
+    activeElement instanceof HTMLInputElement ||
+    activeElement instanceof HTMLTextAreaElement
+  ) {
+    activeElement.select();
+    return true;
+  }
+
+  if (activeElement instanceof HTMLElement && activeElement.isContentEditable) {
+    return selectAllInContentEditable(activeElement);
+  }
+
+  return doc.execCommand?.("selectAll") ?? false;
+}

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -4012,6 +4012,12 @@ pub fn run(
                         let _ = emit_to_label::<_, _, _>(&window, window.label(), "menu:clone", ());
                     }
                 }
+                crate::menu::MENU_SELECT_ALL => {
+                    if let Some(window) = focused_window(app) {
+                        let _ =
+                            emit_to_label::<_, _, _>(&window, window.label(), "menu:select-all", ());
+                    }
+                }
                 crate::menu::MENU_ZOOM_IN => {
                     if let Some(window) = focused_window(app) {
                         let _ = emit_to_label::<_, _, _>(&window, window.label(), "menu:zoom-in", ());

--- a/crates/notebook/src/menu.rs
+++ b/crates/notebook/src/menu.rs
@@ -19,6 +19,7 @@ pub const MENU_OPEN: &str = "open";
 pub const MENU_OPEN_SAMPLE_PREFIX: &str = "open_sample:";
 pub const MENU_SAVE: &str = "save";
 pub const MENU_CLONE_NOTEBOOK: &str = "clone_notebook";
+pub const MENU_SELECT_ALL: &str = "select_all";
 pub const MENU_WINDOW_FOCUS_PREFIX: &str = "focus_window:";
 
 // Menu item IDs for zoom
@@ -232,7 +233,13 @@ pub fn create_menu(
     edit_menu.append(&PredefinedMenuItem::cut(app, None)?)?;
     edit_menu.append(&PredefinedMenuItem::copy(app, None)?)?;
     edit_menu.append(&PredefinedMenuItem::paste(app, None)?)?;
-    edit_menu.append(&PredefinedMenuItem::select_all(app, None)?)?;
+    edit_menu.append(&MenuItem::with_id(
+        app,
+        MENU_SELECT_ALL,
+        "Select All",
+        true,
+        Some("CmdOrCtrl+A"),
+    )?)?;
     menu.append(&edit_menu)?;
 
     // Cell menu


### PR DESCRIPTION
## Summary
- replace the native Select All menu item with an app event
- select the active CodeMirror document directly instead of the whole page
- fall back to standard input selection behavior and cover the helper with tests

Closes #771