### PR TITLE
ci: merge clippy and rust-tests into single parallel job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -221,7 +221,7 @@ jobs:
         run: pnpm vitest bench --run apps/notebook/src/lib/__tests__/
 
   build-linux:
-    name: Linux
+    name: Linux (release artifacts)
     needs: [changes, build-ui]
     if: needs.changes.outputs.source_changed == 'true'
     runs-on: ubuntu-latest
@@ -305,39 +305,8 @@ jobs:
       - name: Test notebook crate
         run: cargo test -p notebook --verbose
 
-  rust-tests:
-    name: Rust Tests (Linux)
-    needs: [changes]
-    if: needs.changes.outputs.source_changed == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libxdo-dev
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-
-      - name: Install rust
-        uses: dsherret/rust-toolchain-file@v1
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: ubuntu-test
-
-      - name: Run tests
-        # Exclude notebook (Tauri app crate) — its build script requires bundled
-        # runtimed/runt binaries. The notebook crate's tests run in build-linux
-        # which builds those binaries first.
-        # Exclude runtimed-wasm — requires wasm-pack (tested in wasm-deno job).
-        # Exclude runtimed-py — requires Python/maturin (tested in runtimed-py-integration job).
-        run: cargo test --workspace --exclude notebook --exclude runtimed-wasm --exclude runtimed-py --verbose
-
-  clippy:
-    name: Clippy (Linux)
+  clippy-and-tests:
+    name: Clippy & Tests (Linux)
     needs: [changes]
     if: needs.changes.outputs.source_changed == 'true'
     runs-on: ubuntu-latest
@@ -359,8 +328,14 @@ jobs:
         with:
           shared-key: ubuntu-latest
 
+      # Excludes: notebook (needs bundled binaries, checked in build-linux),
+      # runtimed-wasm (needs wasm-pack, tested in wasm-deno),
+      # runtimed-py (needs Python/maturin, tested in runtimed-py-integration).
       - name: Clippy
         run: cargo clippy --workspace --exclude notebook --exclude runtimed-wasm --exclude runtimed-py --all-targets -- -D warnings
+
+      - name: Run tests
+        run: cargo test --workspace --exclude notebook --exclude runtimed-wasm --exclude runtimed-py --verbose
 
   build:
     name: ${{ matrix.platform.name }}


### PR DESCRIPTION
## Summary

- Merge the separate `clippy` and `rust-tests` jobs into one `clippy-and-tests` job — they had identical setup (system deps, uv, rust, rust-cache) and the same crate excludes, so this saves a runner and deduplicates ~20 lines of setup
- Clippy runs first (fast-fail on lint before spending time on tests), then tests
- Rename `build-linux` display name to "Linux (release artifacts)" to clarify it builds artifacts for downstream E2E/integration jobs
- Notebook crate clippy + tests remain in `build-linux` where the bundled binaries are available

## Verification

- [ ] `Clippy & Tests (Linux)` job passes
- [ ] `Linux (release artifacts)` job passes (notebook clippy + tauri build + notebook tests)
- [ ] Downstream E2E and integration test jobs pass

_PR submitted by @rgbkrk's agent, Quill_