### PR TITLE
feat(notebook): bulk clear-all-outputs via single WASM call

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -125,6 +125,7 @@ function AppContent() {
     updateOutputByDisplayId,
     applyExecutionCountFromDaemon,
     clearOutputsLocal,
+    clearAllOutputsLocal,
     clearOutputsFromDaemon,
     setCellSourceHidden,
     setCellOutputsHidden,
@@ -822,19 +823,19 @@ function AppContent() {
     const unlistenPromise = webview.listen(
       "menu:clear-all-outputs",
       async () => {
+        // Single WASM call clears all code cells in the CRDT
+        clearAllOutputsLocal();
+        // Tell daemon to clear kernel output tracking for each cell
         const codeCells = getNotebookCellsSnapshot().filter(
           (c) => c.cell_type === "code",
         );
-        for (const cell of codeCells) {
-          clearOutputsLocal(cell.id);
-        }
         await Promise.all(codeCells.map((cell) => clearOutputs(cell.id)));
       },
     );
     return () => {
       unlistenPromise.then((unlisten) => unlisten()).catch(() => {});
     };
-  }, [clearOutputsLocal, clearOutputs]);
+  }, [clearAllOutputsLocal, clearOutputs]);
 
   // Kernel menu: Run All Cells
   useEffect(() => {

--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -313,6 +313,27 @@ export function useAutomergeNotebook() {
   }, []);
 
   /**
+   * Clear outputs from every code cell via a single WASM call.
+   * Updates the CRDT atomically, then refreshes the store.
+   */
+  const clearAllOutputsLocal = useCallback(() => {
+    const handle = handleRef.current;
+    if (!handle) return;
+    const clearedIds: string[] = handle.clear_all_outputs();
+    sourceSync$.current.next();
+    setDirty(true);
+
+    const clearedSet = new Set(clearedIds);
+    updateNotebookCells((prev) =>
+      prev.map((c) =>
+        clearedSet.has(c.id) && c.cell_type === "code"
+          ? { ...c, outputs: [], execution_count: null }
+          : c,
+      ),
+    );
+  }, []);
+
+  /**
    * Apply a daemon output-clear into the store. Store-only —
    * the daemon already wrote to the CRDT, so we just update the
    * local store. No CRDT mutation, no sync, no dirty flag.
@@ -490,6 +511,7 @@ export function useAutomergeNotebook() {
     setFocusedCellId,
     updateCellSource,
     clearOutputsLocal,
+    clearAllOutputsLocal,
     clearOutputsFromDaemon,
     addCell,
     moveCell,

--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -320,6 +320,8 @@ export function useAutomergeNotebook() {
     const handle = handleRef.current;
     if (!handle) return;
     const clearedIds: string[] = handle.clear_all_outputs();
+    if (clearedIds.length === 0) return;
+
     sourceSync$.current.next();
     setDirty(true);
 

--- a/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.d.ts
+++ b/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.d.ts
@@ -79,6 +79,11 @@ export class NotebookHandle {
      */
     cell_count(): number;
     /**
+     * Clear outputs and execution counts from every code cell in the CRDT.
+     * Returns the IDs of cells that were cleared.
+     */
+    clear_all_outputs(): string[];
+    /**
      * Clear the Conda section entirely.
      */
     clear_conda_section(): void;
@@ -475,6 +480,7 @@ export interface InitOutput {
     readonly notebookhandle_update_source: (a: number, b: number, c: number, d: number, e: number, f: number) => void;
     readonly notebookhandle_splice_source: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number) => void;
     readonly notebookhandle_clear_outputs: (a: number, b: number, c: number, d: number) => void;
+    readonly notebookhandle_clear_all_outputs: (a: number, b: number) => void;
     readonly notebookhandle_set_execution_count: (a: number, b: number, c: number, d: number, e: number, f: number) => void;
     readonly notebookhandle_append_source: (a: number, b: number, c: number, d: number, e: number, f: number) => void;
     readonly notebookhandle_get_metadata: (a: number, b: number, c: number, d: number) => void;

--- a/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.js
+++ b/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.js
@@ -355,6 +355,29 @@ export class NotebookHandle {
         return ret >>> 0;
     }
     /**
+     * Clear outputs and execution counts from every code cell in the CRDT.
+     * Returns the IDs of cells that were cleared.
+     * @returns {string[]}
+     */
+    clear_all_outputs() {
+        try {
+            const retptr = wasm.__wbindgen_add_to_stack_pointer(-16);
+            wasm.notebookhandle_clear_all_outputs(retptr, this.__wbg_ptr);
+            var r0 = getDataViewMemory0().getInt32(retptr + 4 * 0, true);
+            var r1 = getDataViewMemory0().getInt32(retptr + 4 * 1, true);
+            var r2 = getDataViewMemory0().getInt32(retptr + 4 * 2, true);
+            var r3 = getDataViewMemory0().getInt32(retptr + 4 * 3, true);
+            if (r3) {
+                throw takeObject(r2);
+            }
+            var v1 = getArrayJsValueFromWasm0(r0, r1).slice();
+            wasm.__wbindgen_export4(r0, r1 * 4, 4);
+            return v1;
+        } finally {
+            wasm.__wbindgen_add_to_stack_pointer(16);
+        }
+    }
+    /**
      * Clear the Conda section entirely.
      */
     clear_conda_section() {

--- a/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm
+++ b/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:618dd49377c84dfdede5fb7f9382a9b9235ed6f5ea4274b947de6edcad880912
-size 1610174
+oid sha256:bc738019d233f5f8161ab29c7fc42ff8c13cb88147cb91ca637115217aa879b6
+size 1611231

--- a/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm.d.ts
+++ b/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm.d.ts
@@ -37,6 +37,7 @@ export const notebookhandle_delete_cell: (a: number, b: number, c: number, d: nu
 export const notebookhandle_update_source: (a: number, b: number, c: number, d: number, e: number, f: number) => void;
 export const notebookhandle_splice_source: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number) => void;
 export const notebookhandle_clear_outputs: (a: number, b: number, c: number, d: number) => void;
+export const notebookhandle_clear_all_outputs: (a: number, b: number) => void;
 export const notebookhandle_set_execution_count: (a: number, b: number, c: number, d: number, e: number, f: number) => void;
 export const notebookhandle_append_source: (a: number, b: number, c: number, d: number, e: number, f: number) => void;
 export const notebookhandle_get_metadata: (a: number, b: number, c: number, d: number) => void;

--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -1397,6 +1397,21 @@ impl NotebookDoc {
         self.set_outputs(cell_id, &[])
     }
 
+    /// Clear outputs and execution counts from every code cell.
+    /// Returns the IDs of cells that were cleared.
+    pub fn clear_all_outputs(&mut self) -> Result<Vec<String>, AutomergeError> {
+        let cell_ids = self.get_cell_ids();
+        let mut cleared = Vec::new();
+        for cell_id in &cell_ids {
+            if self.get_cell_type(cell_id).as_deref() == Some("code") {
+                self.clear_outputs(cell_id)?;
+                self.set_execution_count(cell_id, "null")?;
+                cleared.push(cell_id.clone());
+            }
+        }
+        Ok(cleared)
+    }
+
     /// Get all outputs from all cells.
     ///
     /// Returns a list of (cell_id, output_index, output_string).

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -433,6 +433,14 @@ impl NotebookHandle {
             .map_err(|e| JsError::new(&format!("clear_outputs failed: {}", e)))
     }
 
+    /// Clear outputs and execution counts from every code cell in the CRDT.
+    /// Returns the IDs of cells that were cleared.
+    pub fn clear_all_outputs(&mut self) -> Result<Vec<String>, JsError> {
+        self.doc
+            .clear_all_outputs()
+            .map_err(|e| JsError::new(&format!("clear_all_outputs failed: {}", e)))
+    }
+
     /// Set the execution count for a cell. Pass "null" or a number string like "5".
     pub fn set_execution_count(&mut self, cell_id: &str, count: &str) -> Result<bool, JsError> {
         self.doc


### PR DESCRIPTION
## Summary

- Adds `clear_all_outputs()` to `notebook-doc` and `runtimed-wasm`, replacing the frontend's per-cell loop with a single atomic CRDT mutation
- Frontend "Clear All Outputs" menu action now makes one WASM call to clear outputs and reset execution counts for all code cells
- Daemon requests remain per-cell for kernel output tracking and cross-window broadcast, but fire after the local UI is already updated

Closes #988

## Verification

- [ ] Open a notebook with multiple code cells that have outputs
- [ ] Cell menu → Clear All Outputs → all outputs and execution counts clear instantly
- [ ] Verify single-cell "Clear Outputs" still works as before
- [ ] Multi-window: clear all in one window, confirm the other window syncs

_PR submitted by @rgbkrk's agent, Quill_