### PR TITLE
chore(xtask): add cargo xtask dev-mcp for local MCP server setup

### DIFF
--- a/.zed/tasks.json
+++ b/.zed/tasks.json
@@ -105,4 +105,15 @@
     "reveal": "always",
     "reveal_target": "dock",
   },
+  {
+    "label": "Dev MCP (print config)",
+    "command": "cargo xtask dev-mcp --print-config",
+    "env": {
+      "RUNTIMED_DEV": "1",
+      "RUNTIMED_WORKSPACE_PATH": "$ZED_WORKTREE_ROOT",
+    },
+    "use_new_terminal": false,
+    "allow_concurrent_runs": false,
+    "reveal": "always",
+  },
 ]

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -597,7 +597,7 @@ fn cmd_dev_mcp(print_config: bool) {
         command
             .args(["daemon", "status", "--json"])
             .stdout(Stdio::piped())
-            .stderr(Stdio::null());
+            .stderr(Stdio::piped());
         apply_worktree_env(&mut command, true);
 
         let output = command.output().unwrap_or_else(|e| {
@@ -607,7 +607,11 @@ fn cmd_dev_mcp(print_config: bool) {
         });
 
         if !output.status.success() {
-            eprintln!("runt daemon status failed");
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            eprintln!("runt daemon status failed:");
+            if !stderr.trim().is_empty() {
+                eprintln!("{}", stderr.trim());
+            }
             exit(1);
         }
 
@@ -674,7 +678,13 @@ fn cmd_dev_mcp(print_config: bool) {
                 "RUNTIMED_SOCKET_PATH": socket_path
             }
         });
-        println!("{}", serde_json::to_string_pretty(&config).unwrap());
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&config).unwrap_or_else(|e| {
+                eprintln!("Failed to serialize MCP config: {e}");
+                exit(1);
+            })
+        );
     } else {
         println!();
         println!("Launching nteract MCP server...");

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -49,6 +49,10 @@ fn main() {
             let release = args.iter().any(|a| a == "--release");
             cmd_dev_daemon(release);
         }
+        "dev-mcp" => {
+            let print_config = args.iter().any(|a| a == "--print-config");
+            cmd_dev_mcp(print_config);
+        }
         "lint" => {
             let fix = args.iter().any(|a| a == "--fix");
             cmd_lint(fix);
@@ -86,6 +90,10 @@ Release:
 Daemon:
   install-daemon             Build and install runtimed into the running service
   dev-daemon [--release]     Build and run runtimed in per-worktree dev mode
+
+MCP:
+  dev-mcp                    Build Python bindings and launch nteract MCP server
+  dev-mcp --print-config     Print MCP client config JSON (for Claude, Zed, etc.)
 
 Linting:
   lint                       Check formatting and linting (Rust, JS/TS, Python)
@@ -576,6 +584,124 @@ fn cmd_install_daemon() {
 ///
 /// This enables isolated daemon instances per git worktree, useful when
 /// developing/testing daemon code across multiple worktrees simultaneously.
+fn cmd_dev_mcp(print_config: bool) {
+    // Step 1: Build the runt CLI so we can query daemon status
+    if !Path::new(dev_runt_cli_binary()).exists() {
+        println!("Building runt CLI...");
+        run_cmd("cargo", &["build", "-p", "runt-cli"]);
+    }
+
+    // Step 2: Resolve the socket path from the dev daemon
+    let socket_path = {
+        let mut command = Command::new(dev_runt_cli_binary());
+        command
+            .args(["daemon", "status", "--json"])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null());
+        apply_worktree_env(&mut command, true);
+
+        let output = command.output().unwrap_or_else(|e| {
+            eprintln!("Failed to run runt daemon status: {e}");
+            eprintln!("Build the CLI first: cargo build -p runt-cli");
+            exit(1);
+        });
+
+        if !output.status.success() {
+            eprintln!("runt daemon status failed");
+            exit(1);
+        }
+
+        let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
+            eprintln!("Failed to parse daemon status JSON: {e}");
+            exit(1);
+        });
+
+        let path = json
+            .get("socket_path")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_else(|| {
+                eprintln!("No socket_path in daemon status output");
+                exit(1);
+            })
+            .to_string();
+
+        let running = json
+            .get("running")
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false);
+
+        if !running && !print_config {
+            eprintln!("Warning: dev daemon is not running.");
+            eprintln!("Start it first: cargo xtask dev-daemon");
+            eprintln!();
+        }
+
+        path
+    };
+
+    // Step 3: Build runtimed-py via maturin develop
+    println!("Building runtimed Python bindings (maturin develop)...");
+    let maturin_status = Command::new("uv")
+        .args([
+            "run",
+            "--directory",
+            "python/runtimed",
+            "maturin",
+            "develop",
+        ])
+        .status()
+        .unwrap_or_else(|e| {
+            eprintln!("Failed to run maturin develop: {e}");
+            eprintln!("Make sure uv and maturin are installed: uv tool install maturin");
+            exit(1);
+        });
+    if !maturin_status.success() {
+        eprintln!("maturin develop failed");
+        exit(maturin_status.code().unwrap_or(1));
+    }
+
+    // Step 4: Print config or launch
+    let python_dir = fs::canonicalize("python").unwrap_or_else(|e| {
+        eprintln!("Failed to resolve python/ directory: {e}");
+        exit(1);
+    });
+
+    if print_config {
+        let config = serde_json::json!({
+            "command": "uv",
+            "args": ["run", "--no-sync", "--directory", python_dir.to_string_lossy(), "nteract"],
+            "env": {
+                "RUNTIMED_SOCKET_PATH": socket_path
+            }
+        });
+        println!("{}", serde_json::to_string_pretty(&config).unwrap());
+    } else {
+        println!();
+        println!("Launching nteract MCP server...");
+        println!("Socket: {socket_path}");
+        println!();
+
+        let status = Command::new("uv")
+            .args([
+                "run",
+                "--no-sync",
+                "--directory",
+                &python_dir.to_string_lossy(),
+                "nteract",
+            ])
+            .env("RUNTIMED_SOCKET_PATH", &socket_path)
+            .status()
+            .unwrap_or_else(|e| {
+                eprintln!("Failed to launch nteract MCP server: {e}");
+                exit(1);
+            });
+
+        if !status.success() {
+            exit(status.code().unwrap_or(1));
+        }
+    }
+}
+
 fn cmd_dev_daemon(release: bool) {
     if release {
         println!("Building runtimed (release)...");


### PR DESCRIPTION
Running the nteract MCP server against a local dev build required a fragile multi-step setup with manual socket path resolution. This adds a single command that handles everything:

```bash
# Launch the MCP server connected to your dev daemon
cargo xtask dev-mcp

# Or just print the config JSON for Claude/Zed/etc.
cargo xtask dev-mcp --print-config
```

The command:
1. Builds `runtimed-py` via `maturin develop` (PyO3 bindings into the uv workspace venv)
2. Resolves the socket path from `runt daemon status --json`
3. Launches `uv run --no-sync nteract` with `RUNTIMED_SOCKET_PATH` set, or prints client config JSON with `--print-config`

Also adds a "Dev MCP (print config)" Zed task.

Closes #732

_PR submitted by @rgbkrk's agent Quill, via Zed_