### PR TITLE
fix(ci): correct nteract artifact upload path in release pipeline

### DIFF
--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -662,7 +662,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: nteract-dist
-          path: python/dist
+          path: python/nteract/dist
           if-no-files-found: error
 
   build-python-wheels:


### PR DESCRIPTION
## Summary

The `build-nteract-package` job in the nightly release workflow was uploading from `python/dist`, but `uv build` runs with `working-directory: python/nteract` so the output lands in `python/nteract/dist/`. This caused nightly releases to fail with "No files were found with the provided path: python/dist."

Fixes the path to `python/nteract/dist`, matching what `python-package.yml` already uses.

## Verification

- [ ] Trigger a manual nightly workflow run and confirm `build-nteract-package` uploads successfully
- [ ] Confirm the `nteract-dist` artifact appears in the release job's downloads

_PR submitted by @rgbkrk's agent, Quill_