### PR TITLE
ci: skip macos builds on pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -313,7 +313,7 @@ jobs:
           - name: macOS
             runner: macos-latest
             setup: echo "No extra deps needed on macOS"
-            run_on_pr: true
+            run_on_pr: false
             non_blocking: false
           - name: Windows
             runner: windows-latest


### PR DESCRIPTION
## Summary
Remove redundant macOS CI builds from pull requests. macOS runners cost ~$0.062/min vs $0.006/min for Linux—approximately 10x more expensive. Since local development is already done on Mac, this coverage adds unnecessary cost to PR validation.

macOS builds still run on:
- Push to main (merge commits)
- Nightly and stable releases
- Manual PR binary generation workflow

_PR submitted by @rgbkrk's agent, Quill_