### PR TITLE
fix(window-state): eliminate "main" window label to fix stale geometry restore

### DIFF
--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -71,10 +71,6 @@ impl WindowNotebookRegistry {
     }
 
     /// Remove registry entries whose windows no longer exist.
-    ///
-    /// On macOS the main window's entry is preserved on close (for Cmd+Q session
-    /// restore). If the user reopens a new window before quitting, the stale entry
-    /// would otherwise appear as a ghost notebook in the upgrade dialog and session.
     fn prune_stale_entries(&self, app: &tauri::AppHandle) {
         self.prune_where(|label| app.get_webview_window(label).is_none());
     }
@@ -118,6 +114,22 @@ impl WindowNotebookRegistry {
             if let Ok(guard) = ctx.path.lock() {
                 if guard.as_deref() == Some(target) {
                     return Some(label.clone());
+                }
+            }
+        }
+        None
+    }
+
+    /// Find the first live window that has no file path (untitled/empty notebook).
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    fn find_empty_window_label(&self, app: &tauri::AppHandle) -> Option<String> {
+        let contexts = self.contexts.lock().ok()?;
+        for (label, ctx) in contexts.iter() {
+            if app.get_webview_window(label).is_some() {
+                if let Ok(guard) = ctx.path.lock() {
+                    if guard.is_none() {
+                        return Some(label.clone());
+                    }
                 }
             }
         }
@@ -1713,9 +1725,8 @@ fn create_notebook_window_for_daemon(
         }
     });
 
-    // Remove registry entries for windows that were destroyed but kept for session
-    // restore (e.g. the main window on macOS). Without this, ghost notebooks appear
-    // in the upgrade dialog and saved session when new windows are opened later.
+    // Remove registry entries for windows that no longer exist. Without this,
+    // ghost notebooks appear in the upgrade dialog and saved session.
     registry.prune_stale_entries(app);
 
     // If a window with this label already exists, append a unique suffix so the same
@@ -3316,17 +3327,21 @@ pub fn run(
     // Window registry is always needed for multi-window support
     let window_registry = WindowNotebookRegistry::default();
 
-    // Only set up initial notebook state if not showing onboarding
-    let (window_title, _main_context, main_open_mode) = if needs_onboarding {
+    // Determine the first window's open mode and label.
+    // Unlike the old approach that reused Tauri's auto-created "main" window, we now
+    // create all notebook windows explicitly with proper "notebook-{hash}" labels.
+    // This ensures the window-state plugin persists geometry under a deterministic,
+    // content-based key — not a generic "main" that accumulates stale state.
+    let (window_title, first_window_label, _first_context, first_open_mode) = if needs_onboarding {
         info!("[startup] Onboarding needed, skipping notebook state setup");
-        // No main context - onboarding window doesn't need notebook state
         (
             format!("Welcome to {}", runt_workspace::desktop_display_name()),
             None,
             None,
+            None,
         )
     } else {
-        // Determine how to open the main window — no local file parsing needed.
+        // Determine how to open the first window — no local file parsing needed.
         // The daemon loads/creates the notebook.
         let (mode, title) = match notebook_path.as_ref() {
             Some(path) => {
@@ -3339,8 +3354,9 @@ pub fn run(
             }
             None => {
                 if let Some(ref session) = restored_session {
-                    if let Some(main_session) = session.windows.iter().find(|w| w.label == "main") {
-                        match (&main_session.path, &main_session.env_id) {
+                    // Use the first session window (was the primary window at save time).
+                    if let Some(first_session) = session.windows.first() {
+                        match (&first_session.path, &first_session.env_id) {
                             (Some(path), _) if path.exists() => {
                                 let title = path
                                     .file_name()
@@ -3348,13 +3364,13 @@ pub fn run(
                                     .unwrap_or("Untitled.ipynb")
                                     .to_string();
                                 info!(
-                                    "[session] Restoring main window from path: {}",
+                                    "[session] Restoring first window from path: {}",
                                     path.display()
                                 );
                                 (OpenMode::Open { path: path.clone() }, title)
                             }
                             (_, Some(env_id)) => {
-                                info!("[session] Restoring untitled main window: {}", env_id);
+                                info!("[session] Restoring untitled first window: {}", env_id);
                                 (
                                     OpenMode::Create {
                                         runtime: runtime.to_string(),
@@ -3365,7 +3381,7 @@ pub fn run(
                                 )
                             }
                             _ => {
-                                warn!("[session] Main session has no path or env_id");
+                                warn!("[session] First session entry has no path or env_id");
                                 (
                                     OpenMode::Create {
                                         runtime: runtime.to_string(),
@@ -3399,6 +3415,21 @@ pub fn run(
             }
         };
 
+        // Generate a proper notebook label (same logic as create_notebook_window_for_daemon)
+        let label = match &mode {
+            OpenMode::Open { path } => {
+                let hash = runtimed::worktree_hash(path);
+                format!("notebook-{}", &hash[..8])
+            }
+            OpenMode::Create {
+                notebook_id: Some(ref id),
+                ..
+            } => format!("notebook-{}", &id[..8.min(id.len())]),
+            OpenMode::Create {
+                notebook_id: None, ..
+            } => format!("notebook-{}", uuid::Uuid::new_v4()),
+        };
+
         let placeholder_id = match &mode {
             OpenMode::Open { path } => path
                 .canonicalize()
@@ -3423,10 +3454,10 @@ pub fn run(
             runtime,
         );
         window_registry
-            .insert("main", context.clone())
+            .insert(&label, context.clone())
             .map_err(anyhow::Error::msg)?;
 
-        (title, Some(context), Some(mode))
+        (title, Some(label), Some(context), Some(mode))
     };
 
     // Guard against concurrent reconnect attempts
@@ -3460,7 +3491,7 @@ pub fn run(
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(
             tauri_plugin_window_state::Builder::default()
-                .with_denylist(&["onboarding", "upgrade"])
+                .with_denylist(&["main", "onboarding", "upgrade"])
                 .build(),
         )
         .manage(window_registry.clone())
@@ -3536,11 +3567,6 @@ pub fn run(
             log::info!("[startup] Notebooks directory: {}", notebooks_dir.display());
 
             if needs_onboarding {
-                // Close the default main window - we'll create an onboarding-specific one
-                if let Some(window) = app.get_webview_window("main") {
-                    let _ = window.close();
-                }
-
                 // Create dedicated onboarding window with fixed size appropriate for content.
                 // Uses the separate onboarding app bundle (not the notebook bundle) to avoid
                 // loading notebook hooks that don't apply to the onboarding window.
@@ -3559,15 +3585,26 @@ pub fn run(
                 .build()?;
 
                 log::info!("[startup] Created dedicated onboarding window");
-            } else {
-                // Normal startup - just set the title on the main window
-                if let Some(window) = app.get_webview_window("main") {
-                    let _ = window.set_title(&window_title);
-                    refresh_native_menu(
-                        app.handle(),
-                        app.state::<WindowNotebookRegistry>().inner(),
-                    );
-                }
+            } else if let Some(ref label) = first_window_label {
+                // Create the first notebook window with a proper label.
+                // The window appears immediately with a loading UI; daemon sync
+                // happens later in the async block after the daemon is confirmed available.
+                let _notebook_window = tauri::WebviewWindowBuilder::new(
+                    app,
+                    label,
+                    tauri::WebviewUrl::default(),
+                )
+                .title(&window_title)
+                .inner_size(1100.0, 750.0)
+                .min_inner_size(400.0, 250.0)
+                .resizable(true)
+                .build()?;
+
+                log::info!("[startup] Created first notebook window: {}", label);
+                refresh_native_menu(
+                    app.handle(),
+                    app.state::<WindowNotebookRegistry>().inner(),
+                );
             }
 
             // Start WebDriver server for native E2E testing (if enabled)
@@ -3594,19 +3631,12 @@ pub fn run(
             let menu = crate::menu::create_menu(app.handle(), &window_display_names)?;
             app.set_menu(menu)?;
 
-            // Collect additional session windows (non-main) for deferred restore.
-            // Windows are created after daemon is confirmed available to avoid
-            // sync tasks racing with daemon startup. Session file is cleared
-            // after the deferred restore completes so it remains available for
-            // retry if the daemon fails to start.
+            // Additional session windows (skip first, already created in setup).
+            // Created after daemon is confirmed available to avoid sync tasks
+            // racing with daemon startup.
             let additional_session_windows: Vec<session::WindowSession> =
                 if let Some(session) = &restored_session {
-                    session
-                        .windows
-                        .iter()
-                        .filter(|w| w.label != "main")
-                        .cloned()
-                        .collect()
+                    session.windows.iter().skip(1).cloned().collect()
                 } else {
                     Vec::new()
                 };
@@ -3667,10 +3697,12 @@ pub fn run(
                 // Skip during onboarding - the onboarding window doesn't need notebook sync,
                 // it just needs daemon progress events
                 if daemon_available && !skip_notebook_sync {
-                    if let Some(mode) = main_open_mode {
+                    if let (Some(mode), Some(ref label)) =
+                        (first_open_mode, &first_window_label)
+                    {
                         match (
-                            app_for_notebook_sync.get_webview_window("main"),
-                            registry_for_notebook_sync.get("main"),
+                            app_for_notebook_sync.get_webview_window(label),
+                            registry_for_notebook_sync.get(label),
                         ) {
                             (Some(window), Ok(context)) => {
                                 let result = match mode {
@@ -3718,10 +3750,17 @@ pub fn run(
                                 }
                             }
                             (None, _) => {
-                                log::warn!("[startup] Main window missing during sync init");
+                                log::warn!(
+                                    "[startup] Notebook window '{}' missing during sync init",
+                                    label
+                                );
                             }
                             (_, Err(e)) => {
-                                log::warn!("[startup] Main notebook context missing: {}", e);
+                                log::warn!(
+                                    "[startup] Notebook context for '{}' missing: {}",
+                                    label,
+                                    e
+                                );
                             }
                         }
                     }
@@ -4080,21 +4119,13 @@ pub fn run(
         } = &event
         {
             if let Ok(mut contexts) = registry_for_window_close.contexts.lock() {
-                // Keep the main context for session restore, but always clear
-                // its sync handle so daemon peer tracking can evict idle rooms.
-                let closed_handle = if label == "main" {
-                    contexts
-                        .get(label)
-                        .map(|context| context.notebook_sync.clone())
-                } else {
-                    contexts.remove(label).map(|context| {
-                        log::info!(
-                            "[window] Removed registry entry for closed window: {}",
-                            label
-                        );
-                        context.notebook_sync
-                    })
-                };
+                let closed_handle = contexts.remove(label).map(|context| {
+                    log::info!(
+                        "[window] Removed registry entry for closed window: {}",
+                        label
+                    );
+                    context.notebook_sync
+                });
 
                 if let Some(notebook_sync) = closed_handle {
                     clear_notebook_sync_handles(
@@ -4134,8 +4165,7 @@ pub fn run(
 
                 // For file association (Finder double-click), focus an existing window
                 // for this notebook if one is open — expected macOS behavior. Scan the
-                // registry by path rather than label, since the notebook may be open in
-                // the "main" window or a UUID-suffixed window.
+                // registry by path rather than label.
                 if let Some(label) = registry_for_open.find_label_by_path(&path) {
                     if let Some(existing) = app_handle.get_webview_window(&label) {
                         let _ = existing.set_focus();
@@ -4143,25 +4173,18 @@ pub fn run(
                     }
                 }
 
+                // Reuse an empty (untitled) window if one exists, otherwise open new.
                 // Note: only checks path, not dirty/content state. Cell edits
                 // no longer set NotebookState.dirty (mutations go through sync
                 // handle), so an untitled notebook with user edits may be reused.
-                // Phase 1.4 will move this check to the sync handle.
-                let main_is_empty = registry_for_open
-                    .get("main")
-                    .ok()
-                    .and_then(|context| context.path.lock().ok().map(|path| path.is_none()))
-                    .unwrap_or(false);
-
-                if main_is_empty {
-                    // Reuse the empty main window — update path and reconnect to daemon
-                    if let Ok(context) = registry_for_open.get("main") {
+                if let Some(empty_label) = registry_for_open.find_empty_window_label(app_handle) {
+                    if let Ok(context) = registry_for_open.get(&empty_label) {
                         // Update path in context
                         if let Ok(mut p) = context.path.lock() {
                             *p = Some(path.clone());
                         }
 
-                        if let Some(window) = app_handle.get_webview_window("main") {
+                        if let Some(window) = app_handle.get_webview_window(&empty_label) {
                             let title = path
                                 .file_name()
                                 .and_then(|n| n.to_str())
@@ -4208,9 +4231,7 @@ pub fn run(
         {
             match reopen_action(*has_visible_windows, app_handle.webview_windows().len()) {
                 Some(ReopenAction::RestoreWindow) => {
-                    let window = app_handle
-                        .get_webview_window("main")
-                        .or_else(|| app_handle.webview_windows().into_values().next());
+                    let window = app_handle.webview_windows().into_values().next();
 
                     if let Some(window) = window {
                         if let Err(error) = window.show() {

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -3327,116 +3327,98 @@ pub fn run(
     // Window registry is always needed for multi-window support
     let window_registry = WindowNotebookRegistry::default();
 
-    // Determine the first window's open mode and label.
-    // Unlike the old approach that reused Tauri's auto-created "main" window, we now
-    // create all notebook windows explicitly with proper "notebook-{hash}" labels.
-    // This ensures the window-state plugin persists geometry under a deterministic,
-    // content-based key — not a generic "main" that accumulates stale state.
-    let (window_title, first_window_label, _first_context, first_open_mode) = if needs_onboarding {
+    // Build the list of ALL notebook windows to create at startup.
+    // All windows are created immediately (showing loading UI) and synced
+    // with the daemon once it's available — no primary/secondary distinction.
+    struct StartupWindow {
+        label: String,
+        title: String,
+        mode: OpenMode,
+    }
+
+    let startup_windows: Vec<StartupWindow> = if needs_onboarding {
         info!("[startup] Onboarding needed, skipping notebook state setup");
-        (
-            format!("Welcome to {}", runt_workspace::desktop_display_name()),
-            None,
-            None,
-            None,
-        )
-    } else {
-        // Determine how to open the first window — no local file parsing needed.
-        // The daemon loads/creates the notebook.
-        let (mode, title) = match notebook_path.as_ref() {
-            Some(path) => {
-                let title = path
-                    .file_name()
-                    .and_then(|n| n.to_str())
-                    .unwrap_or("Untitled.ipynb")
-                    .to_string();
-                (OpenMode::Open { path: path.clone() }, title)
-            }
-            None => {
-                if let Some(ref session) = restored_session {
-                    // Find the primary window: use explicit primary_label if present,
-                    // otherwise fall back to first entry (sorted by label during save).
-                    let primary = session
-                        .primary_label
-                        .as_ref()
-                        .and_then(|label| session.windows.iter().find(|w| &w.label == label))
-                        .or_else(|| session.windows.first());
-                    if let Some(first_session) = primary {
-                        match (&first_session.path, &first_session.env_id) {
-                            (Some(path), _) if path.exists() => {
-                                let title = path
-                                    .file_name()
-                                    .and_then(|n| n.to_str())
-                                    .unwrap_or("Untitled.ipynb")
-                                    .to_string();
-                                info!(
-                                    "[session] Restoring first window from path: {}",
-                                    path.display()
-                                );
-                                (OpenMode::Open { path: path.clone() }, title)
-                            }
-                            (_, Some(env_id)) => {
-                                info!("[session] Restoring untitled first window: {}", env_id);
-                                (
-                                    OpenMode::Create {
-                                        runtime: runtime.to_string(),
-                                        working_dir: working_dir.clone(),
-                                        notebook_id: Some(env_id.clone()),
-                                    },
-                                    "Untitled.ipynb".to_string(),
-                                )
-                            }
-                            _ => {
-                                warn!("[session] First session entry has no path or env_id");
-                                (
-                                    OpenMode::Create {
-                                        runtime: runtime.to_string(),
-                                        working_dir: working_dir.clone(),
-                                        notebook_id: None,
-                                    },
-                                    "Untitled.ipynb".to_string(),
-                                )
-                            }
-                        }
-                    } else {
+        Vec::new()
+    } else if let Some(ref path) = notebook_path {
+        // CLI arg: open a specific notebook
+        let title = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("Untitled.ipynb")
+            .to_string();
+        let hash = runtimed::worktree_hash(path);
+        vec![StartupWindow {
+            label: format!("notebook-{}", &hash[..8]),
+            title,
+            mode: OpenMode::Open { path: path.clone() },
+        }]
+    } else if let Some(ref session) = restored_session {
+        // Session restore: recreate all windows from the saved session
+        session
+            .windows
+            .iter()
+            .filter_map(|ws| {
+                let label = session::window_label_for_session(ws);
+                let (title, mode) = match (&ws.path, &ws.env_id) {
+                    (Some(path), _) if path.exists() => {
+                        let title = path
+                            .file_name()
+                            .and_then(|n| n.to_str())
+                            .unwrap_or("Untitled.ipynb")
+                            .to_string();
+                        info!("[session] Restoring window from path: {}", path.display());
+                        (title, OpenMode::Open { path: path.clone() })
+                    }
+                    (_, Some(env_id)) => {
+                        info!("[session] Restoring untitled window: {}", env_id);
                         (
-                            OpenMode::Create {
-                                runtime: runtime.to_string(),
-                                working_dir: working_dir.clone(),
-                                notebook_id: None,
-                            },
                             "Untitled.ipynb".to_string(),
+                            OpenMode::Create {
+                                runtime: ws.runtime.clone(),
+                                working_dir: working_dir.clone(),
+                                notebook_id: Some(env_id.clone()),
+                            },
                         )
                     }
-                } else {
-                    (
-                        OpenMode::Create {
-                            runtime: runtime.to_string(),
-                            working_dir: working_dir.clone(),
-                            notebook_id: None,
-                        },
-                        "Untitled.ipynb".to_string(),
-                    )
-                }
-            }
-        };
+                    _ => {
+                        warn!("[session] Skipping session entry with no path or env_id");
+                        return None;
+                    }
+                };
+                Some(StartupWindow { label, title, mode })
+            })
+            .collect()
+    } else {
+        // Fresh start: create a new untitled notebook
+        vec![StartupWindow {
+            label: format!("notebook-{}", uuid::Uuid::new_v4()),
+            title: "Untitled.ipynb".to_string(),
+            mode: OpenMode::Create {
+                runtime: runtime.to_string(),
+                working_dir: working_dir.clone(),
+                notebook_id: None,
+            },
+        }]
+    };
 
-        // Generate a proper notebook label (same logic as create_notebook_window_for_daemon)
-        let label = match &mode {
-            OpenMode::Open { path } => {
-                let hash = runtimed::worktree_hash(path);
-                format!("notebook-{}", &hash[..8])
-            }
-            OpenMode::Create {
-                notebook_id: Some(ref id),
-                ..
-            } => format!("notebook-{}", &id[..8.min(id.len())]),
-            OpenMode::Create {
-                notebook_id: None, ..
-            } => format!("notebook-{}", uuid::Uuid::new_v4()),
-        };
+    // If session restore yielded no valid windows, fall back to a fresh notebook
+    let startup_windows = if !needs_onboarding && startup_windows.is_empty() {
+        vec![StartupWindow {
+            label: format!("notebook-{}", uuid::Uuid::new_v4()),
+            title: "Untitled.ipynb".to_string(),
+            mode: OpenMode::Create {
+                runtime: runtime.to_string(),
+                working_dir: working_dir.clone(),
+                notebook_id: None,
+            },
+        }]
+    } else {
+        startup_windows
+    };
 
-        let placeholder_id = match &mode {
+    // Register all startup window contexts in the registry before setup
+    for sw in &startup_windows {
+        let placeholder_id = match &sw.mode {
             OpenMode::Open { path } => path
                 .canonicalize()
                 .unwrap_or_else(|_| path.clone())
@@ -3451,20 +3433,18 @@ pub fn run(
             } => String::new(),
         };
         let context = create_window_context_for_daemon(
-            match &mode {
+            match &sw.mode {
                 OpenMode::Open { path } => Some(path.clone()),
                 _ => None,
             },
             working_dir.clone(),
             placeholder_id,
-            runtime,
+            runtime.clone(),
         );
         window_registry
-            .insert(&label, context.clone())
+            .insert(&sw.label, context)
             .map_err(anyhow::Error::msg)?;
-
-        (title, Some(label), Some(context), Some(mode))
-    };
+    }
 
     // Guard against concurrent reconnect attempts
     let reconnect_in_progress = ReconnectInProgress(Arc::new(AtomicBool::new(false)));
@@ -3591,22 +3571,29 @@ pub fn run(
                 .build()?;
 
                 log::info!("[startup] Created dedicated onboarding window");
-            } else if let Some(ref label) = first_window_label {
-                // Create the first notebook window with a proper label.
-                // The window appears immediately with a loading UI; daemon sync
-                // happens later in the async block after the daemon is confirmed available.
-                let _notebook_window = tauri::WebviewWindowBuilder::new(
-                    app,
-                    label,
-                    tauri::WebviewUrl::default(),
-                )
-                .title(&window_title)
-                .inner_size(1100.0, 750.0)
-                .min_inner_size(400.0, 250.0)
-                .resizable(true)
-                .build()?;
-
-                log::info!("[startup] Created first notebook window: {}", label);
+            } else {
+                // Create ALL notebook windows immediately. Each shows a loading UI
+                // until the daemon is ready and sync completes.
+                for sw in &startup_windows {
+                    match tauri::WebviewWindowBuilder::new(
+                        app,
+                        &sw.label,
+                        tauri::WebviewUrl::default(),
+                    )
+                    .title(&sw.title)
+                    .inner_size(1100.0, 750.0)
+                    .min_inner_size(400.0, 250.0)
+                    .resizable(true)
+                    .build()
+                    {
+                        Ok(_) => log::info!("[startup] Created notebook window: {}", sw.label),
+                        Err(e) => log::warn!(
+                            "[startup] Failed to create window '{}': {}",
+                            sw.label,
+                            e
+                        ),
+                    }
+                }
                 refresh_native_menu(
                     app.handle(),
                     app.state::<WindowNotebookRegistry>().inner(),
@@ -3637,28 +3624,6 @@ pub fn run(
             let menu = crate::menu::create_menu(app.handle(), &window_display_names)?;
             app.set_menu(menu)?;
 
-            // Additional session windows (exclude the primary, already created in setup).
-            // Created after daemon is confirmed available to avoid sync tasks
-            // racing with daemon startup.
-            let additional_session_windows: Vec<session::WindowSession> =
-                if let Some(ref session) = restored_session {
-                    // Find the primary label used during restore. This matches the
-                    // session entry selected in the startup block above.
-                    let primary = session
-                        .primary_label
-                        .as_ref()
-                        .and_then(|label| session.windows.iter().find(|w| &w.label == label))
-                        .or_else(|| session.windows.first());
-                    let primary_label = primary.map(|w| w.label.as_str());
-                    session
-                        .windows
-                        .iter()
-                        .filter(|w| primary_label.is_none_or(|p| w.label != p))
-                        .cloned()
-                        .collect()
-                } else {
-                    Vec::new()
-                };
             let has_session_to_clear = restored_session.is_some();
 
             // Ensure runtimed is running (required for daemon-only mode)
@@ -3666,9 +3631,7 @@ pub fn run(
             let app_for_daemon = app.handle().clone();
             let app_for_sync = app.handle().clone();
             let app_for_notebook_sync = app.handle().clone();
-            let app_for_session_restore = app.handle().clone();
             let registry_for_notebook_sync = registry_for_sync.clone();
-            let registry_for_session_restore = registry_for_sync.clone();
             let daemon_status_for_callback = daemon_status_for_startup.clone();
             // Capture for async block - onboarding doesn't need notebook sync
             let skip_notebook_sync = needs_onboarding;
@@ -3712,19 +3675,18 @@ pub fn run(
                 // Reports prewarm pool errors to UI so users know when default packages fail
                 tokio::spawn(run_pool_state_sync(app_for_sync));
 
-                // Initialize notebook sync if daemon is available
+                // Initialize notebook sync for all startup windows.
                 // Skip during onboarding - the onboarding window doesn't need notebook sync,
-                // it just needs daemon progress events
+                // it just needs daemon progress events.
                 if daemon_available && !skip_notebook_sync {
-                    if let (Some(mode), Some(ref label)) =
-                        (first_open_mode, &first_window_label)
-                    {
+                    let mut any_success = false;
+                    for sw in startup_windows {
                         match (
-                            app_for_notebook_sync.get_webview_window(label),
-                            registry_for_notebook_sync.get(label),
+                            app_for_notebook_sync.get_webview_window(&sw.label),
+                            registry_for_notebook_sync.get(&sw.label),
                         ) {
                             (Some(window), Ok(context)) => {
-                                let result = match mode {
+                                let result = match sw.mode {
                                     OpenMode::Open { path } => {
                                         initialize_notebook_sync_open(
                                             window,
@@ -3755,14 +3717,15 @@ pub fn run(
                                 match result {
                                     Ok(()) => {
                                         log::info!(
-                                            "[startup] Notebook sync initialized successfully"
+                                            "[startup] Notebook sync initialized for '{}'",
+                                            sw.label
                                         );
-                                        daemon_sync_success_for_init
-                                            .store(true, Ordering::SeqCst);
+                                        any_success = true;
                                     }
                                     Err(e) => {
                                         log::warn!(
-                                            "[startup] Notebook sync initialization failed: {}",
+                                            "[startup] Notebook sync failed for '{}': {}",
+                                            sw.label,
                                             e
                                         );
                                     }
@@ -3770,18 +3733,21 @@ pub fn run(
                             }
                             (None, _) => {
                                 log::warn!(
-                                    "[startup] Notebook window '{}' missing during sync init",
-                                    label
+                                    "[startup] Window '{}' missing during sync init",
+                                    sw.label
                                 );
                             }
                             (_, Err(e)) => {
                                 log::warn!(
-                                    "[startup] Notebook context for '{}' missing: {}",
-                                    label,
+                                    "[startup] Context for '{}' missing: {}",
+                                    sw.label,
                                     e
                                 );
                             }
                         }
+                    }
+                    if any_success {
+                        daemon_sync_success_for_init.store(true, Ordering::SeqCst);
                     }
                 } else if daemon_available && skip_notebook_sync {
                     // Onboarding mode: daemon is available, notebook sync deliberately skipped
@@ -3792,68 +3758,7 @@ pub fn run(
                 // Signal that daemon sync attempt is complete (success or failure)
                 daemon_sync_complete_for_init.store(true, Ordering::SeqCst);
 
-                // Restore additional session windows now that the daemon is available.
-                // Creating them here (instead of in synchronous setup) ensures their
-                // sync tasks don't race with daemon startup.
-                if daemon_available && !additional_session_windows.is_empty() {
-                    log::info!(
-                        "[session] Restoring {} additional window(s) after daemon ready",
-                        additional_session_windows.len()
-                    );
-                    for window_session in &additional_session_windows {
-                        let label = session::window_label_for_session(window_session);
-                        let mode = match (&window_session.path, &window_session.env_id) {
-                            (Some(path), _) if path.exists() => {
-                                info!(
-                                    "[session] Restoring window from path: {}",
-                                    path.display()
-                                );
-                                OpenMode::Open { path: path.clone() }
-                            }
-                            (_, Some(env_id)) => {
-                                info!(
-                                    "[session] Restoring untitled window: {}",
-                                    env_id
-                                );
-                                OpenMode::Create {
-                                    runtime: window_session.runtime.clone(),
-                                    working_dir: None,
-                                    notebook_id: Some(env_id.clone()),
-                                }
-                            }
-                            _ => {
-                                let rt: Runtime =
-                                    window_session.runtime.parse().unwrap_or(Runtime::Python);
-                                OpenMode::Create {
-                                    runtime: rt.to_string(),
-                                    working_dir: None,
-                                    notebook_id: None,
-                                }
-                            }
-                        };
-                        match create_notebook_window_for_daemon(
-                            &app_for_session_restore,
-                            &registry_for_session_restore,
-                            mode,
-                            Some(label.clone()),
-                        ) {
-                            Ok(created_label) => {
-                                info!(
-                                    "[session] Restored additional window: {}",
-                                    created_label
-                                );
-                            }
-                            Err(e) => {
-                                warn!(
-                                    "[session] Failed to create window for {}: {}",
-                                    label, e
-                                );
-                            }
-                        }
-                    }
-                }
-
-                // Clear session file after all windows have been restored (or
+                // Clear session file after all windows have been synced (or
                 // attempted). Keeping it until now allows a retry on next launch
                 // if the daemon was unavailable this time.
                 if has_session_to_clear {

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -3354,8 +3354,14 @@ pub fn run(
             }
             None => {
                 if let Some(ref session) = restored_session {
-                    // Use the first session window (was the primary window at save time).
-                    if let Some(first_session) = session.windows.first() {
+                    // Find the primary window: use explicit primary_label if present,
+                    // otherwise fall back to first entry (sorted by label during save).
+                    let primary = session
+                        .primary_label
+                        .as_ref()
+                        .and_then(|label| session.windows.iter().find(|w| &w.label == label))
+                        .or_else(|| session.windows.first());
+                    if let Some(first_session) = primary {
                         match (&first_session.path, &first_session.env_id) {
                             (Some(path), _) if path.exists() => {
                                 let title = path
@@ -3631,12 +3637,25 @@ pub fn run(
             let menu = crate::menu::create_menu(app.handle(), &window_display_names)?;
             app.set_menu(menu)?;
 
-            // Additional session windows (skip first, already created in setup).
+            // Additional session windows (exclude the primary, already created in setup).
             // Created after daemon is confirmed available to avoid sync tasks
             // racing with daemon startup.
             let additional_session_windows: Vec<session::WindowSession> =
-                if let Some(session) = &restored_session {
-                    session.windows.iter().skip(1).cloned().collect()
+                if let Some(ref session) = restored_session {
+                    // Find the primary label used during restore. This matches the
+                    // session entry selected in the startup block above.
+                    let primary = session
+                        .primary_label
+                        .as_ref()
+                        .and_then(|label| session.windows.iter().find(|w| &w.label == label))
+                        .or_else(|| session.windows.first());
+                    let primary_label = primary.map(|w| w.label.as_str());
+                    session
+                        .windows
+                        .iter()
+                        .filter(|w| primary_label.is_none_or(|p| w.label != p))
+                        .cloned()
+                        .collect()
                 } else {
                     Vec::new()
                 };

--- a/crates/notebook/src/session.rs
+++ b/crates/notebook/src/session.rs
@@ -11,7 +11,7 @@ use std::path::PathBuf;
 /// Represents a single window's session state.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WindowSession {
-    /// Window label (e.g., "main", "notebook-{hash}")
+    /// Window label (e.g., "notebook-{hash}")
     pub label: String,
     /// File path for saved notebooks, None for untitled
     pub path: Option<PathBuf>,
@@ -173,10 +173,6 @@ pub(crate) fn clear_session_at(path: &std::path::Path) {
 ///
 /// Uses deterministic labels so window-state plugin can restore geometry.
 pub fn window_label_for_session(session: &WindowSession) -> String {
-    if session.label == "main" {
-        return "main".to_string();
-    }
-
     if let Some(path) = &session.path {
         // Hash the path for a stable label
         let hash = runtimed::worktree_hash(path);
@@ -232,7 +228,10 @@ mod tests {
         std::fs::write(&saved_path, "{}").unwrap();
 
         let registry = test_registry(vec![
-            ("main", test_context(Some(saved_path.clone()), "")),
+            (
+                "notebook-ab1234cd",
+                test_context(Some(saved_path.clone()), ""),
+            ),
             ("notebook-abc12345", test_context(None, "env-uuid-1234")),
         ]);
 
@@ -243,9 +242,13 @@ mod tests {
         assert_eq!(loaded.schema_version, SessionState::CURRENT_SCHEMA_VERSION);
         assert_eq!(loaded.windows.len(), 2);
 
-        let main_win = loaded.windows.iter().find(|w| w.label == "main").unwrap();
-        assert_eq!(main_win.path.as_ref().unwrap(), &saved_path);
-        assert!(main_win.env_id.is_none());
+        let saved_win = loaded
+            .windows
+            .iter()
+            .find(|w| w.label == "notebook-ab1234cd")
+            .unwrap();
+        assert_eq!(saved_win.path.as_ref().unwrap(), &saved_path);
+        assert!(saved_win.env_id.is_none());
 
         let untitled = loaded
             .windows
@@ -295,7 +298,7 @@ mod tests {
             schema_version: SessionState::CURRENT_SCHEMA_VERSION,
             saved_at: stale_time.to_rfc3339(),
             windows: vec![WindowSession {
-                label: "main".to_string(),
+                label: "notebook-test1234".to_string(),
                 path: None,
                 env_id: Some("test".to_string()),
                 runtime: "python".to_string(),
@@ -312,7 +315,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let session_path = dir.path().join("session.json");
 
-        let registry = test_registry(vec![("main", test_context(None, "env-id"))]);
+        let registry = test_registry(vec![("notebook-env12345", test_context(None, "env-id"))]);
         save_session_to(&registry, &session_path).unwrap();
         assert!(session_path.exists());
 
@@ -333,17 +336,6 @@ mod tests {
         let label2 = window_label_for_session(&session);
         assert_eq!(label1, label2);
         assert!(label1.starts_with("notebook-"));
-    }
-
-    #[test]
-    fn test_window_label_main_passthrough() {
-        let session = WindowSession {
-            label: "main".to_string(),
-            path: None,
-            env_id: None,
-            runtime: "python".to_string(),
-        };
-        assert_eq!(window_label_for_session(&session), "main");
     }
 
     #[test]
@@ -371,7 +363,7 @@ mod tests {
 
         // Populate registry with 3 entries: 2 real windows + 1 ghost
         let registry = test_registry(vec![
-            ("main", test_context(Some(nb_path.clone()), "")),
+            ("notebook-primary1", test_context(Some(nb_path.clone()), "")),
             ("notebook-real", test_context(None, "env-uuid-5678")),
             ("notebook-ghost", test_context(None, "env-ghost-dead")),
         ]);
@@ -380,7 +372,7 @@ mod tests {
         assert_eq!(registry.contexts.lock().unwrap().len(), 3);
 
         // Prune: simulate that "notebook-ghost" window no longer exists
-        // (only "main" and "notebook-real" are live windows)
+        // (only "notebook-primary1" and "notebook-real" are live windows)
         registry.prune_where(|label| label == "notebook-ghost");
 
         // Ghost entry is gone from the registry
@@ -397,7 +389,7 @@ mod tests {
 
         assert_eq!(loaded.windows.len(), 2);
         let labels: Vec<&str> = loaded.windows.iter().map(|w| w.label.as_str()).collect();
-        assert!(labels.contains(&"main"));
+        assert!(labels.contains(&"notebook-primary1"));
         assert!(labels.contains(&"notebook-real"));
         assert!(!labels.contains(&"notebook-ghost"));
     }

--- a/crates/notebook/src/session.rs
+++ b/crates/notebook/src/session.rs
@@ -29,7 +29,11 @@ pub struct SessionState {
     pub schema_version: u32,
     /// ISO 8601 timestamp when session was saved
     pub saved_at: String,
-    /// List of open windows
+    /// Label of the window that should be restored first (the primary notebook).
+    /// When absent (e.g., old session files), the first entry in `windows` is used.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub primary_label: Option<String>,
+    /// List of open windows (sorted by label for deterministic ordering)
     pub windows: Vec<WindowSession>,
 }
 
@@ -53,7 +57,7 @@ pub(crate) fn save_session_to(
 ) -> Result<(), String> {
     let contexts = registry.contexts.lock().map_err(|e| e.to_string())?;
 
-    let windows: Vec<WindowSession> = contexts
+    let mut windows: Vec<WindowSession> = contexts
         .iter()
         .filter_map(|(label, context)| {
             let path = context.path.lock().ok()?.clone();
@@ -81,9 +85,16 @@ pub(crate) fn save_session_to(
         return Ok(());
     }
 
+    // Sort by label for deterministic ordering (HashMap iteration is arbitrary).
+    windows.sort_by(|a, b| a.label.cmp(&b.label));
+
+    // Use the first window as the primary (the one to restore in the startup window).
+    let primary_label = windows.first().map(|w| w.label.clone());
+
     let session = SessionState {
         schema_version: SessionState::CURRENT_SCHEMA_VERSION,
         saved_at: chrono::Utc::now().to_rfc3339(),
+        primary_label,
         windows,
     };
 
@@ -242,19 +253,18 @@ mod tests {
         assert_eq!(loaded.schema_version, SessionState::CURRENT_SCHEMA_VERSION);
         assert_eq!(loaded.windows.len(), 2);
 
-        let saved_win = loaded
-            .windows
-            .iter()
-            .find(|w| w.label == "notebook-ab1234cd")
-            .unwrap();
+        // Windows are sorted by label for deterministic ordering
+        assert_eq!(loaded.windows[0].label, "notebook-ab1234cd");
+        assert_eq!(loaded.windows[1].label, "notebook-abc12345");
+
+        // Primary label is set to the first sorted window
+        assert_eq!(loaded.primary_label.as_deref(), Some("notebook-ab1234cd"));
+
+        let saved_win = &loaded.windows[0];
         assert_eq!(saved_win.path.as_ref().unwrap(), &saved_path);
         assert!(saved_win.env_id.is_none());
 
-        let untitled = loaded
-            .windows
-            .iter()
-            .find(|w| w.label == "notebook-abc12345")
-            .unwrap();
+        let untitled = &loaded.windows[1];
         assert!(untitled.path.is_none());
         assert_eq!(untitled.env_id.as_deref().unwrap(), "env-uuid-1234");
         assert_eq!(untitled.runtime, "python");
@@ -297,6 +307,7 @@ mod tests {
         let session = SessionState {
             schema_version: SessionState::CURRENT_SCHEMA_VERSION,
             saved_at: stale_time.to_rfc3339(),
+            primary_label: Some("notebook-test1234".to_string()),
             windows: vec![WindowSession {
                 label: "notebook-test1234".to_string(),
                 path: None,

--- a/crates/notebook/src/session.rs
+++ b/crates/notebook/src/session.rs
@@ -29,11 +29,7 @@ pub struct SessionState {
     pub schema_version: u32,
     /// ISO 8601 timestamp when session was saved
     pub saved_at: String,
-    /// Label of the window that should be restored first (the primary notebook).
-    /// When absent (e.g., old session files), the first entry in `windows` is used.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub primary_label: Option<String>,
-    /// List of open windows (sorted by label for deterministic ordering)
+    /// List of open windows
     pub windows: Vec<WindowSession>,
 }
 
@@ -57,7 +53,7 @@ pub(crate) fn save_session_to(
 ) -> Result<(), String> {
     let contexts = registry.contexts.lock().map_err(|e| e.to_string())?;
 
-    let mut windows: Vec<WindowSession> = contexts
+    let windows: Vec<WindowSession> = contexts
         .iter()
         .filter_map(|(label, context)| {
             let path = context.path.lock().ok()?.clone();
@@ -85,16 +81,9 @@ pub(crate) fn save_session_to(
         return Ok(());
     }
 
-    // Sort by label for deterministic ordering (HashMap iteration is arbitrary).
-    windows.sort_by(|a, b| a.label.cmp(&b.label));
-
-    // Use the first window as the primary (the one to restore in the startup window).
-    let primary_label = windows.first().map(|w| w.label.clone());
-
     let session = SessionState {
         schema_version: SessionState::CURRENT_SCHEMA_VERSION,
         saved_at: chrono::Utc::now().to_rfc3339(),
-        primary_label,
         windows,
     };
 
@@ -253,18 +242,19 @@ mod tests {
         assert_eq!(loaded.schema_version, SessionState::CURRENT_SCHEMA_VERSION);
         assert_eq!(loaded.windows.len(), 2);
 
-        // Windows are sorted by label for deterministic ordering
-        assert_eq!(loaded.windows[0].label, "notebook-ab1234cd");
-        assert_eq!(loaded.windows[1].label, "notebook-abc12345");
-
-        // Primary label is set to the first sorted window
-        assert_eq!(loaded.primary_label.as_deref(), Some("notebook-ab1234cd"));
-
-        let saved_win = &loaded.windows[0];
+        let saved_win = loaded
+            .windows
+            .iter()
+            .find(|w| w.label == "notebook-ab1234cd")
+            .unwrap();
         assert_eq!(saved_win.path.as_ref().unwrap(), &saved_path);
         assert!(saved_win.env_id.is_none());
 
-        let untitled = &loaded.windows[1];
+        let untitled = loaded
+            .windows
+            .iter()
+            .find(|w| w.label == "notebook-abc12345")
+            .unwrap();
         assert!(untitled.path.is_none());
         assert_eq!(untitled.env_id.as_deref().unwrap(), "env-uuid-1234");
         assert_eq!(untitled.runtime, "python");
@@ -307,7 +297,6 @@ mod tests {
         let session = SessionState {
             schema_version: SessionState::CURRENT_SCHEMA_VERSION,
             saved_at: stale_time.to_rfc3339(),
-            primary_label: Some("notebook-test1234".to_string()),
             windows: vec![WindowSession {
                 label: "notebook-test1234".to_string(),
                 path: None,

--- a/crates/notebook/tauri.conf.json
+++ b/crates/notebook/tauri.conf.json
@@ -10,16 +10,7 @@
     "beforeBuildCommand": "pnpm --dir apps/notebook build"
   },
   "app": {
-    "windows": [
-      {
-        "title": "Untitled.ipynb",
-        "width": 1100,
-        "height": 750,
-        "minWidth": 400,
-        "minHeight": 250,
-        "resizable": true
-      }
-    ],
+    "windows": [],
     "security": {
       "csp": null
     }


### PR DESCRIPTION
## Summary

- **Root cause**: `tauri-plugin-window-state` persists window geometry by label. The app reused Tauri's auto-created `"main"` window as the first notebook, but this generic label accumulated stale geometry — if it was ever saved at a tiny size, every subsequent launch restored that tiny window.
- **Fix**: All notebook windows (including the first) are now created explicitly with proper `"notebook-{hash}"` labels through the same code path used by `create_notebook_window_for_daemon`. No more `"main"` special case.
- Empties the `windows` array in `tauri.conf.json` (no auto-created default window)
- Adds `"main"` to the window-state plugin denylist as a safety net for users upgrading from older versions
- Removes `"main"` special cases from: window close handler, file association (Finder double-click), macOS dock reopen, and session restore
- Session restore now uses the first entry rather than finding `label == "main"`
- Adds `find_empty_window_label()` to generically reuse any untitled window for file association

Closes #849

## Test plan

- [ ] Launch app fresh (no session) — opens with proper `notebook-*` label
- [ ] Open a saved notebook — gets deterministic `notebook-{hash}` label
- [ ] Close and relaunch — window geometry restores correctly
- [ ] Delete `~/Library/Application Support/io.nteract.runt-nightly/.window-state.json`, resize window tiny, quit, relaunch — does NOT restore tiny size (fresh label)
- [ ] File association (double-click `.ipynb` in Finder) — opens in empty window or new window
- [ ] macOS dock click with no windows — creates new notebook
- [ ] Session restore (Cmd+Q and relaunch) — all windows restore
- [ ] Upgrade from old version with `"main"` in `session.json` — restores correctly with new label