### PR TITLE
ci: force-reinstall tauri-cli via binstall to avoid stale cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -270,7 +270,7 @@ jobs:
         run: curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
 
       - name: Install tauri-cli and tauri-driver
-        run: cargo binstall tauri-cli tauri-driver --no-confirm --locked
+        run: cargo binstall tauri-cli tauri-driver --no-confirm --locked --force
 
       - name: Upload Linux Rust binaries
         uses: actions/upload-artifact@v4

--- a/.github/workflows/pr-binary-generation.yml
+++ b/.github/workflows/pr-binary-generation.yml
@@ -139,7 +139,7 @@ jobs:
           iex (iwr "https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.ps1").Content
 
       - name: Install tauri-cli
-        run: cargo binstall tauri-cli --no-confirm --locked
+        run: cargo binstall tauri-cli --no-confirm --locked --force
 
       - name: Bake PR + commit into version
         id: version

--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -253,7 +253,7 @@ jobs:
         run: curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
 
       - name: Install Tauri CLI
-        run: cargo binstall tauri-cli --no-confirm --locked
+        run: cargo binstall tauri-cli --no-confirm --locked --force
 
       - name: Import Apple signing certificate
         env:
@@ -422,7 +422,7 @@ jobs:
           iex (iwr "https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.ps1").Content
 
       - name: Install Tauri CLI
-        run: cargo binstall tauri-cli --no-confirm --locked
+        run: cargo binstall tauri-cli --no-confirm --locked --force
 
       - name: Set version in tauri.conf.json
         shell: pwsh
@@ -562,7 +562,7 @@ jobs:
         run: curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
 
       - name: Install Tauri CLI
-        run: cargo binstall tauri-cli --no-confirm --locked
+        run: cargo binstall tauri-cli --no-confirm --locked --force
 
       - name: Set version in tauri.conf.json
         run: |


### PR DESCRIPTION
## Summary

`Swatinem/rust-cache` restores a cached `cargo-tauri` binary into `~/.cargo/bin/`. `cargo binstall tauri-cli` sees it and skips installation ("already installed"), but the cached binary is non-functional on the current runner image — causing `cargo tauri --version` to fail and aborting icon generation on all three notebook build jobs.

This adds `--force` to all `cargo binstall tauri-cli` invocations across release, build, and PR binary workflows so a fresh binary is always downloaded.

## Verification

- [ ] Trigger a nightly release via workflow_dispatch and confirm all three notebook builds (macOS ARM64, Windows x64, Linux x64) pass the "Generate Icons" step

_PR submitted by @rgbkrk's agent, Quill_