### PR TITLE
fix(runtimed): handle directory paths in --attach without autosave spin loop

### DIFF
--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -1114,11 +1114,12 @@ impl Daemon {
                     Ok(p) => p.to_string_lossy().to_string(),
                     Err(_) => path_buf.to_string_lossy().to_string(),
                 };
-                // Verify directory is writable
-                let test_file = path_buf.join(".runtimed_write_test");
-                match tokio::fs::write(&test_file, b"").await {
+                // Verify directory is writable using a uniquely-named temp file.
+                // create_new uses O_EXCL so it can never clobber an existing file.
+                let probe = path_buf.join(format!(".runtimed_probe_{}", uuid::Uuid::new_v4()));
+                match std::fs::File::create_new(&probe) {
                     Ok(_) => {
-                        let _ = tokio::fs::remove_file(&test_file).await;
+                        let _ = std::fs::remove_file(&probe);
                     }
                     Err(e) => {
                         let (_reader, mut writer) = tokio::io::split(stream);

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -1104,6 +1104,42 @@ impl Daemon {
         // Check if file exists before canonicalizing (canonicalize fails for non-existent paths)
         let mut path_buf = std::path::PathBuf::from(&path);
         let file_exists = match tokio::fs::metadata(&path_buf).await {
+            Ok(meta) if meta.is_dir() => {
+                // Directory path — create untitled notebook with this as working dir
+                info!(
+                    "[runtimed] Path {} is a directory, creating untitled notebook with working_dir",
+                    path
+                );
+                let dir_path = match path_buf.canonicalize() {
+                    Ok(p) => p.to_string_lossy().to_string(),
+                    Err(_) => path_buf.to_string_lossy().to_string(),
+                };
+                // Verify directory is writable
+                let test_file = path_buf.join(".runtimed_write_test");
+                match tokio::fs::write(&test_file, b"").await {
+                    Ok(_) => {
+                        let _ = tokio::fs::remove_file(&test_file).await;
+                    }
+                    Err(e) => {
+                        let (_reader, mut writer) = tokio::io::split(stream);
+                        send_error_response(
+                            &mut writer,
+                            format!("Directory '{}' is not writable: {}", path, e),
+                        )
+                        .await?;
+                        return Ok(());
+                    }
+                }
+                let settings = self.settings.read().await.get_all();
+                return self
+                    .handle_create_notebook(
+                        stream,
+                        settings.default_runtime.to_string(),
+                        Some(dir_path),
+                        None,
+                    )
+                    .await;
+            }
             Ok(_) => true,
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
                 // For new files, ensure .ipynb extension

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -3772,11 +3772,28 @@ async fn format_notebook_cells(room: &NotebookRoom) -> Result<usize, String> {
 /// 4. Reconstruct cells: source and outputs from Automerge, cell metadata from existing file
 /// 5. Write the merged notebook to disk
 ///
+/// Errors from save_notebook_to_disk.
+#[derive(Debug)]
+enum SaveError {
+    /// Transient / potentially recoverable (e.g. disk full, busy)
+    Retryable(String),
+    /// Permanent — retrying will never help (path is a directory, permission denied, invalid path)
+    Unrecoverable(String),
+}
+
+impl std::fmt::Display for SaveError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SaveError::Retryable(msg) | SaveError::Unrecoverable(msg) => f.write_str(msg),
+        }
+    }
+}
+
 /// Returns the absolute path where the notebook was written.
 async fn save_notebook_to_disk(
     room: &NotebookRoom,
     target_path: Option<&str>,
-) -> Result<String, String> {
+) -> Result<String, SaveError> {
     // Determine the actual save path
     let notebook_path = match target_path {
         Some(p) => {
@@ -3785,10 +3802,10 @@ async fn save_notebook_to_disk(
             // Reject relative paths - daemon CWD is unpredictable (could be / when running as launchd)
             // Clients (Tauri file dialog, Python SDK) should always provide absolute paths.
             if path.is_relative() {
-                return Err(format!(
+                return Err(SaveError::Unrecoverable(format!(
                     "Relative paths are not supported for save: '{}'. Please provide an absolute path.",
                     p
-                ));
+                )));
             }
 
             // Ensure .ipynb extension
@@ -3918,13 +3935,21 @@ async fn save_notebook_to_disk(
 
     // Serialize with trailing newline (nbformat convention)
     let content = serde_json::to_string_pretty(&notebook_json)
-        .map_err(|e| format!("Failed to serialize notebook: {e}"))?;
+        .map_err(|e| SaveError::Retryable(format!("Failed to serialize notebook: {e}")))?;
     let content_with_newline = format!("{content}\n");
 
     // Write to disk (async to avoid blocking the runtime)
     tokio::fs::write(&notebook_path, content_with_newline)
         .await
-        .map_err(|e| format!("Failed to write notebook: {e}"))?;
+        .map_err(|e| {
+            let msg = format!("Failed to write notebook: {e}");
+            match e.kind() {
+                std::io::ErrorKind::PermissionDenied | std::io::ErrorKind::IsADirectory => {
+                    SaveError::Unrecoverable(msg)
+                }
+                _ => SaveError::Retryable(msg),
+            }
+        })?;
 
     // Update last_self_write timestamp so file watcher skips this change
     let now = std::time::SystemTime::now()
@@ -4339,6 +4364,13 @@ fn spawn_autosave_debouncer_with_config(
                                         },
                                     );
                                 }
+                            }
+                            Err(ref e @ SaveError::Unrecoverable(_)) => {
+                                error!(
+                                    "[autosave] Unrecoverable save error, disabling autosave for {}: {}",
+                                    notebook_id, e
+                                );
+                                break;
                             }
                             Err(e) => {
                                 warn!("[autosave] Failed to save: {}", e);
@@ -6901,7 +6933,14 @@ mod tests {
         assert!(result.is_err());
         let error = result.unwrap_err();
         assert!(
-            error.contains("Relative paths are not supported"),
+            matches!(error, SaveError::Unrecoverable(_)),
+            "Error should be unrecoverable: {}",
+            error
+        );
+        assert!(
+            error
+                .to_string()
+                .contains("Relative paths are not supported"),
             "Error should mention relative paths: {}",
             error
         );


### PR DESCRIPTION
## Summary

- When `--attach <directory>` is used, the daemon now detects the directory early in `handle_open_notebook`, verifies it's writable, and delegates to `handle_create_notebook` with the directory as `working_dir` — creating an untitled notebook instead of entering a spin loop
- Introduces a typed `SaveError` enum (`Retryable` / `Unrecoverable`) for `save_notebook_to_disk` so the autosave loop can distinguish permanent failures (`IsADirectory`, `PermissionDenied`) from transient ones and break instead of retrying forever

Closes #1027

## Verification

- [ ] `cargo xtask notebook --attach /tmp/some-dir/` opens an untitled notebook (no spin loop in daemon logs)
- [ ] `--attach /path/to/existing.ipynb` still opens the existing notebook
- [ ] `--attach /path/to/new.ipynb` still creates a new notebook at that path
- [ ] `--attach /tmp/readonly-dir/` (no write perms) returns an error to the client
- [ ] Daemon logs show no "Is a directory" warnings

_PR submitted by @rgbkrk's agent, Quill_