### PR TITLE
fix(notebook): eliminate Python UI flicker for new Deno notebooks

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -960,9 +960,10 @@ function AppContent() {
         // Clear any status banner when daemon reconnects (failed, checking, etc.)
         cancelReadyTimeout();
         setDaemonStatus(null);
-        if (event.payload?.runtime) {
-          setRuntimeHint(event.payload.runtime);
-        }
+        // Set or clear the runtime hint — clearing prevents stale hints
+        // when a window is reused to open a different notebook (Open path
+        // sends runtime: null).
+        setRuntimeHint(event.payload?.runtime ?? null);
       },
     );
 

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -175,7 +175,10 @@ function AppContent() {
   // Notebook runtime type — reactive read from WASM Automerge doc.
   // Re-renders automatically when metadata changes (bootstrap, sync, writes).
   const detectedRuntime = useDetectRuntime();
-  const runtime = detectedRuntime ?? "python";
+  // Runtime hint from daemon:ready payload — available before metadata syncs,
+  // prevents momentary flicker of wrong runtime UI (e.g. Python for Deno notebooks).
+  const [runtimeHint, setRuntimeHint] = useState<string | null>(null);
+  const runtime = detectedRuntime ?? runtimeHint;
 
   // Auto-clear justSynced after 3 seconds
   useEffect(() => {
@@ -951,11 +954,17 @@ function AppContent() {
     });
 
     // Listen for daemon ready (reconnection success)
-    const unlistenReady = webview.listen("daemon:ready", () => {
-      // Clear any status banner when daemon reconnects (failed, checking, etc.)
-      cancelReadyTimeout();
-      setDaemonStatus(null);
-    });
+    const unlistenReady = webview.listen<{ runtime?: string }>(
+      "daemon:ready",
+      (event) => {
+        // Clear any status banner when daemon reconnects (failed, checking, etc.)
+        cancelReadyTimeout();
+        setDaemonStatus(null);
+        if (event.payload?.runtime) {
+          setRuntimeHint(event.payload.runtime);
+        }
+      },
+    );
 
     // Check daemon status on mount (in case events fired before React was ready)
     // Small delay to let initial events settle

--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -35,7 +35,7 @@ interface NotebookToolbarProps {
   /** Pre-start hint: "uv" | "conda" | "pixi" | null, derived from notebook metadata */
   envTypeHint?: EnvBadgeVariant | null;
   envProgress: EnvProgressState | null;
-  runtime?: string;
+  runtime?: string | null;
   onStartKernel: (name: string) => void;
   onInterruptKernel: () => void;
   onRestartKernel: () => void;
@@ -58,7 +58,7 @@ export function NotebookToolbar({
   envSource,
   envTypeHint,
   envProgress,
-  runtime = "python",
+  runtime = null,
   onStartKernel,
   onInterruptKernel,
   onRestartKernel,
@@ -254,54 +254,56 @@ export function NotebookToolbar({
           </button>
         )}
 
-        {/* Runtime / deps toggle */}
-        <button
-          type="button"
-          onClick={onToggleDependencies}
-          data-testid="deps-toggle"
-          data-runtime={runtime}
-          className={cn(
-            "flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium transition-colors",
-            runtime === "deno"
-              ? "bg-emerald-500/10 text-emerald-600 hover:bg-emerald-500/20 dark:text-emerald-400"
-              : "bg-blue-500/10 text-blue-600 hover:bg-blue-500/20 dark:text-blue-400",
-            isDepsOpen && "ring-1 ring-current/25",
-          )}
-          title={(() => {
-            const lang = runtime === "deno" ? "Deno/TypeScript" : "Python";
-            const mgr = envManager ? ` · ${envManager}` : "";
-            const action = isDepsOpen
-              ? "close environment panel"
-              : "open environment panel";
-            return `${lang}${mgr} — ${action}`;
-          })()}
-        >
-          {runtime === "deno" ? (
-            <>
-              <DenoIcon className="h-3 w-3" />
-              <span>Deno</span>
-            </>
-          ) : (
-            <>
-              <PythonIcon className="h-3 w-3" />
-              <span>Python</span>
-            </>
-          )}
-          {envManager && (
-            <>
-              <span className="opacity-40">·</span>
-              {envManager === "uv" && (
-                <UvIcon className="h-2 w-2 text-fuchsia-600 dark:text-fuchsia-400" />
-              )}
-              {envManager === "conda" && (
-                <CondaIcon className="h-2.5 w-2.5 text-emerald-600 dark:text-emerald-400" />
-              )}
-              {envManager === "pixi" && (
-                <PixiIcon className="h-2.5 w-2.5 text-amber-600 dark:text-amber-400" />
-              )}
-            </>
-          )}
-        </button>
+        {/* Runtime / deps toggle — hidden until runtime is known to avoid flicker */}
+        {runtime && (
+          <button
+            type="button"
+            onClick={onToggleDependencies}
+            data-testid="deps-toggle"
+            data-runtime={runtime}
+            className={cn(
+              "flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium transition-colors",
+              runtime === "deno"
+                ? "bg-emerald-500/10 text-emerald-600 hover:bg-emerald-500/20 dark:text-emerald-400"
+                : "bg-blue-500/10 text-blue-600 hover:bg-blue-500/20 dark:text-blue-400",
+              isDepsOpen && "ring-1 ring-current/25",
+            )}
+            title={(() => {
+              const lang = runtime === "deno" ? "Deno/TypeScript" : "Python";
+              const mgr = envManager ? ` · ${envManager}` : "";
+              const action = isDepsOpen
+                ? "close environment panel"
+                : "open environment panel";
+              return `${lang}${mgr} — ${action}`;
+            })()}
+          >
+            {runtime === "deno" ? (
+              <>
+                <DenoIcon className="h-3 w-3" />
+                <span>Deno</span>
+              </>
+            ) : (
+              <>
+                <PythonIcon className="h-3 w-3" />
+                <span>Python</span>
+              </>
+            )}
+            {envManager && (
+              <>
+                <span className="opacity-40">·</span>
+                {envManager === "uv" && (
+                  <UvIcon className="h-2 w-2 text-fuchsia-600 dark:text-fuchsia-400" />
+                )}
+                {envManager === "conda" && (
+                  <CondaIcon className="h-2.5 w-2.5 text-emerald-600 dark:text-emerald-400" />
+                )}
+                {envManager === "pixi" && (
+                  <PixiIcon className="h-2.5 w-2.5 text-amber-600 dark:text-amber-400" />
+                )}
+              </>
+            )}
+          </button>
+        )}
 
         {/* Kernel status */}
         <div

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -53,7 +53,7 @@ interface NotebookViewProps {
   executingCellIds: Set<string>;
   queuedCellIds: Set<string>;
   pagePayloads: Map<string, CellPagePayload>;
-  runtime?: Runtime;
+  runtime?: Runtime | null;
   searchQuery?: string;
   searchCurrentMatch?: FindMatch | null;
   onFocusCell: (cellId: string) => void;

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -162,6 +162,10 @@ struct DaemonReadyPayload {
     notebook_id: String,
     cell_count: usize,
     needs_trust_approval: bool,
+    /// Runtime hint so the frontend can show the correct UI before metadata syncs.
+    /// Only set for Create (where we know the exact runtime); None for Open
+    /// (where the actual runtime is determined from the file's metadata).
+    runtime: Option<String>,
 }
 
 /// How to connect a new window to the daemon.
@@ -518,6 +522,7 @@ async fn initialize_notebook_sync_open(
         notebook_id: info.notebook_id.clone(),
         cell_count: info.cell_count,
         needs_trust_approval: info.needs_trust_approval,
+        runtime: None,
     };
 
     setup_sync_receivers(
@@ -586,6 +591,7 @@ async fn initialize_notebook_sync_create(
         notebook_id: info.notebook_id.clone(),
         cell_count: info.cell_count,
         needs_trust_approval: info.needs_trust_approval,
+        runtime: Some(runtime),
     };
 
     setup_sync_receivers(


### PR DESCRIPTION
## Summary

When creating a fresh Deno notebook, the toolbar briefly flashed a Python icon/badge before the CRDT metadata synced from the daemon. The frontend hardcoded `"python"` as the fallback runtime, causing the wrong UI to render during the sync window.

This PR adds an optional `runtime` hint to the `daemon:ready` event payload so the frontend knows the correct runtime immediately — but only for the **Create** path where the runtime is known with certainty. The **Open** path sends `None`, and the toolbar now hides the runtime pill entirely until a runtime is determined, preventing any incorrect flash.

Closes #1006

## Changes

- **`crates/notebook/src/lib.rs`**: Added `runtime: Option<String>` to `DaemonReadyPayload` — `Some(runtime)` for Create, `None` for Open
- **`apps/notebook/src/App.tsx`**: Replaced hardcoded `"python"` fallback with `runtimeHint` state populated from `daemon:ready` payload
- **`apps/notebook/src/components/NotebookToolbar.tsx`**: Runtime pill hidden when runtime is null (no flash of wrong icon)
- **`apps/notebook/src/components/NotebookView.tsx`**: Prop type accepts null runtime

## Verification

- [ ] Create a new Deno notebook — runtime pill should appear as Deno without any Python flash
- [ ] Create a new Python notebook — runtime pill should appear as Python
- [ ] Open an existing Deno `.ipynb` file — runtime pill should appear after metadata syncs (no wrong icon)
- [ ] Open an existing Python `.ipynb` file — works as before

<!-- Screenshots/recordings welcome here to show before/after -->

_PR submitted by @rgbkrk's agent, Quill_