### PR TITLE
feat(mcp): expose user settings to session and honor default_python_env

### DIFF
--- a/crates/runtimed-py/src/async_session.rs
+++ b/crates/runtimed-py/src/async_session.rs
@@ -5,6 +5,7 @@
 //! All business logic lives in `session_core.rs`.
 
 use pyo3::prelude::*;
+use pyo3::types::PyDict;
 use pyo3_async_runtimes::tokio::future_into_py;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -736,6 +737,51 @@ impl AsyncSession {
             }
             Ok(removed)
         })
+    }
+
+    /// Get the notebook's environment type from metadata structure.
+    ///
+    /// Returns "uv", "conda", or None if no env metadata exists.
+    /// This checks if the metadata structure exists, not whether deps are non-empty.
+    fn get_metadata_env_type<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let state = Arc::clone(&self.state);
+        future_into_py(py, async move {
+            let snapshot = session_core::get_notebook_metadata(&state).await?;
+            Ok(session_core::get_metadata_env_type(&snapshot))
+        })
+    }
+
+    /// Get user settings from local replica.
+    ///
+    /// Returns a dictionary with settings synced from daemon at connection time.
+    /// Returns None if settings sync failed during connection.
+    fn get_settings<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyDict>>> {
+        let state = self.state.blocking_lock();
+
+        match session_core::get_settings(&state) {
+            Some(settings) => {
+                let dict = PyDict::new(py);
+                dict.set_item("theme", settings.theme.to_string())?;
+                dict.set_item("default_runtime", settings.default_runtime.to_string())?;
+                dict.set_item(
+                    "default_python_env",
+                    settings.default_python_env.to_string(),
+                )?;
+                dict.set_item("keep_alive_secs", settings.keep_alive_secs)?;
+                dict.set_item("onboarding_completed", settings.onboarding_completed)?;
+
+                let uv_dict = PyDict::new(py);
+                uv_dict.set_item("default_packages", &settings.uv.default_packages)?;
+                dict.set_item("uv", uv_dict)?;
+
+                let conda_dict = PyDict::new(py);
+                conda_dict.set_item("default_packages", &settings.conda.default_packages)?;
+                dict.set_item("conda", conda_dict)?;
+
+                Ok(Some(dict))
+            }
+            None => Ok(None),
+        }
     }
 
     // =========================================================================

--- a/crates/runtimed-py/src/session.rs
+++ b/crates/runtimed-py/src/session.rs
@@ -5,6 +5,7 @@
 //! All business logic lives in `session_core.rs`.
 
 use pyo3::prelude::*;
+use pyo3::types::PyDict;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::runtime::Runtime;
@@ -547,6 +548,49 @@ impl Session {
                 .block_on(session_core::set_notebook_metadata(&self.state, &snapshot))?;
         }
         Ok(removed)
+    }
+
+    /// Get the notebook's environment type from metadata structure.
+    ///
+    /// Returns "uv", "conda", or None if no env metadata exists.
+    fn get_metadata_env_type(&self) -> PyResult<Option<String>> {
+        let snapshot = self
+            .runtime
+            .block_on(session_core::get_notebook_metadata(&self.state))?;
+        Ok(session_core::get_metadata_env_type(&snapshot))
+    }
+
+    /// Get user settings from local replica.
+    ///
+    /// Returns a dictionary with settings synced from daemon at connection time.
+    /// Returns None if settings sync failed during connection.
+    fn get_settings<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyDict>>> {
+        let state = self.runtime.block_on(self.state.lock());
+
+        match session_core::get_settings(&state) {
+            Some(settings) => {
+                let dict = PyDict::new(py);
+                dict.set_item("theme", settings.theme.to_string())?;
+                dict.set_item("default_runtime", settings.default_runtime.to_string())?;
+                dict.set_item(
+                    "default_python_env",
+                    settings.default_python_env.to_string(),
+                )?;
+                dict.set_item("keep_alive_secs", settings.keep_alive_secs)?;
+                dict.set_item("onboarding_completed", settings.onboarding_completed)?;
+
+                let uv_dict = PyDict::new(py);
+                uv_dict.set_item("default_packages", &settings.uv.default_packages)?;
+                dict.set_item("uv", uv_dict)?;
+
+                let conda_dict = PyDict::new(py);
+                conda_dict.set_item("default_packages", &settings.conda.default_packages)?;
+                dict.set_item("conda", conda_dict)?;
+
+                Ok(Some(dict))
+            }
+            None => Ok(None),
+        }
     }
 
     // =========================================================================

--- a/crates/runtimed-py/src/session_core.rs
+++ b/crates/runtimed-py/src/session_core.rs
@@ -49,6 +49,8 @@ pub(crate) struct SessionState {
     pub connection_info: Option<NotebookConnectionInfo>,
     /// Notebook path (for project file detection during kernel launch)
     pub notebook_path: Option<String>,
+    /// User settings (synced from daemon at connection time)
+    pub settings: Option<runtimed::settings_doc::SyncedSettings>,
 }
 
 impl SessionState {
@@ -63,8 +65,48 @@ impl SessionState {
             blob_store_path: None,
             connection_info: None,
             notebook_path: None,
+            settings: None,
         }
     }
+}
+
+// =========================================================================
+// Settings
+// =========================================================================
+
+/// Sync settings from daemon and return the parsed settings.
+///
+/// This performs a one-shot Automerge sync with the daemon's settings document.
+/// Returns None if the connection fails (graceful degradation).
+pub(crate) async fn sync_settings(
+    socket_path: PathBuf,
+) -> Option<runtimed::settings_doc::SyncedSettings> {
+    match runtimed::sync_client::SyncClient::connect(socket_path).await {
+        Ok(client) => Some(client.get_all()),
+        Err(e) => {
+            log::warn!("[session-core] Settings sync failed: {}", e);
+            None
+        }
+    }
+}
+
+/// Get settings from session state.
+pub(crate) fn get_settings(state: &SessionState) -> Option<runtimed::settings_doc::SyncedSettings> {
+    state.settings.clone()
+}
+
+/// Get the notebook's environment type from metadata structure.
+///
+/// Returns "conda" if conda metadata exists, "uv" if uv metadata exists, None otherwise.
+/// This checks if the metadata structure exists, not whether deps are non-empty.
+pub(crate) fn get_metadata_env_type(snapshot: &NotebookMetadataSnapshot) -> Option<String> {
+    if snapshot.runt.conda.is_some() {
+        return Some("conda".to_string());
+    }
+    if snapshot.runt.uv.is_some() {
+        return Some("uv".to_string());
+    }
+    None
 }
 
 // =========================================================================
@@ -112,6 +154,9 @@ pub(crate) async fn connect_open(
     let (blob_base_url, blob_store_path) = resolve_blob_paths(&socket_path).await;
     let connection_info = NotebookConnectionInfo::from_protocol(result.info);
 
+    // Sync settings from daemon (best-effort, don't fail if unavailable)
+    let settings = sync_settings(socket_path).await;
+
     let state = SessionState {
         handle: Some(result.handle),
         broadcast_rx: Some(result.broadcast_rx),
@@ -122,6 +167,7 @@ pub(crate) async fn connect_open(
         blob_store_path,
         connection_info: Some(connection_info.clone()),
         notebook_path: Some(path.to_string()),
+        settings,
     };
 
     Ok((notebook_id, state, connection_info))
@@ -144,6 +190,9 @@ pub(crate) async fn connect_create(
     let (blob_base_url, blob_store_path) = resolve_blob_paths(&socket_path).await;
     let connection_info = NotebookConnectionInfo::from_protocol(result.info);
 
+    // Sync settings from daemon (best-effort, don't fail if unavailable)
+    let settings = sync_settings(socket_path).await;
+
     let state = SessionState {
         handle: Some(result.handle),
         broadcast_rx: Some(result.broadcast_rx),
@@ -154,6 +203,7 @@ pub(crate) async fn connect_create(
         blob_store_path,
         connection_info: Some(connection_info.clone()),
         notebook_path: working_dir.map(|p| p.to_string_lossy().to_string()),
+        settings,
     };
 
     Ok((notebook_id, state, connection_info))

--- a/crates/runtimed/src/sync_client.rs
+++ b/crates/runtimed/src/sync_client.rs
@@ -183,6 +183,14 @@ where
         get_all_from_doc(&self.doc)
     }
 
+    /// Consume the client and return the local Automerge document.
+    ///
+    /// This is useful when you want to keep the synced settings doc
+    /// without maintaining the network connection.
+    pub fn into_doc(self) -> AutoCommit {
+        self.doc
+    }
+
     /// Get a single scalar setting value.
     pub fn get(&self, key: &str) -> Option<String> {
         self.doc
@@ -348,7 +356,7 @@ where
 ///
 /// Reads nested maps/lists first, falling back to old flat keys for
 /// backward compatibility during upgrades.
-fn get_all_from_doc(doc: &AutoCommit) -> SyncedSettings {
+pub fn get_all_from_doc(doc: &AutoCommit) -> SyncedSettings {
     let defaults = SyncedSettings::default();
 
     let get_str = |key: &str| -> Option<String> {

--- a/python/nteract/src/nteract/_mcp_server.py
+++ b/python/nteract/src/nteract/_mcp_server.py
@@ -566,8 +566,9 @@ async def _get_package_manager(session: runtimed.AsyncSession) -> str:
 
     Detection order:
     1. If kernel is running, check env_source (most reliable)
-    2. Otherwise, check stored metadata for existing dependencies
-    3. Default to "uv" if no signal
+    2. Check notebook metadata structure (conda vs uv)
+    3. Check session's settings replica for default_python_env
+    4. Default to "uv" if no signal
     """
     # First check env_source if kernel is running
     env = await session.env_source()
@@ -576,11 +577,15 @@ async def _get_package_manager(session: runtimed.AsyncSession) -> str:
             return "conda"
         return "uv"
 
-    # No kernel running - check stored metadata
-    # If notebook has conda deps, it's a conda notebook
-    conda_deps = await session.get_conda_dependencies()
-    if conda_deps:
-        return "conda"
+    # Check metadata structure (not just non-empty deps)
+    env_type = await session.get_metadata_env_type()
+    if env_type:
+        return env_type
+
+    # Check settings from session's local replica (no round-trip)
+    settings = session.get_settings()
+    if settings:
+        return settings.get("default_python_env", "uv")
 
     return "uv"
 


### PR DESCRIPTION
## Summary

When the MCP server creates a notebook, the daemon correctly populates metadata based on the user's `default_python_env` setting. However, the MCP server couldn't detect this metadata structure when adding dependencies, causing it to default to UV regardless of user preference (fixes #776).

## Changes

- **Session settings sync**: User settings are synced from daemon via Automerge when session connects, providing instant local reads
- **Metadata structure detection**: New `get_metadata_env_type()` detects whether a notebook has `runt.conda` or `runt.uv` metadata (regardless of empty dependencies)
- **Smart package manager detection**: `_get_package_manager()` now uses: kernel's env_source → metadata structure → user settings → default to uv

## Verification

* [ ] Verify that when user has `default_python_env: conda` in settings and creates a new notebook via MCP, adding a dependency uses conda (not UV)
* [ ] Verify that notebooks created with UV settings use UV for dependency management
* [ ] Verify existing dependency detection still works correctly for notebooks with non-empty dependencies

_PR submitted by @rgbkrk's agent, Quill_