### PR TITLE
fix(widgets): align AFM change callbacks with anywidget spec

### DIFF
--- a/src/components/widgets/anywidget-view.tsx
+++ b/src/components/widgets/anywidget-view.tsx
@@ -27,7 +27,12 @@ export interface AnyWidgetModel {
   get(key: string): unknown;
   /** Set a value in the model state (buffered until save_changes) */
   set(key: string, value: unknown): void;
-  /** Subscribe to model events */
+  /**
+   * Subscribe to model events.
+   * - "change:key" callbacks receive no arguments (use model.get() to read values)
+   * - "change" callbacks receive no arguments
+   * - "msg:custom" callbacks receive (content, buffers)
+   */
   on(event: string, callback: (...args: unknown[]) => void): void;
   /** Unsubscribe from model events */
   off(event: string, callback?: (...args: unknown[]) => void): void;
@@ -225,12 +230,12 @@ export function createAFMModelProxy(
 
         // Only subscribe once per key
         if (!keyUnsubscribers.has(key)) {
-          const unsubscribe = store.subscribeToKey(model.id, key, (value) => {
-            // Notify all listeners for this specific key
+          const unsubscribe = store.subscribeToKey(model.id, key, () => {
+            // Notify all listeners for this specific key (no args per AFM spec)
             const keyEvent = `change:${key}`;
             const keyListeners = listeners.get(keyEvent);
             if (keyListeners) {
-              keyListeners.forEach((cb) => cb(value));
+              keyListeners.forEach((cb) => cb());
             }
 
             // Also notify generic "change" listeners

--- a/src/components/widgets/anywidget-view.tsx
+++ b/src/components/widgets/anywidget-view.tsx
@@ -30,7 +30,7 @@ export interface AnyWidgetModel {
   /**
    * Subscribe to model events.
    * - "change:key" callbacks receive no arguments (use model.get() to read values)
-   * - "change" callbacks receive no arguments
+   * - "change" callbacks receive no arguments (fired alongside change:key events)
    * - "msg:custom" callbacks receive (content, buffers)
    */
   on(event: string, callback: (...args: unknown[]) => void): void;


### PR DESCRIPTION
The anywidget spec now requires `on("change:...")` callbacks to take no arguments. Widget code should use `model.get()` inside the callback to read the current value. This decouples the event API from Backbone.js implementation details and improves portability across host platforms.

Closes #513

## Test Plan

* [ ] Open a notebook with an anywidget (e.g., ipywidgets slider) and verify state updates work correctly
* [ ] Verify widget callbacks can access values via `model.get()` within the callback

_PR submitted by @rgbkrk's agent, Quill_