### PR TITLE
fix(notebook-sync): improve daemon socket unavailable error messages

### DIFF
--- a/crates/notebook-sync/src/connect.rs
+++ b/crates/notebook-sync/src/connect.rs
@@ -100,17 +100,38 @@ pub struct RelayCreateResult {
 /// On Windows: `tokio::net::windows::named_pipe::ClientOptions::new().open`
 macro_rules! connect_stream {
     ($socket_path:expr) => {{
-        #[cfg(unix)]
-        {
-            tokio::net::UnixStream::connect($socket_path)
-                .await
-                .map_err(SyncError::Io)?
-        }
-        #[cfg(windows)]
-        {
-            tokio::net::windows::named_pipe::ClientOptions::new()
-                .open($socket_path)
-                .map_err(SyncError::Io)?
+        let path = $socket_path;
+        let result = {
+            #[cfg(unix)]
+            {
+                tokio::net::UnixStream::connect(path).await
+            }
+            #[cfg(windows)]
+            {
+                tokio::net::windows::named_pipe::ClientOptions::new().open(path)
+            }
+        };
+        match result {
+            Ok(stream) => stream,
+            Err(e) => {
+                let path_display = path.display();
+                return Err(match e.kind() {
+                    std::io::ErrorKind::NotFound => SyncError::DaemonUnavailable(format!(
+                        "Daemon is not running. Socket not found at {path_display}. \
+                         Start the daemon with `runt daemon start` or `cargo xtask dev-daemon`."
+                    )),
+                    std::io::ErrorKind::ConnectionRefused => SyncError::DaemonUnavailable(format!(
+                        "Daemon connection refused at {path_display}. \
+                             The daemon may have crashed. Try restarting with \
+                             `runt daemon start` or `cargo xtask dev-daemon`."
+                    )),
+                    std::io::ErrorKind::PermissionDenied => SyncError::DaemonUnavailable(format!(
+                        "Permission denied connecting to daemon socket at {path_display}. \
+                             Check socket file permissions."
+                    )),
+                    _ => SyncError::Io(e),
+                });
+            }
         }
     }};
 }

--- a/crates/notebook-sync/src/connect.rs
+++ b/crates/notebook-sync/src/connect.rs
@@ -116,19 +116,28 @@ macro_rules! connect_stream {
             Err(e) => {
                 let path_display = path.display();
                 return Err(match e.kind() {
-                    std::io::ErrorKind::NotFound => SyncError::DaemonUnavailable(format!(
-                        "Daemon is not running. Socket not found at {path_display}. \
-                         Start the daemon with `runt daemon start` or `cargo xtask dev-daemon`."
-                    )),
-                    std::io::ErrorKind::ConnectionRefused => SyncError::DaemonUnavailable(format!(
-                        "Daemon connection refused at {path_display}. \
+                    std::io::ErrorKind::NotFound => SyncError::DaemonUnavailable {
+                        message: format!(
+                            "Daemon is not running. Endpoint not found at {path_display}. \
+                             Start the daemon with `runt daemon start` or `cargo xtask dev-daemon`."
+                        ),
+                        source: e,
+                    },
+                    std::io::ErrorKind::ConnectionRefused => SyncError::DaemonUnavailable {
+                        message: format!(
+                            "Daemon connection refused at {path_display}. \
                              The daemon may have crashed. Try restarting with \
                              `runt daemon start` or `cargo xtask dev-daemon`."
-                    )),
-                    std::io::ErrorKind::PermissionDenied => SyncError::DaemonUnavailable(format!(
-                        "Permission denied connecting to daemon socket at {path_display}. \
-                             Check socket file permissions."
-                    )),
+                        ),
+                        source: e,
+                    },
+                    std::io::ErrorKind::PermissionDenied => SyncError::DaemonUnavailable {
+                        message: format!(
+                            "Permission denied connecting to daemon at {path_display}. \
+                             Check file permissions."
+                        ),
+                        source: e,
+                    },
                     _ => SyncError::Io(e),
                 });
             }

--- a/crates/notebook-sync/src/error.rs
+++ b/crates/notebook-sync/src/error.rs
@@ -15,6 +15,10 @@ pub enum SyncError {
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),
 
+    /// The daemon socket is not available (not running, crashed, or permission issue).
+    #[error("{0}")]
+    DaemonUnavailable(String),
+
     /// The sync task has stopped (channels closed).
     #[error("Disconnected from sync task")]
     Disconnected,

--- a/crates/notebook-sync/src/error.rs
+++ b/crates/notebook-sync/src/error.rs
@@ -15,9 +15,13 @@ pub enum SyncError {
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),
 
-    /// The daemon socket is not available (not running, crashed, or permission issue).
-    #[error("{0}")]
-    DaemonUnavailable(String),
+    /// The daemon endpoint is not available (not running, crashed, or permission issue).
+    #[error("{message}")]
+    DaemonUnavailable {
+        message: String,
+        #[source]
+        source: std::io::Error,
+    },
 
     /// The sync task has stopped (channels closed).
     #[error("Disconnected from sync task")]

--- a/crates/notebook-sync/src/tests.rs
+++ b/crates/notebook-sync/src/tests.rs
@@ -960,4 +960,32 @@ mod integration_tests {
             actors
         );
     }
+
+    #[tokio::test]
+    async fn test_connect_to_missing_socket_returns_daemon_unavailable() {
+        use std::error::Error;
+        use std::path::PathBuf;
+
+        let bogus_path = PathBuf::from("/tmp/nonexistent-runtimed-test.sock");
+        let result = crate::connect::connect(bogus_path.clone(), "test-notebook".to_string()).await;
+
+        let err = match result {
+            Err(e) => e,
+            Ok(_) => panic!("should fail to connect to nonexistent socket"),
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("Daemon is not running"),
+            "expected DaemonUnavailable, got: {msg}"
+        );
+        assert!(
+            msg.contains("nonexistent-runtimed-test.sock"),
+            "expected path in error message, got: {msg}"
+        );
+        // Verify the source error is preserved
+        assert!(
+            err.source().is_some(),
+            "expected source io::Error to be preserved"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

When the daemon is not running or unreachable, clients now receive actionable error messages that include the socket path and recovery instructions, instead of the opaque "I/O error: No such file or directory (os error 2)".

The `connect_stream!` macro classifies socket errors by `io::ErrorKind`:
* `NotFound` → "Daemon is not running. Socket not found at {path}..."
* `ConnectionRefused` → "Daemon connection refused. The daemon may have crashed..."
* `PermissionDenied` → "Permission denied connecting to daemon socket..."

## Testing

* [x] Lint and formatting pass (`cargo xtask lint --fix`)
* [x] Unit tests pass (`cargo test`)
* [x] Error variant is additive; no exhaustive matches to update

## Verification

To verify the improved error message:

* [ ] Stop the daemon with `runt daemon stop` or `cargo xtask dev-daemon` in another terminal
* [ ] From Python: `await runtimed.AsyncSession.create_notebook()` and verify the error contains "Daemon is not running" and the socket path
* [ ] From Tauri: Open a notebook file when daemon is stopped and verify error message in console

---

_PR submitted by @rgbkrk's agent, Quill_