### PR TITLE
fix(session): upgrade session save, migrate main geometry, correct scale factor

### DIFF
--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -3690,8 +3690,18 @@ pub fn run(
     // Pre-97b0422f versions used a hardcoded "main" label for the first window.
     // The plugin now denylists "main", orphaning its saved geometry. This renames
     // the entry so the new deterministic label picks up the old geometry.
-    if let Some(ref session) = restored_session {
-        migrate_main_window_state(session);
+    //
+    // Runs unconditionally: the session file may exist even when restored_session
+    // is None (e.g., Finder launch, expired session, CLI open). Uses the
+    // age-ignoring loader so stale sessions still trigger the one-time migration.
+    {
+        let session_for_migration = restored_session
+            .as_ref()
+            .cloned()
+            .or_else(session::load_session_ignoring_age);
+        if let Some(ref session) = session_for_migration {
+            migrate_main_window_state(session);
+        }
     }
 
     let app = tauri::Builder::default()
@@ -4257,19 +4267,38 @@ pub fn run(
     #[cfg(any(target_os = "macos", target_os = "ios"))]
     let registry_for_open = window_registry.clone();
     let registry_for_session = window_registry.clone();
+    let registry_for_exit_session = window_registry.clone();
     let registry_for_window_close = window_registry.clone();
     app.run(move |app_handle, event| {
-        // Keep the app process alive when the final window is closed on macOS.
-        // Other platforms should exit when the final window closes.
+        // Save session at ExitRequested — before windows are destroyed.
+        // WindowEvent::Destroyed removes registry entries, so by RunEvent::Exit
+        // the registry is empty and save_session() would no-op.
         #[cfg(target_os = "macos")]
         if let RunEvent::ExitRequested { code, api, .. } = &event {
             if code.is_none() && app_handle.webview_windows().is_empty() {
+                // Last window closed via X — keep app alive for dock (macOS)
                 log::info!("[app] Preventing exit after closing last window (macOS)");
                 clear_all_notebook_sync_handles(
                     &registry_for_window_close,
                     "macos last-window close",
                 );
                 api.prevent_exit();
+            } else {
+                // Real quit (Cmd+Q or code-initiated). Save now while windows are alive.
+                log::info!("[session] Saving session before windows are destroyed");
+                registry_for_exit_session.prune_stale_entries(app_handle);
+                if let Err(e) = session::save_session(&registry_for_exit_session, app_handle) {
+                    log::error!("[session] Failed to save session on exit: {}", e);
+                }
+            }
+        }
+
+        #[cfg(not(target_os = "macos"))]
+        if let RunEvent::ExitRequested { .. } = &event {
+            log::info!("[session] Saving session before windows are destroyed");
+            registry_for_exit_session.prune_stale_entries(app_handle);
+            if let Err(e) = session::save_session(&registry_for_exit_session, app_handle) {
+                log::error!("[session] Failed to save session on exit: {}", e);
             }
         }
 
@@ -4299,14 +4328,13 @@ pub fn run(
             refresh_native_menu(app_handle, &registry_for_window_close);
         }
 
-        // Save session state when app is about to exit
-        // Use Exit (not ExitRequested) as it fires reliably on all platforms
+        // Fallback session save. ExitRequested (above) is the primary save point;
+        // by this time Destroyed events have usually emptied the registry, so
+        // save_session returns early without overwriting.
         if let RunEvent::Exit = &event {
-            log::info!("[session] App exiting, saving session...");
+            log::info!("[session] App exiting, saving session (fallback)...");
             if let Err(e) = session::save_session(&registry_for_session, app_handle) {
                 log::error!("[session] Failed to save session: {}", e);
-            } else {
-                log::info!("[session] Session saved successfully");
             }
         }
 

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -1003,6 +1003,16 @@ async fn run_upgrade(
 ) -> Result<(), String> {
     log::info!("[upgrade] Starting upgrade sequence...");
 
+    // Save session now in case begin_upgrade() missed windows that were still
+    // loading, or new windows were opened between begin_upgrade() and this call.
+    // This overwrites the file begin_upgrade() wrote, which is fine — the
+    // registry is strictly a superset at this point.
+    registry.prune_stale_entries(&app);
+    if let Err(e) = session::save_session(registry.inner(), &app) {
+        log::warn!("[upgrade] Failed to re-save session: {}", e);
+        // Non-fatal — begin_upgrade() already saved a session
+    }
+
     // Step 1: Save all dirty notebooks
     app.emit("upgrade:progress", UpgradeProgress::SavingNotebooks)
         .map_err(|e| e.to_string())?;
@@ -4247,14 +4257,10 @@ pub fn run(
     #[cfg(any(target_os = "macos", target_os = "ios"))]
     let registry_for_open = window_registry.clone();
     let registry_for_session = window_registry.clone();
-    let registry_for_exit_session = window_registry.clone();
     let registry_for_window_close = window_registry.clone();
     app.run(move |app_handle, event| {
         // Keep the app process alive when the final window is closed on macOS.
         // Other platforms should exit when the final window closes.
-        //
-        // Session save happens here (not at RunEvent::Exit) because Exit fires
-        // AFTER WindowEvent::Destroyed removes all registry entries.
         #[cfg(target_os = "macos")]
         if let RunEvent::ExitRequested { code, api, .. } = &event {
             if code.is_none() && app_handle.webview_windows().is_empty() {
@@ -4264,23 +4270,6 @@ pub fn run(
                     "macos last-window close",
                 );
                 api.prevent_exit();
-            } else {
-                // Real quit (Cmd+Q, menu quit, or code-initiated exit).
-                // Save session now while registry still has live entries.
-                log::info!("[session] ExitRequested: saving session before windows are destroyed");
-                registry_for_exit_session.prune_stale_entries(app_handle);
-                if let Err(e) = session::save_session(&registry_for_exit_session, app_handle) {
-                    log::error!("[session] Failed to save session on exit: {}", e);
-                }
-            }
-        }
-
-        #[cfg(not(target_os = "macos"))]
-        if let RunEvent::ExitRequested { .. } = &event {
-            log::info!("[session] ExitRequested: saving session before windows are destroyed");
-            registry_for_exit_session.prune_stale_entries(app_handle);
-            if let Err(e) = session::save_session(&registry_for_exit_session, app_handle) {
-                log::error!("[session] Failed to save session on exit: {}", e);
             }
         }
 
@@ -4310,14 +4299,14 @@ pub fn run(
             refresh_native_menu(app_handle, &registry_for_window_close);
         }
 
-        // Fallback session save at Exit. Normally ExitRequested (above) saves
-        // the session while windows are still alive. This fires after windows
-        // are destroyed, so the registry is usually empty and save_session
-        // returns early without overwriting the file already written above.
+        // Save session state when app is about to exit
+        // Use Exit (not ExitRequested) as it fires reliably on all platforms
         if let RunEvent::Exit = &event {
-            log::info!("[session] App exiting, saving session (fallback)...");
+            log::info!("[session] App exiting, saving session...");
             if let Err(e) = session::save_session(&registry_for_session, app_handle) {
                 log::error!("[session] Failed to save session: {}", e);
+            } else {
+                log::info!("[session] Session saved successfully");
             }
         }
 

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -871,7 +871,7 @@ async fn begin_upgrade(
     registry.prune_stale_entries(&app);
 
     // Save session for restore after relaunch
-    session::save_session(registry.inner())?;
+    session::save_session(registry.inner(), &app)?;
     log::info!("[upgrade] Session saved");
 
     // Create dedicated upgrade window
@@ -3379,6 +3379,108 @@ fn clear_all_notebook_sync_handles(registry: &WindowNotebookRegistry, reason: &'
     clear_notebook_sync_handles(handles, reason);
 }
 
+/// Migrate stale "main" window geometry to the new deterministic label.
+///
+/// Before commit 97b0422f, the first notebook window used a hardcoded "main" label.
+/// The window-state plugin now denylists "main", orphaning its saved geometry.
+/// This renames the "main" entry in `.window-state.json` so the new hash-based
+/// label (`notebook-{hash}`) inherits the old geometry on first launch after upgrade.
+fn migrate_main_window_state(session: &session::SessionState) {
+    // Find the session entry that was previously the "main" window.
+    // The old code always used "main" for the first window, so look for
+    // entries with label "main" or (more commonly after the fix was applied)
+    // compute what label the first entry would get.
+    let main_entry = session.windows.iter().find(|w| w.label == "main");
+    let Some(entry) = main_entry else {
+        return;
+    };
+
+    let new_label = session::window_label_for_session(entry);
+
+    // Compute the window-state plugin's config directory.
+    // On macOS: ~/Library/Application Support/org.nteract.desktop/
+    let Some(config_base) = dirs::config_dir() else {
+        return;
+    };
+    let state_path = config_base
+        .join("org.nteract.desktop")
+        .join(".window-state.json");
+
+    if !state_path.exists() {
+        return;
+    }
+
+    let Ok(contents) = std::fs::read_to_string(&state_path) else {
+        return;
+    };
+    let Ok(mut map) = serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(&contents)
+    else {
+        return;
+    };
+
+    // Only migrate if "main" exists and the new label doesn't already have geometry
+    if let Some(main_state) = map.remove("main") {
+        if !map.contains_key(&new_label) {
+            log::info!(
+                "[window-state] Migrating geometry from 'main' to '{}'",
+                new_label
+            );
+            map.insert(new_label, main_state);
+        } else {
+            log::info!(
+                "[window-state] Removed stale 'main' entry (new label already has geometry)"
+            );
+        }
+
+        if let Ok(json) = serde_json::to_string_pretty(&serde_json::Value::Object(map)) {
+            let _ = std::fs::write(&state_path, json);
+        }
+    }
+}
+
+/// Correct window size after the window-state plugin restores physical pixels
+/// from a monitor with a different scale factor.
+///
+/// The plugin stores raw physical pixels. A window saved at 1100x750 physical
+/// on a 1x external monitor would appear as 550x375 logical on a 2x Retina
+/// display. This function adjusts the physical size to preserve the logical size.
+fn correct_window_scale(window: &tauri::WebviewWindow, saved_scale_factor: Option<f64>) {
+    let Some(saved_scale) = saved_scale_factor else {
+        return;
+    };
+    let Ok(current_scale) = window.scale_factor() else {
+        return;
+    };
+
+    let ratio = current_scale / saved_scale;
+    // Only correct if the difference is significant (> 5%)
+    if (ratio - 1.0).abs() < 0.05 {
+        return;
+    }
+
+    let Ok(current_size) = window.inner_size() else {
+        return;
+    };
+
+    // The plugin restored physical pixels from the old monitor.
+    // To preserve logical size: new_physical = old_physical * (new_scale / old_scale)
+    let corrected_width = (current_size.width as f64 * ratio) as u32;
+    let corrected_height = (current_size.height as f64 * ratio) as u32;
+
+    log::info!(
+        "[window] Scale correction for {}: {}x{} -> {}x{} (scale {:.1} -> {:.1})",
+        window.label(),
+        current_size.width,
+        current_size.height,
+        corrected_width,
+        corrected_height,
+        saved_scale,
+        current_scale,
+    );
+
+    let _ = window.set_size(tauri::PhysicalSize::new(corrected_width, corrected_height));
+}
+
 /// Run the notebook Tauri app.
 ///
 /// If `notebook_path` is Some, opens that file. If None, creates a new empty notebook.
@@ -3429,6 +3531,7 @@ pub fn run(
         label: String,
         title: String,
         mode: OpenMode,
+        saved_scale_factor: Option<f64>,
     }
 
     let startup_windows: Vec<StartupWindow> = if needs_onboarding {
@@ -3446,6 +3549,7 @@ pub fn run(
             label: format!("notebook-{}", &hash[..8]),
             title,
             mode: OpenMode::Open { path: path.clone() },
+            saved_scale_factor: None,
         }]
     } else if let Some(ref session) = restored_session {
         // Session restore: recreate all windows from the saved session
@@ -3480,7 +3584,12 @@ pub fn run(
                         return None;
                     }
                 };
-                Some(StartupWindow { label, title, mode })
+                Some(StartupWindow {
+                    label,
+                    title,
+                    mode,
+                    saved_scale_factor: ws.scale_factor,
+                })
             })
             .collect()
     } else {
@@ -3493,6 +3602,7 @@ pub fn run(
                 working_dir: working_dir.clone(),
                 notebook_id: None,
             },
+            saved_scale_factor: None,
         }]
     };
 
@@ -3506,6 +3616,7 @@ pub fn run(
                 working_dir: working_dir.clone(),
                 notebook_id: None,
             },
+            saved_scale_factor: None,
         }]
     } else {
         startup_windows
@@ -3564,6 +3675,14 @@ pub fn run(
     // Clone for auto-launch coordination
     let daemon_sync_complete_for_autolaunch = daemon_sync_complete.clone();
     let daemon_sync_success_for_autolaunch = daemon_sync_success.clone();
+
+    // Migrate stale "main" window geometry before the window-state plugin loads.
+    // Pre-97b0422f versions used a hardcoded "main" label for the first window.
+    // The plugin now denylists "main", orphaning its saved geometry. This renames
+    // the entry so the new deterministic label picks up the old geometry.
+    if let Some(ref session) = restored_session {
+        migrate_main_window_state(session);
+    }
 
     let app = tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
@@ -3684,7 +3803,10 @@ pub fn run(
                     .resizable(true)
                     .build()
                     {
-                        Ok(_) => log::info!("[startup] Created notebook window: {}", sw.label),
+                        Ok(window) => {
+                            log::info!("[startup] Created notebook window: {}", sw.label);
+                            correct_window_scale(&window, sw.saved_scale_factor);
+                        }
                         Err(e) => log::warn!(
                             "[startup] Failed to create window '{}': {}",
                             sw.label,
@@ -4125,10 +4247,14 @@ pub fn run(
     #[cfg(any(target_os = "macos", target_os = "ios"))]
     let registry_for_open = window_registry.clone();
     let registry_for_session = window_registry.clone();
+    let registry_for_exit_session = window_registry.clone();
     let registry_for_window_close = window_registry.clone();
     app.run(move |app_handle, event| {
         // Keep the app process alive when the final window is closed on macOS.
         // Other platforms should exit when the final window closes.
+        //
+        // Session save happens here (not at RunEvent::Exit) because Exit fires
+        // AFTER WindowEvent::Destroyed removes all registry entries.
         #[cfg(target_os = "macos")]
         if let RunEvent::ExitRequested { code, api, .. } = &event {
             if code.is_none() && app_handle.webview_windows().is_empty() {
@@ -4138,6 +4264,23 @@ pub fn run(
                     "macos last-window close",
                 );
                 api.prevent_exit();
+            } else {
+                // Real quit (Cmd+Q, menu quit, or code-initiated exit).
+                // Save session now while registry still has live entries.
+                log::info!("[session] ExitRequested: saving session before windows are destroyed");
+                registry_for_exit_session.prune_stale_entries(app_handle);
+                if let Err(e) = session::save_session(&registry_for_exit_session, app_handle) {
+                    log::error!("[session] Failed to save session on exit: {}", e);
+                }
+            }
+        }
+
+        #[cfg(not(target_os = "macos"))]
+        if let RunEvent::ExitRequested { .. } = &event {
+            log::info!("[session] ExitRequested: saving session before windows are destroyed");
+            registry_for_exit_session.prune_stale_entries(app_handle);
+            if let Err(e) = session::save_session(&registry_for_exit_session, app_handle) {
+                log::error!("[session] Failed to save session on exit: {}", e);
             }
         }
 
@@ -4167,14 +4310,14 @@ pub fn run(
             refresh_native_menu(app_handle, &registry_for_window_close);
         }
 
-        // Save session state when app is about to exit
-        // Use Exit (not ExitRequested) as it fires reliably on all platforms
+        // Fallback session save at Exit. Normally ExitRequested (above) saves
+        // the session while windows are still alive. This fires after windows
+        // are destroyed, so the registry is usually empty and save_session
+        // returns early without overwriting the file already written above.
         if let RunEvent::Exit = &event {
-            log::info!("[session] App exiting, saving session...");
-            if let Err(e) = session::save_session(&registry_for_session) {
+            log::info!("[session] App exiting, saving session (fallback)...");
+            if let Err(e) = session::save_session(&registry_for_session, app_handle) {
                 log::error!("[session] Failed to save session: {}", e);
-            } else {
-                log::info!("[session] Session saved successfully");
             }
         }
 

--- a/crates/notebook/src/session.rs
+++ b/crates/notebook/src/session.rs
@@ -204,6 +204,19 @@ pub(crate) fn load_session_from(path: &std::path::Path) -> Option<SessionState> 
     Some(session)
 }
 
+/// Load session state ignoring the age check.
+///
+/// Used for one-time migrations (e.g., renaming stale window labels) where
+/// the session data is needed even if it would be too old for restore.
+pub fn load_session_ignoring_age() -> Option<SessionState> {
+    let path = runtimed::session_state_path();
+    if !path.exists() {
+        return None;
+    }
+    let contents = std::fs::read_to_string(&path).ok()?;
+    serde_json::from_str(&contents).ok()
+}
+
 /// Delete the session file after successful restore.
 pub fn clear_session() {
     clear_session_at(&runtimed::session_state_path());

--- a/crates/notebook/src/session.rs
+++ b/crates/notebook/src/session.rs
@@ -7,6 +7,7 @@ use crate::WindowNotebookRegistry;
 use log::{info, warn};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
+use tauri::Manager;
 
 /// Represents a single window's session state.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -20,6 +21,11 @@ pub struct WindowSession {
     pub env_id: Option<String>,
     /// Runtime type (python, deno)
     pub runtime: String,
+    /// Scale factor of the monitor when this window was saved.
+    /// Used to correct physical pixel dimensions when restoring on a
+    /// monitor with a different scale factor (e.g., 1x external → 2x Retina).
+    #[serde(default)]
+    pub scale_factor: Option<f64>,
 }
 
 /// Complete application session state.
@@ -42,13 +48,17 @@ impl SessionState {
 }
 
 /// Save the current session state to disk.
-pub(crate) fn save_session(registry: &WindowNotebookRegistry) -> Result<(), String> {
-    save_session_to(registry, &runtimed::session_state_path())
+pub(crate) fn save_session<R: tauri::Runtime>(
+    registry: &WindowNotebookRegistry,
+    app: &tauri::AppHandle<R>,
+) -> Result<(), String> {
+    save_session_to(registry, app, &runtimed::session_state_path())
 }
 
 /// Save the current session state to a specific path.
-pub(crate) fn save_session_to(
+pub(crate) fn save_session_to<R: tauri::Runtime>(
     registry: &WindowNotebookRegistry,
+    app: &tauri::AppHandle<R>,
     dest: &std::path::Path,
 ) -> Result<(), String> {
     let contexts = registry.contexts.lock().map_err(|e| e.to_string())?;
@@ -67,15 +77,56 @@ pub(crate) fn save_session_to(
                 None
             };
 
+            let scale_factor = app
+                .get_webview_window(label)
+                .and_then(|w| w.scale_factor().ok());
+
             Some(WindowSession {
                 label: label.clone(),
                 path,
                 env_id,
                 runtime: context.runtime.to_string(),
+                scale_factor,
             })
         })
         .collect();
 
+    write_session(windows, dest)
+}
+
+/// Build session windows from registry without scale factor info (for tests).
+#[cfg(test)]
+pub(crate) fn save_session_to_without_scale(
+    registry: &WindowNotebookRegistry,
+    dest: &std::path::Path,
+) -> Result<(), String> {
+    let contexts = registry.contexts.lock().map_err(|e| e.to_string())?;
+
+    let windows: Vec<WindowSession> = contexts
+        .iter()
+        .filter_map(|(label, context)| {
+            let path = context.path.lock().ok()?.clone();
+            let notebook_id = context.notebook_id.lock().ok()?.clone();
+            let env_id = if path.is_none() && !notebook_id.is_empty() {
+                Some(notebook_id)
+            } else {
+                None
+            };
+            Some(WindowSession {
+                label: label.clone(),
+                path,
+                env_id,
+                runtime: context.runtime.to_string(),
+                scale_factor: None,
+            })
+        })
+        .collect();
+
+    write_session(windows, dest)
+}
+
+/// Write a list of window sessions to disk.
+fn write_session(windows: Vec<WindowSession>, dest: &std::path::Path) -> Result<(), String> {
     if windows.is_empty() {
         info!("[session] No windows to save");
         return Ok(());
@@ -235,7 +286,7 @@ mod tests {
             ("notebook-abc12345", test_context(None, "env-uuid-1234")),
         ]);
 
-        save_session_to(&registry, &session_path).unwrap();
+        save_session_to_without_scale(&registry, &session_path).unwrap();
         assert!(session_path.exists());
 
         let loaded = load_session_from(&session_path).unwrap();
@@ -266,7 +317,7 @@ mod tests {
         let session_path = dir.path().join("session.json");
 
         let registry = test_registry(vec![]);
-        save_session_to(&registry, &session_path).unwrap();
+        save_session_to_without_scale(&registry, &session_path).unwrap();
 
         // Empty registry should not create a session file
         assert!(!session_path.exists());
@@ -302,6 +353,7 @@ mod tests {
                 path: None,
                 env_id: Some("test".to_string()),
                 runtime: "python".to_string(),
+                scale_factor: None,
             }],
         };
         let json = serde_json::to_string_pretty(&session).unwrap();
@@ -316,7 +368,7 @@ mod tests {
         let session_path = dir.path().join("session.json");
 
         let registry = test_registry(vec![("notebook-env12345", test_context(None, "env-id"))]);
-        save_session_to(&registry, &session_path).unwrap();
+        save_session_to_without_scale(&registry, &session_path).unwrap();
         assert!(session_path.exists());
 
         clear_session_at(&session_path);
@@ -330,6 +382,7 @@ mod tests {
             path: Some(PathBuf::from("/tmp/test.ipynb")),
             env_id: None,
             runtime: "python".to_string(),
+            scale_factor: None,
         };
 
         let label1 = window_label_for_session(&session);
@@ -345,6 +398,7 @@ mod tests {
             path: None,
             env_id: Some("abcdef1234567890".to_string()),
             runtime: "python".to_string(),
+            scale_factor: None,
         };
         assert_eq!(window_label_for_session(&session), "notebook-abcdef12");
     }
@@ -384,7 +438,7 @@ mod tests {
             .contains_key("notebook-ghost"));
 
         // Save after pruning — session must only contain the 2 live windows
-        save_session_to(&registry, &session_path).unwrap();
+        save_session_to_without_scale(&registry, &session_path).unwrap();
         let loaded = load_session_from(&session_path).unwrap();
 
         assert_eq!(loaded.windows.len(), 2);


### PR DESCRIPTION
## Summary

Fix three session restore bugs:

1. **Upgrade session save**: Add a second session save at the top of `run_upgrade()`, right before any windows are closed. This captures the final registry state including any windows that opened between `begin_upgrade()` (which also saves) and the actual upgrade execution. The `write_session()` helper returns early on an empty registry, so the saved file is never overwritten by the `RunEvent::Exit` fallback.

2. **Stale "main" geometry migration**: Users upgrading from pre-97b0422f have window geometry orphaned under the `"main"` key in `.window-state.json` (now denylisted). A one-time migration renames the entry to the new `notebook-{hash}` label before the window-state plugin loads, so the first launch after upgrade preserves window position/size.

3. **Scale factor correction**: `tauri-plugin-window-state` stores physical pixels without scale factor context. A 1100×750 window on a 1x external monitor becomes 550×375 logical on a 2x Retina display. We now save `scale_factor` in the session state and apply `new_physical = old_physical × (current_scale / saved_scale)` after the plugin restores.

## Verification

* [ ] Open several notebooks across multiple monitors, trigger upgrade flow, verify all notebooks are restored after relaunch
* [ ] Open notebooks on an external monitor at different DPI, close app, relaunch on laptop — verify windows are correctly sized
* [ ] Verify normal Cmd+Q session restore still works

_PR submitted by @rgbkrk's agent, Quill_