### PR TITLE
fix(session): eliminate `try_lock()` race in `notebook_id` getter after save re-key

### DIFF
--- a/crates/runtimed-py/src/async_session.rs
+++ b/crates/runtimed-py/src/async_session.rs
@@ -34,6 +34,10 @@ use crate::subscription::EventSubscription;
 pub struct AsyncSession {
     state: Arc<Mutex<SessionState>>,
     notebook_id: String,
+    /// Re-keyed notebook ID after saving an ephemeral room.
+    /// Stored outside `SessionState` (behind a lightweight `std::sync::Mutex`)
+    /// so the `notebook_id` getter never contends with the async `tokio::sync::Mutex`.
+    notebook_id_override: Arc<std::sync::Mutex<Option<String>>>,
     peer_label: Option<String>,
 }
 
@@ -59,6 +63,7 @@ impl AsyncSession {
         Ok(Self {
             state: Arc::new(Mutex::new(state)),
             notebook_id,
+            notebook_id_override: Arc::new(std::sync::Mutex::new(None)),
             peer_label,
         })
     }
@@ -67,11 +72,11 @@ impl AsyncSession {
     /// After saving an ephemeral notebook, this reflects the new file-path ID.
     #[getter]
     fn notebook_id(&self) -> String {
-        // Check if save() updated the ID via the daemon re-keying the room
-        if let Ok(st) = self.state.try_lock() {
-            if let Some(ref id) = st.notebook_id_override {
-                return id.clone();
-            }
+        // If save() re-keyed the room, return the new file-path ID.
+        // This lock is a std::sync::Mutex (not tokio), so it never contends
+        // with async SessionState operations.
+        if let Some(ref id) = *self.notebook_id_override.lock().unwrap() {
+            return id.clone();
         }
         self.notebook_id.clone()
     }
@@ -151,6 +156,7 @@ impl AsyncSession {
             Ok(AsyncSession {
                 state: Arc::new(Mutex::new(state)),
                 notebook_id,
+                notebook_id_override: Arc::new(std::sync::Mutex::new(None)),
                 peer_label,
             })
         })
@@ -207,6 +213,7 @@ impl AsyncSession {
             Ok(AsyncSession {
                 state: Arc::new(Mutex::new(state)),
                 notebook_id,
+                notebook_id_override: Arc::new(std::sync::Mutex::new(None)),
                 peer_label,
             })
         })
@@ -215,13 +222,13 @@ impl AsyncSession {
     /// Connect to the daemon.
     fn connect<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let state = Arc::clone(&self.state);
-        let notebook_id = self.notebook_id.clone();
+        let effective_id = self
+            .notebook_id_override
+            .lock()
+            .unwrap()
+            .clone()
+            .unwrap_or_else(|| self.notebook_id.clone());
         future_into_py(py, async move {
-            // Use the override ID if save() re-keyed the room, otherwise the original.
-            let effective_id = {
-                let st = state.lock().await;
-                st.notebook_id_override.clone().unwrap_or(notebook_id)
-            };
             session_core::connect(&state, &effective_id).await
         })
     }
@@ -588,17 +595,23 @@ impl AsyncSession {
     #[pyo3(signature = (path=None))]
     fn save<'py>(&self, py: Python<'py>, path: Option<&str>) -> PyResult<Bound<'py, PyAny>> {
         let state = Arc::clone(&self.state);
-        let notebook_id = self.notebook_id.clone();
+        let override_arc = Arc::clone(&self.notebook_id_override);
+        let effective_id = self
+            .notebook_id_override
+            .lock()
+            .unwrap()
+            .clone()
+            .unwrap_or_else(|| self.notebook_id.clone());
         let path = path.map(|s| s.to_string());
 
         future_into_py(py, async move {
-            // Use the override ID if save() previously re-keyed the room.
-            let effective_id = {
-                let st = state.lock().await;
-                st.notebook_id_override.clone().unwrap_or(notebook_id)
-            };
             session_core::connect(&state, &effective_id).await?;
             let result = session_core::save(&state, path.as_deref()).await?;
+            // If the daemon re-keyed the room (ephemeral → file-path),
+            // store the new ID so the notebook_id getter reflects it.
+            if let Some(ref new_id) = result.new_notebook_id {
+                *override_arc.lock().unwrap() = Some(new_id.clone());
+            }
             Ok(result.path)
         })
     }

--- a/crates/runtimed-py/src/async_session.rs
+++ b/crates/runtimed-py/src/async_session.rs
@@ -153,10 +153,15 @@ impl AsyncSession {
 
             state.peer_label = peer_label.clone();
 
+            let override_arc = Arc::new(std::sync::Mutex::new(None));
+            if let Some(ref rx) = state.broadcast_rx {
+                session_core::spawn_rekey_watcher(rx, Arc::clone(&override_arc));
+            }
+
             Ok(AsyncSession {
                 state: Arc::new(Mutex::new(state)),
                 notebook_id,
-                notebook_id_override: Arc::new(std::sync::Mutex::new(None)),
+                notebook_id_override: override_arc,
                 peer_label,
             })
         })
@@ -210,10 +215,15 @@ impl AsyncSession {
 
             state.peer_label = peer_label.clone();
 
+            let override_arc = Arc::new(std::sync::Mutex::new(None));
+            if let Some(ref rx) = state.broadcast_rx {
+                session_core::spawn_rekey_watcher(rx, Arc::clone(&override_arc));
+            }
+
             Ok(AsyncSession {
                 state: Arc::new(Mutex::new(state)),
                 notebook_id,
-                notebook_id_override: Arc::new(std::sync::Mutex::new(None)),
+                notebook_id_override: override_arc,
                 peer_label,
             })
         })
@@ -222,6 +232,7 @@ impl AsyncSession {
     /// Connect to the daemon.
     fn connect<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let state = Arc::clone(&self.state);
+        let override_arc = Arc::clone(&self.notebook_id_override);
         let effective_id = self
             .notebook_id_override
             .lock()
@@ -229,7 +240,15 @@ impl AsyncSession {
             .clone()
             .unwrap_or_else(|| self.notebook_id.clone());
         future_into_py(py, async move {
-            session_core::connect(&state, &effective_id).await
+            session_core::connect(&state, &effective_id).await?;
+            // Spawn background task to update notebook_id if a peer re-keys the room
+            {
+                let st = state.lock().await;
+                if let Some(ref rx) = st.broadcast_rx {
+                    session_core::spawn_rekey_watcher(rx, override_arc);
+                }
+            }
+            Ok(())
         })
     }
 

--- a/crates/runtimed-py/src/session.rs
+++ b/crates/runtimed-py/src/session.rs
@@ -35,6 +35,10 @@ pub struct Session {
     runtime: Runtime,
     state: Arc<Mutex<SessionState>>,
     notebook_id: String,
+    /// Re-keyed notebook ID after saving an ephemeral room.
+    /// Stored outside `SessionState` (behind a lightweight `std::sync::Mutex`)
+    /// so the `notebook_id` getter never contends with the async `tokio::sync::Mutex`.
+    notebook_id_override: Arc<std::sync::Mutex<Option<String>>>,
     peer_label: Option<String>,
 }
 
@@ -64,6 +68,7 @@ impl Session {
             runtime,
             state: Arc::new(Mutex::new(state)),
             notebook_id,
+            notebook_id_override: Arc::new(std::sync::Mutex::new(None)),
             peer_label,
         })
     }
@@ -72,11 +77,11 @@ impl Session {
     /// After saving an ephemeral notebook, this reflects the new file-path ID.
     #[getter]
     fn notebook_id(&self) -> String {
-        // Check if save() updated the ID via the daemon re-keying the room
-        if let Ok(st) = self.state.try_lock() {
-            if let Some(ref id) = st.notebook_id_override {
-                return id.clone();
-            }
+        // If save() re-keyed the room, return the new file-path ID.
+        // This lock is a std::sync::Mutex (not tokio), so it never contends
+        // with async SessionState operations.
+        if let Some(ref id) = *self.notebook_id_override.lock().unwrap() {
+            return id.clone();
         }
         self.notebook_id.clone()
     }
@@ -148,6 +153,7 @@ impl Session {
             runtime,
             state: Arc::new(Mutex::new(state)),
             notebook_id,
+            notebook_id_override: Arc::new(std::sync::Mutex::new(None)),
             peer_label,
         })
     }
@@ -204,19 +210,18 @@ impl Session {
             runtime: rt,
             state: Arc::new(Mutex::new(state)),
             notebook_id,
+            notebook_id_override: Arc::new(std::sync::Mutex::new(None)),
             peer_label,
         })
     }
 
     /// Connect to the daemon.
     fn connect(&self) -> PyResult<()> {
-        // Use the override ID if save() re-keyed the room, otherwise the original.
         let effective_id = self
-            .runtime
-            .block_on(async {
-                let st = self.state.lock().await;
-                st.notebook_id_override.clone()
-            })
+            .notebook_id_override
+            .lock()
+            .unwrap()
+            .clone()
             .unwrap_or_else(|| self.notebook_id.clone());
         self.runtime
             .block_on(session_core::connect(&self.state, &effective_id))
@@ -476,11 +481,10 @@ impl Session {
         let result = self
             .runtime
             .block_on(session_core::save(&self.state, path))?;
-        // If the daemon re-keyed the room, update self.notebook_id so that
-        // future reconnects (connect() calls) use the new file-path ID
-        // instead of the stale UUID.
+        // If the daemon re-keyed the room (ephemeral → file-path),
+        // store the new ID so the notebook_id getter reflects it.
         if let Some(new_id) = result.new_notebook_id {
-            self.notebook_id = new_id;
+            *self.notebook_id_override.lock().unwrap() = Some(new_id);
         }
         Ok(result.path)
     }

--- a/crates/runtimed-py/src/session.rs
+++ b/crates/runtimed-py/src/session.rs
@@ -149,11 +149,16 @@ impl Session {
 
         state.peer_label = peer_label.clone();
 
+        let override_arc = Arc::new(std::sync::Mutex::new(None));
+        if let Some(ref rx) = state.broadcast_rx {
+            session_core::spawn_rekey_watcher(rx, Arc::clone(&override_arc));
+        }
+
         Ok(Self {
             runtime,
             state: Arc::new(Mutex::new(state)),
             notebook_id,
-            notebook_id_override: Arc::new(std::sync::Mutex::new(None)),
+            notebook_id_override: override_arc,
             peer_label,
         })
     }
@@ -206,11 +211,16 @@ impl Session {
 
         state.peer_label = peer_label.clone();
 
+        let override_arc = Arc::new(std::sync::Mutex::new(None));
+        if let Some(ref rx) = state.broadcast_rx {
+            session_core::spawn_rekey_watcher(rx, Arc::clone(&override_arc));
+        }
+
         Ok(Self {
             runtime: rt,
             state: Arc::new(Mutex::new(state)),
             notebook_id,
-            notebook_id_override: Arc::new(std::sync::Mutex::new(None)),
+            notebook_id_override: override_arc,
             peer_label,
         })
     }
@@ -224,7 +234,15 @@ impl Session {
             .clone()
             .unwrap_or_else(|| self.notebook_id.clone());
         self.runtime
-            .block_on(session_core::connect(&self.state, &effective_id))
+            .block_on(session_core::connect(&self.state, &effective_id))?;
+        // Spawn background task to update notebook_id if a peer re-keys the room
+        self.runtime.block_on(async {
+            let st = self.state.lock().await;
+            if let Some(ref rx) = st.broadcast_rx {
+                session_core::spawn_rekey_watcher(rx, Arc::clone(&self.notebook_id_override));
+            }
+        });
+        Ok(())
     }
 
     // =========================================================================

--- a/crates/runtimed-py/src/session_core.rs
+++ b/crates/runtimed-py/src/session_core.rs
@@ -163,6 +163,33 @@ pub(crate) async fn connect(state: &Arc<Mutex<SessionState>>, notebook_id: &str)
     Ok(())
 }
 
+/// Spawn a background task that listens for `RoomRenamed` broadcasts
+/// and updates the `notebook_id_override` when another peer re-keys the room.
+///
+/// This ensures `Session.notebook_id` / `AsyncSession.notebook_id` stays
+/// correct even when a different peer saves an ephemeral notebook.
+pub(crate) fn spawn_rekey_watcher(
+    broadcast_rx: &BroadcastReceiver,
+    notebook_id_override: Arc<std::sync::Mutex<Option<String>>>,
+) {
+    let mut rx = broadcast_rx.resubscribe();
+    tokio::spawn(async move {
+        loop {
+            match rx.recv().await {
+                Some(NotebookBroadcast::RoomRenamed { new_notebook_id }) => {
+                    log::info!(
+                        "[session] Room re-keyed by peer, new notebook_id: {}",
+                        new_notebook_id
+                    );
+                    *notebook_id_override.lock().unwrap() = Some(new_notebook_id);
+                }
+                Some(_) => continue,
+                None => break, // channel closed
+            }
+        }
+    });
+}
+
 /// Connect and open an existing notebook file.
 ///
 /// Returns (notebook_id, populated SessionState, NotebookConnectionInfo).

--- a/crates/runtimed-py/src/session_core.rs
+++ b/crates/runtimed-py/src/session_core.rs
@@ -58,9 +58,6 @@ pub(crate) struct SessionState {
     pub peer_label: Option<String>,
     /// Actor label for Automerge provenance (e.g., "agent:claude:ab12cd34")
     pub actor_label: Option<String>,
-    /// Updated notebook_id after the daemon re-keys an ephemeral room on save.
-    /// When set, this overrides the original notebook_id on Session/AsyncSession.
-    pub notebook_id_override: Option<String>,
 }
 
 impl SessionState {
@@ -78,7 +75,6 @@ impl SessionState {
             settings: None,
             peer_label: None,
             actor_label: None,
-            notebook_id_override: None,
         }
     }
 }
@@ -204,7 +200,6 @@ pub(crate) async fn connect_open(
         settings,
         peer_label: None, // Set by caller (Session/AsyncSession)
         actor_label: actor_label.map(String::from),
-        notebook_id_override: None,
     };
 
     Ok((notebook_id, state, connection_info))
@@ -249,7 +244,6 @@ pub(crate) async fn connect_create(
         settings,
         peer_label: None, // Set by caller (Session/AsyncSession)
         actor_label: actor_label.map(String::from),
-        notebook_id_override: None,
     };
 
     Ok((notebook_id, state, connection_info))
@@ -1390,8 +1384,6 @@ pub(crate) async fn save(
     state: &Arc<Mutex<SessionState>>,
     path: Option<&str>,
 ) -> PyResult<SaveResult> {
-    // Clone the handle so we can release the lock before the async request,
-    // then re-lock to update notebook_id_override if needed.
     let handle = {
         let st = state.lock().await;
         st.handle
@@ -1417,18 +1409,10 @@ pub(crate) async fn save(
         NotebookResponse::NotebookSaved {
             path: saved_path,
             new_notebook_id,
-        } => {
-            // If the daemon re-keyed the room (ephemeral → file-path),
-            // store the new ID so the Session/AsyncSession getter reflects it.
-            if new_notebook_id.is_some() {
-                let mut st = state.lock().await;
-                st.notebook_id_override = new_notebook_id.clone();
-            }
-            Ok(SaveResult {
-                path: saved_path,
-                new_notebook_id,
-            })
-        }
+        } => Ok(SaveResult {
+            path: saved_path,
+            new_notebook_id,
+        }),
         NotebookResponse::Error { error } => Err(to_py_err(error)),
         other => Err(to_py_err(format!("Unexpected response: {:?}", other))),
     }

--- a/python/nteract/src/nteract/_mcp_server.py
+++ b/python/nteract/src/nteract/_mcp_server.py
@@ -528,7 +528,7 @@ if not _no_show:
                 description="Notebook ID to show. Defaults to current session's notebook.",
             ),
         ] = None,
-    ) -> str:
+    ) -> dict[str, Any]:
         """Open the notebook in the nteract desktop app.
 
         The notebook must be currently running in the daemon. If no notebook_id
@@ -560,7 +560,7 @@ if not _no_show:
             )
 
         runtimed.show_notebook_app(target)
-        return f"Opened notebook in nteract: {target}"
+        return {"notebook_id": target, "opened": True}
 
 
 @mcp.tool(annotations=ToolAnnotations(destructiveHint=False))
@@ -681,6 +681,7 @@ async def save_notebook(path: str | None = None) -> dict[str, Any]:
     file path, so no disconnect/reconnect is needed.
     """
     session = await _get_session()
+    old_notebook_id = session.notebook_id
 
     try:
         saved_path = await session.save(path)
@@ -694,7 +695,11 @@ async def save_notebook(path: str | None = None) -> dict[str, Any]:
             ) from e
         raise
 
-    return {"path": saved_path, "notebook_id": session.notebook_id}
+    new_notebook_id = session.notebook_id
+    result: dict[str, Any] = {"path": saved_path, "notebook_id": new_notebook_id}
+    if old_notebook_id != new_notebook_id:
+        result["previous_notebook_id"] = old_notebook_id
+    return result
 
 
 # =============================================================================


### PR DESCRIPTION
## Problem

Three related issues around `show_notebook()` targeting the wrong notebook when multiple sessions are active (or when a peer re-keys a room):

1. **`try_lock()` race in `notebook_id` getter** — after saving an ephemeral notebook (UUID → file-path re-key), `AsyncSession.notebook_id` could silently return the stale UUID instead of the new path-based ID.

2. **Session context not surfaced in responses** — `show_notebook()` didn't include which `notebook_id` it actually opened, and `save_notebook()` didn't indicate when the ID changed due to re-keying.

3. **Peer-triggered re-keys ignored** — when *another* peer saves an ephemeral notebook, the daemon broadcasts `RoomRenamed`, but the session layer ignored it. The `notebook_id` stayed stale until the current session happened to call `save()` itself.

## Fix 1: Eliminate `try_lock()` race (commit 1)

`notebook_id_override` previously lived inside `SessionState`, behind a `tokio::sync::Mutex`. Both `Session` and `AsyncSession`'s `notebook_id` getters used `try_lock()` to read it — silently falling back to the stale UUID on contention.

Now it lives in a separate `Arc<std::sync::Mutex<Option<String>>>` on the session struct. This lock never contends with async `SessionState` operations, and `lock()` always succeeds.

| File | Change |
|---|---|
| `session_core.rs` | Remove `notebook_id_override` from `SessionState`. Remove the extra `state.lock().await` in `save()` that existed only to write the override. |
| `async_session.rs` | Add `notebook_id_override: Arc<std::sync::Mutex<Option<String>>>` field. Update getter, `connect()`, and `save()`. |
| `session.rs` | Same treatment. Replace the old `self.notebook_id = new_id` mutation with the shared arc. |

## Fix 2: Surface `notebook_id` in tool responses (commit 2)

- **`show_notebook()`** now returns `{"notebook_id": ..., "opened": true}` instead of a plain string.

- **`save_notebook()`** now includes `previous_notebook_id` when the ID changed due to re-keying:
  ```json
  {"path": "/path/to/notebook.ipynb", "notebook_id": "/path/to/notebook.ipynb", "previous_notebook_id": "09625fb1-..."}
  ```

## Fix 3: Handle peer-triggered re-keys via `RoomRenamed` broadcast (commit 3)

Each session now spawns a lightweight background task (via `broadcast_rx.resubscribe()`) that watches for `RoomRenamed` and updates the `notebook_id_override` arc. This ensures `session.notebook_id` stays correct regardless of which peer triggered the re-key.

The watcher is spawned from all connection paths: `open_notebook()`, `create_notebook()`, and `connect()`.

Fixes #944