### PR TITLE
fix(e2e): fix kernel auto-launch and trust flow for fixture notebooks

### DIFF
--- a/crates/notebook-doc/src/metadata.rs
+++ b/crates/notebook-doc/src/metadata.rs
@@ -328,6 +328,11 @@ impl NotebookMetadataSnapshot {
             return Some("deno".to_string());
         }
 
+        // Fall back to runt.uv or runt.conda presence — these are implicitly Python
+        if self.runt.uv.is_some() || self.runt.conda.is_some() {
+            return Some("python".to_string());
+        }
+
         None
     }
 
@@ -894,6 +899,45 @@ mod tests {
             import_map: None,
             config: None,
             flexible_npm_imports: None,
+        });
+        assert_eq!(s.detect_runtime(), Some("deno".to_string()));
+    }
+
+    #[test]
+    fn test_detect_runtime_runt_uv_fallback() {
+        let mut s = NotebookMetadataSnapshot::default();
+        s.runt.uv = Some(UvInlineMetadata {
+            dependencies: vec!["requests".to_string()],
+            requires_python: None,
+            prerelease: None,
+        });
+        assert_eq!(s.detect_runtime(), Some("python".to_string()));
+    }
+
+    #[test]
+    fn test_detect_runtime_runt_conda_fallback() {
+        let mut s = NotebookMetadataSnapshot::default();
+        s.runt.conda = Some(CondaInlineMetadata {
+            dependencies: vec!["numpy".to_string()],
+            channels: vec!["conda-forge".to_string()],
+            python: None,
+        });
+        assert_eq!(s.detect_runtime(), Some("python".to_string()));
+    }
+
+    #[test]
+    fn test_detect_runtime_kernelspec_takes_priority_over_runt_uv() {
+        // kernelspec should still win even if runt.uv is present
+        let mut s = NotebookMetadataSnapshot::default();
+        s.kernelspec = Some(KernelspecSnapshot {
+            name: "deno".to_string(),
+            display_name: "Deno".to_string(),
+            language: Some("typescript".to_string()),
+        });
+        s.runt.uv = Some(UvInlineMetadata {
+            dependencies: vec!["requests".to_string()],
+            requires_python: None,
+            prerelease: None,
         });
         assert_eq!(s.detect_runtime(), Some("deno".to_string()));
     }

--- a/crates/notebook-doc/src/metadata.rs
+++ b/crates/notebook-doc/src/metadata.rs
@@ -905,40 +905,55 @@ mod tests {
 
     #[test]
     fn test_detect_runtime_runt_uv_fallback() {
-        let mut s = NotebookMetadataSnapshot::default();
-        s.runt.uv = Some(UvInlineMetadata {
-            dependencies: vec!["requests".to_string()],
-            requires_python: None,
-            prerelease: None,
-        });
+        let s = NotebookMetadataSnapshot {
+            runt: RuntMetadata {
+                uv: Some(UvInlineMetadata {
+                    dependencies: vec!["requests".to_string()],
+                    requires_python: None,
+                    prerelease: None,
+                }),
+                ..RuntMetadata::default()
+            },
+            ..Default::default()
+        };
         assert_eq!(s.detect_runtime(), Some("python".to_string()));
     }
 
     #[test]
     fn test_detect_runtime_runt_conda_fallback() {
-        let mut s = NotebookMetadataSnapshot::default();
-        s.runt.conda = Some(CondaInlineMetadata {
-            dependencies: vec!["numpy".to_string()],
-            channels: vec!["conda-forge".to_string()],
-            python: None,
-        });
+        let s = NotebookMetadataSnapshot {
+            runt: RuntMetadata {
+                conda: Some(CondaInlineMetadata {
+                    dependencies: vec!["numpy".to_string()],
+                    channels: vec!["conda-forge".to_string()],
+                    python: None,
+                }),
+                ..RuntMetadata::default()
+            },
+            ..Default::default()
+        };
         assert_eq!(s.detect_runtime(), Some("python".to_string()));
     }
 
     #[test]
     fn test_detect_runtime_kernelspec_takes_priority_over_runt_uv() {
         // kernelspec should still win even if runt.uv is present
-        let mut s = NotebookMetadataSnapshot::default();
-        s.kernelspec = Some(KernelspecSnapshot {
-            name: "deno".to_string(),
-            display_name: "Deno".to_string(),
-            language: Some("typescript".to_string()),
-        });
-        s.runt.uv = Some(UvInlineMetadata {
-            dependencies: vec!["requests".to_string()],
-            requires_python: None,
-            prerelease: None,
-        });
+        let s = NotebookMetadataSnapshot {
+            kernelspec: Some(KernelspecSnapshot {
+                name: "deno".to_string(),
+                display_name: "Deno".to_string(),
+                language: Some("typescript".to_string()),
+            }),
+            runt: RuntMetadata {
+                uv: Some(UvInlineMetadata {
+                    dependencies: vec!["requests".to_string()],
+                    requires_python: None,
+                    prerelease: None,
+                }),
+                ..RuntMetadata::default()
+            },
+            ..Default::default()
+        };
         assert_eq!(s.detect_runtime(), Some("deno".to_string()));
     }
 

--- a/crates/notebook/fixtures/audit-test/1-vanilla.ipynb
+++ b/crates/notebook/fixtures/audit-test/1-vanilla.ipynb
@@ -2,6 +2,11 @@
   "nbformat": 4,
   "nbformat_minor": 5,
   "metadata": {
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3",
+      "language": "python"
+    },
     "runt": {
       "schema_version": "1"
     }

--- a/crates/notebook/fixtures/audit-test/2-uv-inline.ipynb
+++ b/crates/notebook/fixtures/audit-test/2-uv-inline.ipynb
@@ -13,6 +13,11 @@
     }
   ],
   "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
     "runt": {
       "env_id": "fixture-uv-inline",
       "uv": {

--- a/crates/notebook/fixtures/audit-test/pyproject-project/5-pyproject.ipynb
+++ b/crates/notebook/fixtures/audit-test/pyproject-project/5-pyproject.ipynb
@@ -13,6 +13,11 @@
     }
   ],
   "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
     "runt": {
       "env_id": "fixture-pyproject"
     }

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -954,7 +954,7 @@ where
         let is_new_notebook =
             !notebook_path_snapshot.exists() && uuid::Uuid::parse_str(&notebook_id).is_ok();
 
-        let (should_auto_launch, trust_status) = {
+        let (should_auto_launch, trust_status, has_kernel) = {
             let trust_state = room.trust_state.read().await;
             let has_kernel = room.has_kernel().await;
             let status = trust_state.status.clone();
@@ -967,7 +967,7 @@ where
                 // For new notebooks (UUID, no file): NoDependencies is safe to auto-launch
                 // For newly-created notebooks at a path: also safe to auto-launch
                 && (notebook_path_snapshot.exists() || is_new_notebook || created_new_at_path);
-            (should_launch, status)
+            (should_launch, status, has_kernel)
         };
 
         if should_auto_launch {
@@ -994,13 +994,11 @@ where
                 )
                 .await;
             });
-        } else if !matches!(
-            trust_status,
-            runt_trust::TrustStatus::Trusted | runt_trust::TrustStatus::NoDependencies
-        ) {
+        } else {
             info!(
-                "[notebook-sync] Notebook {} not trusted, skipping auto-launch (status: {:?})",
-                notebook_id, trust_status
+                "[notebook-sync] Auto-launch skipped for {} (trust: {:?}, has_kernel: {}, path_exists: {}, is_new: {}, created_at_path: {})",
+                notebook_id, trust_status, has_kernel,
+                notebook_path_snapshot.exists(), is_new_notebook, created_new_at_path
             );
         }
     }

--- a/e2e/helpers.js
+++ b/e2e/helpers.js
@@ -284,6 +284,14 @@ export async function approveTrustDialog(timeout = 15000) {
  */
 export async function getKernelStatus() {
   return await browser.execute(() => {
+    // Prefer the data-kernel-status attribute (added in #1041) — it reflects
+    // the raw status enum value and doesn't depend on DOM text rendering.
+    const statusEl = document.querySelector('[data-testid="kernel-status"]');
+    if (statusEl) {
+      const attr = statusEl.getAttribute("data-kernel-status");
+      if (attr) return attr.trim().toLowerCase();
+    }
+    // Fallback: read the visible status text from the toolbar
     const el = document.querySelector(
       '[data-testid="notebook-toolbar"] .capitalize',
     );

--- a/e2e/specs/conda-inline.spec.js
+++ b/e2e/specs/conda-inline.spec.js
@@ -6,8 +6,10 @@
  *
  * Fixture: 3-conda-inline.ipynb (has markupsafe dependency via conda)
  *
- * Updated to use setCellSource + explicit button clicks for compatibility
- * with tauri-plugin-webdriver (synthetic keyboard events don't work).
+ * Flow: Notebooks with inline deps are untrusted by default. The kernel
+ * won't auto-launch until the user approves the trust dialog. This spec
+ * triggers execution to surface the dialog, approves it, then verifies
+ * the kernel starts with the correct conda inline environment.
  */
 
 import { browser } from "@wdio/globals";
@@ -20,9 +22,34 @@ import {
 } from "../helpers.js";
 
 describe("Conda Inline Dependencies", () => {
-  it("should auto-launch kernel (may need trust approval)", async () => {
+  it("should start kernel after trust approval", async () => {
+    console.log("[conda-inline] Waiting for notebook to sync...");
+    await waitForNotebookSynced();
+
+    // For untrusted notebooks, the kernel won't auto-launch.
+    // Trigger execution to surface the trust dialog.
+    const codeCell = await $('[data-cell-type="code"]');
+    await codeCell.waitForExist({ timeout: 10000 });
+
+    await setCellSource(codeCell, "import sys; print(sys.executable)");
+
+    const executeButton = await codeCell.$('[data-testid="execute-button"]');
+    await executeButton.waitForClickable({ timeout: 5000 });
+    await executeButton.click();
+    console.log("[conda-inline] Clicked execute to trigger trust dialog");
+
+    // Approve the trust dialog (inline deps require approval)
+    const approved = await approveTrustDialog(30000);
+    if (approved) {
+      console.log("[conda-inline] Trust dialog approved");
+    } else {
+      console.log(
+        "[conda-inline] No trust dialog appeared (may already be trusted)",
+      );
+    }
+
+    // Now wait for kernel to be ready (300s for conda env creation on cold CI)
     console.log("[conda-inline] Waiting for kernel ready (up to 300s)...");
-    // Wait for kernel or trust dialog (300s for first startup + conda env creation)
     await waitForKernelReady(300000);
     console.log("[conda-inline] Kernel is ready");
   });
@@ -46,48 +73,18 @@ describe("Conda Inline Dependencies", () => {
 
     expect(await depsToggle.getAttribute("data-env-manager")).toBe("conda");
     expect(await depsToggle.getAttribute("data-runtime")).toBe("python");
-    console.log("[conda-inline] Conda badge verified in toolbar");
   });
 
-  it("should have inline deps available after trust", async () => {
-    console.log("[conda-inline] Waiting for notebook to sync...");
-    await waitForNotebookSynced();
-
-    // Find the first code cell
+  it("should execute code in conda inline environment", async () => {
     const codeCell = await $('[data-cell-type="code"]');
     await codeCell.waitForExist({ timeout: 10000 });
-    console.log("[conda-inline] Found first code cell");
 
-    // Set the cell source via CodeMirror dispatch (bypasses keyboard events)
     await setCellSource(codeCell, "import sys; print(sys.executable)");
-    console.log("[conda-inline] Set cell source via setCellSource");
 
-    // Click the execute button
     const executeButton = await codeCell.$('[data-testid="execute-button"]');
     await executeButton.waitForClickable({ timeout: 5000 });
     await executeButton.click();
-    console.log("[conda-inline] Clicked execute button");
 
-    // May need to approve trust dialog for inline deps
-    const approved = await approveTrustDialog(15000);
-    if (approved) {
-      console.log(
-        "[conda-inline] Trust dialog approved, waiting for kernel restart...",
-      );
-      // If trust dialog appeared, wait for kernel to restart with deps
-      await waitForKernelReady(300000);
-      console.log("[conda-inline] Kernel restarted after trust approval");
-
-      // Re-execute after kernel restart by clicking the button again
-      const reExecuteButton = await codeCell.$(
-        '[data-testid="execute-button"]',
-      );
-      await reExecuteButton.waitForClickable({ timeout: 5000 });
-      await reExecuteButton.click();
-      console.log("[conda-inline] Re-executed cell after kernel restart");
-    }
-
-    // Wait for output
     const output = await waitForCellOutput(codeCell, 120000);
     console.log(`[conda-inline] Cell output: ${output}`);
 
@@ -96,31 +93,21 @@ describe("Conda Inline Dependencies", () => {
   });
 
   it("should be able to import inline dependency", async () => {
-    // Find the cells — use a second cell if available, otherwise the first
     const cells = await $$('[data-cell-type="code"]');
     const cell = cells.length > 1 ? cells[1] : cells[0];
-    console.log(
-      `[conda-inline] Using cell index ${cells.length > 1 ? 1 : 0} for import test`,
-    );
 
-    // Set the cell source directly via CodeMirror dispatch
     await setCellSource(
       cell,
       "import markupsafe; print(markupsafe.__version__)",
     );
-    console.log("[conda-inline] Set import test source via setCellSource");
 
-    // Click the execute button
     const executeButton = await cell.$('[data-testid="execute-button"]');
     await executeButton.waitForClickable({ timeout: 5000 });
     await executeButton.click();
-    console.log("[conda-inline] Clicked execute button for import test");
 
-    // Wait for version output
     const output = await waitForCellOutput(cell, 30000);
     console.log(`[conda-inline] Import test output: ${output}`);
 
-    // Should show a version number (e.g., "1.26.4")
     expect(output).toMatch(/^\d+\.\d+/);
   });
 });

--- a/e2e/specs/prewarmed-uv.spec.js
+++ b/e2e/specs/prewarmed-uv.spec.js
@@ -12,9 +12,7 @@
 
 import { browser } from "@wdio/globals";
 import {
-  isManagedEnv,
   setCellSource,
-  waitForAppReady,
   waitForCellOutput,
   waitForKernelReady,
   waitForNotebookSynced,

--- a/e2e/specs/uv-inline.spec.js
+++ b/e2e/specs/uv-inline.spec.js
@@ -6,8 +6,10 @@
  *
  * Fixture: 2-uv-inline.ipynb (has requests dependency)
  *
- * Updated to use setCellSource + explicit button clicks for compatibility
- * with tauri-plugin-webdriver (synthetic keyboard events don't work).
+ * Flow: Notebooks with inline deps are untrusted by default. The kernel
+ * won't auto-launch until the user approves the trust dialog. This spec
+ * triggers execution to surface the dialog, approves it, then verifies
+ * the kernel starts with the correct inline environment.
  */
 
 import { browser } from "@wdio/globals";
@@ -20,9 +22,34 @@ import {
 } from "../helpers.js";
 
 describe("UV Inline Dependencies", () => {
-  it("should auto-launch kernel (may need trust approval)", async () => {
+  it("should start kernel after trust approval", async () => {
+    console.log("[uv-inline] Waiting for notebook to sync...");
+    await waitForNotebookSynced();
+
+    // For untrusted notebooks, the kernel won't auto-launch.
+    // Trigger execution to surface the trust dialog.
+    const codeCell = await $('[data-cell-type="code"]');
+    await codeCell.waitForExist({ timeout: 10000 });
+
+    await setCellSource(codeCell, "import sys; print(sys.executable)");
+
+    const executeButton = await codeCell.$('[data-testid="execute-button"]');
+    await executeButton.waitForClickable({ timeout: 5000 });
+    await executeButton.click();
+    console.log("[uv-inline] Clicked execute to trigger trust dialog");
+
+    // Approve the trust dialog (inline deps require approval)
+    const approved = await approveTrustDialog(30000);
+    if (approved) {
+      console.log("[uv-inline] Trust dialog approved");
+    } else {
+      console.log(
+        "[uv-inline] No trust dialog appeared (may already be trusted)",
+      );
+    }
+
+    // Now wait for kernel to be ready (300s for env creation on cold CI)
     console.log("[uv-inline] Waiting for kernel ready (up to 300s)...");
-    // Wait for kernel or trust dialog (300s for first startup + env creation)
     await waitForKernelReady(300000);
     console.log("[uv-inline] Kernel is ready");
   });
@@ -48,45 +75,16 @@ describe("UV Inline Dependencies", () => {
     expect(await depsToggle.getAttribute("data-runtime")).toBe("python");
   });
 
-  it("should have inline deps available after trust", async () => {
-    console.log("[uv-inline] Waiting for notebook to sync...");
-    await waitForNotebookSynced();
-
-    // Find the first code cell
+  it("should execute code in inline environment", async () => {
     const codeCell = await $('[data-cell-type="code"]');
     await codeCell.waitForExist({ timeout: 10000 });
-    console.log("[uv-inline] Found first code cell");
 
-    // Set cell source via CodeMirror dispatch (bypasses keyboard events)
     await setCellSource(codeCell, "import sys; print(sys.executable)");
-    console.log("[uv-inline] Set cell source to print sys.executable");
 
-    // Click the execute button explicitly
     const executeButton = await codeCell.$('[data-testid="execute-button"]');
     await executeButton.waitForClickable({ timeout: 5000 });
     await executeButton.click();
-    console.log("[uv-inline] Clicked execute button");
 
-    // May need to approve trust dialog for inline deps
-    const approved = await approveTrustDialog(15000);
-    if (approved) {
-      console.log(
-        "[uv-inline] Trust dialog approved, waiting for kernel restart...",
-      );
-      // If trust dialog appeared, wait for kernel to restart with deps
-      await waitForKernelReady(300000);
-      console.log("[uv-inline] Kernel restarted after trust approval");
-
-      // Re-execute after kernel restart by clicking execute button again
-      const reExecuteButton = await codeCell.$(
-        '[data-testid="execute-button"]',
-      );
-      await reExecuteButton.waitForClickable({ timeout: 5000 });
-      await reExecuteButton.click();
-      console.log("[uv-inline] Re-executed cell after kernel restart");
-    }
-
-    // Wait for output
     const output = await waitForCellOutput(codeCell, 60000);
     console.log(`[uv-inline] Cell output: ${output}`);
 
@@ -95,24 +93,15 @@ describe("UV Inline Dependencies", () => {
   });
 
   it("should be able to import inline dependency", async () => {
-    // Find a cell to use for the import test
     const cells = await $$('[data-cell-type="code"]');
     const cell = cells.length > 1 ? cells[1] : cells[0];
-    console.log(
-      `[uv-inline] Using cell index ${cells.length > 1 ? 1 : 0} for import test`,
-    );
 
-    // Set cell source via CodeMirror dispatch (replaces typeSlowly)
     await setCellSource(cell, "import requests; print(requests.__version__)");
-    console.log("[uv-inline] Set cell source to import requests");
 
-    // Click the execute button explicitly (replaces Shift+Enter)
     const executeButton = await cell.$('[data-testid="execute-button"]');
     await executeButton.waitForClickable({ timeout: 5000 });
     await executeButton.click();
-    console.log("[uv-inline] Clicked execute button for import test");
 
-    // Wait for version output
     const output = await waitForCellOutput(cell, 30000);
     console.log(`[uv-inline] Import test output: ${output}`);
 


### PR DESCRIPTION
Fixes 5 of 5 failing E2E runners. Three root causes:

### 1. Missing kernelspec in fixture notebooks

The passing fixtures (`10-deno.ipynb`, `14-cell-visibility.ipynb`) all have `kernelspec` in their metadata. The failing ones (`1-vanilla.ipynb`, `2-uv-inline.ipynb`, `5-pyproject.ipynb`) did not, causing `detect_runtime()` to return `None` and the auto-launch to take a less-tested fallback path. Added `python3` kernelspec to all three.

### 2. `detect_runtime()` didn't infer Python from inline deps

When a notebook has `runt.uv` or `runt.conda` metadata but no `kernelspec`, it's clearly a Python notebook. Added a fallback in `detect_runtime()` so these notebooks are correctly identified. Three new tests cover this, and the kernelspec priority chain is preserved (kernelspec > language_info > runt.deno > runt.uv/conda > None).

### 3. Trust-dependent specs had wrong execution flow

The `uv-inline` and `conda-inline` specs started with `waitForKernelReady(300000)`, but untrusted notebooks **block auto-launch** until the user approves the trust dialog. The kernel never starts → 5-minute timeout → failure.

Restructured both specs to: trigger execution (surfacing the trust dialog) → approve → wait for kernel ready.

### Other improvements

- Auto-launch decision now always logs skip reasons (previously silent for non-trust cases)
- `getKernelStatus()` prefers `data-kernel-status` attribute over DOM text parsing
- Removed unused imports in `prewarmed-uv.spec.js`

Closes #1045

_PR submitted by @rgbkrk's agent Quill, via Zed_