### PR TITLE
feat(notebook): surface error count on hidden cell chips

### DIFF
--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -122,6 +122,8 @@ interface CodeCellProps {
   onExpandHiddenGroup?: () => void;
   /** Whether any cell in a hidden group is currently executing */
   isGroupExecuting?: boolean;
+  /** Number of error outputs across all cells in a hidden group */
+  hiddenGroupErrorCount?: number;
 }
 
 export const CodeCell = memo(function CodeCell({
@@ -151,6 +153,7 @@ export const CodeCell = memo(function CodeCell({
   hiddenGroupCount,
   onExpandHiddenGroup,
   isGroupExecuting,
+  hiddenGroupErrorCount,
 }: CodeCellProps) {
   const editorRef = useRef<CodeMirrorEditorRef>(null);
   const [historyDialogOpen, setHistoryDialogOpen] = useState(false);
@@ -413,6 +416,13 @@ export const CodeCell = memo(function CodeCell({
                       ? `${hiddenGroupCount} cells hidden`
                       : "Cell hidden"}
                   </span>
+                  {hiddenGroupErrorCount ? (
+                    <span className="text-destructive font-medium">
+                      {hiddenGroupErrorCount === 1
+                        ? "1 error"
+                        : `${hiddenGroupErrorCount} errors`}
+                    </span>
+                  ) : null}
                   <ChevronRight className="h-3 w-3" />
                 </button>
               </div>

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -399,14 +399,26 @@ function NotebookViewContent({
     const cells = getNotebookCellsSnapshot();
     const groups = new Map<
       string,
-      { count: number; isFirst: boolean; groupCellIds: string[] }
+      {
+        count: number;
+        isFirst: boolean;
+        groupCellIds: string[];
+        errorCount: number;
+      }
     >();
     let i = 0;
     while (i < cells.length) {
       if (isCellFullyHidden(cells[i])) {
         const groupCellIds: string[] = [];
+        let groupErrorCount = 0;
         while (i < cells.length && isCellFullyHidden(cells[i])) {
-          groupCellIds.push(cells[i].id);
+          const c = cells[i];
+          groupCellIds.push(c.id);
+          if (c.cell_type === "code") {
+            groupErrorCount += c.outputs.filter(
+              (o) => o.output_type === "error",
+            ).length;
+          }
           i++;
         }
         for (let j = 0; j < groupCellIds.length; j++) {
@@ -414,6 +426,7 @@ function NotebookViewContent({
             count: groupCellIds.length,
             isFirst: j === 0,
             groupCellIds,
+            errorCount: groupErrorCount,
           });
         }
       } else {
@@ -574,6 +587,7 @@ function NotebookViewContent({
                 : undefined
             }
             hiddenGroupCount={hiddenGroups.get(cell.id)?.count}
+            hiddenGroupErrorCount={hiddenGroups.get(cell.id)?.errorCount}
             isGroupExecuting={
               hiddenGroups
                 .get(cell.id)

--- a/e2e/specs/cell-visibility.spec.js
+++ b/e2e/specs/cell-visibility.spec.js
@@ -175,4 +175,59 @@ describe("Cell Visibility Toggles", () => {
     await output.waitForExist({ timeout: 5000 });
     expect(await output.isExisting()).toBe(true);
   });
+
+  it("should show error count on hidden cell chip when cell has error output", async () => {
+    const codeCell = await $('[data-cell-type="code"]');
+
+    // Focus editor and type code that raises an error
+    const editor = await codeCell.$('.cm-content[contenteditable="true"]');
+    await editor.click();
+    await browser.pause(200);
+    const modKey = process.platform === "darwin" ? "Meta" : "Control";
+    await browser.keys([modKey, "a"]);
+    await browser.pause(100);
+    await typeSlowly("raise ValueError('test error')");
+
+    // Execute with Shift+Enter
+    await browser.keys(["Shift", "Enter"]);
+
+    // Wait for error output to appear
+    await browser.waitUntil(
+      async () => {
+        const errorOutput = await codeCell.$('[data-slot="ansi-error-output"]');
+        return await errorOutput.isExisting();
+      },
+      {
+        timeout: 30000,
+        interval: 500,
+        timeoutMsg: "Error output did not appear",
+      },
+    );
+
+    // Hide source
+    await codeCell.moveTo();
+    await browser.pause(300);
+    const hideSourceButton = await codeCell.$('button[title="Hide source"]');
+    await hideSourceButton.waitForClickable({ timeout: 5000 });
+    await hideSourceButton.click();
+    await browser.pause(300);
+
+    // Hide outputs
+    await codeCell.moveTo();
+    await browser.pause(300);
+    const hideOutputButton = await codeCell.$('button[title="Hide outputs"]');
+    await hideOutputButton.waitForClickable({ timeout: 5000 });
+    await hideOutputButton.click();
+    await browser.pause(300);
+
+    // The chip should show "1 error"
+    const cellHiddenChip = await codeCell.$('button[title="Show cell"]');
+    expect(await cellHiddenChip.isExisting()).toBe(true);
+    const chipText = await cellHiddenChip.getText();
+    expect(chipText).toContain("1 error");
+
+    // Restore cell for subsequent tests
+    await cellHiddenChip.click();
+    await browser.pause(300);
+  });
 });


### PR DESCRIPTION
When cells are fully hidden via the "Cell hidden" chip, error outputs become invisible to the user. This change surfaces error indicators next to hidden cell chips to alert users that something went wrong without requiring them to expand the cell.

## Changes

- Display "X error" or "X errors" label in destructive/red styling next to hidden cell chips
- Aggregate error counts across all cells in a grouped hidden cells scenario
- Add e2e test to verify error count display on hidden cells with errors

## Verification

- [ ] Hidden cells with errors show error count on the chip
- [ ] Grouped consecutive hidden cells aggregate error counts
- [ ] Error count updates when cells are executed and produce new errors
- [ ] Expanding a hidden cell group still shows individual error outputs

Closes #900

_PR submitted by @rgbkrk's agent, Quill_