### PR TITLE
fix(runtimed): address review feedback on daemon stability

### DIFF
--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -424,11 +424,17 @@ impl Daemon {
                 tokio::fs::create_dir_all(parent).await?;
             }
 
-            // Remove stale socket file (use .ok() since the singleton lock
-            // guarantees exclusivity — if removal fails, bind will report the
-            // real error)
+            // Remove stale socket file — singleton lock guarantees exclusivity,
+            // so NotFound is fine; log other errors for diagnostics.
             if self.config.socket_path.exists() {
-                tokio::fs::remove_file(&self.config.socket_path).await.ok();
+                if let Err(e) = tokio::fs::remove_file(&self.config.socket_path).await {
+                    if e.kind() != std::io::ErrorKind::NotFound {
+                        warn!(
+                            "[runtimed] Failed to remove stale socket {:?}: {}",
+                            self.config.socket_path, e
+                        );
+                    }
+                }
             }
 
             // Clean up obsolete sync socket from pre-unification daemons

--- a/crates/runtimed/src/main.rs
+++ b/crates/runtimed/src/main.rs
@@ -343,10 +343,12 @@ async fn run_daemon(
             // Another daemon is already running — this is expected during
             // launchd double-start races, NOT a crash. Exit 0 so launchd's
             // KeepAlive.Crashed does not restart us.
-            early_log(&format!(
+            let msg = format!(
                 "Another daemon already running (pid={}, endpoint={}), exiting cleanly",
                 e.info.pid, e.info.endpoint
-            ));
+            );
+            early_log(&msg);
+            eprintln!("{msg}");
             std::process::exit(0);
         }
     };

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -46,6 +46,11 @@ use crate::notebook_metadata::NotebookMetadataSnapshot;
 use crate::protocol::{EnvSyncDiff, NotebookBroadcast, NotebookRequest, NotebookResponse};
 use notebook_doc::presence::{self, PresenceState};
 
+/// Capacity for the per-room kernel broadcast channel. Sized to absorb bursts
+/// of output messages (e.g. fast-printing cells) so slower peers trigger a
+/// full doc sync ("peer lagged") rather than losing messages.
+const KERNEL_BROADCAST_CAPACITY: usize = 256;
+
 /// Trust state for a notebook room.
 /// Tracks whether the notebook's dependencies are trusted for auto-launch.
 #[derive(Debug, Clone)]
@@ -641,7 +646,7 @@ impl NotebookRoom {
             NotebookDoc::new_with_actor(notebook_id, runtimed_actor)
         };
         let (changed_tx, _) = broadcast::channel(16);
-        let (kernel_broadcast_tx, _) = broadcast::channel(256);
+        let (kernel_broadcast_tx, _) = broadcast::channel(KERNEL_BROADCAST_CAPACITY);
 
         // Spawn debounced persistence task (watch channel keeps latest value only)
         let (persist_tx, persist_rx) = watch::channel::<Option<Vec<u8>>>(None);
@@ -707,7 +712,7 @@ impl NotebookRoom {
         let persist_path = docs_dir.join(filename);
         let doc = NotebookDoc::load_or_create(&persist_path, notebook_id);
         let (changed_tx, _) = broadcast::channel(16);
-        let (kernel_broadcast_tx, _) = broadcast::channel(256);
+        let (kernel_broadcast_tx, _) = broadcast::channel(KERNEL_BROADCAST_CAPACITY);
         let (persist_tx, persist_rx) = watch::channel::<Option<Vec<u8>>>(None);
         spawn_persist_debouncer(persist_rx, persist_path.clone());
         let (presence_tx, _) = broadcast::channel(64);
@@ -5695,7 +5700,7 @@ mod tests {
 
         let doc = crate::notebook_doc::NotebookDoc::new(&notebook_id);
         let (changed_tx, _) = broadcast::channel(16);
-        let (kernel_broadcast_tx, _) = broadcast::channel(256);
+        let (kernel_broadcast_tx, _) = broadcast::channel(KERNEL_BROADCAST_CAPACITY);
         let persist_path = tmp.path().join("doc.automerge");
         let (persist_tx, persist_rx) = watch::channel::<Option<Vec<u8>>>(None);
         spawn_persist_debouncer(persist_rx, persist_path.clone());


### PR DESCRIPTION
## Summary

Follow-up to #896 addressing Copilot review feedback:

- **Stderr on singleton exit**: The "already running" code path now prints to stderr in addition to `early_log()`, so manual invocations aren't silently swallowed
- **Socket removal diagnostics**: Stale socket removal logs a warning on failure (except `NotFound`) instead of `.ok()`-ing all errors away — makes bind failures easier to diagnose
- **`KERNEL_BROADCAST_CAPACITY` constant**: Extracts the broadcast channel size (256) to a named constant so production and test constructors stay in sync

_PR submitted by @rgbkrk's agent, Quill_