### PR TITLE
docs: update contributor and runtime docs to match current code paths

### DIFF
--- a/contributing/development.md
+++ b/contributing/development.md
@@ -14,8 +14,8 @@
 | Run with notebook | `cargo xtask run path/to/notebook.ipynb` |
 | Build release .app | `cargo xtask build-app` |
 | Build release DMG | `cargo xtask build-dmg` |
-| MCP supervisor (Inkwell) | `cargo xtask mcp` |
-| MCP config JSON | `cargo xtask mcp --print-config` |
+| MCP supervisor (Inkwell) | `cargo xtask run-mcp` |
+| MCP config JSON | `cargo xtask run-mcp --print-config` |
 | MCP server (no supervisor) | `cargo xtask dev-mcp` |
 | Lint (check mode) | `cargo xtask lint` |
 | Lint (auto-fix) | `cargo xtask lint --fix` |
@@ -60,7 +60,9 @@ cargo xtask dev --skip-install --skip-build
 
 ### `cargo xtask notebook` — Hot Reload
 
-Best for UI/React development. Uses Vite dev server on port 5174. Changes to React components hot-reload instantly.
+Best for UI/React development. Uses Vite dev server on port `5174` by default
+(overridable via `RUNTIMED_VITE_PORT` or `CONDUCTOR_PORT`). Changes to React
+components hot-reload instantly.
 
 ```bash
 cargo xtask notebook
@@ -269,8 +271,11 @@ lifecycle, auto-restart on crash, and hot-reload on file changes — one command
 everything works:
 
 ```bash
-cargo xtask mcp
+cargo xtask run-mcp
 ```
+
+`cargo xtask mcp` still works as a compatibility alias, but `run-mcp` is the
+canonical command surfaced by `cargo xtask help`.
 
 This:
 1. Starts the dev daemon if not running
@@ -282,7 +287,7 @@ This:
 For your MCP client config (Zed, Claude Desktop, etc.):
 
 ```bash
-cargo xtask mcp --print-config
+cargo xtask run-mcp --print-config
 ```
 
 Or configure `.zed/settings.json` directly (gitignored):
@@ -308,6 +313,7 @@ These tools are always available, even when the Python child is down:
 | `supervisor_status` | Child process, daemon, restart count, last error |
 | `supervisor_restart` | Restart child or daemon |
 | `supervisor_rebuild` | `maturin develop` + restart (after Rust changes) |
+| `supervisor_set_mode` | Switch the managed daemon between debug and release builds |
 | `supervisor_logs` | Tail the daemon log file |
 | `supervisor_start_vite` | Start the Vite dev server for hot-reload frontend development |
 | `supervisor_stop` | Stop a managed process by name (e.g. `"vite"`) |

--- a/contributing/runtimed.md
+++ b/contributing/runtimed.md
@@ -61,11 +61,16 @@ The daemon provides a single coordinating entity that prewarms environments in t
 
 ## Development Workflow
 
-### Default: Let the notebook start it
+### Default: production auto-manages, dev mode does not
 
-The notebook app automatically tries to connect to or start the daemon on launch. If it's not running, the app falls back to in-process prewarming. You don't need to do anything special.
+The production app automatically connects to the installed daemon and, when
+needed, will install or upgrade it via `ensure_daemon_via_sidecar()` in
+`crates/notebook/src/lib.rs`.
 
-The notebook app calls `ensure_daemon_via_sidecar()` (a private function in `crates/notebook/src/lib.rs`) which takes a `tauri::AppHandle` and a progress callback to start and connect to the daemon.
+Dev builds are intentionally different: when `RUNTIMED_DEV=1` is active, the
+app refuses to auto-install the daemon and instead tells you to start a
+per-worktree daemon yourself with `cargo xtask dev-daemon`. There is no
+in-process prewarming fallback on the current dev path.
 
 ### Install daemon from source
 
@@ -251,9 +256,17 @@ The `runtimed-py` crate provides Python bindings for interacting with the daemon
 ### Installation
 
 ```bash
+# MCP / workspace venv (used by `uv run --directory python nteract`)
 cd crates/runtimed-py
-maturin develop
+VIRTUAL_ENV=../../python/.venv uv run --directory ../../python/runtimed maturin develop
+
+# Test venv (used by `python/runtimed/.venv/bin/python -m pytest ...`)
+cd crates/runtimed-py
+VIRTUAL_ENV=../../python/runtimed/.venv uv run --directory ../../python/runtimed maturin develop
 ```
+
+If you're using the Inkwell supervisor, `supervisor_rebuild` already performs
+the workspace-venv rebuild and restart for you.
 
 ### Basic Usage
 
@@ -299,11 +312,15 @@ session.connect()
 
 **Worktree daemon (for development):**
 ```bash
-# Find your worktree daemon socket
-cat ~/Library/Caches/runt/worktrees/*/daemon.json | grep -A1 worktree_path
+# Start the dev daemon for this worktree
+cargo xtask dev-daemon
 
-# Set the socket path before running Python
-export RUNTIMED_SOCKET_PATH="/Users/you/Library/Caches/runt/worktrees/{hash}/runtimed.sock"
+# Discover the exact socket path for this build channel + worktree
+export RUNTIMED_SOCKET_PATH="$(
+  RUNTIMED_DEV=1 RUNTIMED_WORKSPACE_PATH=$(pwd) ./target/debug/runt daemon status --json \
+    | python3 -c 'import sys,json; print(json.load(sys.stdin)["socket_path"])'
+)"
+
 python your_script.py
 ```
 
@@ -314,8 +331,10 @@ python your_script.py
 cargo xtask dev-daemon
 
 # Find and export the socket path (Terminal 2)
-export RUNTIMED_SOCKET_PATH=$(cat ~/Library/Caches/runt/worktrees/*/daemon.json | \
-  jq -r 'select(.worktree_path == "'$(pwd)'") | .endpoint')
+export RUNTIMED_SOCKET_PATH="$(
+  RUNTIMED_DEV=1 RUNTIMED_WORKSPACE_PATH=$(pwd) ./target/debug/runt daemon status --json \
+    | python3 -c 'import sys,json; print(json.load(sys.stdin)["socket_path"])'
+)"
 
 # Now Python bindings will use the worktree daemon
 python -c "import runtimed; s = runtimed.Session(); s.connect(); print('Connected!')"
@@ -370,11 +389,11 @@ If `session.run()` returns outputs like `Output(stream, stderr: "Failed to parse
 **Fix:** Set `RUNTIMED_SOCKET_PATH` to the correct daemon socket:
 
 ```bash
-# Find your worktree daemon
-cat ~/Library/Caches/runt/worktrees/*/daemon.json | jq -r '.worktree_path + " -> " + .endpoint'
-
-# Export the matching socket path
-export RUNTIMED_SOCKET_PATH="/Users/you/Library/Caches/runt/worktrees/{hash}/runtimed.sock"
+# Export the matching socket path for the current worktree
+export RUNTIMED_SOCKET_PATH="$(
+  RUNTIMED_DEV=1 RUNTIMED_WORKSPACE_PATH=$(pwd) ./target/debug/runt daemon status --json \
+    | python3 -c 'import sys,json; print(json.load(sys.stdin)["socket_path"])'
+)"
 ```
 
 ### Python bindings: get_cell() returns empty outputs

--- a/contributing/testing.md
+++ b/contributing/testing.md
@@ -177,17 +177,25 @@ Configuration in `conftest.py` defines markers and daemon detection.
 
 ```bash
 # Unit tests only (fast, no daemon)
-pytest python/runtimed/tests/test_session_unit.py -v
+python/runtimed/.venv/bin/python -m pytest python/runtimed/tests/test_session_unit.py -v
 
 # Skip integration tests
-SKIP_INTEGRATION_TESTS=1 pytest python/runtimed/tests/ -v
+SKIP_INTEGRATION_TESTS=1 python/runtimed/.venv/bin/python -m pytest python/runtimed/tests/ -v
 
 # Integration tests (requires running dev daemon)
-pytest python/runtimed/tests/test_daemon_integration.py -v
+RUNTIMED_SOCKET_PATH="$(
+  RUNTIMED_DEV=1 RUNTIMED_WORKSPACE_PATH=$(pwd) ./target/debug/runt daemon status --json \
+    | python3 -c 'import sys,json; print(json.load(sys.stdin)["socket_path"])'
+)" python/runtimed/.venv/bin/python -m pytest python/runtimed/tests/test_daemon_integration.py -v
 
 # CI mode (spawns its own daemon)
-RUNTIMED_INTEGRATION_TEST=1 pytest python/runtimed/tests/ -v
+RUNTIMED_INTEGRATION_TEST=1 python/runtimed/.venv/bin/python -m pytest python/runtimed/tests/ -v
 ```
+
+The repository keeps two separate Python environments on purpose:
+`python/.venv` for the MCP server and `python/runtimed/.venv` for pytest.
+Use the latter for `python/runtimed/tests/` so your test run sees the same
+extension build and dependencies as CI.
 
 **Writing tests:**
 

--- a/docs/python-bindings.md
+++ b/docs/python-bindings.md
@@ -8,10 +8,18 @@ The `runtimed` Python package provides programmatic access to the notebook daemo
 # From PyPI
 pip install runtimed
 
-# From source
-cd python/runtimed
-uv run maturin develop
+# From source for the MCP/workspace venv
+cd crates/runtimed-py
+VIRTUAL_ENV=../../python/.venv uv run --directory ../../python/runtimed maturin develop
+
+# From source for the pytest venv
+cd crates/runtimed-py
+VIRTUAL_ENV=../../python/runtimed/.venv uv run --directory ../../python/runtimed maturin develop
 ```
+
+`maturin develop` needs the explicit `VIRTUAL_ENV` because this repository uses
+two different Python environments: `python/.venv` for the MCP server and
+`python/runtimed/.venv` for tests.
 
 ## Quick Start
 
@@ -320,12 +328,14 @@ env = await session.env_source()             # str | None
 notebook_id = session.notebook_id  # str
 ```
 
-## DaemonClient API
+## Client API
 
-The `DaemonClient` class provides low-level access to daemon operations.
+`Client` is the recommended low-level entry point for daemon operations and for
+opening or joining notebooks. `DaemonClient` still exists as a deprecated alias
+for the daemon-only subset of this API.
 
 ```python
-client = runtimed.DaemonClient()
+client = runtimed.Client()
 
 # Health checks
 client.ping()         # True if daemon responding
@@ -356,6 +366,11 @@ rooms = client.list_rooms()
 # Operations
 client.flush_pool()   # Clear and rebuild environment pool
 client.shutdown()     # Stop the daemon
+
+# Notebook operations
+session = client.create_notebook(runtime="python")
+# or
+session = client.open_notebook("/path/to/notebook.ipynb")
 ```
 
 ## Result Types
@@ -515,5 +530,4 @@ Common error scenarios:
 |----------|-------------|
 | `RUNTIMED_WORKSPACE_PATH` | Use dev daemon for this worktree |
 | `RUNTIMED_SOCKET_PATH` | Override daemon socket path |
-
 

--- a/docs/runtimed.md
+++ b/docs/runtimed.md
@@ -8,7 +8,7 @@ The architecture has two core ideas:
 
 1. **Outputs live outside the CRDT.** Kernel outputs (images, HTML, logs) are write-once blobs from a single actor. Storing them in an Automerge document wastes CRDT history tracking on data that will never be concurrently edited. Instead, outputs go into a content-addressed blob store. The CRDT stores lightweight hash references.
 
-2. **Two levels of output abstraction.** An "output" (the Jupyter-level concept — a display_data, stream, error, etc.) is described by a manifest that references raw content blobs. Small data is inlined in the manifest; large data points to the blob store. `GET /output/{id}` returns the manifest. `GET /blob/{hash}` returns raw bytes. Most renders need only one request.
+2. **Two levels of output abstraction.** An "output" (the Jupyter-level concept — a display_data, stream, error, etc.) is described by a manifest that references raw content blobs. Small data is inlined in the manifest; large data points to the blob store. Both manifests and raw blobs are fetched through `GET /blob/{hash}`; the manifest's media type tells clients what they fetched. Text-like outputs often need one request, while binary outputs typically need two (manifest + blob).
 
 ---
 
@@ -118,7 +118,7 @@ Length-prefixed binary framing over a single Unix socket (Unix) or named pipe (W
 
 ### Settings.json file watcher
 
-The daemon watches `~/.config/nteract/settings.json` for external edits. Changes are debounced (500ms), applied to the Automerge settings doc, persisted as Automerge binary (not back to JSON, to avoid formatting churn), and broadcast to all connected sync clients.
+The daemon watches `~/.config/nteract/settings.json` for external edits. Changes are debounced (500ms), applied to the Automerge settings doc, then persisted both as an Automerge binary (`settings.automerge`) and as a human-readable JSON mirror (plus `settings.schema.json`) so manual edits, fallback reads, and editor tooling stay aligned.
 
 ### Service management
 
@@ -222,7 +222,7 @@ ROOT/
       source: Text              <- Automerge Text CRDT (character-level merging)
       execution_count: Str      <- JSON-encoded i32 or "null"
       outputs/                  <- List of Str
-        [j]: Str                <- JSON-encoded Jupyter output (manifest hash)
+        [j]: Str                <- output manifest hash (64-char hex SHA-256)
       metadata: Str             <- JSON-encoded cell metadata object
   metadata/                     <- Map
     runtime: Str
@@ -233,7 +233,7 @@ Cell ordering uses fractional indexing via the `position` field. Cells are sorte
 
 **Design decisions**:
 - Cell `source` uses `ObjType::Text` for proper concurrent edit merging. `update_source()` uses Automerge's `update_text()` (Myers diff internally) for efficient character-level patches.
-- `outputs` are write-once from a single actor (the kernel), so they don't need CRDT text semantics. Stored as JSON strings now. Phase 6 changes these to output manifest hashes.
+- `outputs` are write-once from a single actor (the kernel), so they don't need CRDT text semantics. They are stored as manifest hashes pointing into the blob store.
 - `execution_count` is a string for JSON serialization consistency.
 
 ### Room architecture
@@ -539,15 +539,24 @@ Save is delegated to the daemon via `NotebookRequest::SaveNotebook`. The daemon:
 
 ## Phase 6: Output store
 
-> **Foundation implemented** (PR #237 adds ContentRef, manifest types, inlining threshold)
+> **Implemented**
 
-Move outputs from inline JSON in the CRDT to the blob store. This solves the CRDT bloat problem from Phase 5 and introduces two-level serving.
+Outputs no longer live inline in the notebook CRDT. The daemon writes an output
+manifest to the blob store, stores the manifest hash in `cell.outputs[]`, and
+the frontend resolves that hash on demand.
 
-### The two levels
+### Serving model
 
-**Level 1 — Blob store** (`GET /blob/{hash}`): Pure content-addressed bytes. Returns raw PNG, text, JSON — whatever was stored. Used for `<img src>`, direct rendering, large data.
+There is a single HTTP surface:
 
-**Level 2 — Output store** (`GET /output/{id}`): Jupyter-aware. Returns structured information about an output — what type it is, what representations are available, and the data itself (inlined for small content, blob-referenced for large content). Used by the frontend to understand what to render.
+- `GET /blob/{hash}` serves immutable content-addressed bytes
+- Manifest blobs use media type `application/x-jupyter-output+json`
+- Binary payload blobs (for example `image/png`) are served as raw bytes with
+  the correct `Content-Type`
+- Text payload blobs are served as UTF-8 text
+
+That means "manifest vs payload" is a convention carried by the manifest hash
+and blob metadata, not a separate `/output/{id}` endpoint.
 
 ### ContentRef
 
@@ -633,7 +642,9 @@ Daemon-side decision at write time. The frontend just checks `inline` vs `blob`.
 
 ### Manifest storage
 
-Manifests are themselves blobs (media type `application/x-jupyter-output+json`), content-addressed. `GET /output/{id}` is a thin view over `GET /blob/{hash}` that validates the media type.
+Manifests are themselves blobs (media type
+`application/x-jupyter-output+json`) and are fetched the same way as any other
+blob: `GET /blob/{manifest_hash}`.
 
 ### Automerge doc integration
 
@@ -650,40 +661,44 @@ The CRDT stores only hashes (~64 bytes each). All output structure and content l
 - Clearing outputs removes hashes (no tombstone inflation from large data)
 - Output history doesn't accumulate in the Automerge change log
 
-### Tauri backend changes
+### Current write/read flow
 
-The iopub listener (from Phase 5) changes what it writes to automerge:
+Daemon write path:
+1. Normalize kernel output into nbformat-style JSON
+2. Inline text-like content smaller than 8 KB, or write larger/binary payloads
+   to the blob store
+3. Write the output manifest itself to the blob store
+4. Append the manifest hash to `cell.outputs[]`
 
-**Before** (Phase 5): `sync_client.append_output(cell_id, json_string)` — full JSON output
-**After** (Phase 6):
-1. For each MIME type / stream text / traceback: size < 8KB -> inline, >= 8KB -> blob store via daemon
-2. Construct output manifest JSON
-3. Store manifest in blob store -> get manifest hash
-4. `sync_client.append_output(cell_id, manifest_hash)` — just the hash
+Frontend read path:
+1. `useManifestResolver()` fetches `GET /blob/{manifest_hash}`
+2. `manifest-resolution.ts` parses the manifest and resolves each `ContentRef`
+3. Binary MIME types resolve to blob URLs such as
+   `http://127.0.0.1:{port}/blob/{blob_hash}`
+4. Text MIME types are fetched and returned as strings
 
-### Frontend changes
+For compatibility during the transition, the frontend still accepts legacy
+inline JSON outputs when a cell output string is not a 64-character hash.
 
-**`OutputArea.tsx`** — the big change. Currently receives `JupyterOutput[]` (parsed JSON). Now receives `string[]` (manifest hashes).
+### MIME-type contract
 
-New rendering flow:
-1. Cell outputs = `["hash1", "hash2", ...]`
-2. For each hash, fetch `GET /output/{hash}` -> manifest JSON
-3. Parse manifest, select MIME type by priority
-4. For `ContentRef::Inline` — use data directly
-5. For `ContentRef::Blob` — `<img src="http://localhost:{port}/blob/{blobHash}">` for images, `fetch()` for HTML/text
+Binary-vs-text classification is shared across the daemon, Python bindings, and
+frontend. In particular:
 
-This needs a loading state per output (while manifest is being fetched) and caching (manifests are immutable, cache aggressively).
-
-**Stream output handling during execution**: The iopub listener still emits `kernel:iopub` events for live display. The frontend renders stream text incrementally from events. When execution finishes, the finalized manifest hash appears in the automerge doc. The frontend transitions from live event-driven display to blob-backed display.
+- `image/svg+xml` is treated as text, not binary
+- `image/*` is binary otherwise
+- `audio/*` and `video/*` are binary
+- `application/*` is binary by default, with `json`, `xml`, `+json`, and
+  `+xml` carve-outs
 
 ### Key files
 
 | File | Role |
 |------|------|
 | `crates/runtimed/src/output_store.rs` | Manifest construction, ContentRef, inlining threshold |
-| `crates/runtimed/src/blob_server.rs` | Add `GET /output/{id}` endpoint |
+| `crates/runtimed/src/blob_server.rs` | Serve immutable `GET /blob/{hash}` and `/health` |
 | `crates/runtimed/src/kernel_manager.rs` | iopub listener constructs manifests and stores blobs |
-| `src/components/cell/OutputArea.tsx` | Fetch manifests, resolve blob URLs |
+| `apps/notebook/src/lib/manifest-resolution.ts` | Resolve manifests and MIME-specific blob/text payloads |
 | `apps/notebook/src/hooks/useManifestResolver.ts` | Hook for fetching/caching output manifests |
 
 ---

--- a/python/README.md
+++ b/python/README.md
@@ -12,12 +12,13 @@ Development home for nteract Python packages.
 To run the nteract MCP server against a locally-built runtimed (e.g., for testing presence, new protocol features):
 
 ```bash
-cd runtimed
+cd ../crates/runtimed-py
 
-# 1. Build runtimed from Rust source
-uv run --reinstall-package runtimed maturin develop
+# 1. Build runtimed from Rust source into the MCP/workspace venv
+VIRTUAL_ENV=../../python/.venv uv run --directory ../../python/runtimed maturin develop
 
 # 2. Install local nteract (editable, without re-resolving runtimed from PyPI)
+cd ../../python/runtimed
 uv pip install --no-deps -e ../nteract
 
 # 3. Install nteract's other dependencies
@@ -27,7 +28,8 @@ uv pip install "mcp>=1.26.0" "httpx>=0.27.0,<1.0" "pydantic>=2.0"
 uv run python -c "import runtimed, nteract; print('ok')"
 ```
 
-After this, the runtimed venv has both the local Rust build and the local nteract source.
+After this, `python/.venv` has both the local Rust build and the local
+`nteract` source.
 
 ## Running the MCP Server (Dev)
 
@@ -67,6 +69,6 @@ RUNTIMED_SOCKET_PATH=... uv run python demos/presence_cursor.py <notebook_id>
 If you change code in `crates/runtimed-py/` or `crates/runtimed/`:
 
 ```bash
-cd python/runtimed
-uv run --reinstall-package runtimed maturin develop
+cd crates/runtimed-py
+VIRTUAL_ENV=../../python/.venv uv run --directory ../../python/runtimed maturin develop
 ```

--- a/python/runtimed/README.md
+++ b/python/runtimed/README.md
@@ -91,14 +91,17 @@ async with runtimed.AsyncSession(notebook_id="my-notebook") as session:
     new_position = await session.move_cell(cell_id, after_cell_id="other-id")
 ```
 
-## DaemonClient API
+## Client API
 
 ```python
-client = runtimed.DaemonClient()
+client = runtimed.Client()
 client.ping()        # Health check
 client.status()      # Pool statistics
 client.list_rooms()  # Active notebooks
 ```
+
+`DaemonClient` is still available for backwards compatibility, but `Client` and
+`AsyncClient` are the current entry points.
 
 ## Requirements
 


### PR DESCRIPTION
## Summary
- align contributor docs with the current `cargo xtask` and MCP supervisor commands, including `run-mcp` and `supervisor_set_mode`
- correct daemon development guidance to reflect current dev-mode behavior and worktree socket discovery
- update Python binding and testing docs for the two-venv `maturin develop` workflow and recommended `Client` API
- refresh runtime architecture docs so blob manifest, settings persistence, and output resolution details match the implementation

## Testing
- `cargo xtask lint`