### PR TITLE
chore(xtask): use sccache when available for compilation cache

### DIFF
--- a/contributing/development.md
+++ b/contributing/development.md
@@ -17,6 +17,20 @@
 | Lint (check mode) | `cargo xtask lint` |
 | Lint (auto-fix) | `cargo xtask lint --fix` |
 
+## Build Cache (sccache)
+
+Install [sccache](https://github.com/mozilla/sccache) to share compiled
+artifacts across worktrees. Without it, each worktree rebuilds ~788 crates from
+scratch.
+
+```bash
+brew install sccache   # macOS
+```
+
+The xtask commands auto-detect sccache and set `RUSTC_WRAPPER` when it's
+available — no configuration needed. You'll see "Using sccache for compilation
+cache" in the build output when it's active.
+
 ## Choosing a Workflow
 
 ### `cargo xtask dev` — One Command Setup + Dev

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -3,6 +3,7 @@ use std::fs;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
 use std::process::{exit, Child, Command, ExitStatus, Stdio};
+use std::sync::OnceLock;
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -168,6 +169,7 @@ fn run_notebook_dev_app(notebook: Option<&str>, attach: bool, force_dev_mode: bo
 
     let vite_port = resolve_vite_port(force_dev_mode);
     let mut command = Command::new("cargo");
+    apply_sccache_env(&mut command);
 
     if attach {
         println!("Attaching to existing Vite server...");
@@ -991,6 +993,7 @@ fn run_cmd_ok(cmd: &str, args: &[&str]) -> bool {
     command.args(args);
     if cmd == "cargo" {
         apply_build_channel_env(&mut command);
+        apply_sccache_env(&mut command);
     }
 
     command.status().map(|s| s.success()).unwrap_or_else(|e| {
@@ -1081,6 +1084,7 @@ fn run_cmd(cmd: &str, args: &[&str]) {
     command.args(args);
     if cmd == "cargo" {
         apply_build_channel_env(&mut command);
+        apply_sccache_env(&mut command);
     }
 
     let status = command.status().unwrap_or_else(|e| {
@@ -1109,6 +1113,30 @@ fn run_frontend_build(debug_bundle: bool) {
     if !status.success() {
         eprintln!("Command failed: pnpm build");
         exit(status.code().unwrap_or(1));
+    }
+}
+
+/// Set `RUSTC_WRAPPER=sccache` when sccache is available.
+///
+/// Detection is cached for the lifetime of the process so the `which`
+/// lookup only runs once.
+fn apply_sccache_env(command: &mut Command) {
+    static AVAILABLE: OnceLock<bool> = OnceLock::new();
+    let available = *AVAILABLE.get_or_init(|| {
+        let found = Command::new("sccache")
+            .arg("--version")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        if found {
+            println!("Using sccache for compilation cache");
+        }
+        found
+    });
+    if available {
+        command.env("RUSTC_WRAPPER", "sccache");
     }
 }
 

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -1118,9 +1118,13 @@ fn run_frontend_build(debug_bundle: bool) {
 
 /// Set `RUSTC_WRAPPER=sccache` when sccache is available.
 ///
-/// Detection is cached for the lifetime of the process so the `which`
-/// lookup only runs once.
+/// Skips detection entirely if `RUSTC_WRAPPER` is already set in the
+/// environment (respects existing tooling). Detection runs `sccache
+/// --version` once and caches the result for the lifetime of the process.
 fn apply_sccache_env(command: &mut Command) {
+    if env::var_os("RUSTC_WRAPPER").is_some() {
+        return;
+    }
     static AVAILABLE: OnceLock<bool> = OnceLock::new();
     let available = *AVAILABLE.get_or_init(|| {
         let found = Command::new("sccache")


### PR DESCRIPTION
With 41 worktrees, each one rebuilds ~788 crates from scratch. sccache shares compiled artifacts across worktrees by content hash so the second build of the same crate+flags is a cache hit.

**How it works:** `apply_sccache_env` runs `sccache --version` once per xtask process (cached via `OnceLock`), and sets `RUSTC_WRAPPER=sccache` on every cargo invocation when available. When sccache isn't installed, builds proceed normally.

**Install:** `brew install sccache`

No configuration needed — xtask handles detection and setup automatically.

_PR submitted by @rgbkrk's agent Quill, via Zed_