### PR TITLE
feat: add support for one-shot dev setup

### DIFF
--- a/.zed/tasks.json
+++ b/.zed/tasks.json
@@ -15,7 +15,7 @@
   },
   {
     "label": "Dev App",
-    "command": "export RUNTIMED_VITE_PORT=$((5100 + $(echo -n \"$ZED_WORKTREE_ROOT\" | cksum | cut -d' ' -f1) % 4900)); echo \"Vite port: $RUNTIMED_VITE_PORT\"; cargo xtask dev",
+    "command": "export RUNTIMED_VITE_PORT=$((5100 + $(echo -n \"$ZED_WORKTREE_ROOT\" | cksum | cut -d' ' -f1) % 4900)); echo \"Vite port: $RUNTIMED_VITE_PORT\"; cargo xtask notebook",
     "env": {
       "RUNTIMED_DEV": "1",
       "RUST_LOG": "debug",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,7 +102,9 @@ Each git worktree can run its own isolated daemon during development, preventing
 cargo xtask dev-daemon
 
 # Terminal 2: Run the notebook app
-cargo xtask dev              # Notebook connects to workspace daemon
+cargo xtask notebook         # Notebook connects to workspace daemon
+# or
+cargo xtask dev              # One-shot setup + daemon + app
 runt daemon status           # Shows workspace info
 runt daemon list-worktrees   # See all workspace daemons
 ```
@@ -114,7 +116,7 @@ runt daemon list-worktrees   # See all workspace daemons
 RUNTIMED_DEV=1 cargo xtask dev-daemon
 
 # Terminal 2
-RUNTIMED_DEV=1 cargo xtask dev
+RUNTIMED_DEV=1 cargo xtask notebook
 RUNTIMED_DEV=1 runt daemon status
 ```
 
@@ -140,7 +142,7 @@ When working in a Conductor workspace developing nteract/desktop, the xtask comm
 | `CONDUCTOR_WORKSPACE_NAME` | `RUNTIMED_WORKSPACE_NAME` | Human-readable workspace name for display |
 | `CONDUCTOR_PORT` | (used directly) | Vite dev server port (avoids conflicts between workspaces) |
 
-**Important:** The translation only happens when running `cargo xtask dev` or `cargo xtask dev-daemon`. This allows using Conductor for unrelated projects without interfering with the system daemon.
+**Important:** The translation only happens when running `cargo xtask dev`, `cargo xtask notebook`, or `cargo xtask dev-daemon`. This allows using Conductor for unrelated projects without interfering with the system daemon.
 
 **Interacting with the daemon:**
 
@@ -209,7 +211,7 @@ For production use, install the daemon as a system service:
 cargo xtask install-daemon
 ```
 
-`cargo xtask dev` and `cargo xtask build` do **not** reinstall the daemon. If you're changing daemon code (settings, sync, environments), you must run `cargo xtask install-daemon` separately to test your changes.
+`cargo xtask dev`, `cargo xtask notebook`, and `cargo xtask build` do **not** reinstall the daemon. If you're changing daemon code (settings, sync, environments), you must run `cargo xtask install-daemon` separately to test your changes.
 
 For faster iteration when only changing Rust code, use `cargo xtask build --rust-only` to skip frontend rebuild (requires an initial `cargo xtask build` first).
 

--- a/README.md
+++ b/README.md
@@ -108,14 +108,14 @@ sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libxdo-dev
 ### Quick start
 
 ```bash
-pnpm install
-cargo xtask build
+cargo xtask notebook
 ```
 
 ### Development workflows
 
 | Workflow | Command | Use when |
 |----------|---------|----------|
+| One-shot setup + dev | `cargo xtask notebook` | First-time setup plus daemon + app in one command |
 | Hot reload | `cargo xtask dev` | Iterating on React UI |
 | Standalone Vite | `cargo xtask vite` | Multi-window testing (Vite survives window closes) |
 | Attach to Vite | `cargo xtask dev --attach` | Connect Tauri to already-running Vite |
@@ -124,6 +124,10 @@ cargo xtask build
 | Run bundled | `cargo xtask run notebook.ipynb` | Run standalone binary |
 | Release .app | `cargo xtask build-app` | Testing app bundle locally |
 | Release DMG | `cargo xtask build-dmg` | Distribution (usually CI) |
+
+`cargo xtask notebook` runs the first-time bootstrap (`pnpm install` + `cargo xtask build`),
+starts the per-worktree dev daemon, waits for it to be ready, and then launches the
+notebook app. For repeat launches, use `cargo xtask notebook --skip-install --skip-build`.
 
 ### Build order
 

--- a/README.md
+++ b/README.md
@@ -108,26 +108,26 @@ sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libxdo-dev
 ### Quick start
 
 ```bash
-cargo xtask notebook
+cargo xtask dev
 ```
 
 ### Development workflows
 
 | Workflow | Command | Use when |
 |----------|---------|----------|
-| One-shot setup + dev | `cargo xtask notebook` | First-time setup plus daemon + app in one command |
-| Hot reload | `cargo xtask dev` | Iterating on React UI |
+| One-shot setup + dev | `cargo xtask dev` | First-time setup plus daemon + app in one command |
+| Hot reload | `cargo xtask notebook` | Iterating on React UI |
 | Standalone Vite | `cargo xtask vite` | Multi-window testing (Vite survives window closes) |
-| Attach to Vite | `cargo xtask dev --attach` | Connect Tauri to already-running Vite |
+| Attach to Vite | `cargo xtask notebook --attach` | Connect Tauri to already-running Vite |
 | Debug build | `cargo xtask build` | Full debug build (frontend + rust) |
 | Rust-only build | `cargo xtask build --rust-only` | Rebuild rust, reuse existing frontend |
 | Run bundled | `cargo xtask run notebook.ipynb` | Run standalone binary |
 | Release .app | `cargo xtask build-app` | Testing app bundle locally |
 | Release DMG | `cargo xtask build-dmg` | Distribution (usually CI) |
 
-`cargo xtask notebook` runs the first-time bootstrap (`pnpm install` + `cargo xtask build`),
+`cargo xtask dev` runs the first-time bootstrap (`pnpm install` + `cargo xtask build`),
 starts the per-worktree dev daemon, waits for it to be ready, and then launches the
-notebook app. For repeat launches, use `cargo xtask notebook --skip-install --skip-build`.
+notebook app. For repeat launches, use `cargo xtask dev --skip-install --skip-build`.
 
 ### Build order
 

--- a/contributing/development.md
+++ b/contributing/development.md
@@ -4,10 +4,10 @@
 
 | Task | Command |
 |------|---------|
-| One-shot notebook setup | `cargo xtask notebook` |
-| Start dev server | `cargo xtask dev` |
+| One-shot notebook setup | `cargo xtask dev` |
+| Start dev server | `cargo xtask notebook` |
 | Standalone Vite | `cargo xtask vite` |
-| Attach to Vite | `cargo xtask dev --attach` |
+| Attach to Vite | `cargo xtask notebook --attach` |
 | Full debug build | `cargo xtask build` |
 | Rust-only rebuild | `cargo xtask build --rust-only` |
 | Run bundled binary | `cargo xtask run` |
@@ -19,13 +19,13 @@
 
 ## Choosing a Workflow
 
-### `cargo xtask notebook` — One Command Setup + Dev
+### `cargo xtask dev` — One Command Setup + Dev
 
 Best for first-time local setup or when you want the daemon and notebook app to
 come up together.
 
 ```bash
-cargo xtask notebook
+cargo xtask dev
 ```
 
 This command:
@@ -38,18 +38,18 @@ This command:
 For faster repeat launches:
 
 ```bash
-cargo xtask notebook --skip-install --skip-build
+cargo xtask dev --skip-install --skip-build
 ```
 
-### `cargo xtask dev` — Hot Reload
+### `cargo xtask notebook` — Hot Reload
 
 Best for UI/React development. Uses Vite dev server on port 5174. Changes to React components hot-reload instantly.
 
 ```bash
-cargo xtask dev
+cargo xtask notebook
 ```
 
-### `cargo xtask vite` + `dev --attach` — Multi-Window Testing
+### `cargo xtask vite` + `notebook --attach` — Multi-Window Testing
 
 When testing with multiple notebook windows, closing the first Tauri window normally kills the Vite server. To avoid this:
 
@@ -58,7 +58,7 @@ When testing with multiple notebook windows, closing the first Tauri window norm
 cargo xtask vite
 
 # Terminal 2+: Attach Tauri to existing Vite
-cargo xtask dev --attach
+cargo xtask notebook --attach
 ```
 
 Now you can close and reopen Tauri windows without losing Vite. This is useful for:
@@ -153,7 +153,9 @@ In production, the Tauri app auto-installs and manages the system daemon. In dev
 cargo xtask dev-daemon
 
 # Terminal 2: Run the notebook app
-cargo xtask dev              # Hot-reload mode
+cargo xtask notebook         # Hot-reload mode
+# or
+cargo xtask dev              # One-shot setup + daemon + app
 # or
 cargo xtask build            # Full build once
 cargo xtask build --rust-only && cargo xtask run  # Fast iteration
@@ -161,7 +163,7 @@ cargo xtask build --rust-only && cargo xtask run  # Fast iteration
 
 The app detects dev mode and connects to the per-worktree daemon instead of installing/starting the system daemon.
 
-**Conductor users:** When using `cargo xtask dev` or `cargo xtask dev-daemon`, the xtask commands automatically translate `CONDUCTOR_WORKSPACE_PATH` to `RUNTIMED_WORKSPACE_PATH`, enabling dev mode.
+**Conductor users:** When using `cargo xtask dev`, `cargo xtask notebook`, or `cargo xtask dev-daemon`, the xtask commands automatically translate `CONDUCTOR_WORKSPACE_PATH` to `RUNTIMED_WORKSPACE_PATH`, enabling dev mode.
 
 **Non-Conductor users:** Set `RUNTIMED_DEV=1`:
 
@@ -170,7 +172,7 @@ The app detects dev mode and connects to the per-worktree daemon instead of inst
 RUNTIMED_DEV=1 cargo xtask dev-daemon
 
 # Terminal 2
-RUNTIMED_DEV=1 cargo xtask dev
+RUNTIMED_DEV=1 cargo xtask notebook
 ```
 
 **Useful commands:**
@@ -204,7 +206,7 @@ unset RUNTIMED_WORKSPACE_PATH
 cargo xtask install-daemon
 
 # Run the app (it will connect to system daemon)
-cargo xtask dev
+cargo xtask notebook
 ```
 
 ### Daemon logs
@@ -258,7 +260,7 @@ The repo includes `.zed/tasks.json` with pre-configured tasks that set the corre
 | Task | What it does |
 |------|-------------|
 | **Dev Daemon** | `cargo xtask dev-daemon` with `RUNTIMED_DEV=1` and `RUNTIMED_WORKSPACE_PATH` |
-| **Dev App** | `cargo xtask dev` with dev env vars and auto-assigned Vite port |
+| **Dev App** | `cargo xtask notebook` with dev env vars and auto-assigned Vite port |
 | **Daemon Status** | `./target/debug/runt daemon status` pointed at the worktree daemon |
 | **Daemon Logs** | `./target/debug/runt daemon logs -f` with live tail |
 | **Format** | `cargo fmt` + biome in one step |

--- a/contributing/development.md
+++ b/contributing/development.md
@@ -4,6 +4,7 @@
 
 | Task | Command |
 |------|---------|
+| One-shot notebook setup | `cargo xtask notebook` |
 | Start dev server | `cargo xtask dev` |
 | Standalone Vite | `cargo xtask vite` |
 | Attach to Vite | `cargo xtask dev --attach` |
@@ -17,6 +18,28 @@
 | Lint (auto-fix) | `cargo xtask lint --fix` |
 
 ## Choosing a Workflow
+
+### `cargo xtask notebook` — One Command Setup + Dev
+
+Best for first-time local setup or when you want the daemon and notebook app to
+come up together.
+
+```bash
+cargo xtask notebook
+```
+
+This command:
+- runs `pnpm install` when your workspace dependencies are missing or stale
+- runs `cargo xtask build` unless you pass `--skip-build`
+- starts the per-worktree dev daemon
+- waits for the daemon to be reachable
+- launches the notebook app in dev mode
+
+For faster repeat launches:
+
+```bash
+cargo xtask notebook --skip-install --skip-build
+```
 
 ### `cargo xtask dev` — Hot Reload
 

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -732,6 +732,68 @@ fn dev_daemon_running() -> bool {
         .get("running")
         .and_then(serde_json::Value::as_bool)
         .unwrap_or(false)
+        || fallback_dev_daemon_running()
+}
+
+fn fallback_dev_daemon_running() -> bool {
+    let Some(workspace) = runt_workspace::get_workspace_path() else {
+        return false;
+    };
+
+    for namespace in ["runt", "runt-nightly"] {
+        let daemon_json = dirs::cache_dir()
+            .unwrap_or_else(|| std::path::PathBuf::from("/tmp"))
+            .join(namespace)
+            .join("worktrees")
+            .join(runt_workspace::worktree_hash(&workspace))
+            .join("daemon.json");
+
+        if daemon_state_is_running(&daemon_json) {
+            return true;
+        }
+    }
+
+    false
+}
+
+fn daemon_state_is_running(path: &Path) -> bool {
+    let Ok(contents) = fs::read_to_string(path) else {
+        return false;
+    };
+    let Ok(info) = serde_json::from_str::<serde_json::Value>(&contents) else {
+        return false;
+    };
+
+    let pid_running = info
+        .get("pid")
+        .and_then(serde_json::Value::as_u64)
+        .map(process_is_running)
+        .unwrap_or(false);
+    if pid_running {
+        return true;
+    }
+
+    info.get("endpoint")
+        .and_then(serde_json::Value::as_str)
+        .map(Path::new)
+        .is_some_and(Path::exists)
+}
+
+fn process_is_running(pid: u64) -> bool {
+    #[cfg(unix)]
+    {
+        Command::new("kill")
+            .args(["-0", &pid.to_string()])
+            .status()
+            .map(|status| status.success())
+            .unwrap_or(false)
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = pid;
+        false
+    }
 }
 
 fn dev_daemon_binary(release: bool) -> &'static str {

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -16,17 +16,17 @@ fn main() {
 
     match args[0].as_str() {
         "dev" => {
+            let options = parse_dev_options(&args);
+            cmd_dev(options.notebook, options.skip_install, options.skip_build);
+        }
+        "notebook" => {
             let attach = args.iter().any(|a| a == "--attach");
             let notebook = args
                 .iter()
                 .skip(1)
                 .find(|a| !a.starts_with('-'))
                 .map(String::as_str);
-            cmd_dev(notebook, attach);
-        }
-        "notebook" => {
-            let options = parse_notebook_options(&args);
-            cmd_notebook(options.notebook, options.skip_install, options.skip_build);
+            cmd_notebook(notebook, attach);
         }
         "vite" => cmd_vite(),
         "build" => {
@@ -68,11 +68,11 @@ fn print_help() {
         "Usage: cargo xtask <COMMAND>
 
 Development:
-  notebook [notebook.ipynb]    Setup once, start dev daemon + notebook app
-  notebook --skip-build        Reuse existing build artifacts before launch
-  notebook --skip-install      Reuse existing pnpm install before launch
-  dev [notebook.ipynb]       Start hot-reload dev server (Vite + Tauri)
-  dev --attach [notebook]    Attach Tauri to existing Vite server
+  dev [notebook.ipynb]         Setup once, start dev daemon + notebook app
+  dev --skip-build             Reuse existing build artifacts before launch
+  dev --skip-install           Reuse existing pnpm install before launch
+  notebook [notebook.ipynb]    Start hot-reload dev server (Vite + Tauri)
+  notebook --attach [notebook] Attach Tauri to existing Vite server
   vite                       Start Vite server standalone
   build                      Full debug build (frontend + rust)
   build --rust-only          Rebuild rust only, reuse existing frontend
@@ -99,14 +99,14 @@ Other:
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct NotebookOptions<'a> {
+struct DevOptions<'a> {
     notebook: Option<&'a str>,
     skip_install: bool,
     skip_build: bool,
 }
 
-fn parse_notebook_options(args: &[String]) -> NotebookOptions<'_> {
-    NotebookOptions {
+fn parse_dev_options(args: &[String]) -> DevOptions<'_> {
+    DevOptions {
         notebook: args
             .iter()
             .skip(1)
@@ -117,12 +117,7 @@ fn parse_notebook_options(args: &[String]) -> NotebookOptions<'_> {
     }
 }
 
-fn cmd_dev(notebook: Option<&str>, attach: bool) {
-    let status = run_notebook_dev_app(notebook, attach, false);
-    exit_on_failed_status("cargo tauri dev", status);
-}
-
-fn cmd_notebook(notebook: Option<&str>, skip_install: bool, skip_build: bool) {
+fn cmd_dev(notebook: Option<&str>, skip_install: bool, skip_build: bool) {
     if skip_install {
         println!("Skipping pnpm install (--skip-install)");
     } else {
@@ -158,6 +153,11 @@ fn cmd_notebook(notebook: Option<&str>, skip_install: bool, skip_build: bool) {
     if let Some(ref mut child) = daemon {
         stop_child(child, "development daemon");
     }
+    exit_on_failed_status("cargo tauri dev", status);
+}
+
+fn cmd_notebook(notebook: Option<&str>, attach: bool) {
+    let status = run_notebook_dev_app(notebook, attach, false);
     exit_on_failed_status("cargo tauri dev", status);
 }
 
@@ -220,7 +220,7 @@ fn run_notebook_dev_app(notebook: Option<&str>, attach: bool, force_dev_mode: bo
 fn cmd_vite() {
     println!("Starting Vite dev server...");
     println!("This server will keep running independently of Tauri.");
-    println!("Use `cargo xtask dev --attach` in another terminal to connect.");
+    println!("Use `cargo xtask notebook --attach` in another terminal to connect.");
     println!();
 
     // Check for port override: RUNTIMED_VITE_PORT > CONDUCTOR_PORT
@@ -1141,18 +1141,18 @@ mod tests {
     use std::path::Path;
 
     #[test]
-    fn parse_notebook_options_reads_flags_and_path() {
+    fn parse_dev_options_reads_flags_and_path() {
         let args = vec![
-            "notebook".to_string(),
+            "dev".to_string(),
             "--skip-install".to_string(),
             "notebooks/demo.ipynb".to_string(),
             "--skip-build".to_string(),
         ];
 
-        let options = parse_notebook_options(&args);
+        let options = parse_dev_options(&args);
         assert_eq!(
             options,
-            NotebookOptions {
+            DevOptions {
                 notebook: Some("notebooks/demo.ipynb"),
                 skip_install: true,
                 skip_build: true,

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -138,18 +138,26 @@ fn cmd_notebook(notebook: Option<&str>, skip_install: bool, skip_build: bool) {
     }
 
     println!();
-    println!("Starting development daemon for one-shot notebook workflow...");
-    let mut daemon = spawn_dev_daemon_process(false);
-    if let Err(error) = wait_for_dev_daemon(&mut daemon, Duration::from_secs(30)) {
-        stop_child(&mut daemon, "development daemon");
-        eprintln!("{error}");
-        exit(1);
+    let mut daemon = None;
+    if dev_daemon_running() {
+        println!("Reusing existing development daemon for this worktree.");
+    } else {
+        println!("Starting development daemon for one-shot notebook workflow...");
+        let mut child = spawn_dev_daemon_process(false);
+        if let Err(error) = wait_for_dev_daemon(&mut child, Duration::from_secs(30)) {
+            stop_child(&mut child, "development daemon");
+            eprintln!("{error}");
+            exit(1);
+        }
+        println!("Development daemon is ready.");
+        daemon = Some(child);
     }
-    println!("Development daemon is ready.");
     println!();
 
     let status = run_notebook_dev_app(notebook, false, true);
-    stop_child(&mut daemon, "development daemon");
+    if let Some(ref mut child) = daemon {
+        stop_child(child, "development daemon");
+    }
     exit_on_failed_status("cargo tauri dev", status);
 }
 

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -736,20 +736,14 @@ fn fallback_dev_daemon_running() -> bool {
         return false;
     };
 
-    for namespace in ["runt", "runt-nightly"] {
-        let daemon_json = dirs::cache_dir()
-            .unwrap_or_else(|| std::path::PathBuf::from("/tmp"))
-            .join(namespace)
-            .join("worktrees")
-            .join(runt_workspace::worktree_hash(&workspace))
-            .join("daemon.json");
+    let daemon_json = dirs::cache_dir()
+        .unwrap_or_else(|| std::path::PathBuf::from("/tmp"))
+        .join(runt_workspace::cache_namespace())
+        .join("worktrees")
+        .join(runt_workspace::worktree_hash(&workspace))
+        .join("daemon.json");
 
-        if daemon_state_is_running(&daemon_json) {
-            return true;
-        }
-    }
-
-    false
+    daemon_state_is_running(&daemon_json)
 }
 
 fn daemon_state_is_running(path: &Path) -> bool {

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -1,7 +1,10 @@
 use std::env;
 use std::fs;
+use std::io::{BufRead, BufReader};
 use std::path::Path;
-use std::process::{exit, Command};
+use std::process::{exit, Child, Command, ExitStatus, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
 
 fn main() {
     let args: Vec<String> = env::args().skip(1).collect();
@@ -20,6 +23,10 @@ fn main() {
                 .find(|a| !a.starts_with('-'))
                 .map(String::as_str);
             cmd_dev(notebook, attach);
+        }
+        "notebook" => {
+            let options = parse_notebook_options(&args);
+            cmd_notebook(options.notebook, options.skip_install, options.skip_build);
         }
         "vite" => cmd_vite(),
         "build" => {
@@ -61,6 +68,9 @@ fn print_help() {
         "Usage: cargo xtask <COMMAND>
 
 Development:
+  notebook [notebook.ipynb]    Setup once, start dev daemon + notebook app
+  notebook --skip-build        Reuse existing build artifacts before launch
+  notebook --skip-install      Reuse existing pnpm install before launch
   dev [notebook.ipynb]       Start hot-reload dev server (Vite + Tauri)
   dev --attach [notebook]    Attach Tauri to existing Vite server
   vite                       Start Vite server standalone
@@ -88,18 +98,72 @@ Other:
     );
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct NotebookOptions<'a> {
+    notebook: Option<&'a str>,
+    skip_install: bool,
+    skip_build: bool,
+}
+
+fn parse_notebook_options(args: &[String]) -> NotebookOptions<'_> {
+    NotebookOptions {
+        notebook: args
+            .iter()
+            .skip(1)
+            .find(|arg| !arg.starts_with('-'))
+            .map(String::as_str),
+        skip_install: args.iter().any(|arg| arg == "--skip-install"),
+        skip_build: args.iter().any(|arg| arg == "--skip-build"),
+    }
+}
+
 fn cmd_dev(notebook: Option<&str>, attach: bool) {
+    let status = run_notebook_dev_app(notebook, attach, false);
+    exit_on_failed_status("cargo tauri dev", status);
+}
+
+fn cmd_notebook(notebook: Option<&str>, skip_install: bool, skip_build: bool) {
+    if skip_install {
+        println!("Skipping pnpm install (--skip-install)");
+    } else {
+        ensure_pnpm_install();
+    }
+
+    if skip_build {
+        println!("Skipping cargo xtask build (--skip-build)");
+        ensure_dev_daemon_binaries();
+    } else {
+        println!("Running cargo xtask build for first-time setup...");
+        cmd_build(false);
+    }
+
+    println!();
+    println!("Starting development daemon for one-shot notebook workflow...");
+    let mut daemon = spawn_dev_daemon_process(false);
+    if let Err(error) = wait_for_dev_daemon(&mut daemon, Duration::from_secs(30)) {
+        stop_child(&mut daemon, "development daemon");
+        eprintln!("{error}");
+        exit(1);
+    }
+    println!("Development daemon is ready.");
+    println!();
+
+    let status = run_notebook_dev_app(notebook, false, true);
+    stop_child(&mut daemon, "development daemon");
+    exit_on_failed_status("cargo tauri dev", status);
+}
+
+fn run_notebook_dev_app(notebook: Option<&str>, attach: bool, force_dev_mode: bool) -> ExitStatus {
     // Delete bundled marker since we're building a dev binary
     let marker = Path::new("./target/debug/.notebook-bundled");
     let _ = fs::remove_file(marker);
 
+    let vite_port = resolve_vite_port(force_dev_mode);
+    let mut command = Command::new("cargo");
+
     if attach {
         println!("Attaching to existing Vite server...");
-
-        // Use RUNTIMED_VITE_PORT, fall back to CONDUCTOR_PORT, then default
-        let port = env::var("RUNTIMED_VITE_PORT")
-            .or_else(|_| env::var("CONDUCTOR_PORT"))
-            .unwrap_or_else(|_| "5174".to_string());
+        let port = vite_port.clone().unwrap_or_else(|| "5174".to_string());
         println!("Connecting to Vite at http://localhost:{port}");
 
         // Skip beforeDevCommand (Vite is already running) and set devUrl
@@ -111,19 +175,14 @@ fn cmd_dev(notebook: Option<&str>, attach: bool) {
             args.extend(["--", path]);
         }
 
-        run_cmd_with_rust_log("cargo", &args);
+        command.args(&args);
     } else {
         println!("Starting dev server with hot reload...");
 
-        // Check for port override: RUNTIMED_VITE_PORT > CONDUCTOR_PORT
-        let config_override = env::var("RUNTIMED_VITE_PORT")
-            .map(|port| ("RUNTIMED_VITE_PORT", port))
-            .or_else(|_| env::var("CONDUCTOR_PORT").map(|port| ("CONDUCTOR_PORT", port)))
-            .ok()
-            .map(|(var, port)| {
-                println!("Using {var}={port}");
-                format!(r#"{{"build":{{"devUrl":"http://localhost:{port}"}}}}"#)
-            });
+        let config_override = vite_port.as_ref().map(|port| {
+            println!("Using RUNTIMED_VITE_PORT={port}");
+            format!(r#"{{"build":{{"devUrl":"http://localhost:{port}"}}}}"#)
+        });
 
         let mut args = vec!["tauri", "dev"];
         if let Some(ref config) = config_override {
@@ -134,8 +193,19 @@ fn cmd_dev(notebook: Option<&str>, attach: bool) {
             args.extend(["--", path]);
         }
 
-        run_cmd_with_rust_log("cargo", &args);
+        command.args(&args);
     }
+
+    apply_rust_log_env(&mut command);
+    apply_worktree_env(&mut command, force_dev_mode);
+    if let Some(ref port) = vite_port {
+        command.env("RUNTIMED_VITE_PORT", port);
+    }
+
+    command.status().unwrap_or_else(|e| {
+        eprintln!("Failed to run cargo tauri dev: {e}");
+        exit(1);
+    })
 }
 
 fn cmd_vite() {
@@ -153,6 +223,40 @@ fn cmd_vite() {
 
     // Run pnpm dev for the notebook app
     run_cmd("pnpm", &["--filter", "notebook", "dev"]);
+}
+
+fn ensure_pnpm_install() {
+    if let Some(reason) = pnpm_install_reason() {
+        println!("Running pnpm install ({reason})...");
+        run_cmd("pnpm", &["install"]);
+    } else {
+        println!("Skipping pnpm install (node_modules is up to date).");
+    }
+}
+
+fn pnpm_install_reason() -> Option<&'static str> {
+    let install_marker = Path::new("node_modules/.modules.yaml");
+    if !install_marker.exists() {
+        return Some("missing node_modules metadata");
+    }
+
+    let Some(install_time) = modified_time(install_marker) else {
+        return Some("could not read node_modules metadata timestamp");
+    };
+    for manifest in [Path::new("package.json"), Path::new("pnpm-lock.yaml")] {
+        let Some(manifest_time) = modified_time(manifest) else {
+            return Some("could not read package manifest timestamps");
+        };
+        if manifest_time > install_time {
+            return Some("package manifests changed");
+        }
+    }
+
+    None
+}
+
+fn modified_time(path: &Path) -> Option<std::time::SystemTime> {
+    fs::metadata(path).ok()?.modified().ok()
 }
 
 fn cmd_build(rust_only: bool) {
@@ -528,6 +632,180 @@ fn cmd_dev_daemon(release: bool) {
     }
 }
 
+fn ensure_dev_daemon_binaries() {
+    if Path::new(dev_daemon_binary(false)).exists() && Path::new(dev_runt_cli_binary()).exists() {
+        println!("Reusing existing runtimed/runt debug binaries.");
+        return;
+    }
+
+    println!("Building runtimed + runt binaries for dev daemon...");
+    build_runtimed_daemon(false);
+}
+
+fn spawn_dev_daemon_process(release: bool) -> Child {
+    ensure_dev_daemon_binaries();
+
+    let binary = dev_daemon_binary(release);
+    let cache_base = dirs::cache_dir()
+        .unwrap_or_else(|| std::path::PathBuf::from("/tmp"))
+        .join(runt_workspace::cache_namespace())
+        .join("worktrees");
+
+    let state_dir = match runt_workspace::get_workspace_path() {
+        Some(path) => cache_base.join(runt_workspace::worktree_hash(&path)),
+        None => cache_base.join("<unknown>"),
+    };
+
+    println!("State will be stored in {}/", state_dir.display());
+    println!("Notebook command will stop the daemon when the app exits.");
+    println!();
+
+    let mut command = Command::new(binary);
+    command
+        .args(["--dev", "run"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    apply_worktree_env(&mut command, true);
+
+    let mut child = command.spawn().unwrap_or_else(|e| {
+        eprintln!("Failed to run runtimed: {e}");
+        exit(1);
+    });
+
+    relay_child_output("daemon", child.stdout.take());
+    relay_child_output("daemon", child.stderr.take());
+    child
+}
+
+fn wait_for_dev_daemon(child: &mut Child, timeout: Duration) -> Result<(), String> {
+    let start = Instant::now();
+    while start.elapsed() < timeout {
+        if let Some(status) = child
+            .try_wait()
+            .map_err(|error| format!("Failed to poll dev daemon status: {error}"))?
+        {
+            return Err(format!(
+                "Development daemon exited before it became ready (status: {status})."
+            ));
+        }
+
+        if dev_daemon_running() {
+            return Ok(());
+        }
+
+        thread::sleep(Duration::from_millis(250));
+    }
+
+    Err("Timed out waiting for the development daemon to become ready.".to_string())
+}
+
+fn dev_daemon_running() -> bool {
+    let mut command = Command::new(dev_runt_cli_binary());
+    command
+        .args(["daemon", "status", "--json"])
+        .env("RUST_LOG", "error")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null());
+    apply_worktree_env(&mut command, true);
+
+    let output = command.output();
+
+    let output = match output {
+        Ok(output) if output.status.success() => output,
+        _ => return false,
+    };
+
+    let status_json: serde_json::Value = match serde_json::from_slice(&output.stdout) {
+        Ok(json) => json,
+        Err(_) => return false,
+    };
+
+    status_json
+        .get("running")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false)
+}
+
+fn dev_daemon_binary(release: bool) -> &'static str {
+    if cfg!(windows) {
+        if release {
+            "target/release/runtimed.exe"
+        } else {
+            "target/debug/runtimed.exe"
+        }
+    } else if release {
+        "target/release/runtimed"
+    } else {
+        "target/debug/runtimed"
+    }
+}
+
+fn dev_runt_cli_binary() -> &'static str {
+    if cfg!(windows) {
+        "target/debug/runt.exe"
+    } else {
+        "target/debug/runt"
+    }
+}
+
+fn relay_child_output<R>(label: &'static str, stream: Option<R>)
+where
+    R: std::io::Read + Send + 'static,
+{
+    let Some(stream) = stream else {
+        return;
+    };
+
+    thread::spawn(move || {
+        let reader = BufReader::new(stream);
+        for line in reader.lines() {
+            match line {
+                Ok(line) => eprintln!("[{label}] {line}"),
+                Err(_) => break,
+            }
+        }
+    });
+}
+
+fn stop_child(child: &mut Child, label: &str) {
+    match child.try_wait() {
+        Ok(Some(_)) => {}
+        Ok(None) => {
+            println!("Stopping {label}...");
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+        Err(error) => {
+            eprintln!("Failed to poll {label}: {error}");
+        }
+    }
+}
+
+fn resolve_vite_port(force_dev_mode: bool) -> Option<String> {
+    env::var("RUNTIMED_VITE_PORT")
+        .ok()
+        .or_else(|| env::var("CONDUCTOR_PORT").ok())
+        .or_else(|| {
+            if force_dev_mode {
+                default_dev_vite_port().map(|port| port.to_string())
+            } else {
+                None
+            }
+        })
+}
+
+fn default_dev_vite_port() -> Option<u16> {
+    let workspace = runt_workspace::get_workspace_path()?;
+    Some(default_vite_port_for_workspace(&workspace))
+}
+
+fn default_vite_port_for_workspace(path: &Path) -> u16 {
+    let hash = runt_workspace::worktree_hash(path);
+    let prefix = hash.get(..4).unwrap_or("0000");
+    let offset = u16::from_str_radix(prefix, 16).unwrap_or(0) % 4900;
+    5100 + offset
+}
+
 /// Run linting and formatting checks across all languages.
 ///
 /// In check mode (default): exits non-zero if any issues are found.
@@ -748,30 +1026,71 @@ fn run_cmd(cmd: &str, args: &[&str]) {
     }
 }
 
-/// Run a command with RUST_LOG set to enable info-level logging.
-/// This is useful for dev mode to see Rust logs from the notebook app.
-/// Also translates CONDUCTOR_* env vars to RUNTIMED_* for Conductor workspace users.
-fn run_cmd_with_rust_log(cmd: &str, args: &[&str]) {
-    // Use existing RUST_LOG if set, otherwise default to info
+fn apply_rust_log_env(command: &mut Command) {
     let rust_log = env::var("RUST_LOG").unwrap_or_else(|_| "info".to_string());
-    let mut command = Command::new(cmd);
-    command.args(args).env("RUST_LOG", &rust_log);
+    command.env("RUST_LOG", rust_log);
+}
 
-    // Translate Conductor → Runtimed for Conductor workspace users
+fn apply_worktree_env(command: &mut Command, force_dev_mode: bool) {
+    if force_dev_mode {
+        command.env("RUNTIMED_DEV", "1");
+    }
+
     if let Ok(path) = env::var("CONDUCTOR_WORKSPACE_PATH") {
-        command.env("RUNTIMED_WORKSPACE_PATH", &path);
+        command.env("RUNTIMED_WORKSPACE_PATH", path);
+    } else if force_dev_mode {
+        if let Some(path) = runt_workspace::get_workspace_path() {
+            command.env("RUNTIMED_WORKSPACE_PATH", path);
+        }
     }
+
     if let Ok(name) = env::var("CONDUCTOR_WORKSPACE_NAME") {
-        command.env("RUNTIMED_WORKSPACE_NAME", &name);
+        command.env("RUNTIMED_WORKSPACE_NAME", name);
+    } else if force_dev_mode {
+        if let Some(name) = runt_workspace::get_workspace_name() {
+            command.env("RUNTIMED_WORKSPACE_NAME", name);
+        }
+    }
+}
+
+fn exit_on_failed_status(label: &str, status: ExitStatus) {
+    if !status.success() {
+        eprintln!("{label} exited with status {status}");
+        exit(status.code().unwrap_or(1));
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn parse_notebook_options_reads_flags_and_path() {
+        let args = vec![
+            "notebook".to_string(),
+            "--skip-install".to_string(),
+            "notebooks/demo.ipynb".to_string(),
+            "--skip-build".to_string(),
+        ];
+
+        let options = parse_notebook_options(&args);
+        assert_eq!(
+            options,
+            NotebookOptions {
+                notebook: Some("notebooks/demo.ipynb"),
+                skip_install: true,
+                skip_build: true,
+            }
+        );
     }
 
-    let status = command.status().unwrap_or_else(|e| {
-        eprintln!("Failed to run {cmd}: {e}");
-        exit(1);
-    });
-
-    if !status.success() {
-        eprintln!("Command failed: {cmd} {}", args.join(" "));
-        exit(status.code().unwrap_or(1));
+    #[test]
+    fn default_vite_port_is_stable_for_workspace() {
+        let workspace = Path::new("/workspace/example");
+        let port = default_vite_port_for_workspace(workspace);
+        assert_eq!(port, default_vite_port_for_workspace(workspace));
+        assert!((5100u16..10000u16).contains(&port));
     }
 }

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -205,6 +205,7 @@ fn run_notebook_dev_app(notebook: Option<&str>, attach: bool, force_dev_mode: bo
     }
 
     apply_rust_log_env(&mut command);
+    apply_build_channel_env(&mut command);
     apply_worktree_env(&mut command, force_dev_mode);
     if let Some(ref port) = vite_port {
         command.env("RUNTIMED_VITE_PORT", port);
@@ -641,11 +642,6 @@ fn cmd_dev_daemon(release: bool) {
 }
 
 fn ensure_dev_daemon_binaries() {
-    if Path::new(dev_daemon_binary(false)).exists() && Path::new(dev_runt_cli_binary()).exists() {
-        println!("Reusing existing runtimed/runt debug binaries.");
-        return;
-    }
-
     println!("Building runtimed + runt binaries for dev daemon...");
     build_runtimed_daemon(false);
 }
@@ -997,14 +993,16 @@ fn cmd_lint(fix: bool) {
 
 /// Run a command and return true if it succeeded.
 fn run_cmd_ok(cmd: &str, args: &[&str]) -> bool {
-    Command::new(cmd)
-        .args(args)
-        .status()
-        .map(|s| s.success())
-        .unwrap_or_else(|e| {
-            eprintln!("Failed to run {cmd}: {e}");
-            false
-        })
+    let mut command = Command::new(cmd);
+    command.args(args);
+    if cmd == "cargo" {
+        apply_build_channel_env(&mut command);
+    }
+
+    command.status().map(|s| s.success()).unwrap_or_else(|e| {
+        eprintln!("Failed to run {cmd}: {e}");
+        false
+    })
 }
 
 /// Build external binaries (runtimed daemon and runt CLI) for Tauri bundling.
@@ -1085,7 +1083,13 @@ fn get_host_target() -> String {
 }
 
 fn run_cmd(cmd: &str, args: &[&str]) {
-    let status = Command::new(cmd).args(args).status().unwrap_or_else(|e| {
+    let mut command = Command::new(cmd);
+    command.args(args);
+    if cmd == "cargo" {
+        apply_build_channel_env(&mut command);
+    }
+
+    let status = command.status().unwrap_or_else(|e| {
         eprintln!("Failed to run {cmd}: {e}");
         exit(1);
     });
@@ -1099,6 +1103,12 @@ fn run_cmd(cmd: &str, args: &[&str]) {
 fn apply_rust_log_env(command: &mut Command) {
     let rust_log = env::var("RUST_LOG").unwrap_or_else(|_| "info".to_string());
     command.env("RUST_LOG", rust_log);
+}
+
+fn apply_build_channel_env(command: &mut Command) {
+    let build_channel = env::var("RUNT_BUILD_CHANNEL")
+        .unwrap_or_else(|_| runt_workspace::channel_display_name().to_string());
+    command.env("RUNT_BUILD_CHANNEL", build_channel);
 }
 
 fn apply_worktree_env(command: &mut Command, force_dev_mode: bool) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add `cargo xtask notebook` command to streamline local notebook development setup.

This new command consolidates `pnpm install`, `cargo xtask build`, `cargo xtask dev-daemon`, and `cargo xtask dev` into a single invocation, including daemon readiness checks, reuse logic, and correct build channel propagation for a seamless developer experience.

<div><a href="https://cursor.com/agents/bc-6e502be3-b8ae-4014-a5be-209b0ec56c81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6e502be3-b8ae-4014-a5be-209b0ec56c81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->