### PR TITLE
feat(presence): add periodic stale peer pruning

### DIFF
--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -1091,6 +1091,10 @@ where
     let mut kernel_broadcast_rx = room.kernel_broadcast_tx.subscribe();
     let mut presence_rx = room.presence_tx.subscribe();
 
+    // Periodic pruning of stale presence peers (e.g. clients that silently dropped).
+    let mut prune_interval = tokio::time::interval(std::time::Duration::from_secs(15));
+    prune_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
     // Phase 1: Initial sync — server sends first (typed frame)
     // Encode the sync message inside the lock, then send outside it
     // to avoid holding the write lock across async I/O.
@@ -1422,6 +1426,19 @@ where
                         // Broadcast channel closed — room is being evicted
                         return Ok(());
                     }
+                }
+            }
+
+            // Prune stale presence peers that haven't heartbeated within the TTL
+            _ = prune_interval.tick() => {
+                let now_ms = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_millis() as u64;
+                let pruned = room.presence.write().await.prune_stale(now_ms, presence::DEFAULT_PEER_TTL_MS);
+                for pruned_peer_id in pruned {
+                    let left_bytes = presence::encode_left(&pruned_peer_id);
+                    let _ = room.presence_tx.send((pruned_peer_id, left_bytes));
                 }
             }
         }

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -1092,7 +1092,8 @@ where
     let mut presence_rx = room.presence_tx.subscribe();
 
     // Periodic pruning of stale presence peers (e.g. clients that silently dropped).
-    let mut prune_interval = tokio::time::interval(std::time::Duration::from_secs(15));
+    let prune_period = std::time::Duration::from_millis(presence::DEFAULT_HEARTBEAT_MS);
+    let mut prune_interval = tokio::time::interval(prune_period);
     prune_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
     // Phase 1: Initial sync — server sends first (typed frame)
@@ -1429,13 +1430,19 @@ where
                 }
             }
 
-            // Prune stale presence peers that haven't heartbeated within the TTL
+            // Prune stale presence peers that haven't heartbeated within the TTL.
+            // Each connection's loop is proof-of-life for its own peer, so we
+            // mark ourselves seen before pruning to avoid false self-eviction
+            // (idle-but-connected peers don't send frames).
             _ = prune_interval.tick() => {
                 let now_ms = std::time::SystemTime::now()
                     .duration_since(std::time::UNIX_EPOCH)
                     .unwrap_or_default()
                     .as_millis() as u64;
-                let pruned = room.presence.write().await.prune_stale(now_ms, presence::DEFAULT_PEER_TTL_MS);
+                let mut presence_state = room.presence.write().await;
+                presence_state.mark_seen(peer_id, now_ms);
+                let pruned = presence_state.prune_stale(now_ms, presence::DEFAULT_PEER_TTL_MS);
+                drop(presence_state);
                 for pruned_peer_id in pruned {
                     let left_bytes = presence::encode_left(&pruned_peer_id);
                     let _ = room.presence_tx.send((pruned_peer_id, left_bytes));


### PR DESCRIPTION
## Summary

The daemon now periodically prunes stale presence peers (15-second interval, 45-second TTL). Previously, clients that silently dropped without graceful disconnect would leave ghost cursors visible to other peers until room eviction.

A new `tokio::time::interval` arm in the select loop calls `PresenceState::prune_stale()` and broadcasts `PresenceMessage::Left` for each pruned peer, mirroring the existing disconnect cleanup pattern.

## Verification

* [ ] Connect two clients to a notebook
* [ ] Kill one client process (not graceful close) — verify its cursor appears in the other
* [ ] Wait 45 seconds — verify the ghost cursor disappears automatically

---

_PR submitted by @rgbkrk's agent, Quill_