### PR TITLE
perf(notebook): cell diffing + React.memo + stable IsolatedFrame callbacks

### DIFF
--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -2,6 +2,7 @@ import type { EditorView, KeyBinding } from "@codemirror/view";
 import { ChevronRight, Code2, EyeOff, Trash2, X } from "lucide-react";
 import {
   lazy,
+  memo,
   Suspense,
   useCallback,
   useEffect,
@@ -123,7 +124,7 @@ interface CodeCellProps {
   isGroupExecuting?: boolean;
 }
 
-export function CodeCell({
+export const CodeCell = memo(function CodeCell({
   cell,
   language = "python",
   isFocused,
@@ -326,6 +327,8 @@ export function CodeCell({
     handleExecuteWithClear();
   }, [handleExecuteWithClear]);
 
+  const handleLinkClick = useCallback((url: string) => openUrl(url), []);
+
   const gutterContent = bothHidden ? null : (
     <CompactExecutionButton
       count={cell.execution_count}
@@ -484,7 +487,7 @@ export function CodeCell({
               preloadIframe
               searchQuery={searchQuery}
               onSearchMatchCount={onSearchMatchCount}
-              onLinkClick={(url) => openUrl(url)}
+              onLinkClick={handleLinkClick}
             />
           )
         }
@@ -518,4 +521,4 @@ export function CodeCell({
       )}
     </>
   );
-}
+});

--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -1,6 +1,6 @@
 import type { EditorView, KeyBinding } from "@codemirror/view";
 import { Pencil, Trash2 } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { CellContainer } from "@/components/cell/CellContainer";
 import {
   CodeMirrorEditor,
@@ -27,6 +27,9 @@ import { presenceSenderExtension } from "../lib/presence-sender";
 import type { MarkdownCell as MarkdownCellType } from "../types";
 import { CellPresenceIndicators } from "./cell/CellPresenceIndicators";
 
+const handleIframeError = (err: { message: string; stack?: string }) =>
+  logger.error("[MarkdownCell] iframe error:", err);
+
 interface MarkdownCellProps {
   cell: MarkdownCellType;
   isFocused: boolean;
@@ -46,7 +49,7 @@ interface MarkdownCellProps {
   isDragging?: boolean;
 }
 
-export function MarkdownCell({
+export const MarkdownCell = memo(function MarkdownCell({
   cell,
   isFocused,
   searchQuery,
@@ -480,7 +483,7 @@ export function MarkdownCell({
             onReady={handleFrameReady}
             onLinkClick={handleLinkClick}
             onDoubleClick={handleDoubleClick}
-            onError={(err) => logger.error("[MarkdownCell] iframe error:", err)}
+            onError={handleIframeError}
             className="w-full"
           />
         </div>
@@ -498,4 +501,4 @@ export function MarkdownCell({
       </div>
     </CellContainer>
   );
-}
+});

--- a/apps/notebook/src/components/RawCell.tsx
+++ b/apps/notebook/src/components/RawCell.tsx
@@ -1,6 +1,6 @@
 import type { EditorView, KeyBinding } from "@codemirror/view";
 import { Trash2 } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef } from "react";
 import { CellContainer } from "@/components/cell/CellContainer";
 import {
   CodeMirrorEditor,
@@ -37,7 +37,7 @@ interface RawCellProps {
   isDragging?: boolean;
 }
 
-export function RawCell({
+export const RawCell = memo(function RawCell({
   cell,
   isFocused,
   searchQuery,
@@ -225,4 +225,4 @@ export function RawCell({
       </div>
     </CellContainer>
   );
-}
+});

--- a/apps/notebook/src/lib/__tests__/notebook-cells.test.ts
+++ b/apps/notebook/src/lib/__tests__/notebook-cells.test.ts
@@ -172,6 +172,187 @@ describe("subscriber notifications", () => {
   });
 });
 
+describe("cell diffing in replaceNotebookCells", () => {
+  it("preserves referential identity for unchanged cells", () => {
+    const cells = [codeCell("a", "x = 1"), codeCell("b", "y = 2")];
+    replaceNotebookCells(cells);
+    const ref1 = getCellById("a");
+    const ref2 = getCellById("b");
+
+    // Replace with structurally identical cells (new objects)
+    replaceNotebookCells([codeCell("a", "x = 1"), codeCell("b", "y = 2")]);
+    const ref1After = getCellById("a");
+    const ref2After = getCellById("b");
+
+    // Old references should be preserved — same object, not just equal
+    expect(ref1After).toBe(ref1);
+    expect(ref2After).toBe(ref2);
+  });
+
+  it("replaces reference when source changes", () => {
+    replaceNotebookCells([codeCell("a", "x = 1")]);
+    const ref1 = getCellById("a");
+
+    replaceNotebookCells([codeCell("a", "x = 2")]);
+    const ref2 = getCellById("a");
+
+    expect(ref2).not.toBe(ref1);
+    expect(ref2?.source).toBe("x = 2");
+  });
+
+  it("replaces reference when execution_count changes", () => {
+    const cell: NotebookCell = {
+      cell_type: "code",
+      id: "a",
+      source: "1+1",
+      execution_count: null,
+      outputs: [],
+      metadata: {},
+    };
+    replaceNotebookCells([cell]);
+    const ref1 = getCellById("a");
+
+    replaceNotebookCells([{ ...cell, execution_count: 1 }]);
+    const ref2 = getCellById("a");
+
+    expect(ref2).not.toBe(ref1);
+    expect(ref2?.cell_type === "code" && ref2.execution_count).toBe(1);
+  });
+
+  it("replaces reference when outputs change", () => {
+    const output = {
+      output_type: "stream" as const,
+      name: "stdout" as const,
+      text: "hello",
+    };
+    const cell: NotebookCell = {
+      cell_type: "code",
+      id: "a",
+      source: "print('hello')",
+      execution_count: 1,
+      outputs: [],
+      metadata: {},
+    };
+    replaceNotebookCells([cell]);
+    const ref1 = getCellById("a");
+
+    replaceNotebookCells([{ ...cell, outputs: [output] }]);
+    const ref2 = getCellById("a");
+
+    expect(ref2).not.toBe(ref1);
+  });
+
+  it("preserves reference when outputs are referentially equal", () => {
+    const output = {
+      output_type: "stream" as const,
+      name: "stdout" as const,
+      text: "hello",
+    };
+    const cell: NotebookCell = {
+      cell_type: "code",
+      id: "a",
+      source: "print('hello')",
+      execution_count: 1,
+      outputs: [output],
+      metadata: {},
+    };
+    replaceNotebookCells([cell]);
+    const ref1 = getCellById("a");
+
+    // Same output object reference — cell should be preserved
+    replaceNotebookCells([{ ...cell, outputs: [output] }]);
+    const ref2 = getCellById("a");
+
+    expect(ref2).toBe(ref1);
+  });
+
+  it("replaces reference when metadata changes", () => {
+    replaceNotebookCells([
+      { ...codeCell("a"), metadata: { collapsed: false } },
+    ]);
+    const ref1 = getCellById("a");
+
+    replaceNotebookCells([{ ...codeCell("a"), metadata: { collapsed: true } }]);
+    const ref2 = getCellById("a");
+
+    expect(ref2).not.toBe(ref1);
+  });
+
+  it("preserves reference for markdown with identical resolvedAssets", () => {
+    const assets = { "image.png": "sha256:abc" };
+    const cell: NotebookCell = {
+      cell_type: "markdown",
+      id: "m1",
+      source: "# Hello",
+      metadata: {},
+      resolvedAssets: assets,
+    };
+    replaceNotebookCells([cell]);
+    const ref1 = getCellById("m1");
+
+    // New object with same key/values — shallow compare should match
+    replaceNotebookCells([
+      { ...cell, resolvedAssets: { "image.png": "sha256:abc" } },
+    ]);
+    const ref2 = getCellById("m1");
+
+    expect(ref2).toBe(ref1);
+  });
+
+  it("only changes reference for the cell that changed", () => {
+    replaceNotebookCells([
+      codeCell("a", "unchanged"),
+      codeCell("b", "will change"),
+      codeCell("c", "unchanged"),
+    ]);
+    const refA = getCellById("a");
+    const refB = getCellById("b");
+    const refC = getCellById("c");
+
+    replaceNotebookCells([
+      codeCell("a", "unchanged"),
+      codeCell("b", "changed!"),
+      codeCell("c", "unchanged"),
+    ]);
+
+    expect(getCellById("a")).toBe(refA);
+    expect(getCellById("b")).not.toBe(refB);
+    expect(getCellById("b")?.source).toBe("changed!");
+    expect(getCellById("c")).toBe(refC);
+  });
+
+  it("handles cell addition without breaking existing refs", () => {
+    replaceNotebookCells([codeCell("a", "keep")]);
+    const refA = getCellById("a");
+
+    replaceNotebookCells([codeCell("a", "keep"), codeCell("b", "new")]);
+
+    expect(getCellById("a")).toBe(refA);
+    expect(getCellById("b")?.source).toBe("new");
+    expect(getNotebookCellsSnapshot()).toHaveLength(2);
+  });
+
+  it("handles cell removal", () => {
+    replaceNotebookCells([codeCell("a", "keep"), codeCell("b", "remove")]);
+
+    replaceNotebookCells([codeCell("a", "keep")]);
+
+    expect(getNotebookCellsSnapshot()).toHaveLength(1);
+    expect(getCellById("b")).toBeUndefined();
+  });
+
+  it("handles cell type change", () => {
+    replaceNotebookCells([codeCell("a", "# Title")]);
+    const ref1 = getCellById("a");
+
+    replaceNotebookCells([markdownCell("a", "# Title")]);
+    const ref2 = getCellById("a");
+
+    expect(ref2).not.toBe(ref1);
+    expect(ref2?.cell_type).toBe("markdown");
+  });
+});
+
 describe("mixed cell types", () => {
   it("stores code, markdown, and raw cells", () => {
     const cells: NotebookCell[] = [

--- a/apps/notebook/src/lib/notebook-cells.ts
+++ b/apps/notebook/src/lib/notebook-cells.ts
@@ -146,6 +146,52 @@ function getCellSnapshot(id: string): () => NotebookCell | undefined {
   return () => _cellMap.get(id);
 }
 
+// ── Cell comparison ─────────────────────────────────────────────────────
+
+function shallowRecordEqual(
+  a: Record<string, unknown> | undefined,
+  b: Record<string, unknown> | undefined,
+): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  const keysA = Object.keys(a);
+  const keysB = Object.keys(b);
+  if (keysA.length !== keysB.length) return false;
+  for (const key of keysA) {
+    if (a[key] !== b[key]) return false;
+  }
+  return true;
+}
+
+function cellsEqual(a: NotebookCell, b: NotebookCell): boolean {
+  if (a === b) return true;
+  if (a.cell_type !== b.cell_type) return false;
+  if (a.source !== b.source) return false;
+  if (!shallowRecordEqual(a.metadata, b.metadata)) return false;
+
+  // cell_type-specific fields
+  if (a.cell_type === "code") {
+    const bc = b as typeof a;
+    if (a.execution_count !== bc.execution_count) return false;
+    // outputs — same length and each element referentially equal
+    if (a.outputs.length !== bc.outputs.length) return false;
+    for (let i = 0; i < a.outputs.length; i++) {
+      if (a.outputs[i] !== bc.outputs[i]) return false;
+    }
+  } else if (a.cell_type === "markdown") {
+    const bm = b as typeof a;
+    if (
+      !shallowRecordEqual(
+        a.resolvedAssets as Record<string, unknown> | undefined,
+        bm.resolvedAssets as Record<string, unknown> | undefined,
+      )
+    )
+      return false;
+  }
+
+  return true;
+}
+
 // ── Write operations ────────────────────────────────────────────────────
 
 /**
@@ -169,7 +215,8 @@ export function updateCellById(
 
 /**
  * Replace all cells (full materialization from WASM/sync).
- * Notifies ID list subscribers AND all per-cell subscribers.
+ * Diffs each cell against the previous snapshot so only changed cells
+ * trigger per-cell subscriber notifications.
  */
 export function replaceNotebookCells(cells: NotebookCell[]): void {
   const newIds = cells.map((c) => c.id);
@@ -177,7 +224,26 @@ export function replaceNotebookCells(cells: NotebookCell[]): void {
     newIds.length !== _cellIds.length ||
     newIds.some((id, i) => id !== _cellIds[i]);
 
-  _cellMap = new Map(cells.map((c) => [c.id, c]));
+  const oldIds = _cellIds;
+  const newMap = new Map<string, NotebookCell>();
+  const changedIds: string[] = [];
+  let anySourceChanged = false;
+
+  for (const cell of cells) {
+    const prev = _cellMap.get(cell.id);
+    if (prev && cellsEqual(prev, cell)) {
+      // Structurally identical — preserve old reference, skip notification
+      newMap.set(cell.id, prev);
+    } else {
+      newMap.set(cell.id, cell);
+      changedIds.push(cell.id);
+      if (!prev || prev.source !== cell.source) {
+        anySourceChanged = true;
+      }
+    }
+  }
+
+  _cellMap = newMap;
 
   if (idsChanged) {
     _cellIds = newIds;
@@ -185,8 +251,23 @@ export function replaceNotebookCells(cells: NotebookCell[]): void {
   }
 
   emitMaterializeChange();
-  emitSourceChange();
-  emitAllCellChanges();
+
+  if (anySourceChanged) {
+    emitSourceChange();
+  }
+
+  // Emit for cells that actually changed
+  for (const id of changedIds) {
+    emitCellChange(id);
+  }
+
+  // Emit for removed cells (present in old list but absent from new map)
+  const newIdSet = new Set(newIds);
+  for (const id of oldIds) {
+    if (!newIdSet.has(id)) {
+      emitCellChange(id);
+    }
+  }
 }
 
 /**

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -28,6 +28,9 @@ import { highlightTextInDom } from "@/lib/highlight-text";
 import { OutputErrorFallback } from "@/lib/output-error-fallback";
 import { cn } from "@/lib/utils";
 
+const handleIframeError = (err: { message: string; stack?: string }) =>
+  console.error("[OutputArea] iframe error:", err);
+
 /**
  * Jupyter output types based on the nbformat spec.
  */
@@ -528,9 +531,7 @@ export function OutputArea({
                 onLinkClick={onLinkClick}
                 onWidgetUpdate={onWidgetUpdate}
                 onMessage={handleIframeMessage}
-                onError={(err) =>
-                  console.error("[OutputArea] iframe error:", err)
-                }
+                onError={handleIframeError}
               />
             </div>
           )}

--- a/src/components/isolated/isolated-frame.tsx
+++ b/src/components/isolated/isolated-frame.tsx
@@ -252,6 +252,25 @@ export const IsolatedFrame = forwardRef<
   // Track initial darkMode for blob URL (don't recreate blob on theme change)
   const initialDarkModeRef = useRef(darkMode);
 
+  // Stable refs for callback props — avoids tearing down the message
+  // handler when callers pass unstable (inline) callbacks.
+  const onReadyRef = useRef(onReady);
+  const onResizeRef = useRef(onResize);
+  const onLinkClickRef = useRef(onLinkClick);
+  const onDoubleClickRef = useRef(onDoubleClick);
+  const onWidgetUpdateRef = useRef(onWidgetUpdate);
+  const onErrorRef = useRef(onError);
+  const onMessageRef = useRef(onMessage);
+
+  // Sync refs during render so effects always see the latest callbacks.
+  onReadyRef.current = onReady;
+  onResizeRef.current = onResize;
+  onLinkClickRef.current = onLinkClick;
+  onDoubleClickRef.current = onDoubleClick;
+  onWidgetUpdateRef.current = onWidgetUpdate;
+  onErrorRef.current = onError;
+  onMessageRef.current = onMessage;
+
   // Create blob URL on mount (only once, with initial darkMode)
   useEffect(() => {
     const url = createFrameBlobUrl({ darkMode: initialDarkModeRef.current });
@@ -281,9 +300,12 @@ export const IsolatedFrame = forwardRef<
   // Surface provider errors to consumers
   useEffect(() => {
     if (providerError && !providerLoading) {
-      onError?.({ message: providerError.message, stack: providerError.stack });
+      onErrorRef.current?.({
+        message: providerError.message,
+        stack: providerError.stack,
+      });
     }
-  }, [providerError, providerLoading, onError]);
+  }, [providerError, providerLoading]);
 
   // Send a message to the iframe
   // Uses ref to check ready state to avoid stale closure issues
@@ -329,7 +351,7 @@ export const IsolatedFrame = forwardRef<
       }
 
       // Call generic message handler
-      onMessage?.(data);
+      onMessageRef.current?.(data);
 
       // Handle specific message types
       switch (data.type) {
@@ -374,7 +396,7 @@ export const IsolatedFrame = forwardRef<
         case "renderer_ready":
           // React renderer bundle is initialized
           setIsReady(true);
-          onReady?.();
+          onReadyRef.current?.();
           // Render initial content if provided
           if (initialContent) {
             iframeRef.current?.contentWindow?.postMessage(
@@ -390,7 +412,7 @@ export const IsolatedFrame = forwardRef<
               ? Math.max(minHeight, data.payload.height)
               : Math.max(minHeight, Math.min(maxHeight, data.payload.height));
             setHeight(newHeight);
-            onResize?.(newHeight);
+            onResizeRef.current?.(newHeight);
           }
           break;
 
@@ -402,29 +424,35 @@ export const IsolatedFrame = forwardRef<
               ? Math.max(minHeight, data.payload.height)
               : Math.max(minHeight, Math.min(maxHeight, data.payload.height));
             setHeight(newHeight);
-            onResize?.(newHeight);
+            onResizeRef.current?.(newHeight);
           }
           break;
 
         case "link_click":
           if (data.payload?.url) {
-            onLinkClick?.(data.payload.url, data.payload.newTab ?? false);
+            onLinkClickRef.current?.(
+              data.payload.url,
+              data.payload.newTab ?? false,
+            );
           }
           break;
 
         case "dblclick":
-          onDoubleClick?.();
+          onDoubleClickRef.current?.();
           break;
 
         case "widget_update":
           if (data.payload?.commId && data.payload?.state) {
-            onWidgetUpdate?.(data.payload.commId, data.payload.state);
+            onWidgetUpdateRef.current?.(
+              data.payload.commId,
+              data.payload.state,
+            );
           }
           break;
 
         case "error":
           if (data.payload) {
-            onError?.(data.payload);
+            onErrorRef.current?.(data.payload);
           }
           break;
 
@@ -435,7 +463,9 @@ export const IsolatedFrame = forwardRef<
               "[IsolatedFrame] Bundle eval failed:",
               data.payload.error,
             );
-            onError?.({ message: `Bundle eval failed: ${data.payload.error}` });
+            onErrorRef.current?.({
+              message: `Bundle eval failed: ${data.payload.error}`,
+            });
           }
           break;
       }
@@ -443,19 +473,7 @@ export const IsolatedFrame = forwardRef<
 
     window.addEventListener("message", handleMessage);
     return () => window.removeEventListener("message", handleMessage);
-  }, [
-    initialContent,
-    minHeight,
-    maxHeight,
-    autoHeight,
-    onReady,
-    onResize,
-    onLinkClick,
-    onDoubleClick,
-    onWidgetUpdate,
-    onError,
-    onMessage,
-  ]);
+  }, [initialContent, minHeight, maxHeight, autoHeight]);
 
   // Inject renderer when iframe is ready AND bundle props are available
   useEffect(() => {


### PR DESCRIPTION
Frontend defense-in-depth for the remaining iframe message storm on cell execution. Follows #920 which eliminated the storm for typing — this PR targets the execution path.

## Proposal A: Cell diffing in `replaceNotebookCells`

`replaceNotebookCells` previously created a new Map with all-new cell objects and called `emitAllCellChanges()` unconditionally — firing every `useCell(id)` subscriber even when most cells hadn't changed.

Now it compares each incoming cell against the existing one via `cellsEqual()`. Unchanged cells keep their old reference — `useSyncExternalStore` sees the same snapshot and React skips the re-render. Only actually-changed cells get `emitCellChange(id)`.

`cellsEqual` uses:
- String equality for `cell_type`, `source`
- Strict equality for `execution_count`
- Referential equality per output element (cooperates with the output cache)
- Shallow record comparison for `metadata` and `resolvedAssets`

## Proposal C: Memoize components, stabilize callbacks

**C1** — `React.memo` on `CodeCell`, `MarkdownCell`, `RawCell`. Without this, every cell re-renders when any cell changes, even if the cell diffing preserves the object reference, because the parent might re-render.

**C2** — Extract inline `onError` in `OutputArea` to a module-level constant. Eliminates a new closure every render.

**C3** — Ref-based callback props in `IsolatedFrame`. The message handler `useEffect` dependency array shrinks from 11 entries to 4 (only value props). Handler re-registration only happens when `initialContent`/`minHeight`/`maxHeight`/`autoHeight` change — not on every callback identity change.

**C5** — Extract inline `onError` in `MarkdownCell` to module-level constant. Plus stable `onLinkClick` in `CodeCell` via `useCallback`.

## Combined effect with #920

| Scenario | Before #920 | After #920 | After this PR |
|----------|------------|-----------|--------------|
| Typing next to iframe | 1000+ msgs | **0 msgs** | **0 msgs** |
| Cell execution | 1000+ msgs | 279 msgs / 213ms max | Should be near-zero |

The execution path now has three layers of defense:
1. Changeset routes to full materialization (from #920)
2. `replaceNotebookCells` diffs cells and only notifies changed ones (Proposal A)
3. Even if notified, `React.memo` blocks re-render if props haven't changed (Proposal C1)
4. Even if re-rendered, `IsolatedFrame` doesn't re-register its handler (Proposal C3)

_PR submitted by @rgbkrk's agent Quill, via Zed_