### PR TITLE
ci: extract WASM + Deno tests into parallel job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,6 +109,35 @@ jobs:
       - name: Clippy (Windows cross-check)
         run: cargo clippy --target x86_64-pc-windows-gnu --workspace --exclude notebook --exclude runtimed-wasm --exclude runtimed-py --all-targets -- -D warnings
 
+  wasm-deno:
+    name: WASM + Deno Tests
+    needs: [changes]
+    if: needs.changes.outputs.source_changed == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install rust
+        uses: dsherret/rust-toolchain-file@v1
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ubuntu-latest
+
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - name: Build runtimed-wasm
+        run: wasm-pack build crates/runtimed-wasm --target web --out-dir ../../apps/notebook/src/wasm/runtimed-wasm
+
+      - name: Install Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Run runtimed-wasm Deno tests
+        run: deno test --allow-read --allow-env --no-check crates/runtimed-wasm/tests/
+
   build-ui:
     name: Build shared UI artifacts
     needs: [changes]
@@ -271,20 +300,6 @@ jobs:
 
       - name: Run tests
         run: cargo test --workspace --verbose
-
-      - name: Install wasm-pack
-        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-
-      - name: Build runtimed-wasm
-        run: wasm-pack build crates/runtimed-wasm --target web --out-dir ../../apps/notebook/src/wasm/runtimed-wasm
-
-      - name: Install Deno
-        uses: denoland/setup-deno@v2
-        with:
-          deno-version: v2.x
-
-      - name: Run runtimed-wasm Deno tests
-        run: deno test --allow-read --allow-env --no-check crates/runtimed-wasm/tests/
 
   build:
     name: ${{ matrix.platform.name }}


### PR DESCRIPTION
The wasm-pack build + Deno tests were at the tail end of `build-linux`, which gates E2E and integration tests. A Deno test failure would block the entire downstream pipeline even though it produces no artifacts that other jobs need.

Same pattern as the Windows clippy extraction in #856.

Before:
```
build-linux (compile + clippy + test + wasm-pack + deno) → e2e, integration
```

After:
```
build-linux (compile + clippy + test) → e2e, integration
wasm-deno (parallel, no downstream deps)
```

This was triggered by a Deno test failure in #869 that blocked E2E and integration tests from running — on a PR that only changed `crates/mcp-supervisor/src/main.rs`.

_PR submitted by @rgbkrk's agent Quill, via Zed_