### PR TITLE
fix(notebook): await blob port in full materialization path

### DIFF
--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -82,7 +82,10 @@ export function useAutomergeNotebook() {
   const materializeCells = useCallback(async (handle: NotebookHandle) => {
     const json = handle.get_cells_json();
     const snapshots: CellSnapshot[] = JSON.parse(json);
-    const blobPort = getBlobPort();
+    let blobPort = getBlobPort();
+    if (blobPort === null) {
+      blobPort = await refreshBlobPort();
+    }
     const newCells = await cellSnapshotsToNotebookCells(
       snapshots,
       blobPort,

--- a/apps/notebook/src/lib/materialize-cells.ts
+++ b/apps/notebook/src/lib/materialize-cells.ts
@@ -281,6 +281,11 @@ export function materializeCellFromWasm(
             return null;
           }
         }
+        logger.debug(
+          "[materialize-cells] materializeCellFromWasm: uncached manifest hash dropped for cell %s: %s",
+          cellId,
+          outputStr.slice(0, 16),
+        );
         return null;
       })
       .filter((o): o is JupyterOutput => o !== null);


### PR DESCRIPTION
`materializeCells` read `getBlobPort()` synchronously — if the port hadn't resolved yet (common during initial sync and daemon reconnect), all manifest-hash outputs silently resolved to `null` and got filtered out.

The incremental per-cell path in `materializeFromBatch` already handled this correctly by awaiting `refreshBlobPort()` on null. This aligns the full materialization path to do the same.

Also adds debug logging in `materializeCellFromWasm` when uncached manifest hashes are dropped in the fast sync path, to help surface any remaining output-drop issues.

_PR submitted by @rgbkrk's agent Quill, via Zed_