### PR TITLE
feat(ui): surface prewarm pool errors in notebook UI

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -22,6 +22,7 @@ import { DependencyHeader } from "./components/DependencyHeader";
 import { GlobalFindBar } from "./components/GlobalFindBar";
 import { NotebookToolbar } from "./components/NotebookToolbar";
 import { NotebookView } from "./components/NotebookView";
+import { PoolErrorBanner } from "./components/PoolErrorBanner";
 import { TrustDialog } from "./components/TrustDialog";
 import { UntrustedBanner } from "./components/UntrustedBanner";
 import { PresenceProvider } from "./contexts/PresenceContext";
@@ -33,6 +34,7 @@ import { type EnvSyncState, useDependencies } from "./hooks/useDependencies";
 import { useEnvProgress } from "./hooks/useEnvProgress";
 import { useDaemonInfo, useGitInfo } from "./hooks/useGitInfo";
 import { useGlobalFind } from "./hooks/useGlobalFind";
+import { usePoolState } from "./hooks/usePoolState";
 import { useTrust } from "./hooks/useTrust";
 import { useUpdater } from "./hooks/useUpdater";
 import { startCursorDispatch } from "./lib/cursor-registry";
@@ -132,6 +134,14 @@ function AppContent() {
   const [daemonStatus, setDaemonStatus] = useState<DaemonStatus>(null);
   // Track ready timeout so we can cancel it if status changes
   const readyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Pool state - prewarm pool errors from daemon (typo'd default packages, etc.)
+  const {
+    uvError: poolUvError,
+    condaError: poolCondaError,
+    dismissUvError: dismissPoolUvError,
+    dismissCondaError: dismissPoolCondaError,
+  } = usePoolState();
 
   // Trust verification for notebook dependencies
   const {
@@ -926,6 +936,12 @@ function AppContent() {
                 });
               });
           }}
+        />
+        <PoolErrorBanner
+          uvError={poolUvError}
+          condaError={poolCondaError}
+          onDismissUv={dismissPoolUvError}
+          onDismissConda={dismissPoolCondaError}
         />
         {needsApproval && kernelStatus === KERNEL_STATUS.NOT_STARTED && (
           <UntrustedBanner

--- a/apps/notebook/src/components/PoolErrorBanner.tsx
+++ b/apps/notebook/src/components/PoolErrorBanner.tsx
@@ -1,0 +1,98 @@
+import { AlertTriangle, X } from "lucide-react";
+import { useEffect, useState } from "react";
+import type { PoolErrorWithTimestamp } from "../hooks/usePoolState";
+
+interface PoolErrorItemProps {
+  envType: "UV" | "Conda";
+  error: PoolErrorWithTimestamp;
+  onDismiss: () => void;
+}
+
+function PoolErrorItem({ envType, error, onDismiss }: PoolErrorItemProps) {
+  // Live countdown timer
+  const [secondsRemaining, setSecondsRemaining] = useState(() => {
+    const elapsed = Math.floor((Date.now() - error.receivedAt) / 1000);
+    return Math.max(0, error.retry_in_secs - elapsed);
+  });
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      const elapsed = Math.floor((Date.now() - error.receivedAt) / 1000);
+      setSecondsRemaining(Math.max(0, error.retry_in_secs - elapsed));
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, [error.receivedAt, error.retry_in_secs]);
+
+  const retryText =
+    secondsRemaining > 0 ? `Retrying in ${secondsRemaining}s` : "Retrying...";
+
+  return (
+    <div className="flex items-center justify-between gap-2 bg-amber-600/90 px-3 py-1.5 text-xs text-white">
+      <div className="flex items-center gap-2 min-w-0">
+        <AlertTriangle className="h-3 w-3 flex-shrink-0" />
+        <span className="font-medium flex-shrink-0">{envType} pool error</span>
+        <span className="text-amber-200 flex-shrink-0">—</span>
+        {error.failed_package && (
+          <>
+            <code className="bg-amber-700/50 px-1 rounded text-amber-100 flex-shrink-0">
+              {error.failed_package}
+            </code>
+            <span className="text-amber-200 flex-shrink-0">—</span>
+          </>
+        )}
+        <span className="text-amber-100 truncate">{error.message}</span>
+      </div>
+      <div className="flex items-center gap-2 flex-shrink-0">
+        <span className="text-amber-200 text-[10px]">{retryText}</span>
+        <button
+          type="button"
+          onClick={onDismiss}
+          className="rounded p-0.5 hover:bg-amber-500/50 transition-colors"
+          aria-label="Dismiss"
+        >
+          <X className="h-3 w-3" />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+interface PoolErrorBannerProps {
+  uvError: PoolErrorWithTimestamp | null;
+  condaError: PoolErrorWithTimestamp | null;
+  onDismissUv: () => void;
+  onDismissConda: () => void;
+}
+
+/**
+ * Banner component showing pool warming errors.
+ *
+ * Displays amber warning banners for UV and/or Conda pool errors,
+ * with the failed package name, error message, and live retry countdown.
+ */
+export function PoolErrorBanner({
+  uvError,
+  condaError,
+  onDismissUv,
+  onDismissConda,
+}: PoolErrorBannerProps) {
+  if (!uvError && !condaError) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-col">
+      {uvError && (
+        <PoolErrorItem envType="UV" error={uvError} onDismiss={onDismissUv} />
+      )}
+      {condaError && (
+        <PoolErrorItem
+          envType="Conda"
+          error={condaError}
+          onDismiss={onDismissConda}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/notebook/src/components/PoolErrorBanner.tsx
+++ b/apps/notebook/src/components/PoolErrorBanner.tsx
@@ -1,5 +1,5 @@
-import { AlertTriangle, X } from "lucide-react";
-import { useEffect, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { AlertTriangle, Settings, X } from "lucide-react";
 import type { PoolErrorWithTimestamp } from "../hooks/usePoolState";
 
 interface PoolErrorItemProps {
@@ -9,55 +9,46 @@ interface PoolErrorItemProps {
 }
 
 function PoolErrorItem({ envType, error, onDismiss }: PoolErrorItemProps) {
-  // Live countdown timer
-  const [secondsRemaining, setSecondsRemaining] = useState(() => {
-    const elapsed = Math.floor((Date.now() - error.receivedAt) / 1000);
-    return Math.max(0, error.retry_in_secs - elapsed);
-  });
+  const openSettings = () => {
+    invoke("open_settings_window").catch((e) => {
+      console.error("Failed to open settings:", e);
+    });
+  };
 
-  useEffect(() => {
-    // Don't start interval if already at 0
-    const elapsed = Math.floor((Date.now() - error.receivedAt) / 1000);
-    const remaining = Math.max(0, error.retry_in_secs - elapsed);
-    setSecondsRemaining(remaining);
-
-    if (remaining === 0) return;
-
-    const interval = setInterval(() => {
-      const elapsed = Math.floor((Date.now() - error.receivedAt) / 1000);
-      const remaining = Math.max(0, error.retry_in_secs - elapsed);
-      setSecondsRemaining(remaining);
-
-      // Clear interval once countdown hits 0
-      if (remaining === 0) {
-        clearInterval(interval);
-      }
-    }, 1000);
-
-    return () => clearInterval(interval);
-  }, [error.receivedAt, error.retry_in_secs]);
-
-  const retryText =
-    secondsRemaining > 0 ? `Retrying in ${secondsRemaining}s` : "Retrying...";
+  // Build a helpful message based on the error
+  const failureCount = error.consecutive_failures;
+  const failureText =
+    failureCount > 1 ? `Failed ${failureCount} times` : "Failed";
 
   return (
     <div className="flex items-center justify-between gap-2 bg-amber-600/90 px-3 py-1.5 text-xs text-white">
       <div className="flex items-center gap-2 min-w-0">
         <AlertTriangle className="h-3 w-3 flex-shrink-0" />
-        <span className="font-medium flex-shrink-0">{envType} pool error</span>
-        <span className="text-amber-200 flex-shrink-0">—</span>
+        <span className="font-medium flex-shrink-0">
+          {envType} default package error
+        </span>
         {error.failed_package && (
           <>
+            <span className="text-amber-200 flex-shrink-0">—</span>
             <code className="bg-amber-700/50 px-1 rounded text-amber-100 flex-shrink-0">
               {error.failed_package}
             </code>
-            <span className="text-amber-200 flex-shrink-0">—</span>
           </>
         )}
-        <span className="text-amber-100 truncate">{error.message}</span>
+        <span className="text-amber-200 flex-shrink-0">—</span>
+        <span className="text-amber-100 truncate" title={error.message}>
+          {failureText}. Check package name in settings.
+        </span>
       </div>
       <div className="flex items-center gap-2 flex-shrink-0">
-        <span className="text-amber-200 text-[10px]">{retryText}</span>
+        <button
+          type="button"
+          onClick={openSettings}
+          className="flex items-center gap-1 rounded bg-amber-700/60 px-2 py-0.5 hover:bg-amber-700 transition-colors"
+        >
+          <Settings className="h-3 w-3" />
+          <span>Settings</span>
+        </button>
         <button
           type="button"
           onClick={onDismiss}
@@ -82,7 +73,7 @@ interface PoolErrorBannerProps {
  * Banner component showing pool warming errors.
  *
  * Displays amber warning banners for UV and/or Conda pool errors,
- * with the failed package name, error message, and live retry countdown.
+ * with the failed package name and a link to open settings to fix the issue.
  */
 export function PoolErrorBanner({
   uvError,

--- a/apps/notebook/src/components/PoolErrorBanner.tsx
+++ b/apps/notebook/src/components/PoolErrorBanner.tsx
@@ -15,17 +15,15 @@ function PoolErrorItem({ envType, error, onDismiss }: PoolErrorItemProps) {
     });
   };
 
-  // Build a helpful message based on the error
-  const failureCount = error.consecutive_failures;
-  const failureText =
-    failureCount > 1 ? `Failed ${failureCount} times` : "Failed";
-
   return (
-    <div className="flex items-center justify-between gap-2 bg-amber-600/90 px-3 py-1.5 text-xs text-white">
+    <div
+      className="flex items-center justify-between gap-2 bg-amber-600/90 px-3 py-1.5 text-xs text-white"
+      title={error.message}
+    >
       <div className="flex items-center gap-2 min-w-0">
         <AlertTriangle className="h-3 w-3 flex-shrink-0" />
         <span className="font-medium flex-shrink-0">
-          {envType} default package error
+          Invalid or unavailable package
         </span>
         {error.failed_package && (
           <>
@@ -36,8 +34,8 @@ function PoolErrorItem({ envType, error, onDismiss }: PoolErrorItemProps) {
           </>
         )}
         <span className="text-amber-200 flex-shrink-0">—</span>
-        <span className="text-amber-100 truncate" title={error.message}>
-          {failureText}. Check package name in settings.
+        <span className="text-amber-100">
+          Check package name in {envType.toLowerCase()} settings.
         </span>
       </div>
       <div className="flex items-center gap-2 flex-shrink-0">

--- a/apps/notebook/src/components/PoolErrorBanner.tsx
+++ b/apps/notebook/src/components/PoolErrorBanner.tsx
@@ -16,9 +16,22 @@ function PoolErrorItem({ envType, error, onDismiss }: PoolErrorItemProps) {
   });
 
   useEffect(() => {
+    // Don't start interval if already at 0
+    const elapsed = Math.floor((Date.now() - error.receivedAt) / 1000);
+    const remaining = Math.max(0, error.retry_in_secs - elapsed);
+    setSecondsRemaining(remaining);
+
+    if (remaining === 0) return;
+
     const interval = setInterval(() => {
       const elapsed = Math.floor((Date.now() - error.receivedAt) / 1000);
-      setSecondsRemaining(Math.max(0, error.retry_in_secs - elapsed));
+      const remaining = Math.max(0, error.retry_in_secs - elapsed);
+      setSecondsRemaining(remaining);
+
+      // Clear interval once countdown hits 0
+      if (remaining === 0) {
+        clearInterval(interval);
+      }
     }, 1000);
 
     return () => clearInterval(interval);

--- a/apps/notebook/src/hooks/usePoolState.ts
+++ b/apps/notebook/src/hooks/usePoolState.ts
@@ -1,5 +1,5 @@
 import { listen } from "@tauri-apps/api/event";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { PoolError, PoolStateEvent } from "../types";
 
 /** PoolError with timestamp for countdown calculation */
@@ -11,6 +11,21 @@ export interface PoolErrorWithTimestamp extends PoolError {
 export interface PoolState {
   uvError: PoolErrorWithTimestamp | null;
   condaError: PoolErrorWithTimestamp | null;
+}
+
+/** Compare two pool errors for equality (all fields except receivedAt) */
+function errorsEqual(
+  a: PoolError | null | undefined,
+  b: PoolError | null | undefined,
+): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  return (
+    a.message === b.message &&
+    a.failed_package === b.failed_package &&
+    a.consecutive_failures === b.consecutive_failures &&
+    a.retry_in_secs === b.retry_in_secs
+  );
 }
 
 /**
@@ -29,6 +44,9 @@ export function usePoolState() {
   const [dismissedUv, setDismissedUv] = useState(false);
   const [dismissedConda, setDismissedConda] = useState(false);
 
+  // Track previous errors to detect changes outside of setState
+  const prevStateRef = useRef<PoolState>(state);
+
   useEffect(() => {
     let cancelled = false;
 
@@ -38,24 +56,26 @@ export function usePoolState() {
       const now = Date.now();
       const payload = event.payload;
 
-      setState((prev) => {
-        const uvError = payload.uv_error
-          ? { ...payload.uv_error, receivedAt: now }
-          : null;
-        const condaError = payload.conda_error
-          ? { ...payload.conda_error, receivedAt: now }
-          : null;
+      const uvError = payload.uv_error
+        ? { ...payload.uv_error, receivedAt: now }
+        : null;
+      const condaError = payload.conda_error
+        ? { ...payload.conda_error, receivedAt: now }
+        : null;
 
-        // Reset dismissed state if error changed (new error or cleared)
-        if (uvError?.message !== prev.uvError?.message) {
-          setDismissedUv(false);
-        }
-        if (condaError?.message !== prev.condaError?.message) {
-          setDismissedConda(false);
-        }
+      // Check if errors changed (compare all fields, not just message)
+      const prev = prevStateRef.current;
+      if (!errorsEqual(uvError, prev.uvError)) {
+        setDismissedUv(false);
+      }
+      if (!errorsEqual(condaError, prev.condaError)) {
+        setDismissedConda(false);
+      }
 
-        return { uvError, condaError };
-      });
+      // Update state and ref
+      const newState = { uvError, condaError };
+      prevStateRef.current = newState;
+      setState(newState);
     });
 
     return () => {

--- a/apps/notebook/src/hooks/usePoolState.ts
+++ b/apps/notebook/src/hooks/usePoolState.ts
@@ -1,0 +1,90 @@
+import { listen } from "@tauri-apps/api/event";
+import { useCallback, useEffect, useState } from "react";
+import type { PoolError, PoolStateEvent } from "../types";
+
+/** PoolError with timestamp for countdown calculation */
+export interface PoolErrorWithTimestamp extends PoolError {
+  /** When this state was received (epoch ms) */
+  receivedAt: number;
+}
+
+export interface PoolState {
+  uvError: PoolErrorWithTimestamp | null;
+  condaError: PoolErrorWithTimestamp | null;
+}
+
+/**
+ * Hook that listens to pool state broadcasts from the daemon.
+ *
+ * Reports prewarm pool errors (e.g., typo'd package in default_packages)
+ * so the UI can display warnings with retry countdowns.
+ */
+export function usePoolState() {
+  const [state, setState] = useState<PoolState>({
+    uvError: null,
+    condaError: null,
+  });
+
+  // Track dismissed errors so they don't reappear until state changes
+  const [dismissedUv, setDismissedUv] = useState(false);
+  const [dismissedConda, setDismissedConda] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const unlisten = listen<PoolStateEvent>("pool:state", (event) => {
+      if (cancelled) return;
+
+      const now = Date.now();
+      const payload = event.payload;
+
+      setState((prev) => {
+        const uvError = payload.uv_error
+          ? { ...payload.uv_error, receivedAt: now }
+          : null;
+        const condaError = payload.conda_error
+          ? { ...payload.conda_error, receivedAt: now }
+          : null;
+
+        // Reset dismissed state if error changed (new error or cleared)
+        if (uvError?.message !== prev.uvError?.message) {
+          setDismissedUv(false);
+        }
+        if (condaError?.message !== prev.condaError?.message) {
+          setDismissedConda(false);
+        }
+
+        return { uvError, condaError };
+      });
+    });
+
+    return () => {
+      cancelled = true;
+      unlisten.then((fn) => fn()).catch(() => {});
+    };
+  }, []);
+
+  const dismissUvError = useCallback(() => {
+    setDismissedUv(true);
+  }, []);
+
+  const dismissCondaError = useCallback(() => {
+    setDismissedConda(true);
+  }, []);
+
+  const dismissAll = useCallback(() => {
+    setDismissedUv(true);
+    setDismissedConda(true);
+  }, []);
+
+  return {
+    uvError: dismissedUv ? null : state.uvError,
+    condaError: dismissedConda ? null : state.condaError,
+    hasErrors:
+      (!dismissedUv && state.uvError !== null) ||
+      (!dismissedConda && state.condaError !== null),
+    dismissUvError,
+    dismissCondaError,
+    dismissAll,
+  };
+}

--- a/apps/notebook/src/types.ts
+++ b/apps/notebook/src/types.ts
@@ -259,3 +259,28 @@ export type DaemonNotebookResponse =
       error: string;
       needs_restart: boolean;
     };
+
+// =============================================================================
+// Pool State Types (Prewarm pool error reporting)
+// =============================================================================
+
+/** Error information for a pool that is failing to warm environments. */
+export interface PoolError {
+  /** Human-readable error message. */
+  message: string;
+  /** Package that failed to install (if identified). */
+  failed_package?: string;
+  /** Number of consecutive failures. */
+  consecutive_failures: number;
+  /** Seconds until next retry (0 if retry is imminent). */
+  retry_in_secs: number;
+}
+
+/** Pool state broadcast from daemon. */
+export interface PoolStateEvent {
+  event: "pool_state";
+  /** Error info for UV pool (null if healthy). */
+  uv_error: PoolError | null;
+  /** Error info for Conda pool (null if healthy). */
+  conda_error: PoolError | null;
+}

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -3267,7 +3267,7 @@ async fn run_settings_sync(app: tauri::AppHandle) {
 /// Background task that subscribes to pool state changes from the runtimed daemon
 /// and emits Tauri events to all windows when pool errors occur or clear.
 ///
-/// Reconnects automatically with backoff if the connection drops.
+/// Reconnects automatically after 5s if the connection drops.
 async fn run_pool_state_sync(app: tauri::AppHandle) {
     use tauri::Emitter;
 
@@ -3292,7 +3292,7 @@ async fn run_pool_state_sync(app: tauri::AppHandle) {
             }
         }
 
-        // Backoff before reconnecting
+        // Wait before reconnecting
         tokio::time::sleep(std::time::Duration::from_secs(5)).await;
     }
 }

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -3264,6 +3264,39 @@ async fn run_settings_sync(app: tauri::AppHandle) {
     }
 }
 
+/// Background task that subscribes to pool state changes from the runtimed daemon
+/// and emits Tauri events to all windows when pool errors occur or clear.
+///
+/// Reconnects automatically with backoff if the connection drops.
+async fn run_pool_state_sync(app: tauri::AppHandle) {
+    use tauri::Emitter;
+
+    loop {
+        match runtimed::client::subscribe_pool_state().await {
+            Ok(mut rx) => {
+                log::info!("[pool-state-sync] Connected to pool state subscription");
+
+                while let Some(broadcast) = rx.recv().await {
+                    if let Err(e) = app.emit("pool:state", &broadcast) {
+                        log::warn!("[pool-state-sync] Failed to emit pool:state: {}", e);
+                    }
+                }
+
+                log::warn!("[pool-state-sync] Disconnected from pool state subscription");
+            }
+            Err(e) => {
+                log::info!(
+                    "[pool-state-sync] Cannot connect to daemon: {}. Retrying in 5s.",
+                    e
+                );
+            }
+        }
+
+        // Backoff before reconnecting
+        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+    }
+}
+
 /// Create initial notebook state for a new notebook, detecting project-level config for Python.
 /// Create a window context for daemon-owned notebook loading.
 ///
@@ -3775,7 +3808,11 @@ pub fn run(
 
                 // Start settings sync subscription (reconnects automatically)
                 // Spawn as separate task since it runs forever
-                tokio::spawn(run_settings_sync(app_for_sync));
+                tokio::spawn(run_settings_sync(app_for_sync.clone()));
+
+                // Start pool state subscription (reconnects automatically)
+                // Reports prewarm pool errors to UI so users know when default packages fail
+                tokio::spawn(run_pool_state_sync(app_for_sync));
 
                 // Initialize notebook sync if daemon is available
                 // Skip during onboarding - the onboarding window doesn't need notebook sync,


### PR DESCRIPTION
## Summary

- Adds frontend support for displaying prewarm pool errors (e.g., typo'd packages in `uv.default_packages` or `conda.default_packages`)
- Backend support was added in PR #294; this completes the UI portion
- When pool errors occur, an amber warning banner appears with the failed package name, error message, and live retry countdown

## Changes

1. **Tauri event forwarding** (`crates/notebook/src/lib.rs`): Added `run_pool_state_sync()` that subscribes to daemon's `PoolStateSubscribe` channel and emits `pool:state` Tauri events
2. **TypeScript types** (`apps/notebook/src/types.ts`): Added `PoolError` and `PoolStateEvent` interfaces
3. **usePoolState hook** (`apps/notebook/src/hooks/usePoolState.ts`): Listens for pool errors with dismiss support and timestamp tracking for countdowns
4. **PoolErrorBanner component** (`apps/notebook/src/components/PoolErrorBanner.tsx`): Amber warning banner with live countdown timer
5. **App integration** (`apps/notebook/src/App.tsx`): Wired up hook and banner after DaemonStatusBanner

<img width="1094" height="741" alt="image" src="https://github.com/user-attachments/assets/680776e3-234b-4a1e-a6a5-1c2d9580faf1" />


## Test plan

- [x] Add a typo'd package to Settings > Default Packages (e.g., `scitkit-learn`)
- [x] Observe amber banner appears with package name and countdown timer
- [x] Fix the typo in settings
- [x] Observe banner disappears when pool recovers
- [x] Test dismiss button hides banner until next state change

Closes #296