### PR TITLE
refactor: RxJS migration for useAutomergeNotebook

### DIFF
--- a/.voice-subs
+++ b/.voice-subs
@@ -1,0 +1,25 @@
+# Voice substitutions for nteract desktop project
+# Usage: voice --sub-file .voice-subs "your text here"
+
+nteract=en-ter-act
+RxJS=R X J S
+rxjs=R X J S
+useAutomergeNotebook=use automerge notebook
+useEffect=use effect
+useState=use state
+useCallback=use callback
+useRef=use ref
+useSyncExternalStore=use sync external store
+useMemo=use memo
+fromTauriEvent=from tauri event
+debounceTime=debounce time
+bufferTime=buffer time
+switchMap=switch map
+mergeMap=merge map
+WASM=wasm
+wasm=wasm
+PRs=P Rs
+PR=P R
+tsconfig=T S config
+vitest=vye test
+TypeScript=typescript

--- a/apps/notebook/package.json
+++ b/apps/notebook/package.json
@@ -47,6 +47,7 @@
     "rehype-raw": "^7.0.0",
     "remark-gfm": "^4.0.1",
     "remark-math": "^6.0.0",
+    "rxjs": "^7.8.2",
     "tailwind-merge": "^3.4.0"
   },
   "devDependencies": {

--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -7,6 +7,7 @@ import {
 import { useCallback, useEffect, useRef, useState } from "react";
 import { getBlobPort, refreshBlobPort } from "../lib/blob-port";
 import { frame_types, sendFrame } from "../lib/frame-types";
+import { Subject, debounceTime } from "rxjs";
 import { createFramePipeline } from "../lib/frame-pipeline";
 import { logger } from "../lib/logger";
 import {
@@ -114,52 +115,19 @@ export function useAutomergeNotebook() {
     }
   }, []);
 
-  // Debounced sync for source updates — batches rapid keystrokes into a
-  // single IPC call. Structural mutations (add/delete/move cell) still use
-  // syncToRelay directly for immediate consistency.
-  const pendingSyncTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
-    null,
-  );
+  // RxJS subjects for debounced outbound sync pipelines.
+  // Subjects are stable refs — subscriptions are managed in useEffect.
 
-  const debouncedSyncToRelay = useCallback(
-    (handle: NotebookHandle) => {
-      if (pendingSyncTimerRef.current) {
-        clearTimeout(pendingSyncTimerRef.current);
-      }
-      pendingSyncTimerRef.current = setTimeout(() => {
-        pendingSyncTimerRef.current = null;
-        syncToRelay(handle);
-      }, 20);
-    },
-    [syncToRelay],
-  );
+  // Source sync (20ms debounce): batches rapid keystrokes into a single IPC
+  // call. Structural mutations (add/delete/move) still use syncToRelay
+  // directly for immediate consistency.
+  const sourceSync$ = useRef(new Subject<void>());
 
-  // Debounced sync reply for inbound frames — coalesces multiple receives
-  // into a single outbound reply. The Automerge sync protocol is safe to
-  // batch: receive,receive,receive → generate covers all received changes.
+  // Sync reply (50ms debounce): coalesces multiple inbound receives into a
+  // single outbound reply. The Automerge sync protocol is safe to batch:
+  // receive,receive,receive → generate covers all received changes.
   // Matches automerge-repo's syncDebounceRate pattern (they use 100ms).
-  const pendingSyncReplyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
-    null,
-  );
-
-  const scheduleSyncReply = useCallback(() => {
-    if (pendingSyncReplyTimerRef.current) {
-      clearTimeout(pendingSyncReplyTimerRef.current);
-    }
-    pendingSyncReplyTimerRef.current = setTimeout(() => {
-      pendingSyncReplyTimerRef.current = null;
-      // Read handle at fire time — not capture time — to avoid
-      // use-after-free if bootstrap() replaced/freed the handle.
-      const handle = handleRef.current;
-      if (!handle) return;
-      const reply = handle.generate_sync_reply();
-      if (reply) {
-        sendFrame(frame_types.AUTOMERGE_SYNC, reply).catch((e: unknown) =>
-          logger.warn("[automerge-notebook] sync reply failed:", e),
-        );
-      }
-    }, 50);
-  }, []);
+  const syncReply$ = useRef(new Subject<void>());
 
   /**
    * Synchronously re-read cells from WASM after a local mutation.
@@ -278,8 +246,32 @@ export function useAutomergeNotebook() {
       setIsLoading,
       materializeCells,
       outputCache: outputCacheRef.current,
-      onSyncApplied: scheduleSyncReply,
+      onSyncApplied: () => syncReply$.current.next(),
     });
+
+    // ── Debounced outbound sync pipelines (RxJS) ────────────────────
+
+    // Source sync: 20ms debounce for batching rapid keystrokes.
+    const sourceSyncSub = sourceSync$.current
+      .pipe(debounceTime(20))
+      .subscribe(() => {
+        const handle = handleRef.current;
+        if (handle) syncToRelay(handle);
+      });
+
+    // Sync reply: 50ms debounce for coalescing inbound frame replies.
+    const syncReplySub = syncReply$.current
+      .pipe(debounceTime(50))
+      .subscribe(() => {
+        const handle = handleRef.current;
+        if (!handle) return;
+        const reply = handle.generate_sync_reply();
+        if (reply) {
+          sendFrame(frame_types.AUTOMERGE_SYNC, reply).catch((e: unknown) =>
+            logger.warn("[automerge-notebook] sync reply failed:", e),
+          );
+        }
+      });
 
     // ── Bulk output clearing (run-all / restart-and-run-all) ─────────
     const unlistenClearOutputs = webview.listen<string[]>(
@@ -300,29 +292,22 @@ export function useAutomergeNotebook() {
     return () => {
       cancelled = true;
       frameSub.unsubscribe();
+      // Unsubscribe debounce pipelines (cancels pending timers)
+      sourceSyncSub.unsubscribe();
+      syncReplySub.unsubscribe();
       unlistenReady.then((fn) => fn()).catch(() => {});
       unlistenFileOpened.then((fn) => fn()).catch(() => {});
       unlistenClearOutputs.then((fn) => fn()).catch(() => {});
-      // Flush any pending debounced sync before teardown
-      if (pendingSyncTimerRef.current) {
-        clearTimeout(pendingSyncTimerRef.current);
-        pendingSyncTimerRef.current = null;
-        if (handleRef.current) syncToRelay(handleRef.current);
-      }
-      // Flush any pending sync reply before teardown
-      if (pendingSyncReplyTimerRef.current) {
-        clearTimeout(pendingSyncReplyTimerRef.current);
-        pendingSyncReplyTimerRef.current = null;
-        if (handleRef.current) {
-          const reply = handleRef.current.generate_sync_reply();
-          if (reply) {
-            sendFrame(frame_types.AUTOMERGE_SYNC, reply).catch((e: unknown) =>
-              logger.warn(
-                "[automerge-notebook] teardown sync reply failed:",
-                e,
-              ),
-            );
-          }
+      // Flush any pending sync before teardown — unsubscribing the
+      // debounce pipelines above cancels their timers, so we do a
+      // final sync + reply here to avoid dropping in-flight changes.
+      if (handleRef.current) {
+        syncToRelay(handleRef.current);
+        const reply = handleRef.current.generate_sync_reply();
+        if (reply) {
+          sendFrame(frame_types.AUTOMERGE_SYNC, reply).catch((e: unknown) =>
+            logger.warn("[automerge-notebook] teardown sync reply failed:", e),
+          );
         }
       }
       // Free WASM handle.
@@ -331,30 +316,27 @@ export function useAutomergeNotebook() {
       handleRef.current?.free();
       handleRef.current = null;
     };
-  }, [bootstrap, materializeCells, scheduleSyncReply, syncToRelay]);
+  }, [bootstrap, materializeCells, syncToRelay]);
 
   // ── Cell mutations ─────────────────────────────────────────────────
 
-  const updateCellSource = useCallback(
-    (cellId: string, source: string) => {
-      const handle = handleRef.current;
-      if (!handle || awaitingInitialSyncRef.current) return;
+  const updateCellSource = useCallback((cellId: string, source: string) => {
+    const handle = handleRef.current;
+    if (!handle || awaitingInitialSyncRef.current) return;
 
-      // Mutate WASM (instant, local-first)
-      const updated = handle.update_source(cellId, source);
-      if (!updated) return;
+    // Mutate WASM (instant, local-first)
+    const updated = handle.update_source(cellId, source);
+    if (!updated) return;
 
-      // Fast-path: update only the affected cell in the store — triggers only
-      // that cell's subscribers, not all cells.
-      updateCellById(cellId, (c) => ({ ...c, source }));
+    // Fast-path: update only the affected cell in the store — triggers only
+    // that cell's subscribers, not all cells.
+    updateCellById(cellId, (c) => ({ ...c, source }));
 
-      // Debounced sync to daemon — batches rapid keystrokes
-      debouncedSyncToRelay(handle);
+    // Debounced sync to daemon — batches rapid keystrokes
+    sourceSync$.current.next();
 
-      setDirty(true);
-    },
-    [debouncedSyncToRelay],
-  );
+    setDirty(true);
+  }, []);
 
   const clearCellOutputs = useCallback((cellId: string) => {
     updateCellById(cellId, (c) =>
@@ -468,13 +450,9 @@ export function useAutomergeNotebook() {
     const handle = handleRef.current;
     if (!handle) return;
 
-    // Cancel pending debounced sync
-    if (pendingSyncTimerRef.current) {
-      clearTimeout(pendingSyncTimerRef.current);
-      pendingSyncTimerRef.current = null;
-    }
-
-    // Generate and send sync message, awaiting the IPC
+    // Generate and send sync message immediately, bypassing the debounce.
+    // Any pending debounced emission becomes a no-op (generate_sync_message
+    // returns null when there's nothing new to sync).
     const msg = handle.generate_sync_message();
     if (msg) {
       await sendFrame(frame_types.AUTOMERGE_SYNC, msg);

--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -1,5 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
-import { getCurrentWebview } from "@tauri-apps/api/webview";
+
 import {
   open as openDialog,
   save as saveDialog,
@@ -7,8 +7,9 @@ import {
 import { useCallback, useEffect, useRef, useState } from "react";
 import { getBlobPort, refreshBlobPort } from "../lib/blob-port";
 import { frame_types, sendFrame } from "../lib/frame-types";
-import { Subject, debounceTime } from "rxjs";
+import { Subject, debounceTime, merge, switchMap, from } from "rxjs";
 import { createFramePipeline } from "../lib/frame-pipeline";
+import { fromTauriEvent } from "../lib/tauri-rx";
 import { logger } from "../lib/logger";
 import {
   type CellSnapshot,
@@ -204,32 +205,37 @@ export function useAutomergeNotebook() {
       }
     });
 
-    const webview = getCurrentWebview();
-
-    // On (re)connect, create a fresh empty handle and let sync deliver
-    // everything. We must NOT reset_sync_state() on an existing handle —
-    // that creates an infinite loop of 85-byte sync messages that never
-    // converge (the WASM keeps re-requesting content it already has).
-    const unlistenReady = webview.listen("daemon:ready", async () => {
-      if (cancelled) return;
-      refreshBlobPort(); // Update blob-port store for new daemon session
-      awaitingInitialSyncRef.current = true;
-      setIsLoading(true);
-      await bootstrap();
-    });
-
-    // Different file opened in this window — need a fresh handle since the
-    // old handle's doc has the previous notebook's content.
-    const unlistenFileOpened = webview.listen(
-      "notebook:file-opened",
-      async () => {
-        if (cancelled) return;
-        awaitingInitialSyncRef.current = true;
-        setIsLoading(true);
-        resetNotebookCells();
-        await bootstrap();
-      },
-    );
+    // ── Daemon lifecycle (RxJS) ─────────────────────────────────────
+    //
+    // daemon:ready (reconnect) and notebook:file-opened (new file in this
+    // window) both require a fresh bootstrap. Merged into one observable
+    // so the switchMap cancels any in-flight bootstrap when a new event
+    // arrives (e.g. rapid file-open, file-open during reconnect).
+    const lifecycleSub = merge(
+      fromTauriEvent("daemon:ready"),
+      fromTauriEvent("notebook:file-opened"),
+    )
+      .pipe(
+        switchMap(() => {
+          // The Tauri event name isn't carried through merge, but we can
+          // distinguish by checking: daemon:ready always refreshes the
+          // blob port, file-opened always resets cells. Doing both is
+          // safe and idempotent, so we just do both unconditionally.
+          refreshBlobPort();
+          resetNotebookCells();
+          awaitingInitialSyncRef.current = true;
+          setIsLoading(true);
+          return from(
+            bootstrap().catch((err: unknown) => {
+              logger.error(
+                "[automerge-notebook] lifecycle bootstrap failed:",
+                err,
+              );
+            }),
+          );
+        }),
+      )
+      .subscribe();
 
     // ── Inbound frame pipeline (RxJS) ───────────────────────────────
     //
@@ -274,30 +280,27 @@ export function useAutomergeNotebook() {
       });
 
     // ── Bulk output clearing (run-all / restart-and-run-all) ─────────
-    const unlistenClearOutputs = webview.listen<string[]>(
+    const unlistenClearOutputs = fromTauriEvent<string[]>(
       "cells:outputs_cleared",
-      (event) => {
-        if (cancelled) return;
-        const clearedIds = new Set(event.payload);
-        updateNotebookCells((prev) =>
-          prev.map((c) =>
-            clearedIds.has(c.id) && c.cell_type === "code"
-              ? { ...c, outputs: [], execution_count: null }
-              : c,
-          ),
-        );
-      },
-    );
+    ).subscribe((payload) => {
+      const clearedIds = new Set(payload);
+      updateNotebookCells((prev) =>
+        prev.map((c) =>
+          clearedIds.has(c.id) && c.cell_type === "code"
+            ? { ...c, outputs: [], execution_count: null }
+            : c,
+        ),
+      );
+    });
 
     return () => {
       cancelled = true;
       frameSub.unsubscribe();
+      lifecycleSub.unsubscribe();
       // Unsubscribe debounce pipelines (cancels pending timers)
       sourceSyncSub.unsubscribe();
       syncReplySub.unsubscribe();
-      unlistenReady.then((fn) => fn()).catch(() => {});
-      unlistenFileOpened.then((fn) => fn()).catch(() => {});
-      unlistenClearOutputs.then((fn) => fn()).catch(() => {});
+      unlistenClearOutputs.unsubscribe();
       // Flush any pending sync before teardown — unsubscribing the
       // debounce pipelines above cancels their timers, so we do a
       // final sync + reply here to avoid dropping in-flight changes.

--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -1,15 +1,9 @@
 import { invoke } from "@tauri-apps/api/core";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Subject, debounceTime, merge, switchMap, from } from "rxjs";
+import { debounceTime, from, merge, Subject, switchMap } from "rxjs";
 import { getBlobPort, refreshBlobPort } from "../lib/blob-port";
-import { frame_types, sendFrame } from "../lib/frame-types";
 import { createFramePipeline } from "../lib/frame-pipeline";
-import {
-  saveNotebook,
-  openNotebookFile,
-  cloneNotebookFile,
-} from "../lib/notebook-file-ops";
-import { fromTauriEvent } from "../lib/tauri-rx";
+import { frame_types, sendFrame } from "../lib/frame-types";
 import { logger } from "../lib/logger";
 import {
   type CellSnapshot,
@@ -24,8 +18,14 @@ import {
   updateNotebookCells,
   useCellIds,
 } from "../lib/notebook-cells";
+import {
+  cloneNotebookFile,
+  openNotebookFile,
+  saveNotebook,
+} from "../lib/notebook-file-ops";
 import { subscribeBroadcast } from "../lib/notebook-frame-bus";
 import { setNotebookHandle } from "../lib/notebook-metadata";
+import { fromTauriEvent } from "../lib/tauri-rx";
 import type { DaemonBroadcast, JupyterOutput } from "../types";
 import init, { NotebookHandle } from "../wasm/runtimed-wasm/runtimed_wasm.js";
 
@@ -118,11 +118,10 @@ export function useAutomergeNotebook() {
    * After the mutation callback runs, re-materializes and syncs.
    */
   const commitMutation = useCallback(
-    (mutate: (handle: NotebookHandle) => boolean | void) => {
+    (mutate: (handle: NotebookHandle) => boolean) => {
       const handle = handleRef.current;
       if (!handle || awaitingInitialSyncRef.current) return false;
-      const result = mutate(handle);
-      if (result === false) return false;
+      if (!mutate(handle)) return false;
       rematerializeCellsSync(handle);
       syncToRelay(handle);
       setDirty(true);
@@ -336,6 +335,7 @@ export function useAutomergeNotebook() {
     (cellId: string, afterCellId?: string | null) => {
       commitMutation((handle) => {
         handle.move_cell(cellId, afterCellId ?? null);
+        return true;
       });
     },
     [commitMutation],
@@ -345,8 +345,7 @@ export function useAutomergeNotebook() {
     (cellId: string) => {
       commitMutation((handle) => {
         if (handle.cell_count() <= 1) return false;
-        const deleted = handle.delete_cell(cellId);
-        if (!deleted) return false;
+        return !!handle.delete_cell(cellId);
       });
     },
     [commitMutation],
@@ -355,8 +354,7 @@ export function useAutomergeNotebook() {
   const setCellSourceHidden = useCallback(
     (cellId: string, hidden: boolean) => {
       commitMutation((handle) => {
-        const updated = handle.set_cell_source_hidden(cellId, hidden);
-        if (!updated) return false;
+        return !!handle.set_cell_source_hidden(cellId, hidden);
       });
     },
     [commitMutation],
@@ -365,8 +363,7 @@ export function useAutomergeNotebook() {
   const setCellOutputsHidden = useCallback(
     (cellId: string, hidden: boolean) => {
       commitMutation((handle) => {
-        const updated = handle.set_cell_outputs_hidden(cellId, hidden);
-        if (!updated) return false;
+        return !!handle.set_cell_outputs_hidden(cellId, hidden);
       });
     },
     [commitMutation],

--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -7,17 +7,14 @@ import {
 import { useCallback, useEffect, useRef, useState } from "react";
 import { getBlobPort, refreshBlobPort } from "../lib/blob-port";
 import { frame_types, sendFrame } from "../lib/frame-types";
+import { createFramePipeline } from "../lib/frame-pipeline";
 import { logger } from "../lib/logger";
 import {
   type CellSnapshot,
   cellSnapshotsToNotebookCells,
   cellSnapshotsToNotebookCellsSync,
-  isManifestHash,
-  materializeCellFromWasm,
-  resolveOutput,
 } from "../lib/materialize-cells";
 import {
-  getCellById,
   getNotebookCellsSnapshot,
   replaceNotebookCells,
   resetNotebookCells,
@@ -25,15 +22,8 @@ import {
   updateNotebookCells,
   useCellIds,
 } from "../lib/notebook-cells";
-import {
-  emitBroadcast,
-  emitPresence,
-  subscribeBroadcast,
-} from "../lib/notebook-frame-bus";
-import {
-  notifyMetadataChanged,
-  setNotebookHandle,
-} from "../lib/notebook-metadata";
+import { subscribeBroadcast } from "../lib/notebook-frame-bus";
+import { setNotebookHandle } from "../lib/notebook-metadata";
 import type { DaemonBroadcast, JupyterOutput } from "../types";
 import init, { NotebookHandle } from "../wasm/runtimed-wasm/runtimed_wasm.js";
 
@@ -45,56 +35,6 @@ import init, { NotebookHandle } from "../wasm/runtimed-wasm/runtimed_wasm.js";
 const wasmReady: Promise<void> = init().then(() => {
   logger.info("[automerge-notebook] WASM initialized");
 });
-
-// ---------------------------------------------------------------------------
-// CellChangeset types — mirrors the Rust `notebook_doc::diff` types
-// serialized from WASM via serde-wasm-bindgen.
-// ---------------------------------------------------------------------------
-
-/** Which fields changed on a cell (only `true` fields are present in the JS object). */
-interface ChangedFields {
-  source?: boolean;
-  outputs?: boolean;
-  execution_count?: boolean;
-  cell_type?: boolean;
-  metadata?: boolean;
-  position?: boolean;
-  resolved_assets?: boolean;
-}
-
-interface ChangedCell {
-  cell_id: string;
-  fields: ChangedFields;
-}
-
-/** Structural diff between two Automerge head sets, produced by WASM `diff_cells`. */
-interface CellChangeset {
-  changed: ChangedCell[];
-  added: string[];
-  removed: string[];
-  order_changed: boolean;
-}
-
-/** Merge two CellChangesets (for coalescing frames across the throttle window). */
-function mergeChangesets(a: CellChangeset, b: CellChangeset): CellChangeset {
-  const changedMap = new Map<string, ChangedFields>();
-  for (const c of [...a.changed, ...b.changed]) {
-    const existing = changedMap.get(c.cell_id);
-    if (existing) {
-      for (const [key, val] of Object.entries(c.fields)) {
-        if (val) (existing as Record<string, boolean>)[key] = true;
-      }
-    } else {
-      changedMap.set(c.cell_id, { ...c.fields });
-    }
-  }
-  return {
-    changed: [...changedMap].map(([cell_id, fields]) => ({ cell_id, fields })),
-    added: [...new Set([...a.added, ...b.added])],
-    removed: [...new Set([...a.removed, ...b.removed])],
-    order_changed: a.order_changed || b.order_changed,
-  };
-}
 
 // ---------------------------------------------------------------------------
 // Hook
@@ -235,123 +175,6 @@ export function useAutomergeNotebook() {
     replaceNotebookCells(newCells);
   }, []);
 
-  // Coalescing timer for incoming sync frames — when an agent is active,
-  // frames arrive rapidly. Instead of materializing on every frame, batch
-  // into a single materialization per ~32ms window.
-  //
-  // Tracks a CellChangeset that accumulates across frames. If any frame
-  // arrives without a changeset, falls back to full materialization.
-  const pendingMaterializeTimerRef = useRef<ReturnType<
-    typeof setTimeout
-  > | null>(null);
-  const pendingFullMaterializeRef = useRef(false);
-  const pendingChangesetRef = useRef<CellChangeset | null>(null);
-
-  const scheduleMaterialize = useCallback(
-    (_handle: NotebookHandle, changeset?: CellChangeset) => {
-      if (changeset) {
-        // Merge into accumulated changeset for this coalescing window.
-        pendingChangesetRef.current = pendingChangesetRef.current
-          ? mergeChangesets(pendingChangesetRef.current, changeset)
-          : changeset;
-      } else {
-        // No changeset — can't do incremental, need full materialization.
-        pendingFullMaterializeRef.current = true;
-      }
-      if (pendingMaterializeTimerRef.current) return;
-      pendingMaterializeTimerRef.current = setTimeout(async () => {
-        pendingMaterializeTimerRef.current = null;
-        // Read handle at fire time — not capture time — to avoid
-        // use-after-free if bootstrap() replaced/freed the handle.
-        const handle = handleRef.current;
-        if (!handle) return;
-        const needsFull = pendingFullMaterializeRef.current;
-        const cs = pendingChangesetRef.current;
-        pendingFullMaterializeRef.current = false;
-        pendingChangesetRef.current = null;
-
-        if (needsFull || !cs) {
-          await materializeCells(handle);
-          notifyMetadataChanged();
-          return;
-        }
-
-        // Structural changes (cells added/removed/reordered) require full
-        // materialization — the cell ID list and ordering need updating.
-        if (cs.added.length > 0 || cs.removed.length > 0 || cs.order_changed) {
-          await materializeCells(handle);
-          notifyMetadataChanged();
-          return;
-        }
-
-        // Per-cell materialization. For cells with output changes, check
-        // whether all outputs are already in the cache. Cache hits use the
-        // fast synchronous path; cache misses resolve the individual cell's
-        // outputs asynchronously (without serializing the entire document).
-        const cache = outputCacheRef.current;
-
-        for (const { cell_id: cellId, fields } of cs.changed) {
-          if (fields.outputs) {
-            // Check if every output for this cell is already cached.
-            const rawOutputs: string[] = handle.get_cell_outputs(cellId) ?? [];
-            const allCached = rawOutputs.every(
-              (o) => cache.has(o) || !isManifestHash(o),
-            );
-
-            if (allCached) {
-              // All outputs resolved from cache — fast sync path.
-              const cell = materializeCellFromWasm(
-                handle,
-                cellId,
-                cache,
-                getCellById(cellId),
-              );
-              if (cell) updateCellById(cellId, () => cell);
-            } else {
-              // Cache miss — resolve this cell's outputs async (fetch
-              // manifests from blob store) without re-serializing the
-              // entire document.
-              let blobPort = getBlobPort();
-              if (blobPort === null) {
-                blobPort = await refreshBlobPort();
-              }
-              const resolved = (
-                await Promise.all(
-                  rawOutputs.map((o) => resolveOutput(o, blobPort, cache)),
-                )
-              ).filter((o): o is JupyterOutput => o !== null);
-
-              const ecStr = handle.get_cell_execution_count(cellId);
-              const ec =
-                !ecStr || ecStr === "null" ? null : Number.parseInt(ecStr, 10);
-              const source = handle.get_cell_source(cellId) ?? "";
-              const metadata = handle.get_cell_metadata(cellId) ?? {};
-
-              updateCellById(cellId, () => ({
-                id: cellId,
-                cell_type: "code" as const,
-                source,
-                execution_count: Number.isNaN(ec) ? null : ec,
-                outputs: resolved,
-                metadata,
-              }));
-            }
-          } else {
-            // No output changes — always use fast sync path.
-            const cell = materializeCellFromWasm(
-              handle,
-              cellId,
-              cache,
-              getCellById(cellId),
-            );
-            if (cell) updateCellById(cellId, () => cell);
-          }
-        }
-      }, 32);
-    },
-    [materializeCells],
-  );
-
   // ── Bootstrap ──────────────────────────────────────────────────────
 
   /**
@@ -440,88 +263,23 @@ export function useAutomergeNotebook() {
       },
     );
 
-    // ── Incoming frames from daemon (unified pipe) ──────────────────
+    // ── Inbound frame pipeline (RxJS) ───────────────────────────────
     //
     // All frame types (AutomergeSync, Broadcast, Presence) arrive through
-    // one event. The WASM handle.receive_frame() demuxes by the first byte,
-    // applies sync internally, and returns typed FrameEvent JSON.
-    //
-    // Broadcasts and presence are dispatched via the frame bus (in-memory
-    // pub/sub) to useDaemonKernel, useEnvProgress, and usePresence.
-    const unlistenFrame = webview.listen<number[]>(
-      "notebook:frame",
-      async (event) => {
-        if (cancelled) return;
-        const handle = handleRef.current;
-        if (!handle) return;
-        try {
-          const bytes = new Uint8Array(event.payload);
-          const result = handle.receive_frame(bytes);
-          if (!result || !Array.isArray(result)) return;
-
-          const events = result as Array<{
-            type: string;
-            changed?: boolean;
-            changeset?: CellChangeset;
-            attributions?: Array<{
-              cell_id: string;
-              index: number;
-              text: string;
-              deleted: number;
-              actors: string[];
-            }>;
-            payload?: unknown;
-          }>;
-
-          for (const frameEvent of events) {
-            switch (frameEvent.type) {
-              case "sync_applied": {
-                if (awaitingInitialSyncRef.current) {
-                  awaitingInitialSyncRef.current = false;
-                  setIsLoading(false);
-                  // Initial sync: materialize immediately (no throttle)
-                  if (frameEvent.changed) {
-                    await materializeCells(handle);
-                    notifyMetadataChanged();
-                  }
-                } else if (frameEvent.changed) {
-                  // Use the WASM-computed CellChangeset for surgical updates.
-                  // Falls back to full materialization if changeset is absent.
-                  scheduleMaterialize(handle, frameEvent.changeset);
-                }
-                if (
-                  frameEvent.attributions &&
-                  frameEvent.attributions.length > 0
-                ) {
-                  emitBroadcast({
-                    type: "text_attribution",
-                    attributions: frameEvent.attributions,
-                  });
-                }
-                // Schedule a debounced sync reply — multiple inbound frames
-                // coalesce into a single outbound reply per 50ms window.
-                scheduleSyncReply();
-                break;
-              }
-              case "broadcast": {
-                if (frameEvent.payload) {
-                  emitBroadcast(frameEvent.payload);
-                }
-                break;
-              }
-              case "presence": {
-                if (frameEvent.payload) {
-                  emitPresence(frameEvent.payload);
-                }
-                break;
-              }
-            }
-          }
-        } catch (e) {
-          logger.warn("[automerge-notebook] receive frame failed:", e);
-        }
+    // one Tauri event. The RxJS pipeline owns WASM demux, coalescing,
+    // materialization, and fan-out to the frame bus. Replaces the old
+    // imperative listener + scheduleMaterialize + 3 timer/accumulator refs.
+    const frameSub = createFramePipeline({
+      getHandle: () => handleRef.current,
+      getAwaitingInitialSync: () => awaitingInitialSyncRef.current,
+      setAwaitingInitialSync: (v) => {
+        awaitingInitialSyncRef.current = v;
       },
-    );
+      setIsLoading,
+      materializeCells,
+      outputCache: outputCacheRef.current,
+      onSyncApplied: scheduleSyncReply,
+    });
 
     // ── Bulk output clearing (run-all / restart-and-run-all) ─────────
     const unlistenClearOutputs = webview.listen<string[]>(
@@ -541,9 +299,9 @@ export function useAutomergeNotebook() {
 
     return () => {
       cancelled = true;
+      frameSub.unsubscribe();
       unlistenReady.then((fn) => fn()).catch(() => {});
       unlistenFileOpened.then((fn) => fn()).catch(() => {});
-      unlistenFrame.then((fn) => fn()).catch(() => {});
       unlistenClearOutputs.then((fn) => fn()).catch(() => {});
       // Flush any pending debounced sync before teardown
       if (pendingSyncTimerRef.current) {
@@ -567,24 +325,13 @@ export function useAutomergeNotebook() {
           }
         }
       }
-      // Cancel pending materialize timer
-      if (pendingMaterializeTimerRef.current) {
-        clearTimeout(pendingMaterializeTimerRef.current);
-        pendingMaterializeTimerRef.current = null;
-      }
       // Free WASM handle.
       resetNotebookCells();
       setNotebookHandle(null);
       handleRef.current?.free();
       handleRef.current = null;
     };
-  }, [
-    bootstrap,
-    materializeCells,
-    scheduleMaterialize,
-    scheduleSyncReply,
-    syncToRelay,
-  ]);
+  }, [bootstrap, materializeCells, scheduleSyncReply, syncToRelay]);
 
   // ── Cell mutations ─────────────────────────────────────────────────
 

--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -1,14 +1,14 @@
 import { invoke } from "@tauri-apps/api/core";
-
-import {
-  open as openDialog,
-  save as saveDialog,
-} from "@tauri-apps/plugin-dialog";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { Subject, debounceTime, merge, switchMap, from } from "rxjs";
 import { getBlobPort, refreshBlobPort } from "../lib/blob-port";
 import { frame_types, sendFrame } from "../lib/frame-types";
-import { Subject, debounceTime, merge, switchMap, from } from "rxjs";
 import { createFramePipeline } from "../lib/frame-pipeline";
+import {
+  saveNotebook,
+  openNotebookFile,
+  cloneNotebookFile,
+} from "../lib/notebook-file-ops";
 import { fromTauriEvent } from "../lib/tauri-rx";
 import { logger } from "../lib/logger";
 import {
@@ -29,11 +29,7 @@ import { setNotebookHandle } from "../lib/notebook-metadata";
 import type { DaemonBroadcast, JupyterOutput } from "../types";
 import init, { NotebookHandle } from "../wasm/runtimed-wasm/runtimed_wasm.js";
 
-// ---------------------------------------------------------------------------
-// Module-level WASM initialization — starts loading immediately when module
-// is imported. This runs before React renders, eliminating WASM init latency
-// from the critical path that causes the "empty notebook" flash.
-// ---------------------------------------------------------------------------
+// Module-level WASM init — runs before React renders.
 const wasmReady: Promise<void> = init().then(() => {
   logger.info("[automerge-notebook] WASM initialized");
 });
@@ -45,10 +41,9 @@ const wasmReady: Promise<void> = init().then(() => {
 /**
  * Local-first notebook hook backed by `runtimed-wasm` NotebookHandle.
  *
- * All document mutations (add/delete cell, edit source) execute instantly
- * inside the WASM Automerge document. The external store is derived from the doc.
- * Sync messages flow through the Tauri relay to the daemon — the frontend
- * NEVER creates Automerge objects via the JS library.
+ * All document mutations execute instantly inside the WASM Automerge
+ * document. The external store is derived from the doc. Sync messages
+ * flow through the Tauri relay to the daemon.
  */
 export function useAutomergeNotebook() {
   const cellIds = useCellIds();
@@ -56,25 +51,21 @@ export function useAutomergeNotebook() {
   const [dirty, setDirty] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
 
-  // The WASM handle is mutated in place — must live in a ref.
   const handleRef = useRef<NotebookHandle | null>(null);
   const awaitingInitialSyncRef = useRef(true);
-
-  // Stable session ID for provenance — generated once so the actor label
-  // remains consistent across bootstrap() re-invocations (daemon:ready,
-  // file-opened, etc.).
   const sessionIdRef = useRef(crypto.randomUUID().slice(0, 8));
-
-  // Output manifest cache (shared with materialize-cells utilities).
   const outputCacheRef = useRef<Map<string, JupyterOutput>>(new Map());
 
-  // Blob port is managed by the blob-port store (lib/blob-port.ts).
-  // Refresh on mount; daemon:ready handler refreshes on reconnect.
+  // RxJS subjects for debounced outbound sync.
+  const sourceSync$ = useRef(new Subject<void>());
+  const syncReply$ = useRef(new Subject<void>());
+
+  // Refresh blob port on mount.
   useEffect(() => {
     refreshBlobPort();
   }, []);
 
-  // Clear dirty state when daemon autosaves the notebook to disk.
+  // Clear dirty state on daemon autosave.
   useEffect(() => {
     return subscribeBroadcast((payload) => {
       const broadcast = payload as DaemonBroadcast;
@@ -85,12 +76,9 @@ export function useAutomergeNotebook() {
     });
   }, []);
 
-  // ── Helpers ────────────────────────────────────────────────────────
+  // ── Core helpers ───────────────────────────────────────────────────
 
-  /**
-   * Read cells from the WASM doc and push them into the external store.
-   * Resolves blob manifest hashes as needed.
-   */
+  /** Full materialization: WASM doc → resolve manifests → write to store. */
   const materializeCells = useCallback(async (handle: NotebookHandle) => {
     const json = handle.get_cells_json();
     const snapshots: CellSnapshot[] = JSON.parse(json);
@@ -103,10 +91,7 @@ export function useAutomergeNotebook() {
     replaceNotebookCells(newCells);
   }, []);
 
-  /**
-   * Generate a sync message from the local doc and forward it to the
-   * Tauri relay.  Fire-and-forget — the relay handles daemon forwarding.
-   */
+  /** Send a sync message to the Tauri relay (fire-and-forget). */
   const syncToRelay = useCallback((handle: NotebookHandle) => {
     const msg = handle.generate_sync_message();
     if (msg) {
@@ -116,24 +101,7 @@ export function useAutomergeNotebook() {
     }
   }, []);
 
-  // RxJS subjects for debounced outbound sync pipelines.
-  // Subjects are stable refs — subscriptions are managed in useEffect.
-
-  // Source sync (20ms debounce): batches rapid keystrokes into a single IPC
-  // call. Structural mutations (add/delete/move) still use syncToRelay
-  // directly for immediate consistency.
-  const sourceSync$ = useRef(new Subject<void>());
-
-  // Sync reply (50ms debounce): coalesces multiple inbound receives into a
-  // single outbound reply. The Automerge sync protocol is safe to batch:
-  // receive,receive,receive → generate covers all received changes.
-  // Matches automerge-repo's syncDebounceRate pattern (they use 100ms).
-  const syncReply$ = useRef(new Subject<void>());
-
-  /**
-   * Synchronously re-read cells from WASM after a local mutation.
-   * Uses cache-only output resolution (no blob fetches).
-   */
+  /** Sync re-read cells from WASM (cache-only, no blob fetches). */
   const rematerializeCellsSync = useCallback((handle: NotebookHandle) => {
     const json = handle.get_cells_json();
     const snapshots: CellSnapshot[] = JSON.parse(json);
@@ -144,35 +112,34 @@ export function useAutomergeNotebook() {
     replaceNotebookCells(newCells);
   }, []);
 
+  /**
+   * Guard + commit helper for WASM mutations.
+   * Returns the handle if ready, or null if bootstrapping.
+   * After the mutation callback runs, re-materializes and syncs.
+   */
+  const commitMutation = useCallback(
+    (mutate: (handle: NotebookHandle) => boolean | void) => {
+      const handle = handleRef.current;
+      if (!handle || awaitingInitialSyncRef.current) return false;
+      const result = mutate(handle);
+      if (result === false) return false;
+      rematerializeCellsSync(handle);
+      syncToRelay(handle);
+      setDirty(true);
+      return true;
+    },
+    [rematerializeCellsSync, syncToRelay],
+  );
+
   // ── Bootstrap ──────────────────────────────────────────────────────
 
-  /**
-   * Create an empty WASM NotebookHandle for sync-only bootstrap.
-   *
-   * The handle starts with a zero-operation Automerge doc. The sync
-   * protocol delivers everything — cells, outputs, metadata — from the
-   * daemon through the pipe. No `GetDocBytes` call needed.
-   *
-   * Bootstrap itself is a local operation that always completes once the
-   * WASM runtime is ready, but it immediately kicks off the sync protocol
-   * via `syncToRelay()`, which performs an IPC `invoke` under the hood.
-   * Any IPC failures are logged and do not cause `bootstrap()` to reject.
-   *
-   * Loading state is set to `true` here and is cleared when the first
-   * `notebook:frame` sync message is received, regardless of its
-   * `changed` flag.
-   */
   const bootstrap = useCallback(async () => {
     await wasmReady;
 
-    // Tag this peer's edits with a "human" actor label for provenance.
-    // The session suffix (stable for this hook instance) ensures uniqueness
-    // across concurrent tabs without fragmenting provenance on re-bootstrap.
     const handle = NotebookHandle.create_empty_with_actor(
       `human:${sessionIdRef.current}`,
     );
 
-    // Dispose previous handle (WASM allocation).
     handleRef.current?.free();
     handleRef.current = handle;
     setNotebookHandle(handle);
@@ -180,21 +147,16 @@ export function useAutomergeNotebook() {
     awaitingInitialSyncRef.current = true;
     setIsLoading(true);
 
-    // Kick off the sync protocol. If the relay isn't connected yet this
-    // fails silently — the daemon's Phase 1 message (or the daemon:ready
-    // retry) will start the exchange.
     syncToRelay(handle);
-
     logger.info("[automerge-notebook] Bootstrap: empty handle, awaiting sync");
     return true;
   }, [syncToRelay]);
 
-  // ── Lifecycle (effects) ────────────────────────────────────────────
+  // ── Lifecycle (single effect) ──────────────────────────────────────
 
   useEffect(() => {
     let cancelled = false;
 
-    // Create empty handle immediately — sync will populate it.
     awaitingInitialSyncRef.current = true;
     setIsLoading(true);
     void bootstrap().catch((error) => {
@@ -205,22 +167,14 @@ export function useAutomergeNotebook() {
       }
     });
 
-    // ── Daemon lifecycle (RxJS) ─────────────────────────────────────
-    //
-    // daemon:ready (reconnect) and notebook:file-opened (new file in this
-    // window) both require a fresh bootstrap. Merged into one observable
-    // so the switchMap cancels any in-flight bootstrap when a new event
-    // arrives (e.g. rapid file-open, file-open during reconnect).
+    // Daemon lifecycle — daemon:ready + file-opened both need fresh bootstrap.
+    // switchMap cancels any in-flight bootstrap on rapid events.
     const lifecycleSub = merge(
       fromTauriEvent("daemon:ready"),
       fromTauriEvent("notebook:file-opened"),
     )
       .pipe(
         switchMap(() => {
-          // The Tauri event name isn't carried through merge, but we can
-          // distinguish by checking: daemon:ready always refreshes the
-          // blob port, file-opened always resets cells. Doing both is
-          // safe and idempotent, so we just do both unconditionally.
           refreshBlobPort();
           resetNotebookCells();
           awaitingInitialSyncRef.current = true;
@@ -237,12 +191,7 @@ export function useAutomergeNotebook() {
       )
       .subscribe();
 
-    // ── Inbound frame pipeline (RxJS) ───────────────────────────────
-    //
-    // All frame types (AutomergeSync, Broadcast, Presence) arrive through
-    // one Tauri event. The RxJS pipeline owns WASM demux, coalescing,
-    // materialization, and fan-out to the frame bus. Replaces the old
-    // imperative listener + scheduleMaterialize + 3 timer/accumulator refs.
+    // Inbound frame pipeline (WASM demux → coalesce → materialize → store).
     const frameSub = createFramePipeline({
       getHandle: () => handleRef.current,
       getAwaitingInitialSync: () => awaitingInitialSyncRef.current,
@@ -254,8 +203,6 @@ export function useAutomergeNotebook() {
       outputCache: outputCacheRef.current,
       onSyncApplied: () => syncReply$.current.next(),
     });
-
-    // ── Debounced outbound sync pipelines (RxJS) ────────────────────
 
     // Source sync: 20ms debounce for batching rapid keystrokes.
     const sourceSyncSub = sourceSync$.current
@@ -279,8 +226,8 @@ export function useAutomergeNotebook() {
         }
       });
 
-    // ── Bulk output clearing (run-all / restart-and-run-all) ─────────
-    const unlistenClearOutputs = fromTauriEvent<string[]>(
+    // Bulk output clearing (run-all / restart-and-run-all).
+    const clearOutputsSub = fromTauriEvent<string[]>(
       "cells:outputs_cleared",
     ).subscribe((payload) => {
       const clearedIds = new Set(payload);
@@ -297,13 +244,11 @@ export function useAutomergeNotebook() {
       cancelled = true;
       frameSub.unsubscribe();
       lifecycleSub.unsubscribe();
-      // Unsubscribe debounce pipelines (cancels pending timers)
       sourceSyncSub.unsubscribe();
       syncReplySub.unsubscribe();
-      unlistenClearOutputs.unsubscribe();
-      // Flush any pending sync before teardown — unsubscribing the
-      // debounce pipelines above cancels their timers, so we do a
-      // final sync + reply here to avoid dropping in-flight changes.
+      clearOutputsSub.unsubscribe();
+
+      // Flush pending sync before freeing handle.
       if (handleRef.current) {
         syncToRelay(handleRef.current);
         const reply = handleRef.current.generate_sync_reply();
@@ -313,7 +258,7 @@ export function useAutomergeNotebook() {
           );
         }
       }
-      // Free WASM handle.
+
       resetNotebookCells();
       setNotebookHandle(null);
       handleRef.current?.free();
@@ -327,17 +272,11 @@ export function useAutomergeNotebook() {
     const handle = handleRef.current;
     if (!handle || awaitingInitialSyncRef.current) return;
 
-    // Mutate WASM (instant, local-first)
     const updated = handle.update_source(cellId, source);
     if (!updated) return;
 
-    // Fast-path: update only the affected cell in the store — triggers only
-    // that cell's subscribers, not all cells.
     updateCellById(cellId, (c) => ({ ...c, source }));
-
-    // Debounced sync to daemon — batches rapid keystrokes
     sourceSync$.current.next();
-
     setDirty(true);
   }, []);
 
@@ -351,9 +290,7 @@ export function useAutomergeNotebook() {
     (cellType: "code" | "markdown" | "raw", afterCellId?: string | null) => {
       const handle = handleRef.current;
 
-      // Don't allow adding cells while bootstrapping or if no handle
       if (!handle || awaitingInitialSyncRef.current) {
-        // Return a placeholder cell without mutating state
         const placeholderId = crypto.randomUUID();
         return cellType === "code"
           ? {
@@ -373,20 +310,12 @@ export function useAutomergeNotebook() {
       }
 
       const cellId = crypto.randomUUID();
-
-      // Mutate WASM (instant, local-first)
       handle.add_cell_after(cellId, cellType, afterCellId ?? null);
-
-      // Re-read from WASM (single source of truth)
       rematerializeCellsSync(handle);
-
-      // Sync to daemon (fire-and-forget)
       syncToRelay(handle);
-
       setFocusedCellId(cellId);
       setDirty(true);
 
-      // Return the cell from the store (derived from WASM)
       const cell = getNotebookCellsSnapshot().find((c) => c.id === cellId);
       return (
         cell ?? {
@@ -405,124 +334,69 @@ export function useAutomergeNotebook() {
 
   const moveCell = useCallback(
     (cellId: string, afterCellId?: string | null) => {
-      const handle = handleRef.current;
-      if (!handle || awaitingInitialSyncRef.current) return;
-
-      // Mutate WASM (instant, local-first)
-      handle.move_cell(cellId, afterCellId ?? null);
-
-      // Re-read from WASM (single source of truth)
-      rematerializeCellsSync(handle);
-
-      // Sync to daemon (fire-and-forget)
-      syncToRelay(handle);
-
-      setDirty(true);
+      commitMutation((handle) => {
+        handle.move_cell(cellId, afterCellId ?? null);
+      });
     },
-    [rematerializeCellsSync, syncToRelay],
+    [commitMutation],
   );
 
   const deleteCell = useCallback(
     (cellId: string) => {
-      const handle = handleRef.current;
-      if (!handle || awaitingInitialSyncRef.current) return;
-
-      // Guard: never delete the last cell
-      if (handle.cell_count() <= 1) return;
-
-      // Mutate WASM (instant, local-first)
-      const deleted = handle.delete_cell(cellId);
-      if (!deleted) return;
-
-      // Re-read from WASM (single source of truth)
-      rematerializeCellsSync(handle);
-
-      // Sync to daemon (fire-and-forget)
-      syncToRelay(handle);
-
-      setDirty(true);
+      commitMutation((handle) => {
+        if (handle.cell_count() <= 1) return false;
+        const deleted = handle.delete_cell(cellId);
+        if (!deleted) return false;
+      });
     },
-    [rematerializeCellsSync, syncToRelay],
+    [commitMutation],
   );
 
-  /**
-   * Flush any pending debounced sync immediately so the daemon has the
-   * latest source. Call before execute/runAll to avoid stale code.
-   */
+  const setCellSourceHidden = useCallback(
+    (cellId: string, hidden: boolean) => {
+      commitMutation((handle) => {
+        const updated = handle.set_cell_source_hidden(cellId, hidden);
+        if (!updated) return false;
+      });
+    },
+    [commitMutation],
+  );
+
+  const setCellOutputsHidden = useCallback(
+    (cellId: string, hidden: boolean) => {
+      commitMutation((handle) => {
+        const updated = handle.set_cell_outputs_hidden(cellId, hidden);
+        if (!updated) return false;
+      });
+    },
+    [commitMutation],
+  );
+
+  // ── Sync flush ─────────────────────────────────────────────────────
+
+  /** Flush pending debounced sync immediately (call before execute/save). */
   const flushSync = useCallback(async () => {
     const handle = handleRef.current;
     if (!handle) return;
-
-    // Generate and send sync message immediately, bypassing the debounce.
-    // Any pending debounced emission becomes a no-op (generate_sync_message
-    // returns null when there's nothing new to sync).
+    // Bypasses the debounce; any pending emission becomes a no-op.
     const msg = handle.generate_sync_message();
     if (msg) {
       await sendFrame(frame_types.AUTOMERGE_SYNC, msg);
     }
   }, []);
 
-  // ── Save / Open / Clone ────────────────────────────────────────────
+  // ── File operations ────────────────────────────────────────────────
 
   const save = useCallback(async () => {
-    try {
-      // Flush any pending sync so the daemon has the latest source before
-      // writing to disk.
-      await flushSync();
-
-      const hasPath = await invoke<boolean>("has_notebook_path");
-
-      if (hasPath) {
-        await invoke("save_notebook");
-      } else {
-        const defaultDir = await invoke<string>("get_default_save_directory");
-        const filePath = await saveDialog({
-          filters: [{ name: "Jupyter Notebook", extensions: ["ipynb"] }],
-          defaultPath: `${defaultDir}/Untitled.ipynb`,
-        });
-        if (!filePath) return;
-        await invoke("save_notebook_as", { path: filePath });
-      }
-
-      setDirty(false);
-    } catch (e) {
-      logger.error("[automerge-notebook] Save failed:", e);
-    }
+    const saved = await saveNotebook(flushSync);
+    if (saved) setDirty(false);
   }, [flushSync]);
 
-  const openNotebook = useCallback(async () => {
-    try {
-      const filePath = await openDialog({
-        multiple: false,
-        filters: [{ name: "Jupyter Notebook", extensions: ["ipynb"] }],
-      });
-      if (!filePath || typeof filePath !== "string") return;
-      await invoke("open_notebook_in_new_window", { path: filePath });
-    } catch (e) {
-      logger.error("[automerge-notebook] Open failed:", e);
-    }
-  }, []);
+  const openNotebook = useCallback(() => openNotebookFile(), []);
 
-  const cloneNotebook = useCallback(async () => {
-    try {
-      const defaultDir = await invoke<string>("get_default_save_directory");
-      const filePath = await saveDialog({
-        filters: [{ name: "Jupyter Notebook", extensions: ["ipynb"] }],
-        defaultPath: `${defaultDir}/Untitled-Clone.ipynb`,
-      });
-      if (!filePath) return;
-      await invoke("clone_notebook_to_path", { path: filePath });
-      await invoke("open_notebook_in_new_window", { path: filePath });
-    } catch (e) {
-      logger.error("[automerge-notebook] Clone failed:", e);
-    }
-  }, []);
+  const cloneNotebook = useCallback(() => cloneNotebookFile(), []);
 
-  // ── Output / execution (optimistic overlays) ───────────────────────
-  //
-  // Canonical outputs arrive through Automerge sync (materializeCells).
-  // These callbacks give instant feedback from daemon broadcasts for
-  // display updates and execution counts before sync lands.
+  // ── Output overlays (optimistic, pre-sync) ─────────────────────────
 
   const updateOutputByDisplayId = useCallback(
     (
@@ -557,48 +431,6 @@ export function useAutomergeNotebook() {
       c.cell_type === "code" ? { ...c, execution_count: count } : c,
     );
   }, []);
-
-  // ── Cell visibility ─────────────────────────────────────────────────
-
-  const setCellSourceHidden = useCallback(
-    (cellId: string, hidden: boolean) => {
-      const handle = handleRef.current;
-      if (!handle || awaitingInitialSyncRef.current) return;
-
-      // Mutate WASM (instant, local-first)
-      const updated = handle.set_cell_source_hidden(cellId, hidden);
-      if (!updated) return;
-
-      // Re-read from WASM (single source of truth)
-      rematerializeCellsSync(handle);
-
-      // Sync to daemon (fire-and-forget)
-      syncToRelay(handle);
-
-      setDirty(true);
-    },
-    [rematerializeCellsSync, syncToRelay],
-  );
-
-  const setCellOutputsHidden = useCallback(
-    (cellId: string, hidden: boolean) => {
-      const handle = handleRef.current;
-      if (!handle || awaitingInitialSyncRef.current) return;
-
-      // Mutate WASM (instant, local-first)
-      const updated = handle.set_cell_outputs_hidden(cellId, hidden);
-      if (!updated) return;
-
-      // Re-read from WASM (single source of truth)
-      rematerializeCellsSync(handle);
-
-      // Sync to daemon (fire-and-forget)
-      syncToRelay(handle);
-
-      setDirty(true);
-    },
-    [rematerializeCellsSync, syncToRelay],
-  );
 
   // ── Public interface ───────────────────────────────────────────────
 

--- a/apps/notebook/src/lib/__tests__/cell-changeset.test.ts
+++ b/apps/notebook/src/lib/__tests__/cell-changeset.test.ts
@@ -3,7 +3,7 @@ import {
   type CellChangeset,
   type ChangedFields,
   mergeChangesets,
-} from "../frame-pipeline";
+} from "../cell-changeset";
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/apps/notebook/src/lib/__tests__/cell-changeset.test.ts
+++ b/apps/notebook/src/lib/__tests__/cell-changeset.test.ts
@@ -1,53 +1,9 @@
 import { describe, expect, it } from "vitest";
-
-// ---------------------------------------------------------------------------
-// CellChangeset types — mirrors the Rust `notebook_doc::diff` types.
-// Duplicated here from useAutomergeNotebook.ts because those are module-private.
-// If we ever extract them to a shared module, these tests should import from there.
-// ---------------------------------------------------------------------------
-
-interface ChangedFields {
-  source?: boolean;
-  outputs?: boolean;
-  execution_count?: boolean;
-  cell_type?: boolean;
-  metadata?: boolean;
-  position?: boolean;
-  resolved_assets?: boolean;
-}
-
-interface ChangedCell {
-  cell_id: string;
-  fields: ChangedFields;
-}
-
-interface CellChangeset {
-  changed: ChangedCell[];
-  added: string[];
-  removed: string[];
-  order_changed: boolean;
-}
-
-/** Merge two CellChangesets (same logic as in useAutomergeNotebook.ts). */
-function mergeChangesets(a: CellChangeset, b: CellChangeset): CellChangeset {
-  const changedMap = new Map<string, ChangedFields>();
-  for (const c of [...a.changed, ...b.changed]) {
-    const existing = changedMap.get(c.cell_id);
-    if (existing) {
-      for (const [key, val] of Object.entries(c.fields)) {
-        if (val) (existing as Record<string, boolean>)[key] = true;
-      }
-    } else {
-      changedMap.set(c.cell_id, { ...c.fields });
-    }
-  }
-  return {
-    changed: [...changedMap].map(([cell_id, fields]) => ({ cell_id, fields })),
-    added: [...new Set([...a.added, ...b.added])],
-    removed: [...new Set([...a.removed, ...b.removed])],
-    order_changed: a.order_changed || b.order_changed,
-  };
-}
+import {
+  type CellChangeset,
+  type ChangedFields,
+  mergeChangesets,
+} from "../frame-pipeline";
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/apps/notebook/src/lib/__tests__/frame-pipeline.test.ts
+++ b/apps/notebook/src/lib/__tests__/frame-pipeline.test.ts
@@ -3,7 +3,7 @@ import {
   type CellChangeset,
   type ChangedFields,
   mergeChangesets,
-} from "../frame-pipeline";
+} from "../cell-changeset";
 
 // ---------------------------------------------------------------------------
 // mergeChangesets — merges two CellChangesets produced by successive WASM
@@ -153,17 +153,13 @@ describe("mergeChangesets", () => {
     // If both changesets mark the same field as true, result should be true.
     // If only one does, the field should still be true (union, not intersection).
     const a: CellChangeset = {
-      changed: [
-        { cell_id: "c1", fields: { source: true, outputs: true } },
-      ],
+      changed: [{ cell_id: "c1", fields: { source: true, outputs: true } }],
       added: [],
       removed: [],
       order_changed: false,
     };
     const b: CellChangeset = {
-      changed: [
-        { cell_id: "c1", fields: { source: true, metadata: true } },
-      ],
+      changed: [{ cell_id: "c1", fields: { source: true, metadata: true } }],
       added: [],
       removed: [],
       order_changed: false,

--- a/apps/notebook/src/lib/__tests__/frame-pipeline.test.ts
+++ b/apps/notebook/src/lib/__tests__/frame-pipeline.test.ts
@@ -1,0 +1,253 @@
+import { describe, expect, it } from "vitest";
+import {
+  type CellChangeset,
+  type ChangedFields,
+  mergeChangesets,
+} from "../frame-pipeline";
+
+// ---------------------------------------------------------------------------
+// mergeChangesets — merges two CellChangesets produced by successive WASM
+// sync frames within a coalescing window.
+// ---------------------------------------------------------------------------
+
+describe("mergeChangesets", () => {
+  const empty: CellChangeset = {
+    changed: [],
+    added: [],
+    removed: [],
+    order_changed: false,
+  };
+
+  it("merges two empty changesets", () => {
+    const result = mergeChangesets(empty, empty);
+    expect(result).toEqual(empty);
+  });
+
+  it("merges when first changeset is empty", () => {
+    const b: CellChangeset = {
+      changed: [{ cell_id: "c1", fields: { source: true } }],
+      added: ["c2"],
+      removed: [],
+      order_changed: false,
+    };
+    const result = mergeChangesets(empty, b);
+    expect(result.changed).toEqual([
+      { cell_id: "c1", fields: { source: true } },
+    ]);
+    expect(result.added).toEqual(["c2"]);
+  });
+
+  it("merges when second changeset is empty", () => {
+    const a: CellChangeset = {
+      changed: [{ cell_id: "c1", fields: { outputs: true } }],
+      added: [],
+      removed: ["c3"],
+      order_changed: true,
+    };
+    const result = mergeChangesets(a, empty);
+    expect(result.changed).toEqual([
+      { cell_id: "c1", fields: { outputs: true } },
+    ]);
+    expect(result.removed).toEqual(["c3"]);
+    expect(result.order_changed).toBe(true);
+  });
+
+  it("unions changed fields for the same cell_id", () => {
+    const a: CellChangeset = {
+      changed: [{ cell_id: "c1", fields: { source: true } }],
+      added: [],
+      removed: [],
+      order_changed: false,
+    };
+    const b: CellChangeset = {
+      changed: [
+        { cell_id: "c1", fields: { outputs: true, execution_count: true } },
+      ],
+      added: [],
+      removed: [],
+      order_changed: false,
+    };
+    const result = mergeChangesets(a, b);
+    expect(result.changed).toHaveLength(1);
+    expect(result.changed[0].cell_id).toBe("c1");
+    expect(result.changed[0].fields).toEqual({
+      source: true,
+      outputs: true,
+      execution_count: true,
+    });
+  });
+
+  it("keeps distinct cells separate", () => {
+    const a: CellChangeset = {
+      changed: [{ cell_id: "c1", fields: { source: true } }],
+      added: [],
+      removed: [],
+      order_changed: false,
+    };
+    const b: CellChangeset = {
+      changed: [{ cell_id: "c2", fields: { metadata: true } }],
+      added: [],
+      removed: [],
+      order_changed: false,
+    };
+    const result = mergeChangesets(a, b);
+    expect(result.changed).toHaveLength(2);
+    const ids = result.changed.map((c) => c.cell_id).sort();
+    expect(ids).toEqual(["c1", "c2"]);
+  });
+
+  it("deduplicates added cell IDs", () => {
+    const a: CellChangeset = {
+      changed: [],
+      added: ["c1", "c2"],
+      removed: [],
+      order_changed: false,
+    };
+    const b: CellChangeset = {
+      changed: [],
+      added: ["c2", "c3"],
+      removed: [],
+      order_changed: false,
+    };
+    const result = mergeChangesets(a, b);
+    expect(result.added).toEqual(["c1", "c2", "c3"]);
+  });
+
+  it("deduplicates removed cell IDs", () => {
+    const a: CellChangeset = {
+      changed: [],
+      added: [],
+      removed: ["c1"],
+      order_changed: false,
+    };
+    const b: CellChangeset = {
+      changed: [],
+      added: [],
+      removed: ["c1", "c2"],
+      order_changed: false,
+    };
+    const result = mergeChangesets(a, b);
+    expect(result.removed).toEqual(["c1", "c2"]);
+  });
+
+  it("propagates order_changed if either is true", () => {
+    const a: CellChangeset = {
+      changed: [],
+      added: [],
+      removed: [],
+      order_changed: false,
+    };
+    const b: CellChangeset = {
+      changed: [],
+      added: [],
+      removed: [],
+      order_changed: true,
+    };
+    expect(mergeChangesets(a, b).order_changed).toBe(true);
+    expect(mergeChangesets(b, a).order_changed).toBe(true);
+    expect(mergeChangesets(b, b).order_changed).toBe(true);
+    expect(mergeChangesets(a, a).order_changed).toBe(false);
+  });
+
+  it("does not set false fields when merging overlapping field keys", () => {
+    // If both changesets mark the same field as true, result should be true.
+    // If only one does, the field should still be true (union, not intersection).
+    const a: CellChangeset = {
+      changed: [
+        { cell_id: "c1", fields: { source: true, outputs: true } },
+      ],
+      added: [],
+      removed: [],
+      order_changed: false,
+    };
+    const b: CellChangeset = {
+      changed: [
+        { cell_id: "c1", fields: { source: true, metadata: true } },
+      ],
+      added: [],
+      removed: [],
+      order_changed: false,
+    };
+    const result = mergeChangesets(a, b);
+    const fields = result.changed[0].fields;
+    expect(fields.source).toBe(true);
+    expect(fields.outputs).toBe(true);
+    expect(fields.metadata).toBe(true);
+  });
+
+  it("handles all ChangedFields keys", () => {
+    const allFields: ChangedFields = {
+      source: true,
+      outputs: true,
+      execution_count: true,
+      cell_type: true,
+      metadata: true,
+      position: true,
+      resolved_assets: true,
+    };
+    const a: CellChangeset = {
+      changed: [{ cell_id: "c1", fields: { source: true, outputs: true } }],
+      added: [],
+      removed: [],
+      order_changed: false,
+    };
+    const b: CellChangeset = {
+      changed: [
+        {
+          cell_id: "c1",
+          fields: {
+            execution_count: true,
+            cell_type: true,
+            metadata: true,
+            position: true,
+            resolved_assets: true,
+          },
+        },
+      ],
+      added: [],
+      removed: [],
+      order_changed: false,
+    };
+    const result = mergeChangesets(a, b);
+    expect(result.changed[0].fields).toEqual(allFields);
+  });
+
+  it("does not mutate input changesets", () => {
+    const a: CellChangeset = {
+      changed: [{ cell_id: "c1", fields: { source: true } }],
+      added: ["c2"],
+      removed: [],
+      order_changed: false,
+    };
+    const b: CellChangeset = {
+      changed: [{ cell_id: "c1", fields: { outputs: true } }],
+      added: ["c3"],
+      removed: ["c4"],
+      order_changed: true,
+    };
+
+    // Snapshot originals
+    const aJson = JSON.stringify(a);
+    const bJson = JSON.stringify(b);
+
+    mergeChangesets(a, b);
+
+    expect(JSON.stringify(a)).toBe(aJson);
+    expect(JSON.stringify(b)).toBe(bJson);
+  });
+
+  it("handles many cells across multiple merges (chained)", () => {
+    let acc = empty;
+    for (let i = 0; i < 100; i++) {
+      const cs: CellChangeset = {
+        changed: [{ cell_id: `c${i}`, fields: { source: true } }],
+        added: i % 10 === 0 ? [`new-${i}`] : [],
+        removed: [],
+        order_changed: false,
+      };
+      acc = mergeChangesets(acc, cs);
+    }
+    expect(acc.changed).toHaveLength(100);
+    expect(acc.added).toHaveLength(10);
+  });
+});

--- a/apps/notebook/src/lib/cell-changeset.ts
+++ b/apps/notebook/src/lib/cell-changeset.ts
@@ -1,0 +1,67 @@
+/**
+ * CellChangeset types and merge utilities.
+ *
+ * Pure module with zero external dependencies — safe to import from
+ * unit tests without pulling in Tauri, RxJS, or WASM runtime.
+ *
+ * Mirrors the Rust `notebook_doc::diff` types serialized from WASM
+ * via serde-wasm-bindgen.
+ */
+
+// ── Types ────────────────────────────────────────────────────────────
+
+/** Which fields changed on a cell (only `true` keys are present). */
+export interface ChangedFields {
+  source?: boolean;
+  outputs?: boolean;
+  execution_count?: boolean;
+  cell_type?: boolean;
+  metadata?: boolean;
+  position?: boolean;
+  resolved_assets?: boolean;
+}
+
+export interface ChangedCell {
+  cell_id: string;
+  fields: ChangedFields;
+}
+
+/** Structural diff between two Automerge head sets, produced by WASM `diff_cells`. */
+export interface CellChangeset {
+  changed: ChangedCell[];
+  added: string[];
+  removed: string[];
+  order_changed: boolean;
+}
+
+// ── Utilities ────────────────────────────────────────────────────────
+
+/**
+ * Merge two CellChangesets (for coalescing frames across a buffer window).
+ *
+ * Field unions are additive — if either changeset marks a field as changed,
+ * the merged result marks it as changed. Added/removed lists are deduplicated.
+ * `order_changed` is true if either input is true.
+ */
+export function mergeChangesets(
+  a: CellChangeset,
+  b: CellChangeset,
+): CellChangeset {
+  const changedMap = new Map<string, ChangedFields>();
+  for (const c of [...a.changed, ...b.changed]) {
+    const existing = changedMap.get(c.cell_id);
+    if (existing) {
+      for (const [key, val] of Object.entries(c.fields)) {
+        if (val) (existing as Record<string, boolean>)[key] = true;
+      }
+    } else {
+      changedMap.set(c.cell_id, { ...c.fields });
+    }
+  }
+  return {
+    changed: [...changedMap].map(([cell_id, fields]) => ({ cell_id, fields })),
+    added: [...new Set([...a.added, ...b.added])],
+    removed: [...new Set([...a.removed, ...b.removed])],
+    order_changed: a.order_changed || b.order_changed,
+  };
+}

--- a/apps/notebook/src/lib/frame-pipeline.ts
+++ b/apps/notebook/src/lib/frame-pipeline.ts
@@ -1,0 +1,399 @@
+/**
+ * Inbound frame processing pipeline (Pipeline 1).
+ *
+ * Replaces the imperative `notebook:frame` listener, `scheduleMaterialize`,
+ * and three timer/accumulator refs from `useAutomergeNotebook` with a
+ * declarative RxJS pipeline that splits incoming frames into sub-streams:
+ *
+ *   1. sync_applied → coalesce (32ms buffer) → materialize → write to store
+ *   2. sync_applied attributions → emitBroadcast
+ *   3. broadcast → emitBroadcast
+ *   4. presence → emitPresence
+ *
+ * Usage (in useEffect):
+ *   const sub = createFramePipeline(deps);
+ *   return () => sub.unsubscribe();
+ *
+ * Web-worker future: the `mergeMap(payload => ...)` that calls WASM
+ * `receive_frame` becomes a `switchMap` through the worker bridge. The
+ * rest of the pipeline (coalesce, materialize, write to store) stays
+ * identical.
+ */
+
+import {
+  EMPTY,
+  Subject,
+  Subscription,
+  from,
+  bufferTime,
+  filter,
+  mergeMap,
+  share,
+} from "rxjs";
+
+import type { JupyterOutput } from "../types";
+import type { NotebookHandle } from "../wasm/runtimed-wasm/runtimed_wasm.js";
+import { getBlobPort, refreshBlobPort } from "./blob-port";
+import { logger } from "./logger";
+import {
+  isManifestHash,
+  materializeCellFromWasm,
+  resolveOutput,
+} from "./materialize-cells";
+import { getCellById, updateCellById } from "./notebook-cells";
+import { emitBroadcast, emitPresence } from "./notebook-frame-bus";
+import { notifyMetadataChanged } from "./notebook-metadata";
+import { fromTauriEvent } from "./tauri-rx";
+
+// ── Constants ────────────────────────────────────────────────────────
+
+/** Coalescing window for incoming sync frames (ms). */
+const COALESCE_MS = 32;
+
+// ── CellChangeset types ─────────────────────────────────────────────
+//
+// Mirrors the Rust `notebook_doc::diff` types serialized from WASM via
+// serde-wasm-bindgen. Moved here from useAutomergeNotebook so the
+// pipeline owns the types it operates on.
+// ─────────────────────────────────────────────────────────────────────
+
+/** Which fields changed on a cell (only `true` keys are present). */
+export interface ChangedFields {
+  source?: boolean;
+  outputs?: boolean;
+  execution_count?: boolean;
+  cell_type?: boolean;
+  metadata?: boolean;
+  position?: boolean;
+  resolved_assets?: boolean;
+}
+
+export interface ChangedCell {
+  cell_id: string;
+  fields: ChangedFields;
+}
+
+/** Structural diff between two Automerge head sets, produced by WASM `diff_cells`. */
+export interface CellChangeset {
+  changed: ChangedCell[];
+  added: string[];
+  removed: string[];
+  order_changed: boolean;
+}
+
+/** Merge two CellChangesets (for coalescing frames across the buffer window). */
+export function mergeChangesets(
+  a: CellChangeset,
+  b: CellChangeset,
+): CellChangeset {
+  const changedMap = new Map<string, ChangedFields>();
+  for (const c of [...a.changed, ...b.changed]) {
+    const existing = changedMap.get(c.cell_id);
+    if (existing) {
+      for (const [key, val] of Object.entries(c.fields)) {
+        if (val) (existing as Record<string, boolean>)[key] = true;
+      }
+    } else {
+      changedMap.set(c.cell_id, { ...c.fields });
+    }
+  }
+  return {
+    changed: [...changedMap].map(([cell_id, fields]) => ({ cell_id, fields })),
+    added: [...new Set([...a.added, ...b.added])],
+    removed: [...new Set([...a.removed, ...b.removed])],
+    order_changed: a.order_changed || b.order_changed,
+  };
+}
+
+// ── Internal types ──────────────────────────────────────────────────
+
+/** Attribution for text changes, produced by WASM sync. */
+interface TextAttribution {
+  cell_id: string;
+  index: number;
+  text: string;
+  deleted: number;
+  actors: string[];
+}
+
+/** Typed event returned by WASM `receive_frame()`. */
+interface FrameEvent {
+  type: string;
+  changed?: boolean;
+  changeset?: CellChangeset;
+  attributions?: TextAttribution[];
+  payload?: unknown;
+}
+
+// ── Pipeline dependencies ───────────────────────────────────────────
+
+/**
+ * External dependencies injected by the hook.
+ *
+ * Getters read from React refs at event-processing time (not capture
+ * time) so the pipeline never holds stale closures across bootstrap
+ * cycles (daemon:ready, file-opened, etc.).
+ */
+export interface FramePipelineDeps {
+  /** Read the current WASM handle (null during bootstrap). */
+  getHandle: () => NotebookHandle | null;
+
+  /** Check if we're still waiting for the first sync from the daemon. */
+  getAwaitingInitialSync: () => boolean;
+
+  /** Mark initial sync as received. */
+  setAwaitingInitialSync: (value: boolean) => void;
+
+  /** Update the loading state in React. */
+  setIsLoading: (loading: boolean) => void;
+
+  /**
+   * Full materialization: serialize entire doc → resolve manifests →
+   * write to notebook-cells store. The pipeline calls this for initial
+   * sync and structural changes (add/remove/reorder cells).
+   */
+  materializeCells: (handle: NotebookHandle) => Promise<void>;
+
+  /** Shared output manifest cache (mutated in place). */
+  outputCache: Map<string, JupyterOutput>;
+
+  /**
+   * Called after each `sync_applied` event. The hook uses this to
+   * schedule a debounced sync reply (until Phase 2 inlines it as a
+   * `debounceTime` operator).
+   */
+  onSyncApplied: () => void;
+}
+
+// ── Pipeline factory ────────────────────────────────────────────────
+
+/**
+ * Create and subscribe the inbound frame processing pipeline.
+ *
+ * Returns a `Subscription` — call `.unsubscribe()` to tear down the
+ * Tauri event listener, all sub-streams, and the coalescing timer.
+ *
+ * The pipeline is **cold**: nothing happens until this function is
+ * called, and everything is cleaned up when the subscription ends.
+ */
+export function createFramePipeline(deps: FramePipelineDeps): Subscription {
+  const subscription = new Subscription();
+
+  // Subject bridging sync_applied events into the coalescing buffer.
+  // Each emission is a CellChangeset (incremental) or null (needs full).
+  const materialize$ = new Subject<CellChangeset | null>();
+
+  // ── Source: Tauri frames → WASM demux → individual FrameEvents ────
+
+  const frameEvents$ = fromTauriEvent<number[]>("notebook:frame").pipe(
+    mergeMap((payload) => {
+      try {
+        const handle = deps.getHandle();
+        if (!handle) return EMPTY;
+        const bytes = new Uint8Array(payload);
+        const result = handle.receive_frame(bytes);
+        if (!result || !Array.isArray(result)) return EMPTY;
+        return from(result as FrameEvent[]);
+      } catch (e) {
+        logger.warn("[frame-pipeline] receive_frame failed:", e);
+        return EMPTY;
+      }
+    }),
+    share(), // multicast to all sub-pipelines below
+  );
+
+  // ── Sub-pipeline: sync_applied → initial sync / coalesce ──────────
+
+  subscription.add(
+    frameEvents$
+      .pipe(filter((e) => e.type === "sync_applied"))
+      .subscribe((e) => {
+        // ── Initial sync: materialize immediately (no coalescing) ────
+        if (deps.getAwaitingInitialSync()) {
+          deps.setAwaitingInitialSync(false);
+          deps.setIsLoading(false);
+          if (e.changed) {
+            const handle = deps.getHandle();
+            if (handle) {
+              deps.materializeCells(handle).then(
+                () => notifyMetadataChanged(),
+                (err: unknown) =>
+                  logger.warn(
+                    "[frame-pipeline] initial materialize failed:",
+                    err,
+                  ),
+              );
+            }
+          }
+        } else if (e.changed) {
+          // ── Steady-state: push changeset into coalescing buffer ────
+          materialize$.next(e.changeset ?? null);
+        }
+
+        // ── Attributions (text provenance for agent-authored changes) ─
+        if (e.attributions && e.attributions.length > 0) {
+          emitBroadcast({
+            type: "text_attribution",
+            attributions: e.attributions,
+          });
+        }
+
+        // ── Signal for sync reply ────────────────────────────────────
+        deps.onSyncApplied();
+      }),
+  );
+
+  // ── Coalescing buffer → materialization ────────────────────────────
+  //
+  // Collects changesets over a COALESCE_MS window, merges them, then
+  // materializes once. Replaces pendingMaterializeTimerRef +
+  // pendingChangesetRef + pendingFullMaterializeRef.
+
+  subscription.add(
+    materialize$
+      .pipe(
+        bufferTime(COALESCE_MS),
+        filter((batch) => batch.length > 0),
+      )
+      .subscribe((batch) => {
+        materializeFromBatch(batch, deps).catch((err: unknown) =>
+          logger.warn("[frame-pipeline] materialize batch failed:", err),
+        );
+      }),
+  );
+
+  // ── Sub-pipeline: broadcasts ───────────────────────────────────────
+
+  subscription.add(
+    frameEvents$
+      .pipe(filter((e) => e.type === "broadcast" && e.payload != null))
+      .subscribe((e) => emitBroadcast(e.payload)),
+  );
+
+  // ── Sub-pipeline: presence ─────────────────────────────────────────
+
+  subscription.add(
+    frameEvents$
+      .pipe(filter((e) => e.type === "presence" && e.payload != null))
+      .subscribe((e) => emitPresence(e.payload)),
+  );
+
+  return subscription;
+}
+
+// ── Internal: batch materialization ─────────────────────────────────
+
+/**
+ * Process a coalesced batch of changesets.
+ *
+ * Falls back to full materialization when:
+ * - Any frame in the batch lacked a changeset (null entry)
+ * - The merged changeset includes structural changes (add/remove/reorder)
+ *
+ * Otherwise performs surgical per-cell updates using the WASM handle's
+ * per-field accessors — O(changed cells) rather than O(all cells).
+ */
+async function materializeFromBatch(
+  batch: Array<CellChangeset | null>,
+  deps: FramePipelineDeps,
+): Promise<void> {
+  // Read handle at fire time — not capture time — to avoid use-after-free
+  // if bootstrap() replaced/freed the handle during the coalescing window.
+  const handle = deps.getHandle();
+  if (!handle) return;
+
+  // Merge all changesets in the batch.
+  let merged: CellChangeset | null = null;
+  let needsFull = false;
+
+  for (const cs of batch) {
+    if (cs === null) {
+      needsFull = true;
+    } else if (merged === null) {
+      merged = cs;
+    } else {
+      merged = mergeChangesets(merged, cs);
+    }
+  }
+
+  // ── Full materialization fallback ──────────────────────────────────
+
+  if (needsFull || !merged) {
+    await deps.materializeCells(handle);
+    notifyMetadataChanged();
+    return;
+  }
+
+  // Structural changes (cells added/removed/reordered) require full
+  // materialization — the cell ID list and ordering need updating.
+  if (
+    merged.added.length > 0 ||
+    merged.removed.length > 0 ||
+    merged.order_changed
+  ) {
+    await deps.materializeCells(handle);
+    notifyMetadataChanged();
+    return;
+  }
+
+  // ── Per-cell incremental materialization ───────────────────────────
+
+  const cache = deps.outputCache;
+
+  for (const { cell_id: cellId, fields } of merged.changed) {
+    if (fields.outputs) {
+      // Check if every output for this cell is already cached.
+      const rawOutputs: string[] = handle.get_cell_outputs(cellId) ?? [];
+      const allCached = rawOutputs.every(
+        (o) => cache.has(o) || !isManifestHash(o),
+      );
+
+      if (allCached) {
+        // All outputs resolved from cache — fast sync path.
+        const cell = materializeCellFromWasm(
+          handle,
+          cellId,
+          cache,
+          getCellById(cellId),
+        );
+        if (cell) updateCellById(cellId, () => cell);
+      } else {
+        // Cache miss — resolve this cell's outputs async (fetch manifests
+        // from blob store) without re-serializing the entire document.
+        let blobPort = getBlobPort();
+        if (blobPort === null) {
+          blobPort = await refreshBlobPort();
+        }
+        const resolved = (
+          await Promise.all(
+            rawOutputs.map((o) => resolveOutput(o, blobPort, cache)),
+          )
+        ).filter((o): o is JupyterOutput => o !== null);
+
+        const ecStr = handle.get_cell_execution_count(cellId);
+        const ec =
+          !ecStr || ecStr === "null" ? null : Number.parseInt(ecStr, 10);
+        const source = handle.get_cell_source(cellId) ?? "";
+        const metadata = handle.get_cell_metadata(cellId) ?? {};
+
+        updateCellById(cellId, () => ({
+          id: cellId,
+          cell_type: "code" as const,
+          source,
+          execution_count: Number.isNaN(ec) ? null : ec,
+          outputs: resolved,
+          metadata,
+        }));
+      }
+    } else {
+      // No output changes — always use fast sync path.
+      const cell = materializeCellFromWasm(
+        handle,
+        cellId,
+        cache,
+        getCellById(cellId),
+      );
+      if (cell) updateCellById(cellId, () => cell);
+    }
+  }
+}

--- a/apps/notebook/src/lib/frame-pipeline.ts
+++ b/apps/notebook/src/lib/frame-pipeline.ts
@@ -21,14 +21,14 @@
  */
 
 import {
-  EMPTY,
-  Subject,
-  Subscription,
-  from,
   bufferTime,
   concatMap,
+  EMPTY,
   filter,
+  from,
   mergeMap,
+  Subject,
+  Subscription,
   share,
 } from "rxjs";
 

--- a/apps/notebook/src/lib/frame-pipeline.ts
+++ b/apps/notebook/src/lib/frame-pipeline.ts
@@ -26,6 +26,7 @@ import {
   Subscription,
   from,
   bufferTime,
+  concatMap,
   filter,
   mergeMap,
   share,
@@ -34,6 +35,7 @@ import {
 import type { JupyterOutput } from "../types";
 import type { NotebookHandle } from "../wasm/runtimed-wasm/runtimed_wasm.js";
 import { getBlobPort, refreshBlobPort } from "./blob-port";
+import { type CellChangeset, mergeChangesets } from "./cell-changeset";
 import { logger } from "./logger";
 import {
   isManifestHash,
@@ -45,65 +47,18 @@ import { emitBroadcast, emitPresence } from "./notebook-frame-bus";
 import { notifyMetadataChanged } from "./notebook-metadata";
 import { fromTauriEvent } from "./tauri-rx";
 
+// Re-export CellChangeset types so existing consumers don't break.
+export type {
+  CellChangeset,
+  ChangedCell,
+  ChangedFields,
+} from "./cell-changeset";
+export { mergeChangesets } from "./cell-changeset";
+
 // ── Constants ────────────────────────────────────────────────────────
 
 /** Coalescing window for incoming sync frames (ms). */
 const COALESCE_MS = 32;
-
-// ── CellChangeset types ─────────────────────────────────────────────
-//
-// Mirrors the Rust `notebook_doc::diff` types serialized from WASM via
-// serde-wasm-bindgen. Moved here from useAutomergeNotebook so the
-// pipeline owns the types it operates on.
-// ─────────────────────────────────────────────────────────────────────
-
-/** Which fields changed on a cell (only `true` keys are present). */
-export interface ChangedFields {
-  source?: boolean;
-  outputs?: boolean;
-  execution_count?: boolean;
-  cell_type?: boolean;
-  metadata?: boolean;
-  position?: boolean;
-  resolved_assets?: boolean;
-}
-
-export interface ChangedCell {
-  cell_id: string;
-  fields: ChangedFields;
-}
-
-/** Structural diff between two Automerge head sets, produced by WASM `diff_cells`. */
-export interface CellChangeset {
-  changed: ChangedCell[];
-  added: string[];
-  removed: string[];
-  order_changed: boolean;
-}
-
-/** Merge two CellChangesets (for coalescing frames across the buffer window). */
-export function mergeChangesets(
-  a: CellChangeset,
-  b: CellChangeset,
-): CellChangeset {
-  const changedMap = new Map<string, ChangedFields>();
-  for (const c of [...a.changed, ...b.changed]) {
-    const existing = changedMap.get(c.cell_id);
-    if (existing) {
-      for (const [key, val] of Object.entries(c.fields)) {
-        if (val) (existing as Record<string, boolean>)[key] = true;
-      }
-    } else {
-      changedMap.set(c.cell_id, { ...c.fields });
-    }
-  }
-  return {
-    changed: [...changedMap].map(([cell_id, fields]) => ({ cell_id, fields })),
-    added: [...new Set([...a.added, ...b.added])],
-    removed: [...new Set([...a.removed, ...b.removed])],
-    order_changed: a.order_changed || b.order_changed,
-  };
-}
 
 // ── Internal types ──────────────────────────────────────────────────
 
@@ -206,41 +161,58 @@ export function createFramePipeline(deps: FramePipelineDeps): Subscription {
 
   subscription.add(
     frameEvents$
-      .pipe(filter((e) => e.type === "sync_applied"))
-      .subscribe((e) => {
-        // ── Initial sync: materialize immediately (no coalescing) ────
-        if (deps.getAwaitingInitialSync()) {
-          deps.setAwaitingInitialSync(false);
-          deps.setIsLoading(false);
-          if (e.changed) {
-            const handle = deps.getHandle();
-            if (handle) {
-              deps.materializeCells(handle).then(
-                () => notifyMetadataChanged(),
-                (err: unknown) =>
-                  logger.warn(
-                    "[frame-pipeline] initial materialize failed:",
-                    err,
-                  ),
-              );
-            }
+      .pipe(
+        filter((e) => e.type === "sync_applied"),
+        // concatMap serializes async work (initial materialization) so
+        // we don't send a sync reply before the store is populated.
+        concatMap((e) => {
+          // ── Attributions (fire-and-forget, no async work) ──────────
+          if (e.attributions && e.attributions.length > 0) {
+            emitBroadcast({
+              type: "text_attribution",
+              attributions: e.attributions,
+            });
           }
-        } else if (e.changed) {
+
+          // ── Initial sync: materialize immediately (no coalescing) ──
+          if (deps.getAwaitingInitialSync()) {
+            deps.setAwaitingInitialSync(false);
+            deps.setIsLoading(false);
+            if (e.changed) {
+              const handle = deps.getHandle();
+              if (handle) {
+                // Return a promise so concatMap waits for materialization
+                // to complete before signaling the sync reply.
+                return from(
+                  deps
+                    .materializeCells(handle)
+                    .then(() => {
+                      notifyMetadataChanged();
+                      deps.onSyncApplied();
+                    })
+                    .catch((err: unknown) => {
+                      logger.warn(
+                        "[frame-pipeline] initial materialize failed:",
+                        err,
+                      );
+                      deps.onSyncApplied();
+                    }),
+                );
+              }
+            }
+            deps.onSyncApplied();
+            return EMPTY;
+          }
+
           // ── Steady-state: push changeset into coalescing buffer ────
-          materialize$.next(e.changeset ?? null);
-        }
-
-        // ── Attributions (text provenance for agent-authored changes) ─
-        if (e.attributions && e.attributions.length > 0) {
-          emitBroadcast({
-            type: "text_attribution",
-            attributions: e.attributions,
-          });
-        }
-
-        // ── Signal for sync reply ────────────────────────────────────
-        deps.onSyncApplied();
-      }),
+          if (e.changed) {
+            materialize$.next(e.changeset ?? null);
+          }
+          deps.onSyncApplied();
+          return EMPTY;
+        }),
+      )
+      .subscribe(),
   );
 
   // ── Coalescing buffer → materialization ────────────────────────────
@@ -254,12 +226,18 @@ export function createFramePipeline(deps: FramePipelineDeps): Subscription {
       .pipe(
         bufferTime(COALESCE_MS),
         filter((batch) => batch.length > 0),
+        // concatMap(_, 1) serializes materialization — if a batch takes
+        // longer than COALESCE_MS (e.g. blob resolution), subsequent
+        // batches queue rather than overlapping and racing store writes.
+        concatMap((batch) =>
+          from(
+            materializeFromBatch(batch, deps).catch((err: unknown) =>
+              logger.warn("[frame-pipeline] materialize batch failed:", err),
+            ),
+          ),
+        ),
       )
-      .subscribe((batch) => {
-        materializeFromBatch(batch, deps).catch((err: unknown) =>
-          logger.warn("[frame-pipeline] materialize batch failed:", err),
-        );
-      }),
+      .subscribe(),
   );
 
   // ── Sub-pipeline: broadcasts ───────────────────────────────────────

--- a/apps/notebook/src/lib/notebook-file-ops.ts
+++ b/apps/notebook/src/lib/notebook-file-ops.ts
@@ -1,0 +1,85 @@
+import { invoke } from "@tauri-apps/api/core";
+import {
+  open as openDialog,
+  save as saveDialog,
+} from "@tauri-apps/plugin-dialog";
+import { logger } from "./logger";
+
+/**
+ * Notebook file operations — save, open, clone.
+ *
+ * Pure Tauri IPC calls with no WASM/sync/store dependencies.
+ * Extracted from useAutomergeNotebook to keep the hook focused on
+ * document sync and cell mutations.
+ */
+
+/**
+ * Save the current notebook to disk.
+ *
+ * If the notebook already has a path, saves in place. Otherwise opens
+ * a save dialog for the user to choose a location.
+ *
+ * @param flushSync - Flush any pending debounced sync before saving so
+ *   the daemon has the latest source when writing to disk.
+ * @returns `true` if saved successfully, `false` on cancel or error.
+ */
+export async function saveNotebook(
+  flushSync: () => Promise<void>,
+): Promise<boolean> {
+  try {
+    await flushSync();
+
+    const hasPath = await invoke<boolean>("has_notebook_path");
+
+    if (hasPath) {
+      await invoke("save_notebook");
+    } else {
+      const defaultDir = await invoke<string>("get_default_save_directory");
+      const filePath = await saveDialog({
+        filters: [{ name: "Jupyter Notebook", extensions: ["ipynb"] }],
+        defaultPath: `${defaultDir}/Untitled.ipynb`,
+      });
+      if (!filePath) return false;
+      await invoke("save_notebook_as", { path: filePath });
+    }
+
+    return true;
+  } catch (e) {
+    logger.error("[notebook-file-ops] Save failed:", e);
+    return false;
+  }
+}
+
+/**
+ * Open a notebook file in a new window via a file picker dialog.
+ */
+export async function openNotebookFile(): Promise<void> {
+  try {
+    const filePath = await openDialog({
+      multiple: false,
+      filters: [{ name: "Jupyter Notebook", extensions: ["ipynb"] }],
+    });
+    if (!filePath || typeof filePath !== "string") return;
+    await invoke("open_notebook_in_new_window", { path: filePath });
+  } catch (e) {
+    logger.error("[notebook-file-ops] Open failed:", e);
+  }
+}
+
+/**
+ * Clone the current notebook to a new file and open it in a new window.
+ */
+export async function cloneNotebookFile(): Promise<void> {
+  try {
+    const defaultDir = await invoke<string>("get_default_save_directory");
+    const filePath = await saveDialog({
+      filters: [{ name: "Jupyter Notebook", extensions: ["ipynb"] }],
+      defaultPath: `${defaultDir}/Untitled-Clone.ipynb`,
+    });
+    if (!filePath) return;
+    await invoke("clone_notebook_to_path", { path: filePath });
+    await invoke("open_notebook_in_new_window", { path: filePath });
+  } catch (e) {
+    logger.error("[notebook-file-ops] Clone failed:", e);
+  }
+}

--- a/apps/notebook/src/lib/tauri-rx.ts
+++ b/apps/notebook/src/lib/tauri-rx.ts
@@ -1,0 +1,42 @@
+import { getCurrentWebview } from "@tauri-apps/api/webview";
+import { Observable } from "rxjs";
+
+/**
+ * Create an Observable from a Tauri webview event listener.
+ *
+ * Subscribing starts listening; unsubscribing tears down the listener.
+ * Each emission is the `event.payload` — the Tauri `Event<T>` wrapper
+ * is unwrapped automatically.
+ *
+ * ```ts
+ * fromTauriEvent<number[]>("notebook:frame").subscribe(payload => {
+ *   // payload is number[], not Event<number[]>
+ * });
+ * ```
+ *
+ * The returned Observable is **cold** — each subscriber gets its own
+ * Tauri listener. Use `share()` or `shareReplay()` to multicast.
+ */
+export function fromTauriEvent<T>(eventName: string): Observable<T> {
+  return new Observable<T>((subscriber) => {
+    const webview = getCurrentWebview();
+
+    // webview.listen returns Promise<UnlistenFn>. We stash the promise
+    // so we can unlisten on teardown even if subscribe is called before
+    // the listener is fully registered.
+    const unlistenPromise = webview.listen<T>(eventName, (event) => {
+      subscriber.next(event.payload);
+    });
+
+    // If the listen call itself rejects (e.g. webview destroyed), surface
+    // the error through the Observable.
+    unlistenPromise.catch((err: unknown) => {
+      subscriber.error(err);
+    });
+
+    // Teardown: unlisten when the subscriber unsubscribes.
+    return () => {
+      unlistenPromise.then((fn) => fn()).catch(() => {});
+    };
+  });
+}

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "rehype-raw": "^7.0.0",
     "remark-gfm": "^4.0.1",
     "remark-math": "^6.0.0",
+    "rxjs": "^7.8.2",
     "tailwind-merge": "^3.4.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "rehype-raw": "^7.0.0",
     "remark-gfm": "^4.0.1",
     "remark-math": "^6.0.0",
-    "rxjs": "^7.8.2",
     "tailwind-merge": "^3.4.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -173,9 +173,6 @@ importers:
       remark-math:
         specifier: ^6.0.0
         version: 6.0.0
-      rxjs:
-        specifier: ^7.8.2
-        version: 7.8.2
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.5.0
@@ -363,6 +360,9 @@ importers:
       remark-math:
         specifier: ^6.0.0
         version: 6.0.0
+      rxjs:
+        specifier: ^7.8.2
+        version: 7.8.2
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.5.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -173,6 +173,9 @@ importers:
       remark-math:
         specifier: ^6.0.0
         version: 6.0.0
+      rxjs:
+        specifier: ^7.8.2
+        version: 7.8.2
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.5.0


### PR DESCRIPTION
# RxJS Migration for `useAutomergeNotebook`

Replaces imperative timer/accumulator patterns in `useAutomergeNotebook.ts` with declarative RxJS pipelines. Each phase is a separate commit.

## Phases

### Phase 1: Add RxJS + extract inbound frame pipeline ✅
- **New dep**: `rxjs` (~30KB gzipped, tree-shakeable)
- **`lib/tauri-rx.ts`**: `fromTauriEvent()` — cold Observable adapter for Tauri webview events
- **`lib/frame-pipeline.ts`**: `createFramePipeline()` with 4 sub-streams:
  1. `sync_applied` → `bufferTime(32ms)` coalesce → materialize → write to store
  2. `sync_applied` attributions → `emitBroadcast`
  3. `broadcast` → `emitBroadcast`
  4. `presence` → `emitPresence`
- **Removed from hook**: `scheduleMaterialize` callback (~100 lines), `pendingMaterializeTimerRef`, `pendingFullMaterializeRef`, `pendingChangesetRef`
- `CellChangeset` types + `mergeChangesets()` extracted as public exports; existing tests updated to import from shared module
- Stores and React hooks **untouched**

### Phase 2: Extract sync reply + source debounce pipelines 🔄
Two `debounceTime` one-liners replace `scheduleSyncReply` and `debouncedSyncToRelay`.

### Phase 3: Merge daemon lifecycle events into one observable
Replace scattered `webview.listen("daemon:ready")` and `webview.listen("notebook:file-opened")` with a merged lifecycle observable.

### Phase 4: Clean up — shrink `useAutomergeNotebook`
After all pipelines extracted, the hook becomes a thin orchestrator (~400 lines down from 897).

## Why

The key insight for the **web worker future**: with RxJS, the worker bridge becomes a transparent `switchMap` operator swap in Pipeline 1. The rest of the pipeline (coalesce, materialize, write to store) stays identical. No re-plumbing needed.

## What stays in React
- `useState` for local UI state (editing, focused cell, loading)
- `useCallback` for event handlers passed to child components
- `useSyncExternalStore` for store subscriptions
- `useRef` for imperative handles (iframe refs, editor refs)

## Test results
All existing tests pass + new `frame-pipeline.test.ts` with 12 tests for `mergeChangesets`.