### PR TITLE
fix(trust): retry trust check on daemon:ready to fix session restore race

### DIFF
--- a/apps/notebook/src/hooks/useTrust.ts
+++ b/apps/notebook/src/hooks/useTrust.ts
@@ -1,4 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
+import { getCurrentWebview } from "@tauri-apps/api/webview";
 import { useCallback, useEffect, useState } from "react";
 import { logger } from "../lib/logger";
 
@@ -53,7 +54,11 @@ export function useTrust() {
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
       setError(message);
-      logger.error("Failed to check trust:", e);
+      if (message === "Not connected to daemon") {
+        logger.debug("Trust check deferred: daemon not yet connected");
+      } else {
+        logger.error("Failed to check trust:", e);
+      }
       return null;
     } finally {
       setLoading(false);
@@ -82,6 +87,18 @@ export function useTrust() {
   // Check trust on mount
   useEffect(() => {
     checkTrust();
+  }, [checkTrust]);
+
+  // Re-check trust when daemon (re)connects — handles the startup race where
+  // the initial mount-time check fires before the relay handle is stored.
+  useEffect(() => {
+    const webview = getCurrentWebview();
+    const unlistenReady = webview.listen("daemon:ready", () => {
+      checkTrust();
+    });
+    return () => {
+      unlistenReady.then((unlisten) => unlisten()).catch(() => {});
+    };
   }, [checkTrust]);
 
   // Computed properties


### PR DESCRIPTION
## Problem

On nightly session restore, untitled notebooks displayed console errors:
- `Failed to check trust: "Not connected to daemon"`
- `sync to relay failed: "Not connected to daemon"`

This prevented kernel auto-start, leaving the notebook in a broken state.

## Root Cause

`useTrust` was the only frontend hook without `daemon:ready` recovery. On startup, it called `checkTrust()` on mount before the daemon relay handle was stored, failed permanently, and blocked kernel initialization.

## Solution

- Add `daemon:ready` event listener that retries `checkTrust()` when the daemon connects (mirrors existing pattern in `useDaemonKernel` and `useAutomergeNotebook`)
- Downgrade "Not connected to daemon" error to debug level—this is an expected transient condition during startup

## Verification

- [x] `cargo test --verbose` passes (118 tests)
- [x] `cargo xtask lint --fix` passes
- Session restore should now proceed cleanly without console errors
- Kernel should auto-start after daemon connects

## Follow-up

A deeper fix is planned to defer secondary window sync until after daemon availability is confirmed (Rust-side change in `setup()`).

---

_PR submitted by @rgbkrk's agent, Quill_