### PR TITLE
feat(notebook): autofocus first cell in new notebooks

### DIFF
--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -489,6 +489,25 @@ function NotebookViewContent({
     }
   }, [focusedCellId]);
 
+  // ── Auto-seed first cell for empty notebooks ───────────────────────
+  // For new notebooks the daemon creates zero cells. Once sync completes
+  // (isLoading becomes false), we create the first code cell locally via
+  // the CRDT so the user gets an instant focused editor. The ref guard
+  // ensures we only seed once even if the effect re-fires before React
+  // processes the focusedCellId update from onAddCell.
+  const didAutoSeed = useRef(false);
+  useEffect(() => {
+    if (isLoading || focusedCellId !== null) return;
+    if (cellIds.length === 0) {
+      if (!didAutoSeed.current) {
+        didAutoSeed.current = true;
+        onAddCell("code");
+      }
+    } else {
+      onFocusCell(cellIds[0]);
+    }
+  }, [isLoading, cellIds, focusedCellId, onFocusCell, onAddCell]);
+
   const renderCell = useCallback(
     (
       cell: NotebookCell,

--- a/apps/notebook/src/lib/frame-pipeline.ts
+++ b/apps/notebook/src/lib/frame-pipeline.ts
@@ -205,13 +205,13 @@ export function createFramePipeline(deps: FramePipelineDeps): Subscription {
               // Sync delivered actual document content — clear the gate
               // and materialize. This is the success path.
               deps.setAwaitingInitialSync(false);
-              deps.setIsLoading(false);
               const handle = deps.getHandle();
               if (handle) {
                 return from(
                   deps
                     .materializeCells(handle)
                     .then(() => {
+                      deps.setIsLoading(false);
                       notifyMetadataChanged();
                       deps.onSyncApplied();
                     })
@@ -220,10 +220,12 @@ export function createFramePipeline(deps: FramePipelineDeps): Subscription {
                         "[frame-pipeline] initial materialize failed:",
                         err,
                       );
+                      deps.setIsLoading(false);
                       deps.onSyncApplied();
                     }),
                 );
               }
+              deps.setIsLoading(false); // Fallback if no handle
             }
             // changed:false — Automerge sync protocol handshake round
             // (exchanging heads/bloom filters, no actual content yet).

--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -4123,6 +4123,55 @@ mod tests {
         assert_eq!(actors, vec!["human:tab-1", "runtimed"]);
     }
 
+    /// Validates the local-first empty notebook flow: daemon creates a doc
+    /// with metadata but zero cells, frontend creates a cell locally, then
+    /// sync converges so both sides have the cell.
+    #[test]
+    fn test_frontend_creates_cell_syncs_to_empty_daemon() {
+        use automerge::sync;
+
+        // Daemon creates doc with metadata but 0 cells
+        let mut daemon = NotebookDoc::new_with_actor("nb", "runtimed");
+        assert_eq!(daemon.cell_count(), 0);
+
+        // Frontend starts empty
+        let mut frontend = NotebookDoc::empty_with_actor("human:tab-1");
+
+        let mut ds = sync::State::new();
+        let mut fs = sync::State::new();
+
+        // Initial sync: frontend gets daemon's schema/metadata
+        for _ in 0..10 {
+            if let Some(m) = daemon.generate_sync_message(&mut ds) {
+                frontend.receive_sync_message(&mut fs, m).unwrap();
+            }
+            if let Some(m) = frontend.generate_sync_message(&mut fs) {
+                daemon.receive_sync_message(&mut ds, m).unwrap();
+            }
+        }
+        assert_eq!(frontend.cell_count(), 0);
+        assert_eq!(daemon.cell_count(), 0);
+
+        // Frontend creates a cell locally (like the autoseed effect)
+        frontend.add_cell(0, "cell-1", "code").unwrap();
+        assert_eq!(frontend.cell_count(), 1);
+
+        // Sync again — frontend's cell should reach the daemon
+        for _ in 0..10 {
+            if let Some(m) = frontend.generate_sync_message(&mut fs) {
+                daemon.receive_sync_message(&mut ds, m).unwrap();
+            }
+            if let Some(m) = daemon.generate_sync_message(&mut ds) {
+                frontend.receive_sync_message(&mut fs, m).unwrap();
+            }
+        }
+
+        // Both should have the cell
+        assert_eq!(daemon.cell_count(), 1);
+        assert_eq!(frontend.cell_count(), 1);
+        assert_eq!(daemon.get_cells()[0].id, "cell-1");
+    }
+
     #[test]
     fn test_per_cell_accessors() {
         let mut doc = NotebookDoc::new("nb-accessors");

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -1284,7 +1284,7 @@ impl Daemon {
 
     /// Handle a CreateNotebook connection.
     ///
-    /// Daemon creates empty room with one code cell, generates env_id as notebook_id.
+    /// Daemon creates empty room with zero cells, generates env_id as notebook_id.
     /// Returns NotebookConnectionInfo, then continues as normal notebook sync.
     async fn handle_create_notebook<S>(
         self: Arc<Self>,

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -5031,13 +5031,8 @@ pub fn create_empty_notebook(
     let env_id = env_id
         .map(|s| s.to_string())
         .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
-    let cell_id = uuid::Uuid::new_v4().to_string();
-
-    // Add a single empty code cell
-    doc.add_cell(0, &cell_id, "code")
-        .map_err(|e| format!("Failed to add cell: {}", e))?;
-
-    // Build metadata based on runtime
+    // Build metadata based on runtime (no cells — the frontend creates the
+    // first cell locally via the CRDT so the user gets instant autofocus)
     let metadata_snapshot = build_new_notebook_metadata(runtime, &env_id, default_python_env);
 
     doc.set_metadata_snapshot(&metadata_snapshot)
@@ -7030,11 +7025,8 @@ mod tests {
         let env_id = result.unwrap();
         assert!(!env_id.is_empty(), "Should generate an env_id");
 
-        // Should have exactly one cell
-        assert_eq!(doc.cell_count(), 1);
-        let cells = doc.get_cells();
-        assert_eq!(cells[0].cell_type, "code");
-        assert!(cells[0].source.is_empty());
+        // Should have zero cells (frontend creates the first cell locally)
+        assert_eq!(doc.cell_count(), 0);
     }
 
     #[test]
@@ -7048,7 +7040,7 @@ mod tests {
         );
 
         assert!(result.is_ok());
-        assert_eq!(doc.cell_count(), 1);
+        assert_eq!(doc.cell_count(), 0);
 
         // Check metadata was set correctly
         let metadata = doc.get_metadata_snapshot();

--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -2318,25 +2318,23 @@ class TestCreateNotebook:
     """Test Client.create_notebook() - daemon-owned creation."""
 
     def test_create_python_notebook(self, client):
-        """Creating Python notebook returns session with one empty cell."""
+        """Creating Python notebook returns session with zero cells."""
         session = client.create_notebook(runtime="python")
         assert session.is_connected
 
         # notebook_id is UUID (not a path)
         assert len(session.notebook_id) == 36  # UUID format
 
-        # Has one empty code cell
+        # Has zero cells (frontend creates the first cell locally)
         cells = session.get_cells()
-        assert len(cells) == 1
-        assert cells[0].cell_type == "code"
-        assert cells[0].source == ""
+        assert len(cells) == 0
 
     def test_create_notebook_returns_connection_info(self, client):
         """NotebookConnectionInfo is available for created notebooks."""
         session = client.create_notebook(runtime="python")
         info = session.connection_info
         assert info is not None
-        assert info.cell_count == 1
+        assert info.cell_count == 0
         assert info.notebook_id == session.notebook_id
         # New notebooks don't need trust approval
         assert info.needs_trust_approval is False
@@ -2346,9 +2344,9 @@ class TestCreateNotebook:
         session = client.create_notebook(runtime="deno")
         assert session.is_connected
 
-        # Has one empty code cell
+        # Has zero cells (frontend creates the first cell locally)
         cells = session.get_cells()
-        assert len(cells) == 1
+        assert len(cells) == 0
 
     def test_create_notebook_with_working_dir(self, client, tmp_path):
         """working_dir is used for project file detection."""

--- a/src/components/editor/codemirror-editor.tsx
+++ b/src/components/editor/codemirror-editor.tsx
@@ -272,6 +272,14 @@ export const CodeMirrorEditor = forwardRef<
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
+    // Focus when autoFocus becomes true after mount (e.g. notebook
+    // auto-seeds a cell then sets focusedCellId).
+    useEffect(() => {
+      if (autoFocus && viewRef.current && !viewRef.current.hasFocus) {
+        requestAnimationFrame(() => viewRef.current?.focus());
+      }
+    }, [autoFocus]);
+
     // ── Dynamic reconfiguration via compartments ─────────────────────
 
     useEffect(() => {


### PR DESCRIPTION
## Summary

New notebooks now start with zero cells. After the CRDT sync completes, the frontend creates the first code cell locally and autofocuses it — giving the user an instant editor without waiting for a daemon round-trip.

- **Daemon**: `create_empty_notebook()` no longer seeds a cell; only sets metadata
- **Frontend**: autoseed effect in `NotebookView` creates a code cell when `cellIds` is empty post-sync, with a `didAutoSeed` ref guard to prevent duplicates
- **Frame pipeline**: `setIsLoading(false)` moved after `materializeCells` completes (prevents race where React renders `isLoading=false` + `cellIds=[]`)
- **CodeMirror**: `useEffect([autoFocus])` handles focus for cells that mount before `focusedCellId` is set

Closes #1007

## Verification

- [ ] Launch new notebook → single code cell appears immediately with cursor focused
- [ ] Open existing `.ipynb` → cells load from disk, first cell focused
- [ ] Cmd+N for second notebook → cell appears with focus
- [ ] Type code and Shift+Enter → executes (kernel auto-launched by daemon)
- [ ] Daemon reconnect → focus stays on user's selected cell

<!-- Screenshots / screen recordings of the autofocus behavior -->

_PR submitted by @rgbkrk's agent, Quill_