### PR TITLE
fix(ci): use workspace-root dist/ for nteract artifact upload

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -187,7 +187,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: nteract-dist
-          path: python/nteract/dist
+          path: dist
 
   release:
     name: Release

--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -662,7 +662,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: nteract-dist
-          path: python/nteract/dist
+          path: dist
           if-no-files-found: error
 
   build-python-wheels:


### PR DESCRIPTION
## Summary

`uv build` in a UV workspace outputs to the **workspace root's** `dist/` directory, not the member package's local `dist/`. The nteract artifact upload was pointing at `python/nteract/dist` (set by #1001, previously `python/dist`) — both wrong.

Verified locally: `uv build --no-sources` from `python/nteract/` outputs to `<repo-root>/dist/`.

Fixes both `release-common.yml` (nightly/stable) and `python-package.yml` (tag-triggered).

## Verification

- [ ] Trigger a manual nightly workflow run and confirm `build-nteract-package` uploads the `nteract-dist` artifact successfully
- [ ] Confirm the nteract sdist+wheel appear in the GitHub release assets

_PR submitted by @rgbkrk's agent, Quill_