### PR TITLE
refactor(notebook-sync): extract relay for zero-sync pipe connections

### DIFF
--- a/crates/notebook-sync/src/connect.rs
+++ b/crates/notebook-sync/src/connect.rs
@@ -628,6 +628,62 @@ pub async fn connect_create_relay(
     Ok(RelayCreateResult { handle, info })
 }
 
+/// Connect to a notebook room by ID as a relay — no local document.
+///
+/// Same as `connect_open_relay` but for connecting to an existing room
+/// by notebook ID rather than file path. Used by integration tests.
+pub async fn connect_relay(
+    socket_path: PathBuf,
+    notebook_id: String,
+    frame_tx: mpsc::UnboundedSender<Vec<u8>>,
+) -> Result<RelayConnectResult, SyncError> {
+    let stream = connect_stream!(&socket_path);
+    let (reader, writer) = tokio::io::split(stream);
+    let mut reader = tokio::io::BufReader::new(reader);
+    let mut writer = tokio::io::BufWriter::new(writer);
+
+    // Send preamble
+    connection::send_preamble(&mut writer).await?;
+
+    // Send notebook sync handshake
+    let handshake = Handshake::NotebookSync {
+        notebook_id: notebook_id.clone(),
+        protocol: Some(PROTOCOL_V2.to_string()),
+        initial_metadata: None,
+        working_dir: None,
+    };
+    connection::send_json_frame(&mut writer, &handshake)
+        .await
+        .map_err(|e| SyncError::Protocol(format!("Send handshake: {}", e)))?;
+
+    // Receive protocol capabilities (v2 handshake)
+    let caps_data = connection::recv_frame(&mut reader)
+        .await?
+        .ok_or_else(|| SyncError::Protocol("Connection closed during handshake".into()))?;
+    let _caps: ProtocolCapabilities = serde_json::from_slice(&caps_data)
+        .map_err(|e| SyncError::Protocol(format!("Parse capabilities: {}", e)))?;
+
+    // Receive initial metadata frame (may be empty)
+    let _initial_data = connection::recv_frame(&mut reader)
+        .await?
+        .ok_or_else(|| SyncError::Protocol("Connection closed during handshake".into()))?;
+
+    info!(
+        "[relay] Connected to {} (relay mode, no initial sync)",
+        notebook_id
+    );
+
+    let handle = spawn_relay(notebook_id, frame_tx, reader, writer);
+
+    Ok(RelayConnectResult { handle })
+}
+
+/// Result of connecting to a notebook room by ID as a relay.
+pub struct RelayConnectResult {
+    /// Handle for forwarding frames and sending requests.
+    pub handle: RelayHandle,
+}
+
 /// Spawn a relay task and return the handle.
 ///
 /// Common tail for `connect_open_relay` and `connect_create_relay`.

--- a/crates/notebook-sync/src/connect.rs
+++ b/crates/notebook-sync/src/connect.rs
@@ -25,6 +25,8 @@ use notebook_protocol::protocol::NotebookBroadcast;
 
 use crate::error::SyncError;
 use crate::handle::DocHandle;
+use crate::relay::RelayHandle;
+use crate::relay_task;
 use crate::shared::SharedDocState;
 use crate::snapshot::NotebookSnapshot;
 use crate::sync_task;
@@ -72,6 +74,24 @@ pub struct CreateResult {
 
     /// Initial cells in the document after sync.
     pub cells: Vec<notebook_doc::CellSnapshot>,
+}
+
+/// Result of opening a notebook as a relay (no local document).
+pub struct RelayOpenResult {
+    /// Handle for forwarding frames and sending requests.
+    pub handle: RelayHandle,
+
+    /// Connection info from the daemon (notebook_id, trust status, etc).
+    pub info: NotebookConnectionInfo,
+}
+
+/// Result of creating a notebook as a relay (no local document).
+pub struct RelayCreateResult {
+    /// Handle for forwarding frames and sending requests.
+    pub handle: RelayHandle,
+
+    /// Connection info from the daemon (notebook_id, trust status, etc).
+    pub info: NotebookConnectionInfo,
 }
 
 /// Platform-specific helper macro to connect to the daemon socket.
@@ -499,6 +519,143 @@ where
     });
 
     Ok((handle, broadcast_rx.into()))
+}
+
+// =========================================================================
+// Relay connect functions — no initial sync, no local doc
+// =========================================================================
+
+/// Open a notebook as a relay — transparent byte pipe, no local document.
+///
+/// Performs the handshake only (preamble + OpenNotebook + receive info).
+/// Does NOT call `do_initial_sync` — the daemon's initial sync message
+/// stays in the socket buffer and gets piped to the frontend by the relay
+/// task. The frontend (WASM) owns the sync protocol.
+///
+/// This eliminates the 100ms convergence floor and wasted doc allocation
+/// that the full-peer `connect_open` incurs.
+pub async fn connect_open_relay(
+    socket_path: PathBuf,
+    path: PathBuf,
+    frame_tx: mpsc::UnboundedSender<Vec<u8>>,
+) -> Result<RelayOpenResult, SyncError> {
+    let stream = connect_stream!(&socket_path);
+    let (reader, writer) = tokio::io::split(stream);
+    let mut reader = tokio::io::BufReader::new(reader);
+    let mut writer = tokio::io::BufWriter::new(writer);
+
+    // Send preamble
+    connection::send_preamble(&mut writer).await?;
+
+    // Send open handshake
+    let handshake = Handshake::OpenNotebook {
+        path: path.to_string_lossy().to_string(),
+    };
+    connection::send_json_frame(&mut writer, &handshake)
+        .await
+        .map_err(|e| SyncError::Protocol(format!("Send handshake: {}", e)))?;
+
+    // Receive connection info
+    let info_data = connection::recv_frame(&mut reader)
+        .await?
+        .ok_or_else(|| SyncError::Protocol("Connection closed during handshake".into()))?;
+    let info: NotebookConnectionInfo = serde_json::from_slice(&info_data)?;
+
+    if let Some(ref error) = info.error {
+        return Err(SyncError::Protocol(error.clone()));
+    }
+
+    let notebook_id = info.notebook_id.clone();
+    info!(
+        "[relay] Connected to {} (relay mode, no initial sync)",
+        notebook_id
+    );
+
+    let handle = spawn_relay(notebook_id, frame_tx, reader, writer);
+
+    Ok(RelayOpenResult { handle, info })
+}
+
+/// Create a notebook as a relay — transparent byte pipe, no local document.
+///
+/// Same as `connect_open_relay` but for new notebooks. Performs the
+/// CreateNotebook handshake, then immediately starts piping.
+pub async fn connect_create_relay(
+    socket_path: PathBuf,
+    runtime: &str,
+    working_dir: Option<PathBuf>,
+    notebook_id: Option<String>,
+    frame_tx: mpsc::UnboundedSender<Vec<u8>>,
+) -> Result<RelayCreateResult, SyncError> {
+    let stream = connect_stream!(&socket_path);
+    let (reader, writer) = tokio::io::split(stream);
+    let mut reader = tokio::io::BufReader::new(reader);
+    let mut writer = tokio::io::BufWriter::new(writer);
+
+    // Send preamble
+    connection::send_preamble(&mut writer).await?;
+
+    // Send create handshake
+    let handshake = Handshake::CreateNotebook {
+        runtime: runtime.to_string(),
+        working_dir: working_dir
+            .as_ref()
+            .map(|p| p.to_string_lossy().to_string()),
+        notebook_id,
+    };
+    connection::send_json_frame(&mut writer, &handshake)
+        .await
+        .map_err(|e| SyncError::Protocol(format!("Send handshake: {}", e)))?;
+
+    // Receive connection info
+    let info_data = connection::recv_frame(&mut reader)
+        .await?
+        .ok_or_else(|| SyncError::Protocol("Connection closed during handshake".into()))?;
+    let info: NotebookConnectionInfo = serde_json::from_slice(&info_data)?;
+
+    if let Some(ref error) = info.error {
+        return Err(SyncError::Protocol(error.clone()));
+    }
+
+    let notebook_id = info.notebook_id.clone();
+    info!(
+        "[relay] Created {} (relay mode, no initial sync)",
+        notebook_id
+    );
+
+    let handle = spawn_relay(notebook_id, frame_tx, reader, writer);
+
+    Ok(RelayCreateResult { handle, info })
+}
+
+/// Spawn a relay task and return the handle.
+///
+/// Common tail for `connect_open_relay` and `connect_create_relay`.
+fn spawn_relay<R, W>(
+    notebook_id: String,
+    frame_tx: mpsc::UnboundedSender<Vec<u8>>,
+    reader: R,
+    writer: W,
+) -> RelayHandle
+where
+    R: AsyncRead + Unpin + Send + 'static,
+    W: AsyncWrite + Unpin + Send + 'static,
+{
+    let (cmd_tx, cmd_rx) = mpsc::channel::<crate::relay::RelayCommand>(32);
+
+    let handle = RelayHandle::new(cmd_tx, notebook_id.clone());
+
+    let task_config = relay_task::RelayTaskConfig {
+        cmd_rx,
+        frame_tx,
+        notebook_id: notebook_id.clone(),
+    };
+
+    tokio::spawn(async move {
+        relay_task::run(task_config, reader, writer).await;
+    });
+
+    handle
 }
 
 /// Perform the initial Automerge sync exchange after handshake.

--- a/crates/notebook-sync/src/lib.rs
+++ b/crates/notebook-sync/src/lib.rs
@@ -51,6 +51,8 @@ pub mod broadcast;
 pub mod connect;
 pub mod error;
 pub mod handle;
+pub mod relay;
+pub mod relay_task;
 mod shared;
 mod snapshot;
 pub mod sync_task;
@@ -58,6 +60,7 @@ pub mod sync_task;
 pub use broadcast::BroadcastReceiver;
 pub use error::SyncError;
 pub use handle::DocHandle;
+pub use relay::RelayHandle;
 pub use shared::SharedDocState;
 pub use snapshot::NotebookSnapshot;
 

--- a/crates/notebook-sync/src/relay.rs
+++ b/crates/notebook-sync/src/relay.rs
@@ -40,8 +40,9 @@ pub enum RelayCommand {
 
     /// Forward a typed frame from the frontend to the daemon.
     ///
-    /// The relay does not decode or validate the frame — it writes the
-    /// type byte and payload directly to the daemon socket.
+    /// The relay validates the frame type byte but does not decode
+    /// the payload — it writes the type and payload directly to the
+    /// daemon socket.
     ForwardFrame {
         frame_type: u8,
         payload: Vec<u8>,

--- a/crates/notebook-sync/src/relay.rs
+++ b/crates/notebook-sync/src/relay.rs
@@ -1,0 +1,166 @@
+//! `RelayHandle` — transparent byte pipe between a frontend (WASM) and the daemon.
+//!
+//! Unlike [`DocHandle`](crate::DocHandle), the relay does not maintain a local
+//! Automerge document replica. It does not participate in the sync protocol —
+//! the frontend owns the sync state and the relay just forwards bytes.
+//!
+//! This eliminates the "dual sync" problem where both the relay and the WASM
+//! generate sync messages on the same daemon connection, and removes the 100ms
+//! convergence floor from `do_initial_sync` (which the relay never calls).
+//!
+//! ## API surface
+//!
+//! The relay handle exposes only what Tauri needs:
+//!
+//! - `send_request` — daemon protocol (launch kernel, save, etc.)
+//! - `notebook_id` — read the notebook identifier
+//! - `forward_frame` — pipe a typed frame from the frontend to the daemon
+//!
+//! No `with_doc`. No `get_cells`. No `snapshot`. No `subscribe`.
+
+use tokio::sync::{broadcast, mpsc, oneshot};
+
+use notebook_protocol::protocol::{NotebookBroadcast, NotebookRequest, NotebookResponse};
+
+use crate::error::SyncError;
+
+/// Commands for the relay task — only socket I/O operations.
+///
+/// This is intentionally minimal. The relay has no local document,
+/// so there are no mutation or sync confirmation commands.
+pub enum RelayCommand {
+    /// Send a request to the daemon and wait for a response.
+    SendRequest {
+        request: NotebookRequest,
+        reply: oneshot::Sender<Result<NotebookResponse, SyncError>>,
+        /// Optional broadcast sender for delivering broadcasts during long-running
+        /// requests (e.g., LaunchKernel with environment progress updates).
+        broadcast_tx: Option<broadcast::Sender<NotebookBroadcast>>,
+    },
+
+    /// Forward a typed frame from the frontend to the daemon.
+    ///
+    /// The relay does not decode or validate the frame — it writes the
+    /// type byte and payload directly to the daemon socket.
+    ForwardFrame {
+        frame_type: u8,
+        payload: Vec<u8>,
+        reply: oneshot::Sender<Result<(), SyncError>>,
+    },
+}
+
+/// A handle to a relay connection — forwards frames between a frontend
+/// (WASM) and the daemon without maintaining a local document replica.
+///
+/// Unlike `DocHandle`, this does not participate in the Automerge sync
+/// protocol. The frontend owns the sync state; the relay just pipes bytes.
+///
+/// `RelayHandle` is `Clone` — multiple callers can hold handles to the
+/// same relay connection.
+///
+/// # Example
+///
+/// ```ignore
+/// // Forward a WASM sync frame to the daemon
+/// handle.forward_frame(frame_types::AUTOMERGE_SYNC, payload).await?;
+///
+/// // Send a daemon protocol request
+/// let response = handle.send_request(NotebookRequest::SaveNotebook { ... }).await?;
+///
+/// // Read the notebook ID (synchronous)
+/// let id = handle.notebook_id();
+/// ```
+#[derive(Clone)]
+pub struct RelayHandle {
+    cmd_tx: mpsc::Sender<RelayCommand>,
+    notebook_id: String,
+}
+
+impl std::fmt::Debug for RelayHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RelayHandle")
+            .field("notebook_id", &self.notebook_id)
+            .finish()
+    }
+}
+
+impl RelayHandle {
+    /// Create a new `RelayHandle` from a command channel and notebook ID.
+    ///
+    /// Called by the relay connect functions, not by end users.
+    pub(crate) fn new(cmd_tx: mpsc::Sender<RelayCommand>, notebook_id: String) -> Self {
+        Self {
+            cmd_tx,
+            notebook_id,
+        }
+    }
+
+    /// Get the notebook ID this handle is connected to.
+    pub fn notebook_id(&self) -> &str {
+        &self.notebook_id
+    }
+
+    /// Send a request to the daemon and wait for a response.
+    ///
+    /// This is async because it involves socket I/O. The request is sent
+    /// to the daemon via the relay task, which handles the wire protocol.
+    pub async fn send_request(
+        &self,
+        request: NotebookRequest,
+    ) -> Result<NotebookResponse, SyncError> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.cmd_tx
+            .send(RelayCommand::SendRequest {
+                request,
+                reply: reply_tx,
+                broadcast_tx: None,
+            })
+            .await
+            .map_err(|_| SyncError::Disconnected)?;
+        reply_rx.await.map_err(|_| SyncError::Disconnected)?
+    }
+
+    /// Send a request with a broadcast channel for real-time progress updates.
+    ///
+    /// Used for long-running requests like `LaunchKernel` where the daemon
+    /// sends progress broadcasts (env creation, package installs) while
+    /// the request is in flight.
+    pub async fn send_request_with_broadcast(
+        &self,
+        request: NotebookRequest,
+        broadcast_tx: broadcast::Sender<NotebookBroadcast>,
+    ) -> Result<NotebookResponse, SyncError> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.cmd_tx
+            .send(RelayCommand::SendRequest {
+                request,
+                reply: reply_tx,
+                broadcast_tx: Some(broadcast_tx),
+            })
+            .await
+            .map_err(|_| SyncError::Disconnected)?;
+        reply_rx.await.map_err(|_| SyncError::Disconnected)?
+    }
+
+    /// Forward a typed frame from the frontend to the daemon.
+    ///
+    /// The relay writes the frame directly to the daemon socket without
+    /// decoding or processing it. Used for Automerge sync messages and
+    /// presence frames originating from the WASM frontend.
+    pub async fn forward_frame(
+        &self,
+        frame_type: u8,
+        payload: Vec<u8>,
+    ) -> Result<(), SyncError> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.cmd_tx
+            .send(RelayCommand::ForwardFrame {
+                frame_type,
+                payload,
+                reply: reply_tx,
+            })
+            .await
+            .map_err(|_| SyncError::Disconnected)?;
+        reply_rx.await.map_err(|_| SyncError::Disconnected)?
+    }
+}

--- a/crates/notebook-sync/src/relay.rs
+++ b/crates/notebook-sync/src/relay.rs
@@ -147,11 +147,7 @@ impl RelayHandle {
     /// The relay writes the frame directly to the daemon socket without
     /// decoding or processing it. Used for Automerge sync messages and
     /// presence frames originating from the WASM frontend.
-    pub async fn forward_frame(
-        &self,
-        frame_type: u8,
-        payload: Vec<u8>,
-    ) -> Result<(), SyncError> {
+    pub async fn forward_frame(&self, frame_type: u8, payload: Vec<u8>) -> Result<(), SyncError> {
         let (reply_tx, reply_rx) = oneshot::channel();
         self.cmd_tx
             .send(RelayCommand::ForwardFrame {

--- a/crates/notebook-sync/src/relay_task.rs
+++ b/crates/notebook-sync/src/relay_task.rs
@@ -64,6 +64,7 @@ where
         }
 
         let select_result = tokio::select! {
+            biased;
             cmd = config.cmd_rx.recv() => SelectResult::Command(cmd),
             frame = connection::recv_typed_frame(&mut reader) => SelectResult::Frame(frame),
         };
@@ -194,10 +195,13 @@ async fn send_request_impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
 
     match result {
         Ok(inner) => inner,
-        Err(_) => Err(SyncError::Protocol(format!(
-            "Request timed out after {}s: {:?}",
-            timeout_secs, request
-        ))),
+        Err(_) => {
+            warn!(
+                "[relay] Request timed out after {}s: {:?}",
+                timeout_secs, request
+            );
+            Err(SyncError::Timeout)
+        }
     }
 }
 

--- a/crates/notebook-sync/src/relay_task.rs
+++ b/crates/notebook-sync/src/relay_task.rs
@@ -1,0 +1,242 @@
+//! Relay task — transparent byte pipe between frontend (WASM) and daemon.
+//!
+//! Unlike the sync task, the relay does not maintain a local Automerge document.
+//! It does not participate in the sync protocol — the frontend owns the sync
+//! state and the relay just forwards bytes in both directions.
+//!
+//! ## Select loop
+//!
+//! Two arms:
+//! 1. **Commands** from `RelayHandle` — send requests, forward frames
+//! 2. **Incoming daemon frames** — pipe to frontend via `frame_tx`
+//!
+//! No `changed_rx` (no local doc to sync). No snapshot publishing.
+//! No `FrameForwarder` conditionals — the relay always pipes.
+
+use std::time::Duration;
+
+use log::{debug, info, warn};
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::sync::mpsc;
+
+use notebook_protocol::connection::{self, NotebookFrameType};
+use notebook_protocol::protocol::{NotebookBroadcast, NotebookResponse};
+
+use crate::error::SyncError;
+use crate::relay::RelayCommand;
+
+/// Configuration for the relay task.
+pub struct RelayTaskConfig {
+    /// Receives commands from `RelayHandle` (send_request, forward_frame).
+    pub cmd_rx: mpsc::Receiver<RelayCommand>,
+
+    /// Sends piped daemon frames to the frontend (e.g., Tauri webview).
+    /// NOT optional — the relay always pipes.
+    pub frame_tx: mpsc::UnboundedSender<Vec<u8>>,
+
+    /// The notebook identifier (for logging).
+    pub notebook_id: String,
+}
+
+/// Run the relay task.
+///
+/// This is spawned as a background tokio task. It runs until the socket
+/// closes or all handles are dropped (command channel closes).
+///
+/// The relay has no local document, no mutex, no snapshot publishing.
+/// It is a transparent byte pipe with request/response support.
+pub async fn run<R, W>(mut config: RelayTaskConfig, reader: R, writer: W)
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    let mut reader = tokio::io::BufReader::new(reader);
+    let mut writer = tokio::io::BufWriter::new(writer);
+
+    let notebook_id = &config.notebook_id;
+
+    info!("[relay] Started for {}", notebook_id);
+
+    loop {
+        enum SelectResult {
+            Command(Option<RelayCommand>),
+            Frame(std::io::Result<Option<connection::TypedNotebookFrame>>),
+        }
+
+        let select_result = tokio::select! {
+            cmd = config.cmd_rx.recv() => SelectResult::Command(cmd),
+            frame = connection::recv_typed_frame(&mut reader) => SelectResult::Frame(frame),
+        };
+
+        match select_result {
+            // ─── Command from handle ───────────────────────────────────
+            SelectResult::Command(None) => {
+                // All handles dropped — shut down
+                info!(
+                    "[relay] All handles dropped for {}, shutting down",
+                    notebook_id
+                );
+                break;
+            }
+
+            SelectResult::Command(Some(cmd)) => match cmd {
+                RelayCommand::SendRequest {
+                    request,
+                    reply,
+                    broadcast_tx,
+                } => {
+                    let result = send_request_impl(
+                        &mut reader,
+                        &mut writer,
+                        &config.frame_tx,
+                        broadcast_tx.as_ref(),
+                        &request,
+                        notebook_id,
+                    )
+                    .await;
+                    let _ = reply.send(result);
+                }
+
+                RelayCommand::ForwardFrame {
+                    frame_type,
+                    payload,
+                    reply,
+                } => {
+                    let ft = NotebookFrameType::try_from(frame_type);
+                    let result = match ft {
+                        Ok(ft) => connection::send_typed_frame(&mut writer, ft, &payload)
+                            .await
+                            .map_err(SyncError::Io),
+                        Err(_) => Err(SyncError::Protocol(format!(
+                            "Unknown frame type: 0x{:02x}",
+                            frame_type,
+                        ))),
+                    };
+                    let _ = reply.send(result);
+                }
+            },
+
+            // ─── Incoming frame from daemon → pipe to frontend ─────────
+            SelectResult::Frame(Ok(Some(frame))) => {
+                pipe_frame(&config.frame_tx, &frame);
+            }
+
+            SelectResult::Frame(Ok(None)) => {
+                info!("[relay] Daemon closed connection for {}", notebook_id);
+                break;
+            }
+
+            SelectResult::Frame(Err(e)) => {
+                warn!("[relay] Read error for {}: {}", notebook_id, e);
+                break;
+            }
+        }
+    }
+
+    info!("[relay] Stopped for {}", notebook_id);
+}
+
+/// Pipe a daemon frame to the frontend.
+///
+/// Only sync, broadcast, and presence frames are forwarded. Response and
+/// request frames are internal to the protocol and must not reach the frontend.
+fn pipe_frame(frame_tx: &mpsc::UnboundedSender<Vec<u8>>, frame: &connection::TypedNotebookFrame) {
+    match frame.frame_type {
+        NotebookFrameType::AutomergeSync
+        | NotebookFrameType::Broadcast
+        | NotebookFrameType::Presence => {
+            let mut bytes = vec![frame.frame_type as u8];
+            bytes.extend_from_slice(&frame.payload);
+            let _ = frame_tx.send(bytes);
+        }
+        _ => {
+            debug!(
+                "[relay] Not piping {:?} frame ({} bytes)",
+                frame.frame_type,
+                frame.payload.len()
+            );
+        }
+    }
+}
+
+/// Send a request to the daemon and wait for the response.
+///
+/// While waiting, non-response frames are piped to the frontend.
+/// This ensures the WASM frontend doesn't miss sync/broadcast/presence
+/// frames that arrive during a request/response cycle.
+async fn send_request_impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
+    reader: &mut R,
+    writer: &mut W,
+    frame_tx: &mpsc::UnboundedSender<Vec<u8>>,
+    req_broadcast_tx: Option<&tokio::sync::broadcast::Sender<NotebookBroadcast>>,
+    request: &notebook_protocol::protocol::NotebookRequest,
+    notebook_id: &str,
+) -> Result<NotebookResponse, SyncError> {
+    // Serialize and send the request
+    let payload =
+        serde_json::to_vec(request).map_err(|e| SyncError::Serialization(e.to_string()))?;
+    connection::send_typed_frame(writer, NotebookFrameType::Request, &payload)
+        .await
+        .map_err(SyncError::Io)?;
+
+    // Determine timeout based on request type
+    let timeout_secs = match request {
+        notebook_protocol::protocol::NotebookRequest::LaunchKernel { .. } => 300,
+        notebook_protocol::protocol::NotebookRequest::SyncEnvironment { .. } => 300,
+        _ => 30,
+    };
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(timeout_secs),
+        wait_for_response(reader, frame_tx, req_broadcast_tx, notebook_id),
+    )
+    .await;
+
+    match result {
+        Ok(inner) => inner,
+        Err(_) => Err(SyncError::Protocol(format!(
+            "Request timed out after {}s: {:?}",
+            timeout_secs, request
+        ))),
+    }
+}
+
+/// Wait for a Response frame, piping all other frames to the frontend.
+async fn wait_for_response<R: AsyncRead + Unpin>(
+    reader: &mut R,
+    frame_tx: &mpsc::UnboundedSender<Vec<u8>>,
+    req_broadcast_tx: Option<&tokio::sync::broadcast::Sender<NotebookBroadcast>>,
+    _notebook_id: &str,
+) -> Result<NotebookResponse, SyncError> {
+    loop {
+        let frame = connection::recv_typed_frame(reader)
+            .await
+            .map_err(SyncError::Io)?
+            .ok_or_else(|| SyncError::Protocol("Connection closed waiting for response".into()))?;
+
+        match frame.frame_type {
+            NotebookFrameType::Response => {
+                let response: NotebookResponse = serde_json::from_slice(&frame.payload)
+                    .map_err(|e| SyncError::Serialization(e.to_string()))?;
+                return Ok(response);
+            }
+
+            NotebookFrameType::Broadcast => {
+                // Deliver to request-specific broadcast channel if provided
+                // (for real-time progress during long requests like LaunchKernel)
+                if let Some(tx) = req_broadcast_tx {
+                    if let Ok(bc) = serde_json::from_slice::<NotebookBroadcast>(&frame.payload) {
+                        let _ = tx.send(bc);
+                    }
+                }
+                // Also pipe to frontend
+                pipe_frame(frame_tx, &frame);
+            }
+
+            _ => {
+                // Sync, presence, etc. — pipe to frontend
+                pipe_frame(frame_tx, &frame);
+            }
+        }
+    }
+}

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -21,7 +21,7 @@ pub mod webdriver;
 
 pub use runtime::Runtime;
 
-use notebook_sync::DocHandle;
+use notebook_sync::RelayHandle;
 use runtimed::protocol::{CompletionItem, HistoryEntry, NotebookRequest, NotebookResponse};
 
 use log::{debug, info, warn};
@@ -32,7 +32,7 @@ use std::ffi::OsStr;
 /// Shared notebook sync handle for cross-window state synchronization.
 /// The Option allows graceful fallback when daemon is unavailable.
 /// Uses the split handle pattern - the handle is clonable and doesn't block.
-type SharedNotebookSync = Arc<tokio::sync::Mutex<Option<DocHandle>>>;
+type SharedNotebookSync = Arc<tokio::sync::Mutex<Option<RelayHandle>>>;
 
 #[derive(Clone)]
 struct WindowNotebookContext {
@@ -244,7 +244,7 @@ where
 /// Read the notebook metadata from the daemon's canonical Automerge doc.
 /// Returns the deserialized NotebookMetadataSnapshot, or None if not available.
 async fn get_metadata_snapshot(
-    handle: &DocHandle,
+    handle: &RelayHandle,
 ) -> Option<runtimed::notebook_metadata::NotebookMetadataSnapshot> {
     match handle
         .send_request(NotebookRequest::GetMetadataSnapshot {})
@@ -259,7 +259,7 @@ async fn get_metadata_snapshot(
 
 /// Write a NotebookMetadataSnapshot to the daemon's canonical Automerge doc.
 async fn set_metadata_snapshot(
-    handle: &DocHandle,
+    handle: &RelayHandle,
     snapshot: &runtimed::notebook_metadata::NotebookMetadataSnapshot,
 ) -> Result<(), String> {
     let snapshot_json =
@@ -280,7 +280,7 @@ async fn set_metadata_snapshot(
 /// Read the metadata `additional` fields from the daemon's Automerge doc.
 /// Returns a HashMap with the `runt` field as a JSON value for trust verification.
 async fn get_raw_metadata_additional(
-    handle: &DocHandle,
+    handle: &RelayHandle,
 ) -> Option<HashMap<String, serde_json::Value>> {
     let snapshot = get_metadata_snapshot(handle).await?;
     let runt_value = serde_json::to_value(&snapshot.runt).ok()?;
@@ -291,7 +291,7 @@ async fn get_raw_metadata_additional(
 
 /// Write trust fields into the daemon's metadata.
 async fn set_raw_trust_in_metadata(
-    handle: &DocHandle,
+    handle: &RelayHandle,
     signature: &str,
     timestamp: &str,
 ) -> Result<(), String> {
@@ -473,7 +473,7 @@ async fn initialize_notebook_sync_open(
 
     let (frame_tx, raw_frame_rx) = tokio::sync::mpsc::unbounded_channel::<Vec<u8>>();
 
-    let result = notebook_sync::connect::connect_open_with_pipe(socket_path, path, frame_tx)
+    let result = notebook_sync::connect::connect_open_relay(socket_path, path, frame_tx)
         .await
         .map_err(|e| format!("sync connect (open): {}", e))?;
 
@@ -535,7 +535,7 @@ async fn initialize_notebook_sync_create(
 
     let (frame_tx, raw_frame_rx) = tokio::sync::mpsc::unbounded_channel::<Vec<u8>>();
 
-    let result = notebook_sync::connect::connect_create_with_pipe(
+    let result = notebook_sync::connect::connect_create_relay(
         socket_path,
         &runtime,
         working_dir,
@@ -591,7 +591,7 @@ async fn initialize_notebook_sync_create(
 async fn setup_sync_receivers(
     window: tauri::WebviewWindow,
     notebook_id: String,
-    handle: DocHandle,
+    handle: RelayHandle,
     mut raw_frame_rx: tokio::sync::mpsc::UnboundedReceiver<Vec<u8>>,
     notebook_sync: SharedNotebookSync,
     sync_generation: Arc<AtomicU64>,
@@ -2469,14 +2469,10 @@ async fn send_frame(
     let payload = &frame_data[1..];
 
     match frame_type {
-        frame_types::AUTOMERGE_SYNC => handle
-            .receive_frontend_sync_message(payload.to_vec())
+        frame_types::AUTOMERGE_SYNC | frame_types::PRESENCE => handle
+            .forward_frame(frame_type, payload.to_vec())
             .await
-            .map_err(|e| format!("send_frame(sync): {}", e)),
-        frame_types::PRESENCE => handle
-            .send_presence(payload.to_vec())
-            .await
-            .map_err(|e| format!("send_frame(presence): {}", e)),
+            .map_err(|e| format!("send_frame(0x{:02x}): {}", frame_type, e)),
         _ => Err(format!(
             "Unsupported outgoing frame type: 0x{:02x}",
             frame_type

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -1043,16 +1043,11 @@ async fn test_pipe_mode_forwards_sync_frames() {
     // Create a pipe channel
     let (frame_tx, mut frame_rx) = mpsc::unbounded_channel::<Vec<u8>>();
 
-    // Connect pipe client
-    let _result = connect::connect_with_pipe(
-        socket_path.clone(),
-        "pipe-sync-test".to_string(),
-        None,
-        None,
-        frame_tx,
-    )
-    .await
-    .unwrap();
+    // Connect pipe client (relay mode — no local doc, no initial sync)
+    let _result =
+        connect::connect_relay(socket_path.clone(), "pipe-sync-test".to_string(), frame_tx)
+            .await
+            .unwrap();
 
     // Second client (full peer) adds a cell and updates source
     let client2 = connect::connect(socket_path.clone(), "pipe-sync-test".to_string())
@@ -1109,11 +1104,9 @@ async fn test_pipe_mode_only_pipes_allowed_frame_types() {
 
     let (frame_tx, mut frame_rx) = mpsc::unbounded_channel::<Vec<u8>>();
 
-    let _result = connect::connect_with_pipe(
+    let _result = connect::connect_relay(
         socket_path.clone(),
         "pipe-broadcast-test".to_string(),
-        None,
-        None,
         frame_tx,
     )
     .await
@@ -1183,11 +1176,9 @@ async fn test_pipe_mode_does_not_forward_response_frames() {
 
     let (frame_tx, mut frame_rx) = mpsc::unbounded_channel::<Vec<u8>>();
 
-    let result = connect::connect_with_pipe(
+    let result = connect::connect_relay(
         socket_path.clone(),
         "pipe-response-test".to_string(),
-        None,
-        None,
         frame_tx,
     )
     .await
@@ -1257,15 +1248,10 @@ async fn test_pipe_mode_preserves_frame_order() {
 
     let (frame_tx, mut frame_rx) = mpsc::unbounded_channel::<Vec<u8>>();
 
-    let _result = connect::connect_with_pipe(
-        socket_path.clone(),
-        "pipe-order-test".to_string(),
-        None,
-        None,
-        frame_tx,
-    )
-    .await
-    .unwrap();
+    let _result =
+        connect::connect_relay(socket_path.clone(), "pipe-order-test".to_string(), frame_tx)
+            .await
+            .unwrap();
 
     // Second client rapidly adds multiple cells
     let client2 = connect::connect(socket_path.clone(), "pipe-order-test".to_string())


### PR DESCRIPTION
Extract a relay module from `notebook-sync` that provides a transparent byte pipe between the frontend (WASM) and daemon — no local Automerge document, no sync protocol participation, no wasted time-to-first-cell.

**The problem:** The Tauri path previously used `DocHandle` (full-peer) with pipe forwarding bolted on:
- `do_initial_sync` runs for 100ms+ to populate a doc nobody reads
- The WASM then syncs *again* via piped frames (double sync)
- The relay generates redundant sync acks (dual-sync confusion)

**The fix:** `RelayHandle` skips `do_initial_sync` entirely. The daemon's initial sync message stays in the socket buffer until the relay task pipes it to WASM. One sync, not two.

**Phase 1:** Additive relay module (no existing code modified).
- `relay.rs` — `RelayHandle` (`send_request`, `notebook_id`, `forward_frame`)
- `relay_task.rs` — pipe-only select loop (no doc, no mutex, no snapshots)
- `connect.rs` — `connect_open_relay` / `connect_create_relay` / `connect_relay` (handshake only)

**Phase 2:** Migrate Tauri + pipe tests to `RelayHandle`.
- `SharedNotebookSync`: `DocHandle` → `RelayHandle`
- `connect_open_with_pipe` → `connect_open_relay` (zero initial sync)
- `send_frame`: unified into `handle.forward_frame(type, payload)`
- Pipe integration tests: `connect_with_pipe` → `connect_relay`
- All 22 integration tests pass

**Phase 3 (follow-up):** Remove `FrameForwarder` and pipe logic from sync task.

_PR submitted by @rgbkrk's agent Quill, via Zed_