### PR TITLE
ci: auto-label PRs by file paths and agent provenance

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,87 @@
+# Auto-label PRs based on changed file paths.
+# Used by the actions/labeler workflow in .github/workflows/labeler.yml
+#
+# Docs: https://github.com/actions/labeler
+
+frontend:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'apps/notebook/**'
+      - 'src/components/**'
+      - 'src/bindings/**'
+
+daemon:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'crates/runtimed/**'
+      - 'crates/notebook-protocol/**'
+      - 'crates/notebook-sync/**'
+      - 'crates/kernel-env/**'
+      - 'crates/kernel-launch/**'
+      - 'crates/runt/**'
+      - 'crates/runt-trust/**'
+      - 'crates/runt-workspace/**'
+
+editor:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'src/components/editor/**'
+      - 'apps/notebook/src/lib/cursor-registry*'
+      - 'apps/notebook/src/lib/presence-sender*'
+
+ipywidgets:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'src/components/widgets/**'
+      - 'crates/runtimed/src/comm_state*'
+
+mcp:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'python/nteract/**'
+
+presence:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'crates/notebook-doc/src/presence*'
+      - 'apps/notebook/src/lib/cursor-registry*'
+      - 'apps/notebook/src/lib/presence-sender*'
+      - 'apps/notebook/src/hooks/usePresence*'
+      - 'apps/notebook/src/contexts/PresenceContext*'
+      - 'apps/notebook/src/components/cell/CellPresenceIndicators*'
+      - 'src/components/editor/remote-cursors*'
+
+documentation:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'docs/**'
+      - 'contributing/**'
+      - 'AGENTS.md'
+      - 'CLAUDE.md'
+      - 'README.md'
+
+test:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'e2e/**'
+      - 'crates/runtimed/tests/**'
+      - 'crates/notebook-sync/src/tests*'
+      - 'python/runtimed/tests/**'
+      - 'python/nteract/tests/**'
+      - 'apps/notebook/src/lib/__tests__/**'
+
+sync:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'crates/notebook-sync/**'
+      - 'crates/notebook-doc/src/frame_types*'
+      - 'crates/runtimed/src/notebook_sync_server*'
+      - 'crates/runtimed/src/notebook_sync_client*'
+      - 'crates/runtimed-wasm/**'
+
+notebook-dependencies:
+  - changed-files:
+    - any-glob-to-any-file:
+      - 'crates/kernel-env/**'
+      - 'crates/notebook-doc/src/pep723*'
+      - 'crates/notebook-doc/src/metadata*'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -12,7 +12,7 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@v6
         with:
           sync-labels: false
 

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,31 @@
+name: Label PRs
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          sync-labels: false
+
+      # Apply quill label for Quill Agent PRs
+      - uses: actions/github-script@v8
+        with:
+          script: |
+            const body = context.payload.pull_request.body || '';
+            if (body.includes('agent Quill') || body.includes('agent, Quill')) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                labels: ['quill']
+              });
+            }

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -21,7 +21,9 @@ jobs:
         with:
           script: |
             const body = context.payload.pull_request.body || '';
-            if (body.includes('agent Quill') || body.includes('agent, Quill')) {
+            const author = context.payload.pull_request.user.login;
+            if ((author === 'rgbkrk' || author === 'quillaid') &&
+                (body.includes('agent Quill') || body.includes('agent, Quill'))) {
               await github.rest.issues.addLabels({
                 owner: context.repo.owner,
                 repo: context.repo.repo,


### PR DESCRIPTION
## Summary

Auto-label PRs based on changed file paths using [actions/labeler](https://github.com/actions/labeler), plus auto-apply the `quill` 🦆 label for Quill Agent PRs.

### File-path → label mapping

| Label | File patterns |
|-------|--------------|
| `frontend` | `apps/notebook/**`, `src/components/**`, `src/bindings/**` |
| `daemon` | `crates/runtimed/**`, `crates/notebook-protocol/**`, `crates/notebook-sync/**`, `crates/kernel-env/**`, `crates/kernel-launch/**`, `crates/runt*/**` |
| `editor` | `src/components/editor/**`, cursor-registry, presence-sender |
| `ipywidgets` | `src/components/widgets/**`, `comm_state*` |
| `mcp` | `python/nteract/**` |
| `presence` | presence/cursor files across notebook-doc, frontend hooks, and editor |
| `sync` | `notebook-sync/**`, frame types, sync server/client, WASM |
| `notebook-dependencies` | `kernel-env/**`, pep723, metadata |
| `documentation` | `docs/**`, `contributing/**`, top-level .md files |
| `test` | `e2e/**`, test directories across all crates |

### Agent provenance

The `quill` label is applied when the PR body contains the Quill Agent signature (`agent Quill` or `agent, Quill`).

### Design choices

- **`sync-labels: false`** — labels are only added, never removed. A PR that starts touching daemon code and later drops those changes keeps the `daemon` label. This avoids surprise label removal on force-push.
- **Triggers on `opened` and `synchronize`** — labels update when new commits are pushed, catching PRs that expand scope.
- **No `ux` auto-labeling** — UX polish is a human judgment call, not derivable from file paths.

_PR submitted by @rgbkrk's agent, Quill_