### PR TITLE
feat(runtimed-py): add Client and AsyncClient API

### DIFF
--- a/crates/runtimed-py/src/async_client.rs
+++ b/crates/runtimed-py/src/async_client.rs
@@ -1,0 +1,218 @@
+//! AsyncClient for async daemon operations and session creation.
+//!
+//! Async counterpart to `Client`. Uses `future_into_py` for all operations.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use pyo3::prelude::*;
+use pyo3_async_runtimes::tokio::future_into_py;
+
+use crate::async_session::AsyncSession;
+use crate::daemon_paths::get_socket_path;
+use crate::error::to_py_err;
+
+/// Async client for the runtimed daemon.
+///
+/// Primary entry point for the async runtimed Python API. Creates pre-connected
+/// async sessions for notebook operations and provides daemon-level operations.
+///
+/// Example:
+///     client = AsyncClient()
+///     session = await client.open_notebook("/path/to/notebook.ipynb")
+///     cell_ids = await session.get_cell_ids()
+#[pyclass]
+pub struct AsyncClient {
+    socket_path: PathBuf,
+    peer_label: Option<String>,
+}
+
+#[pymethods]
+impl AsyncClient {
+    /// Create a new async client.
+    ///
+    /// Args:
+    ///     socket_path: Optional path to the daemon socket. If not provided,
+    ///         uses RUNTIMED_SOCKET_PATH env var or the default path.
+    ///     peer_label: Optional label for collaborative presence (e.g., "Claude").
+    ///         Applied to all sessions created by this client unless overridden.
+    #[new]
+    #[pyo3(signature = (socket_path=None, peer_label=None))]
+    fn new(socket_path: Option<String>, peer_label: Option<String>) -> Self {
+        let socket_path = socket_path
+            .map(PathBuf::from)
+            .unwrap_or_else(get_socket_path);
+        Self {
+            socket_path,
+            peer_label,
+        }
+    }
+
+    /// Ping the daemon to check if it's alive.
+    fn ping<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let socket_path = self.socket_path.clone();
+        future_into_py(py, async move {
+            let client = runtimed::client::PoolClient::new(socket_path);
+            Ok(client.ping().await.is_ok())
+        })
+    }
+
+    /// Check if the daemon is running.
+    fn is_running<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let socket_path = self.socket_path.clone();
+        future_into_py(py, async move {
+            let client = runtimed::client::PoolClient::new(socket_path);
+            Ok(client.is_daemon_running().await)
+        })
+    }
+
+    /// Get pool statistics.
+    fn status<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let socket_path = self.socket_path.clone();
+        future_into_py(py, async move {
+            let client = runtimed::client::PoolClient::new(socket_path);
+            let stats = client.status().await.map_err(to_py_err)?;
+            let mut map = HashMap::new();
+            map.insert("uv_available".to_string(), stats.uv_available as i64);
+            map.insert("conda_available".to_string(), stats.conda_available as i64);
+            map.insert("uv_warming".to_string(), stats.uv_warming as i64);
+            map.insert("conda_warming".to_string(), stats.conda_warming as i64);
+            Ok(map)
+        })
+    }
+
+    /// List all active notebook rooms.
+    fn list_rooms<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let socket_path = self.socket_path.clone();
+        future_into_py(py, async move {
+            let client = runtimed::client::PoolClient::new(socket_path);
+            let rooms = client.list_rooms().await.map_err(to_py_err)?;
+            let result: Vec<HashMap<String, String>> = rooms
+                .into_iter()
+                .map(|room| {
+                    let mut map = HashMap::new();
+                    map.insert("notebook_id".to_string(), room.notebook_id);
+                    map.insert("active_peers".to_string(), room.active_peers.to_string());
+                    map.insert("has_kernel".to_string(), room.has_kernel.to_string());
+                    if let Some(kernel_type) = room.kernel_type {
+                        map.insert("kernel_type".to_string(), kernel_type);
+                    }
+                    if let Some(kernel_status) = room.kernel_status {
+                        map.insert("kernel_status".to_string(), kernel_status);
+                    }
+                    if let Some(env_source) = room.env_source {
+                        map.insert("env_source".to_string(), env_source);
+                    }
+                    map
+                })
+                .collect();
+            Ok(result)
+        })
+    }
+
+    /// Flush all pooled environments and rebuild.
+    fn flush_pool<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let socket_path = self.socket_path.clone();
+        future_into_py(py, async move {
+            let client = runtimed::client::PoolClient::new(socket_path);
+            client.flush_pool().await.map_err(to_py_err)
+        })
+    }
+
+    /// Request daemon shutdown.
+    fn shutdown<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let socket_path = self.socket_path.clone();
+        future_into_py(py, async move {
+            let client = runtimed::client::PoolClient::new(socket_path);
+            client.shutdown().await.map_err(to_py_err)
+        })
+    }
+
+    // =========================================================================
+    // Session factory methods
+    // =========================================================================
+
+    /// Open an existing notebook file and return a connected AsyncSession.
+    ///
+    /// Args:
+    ///     path: Path to the .ipynb file.
+    ///     peer_label: Optional label override (defaults to client's peer_label).
+    #[pyo3(signature = (path, peer_label=None))]
+    fn open_notebook<'py>(
+        &self,
+        py: Python<'py>,
+        path: &str,
+        peer_label: Option<String>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let label = peer_label.or_else(|| self.peer_label.clone());
+        let socket_path = self.socket_path.clone();
+        let path = path.to_string();
+        future_into_py(py, async move {
+            AsyncSession::open_notebook_async(socket_path, path, label).await
+        })
+    }
+
+    /// Create a new notebook and return a connected AsyncSession.
+    ///
+    /// Args:
+    ///     runtime: Kernel runtime type (default: "python").
+    ///     working_dir: Optional working directory for environment detection.
+    ///     peer_label: Optional label override (defaults to client's peer_label).
+    #[pyo3(signature = (runtime="python", working_dir=None, peer_label=None))]
+    fn create_notebook<'py>(
+        &self,
+        py: Python<'py>,
+        runtime: &str,
+        working_dir: Option<&str>,
+        peer_label: Option<String>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        // Validate working_dir if provided
+        if let Some(wd) = working_dir {
+            let path = std::path::Path::new(wd);
+            if !path.exists() {
+                return Err(pyo3::exceptions::PyFileNotFoundError::new_err(format!(
+                    "working_dir does not exist: {}",
+                    wd
+                )));
+            }
+            if !path.is_dir() {
+                return Err(pyo3::exceptions::PyNotADirectoryError::new_err(format!(
+                    "working_dir is not a directory: {}",
+                    wd
+                )));
+            }
+        }
+
+        let label = peer_label.or_else(|| self.peer_label.clone());
+        let socket_path = self.socket_path.clone();
+        let runtime = runtime.to_string();
+        let working_dir_buf = working_dir.map(PathBuf::from);
+        future_into_py(py, async move {
+            AsyncSession::create_notebook_async(socket_path, runtime, working_dir_buf, label).await
+        })
+    }
+
+    /// Join an existing notebook room by ID and return a connected AsyncSession.
+    ///
+    /// Args:
+    ///     notebook_id: The notebook room ID to join.
+    ///     peer_label: Optional label override (defaults to client's peer_label).
+    #[pyo3(signature = (notebook_id, peer_label=None))]
+    fn join_notebook<'py>(
+        &self,
+        py: Python<'py>,
+        notebook_id: &str,
+        peer_label: Option<String>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let label = peer_label.or_else(|| self.peer_label.clone());
+        let socket_path = self.socket_path.clone();
+        let notebook_id = notebook_id.to_string();
+        future_into_py(py, async move {
+            AsyncSession::join_notebook_async(socket_path, notebook_id, label).await
+        })
+    }
+
+    fn __repr__(&self) -> String {
+        format!("AsyncClient(socket={})", self.socket_path.display())
+    }
+}

--- a/crates/runtimed-py/src/async_session.rs
+++ b/crates/runtimed-py/src/async_session.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 
 use crate::daemon_paths::get_socket_path;
-use crate::error::to_py_err;
+use crate::error::{emit_deprecation_warning, to_py_err};
 use crate::event_stream::ExecutionEventStream;
 use crate::session_core::{self, SessionState};
 use crate::subscription::EventSubscription;
@@ -41,6 +41,84 @@ pub struct AsyncSession {
     peer_label: Option<String>,
 }
 
+impl AsyncSession {
+    /// Create a pre-connected AsyncSession from a notebook_id and SessionState.
+    /// Used by AsyncClient.open_notebook() / AsyncClient.create_notebook() / AsyncClient.join_notebook().
+    pub(crate) fn from_state(
+        notebook_id: String,
+        state: SessionState,
+        peer_label: Option<String>,
+    ) -> Self {
+        let override_arc = Arc::new(std::sync::Mutex::new(None));
+        if let Some(ref rx) = state.broadcast_rx {
+            session_core::spawn_rekey_watcher(
+                rx,
+                Arc::clone(&override_arc),
+                &tokio::runtime::Handle::current(),
+            );
+        }
+        Self {
+            state: Arc::new(Mutex::new(state)),
+            notebook_id,
+            notebook_id_override: override_arc,
+            peer_label,
+        }
+    }
+
+    /// Async helper for open_notebook (no deprecation warning).
+    pub(crate) async fn open_notebook_async(
+        socket_path: PathBuf,
+        path: String,
+        peer_label: Option<String>,
+    ) -> PyResult<Self> {
+        let actor_label = peer_label.as_deref().map(session_core::make_actor_label);
+        let (notebook_id, mut state, _info) =
+            session_core::connect_open(socket_path, &path, actor_label.as_deref()).await?;
+        state.peer_label = peer_label.clone();
+        Ok(Self::from_state(notebook_id, state, peer_label))
+    }
+
+    /// Async helper for create_notebook (no deprecation warning).
+    pub(crate) async fn create_notebook_async(
+        socket_path: PathBuf,
+        runtime: String,
+        working_dir: Option<PathBuf>,
+        peer_label: Option<String>,
+    ) -> PyResult<Self> {
+        let actor_label = peer_label.as_deref().map(session_core::make_actor_label);
+        let (notebook_id, mut state, _info) = session_core::connect_create(
+            socket_path,
+            &runtime,
+            working_dir,
+            actor_label.as_deref(),
+        )
+        .await?;
+        state.peer_label = peer_label.clone();
+        Ok(Self::from_state(notebook_id, state, peer_label))
+    }
+
+    /// Async helper for join_notebook (no deprecation warning).
+    pub(crate) async fn join_notebook_async(
+        socket_path: PathBuf,
+        notebook_id: String,
+        peer_label: Option<String>,
+    ) -> PyResult<Self> {
+        let actor_label = peer_label.as_deref().map(session_core::make_actor_label);
+        let mut state = SessionState::new();
+        state.peer_label = peer_label.clone();
+        state.actor_label = actor_label;
+
+        let state_arc = Arc::new(Mutex::new(state));
+        session_core::connect_with_socket(&state_arc, &notebook_id, socket_path).await?;
+
+        let state = Arc::try_unwrap(state_arc)
+            .map_err(|_| to_py_err("Failed to unwrap session state"))?
+            .into_inner();
+
+        Ok(Self::from_state(notebook_id, state, peer_label))
+    }
+}
+
 #[pymethods]
 impl AsyncSession {
     /// Create a new async session.
@@ -50,7 +128,12 @@ impl AsyncSession {
     ///     peer_label: Optional label for collaborative presence.
     #[new]
     #[pyo3(signature = (notebook_id=None, peer_label=None))]
-    fn new(notebook_id: Option<String>, peer_label: Option<String>) -> PyResult<Self> {
+    fn new(
+        py: Python<'_>,
+        notebook_id: Option<String>,
+        peer_label: Option<String>,
+    ) -> PyResult<Self> {
+        emit_deprecation_warning(py, "AsyncSession() is deprecated. Use AsyncClient().open_notebook() or AsyncClient().create_notebook() instead.")?;
         let notebook_id =
             notebook_id.unwrap_or_else(|| format!("agent-session-{}", uuid::Uuid::new_v4()));
 
@@ -143,31 +226,11 @@ impl AsyncSession {
         path: &str,
         peer_label: Option<String>,
     ) -> PyResult<Bound<'py, PyAny>> {
+        emit_deprecation_warning(py, "AsyncSession.open_notebook() is deprecated. Use AsyncClient().open_notebook() instead.")?;
         let path = path.to_string();
-        let actor_label = peer_label.as_deref().map(session_core::make_actor_label);
-
+        let socket_path = get_socket_path();
         future_into_py(py, async move {
-            let socket_path = get_socket_path();
-            let (notebook_id, mut state, _info) =
-                session_core::connect_open(socket_path, &path, actor_label.as_deref()).await?;
-
-            state.peer_label = peer_label.clone();
-
-            let override_arc = Arc::new(std::sync::Mutex::new(None));
-            if let Some(ref rx) = state.broadcast_rx {
-                session_core::spawn_rekey_watcher(
-                    rx,
-                    Arc::clone(&override_arc),
-                    &tokio::runtime::Handle::current(),
-                );
-            }
-
-            Ok(AsyncSession {
-                state: Arc::new(Mutex::new(state)),
-                notebook_id,
-                notebook_id_override: override_arc,
-                peer_label,
-            })
+            Self::open_notebook_async(socket_path, path, peer_label).await
         })
     }
 
@@ -186,7 +249,7 @@ impl AsyncSession {
         working_dir: Option<&str>,
         peer_label: Option<String>,
     ) -> PyResult<Bound<'py, PyAny>> {
-        let actor_label = peer_label.as_deref().map(session_core::make_actor_label);
+        emit_deprecation_warning(py, "AsyncSession.create_notebook() is deprecated. Use AsyncClient().create_notebook() instead.")?;
         // Validate working_dir if provided
         if let Some(wd) = working_dir {
             let path = std::path::Path::new(wd);
@@ -206,34 +269,10 @@ impl AsyncSession {
 
         let runtime = runtime.to_string();
         let working_dir_buf = working_dir.map(PathBuf::from);
+        let socket_path = get_socket_path();
 
         future_into_py(py, async move {
-            let socket_path = get_socket_path();
-            let (notebook_id, mut state, _info) = session_core::connect_create(
-                socket_path,
-                &runtime,
-                working_dir_buf,
-                actor_label.as_deref(),
-            )
-            .await?;
-
-            state.peer_label = peer_label.clone();
-
-            let override_arc = Arc::new(std::sync::Mutex::new(None));
-            if let Some(ref rx) = state.broadcast_rx {
-                session_core::spawn_rekey_watcher(
-                    rx,
-                    Arc::clone(&override_arc),
-                    &tokio::runtime::Handle::current(),
-                );
-            }
-
-            Ok(AsyncSession {
-                state: Arc::new(Mutex::new(state)),
-                notebook_id,
-                notebook_id_override: override_arc,
-                peer_label,
-            })
+            Self::create_notebook_async(socket_path, runtime, working_dir_buf, peer_label).await
         })
     }
 

--- a/crates/runtimed-py/src/client.rs
+++ b/crates/runtimed-py/src/client.rs
@@ -2,12 +2,15 @@
 //!
 //! Provides access to daemon status, pool information, and room listing.
 
+use std::path::PathBuf;
+
 use crate::daemon_paths::get_socket_path;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 use tokio::runtime::Runtime;
 
-use crate::error::to_py_err;
+use crate::error::{emit_deprecation_warning, to_py_err};
+use crate::session::Session;
 
 /// Client for communicating with the runtimed daemon.
 ///
@@ -33,7 +36,11 @@ impl DaemonClient {
     /// if set, otherwise falls back to the default path (which uses
     /// RUNTIMED_WORKSPACE_PATH for dev mode).
     #[new]
-    fn new() -> PyResult<Self> {
+    fn new(py: Python<'_>) -> PyResult<Self> {
+        emit_deprecation_warning(
+            py,
+            "DaemonClient() is deprecated. Use Client() or AsyncClient() instead.",
+        )?;
         let runtime = Runtime::new().map_err(to_py_err)?;
         let socket_path = get_socket_path();
         let client = runtimed::client::PoolClient::new(socket_path);
@@ -134,5 +141,170 @@ impl DaemonClient {
             "disconnected"
         };
         format!("DaemonClient({})", status)
+    }
+}
+
+// =========================================================================
+// New Client API
+// =========================================================================
+
+/// Synchronous client for the runtimed daemon.
+///
+/// Primary entry point for the runtimed Python API. Creates pre-connected
+/// sessions for notebook operations and provides daemon-level operations.
+///
+/// Example:
+///     client = Client()
+///     session = client.open_notebook("/path/to/notebook.ipynb")
+///     cell_ids = session.get_cell_ids()
+#[pyclass]
+pub struct Client {
+    runtime: Runtime,
+    client: runtimed::client::PoolClient,
+    socket_path: PathBuf,
+    peer_label: Option<String>,
+}
+
+#[pymethods]
+impl Client {
+    /// Create a new client.
+    ///
+    /// Args:
+    ///     socket_path: Optional path to the daemon socket. If not provided,
+    ///         uses RUNTIMED_SOCKET_PATH env var or the default path.
+    ///     peer_label: Optional label for collaborative presence (e.g., "Claude").
+    ///         Applied to all sessions created by this client unless overridden.
+    #[new]
+    #[pyo3(signature = (socket_path=None, peer_label=None))]
+    fn new(socket_path: Option<String>, peer_label: Option<String>) -> PyResult<Self> {
+        let runtime = Runtime::new().map_err(to_py_err)?;
+        let socket_path = socket_path
+            .map(PathBuf::from)
+            .unwrap_or_else(get_socket_path);
+        let client = runtimed::client::PoolClient::new(socket_path.clone());
+        Ok(Self {
+            runtime,
+            client,
+            socket_path,
+            peer_label,
+        })
+    }
+
+    /// Ping the daemon to check if it's alive.
+    fn ping(&self) -> bool {
+        self.runtime.block_on(self.client.ping()).is_ok()
+    }
+
+    /// Check if the daemon is running.
+    fn is_running(&self) -> bool {
+        self.runtime.block_on(self.client.is_daemon_running())
+    }
+
+    /// Get pool statistics.
+    fn status<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let stats = self
+            .runtime
+            .block_on(self.client.status())
+            .map_err(to_py_err)?;
+
+        let dict = PyDict::new(py);
+        dict.set_item("uv_available", stats.uv_available)?;
+        dict.set_item("conda_available", stats.conda_available)?;
+        dict.set_item("uv_warming", stats.uv_warming)?;
+        dict.set_item("conda_warming", stats.conda_warming)?;
+        Ok(dict)
+    }
+
+    /// List all active notebook rooms.
+    fn list_rooms<'py>(&self, py: Python<'py>) -> PyResult<Vec<Bound<'py, PyDict>>> {
+        let rooms = self
+            .runtime
+            .block_on(self.client.list_rooms())
+            .map_err(to_py_err)?;
+
+        let mut result = Vec::with_capacity(rooms.len());
+        for room in rooms {
+            let dict = PyDict::new(py);
+            dict.set_item("notebook_id", &room.notebook_id)?;
+            dict.set_item("active_peers", room.active_peers)?;
+            dict.set_item("has_kernel", room.has_kernel)?;
+            if let Some(kernel_type) = &room.kernel_type {
+                dict.set_item("kernel_type", kernel_type)?;
+            }
+            if let Some(kernel_status) = &room.kernel_status {
+                dict.set_item("kernel_status", kernel_status)?;
+            }
+            if let Some(env_source) = &room.env_source {
+                dict.set_item("env_source", env_source)?;
+            }
+            result.push(dict);
+        }
+        Ok(result)
+    }
+
+    /// Flush all pooled environments and rebuild.
+    fn flush_pool(&self) -> PyResult<()> {
+        self.runtime
+            .block_on(self.client.flush_pool())
+            .map_err(to_py_err)
+    }
+
+    /// Request daemon shutdown.
+    fn shutdown(&self) -> PyResult<()> {
+        self.runtime
+            .block_on(self.client.shutdown())
+            .map_err(to_py_err)
+    }
+
+    // =========================================================================
+    // Session factory methods
+    // =========================================================================
+
+    /// Open an existing notebook file and return a connected Session.
+    ///
+    /// Args:
+    ///     path: Path to the .ipynb file.
+    ///     peer_label: Optional label override (defaults to client's peer_label).
+    #[pyo3(signature = (path, peer_label=None))]
+    fn open_notebook(&self, path: &str, peer_label: Option<String>) -> PyResult<Session> {
+        let label = peer_label.or_else(|| self.peer_label.clone());
+        Session::open_notebook_with_socket(self.socket_path.clone(), path, label)
+    }
+
+    /// Create a new notebook and return a connected Session.
+    ///
+    /// Args:
+    ///     runtime: Kernel runtime type (default: "python").
+    ///     working_dir: Optional working directory for environment detection.
+    ///     peer_label: Optional label override (defaults to client's peer_label).
+    #[pyo3(signature = (runtime="python", working_dir=None, peer_label=None))]
+    fn create_notebook(
+        &self,
+        runtime: &str,
+        working_dir: Option<&str>,
+        peer_label: Option<String>,
+    ) -> PyResult<Session> {
+        let label = peer_label.or_else(|| self.peer_label.clone());
+        Session::create_notebook_with_socket(self.socket_path.clone(), runtime, working_dir, label)
+    }
+
+    /// Join an existing notebook room by ID and return a connected Session.
+    ///
+    /// Args:
+    ///     notebook_id: The notebook room ID to join.
+    ///     peer_label: Optional label override (defaults to client's peer_label).
+    #[pyo3(signature = (notebook_id, peer_label=None))]
+    fn join_notebook(&self, notebook_id: &str, peer_label: Option<String>) -> PyResult<Session> {
+        let label = peer_label.or_else(|| self.peer_label.clone());
+        Session::join_notebook_with_socket(self.socket_path.clone(), notebook_id, label)
+    }
+
+    fn __repr__(&self) -> String {
+        let status = if self.ping() {
+            "connected"
+        } else {
+            "disconnected"
+        };
+        format!("Client({})", status)
     }
 }

--- a/crates/runtimed-py/src/error.rs
+++ b/crates/runtimed-py/src/error.rs
@@ -9,3 +9,16 @@ pyo3::create_exception!(runtimed, RuntimedError, PyException);
 pub fn to_py_err(err: impl std::fmt::Display) -> PyErr {
     RuntimedError::new_err(err.to_string())
 }
+
+/// Emit a DeprecationWarning via Python's warnings module.
+pub fn emit_deprecation_warning(py: Python<'_>, message: &str) -> PyResult<()> {
+    let warnings = py.import("warnings")?;
+    warnings.call_method1(
+        "warn",
+        (
+            message,
+            py.get_type::<pyo3::exceptions::PyDeprecationWarning>(),
+        ),
+    )?;
+    Ok(())
+}

--- a/crates/runtimed-py/src/lib.rs
+++ b/crates/runtimed-py/src/lib.rs
@@ -12,6 +12,7 @@
 use pyo3::prelude::*;
 use std::path::PathBuf;
 
+mod async_client;
 mod async_session;
 mod client;
 mod daemon_paths;
@@ -23,8 +24,9 @@ mod session;
 mod session_core;
 mod subscription;
 
+use async_client::AsyncClient;
 use async_session::AsyncSession;
-use client::DaemonClient;
+use client::{Client, DaemonClient};
 use error::RuntimedError;
 use event_stream::{ExecutionEventIterator, ExecutionEventStream};
 use output::{
@@ -63,11 +65,15 @@ fn default_socket_path() -> String {
 /// Python module for runtimed daemon client.
 #[pymodule]
 fn runtimed(m: &Bound<'_, PyModule>) -> PyResult<()> {
-    // Core classes - sync API
+    // Core classes - new API (recommended)
+    m.add_class::<Client>()?;
+    m.add_class::<AsyncClient>()?;
+
+    // Core classes - sync API (deprecated, use Client instead)
     m.add_class::<DaemonClient>()?;
     m.add_class::<Session>()?;
 
-    // Core classes - async API
+    // Core classes - async API (deprecated, use AsyncClient instead)
     m.add_class::<AsyncSession>()?;
 
     // Iterator types for streaming execution

--- a/crates/runtimed-py/src/session.rs
+++ b/crates/runtimed-py/src/session.rs
@@ -42,6 +42,126 @@ pub struct Session {
     peer_label: Option<String>,
 }
 
+use crate::error::emit_deprecation_warning;
+
+impl Session {
+    /// Open a notebook without deprecation warning (used by Client).
+    pub(crate) fn open_notebook_inner(path: &str, peer_label: Option<String>) -> PyResult<Self> {
+        let socket_path = get_socket_path();
+        Self::open_notebook_with_socket(socket_path, path, peer_label)
+    }
+
+    /// Open a notebook with a specific socket path (used by Client).
+    pub(crate) fn open_notebook_with_socket(
+        socket_path: PathBuf,
+        path: &str,
+        peer_label: Option<String>,
+    ) -> PyResult<Self> {
+        let runtime = Runtime::new().map_err(to_py_err)?;
+        let actor_label = peer_label.as_deref().map(session_core::make_actor_label);
+
+        let (notebook_id, mut state, _info) = runtime.block_on(session_core::connect_open(
+            socket_path,
+            path,
+            actor_label.as_deref(),
+        ))?;
+
+        state.peer_label = peer_label.clone();
+        drop(runtime);
+
+        Self::from_state(notebook_id, state, peer_label)
+    }
+
+    /// Create a notebook without deprecation warning (used by Client).
+    pub(crate) fn create_notebook_with_socket(
+        socket_path: PathBuf,
+        runtime_type: &str,
+        working_dir: Option<&str>,
+        peer_label: Option<String>,
+    ) -> PyResult<Self> {
+        if let Some(wd) = working_dir {
+            let path = std::path::Path::new(wd);
+            if !path.exists() {
+                return Err(pyo3::exceptions::PyFileNotFoundError::new_err(format!(
+                    "working_dir does not exist: {}",
+                    wd
+                )));
+            }
+            if !path.is_dir() {
+                return Err(pyo3::exceptions::PyNotADirectoryError::new_err(format!(
+                    "working_dir is not a directory: {}",
+                    wd
+                )));
+            }
+        }
+
+        let rt = Runtime::new().map_err(to_py_err)?;
+        let working_dir_buf = working_dir.map(PathBuf::from);
+        let actor_label = peer_label.as_deref().map(session_core::make_actor_label);
+
+        let (notebook_id, mut state, _info) = rt.block_on(session_core::connect_create(
+            socket_path,
+            runtime_type,
+            working_dir_buf,
+            actor_label.as_deref(),
+        ))?;
+
+        state.peer_label = peer_label.clone();
+        drop(rt);
+
+        Self::from_state(notebook_id, state, peer_label)
+    }
+
+    /// Join an existing notebook room by ID (used by Client).
+    pub(crate) fn join_notebook_with_socket(
+        socket_path: PathBuf,
+        notebook_id: &str,
+        peer_label: Option<String>,
+    ) -> PyResult<Self> {
+        let actor_label = peer_label.as_deref().map(session_core::make_actor_label);
+
+        let mut state = SessionState::new();
+        state.peer_label = peer_label.clone();
+        state.actor_label = actor_label;
+
+        let rt = Runtime::new().map_err(to_py_err)?;
+        let state_arc = Arc::new(Mutex::new(state));
+        rt.block_on(session_core::connect_with_socket(
+            &state_arc,
+            notebook_id,
+            socket_path,
+        ))?;
+
+        let state = Arc::try_unwrap(state_arc)
+            .map_err(|_| to_py_err("Failed to unwrap session state"))?
+            .into_inner();
+
+        drop(rt);
+        Self::from_state(notebook_id.to_string(), state, peer_label)
+    }
+
+    /// Create a pre-connected Session from a notebook_id and SessionState.
+    /// Used by Client.open_notebook() / Client.create_notebook() / Client.join_notebook().
+    pub(crate) fn from_state(
+        notebook_id: String,
+        state: SessionState,
+        peer_label: Option<String>,
+    ) -> PyResult<Self> {
+        let runtime = Runtime::new().map_err(to_py_err)?;
+        let override_arc = Arc::new(std::sync::Mutex::new(None));
+        if let Some(ref rx) = state.broadcast_rx {
+            session_core::spawn_rekey_watcher(rx, Arc::clone(&override_arc), runtime.handle());
+        }
+        Ok(Self {
+            runtime,
+            state: Arc::new(Mutex::new(state)),
+            notebook_id,
+            notebook_id_override: override_arc,
+            peer_label,
+        })
+    }
+}
+
 #[pymethods]
 impl Session {
     /// Create a new session.
@@ -53,7 +173,12 @@ impl Session {
     ///                  will share the same kernel.
     #[new]
     #[pyo3(signature = (notebook_id=None, peer_label=None))]
-    fn new(notebook_id: Option<String>, peer_label: Option<String>) -> PyResult<Self> {
+    fn new(
+        py: Python<'_>,
+        notebook_id: Option<String>,
+        peer_label: Option<String>,
+    ) -> PyResult<Self> {
+        emit_deprecation_warning(py, "Session() is deprecated. Use Client().open_notebook() or Client().create_notebook() instead.")?;
         let runtime = Runtime::new().map_err(to_py_err)?;
         let notebook_id =
             notebook_id.unwrap_or_else(|| format!("agent-session-{}", uuid::Uuid::new_v4()));
@@ -136,31 +261,12 @@ impl Session {
     ///     RuntimedError: If the file cannot be opened or parsed.
     #[staticmethod]
     #[pyo3(signature = (path, peer_label=None))]
-    fn open_notebook(path: &str, peer_label: Option<String>) -> PyResult<Self> {
-        let runtime = Runtime::new().map_err(to_py_err)?;
-        let socket_path = get_socket_path();
-        let actor_label = peer_label.as_deref().map(session_core::make_actor_label);
-
-        let (notebook_id, mut state, _info) = runtime.block_on(session_core::connect_open(
-            socket_path,
-            path,
-            actor_label.as_deref(),
-        ))?;
-
-        state.peer_label = peer_label.clone();
-
-        let override_arc = Arc::new(std::sync::Mutex::new(None));
-        if let Some(ref rx) = state.broadcast_rx {
-            session_core::spawn_rekey_watcher(rx, Arc::clone(&override_arc), runtime.handle());
-        }
-
-        Ok(Self {
-            runtime,
-            state: Arc::new(Mutex::new(state)),
-            notebook_id,
-            notebook_id_override: override_arc,
-            peer_label,
-        })
+    fn open_notebook(py: Python<'_>, path: &str, peer_label: Option<String>) -> PyResult<Self> {
+        emit_deprecation_warning(
+            py,
+            "Session.open_notebook() is deprecated. Use Client().open_notebook() instead.",
+        )?;
+        Self::open_notebook_inner(path, peer_label)
     }
 
     /// Create a new notebook.
@@ -176,53 +282,17 @@ impl Session {
     #[staticmethod]
     #[pyo3(signature = (runtime="python", working_dir=None, peer_label=None))]
     fn create_notebook(
+        py: Python<'_>,
         runtime: &str,
         working_dir: Option<&str>,
         peer_label: Option<String>,
     ) -> PyResult<Self> {
-        // Validate working_dir if provided
-        if let Some(wd) = working_dir {
-            let path = std::path::Path::new(wd);
-            if !path.exists() {
-                return Err(pyo3::exceptions::PyFileNotFoundError::new_err(format!(
-                    "working_dir does not exist: {}",
-                    wd
-                )));
-            }
-            if !path.is_dir() {
-                return Err(pyo3::exceptions::PyNotADirectoryError::new_err(format!(
-                    "working_dir is not a directory: {}",
-                    wd
-                )));
-            }
-        }
-
-        let rt = Runtime::new().map_err(to_py_err)?;
+        emit_deprecation_warning(
+            py,
+            "Session.create_notebook() is deprecated. Use Client().create_notebook() instead.",
+        )?;
         let socket_path = get_socket_path();
-        let working_dir_buf = working_dir.map(PathBuf::from);
-        let actor_label = peer_label.as_deref().map(session_core::make_actor_label);
-
-        let (notebook_id, mut state, _info) = rt.block_on(session_core::connect_create(
-            socket_path,
-            runtime,
-            working_dir_buf,
-            actor_label.as_deref(),
-        ))?;
-
-        state.peer_label = peer_label.clone();
-
-        let override_arc = Arc::new(std::sync::Mutex::new(None));
-        if let Some(ref rx) = state.broadcast_rx {
-            session_core::spawn_rekey_watcher(rx, Arc::clone(&override_arc), rt.handle());
-        }
-
-        Ok(Self {
-            runtime: rt,
-            state: Arc::new(Mutex::new(state)),
-            notebook_id,
-            notebook_id_override: override_arc,
-            peer_label,
-        })
+        Self::create_notebook_with_socket(socket_path, runtime, working_dir, peer_label)
     }
 
     /// Connect to the daemon.

--- a/crates/runtimed-py/src/session_core.rs
+++ b/crates/runtimed-py/src/session_core.rs
@@ -136,12 +136,22 @@ pub(crate) fn get_metadata_env_type(snapshot: &NotebookMetadataSnapshot) -> Opti
 ///
 /// Populates the state with handle, broadcast_rx, and blob paths.
 pub(crate) async fn connect(state: &Arc<Mutex<SessionState>>, notebook_id: &str) -> PyResult<()> {
+    let socket_path = get_socket_path();
+    connect_with_socket(state, notebook_id, socket_path).await
+}
+
+/// Connect to the daemon using a specific socket path.
+///
+/// Populates the state with handle, broadcast_rx, and blob paths.
+pub(crate) async fn connect_with_socket(
+    state: &Arc<Mutex<SessionState>>,
+    notebook_id: &str,
+    socket_path: PathBuf,
+) -> PyResult<()> {
     let mut st = state.lock().await;
     if st.handle.is_some() {
         return Ok(());
     }
-
-    let socket_path = get_socket_path();
 
     let result = notebook_sync::connect::connect(socket_path.clone(), notebook_id.to_string())
         .await

--- a/python/nteract/src/nteract/_mcp_server.py
+++ b/python/nteract/src/nteract/_mcp_server.py
@@ -73,15 +73,15 @@ def _peer_label() -> str:
 
 # Session state - single active session at a time
 _session: runtimed.AsyncSession | None = None
-_daemon_client: runtimed.DaemonClient | None = None
+_client: runtimed.AsyncClient | None = None
 
 
-def _get_daemon_client() -> runtimed.DaemonClient:
-    """Get or create the daemon client."""
-    global _daemon_client
-    if _daemon_client is None:
-        _daemon_client = runtimed.DaemonClient()
-    return _daemon_client
+def _get_client() -> runtimed.AsyncClient:
+    """Get or create the async client."""
+    global _client
+    if _client is None:
+        _client = runtimed.AsyncClient()
+    return _client
 
 
 async def _get_session() -> runtimed.AsyncSession:
@@ -504,8 +504,8 @@ async def list_active_notebooks() -> list[dict[str, Any]]:
     Returns notebooks currently open by users or other agents.
     Use join_notebook(notebook_id) to connect to one.
     """
-    client = _get_daemon_client()
-    rooms = client.list_rooms()
+    client = _get_client()
+    rooms = await client.list_rooms()
     return [
         {
             "notebook_id": room["notebook_id"],
@@ -544,8 +544,8 @@ if not _no_show:
                     "Use list_active_notebooks() to find a notebook_id, or connect to one first."
                 )
 
-        client = _get_daemon_client()
-        rooms = client.list_rooms()
+        client = _get_client()
+        rooms = await client.list_rooms()
         room_ids = {room["notebook_id"] for room in rooms}
         if target not in room_ids:
             raise ValueError(
@@ -583,9 +583,9 @@ async def join_notebook(
             await _session.close()
 
     # Join existing session
-    _session = runtimed.AsyncSession(notebook_id=notebook_id, peer_label=_peer_label())
+    client = _get_client()
+    _session = await client.join_notebook(notebook_id, peer_label=_peer_label())
     session = _session
-    await session.connect()
 
     return {
         "notebook_id": session.notebook_id,
@@ -607,7 +607,8 @@ async def open_notebook(path: str, ctx: Context | None = None) -> dict[str, Any]
         with contextlib.suppress(Exception):
             await _session.close()
 
-    _session = await runtimed.AsyncSession.open_notebook(path, peer_label=_peer_label())
+    client = _get_client()
+    _session = await client.open_notebook(path, peer_label=_peer_label())
     session = _session
     return {
         "notebook_id": session.notebook_id,
@@ -651,7 +652,8 @@ async def create_notebook(
         with contextlib.suppress(Exception):
             await _session.close()
 
-    _session = await runtimed.AsyncSession.create_notebook(
+    client = _get_client()
+    _session = await client.create_notebook(
         runtime=runtime, working_dir=working_dir, peer_label=_peer_label()
     )
     session = _session
@@ -1359,8 +1361,8 @@ async def resource_status() -> str:
 async def resource_rooms() -> str:
     """Get all active notebook rooms as JSON."""
     try:
-        client = _get_daemon_client()
-        rooms = client.list_rooms()
+        client = _get_client()
+        rooms = await client.list_rooms()
         return json.dumps([dict(room) for room in rooms])
     except Exception as e:
         return json.dumps({"error": str(e)})

--- a/python/runtimed/src/runtimed/__init__.py
+++ b/python/runtimed/src/runtimed/__init__.py
@@ -4,8 +4,10 @@ from importlib.metadata import PackageNotFoundError, version
 
 # Native daemon client (PyO3 bindings)
 from runtimed.runtimed import (
+    AsyncClient,
     AsyncSession,
     Cell,
+    Client,
     CompletionItem,
     CompletionResult,
     DaemonClient,
@@ -22,10 +24,12 @@ from runtimed.runtimed import (
 )
 
 __all__ = [
-    # Daemon client API - sync
+    # New API (recommended)
+    "Client",
+    "AsyncClient",
+    # Legacy API (deprecated, kept for backwards compatibility)
     "DaemonClient",
     "Session",
-    # Daemon client API - async
     "AsyncSession",
     # Output types
     "Cell",

--- a/python/runtimed/src/runtimed/__init__.pyi
+++ b/python/runtimed/src/runtimed/__init__.pyi
@@ -1,10 +1,16 @@
 """Type stubs for the runtimed package."""
 
 from runtimed.runtimed import (
+    AsyncClient as AsyncClient,
+)
+from runtimed.runtimed import (
     AsyncSession as AsyncSession,
 )
 from runtimed.runtimed import (
     Cell as Cell,
+)
+from runtimed.runtimed import (
+    Client as Client,
 )
 from runtimed.runtimed import (
     CompletionItem as CompletionItem,
@@ -64,6 +70,8 @@ from runtimed.runtimed import (
 __version__: str
 
 __all__ = [
+    "Client",
+    "AsyncClient",
     "DaemonClient",
     "Session",
     "AsyncSession",

--- a/python/runtimed/src/runtimed/runtimed.pyi
+++ b/python/runtimed/src/runtimed/runtimed.pyi
@@ -281,7 +281,97 @@ class EventIteratorSubscription:
     def close(self) -> None: ...
 
 # ---------------------------------------------------------------------------
-# DaemonClient
+# Client (recommended sync API)
+# ---------------------------------------------------------------------------
+
+class Client:
+    """Synchronous client for the runtimed daemon.
+
+    Primary entry point for the runtimed Python API. Creates pre-connected
+    sessions for notebook operations and provides daemon-level operations.
+
+    Example::
+
+        client = Client()
+        session = client.open_notebook("/path/to/notebook.ipynb")
+        cell_ids = session.get_cell_ids()
+    """
+
+    def __init__(
+        self,
+        socket_path: str | None = None,
+        peer_label: str | None = None,
+    ) -> None: ...
+    def ping(self) -> bool: ...
+    def is_running(self) -> bool: ...
+    def status(self) -> dict[str, Any]: ...
+    def list_rooms(self) -> list[dict[str, Any]]: ...
+    def flush_pool(self) -> None: ...
+    def shutdown(self) -> None: ...
+    def open_notebook(
+        self,
+        path: str,
+        peer_label: str | None = None,
+    ) -> Session: ...
+    def create_notebook(
+        self,
+        runtime: str = "python",
+        working_dir: str | None = None,
+        peer_label: str | None = None,
+    ) -> Session: ...
+    def join_notebook(
+        self,
+        notebook_id: str,
+        peer_label: str | None = None,
+    ) -> Session: ...
+
+# ---------------------------------------------------------------------------
+# AsyncClient (recommended async API)
+# ---------------------------------------------------------------------------
+
+class AsyncClient:
+    """Async client for the runtimed daemon.
+
+    Primary entry point for the async runtimed Python API. Creates pre-connected
+    async sessions for notebook operations and provides daemon-level operations.
+
+    Example::
+
+        client = AsyncClient()
+        session = await client.open_notebook("/path/to/notebook.ipynb")
+        cell_ids = await session.get_cell_ids()
+    """
+
+    def __init__(
+        self,
+        socket_path: str | None = None,
+        peer_label: str | None = None,
+    ) -> None: ...
+    def ping(self) -> Coroutine[Any, Any, bool]: ...
+    def is_running(self) -> Coroutine[Any, Any, bool]: ...
+    def status(self) -> Coroutine[Any, Any, dict[str, Any]]: ...
+    def list_rooms(self) -> Coroutine[Any, Any, list[dict[str, Any]]]: ...
+    def flush_pool(self) -> Coroutine[Any, Any, None]: ...
+    def shutdown(self) -> Coroutine[Any, Any, None]: ...
+    def open_notebook(
+        self,
+        path: str,
+        peer_label: str | None = None,
+    ) -> Coroutine[Any, Any, AsyncSession]: ...
+    def create_notebook(
+        self,
+        runtime: str = "python",
+        working_dir: str | None = None,
+        peer_label: str | None = None,
+    ) -> Coroutine[Any, Any, AsyncSession]: ...
+    def join_notebook(
+        self,
+        notebook_id: str,
+        peer_label: str | None = None,
+    ) -> Coroutine[Any, Any, AsyncSession]: ...
+
+# ---------------------------------------------------------------------------
+# DaemonClient (deprecated, use Client or AsyncClient)
 # ---------------------------------------------------------------------------
 
 class DaemonClient:


### PR DESCRIPTION
## Summary

Introduces `Client` and `AsyncClient` as the primary entry points for the runtimed Python API. These classes combine daemon-level operations with session factory methods, eliminating the awkward multi-step flow of opening/creating notebooks in the old API.

**Before:** `Session()` → `open_notebook()` → `connect()` (3 steps, confusing)
**After:** `Client().open_notebook()` (1 step, clear)

Includes deprecation warnings on old API (`DaemonClient`, bare `Session()` constructor, staticmethod factories). Existing code continues to work with warnings, enabling a smooth migration path.

Migrates nteract MCP server to new API to eliminate deprecation warnings and improve ergonomics.

## Verification

- [x] `cargo test --verbose` — 119 tests passed
- [x] `cargo xtask lint` — all checks passed
- [ ] Test new API by connecting to a running daemon:
  - Create session with `Client().open_notebook(path)`
  - Verify session is pre-connected and ready for operations

_PR submitted by @rgbkrk's agent, Quill_