### PR TITLE
feat(notebook-sync): add incoming presence support to runtimed-py

### DIFF
--- a/crates/notebook-sync/src/handle.rs
+++ b/crates/notebook-sync/src/handle.rs
@@ -465,6 +465,41 @@ impl DocHandle {
         reply_rx.await.map_err(|_| SyncError::Disconnected)?
     }
 
+    /// Get all connected peer IDs and labels.
+    pub fn get_peers(&self) -> Vec<(String, String)> {
+        let state = self.doc.lock().unwrap_or_else(|e| e.into_inner());
+        state
+            .presence
+            .peers()
+            .values()
+            .map(|p| (p.peer_id.clone(), p.peer_label.clone()))
+            .collect()
+    }
+
+    /// Get all remote peer cursors, excluding the given peer ID.
+    ///
+    /// Returns `(peer_id, peer_label, cursor_position)` tuples.
+    pub fn remote_cursors(
+        &self,
+        exclude_peer: &str,
+    ) -> Vec<(String, String, notebook_doc::presence::CursorPosition)> {
+        let state = self.doc.lock().unwrap_or_else(|e| e.into_inner());
+        state
+            .presence
+            .remote_cursors(exclude_peer)
+            .into_iter()
+            .map(|(id, pos)| {
+                let label = state
+                    .presence
+                    .peers()
+                    .get(id)
+                    .map(|p| p.peer_label.clone())
+                    .unwrap_or_default();
+                (id.to_string(), label, pos.clone())
+            })
+            .collect()
+    }
+
     /// Send a raw presence frame to the daemon.
     ///
     /// The daemon relays this to all other peers in the notebook room.

--- a/crates/notebook-sync/src/handle.rs
+++ b/crates/notebook-sync/src/handle.rs
@@ -465,26 +465,28 @@ impl DocHandle {
         reply_rx.await.map_err(|_| SyncError::Disconnected)?
     }
 
-    /// Get all connected peer IDs and labels.
+    /// Get all connected peer IDs and labels, sorted by peer ID for stable ordering.
     pub fn get_peers(&self) -> Vec<(String, String)> {
         let state = self.doc.lock().unwrap_or_else(|e| e.into_inner());
-        state
+        let mut peers: Vec<_> = state
             .presence
             .peers()
             .values()
             .map(|p| (p.peer_id.clone(), p.peer_label.clone()))
-            .collect()
+            .collect();
+        peers.sort_by(|a, b| a.0.cmp(&b.0));
+        peers
     }
 
     /// Get all remote peer cursors, excluding the given peer ID.
     ///
-    /// Returns `(peer_id, peer_label, cursor_position)` tuples.
+    /// Returns `(peer_id, peer_label, cursor_position)` tuples sorted by peer ID.
     pub fn remote_cursors(
         &self,
         exclude_peer: &str,
     ) -> Vec<(String, String, notebook_doc::presence::CursorPosition)> {
         let state = self.doc.lock().unwrap_or_else(|e| e.into_inner());
-        state
+        let mut cursors: Vec<_> = state
             .presence
             .remote_cursors(exclude_peer)
             .into_iter()
@@ -497,7 +499,9 @@ impl DocHandle {
                     .unwrap_or_default();
                 (id.to_string(), label, pos.clone())
             })
-            .collect()
+            .collect();
+        cursors.sort_by(|a, b| a.0.cmp(&b.0));
+        cursors
     }
 
     /// Send a raw presence frame to the daemon.

--- a/crates/notebook-sync/src/shared.rs
+++ b/crates/notebook-sync/src/shared.rs
@@ -7,6 +7,7 @@
 
 use automerge::sync;
 use automerge::AutoCommit;
+use notebook_doc::presence::PresenceState;
 
 /// The shared state behind `Arc<Mutex<SharedDocState>>`.
 ///
@@ -22,6 +23,9 @@ pub struct SharedDocState {
     /// The notebook identifier (canonical path for file-backed notebooks,
     /// UUID for ephemeral/untitled notebooks).
     pub(crate) notebook_id: String,
+
+    /// Incoming presence state from remote peers (cursors, selections, etc.).
+    pub(crate) presence: PresenceState,
 }
 
 impl SharedDocState {
@@ -31,6 +35,7 @@ impl SharedDocState {
             doc,
             peer_state: sync::State::new(),
             notebook_id,
+            presence: PresenceState::new(),
         }
     }
 

--- a/crates/notebook-sync/src/sync_task.rs
+++ b/crates/notebook-sync/src/sync_task.rs
@@ -364,12 +364,46 @@ async fn handle_incoming_frame<W: AsyncWrite + Unpin>(
         }
 
         NotebookFrameType::Presence => {
-            // Presence frames are typically forwarded to UI — for now, log and ignore
-            debug!(
-                "[notebook-sync] Received presence frame for {} ({} bytes)",
-                notebook_id,
-                frame.payload.len()
-            );
+            use notebook_doc::presence::{decode_message, PresenceMessage};
+
+            match decode_message(&frame.payload) {
+                Ok(msg) => {
+                    let now_ms = std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap_or_default()
+                        .as_millis() as u64;
+                    let mut state = doc.lock().unwrap_or_else(|e| e.into_inner());
+                    match msg {
+                        PresenceMessage::Update {
+                            peer_id,
+                            peer_label,
+                            data,
+                        } => {
+                            state.presence.update_peer(
+                                &peer_id,
+                                peer_label.as_deref().unwrap_or("peer"),
+                                data,
+                                now_ms,
+                            );
+                        }
+                        PresenceMessage::Snapshot { peers, .. } => {
+                            state.presence.apply_snapshot(&peers, now_ms);
+                        }
+                        PresenceMessage::Left { peer_id } => {
+                            state.presence.remove_peer(&peer_id);
+                        }
+                        PresenceMessage::Heartbeat { peer_id } => {
+                            state.presence.mark_seen(&peer_id, now_ms);
+                        }
+                    }
+                }
+                Err(e) => {
+                    debug!(
+                        "[notebook-sync] Failed to decode presence for {}: {}",
+                        notebook_id, e
+                    );
+                }
+            }
         }
 
         NotebookFrameType::Response => {

--- a/crates/notebook-sync/src/sync_task.rs
+++ b/crates/notebook-sync/src/sync_task.rs
@@ -364,7 +364,15 @@ async fn handle_incoming_frame<W: AsyncWrite + Unpin>(
         }
 
         NotebookFrameType::Presence => {
-            use notebook_doc::presence::{decode_message, PresenceMessage};
+            use notebook_doc::presence::{decode_message, validate_frame_size, PresenceMessage};
+
+            if let Err(e) = validate_frame_size(&frame.payload) {
+                debug!(
+                    "[notebook-sync] Dropping oversized presence frame for {}: {}",
+                    notebook_id, e
+                );
+                return;
+            }
 
             match decode_message(&frame.payload) {
                 Ok(msg) => {

--- a/crates/runtimed-py/src/async_session.rs
+++ b/crates/runtimed-py/src/async_session.rs
@@ -405,6 +405,29 @@ impl AsyncSession {
     // Presence
     // =========================================================================
 
+    /// Get all connected peer IDs and labels.
+    ///
+    /// Returns:
+    ///     List of (peer_id, peer_label) tuples.
+    fn get_peers<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let state = Arc::clone(&self.state);
+
+        future_into_py(py, async move { session_core::get_peers(&state).await })
+    }
+
+    /// Get remote peer cursors.
+    ///
+    /// Returns:
+    ///     List of (peer_id, peer_label, cell_id, line, column) tuples.
+    fn get_remote_cursors<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let state = Arc::clone(&self.state);
+
+        future_into_py(
+            py,
+            async move { session_core::get_remote_cursors(&state).await },
+        )
+    }
+
     /// Set cursor position for collaborative presence.
     fn set_cursor<'py>(
         &self,

--- a/crates/runtimed-py/src/session.rs
+++ b/crates/runtimed-py/src/session.rs
@@ -333,6 +333,23 @@ impl Session {
     // Presence
     // =========================================================================
 
+    /// Get all connected peer IDs and labels.
+    ///
+    /// Returns:
+    ///     List of (peer_id, peer_label) tuples.
+    fn get_peers(&self) -> PyResult<Vec<(String, String)>> {
+        self.runtime.block_on(session_core::get_peers(&self.state))
+    }
+
+    /// Get remote peer cursors.
+    ///
+    /// Returns:
+    ///     List of (peer_id, peer_label, cell_id, line, column) tuples.
+    fn get_remote_cursors(&self) -> PyResult<Vec<(String, String, String, u32, u32)>> {
+        self.runtime
+            .block_on(session_core::get_remote_cursors(&self.state))
+    }
+
     /// Set cursor position for collaborative presence.
     fn set_cursor(&self, cell_id: &str, line: u32, column: u32) -> PyResult<()> {
         self.runtime.block_on(session_core::set_cursor(

--- a/crates/runtimed-py/src/session.rs
+++ b/crates/runtimed-py/src/session.rs
@@ -345,7 +345,7 @@ impl Session {
     ///
     /// Returns:
     ///     List of (peer_id, peer_label, cell_id, line, column) tuples.
-    fn get_remote_cursors(&self) -> PyResult<Vec<(String, String, String, u32, u32)>> {
+    fn get_remote_cursors(&self) -> PyResult<Vec<session_core::RemoteCursor>> {
         self.runtime
             .block_on(session_core::get_remote_cursors(&self.state))
     }

--- a/crates/runtimed-py/src/session_core.rs
+++ b/crates/runtimed-py/src/session_core.rs
@@ -1015,6 +1015,32 @@ pub(crate) async fn set_selection(
     handle.send_presence(data).await.map_err(to_py_err)
 }
 
+/// Get all connected peer IDs and labels.
+pub(crate) async fn get_peers(state: &Arc<Mutex<SessionState>>) -> PyResult<Vec<(String, String)>> {
+    let st = state.lock().await;
+    let handle = st
+        .handle
+        .as_ref()
+        .ok_or_else(|| to_py_err("Not connected"))?;
+    Ok(handle.get_peers())
+}
+
+/// Get remote peer cursors as (peer_id, peer_label, cell_id, line, column).
+pub(crate) async fn get_remote_cursors(
+    state: &Arc<Mutex<SessionState>>,
+) -> PyResult<Vec<(String, String, String, u32, u32)>> {
+    let st = state.lock().await;
+    let handle = st
+        .handle
+        .as_ref()
+        .ok_or_else(|| to_py_err("Not connected"))?;
+    Ok(handle
+        .remote_cursors("local")
+        .into_iter()
+        .map(|(id, label, pos)| (id, label, pos.cell_id, pos.line, pos.column))
+        .collect())
+}
+
 /// Internal helper to emit cursor presence (best-effort).
 /// Reads peer_label from SessionState, so callers don't need to pass it.
 /// Errors are silently ignored since presence is non-critical.

--- a/crates/runtimed-py/src/session_core.rs
+++ b/crates/runtimed-py/src/session_core.rs
@@ -25,6 +25,9 @@ use crate::output_resolver;
 
 use pyo3::prelude::*;
 
+/// Remote cursor info: (peer_id, peer_label, cell_id, line, column).
+pub(crate) type RemoteCursor = (String, String, String, u32, u32);
+
 // =========================================================================
 // Shared state
 // =========================================================================
@@ -1028,7 +1031,7 @@ pub(crate) async fn get_peers(state: &Arc<Mutex<SessionState>>) -> PyResult<Vec<
 /// Get remote peer cursors as (peer_id, peer_label, cell_id, line, column).
 pub(crate) async fn get_remote_cursors(
     state: &Arc<Mutex<SessionState>>,
-) -> PyResult<Vec<(String, String, String, u32, u32)>> {
+) -> PyResult<Vec<RemoteCursor>> {
     let st = state.lock().await;
     let handle = st
         .handle

--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -2737,18 +2737,19 @@ class TestPresence:
         peers = s2.get_peers()
         assert len(peers) > 0, "Expected at least one remote peer"
 
-        # Session B should see Session A's cursor
+        # Session B should see Session A's cursor at (5, 10).
+        # Note: create_cell auto-emits presence at (0, 0), so we must wait
+        # specifically for the updated cursor position from set_cursor.
+        def _cursor_at_expected_pos():
+            for _, _, cid, ln, col in s2.get_remote_cursors():
+                if cid == cell_id and ln == 5 and col == 10:
+                    return True
+            return False
+
         wait_for_sync(
-            lambda: len(s2.get_remote_cursors()) > 0,
-            description="s2 sees s1 cursor",
+            _cursor_at_expected_pos,
+            description="s2 sees s1 cursor at (5, 10)",
         )
-        cursors = s2.get_remote_cursors()
-        assert len(cursors) > 0, "Expected at least one remote cursor"
-        # Each cursor is (peer_id, peer_label, cell_id, line, column)
-        _, _, cursor_cell_id, line, column = cursors[0]
-        assert cursor_cell_id == cell_id
-        assert line == 5
-        assert column == 10
 
     def test_get_peers_not_connected_raises(self):
         """get_peers raises when not connected."""

--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -2782,6 +2782,16 @@ class TestAsyncPresence:
             head_col=5,
         )
 
+    async def test_async_get_peers(self, async_session):
+        """Can query peers via AsyncSession."""
+        peers = await async_session.get_peers()
+        assert isinstance(peers, list)
+
+    async def test_async_get_remote_cursors(self, async_session):
+        """Can query remote cursors via AsyncSession."""
+        cursors = await async_session.get_remote_cursors()
+        assert isinstance(cursors, list)
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -2715,6 +2715,53 @@ class TestPresence:
         s1.set_cursor(cell_id, line=0, column=0)
         s2.set_cursor(cell_id, line=0, column=5)
 
+    def test_get_peers_and_remote_cursors(self, two_sessions):
+        """Session B sees Session A's cursor via get_peers/get_remote_cursors."""
+        s1, s2 = two_sessions
+        cell_id = s1.create_cell("shared cell")
+
+        # Wait for cell to sync to s2
+        wait_for_sync(
+            lambda: len(s2.get_cells()) > 0,
+            description="cell sync to s2",
+        )
+
+        # Session A sends cursor presence
+        s1.set_cursor(cell_id, line=5, column=10)
+
+        # Session B should see Session A as a peer
+        wait_for_sync(
+            lambda: len(s2.get_peers()) > 0,
+            description="s2 sees s1 peer",
+        )
+        peers = s2.get_peers()
+        assert len(peers) > 0, "Expected at least one remote peer"
+
+        # Session B should see Session A's cursor
+        wait_for_sync(
+            lambda: len(s2.get_remote_cursors()) > 0,
+            description="s2 sees s1 cursor",
+        )
+        cursors = s2.get_remote_cursors()
+        assert len(cursors) > 0, "Expected at least one remote cursor"
+        # Each cursor is (peer_id, peer_label, cell_id, line, column)
+        _, _, cursor_cell_id, line, column = cursors[0]
+        assert cursor_cell_id == cell_id
+        assert line == 5
+        assert column == 10
+
+    def test_get_peers_not_connected_raises(self):
+        """get_peers raises when not connected."""
+        sess = runtimed.Session()
+        with pytest.raises(runtimed.RuntimedError):
+            sess.get_peers()
+
+    def test_get_remote_cursors_not_connected_raises(self):
+        """get_remote_cursors raises when not connected."""
+        sess = runtimed.Session()
+        with pytest.raises(runtimed.RuntimedError):
+            sess.get_remote_cursors()
+
 
 class TestAsyncPresence:
     """Async versions of presence tests."""


### PR DESCRIPTION
## Summary

Notebook-sync now processes incoming presence frames (cursor, selection, kernel state) from remote peers. Python SDK users can query connected peers and remote cursor positions via `get_peers()` and `get_remote_cursors()` methods on both `Session` and `AsyncSession`.

Previously, presence frames were silently dropped with a debug log. Now they're decoded and stored, enabling multi-peer collaboration tracking in MCP agents and scripts.

## Changes

* SharedDocState maintains PresenceState for all peers
* sync_task decodes and processes Presence frames (Update, Snapshot, Left, Heartbeat)
* DocHandle exposes get_peers() and remote_cursors() queries
* session_core provides async get_peers() and get_remote_cursors()
* Session/AsyncSession expose presence queries to Python
* Integration test verifies two sessions can query each other's presence

## Verification

* [ ] Run the integration test: `cd python && python -m pytest runtimed/tests/test_daemon_integration.py::TestPresence::test_get_peers_and_remote_cursors -v`
* [ ] Verify cursor tracking: Create two sessions with same notebook ID, have Session A send cursor, verify Session B can call get_remote_cursors() and retrieve the cursor position

Closes #837

_PR submitted by @rgbkrk's agent, Quill_