### PR TITLE
fix(mcp): handle keyboard interrupt gracefully

### DIFF
--- a/python/nteract/src/nteract/_mcp_server.py
+++ b/python/nteract/src/nteract/_mcp_server.py
@@ -1312,8 +1312,10 @@ def main():
         format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
         stream=sys.stderr,
     )
-    with contextlib.suppress(KeyboardInterrupt):
+    try:
         mcp.run(transport="stdio")
+    except KeyboardInterrupt:
+        sys.exit(130)
 
 
 if __name__ == "__main__":

--- a/python/nteract/src/nteract/_mcp_server.py
+++ b/python/nteract/src/nteract/_mcp_server.py
@@ -1312,7 +1312,8 @@ def main():
         format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
         stream=sys.stderr,
     )
-    mcp.run(transport="stdio")
+    with contextlib.suppress(KeyboardInterrupt):
+        mcp.run(transport="stdio")
 
 
 if __name__ == "__main__":

--- a/python/nteract/tests/test_smoke.py
+++ b/python/nteract/tests/test_smoke.py
@@ -1,5 +1,7 @@
 """Smoke tests to verify the package can be imported."""
 
+from unittest.mock import patch
+
 
 def test_import():
     """Verify the nteract package can be imported."""
@@ -13,3 +15,18 @@ def test_mcp_server_import():
     from nteract._mcp_server import mcp
 
     assert mcp.name == "nteract"
+
+
+def test_keyboard_interrupt_exits_130():
+    """Ctrl+C should exit with code 130 (Unix SIGINT convention), not dump a traceback."""
+    from nteract._mcp_server import main
+
+    with patch("nteract._mcp_server.mcp") as mock_mcp:
+        mock_mcp.run.side_effect = KeyboardInterrupt
+        try:
+            main()
+            raised = False
+        except SystemExit as e:
+            raised = True
+            assert e.code == 130, f"Expected exit code 130, got {e.code}"
+        assert raised, "main() should have called sys.exit(130)"


### PR DESCRIPTION
Ctrl+C on the MCP server dumps a traceback through anyio, threading, and a fatal Python error about the buffered stdin reader lock. The fix: `contextlib.suppress(KeyboardInterrupt)` around `mcp.run()`.

Fixes #850

_PR submitted by @rgbkrk's agent Quill, via Zed_