### PR TITLE
feat(xtask): add `cargo xtask integration` with isolated daemon + health check

### DIFF
--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -63,6 +63,10 @@ fn main() {
             let fix = args.iter().any(|a| a == "--fix");
             cmd_lint(fix);
         }
+        "integration" => {
+            let filter = args.iter().find(|a| !a.starts_with('-')).cloned();
+            cmd_integration(filter);
+        }
         "wasm" => cmd_wasm(),
         "--help" | "-h" | "help" => print_help(),
         cmd => {
@@ -108,12 +112,100 @@ Linting:
   lint                       Check formatting and linting (Rust, JS/TS, Python)
   lint --fix                 Auto-fix formatting and linting issues
 
+Testing:
+  integration [filter]       Run Python integration tests with an isolated daemon
+                             Optional filter is passed to pytest -k (e.g. 'test_start_kernel')
+
 Other:
   wasm                       Rebuild runtimed-wasm (wasm-pack build)
   icons [source.png]         Generate icon variants
   help                       Show this help
 "
     );
+}
+
+/// Run Python integration tests with a fresh isolated daemon.
+///
+/// Builds the daemon binary, spawns it in a temp directory with its own
+/// worktree hash (no singleton conflicts), and runs pytest against it.
+/// The daemon is cleaned up when tests finish.
+fn cmd_integration(filter: Option<String>) {
+    // 1. Build the daemon
+    println!("Building runtimed for integration tests...");
+    let status = Command::new("cargo")
+        .args(["build", "-p", "runtimed"])
+        .status();
+    if !status.map(|s| s.success()).unwrap_or(false) {
+        eprintln!("Failed to build runtimed");
+        exit(1);
+    }
+
+    // 2. Ensure Python env is ready
+    ensure_python_env();
+    ensure_maturin_develop();
+
+    // 3. Create an isolated workspace path so the daemon gets its own
+    //    worktree hash and doesn't conflict with the dev daemon.
+    let workspace_dir =
+        std::env::temp_dir().join(format!("runtimed-integration-{}", std::process::id()));
+    std::fs::create_dir_all(&workspace_dir).unwrap_or_else(|e| {
+        eprintln!("Failed to create temp workspace: {e}");
+        exit(1);
+    });
+
+    // 4. Build pytest args
+    let binary = std::fs::canonicalize("target/debug/runtimed").unwrap_or_else(|e| {
+        eprintln!("Failed to resolve runtimed binary: {e}");
+        exit(1);
+    });
+
+    let mut pytest_args = vec![
+        "run".to_string(),
+        "pytest".to_string(),
+        "python/runtimed/tests/test_daemon_integration.py".to_string(),
+        "-v".to_string(),
+        "--timeout=120".to_string(),
+        "--tb=short".to_string(),
+        "--durations=15".to_string(),
+    ];
+    if let Some(ref f) = filter {
+        pytest_args.push("-k".to_string());
+        pytest_args.push(f.clone());
+    }
+
+    println!("Running integration tests...");
+    println!("  Daemon binary: {}", binary.display());
+    println!("  Workspace: {}", workspace_dir.display());
+    if let Some(ref f) = filter {
+        println!("  Filter: {f}");
+    }
+    println!();
+
+    // 5. Run pytest with CI mode env vars
+    let status = Command::new("uv")
+        .args(&pytest_args)
+        .env("RUNTIMED_INTEGRATION_TEST", "1")
+        .env("RUNTIMED_BINARY", &binary)
+        .env("RUNTIMED_WORKSPACE_PATH", &workspace_dir)
+        .env("RUNTIMED_LOG_LEVEL", "info")
+        .status();
+
+    // 6. Cleanup temp workspace
+    let _ = std::fs::remove_dir_all(&workspace_dir);
+
+    match status {
+        Ok(s) if s.success() => {
+            println!("\nAll integration tests passed!");
+        }
+        Ok(s) => {
+            eprintln!("\nSome integration tests failed.");
+            exit(s.code().unwrap_or(1));
+        }
+        Err(e) => {
+            eprintln!("Failed to run pytest: {e}");
+            exit(1);
+        }
+    }
 }
 
 /// Check that an external tool is available in PATH, exit with install instructions if not.

--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -246,7 +246,7 @@ def daemon_health_check(daemon_process):
             f"Mode: {mode}"
         )
 
-    print(f"[health] All checks passed", file=sys.stderr)
+    print("[health] All checks passed", file=sys.stderr)
     print(f"{'=' * 60}", file=sys.stderr)
 
 
@@ -391,12 +391,9 @@ def daemon_process():
                                 file=sys.stderr,
                             )
                             break
-                if not conda_ready:
-                    if conda_env_ready_pattern.search(log_contents):
-                        conda_ready = True
-                        print(
-                            f"[test] Conda pool ready after {i + 1}s (env ready)", file=sys.stderr
-                        )
+                if not conda_ready and conda_env_ready_pattern.search(log_contents):
+                    conda_ready = True
+                    print(f"[test] Conda pool ready after {i + 1}s (env ready)", file=sys.stderr)
             except Exception:
                 pass
             if uv_ready and conda_ready:

--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -189,6 +189,67 @@ def _get_socket_path():
     )
 
 
+@pytest.fixture(scope="module", autouse=True)
+def daemon_health_check(daemon_process):
+    """Run a health check on the daemon before any tests execute.
+
+    Reports daemon status (socket path, pool stats, version) and verifies
+    that basic operations work (ping, create_notebook, start_kernel, execute).
+    Fails fast with actionable diagnostics instead of hanging silently.
+    """
+    socket_path, proc = daemon_process
+    mode = "CI (spawned)" if proc is not None else "dev (external)"
+    print(f"\n{'=' * 60}", file=sys.stderr)
+    print(f"[health] Daemon mode: {mode}", file=sys.stderr)
+    print(f"[health] Socket: {socket_path}", file=sys.stderr)
+
+    # 1. Create client and ping
+    try:
+        if socket_path is not None:
+            client = runtimed.Client(socket_path=str(socket_path))
+        else:
+            client = runtimed.Client()
+        assert client.ping(), "Daemon did not respond to ping"
+        print("[health] Ping: OK", file=sys.stderr)
+    except Exception as e:
+        pytest.fail(f"Daemon health check failed at ping: {e}")
+
+    # 2. Pool status
+    try:
+        status = client.status()
+        print(
+            f"[health] Pool: uv={status['uv_available']} conda={status['conda_available']}",
+            file=sys.stderr,
+        )
+        if status["uv_available"] == 0:
+            print("[health] WARNING: no UV environments available", file=sys.stderr)
+    except Exception as e:
+        print(f"[health] WARNING: could not read status: {e}", file=sys.stderr)
+
+    # 3. Create notebook + start kernel + execute
+    try:
+        session = client.create_notebook(runtime="python")
+        print(f"[health] Created notebook: {session.notebook_id}", file=sys.stderr)
+
+        session.start_kernel(kernel_type="python", env_source="uv:prewarmed")
+        print("[health] Kernel started: OK", file=sys.stderr)
+
+        result = session.run("print('health-check-ok')")
+        assert result.success, f"Health check execution failed: {result.stderr}"
+        print("[health] Execute: OK", file=sys.stderr)
+
+        session.shutdown_kernel()
+    except Exception as e:
+        pytest.fail(
+            f"Daemon health check failed at create/execute: {e}\n"
+            f"Socket: {socket_path}\n"
+            f"Mode: {mode}"
+        )
+
+    print(f"[health] All checks passed", file=sys.stderr)
+    print(f"{'=' * 60}", file=sys.stderr)
+
+
 @pytest.fixture(scope="module")
 def daemon_process():
     """Fixture that ensures a daemon is running.
@@ -290,29 +351,52 @@ def daemon_process():
         conda_ready = False
         import re
 
-        # Match "UV pool: N/M available" where N > 0 (works for any pool size)
-        uv_pattern = re.compile(r"UV pool: (\d+)/\d+ available")
-        conda_pattern = re.compile(r"Conda pool: (\d+)/\d+ available")
-        for i in range(120):
+        # Match either format:
+        #   "UV pool: N/M available" (periodic status line)
+        #   "UV environment ready at ..." (per-env completion)
+        uv_pool_pattern = re.compile(r"UV pool: (\d+)/\d+ available")
+        uv_env_ready_pattern = re.compile(r"UV environment ready at")
+        conda_pool_pattern = re.compile(r"Conda pool: (\d+)/\d+ available")
+        conda_env_ready_pattern = re.compile(r"Conda environment ready:")
+        for i in range(150):
             try:
                 log_contents = log_file.read_text()
                 if not uv_ready:
+                    # Check pool summary first
                     for line in log_contents.splitlines():
-                        match = uv_pattern.search(line)
+                        match = uv_pool_pattern.search(line)
                         if match and int(match.group(1)) > 0:
                             uv_ready = True
-                            print(f"[test] UV pool ready after {i + 1}s", file=sys.stderr)
-                            break
-                if not conda_ready:
-                    for line in log_contents.splitlines():
-                        match = conda_pattern.search(line)
-                        if match and int(match.group(1)) > 0:
-                            conda_ready = True
                             print(
-                                f"[test] Conda pool ready after {i + 1}s",
+                                f"[test] UV pool ready after {i + 1}s (pool summary)",
                                 file=sys.stderr,
                             )
                             break
+                if not uv_ready:
+                    # Fall back to counting individual env-ready lines
+                    uv_count = len(uv_env_ready_pattern.findall(log_contents))
+                    if uv_count > 0:
+                        uv_ready = True
+                        print(
+                            f"[test] UV pool ready after {i + 1}s ({uv_count} envs)",
+                            file=sys.stderr,
+                        )
+                if not conda_ready:
+                    for line in log_contents.splitlines():
+                        match = conda_pool_pattern.search(line)
+                        if match and int(match.group(1)) > 0:
+                            conda_ready = True
+                            print(
+                                f"[test] Conda pool ready after {i + 1}s (pool summary)",
+                                file=sys.stderr,
+                            )
+                            break
+                if not conda_ready:
+                    if conda_env_ready_pattern.search(log_contents):
+                        conda_ready = True
+                        print(
+                            f"[test] Conda pool ready after {i + 1}s (env ready)", file=sys.stderr
+                        )
             except Exception:
                 pass
             if uv_ready and conda_ready:
@@ -320,7 +404,7 @@ def daemon_process():
             time.sleep(1)
         else:
             pytest.fail(
-                f"Pools not ready within 120s (uv={uv_ready}, conda={conda_ready}). "
+                f"Pools not ready within 150s (uv={uv_ready}, conda={conda_ready}). "
                 f"Daemon logs:\n{log_file.read_text()}"
             )
 


### PR DESCRIPTION
## Summary

Add `cargo xtask integration` — a one-command way to run Python integration tests with a fresh isolated daemon. Also adds a health check fixture and fixes pool warmup detection.

### `cargo xtask integration`

Builds the daemon, spawns it in a temp directory with a unique worktree hash (no singleton conflicts with the dev daemon), runs pytest, and cleans up.

```bash
cargo xtask integration                    # run all 107 tests
cargo xtask integration test_start_kernel  # filter by name
```

### Health check fixture

`daemon_health_check` runs automatically before any tests: pings the daemon, checks pool status, creates a notebook, starts a kernel, executes code. Fails fast with actionable diagnostics instead of hanging silently.

### Pool warmup detection fix

The test fixture was looking for `UV pool: N/M available` log lines, but the daemon now logs `UV environment ready at ...` per-env. Fixed to match both formats.

### Current test results

95 passed, 9 failed, 2 skipped (~3 minutes with fresh daemon)

Failures:
- **3 Project detection**: daemon's walk-up doesn't find fixture `pyproject.toml` — likely a daemon-side regression, not a test issue
- **3 Deno kernel**: deno runtime errors during execution
- **1 Conda inline deps**: env setup issue
- **1 display_data mimetype**: may be related to Output.data typing changes from #990
- **1 default_deno_but_python**: deno-related