### PR TITLE
ci: move Windows cross-compile clippy to parallel job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,6 +85,30 @@ jobs:
         with:
           shellcheck: false
 
+  windows-clippy:
+    name: Windows (clippy)
+    needs: [changes]
+    if: needs.changes.outputs.source_changed == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install rust
+        uses: dsherret/rust-toolchain-file@v1
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: windows-cross
+
+      - name: Install mingw-w64 and add Windows GNU target
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y gcc-mingw-w64-x86-64 nasm
+          rustup target add x86_64-pc-windows-gnu
+
+      - name: Clippy (Windows cross-check)
+        run: cargo clippy --target x86_64-pc-windows-gnu --workspace --exclude notebook --exclude runtimed-wasm --exclude runtimed-py --all-targets -- -D warnings
+
   build-ui:
     name: Build shared UI artifacts
     needs: [changes]
@@ -222,15 +246,6 @@ jobs:
 
       - name: Clippy
         run: cargo clippy --workspace --all-targets -- -D warnings
-
-      - name: Install mingw-w64 and add Windows GNU target
-        run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y gcc-mingw-w64-x86-64 nasm
-          rustup target add x86_64-pc-windows-gnu
-
-      - name: Clippy (Windows cross-check)
-        run: cargo clippy --target x86_64-pc-windows-gnu --workspace --exclude notebook --exclude runtimed-wasm --exclude runtimed-py --all-targets -- -D warnings
 
       - name: Build
         run: cargo build --release


### PR DESCRIPTION
The Windows cross-compile clippy check (`cargo clippy --target x86_64-pc-windows-gnu`) was running inside `build-linux`, which gates E2E tests and runtimed-py integration tests. Installing mingw-w64 + running the cross clippy adds minutes to the critical path that has nothing to do with Linux.

This extracts it into a parallel `windows-clippy` job that:
- Runs on every PR (the actual Windows runner was `run_on_pr: false`)
- Uses its own rust cache key (`windows-cross`)
- Catches Windows compilation errors without blocking the Linux pipeline

Before:
```
build-linux (clippy + windows-clippy + build + test + e2e-build) → e2e, e2e-fixtures, runtimed-py
```

After:
```
build-linux (clippy + build + test + e2e-build) → e2e, e2e-fixtures, runtimed-py
windows-clippy (parallel, no downstream deps)
```

_PR submitted by @rgbkrk's agent Quill, via Zed_