### PR TITLE
chore(cargo): inherit edition, repository, and license from workspace

### DIFF
--- a/crates/kernel-env/Cargo.toml
+++ b/crates/kernel-env/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "kernel-env"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 description = "Python environment management (UV + Conda) with progress reporting"
-repository = "https://github.com/nteract/desktop"
-license = "BSD-3-Clause"
+repository.workspace = true
+license.workspace = true
 
 [lints]
 workspace = true

--- a/crates/kernel-launch/Cargo.toml
+++ b/crates/kernel-launch/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "kernel-launch"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 description = "Shared kernel launching and tool bootstrapping for nteract"
-repository = "https://github.com/nteract/desktop"
-license = "BSD-3-Clause"
+repository.workspace = true
+license.workspace = true
 
 [lints]
 workspace = true

--- a/crates/mcp-supervisor/Cargo.toml
+++ b/crates/mcp-supervisor/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "mcp-supervisor"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 description = "Inkwell — MCP supervisor that proxies to the nteract MCP server with auto-restart, file watching, and daemon management"
+repository.workspace = true
+license.workspace = true
 publish = false
 
 [[bin]]

--- a/crates/notebook-doc/Cargo.toml
+++ b/crates/notebook-doc/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "notebook-doc"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 description = "Shared Automerge notebook document types and operations, used by both runtimed (daemon) and runtimed-wasm (frontend)"
-license = "BSD-3-Clause"
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
 automerge = "0.7"

--- a/crates/notebook-protocol/Cargo.toml
+++ b/crates/notebook-protocol/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "notebook-protocol"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 description = "Shared wire protocol types for notebook sync (client and server)"
-repository = "https://github.com/nteract/desktop"
-license = "BSD-3-Clause"
+repository.workspace = true
+license.workspace = true
 
 [lints]
 workspace = true

--- a/crates/notebook-sync/Cargo.toml
+++ b/crates/notebook-sync/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "notebook-sync"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 description = "Automerge-based notebook sync client with direct document access"
-repository = "https://github.com/nteract/desktop"
-license = "BSD-3-Clause"
+repository.workspace = true
+license.workspace = true
 
 [lints]
 workspace = true

--- a/crates/notebook/Cargo.toml
+++ b/crates/notebook/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "notebook"
 version = "2.0.0"
-edition = "2021"
+edition.workspace = true
 description = "Tauri-based notebook UI for Jupyter kernels"
-repository = "https://github.com/nteract/desktop"
-license = "BSD-3-Clause"
+repository.workspace = true
+license.workspace = true
 
 [lints]
 workspace = true

--- a/crates/runt-trust/Cargo.toml
+++ b/crates/runt-trust/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "runt-trust"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 description = "Notebook trust verification using HMAC signatures over dependency metadata"
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
 dirs = "5"

--- a/crates/runt-workspace/Cargo.toml
+++ b/crates/runt-workspace/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "runt-workspace"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 description = "Workspace and dev mode utilities for Runt"
+repository.workspace = true
+license.workspace = true
 
 [dependencies]
 dirs = "5"

--- a/crates/runtimed-wasm/Cargo.toml
+++ b/crates/runtimed-wasm/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "runtimed-wasm"
 version = "0.1.0"
-edition = "2021"
-license = "BSD-3-Clause"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 description = "WASM bindings for runtimed notebook document operations, compiled from the same automerge crate as the daemon"
 
 [lib]

--- a/crates/runtimed/Cargo.toml
+++ b/crates/runtimed/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "runtimed"
 version = "2.0.0"
-edition = "2021"
+edition.workspace = true
 description = "Central daemon for managing Jupyter runtimes and prewarmed environments"
-repository = "https://github.com/nteract/desktop"
-license = "BSD-3-Clause"
+repository.workspace = true
+license.workspace = true
 
 [lints]
 workspace = true

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -2,6 +2,8 @@
 name = "xtask"
 version = "0.1.0"
 edition.workspace = true
+repository.workspace = true
+license.workspace = true
 publish = false
 
 [lints]


### PR DESCRIPTION
Consolidate Cargo.toml metadata across all crates by inheriting `edition`, `repository`, and `license` from the workspace configuration. This reduces duplication and ensures consistent package metadata throughout the project.

**Changes:**
- 6 crates now use `*.workspace = true` for all three fields
- 2 crates gained missing `repository` field
- 3 crates gained missing `repository` and `license` fields  
- 1 crate gained missing `repository` and `license` (already had `edition.workspace`)

This resolves the wasm-pack warning about the missing repository field in runtimed-wasm.

## Verification

* [ ] Verify the wasm-pack build produces no metadata warnings
* [ ] Confirm all crates build successfully with `cargo check`

_PR submitted by @rgbkrk's agent, Quill_