### PR TITLE
fix(kernel-manager): suppress EPERM when killing process groups

### DIFF
--- a/crates/runtimed/src/kernel_manager.rs
+++ b/crates/runtimed/src/kernel_manager.rs
@@ -2117,11 +2117,22 @@ impl RoomKernel {
             use nix::sys::signal::{killpg, Signal};
             use nix::unistd::Pid;
             if let Err(e) = killpg(Pid::from_raw(pgid), Signal::SIGKILL) {
-                if e != nix::errno::Errno::ESRCH {
-                    error!(
-                        "[kernel-manager] Failed to kill process group {}: {}",
-                        pgid, e
-                    );
+                match e {
+                    // Process group already gone — nothing to do
+                    nix::errno::Errno::ESRCH => {}
+                    // No permission — process group was likely reparented after kernel exited
+                    nix::errno::Errno::EPERM => {
+                        debug!(
+                            "[kernel-manager] No permission to kill process group {} (likely already exited)",
+                            pgid
+                        );
+                    }
+                    other => {
+                        error!(
+                            "[kernel-manager] Failed to kill process group {}: {}",
+                            pgid, other
+                        );
+                    }
                 }
             }
         }

--- a/crates/runtimed/src/kernel_manager.rs
+++ b/crates/runtimed/src/kernel_manager.rs
@@ -2120,10 +2120,10 @@ impl RoomKernel {
                 match e {
                     // Process group already gone — nothing to do
                     nix::errno::Errno::ESRCH => {}
-                    // No permission — process group was likely reparented after kernel exited
+                    // Permission denied — pgid may have been reused or is no longer ours
                     nix::errno::Errno::EPERM => {
                         debug!(
-                            "[kernel-manager] No permission to kill process group {} (likely already exited)",
+                            "[kernel-manager] Permission denied killing process group {}",
                             pgid
                         );
                     }

--- a/crates/runtimed/src/kernel_pids.rs
+++ b/crates/runtimed/src/kernel_pids.rs
@@ -159,10 +159,11 @@ pub fn reap_orphaned_kernels() -> usize {
             }
             Err(nix::errno::Errno::EPERM) => {
                 warn!(
-                    "[kernel-pids] No permission to kill orphaned kernel '{}' (pgid {})",
+                    "[kernel-pids] No permission to kill orphaned kernel '{}' (pgid {}), \
+                     removing from registry (process likely already exited and was reparented)",
                     kernel_id, entry.pgid
                 );
-                false
+                true
             }
             Err(e) => {
                 error!(

--- a/crates/runtimed/src/kernel_pids.rs
+++ b/crates/runtimed/src/kernel_pids.rs
@@ -141,7 +141,7 @@ pub fn reap_orphaned_kernels() -> usize {
             continue;
         }
 
-        let kill_succeeded = match killpg(Pid::from_raw(entry.pgid), Signal::SIGKILL) {
+        let should_remove = match killpg(Pid::from_raw(entry.pgid), Signal::SIGKILL) {
             Ok(()) => {
                 info!(
                     "[kernel-pids] Reaped orphaned kernel '{}' (pgid {})",
@@ -159,8 +159,8 @@ pub fn reap_orphaned_kernels() -> usize {
             }
             Err(nix::errno::Errno::EPERM) => {
                 warn!(
-                    "[kernel-pids] No permission to kill orphaned kernel '{}' (pgid {}), \
-                     removing from registry (process likely already exited and was reparented)",
+                    "[kernel-pids] Permission denied killing orphaned kernel '{}' (pgid {}), \
+                     removing stale entry from registry",
                     kernel_id, entry.pgid
                 );
                 true
@@ -174,7 +174,7 @@ pub fn reap_orphaned_kernels() -> usize {
             }
         };
 
-        if !kill_succeeded {
+        if !should_remove {
             failed_entries.insert(kernel_id, entry);
         }
     }


### PR DESCRIPTION
## Summary

When killing kernel process groups during shutdown, EPERM (permission denied) errors are treated as non-fatal — the process group was likely reparented to init after the kernel exited. Also, stale EPERM entries are now removed from `kernels.json` instead of being re-persisted on every daemon restart, which was causing infinite retries and potential registry bloat.

## Changes

- `kernel_manager.rs`: Log EPERM at debug level instead of error when killing process groups during shutdown
- `kernel_pids.rs`: Return success (true) for EPERM in `reap_orphaned_kernels()`, removing stale entries from the registry instead of persisting them back

## Verification

- [ ] Restart daemon multiple times and verify `kernels.json` is cleaned up
- [ ] Kill a kernel mid-execution and verify no repeated EPERM errors in daemon logs
- [ ] Confirm normal kernel shutdown still works with process groups cleaned up properly

_PR submitted by @rgbkrk's agent, Quill_