### PR TITLE
fix(daemon): eliminate keepalive race and bind socket earlier during upgrade

### DIFF
--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -806,7 +806,7 @@ where
     on_progress(DaemonProgress::Starting);
 
     let client = runtimed::client::PoolClient::default();
-    let max_attempts = 20;
+    let max_attempts = 40;
     for attempt in 1..=max_attempts {
         on_progress(DaemonProgress::WaitingForReady {
             attempt,

--- a/crates/runtimed/src/client.rs
+++ b/crates/runtimed/src/client.rs
@@ -249,7 +249,19 @@ impl PoolClient {
     }
 
     /// Send a request to the daemon and receive a response.
+    ///
+    /// The entire request (connect + send + recv) is bounded by a timeout
+    /// derived from `connect_timeout` so that a bound-but-not-yet-accepting
+    /// socket cannot stall the caller indefinitely.
     async fn send_request(&self, request: Request) -> Result<Response, ClientError> {
+        // Overall timeout: connect_timeout + 3s for the request/response exchange.
+        let overall_timeout = self.connect_timeout + Duration::from_secs(3);
+        tokio::time::timeout(overall_timeout, self.send_request_inner(request))
+            .await
+            .map_err(|_| ClientError::Timeout)?
+    }
+
+    async fn send_request_inner(&self, request: Request) -> Result<Response, ClientError> {
         #[cfg(unix)]
         let stream = {
             let connect_result =

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -458,6 +458,24 @@ impl Daemon {
             }
         };
 
+        // Bind the Unix socket early so clients can connect (and ping) while
+        // the rest of initialisation finishes.  The accept loop runs later.
+        #[cfg(unix)]
+        let unix_listener = {
+            let listener = UnixListener::bind(&self.config.socket_path)?;
+            // Restrict socket permissions to owner-only (0600) so other users
+            // cannot connect to the daemon.
+            {
+                use std::os::unix::fs::PermissionsExt;
+                std::fs::set_permissions(
+                    &self.config.socket_path,
+                    std::fs::Permissions::from_mode(0o600),
+                )?;
+            }
+            info!("[runtimed] Listening on {:?}", self.config.socket_path);
+            listener
+        };
+
         // Write daemon info so clients can discover us
         if let Err(e) = self
             ._lock
@@ -501,7 +519,7 @@ impl Daemon {
         // Platform-specific accept loop
         #[cfg(unix)]
         {
-            self.run_unix_server().await?;
+            self.run_unix_server(unix_listener).await?;
         }
 
         #[cfg(windows)]
@@ -549,23 +567,12 @@ impl Daemon {
         Ok(())
     }
 
-    /// Unix-specific server loop using Unix domain sockets.
+    /// Unix-specific server loop using a pre-bound Unix domain socket.
     #[cfg(unix)]
-    async fn run_unix_server(self: &Arc<Self>) -> anyhow::Result<()> {
-        let listener = UnixListener::bind(&self.config.socket_path)?;
-
-        // Restrict socket permissions to owner-only (0600) so other users cannot
-        // connect to the daemon.
-        {
-            use std::os::unix::fs::PermissionsExt;
-            std::fs::set_permissions(
-                &self.config.socket_path,
-                std::fs::Permissions::from_mode(0o600),
-            )?;
-        }
-
-        info!("[runtimed] Listening on {:?}", self.config.socket_path);
-
+    async fn run_unix_server(
+        self: &Arc<Self>,
+        listener: tokio::net::UnixListener,
+    ) -> anyhow::Result<()> {
         loop {
             tokio::select! {
                 accept_result = listener.accept() => {

--- a/crates/runtimed/src/service.rs
+++ b/crates/runtimed/src/service.rs
@@ -274,6 +274,13 @@ impl ServiceManager {
         self.create_service_config()?;
         info!("[service] Updated service config");
 
+        // Use launchd_start() which always does bootout+bootstrap, not
+        // start() which uses ensure_loaded (a no-op if KeepAlive already
+        // restarted the old binary during the stop→copy window).
+        #[cfg(target_os = "macos")]
+        runt_workspace::launchd_start().map_err(ServiceError::StartFailed)?;
+
+        #[cfg(not(target_os = "macos"))]
         self.start()?;
 
         info!("[service] Upgrade completed successfully");


### PR DESCRIPTION
## Summary

- **KeepAlive race fix**: `upgrade()` now uses `launchd_start()` (bootout+bootstrap) instead of `start()` which calls `ensure_loaded` — a no-op if `KeepAlive.Crashed` already auto-restarted the old binary during the stop→copy window
- **Early socket bind**: Unix socket is bound right after blob server starts, before `daemon.json` write, orphan reaping, env scanning, and warmup spawning — so `ping()` succeeds much sooner
- **Timeout increase**: Upgrade readiness timeout bumped from 10s to 20s as safety margin

## Test plan

- [ ] `cargo xtask lint` passes
- [ ] `cargo test -p runtimed` passes (22 tests)
- [ ] Test nightly upgrade: stop daemon, install new version, verify single-start and fast readiness in logs