### PR TITLE
feat(notebook): show "Cell hidden" chip and group consecutive hidden cells

### DIFF
--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -375,7 +375,7 @@ export function CodeCell({
             {/* Source visibility toggle + Editor */}
             {bothHidden ? (
               /* Compact layout: both badges side by side when both hidden */
-              <div className="flex justify-end gap-2">
+              <div className="flex justify-start gap-2">
                 <button
                   type="button"
                   onClick={() => onToggleSourceHidden?.(false)}
@@ -402,7 +402,7 @@ export function CodeCell({
                 </button>
               </div>
             ) : isSourceHidden ? (
-              <div className="flex justify-end">
+              <div className="flex justify-start">
                 <button
                   type="button"
                   onClick={() => onToggleSourceHidden?.(false)}
@@ -452,7 +452,7 @@ export function CodeCell({
         }
         outputContent={
           isOutputsHidden && cell.outputs.length > 0 ? (
-            <div className="flex justify-end">
+            <div className="flex justify-start">
               <button
                 type="button"
                 onClick={() => onToggleOutputsHidden?.(false)}

--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -160,9 +160,10 @@ export function CodeCell({
     (cell.metadata?.jupyter as { outputs_hidden?: boolean })?.outputs_hidden ===
     true;
 
-  // When both are hidden, show a compact single-row layout with both badges side by side
-  const bothHidden =
-    isSourceHidden && isOutputsHidden && cell.outputs.length > 0;
+  // When both are hidden, show a single "Cell hidden" chip.
+  // We check metadata only (not outputs.length) so the cell stays collapsed
+  // when outputs are transiently cleared during re-execution.
+  const bothHidden = isSourceHidden && isOutputsHidden;
 
   // Register EditorView with the cursor registry for remote cursor rendering.
   // We use a ref + polling approach because the EditorView is created async
@@ -322,7 +323,7 @@ export function CodeCell({
     handleExecuteWithClear();
   }, [handleExecuteWithClear]);
 
-  const gutterContent = (
+  const gutterContent = bothHidden ? null : (
     <CompactExecutionButton
       count={cell.execution_count}
       isExecuting={isExecuting}

--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -115,6 +115,10 @@ interface CodeCellProps {
   onToggleSourceHidden?: (hidden: boolean) => void;
   /** Callback to toggle outputs visibility (JupyterLab convention) */
   onToggleOutputsHidden?: (hidden: boolean) => void;
+  /** Number of consecutive fully-hidden cells in this group (including this one) */
+  hiddenGroupCount?: number;
+  /** Callback to expand all cells in a hidden group */
+  onExpandHiddenGroup?: () => void;
 }
 
 export function CodeCell({
@@ -141,6 +145,8 @@ export function CodeCell({
   isDragging,
   onToggleSourceHidden,
   onToggleOutputsHidden,
+  hiddenGroupCount,
+  onExpandHiddenGroup,
 }: CodeCellProps) {
   const editorRef = useRef<CodeMirrorEditorRef>(null);
   const [historyDialogOpen, setHistoryDialogOpen] = useState(false);
@@ -374,29 +380,28 @@ export function CodeCell({
           <>
             {/* Source visibility toggle + Editor */}
             {bothHidden ? (
-              /* Compact layout: both badges side by side when both hidden */
-              <div className="flex justify-start gap-2">
+              <div className="flex justify-start">
                 <button
                   type="button"
-                  onClick={() => onToggleSourceHidden?.(false)}
+                  onClick={() => {
+                    if (onExpandHiddenGroup) {
+                      onExpandHiddenGroup();
+                    } else {
+                      onToggleSourceHidden?.(false);
+                      onToggleOutputsHidden?.(false);
+                    }
+                  }}
                   className="inline-flex items-center gap-1 px-2 py-0.5 text-xs text-muted-foreground hover:text-foreground bg-muted/50 hover:bg-muted rounded transition-colors"
-                  title="Show source"
-                >
-                  <Code2 className="h-3 w-3" />
-                  <span className="font-mono truncate max-w-32">
-                    {cell.source.split("\n")[0] || "source"}
-                  </span>
-                  <ChevronRight className="h-3 w-3" />
-                </button>
-                <button
-                  type="button"
-                  onClick={() => onToggleOutputsHidden?.(false)}
-                  className="inline-flex items-center gap-1 px-2 py-0.5 text-xs text-muted-foreground hover:text-foreground bg-muted/50 hover:bg-muted rounded transition-colors"
-                  title="Show outputs"
+                  title={
+                    hiddenGroupCount && hiddenGroupCount > 1
+                      ? `Show ${hiddenGroupCount} cells`
+                      : "Show cell"
+                  }
                 >
                   <span>
-                    {cell.outputs.length} output
-                    {cell.outputs.length !== 1 ? "s" : ""}
+                    {hiddenGroupCount && hiddenGroupCount > 1
+                      ? `${hiddenGroupCount} cells hidden`
+                      : "Cell hidden"}
                   </span>
                   <ChevronRight className="h-3 w-3" />
                 </button>

--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -119,6 +119,8 @@ interface CodeCellProps {
   hiddenGroupCount?: number;
   /** Callback to expand all cells in a hidden group */
   onExpandHiddenGroup?: () => void;
+  /** Whether any cell in a hidden group is currently executing */
+  isGroupExecuting?: boolean;
 }
 
 export function CodeCell({
@@ -147,6 +149,7 @@ export function CodeCell({
   onToggleOutputsHidden,
   hiddenGroupCount,
   onExpandHiddenGroup,
+  isGroupExecuting,
 }: CodeCellProps) {
   const editorRef = useRef<CodeMirrorEditorRef>(null);
   const [historyDialogOpen, setHistoryDialogOpen] = useState(false);
@@ -392,7 +395,10 @@ export function CodeCell({
                       onToggleOutputsHidden?.(false);
                     }
                   }}
-                  className="inline-flex items-center gap-1 px-2 py-0.5 text-xs text-muted-foreground hover:text-foreground bg-muted/50 hover:bg-muted rounded transition-colors"
+                  className={cn(
+                    "inline-flex items-center gap-1 px-2 py-0.5 text-xs text-muted-foreground hover:text-foreground bg-muted/50 hover:bg-muted rounded transition-colors",
+                    (isExecuting || isGroupExecuting) && "animate-pulse",
+                  )}
                   title={
                     hiddenGroupCount && hiddenGroupCount > 1
                       ? `Show ${hiddenGroupCount} cells`

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -513,6 +513,11 @@ function NotebookViewContent({
                 : undefined
             }
             hiddenGroupCount={hiddenGroups.get(cell.id)?.count}
+            isGroupExecuting={
+              hiddenGroups
+                .get(cell.id)
+                ?.groupCellIds.some((id) => executingCellIds.has(id)) ?? false
+            }
             onExpandHiddenGroup={
               hiddenGroups.has(cell.id)
                 ? () => {

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -199,6 +199,19 @@ function CellDragPreview({ cell }: { cell: NotebookCell | undefined }) {
   );
 }
 
+/** Check if a cell has both source and outputs hidden */
+function isCellFullyHidden(cell: NotebookCell): boolean {
+  if (cell.cell_type !== "code") return false;
+  const jupyter = cell.metadata?.jupyter as
+    | { source_hidden?: boolean; outputs_hidden?: boolean }
+    | undefined;
+  return (
+    jupyter?.source_hidden === true &&
+    jupyter?.outputs_hidden === true &&
+    (cell as CodeCellType).outputs.length > 0
+  );
+}
+
 /** Wrapper component for sortable cells */
 function SortableCell({
   cell,
@@ -206,6 +219,7 @@ function SortableCell({
   renderCell,
   onAddCell,
   onDeleteCell,
+  isHiddenInGroup,
 }: {
   cell: NotebookCell;
   index: number;
@@ -217,6 +231,7 @@ function SortableCell({
   ) => React.ReactNode;
   onAddCell: (type: "code" | "markdown", afterCellId?: string | null) => void;
   onDeleteCell: (cellId: string) => void;
+  isHiddenInGroup?: boolean;
 }) {
   const {
     attributes,
@@ -238,6 +253,10 @@ function SortableCell({
     ...listeners,
     ...attributes,
   };
+
+  if (isHiddenInGroup) {
+    return <div ref={setNodeRef} style={style} />;
+  }
 
   return (
     <div ref={setNodeRef} style={style}>
@@ -331,6 +350,35 @@ function NotebookViewContent({
 
   // Memoize cell IDs array
   const cellIds = useMemo(() => cells.map((c) => c.id), [cells]);
+
+  // Compute consecutive groups of fully-hidden cells
+  // Maps cell ID → { count, isFirst, groupCellIds }
+  const hiddenGroups = useMemo(() => {
+    const groups = new Map<
+      string,
+      { count: number; isFirst: boolean; groupCellIds: string[] }
+    >();
+    let i = 0;
+    while (i < cells.length) {
+      if (isCellFullyHidden(cells[i])) {
+        const groupCellIds: string[] = [];
+        while (i < cells.length && isCellFullyHidden(cells[i])) {
+          groupCellIds.push(cells[i].id);
+          i++;
+        }
+        for (let j = 0; j < groupCellIds.length; j++) {
+          groups.set(groupCellIds[j], {
+            count: groupCellIds.length,
+            isFirst: j === 0,
+            groupCellIds,
+          });
+        }
+      } else {
+        i++;
+      }
+    }
+    return groups;
+  }, [cells]);
 
   // Compute the cell ID that precedes the focused cell (keeps its output bright)
   const previousCellId = useMemo(() => {
@@ -466,6 +514,20 @@ function NotebookViewContent({
                 ? (hidden: boolean) => onSetCellOutputsHidden(cell.id, hidden)
                 : undefined
             }
+            hiddenGroupCount={hiddenGroups.get(cell.id)?.count}
+            onExpandHiddenGroup={
+              hiddenGroups.has(cell.id)
+                ? () => {
+                    const group = hiddenGroups.get(cell.id);
+                    if (group) {
+                      for (const id of group.groupCellIds) {
+                        onSetCellSourceHidden?.(id, false);
+                        onSetCellOutputsHidden?.(id, false);
+                      }
+                    }
+                  }
+                : undefined
+            }
           />
         );
       }
@@ -531,6 +593,7 @@ function NotebookViewContent({
       onReportOutputMatchCount,
       onSetCellSourceHidden,
       onSetCellOutputsHidden,
+      hiddenGroups,
       focusCell,
     ],
   );
@@ -584,16 +647,20 @@ function NotebookViewContent({
             items={cellIds}
             strategy={verticalListSortingStrategy}
           >
-            {cells.map((cell, index) => (
-              <SortableCell
-                key={cell.id}
-                cell={cell}
-                index={index}
-                renderCell={renderCell}
-                onAddCell={onAddCell}
-                onDeleteCell={onDeleteCell}
-              />
-            ))}
+            {cells.map((cell, index) => {
+              const group = hiddenGroups.get(cell.id);
+              return (
+                <SortableCell
+                  key={cell.id}
+                  cell={cell}
+                  index={index}
+                  renderCell={renderCell}
+                  onAddCell={onAddCell}
+                  onDeleteCell={onDeleteCell}
+                  isHiddenInGroup={group != null && !group.isFirst}
+                />
+              );
+            })}
           </SortableContext>
           <DragOverlay>
             {activeCell && <CellDragPreview cell={activeCell} />}

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -199,17 +199,15 @@ function CellDragPreview({ cell }: { cell: NotebookCell | undefined }) {
   );
 }
 
-/** Check if a cell has both source and outputs hidden */
+/** Check if a cell has both source and outputs hidden via metadata.
+ *  We intentionally don't check outputs.length so cells stay collapsed
+ *  when outputs are transiently cleared during re-execution. */
 function isCellFullyHidden(cell: NotebookCell): boolean {
   if (cell.cell_type !== "code") return false;
   const jupyter = cell.metadata?.jupyter as
     | { source_hidden?: boolean; outputs_hidden?: boolean }
     | undefined;
-  return (
-    jupyter?.source_hidden === true &&
-    jupyter?.outputs_hidden === true &&
-    (cell as CodeCellType).outputs.length > 0
-  );
+  return jupyter?.source_hidden === true && jupyter?.outputs_hidden === true;
 }
 
 /** Wrapper component for sortable cells */

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -432,13 +432,22 @@ function NotebookViewContent({
       const isFocused = cell.id === focusedCellId;
       const isExecuting = executingCellIds.has(cell.id);
 
-      // Navigation callbacks
+      // Navigation callbacks — skip cells that are collapsed into a hidden group
+      const isVisibleCell = (id: string) => {
+        const g = hiddenGroups.get(id);
+        return !g || g.isFirst;
+      };
+
       const onFocusPrevious = (cursorPosition: "start" | "end") => {
         logger.debug(
           `[cell-nav] onFocusPrevious called: cell=${cell.id.slice(0, 8)} index=${index} cellIds=${cellIds.map((id) => id.slice(0, 8)).join(",")}`,
         );
-        if (index > 0) {
-          const prevCellId = cellIds[index - 1];
+        let prevIndex = index - 1;
+        while (prevIndex >= 0 && !isVisibleCell(cellIds[prevIndex])) {
+          prevIndex--;
+        }
+        if (prevIndex >= 0) {
+          const prevCellId = cellIds[prevIndex];
           logger.debug(
             `[cell-nav] Focusing previous: ${prevCellId.slice(0, 8)}`,
           );
@@ -453,8 +462,15 @@ function NotebookViewContent({
         logger.debug(
           `[cell-nav] onFocusNext called: cell=${cell.id.slice(0, 8)} index=${index} cellIds=${cellIds.map((id) => id.slice(0, 8)).join(",")}`,
         );
-        if (index < cellIds.length - 1) {
-          const nextCellId = cellIds[index + 1];
+        let nextIndex = index + 1;
+        while (
+          nextIndex < cellIds.length &&
+          !isVisibleCell(cellIds[nextIndex])
+        ) {
+          nextIndex++;
+        }
+        if (nextIndex < cellIds.length) {
+          const nextCellId = cellIds[nextIndex];
           logger.debug(`[cell-nav] Focusing next: ${nextCellId.slice(0, 8)}`);
           onFocusCell(nextCellId);
           focusCell(nextCellId, cursorPosition);
@@ -519,13 +535,15 @@ function NotebookViewContent({
                 ?.groupCellIds.some((id) => executingCellIds.has(id)) ?? false
             }
             onExpandHiddenGroup={
-              hiddenGroups.has(cell.id)
+              hiddenGroups.has(cell.id) &&
+              onSetCellSourceHidden &&
+              onSetCellOutputsHidden
                 ? () => {
                     const group = hiddenGroups.get(cell.id);
                     if (group) {
                       for (const id of group.groupCellIds) {
-                        onSetCellSourceHidden?.(id, false);
-                        onSetCellOutputsHidden?.(id, false);
+                        onSetCellSourceHidden(id, false);
+                        onSetCellOutputsHidden(id, false);
                       }
                     }
                   }


### PR DESCRIPTION
When both source and outputs are hidden on a code cell, instead of showing two separate chips (one for source, one for outputs), show a single **"Cell hidden"** chip. When multiple consecutive cells are fully hidden, they collapse into a single **"N cells hidden"** chip that expands all cells in the group on click.

This also keeps the left-alignment for chips when only source or only outputs are hidden.

<!-- screenshots -->

## Verification

* [ ] Hide both source and outputs on a single cell — shows "Cell hidden" chip
* [ ] Click "Cell hidden" — both source and outputs are restored
* [ ] Hide both source and outputs on 2+ consecutive cells — first cell shows "N cells hidden", others are collapsed
* [ ] Click "N cells hidden" — all cells in the group are expanded
* [ ] Non-consecutive fully-hidden cells each show their own "Cell hidden" chip
* [ ] Hiding only source or only outputs still works as before (individual chips)

_PR submitted by @rgbkrk's agent, Quill_