### PR TITLE
fix(runtimed-py): make create_cell(index=None) append instead of prepend

### DIFF
--- a/crates/runtimed-py/src/session_core.rs
+++ b/crates/runtimed-py/src/session_core.rs
@@ -472,15 +472,14 @@ pub(crate) async fn create_cell(
             .as_ref()
             .ok_or_else(|| to_py_err("Not connected"))?;
 
-        // Determine after_cell_id from index
-        let after_cell_id = index.and_then(|i| {
-            if i == 0 {
-                None
-            } else {
-                let cells = handle.get_cells();
-                cells.get(i.saturating_sub(1)).map(|c| c.id.clone())
-            }
-        });
+        // Determine after_cell_id from index.
+        // None → append at end; Some(0) → prepend; Some(i) → after cell i-1.
+        let cells = handle.get_cells();
+        let after_cell_id = match index {
+            None => cells.last().map(|c| c.id.clone()),
+            Some(0) => None,
+            Some(i) => cells.get(i.saturating_sub(1)).map(|c| c.id.clone()),
+        };
 
         handle
             .add_cell_with_source(&cell_id, cell_type, after_cell_id.as_deref(), source)

--- a/crates/runtimed-py/src/session_core.rs
+++ b/crates/runtimed-py/src/session_core.rs
@@ -474,11 +474,18 @@ pub(crate) async fn create_cell(
 
         // Determine after_cell_id from index.
         // None → append at end; Some(0) → prepend; Some(i) → after cell i-1.
-        let cells = handle.get_cells();
-        let after_cell_id = match index {
-            None => cells.last().map(|c| c.id.clone()),
-            Some(0) => None,
-            Some(i) => cells.get(i.saturating_sub(1)).map(|c| c.id.clone()),
+        // Out-of-range indices are clamped to append.
+        let after_cell_id = if let Some(0) = index {
+            None
+        } else {
+            let cells = handle.get_cells();
+            match index {
+                None => cells.last().map(|c| c.id.clone()),
+                Some(i) => {
+                    let clamped = i.min(cells.len());
+                    cells.get(clamped.saturating_sub(1)).map(|c| c.id.clone())
+                }
+            }
         };
 
         handle

--- a/python/runtimed/src/runtimed/runtimed.pyi
+++ b/python/runtimed/src/runtimed/runtimed.pyi
@@ -349,7 +349,19 @@ class Session:
         source: str = "",
         cell_type: str = "code",
         index: int | None = None,
-    ) -> str: ...
+    ) -> str:
+        """Create a new cell.
+
+        Args:
+            source: Cell source text.
+            cell_type: One of "code", "markdown", "raw".
+            index: Position to insert. ``None`` appends at the end,
+                ``0`` prepends at the beginning.
+
+        Returns:
+            The new cell's ID.
+        """
+        ...
     def set_source(self, cell_id: str, source: str) -> None: ...
     def append_source(self, cell_id: str, text: str) -> None: ...
     def set_cell_type(self, cell_id: str, cell_type: str) -> None: ...
@@ -500,7 +512,19 @@ class AsyncSession:
         source: str = "",
         cell_type: str = "code",
         index: int | None = None,
-    ) -> Coroutine[Any, Any, str]: ...
+    ) -> Coroutine[Any, Any, str]:
+        """Create a new cell.
+
+        Args:
+            source: Cell source text.
+            cell_type: One of "code", "markdown", "raw".
+            index: Position to insert. ``None`` appends at the end,
+                ``0`` prepends at the beginning.
+
+        Returns:
+            The new cell's ID.
+        """
+        ...
     def set_source(self, cell_id: str, source: str) -> Coroutine[Any, Any, None]: ...
     def append_source(self, cell_id: str, text: str) -> Coroutine[Any, Any, None]: ...
     def set_cell_type(self, cell_id: str, cell_type: str) -> Coroutine[Any, Any, None]: ...


### PR DESCRIPTION
## Summary

Fixed a footgun where `create_cell(index=None)` prepended cells at the top instead of appending at the bottom. API consumers expect `None` to mean "just add it at the end," but it was inserting before everything, producing reverse-chronological notebooks.

The underlying issue was in `crates/runtimed-py/src/session_core.rs`: when `index=None`, it was converted to `after_cell_id=None`, which in the Rust layer means "insert before everything."

Now `index=None` correctly maps to appending after the last cell.

## Verification

- [x] All lint checks pass
- [x] All tests pass

_PR submitted by @rgbkrk's agent, Quill_