### PR TITLE
fix(conda): improve channel error recovery and default channel UX

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -1126,6 +1126,7 @@ function AppContent() {
               onSetChannels={setCondaChannels}
               onSetPython={setCondaPython}
               onSyncNow={condaDerivedSyncState ? handleSyncDeps : syncCondaNow}
+              onRetryLaunch={tryStartKernel}
               envProgress={envProgress.envType === "conda" ? envProgress : null}
               onResetProgress={envProgress.reset}
               environmentYmlInfo={environmentYmlInfo}

--- a/apps/notebook/src/components/CondaDependencyHeader.tsx
+++ b/apps/notebook/src/components/CondaDependencyHeader.tsx
@@ -32,6 +32,8 @@ interface CondaDependencyHeaderProps {
   onSetChannels: (channels: string[]) => Promise<void>;
   onSetPython: (python: string | null) => Promise<void>;
   onSyncNow: () => Promise<boolean>;
+  /** Re-launch kernel (used for retry after env creation failure) */
+  onRetryLaunch?: () => Promise<boolean>;
   /** Environment preparation progress state */
   envProgress?: EnvProgressState | null;
   /** Callback to reset/dismiss error state */
@@ -61,6 +63,7 @@ export function CondaDependencyHeader({
   onSetChannels,
   onSetPython,
   onSyncNow,
+  onRetryLaunch,
   envProgress,
   onResetProgress,
   environmentYmlInfo,
@@ -186,11 +189,12 @@ export function CondaDependencyHeader({
               <div className="flex items-center gap-1 shrink-0">
                 <button
                   type="button"
+                  disabled={syncing || loading}
                   onClick={() => {
                     onResetProgress?.();
-                    onSyncNow();
+                    (onRetryLaunch ?? onSyncNow)();
                   }}
-                  className="flex items-center gap-1 rounded bg-red-600 px-2 py-0.5 text-white text-xs font-medium hover:bg-red-700 transition-colors"
+                  className="flex items-center gap-1 rounded bg-red-600 px-2 py-0.5 text-white text-xs font-medium hover:bg-red-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                   title="Retry environment creation"
                 >
                   <RefreshCw className="h-3 w-3" />

--- a/apps/notebook/src/components/CondaDependencyHeader.tsx
+++ b/apps/notebook/src/components/CondaDependencyHeader.tsx
@@ -92,19 +92,28 @@ export function CondaDependencyHeader({
 
   const handleAddChannel = useCallback(async () => {
     if (newChannel.trim()) {
-      const updated = [...channels, newChannel.trim()];
+      const trimmed = newChannel.trim();
+      let updated: string[];
+      if (channels.length === 0 && trimmed !== "conda-forge") {
+        // Preserve the implicit conda-forge default as an explicit channel
+        updated = ["conda-forge", trimmed];
+      } else {
+        updated = [...channels, trimmed];
+      }
+      onResetProgress?.();
       await onSetChannels(updated);
       setNewChannel("");
       setShowChannelInput(false);
     }
-  }, [newChannel, channels, onSetChannels]);
+  }, [newChannel, channels, onSetChannels, onResetProgress]);
 
   const handleRemoveChannel = useCallback(
     async (channel: string) => {
       const updated = channels.filter((c) => c !== channel);
+      onResetProgress?.();
       await onSetChannels(updated);
     },
-    [channels, onSetChannels],
+    [channels, onSetChannels, onResetProgress],
   );
 
   const handlePythonChange = useCallback(
@@ -117,6 +126,7 @@ export function CondaDependencyHeader({
 
   // Default channels if none specified
   const displayChannels = channels.length > 0 ? channels : ["conda-forge"];
+  const isUsingDefault = channels.length === 0;
 
   // Calculate progress percentage
   const progressPercent =
@@ -169,17 +179,34 @@ export function CondaDependencyHeader({
                 <pre className="mt-1 whitespace-pre-wrap font-mono text-[10px] opacity-80 overflow-x-auto">
                   {envProgress.error}
                 </pre>
+                <div className="mt-2 text-[11px] text-red-600/80 dark:text-red-400/80">
+                  Fix channels or dependencies above, then retry.
+                </div>
               </div>
-              {onResetProgress && (
+              <div className="flex items-center gap-1 shrink-0">
                 <button
                   type="button"
-                  onClick={onResetProgress}
-                  className="text-red-500 hover:text-red-700 dark:hover:text-red-300 shrink-0"
-                  title="Dismiss"
+                  onClick={() => {
+                    onResetProgress?.();
+                    onSyncNow();
+                  }}
+                  className="flex items-center gap-1 rounded bg-red-600 px-2 py-0.5 text-white text-xs font-medium hover:bg-red-700 transition-colors"
+                  title="Retry environment creation"
                 >
-                  <X className="h-3 w-3" />
+                  <RefreshCw className="h-3 w-3" />
+                  Retry
                 </button>
-              )}
+                {onResetProgress && (
+                  <button
+                    type="button"
+                    onClick={onResetProgress}
+                    className="text-red-500 hover:text-red-700 dark:hover:text-red-300"
+                    title="Dismiss"
+                  >
+                    <X className="h-3 w-3" />
+                  </button>
+                )}
+              </div>
             </div>
           </div>
         )}
@@ -337,6 +364,11 @@ export function CondaDependencyHeader({
                 className="flex items-center gap-1 rounded bg-emerald-100 dark:bg-emerald-900/30 px-2 py-0.5 text-xs border border-emerald-200 dark:border-emerald-800"
               >
                 <span className="font-mono">{channel}</span>
+                {isUsingDefault && (
+                  <span className="text-[10px] text-muted-foreground ml-0.5">
+                    (default)
+                  </span>
+                )}
                 {channels.length > 0 && (
                   <button
                     type="button"


### PR DESCRIPTION
## Summary

- **Error recovery**: Add a Retry button to the env creation error banner so users can re-trigger after fixing channels/deps. Also auto-clears stale errors when channels are added or removed, so the user isn't stuck in a dead-end error state.
- **Default channel UX**: Labels the implicit `conda-forge` as "(default)" when no channels are explicitly set. When adding the first custom channel, `conda-forge` is auto-preserved so it doesn't silently disappear.

Reported during nightly testing — adding `defaults` (anaconda.org) caused an error with no recovery path, and the phantom conda-forge default was confusing.

## Test plan

- [ ] Add an invalid/failing channel, trigger kernel launch, see error banner → click Retry
- [ ] Modify channels while error is shown → error auto-clears
- [ ] Empty channels shows `conda-forge (default)` with no remove button
- [ ] Add `bioconda` to empty channels → result is `["conda-forge", "bioconda"]`, both removable
- [ ] Remove all channels → `conda-forge (default)` reappears