### PR TITLE
fix(mcp): remove inaccurate cell_count and needs_trust_approval from tool responses

### DIFF
--- a/python/nteract/src/nteract/_mcp_server.py
+++ b/python/nteract/src/nteract/_mcp_server.py
@@ -606,12 +606,9 @@ async def open_notebook(path: str, ctx: Context | None = None) -> dict[str, Any]
 
     _session = await runtimed.AsyncSession.open_notebook(path, peer_label=_peer_label())
     session = _session
-    info = await session.connection_info()
     return {
         "notebook_id": session.notebook_id,
         "path": path,
-        "cell_count": info.cell_count if info else 0,
-        "needs_trust_approval": info.needs_trust_approval if info else False,
     }
 
 
@@ -634,11 +631,9 @@ async def create_notebook(
         runtime=runtime, working_dir=working_dir, peer_label=_peer_label()
     )
     session = _session
-    info = await session.connection_info()
     return {
         "notebook_id": session.notebook_id,
         "runtime": runtime,
-        "cell_count": info.cell_count if info else 1,
     }
 
 


### PR DESCRIPTION
Removes misleading fields from the `open_notebook` and `create_notebook` MCP tool responses:

- `cell_count` shows 0 on first call since the CRDT doc hasn't synced yet
- `needs_trust_approval` is an internal UI concern, not actionable by agents

Also removed the unused `connection_info()` calls.

_PR submitted by @rgbkrk's agent, Quill_