### PR TITLE
fix(ci): use version-agnostic regex for runtimed dep pinning

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -174,7 +174,7 @@ jobs:
           echo "Setting nteract version to: ${DEV_VERSION}"
           sed -i "s/^version = .*/version = \"${DEV_VERSION}\"/" pyproject.toml
           # Pin runtimed dep to the same prerelease series
-          sed -i "s/runtimed>=2.0.0a0/runtimed>=${DEV_VERSION}/" pyproject.toml
+          sed -i "s/runtimed>=[^,]*/runtimed>=${DEV_VERSION}/" pyproject.toml
         working-directory: python/nteract
 
       - name: Build

--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -668,7 +668,7 @@ jobs:
           echo "Setting nteract version to: ${DEV_VERSION}"
           sed -i "s/^version = .*/version = \"${DEV_VERSION}\"/" pyproject.toml
           # Pin runtimed dep to the same prerelease timestamp
-          sed -i "s/runtimed>=2.0.0a0/runtimed>=${DEV_VERSION}/" pyproject.toml
+          sed -i "s/runtimed>=[^,]*/runtimed>=${DEV_VERSION}/" pyproject.toml
         working-directory: python/nteract
 
       - name: Build sdist + wheel


### PR DESCRIPTION
The nightly and python-package workflows hardcoded `runtimed>=2.0.0a0` as a literal sed match when pinning the nteract→runtimed dependency for co-built wheels. If the floor version in pyproject.toml ever drifted, the sed would silently no-op and nightly nteract would ship with a stale lower bound.

`runtimed>=[^,]*` matches any version up to the comma (preserving the `,<3.0` upper bound), so it survives version bumps.

_PR submitted by @rgbkrk's agent Quill, via Zed_