### PR TITLE
fix(daemon-error): context-aware error messages for unavailable daemon

### DIFF
--- a/crates/notebook-sync/src/connect.rs
+++ b/crates/notebook-sync/src/connect.rs
@@ -118,7 +118,7 @@ macro_rules! connect_stream {
                 return Err(match e.kind() {
                     std::io::ErrorKind::NotFound => SyncError::DaemonUnavailable {
                         message: format!(
-                            "Daemon is not running. Socket not found at {path_display}."
+                            "Daemon is not running. Endpoint not found at {path_display}."
                         ),
                         source: e,
                     },

--- a/crates/notebook-sync/src/connect.rs
+++ b/crates/notebook-sync/src/connect.rs
@@ -118,16 +118,14 @@ macro_rules! connect_stream {
                 return Err(match e.kind() {
                     std::io::ErrorKind::NotFound => SyncError::DaemonUnavailable {
                         message: format!(
-                            "Daemon is not running. Endpoint not found at {path_display}. \
-                             Start the daemon with `runt daemon start` or `cargo xtask dev-daemon`."
+                            "Daemon is not running. Socket not found at {path_display}."
                         ),
                         source: e,
                     },
                     std::io::ErrorKind::ConnectionRefused => SyncError::DaemonUnavailable {
                         message: format!(
                             "Daemon connection refused at {path_display}. \
-                             The daemon may have crashed. Try restarting with \
-                             `runt daemon start` or `cargo xtask dev-daemon`."
+                             The daemon may have crashed or is restarting."
                         ),
                         source: e,
                     },

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -2325,10 +2325,9 @@ async fn reconnect_to_daemon(
             // In dev mode, don't attempt recovery - show helpful guidance
             if runtimed::is_dev_mode() {
                 reset_flag();
-                return Err(format!(
-                    "Dev daemon not running. {}",
-                    runt_workspace::daemon_start_guidance()
-                ));
+                return Err(
+                    "Dev daemon not running. Start it with: cargo xtask dev-daemon".to_string(),
+                );
             }
 
             // Try to acquire the restart flag (only one window should restart)
@@ -3805,7 +3804,7 @@ pub fn run(
                     let _ = app_for_autolaunch.emit("daemon:unavailable", serde_json::json!({
                         "reason": "sync_timeout",
                         "message": "Daemon sync timed out. The runtime daemon may not be running.",
-                        "guidance": runt_workspace::daemon_start_guidance()
+                        "guidance": runt_workspace::daemon_unavailable_guidance()
                     }));
                 } else if daemon_sync_success_for_autolaunch.load(Ordering::SeqCst) {
                     // Daemon sync succeeded - daemon handles auto-launch
@@ -3822,7 +3821,7 @@ pub fn run(
                     let _ = app_for_autolaunch.emit("daemon:unavailable", serde_json::json!({
                         "reason": "sync_failed",
                         "message": "Failed to connect to runtime daemon.",
-                        "guidance": runt_workspace::daemon_start_guidance()
+                        "guidance": runt_workspace::daemon_unavailable_guidance()
                     }));
                 }
             });

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -2325,9 +2325,10 @@ async fn reconnect_to_daemon(
             // In dev mode, don't attempt recovery - show helpful guidance
             if runtimed::is_dev_mode() {
                 reset_flag();
-                return Err(
-                    "Dev daemon not running. Start it with: cargo xtask dev-daemon".to_string(),
-                );
+                return Err(format!(
+                    "Dev daemon not running. {}",
+                    runt_workspace::daemon_start_guidance()
+                ));
             }
 
             // Try to acquire the restart flag (only one window should restart)
@@ -3804,10 +3805,7 @@ pub fn run(
                     let _ = app_for_autolaunch.emit("daemon:unavailable", serde_json::json!({
                         "reason": "sync_timeout",
                         "message": "Daemon sync timed out. The runtime daemon may not be running.",
-                        "guidance": format!(
-                            "Run 'cargo xtask dev-daemon' in another terminal (dev mode), or check daemon status with '{} daemon status'.",
-                            runt_workspace::cli_command_name()
-                        )
+                        "guidance": runt_workspace::daemon_start_guidance()
                     }));
                 } else if daemon_sync_success_for_autolaunch.load(Ordering::SeqCst) {
                     // Daemon sync succeeded - daemon handles auto-launch
@@ -3824,10 +3822,7 @@ pub fn run(
                     let _ = app_for_autolaunch.emit("daemon:unavailable", serde_json::json!({
                         "reason": "sync_failed",
                         "message": "Failed to connect to runtime daemon.",
-                        "guidance": format!(
-                            "Run 'cargo xtask dev-daemon' in another terminal (dev mode), or check daemon status with '{} daemon status'.",
-                            runt_workspace::cli_command_name()
-                        )
+                        "guidance": runt_workspace::daemon_start_guidance()
                     }));
                 }
             });

--- a/crates/runt-workspace/src/lib.rs
+++ b/crates/runt-workspace/src/lib.rs
@@ -147,6 +147,21 @@ pub fn channel_display_name() -> &'static str {
     }
 }
 
+/// Context-aware guidance string for when the daemon is unavailable.
+///
+/// Returns appropriate instructions based on whether the user is in
+/// dev mode (building from source) or running a released build.
+pub fn daemon_start_guidance() -> String {
+    if is_dev_mode() {
+        "Start the dev daemon with: cargo xtask dev-daemon".to_string()
+    } else {
+        format!(
+            "Check daemon status with: {} daemon status",
+            cli_command_name()
+        )
+    }
+}
+
 // ============================================================================
 // Desktop App Launching
 // ============================================================================

--- a/crates/runt-workspace/src/lib.rs
+++ b/crates/runt-workspace/src/lib.rs
@@ -151,7 +151,7 @@ pub fn channel_display_name() -> &'static str {
 ///
 /// Returns appropriate instructions based on whether the user is in
 /// dev mode (building from source) or running a released build.
-pub fn daemon_start_guidance() -> String {
+pub fn daemon_unavailable_guidance() -> String {
     if is_dev_mode() {
         "Start the dev daemon with: cargo xtask dev-daemon".to_string()
     } else {


### PR DESCRIPTION
When the daemon is unavailable, error messages should adapt based on the build mode:

* **Dev mode**: Users see "Start the dev daemon with: cargo xtask dev-daemon"
* **Nightly**: Users see "Check daemon status with: runt-nightly daemon status"
* **Stable**: Users see "Check daemon status with: runt daemon status"

Previously, nightly and stable users were always told to run `cargo xtask dev-daemon`, a developer-only command that doesn't apply to them.

## Changes

- Add `daemon_start_guidance()` helper in `runt-workspace` that returns appropriate guidance based on `is_dev_mode()` and `build_channel()`
- Remove hardcoded command suggestions from the low-level `notebook-sync` connect macro — it now emits neutral, factual error messages
- Replace three error message sites in `notebook/src/lib.rs` to use the new helper

## Verification

* [ ] Run nightly build, kill daemon, click Retry → verify no `cargo xtask` in error banner
* [ ] Verify dev mode still shows the cargo xtask command
* [ ] Verify stable build shows `runt daemon status` (not `runt-nightly`)

_PR submitted by @rgbkrk's agent, Quill_