### PR TITLE
fix(runtimed): bump default python from 3.9 to 3.13

### DIFF
--- a/crates/kernel-env/src/conda.rs
+++ b/crates/kernel-env/src/conda.rs
@@ -216,7 +216,7 @@ async fn install_conda_env(
             match_spec_options,
         )?);
     } else {
-        specs.push(MatchSpec::from_str("python>=3.9", match_spec_options)?);
+        specs.push(MatchSpec::from_str("python>=3.13", match_spec_options)?);
     }
 
     specs.push(MatchSpec::from_str("ipykernel", match_spec_options)?);

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -2042,7 +2042,7 @@ impl Daemon {
         let match_spec_options = ParseMatchSpecOptions::strict();
         let specs: Vec<MatchSpec> = match (|| -> anyhow::Result<Vec<MatchSpec>> {
             let mut specs = vec![
-                MatchSpec::from_str("python>=3.9", match_spec_options)?,
+                MatchSpec::from_str("python>=3.13", match_spec_options)?,
                 MatchSpec::from_str("ipykernel", match_spec_options)?,
                 MatchSpec::from_str("ipywidgets", match_spec_options)?,
             ];
@@ -2392,6 +2392,8 @@ print("warmup complete")
             tokio::process::Command::new(&uv_path)
                 .arg("venv")
                 .arg(&venv_path)
+                .arg("--python")
+                .arg("3.13")
                 .stdout(Stdio::piped())
                 .stderr(Stdio::piped())
                 .output(),

--- a/crates/runtimed/src/inline_env.rs
+++ b/crates/runtimed/src/inline_env.rs
@@ -68,7 +68,7 @@ pub async fn prepare_uv_inline_env(
 ) -> Result<PreparedEnv> {
     let uv_deps = kernel_env::UvDependencies {
         dependencies: deps.to_vec(),
-        requires_python: None,
+        requires_python: Some(">=3.13".to_string()),
         prerelease: prerelease.map(|s| s.to_string()),
     };
 


### PR DESCRIPTION
## Summary

On a fresh Mac, the system Python is 3.9.6, which is too old for `runtimed` (requires `>=3.10`). Prewarmed UV environments inherited the system Python, and conda pools specified `>=3.9`, causing "Environment error" failures when trying to install dependencies.

This bumps all default Python version specs to `>=3.13` across conda prewarmed pools, conda env creation fallback, UV prewarmed pools (now passes `--python 3.13` to `uv venv`), and UV inline environments.

## Verification

- [ ] On a fresh Mac (or one with only system Python 3.9), open a new notebook and confirm the kernel starts without an "Environment error"
- [ ] Confirm prewarmed UV pool creates a venv with Python 3.13+
- [ ] Confirm prewarmed conda pool resolves Python 3.13+

_PR submitted by @rgbkrk's agent, Quill_