### PR TITLE
fix(launchd): address copilot review feedback on error handling

### DIFF
--- a/crates/runt-workspace/src/lib.rs
+++ b/crates/runt-workspace/src/lib.rs
@@ -289,6 +289,15 @@ pub fn launchd_uid() -> Result<String, String> {
         .output()
         .map_err(|e| format!("Failed to run `id -u`: {e}"))?;
 
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!(
+            "`id -u` failed (exit {}): {}",
+            output.status,
+            stderr.trim()
+        ));
+    }
+
     let uid = String::from_utf8(output.stdout)
         .map_err(|e| format!("Non-UTF8 output from `id -u`: {e}"))?;
 
@@ -353,29 +362,14 @@ pub fn launchd_start() -> Result<(), String> {
     let uid = launchd_uid()?;
     let domain = format!("gui/{uid}");
 
-    // Clear any stale registration (ignore "not found" errors)
-    launchd_stop().ok();
+    // Clear any stale registration — launchd_stop() already treats "not found"
+    // as Ok, so ? propagates only unexpected failures.
+    launchd_stop()?;
 
     // Brief pause for launchd to clean up
     std::thread::sleep(std::time::Duration::from_millis(100));
 
-    // Bootstrap fresh
-    let output = Command::new("launchctl")
-        .arg("bootstrap")
-        .arg(&domain)
-        .arg(&plist)
-        .output()
-        .map_err(|e| format!("Failed to run launchctl bootstrap: {e}"))?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        // Error 37 means service is already loaded (which is fine)
-        if !stderr.contains("37") {
-            return Err(format!("launchctl bootstrap failed: {}", stderr.trim()));
-        }
-    }
-
-    Ok(())
+    launchd_bootstrap(&plist, &domain)
 }
 
 /// Check whether the daemon's launchd service is currently loaded.
@@ -386,7 +380,22 @@ pub fn launchd_is_loaded() -> Result<bool, String> {
         .args(["list", label])
         .output()
         .map_err(|e| format!("Failed to run launchctl list: {e}"))?;
-    Ok(output.status.success())
+
+    if output.status.success() {
+        return Ok(true);
+    }
+
+    // Only treat "not found" as "not loaded"; surface unexpected errors
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if stderr.contains("Could not find")
+        || stderr.contains("No such")
+        || stderr.contains("36")
+        || stderr.contains("113")
+    {
+        return Ok(false);
+    }
+
+    Err(format!("launchctl list failed: {}", stderr.trim()))
 }
 
 /// Ensure the daemon's launchd service is loaded, without restarting it
@@ -394,12 +403,12 @@ pub fn launchd_is_loaded() -> Result<bool, String> {
 ///
 /// Unlike `launchd_start()` which always does bootout+bootstrap (a restart),
 /// this only bootstraps if the service is not currently loaded.
+/// Returns `true` if it actually bootstrapped, `false` if already loaded.
 #[cfg(target_os = "macos")]
-pub fn launchd_ensure_loaded() -> Result<(), String> {
+pub fn launchd_ensure_loaded() -> Result<bool, String> {
     if launchd_is_loaded()? {
-        return Ok(());
+        return Ok(false);
     }
-    // Not loaded — bootstrap it
     let plist = launchd_plist_path()?;
     if !plist.exists() {
         return Err(format!("launchd plist not found at {}", plist.display()));
@@ -407,15 +416,23 @@ pub fn launchd_ensure_loaded() -> Result<(), String> {
     let uid = launchd_uid()?;
     let domain = format!("gui/{uid}");
 
+    launchd_bootstrap(&plist, &domain)?;
+    Ok(true)
+}
+
+/// Run `launchctl bootstrap` for the given plist in the given domain.
+#[cfg(target_os = "macos")]
+fn launchd_bootstrap(plist: &Path, domain: &str) -> Result<(), String> {
     let output = Command::new("launchctl")
         .arg("bootstrap")
-        .arg(&domain)
-        .arg(&plist)
+        .arg(domain)
+        .arg(plist)
         .output()
         .map_err(|e| format!("Failed to run launchctl bootstrap: {e}"))?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
+        // Error 37 means service is already loaded (which is fine)
         if !stderr.contains("37") {
             return Err(format!("launchctl bootstrap failed: {}", stderr.trim()));
         }

--- a/crates/runt-workspace/src/lib.rs
+++ b/crates/runt-workspace/src/lib.rs
@@ -283,23 +283,31 @@ fn open_notebook_installed(path: Option<&Path>, extra_args: &[&str]) -> Result<(
 
 /// Get the current user's UID for the launchd gui domain.
 #[cfg(target_os = "macos")]
-pub fn launchd_uid() -> String {
-    Command::new("id")
+pub fn launchd_uid() -> Result<String, String> {
+    let output = Command::new("id")
         .args(["-u"])
         .output()
-        .ok()
-        .and_then(|o| String::from_utf8(o.stdout).ok())
-        .map(|s| s.trim().to_string())
-        .unwrap_or_else(|| "501".to_string())
+        .map_err(|e| format!("Failed to run `id -u`: {e}"))?;
+
+    let uid = String::from_utf8(output.stdout)
+        .map_err(|e| format!("Non-UTF8 output from `id -u`: {e}"))?;
+
+    let uid = uid.trim().to_string();
+    if uid.is_empty() {
+        return Err("Empty UID from `id -u`".to_string());
+    }
+
+    Ok(uid)
 }
 
 /// Path to the launchd plist for the current channel.
 #[cfg(target_os = "macos")]
-pub fn launchd_plist_path() -> PathBuf {
-    dirs::home_dir().expect("No home directory").join(format!(
+pub fn launchd_plist_path() -> Result<PathBuf, String> {
+    let home = dirs::home_dir().ok_or("Could not determine home directory")?;
+    Ok(home.join(format!(
         "Library/LaunchAgents/{}.plist",
         daemon_launchd_label()
-    ))
+    )))
 }
 
 /// Stop the daemon's launchd service via `bootout`.
@@ -307,7 +315,7 @@ pub fn launchd_plist_path() -> PathBuf {
 /// Ignores errors if the service is not currently loaded.
 #[cfg(target_os = "macos")]
 pub fn launchd_stop() -> Result<(), String> {
-    let uid = launchd_uid();
+    let uid = launchd_uid()?;
     let label = daemon_launchd_label();
     let domain_target = format!("gui/{uid}/{label}");
 
@@ -333,36 +341,81 @@ pub fn launchd_stop() -> Result<(), String> {
 
 /// Start the daemon's launchd service via `bootstrap`.
 ///
-/// Clears any stale registration first (bootout, ignoring errors),
-/// then bootstraps fresh from the plist.
+/// Clears any stale registration first via `launchd_stop()` (ignoring
+/// "not found" errors), then bootstraps fresh from the plist.
 #[cfg(target_os = "macos")]
 pub fn launchd_start() -> Result<(), String> {
-    let plist = launchd_plist_path();
+    let plist = launchd_plist_path()?;
     if !plist.exists() {
         return Err(format!("launchd plist not found at {}", plist.display()));
     }
 
-    let uid = launchd_uid();
-    let label = daemon_launchd_label();
+    let uid = launchd_uid()?;
     let domain = format!("gui/{uid}");
 
-    // Clear any stale registration (ignore errors)
-    let _ = Command::new("launchctl")
-        .args(["bootout", &format!("{domain}/{label}")])
-        .output();
+    // Clear any stale registration (ignore "not found" errors)
+    launchd_stop().ok();
 
     // Brief pause for launchd to clean up
     std::thread::sleep(std::time::Duration::from_millis(100));
 
     // Bootstrap fresh
     let output = Command::new("launchctl")
-        .args(["bootstrap", &domain, &plist.to_string_lossy()])
+        .arg("bootstrap")
+        .arg(&domain)
+        .arg(&plist)
         .output()
         .map_err(|e| format!("Failed to run launchctl bootstrap: {e}"))?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         // Error 37 means service is already loaded (which is fine)
+        if !stderr.contains("37") {
+            return Err(format!("launchctl bootstrap failed: {}", stderr.trim()));
+        }
+    }
+
+    Ok(())
+}
+
+/// Check whether the daemon's launchd service is currently loaded.
+#[cfg(target_os = "macos")]
+pub fn launchd_is_loaded() -> Result<bool, String> {
+    let label = daemon_launchd_label();
+    let output = Command::new("launchctl")
+        .args(["list", label])
+        .output()
+        .map_err(|e| format!("Failed to run launchctl list: {e}"))?;
+    Ok(output.status.success())
+}
+
+/// Ensure the daemon's launchd service is loaded, without restarting it
+/// if it's already running.
+///
+/// Unlike `launchd_start()` which always does bootout+bootstrap (a restart),
+/// this only bootstraps if the service is not currently loaded.
+#[cfg(target_os = "macos")]
+pub fn launchd_ensure_loaded() -> Result<(), String> {
+    if launchd_is_loaded()? {
+        return Ok(());
+    }
+    // Not loaded — bootstrap it
+    let plist = launchd_plist_path()?;
+    if !plist.exists() {
+        return Err(format!("launchd plist not found at {}", plist.display()));
+    }
+    let uid = launchd_uid()?;
+    let domain = format!("gui/{uid}");
+
+    let output = Command::new("launchctl")
+        .arg("bootstrap")
+        .arg(&domain)
+        .arg(&plist)
+        .output()
+        .map_err(|e| format!("Failed to run launchctl bootstrap: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
         if !stderr.contains("37") {
             return Err(format!("launchctl bootstrap failed: {}", stderr.trim()));
         }

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -2272,7 +2272,7 @@ async fn doctor_command(
         if launchd_not_loaded && config_exists && binary_exists && !daemon_running_before {
             match runt_workspace::launchd_start() {
                 Ok(()) => {
-                    actions_taken.push("Reset launchd service registration".to_string());
+                    actions_taken.push("Ensured launchd service registration".to_string());
                 }
                 Err(e) => {
                     eprintln!("Failed to reset launchd registration: {e}");

--- a/crates/runtimed/src/service.rs
+++ b/crates/runtimed/src/service.rs
@@ -481,7 +481,7 @@ impl ServiceManager {
 
     #[cfg(target_os = "macos")]
     fn start_macos(&self) -> ServiceResult<()> {
-        runt_workspace::launchd_start().map_err(ServiceError::StartFailed)?;
+        runt_workspace::launchd_ensure_loaded().map_err(ServiceError::StartFailed)?;
 
         info!("[service] Started launchd service");
         Ok(())

--- a/crates/runtimed/src/service.rs
+++ b/crates/runtimed/src/service.rs
@@ -481,9 +481,14 @@ impl ServiceManager {
 
     #[cfg(target_os = "macos")]
     fn start_macos(&self) -> ServiceResult<()> {
-        runt_workspace::launchd_ensure_loaded().map_err(ServiceError::StartFailed)?;
+        let bootstrapped =
+            runt_workspace::launchd_ensure_loaded().map_err(ServiceError::StartFailed)?;
 
-        info!("[service] Started launchd service");
+        if bootstrapped {
+            info!("[service] Started launchd service");
+        } else {
+            info!("[service] Launchd service already loaded");
+        }
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

Improve launchd service management based on code review feedback:

- `launchd_uid()` and `launchd_plist_path()` now return `Result` instead of panicking/unwrapping on errors
- `launchd_start()` reuses `launchd_stop()` for consistent error handling (only ignores "not found" errors, surfaces unexpected failures)
- `launchd_start()` uses `.arg(&plist)` instead of `to_string_lossy()` to preserve non-UTF8 paths
- Add `launchd_is_loaded()` and `launchd_ensure_loaded()` for idempotent service loading
- `start_macos()` now uses `launchd_ensure_loaded()` (doesn't restart already-running services)
- Doctor `--fix` message changed to "Ensured" instead of "Reset" for accuracy

## Verification

* [ ] Run `cargo xtask install-daemon` and verify service registers correctly
* [ ] Run `runt daemon doctor` and verify version check displays properly
* [ ] Test on macOS with and without existing launchd registration

_PR submitted by @rgbkrk's agent, Quill_