### PR TITLE
perf(notebook): per-cell output materialization + referential identity

### DIFF
--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -257,7 +257,7 @@ export function useAutomergeNotebook() {
   const pendingChangesetRef = useRef<CellChangeset | null>(null);
 
   const scheduleMaterialize = useCallback(
-    (handle: NotebookHandle, changeset?: CellChangeset) => {
+    (_handle: NotebookHandle, changeset?: CellChangeset) => {
       if (changeset) {
         // Merge into accumulated changeset for this coalescing window.
         pendingChangesetRef.current = pendingChangesetRef.current
@@ -270,6 +270,10 @@ export function useAutomergeNotebook() {
       if (pendingMaterializeTimerRef.current) return;
       pendingMaterializeTimerRef.current = setTimeout(async () => {
         pendingMaterializeTimerRef.current = null;
+        // Read handle at fire time — not capture time — to avoid
+        // use-after-free if bootstrap() replaced/freed the handle.
+        const handle = handleRef.current;
+        if (!handle) return;
         const needsFull = pendingFullMaterializeRef.current;
         const cs = pendingChangesetRef.current;
         pendingFullMaterializeRef.current = false;
@@ -294,9 +298,9 @@ export function useAutomergeNotebook() {
         // fast synchronous path; cache misses resolve the individual cell's
         // outputs asynchronously (without serializing the entire document).
         const cache = outputCacheRef.current;
-        const blobPort = blobPortPromiseRef.current
-          ? await blobPortPromiseRef.current
-          : null;
+        // Defer blobPort resolution until a cache miss actually needs it.
+        let blobPort: number | null = null;
+        let blobPortResolved = false;
 
         for (const { cell_id: cellId, fields } of cs.changed) {
           if (fields.outputs) {
@@ -319,6 +323,12 @@ export function useAutomergeNotebook() {
               // Cache miss — resolve this cell's outputs async (fetch
               // manifests from blob store) without re-serializing the
               // entire document.
+              if (!blobPortResolved) {
+                blobPort = blobPortPromiseRef.current
+                  ? await blobPortPromiseRef.current
+                  : null;
+                blobPortResolved = true;
+              }
               const resolved = (
                 await Promise.all(
                   rawOutputs.map((o) => resolveOutput(o, blobPort, cache)),

--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -11,7 +11,9 @@ import {
   type CellSnapshot,
   cellSnapshotsToNotebookCells,
   cellSnapshotsToNotebookCellsSync,
+  isManifestHash,
   materializeCellFromWasm,
+  resolveOutput,
 } from "../lib/materialize-cells";
 import {
   getCellById,
@@ -287,30 +289,66 @@ export function useAutomergeNotebook() {
           return;
         }
 
-        // Split changed cells: outputs need async blob fetches via full
-        // materialization; source/metadata-only can use the fast sync path.
-        const hasOutputChanges = cs.changed.some((c) => c.fields.outputs);
+        // Per-cell materialization. For cells with output changes, check
+        // whether all outputs are already in the cache. Cache hits use the
+        // fast synchronous path; cache misses resolve the individual cell's
+        // outputs asynchronously (without serializing the entire document).
+        const cache = outputCacheRef.current;
+        const blobPort = blobPortPromiseRef.current
+          ? await blobPortPromiseRef.current
+          : null;
 
-        if (hasOutputChanges) {
-          // At least one cell has new outputs (likely blob manifest hashes
-          // not yet in cache). Full materialization resolves them via fetch.
-          await materializeCells(handle);
-          return;
-        }
+        for (const { cell_id: cellId, fields } of cs.changed) {
+          if (fields.outputs) {
+            // Check if every output for this cell is already cached.
+            const rawOutputs: string[] = handle.get_cell_outputs(cellId) ?? [];
+            const allCached = rawOutputs.every(
+              (o) => cache.has(o) || !isManifestHash(o),
+            );
 
-        // Fast path: no output changes — per-cell sync materialization.
-        if (cs.changed.length > 0) {
-          const cache = outputCacheRef.current;
-          for (const { cell_id: cellId } of cs.changed) {
+            if (allCached) {
+              // All outputs resolved from cache — fast sync path.
+              const cell = materializeCellFromWasm(
+                handle,
+                cellId,
+                cache,
+                getCellById(cellId),
+              );
+              if (cell) updateCellById(cellId, () => cell);
+            } else {
+              // Cache miss — resolve this cell's outputs async (fetch
+              // manifests from blob store) without re-serializing the
+              // entire document.
+              const resolved = (
+                await Promise.all(
+                  rawOutputs.map((o) => resolveOutput(o, blobPort, cache)),
+                )
+              ).filter((o): o is JupyterOutput => o !== null);
+
+              const ecStr = handle.get_cell_execution_count(cellId);
+              const ec =
+                !ecStr || ecStr === "null" ? null : Number.parseInt(ecStr, 10);
+              const source = handle.get_cell_source(cellId) ?? "";
+              const metadata = handle.get_cell_metadata(cellId) ?? {};
+
+              updateCellById(cellId, () => ({
+                id: cellId,
+                cell_type: "code" as const,
+                source,
+                execution_count: Number.isNaN(ec) ? null : ec,
+                outputs: resolved,
+                metadata,
+              }));
+            }
+          } else {
+            // No output changes — always use fast sync path.
             const cell = materializeCellFromWasm(
               handle,
               cellId,
               cache,
               getCellById(cellId),
             );
-            if (cell) {
-              updateCellById(cellId, () => cell);
-            }
+            if (cell) updateCellById(cellId, () => cell);
           }
         }
       }, 32);

--- a/apps/notebook/src/lib/__tests__/materialize-cells.bench.ts
+++ b/apps/notebook/src/lib/__tests__/materialize-cells.bench.ts
@@ -3,7 +3,6 @@ import type { JupyterOutput } from "../../types";
 import {
   type CellSnapshot,
   cellSnapshotsToNotebookCellsSync,
-  mergeConsecutiveStreams,
 } from "../materialize-cells";
 
 // ── Test data generators ──────────────────────────────────────────────
@@ -124,35 +123,6 @@ describe("per-output JSON.parse", () => {
     for (const json of outputJsons) {
       cachedOutputs.get(json);
     }
-  });
-});
-
-// ── Benchmarks: mergeConsecutiveStreams ────────────────────────────────
-
-describe("mergeConsecutiveStreams", () => {
-  // Simulate rapid stdout output from a print loop
-  const streamOutputs: JupyterOutput[] = Array.from(
-    { length: 200 },
-    (_, i) => ({
-      output_type: "stream" as const,
-      name: "stdout" as const,
-      text: `line ${i}: ${Array.from({ length: 80 }, () => "x").join("")}\n`,
-    }),
-  );
-
-  bench("merge 200 consecutive stdout streams", () => {
-    mergeConsecutiveStreams(streamOutputs);
-  });
-
-  // Mixed stdout/stderr
-  const mixedOutputs: JupyterOutput[] = Array.from({ length: 100 }, (_, i) => ({
-    output_type: "stream" as const,
-    name: (i % 3 === 0 ? "stderr" : "stdout") as "stdout" | "stderr",
-    text: `output ${i}\n`,
-  }));
-
-  bench("merge 100 mixed stdout/stderr streams", () => {
-    mergeConsecutiveStreams(mixedOutputs);
   });
 });
 

--- a/apps/notebook/src/lib/__tests__/materialize-cells.test.ts
+++ b/apps/notebook/src/lib/__tests__/materialize-cells.test.ts
@@ -5,6 +5,7 @@ import {
   cellSnapshotsToNotebookCells,
   cellSnapshotsToNotebookCellsSync,
   resolveOutput,
+  reuseOutputsIfUnchanged,
 } from "../materialize-cells";
 
 // ---------------------------------------------------------------------------
@@ -76,6 +77,82 @@ function rawSnapshot(id: string, source: string): CellSnapshot {
     metadata: {},
   };
 }
+
+// ---------------------------------------------------------------------------
+// reuseOutputsIfUnchanged
+// ---------------------------------------------------------------------------
+
+describe("reuseOutputsIfUnchanged", () => {
+  it("returns previous array when all elements are referentially identical", () => {
+    const a: JupyterOutput = {
+      output_type: "stream",
+      name: "stdout",
+      text: "hello",
+    };
+    const b: JupyterOutput = {
+      output_type: "stream",
+      name: "stderr",
+      text: "err",
+    };
+    const previous = [a, b];
+    const resolved = [a, b]; // same references, different array
+
+    const result = reuseOutputsIfUnchanged(resolved, previous);
+    expect(result).toBe(previous); // same array reference
+  });
+
+  it("returns resolved array when an element differs", () => {
+    const a: JupyterOutput = {
+      output_type: "stream",
+      name: "stdout",
+      text: "hello",
+    };
+    const b: JupyterOutput = {
+      output_type: "stream",
+      name: "stdout",
+      text: "hello",
+    };
+    const previous = [a];
+    const resolved = [b]; // same content, different object
+
+    const result = reuseOutputsIfUnchanged(resolved, previous);
+    expect(result).toBe(resolved);
+    expect(result).not.toBe(previous);
+  });
+
+  it("returns resolved array when lengths differ", () => {
+    const a: JupyterOutput = {
+      output_type: "stream",
+      name: "stdout",
+      text: "hello",
+    };
+    const previous = [a];
+    const resolved = [a, a];
+
+    const result = reuseOutputsIfUnchanged(resolved, previous);
+    expect(result).toBe(resolved);
+  });
+
+  it("returns resolved array when previous is undefined", () => {
+    const a: JupyterOutput = {
+      output_type: "stream",
+      name: "stdout",
+      text: "hello",
+    };
+    const resolved = [a];
+
+    const result = reuseOutputsIfUnchanged(resolved, undefined);
+    expect(result).toBe(resolved);
+  });
+
+  it("returns previous for empty arrays", () => {
+    const previous: JupyterOutput[] = [];
+    const resolved: JupyterOutput[] = [];
+
+    const result = reuseOutputsIfUnchanged(resolved, previous);
+    expect(result).toBe(previous);
+  });
+});
 
 // ---------------------------------------------------------------------------
 // resolveOutput

--- a/apps/notebook/src/lib/__tests__/materialize-cells.test.ts
+++ b/apps/notebook/src/lib/__tests__/materialize-cells.test.ts
@@ -4,7 +4,6 @@ import {
   type CellSnapshot,
   cellSnapshotsToNotebookCells,
   cellSnapshotsToNotebookCellsSync,
-  mergeConsecutiveStreams,
   resolveOutput,
 } from "../materialize-cells";
 
@@ -30,30 +29,6 @@ afterEach(() => {
 
 function streamOutput(name: "stdout" | "stderr", text: string): JupyterOutput {
   return { output_type: "stream", name, text };
-}
-
-function executeResult(
-  data: Record<string, unknown>,
-  executionCount?: number | null,
-): JupyterOutput {
-  return {
-    output_type: "execute_result",
-    data,
-    metadata: {},
-    execution_count: executionCount ?? null,
-  };
-}
-
-function displayData(data: Record<string, unknown>): JupyterOutput {
-  return { output_type: "display_data", data, metadata: {} };
-}
-
-function errorOutput(
-  ename: string,
-  evalue: string,
-  traceback: string[],
-): JupyterOutput {
-  return { output_type: "error", ename, evalue, traceback };
 }
 
 function codeSnapshot(
@@ -101,147 +76,6 @@ function rawSnapshot(id: string, source: string): CellSnapshot {
     metadata: {},
   };
 }
-
-// ---------------------------------------------------------------------------
-// mergeConsecutiveStreams
-// ---------------------------------------------------------------------------
-
-describe("mergeConsecutiveStreams", () => {
-  it("returns empty array for empty input", () => {
-    expect(mergeConsecutiveStreams([])).toEqual([]);
-  });
-
-  it("passes through a single stream output unchanged", () => {
-    const outputs = [streamOutput("stdout", "hello\n")];
-    const merged = mergeConsecutiveStreams(outputs);
-    expect(merged).toHaveLength(1);
-    expect(merged[0]).toEqual(streamOutput("stdout", "hello\n"));
-  });
-
-  it("merges consecutive stdout streams", () => {
-    const outputs = [
-      streamOutput("stdout", "line1\n"),
-      streamOutput("stdout", "line2\n"),
-      streamOutput("stdout", "line3\n"),
-    ];
-    const merged = mergeConsecutiveStreams(outputs);
-    expect(merged).toHaveLength(1);
-    expect(merged[0]).toEqual(streamOutput("stdout", "line1\nline2\nline3\n"));
-  });
-
-  it("merges consecutive stderr streams", () => {
-    const outputs = [
-      streamOutput("stderr", "warn1 "),
-      streamOutput("stderr", "warn2"),
-    ];
-    const merged = mergeConsecutiveStreams(outputs);
-    expect(merged).toHaveLength(1);
-    expect(merged[0]).toEqual(streamOutput("stderr", "warn1 warn2"));
-  });
-
-  it("does NOT merge stdout and stderr", () => {
-    const outputs = [
-      streamOutput("stdout", "out\n"),
-      streamOutput("stderr", "err\n"),
-    ];
-    const merged = mergeConsecutiveStreams(outputs);
-    expect(merged).toHaveLength(2);
-    expect(merged[0]).toEqual(streamOutput("stdout", "out\n"));
-    expect(merged[1]).toEqual(streamOutput("stderr", "err\n"));
-  });
-
-  it("does NOT merge streams separated by a non-stream output", () => {
-    const outputs = [
-      streamOutput("stdout", "before\n"),
-      displayData({ "text/plain": "interruption" }),
-      streamOutput("stdout", "after\n"),
-    ];
-    const merged = mergeConsecutiveStreams(outputs);
-    expect(merged).toHaveLength(3);
-    expect(merged[0]).toEqual(streamOutput("stdout", "before\n"));
-    expect(merged[2]).toEqual(streamOutput("stdout", "after\n"));
-  });
-
-  it("handles interleaved stdout and stderr", () => {
-    const outputs = [
-      streamOutput("stdout", "out1\n"),
-      streamOutput("stdout", "out2\n"),
-      streamOutput("stderr", "err1\n"),
-      streamOutput("stderr", "err2\n"),
-      streamOutput("stdout", "out3\n"),
-    ];
-    const merged = mergeConsecutiveStreams(outputs);
-    expect(merged).toHaveLength(3);
-    expect(merged[0]).toEqual(streamOutput("stdout", "out1\nout2\n"));
-    expect(merged[1]).toEqual(streamOutput("stderr", "err1\nerr2\n"));
-    expect(merged[2]).toEqual(streamOutput("stdout", "out3\n"));
-  });
-
-  it("handles array text format by joining before merge", () => {
-    // The function handles both string and string[] text formats
-    const outputs: JupyterOutput[] = [
-      { output_type: "stream", name: "stdout", text: "part1" as string },
-      { output_type: "stream", name: "stdout", text: "part2" as string },
-    ];
-    const merged = mergeConsecutiveStreams(outputs);
-    expect(merged).toHaveLength(1);
-    if (merged[0].output_type === "stream") {
-      expect(merged[0].text).toBe("part1part2");
-    }
-  });
-
-  it("passes through non-stream outputs untouched", () => {
-    const outputs = [
-      executeResult({ "text/plain": "42" }, 1),
-      displayData({ "image/png": "base64..." }),
-      errorOutput("Error", "boom", ["traceback"]),
-    ];
-    const merged = mergeConsecutiveStreams(outputs);
-    expect(merged).toHaveLength(3);
-    expect(merged).toEqual(outputs);
-  });
-
-  it("handles a complex mixed sequence", () => {
-    const outputs = [
-      streamOutput("stdout", "a"),
-      streamOutput("stdout", "b"),
-      executeResult({ "text/plain": "1" }, 1),
-      streamOutput("stderr", "e1"),
-      streamOutput("stderr", "e2"),
-      streamOutput("stdout", "c"),
-      errorOutput("Err", "x", []),
-      streamOutput("stdout", "d"),
-      streamOutput("stdout", "e"),
-    ];
-    const merged = mergeConsecutiveStreams(outputs);
-    expect(merged).toHaveLength(6);
-    expect(merged[0]).toEqual(streamOutput("stdout", "ab"));
-    expect(merged[1]).toEqual(executeResult({ "text/plain": "1" }, 1));
-    expect(merged[2]).toEqual(streamOutput("stderr", "e1e2"));
-    expect(merged[3]).toEqual(streamOutput("stdout", "c"));
-    expect(merged[4]).toEqual(errorOutput("Err", "x", []));
-    expect(merged[5]).toEqual(streamOutput("stdout", "de"));
-  });
-
-  it("preserves empty stream text", () => {
-    const outputs = [
-      streamOutput("stdout", ""),
-      streamOutput("stdout", "text"),
-    ];
-    const merged = mergeConsecutiveStreams(outputs);
-    expect(merged).toHaveLength(1);
-    if (merged[0].output_type === "stream") {
-      expect(merged[0].text).toBe("text");
-    }
-  });
-
-  it("does not mutate the input array", () => {
-    const outputs = [streamOutput("stdout", "a"), streamOutput("stdout", "b")];
-    const original = [...outputs];
-    mergeConsecutiveStreams(outputs);
-    expect(outputs).toEqual(original);
-  });
-});
 
 // ---------------------------------------------------------------------------
 // resolveOutput
@@ -584,7 +418,7 @@ describe("cellSnapshotsToNotebookCells", () => {
     }
   });
 
-  it("merges consecutive streams in code cell outputs", async () => {
+  it("passes through consecutive streams without merging (daemon consolidates)", async () => {
     const out1 = JSON.stringify({
       output_type: "stream",
       name: "stdout",
@@ -597,13 +431,21 @@ describe("cellSnapshotsToNotebookCells", () => {
     });
     const snap = codeSnapshot("c1", "print(...)", [out1, out2], "1");
 
+    // The daemon's StreamTerminals consolidates streams via terminal
+    // emulation before writing to the Automerge doc. The frontend no
+    // longer merges — it passes outputs through as-is.
     const cells = await cellSnapshotsToNotebookCells([snap], null, new Map());
     if (cells[0].cell_type === "code") {
-      expect(cells[0].outputs).toHaveLength(1);
+      expect(cells[0].outputs).toHaveLength(2);
       expect(cells[0].outputs[0]).toEqual({
         output_type: "stream",
         name: "stdout",
-        text: "line1\nline2\n",
+        text: "line1\n",
+      });
+      expect(cells[0].outputs[1]).toEqual({
+        output_type: "stream",
+        name: "stdout",
+        text: "line2\n",
       });
     }
   });

--- a/apps/notebook/src/lib/materialize-cells.ts
+++ b/apps/notebook/src/lib/materialize-cells.ts
@@ -84,6 +84,26 @@ export async function resolveOutput(
 }
 
 /**
+ * Return the previous outputs array if every element is referentially
+ * identical to the resolved outputs. This lets `cellsEqual()` short-circuit
+ * on `===` checks and skip React re-renders for cells whose outputs
+ * haven't actually changed (all cache hits, same order, same length).
+ */
+export function reuseOutputsIfUnchanged(
+  resolvedOutputs: JupyterOutput[],
+  previousOutputs: JupyterOutput[] | undefined,
+): JupyterOutput[] {
+  if (
+    previousOutputs &&
+    previousOutputs.length === resolvedOutputs.length &&
+    previousOutputs.every((o, i) => o === resolvedOutputs[i])
+  ) {
+    return previousOutputs;
+  }
+  return resolvedOutputs;
+}
+
+/**
  * Synchronous cell materialization for local mutations.
  *
  * Uses cache-only output resolution (no blob fetches). Safe to call when:
@@ -265,17 +285,9 @@ export function materializeCellFromWasm(
       })
       .filter((o): o is JupyterOutput => o !== null);
 
-    // Preserve the previous outputs array if every element is referentially
-    // identical (all cache hits, same order, same length). This lets
-    // cellsEqual() short-circuit on === checks and skip React re-renders.
     const prevOutputs =
       previousCell?.cell_type === "code" ? previousCell.outputs : undefined;
-    const outputs =
-      prevOutputs &&
-      prevOutputs.length === resolvedOutputs.length &&
-      prevOutputs.every((o, i) => o === resolvedOutputs[i])
-        ? prevOutputs
-        : resolvedOutputs;
+    const outputs = reuseOutputsIfUnchanged(resolvedOutputs, prevOutputs);
 
     return {
       id: cellId,

--- a/apps/notebook/src/lib/materialize-cells.ts
+++ b/apps/notebook/src/lib/materialize-cells.ts
@@ -84,35 +84,6 @@ export async function resolveOutput(
 }
 
 /**
- * Merge consecutive stream outputs sharing the same name (stdout/stderr).
- * Handles both `string` and `string[]` text formats.
- */
-export function mergeConsecutiveStreams(
-  outputs: JupyterOutput[],
-): JupyterOutput[] {
-  return outputs.reduce<JupyterOutput[]>((merged, output) => {
-    if (output.output_type === "stream" && merged.length > 0) {
-      const last = merged[merged.length - 1];
-      if (last.output_type === "stream" && last.name === output.name) {
-        const lastText = Array.isArray(last.text)
-          ? last.text.join("")
-          : last.text;
-        const outputText = Array.isArray(output.text)
-          ? output.text.join("")
-          : output.text;
-        merged[merged.length - 1] = {
-          ...last,
-          text: lastText + outputText,
-        };
-        return merged;
-      }
-    }
-    merged.push(output);
-    return merged;
-  }, []);
-}
-
-/**
  * Synchronous cell materialization for local mutations.
  *
  * Uses cache-only output resolution (no blob fetches). Safe to call when:
@@ -162,14 +133,12 @@ export function cellSnapshotsToNotebookCellsSync(
         })
         .filter((o): o is JupyterOutput => o !== null);
 
-      const outputs = mergeConsecutiveStreams(resolvedOutputs);
-
       return {
         id: snap.id,
         cell_type: "code" as const,
         source: snap.source,
         execution_count: Number.isNaN(executionCount) ? null : executionCount,
-        outputs,
+        outputs: resolvedOutputs,
         metadata,
       };
     }
@@ -223,15 +192,12 @@ export async function cellSnapshotsToNotebookCells(
           )
         ).filter((o): o is JupyterOutput => o !== null);
 
-        // Merge consecutive stream outputs as a fallback for unmerged data
-        const outputs = mergeConsecutiveStreams(resolvedOutputs);
-
         return {
           id: snap.id,
           cell_type: "code" as const,
           source: snap.source,
           execution_count: Number.isNaN(executionCount) ? null : executionCount,
-          outputs,
+          outputs: resolvedOutputs,
           metadata,
         };
       }
@@ -299,12 +265,24 @@ export function materializeCellFromWasm(
       })
       .filter((o): o is JupyterOutput => o !== null);
 
+    // Preserve the previous outputs array if every element is referentially
+    // identical (all cache hits, same order, same length). This lets
+    // cellsEqual() short-circuit on === checks and skip React re-renders.
+    const prevOutputs =
+      previousCell?.cell_type === "code" ? previousCell.outputs : undefined;
+    const outputs =
+      prevOutputs &&
+      prevOutputs.length === resolvedOutputs.length &&
+      prevOutputs.every((o, i) => o === resolvedOutputs[i])
+        ? prevOutputs
+        : resolvedOutputs;
+
     return {
       id: cellId,
       cell_type: "code",
       source,
       execution_count: Number.isNaN(executionCount) ? null : executionCount,
-      outputs: mergeConsecutiveStreams(resolvedOutputs),
+      outputs,
       metadata,
     };
   }


### PR DESCRIPTION
Phase 2 of the sync perf overhaul. Eliminates unnecessary React re-renders during agent activity.

**Problem:** `scheduleMaterialize` fell back to full doc serialization (`get_cells_json()` + `replaceNotebookCells`) whenever any cell had output changes. During agent execution, outputs change on every cell — so every 32ms timer tick serialized the entire doc and re-rendered all cells, even cells whose outputs hadn't actually changed.

**Three fixes:**

1. **Remove `mergeConsecutiveStreams`** — the daemon's `StreamTerminals` already consolidates stream outputs via terminal emulation before writing to the Automerge doc. The frontend never sees consecutive streams to merge. This was just allocating new arrays/objects on every materialization for no reason. (-172 lines net)

2. **Preserve output referential identity** — `materializeCellFromWasm` now compares resolved outputs against the previous cell's `outputs` array. When all outputs are cache hits and match referentially (same length, every element `===`), it reuses the previous array. `cellsEqual()` then short-circuits → no React re-render for that cell. Extracted as `reuseOutputsIfUnchanged()` with unit tests.

3. **Cache-aware per-cell output resolution** — instead of falling back to full materialization when any cell has output changes, `scheduleMaterialize` now checks each cell's outputs against the cache individually:
   - Cache hits → fast synchronous per-cell path
   - Cache misses → async `resolveOutput()` for just that cell (fetch from blob store), not the entire notebook
   - `blobPort` await is deferred to the cache-miss branch so sync-only updates aren't blocked

Also fixes use-after-free in `scheduleMaterialize` (same pattern as #939 — reads `handleRef.current` at timer fire time, not capture time).

**Before:** ~31 full doc serializations + full React tree re-renders per second during agent activity.
**After:** Only cells with actual content changes get updated. Cache hits (the common case after first fetch) skip re-rendering entirely.

---

_PR submitted by @rgbkrk's agent Quill, via Zed_