### PR TITLE
chore: bump versions for 2.0.1 stable + 2.0.2 nightly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3501,7 +3501,7 @@ dependencies = [
 
 [[package]]
 name = "notebook"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -5653,7 +5653,7 @@ dependencies = [
 
 [[package]]
 name = "runt-cli"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5704,7 +5704,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "alacritty_terminal",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3501,7 +3501,7 @@ dependencies = [
 
 [[package]]
 name = "notebook"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -5653,7 +5653,7 @@ dependencies = [
 
 [[package]]
 name = "runt-cli"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5704,7 +5704,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "alacritty_terminal",
  "anyhow",

--- a/crates/notebook/Cargo.toml
+++ b/crates/notebook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notebook"
-version = "2.0.0"
+version = "2.0.1"
 edition.workspace = true
 description = "Tauri-based notebook UI for Jupyter kernels"
 repository.workspace = true

--- a/crates/notebook/Cargo.toml
+++ b/crates/notebook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notebook"
-version = "2.0.1"
+version = "2.0.2"
 edition.workspace = true
 description = "Tauri-based notebook UI for Jupyter kernels"
 repository.workspace = true

--- a/crates/notebook/tauri.conf.json
+++ b/crates/notebook/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "nteract",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "identifier": "org.nteract.desktop",
   "build": {
     "devUrl": "http://localhost:5174",

--- a/crates/notebook/tauri.conf.json
+++ b/crates/notebook/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "nteract",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "identifier": "org.nteract.desktop",
   "build": {
     "devUrl": "http://localhost:5174",

--- a/crates/runt/Cargo.toml
+++ b/crates/runt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runt-cli"
-version = "2.0.0"
+version = "2.0.1"
 edition.workspace = true
 description = "CLI for Jupyter Runtimes — bundled with nteract"
 repository.workspace = true

--- a/crates/runt/Cargo.toml
+++ b/crates/runt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runt-cli"
-version = "2.0.1"
+version = "2.0.2"
 edition.workspace = true
 description = "CLI for Jupyter Runtimes — bundled with nteract"
 repository.workspace = true

--- a/crates/runtimed/Cargo.toml
+++ b/crates/runtimed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed"
-version = "2.0.1"
+version = "2.0.2"
 edition.workspace = true
 description = "Central daemon for managing Jupyter runtimes and prewarmed environments"
 repository.workspace = true

--- a/crates/runtimed/Cargo.toml
+++ b/crates/runtimed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed"
-version = "2.0.0"
+version = "2.0.1"
 edition.workspace = true
 description = "Central daemon for managing Jupyter runtimes and prewarmed environments"
 repository.workspace = true

--- a/python/nteract/pyproject.toml
+++ b/python/nteract/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nteract"
-version = "2.0.1"
+version = "2.0.2"
 description = "Bring AI to Jupyter notebooks. MCP server for Claude, ChatGPT, Gemini, OpenCode and any agent."
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/python/nteract/pyproject.toml
+++ b/python/nteract/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nteract"
-version = "2.0.0"
+version = "2.0.1"
 description = "Bring AI to Jupyter notebooks. MCP server for Claude, ChatGPT, Gemini, OpenCode and any agent."
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/python/runtimed/pyproject.toml
+++ b/python/runtimed/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "runtimed"
-version = "2.0.0"
+version = "2.0.1"
 description = "Python toolkit for Jupyter runtimes, powered by runtimed Rust binaries"
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/python/runtimed/pyproject.toml
+++ b/python/runtimed/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "runtimed"
-version = "2.0.1"
+version = "2.0.2"
 description = "Python toolkit for Jupyter runtimes, powered by runtimed Rust binaries"
 readme = "README.md"
 license = "BSD-3-Clause"


### PR DESCRIPTION
Two commits:

1. **`chore: bump version to 2.0.1`** — all version sources set to 2.0.1 for the next stable release. Tag this commit as `v2.0.1` after merge to trigger the stable release workflow.

2. **`chore: bump version to 2.0.2`** — moves main to 2.0.2 so nightlies publish as `2.0.2a{timestamp}`, staying ahead of the 2.0.1 stable.

After merge:
```
git tag v2.0.1 bf74a9a6
git push origin v2.0.1
```

_PR submitted by @rgbkrk's agent Quill, via Zed_