### PR TITLE
fix(notebook): prevent text corruption from materialization re-renders

### DIFF
--- a/apps/notebook/src/lib/frame-pipeline.ts
+++ b/apps/notebook/src/lib/frame-pipeline.ts
@@ -398,8 +398,18 @@ async function materializeFromBatch(
         const ecStr = handle.get_cell_execution_count(cellId);
         const ec =
           !ecStr || ecStr === "null" ? null : Number.parseInt(ecStr, 10);
-        const source = handle.get_cell_source(cellId) ?? "";
         const metadata = handle.get_cell_metadata(cellId) ?? {};
+
+        // Preserve the store's source when the changeset says source didn't
+        // change. Reading from WASM after the await is unsafe — the user may
+        // have typed more keystrokes, and the WASM doc could reflect a CRDT
+        // merge that diverges from CodeMirror's state. Using the stale WASM
+        // source would arm @uiw/react-codemirror's typing latch to overwrite
+        // the editor with the stale value on the next typing pause.
+        const existingCell = getCellById(cellId);
+        const source = fields.source
+          ? (handle.get_cell_source(cellId) ?? "")
+          : (existingCell?.source ?? handle.get_cell_source(cellId) ?? "");
 
         updateCellById(cellId, () => ({
           id: cellId,

--- a/apps/notebook/src/lib/notebook-cells.ts
+++ b/apps/notebook/src/lib/notebook-cells.ts
@@ -206,6 +206,7 @@ export function updateCellById(
   const cell = _cellMap.get(id);
   if (!cell) return;
   const updated = updater(cell);
+  if (cellsEqual(cell, updated)) return;
   _cellMap.set(id, updated);
   emitCellChange(id);
   if (updated.source !== cell.source) {


### PR DESCRIPTION
## Root cause

The incremental materialization pipeline (#940) creates new cell objects for every changed cell in a sync batch, even when content is identical. `updateCellById` writes these unconditionally (no equality check), triggering React re-renders that pass `value` props to CodeMirror.

When the user is mid-keystroke, `@uiw/react-codemirror`'s typing latch (200ms) detects the mismatch between the `value` prop and CM's internal state, and **defers** a full document replacement. The deferred closure captures the `value` at creation time. When the user pauses typing, the latch fires and replaces the entire editor with the stale captured value — destroying whatever the user typed since.

This explains the `import time\ntime.sleep(0` → `uim` corruption: characters were overwritten by a stale snapshot from the cell store.

## Fixes

**1. `cellsEqual` guard in `updateCellById`** — the primary defense. Skips the write + emit when the materialized cell is structurally identical to the existing one. This prevents unnecessary re-renders that arm the typing latch.

**2. Preserve store source in async output path** — when `fields.source` is false in the changeset, use the store's source instead of reading from WASM after an `await`. The WASM source after an async blob fetch could reflect a CRDT merge that diverges from what CodeMirror holds.

## What this doesn't fix

The fundamental architecture issue: `update_text()` does a full-string Myers diff, and CodeMirror's `value` prop goes through React's render cycle with inherent latency. The long-term fix is character-level CM → Automerge bridging that bypasses React's value roundtrip. But that's a bigger refactor.

_PR submitted by @rgbkrk's agent Quill, via Zed_