### PR TITLE
docs: audit and fix 22 markdown files against codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,13 @@ Built on [runtimelib](https://crates.io/crates/runtimelib) and [jupyter-protocol
 
 Download the latest release from [GitHub Releases](https://github.com/nteract/desktop/releases).
 
-The desktop app bundles everything — `runt` CLI, `runtimed` daemon, and `sidecar`.
+The desktop app bundles everything — `runt` CLI and `runtimed` daemon.
 
-The Python bindings are available on PyPI:
+The Python bindings and MCP server are available on PyPI:
 
 ```bash
 pip install runtimed
+pip install nteract
 ```
 
 ## What's in here
@@ -23,7 +24,6 @@ pip install runtimed
 | `nteract` | Desktop notebook editor (Tauri + React) |
 | `runtimed` | Background daemon — environment pools, notebook sync, kernel execution |
 | `runt` | CLI for managing kernels, notebooks, and the daemon |
-| `sidecar` | Viewer for Jupyter kernel outputs |
 | `runtimed` (PyPI) | Python bindings for the daemon |
 
 ## MCP Server
@@ -70,8 +70,7 @@ nteract/desktop
 │   └── lib/
 │       └── utils.ts       # cn() and other utilities
 ├── apps/                   # App entry points
-│   ├── notebook/          # Notebook Tauri frontend
-│   └── sidecar/           # Sidecar WebView frontend
+│   └── notebook/          # Notebook Tauri frontend
 ├── crates/                 # Rust code
 │   ├── runt/              # CLI binary
 │   ├── runtimed/          # Background daemon
@@ -79,7 +78,8 @@ nteract/desktop
 │   ├── runtimed-wasm/     # WASM Automerge bindings for frontend (same automerge crate as daemon)
 │   ├── notebook/          # Notebook Tauri app
 │   ├── notebook-doc/      # Shared Automerge document operations (cells, metadata, sync)
-│   ├── sidecar/           # Sidecar wry/tao app
+│   ├── notebook-protocol/ # Notebook wire protocol types
+│   ├── notebook-sync/     # Notebook sync layer
 │   ├── tauri-jupyter/     # Shared Tauri/Jupyter utilities
 │   ├── kernel-launch/     # Shared kernel launching API
 │   ├── kernel-env/        # Environment progress reporting
@@ -127,14 +127,12 @@ cargo xtask build
 
 ### Build order
 
-The UI must be built before Rust because:
-- `crates/sidecar` embeds assets from `apps/sidecar/dist/` at compile time via [rust-embed](https://crates.io/crates/rust-embed)
-- `crates/notebook` embeds assets from `apps/notebook/dist/` via Tauri
+The UI must be built before Rust because `crates/notebook` embeds assets from `apps/notebook/dist/` via Tauri.
 
 ### Common commands
 
 ```bash
-pnpm build                          # Build all UIs
+pnpm build                          # Build notebook UI
 cargo test                          # Run Rust tests
 pnpm test:run                       # Run JS tests
 cargo fmt                           # Format Rust

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,13 +4,15 @@
 
 | Stream | Tag | Trigger | Destination |
 |--------|-----|---------|-------------|
-| **Stable** | `v{version}-stable.{sha}` | Tag push (`v*`) or manual | GitHub Releases |
-| **Nightly** | `v{version}-nightly.{sha}` | Cron (daily, 24h cadence) or manual | GitHub Pre-releases |
+| **Stable** | `v{version}-stable.{timestamp}` | Tag push (`v*`) or manual | GitHub Releases |
+| **Nightly** | `v{version}-nightly.{timestamp}` | Cron (daily, 24h cadence) or manual | GitHub Pre-releases |
 | **Python package** | `python-v{semver}` | Manual tag push | PyPI + GitHub Releases |
+
+Timestamps are UTC in `YYYYMMDDHHMM` format, e.g. `v2.0.0-stable.202507010900`.
 
 ## Desktop App (nteract)
 
-The desktop app, `runt` CLI, `runtimed` daemon, and `sidecar` are all built and released together via reusable workflow `.github/workflows/release-common.yml`, invoked by `.github/workflows/release-stable.yml` and `.github/workflows/release-nightly.yml`.
+The desktop app, `runt` CLI, and `runtimed` daemon are all built and released together via reusable workflow `.github/workflows/release-common.yml`, invoked by `.github/workflows/release-stable.yml` and `.github/workflows/release-nightly.yml`.
 
 Stable releases run when a `v*` tag is pushed (or manually), and nightly pre-releases run every 24 hours. Both can also be triggered manually.
 
@@ -18,27 +20,26 @@ Stable releases run when a `v*` tag is pushed (or manually), and nightly pre-rel
 
 | Platform | File |
 |----------|------|
-| macOS ARM64 (Apple Silicon) | `nteract-darwin-arm64.dmg` |
-| macOS x64 (Intel) | `nteract-darwin-x64.dmg` |
-| Windows x64 | `nteract-windows-x64.exe` |
-| Linux x64 | `nteract-linux-x64.AppImage` |
+| macOS ARM64 (Apple Silicon) | `nteract-{channel}-darwin-arm64.dmg` |
+| Windows x64 | `nteract-{channel}-windows-x64.exe` |
+| Linux x64 | `nteract-{channel}-linux-x64.AppImage` |
+| Linux x64 | `nteract-{channel}-linux-x64.deb` |
 | CLI (macOS ARM64) | `runt-darwin-arm64` |
-| CLI (macOS x64) | `runt-darwin-x64` |
 | CLI (Linux x64) | `runt-linux-x64` |
 
 macOS builds are signed and notarized. Windows builds are not code signed.
 
 ### Crate publishing
 
-`runt-cli` and `sidecar` are **not published to crates.io** (`publish = false`). Sidecar embeds UI assets from `apps/sidecar/dist/` via `rust-embed`, which requires files outside the crate directory.
+`runt-cli`, `runtimed-py`, and `xtask` are **not published to crates.io** (`publish = false`).
 
-## Python Package (runtimed)
+## Python Packages (runtimed, nteract)
 
-The `runtimed` Python package provides bindings for the daemon and is released separately.
+The `runtimed` and `nteract` Python packages are released separately.
 
 ### 1. Bump the version
 
-Edit `python/runtimed/pyproject.toml` and update the `version` field.
+Edit `python/runtimed/pyproject.toml` and `python/nteract/pyproject.toml` and update the `version` field in each.
 
 ### 2. Create a PR
 
@@ -52,9 +53,9 @@ git push origin python-v<version>
 ```
 
 The `python-package.yml` workflow triggers on `python-v*` tags and will:
-- Build wheels for macOS (arm64 + x64)
+- Build wheels for macOS arm64 and Linux x64
 - Publish to PyPI via trusted publishing (OIDC)
-- Create a GitHub release with wheels and `runt` binaries
+- Create a GitHub release with wheels and nteract-dist packages
 
 ## Development
 

--- a/contributing/build-dependencies.md
+++ b/contributing/build-dependencies.md
@@ -14,7 +14,6 @@ compile.
 ```mermaid
 graph TD
     subgraph "Frontend Assets (pnpm / Vite)"
-        SUI["sidecar-ui<br/><i>apps/sidecar/</i>"]
         NUI["notebook-ui<br/><i>apps/notebook/</i><br/>(includes isolated-renderer)"]
     end
 
@@ -22,7 +21,6 @@ graph TD
         TJ["tauri-jupyter<br/><i>shared Jupyter types</i>"]
         ND["notebook-doc<br/><i>shared Automerge doc ops</i>"]
         RD["runtimed (lib + bin)<br/><i>daemon</i>"]
-        SC["sidecar (lib + bin)<br/><i>output viewer</i>"]
         RC["runt-cli (bin: runt)<br/><i>CLI</i>"]
         NB["notebook (Tauri app)<br/><i>main app</i>"]
         XT["xtask<br/><i>build orchestrator</i>"]
@@ -36,12 +34,10 @@ graph TD
     end
 
     %% Frontend → Rust compile-time dependencies
-    SUI -->|"build.rs panics<br/>if dist/ missing"| SC
     NUI -->|"tauri beforeBuildCommand"| NB
     RWASM -->|"wasm-pack output in<br/>apps/notebook/src/wasm/"| NUI
 
     %% Rust crate dependencies (path deps in Cargo.toml)
-    TJ -->|"path dep"| SC
     TJ -->|"path dep"| NB
     ND -->|"path dep"| RD
     ND -->|"path dep"| RWASM
@@ -57,10 +53,8 @@ graph TD
 
     %% Python package
     RDPY -->|"maturin build<br/>(bindings = pyo3)"| PY
-    SUI -->|"embedded via<br/>rust-embed in sidecar crate"| PY
 
     %% xtask orchestrates everything
-    XT -.->|"orchestrates"| SUI
     XT -.->|"orchestrates"| NUI
     XT -.->|"builds + copies<br/>runtimed & runt binaries"| APP
 
@@ -68,8 +62,8 @@ graph TD
     classDef rust fill:#fff3e0,stroke:#ef6c00
     classDef artifact fill:#e8f5e9,stroke:#2e7d32
 
-    class SUI,NUI frontend
-    class TJ,ND,RD,SC,RC,NB,XT,RWASM,RDPY rust
+    class NUI frontend
+    class TJ,ND,RD,RC,NB,XT,RWASM,RDPY rust
     class APP,PY artifact
 ```
 
@@ -80,16 +74,14 @@ here is what happens under the hood:
 
 ```mermaid
 graph LR
-    A["1. pnpm install"] --> B["2. pnpm --dir apps/sidecar build"]
-    A --> W["3. wasm-pack build<br/>crates/runtimed-wasm"]
-    W --> C["4. pnpm --dir apps/notebook build<br/>(includes isolated-renderer)"]
-    B --> D["5. cargo build --release<br/>-p runtimed -p runt-cli"]
-    C --> D
-    D --> E["6. Copy binaries to<br/>crates/notebook/binaries/"]
-    E --> F["7. cargo tauri build"]
+    A["1. pnpm install"] --> W["2. wasm-pack build<br/>crates/runtimed-wasm"]
+    W --> C["3. pnpm --dir apps/notebook build<br/>(includes isolated-renderer)"]
+    C --> D["4. cargo build --release<br/>-p runtimed -p runt-cli"]
+    D --> E["5. Copy binaries to<br/>crates/notebook/binaries/"]
+    E --> F["6. cargo tauri build"]
 
     classDef step fill:#f3e5f5,stroke:#7b1fa2
-    class A,B,W,C,D,E,F step
+    class A,W,C,D,E,F step
 ```
 
 ## Rust Crate Dependency Graph
@@ -100,10 +92,11 @@ Shows only the Cargo `path` dependencies between workspace members:
 graph BT
     TJ["tauri-jupyter"]
     RD["runtimed"]
-    SC["sidecar"]
     RC["runt-cli"]
     NB["notebook"]
     ND["notebook-doc"]
+    NP["notebook-protocol"]
+    NS["notebook-sync"]
     XT["xtask"]
     KL["kernel-launch"]
     KE["kernel-env"]
@@ -112,7 +105,6 @@ graph BT
     RDPY["runtimed-py"]
     RWASM["runtimed-wasm"]
 
-    SC -->|"depends on"| TJ
     NB -->|"depends on"| TJ
     NB -->|"depends on"| RD
     NB -->|"depends on"| KL
@@ -122,9 +114,16 @@ graph BT
     RC -->|"depends on"| RD
     RC -->|"depends on"| RW
     RD -->|"depends on"| ND
+    RD -->|"depends on"| NP
+    RD -->|"depends on"| NS
     RD -->|"depends on"| KL
     RD -->|"depends on"| KE
+    RD -->|"depends on"| RT
+    RD -->|"depends on"| RW
     RDPY -->|"depends on"| RD
+    RDPY -->|"depends on"| ND
+    RDPY -->|"depends on"| NP
+    RDPY -->|"depends on"| NS
     RWASM -->|"depends on"| ND
 
     classDef standalone fill:#fff9c4,stroke:#f9a825
@@ -134,18 +133,17 @@ graph BT
     class TJ,KL,KE,RT,RW,RWASM standalone
     class XT standalone
     class NB,RC,RDPY leaf
-    class RD,ND shared
+    class RD,ND,NP,NS shared
 ```
 
 ## Key Points
 
 | Constraint | Why |
 |---|---|
-| `sidecar-ui` must build before `sidecar` crate | `build.rs` panics if `apps/sidecar/dist/index.html` is missing — the UI is embedded via `rust-embed` |
 | `notebook-ui` must build before Tauri bundle | `tauri.conf.json` `beforeBuildCommand` runs `pnpm --dir apps/notebook build` |
 | `runtimed` + `runt` binaries must exist in `crates/notebook/binaries/` | `tauri.conf.json` lists them in `bundle.externalBin` — Tauri bundles them into the .app/.dmg/.exe |
 | `isolated-renderer` built inline | The notebook-ui Vite plugin builds the isolated renderer and embeds it as a virtual module — no separate build step needed |
-| `xtask` has no Cargo deps | It shells out to `cargo build`, `pnpm`, and `cargo tauri` to orchestrate the full build |
+| `xtask` depends on `dirs`, `runt-workspace`, `serde_json` | It shells out to `cargo build`, `pnpm`, and `cargo tauri` but also reads workspace config via `runt-workspace` and resolves paths via `dirs` |
 | `runtimed-wasm` must build before `notebook-ui` | wasm-pack output lands in `apps/notebook/src/wasm/runtimed-wasm/`; Vite imports it at build time. Artifacts are committed to the repo, so this step is only needed when changing `crates/runtimed-wasm/`. |
 | Python wheel uses maturin | `python/runtimed/pyproject.toml` points `maturin` at `crates/runtimed-py/Cargo.toml` with `bindings = "pyo3"` |
 | `notebook-doc` is shared | `crates/notebook-doc/` provides Automerge document operations used by `runtimed`, `runtimed-wasm`, and `runtimed-py` — the single source of truth for cell mutations |

--- a/contributing/development.md
+++ b/contributing/development.md
@@ -88,13 +88,12 @@ Mostly handled by CI for preview releases. Use locally only when testing:
 ## Build Order
 
 The UI must be built before Rust because:
-- `crates/sidecar` embeds assets from `apps/sidecar/dist/` at compile time via rust-embed
 - `crates/notebook` embeds assets from `apps/notebook/dist/` via Tauri
 
 The xtask commands handle this automatically. If building manually:
 
 ```bash
-pnpm build          # Build all UIs (sidecar, notebook — isolated-renderer built inline)
+pnpm build          # Build notebook UI (isolated-renderer built inline)
 cargo build         # Build Rust
 ```
 
@@ -104,11 +103,11 @@ cargo build         # Build Rust
 
 ## Test Notebooks
 
-The `notebooks/` directory has test files:
+Test notebooks live in `crates/notebook/fixtures/audit-test/` and sample notebooks in `crates/notebook/resources/sample-notebooks/`.
 
 ```bash
 cargo xtask build
-./target/debug/notebook notebooks/test-isolation.ipynb
+./target/debug/notebook crates/notebook/fixtures/audit-test/test-isolation.ipynb
 ```
 
 ## Daemon Development

--- a/contributing/e2e.md
+++ b/contributing/e2e.md
@@ -20,7 +20,7 @@ The `e2e/dev.sh` script handles everything:
 # Step by step:
 ./e2e/dev.sh build       # Build with WebDriver support (embeds frontend)
 ./e2e/dev.sh start       # Start app with WebDriver server (foreground)
-./e2e/dev.sh test        # Smoke test (notebook-execution only)
+./e2e/dev.sh test        # Smoke test (smoke.spec.js only)
 ./e2e/dev.sh test all    # All non-fixture specs
 ./e2e/dev.sh stop        # Stop the running app
 ```
@@ -35,7 +35,7 @@ Fixture tests open a specific notebook and get a fresh app instance per test:
 # Run a single fixture test
 ./e2e/dev.sh test-fixture \
   crates/notebook/fixtures/audit-test/1-vanilla.ipynb \
-  e2e/specs/vanilla-startup.spec.js
+  e2e/specs/prewarmed-uv.spec.js
 
 # Run all fixture tests (fresh app per test, exits 1 if any fail)
 ./e2e/dev.sh test-fixtures
@@ -50,11 +50,13 @@ Fixture tests open a specific notebook and get a fresh app instance per test:
 | `start` | Start app with WebDriver server (foreground) |
 | `stop` | Stop the running app |
 | `restart` | Stop + start |
-| `test [spec\|all]` | Run E2E tests (default: notebook-execution only) |
+| `test [spec\|all]` | Run E2E tests (default: smoke.spec.js only) |
 | `test-fixture <nb> <spec>` | Run a fixture test (fresh app per test) |
 | `test-fixtures` | Run all fixture tests |
+| `test-untitled-pyproject` | Test untitled notebook with pyproject.toml (CWD = fixture dir) |
 | `cycle` | Build + start + test in one shot |
 | `status` | Check if WebDriver server is running |
+| `daemon` | Check if E2E daemon is running |
 | `session` | Create a session and print ID |
 | `exec 'js'` | Execute JS in the app |
 
@@ -106,12 +108,12 @@ Use a regular test when:
 | `3-conda-inline.ipynb` | `conda-inline.spec.js` | Conda inline dependency resolution |
 | `10-deno.ipynb` | `deno.spec.js` | Deno kernel start + TypeScript execution |
 | `pyproject-project/5-pyproject.ipynb` | `uv-pyproject.spec.js` | pyproject.toml environment detection |
+| *(untitled)* | `untitled-pyproject.spec.js` | pyproject.toml detection from CWD (requires `test-untitled-pyproject`) |
 
 **Regular specs** (run against default app, not fixtures):
 - `smoke.spec.js` — Basic cell execution and output
 - `tab-completion.spec.js` — Tab completion in code cells
 - `cell-visibility.spec.js` — Source/output visibility toggles
-- `untitled-pyproject.spec.js` — Untitled notebook in pyproject.toml directory
 
 Multiple specs can reuse the same fixture notebook — each gets its own fresh app instance.
 
@@ -196,7 +198,7 @@ import {
 | Helper | What it does |
 |--------|-------------|
 | `waitForAppReady()` | Waits for the toolbar to appear (15s). Use in every `before()` hook. |
-| `waitForKernelReady()` | Waits for kernel to reach `idle` or `busy` (30s). Superset of `waitForAppReady()`. |
+| `waitForKernelReady()` | Waits for kernel to reach `idle` or `busy` (60s). Superset of `waitForAppReady()`. |
 | `executeFirstCell()` | Focuses the first code cell's editor and hits Shift+Enter. Returns the cell element. |
 | `waitForCellOutput(cell, timeout?)` | Waits for stream output to appear in a cell. Returns the text. |
 | `waitForOutputContaining(cell, text, timeout?)` | Waits for stream output containing specific text. Returns the full text. |
@@ -514,7 +516,7 @@ Configuration is in `e2e/wdio.conf.js`:
 | Operation | Timeout | Notes |
 |-----------|---------|-------|
 | App load (`waitForAppReady`) | 15s | Toolbar mounting |
-| Kernel startup (`waitForKernelReady`) | 30s | First kernel start can be slow |
+| Kernel startup (`waitForKernelReady`) | 60s | First kernel start can be slow |
 | Cell execution | 120s (default) | Environment creation on first run |
 | Element appear | 5s | DOM rendering |
 | Button clickable | 5s | React hydration |
@@ -579,7 +581,7 @@ Paths are relative to the project root. `dev.sh` will list available fixtures an
 
 ```bash
 # Correct:
-./e2e/dev.sh test-fixture crates/notebook/fixtures/audit-test/1-vanilla.ipynb e2e/specs/vanilla-startup.spec.js
+./e2e/dev.sh test-fixture crates/notebook/fixtures/audit-test/1-vanilla.ipynb e2e/specs/prewarmed-uv.spec.js
 
 # Wrong — don't use absolute paths or paths from other directories:
 ./e2e/dev.sh test-fixture /Users/me/runt/crates/notebook/fixtures/audit-test/1-vanilla.ipynb ...

--- a/contributing/environments.md
+++ b/contributing/environments.md
@@ -408,7 +408,8 @@ All walk-up functions (both unified and individual) stop at `.git` boundaries an
 
 Each per-format module provides:
 - A parse function to extract dependencies
-- Tauri commands for frontend detection (`detect_*`) and dependency listing (`get_*_dependencies`)
+- Tauri commands for frontend detection (`detect_*`)
+- Dependency listing (`get_*_dependencies`) for pyproject.toml and environment.yml (pixi does not have a `get_pixi_dependencies` command — only `detect_pixi_toml` and `import_pixi_dependencies`)
 - Import commands (`import_*_dependencies`) for pyproject.toml and pixi.toml (environment.yml does not have an import command)
 
 ## Notebook Metadata Schema
@@ -456,7 +457,7 @@ Dependencies are signed with HMAC-SHA256 to prevent untrusted code execution on 
 - **Signed content**: Canonical JSON of `metadata.uv` + `metadata.conda` (not cell contents or outputs)
 - **Signature format**: `"hmac-sha256:{hex_digest}"` stored in notebook metadata
 - **Machine-specific**: The key is per-machine, so every shared notebook is untrusted on the recipient's machine
-- **Verification**: `trust.rs:verify_signature()` returns `TrustStatus`: Trusted, Untrusted, SignatureInvalid, or NoDependencies
+- **Verification**: `trust.rs:verify_signature()` returns `bool`. The higher-level `verify_notebook_trust()` returns `TrustInfo` (containing a `TrustStatus`: Trusted, Untrusted, SignatureInvalid, or NoDependencies)
 
 Changes to the dependency metadata structure require updating the signing logic in `crates/notebook/src/trust.rs`.
 

--- a/contributing/frontend-architecture.md
+++ b/contributing/frontend-architecture.md
@@ -11,7 +11,7 @@ This guide explains the frontend code organization and how shared components rel
 │   ├── components/
 │   │   ├── cell/                 ← Cell container, controls, execution count
 │   │   ├── editor/               ← CodeMirror wrappers, extensions, themes
-│   │   ├── isolated/             ← Iframe security isolation (IsolatedFrame, CommBridge)
+│   │   ├── isolated/             ← Iframe security isolation (IsolatedFrame, CommBridgeManager)
 │   │   ├── outputs/              ← Output renderers (MediaRouter, AnsiOutput, etc.)
 │   │   ├── widgets/              ← ipywidgets and anywidget implementations
 │   │   └── ui/                   ← shadcn components (Button, Dialog, etc.)
@@ -29,8 +29,7 @@ This guide explains the frontend code organization and how shared components rel
 │   │   ├── App.tsx               ← Root component
 │   │   └── types.ts              ← App types
 │   │
-│   └── sidecar/src/              ← Standalone output viewer for REPL use
-│                                   (embeds via rust-embed in crates/sidecar/)
+
 ```
 
 ## Path Aliases
@@ -52,7 +51,7 @@ import { useDaemonKernel } from "~/hooks/useDaemonKernel";  // app-specific
 
 **Put code in `src/` (shared) when:**
 - It's a pure UI component with no Tauri/daemon dependencies
-- It could be reused by sidecar or future apps
+- It could be reused by future apps
 - It's a generic utility (cn(), theme helpers)
 
 **Put code in `apps/notebook/src/` when:**
@@ -75,9 +74,9 @@ import { useDaemonKernel } from "~/hooks/useDaemonKernel";  // app-specific
 
 CodeMirror integration with Jupyter-specific extensions:
 - `codemirror-editor.tsx` — Main editor component
-- `extensions/` — Keybindings, line numbers, bracket matching
-- `languages/` — Python, Markdown, SQL syntax
-- `themes/` — Light and dark themes
+- `extensions.ts` — Keybindings, line numbers, bracket matching
+- `languages.ts` — Python, Markdown, SQL syntax
+- `themes.ts` — Light and dark themes
 
 ### Outputs (`src/components/outputs/`)
 
@@ -88,6 +87,7 @@ CodeMirror integration with Jupyter-specific extensions:
 | `ImageOutput` | `image/png`, `image/jpeg`, etc. |
 | `MarkdownOutput` | `text/markdown` |
 | `JsonOutput` | `application/json` |
+| `SvgOutput` | `image/svg+xml` |
 | `MediaRouter` | Dispatches to appropriate renderer |
 
 ### Widgets (`src/components/widgets/`)
@@ -123,8 +123,9 @@ Security boundary for untrusted HTML/widget outputs. See [iframe-isolation.md](i
 │                          sync_applied ─┘          │         │   │
 │                          ▼                        │         │   │
 │                   ┌──────────────┐                │         │   │
-│                   │ materialize- │    "notebook:   │  "notebook: │
-│                   │ Cells()      │    broadcast"   │  presence"  │
+│                   │cellSnapshots-│    "notebook:   │  "notebook: │
+│                   │ToNotebook-   │    broadcast"   │  presence"  │
+│                   │Cells()       │                 │             │
 │                   └──────┬───────┘        │         │       │   │
 │                          │                ▼         │       │   │
 │                          │        ┌──────────────┐  │       │   │
@@ -144,7 +145,7 @@ Security boundary for untrusted HTML/widget outputs. See [iframe-isolation.md](i
 ```
 
 1. **useAutomergeNotebook** — Single ingress point. Listens for `notebook:frame`, demuxes via WASM `receive_frame()`, applies sync locally, re-emits `notebook:broadcast` and `notebook:presence` for downstream hooks
-2. **materializeCells()** — Converts WASM cell snapshots to React-friendly objects on sync changes
+2. **cellSnapshotsToNotebookCells()** / **cellSnapshotsToNotebookCellsSync()** — Converts WASM cell snapshots to React-friendly objects on sync changes
 3. **useDaemonKernel / useEnvProgress** — Consume `notebook:broadcast` events for kernel status, outputs, and environment progress
 4. **usePresence** — Consumes `notebook:presence` events for remote cursor/selection state
 

--- a/contributing/iframe-isolation.md
+++ b/contributing/iframe-isolation.md
@@ -33,7 +33,7 @@ Blob URLs have a unique **opaque origin** (displayed as `"null"`). Because the o
 The iframe uses restricted sandbox attributes:
 
 ```tsx
-// src/components/isolated/isolated-frame.tsx:137
+// src/components/isolated/isolated-frame.tsx
 const SANDBOX_ATTRS = [
   "allow-scripts",          // Required for widgets
   "allow-downloads",        // Allow file downloads
@@ -69,7 +69,7 @@ it("sandbox does NOT include allow-same-origin", () => {
 The iframe's message handler validates that messages come from the parent window:
 
 ```javascript
-// src/components/isolated/frame-html.ts:161
+// src/components/isolated/frame-html.ts
 window.addEventListener('message', function(event) {
   if (event.source !== window.parent) {
     return;  // Reject messages from other windows
@@ -95,7 +95,7 @@ This prevents other windows/iframes from injecting messages.
 ┌─────────────────────────────────────────────────────────────────┐
 │                     ISOLATED IFRAME (blob:)                      │
 │                                                                  │
-│  CommBridgeClient ←→ IframeWidgetStore ←→ WidgetView/AnyWidget  │
+│  WidgetBridgeClient ←→ WidgetStore ←→ WidgetView/AnyWidget      │
 │                                                                  │
 │  ❌ window.__TAURI__ = undefined                                 │
 │  ❌ window.parent.document → cross-origin error                  │
@@ -109,7 +109,7 @@ This prevents other windows/iframes from injecting messages.
 |-----------|----------|---------|
 | `IsolatedFrame` | `src/components/isolated/isolated-frame.tsx` | React component that manages blob URL lifecycle |
 | `CommBridgeManager` | `src/components/isolated/comm-bridge-manager.ts` | Parent-side: syncs widget state to iframe |
-| `CommBridgeClient` | `src/isolated-renderer/widget-bridge-client.ts` | Iframe-side: receives comm messages |
+| `WidgetBridgeClient` | `src/isolated-renderer/widget-bridge-client.ts` | Iframe-side: receives comm messages (via `createWidgetBridgeClient`) |
 | `frame-html.ts` | `src/components/isolated/frame-html.ts` | Generates bootstrap HTML for iframe |
 | `frame-bridge.ts` | `src/components/isolated/frame-bridge.ts` | Message type definitions |
 
@@ -134,6 +134,10 @@ All communication uses structured `postMessage` calls.
 | `comm_close` | Forward widget destruction |
 | `comm_sync` | Bulk sync all existing models on ready |
 | `bridge_ready` | Signal parent bridge is initialized |
+| `widget_state` | Send widget state to iframe |
+| `ping` | Liveness check |
+| `search` | Trigger in-iframe text search |
+| `search_navigate` | Navigate between search matches |
 
 ### Iframe → Parent
 
@@ -147,6 +151,12 @@ All communication uses structured `postMessage` calls.
 | `link_click` | User clicked a link |
 | `widget_comm_msg` | Widget state update (forward to kernel) |
 | `widget_comm_close` | Widget close request |
+| `pong` | Response to `ping` |
+| `eval_result` | Result of eval'd script |
+| `render_complete` | Content finished rendering |
+| `dblclick` | Double-click event (for cell editing) |
+| `widget_update` | Widget display update |
+| `search_results` | Search match count/position info |
 
 ### Widget Sync Flow
 
@@ -167,12 +177,12 @@ All communication uses structured `postMessage` calls.
 These are security-sensitive and should be reviewed carefully:
 
 ### 1. Sandbox Configuration
-**File:** `src/components/isolated/isolated-frame.tsx:137`
+**File:** `src/components/isolated/isolated-frame.tsx` — `SANDBOX_ATTRS`
 
 The `SANDBOX_ATTRS` constant defines what the iframe can do. Changes here can compromise security.
 
 ### 2. Source Validation
-**File:** `src/components/isolated/frame-html.ts:161`
+**File:** `src/components/isolated/frame-html.ts` — `event.source` check
 
 The `event.source !== window.parent` check prevents message spoofing. This must remain intact.
 
@@ -182,7 +192,7 @@ The `event.source !== window.parent` check prevents message spoofing. This must 
 The `subscribeToModelCustomMessages` method was added to support anywidgets like quak that use custom messages. Without it, widgets would appear to load but not receive kernel data.
 
 ### 4. Type Guard Whitelist
-**File:** `src/components/isolated/frame-bridge.ts:368`
+**File:** `src/components/isolated/frame-bridge.ts` — `isIframeMessage`
 
 The `isIframeMessage` function whitelists valid message types. New message types must be added here.
 
@@ -215,13 +225,10 @@ Tests verify:
 
 Use the test notebook to verify isolation:
 
-```bash
-# Open notebooks/test-isolation.ipynb
-# Run all cells to verify:
-# - window.__TAURI__ is undefined
-# - Parent DOM access throws error
-# - localStorage access throws error
-```
+Open any notebook (e.g. `crates/notebook/fixtures/audit-test/1-vanilla.ipynb`), add a code cell with JavaScript output, and verify:
+- `window.__TAURI__` is undefined in the iframe
+- Parent DOM access throws a cross-origin error
+- `localStorage` access throws a cross-origin error
 
 ### Dev Tools Toggle
 

--- a/contributing/logging.md
+++ b/contributing/logging.md
@@ -46,10 +46,10 @@ RUST_LOG=runtimed::notebook_sync_server=debug cargo xtask dev-daemon
 
 ## TypeScript Logging
 
-Use the `logger` utility from `@/lib/logger` instead of raw `console.*`:
+Use the `logger` utility from `lib/logger` instead of raw `console.*`. The codebase uses relative imports:
 
 ```typescript
-import { logger } from "@/lib/logger";
+import { logger } from "../lib/logger";
 
 logger.debug("[component] Internal detail");
 logger.info("[component] Significant event");

--- a/contributing/nteract-elements.md
+++ b/contributing/nteract-elements.md
@@ -138,7 +138,7 @@ If a component imports from a path that doesn't exist (e.g., `@/components/theme
 
 ### Build errors after update
 
-Run `pnpm run types:check` to catch TypeScript errors. Common issues:
+Run `tsc -b` (or `pnpm build`) to catch TypeScript errors. Common issues:
 - Missing imports (add the dependency)
 - Path mismatches (adjust imports)
 - Type mismatches (check component prop changes)

--- a/contributing/protocol.md
+++ b/contributing/protocol.md
@@ -75,7 +75,7 @@ The **Tauri relay** is a transparent byte pipe for Automerge sync frames — it 
 
 ### 1. Opening a notebook
 
-The frontend invokes a Tauri command (`open_notebook_in_new_window` or `create_notebook`), which causes the relay to connect to the daemon's Unix socket and send a handshake frame.
+The frontend invokes a Tauri command (`open_notebook_in_new_window`), which causes the relay to connect to the daemon's Unix socket and send a handshake frame. New notebook creation goes through Rust menu events (`spawn_new_notebook()` → `create_notebook_window_for_daemon()`), not a frontend `invoke()`.
 
 ### 2. Handshake
 
@@ -108,7 +108,7 @@ The daemon responds with a `NotebookConnectionInfo`:
 
 ### 3. Initial Automerge sync
 
-After the handshake, both sides exchange Automerge sync messages until their documents converge. The frontend starts with an empty document — all notebook state comes from the daemon during this sync phase. A 2-second timeout guards against stalls.
+After the handshake, both sides exchange Automerge sync messages until their documents converge. The frontend starts with an empty document — all notebook state comes from the daemon during this sync phase. A 2-second timeout guards against the initial socket connection; the sync loop itself uses a 100ms per-frame timeout to drain incoming frames.
 
 ### 4. Steady state
 
@@ -189,8 +189,9 @@ Requests are one-shot JSON messages sent from the client to the daemon. Each req
 | `RunAllCells` | Execute all code cells in order |
 | `SaveNotebook` | Persist the Automerge doc to `.ipynb` on disk |
 | `SyncEnvironment` | Hot-install packages into the running kernel's environment |
+| `SendComm { message }` | Send a comm message to the kernel (widget interactions) |
 | `Complete { code, cursor_pos }` | Get code completions from the kernel |
-| `GetHistory { pattern, n }` | Search kernel input history |
+| `GetHistory { pattern, n, unique }` | Search kernel input history |
 | `GetKernelInfo` | Query current kernel status |
 | `GetQueueState` | Query the execution queue |
 
@@ -200,10 +201,9 @@ Requests are one-shot JSON messages sent from the client to the daemon. Each req
 |----------|---------|
 | `KernelLaunched { env_source, ... }` | Kernel started, includes environment origin label |
 | `CellQueued` | Cell added to execution queue |
-| `ExecutionDone` | Cell finished executing |
 | `NotebookSaved` | File written to disk |
-| `CompletionResult { matches, ... }` | Code completion results |
-| `Error { message }` | Something went wrong |
+| `CompletionResult { items, cursor_start, cursor_end }` | Code completion results (`items: Vec<CompletionItem>`) |
+| `Error { error }` | Something went wrong |
 
 ### Request flow through the stack
 
@@ -226,17 +226,17 @@ Broadcasts are daemon-initiated messages pushed to all connected clients for a n
 
 | Broadcast | Purpose |
 |-----------|---------|
-| `KernelStatus { status }` | Kernel state changed: `"starting"`, `"idle"`, `"busy"`, `"error"`, `"shutdown"` |
-| `ExecutionStarted { cell_id }` | A cell began executing |
-| `Output { cell_id, output }` | Cell produced output (stdout, display data, error) |
-| `DisplayUpdate { display_id, output }` | Update an existing output by display ID |
-| `ExecutionDone { cell_id, ... }` | Cell execution completed with timing and execution count |
-| `QueueChanged { queue }` | Execution queue state changed |
-| `KernelError { message }` | Kernel crashed or failed to launch |
+| `KernelStatus { status, cell_id }` | Kernel state changed: `"starting"`, `"idle"`, `"busy"`, `"error"`, `"shutdown"` |
+| `ExecutionStarted { cell_id, execution_count }` | A cell began executing |
+| `Output { cell_id, output_type, output_json, output_index }` | Cell produced output (stdout, display data, error) |
+| `DisplayUpdate { display_id, data, metadata }` | Update an existing output by display ID |
+| `ExecutionDone { cell_id }` | Cell execution completed |
+| `QueueChanged { executing, queued }` | Execution queue state changed |
+| `KernelError { error }` | Kernel crashed or failed to launch |
 | `Comm { msg_type, ... }` | Jupyter comm message (widget open/msg/close) |
 | `FileChanged` | External file change merged into the doc |
-| `EnvProgress { stage, message }` | Environment setup progress |
-| `EnvSyncState { diff }` | Notebook dependencies drifted from launched kernel config |
+| `EnvProgress { env_type, phase }` | Environment setup progress (`phase` is a flattened `EnvProgressPhase`) |
+| `EnvSyncState { in_sync, diff }` | Notebook dependencies drifted from launched kernel config |
 
 ### Broadcast flow
 
@@ -248,24 +248,35 @@ Kernel produces output
   → Frame type 0x03 sent to all connected clients
   → Relay receives, emits "notebook:frame" Tauri event
   → WASM handle.receive_frame() demuxes → Broadcast event
-  → useAutomergeNotebook re-emits as "notebook:broadcast" webview event
-  → useDaemonKernel hook processes the broadcast
+  → useAutomergeNotebook dispatches via emitBroadcast() (in-memory frame bus)
+  → useDaemonKernel subscribeBroadcast() callback processes the broadcast
   → UI updates
 ```
 
-## Tauri Event Bridge
+## Tauri Event Bridge & Frame Bus
 
-The relay and frontend use these Tauri events:
+The relay and frontend use these Tauri events for cross-process communication:
 
 | Event | Direction | Payload | Purpose |
 |-------|-----------|---------|---------|
 | `notebook:frame` | Relay → Frontend | `number[]` (typed frame bytes) | All daemon frames (sync, broadcast, presence) via unified pipe |
-| `notebook:broadcast` | Frontend → Frontend | JSON | Re-emitted by `useAutomergeNotebook` after WASM demux; consumed by `useDaemonKernel`, `useEnvProgress` |
-| `notebook:presence` | Frontend → Frontend | JSON | Re-emitted by `useAutomergeNotebook` after WASM CBOR decode; consumed by `usePresence` |
 | `daemon:ready` | Relay → Frontend | `DaemonReadyPayload` | Connection established, ready to bootstrap |
 | `daemon:disconnected` | Relay → Frontend | — | Connection to daemon lost |
 
 Outgoing frames from the frontend use `invoke("send_frame", { frameData })` where `frameData` is `number[]` with the first byte as the frame type. Only `0x00` (AutomergeSync) and `0x04` (Presence) are valid outgoing types.
+
+### In-memory frame bus
+
+After WASM `receive_frame()` demuxes typed frames, broadcast and presence payloads are dispatched via an in-memory pub/sub bus (`notebook-frame-bus.ts`) instead of Tauri webview events. This avoids an event loop round-trip:
+
+| Function | Purpose |
+|----------|---------|
+| `emitBroadcast(payload)` | Called by `useAutomergeNotebook` after WASM demux for type `0x03` frames |
+| `subscribeBroadcast(cb)` | Used by `useDaemonKernel`, `useEnvProgress` to receive kernel/env broadcasts |
+| `emitPresence(payload)` | Called by `useAutomergeNotebook` after WASM CBOR decode for type `0x04` frames |
+| `subscribePresence(cb)` | Used by `usePresence`, `cursor-registry` to receive remote cursor updates |
+
+All dispatch is synchronous and in-process — no serialization or Tauri event loop hop.
 
 ## Output Storage
 
@@ -281,7 +292,8 @@ Cell outputs use a blob manifest system rather than inline data. When the daemon
 | File | Role |
 |------|------|
 | `crates/runtimed/src/connection.rs` | Frame protocol implementation (length-prefixed, typed frames) |
-| `crates/runtimed/src/protocol.rs` | Message type definitions (Request, Response, Broadcast enums) |
+| `crates/notebook-protocol/src/protocol.rs` | Canonical message type definitions (Request, Response, Broadcast enums) — shared crate |
+| `crates/runtimed/src/protocol.rs` | Daemon-internal protocol types, plus re-exports from `notebook-protocol` |
 | `crates/runtimed/src/notebook_sync_client.rs` | Client-side connection, channels, sync handle |
 | `crates/runtimed/src/notebook_sync_server.rs` | Daemon-side room management, kernel dispatch, sync loop |
 | `crates/runtimed/src/kernel_manager.rs` | Kernel process lifecycle, execution queue, output interception |

--- a/contributing/releasing.md
+++ b/contributing/releasing.md
@@ -12,7 +12,6 @@ All published artifacts share the same version and follow semver:
 | `runt` CLI | GitHub Releases | `crates/runt/Cargo.toml` |
 | `runtimed` daemon | Bundled in app + Python wheel | `crates/runtimed/Cargo.toml` |
 | `runtimed` Python package | PyPI | `python/runtimed/pyproject.toml` |
-| `sidecar` | Bundled in Python wheel | `crates/sidecar/Cargo.toml` |
 
 Standard semver rules apply:
 
@@ -31,7 +30,7 @@ These are just incrementing integers. They evolve independently from each other 
 
 ## Bumping Versions
 
-All five version sources must stay in sync. When preparing a release:
+All four version sources must stay in sync. When preparing a release:
 
 ```bash
 # Update all of these to the same version:
@@ -39,7 +38,6 @@ All five version sources must stay in sync. When preparing a release:
 #   crates/runt/Cargo.toml
 #   crates/notebook/Cargo.toml
 #   crates/notebook/tauri.conf.json
-#   crates/sidecar/Cargo.toml
 #   python/runtimed/pyproject.toml
 
 # Then let Cargo.lock catch up:

--- a/contributing/runtimed.md
+++ b/contributing/runtimed.md
@@ -63,8 +63,7 @@ The daemon provides a single coordinating entity that prewarms environments in t
 The notebook app automatically tries to connect to or start the daemon on launch. If it's not running, the app falls back to in-process prewarming. You don't need to do anything special.
 
 ```rust
-// crates/notebook/src/lib.rs:2408
-runtimed::client::ensure_daemon_running(None).await
+runtimed::client::ensure_daemon_via_sidecar().await
 ```
 
 ### Install daemon from source
@@ -121,7 +120,7 @@ crates/runtimed/
 │   ├── main.rs                  # CLI entry point (run, install, status, etc.)
 │   ├── daemon.rs                # Daemon state, pool management, connection routing
 │   ├── connection.rs            # Unified framing, Handshake enum, send/recv helpers
-│   ├── protocol.rs              # Request/Response enums, BlobRequest/BlobResponse
+│   ├── protocol.rs              # Request/Response enums, BlobRequest/BlobResponse (re-exported from notebook-protocol crate)
 │   ├── client.rs                # PoolClient for pool operations
 │   ├── singleton.rs             # File-based locking for single instance
 │   ├── service.rs               # Cross-platform service installation
@@ -139,6 +138,7 @@ crates/runtimed/
 │   ├── project_file.rs          # Project file detection (pyproject.toml, pixi.toml, etc.)
 │   ├── comm_state.rs            # Comm message state for ipywidgets
 │   ├── output_store.rs          # Output persistence and retrieval
+│   ├── markdown_assets.rs       # Markdown image/asset resolution and rewriting
 │   ├── (metadata via notebook_doc) # `notebook_doc::metadata` re-exported as `notebook_metadata`
 │   ├── stream_terminal.rs       # Stream terminal output handling
 │   └── terminal_size.rs         # Terminal size tracking

--- a/contributing/testing.md
+++ b/contributing/testing.md
@@ -19,7 +19,10 @@ Configuration: `vitest.config.ts`
 ```ts
 test: {
   environment: "jsdom",
-  include: ["src/**/__tests__/**/*.test.{ts,tsx}"],
+  include: [
+    "src/**/__tests__/**/*.test.{ts,tsx}",
+    "apps/notebook/src/**/__tests__/**/*.test.{ts,tsx}",
+  ],
   globals: true,
   setupFiles: ["./src/test-setup.ts"],
 }
@@ -41,7 +44,7 @@ import { AnsiOutput } from "../ansi-output";
 
 describe("AnsiOutput", () => {
   it("renders plain text", () => {
-    const { container } = render(<AnsiOutput text="hello" />);
+    const { container } = render(<AnsiOutput>{"hello"}</AnsiOutput>);
     expect(container.textContent).toBe("hello");
   });
 
@@ -49,8 +52,8 @@ describe("AnsiOutput", () => {
     ["red", "\x1b[31mred\x1b[0m"],
     ["green", "\x1b[32mgreen\x1b[0m"],
   ])("renders %s ANSI color", (_, text) => {
-    const { container } = render(<AnsiOutput text={text} />);
-    expect(container.querySelector(".ansi-red")).toBeTruthy();
+    const { container } = render(<AnsiOutput>{text}</AnsiOutput>);
+    expect(container.querySelector(".ansi-red-fg")).toBeTruthy();
   });
 });
 ```
@@ -72,7 +75,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_runtime_serialization() {
+    fn test_runtime_serde() {
         let runtime = Runtime::Python;
         let json = serde_json::to_string(&runtime).unwrap();
         assert_eq!(json, "\"python\"");
@@ -163,7 +166,6 @@ Configuration in `conftest.py` defines markers and daemon detection.
 | `test_session_unit.py` | Unit | No |
 | `test_daemon_integration.py` | Integration | Yes |
 | `test_ipython_bridge.py` | Integration | Yes |
-| `test_sidecar.py` | Integration | Yes |
 | `test_binary.py` | Binary/CLI | No |
 
 **Running tests:**

--- a/contributing/typescript-bindings.md
+++ b/contributing/typescript-bindings.md
@@ -20,9 +20,11 @@ Rust types use `#[derive(TS)]` and `#[ts(export)]` attributes:
 ```rust
 use ts_rs::TS;
 
-#[derive(Debug, Clone, Serialize, Deserialize, TS)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, JsonSchema, TS)]
+#[serde(rename_all = "lowercase")]
 #[ts(export)]
 pub enum ThemeMode {
+    #[default]
     System,
     Light,
     Dark,
@@ -77,7 +79,7 @@ The ts-rs procedural macro exports types during test compilation. Generated file
 1. Add the `ts-rs` dependency to your crate's `Cargo.toml`:
    ```toml
    [dependencies]
-   ts-rs = { version = "10", features = ["serde-compat"] }
+   ts-rs = { version = "12", features = ["serde-compat"] }
    ```
 
 2. Annotate your type:

--- a/contributing/ui.md
+++ b/contributing/ui.md
@@ -23,11 +23,10 @@ pnpm dlx shadcn@latest add dialog -yo
 │   ├── components/ui/       # 23 shared shadcn components
 │   └── lib/utils.ts         # cn() utility
 └── apps/
-    ├── notebook/            # Uses @/components/ui/* via path alias
-    └── sidecar/             # Uses @/components/ui/* via path alias
+    └── notebook/            # Uses @/components/ui/* via path alias
 ```
 
-Both apps access shared components via the `@/` path alias, which resolves to `../../src/` in their tsconfig.json files.
+The notebook app accesses shared components via the `@/` path alias, which resolves to `../../src/` in its tsconfig.json.
 
 ## Key Points
 

--- a/contributing/widget-development.md
+++ b/contributing/widget-development.md
@@ -61,6 +61,7 @@ interface WidgetStore {
   createModel(commId: string, state: Record<string, unknown>, buffers?: ArrayBuffer[]): void;
   updateModel(commId: string, statePatch: Record<string, unknown>, buffers?: ArrayBuffer[]): void;
   deleteModel(commId: string): void;
+  wasModelClosed(commId: string): boolean;
 
   // Fine-grained subscriptions
   subscribeToKey(modelId: string, key: string, callback: (value: unknown) => void): () => void;
@@ -71,18 +72,16 @@ interface WidgetStore {
 }
 ```
 
-Usage in components:
+Usage in components via the `useWidgetModelValue` hook from `widget-store-context.tsx`:
 
 ```tsx
-import { useSyncExternalStore } from "react";
+import { useWidgetModelValue } from "../widget-store-context";
 
-function useWidgetValue(store: WidgetStore, modelId: string, key: string) {
-  return useSyncExternalStore(
-    (callback) => store.subscribeToKey(modelId, key, callback),
-    () => store.getModel(modelId)?.state[key]
-  );
-}
+// Inside a widget component
+const value = useWidgetModelValue(modelId, "value");
 ```
+
+Under the hood this calls `useSyncExternalStore` with `subscribeToKey` and `getModel`.
 
 ## Comm Bridge Protocol
 
@@ -107,11 +106,12 @@ The CommBridgeManager:
 ```tsx
 // src/components/widgets/controls/my-widget.tsx
 import type { WidgetComponentProps } from "../widget-registry";
+import { useWidgetModelValue, useWidgetStoreRequired } from "../widget-store-context";
 
 export function MyWidget({ modelId }: WidgetComponentProps) {
-  // Access widget store via context or props
-  const value = useWidgetValue(modelId, "value");
-  const description = useWidgetValue(modelId, "description");
+  const { sendUpdate } = useWidgetStoreRequired();
+  const value = useWidgetModelValue(modelId, "value");
+  const description = useWidgetModelValue(modelId, "description");
 
   const handleChange = (newValue: number) => {
     // Send update back to kernel
@@ -204,8 +204,9 @@ display(slider)
 Enable widget debug logging:
 
 ```typescript
-// In browser console
-localStorage.setItem("DEBUG", "widgets:*");
+// In browser console — enables all frontend debug logging
+localStorage.setItem("runt:debug", "true");
+// Reload the page for it to take effect
 ```
 
 Watch for comm messages in the daemon logs:

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -33,7 +33,7 @@ The simplest way to manage packages. Dependencies are stored directly in the not
 
 **Adding packages**: Use the dependency panel in the sidebar to add, remove, or sync packages. UV dependencies use pip-style package names (`pandas`, `numpy>=2.0`). Conda dependencies support conda channels.
 
-**How it's stored**: Dependencies live in the notebook's JSON metadata under `metadata.uv.dependencies` (for UV/pip packages) or `metadata.conda.dependencies` (for conda packages).
+**How it's stored**: Dependencies live in the notebook's JSON metadata under `metadata.runt.uv.dependencies` (for UV/pip packages) or `metadata.runt.conda.dependencies` (for conda packages). Legacy notebooks may use `metadata.uv` / `metadata.conda` directly — these are still read as fallbacks.
 
 ## Working with pyproject.toml
 
@@ -64,8 +64,9 @@ The dependency panel shows pixi dependencies and offers an "Import to notebook" 
 Deno notebooks use the Deno runtime for TypeScript/JavaScript. Unlike Python, Deno manages its own dependencies through import maps and URL imports, so there's no separate environment to create.
 
 **How Deno is obtained:**
-- nteract Desktop first checks if `deno` is on your PATH
-- If not found, nteract Desktop automatically installs Deno from conda-forge (stored in `~/.cache/runt/tools/`)
+- nteract Desktop first checks if a system `deno` 2.x+ is on your PATH
+- If not found, it downloads Deno from GitHub releases (primary method)
+- As a last resort, it falls back to installing Deno from conda-forge via rattler (stored in `~/.cache/runt/tools/`)
 
 This means Deno notebooks work out of the box — you don't need to install Deno manually.
 

--- a/docs/python-bindings.md
+++ b/docs/python-bindings.md
@@ -60,8 +60,10 @@ session = runtimed.Session(notebook_id="my-notebook")
 
 ```python
 session.connect()                    # Connect to daemon (auto-called by start_kernel)
-session.start_kernel()               # Launch Python kernel
+session.start_kernel()               # Launch Python kernel (env_source="auto", notebook_path=None)
 session.start_kernel(kernel_type="deno")  # Launch Deno kernel
+session.start_kernel(env_source="uv:prewarmed")  # Explicit env source
+session.start_kernel(notebook_path="/path/to/nb.ipynb")  # Hint for project file detection
 session.interrupt()                  # Interrupt running execution
 session.shutdown_kernel()            # Stop the kernel
 ```
@@ -174,7 +176,9 @@ with runtimed.Session() as session:
 | `notebook_id` | `str` | Unique identifier for this notebook |
 | `is_connected` | `bool` | Whether connected to daemon |
 | `kernel_started` | `bool` | Whether kernel is running |
+| `kernel_type` | `str \| None` | Current kernel type ("python", "deno", or None if not started) |
 | `env_source` | `str \| None` | Environment source (e.g., "uv:prewarmed") |
+| `connection_info` | `dict \| None` | Kernel connection info (ports, transport, key) when kernel is running |
 
 ## AsyncSession API
 
@@ -509,27 +513,4 @@ Common error scenarios:
 | `RUNTIMED_WORKSPACE_PATH` | Use dev daemon for this worktree |
 | `RUNTIMED_SOCKET_PATH` | Override daemon socket path |
 
-## Sidecar (Rich Output Viewer)
 
-The package also includes a sidecar launcher for rich output display:
-
-```python
-from runtimed import sidecar
-
-# In a Jupyter kernel - auto-detects connection file
-s = sidecar()
-
-# In terminal IPython - creates IOPub bridge
-s = sidecar()
-
-# Explicit connection file
-s = sidecar("/path/to/kernel-123.json")
-
-# Check status
-print(s.running)  # True if sidecar process is alive
-
-# Cleanup
-s.close()
-```
-
-The sidecar provides a GUI window that displays rich outputs (plots, HTML, images) from kernel execution.

--- a/docs/runtimed.md
+++ b/docs/runtimed.md
@@ -114,6 +114,7 @@ Length-prefixed binary framing over a single Unix socket (Unix) or named pipe (W
 | `FlushPool` | `Flushed` | Drain and rebuild all envs |
 | `InspectNotebook { notebook_id }` | `NotebookState { ... }` | Debug notebook sync state |
 | `ListRooms` | `RoomsList { rooms }` | List active notebook sync rooms |
+| `ShutdownNotebook { notebook_id }` | `NotebookShutdown { found }` | Shutdown kernel and evict room |
 
 ### Settings.json file watcher
 
@@ -136,6 +137,10 @@ runt daemon restart    # Restart the daemon
 runt daemon logs -f    # Tail daemon logs
 runt daemon install    # Install as system service (system daemon only)
 runt daemon uninstall  # Uninstall system service (system daemon only)
+runt daemon doctor     # Diagnose installation issues (--fix to auto-repair)
+runt daemon flush      # Flush and rebuild all pooled environments
+runt daemon shutdown   # Request graceful daemon shutdown via IPC
+runt daemon ping       # Health-check the running daemon
 ```
 
 **Machine-readable output** (`--json`):
@@ -233,14 +238,20 @@ Cell ordering uses fractional indexing via the `position` field. Cells are sorte
 
 ### Room architecture
 
-```rust
-pub struct NotebookRoom {
-    pub doc: Arc<RwLock<NotebookDoc>>,
-    pub changed_tx: broadcast::Sender<()>,
-    pub persist_path: PathBuf,
-    pub active_peers: AtomicUsize,
-}
-```
+`NotebookRoom` (defined in `crates/runtimed/src/notebook_sync_server.rs`) has 20+ fields — key ones:
+
+| Field | Type | Role |
+|-------|------|------|
+| `doc` | `Arc<RwLock<NotebookDoc>>` | Canonical Automerge document |
+| `kernel` | `Arc<Mutex<Option<RoomKernel>>>` | Daemon-owned kernel process |
+| `blob_store` | `Arc<BlobStore>` | Content-addressed output storage |
+| `trust_state` | `Arc<RwLock<TrustState>>` | HMAC trust for auto-launch |
+| `notebook_path` | `PathBuf` | Notebook file path (= notebook_id) |
+| `comm_state` | `Arc<CommState>` | Active widget comm channels |
+| `presence` | `Arc<RwLock<PresenceState>>` | Cursor/selection peer state |
+| `persist_tx` | `watch::Sender<Option<Vec<u8>>>` | Debounced persistence channel |
+
+See source for full definition (includes `working_dir`, `nbformat_attachments`, `auto_launch_at`, `last_self_write`, file watcher shutdown, etc.).
 
 **Room lifecycle**:
 1. First window opens notebook -> daemon acquires room via `get_or_create_room()`, loading persisted doc from disk (or creating fresh)
@@ -378,8 +389,20 @@ Helpers: `send_frame()` / `recv_frame()` for raw binary, `send_json_frame()` / `
 pub enum Handshake {
     Pool,
     SettingsSync,
-    NotebookSync { notebook_id: String },
+    NotebookSync {
+        notebook_id: String,
+        protocol: Option<String>,        // version negotiation (v2 = typed frames)
+        working_dir: Option<String>,      // for untitled notebook project detection
+        initial_metadata: Option<String>, // kernelspec JSON for auto-launch
+    },
     Blob,
+    PoolStateSubscribe,                   // read-only pool error broadcasts
+    OpenNotebook { path: String },        // daemon loads from disk, returns NotebookConnectionInfo
+    CreateNotebook {                      // daemon creates empty room
+        runtime: String,                  // "python" or "deno"
+        working_dir: Option<String>,
+        notebook_id: Option<String>,      // restore hint for previous session
+    },
 }
 ```
 
@@ -391,6 +414,9 @@ The daemon's `route_connection()` validates the preamble first via `recv_preambl
 | `SettingsSync` | Automerge sync messages | Long-lived, bidirectional |
 | `NotebookSync` | Automerge sync messages, room-routed by `notebook_id` | Long-lived, bidirectional |
 | `Blob` | Binary blob writes | Short-lived |
+| `PoolStateSubscribe` | Server pushes `DaemonBroadcast` messages | Long-lived, read-only |
+| `OpenNotebook` | Returns `NotebookConnectionInfo`, then notebook sync | Long-lived |
+| `CreateNotebook` | Returns `NotebookConnectionInfo`, then notebook sync | Long-lived |
 
 ### Blob channel protocol
 
@@ -481,7 +507,7 @@ Outputs flow through the Automerge doc, not Tauri events:
 4. Frontend receives `notebook:frame` → WASM `receive_frame()` demuxes and merges into local doc
 5. `materialize-cells.ts` converts the updated doc into React cell state
 
-The `onOutput` callback in `App.tsx` is set to a no-op (`() => {}`) — outputs are rendered from Automerge sync, not broadcasts. The daemon still sends `Output` broadcasts and `useDaemonKernel.ts` still processes them (resolves blob manifests), but the resolved output is discarded by the no-op callback.
+The `onOutput` callback is omitted entirely from the `useDaemonKernel` call — when undefined, the hook skips Output broadcast processing (including blob resolution). Outputs are rendered from Automerge sync, not broadcasts.
 
 ### Save and format-on-save
 
@@ -742,14 +768,22 @@ runtimed (daemon)
 
 **Why both?** Automerge provides persistence and late-joiner sync. Broadcasts provide sub-50ms UI updates for kernel status during execution.
 
-Broadcast types:
-- `KernelStatus { status }` — idle/busy/starting
-- `Output { cell_id, output }` — daemon sends these and `useDaemonKernel.ts` processes them, but the `onOutput` rendering callback is a no-op; outputs are rendered from Automerge sync instead
+Broadcast types (see `NotebookBroadcast` in `crates/notebook-protocol/src/protocol.rs`):
+- `KernelStatus { status, cell_id }` — idle/busy/starting/error/shutdown, with optional triggering cell
 - `ExecutionStarted { cell_id, execution_count }` — clear outputs, show spinner
-- `ClearOutputs { cell_id }` — explicit clear request
-- `DisplayUpdate { cell_id, output }` — update_display_data (widget progress bars)
+- `Output { cell_id, output_type, output_json, output_index }` — streamed output; `output_index` distinguishes append vs update-in-place
+- `DisplayUpdate { display_id, data, metadata }` — update_display_data (widget progress bars); keyed by `display_id`, no `cell_id`
+- `ExecutionDone { cell_id }` — execution completed
+- `OutputsCleared { cell_id }` — outputs cleared for a cell
+- `QueueChanged { executing, queued }` — execution queue state
+- `KernelError { error }` — launch failure or crash
+- `Comm { msg_type, content, buffers }` — ipywidgets protocol (comm_open/msg/close)
+- `CommSync { comms }` — initial widget state for newly connected clients
+- `FileChanged { cells, metadata }` — external .ipynb edits merged into Automerge doc
+- `EnvProgress { env_type, phase }` — rich environment setup progress (repodata, solve, download, link)
+- `EnvSyncState { in_sync, diff }` — notebook metadata vs launched config drift
 
-> **Note:** `Output` broadcasts are still sent by the daemon and processed by `useDaemonKernel.ts` (blob resolution runs), but the `onOutput` rendering callback in `App.tsx` is a no-op to avoid duplicates with Automerge-synced outputs (no dedup IDs). All output **rendering** is driven by the Automerge sync channel (`notebook:frame` → WASM `receive_frame()` → `materializeCells`). Issue #557 was resolved by making sync the sole output rendering path.
+> **Note:** `Output` broadcasts are still sent by the daemon, but `onOutput` is omitted from the `useDaemonKernel` call so the hook skips broadcast processing entirely. All output **rendering** is driven by the Automerge sync channel (`notebook:frame` → WASM `receive_frame()` → `materializeCells`). Issue #557 was resolved by making sync the sole output rendering path.
 
 ### Project file auto-detection
 
@@ -855,9 +889,9 @@ For output manifests, the `output_type` field provides structural versioning. Ne
 
 ### Output Flow
 
-Output **rendering** is driven exclusively by Automerge sync: the daemon writes outputs to the notebook doc, produces a sync message, and the Tauri relay forwards raw bytes to the frontend WASM where `materialize-cells.ts` renders them. The daemon still sends `Output` broadcasts (and `useDaemonKernel.ts` processes them), but the `onOutput` rendering callback is a no-op.
+Output **rendering** is driven exclusively by Automerge sync: the daemon writes outputs to the notebook doc, produces a sync message, and the Tauri relay forwards raw bytes to the frontend WASM where `materialize-cells.ts` renders them. The `onOutput` callback is omitted from the `useDaemonKernel` call, so the hook skips Output broadcast processing entirely (including blob resolution).
 
-Output latency is bounded by the Automerge sync round-trip rather than direct broadcast delivery. Re-enabling `onOutput` for lower-latency streaming would require dedup IDs to prevent duplicates with sync-delivered outputs. Issue #557 was resolved by making sync the sole output rendering path.
+Output latency is bounded by the Automerge sync round-trip rather than direct broadcast delivery. Providing an `onOutput` callback would re-enable broadcast processing for lower-latency streaming, but would require dedup IDs to prevent duplicates with sync-delivered outputs. Issue #557 was resolved by making sync the sole output rendering path.
 
 ### Multi-Window Widget Sync (#276)
 
@@ -885,4 +919,4 @@ Widgets only render in the window that was active when the widget was created. S
 | **5** | Local-first Automerge notebook sync | Implemented — frontend owns local Automerge doc via `runtimed-wasm` WASM, cell mutations happen in WASM, sync to daemon via binary messages |
 | **6** | Output store (manifests, ContentRef, inlining) | Implemented (PR #237) |
 | **7** | ipynb round-tripping | Future (outputs already persist in nbformat) |
-| **8** | Daemon-owned kernels | Implemented (PRs #258, #259, #267, #271, #275) — widgets work single-window |
+| **8** | Daemon-owned kernels | Implemented (PRs #258, #259, #265, #267, #271) — widgets work single-window |

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -11,6 +11,8 @@ nteract Desktop settings control default behavior for new notebooks, appearance,
 | Default Python env | uv, conda | uv | Synced (Automerge) + settings file |
 | Default uv packages | list of strings | (empty) | Synced (Automerge) + settings file |
 | Default conda packages | list of strings | (empty) | Synced (Automerge) + settings file |
+| Keep alive secs | integer | 300 | Synced (Automerge) + settings file |
+| Onboarding completed | boolean | false | Synced (Automerge) + settings file |
 
 ## How Settings Sync Works
 
@@ -33,6 +35,8 @@ ROOT/
   theme: "system"
   default_runtime: "python"
   default_python_env: "uv"
+  keep_alive_secs: 300
+  onboarding_completed: false
   uv/                                         ← nested Map
     default_packages: List["numpy", "pandas"] ← List of Str
   conda/                                      ← nested Map
@@ -71,7 +75,7 @@ Example:
 
 ### JSON Schema
 
-The settings structs derive `schemars::JsonSchema`. Both `SyncedSettings` (in runtimed) and `AppSettings` (in the notebook crate) serialize to the same JSON schema.
+The settings struct derives `schemars::JsonSchema`. `SyncedSettings` (in runtimed) defines the canonical schema used by both the daemon and the notebook app.
 
 ## Theme
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -28,6 +28,7 @@ The doctor checks:
 - **Installed binary** - Is the daemon binary present?
 - **Quarantine** (macOS) - Is Gatekeeper blocking the binary?
 - **Service config** - Is the launchd/systemd service configured?
+- **Plist HOME env** (macOS) - Does the launchd plist set the HOME environment variable?
 - **Socket file** - Can the app communicate with the daemon?
 - **Daemon state** - Is the daemon actually running?
 
@@ -35,6 +36,12 @@ If issues are found, run with `--fix` to attempt automatic repair:
 
 ```bash
 /Applications/nteract.app/Contents/MacOS/runt doctor --fix
+```
+
+For machine-readable output, use `--json`:
+
+```bash
+runt doctor --json
 ```
 
 ## Common Issues

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -8,7 +8,7 @@ This guide covers ipywidgets and anywidget support in nteract Desktop.
 
 | Category | Examples | Status |
 |----------|----------|--------|
-| **ipywidgets core** | IntSlider, Button, VBox, Dropdown | ✅ 54+ widget types |
+| **ipywidgets core** | IntSlider, Button, VBox, Dropdown | ✅ 57+ widget types |
 | **anywidget** | quak, drawdata, tqdm | ✅ Full AFM support |
 | **ipycanvas** | Canvas, MultiCanvas | ✅ Custom implementation (tested with 0.14.3) |
 | **Display outputs** | Plotly, Vega-Lite, HTML, images | ✅ Via display |
@@ -110,11 +110,13 @@ nteract Desktop runs widgets in isolated iframes for security. The architecture 
 
 ```
 Parent Window (Tauri app)
-├── WidgetStore (manages state)
-├── CommBridgeManager (routes messages)
-└── PostMessage ↔ Iframe
+├── WidgetStoreProvider (React context, manages WidgetStore)
+│   └── OutputArea (per-cell)
+│       ├── CommBridgeManager (instantiated per-iframe)
+│       └── PostMessage ↔ Iframe
 
 Isolated Iframe (blob: URL, sandboxed)
+├── IframeWidgetStoreProvider (proxies via WidgetBridgeClient)
 ├── Widget rendering
 └── No access to Tauri APIs
 ```

--- a/python/nteract/README.md
+++ b/python/nteract/README.md
@@ -110,7 +110,8 @@ claude mcp add nteract -- env RUNTIMED_SOCKET_PATH="$HOME/Library/Caches/runt-ni
 
 | Tool | Description |
 |------|-------------|
-| `connect_notebook` | Connect to a notebook by ID |
+| `list_notebooks` | List all open notebook sessions |
+| `join_notebook` | Join an existing notebook session by ID |
 | `open_notebook` | Open an existing .ipynb file |
 | `create_notebook` | Create a new notebook |
 | `save_notebook` | Save notebook to disk as .ipynb file |
@@ -120,16 +121,15 @@ claude mcp add nteract -- env RUNTIMED_SOCKET_PATH="$HOME/Library/Caches/runt-ni
 | `append_source` | Stream tokens into a cell (ideal for LLM output) |
 | `get_cell` | Get a cell by ID with outputs |
 | `get_all_cells` | View all cells in the notebook |
-| `set_cell_source` | Update a cell's source code |
+| `set_cell_source` | Replace a cell's entire source code |
+| `replace_match` | Targeted literal text find-and-replace in a cell |
+| `replace_regex` | Regex-based find-and-replace in a cell |
+| `set_cell_type` | Change a cell's type (code, markdown, or raw) |
 | `move_cell` | Reorder a cell within the notebook |
 | `clear_outputs` | Clear a cell's outputs |
 | `delete_cell` | Remove a cell from the notebook |
-| `start_kernel` | Start a Python kernel |
+| `interrupt_kernel` | Interrupt the currently executing cell |
 | `restart_kernel` | Restart kernel with updated dependencies |
-| `get_kernel_status` | Check kernel state |
-| `get_queue_state` | See what's executing and what's queued |
-| `complete_code` | Get code completions from the kernel |
-| `get_history` | Search kernel execution history |
 | `add_dependency` | Add a Python package dependency |
 | `remove_dependency` | Remove a dependency |
 | `get_dependencies` | List current dependencies |

--- a/python/runtimed/README.md
+++ b/python/runtimed/README.md
@@ -100,8 +100,8 @@ client.list_rooms()  # Active notebooks
 
 ## Requirements
 
-- runtimed daemon running (`runt daemon start`)
-- Python 3.9+
+- runtimed daemon running (see [CLAUDE.md](../../CLAUDE.md) — use `cargo xtask dev-daemon` for development or `cargo xtask install-daemon` for the system service)
+- Python 3.10+
 
 ## Documentation
 


### PR DESCRIPTION
Systematic audit of all 33 non-agent markdown files against the actual codebase. 67 issues found, 22 files fixed.

**Three dominant themes:**

1. **Sidecar ghost references** — removed from the codebase but still haunting 7 docs files. All cleaned up.
2. **Protocol field names** — `contributing/protocol.md` had systematically wrong field names for requests, responses, and broadcasts. All corrected against `notebook-protocol` crate.
3. **Missing crates** — `notebook-protocol` and `notebook-sync` weren't in any diagrams or file trees. Added throughout.

**Other fixes across the 22 files:**
- Removed phantom `apps/sidecar/`, `crates/sidecar/` from trees and diagrams
- Fixed RELEASING.md: tag format (timestamp not SHA), artifact names, platform coverage
- Rewrote `python/nteract/README.md` tool table (6 listed tools didn't exist, 5 real tools missing)
- Fixed ts-rs version 10→12, Python version 3.9→3.10
- Added `keep_alive_secs` and `onboarding_completed` to settings docs
- Removed fabricated sidecar Python API section from `docs/python-bindings.md`
- Fixed `useWidgetValue`→`useWidgetModelValue`, `CommBridgeClient`→`WidgetBridgeClient`
- Fixed stale `ensure_daemon_running` ref (now `ensure_daemon_via_sidecar`)
- Updated e2e docs: timeouts 30s→60s, fixed phantom spec files, recategorized fixture specs
- Completed iframe message type tables (was missing ~10 message types)
- Fixed `AnsiOutput` test example (uses `children` prop, not `text`)

_PR submitted by @rgbkrk's agent Quill, via Zed_