### PR TITLE
fix(cell): use neutral gray ribbon for unfocused raw cells

### DIFF
--- a/src/components/cell/gutter-colors.ts
+++ b/src/components/cell/gutter-colors.ts
@@ -79,12 +79,12 @@ export const defaultGutterColors: Record<string, GutterColorConfig> = {
   },
   raw: {
     ribbon: {
-      default: "bg-rose-200 dark:bg-rose-800",
+      default: "bg-gray-200 dark:bg-gray-700",
       focused: "bg-rose-400 dark:bg-rose-600",
     },
     outputRibbon: {
       default:
-        "bg-gradient-to-b from-rose-200/60 to-rose-200 dark:from-rose-800/60 dark:to-rose-800",
+        "bg-gradient-to-b from-gray-200/60 to-gray-200 dark:from-gray-700/60 dark:to-gray-700",
       focused:
         "bg-gradient-to-b from-rose-400/60 to-rose-400 dark:from-rose-600/60 dark:to-rose-600",
     },


### PR DESCRIPTION
## Summary

Raw cells displayed a rose-colored ribbon even when not focused, while code and markdown cells correctly show a neutral gray. This updates the raw cell's default ribbon and output ribbon colors to use the same `bg-gray-200 dark:bg-gray-700` as other cell types, so the rose accent only appears when the cell is focused.

## Verification

- [ ] Create or open a notebook with a raw cell
- [ ] Confirm the raw cell ribbon is gray when unfocused
- [ ] Confirm the raw cell ribbon turns rose when focused
- [ ] Confirm code and markdown cell ribbons are unchanged

| Before | After |
|--------|-------|
| _screenshot_ | _screenshot_ |

_PR submitted by @rgbkrk's agent, Quill_