### PR TITLE
fix(sync): use-after-free in sync reply timer + binary IPC for send_frame

### DIFF
--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -5,7 +5,7 @@ import {
   save as saveDialog,
 } from "@tauri-apps/plugin-dialog";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { frame_types } from "../lib/frame-types";
+import { frame_types, sendFrame } from "../lib/frame-types";
 import { logger } from "../lib/logger";
 import {
   type CellSnapshot,
@@ -175,13 +175,7 @@ export function useAutomergeNotebook() {
   const syncToRelay = useCallback((handle: NotebookHandle) => {
     const msg = handle.generate_sync_message();
     if (msg) {
-      // Prepend frame type byte for the unified send_frame command
-      const frameData = new Uint8Array(1 + msg.length);
-      frameData[0] = frame_types.AUTOMERGE_SYNC;
-      frameData.set(msg, 1);
-      invoke("send_frame", {
-        frameData: Array.from(frameData),
-      }).catch((e: unknown) =>
+      sendFrame(frame_types.AUTOMERGE_SYNC, msg).catch((e: unknown) =>
         logger.warn("[automerge-notebook] sync to relay failed:", e),
       );
     }
@@ -215,20 +209,19 @@ export function useAutomergeNotebook() {
     null,
   );
 
-  const scheduleSyncReply = useCallback((handle: NotebookHandle) => {
+  const scheduleSyncReply = useCallback(() => {
     if (pendingSyncReplyTimerRef.current) {
       clearTimeout(pendingSyncReplyTimerRef.current);
     }
     pendingSyncReplyTimerRef.current = setTimeout(() => {
       pendingSyncReplyTimerRef.current = null;
+      // Read handle at fire time — not capture time — to avoid
+      // use-after-free if bootstrap() replaced/freed the handle.
+      const handle = handleRef.current;
+      if (!handle) return;
       const reply = handle.generate_sync_reply();
       if (reply) {
-        const frameData = new Uint8Array(1 + reply.length);
-        frameData[0] = frame_types.AUTOMERGE_SYNC;
-        frameData.set(reply, 1);
-        invoke("send_frame", {
-          frameData: Array.from(frameData),
-        }).catch((e: unknown) =>
+        sendFrame(frame_types.AUTOMERGE_SYNC, reply).catch((e: unknown) =>
           logger.warn("[automerge-notebook] sync reply failed:", e),
         );
       }
@@ -473,7 +466,7 @@ export function useAutomergeNotebook() {
                 }
                 // Schedule a debounced sync reply — multiple inbound frames
                 // coalesce into a single outbound reply per 50ms window.
-                scheduleSyncReply(handle);
+                scheduleSyncReply();
                 break;
               }
               case "broadcast": {
@@ -531,12 +524,12 @@ export function useAutomergeNotebook() {
         if (handleRef.current) {
           const reply = handleRef.current.generate_sync_reply();
           if (reply) {
-            const frameData = new Uint8Array(1 + reply.length);
-            frameData[0] = frame_types.AUTOMERGE_SYNC;
-            frameData.set(reply, 1);
-            invoke("send_frame", {
-              frameData: Array.from(frameData),
-            }).catch(() => {});
+            sendFrame(frame_types.AUTOMERGE_SYNC, reply).catch((e: unknown) =>
+              logger.warn(
+                "[automerge-notebook] teardown sync reply failed:",
+                e,
+              ),
+            );
           }
         }
       }
@@ -704,12 +697,7 @@ export function useAutomergeNotebook() {
     // Generate and send sync message, awaiting the IPC
     const msg = handle.generate_sync_message();
     if (msg) {
-      const frameData = new Uint8Array(1 + msg.length);
-      frameData[0] = frame_types.AUTOMERGE_SYNC;
-      frameData.set(msg, 1);
-      await invoke("send_frame", {
-        frameData: Array.from(frameData),
-      });
+      await sendFrame(frame_types.AUTOMERGE_SYNC, msg);
     }
   }, []);
 

--- a/apps/notebook/src/hooks/usePresence.ts
+++ b/apps/notebook/src/hooks/usePresence.ts
@@ -1,6 +1,5 @@
-import { invoke } from "@tauri-apps/api/core";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { frame_types } from "../lib/frame-types";
+import { frame_types, sendFrame } from "../lib/frame-types";
 import { logger } from "../lib/logger";
 import { subscribePresence } from "../lib/notebook-frame-bus";
 import {
@@ -184,11 +183,8 @@ export function usePresence(peerId: string | null) {
     (cellId: string, line: number, column: number) => {
       if (!peerId) return;
       const payload = encode_cursor_presence(peerId, cellId, line, column);
-      const frameData = new Uint8Array(1 + payload.length);
-      frameData[0] = frame_types.PRESENCE;
-      frameData.set(payload, 1);
-      invoke("send_frame", { frameData: Array.from(frameData) }).catch(
-        (e: unknown) => logger.warn("[presence] send cursor failed:", e),
+      sendFrame(frame_types.PRESENCE, payload).catch((e: unknown) =>
+        logger.warn("[presence] send cursor failed:", e),
       );
     },
     [peerId],
@@ -211,11 +207,8 @@ export function usePresence(peerId: string | null) {
         headLine,
         headCol,
       );
-      const frameData = new Uint8Array(1 + payload.length);
-      frameData[0] = frame_types.PRESENCE;
-      frameData.set(payload, 1);
-      invoke("send_frame", { frameData: Array.from(frameData) }).catch(
-        (e: unknown) => logger.warn("[presence] send selection failed:", e),
+      sendFrame(frame_types.PRESENCE, payload).catch((e: unknown) =>
+        logger.warn("[presence] send selection failed:", e),
       );
     },
     [peerId],

--- a/apps/notebook/src/lib/frame-types.ts
+++ b/apps/notebook/src/lib/frame-types.ts
@@ -1,3 +1,5 @@
+import { invoke } from "@tauri-apps/api/core";
+
 /**
  * Frame type constants matching `notebook_doc::frame_types` in Rust.
  *
@@ -17,3 +19,21 @@ export const frame_types = {
   /** Presence (CBOR, see notebook_doc::presence). */
   PRESENCE: 0x04,
 } as const;
+
+/**
+ * Send a typed frame to the daemon via the Tauri relay.
+ *
+ * Prepends the frame type byte to the payload and sends the resulting
+ * `Uint8Array` as a raw binary IPC payload — no JSON serialization.
+ * The Rust `send_frame` command accepts `tauri::ipc::Request` and
+ * extracts the bytes directly from `InvokeBody::Raw`.
+ */
+export function sendFrame(
+  frameType: number,
+  payload: Uint8Array,
+): Promise<void> {
+  const frame = new Uint8Array(1 + payload.length);
+  frame[0] = frameType;
+  frame.set(payload, 1);
+  return invoke("send_frame", frame);
+}

--- a/apps/notebook/src/lib/notebook-metadata.ts
+++ b/apps/notebook/src/lib/notebook-metadata.ts
@@ -1,7 +1,6 @@
-import { invoke } from "@tauri-apps/api/core";
 import { useMemo, useSyncExternalStore } from "react";
 import type { NotebookHandle } from "../wasm/runtimed-wasm/runtimed_wasm.js";
-import { frame_types } from "./frame-types";
+import { frame_types, sendFrame } from "./frame-types";
 import { logger } from "./logger";
 
 // ---------------------------------------------------------------------------
@@ -241,12 +240,7 @@ async function syncToRelay(): Promise<void> {
   if (!_handle) return;
   const msg = _handle.generate_sync_message();
   if (msg) {
-    const frameData = new Uint8Array(1 + msg.length);
-    frameData[0] = frame_types.AUTOMERGE_SYNC;
-    frameData.set(msg, 1);
-    await invoke("send_frame", {
-      frameData: Array.from(frameData),
-    });
+    await sendFrame(frame_types.AUTOMERGE_SYNC, msg);
   }
 }
 

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -2536,17 +2536,44 @@ async fn reconnect_to_daemon(
 /// Supported outgoing types:
 /// - 0x00: AutomergeSync (forwarded via RelayHandle::forward_frame)
 /// - 0x04: Presence (forwarded via RelayHandle::forward_frame)
+///
+/// Accepts raw binary via `tauri::ipc::Request` — the frontend passes a
+/// `Uint8Array` directly as the invoke payload, bypassing JSON serialization.
 #[tauri::command]
 async fn send_frame(
+    request: tauri::ipc::Request<'_>,
     window: tauri::Window,
-    frame_data: Vec<u8>,
     registry: tauri::State<'_, WindowNotebookRegistry>,
+) -> Result<(), String> {
+    let frame_data = match request.body() {
+        tauri::ipc::InvokeBody::Raw(bytes) => bytes.as_slice(),
+        tauri::ipc::InvokeBody::Json(value) => {
+            // Backward compatibility: accept JSON array of bytes.
+            // This path is slower and should be removed once all callers
+            // migrate to raw binary.
+            warn!("[send_frame] Received JSON payload — callers should send Uint8Array directly");
+            return match serde_json::from_value::<Vec<u8>>(
+                value.get("frameData").cloned().unwrap_or(value.clone()),
+            ) {
+                Ok(bytes) => send_frame_bytes(&bytes, &window, &registry).await,
+                Err(e) => Err(format!("Failed to parse JSON frame data: {}", e)),
+            };
+        }
+    };
+
+    send_frame_bytes(frame_data, &window, &registry).await
+}
+
+async fn send_frame_bytes(
+    frame_data: &[u8],
+    window: &tauri::Window,
+    registry: &tauri::State<'_, WindowNotebookRegistry>,
 ) -> Result<(), String> {
     if frame_data.is_empty() {
         return Err("Empty frame".to_string());
     }
 
-    let notebook_sync = notebook_sync_for_window(&window, registry.inner())?;
+    let notebook_sync = notebook_sync_for_window(window, registry.inner())?;
     let guard = notebook_sync.lock().await;
     let handle = guard.as_ref().ok_or("Not connected to daemon")?;
 


### PR DESCRIPTION
Two fixes from #937 follow-up:

**Use-after-free in sync reply timer** (from Copilot review): `scheduleSyncReply` captured the `NotebookHandle` at call time and used it in the `setTimeout` callback. If `bootstrap()` replaced/freed the handle before the timer fired, the callback would call into freed WASM memory. Now reads `handleRef.current` at fire time.

**Binary IPC for send_frame**: All 7 `send_frame` call sites were doing `Array.from(Uint8Array)` to convert binary frames into JSON number arrays. Tauri v2 supports passing `Uint8Array` directly as raw binary via `tauri::ipc::Request` + `InvokeBody::Raw` — no JSON serialization overhead.

- Rust `send_frame` now accepts `tauri::ipc::Request`, extracts raw bytes. Falls back to JSON with a warning for backward compat.
- New `sendFrame()` helper in `frame-types.ts` — prepends type byte, passes `Uint8Array` directly to `invoke()`
- All 7 call sites across `useAutomergeNotebook.ts`, `usePresence.ts`, and `notebook-metadata.ts` use the helper
- Teardown `.catch(() => {})` now logs warnings

---

_PR submitted by @rgbkrk's agent Quill, via Zed_