### PR TITLE
refactor(notebook): single blob port store with synchronous reads

### DIFF
--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -14,11 +14,11 @@ import { useDarkMode } from "@/lib/dark-mode";
 import { cn } from "@/lib/utils";
 import { usePresenceContext } from "../contexts/PresenceContext";
 import { useCellKeyboardNavigation } from "../hooks/useCellKeyboardNavigation";
-import { useBlobPort } from "../hooks/useManifestResolver";
 import {
   registerAttributionEditor,
   unregisterAttributionEditor,
 } from "../lib/attribution-registry";
+import { useBlobPort } from "../lib/blob-port";
 import { registerEditor, unregisterEditor } from "../lib/cursor-registry";
 import { logger } from "../lib/logger";
 import { rewriteMarkdownAssetRefs } from "../lib/markdown-assets";

--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -5,6 +5,7 @@ import {
   save as saveDialog,
 } from "@tauri-apps/plugin-dialog";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { getBlobPort, refreshBlobPort } from "../lib/blob-port";
 import { frame_types, sendFrame } from "../lib/frame-types";
 import { logger } from "../lib/logger";
 import {
@@ -125,19 +126,11 @@ export function useAutomergeNotebook() {
   // Output manifest cache (shared with materialize-cells utilities).
   const outputCacheRef = useRef<Map<string, JupyterOutput>>(new Map());
 
-  // Blob port for manifest resolution.
-  const blobPortPromiseRef = useRef<Promise<number | null> | null>(null);
-
-  const refreshBlobPort = useCallback(() => {
-    blobPortPromiseRef.current = invoke<number>("get_blob_port").catch((e) => {
-      logger.warn("[automerge-notebook] Failed to get blob port:", e);
-      return null;
-    });
-  }, []);
-
+  // Blob port is managed by the blob-port store (lib/blob-port.ts).
+  // Refresh on mount; daemon:ready handler refreshes on reconnect.
   useEffect(() => {
     refreshBlobPort();
-  }, [refreshBlobPort]);
+  }, []);
 
   // Clear dirty state when daemon autosaves the notebook to disk.
   useEffect(() => {
@@ -159,9 +152,7 @@ export function useAutomergeNotebook() {
   const materializeCells = useCallback(async (handle: NotebookHandle) => {
     const json = handle.get_cells_json();
     const snapshots: CellSnapshot[] = JSON.parse(json);
-    const blobPort = blobPortPromiseRef.current
-      ? await blobPortPromiseRef.current
-      : null;
+    const blobPort = getBlobPort();
     const newCells = await cellSnapshotsToNotebookCells(
       snapshots,
       blobPort,
@@ -298,9 +289,6 @@ export function useAutomergeNotebook() {
         // fast synchronous path; cache misses resolve the individual cell's
         // outputs asynchronously (without serializing the entire document).
         const cache = outputCacheRef.current;
-        // Defer blobPort resolution until a cache miss actually needs it.
-        let blobPort: number | null = null;
-        let blobPortResolved = false;
 
         for (const { cell_id: cellId, fields } of cs.changed) {
           if (fields.outputs) {
@@ -323,11 +311,9 @@ export function useAutomergeNotebook() {
               // Cache miss — resolve this cell's outputs async (fetch
               // manifests from blob store) without re-serializing the
               // entire document.
-              if (!blobPortResolved) {
-                blobPort = blobPortPromiseRef.current
-                  ? await blobPortPromiseRef.current
-                  : null;
-                blobPortResolved = true;
+              let blobPort = getBlobPort();
+              if (blobPort === null) {
+                blobPort = await refreshBlobPort();
               }
               const resolved = (
                 await Promise.all(
@@ -435,7 +421,7 @@ export function useAutomergeNotebook() {
     // converge (the WASM keeps re-requesting content it already has).
     const unlistenReady = webview.listen("daemon:ready", async () => {
       if (cancelled) return;
-      refreshBlobPort();
+      refreshBlobPort(); // Update blob-port store for new daemon session
       awaitingInitialSyncRef.current = true;
       setIsLoading(true);
       await bootstrap();
@@ -595,7 +581,6 @@ export function useAutomergeNotebook() {
   }, [
     bootstrap,
     materializeCells,
-    refreshBlobPort,
     scheduleMaterialize,
     scheduleSyncReply,
     syncToRelay,

--- a/apps/notebook/src/hooks/useDaemonKernel.ts
+++ b/apps/notebook/src/hooks/useDaemonKernel.ts
@@ -9,6 +9,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWebview } from "@tauri-apps/api/webview";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { getBlobPort, refreshBlobPort, resetBlobPort } from "../lib/blob-port";
 import {
   isKernelStatus,
   KERNEL_STATUS,
@@ -22,10 +23,7 @@ import type {
   JupyterMessage,
   JupyterOutput,
 } from "../types";
-import {
-  fetchBlobPortWithRetry,
-  resolveOutputString,
-} from "./useManifestResolver";
+import { resolveOutputString } from "./useManifestResolver";
 
 /** Kernel status from daemon */
 export type DaemonKernelStatus = KernelStatus;
@@ -98,9 +96,6 @@ export function useDaemonKernel({
     };
   } | null>(null);
 
-  // Store blob port in ref for use in event handlers
-  const blobPortRef = useRef<number>(0);
-
   // Timer ref for throttling transient busy states
   // Ignores busy if it disappears within the threshold (e.g., from completions)
   const busyTimerRef = useRef<number | null>(null);
@@ -134,16 +129,7 @@ export function useDaemonKernel({
     let cancelled = false;
     const webview = getCurrentWebview();
 
-    // Helper to refresh blob port (called on mount, reconnect, and daemon:ready)
-    const refreshBlobPort = () => {
-      fetchBlobPortWithRetry().then((port) => {
-        if (port && !cancelled) {
-          blobPortRef.current = port;
-        }
-      });
-    };
-
-    // Fetch blob port for manifest resolution
+    // Ensure blob port is fresh on mount
     refreshBlobPort();
 
     const unsubscribeBroadcast = subscribeBroadcast((payload) => {
@@ -224,14 +210,10 @@ export function useDaemonKernel({
 
           // Helper to resolve with retry if port is unavailable or stale
           const resolveWithRetry = async (retried = false) => {
-            let port = blobPortRef.current;
+            let port = getBlobPort();
             // If port not yet available, try to fetch it
             if (!port) {
-              const freshPort = await fetchBlobPortWithRetry();
-              if (freshPort) {
-                blobPortRef.current = freshPort;
-                port = freshPort;
-              }
+              port = await refreshBlobPort();
             }
             if (!port) {
               logger.error(
@@ -248,7 +230,7 @@ export function useDaemonKernel({
               logger.debug(
                 "[daemon-kernel] Output resolution failed, refreshing port",
               );
-              blobPortRef.current = 0;
+              resetBlobPort();
               await resolveWithRetry(true);
             } else {
               logger.error(
@@ -469,7 +451,7 @@ export function useDaemonKernel({
         setQueueState({ executing: null, queued: [] });
         setEnvSyncState(null);
         // Reset blob port so next output triggers fresh fetch
-        blobPortRef.current = 0;
+        resetBlobPort();
 
         // Attempt to reconnect to the daemon
         try {
@@ -488,7 +470,7 @@ export function useDaemonKernel({
     const unlistenReady = webview.listen("daemon:ready", () => {
       if (cancelled) return;
       logger.debug("[daemon-kernel] Daemon ready");
-      refreshBlobPort();
+      refreshBlobPort(); // Update blob-port store for new daemon session
       fetchKernelInfo();
     });
 

--- a/apps/notebook/src/hooks/useManifestResolver.ts
+++ b/apps/notebook/src/hooks/useManifestResolver.ts
@@ -1,74 +1,9 @@
-import { invoke } from "@tauri-apps/api/core";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useRef } from "react";
+import { useBlobPort } from "../lib/blob-port";
 import { logger } from "../lib/logger";
 import type { OutputManifest } from "../lib/manifest-resolution";
 import { isManifestHash, resolveManifest } from "../lib/manifest-resolution";
 import type { JupyterOutput } from "../types";
-
-let sharedBlobPort: number | null = null;
-let sharedBlobPortPromise: Promise<number | null> | null = null;
-
-/**
- * Fetch blob port with retry logic.
- */
-export async function fetchBlobPortWithRetry(
-  maxAttempts = 5,
-  delayMs = 500,
-): Promise<number | null> {
-  if (sharedBlobPort !== null) {
-    return sharedBlobPort;
-  }
-
-  if (sharedBlobPortPromise) {
-    return sharedBlobPortPromise;
-  }
-
-  sharedBlobPortPromise = (async () => {
-    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-      try {
-        const port = await invoke<number>("get_blob_port");
-        sharedBlobPort = port;
-        return port;
-      } catch (e) {
-        if (attempt < maxAttempts) {
-          await new Promise((resolve) => setTimeout(resolve, delayMs));
-        } else {
-          logger.warn(
-            `[manifest-resolver] Failed to get blob port after ${maxAttempts} attempts:`,
-            e,
-          );
-        }
-      }
-    }
-    return null;
-  })();
-
-  try {
-    return await sharedBlobPortPromise;
-  } finally {
-    sharedBlobPortPromise = null;
-  }
-}
-
-export function useBlobPort() {
-  const [blobPort, setBlobPort] = useState<number | null>(sharedBlobPort);
-
-  useEffect(() => {
-    let cancelled = false;
-
-    fetchBlobPortWithRetry().then((port) => {
-      if (!cancelled) {
-        setBlobPort(port);
-      }
-    });
-
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  return blobPort;
-}
 
 /**
  * Resolve an output string to a JupyterOutput.

--- a/apps/notebook/src/lib/__tests__/blob-port.test.ts
+++ b/apps/notebook/src/lib/__tests__/blob-port.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  _testGetGeneration,
+  _testReset,
+  getBlobPort,
+  refreshBlobPort,
+  resetBlobPort,
+} from "../blob-port";
+
+// Mock invoke
+const mockInvoke = vi.fn<() => Promise<number>>();
+
+beforeEach(() => {
+  _testReset();
+  vi.stubGlobal("__TAURI_INTERNALS__", {
+    invoke: mockInvoke,
+    transformCallback: vi.fn(),
+  });
+});
+
+afterEach(() => {
+  mockInvoke.mockReset();
+  vi.unstubAllGlobals();
+});
+
+// We need to mock the @tauri-apps/api/core invoke
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) =>
+    (globalThis as any).__TAURI_INTERNALS__.invoke(...args),
+}));
+
+describe("blob-port store", () => {
+  it("starts with null", () => {
+    expect(getBlobPort()).toBeNull();
+  });
+
+  it("refreshBlobPort fetches and caches the port", async () => {
+    mockInvoke.mockResolvedValueOnce(12345);
+    const port = await refreshBlobPort();
+    expect(port).toBe(12345);
+    expect(getBlobPort()).toBe(12345);
+  });
+
+  it("deduplicates concurrent refresh calls", async () => {
+    mockInvoke.mockResolvedValueOnce(9999);
+    const [a, b, c] = await Promise.all([
+      refreshBlobPort(),
+      refreshBlobPort(),
+      refreshBlobPort(),
+    ]);
+    expect(a).toBe(9999);
+    expect(b).toBe(9999);
+    expect(c).toBe(9999);
+    // Only one IPC call
+    expect(mockInvoke).toHaveBeenCalledTimes(1);
+  });
+
+  it("resetBlobPort clears the port", async () => {
+    mockInvoke.mockResolvedValueOnce(12345);
+    await refreshBlobPort();
+    expect(getBlobPort()).toBe(12345);
+
+    resetBlobPort();
+    expect(getBlobPort()).toBeNull();
+  });
+
+  it("resetBlobPort increments generation", () => {
+    const gen0 = _testGetGeneration();
+    resetBlobPort();
+    expect(_testGetGeneration()).toBe(gen0 + 1);
+  });
+
+  it("discards stale refresh after reset", async () => {
+    // Simulate a slow refresh that resolves after a reset
+    let resolveInvoke: (v: number) => void;
+    mockInvoke.mockReturnValueOnce(
+      new Promise<number>((r) => {
+        resolveInvoke = r;
+      }),
+    );
+
+    const refreshPromise = refreshBlobPort();
+
+    // Reset while refresh is in flight
+    resetBlobPort();
+    expect(getBlobPort()).toBeNull();
+
+    // Now the slow invoke resolves with the OLD port
+    resolveInvoke!(54321);
+    await refreshPromise;
+
+    // The stale result should be discarded — port stays null
+    expect(getBlobPort()).toBeNull();
+  });
+
+  it("retries on failure", async () => {
+    mockInvoke
+      .mockRejectedValueOnce(new Error("not ready"))
+      .mockRejectedValueOnce(new Error("not ready"))
+      .mockResolvedValueOnce(7777);
+
+    const port = await refreshBlobPort();
+    expect(port).toBe(7777);
+    expect(mockInvoke).toHaveBeenCalledTimes(3);
+  });
+
+  it("allows fresh refresh after reset", async () => {
+    mockInvoke.mockResolvedValueOnce(1111);
+    await refreshBlobPort();
+    expect(getBlobPort()).toBe(1111);
+
+    resetBlobPort();
+    expect(getBlobPort()).toBeNull();
+
+    mockInvoke.mockResolvedValueOnce(2222);
+    await refreshBlobPort();
+    expect(getBlobPort()).toBe(2222);
+  });
+});

--- a/apps/notebook/src/lib/blob-port.ts
+++ b/apps/notebook/src/lib/blob-port.ts
@@ -1,0 +1,142 @@
+import { invoke } from "@tauri-apps/api/core";
+import { useSyncExternalStore } from "react";
+import { logger } from "./logger";
+
+// ---------------------------------------------------------------------------
+// Blob port store — single source of truth for the daemon's blob server port.
+//
+// The blob port is set once on daemon connect and only changes on reconnect.
+// All consumers read synchronously from this store instead of re-awaiting
+// a promise on every access.
+//
+// Usage:
+//   - React components: `const port = useBlobPort()`
+//   - Non-React code:   `const port = getBlobPort()`
+//   - On connect/reconnect: `refreshBlobPort()`
+// ---------------------------------------------------------------------------
+
+let _blobPort: number | null = null;
+let _refreshPromise: Promise<number | null> | null = null;
+
+// Generation counter — incremented on every reset. Refresh results from
+// a previous generation are discarded to prevent a stale port from a
+// pre-reset fetch overwriting the reset state.
+let _generation = 0;
+
+const _subscribers = new Set<() => void>();
+
+function emit(): void {
+  for (const cb of _subscribers) cb();
+}
+
+function subscribe(callback: () => void): () => void {
+  _subscribers.add(callback);
+  return () => _subscribers.delete(callback);
+}
+
+function getSnapshot(): number | null {
+  return _blobPort;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Get the current blob port synchronously. Returns `null` if not yet resolved.
+ */
+export function getBlobPort(): number | null {
+  return _blobPort;
+}
+
+/**
+ * Fetch the blob port from the daemon and update the store.
+ *
+ * Call on initial connect and on `daemon:ready` / reconnect events.
+ * Deduplicates concurrent calls — only one IPC request in flight at a time.
+ * If `resetBlobPort()` is called while a refresh is in flight, the stale
+ * result is discarded (generation counter check).
+ * Returns the resolved port (or null on failure).
+ */
+export async function refreshBlobPort(): Promise<number | null> {
+  if (_refreshPromise) return _refreshPromise;
+
+  const gen = _generation;
+
+  _refreshPromise = (async () => {
+    // Retry a few times — the blob server may not be ready immediately
+    // after daemon startup.
+    for (let attempt = 1; attempt <= 5; attempt++) {
+      // Bail early if a reset occurred while we were retrying.
+      if (_generation !== gen) return _blobPort;
+
+      try {
+        const port = await invoke<number>("get_blob_port");
+
+        // Discard result if a reset happened since we started.
+        if (_generation !== gen) return _blobPort;
+
+        _blobPort = port;
+        emit();
+        return port;
+      } catch (e) {
+        if (attempt < 5) {
+          await new Promise((r) => setTimeout(r, 500));
+        } else {
+          logger.warn(
+            `[blob-port] Failed to get blob port after 5 attempts:`,
+            e,
+          );
+        }
+      }
+    }
+    return null;
+  })();
+
+  try {
+    return await _refreshPromise;
+  } finally {
+    // Only clear the dedup promise if we're still the current generation.
+    // A reset during our flight already cleared it.
+    if (_generation === gen) {
+      _refreshPromise = null;
+    }
+  }
+}
+
+/**
+ * Reset the blob port (e.g., on daemon disconnect). Forces the next
+ * `refreshBlobPort()` call to fetch fresh. Any in-flight refresh from
+ * a prior generation will be discarded when it resolves.
+ */
+export function resetBlobPort(): void {
+  _generation++;
+  _blobPort = null;
+  _refreshPromise = null;
+  emit();
+}
+
+/**
+ * React hook — subscribes to the blob port store.
+ * Re-renders only when the port value changes.
+ */
+export function useBlobPort(): number | null {
+  return useSyncExternalStore(subscribe, getSnapshot);
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers — only exported for unit tests
+// ---------------------------------------------------------------------------
+
+/** @internal Reset all state for test isolation. */
+export function _testReset(): void {
+  _blobPort = null;
+  _refreshPromise = null;
+  _generation = 0;
+  _subscribers.clear();
+}
+
+/** @internal Get the current generation (for verifying reset behavior). */
+export function _testGetGeneration(): number {
+  return _generation;
+}


### PR DESCRIPTION
Three separate blob port caching mechanisms existed:

- `useAutomergeNotebook`: `blobPortPromiseRef` — stored a `Promise<number | null>` that was re-awaited on every materialize call
- `useDaemonKernel`: `blobPortRef` — plain number ref, local to the hook
- `useManifestResolver`: `sharedBlobPort` — module-level singleton with its own retry logic

All three did the same thing: cache the daemon's blob server port. The blob port is set once on daemon connect and only changes on reconnect — there's no reason for three copies or for re-awaiting a promise in the hot path.

Replaced with a single store in `lib/blob-port.ts`:

- `getBlobPort()` — synchronous read, no await needed in `scheduleMaterialize` or `materializeCells`
- `refreshBlobPort()` — async fetch with 5x retry + request dedup, called on connect and `daemon:ready`
- `resetBlobPort()` — clear on disconnect, forces fresh fetch on reconnect
- `useBlobPort()` — React hook via `useSyncExternalStore` for components that need reactivity (MarkdownCell, useManifestResolver)

---

_PR submitted by @rgbkrk's agent Quill, via Zed_