### PR TITLE
refactor(python): use runtime terminology in user-facing API

### DIFF
--- a/contributing/runtimed.md
+++ b/contributing/runtimed.md
@@ -298,7 +298,7 @@ import runtimed
 
 async def main():
     client = runtimed.Client()
-    async with await client.create() as notebook:
+    async with await client.create_notebook() as notebook:
         # Work with cells
         cell = await notebook.cells.create("print('hello')")
         result = await cell.run()

--- a/docs/python-bindings.md
+++ b/docs/python-bindings.md
@@ -61,7 +61,7 @@ client = runtimed.Client()
 # Discover active notebooks
 notebooks = await client.list_active_notebooks()
 for info in notebooks:
-    print(f"{info.name} [{info.kernel_status}] ({info.active_peers} peers)")
+    print(f"{info.name} [{info.status}] ({info.active_peers} peers)")
 
 # Open, create, or join notebooks
 notebook = await client.open("/path/to/notebook.ipynb")
@@ -98,12 +98,12 @@ async with await client.create() as notebook:
     print(notebook.runtime.kernel.status)
     print(notebook.peers)
 
-    # Kernel lifecycle
-    await notebook.start_kernel(kernel_type="python")
-    await notebook.start_kernel(kernel_type="deno")
-    await notebook.restart_kernel()
+    # Runtime lifecycle
+    await notebook.start(runtime="python")
+    await notebook.start(runtime="deno")
+    await notebook.restart()
     await notebook.interrupt()
-    await notebook.shutdown_kernel()
+    await notebook.shutdown()
 
     # Save
     path = await notebook.save()

--- a/docs/python-bindings.md
+++ b/docs/python-bindings.md
@@ -43,7 +43,7 @@ import runtimed
 
 async def main():
     client = runtimed.Client()
-    async with await client.create() as notebook:
+    async with await client.create_notebook() as notebook:
         cell = await notebook.cells.create("print('hello')")
         result = await cell.run()
         print(result.stdout)  # "hello\n"
@@ -64,9 +64,9 @@ for info in notebooks:
     print(f"{info.name} [{info.status}] ({info.active_peers} peers)")
 
 # Open, create, or join notebooks
-notebook = await client.open("/path/to/notebook.ipynb")
-notebook = await client.create(runtime="python")
-notebook = await client.join(notebook_id)
+notebook = await client.open_notebook("/path/to/notebook.ipynb")
+notebook = await client.create_notebook(runtime="python")
+notebook = await client.join_notebook(notebook_id)
 
 # Health checks
 await client.ping()        # True if daemon responding
@@ -86,7 +86,7 @@ await client.shutdown()    # Stop the daemon
 A `Notebook` wraps a connected session. Properties are **sync reads** from the local Automerge replica. Methods are **async writes** that sync to peers.
 
 ```python
-async with await client.create() as notebook:
+async with await client.create_notebook() as notebook:
     print(notebook.notebook_id)
 
     # Cells collection (sync reads, async writes)
@@ -247,12 +247,12 @@ async def multi_client_demo():
     client = runtimed.Client()
 
     # Client 1 creates a notebook and executes code
-    nb1 = await client.create()
+    nb1 = await client.create_notebook()
     cell = await nb1.cells.create("x = 42")
     await cell.run()
 
     # Client 2 joins the same notebook, sees the cell, shares the kernel
-    nb2 = await client.join(nb1.notebook_id)
+    nb2 = await client.join_notebook(nb1.notebook_id)
     print(len(nb2.cells))  # 1 — synced from nb1
 
     cell2 = await nb2.cells.create("print(x)")

--- a/python/runtimed/README.md
+++ b/python/runtimed/README.md
@@ -20,7 +20,7 @@ import runtimed
 
 async def main():
     client = runtimed.Client()
-    notebook = await client.create()
+    notebook = await client.create_notebook()
 
     # Create and execute cells
     cell = await notebook.cells.create("print('hello')")
@@ -61,15 +61,15 @@ for info in notebooks:
     print(f"{info.name} [{info.status}] ({info.active_peers} peers)")
 
 # Open, create, or join notebooks
-notebook = await client.open("/path/to/notebook.ipynb")
-notebook = await client.create(runtime="python")
-notebook = await client.join(notebook_id)
+notebook = await client.open_notebook("/path/to/notebook.ipynb")
+notebook = await client.create_notebook(runtime="python")
+notebook = await client.join_notebook(notebook_id)
 ```
 
 ### Notebook
 
 ```python
-async with await client.create() as notebook:
+async with await client.create_notebook() as notebook:
     # Cells collection (sync reads, async writes)
     print(len(notebook.cells))
     for cell in notebook.cells:

--- a/python/runtimed/README.md
+++ b/python/runtimed/README.md
@@ -58,7 +58,7 @@ client = runtimed.Client()
 # Discover active notebooks
 notebooks = await client.list_active_notebooks()
 for info in notebooks:
-    print(f"{info.name} [{info.kernel_status}] ({info.active_peers} peers)")
+    print(f"{info.name} [{info.status}] ({info.active_peers} peers)")
 
 # Open, create, or join notebooks
 notebook = await client.open("/path/to/notebook.ipynb")
@@ -78,9 +78,9 @@ async with await client.create() as notebook:
     # Runtime state (sync read from local doc)
     print(notebook.runtime.kernel.status)
 
-    # Kernel lifecycle
-    await notebook.start_kernel(kernel_type="python")
-    await notebook.restart_kernel()
+    # Runtime lifecycle
+    await notebook.start(runtime="python")
+    await notebook.restart()
     await notebook.interrupt()
     await notebook.save()
 # Session closed automatically on exit

--- a/python/runtimed/src/runtimed/_cell.py
+++ b/python/runtimed/src/runtimed/_cell.py
@@ -77,7 +77,7 @@ class CellHandle:
             return []
 
     @property
-    def is_source_hidden(self) -> bool:
+    def source_hidden(self) -> bool:
         """Whether cell source is hidden (sync read). Uses Rust Cell helpers."""
         try:
             return self._session.get_cell_sync(self._id).is_source_hidden
@@ -85,7 +85,7 @@ class CellHandle:
             return False
 
     @property
-    def is_outputs_hidden(self) -> bool:
+    def outputs_hidden(self) -> bool:
         """Whether cell outputs are hidden (sync read). Uses Rust Cell helpers."""
         try:
             return self._session.get_cell_sync(self._id).is_outputs_hidden

--- a/python/runtimed/src/runtimed/_client.py
+++ b/python/runtimed/src/runtimed/_client.py
@@ -16,7 +16,7 @@ class Client:
     Example::
 
         client = Client()
-        notebook = await client.create()
+        notebook = await client.create_notebook()
         cell = await notebook.cells.create("print('hello')")
         print(cell.source)   # sync read
         result = await cell.run()  # async
@@ -34,12 +34,12 @@ class Client:
         raw = await self._native.list_active_notebooks()
         return [NotebookInfo._from_dict(d) for d in raw]
 
-    async def open(self, path: str, peer_label: str | None = None) -> Notebook:
+    async def open_notebook(self, path: str, peer_label: str | None = None) -> Notebook:
         """Open an existing notebook file and return a connected Notebook."""
         session = await self._native.open_notebook(path, peer_label)
         return Notebook(session)
 
-    async def create(
+    async def create_notebook(
         self,
         runtime: str = "python",
         working_dir: str | None = None,
@@ -49,7 +49,7 @@ class Client:
         session = await self._native.create_notebook(runtime, working_dir, peer_label)
         return Notebook(session)
 
-    async def join(self, notebook_id: str, peer_label: str | None = None) -> Notebook:
+    async def join_notebook(self, notebook_id: str, peer_label: str | None = None) -> Notebook:
         """Join an existing notebook room by ID."""
         session = await self._native.join_notebook(notebook_id, peer_label)
         return Notebook(session)

--- a/python/runtimed/src/runtimed/_notebook.py
+++ b/python/runtimed/src/runtimed/_notebook.py
@@ -13,7 +13,8 @@ if TYPE_CHECKING:
 class Notebook:
     """A connected notebook with sync reads and async writes.
 
-    Created by ``Client.open()``, ``Client.create()``, or ``Client.join()``.
+    Created by ``Client.open_notebook()``, ``Client.create_notebook()``,
+    or ``Client.join_notebook()``.
 
     Properties read from the local Automerge replica (sync).
     Mutation methods are async (synced to peers).

--- a/python/runtimed/src/runtimed/_notebook.py
+++ b/python/runtimed/src/runtimed/_notebook.py
@@ -52,27 +52,27 @@ class Notebook:
         """Save the notebook to disk. Returns the path saved to."""
         return await self._session.save(path)
 
-    async def start_kernel(
+    async def start(
         self,
-        kernel_type: str = "python",
+        runtime: str = "python",
         env_source: str = "auto",
         notebook_path: str | None = None,
     ) -> None:
-        """Start a kernel in this notebook.
+        """Start a runtime for this notebook.
 
         Args:
-            kernel_type: Kernel runtime type (e.g. "python", "deno").
+            runtime: Runtime type (e.g. "python", "deno").
             env_source: Environment source (e.g. "auto", "uv:inline").
             notebook_path: Optional path for project file detection.
         """
-        await self._session.start_kernel(kernel_type, env_source, notebook_path)
+        await self._session.start_kernel(runtime, env_source, notebook_path)
 
-    async def shutdown_kernel(self) -> None:
-        """Shut down the kernel (daemon manages cleanup on last peer disconnect)."""
+    async def shutdown(self) -> None:
+        """Shut down the runtime."""
         await self._session.shutdown_kernel()
 
-    async def restart_kernel(self, wait_for_ready: bool = True) -> list[str]:
-        """Restart the kernel. Returns progress messages."""
+    async def restart(self, wait_for_ready: bool = True) -> list[str]:
+        """Restart the runtime. Returns progress messages."""
         return await self._session.restart_kernel(wait_for_ready)
 
     async def interrupt(self) -> None:

--- a/python/runtimed/src/runtimed/_notebook_info.py
+++ b/python/runtimed/src/runtimed/_notebook_info.py
@@ -46,7 +46,7 @@ class NotebookInfo:
 
     async def join(self, client: Client, peer_label: str | None = None) -> Notebook:
         """Join this room and return a Notebook."""
-        return await client.join(self.notebook_id, peer_label=peer_label)
+        return await client.join_notebook(self.notebook_id, peer_label=peer_label)
 
     @classmethod
     def _from_dict(cls, d: dict[str, Any]) -> NotebookInfo:

--- a/python/runtimed/src/runtimed/_notebook_info.py
+++ b/python/runtimed/src/runtimed/_notebook_info.py
@@ -19,10 +19,10 @@ class NotebookInfo:
     """
 
     notebook_id: str
-    kernel_type: str | None = None
-    kernel_status: str | None = None
+    runtime_type: str | None = None
+    status: str | None = None
     active_peers: int = 0
-    has_kernel: bool = False
+    has_runtime: bool = False
     env_source: str | None = None
 
     @property
@@ -53,14 +53,14 @@ class NotebookInfo:
         """Construct from the dict returned by NativeAsyncClient.list_active_notebooks()."""
         return cls(
             notebook_id=d["notebook_id"],
-            kernel_type=d.get("kernel_type"),
-            kernel_status=d.get("kernel_status"),
+            runtime_type=d.get("kernel_type"),
+            status=d.get("kernel_status"),
             active_peers=int(d.get("active_peers", 0)),
-            has_kernel=bool(d.get("has_kernel", False)),
+            has_runtime=bool(d.get("has_kernel", False)),
             env_source=d.get("env_source"),
         )
 
     def __repr__(self) -> str:
-        status = f" [{self.kernel_status}]" if self.kernel_status else ""
+        status_str = f" [{self.status}]" if self.status else ""
         peers = f" ({self.active_peers} peers)" if self.active_peers else ""
-        return f"NotebookInfo({self.name!r}{status}{peers})"
+        return f"NotebookInfo({self.name!r}{status_str}{peers})"

--- a/python/runtimed/tests/test_session_unit.py
+++ b/python/runtimed/tests/test_session_unit.py
@@ -131,14 +131,14 @@ class TestNotebookInfo:
         assert info.path is not None
         assert not info.is_ephemeral
         assert info.active_peers == 2
-        assert info.has_kernel is True
+        assert info.has_runtime is True
 
     def test_from_dict_ephemeral(self):
         info = runtimed.NotebookInfo._from_dict(
             {
                 "notebook_id": "abc123",
                 "active_peers": 0,
-                "has_kernel": False,
+                "has_runtime": False,
             }
         )
         assert info.name == "abc123"
@@ -148,7 +148,7 @@ class TestNotebookInfo:
     def test_repr(self):
         info = runtimed.NotebookInfo(
             notebook_id="/test/gremlins.ipynb",
-            kernel_status="idle",
+            status="idle",
             active_peers=3,
         )
         r = repr(info)

--- a/python/runtimed/tests/test_session_unit.py
+++ b/python/runtimed/tests/test_session_unit.py
@@ -138,12 +138,13 @@ class TestNotebookInfo:
             {
                 "notebook_id": "abc123",
                 "active_peers": 0,
-                "has_runtime": False,
+                "has_kernel": False,
             }
         )
         assert info.name == "abc123"
         assert info.path is None
         assert info.is_ephemeral is True
+        assert info.has_runtime is False
 
     def test_repr(self):
         info = runtimed.NotebookInfo(


### PR DESCRIPTION
Use runtime terminology in the user-facing Python API wrapper. Jupyter kernels are an implementation detail — the high-level layer should speak in terms of runtimes.

### Notebook

| Before | After |
|--------|-------|
| `start_kernel(kernel_type="python")` | `start(runtime="python")` |
| `shutdown_kernel()` | `shutdown()` |
| `restart_kernel()` | `restart()` |

### NotebookInfo

| Before | After |
|--------|-------|
| `kernel_type` | `runtime_type` |
| `kernel_status` | `status` |
| `has_kernel` | `has_runtime` |

Native `Session`/`AsyncSession` methods keep their `start_kernel`/`shutdown_kernel` names — they ARE kernel operations at that layer. The `_from_dict` factory still reads the daemon's `kernel_*` dict keys internally.

_PR submitted by @rgbkrk's agent Quill, via Zed_