### PR TITLE
docs(agents): add Codex repo skills

### DIFF
--- a/.codex/skills/nteract-daemon-dev/SKILL.md
+++ b/.codex/skills/nteract-daemon-dev/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: nteract-daemon-dev
+description: Work with the per-worktree runtimed daemon in the nteract desktop repo. Use when changing `crates/runtimed/**`, debugging daemon-backed notebook behavior, deriving `RUNTIMED_SOCKET_PATH`, checking daemon logs/status, running daemon-backed tests or reviews, or deciding whether to use `supervisor_*` tools versus manual `cargo xtask dev-daemon` commands.
+---
+
+# nteract Daemon Dev
+
+Use this skill to avoid talking to the wrong daemon and to keep daemon-backed verification tied to the current worktree.
+
+## Workflow
+
+1. Prefer `supervisor_*` tools when they are available.
+2. Otherwise, treat the worktree daemon as mandatory for daemon-backed verification.
+3. Export `RUNTIMED_DEV=1` and `RUNTIMED_WORKSPACE_PATH="$(pwd)"` before any manual `runt` command.
+4. Start or restart the daemon before validating changes in `crates/runtimed/**`, notebook sync paths, or Python integration flows.
+5. Derive `RUNTIMED_SOCKET_PATH` from `./target/debug/runt daemon status --json` before running Python or cross-implementation tests.
+
+## Guardrails
+
+- Never use `pkill`, `killall`, or other system-wide process killers for `runtimed`.
+- Never assume the system daemon is correct for a repo worktree.
+- Never run the notebook GUI from an agent terminal; let the human launch it.
+- If a test or script depends on notebook execution, blob resolution, or MCP server behavior, confirm it is pointed at the worktree daemon first.
+
+## Quick Start
+
+If you have supervisor tools, use them for daemon lifecycle and logs.
+
+If you do not, read [references/daemon-workflows.md](references/daemon-workflows.md) and follow the manual command sequence there.

--- a/.codex/skills/nteract-daemon-dev/agents/openai.yaml
+++ b/.codex/skills/nteract-daemon-dev/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "nteract Daemon Dev"
+  short_description: "Per-worktree daemon workflows"
+  default_prompt: "Use $nteract-daemon-dev to work safely with the per-worktree runtimed daemon in this repo."

--- a/.codex/skills/nteract-daemon-dev/references/daemon-workflows.md
+++ b/.codex/skills/nteract-daemon-dev/references/daemon-workflows.md
@@ -1,0 +1,63 @@
+# Daemon Workflows
+
+## Manual setup
+
+Run all manual daemon commands from the repo root:
+
+```bash
+export RUNTIMED_DEV=1
+export RUNTIMED_WORKSPACE_PATH="$(pwd)"
+```
+
+Start the worktree daemon:
+
+```bash
+cargo xtask dev-daemon
+```
+
+Check status or logs:
+
+```bash
+./target/debug/runt daemon status
+./target/debug/runt daemon logs -f
+./target/debug/runt ps
+./target/debug/runt notebooks
+```
+
+## Derive the socket path
+
+Use this before Python integration tests, `uv run nteract`, or anything else that needs the daemon socket explicitly:
+
+```bash
+export RUNTIMED_SOCKET_PATH="$(
+  RUNTIMED_DEV=1 RUNTIMED_WORKSPACE_PATH="$(pwd)" \
+  ./target/debug/runt daemon status --json \
+  | python3 -c 'import sys,json; print(json.load(sys.stdin)["socket_path"])'
+)"
+```
+
+## When to start your own daemon
+
+Start or restart the worktree daemon when:
+
+- You changed `crates/runtimed/**`
+- You are reviewing or debugging notebook sync behavior that depends on the daemon
+- You are running daemon-backed Python tests
+- You are verifying MCP server behavior against local Rust changes
+- You are comparing behavior across worktrees and need isolation
+
+## Prefer supervisor tools when available
+
+If the MCP supervisor is available, prefer:
+
+- `supervisor_restart(target="daemon")`
+- `supervisor_status`
+- `supervisor_logs`
+
+These avoid manual env-var mistakes.
+
+## Safety rules
+
+- Use `./target/debug/runt daemon stop` instead of `pkill` or `killall`
+- Do not point tests at the system daemon by accident
+- Do not launch `cargo xtask notebook` from an agent terminal

--- a/.codex/skills/nteract-notebook-sync/SKILL.md
+++ b/.codex/skills/nteract-notebook-sync/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: nteract-notebook-sync
+description: Change Automerge notebook sync, CRDT ownership, output manifests, or notebook wire protocol in the nteract desktop repo. Use when editing `crates/notebook-doc/**`, `crates/notebook-protocol/**`, `crates/notebook-sync/**`, `crates/runtimed-wasm/**`, `apps/notebook/src/hooks/useAutomergeNotebook*`, `apps/notebook/src/lib/frame-*`, `materialize-*`, `notebook-cells*`, or daemon blob/output sync paths.
+---
+
+# nteract Notebook Sync
+
+Use this skill when a change can break notebook state convergence, output rendering, or ownership boundaries between frontend and daemon.
+
+## Workflow
+
+1. Identify which side owns the state you are touching before editing anything.
+2. Separate local user-authored CRDT mutations from daemon-authored projections.
+3. Update mirrored protocol or MIME-classification implementations together.
+4. Validate with narrow sync-oriented tests after each meaningful change.
+
+## Core Invariants
+
+- The Automerge notebook document is the source of truth for notebook content and structure.
+- The React cell store is a projection, not an authority.
+- The daemon owns outputs, execution counts, runtime state, and other execution-side state.
+- The frontend owns local editing mutations and sends them through WASM sync.
+- Do not write to the CRDT in response to a daemon broadcast that already reflects a daemon-authored change.
+
+## Read Next
+
+- Read [references/crdt-ownership.md](references/crdt-ownership.md) before changing mutation paths.
+- Read [references/output-and-protocol.md](references/output-and-protocol.md) before changing frame handling, blob resolution, or MIME classification.

--- a/.codex/skills/nteract-notebook-sync/agents/openai.yaml
+++ b/.codex/skills/nteract-notebook-sync/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "nteract Notebook Sync"
+  short_description: "Notebook sync and CRDT rules"
+  default_prompt: "Use $nteract-notebook-sync when changing Automerge sync, notebook doc ownership, or output materialization in this repo."

--- a/.codex/skills/nteract-notebook-sync/references/crdt-ownership.md
+++ b/.codex/skills/nteract-notebook-sync/references/crdt-ownership.md
@@ -1,0 +1,21 @@
+# CRDT Ownership
+
+## Ownership map
+
+- Frontend-authored CRDT writes: cell source, structure, cell metadata, notebook metadata
+- Daemon-authored CRDT writes: outputs and execution-side notebook state written from kernel activity
+- Store-only frontend projections: daemon execution count updates, daemon output clears, runtime-state UI updates
+
+## Rules
+
+- Write persistent notebook state to the WASM handle first, then let materialization update the store.
+- Use store-only updates only for immediate UI feedback that already matches the CRDT, or for daemon-authored projections.
+- Do not write to the CRDT in response to daemon broadcasts. That re-authors the same change and can create dirty-state or sync bugs.
+- Treat CodeMirror source editing as a dedicated bridge. Avoid bypassing it with ad hoc source update flows.
+
+## Common review questions
+
+- Is this change writing to the store without a matching CRDT write?
+- Is this change re-writing daemon-authored state from the frontend?
+- Is the change on the local-mutation path, inbound sync path, or both?
+- Does the sync rollback or retry logic preserve convergence if delivery fails?

--- a/.codex/skills/nteract-notebook-sync/references/output-and-protocol.md
+++ b/.codex/skills/nteract-notebook-sync/references/output-and-protocol.md
@@ -1,0 +1,36 @@
+# Output and Protocol
+
+## Frame and protocol changes
+
+When changing frame handling, keep the following aligned:
+
+- `crates/notebook-doc/src/frame_types.rs`
+- `apps/notebook/src/lib/frame-types.ts`
+- Any relay or sync code that assumes a specific frame layout
+
+When changing the wire handshake or typed frame semantics, also inspect:
+
+- `crates/notebook-protocol/src/connection.rs`
+- `crates/notebook-protocol/src/protocol.rs`
+- `contributing/protocol.md`
+
+## MIME classification contract
+
+Keep these implementations in sync when changing text-vs-binary rules:
+
+- `crates/runtimed/src/output_store.rs`
+- `crates/runtimed-py/src/output_resolver.rs`
+- `apps/notebook/src/lib/manifest-resolution.ts`
+
+Important rule: `image/svg+xml` is text, not binary.
+
+## Output pipeline
+
+The daemon stores manifests and blobs; the CRDT stores only manifest hashes. Frontend and Python consumers resolve through the manifest layer rather than treating output payloads as inline notebook state.
+
+## Common pitfalls
+
+- Storing base64 text for binary blobs instead of raw bytes
+- Reading binary blobs as UTF-8 strings
+- Forgetting to update both frontend and Python MIME classification paths
+- Changing sync reply or retry behavior without testing failed-delivery cases

--- a/.codex/skills/nteract-python-bindings/SKILL.md
+++ b/.codex/skills/nteract-python-bindings/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: nteract-python-bindings
+description: Build, rebuild, test, and debug the Python bindings and MCP server in the nteract desktop repo. Use when working in `crates/runtimed-py/**`, `python/runtimed/**`, `python/nteract/**`, or `python/gremlin/**`, especially for choosing the correct venv, running `maturin develop`, wiring tests to the right daemon socket, or validating MCP behavior after Rust changes.
+---
+
+# nteract Python Bindings
+
+Use this skill when Python behavior depends on both Rust extension state and daemon selection.
+
+## Workflow
+
+1. Identify whether the task targets the workspace venv or the test venv.
+2. Rebuild bindings into the correct venv before trusting results from Python or MCP code.
+3. Use the worktree daemon, not the system daemon, for daemon-backed tests.
+4. Re-run the narrowest relevant test or command after rebuilding.
+
+## Core Rules
+
+- Use `.venv` at the repo root for `uv run nteract`, MCP server work, and most day-to-day development.
+- Use `python/runtimed/.venv` for isolated pytest integration runs.
+- Set `VIRTUAL_ENV` explicitly when running `maturin develop`; otherwise it is easy to rebuild into the wrong venv.
+- If outputs, blobs, or notebook execution look wrong, verify `RUNTIMED_SOCKET_PATH` before assuming the bindings are broken.
+
+## Quick Start
+
+Read [references/bindings-workflows.md](references/bindings-workflows.md) for the exact rebuild and test commands.

--- a/.codex/skills/nteract-python-bindings/agents/openai.yaml
+++ b/.codex/skills/nteract-python-bindings/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "nteract Python Bindings"
+  short_description: "Python bindings and MCP dev"
+  default_prompt: "Use $nteract-python-bindings to build, test, or debug the Python bindings and MCP server in this repo."

--- a/.codex/skills/nteract-python-bindings/references/bindings-workflows.md
+++ b/.codex/skills/nteract-python-bindings/references/bindings-workflows.md
@@ -1,0 +1,59 @@
+# Python Bindings Workflows
+
+## Venv split
+
+Use these venvs intentionally:
+
+- `.venv` at the repo root: workspace venv for `uv run nteract`, `gremlin`, and general development
+- `python/runtimed/.venv`: test venv for pytest integration runs
+
+## Rebuild into the workspace venv
+
+Use this for MCP server work and most local development:
+
+```bash
+cd crates/runtimed-py
+VIRTUAL_ENV=../../.venv uv run --directory ../../python/runtimed maturin develop
+```
+
+## Rebuild into the test venv
+
+Use this before daemon-backed pytest runs:
+
+```bash
+cd crates/runtimed-py
+VIRTUAL_ENV=../../python/runtimed/.venv uv run --directory ../../python/runtimed maturin develop
+```
+
+## Run tests
+
+Unit-only:
+
+```bash
+python/runtimed/.venv/bin/python -m pytest python/runtimed/tests/test_session_unit.py -v
+```
+
+Daemon-backed integration:
+
+```bash
+RUNTIMED_SOCKET_PATH="$(
+  RUNTIMED_DEV=1 RUNTIMED_WORKSPACE_PATH="$(pwd)" \
+  ./target/debug/runt daemon status --json \
+  | python3 -c 'import sys,json; print(json.load(sys.stdin)["socket_path"])'
+)" \
+python/runtimed/.venv/bin/python -m pytest python/runtimed/tests/test_daemon_integration.py -v
+```
+
+## Run the MCP server
+
+From the repo root:
+
+```bash
+uv run nteract
+```
+
+If the MCP supervisor is available, prefer `cargo xtask run-mcp` or the supervisor tools instead of a manual launch.
+
+## Common failure mode
+
+If `maturin develop` ran successfully but behavior did not change, you likely rebuilt into the wrong venv. Check `VIRTUAL_ENV` first.

--- a/.codex/skills/nteract-testing/SKILL.md
+++ b/.codex/skills/nteract-testing/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: nteract-testing
+description: Choose and run the right test suites for the nteract desktop repo. Use when adding tests, verifying fixes, or debugging failures across Rust, Deno WASM, Vitest, Python pytest, Hone CLI tests, or E2E/WebDriver flows, especially when a change may require a dev daemon, `--allow-env`, or fixture notebooks.
+---
+
+# nteract Testing
+
+Use this skill to map a code change to the narrowest credible verification path and avoid false negatives from missing daemon or env setup.
+
+## Workflow
+
+1. Map the touched files to one or two likely test layers.
+2. Run the narrowest relevant test first.
+3. Escalate to broader integration or E2E coverage only if the narrow test cannot validate the change.
+4. For daemon-backed tests, confirm the worktree daemon and socket wiring before trusting failures.
+
+## Testing Rules
+
+- Prefer targeted crate, file, or test-name runs over whole-repo test sweeps.
+- Distinguish implementation failures from harness/setup failures.
+- Note when a suite needs extra permissions such as `--allow-env` or a running daemon.
+- If a test file mixes unit and integration setup, inspect top-level environment access before assuming it is safe to run in a restricted mode.
+
+## Read Next
+
+Read [references/test-matrix.md](references/test-matrix.md) to pick commands and setup for the relevant layer.

--- a/.codex/skills/nteract-testing/agents/openai.yaml
+++ b/.codex/skills/nteract-testing/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "nteract Testing"
+  short_description: "Repo test selection and setup"
+  default_prompt: "Use $nteract-testing to choose, run, and interpret the right test suites for this repo."

--- a/.codex/skills/nteract-testing/references/test-matrix.md
+++ b/.codex/skills/nteract-testing/references/test-matrix.md
@@ -1,0 +1,62 @@
+# Test Matrix
+
+## Fast mapping
+
+- `crates/runtimed/**`, `crates/notebook-doc/**`, `crates/notebook-protocol/**`: start with `cargo test` in the relevant crate
+- `crates/runtimed-wasm/**`, `apps/notebook/src/wasm/**`, notebook sync plumbing: start with `deno test --allow-read --allow-env --no-check crates/runtimed-wasm/tests/`
+- `apps/notebook/src/**` or shared frontend code: start with `pnpm test:run`
+- `python/runtimed/**`, `python/nteract/**`, `crates/runtimed-py/**`: start with targeted pytest or `uv run nteract`
+- `e2e/**` or cross-window UX flows: use `./e2e/dev.sh ...`
+
+## Commands
+
+Rust:
+
+```bash
+cargo test -p runtimed
+cargo test -p notebook-doc
+```
+
+Deno WASM:
+
+```bash
+deno test --allow-read --allow-env --no-check crates/runtimed-wasm/tests/
+```
+
+Frontend:
+
+```bash
+pnpm test:run
+```
+
+Python unit:
+
+```bash
+python/runtimed/.venv/bin/python -m pytest python/runtimed/tests/test_session_unit.py -v
+```
+
+Python integration:
+
+```bash
+RUNTIMED_SOCKET_PATH="$(
+  RUNTIMED_DEV=1 RUNTIMED_WORKSPACE_PATH="$(pwd)" \
+  ./target/debug/runt daemon status --json \
+  | python3 -c 'import sys,json; print(json.load(sys.stdin)["socket_path"])'
+)" \
+python/runtimed/.venv/bin/python -m pytest python/runtimed/tests/test_daemon_integration.py -v
+```
+
+E2E:
+
+```bash
+./e2e/dev.sh build
+./e2e/dev.sh start
+./e2e/dev.sh test
+```
+
+## Gotchas
+
+- `crates/runtimed-wasm/tests/cross_impl_test.ts` touches `Deno.env` at module scope, so it needs `--allow-env` even before daemon-backed cases run.
+- Some Deno tests type-check poorly in spite of working at runtime; `--no-check` is often the intended mode in this repo.
+- Python integration failures are often socket-selection problems before they are logic regressions.
+- E2E flows require the repo’s helper scripts; do not replace them with ad hoc Tauri launch commands.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,12 @@
 
 This document provides guidance for AI agents working in this repository. Claude agents also receive contextual rules (`.claude/rules/`) and skills (`.claude/skills/`) auto-loaded when relevant. All agents should run `cargo xtask help` to discover build commands.
 
+Codex-specific repo skills live in `.codex/skills/`. Prefer them when the task matches:
+- `nteract-daemon-dev` for per-worktree daemon lifecycle, socket setup, and daemon-backed verification
+- `nteract-python-bindings` for `maturin develop`, venv selection, and MCP server work
+- `nteract-notebook-sync` for Automerge ownership, output manifests, and sync-path changes
+- `nteract-testing` for choosing and running the right verification path
+
 ## Quick Recipes (Common Dev Tasks)
 
 ### If you have `supervisor_*` tools — use them


### PR DESCRIPTION
## Summary
- add repo-local Codex skills for daemon workflows, Python bindings, notebook sync, and test selection
- add focused reference docs for the high-risk workflows those skills cover
- point future agents at the new `.codex/skills/` set from `AGENTS.md`

## Notes
- skill docs use lowercase `nteract` in the added descriptions and headings
- validated all four skills with `uv run --no-project --isolated --with pyyaml ... quick_validate.py`