### PR TITLE
fix(runtimed-py): keep connect runtime alive — fixes kernel launch from Python bindings

### DIFF
--- a/crates/runtimed-py/src/session.rs
+++ b/crates/runtimed-py/src/session.rs
@@ -67,9 +67,11 @@ impl Session {
         ))?;
 
         state.peer_label = peer_label.clone();
-        drop(runtime);
 
-        Self::from_state(notebook_id, state, peer_label)
+        // Keep the runtime alive — the sync task was spawned on it during
+        // connect_open. Dropping the runtime would cancel the sync task and
+        // break all subsequent daemon requests (start_kernel, execute, etc.).
+        Self::from_state_with_runtime(runtime, notebook_id, state, peer_label)
     }
 
     /// Create a notebook without deprecation warning (used by Client).
@@ -95,11 +97,11 @@ impl Session {
             }
         }
 
-        let rt = Runtime::new().map_err(to_py_err)?;
+        let runtime = Runtime::new().map_err(to_py_err)?;
         let working_dir_buf = working_dir.map(PathBuf::from);
         let actor_label = peer_label.as_deref().map(session_core::make_actor_label);
 
-        let (notebook_id, mut state, _info) = rt.block_on(session_core::connect_create(
+        let (notebook_id, mut state, _info) = runtime.block_on(session_core::connect_create(
             socket_path,
             runtime_type,
             working_dir_buf,
@@ -107,9 +109,8 @@ impl Session {
         ))?;
 
         state.peer_label = peer_label.clone();
-        drop(rt);
 
-        Self::from_state(notebook_id, state, peer_label)
+        Self::from_state_with_runtime(runtime, notebook_id, state, peer_label)
     }
 
     /// Join an existing notebook room by ID (used by Client).
@@ -124,9 +125,9 @@ impl Session {
         state.peer_label = peer_label.clone();
         state.actor_label = actor_label;
 
-        let rt = Runtime::new().map_err(to_py_err)?;
+        let runtime = Runtime::new().map_err(to_py_err)?;
         let state_arc = Arc::new(Mutex::new(state));
-        rt.block_on(session_core::connect_with_socket(
+        runtime.block_on(session_core::connect_with_socket(
             &state_arc,
             notebook_id,
             socket_path,
@@ -136,18 +137,22 @@ impl Session {
             .map_err(|_| to_py_err("Failed to unwrap session state"))?
             .into_inner();
 
-        drop(rt);
-        Self::from_state(notebook_id.to_string(), state, peer_label)
+        Self::from_state_with_runtime(runtime, notebook_id.to_string(), state, peer_label)
     }
 
     /// Create a pre-connected Session from a notebook_id and SessionState.
     /// Used by Client.open_notebook() / Client.create_notebook() / Client.join_notebook().
-    pub(crate) fn from_state(
+    /// Create a Session with a provided runtime.
+    ///
+    /// The runtime MUST be the same one that the sync task was spawned on
+    /// during connect. Dropping that runtime kills the sync task and breaks
+    /// all daemon communication.
+    pub(crate) fn from_state_with_runtime(
+        runtime: Runtime,
         notebook_id: String,
         state: SessionState,
         peer_label: Option<String>,
     ) -> PyResult<Self> {
-        let runtime = Runtime::new().map_err(to_py_err)?;
         let override_arc = Arc::new(std::sync::Mutex::new(None));
         if let Some(ref rx) = state.broadcast_rx {
             session_core::spawn_rekey_watcher(rx, Arc::clone(&override_arc), runtime.handle());


### PR DESCRIPTION
Fixes #992.

## The bug

Every `start_kernel()` call from the Python bindings failed with `RuntimedError: Disconnected from sync task`. The daemon log showed `Broken pipe (os error 32)` during streaming load. The Tauri frontend also couldn't start kernels for saved notebooks.

## Root cause

The sync `Session` methods (`open_notebook_with_socket`, `create_notebook_with_socket`, `join_notebook_with_socket`) all followed this pattern:

```rust
let runtime = Runtime::new()?;
let (notebook_id, state, _) = runtime.block_on(connect_open(...))?;
drop(runtime);  // ← KILLS THE SYNC TASK
Self::from_state(notebook_id, state, peer_label)  // creates a NEW runtime
```

`connect_open` spawns a sync task via `tokio::spawn` inside `build_and_spawn`. That task runs on `runtime`. When `runtime` is dropped, the sync task is cancelled. `from_state` creates a fresh runtime, but the sync task is gone — the `DocHandle`'s command channels are dead.

**Why reads worked**: `get_cells()` reads directly from the local Automerge doc (no sync task needed).

**Why writes failed**: `start_kernel()` sends `LaunchKernel` through `DocHandle::send_request()` → `cmd_tx.send()` → the sync task's `cmd_rx` is dead → `SyncError::Disconnected`.

**Why the daemon saw broken pipe**: The sync task owned the socket reader. When the runtime dropped, the socket closed. The daemon's next `send_typed_frame()` got EPIPE.

## Fix

Pass the connect runtime through to the Session instead of dropping it and creating a new one. New method `from_state_with_runtime(runtime, ...)` keeps the sync task alive.

## Verification

```python
client = runtimed.Client()
session = client.create_notebook(runtime='python')
session.start_kernel(kernel_type='python', env_source='uv:prewarmed')
result = session.run('print("Hello!")')
# success=True → "Hello!"
```

Also verified with `open_notebook` on a saved `.ipynb` file with `env_source='auto'`.