### PR TITLE
feat(sync): PoolDoc — daemon pool state via read-only Automerge document

### DIFF
--- a/apps/notebook/src/components/PoolErrorBanner.tsx
+++ b/apps/notebook/src/components/PoolErrorBanner.tsx
@@ -22,21 +22,9 @@ function PoolErrorItem({ envType, error, onDismiss }: PoolErrorItemProps) {
     >
       <div className="flex items-center gap-2 min-w-0">
         <AlertTriangle className="h-3 w-3 flex-shrink-0" />
-        <span className="font-medium flex-shrink-0">
-          Invalid or unavailable package
-        </span>
-        {error.failed_package && (
-          <>
-            <span className="text-amber-200 flex-shrink-0">—</span>
-            <code className="bg-amber-700/50 px-1 rounded text-amber-100 flex-shrink-0">
-              {error.failed_package}
-            </code>
-          </>
-        )}
+        <span className="font-medium flex-shrink-0">{envType} pool error</span>
         <span className="text-amber-200 flex-shrink-0">—</span>
-        <span className="text-amber-100">
-          Check package name in {envType.toLowerCase()} settings.
-        </span>
+        <span className="text-amber-100 truncate">{error.message}</span>
       </div>
       <div className="flex items-center gap-2 flex-shrink-0">
         <button

--- a/apps/notebook/src/hooks/usePoolState.ts
+++ b/apps/notebook/src/hooks/usePoolState.ts
@@ -6,6 +6,10 @@ import type { PoolStateEvent } from "../types";
 export interface PoolErrorWithTimestamp {
   /** Error message from the pool. */
   message: string;
+  /** Number of consecutive failures. */
+  consecutiveFailures: number;
+  /** Seconds until next retry (0 if imminent). */
+  retryInSecs: number;
   /** When this state was received (epoch ms). */
   receivedAt: number;
 }
@@ -39,7 +43,11 @@ function errorsEqual(
 ): boolean {
   if (a === b) return true;
   if (!a || !b) return false;
-  return a.message === b.message;
+  return (
+    a.message === b.message &&
+    a.consecutiveFailures === b.consecutiveFailures &&
+    a.retryInSecs === b.retryInSecs
+  );
 }
 
 /**
@@ -69,10 +77,20 @@ export function usePoolState() {
       const payload = event.payload;
 
       const uvError: PoolErrorWithTimestamp | null = payload.uv_error
-        ? { message: payload.uv_error, receivedAt: now }
+        ? {
+            message: payload.uv_error,
+            consecutiveFailures: payload.uv_consecutive_failures,
+            retryInSecs: payload.uv_retry_in_secs,
+            receivedAt: now,
+          }
         : null;
       const condaError: PoolErrorWithTimestamp | null = payload.conda_error
-        ? { message: payload.conda_error, receivedAt: now }
+        ? {
+            message: payload.conda_error,
+            consecutiveFailures: payload.conda_consecutive_failures,
+            retryInSecs: payload.conda_retry_in_secs,
+            receivedAt: now,
+          }
         : null;
 
       // Check if errors changed — reset dismiss state on new errors

--- a/apps/notebook/src/hooks/usePoolState.ts
+++ b/apps/notebook/src/hooks/usePoolState.ts
@@ -1,44 +1,56 @@
 import { listen } from "@tauri-apps/api/event";
 import { useCallback, useEffect, useRef, useState } from "react";
-import type { PoolError, PoolStateEvent } from "../types";
+import type { PoolStateEvent } from "../types";
 
-/** PoolError with timestamp for countdown calculation */
-export interface PoolErrorWithTimestamp extends PoolError {
-  /** When this state was received (epoch ms) */
+/** Pool error info with timestamp for countdown calculation. */
+export interface PoolErrorWithTimestamp {
+  /** Error message from the pool. */
+  message: string;
+  /** When this state was received (epoch ms). */
   receivedAt: number;
 }
 
+/** Full pool state including counts and errors. */
 export interface PoolState {
+  uvAvailable: number;
+  uvWarming: number;
+  uvPoolSize: number;
   uvError: PoolErrorWithTimestamp | null;
+  condaAvailable: number;
+  condaWarming: number;
+  condaPoolSize: number;
   condaError: PoolErrorWithTimestamp | null;
 }
 
-/** Compare two pool errors for equality (all fields except receivedAt) */
+const INITIAL_STATE: PoolState = {
+  uvAvailable: 0,
+  uvWarming: 0,
+  uvPoolSize: 0,
+  uvError: null,
+  condaAvailable: 0,
+  condaWarming: 0,
+  condaPoolSize: 0,
+  condaError: null,
+};
+
 function errorsEqual(
-  a: PoolError | null | undefined,
-  b: PoolError | null | undefined,
+  a: PoolErrorWithTimestamp | null,
+  b: PoolErrorWithTimestamp | null,
 ): boolean {
   if (a === b) return true;
   if (!a || !b) return false;
-  return (
-    a.message === b.message &&
-    a.failed_package === b.failed_package &&
-    a.consecutive_failures === b.consecutive_failures &&
-    a.retry_in_secs === b.retry_in_secs
-  );
+  return a.message === b.message;
 }
 
 /**
- * Hook that listens to pool state broadcasts from the daemon.
+ * Subscribe to daemon pool state via the PoolDoc Automerge sync.
  *
- * Reports prewarm pool errors (e.g., typo'd package in default_packages)
- * so the UI can display warnings with retry countdowns.
+ * Returns pool counts (available/warming/pool_size) and error info for
+ * both UV and Conda pools. Errors include dismiss support — dismissed
+ * errors reappear when the error message changes.
  */
 export function usePoolState() {
-  const [state, setState] = useState<PoolState>({
-    uvError: null,
-    condaError: null,
-  });
+  const [state, setState] = useState<PoolState>(INITIAL_STATE);
 
   // Track dismissed errors so they don't reappear until state changes
   const [dismissedUv, setDismissedUv] = useState(false);
@@ -56,14 +68,14 @@ export function usePoolState() {
       const now = Date.now();
       const payload = event.payload;
 
-      const uvError = payload.uv_error
-        ? { ...payload.uv_error, receivedAt: now }
+      const uvError: PoolErrorWithTimestamp | null = payload.uv_error
+        ? { message: payload.uv_error, receivedAt: now }
         : null;
-      const condaError = payload.conda_error
-        ? { ...payload.conda_error, receivedAt: now }
+      const condaError: PoolErrorWithTimestamp | null = payload.conda_error
+        ? { message: payload.conda_error, receivedAt: now }
         : null;
 
-      // Check if errors changed (compare all fields, not just message)
+      // Check if errors changed — reset dismiss state on new errors
       const prev = prevStateRef.current;
       if (!errorsEqual(uvError, prev.uvError)) {
         setDismissedUv(false);
@@ -73,7 +85,16 @@ export function usePoolState() {
       }
 
       // Update state and ref
-      const newState = { uvError, condaError };
+      const newState: PoolState = {
+        uvAvailable: payload.uv_available,
+        uvWarming: payload.uv_warming,
+        uvPoolSize: payload.uv_pool_size,
+        uvError,
+        condaAvailable: payload.conda_available,
+        condaWarming: payload.conda_warming,
+        condaPoolSize: payload.conda_pool_size,
+        condaError,
+      };
       prevStateRef.current = newState;
       setState(newState);
     });
@@ -98,11 +119,22 @@ export function usePoolState() {
   }, []);
 
   return {
+    // Pool counts
+    uvAvailable: state.uvAvailable,
+    uvWarming: state.uvWarming,
+    uvPoolSize: state.uvPoolSize,
+    condaAvailable: state.condaAvailable,
+    condaWarming: state.condaWarming,
+    condaPoolSize: state.condaPoolSize,
+
+    // Errors (null when dismissed or no error)
     uvError: dismissedUv ? null : state.uvError,
     condaError: dismissedConda ? null : state.condaError,
     hasErrors:
       (!dismissedUv && state.uvError !== null) ||
       (!dismissedConda && state.condaError !== null),
+
+    // Dismiss controls
     dismissUvError,
     dismissCondaError,
     dismissAll,

--- a/apps/notebook/src/types.ts
+++ b/apps/notebook/src/types.ts
@@ -286,6 +286,10 @@ export interface PoolStateEvent {
   uv_pool_size: number;
   /** UV pool error (null if healthy). */
   uv_error: string | null;
+  /** UV pool: consecutive failure count (0 if healthy). */
+  uv_consecutive_failures: number;
+  /** UV pool: seconds until next retry (0 if healthy or imminent). */
+  uv_retry_in_secs: number;
   /** Conda pool: available prewarmed environments. */
   conda_available: number;
   /** Conda pool: environments currently warming. */
@@ -294,4 +298,8 @@ export interface PoolStateEvent {
   conda_pool_size: number;
   /** Conda pool error (null if healthy). */
   conda_error: string | null;
+  /** Conda pool: consecutive failure count (0 if healthy). */
+  conda_consecutive_failures: number;
+  /** Conda pool: seconds until next retry (0 if healthy or imminent). */
+  conda_retry_in_secs: number;
 }

--- a/apps/notebook/src/types.ts
+++ b/apps/notebook/src/types.ts
@@ -276,11 +276,22 @@ export interface PoolError {
   retry_in_secs: number;
 }
 
-/** Pool state broadcast from daemon. */
+/** Pool state from daemon PoolDoc (Automerge sync). */
 export interface PoolStateEvent {
-  event: "pool_state";
-  /** Error info for UV pool (null if healthy). */
-  uv_error: PoolError | null;
-  /** Error info for Conda pool (null if healthy). */
-  conda_error: PoolError | null;
+  /** UV pool: available prewarmed environments. */
+  uv_available: number;
+  /** UV pool: environments currently warming. */
+  uv_warming: number;
+  /** UV pool: target pool size. */
+  uv_pool_size: number;
+  /** UV pool error (null if healthy). */
+  uv_error: string | null;
+  /** Conda pool: available prewarmed environments. */
+  conda_available: number;
+  /** Conda pool: environments currently warming. */
+  conda_warming: number;
+  /** Conda pool: target pool size. */
+  conda_pool_size: number;
+  /** Conda pool error (null if healthy). */
+  conda_error: string | null;
 }

--- a/crates/notebook-protocol/src/connection.rs
+++ b/crates/notebook-protocol/src/connection.rs
@@ -68,9 +68,16 @@ pub enum Handshake {
     },
     /// Blob store: write blobs, query port.
     Blob,
-    /// Pool state subscription: receive broadcasts when pool errors occur/clear.
+    /// Pool state subscription (legacy): receive broadcasts when pool errors occur/clear.
     /// Read-only channel - server pushes DaemonBroadcast messages to client.
+    /// Deprecated: use PoolStateSync instead.
     PoolStateSubscribe,
+
+    /// Pool state sync: bidirectional Automerge sync of the PoolDoc.
+    /// Daemon-authoritative — clients read pool state (uv/conda availability,
+    /// errors) via the standard Automerge sync protocol. Same pattern as
+    /// SettingsSync but read-only (client writes are ignored).
+    PoolStateSync,
 
     /// Open an existing notebook file. Daemon loads from disk, derives notebook_id.
     ///

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -3340,10 +3340,14 @@ struct PoolStateEvent {
     uv_warming: u64,
     uv_pool_size: u64,
     uv_error: Option<String>,
+    uv_consecutive_failures: u32,
+    uv_retry_in_secs: u64,
     conda_available: u64,
     conda_warming: u64,
     conda_pool_size: u64,
     conda_error: Option<String>,
+    conda_consecutive_failures: u32,
+    conda_retry_in_secs: u64,
 }
 
 impl From<&runtimed::pool_doc::PoolState> for PoolStateEvent {
@@ -3353,10 +3357,14 @@ impl From<&runtimed::pool_doc::PoolState> for PoolStateEvent {
             uv_warming: state.uv.warming,
             uv_pool_size: state.uv.pool_size,
             uv_error: state.uv.error.clone(),
+            uv_consecutive_failures: state.uv.consecutive_failures,
+            uv_retry_in_secs: state.uv.retry_in_secs,
             conda_available: state.conda.available,
             conda_warming: state.conda.warming,
             conda_pool_size: state.conda.pool_size,
             conda_error: state.conda.error.clone(),
+            conda_consecutive_failures: state.conda.consecutive_failures,
+            conda_retry_in_secs: state.conda.retry_in_secs,
         }
     }
 }

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -3330,21 +3330,53 @@ async fn run_settings_sync(app: tauri::AppHandle) {
 /// and emits Tauri events to all windows when pool errors occur or clear.
 ///
 /// Reconnects automatically after 5s if the connection drops.
+/// Serializable pool state event emitted to the frontend.
+///
+/// Carries the full pool snapshot (counts + errors) from the PoolDoc.
+/// Replaces the legacy `DaemonBroadcast::PoolState` which only carried errors.
+#[derive(serde::Serialize, Clone, Debug)]
+struct PoolStateEvent {
+    uv_available: u64,
+    uv_warming: u64,
+    uv_pool_size: u64,
+    uv_error: Option<String>,
+    conda_available: u64,
+    conda_warming: u64,
+    conda_pool_size: u64,
+    conda_error: Option<String>,
+}
+
+impl From<&runtimed::pool_doc::PoolState> for PoolStateEvent {
+    fn from(state: &runtimed::pool_doc::PoolState) -> Self {
+        Self {
+            uv_available: state.uv.available,
+            uv_warming: state.uv.warming,
+            uv_pool_size: state.uv.pool_size,
+            uv_error: state.uv.error.clone(),
+            conda_available: state.conda.available,
+            conda_warming: state.conda.warming,
+            conda_pool_size: state.conda.pool_size,
+            conda_error: state.conda.error.clone(),
+        }
+    }
+}
+
 async fn run_pool_state_sync(app: tauri::AppHandle) {
     use tauri::Emitter;
 
     loop {
-        match runtimed::client::subscribe_pool_state().await {
+        match runtimed::client::sync_pool_state().await {
             Ok(mut rx) => {
-                log::info!("[pool-state-sync] Connected to pool state subscription");
+                log::info!("[pool-state-sync] Connected via PoolDoc Automerge sync");
 
-                while let Some(broadcast) = rx.recv().await {
-                    if let Err(e) = app.emit("pool:state", &broadcast) {
+                while let Some(state) = rx.recv().await {
+                    let event = PoolStateEvent::from(&state);
+                    if let Err(e) = app.emit("pool:state", &event) {
                         log::warn!("[pool-state-sync] Failed to emit pool:state: {}", e);
                     }
                 }
 
-                log::warn!("[pool-state-sync] Disconnected from pool state subscription");
+                log::warn!("[pool-state-sync] Disconnected from PoolDoc sync");
             }
             Err(e) => {
                 log::info!(

--- a/crates/runtimed/src/client.rs
+++ b/crates/runtimed/src/client.rs
@@ -737,7 +737,7 @@ pub async fn subscribe_pool_state(
 /// ```
 pub async fn sync_pool_state(
 ) -> Result<tokio::sync::mpsc::Receiver<crate::pool_doc::PoolState>, ClientError> {
-    use automerge::{sync, sync::SyncDoc, AutoCommit, ReadDoc, ROOT};
+    use automerge::{sync, sync::SyncDoc, AutoCommit};
 
     let socket_path = default_socket_path();
     let connect_timeout = Duration::from_secs(2);
@@ -882,6 +882,20 @@ fn read_pool_state_from_doc(doc: &automerge::AutoCommit) -> Option<crate::pool_d
             .ok()?
             .and_then(|(v, _)| v.to_u64())
             .unwrap_or(0);
+        let consecutive_failures = doc
+            .get(&obj_id, "consecutive_failures")
+            .ok()
+            .flatten()
+            .and_then(|(v, _)| v.to_u64())
+            .unwrap_or(0) as u32;
+
+        let retry_in_secs = doc
+            .get(&obj_id, "retry_in_secs")
+            .ok()
+            .flatten()
+            .and_then(|(v, _)| v.to_u64())
+            .unwrap_or(0);
+
         let error = doc
             .get(&obj_id, "error")
             .ok()
@@ -893,6 +907,8 @@ fn read_pool_state_from_doc(doc: &automerge::AutoCommit) -> Option<crate::pool_d
             warming,
             pool_size,
             error,
+            consecutive_failures,
+            retry_in_secs,
         })
     };
 

--- a/crates/runtimed/src/client.rs
+++ b/crates/runtimed/src/client.rs
@@ -711,6 +711,197 @@ pub async fn subscribe_pool_state(
     Ok(rx)
 }
 
+/// Connect to the daemon's PoolDoc via Automerge sync and return a receiver
+/// that yields [`crate::pool_doc::PoolState`] snapshots whenever the pool
+/// state changes.
+///
+/// Unlike `subscribe_pool_state` (legacy broadcast subscription), this uses
+/// the standard Automerge sync protocol — the client maintains a local doc
+/// that converges with the daemon's PoolDoc. State is read from the local
+/// doc after each sync round, so it's always consistent.
+///
+/// The first snapshot is sent after initial sync completes (immediate state).
+/// Subsequent snapshots are sent whenever the daemon pushes a sync message
+/// (pool state changed).
+///
+/// # Example
+///
+/// ```ignore
+/// let mut rx = sync_pool_state().await?;
+/// while let Some(state) = rx.recv().await {
+///     println!("UV: {}/{} available", state.uv.available, state.uv.pool_size);
+///     if let Some(err) = &state.uv.error {
+///         eprintln!("UV error: {}", err);
+///     }
+/// }
+/// ```
+pub async fn sync_pool_state(
+) -> Result<tokio::sync::mpsc::Receiver<crate::pool_doc::PoolState>, ClientError> {
+    use automerge::{sync, sync::SyncDoc, AutoCommit, ReadDoc, ROOT};
+
+    let socket_path = default_socket_path();
+    let connect_timeout = Duration::from_secs(2);
+
+    #[cfg(unix)]
+    let stream = {
+        let connect_result = tokio::time::timeout(
+            connect_timeout,
+            tokio::net::UnixStream::connect(&socket_path),
+        )
+        .await;
+
+        match connect_result {
+            Ok(Ok(s)) => s,
+            Ok(Err(e)) => return Err(ClientError::ConnectionFailed(e)),
+            Err(_) => return Err(ClientError::Timeout),
+        }
+    };
+
+    #[cfg(windows)]
+    let stream = {
+        let pipe_name = socket_path.to_string_lossy().to_string();
+        let connect_result = tokio::time::timeout(connect_timeout, async {
+            let mut attempts = 0;
+            loop {
+                match ClientOptions::new().open(&pipe_name) {
+                    Ok(client) => return Ok(client),
+                    Err(_) if attempts < 5 => {
+                        attempts += 1;
+                        tokio::time::sleep(Duration::from_millis(50)).await;
+                    }
+                    Err(e) => return Err(e),
+                }
+            }
+        })
+        .await;
+
+        match connect_result {
+            Ok(Ok(s)) => s,
+            Ok(Err(e)) => return Err(ClientError::ConnectionFailed(e)),
+            Err(_) => return Err(ClientError::Timeout),
+        }
+    };
+
+    // Send preamble + handshake
+    let mut stream = stream;
+    connection::send_preamble(&mut stream)
+        .await
+        .map_err(|e| ClientError::ProtocolError(format!("preamble: {}", e)))?;
+    connection::send_json_frame(&mut stream, &Handshake::PoolStateSync)
+        .await
+        .map_err(|e| ClientError::ProtocolError(format!("handshake: {}", e)))?;
+
+    // Create a channel to forward pool state snapshots
+    let (tx, rx) = tokio::sync::mpsc::channel(16);
+
+    // Spawn a task that maintains a local Automerge doc synced with the daemon's PoolDoc
+    tokio::spawn(async move {
+        let mut doc = AutoCommit::new();
+        let mut peer_state = sync::State::new();
+        let mut last_snapshot: Option<crate::pool_doc::PoolState> = None;
+
+        // Helper: read pool state from the local doc and send if changed
+        let read_and_send =
+            |doc: &AutoCommit,
+             last: &mut Option<crate::pool_doc::PoolState>,
+             tx: &tokio::sync::mpsc::Sender<crate::pool_doc::PoolState>| {
+                // Read uv/ and conda/ from the local doc
+                let state = read_pool_state_from_doc(doc);
+                if let Some(ref state) = state {
+                    if last.as_ref() != Some(state) {
+                        *last = Some(state.clone());
+                        // Best-effort send — if receiver dropped, we'll notice next loop
+                        let _ = tx.try_send(state.clone());
+                    }
+                }
+            };
+
+        let (mut reader, mut writer) = tokio::io::split(stream);
+
+        loop {
+            match connection::recv_frame(&mut reader).await {
+                Ok(Some(data)) => {
+                    // Decode and apply the sync message
+                    let message = match sync::Message::decode(&data) {
+                        Ok(msg) => msg,
+                        Err(e) => {
+                            warn!("[pool-sync-client] Decode error: {}", e);
+                            break;
+                        }
+                    };
+
+                    if let Err(e) = doc.sync().receive_sync_message(&mut peer_state, message) {
+                        warn!("[pool-sync-client] Sync error: {}", e);
+                        break;
+                    }
+
+                    // Send our reply (ACK) so the server knows our state
+                    if let Some(reply) = doc.sync().generate_sync_message(&mut peer_state) {
+                        if connection::send_frame(&mut writer, &reply.encode())
+                            .await
+                            .is_err()
+                        {
+                            break;
+                        }
+                    }
+
+                    // Read state from doc and send if changed
+                    read_and_send(&doc, &mut last_snapshot, &tx);
+                }
+                Ok(None) => break, // Connection closed
+                Err(e) => {
+                    warn!("[pool-sync-client] Frame error: {}", e);
+                    break;
+                }
+            }
+        }
+    });
+
+    Ok(rx)
+}
+
+/// Read pool state from a local Automerge doc (client-side copy of PoolDoc).
+fn read_pool_state_from_doc(doc: &automerge::AutoCommit) -> Option<crate::pool_doc::PoolState> {
+    use automerge::{ReadDoc, ROOT};
+
+    let read_runtime = |key: &str| -> Option<crate::pool_doc::RuntimePoolState> {
+        let (_, obj_id) = doc.get(ROOT, key).ok()??;
+
+        let available = doc
+            .get(&obj_id, "available")
+            .ok()?
+            .and_then(|(v, _)| v.to_u64())
+            .unwrap_or(0);
+        let warming = doc
+            .get(&obj_id, "warming")
+            .ok()?
+            .and_then(|(v, _)| v.to_u64())
+            .unwrap_or(0);
+        let pool_size = doc
+            .get(&obj_id, "pool_size")
+            .ok()?
+            .and_then(|(v, _)| v.to_u64())
+            .unwrap_or(0);
+        let error = doc
+            .get(&obj_id, "error")
+            .ok()
+            .flatten()
+            .and_then(|(v, _)| v.to_str().map(|s| s.to_string()));
+
+        Some(crate::pool_doc::RuntimePoolState {
+            available,
+            warming,
+            pool_size,
+            error,
+        })
+    };
+
+    Some(crate::pool_doc::PoolState {
+        uv: read_runtime("uv")?,
+        conda: read_runtime("conda")?,
+    })
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -1607,6 +1607,8 @@ impl Daemon {
                 match env {
                     Some(env) => {
                         debug!("[runtimed] Took {} env: {:?}", env_type, env.venv_path);
+                        // Update PoolDoc immediately so clients see the count change
+                        self.update_pool_doc().await;
                         // Spawn replenishment
                         let daemon = self.clone();
                         match env_type {
@@ -1659,6 +1661,8 @@ impl Daemon {
                         }
                     }
                 }
+                // Update PoolDoc immediately so clients see the returned env
+                self.update_pool_doc().await;
                 Response::Returned
             }
 
@@ -2388,12 +2392,16 @@ print("warmup complete")
                 available: uv_available as u64,
                 warming: uv_warming as u64,
                 pool_size: self.config.uv_pool_size as u64,
+                consecutive_failures: uv_error.as_ref().map_or(0, |e| e.consecutive_failures),
+                retry_in_secs: uv_error.as_ref().map_or(0, |e| e.retry_in_secs),
                 error: uv_error.map(|e| e.message),
             },
             conda: crate::pool_doc::RuntimePoolState {
                 available: conda_available as u64,
                 warming: conda_warming as u64,
                 pool_size: self.config.conda_pool_size as u64,
+                consecutive_failures: conda_error.as_ref().map_or(0, |e| e.consecutive_failures),
+                retry_in_secs: conda_error.as_ref().map_or(0, |e| e.retry_in_secs),
                 error: conda_error.map(|e| e.message),
             },
         };

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -326,7 +326,12 @@ pub struct Daemon {
     /// Broadcast channel to notify sync connections of settings changes.
     settings_changed: tokio::sync::broadcast::Sender<()>,
     /// Broadcast channel to notify clients of pool state changes (errors, recovery).
+    /// Legacy: replaced by pool_doc for new clients using PoolStateSync handshake.
     pool_state_changed: tokio::sync::broadcast::Sender<DaemonBroadcast>,
+    /// Shared Automerge pool state document (daemon-authoritative, ephemeral).
+    pool_doc: Arc<RwLock<crate::pool_doc::PoolDoc>>,
+    /// Broadcast channel to notify pool sync connections of pool doc changes.
+    pool_doc_changed: tokio::sync::broadcast::Sender<()>,
     /// Content-addressed blob store.
     blob_store: Arc<BlobStore>,
     /// HTTP port for the blob server (set after startup).
@@ -363,6 +368,8 @@ impl Daemon {
 
         let (settings_changed, _) = tokio::sync::broadcast::channel(16);
         let (pool_state_changed, _) = tokio::sync::broadcast::channel(16);
+        let (pool_doc_changed, _) = tokio::sync::broadcast::channel(16);
+        let pool_doc = Arc::new(RwLock::new(crate::pool_doc::PoolDoc::new()));
 
         let blob_store = Arc::new(BlobStore::new(config.blob_store_dir.clone()));
 
@@ -376,6 +383,8 @@ impl Daemon {
             settings: Arc::new(RwLock::new(settings)),
             settings_changed,
             pool_state_changed,
+            pool_doc,
+            pool_doc_changed,
             blob_store,
             blob_port: Mutex::new(None),
             notebook_rooms: Arc::new(Mutex::new(HashMap::new())),
@@ -1053,6 +1062,16 @@ impl Daemon {
             }
             Handshake::Blob => self.handle_blob_connection(stream).await,
             Handshake::PoolStateSubscribe => self.handle_pool_state_subscription(stream).await,
+            Handshake::PoolStateSync => {
+                let (reader, writer) = tokio::io::split(stream);
+                crate::sync_server::handle_pool_sync_connection(
+                    reader,
+                    writer,
+                    self.pool_doc.clone(),
+                    self.pool_doc_changed.subscribe(),
+                )
+                .await
+            }
             Handshake::OpenNotebook { path } => self.handle_open_notebook(stream, path).await,
             Handshake::CreateNotebook {
                 runtime,
@@ -1874,12 +1893,13 @@ impl Daemon {
                 }
             }
 
-            // Log status
+            // Log status + update PoolDoc
             let (available, warming) = self.uv_pool.lock().await.stats();
             debug!(
                 "[runtimed] UV pool: {}/{} available, {} warming",
                 available, self.config.uv_pool_size, warming
             );
+            self.update_pool_doc().await;
 
             tokio::time::sleep(std::time::Duration::from_secs(30)).await;
         }
@@ -1958,12 +1978,13 @@ impl Daemon {
                 }
             }
 
-            // Log status
+            // Log status + update PoolDoc
             let (available, warming) = self.conda_pool.lock().await.stats();
             debug!(
                 "[runtimed] Conda pool: {}/{} available, {} warming",
                 available, self.config.conda_pool_size, warming
             );
+            self.update_pool_doc().await;
 
             // Wait before checking again
             tokio::time::sleep(std::time::Duration::from_secs(30)).await;
@@ -2333,14 +2354,46 @@ print("warmup complete")
         let uv_error = self.uv_pool.lock().await.get_error();
         let conda_error = self.conda_pool.lock().await.get_error();
 
-        // Only broadcast if there's something to report or if we're clearing errors
+        // Legacy broadcast for old clients using PoolStateSubscribe
         let broadcast = DaemonBroadcast::PoolState {
             uv_error,
             conda_error,
         };
-
-        // Send to all subscribers (ignore errors if no subscribers)
         let _ = self.pool_state_changed.send(broadcast);
+
+        // Also update the PoolDoc for new clients using PoolStateSync
+        self.update_pool_doc().await;
+    }
+
+    /// Write the current pool state to the PoolDoc and notify sync clients.
+    ///
+    /// Called from both warming loops (every 30s tick) and on error/recovery.
+    /// The PoolDoc deduplicates — if nothing changed, this is a no-op.
+    async fn update_pool_doc(&self) {
+        let (uv_available, uv_warming) = self.uv_pool.lock().await.stats();
+        let uv_error = self.uv_pool.lock().await.get_error();
+        let (conda_available, conda_warming) = self.conda_pool.lock().await.stats();
+        let conda_error = self.conda_pool.lock().await.get_error();
+
+        let state = crate::pool_doc::PoolState {
+            uv: crate::pool_doc::RuntimePoolState {
+                available: uv_available as u64,
+                warming: uv_warming as u64,
+                pool_size: self.config.uv_pool_size as u64,
+                error: uv_error.map(|e| e.message),
+            },
+            conda: crate::pool_doc::RuntimePoolState {
+                available: conda_available as u64,
+                warming: conda_warming as u64,
+                pool_size: self.config.conda_pool_size as u64,
+                error: conda_error.map(|e| e.message),
+            },
+        };
+
+        let changed = self.pool_doc.write().await.update(&state);
+        if changed {
+            let _ = self.pool_doc_changed.send(());
+        }
     }
 
     /// Create a single UV environment and add it to the pool.

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -2370,10 +2370,18 @@ print("warmup complete")
     /// Called from both warming loops (every 30s tick) and on error/recovery.
     /// The PoolDoc deduplicates — if nothing changed, this is a no-op.
     async fn update_pool_doc(&self) {
-        let (uv_available, uv_warming) = self.uv_pool.lock().await.stats();
-        let uv_error = self.uv_pool.lock().await.get_error();
-        let (conda_available, conda_warming) = self.conda_pool.lock().await.stats();
-        let conda_error = self.conda_pool.lock().await.get_error();
+        let (uv_available, uv_warming, uv_error) = {
+            let pool = self.uv_pool.lock().await;
+            let (available, warming) = pool.stats();
+            let error = pool.get_error();
+            (available, warming, error)
+        };
+        let (conda_available, conda_warming, conda_error) = {
+            let pool = self.conda_pool.lock().await;
+            let (available, warming) = pool.stats();
+            let error = pool.get_error();
+            (available, warming, error)
+        };
 
         let state = crate::pool_doc::PoolState {
             uv: crate::pool_doc::RuntimePoolState {

--- a/crates/runtimed/src/lib.rs
+++ b/crates/runtimed/src/lib.rs
@@ -253,3 +253,4 @@ pub fn settings_schema_path() -> PathBuf {
 pub fn default_notebook_docs_dir() -> PathBuf {
     daemon_base_dir().join("notebook-docs")
 }
+pub mod pool_doc;

--- a/crates/runtimed/src/pool_doc.rs
+++ b/crates/runtimed/src/pool_doc.rs
@@ -1,0 +1,406 @@
+//! PoolDoc — Automerge document for daemon pool state.
+//!
+//! A global, daemon-authoritative, ephemeral Automerge document that carries
+//! the prewarmed environment pool state. Clients sync it read-only via the
+//! standard Automerge sync protocol (same pattern as `SettingsDoc`).
+//!
+//! Schema:
+//! ```text
+//! ROOT/
+//!   uv/
+//!     available: u64
+//!     warming: u64
+//!     pool_size: u64
+//!     error: Str | null
+//!   conda/
+//!     available: u64
+//!     warming: u64
+//!     pool_size: u64
+//!     error: Str | null
+//! ```
+//!
+//! The daemon writes to this doc on every warming loop tick and on every
+//! error/recovery event. Clients receive updates via Automerge sync —
+//! no dedicated broadcast subscription channel needed.
+
+use automerge::{
+    sync, sync::SyncDoc, transaction::Transactable, AutoCommit, AutomergeError, ObjType, ReadDoc,
+    ROOT,
+};
+use log::warn;
+
+/// Snapshot of pool state for a single runtime (uv or conda).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimePoolState {
+    pub available: u64,
+    pub warming: u64,
+    pub pool_size: u64,
+    pub error: Option<String>,
+}
+
+/// Full pool state snapshot.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PoolState {
+    pub uv: RuntimePoolState,
+    pub conda: RuntimePoolState,
+}
+
+/// Automerge-backed pool state document.
+///
+/// The daemon creates one of these on startup. It's never persisted to disk —
+/// pool state is ephemeral and reconstructed from the actual pool on restart.
+pub struct PoolDoc {
+    doc: AutoCommit,
+    /// Cached last-written state to avoid redundant Automerge writes
+    /// when the pool state hasn't changed (common during idle periods).
+    last_state: Option<PoolState>,
+}
+
+impl PoolDoc {
+    /// Create a new empty PoolDoc with the schema scaffolded.
+    pub fn new() -> Self {
+        let mut doc = AutoCommit::new();
+        doc.set_actor(automerge::ActorId::from(b"runtimed:pool".as_slice()));
+
+        // Scaffold the schema
+        let uv = doc
+            .put_object(ROOT, "uv", ObjType::Map)
+            .expect("scaffold uv");
+        doc.put(&uv, "available", 0u64)
+            .expect("scaffold uv.available");
+        doc.put(&uv, "warming", 0u64).expect("scaffold uv.warming");
+        doc.put(&uv, "pool_size", 0u64)
+            .expect("scaffold uv.pool_size");
+        // error starts as null (absent)
+
+        let conda = doc
+            .put_object(ROOT, "conda", ObjType::Map)
+            .expect("scaffold conda");
+        doc.put(&conda, "available", 0u64)
+            .expect("scaffold conda.available");
+        doc.put(&conda, "warming", 0u64)
+            .expect("scaffold conda.warming");
+        doc.put(&conda, "pool_size", 0u64)
+            .expect("scaffold conda.pool_size");
+
+        PoolDoc {
+            doc,
+            last_state: None,
+        }
+    }
+
+    /// Write the full pool state to the document.
+    ///
+    /// Returns `true` if the doc was actually mutated (state changed).
+    /// Returns `false` if the state is identical to the last write (no-op).
+    ///
+    /// This is called on every warming loop tick (~30s) so the dedup check
+    /// avoids growing Automerge history during idle periods.
+    pub fn update(&mut self, state: &PoolState) -> bool {
+        // Fast path: skip if unchanged
+        if self.last_state.as_ref() == Some(state) {
+            return false;
+        }
+
+        if let Err(e) = self.write_state(state) {
+            warn!("[pool-doc] Failed to write pool state: {}", e);
+            return false;
+        }
+
+        self.last_state = Some(state.clone());
+        true
+    }
+
+    /// Internal: write the state fields into the Automerge doc.
+    fn write_state(&mut self, state: &PoolState) -> Result<(), AutomergeError> {
+        // Write uv/ fields
+        let uv_id = self
+            .doc
+            .get(ROOT, "uv")?
+            .and_then(|(_, id)| Some(id))
+            .expect("uv map missing");
+
+        self.doc.put(&uv_id, "available", state.uv.available)?;
+        self.doc.put(&uv_id, "warming", state.uv.warming)?;
+        self.doc.put(&uv_id, "pool_size", state.uv.pool_size)?;
+        match &state.uv.error {
+            Some(err) => self.doc.put(&uv_id, "error", err.as_str())?,
+            None => {
+                // Delete the key to represent null. If the key doesn't exist,
+                // delete is a no-op — safe to call unconditionally.
+                let _ = self.doc.delete(&uv_id, "error");
+            }
+        }
+
+        // Write conda/ fields
+        let conda_id = self
+            .doc
+            .get(ROOT, "conda")?
+            .and_then(|(_, id)| Some(id))
+            .expect("conda map missing");
+
+        self.doc
+            .put(&conda_id, "available", state.conda.available)?;
+        self.doc.put(&conda_id, "warming", state.conda.warming)?;
+        self.doc
+            .put(&conda_id, "pool_size", state.conda.pool_size)?;
+        match &state.conda.error {
+            Some(err) => self.doc.put(&conda_id, "error", err.as_str())?,
+            None => {
+                let _ = self.doc.delete(&conda_id, "error");
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Read the current pool state from the document.
+    ///
+    /// Used by the frontend-facing sync handler to verify state, and by tests.
+    pub fn read_state(&self) -> Option<PoolState> {
+        let uv = self.read_runtime_state("uv")?;
+        let conda = self.read_runtime_state("conda")?;
+        Some(PoolState { uv, conda })
+    }
+
+    fn read_runtime_state(&self, key: &str) -> Option<RuntimePoolState> {
+        let (_, obj_id) = self.doc.get(ROOT, key).ok()??;
+
+        let available = self
+            .doc
+            .get(&obj_id, "available")
+            .ok()?
+            .and_then(|(v, _)| v.to_u64())
+            .unwrap_or(0);
+
+        let warming = self
+            .doc
+            .get(&obj_id, "warming")
+            .ok()?
+            .and_then(|(v, _)| v.to_u64())
+            .unwrap_or(0);
+
+        let pool_size = self
+            .doc
+            .get(&obj_id, "pool_size")
+            .ok()?
+            .and_then(|(v, _)| v.to_u64())
+            .unwrap_or(0);
+
+        let error = self
+            .doc
+            .get(&obj_id, "error")
+            .ok()
+            .flatten()
+            .and_then(|(v, _)| v.to_str().map(|s| s.to_string()));
+
+        Some(RuntimePoolState {
+            available,
+            warming,
+            pool_size,
+            error,
+        })
+    }
+
+    // ── Automerge sync protocol ──────────────────────────────────────
+
+    /// Generate a sync message for a peer.
+    pub fn generate_sync_message(&mut self, peer_state: &mut sync::State) -> Option<sync::Message> {
+        self.doc.sync().generate_sync_message(peer_state)
+    }
+
+    /// Receive a sync message from a peer.
+    ///
+    /// For PoolDoc this is used to complete the sync protocol handshake
+    /// (the client sends back acknowledgments). We intentionally do NOT
+    /// apply any document mutations from the client — the pool doc is
+    /// daemon-authoritative.
+    pub fn receive_sync_message(
+        &mut self,
+        peer_state: &mut sync::State,
+        message: sync::Message,
+    ) -> Result<(), AutomergeError> {
+        self.doc.sync().receive_sync_message(peer_state, message)?;
+        Ok(())
+    }
+}
+
+impl Default for PoolDoc {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_doc_has_zero_state() {
+        let doc = PoolDoc::new();
+        let state = doc.read_state().unwrap();
+        assert_eq!(state.uv.available, 0);
+        assert_eq!(state.uv.warming, 0);
+        assert_eq!(state.uv.pool_size, 0);
+        assert_eq!(state.uv.error, None);
+        assert_eq!(state.conda.available, 0);
+        assert_eq!(state.conda.warming, 0);
+        assert_eq!(state.conda.pool_size, 0);
+        assert_eq!(state.conda.error, None);
+    }
+
+    #[test]
+    fn test_update_writes_state() {
+        let mut doc = PoolDoc::new();
+        let state = PoolState {
+            uv: RuntimePoolState {
+                available: 3,
+                warming: 1,
+                pool_size: 4,
+                error: None,
+            },
+            conda: RuntimePoolState {
+                available: 2,
+                warming: 0,
+                pool_size: 3,
+                error: Some("rattler failed".to_string()),
+            },
+        };
+
+        let changed = doc.update(&state);
+        assert!(changed);
+
+        let read = doc.read_state().unwrap();
+        assert_eq!(read.uv.available, 3);
+        assert_eq!(read.uv.warming, 1);
+        assert_eq!(read.uv.pool_size, 4);
+        assert_eq!(read.uv.error, None);
+        assert_eq!(read.conda.available, 2);
+        assert_eq!(read.conda.warming, 0);
+        assert_eq!(read.conda.pool_size, 3);
+        assert_eq!(read.conda.error, Some("rattler failed".to_string()));
+    }
+
+    #[test]
+    fn test_update_deduplicates() {
+        let mut doc = PoolDoc::new();
+        let state = PoolState {
+            uv: RuntimePoolState {
+                available: 3,
+                warming: 0,
+                pool_size: 3,
+                error: None,
+            },
+            conda: RuntimePoolState {
+                available: 0,
+                warming: 0,
+                pool_size: 0,
+                error: None,
+            },
+        };
+
+        assert!(doc.update(&state)); // first write — changed
+        assert!(!doc.update(&state)); // same state — no-op
+    }
+
+    #[test]
+    fn test_error_cleared() {
+        let mut doc = PoolDoc::new();
+
+        // Set an error
+        let with_error = PoolState {
+            uv: RuntimePoolState {
+                available: 0,
+                warming: 0,
+                pool_size: 2,
+                error: Some("venv creation failed".to_string()),
+            },
+            conda: RuntimePoolState {
+                available: 0,
+                warming: 0,
+                pool_size: 0,
+                error: None,
+            },
+        };
+        doc.update(&with_error);
+        assert_eq!(
+            doc.read_state().unwrap().uv.error,
+            Some("venv creation failed".to_string())
+        );
+
+        // Clear the error
+        let without_error = PoolState {
+            uv: RuntimePoolState {
+                available: 2,
+                warming: 0,
+                pool_size: 2,
+                error: None,
+            },
+            conda: RuntimePoolState {
+                available: 0,
+                warming: 0,
+                pool_size: 0,
+                error: None,
+            },
+        };
+        doc.update(&without_error);
+        assert_eq!(doc.read_state().unwrap().uv.error, None);
+    }
+
+    #[test]
+    fn test_sync_between_two_docs() {
+        let mut server = PoolDoc::new();
+        let mut client_doc = AutoCommit::new();
+        let mut server_to_client = sync::State::new();
+        let mut client_to_server = sync::State::new();
+
+        // Server writes some state
+        let state = PoolState {
+            uv: RuntimePoolState {
+                available: 4,
+                warming: 0,
+                pool_size: 4,
+                error: None,
+            },
+            conda: RuntimePoolState {
+                available: 1,
+                warming: 2,
+                pool_size: 3,
+                error: None,
+            },
+        };
+        server.update(&state);
+
+        // Sync: server → client
+        for _ in 0..10 {
+            let msg_s = server.generate_sync_message(&mut server_to_client);
+            let msg_c = client_doc
+                .sync()
+                .generate_sync_message(&mut client_to_server);
+
+            if msg_s.is_none() && msg_c.is_none() {
+                break;
+            }
+            if let Some(msg) = msg_s {
+                client_doc
+                    .sync()
+                    .receive_sync_message(&mut client_to_server, msg)
+                    .unwrap();
+            }
+            if let Some(msg) = msg_c {
+                server
+                    .receive_sync_message(&mut server_to_client, msg)
+                    .unwrap();
+            }
+        }
+
+        // Client should have the same state
+        let (_, uv_id) = client_doc.get(ROOT, "uv").unwrap().unwrap();
+        let (avail, _) = client_doc.get(&uv_id, "available").unwrap().unwrap();
+        assert_eq!(avail.to_u64(), Some(4));
+
+        let (_, conda_id) = client_doc.get(ROOT, "conda").unwrap().unwrap();
+        let (warming, _) = client_doc.get(&conda_id, "warming").unwrap().unwrap();
+        assert_eq!(warming.to_u64(), Some(2));
+    }
+}

--- a/crates/runtimed/src/pool_doc.rs
+++ b/crates/runtimed/src/pool_doc.rs
@@ -67,7 +67,7 @@ impl PoolDoc {
     /// These operations on a fresh `AutoCommit` are infallible — there are no
     /// conflicting keys or invalid object IDs. The `expect` calls document this
     /// invariant rather than propagating impossible errors.
-    #[allow(clippy::expect_used)]
+    #[allow(clippy::expect_used, clippy::new_without_default)]
     pub fn new() -> Self {
         let mut doc = AutoCommit::new();
         doc.set_actor(automerge::ActorId::from(b"runtimed:pool".as_slice()));

--- a/crates/runtimed/src/pool_doc.rs
+++ b/crates/runtimed/src/pool_doc.rs
@@ -396,22 +396,34 @@ mod tests {
                 client_doc
                     .sync()
                     .receive_sync_message(&mut client_to_server, msg)
-                    .unwrap();
+                    .expect("client should accept server sync message");
             }
             if let Some(msg) = msg_c {
                 server
                     .receive_sync_message(&mut server_to_client, msg)
-                    .unwrap();
+                    .expect("server should accept client sync message");
             }
         }
 
         // Client should have the same state
-        let (_, uv_id) = client_doc.get(ROOT, "uv").unwrap().unwrap();
-        let (avail, _) = client_doc.get(&uv_id, "available").unwrap().unwrap();
+        let (_, uv_id) = client_doc
+            .get(ROOT, "uv")
+            .expect("uv lookup should not error")
+            .expect("uv map should exist after sync");
+        let (avail, _) = client_doc
+            .get(&uv_id, "available")
+            .expect("available lookup should not error")
+            .expect("available field should exist after sync");
         assert_eq!(avail.to_u64(), Some(4));
 
-        let (_, conda_id) = client_doc.get(ROOT, "conda").unwrap().unwrap();
-        let (warming, _) = client_doc.get(&conda_id, "warming").unwrap().unwrap();
+        let (_, conda_id) = client_doc
+            .get(ROOT, "conda")
+            .expect("conda lookup should not error")
+            .expect("conda map should exist after sync");
+        let (warming, _) = client_doc
+            .get(&conda_id, "warming")
+            .expect("warming lookup should not error")
+            .expect("warming field should exist after sync");
         assert_eq!(warming.to_u64(), Some(2));
     }
 }

--- a/crates/runtimed/src/pool_doc.rs
+++ b/crates/runtimed/src/pool_doc.rs
@@ -35,7 +35,12 @@ pub struct RuntimePoolState {
     pub available: u64,
     pub warming: u64,
     pub pool_size: u64,
+    /// Human-readable error message (None if healthy).
     pub error: Option<String>,
+    /// Number of consecutive failures (0 if healthy).
+    pub consecutive_failures: u32,
+    /// Seconds until next retry (0 if retry is imminent or healthy).
+    pub retry_in_secs: u64,
 }
 
 /// Full pool state snapshot.
@@ -58,30 +63,44 @@ pub struct PoolDoc {
 
 impl PoolDoc {
     /// Create a new empty PoolDoc with the schema scaffolded.
+    ///
+    /// These operations on a fresh `AutoCommit` are infallible — there are no
+    /// conflicting keys or invalid object IDs. The `expect` calls document this
+    /// invariant rather than propagating impossible errors.
+    #[allow(clippy::expect_used)]
     pub fn new() -> Self {
         let mut doc = AutoCommit::new();
         doc.set_actor(automerge::ActorId::from(b"runtimed:pool".as_slice()));
 
-        // Scaffold the schema
+        // Scaffold the schema — fresh AutoCommit, these cannot fail
         let uv = doc
             .put_object(ROOT, "uv", ObjType::Map)
-            .expect("scaffold uv");
+            .expect("fresh AutoCommit: put_object cannot fail");
         doc.put(&uv, "available", 0u64)
-            .expect("scaffold uv.available");
-        doc.put(&uv, "warming", 0u64).expect("scaffold uv.warming");
+            .expect("fresh AutoCommit: put cannot fail");
+        doc.put(&uv, "warming", 0u64)
+            .expect("fresh AutoCommit: put cannot fail");
         doc.put(&uv, "pool_size", 0u64)
-            .expect("scaffold uv.pool_size");
+            .expect("fresh AutoCommit: put cannot fail");
+        doc.put(&uv, "consecutive_failures", 0u64)
+            .expect("fresh AutoCommit: put cannot fail");
+        doc.put(&uv, "retry_in_secs", 0u64)
+            .expect("fresh AutoCommit: put cannot fail");
         // error starts as null (absent)
 
         let conda = doc
             .put_object(ROOT, "conda", ObjType::Map)
-            .expect("scaffold conda");
+            .expect("fresh AutoCommit: put_object cannot fail");
         doc.put(&conda, "available", 0u64)
-            .expect("scaffold conda.available");
+            .expect("fresh AutoCommit: put cannot fail");
         doc.put(&conda, "warming", 0u64)
-            .expect("scaffold conda.warming");
+            .expect("fresh AutoCommit: put cannot fail");
         doc.put(&conda, "pool_size", 0u64)
-            .expect("scaffold conda.pool_size");
+            .expect("fresh AutoCommit: put cannot fail");
+        doc.put(&conda, "consecutive_failures", 0u64)
+            .expect("fresh AutoCommit: put cannot fail");
+        doc.put(&conda, "retry_in_secs", 0u64)
+            .expect("fresh AutoCommit: put cannot fail");
 
         PoolDoc {
             doc,
@@ -123,6 +142,13 @@ impl PoolDoc {
         self.doc.put(&uv_id, "available", state.uv.available)?;
         self.doc.put(&uv_id, "warming", state.uv.warming)?;
         self.doc.put(&uv_id, "pool_size", state.uv.pool_size)?;
+        self.doc.put(
+            &uv_id,
+            "consecutive_failures",
+            state.uv.consecutive_failures as u64,
+        )?;
+        self.doc
+            .put(&uv_id, "retry_in_secs", state.uv.retry_in_secs)?;
         match &state.uv.error {
             Some(err) => self.doc.put(&uv_id, "error", err.as_str())?,
             None => {
@@ -144,6 +170,13 @@ impl PoolDoc {
         self.doc.put(&conda_id, "warming", state.conda.warming)?;
         self.doc
             .put(&conda_id, "pool_size", state.conda.pool_size)?;
+        self.doc.put(
+            &conda_id,
+            "consecutive_failures",
+            state.conda.consecutive_failures as u64,
+        )?;
+        self.doc
+            .put(&conda_id, "retry_in_secs", state.conda.retry_in_secs)?;
         match &state.conda.error {
             Some(err) => self.doc.put(&conda_id, "error", err.as_str())?,
             None => {
@@ -187,6 +220,22 @@ impl PoolDoc {
             .and_then(|(v, _)| v.to_u64())
             .unwrap_or(0);
 
+        let consecutive_failures = self
+            .doc
+            .get(&obj_id, "consecutive_failures")
+            .ok()
+            .flatten()
+            .and_then(|(v, _)| v.to_u64())
+            .unwrap_or(0) as u32;
+
+        let retry_in_secs = self
+            .doc
+            .get(&obj_id, "retry_in_secs")
+            .ok()
+            .flatten()
+            .and_then(|(v, _)| v.to_u64())
+            .unwrap_or(0);
+
         let error = self
             .doc
             .get(&obj_id, "error")
@@ -199,6 +248,8 @@ impl PoolDoc {
             warming,
             pool_size,
             error,
+            consecutive_failures,
+            retry_in_secs,
         })
     }
 
@@ -236,28 +287,27 @@ impl PoolDoc {
     }
 }
 
-impl Default for PoolDoc {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 
     #[test]
     fn test_new_doc_has_zero_state() {
         let doc = PoolDoc::new();
-        let state = doc.read_state().unwrap();
+        let state = doc.read_state().expect("fresh doc should have state");
         assert_eq!(state.uv.available, 0);
         assert_eq!(state.uv.warming, 0);
         assert_eq!(state.uv.pool_size, 0);
         assert_eq!(state.uv.error, None);
+        assert_eq!(state.uv.consecutive_failures, 0);
+        assert_eq!(state.uv.retry_in_secs, 0);
         assert_eq!(state.conda.available, 0);
         assert_eq!(state.conda.warming, 0);
         assert_eq!(state.conda.pool_size, 0);
         assert_eq!(state.conda.error, None);
+        assert_eq!(state.conda.consecutive_failures, 0);
+        assert_eq!(state.conda.retry_in_secs, 0);
     }
 
     #[test]
@@ -269,19 +319,25 @@ mod tests {
                 warming: 1,
                 pool_size: 4,
                 error: None,
+                consecutive_failures: 0,
+                retry_in_secs: 0,
             },
             conda: RuntimePoolState {
                 available: 2,
                 warming: 0,
                 pool_size: 3,
                 error: Some("rattler failed".to_string()),
+                consecutive_failures: 3,
+                retry_in_secs: 30,
             },
         };
 
         let changed = doc.update(&state);
         assert!(changed);
 
-        let read = doc.read_state().unwrap();
+        let read = doc
+            .read_state()
+            .expect("state should be readable after update");
         assert_eq!(read.uv.available, 3);
         assert_eq!(read.uv.warming, 1);
         assert_eq!(read.uv.pool_size, 4);
@@ -290,6 +346,8 @@ mod tests {
         assert_eq!(read.conda.warming, 0);
         assert_eq!(read.conda.pool_size, 3);
         assert_eq!(read.conda.error, Some("rattler failed".to_string()));
+        assert_eq!(read.conda.consecutive_failures, 3);
+        assert_eq!(read.conda.retry_in_secs, 30);
     }
 
     #[test]
@@ -301,12 +359,16 @@ mod tests {
                 warming: 0,
                 pool_size: 3,
                 error: None,
+                consecutive_failures: 0,
+                retry_in_secs: 0,
             },
             conda: RuntimePoolState {
                 available: 0,
                 warming: 0,
                 pool_size: 0,
                 error: None,
+                consecutive_failures: 0,
+                retry_in_secs: 0,
             },
         };
 
@@ -325,17 +387,21 @@ mod tests {
                 warming: 0,
                 pool_size: 2,
                 error: Some("venv creation failed".to_string()),
+                consecutive_failures: 2,
+                retry_in_secs: 15,
             },
             conda: RuntimePoolState {
                 available: 0,
                 warming: 0,
                 pool_size: 0,
                 error: None,
+                consecutive_failures: 0,
+                retry_in_secs: 0,
             },
         };
         doc.update(&with_error);
         assert_eq!(
-            doc.read_state().unwrap().uv.error,
+            doc.read_state().expect("state should be readable").uv.error,
             Some("venv creation failed".to_string())
         );
 
@@ -346,16 +412,23 @@ mod tests {
                 warming: 0,
                 pool_size: 2,
                 error: None,
+                consecutive_failures: 0,
+                retry_in_secs: 0,
             },
             conda: RuntimePoolState {
                 available: 0,
                 warming: 0,
                 pool_size: 0,
                 error: None,
+                consecutive_failures: 0,
+                retry_in_secs: 0,
             },
         };
         doc.update(&without_error);
-        assert_eq!(doc.read_state().unwrap().uv.error, None);
+        assert_eq!(
+            doc.read_state().expect("state should be readable").uv.error,
+            None
+        );
     }
 
     #[test]
@@ -372,12 +445,16 @@ mod tests {
                 warming: 0,
                 pool_size: 4,
                 error: None,
+                consecutive_failures: 0,
+                retry_in_secs: 0,
             },
             conda: RuntimePoolState {
                 available: 1,
                 warming: 2,
                 pool_size: 3,
                 error: None,
+                consecutive_failures: 0,
+                retry_in_secs: 0,
             },
         };
         server.update(&state);

--- a/crates/runtimed/src/pool_doc.rs
+++ b/crates/runtimed/src/pool_doc.rs
@@ -117,8 +117,8 @@ impl PoolDoc {
         let uv_id = self
             .doc
             .get(ROOT, "uv")?
-            .and_then(|(_, id)| Some(id))
-            .expect("uv map missing");
+            .map(|(_, id)| id)
+            .ok_or(AutomergeError::InvalidIndex(0))?;
 
         self.doc.put(&uv_id, "available", state.uv.available)?;
         self.doc.put(&uv_id, "warming", state.uv.warming)?;
@@ -136,8 +136,8 @@ impl PoolDoc {
         let conda_id = self
             .doc
             .get(ROOT, "conda")?
-            .and_then(|(_, id)| Some(id))
-            .expect("conda map missing");
+            .map(|(_, id)| id)
+            .ok_or(AutomergeError::InvalidIndex(0))?;
 
         self.doc
             .put(&conda_id, "available", state.conda.available)?;
@@ -212,15 +212,26 @@ impl PoolDoc {
     /// Receive a sync message from a peer.
     ///
     /// For PoolDoc this is used to complete the sync protocol handshake
-    /// (the client sends back acknowledgments). We intentionally do NOT
-    /// apply any document mutations from the client — the pool doc is
-    /// daemon-authoritative.
+    /// (the client sends back acknowledgments). We intentionally strip
+    /// any document changes from the client — the pool doc is
+    /// daemon-authoritative and read-only for clients.
     pub fn receive_sync_message(
         &mut self,
         peer_state: &mut sync::State,
         message: sync::Message,
     ) -> Result<(), AutomergeError> {
-        self.doc.sync().receive_sync_message(peer_state, message)?;
+        // Strip any changes the client may have included — the daemon is the
+        // sole authority for pool state. We preserve heads/need/have so the
+        // sync protocol handshake (bloom filter exchange, ACKs) still works.
+        let filtered = sync::Message {
+            heads: message.heads,
+            need: message.need,
+            have: message.have,
+            changes: sync::ChunkList::empty(),
+            supported_capabilities: message.supported_capabilities,
+            version: message.version,
+        };
+        self.doc.sync().receive_sync_message(peer_state, filtered)?;
         Ok(())
     }
 }

--- a/crates/runtimed/src/sync_server.rs
+++ b/crates/runtimed/src/sync_server.rs
@@ -1,8 +1,12 @@
-//! Automerge sync protocol handler for settings synchronization.
+//! Automerge sync protocol handlers for global documents.
 //!
-//! Handles a single client connection that has already been routed by the
-//! daemon's unified socket. Exchanges Automerge sync messages to keep a
-//! shared settings document in sync across all notebook windows.
+//! Handles client connections that have already been routed by the daemon's
+//! unified socket. Exchanges Automerge sync messages to keep shared documents
+//! in sync across all notebook windows.
+//!
+//! Two handlers:
+//! - `handle_settings_sync_connection` — bidirectional sync for user settings
+//! - `handle_pool_sync_connection` — daemon-authoritative sync for pool state
 
 use std::sync::Arc;
 
@@ -89,6 +93,72 @@ where
             // Another peer changed settings -- push update to this client
             _ = changed_rx.recv() => {
                 let mut doc = settings.write().await;
+                if let Some(msg) = doc.generate_sync_message(&mut peer_state) {
+                    connection::send_frame(&mut writer, &msg.encode()).await?;
+                }
+            }
+        }
+    }
+}
+
+/// Handle a pool state sync connection (daemon-authoritative, read-only for clients).
+///
+/// Same Automerge sync protocol as settings, but the daemon is the sole writer.
+/// Client sync messages are processed (for protocol handshake / ACKs) but any
+/// document mutations from the client are effectively no-ops — the daemon's
+/// writes always win because the client has no meaningful changes to contribute.
+pub async fn handle_pool_sync_connection<R, W>(
+    mut reader: R,
+    mut writer: W,
+    pool_doc: Arc<RwLock<crate::pool_doc::PoolDoc>>,
+    mut changed_rx: broadcast::Receiver<()>,
+) -> anyhow::Result<()>
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    let mut peer_state = sync::State::new();
+    info!("[sync] Pool state client connected");
+
+    // Phase 1: Initial sync — server sends first
+    {
+        let mut doc = pool_doc.write().await;
+        if let Some(msg) = doc.generate_sync_message(&mut peer_state) {
+            connection::send_frame(&mut writer, &msg.encode()).await?;
+        }
+    }
+
+    // Phase 2: Exchange messages until sync is complete, then push on changes
+    loop {
+        tokio::select! {
+            // Incoming message from client (protocol ACKs)
+            result = connection::recv_frame(&mut reader) => {
+                match result? {
+                    Some(data) => {
+                        let message = sync::Message::decode(&data)
+                            .map_err(|e| anyhow::anyhow!("decode error: {}", e))?;
+
+                        let mut doc = pool_doc.write().await;
+                        // Process for sync protocol state, but client can't
+                        // meaningfully mutate pool state — daemon is authoritative.
+                        doc.receive_sync_message(&mut peer_state, message)?;
+
+                        // Send our response (completes handshake)
+                        if let Some(reply) = doc.generate_sync_message(&mut peer_state) {
+                            connection::send_frame(&mut writer, &reply.encode()).await?;
+                        }
+                    }
+                    None => {
+                        // Client disconnected
+                        info!("[sync] Pool state client disconnected");
+                        return Ok(());
+                    }
+                }
+            }
+
+            // Pool state changed — push update to this client
+            _ = changed_rx.recv() => {
+                let mut doc = pool_doc.write().await;
                 if let Some(msg) = doc.generate_sync_message(&mut peer_state) {
                     connection::send_frame(&mut writer, &msg.encode()).await?;
                 }

--- a/crates/runtimed/src/sync_server.rs
+++ b/crates/runtimed/src/sync_server.rs
@@ -121,11 +121,13 @@ where
     info!("[sync] Pool state client connected");
 
     // Phase 1: Initial sync — server sends first
-    {
+    let initial_data = {
         let mut doc = pool_doc.write().await;
-        if let Some(msg) = doc.generate_sync_message(&mut peer_state) {
-            connection::send_frame(&mut writer, &msg.encode()).await?;
-        }
+        doc.generate_sync_message(&mut peer_state)
+            .map(|msg| msg.encode())
+    };
+    if let Some(data) = initial_data {
+        connection::send_frame(&mut writer, &data).await?;
     }
 
     // Phase 2: Exchange messages until sync is complete, then push on changes
@@ -138,14 +140,17 @@ where
                         let message = sync::Message::decode(&data)
                             .map_err(|e| anyhow::anyhow!("decode error: {}", e))?;
 
-                        let mut doc = pool_doc.write().await;
-                        // Process for sync protocol state, but client can't
-                        // meaningfully mutate pool state — daemon is authoritative.
-                        doc.receive_sync_message(&mut peer_state, message)?;
-
-                        // Send our response (completes handshake)
-                        if let Some(reply) = doc.generate_sync_message(&mut peer_state) {
-                            connection::send_frame(&mut writer, &reply.encode()).await?;
+                        let reply_data = {
+                            let mut doc = pool_doc.write().await;
+                            // Process for sync protocol state, but client can't
+                            // meaningfully mutate pool state — daemon is authoritative.
+                            doc.receive_sync_message(&mut peer_state, message)?;
+                            doc.generate_sync_message(&mut peer_state)
+                                .map(|msg| msg.encode())
+                        };
+                        // Send our response (completes handshake) — lock released
+                        if let Some(data) = reply_data {
+                            connection::send_frame(&mut writer, &data).await?;
                         }
                     }
                     None => {
@@ -157,10 +162,23 @@ where
             }
 
             // Pool state changed — push update to this client
-            _ = changed_rx.recv() => {
-                let mut doc = pool_doc.write().await;
-                if let Some(msg) = doc.generate_sync_message(&mut peer_state) {
-                    connection::send_frame(&mut writer, &msg.encode()).await?;
+            recv_result = changed_rx.recv() => {
+                match recv_result {
+                    Ok(()) => {}
+                    Err(broadcast::error::RecvError::Closed) => {
+                        info!("[sync] Pool state broadcast channel closed, disconnecting");
+                        return Ok(());
+                    }
+                    Err(broadcast::error::RecvError::Lagged(n)) => {
+                        warn!("[sync] Pool state receiver lagged by {} messages", n);
+                    }
+                }
+                let push_data = {
+                    let mut doc = pool_doc.write().await;
+                    doc.generate_sync_message(&mut peer_state).map(|msg| msg.encode())
+                };
+                if let Some(data) = push_data {
+                    connection::send_frame(&mut writer, &data).await?;
                 }
             }
         }


### PR DESCRIPTION
## Closed — deferred to 2.1

The daemon-side PoolDoc is solid but without the WASM relay (frame multiplexing), the frontend integration is just a fancier pipe to the same Tauri event — additive complexity for marginal benefit.

The work isn't wasted: the branch has the foundation for 2.1 when frame multiplexing makes it real. See `.context/plans/daemon-state-doc.md` for the full architecture.

### What's on this branch (preserved for 2.1)

- `PoolDoc` struct with Automerge schema, dedup, read-only enforcement, 5 tests
- `Handshake::PoolStateSync` protocol variant
- Daemon wiring: sync handler, warming loop writes, take/return updates
- `sync_pool_state()` client for Python/CLI
- Frontend Tauri event shim (will be replaced by WASM relay in 2.1)

### Why not 2.0.1

- Two mechanisms doing one job (legacy broadcast + PoolDoc shim)
- The hard part (frame multiplexing, WASM relay) isn't built yet
- No user-visible improvement over the existing pool subscription
- Risk > benefit for a Monday stable release