### PR TITLE
refactor(python): split save into save() and save_as(path)

### DIFF
--- a/docs/python-bindings.md
+++ b/docs/python-bindings.md
@@ -107,7 +107,7 @@ async with await client.create_notebook() as notebook:
 
     # Save
     path = await notebook.save()
-    path = await notebook.save("/tmp/copy.ipynb")
+    path = await notebook.save_as("/tmp/copy.ipynb")
 
     # Execute code
     cell = await notebook.cells.create("print('hello')")

--- a/python/runtimed/README.md
+++ b/python/runtimed/README.md
@@ -36,7 +36,7 @@ async def main():
     await cell.run()
 
     # Save the notebook
-    path = await notebook.save("/tmp/my-notebook.ipynb")
+    path = await notebook.save_as("/tmp/my-notebook.ipynb")
 
 asyncio.run(main())
 ```

--- a/python/runtimed/src/runtimed/_notebook.py
+++ b/python/runtimed/src/runtimed/_notebook.py
@@ -49,8 +49,12 @@ class Notebook:
 
     # ── Async operations ─────────────────────────────────────────────
 
-    async def save(self, path: str | None = None) -> str:
-        """Save the notebook to disk. Returns the path saved to."""
+    async def save(self) -> str:
+        """Save the notebook to its current path. Returns the path saved to."""
+        return await self._session.save(None)
+
+    async def save_as(self, path: str) -> str:
+        """Save the notebook to a new path. Returns the path saved to."""
         return await self._session.save(path)
 
     async def start(


### PR DESCRIPTION
Split `notebook.save(path=None)` into two explicit methods:

- `save()` — save in-place to the current path
- `save_as(path)` — save to a new location

Clearer intent than a single method with an optional path arg.

_PR submitted by @rgbkrk's agent Quill, via Zed_