### PR TITLE
fix(runtimed): sync test_all_exports with __all__

### DIFF
--- a/python/runtimed/tests/test_session_unit.py
+++ b/python/runtimed/tests/test_session_unit.py
@@ -55,17 +55,8 @@ class TestModuleExports:
             "CellHandle",
             "CellCollection",
             "Presence",
-            # Data types (reachable through wrapper)
-            "Cell",
-            "ExecutionEvent",
-            "ExecutionResult",
-            "Output",
+            # Error type
             "RuntimedError",
-            "SyncEnvironmentResult",
-            # Runtime state
-            "RuntimeState",
-            "KernelState",
-            "EnvState",
             # Standalone functions
             "default_socket_path",
             "show_notebook_app",


### PR DESCRIPTION
Remove data types from test expectation to match the intentionally small `__all__`.