### PR TITLE
fix(session): use runtime Handle for spawn_rekey_watcher (tokio panic)

### DIFF
--- a/crates/runtimed-py/src/async_session.rs
+++ b/crates/runtimed-py/src/async_session.rs
@@ -155,7 +155,11 @@ impl AsyncSession {
 
             let override_arc = Arc::new(std::sync::Mutex::new(None));
             if let Some(ref rx) = state.broadcast_rx {
-                session_core::spawn_rekey_watcher(rx, Arc::clone(&override_arc));
+                session_core::spawn_rekey_watcher(
+                    rx,
+                    Arc::clone(&override_arc),
+                    &tokio::runtime::Handle::current(),
+                );
             }
 
             Ok(AsyncSession {
@@ -217,7 +221,11 @@ impl AsyncSession {
 
             let override_arc = Arc::new(std::sync::Mutex::new(None));
             if let Some(ref rx) = state.broadcast_rx {
-                session_core::spawn_rekey_watcher(rx, Arc::clone(&override_arc));
+                session_core::spawn_rekey_watcher(
+                    rx,
+                    Arc::clone(&override_arc),
+                    &tokio::runtime::Handle::current(),
+                );
             }
 
             Ok(AsyncSession {
@@ -245,7 +253,11 @@ impl AsyncSession {
             {
                 let st = state.lock().await;
                 if let Some(ref rx) = st.broadcast_rx {
-                    session_core::spawn_rekey_watcher(rx, override_arc);
+                    session_core::spawn_rekey_watcher(
+                        rx,
+                        override_arc,
+                        &tokio::runtime::Handle::current(),
+                    );
                 }
             }
             Ok(())

--- a/crates/runtimed-py/src/session.rs
+++ b/crates/runtimed-py/src/session.rs
@@ -151,7 +151,7 @@ impl Session {
 
         let override_arc = Arc::new(std::sync::Mutex::new(None));
         if let Some(ref rx) = state.broadcast_rx {
-            session_core::spawn_rekey_watcher(rx, Arc::clone(&override_arc));
+            session_core::spawn_rekey_watcher(rx, Arc::clone(&override_arc), runtime.handle());
         }
 
         Ok(Self {
@@ -213,7 +213,7 @@ impl Session {
 
         let override_arc = Arc::new(std::sync::Mutex::new(None));
         if let Some(ref rx) = state.broadcast_rx {
-            session_core::spawn_rekey_watcher(rx, Arc::clone(&override_arc));
+            session_core::spawn_rekey_watcher(rx, Arc::clone(&override_arc), rt.handle());
         }
 
         Ok(Self {
@@ -239,7 +239,11 @@ impl Session {
         self.runtime.block_on(async {
             let st = self.state.lock().await;
             if let Some(ref rx) = st.broadcast_rx {
-                session_core::spawn_rekey_watcher(rx, Arc::clone(&self.notebook_id_override));
+                session_core::spawn_rekey_watcher(
+                    rx,
+                    Arc::clone(&self.notebook_id_override),
+                    self.runtime.handle(),
+                );
             }
         });
         Ok(())

--- a/crates/runtimed-py/src/session_core.rs
+++ b/crates/runtimed-py/src/session_core.rs
@@ -1882,4 +1882,44 @@ mod tests {
         let b = make_actor_label("Claude");
         assert_ne!(a, b, "each call should produce a unique session suffix");
     }
+
+    /// Regression test: spawn_rekey_watcher must work when called OUTSIDE
+    /// of `runtime.block_on()` — the sync Session API calls it after
+    /// `block_on` returns. Previously it used `tokio::spawn` which panics
+    /// without an active runtime context. The fix uses `handle.spawn()`.
+    #[test]
+    fn test_spawn_rekey_watcher_outside_block_on() {
+        use notebook_protocol::protocol::NotebookBroadcast;
+
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+
+        // Create a broadcast channel (capacity 16 is fine for tests)
+        let (tx, rx) = tokio::sync::broadcast::channel::<NotebookBroadcast>(16);
+        let broadcast_rx = notebook_sync::BroadcastReceiver::new(rx);
+
+        let override_arc = Arc::new(std::sync::Mutex::new(None::<String>));
+
+        // This is the critical call — it must NOT panic when called
+        // outside of block_on, using only the runtime handle.
+        spawn_rekey_watcher(&broadcast_rx, Arc::clone(&override_arc), runtime.handle());
+
+        // Send a RoomRenamed broadcast and verify the override is updated
+        let new_id = "notebooks/test.ipynb".to_string();
+        tx.send(NotebookBroadcast::RoomRenamed {
+            new_notebook_id: new_id.clone(),
+        })
+        .unwrap();
+
+        // Give the spawned task a moment to process
+        runtime.block_on(async {
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        });
+
+        let override_val = override_arc.lock().unwrap();
+        assert_eq!(
+            override_val.as_deref(),
+            Some("notebooks/test.ipynb"),
+            "spawn_rekey_watcher should update notebook_id_override on RoomRenamed"
+        );
+    }
 }

--- a/crates/runtimed-py/src/session_core.rs
+++ b/crates/runtimed-py/src/session_core.rs
@@ -171,9 +171,10 @@ pub(crate) async fn connect(state: &Arc<Mutex<SessionState>>, notebook_id: &str)
 pub(crate) fn spawn_rekey_watcher(
     broadcast_rx: &BroadcastReceiver,
     notebook_id_override: Arc<std::sync::Mutex<Option<String>>>,
+    handle: &tokio::runtime::Handle,
 ) {
     let mut rx = broadcast_rx.resubscribe();
-    tokio::spawn(async move {
+    handle.spawn(async move {
         loop {
             match rx.recv().await {
                 Some(NotebookBroadcast::RoomRenamed { new_notebook_id }) => {


### PR DESCRIPTION
## Problem

`spawn_rekey_watcher` (introduced in PR #945) calls `tokio::spawn()` without an active tokio runtime context. This panics in the sync `Session` API (`open_notebook`, `create_notebook`, `connect`) because `runtime.block_on()` has already returned by the time `spawn_rekey_watcher` is called.

```
pyo3_runtime.PanicException: there is no reactor running, must be called from the context of a Tokio 1.x runtime
```

11 integration tests failed on Linux CI: all `TestOpenNotebook`, `TestCreateNotebook`, and `TestTrustApproval` tests.

## Fix

Accept a `&tokio::runtime::Handle` parameter in `spawn_rekey_watcher` and use `handle.spawn()` instead of `tokio::spawn()`.

- **Sync `Session`**: passes `runtime.handle()` (the owned `Runtime` is still alive)
- **Async `AsyncSession`**: passes `Handle::current()` (already in a tokio context)

## Files changed

| File | Change |
|------|--------|
| `session_core.rs` | `spawn_rekey_watcher` accepts `&Handle`, uses `handle.spawn()` |
| `session.rs` | 3 call sites pass `runtime.handle()` / `rt.handle()` |
| `async_session.rs` | 3 call sites pass `Handle::current()` |