### PR TITLE
feat(mcp): improve nteract tool naming and defaults for LLM agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,7 +107,7 @@ tools in addition to the standard nteract notebook tools:
 | `supervisor_start_vite` | Start the Vite dev server for hot-reload frontend development. Returns the port number. If already running, returns the existing port. |
 | `supervisor_stop` | Stop a managed process by name (e.g. `"vite"`). |
 
-The nteract tools (`list_notebooks`, `create_notebook`, `execute_cell`, etc.)
+The nteract tools (`list_active_notebooks`, `create_notebook`, `execute_cell`, etc.)
 are proxied through the supervisor. If tools start failing, call
 `supervisor_status` to diagnose, then `supervisor_restart` or
 `supervisor_rebuild` to recover.

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -1658,28 +1658,25 @@ async fn auto_launch_kernel(
         return;
     }
 
-    // notebook_path_opt is ONLY for saved notebooks (actual file paths).
-    // For untitled notebooks, kernel_manager will use default_notebooks_dir() for CWD.
+    // For saved notebooks, notebook_path_opt is the file path (kernel cwd = parent dir).
+    // For untitled notebooks, use working_dir as-is (kernel_manager handles is_dir()).
     let notebook_path = PathBuf::from(notebook_id);
     let notebook_path_opt = if notebook_path.exists() {
         Some(notebook_path.clone())
-    } else {
-        None
-    };
-
-    // For untitled notebooks, get working_dir separately for project file detection.
-    // This is NOT passed to kernel.launch() - that would cause .parent() to give wrong CWD.
-    let working_dir_for_detection = if is_untitled_notebook(notebook_id) {
+    } else if is_untitled_notebook(notebook_id) {
         let working_dir = room.working_dir.read().await;
         working_dir.clone().inspect(|p| {
             info!(
-                "[notebook-sync] Using working_dir for untitled notebook project detection: {}",
+                "[notebook-sync] Using working_dir for untitled notebook: {}",
                 p.display()
             );
         })
     } else {
         None
     };
+
+    // For project file detection, use the same path
+    let working_dir_for_detection = notebook_path_opt.clone();
 
     // Resolve metadata snapshot: try Automerge doc first, fall back to disk
     let metadata_snapshot = resolve_metadata_snapshot(room, notebook_path_opt.as_deref()).await;

--- a/python/nteract/CHANGELOG.md
+++ b/python/nteract/CHANGELOG.md
@@ -7,7 +7,7 @@ First release from `nteract/desktop`. The `nteract` Python package is now an MCP
 ### Highlights
 
 - **MCP server** — `nteract` runs as a stdio MCP server, compatible with Claude, ChatGPT, Gemini, OpenCode, and any MCP-capable agent
-- **Notebook lifecycle** — `list_notebooks`, `join_notebook`, `open_notebook`, `create_notebook`, `save_notebook`
+- **Notebook lifecycle** — `list_active_notebooks`, `join_notebook`, `open_notebook`, `create_notebook`, `save_notebook`
 - **Cell operations** — `create_cell`, `get_cell`, `get_all_cells`, `set_cell`, `delete_cell`, `move_cell`, `clear_outputs`
 - **Targeted editing** — `replace_match` (literal find-and-replace) and `replace_regex` (regex-based) for surgical cell edits without rewriting entire sources
 - **Execution** — `execute_cell`, `run_all_cells`, `interrupt_kernel`, `restart_kernel`

--- a/python/nteract/README.md
+++ b/python/nteract/README.md
@@ -110,7 +110,7 @@ claude mcp add nteract -- env RUNTIMED_SOCKET_PATH="$HOME/Library/Caches/runt-ni
 
 | Tool | Description |
 |------|-------------|
-| `list_notebooks` | List all open notebook sessions |
+| `list_active_notebooks` | List all open notebook sessions |
 | `join_notebook` | Join an existing notebook session by ID |
 | `open_notebook` | Open an existing .ipynb file |
 | `create_notebook` | Create a new notebook |

--- a/python/nteract/src/nteract/_mcp_server.py
+++ b/python/nteract/src/nteract/_mcp_server.py
@@ -498,7 +498,7 @@ def _execution_result_to_content(
 
 
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
-async def list_notebooks() -> list[dict[str, Any]]:
+async def list_active_notebooks() -> list[dict[str, Any]]:
     """List all open notebook sessions.
 
     Returns notebooks currently open by users or other agents.
@@ -541,7 +541,7 @@ if not _no_show:
             else:
                 raise ValueError(
                     "No notebook_id provided and no active session. "
-                    "Use list_notebooks() to find a notebook_id, or connect to one first."
+                    "Use list_active_notebooks() to find a notebook_id, or connect to one first."
                 )
 
         client = _get_daemon_client()
@@ -550,7 +550,7 @@ if not _no_show:
         if target not in room_ids:
             raise ValueError(
                 f"Notebook '{target}' is not currently running. "
-                f"Use list_notebooks() to see active notebooks."
+                f"Use list_active_notebooks() to see active notebooks."
             )
 
         if not os.path.isabs(target):
@@ -570,7 +570,7 @@ async def join_notebook(
 ) -> dict[str, Any]:
     """Join an existing notebook session by ID.
 
-    Use list_notebooks() to see available sessions. To open a file from disk,
+    Use list_active_notebooks() to see available sessions. To open a file from disk,
     use open_notebook(path). To create a new notebook, use create_notebook().
     """
     global _session
@@ -595,7 +595,10 @@ async def join_notebook(
 
 @mcp.tool(annotations=ToolAnnotations(destructiveHint=False))
 async def open_notebook(path: str, ctx: Context | None = None) -> dict[str, Any]:
-    """Open an existing .ipynb file. Use create_notebook() for new notebooks."""
+    """Open an existing .ipynb file. The kernel starts automatically.
+
+    Use create_notebook() for new notebooks.
+    """
     global _session
     if ctx:
         _sniff_client_name(ctx)
@@ -615,10 +618,20 @@ async def open_notebook(path: str, ctx: Context | None = None) -> dict[str, Any]
 @mcp.tool(annotations=ToolAnnotations(destructiveHint=False))
 async def create_notebook(
     runtime: Literal["python", "deno"] = "python",
-    working_dir: str | None = None,
+    working_dir: Annotated[
+        str,
+        Field(
+            description="Working directory for the kernel and"
+            " environment detection (e.g. pyproject.toml)."
+            f" Defaults to {os.getcwd()}"
+        ),
+    ] = os.getcwd(),
     ctx: Context | None = None,
 ) -> dict[str, Any]:
-    """Create a new empty notebook in memory. Call save_notebook(path) to persist to disk."""
+    """Create a new empty notebook. The kernel starts automatically.
+
+    Call save_notebook(path) to persist to disk.
+    """
     global _session
     if ctx:
         _sniff_client_name(ctx)
@@ -785,7 +798,7 @@ async def create_cell(
     and_run: Annotated[
         bool, Field(description="Execute the cell immediately after creation")
     ] = False,
-    timeout_secs: Annotated[float, Field(description="Max seconds to wait for execution")] = 5.0,
+    timeout_secs: Annotated[float, Field(description="Max seconds to wait for execution")] = 30.0,
 ) -> list[ContentItem]:
     """Create a cell, optionally executing it."""
     session = await _get_session()
@@ -814,7 +827,7 @@ async def set_cell(
     and_run: Annotated[
         bool, Field(description="Execute the cell after changes (code cells only)")
     ] = False,
-    timeout_secs: Annotated[float, Field(description="Max seconds to wait for execution")] = 5.0,
+    timeout_secs: Annotated[float, Field(description="Max seconds to wait for execution")] = 30.0,
 ) -> ContentItem | list[ContentItem]:
     """Update a cell's source and/or type. Use replace_match for targeted edits."""
     session = await _get_session()
@@ -886,7 +899,7 @@ async def replace_match(
     ] = "",
     context_after: Annotated[str, Field(description="Text that must appear after the match")] = "",
     and_run: Annotated[bool, Field(description="Execute the cell immediately after edit")] = False,
-    timeout_secs: Annotated[float, Field(description="Max seconds to wait for execution")] = 5.0,
+    timeout_secs: Annotated[float, Field(description="Max seconds to wait for execution")] = 30.0,
 ) -> ContentItem | list[ContentItem]:
     """Replace matched text in a cell. Prefer this for simple, targeted edits.
 
@@ -938,7 +951,7 @@ async def replace_regex(
         str, Field(description="Literal replacement text — not re.sub syntax, no backreferences")
     ],
     and_run: Annotated[bool, Field(description="Execute the cell immediately after edit")] = False,
-    timeout_secs: Annotated[float, Field(description="Max seconds to wait for execution")] = 5.0,
+    timeout_secs: Annotated[float, Field(description="Max seconds to wait for execution")] = 30.0,
 ) -> ContentItem | list[ContentItem]:
     """Replace a regex-matched span. Use for anchors, lookarounds, or zero-width insertions.
 
@@ -1131,7 +1144,7 @@ async def clear_outputs(cell_id: str) -> dict[str, Any]:
 
 async def _execute_cell_internal(
     cell_id: str,
-    timeout_secs: float = 5.0,
+    timeout_secs: float = 30.0,
 ) -> list[ContentItem]:
     """Internal execution with streaming and partial results."""
     session = await _get_session()
@@ -1172,7 +1185,7 @@ async def execute_cell(
     cell_id: str,
     timeout_secs: Annotated[
         float, Field(description="Max seconds to wait; returns partial results if exceeded")
-    ] = 5.0,
+    ] = 30.0,
 ) -> list[ContentItem]:
     """Execute a cell. Returns partial results if timeout exceeded."""
     return await _execute_cell_internal(cell_id, timeout_secs=timeout_secs)

--- a/python/nteract/tests/test_mcp_integration.py
+++ b/python/nteract/tests/test_mcp_integration.py
@@ -119,7 +119,7 @@ async def test_list_tools(mcp_client: ClientSession):
     tool_names = {t.name for t in tools.tools}
 
     # Core tools should be present
-    assert "list_notebooks" in tool_names
+    assert "list_active_notebooks" in tool_names
     assert "join_notebook" in tool_names
     assert "open_notebook" in tool_names
     assert "create_notebook" in tool_names


### PR DESCRIPTION
## Summary

Improves nteract MCP tool discoverability and correctness for LLM agents:

* Rename `list_notebooks` → `list_active_notebooks` to clarify it lists active daemon sessions, not files on disk
* Default `create_notebook` `working_dir` to the MCP server's current directory, so Claude Code notebooks inherit the project context
* Wire `working_dir` through to kernel working directory for untitled notebooks (was only affecting environment detection)
* Add "kernel starts automatically" to docstrings to prevent LLM hallucination of deleted `start_kernel` tool
* Bump default `timeout_secs` from 5.0s to 30.0s (5s was too tight for data loading and package installations)

## Verification

* [ ] Verify `list_active_notebooks` lists active daemon sessions correctly
* [ ] Create an untitled notebook with `working_dir` and confirm the kernel runs code from that directory (check `os.getcwd()`)
* [ ] Verify long-running cell executions no longer timeout prematurely (test with a 10s operation)
* [ ] Confirm LLM agents no longer try to call the removed `start_kernel` tool

_PR submitted by @rgbkrk's agent, Quill_