### PR TITLE
docs: fix inaccuracies across 21 documentation files

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ pip install nteract
 | `runtimed` | Background daemon — environment pools, notebook sync, kernel execution |
 | `runt` | CLI for managing kernels, notebooks, and the daemon |
 | `runtimed` (PyPI) | Python bindings for the daemon |
+| `nteract` (PyPI) | MCP server for AI agent integration with notebooks |
 
 ## MCP Server
 
@@ -61,16 +62,21 @@ $ runt notebooks
 ```
 nteract/desktop
 ├── src/                    # Shared UI code (React components, hooks, utilities)
+│   ├── bindings/          # TypeScript types generated from Rust (ts-rs)
 │   ├── components/
 │   │   ├── ui/            # shadcn primitives (button, dialog, etc.)
 │   │   ├── cell/          # Notebook cell components
 │   │   ├── outputs/       # Output renderers (stream, error, display data)
 │   │   ├── editor/        # CodeMirror editor
+│   │   ├── isolated/      # Iframe security isolation (IsolatedFrame, CommBridgeManager)
 │   │   └── widgets/       # ipywidgets controls
-│   └── lib/
-│       └── utils.ts       # cn() and other utilities
+│   ├── hooks/             # Shared hooks (useSyncedSettings, useTheme)
+│   ├── isolated-renderer/ # Code that runs inside isolated iframes
+│   ├── lib/               # Shared utilities (cn(), dark-mode, error-boundary)
+│   └── styles/            # Global stylesheets
 ├── apps/                   # App entry points
-│   └── notebook/          # Notebook Tauri frontend
+│   ├── notebook/          # Notebook Tauri frontend
+│   └── sidecar/           # Sidecar app
 ├── crates/                 # Rust code
 │   ├── runt/              # CLI binary
 │   ├── runtimed/          # Background daemon
@@ -86,7 +92,7 @@ nteract/desktop
 │   ├── runt-trust/        # HMAC trust verification
 │   ├── runt-workspace/    # Workspace detection utilities
 │   └── xtask/             # Build automation tasks
-├── docs/                   # Architecture documentation
+├── docs/                   # User-facing documentation
 └── contributing/           # Developer guides
 ```
 
@@ -102,7 +108,8 @@ nteract/desktop
 
 **Linux only:** Install GTK/WebKit dev libraries:
 ```bash
-sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libxdo-dev
+sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libxdo-dev \
+  libssl-dev libayatana-appindicator3-dev librsvg2-dev
 ```
 
 ### Quick start
@@ -120,10 +127,16 @@ cargo xtask dev
 | Standalone Vite | `cargo xtask vite` | Multi-window testing (Vite survives window closes) |
 | Attach to Vite | `cargo xtask notebook --attach` | Connect Tauri to already-running Vite |
 | Debug build | `cargo xtask build` | Full debug build (frontend + rust) |
+| E2E debug build | `cargo xtask build-e2e` | Debug build with built-in WebDriver server |
 | Rust-only build | `cargo xtask build --rust-only` | Rebuild rust, reuse existing frontend |
 | Run bundled | `cargo xtask run notebook.ipynb` | Run standalone binary |
+| Lint (check) | `cargo xtask lint` | Check formatting and linting across Rust, JS/TS, Python |
+| Lint (fix) | `cargo xtask lint --fix` | Auto-fix formatting and linting |
+| Dev daemon | `cargo xtask dev-daemon` | Run per-worktree dev daemon |
+| Install daemon | `cargo xtask install-daemon` | Install daemon into the running service |
 | Release .app | `cargo xtask build-app` | Testing app bundle locally |
 | Release DMG | `cargo xtask build-dmg` | Distribution (usually CI) |
+| Generate icons | `cargo xtask icons [source.png]` | Generate icon variants from source image |
 
 `cargo xtask dev` runs the first-time bootstrap (`pnpm install` + `cargo xtask build`),
 starts the per-worktree dev daemon, waits for it to be ready, and then launches the
@@ -140,7 +153,7 @@ pnpm build                          # Build notebook UI
 cargo test                          # Run Rust tests
 pnpm test:run                       # Run JS tests
 cargo fmt                           # Format Rust
-npx @biomejs/biome check --fix apps/notebook/src/ e2e/  # Format JS
+npx @biomejs/biome check --fix apps/notebook/src/ e2e/  # Lint + format JS/TS
 cargo clippy --all-targets -- -D warnings               # Lint Rust
 ```
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -16,7 +16,7 @@ The desktop app, `runt` CLI, and `runtimed` daemon are all built and released to
 
 Stable releases run when a `v*` tag is pushed (or manually), and nightly pre-releases run every 24 hours. Both can also be triggered manually.
 
-> **Note:** Desktop releases also build and publish the `runtimed` and `nteract` Python packages to PyPI via trusted publishing. This means every stable and nightly release pushes new Python wheels — the separate `python-v*` tag workflow is only needed for Python-specific patches that don't warrant a full desktop release.
+> **Note:** Desktop releases also build Python wheels and attempt to publish the `runtimed` and `nteract` packages to PyPI via trusted publishing (`continue-on-error: true`, so publishing is best-effort and will silently skip if the version already exists). This means every stable and nightly release builds and attempts to push new Python wheels — the separate `python-v*` tag workflow is only needed for Python-specific patches that don't warrant a full desktop release.
 
 ### Artifacts
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -16,6 +16,8 @@ The desktop app, `runt` CLI, and `runtimed` daemon are all built and released to
 
 Stable releases run when a `v*` tag is pushed (or manually), and nightly pre-releases run every 24 hours. Both can also be triggered manually.
 
+> **Note:** Desktop releases also build and publish the `runtimed` and `nteract` Python packages to PyPI via trusted publishing. This means every stable and nightly release pushes new Python wheels — the separate `python-v*` tag workflow is only needed for Python-specific patches that don't warrant a full desktop release.
+
 ### Artifacts
 
 | Platform | File |
@@ -53,7 +55,7 @@ git push origin python-v<version>
 ```
 
 The `python-package.yml` workflow triggers on `python-v*` tags and will:
-- Build wheels for macOS arm64 and Linux x64
+- Build wheels for macOS arm64, macOS x86_64, and Linux x64
 - Publish to PyPI via trusted publishing (OIDC)
 - Create a GitHub release with wheels and nteract-dist packages
 

--- a/contributing/build-dependencies.md
+++ b/contributing/build-dependencies.md
@@ -115,7 +115,6 @@ graph BT
     RC -->|"depends on"| RW
     RD -->|"depends on"| ND
     RD -->|"depends on"| NP
-    RD -->|"depends on"| NS
     RD -->|"depends on"| KL
     RD -->|"depends on"| KE
     RD -->|"depends on"| RT
@@ -125,6 +124,10 @@ graph BT
     RDPY -->|"depends on"| NP
     RDPY -->|"depends on"| NS
     RWASM -->|"depends on"| ND
+    NP -->|"depends on"| ND
+    NP -->|"depends on"| KE
+    NS -->|"depends on"| ND
+    NS -->|"depends on"| NP
 
     classDef standalone fill:#fff9c4,stroke:#f9a825
     classDef leaf fill:#c8e6c9,stroke:#388e3c

--- a/contributing/development.md
+++ b/contributing/development.md
@@ -130,7 +130,7 @@ Test notebooks live in `crates/notebook/fixtures/audit-test/` and sample noteboo
 
 ```bash
 cargo xtask build
-./target/debug/notebook crates/notebook/fixtures/audit-test/test-isolation.ipynb
+./target/debug/notebook crates/notebook/fixtures/audit-test/1-vanilla.ipynb
 ```
 
 ## Daemon Development
@@ -178,7 +178,7 @@ RUNTIMED_DEV=1 cargo xtask notebook
 
 ```bash
 ./target/debug/runt daemon status           # Shows dev mode, worktree path, version
-./target/debug/runt daemon list-worktrees   # List all running dev daemons
+./target/debug/runt dev worktrees           # List all running dev daemons (requires RUNTIMED_DEV=1)
 ./target/debug/runt daemon logs -f          # Tail logs (uses correct log path in dev mode)
 ```
 

--- a/contributing/e2e.md
+++ b/contributing/e2e.md
@@ -209,6 +209,12 @@ import {
 | `typeSlowly(text, delay?)` | Types character-by-character (30ms default). Use for CodeMirror input. |
 | `findButton(patterns[])` | Tries CSS selectors in order, returns first match or null. |
 | `setupCodeCell()` | Finds or creates a code cell, focuses editor, selects all. Returns the cell. |
+| `waitForNotebookSynced(timeout?)` | Waits for Automerge sync + cells rendered (`data-notebook-synced` attribute). |
+| `waitForCodeCells(expectedCount, timeout?)` | Waits for a specific number of code cells to load. |
+| `isUvManagedEnv(path)` | Checks if a Python path is from a UV-managed environment. |
+| `isCondaManagedEnv(path)` | Checks if a Python path is from a Conda-managed environment. |
+| `isSystemPythonEnv(path)` | Checks if a Python path is from system Python. |
+| `isManagedEnv(path)` | Checks if a Python path is from any runt-managed environment. |
 
 Platform note: `MOD_KEY` is `"Meta"` on macOS, `"Control"` on Linux. Used internally by `executeFirstCell()` and `setupCodeCell()`.
 

--- a/contributing/environments.md
+++ b/contributing/environments.md
@@ -363,7 +363,7 @@ When a user creates a new notebook (File → New), the kernel type is determined
 Environments are cached by a hash of their dependencies so notebooks with identical deps share a single environment.
 
 **UV** (`uv_env.rs`):
-- Hash = SHA256(sorted deps + requires_python + env_id), first 16 hex chars
+- Hash = SHA256(sorted deps + requires_python + prerelease + env_id), first 16 hex chars
 - Location: `~/.cache/runt/envs/{hash}/`
 - When deps are non-empty, env_id is excluded from hash (allows cross-notebook sharing)
 - When deps are empty, env_id is included (per-notebook isolation)
@@ -454,12 +454,12 @@ Note: The runtime type (Python vs Deno) is determined by `kernelspec.name`, not 
 Dependencies are signed with HMAC-SHA256 to prevent untrusted code execution on notebook open.
 
 - **Key**: 32 random bytes stored at `~/.config/runt/trust-key`, generated on first use
-- **Signed content**: Canonical JSON of `metadata.uv` + `metadata.conda` (not cell contents or outputs)
+- **Signed content**: Canonical JSON of `metadata.runt.uv` + `metadata.runt.conda` (with fallback to legacy `metadata.uv` + `metadata.conda`; not cell contents or outputs)
 - **Signature format**: `"hmac-sha256:{hex_digest}"` stored in notebook metadata
 - **Machine-specific**: The key is per-machine, so every shared notebook is untrusted on the recipient's machine
 - **Verification**: `trust.rs:verify_signature()` returns `bool`. The higher-level `verify_notebook_trust()` returns `TrustInfo` (containing a `TrustStatus`: Trusted, Untrusted, SignatureInvalid, or NoDependencies)
 
-Changes to the dependency metadata structure require updating the signing logic in `crates/notebook/src/trust.rs`.
+Changes to the dependency metadata structure require updating the signing logic in `crates/runt-trust/src/lib.rs` (re-exported by `crates/notebook/src/trust.rs`).
 
 ## Frontend Architecture
 
@@ -469,7 +469,7 @@ Three UI components manage dependencies for different runtimes:
 |-----------|------|---------|
 | `DependencyHeader.tsx` | `useDependencies.ts` | UV deps, pyproject.toml detection |
 | `CondaDependencyHeader.tsx` | `useCondaDependencies.ts` | Conda deps, environment.yml and pixi.toml detection |
-| `DenoDependencyHeader.tsx` | — | Deno configuration and deno.json detection |
+| `DenoDependencyHeader.tsx` | `useDenoDependencies.ts` | Deno configuration and deno.json detection |
 
 The kernel lifecycle is managed by `useDaemonKernel.ts`, which:
 - Listens for `notebook:broadcast` events (re-emitted by `useAutomergeNotebook` after WASM frame demux)
@@ -509,22 +509,22 @@ The kernel lifecycle is managed by `useDaemonKernel.ts`, which:
 | `crates/runtimed/src/daemon.rs` | Background daemon pool management, passes settings to handlers |
 | `crates/runtimed/src/notebook_sync_server.rs` | `auto_launch_kernel()` — runtime detection and environment resolution |
 | `crates/runtimed/src/kernel_manager.rs` | `RoomKernel::launch()` — spawns Python or Deno kernel processes |
+| `crates/runtimed/src/project_file.rs` | Unified closest-wins project file detection (pyproject.toml, pixi.toml, environment.yml/yaml) |
 
 ### Notebook Crate (Tauri Commands)
 
 | File | Role |
 |------|------|
-| `crates/notebook/src/lib.rs` | Tauri commands, `launch_kernel_via_daemon` |
+| `crates/notebook/src/lib.rs` | Tauri commands (save, format, kernel, env), sync pipe setup, `launch_kernel_via_daemon` |
 | `crates/notebook/src/project_file.rs` | Unified closest-wins project file detection |
-| `crates/notebook/src/uv_env.rs` | UV environment creation, dep hashing, caching |
-| `crates/notebook/src/conda_env.rs` | Conda environment creation via rattler |
+| `crates/notebook/src/uv_env.rs` | UV environment creation, dep hashing (delegates to `kernel-env`), caching |
+| `crates/notebook/src/conda_env.rs` | Conda environment creation via rattler (delegates to `kernel-env`) |
 | `crates/notebook/src/pyproject.rs` | pyproject.toml discovery and parsing |
 | `crates/notebook/src/pixi.rs` | pixi.toml discovery and parsing |
 | `crates/notebook/src/environment_yml.rs` | environment.yml discovery and parsing |
 | `crates/notebook/src/deno_env.rs` | Deno config detection |
-| `crates/notebook/src/lib.rs` | Tauri commands (save, format, kernel, env), sync pipe setup |
 | `crates/notebook/src/settings.rs` | User preferences (default runtime, env type) |
-| `crates/notebook/src/trust.rs` | HMAC trust verification |
+| `crates/notebook/src/trust.rs` | HMAC trust verification (re-exports from `runt-trust` crate) |
 
 ### Frontend
 

--- a/contributing/frontend-architecture.md
+++ b/contributing/frontend-architecture.md
@@ -23,12 +23,17 @@ This guide explains the frontend code organization and how shared components rel
 ├── apps/
 │   ├── notebook/src/             ← Notebook app (path alias ~/)
 │   │   ├── components/           ← App-specific components (toolbar, banners)
+│   │   ├── contexts/             ← React contexts (PresenceContext)
 │   │   ├── hooks/                ← Notebook-specific hooks (useDaemonKernel, etc.)
 │   │   ├── lib/                  ← App-specific utilities (materialize-cells.ts)
 │   │   ├── wasm/                 ← WASM bindings (runtimed-wasm)
 │   │   ├── App.tsx               ← Root component
 │   │   └── types.ts              ← App types
-│   │
+│   ├── notebook/onboarding/      ← Onboarding sub-app (separate HTML entry point)
+│   ├── notebook/settings/        ← Settings sub-app
+│   ├── notebook/upgrade/         ← Upgrade sub-app
+│   └── sidecar/                  ← Sidecar app
+│
 
 ```
 
@@ -108,8 +113,15 @@ Security boundary for untrusted HTML/widget outputs. See [iframe-isolation.md](i
 | `useEnvProgress` | Environment setup progress tracking |
 | `useDependencies` | UV dependency management |
 | `useCondaDependencies` | Conda dependency management |
+| `useDenoDependencies` | Deno dependency management |
 | `useManifestResolver` | Resolves blob hashes to output data |
 | `useCellKeyboardNavigation` | Arrow keys, enter/escape modes |
+| `useEditorRegistry` | CodeMirror editor instance registry |
+| `useGitInfo` | Git branch/status for the notebook file |
+| `useGlobalFind` | Global find-and-replace across cells |
+| `useHistorySearch` | Kernel input history search |
+| `useTrust` | Notebook trust verification state |
+| `useUpdater` | App update checking and installation |
 
 ## Data Flow
 
@@ -123,8 +135,8 @@ Security boundary for untrusted HTML/widget outputs. See [iframe-isolation.md](i
 │                          sync_applied ─┘          │         │   │
 │                          ▼                        │         │   │
 │                   ┌──────────────┐                │         │   │
-│                   │cellSnapshots-│    "notebook:   │  "notebook: │
-│                   │ToNotebook-   │    broadcast"   │  presence"  │
+│                   │cellSnapshots-│  emitBroadcast  │ emitPresence│
+│                   │ToNotebook-   │  (frame bus)    │ (frame bus) │
 │                   │Cells()       │                 │             │
 │                   └──────┬───────┘        │         │       │   │
 │                          │                ▼         │       │   │
@@ -144,10 +156,10 @@ Security boundary for untrusted HTML/widget outputs. See [iframe-isolation.md](i
 └─────────────────────────────────────────────────────────────────┘
 ```
 
-1. **useAutomergeNotebook** — Single ingress point. Listens for `notebook:frame`, demuxes via WASM `receive_frame()`, applies sync locally, re-emits `notebook:broadcast` and `notebook:presence` for downstream hooks
+1. **useAutomergeNotebook** — Single ingress point. Listens for `notebook:frame`, demuxes via WASM `receive_frame()`, applies sync locally, dispatches to downstream hooks via the in-memory frame bus (`emitBroadcast()` and `emitPresence()` from `notebook-frame-bus.ts`)
 2. **cellSnapshotsToNotebookCells()** / **cellSnapshotsToNotebookCellsSync()** — Converts WASM cell snapshots to React-friendly objects on sync changes
-3. **useDaemonKernel / useEnvProgress** — Consume `notebook:broadcast` events for kernel status, outputs, and environment progress
-4. **usePresence** — Consumes `notebook:presence` events for remote cursor/selection state
+3. **useDaemonKernel / useEnvProgress** — Subscribe via `subscribeBroadcast()` from the frame bus for kernel status, outputs, and environment progress
+4. **usePresence** — Subscribes via `subscribePresence()` from the frame bus for remote cursor/selection state
 
 Cell mutations (add, delete, edit) go through the WASM handle for instant response, then sync to the daemon via `invoke("send_frame", { frameData })` where `frameData` includes the type byte prefix. Execution requests go to the daemon via dedicated Tauri commands.
 
@@ -159,6 +171,7 @@ Cell mutations (add, delete, edit) go through the WASM handle for instant respon
 | `apps/notebook/src/App.tsx` | Root component, provider setup |
 | `apps/notebook/src/hooks/useAutomergeNotebook.ts` | WASM notebook sync |
 | `apps/notebook/src/lib/materialize-cells.ts` | WASM → React conversion |
+| `apps/notebook/src/lib/notebook-frame-bus.ts` | In-memory pub/sub for broadcast and presence dispatch |
 | `apps/notebook/src/hooks/usePresence.ts` | Remote presence tracking |
 | `apps/notebook/src/lib/frame-types.ts` | Frame type constants (mirrors Rust) |
 | `src/components/outputs/media-router.tsx` | Output type dispatch |

--- a/contributing/iframe-isolation.md
+++ b/contributing/iframe-isolation.md
@@ -115,7 +115,7 @@ This prevents other windows/iframes from injecting messages.
 
 ### Renderer Bundle
 
-The isolated renderer code is built inline during the notebook app build via the Vite plugin (`apps/notebook/vite-plugin-isolated-renderer.ts`). The bundle is embedded as a virtual module and passed to `IsolatedFrame` via `rendererCode` and `rendererCss` props—no separate build step or HTTP fetch required.
+The isolated renderer code is built inline during the notebook app build via the Vite plugin (`apps/notebook/vite-plugin-isolated-renderer.ts`). The bundle is embedded as a virtual module and provided to `IsolatedFrame` via the `IsolatedRendererProvider` context (accessed internally through the `useIsolatedRenderer()` hook)—no separate build step or HTTP fetch required.
 
 ## Message Protocol
 

--- a/contributing/logging.md
+++ b/contributing/logging.md
@@ -49,7 +49,7 @@ RUST_LOG=runtimed::notebook_sync_server=debug cargo xtask dev-daemon
 Use the `logger` utility from `apps/notebook/src/lib/logger.ts` instead of raw `console.*`. The codebase uses relative imports from within the notebook app:
 
 ```typescript
-import { logger } from "~/lib/logger";
+import { logger } from "../lib/logger";
 
 logger.debug("[component] Internal detail");
 logger.info("[component] Significant event");

--- a/contributing/logging.md
+++ b/contributing/logging.md
@@ -46,10 +46,10 @@ RUST_LOG=runtimed::notebook_sync_server=debug cargo xtask dev-daemon
 
 ## TypeScript Logging
 
-Use the `logger` utility from `lib/logger` instead of raw `console.*`. The codebase uses relative imports:
+Use the `logger` utility from `apps/notebook/src/lib/logger.ts` instead of raw `console.*`. The codebase uses relative imports from within the notebook app:
 
 ```typescript
-import { logger } from "../lib/logger";
+import { logger } from "~/lib/logger";
 
 logger.debug("[component] Internal detail");
 logger.info("[component] Significant event");

--- a/contributing/protocol.md
+++ b/contributing/protocol.md
@@ -83,28 +83,28 @@ The first frame is a JSON `Handshake` message:
 
 ```json
 {
-  "NotebookSync": {
-    "notebook_id": "/path/to/notebook.ipynb",
-    "protocol": "v2",
-    "working_dir": null,
-    "initial_metadata": "..."
-  }
+  "channel": "notebook_sync",
+  "notebook_id": "/path/to/notebook.ipynb",
+  "protocol": "v2"
 }
 ```
+
+The `Handshake` enum uses `#[serde(tag = "channel", rename_all = "snake_case")]`, so the wire format is flat with a `"channel"` discriminator field — not nested. Optional fields like `working_dir` and `initial_metadata` are omitted when `None` (via `skip_serializing_if`).
+
+Other handshake variants include `Pool`, `SettingsSync`, `Blob`, `PoolStateSubscribe`, `OpenNotebook { path }`, and `CreateNotebook { runtime, ... }`. The `OpenNotebook` and `CreateNotebook` variants are the primary paths for opening/creating notebooks from the desktop app, while `NotebookSync` is used by programmatic clients (e.g., Python bindings).
 
 The daemon responds with a `NotebookConnectionInfo`:
 
 ```json
 {
   "protocol": "v2",
-  "protocol_version": 2,
-  "daemon_version": "2.0.0+abc123",
   "notebook_id": "derived-id",
   "cell_count": 5,
-  "needs_trust_approval": false,
-  "error": null
+  "needs_trust_approval": false
 }
 ```
+
+The `protocol_version` and `daemon_version` fields are `Option` types with `skip_serializing_if = "Option::is_none"`, so they are only present when the daemon populates them (e.g., for version negotiation). A minimal response omits them entirely.
 
 ### 3. Initial Automerge sync
 

--- a/contributing/protocol.md
+++ b/contributing/protocol.md
@@ -104,7 +104,7 @@ The daemon responds with a `NotebookConnectionInfo`:
 }
 ```
 
-The `protocol_version` and `daemon_version` fields are `Option` types with `skip_serializing_if = "Option::is_none"`, so they are only present when the daemon populates them (e.g., for version negotiation). A minimal response omits them entirely.
+The `protocol_version`, `daemon_version`, and `error` fields are `Option` types with `skip_serializing_if = "Option::is_none"`, so they are only present when the daemon populates them. `protocol_version` and `daemon_version` appear for version negotiation; `error` appears only in failure cases. A minimal successful response omits all three.
 
 ### 3. Initial Automerge sync
 

--- a/contributing/runtimed.md
+++ b/contributing/runtimed.md
@@ -51,10 +51,10 @@ The daemon provides a single coordinating entity that prewarms environments in t
 
 | Component | Purpose | Location |
 |-----------|---------|----------|
-| Unix socket | IPC endpoint | `~/.cache/runt/runtimed.sock` |
-| Lock file | Singleton guarantee | `~/.cache/runt/daemon.lock` |
-| Info file | Discovery (PID, endpoint) | `~/.cache/runt/daemon.json` |
-| Environments | Prewarmed venvs | `~/.cache/runt/envs/` |
+| Unix socket | IPC endpoint | `~/.cache/runt/runtimed.sock` (Linux) / `~/Library/Caches/runt/runtimed.sock` (macOS) |
+| Lock file | Singleton guarantee | `~/.cache/runt/daemon.lock` (Linux) / `~/Library/Caches/runt/daemon.lock` (macOS) |
+| Info file | Discovery (PID, endpoint) | `~/.cache/runt/daemon.json` (Linux) / `~/Library/Caches/runt/daemon.json` (macOS) |
+| Environments | Prewarmed venvs | `~/.cache/runt/envs/` (Linux) / `~/Library/Caches/runt/envs/` (macOS) |
 
 ## Development Workflow
 
@@ -62,9 +62,7 @@ The daemon provides a single coordinating entity that prewarms environments in t
 
 The notebook app automatically tries to connect to or start the daemon on launch. If it's not running, the app falls back to in-process prewarming. You don't need to do anything special.
 
-```rust
-runtimed::client::ensure_daemon_via_sidecar().await
-```
+The notebook app calls `ensure_daemon_via_sidecar()` (a private function in `crates/notebook/src/lib.rs`) which takes a `tauri::AppHandle` and a progress callback to start and connect to the daemon.
 
 ### Install daemon from source
 
@@ -132,7 +130,7 @@ crates/runtimed/
 │   ├── notebook_sync_client.rs  # Notebook sync client library
 │   ├── blob_store.rs            # Content-addressed blob store with metadata sidecars
 │   ├── blob_server.rs           # HTTP read server for blobs (hyper 1.x)
-│   ├── runtime.rs               # Runtime detection (Python/Deno)
+│   ├── runtime.rs               # Runtime enum definition (Python/Deno/Other)
 │   ├── kernel_manager.rs        # Kernel lifecycle, ZMQ iopub watching, execution queue
 │   ├── inline_env.rs            # Inline dependency environment caching (UV/Conda)
 │   ├── project_file.rs          # Project file detection (pyproject.toml, pixi.toml, etc.)

--- a/contributing/testing.md
+++ b/contributing/testing.md
@@ -9,7 +9,7 @@ This guide covers all test types in the codebase. For E2E tests specifically, se
 | E2E | `e2e/specs/` | `./e2e/dev.sh test` | WebdriverIO + Mocha |
 | Frontend unit | `src/**/__tests__/` | `pnpm test` | Vitest + jsdom |
 | Rust unit | inline `#[cfg(test)]` | `cargo test` | built-in |
-| CLI behavior | `crates/runt/tests/*.hone` | `cargo hone test` | Hone |
+| CLI behavior | `crates/runt/tests/*.hone` | `cargo hone test` | Hone (not yet published) |
 | Python | `python/runtimed/tests/` | `pytest` | pytest |
 
 ## Frontend Unit Tests (Vitest)
@@ -63,6 +63,9 @@ describe("AnsiOutput", () => {
 - `src/components/isolated/__tests__/` — Frame bridge, message protocol
 - `src/components/outputs/__tests__/` — Output renderers
 - `src/components/widgets/__tests__/` — Widget store, registry
+- `src/lib/__tests__/` — ErrorBoundary
+- `apps/notebook/src/hooks/__tests__/` — useEnvProgress
+- `apps/notebook/src/lib/__tests__/` — Cursor registry, manifest resolution, materialize cells, kernel status, markdown assets, and more
 
 ## Rust Unit Tests
 
@@ -147,6 +150,8 @@ ASSERT stdout matches /runt-cli \d+\.\d+\.\d+/
 | `stop_errors.hone` | Stop command edge cases |
 
 **Running Hone tests:**
+
+> **Note:** `cargo hone` is not yet published to crates.io. The `.hone` test files exist in the repo but the test runner is not currently installable. This section will be updated once `hone` is available.
 
 ```bash
 cargo hone test               # All hone tests

--- a/contributing/widget-development.md
+++ b/contributing/widget-development.md
@@ -87,12 +87,14 @@ Under the hood this calls `useSyncExternalStore` with `subscribeToKey` and `getM
 
 Widget communication follows the Jupyter Comm protocol:
 
-| Message | When | Data |
-|---------|------|------|
+| Message | When | Jupyter Wire Format |
+|---------|------|---------------------|
 | `comm_open` | Widget created | `{ comm_id, target_name, data: { state } }` |
 | `comm_msg` | State update | `{ comm_id, data: { method: "update", state } }` |
 | `comm_msg` | Custom message | `{ comm_id, data: { method: "custom", content } }` |
 | `comm_close` | Widget destroyed | `{ comm_id }` |
+
+> **Note:** The table above shows the Jupyter wire protocol message shapes. The internal TypeScript types in `frame-bridge.ts` use camelCase (`commId`, `targetName`) and a flatter structure (e.g., `method` is a sibling of `data` in `CommMsgMessage`, not nested inside it). See `CommOpenMessage` and `CommMsgMessage` in `src/components/isolated/frame-bridge.ts` for the actual postMessage payload shapes.
 
 The CommBridgeManager:
 1. Subscribes to WidgetStore changes

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -20,7 +20,7 @@ This means Python and Deno notebooks can coexist in the same project directory �
 For Python notebooks, nteract Desktop looks for dependencies in this order:
 
 1. **Inline dependencies** stored in the notebook itself
-2. **Closest project file** — nteract Desktop walks up from the notebook's directory looking for `pyproject.toml`, `pixi.toml`, or `environment.yml`. The closest match wins, regardless of file type. If the same directory has multiple project files, the tiebreaker is: pyproject.toml > pixi.toml > environment.yml
+2. **Closest project file** — nteract Desktop walks up from the notebook's directory looking for `pyproject.toml`, `pixi.toml`, or `environment.yml`/`environment.yaml`. The closest match wins, regardless of file type. If the same directory has multiple project files, the tiebreaker is: pyproject.toml > pixi.toml > environment.yml > environment.yaml
 3. If none found, a **prewarmed environment** with just the basics
 
 The search stops at git repository boundaries and your home directory, so project files from unrelated repos won't interfere.
@@ -47,9 +47,9 @@ The dependency panel offers two actions:
 - **Use project environment** — run the kernel in the project's `.venv` (keeps deps in sync with the project)
 - **Copy to notebook** — snapshot the project's dependencies into the notebook metadata (makes the notebook portable but deps may drift from the project)
 
-## Working with environment.yml
+## Working with environment.yml / environment.yaml
 
-Conda `environment.yml` files are auto-detected. nteract Desktop parses the channels, conda dependencies, and pip dependencies from the file and creates a conda environment using rattler.
+Conda `environment.yml` (and `environment.yaml`) files are auto-detected. nteract Desktop parses the channels, conda dependencies, and pip dependencies from the file and creates a conda environment using rattler.
 
 The dependency panel shows the environment.yml dependencies and offers an "Import to notebook" action to copy them into the notebook's conda metadata for portability.
 
@@ -86,7 +86,7 @@ Choose which package manager to use for Python notebooks:
 - **UV** (default) — fast, pip-compatible package management
 - **Conda** — supports conda packages (useful for non-Python dependencies like CUDA libraries)
 
-This preference is used when no project files are detected and the notebook has no inline dependencies. When a project file is present, nteract Desktop picks the appropriate backend automatically (UV for pyproject.toml, Conda for environment.yml and pixi.toml).
+This preference is used when no project files are detected and the notebook has no inline dependencies. When a project file is present, nteract Desktop picks the appropriate backend automatically (UV for pyproject.toml, Conda for environment.yml/environment.yaml and pixi.toml).
 
 See [Settings](settings.md) for how to change these defaults.
 
@@ -118,7 +118,7 @@ To reclaim disk space, delete the environment cache directories. nteract Desktop
 
 **Packages aren't available after adding them**: Click "Sync Now" in the dependency panel to install pending changes, then restart the kernel.
 
-**Wrong environment**: If the kernel started with a prewarmed environment instead of your project's dependencies, check that your project file (pyproject.toml, environment.yml, pixi.toml) is in the notebook's directory or a parent directory within the same git repository.
+**Wrong environment**: If the kernel started with a prewarmed environment instead of your project's dependencies, check that your project file (pyproject.toml, environment.yml/environment.yaml, pixi.toml) is in the notebook's directory or a parent directory within the same git repository.
 
 **Slow first start**: The first time a notebook opens with dependencies, nteract Desktop needs to download and install packages. Subsequent opens with the same dependencies are instant due to caching.
 

--- a/docs/python-bindings.md
+++ b/docs/python-bindings.md
@@ -178,7 +178,7 @@ with runtimed.Session() as session:
 | `kernel_started` | `bool` | Whether kernel is running |
 | `kernel_type` | `str \| None` | Current kernel type ("python", "deno", or None if not started) |
 | `env_source` | `str \| None` | Environment source (e.g., "uv:prewarmed") |
-| `connection_info` | `NotebookConnectionInfo \| None` | Notebook connection info (protocol, daemon_version, notebook_id, cell_count, needs_trust_approval) after connecting |
+| `connection_info` | `NotebookConnectionInfo \| None` | Notebook connection info after connecting. Fields: `protocol` (str), `notebook_id` (str), `cell_count` (int), `needs_trust_approval` (bool), and optional `protocol_version` (int \| None), `daemon_version` (str \| None), `error` (str \| None) |
 
 ## AsyncSession API
 
@@ -389,7 +389,7 @@ for event in events:
     event.event_type      # "execution_started", "output", "done", "error"
     event.cell_id         # Cell this event is for
     event.output          # Output object (only for "output" events)
-    event.output_index    # int (only for "output" events: index in cell's output list)
+    event.output_index    # int | None (only for "output" events: index in cell's output list)
     event.execution_count # int (only for "execution_started" events)
     event.error_message   # str (only for "error" events)
 ```

--- a/docs/python-bindings.md
+++ b/docs/python-bindings.md
@@ -178,7 +178,7 @@ with runtimed.Session() as session:
 | `kernel_started` | `bool` | Whether kernel is running |
 | `kernel_type` | `str \| None` | Current kernel type ("python", "deno", or None if not started) |
 | `env_source` | `str \| None` | Environment source (e.g., "uv:prewarmed") |
-| `connection_info` | `dict \| None` | Kernel connection info (ports, transport, key) when kernel is running |
+| `connection_info` | `NotebookConnectionInfo \| None` | Notebook connection info (protocol, daemon_version, notebook_id, cell_count, needs_trust_approval) after connecting |
 
 ## AsyncSession API
 
@@ -389,6 +389,7 @@ for event in events:
     event.event_type      # "execution_started", "output", "done", "error"
     event.cell_id         # Cell this event is for
     event.output          # Output object (only for "output" events)
+    event.output_index    # int (only for "output" events: index in cell's output list)
     event.execution_count # int (only for "execution_started" events)
     event.error_message   # str (only for "error" events)
 ```
@@ -426,6 +427,8 @@ cell.cell_type       # "code", "markdown", or "raw"
 cell.position        # Fractional index string for ordering
 cell.source          # Cell source content
 cell.execution_count # Execution count if executed
+cell.outputs         # List of Output objects (resolved from automerge document)
+cell.metadata_json   # Cell metadata as JSON string
 ```
 
 ## Multi-Client Scenarios

--- a/docs/runtimed.md
+++ b/docs/runtimed.md
@@ -796,14 +796,16 @@ When daemon receives `LaunchKernel { env_source: "auto" }`:
 Detection priority:
 | File | env_source |
 |------|------------|
-| `metadata.uv.dependencies` | `uv:inline` |
-| `metadata.conda.dependencies` | `conda:inline` |
+| `metadata.runt.uv.dependencies` | `uv:inline` |
+| `metadata.runt.conda.dependencies` | `conda:inline` |
 | `pyproject.toml` | `uv:pyproject` |
 | `pixi.toml` | `conda:pixi` |
 | `environment.yml` | `conda:env_yml` |
 | No match | `uv:prewarmed` (or `conda:prewarmed` per user pref) |
 
 Walk-up stops at `.git` boundary or home directory.
+
+> **Note:** The daemon also checks the legacy paths `metadata.uv.dependencies` and `metadata.conda.dependencies` as fallbacks for notebooks that haven't been migrated to the `metadata.runt.*` namespace.
 
 ### Widget support (partial)
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -11,7 +11,7 @@ nteract Desktop settings control default behavior for new notebooks, appearance,
 | Default Python env | uv, conda | uv | Synced (Automerge) + settings file |
 | Default uv packages | list of strings | (empty) | Synced (Automerge) + settings file |
 | Default conda packages | list of strings | (empty) | Synced (Automerge) + settings file |
-| Keep alive secs | integer | 300 | Synced (Automerge) + settings file |
+| Keep alive secs | integer | 30 | Synced (Automerge) + settings file |
 | Onboarding completed | boolean | false | Synced (Automerge) + settings file |
 
 ## How Settings Sync Works
@@ -35,7 +35,7 @@ ROOT/
   theme: "system"
   default_runtime: "python"
   default_python_env: "uv"
-  keep_alive_secs: 300
+  keep_alive_secs: 30
   onboarding_completed: false
   uv/                                         ← nested Map
     default_packages: List["numpy", "pandas"] ← List of Str

--- a/python/README.md
+++ b/python/README.md
@@ -21,7 +21,7 @@ uv run --reinstall-package runtimed maturin develop
 uv pip install --no-deps -e ../nteract
 
 # 3. Install nteract's other dependencies
-uv pip install "mcp>=1.26.0" "httpx>=0.27.0,<1.0"
+uv pip install "mcp>=1.26.0" "httpx>=0.27.0,<1.0" "pydantic>=2.0"
 
 # 4. Verify both packages are local
 uv run python -c "import runtimed, nteract; print('ok')"

--- a/python/nteract/CHANGELOG.md
+++ b/python/nteract/CHANGELOG.md
@@ -8,11 +8,11 @@ First release from `nteract/desktop`. The `nteract` Python package is now an MCP
 
 - **MCP server** — `nteract` runs as a stdio MCP server, compatible with Claude, ChatGPT, Gemini, OpenCode, and any MCP-capable agent
 - **Notebook lifecycle** — `list_notebooks`, `join_notebook`, `open_notebook`, `create_notebook`, `save_notebook`
-- **Cell operations** — `create_cell`, `get_cell`, `get_all_cells`, `set_cell_source`, `append_source`, `delete_cell`, `move_cell`, `set_cell_type`, `clear_outputs`
+- **Cell operations** — `create_cell`, `get_cell`, `get_all_cells`, `set_cell`, `delete_cell`, `move_cell`, `clear_outputs`
 - **Targeted editing** — `replace_match` (literal find-and-replace) and `replace_regex` (regex-based) for surgical cell edits without rewriting entire sources
 - **Execution** — `execute_cell`, `run_all_cells`, `interrupt_kernel`, `restart_kernel`
 - **Dependencies** — `get_dependencies`, `add_dependency`, `remove_dependency`, `sync_environment` with UV and Conda support
-- **Resources** — `notebook://cells`, `notebook://status`, `notebook://rooms` for read-only state access
+- **Resources** — `notebook://cells`, `notebook://cell/{cell_id}`, `notebook://cells/by-index/{index}`, `notebook://cell/{cell_id}/outputs`, `notebook://status`, `notebook://rooms` for read-only state access
 
 ### Breaking changes from 1.x
 

--- a/python/nteract/README.md
+++ b/python/nteract/README.md
@@ -4,11 +4,11 @@
 
 If you're here looking for the Electron-based nteract desktop app, you can view the source [in this repo](https://github.com/nteract/archived-desktop-app). **That desktop app is not actively maintained.**
 
-We're actively developing the spritual successor to the nteract desktop app in the [nteract/desktop repo](https://github.com/nteract/desktop).
+We're actively developing the spiritual successor to the nteract desktop app in the [nteract/desktop repo](https://github.com/nteract/desktop).
 
 ### The New Desktop App
 
-We're actively developing the spritual successor to the nteract desktop app in the [nteract/desktop repo](https://github.com/nteract/desktop).
+We're actively developing the spiritual successor to the nteract desktop app in the [nteract/desktop repo](https://github.com/nteract/desktop).
 
 The new app is a native desktop app with instant startup and intelligent environment management.
 
@@ -16,7 +16,7 @@ The new app is a native desktop app with instant startup and intelligent environ
 
 ## Bringing Agents in the Loop
 
-We're in the prelimiary stages of hooking up the realtime system from nteract/desktop to any agent of your choice. Collaborate with agents in notebooks, render interactive elements, and explore data together.
+We're in the preliminary stages of hooking up the realtime system from nteract/desktop to any agent of your choice. Collaborate with agents in notebooks, render interactive elements, and explore data together.
 
 ### Quick Start
 
@@ -118,13 +118,11 @@ claude mcp add nteract -- env RUNTIMED_SOCKET_PATH="$HOME/Library/Caches/runt-ni
 | `create_cell` | Add a cell to the notebook (use `and_run=True` to execute) |
 | `execute_cell` | Run a specific cell (returns partial results after timeout) |
 | `run_all_cells` | Queue all code cells for execution |
-| `append_source` | Stream tokens into a cell (ideal for LLM output) |
+| `set_cell` | Update a cell's source and/or type |
 | `get_cell` | Get a cell by ID with outputs |
 | `get_all_cells` | View all cells in the notebook |
-| `set_cell_source` | Replace a cell's entire source code |
 | `replace_match` | Targeted literal text find-and-replace in a cell |
 | `replace_regex` | Regex-based find-and-replace in a cell |
-| `set_cell_type` | Change a cell's type (code, markdown, or raw) |
 | `move_cell` | Reorder a cell within the notebook |
 | `clear_outputs` | Clear a cell's outputs |
 | `delete_cell` | Remove a cell from the notebook |

--- a/python/runtimed/README.md
+++ b/python/runtimed/README.md
@@ -1,11 +1,15 @@
 # runtimed
 
-Python bindings for the runtimed notebook daemon. Execute code, manage kernels, and interact with notebooks programmatically.
+Python toolkit for Jupyter runtimes, powered by runtimed Rust binaries. Execute code, manage kernels, and interact with notebooks programmatically.
 
 ## Installation
 
 ```bash
+# Stable (1.x)
 pip install runtimed
+
+# Pre-release (2.x — matches nteract desktop nightly)
+pip install --pre runtimed
 ```
 
 ## Quick Start

--- a/python/runtimed/README.md
+++ b/python/runtimed/README.md
@@ -5,12 +5,10 @@ Python toolkit for Jupyter runtimes, powered by runtimed Rust binaries. Execute 
 ## Installation
 
 ```bash
-# Stable (1.x)
 pip install runtimed
-
-# Pre-release (2.x — matches nteract desktop nightly)
-pip install --pre runtimed
 ```
+
+> **Note:** The 2.0 release is currently in pre-release. Use `pip install --pre runtimed` (or `uv pip install --prerelease allow runtimed`) to get the latest 2.x build matching the nteract desktop nightly.
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary

Comprehensive audit of all 33 markdown files (excluding AGENTS.md/CLAUDE.md) against the actual codebase. Fixes inaccuracies, outdated references, missing info, and broken paths across 21 files.

## 🔴 High Severity Fixes

| File | Issue |
|------|-------|
| `README.md` | Linux build deps missing `libssl-dev`, `libayatana-appindicator3-dev`, `librsvg2-dev` — would cause build failures |
| `RELEASING.md` | Desktop releases also publish Python packages to PyPI — was completely undocumented |
| `RELEASING.md` | Python wheel targets missing macOS x86_64 |
| `docs/settings.md` | `keep_alive_secs` default was 300, actual is **30** (10× difference) |
| `docs/python-bindings.md` | `connection_info` documented as `dict` with ports/transport/key — actually `NotebookConnectionInfo` |
| `python/README.md` | Manual install missing `pydantic>=2.0` — would cause import error |
| `python/nteract/README.md` | Tools table listed 3 non-existent tools; missing actual `set_cell` tool |

## 🟡 Medium Severity Fixes

| File | Issue |
|------|-------|
| `README.md` | `docs/` → "User-facing docs"; added `sidecar/`, expanded `src/` tree, 6 missing xtask commands, `nteract` PyPI component |
| `contributing/development.md` | Non-existent fixture path; wrong `daemon list-worktrees` → `dev worktrees` |
| `contributing/build-dependencies.md` | Removed false `runtimed → notebook-sync` dep edge; added 4 missing edges |
| `contributing/testing.md` | `cargo hone test` doesn't exist — noted hone is not yet published |
| `contributing/frontend-architecture.md` | Data flow referenced `notebook:broadcast`/`notebook:presence` Tauri events — replaced by in-memory frame bus; added missing dirs, sub-apps, 7 hooks |
| `contributing/iframe-isolation.md` | Renderer bundle uses `IsolatedRendererProvider` context, not props |
| `contributing/protocol.md` | Handshake JSON was nested — actual wire format is flat with `"channel"` discriminator; optional fields clarified; added additional handshake variants |
| `contributing/runtimed.md` | Fixed `ensure_daemon_via_sidecar()` location; `runtime.rs` description; added macOS paths |
| `contributing/environments.md` | Trust logic → `runt-trust`; added `useDenoDependencies` hook; `prerelease` in hash formula; fixed duplicate entry |
| `docs/python-bindings.md` | Added `outputs`, `metadata_json` to Cell; `output_index` to ExecutionEvent |
| `docs/runtimed.md` | Legacy `metadata.uv` → `metadata.runt.uv` |
| `docs/environments.md` | Added `environment.yaml` variant |
| `python/nteract/CHANGELOG.md` | Replaced 3 phantom tools with `set_cell`; expanded Resources to all 6 |
| `python/runtimed/README.md` | Added `--pre` for 2.x installs |
| `e2e/README.md` | Added 6 missing helper functions |

## 🟢 Low Severity Fixes

- `README.md`: Biome comment "Format JS" → "Lint + format JS/TS"
- `contributing/testing.md`: Added 3 missing frontend test directory locations
- `contributing/logging.md`: Clarified logger lives in `apps/notebook/src/lib/logger.ts`
- `contributing/widget-development.md`: Note that comm protocol table shows Jupyter wire format, not TS types
- `python/nteract/README.md`: Typos "spritual" → "spiritual", "prelimiary" → "preliminary"

## Files Verified Clean (no changes needed)

`contributing/architecture.md`, `contributing/releasing.md`, `contributing/ui.md`, `contributing/nteract-elements.md`, `docs/logging.md`, `docs/sharing.md`, `docs/troubleshooting.md`, `docs/widgets.md`, `python/runtimed/demos/README.md`, `crates/notebook/fixtures/trust-tests/README.md`