### PR TITLE
fix(notebook): guard Run All against concurrent invocations

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -169,6 +169,9 @@ function AppContent() {
   // Track pending kernel start that was blocked by trust dialog
   const pendingKernelStartRef = useRef(false);
 
+  // Guard against concurrent Run All / Restart & Run All operations (#982)
+  const runAllInFlightRef = useRef(false);
+
   // Notebook runtime type — reactive read from WASM Automerge doc.
   // Re-renders automatically when metadata changes (bootstrap, sync, writes).
   const detectedRuntime = useDetectRuntime();
@@ -489,37 +492,46 @@ function AppContent() {
 
   // Restart and run all cells
   const restartAndRunAll = useCallback(async () => {
-    const codeCells = getNotebookCellsSnapshot().filter(
-      (c) => c.cell_type === "code",
-    );
-
-    // Flush pending source sync so daemon has latest code
-    await flushSync();
-
-    // Clear all outputs locally (immediate feedback)
-    for (const cell of codeCells) {
-      clearOutputsLocal(cell.id);
-    }
-
-    // Clear outputs via daemon for cross-window sync
-    await Promise.all(codeCells.map((cell) => clearOutputs(cell.id)));
-
-    // Shutdown existing kernel
-    await shutdownKernel();
-
-    // Start kernel - returns false if not started (e.g., trust dialog)
-    const kernelStarted = await tryStartKernel();
-    if (!kernelStarted) {
-      logger.debug("[App] restartAndRunAll: kernel not started, skipping");
+    if (runAllInFlightRef.current) {
+      logger.debug("[App] restartAndRunAll: already in flight, skipping");
       return;
     }
+    runAllInFlightRef.current = true;
+    try {
+      const codeCells = getNotebookCellsSnapshot().filter(
+        (c) => c.cell_type === "code",
+      );
 
-    // Daemon reads cell sources from Automerge doc and queues them
-    const response = await daemonRunAllCells();
-    if (response.result === "error") {
-      logger.error("[App] restartAndRunAll: daemon error", response.error);
-    } else if (response.result === "no_kernel") {
-      logger.warn("[App] restartAndRunAll: no kernel available");
+      // Flush pending source sync so daemon has latest code
+      await flushSync();
+
+      // Clear all outputs locally (immediate feedback)
+      for (const cell of codeCells) {
+        clearOutputsLocal(cell.id);
+      }
+
+      // Clear outputs via daemon for cross-window sync
+      await Promise.all(codeCells.map((cell) => clearOutputs(cell.id)));
+
+      // Shutdown existing kernel
+      await shutdownKernel();
+
+      // Start kernel - returns false if not started (e.g., trust dialog)
+      const kernelStarted = await tryStartKernel();
+      if (!kernelStarted) {
+        logger.debug("[App] restartAndRunAll: kernel not started, skipping");
+        return;
+      }
+
+      // Daemon reads cell sources from Automerge doc and queues them
+      const response = await daemonRunAllCells();
+      if (response.result === "error") {
+        logger.error("[App] restartAndRunAll: daemon error", response.error);
+      } else if (response.result === "no_kernel") {
+        logger.warn("[App] restartAndRunAll: no kernel available");
+      }
+    } finally {
+      runAllInFlightRef.current = false;
     }
   }, [
     clearOutputsLocal,
@@ -622,38 +634,47 @@ function AppContent() {
   }, [shutdownKernel, tryStartKernel]);
 
   const handleRunAllCells = useCallback(async () => {
-    // Daemon reads cells from synced Automerge doc
-    const codeCells = getNotebookCellsSnapshot().filter(
-      (c) => c.cell_type === "code",
-    );
-    if (codeCells.length === 0) return;
-
-    // Flush pending source sync so daemon has latest code
-    await flushSync();
-
-    // Clear all outputs first (local for immediate feedback)
-    for (const cell of codeCells) {
-      clearOutputsLocal(cell.id);
+    if (runAllInFlightRef.current) {
+      logger.debug("[App] handleRunAllCells: already in flight, skipping");
+      return;
     }
+    runAllInFlightRef.current = true;
+    try {
+      // Daemon reads cells from synced Automerge doc
+      const codeCells = getNotebookCellsSnapshot().filter(
+        (c) => c.cell_type === "code",
+      );
+      if (codeCells.length === 0) return;
 
-    // Await all daemon clears to ensure ordering before queueing
-    await Promise.all(codeCells.map((cell) => clearOutputs(cell.id)));
+      // Flush pending source sync so daemon has latest code
+      await flushSync();
 
-    // Start kernel via daemon if not running
-    if (kernelStatus === KERNEL_STATUS.NOT_STARTED) {
-      const started = await tryStartKernel();
-      if (!started) {
-        logger.debug("[App] handleRunAllCells: kernel not started, skipping");
-        return;
+      // Clear all outputs first (local for immediate feedback)
+      for (const cell of codeCells) {
+        clearOutputsLocal(cell.id);
       }
-    }
 
-    // Daemon reads cell sources from Automerge doc and queues them
-    const response = await daemonRunAllCells();
-    if (response.result === "error") {
-      logger.error("[App] handleRunAllCells: daemon error", response.error);
-    } else if (response.result === "no_kernel") {
-      logger.warn("[App] handleRunAllCells: no kernel available");
+      // Await all daemon clears to ensure ordering before queueing
+      await Promise.all(codeCells.map((cell) => clearOutputs(cell.id)));
+
+      // Start kernel via daemon if not running
+      if (kernelStatus === KERNEL_STATUS.NOT_STARTED) {
+        const started = await tryStartKernel();
+        if (!started) {
+          logger.debug("[App] handleRunAllCells: kernel not started, skipping");
+          return;
+        }
+      }
+
+      // Daemon reads cell sources from Automerge doc and queues them
+      const response = await daemonRunAllCells();
+      if (response.result === "error") {
+        logger.error("[App] handleRunAllCells: daemon error", response.error);
+      } else if (response.result === "no_kernel") {
+        logger.warn("[App] handleRunAllCells: no kernel available");
+      }
+    } finally {
+      runAllInFlightRef.current = false;
     }
   }, [
     kernelStatus,

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -505,13 +505,10 @@ function AppContent() {
       // Flush pending source sync so daemon has latest code
       await flushSync();
 
-      // Clear all outputs locally (immediate feedback)
+      // Clear all outputs via WASM CRDT (syncs to daemon via Automerge)
       for (const cell of codeCells) {
         clearOutputsLocal(cell.id);
       }
-
-      // Clear outputs via daemon for cross-window sync
-      await Promise.all(codeCells.map((cell) => clearOutputs(cell.id)));
 
       // Shutdown existing kernel
       await shutdownKernel();
@@ -535,7 +532,6 @@ function AppContent() {
     }
   }, [
     clearOutputsLocal,
-    clearOutputs,
     flushSync,
     shutdownKernel,
     tryStartKernel,
@@ -649,13 +645,10 @@ function AppContent() {
       // Flush pending source sync so daemon has latest code
       await flushSync();
 
-      // Clear all outputs first (local for immediate feedback)
+      // Clear all outputs via WASM CRDT (syncs to daemon via Automerge)
       for (const cell of codeCells) {
         clearOutputsLocal(cell.id);
       }
-
-      // Await all daemon clears to ensure ordering before queueing
-      await Promise.all(codeCells.map((cell) => clearOutputs(cell.id)));
 
       // Start kernel via daemon if not running
       if (kernelStatus === KERNEL_STATUS.NOT_STARTED) {
@@ -680,7 +673,6 @@ function AppContent() {
     kernelStatus,
     tryStartKernel,
     clearOutputsLocal,
-    clearOutputs,
     flushSync,
     daemonRunAllCells,
   ]);


### PR DESCRIPTION
## Summary

Rapidly clicking "Run All" flooded the relay with duplicate `ClearOutputs` and `RunAllCells` requests (e.g. 5 clicks × 11 cells = 55 ClearOutputs + 5 RunAllCells queued sequentially), causing 30s request timeouts and stuck outputs.

Two changes:

1. **In-flight guard** — a shared `useRef` prevents concurrent `handleRunAllCells` / `restartAndRunAll` invocations. The second click is silently skipped while the first is in progress.

2. **Remove redundant daemon ClearOutputs** — `clearOutputsLocal` already writes to the WASM CRDT which syncs to the daemon via Automerge, and the kernel clears terminal state on `execute_input`. The per-cell `ClearOutputs` relay requests were redundant and the primary source of flooding.

Together these reduce a rapid 5-click Run All from ~60 relay requests to exactly 1 (`RunAllCells`).

Closes #982

See #988 for a follow-up to add a bulk `ClearAllOutputs` request for the menu action.

## Verification

- [ ] Open a notebook with several code cells
- [ ] Rapidly click "Run All" multiple times — only one execution cycle should occur
- [ ] Rapidly click "Restart & Run All" — same single-execution behavior
- [ ] Click "Run All" then immediately "Restart & Run All" — the second should be blocked
- [ ] Confirm outputs render correctly after Run All completes
- [ ] Use "Clear All Outputs" from the menu — should still work (uses separate code path)

_PR submitted by @rgbkrk's agent, Quill_