### PR TITLE
fix(runtimed): resolve duplicate rooms after saving untitled notebook

### DIFF
--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -2430,7 +2430,12 @@ async fn rekey_ephemeral_room(
                 if let Some(interloper) = interloper {
                     tokio::spawn(async move {
                         if let Some(mut kernel) = interloper.kernel.lock().await.take() {
-                            let _ = kernel.shutdown().await;
+                            if let Err(e) = kernel.shutdown().await {
+                                warn!(
+                                    "[notebook-sync] Failed to shut down interloper kernel: {}",
+                                    e
+                                );
+                            }
                         }
                         if let Some(tx) = interloper.watcher_shutdown_tx.lock().await.take() {
                             let _ = tx.send(());

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -1098,11 +1098,23 @@ where
                     );
                 }
 
-                rooms_guard.remove(&notebook_id_for_eviction);
-                info!(
-                    "[notebook-sync] Evicted room {} (idle timeout)",
-                    notebook_id_for_eviction
-                );
+                // Only remove if the room in the map is still the one we're evicting.
+                // A rekey may have replaced the room at this key with a different one.
+                if rooms_guard
+                    .get(&notebook_id_for_eviction)
+                    .is_some_and(|r| Arc::ptr_eq(r, &room_for_eviction))
+                {
+                    rooms_guard.remove(&notebook_id_for_eviction);
+                    info!(
+                        "[notebook-sync] Evicted room {} (idle timeout)",
+                        notebook_id_for_eviction
+                    );
+                } else {
+                    debug!(
+                        "[notebook-sync] Eviction skipped for {} (room was replaced)",
+                        notebook_id_for_eviction
+                    );
+                }
             }
         });
     } else {
@@ -2409,10 +2421,23 @@ async fn rekey_ephemeral_room(
                 .is_some_and(|r| Arc::ptr_eq(r, rooms_guard.get(old_notebook_id).unwrap_or(r)));
             if !is_same_room {
                 warn!(
-                    "[notebook-sync] Re-key skipped: canonical path {} already has a different room",
+                    "[notebook-sync] Re-key collision: evicting interloper room at {}",
                     canonical
                 );
-                return None;
+                // Remove the interloper — the ephemeral room has the real content.
+                let interloper = rooms_guard.remove(&canonical);
+                // Clean up interloper resources in background
+                if let Some(interloper) = interloper {
+                    tokio::spawn(async move {
+                        if let Some(mut kernel) = interloper.kernel.lock().await.take() {
+                            let _ = kernel.shutdown().await;
+                        }
+                        if let Some(tx) = interloper.watcher_shutdown_tx.lock().await.take() {
+                            let _ = tx.send(());
+                        }
+                    });
+                }
+                // Fall through to normal rekey below
             }
         }
 


### PR DESCRIPTION
## Summary

- When `rekey_ephemeral_room` found a different room already at the canonical path (created by a racing `get_or_create_room` call), it silently returned `None` — leaving the UUID-keyed room orphaned in the rooms map. This produced two rooms for the same file path, causing edits from Python clients to be invisible in the UI.
- Now `rekey_ephemeral_room` evicts the interloper room (which is empty/just-created) and proceeds with the normal rekey, so only one room exists for a given path.
- Adds an `Arc::ptr_eq` guard to the eviction task to prevent a stale eviction timer from accidentally removing a rekeyed room that now lives at the same key.

Closes #942

## Verification

- [ ] Create an untitled notebook, add some cells/content, then save it to a file path. Run `runt notebooks` and confirm only one room exists for that path.
- [ ] Open the saved notebook from a Python MCP client — edits should be visible in the UI and vice versa.
- [ ] Stress test: rapidly save an untitled notebook while simultaneously opening the same path from another connection. Confirm no duplicate rooms appear.

_PR submitted by @rgbkrk's agent, Quill_