### PR TITLE
fix(python): add missing CellHandle properties and harden deleted-cell behavior

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,13 +75,14 @@ python/runtimed/.venv/bin/python -m pytest python/runtimed/tests/test_session_un
 
 ### Running the notebook app (dev mode)
 
-With supervisor tools:
+**Do not launch the notebook app from an agent terminal.** The app is a GUI process that blocks until the user quits it (⌘Q), and the agent will misinterpret the exit. Let the human launch it from their own terminal or Zed task.
+
+With supervisor tools, the daemon and vite are already managed — the human just runs:
 ```bash
-# Daemon is already managed — just launch the app
 cargo xtask notebook
 ```
 
-Without supervisor (two terminals):
+Without supervisor (human runs both):
 ```bash
 # Terminal 1: Start dev daemon
 cargo xtask dev-daemon

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,23 @@ This document provides guidance for AI agents working in this repository. Claude
 
 ## Quick Recipes (Common Dev Tasks)
 
-These are copy-paste-ready commands. **All commands that interact with the dev daemon require two env vars.** Without them you'll hit the system daemon and cause problems.
+### If you have `supervisor_*` tools — use them
+
+If your MCP client provides `supervisor_status`, `supervisor_restart`, `supervisor_rebuild`, etc., **prefer those over manual terminal commands**. The supervisor manages the dev daemon lifecycle for you — no env vars, no extra terminals.
+
+| Instead of… | Use… |
+|-------------|------|
+| `cargo xtask dev-daemon` (in a terminal) | `supervisor_restart(target="daemon")` |
+| `maturin develop` (rebuild bindings) | `supervisor_rebuild` |
+| `runt daemon status` (with env vars) | `supervisor_status` |
+| `runt daemon logs` | `supervisor_logs` |
+| `cargo xtask vite` | `supervisor_start_vite` |
+
+The supervisor automatically handles per-worktree isolation, env var plumbing, and daemon restarts. You only need the manual commands below when the supervisor isn't available.
+
+### Manual commands (when supervisor is not available)
+
+All commands that interact with the dev daemon require two env vars. Without them you'll hit the system daemon and cause problems.
 
 ```bash
 # ── Dev daemon env vars (required for ALL dev commands) ────────────
@@ -59,6 +75,13 @@ python/runtimed/.venv/bin/python -m pytest python/runtimed/tests/test_session_un
 
 ### Running the notebook app (dev mode)
 
+With supervisor tools:
+```bash
+# Daemon is already managed — just launch the app
+cargo xtask notebook
+```
+
+Without supervisor (two terminals):
 ```bash
 # Terminal 1: Start dev daemon
 cargo xtask dev-daemon
@@ -183,10 +206,10 @@ The supervisor watches `python/nteract/src/`, `python/runtimed/src/`, `crates/ru
 
 ### Tool availability
 
-- **Inkwell active** → all supervisor + nteract tools available
-- **nteract MCP only** → nteract tools only, no `supervisor_*`
+- **Inkwell active** → all supervisor + nteract tools available. **Prefer supervisor tools for daemon lifecycle** — they handle env vars and isolation automatically.
+- **nteract MCP only** → nteract tools only, no `supervisor_*`. Use manual terminal commands for daemon management.
 - **No MCP server** → use `cargo xtask run-mcp` to set one up
-- **Dev daemon not running** → Inkwell starts it automatically
+- **Dev daemon not running** → Inkwell starts it automatically via `supervisor_restart(target="daemon")`
 
 ## Build System (`cargo xtask`)
 
@@ -206,7 +229,9 @@ Use instead:
 
 ### Per-Worktree Daemon Isolation
 
-Each git worktree runs its own isolated daemon in dev mode.
+Each git worktree runs its own isolated daemon in dev mode. If you have supervisor tools, the daemon is managed for you — use `supervisor_restart(target="daemon")` to start or restart it, and `supervisor_status` to check it.
+
+Without supervisor (manual two-terminal workflow):
 
 ```bash
 # Terminal 1: Start dev daemon
@@ -216,7 +241,7 @@ cargo xtask dev-daemon
 cargo xtask notebook
 ```
 
-Use `./target/debug/runt` to interact with the worktree daemon:
+Use `./target/debug/runt` to interact with the worktree daemon (or `supervisor_status`/`supervisor_logs` if available):
 
 ```bash
 ./target/debug/runt daemon status

--- a/contributing/development.md
+++ b/contributing/development.md
@@ -166,7 +166,18 @@ In production, the Tauri app auto-installs and manages the system daemon. In dev
 - Your code changes take effect immediately on daemon restart
 - No interference with the system daemon
 
-**Two-terminal workflow:**
+**With Inkwell supervisor (preferred for agents):**
+
+If you have `supervisor_*` MCP tools available (e.g. in Zed with `mcp-supervisor`), the daemon is managed for you:
+
+- `supervisor_restart(target="daemon")` — start or restart the dev daemon
+- `supervisor_status` — check daemon status (includes `daemon_managed: true/false`)
+- `supervisor_rebuild` — rebuild Python bindings + restart
+- `supervisor_logs` — tail daemon logs
+
+No env vars or extra terminals needed. The supervisor handles per-worktree isolation automatically.
+
+**Two-terminal workflow (without supervisor):**
 
 ```bash
 # Terminal 1: Start the dev daemon (stays running)
@@ -205,7 +216,7 @@ RUNTIMED_DEV=1 cargo xtask notebook
 
 Per-worktree state is stored in `<cache>/runt-nightly/worktrees/{hash}/` (macOS: `~/Library/Caches/`, Linux: `~/.cache/`).
 
-**For AI agents:** Use `./target/debug/runt` directly to interact with the daemon. See the "Agent Access to Dev Daemon" section in CLAUDE.md. When using a raw terminal (not Zed tasks), set the env vars manually:
+**For AI agents:** If `supervisor_*` tools are available, prefer those — they handle env vars and daemon lifecycle automatically. Otherwise, use `./target/debug/runt` directly (see "Agent Access to Dev Daemon" in CLAUDE.md). When using a raw terminal (not Zed tasks), set the env vars manually:
 
 ```bash
 export RUNTIMED_DEV=1

--- a/contributing/runtimed.md
+++ b/contributing/runtimed.md
@@ -83,7 +83,26 @@ cat ~/.cache/runt/daemon.json   # check "version" field
 
 ### Fast iteration: Daemon + bundled notebook
 
-When iterating on daemon code, you often want to test changes in the notebook app without rebuilding the frontend:
+When iterating on daemon code, you often want to test changes in the notebook app without rebuilding the frontend.
+
+**With Inkwell supervisor** (if you have `supervisor_*` MCP tools — e.g. in Zed):
+
+The supervisor manages the dev daemon for you. No env vars or extra terminals needed.
+
+- `supervisor_restart(target="daemon")` — start or restart the dev daemon after code changes
+- `supervisor_rebuild` — rebuild Python bindings (`maturin develop`) + restart
+- `supervisor_status` — check daemon status (`daemon_managed: true` confirms it's running)
+- `supervisor_logs` — tail daemon logs
+- `supervisor_start_vite` — start the Vite dev server for hot-reload
+
+Then build and run the app normally:
+```bash
+cargo xtask build                 # Full build (includes frontend)
+cargo xtask build --rust-only     # Fast rebuild (reuses frontend assets)
+cargo xtask run                   # Run the bundled binary
+```
+
+**Without supervisor** (manual two-terminal workflow):
 
 ```bash
 # Terminal 1: Run dev daemon (restart when you change daemon code)

--- a/python/runtimed/src/runtimed/_cell.py
+++ b/python/runtimed/src/runtimed/_cell.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import json
 from typing import TYPE_CHECKING, Any
+
+from runtimed.runtimed import RuntimedError as _RuntimedError
 
 if TYPE_CHECKING:
     from runtimed.runtimed import AsyncSession, Cell, ExecutionResult, Output
@@ -40,7 +43,7 @@ class CellHandle:
         try:
             cell = self._session.get_cell_sync(self._id)
             return cell.outputs
-        except Exception:
+        except _RuntimedError:
             return []
 
     @property
@@ -57,37 +60,36 @@ class CellHandle:
     @property
     def metadata(self) -> Any:
         """Parsed metadata dict (sync read)."""
+        raw = self._session.get_cell_metadata_sync(self._id)
+        if raw is None:
+            return {}
         try:
-            cell = self._session.get_cell_sync(self._id)
-            return cell.metadata
-        except Exception:
+            return json.loads(raw)
+        except (json.JSONDecodeError, TypeError):
             return {}
 
     @property
     def tags(self) -> list[str]:
-        """Cell tags (sync read)."""
+        """Cell tags (sync read). Uses Rust Cell helpers for key resolution."""
         try:
-            cell = self._session.get_cell_sync(self._id)
-            return cell.tags
-        except Exception:
+            return self._session.get_cell_sync(self._id).tags
+        except _RuntimedError:
             return []
 
     @property
     def is_source_hidden(self) -> bool:
-        """Whether cell source is hidden (sync read)."""
+        """Whether cell source is hidden (sync read). Uses Rust Cell helpers."""
         try:
-            cell = self._session.get_cell_sync(self._id)
-            return cell.is_source_hidden
-        except Exception:
+            return self._session.get_cell_sync(self._id).is_source_hidden
+        except _RuntimedError:
             return False
 
     @property
     def is_outputs_hidden(self) -> bool:
-        """Whether cell outputs are hidden (sync read)."""
+        """Whether cell outputs are hidden (sync read). Uses Rust Cell helpers."""
         try:
-            cell = self._session.get_cell_sync(self._id)
-            return cell.is_outputs_hidden
-        except Exception:
+            return self._session.get_cell_sync(self._id).is_outputs_hidden
+        except _RuntimedError:
             return False
 
     def snapshot(self) -> Cell:

--- a/python/runtimed/src/runtimed/_cell.py
+++ b/python/runtimed/src/runtimed/_cell.py
@@ -37,8 +37,11 @@ class CellHandle:
     @property
     def outputs(self) -> list[Output]:
         """Resolved outputs (sync — may do disk I/O for blob resolution)."""
-        cell = self._session.get_cell_sync(self._id)
-        return cell.outputs
+        try:
+            cell = self._session.get_cell_sync(self._id)
+            return cell.outputs
+        except Exception:
+            return []
 
     @property
     def execution_count(self) -> int | None:
@@ -54,8 +57,38 @@ class CellHandle:
     @property
     def metadata(self) -> Any:
         """Parsed metadata dict (sync read)."""
-        cell = self._session.get_cell_sync(self._id)
-        return cell.metadata
+        try:
+            cell = self._session.get_cell_sync(self._id)
+            return cell.metadata
+        except Exception:
+            return {}
+
+    @property
+    def tags(self) -> list[str]:
+        """Cell tags (sync read)."""
+        try:
+            cell = self._session.get_cell_sync(self._id)
+            return cell.tags
+        except Exception:
+            return []
+
+    @property
+    def is_source_hidden(self) -> bool:
+        """Whether cell source is hidden (sync read)."""
+        try:
+            cell = self._session.get_cell_sync(self._id)
+            return cell.is_source_hidden
+        except Exception:
+            return False
+
+    @property
+    def is_outputs_hidden(self) -> bool:
+        """Whether cell outputs are hidden (sync read)."""
+        try:
+            cell = self._session.get_cell_sync(self._id)
+            return cell.is_outputs_hidden
+        except Exception:
+            return False
 
     def snapshot(self) -> Cell:
         """Return the full Cell object (sync — includes resolved outputs)."""

--- a/python/runtimed/src/runtimed/_notebook_info.py
+++ b/python/runtimed/src/runtimed/_notebook_info.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from runtimed._client import Client
     from runtimed._notebook import Notebook
 
 
@@ -43,7 +44,7 @@ class NotebookInfo:
         """True if this notebook has no backing file."""
         return self.path is None
 
-    async def join(self, client: Any, peer_label: str | None = None) -> Notebook:
+    async def join(self, client: Client, peer_label: str | None = None) -> Notebook:
         """Join this room and return a Notebook."""
         return await client.join(self.notebook_id, peer_label=peer_label)
 

--- a/python/runtimed/tests/test_session_unit.py
+++ b/python/runtimed/tests/test_session_unit.py
@@ -46,22 +46,40 @@ class TestModuleExports:
         assert not hasattr(runtimed, "DaemonClient")
 
     def test_all_exports(self):
-        """Check __all__ exports the expected items."""
-        expected = [
+        """Check __all__ exports match expected items exactly."""
+        expected = {
+            # Primary API
             "Client",
             "Notebook",
             "NotebookInfo",
             "CellHandle",
             "CellCollection",
+            # Data types
+            "Cell",
+            "CompletionItem",
+            "CompletionResult",
+            "ExecutionEvent",
             "ExecutionResult",
+            "HistoryEntry",
+            "NotebookConnectionInfo",
             "Output",
+            "QueueState",
             "RuntimedError",
+            "SyncEnvironmentResult",
+            # Runtime state
             "RuntimeState",
             "KernelState",
             "EnvState",
-        ]
-        for name in expected:
-            assert name in runtimed.__all__, f"{name} not in __all__"
+            # Standalone functions
+            "default_socket_path",
+            "show_notebook_app",
+            # Native types (advanced)
+            "NativeAsyncClient",
+            "NativeClient",
+            "AsyncSession",
+            "Session",
+        }
+        assert set(runtimed.__all__) == expected
 
 
 class TestOutputTypes:


### PR DESCRIPTION
Audit fixes for #1030.

### Changes

**CellHandle: add missing sync properties**
- `tags`, `is_source_hidden`, `is_outputs_hidden` — these exist on `Cell` (snapshot) and have corresponding setters on `AsyncSession`, but weren't exposed as sync reads on `CellHandle`

**CellHandle: consistent deleted-cell behavior**
- `source`/`cell_type`/`execution_count` silently return defaults when the cell is deleted, but `outputs`/`metadata` raised `RuntimedError`. Now all properties return sensible defaults (`[]`, `{}`) instead of raising.
- `snapshot()` still raises — that's intentional since the caller explicitly asked for the full `Cell` object

**NotebookInfo: fix `join()` typing**
- `client: Any` → `client: Client` via `TYPE_CHECKING` import

**Unit tests: exact `__all__` match**
- `test_all_exports` checked 11 of 27 items with a subset assertion. Now does `set(runtimed.__all__) == expected` so drift is caught.

### Audit notes (not in this PR)

- `Notebook.run()` creates a cell and leaves it — documented behavior, matches `Session.run()`
- `start_kernel`/`shutdown_kernel` already added to `Notebook` upstream in `7a7f2611`
- `CellHandle.outputs` calls `get_cell_sync()` which may do blob I/O on every access — inherent to blob-backed architecture, docstring warns about it
- MCP server correctly uses `NativeAsyncClient` + `AsyncSession` directly, unaffected by wrapper renames

_PR submitted by @rgbkrk's agent Quill, via Zed_