### PR TITLE
fix(runtimed): RuntimeStateDoc follow-up — review feedback fixes

### DIFF
--- a/apps/notebook/src/hooks/useDaemonKernel.ts
+++ b/apps/notebook/src/hooks/useDaemonKernel.ts
@@ -100,8 +100,10 @@ export function useDaemonKernel({
     // Before any kernel launch, env state is default (in_sync: true, empty lists).
     // Return null to indicate "unknown" to consumers, matching prior behavior.
     if (
-      runtimeState.kernel.status === "not_started" &&
-      !runtimeState.kernel.env_source
+      (runtimeState.kernel.status === "not_started" &&
+        !runtimeState.kernel.env_source) ||
+      runtimeState.kernel.status === "shutdown" ||
+      runtimeState.kernel.status === "error"
     ) {
       return null;
     }
@@ -227,20 +229,20 @@ export function useDaemonKernel({
   useEffect(() => {
     const prev = prevQueueRef.current;
     prevQueueRef.current = queueState;
-    if (
-      prev.executing !== queueState.executing ||
-      prev.queued !== queueState.queued
-    ) {
+    const executingChanged = prev.executing !== queueState.executing;
+    let queuedChanged = prev.queued.length !== queueState.queued.length;
+    if (!queuedChanged) {
+      for (let i = 0; i < prev.queued.length; i++) {
+        if (prev.queued[i] !== queueState.queued[i]) {
+          queuedChanged = true;
+          break;
+        }
+      }
+    }
+    if (executingChanged || queuedChanged) {
       callbacksRef.current.onQueueChange?.(queueState);
     }
   }, [queueState]);
-
-  // Fire onKernelError when status transitions to error
-  useEffect(() => {
-    if (kernelStatus === KERNEL_STATUS.ERROR) {
-      callbacksRef.current.onKernelError?.("Kernel error");
-    }
-  }, [kernelStatus]);
 
   // ── Broadcast listener (events only — no state) ──────────────────
 
@@ -408,9 +410,16 @@ export function useDaemonKernel({
 
         case "kernel_status":
         case "queue_changed":
-        case "kernel_error":
         case "env_sync_state":
           break;
+
+        case "kernel_error": {
+          // Still consume this broadcast for the detailed error message.
+          // Status is derived from RuntimeStateDoc, but the error string
+          // only arrives via broadcast.
+          callbacksRef.current.onKernelError?.(broadcast.error);
+          break;
+        }
 
         default: {
           logger.debug(

--- a/crates/runtimed/src/kernel_manager.rs
+++ b/crates/runtimed/src/kernel_manager.rs
@@ -765,7 +765,8 @@ impl RoomKernel {
                                     jupyter_protocol::ExecutionState::Busy => "busy",
                                     jupyter_protocol::ExecutionState::Idle => "idle",
                                     jupyter_protocol::ExecutionState::Starting => "starting",
-                                    jupyter_protocol::ExecutionState::Restarting => "restarting",
+                                    // Normalize "restarting" to "starting" — same user-facing meaning
+                                    jupyter_protocol::ExecutionState::Restarting => "starting",
                                     jupyter_protocol::ExecutionState::Terminating
                                     | jupyter_protocol::ExecutionState::Dead => "shutdown",
                                     _ => "unknown",
@@ -776,10 +777,13 @@ impl RoomKernel {
                                     cell_id: cell_id.clone(),
                                 });
 
-                                {
+                                // Only write known statuses to RuntimeStateDoc — skip "unknown"
+                                // to avoid polluting the schema with values clients can't handle.
+                                if status_str != "unknown" {
                                     let mut sd = state_doc_for_iopub.write().await;
-                                    sd.set_kernel_status(status_str);
-                                    let _ = state_changed_for_iopub.send(());
+                                    if sd.set_kernel_status(status_str) {
+                                        let _ = state_changed_for_iopub.send(());
+                                    }
                                 }
 
                                 // Signal execution done when idle

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -1557,20 +1557,49 @@ where
             }
 
             // RuntimeStateDoc changed — push update to this client
-            _ = state_changed_rx.recv() => {
-                let encoded = {
-                    let mut state_doc = room.state_doc.write().await;
-                    state_doc
-                        .generate_sync_message(&mut state_peer_state)
-                        .map(|msg| msg.encode())
-                };
-                if let Some(encoded) = encoded {
-                    connection::send_typed_frame(
-                        writer,
-                        NotebookFrameType::RuntimeStateSync,
-                        &encoded,
-                    )
-                    .await?;
+            result = state_changed_rx.recv() => {
+                match result {
+                    Ok(()) => {
+                        let encoded = {
+                            let mut state_doc = room.state_doc.write().await;
+                            state_doc
+                                .generate_sync_message(&mut state_peer_state)
+                                .map(|msg| msg.encode())
+                        };
+                        if let Some(encoded) = encoded {
+                            connection::send_typed_frame(
+                                writer,
+                                NotebookFrameType::RuntimeStateSync,
+                                &encoded,
+                            )
+                            .await?;
+                        }
+                    }
+                    Err(broadcast::error::RecvError::Lagged(n)) => {
+                        log::debug!(
+                            "[notebook-sync] Peer {} lagged {} runtime state updates",
+                            peer_id, n
+                        );
+                        // Send a full sync to catch up
+                        let encoded = {
+                            let mut state_doc = room.state_doc.write().await;
+                            state_doc
+                                .generate_sync_message(&mut state_peer_state)
+                                .map(|msg| msg.encode())
+                        };
+                        if let Some(encoded) = encoded {
+                            connection::send_typed_frame(
+                                writer,
+                                NotebookFrameType::RuntimeStateSync,
+                                &encoded,
+                            )
+                            .await?;
+                        }
+                    }
+                    Err(broadcast::error::RecvError::Closed) => {
+                        // State change channel closed — room is being evicted
+                        return Ok(());
+                    }
                 }
             }
 

--- a/src/components/cell/CompactExecutionButton.tsx
+++ b/src/components/cell/CompactExecutionButton.tsx
@@ -19,7 +19,7 @@ interface CompactExecutionButtonProps {
  * Compact execution button combining play + execution count into one element.
  *
  * - Never run: `[ ▶ ]` - click to execute
- * - Queued: `[⏳]` - waiting in execution queue
+ * - Queued: `[·]` - breathing dot, waiting in execution queue
  * - Running: `[■]` with pulse - click to stop
  * - Executed: `[1]` - hover to show play, click to re-run
  */
@@ -58,6 +58,7 @@ export function CompactExecutionButton({
             ? "Queued for execution"
             : "Run cell"
       }
+      aria-disabled={isQueued || undefined}
       data-testid="execute-button"
     >
       <span className="opacity-60">[</span>


### PR DESCRIPTION
Follow-up fixes for #977 (RuntimeStateDoc), addressing Copilot review feedback.

**P1 fixes:**
- `state_changed_rx` now handles `Lagged`/`Closed` — prevents hot-loop when room is evicted
- `onKernelError` re-consumes the `kernel_error` broadcast for the detailed error message instead of a generic string
- IOPub normalizes "restarting" → "starting", skips "unknown" for RuntimeStateDoc writes

**P2 fixes:**
- Queue change callback uses deep comparison instead of reference equality (prevents spurious `onQueueChange` from fresh array instances)
- `envSyncState` returns null on shutdown/error status (preserves prior behavior)
- Queued execution button gets `aria-disabled` for accessibility
- Doc comment updated (CSS dot, not hourglass emoji)

_PR submitted by @rgbkrk's agent Quill, via Zed_