### PR TITLE
feat(mcp): add show_notebook tool + --no-show flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5655,6 +5655,7 @@ dependencies = [
  "pyo3",
  "pyo3-async-runtimes",
  "reqwest 0.12.28",
+ "runt-workspace",
  "runtimed",
  "serde_json",
  "thiserror 1.0.69",

--- a/crates/runt-workspace/src/lib.rs
+++ b/crates/runt-workspace/src/lib.rs
@@ -184,7 +184,8 @@ pub fn open_notebook_app(path: Option<&Path>, extra_args: &[&str]) -> Result<(),
 
 fn open_notebook_dev(path: Option<&Path>, extra_args: &[&str]) -> Result<(), String> {
     let workspace = get_workspace_path().ok_or("Dev mode active but no workspace path found")?;
-    let binary = workspace.join("target/debug/notebook");
+    let binary_name = format!("notebook{}", std::env::consts::EXE_SUFFIX);
+    let binary = workspace.join("target/debug").join(&binary_name);
     let marker = workspace.join("target/debug/.notebook-bundled");
 
     if !binary.exists() {

--- a/crates/runt-workspace/src/lib.rs
+++ b/crates/runt-workspace/src/lib.rs
@@ -148,6 +148,120 @@ pub fn channel_display_name() -> &'static str {
 }
 
 // ============================================================================
+// Desktop App Launching
+// ============================================================================
+
+/// App names to try when launching the desktop notebook app.
+///
+/// Returns candidates in priority order. On nightly, tries nightly-specific
+/// names first, falling back to stable. On stable, only tries "nteract".
+pub fn desktop_app_launch_candidates() -> &'static [&'static str] {
+    match build_channel() {
+        BuildChannel::Stable => &["nteract"],
+        BuildChannel::Nightly => &[
+            "nteract Nightly",
+            "nteract-nightly",
+            "nteract (Nightly)", // legacy fallback for older installs
+            "nteract",
+        ],
+    }
+}
+
+/// Launch the desktop notebook app, optionally opening a specific notebook.
+///
+/// In dev mode, uses the local bundled binary at `{workspace}/target/debug/notebook`.
+/// Requires `cargo xtask build` first (checks for `.notebook-bundled` marker).
+/// This ensures the app connects to the worktree daemon, not the system daemon.
+///
+/// In production, tries installed app candidates via platform-specific launch
+/// (macOS: `open -a`, Linux/Windows: direct exec).
+pub fn open_notebook_app(path: Option<&Path>, extra_args: &[&str]) -> Result<(), String> {
+    if is_dev_mode() {
+        return open_notebook_dev(path, extra_args);
+    }
+    open_notebook_installed(path, extra_args)
+}
+
+fn open_notebook_dev(path: Option<&Path>, extra_args: &[&str]) -> Result<(), String> {
+    let workspace = get_workspace_path().ok_or("Dev mode active but no workspace path found")?;
+    let binary = workspace.join("target/debug/notebook");
+    let marker = workspace.join("target/debug/.notebook-bundled");
+
+    if !binary.exists() {
+        return Err(format!(
+            "No notebook binary found at {}. Run `cargo xtask build` first.",
+            binary.display()
+        ));
+    }
+    if !marker.exists() {
+        return Err(format!(
+            "Notebook binary at {} is a dev build (requires Vite server). \
+             Run `cargo xtask build` for a standalone bundled binary.",
+            binary.display()
+        ));
+    }
+
+    let mut cmd = Command::new(&binary);
+    if let Some(p) = path {
+        cmd.arg(p);
+    }
+    for arg in extra_args {
+        cmd.arg(arg);
+    }
+    cmd.spawn()
+        .map_err(|e| format!("Failed to launch {}: {}", binary.display(), e))?;
+    Ok(())
+}
+
+fn open_notebook_installed(path: Option<&Path>, extra_args: &[&str]) -> Result<(), String> {
+    let mut last_error = None;
+
+    for app_name in desktop_app_launch_candidates() {
+        #[cfg(target_os = "macos")]
+        let spawn_result = {
+            let mut cmd = Command::new("open");
+            cmd.arg("-a").arg(app_name);
+            if path.is_some() || !extra_args.is_empty() {
+                cmd.arg("--args");
+            }
+            if let Some(p) = path {
+                cmd.arg(p);
+            }
+            for arg in extra_args {
+                cmd.arg(arg);
+            }
+            cmd.spawn()
+        };
+
+        #[cfg(not(target_os = "macos"))]
+        let spawn_result = {
+            let mut cmd = Command::new(app_name);
+            if let Some(p) = path {
+                cmd.arg(p);
+            }
+            for arg in extra_args {
+                cmd.arg(arg);
+            }
+            cmd.spawn()
+        };
+
+        match spawn_result {
+            Ok(_) => return Ok(()),
+            Err(e) => last_error = Some((app_name, e)),
+        }
+    }
+
+    let detail = last_error
+        .map(|(candidate, e)| format!("last attempt ({candidate}) failed: {e}"))
+        .unwrap_or_else(|| "no launch candidates were attempted".to_string());
+    Err(format!(
+        "Failed to launch {}: {}",
+        desktop_display_name(),
+        detail
+    ))
+}
+
+// ============================================================================
 // Development Mode Detection
 // ============================================================================
 
@@ -333,6 +447,15 @@ mod tests {
             build_channel_from_str(Some("something-else")),
             BuildChannel::Nightly
         );
+    }
+
+    #[test]
+    fn test_desktop_app_launch_candidates() {
+        let candidates = desktop_app_launch_candidates();
+        // Should always have at least one candidate
+        assert!(!candidates.is_empty());
+        // Last candidate should always be "nteract" (the stable fallback)
+        assert_eq!(*candidates.last().unwrap(), "nteract");
     }
 
     #[test]

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -473,18 +473,6 @@ fn main() -> Result<()> {
 ///
 /// The app automatically captures its working directory at startup for untitled
 /// notebooks, so we don't need to pass --cwd explicitly.
-fn desktop_app_launch_candidates() -> &'static [&'static str] {
-    match runt_workspace::build_channel() {
-        runt_workspace::BuildChannel::Stable => &["nteract"],
-        runt_workspace::BuildChannel::Nightly => &[
-            "nteract Nightly",
-            "nteract-nightly",
-            "nteract (Nightly)", // legacy fallback for older installs
-            "nteract",
-        ],
-    }
-}
-
 fn open_notebook(path: Option<PathBuf>, runtime: Option<String>) -> Result<()> {
     // Convert relative paths to absolute
     let abs_path = path.map(|p| {
@@ -495,98 +483,14 @@ fn open_notebook(path: Option<PathBuf>, runtime: Option<String>) -> Result<()> {
         }
     });
 
-    let launch_result: Result<()> = {
-        #[cfg(target_os = "macos")]
-        {
-            let mut last_error = None;
-            for app_name in desktop_app_launch_candidates() {
-                let mut cmd = std::process::Command::new("open");
-                cmd.arg("-a").arg(app_name);
+    let mut extra_args = Vec::new();
+    if let Some(ref r) = runtime {
+        extra_args.push("--runtime");
+        extra_args.push(r);
+    }
 
-                if abs_path.is_some() || runtime.is_some() {
-                    cmd.arg("--args");
-                }
-                if let Some(ref p) = abs_path {
-                    cmd.arg(p);
-                }
-                if let Some(ref r) = runtime {
-                    cmd.arg("--runtime").arg(r);
-                }
-
-                match cmd.spawn() {
-                    Ok(_) => return Ok(()),
-                    Err(e) => last_error = Some((app_name, e)),
-                }
-            }
-
-            let detail = last_error
-                .map(|(candidate, e)| format!("last attempt ({candidate}) failed: {e}"))
-                .unwrap_or_else(|| "no launch candidates were attempted".to_string());
-            Err(anyhow::anyhow!(
-                "Failed to launch {}: {}",
-                runt_workspace::desktop_display_name(),
-                detail
-            ))
-        }
-        #[cfg(target_os = "windows")]
-        {
-            let mut last_error = None;
-            for app_name in desktop_app_launch_candidates() {
-                let mut cmd = std::process::Command::new(app_name);
-
-                if let Some(ref p) = abs_path {
-                    cmd.arg(p);
-                }
-                if let Some(ref r) = runtime {
-                    cmd.arg("--runtime").arg(r);
-                }
-
-                match cmd.spawn() {
-                    Ok(_) => return Ok(()),
-                    Err(e) => last_error = Some((app_name, e)),
-                }
-            }
-
-            let detail = last_error
-                .map(|(candidate, e)| format!("last attempt ({candidate}) failed: {e}"))
-                .unwrap_or_else(|| "no launch candidates were attempted".to_string());
-            Err(anyhow::anyhow!(
-                "Failed to launch {}: {}",
-                runt_workspace::desktop_display_name(),
-                detail
-            ))
-        }
-        #[cfg(target_os = "linux")]
-        {
-            let mut last_error = None;
-            for app_name in desktop_app_launch_candidates() {
-                let mut cmd = std::process::Command::new(app_name);
-
-                if let Some(ref p) = abs_path {
-                    cmd.arg(p);
-                }
-                if let Some(ref r) = runtime {
-                    cmd.arg("--runtime").arg(r);
-                }
-
-                match cmd.spawn() {
-                    Ok(_) => return Ok(()),
-                    Err(e) => last_error = Some((app_name, e)),
-                }
-            }
-
-            let detail = last_error
-                .map(|(candidate, e)| format!("last attempt ({candidate}) failed: {e}"))
-                .unwrap_or_else(|| "no launch candidates were attempted".to_string());
-            Err(anyhow::anyhow!(
-                "Failed to launch {}: {}",
-                runt_workspace::desktop_display_name(),
-                detail
-            ))
-        }
-    };
-
-    launch_result
+    runt_workspace::open_notebook_app(abs_path.as_deref(), &extra_args)
+        .map_err(|e| anyhow::anyhow!(e))
 }
 
 async fn async_main(command: Option<Commands>) -> Result<()> {
@@ -2644,7 +2548,7 @@ fn find_bundled_runtimed() -> Option<PathBuf> {
     #[cfg(target_os = "macos")]
     {
         let mut locations = Vec::new();
-        for app_name in desktop_app_launch_candidates() {
+        for app_name in runt_workspace::desktop_app_launch_candidates() {
             locations.push(PathBuf::from(format!(
                 "/Applications/{app_name}.app/Contents/MacOS/{binary_name}"
             )));
@@ -2663,7 +2567,7 @@ fn find_bundled_runtimed() -> Option<PathBuf> {
     #[cfg(target_os = "linux")]
     {
         let mut locations = Vec::new();
-        for app_name in desktop_app_launch_candidates() {
+        for app_name in runt_workspace::desktop_app_launch_candidates() {
             locations.push(PathBuf::from(format!(
                 "/usr/share/{app_name}/{binary_name}"
             )));
@@ -2682,7 +2586,7 @@ fn find_bundled_runtimed() -> Option<PathBuf> {
     #[cfg(target_os = "windows")]
     {
         let mut locations = Vec::new();
-        for app_name in desktop_app_launch_candidates() {
+        for app_name in runt_workspace::desktop_app_launch_candidates() {
             locations.push(
                 dirs::data_local_dir()
                     .unwrap_or_default()

--- a/crates/runtimed-py/Cargo.toml
+++ b/crates/runtimed-py/Cargo.toml
@@ -24,3 +24,4 @@ uuid = { workspace = true }
 log = "0.4"
 thiserror = { workspace = true }
 reqwest = { version = "0.12", default-features = false, features = ["native-tls", "json"] }
+runt-workspace = { path = "../runt-workspace" }

--- a/crates/runtimed-py/src/lib.rs
+++ b/crates/runtimed-py/src/lib.rs
@@ -46,7 +46,7 @@ use subscription::{EventIteratorSubscription, EventSubscription};
 #[pyo3(signature = (notebook_path=None))]
 fn show_notebook_app(notebook_path: Option<PathBuf>) -> PyResult<()> {
     runt_workspace::open_notebook_app(notebook_path.as_deref(), &[])
-        .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e))
+        .map_err(PyErr::new::<pyo3::exceptions::PyRuntimeError, _>)
 }
 
 /// Python module for runtimed daemon client.

--- a/crates/runtimed-py/src/lib.rs
+++ b/crates/runtimed-py/src/lib.rs
@@ -10,6 +10,7 @@
 //! Both sync and async APIs are provided with full feature parity.
 
 use pyo3::prelude::*;
+use std::path::PathBuf;
 
 mod async_session;
 mod client;
@@ -32,6 +33,18 @@ use output::{
 };
 use session::Session;
 use subscription::{EventIteratorSubscription, EventSubscription};
+
+/// Launch the desktop notebook app, optionally opening a specific notebook.
+///
+/// In dev mode, uses the local bundled binary. In production, tries installed
+/// app candidates via platform-specific launch.
+#[pyfunction]
+#[pyo3(signature = (path=None))]
+fn show_notebook_app(path: Option<String>) -> PyResult<()> {
+    let path_buf = path.map(PathBuf::from);
+    runt_workspace::open_notebook_app(path_buf.as_deref(), &[])
+        .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e))
+}
 
 /// Python module for runtimed daemon client.
 #[pymodule]
@@ -67,6 +80,9 @@ fn runtimed(m: &Bound<'_, PyModule>) -> PyResult<()> {
 
     // Error type
     m.add("RuntimedError", m.py().get_type::<RuntimedError>())?;
+
+    // Standalone functions
+    m.add_function(wrap_pyfunction!(show_notebook_app, m)?)?;
 
     Ok(())
 }

--- a/crates/runtimed-py/src/lib.rs
+++ b/crates/runtimed-py/src/lib.rs
@@ -38,11 +38,14 @@ use subscription::{EventIteratorSubscription, EventSubscription};
 ///
 /// In dev mode, uses the local bundled binary. In production, tries installed
 /// app candidates via platform-specific launch.
+///
+/// Args:
+///     notebook_path: Optional filesystem path to the notebook to open.
+///         Accepts str or pathlib.Path (any os.PathLike).
 #[pyfunction]
-#[pyo3(signature = (path=None))]
-fn show_notebook_app(path: Option<String>) -> PyResult<()> {
-    let path_buf = path.map(PathBuf::from);
-    runt_workspace::open_notebook_app(path_buf.as_deref(), &[])
+#[pyo3(signature = (notebook_path=None))]
+fn show_notebook_app(notebook_path: Option<PathBuf>) -> PyResult<()> {
+    runt_workspace::open_notebook_app(notebook_path.as_deref(), &[])
         .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e))
 }
 

--- a/python/nteract/src/nteract/_mcp_server.py
+++ b/python/nteract/src/nteract/_mcp_server.py
@@ -502,6 +502,12 @@ if not _no_show:
                 f"Use list_notebooks() to see active notebooks."
             )
 
+        if not os.path.isabs(target):
+            raise ValueError(
+                f"Notebook '{target}' is an untitled notebook (not saved to disk). "
+                f"Use save_notebook(path) first, then call show_notebook()."
+            )
+
         runtimed.show_notebook_app(target)
         return f"Opened notebook in nteract: {target}"
 

--- a/python/nteract/src/nteract/_mcp_server.py
+++ b/python/nteract/src/nteract/_mcp_server.py
@@ -39,6 +39,10 @@ ContentItem = TextContent | ImageContent
 # Create the MCP server
 mcp = FastMCP("nteract")
 
+# When --no-show is passed, the show_notebook tool is not registered.
+# This is useful for headless environments where no desktop app is available.
+_no_show = "--no-show" in sys.argv
+
 
 # ── Peer label for remote cursors ─────────────────────────────────────
 # The MCP initialize handshake includes clientInfo with `name` and
@@ -461,6 +465,45 @@ async def list_notebooks() -> list[dict[str, Any]]:
         }
         for room in rooms
     ]
+
+
+if not _no_show:
+
+    @mcp.tool()
+    async def show_notebook(
+        notebook_id: Annotated[
+            str | None,
+            Field(
+                description="Notebook ID to show. Defaults to current session's notebook.",
+            ),
+        ] = None,
+    ) -> str:
+        """Open the notebook in the nteract desktop app.
+
+        The notebook must be currently running in the daemon. If no notebook_id
+        is provided, opens the notebook from the current session.
+        """
+        target = notebook_id
+        if target is None:
+            if _session is not None:
+                target = _session.notebook_id
+            else:
+                raise ValueError(
+                    "No notebook_id provided and no active session. "
+                    "Use list_notebooks() to find a notebook_id, or connect to one first."
+                )
+
+        client = _get_daemon_client()
+        rooms = client.list_rooms()
+        room_ids = {room["notebook_id"] for room in rooms}
+        if target not in room_ids:
+            raise ValueError(
+                f"Notebook '{target}' is not currently running. "
+                f"Use list_notebooks() to see active notebooks."
+            )
+
+        runtimed.show_notebook_app(target)
+        return f"Opened notebook in nteract: {target}"
 
 
 @mcp.tool(annotations=ToolAnnotations(destructiveHint=False))

--- a/python/runtimed/src/runtimed/__init__.py
+++ b/python/runtimed/src/runtimed/__init__.py
@@ -17,6 +17,7 @@ from runtimed.runtimed import (
     QueueState,
     RuntimedError,
     Session,
+    show_notebook_app,
 )
 
 __all__ = [
@@ -37,6 +38,8 @@ __all__ = [
     "CompletionResult",
     "QueueState",
     "HistoryEntry",
+    # Standalone functions
+    "show_notebook_app",
 ]
 
 try:


### PR DESCRIPTION
## Summary

Adds a new `show_notebook` MCP tool that launches the nteract desktop app to display the current notebook. The tool validates that the notebook is actively running via the daemon before launching.

For headless environments, the nteract MCP server accepts a `--no-show` flag that prevents the tool from being registered.

Closes #773

## Changes

Extracts cross-platform app launch logic into `runt-workspace` crate for reuse by both the CLI (`runt open`) and Python bindings (`runtimed.show_notebook_app`). In dev mode, prefers the local `target/debug/notebook` binary (if bundled with `cargo xtask build`), ensuring agents connect to the worktree daemon instead of the system daemon. Removes ~100 lines of duplicated platform-specific launch code in `runt` CLI.

## Verification

* [ ] Test `show_notebook` tool in MCP client: creates notebook, calls `show_notebook`, verifies app launches
* [ ] Test `--no-show` flag: run `nteract --no-show`, verify `show_notebook` tool not in tool list
* [ ] Test dev mode: build with `cargo xtask build`, verify local binary is used over installed app
* [ ] Test error handling: call `show_notebook` with non-running notebook, verify clear error

_PR submitted by @rgbkrk's agent, Quill_