### PR TITLE
chore: clean bundled sample notebook metadata

### DIFF
--- a/crates/notebook/resources/sample-notebooks/download-stats.ipynb
+++ b/crates/notebook/resources/sample-notebooks/download-stats.ipynb
@@ -2,10 +2,6 @@
   "nbformat": 4,
   "nbformat_minor": 5,
   "metadata": {
-    "anaconda-cloud": {},
-    "kernel_info": {
-      "name": "python3"
-    },
     "kernelspec": {
       "name": "python3",
       "display_name": "Python 3",
@@ -14,9 +10,6 @@
     "language_info": {
       "name": "python",
       "version": "3.11.0"
-    },
-    "nteract": {
-      "version": "nteract-on-jupyter@2.0.4"
     },
     "title": "Download counts for nteract desktop stable and nightly releases",
     "conda": {
@@ -44,9 +37,7 @@
           "conda-forge"
         ],
         "python": "3.11"
-      },
-      "trust_signature": "hmac-sha256:c88b2c6d2cf664dd9ec6f274384f5126a6999abc5ddd0e390453dd6d9d6cf58a",
-      "trust_timestamp": "2026-03-13T18:59:48.759675+00:00"
+      }
     }
   },
   "cells": [

--- a/crates/notebook/resources/sample-notebooks/pandas-to-geojson.ipynb
+++ b/crates/notebook/resources/sample-notebooks/pandas-to-geojson.ipynb
@@ -2,9 +2,6 @@
   "nbformat": 4,
   "nbformat_minor": 5,
   "metadata": {
-    "kernel_info": {
-      "name": "python3"
-    },
     "kernelspec": {
       "name": "python3",
       "display_name": "Python 3",
@@ -13,9 +10,6 @@
     "language_info": {
       "name": "python",
       "version": "3.11.0"
-    },
-    "nteract": {
-      "version": "0.24.0"
     },
     "title": "Go from Pandas to GeoJSON",
     "uv": {
@@ -35,9 +29,7 @@
           "requests"
         ],
         "requires-python": ">=3.10"
-      },
-      "trust_signature": "hmac-sha256:12ed32df03b5798211419cb43626637ab7b51553ce2b71e06f5f9e1fdabd579e",
-      "trust_timestamp": "2026-03-13T17:58:45.261136+00:00"
+      }
     }
   },
   "cells": [


### PR DESCRIPTION
## Summary
- remove stale `metadata.nteract` entries from bundled sample notebooks
- keep the legacy-compatible top-level `uv`/`conda` fields while removing redundant `kernel_info` and empty `anaconda-cloud`
- drop machine-specific trust signatures and timestamps from the shipped notebook JSON

## Verification
- parsed all bundled sample notebooks as JSON
- confirmed no bundled sample notebook still mentions `nteract-on-jupyter`