### PR TITLE
perf(iframe): deduplicate ResizeObservers, rAF-gate resize messages, shared dark mode hook

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -6,6 +6,5 @@
 PATH_add bin
 
 export RUNTIMED_WORKSPACE_PATH="$(expand_path .)"
-export RUNTIMED_WORKSPACE_NAME="$(basename $(expand_path .))"
 export RUNTIMED_VITE_PORT="${CONDUCTOR_PORT:-5174}"
 export RUNTIMED_DEV=1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,6 @@ These are copy-paste-ready commands. **All commands that interact with the dev d
 # ── Dev daemon env vars (required for ALL dev commands) ────────────
 export RUNTIMED_DEV=1
 export RUNTIMED_WORKSPACE_PATH="$(pwd)"
-# RUNTIMED_WORKSPACE_NAME is optional — cosmetic label for the debug banner.
-# Falls back to .context/workspace-description if unset.
 ```
 
 ### Interacting with the dev daemon
@@ -412,9 +410,9 @@ The **Tauri relay** (`NotebookSyncClient` in `crates/runtimed/src/notebook_sync_
 
 Cells are stored in an Automerge Map keyed by cell ID, with a `position` field (fractional index hex string) for ordering. `move_cell` updates only the position field — no delete/re-insert. `get_cells()` returns cells sorted by position with cell ID as tiebreaker.
 
-Mutation flow: React → WASM `handle.add_cell_after()` → `handle.generate_sync_message()` → prepend `0x00` type byte → `invoke("send_frame", { frameData })` → relay pipe → daemon.
+Mutation flow: React → WASM `handle.add_cell_after()` → `handle.generate_sync_message()` → `sendFrame(frame_types.AUTOMERGE_SYNC, msg)` (binary IPC via `frame-types.ts` helper, no `Array.from`) → relay pipe → daemon.
 
-Incoming sync: daemon → relay pipe → `notebook:frame` event → WASM `handle.receive_frame()` → demux by type byte → returns `FrameEvent[]` with `CellChangeset` → incremental cell updates → React state. Broadcasts and presence are re-emitted via an in-memory frame bus (`notebook-frame-bus.ts`) for downstream hooks.
+Incoming sync: daemon → relay pipe → `notebook:frame` event → WASM `handle.receive_frame()` → demux by type byte → returns `FrameEvent[]` with `CellChangeset` → incremental cell updates → React state. The frontend calls `handle.generate_sync_reply()` on a 50ms debounce timer (`scheduleSyncReply`) to batch multiple inbound frames into a single outbound reply. Broadcasts and presence are re-emitted via an in-memory frame bus (`notebook-frame-bus.ts`) for downstream hooks.
 
 The `runtimed-wasm` crate compiles from the same `automerge = "0.7"` as the daemon. This is critical — the JS `@automerge/automerge` package creates `Object(Text)` CRDTs for all string fields, but Rust uses scalar `Str` for metadata fields (`id`, `cell_type`, `execution_count`). Using the same Rust code in WASM guarantees schema compatibility.
 
@@ -443,7 +441,7 @@ The sync pipeline avoids full-notebook re-reads on every change. Each layer is d
 
 2. **`scheduleMaterialize()`** — coalesces multiple sync frames within a 32ms window via `mergeChangesets()`. Dispatches:
    - Structural changes (cells added/removed/reordered) → full materialization
-   - Output changes (blob manifests need async fetch) → full materialization
+   - Output changes → per-cell cache-aware resolution: cache hits use `materializeCellFromWasm()` (fast sync path); cache misses resolve just that cell's outputs async via `resolveOutput()`, not the full document
    - Source/metadata/execution_count only → per-cell `materializeCellFromWasm()` via O(1) WASM accessors
 
 3. **Split cell store** — `Map<id, NotebookCell>` with per-cell subscriptions. `useCell(id)` re-renders only when that specific cell changes. `useCellIds()` re-renders only on structural changes.
@@ -627,4 +625,5 @@ Dependencies are signed with HMAC-SHA256 using a per-machine key at `~/.config/r
 | `apps/notebook/src/lib/materialize-cells.ts` | `materializeCellFromWasm()` (per-cell) + `cellSnapshotsToNotebookCells()` (full) |
 | `apps/notebook/src/lib/notebook-cells.ts` | Split cell store — `useCell(id)`, `useCellIds()`, per-cell subscriptions |
 | `apps/notebook/src/lib/notebook-frame-bus.ts` | In-memory sync pub/sub for broadcasts and presence (no Tauri event hop) |
+| `apps/notebook/src/lib/frame-types.ts` | Frame type constants + `sendFrame()` binary IPC helper |
 | `src/components/widgets/widget-store.ts` | `WidgetStore` — per-model subscriptions, IPY_MODEL_ resolution |

--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -10,7 +10,7 @@ import { remoteCursorsExtension } from "@/components/editor/remote-cursors";
 import { searchHighlight } from "@/components/editor/search-highlight";
 import { textAttributionExtension } from "@/components/editor/text-attribution";
 import { IsolatedFrame, type IsolatedFrameHandle } from "@/components/isolated";
-import { isDarkMode as detectDarkMode } from "@/lib/dark-mode";
+import { useDarkMode } from "@/lib/dark-mode";
 import { cn } from "@/lib/utils";
 import { usePresenceContext } from "../contexts/PresenceContext";
 import { useCellKeyboardNavigation } from "../hooks/useCellKeyboardNavigation";
@@ -197,19 +197,7 @@ export const MarkdownCell = memo(function MarkdownCell({
     };
   }, [cell.id, editing]);
 
-  // Track dark mode state for iframe theme sync
-  const [darkMode, setDarkMode] = useState(() => detectDarkMode());
-
-  useEffect(() => {
-    const observer = new MutationObserver(() => {
-      setDarkMode(detectDarkMode());
-    });
-    observer.observe(document.documentElement, {
-      attributes: true,
-      attributeFilter: ["class", "data-theme", "data-mode"],
-    });
-    return () => observer.disconnect();
-  }, []);
+  const darkMode = useDarkMode();
 
   const blobPort = useBlobPort();
 

--- a/contributing/architecture.md
+++ b/contributing/architecture.md
@@ -54,7 +54,7 @@ Editing is local-first for responsiveness. Execution is always against synced st
 **Incremental sync pipeline:**
 - WASM `receive_frame()` computes a `CellChangeset` (in `notebook-doc/src/diff.rs`) by walking Automerge patches — O(delta), not O(doc)
 - The changeset carries per-field flags (`source`, `outputs`, `execution_count`, `cell_type`, `metadata`, `position`, `resolved_assets`) per changed cell, plus lists of added/removed cell IDs
-- `scheduleMaterialize` coalesces changesets within a 32ms window, then dispatches: structural changes → full materialization; field-only changes → per-cell `materializeCellFromWasm()` using O(1) WASM accessors
+- `scheduleMaterialize` coalesces changesets within a 32ms window, then dispatches: structural changes → full materialization; output changes → per-cell cache-aware resolution (cache hits use `materializeCellFromWasm()`, cache misses resolve just that cell async); source/metadata-only → per-cell `materializeCellFromWasm()` via O(1) WASM accessors
 - The split cell store (`notebook-cells.ts`) provides per-cell React subscriptions — `useCell(id)` re-renders only when that specific cell changes
 
 **Per-cell accessors** (O(1) Automerge map lookups, available on `NotebookDoc`, `NotebookHandle`, and `DocHandle`):
@@ -190,8 +190,9 @@ The frontend now owns a local Automerge doc via `runtimed-wasm` WASM bindings, m
 - `crates/notebook-sync/src/relay.rs` — `RelayHandle`: relay API for forwarding typed frames between WASM and daemon
 - `crates/notebook-sync/src/connect.rs` — `connect_open_relay()`, `connect_create_relay()`: transparent byte pipe setup
 - `crates/runtimed-wasm/src/lib.rs` — WASM bindings: local Automerge peer, frame demux, per-cell accessors, `CellChangeset`
-- `crates/notebook/src/lib.rs` — Tauri commands and relay tasks (`send_frame`, `setup_sync_receivers`)
+- `crates/notebook/src/lib.rs` — Tauri commands and relay tasks (`send_frame` accepts raw binary via `tauri::ipc::Request`, `setup_sync_receivers`)
 - `crates/notebook-doc/src/frame_types.rs` — Shared frame type constants (0x00–0x04)
+- `apps/notebook/src/lib/frame-types.ts` — Frame type constants + `sendFrame()` binary IPC helper
 - `apps/notebook/src/hooks/useAutomergeNotebook.ts` — WASM handle owner, `scheduleMaterialize`, `CellChangeset` dispatch
 - `apps/notebook/src/lib/materialize-cells.ts` — `materializeCellFromWasm()` (per-cell) + `cellSnapshotsToNotebookCells()` (full)
 - `apps/notebook/src/lib/notebook-cells.ts` — Split cell store: `useCell(id)`, `useCellIds()`, per-cell subscriptions

--- a/contributing/frontend-architecture.md
+++ b/contributing/frontend-architecture.md
@@ -150,11 +150,13 @@ Security boundary for untrusted HTML/widget outputs. See [iframe-isolation.md](i
 │                          │             (frame bus)  │  (frame bus)
 │                   ┌──────┴──────┐             │     │       │   │
 │                   │ structural? │             ▼     │       │   │
-│                   │  outputs?   │     ┌──────────────┐      │   │
+│                   │             │     ┌──────────────┐      │   │
 │                   └──┬──────┬───┘     │useDaemonKernel│     │   │
 │             full ◄───┘      └───► per-cell            │     │   │
 │          materialize-     materialize-  useEnvProgress │     │   │
 │          Cells()          CellFromWasm  └──────┬───────┘     │   │
+│                      (cache-aware for          │      │      │   │
+│                       output changes)          │      │      │   │
 │                   │           │                │      ▼      │   │
 │                   ▼           ▼                │  usePresence │   │
 │             ┌────────────────────┐             │      │      │   │
@@ -176,7 +178,7 @@ Security boundary for untrusted HTML/widget outputs. See [iframe-isolation.md](i
 
 2. **scheduleMaterialize** — Coalesces sync frames within a 32ms window via `mergeChangesets()`, then dispatches:
    - **Structural changes** (cells added/removed/reordered) → full `cellSnapshotsToNotebookCells()` from `get_cells_json()`
-   - **Output changes** (blob manifests need async fetch) → full materialization
+   - **Output changes** → per-cell cache-aware resolution: cache hits use fast sync path via `materializeCellFromWasm()`; cache misses resolve just that cell async
    - **Source/metadata/execution_count only** → per-cell `materializeCellFromWasm()` using O(1) WASM accessors (`get_cell_source()`, `get_cell_type()`, etc.)
 
 3. **Split cell store** (`notebook-cells.ts`) — `Map<id, NotebookCell>` + ordered ID list with independent subscriber channels:
@@ -214,6 +216,6 @@ The `CellChangeset` from WASM (`notebook-doc/src/diff.rs`) has TypeScript mirror
 | `apps/notebook/src/lib/materialize-cells.ts` | WASM → React conversion |
 | `apps/notebook/src/lib/notebook-frame-bus.ts` | In-memory pub/sub for broadcast and presence dispatch |
 | `apps/notebook/src/hooks/usePresence.ts` | Remote presence tracking |
-| `apps/notebook/src/lib/frame-types.ts` | Frame type constants (mirrors Rust) |
+| `apps/notebook/src/lib/frame-types.ts` | Frame type constants + `sendFrame()` binary IPC helper |
 | `src/components/outputs/media-router.tsx` | Output type dispatch |
 | `src/components/editor/codemirror-editor.tsx` | Main editor |

--- a/contributing/protocol.md
+++ b/contributing/protocol.md
@@ -162,7 +162,7 @@ User types in cell
   → React calls WASM handle.update_source(cell_id, text)
   → WASM applies mutation locally (instant)
   → debouncedSyncToRelay (20ms batch) → handle.generate_sync_message() → sync bytes
-  → Frontend prepends 0x00 type byte → invoke("send_frame", { frameData })
+  → sendFrame(frame_types.AUTOMERGE_SYNC, msg) → raw binary via tauri::ipc::Request
   → Tauri send_frame dispatches by type → relay pipes to daemon socket
   → Daemon applies sync, updates canonical doc
   → Daemon generates response sync message → frame type 0x00
@@ -172,10 +172,10 @@ User types in cell
   → FrameEvent::SyncApplied includes a CellChangeset (field-level diff)
   → scheduleMaterialize coalesces within 32ms, then dispatches:
       - structural change (cells added/removed/reordered) → full materializeCells()
-      - output changes (blob manifests need async fetch) → full materializeCells()
+      - output changes → per-cell cache-aware resolution (cache hits use materializeCellFromWasm(), cache misses resolve just that cell async)
       - source/metadata/exec_count only → per-cell materializeCellFromWasm() via O(1) accessors
   → React state updated via split cell store (only affected cells re-render)
-  → sync_reply event → prepend 0x00, invoke("send_frame", { frameData }) back to daemon
+  → scheduleSyncReply → 50ms debounce → handle.generate_sync_reply() → sendFrame() (one reply per window)
 ```
 
 ### CellChangeset
@@ -287,7 +287,7 @@ The relay and frontend use these Tauri events for cross-process communication:
 | `daemon:ready` | Relay → Frontend | `DaemonReadyPayload` | Connection established, ready to bootstrap |
 | `daemon:disconnected` | Relay → Frontend | — | Connection to daemon lost |
 
-Outgoing frames from the frontend use `invoke("send_frame", { frameData })` where `frameData` is `number[]` with the first byte as the frame type. Only `0x00` (AutomergeSync) and `0x04` (Presence) are valid outgoing types.
+Outgoing frames from the frontend use `sendFrame(frameType, payload)` where `payload` is `Uint8Array` passed as raw binary via `tauri::ipc::Request`. Only `0x00` (AutomergeSync) and `0x04` (Presence) are valid outgoing types.
 
 ### In-memory frame bus
 
@@ -358,7 +358,7 @@ The implementation is phased: #808 (schema + dual-write) → #809 (clients read 
 | `crates/notebook-doc/src/lib.rs` | `NotebookDoc`: Automerge schema, cell CRUD, output writes, per-cell accessors |
 | `crates/notebook-doc/src/diff.rs` | `CellChangeset`: structural diff from Automerge patches |
 | `crates/notebook-doc/src/frame_types.rs` | Shared frame type constants (0x00–0x04) |
-| `apps/notebook/src/lib/frame-types.ts` | TypeScript mirror of frame type constants |
+| `apps/notebook/src/lib/frame-types.ts` | Frame type constants + `sendFrame()` binary IPC helper |
 | `apps/notebook/src/hooks/useAutomergeNotebook.ts` | WASM handle owner, `scheduleMaterialize`, `CellChangeset` dispatch |
 | `apps/notebook/src/hooks/useDaemonKernel.ts` | Kernel execution, widget comm routing, broadcast handling |
 | `apps/notebook/src/lib/materialize-cells.ts` | `materializeCellFromWasm()` (per-cell) + `cellSnapshotsToNotebookCells()` (full) |

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -1,12 +1,5 @@
 import { ChevronDown, ChevronRight } from "lucide-react";
-import {
-  type ReactNode,
-  useCallback,
-  useEffect,
-  useId,
-  useRef,
-  useState,
-} from "react";
+import { type ReactNode, useCallback, useEffect, useId, useRef } from "react";
 import {
   CommBridgeManager,
   type IframeToParentMessage,
@@ -22,7 +15,7 @@ import {
   MediaRouter,
 } from "@/components/outputs/media-router";
 import { useWidgetStore } from "@/components/widgets/widget-store-context";
-import { isDarkMode as detectDarkMode } from "@/lib/dark-mode";
+import { useDarkMode } from "@/lib/dark-mode";
 import { ErrorBoundary } from "@/lib/error-boundary";
 import { highlightTextInDom } from "@/lib/highlight-text";
 import { OutputErrorFallback } from "@/lib/output-error-fallback";
@@ -304,25 +297,10 @@ export function OutputArea({
   const searchQueryRef = useRef(searchQuery);
   searchQueryRef.current = searchQuery;
 
-  // Track dark mode state and observe changes
-  const [darkMode, setDarkMode] = useState(() => detectDarkMode());
+  const darkMode = useDarkMode();
   // Ref for reading current darkMode in callbacks without adding to deps
   const darkModeRef = useRef(darkMode);
   darkModeRef.current = darkMode;
-
-  useEffect(() => {
-    // Update dark mode when document class changes
-    const observer = new MutationObserver(() => {
-      setDarkMode(detectDarkMode());
-    });
-
-    observer.observe(document.documentElement, {
-      attributes: true,
-      attributeFilter: ["class", "data-theme", "data-mode"],
-    });
-
-    return () => observer.disconnect();
-  }, []);
 
   // Get widget store context (may be null if not in provider)
   const widgetContext = useWidgetStore();

--- a/src/components/isolated/frame-html.ts
+++ b/src/components/isolated/frame-html.ts
@@ -494,9 +494,22 @@ export function generateFrameHtml(options: FrameHtmlOptions = {}): string {
       }
 
       // --- Resize Observer ---
-      const resizeObserver = new ResizeObserver(function(entries) {
-        const height = document.body.scrollHeight;
-        send('resize', { height: height });
+      // Gate with __REACT_RENDERER_ACTIVE__ so the bootstrap observer
+      // stops firing once the React renderer creates its own observer.
+      // Use rAF to collapse multiple resize callbacks per frame into one
+      // postMessage (avoids "ResizeObserver loop completed with undelivered
+      // notifications" errors when many iframes resize simultaneously).
+      var resizeRafPending = false;
+      var resizeObserver = new ResizeObserver(function(entries) {
+        if (window.__REACT_RENDERER_ACTIVE__) return;
+        if (resizeRafPending) return;
+        resizeRafPending = true;
+        requestAnimationFrame(function() {
+          resizeRafPending = false;
+          if (window.__REACT_RENDERER_ACTIVE__) return;
+          var height = document.body.scrollHeight;
+          send('resize', { height: height });
+        });
       });
       resizeObserver.observe(document.body);
 

--- a/src/isolated-renderer/index.tsx
+++ b/src/isolated-renderer/index.tsx
@@ -336,11 +336,20 @@ export function init() {
   );
 
   // Set up resize observer
+  // Use rAF to collapse multiple resize callbacks per frame into one
+  // postMessage (avoids "ResizeObserver loop completed with undelivered
+  // notifications" errors when many iframes resize simultaneously).
+  let resizeRafPending = false;
   const resizeObserver = new ResizeObserver(() => {
-    window.parent.postMessage(
-      { type: "resize", payload: { height: document.body.scrollHeight } },
-      "*",
-    );
+    if (resizeRafPending) return;
+    resizeRafPending = true;
+    requestAnimationFrame(() => {
+      resizeRafPending = false;
+      window.parent.postMessage(
+        { type: "resize", payload: { height: document.body.scrollHeight } },
+        "*",
+      );
+    });
   });
   resizeObserver.observe(document.body);
 


### PR DESCRIPTION
Three fixes for iframe-related jank during agent activity. Found via Safari trace investigation showing dozens of `ResizeObserver loop completed with undelivered notifications` errors.

**1. Deduplicate ResizeObservers**

Each iframe had TWO `ResizeObserver` instances on `document.body` — one from the bootstrap HTML (`frame-html.ts`) and one from the React renderer (`isolated-renderer/index.tsx`). The bootstrap observer was never disconnected when React took over, so both fired on every resize, sending duplicate `resize` postMessages. The bootstrap observer now checks `__REACT_RENDERER_ACTIVE__` and stops firing once React takes over.

**2. rAF-gate resize messages**

Both observers now use `requestAnimationFrame` to collapse multiple resize callbacks per frame into a single postMessage. Previously, each callback sent immediately — with 25 iframes resizing simultaneously during cell creation, that's 50+ postMessages per frame, each triggering `setHeight()` → React re-render → CSS height change → potentially another observer callback. The rAF gate breaks this feedback loop.

**3. Shared dark mode hook**

`MarkdownCell` and `OutputArea` each created their own `MutationObserver` watching `document.documentElement` for theme changes. Replaced with the existing `useDarkMode()` hook from `lib/dark-mode.ts`. With 25 cells this eliminates up to 50 redundant `MutationObserver` instances.

---

_PR submitted by @rgbkrk's agent Quill, via Zed_