### PR TITLE
feat(xtask): build MCP supervisor + Python bindings in cargo xtask build, add --release to mcp

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,10 +166,13 @@ hot-reloads when source files change.
 
 ```bash
 # Build and run the supervisor (starts daemon if needed)
-cargo xtask mcp
+cargo xtask run-mcp
+
+# Run with release-optimized daemon (for perf testing)
+cargo xtask run-mcp --release
 
 # Or print config JSON for your MCP client
-cargo xtask mcp --print-config
+cargo xtask run-mcp --print-config
 ```
 
 For `.zed/settings.json` (gitignored, per-developer):
@@ -192,9 +195,10 @@ tools in addition to the standard nteract notebook tools:
 
 | Tool | Purpose |
 |------|---------|
-| `supervisor_status` | Check child process, daemon, restart count, last error |
+| `supervisor_status` | Check child process, daemon, build mode, restart count, last error |
 | `supervisor_restart` | Restart child (`target="child"`) or daemon (`target="daemon"`) |
 | `supervisor_rebuild` | Run `maturin develop` to rebuild Rust Python bindings, then restart |
+| `supervisor_set_mode` | Switch daemon between `"debug"` and `"release"` builds at runtime (no editor restart needed) |
 | `supervisor_logs` | Tail the daemon log file |
 | `supervisor_start_vite` | Start the Vite dev server for hot-reload frontend development. Returns the port number. If already running, returns the existing port. |
 | `supervisor_stop` | Stop a managed process by name (e.g. `"vite"`). |
@@ -220,10 +224,16 @@ MCP tools may or may not be available depending on your session:
 
 - **Inkwell active** → all supervisor + nteract tools available
 - **nteract MCP only** (no supervisor) → nteract tools only, no `supervisor_*`
-- **No MCP server** → use `cargo xtask dev-mcp` or `cargo xtask mcp` to set one up
+- **No MCP server** → use `cargo xtask dev-mcp` or `cargo xtask run-mcp` to set one up
 - **Dev daemon not running** → Inkwell starts it automatically; for manual control use `cargo xtask dev-daemon`
 
 See `contributing/development.md` for the full MCP development workflow.
+
+## Build System (`cargo xtask`)
+
+All build, lint, and dev commands go through `cargo xtask`. **Run `cargo xtask help` at the start of each session** to see the current command list — it's the source of truth and changes as the project evolves.
+
+**Always run `cargo xtask lint` before committing.** The `--fix` flag auto-fixes formatting and also runs clippy (check-only). CI rejects PRs that fail any lint check.
 
 ## Contributing Guidelines
 

--- a/crates/mcp-supervisor/src/main.rs
+++ b/crates/mcp-supervisor/src/main.rs
@@ -42,13 +42,29 @@ use tracing::{error, info, warn};
 // Daemon management
 // ---------------------------------------------------------------------------
 
+/// Whether to use release-mode binaries (set RUNTIMED_RELEASE=1).
+fn use_release_binaries() -> bool {
+    std::env::var("RUNTIMED_RELEASE").map_or(false, |v| v == "1")
+}
+
+/// Resolve the path to a Cargo-built binary, respecting release mode.
+fn cargo_binary(project_root: &Path, name: &str) -> std::path::PathBuf {
+    let profile = if use_release_binaries() {
+        "release"
+    } else {
+        "debug"
+    };
+    let bin_name = if cfg!(windows) {
+        format!("{name}.exe")
+    } else {
+        name.to_string()
+    };
+    project_root.join("target").join(profile).join(bin_name)
+}
+
 /// Check if the dev daemon is running and get its socket path.
 fn daemon_status(project_root: &Path) -> Option<DaemonInfo> {
-    let runt = if cfg!(windows) {
-        project_root.join("target/debug/runt.exe")
-    } else {
-        project_root.join("target/debug/runt")
-    };
+    let runt = cargo_binary(project_root, "runt");
 
     if !runt.exists() {
         return None;
@@ -80,11 +96,7 @@ struct DaemonInfo {
 
 /// Start the dev daemon as a background process. Returns the child handle.
 fn start_daemon(project_root: &Path) -> Option<std::process::Child> {
-    let runtimed = if cfg!(windows) {
-        project_root.join("target/debug/runtimed.exe")
-    } else {
-        project_root.join("target/debug/runtimed")
-    };
+    let runtimed = cargo_binary(project_root, "runtimed");
 
     if !runtimed.exists() {
         error!("runtimed binary not found at {}", runtimed.display());

--- a/crates/mcp-supervisor/src/main.rs
+++ b/crates/mcp-supervisor/src/main.rs
@@ -20,6 +20,7 @@ use std::collections::HashMap;
 use std::fs::OpenOptions;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -42,9 +43,13 @@ use tracing::{error, info, warn};
 // Daemon management
 // ---------------------------------------------------------------------------
 
-/// Whether to use release-mode binaries (set RUNTIMED_RELEASE=1).
+/// Global flag for release-mode binaries. Initialized from `RUNTIMED_RELEASE=1`
+/// and toggled at runtime by the `supervisor_set_mode` MCP tool.
+static RELEASE_MODE: AtomicBool = AtomicBool::new(false);
+
+/// Whether to use release-mode binaries.
 fn use_release_binaries() -> bool {
-    std::env::var("RUNTIMED_RELEASE").map_or(false, |v| v == "1")
+    RELEASE_MODE.load(Ordering::Relaxed)
 }
 
 /// Resolve the path to a Cargo-built binary, respecting release mode.
@@ -528,6 +533,12 @@ impl Supervisor {
             socket_path: state.socket_path.clone(),
             project_root: state.project_root.to_string_lossy().to_string(),
             daemon_managed: state.daemon_child.is_some(),
+            build_mode: if use_release_binaries() {
+                "release"
+            } else {
+                "debug"
+            }
+            .to_string(),
             managed_processes,
         }
     }
@@ -804,6 +815,8 @@ struct SupervisorStatus {
     project_root: String,
     /// Whether the supervisor started (and manages) the daemon.
     daemon_managed: bool,
+    /// Current build mode for daemon binaries: "debug" or "release".
+    build_mode: String,
     /// Status of managed long-running processes (vite, app, etc.).
     managed_processes: HashMap<String, ManagedProcessStatus>,
 }
@@ -842,6 +855,13 @@ struct StopProcessParams {
 // The supervisor_status tool schema — no input params needed.
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
 struct EmptyParams {}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+#[allow(dead_code)] // `mode` is read via serde deserialization, not directly
+struct SetModeParams {
+    /// The build mode: "debug" or "release".
+    mode: String,
+}
 
 /// MCP ServerHandler that proxies to the nteract child + injects supervisor tools.
 impl ServerHandler for Supervisor {
@@ -928,6 +948,17 @@ impl ServerHandler for Supervisor {
             "supervisor_stop",
             "Stop a managed process by name (e.g. 'vite').",
             serde_json::to_value(schemars::schema_for!(StopProcessParams))
+                .unwrap()
+                .as_object()
+                .cloned()
+                .unwrap_or_default(),
+        ));
+        tools.push(Tool::new(
+            "supervisor_set_mode",
+            "Switch the daemon between debug and release builds at runtime. \
+             Stops the current daemon, flips the binary path, and restarts. \
+             Use mode='debug' or mode='release'. No settings.json change needed.",
+            serde_json::to_value(schemars::schema_for!(SetModeParams))
                 .unwrap()
                 .as_object()
                 .cloned()
@@ -1154,6 +1185,80 @@ impl ServerHandler for Supervisor {
                     )])),
                 }
             }
+            "supervisor_set_mode" => {
+                let mode = request
+                    .arguments
+                    .as_ref()
+                    .and_then(|args| args.get("mode"))
+                    .and_then(Value::as_str)
+                    .unwrap_or("");
+
+                let new_release = match mode {
+                    "release" => true,
+                    "debug" => false,
+                    other => {
+                        return Ok(CallToolResult::success(vec![Content::text(format!(
+                            "Unknown mode '{other}'. Use 'debug' or 'release'."
+                        ))]));
+                    }
+                };
+
+                let old_release = RELEASE_MODE.swap(new_release, Ordering::Relaxed);
+                if old_release == new_release {
+                    return Ok(CallToolResult::success(vec![Content::text(format!(
+                        "Already in {mode} mode, no change needed."
+                    ))]));
+                }
+
+                info!(
+                    "Switching daemon mode: {} → {mode}",
+                    if old_release { "release" } else { "debug" }
+                );
+
+                // Check that the target binary exists before stopping anything
+                let project_root = {
+                    let state = self.state.read().await;
+                    state.project_root.clone()
+                };
+                let target_binary = cargo_binary(&project_root, "runtimed");
+                if !target_binary.exists() {
+                    // Roll back
+                    RELEASE_MODE.store(old_release, Ordering::Relaxed);
+                    return Ok(CallToolResult::success(vec![Content::text(format!(
+                        "Cannot switch to {mode} mode: binary not found at {}. \
+                         Build it first with: cargo build {} -p runtimed",
+                        target_binary.display(),
+                        if new_release { "--release" } else { "" }
+                    ))]));
+                }
+
+                // Stop the current daemon
+                {
+                    let mut state = self.state.write().await;
+                    if let Some(ref mut child) = state.daemon_child {
+                        info!("Stopping daemon for mode switch...");
+                        let _ = child.kill();
+                        let _ = child.wait();
+                    }
+                    state.daemon_child = start_daemon(&project_root);
+                }
+
+                if !wait_for_daemon(&project_root, Duration::from_secs(30)) {
+                    return Ok(CallToolResult::success(vec![Content::text(format!(
+                        "Switched to {mode} mode but daemon did not become ready within 30s"
+                    ))]));
+                }
+
+                // Restart the MCP child so it reconnects to the new daemon
+                match self.restart_child().await {
+                    Ok(()) => Ok(CallToolResult::success(vec![Content::text(format!(
+                        "Switched to {mode} mode. Daemon and MCP server restarted."
+                    ))])),
+                    Err(e) => Ok(CallToolResult::success(vec![Content::text(format!(
+                        "Switched to {mode} mode. Daemon restarted but MCP server failed: {e}"
+                    ))])),
+                }
+            }
             // Everything else → forward to child
             _ => self.forward_tool_call(request).await,
         }
@@ -1374,6 +1479,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .with_env_filter(env_filter)
             .with_writer(std::io::stderr)
             .init();
+    }
+
+    // Initialize release mode from env var (can be toggled at runtime via supervisor_set_mode)
+    if std::env::var("RUNTIMED_RELEASE").map_or(false, |v| v == "1") {
+        RELEASE_MODE.store(true, Ordering::Relaxed);
+        info!("Starting in release mode (RUNTIMED_RELEASE=1)");
     }
 
     let project_root = resolve_project_root();

--- a/crates/mcp-supervisor/src/main.rs
+++ b/crates/mcp-supervisor/src/main.rs
@@ -1203,7 +1203,7 @@ impl ServerHandler for Supervisor {
                     }
                 };
 
-                let old_release = RELEASE_MODE.swap(new_release, Ordering::Relaxed);
+                let old_release = RELEASE_MODE.load(Ordering::Relaxed);
                 if old_release == new_release {
                     return Ok(CallToolResult::success(vec![Content::text(format!(
                         "Already in {mode} mode, no change needed."
@@ -1215,37 +1215,77 @@ impl ServerHandler for Supervisor {
                     if old_release { "release" } else { "debug" }
                 );
 
-                // Check that the target binary exists before stopping anything
                 let project_root = {
                     let state = self.state.read().await;
                     state.project_root.clone()
                 };
-                let target_binary = cargo_binary(&project_root, "runtimed");
-                if !target_binary.exists() {
-                    // Roll back
+
+                // Validate both target binaries exist before stopping anything.
+                // wait_for_daemon uses `runt` to probe status, so both are needed.
+                RELEASE_MODE.store(new_release, Ordering::Relaxed);
+                let target_runtimed = cargo_binary(&project_root, "runtimed");
+                let target_runt = cargo_binary(&project_root, "runt");
+                let profile_flag = if new_release { "--release " } else { "" };
+
+                if !target_runtimed.exists() || !target_runt.exists() {
                     RELEASE_MODE.store(old_release, Ordering::Relaxed);
+                    let mut missing = Vec::new();
+                    if !target_runtimed.exists() {
+                        missing.push(format!("runtimed: {}", target_runtimed.display()));
+                    }
+                    if !target_runt.exists() {
+                        missing.push(format!("runt: {}", target_runt.display()));
+                    }
                     return Ok(CallToolResult::success(vec![Content::text(format!(
-                        "Cannot switch to {mode} mode: binary not found at {}. \
-                         Build it first with: cargo build {} -p runtimed",
-                        target_binary.display(),
-                        if new_release { "--release" } else { "" }
+                        "Cannot switch to {mode} mode — missing binaries:\n  {}\n\
+                         Build them first with: cargo build {}-p runtimed -p runt-cli",
+                        missing.join("\n  "),
+                        profile_flag
                     ))]));
                 }
 
-                // Stop the current daemon
+                // Stop the current daemon. If we manage it, kill the child directly.
+                // If it was already running (unmanaged), stop it via `runt daemon stop`
+                // using the OLD mode's binary so the CLI matches the running daemon.
                 {
                     let mut state = self.state.write().await;
                     if let Some(ref mut child) = state.daemon_child {
-                        info!("Stopping daemon for mode switch...");
+                        info!("Stopping managed daemon for mode switch...");
                         let _ = child.kill();
                         let _ = child.wait();
+                        state.daemon_child = None;
+                    } else {
+                        // Unmanaged daemon — stop via runt CLI (old mode binary)
+                        RELEASE_MODE.store(old_release, Ordering::Relaxed);
+                        let old_runt = cargo_binary(&project_root, "runt");
+                        RELEASE_MODE.store(new_release, Ordering::Relaxed);
+                        if old_runt.exists() {
+                            info!("Stopping unmanaged daemon via runt CLI...");
+                            let mut stop_cmd = std::process::Command::new(&old_runt);
+                            stop_cmd.args(["daemon", "stop"]).env("RUNTIMED_DEV", "1");
+                            if let Some(workspace) = runt_workspace::get_workspace_path() {
+                                stop_cmd.env("RUNTIMED_WORKSPACE_PATH", &workspace);
+                            }
+                            let _ = stop_cmd.status();
+                            // Give it a moment to release the socket
+                            std::thread::sleep(Duration::from_secs(2));
+                        }
                     }
+                }
+
+                // Start the new daemon (now using the new mode's binary)
+                {
+                    let mut state = self.state.write().await;
                     state.daemon_child = start_daemon(&project_root);
                 }
 
                 if !wait_for_daemon(&project_root, Duration::from_secs(30)) {
+                    // Roll back on failure
+                    RELEASE_MODE.store(old_release, Ordering::Relaxed);
                     return Ok(CallToolResult::success(vec![Content::text(format!(
-                        "Switched to {mode} mode but daemon did not become ready within 30s"
+                        "Failed to switch to {mode} mode — daemon did not become ready within 30s. \
+                         Rolled back to {} mode.",
+                        if old_release { "release" } else { "debug" }
                     ))]));
                 }
 
@@ -1254,9 +1294,13 @@ impl ServerHandler for Supervisor {
                     Ok(()) => Ok(CallToolResult::success(vec![Content::text(format!(
                         "Switched to {mode} mode. Daemon and MCP server restarted."
                     ))])),
-                    Err(e) => Ok(CallToolResult::success(vec![Content::text(format!(
-                        "Switched to {mode} mode. Daemon restarted but MCP server failed: {e}"
-                    ))])),
+                    Err(e) => {
+                        // Daemon is running in new mode but child failed — don't roll back
+                        // the daemon, just report the child failure
+                        Ok(CallToolResult::success(vec![Content::text(format!(
+                            "Switched to {mode} mode. Daemon restarted but MCP server failed: {e}"
+                        ))]))
+                    }
                 }
             }
             // Everything else → forward to child

--- a/crates/mcp-supervisor/src/main.rs
+++ b/crates/mcp-supervisor/src/main.rs
@@ -1482,7 +1482,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // Initialize release mode from env var (can be toggled at runtime via supervisor_set_mode)
-    if std::env::var("RUNTIMED_RELEASE").map_or(false, |v| v == "1") {
+    if std::env::var("RUNTIMED_RELEASE").is_ok_and(|v| v == "1") {
         RELEASE_MODE.store(true, Ordering::Relaxed);
         info!("Starting in release mode (RUNTIMED_RELEASE=1)");
     }

--- a/crates/mcp-supervisor/src/main.rs
+++ b/crates/mcp-supervisor/src/main.rs
@@ -1262,10 +1262,11 @@ impl ServerHandler for Supervisor {
                         if old_runt.exists() {
                             info!("Stopping unmanaged daemon via runt CLI...");
                             let mut stop_cmd = std::process::Command::new(&old_runt);
-                            stop_cmd.args(["daemon", "stop"]).env("RUNTIMED_DEV", "1");
-                            if let Some(workspace) = runt_workspace::get_workspace_path() {
-                                stop_cmd.env("RUNTIMED_WORKSPACE_PATH", &workspace);
-                            }
+                            stop_cmd
+                                .args(["daemon", "stop"])
+                                .env("RUNTIMED_DEV", "1")
+                                // Always target this worktree's daemon — never the system daemon.
+                                .env("RUNTIMED_WORKSPACE_PATH", &project_root);
                             let _ = stop_cmd.status();
                             // Give it a moment to release the socket
                             std::thread::sleep(Duration::from_secs(2));

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -56,7 +56,8 @@ fn main() {
         }
         "mcp" => {
             let print_config = args.iter().any(|a| a == "--print-config");
-            cmd_mcp(print_config);
+            let release = args.iter().any(|a| a == "--release");
+            cmd_mcp(print_config, release);
         }
         "lint" => {
             let fix = args.iter().any(|a| a == "--fix");
@@ -98,7 +99,7 @@ Daemon:
   dev-daemon [--release]     Build and run runtimed in per-worktree dev mode
 
 MCP:
-  mcp                        MCP supervisor (proxy + daemon + auto-restart)
+  mcp [--release]            MCP supervisor (proxy + daemon + auto-restart)
   mcp --print-config         Print MCP client config JSON (for Claude, Zed, etc.)
   dev-mcp                    Build Python bindings and launch nteract MCP server
   dev-mcp --print-config     Print MCP client config JSON (for Claude, Zed, etc.)
@@ -416,6 +417,14 @@ fn cmd_build(rust_only: bool) {
     // Build runtimed daemon binary for bundling (debug mode for faster builds)
     build_runtimed_daemon(false);
 
+    // Build MCP supervisor binary
+    println!("Building MCP supervisor...");
+    run_cmd("cargo", &["build", "-p", "mcp-supervisor"]);
+
+    // Sync Python workspace and build native bindings (runtimed-py)
+    ensure_python_env();
+    ensure_maturin_develop();
+
     if rust_only {
         // Check that frontend dist exists
         let dist_dir = Path::new("apps/notebook/dist");
@@ -725,9 +734,16 @@ fn cmd_install_daemon() {
 ///
 /// This enables isolated daemon instances per git worktree, useful when
 /// developing/testing daemon code across multiple worktrees simultaneously.
-fn cmd_mcp(print_config: bool) {
+fn cmd_mcp(print_config: bool, release: bool) {
     ensure_python_env();
     ensure_maturin_develop();
+
+    // Build the daemon in the requested mode so the supervisor finds it
+    if release {
+        println!("Building runtimed (release) for supervisor...");
+        run_cmd("cargo", &["build", "--release", "-p", "runtimed"]);
+        run_cmd("cargo", &["build", "--release", "-p", "runt-cli"]);
+    }
 
     if print_config {
         // Build the supervisor, then run it with --print-config
@@ -742,11 +758,17 @@ fn cmd_mcp(print_config: bool) {
             eprintln!("Failed to resolve supervisor binary path: {e}");
             exit(1);
         });
+        let mut env = serde_json::json!({
+            "RUNTIMED_DEV": "1"
+        });
+        if release {
+            env.as_object_mut()
+                .unwrap()
+                .insert("RUNTIMED_RELEASE".to_string(), serde_json::json!("1"));
+        }
         let config = serde_json::json!({
             "command": binary_path.to_string_lossy(),
-            "env": {
-                "RUNTIMED_DEV": "1"
-            }
+            "env": env
         });
         println!(
             "{}",
@@ -768,6 +790,9 @@ fn cmd_mcp(print_config: bool) {
 
     let mut command = Command::new(binary);
     apply_worktree_env(&mut command, true);
+    if release {
+        command.env("RUNTIMED_RELEASE", "1");
+    }
 
     let status = command.status().unwrap_or_else(|e| {
         eprintln!("Failed to run mcp-supervisor: {e}");

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -54,7 +54,7 @@ fn main() {
             let print_config = args.iter().any(|a| a == "--print-config");
             cmd_dev_mcp(print_config);
         }
-        "mcp" => {
+        "run-mcp" | "mcp" => {
             let print_config = args.iter().any(|a| a == "--print-config");
             let release = args.iter().any(|a| a == "--release");
             cmd_mcp(print_config, release);
@@ -99,10 +99,10 @@ Daemon:
   dev-daemon [--release]     Build and run runtimed in per-worktree dev mode
 
 MCP:
-  mcp [--release]            MCP supervisor (proxy + daemon + auto-restart)
-  mcp --print-config         Print MCP client config JSON (for Claude, Zed, etc.)
-  dev-mcp                    Build Python bindings and launch nteract MCP server
-  dev-mcp --print-config     Print MCP client config JSON (for Claude, Zed, etc.)
+  run-mcp [--release]        Build and run the Inkwell MCP supervisor (proxy + daemon + auto-restart)
+  run-mcp --print-config     Print MCP client config JSON (for Zed, Claude, etc.)
+  dev-mcp                    Build Python bindings and launch nteract MCP server directly (no supervisor)
+  dev-mcp --print-config     Print MCP client config JSON (for Zed, Claude, etc.)
 
 Linting:
   lint                       Check formatting and linting (Rust, JS/TS, Python)
@@ -758,18 +758,22 @@ fn cmd_mcp(print_config: bool, release: bool) {
             eprintln!("Failed to resolve supervisor binary path: {e}");
             exit(1);
         });
-        let mut env = serde_json::json!({
-            "RUNTIMED_DEV": "1"
-        });
-        if release {
-            env.as_object_mut()
-                .unwrap()
-                .insert("RUNTIMED_RELEASE".to_string(), serde_json::json!("1"));
-        }
-        let config = serde_json::json!({
-            "command": binary_path.to_string_lossy(),
-            "env": env
-        });
+        let config = if release {
+            serde_json::json!({
+                "command": binary_path.to_string_lossy(),
+                "env": {
+                    "RUNTIMED_DEV": "1",
+                    "RUNTIMED_RELEASE": "1"
+                }
+            })
+        } else {
+            serde_json::json!({
+                "command": binary_path.to_string_lossy(),
+                "env": {
+                    "RUNTIMED_DEV": "1"
+                }
+            })
+        };
         println!(
             "{}",
             serde_json::to_string_pretty(&config).unwrap_or_else(|e| {
@@ -1216,24 +1220,22 @@ fn cmd_lint(fix: bool) {
     }
     println!();
 
-    // Rust clippy (check-only, no auto-fix available)
-    if !fix {
-        println!("=== Rust clippy ===");
-        if !run_cmd_ok(
-            "cargo",
-            &[
-                "clippy",
-                "--workspace",
-                "--all-targets",
-                "--",
-                "-D",
-                "warnings",
-            ],
-        ) {
-            failed = true;
-        }
-        println!();
+    // Rust clippy (always check-only — clippy doesn't auto-fix)
+    println!("=== Rust clippy ===");
+    if !run_cmd_ok(
+        "cargo",
+        &[
+            "clippy",
+            "--workspace",
+            "--all-targets",
+            "--",
+            "-D",
+            "warnings",
+        ],
+    ) {
+        failed = true;
     }
+    println!();
 
     // JavaScript/TypeScript with Biome
     println!("=== JavaScript/TypeScript (Biome) ===");


### PR DESCRIPTION
`cargo xtask build` now produces everything needed for local development in one shot:

- runtimed + runt (daemon binaries)
- mcp-supervisor
- Python workspace sync + maturin develop (runtimed-py bindings)
- Frontend + Tauri app (as before)

Also adds `--release` to `cargo xtask mcp` for testing with release-optimized daemon binaries while keeping dev-mode isolation (RUNTIMED_DEV=1). The supervisor resolves binary paths via `RUNTIMED_RELEASE=1` env var.

### `supervisor_set_mode` MCP tool

Hot-swap the daemon between debug and release at runtime without touching settings.json:

```
supervisor_set_mode(mode="release")  → stops daemon, switches to target/release/runtimed, restarts
supervisor_set_mode(mode="debug")    → switches back to target/debug/runtimed
```

`supervisor_status` now shows the current `build_mode`. The mode is initialized from `RUNTIMED_RELEASE` env var and toggled at runtime via the tool.

_PR submitted by @rgbkrk's agent Quill, via Zed_