### PR TITLE
feat(runtimed): track and reap orphaned kernel process groups

### DIFF
--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -458,6 +458,18 @@ impl Daemon {
             error!("[runtimed] Failed to write daemon info: {}", e);
         }
 
+        // Reap any orphaned kernel process groups from a previous crash
+        #[cfg(unix)]
+        {
+            let reaped = crate::kernel_pids::reap_orphaned_kernels();
+            if reaped > 0 {
+                info!(
+                    "[runtimed] Reaped {} orphaned kernel process group(s)",
+                    reaped
+                );
+            }
+        }
+
         // Find and reuse existing environments from previous runs
         self.find_existing_environments().await;
 

--- a/crates/runtimed/src/kernel_manager.rs
+++ b/crates/runtimed/src/kernel_manager.rs
@@ -261,6 +261,8 @@ pub struct RoomKernel {
     /// Process group ID for cleanup (Unix only)
     #[cfg(unix)]
     process_group_id: Option<i32>,
+    /// Kernel ID for the process registry (orphan reaping)
+    kernel_id: Option<String>,
     /// Mapping from msg_id → cell_id for routing iopub messages
     cell_id_map: Arc<StdMutex<HashMap<String, String>>>,
     /// Execution queue (pending cells)
@@ -371,6 +373,7 @@ impl RoomKernel {
             shell_writer: None,
             #[cfg(unix)]
             process_group_id: None,
+            kernel_id: None,
             cell_id_map: Arc::new(StdMutex::new(HashMap::new())),
             queue: VecDeque::new(),
             executing: None,
@@ -669,7 +672,11 @@ impl RoomKernel {
         #[cfg(unix)]
         {
             self.process_group_id = process.id().map(|pid| pid as i32);
+            if let Some(pgid) = self.process_group_id {
+                crate::kernel_pids::register_kernel(&kernel_id, pgid, &connection_file_path);
+            }
         }
+        self.kernel_id = Some(kernel_id.clone());
 
         // Small delay to let the kernel start
         tokio::time::sleep(std::time::Duration::from_millis(500)).await;
@@ -2118,6 +2125,11 @@ impl RoomKernel {
             }
         }
 
+        // Unregister from process registry
+        if let Some(ref kid) = self.kernel_id {
+            crate::kernel_pids::unregister_kernel(kid);
+        }
+
         // Clean up connection file
         if let Some(ref path) = self.connection_file {
             let _ = std::fs::remove_file(path);
@@ -2158,6 +2170,11 @@ impl Drop for RoomKernel {
             use nix::sys::signal::{killpg, Signal};
             use nix::unistd::Pid;
             let _ = killpg(Pid::from_raw(pgid), Signal::SIGKILL);
+        }
+
+        // Unregister from process registry
+        if let Some(ref kid) = self.kernel_id {
+            crate::kernel_pids::unregister_kernel(kid);
         }
 
         // Clean up connection file

--- a/crates/runtimed/src/kernel_manager.rs
+++ b/crates/runtimed/src/kernel_manager.rs
@@ -501,13 +501,14 @@ impl RoomKernel {
             kernel_name: Some(kernelspec_name.to_string()),
         };
 
-        // Write connection file
-        let runtime_dir = runtimelib::dirs::runtime_dir();
-        tokio::fs::create_dir_all(&runtime_dir).await?;
+        // Write connection file to the daemon's own directory (not the shared
+        // Jupyter runtime dir) so we can safely clean up orphans on restart.
+        let conn_dir = crate::connections_dir();
+        tokio::fs::create_dir_all(&conn_dir).await?;
 
         let kernel_id: String =
             petname::petname(2, "-").unwrap_or_else(|| Uuid::new_v4().to_string());
-        let connection_file_path = runtime_dir.join(format!("runtimed-kernel-{}.json", kernel_id));
+        let connection_file_path = conn_dir.join(format!("{}.json", kernel_id));
 
         tokio::fs::write(
             &connection_file_path,
@@ -673,7 +674,7 @@ impl RoomKernel {
         {
             self.process_group_id = process.id().map(|pid| pid as i32);
             if let Some(pgid) = self.process_group_id {
-                crate::kernel_pids::register_kernel(&kernel_id, pgid, &connection_file_path);
+                crate::kernel_pids::register_kernel(&kernel_id, pgid);
             }
         }
         self.kernel_id = Some(kernel_id.clone());
@@ -2126,8 +2127,8 @@ impl RoomKernel {
         }
 
         // Unregister from process registry
-        if let Some(ref kid) = self.kernel_id {
-            crate::kernel_pids::unregister_kernel(kid);
+        if let Some(kid) = self.kernel_id.take() {
+            crate::kernel_pids::unregister_kernel(&kid);
         }
 
         // Clean up connection file
@@ -2173,8 +2174,8 @@ impl Drop for RoomKernel {
         }
 
         // Unregister from process registry
-        if let Some(ref kid) = self.kernel_id {
-            crate::kernel_pids::unregister_kernel(kid);
+        if let Some(kid) = self.kernel_id.take() {
+            crate::kernel_pids::unregister_kernel(&kid);
         }
 
         // Clean up connection file

--- a/crates/runtimed/src/kernel_pids.rs
+++ b/crates/runtimed/src/kernel_pids.rs
@@ -5,8 +5,15 @@
 //! module persists kernel pgids to `kernels.json` so the next daemon instance
 //! can reap them on startup.
 //!
+//! Connection files are colocated in `connections_dir()` alongside this registry.
+//! Together they contain enough information to either kill orphaned kernels (the
+//! current strategy) or, in a future iteration, reattach to still-running kernels
+//! during a daemon upgrade (pgid to verify liveness, connection file for ZMQ ports).
+//!
 //! All I/O is synchronous (`std::fs`) since it's called from both async and
-//! `Drop` contexts.
+//! `Drop` contexts. The registry is only accessed by a single daemon process,
+//! so no file locking is needed — Tokio's cooperative scheduling ensures the
+//! synchronous read-modify-write won't interleave between tasks.
 
 use log::error;
 #[cfg(unix)]
@@ -20,7 +27,6 @@ use crate::daemon_base_dir;
 #[derive(Debug, Serialize, Deserialize)]
 struct KernelEntry {
     pgid: i32,
-    connection_file: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -60,19 +66,15 @@ fn write_registry(registry: &KernelRegistry) {
     }
 }
 
-/// Register a kernel's process group ID and connection file path.
-pub fn register_kernel(kernel_id: &str, pgid: i32, connection_file_path: &std::path::Path) {
+/// Register a kernel's process group ID for orphan tracking.
+pub fn register_kernel(kernel_id: &str, pgid: i32) {
     let mut registry = read_registry().unwrap_or(KernelRegistry {
         kernels: HashMap::new(),
     });
 
-    registry.kernels.insert(
-        kernel_id.to_string(),
-        KernelEntry {
-            pgid,
-            connection_file: connection_file_path.to_string_lossy().to_string(),
-        },
-    );
+    registry
+        .kernels
+        .insert(kernel_id.to_string(), KernelEntry { pgid });
 
     write_registry(&registry);
 }
@@ -87,7 +89,6 @@ pub fn unregister_kernel(kernel_id: &str) {
     registry.kernels.remove(kernel_id);
 
     if registry.kernels.is_empty() {
-        // Clean up the file entirely when no kernels remain
         let _ = std::fs::remove_file(registry_path());
     } else {
         write_registry(&registry);
@@ -96,70 +97,112 @@ pub fn unregister_kernel(kernel_id: &str) {
 
 /// Reap orphaned kernel process groups from a previous daemon instance.
 ///
-/// Reads `kernels.json`, sends SIGKILL to each process group, cleans up
-/// connection files, and deletes the registry. Returns the number of
-/// process groups successfully killed.
+/// Reads `kernels.json`, sends SIGKILL to each process group, bulk-cleans
+/// leftover connection files from `connections_dir()`, and removes the
+/// registry. Returns the number of process groups successfully killed.
+///
+/// This runs at daemon startup before any new kernels are launched, so all
+/// files in `connections_dir()` are guaranteed to be orphaned from a previous
+/// run and safe to delete.
+///
+/// Currently this always kills orphaned kernels. A future "reattach" strategy
+/// could instead verify kernel liveness and reconnect via the connection files,
+/// enabling daemon upgrades without interrupting running kernels.
 #[cfg(unix)]
 pub fn reap_orphaned_kernels() -> usize {
     let registry = match read_registry() {
         Some(r) => r,
-        None => return 0,
+        None => {
+            // No registry, but there may still be leftover connection files
+            // from a previous version that didn't clean up properly.
+            clean_connection_files();
+            return 0;
+        }
     };
 
     if registry.kernels.is_empty() {
         let _ = std::fs::remove_file(registry_path());
+        clean_connection_files();
         return 0;
     }
 
     let mut reaped = 0;
+    let mut failed_entries: HashMap<String, KernelEntry> = HashMap::new();
 
-    for (kernel_id, entry) in &registry.kernels {
+    for (kernel_id, entry) in registry.kernels {
         use nix::sys::signal::{killpg, Signal};
         use nix::unistd::Pid;
 
-        match killpg(Pid::from_raw(entry.pgid), Signal::SIGKILL) {
+        if entry.pgid <= 0 {
+            warn!(
+                "[kernel-pids] Skipping invalid pgid {} for kernel '{}'",
+                entry.pgid, kernel_id
+            );
+            continue;
+        }
+
+        let kill_succeeded = match killpg(Pid::from_raw(entry.pgid), Signal::SIGKILL) {
             Ok(()) => {
                 info!(
                     "[kernel-pids] Reaped orphaned kernel '{}' (pgid {})",
                     kernel_id, entry.pgid
                 );
                 reaped += 1;
+                true
             }
             Err(nix::errno::Errno::ESRCH) => {
-                // Process group already dead — not an error
                 info!(
                     "[kernel-pids] Orphaned kernel '{}' (pgid {}) already dead",
                     kernel_id, entry.pgid
                 );
+                true
             }
             Err(nix::errno::Errno::EPERM) => {
                 warn!(
                     "[kernel-pids] No permission to kill orphaned kernel '{}' (pgid {})",
                     kernel_id, entry.pgid
                 );
+                false
             }
             Err(e) => {
                 error!(
                     "[kernel-pids] Failed to kill orphaned kernel '{}' (pgid {}): {}",
                     kernel_id, entry.pgid, e
                 );
+                false
             }
-        }
+        };
 
-        // Clean up connection file
-        let conn_path = std::path::Path::new(&entry.connection_file);
-        if conn_path.exists() {
-            if let Err(e) = std::fs::remove_file(conn_path) {
-                warn!(
-                    "[kernel-pids] Failed to remove connection file {}: {}",
-                    entry.connection_file, e
-                );
-            }
+        if !kill_succeeded {
+            failed_entries.insert(kernel_id, entry);
         }
     }
 
-    // Remove the registry file
-    let _ = std::fs::remove_file(registry_path());
+    // Rewrite registry with only the failed entries, or remove it entirely
+    if failed_entries.is_empty() {
+        let _ = std::fs::remove_file(registry_path());
+    } else {
+        write_registry(&KernelRegistry {
+            kernels: failed_entries,
+        });
+    }
+
+    // Bulk-clean all leftover connection files. Safe because this runs at
+    // startup before any new kernels are launched.
+    clean_connection_files();
 
     reaped
+}
+
+/// Remove all files in the connections directory.
+#[cfg(unix)]
+fn clean_connection_files() {
+    let conn_dir = crate::connections_dir();
+    if conn_dir.exists() {
+        if let Ok(entries) = std::fs::read_dir(&conn_dir) {
+            for entry in entries.flatten() {
+                let _ = std::fs::remove_file(entry.path());
+            }
+        }
+    }
 }

--- a/crates/runtimed/src/kernel_pids.rs
+++ b/crates/runtimed/src/kernel_pids.rs
@@ -1,0 +1,163 @@
+//! Persist kernel process group IDs to disk for orphan reaping.
+//!
+//! When runtimed is killed with SIGKILL, its graceful shutdown code never runs.
+//! Kernel processes spawned with `process_group(0)` survive as orphans. This
+//! module persists kernel pgids to `kernels.json` so the next daemon instance
+//! can reap them on startup.
+//!
+//! All I/O is synchronous (`std::fs`) since it's called from both async and
+//! `Drop` contexts.
+
+use log::{error, info, warn};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use crate::daemon_base_dir;
+
+#[derive(Debug, Serialize, Deserialize)]
+struct KernelEntry {
+    pgid: i32,
+    connection_file: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct KernelRegistry {
+    kernels: HashMap<String, KernelEntry>,
+}
+
+fn registry_path() -> PathBuf {
+    daemon_base_dir().join("kernels.json")
+}
+
+fn read_registry() -> Option<KernelRegistry> {
+    let path = registry_path();
+    let data = std::fs::read_to_string(&path).ok()?;
+    serde_json::from_str(&data).ok()
+}
+
+fn write_registry(registry: &KernelRegistry) {
+    let path = registry_path();
+    let tmp_path = path.with_extension("json.tmp");
+
+    let data = match serde_json::to_string_pretty(registry) {
+        Ok(d) => d,
+        Err(e) => {
+            error!("[kernel-pids] Failed to serialize registry: {}", e);
+            return;
+        }
+    };
+
+    if let Err(e) = std::fs::write(&tmp_path, &data) {
+        error!("[kernel-pids] Failed to write temp file: {}", e);
+        return;
+    }
+
+    if let Err(e) = std::fs::rename(&tmp_path, &path) {
+        error!("[kernel-pids] Failed to rename temp file: {}", e);
+    }
+}
+
+/// Register a kernel's process group ID and connection file path.
+pub fn register_kernel(kernel_id: &str, pgid: i32, connection_file_path: &std::path::Path) {
+    let mut registry = read_registry().unwrap_or(KernelRegistry {
+        kernels: HashMap::new(),
+    });
+
+    registry.kernels.insert(
+        kernel_id.to_string(),
+        KernelEntry {
+            pgid,
+            connection_file: connection_file_path.to_string_lossy().to_string(),
+        },
+    );
+
+    write_registry(&registry);
+}
+
+/// Remove a kernel from the registry (called during graceful shutdown).
+pub fn unregister_kernel(kernel_id: &str) {
+    let mut registry = match read_registry() {
+        Some(r) => r,
+        None => return,
+    };
+
+    registry.kernels.remove(kernel_id);
+
+    if registry.kernels.is_empty() {
+        // Clean up the file entirely when no kernels remain
+        let _ = std::fs::remove_file(registry_path());
+    } else {
+        write_registry(&registry);
+    }
+}
+
+/// Reap orphaned kernel process groups from a previous daemon instance.
+///
+/// Reads `kernels.json`, sends SIGKILL to each process group, cleans up
+/// connection files, and deletes the registry. Returns the number of
+/// process groups successfully killed.
+#[cfg(unix)]
+pub fn reap_orphaned_kernels() -> usize {
+    let registry = match read_registry() {
+        Some(r) => r,
+        None => return 0,
+    };
+
+    if registry.kernels.is_empty() {
+        let _ = std::fs::remove_file(registry_path());
+        return 0;
+    }
+
+    let mut reaped = 0;
+
+    for (kernel_id, entry) in &registry.kernels {
+        use nix::sys::signal::{killpg, Signal};
+        use nix::unistd::Pid;
+
+        match killpg(Pid::from_raw(entry.pgid), Signal::SIGKILL) {
+            Ok(()) => {
+                info!(
+                    "[kernel-pids] Reaped orphaned kernel '{}' (pgid {})",
+                    kernel_id, entry.pgid
+                );
+                reaped += 1;
+            }
+            Err(nix::errno::Errno::ESRCH) => {
+                // Process group already dead — not an error
+                info!(
+                    "[kernel-pids] Orphaned kernel '{}' (pgid {}) already dead",
+                    kernel_id, entry.pgid
+                );
+            }
+            Err(nix::errno::Errno::EPERM) => {
+                warn!(
+                    "[kernel-pids] No permission to kill orphaned kernel '{}' (pgid {})",
+                    kernel_id, entry.pgid
+                );
+            }
+            Err(e) => {
+                error!(
+                    "[kernel-pids] Failed to kill orphaned kernel '{}' (pgid {}): {}",
+                    kernel_id, entry.pgid, e
+                );
+            }
+        }
+
+        // Clean up connection file
+        let conn_path = std::path::Path::new(&entry.connection_file);
+        if conn_path.exists() {
+            if let Err(e) = std::fs::remove_file(conn_path) {
+                warn!(
+                    "[kernel-pids] Failed to remove connection file {}: {}",
+                    entry.connection_file, e
+                );
+            }
+        }
+    }
+
+    // Remove the registry file
+    let _ = std::fs::remove_file(registry_path());
+
+    reaped
+}

--- a/crates/runtimed/src/kernel_pids.rs
+++ b/crates/runtimed/src/kernel_pids.rs
@@ -8,7 +8,9 @@
 //! All I/O is synchronous (`std::fs`) since it's called from both async and
 //! `Drop` contexts.
 
-use log::{error, info, warn};
+use log::error;
+#[cfg(unix)]
+use log::{info, warn};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;

--- a/crates/runtimed/src/lib.rs
+++ b/crates/runtimed/src/lib.rs
@@ -201,6 +201,16 @@ pub fn default_blob_store_dir() -> PathBuf {
     daemon_base_dir().join("blobs")
 }
 
+/// Get the directory for kernel connection files.
+///
+/// Connection files are stored here (rather than the shared Jupyter runtime
+/// directory) so the daemon owns its files exclusively. This enables safe
+/// bulk cleanup on startup and opens the door for future kernel reattachment
+/// during daemon upgrades.
+pub fn connections_dir() -> PathBuf {
+    daemon_base_dir().join("connections")
+}
+
 /// Get the default path for the persisted Automerge settings document.
 pub fn default_settings_doc_path() -> PathBuf {
     daemon_base_dir().join("settings.automerge")

--- a/crates/runtimed/src/lib.rs
+++ b/crates/runtimed/src/lib.rs
@@ -29,6 +29,7 @@ pub use notebook_protocol::connection;
 pub mod daemon;
 pub mod inline_env;
 pub mod kernel_manager;
+pub mod kernel_pids;
 pub mod markdown_assets;
 pub use notebook_doc;
 pub use notebook_doc::metadata as notebook_metadata;


### PR DESCRIPTION
## Summary

When runtimed is killed with SIGKILL, kernel processes spawned with `process_group(0)` survive as orphans. This adds a `kernel_pids` module that persists process group IDs to disk so the next daemon instance can reap them on startup.

Kernel connection files are written to `daemon_base_dir()/connections/` (the daemon's own cache directory) rather than the shared Jupyter runtime directory. This isolates runtimed's files from JupyterLab and other Jupyter servers, and enables safe bulk cleanup of orphaned connection files on startup.

## Changes

- **`kernel_pids.rs`** — new module that persists kernel pgids to `kernels.json` using atomic write-via-rename. On startup, `reap_orphaned_kernels()` kills orphaned process groups and bulk-cleans leftover connection files.
- **`kernel_manager.rs`** — registers kernel pgid on launch, unregisters on shutdown/Drop (using `.take()` to prevent double-unregister). Writes connection files to `connections_dir()`.
- **`daemon.rs`** — calls `reap_orphaned_kernels()` at daemon startup (Unix only).
- **`lib.rs`** — adds `connections_dir()` helper and exports `kernel_pids` module.

## Design decisions

- **No file locking** on the registry — it's only accessed by a single daemon process and Tokio's cooperative scheduling prevents interleaving of synchronous I/O within tasks.
- **Failed kills are retained** in the registry so the next daemon restart can retry, rather than silently losing track of orphans.
- **Pgid validated > 0** before `killpg` to guard against corrupted registry entries.
- Connection file colocation with the pgid registry opens the door for future kernel reattachment during daemon upgrades (verifying liveness + reconnecting via ZMQ ports instead of killing).

## Verification

- [ ] Start daemon, launch a kernel, confirm connection file appears in `daemon_base_dir()/connections/` (not `~/.local/share/jupyter/runtime/`)
- [ ] Kill daemon with SIGKILL while kernel is running, restart daemon, confirm orphaned kernel is reaped and logged
- [ ] Graceful shutdown removes kernel from `kernels.json` and cleans up connection file
- [ ] No interference with JupyterLab connection files in the shared runtime directory

_PR submitted by @rgbkrk's agent, Quill_