### PR TITLE
refactor(notebook-sync): remove pipe/forwarder code from sync task

### DIFF
--- a/crates/notebook-sync/src/connect.rs
+++ b/crates/notebook-sync/src/connect.rs
@@ -138,35 +138,7 @@ pub async fn connect_with_options(
     working_dir: Option<PathBuf>,
     initial_metadata: Option<String>,
 ) -> Result<ConnectResult, SyncError> {
-    connect_with_options_impl(
-        socket_path,
-        notebook_id,
-        working_dir,
-        initial_metadata,
-        None,
-    )
-    .await
-}
-
-/// Connect to a notebook room by ID with pipe frame forwarding.
-///
-/// Same as `connect_with_options` but forwards raw daemon frames to the
-/// given channel before processing them locally.
-pub async fn connect_with_pipe(
-    socket_path: PathBuf,
-    notebook_id: String,
-    initial_metadata: Option<String>,
-    working_dir: Option<PathBuf>,
-    pipe_frame_tx: mpsc::UnboundedSender<Vec<u8>>,
-) -> Result<ConnectResult, SyncError> {
-    connect_with_options_impl(
-        socket_path,
-        notebook_id,
-        working_dir,
-        initial_metadata,
-        Some(pipe_frame_tx),
-    )
-    .await
+    connect_with_options_impl(socket_path, notebook_id, working_dir, initial_metadata).await
 }
 
 async fn connect_with_options_impl(
@@ -174,7 +146,6 @@ async fn connect_with_options_impl(
     notebook_id: String,
     working_dir: Option<PathBuf>,
     initial_metadata: Option<String>,
-    pipe_frame_tx: Option<mpsc::UnboundedSender<Vec<u8>>>,
 ) -> Result<ConnectResult, SyncError> {
     let stream = connect_stream!(&socket_path);
     let (reader, writer) = tokio::io::split(stream);
@@ -234,7 +205,6 @@ async fn connect_with_options_impl(
         pending_broadcasts,
         reader,
         writer,
-        pipe_frame_tx,
     )
     .map(|(handle, broadcast_rx)| ConnectResult {
         handle,
@@ -246,27 +216,10 @@ async fn connect_with_options_impl(
 
 /// Connect and open an existing notebook file.
 pub async fn connect_open(socket_path: PathBuf, path: PathBuf) -> Result<OpenResult, SyncError> {
-    connect_open_impl(socket_path, path, None).await
+    connect_open_impl(socket_path, path).await
 }
 
-/// Open a notebook with pipe frame forwarding for Tauri relay mode.
-///
-/// Same as `connect_open` but forwards raw daemon frames to the given
-/// channel before processing them locally. Used by the Tauri webview
-/// to relay frames to the WASM frontend.
-pub async fn connect_open_with_pipe(
-    socket_path: PathBuf,
-    path: PathBuf,
-    pipe_frame_tx: mpsc::UnboundedSender<Vec<u8>>,
-) -> Result<OpenResult, SyncError> {
-    connect_open_impl(socket_path, path, Some(pipe_frame_tx)).await
-}
-
-async fn connect_open_impl(
-    socket_path: PathBuf,
-    path: PathBuf,
-    pipe_frame_tx: Option<mpsc::UnboundedSender<Vec<u8>>>,
-) -> Result<OpenResult, SyncError> {
+async fn connect_open_impl(socket_path: PathBuf, path: PathBuf) -> Result<OpenResult, SyncError> {
     let stream = connect_stream!(&socket_path);
     let (reader, writer) = tokio::io::split(stream);
     let mut reader = tokio::io::BufReader::new(reader);
@@ -324,7 +277,6 @@ async fn connect_open_impl(
         pending_broadcasts,
         reader,
         writer,
-        pipe_frame_tx,
     )
     .map(|(handle, broadcast_rx)| OpenResult {
         handle,
@@ -343,29 +295,7 @@ pub async fn connect_create(
     runtime: &str,
     working_dir: Option<PathBuf>,
 ) -> Result<CreateResult, SyncError> {
-    connect_create_impl(socket_path, runtime, working_dir, None, None).await
-}
-
-/// Create a notebook with pipe frame forwarding for Tauri relay mode.
-///
-/// Same as `connect_create` but forwards raw daemon frames to the given
-/// channel before processing them locally. Used by the Tauri webview
-/// to relay frames to the WASM frontend.
-pub async fn connect_create_with_pipe(
-    socket_path: PathBuf,
-    runtime: &str,
-    working_dir: Option<PathBuf>,
-    notebook_id: Option<String>,
-    pipe_frame_tx: mpsc::UnboundedSender<Vec<u8>>,
-) -> Result<CreateResult, SyncError> {
-    connect_create_impl(
-        socket_path,
-        runtime,
-        working_dir,
-        notebook_id,
-        Some(pipe_frame_tx),
-    )
-    .await
+    connect_create_impl(socket_path, runtime, working_dir, None).await
 }
 
 async fn connect_create_impl(
@@ -373,7 +303,6 @@ async fn connect_create_impl(
     runtime: &str,
     working_dir: Option<PathBuf>,
     notebook_id: Option<String>,
-    pipe_frame_tx: Option<mpsc::UnboundedSender<Vec<u8>>>,
 ) -> Result<CreateResult, SyncError> {
     let stream = connect_stream!(&socket_path);
     let (reader, writer) = tokio::io::split(stream);
@@ -436,7 +365,6 @@ async fn connect_create_impl(
         pending_broadcasts,
         reader,
         writer,
-        pipe_frame_tx,
     )
     .map(|(handle, broadcast_rx)| CreateResult {
         handle,
@@ -461,7 +389,6 @@ fn build_and_spawn<R, W>(
     pending_broadcasts: Vec<NotebookBroadcast>,
     reader: R,
     writer: W,
-    pipe_frame_tx: Option<mpsc::UnboundedSender<Vec<u8>>>,
 ) -> Result<(DocHandle, crate::BroadcastReceiver), SyncError>
 where
     R: AsyncRead + Unpin + Send + 'static,
@@ -502,7 +429,6 @@ where
         cmd_rx,
         snapshot_tx: Arc::clone(&snapshot_tx),
         broadcast_tx,
-        pipe_forwarder: sync_task::FrameForwarder::new(pipe_frame_tx),
     };
 
     let notebook_id_for_task = notebook_id;

--- a/crates/notebook-sync/src/handle.rs
+++ b/crates/notebook-sync/src/handle.rs
@@ -480,23 +480,6 @@ impl DocHandle {
         reply_rx.await.map_err(|_| SyncError::Disconnected)?
     }
 
-    /// Forward a raw Automerge sync message from the frontend (WASM) to the daemon.
-    ///
-    /// In pipe mode, the WASM frontend generates sync messages that need to be
-    /// applied to the local doc and forwarded to the daemon. This method sends
-    /// the raw bytes through the sync task which handles decode, apply, and relay.
-    pub async fn receive_frontend_sync_message(&self, message: Vec<u8>) -> Result<(), SyncError> {
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.cmd_tx
-            .send(SyncCommand::ReceiveFrontendSyncMessage {
-                message,
-                reply: reply_tx,
-            })
-            .await
-            .map_err(|_| SyncError::Disconnected)?;
-        reply_rx.await.map_err(|_| SyncError::Disconnected)?
-    }
-
     // =====================================================================
     // Read-only access — no lock needed
     // =====================================================================

--- a/crates/notebook-sync/src/sync_task.rs
+++ b/crates/notebook-sync/src/sync_task.rs
@@ -60,44 +60,6 @@ pub enum SyncCommand {
         data: Vec<u8>,
         reply: oneshot::Sender<Result<(), SyncError>>,
     },
-
-    /// Apply a raw Automerge sync message from the frontend (WASM/pipe mode)
-    /// and forward to the daemon.
-    ReceiveFrontendSyncMessage {
-        message: Vec<u8>,
-        reply: oneshot::Sender<Result<(), SyncError>>,
-    },
-}
-
-/// Optionally forwards selected frame types to a pipe consumer (e.g. Tauri webview).
-///
-/// Sync, broadcast, and presence frames are forwarded. Request/response frames
-/// are internal to the protocol and are never piped.
-pub struct FrameForwarder {
-    tx: Option<mpsc::UnboundedSender<Vec<u8>>>,
-}
-
-impl FrameForwarder {
-    /// Create a new forwarder. Pass `None` to disable forwarding.
-    pub fn new(tx: Option<mpsc::UnboundedSender<Vec<u8>>>) -> Self {
-        Self { tx }
-    }
-
-    /// Forward sync, broadcast, and presence frames. Skips request/response.
-    pub fn forward(&self, frame: &connection::TypedNotebookFrame) {
-        if let Some(ref tx) = self.tx {
-            match frame.frame_type {
-                NotebookFrameType::AutomergeSync
-                | NotebookFrameType::Broadcast
-                | NotebookFrameType::Presence => {
-                    let mut bytes = vec![frame.frame_type as u8];
-                    bytes.extend_from_slice(&frame.payload);
-                    let _ = tx.send(bytes);
-                }
-                _ => {}
-            }
-        }
-    }
 }
 
 /// Configuration for the sync task.
@@ -116,10 +78,6 @@ pub struct SyncTaskConfig {
 
     /// Broadcast sender for kernel/execution events from the daemon.
     pub broadcast_tx: broadcast::Sender<NotebookBroadcast>,
-
-    /// Forwards selected daemon frames to a pipe consumer (e.g. Tauri relay
-    /// to WASM frontend).
-    pub pipe_forwarder: FrameForwarder,
 }
 
 /// Run the sync task.
@@ -224,7 +182,6 @@ where
                             &config.snapshot_tx,
                             &config.broadcast_tx,
                             &notebook_id,
-                            &config.pipe_forwarder,
                         )
                         .await;
                     }
@@ -268,7 +225,6 @@ where
                             req_broadcast_tx.as_ref(),
                             &request,
                             &notebook_id,
-                            &config.pipe_forwarder,
                         )
                         .await;
                         let _ = reply.send(result);
@@ -282,7 +238,6 @@ where
                             &config.snapshot_tx,
                             &config.broadcast_tx,
                             &notebook_id,
-                            &config.pipe_forwarder,
                         )
                         .await;
                         let _ = reply.send(result);
@@ -298,36 +253,6 @@ where
                         .map_err(SyncError::Io);
                         let _ = reply.send(result);
                     }
-
-                    SyncCommand::ReceiveFrontendSyncMessage { message, reply } => {
-                        // Decode and apply the frontend's sync message to our doc.
-                        // Reject invalid bytes early — never forward garbage to the daemon.
-                        let msg = match sync::Message::decode(&message) {
-                            Ok(msg) => msg,
-                            Err(e) => {
-                                let _ = reply
-                                    .send(Err(SyncError::Protocol(format!("decode sync: {}", e))));
-                                continue;
-                            }
-                        };
-
-                        {
-                            let mut state = config.doc.lock().unwrap_or_else(|e| e.into_inner());
-                            let _ = state.receive_sync_message(msg);
-                        }
-
-                        // Forward valid message to daemon
-                        let result = connection::send_typed_frame(
-                            &mut writer,
-                            NotebookFrameType::AutomergeSync,
-                            &message,
-                        )
-                        .await
-                        .map_err(SyncError::Io);
-
-                        publish_snapshot(&config.doc, &config.snapshot_tx);
-                        let _ = reply.send(result);
-                    }
                 }
             }
 
@@ -341,7 +266,6 @@ where
                         &config.snapshot_tx,
                         &config.broadcast_tx,
                         &notebook_id,
-                        &config.pipe_forwarder,
                     )
                     .await;
                 }
@@ -381,13 +305,7 @@ async fn handle_incoming_frame<W: AsyncWrite + Unpin>(
     snapshot_tx: &Arc<tokio::sync::watch::Sender<NotebookSnapshot>>,
     broadcast_tx: &broadcast::Sender<NotebookBroadcast>,
     notebook_id: &str,
-    pipe_forwarder: &FrameForwarder,
 ) {
-    // Forward sync/broadcast/presence frames to pipe consumer before local
-    // processing. Response and Request frames are internal to the protocol
-    // and must not be piped to the WASM frontend.
-    pipe_forwarder.forward(frame);
-
     match frame.frame_type {
         NotebookFrameType::AutomergeSync => {
             let msg = match sync::Message::decode(&frame.payload) {
@@ -485,7 +403,6 @@ async fn send_request_impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
     req_broadcast_tx: Option<&broadcast::Sender<NotebookBroadcast>>,
     request: &NotebookRequest,
     notebook_id: &str,
-    pipe_forwarder: &FrameForwarder,
 ) -> Result<NotebookResponse, SyncError> {
     // Serialize and send the request
     let payload =
@@ -512,7 +429,6 @@ async fn send_request_impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
             broadcast_tx,
             req_broadcast_tx,
             notebook_id,
-            pipe_forwarder,
         ),
     )
     .await;
@@ -525,7 +441,6 @@ async fn send_request_impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
 }
 
 /// Wait for a Response frame from the daemon, processing other frames.
-#[allow(clippy::too_many_arguments)]
 async fn wait_for_response<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
     doc: &Arc<Mutex<SharedDocState>>,
     reader: &mut R,
@@ -534,19 +449,12 @@ async fn wait_for_response<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
     broadcast_tx: &broadcast::Sender<NotebookBroadcast>,
     req_broadcast_tx: Option<&broadcast::Sender<NotebookBroadcast>>,
     notebook_id: &str,
-    pipe_forwarder: &FrameForwarder,
 ) -> Result<NotebookResponse, SyncError> {
     loop {
         let frame = connection::recv_typed_frame(reader)
             .await
             .map_err(SyncError::Io)?
             .ok_or_else(|| SyncError::Protocol("Connection closed waiting for response".into()))?;
-
-        // Forward sync/broadcast/presence frames to pipe consumer while
-        // waiting for a response. Without this, daemon frames received
-        // during a request/response cycle would be consumed locally but
-        // never reach the WASM frontend, causing it to desync.
-        pipe_forwarder.forward(&frame);
 
         match frame.frame_type {
             NotebookFrameType::Response => {
@@ -611,7 +519,6 @@ async fn confirm_sync_impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
     snapshot_tx: &Arc<tokio::sync::watch::Sender<NotebookSnapshot>>,
     broadcast_tx: &broadcast::Sender<NotebookBroadcast>,
     notebook_id: &str,
-    pipe_forwarder: &FrameForwarder,
 ) -> Result<(), SyncError> {
     for round in 0..5 {
         // Generate and send sync message
@@ -647,16 +554,8 @@ async fn confirm_sync_impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
         .await
         {
             Ok(Ok(Some(frame))) => {
-                handle_incoming_frame(
-                    &frame,
-                    doc,
-                    writer,
-                    snapshot_tx,
-                    broadcast_tx,
-                    notebook_id,
-                    pipe_forwarder,
-                )
-                .await;
+                handle_incoming_frame(&frame, doc, writer, snapshot_tx, broadcast_tx, notebook_id)
+                    .await;
             }
             Ok(Ok(None)) => {
                 return Err(SyncError::Protocol(

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -2447,8 +2447,8 @@ async fn get_automerge_doc_bytes(
 ///
 /// The first byte is the frame type, the rest is the payload.
 /// Supported outgoing types:
-/// - 0x00: AutomergeSync (forwarded via receive_frontend_sync_message)
-/// - 0x04: Presence (forwarded via send_presence)
+/// - 0x00: AutomergeSync (forwarded via RelayHandle::forward_frame)
+/// - 0x04: Presence (forwarded via RelayHandle::forward_frame)
 #[tauri::command]
 async fn send_frame(
     window: tauri::Window,


### PR DESCRIPTION
Phase 3 of the relay extraction: remove all pipe/forwarder code from the sync task now that `RelayHandle` owns piping.

**−200 lines, pure deletion.**

- `FrameForwarder` struct — gone
- `pipe_forwarder` field on `SyncTaskConfig` — gone
- `pipe_forwarder` parameter threaded through 4 functions — gone
- `ReceiveFrontendSyncMessage` command variant — gone
- `receive_frontend_sync_message` on `DocHandle` — gone
- `connect_with_pipe`, `connect_open_with_pipe`, `connect_create_with_pipe` — gone
- `pipe_frame_tx` parameter on all `_impl` functions and `build_and_spawn` — gone

The sync task is now a clean full-peer implementation. The relay task is a clean pipe. No conditional logic between them.

_PR submitted by @rgbkrk's agent Quill, via Zed_