### PR TITLE
feat(menu): add clear outputs actions to Cell menu

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -742,6 +742,38 @@ function AppContent() {
     };
   }, [handleAddCell, focusedCellId]);
 
+  // Cell menu: Clear Outputs (focused cell)
+  useEffect(() => {
+    const webview = getCurrentWebview();
+    const unlistenPromise = webview.listen("menu:clear-outputs", () => {
+      if (focusedCellId) {
+        clearCellOutputs(focusedCellId);
+        clearOutputs(focusedCellId);
+      }
+    });
+    return () => {
+      unlistenPromise.then((unlisten) => unlisten()).catch(() => {});
+    };
+  }, [focusedCellId, clearCellOutputs, clearOutputs]);
+
+  // Cell menu: Clear All Outputs
+  useEffect(() => {
+    const webview = getCurrentWebview();
+    const unlistenPromise = webview.listen(
+      "menu:clear-all-outputs",
+      async () => {
+        const codeCells = cells.filter((c) => c.cell_type === "code");
+        for (const cell of codeCells) {
+          clearCellOutputs(cell.id);
+        }
+        await Promise.all(codeCells.map((cell) => clearOutputs(cell.id)));
+      },
+    );
+    return () => {
+      unlistenPromise.then((unlisten) => unlisten()).catch(() => {});
+    };
+  }, [cells, clearCellOutputs, clearOutputs]);
+
   // Kernel menu: Run All Cells
   useEffect(() => {
     const webview = getCurrentWebview();

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -745,16 +745,17 @@ function AppContent() {
   // Cell menu: Clear Outputs (focused cell)
   useEffect(() => {
     const webview = getCurrentWebview();
-    const unlistenPromise = webview.listen("menu:clear-outputs", () => {
-      if (focusedCellId) {
-        clearCellOutputs(focusedCellId);
-        clearOutputs(focusedCellId);
-      }
+    const unlistenPromise = webview.listen("menu:clear-outputs", async () => {
+      if (!focusedCellId) return;
+      const cell = cells.find((c) => c.id === focusedCellId);
+      if (!cell || cell.cell_type !== "code") return;
+      clearCellOutputs(focusedCellId);
+      await clearOutputs(focusedCellId);
     });
     return () => {
       unlistenPromise.then((unlisten) => unlisten()).catch(() => {});
     };
-  }, [focusedCellId, clearCellOutputs, clearOutputs]);
+  }, [focusedCellId, cells, clearCellOutputs, clearOutputs]);
 
   // Cell menu: Clear All Outputs
   useEffect(() => {

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -4041,6 +4041,22 @@ pub fn run(
                             emit_to_label::<_, _, _>(&window, window.label(), "menu:insert-cell", "raw");
                     }
                 }
+                crate::menu::MENU_CLEAR_OUTPUTS => {
+                    if let Some(window) = focused_window(app) {
+                        let _ =
+                            emit_to_label::<_, _, _>(&window, window.label(), "menu:clear-outputs", ());
+                    }
+                }
+                crate::menu::MENU_CLEAR_ALL_OUTPUTS => {
+                    if let Some(window) = focused_window(app) {
+                        let _ = emit_to_label::<_, _, _>(
+                            &window,
+                            window.label(),
+                            "menu:clear-all-outputs",
+                            (),
+                        );
+                    }
+                }
                 crate::menu::MENU_CHECK_FOR_UPDATES => {
                     if let Some(window) = focused_window(app) {
                         let _ = emit_to_label::<_, _, _>(

--- a/crates/notebook/src/menu.rs
+++ b/crates/notebook/src/menu.rs
@@ -34,6 +34,8 @@ pub const MENU_RESTART_AND_RUN_ALL: &str = "restart_and_run_all";
 pub const MENU_INSERT_CODE_CELL: &str = "insert_code_cell";
 pub const MENU_INSERT_MARKDOWN_CELL: &str = "insert_markdown_cell";
 pub const MENU_INSERT_RAW_CELL: &str = "insert_raw_cell";
+pub const MENU_CLEAR_OUTPUTS: &str = "clear_outputs";
+pub const MENU_CLEAR_ALL_OUTPUTS: &str = "clear_all_outputs";
 
 // Menu item IDs for CLI installation and settings
 pub const MENU_INSTALL_CLI: &str = "install_cli";
@@ -257,6 +259,21 @@ pub fn create_menu(
         "Insert Raw Cell",
         true,
         Some("CmdOrCtrl+Shift+R"),
+    )?)?;
+    cell_menu.append(&PredefinedMenuItem::separator(app)?)?;
+    cell_menu.append(&MenuItem::with_id(
+        app,
+        MENU_CLEAR_OUTPUTS,
+        "Clear Outputs",
+        true,
+        None::<&str>,
+    )?)?;
+    cell_menu.append(&MenuItem::with_id(
+        app,
+        MENU_CLEAR_ALL_OUTPUTS,
+        "Clear All Outputs",
+        true,
+        None::<&str>,
     )?)?;
     menu.append(&cell_menu)?;
 


### PR DESCRIPTION
## Summary
Add "Clear Outputs" and "Clear All Outputs" actions to the Cell menu.

- **Clear Outputs**: clears outputs of the focused cell
- **Clear All Outputs**: clears outputs of all code cells

Both actions reuse existing `clearOutputs` (daemon sync) and `clearCellOutputs` (local WASM) functions for consistency with existing execution workflows.

## Verification
* [ ] Focus a cell with outputs and use Cell > Clear Outputs to clear only that cell's outputs
* [ ] Use Cell > Clear All Outputs to clear all code cell outputs in the notebook

---
_PR submitted by @rgbkrk's agent, Quill_