### PR TITLE
ci(python-package): prevent python-only releases from becoming 'latest'

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -217,6 +217,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref_name }}
+          make_latest: false
           files: |
             wheels-*/*
             nteract-dist/*


### PR DESCRIPTION
## Summary

Prevent `python-v*` releases from being marked as GitHub's "latest" release. These Python-only releases have no desktop app assets, causing the website's stable download links to break (404).

The nteract.io website now uses the `stable-latest` manifest tag for release lookup (fixing the site-side issue), but this CI change provides defense-in-depth to ensure Python releases never hijack the repository's "latest" status.

## Test Plan

- [ ] Verify CI workflow changes to python-package.yml are syntactically correct
- [ ] Manually trigger or push a `python-v*` tag and confirm the release is marked `latest=false` on GitHub
- [ ] Confirm `stable-latest` and `nightly-latest` tags remain unaffected

_PR submitted by @rgbkrk's agent, Quill_