### PR TITLE
fix(notebook): use white text for cell ribbon buttons in light mode

### DIFF
--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -112,7 +112,7 @@ function CellAdder({
               type="button"
               title="Add code cell"
               onClick={() => onAdd("code", afterCellId)}
-              className="flex items-center whitespace-nowrap rounded-sm px-2 py-0.5 text-xs font-medium text-foreground/70 transition-colors hover:bg-white/20 hover:text-foreground dark:text-white/70 dark:hover:text-white"
+              className="flex items-center whitespace-nowrap rounded-sm px-2 py-0.5 text-xs font-medium text-white/70 transition-colors hover:bg-white/20 hover:text-white"
             >
               + Code
             </button>
@@ -120,7 +120,7 @@ function CellAdder({
               type="button"
               title="Add markdown cell"
               onClick={() => onAdd("markdown", afterCellId)}
-              className="flex items-center whitespace-nowrap rounded-sm px-2 py-0.5 text-xs font-medium text-foreground/70 transition-colors hover:bg-white/20 hover:text-foreground dark:text-white/70 dark:hover:text-white"
+              className="flex items-center whitespace-nowrap rounded-sm px-2 py-0.5 text-xs font-medium text-white/70 transition-colors hover:bg-white/20 hover:text-white"
             >
               + Markdown
             </button>


### PR DESCRIPTION
## Summary

- The cell adder ribbon ("+ Code" / "+ Markdown") has a blue background in both light and dark mode, but the button text used `text-foreground/70` which rendered as dark text in light mode
- Changed to `text-white/70` unconditionally so the text is always white against the blue ribbon background, and removed the now-redundant `dark:` variants

<!-- screenshots: light mode before/after -->

## Verification

- [ ] Open a notebook in light mode and hover between cells to reveal the cell adder ribbon
- [ ] Confirm "+ Code" and "+ Markdown" buttons have white text on the blue background
- [ ] Confirm dark mode still looks correct (white text on blue)

_PR submitted by @rgbkrk's agent, Quill_