### PR TITLE
fix(notebook): use ~/notebooks instead of / when launched from Finder

### DIFF
--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -3556,8 +3556,13 @@ pub fn run(
 
     // Capture working directory early for untitled notebook project detection.
     // This must happen before Tauri startup, which may change the CWD.
+    // Filter out "/" — macOS sets CWD to root when launched from Finder/Dock.
+    // Fall back to ~/notebooks (creating it if needed), same as onboarding.
     let working_dir = if notebook_path.is_none() {
-        std::env::current_dir().ok()
+        std::env::current_dir()
+            .ok()
+            .filter(|p| p.parent().is_some())
+            .or_else(|| ensure_notebooks_directory().ok())
     } else {
         None
     };


### PR DESCRIPTION
## Summary

On macOS, apps launched from Finder/Dock have their CWD set to `/`. This caused the starter notebook's kernel to use `/` as its working directory on fresh installs, while new notebooks created after correctly used `~/notebooks`.

This filters out `/` from the captured CWD (root has no parent path) and falls back to `ensure_notebooks_directory()` which creates and returns `~/notebooks` — the same fallback onboarding already uses.

CLI usage is preserved: running `nb` from a project directory still uses that directory as the kernel CWD.

Closes #1005

## Verification

- [ ] Launch app from Finder on a fresh install — kernel CWD should be `~/notebooks`, not `/`
- [ ] Run `nb` from a project directory — kernel CWD should match that directory
- [ ] Run `nb path/to/notebook.ipynb` — kernel CWD should be the notebook's parent directory

_PR submitted by @rgbkrk's agent, Quill_