### PR TITLE
docs: refresh architecture docs with incremental sync, state ownership, and notebook lifecycle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,8 +83,11 @@ Before diving into a subsystem, read the relevant guide:
 | Python bindings / MCP | `contributing/runtimed.md` § Python Bindings |
 | Running tests | `contributing/testing.md` |
 | Frontend architecture | `contributing/frontend-architecture.md` |
+| Wire protocol / sync | `contributing/protocol.md` |
+| Widget system | `contributing/widget-development.md` |
 | Daemon development | `contributing/runtimed.md` |
 | Environment management | `contributing/environments.md` |
+| Output iframe sandbox | `contributing/iframe-isolation.md` |
 
 ## Code Formatting (Required Before Committing)
 
@@ -393,20 +396,122 @@ runt daemon status
 
 The notebook uses a local-first CRDT architecture. The frontend owns its own Automerge document via WASM, making cell mutations instant. Two Automerge peers participate:
 
-- **Frontend (WASM)** — `NotebookHandle` from `crates/runtimed-wasm`, loaded in the webview. Cell mutations (add, delete, move, edit source) execute locally in WASM. React state is derived from the WASM doc via `handle.get_cells_json()`. The WASM starts with an empty doc (`create_empty()`); the sync protocol delivers all state from the daemon.
-- **Daemon** — `NotebookDoc` from `crates/notebook-doc/src/lib.rs` (re-exported by `crates/runtimed/src/lib.rs`). Canonical doc for kernel execution, output writing, and persistence.
+- **Frontend (WASM)** — `NotebookHandle` from `crates/runtimed-wasm`, loaded in the webview. Cell mutations (add, delete, move, edit source) execute locally in WASM. The WASM starts with an empty doc (`create_empty()`); the sync protocol delivers all state from the daemon.
+- **Daemon** — `NotebookDoc` from `crates/notebook-doc/src/lib.rs`. Canonical doc for kernel execution, output writing, and persistence.
 
-The **Tauri relay** (`NotebookSyncClient` in `crates/runtimed/src/notebook_sync_client.rs`) is a transparent byte pipe — it forwards raw Automerge sync frames between the WASM and the daemon without merging or maintaining its own doc replica. The daemon's `peer_state` tracks the WASM peer directly through the pipe. A non-pipe "full peer" mode exists for `runtimed-py` (Python bindings), where the relay does maintain a local doc replica — but this is not the Tauri path.
+The **Tauri relay** (`NotebookSyncClient` in `crates/runtimed/src/notebook_sync_client.rs`) is a transparent byte pipe — it forwards raw Automerge sync frames between the WASM and the daemon without merging or maintaining its own doc replica. A non-pipe "full peer" mode exists for `runtimed-py` (Python bindings), where the relay does maintain a local doc replica — but this is not the Tauri path.
 
 Cells are stored in an Automerge Map keyed by cell ID, with a `position` field (fractional index hex string) for ordering. `move_cell` updates only the position field — no delete/re-insert. `get_cells()` returns cells sorted by position with cell ID as tiebreaker.
 
 Mutation flow: React → WASM `handle.add_cell_after()` → `handle.generate_sync_message()` → prepend `0x00` type byte → `invoke("send_frame", { frameData })` → relay pipe → daemon.
 
-Incoming sync: daemon → relay pipe → `notebook:frame` event → WASM `handle.receive_frame()` → demux by type byte → `materializeCells()` → React state. Broadcasts and presence are re-emitted as `notebook:broadcast` and `notebook:presence` webview events for downstream hooks.
+Incoming sync: daemon → relay pipe → `notebook:frame` event → WASM `handle.receive_frame()` → demux by type byte → returns `FrameEvent[]` with `CellChangeset` → incremental cell updates → React state. Broadcasts and presence are re-emitted via an in-memory frame bus (`notebook-frame-bus.ts`) for downstream hooks.
 
 The `runtimed-wasm` crate compiles from the same `automerge = "0.7"` as the daemon. This is critical — the JS `@automerge/automerge` package creates `Object(Text)` CRDTs for all string fields, but Rust uses scalar `Str` for metadata fields (`id`, `cell_type`, `execution_count`). Using the same Rust code in WASM guarantees schema compatibility.
 
 **Important:** Like the daemon binary, `runtimed-wasm` is a separate build artifact. Changes to `crates/runtimed-wasm/` require rebuilding with `wasm-pack build crates/runtimed-wasm --target web --out-dir ../../apps/notebook/src/wasm/runtimed-wasm` and committing the output. The WASM artifacts are committed to the repo so developers don't need wasm-pack installed for normal development.
+
+### State Ownership
+
+The frontend and daemon both write to the same CRDT. The convention of who writes what is a protocol rule:
+
+| State | Writer | Notes |
+|-------|--------|-------|
+| Cell source (`Text` CRDT) | Frontend WASM | Local-first, character-level merge |
+| Cell position, type, metadata | Frontend WASM | User-initiated via UI |
+| Notebook metadata (deps, runtime) | Frontend WASM | User edits deps, runtime picker |
+| Cell outputs (manifest hashes) | Daemon | Kernel IOPub → blob store → hash in doc |
+| Execution count | Daemon | Set on `execute_input` from kernel |
+| Widget state | Daemon (via `CommState`) | Kernel `comm_open`/`comm_msg` — see #761 for plans to move to `doc.comms` |
+
+**Reads are free for both sides.** The daemon reads cell source from the doc for execution. The frontend reads outputs from the doc for rendering. Both use the same Automerge sync to stay current.
+
+### Incremental Sync Pipeline
+
+The sync pipeline avoids full-notebook re-reads on every change. Each layer is delta-aware:
+
+1. **WASM `receive_frame()`** — applies sync message, computes a `CellChangeset` by walking `doc.diff(before, after)` patches. Returns field-level flags per changed cell (`source`, `outputs`, `execution_count`, `metadata`, `position`). Cost is O(delta), not O(doc).
+
+2. **`scheduleMaterialize()`** — coalesces multiple sync frames within a 32ms window via `mergeChangesets()`. Dispatches:
+   - Structural changes (cells added/removed/reordered) → full materialization
+   - Output changes (blob manifests need async fetch) → full materialization
+   - Source/metadata/execution_count only → per-cell `materializeCellFromWasm()` via O(1) WASM accessors
+
+3. **Split cell store** — `Map<id, NotebookCell>` with per-cell subscriptions. `useCell(id)` re-renders only when that specific cell changes. `useCellIds()` re-renders only on structural changes.
+
+4. **Debounced outbound sync** — source edits batch keystrokes via `debouncedSyncToRelay` (20ms). `flushSync()` fires immediately before execute/save.
+
+**Per-cell WASM accessors** (O(1) Automerge map lookups, no full doc serialization):
+- `get_cell_source(id)`, `get_cell_type(id)`, `get_cell_outputs(id)`, `get_cell_execution_count(id)`, `get_cell_metadata(id)`, `get_cell_position(id)`
+- `get_cell_ids()` — position-sorted IDs (O(n log n) sort, reads only position strings, skips source/outputs/metadata)
+
+The `CellChangeset` and diff logic live in `crates/notebook-doc/src/diff.rs`. The TypeScript mirror types are defined inline in `apps/notebook/src/hooks/useAutomergeNotebook.ts` (module-private; tests duplicate them in `apps/notebook/src/lib/__tests__/cell-changeset.test.ts`).
+
+Full materialization (structural changes, initial load) still uses `handle.get_cells_json()` for bulk serialization. The per-cell path is for incremental updates only.
+
+### Crate Boundaries
+
+Three crates have "notebook" in the name. They have distinct roles:
+
+| Crate | What it owns | Used by |
+|-------|-------------|---------|
+| `notebook-doc` | Automerge document schema and operations (`NotebookDoc`), cell CRUD, output writes, fractional indexing, `CellChangeset` diffing, presence encoding, frame type constants | daemon, WASM, `notebook-protocol`, `notebook-sync`, Python bindings |
+| `notebook-protocol` | Wire protocol types (`NotebookRequest`, `NotebookResponse`, `NotebookBroadcast`, `CommSnapshot`), connection handshake, frame parsing | daemon, `notebook-sync`, Python bindings |
+| `notebook-sync` | Sync infrastructure (`DocHandle`), snapshot watch channel, per-cell accessors for Python clients, sync task management | Tauri app crate (`notebook`), Python bindings (`runtimed-py`) |
+
+**Rule of thumb:** If you're changing the document schema or cell operations → `notebook-doc`. If you're adding a new request/response/broadcast type → `notebook-protocol`. If you're changing how Python clients sync → `notebook-sync`.
+
+The Tauri app crate (`crates/notebook/`) is the glue — it wires Tauri commands to daemon requests and manages the socket relay. It does not own protocol types or document operations.
+
+### Blob Store and Output Manifests
+
+Large binary outputs (images, plots, HTML) are stored in a content-addressed blob store, not inline in the CRDT. The Automerge doc carries only 64-char SHA-256 hashes.
+
+**Two-tier indirection:**
+1. **Cell outputs list** → manifest hashes (64-char hex strings in `doc.cells[id].outputs`)
+2. **Manifest** (JSON in blob store) → `ContentRef` per MIME type: `{"inline": "<data>"}` for ≤8KB, `{"blob": "<hash>", "size": N}` for >8KB
+
+**Blob store location:** `~/.cache/runt/blobs/` (sharded by first 2 hex chars). Each blob has a `.meta` sidecar with `{media_type, size}`.
+
+**Blob HTTP server:** `127.0.0.1:<dynamic-port>`, serves `GET /blob/{hash}`. The port is included in the connection capabilities and available via `runt daemon status --json | jq -r .blob_url`.
+
+**Frontend resolution:** `materialize-cells.ts` resolves manifest hashes → fetches manifest JSON from HTTP → resolves `ContentRef::Blob` entries → renders. An output cache deduplicates fetches.
+
+**Key files:** `crates/runtimed/src/output_store.rs` (manifest creation, inlining threshold), `crates/runtimed/src/blob_store.rs` (content-addressed storage), `crates/runtimed/src/blob_server.rs` (HTTP server).
+
+### Notebook Room Lifecycle
+
+Each open notebook is a **room** on the daemon (`NotebookRoom` in `notebook_sync_server.rs`). Rooms are keyed by notebook ID (file path or UUID for untitled notebooks).
+
+**Autosave:** The daemon autosaves `.ipynb` on a debounce (2s quiet period, 10s max interval). No user action required. The `NotebookAutosaved` broadcast clears the frontend's dirty flag. Explicit Cmd+S still works and additionally runs cell formatting.
+
+**Room re-keying:** When an untitled notebook (UUID room) is first saved to a file path, `rekey_ephemeral_room()` atomically re-keys the room in the HashMap, spawns a file watcher, cleans up the old persist file, and broadcasts `RoomRenamed` so all peers update their `notebook_id`.
+
+**Crash recovery:** Untitled notebooks are persisted to `notebook-docs/{hash}.automerge` in the cache directory. On daemon restart, the room loads from this file. Saved notebooks reload from `.ipynb`. Before deleting a persisted doc (on reopen), the daemon snapshots it to `notebook-docs/snapshots/`. `runt recover` can export any snapshot to `.ipynb`.
+
+**Multi-window:** Multiple windows can open the same notebook. Each connects as a separate Automerge peer to the same room. The first window gets a deterministic label (for geometry persistence); additional windows get a UUID suffix. All peers receive the same sync frames and broadcasts.
+
+**Eviction:** When all peers disconnect, a delayed eviction task runs (configurable via `keep_alive_secs` setting, default 30s). If no peers reconnect within the window, the kernel is shut down and the room is removed.
+
+### Widget State (Current Architecture)
+
+Widget state currently lives **outside** the Automerge doc, in parallel in-memory stores:
+- **Daemon:** `CommState` in `comm_state.rs` — tracks all active Jupyter comm channels (ipywidgets), maintains output capture routing for Output widgets
+- **Frontend:** `WidgetStore` in `src/components/widgets/widget-store.ts` — per-model subscriptions, IPY_MODEL_ reference resolution, custom message buffering
+
+New clients receive a `CommSync` broadcast (snapshot of all active widgets) when they connect. Widget messages flow as `NotebookBroadcast::Comm` events, not document mutations.
+
+**Planned:** Move widget state into `doc.comms/` in the Automerge document (#761). This eliminates `CommSync`, simplifies Output widget routing, and means new clients get widget state via normal CRDT sync. See the phased plan in #808–#811.
+
+See `contributing/widget-development.md` for the widget rendering architecture and `contributing/protocol.md` for the wire protocol details.
+
+### Settings Sync
+
+Settings (theme, default_runtime, default_python_env, keep_alive_secs, etc.) are synced via a **separate Automerge document** — not the notebook doc. The daemon holds the canonical copy and persists to disk.
+
+Any window can write a setting; all other windows receive the change via Automerge sync. The frontend connects with a `SettingsSync` handshake on the same Unix socket. Frontend falls back to a local `settings.json` if the daemon is unavailable.
+
+Settings types: `crates/runtimed/src/settings_doc.rs`. Frontend hook: `src/hooks/useSyncedSettings.ts`.
 
 ## Environment Management
 
@@ -484,10 +589,14 @@ Dependencies are signed with HMAC-SHA256 using a per-machine key at `~/.config/r
 |------|------|
 | `crates/kernel-launch/src/lib.rs` | Shared kernel launching API |
 | `crates/kernel-launch/src/tools.rs` | Tool bootstrapping (deno, uv, ruff) via rattler |
-| `crates/runtimed/src/notebook_sync_server.rs` | `auto_launch_kernel()` — runtime detection and environment resolution |
-| `crates/runtimed/src/kernel_manager.rs` | `RoomKernel::launch()` — spawns Python or Deno kernel processes |
+| `crates/runtimed/src/notebook_sync_server.rs` | `NotebookRoom`, `auto_launch_kernel()`, room lifecycle, autosave, re-keying |
+| `crates/runtimed/src/kernel_manager.rs` | `RoomKernel::launch()` — spawns kernel, IOPub handler, output routing |
+| `crates/runtimed/src/comm_state.rs` | Widget comm state tracking + Output widget capture routing |
+| `crates/runtimed/src/output_store.rs` | Output manifest creation, blob inlining threshold |
+| `crates/runtimed/src/blob_store.rs` | Content-addressed blob storage |
 | `crates/runtimed/src/inline_env.rs` | Cached environment creation for inline deps (UV and Conda) |
-| `crates/notebook/src/lib.rs` | Tauri commands (save, format, kernel, env), Automerge sync pipe (forwards raw frames between WASM and daemon). Cell mutation commands removed — mutations go through WASM. |
+| `crates/runtimed/src/settings_doc.rs` | Settings Automerge doc schema and persistence |
+| `crates/notebook/src/lib.rs` | Tauri commands, Automerge sync pipe (transparent byte relay between WASM and daemon) |
 | `crates/notebook/src/project_file.rs` | Unified closest-wins project file detection |
 | `crates/notebook/src/uv_env.rs` | UV environment creation and caching |
 | `crates/notebook/src/conda_env.rs` | Conda environment creation via rattler |
@@ -495,11 +604,18 @@ Dependencies are signed with HMAC-SHA256 using a per-machine key at `~/.config/r
 | `crates/notebook/src/pixi.rs` | pixi.toml discovery and parsing |
 | `crates/notebook/src/environment_yml.rs` | environment.yml discovery and parsing |
 | `crates/notebook/src/deno_env.rs` | Deno config detection and version checking |
-| `crates/notebook/src/trust.rs` | HMAC trust verification |
-| `crates/runtimed-wasm/src/lib.rs` | WASM bindings for NotebookDoc — cell mutations, sync messages |
-| `crates/notebook-doc/src/lib.rs` | Shared Automerge document operations (`NotebookDoc`) used by daemon and WASM bindings |
-| `apps/notebook/src/hooks/useAutomergeNotebook.ts` | Local-first notebook hook — owns NotebookHandle WASM, drives React cell state, sync-only bootstrap (empty doc, no GetDocBytes) |
-| `apps/notebook/src/hooks/useDaemonKernel.ts` | Daemon-owned kernel execution, status broadcasts, environment sync |
+| `crates/notebook/src/trust.rs` | HMAC trust verification (re-exports from `runt-trust`) |
+| `crates/notebook-doc/src/lib.rs` | `NotebookDoc` — Automerge schema, cell CRUD, output writes, per-cell accessors |
+| `crates/notebook-doc/src/diff.rs` | `CellChangeset` — structural diff from Automerge patches |
+| `crates/notebook-doc/src/presence.rs` | CBOR-encoded ephemeral presence (cursors, selections, kernel state) |
+| `crates/notebook-protocol/src/protocol.rs` | Wire types: `NotebookRequest`, `NotebookResponse`, `NotebookBroadcast`, `CommSnapshot` |
+| `crates/notebook-sync/src/handle.rs` | `DocHandle` — sync infrastructure + per-cell accessors for Python clients |
+| `crates/runtimed-wasm/src/lib.rs` | WASM bindings — cell mutations, sync, per-cell accessors, `CellChangeset` |
+| `apps/notebook/src/hooks/useAutomergeNotebook.ts` | WASM handle owner, `scheduleMaterialize`, debounced sync, `CellChangeset` dispatch |
+| `apps/notebook/src/hooks/useDaemonKernel.ts` | Kernel execution, status broadcasts, widget comm routing |
 | `apps/notebook/src/hooks/useDependencies.ts` | Frontend UV dependency management |
 | `apps/notebook/src/hooks/useCondaDependencies.ts` | Frontend conda dependency management |
-| `apps/notebook/src/lib/materialize-cells.ts` | Converts CellSnapshot[] from WASM/sync to NotebookCell[] for React (resolves blob manifests) |
+| `apps/notebook/src/lib/materialize-cells.ts` | `materializeCellFromWasm()` (per-cell) + `cellSnapshotsToNotebookCells()` (full) |
+| `apps/notebook/src/lib/notebook-cells.ts` | Split cell store — `useCell(id)`, `useCellIds()`, per-cell subscriptions |
+| `apps/notebook/src/lib/notebook-frame-bus.ts` | In-memory sync pub/sub for broadcasts and presence (no Tauri event hop) |
+| `src/components/widgets/widget-store.ts` | `WidgetStore` — per-model subscriptions, IPY_MODEL_ resolution |

--- a/contributing/architecture.md
+++ b/contributing/architecture.md
@@ -25,23 +25,42 @@ The automerge document is the source of truth for notebook content: cells, their
 
 ### 3. On-Disk Notebook as Checkpoint
 
-The `.ipynb` file on disk is a checkpoint/snapshot that the daemon periodically saves. It is not the live state.
+The `.ipynb` file on disk is a checkpoint/snapshot. The Automerge document is the live state.
 
 **Implications:**
 - Daemon reads `.ipynb` on first open, loads into automerge doc
-- Daemon writes `.ipynb` on explicit save or auto-save intervals
+- Daemon autosaves `.ipynb` on a debounce (2s quiet period, 10s max interval) via `spawn_autosave_debouncer` — no user action required
+- Explicit save (Cmd+S) additionally runs cell formatting (ruff/deno fmt) before writing
 - Unknown metadata keys in `.ipynb` are preserved through round-trips
-- Crash recovery: last checkpoint + automerge doc replay
+- `NotebookAutosaved` broadcast clears the frontend dirty flag; `NotebookSaved` response confirms explicit saves
+
+**Crash recovery:**
+- Untitled notebooks (UUID-keyed rooms) persist their Automerge doc to `notebook-docs/{hash}.automerge` in the cache directory. On daemon restart, the room loads from this file.
+- Saved notebooks reload from `.ipynb` (which autosave keeps current). Before deleting a persisted Automerge doc on reopen, the daemon snapshots it to `notebook-docs/snapshots/` (max 5 per notebook).
+- `runt recover` can list all snapshots and export any to `.ipynb`.
+
+**Room re-keying:** When an untitled notebook is first saved to a file path, `rekey_ephemeral_room()` atomically changes the room key from a UUID to the canonical path, spawns a file watcher, cleans up the old persist file, and broadcasts `RoomRenamed` so all peers update their `notebook_id`.
 
 ### 4. Local-First Editing, Synced Execution
 
-Editing is local-first for responsiveness. Execution is always against synced state.
+Editing is local-first for responsiveness. Execution is always against synced state. The sync pipeline is incremental — changes propagate without full-document re-reads.
 
 **Implications:**
 - Type freely in cells; automerge handles sync and conflict resolution
 - When you run a cell, you execute what's in the synced document
 - No executing code that differs from the document state
-- If a cell is mid-sync, wait for sync before allowing execution
+- Source edits are debounced (20ms) before syncing to the daemon; `flushSync()` fires immediately before execute/save
+
+**Incremental sync pipeline:**
+- WASM `receive_frame()` computes a `CellChangeset` (in `notebook-doc/src/diff.rs`) by walking Automerge patches — O(delta), not O(doc)
+- The changeset carries per-field flags (`source`, `outputs`, `execution_count`, `cell_type`, `metadata`, `position`, `resolved_assets`) per changed cell, plus lists of added/removed cell IDs
+- `scheduleMaterialize` coalesces changesets within a 32ms window, then dispatches: structural changes → full materialization; field-only changes → per-cell `materializeCellFromWasm()` using O(1) WASM accessors
+- The split cell store (`notebook-cells.ts`) provides per-cell React subscriptions — `useCell(id)` re-renders only when that specific cell changes
+
+**Per-cell accessors** (O(1) Automerge map lookups, available on `NotebookDoc`, `NotebookHandle`, and `DocHandle`):
+- `get_cell_source(id)`, `get_cell_type(id)`, `get_cell_outputs(id)`, `get_cell_execution_count(id)`, `get_cell_metadata(id)`, `get_cell_position(id)`
+- `get_cell_ids()` — position-sorted IDs (O(n log n) sort, reads only position strings, skips source/outputs/metadata)
+- These are used by the frontend (per-cell materialization), the daemon (reading source for execution), and Python bindings (MCP tool responses)
 
 ### 5. Binary Separation via Manifests
 
@@ -89,6 +108,20 @@ The daemon owns kernel lifecycle, environment pools, and tooling (ruff, deno, et
 - Environment selection is the daemon's decision based on notebook metadata
 - Tool availability is the daemon's responsibility (bootstrap via rattler if needed)
 - Clients are stateless with respect to runtime resources
+
+### Crate Boundaries
+
+Three crates share "notebook" in the name but have distinct responsibilities:
+
+| Crate | Owns | Consumers |
+|-------|------|-----------|
+| `notebook-doc` | Automerge document schema, cell CRUD, output writes, per-cell accessors, `CellChangeset` diffing, fractional indexing, presence encoding, frame type constants | daemon, WASM, Python bindings |
+| `notebook-protocol` | Wire protocol types (`NotebookRequest`, `NotebookResponse`, `NotebookBroadcast`, `CommSnapshot`), connection handshake, frame parsing | daemon, `notebook-sync`, Python bindings |
+| `notebook-sync` | Sync infrastructure (`DocHandle`), snapshot watch channel, per-cell accessors for Python clients, sync task management | Python bindings (`runtimed-py`) |
+
+**Rule of thumb:** Document schema or cell operations → `notebook-doc`. New request/response/broadcast type → `notebook-protocol`. Python client sync behavior → `notebook-sync`.
+
+The Tauri app crate (`crates/notebook/`) is glue — it wires Tauri commands to daemon requests and manages the socket relay. It does not own protocol types or document operations.
 
 ## Anti-Pattern: Bypassing the Document
 
@@ -146,13 +179,19 @@ The frontend now owns a local Automerge doc via `runtimed-wasm` WASM bindings, m
 
 ## References
 
-- `crates/notebook-protocol/src/protocol.rs` - Canonical request/response/broadcast type definitions
-- `crates/notebook-doc/src/lib.rs` - Shared Automerge document operations (`NotebookDoc`) used by daemon and WASM
-- `crates/runtimed/src/notebook_sync_server.rs` - Sync protocol handling
-- `crates/runtimed/src/kernel_manager.rs` - Kernel lifecycle
-- `crates/notebook-sync/src/relay.rs` - `RelayHandle`: relay API for forwarding typed frames between WASM and daemon
-- `crates/notebook-sync/src/connect.rs` - `connect_open_relay()`, `connect_create_relay()`: transparent byte pipe setup
-- `crates/runtimed-wasm/src/lib.rs` - WASM bindings: local Automerge peer, frame demux (`receive_frame`)
-- `crates/notebook/src/lib.rs` - Tauri commands and relay tasks (`send_frame`, `setup_sync_receivers`)
-- `crates/notebook-doc/src/frame_types.rs` - Shared frame type constants (0x00–0x04)
-- `apps/notebook/src/hooks/useAutomergeNotebook.ts` - Frontend sync hub: WASM handle, `notebook:frame` listener, cell materialization
+- `crates/notebook-protocol/src/protocol.rs` — Canonical wire types: `NotebookRequest`, `NotebookResponse`, `NotebookBroadcast`, `CommSnapshot`
+- `crates/notebook-doc/src/lib.rs` — `NotebookDoc`: Automerge schema, cell CRUD, output writes, per-cell accessors
+- `crates/notebook-doc/src/diff.rs` — `CellChangeset`: structural diff from Automerge patches
+- `crates/notebook-sync/src/handle.rs` — `DocHandle`: sync infrastructure, per-cell accessors for Python clients
+- `crates/runtimed/src/notebook_sync_server.rs` — `NotebookRoom`, room lifecycle, autosave debouncer, re-keying, sync loop
+- `crates/runtimed/src/kernel_manager.rs` — Kernel process lifecycle, execution queue, IOPub output routing
+- `crates/runtimed/src/comm_state.rs` — Widget comm state + Output widget capture routing
+- `crates/runtimed/src/output_store.rs` — Output manifest creation, blob inlining threshold
+- `crates/notebook-sync/src/relay.rs` — `RelayHandle`: relay API for forwarding typed frames between WASM and daemon
+- `crates/notebook-sync/src/connect.rs` — `connect_open_relay()`, `connect_create_relay()`: transparent byte pipe setup
+- `crates/runtimed-wasm/src/lib.rs` — WASM bindings: local Automerge peer, frame demux, per-cell accessors, `CellChangeset`
+- `crates/notebook/src/lib.rs` — Tauri commands and relay tasks (`send_frame`, `setup_sync_receivers`)
+- `crates/notebook-doc/src/frame_types.rs` — Shared frame type constants (0x00–0x04)
+- `apps/notebook/src/hooks/useAutomergeNotebook.ts` — WASM handle owner, `scheduleMaterialize`, `CellChangeset` dispatch
+- `apps/notebook/src/lib/materialize-cells.ts` — `materializeCellFromWasm()` (per-cell) + `cellSnapshotsToNotebookCells()` (full)
+- `apps/notebook/src/lib/notebook-cells.ts` — Split cell store: `useCell(id)`, `useCellIds()`, per-cell subscriptions

--- a/contributing/frontend-architecture.md
+++ b/contributing/frontend-architecture.md
@@ -117,8 +117,8 @@ Security boundary for untrusted HTML/widget outputs. See [iframe-isolation.md](i
 
 | Hook | Role |
 |------|------|
-| `useAutomergeNotebook` | Owns WASM NotebookHandle, drives cell state |
-| `useDaemonKernel` | Kernel execution, status broadcasts |
+| `useAutomergeNotebook` | Owns WASM NotebookHandle, `scheduleMaterialize`, `CellChangeset` dispatch |
+| `useDaemonKernel` | Kernel execution, status broadcasts, widget comm routing |
 | `usePresence` | Remote cursor/selection tracking via presence frames |
 | `useEnvProgress` | Environment setup progress tracking |
 | `useDependencies` | UV dependency management |
@@ -142,36 +142,67 @@ Security boundary for untrusted HTML/widget outputs. See [iframe-isolation.md](i
 │  Tauri relay ── "notebook:frame" ──► useAutomergeNotebook       │
 │                                      (WASM receive_frame demux) │
 │                                        │          │         │   │
-│                          sync_applied ─┘          │         │   │
+│                   sync_applied ────────┘          │         │   │
+│                   + CellChangeset                 │         │   │
 │                          ▼                        │         │   │
-│                   ┌──────────────┐                │         │   │
-│                   │cellSnapshots-│  emitBroadcast  │ emitPresence│
-│                   │ToNotebook-   │  (frame bus)    │ (frame bus) │
-│                   │Cells()       │                 │             │
-│                   └──────┬───────┘        │         │       │   │
-│                          │                ▼         │       │   │
-│                          │        ┌──────────────┐  │       │   │
-│                          │        │useDaemonKernel│  │       │   │
-│                          │        │useEnvProgress │  │       │   │
-│                          │        └──────┬───────┘  │       │   │
-│                          │               │          ▼       │   │
-│                          │               │   ┌────────────┐ │   │
-│                          │               │   │usePresence │ │   │
-│                          │               │   └─────┬──────┘ │   │
-│                          ▼               ▼         ▼        │   │
-│  ┌─────────────────────────────────────────────────────────┐│   │
-│  │ React Components                                         ││   │
-│  │ (CellContainer → CodeCell/MarkdownCell → Outputs)        ││   │
-│  └─────────────────────────────────────────────────────────┘│   │
+│                   scheduleMaterialize              │         │   │
+│                   (32ms coalesce)       emitBroadcast emitPresence
+│                          │             (frame bus)  │  (frame bus)
+│                   ┌──────┴──────┐             │     │       │   │
+│                   │ structural? │             ▼     │       │   │
+│                   │  outputs?   │     ┌──────────────┐      │   │
+│                   └──┬──────┬───┘     │useDaemonKernel│     │   │
+│             full ◄───┘      └───► per-cell            │     │   │
+│          materialize-     materialize-  useEnvProgress │     │   │
+│          Cells()          CellFromWasm  └──────┬───────┘     │   │
+│                   │           │                │      ▼      │   │
+│                   ▼           ▼                │  usePresence │   │
+│             ┌────────────────────┐             │      │      │   │
+│             │ Split Cell Store   │             │      │      │   │
+│             │ useCell(id)        │             │      │      │   │
+│             │ useCellIds()       │             │      │      │   │
+│             └────────┬───────────┘             │      │      │   │
+│                      ▼                         ▼      ▼      │   │
+│  ┌─────────────────────────────────────────────────────────┐ │   │
+│  │ React Components (React.memo per cell)                   │ │   │
+│  │ CellRenderer → useCell(id) → CodeCell/MarkdownCell       │ │   │
+│  └─────────────────────────────────────────────────────────┘ │   │
 └─────────────────────────────────────────────────────────────────┘
 ```
 
-1. **useAutomergeNotebook** — Single ingress point. Listens for `notebook:frame`, demuxes via WASM `receive_frame()`, applies sync locally, dispatches to downstream hooks via the in-memory frame bus (`emitBroadcast()` and `emitPresence()` from `notebook-frame-bus.ts`)
-2. **cellSnapshotsToNotebookCells()** / **cellSnapshotsToNotebookCellsSync()** — Converts WASM cell snapshots to React-friendly objects on sync changes
-3. **useDaemonKernel / useEnvProgress** — Subscribe via `subscribeBroadcast()` from the frame bus for kernel status, outputs, and environment progress
-4. **usePresence** — Subscribes via `subscribePresence()` from the frame bus for remote cursor/selection state
+### Incremental sync pipeline
 
-Cell mutations (add, delete, edit) go through the WASM handle for instant response, then sync to the daemon via `invoke("send_frame", { frameData })` where `frameData` includes the type byte prefix. Execution requests go to the daemon via dedicated Tauri commands.
+1. **useAutomergeNotebook** — Single ingress point. Listens for `notebook:frame`, demuxes via WASM `receive_frame()`, applies sync locally. WASM returns a `CellChangeset` with field-level granularity (which cells changed, which fields). Broadcasts and presence are dispatched via in-memory frame bus (`emitBroadcast()` / `emitPresence()` from `notebook-frame-bus.ts`).
+
+2. **scheduleMaterialize** — Coalesces sync frames within a 32ms window via `mergeChangesets()`, then dispatches:
+   - **Structural changes** (cells added/removed/reordered) → full `cellSnapshotsToNotebookCells()` from `get_cells_json()`
+   - **Output changes** (blob manifests need async fetch) → full materialization
+   - **Source/metadata/execution_count only** → per-cell `materializeCellFromWasm()` using O(1) WASM accessors (`get_cell_source()`, `get_cell_type()`, etc.)
+
+3. **Split cell store** (`notebook-cells.ts`) — `Map<id, NotebookCell>` + ordered ID list with independent subscriber channels:
+   - `useCell(id)` — re-renders only when that specific cell changes
+   - `useCellIds()` — re-renders only on structural changes (add/remove/reorder)
+   - `updateCellById()` — O(1) map update, notifies only that cell's subscribers
+   - `replaceNotebookCells()` — full replacement with `cellsEqual()` diffing to preserve object identity for unchanged cells
+
+4. **useDaemonKernel / useEnvProgress** — Subscribe via `subscribeBroadcast()` from the frame bus for kernel status, execution events, and environment progress
+
+5. **usePresence** — Subscribes via `subscribePresence()` from the frame bus. Maintains a React-accessible peer map with `cursorsForCell()`/`selectionsForCell()` queries.
+
+6. **cursor-registry.ts** — Independent frame bus subscriber (parallel to `usePresence`, not delegated). Dispatches `setRemoteCursors()`/`setRemoteSelections()` as CodeMirror `StateEffect`s directly to registered `EditorView` instances — bypasses React entirely for low-latency cursor rendering.
+
+### Mutation flow
+
+Cell mutations (add, delete, edit) go through the WASM handle for instant response. Source edits are batched via `debouncedSyncToRelay` (20ms), with `flushSync()` before execute/save. The fast path for typing: `updateCellSource()` → WASM `update_source()` → `updateCellById()` (one cell, one subscriber) → debounced sync to daemon.
+
+Execution requests go to the daemon via dedicated Tauri commands (`execute_cell_via_daemon`, etc.).
+
+### CellChangeset types
+
+The `CellChangeset` from WASM (`notebook-doc/src/diff.rs`) has TypeScript mirrors defined inline in `apps/notebook/src/hooks/useAutomergeNotebook.ts` (module-private; tests duplicate them in `apps/notebook/src/lib/__tests__/cell-changeset.test.ts`):
+- `CellChangeset` — `{ changed, added, removed, order_changed }`
+- `ChangedCell` — `{ cell_id, fields }` where `fields` has boolean flags per field (`source`, `outputs`, `execution_count`, `cell_type`, `metadata`, `position`, `resolved_assets`)
+- `mergeChangesets()` — union semantics for the coalescing window
 
 ## Key Files
 
@@ -179,7 +210,7 @@ Cell mutations (add, delete, edit) go through the WASM handle for instant respon
 |------|------|
 | `apps/notebook/tsconfig.json` | Path alias configuration |
 | `apps/notebook/src/App.tsx` | Root component, provider setup |
-| `apps/notebook/src/hooks/useAutomergeNotebook.ts` | WASM notebook sync |
+| `apps/notebook/src/hooks/useAutomergeNotebook.ts` | WASM handle owner, `scheduleMaterialize`, `CellChangeset` dispatch |
 | `apps/notebook/src/lib/materialize-cells.ts` | WASM → React conversion |
 | `apps/notebook/src/lib/notebook-frame-bus.ts` | In-memory pub/sub for broadcast and presence dispatch |
 | `apps/notebook/src/hooks/usePresence.ts` | Remote presence tracking |

--- a/contributing/protocol.md
+++ b/contributing/protocol.md
@@ -161,7 +161,7 @@ Both sides use the same Rust `automerge = "0.7"` crate, which guarantees schema 
 User types in cell
   → React calls WASM handle.update_source(cell_id, text)
   → WASM applies mutation locally (instant)
-  → handle.generate_sync_message() → sync bytes
+  → debouncedSyncToRelay (20ms batch) → handle.generate_sync_message() → sync bytes
   → Frontend prepends 0x00 type byte → invoke("send_frame", { frameData })
   → Tauri send_frame dispatches by type → relay pipes to daemon socket
   → Daemon applies sync, updates canonical doc
@@ -169,9 +169,27 @@ User types in cell
   → Relay receives, emits "notebook:frame" Tauri event (raw typed bytes)
   → Frontend useAutomergeNotebook listener → WASM handle.receive_frame(bytes)
   → WASM demuxes by first byte, applies sync, returns FrameEvent[]
-  → sync_applied event → materializeCells() updates React state if doc changed
+  → FrameEvent::SyncApplied includes a CellChangeset (field-level diff)
+  → scheduleMaterialize coalesces within 32ms, then dispatches:
+      - structural change (cells added/removed/reordered) → full materializeCells()
+      - output changes (blob manifests need async fetch) → full materializeCells()
+      - source/metadata/exec_count only → per-cell materializeCellFromWasm() via O(1) accessors
+  → React state updated via split cell store (only affected cells re-render)
   → sync_reply event → prepend 0x00, invoke("send_frame", { frameData }) back to daemon
 ```
+
+### CellChangeset
+
+The WASM module computes a structural diff after each sync by walking `doc.diff(before, after)` patches (in `notebook-doc/src/diff.rs`). This produces a `CellChangeset`:
+
+- **`changed`**: cells that existed before and after, with per-field flags (`source`, `outputs`, `execution_count`, `metadata`, `position`, `cell_type`, `resolved_assets`)
+- **`added`**: new cell IDs
+- **`removed`**: deleted cell IDs
+- **`order_changed`**: whether any position was modified or cells were added/removed
+
+Cost is O(delta), not O(doc). Multiple changesets within a throttle window are merged via `mergeChangesets()` (union on field flags, dedup on added/removed).
+
+This is the key primitive that makes the sync pipeline incremental — the frontend knows exactly which cells changed and which fields, avoiding full-notebook materialization on every frame.
 
 ## Request / Response
 
@@ -233,10 +251,16 @@ Broadcasts are daemon-initiated messages pushed to all connected clients for a n
 | `ExecutionDone { cell_id }` | Cell execution completed |
 | `QueueChanged { executing, queued }` | Execution queue state changed |
 | `KernelError { error }` | Kernel crashed or failed to launch |
-| `Comm { msg_type, ... }` | Jupyter comm message (widget open/msg/close) |
-| `FileChanged` | External file change merged into the doc |
+| `OutputsCleared { cell_id }` | Cell outputs cleared |
+| `Comm { msg_type, content, buffers }` | Jupyter comm message (widget open/msg/close) |
+| `CommSync { comms }` | Full widget state snapshot for newly connected clients |
+| `FileChanged` | External file change merged into the doc (signal only — data arrives via sync) |
 | `EnvProgress { env_type, phase }` | Environment setup progress (`phase` is a flattened `EnvProgressPhase`) |
 | `EnvSyncState { in_sync, diff }` | Notebook dependencies drifted from launched kernel config |
+| `RoomRenamed { new_notebook_id }` | Untitled notebook saved — room re-keyed from UUID to file path |
+| `NotebookAutosaved { path }` | Daemon autosaved `.ipynb` to disk — frontend clears dirty flag |
+
+Currently 15 variants. Five carry data that also arrives via Automerge sync and are planned for removal (#761): `Output`, `OutputsCleared`, `DisplayUpdate`, `CommSync`, and `Comm` for `comm_open`/`comm_msg(update)`/`comm_close` (the `Comm` variant would be renamed to `CommCustom` and restricted to `method: "custom"` only). This would reduce the surface to ~10 variants.
 
 ### Broadcast flow
 
@@ -280,28 +304,63 @@ All dispatch is synchronous and in-process — no serialization or Tauri event l
 
 ## Output Storage
 
-Cell outputs use a blob manifest system rather than inline data. When the daemon receives output from a kernel:
+Cell outputs use a two-tier blob manifest system rather than inline data. When the daemon receives output from a kernel:
 
-1. Binary content (images, plots) is stored in a content-addressed blob store
-2. The Automerge doc stores a manifest referencing the blob by hash
-3. Clients resolve blobs from the daemon's HTTP blob server (`get_blob_port()`)
-4. This keeps large binary data out of the sync protocol
+1. The output is converted to nbformat JSON, then a **manifest** is created (`output_store.rs`)
+2. Each MIME type's content becomes a `ContentRef`: `Inline` for < 8KB, `Blob { hash, size }` for ≥ 8KB
+3. Large binary content (images, plots) is stored in a content-addressed **blob store** (`blob_store.rs`, SHA-256 hashes, `~/.cache/runt/blobs/`)
+4. The manifest itself is stored in the blob store → produces a 64-char hex manifest hash
+5. The Automerge doc stores only the manifest hash in `cell.outputs[]`
+6. Clients resolve manifests and blobs from the daemon's HTTP blob server (`GET /blob/{hash}` on a dynamic port)
+
+This keeps the CRDT small: a cell with 50 outputs adds ~3.2KB to the doc (50 × 64 bytes), regardless of output content size.
+
+Stream outputs (stdout/stderr) are special: text is fed through a terminal emulator (`stream_terminals`) for carriage return and ANSI escape handling before manifest creation. `upsert_stream_output` updates in-place when consecutive stream outputs arrive.
+
+## Notebook Lifecycle
+
+**Autosave:** The daemon autosaves `.ipynb` on a debounce (2s quiet, 10s max). `NotebookAutosaved` broadcast clears the frontend dirty flag. Explicit save (Cmd+S) additionally formats cells.
+
+**Room re-keying:** When an untitled notebook is first saved, `rekey_ephemeral_room()` atomically changes the room key from a UUID to the canonical file path. `RoomRenamed` broadcast tells all peers to update their `notebook_id` for reconnection.
+
+**Crash recovery:** Untitled notebooks persist their Automerge doc to `notebook-docs/{hash}.automerge`. Before overwriting on reopen, the daemon snapshots to `notebook-docs/snapshots/`. `runt recover` exports snapshots to `.ipynb`.
+
+**Multi-window:** Multiple windows join the same room as separate Automerge peers. Each gets sync frames and broadcasts independently. The daemon tracks `active_peers` per room for eviction.
+
+## Architectural Direction
+
+The current protocol has widget state (`CommState`, `CommSync`) as a parallel system alongside the CRDT. Issue #761 tracks moving widget state into `doc.comms/` in the Automerge document, which would:
+
+- Eliminate `CommSync` (new clients get widgets via normal sync)
+- Eliminate `Output`, `OutputsCleared`, `DisplayUpdate` broadcasts (doc sync carries the data)
+- Simplify Output widget capture (daemon writes to `doc.comms[widget_id].outputs` instead of custom messages)
+- Reduce `CommState` to just the output capture routing logic
+
+The implementation is phased: #808 (schema + dual-write) → #809 (clients read from doc) → #810 (eliminate parallel paths) → #811 (blob unification + `update_comm` request).
 
 ## Key Source Files
 
 | File | Role |
 |------|------|
-| `crates/notebook-protocol/src/connection.rs` | Frame protocol implementation (length-prefixed, typed frames, handshake) |
-| `crates/notebook-protocol/src/protocol.rs` | Canonical message type definitions (Request, Response, Broadcast enums) — shared crate |
-| `crates/runtimed/src/protocol.rs` | Daemon-internal protocol types, plus re-exports from `notebook-protocol` |
+| `crates/notebook-protocol/src/connection.rs` | Frame protocol: length-prefixed typed frames, handshake, preamble |
+| `crates/notebook-protocol/src/protocol.rs` | Canonical wire types: `NotebookRequest`, `NotebookResponse`, `NotebookBroadcast`, `CommSnapshot` |
+| `crates/runtimed/src/protocol.rs` | Daemon-internal types (`Request`, `Response`, `BlobRequest`), re-exports from `notebook-protocol` |
 | `crates/notebook-sync/src/relay.rs` | Relay handle for notebook sync connections |
 | `crates/notebook-sync/src/connect.rs` | Connection setup (`connect_open_relay`, `connect_create_relay`) |
-| `crates/runtimed/src/notebook_sync_server.rs` | Daemon-side room management, kernel dispatch, sync loop |
-| `crates/runtimed/src/kernel_manager.rs` | Kernel process lifecycle, execution queue, output interception |
-| `crates/notebook/src/lib.rs` | Tauri commands and relay tasks (pipes sync bytes, emits events) |
-| `crates/runtimed-wasm/src/lib.rs` | WASM bindings for local-first cell mutations |
-| `crates/notebook-doc/src/lib.rs` | Shared Automerge document schema and operations |
+| `crates/notebook-sync/src/handle.rs` | `DocHandle` — sync infrastructure, per-cell accessors for Python clients |
+| `crates/runtimed/src/notebook_sync_server.rs` | `NotebookRoom`, room lifecycle, autosave debouncer, re-keying, sync loop |
+| `crates/runtimed/src/kernel_manager.rs` | Kernel process lifecycle, execution queue, IOPub output routing |
+| `crates/runtimed/src/comm_state.rs` | Widget comm state + Output widget capture routing |
+| `crates/runtimed/src/output_store.rs` | Output manifest creation, blob inlining threshold |
+| `crates/runtimed/src/blob_store.rs` | Content-addressed blob storage |
+| `crates/notebook/src/lib.rs` | Tauri commands and relay tasks (transparent byte pipe) |
+| `crates/runtimed-wasm/src/lib.rs` | WASM bindings: cell mutations, sync, per-cell accessors, `CellChangeset` |
+| `crates/notebook-doc/src/lib.rs` | `NotebookDoc`: Automerge schema, cell CRUD, output writes, per-cell accessors |
+| `crates/notebook-doc/src/diff.rs` | `CellChangeset`: structural diff from Automerge patches |
 | `crates/notebook-doc/src/frame_types.rs` | Shared frame type constants (0x00–0x04) |
 | `apps/notebook/src/lib/frame-types.ts` | TypeScript mirror of frame type constants |
-| `apps/notebook/src/hooks/useAutomergeNotebook.ts` | Frontend sync integration (WASM handle, sync loop, cell materialization) |
-| `apps/notebook/src/hooks/useDaemonKernel.ts` | Frontend broadcast handling (kernel status, outputs, environment) |
+| `apps/notebook/src/hooks/useAutomergeNotebook.ts` | WASM handle owner, `scheduleMaterialize`, `CellChangeset` dispatch |
+| `apps/notebook/src/hooks/useDaemonKernel.ts` | Kernel execution, widget comm routing, broadcast handling |
+| `apps/notebook/src/lib/materialize-cells.ts` | `materializeCellFromWasm()` (per-cell) + `cellSnapshotsToNotebookCells()` (full) |
+| `apps/notebook/src/lib/notebook-cells.ts` | Split cell store: `useCell(id)`, `useCellIds()`, per-cell subscriptions |
+| `apps/notebook/src/lib/notebook-frame-bus.ts` | In-memory sync pub/sub for broadcasts and presence |

--- a/contributing/runtimed.md
+++ b/contributing/runtimed.md
@@ -1,6 +1,6 @@
 # Runtime Daemon (runtimed)
 
-The runtime daemon manages prewarmed Python environments, notebook document sync, and kernel execution across notebook windows.
+The runtime daemon manages prewarmed Python environments, notebook document sync, kernel execution, autosave, and widget state across notebook windows.
 
 ## Quick Reference
 
@@ -51,10 +51,13 @@ The daemon provides a single coordinating entity that prewarms environments in t
 
 | Component | Purpose | Location |
 |-----------|---------|----------|
-| Unix socket | IPC endpoint | `~/.cache/runt/runtimed.sock` (Linux) / `~/Library/Caches/runt/runtimed.sock` (macOS) |
-| Lock file | Singleton guarantee | `~/.cache/runt/daemon.lock` (Linux) / `~/Library/Caches/runt/daemon.lock` (macOS) |
-| Info file | Discovery (PID, endpoint) | `~/.cache/runt/daemon.json` (Linux) / `~/Library/Caches/runt/daemon.json` (macOS) |
-| Environments | Prewarmed venvs | `~/.cache/runt/envs/` (Linux) / `~/Library/Caches/runt/envs/` (macOS) |
+| Unix socket | IPC endpoint | `~/Library/Caches/runt/runtimed.sock` (macOS) / `~/.cache/runt/runtimed.sock` (Linux) |
+| Lock file | Singleton guarantee | `~/Library/Caches/runt/daemon.lock` (macOS) / `~/.cache/runt/daemon.lock` (Linux) |
+| Info file | Discovery (PID, endpoint) | `~/Library/Caches/runt/daemon.json` (macOS) / `~/.cache/runt/daemon.json` (Linux) |
+| Environments | Prewarmed venvs | `~/Library/Caches/runt/envs/` (macOS) / `~/.cache/runt/envs/` (Linux) |
+| Blob store | Content-addressed outputs | `~/Library/Caches/runt/blobs/` (macOS) / `~/.cache/runt/blobs/` (Linux) |
+| Notebook docs | Persisted Automerge docs | `~/Library/Caches/runt/notebook-docs/` (macOS) / `~/.cache/runt/notebook-docs/` (Linux) |
+| Snapshots | Pre-delete safety copies | `~/Library/Caches/runt/notebook-docs/snapshots/` (macOS) / `~/.cache/runt/notebook-docs/snapshots/` (Linux) |
 
 ## Development Workflow
 
@@ -109,6 +112,59 @@ cargo test -p runtimed test_daemon_ping_pong
 
 Integration tests use temp directories for socket and lock files to avoid conflicts with a running daemon.
 
+## Notebook Room Lifecycle
+
+Each open notebook has a **room** (`NotebookRoom` in `notebook_sync_server.rs`), keyed by notebook ID (canonical file path or UUID for untitled notebooks).
+
+### Autosave
+
+The daemon autosaves `.ipynb` on a debounce (2s quiet period, 10s max interval) via `spawn_autosave_debouncer`. No user action required. `NotebookAutosaved` broadcast clears the frontend dirty flag. Explicit Cmd+S additionally runs cell formatting (ruff/deno fmt).
+
+Autosave skips untitled notebooks (no file path) and notebooks mid-load (`is_loading` flag). After saving, the debouncer drains the change channel to detect mutations during the async write — the `NotebookAutosaved` broadcast only fires when the file is truly caught up.
+
+### Room re-keying
+
+When an untitled notebook (UUID room) is first saved, `rekey_ephemeral_room()`:
+1. Canonicalizes the save path
+2. Guards against overwriting an existing room
+3. Re-keys the `NotebookRooms` HashMap (remove UUID, insert path)
+4. Updates the room's `notebook_path` (`RwLock<PathBuf>`)
+5. Deletes the old UUID-based persist file
+6. Spawns a file watcher for the new path
+7. Broadcasts `RoomRenamed { new_notebook_id }` so all peers update their local ID
+
+The `NotebookSaved` response includes `new_notebook_id: Option<String>` for the re-key case.
+
+### Crash recovery
+
+Untitled notebooks persist their Automerge doc to `notebook-docs/{hash}.automerge`. Before deleting a persisted doc on reopen (saved notebooks reload from `.ipynb`), the daemon snapshots it to `notebook-docs/snapshots/` (max 5 per notebook hash).
+
+`runt recover --list` scans all cache namespaces (stable, nightly, per-worktree). `runt recover <path>` finds the live doc or most recent snapshot and exports to `.ipynb`.
+
+### Multi-window
+
+Multiple windows join the same room as separate Automerge peers. The first window gets a deterministic label (for geometry persistence); additional windows get a UUID suffix. All peers receive sync frames and broadcasts independently.
+
+### Eviction
+
+When all peers disconnect, a delayed eviction task runs (configurable via `keep_alive_secs` setting, default 30s). If no peers reconnect, the kernel shuts down, the file watcher stops, and the room is removed. If peers reconnect during the window, eviction is cancelled.
+
+## Per-Cell Accessors
+
+`NotebookDoc` and `DocHandle` expose O(1) cell reads that avoid full-document materialization:
+
+| Method | Returns | Used by |
+|--------|---------|---------|
+| `get_cell_source(id)` | `Option<String>` | Daemon (execution), Python SDK, WASM |
+| `get_cell_type(id)` | `Option<String>` | MCP tools, WASM |
+| `get_cell_outputs(id)` | `Option<Vec<String>>` | Python SDK output collection |
+| `get_cell_execution_count(id)` | `Option<String>` | WASM materialization |
+| `get_cell_metadata(id)` | `Option<Value>` | Python SDK, WASM |
+| `get_cell_position(id)` | `Option<String>` | WASM, fractional index operations |
+| `get_cell_ids()` | `Vec<String>` (position-sorted) | Daemon, Python SDK, WASM |
+
+These are critical for performance — `get_cells()` materializes every cell's source, outputs, and metadata. Use per-cell accessors when you only need one cell or one field.
+
 ## Code Structure
 
 ```
@@ -117,31 +173,37 @@ crates/runtimed/
 │   ├── lib.rs                   # Public types, path helpers (default_socket_path, etc.)
 │   ├── main.rs                  # CLI entry point (run, install, status, etc.)
 │   ├── daemon.rs                # Daemon state, pool management, connection routing
-│   ├── protocol.rs              # BlobRequest/BlobResponse enums (notebook types re-exported from notebook-protocol crate)
+│   ├── protocol.rs              # BlobRequest/BlobResponse + re-exports from notebook-protocol
 │   ├── client.rs                # PoolClient for pool operations
 │   ├── singleton.rs             # File-based locking for single instance
-│   ├── service.rs               # Cross-platform service installation
+│   ├── service.rs               # Cross-platform service installation (launchd/systemd)
 │   ├── settings_doc.rs          # Settings Automerge document, schema, migration
 │   ├── sync_server.rs           # Settings sync handler
 │   ├── sync_client.rs           # Settings sync client library
-│   ├── (uses notebook_doc crate) # Shared `NotebookDoc` from crates/notebook-doc/src/lib.rs
-│   ├── notebook_sync_server.rs  # Room-based notebook sync, peer management, eviction
+│   ├── notebook_sync_server.rs  # NotebookRoom, room lifecycle, autosave, re-keying, sync loop
+│   ├── kernel_manager.rs        # RoomKernel: kernel lifecycle, execution queue, IOPub output routing
+│   ├── kernel_pids.rs           # Kernel PID tracking and orphan reaping
+│   ├── comm_state.rs            # Widget comm state + Output widget capture routing
+│   ├── output_store.rs          # Output manifest creation, blob inlining threshold
 │   ├── blob_store.rs            # Content-addressed blob store with metadata sidecars
 │   ├── blob_server.rs           # HTTP read server for blobs (hyper 1.x)
-│   ├── runtime.rs               # Runtime enum definition (Python/Deno/Other)
-│   ├── kernel_manager.rs        # Kernel lifecycle, ZMQ iopub watching, execution queue
-│   ├── kernel_pids.rs           # Kernel PID tracking and cleanup
 │   ├── inline_env.rs            # Inline dependency environment caching (UV/Conda)
 │   ├── project_file.rs          # Project file detection (pyproject.toml, pixi.toml, etc.)
-│   ├── comm_state.rs            # Comm message state for ipywidgets
-│   ├── output_store.rs          # Output persistence and retrieval
 │   ├── markdown_assets.rs       # Markdown image/asset resolution and rewriting
-│   ├── (metadata via notebook_doc) # `notebook_doc::metadata` re-exported as `notebook_metadata`
-│   ├── stream_terminal.rs       # Stream terminal output handling
+│   ├── stream_terminal.rs       # Stream terminal output handling (carriage return, ANSI)
+│   ├── runtime.rs               # Runtime enum definition (Python/Deno/Other)
 │   └── terminal_size.rs         # Terminal size tracking
 └── tests/
     └── integration.rs           # Integration tests (daemon, pool, settings sync, notebook sync)
 ```
+
+**Related crates** (shared across daemon, WASM, Python):
+
+| Crate | What it owns |
+|-------|-------------|
+| `notebook-doc` | `NotebookDoc`: Automerge schema, cell CRUD, per-cell accessors, `CellChangeset` diffing |
+| `notebook-protocol` | Wire types: `NotebookRequest`, `NotebookResponse`, `NotebookBroadcast`, `CommSnapshot` |
+| `notebook-sync` | `DocHandle`: sync infrastructure, snapshot watch channel, per-cell accessors for Python |
 
 For the full architecture (all phases, schemas, and design decisions), see [docs/runtimed.md](../docs/runtimed.md).
 
@@ -210,12 +272,19 @@ print(result.outputs)  # [Output(stream, stdout: "hello\n")]
 cell = session.get_cell(result.cell_id)
 print(cell.outputs)  # [Output(stream, stdout: "hello\n")]
 
+# Per-cell accessors (O(1), no full-doc materialization)
+source = session.get_cell_source(result.cell_id)  # just the source string
+cell_type = session.get_cell_type(result.cell_id)  # "code" | "markdown" | "raw"
+cell_ids = session.get_cell_ids()                   # position-sorted IDs
+
 # Move a cell (updates fractional index position)
 new_position = session.move_cell("cell-id", after_cell_id="other-cell-id")
 
 # Cell objects include position
 print(cell.position)  # fractional index string e.g. "80", "C0"
 ```
+
+**Prefer per-cell accessors** (`get_cell_source`, `get_cell_type`, `get_cell_ids`) over `get_cells()` when you only need one cell or one field. `get_cells()` materializes every cell's source, outputs, and metadata.
 
 ### Socket Path Configuration
 


### PR DESCRIPTION
Update AGENTS.md and four contributing guides to reflect the incremental sync pipeline, state ownership model, and notebook lifecycle work that's landed over the past week.

## What changed

**AGENTS.md** — expanded from architectural sketch to operational reference:
- **State Ownership** table: who writes what to the CRDT (frontend writes source/metadata, daemon writes outputs/exec count/widget state)
- **Incremental Sync Pipeline**: CellChangeset → scheduleMaterialize → per-cell accessors → split cell store. The full pipeline from WASM diff to React re-render.
- **Crate Boundaries**: notebook-doc vs notebook-protocol vs notebook-sync — when to modify which
- **Blob Store**: two-tier manifest system, content-addressed storage, HTTP server, frontend resolution
- **Notebook Room Lifecycle**: autosave (2s/10s debounce), room re-keying (untitled→saved), crash recovery (snapshots), multi-window, eviction (30s default)
- **Widget State**: current CommState/WidgetStore architecture + pointer to #761 for comms-in-doc direction
- **Settings Sync**: separate Automerge doc, SettingsSync handshake
- **Key Files table**: added blob store, output store, comm state, diff.rs, notebook-protocol, notebook-sync, split cell store, frame bus; restored env management files that were accidentally dropped

**contributing/protocol.md**:
- CellChangeset section in sync flow (field-level diff, O(delta))
- Missing broadcast types: OutputsCleared, CommSync, RoomRenamed, NotebookAutosaved (was 11 listed, now all 15)
- Architectural Direction section pointing to #761 phased plan
- Expanded Output Storage with two-tier manifest detail
- Notebook Lifecycle section (autosave, re-keying, recovery, multi-window)

**contributing/architecture.md**:
- Principle 3: autosave details, crash recovery flow, room re-keying
- Principle 4: incremental sync pipeline, per-cell accessors, split cell store
- Crate Boundaries section
- Updated references

**contributing/frontend-architecture.md**:
- Data flow diagram redrawn: CellChangeset → scheduleMaterialize → structural/per-cell dispatch → split cell store → React.memo per cell
- Incremental sync pipeline section with the full decision tree
- Split cell store API (useCell, useCellIds, updateCellById)
- cursor-registry.ts as independent frame bus subscriber (not delegated from usePresence)
- CellChangeset TypeScript types (inline in useAutomergeNotebook.ts, not a separate file)

**contributing/runtimed.md**:
- Notebook Room Lifecycle section (autosave, re-keying, recovery, multi-window, eviction)
- Per-Cell Accessors table with methods, return types, consumers
- Code structure tree reorganized by responsibility
- Related crates table
- Python bindings: per-cell accessor examples

## Review notes

Each doc was verified against source by a subagent reviewer. Fixes applied for: phantom `get_cell_positions()` reference (doesn't exist), broken `cell-changeset.ts` path (types are inline in useAutomergeNotebook.ts), eviction default (30s not 300s), inline threshold boundary (< 8KB not ≤), rekey step claiming autosave debouncer spawn (only file watcher), incomplete crate consumer lists.

_PR submitted by @rgbkrk's agent Quill, via Zed_