### PR TITLE
feat(runtimed-py): emit presence events from cell operations

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -33,7 +33,6 @@ import { type EnvSyncState, useDependencies } from "./hooks/useDependencies";
 import { useEnvProgress } from "./hooks/useEnvProgress";
 import { useDaemonInfo, useGitInfo } from "./hooks/useGitInfo";
 import { useGlobalFind } from "./hooks/useGlobalFind";
-import { usePresence } from "./hooks/usePresence";
 import { useTrust } from "./hooks/useTrust";
 import { useUpdater } from "./hooks/useUpdater";
 import { startCursorDispatch } from "./lib/cursor-registry";
@@ -92,9 +91,6 @@ function AppContent() {
 
   // Stable peer ID for presence (generated once per window lifetime)
   const peerIdRef = useRef(crypto.randomUUID());
-
-  // Remote cursor/selection presence (outgoing setCursor/setSelection wired in step 5)
-  usePresence(peerIdRef.current);
 
   // Start dispatching presence events to CodeMirror EditorViews
   useEffect(() => {

--- a/apps/notebook/src/hooks/usePresence.ts
+++ b/apps/notebook/src/hooks/usePresence.ts
@@ -36,6 +36,7 @@ export interface RemotePeer {
 interface PresenceUpdate {
   type: "update";
   peer_id: string;
+  peer_label?: string;
   channel: "cursor" | "selection" | "kernel_state" | "custom";
   data: CursorPosition | SelectionRange | unknown;
 }
@@ -111,8 +112,13 @@ export function usePresence(peerId: string | null) {
           const existing = peersRef.current.get(msg.peer_id);
           const peer: RemotePeer = existing ?? {
             peerId: msg.peer_id,
-            peerLabel: "",
+            peerLabel: msg.peer_label ?? "",
           };
+
+          // Update peer_label if provided (may arrive with cursor/selection updates)
+          if (msg.peer_label && !peer.peerLabel) {
+            peer.peerLabel = msg.peer_label;
+          }
 
           if (msg.channel === "cursor") {
             peer.cursor = msg.data as CursorPosition;

--- a/crates/runtimed-py/src/async_session.rs
+++ b/crates/runtimed-py/src/async_session.rs
@@ -50,8 +50,11 @@ impl AsyncSession {
         let notebook_id =
             notebook_id.unwrap_or_else(|| format!("agent-session-{}", uuid::Uuid::new_v4()));
 
+        let mut state = SessionState::new();
+        state.peer_label = peer_label.clone();
+
         Ok(Self {
-            state: Arc::new(Mutex::new(SessionState::new())),
+            state: Arc::new(Mutex::new(state)),
             notebook_id,
             peer_label,
         })
@@ -129,8 +132,10 @@ impl AsyncSession {
 
         future_into_py(py, async move {
             let socket_path = get_socket_path();
-            let (notebook_id, state, _info) =
+            let (notebook_id, mut state, _info) =
                 session_core::connect_open(socket_path, &path).await?;
+
+            state.peer_label = peer_label.clone();
 
             Ok(AsyncSession {
                 state: Arc::new(Mutex::new(state)),
@@ -177,8 +182,10 @@ impl AsyncSession {
 
         future_into_py(py, async move {
             let socket_path = get_socket_path();
-            let (notebook_id, state, _info) =
+            let (notebook_id, mut state, _info) =
                 session_core::connect_create(socket_path, &runtime, working_dir_buf).await?;
+
+            state.peer_label = peer_label.clone();
 
             Ok(AsyncSession {
                 state: Arc::new(Mutex::new(state)),

--- a/crates/runtimed-py/src/session.rs
+++ b/crates/runtimed-py/src/session.rs
@@ -54,9 +54,12 @@ impl Session {
         let notebook_id =
             notebook_id.unwrap_or_else(|| format!("agent-session-{}", uuid::Uuid::new_v4()));
 
+        let mut state = SessionState::new();
+        state.peer_label = peer_label.clone();
+
         Ok(Self {
             runtime,
-            state: Arc::new(Mutex::new(SessionState::new())),
+            state: Arc::new(Mutex::new(state)),
             notebook_id,
             peer_label,
         })
@@ -122,8 +125,10 @@ impl Session {
         let runtime = Runtime::new().map_err(to_py_err)?;
         let socket_path = get_socket_path();
 
-        let (notebook_id, state, _info) =
+        let (notebook_id, mut state, _info) =
             runtime.block_on(session_core::connect_open(socket_path, path))?;
+
+        state.peer_label = peer_label.clone();
 
         Ok(Self {
             runtime,
@@ -171,11 +176,13 @@ impl Session {
         let socket_path = get_socket_path();
         let working_dir_buf = working_dir.map(PathBuf::from);
 
-        let (notebook_id, state, _info) = rt.block_on(session_core::connect_create(
+        let (notebook_id, mut state, _info) = rt.block_on(session_core::connect_create(
             socket_path,
             runtime,
             working_dir_buf,
         ))?;
+
+        state.peer_label = peer_label.clone();
 
         Ok(Self {
             runtime: rt,

--- a/crates/runtimed-py/src/session_core.rs
+++ b/crates/runtimed-py/src/session_core.rs
@@ -469,10 +469,13 @@ pub(crate) async fn set_source(
         handle.update_source(cell_id, source).map_err(to_py_err)?;
     }
 
-    // Emit presence at end of new source
-    let lines: Vec<&str> = source.lines().collect();
-    let last_line = lines.len().saturating_sub(1) as u32;
-    let last_col = lines.last().map(|l| l.len()).unwrap_or(0) as u32;
+    // Emit presence at end of new source (single pass, no allocation)
+    let (last_line, last_col) = source
+        .lines()
+        .enumerate()
+        .last()
+        .map(|(i, line)| (i as u32, line.len() as u32))
+        .unwrap_or((0, 0));
     emit_cursor_presence(state, cell_id, last_line, last_col).await;
 
     Ok(())
@@ -961,8 +964,9 @@ pub(crate) async fn set_selection(
     handle.send_presence(data).await.map_err(to_py_err)
 }
 
-/// Internal helper to emit cursor presence (best-effort, non-blocking).
+/// Internal helper to emit cursor presence (best-effort).
 /// Reads peer_label from SessionState, so callers don't need to pass it.
+/// Errors are silently ignored since presence is non-critical.
 pub(crate) async fn emit_cursor_presence(
     state: &Arc<Mutex<SessionState>>,
     cell_id: &str,
@@ -979,18 +983,22 @@ async fn emit_cursor_presence_internal(
     line: u32,
     column: u32,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    let st = state.lock().await;
-    let peer_label = st.peer_label.as_deref();
-    let data = notebook_doc::presence::encode_cursor_update_labeled(
-        "local",
-        peer_label,
-        &notebook_doc::presence::CursorPosition {
-            cell_id: cell_id.to_string(),
-            line,
-            column,
-        },
-    );
-    let handle = st.handle.as_ref().ok_or("Not connected")?;
+    // Clone what we need and drop the lock before await to avoid contention
+    let (data, handle) = {
+        let st = state.lock().await;
+        let peer_label = st.peer_label.clone();
+        let data = notebook_doc::presence::encode_cursor_update_labeled(
+            "local",
+            peer_label.as_deref(),
+            &notebook_doc::presence::CursorPosition {
+                cell_id: cell_id.to_string(),
+                line,
+                column,
+            },
+        );
+        let handle = st.handle.clone().ok_or("Not connected")?;
+        (data, handle)
+    };
     handle.send_presence(data).await?;
     Ok(())
 }

--- a/crates/runtimed-py/src/session_core.rs
+++ b/crates/runtimed-py/src/session_core.rs
@@ -51,6 +51,8 @@ pub(crate) struct SessionState {
     pub notebook_path: Option<String>,
     /// User settings (synced from daemon at connection time)
     pub settings: Option<runtimed::settings_doc::SyncedSettings>,
+    /// Peer label for presence (e.g., "Claude", "Agent")
+    pub peer_label: Option<String>,
 }
 
 impl SessionState {
@@ -66,6 +68,7 @@ impl SessionState {
             connection_info: None,
             notebook_path: None,
             settings: None,
+            peer_label: None,
         }
     }
 }
@@ -168,6 +171,7 @@ pub(crate) async fn connect_open(
         connection_info: Some(connection_info.clone()),
         notebook_path: Some(path.to_string()),
         settings,
+        peer_label: None, // Set by caller (Session/AsyncSession)
     };
 
     Ok((notebook_id, state, connection_info))
@@ -204,6 +208,7 @@ pub(crate) async fn connect_create(
         connection_info: Some(connection_info.clone()),
         notebook_path: working_dir.map(|p| p.to_string_lossy().to_string()),
         settings,
+        peer_label: None, // Set by caller (Session/AsyncSession)
     };
 
     Ok((notebook_id, state, connection_info))
@@ -419,25 +424,30 @@ pub(crate) async fn create_cell(
 ) -> PyResult<String> {
     let cell_id = format!("cell-{}", uuid::Uuid::new_v4());
 
-    let st = state.lock().await;
-    let handle = st
-        .handle
-        .as_ref()
-        .ok_or_else(|| to_py_err("Not connected"))?;
+    {
+        let st = state.lock().await;
+        let handle = st
+            .handle
+            .as_ref()
+            .ok_or_else(|| to_py_err("Not connected"))?;
 
-    // Determine after_cell_id from index
-    let after_cell_id = index.and_then(|i| {
-        if i == 0 {
-            None
-        } else {
-            let cells = handle.get_cells();
-            cells.get(i.saturating_sub(1)).map(|c| c.id.clone())
-        }
-    });
+        // Determine after_cell_id from index
+        let after_cell_id = index.and_then(|i| {
+            if i == 0 {
+                None
+            } else {
+                let cells = handle.get_cells();
+                cells.get(i.saturating_sub(1)).map(|c| c.id.clone())
+            }
+        });
 
-    handle
-        .add_cell_with_source(&cell_id, cell_type, after_cell_id.as_deref(), source)
-        .map_err(to_py_err)?;
+        handle
+            .add_cell_with_source(&cell_id, cell_type, after_cell_id.as_deref(), source)
+            .map_err(to_py_err)?;
+    }
+
+    // Emit presence on the new cell
+    emit_cursor_presence(state, &cell_id, 0, 0).await;
 
     Ok(cell_id)
 }
@@ -448,14 +458,23 @@ pub(crate) async fn set_source(
     cell_id: &str,
     source: &str,
 ) -> PyResult<()> {
-    let st = state.lock().await;
-    let handle = st
-        .handle
-        .as_ref()
-        .ok_or_else(|| to_py_err("Not connected"))?;
+    {
+        let st = state.lock().await;
+        let handle = st
+            .handle
+            .as_ref()
+            .ok_or_else(|| to_py_err("Not connected"))?;
 
-    // Synchronous — direct doc mutation via DocHandle
-    handle.update_source(cell_id, source).map_err(to_py_err)?;
+        // Synchronous — direct doc mutation via DocHandle
+        handle.update_source(cell_id, source).map_err(to_py_err)?;
+    }
+
+    // Emit presence at end of new source
+    let lines: Vec<&str> = source.lines().collect();
+    let last_line = lines.len().saturating_sub(1) as u32;
+    let last_col = lines.last().map(|l| l.len()).unwrap_or(0) as u32;
+    emit_cursor_presence(state, cell_id, last_line, last_col).await;
+
     Ok(())
 }
 
@@ -572,37 +591,49 @@ pub(crate) async fn move_cell(
     cell_id: &str,
     after_cell_id: Option<&str>,
 ) -> PyResult<String> {
-    let st = state.lock().await;
-    let handle = st
-        .handle
-        .as_ref()
-        .ok_or_else(|| to_py_err("Not connected"))?;
+    {
+        let st = state.lock().await;
+        let handle = st
+            .handle
+            .as_ref()
+            .ok_or_else(|| to_py_err("Not connected"))?;
 
-    // Synchronous — direct doc mutation via DocHandle
-    handle
-        .move_cell(cell_id, after_cell_id)
-        .map_err(to_py_err)?;
+        // Synchronous — direct doc mutation via DocHandle
+        handle
+            .move_cell(cell_id, after_cell_id)
+            .map_err(to_py_err)?;
+    }
+
+    // Emit presence on the moved cell
+    emit_cursor_presence(state, cell_id, 0, 0).await;
+
     Ok(cell_id.to_string())
 }
 
 /// Clear a cell's outputs.
 pub(crate) async fn clear_outputs(state: &Arc<Mutex<SessionState>>, cell_id: &str) -> PyResult<()> {
-    let st = state.lock().await;
-    let handle = st
-        .handle
-        .as_ref()
-        .ok_or_else(|| to_py_err("Not connected"))?;
+    let response = {
+        let st = state.lock().await;
+        let handle = st
+            .handle
+            .as_ref()
+            .ok_or_else(|| to_py_err("Not connected"))?;
 
-    // clear_outputs still goes through send_request (daemon clears kernel state too)
-    let response = handle
-        .send_request(NotebookRequest::ClearOutputs {
-            cell_id: cell_id.to_string(),
-        })
-        .await
-        .map_err(to_py_err)?;
+        // clear_outputs still goes through send_request (daemon clears kernel state too)
+        handle
+            .send_request(NotebookRequest::ClearOutputs {
+                cell_id: cell_id.to_string(),
+            })
+            .await
+            .map_err(to_py_err)?
+    };
 
     match response {
-        NotebookResponse::OutputsCleared { .. } => Ok(()),
+        NotebookResponse::OutputsCleared { .. } => {
+            // Emit presence on the cleared cell
+            emit_cursor_presence(state, cell_id, 0, 0).await;
+            Ok(())
+        }
         NotebookResponse::Error { error } => Err(to_py_err(error)),
         other => Err(to_py_err(format!("Unexpected response: {:?}", other))),
     }
@@ -630,6 +661,9 @@ pub(crate) async fn execute_cell(
             ensure_kernel_started(state, notebook_id).await?;
         }
     }
+
+    // Emit presence on the cell being executed
+    emit_cursor_presence(state, cell_id, 0, 0).await;
 
     let timeout = std::time::Duration::from_secs_f64(timeout_secs);
     let result = tokio::time::timeout(timeout, async {
@@ -828,23 +862,39 @@ pub(crate) async fn run_all_cells(
         }
     }
 
-    let st = state.lock().await;
-    let handle = st
-        .handle
-        .as_ref()
-        .ok_or_else(|| to_py_err("Not connected"))?;
+    let (response, last_code_cell_id) = {
+        let st = state.lock().await;
+        let handle = st
+            .handle
+            .as_ref()
+            .ok_or_else(|| to_py_err("Not connected"))?;
 
-    handle.confirm_sync().await.map_err(to_py_err)?;
+        // Get last code cell ID before queuing (for presence)
+        let cells = handle.get_cells();
+        let last_code_cell_id = cells
+            .iter()
+            .rev()
+            .find(|c| c.cell_type == "code")
+            .map(|c| c.id.clone());
 
-    let response = handle
-        .send_request(NotebookRequest::RunAllCells {})
-        .await
-        .map_err(to_py_err)?;
+        handle.confirm_sync().await.map_err(to_py_err)?;
 
-    drop(st);
+        let response = handle
+            .send_request(NotebookRequest::RunAllCells {})
+            .await
+            .map_err(to_py_err)?;
+
+        (response, last_code_cell_id)
+    };
 
     match response {
-        NotebookResponse::AllCellsQueued { count } => Ok(count),
+        NotebookResponse::AllCellsQueued { count } => {
+            // Emit presence on last code cell
+            if let Some(cell_id) = last_code_cell_id {
+                emit_cursor_presence(state, &cell_id, 0, 0).await;
+            }
+            Ok(count)
+        }
         NotebookResponse::NoKernel {} => Err(to_py_err("No kernel running")),
         NotebookResponse::Error { error } => Err(to_py_err(error)),
         other => Err(to_py_err(format!("Unexpected response: {:?}", other))),
@@ -909,6 +959,40 @@ pub(crate) async fn set_selection(
         .ok_or_else(|| to_py_err("Not connected"))?;
 
     handle.send_presence(data).await.map_err(to_py_err)
+}
+
+/// Internal helper to emit cursor presence (best-effort, non-blocking).
+/// Reads peer_label from SessionState, so callers don't need to pass it.
+pub(crate) async fn emit_cursor_presence(
+    state: &Arc<Mutex<SessionState>>,
+    cell_id: &str,
+    line: u32,
+    column: u32,
+) {
+    // Best-effort: don't propagate errors
+    let _ = emit_cursor_presence_internal(state, cell_id, line, column).await;
+}
+
+async fn emit_cursor_presence_internal(
+    state: &Arc<Mutex<SessionState>>,
+    cell_id: &str,
+    line: u32,
+    column: u32,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let st = state.lock().await;
+    let peer_label = st.peer_label.as_deref();
+    let data = notebook_doc::presence::encode_cursor_update_labeled(
+        "local",
+        peer_label,
+        &notebook_doc::presence::CursorPosition {
+            cell_id: cell_id.to_string(),
+            line,
+            column,
+        },
+    );
+    let handle = st.handle.as_ref().ok_or("Not connected")?;
+    handle.send_presence(data).await?;
+    Ok(())
 }
 
 // =========================================================================

--- a/python/nteract/src/nteract/_mcp_server.py
+++ b/python/nteract/src/nteract/_mcp_server.py
@@ -769,6 +769,14 @@ async def _send_edit_cursor(
         pass  # Presence is best-effort — don't fail the edit
 
 
+async def _send_cell_cursor(
+    session: runtimed.AsyncSession, cell_id: str, line: int = 0, column: int = 0
+) -> None:
+    """Send cursor presence on a cell (best-effort, non-blocking)."""
+    with contextlib.suppress(Exception):
+        await session.set_cursor(cell_id=cell_id, line=line, column=column)
+
+
 def _format_edit_diff(cell_id: str, old_text: str, new_text: str) -> str:
     """Format a unified diff for an edit operation."""
     # splitlines(keepends=False) + manual newlines ensures consistent output
@@ -881,6 +889,7 @@ async def get_cell(
 ) -> list[ContentItem]:
     """Get a cell's source and outputs by ID."""
     session = await _get_session()
+    await _send_cell_cursor(session, cell_id)
     cell = await session.get_cell(cell_id=cell_id)
     return _cell_to_content(cell)
 
@@ -1089,6 +1098,7 @@ async def resource_cell(cell_id: str) -> str:
         return "Error: No active session"
 
     try:
+        await _send_cell_cursor(_session, cell_id)
         cell = await _session.get_cell(cell_id=cell_id)
         return _format_cell(cell)
     except Exception as e:
@@ -1105,7 +1115,9 @@ async def resource_cell_by_index(index: int) -> str:
         cells = await _session.get_cells()
         if index < 0 or index >= len(cells):
             return f"Error: Index {index} out of range (notebook has {len(cells)} cells)"
-        return _format_cell(cells[index])
+        cell = cells[index]
+        await _send_cell_cursor(_session, cell.id)
+        return _format_cell(cell)
     except Exception as e:
         return f"Error: {e}"
 
@@ -1117,6 +1129,7 @@ async def resource_cell_outputs(cell_id: str) -> str:
         return "Error: No active session"
 
     try:
+        await _send_cell_cursor(_session, cell_id)
         cell = await _session.get_cell(cell_id=cell_id)
         output_text = _format_outputs_text(cell.outputs)
         if not output_text:

--- a/python/nteract/src/nteract/_mcp_server.py
+++ b/python/nteract/src/nteract/_mcp_server.py
@@ -772,7 +772,7 @@ async def _send_edit_cursor(
 async def _send_cell_cursor(
     session: runtimed.AsyncSession, cell_id: str, line: int = 0, column: int = 0
 ) -> None:
-    """Send cursor presence on a cell (best-effort, non-blocking)."""
+    """Send cursor presence on a cell (best-effort, errors silently ignored)."""
     with contextlib.suppress(Exception):
         await session.set_cursor(cell_id=cell_id, line=line, column=column)
 


### PR DESCRIPTION
Emit presence events from cell operations so agents show up on cells they interact with in collaborative views.

Closes #774

**Changes in runtimed-py (Rust):**
- Add `peer_label` to `SessionState` for automatic presence emission
- Add `emit_cursor_presence()` helper (best-effort, errors silently ignored)  
- Emit presence from: `create_cell`, `set_source`, `move_cell`, `execute_cell`, `clear_outputs`, `run_all_cells`

**Changes in nteract MCP (Python):**
- Add `_send_cell_cursor()` helper for read operations
- Emit presence from: `get_cell` tool, `resource_cell`, `resource_cell_by_index`, `resource_cell_outputs`

**Frontend fixes:**
- Remove dead `usePresence()` call in `AppContent` (already called in `PresenceProvider`)
- Add missing `peer_label` field to `PresenceUpdate` in `usePresence.ts` so agent labels display correctly

## Verification

* [ ] Open notebook in nteract desktop app
* [ ] Run MCP server against same notebook  
* [ ] Use MCP tools (create_cell, execute_cell, etc.) and verify presence indicators appear in desktop UI with correct agent label
* [ ] Use read tools/resources (get_cell, etc.) and verify cursor appears on accessed cells

_PR submitted by @rgbkrk's agent, Quill_