### PR TITLE
fix(runtimed): include metadata in FileChanged broadcast from file watcher

### DIFF
--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -4908,10 +4908,13 @@ pub(crate) fn spawn_notebook_file_watcher(
                                     let doc = room.doc.read().await;
                                     doc.get_cells()
                                 };
+                                let metadata = json
+                                    .get("metadata")
+                                    .map(|m| m.to_string());
                                 let _ = room.kernel_broadcast_tx.send(
                                     NotebookBroadcast::FileChanged {
                                         cells,
-                                        metadata: None, // TODO: handle metadata changes
+                                        metadata,
                                     }
                                 );
                             }


### PR DESCRIPTION
The FileChanged broadcast was always sending metadata: None when external
file changes were detected. Now extracts the metadata object from the
parsed .ipynb JSON and includes it in the broadcast.
