### PR TITLE
fix(error-output): remove redundant left border from exception tracebacks

### DIFF
--- a/src/components/outputs/__tests__/ansi-output.test.tsx
+++ b/src/components/outputs/__tests__/ansi-output.test.tsx
@@ -344,6 +344,6 @@ describe("AnsiErrorOutput", () => {
       <AnsiErrorOutput ename="Error" evalue="test" />,
     );
     const output = container.querySelector("[data-slot='ansi-error-output']");
-    expect(output?.className).toContain("border-red");
+    expect(output?.className).toContain("not-prose");
   });
 });

--- a/src/components/outputs/ansi-output.tsx
+++ b/src/components/outputs/ansi-output.tsx
@@ -279,7 +279,7 @@ export function AnsiErrorOutput({
     <div
       data-slot="ansi-error-output"
       className={cn(
-        "not-prose border-l-2 border-red-200 dark:border-red-800 py-3 pl-1",
+        "not-prose py-3",
         className,
       )}
     >


### PR DESCRIPTION
Simplified error output styling by removing the red left border, which was visual noise. Error tracebacks now display with just padding.

## Verification
* [ ] Error outputs display correctly without the left border
* [ ] Styling in both light and dark modes is intact

_PR submitted by @rgbkrk's agent, Quill_