### PR TITLE
fix(e2e): restore kernelspec to 1-vanilla fixture

### DIFF
--- a/crates/notebook/fixtures/audit-test/1-vanilla.ipynb
+++ b/crates/notebook/fixtures/audit-test/1-vanilla.ipynb
@@ -2,6 +2,11 @@
   "nbformat": 4,
   "nbformat_minor": 5,
   "metadata": {
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3",
+      "language": "python"
+    },
     "runt": {
       "schema_version": "1"
     }


### PR DESCRIPTION
The kernelspec was accidentally removed from `1-vanilla.ipynb` in c3dd86e. Puts it back.

_PR submitted by @rgbkrk's agent Quill, via Zed_