### PR TITLE
docs: Inkwell docs + managed Vite dev server + shared port logic

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,8 @@ tools in addition to the standard nteract notebook tools:
 | `supervisor_restart` | Restart child (`target="child"`) or daemon (`target="daemon"`) |
 | `supervisor_rebuild` | Run `maturin develop` to rebuild Rust Python bindings, then restart |
 | `supervisor_logs` | Tail the daemon log file |
+| `supervisor_start_vite` | Start the Vite dev server for hot-reload frontend development. Returns the port number. If already running, returns the existing port. |
+| `supervisor_stop` | Stop a managed process by name (e.g. `"vite"`). |
 
 The nteract tools (`list_notebooks`, `create_notebook`, `execute_cell`, etc.)
 are proxied through the supervisor. If tools start failing, call

--- a/contributing/development.md
+++ b/contributing/development.md
@@ -309,6 +309,8 @@ These tools are always available, even when the Python child is down:
 | `supervisor_restart` | Restart child or daemon |
 | `supervisor_rebuild` | `maturin develop` + restart (after Rust changes) |
 | `supervisor_logs` | Tail the daemon log file |
+| `supervisor_start_vite` | Start the Vite dev server for hot-reload frontend development |
+| `supervisor_stop` | Stop a managed process by name (e.g. `"vite"`) |
 
 #### Hot reload
 

--- a/crates/mcp-supervisor/src/main.rs
+++ b/crates/mcp-supervisor/src/main.rs
@@ -1,4 +1,5 @@
-//! Inkwell — a stable MCP server that proxies to the nteract MCP server.
+//! Inkwell — a stable MCP server that proxies to the nteract MCP server
+//! and manages the full dev environment (daemon, vite, notebook app).
 //!
 //! Architecture:
 //! - Acts as an MCP **server** facing the client (Zed, Claude, etc.) via stdin/stdout
@@ -14,6 +15,8 @@
 //!   cargo run -p mcp-supervisor
 //!   # or via xtask:
 //!   cargo xtask mcp
+
+use std::collections::HashMap;
 
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
@@ -253,6 +256,29 @@ enum ChangeKind {
     RustChanged,
 }
 
+/// A managed long-running child process (vite, notebook app, etc.).
+#[allow(dead_code)]
+struct ManagedProcess {
+    /// Human-readable name for logging and status.
+    name: String,
+    /// The child process handle.
+    child: std::process::Child,
+    /// The port it's listening on, if applicable.
+    port: Option<u16>,
+}
+
+impl ManagedProcess {
+    fn is_alive(&self) -> bool {
+        // Check if process is still running (non-blocking)
+        let child_ref = std::process::Command::new("kill")
+            .args(["-0", &self.child.id().to_string()])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+        child_ref.map(|s| s.success()).unwrap_or(false)
+    }
+}
+
 /// Shared state for the supervisor.
 struct SupervisorState {
     /// rmcp client connected to the nteract child process.
@@ -272,6 +298,8 @@ struct SupervisorState {
     /// Channel to request a tool list changed notification from the server context.
     /// The file watcher sends on this channel after triggering a restart.
     tool_list_changed_tx: Option<mpsc::Sender<()>>,
+    /// Managed long-running processes (vite dev server, notebook app, etc.).
+    managed: HashMap<String, ManagedProcess>,
 }
 
 impl SupervisorState {
@@ -315,6 +343,7 @@ impl Supervisor {
                 last_error: None,
                 daemon_child,
                 tool_list_changed_tx: Some(tool_list_changed_tx),
+                managed: HashMap::new(),
             })),
         }
     }
@@ -422,6 +451,20 @@ impl Supervisor {
         } else {
             false
         };
+        let managed_processes: HashMap<String, ManagedProcessStatus> = state
+            .managed
+            .iter()
+            .map(|(name, proc)| {
+                (
+                    name.clone(),
+                    ManagedProcessStatus {
+                        pid: proc.child.id(),
+                        alive: proc.is_alive(),
+                        port: proc.port,
+                    },
+                )
+            })
+            .collect();
         SupervisorStatus {
             child_running,
             restart_count: state.restart_count,
@@ -429,6 +472,87 @@ impl Supervisor {
             socket_path: state.socket_path.clone(),
             project_root: state.project_root.to_string_lossy().to_string(),
             daemon_managed: state.daemon_child.is_some(),
+            managed_processes,
+        }
+    }
+
+    /// Start the Vite dev server for hot-reload frontend development.
+    async fn start_vite(&self) -> Result<u16, String> {
+        let mut state = self.state.write().await;
+
+        // Already running?
+        if let Some(proc) = state.managed.get("vite") {
+            if proc.is_alive() {
+                return proc
+                    .port
+                    .ok_or_else(|| "Vite is running but port unknown".into());
+            }
+            // Dead — clean up
+            state.managed.remove("vite");
+        }
+
+        let project_root = state.project_root.clone();
+
+        // Pick a port — check env var first, then derive from worktree hash
+        let port = std::env::var("RUNTIMED_VITE_PORT")
+            .ok()
+            .and_then(|p| p.parse::<u16>().ok())
+            .or_else(|| runt_workspace::default_vite_port())
+            .unwrap_or(5174);
+
+        // Ensure pnpm install has been run
+        let node_modules = project_root.join("node_modules/.modules.yaml");
+        if !node_modules.exists() {
+            info!("Running pnpm install...");
+            let status = std::process::Command::new("pnpm")
+                .args(["install"])
+                .current_dir(&project_root)
+                .stdout(Stdio::null())
+                .stderr(Stdio::inherit())
+                .status()
+                .map_err(|e| format!("Failed to run pnpm install: {e}"))?;
+            if !status.success() {
+                return Err("pnpm install failed".into());
+            }
+        }
+
+        info!("Starting Vite dev server on port {port}...");
+        let child = std::process::Command::new("pnpm")
+            .args(["--dir", "apps/notebook", "dev", "--port", &port.to_string()])
+            .current_dir(&project_root)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .map_err(|e| format!("Failed to start Vite: {e}"))?;
+
+        info!("Vite dev server started (PID {}, port {port})", child.id());
+
+        state.managed.insert(
+            "vite".into(),
+            ManagedProcess {
+                name: "vite".into(),
+                child,
+                port: Some(port),
+            },
+        );
+
+        Ok(port)
+    }
+
+    /// Stop a managed process by name.
+    async fn stop_managed(&self, name: &str) -> Result<(), String> {
+        let mut state = self.state.write().await;
+        if let Some(mut proc) = state.managed.remove(name) {
+            info!(
+                "Stopping managed process '{}' (PID {})...",
+                name,
+                proc.child.id()
+            );
+            let _ = proc.child.kill();
+            let _ = proc.child.wait();
+            Ok(())
+        } else {
+            Err(format!("No managed process named '{name}'"))
         }
     }
 
@@ -469,6 +593,13 @@ impl Supervisor {
 }
 
 #[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
+struct ManagedProcessStatus {
+    pid: u32,
+    alive: bool,
+    port: Option<u16>,
+}
+
+#[derive(Debug, Serialize, Deserialize, schemars::JsonSchema)]
 struct SupervisorStatus {
     /// Whether the nteract MCP child process is running.
     child_running: bool,
@@ -482,6 +613,8 @@ struct SupervisorStatus {
     project_root: String,
     /// Whether the supervisor started (and manages) the daemon.
     daemon_managed: bool,
+    /// Status of managed long-running processes (vite, app, etc.).
+    managed_processes: HashMap<String, ManagedProcessStatus>,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -506,6 +639,13 @@ struct SupervisorLogsParams {
 
 fn default_log_lines() -> usize {
     50
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+#[allow(dead_code)]
+struct StopProcessParams {
+    /// Name of the managed process to stop (e.g. "vite").
+    name: String,
 }
 
 // The supervisor_status tool schema — no input params needed.
@@ -573,6 +713,20 @@ impl ServerHandler for Supervisor {
             "supervisor_logs",
             "Read the last N lines of the daemon log file. Defaults to 50 lines.",
             serde_json::to_value(schemars::schema_for!(SupervisorLogsParams))
+                .unwrap()
+                .as_object()
+                .cloned()
+                .unwrap_or_default(),
+        ));
+        tools.push(Tool::new(
+            "supervisor_start_vite",
+            "Start the Vite dev server for hot-reload frontend development. Returns the port number. If already running, returns the existing port.",
+            empty_schema.clone(),
+        ));
+        tools.push(Tool::new(
+            "supervisor_stop",
+            "Stop a managed process by name (e.g. 'vite').",
+            serde_json::to_value(schemars::schema_for!(StopProcessParams))
                 .unwrap()
                 .as_object()
                 .cloned()
@@ -664,6 +818,28 @@ impl ServerHandler for Supervisor {
                             ))])),
                         }
                     }
+                }
+            }
+            "supervisor_start_vite" => match self.start_vite().await {
+                Ok(port) => Ok(CallToolResult::success(vec![Content::text(format!(
+                    "Vite dev server running on http://localhost:{port}"
+                ))])),
+                Err(e) => Ok(CallToolResult::success(vec![Content::text(format!(
+                    "Failed to start Vite: {e}"
+                ))])),
+            },
+            "supervisor_stop" => {
+                let name = request
+                    .arguments
+                    .as_ref()
+                    .and_then(|args| args.get("name"))
+                    .and_then(Value::as_str)
+                    .unwrap_or("");
+                match self.stop_managed(name).await {
+                    Ok(()) => Ok(CallToolResult::success(vec![Content::text(format!(
+                        "Stopped '{name}'"
+                    ))])),
+                    Err(e) => Ok(CallToolResult::success(vec![Content::text(e)])),
                 }
             }
             "supervisor_rebuild" => {

--- a/crates/mcp-supervisor/src/main.rs
+++ b/crates/mcp-supervisor/src/main.rs
@@ -302,14 +302,13 @@ struct ManagedProcess {
 }
 
 impl ManagedProcess {
-    fn is_alive(&self) -> bool {
-        // Check if process is still running (non-blocking)
-        let child_ref = std::process::Command::new("kill")
-            .args(["-0", &self.child.id().to_string()])
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status();
-        child_ref.map(|s| s.success()).unwrap_or(false)
+    fn is_alive(&mut self) -> bool {
+        // Cross-platform liveness check via try_wait (no extra process spawn)
+        match self.child.try_wait() {
+            Ok(None) => true,     // Still running
+            Ok(Some(_)) => false, // Exited
+            Err(_) => false,      // Can't check — assume dead
+        }
     }
 }
 
@@ -476,7 +475,7 @@ impl Supervisor {
 
     /// Build the supervisor_status result.
     async fn status(&self) -> SupervisorStatus {
-        let state = self.state.read().await;
+        let mut state = self.state.write().await;
         // Just check if we have a client handle. A full liveness probe
         // (list_tools) can hang if the child is wedged, which blocks the
         // entire status call. The forward_tool_call path handles detection
@@ -484,7 +483,7 @@ impl Supervisor {
         let child_running = state.child_client.is_some();
         let managed_processes: HashMap<String, ManagedProcessStatus> = state
             .managed
-            .iter()
+            .iter_mut()
             .map(|(name, proc)| {
                 (
                     name.clone(),
@@ -509,27 +508,34 @@ impl Supervisor {
 
     /// Start the Vite dev server for hot-reload frontend development.
     async fn start_vite(&self) -> Result<u16, String> {
-        let mut state = self.state.write().await;
+        // Phase 1: Check existing process and extract state (hold lock briefly)
+        let (project_root, needs_start) = {
+            let mut state = self.state.write().await;
 
-        // Already running?
-        if let Some(proc) = state.managed.get("vite") {
-            if proc.is_alive() {
-                return proc
-                    .port
-                    .ok_or_else(|| "Vite is running but port unknown".into());
+            // Already running?
+            if let Some(proc) = state.managed.get_mut("vite") {
+                if proc.is_alive() {
+                    return proc
+                        .port
+                        .ok_or_else(|| "Vite is running but port unknown".into());
+                }
+                // Dead — clean up
+                state.managed.remove("vite");
             }
-            // Dead — clean up
-            state.managed.remove("vite");
+
+            (state.project_root.clone(), true)
+            // Lock dropped here
+        };
+
+        if !needs_start {
+            unreachable!();
         }
 
-        let project_root = state.project_root.clone();
-
-        // Pick a port — check env var first, then derive from worktree hash
+        // Phase 2: Derive port and run pnpm install without holding the lock
         let port = std::env::var("RUNTIMED_VITE_PORT")
             .ok()
             .and_then(|p| p.parse::<u16>().ok())
-            .or_else(|| runt_workspace::default_vite_port())
-            .unwrap_or(5174);
+            .unwrap_or_else(|| runt_workspace::vite_port_for_workspace(&project_root));
 
         // Ensure pnpm install has been run
         let node_modules = project_root.join("node_modules/.modules.yaml");
@@ -550,7 +556,14 @@ impl Supervisor {
 
         info!("Starting Vite dev server on port {port}...");
         let child = std::process::Command::new("pnpm")
-            .args(["--dir", "apps/notebook", "dev", "--port", &port.to_string()])
+            .args([
+                "--dir",
+                "apps/notebook",
+                "dev",
+                "--",
+                "--port",
+                &port.to_string(),
+            ])
             .current_dir(&project_root)
             .env("PATH", augmented_path())
             .stdout(Stdio::null())
@@ -560,6 +573,8 @@ impl Supervisor {
 
         info!("Vite dev server started (PID {}, port {port})", child.id());
 
+        // Phase 3: Re-acquire lock to store the process
+        let mut state = self.state.write().await;
         state.managed.insert(
             "vite".into(),
             ManagedProcess {
@@ -574,19 +589,24 @@ impl Supervisor {
 
     /// Stop a managed process by name.
     async fn stop_managed(&self, name: &str) -> Result<(), String> {
-        let mut state = self.state.write().await;
-        if let Some(mut proc) = state.managed.remove(name) {
-            info!(
-                "Stopping managed process '{}' (PID {})...",
-                name,
-                proc.child.id()
-            );
-            let _ = proc.child.kill();
-            let _ = proc.child.wait();
-            Ok(())
-        } else {
-            Err(format!("No managed process named '{name}'"))
-        }
+        // Remove from map under the lock, then kill outside the lock
+        let mut proc = {
+            let mut state = self.state.write().await;
+            state
+                .managed
+                .remove(name)
+                .ok_or_else(|| format!("No managed process named '{name}'"))?
+            // Lock dropped here
+        };
+
+        info!(
+            "Stopping managed process '{}' (PID {})...",
+            name,
+            proc.child.id()
+        );
+        let _ = proc.child.kill();
+        let _ = proc.child.wait();
+        Ok(())
     }
 
     /// Handle a file change event: restart child (and rebuild if Rust changed).
@@ -699,7 +719,8 @@ impl ServerHandler for Supervisor {
             instructions: Some(
                 "Inkwell — MCP supervisor proxying to the nteract notebook server. \
                  Includes supervisor_status, supervisor_restart, supervisor_rebuild, \
-                 and supervisor_logs tools for managing the server lifecycle. \
+                 supervisor_logs, supervisor_start_vite, and supervisor_stop tools \
+                 for managing the server lifecycle and dev environment. \
                  File watching is active: Python changes hot-reload instantly, \
                  Rust changes trigger maturin develop + reload. Changed tool \
                  behavior takes effect immediately; new/removed tools may take \

--- a/crates/mcp-supervisor/src/main.rs
+++ b/crates/mcp-supervisor/src/main.rs
@@ -164,7 +164,8 @@ fn augmented_path() -> String {
         dirs.push(format!("{home}/.local/bin"));
         dirs.push(format!("{home}/.cargo/bin"));
 
-        // nvm: scan for node versions (picks the latest lexicographically)
+        // nvm: include all node version bin dirs (pnpm may only be installed
+        // in some versions, not necessarily the latest)
         let nvm_dir = PathBuf::from(&home).join(".nvm/versions/node");
         if let Ok(entries) = std::fs::read_dir(&nvm_dir) {
             let mut versions: Vec<PathBuf> = entries
@@ -173,8 +174,9 @@ fn augmented_path() -> String {
                 .filter(|p| p.join("bin/node").exists())
                 .collect();
             versions.sort();
-            if let Some(latest) = versions.last() {
-                dirs.push(latest.join("bin").to_string_lossy().to_string());
+            // Add in reverse order so newer versions take priority
+            for version in versions.into_iter().rev() {
+                dirs.push(version.join("bin").to_string_lossy().to_string());
             }
         }
     }

--- a/crates/mcp-supervisor/src/main.rs
+++ b/crates/mcp-supervisor/src/main.rs
@@ -152,6 +152,39 @@ fn ensure_maturin_develop(project_root: &Path) -> bool {
     }
 }
 
+/// Build an augmented PATH that includes common user-local tool directories.
+///
+/// MCP clients (Zed, Claude, etc.) often spawn servers with a minimal PATH
+/// that's missing ~/.local/bin (uv), ~/.cargo/bin, ~/.nvm/*, /opt/homebrew/bin, etc.
+fn augmented_path() -> String {
+    let base = std::env::var("PATH").unwrap_or_default();
+    let mut dirs: Vec<String> = Vec::new();
+
+    if let Ok(home) = std::env::var("HOME") {
+        dirs.push(format!("{home}/.local/bin"));
+        dirs.push(format!("{home}/.cargo/bin"));
+
+        // nvm: scan for node versions (picks the latest lexicographically)
+        let nvm_dir = PathBuf::from(&home).join(".nvm/versions/node");
+        if let Ok(entries) = std::fs::read_dir(&nvm_dir) {
+            let mut versions: Vec<PathBuf> = entries
+                .filter_map(|e| e.ok())
+                .map(|e| e.path())
+                .filter(|p| p.join("bin/node").exists())
+                .collect();
+            versions.sort();
+            if let Some(latest) = versions.last() {
+                dirs.push(latest.join("bin").to_string_lossy().to_string());
+            }
+        }
+    }
+
+    dirs.push("/opt/homebrew/bin".into());
+
+    let prefix = dirs.join(":");
+    format!("{prefix}:{base}")
+}
+
 fn run_maturin_develop(project_root: &Path) -> bool {
     // Route stdout to null — the supervisor uses stdout for MCP transport,
     // so maturin output would corrupt the JSON-RPC stream. Stderr goes to
@@ -195,11 +228,7 @@ async fn spawn_nteract_child(
 ) -> Result<rmcp::service::RunningService<RoleNteractClient, NteractClientHandler>, String> {
     let python_dir = project_root.join("python");
 
-    // Augment PATH for uv discovery (same issue as the wrapper script)
-    let mut path = std::env::var("PATH").unwrap_or_default();
-    if let Ok(home) = std::env::var("HOME") {
-        path = format!("{home}/.local/bin:{home}/.cargo/bin:/opt/homebrew/bin:{path}");
-    }
+    let path = augmented_path();
 
     let transport = TokioChildProcess::new(Command::new("uv").configure(|cmd| {
         cmd.args([
@@ -507,6 +536,7 @@ impl Supervisor {
             let status = std::process::Command::new("pnpm")
                 .args(["install"])
                 .current_dir(&project_root)
+                .env("PATH", augmented_path())
                 .stdout(Stdio::null())
                 .stderr(Stdio::inherit())
                 .status()
@@ -520,6 +550,7 @@ impl Supervisor {
         let child = std::process::Command::new("pnpm")
             .args(["--dir", "apps/notebook", "dev", "--port", &port.to_string()])
             .current_dir(&project_root)
+            .env("PATH", augmented_path())
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .spawn()

--- a/crates/mcp-supervisor/src/main.rs
+++ b/crates/mcp-supervisor/src/main.rs
@@ -186,8 +186,10 @@ fn augmented_path() -> String {
 
     dirs.push("/opt/homebrew/bin".into());
 
-    let prefix = dirs.join(":");
-    format!("{prefix}:{base}")
+    // Use platform-appropriate PATH separator
+    let sep = if cfg!(windows) { ";" } else { ":" };
+    let prefix = dirs.join(sep);
+    format!("{prefix}{sep}{base}")
 }
 
 fn run_maturin_develop(project_root: &Path) -> bool {
@@ -291,10 +293,7 @@ enum ChangeKind {
 }
 
 /// A managed long-running child process (vite, notebook app, etc.).
-#[allow(dead_code)]
 struct ManagedProcess {
-    /// Human-readable name for logging and status.
-    name: String,
     /// The child process handle.
     child: std::process::Child,
     /// The port it's listening on, if applicable.
@@ -537,18 +536,24 @@ impl Supervisor {
             .and_then(|p| p.parse::<u16>().ok())
             .unwrap_or_else(|| runt_workspace::vite_port_for_workspace(&project_root));
 
-        // Ensure pnpm install has been run
+        // Ensure pnpm install has been run (use spawn_blocking to avoid
+        // stalling the tokio runtime during a potentially long install)
         let node_modules = project_root.join("node_modules/.modules.yaml");
         if !node_modules.exists() {
             info!("Running pnpm install...");
-            let status = std::process::Command::new("pnpm")
-                .args(["install"])
-                .current_dir(&project_root)
-                .env("PATH", augmented_path())
-                .stdout(Stdio::null())
-                .stderr(Stdio::inherit())
-                .status()
-                .map_err(|e| format!("Failed to run pnpm install: {e}"))?;
+            let pr = project_root.clone();
+            let status = tokio::task::spawn_blocking(move || {
+                std::process::Command::new("pnpm")
+                    .args(["install"])
+                    .current_dir(&pr)
+                    .env("PATH", augmented_path())
+                    .stdout(Stdio::null())
+                    .stderr(Stdio::inherit())
+                    .status()
+            })
+            .await
+            .map_err(|e| format!("pnpm install task failed: {e}"))?
+            .map_err(|e| format!("Failed to run pnpm install: {e}"))?;
             if !status.success() {
                 return Err("pnpm install failed".into());
             }
@@ -563,6 +568,7 @@ impl Supervisor {
                 "--",
                 "--port",
                 &port.to_string(),
+                "--strictPort",
             ])
             .current_dir(&project_root)
             .env("PATH", augmented_path())
@@ -578,7 +584,6 @@ impl Supervisor {
         state.managed.insert(
             "vite".into(),
             ManagedProcess {
-                name: "vite".into(),
                 child,
                 port: Some(port),
             },
@@ -889,6 +894,11 @@ impl ServerHandler for Supervisor {
                     .and_then(|args| args.get("name"))
                     .and_then(Value::as_str)
                     .unwrap_or("");
+                if name.is_empty() {
+                    return Ok(CallToolResult::success(vec![Content::text(
+                        "Missing required 'name' argument (e.g. \"vite\")",
+                    )]));
+                }
                 match self.stop_managed(name).await {
                     Ok(()) => Ok(CallToolResult::success(vec![Content::text(format!(
                         "Stopped '{name}'"

--- a/crates/mcp-supervisor/src/main.rs
+++ b/crates/mcp-supervisor/src/main.rs
@@ -179,6 +179,9 @@ fn augmented_path() -> String {
                 dirs.push(version.join("bin").to_string_lossy().to_string());
             }
         }
+
+        // Standalone pnpm installer location
+        dirs.push(format!("{home}/Library/pnpm"));
     }
 
     dirs.push("/opt/homebrew/bin".into());
@@ -474,14 +477,11 @@ impl Supervisor {
     /// Build the supervisor_status result.
     async fn status(&self) -> SupervisorStatus {
         let state = self.state.read().await;
-        // Check actual liveness: is_some() means we have a client handle,
-        // but the child may have crashed. Try a lightweight probe.
-        let child_running = if let Some(ref client) = state.child_client {
-            // list_tools is a cheap probe — if it fails, the child is dead
-            client.list_tools(None).await.is_ok()
-        } else {
-            false
-        };
+        // Just check if we have a client handle. A full liveness probe
+        // (list_tools) can hang if the child is wedged, which blocks the
+        // entire status call. The forward_tool_call path handles detection
+        // and auto-restart on actual failures.
+        let child_running = state.child_client.is_some();
         let managed_processes: HashMap<String, ManagedProcessStatus> = state
             .managed
             .iter()

--- a/crates/runt-workspace/src/lib.rs
+++ b/crates/runt-workspace/src/lib.rs
@@ -335,6 +335,24 @@ pub fn worktree_hash(path: &Path) -> String {
     hex::encode(&hasher.finalize()[..6]) // 6 bytes = 12 hex chars
 }
 
+/// Derive a stable Vite dev server port for a worktree.
+///
+/// Uses the first 4 hex chars of the worktree hash to pick a port in
+/// the range 5100–9999, avoiding conflicts between parallel worktrees.
+/// Returns `None` if the workspace path can't be determined.
+pub fn default_vite_port() -> Option<u16> {
+    let workspace = get_workspace_path()?;
+    Some(vite_port_for_workspace(&workspace))
+}
+
+/// Derive a Vite port for a specific workspace path.
+pub fn vite_port_for_workspace(path: &Path) -> u16 {
+    let hash = worktree_hash(path);
+    let prefix = hash.get(..4).unwrap_or("0000");
+    let offset = u16::from_str_radix(prefix, 16).unwrap_or(0) % 4900;
+    5100 + offset
+}
+
 // ============================================================================
 // Directory Paths
 // ============================================================================

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -1057,15 +1057,7 @@ fn resolve_vite_port(force_dev_mode: bool) -> Option<String> {
 }
 
 fn default_dev_vite_port() -> Option<u16> {
-    let workspace = runt_workspace::get_workspace_path()?;
-    Some(default_vite_port_for_workspace(&workspace))
-}
-
-fn default_vite_port_for_workspace(path: &Path) -> u16 {
-    let hash = runt_workspace::worktree_hash(path);
-    let prefix = hash.get(..4).unwrap_or("0000");
-    let offset = u16::from_str_radix(prefix, 16).unwrap_or(0) % 4900;
-    5100 + offset
+    runt_workspace::default_vite_port()
 }
 
 /// Run linting and formatting checks across all languages.
@@ -1413,8 +1405,8 @@ mod tests {
     #[test]
     fn default_vite_port_is_stable_for_workspace() {
         let workspace = Path::new("/workspace/example");
-        let port = default_vite_port_for_workspace(workspace);
-        assert_eq!(port, default_vite_port_for_workspace(workspace));
+        let port = runt_workspace::vite_port_for_workspace(workspace);
+        assert_eq!(port, runt_workspace::vite_port_for_workspace(workspace));
         assert!((5100u16..10000u16).contains(&port));
     }
 }


### PR DESCRIPTION
Docs cleanup + managed Vite dev server for Inkwell.

## Docs
- Rewrite AGENTS.md MCP section with Inkwell supervisor docs, tool availability matrix, hot-reload behavior
- Add symlink note (CLAUDE.md → AGENTS.md) 
- Rewrite contributing/development.md MCP section with both Inkwell (recommended) and direct mode workflows
- Remove `scripts/dev-nteract-mcp.sh` (replaced by Inkwell)

## Managed Vite dev server
- New `supervisor_start_vite` tool: starts the Vite dev server as a managed child process with per-worktree port
- New `supervisor_stop` tool: stops a managed process by name
- `supervisor_status` now includes managed process info (PID, alive, port)

## Shared port logic
- Move Vite port derivation (`vite_port_for_workspace`, `default_vite_port`) to `runt-workspace` crate
- Both xtask and mcp-supervisor use the same stable per-worktree port calculation
- Remove duplicated logic from xtask

_PR submitted by @rgbkrk's agent Quill, via Zed_