### PR TITLE
fix(notebook): scroll focused cells into view

### DIFF
--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -366,6 +366,16 @@ function NotebookViewContent({
     }
   }, [searchCurrentMatch]);
 
+  useEffect(() => {
+    if (!focusedCellId) return;
+    const cellEl = containerRef.current?.querySelector(
+      `[data-cell-id="${CSS.escape(focusedCellId)}"]`,
+    );
+    if (cellEl) {
+      cellEl.scrollIntoView({ block: "nearest", behavior: "smooth" });
+    }
+  }, [focusedCellId]);
+
   const renderCell = useCallback(
     (
       cell: NotebookCell,

--- a/apps/notebook/src/hooks/useEditorRegistry.tsx
+++ b/apps/notebook/src/hooks/useEditorRegistry.tsx
@@ -50,9 +50,6 @@ export function EditorRegistryProvider({ children }: { children: ReactNode }) {
         scrollIntoView: true,
       });
       view.focus();
-
-      // Scroll cell into view
-      cellElement.scrollIntoView({ behavior: "smooth", block: "nearest" });
     },
     [],
   );


### PR DESCRIPTION
## Summary
- scroll the focused cell into view when focusedCellId changes in NotebookView
- keep editor-specific focus handling in useEditorRegistry
- remove the redundant scroll after CodeMirror focus

## Testing
- cargo xtask lint --fix
- manually verified adding a new cell at the bottom scrolls it into view

Closes #770
