### PR TITLE
fix(relay): reduce Complete timeout and prioritize sync frames

### DIFF
--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -439,7 +439,14 @@ export function useAutomergeNotebook() {
     // Bypasses the debounce; any pending emission becomes a no-op.
     const msg = handle.generate_sync_message();
     if (msg) {
-      await sendFrame(frame_types.AUTOMERGE_SYNC, msg);
+      try {
+        await sendFrame(frame_types.AUTOMERGE_SYNC, msg);
+      } catch (e) {
+        // Best-effort: don't block callers (execute, save) if the relay
+        // is temporarily unable to forward the sync frame.  The daemon
+        // will catch up on the next successful sync round-trip.
+        logger.warn("[flushSync] failed to send sync frame, continuing", e);
+      }
     }
   }, []);
 

--- a/crates/notebook-sync/src/relay_task.rs
+++ b/crates/notebook-sync/src/relay_task.rs
@@ -65,8 +65,11 @@ where
 
         let select_result = tokio::select! {
             biased;
-            cmd = config.cmd_rx.recv() => SelectResult::Command(cmd),
+            // Prioritize incoming daemon frames (sync, broadcast, presence)
+            // over outgoing commands.  Keeping sync frames flowing prevents
+            // head divergence; commands can wait a tick.
             frame = connection::recv_typed_frame(&mut reader) => SelectResult::Frame(frame),
+            cmd = config.cmd_rx.recv() => SelectResult::Command(cmd),
         };
 
         match select_result {
@@ -181,10 +184,14 @@ async fn send_request_impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
         .await
         .map_err(SyncError::Io)?;
 
-    // Determine timeout based on request type
+    // Determine timeout based on request type.
+    // Completions get a short timeout — they should be fast or not at all,
+    // and a long wait blocks the entire relay (no other commands can be
+    // processed while we wait for the response frame).
     let timeout_secs = match request {
         notebook_protocol::protocol::NotebookRequest::LaunchKernel { .. } => 300,
         notebook_protocol::protocol::NotebookRequest::SyncEnvironment { .. } => 300,
+        notebook_protocol::protocol::NotebookRequest::Complete { .. } => 5,
         _ => 30,
     };
 


### PR DESCRIPTION
## Summary

- **5s timeout for `Complete` requests** (was 30s) — autocomplete should be fast or not at all. A stuck completion was blocking the entire relay select loop for 30s, preventing all other commands (execute, sync frames) from being processed.
- **Bias select loop toward incoming daemon frames** over outgoing commands. Sync/broadcast/presence frames now take priority, preventing head divergence when the relay is under load.
- **Make `flushSync` best-effort** — catches errors instead of aborting execution. If the relay can't forward a sync frame, the daemon catches up on the next round-trip.

## Context

Diagnosed from `runt-nightly diagnostics`: a `Complete` request timed out after 30s, during which the user's execute requests queued up and sync frames couldn't flow. After the timeout, 5 queued executes fired at once, but the notebook was left in a broken state requiring a reload — likely due to sync head divergence from the blocked relay.

## Test plan

- [ ] Verify autocomplete still works normally (responds within 5s)
- [ ] Trigger autocomplete on a busy kernel — should timeout gracefully without blocking executions
- [ ] Execute cells while sync is temporarily disrupted — should proceed with warning, not silently abort

🤖 Generated with [Claude Code](https://claude.com/claude-code)