### PR TITLE
fix: notify metadata store on incremental sync (dep chip regression)

### DIFF
--- a/apps/notebook/src/lib/frame-pipeline.ts
+++ b/apps/notebook/src/lib/frame-pipeline.ts
@@ -421,4 +421,9 @@ async function materializeFromBatch(
       if (cell) updateCellById(cellId, () => cell);
     }
   }
+
+  // Always notify metadata — a sync batch may contain metadata-only
+  // changes (e.g. add_dependency) that produce an empty cell changeset.
+  // Without this, the dependency chip UI won't re-render.
+  notifyMetadataChanged();
 }

--- a/apps/notebook/src/lib/frame-pipeline.ts
+++ b/apps/notebook/src/lib/frame-pipeline.ts
@@ -421,9 +421,4 @@ async function materializeFromBatch(
       if (cell) updateCellById(cellId, () => cell);
     }
   }
-
-  // Always notify metadata — a sync batch may contain metadata-only
-  // changes (e.g. add_dependency) that produce an empty cell changeset.
-  // Without this, the dependency chip UI won't re-render.
-  notifyMetadataChanged();
 }

--- a/apps/notebook/src/lib/frame-pipeline.ts
+++ b/apps/notebook/src/lib/frame-pipeline.ts
@@ -421,4 +421,9 @@ async function materializeFromBatch(
       if (cell) updateCellById(cellId, () => cell);
     }
   }
+
+  // Always refresh notebook-level metadata after any sync batch.
+  // The Automerge doc may contain metadata-only changes (e.g. dependency
+  // additions via MCP) that don't appear in the cell changeset.
+  notifyMetadataChanged();
 }


### PR DESCRIPTION
## Problem

Adding dependencies via MCP (`add_dependency`) updates the Automerge doc metadata, but the dependency chip list in the frontend never re-renders. The "Re-initialize environment" banner DOES update because it uses a separate channel (daemon `env_sync_state` broadcast).

Root cause: `materializeFromBatch()` in the frame pipeline only called `notifyMetadataChanged()` after full materialization or structural cell changes. Metadata-only syncs (no cell changes) produce an empty `CellChangeset`, so the per-cell loop has nothing to iterate and the metadata store notification was skipped.

## Fix

Call `notifyMetadataChanged()` at the end of every `materializeFromBatch()` call. This is cheap — only 4-5 components subscribe (`useDetectRuntime`, `useUvDependencies`, `useCondaDeps`, `useDenoFlexibleNpmImports`), all with `useMemo` gating on derived values.