### PR TITLE
fix(daemon): unify launchd service management API

### DIFF
--- a/crates/runt-workspace/src/lib.rs
+++ b/crates/runt-workspace/src/lib.rs
@@ -278,6 +278,100 @@ fn open_notebook_installed(path: Option<&Path>, extra_args: &[&str]) -> Result<(
 }
 
 // ============================================================================
+// macOS launchd Service Management
+// ============================================================================
+
+/// Get the current user's UID for the launchd gui domain.
+#[cfg(target_os = "macos")]
+pub fn launchd_uid() -> String {
+    Command::new("id")
+        .args(["-u"])
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .unwrap_or_else(|| "501".to_string())
+}
+
+/// Path to the launchd plist for the current channel.
+#[cfg(target_os = "macos")]
+pub fn launchd_plist_path() -> PathBuf {
+    dirs::home_dir().expect("No home directory").join(format!(
+        "Library/LaunchAgents/{}.plist",
+        daemon_launchd_label()
+    ))
+}
+
+/// Stop the daemon's launchd service via `bootout`.
+///
+/// Ignores errors if the service is not currently loaded.
+#[cfg(target_os = "macos")]
+pub fn launchd_stop() -> Result<(), String> {
+    let uid = launchd_uid();
+    let label = daemon_launchd_label();
+    let domain_target = format!("gui/{uid}/{label}");
+
+    let output = Command::new("launchctl")
+        .args(["bootout", &domain_target])
+        .output()
+        .map_err(|e| format!("Failed to run launchctl bootout: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        // Ignore "not found" errors — service may not be loaded
+        if !stderr.contains("Could not find")
+            && !stderr.contains("No such")
+            && !stderr.contains("36")
+            && !stderr.contains("113")
+        {
+            return Err(format!("launchctl bootout failed: {}", stderr.trim()));
+        }
+    }
+
+    Ok(())
+}
+
+/// Start the daemon's launchd service via `bootstrap`.
+///
+/// Clears any stale registration first (bootout, ignoring errors),
+/// then bootstraps fresh from the plist.
+#[cfg(target_os = "macos")]
+pub fn launchd_start() -> Result<(), String> {
+    let plist = launchd_plist_path();
+    if !plist.exists() {
+        return Err(format!("launchd plist not found at {}", plist.display()));
+    }
+
+    let uid = launchd_uid();
+    let label = daemon_launchd_label();
+    let domain = format!("gui/{uid}");
+
+    // Clear any stale registration (ignore errors)
+    let _ = Command::new("launchctl")
+        .args(["bootout", &format!("{domain}/{label}")])
+        .output();
+
+    // Brief pause for launchd to clean up
+    std::thread::sleep(std::time::Duration::from_millis(100));
+
+    // Bootstrap fresh
+    let output = Command::new("launchctl")
+        .args(["bootstrap", &domain, &plist.to_string_lossy()])
+        .output()
+        .map_err(|e| format!("Failed to run launchctl bootstrap: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        // Error 37 means service is already loaded (which is fine)
+        if !stderr.contains("37") {
+            return Err(format!("launchctl bootstrap failed: {}", stderr.trim()));
+        }
+    }
+
+    Ok(())
+}
+
+// ============================================================================
 // Development Mode Detection
 // ============================================================================
 

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -2270,46 +2270,12 @@ async fn doctor_command(
         // This happens when launchctl load/unload leaves corrupted state
         #[cfg(target_os = "macos")]
         if launchd_not_loaded && config_exists && binary_exists && !daemon_running_before {
-            let label = runt_workspace::daemon_launchd_label();
-
-            // Get current user's UID for the gui domain
-            let uid = std::process::Command::new("id")
-                .args(["-u"])
-                .output()
-                .ok()
-                .and_then(|o| String::from_utf8(o.stdout).ok())
-                .map(|s| s.trim().to_string())
-                .unwrap_or_else(|| "501".to_string());
-            let domain = format!("gui/{}", uid);
-
-            // First bootout any stale registration (ignore errors - may not exist)
-            let _ = std::process::Command::new("launchctl")
-                .args(["bootout", &format!("{}/{}", domain, label)])
-                .output();
-
-            // Small delay for launchd to clean up
-            std::thread::sleep(std::time::Duration::from_millis(100));
-
-            // Bootstrap to register fresh
-            let result = std::process::Command::new("launchctl")
-                .args(["bootstrap", &domain, &service_config_path.to_string_lossy()])
-                .output();
-
-            match result {
-                Ok(o) if o.status.success() => {
+            match runt_workspace::launchd_start() {
+                Ok(()) => {
                     actions_taken.push("Reset launchd service registration".to_string());
                 }
-                Ok(o) => {
-                    let stderr = String::from_utf8_lossy(&o.stderr);
-                    // Error 37 means service is already loaded (which is fine)
-                    if !stderr.contains("37") {
-                        eprintln!("Failed to bootstrap service: {}", stderr.trim());
-                    } else {
-                        actions_taken.push("Launchd service already registered".to_string());
-                    }
-                }
                 Err(e) => {
-                    eprintln!("launchctl bootstrap failed: {}", e);
+                    eprintln!("Failed to reset launchd registration: {e}");
                 }
             }
         }

--- a/crates/runtimed/src/service.rs
+++ b/crates/runtimed/src/service.rs
@@ -481,18 +481,7 @@ impl ServiceManager {
 
     #[cfg(target_os = "macos")]
     fn start_macos(&self) -> ServiceResult<()> {
-        let output = std::process::Command::new("launchctl")
-            .args(["load", "-w"])
-            .arg(plist_path())
-            .output()?;
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            // Ignore "already loaded" error
-            if !stderr.contains("already loaded") {
-                return Err(ServiceError::StartFailed(stderr.to_string()));
-            }
-        }
+        runt_workspace::launchd_start().map_err(ServiceError::StartFailed)?;
 
         info!("[service] Started launchd service");
         Ok(())
@@ -500,18 +489,7 @@ impl ServiceManager {
 
     #[cfg(target_os = "macos")]
     fn stop_macos(&self) -> ServiceResult<()> {
-        let output = std::process::Command::new("launchctl")
-            .args(["unload"])
-            .arg(plist_path())
-            .output()?;
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            // Ignore "not loaded" error
-            if !stderr.contains("Could not find") && !stderr.contains("No such") {
-                return Err(ServiceError::StopFailed(stderr.to_string()));
-            }
-        }
+        runt_workspace::launchd_stop().map_err(ServiceError::StopFailed)?;
 
         info!("[service] Stopped launchd service");
         Ok(())

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -475,20 +475,7 @@ fn cmd_install_daemon() {
     // Stop the running daemon gracefully
     #[cfg(target_os = "macos")]
     {
-        let uid = Command::new("id")
-            .args(["-u"])
-            .output()
-            .ok()
-            .and_then(|o| String::from_utf8(o.stdout).ok())
-            .map(|s| s.trim().to_string())
-            .unwrap_or_else(|| "501".to_string());
-        let domain = format!("gui/{uid}/{}", runt_workspace::daemon_launchd_label());
-
-        // Stop (ignore errors — may not be running)
-        let _ = Command::new("launchctl")
-            .args(["bootout", &domain])
-            .status();
-
+        let _ = runt_workspace::launchd_stop();
         // Brief pause for process cleanup
         std::thread::sleep(std::time::Duration::from_secs(1));
     }
@@ -545,25 +532,8 @@ fn cmd_install_daemon() {
     // Restart the service
     #[cfg(target_os = "macos")]
     {
-        let plist = dirs::home_dir().expect("No home dir").join(format!(
-            "Library/LaunchAgents/{}.plist",
-            runt_workspace::daemon_launchd_label()
-        ));
-        if plist.exists() {
-            let uid = Command::new("id")
-                .args(["-u"])
-                .output()
-                .ok()
-                .and_then(|o| String::from_utf8(o.stdout).ok())
-                .map(|s| s.trim().to_string())
-                .unwrap_or_else(|| "501".to_string());
-            let domain = format!("gui/{uid}");
-            run_cmd(
-                "launchctl",
-                &["bootstrap", &domain, &plist.to_string_lossy()],
-            );
-        } else {
-            eprintln!("Warning: launchd plist not found at {}", plist.display());
+        if let Err(e) = runt_workspace::launchd_start() {
+            eprintln!("Warning: failed to start launchd service: {e}");
             eprintln!("Start manually with: {}", install_path.display());
         }
     }


### PR DESCRIPTION
## Summary

The nightly daemon was stopping (receiving SIGTERM) but not restarting due to inconsistent launchd service management APIs. Three callsites were using two incompatible APIs: `bootout`/`bootstrap` (modern, used by xtask and runt CLI) and `load`/`unload` (deprecated, used by the runtimed install sidecar). When mixed, launchd's domain registration became inconsistent — the plist file existed but the service was deregistered.

This fix extracts shared launchd helpers to `runt-workspace` and routes all three callsites through the same modern `bootout`/`bootstrap` API path, preventing future service deregistration.

## Changes

- **runt-workspace**: New macOS launchd helpers (`launchd_uid()`, `launchd_plist_path()`, `launchd_stop()`, `launchd_start()`)
- **runtimed service.rs**: Replace deprecated `load -w`/`unload` with shared helpers
- **xtask**: Replace inline UID lookup and `bootstrap` with shared helpers
- **runt CLI**: Replace inline launchd management with shared helpers

## Verification

* [ ] Run `cargo xtask install-daemon` and verify `launchctl list | grep nteract` shows the service registered
* [ ] Restart the daemon via `runt daemon stop` and `runt daemon start`, verify it comes back
* [ ] Trigger the sidecar path by running `./target/release/runtimed install` after `cargo xtask install-daemon` — daemon should remain responsive

_PR submitted by @rgbkrk's agent, Quill_