### PR TITLE
perf(notebook): debounce and cancel stale kernel completion requests

### DIFF
--- a/apps/notebook/src/lib/kernel-completion.ts
+++ b/apps/notebook/src/lib/kernel-completion.ts
@@ -34,6 +34,10 @@ async function kernelCompletionSource(
   const word = context.matchBefore(/[\w.]+/);
   if (!word && !context.explicit) return null;
 
+  // Debounce: wait 150ms, bail if the user has typed again
+  await new Promise((resolve) => setTimeout(resolve, 150));
+  if (context.aborted) return null;
+
   const code = context.state.doc.toString();
   const cursorPos = context.pos;
 
@@ -43,6 +47,8 @@ async function kernelCompletionSource(
       cursorPos,
     });
 
+    // Discard stale response if the user has moved on
+    if (context.aborted) return null;
     if (!result.items || result.items.length === 0) return null;
 
     return {
@@ -62,4 +68,5 @@ async function kernelCompletionSource(
  */
 export const kernelCompletionExtension: Extension = autocompletion({
   override: [kernelCompletionSource],
+  activateOnTypingDelay: 150,
 });

--- a/apps/notebook/src/lib/kernel-completion.ts
+++ b/apps/notebook/src/lib/kernel-completion.ts
@@ -34,10 +34,6 @@ async function kernelCompletionSource(
   const word = context.matchBefore(/[\w.]+/);
   if (!word && !context.explicit) return null;
 
-  // Debounce: wait 150ms, bail if the user has typed again
-  await new Promise((resolve) => setTimeout(resolve, 150));
-  if (context.aborted) return null;
-
   const code = context.state.doc.toString();
   const cursorPos = context.pos;
 


### PR DESCRIPTION
Adds 150ms debounce before sending kernel completion IPC calls and checks `context.aborted` to discard stale responses. This prevents rapid keystrokes from firing multiple round-trips to the daemon, reducing typing lag especially with slow kernels.

**Verification:**
- [ ] Open a notebook and type quickly in a cell
- [ ] Verify completions appear after a pause rather than on every keystroke
- [ ] Verify Ctrl+Space (explicit completion) still triggers after 150ms debounce

Closes #916

_PR submitted by @rgbkrk's agent, Quill_