### PR TITLE
fix(runtimed): broadcast env sync state when deps are removed

### DIFF
--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -395,7 +395,23 @@ async fn check_and_broadcast_sync_state(room: &NotebookRoom) {
                                 deno_changed: false,
                             }),
                         });
+                } else {
+                    // Inline section exists but deps list is empty - back in sync
+                    let _ = room
+                        .kernel_broadcast_tx
+                        .send(NotebookBroadcast::EnvSyncState {
+                            in_sync: true,
+                            diff: None,
+                        });
                 }
+            } else {
+                // No inline deps in metadata at all - back in sync
+                let _ = room
+                    .kernel_broadcast_tx
+                    .send(NotebookBroadcast::EnvSyncState {
+                        in_sync: true,
+                        diff: None,
+                    });
             }
         }
     }


### PR DESCRIPTION
When a prewarmed kernel is running and the user removes all inline dependencies, the daemon was not broadcasting `EnvSyncState { in_sync: true }`, leaving the "Restart kernel to use N new packages" banner stuck at its last non-zero count.

The fix adds two else branches in the prewarmed case to broadcast `in_sync: true` when deps are completely removed—either by clearing the deps list or removing the inline deps section entirely.

Closes #571

## Verification Checklist
* [ ] Add 2 UV deps → banner shows "2 new packages"
* [ ] Remove 1 dep → banner shows "1 new package"
* [ ] Remove last dep → banner disappears
* [ ] Add 1 dep back → banner shows "1 new package"
* [ ] Restart kernel → banner clears

_PR submitted by @rgbkrk's agent, Quill_