### PR TITLE
refactor(notebook): migrate tauri from NotebookSyncClient to notebook-sync DocHandle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3447,6 +3447,7 @@ dependencies = [
  "log",
  "nbformat",
  "nix",
+ "notebook-sync",
  "pathdiff",
  "petname",
  "pyproject-toml",

--- a/crates/notebook-sync/src/connect.rs
+++ b/crates/notebook-sync/src/connect.rs
@@ -176,6 +176,7 @@ pub async fn connect_with_options(
         pending_broadcasts,
         reader,
         writer,
+        None,
     )
     .map(|(handle, broadcast_rx)| ConnectResult {
         handle,
@@ -187,6 +188,27 @@ pub async fn connect_with_options(
 
 /// Connect and open an existing notebook file.
 pub async fn connect_open(socket_path: PathBuf, path: PathBuf) -> Result<OpenResult, SyncError> {
+    connect_open_impl(socket_path, path, None).await
+}
+
+/// Open a notebook with pipe frame forwarding for Tauri relay mode.
+///
+/// Same as `connect_open` but forwards raw daemon frames to the given
+/// channel before processing them locally. Used by the Tauri webview
+/// to relay frames to the WASM frontend.
+pub async fn connect_open_with_pipe(
+    socket_path: PathBuf,
+    path: PathBuf,
+    pipe_frame_tx: mpsc::UnboundedSender<Vec<u8>>,
+) -> Result<OpenResult, SyncError> {
+    connect_open_impl(socket_path, path, Some(pipe_frame_tx)).await
+}
+
+async fn connect_open_impl(
+    socket_path: PathBuf,
+    path: PathBuf,
+    pipe_frame_tx: Option<mpsc::UnboundedSender<Vec<u8>>>,
+) -> Result<OpenResult, SyncError> {
     let stream = connect_stream!(&socket_path);
     let (reader, writer) = tokio::io::split(stream);
     let mut reader = tokio::io::BufReader::new(reader);
@@ -244,6 +266,7 @@ pub async fn connect_open(socket_path: PathBuf, path: PathBuf) -> Result<OpenRes
         pending_broadcasts,
         reader,
         writer,
+        pipe_frame_tx,
     )
     .map(|(handle, broadcast_rx)| OpenResult {
         handle,
@@ -262,6 +285,38 @@ pub async fn connect_create(
     runtime: &str,
     working_dir: Option<PathBuf>,
 ) -> Result<CreateResult, SyncError> {
+    connect_create_impl(socket_path, runtime, working_dir, None, None).await
+}
+
+/// Create a notebook with pipe frame forwarding for Tauri relay mode.
+///
+/// Same as `connect_create` but forwards raw daemon frames to the given
+/// channel before processing them locally. Used by the Tauri webview
+/// to relay frames to the WASM frontend.
+pub async fn connect_create_with_pipe(
+    socket_path: PathBuf,
+    runtime: &str,
+    working_dir: Option<PathBuf>,
+    notebook_id: Option<String>,
+    pipe_frame_tx: mpsc::UnboundedSender<Vec<u8>>,
+) -> Result<CreateResult, SyncError> {
+    connect_create_impl(
+        socket_path,
+        runtime,
+        working_dir,
+        notebook_id,
+        Some(pipe_frame_tx),
+    )
+    .await
+}
+
+async fn connect_create_impl(
+    socket_path: PathBuf,
+    runtime: &str,
+    working_dir: Option<PathBuf>,
+    notebook_id: Option<String>,
+    pipe_frame_tx: Option<mpsc::UnboundedSender<Vec<u8>>>,
+) -> Result<CreateResult, SyncError> {
     let stream = connect_stream!(&socket_path);
     let (reader, writer) = tokio::io::split(stream);
     let mut reader = tokio::io::BufReader::new(reader);
@@ -276,7 +331,7 @@ pub async fn connect_create(
         working_dir: working_dir
             .as_ref()
             .map(|p| p.to_string_lossy().to_string()),
-        notebook_id: None,
+        notebook_id,
     };
     connection::send_json_frame(&mut writer, &handshake)
         .await
@@ -323,6 +378,7 @@ pub async fn connect_create(
         pending_broadcasts,
         reader,
         writer,
+        pipe_frame_tx,
     )
     .map(|(handle, broadcast_rx)| CreateResult {
         handle,
@@ -347,6 +403,7 @@ fn build_and_spawn<R, W>(
     pending_broadcasts: Vec<NotebookBroadcast>,
     reader: R,
     writer: W,
+    pipe_frame_tx: Option<mpsc::UnboundedSender<Vec<u8>>>,
 ) -> Result<(DocHandle, crate::BroadcastReceiver), SyncError>
 where
     R: AsyncRead + Unpin + Send + 'static,
@@ -387,6 +444,7 @@ where
         cmd_rx,
         snapshot_tx: Arc::clone(&snapshot_tx),
         broadcast_tx,
+        pipe_frame_tx,
     };
 
     let notebook_id_for_task = notebook_id;

--- a/crates/notebook-sync/src/handle.rs
+++ b/crates/notebook-sync/src/handle.rs
@@ -441,6 +441,23 @@ impl DocHandle {
         reply_rx.await.map_err(|_| SyncError::Disconnected)?
     }
 
+    /// Forward a raw Automerge sync message from the frontend (WASM) to the daemon.
+    ///
+    /// In pipe mode, the WASM frontend generates sync messages that need to be
+    /// applied to the local doc and forwarded to the daemon. This method sends
+    /// the raw bytes through the sync task which handles decode, apply, and relay.
+    pub async fn receive_frontend_sync_message(&self, message: Vec<u8>) -> Result<(), SyncError> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.cmd_tx
+            .send(SyncCommand::ReceiveFrontendSyncMessage {
+                message,
+                reply: reply_tx,
+            })
+            .await
+            .map_err(|_| SyncError::Disconnected)?;
+        reply_rx.await.map_err(|_| SyncError::Disconnected)?
+    }
+
     // =====================================================================
     // Read-only access — no lock needed
     // =====================================================================

--- a/crates/notebook-sync/src/sync_task.rs
+++ b/crates/notebook-sync/src/sync_task.rs
@@ -85,6 +85,11 @@ pub struct SyncTaskConfig {
 
     /// Broadcast sender for kernel/execution events from the daemon.
     pub broadcast_tx: broadcast::Sender<NotebookBroadcast>,
+
+    /// Optional channel for forwarding raw daemon frames to a pipe consumer
+    /// (e.g. Tauri relay to WASM frontend). When `Some`, incoming frames are
+    /// cloned to this sender before local processing.
+    pub pipe_frame_tx: Option<mpsc::UnboundedSender<Vec<u8>>>,
 }
 
 /// Run the sync task.
@@ -189,6 +194,7 @@ where
                             &config.snapshot_tx,
                             &config.broadcast_tx,
                             &notebook_id,
+                            &config.pipe_frame_tx,
                         )
                         .await;
                     }
@@ -245,6 +251,7 @@ where
                             &config.snapshot_tx,
                             &config.broadcast_tx,
                             &notebook_id,
+                            &config.pipe_frame_tx,
                         )
                         .await;
                         let _ = reply.send(result);
@@ -303,6 +310,7 @@ where
                         &config.snapshot_tx,
                         &config.broadcast_tx,
                         &notebook_id,
+                        &config.pipe_frame_tx,
                     )
                     .await;
                 }
@@ -342,7 +350,16 @@ async fn handle_incoming_frame<W: AsyncWrite + Unpin>(
     snapshot_tx: &Arc<tokio::sync::watch::Sender<NotebookSnapshot>>,
     broadcast_tx: &broadcast::Sender<NotebookBroadcast>,
     notebook_id: &str,
+    pipe_frame_tx: &Option<mpsc::UnboundedSender<Vec<u8>>>,
 ) {
+    // Forward raw frame to pipe consumer before local processing.
+    // This preserves frame ordering for the WASM frontend.
+    if let Some(ref pipe_tx) = pipe_frame_tx {
+        let mut bytes = vec![frame.frame_type as u8];
+        bytes.extend_from_slice(&frame.payload);
+        let _ = pipe_tx.send(bytes);
+    }
+
     match frame.frame_type {
         NotebookFrameType::AutomergeSync => {
             let msg = match sync::Message::decode(&frame.payload) {
@@ -556,6 +573,7 @@ async fn confirm_sync_impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
     snapshot_tx: &Arc<tokio::sync::watch::Sender<NotebookSnapshot>>,
     broadcast_tx: &broadcast::Sender<NotebookBroadcast>,
     notebook_id: &str,
+    pipe_frame_tx: &Option<mpsc::UnboundedSender<Vec<u8>>>,
 ) -> Result<(), SyncError> {
     for round in 0..5 {
         // Generate and send sync message
@@ -591,8 +609,16 @@ async fn confirm_sync_impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
         .await
         {
             Ok(Ok(Some(frame))) => {
-                handle_incoming_frame(&frame, doc, writer, snapshot_tx, broadcast_tx, notebook_id)
-                    .await;
+                handle_incoming_frame(
+                    &frame,
+                    doc,
+                    writer,
+                    snapshot_tx,
+                    broadcast_tx,
+                    notebook_id,
+                    pipe_frame_tx,
+                )
+                .await;
             }
             Ok(Ok(None)) => {
                 return Err(SyncError::Protocol(

--- a/crates/notebook-sync/src/sync_task.rs
+++ b/crates/notebook-sync/src/sync_task.rs
@@ -238,6 +238,7 @@ where
                             req_broadcast_tx.as_ref(),
                             &request,
                             &notebook_id,
+                            &config.pipe_frame_tx,
                         )
                         .await;
                         let _ = reply.send(result);
@@ -352,12 +353,20 @@ async fn handle_incoming_frame<W: AsyncWrite + Unpin>(
     notebook_id: &str,
     pipe_frame_tx: &Option<mpsc::UnboundedSender<Vec<u8>>>,
 ) {
-    // Forward raw frame to pipe consumer before local processing.
-    // This preserves frame ordering for the WASM frontend.
+    // Forward sync/broadcast/presence frames to pipe consumer before local
+    // processing. Response and Request frames are internal to the protocol
+    // and must not be piped to the WASM frontend.
     if let Some(ref pipe_tx) = pipe_frame_tx {
-        let mut bytes = vec![frame.frame_type as u8];
-        bytes.extend_from_slice(&frame.payload);
-        let _ = pipe_tx.send(bytes);
+        match frame.frame_type {
+            NotebookFrameType::AutomergeSync
+            | NotebookFrameType::Broadcast
+            | NotebookFrameType::Presence => {
+                let mut bytes = vec![frame.frame_type as u8];
+                bytes.extend_from_slice(&frame.payload);
+                let _ = pipe_tx.send(bytes);
+            }
+            _ => {}
+        }
     }
 
     match frame.frame_type {
@@ -457,6 +466,7 @@ async fn send_request_impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
     req_broadcast_tx: Option<&broadcast::Sender<NotebookBroadcast>>,
     request: &NotebookRequest,
     notebook_id: &str,
+    pipe_frame_tx: &Option<mpsc::UnboundedSender<Vec<u8>>>,
 ) -> Result<NotebookResponse, SyncError> {
     // Serialize and send the request
     let payload =
@@ -483,6 +493,7 @@ async fn send_request_impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
             broadcast_tx,
             req_broadcast_tx,
             notebook_id,
+            pipe_frame_tx,
         ),
     )
     .await;
@@ -495,6 +506,7 @@ async fn send_request_impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
 }
 
 /// Wait for a Response frame from the daemon, processing other frames.
+#[allow(clippy::too_many_arguments)]
 async fn wait_for_response<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
     doc: &Arc<Mutex<SharedDocState>>,
     reader: &mut R,
@@ -503,12 +515,30 @@ async fn wait_for_response<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
     broadcast_tx: &broadcast::Sender<NotebookBroadcast>,
     req_broadcast_tx: Option<&broadcast::Sender<NotebookBroadcast>>,
     notebook_id: &str,
+    pipe_frame_tx: &Option<mpsc::UnboundedSender<Vec<u8>>>,
 ) -> Result<NotebookResponse, SyncError> {
     loop {
         let frame = connection::recv_typed_frame(reader)
             .await
             .map_err(SyncError::Io)?
             .ok_or_else(|| SyncError::Protocol("Connection closed waiting for response".into()))?;
+
+        // Forward sync/broadcast/presence frames to pipe consumer while
+        // waiting for a response. Without this, daemon frames received
+        // during a request/response cycle would be consumed locally but
+        // never reach the WASM frontend, causing it to desync.
+        if let Some(ref pipe_tx) = pipe_frame_tx {
+            match frame.frame_type {
+                NotebookFrameType::AutomergeSync
+                | NotebookFrameType::Broadcast
+                | NotebookFrameType::Presence => {
+                    let mut bytes = vec![frame.frame_type as u8];
+                    bytes.extend_from_slice(&frame.payload);
+                    let _ = pipe_tx.send(bytes);
+                }
+                _ => {}
+            }
+        }
 
         match frame.frame_type {
             NotebookFrameType::Response => {

--- a/crates/notebook/Cargo.toml
+++ b/crates/notebook/Cargo.toml
@@ -37,6 +37,7 @@ jupyter-protocol = { workspace = true }
 runtimelib = { workspace = true, features = ["tokio-runtime", "aws-lc-rs"] }
 tauri-jupyter = { path = "../tauri-jupyter" }
 runtimed = { path = "../runtimed" }
+notebook-sync = { path = "../notebook-sync" }
 runt-trust = { path = "../runt-trust" }
 runt-workspace = { path = "../runt-workspace" }
 kernel-launch = { path = "../kernel-launch" }

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -21,7 +21,7 @@ pub mod webdriver;
 
 pub use runtime::Runtime;
 
-use runtimed::notebook_sync_client::{NotebookSyncClient, NotebookSyncHandle};
+use notebook_sync::DocHandle;
 use runtimed::protocol::{CompletionItem, HistoryEntry, NotebookRequest, NotebookResponse};
 
 use log::{debug, info, warn};
@@ -32,7 +32,7 @@ use std::ffi::OsStr;
 /// Shared notebook sync handle for cross-window state synchronization.
 /// The Option allows graceful fallback when daemon is unavailable.
 /// Uses the split handle pattern - the handle is clonable and doesn't block.
-type SharedNotebookSync = Arc<tokio::sync::Mutex<Option<NotebookSyncHandle>>>;
+type SharedNotebookSync = Arc<tokio::sync::Mutex<Option<DocHandle>>>;
 
 #[derive(Clone)]
 struct WindowNotebookContext {
@@ -244,7 +244,7 @@ where
 /// Read the notebook metadata from the daemon's canonical Automerge doc.
 /// Returns the deserialized NotebookMetadataSnapshot, or None if not available.
 async fn get_metadata_snapshot(
-    handle: &NotebookSyncHandle,
+    handle: &DocHandle,
 ) -> Option<runtimed::notebook_metadata::NotebookMetadataSnapshot> {
     match handle
         .send_request(NotebookRequest::GetMetadataSnapshot {})
@@ -259,7 +259,7 @@ async fn get_metadata_snapshot(
 
 /// Write a NotebookMetadataSnapshot to the daemon's canonical Automerge doc.
 async fn set_metadata_snapshot(
-    handle: &NotebookSyncHandle,
+    handle: &DocHandle,
     snapshot: &runtimed::notebook_metadata::NotebookMetadataSnapshot,
 ) -> Result<(), String> {
     let snapshot_json =
@@ -280,7 +280,7 @@ async fn set_metadata_snapshot(
 /// Read the metadata `additional` fields from the daemon's Automerge doc.
 /// Returns a HashMap with the `runt` field as a JSON value for trust verification.
 async fn get_raw_metadata_additional(
-    handle: &NotebookSyncHandle,
+    handle: &DocHandle,
 ) -> Option<HashMap<String, serde_json::Value>> {
     let snapshot = get_metadata_snapshot(handle).await?;
     let runt_value = serde_json::to_value(&snapshot.runt).ok()?;
@@ -291,7 +291,7 @@ async fn get_raw_metadata_additional(
 
 /// Write trust fields into the daemon's metadata.
 async fn set_raw_trust_in_metadata(
-    handle: &NotebookSyncHandle,
+    handle: &DocHandle,
     signature: &str,
     timestamp: &str,
 ) -> Result<(), String> {
@@ -472,12 +472,13 @@ async fn initialize_notebook_sync_open(
     );
 
     let (frame_tx, raw_frame_rx) = tokio::sync::mpsc::unbounded_channel::<Vec<u8>>();
-    let pipe_channel = runtimed::notebook_sync_client::PipeChannel { frame_tx };
 
-    let (handle, receiver, _broadcast_receiver, _cells, _metadata, info) =
-        NotebookSyncClient::connect_open_split(socket_path, path, Some(pipe_channel))
-            .await
-            .map_err(|e| format!("sync connect (open): {}", e))?;
+    let result = notebook_sync::connect::connect_open_with_pipe(socket_path, path, frame_tx)
+        .await
+        .map_err(|e| format!("sync connect (open): {}", e))?;
+
+    let handle = result.handle;
+    let info = result.info;
 
     info!(
         "[notebook-sync] Daemon opened notebook: id={}, cells={}, trust_approval={}",
@@ -494,10 +495,6 @@ async fn initialize_notebook_sync_open(
         cell_count: info.cell_count,
         needs_trust_approval: info.needs_trust_approval,
     };
-
-    // Drop the SyncUpdate receiver — in pipe mode the relay never sends metadata
-    // diffs through changes_tx, and no frontend code listens for notebook:metadata_updated.
-    drop(receiver);
 
     setup_sync_receivers(
         window,
@@ -537,18 +534,19 @@ async fn initialize_notebook_sync_create(
     );
 
     let (frame_tx, raw_frame_rx) = tokio::sync::mpsc::unbounded_channel::<Vec<u8>>();
-    let pipe_channel = runtimed::notebook_sync_client::PipeChannel { frame_tx };
 
-    let (handle, receiver, _broadcast_receiver, _cells, _metadata, info) =
-        NotebookSyncClient::connect_create_split(
-            socket_path,
-            runtime,
-            working_dir,
-            notebook_id_hint,
-            Some(pipe_channel),
-        )
-        .await
-        .map_err(|e| format!("sync connect (create): {}", e))?;
+    let result = notebook_sync::connect::connect_create_with_pipe(
+        socket_path,
+        &runtime,
+        working_dir,
+        notebook_id_hint,
+        frame_tx,
+    )
+    .await
+    .map_err(|e| format!("sync connect (create): {}", e))?;
+
+    let handle = result.handle;
+    let info = result.info;
 
     info!(
         "[notebook-sync] Daemon created notebook: id={}, cells={}",
@@ -565,8 +563,6 @@ async fn initialize_notebook_sync_create(
         cell_count: info.cell_count,
         needs_trust_approval: info.needs_trust_approval,
     };
-
-    drop(receiver);
 
     setup_sync_receivers(
         window,
@@ -595,7 +591,7 @@ async fn initialize_notebook_sync_create(
 async fn setup_sync_receivers(
     window: tauri::WebviewWindow,
     notebook_id: String,
-    handle: NotebookSyncHandle,
+    handle: DocHandle,
     mut raw_frame_rx: tokio::sync::mpsc::UnboundedReceiver<Vec<u8>>,
     notebook_sync: SharedNotebookSync,
     sync_generation: Arc<AtomicU64>,

--- a/python/runtimed/demos/test-presence.ipynb
+++ b/python/runtimed/demos/test-presence.ipynb
@@ -1,215 +1,214 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 5,
-  "metadata": {
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3",
-      "language": "python"
-    },
-    "language_info": {
-      "name": "python",
-      "version": "3.12.0"
-    },
-    "runt": {
-      "schema_version": "1"
-    }
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "8897a84c",
+   "metadata": {},
+   "source": [
+    "# Presence Test\n",
+    "\n",
+    "This notebook connects a second peer (\"notebook-agent\") back to itself via `runtimed`,\n",
+    "then animates cursor presence across cells. You should see a colored cursor bar and\n",
+    "gutter dots appear as the agent peer moves around.\n",
+    "\n",
+    "**Requirements:** Open this notebook in the nteract dev app. The daemon will resolve\n",
+    "`runtimed` from `python/runtimed/pyproject.toml` automatically."
+   ]
   },
-  "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "21e509b9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "\n",
+    "import runtimed"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "69618507",
+   "metadata": {},
+   "outputs": [
     {
-      "id": "8897a84c",
-      "cell_type": "markdown",
-      "source": [
-        "# Presence Test\n",
-        "\n",
-        "This notebook connects a second peer (\"notebook-agent\") back to itself via `runtimed`,\n",
-        "then animates cursor presence across cells. You should see a colored cursor bar and\n",
-        "gutter dots appear as the agent peer moves around.\n",
-        "\n",
-        "**Requirements:** Open this notebook in the nteract dev app. The daemon will resolve\n",
-        "`runtimed` from `python/runtimed/pyproject.toml` automatically."
-      ],
-      "metadata": {}
-    },
-    {
-      "id": "21e509b9",
-      "cell_type": "code",
-      "source": [
-        "import runtimed\n",
-        "import time\n",
-        "import os"
-      ],
-      "metadata": {},
-      "outputs": [],
-      "execution_count": 1
-    },
-    {
-      "id": "69618507",
-      "cell_type": "code",
-      "source": [
-        "# Connect a second peer to this same notebook.\n",
-        "# The daemon client auto-detects the socket path.\n",
-        "client = runtimed.DaemonClient()\n",
-        "rooms = client.list_rooms()\n",
-        "print(f\"Open notebooks: {len(rooms)}\")\n",
-        "for r in rooms:\n",
-        "    print(f\"  {r['notebook_id']}\")"
-      ],
-      "metadata": {},
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": "Open notebooks: 2\n  /Users/kylekelley/code/src/github.com/nteract/worktrees/desktop/new-branch-who\n\u001b[0m-dis/notebooks/whatevs.ipynb\n  /Users/kylekelley/code/src/github.com/nteract/worktrees/desktop/new-branch-who\n\u001b[0m-dis/python/runtimed/demos/test-presence.ipynb\n"
-        }
-      ],
-      "execution_count": 2
-    },
-    {
-      "id": "19115018",
-      "cell_type": "code",
-      "source": [
-        "# Pick the first room (this notebook) and connect as a second peer\n",
-        "notebook_id = None\n",
-        "\n",
-        "for room in rooms:\n",
-        "    if \"test-presence\" in room[\"notebook_id\"]:\n",
-        "        notebook_id = room[\"notebook_id\"]\n",
-        "\n",
-        "if notebook_id is None:\n",
-        "    raise ValueError(\"Test Presence not found\")\n",
-        "session = runtimed.Session(notebook_id=notebook_id, peer_label=\"\\U0001f916 Agent\")\n",
-        "session.connect()\n",
-        "print(f\"Connected to {notebook_id} as second peer\")"
-      ],
-      "metadata": {},
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": "Connected to /Users/kylekelley/code/src/github.com/nteract/worktrees/desktop/new\n\u001b[0m-branch-who-dis/python/runtimed/demos/test-presence.ipynb as second peer\n"
-        }
-      ],
-      "execution_count": 6
-    },
-    {
-      "id": "36841cd7",
-      "cell_type": "code",
-      "source": [
-        "# List cells — you should see a gutter dot appear briefly on each cell\n",
-        "import time\n",
-        "\n",
-        "cells = session.get_cells()\n",
-        "print(f\"{len(cells)} cells:\")\n",
-        "for i, c in enumerate(cells):\n",
-        "    time.sleep(0.5)\n",
-        "    preview = c.source[:50].replace(\"\\n\", \"\\u21b5\") if c.source else \"(empty)\"\n",
-        "    print(f\"  [{i}] {c.cell_type}: {preview}\")"
-      ],
-      "metadata": {},
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": "9 cells:\n  [0] markdown: # Presence Test↵↵This notebook connects a second p\n  [1] code: import runtimed↵import time↵import os\n  [2] code: # Connect a second peer to this same notebook.↵# T\n  [3] code: # Pick the first room (this notebook) and connect\n  [4] code: # List cells — you should see a gutter dot appear\n  [5] code: # Animate cursor across cells — watch the gutter d\n  [6] code: # Animate cursor within this cell — watch the curs\n  [7] code: # Selection demo — grow a highlight across a cell↵\n  [8] code: # Clean up — disconnect the second peer↵session.cl\n"
-        }
-      ],
-      "execution_count": 8
-    },
-    {
-      "id": "0fc5b64f",
-      "cell_type": "code",
-      "source": [
-        "# Animate cursor across cells — watch the gutter dots jump\n",
-        "print(\"Jumping between cells...\")\n",
-        "for c in cells:\n",
-        "    session.set_cursor(c.id, line=0, column=0)\n",
-        "    time.sleep(0.8)\n",
-        "print(\"Done — did you see the dots?\")"
-      ],
-      "metadata": {},
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": "Jumping between cells...\nDone — did you see the dots?\n"
-        }
-      ],
-      "execution_count": 10
-    },
-    {
-      "id": "8494d4d2",
-      "cell_type": "code",
-      "source": [
-        "# Animate cursor within this cell — watch the cursor bar sweep\n",
-        "code_cells = [c for c in cells if c.cell_type == \"code\" and len(c.source) > 20]\n",
-        "if code_cells:\n",
-        "    target = code_cells[0]\n",
-        "    lines = target.source.split(\"\\n\")\n",
-        "    print(f\"Sweeping cursor across '{lines[0][:30]}...' ({len(lines)} lines)\")\n",
-        "    for line_num, line_text in enumerate(lines[:5]):\n",
-        "        for col in range(0, len(line_text) + 1, 2):\n",
-        "            session.set_cursor(target.id, line=line_num, column=col)\n",
-        "            time.sleep(0.03)\n",
-        "    print(\"Sweep complete\")\n",
-        "else:\n",
-        "    print(\"No code cells with enough content to demo\")"
-      ],
-      "metadata": {},
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": "Sweeping cursor across 'import runtimed...' (3 lines)\nSweep complete\n"
-        }
-      ],
-      "execution_count": 12
-    },
-    {
-      "id": "dcb513c9",
-      "cell_type": "code",
-      "source": [
-        "# Selection demo — grow a highlight across a cell\n",
-        "if code_cells:\n",
-        "    target = code_cells[0]\n",
-        "    lines = target.source.split(\"\\n\")\n",
-        "    print(\"Growing selection...\")\n",
-        "    for line_num, line_text in enumerate(lines[:4]):\n",
-        "        for col in range(0, len(line_text) + 1, 3):\n",
-        "            session.set_selection(\n",
-        "                target.id,\n",
-        "                anchor_line=0,\n",
-        "                anchor_col=0,\n",
-        "                head_line=line_num,\n",
-        "                head_col=col,\n",
-        "            )\n",
-        "            time.sleep(0.05)\n",
-        "    time.sleep(1)\n",
-        "    # Clear by setting cursor\n",
-        "    session.set_cursor(target.id, line=0, column=0)\n",
-        "    print(\"Selection cleared\")"
-      ],
-      "metadata": {},
-      "outputs": [
-        {
-          "output_type": "stream",
-          "name": "stdout",
-          "text": "Growing selection...\nSelection cleared\n"
-        }
-      ],
-      "execution_count": 13
-    },
-    {
-      "id": "824f8f0e",
-      "cell_type": "code",
-      "source": [
-        "# Clean up — disconnect the second peer\n",
-        "session.close()\n",
-        "print(\"Second peer disconnected — cursor should disappear\")"
-      ],
-      "metadata": {},
-      "outputs": [],
-      "execution_count": null
+     "name": "stdout",
+     "output_type": "stream",
+     "text": "Open notebooks: 2\n  /Users/kylekelley/code/src/github.com/nteract/worktrees/desktop/new-branch-who\n\u001b[0m-dis/notebooks/whatevs.ipynb\n  /Users/kylekelley/code/src/github.com/nteract/worktrees/desktop/new-branch-who\n\u001b[0m-dis/python/runtimed/demos/test-presence.ipynb\n"
     }
-  ]
+   ],
+   "source": [
+    "# Connect a second peer to this same notebook.\n",
+    "# The daemon client auto-detects the socket path.\n",
+    "client = runtimed.DaemonClient()\n",
+    "rooms = client.list_rooms()\n",
+    "print(f\"Open notebooks: {len(rooms)}\")\n",
+    "for r in rooms:\n",
+    "    print(f\"  {r['notebook_id']}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "19115018",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": "Connected to /Users/kylekelley/code/src/github.com/nteract/worktrees/desktop/new\n\u001b[0m-branch-who-dis/python/runtimed/demos/test-presence.ipynb as second peer\n"
+    }
+   ],
+   "source": [
+    "# Pick the first room (this notebook) and connect as a second peer\n",
+    "notebook_id = None\n",
+    "\n",
+    "for room in rooms:\n",
+    "    if \"test-presence\" in room[\"notebook_id\"]:\n",
+    "        notebook_id = room[\"notebook_id\"]\n",
+    "\n",
+    "if notebook_id is None:\n",
+    "    raise ValueError(\"Test Presence not found\")\n",
+    "session = runtimed.Session(notebook_id=notebook_id, peer_label=\"\\U0001f916 Agent\")\n",
+    "session.connect()\n",
+    "print(f\"Connected to {notebook_id} as second peer\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "36841cd7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": "9 cells:\n  [0] markdown: # Presence Test↵↵This notebook connects a second p\n  [1] code: import runtimed↵import time↵import os\n  [2] code: # Connect a second peer to this same notebook.↵# T\n  [3] code: # Pick the first room (this notebook) and connect\n  [4] code: # List cells — you should see a gutter dot appear\n  [5] code: # Animate cursor across cells — watch the gutter d\n  [6] code: # Animate cursor within this cell — watch the curs\n  [7] code: # Selection demo — grow a highlight across a cell↵\n  [8] code: # Clean up — disconnect the second peer↵session.cl\n"
+    }
+   ],
+   "source": [
+    "# List cells — you should see a gutter dot appear briefly on each cell\n",
+    "\n",
+    "cells = session.get_cells()\n",
+    "print(f\"{len(cells)} cells:\")\n",
+    "for i, c in enumerate(cells):\n",
+    "    time.sleep(0.5)\n",
+    "    preview = c.source[:50].replace(\"\\n\", \"\\u21b5\") if c.source else \"(empty)\"\n",
+    "    print(f\"  [{i}] {c.cell_type}: {preview}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "0fc5b64f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": "Jumping between cells...\nDone — did you see the dots?\n"
+    }
+   ],
+   "source": [
+    "# Animate cursor across cells — watch the gutter dots jump\n",
+    "print(\"Jumping between cells...\")\n",
+    "for c in cells:\n",
+    "    session.set_cursor(c.id, line=0, column=0)\n",
+    "    time.sleep(0.8)\n",
+    "print(\"Done — did you see the dots?\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "8494d4d2",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": "Sweeping cursor across 'import runtimed...' (3 lines)\nSweep complete\n"
+    }
+   ],
+   "source": [
+    "# Animate cursor within this cell — watch the cursor bar sweep\n",
+    "code_cells = [c for c in cells if c.cell_type == \"code\" and len(c.source) > 20]\n",
+    "if code_cells:\n",
+    "    target = code_cells[0]\n",
+    "    lines = target.source.split(\"\\n\")\n",
+    "    print(f\"Sweeping cursor across '{lines[0][:30]}...' ({len(lines)} lines)\")\n",
+    "    for line_num, line_text in enumerate(lines[:5]):\n",
+    "        for col in range(0, len(line_text) + 1, 2):\n",
+    "            session.set_cursor(target.id, line=line_num, column=col)\n",
+    "            time.sleep(0.03)\n",
+    "    print(\"Sweep complete\")\n",
+    "else:\n",
+    "    print(\"No code cells with enough content to demo\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "dcb513c9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": "Growing selection...\nSelection cleared\n"
+    }
+   ],
+   "source": [
+    "# Selection demo — grow a highlight across a cell\n",
+    "if code_cells:\n",
+    "    target = code_cells[0]\n",
+    "    lines = target.source.split(\"\\n\")\n",
+    "    print(\"Growing selection...\")\n",
+    "    for line_num, line_text in enumerate(lines[:4]):\n",
+    "        for col in range(0, len(line_text) + 1, 3):\n",
+    "            session.set_selection(\n",
+    "                target.id,\n",
+    "                anchor_line=0,\n",
+    "                anchor_col=0,\n",
+    "                head_line=line_num,\n",
+    "                head_col=col,\n",
+    "            )\n",
+    "            time.sleep(0.05)\n",
+    "    time.sleep(1)\n",
+    "    # Clear by setting cursor\n",
+    "    session.set_cursor(target.id, line=0, column=0)\n",
+    "    print(\"Selection cleared\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "824f8f0e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Clean up — disconnect the second peer\n",
+    "session.close()\n",
+    "print(\"Second peer disconnected — cursor should disappear\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.0"
+  },
+  "runt": {
+   "schema_version": "1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }

--- a/python/runtimed/demos/test-presence.ipynb
+++ b/python/runtimed/demos/test-presence.ipynb
@@ -1,0 +1,215 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 5,
+  "metadata": {
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3",
+      "language": "python"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.12.0"
+    },
+    "runt": {
+      "schema_version": "1"
+    }
+  },
+  "cells": [
+    {
+      "id": "8897a84c",
+      "cell_type": "markdown",
+      "source": [
+        "# Presence Test\n",
+        "\n",
+        "This notebook connects a second peer (\"notebook-agent\") back to itself via `runtimed`,\n",
+        "then animates cursor presence across cells. You should see a colored cursor bar and\n",
+        "gutter dots appear as the agent peer moves around.\n",
+        "\n",
+        "**Requirements:** Open this notebook in the nteract dev app. The daemon will resolve\n",
+        "`runtimed` from `python/runtimed/pyproject.toml` automatically."
+      ],
+      "metadata": {}
+    },
+    {
+      "id": "21e509b9",
+      "cell_type": "code",
+      "source": [
+        "import runtimed\n",
+        "import time\n",
+        "import os"
+      ],
+      "metadata": {},
+      "outputs": [],
+      "execution_count": 1
+    },
+    {
+      "id": "69618507",
+      "cell_type": "code",
+      "source": [
+        "# Connect a second peer to this same notebook.\n",
+        "# The daemon client auto-detects the socket path.\n",
+        "client = runtimed.DaemonClient()\n",
+        "rooms = client.list_rooms()\n",
+        "print(f\"Open notebooks: {len(rooms)}\")\n",
+        "for r in rooms:\n",
+        "    print(f\"  {r['notebook_id']}\")"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Open notebooks: 2\n  /Users/kylekelley/code/src/github.com/nteract/worktrees/desktop/new-branch-who\n\u001b[0m-dis/notebooks/whatevs.ipynb\n  /Users/kylekelley/code/src/github.com/nteract/worktrees/desktop/new-branch-who\n\u001b[0m-dis/python/runtimed/demos/test-presence.ipynb\n"
+        }
+      ],
+      "execution_count": 2
+    },
+    {
+      "id": "19115018",
+      "cell_type": "code",
+      "source": [
+        "# Pick the first room (this notebook) and connect as a second peer\n",
+        "notebook_id = None\n",
+        "\n",
+        "for room in rooms:\n",
+        "    if \"test-presence\" in room[\"notebook_id\"]:\n",
+        "        notebook_id = room[\"notebook_id\"]\n",
+        "\n",
+        "if notebook_id is None:\n",
+        "    raise ValueError(\"Test Presence not found\")\n",
+        "session = runtimed.Session(notebook_id=notebook_id, peer_label=\"\\U0001f916 Agent\")\n",
+        "session.connect()\n",
+        "print(f\"Connected to {notebook_id} as second peer\")"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Connected to /Users/kylekelley/code/src/github.com/nteract/worktrees/desktop/new\n\u001b[0m-branch-who-dis/python/runtimed/demos/test-presence.ipynb as second peer\n"
+        }
+      ],
+      "execution_count": 6
+    },
+    {
+      "id": "36841cd7",
+      "cell_type": "code",
+      "source": [
+        "# List cells — you should see a gutter dot appear briefly on each cell\n",
+        "import time\n",
+        "\n",
+        "cells = session.get_cells()\n",
+        "print(f\"{len(cells)} cells:\")\n",
+        "for i, c in enumerate(cells):\n",
+        "    time.sleep(0.5)\n",
+        "    preview = c.source[:50].replace(\"\\n\", \"\\u21b5\") if c.source else \"(empty)\"\n",
+        "    print(f\"  [{i}] {c.cell_type}: {preview}\")"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "9 cells:\n  [0] markdown: # Presence Test↵↵This notebook connects a second p\n  [1] code: import runtimed↵import time↵import os\n  [2] code: # Connect a second peer to this same notebook.↵# T\n  [3] code: # Pick the first room (this notebook) and connect\n  [4] code: # List cells — you should see a gutter dot appear\n  [5] code: # Animate cursor across cells — watch the gutter d\n  [6] code: # Animate cursor within this cell — watch the curs\n  [7] code: # Selection demo — grow a highlight across a cell↵\n  [8] code: # Clean up — disconnect the second peer↵session.cl\n"
+        }
+      ],
+      "execution_count": 8
+    },
+    {
+      "id": "0fc5b64f",
+      "cell_type": "code",
+      "source": [
+        "# Animate cursor across cells — watch the gutter dots jump\n",
+        "print(\"Jumping between cells...\")\n",
+        "for c in cells:\n",
+        "    session.set_cursor(c.id, line=0, column=0)\n",
+        "    time.sleep(0.8)\n",
+        "print(\"Done — did you see the dots?\")"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Jumping between cells...\nDone — did you see the dots?\n"
+        }
+      ],
+      "execution_count": 10
+    },
+    {
+      "id": "8494d4d2",
+      "cell_type": "code",
+      "source": [
+        "# Animate cursor within this cell — watch the cursor bar sweep\n",
+        "code_cells = [c for c in cells if c.cell_type == \"code\" and len(c.source) > 20]\n",
+        "if code_cells:\n",
+        "    target = code_cells[0]\n",
+        "    lines = target.source.split(\"\\n\")\n",
+        "    print(f\"Sweeping cursor across '{lines[0][:30]}...' ({len(lines)} lines)\")\n",
+        "    for line_num, line_text in enumerate(lines[:5]):\n",
+        "        for col in range(0, len(line_text) + 1, 2):\n",
+        "            session.set_cursor(target.id, line=line_num, column=col)\n",
+        "            time.sleep(0.03)\n",
+        "    print(\"Sweep complete\")\n",
+        "else:\n",
+        "    print(\"No code cells with enough content to demo\")"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Sweeping cursor across 'import runtimed...' (3 lines)\nSweep complete\n"
+        }
+      ],
+      "execution_count": 12
+    },
+    {
+      "id": "dcb513c9",
+      "cell_type": "code",
+      "source": [
+        "# Selection demo — grow a highlight across a cell\n",
+        "if code_cells:\n",
+        "    target = code_cells[0]\n",
+        "    lines = target.source.split(\"\\n\")\n",
+        "    print(\"Growing selection...\")\n",
+        "    for line_num, line_text in enumerate(lines[:4]):\n",
+        "        for col in range(0, len(line_text) + 1, 3):\n",
+        "            session.set_selection(\n",
+        "                target.id,\n",
+        "                anchor_line=0,\n",
+        "                anchor_col=0,\n",
+        "                head_line=line_num,\n",
+        "                head_col=col,\n",
+        "            )\n",
+        "            time.sleep(0.05)\n",
+        "    time.sleep(1)\n",
+        "    # Clear by setting cursor\n",
+        "    session.set_cursor(target.id, line=0, column=0)\n",
+        "    print(\"Selection cleared\")"
+      ],
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": "Growing selection...\nSelection cleared\n"
+        }
+      ],
+      "execution_count": 13
+    },
+    {
+      "id": "824f8f0e",
+      "cell_type": "code",
+      "source": [
+        "# Clean up — disconnect the second peer\n",
+        "session.close()\n",
+        "print(\"Second peer disconnected — cursor should disappear\")"
+      ],
+      "metadata": {},
+      "outputs": [],
+      "execution_count": null
+    }
+  ]
+}


### PR DESCRIPTION
Migrate Tauri from the old `NotebookSyncClient`/`NotebookSyncHandle` (16-variant `SyncCommand` channel actor) to the `notebook-sync` crate's `DocHandle` (samod-inspired `Arc<Mutex>` + `with_doc` pattern).

The `notebook-sync` crate has been in production via `runtimed-py` since the session unification (#763). This PR brings Tauri onto the same code path.

**notebook-sync changes:**
- Add `pipe_frame_tx` to `SyncTaskConfig` — optionally forwards raw daemon frames to a pipe consumer (Tauri webview) before local processing
- Add `receive_frontend_sync_message` to `DocHandle` — forwards WASM Automerge sync frames through the sync task
- Add `connect_open_with_pipe` / `connect_create_with_pipe` — pipe-aware connection functions with `_impl` helpers to avoid duplication

**Tauri changes:**
- `SharedNotebookSync` type alias: `NotebookSyncHandle` → `DocHandle`
- Connection setup uses `notebook_sync::connect::{connect_open_with_pipe, connect_create_with_pipe}`
- Metadata helpers accept `&DocHandle` (same `send_request` API)
- Drops `PipeChannel` and `NotebookSyncClient` imports

The old `notebook_sync_client.rs` still exists for integration tests and one example binary — those get migrated in a follow-up, then the file is deleted.

## Verification

* [ ] `cargo check --workspace` passes
* [ ] `cargo test -p notebook-sync` — 27 tests pass
* [ ] `cargo xtask lint` — clean
* [ ] Open notebook in dev mode, verify cells render and execute
* [ ] Verify WASM sync frames flow (cell edits sync to daemon)
* [ ] Verify presence works (remote cursors via MCP)

_PR submitted by @rgbkrk's agent Quill, via Zed_