### PR TITLE
fix(trust): use daemon:ready payload for initial trust state (fixes #1057)

### DIFF
--- a/apps/notebook/src/hooks/useTrust.ts
+++ b/apps/notebook/src/hooks/useTrust.ts
@@ -1,6 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWebview } from "@tauri-apps/api/webview";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { logger } from "../lib/logger";
 
 /** Trust status from the backend */
@@ -89,11 +89,40 @@ export function useTrust() {
     checkTrust();
   }, [checkTrust]);
 
-  // Re-check trust when daemon (re)connects — handles the startup race where
-  // the initial mount-time check fires before the relay handle is stored.
+  // Use needs_trust_approval from daemon:ready payload as the authoritative
+  // initial trust state. The daemon computes this from the .ipynb file during
+  // room creation — before the Automerge doc is populated via streaming load.
+  // Without this, checkTrust() queries the Automerge doc which may still be
+  // empty, returning NoDependencies and skipping the trust dialog.
+  const hasReceivedDaemonReady = useRef(false);
   useEffect(() => {
     const webview = getCurrentWebview();
-    const unlistenReady = webview.listen("daemon:ready", () => {
+    const unlistenReady = webview.listen<{
+      notebook_id: string;
+      cell_count: number;
+      needs_trust_approval: boolean;
+    }>("daemon:ready", (event) => {
+      const { needs_trust_approval } = event.payload;
+      hasReceivedDaemonReady.current = true;
+
+      if (needs_trust_approval) {
+        // The daemon says this notebook has untrusted deps — set a provisional
+        // "untrusted" state immediately so the dialog appears, then do the full
+        // check to get dependency details (dep names, typosquat warnings, etc.)
+        logger.info(
+          "[trust] daemon:ready says needs_trust_approval=true, showing dialog",
+        );
+        setTrustInfo({
+          status: "untrusted",
+          uv_dependencies: [],
+          conda_dependencies: [],
+          conda_channels: [],
+        });
+      }
+
+      // Full check to populate dependency lists and typosquat warnings.
+      // This reads from the Automerge doc which may now have metadata
+      // (streaming load may have completed by the time this runs).
       checkTrust();
     });
     return () => {

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -484,34 +484,82 @@ async fn resolve_metadata_snapshot(
 fn verify_trust_from_file(notebook_path: &Path) -> TrustState {
     // Read and parse the notebook file
     let metadata = match std::fs::read_to_string(notebook_path) {
-        Ok(content) => match serde_json::from_str::<serde_json::Value>(&content) {
-            Ok(nb) => nb
-                .get("metadata")
-                .and_then(|m| m.as_object())
-                .map(|m| m.iter().map(|(k, v)| (k.clone(), v.clone())).collect())
-                .unwrap_or_default(),
-            Err(_) => std::collections::HashMap::new(),
-        },
-        Err(_) => std::collections::HashMap::new(),
+        Ok(content) => {
+            debug!(
+                "[trust] Read notebook file: {} ({} bytes)",
+                notebook_path.display(),
+                content.len()
+            );
+            match serde_json::from_str::<serde_json::Value>(&content) {
+                Ok(nb) => {
+                    let meta: std::collections::HashMap<String, serde_json::Value> = nb
+                        .get("metadata")
+                        .and_then(|m| m.as_object())
+                        .map(|m| m.iter().map(|(k, v)| (k.clone(), v.clone())).collect())
+                        .unwrap_or_default();
+                    let keys: Vec<&String> = meta.keys().collect();
+                    debug!("[trust] Metadata keys: {:?}", keys);
+                    if let Some(runt) = meta.get("runt") {
+                        debug!("[trust] runt metadata: {}", runt);
+                    }
+                    meta
+                }
+                Err(e) => {
+                    warn!("[trust] Failed to parse notebook JSON: {}", e);
+                    std::collections::HashMap::new()
+                }
+            }
+        }
+        Err(e) => {
+            warn!(
+                "[trust] Failed to read notebook file {}: {}",
+                notebook_path.display(),
+                e
+            );
+            std::collections::HashMap::new()
+        }
     };
+
+    let has_deps = runt_trust::has_dependencies(&metadata);
+    debug!(
+        "[trust] has_dependencies={}, path={}",
+        has_deps,
+        notebook_path.display()
+    );
 
     // Verify trust using the shared runt-trust crate
     match runt_trust::verify_notebook_trust(&metadata) {
-        Ok(info) => TrustState {
-            status: info.status.clone(),
-            info,
-            pending_launch: false,
-        },
-        Err(_) => TrustState {
-            status: runt_trust::TrustStatus::Untrusted,
-            info: runt_trust::TrustInfo {
+        Ok(info) => {
+            info!(
+                "[trust] Verification result for {}: {:?} (uv_deps={:?}, conda_deps={:?})",
+                notebook_path.display(),
+                info.status,
+                info.uv_dependencies,
+                info.conda_dependencies,
+            );
+            TrustState {
+                status: info.status.clone(),
+                info,
+                pending_launch: false,
+            }
+        }
+        Err(e) => {
+            warn!(
+                "[trust] Verification error for {}: {}",
+                notebook_path.display(),
+                e
+            );
+            TrustState {
                 status: runt_trust::TrustStatus::Untrusted,
-                uv_dependencies: vec![],
-                conda_dependencies: vec![],
-                conda_channels: vec![],
-            },
-            pending_launch: false,
-        },
+                info: runt_trust::TrustInfo {
+                    status: runt_trust::TrustStatus::Untrusted,
+                    uv_dependencies: vec![],
+                    conda_dependencies: vec![],
+                    conda_channels: vec![],
+                },
+                pending_launch: false,
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Superseded by #1061 which adds trust state to the RuntimeStateDoc instead of relying on events. The daemon:ready payload approach had a race where the event fires before the React listener mounts.