### PR TITLE
fix: voice substitutions for demos, TODO, demuxing, demultiplexing, Jupyter

### DIFF
--- a/.voice-subs
+++ b/.voice-subs
@@ -23,3 +23,7 @@ PR=P R
 tsconfig=T S config
 vitest=vye test
 TypeScript=typescript
+demos=/dˈɛmoʊz/
+TODO=to do
+demuxing=/diːmˈʌksɪŋ/
+demultiplexing=/diːmˈʌltɪplɛksɪŋ/

--- a/.voice-subs
+++ b/.voice-subs
@@ -27,3 +27,4 @@ demos=/dˈɛmoʊz/
 TODO=to do
 demuxing=/diːmˈʌksɪŋ/
 demultiplexing=/diːmˈʌltɪplɛksɪŋ/
+Jupyter=jupiter


### PR DESCRIPTION
Fixes mispronunciations in the voice TTS substitutions file.

| Word | Before | After |
|------|--------|-------|
| demos | "dee-moss" (`dˈimˌɑs`) | "deh-moze" (`dˈɛmoʊz`) |
| TODO | garbled (`tˌiˌOdˌiˈO`) | "to do" |
| demuxing | "deh-muck-sing" (`dˈɛmʌksɪŋ`) | "dee-muck-sing" (`diːmˈʌksɪŋ`) |
| demultiplexing | "deh-multiplex-sing" (`dˈɛməltˌɪplɛksɪŋ`) | "dee-multiplex-sing" (`diːmˈʌltɪplɛksɪŋ`) |
| Jupyter | varies | "jupiter" |

Uses IPA phonemes (`/phonemes/` syntax) for precise control where plain text substitution isn't enough.