### PR TITLE
fix(xtask): auto-sync Python workspace and build native bindings on setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,3 @@ crates/notebook/icons/ios/
 crates/notebook/icons/icon.icns
 apps/notebook/package-lock.json
 deno.lock
-
-# Local editor settings (per-developer MCP config, etc.)
-.zed/settings.json

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,16 @@
+{
+  "context_servers": {
+    "supervisor": {
+      "command": "./target/debug/mcp-supervisor",
+      "args": [],
+      "env": {
+        "RUNTIMED_DEV": "1",
+      },
+    },
+  },
+  "languages": {
+    "Python": {
+      "language_servers": ["!pyright", "!basedpyright", "..."],
+    },
+  },
+}

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -137,6 +137,7 @@ fn cmd_dev(notebook: Option<&str>, skip_install: bool, skip_build: bool) {
         println!("Skipping pnpm install (--skip-install)");
     } else {
         ensure_pnpm_install();
+        ensure_python_env();
     }
 
     if skip_build {
@@ -304,6 +305,109 @@ fn pnpm_install_reason() -> Option<&'static str> {
 
 fn modified_time(path: &Path) -> Option<std::time::SystemTime> {
     fs::metadata(path).ok()?.modified().ok()
+}
+
+/// Ensure the Python workspace venv is synced (`uv sync --directory python`).
+///
+/// This installs all workspace members (nteract, runtimed) and their
+/// dependencies (mcp, pydantic, etc.) into `python/.venv`. Needed for:
+/// - `maturin develop` (installs into this venv)
+/// - `uv run --no-sync` (expects deps to be present)
+/// - Editor type-checking / LSP (needs the venv to resolve imports)
+fn ensure_python_env() {
+    let python_dir = Path::new("python");
+    if !python_dir.exists() {
+        return;
+    }
+    if Command::new("uv").arg("--version").output().is_err() {
+        println!("Skipping Python env sync (uv not found).");
+        return;
+    }
+
+    if let Some(reason) = python_sync_reason() {
+        println!("Syncing Python workspace ({reason})...");
+        let status = Command::new("uv")
+            .args(["sync", "--directory", "python"])
+            .status();
+        match status {
+            Ok(s) if s.success() => {}
+            Ok(s) => {
+                eprintln!("Warning: uv sync failed (exit {})", s.code().unwrap_or(-1));
+            }
+            Err(e) => {
+                eprintln!("Warning: failed to run uv sync: {e}");
+            }
+        }
+    } else {
+        println!("Skipping Python env sync (venv is up to date).");
+    }
+}
+
+fn python_sync_reason() -> Option<&'static str> {
+    let venv_marker = Path::new("python/.venv/pyvenv.cfg");
+    if !venv_marker.exists() {
+        return Some("missing .venv");
+    }
+
+    let Some(venv_time) = modified_time(venv_marker) else {
+        return Some("could not read .venv timestamp");
+    };
+
+    for manifest in [
+        Path::new("python/uv.lock"),
+        Path::new("python/pyproject.toml"),
+        Path::new("python/nteract/pyproject.toml"),
+        Path::new("python/runtimed/pyproject.toml"),
+    ] {
+        if let Some(manifest_time) = modified_time(manifest) {
+            if manifest_time > venv_time {
+                return Some("pyproject.toml or uv.lock changed");
+            }
+        }
+    }
+
+    None
+}
+
+/// Ensure `maturin develop` has been run so the native `runtimed` extension
+/// is installed into `python/.venv`.
+///
+/// Unlike `uv sync` (which builds a release wheel), `maturin develop` builds
+/// a debug `.so` and symlinks it — faster to compile and always reflects the
+/// latest Rust source.
+fn ensure_maturin_develop() {
+    let python_dir = Path::new("python");
+    if !python_dir.exists() {
+        return;
+    }
+    if Command::new("uv").arg("--version").output().is_err() {
+        println!("Skipping maturin develop (uv not found).");
+        return;
+    }
+
+    println!("Building runtimed Python bindings (maturin develop)...");
+    let status = Command::new("uv")
+        .args([
+            "run",
+            "--directory",
+            "python/runtimed",
+            "maturin",
+            "develop",
+        ])
+        .status();
+
+    match status {
+        Ok(s) if s.success() => {}
+        Ok(s) => {
+            eprintln!(
+                "Warning: maturin develop failed (exit {})",
+                s.code().unwrap_or(-1)
+            );
+        }
+        Err(e) => {
+            eprintln!("Warning: failed to run maturin develop: {e}");
+        }
+    }
 }
 
 fn cmd_build(rust_only: bool) {
@@ -604,6 +708,9 @@ fn cmd_install_daemon() {
 /// This enables isolated daemon instances per git worktree, useful when
 /// developing/testing daemon code across multiple worktrees simultaneously.
 fn cmd_mcp(print_config: bool) {
+    ensure_python_env();
+    ensure_maturin_develop();
+
     if print_config {
         // Build the supervisor, then run it with --print-config
         // For now, print the config pointing at the binary
@@ -713,26 +820,9 @@ fn cmd_dev_mcp(print_config: bool) {
         path
     };
 
-    // Step 3: Build runtimed-py via maturin develop
-    println!("Building runtimed Python bindings (maturin develop)...");
-    let maturin_status = Command::new("uv")
-        .args([
-            "run",
-            "--directory",
-            "python/runtimed",
-            "maturin",
-            "develop",
-        ])
-        .status()
-        .unwrap_or_else(|e| {
-            eprintln!("Failed to run maturin develop: {e}");
-            eprintln!("Make sure uv and maturin are installed: uv tool install maturin");
-            exit(1);
-        });
-    if !maturin_status.success() {
-        eprintln!("maturin develop failed");
-        exit(maturin_status.code().unwrap_or(1));
-    }
+    // Step 3: Sync Python workspace + build native bindings
+    ensure_python_env();
+    ensure_maturin_develop();
 
     // Step 4: Print config or launch
     let python_dir = fs::canonicalize("python").unwrap_or_else(|e| {

--- a/python/runtimed/src/runtimed/__init__.pyi
+++ b/python/runtimed/src/runtimed/__init__.pyi
@@ -1,0 +1,87 @@
+"""Type stubs for the runtimed package."""
+
+from runtimed.runtimed import (
+    AsyncSession as AsyncSession,
+)
+from runtimed.runtimed import (
+    Cell as Cell,
+)
+from runtimed.runtimed import (
+    CompletionItem as CompletionItem,
+)
+from runtimed.runtimed import (
+    CompletionResult as CompletionResult,
+)
+from runtimed.runtimed import (
+    DaemonClient as DaemonClient,
+)
+from runtimed.runtimed import (
+    EventIteratorSubscription as EventIteratorSubscription,
+)
+from runtimed.runtimed import (
+    EventSubscription as EventSubscription,
+)
+from runtimed.runtimed import (
+    ExecutionEvent as ExecutionEvent,
+)
+from runtimed.runtimed import (
+    ExecutionEventIterator as ExecutionEventIterator,
+)
+from runtimed.runtimed import (
+    ExecutionEventStream as ExecutionEventStream,
+)
+from runtimed.runtimed import (
+    ExecutionResult as ExecutionResult,
+)
+from runtimed.runtimed import (
+    HistoryEntry as HistoryEntry,
+)
+from runtimed.runtimed import (
+    NotebookConnectionInfo as NotebookConnectionInfo,
+)
+from runtimed.runtimed import (
+    Output as Output,
+)
+from runtimed.runtimed import (
+    QueueState as QueueState,
+)
+from runtimed.runtimed import (
+    RuntimedError as RuntimedError,
+)
+from runtimed.runtimed import (
+    Session as Session,
+)
+from runtimed.runtimed import (
+    SyncEnvironmentResult as SyncEnvironmentResult,
+)
+from runtimed.runtimed import (
+    default_socket_path as default_socket_path,
+)
+from runtimed.runtimed import (
+    show_notebook_app as show_notebook_app,
+)
+
+__version__: str
+
+__all__ = [
+    "DaemonClient",
+    "Session",
+    "AsyncSession",
+    "Cell",
+    "ExecutionEvent",
+    "ExecutionEventIterator",
+    "ExecutionEventStream",
+    "ExecutionResult",
+    "EventSubscription",
+    "EventIteratorSubscription",
+    "NotebookConnectionInfo",
+    "Output",
+    "RuntimedError",
+    "SyncEnvironmentResult",
+    "CompletionItem",
+    "CompletionResult",
+    "QueueState",
+    "HistoryEntry",
+    "default_socket_path",
+    "show_notebook_app",
+]


### PR DESCRIPTION
## Problem

The "fresh clone to working" path has too many corners. Three specific gaps:

### 1. No `uv sync` in any xtask command

The Python workspace `.venv` at `python/.venv` was never explicitly created. It only appeared as a side effect of `maturin develop` (if uv happened to resolve the workspace). Without it:
- Editor type-checking can't resolve `import runtimed`, `import mcp`, etc.
- `uv run --no-sync` commands fail
- `pytest` can't find dependencies

### 2. `cargo xtask mcp` didn't build native bindings

The supervisor's `ensure_maturin_develop` only checks if `import runtimed` succeeds. After `uv sync` builds a release wheel, the import check passes — even if the wheel is stale after Rust changes. The stale bindings persist until the file watcher catches up.

`cmd_dev_mcp` had an explicit `maturin develop` step; `cmd_mcp` didn't.

### 3. Missing `__init__.pyi` for the runtimed package

The `.pyi` stub existed for the inner native module (`runtimed/runtimed.pyi`) but not for the package itself. Type checkers could resolve `from runtimed.runtimed import Session` but not `runtimed.show_notebook_app` (which is re-exported in `__init__.py`).

## Fix

### `ensure_python_env()` — runs `uv sync --directory python`

Freshness-checked: compares `python/.venv/pyvenv.cfg` timestamp against `uv.lock` and `pyproject.toml` files. Skips if up-to-date.

Called from:
- `cmd_dev` (inside the `ensure_pnpm_install` gate — same "setup" phase)
- `cmd_mcp`
- `cmd_dev_mcp`

### `ensure_maturin_develop()` — runs `maturin develop`

Builds the debug `.so` native extension and installs it into `python/.venv`. Unlike `uv sync` (which builds a release wheel), this is faster and always reflects the latest Rust source.

Called from:
- `cmd_mcp` (was missing, now matches `cmd_dev_mcp`)
- `cmd_dev_mcp` (replaces the inline maturin invocation)

### `python/runtimed/src/runtimed/__init__.pyi`

Re-exports all public symbols from the inner native module stub, matching `__init__.py`. Type checkers can now resolve `runtimed.show_notebook_app`, `runtimed.AsyncSession`, etc.

## Setup path after this PR

| Command | What happens |
|---|---|
| `cargo xtask dev` | pnpm install + **uv sync** + build + daemon + app |
| `cargo xtask mcp` | **uv sync** + **maturin develop** + build supervisor + run |
| `cargo xtask dev-mcp` | daemon check + **uv sync** + **maturin develop** + run MCP server |
| Editor opens project | `.venv` already exists → type checking works |