### PR TITLE
fix(runtimed): reduce daemon restart churn and improve diagnostics

### DIFF
--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -424,9 +424,11 @@ impl Daemon {
                 tokio::fs::create_dir_all(parent).await?;
             }
 
-            // Remove stale socket file
+            // Remove stale socket file (use .ok() since the singleton lock
+            // guarantees exclusivity — if removal fails, bind will report the
+            // real error)
             if self.config.socket_path.exists() {
-                tokio::fs::remove_file(&self.config.socket_path).await?;
+                tokio::fs::remove_file(&self.config.socket_path).await.ok();
             }
 
             // Clean up obsolete sync socket from pre-unification daemons

--- a/crates/runtimed/src/main.rs
+++ b/crates/runtimed/src/main.rs
@@ -6,7 +6,7 @@
 use std::path::PathBuf;
 
 use clap::{Parser, Subcommand};
-use log::{error, info};
+use log::info;
 use runtimed::client::PoolClient;
 use runtimed::daemon::{Daemon, DaemonConfig};
 use runtimed::service::ServiceManager;
@@ -340,16 +340,14 @@ async fn run_daemon(
     let daemon = match Daemon::new(config) {
         Ok(d) => d,
         Err(e) => {
-            error!(
-                "Daemon already running: pid={}, endpoint={}",
+            // Another daemon is already running — this is expected during
+            // launchd double-start races, NOT a crash. Exit 0 so launchd's
+            // KeepAlive.Crashed does not restart us.
+            early_log(&format!(
+                "Another daemon already running (pid={}, endpoint={}), exiting cleanly",
                 e.info.pid, e.info.endpoint
-            );
-            eprintln!("Error: {}", e);
-            eprintln!(
-                "Running daemon: pid={}, endpoint={}",
-                e.info.pid, e.info.endpoint
-            );
-            std::process::exit(1);
+            ));
+            std::process::exit(0);
         }
     };
 
@@ -369,17 +367,22 @@ async fn run_daemon(
 
             tokio::select! {
                 _ = sigterm.recv() => {
-                    info!("[runtimed] Received SIGTERM");
+                    early_log("Received SIGTERM, initiating shutdown");
                 }
                 _ = sigint.recv() => {
-                    info!("[runtimed] Received SIGINT");
+                    early_log("Received SIGINT, initiating shutdown");
                 }
             }
             shutdown_daemon.trigger_shutdown().await;
         });
     }
 
-    daemon.run().await
+    let result = daemon.run().await;
+    match &result {
+        Ok(()) => early_log("Daemon exited: Ok (graceful shutdown)"),
+        Err(e) => early_log(&format!("Daemon exited: Err: {}", e)),
+    }
+    result
 }
 
 fn install_service(binary: Option<PathBuf>) -> anyhow::Result<()> {

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -641,7 +641,7 @@ impl NotebookRoom {
             NotebookDoc::new_with_actor(notebook_id, runtimed_actor)
         };
         let (changed_tx, _) = broadcast::channel(16);
-        let (kernel_broadcast_tx, _) = broadcast::channel(64);
+        let (kernel_broadcast_tx, _) = broadcast::channel(256);
 
         // Spawn debounced persistence task (watch channel keeps latest value only)
         let (persist_tx, persist_rx) = watch::channel::<Option<Vec<u8>>>(None);
@@ -707,7 +707,7 @@ impl NotebookRoom {
         let persist_path = docs_dir.join(filename);
         let doc = NotebookDoc::load_or_create(&persist_path, notebook_id);
         let (changed_tx, _) = broadcast::channel(16);
-        let (kernel_broadcast_tx, _) = broadcast::channel(64);
+        let (kernel_broadcast_tx, _) = broadcast::channel(256);
         let (persist_tx, persist_rx) = watch::channel::<Option<Vec<u8>>>(None);
         spawn_persist_debouncer(persist_rx, persist_path.clone());
         let (presence_tx, _) = broadcast::channel(64);
@@ -5695,7 +5695,7 @@ mod tests {
 
         let doc = crate::notebook_doc::NotebookDoc::new(&notebook_id);
         let (changed_tx, _) = broadcast::channel(16);
-        let (kernel_broadcast_tx, _) = broadcast::channel(64);
+        let (kernel_broadcast_tx, _) = broadcast::channel(256);
         let persist_path = tmp.path().join("doc.automerge");
         let (persist_tx, persist_rx) = watch::channel::<Option<Vec<u8>>>(None);
         spawn_persist_debouncer(persist_rx, persist_path.clone());


### PR DESCRIPTION
## Summary

The daemon was restarting frequently due to two underlying issues:

1. **Singleton race exit code**: When the daemon lost the singleton lock race, it exited with code 1, which launchd interpreted as a crash and triggered unnecessary restarts
2. **Invisible lifecycle logging**: All lifecycle events used `info!()` which is invisible at the default `warn` log level, making it impossible to diagnose silent crashes

## Changes

- Exit with code 0 when another daemon is already running (singleton race is not a crash)
- Promote critical lifecycle events to `early_log()` to always appear in the log file
- Make stale socket removal resilient to errors (use `.ok()` instead of `?`)
- Increase kernel broadcast channel capacity from 64 to 256 to reduce "Peer lagged" events under heavy output

## Verification

- [ ] Manual test: After `cargo xtask install-daemon`, start two daemon instances and verify the loser exits cleanly without causing a launchd restart
- [ ] Verify daemon logs show lifecycle events (signal receipt, shutdown status) even when logger is at default `warn` level
- [ ] Kill the daemon and verify launchd correctly restarts it (non-zero exit path should still work)

_PR submitted by @rgbkrk's agent, Quill_