### PR TITLE
feat(notebook): autosave .ipynb files on daemon

### DIFF
--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -19,12 +19,16 @@ import {
   updateNotebookCells,
   useNotebookCells,
 } from "../lib/notebook-cells";
-import { emitBroadcast, emitPresence } from "../lib/notebook-frame-bus";
+import {
+  emitBroadcast,
+  emitPresence,
+  subscribeBroadcast,
+} from "../lib/notebook-frame-bus";
 import {
   notifyMetadataChanged,
   setNotebookHandle,
 } from "../lib/notebook-metadata";
-import type { JupyterOutput } from "../types";
+import type { DaemonBroadcast, JupyterOutput } from "../types";
 import init, { NotebookHandle } from "../wasm/runtimed-wasm/runtimed_wasm.js";
 
 // ---------------------------------------------------------------------------
@@ -79,6 +83,17 @@ export function useAutomergeNotebook() {
   useEffect(() => {
     refreshBlobPort();
   }, [refreshBlobPort]);
+
+  // Clear dirty state when daemon autosaves the notebook to disk.
+  useEffect(() => {
+    return subscribeBroadcast((payload) => {
+      const broadcast = payload as DaemonBroadcast;
+      if (broadcast.event === "notebook_autosaved") {
+        setDirty(false);
+        invoke("mark_notebook_clean").catch(() => {});
+      }
+    });
+  }, []);
 
   // ── Helpers ────────────────────────────────────────────────────────
 

--- a/apps/notebook/src/types.ts
+++ b/apps/notebook/src/types.ts
@@ -219,6 +219,10 @@ export type DaemonBroadcast =
     }
   | {
       event: "file_changed";
+    }
+  | {
+      event: "notebook_autosaved";
+      path: string;
     };
 
 /** Response types from daemon notebook requests */

--- a/crates/notebook-protocol/src/protocol.rs
+++ b/crates/notebook-protocol/src/protocol.rs
@@ -527,4 +527,7 @@ pub enum NotebookBroadcast {
         #[serde(skip_serializing_if = "Option::is_none")]
         diff: Option<EnvSyncDiff>,
     },
+
+    /// Notebook was autosaved to disk by the daemon.
+    NotebookAutosaved { path: String },
 }

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -1432,6 +1432,18 @@ async fn has_notebook_path(
     Ok(path.is_some())
 }
 
+/// Clear the Tauri-side dirty flag. Called by the frontend when the daemon
+/// autosaves the notebook, so the flag stays in sync without a full save round-trip.
+#[tauri::command]
+fn mark_notebook_clean(
+    window: tauri::Window,
+    registry: tauri::State<'_, WindowNotebookRegistry>,
+) -> Result<(), String> {
+    let dirty = dirty_for_window(&window, registry.inner())?;
+    dirty.store(false, Ordering::SeqCst);
+    Ok(())
+}
+
 /// Format all code cells in the notebook and save.
 /// Formatting is best-effort - cells that fail to format are saved as-is.
 ///
@@ -3426,6 +3438,7 @@ pub fn run(
         .invoke_handler(tauri::generate_handler![
             // Notebook file operations
             has_notebook_path,
+            mark_notebook_clean,
             save_notebook,
             save_notebook_as,
             get_default_save_directory,

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -718,6 +718,9 @@ pub fn get_or_create_room(
                         *guard = Some(shutdown_tx);
                     }
                 }
+
+                // Spawn autosave debouncer to keep .ipynb on disk current
+                spawn_autosave_debouncer(notebook_id.to_string(), room.clone());
             }
 
             room
@@ -3730,6 +3733,98 @@ fn spawn_persist_debouncer_with_config(
                             do_persist(&data, &persist_path);
                             last_flush = Some(Instant::now());
                             last_receive = None;
+                        }
+                    }
+                }
+            }
+        }
+    });
+}
+
+/// Spawn a debounced autosave task that writes the `.ipynb` file to disk
+/// whenever the Automerge document changes. Only for saved (non-untitled)
+/// notebooks. Does NOT format cells — formatting is reserved for explicit saves.
+fn spawn_autosave_debouncer(notebook_id: String, room: Arc<NotebookRoom>) {
+    let mut changed_rx = room.changed_tx.subscribe();
+    tokio::spawn(async move {
+        use std::time::Duration;
+        use tokio::time::{interval, Instant, MissedTickBehavior};
+
+        let debounce_duration = Duration::from_secs(2);
+        let max_flush_interval = Duration::from_secs(10);
+
+        let mut last_receive: Option<Instant> = None;
+        let mut last_flush: Option<Instant> = None;
+
+        let mut check_interval = interval(Duration::from_millis(500));
+        check_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
+        loop {
+            tokio::select! {
+                result = changed_rx.recv() => {
+                    match result {
+                        Ok(()) => {
+                            last_receive = Some(Instant::now());
+                        }
+                        Err(broadcast::error::RecvError::Closed) => {
+                            // Room is being evicted — do a final autosave
+                            if !is_untitled_notebook(&notebook_id)
+                                && !room.is_loading.load(Ordering::Relaxed)
+                            {
+                                match save_notebook_to_disk(&room, None).await {
+                                    Ok(path) => {
+                                        info!("[autosave] Final save on room close: {}", path);
+                                    }
+                                    Err(e) => {
+                                        warn!("[autosave] Final save failed: {}", e);
+                                    }
+                                }
+                            }
+                            break;
+                        }
+                        Err(broadcast::error::RecvError::Lagged(n)) => {
+                            // Missed some updates, treat as a change
+                            debug!("[autosave] Lagged {} messages", n);
+                            last_receive = Some(Instant::now());
+                        }
+                    }
+                }
+                _ = check_interval.tick() => {
+                    let should_flush = if let Some(recv) = last_receive {
+                        let debounce_ready = recv.elapsed() >= debounce_duration;
+                        let max_interval_ready = last_flush
+                            .map(|f| f.elapsed() >= max_flush_interval)
+                            .unwrap_or(recv.elapsed() >= max_flush_interval);
+                        debounce_ready || max_interval_ready
+                    } else {
+                        false
+                    };
+
+                    if should_flush {
+                        // Skip during initial load
+                        if room.is_loading.load(Ordering::Relaxed) {
+                            continue;
+                        }
+
+                        match save_notebook_to_disk(&room, None).await {
+                            Ok(path) => {
+                                debug!("[autosave] Saved {}", path);
+                                last_flush = Some(Instant::now());
+                                last_receive = None;
+
+                                // Broadcast to connected clients so they can clear dirty state
+                                let _ = room.kernel_broadcast_tx.send(
+                                    NotebookBroadcast::NotebookAutosaved {
+                                        path,
+                                    },
+                                );
+                            }
+                            Err(e) => {
+                                warn!("[autosave] Failed to save: {}", e);
+                                // Reset receive so we retry on next interval
+                                last_flush = Some(Instant::now());
+                                last_receive = None;
+                            }
                         }
                     }
                 }

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -3741,22 +3741,51 @@ fn spawn_persist_debouncer_with_config(
     });
 }
 
+/// Configuration for the autosave debouncer (testable).
+struct AutosaveDebouncerConfig {
+    /// Quiet period: flush only after no changes for this long.
+    debounce_ms: u64,
+    /// Max interval: flush even during continuous changes after this long.
+    max_interval_ms: u64,
+    /// How often to check whether a flush is due.
+    check_interval_ms: u64,
+}
+
+impl Default for AutosaveDebouncerConfig {
+    fn default() -> Self {
+        Self {
+            debounce_ms: 2_000,
+            max_interval_ms: 10_000,
+            check_interval_ms: 500,
+        }
+    }
+}
+
 /// Spawn a debounced autosave task that writes the `.ipynb` file to disk
 /// whenever the Automerge document changes. Only for saved (non-untitled)
 /// notebooks. Does NOT format cells — formatting is reserved for explicit saves.
 fn spawn_autosave_debouncer(notebook_id: String, room: Arc<NotebookRoom>) {
+    spawn_autosave_debouncer_with_config(notebook_id, room, AutosaveDebouncerConfig::default());
+}
+
+/// Spawn autosave debouncer with custom timing configuration (for testing).
+fn spawn_autosave_debouncer_with_config(
+    notebook_id: String,
+    room: Arc<NotebookRoom>,
+    config: AutosaveDebouncerConfig,
+) {
     let mut changed_rx = room.changed_tx.subscribe();
     tokio::spawn(async move {
         use std::time::Duration;
         use tokio::time::{interval, Instant, MissedTickBehavior};
 
-        let debounce_duration = Duration::from_secs(2);
-        let max_flush_interval = Duration::from_secs(10);
+        let debounce_duration = Duration::from_millis(config.debounce_ms);
+        let max_flush_interval = Duration::from_millis(config.max_interval_ms);
 
         let mut last_receive: Option<Instant> = None;
         let mut last_flush: Option<Instant> = None;
 
-        let mut check_interval = interval(Duration::from_millis(500));
+        let mut check_interval = interval(Duration::from_millis(config.check_interval_ms));
         check_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
         loop {
@@ -3769,7 +3798,7 @@ fn spawn_autosave_debouncer(notebook_id: String, room: Arc<NotebookRoom>) {
                         Err(broadcast::error::RecvError::Closed) => {
                             // Room is being evicted — do a final autosave
                             if !is_untitled_notebook(&notebook_id)
-                                && !room.is_loading.load(Ordering::Relaxed)
+                                && !room.is_loading.load(Ordering::Acquire)
                             {
                                 match save_notebook_to_disk(&room, None).await {
                                     Ok(path) => {
@@ -3802,7 +3831,7 @@ fn spawn_autosave_debouncer(notebook_id: String, room: Arc<NotebookRoom>) {
 
                     if should_flush {
                         // Skip during initial load
-                        if room.is_loading.load(Ordering::Relaxed) {
+                        if room.is_loading.load(Ordering::Acquire) {
                             continue;
                         }
 
@@ -3810,20 +3839,28 @@ fn spawn_autosave_debouncer(notebook_id: String, room: Arc<NotebookRoom>) {
                             Ok(path) => {
                                 debug!("[autosave] Saved {}", path);
                                 last_flush = Some(Instant::now());
-                                last_receive = None;
 
-                                // Broadcast to connected clients so they can clear dirty state
-                                let _ = room.kernel_broadcast_tx.send(
-                                    NotebookBroadcast::NotebookAutosaved {
-                                        path,
-                                    },
-                                );
+                                // Check if changes arrived during the save. If so,
+                                // keep last_receive set so we flush again soon —
+                                // don't broadcast "clean" when the file is already stale.
+                                let changed_during_save =
+                                    matches!(changed_rx.try_recv(), Ok(()) | Err(broadcast::error::TryRecvError::Lagged(_)));
+                                if changed_during_save {
+                                    last_receive = Some(Instant::now());
+                                } else {
+                                    last_receive = None;
+                                    // Broadcast to connected clients so they can clear dirty state
+                                    let _ = room.kernel_broadcast_tx.send(
+                                        NotebookBroadcast::NotebookAutosaved {
+                                            path,
+                                        },
+                                    );
+                                }
                             }
                             Err(e) => {
                                 warn!("[autosave] Failed to save: {}", e);
-                                // Reset receive so we retry on next interval
+                                // Keep last_receive set so we retry on next interval
                                 last_flush = Some(Instant::now());
-                                last_receive = None;
                             }
                         }
                     }


### PR DESCRIPTION
## Summary

Adds daemon-side autosave for saved (non-untitled) notebooks. When the Automerge document changes, the daemon now writes the `.ipynb` file to disk on a 2-second debounce without formatting. The frontend's dirty indicator is cleared when autosave completes.

Previously, closing the app without pressing Cmd+S would lose all work. Now the file is kept current automatically — formatting (ruff/deno fmt) is reserved for explicit saves, so autosave doesn't interrupt your flow.

Closes #781

## Verification

- [ ] Open a saved notebook and edit cells
- [ ] Verify the `.ipynb` file on disk is updated within 2 seconds
- [ ] Verify the dirty bullet disappears from the save button
- [ ] Verify untitled notebooks still persist only to Automerge binary (no `.ipynb` created)
- [ ] Press Cmd+S and verify code is formatted as before

_PR submitted by @rgbkrk's agent, Quill_