### PR TITLE
fix(sync): eliminate sync state consumption race from rapid execution (#1067)

### DIFF
--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -59,7 +59,6 @@ export function useAutomergeNotebook() {
 
   // RxJS subjects for debounced outbound sync.
   const sourceSync$ = useRef(new Subject<void>());
-  const syncReply$ = useRef(new Subject<void>());
 
   // Refresh blob port on mount.
   useEffect(() => {
@@ -95,13 +94,16 @@ export function useAutomergeNotebook() {
     replaceNotebookCells(newCells);
   }, []);
 
-  /** Send a sync message to the Tauri relay (fire-and-forget). */
+  /** Flush local CRDT changes to the Tauri relay (fire-and-forget).
+   *  Uses flush_local_changes + cancel_last_flush to prevent the sync
+   *  state consumption race from #1067. */
   const syncToRelay = useCallback((handle: NotebookHandle) => {
-    const msg = handle.generate_sync_message();
+    const msg = handle.flush_local_changes();
     if (msg) {
-      sendFrame(frame_types.AUTOMERGE_SYNC, msg).catch((e: unknown) =>
-        logger.warn("[automerge-notebook] sync to relay failed:", e),
-      );
+      sendFrame(frame_types.AUTOMERGE_SYNC, msg).catch((e: unknown) => {
+        handle.cancel_last_flush();
+        logger.warn("[automerge-notebook] sync to relay failed:", e);
+      });
     }
   }, []);
 
@@ -202,11 +204,10 @@ export function useAutomergeNotebook() {
       setIsLoading,
       materializeCells,
       outputCache: outputCacheRef.current,
-      onSyncApplied: () => syncReply$.current.next(),
       retrySyncToRelay: () => {
         const handle = handleRef.current;
         if (!handle) return;
-        // Reset sync state so generate_sync_message() produces a fresh
+        // Reset sync state so flush_local_changes() produces a fresh
         // request instead of returning null (which it does when the
         // handle believes it's already in sync with the peer).
         handle.reset_sync_state();
@@ -220,20 +221,6 @@ export function useAutomergeNotebook() {
       .subscribe(() => {
         const handle = handleRef.current;
         if (handle) syncToRelay(handle);
-      });
-
-    // Sync reply: 50ms debounce for coalescing inbound frame replies.
-    const syncReplySub = syncReply$.current
-      .pipe(debounceTime(50))
-      .subscribe(() => {
-        const handle = handleRef.current;
-        if (!handle) return;
-        const reply = handle.generate_sync_reply();
-        if (reply) {
-          sendFrame(frame_types.AUTOMERGE_SYNC, reply).catch((e: unknown) =>
-            logger.warn("[automerge-notebook] sync reply failed:", e),
-          );
-        }
       });
 
     // Bulk output clearing (run-all / restart-and-run-all).
@@ -255,18 +242,11 @@ export function useAutomergeNotebook() {
       frameSub.unsubscribe();
       lifecycleSub.unsubscribe();
       sourceSyncSub.unsubscribe();
-      syncReplySub.unsubscribe();
       clearOutputsSub.unsubscribe();
 
-      // Flush pending sync before freeing handle.
+      // Flush pending local changes before freeing handle.
       if (handleRef.current) {
         syncToRelay(handleRef.current);
-        const reply = handleRef.current.generate_sync_reply();
-        if (reply) {
-          sendFrame(frame_types.AUTOMERGE_SYNC, reply).catch((e: unknown) =>
-            logger.warn("[automerge-notebook] teardown sync reply failed:", e),
-          );
-        }
       }
 
       resetNotebookCells();
@@ -437,15 +417,16 @@ export function useAutomergeNotebook() {
     const handle = handleRef.current;
     if (!handle) return;
     // Bypasses the debounce; any pending emission becomes a no-op.
-    const msg = handle.generate_sync_message();
+    const msg = handle.flush_local_changes();
     if (msg) {
       try {
         await sendFrame(frame_types.AUTOMERGE_SYNC, msg);
       } catch (e) {
-        // Best-effort: don't block callers (execute, save) if the relay
-        // is temporarily unable to forward the sync frame.  The daemon
-        // will catch up on the next successful sync round-trip.
-        logger.warn("[flushSync] failed to send sync frame, continuing", e);
+        // flush_local_changes advanced sync_state (in_flight, sent_hashes).
+        // Cancel to prevent sent_hashes from permanently filtering out
+        // the change data we never delivered (#1067).
+        handle.cancel_last_flush();
+        logger.warn("[flushSync] failed, rolled back sync state", e);
       }
     }
   }, []);

--- a/apps/notebook/src/lib/frame-pipeline.ts
+++ b/apps/notebook/src/lib/frame-pipeline.ts
@@ -84,6 +84,7 @@ interface FrameEvent {
   changed?: boolean;
   changeset?: CellChangeset;
   attributions?: TextAttribution[];
+  reply?: number[]; // Inline sync reply bytes from receive_frame (#1067 fix)
   payload?: unknown;
   state?: unknown; // RuntimeState from RuntimeStateSyncApplied
 }
@@ -119,13 +120,6 @@ export interface FramePipelineDeps {
 
   /** Shared output manifest cache (mutated in place). */
   outputCache: Map<string, JupyterOutput>;
-
-  /**
-   * Called after each `sync_applied` event. The hook uses this to
-   * schedule a debounced sync reply (until Phase 2 inlines it as a
-   * `debounceTime` operator).
-   */
-  onSyncApplied: () => void;
 
   /**
    * Resend the initial sync message. Called by the retry timer when
@@ -199,6 +193,22 @@ export function createFramePipeline(deps: FramePipelineDeps): Subscription {
             });
           }
 
+          // ── Send inline sync reply immediately (fire-and-forget) ───
+          // The reply was generated atomically inside WASM's receive_frame,
+          // eliminating the consumption race from #1067 where a separate
+          // generate_sync_reply() could be preempted by flushSync.
+          if (e.reply) {
+            sendFrame(
+              frame_types.AUTOMERGE_SYNC,
+              new Uint8Array(e.reply),
+            ).catch((err: unknown) =>
+              logger.warn(
+                "[frame-pipeline] inline sync reply send failed:",
+                err,
+              ),
+            );
+          }
+
           // ── Initial sync: materialize immediately (no coalescing) ──
           if (deps.getAwaitingInitialSync()) {
             if (e.changed) {
@@ -213,7 +223,6 @@ export function createFramePipeline(deps: FramePipelineDeps): Subscription {
                     .then(() => {
                       deps.setIsLoading(false);
                       notifyMetadataChanged();
-                      deps.onSyncApplied();
                     })
                     .catch((err: unknown) => {
                       logger.warn(
@@ -221,7 +230,6 @@ export function createFramePipeline(deps: FramePipelineDeps): Subscription {
                         err,
                       );
                       deps.setIsLoading(false);
-                      deps.onSyncApplied();
                     }),
                 );
               }
@@ -233,7 +241,6 @@ export function createFramePipeline(deps: FramePipelineDeps): Subscription {
             // user sees the loading state until real content arrives.
             // Restart the retry timer in case the exchange stalls.
             retrySync$.next();
-            deps.onSyncApplied();
             return EMPTY;
           }
 
@@ -241,7 +248,6 @@ export function createFramePipeline(deps: FramePipelineDeps): Subscription {
           if (e.changed) {
             materialize$.next(e.changeset ?? null);
           }
-          deps.onSyncApplied();
           return EMPTY;
         }),
       )

--- a/apps/notebook/src/lib/notebook-metadata.ts
+++ b/apps/notebook/src/lib/notebook-metadata.ts
@@ -254,13 +254,19 @@ export async function setMetadataSnapshot(
 }
 
 /**
- * Generate a sync message from the WASM doc and send it to the daemon via the Tauri relay pipe.
+ * Flush local CRDT changes to the daemon via the Tauri relay pipe.
+ * Uses flush_local_changes + cancel_last_flush to prevent the sync
+ * state consumption race from #1067.
  */
 async function syncToRelay(): Promise<void> {
   if (!_handle) return;
-  const msg = _handle.generate_sync_message();
+  const msg = _handle.flush_local_changes();
   if (msg) {
-    await sendFrame(frame_types.AUTOMERGE_SYNC, msg);
+    try {
+      await sendFrame(frame_types.AUTOMERGE_SYNC, msg);
+    } catch {
+      _handle.cancel_last_flush();
+    }
   }
 }
 

--- a/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.d.ts
+++ b/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.d.ts
@@ -75,6 +75,21 @@ export class NotebookHandle {
      */
     append_source(cell_id: string, text: string): boolean;
     /**
+     * Roll back sync state after a failed `flush_local_changes()` delivery.
+     *
+     * If the message from `flush_local_changes()` was NOT delivered to the
+     * daemon (e.g. sendFrame failed, relay mutex blocked), call this to clear
+     * `in_flight` and `sent_hashes`. Without this, `generate_sync_message`
+     * will permanently filter out the change data for hashes it believes were
+     * already sent, causing a protocol stall that only `reset_sync_state()`
+     * (page reload) can recover from.
+     *
+     * Clearing `sent_hashes` may cause some change data to be resent on the
+     * next sync message, but the protocol tolerates duplicates — Automerge's
+     * `load_incremental` deduplicates on receive.
+     */
+    cancel_last_flush(): void;
+    /**
      * Get the number of cells in the document.
      */
     cell_count(): number;
@@ -127,32 +142,29 @@ export class NotebookHandle {
      */
     detect_runtime(): string | undefined;
     /**
+     * Flush any pending local changes as a sync message to send to the daemon.
+     *
+     * Call this after local CRDT mutations (cell edits, metadata changes) to
+     * push them to the daemon. Returns the message as a byte array, or
+     * `undefined` if there are no unsent local changes.
+     *
+     * This is the ONLY way to generate an outbound sync message besides the
+     * reply embedded in `receive_frame()`. Having exactly two controlled paths
+     * (reply-to-inbound and flush-local) prevents the consumption race from
+     * #1067 where `flushSync` and `syncReply$` both called
+     * `generate_sync_message`, racing on the shared `sync_state`.
+     *
+     * If the returned message cannot be delivered, the caller MUST call
+     * `cancel_last_flush()` to prevent `sent_hashes` from permanently
+     * filtering out the undelivered change data.
+     */
+    flush_local_changes(): Uint8Array | undefined;
+    /**
      * Generate a sync reply for the RuntimeStateDoc.
      * Called immediately after each `RuntimeStateSyncApplied` event
      * so the daemon knows which state the client has received.
      */
     generate_runtime_state_sync_reply(): Uint8Array | undefined;
-    /**
-     * Generate a sync message to send to the daemon (via the Tauri relay pipe).
-     *
-     * Returns the message as a byte array, or undefined if already in sync.
-     * The caller should prepend the frame type byte (0x00 for AutomergeSync)
-     * and send via `invoke("send_frame", { frameData })`.
-     */
-    generate_sync_message(): Uint8Array | undefined;
-    /**
-     * Generate a sync reply after one or more inbound frames have been applied.
-     *
-     * This is the same operation as `generate_sync_message()` but named to
-     * communicate the intended usage: the frontend should call this on a
-     * debounce timer after processing inbound sync frames, rather than
-     * replying to every frame individually.
-     *
-     * Safe to call after multiple `receive_frame()` calls — each receive
-     * applies changes cumulatively, and one generate covers everything.
-     * The Automerge sync protocol converges regardless of reply timing.
-     */
-    generate_sync_reply(): Uint8Array | undefined;
     /**
      * Get the actor identity label for this document.
      */
@@ -268,12 +280,15 @@ export class NotebookHandle {
      *
      * Returns a JS array of `FrameEvent` objects directly via `serde-wasm-bindgen`
      * (no JSON string intermediate). Sync frames return a single `sync_applied`
-     * event with an optional `CellChangeset`.
+     * event with an optional `CellChangeset` and an optional `reply`.
      *
-     * **Sync replies are NOT generated here.** The frontend must call
-     * `generate_sync_reply()` on a debounce timer to send replies back to the
-     * daemon. This avoids an IPC-per-frame amplification loop — multiple
-     * inbound frames coalesce into a single outbound reply.
+     * **Sync replies are generated atomically** within this method after applying
+     * each inbound `AUTOMERGE_SYNC` frame. The reply bytes (if any) are returned
+     * in `FrameEvent::SyncApplied.reply` — the caller should send them immediately
+     * via `sendFrame(0x00, reply)`. This eliminates the consumption race from #1067
+     * where a separate `generate_sync_reply()` call could be preempted by
+     * `flushSync`'s `generate_sync_message()`, both competing on the same
+     * `sync_state`.
      *
      * Returns `undefined` if the frame is empty or cannot be processed.
      */
@@ -510,7 +525,8 @@ export interface InitOutput {
     readonly notebookhandle_clear_conda_section: (a: number, b: number) => void;
     readonly notebookhandle_set_conda_channels: (a: number, b: number, c: number, d: number) => void;
     readonly notebookhandle_set_conda_python: (a: number, b: number, c: number, d: number) => void;
-    readonly notebookhandle_generate_sync_message: (a: number, b: number) => void;
+    readonly notebookhandle_flush_local_changes: (a: number, b: number) => void;
+    readonly notebookhandle_cancel_last_flush: (a: number) => void;
     readonly notebookhandle_receive_sync_message: (a: number, b: number, c: number, d: number) => void;
     readonly notebookhandle_save: (a: number, b: number) => void;
     readonly notebookhandle_generate_runtime_state_sync_reply: (a: number, b: number) => void;
@@ -521,7 +537,6 @@ export interface InitOutput {
     readonly encode_selection_presence: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number, i: number) => void;
     readonly encode_focus_presence: (a: number, b: number, c: number, d: number, e: number) => void;
     readonly encode_clear_channel_presence: (a: number, b: number, c: number, d: number, e: number) => void;
-    readonly notebookhandle_generate_sync_reply: (a: number, b: number) => void;
     readonly __wbindgen_export: (a: number, b: number) => number;
     readonly __wbindgen_export2: (a: number, b: number, c: number, d: number) => number;
     readonly __wbindgen_export3: (a: number) => void;

--- a/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.js
+++ b/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.js
@@ -347,6 +347,23 @@ export class NotebookHandle {
         }
     }
     /**
+     * Roll back sync state after a failed `flush_local_changes()` delivery.
+     *
+     * If the message from `flush_local_changes()` was NOT delivered to the
+     * daemon (e.g. sendFrame failed, relay mutex blocked), call this to clear
+     * `in_flight` and `sent_hashes`. Without this, `generate_sync_message`
+     * will permanently filter out the change data for hashes it believes were
+     * already sent, causing a protocol stall that only `reset_sync_state()`
+     * (page reload) can recover from.
+     *
+     * Clearing `sent_hashes` may cause some change data to be resent on the
+     * next sync message, but the protocol tolerates duplicates — Automerge's
+     * `load_incremental` deduplicates on receive.
+     */
+    cancel_last_flush() {
+        wasm.notebookhandle_cancel_last_flush(this.__wbg_ptr);
+    }
+    /**
      * Get the number of cells in the document.
      * @returns {number}
      */
@@ -521,6 +538,40 @@ export class NotebookHandle {
         }
     }
     /**
+     * Flush any pending local changes as a sync message to send to the daemon.
+     *
+     * Call this after local CRDT mutations (cell edits, metadata changes) to
+     * push them to the daemon. Returns the message as a byte array, or
+     * `undefined` if there are no unsent local changes.
+     *
+     * This is the ONLY way to generate an outbound sync message besides the
+     * reply embedded in `receive_frame()`. Having exactly two controlled paths
+     * (reply-to-inbound and flush-local) prevents the consumption race from
+     * #1067 where `flushSync` and `syncReply$` both called
+     * `generate_sync_message`, racing on the shared `sync_state`.
+     *
+     * If the returned message cannot be delivered, the caller MUST call
+     * `cancel_last_flush()` to prevent `sent_hashes` from permanently
+     * filtering out the undelivered change data.
+     * @returns {Uint8Array | undefined}
+     */
+    flush_local_changes() {
+        try {
+            const retptr = wasm.__wbindgen_add_to_stack_pointer(-16);
+            wasm.notebookhandle_flush_local_changes(retptr, this.__wbg_ptr);
+            var r0 = getDataViewMemory0().getInt32(retptr + 4 * 0, true);
+            var r1 = getDataViewMemory0().getInt32(retptr + 4 * 1, true);
+            let v1;
+            if (r0 !== 0) {
+                v1 = getArrayU8FromWasm0(r0, r1).slice();
+                wasm.__wbindgen_export4(r0, r1 * 1, 1);
+            }
+            return v1;
+        } finally {
+            wasm.__wbindgen_add_to_stack_pointer(16);
+        }
+    }
+    /**
      * Generate a sync reply for the RuntimeStateDoc.
      * Called immediately after each `RuntimeStateSyncApplied` event
      * so the daemon knows which state the client has received.
@@ -530,59 +581,6 @@ export class NotebookHandle {
         try {
             const retptr = wasm.__wbindgen_add_to_stack_pointer(-16);
             wasm.notebookhandle_generate_runtime_state_sync_reply(retptr, this.__wbg_ptr);
-            var r0 = getDataViewMemory0().getInt32(retptr + 4 * 0, true);
-            var r1 = getDataViewMemory0().getInt32(retptr + 4 * 1, true);
-            let v1;
-            if (r0 !== 0) {
-                v1 = getArrayU8FromWasm0(r0, r1).slice();
-                wasm.__wbindgen_export4(r0, r1 * 1, 1);
-            }
-            return v1;
-        } finally {
-            wasm.__wbindgen_add_to_stack_pointer(16);
-        }
-    }
-    /**
-     * Generate a sync message to send to the daemon (via the Tauri relay pipe).
-     *
-     * Returns the message as a byte array, or undefined if already in sync.
-     * The caller should prepend the frame type byte (0x00 for AutomergeSync)
-     * and send via `invoke("send_frame", { frameData })`.
-     * @returns {Uint8Array | undefined}
-     */
-    generate_sync_message() {
-        try {
-            const retptr = wasm.__wbindgen_add_to_stack_pointer(-16);
-            wasm.notebookhandle_generate_sync_message(retptr, this.__wbg_ptr);
-            var r0 = getDataViewMemory0().getInt32(retptr + 4 * 0, true);
-            var r1 = getDataViewMemory0().getInt32(retptr + 4 * 1, true);
-            let v1;
-            if (r0 !== 0) {
-                v1 = getArrayU8FromWasm0(r0, r1).slice();
-                wasm.__wbindgen_export4(r0, r1 * 1, 1);
-            }
-            return v1;
-        } finally {
-            wasm.__wbindgen_add_to_stack_pointer(16);
-        }
-    }
-    /**
-     * Generate a sync reply after one or more inbound frames have been applied.
-     *
-     * This is the same operation as `generate_sync_message()` but named to
-     * communicate the intended usage: the frontend should call this on a
-     * debounce timer after processing inbound sync frames, rather than
-     * replying to every frame individually.
-     *
-     * Safe to call after multiple `receive_frame()` calls — each receive
-     * applies changes cumulatively, and one generate covers everything.
-     * The Automerge sync protocol converges regardless of reply timing.
-     * @returns {Uint8Array | undefined}
-     */
-    generate_sync_reply() {
-        try {
-            const retptr = wasm.__wbindgen_add_to_stack_pointer(-16);
-            wasm.notebookhandle_generate_sync_reply(retptr, this.__wbg_ptr);
             var r0 = getDataViewMemory0().getInt32(retptr + 4 * 0, true);
             var r1 = getDataViewMemory0().getInt32(retptr + 4 * 1, true);
             let v1;
@@ -987,12 +985,15 @@ export class NotebookHandle {
      *
      * Returns a JS array of `FrameEvent` objects directly via `serde-wasm-bindgen`
      * (no JSON string intermediate). Sync frames return a single `sync_applied`
-     * event with an optional `CellChangeset`.
+     * event with an optional `CellChangeset` and an optional `reply`.
      *
-     * **Sync replies are NOT generated here.** The frontend must call
-     * `generate_sync_reply()` on a debounce timer to send replies back to the
-     * daemon. This avoids an IPC-per-frame amplification loop — multiple
-     * inbound frames coalesce into a single outbound reply.
+     * **Sync replies are generated atomically** within this method after applying
+     * each inbound `AUTOMERGE_SYNC` frame. The reply bytes (if any) are returned
+     * in `FrameEvent::SyncApplied.reply` — the caller should send them immediately
+     * via `sendFrame(0x00, reply)`. This eliminates the consumption race from #1067
+     * where a separate `generate_sync_reply()` call could be preempted by
+     * `flushSync`'s `generate_sync_message()`, both competing on the same
+     * `sync_state`.
      *
      * Returns `undefined` if the frame is empty or cannot be processed.
      * @param {Uint8Array} frame_bytes

--- a/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm
+++ b/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9672b3eee66bb8a083d295ac88edab45dc0ba434100482c5e9681635f0458068
-size 1612013
+oid sha256:68eddb9a5b6a05c976f2bde2575bd6e1c1f71c151604f6dd313a5a29d22eca49
+size 1613020

--- a/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm.d.ts
+++ b/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm.d.ts
@@ -67,7 +67,8 @@ export const notebookhandle_remove_conda_dependency: (a: number, b: number, c: n
 export const notebookhandle_clear_conda_section: (a: number, b: number) => void;
 export const notebookhandle_set_conda_channels: (a: number, b: number, c: number, d: number) => void;
 export const notebookhandle_set_conda_python: (a: number, b: number, c: number, d: number) => void;
-export const notebookhandle_generate_sync_message: (a: number, b: number) => void;
+export const notebookhandle_flush_local_changes: (a: number, b: number) => void;
+export const notebookhandle_cancel_last_flush: (a: number) => void;
 export const notebookhandle_receive_sync_message: (a: number, b: number, c: number, d: number) => void;
 export const notebookhandle_save: (a: number, b: number) => void;
 export const notebookhandle_generate_runtime_state_sync_reply: (a: number, b: number) => void;
@@ -78,7 +79,6 @@ export const encode_cursor_presence: (a: number, b: number, c: number, d: number
 export const encode_selection_presence: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number, i: number) => void;
 export const encode_focus_presence: (a: number, b: number, c: number, d: number, e: number) => void;
 export const encode_clear_channel_presence: (a: number, b: number, c: number, d: number, e: number) => void;
-export const notebookhandle_generate_sync_reply: (a: number, b: number) => void;
 export const __wbindgen_export: (a: number, b: number) => number;
 export const __wbindgen_export2: (a: number, b: number, c: number, d: number) => number;
 export const __wbindgen_export3: (a: number) => void;

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -72,6 +72,12 @@ pub enum FrameEvent {
         /// Empty when `changed` is false or when only non-source fields changed.
         #[serde(skip_serializing_if = "Vec::is_empty")]
         attributions: Vec<TextAttribution>,
+        /// Sync reply to send back to the daemon, generated atomically after
+        /// applying the inbound message. `None` when the protocol has nothing
+        /// to send (e.g. already in sync). The caller should prepend frame type
+        /// byte 0x00 and send via `sendFrame`.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        reply: Option<Vec<u8>>,
     },
     /// Broadcast event from the daemon (kernel status, output, etc.)
     Broadcast {
@@ -779,31 +785,42 @@ impl NotebookHandle {
             .map_err(|e| JsError::new(&format!("set_conda_python failed: {}", e)))
     }
 
-    /// Generate a sync message to send to the daemon (via the Tauri relay pipe).
+    /// Flush any pending local changes as a sync message to send to the daemon.
     ///
-    /// Returns the message as a byte array, or undefined if already in sync.
-    /// The caller should prepend the frame type byte (0x00 for AutomergeSync)
-    /// and send via `invoke("send_frame", { frameData })`.
-    pub fn generate_sync_message(&mut self) -> Option<Vec<u8>> {
+    /// Call this after local CRDT mutations (cell edits, metadata changes) to
+    /// push them to the daemon. Returns the message as a byte array, or
+    /// `undefined` if there are no unsent local changes.
+    ///
+    /// This is the ONLY way to generate an outbound sync message besides the
+    /// reply embedded in `receive_frame()`. Having exactly two controlled paths
+    /// (reply-to-inbound and flush-local) prevents the consumption race from
+    /// #1067 where `flushSync` and `syncReply$` both called
+    /// `generate_sync_message`, racing on the shared `sync_state`.
+    ///
+    /// If the returned message cannot be delivered, the caller MUST call
+    /// `cancel_last_flush()` to prevent `sent_hashes` from permanently
+    /// filtering out the undelivered change data.
+    pub fn flush_local_changes(&mut self) -> Option<Vec<u8>> {
         self.doc
             .generate_sync_message(&mut self.sync_state)
             .map(|msg| msg.encode())
     }
 
-    /// Generate a sync reply after one or more inbound frames have been applied.
+    /// Roll back sync state after a failed `flush_local_changes()` delivery.
     ///
-    /// This is the same operation as `generate_sync_message()` but named to
-    /// communicate the intended usage: the frontend should call this on a
-    /// debounce timer after processing inbound sync frames, rather than
-    /// replying to every frame individually.
+    /// If the message from `flush_local_changes()` was NOT delivered to the
+    /// daemon (e.g. sendFrame failed, relay mutex blocked), call this to clear
+    /// `in_flight` and `sent_hashes`. Without this, `generate_sync_message`
+    /// will permanently filter out the change data for hashes it believes were
+    /// already sent, causing a protocol stall that only `reset_sync_state()`
+    /// (page reload) can recover from.
     ///
-    /// Safe to call after multiple `receive_frame()` calls — each receive
-    /// applies changes cumulatively, and one generate covers everything.
-    /// The Automerge sync protocol converges regardless of reply timing.
-    pub fn generate_sync_reply(&mut self) -> Option<Vec<u8>> {
-        self.doc
-            .generate_sync_message(&mut self.sync_state)
-            .map(|msg| msg.encode())
+    /// Clearing `sent_hashes` may cause some change data to be resent on the
+    /// next sync message, but the protocol tolerates duplicates — Automerge's
+    /// `load_incremental` deduplicates on receive.
+    pub fn cancel_last_flush(&mut self) {
+        self.sync_state.in_flight = false;
+        self.sync_state.sent_hashes.clear();
     }
 
     /// Receive and apply a sync message from the daemon (via the Tauri relay pipe).
@@ -859,12 +876,15 @@ impl NotebookHandle {
     ///
     /// Returns a JS array of `FrameEvent` objects directly via `serde-wasm-bindgen`
     /// (no JSON string intermediate). Sync frames return a single `sync_applied`
-    /// event with an optional `CellChangeset`.
+    /// event with an optional `CellChangeset` and an optional `reply`.
     ///
-    /// **Sync replies are NOT generated here.** The frontend must call
-    /// `generate_sync_reply()` on a debounce timer to send replies back to the
-    /// daemon. This avoids an IPC-per-frame amplification loop — multiple
-    /// inbound frames coalesce into a single outbound reply.
+    /// **Sync replies are generated atomically** within this method after applying
+    /// each inbound `AUTOMERGE_SYNC` frame. The reply bytes (if any) are returned
+    /// in `FrameEvent::SyncApplied.reply` — the caller should send them immediately
+    /// via `sendFrame(0x00, reply)`. This eliminates the consumption race from #1067
+    /// where a separate `generate_sync_reply()` call could be preempted by
+    /// `flushSync`'s `generate_sync_message()`, both competing on the same
+    /// `sync_state`.
     ///
     /// Returns `undefined` if the frame is empty or cannot be processed.
     pub fn receive_frame(&mut self, frame_bytes: &[u8]) -> JsValue {
@@ -916,10 +936,20 @@ impl NotebookHandle {
                     (None, Vec::new())
                 };
 
+                // Generate sync reply atomically — within the same &mut self
+                // borrow as receive_sync_message. This eliminates the race from
+                // #1067 where a separate generate_sync_reply() call could be
+                // preempted by flushSync's generate_sync_message().
+                let reply = self
+                    .doc
+                    .generate_sync_message(&mut self.sync_state)
+                    .map(|msg| msg.encode());
+
                 events.push(FrameEvent::SyncApplied {
                     changed,
                     changeset,
                     attributions,
+                    reply,
                 });
             }
             frame_types::BROADCAST => {

--- a/crates/runtimed-wasm/tests/cross_impl_test.ts
+++ b/crates/runtimed-wasm/tests/cross_impl_test.ts
@@ -135,8 +135,8 @@ Deno.test("Cross-impl: WASM sync between two independent handles", () => {
 
   // Sync messages exchange
   for (let i = 0; i < 10; i++) {
-    const msgA = frontend.generate_sync_message();
-    const msgB = relay.generate_sync_message();
+    const msgA = frontend.flush_local_changes();
+    const msgB = relay.flush_local_changes();
     if (!msgA && !msgB) break;
     if (msgA) relay.receive_sync_message(msgA);
     if (msgB) frontend.receive_sync_message(msgB);

--- a/crates/runtimed-wasm/tests/deno_smoke_test.ts
+++ b/crates/runtimed-wasm/tests/deno_smoke_test.ts
@@ -353,6 +353,206 @@ Deno.test("Sync: generate_sync_message returns null when in sync", () => {
   client.free();
 });
 
+// ── Bug reproduction: #1067 — sync head divergence ───────────────────
+
+Deno.test("Bug #1067: consumed sync message causes protocol stall", () => {
+  // Reproduces the rapid Ctrl+Enter bug where flushSync() calls
+  // generate_sync_message() (advancing sync_state) but the message
+  // is never delivered to the server. The sync protocol stalls because
+  // sync_state believes the message was sent.
+  //
+  // This simulates:
+  //   1. Server makes a change (kernel writes output)
+  //   2. Client receives the sync message (WASM applies it)
+  //   3. Client calls generate_sync_message() — like flushSync() does
+  //   4. The message is DROPPED (simulating failed/delayed sendFrame)
+  //   5. Server makes another change
+  //   6. Client should still be able to sync — but can't
+
+  const server = new NotebookHandle("stall-test");
+  server.add_cell(0, "cell-1", "code");
+
+  const client = NotebookHandle.load(server.save());
+  syncHandles(server, client);
+
+  // Step 1: Server makes a change (simulates daemon writing output)
+  server.update_source("cell-1", "output-v1");
+
+  // Step 2: Client receives the server's sync message
+  const serverMsg1 = server.generate_sync_message();
+  assert(serverMsg1 !== undefined, "server should have a sync message");
+  const changed = client.receive_sync_message(serverMsg1);
+  assert(changed, "client doc should have changed");
+
+  // Step 3: Client generates a reply — like flushSync() does.
+  // This ADVANCES client's sync_state.last_sent_heads.
+  const consumedReply = client.generate_sync_message();
+  assert(consumedReply !== undefined, "client should have a reply");
+
+  // Step 4: The reply is DROPPED. Never delivered to server.
+  // (Simulates sendFrame failing or being blocked by the relay mutex)
+
+  // Step 5: Server makes another change
+  server.update_source("cell-1", "output-v2");
+
+  // Step 6: Try to sync. The client's sync_state thinks it already
+  // sent a reply for output-v1, so generate_sync_message may return
+  // nothing — even though the server never received the reply.
+  //
+  // Meanwhile, the server sends its new change. Let's see if the
+  // protocol can recover.
+  const serverMsg2 = server.generate_sync_message();
+  assert(serverMsg2 !== undefined, "server should have msg for output-v2");
+  client.receive_sync_message(serverMsg2);
+
+  // The client should now generate a reply that covers BOTH the
+  // previously-dropped reply AND the new change.
+  const recoveryReply = client.generate_sync_message();
+
+  // THIS IS THE BUG: if recoveryReply is undefined, the protocol has
+  // stalled. The client thinks it's in sync (because sync_state was
+  // advanced by the dropped message) but the server disagrees.
+  //
+  // If Automerge's sync protocol is resilient to this, recoveryReply
+  // will be defined and delivering it will converge the two docs.
+  if (recoveryReply === undefined) {
+    // Protocol stalled — this is the bug.
+    // Verify the docs have diverged.
+    const serverCell = server.get_cell("cell-1");
+    const clientCell = client.get_cell("cell-1");
+    assertExists(serverCell);
+    assertExists(clientCell);
+
+    // Client should have output-v2 (it received the sync message)
+    assertEquals(clientCell.source, "output-v2");
+    clientCell.free();
+
+    // Server should also have output-v2 (it wrote it)
+    assertEquals(serverCell.source, "output-v2");
+    serverCell.free();
+
+    // But can the server see what the client knows? Without the reply,
+    // the server can't advance. Let's check if a full sync recovers.
+    // This simulates what happens after a page reload (reset_sync_state).
+    console.warn(
+      "BUG #1067 REPRODUCED: generate_sync_message() returned undefined " +
+        "after dropped message. Protocol stalled. Testing reset recovery...",
+    );
+
+    // Reset sync state (simulates page reload)
+    client.reset_sync_state();
+    syncHandles(server, client);
+
+    const recoveredCell = server.get_cell("cell-1");
+    assertExists(recoveredCell);
+    assertEquals(recoveredCell.source, "output-v2");
+    recoveredCell.free();
+  } else {
+    // Protocol recovered — deliver the reply and verify convergence.
+    server.receive_sync_message(recoveryReply);
+    syncHandles(server, client);
+
+    const serverCell = server.get_cell("cell-1");
+    assertExists(serverCell);
+    assertEquals(serverCell.source, "output-v2");
+    serverCell.free();
+  }
+
+  server.free();
+  client.free();
+});
+
+Deno.test("Bug #1067: rapid flushSync steals debounced reply", () => {
+  // Simulates the exact interleaving from the bug:
+  //   - Server streams outputs (multiple sync frames)
+  //   - Client calls generate_sync_reply (debounced) — but before it fires,
+  //     flushSync calls generate_sync_message, consuming the pending reply
+  //   - The debounced reply then returns undefined
+
+  const server = new NotebookHandle("rapid-test");
+  server.add_cell(0, "cell-1", "code");
+
+  const client = NotebookHandle.load(server.save());
+  syncHandles(server, client);
+
+  // Server streams multiple rapid changes (simulates IOPub output burst)
+  server.update_source("cell-1", "line 1");
+  const msg1 = server.generate_sync_message();
+  assert(msg1 !== undefined);
+  client.receive_sync_message(msg1);
+
+  server.update_source("cell-1", "line 1\nline 2");
+  const msg2 = server.generate_sync_message();
+  assert(msg2 !== undefined);
+  client.receive_sync_message(msg2);
+
+  server.update_source("cell-1", "line 1\nline 2\nline 3");
+  const msg3 = server.generate_sync_message();
+  assert(msg3 !== undefined);
+  client.receive_sync_message(msg3);
+
+  // At this point, the client has 3 unacknowledged inbound syncs.
+  // A debounced syncReply$ would call generate_sync_reply() here.
+  // But flushSync() fires first (user presses Ctrl+Enter):
+
+  const flushMsg = client.generate_sync_message(); // flushSync steals it
+  // flushMsg is defined — it covers all 3 inbound syncs.
+
+  // Now the debounced syncReply fires:
+  const debouncedReply = client.generate_sync_message(); // generates reply
+
+  // The debounced reply should ideally still work, but if flushMsg
+  // already advanced sync_state, debouncedReply may be undefined.
+  // This demonstrates the consumption race.
+
+  if (flushMsg !== undefined && debouncedReply === undefined) {
+    console.warn(
+      "BUG #1067 CONFIRMED: flushSync consumed the debounced reply. " +
+        "If flushMsg delivery fails, no recovery path exists.",
+    );
+
+    // Simulate flushMsg delivery failure (best-effort catch from PR #1053)
+    // The message is lost. Can the protocol recover?
+
+    // Server makes a new change
+    server.update_source("cell-1", "line 1\nline 2\nline 3\nline 4");
+    const msg4 = server.generate_sync_message();
+    assert(msg4 !== undefined, "server should still produce messages");
+    client.receive_sync_message(msg4);
+
+    // Client tries to reply again
+    const retryReply = client.generate_sync_message();
+
+    if (retryReply === undefined) {
+      console.warn(
+        "STALL CONFIRMED: client cannot generate reply after lost flushSync. " +
+          "Only reset_sync_state() (page reload) recovers.",
+      );
+    } else {
+      // Partial recovery — deliver and check convergence
+      server.receive_sync_message(retryReply);
+      syncHandles(server, client);
+    }
+  }
+
+  // Regardless of the race outcome, verify final state consistency
+  // after a full reset + sync (simulates page reload)
+  client.reset_sync_state();
+  syncHandles(server, client);
+
+  const clientCell = client.get_cell("cell-1");
+  assertExists(clientCell);
+  // Client should have whatever the server's latest source is
+  const serverCell = server.get_cell("cell-1");
+  assertExists(serverCell);
+  assertEquals(clientCell.source, serverCell.source);
+  clientCell.free();
+  serverCell.free();
+
+  server.free();
+  client.free();
+});
+
 Deno.test("Sync: source edit character-level merge", () => {
   const server = new NotebookHandle("sync-test");
   server.add_cell(0, "cell-1", "code");

--- a/crates/runtimed-wasm/tests/deno_smoke_test.ts
+++ b/crates/runtimed-wasm/tests/deno_smoke_test.ts
@@ -553,6 +553,359 @@ Deno.test("Bug #1067: rapid flushSync steals debounced reply", () => {
   client.free();
 });
 
+// ── Regression tests: #1067 fix verification ─────────────────────────
+
+Deno.test("Fix #1067: receive_frame returns inline sync reply", () => {
+  // After the fix, receive_frame() generates a reply atomically after
+  // applying an AUTOMERGE_SYNC frame. The reply is in FrameEvent.reply.
+  const server = new NotebookHandle("reply-test");
+  server.add_cell(0, "cell-1", "code");
+  server.update_source("cell-1", "hello");
+
+  const client = NotebookHandle.load(server.save());
+  syncHandles(server, client);
+
+  // Server makes a change
+  server.update_source("cell-1", "hello world");
+  const serverMsg = server.flush_local_changes();
+  assert(serverMsg !== undefined, "server should have a sync message");
+
+  // Client receives via receive_frame (with 0x00 type byte prefix)
+  const frameBytes = new Uint8Array(1 + serverMsg.length);
+  frameBytes[0] = 0x00; // AUTOMERGE_SYNC
+  frameBytes.set(serverMsg, 1);
+
+  const events = client.receive_frame(frameBytes);
+  assert(Array.isArray(events), "receive_frame should return an array");
+  assertEquals(events.length, 1);
+
+  const event = events[0];
+  assertEquals(event.type, "sync_applied");
+  assertEquals(event.changed, true);
+
+  // The fix: reply should be present — generated atomically
+  assert(
+    event.reply !== undefined && event.reply !== null,
+    "SyncApplied should include a reply (the core #1067 fix)",
+  );
+
+  // Deliver the reply to the server — should converge
+  server.receive_sync_message(new Uint8Array(event.reply));
+
+  // Verify convergence
+  const serverCell = server.get_cell("cell-1");
+  const clientCell = client.get_cell("cell-1");
+  assertExists(serverCell);
+  assertExists(clientCell);
+  assertEquals(serverCell.source, "hello world");
+  assertEquals(clientCell.source, "hello world");
+  serverCell.free();
+  clientCell.free();
+
+  server.free();
+  client.free();
+});
+
+Deno.test(
+  "Fix #1067: flush_local_changes only fires for local mutations",
+  () => {
+    const server = new NotebookHandle("flush-test");
+    server.add_cell(0, "cell-1", "code");
+
+    const client = NotebookHandle.load(server.save());
+    syncHandles(server, client);
+
+    // No local changes — flush should return undefined
+    assertEquals(
+      client.flush_local_changes(),
+      undefined,
+      "flush_local_changes should return undefined when no local changes exist",
+    );
+
+    // Make a local change
+    client.update_source("cell-1", "edited");
+
+    // Now flush should return bytes
+    const msg = client.flush_local_changes();
+    assert(
+      msg !== undefined,
+      "flush_local_changes should return bytes after local edit",
+    );
+
+    // Calling again without new changes — should return undefined (in_flight)
+    assertEquals(
+      client.flush_local_changes(),
+      undefined,
+      "flush_local_changes should return undefined after already flushing (in_flight)",
+    );
+
+    server.free();
+    client.free();
+  },
+);
+
+Deno.test("Fix #1067: no reply consumption race with new API", () => {
+  // This tests that the old race can't happen with the new API:
+  // receive_frame generates replies inline, so flush_local_changes
+  // can't steal them.
+  const server = new NotebookHandle("no-race-test");
+  server.add_cell(0, "cell-1", "code");
+
+  const client = NotebookHandle.load(server.save());
+  syncHandles(server, client);
+
+  // Server streams rapid changes (simulates IOPub output burst)
+  server.update_source("cell-1", "output-v1");
+  const msg1 = server.flush_local_changes();
+  assert(msg1 !== undefined);
+
+  server.update_source("cell-1", "output-v2");
+  const msg2 = server.flush_local_changes();
+  assert(msg2 !== undefined);
+
+  // Client receives both via receive_frame — replies generated inline
+  const frame1 = new Uint8Array(1 + msg1.length);
+  frame1[0] = 0x00;
+  frame1.set(msg1, 1);
+  const events1 = client.receive_frame(frame1);
+  const reply1 = events1[0]?.reply;
+
+  const frame2 = new Uint8Array(1 + msg2.length);
+  frame2[0] = 0x00;
+  frame2.set(msg2, 1);
+  const events2 = client.receive_frame(frame2);
+  const reply2 = events2[0]?.reply;
+
+  // Now client calls flush_local_changes (simulating flushSync before execute)
+  // This should NOT consume any pending reply — replies were already generated
+  // inline by receive_frame.
+  const flushMsg = client.flush_local_changes();
+  // flushMsg should be undefined — client has no local changes, only received changes
+  assertEquals(
+    flushMsg,
+    undefined,
+    "flush_local_changes should return undefined when client only received (no local edits)",
+  );
+
+  // Deliver whichever replies were generated — protocol should converge
+  if (reply1) server.receive_sync_message(new Uint8Array(reply1));
+  if (reply2) server.receive_sync_message(new Uint8Array(reply2));
+  syncHandles(server, client);
+
+  const clientCell = client.get_cell("cell-1");
+  assertExists(clientCell);
+  assertEquals(clientCell.source, "output-v2");
+  clientCell.free();
+
+  server.free();
+  client.free();
+});
+
+Deno.test("Fix #1067: cancel_last_flush recovers from failed send", () => {
+  // Tests that cancel_last_flush clears in_flight and sent_hashes,
+  // allowing the next flush to include the full change data.
+  const server = new NotebookHandle("cancel-test");
+  server.add_cell(0, "cell-1", "code");
+
+  const client = NotebookHandle.load(server.save());
+  syncHandles(server, client);
+
+  // Client makes a local change
+  client.update_source("cell-1", "local edit");
+
+  // Flush generates a message (advances sync_state)
+  const msg1 = client.flush_local_changes();
+  assert(msg1 !== undefined, "first flush should produce a message");
+
+  // Simulate delivery failure — message is DROPPED
+  // Call cancel_last_flush to roll back sync_state
+  client.cancel_last_flush();
+
+  // Now flush again — should produce a NEW message with the same change data
+  const msg2 = client.flush_local_changes();
+  assert(
+    msg2 !== undefined,
+    "after cancel_last_flush, flush should produce a message (sent_hashes cleared)",
+  );
+
+  // Deliver msg2 to server — should converge
+  server.receive_sync_message(msg2);
+  syncHandles(server, client);
+
+  const serverCell = server.get_cell("cell-1");
+  assertExists(serverCell);
+  assertEquals(serverCell.source, "local edit");
+  serverCell.free();
+
+  server.free();
+  client.free();
+});
+
+Deno.test(
+  "Fix #1067: sent_hashes sticky without cancel (documents danger)",
+  () => {
+    // This test documents the DANGEROUS behavior when cancel_last_flush
+    // is NOT called after a failed send. The sent_hashes set retains
+    // hashes for changes the server never received, causing future
+    // sync messages to filter them out.
+    const server = new NotebookHandle("sticky-test");
+    server.add_cell(0, "cell-1", "code");
+
+    const client = NotebookHandle.load(server.save());
+    syncHandles(server, client);
+
+    // Client makes a local change
+    client.update_source("cell-1", "local edit");
+
+    // Flush generates a message (advances sync_state, adds to sent_hashes)
+    const msg1 = client.flush_local_changes();
+    assert(msg1 !== undefined);
+
+    // Simulate delivery failure — message is DROPPED
+    // DELIBERATELY do NOT call cancel_last_flush
+
+    // Try to flush again — in_flight is true, so this returns undefined
+    const msg2 = client.flush_local_changes();
+    assertEquals(
+      msg2,
+      undefined,
+      "without cancel, in_flight blocks the next flush",
+    );
+
+    // Even after receiving a server frame (which clears in_flight),
+    // the local change data may be filtered by sent_hashes.
+    // Server sends a trivial change to clear in_flight on client.
+    server.update_source("cell-1", "server edit");
+    const serverMsg = server.flush_local_changes();
+    assert(serverMsg !== undefined);
+    client.receive_sync_message(serverMsg);
+
+    // Now try flush again — in_flight was cleared by receive_sync_message
+    const msg3 = client.flush_local_changes();
+    // msg3 might be defined (protocol can partially recover when heads changed)
+    // but the important thing is that without cancel, recovery is unreliable.
+
+    // Verify: reset_sync_state always recovers (the nuclear option)
+    client.reset_sync_state();
+    syncHandles(server, client);
+
+    // After reset, both should converge to the server's version
+    // (client's "local edit" was superseded by "server edit" via CRDT merge)
+    const serverCell = server.get_cell("cell-1");
+    const clientCell = client.get_cell("cell-1");
+    assertExists(serverCell);
+    assertExists(clientCell);
+    assertEquals(clientCell.source, serverCell.source);
+    serverCell.free();
+    clientCell.free();
+
+    server.free();
+    client.free();
+  },
+);
+
+Deno.test(
+  "Fix #1067: rapid receive_frame produces correct reply pattern",
+  () => {
+    // Verifies that rapid inbound frames produce the right pattern of
+    // replies: first frame gets a reply, subsequent frames may or may not
+    // depending on in_flight and heads.
+    const server = new NotebookHandle("rapid-reply-test");
+    server.add_cell(0, "cell-1", "code");
+
+    const client = NotebookHandle.load(server.save());
+    syncHandles(server, client);
+
+    const replies: (Uint8Array | null)[] = [];
+
+    // Server sends 5 rapid changes
+    for (let i = 1; i <= 5; i++) {
+      server.update_source("cell-1", `line ${i}`);
+      const msg = server.flush_local_changes();
+      assert(msg !== undefined, `server msg ${i} should exist`);
+
+      const frame = new Uint8Array(1 + msg.length);
+      frame[0] = 0x00;
+      frame.set(msg, 1);
+
+      const events = client.receive_frame(frame);
+      assert(Array.isArray(events) && events.length === 1);
+      assertEquals(events[0].type, "sync_applied");
+
+      const reply = events[0].reply;
+      replies.push(reply ? new Uint8Array(reply) : null);
+
+      // Deliver reply to server immediately (simulating no batching)
+      if (reply) {
+        server.receive_sync_message(new Uint8Array(reply));
+      }
+    }
+
+    // At least the first reply should be defined
+    assert(replies[0] !== null, "first frame should produce a reply");
+
+    // After all frames delivered, client should have latest content
+    const clientCell = client.get_cell("cell-1");
+    assertExists(clientCell);
+    assertEquals(clientCell.source, "line 5");
+    clientCell.free();
+
+    // Protocol should be converged
+    assertEquals(client.flush_local_changes(), undefined);
+    assertEquals(server.flush_local_changes(), undefined);
+
+    server.free();
+    client.free();
+  },
+);
+
+Deno.test("Fix #1067: concurrent local edit + daemon frame", () => {
+  // Client makes a local edit, then receives a daemon frame before
+  // flushing. The inline reply should include the local changes.
+  const server = new NotebookHandle("concurrent-test");
+  server.add_cell(0, "cell-1", "code");
+  server.add_cell(1, "cell-2", "code");
+
+  const client = NotebookHandle.load(server.save());
+  syncHandles(server, client);
+
+  // Client makes a local edit (not yet flushed)
+  client.update_source("cell-1", "client edit");
+
+  // Server makes a different change
+  server.update_source("cell-2", "server edit");
+  const serverMsg = server.flush_local_changes();
+  assert(serverMsg !== undefined);
+
+  // Client receives the server's change via receive_frame
+  const frame = new Uint8Array(1 + serverMsg.length);
+  frame[0] = 0x00;
+  frame.set(serverMsg, 1);
+  const events = client.receive_frame(frame);
+  const reply = events[0]?.reply;
+
+  // The inline reply should exist and when delivered should bring
+  // the server up to date with the client's local edit
+  assert(reply !== undefined, "reply should include client's local changes");
+  server.receive_sync_message(new Uint8Array(reply));
+
+  // May need another round to fully converge
+  syncHandles(server, client);
+
+  // Both should have both edits
+  const serverCell1 = server.get_cell("cell-1");
+  const serverCell2 = server.get_cell("cell-2");
+  assertExists(serverCell1);
+  assertExists(serverCell2);
+  assertEquals(serverCell1.source, "client edit");
+  assertEquals(serverCell2.source, "server edit");
+  serverCell1.free();
+  serverCell2.free();
+
+  server.free();
+  client.free();
+});
+
 Deno.test("Sync: source edit character-level merge", () => {
   const server = new NotebookHandle("sync-test");
   server.add_cell(0, "cell-1", "code");

--- a/crates/runtimed-wasm/tests/deno_smoke_test.ts
+++ b/crates/runtimed-wasm/tests/deno_smoke_test.ts
@@ -47,8 +47,8 @@ await init(wasmBytes);
 /** Sync two handles until both return no more messages (convergence). */
 function syncHandles(a: NotebookHandle, b: NotebookHandle, maxRounds = 10) {
   for (let i = 0; i < maxRounds; i++) {
-    const msgA = a.generate_sync_message();
-    const msgB = b.generate_sync_message();
+    const msgA = a.flush_local_changes();
+    const msgB = b.flush_local_changes();
     if (!msgA && !msgB) break;
     if (msgA) b.receive_sync_message(msgA);
     if (msgB) a.receive_sync_message(msgB);
@@ -338,7 +338,7 @@ Deno.test("Sync: delete cell syncs correctly", () => {
   client.free();
 });
 
-Deno.test("Sync: generate_sync_message returns null when in sync", () => {
+Deno.test("Sync: flush_local_changes returns null when in sync", () => {
   const server = new NotebookHandle("sync-test");
   const client = NotebookHandle.load(server.save());
 
@@ -346,8 +346,8 @@ Deno.test("Sync: generate_sync_message returns null when in sync", () => {
   syncHandles(server, client);
 
   // Both should report no message needed
-  assertEquals(server.generate_sync_message(), undefined);
-  assertEquals(client.generate_sync_message(), undefined);
+  assertEquals(server.flush_local_changes(), undefined);
+  assertEquals(client.flush_local_changes(), undefined);
 
   server.free();
   client.free();
@@ -379,14 +379,14 @@ Deno.test("Bug #1067: consumed sync message causes protocol stall", () => {
   server.update_source("cell-1", "output-v1");
 
   // Step 2: Client receives the server's sync message
-  const serverMsg1 = server.generate_sync_message();
+  const serverMsg1 = server.flush_local_changes();
   assert(serverMsg1 !== undefined, "server should have a sync message");
   const changed = client.receive_sync_message(serverMsg1);
   assert(changed, "client doc should have changed");
 
   // Step 3: Client generates a reply — like flushSync() does.
   // This ADVANCES client's sync_state.last_sent_heads.
-  const consumedReply = client.generate_sync_message();
+  const consumedReply = client.flush_local_changes();
   assert(consumedReply !== undefined, "client should have a reply");
 
   // Step 4: The reply is DROPPED. Never delivered to server.
@@ -401,13 +401,13 @@ Deno.test("Bug #1067: consumed sync message causes protocol stall", () => {
   //
   // Meanwhile, the server sends its new change. Let's see if the
   // protocol can recover.
-  const serverMsg2 = server.generate_sync_message();
+  const serverMsg2 = server.flush_local_changes();
   assert(serverMsg2 !== undefined, "server should have msg for output-v2");
   client.receive_sync_message(serverMsg2);
 
   // The client should now generate a reply that covers BOTH the
   // previously-dropped reply AND the new change.
-  const recoveryReply = client.generate_sync_message();
+  const recoveryReply = client.flush_local_changes();
 
   // THIS IS THE BUG: if recoveryReply is undefined, the protocol has
   // stalled. The client thinks it's in sync (because sync_state was
@@ -477,17 +477,17 @@ Deno.test("Bug #1067: rapid flushSync steals debounced reply", () => {
 
   // Server streams multiple rapid changes (simulates IOPub output burst)
   server.update_source("cell-1", "line 1");
-  const msg1 = server.generate_sync_message();
+  const msg1 = server.flush_local_changes();
   assert(msg1 !== undefined);
   client.receive_sync_message(msg1);
 
   server.update_source("cell-1", "line 1\nline 2");
-  const msg2 = server.generate_sync_message();
+  const msg2 = server.flush_local_changes();
   assert(msg2 !== undefined);
   client.receive_sync_message(msg2);
 
   server.update_source("cell-1", "line 1\nline 2\nline 3");
-  const msg3 = server.generate_sync_message();
+  const msg3 = server.flush_local_changes();
   assert(msg3 !== undefined);
   client.receive_sync_message(msg3);
 
@@ -495,11 +495,11 @@ Deno.test("Bug #1067: rapid flushSync steals debounced reply", () => {
   // A debounced syncReply$ would call generate_sync_reply() here.
   // But flushSync() fires first (user presses Ctrl+Enter):
 
-  const flushMsg = client.generate_sync_message(); // flushSync steals it
+  const flushMsg = client.flush_local_changes(); // flushSync steals it
   // flushMsg is defined — it covers all 3 inbound syncs.
 
   // Now the debounced syncReply fires:
-  const debouncedReply = client.generate_sync_message(); // generates reply
+  const debouncedReply = client.flush_local_changes(); // generates reply
 
   // The debounced reply should ideally still work, but if flushMsg
   // already advanced sync_state, debouncedReply may be undefined.
@@ -516,12 +516,12 @@ Deno.test("Bug #1067: rapid flushSync steals debounced reply", () => {
 
     // Server makes a new change
     server.update_source("cell-1", "line 1\nline 2\nline 3\nline 4");
-    const msg4 = server.generate_sync_message();
+    const msg4 = server.flush_local_changes();
     assert(msg4 !== undefined, "server should still produce messages");
     client.receive_sync_message(msg4);
 
     // Client tries to reply again
-    const retryReply = client.generate_sync_message();
+    const retryReply = client.flush_local_changes();
 
     if (retryReply === undefined) {
       console.warn(
@@ -612,8 +612,8 @@ Deno.test("Sync: bootstrap from saved bytes preserves all content", () => {
 
   // Sync should converge immediately (no changes needed)
   syncHandles(daemon, wasm);
-  assertEquals(daemon.generate_sync_message(), undefined);
-  assertEquals(wasm.generate_sync_message(), undefined);
+  assertEquals(daemon.flush_local_changes(), undefined);
+  assertEquals(wasm.flush_local_changes(), undefined);
 
   for (const c of cells) c.free();
   daemon.free();
@@ -633,15 +633,15 @@ Deno.test("Sync: load from bytes + incremental sync with changed flag", () => {
   syncHandles(daemon, wasm);
 
   // Verify sync state is converged
-  assertEquals(daemon.generate_sync_message(), undefined);
-  assertEquals(wasm.generate_sync_message(), undefined);
+  assertEquals(daemon.flush_local_changes(), undefined);
+  assertEquals(wasm.flush_local_changes(), undefined);
 
   // Daemon adds new content
   daemon.add_cell(1, "new-cell", "markdown");
   daemon.update_source("new-cell", "# New section");
 
   // Generate sync message from daemon
-  const msg = daemon.generate_sync_message();
+  const msg = daemon.flush_local_changes();
   assertExists(msg, "Daemon should have sync message after mutation");
 
   // WASM receives and should report changed=true
@@ -675,12 +675,12 @@ Deno.test("Sync: converged peers have no sync messages", () => {
 
   // After convergence, neither should have messages
   assertEquals(
-    daemon.generate_sync_message(),
+    daemon.flush_local_changes(),
     undefined,
     "Daemon has no message when converged",
   );
   assertEquals(
-    wasm.generate_sync_message(),
+    wasm.flush_local_changes(),
     undefined,
     "WASM has no message when converged",
   );
@@ -705,8 +705,8 @@ Deno.test("Sync: reset_sync_state allows re-sync from scratch", () => {
   syncHandles(daemon, wasm);
 
   // Both converged
-  assertEquals(daemon.generate_sync_message(), undefined);
-  assertEquals(wasm.generate_sync_message(), undefined);
+  assertEquals(daemon.flush_local_changes(), undefined);
+  assertEquals(wasm.flush_local_changes(), undefined);
 
   // Daemon updates the cell
   daemon.update_source("cell-1", "updated");
@@ -715,7 +715,7 @@ Deno.test("Sync: reset_sync_state allows re-sync from scratch", () => {
   wasm.reset_sync_state();
 
   // After reset, WASM should need to sync again
-  const wasmMsg = wasm.generate_sync_message();
+  const wasmMsg = wasm.flush_local_changes();
   assertExists(
     wasmMsg,
     "After reset_sync_state, WASM should generate sync message",
@@ -866,7 +866,7 @@ Deno.test("create_empty: incremental sync after bootstrap works", () => {
   daemon.update_source("cell-2", "y = 2");
 
   // Generate sync message and verify change detection
-  const msg = daemon.generate_sync_message();
+  const msg = daemon.flush_local_changes();
   assertExists(msg, "Daemon should have sync message after adding cell");
 
   const changed = wasm.receive_sync_message(msg);

--- a/crates/runtimed-wasm/tests/splice_source_test.ts
+++ b/crates/runtimed-wasm/tests/splice_source_test.ts
@@ -60,8 +60,8 @@ type Handle = any;
 /** Sync two handles until convergence (no more messages in either direction). */
 function syncHandles(a: Handle, b: Handle, maxRounds = 20) {
   for (let i = 0; i < maxRounds; i++) {
-    const msgA = a.generate_sync_message();
-    const msgB = b.generate_sync_message();
+    const msgA = a.flush_local_changes();
+    const msgB = b.flush_local_changes();
     if (!msgA && !msgB) break;
     if (msgA) b.receive_sync_message(msgA);
     if (msgB) a.receive_sync_message(msgB);
@@ -94,7 +94,7 @@ function syncViaFrame(
   to: Handle,
   // deno-lint-ignore no-explicit-any
 ): any[] | null {
-  const msg = from.generate_sync_message();
+  const msg = from.flush_local_changes();
   if (!msg) return null;
 
   // Build a frame: type byte 0x00 (AUTOMERGE_SYNC) + payload


### PR DESCRIPTION
## Fix sync head divergence from rapid Ctrl+Enter (#1067)

### Root cause

`generate_sync_message()` and `generate_sync_reply()` were two identical WASM methods called from three independent TypeScript callsites, all sharing the same mutable `sync::State`. Automerge's `generate_sync_message` destructively advances `sync_state.last_sent_heads` and sets `in_flight = true` **before** the message reaches the wire. When one callsite consumed the pending reply and its delivery failed, the protocol stalled permanently.

Confirmed by Deno test: `BUG #1067 CONFIRMED: flushSync consumed the debounced reply. If flushMsg delivery fails, no recovery path exists.`

### Fix

**WASM layer** (`crates/runtimed-wasm/src/lib.rs`):
- `receive_frame()` now generates the sync reply **atomically** after applying each `AUTOMERGE_SYNC` frame — returned in `FrameEvent::SyncApplied.reply`. No separate call needed.
- `generate_sync_message()` and `generate_sync_reply()` **removed** from public API
- New `flush_local_changes()` — the only way to push local CRDT mutations. Named to clarify intent.
- New `cancel_last_flush()` — clears `in_flight` + `sent_hashes` when delivery fails, preventing permanent stalls from stuck deduplication state.

**TypeScript layer**:
- `frame-pipeline.ts`: Sends inline `reply` from `FrameEvent` immediately (no debounce). Removed `onSyncApplied` callback.
- `useAutomergeNotebook.ts`: `syncToRelay` and `flushSync` use `flush_local_changes()` + `cancel_last_flush()` on error. Removed `syncReply$` subject entirely. Simplified teardown.
- `notebook-metadata.ts`: `syncToRelay` updated to same pattern (was the third racing callsite with 12 callers).

### How it works now

| Path | When | Method |
|------|------|--------|
| Reply to inbound sync | Every `receive_frame(AUTOMERGE_SYNC)` | Atomic inside WASM — no JS interleaving possible |
| Push local edits | Cell edit, metadata change, pre-execute flush | `flush_local_changes()` + `cancel_last_flush()` on error |

Only one code path touches `sync_state` for replies. Only one code path touches it for local pushes. They can't race because JS is single-threaded and they never yield between state mutation and message production.

### Design references

- Studied Automerge's `sync::State.in_flight` flag behavior (`automerge/rust/automerge/src/sync.rs`)
- Studied `automerge-repo`'s `DocSynchronizer` — one sync state per peer, one code path, serialized access
- Design doc: `.context/plans/sync-controller.md`

### Tests

- 2 bug reproduction tests (confirm the old race exists)
- 7 fix verification tests (inline replies, flush behavior, cancel recovery, rapid frames, concurrent edits)
- All 113 Deno WASM tests pass across 3 test files

Fixes #1067