### PR TITLE
fix(e2e): poll for kernel status after trust approval and wait for button enabled

### DIFF
--- a/e2e/specs/trust-dialog-dismiss.spec.js
+++ b/e2e/specs/trust-dialog-dismiss.spec.js
@@ -68,7 +68,10 @@ describe("Trust Dialog Dismiss", () => {
     const declineButton = await $('[data-testid="trust-decline-button"]');
     expect(await declineButton.isExisting()).toBe(true);
 
-    // Click the approve button
+    // Wait for the button to be enabled — a checkTrust() call from the
+    // daemon:ready listener can briefly set loading=true, which disables
+    // the buttons. Poll until the disabled attribute clears.
+    await approveButton.waitForEnabled({ timeout: 10000 });
     await approveButton.waitForClickable({ timeout: 5000 });
 
     const clickTime = Date.now();
@@ -88,11 +91,23 @@ describe("Trust Dialog Dismiss", () => {
     const dismissTime = closeTime - clickTime;
     console.log(`[trust-dialog-dismiss] Dialog dismissed in ${dismissTime}ms`);
 
-    // Check kernel status - should be starting or have quickly reached idle
+    // Kernel launch is fire-and-forget — status propagates via RuntimeStateDoc
+    // sync, so poll briefly instead of reading once.
+    await browser.waitUntil(
+      async () => {
+        const s = await getKernelStatus();
+        return s === "starting" || s === "idle" || s === "busy";
+      },
+      {
+        timeout: 10000,
+        interval: 200,
+        timeoutMsg:
+          "Kernel status never reached starting/idle/busy after trust approval",
+      },
+    );
     const statusAfter = await getKernelStatus();
     console.log(
       `[trust-dialog-dismiss] Kernel status after dialog closed: ${statusAfter}`,
     );
-    expect(["starting", "idle", "busy"]).toContain(statusAfter);
   });
 });


### PR DESCRIPTION
Fixes the Trust Dialog E2E runner. Two bugs found by running the test locally and watching the app:

### 1. Approve button disabled during loading race

The `daemon:ready` event triggers `checkTrust()` which briefly sets `loading=true`, disabling the dialog buttons. If WebDriver tries to click during that window, `waitForClickable` times out after 5s. Fix: added `waitForEnabled({ timeout: 10000 })` before `waitForClickable`.

### 2. Kernel status read too early after approval

`handleTrustApprove` calls `launchKernel("auto", "auto")` as fire-and-forget (no `await`). The kernel status propagates via RuntimeStateDoc sync, so it's still `not_started` when read immediately. Fix: replaced the single-read `expect` with a 10s `waitUntil` poll for `starting`/`idle`/`busy`.

Local test result after fix:
```
Trust dialog appeared
Kernel status before trust approval: not_started
Clicked approve button  
Dialog dismissed in 307ms
Kernel status after dialog closed: idle
✓ should close trust dialog on single click without waiting for kernel (1.5s)
```

_PR submitted by @rgbkrk's agent Quill, via Zed_