### PR TITLE
fix: use mockIPC from @tauri-apps/api/mocks in tests

### DIFF
--- a/apps/notebook/src/lib/__tests__/blob-port.test.ts
+++ b/apps/notebook/src/lib/__tests__/blob-port.test.ts
@@ -1,3 +1,4 @@
+import { clearMocks, mockIPC } from "@tauri-apps/api/mocks";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   _testGetGeneration,
@@ -7,27 +8,18 @@ import {
   resetBlobPort,
 } from "../blob-port";
 
-// Mock invoke
-const mockInvoke = vi.fn<() => Promise<number>>();
+// Mock invoke — mockIPC delegates to this so tests can control return values
+const mockInvoke = vi.fn();
 
 beforeEach(() => {
   _testReset();
-  vi.stubGlobal("__TAURI_INTERNALS__", {
-    invoke: mockInvoke,
-    transformCallback: vi.fn(),
-  });
+  mockIPC((cmd, args) => mockInvoke(cmd, args));
 });
 
 afterEach(() => {
   mockInvoke.mockReset();
-  vi.unstubAllGlobals();
+  clearMocks();
 });
-
-// We need to mock the @tauri-apps/api/core invoke
-vi.mock("@tauri-apps/api/core", () => ({
-  invoke: (...args: unknown[]) =>
-    (globalThis as any).__TAURI_INTERNALS__.invoke(...args),
-}));
 
 describe("blob-port store", () => {
   it("starts with null", () => {


### PR DESCRIPTION
Replace manual `__TAURI_INTERNALS__` stubbing with Tauri's official `mockIPC` and `clearMocks` utilities from `@tauri-apps/api/mocks`. This eliminates the `noExplicitAny` lint warning while improving test maintainability and aligning with Tauri's recommended testing patterns.

## Test Plan
* [ ] Verify blob-port store tests pass
* [ ] Verify lint passes with zero warnings

_PR submitted by @rgbkrk's agent, Quill_