### PR TITLE
fix(xtask): drop externalBin requirement in dev mode

### DIFF
--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -157,13 +157,12 @@ fn cmd_dev(notebook: Option<&str>, skip_install: bool, skip_build: bool) {
 }
 
 fn cmd_notebook(notebook: Option<&str>, attach: bool) {
+    ensure_pnpm_install();
     let status = run_notebook_dev_app(notebook, attach, false);
     exit_on_failed_status("cargo tauri dev", status);
 }
 
 fn run_notebook_dev_app(notebook: Option<&str>, attach: bool, force_dev_mode: bool) -> ExitStatus {
-    ensure_pnpm_install();
-
     // Delete bundled marker since we're building a dev binary
     let marker = Path::new("./target/debug/.notebook-bundled");
     let _ = fs::remove_file(marker);

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -162,6 +162,8 @@ fn cmd_notebook(notebook: Option<&str>, attach: bool) {
 }
 
 fn run_notebook_dev_app(notebook: Option<&str>, attach: bool, force_dev_mode: bool) -> ExitStatus {
+    ensure_pnpm_install();
+
     // Delete bundled marker since we're building a dev binary
     let marker = Path::new("./target/debug/.notebook-bundled");
     let _ = fs::remove_file(marker);

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -174,9 +174,11 @@ fn run_notebook_dev_app(notebook: Option<&str>, attach: bool, force_dev_mode: bo
         let port = vite_port.clone().unwrap_or_else(|| "5174".to_string());
         println!("Connecting to Vite at http://localhost:{port}");
 
-        // Skip beforeDevCommand (Vite is already running) and set devUrl
-        let config =
-            format!(r#"{{"build":{{"devUrl":"http://localhost:{port}","beforeDevCommand":""}}}}"#);
+        // Skip beforeDevCommand (Vite is already running), set devUrl,
+        // and drop externalBin so sidecar binaries aren't required in dev
+        let config = format!(
+            r#"{{"build":{{"devUrl":"http://localhost:{port}","beforeDevCommand":""}},"bundle":{{"externalBin":[]}}}}"#
+        );
 
         let mut args = vec!["tauri", "dev", "--config", &config, "--", "-p", "notebook"];
         if let Some(path) = notebook {
@@ -187,15 +189,19 @@ fn run_notebook_dev_app(notebook: Option<&str>, attach: bool, force_dev_mode: bo
     } else {
         println!("Starting dev server with hot reload...");
 
-        let config_override = vite_port.as_ref().map(|port| {
-            println!("Using RUNTIMED_VITE_PORT={port}");
-            format!(r#"{{"build":{{"devUrl":"http://localhost:{port}"}}}}"#)
-        });
+        // Always override externalBin so sidecar binaries aren't required
+        // in dev mode (the daemon is started separately via dev-daemon)
+        let config_override = match vite_port.as_ref() {
+            Some(port) => {
+                println!("Using RUNTIMED_VITE_PORT={port}");
+                format!(
+                    r#"{{"build":{{"devUrl":"http://localhost:{port}"}},"bundle":{{"externalBin":[]}}}}"#
+                )
+            }
+            None => r#"{"bundle":{"externalBin":[]}}"#.to_string(),
+        };
 
-        let mut args = vec!["tauri", "dev"];
-        if let Some(ref config) = config_override {
-            args.extend(["--config", config]);
-        }
+        let mut args = vec!["tauri", "dev", "--config", &config_override];
         args.extend(["--", "-p", "notebook"]);
         if let Some(path) = notebook {
             args.extend(["--", path]);


### PR DESCRIPTION
On a fresh checkout, `cargo xtask notebook` fails because Tauri's build script validates that `externalBin` paths (`binaries/runtimed-{triple}`, `binaries/runt-{triple}`) exist — even though sidecars are never used in dev mode (the daemon is started separately via `dev-daemon`).

Override `bundle.externalBin` to `[]` in the `--config` passed to `cargo tauri dev` so sidecar binaries aren't required for dev builds. Bundled builds (`cargo xtask build`, `build-app`, `build-dmg`, `build-e2e`) are unaffected — they call `build_runtimed_daemon()` first.

_PR submitted by @rgbkrk's agent Quill, via Zed_