### PR TITLE
refactor(mcp): migrate nteract server to Client/Notebook wrapper API

### DIFF
--- a/python/nteract/src/nteract/_mcp_server.py
+++ b/python/nteract/src/nteract/_mcp_server.py
@@ -757,9 +757,8 @@ async def create_notebook(
 
     if dependencies and runtime == "python":
         # Add dependencies to notebook metadata
-        session = _notebook.session
         for dep in dependencies:
-            await session.add_uv_dependency(dep)
+            await _notebook.add_dependency(dep)
 
         # The daemon may have auto-launched a kernel (without these deps).
         # Restart to ensure the kernel picks up the inline deps.
@@ -847,80 +846,35 @@ async def restart_kernel(ctx: Context | None = None) -> dict[str, Any]:
 # =============================================================================
 
 
-async def _get_package_manager(session: runtimed.AsyncSession) -> str:
-    """Detect which package manager the notebook is using.
-
-    Detection order:
-    1. If kernel is running, check env_source (most reliable)
-    2. Check notebook metadata structure (conda vs uv)
-    3. Check session's settings replica for default_python_env
-    4. Default to "uv" if no signal
-    """
-    # First check env_source if kernel is running
-    env = await session.env_source()
-    if env:
-        if env.startswith("conda:"):
-            return "conda"
-        return "uv"
-
-    # Check metadata structure (not just non-empty deps)
-    env_type = await session.get_metadata_env_type()
-    if env_type:
-        return env_type
-
-    # Check settings from session's local replica (no round-trip)
-    settings = session.get_settings()
-    if settings:
-        return settings.get("default_python_env", "uv")
-
-    return "uv"
-
-
 @mcp.tool(annotations=ToolAnnotations(destructiveHint=True))
 async def add_dependency(package: str) -> dict[str, Any]:
     """Add a package dependency (e.g. "pandas>=2.0"). Call sync_environment() to install."""
-    session = await _get_session()
-    pm = await _get_package_manager(session)
-    if pm == "conda":
-        await session.add_conda_dependency(package)
-        deps = await session.get_conda_dependencies()
-    else:
-        await session.add_uv_dependency(package)
-        deps = await session.get_uv_dependencies()
-    return {"dependencies": deps, "added": package, "package_manager": pm}
+    notebook = await _get_notebook()
+    deps = await notebook.add_dependency(package)
+    return {"dependencies": deps, "added": package}
 
 
 @mcp.tool(annotations=ToolAnnotations(destructiveHint=True))
 async def remove_dependency(package: str) -> dict[str, Any]:
     """Remove a package dependency. Requires restart_kernel() to take effect."""
-    session = await _get_session()
-    pm = await _get_package_manager(session)
-    if pm == "conda":
-        await session.remove_conda_dependency(package)
-        deps = await session.get_conda_dependencies()
-    else:
-        await session.remove_uv_dependency(package)
-        deps = await session.get_uv_dependencies()
-    return {"dependencies": deps, "removed": package, "package_manager": pm}
+    notebook = await _get_notebook()
+    deps = await notebook.remove_dependency(package)
+    return {"dependencies": deps, "removed": package}
 
 
 @mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
 async def get_dependencies() -> dict[str, Any]:
     """Get the notebook's current package dependencies."""
-    session = await _get_session()
-    pm = await _get_package_manager(session)
-    if pm == "conda":
-        deps = await session.get_conda_dependencies()
-    else:
-        deps = await session.get_uv_dependencies()
-    return {"dependencies": deps, "package_manager": pm}
+    notebook = await _get_notebook()
+    deps = await notebook.get_dependencies()
+    return {"dependencies": deps}
 
 
 @mcp.tool(annotations=ToolAnnotations(destructiveHint=True))
 async def sync_environment() -> dict[str, Any]:
     """Hot-install new dependencies without restarting. Use restart_kernel() if this fails."""
-    session = await _get_session()
-    result = await session.sync_environment()
+    notebook = await _get_notebook()
+    result = await notebook.sync_environment()
     return {
         "success": result.success,
         "synced_packages": result.synced_packages,
@@ -947,17 +901,16 @@ async def create_cell(
     timeout_secs: Annotated[float, Field(description="Max seconds to wait for execution")] = 30.0,
 ) -> list[ContentItem]:
     """Create a cell, optionally executing it."""
-    session = await _get_session()
-    cell_id = await session.create_cell(
-        source=source,
-        cell_type=cell_type,
-        index=index,
-    )
+    notebook = await _get_notebook()
+    if index is not None:
+        cell = await notebook.cells.insert_at(index, source, cell_type)
+    else:
+        cell = await notebook.cells.create(source, cell_type)
 
     if and_run and cell_type == "code":
-        return await _execute_cell_internal(cell_id, timeout_secs=timeout_secs)
+        return await _execute_cell_internal(cell.id, timeout_secs=timeout_secs)
 
-    return [TextContent(type="text", text=f"Created cell: {cell_id}")]
+    return [TextContent(type="text", text=f"Created cell: {cell.id}")]
 
 
 @mcp.tool(annotations=ToolAnnotations(destructiveHint=True))
@@ -976,31 +929,31 @@ async def set_cell(
     timeout_secs: Annotated[float, Field(description="Max seconds to wait for execution")] = 30.0,
 ) -> ContentItem | list[ContentItem]:
     """Update a cell's source and/or type. Use replace_match for targeted edits."""
-    session = await _get_session()
+    notebook = await _get_notebook()
+    try:
+        cell = notebook.cells.get_by_id(cell_id)
+    except KeyError:
+        return TextContent(type="text", text=f'Cell "{cell_id}" not found')
 
     # Update source if provided
     if source is not None:
-        await session.set_source(cell_id=cell_id, source=source)
+        await cell.set_source(source)
 
     # Update cell type if provided
     if cell_type is not None:
-        await session.set_cell_type(cell_id=cell_id, cell_type=cell_type)
+        await cell.set_type(cell_type)
 
     # If source was changed, ensure the final presence is cursor-at-end (not focus
     # from set_cell_type, which would clear the cursor on the frontend).
     if source is not None:
-        await _send_edit_cursor(session, cell_id, source, len(source))
+        await _send_edit_cursor(cell_id, source, len(source))
 
     # If nothing was changed, return current cell state
     if source is None and cell_type is None:
         return TextContent(type="text", text=f'Cell "{cell_id}" unchanged (no updates specified)')
 
-    if and_run:
-        ct = await session.get_cell_type(cell_id=cell_id)
-        if ct is None:
-            return TextContent(type="text", text=f'Cell "{cell_id}" not found')
-        if ct == "code":
-            return await _execute_cell_internal(cell_id, timeout_secs=timeout_secs)
+    if and_run and cell.cell_type == "code":
+        return await _execute_cell_internal(cell_id, timeout_secs=timeout_secs)
 
     return TextContent(type="text", text=f'Cell "{cell_id}" updated')
 
@@ -1011,11 +964,13 @@ async def set_cells_source_hidden(
     hidden: Annotated[bool, Field(description="True to hide source, False to show")],
 ) -> TextContent:
     """Hide or show the source (code input) of one or more cells."""
-    session = await _get_session()
+    notebook = await _get_notebook()
     not_found: list[str] = []
     for cell_id in cell_ids:
-        ok = await session.set_cell_source_hidden(cell_id=cell_id, hidden=hidden)
-        if not ok:
+        try:
+            cell = notebook.cells.get_by_id(cell_id)
+            await cell.set_source_hidden(hidden)
+        except KeyError:
             not_found.append(cell_id)
     updated = len(cell_ids) - len(not_found)
     msg = f"Set source_hidden={hidden} on {updated} cell(s)"
@@ -1030,11 +985,13 @@ async def set_cells_outputs_hidden(
     hidden: Annotated[bool, Field(description="True to hide outputs, False to show")],
 ) -> TextContent:
     """Hide or show the outputs of one or more cells."""
-    session = await _get_session()
+    notebook = await _get_notebook()
     not_found: list[str] = []
     for cell_id in cell_ids:
-        ok = await session.set_cell_outputs_hidden(cell_id=cell_id, hidden=hidden)
-        if not ok:
+        try:
+            cell = notebook.cells.get_by_id(cell_id)
+            await cell.set_outputs_hidden(hidden)
+        except KeyError:
             not_found.append(cell_id)
     updated = len(cell_ids) - len(not_found)
     msg = f"Set outputs_hidden={hidden} on {updated} cell(s)"
@@ -1049,14 +1006,14 @@ async def add_cell_tags(
     tags: Annotated[list[str], Field(description="Tags to add")],
 ) -> TextContent:
     """Add tags to a cell's metadata. Existing tags are preserved."""
-    session = await _get_session()
+    notebook = await _get_notebook()
     try:
-        cell = await session.get_cell(cell_id=cell_id)
-    except Exception as e:
-        return TextContent(type="text", text=str(e))
-    existing: list[str] = list(cell.metadata.get("tags", []))
+        cell = notebook.cells.get_by_id(cell_id)
+    except KeyError:
+        return TextContent(type="text", text=f"Cell {cell_id} not found")
+    existing = cell.tags
     merged = existing + [t for t in tags if t not in existing]
-    await session.set_cell_tags(cell_id=cell_id, tags=merged)
+    await cell.set_tags(merged)
     return TextContent(type="text", text=f"Tags for {cell_id}: {merged}")
 
 
@@ -1066,42 +1023,44 @@ async def remove_cell_tags(
     tags: Annotated[list[str], Field(description="Tags to remove")],
 ) -> TextContent:
     """Remove tags from a cell's metadata."""
-    session = await _get_session()
+    notebook = await _get_notebook()
     try:
-        cell = await session.get_cell(cell_id=cell_id)
-    except Exception as e:
-        return TextContent(type="text", text=str(e))
-    existing: list[str] = list(cell.metadata.get("tags", []))
+        cell = notebook.cells.get_by_id(cell_id)
+    except KeyError:
+        return TextContent(type="text", text=f"Cell {cell_id} not found")
+    existing = cell.tags
     filtered = [t for t in existing if t not in tags]
-    await session.set_cell_tags(cell_id=cell_id, tags=filtered)
+    await cell.set_tags(filtered)
     return TextContent(type="text", text=f"Tags for {cell_id}: {filtered}")
 
 
-async def _send_edit_cursor(
-    session: runtimed.AsyncSession, cell_id: str, source: str, offset: int
-) -> None:
+async def _send_edit_cursor(cell_id: str, source: str, offset: int) -> None:
     """Send cursor presence at a character offset (best-effort, non-blocking)."""
+    if _notebook is None:
+        return
     from nteract._editing import offset_to_line_col
 
     try:
         line, col = offset_to_line_col(source, offset)
-        await session.set_cursor(cell_id=cell_id, line=line, column=col)
+        await _notebook.presence.set_cursor(cell_id, line, col)
     except Exception:
         pass  # Presence is best-effort — don't fail the edit
 
 
-async def _send_cell_cursor(
-    session: runtimed.AsyncSession, cell_id: str, line: int = 0, column: int = 0
-) -> None:
+async def _send_cell_cursor(cell_id: str, line: int = 0, column: int = 0) -> None:
     """Send cursor presence on a cell (best-effort, errors silently ignored)."""
+    if _notebook is None:
+        return
     with contextlib.suppress(Exception):
-        await session.set_cursor(cell_id=cell_id, line=line, column=column)
+        await _notebook.presence.set_cursor(cell_id, line, column)
 
 
-async def _send_cell_focus(session: runtimed.AsyncSession, cell_id: str) -> None:
+async def _send_cell_focus(cell_id: str) -> None:
     """Send focus presence on a cell (best-effort, errors silently ignored)."""
+    if _notebook is None:
+        return
     with contextlib.suppress(Exception):
-        await session.set_focus(cell_id=cell_id)
+        await _notebook.presence.focus(cell_id)
 
 
 def _format_edit_diff(cell_id: str, old_text: str, new_text: str) -> str:
@@ -1137,10 +1096,13 @@ async def replace_match(
     from nteract._editing import PatternError
     from nteract._editing import replace_match as _replace_match
 
-    session = await _get_session()
-    source = await session.get_cell_source(cell_id=cell_id)
-    if source is None:
+    notebook = await _get_notebook()
+    try:
+        cell = notebook.cells.get_by_id(cell_id)
+    except KeyError:
         return TextContent(type="text", text=f'Cell "{cell_id}" not found')
+
+    source = cell.source
 
     try:
         result = _replace_match(source, match, content, context_before, context_after)
@@ -1148,18 +1110,13 @@ async def replace_match(
         raise RuntimeError(f"{e} (match_count={e.match_count}, source_length={len(source)})") from e
 
     # Show cursor at edit location before applying
-    await _send_edit_cursor(session, cell_id, source, result.span.start)
+    await _send_edit_cursor(cell_id, source, result.span.start)
 
-    await session.splice_source(
-        cell_id=cell_id,
-        index=result.span.start,
-        delete_count=result.span.end - result.span.start,
-        text=content,
-    )
+    await cell.splice(result.span.start, result.span.end - result.span.start, content)
 
     # Move cursor to end of replacement
     end_offset = result.span.start + len(content)
-    await _send_edit_cursor(session, cell_id, result.new_source, end_offset)
+    await _send_edit_cursor(cell_id, result.new_source, end_offset)
 
     if and_run:
         return await _execute_cell_internal(cell_id, timeout_secs=timeout_secs)
@@ -1191,10 +1148,13 @@ async def replace_regex(
     from nteract._editing import PatternError
     from nteract._editing import replace_regex as _replace_regex
 
-    session = await _get_session()
-    source = await session.get_cell_source(cell_id=cell_id)
-    if source is None:
+    notebook = await _get_notebook()
+    try:
+        cell = notebook.cells.get_by_id(cell_id)
+    except KeyError:
         return TextContent(type="text", text=f'Cell "{cell_id}" not found')
+
+    source = cell.source
 
     try:
         result = _replace_regex(source, pattern, content)
@@ -1202,18 +1162,13 @@ async def replace_regex(
         raise RuntimeError(f"{e} (match_count={e.match_count}, source_length={len(source)})") from e
 
     # Show cursor at edit location before applying
-    await _send_edit_cursor(session, cell_id, source, result.span.start)
+    await _send_edit_cursor(cell_id, source, result.span.start)
 
-    await session.splice_source(
-        cell_id=cell_id,
-        index=result.span.start,
-        delete_count=result.span.end - result.span.start,
-        text=content,
-    )
+    await cell.splice(result.span.start, result.span.end - result.span.start, content)
 
     # Move cursor to end of replacement
     end_offset = result.span.start + len(content)
-    await _send_edit_cursor(session, cell_id, result.new_source, end_offset)
+    await _send_edit_cursor(cell_id, result.new_source, end_offset)
 
     if and_run:
         return await _execute_cell_internal(cell_id, timeout_secs=timeout_secs)
@@ -1227,12 +1182,14 @@ async def get_cell(
     cell_id: str,
 ) -> list[ContentItem]:
     """Get a cell's source and outputs by ID."""
-    session = await _get_session()
-    await _send_cell_focus(session, cell_id)
-    cell = await session.get_cell(cell_id=cell_id)
-    if cell is None:
+    notebook = await _get_notebook()
+    await _send_cell_focus(cell_id)
+    try:
+        handle = notebook.cells.get_by_id(cell_id)
+        cell = handle.snapshot()
+    except (KeyError, runtimed.RuntimedError):
         return [TextContent(type="text", text=f'Cell "{cell_id}" not found')]
-    status = await _get_single_cell_status(session, cell_id)
+    status = await _get_single_cell_status(notebook.session, cell_id)
     return _cell_to_content(cell, status=status)
 
 
@@ -1346,9 +1303,9 @@ async def get_all_cells(
 @mcp.tool(annotations=ToolAnnotations(destructiveHint=True))
 async def delete_cell(cell_id: str) -> dict[str, Any]:
     """Delete a cell by ID."""
-    session = await _get_session()
-    await session.delete_cell(cell_id=cell_id)
-
+    notebook = await _get_notebook()
+    cell = notebook.cells.get_by_id(cell_id)
+    await cell.delete()
     return {"cell_id": cell_id, "deleted": True}
 
 
@@ -1360,12 +1317,13 @@ async def move_cell(
     ] = None,
 ) -> dict[str, Any]:
     """Move a cell to a new position."""
-    session = await _get_session()
-    new_position = await session.move_cell(cell_id=cell_id, after_cell_id=after_cell_id)
+    notebook = await _get_notebook()
+    cell = notebook.cells.get_by_id(cell_id)
+    after = notebook.cells.get_by_id(after_cell_id) if after_cell_id else None
+    await cell.move_after(after)
     return {
         "cell_id": cell_id,
         "after_cell_id": after_cell_id,
-        "new_position": new_position,
         "moved": True,
     }
 
@@ -1373,8 +1331,9 @@ async def move_cell(
 @mcp.tool(annotations=ToolAnnotations(destructiveHint=True))
 async def clear_outputs(cell_id: str) -> dict[str, Any]:
     """Clear a cell's outputs."""
-    session = await _get_session()
-    await session.clear_outputs(cell_id)
+    notebook = await _get_notebook()
+    cell = notebook.cells.get_by_id(cell_id)
+    await cell.clear_outputs()
     return {"cell_id": cell_id, "cleared": True}
 
 
@@ -1388,14 +1347,15 @@ async def _execute_cell_internal(
     timeout_secs: float = 30.0,
 ) -> list[ContentItem]:
     """Internal execution with streaming and partial results."""
-    session = await _get_session()
-    await _send_cell_focus(session, cell_id)
+    notebook = await _get_notebook()
+    await _send_cell_focus(cell_id)
+    handle = notebook.cells.get_by_id(cell_id)
     events: list[Any] = []  # list[runtimed.ExecutionEvent]
     complete = False
 
     async def collect_events() -> None:
         nonlocal complete
-        async for event in await session.stream_execute(cell_id):
+        async for event in await handle.stream():
             events.append(event)
             if event.event_type in ("done", "error"):
                 complete = True
@@ -1407,11 +1367,8 @@ async def _execute_cell_internal(
     if complete:
         # Prefer the synced document as the final source of truth once execution
         # finishes. This is more robust across runtimed output transport changes.
-        session = await _get_session()
         with contextlib.suppress(Exception):
-            cell = await session.get_cell(cell_id=cell_id)
-            if cell is None:
-                raise ValueError(f'Cell "{cell_id}" not found')
+            cell = handle.snapshot()
             has_error_output = any(output.output_type == "error" for output in cell.outputs)
             status = "error" if has_error_output else "idle"
             header = _format_header(cell.id, status=status, execution_count=cell.execution_count)
@@ -1436,8 +1393,8 @@ async def execute_cell(
 @mcp.tool(annotations=ToolAnnotations(destructiveHint=True))
 async def run_all_cells() -> dict[str, Any]:
     """Queue all code cells for execution. Use get_all_cells() to see results."""
-    session = await _get_session()
-    count = await session.run_all_cells()
+    notebook = await _get_notebook()
+    count = await notebook.run_all()
     return {"status": "queued", "count": count}
 
 
@@ -1453,9 +1410,8 @@ async def resource_cells() -> str:
         return "Error: No active notebook"
 
     try:
-        session = _notebook.session
-        cells = await session.get_cells()
-        cell_status = await _get_cell_status_map(session)
+        cells = await _notebook.session.get_cells()
+        cell_status = await _get_cell_status_map(_notebook.session)
         lines = [
             _format_cell_summary(i, cell, status=cell_status.get(cell.id))
             for i, cell in enumerate(cells)
@@ -1472,12 +1428,11 @@ async def resource_cell(cell_id: str) -> str:
         return "Error: No active notebook"
 
     try:
-        session = _notebook.session
-        await _send_cell_focus(session, cell_id)
-        cell = await session.get_cell(cell_id=cell_id)
+        await _send_cell_focus(cell_id)
+        cell = await _notebook.session.get_cell(cell_id=cell_id)
         if cell is None:
             return f"Error: Cell {cell_id} not found"
-        status = await _get_single_cell_status(session, cell_id)
+        status = await _get_single_cell_status(_notebook.session, cell_id)
         return _format_cell(cell, status=status)
     except Exception as e:
         return f"Error: {e}"
@@ -1490,16 +1445,15 @@ async def resource_cell_by_index(index: int) -> str:
         return "Error: No active notebook"
 
     try:
-        session = _notebook.session
-        cell_ids = await session.get_cell_ids()
+        cell_ids = _notebook.cells.ids
         if index < 0 or index >= len(cell_ids):
             return f"Error: Index {index} out of range (notebook has {len(cell_ids)} cells)"
         cell_id = cell_ids[index]
-        await _send_cell_focus(session, cell_id)
-        cell = await session.get_cell(cell_id=cell_id)
+        await _send_cell_focus(cell_id)
+        cell = await _notebook.session.get_cell(cell_id=cell_id)
         if cell is None:
             return f"Error: Cell at index {index} not found"
-        status = await _get_single_cell_status(session, cell_id)
+        status = await _get_single_cell_status(_notebook.session, cell_id)
         return _format_cell(cell, status=status)
     except Exception as e:
         return f"Error: {e}"
@@ -1512,9 +1466,8 @@ async def resource_cell_outputs(cell_id: str) -> str:
         return "Error: No active notebook"
 
     try:
-        session = _notebook.session
-        await _send_cell_focus(session, cell_id)
-        cell = await session.get_cell(cell_id=cell_id)
+        await _send_cell_focus(cell_id)
+        cell = await _notebook.session.get_cell(cell_id=cell_id)
         if cell is None:
             return f"Error: Cell {cell_id} not found"
         output_text = _format_outputs_text(cell.outputs)
@@ -1538,13 +1491,13 @@ async def resource_status() -> str:
         )
 
     try:
-        session = _notebook.session
+        rt = _notebook.runtime
         return json.dumps(
             {
                 "notebook_id": _notebook.notebook_id,
-                "connected": await session.is_connected(),
-                "kernel_started": await session.kernel_started(),
-                "env_source": await session.env_source(),
+                "connected": await _notebook.session.is_connected(),
+                "runtime_status": rt.kernel.status,
+                "env_source": rt.kernel.env_source,
             }
         )
     except Exception as e:

--- a/python/nteract/src/nteract/_mcp_server.py
+++ b/python/nteract/src/nteract/_mcp_server.py
@@ -92,12 +92,6 @@ async def _get_notebook() -> runtimed.Notebook:
     return _notebook
 
 
-async def _get_session() -> runtimed.AsyncSession:
-    """Get the current session (escape hatch for advanced operations)."""
-    notebook = await _get_notebook()
-    return notebook.session
-
-
 # Regex to strip ANSI escape sequences (terminal colors, cursor movement, etc.)
 _ANSI_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]|\x1b\].*?\x07|\x1b\(B")
 
@@ -365,14 +359,14 @@ def _build_cell_status_map(queue_state: runtimed.QueueState) -> dict[str, str]:
     return cell_status
 
 
-async def _get_cell_status_map(session: runtimed.AsyncSession) -> dict[str, str]:
+async def _get_cell_status_map(notebook: runtimed.Notebook) -> dict[str, str]:
     """Fetch queue state and return cell status map, empty on failure.
 
     Status is a best-effort annotation — errors should never prevent
     get_all_cells or get_cell from returning results.
     """
     try:
-        queue_state = await session.get_queue_state()
+        queue_state = await notebook.session.get_queue_state()
         return _build_cell_status_map(queue_state)
     except asyncio.CancelledError:
         raise
@@ -380,10 +374,10 @@ async def _get_cell_status_map(session: runtimed.AsyncSession) -> dict[str, str]
         return {}
 
 
-async def _get_single_cell_status(session: runtimed.AsyncSession, cell_id: str) -> str | None:
+async def _get_single_cell_status(notebook: runtimed.Notebook, cell_id: str) -> str | None:
     """Fetch queue status for a single cell, None on failure."""
     try:
-        queue_state = await session.get_queue_state()
+        queue_state = await notebook.session.get_queue_state()
         if queue_state.executing == cell_id:
             return "running"
         if cell_id in queue_state.queued:
@@ -397,7 +391,7 @@ async def _get_single_cell_status(session: runtimed.AsyncSession, cell_id: str) 
 
 def _format_cell_summary(
     index: int,
-    cell: runtimed.Cell,
+    cell: runtimed.CellHandle,
     preview_chars: int = 60,
     include_outputs: bool = False,
     status: str | None = None,
@@ -472,7 +466,7 @@ def _format_header(
     return " ".join(parts)
 
 
-def _format_cell(cell: runtimed.Cell, status: str | None = None) -> str:
+def _format_cell(cell: runtimed.CellHandle, status: str | None = None) -> str:
     """Format a cell for terminal display (includes source).
 
     Used by get_cell to show full cell state.
@@ -492,7 +486,7 @@ def _format_cell(cell: runtimed.Cell, status: str | None = None) -> str:
         return header
 
 
-def _cell_to_content(cell: runtimed.Cell, status: str | None = None) -> list[ContentItem]:
+def _cell_to_content(cell: runtimed.CellHandle, status: str | None = None) -> list[ContentItem]:
     """Convert a cell to rich MCP content items.
 
     Returns a header as TextContent, then each output as its richest type.
@@ -1185,11 +1179,10 @@ async def get_cell(
     notebook = await _get_notebook()
     await _send_cell_focus(cell_id)
     try:
-        handle = notebook.cells.get_by_id(cell_id)
-        cell = handle.snapshot()
-    except (KeyError, runtimed.RuntimedError):
+        cell = notebook.cells.get_by_id(cell_id)
+    except KeyError:
         return [TextContent(type="text", text=f'Cell "{cell_id}" not found')]
-    status = await _get_single_cell_status(notebook.session, cell_id)
+    status = await _get_single_cell_status(notebook, cell_id)
     return _cell_to_content(cell, status=status)
 
 
@@ -1251,15 +1244,15 @@ async def get_all_cells(
     if preview_chars < 1:
         raise ValueError(f"preview_chars must be >= 1, got {preview_chars}")
 
-    session = await _get_session()
-    cells = await session.get_cells()
+    notebook = await _get_notebook()
+    all_cells = list(notebook.cells)
 
     # Fetch execution queue state to annotate running/queued cells
-    cell_status = await _get_cell_status_map(session)
+    cell_status = await _get_cell_status_map(notebook)
 
     # Apply pagination
-    end = start + count if count is not None else len(cells)
-    cells = cells[start:end]
+    end = start + count if count is not None else len(all_cells)
+    cells = all_cells[start:end]
 
     if format == "json":
         return [
@@ -1349,13 +1342,13 @@ async def _execute_cell_internal(
     """Internal execution with streaming and partial results."""
     notebook = await _get_notebook()
     await _send_cell_focus(cell_id)
-    handle = notebook.cells.get_by_id(cell_id)
+    cell = notebook.cells.get_by_id(cell_id)
     events: list[Any] = []  # list[runtimed.ExecutionEvent]
     complete = False
 
     async def collect_events() -> None:
         nonlocal complete
-        async for event in await handle.stream():
+        async for event in await cell.stream():
             events.append(event)
             if event.event_type in ("done", "error"):
                 complete = True
@@ -1366,10 +1359,9 @@ async def _execute_cell_internal(
 
     if complete:
         # Prefer the synced document as the final source of truth once execution
-        # finishes. This is more robust across runtimed output transport changes.
+        # finishes. CellHandle reads from the local CRDT replica.
         with contextlib.suppress(Exception):
-            cell = handle.snapshot()
-            has_error_output = any(output.output_type == "error" for output in cell.outputs)
+            has_error_output = any(o.output_type == "error" for o in cell.outputs)
             status = "error" if has_error_output else "idle"
             header = _format_header(cell.id, status=status, execution_count=cell.execution_count)
             items: list[ContentItem] = [TextContent(type="text", text=header)]
@@ -1410,11 +1402,10 @@ async def resource_cells() -> str:
         return "Error: No active notebook"
 
     try:
-        cells = await _notebook.session.get_cells()
-        cell_status = await _get_cell_status_map(_notebook.session)
+        cell_status = await _get_cell_status_map(_notebook)
         lines = [
             _format_cell_summary(i, cell, status=cell_status.get(cell.id))
-            for i, cell in enumerate(cells)
+            for i, cell in enumerate(_notebook.cells)
         ]
         return "\n".join(lines)
     except Exception as e:
@@ -1429,10 +1420,8 @@ async def resource_cell(cell_id: str) -> str:
 
     try:
         await _send_cell_focus(cell_id)
-        cell = await _notebook.session.get_cell(cell_id=cell_id)
-        if cell is None:
-            return f"Error: Cell {cell_id} not found"
-        status = await _get_single_cell_status(_notebook.session, cell_id)
+        cell = _notebook.cells.get_by_id(cell_id)
+        status = await _get_single_cell_status(_notebook, cell_id)
         return _format_cell(cell, status=status)
     except Exception as e:
         return f"Error: {e}"
@@ -1445,15 +1434,12 @@ async def resource_cell_by_index(index: int) -> str:
         return "Error: No active notebook"
 
     try:
-        cell_ids = _notebook.cells.ids
-        if index < 0 or index >= len(cell_ids):
-            return f"Error: Index {index} out of range (notebook has {len(cell_ids)} cells)"
-        cell_id = cell_ids[index]
-        await _send_cell_focus(cell_id)
-        cell = await _notebook.session.get_cell(cell_id=cell_id)
-        if cell is None:
-            return f"Error: Cell at index {index} not found"
-        status = await _get_single_cell_status(_notebook.session, cell_id)
+        num_cells = len(_notebook.cells)
+        if index < 0 or index >= num_cells:
+            return f"Error: Index {index} out of range (notebook has {num_cells} cells)"
+        cell = _notebook.cells.get_by_index(index)
+        await _send_cell_focus(cell.id)
+        status = await _get_single_cell_status(_notebook, cell.id)
         return _format_cell(cell, status=status)
     except Exception as e:
         return f"Error: {e}"
@@ -1467,9 +1453,7 @@ async def resource_cell_outputs(cell_id: str) -> str:
 
     try:
         await _send_cell_focus(cell_id)
-        cell = await _notebook.session.get_cell(cell_id=cell_id)
-        if cell is None:
-            return f"Error: Cell {cell_id} not found"
+        cell = _notebook.cells.get_by_id(cell_id)
         output_text = _format_outputs_text(cell.outputs)
         if not output_text:
             return "(no outputs)"
@@ -1491,13 +1475,12 @@ async def resource_status() -> str:
         )
 
     try:
-        rt = _notebook.runtime
         return json.dumps(
             {
                 "notebook_id": _notebook.notebook_id,
                 "connected": await _notebook.session.is_connected(),
-                "runtime_status": rt.kernel.status,
-                "env_source": rt.kernel.env_source,
+                "runtime_status": _notebook.runtime.kernel.status,
+                "env_source": _notebook.runtime.kernel.env_source,
             }
         )
     except Exception as e:

--- a/python/nteract/src/nteract/_mcp_server.py
+++ b/python/nteract/src/nteract/_mcp_server.py
@@ -72,24 +72,30 @@ def _peer_label() -> str:
     return _client_name or "Agent"
 
 
-# Session state - single active session at a time
-_session: runtimed.AsyncSession | None = None
-_client: runtimed.NativeAsyncClient | None = None
+# Notebook state - single active notebook at a time
+_notebook: runtimed.Notebook | None = None
+_client: runtimed.Client | None = None
 
 
-def _get_client() -> runtimed.NativeAsyncClient:
-    """Get or create the async client."""
+def _get_client() -> runtimed.Client:
+    """Get or create the client."""
     global _client
     if _client is None:
-        _client = runtimed.NativeAsyncClient()
+        _client = runtimed.Client()
     return _client
 
 
-async def _get_session() -> runtimed.AsyncSession:
-    """Get the current session, raising error if not connected."""
-    if _session is None:
+async def _get_notebook() -> runtimed.Notebook:
+    """Get the current notebook, raising error if not connected."""
+    if _notebook is None:
         raise RuntimeError("No active notebook session. Call join_notebook first.")
-    return _session
+    return _notebook
+
+
+async def _get_session() -> runtimed.AsyncSession:
+    """Get the current session (escape hatch for advanced operations)."""
+    notebook = await _get_notebook()
+    return notebook.session
 
 
 # Regex to strip ANSI escape sequences (terminal colors, cursor movement, etc.)
@@ -599,16 +605,16 @@ async def list_active_notebooks() -> list[dict[str, Any]]:
     Use join_notebook(notebook_id) to connect to one.
     """
     client = _get_client()
-    rooms = await client.list_active_notebooks()
+    notebooks = await client.list_active_notebooks()
     return [
         {
-            "notebook_id": room["notebook_id"],
-            "active_peers": room["active_peers"],
-            "has_kernel": room["has_kernel"],
-            "kernel_type": room.get("kernel_type"),
-            "kernel_status": room.get("kernel_status"),
+            "notebook_id": info.notebook_id,
+            "active_peers": info.active_peers,
+            "has_runtime": info.has_runtime,
+            "runtime_type": info.runtime_type,
+            "status": info.status,
         }
-        for room in rooms
+        for info in notebooks
     ]
 
 
@@ -630,8 +636,8 @@ if not _no_show:
         """
         target = notebook_id
         if target is None:
-            if _session is not None:
-                target = _session.notebook_id
+            if _notebook is not None:
+                target = _notebook.notebook_id
             else:
                 raise ValueError(
                     "No notebook_id provided and no active session. "
@@ -639,9 +645,9 @@ if not _no_show:
                 )
 
         client = _get_client()
-        rooms = await client.list_active_notebooks()
-        room_ids = {room["notebook_id"] for room in rooms}
-        if target not in room_ids:
+        notebooks = await client.list_active_notebooks()
+        notebook_ids = {info.notebook_id for info in notebooks}
+        if target not in notebook_ids:
             raise ValueError(
                 f"Notebook '{target}' is not currently running. "
                 f"Use list_active_notebooks() to see active notebooks."
@@ -667,22 +673,21 @@ async def join_notebook(
     Use list_active_notebooks() to see available sessions. To open a file from disk,
     use open_notebook(path). To create a new notebook, use create_notebook().
     """
-    global _session
+    global _notebook
     if ctx:
         _sniff_client_name(ctx)
 
-    # Close existing session if any
-    if _session is not None:
+    # Close existing notebook if any
+    if _notebook is not None:
         with contextlib.suppress(Exception):
-            await _session.close()
+            await _notebook.close()
 
-    # Join existing session
+    # Join existing notebook
     client = _get_client()
-    _session = await client.join_notebook(notebook_id, peer_label=_peer_label())
-    session = _session
+    _notebook = await client.join_notebook(notebook_id, peer_label=_peer_label())
 
     return {
-        "notebook_id": session.notebook_id,
+        "notebook_id": _notebook.notebook_id,
         "connected": True,
     }
 
@@ -693,19 +698,18 @@ async def open_notebook(path: str, ctx: Context | None = None) -> dict[str, Any]
 
     Use create_notebook() for new notebooks.
     """
-    global _session
+    global _notebook
     if ctx:
         _sniff_client_name(ctx)
 
-    if _session is not None:
+    if _notebook is not None:
         with contextlib.suppress(Exception):
-            await _session.close()
+            await _notebook.close()
 
     client = _get_client()
-    _session = await client.open_notebook(path, peer_label=_peer_label())
-    session = _session
+    _notebook = await client.open_notebook(path, peer_label=_peer_label())
     return {
-        "notebook_id": session.notebook_id,
+        "notebook_id": _notebook.notebook_id,
         "path": path,
     }
 
@@ -738,32 +742,32 @@ async def create_notebook(
 
     Call save_notebook(path) to persist to disk.
     """
-    global _session
+    global _notebook
     if ctx:
         _sniff_client_name(ctx)
 
-    if _session is not None:
+    if _notebook is not None:
         with contextlib.suppress(Exception):
-            await _session.close()
+            await _notebook.close()
 
     client = _get_client()
-    _session = await client.create_notebook(
+    _notebook = await client.create_notebook(
         runtime=runtime, working_dir=working_dir, peer_label=_peer_label()
     )
-    session = _session
 
     if dependencies and runtime == "python":
         # Add dependencies to notebook metadata
+        session = _notebook.session
         for dep in dependencies:
             await session.add_uv_dependency(dep)
 
         # The daemon may have auto-launched a kernel (without these deps).
         # Restart to ensure the kernel picks up the inline deps.
         with contextlib.suppress(Exception):
-            await session.restart_kernel(wait_for_ready=True)
+            await _notebook.restart()
 
     return {
-        "notebook_id": session.notebook_id,
+        "notebook_id": _notebook.notebook_id,
         "runtime": runtime,
         "dependencies": dependencies or [],
     }
@@ -776,11 +780,14 @@ async def save_notebook(path: str | None = None) -> dict[str, Any]:
     The daemon automatically re-keys ephemeral (UUID-based) rooms to the saved
     file path, so no disconnect/reconnect is needed.
     """
-    session = await _get_session()
-    old_notebook_id = session.notebook_id
+    notebook = await _get_notebook()
+    old_notebook_id = notebook.notebook_id
 
     try:
-        saved_path = await session.save(path)
+        if path is not None:
+            saved_path = await notebook.save_as(path)
+        else:
+            saved_path = await notebook.save()
     except Exception as e:
         error_msg = str(e)
         is_write_error = "Read-only" in error_msg or "Failed to write" in error_msg
@@ -791,7 +798,7 @@ async def save_notebook(path: str | None = None) -> dict[str, Any]:
             ) from e
         raise
 
-    new_notebook_id = session.notebook_id
+    new_notebook_id = notebook.notebook_id
     result: dict[str, Any] = {"path": saved_path, "notebook_id": new_notebook_id}
     if old_notebook_id != new_notebook_id:
         result["previous_notebook_id"] = old_notebook_id
@@ -806,8 +813,8 @@ async def save_notebook(path: str | None = None) -> dict[str, Any]:
 @mcp.tool(annotations=ToolAnnotations(destructiveHint=True))
 async def interrupt_kernel() -> dict[str, Any]:
     """Interrupt the currently executing cell."""
-    session = await _get_session()
-    await session.interrupt()
+    notebook = await _get_notebook()
+    await notebook.interrupt()
 
     return {"interrupted": True}
 
@@ -819,8 +826,8 @@ async def restart_kernel(ctx: Context | None = None) -> dict[str, Any]:
     Reports environment preparation progress (package downloads, installs)
     via MCP log notifications while waiting. Times out after 120s.
     """
-    session = await _get_session()
-    progress_messages: list[str] = await session.restart_kernel(wait_for_ready=True)
+    notebook = await _get_notebook()
+    progress_messages: list[str] = await notebook.restart()
 
     # Send progress messages as MCP log notifications (retroactively)
     if ctx and progress_messages:
@@ -830,7 +837,7 @@ async def restart_kernel(ctx: Context | None = None) -> dict[str, Any]:
 
     return {
         "restarted": True,
-        "env_source": await session.env_source(),
+        "env_source": notebook.runtime.kernel.env_source,
         "progress": progress_messages,
     }
 
@@ -1442,12 +1449,13 @@ async def run_all_cells() -> dict[str, Any]:
 @mcp.resource("notebook://cells")
 async def resource_cells() -> str:
     """Get all cells in the current notebook as a compact summary."""
-    if _session is None:
-        return "Error: No active session"
+    if _notebook is None:
+        return "Error: No active notebook"
 
     try:
-        cells = await _session.get_cells()
-        cell_status = await _get_cell_status_map(_session)
+        session = _notebook.session
+        cells = await session.get_cells()
+        cell_status = await _get_cell_status_map(session)
         lines = [
             _format_cell_summary(i, cell, status=cell_status.get(cell.id))
             for i, cell in enumerate(cells)
@@ -1460,15 +1468,16 @@ async def resource_cells() -> str:
 @mcp.resource("notebook://cell/{cell_id}")
 async def resource_cell(cell_id: str) -> str:
     """Get a specific cell's source and outputs."""
-    if _session is None:
-        return "Error: No active session"
+    if _notebook is None:
+        return "Error: No active notebook"
 
     try:
-        await _send_cell_focus(_session, cell_id)
-        cell = await _session.get_cell(cell_id=cell_id)
+        session = _notebook.session
+        await _send_cell_focus(session, cell_id)
+        cell = await session.get_cell(cell_id=cell_id)
         if cell is None:
             return f"Error: Cell {cell_id} not found"
-        status = await _get_single_cell_status(_session, cell_id)
+        status = await _get_single_cell_status(session, cell_id)
         return _format_cell(cell, status=status)
     except Exception as e:
         return f"Error: {e}"
@@ -1477,19 +1486,20 @@ async def resource_cell(cell_id: str) -> str:
 @mcp.resource("notebook://cells/by-index/{index}")
 async def resource_cell_by_index(index: int) -> str:
     """Get the cell at the specified position (0-based index)."""
-    if _session is None:
-        return "Error: No active session"
+    if _notebook is None:
+        return "Error: No active notebook"
 
     try:
-        cell_ids = await _session.get_cell_ids()
+        session = _notebook.session
+        cell_ids = await session.get_cell_ids()
         if index < 0 or index >= len(cell_ids):
             return f"Error: Index {index} out of range (notebook has {len(cell_ids)} cells)"
         cell_id = cell_ids[index]
-        await _send_cell_focus(_session, cell_id)
-        cell = await _session.get_cell(cell_id=cell_id)
+        await _send_cell_focus(session, cell_id)
+        cell = await session.get_cell(cell_id=cell_id)
         if cell is None:
             return f"Error: Cell at index {index} not found"
-        status = await _get_single_cell_status(_session, cell_id)
+        status = await _get_single_cell_status(session, cell_id)
         return _format_cell(cell, status=status)
     except Exception as e:
         return f"Error: {e}"
@@ -1498,12 +1508,13 @@ async def resource_cell_by_index(index: int) -> str:
 @mcp.resource("notebook://cell/{cell_id}/outputs")
 async def resource_cell_outputs(cell_id: str) -> str:
     """Get a specific cell's outputs only (text format)."""
-    if _session is None:
-        return "Error: No active session"
+    if _notebook is None:
+        return "Error: No active notebook"
 
     try:
-        await _send_cell_focus(_session, cell_id)
-        cell = await _session.get_cell(cell_id=cell_id)
+        session = _notebook.session
+        await _send_cell_focus(session, cell_id)
+        cell = await session.get_cell(cell_id=cell_id)
         if cell is None:
             return f"Error: Cell {cell_id} not found"
         output_text = _format_outputs_text(cell.outputs)
@@ -1516,8 +1527,8 @@ async def resource_cell_outputs(cell_id: str) -> str:
 
 @mcp.resource("notebook://status")
 async def resource_status() -> str:
-    """Get the current session and kernel status as JSON."""
-    if _session is None:
+    """Get the current notebook and runtime status as JSON."""
+    if _notebook is None:
         return json.dumps(
             {
                 "connected": False,
@@ -1527,12 +1538,13 @@ async def resource_status() -> str:
         )
 
     try:
+        session = _notebook.session
         return json.dumps(
             {
-                "notebook_id": _session.notebook_id,
-                "connected": await _session.is_connected(),
-                "kernel_started": await _session.kernel_started(),
-                "env_source": await _session.env_source(),
+                "notebook_id": _notebook.notebook_id,
+                "connected": await session.is_connected(),
+                "kernel_started": await session.kernel_started(),
+                "env_source": await session.env_source(),
             }
         )
     except Exception as e:
@@ -1544,8 +1556,19 @@ async def resource_rooms() -> str:
     """Get all active notebook rooms as JSON."""
     try:
         client = _get_client()
-        rooms = await client.list_active_notebooks()
-        return json.dumps([dict(room) for room in rooms])
+        notebooks = await client.list_active_notebooks()
+        return json.dumps(
+            [
+                {
+                    "notebook_id": info.notebook_id,
+                    "active_peers": info.active_peers,
+                    "has_runtime": info.has_runtime,
+                    "runtime_type": info.runtime_type,
+                    "status": info.status,
+                }
+                for info in notebooks
+            ]
+        )
     except Exception as e:
         return json.dumps({"error": str(e)})
 

--- a/python/runtimed/src/runtimed/__init__.py
+++ b/python/runtimed/src/runtimed/__init__.py
@@ -8,6 +8,7 @@ from runtimed._cell import CellCollection, CellHandle
 from runtimed._client import Client
 from runtimed._notebook import Notebook
 from runtimed._notebook_info import NotebookInfo
+from runtimed._presence import Presence
 
 # Data types (from native bindings)
 # Runtime state types (renamed from Py* to clean names)
@@ -43,6 +44,7 @@ __all__ = [
     "NotebookInfo",
     "CellHandle",
     "CellCollection",
+    "Presence",
     # Data types
     "Cell",
     "CompletionItem",

--- a/python/runtimed/src/runtimed/__init__.pyi
+++ b/python/runtimed/src/runtimed/__init__.pyi
@@ -5,6 +5,7 @@ from runtimed._cell import CellHandle as CellHandle
 from runtimed._client import Client as Client
 from runtimed._notebook import Notebook as Notebook
 from runtimed._notebook_info import NotebookInfo as NotebookInfo
+from runtimed._presence import Presence as Presence
 from runtimed.runtimed import AsyncSession as AsyncSession
 from runtimed.runtimed import Cell as Cell
 from runtimed.runtimed import CompletionItem as CompletionItem

--- a/python/runtimed/src/runtimed/_cell.py
+++ b/python/runtimed/src/runtimed/_cell.py
@@ -3,12 +3,19 @@
 from __future__ import annotations
 
 import json
+from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING, Any
 
 from runtimed.runtimed import RuntimedError as _RuntimedError
 
 if TYPE_CHECKING:
-    from runtimed.runtimed import AsyncSession, Cell, ExecutionResult, Output
+    from runtimed.runtimed import (
+        AsyncSession,
+        Cell,
+        ExecutionEvent,
+        ExecutionResult,
+        Output,
+    )
 
 
 class CellHandle:
@@ -141,6 +148,38 @@ class CellHandle:
         """Clear this cell's outputs."""
         await self._session.clear_outputs(self._id)
         return self
+
+    async def set_tags(self, tags: list[str]) -> CellHandle:
+        """Set the cell's tags."""
+        await self._session.set_cell_tags(self._id, tags)
+        return self
+
+    async def set_source_hidden(self, hidden: bool) -> CellHandle:
+        """Show or hide the cell's source."""
+        await self._session.set_cell_source_hidden(self._id, hidden)
+        return self
+
+    async def set_outputs_hidden(self, hidden: bool) -> CellHandle:
+        """Show or hide the cell's outputs."""
+        await self._session.set_cell_outputs_hidden(self._id, hidden)
+        return self
+
+    async def stream(
+        self,
+        timeout_secs: float = 60.0,
+        signal_only: bool = False,
+    ) -> AsyncIterator[ExecutionEvent]:
+        """Execute and stream events as an async iterator.
+
+        Yields ``ExecutionEvent`` objects until execution completes.
+        Use ``signal_only=True`` to receive only start/done signals
+        without output payloads.
+        """
+        return await self._session.stream_execute(
+            self._id,
+            timeout_secs,
+            signal_only,
+        )
 
     def __repr__(self) -> str:
         return f"Cell({self._id[:8]}, {self.cell_type})"

--- a/python/runtimed/src/runtimed/_notebook.py
+++ b/python/runtimed/src/runtimed/_notebook.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from runtimed._cell import CellCollection
+from runtimed._presence import Presence
 
 if TYPE_CHECKING:
-    from runtimed.runtimed import AsyncSession
+    from runtimed.runtimed import AsyncSession, SyncEnvironmentResult
 
 
 class Notebook:
@@ -20,11 +21,12 @@ class Notebook:
     Mutation methods are async (synced to peers).
     """
 
-    __slots__ = ("_session", "_cells")
+    __slots__ = ("_session", "_cells", "_presence")
 
     def __init__(self, async_session: AsyncSession) -> None:
         self._session = async_session
         self._cells: CellCollection | None = None
+        self._presence: Presence | None = None
 
     @property
     def notebook_id(self) -> str:
@@ -36,6 +38,13 @@ class Notebook:
         if self._cells is None:
             self._cells = CellCollection(self._session)
         return self._cells
+
+    @property
+    def presence(self) -> Presence:
+        """Presence operations (cursor, selection, focus)."""
+        if self._presence is None:
+            self._presence = Presence(self._session)
+        return self._presence
 
     @property
     def runtime(self):
@@ -84,9 +93,60 @@ class Notebook:
         """Interrupt the currently executing cell."""
         await self._session.interrupt()
 
+    async def run_all(self) -> int:
+        """Queue all code cells for execution. Returns number of cells queued."""
+        return await self._session.run_all_cells()
+
     async def close(self) -> None:
         """Close the notebook session."""
         await self._session.close()
+
+    # ── Dependency management ────────────────────────────────────────
+
+    async def _package_manager(self) -> str:
+        """Auto-detect the package manager (uv or conda)."""
+        env = await self._session.env_source()
+        if env:
+            return "conda" if env.startswith("conda:") else "uv"
+        env_type = await self._session.get_metadata_env_type()
+        if env_type:
+            return env_type
+        settings = self._session.get_settings()
+        if settings:
+            return settings.get("default_python_env", "uv")
+        return "uv"
+
+    async def add_dependency(self, package: str) -> list[str]:
+        """Add a package dependency. Returns updated dependency list."""
+        pm = await self._package_manager()
+        if pm == "conda":
+            await self._session.add_conda_dependency(package)
+            return await self._session.get_conda_dependencies()
+        else:
+            await self._session.add_uv_dependency(package)
+            return await self._session.get_uv_dependencies()
+
+    async def remove_dependency(self, package: str) -> list[str]:
+        """Remove a package dependency. Returns updated dependency list."""
+        pm = await self._package_manager()
+        if pm == "conda":
+            await self._session.remove_conda_dependency(package)
+            return await self._session.get_conda_dependencies()
+        else:
+            await self._session.remove_uv_dependency(package)
+            return await self._session.get_uv_dependencies()
+
+    async def get_dependencies(self) -> list[str]:
+        """Get current package dependencies."""
+        pm = await self._package_manager()
+        if pm == "conda":
+            return await self._session.get_conda_dependencies()
+        else:
+            return await self._session.get_uv_dependencies()
+
+    async def sync_environment(self) -> SyncEnvironmentResult:
+        """Hot-install dependencies without restarting."""
+        return await self._session.sync_environment()
 
     @property
     def session(self) -> AsyncSession:

--- a/python/runtimed/src/runtimed/_presence.py
+++ b/python/runtimed/src/runtimed/_presence.py
@@ -1,0 +1,69 @@
+"""Presence — cursor, selection, and focus tracking for Notebook."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from runtimed.runtimed import AsyncSession
+
+
+class Presence:
+    """Presence operations for a notebook.
+
+    Access via ``notebook.presence``. All operations are async
+    (synced to peers via the daemon).
+
+    Presence is best-effort — operations silently succeed even if
+    the daemon hasn't fully connected yet. This matches the expectation
+    that cursor/selection state is ephemeral and non-critical.
+    """
+
+    __slots__ = ("_session",)
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    # ── Write operations ─────────────────────────────────────────────
+
+    async def set_cursor(self, cell_id: str, line: int = 0, column: int = 0) -> None:
+        """Set cursor position in a cell."""
+        await self._session.set_cursor(cell_id=cell_id, line=line, column=column)
+
+    async def set_selection(
+        self,
+        cell_id: str,
+        anchor_line: int,
+        anchor_col: int,
+        head_line: int,
+        head_col: int,
+    ) -> None:
+        """Set selection range in a cell."""
+        await self._session.set_selection(
+            cell_id=cell_id,
+            anchor_line=anchor_line,
+            anchor_col=anchor_col,
+            head_line=head_line,
+            head_col=head_col,
+        )
+
+    async def focus(self, cell_id: str) -> None:
+        """Set focus on a cell (without a specific cursor position)."""
+        await self._session.set_focus(cell_id=cell_id)
+
+    async def clear_cursor(self) -> None:
+        """Clear cursor presence."""
+        await self._session.clear_cursor()
+
+    async def clear_selection(self) -> None:
+        """Clear selection presence."""
+        await self._session.clear_selection()
+
+    # ── Read operations ──────────────────────────────────────────────
+
+    async def get_remote_cursors(self) -> list[dict[str, Any]]:
+        """Get cursor positions from other connected peers."""
+        return await self._session.get_remote_cursors()
+
+    def __repr__(self) -> str:
+        return "Presence()"

--- a/python/runtimed/src/runtimed/_presence.py
+++ b/python/runtimed/src/runtimed/_presence.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from runtimed.runtimed import AsyncSession
@@ -61,8 +61,11 @@ class Presence:
 
     # ── Read operations ──────────────────────────────────────────────
 
-    async def get_remote_cursors(self) -> list[dict[str, Any]]:
-        """Get cursor positions from other connected peers."""
+    async def get_remote_cursors(self) -> list[tuple[str, str, str, int, int]]:
+        """Get cursor positions from other connected peers.
+
+        Returns a list of (peer_id, peer_label, cell_id, line, column) tuples.
+        """
         return await self._session.get_remote_cursors()
 
     def __repr__(self) -> str:

--- a/python/runtimed/tests/test_session_unit.py
+++ b/python/runtimed/tests/test_session_unit.py
@@ -54,6 +54,7 @@ class TestModuleExports:
             "NotebookInfo",
             "CellHandle",
             "CellCollection",
+            "Presence",
             # Data types
             "Cell",
             "CompletionItem",


### PR DESCRIPTION
Dogfood the wrapper API — migrate the nteract MCP server from `NativeAsyncClient`/`AsyncSession` to the high-level `Client`/`Notebook`/`CellHandle`/`Presence` API.

This also expands the wrapper surface where dogfooding revealed gaps.

### New wrapper API additions

**Notebook:**
- `add_dependency(package)` / `remove_dependency(package)` / `get_dependencies()` — auto-detects uv vs conda
- `sync_environment()` — hot-install deps
- `run_all()` — queue all code cells
- `presence` → `Presence` object

**CellHandle:**
- `set_tags(tags)` — async mutation
- `set_source_hidden(hidden)` / `set_outputs_hidden(hidden)` — async mutations
- `stream(timeout_secs)` — streaming execution returning async iterator

**Presence** (new class, `notebook.presence`):
- `set_cursor(cell_id, line, column)`
- `set_selection(cell_id, anchor_line, anchor_col, head_line, head_col)`
- `focus(cell_id)`
- `clear_cursor()` / `clear_selection()`
- `get_remote_cursors()`

### MCP server migration

| Operation | Before (escape hatch) | After (wrapper) |
|-----------|----------------------|-----------------|
| Create cell | `session.create_cell()` | `notebook.cells.create()` / `.insert_at()` |
| Delete cell | `session.delete_cell()` | `cell.delete()` |
| Move cell | `session.move_cell()` | `cell.move_after()` |
| Clear outputs | `session.clear_outputs()` | `cell.clear_outputs()` |
| Set source | `session.set_source()` | `cell.set_source()` |
| Set type | `session.set_cell_type()` | `cell.set_type()` |
| Splice | `session.splice_source()` | `cell.splice()` |
| Read source | `session.get_cell_source()` | `cell.source` |
| Tags | `session.get_cell()` + `session.set_cell_tags()` | `cell.tags` + `cell.set_tags()` |
| Hidden | `session.set_cell_source_hidden()` | `cell.set_source_hidden()` |
| Dependencies | `session.add_uv_dependency()` etc. | `notebook.add_dependency()` |
| Sync env | `session.sync_environment()` | `notebook.sync_environment()` |
| Run all | `session.run_all_cells()` | `notebook.run_all()` |
| Stream exec | `session.stream_execute()` | `cell.stream()` |
| Presence | `session.set_cursor()` etc. | `notebook.presence.set_cursor()` etc. |
| Restart | `session.restart_kernel()` | `notebook.restart()` |
| Interrupt | `session.interrupt()` | `notebook.interrupt()` |

### Remaining escape hatch usage

Only `get_cells()`/`get_cell()` for full `Cell` snapshots with resolved outputs (needed by formatting helpers), `is_connected()`/`kernel_started()` for status resource, and `get_queue_state()` for execution status annotations.

### Verified live

All MCP tools tested through the supervisor: create, execute, get_all_cells, list_active_notebooks, tags, hidden, replace_match, move, clear_outputs, delete, run_all.

_PR submitted by @rgbkrk's agent Quill, via Zed_