### PR TITLE
fix: prevent blank screen on save-as for untitled notebooks

### DIFF
--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -1,6 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { debounceTime, from, merge, Subject, switchMap } from "rxjs";
+import { debounceTime, from, Subject, switchMap } from "rxjs";
 import { getBlobPort, refreshBlobPort } from "../lib/blob-port";
 import { createFramePipeline } from "../lib/frame-pipeline";
 import { frame_types, sendFrame } from "../lib/frame-types";
@@ -166,12 +166,9 @@ export function useAutomergeNotebook() {
       }
     });
 
-    // Daemon lifecycle — daemon:ready + file-opened both need fresh bootstrap.
-    // switchMap cancels any in-flight bootstrap on rapid events.
-    const lifecycleSub = merge(
-      fromTauriEvent("daemon:ready"),
-      fromTauriEvent("notebook:file-opened"),
-    )
+    // Daemon lifecycle — daemon:ready triggers a fresh bootstrap.
+    // switchMap cancels any in-flight bootstrap on rapid reconnects.
+    const lifecycleSub = fromTauriEvent("daemon:ready")
       .pipe(
         switchMap(() => {
           refreshBlobPort();
@@ -201,6 +198,10 @@ export function useAutomergeNotebook() {
       materializeCells,
       outputCache: outputCacheRef.current,
       onSyncApplied: () => syncReply$.current.next(),
+      retrySyncToRelay: () => {
+        const handle = handleRef.current;
+        if (handle) syncToRelay(handle);
+      },
     });
 
     // Source sync: 20ms debounce for batching rapid keystrokes.

--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -200,7 +200,12 @@ export function useAutomergeNotebook() {
       onSyncApplied: () => syncReply$.current.next(),
       retrySyncToRelay: () => {
         const handle = handleRef.current;
-        if (handle) syncToRelay(handle);
+        if (!handle) return;
+        // Reset sync state so generate_sync_message() produces a fresh
+        // request instead of returning null (which it does when the
+        // handle believes it's already in sync with the peer).
+        handle.reset_sync_state();
+        syncToRelay(handle);
       },
     });
 

--- a/apps/notebook/src/lib/frame-pipeline.ts
+++ b/apps/notebook/src/lib/frame-pipeline.ts
@@ -30,6 +30,8 @@ import {
   Subject,
   Subscription,
   share,
+  switchMap,
+  timer,
 } from "rxjs";
 
 import type { JupyterOutput } from "../types";
@@ -59,6 +61,9 @@ export { mergeChangesets } from "./cell-changeset";
 
 /** Coalescing window for incoming sync frames (ms). */
 const COALESCE_MS = 32;
+
+/** Timeout before retrying sync if initial sync hasn't produced cells (ms). */
+const SYNC_RETRY_MS = 3000;
 
 // ── Internal types ──────────────────────────────────────────────────
 
@@ -118,6 +123,13 @@ export interface FramePipelineDeps {
    * `debounceTime` operator).
    */
   onSyncApplied: () => void;
+
+  /**
+   * Resend the initial sync message. Called by the retry timer when
+   * the first sync exchange didn't produce cells within SYNC_RETRY_MS.
+   * The empty WASM handle's sync message requests the full document.
+   */
+  retrySyncToRelay: () => void;
 }
 
 // ── Pipeline factory ────────────────────────────────────────────────
@@ -137,6 +149,11 @@ export function createFramePipeline(deps: FramePipelineDeps): Subscription {
   // Subject bridging sync_applied events into the coalescing buffer.
   // Each emission is a CellChangeset (incremental) or null (needs full).
   const materialize$ = new Subject<CellChangeset | null>();
+
+  // Subject for the sync retry timer. Each emission restarts the timer.
+  // If SYNC_RETRY_MS elapses without a successful initial sync (changed:true),
+  // the pipeline resends sync to recover from lost/consumed messages.
+  const retrySync$ = new Subject<void>();
 
   // ── Source: Tauri frames → WASM demux → individual FrameEvents ────
 
@@ -176,13 +193,13 @@ export function createFramePipeline(deps: FramePipelineDeps): Subscription {
 
           // ── Initial sync: materialize immediately (no coalescing) ──
           if (deps.getAwaitingInitialSync()) {
-            deps.setAwaitingInitialSync(false);
-            deps.setIsLoading(false);
             if (e.changed) {
+              // Sync delivered actual document content — clear the gate
+              // and materialize. This is the success path.
+              deps.setAwaitingInitialSync(false);
+              deps.setIsLoading(false);
               const handle = deps.getHandle();
               if (handle) {
-                // Return a promise so concatMap waits for materialization
-                // to complete before signaling the sync reply.
                 return from(
                   deps
                     .materializeCells(handle)
@@ -200,6 +217,12 @@ export function createFramePipeline(deps: FramePipelineDeps): Subscription {
                 );
               }
             }
+            // changed:false — Automerge sync protocol handshake round
+            // (exchanging heads/bloom filters, no actual content yet).
+            // Keep awaitingInitialSync=true and isLoading=true so the
+            // user sees the loading state until real content arrives.
+            // Restart the retry timer in case the exchange stalls.
+            retrySync$.next();
             deps.onSyncApplied();
             return EMPTY;
           }
@@ -213,6 +236,25 @@ export function createFramePipeline(deps: FramePipelineDeps): Subscription {
         }),
       )
       .subscribe(),
+  );
+
+  // ── Sync retry timer ──────────────────────────────────────────────
+  //
+  // If the initial sync exchange doesn't produce cells within
+  // SYNC_RETRY_MS (e.g., the daemon's response was consumed by a stale
+  // handle during save-as, or the initial sync message was lost), resend
+  // the sync message. The empty WASM handle requests the full document.
+  // switchMap restarts the timer on each changed:false handshake round.
+  subscription.add(
+    retrySync$
+      .pipe(
+        switchMap(() => timer(SYNC_RETRY_MS)),
+        filter(() => deps.getAwaitingInitialSync()),
+      )
+      .subscribe(() => {
+        logger.info("[frame-pipeline] Retrying sync after timeout");
+        deps.retrySyncToRelay();
+      }),
   );
 
   // ── Coalescing buffer → materialization ────────────────────────────

--- a/apps/notebook/src/lib/frame-pipeline.ts
+++ b/apps/notebook/src/lib/frame-pipeline.ts
@@ -155,6 +155,11 @@ export function createFramePipeline(deps: FramePipelineDeps): Subscription {
   // the pipeline resends sync to recover from lost/consumed messages.
   const retrySync$ = new Subject<void>();
 
+  // Arm the retry timer immediately — if no sync_applied arrives at all
+  // (e.g., all frames dropped before reaching WASM), this ensures we
+  // still retry after SYNC_RETRY_MS rather than hanging indefinitely.
+  retrySync$.next();
+
   // ── Source: Tauri frames → WASM demux → individual FrameEvents ────
 
   const frameEvents$ = fromTauriEvent<number[]>("notebook:frame").pipe(

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -639,6 +639,18 @@ async fn setup_sync_receivers(
     let sync_generation_for_cleanup = sync_generation.clone();
     tokio::spawn(async move {
         while let Some(frame_bytes) = raw_frame_rx.recv().await {
+            // Stop forwarding if a newer connection has replaced this one.
+            // Without this check, frames from the old room can interleave
+            // with the new connection's frames on the notebook:frame event
+            // channel, causing the frontend to feed them to the wrong WASM
+            // handle (stale Automerge document).
+            if sync_generation_for_cleanup.load(Ordering::SeqCst) != current_generation {
+                info!(
+                    "[notebook-sync] Stale relay for {} (gen {} superseded) — stopping frame emission",
+                    notebook_id_for_relay, current_generation,
+                );
+                break;
+            }
             if let Err(e) =
                 emit_to_label::<_, _, _>(&window, window.label(), "notebook:frame", &frame_bytes)
             {


### PR DESCRIPTION
## Problem

Save-as on untitled notebooks (UUID → file-path room re-key) can leave the notebook blank. The frontend receives `daemon:ready`, resets cells, bootstraps with an empty WASM handle, sends sync — but the notebook stays empty.

Root cause analysis (via two parallel investigations of the Rust and frontend flows):

### 1. One-shot gate bug in the frame pipeline

The `awaitingInitialSync` gate was cleared by the **first** `sync_applied` event regardless of its `changed` flag:

```ts
if (deps.getAwaitingInitialSync()) {
  deps.setAwaitingInitialSync(false);  // ← unconditional
  deps.setIsLoading(false);            // ← unconditional
  if (e.changed) { /* materialize */ }
}
```

If the Automerge sync protocol's handshake round arrives with `changed: false` (just exchanging heads/bloom filters, no actual document content), `isLoading` is cleared but no cells are materialized. The user sees a blank notebook with no loading indicator — and the notebook **stays** blank because subsequent `sync_applied` events go through the steady-state coalescing path.

### 2. No connection isolation + stale handle processing

During save-as, the Rust `setup_sync_receivers` spawns the frame relay task *before* emitting `daemon:ready`. If the daemon sends frames quickly, they can arrive at the frontend before `bootstrap()` replaces the WASM handle. The old handle processes frames from the new room, consuming sync state. When the new handle sends its sync message, the daemon may respond with `changed: false` (believing it already sent the data), triggering the one-shot gate bug.

### 3. Dead `notebook:file-opened` listener

`notebook:file-opened` is never emitted from the Rust side — the only lifecycle event is `daemon:ready`. The listener was dead code creating a false sense of coverage.

## Fix

### Fix 1: Only clear the initial sync gate on `changed: true`

`changed: false` events during initial sync are now treated as protocol handshake rounds. `isLoading` stays true and the retry timer restarts. The gate only opens when actual document content arrives.

### Fix 2: Sync retry timer (3 seconds)

If the initial sync exchange doesn't produce cells within 3s (daemon response consumed by stale handle, message lost, etc.), the pipeline resends the sync message. The empty WASM handle's sync request asks for the full document, recovering the exchange.

Uses `switchMap` + `timer` so each `changed: false` handshake round restarts the timer.

### Fix 3: Remove dead `notebook:file-opened` listener

Simplified the lifecycle observable from `merge(daemon:ready, file-opened)` to just `fromTauriEvent('daemon:ready')`.

## Test results

All 488 tests pass, tsc clean, biome clean.