### PR TITLE
fix: store binary blobs as raw bytes, resolve as blob URLs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5764,6 +5764,7 @@ dependencies = [
 name = "runtimed-py"
 version = "0.1.0"
 dependencies = [
+ "base64 0.22.1",
  "kernel-env",
  "log",
  "notebook-doc",

--- a/apps/notebook/src/lib/__tests__/manifest-resolution.test.ts
+++ b/apps/notebook/src/lib/__tests__/manifest-resolution.test.ts
@@ -90,7 +90,10 @@ describe("isBinaryMime", () => {
     expect(isBinaryMime("image/jpeg")).toBe(true);
     expect(isBinaryMime("image/gif")).toBe(true);
     expect(isBinaryMime("image/webp")).toBe(true);
-    expect(isBinaryMime("image/svg+xml")).toBe(true);
+  });
+
+  it("returns false for SVG (plain XML text in Jupyter)", () => {
+    expect(isBinaryMime("image/svg+xml")).toBe(false);
   });
 
   it("returns true for audio/video types", () => {

--- a/apps/notebook/src/lib/__tests__/manifest-resolution.test.ts
+++ b/apps/notebook/src/lib/__tests__/manifest-resolution.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   type ContentRef,
+  isBinaryMime,
   isManifestHash,
   type OutputManifest,
   resolveContentRef,
@@ -80,6 +81,47 @@ describe("isManifestHash", () => {
 });
 
 // ---------------------------------------------------------------------------
+// isBinaryMime
+// ---------------------------------------------------------------------------
+
+describe("isBinaryMime", () => {
+  it("returns true for image types", () => {
+    expect(isBinaryMime("image/png")).toBe(true);
+    expect(isBinaryMime("image/jpeg")).toBe(true);
+    expect(isBinaryMime("image/gif")).toBe(true);
+    expect(isBinaryMime("image/webp")).toBe(true);
+    expect(isBinaryMime("image/svg+xml")).toBe(true);
+  });
+
+  it("returns true for audio/video types", () => {
+    expect(isBinaryMime("audio/mpeg")).toBe(true);
+    expect(isBinaryMime("video/mp4")).toBe(true);
+  });
+
+  it("returns true for binary application types", () => {
+    expect(isBinaryMime("application/pdf")).toBe(true);
+    expect(isBinaryMime("application/octet-stream")).toBe(true);
+    expect(isBinaryMime("application/vnd.apache.arrow.stream")).toBe(true);
+    expect(isBinaryMime("application/vnd.apache.parquet")).toBe(true);
+    expect(isBinaryMime("application/wasm")).toBe(true);
+  });
+
+  it("returns false for text-like application types", () => {
+    expect(isBinaryMime("application/json")).toBe(false);
+    expect(isBinaryMime("application/javascript")).toBe(false);
+    expect(isBinaryMime("application/xml")).toBe(false);
+    expect(isBinaryMime("application/vnd.vegalite.v5+json")).toBe(false);
+    expect(isBinaryMime("application/xhtml+xml")).toBe(false);
+  });
+
+  it("returns false for text types", () => {
+    expect(isBinaryMime("text/plain")).toBe(false);
+    expect(isBinaryMime("text/html")).toBe(false);
+    expect(isBinaryMime("text/latex")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // resolveContentRef
 // ---------------------------------------------------------------------------
 
@@ -99,7 +141,7 @@ describe("resolveContentRef", () => {
     expect(result).toBe("");
   });
 
-  it("fetches blob content from the blob store", async () => {
+  it("fetches text blob content from the blob store", async () => {
     const blobHash = "abc123";
     const ref: ContentRef = { blob: blobHash, size: 42 };
 
@@ -107,11 +149,37 @@ describe("resolveContentRef", () => {
       new Response("fetched content", { status: 200 }),
     );
 
-    const result = await resolveContentRef(ref, blobPort);
+    // Text MIME type: fetches content as text
+    const result = await resolveContentRef(ref, blobPort, "text/plain");
     expect(result).toBe("fetched content");
     expect(mockFetch).toHaveBeenCalledWith(
       `http://127.0.0.1:${blobPort}/blob/${blobHash}`,
     );
+  });
+
+  it("returns blob URL for binary MIME types without fetching", async () => {
+    const ref: ContentRef = { blob: "pnghash", size: 5000 };
+
+    const result = await resolveContentRef(ref, blobPort, "image/png");
+    expect(result).toBe("http://127.0.0.1:9876/blob/pnghash");
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("returns blob URL for application/pdf", async () => {
+    const ref: ContentRef = { blob: "pdfhash", size: 10000 };
+
+    const result = await resolveContentRef(ref, blobPort, "application/pdf");
+    expect(result).toBe("http://127.0.0.1:9876/blob/pdfhash");
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("fetches blob content when no mimeType is provided", async () => {
+    const ref: ContentRef = { blob: "hash123", size: 5 };
+    mockFetch.mockResolvedValueOnce(new Response("ok", { status: 200 }));
+
+    const result = await resolveContentRef(ref, blobPort);
+    expect(result).toBe("ok");
+    expect(mockFetch).toHaveBeenCalled();
   });
 
   it("throws on non-OK response from blob store", async () => {
@@ -119,19 +187,17 @@ describe("resolveContentRef", () => {
 
     mockFetch.mockResolvedValueOnce(new Response("not found", { status: 404 }));
 
-    await expect(resolveContentRef(ref, blobPort)).rejects.toThrow(
-      "Failed to fetch blob deadbeef: 404",
-    );
+    await expect(
+      resolveContentRef(ref, blobPort, "text/plain"),
+    ).rejects.toThrow("Failed to fetch blob deadbeef: 404");
   });
 
   it("uses the correct port in the URL", async () => {
     const ref: ContentRef = { blob: "hash123", size: 5 };
-    mockFetch.mockResolvedValueOnce(new Response("ok", { status: 200 }));
 
-    await resolveContentRef(ref, 5555);
-    expect(mockFetch).toHaveBeenCalledWith(
-      "http://127.0.0.1:5555/blob/hash123",
-    );
+    // Binary MIME: uses port in the URL
+    const result = await resolveContentRef(ref, 5555, "image/jpeg");
+    expect(result).toBe("http://127.0.0.1:5555/blob/hash123");
   });
 });
 
@@ -197,32 +263,26 @@ describe("resolveDataBundle", () => {
     expect(result["text/plain"]).toBe(jsonString);
   });
 
-  it("resolves blob refs by fetching from the store", async () => {
+  it("resolves binary blob refs to URLs without fetching", async () => {
     const data: Record<string, ContentRef> = {
       "image/png": { blob: "pnghash", size: 100 },
     };
 
-    mockFetch.mockResolvedValueOnce(
-      new Response("base64pngdata", { status: 200 }),
-    );
-
     const result = await resolveDataBundle(data, blobPort);
-    expect(result["image/png"]).toBe("base64pngdata");
+    expect(result["image/png"]).toBe("http://127.0.0.1:9876/blob/pnghash");
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 
-  it("handles mixed inline and blob refs", async () => {
+  it("handles mixed inline text and binary blob refs", async () => {
     const data: Record<string, ContentRef> = {
       "text/plain": { inline: "fallback text" },
       "image/png": { blob: "pnghash", size: 200 },
     };
 
-    mockFetch.mockResolvedValueOnce(
-      new Response("pngblobcontent", { status: 200 }),
-    );
-
     const result = await resolveDataBundle(data, blobPort);
     expect(result["text/plain"]).toBe("fallback text");
-    expect(result["image/png"]).toBe("pngblobcontent");
+    expect(result["image/png"]).toBe("http://127.0.0.1:9876/blob/pnghash");
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 
   it("handles empty data bundle", async () => {
@@ -277,7 +337,7 @@ describe("resolveManifest", () => {
       });
     });
 
-    it("resolves blob refs in data", async () => {
+    it("resolves binary blob refs to URLs", async () => {
       const manifest: OutputManifest = {
         output_type: "display_data",
         data: {
@@ -285,17 +345,14 @@ describe("resolveManifest", () => {
         },
       };
 
-      mockFetch.mockResolvedValueOnce(
-        new Response("base64png", { status: 200 }),
-      );
-
       const output = await resolveManifest(manifest, blobPort);
       expect(output).toEqual({
         output_type: "display_data",
-        data: { "image/png": "base64png" },
+        data: { "image/png": "http://127.0.0.1:9876/blob/pnghash" },
         metadata: {},
         display_id: undefined,
       });
+      expect(mockFetch).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/notebook/src/lib/manifest-resolution.ts
+++ b/apps/notebook/src/lib/manifest-resolution.ts
@@ -16,11 +16,11 @@ export function isManifestHash(s: string): boolean {
  * directly (e.g., `<img src="http://...">`) instead of base64 data URIs.
  */
 export function isBinaryMime(mime: string): boolean {
-  if (
-    mime.startsWith("image/") ||
-    mime.startsWith("audio/") ||
-    mime.startsWith("video/")
-  ) {
+  if (mime.startsWith("image/")) {
+    // SVG is plain XML text in Jupyter, not base64-encoded binary.
+    return !mime.endsWith("+xml");
+  }
+  if (mime.startsWith("audio/") || mime.startsWith("video/")) {
     return true;
   }
 

--- a/apps/notebook/src/lib/manifest-resolution.ts
+++ b/apps/notebook/src/lib/manifest-resolution.ts
@@ -8,6 +8,45 @@ export function isManifestHash(s: string): boolean {
 }
 
 /**
+ * Check if a MIME type represents binary content.
+ *
+ * Binary MIME types are stored as raw bytes in the blob store (decoded
+ * from Jupyter's base64 wire format). The blob HTTP server serves them
+ * with the correct Content-Type, so the frontend can use blob URLs
+ * directly (e.g., `<img src="http://...">`) instead of base64 data URIs.
+ */
+export function isBinaryMime(mime: string): boolean {
+  if (
+    mime.startsWith("image/") ||
+    mime.startsWith("audio/") ||
+    mime.startsWith("video/")
+  ) {
+    return true;
+  }
+
+  // application/* is binary by default, with carve-outs for text-like formats.
+  if (mime.startsWith("application/")) {
+    const subtype = mime.slice("application/".length);
+    const isText =
+      subtype === "json" ||
+      subtype === "javascript" ||
+      subtype === "ecmascript" ||
+      subtype === "xml" ||
+      subtype === "xhtml+xml" ||
+      subtype === "mathml+xml" ||
+      subtype === "sql" ||
+      subtype === "graphql" ||
+      subtype === "x-latex" ||
+      subtype === "x-tex" ||
+      subtype.endsWith("+json") ||
+      subtype.endsWith("+xml");
+    return !isText;
+  }
+
+  return false;
+}
+
+/**
  * A content reference — either inlined data or a blob-store hash.
  */
 export type ContentRef = { inline: string } | { blob: string; size: number };
@@ -43,14 +82,26 @@ export type OutputManifest =
 
 /**
  * Resolve a content reference to its string value.
- * Inlined refs return immediately; blob refs are fetched from the blob store.
+ *
+ * For binary MIME types (images, etc.), blob refs resolve to an HTTP URL
+ * pointing at the blob server. The browser fetches the raw bytes directly
+ * when rendering (e.g., `<img src="http://...">`) — no base64 round-trip.
+ *
+ * For text MIME types, blob refs are fetched and returned as strings.
+ * Inlined refs always return the embedded string directly.
  */
 export async function resolveContentRef(
   ref: ContentRef,
   blobPort: number,
+  mimeType?: string,
 ): Promise<string> {
   if ("inline" in ref) {
     return ref.inline;
+  }
+  // Binary blob refs resolve to a URL — the blob server serves raw bytes
+  // with the correct Content-Type. The browser/iframe fetches directly.
+  if (mimeType && isBinaryMime(mimeType)) {
+    return `http://127.0.0.1:${blobPort}/blob/${ref.blob}`;
   }
   const response = await fetch(`http://127.0.0.1:${blobPort}/blob/${ref.blob}`);
   if (!response.ok) {
@@ -61,7 +112,10 @@ export async function resolveContentRef(
 
 /**
  * Resolve a MIME-type → ContentRef map to a fully hydrated data bundle.
- * JSON MIME types are auto-parsed.
+ *
+ * Binary MIME types resolve to blob URLs (the browser fetches raw bytes
+ * directly from the blob server). JSON MIME types are auto-parsed.
+ * Text MIME types are returned as strings.
  */
 export async function resolveDataBundle(
   data: Record<string, ContentRef>,
@@ -69,7 +123,7 @@ export async function resolveDataBundle(
 ): Promise<Record<string, unknown>> {
   const resolved: Record<string, unknown> = {};
   for (const [mimeType, ref] of Object.entries(data)) {
-    const content = await resolveContentRef(ref, blobPort);
+    const content = await resolveContentRef(ref, blobPort, mimeType);
     if (mimeType.includes("json")) {
       try {
         resolved[mimeType] = JSON.parse(content);

--- a/crates/runtimed-py/Cargo.toml
+++ b/crates/runtimed-py/Cargo.toml
@@ -22,6 +22,7 @@ notebook-sync = { path = "../notebook-sync" }
 tokio = { version = "1", features = ["full"] }
 serde_json = { workspace = true }
 uuid = { workspace = true }
+base64 = "0.22"
 log = "0.4"
 thiserror = { workspace = true }
 reqwest = { version = "0.12", default-features = false, features = ["native-tls", "json"] }

--- a/crates/runtimed-py/src/output_resolver.rs
+++ b/crates/runtimed-py/src/output_resolver.rs
@@ -24,7 +24,11 @@ fn is_blob_hash(s: &str) -> bool {
 /// Must match the Rust `is_binary_mime` in `output_store.rs` and the
 /// TypeScript `isBinaryMime` in `manifest-resolution.ts`.
 fn is_binary_mime(mime: &str) -> bool {
-    if mime.starts_with("image/") || mime.starts_with("audio/") || mime.starts_with("video/") {
+    if mime.starts_with("image/") {
+        // SVG is plain XML text in Jupyter, not base64-encoded binary.
+        return !mime.ends_with("+xml");
+    }
+    if mime.starts_with("audio/") || mime.starts_with("video/") {
         return true;
     }
 

--- a/crates/runtimed-py/src/output_resolver.rs
+++ b/crates/runtimed-py/src/output_resolver.rs
@@ -6,11 +6,46 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 
+use base64::Engine as _;
+
 use crate::output::Output;
 
 /// Check if a string looks like a blob hash (64 hex characters).
 fn is_blob_hash(s: &str) -> bool {
     s.len() == 64 && s.chars().all(|c| c.is_ascii_hexdigit())
+}
+
+/// Check if a MIME type represents binary content.
+///
+/// Binary MIME types are stored as raw bytes in the blob store (decoded
+/// from Jupyter's base64 wire format). When resolving, we read the raw
+/// bytes and base64-encode them back to a string for the Output struct.
+///
+/// Must match the Rust `is_binary_mime` in `output_store.rs` and the
+/// TypeScript `isBinaryMime` in `manifest-resolution.ts`.
+fn is_binary_mime(mime: &str) -> bool {
+    if mime.starts_with("image/") || mime.starts_with("audio/") || mime.starts_with("video/") {
+        return true;
+    }
+
+    // application/* is binary by default, with carve-outs for text-like formats.
+    if let Some(subtype) = mime.strip_prefix("application/") {
+        let is_text = subtype == "json"
+            || subtype == "javascript"
+            || subtype == "ecmascript"
+            || subtype == "xml"
+            || subtype == "xhtml+xml"
+            || subtype == "mathml+xml"
+            || subtype == "sql"
+            || subtype == "graphql"
+            || subtype == "x-latex"
+            || subtype == "x-tex"
+            || subtype.ends_with("+json")
+            || subtype.ends_with("+xml");
+        return !is_text;
+    }
+
+    false
 }
 
 /// Resolve an output string to an Output.
@@ -36,7 +71,8 @@ pub async fn resolve_output_string(
     if is_blob_hash(output_str) {
         log::debug!("[output_resolver] Detected blob hash: {}", output_str);
 
-        // First try: read directly from disk (most reliable)
+        // First try: read directly from disk (most reliable).
+        // Manifests are always JSON text, so read_to_string is correct here.
         if let Some(store_path) = blob_store_path {
             let prefix = &output_str[..2];
             let rest = &output_str[2..];
@@ -66,7 +102,7 @@ pub async fn resolve_output_string(
 
         // Second try: fetch from blob server
         if let Some(base_url) = blob_base_url {
-            let url = format!("{}/blobs/{}", base_url, output_str);
+            let url = format!("{}/blob/{}", base_url, output_str);
             if let Ok(response) = reqwest::get(&url).await {
                 if response.status().is_success() {
                     if let Ok(manifest) = response.json::<serde_json::Value>().await {
@@ -119,7 +155,8 @@ pub async fn resolve_output_with_type(
     if is_blob_hash(output_json) {
         log::debug!("[output_resolver] Detected blob hash: {}", output_json);
 
-        // First try: read directly from disk (most reliable)
+        // First try: read directly from disk (most reliable).
+        // Manifests are always JSON text, so read_to_string is correct here.
         if let Some(store_path) = blob_store_path {
             let prefix = &output_json[..2];
             let rest = &output_json[2..];
@@ -145,7 +182,7 @@ pub async fn resolve_output_with_type(
 
         // Second try: fetch from blob server
         if let Some(base_url) = blob_base_url {
-            let url = format!("{}/blobs/{}", base_url, output_json);
+            let url = format!("{}/blob/{}", base_url, output_json);
             if let Ok(response) = reqwest::get(&url).await {
                 if response.status().is_success() {
                     if let Ok(manifest) = response.json::<serde_json::Value>().await {
@@ -229,6 +266,10 @@ pub fn output_from_json(output_type: &str, json: &serde_json::Value) -> Option<O
 ///
 /// The manifest has a format like:
 /// {"output_type": "stream", "name": "stdout", "text": {"inline": "..."}}
+///
+/// For display_data/execute_result, each MIME type's content ref is resolved
+/// according to its type: binary MIME types read raw bytes from the blob store
+/// and base64-encode them; text MIME types read as UTF-8 strings.
 pub async fn output_from_manifest(
     output_type: &str,
     manifest: &serde_json::Value,
@@ -239,7 +280,7 @@ pub async fn output_from_manifest(
         "stream" => {
             let name = manifest.get("name")?.as_str()?;
             let text_ref = manifest.get("text")?;
-            let text = resolve_content_ref(text_ref, blob_base_url, blob_store_path).await?;
+            let text = resolve_content_ref(text_ref, blob_base_url, blob_store_path, None).await?;
             Some(Output::stream(name, &text))
         }
         "display_data" | "execute_result" => {
@@ -247,8 +288,13 @@ pub async fn output_from_manifest(
             let mut output_data = HashMap::new();
 
             for (mime_type, content_ref) in data_map {
-                if let Some(content) =
-                    resolve_content_ref(content_ref, blob_base_url, blob_store_path).await
+                if let Some(content) = resolve_content_ref(
+                    content_ref,
+                    blob_base_url,
+                    blob_store_path,
+                    Some(mime_type.as_str()),
+                )
+                .await
                 {
                     output_data.insert(mime_type.clone(), content);
                 }
@@ -275,7 +321,8 @@ pub async fn output_from_manifest(
             } else {
                 // Content reference - resolve it and parse as JSON array
                 let tb_str =
-                    resolve_content_ref(traceback_val, blob_base_url, blob_store_path).await?;
+                    resolve_content_ref(traceback_val, blob_base_url, blob_store_path, None)
+                        .await?;
                 serde_json::from_str::<Vec<String>>(&tb_str).ok()?
             };
 
@@ -288,37 +335,63 @@ pub async fn output_from_manifest(
 /// Resolve a content reference from a blob manifest.
 ///
 /// Content refs can be:
-/// - {"inline": "actual content"} - content is inline
-/// - {"blob": "hash"} - content is in blob store
+/// - `{"inline": "actual content"}` — content is inline
+/// - `{"blob": "hash", "size": N}` — content is in the blob store
+///
+/// For binary MIME types (images, etc.), the blob store holds raw bytes
+/// (decoded from Jupyter's base64 wire format). This function reads the
+/// raw bytes and base64-encodes them so the Output struct always contains
+/// base64 strings for binary content (matching Jupyter conventions).
+///
+/// For text MIME types, the blob store holds UTF-8 text which is returned
+/// as-is.
 pub async fn resolve_content_ref(
     content_ref: &serde_json::Value,
     blob_base_url: &Option<String>,
     blob_store_path: &Option<PathBuf>,
+    mime_type: Option<&str>,
 ) -> Option<String> {
     if let Some(inline) = content_ref.get("inline") {
         return inline.as_str().map(|s| s.to_string());
     }
 
-    if let Some(blob_hash) = content_ref.get("blob").and_then(|v| v.as_str()) {
-        // First try: read directly from disk
-        if let Some(store_path) = blob_store_path {
-            if blob_hash.len() >= 2 {
-                let prefix = &blob_hash[..2];
-                let rest = &blob_hash[2..];
-                let blob_path = store_path.join(prefix).join(rest);
+    let blob_hash = content_ref.get("blob").and_then(|v| v.as_str())?;
+    let binary = mime_type.is_some_and(is_binary_mime);
 
+    // First try: read directly from disk
+    if let Some(store_path) = blob_store_path {
+        if blob_hash.len() >= 2 {
+            let prefix = &blob_hash[..2];
+            let rest = &blob_hash[2..];
+            let blob_path = store_path.join(prefix).join(rest);
+
+            if binary {
+                // Binary: read raw bytes and base64-encode
+                if let Ok(bytes) = tokio::fs::read(&blob_path).await {
+                    return Some(base64::engine::general_purpose::STANDARD.encode(&bytes));
+                }
+            } else {
+                // Text: read as UTF-8 string
                 if let Ok(contents) = tokio::fs::read_to_string(&blob_path).await {
                     return Some(contents);
                 }
             }
         }
+    }
 
-        // Second try: fetch from server
-        if let Some(base_url) = blob_base_url {
-            let url = format!("{}/blobs/{}", base_url, blob_hash);
+    // Second try: fetch from blob server
+    if let Some(base_url) = blob_base_url {
+        let url = format!("{}/blob/{}", base_url, blob_hash);
 
-            if let Ok(response) = reqwest::get(&url).await {
-                if response.status().is_success() {
+        if let Ok(response) = reqwest::get(&url).await {
+            if response.status().is_success() {
+                if binary {
+                    // Binary: read raw bytes and base64-encode
+                    if let Ok(bytes) = response.bytes().await {
+                        return Some(base64::engine::general_purpose::STANDARD.encode(&bytes));
+                    }
+                } else {
+                    // Text: read as UTF-8 string
                     return response.text().await.ok();
                 }
             }

--- a/crates/runtimed/src/output_store.rs
+++ b/crates/runtimed/src/output_store.rs
@@ -657,8 +657,7 @@ fn is_binary_mime(mime: &str) -> bool {
     }
 
     // application/* is binary by default, with carve-outs for text-like formats.
-    if mime.starts_with("application/") {
-        let subtype = &mime["application/".len()..];
+    if let Some(subtype) = mime.strip_prefix("application/") {
         // Text-like application types that should NOT be treated as binary
         let is_text = subtype == "json"
             || subtype == "javascript"

--- a/crates/runtimed/src/output_store.rs
+++ b/crates/runtimed/src/output_store.rs
@@ -652,7 +652,11 @@ fn value_to_string(value: &Value) -> String {
 /// - The HTTP blob server serves correct Content-Type with real bytes
 /// - Future binary formats (Arrow IPC, Parquet) work without changes
 fn is_binary_mime(mime: &str) -> bool {
-    if mime.starts_with("image/") || mime.starts_with("audio/") || mime.starts_with("video/") {
+    if mime.starts_with("image/") {
+        // SVG is plain XML text in Jupyter, not base64-encoded binary.
+        return !mime.ends_with("+xml");
+    }
+    if mime.starts_with("audio/") || mime.starts_with("video/") {
         return true;
     }
 
@@ -988,5 +992,113 @@ mod tests {
         let resolved = resolve_manifest(&manifest_json, &store).await.unwrap();
 
         assert_eq!(resolved["text"], "line 1\nline 2\n");
+    }
+
+    // ── Binary blob tests ───────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_from_binary_always_uses_blob() {
+        let dir = TempDir::new().unwrap();
+        let store = test_store(&dir);
+
+        // Even tiny binary data should go to blob (no inline threshold)
+        let tiny_png = b"\x89PNG\r\n\x1a\n";
+        let content_ref = ContentRef::from_binary(tiny_png, "image/png", &store)
+            .await
+            .unwrap();
+
+        assert!(
+            !content_ref.is_inline(),
+            "Binary content should always use blob, never inline"
+        );
+        if let ContentRef::Blob { size, .. } = &content_ref {
+            assert_eq!(*size, tiny_png.len() as u64);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_binary_round_trip_base64() {
+        let dir = TempDir::new().unwrap();
+        let store = test_store(&dir);
+
+        // Known bytes → store as blob → resolve back as base64
+        let raw_bytes: Vec<u8> = (0..=255).collect();
+        let content_ref = ContentRef::from_binary(&raw_bytes, "image/png", &store)
+            .await
+            .unwrap();
+
+        let base64_result = content_ref.resolve_binary_as_base64(&store).await.unwrap();
+
+        // Decode the base64 and verify it matches the original bytes
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(&base64_result)
+            .unwrap();
+        assert_eq!(decoded, raw_bytes);
+    }
+
+    #[tokio::test]
+    async fn test_binary_display_data_round_trip() {
+        let dir = TempDir::new().unwrap();
+        let store = test_store(&dir);
+
+        // Simulate what the kernel sends: base64-encoded PNG in a display_data
+        let raw_pixels = vec![0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+        let base64_from_kernel = base64::engine::general_purpose::STANDARD.encode(&raw_pixels);
+
+        let output = serde_json::json!({
+            "output_type": "display_data",
+            "data": {
+                "text/plain": "<Figure>",
+                "image/png": base64_from_kernel
+            },
+            "metadata": {}
+        });
+
+        // Create manifest (should base64-decode the PNG and store raw bytes)
+        let manifest_json = create_manifest(&output, &store, DEFAULT_INLINE_THRESHOLD)
+            .await
+            .unwrap();
+
+        // Resolve manifest (should base64-encode raw bytes back for nbformat)
+        let resolved = resolve_manifest(&manifest_json, &store).await.unwrap();
+
+        assert_eq!(resolved["output_type"], "display_data");
+        assert_eq!(resolved["data"]["text/plain"], "<Figure>");
+        // The resolved base64 should match what the kernel originally sent
+        assert_eq!(resolved["data"]["image/png"], base64_from_kernel);
+    }
+
+    #[test]
+    fn test_is_binary_mime() {
+        // Binary image types
+        assert!(is_binary_mime("image/png"));
+        assert!(is_binary_mime("image/jpeg"));
+        assert!(is_binary_mime("image/gif"));
+        assert!(is_binary_mime("image/webp"));
+
+        // SVG is text (plain XML in Jupyter)
+        assert!(!is_binary_mime("image/svg+xml"));
+
+        // Audio/video
+        assert!(is_binary_mime("audio/mpeg"));
+        assert!(is_binary_mime("video/mp4"));
+
+        // Binary application types
+        assert!(is_binary_mime("application/pdf"));
+        assert!(is_binary_mime("application/octet-stream"));
+        assert!(is_binary_mime("application/vnd.apache.arrow.stream"));
+        assert!(is_binary_mime("application/wasm"));
+
+        // Text-like application types
+        assert!(!is_binary_mime("application/json"));
+        assert!(!is_binary_mime("application/javascript"));
+        assert!(!is_binary_mime("application/xml"));
+        assert!(!is_binary_mime("application/vnd.vegalite.v5+json"));
+        assert!(!is_binary_mime("application/xhtml+xml"));
+
+        // Text types
+        assert!(!is_binary_mime("text/plain"));
+        assert!(!is_binary_mime("text/html"));
+        assert!(!is_binary_mime("text/latex"));
     }
 }

--- a/crates/runtimed/src/output_store.rs
+++ b/crates/runtimed/src/output_store.rs
@@ -18,6 +18,7 @@
 use std::collections::HashMap;
 use std::io;
 
+use base64::Engine as _;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -91,6 +92,44 @@ impl ContentRef {
     /// Returns true if the content is inlined.
     pub fn is_inline(&self) -> bool {
         matches!(self, ContentRef::Inline { .. })
+    }
+
+    /// Create a ContentRef from raw binary data, always using the blob store.
+    ///
+    /// Binary content (images, Arrow IPC, etc.) skips the inline threshold
+    /// and is always stored as a blob. The raw bytes are stored directly —
+    /// no base64 encoding — so the blob store holds the actual binary content
+    /// and the HTTP server can serve it with the correct Content-Type.
+    pub async fn from_binary(
+        data: &[u8],
+        media_type: &str,
+        blob_store: &BlobStore,
+    ) -> io::Result<Self> {
+        let hash = blob_store.put(data, media_type).await?;
+        Ok(ContentRef::Blob {
+            blob: hash,
+            size: data.len() as u64,
+        })
+    }
+
+    /// Resolve a ContentRef that holds binary content, returning base64.
+    ///
+    /// For inline content, returns the string as-is (it's already base64
+    /// from the Jupyter wire protocol, kept inline for small images).
+    /// For blob content, reads the raw bytes and base64-encodes them.
+    ///
+    /// Used by `resolve_data_bundle` for binary MIME types to reconstruct
+    /// the Jupyter nbformat representation (base64 strings for images).
+    pub async fn resolve_binary_as_base64(&self, blob_store: &BlobStore) -> io::Result<String> {
+        match self {
+            ContentRef::Inline { inline } => Ok(inline.clone()),
+            ContentRef::Blob { blob, .. } => {
+                let data = blob_store.get(blob).await?.ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::NotFound, format!("blob not found: {}", blob))
+                })?;
+                Ok(base64::engine::general_purpose::STANDARD.encode(&data))
+            }
+        }
     }
 }
 
@@ -378,9 +417,22 @@ async fn convert_value_to_content_refs(
     let mut result = HashMap::new();
     if let Value::Object(map) = data {
         for (mime_type, value) in map {
-            let content_str = value_to_string(value);
-            let content_ref =
-                ContentRef::from_data(&content_str, mime_type, blob_store, threshold).await?;
+            let content_ref = if is_binary_mime(mime_type) {
+                // Binary MIME type: base64-decode → store raw bytes in blob.
+                let base64_str = value_to_string(value);
+                let raw_bytes = base64::engine::general_purpose::STANDARD
+                    .decode(&base64_str)
+                    .map_err(|e| {
+                        io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            format!("base64 decode failed for {}: {}", mime_type, e),
+                        )
+                    })?;
+                ContentRef::from_binary(&raw_bytes, mime_type, blob_store).await?
+            } else {
+                let content_str = value_to_string(value);
+                ContentRef::from_data(&content_str, mime_type, blob_store, threshold).await?
+            };
             result.insert(mime_type.clone(), content_ref);
         }
     }
@@ -476,6 +528,10 @@ pub async fn resolve_manifest(manifest_json: &str, blob_store: &BlobStore) -> io
 // =============================================================================
 
 /// Convert a Jupyter data bundle (MIME type -> content) to ContentRefs.
+///
+/// Binary MIME types (images, Arrow IPC, etc.) are base64-decoded and stored
+/// as raw bytes in the blob store. Text MIME types use the existing
+/// inline/blob threshold logic.
 async fn convert_data_bundle(
     data: Option<&Value>,
     blob_store: &BlobStore,
@@ -485,10 +541,26 @@ async fn convert_data_bundle(
 
     if let Some(Value::Object(map)) = data {
         for (mime_type, value) in map {
-            let content_str = value_to_string(value);
-            // Use the MIME type as the blob media type
-            let content_ref =
-                ContentRef::from_data(&content_str, mime_type, blob_store, threshold).await?;
+            let content_ref = if is_binary_mime(mime_type) {
+                // Binary MIME type: base64-decode → store raw bytes in blob.
+                // Jupyter sends image data as base64 strings on the wire.
+                // We decode to actual bytes so the blob store holds real
+                // binary content and the HTTP server serves it correctly.
+                let base64_str = value_to_string(value);
+                let raw_bytes = base64::engine::general_purpose::STANDARD
+                    .decode(&base64_str)
+                    .map_err(|e| {
+                        io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            format!("base64 decode failed for {}: {}", mime_type, e),
+                        )
+                    })?;
+                ContentRef::from_binary(&raw_bytes, mime_type, blob_store).await?
+            } else {
+                // Text MIME type: store as-is with inline/blob threshold.
+                let content_str = value_to_string(value);
+                ContentRef::from_data(&content_str, mime_type, blob_store, threshold).await?
+            };
             result.insert(mime_type.clone(), content_ref);
         }
     }
@@ -497,6 +569,10 @@ async fn convert_data_bundle(
 }
 
 /// Resolve a data bundle of ContentRefs back to string values.
+///
+/// Binary MIME types are resolved via `resolve_binary_as_base64` which
+/// reads raw bytes from the blob store and base64-encodes them for the
+/// Jupyter nbformat representation (used when saving .ipynb to disk).
 async fn resolve_data_bundle(
     data: HashMap<String, ContentRef>,
     blob_store: &BlobStore,
@@ -504,11 +580,17 @@ async fn resolve_data_bundle(
     let mut result = HashMap::new();
 
     for (mime_type, content_ref) in data {
-        let content = content_ref.resolve(blob_store).await?;
-        // Try to parse as JSON for structured MIME types, otherwise use as string
-        let value = if mime_type.ends_with("+json") || mime_type == "application/json" {
+        let value = if is_binary_mime(&mime_type) {
+            // Binary: read raw bytes from blob → base64-encode for nbformat
+            let base64_str = content_ref.resolve_binary_as_base64(blob_store).await?;
+            Value::String(base64_str)
+        } else if mime_type.ends_with("+json") || mime_type == "application/json" {
+            // JSON: parse into structured Value
+            let content = content_ref.resolve(blob_store).await?;
             serde_json::from_str(&content).unwrap_or(Value::String(content))
         } else {
+            // Text: return as string
+            let content = content_ref.resolve(blob_store).await?;
             Value::String(content)
         };
         result.insert(mime_type, value);
@@ -560,6 +642,40 @@ fn value_to_string(value: &Value) -> String {
         Value::String(s) => s.clone(),
         _ => serde_json::to_string(value).unwrap_or_default(),
     }
+}
+
+/// Check if a MIME type represents binary content.
+///
+/// Binary MIME types are base64-encoded on the Jupyter wire protocol.
+/// We decode them to raw bytes before storing in the blob store so that:
+/// - The blob store holds actual binary content (33% smaller than base64)
+/// - The HTTP blob server serves correct Content-Type with real bytes
+/// - Future binary formats (Arrow IPC, Parquet) work without changes
+fn is_binary_mime(mime: &str) -> bool {
+    if mime.starts_with("image/") || mime.starts_with("audio/") || mime.starts_with("video/") {
+        return true;
+    }
+
+    // application/* is binary by default, with carve-outs for text-like formats.
+    if mime.starts_with("application/") {
+        let subtype = &mime["application/".len()..];
+        // Text-like application types that should NOT be treated as binary
+        let is_text = subtype == "json"
+            || subtype == "javascript"
+            || subtype == "ecmascript"
+            || subtype == "xml"
+            || subtype == "xhtml+xml"
+            || subtype == "mathml+xml"
+            || subtype == "sql"
+            || subtype == "graphql"
+            || subtype == "x-latex"
+            || subtype == "x-tex"
+            || subtype.ends_with("+json")
+            || subtype.ends_with("+xml");
+        return !is_text;
+    }
+
+    false
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Problem

Binary MIME types (images, Arrow IPC, PDF, etc.) from Jupyter kernels are stored as **base64 TEXT** in the blob store instead of raw binary bytes.

The Jupyter wire protocol sends image data as base64 strings (`"image/png": "iVBOR..."`). The `value_to_string()` → `ContentRef::from_data(&str)` pipeline stores these base64 characters as UTF-8 bytes — not the decoded PNG binary. The blob HTTP server then serves this base64 text with `Content-Type: image/png`, which is semantically wrong.

**Impact:**
- 33% storage overhead on every image (base64 expansion)
- Wrong HTTP semantics (`Content-Type: image/png` with base64 text body)
- Blocks binary format support (Arrow IPC, Parquet, MessagePack, CBOR)
- Content hashes are of base64 text, not actual content

This worked by accident because the frontend's manifest resolution fetches blob content as text, feeds it through `ImageOutput` which wraps it as `data:image/png;base64,{str}` — reconstructing what should have been a direct binary fetch.

## Fix

### Rust side (`output_store.rs`)

- **`is_binary_mime()`** — `image/*`, `audio/*`, `video/*`, and `application/*` (except text-like: json, javascript, xml, `+json`, `+xml`)
- **`ContentRef::from_binary()`** — always blob (no inline threshold for binary), stores raw `&[u8]`
- **`ContentRef::resolve_binary_as_base64()`** — reads raw bytes, base64-encodes for `.ipynb` save path
- **`convert_data_bundle`** / **`convert_value_to_content_refs`** — base64-decode before storing for binary MIME types
- **`resolve_data_bundle`** — use `resolve_binary_as_base64` for binary MIME types

### Frontend side (`manifest-resolution.ts`)

- **`isBinaryMime()`** — matches the Rust implementation
- **`resolveContentRef(ref, blobPort, mimeType?)`** — for binary blob refs, returns `http://127.0.0.1:PORT/blob/HASH` instead of fetching. The browser `<img>` tag fetches raw bytes directly with correct `Content-Type`.
- **`resolveDataBundle`** — passes `mimeType` through

### No changes needed

| Component | Why |
|-----------|-----|
| `blob_store.rs` | Already binary-clean (`&[u8]` in, bytes out) |
| `blob_server.rs` | Already serves raw bytes with Content-Type from `.meta` |
| `ImageOutput` | Already handles `http://` URLs |
| iframe `frame-html.ts` | Already handles `http` URLs |
| `MediaRouter` | No change |

## What this enables

- **Correct HTTP semantics** — `Content-Type: image/png` with actual PNG bytes
- **33% smaller blob storage** for images
- **Direct `<img src=URL>` rendering** — no base64 data URIs, no memory pressure
- **Tiny postMessage payloads** for iframes — URL string vs megabytes of base64
- **Future binary formats** — Arrow IPC, Parquet, CBOR, MessagePack just work through the same pipeline

## Tests

- All 16 Rust `output_store` tests pass
- All 496 frontend tests pass (8 new tests for `isBinaryMime`, updated manifest-resolution tests)
- tsc clean, biome clean, cargo check clean