### PR TITLE
fix(runtimed): improve kernel launch diagnostics and pool env validation

### DIFF
--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -194,13 +194,16 @@ impl Pool {
     fn take(&mut self) -> Option<PooledEnv> {
         self.prune_stale();
 
-        // Try to get a valid environment, skipping any with missing paths
+        // Try to get a valid environment, skipping any with missing paths or missing warmup
         while let Some(entry) = self.available.pop_front() {
-            if entry.env.venv_path.exists() && entry.env.python_path.exists() {
+            if entry.env.venv_path.exists()
+                && entry.env.python_path.exists()
+                && entry.env.venv_path.join(".warmed").exists()
+            {
                 return Some(entry.env);
             }
             warn!(
-                "[runtimed] Skipping env with missing path: {:?}",
+                "[runtimed] Skipping env with missing path or warmup marker: {:?}",
                 entry.env.venv_path
             );
         }
@@ -2245,36 +2248,51 @@ impl Daemon {
         }
 
         // Run warmup script
-        self.warmup_conda_env(&python_path, &env_path).await;
+        let warmup_ok = self.warmup_conda_env(&python_path, &env_path).await;
 
-        // Add to pool and check if we're clearing a previous error state
-        let had_errors = {
-            let mut pool = self.conda_pool.lock().await;
-            let had = pool.failure_state.consecutive_failures > 0;
-            pool.add(PooledEnv {
-                env_type: EnvType::Conda,
-                venv_path: env_path.clone(),
-                python_path,
-            });
-            had
-        };
+        if warmup_ok {
+            // Add to pool and check if we're clearing a previous error state
+            let had_errors = {
+                let mut pool = self.conda_pool.lock().await;
+                let had = pool.failure_state.consecutive_failures > 0;
+                pool.add(PooledEnv {
+                    env_type: EnvType::Conda,
+                    venv_path: env_path.clone(),
+                    python_path,
+                });
+                had
+            };
 
-        info!(
-            "[runtimed] Conda environment ready: {:?} (pool: {}/{})",
-            env_path,
-            self.conda_pool.lock().await.stats().0,
-            self.config.conda_pool_size
-        );
+            info!(
+                "[runtimed] Conda environment ready: {:?} (pool: {}/{})",
+                env_path,
+                self.conda_pool.lock().await.stats().0,
+                self.config.conda_pool_size
+            );
 
-        // Broadcast cleared state if we recovered from errors
-        if had_errors {
-            info!("[runtimed] Conda pool recovered from error state");
+            // Broadcast cleared state if we recovered from errors
+            if had_errors {
+                info!("[runtimed] Conda pool recovered from error state");
+                self.broadcast_pool_state().await;
+            }
+        } else {
+            // Clean up failed env and record failure
+            let _ = tokio::fs::remove_dir_all(&env_path).await;
+            self.conda_pool
+                .lock()
+                .await
+                .warming_failed_with_error(Some(PackageInstallError {
+                    failed_package: None,
+                    error_message: "Conda warmup script failed (ipykernel may not be installed)"
+                        .into(),
+                }));
             self.broadcast_pool_state().await;
         }
     }
 
     /// Warm up a conda environment by running Python to trigger .pyc compilation.
-    async fn warmup_conda_env(&self, python_path: &PathBuf, env_path: &PathBuf) {
+    /// Returns `true` if warmup succeeded (ipykernel imports work).
+    async fn warmup_conda_env(&self, python_path: &PathBuf, env_path: &PathBuf) -> bool {
         let warmup_script = r#"
 import ipykernel
 import IPython
@@ -2302,20 +2320,24 @@ print("warmup complete")
                 // Create marker file
                 tokio::fs::write(env_path.join(".warmed"), "").await.ok();
                 info!("[runtimed] Conda warmup complete for {:?}", env_path);
+                true
             }
             Ok(Ok(output)) => {
                 let stderr = String::from_utf8_lossy(&output.stderr);
-                warn!(
+                error!(
                     "[runtimed] Conda warmup failed for {:?}: {}",
                     env_path,
                     stderr.lines().take(3).collect::<Vec<_>>().join(" | ")
                 );
+                false
             }
             Ok(Err(e)) => {
-                warn!("[runtimed] Failed to run conda warmup: {}", e);
+                error!("[runtimed] Failed to run conda warmup: {}", e);
+                false
             }
             Err(_) => {
-                warn!("[runtimed] Conda warmup timed out");
+                error!("[runtimed] Conda warmup timed out");
+                false
             }
         }
     }
@@ -2573,36 +2595,60 @@ print("warmup complete")
         )
         .await;
 
-        match warmup_result {
+        let warmup_ok = match warmup_result {
             Ok(Ok(output)) if output.status.success() => {
                 // Create marker file
                 tokio::fs::write(venv_path.join(".warmed"), "").await.ok();
+                true
             }
-            Ok(_) => {
-                warn!("[runtimed] Warmup script failed, continuing anyway");
+            Ok(Ok(output)) => {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                error!(
+                    "[runtimed] UV warmup failed, NOT adding to pool: {}",
+                    stderr.lines().take(3).collect::<Vec<_>>().join(" | ")
+                );
+                false
+            }
+            Ok(Err(e)) => {
+                error!("[runtimed] Failed to run UV warmup: {}", e);
+                false
             }
             Err(_) => {
-                warn!("[runtimed] Warmup script timed out, continuing anyway");
+                error!("[runtimed] UV warmup timed out, NOT adding to pool");
+                false
             }
-        }
-
-        info!("[runtimed] UV environment ready at {:?}", venv_path);
-
-        // Add to pool and check if we're clearing a previous error state
-        let had_errors = {
-            let mut pool = self.uv_pool.lock().await;
-            let had = pool.failure_state.consecutive_failures > 0;
-            pool.add(PooledEnv {
-                env_type: EnvType::Uv,
-                venv_path,
-                python_path,
-            });
-            had
         };
 
-        // Broadcast cleared state if we recovered from errors
-        if had_errors {
-            info!("[runtimed] UV pool recovered from error state");
+        if warmup_ok {
+            info!("[runtimed] UV environment ready at {:?}", venv_path);
+
+            // Add to pool and check if we're clearing a previous error state
+            let had_errors = {
+                let mut pool = self.uv_pool.lock().await;
+                let had = pool.failure_state.consecutive_failures > 0;
+                pool.add(PooledEnv {
+                    env_type: EnvType::Uv,
+                    venv_path,
+                    python_path,
+                });
+                had
+            };
+
+            // Broadcast cleared state if we recovered from errors
+            if had_errors {
+                info!("[runtimed] UV pool recovered from error state");
+                self.broadcast_pool_state().await;
+            }
+        } else {
+            // Clean up failed env and record failure
+            let _ = tokio::fs::remove_dir_all(&venv_path).await;
+            self.uv_pool
+                .lock()
+                .await
+                .warming_failed_with_error(Some(PackageInstallError {
+                    failed_package: None,
+                    error_message: "Warmup script failed (ipykernel may not be installed)".into(),
+                }));
             self.broadcast_pool_state().await;
         }
     }
@@ -2629,6 +2675,9 @@ mod tests {
             std::fs::create_dir_all(parent).unwrap();
         }
         std::fs::write(&python_path, "").unwrap();
+
+        // Create warmup marker so take() accepts this env
+        std::fs::write(venv_path.join(".warmed"), "").unwrap();
 
         PooledEnv {
             env_type: EnvType::Uv,
@@ -2892,6 +2941,43 @@ mod tests {
         assert_eq!(err.failed_package, Some("scitkit-learn".to_string()));
         assert_eq!(err.consecutive_failures, 1);
         assert!(err.message.contains("scitkit-learn"));
+    }
+
+    #[test]
+    fn test_pool_take_skips_unwarmed() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut pool = Pool::new(3, 3600);
+
+        // Create an env with valid paths but NO .warmed marker
+        let venv_path = temp_dir.path().join("unwarmed-env");
+        std::fs::create_dir_all(&venv_path).unwrap();
+        #[cfg(windows)]
+        let python_path = venv_path.join("Scripts").join("python.exe");
+        #[cfg(not(windows))]
+        let python_path = venv_path.join("bin").join("python");
+        if let Some(parent) = python_path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(&python_path, "").unwrap();
+
+        let unwarmed_env = PooledEnv {
+            env_type: EnvType::Uv,
+            venv_path,
+            python_path,
+        };
+        pool.add(unwarmed_env);
+
+        // take() should skip the unwarmed env
+        assert!(pool.take().is_none());
+
+        // Add a properly warmed env
+        let warmed_env = create_test_env(&temp_dir, "warmed-env");
+        pool.add(warmed_env.clone());
+
+        // take() should return the warmed env
+        let taken = pool.take();
+        assert!(taken.is_some());
+        assert_eq!(taken.unwrap().venv_path, warmed_env.venv_path);
     }
 
     #[test]

--- a/crates/runtimed/src/kernel_manager.rs
+++ b/crates/runtimed/src/kernel_manager.rs
@@ -574,7 +574,7 @@ impl RoomKernel {
                         cmd.args(["-Xfrozen_modules=off", "-m", "ipykernel_launcher", "-f"]);
                         cmd.arg(&connection_file_path);
                         cmd.stdout(Stdio::null());
-                        cmd.stderr(Stdio::null());
+                        cmd.stderr(Stdio::piped());
 
                         // Set VIRTUAL_ENV so uv knows which environment to target
                         cmd.env("VIRTUAL_ENV", &pooled_env.venv_path);
@@ -609,7 +609,7 @@ impl RoomKernel {
                         ]);
                         cmd.arg(&connection_file_path);
                         cmd.stdout(Stdio::null());
-                        cmd.stderr(Stdio::null());
+                        cmd.stderr(Stdio::piped());
                         cmd
                     }
                     "conda:inline" => {
@@ -627,7 +627,7 @@ impl RoomKernel {
                         cmd.args(["-Xfrozen_modules=off", "-m", "ipykernel_launcher", "-f"]);
                         cmd.arg(&connection_file_path);
                         cmd.stdout(Stdio::null());
-                        cmd.stderr(Stdio::null());
+                        cmd.stderr(Stdio::piped());
                         cmd
                     }
                     _ => {
@@ -646,7 +646,7 @@ impl RoomKernel {
                         cmd.args(["-Xfrozen_modules=off", "-m", "ipykernel_launcher", "-f"]);
                         cmd.arg(&connection_file_path);
                         cmd.stdout(Stdio::null());
-                        cmd.stderr(Stdio::null());
+                        cmd.stderr(Stdio::piped());
 
                         // Set VIRTUAL_ENV and add uv to PATH for UV prewarmed environments
                         if pooled_env.env_type == EnvType::Uv {
@@ -669,7 +669,7 @@ impl RoomKernel {
                 cmd.args(["jupyter", "--kernel", "--conn"]);
                 cmd.arg(&connection_file_path);
                 cmd.stdout(Stdio::null());
-                cmd.stderr(Stdio::null());
+                cmd.stderr(Stdio::piped());
                 cmd
             }
             _ => {
@@ -690,6 +690,24 @@ impl RoomKernel {
 
         let mut process = cmd.kill_on_drop(true).spawn()?;
 
+        // Capture kernel stderr for diagnostics — log errors/warnings at warn level,
+        // everything else at debug to avoid flooding logs with uv's verbose output
+        if let Some(stderr) = process.stderr.take() {
+            let kid = kernel_id.clone();
+            tokio::spawn(async move {
+                use tokio::io::{AsyncBufReadExt, BufReader};
+                let mut lines = BufReader::new(stderr).lines();
+                while let Ok(Some(line)) = lines.next_line().await {
+                    let lower = line.to_ascii_lowercase();
+                    if lower.contains("error") || lower.contains("traceback") {
+                        warn!("[kernel-stderr:{}] {}", kid, line);
+                    } else {
+                        debug!("[kernel-stderr:{}] {}", kid, line);
+                    }
+                }
+            });
+        }
+
         #[cfg(unix)]
         {
             self.process_group_id = process.id().map(|pid| pid as i32);
@@ -699,8 +717,37 @@ impl RoomKernel {
         }
         self.kernel_id = Some(kernel_id.clone());
 
+        info!(
+            "[kernel-manager] Spawned kernel process (pid={:?}, kernel_id={})",
+            process.id(),
+            kernel_id
+        );
+
         // Small delay to let the kernel start
         tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
+        // Early crash detection: check if process exited during startup
+        match process.try_wait() {
+            Ok(Some(exit_status)) => {
+                error!(
+                    "[kernel-manager] Kernel process exited immediately: {} (kernel_id={})",
+                    exit_status, kernel_id
+                );
+                return Err(anyhow::anyhow!(
+                    "Kernel process exited immediately: {}",
+                    exit_status
+                ));
+            }
+            Ok(None) => {
+                // Process still running — good
+            }
+            Err(e) => {
+                warn!(
+                    "[kernel-manager] Could not check kernel process status: {}",
+                    e
+                );
+            }
+        }
 
         self.session_id = Uuid::new_v4().to_string();
 
@@ -713,18 +760,22 @@ impl RoomKernel {
         let (cmd_tx, cmd_rx) = mpsc::channel::<QueueCommand>(100);
         self.cmd_tx = Some(cmd_tx.clone());
 
-        // Spawn process watcher - detects immediate process exit (e.g., os._exit(1))
+        // Spawn process watcher - detects process exit and signals via oneshot
         let process_cmd_tx = cmd_tx.clone();
+        let (died_tx, died_rx) = tokio::sync::oneshot::channel::<String>();
         let process_watcher_task = tokio::spawn(async move {
             let status = process.wait().await;
-            match status {
+            let msg = match status {
                 Ok(exit_status) => {
                     warn!("[kernel-manager] Kernel process exited: {}", exit_status);
+                    format!("Kernel process exited: {}", exit_status)
                 }
                 Err(e) => {
                     error!("[kernel-manager] Error waiting for kernel process: {}", e);
+                    format!("Error waiting for kernel process: {}", e)
                 }
-            }
+            };
+            let _ = died_tx.send(msg);
             let _ = process_cmd_tx.try_send(QueueCommand::KernelDied);
         });
         // Store immediately so early-return error paths can clean it up
@@ -1407,33 +1458,38 @@ impl RoomKernel {
         )
         .await?;
 
-        // Verify kernel is alive
+        // Verify kernel is alive — race kernel_info_reply against process death
         let request: JupyterMessage = KernelInfoRequest::default().into();
         shell.send(request).await?;
 
-        let reply = tokio::time::timeout(std::time::Duration::from_secs(30), shell.read()).await;
+        let reply = tokio::select! {
+            result = tokio::time::timeout(std::time::Duration::from_secs(30), shell.read()) => {
+                match result {
+                    Ok(Ok(msg)) => Ok(msg),
+                    Ok(Err(e)) => Err(anyhow::anyhow!("Kernel did not respond: {}", e)),
+                    Err(_) => Err(anyhow::anyhow!("Kernel did not respond within 30s")),
+                }
+            }
+            died_msg = died_rx => {
+                let msg = died_msg.unwrap_or_else(|_| "unknown".to_string());
+                Err(anyhow::anyhow!("Kernel process died before responding: {}", msg))
+            }
+        };
+
         match reply {
-            Ok(Ok(msg)) => {
+            Ok(msg) => {
                 info!(
                     "[kernel-manager] Kernel alive: got {} reply",
                     msg.header.msg_type
                 );
             }
-            Ok(Err(e)) => {
-                error!("[kernel-manager] Error reading kernel_info_reply: {}", e);
+            Err(e) => {
+                error!("[kernel-manager] {}", e);
                 // Abort process watcher to kill orphaned kernel
                 if let Some(task) = self.process_watcher_task.take() {
                     task.abort();
                 }
-                return Err(anyhow::anyhow!("Kernel did not respond: {}", e));
-            }
-            Err(_) => {
-                error!("[kernel-manager] Timeout waiting for kernel_info_reply");
-                // Abort process watcher to kill orphaned kernel
-                if let Some(task) = self.process_watcher_task.take() {
-                    task.abort();
-                }
-                return Err(anyhow::anyhow!("Kernel did not respond within 30s"));
+                return Err(e);
             }
         }
 


### PR DESCRIPTION
## Summary

- **Pool warmup gating**: Don't add UV/conda environments to the pool when the warmup script fails — the env may not have working ipykernel. Failed envs are cleaned up and the failure is recorded for backoff/retry.
- **`.warmed` marker check**: `Pool::take()` now verifies the `.warmed` marker file exists as defense-in-depth against unwarmed envs entering the pool.
- **Kernel stderr capture**: Pipe kernel process stderr instead of `/dev/null`. Lines containing "error" or "traceback" log at `warn`; everything else at `debug` to avoid flooding with uv's verbose output.
- **Early crash detection**: `try_wait()` after the 500ms startup delay catches immediate kernel process crashes instead of waiting the full 30s timeout.
- **Process death racing**: The `kernel_info_reply` wait now uses `tokio::select!` to race against process death — if the kernel exits before responding, we get an instant error with exit status instead of a 30s timeout.
- **PID logging**: Kernel process PID is logged at spawn time for debugging.

## Context

When opening new notebooks (Cmd+N), prewarmed kernel processes sometimes fail silently — the process is spawned but never sends `kernel_info_reply`. Without stderr capture or early death detection, the daemon waited 30s with no diagnostics. This PR improves observability so the root cause of prewarmed kernel failures can be identified.

## Test plan

- [x] `cargo build -p runtimed`
- [x] `cargo test -p runtimed` — 22 tests pass including new `test_pool_take_skips_unwarmed`
- [x] `cargo xtask lint` — clean
- [ ] Manual: `cargo xtask dev-daemon` + `cargo xtask dev`, open two notebooks, check daemon logs for new diagnostics