### PR TITLE
chore(python): clean up stale references and dead tests

### DIFF
--- a/crates/runtimed-py/src/lib.rs
+++ b/crates/runtimed-py/src/lib.rs
@@ -1,9 +1,9 @@
 //! Python bindings for runtimed daemon client.
 //!
 //! Provides Python classes for:
-//! - `DaemonClient`: Low-level daemon operations (status, ping, list rooms)
-//! - `Session`: Synchronous code execution with kernel management
-//! - `AsyncSession`: Async code execution with kernel management
+//! - `NativeClient`/`NativeAsyncClient`: Daemon operations (status, ping, list active notebooks)
+//! - `Session`: Synchronous notebook interaction with kernel management
+//! - `AsyncSession`: Async notebook interaction with kernel management
 //! - `ExecutionEventStream`: Async iterator over execution events
 //! - `ExecutionEventIterator`: Sync iterator over execution events
 //!

--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -427,7 +427,7 @@ def daemon_process():
 
         # Wait for pools to warm up before running tests.
         # We poll the daemon log file for pool-ready messages since
-        # DaemonClient uses default_socket_path() which doesn't respect
+        # NativeClient uses default_socket_path() which doesn't respect
         # RUNTIMED_SOCKET_PATH for CI mode.
         uv_ready = False
         conda_ready = False
@@ -2591,16 +2591,6 @@ class TestPresence:
         )
 
     @pytest.mark.asyncio
-    async def test_set_cursor_not_connected_raises(self):
-        """set_cursor raises when not connected."""
-        pytest.skip("AsyncSession() constructor removed — sessions always pre-connected")
-
-    @pytest.mark.asyncio
-    async def test_set_selection_not_connected_raises(self):
-        """set_selection raises when not connected."""
-        pytest.skip("AsyncSession() constructor removed — sessions always pre-connected")
-
-    @pytest.mark.asyncio
     async def test_presence_with_two_peers(self, two_async_sessions):
         """Both peers can send presence without error."""
         s1, s2 = two_async_sessions
@@ -2667,16 +2657,6 @@ class TestPresence:
         """Can query remote cursors via AsyncSession."""
         cursors = await async_session.get_remote_cursors()
         assert isinstance(cursors, list)
-
-    @pytest.mark.asyncio
-    async def test_get_peers_not_connected_raises(self):
-        """get_peers raises when not connected."""
-        pytest.skip("AsyncSession() constructor removed — sessions always pre-connected")
-
-    @pytest.mark.asyncio
-    async def test_get_remote_cursors_not_connected_raises(self):
-        """get_remote_cursors raises when not connected."""
-        pytest.skip("AsyncSession() constructor removed — sessions always pre-connected")
 
 
 if __name__ == "__main__":

--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -427,8 +427,7 @@ def daemon_process():
 
         # Wait for pools to warm up before running tests.
         # We poll the daemon log file for pool-ready messages since
-        # NativeClient uses default_socket_path() which doesn't respect
-        # RUNTIMED_SOCKET_PATH for CI mode.
+        # a reachable socket doesn't guarantee pools are warmed.
         uv_ready = False
         conda_ready = False
         import re


### PR DESCRIPTION
Second audit pass on the Python API.

### Changes

**Stale doc comment in `lib.rs`**
- `DaemonClient` → `NativeClient`/`NativeAsyncClient`
- "list rooms" → "list active notebooks"

**Dead tests removed**
- 4 unconditionally-skipped presence tests that tested a removed `AsyncSession()` constructor — they can never pass or fail, just noise

**Stale comment in integration tests**
- `DaemonClient` reference in pool warmup comment → `NativeClient`

### Audit findings (no action needed)

- **Type stubs are accurate** — every `#[pymethods]` block, `#[getter]`, `#[pyo3(signature)]`, `#[pyclass(name)]` rename, and `future_into_py` vs direct-return distinction is correctly reflected in `.pyi` stubs
- **`__all__` (25 items) matches test expected set exactly**
- **Demos and README are clean** — no stale API references
- **`Session.run()` in integration tests is valid** — it's the native Rust method, not the removed `Notebook.run()`
- **High-level wrappers (`Notebook`/`CellHandle`/`CellCollection`) have no integration test coverage** — all tests go through `Session`/`AsyncSession` directly. Worth adding in a follow-up but not blocking the redesign merge.

_PR submitted by @rgbkrk's agent Quill, via Zed_