### PR TITLE
fix(session): hydrate kernel state from RuntimeStateDoc after connect

### DIFF
--- a/crates/runtimed-py/src/async_session.rs
+++ b/crates/runtimed-py/src/async_session.rs
@@ -1097,9 +1097,10 @@ impl AsyncSession {
     /// Queue a cell for execution without waiting for the result.
     fn queue_cell<'py>(&self, py: Python<'py>, cell_id: &str) -> PyResult<Bound<'py, PyAny>> {
         let state = Arc::clone(&self.state);
+        let notebook_id = self.notebook_id.clone();
         let cell_id = cell_id.to_string();
         future_into_py(py, async move {
-            session_core::queue_cell(&state, &cell_id).await
+            session_core::queue_cell(&state, &notebook_id, &cell_id).await
         })
     }
 

--- a/crates/runtimed-py/src/session.rs
+++ b/crates/runtimed-py/src/session.rs
@@ -884,8 +884,11 @@ impl Session {
 
     /// Queue a cell for execution without waiting for the result.
     fn queue_cell(&self, cell_id: &str) -> PyResult<()> {
-        self.runtime
-            .block_on(session_core::queue_cell(&self.state, cell_id))
+        self.runtime.block_on(session_core::queue_cell(
+            &self.state,
+            &self.notebook_id,
+            cell_id,
+        ))
     }
 
     /// Stream execution events for a cell as an iterator.

--- a/crates/runtimed-py/src/session_core.rs
+++ b/crates/runtimed-py/src/session_core.rs
@@ -170,7 +170,29 @@ pub(crate) async fn connect_with_socket(
     st.blob_base_url = blob_base_url;
     st.blob_store_path = blob_store_path;
 
+    hydrate_kernel_state(&mut st);
+
     Ok(())
+}
+
+/// Populate `kernel_started`, `kernel_type`, and `env_source` from the
+/// RuntimeStateDoc (the daemon's source of truth for kernel status).
+///
+/// Best-effort: silently does nothing if the handle is missing or the
+/// runtime state can't be read (e.g. brand-new notebook with no state yet).
+fn hydrate_kernel_state(state: &mut SessionState) {
+    let Some(handle) = state.handle.as_ref() else {
+        return;
+    };
+    let Ok(rs) = handle.get_runtime_state() else {
+        return;
+    };
+    let running = matches!(rs.kernel.status.as_str(), "idle" | "busy" | "starting");
+    if running {
+        state.kernel_started = true;
+        state.kernel_type = Some(rs.kernel.language.clone());
+        state.env_source = Some(rs.kernel.env_source.clone());
+    }
 }
 
 /// Spawn a background task that listens for `RoomRenamed` broadcasts
@@ -225,7 +247,7 @@ pub(crate) async fn connect_open(
     // Sync settings from daemon (best-effort, don't fail if unavailable)
     let settings = sync_settings(socket_path).await;
 
-    let state = SessionState {
+    let mut state = SessionState {
         handle: Some(result.handle),
         broadcast_rx: Some(result.broadcast_rx),
         kernel_started: false,
@@ -239,6 +261,8 @@ pub(crate) async fn connect_open(
         peer_label: None, // Set by caller (Session/AsyncSession)
         actor_label: actor_label.map(String::from),
     };
+
+    hydrate_kernel_state(&mut state);
 
     Ok((notebook_id, state, connection_info))
 }
@@ -269,7 +293,7 @@ pub(crate) async fn connect_create(
     // Sync settings from daemon (best-effort, don't fail if unavailable)
     let settings = sync_settings(socket_path).await;
 
-    let state = SessionState {
+    let mut state = SessionState {
         handle: Some(result.handle),
         broadcast_rx: Some(result.broadcast_rx),
         kernel_started: false,
@@ -283,6 +307,8 @@ pub(crate) async fn connect_create(
         peer_label: None, // Set by caller (Session/AsyncSession)
         actor_label: actor_label.map(String::from),
     };
+
+    hydrate_kernel_state(&mut state);
 
     Ok((notebook_id, state, connection_info))
 }
@@ -336,8 +362,14 @@ pub(crate) async fn start_kernel(
             ..
         } => {
             st.kernel_started = true;
-            st.kernel_type = Some(actual_type);
+            st.kernel_type = Some(actual_type.clone());
             st.env_source = Some(actual_env);
+            if kernel_type != actual_type {
+                return Err(to_py_err(format!(
+                    "Kernel type mismatch: requested '{}' but '{}' is already running",
+                    kernel_type, actual_type
+                )));
+            }
             Ok(())
         }
         NotebookResponse::Error { error } => Err(to_py_err(error)),
@@ -405,7 +437,7 @@ pub(crate) async fn restart_kernel(
 
     // Clone handle and resubscribe broadcast_rx so we can release the lock
     // before the potentially long-running LaunchKernel request.
-    let (handle, resolved_path, mut progress_rx) = {
+    let (handle, resolved_path, relaunch_kernel_type, relaunch_env_source, mut progress_rx) = {
         let st = state.lock().await;
         let handle = st
             .handle
@@ -413,8 +445,13 @@ pub(crate) async fn restart_kernel(
             .ok_or_else(|| to_py_err("Not connected"))?
             .clone();
         let resolved_path = st.notebook_path.clone();
+        let kt = st
+            .kernel_type
+            .clone()
+            .unwrap_or_else(|| "python".to_string());
+        let es = st.env_source.clone().unwrap_or_else(|| "auto".to_string());
         let progress_rx = st.broadcast_rx.as_ref().map(|rx| rx.resubscribe());
-        (handle, resolved_path, progress_rx)
+        (handle, resolved_path, kt, es, progress_rx)
     };
     // Lock is now released — other operations can proceed.
 
@@ -423,8 +460,8 @@ pub(crate) async fn restart_kernel(
     let launch_timeout = std::time::Duration::from_secs(120);
 
     let launch_fut = handle.send_request(NotebookRequest::LaunchKernel {
-        kernel_type: "python".to_string(),
-        env_source: "auto".to_string(),
+        kernel_type: relaunch_kernel_type,
+        env_source: relaunch_env_source,
         notebook_path: resolved_path,
     });
 
@@ -1026,7 +1063,20 @@ pub(crate) async fn run(
 }
 
 /// Queue a cell for execution without waiting for the result.
-pub(crate) async fn queue_cell(state: &Arc<Mutex<SessionState>>, cell_id: &str) -> PyResult<()> {
+pub(crate) async fn queue_cell(
+    state: &Arc<Mutex<SessionState>>,
+    notebook_id: &str,
+    cell_id: &str,
+) -> PyResult<()> {
+    // Auto-start kernel if not running
+    {
+        let st = state.lock().await;
+        if !st.kernel_started {
+            drop(st);
+            ensure_kernel_started(state, notebook_id).await?;
+        }
+    }
+
     let response = {
         let st = state.lock().await;
 

--- a/crates/runtimed-py/src/session_core.rs
+++ b/crates/runtimed-py/src/session_core.rs
@@ -411,13 +411,20 @@ pub(crate) async fn restart_kernel(
     state: &Arc<Mutex<SessionState>>,
     wait_for_ready: bool,
 ) -> PyResult<Vec<String>> {
-    // Shutdown
-    {
+    // Capture kernel type/env before shutdown clears them, then shut down.
+    let (handle, resolved_path, relaunch_kernel_type, relaunch_env_source, mut progress_rx) = {
         let mut st = state.lock().await;
         let handle = st
             .handle
             .as_ref()
             .ok_or_else(|| to_py_err("Not connected"))?;
+
+        // Snapshot relaunch config before shutdown clears it
+        let kt = st
+            .kernel_type
+            .clone()
+            .unwrap_or_else(|| "python".to_string());
+        let es = st.env_source.clone().unwrap_or_else(|| "auto".to_string());
 
         let response = handle
             .send_request(NotebookRequest::ShutdownKernel {})
@@ -433,23 +440,13 @@ pub(crate) async fn restart_kernel(
             NotebookResponse::Error { error } => return Err(to_py_err(error)),
             _ => {}
         }
-    }
 
-    // Clone handle and resubscribe broadcast_rx so we can release the lock
-    // before the potentially long-running LaunchKernel request.
-    let (handle, resolved_path, relaunch_kernel_type, relaunch_env_source, mut progress_rx) = {
-        let st = state.lock().await;
         let handle = st
             .handle
             .as_ref()
             .ok_or_else(|| to_py_err("Not connected"))?
             .clone();
         let resolved_path = st.notebook_path.clone();
-        let kt = st
-            .kernel_type
-            .clone()
-            .unwrap_or_else(|| "python".to_string());
-        let es = st.env_source.clone().unwrap_or_else(|| "auto".to_string());
         let progress_rx = st.broadcast_rx.as_ref().map(|rx| rx.resubscribe());
         (handle, resolved_path, kt, es, progress_rx)
     };


### PR DESCRIPTION
## Summary

After `connect_open()`, `connect_create()`, or `connect_with_socket()`, `Session.kernel_started` / `kernel_type` / `env_source` were always `false`/`None` — even when the daemon had already auto-launched a kernel. This caused callers to redundantly call `start_kernel()`, which silently succeeded via `KernelAlreadyRunning` (potentially with the wrong kernel type).

This PR adds a `hydrate_kernel_state()` helper that reads the RuntimeStateDoc (the daemon's source of truth) at connect time and populates Session state accordingly. It also fixes three related issues:

- **`start_kernel()` now errors on type mismatch** — requesting `"typescript"` when `"python"` is already running returns an error instead of silently succeeding
- **`restart_kernel()` preserves current kernel type** — no longer hardcodes `"python"` / `"auto"`
- **`queue_cell()` gains `ensure_kernel_started` guard** — matching the existing behavior in `execute_cell()` and `stream_execute()`

Closes #1018

## Verification

- [ ] `open_notebook()` a trusted notebook → `session.kernel_started` is `True` and `session.get_runtime_state().kernel.language` matches `session.kernel_type`
- [ ] `start_kernel("typescript")` when Python is already running → raises error with mismatch message
- [ ] `restart_kernel()` on a non-Python kernel → relaunches same kernel type
- [ ] `queue_cell()` on a fresh session with no kernel → auto-starts kernel (same as `execute_cell()`)

_PR submitted by @rgbkrk's agent, Quill_