### PR TITLE
fix(python): remove Notebook.run() — ambiguous semantics

### DIFF
--- a/contributing/runtimed.md
+++ b/contributing/runtimed.md
@@ -299,11 +299,11 @@ import runtimed
 async def main():
     client = runtimed.Client()
     async with await client.create() as notebook:
-        # Execute code
-        result = await notebook.run("print('hello')")
+        # Work with cells
+        cell = await notebook.cells.create("print('hello')")
+        result = await cell.run()
         print(result.stdout)  # "hello\n"
 
-        # Work with cells
         cell = await notebook.cells.create("x = 42")
         await cell.run()
 

--- a/docs/python-bindings.md
+++ b/docs/python-bindings.md
@@ -109,8 +109,9 @@ async with await client.create() as notebook:
     path = await notebook.save()
     path = await notebook.save("/tmp/copy.ipynb")
 
-    # Quick execution (create cell + execute + return result)
-    result = await notebook.run("print('hello')")
+    # Execute code
+    cell = await notebook.cells.create("print('hello')")
+    result = await cell.run()
 # Session closed automatically on exit
 ```
 
@@ -171,7 +172,7 @@ await cell.queue()  # fire-and-forget
 
 ### ExecutionResult
 
-Returned by `cell.run()` or `notebook.run()`:
+Returned by `cell.run()`:
 
 ```python
 result = await cell.run()
@@ -254,7 +255,8 @@ async def multi_client_demo():
     nb2 = await client.join(nb1.notebook_id)
     print(len(nb2.cells))  # 1 — synced from nb1
 
-    result = await nb2.run("print(x)")
+    cell2 = await nb2.cells.create("print(x)")
+    result = await cell2.run()
     print(result.stdout)  # "42\n" — shared kernel state
 ```
 

--- a/python/runtimed/src/runtimed/_notebook.py
+++ b/python/runtimed/src/runtimed/_notebook.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 from runtimed._cell import CellCollection
 
 if TYPE_CHECKING:
-    from runtimed.runtimed import AsyncSession, ExecutionResult
+    from runtimed.runtimed import AsyncSession
 
 
 class Notebook:
@@ -47,10 +47,6 @@ class Notebook:
         return self._session.get_peers_sync()
 
     # ── Async operations ─────────────────────────────────────────────
-
-    async def run(self, code: str, timeout_secs: float = 60.0) -> ExecutionResult:
-        """Create a cell, execute it, and return the result."""
-        return await self._session.run(code, timeout_secs)
 
     async def save(self, path: str | None = None) -> str:
         """Save the notebook to disk. Returns the path saved to."""


### PR DESCRIPTION
Remove `Notebook.run()` from the high-level API.

`notebook.run(code)` creates a persistent cell as a side effect and the name is ambiguous — could mean "run all cells" to anyone familiar with Jupyter. The explicit two-step is clearer:

```python
cell = await notebook.cells.create("print('hello')")
result = await cell.run()
```

`Session.run()` / `AsyncSession.run()` / `session_core::run` are kept — they're session-level primitives used throughout integration tests.

_PR submitted by @rgbkrk's agent Quill, via Zed_