### PR TITLE
chore(sync): remove FileChanged broadcast

### DIFF
--- a/apps/notebook/src/hooks/useDaemonKernel.ts
+++ b/apps/notebook/src/hooks/useDaemonKernel.ts
@@ -383,13 +383,6 @@ export function useDaemonKernel({
           break;
         }
 
-        case "file_changed": {
-          // Signal only — actual data arrives via Automerge sync frames,
-          // which triggers notifyMetadataChanged() automatically.
-          logger.info("[daemon-kernel] External file changes detected");
-          break;
-        }
-
         default: {
           // Log unknown events to help debug unexpected broadcast types
           logger.debug(

--- a/apps/notebook/src/lib/notebook-frame-bus.ts
+++ b/apps/notebook/src/lib/notebook-frame-bus.ts
@@ -31,7 +31,7 @@ const presenceSubscribers = new Set<PresenceSubscriber>();
  * Subscribe to broadcast events. Returns an unsubscribe function.
  *
  * Broadcasts include kernel_status, KernelLaunched, env_progress,
- * file_changed, and other daemon lifecycle events scoped to the notebook room.
+ * and other daemon lifecycle events scoped to the notebook room.
  */
 export function subscribeBroadcast(cb: BroadcastSubscriber): () => void {
   broadcastSubscribers.add(cb);

--- a/apps/notebook/src/types.ts
+++ b/apps/notebook/src/types.ts
@@ -218,9 +218,6 @@ export type DaemonBroadcast =
       };
     }
   | {
-      event: "file_changed";
-    }
-  | {
       event: "room_renamed";
       new_notebook_id: string;
     }

--- a/contributing/protocol.md
+++ b/contributing/protocol.md
@@ -254,7 +254,6 @@ Broadcasts are daemon-initiated messages pushed to all connected clients for a n
 | `OutputsCleared { cell_id }` | Cell outputs cleared |
 | `Comm { msg_type, content, buffers }` | Jupyter comm message (widget open/msg/close) |
 | `CommSync { comms }` | Full widget state snapshot for newly connected clients |
-| `FileChanged` | External file change merged into the doc (signal only — data arrives via sync) |
 | `EnvProgress { env_type, phase }` | Environment setup progress (`phase` is a flattened `EnvProgressPhase`) |
 | `EnvSyncState { in_sync, diff }` | Notebook dependencies drifted from launched kernel config |
 | `RoomRenamed { new_notebook_id }` | Untitled notebook saved — room re-keyed from UUID to file path |

--- a/crates/notebook-protocol/src/protocol.rs
+++ b/crates/notebook-protocol/src/protocol.rs
@@ -506,10 +506,6 @@ pub enum NotebookBroadcast {
         comms: Vec<CommSnapshot>,
     },
 
-    /// External file changes were detected and merged into the Automerge doc.
-    /// This is a signal only — the actual data arrives via Automerge sync frames.
-    FileChanged,
-
     /// Environment progress update during kernel launch.
     ///
     /// Carries rich progress phases (repodata, solve, download, link)

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -5282,11 +5282,6 @@ pub(crate) fn spawn_notebook_file_watcher(
                                 // Notify peers of the change — actual data
                                 // arrives via Automerge sync frames
                                 let _ = room.changed_tx.send(());
-
-                                // Signal that external file changes were merged
-                                let _ = room
-                                    .kernel_broadcast_tx
-                                    .send(NotebookBroadcast::FileChanged);
                             }
                         }
                         Err(errs) => {

--- a/docs/runtimed.md
+++ b/docs/runtimed.md
@@ -779,7 +779,6 @@ Broadcast types (see `NotebookBroadcast` in `crates/notebook-protocol/src/protoc
 - `KernelError { error }` — launch failure or crash
 - `Comm { msg_type, content, buffers }` — ipywidgets protocol (comm_open/msg/close)
 - `CommSync { comms }` — initial widget state for newly connected clients
-- `FileChanged` — External file changes detected and merged into the Automerge doc (signal only — actual data arrives via sync frames)
 - `EnvProgress { env_type, phase }` — rich environment setup progress (repodata, solve, download, link)
 - `EnvSyncState { in_sync, diff }` — notebook metadata vs launched config drift
 


### PR DESCRIPTION
Removed the dead-code `FileChanged` broadcast variant from the protocol.

The broadcast served as a signal-only notification that external notebook file changes were detected and merged. However, the actual data from file watcher changes flows through Automerge sync frames, which already trigger the normal materialization path. The daemon continues to notify peers via the `changed_tx` channel — the broadcast overlay was redundant overhead.

**Changes:**
- Removed enum variant from `NotebookBroadcast` protocol
- Removed daemon emission in file watcher task
- Removed frontend listener (only logged, no state updates)
- Removed TypeScript type definition
- Updated documentation (protocol guide and daemon docs)

Closes #971

## Testing Plan
- [ ] Verify notebook syncs correctly when `.ipynb` is edited externally (changes should arrive via Automerge sync frames)
- [ ] Confirm no build/lint warnings

_PR submitted by @rgbkrk's agent, Quill_