### PR TITLE
feat: runtimed JavaScript bindings package

### DIFF
--- a/apps/notebook/package.json
+++ b/apps/notebook/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@nteract/runtimed": "workspace:*",
+    "runtimed": "workspace:*",
     "@codemirror/autocomplete": "^6.20.0",
     "@codemirror/commands": "^6.10.2",
     "@codemirror/lang-html": "^6.4.11",

--- a/apps/notebook/package.json
+++ b/apps/notebook/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@nteract/runtimed": "workspace:*",
     "@codemirror/autocomplete": "^6.20.0",
     "@codemirror/commands": "^6.10.2",
     "@codemirror/lang-html": "^6.4.11",

--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -137,14 +137,17 @@ export function useAutomergeNotebook() {
       NH as typeof NotebookHandle
     ).create_empty_with_actor(`human:${sessionIdRef.current}`);
 
-    // Clean up previous handle.
+    // Clean up previous engine + transport BEFORE freeing the handle.
+    // The engine's stop() calls flushNow() which needs the handle alive.
+    engineRef.current?.stop();
+    engineRef.current = null;
+    transportRef.current?.disconnect();
+    transportRef.current = null;
+
+    // Now safe to free the old handle.
     handleRef.current?.free();
     handleRef.current = handle;
     setNotebookHandle(handle);
-
-    // Clean up previous engine + transport.
-    engineRef.current?.stop();
-    transportRef.current?.disconnect();
 
     // Create transport + engine.
     const transport = new TauriTransport();

--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -205,12 +205,84 @@ export function useAutomergeNotebook() {
           });
         }
 
-        // Full async materialization — resolves manifest hashes from
-        // the blob HTTP server. The coalescing ensures we don't start
-        // a new materialization while the previous one is resolving blobs.
-        materializeCells(h).catch((err: unknown) => {
-          logger.warn("[automerge-notebook] materialize failed:", err);
-        });
+        // Structural changes (add/remove/reorder) need full materialization.
+        // Field-only changes (outputs, execution_count, metadata) get
+        // targeted per-cell updates — we MUST NOT overwrite source text
+        // because CodeMirror owns it via the CRDT-bridge. Replacing source
+        // from the store causes splice_source index-out-of-bounds crashes
+        // when text_attribution broadcasts arrive with stale positions.
+        const cs = batch.changeset;
+        const needsFull =
+          batch.needsFull ||
+          (cs !== null &&
+            (cs.added.length > 0 || cs.removed.length > 0 || cs.order_changed));
+
+        if (needsFull) {
+          materializeCells(h).catch((err: unknown) => {
+            logger.warn("[automerge-notebook] full materialize failed:", err);
+          });
+        } else if (cs !== null && cs.changed.length > 0) {
+          // Targeted update: only touch outputs, execution_count, metadata
+          // for cells that changed. Never touch source (CodeMirror owns it).
+          for (const cell of cs.changed) {
+            if (
+              cell.fields.outputs ||
+              cell.fields.execution_count ||
+              cell.fields.metadata
+            ) {
+              const outputs = h.get_cell_outputs(cell.cell_id);
+              const ecStr = h.get_cell_execution_count(cell.cell_id);
+              const ec = ecStr && ecStr !== "null" ? parseInt(ecStr, 10) : null;
+              const metadata = h.get_cell_metadata(cell.cell_id) ?? {};
+
+              updateCellById(cell.cell_id, (c) => {
+                if (c.cell_type !== "code") return c;
+
+                // Resolve outputs from cache (sync path).
+                // Outputs that are manifest hashes not in cache will show
+                // as loading — a subsequent full materialize will resolve them.
+                const resolvedOutputs = (outputs ?? []).map(
+                  (o: string) =>
+                    outputCacheRef.current.get(o) ??
+                    (typeof o === "string" && o.length === 16
+                      ? (c.outputs.find(
+                          (existing: JupyterOutput) =>
+                            existing && "_manifest" in existing,
+                        ) ?? { output_type: "loading", _manifest: o })
+                      : JSON.parse(o)),
+                );
+
+                return {
+                  ...c,
+                  outputs: resolvedOutputs,
+                  execution_count: ec,
+                  metadata,
+                };
+              });
+            }
+          }
+
+          // If any outputs had unresolved manifest hashes, trigger an
+          // async materialization to resolve them from the blob server.
+          const hasUnresolved = cs.changed.some(
+            (cell) =>
+              cell.fields.outputs &&
+              (h.get_cell_outputs(cell.cell_id) ?? []).some(
+                (o: string) =>
+                  typeof o === "string" &&
+                  o.length === 16 &&
+                  !outputCacheRef.current.has(o),
+              ),
+          );
+          if (hasUnresolved) {
+            materializeCells(h).catch((err: unknown) => {
+              logger.warn(
+                "[automerge-notebook] blob resolve materialize failed:",
+                err,
+              );
+            });
+          }
+        }
       }),
     );
 

--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -1,9 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { debounceTime, from, Subject, switchMap } from "rxjs";
+import { from, switchMap } from "rxjs";
 import { getBlobPort, refreshBlobPort } from "../lib/blob-port";
-import { createFramePipeline } from "../lib/frame-pipeline";
-import { frame_types, sendFrame } from "../lib/frame-types";
 import { logger } from "../lib/logger";
 import {
   type CellSnapshot,
@@ -18,33 +16,36 @@ import {
   updateNotebookCells,
   useCellIds,
 } from "../lib/notebook-cells";
+import { subscribeBroadcast, emitBroadcast } from "../lib/notebook-frame-bus";
 import {
-  cloneNotebookFile,
-  openNotebookFile,
-  saveNotebook,
-} from "../lib/notebook-file-ops";
-import { subscribeBroadcast } from "../lib/notebook-frame-bus";
-import { setNotebookHandle } from "../lib/notebook-metadata";
-import { resetRuntimeState } from "../lib/runtime-state";
+  notifyMetadataChanged,
+  setNotebookHandle,
+} from "../lib/notebook-metadata";
+import { resetRuntimeState, setRuntimeState } from "../lib/runtime-state";
 import { fromTauriEvent } from "../lib/tauri-rx";
+import { TauriTransport } from "../lib/tauri-transport";
+import type { NotebookHandle } from "../wasm/runtimed-wasm/runtimed_wasm.js";
 import type { DaemonBroadcast, JupyterOutput } from "../types";
-import init, { NotebookHandle } from "../wasm/runtimed-wasm/runtimed_wasm.js";
 
-// Module-level WASM init — runs before React renders.
-const wasmReady: Promise<void> = init().then(() => {
-  logger.info("[automerge-notebook] WASM initialized");
-});
+import { SyncEngine } from "@nteract/runtimed";
 
-// ---------------------------------------------------------------------------
-// Hook
-// ---------------------------------------------------------------------------
+// ── WASM init ────────────────────────────────────────────────────────
+
+const wasmReady = (async () => {
+  const { default: init } =
+    await import("../wasm/runtimed-wasm/runtimed_wasm.js");
+  await init();
+})();
+
+// ── Hook ─────────────────────────────────────────────────────────────
 
 /**
- * Local-first notebook hook backed by `runtimed-wasm` NotebookHandle.
+ * Core Automerge notebook hook — manages the WASM document, sync lifecycle,
+ * and cell store.
  *
- * All document mutations execute instantly inside the WASM Automerge
- * document. The external store is derived from the doc. Sync messages
- * flow through the Tauri relay to the daemon.
+ * Uses {@link SyncEngine} from `@nteract/runtimed` for all sync management
+ * and {@link TauriTransport} for the IPC layer. The hook subscribes to engine
+ * events and writes to the React cell/runtime stores.
  */
 export function useAutomergeNotebook() {
   const cellIds = useCellIds();
@@ -53,12 +54,12 @@ export function useAutomergeNotebook() {
   const [isLoading, setIsLoading] = useState(true);
 
   const handleRef = useRef<NotebookHandle | null>(null);
-  const awaitingInitialSyncRef = useRef(true);
   const sessionIdRef = useRef(crypto.randomUUID().slice(0, 8));
   const outputCacheRef = useRef<Map<string, JupyterOutput>>(new Map());
 
-  // RxJS subjects for debounced outbound sync.
-  const sourceSync$ = useRef(new Subject<void>());
+  // SyncEngine + TauriTransport refs (stable across re-renders).
+  const engineRef = useRef<SyncEngine | null>(null);
+  const transportRef = useRef<TauriTransport | null>(null);
 
   // Refresh blob port on mount.
   useEffect(() => {
@@ -94,36 +95,6 @@ export function useAutomergeNotebook() {
     replaceNotebookCells(newCells);
   }, []);
 
-  /** Flush local CRDT changes to the Tauri relay (fire-and-forget).
-   *  Uses flush_local_changes + cancel_last_flush to prevent the sync
-   *  state consumption race from #1067. */
-  const syncToRelay = useCallback((handle: NotebookHandle) => {
-    const msg = handle.flush_local_changes();
-    if (msg) {
-      sendFrame(frame_types.AUTOMERGE_SYNC, msg).catch((e: unknown) => {
-        handle.cancel_last_flush();
-        logger.warn("[automerge-notebook] sync to relay failed:", e);
-      });
-    }
-
-    // Also initiate RuntimeStateDoc sync so the daemon sends kernel status,
-    // trust state, etc. Without this, if the daemon's initial RuntimeStateSync
-    // frame arrived before the WASM handle was ready, the frontend would stay
-    // stuck on "not_started" with no way to recover (#runtime-state-race).
-    const stateMsg = handle.flush_runtime_state_sync();
-    if (stateMsg) {
-      sendFrame(frame_types.RUNTIME_STATE_SYNC, stateMsg).catch(
-        (e: unknown) => {
-          handle.cancel_last_runtime_state_flush();
-          logger.warn(
-            "[automerge-notebook] runtime state sync to relay failed:",
-            e,
-          );
-        },
-      );
-    }
-  }, []);
-
   /** Sync re-read cells from WASM (cache-only, no blob fetches). */
   const rematerializeCellsSync = useCallback((handle: NotebookHandle) => {
     const json = handle.get_cells_json();
@@ -138,19 +109,20 @@ export function useAutomergeNotebook() {
   /**
    * Guard + commit helper for WASM mutations.
    * Returns the handle if ready, or null if bootstrapping.
-   * After the mutation callback runs, re-materializes and syncs.
+   * After the mutation callback runs, re-materializes and schedules sync.
    */
   const commitMutation = useCallback(
     (mutate: (handle: NotebookHandle) => boolean) => {
       const handle = handleRef.current;
-      if (!handle || awaitingInitialSyncRef.current) return false;
+      const engine = engineRef.current;
+      if (!handle || !engine || !engine.synced) return false;
       if (!mutate(handle)) return false;
       rematerializeCellsSync(handle);
-      syncToRelay(handle);
+      engine.scheduleFlush();
       setDirty(true);
       return true;
     },
-    [rematerializeCellsSync, syncToRelay],
+    [rematerializeCellsSync],
   );
 
   // ── Bootstrap ──────────────────────────────────────────────────────
@@ -158,33 +130,117 @@ export function useAutomergeNotebook() {
   const bootstrap = useCallback(async () => {
     await wasmReady;
 
-    const handle = NotebookHandle.create_empty_with_actor(
-      `human:${sessionIdRef.current}`,
-    );
+    // Create WASM handle.
+    const { NotebookHandle: NH } =
+      await import("../wasm/runtimed-wasm/runtimed_wasm.js");
+    const handle: NotebookHandle = (
+      NH as typeof NotebookHandle
+    ).create_empty_with_actor(`human:${sessionIdRef.current}`);
 
+    // Clean up previous handle.
     handleRef.current?.free();
     handleRef.current = handle;
     setNotebookHandle(handle);
 
-    awaitingInitialSyncRef.current = true;
-    setIsLoading(true);
+    // Clean up previous engine + transport.
+    engineRef.current?.stop();
+    transportRef.current?.disconnect();
 
-    syncToRelay(handle);
-    logger.info("[automerge-notebook] Bootstrap: empty handle, awaiting sync");
+    // Create transport + engine.
+    const transport = new TauriTransport();
+    await transport.connect();
+    transportRef.current = transport;
+
+    const engine = new SyncEngine(handle, transport, {
+      flushDebounceMs: 20,
+      initialSyncTimeoutMs: 3000,
+    });
+    engineRef.current = engine;
+
+    // ── Subscribe to engine events ───────────────────────────────
+
+    engine.on("initial_sync_complete", () => {
+      setIsLoading(false);
+      // Full materialization on initial sync.
+      const h = handleRef.current;
+      if (h) {
+        materializeCells(h)
+          .then(() => {
+            notifyMetadataChanged();
+          })
+          .catch((err: unknown) => {
+            logger.warn(
+              "[automerge-notebook] initial materialize failed:",
+              err,
+            );
+            setIsLoading(false);
+          });
+      }
+    });
+
+    engine.on("cells_changed", (event) => {
+      // Re-materialize from WASM after inbound sync changes.
+      // For now, full re-materialize. The frame pipeline's coalescing
+      // and incremental materialization can be layered on top later.
+      const h = handleRef.current;
+      if (h) {
+        // Emit text attributions as broadcasts for CodeMirror.
+        if (event.attributions && event.attributions.length > 0) {
+          emitBroadcast({
+            type: "text_attribution",
+            attributions: event.attributions,
+          });
+        }
+
+        // Sync re-read (cache-only) for fast visual feedback.
+        // TODO: Use incremental materialization with changeset for
+        // output-heavy cells (blob resolution). For now, sync read
+        // is fast enough for source/metadata changes and outputs
+        // that are already cached.
+        rematerializeCellsSync(h);
+      }
+    });
+
+    engine.on("broadcast", (event) => {
+      emitBroadcast(event.payload);
+    });
+
+    engine.on("runtime_state_changed", (event) => {
+      setRuntimeState(
+        event.state as import("../lib/runtime-state").RuntimeState,
+      );
+    });
+
+    engine.on("sync_retry", () => {
+      logger.info("[automerge-notebook] SyncEngine retrying initial sync");
+    });
+
+    engine.on("error", (event) => {
+      logger.warn(
+        `[automerge-notebook] SyncEngine error (${event.context}):`,
+        event.error,
+      );
+    });
+
+    // Start the engine — sends initial sync, arms retry timer.
+    engine.start();
+
+    setIsLoading(true);
+    logger.info(
+      "[automerge-notebook] Bootstrap: SyncEngine started, awaiting sync",
+    );
     return true;
-  }, [syncToRelay]);
+  }, [materializeCells, rematerializeCellsSync]);
 
   // ── Lifecycle (single effect) ──────────────────────────────────────
 
   useEffect(() => {
     let cancelled = false;
 
-    awaitingInitialSyncRef.current = true;
     setIsLoading(true);
     void bootstrap().catch((error) => {
       logger.error("[automerge-notebook] Bootstrap failed", error);
       if (!cancelled) {
-        awaitingInitialSyncRef.current = false;
         setIsLoading(false);
       }
     });
@@ -197,7 +253,6 @@ export function useAutomergeNotebook() {
           refreshBlobPort();
           resetNotebookCells();
           resetRuntimeState();
-          awaitingInitialSyncRef.current = true;
           setIsLoading(true);
           return from(
             bootstrap().catch((err: unknown) => {
@@ -210,35 +265,6 @@ export function useAutomergeNotebook() {
         }),
       )
       .subscribe();
-
-    // Inbound frame pipeline (WASM demux → coalesce → materialize → store).
-    const frameSub = createFramePipeline({
-      getHandle: () => handleRef.current,
-      getAwaitingInitialSync: () => awaitingInitialSyncRef.current,
-      setAwaitingInitialSync: (v) => {
-        awaitingInitialSyncRef.current = v;
-      },
-      setIsLoading,
-      materializeCells,
-      outputCache: outputCacheRef.current,
-      retrySyncToRelay: () => {
-        const handle = handleRef.current;
-        if (!handle) return;
-        // Reset sync state so flush_local_changes() produces a fresh
-        // request instead of returning null (which it does when the
-        // handle believes it's already in sync with the peer).
-        handle.reset_sync_state();
-        syncToRelay(handle);
-      },
-    });
-
-    // Source sync: 20ms debounce for batching rapid keystrokes.
-    const sourceSyncSub = sourceSync$.current
-      .pipe(debounceTime(20))
-      .subscribe(() => {
-        const handle = handleRef.current;
-        if (handle) syncToRelay(handle);
-      });
 
     // Bulk output clearing (run-all / restart-and-run-all).
     const clearOutputsSub = fromTauriEvent<string[]>(
@@ -256,15 +282,16 @@ export function useAutomergeNotebook() {
 
     return () => {
       cancelled = true;
-      frameSub.unsubscribe();
       lifecycleSub.unsubscribe();
-      sourceSyncSub.unsubscribe();
       clearOutputsSub.unsubscribe();
 
-      // Flush pending local changes before freeing handle.
-      if (handleRef.current) {
-        syncToRelay(handleRef.current);
-      }
+      // Stop the engine (flushes pending changes).
+      engineRef.current?.stop();
+      engineRef.current = null;
+
+      // Disconnect transport.
+      transportRef.current?.disconnect();
+      transportRef.current = null;
 
       resetNotebookCells();
       resetRuntimeState();
@@ -272,33 +299,34 @@ export function useAutomergeNotebook() {
       handleRef.current?.free();
       handleRef.current = null;
     };
-  }, [bootstrap, materializeCells, syncToRelay]);
+  }, [bootstrap]);
 
   // ── Cell mutations ─────────────────────────────────────────────────
 
   const updateCellSource = useCallback((cellId: string, source: string) => {
     const handle = handleRef.current;
-    if (!handle || awaitingInitialSyncRef.current) return;
+    const engine = engineRef.current;
+    if (!handle || !engine || !engine.synced) return;
 
     const updated = handle.update_source(cellId, source);
     if (!updated) return;
 
     updateCellById(cellId, (c) => ({ ...c, source }));
-    sourceSync$.current.next();
+    engine.scheduleFlush();
     setDirty(true);
   }, []);
 
   /**
    * Clear outputs for a local UI action (Ctrl-Enter, menu clear).
-   * Writes to the CRDT first so the store stays in sync with the
-   * source of truth, then updates the store for instant feedback.
+   * Writes to WASM CRDT + React store optimistically, then syncs.
    */
   const clearOutputsLocal = useCallback((cellId: string) => {
     const handle = handleRef.current;
+    const engine = engineRef.current;
     if (handle) {
       handle.clear_outputs(cellId);
       handle.set_execution_count(cellId, "null");
-      sourceSync$.current.next();
+      engine?.scheduleFlush();
       setDirty(true);
     }
 
@@ -310,16 +338,17 @@ export function useAutomergeNotebook() {
   }, []);
 
   /**
-   * Clear outputs from every code cell via a single WASM call.
-   * Updates the CRDT atomically, then refreshes the store.
+   * Clear all outputs for a local UI action (restart-and-run-all, menu).
+   * Returns the list of cell IDs that were cleared.
    */
   const clearAllOutputsLocal = useCallback(() => {
     const handle = handleRef.current;
+    const engine = engineRef.current;
     if (!handle) return;
     const clearedIds: string[] = handle.clear_all_outputs();
     if (clearedIds.length === 0) return;
 
-    sourceSync$.current.next();
+    engine?.scheduleFlush();
     setDirty(true);
 
     const clearedSet = new Set(clearedIds);
@@ -332,11 +361,7 @@ export function useAutomergeNotebook() {
     );
   }, []);
 
-  /**
-   * Apply a daemon output-clear into the store. Store-only —
-   * the daemon already wrote to the CRDT, so we just update the
-   * local store. No CRDT mutation, no sync, no dirty flag.
-   */
+  /** Clear outputs when notified by a broadcast from another window. */
   const clearOutputsFromDaemon = useCallback((cellId: string) => {
     updateCellById(cellId, (c) =>
       c.cell_type === "code" ? { ...c, outputs: [], execution_count: null } : c,
@@ -344,55 +369,93 @@ export function useAutomergeNotebook() {
   }, []);
 
   const addCell = useCallback(
-    (cellType: "code" | "markdown" | "raw", afterCellId?: string | null) => {
+    (
+      afterCellId: string | null,
+      cellType: "code" | "markdown",
+      initialSource?: string,
+    ) => {
       const handle = handleRef.current;
+      const engine = engineRef.current;
+      if (!handle || !engine || !engine.synced) return null;
 
-      if (!handle || awaitingInitialSyncRef.current) {
-        const placeholderId = crypto.randomUUID();
-        return cellType === "code"
-          ? {
-              cell_type: "code" as const,
-              id: placeholderId,
-              source: "",
-              outputs: [],
-              execution_count: null,
-              metadata: {},
-            }
-          : {
-              cell_type: cellType,
-              id: placeholderId,
-              source: "",
-              metadata: {},
-            };
+      const placeholderId = crypto.randomUUID();
+
+      // Optimistic store write for instant placeholder rendering.
+      if (cellType === "code") {
+        updateNotebookCells((prev) => {
+          const idx = afterCellId
+            ? prev.findIndex((c) => c.id === afterCellId) + 1
+            : 0;
+          const newCell = {
+            cell_type: cellType as "code",
+            id: placeholderId,
+            source: initialSource ?? "",
+            outputs: [],
+            execution_count: null,
+            metadata: {},
+          };
+          const next = [...prev];
+          next.splice(idx, 0, newCell);
+          return next;
+        });
+      } else {
+        updateNotebookCells((prev) => {
+          const idx = afterCellId
+            ? prev.findIndex((c) => c.id === afterCellId) + 1
+            : 0;
+          const newCell = {
+            cell_type: cellType as "markdown",
+            id: placeholderId,
+            source: initialSource ?? "",
+            metadata: {},
+          };
+          const next = [...prev];
+          next.splice(idx, 0, newCell);
+          return next;
+        });
       }
 
-      const cellId = crypto.randomUUID();
-      handle.add_cell_after(cellId, cellType, afterCellId ?? null);
-      rematerializeCellsSync(handle);
-      syncToRelay(handle);
-      setFocusedCellId(cellId);
-      setDirty(true);
+      // CRDT mutation — this generates the real cell ID.
+      const cellId = placeholderId;
+      handle.add_cell_after(cellId, cellType, afterCellId ?? undefined);
+      if (initialSource) {
+        handle.update_source(cellId, initialSource);
+      }
 
-      const cell = getNotebookCellsSnapshot().find((c) => c.id === cellId);
-      return (
-        cell ?? {
-          cell_type: cellType,
-          id: cellId,
-          source: "",
-          ...(cellType === "code"
-            ? { outputs: [], execution_count: null }
-            : {}),
-          metadata: {},
+      // Re-read from WASM to get the canonical state (replaces placeholder).
+      const cell = handle.get_cell(cellId);
+      if (cell) {
+        if (cell.cell_type === "code") {
+          updateCellById(cellId, () => ({
+            cell_type: "code" as const,
+            id: cell.id,
+            source: cell.source,
+            outputs: [],
+            execution_count: null,
+            metadata: cell.metadata_json ? JSON.parse(cell.metadata_json) : {},
+          }));
+        } else {
+          updateCellById(cellId, () => ({
+            cell_type: cell.cell_type as "markdown" | "raw",
+            id: cell.id,
+            source: cell.source,
+            metadata: cell.metadata_json ? JSON.parse(cell.metadata_json) : {},
+          }));
         }
-      );
+        cell.free();
+      }
+
+      engine.scheduleFlush();
+      setDirty(true);
+      return cellId;
     },
-    [rematerializeCellsSync, syncToRelay],
+    [],
   );
 
   const moveCell = useCallback(
-    (cellId: string, afterCellId?: string | null) => {
+    (cellId: string, afterCellId: string | null) => {
       commitMutation((handle) => {
-        handle.move_cell(cellId, afterCellId ?? null);
+        handle.move_cell(cellId, afterCellId ?? undefined);
         return true;
       });
     },
@@ -402,8 +465,7 @@ export function useAutomergeNotebook() {
   const deleteCell = useCallback(
     (cellId: string) => {
       commitMutation((handle) => {
-        if (handle.cell_count() <= 1) return false;
-        return !!handle.delete_cell(cellId);
+        return handle.delete_cell(cellId);
       });
     },
     [commitMutation],
@@ -412,7 +474,7 @@ export function useAutomergeNotebook() {
   const setCellSourceHidden = useCallback(
     (cellId: string, hidden: boolean) => {
       commitMutation((handle) => {
-        return !!handle.set_cell_source_hidden(cellId, hidden);
+        return handle.set_cell_source_hidden(cellId, hidden);
       });
     },
     [commitMutation],
@@ -421,43 +483,46 @@ export function useAutomergeNotebook() {
   const setCellOutputsHidden = useCallback(
     (cellId: string, hidden: boolean) => {
       commitMutation((handle) => {
-        return !!handle.set_cell_outputs_hidden(cellId, hidden);
+        return handle.set_cell_outputs_hidden(cellId, hidden);
       });
     },
     [commitMutation],
   );
 
-  // ── Sync flush ─────────────────────────────────────────────────────
+  // ── Sync operations ────────────────────────────────────────────────
 
-  /** Flush pending debounced sync immediately (call before execute/save). */
+  /**
+   * Flush local CRDT changes immediately (bypasses debounce).
+   *
+   * Call before operations that depend on the daemon having the latest
+   * state, e.g., before `executeCell` or `save`.
+   */
   const flushSync = useCallback(async () => {
-    const handle = handleRef.current;
-    if (!handle) return;
-    // Bypasses the debounce; any pending emission becomes a no-op.
-    const msg = handle.flush_local_changes();
-    if (msg) {
-      try {
-        await sendFrame(frame_types.AUTOMERGE_SYNC, msg);
-      } catch (e) {
-        // flush_local_changes advanced sync_state (in_flight, sent_hashes).
-        // Cancel to prevent sent_hashes from permanently filtering out
-        // the change data we never delivered (#1067).
-        handle.cancel_last_flush();
-        logger.warn("[flushSync] failed, rolled back sync state", e);
-      }
+    const engine = engineRef.current;
+    if (!engine) return;
+    try {
+      await engine.flush();
+    } catch (e) {
+      // flush() already rolled back sync state via cancel_last_flush.
+      logger.warn("[flushSync] failed, sync state rolled back", e);
     }
   }, []);
 
   // ── File operations ────────────────────────────────────────────────
 
   const save = useCallback(async () => {
+    const { saveNotebook } = await import("../lib/notebook-file-ops");
     const saved = await saveNotebook(flushSync);
     if (saved) setDirty(false);
   }, [flushSync]);
 
-  const openNotebook = useCallback(() => openNotebookFile(), []);
+  const openNotebook = useCallback(() => {
+    import("../lib/notebook-file-ops").then((m) => m.openNotebookFile());
+  }, []);
 
-  const cloneNotebook = useCallback(() => cloneNotebookFile(), []);
+  const cloneNotebook = useCallback(() => {
+    import("../lib/notebook-file-ops").then((m) => m.cloneNotebookFile());
+  }, []);
 
   // ── Output overlays (optimistic, pre-sync) ─────────────────────────
 
@@ -478,7 +543,11 @@ export function useAutomergeNotebook() {
               output.display_id === displayId
             ) {
               changed = true;
-              return { ...output, data: newData, metadata: newMetadata };
+              return {
+                ...output,
+                data: { ...output.data, ...newData },
+                metadata: { ...output.metadata, ...newMetadata },
+              };
             }
             return output;
           });
@@ -490,32 +559,34 @@ export function useAutomergeNotebook() {
   );
 
   /**
-   * Apply a daemon execution-count update into the store. Store-only —
-   * the daemon already wrote to the CRDT.
+   * Apply execution count from daemon broadcast (optimistic overlay).
+   * The CRDT will catch up via sync, but this gives instant visual feedback.
    */
   const applyExecutionCountFromDaemon = useCallback(
-    (cellId: string, count: number) => {
+    (cellId: string, executionCount: number) => {
       updateCellById(cellId, (c) =>
-        c.cell_type === "code" ? { ...c, execution_count: count } : c,
+        c.cell_type === "code" ? { ...c, execution_count: executionCount } : c,
       );
     },
     [],
   );
 
-  // ── Public interface ───────────────────────────────────────────────
-
   // ── CRDT bridge deps ───────────────────────────────────────────────
   // Stable getter for the WASM handle (reads ref at call time).
   const getHandle = useCallback(() => handleRef.current, []);
-  // Trigger a debounced sync to the daemon (same Subject the old
-  // updateCellSource used via sourceSync$).
-  const triggerSync = useCallback(() => sourceSync$.current.next(), []);
+  // Trigger a debounced sync to the daemon.
+  const triggerSync = useCallback(() => {
+    engineRef.current?.scheduleFlush();
+  }, []);
 
   return {
     cellIds,
-    isLoading,
     focusedCellId,
     setFocusedCellId,
+    dirty,
+    isLoading,
+
+    // Cell mutations
     updateCellSource,
     clearOutputsLocal,
     clearAllOutputsLocal,
@@ -523,18 +594,26 @@ export function useAutomergeNotebook() {
     addCell,
     moveCell,
     deleteCell,
+    setCellSourceHidden,
+    setCellOutputsHidden,
+
+    // Sync
+    flushSync,
+
+    // File operations
     save,
     openNotebook,
     cloneNotebook,
-    dirty,
-    setDirty,
+
+    // Output overlays
     updateOutputByDisplayId,
     applyExecutionCountFromDaemon,
-    setCellSourceHidden,
-    setCellOutputsHidden,
-    flushSync,
-    // CRDT bridge context deps
+
+    // For child components that need direct WASM access
     getHandle,
     triggerSync,
+
+    // Snapshot for save/export
+    getNotebookCellsSnapshot,
   };
 }

--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -17,7 +17,11 @@ import {
   updateNotebookCells,
   useCellIds,
 } from "../lib/notebook-cells";
-import { subscribeBroadcast, emitBroadcast } from "../lib/notebook-frame-bus";
+import {
+  subscribeBroadcast,
+  emitBroadcast,
+  emitPresence,
+} from "../lib/notebook-frame-bus";
 import {
   notifyMetadataChanged,
   setNotebookHandle,
@@ -310,6 +314,12 @@ export function useAutomergeNotebook() {
     rxSub.add(
       engine.broadcasts$.subscribe((payload) => {
         emitBroadcast(payload);
+      }),
+    );
+
+    rxSub.add(
+      engine.presence$.subscribe((payload) => {
+        emitPresence(payload);
       }),
     );
 

--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -349,7 +349,7 @@ export function useAutomergeNotebook() {
       "[automerge-notebook] Bootstrap: SyncEngine started, awaiting sync",
     );
     return true;
-  }, [materializeCells, rematerializeCellsSync]);
+  }, [materializeCells]);
 
   // ── Lifecycle (single effect) ──────────────────────────────────────
 

--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -370,8 +370,8 @@ export function useAutomergeNotebook() {
 
   const addCell = useCallback(
     (
-      afterCellId: string | null,
-      cellType: "code" | "markdown",
+      cellType: "code" | "markdown" | "raw",
+      afterCellId?: string | null,
       initialSource?: string,
     ) => {
       const handle = handleRef.current;
@@ -453,7 +453,7 @@ export function useAutomergeNotebook() {
   );
 
   const moveCell = useCallback(
-    (cellId: string, afterCellId: string | null) => {
+    (cellId: string, afterCellId?: string | null) => {
       commitMutation((handle) => {
         handle.move_cell(cellId, afterCellId ?? undefined);
         return true;
@@ -596,6 +596,7 @@ export function useAutomergeNotebook() {
     deleteCell,
     setCellSourceHidden,
     setCellOutputsHidden,
+    setDirty,
 
     // Sync
     flushSync,

--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -183,8 +183,6 @@ export function useAutomergeNotebook() {
 
     engine.on("cells_changed", (event) => {
       // Re-materialize from WASM after inbound sync changes.
-      // For now, full re-materialize. The frame pipeline's coalescing
-      // and incremental materialization can be layered on top later.
       const h = handleRef.current;
       if (h) {
         // Emit text attributions as broadcasts for CodeMirror.
@@ -195,12 +193,14 @@ export function useAutomergeNotebook() {
           });
         }
 
-        // Sync re-read (cache-only) for fast visual feedback.
-        // TODO: Use incremental materialization with changeset for
-        // output-heavy cells (blob resolution). For now, sync read
-        // is fast enough for source/metadata changes and outputs
-        // that are already cached.
-        rematerializeCellsSync(h);
+        // Full async materialization — resolves manifest hashes from
+        // the blob HTTP server. Required for outputs (which are stored
+        // as content-addressed blob references in the CRDT).
+        // TODO: Use incremental materialization with changeset to avoid
+        // re-resolving outputs that haven't changed.
+        materializeCells(h).catch((err: unknown) => {
+          logger.warn("[automerge-notebook] materialize failed:", err);
+        });
       }
     });
 

--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -28,7 +28,7 @@ import { TauriTransport } from "../lib/tauri-transport";
 import type { NotebookHandle } from "../wasm/runtimed-wasm/runtimed_wasm.js";
 import type { DaemonBroadcast, JupyterOutput } from "../types";
 
-import { SyncEngine } from "@nteract/runtimed";
+import { SyncEngine } from "runtimed";
 
 // ── WASM init ────────────────────────────────────────────────────────
 
@@ -44,7 +44,7 @@ const wasmReady = (async () => {
  * Core Automerge notebook hook — manages the WASM document, sync lifecycle,
  * and cell store.
  *
- * Uses {@link SyncEngine} from `@nteract/runtimed` for all sync management
+ * Uses {@link SyncEngine} from `runtimed` for all sync management
  * and {@link TauriTransport} for the IPC layer. The hook subscribes to engine
  * events and writes to the React cell/runtime stores.
  */
@@ -242,7 +242,7 @@ export function useAutomergeNotebook() {
                 // Resolve outputs from cache (sync path).
                 // Outputs that are manifest hashes not in cache will show
                 // as loading — a subsequent full materialize will resolve them.
-                const resolvedOutputs = (outputs ?? [])
+                const resolvedOutputs = ((outputs ?? []) as string[])
                   .map((o: string) => {
                     // 1. Already resolved in cache
                     const cached = outputCacheRef.current.get(o);

--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -7,6 +7,7 @@ import {
   type CellSnapshot,
   cellSnapshotsToNotebookCells,
   cellSnapshotsToNotebookCellsSync,
+  isManifestHash,
 } from "../lib/materialize-cells";
 import {
   getNotebookCellsSnapshot,
@@ -241,16 +242,27 @@ export function useAutomergeNotebook() {
                 // Resolve outputs from cache (sync path).
                 // Outputs that are manifest hashes not in cache will show
                 // as loading — a subsequent full materialize will resolve them.
-                const resolvedOutputs = (outputs ?? []).map(
-                  (o: string) =>
-                    outputCacheRef.current.get(o) ??
-                    (typeof o === "string" && o.length === 16
-                      ? (c.outputs.find(
-                          (existing: JupyterOutput) =>
-                            existing && "_manifest" in existing,
-                        ) ?? { output_type: "loading", _manifest: o })
-                      : JSON.parse(o)),
-                );
+                const resolvedOutputs = (outputs ?? [])
+                  .map((o: string) => {
+                    // 1. Already resolved in cache
+                    const cached = outputCacheRef.current.get(o);
+                    if (cached) return cached;
+
+                    // 2. Manifest hash — needs async blob resolution
+                    if (isManifestHash(o)) {
+                      return null; // will trigger deferred materialize below
+                    }
+
+                    // 3. Inline JSON output
+                    try {
+                      const parsed = JSON.parse(o) as JupyterOutput;
+                      outputCacheRef.current.set(o, parsed);
+                      return parsed;
+                    } catch {
+                      return null;
+                    }
+                  })
+                  .filter((o): o is JupyterOutput => o !== null);
 
                 return {
                   ...c,
@@ -269,9 +281,7 @@ export function useAutomergeNotebook() {
               cell.fields.outputs &&
               (h.get_cell_outputs(cell.cell_id) ?? []).some(
                 (o: string) =>
-                  typeof o === "string" &&
-                  o.length === 16 &&
-                  !outputCacheRef.current.has(o),
+                  isManifestHash(o) && !outputCacheRef.current.has(o),
               ),
           );
           if (hasUnresolved) {

--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -1,6 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { from, switchMap, Subscription as RxSubscription } from "rxjs";
+import { SyncEngine } from "runtimed";
+import { from, Subscription as RxSubscription, switchMap } from "rxjs";
 import { getBlobPort, refreshBlobPort } from "../lib/blob-port";
 import { logger } from "../lib/logger";
 import {
@@ -18,9 +19,9 @@ import {
   useCellIds,
 } from "../lib/notebook-cells";
 import {
-  subscribeBroadcast,
   emitBroadcast,
   emitPresence,
+  subscribeBroadcast,
 } from "../lib/notebook-frame-bus";
 import {
   notifyMetadataChanged,
@@ -29,16 +30,15 @@ import {
 import { resetRuntimeState, setRuntimeState } from "../lib/runtime-state";
 import { fromTauriEvent } from "../lib/tauri-rx";
 import { TauriTransport } from "../lib/tauri-transport";
-import type { NotebookHandle } from "../wasm/runtimed-wasm/runtimed_wasm.js";
 import type { DaemonBroadcast, JupyterOutput } from "../types";
-
-import { SyncEngine } from "runtimed";
+import type { NotebookHandle } from "../wasm/runtimed-wasm/runtimed_wasm.js";
 
 // ── WASM init ────────────────────────────────────────────────────────
 
 const wasmReady = (async () => {
-  const { default: init } =
-    await import("../wasm/runtimed-wasm/runtimed_wasm.js");
+  const { default: init } = await import(
+    "../wasm/runtimed-wasm/runtimed_wasm.js"
+  );
   await init();
 })();
 
@@ -143,8 +143,9 @@ export function useAutomergeNotebook() {
     await wasmReady;
 
     // Create WASM handle.
-    const { NotebookHandle: NH } =
-      await import("../wasm/runtimed-wasm/runtimed_wasm.js");
+    const { NotebookHandle: NH } = await import(
+      "../wasm/runtimed-wasm/runtimed_wasm.js"
+    );
     const handle: NotebookHandle = (
       NH as typeof NotebookHandle
     ).create_empty_with_actor(`human:${sessionIdRef.current}`);

--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -1,6 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { from, switchMap } from "rxjs";
+import { from, switchMap, Subscription as RxSubscription } from "rxjs";
 import { getBlobPort, refreshBlobPort } from "../lib/blob-port";
 import { logger } from "../lib/logger";
 import {
@@ -60,6 +60,7 @@ export function useAutomergeNotebook() {
   // SyncEngine + TauriTransport refs (stable across re-renders).
   const engineRef = useRef<SyncEngine | null>(null);
   const transportRef = useRef<TauriTransport | null>(null);
+  const rxSubRef = useRef<RxSubscription | null>(null);
 
   // Refresh blob port on mount.
   useEffect(() => {
@@ -181,38 +182,49 @@ export function useAutomergeNotebook() {
       }
     });
 
-    engine.on("cells_changed", (event) => {
-      // Re-materialize from WASM after inbound sync changes.
-      const h = handleRef.current;
-      if (h) {
-        // Emit text attributions as broadcasts for CodeMirror.
-        if (event.attributions && event.attributions.length > 0) {
+    // ── RxJS subscriptions to coalesced engine streams ────────────
+    //
+    // cellChanges$ buffers rapid cells_changed events over 32ms and
+    // merges their changesets. This prevents over-materializing during
+    // output streaming (which can cause blob resolution races and
+    // CodeMirror splice_source errors from stale positions).
+
+    const rxSub = new RxSubscription();
+    rxSubRef.current = rxSub;
+
+    rxSub.add(
+      engine.cellChanges$.subscribe((batch) => {
+        const h = handleRef.current;
+        if (!h) return;
+
+        // Emit text attributions for CodeMirror remote cursors.
+        if (batch.attributions.length > 0) {
           emitBroadcast({
             type: "text_attribution",
-            attributions: event.attributions,
+            attributions: batch.attributions,
           });
         }
 
         // Full async materialization — resolves manifest hashes from
-        // the blob HTTP server. Required for outputs (which are stored
-        // as content-addressed blob references in the CRDT).
-        // TODO: Use incremental materialization with changeset to avoid
-        // re-resolving outputs that haven't changed.
+        // the blob HTTP server. The coalescing ensures we don't start
+        // a new materialization while the previous one is resolving blobs.
         materializeCells(h).catch((err: unknown) => {
           logger.warn("[automerge-notebook] materialize failed:", err);
         });
-      }
-    });
+      }),
+    );
 
-    engine.on("broadcast", (event) => {
-      emitBroadcast(event.payload);
-    });
+    rxSub.add(
+      engine.broadcasts$.subscribe((payload) => {
+        emitBroadcast(payload);
+      }),
+    );
 
-    engine.on("runtime_state_changed", (event) => {
-      setRuntimeState(
-        event.state as import("../lib/runtime-state").RuntimeState,
-      );
-    });
+    rxSub.add(
+      engine.runtimeState$.subscribe((state) => {
+        setRuntimeState(state as import("../lib/runtime-state").RuntimeState);
+      }),
+    );
 
     engine.on("sync_retry", () => {
       logger.info("[automerge-notebook] SyncEngine retrying initial sync");
@@ -285,6 +297,7 @@ export function useAutomergeNotebook() {
 
     return () => {
       cancelled = true;
+      rxSubRef.current?.unsubscribe();
       lifecycleSub.unsubscribe();
       clearOutputsSub.unsubscribe();
 

--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -63,6 +63,12 @@ export function useAutomergeNotebook() {
   const transportRef = useRef<TauriTransport | null>(null);
   const rxSubRef = useRef<RxSubscription | null>(null);
 
+  // Guard: don't emit text_attributions until after the first successful
+  // materialization. During initial sync, CodeMirror hasn't rendered cells
+  // yet — attributions referencing positions in the source will crash with
+  // "splice_source failed: index N is out of bounds".
+  const materializedOnceRef = useRef(false);
+
   // Refresh blob port on mount.
   useEffect(() => {
     refreshBlobPort();
@@ -164,6 +170,8 @@ export function useAutomergeNotebook() {
 
     // ── Subscribe to engine events ───────────────────────────────
 
+    materializedOnceRef.current = false;
+
     engine.on("initial_sync_complete", () => {
       setIsLoading(false);
       // Full materialization on initial sync.
@@ -171,6 +179,7 @@ export function useAutomergeNotebook() {
       if (h) {
         materializeCells(h)
           .then(() => {
+            materializedOnceRef.current = true;
             notifyMetadataChanged();
           })
           .catch((err: unknown) => {
@@ -198,8 +207,10 @@ export function useAutomergeNotebook() {
         const h = handleRef.current;
         if (!h) return;
 
-        // Emit text attributions for CodeMirror remote cursors.
-        if (batch.attributions.length > 0) {
+        // Emit text attributions for CodeMirror remote cursors — but only
+        // after the first materialization. During initial sync, CodeMirror
+        // hasn't rendered the cells yet, so splice positions are invalid.
+        if (batch.attributions.length > 0 && materializedOnceRef.current) {
           emitBroadcast({
             type: "text_attribution",
             attributions: batch.attributions,

--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -154,7 +154,7 @@ export function useAutomergeNotebook() {
     await transport.connect();
     transportRef.current = transport;
 
-    const engine = new SyncEngine(handle, transport, {
+    const engine = new SyncEngine(() => handleRef.current, transport, {
       flushDebounceMs: 20,
       initialSyncTimeoutMs: 3000,
     });

--- a/apps/notebook/src/lib/tauri-transport.ts
+++ b/apps/notebook/src/lib/tauri-transport.ts
@@ -1,7 +1,7 @@
 /**
  * TauriTransport — NotebookTransport implementation for the Tauri desktop app.
  *
- * Bridges the @nteract/runtimed library to Tauri IPC:
+ * Bridges the runtimed library to Tauri IPC:
  * - `sendFrame` → `invoke("send_frame", rawBytes)`
  * - `onFrame` → `getCurrentWebview().listen("notebook:frame")`
  * - `sendRequest` → `invoke(commandName, args)` for daemon commands
@@ -19,7 +19,7 @@ import type {
   NotebookTransport,
   FrameTypeValue,
   Unsubscribe,
-} from "@nteract/runtimed";
+} from "runtimed";
 
 // ── TauriTransport ──────────────────────────────────────────────────
 

--- a/apps/notebook/src/lib/tauri-transport.ts
+++ b/apps/notebook/src/lib/tauri-transport.ts
@@ -1,0 +1,190 @@
+/**
+ * TauriTransport — NotebookTransport implementation for the Tauri desktop app.
+ *
+ * Bridges the @nteract/runtimed library to Tauri IPC:
+ * - `sendFrame` → `invoke("send_frame", rawBytes)`
+ * - `onFrame` → `getCurrentWebview().listen("notebook:frame")`
+ * - `sendRequest` → `invoke(commandName, args)` for daemon commands
+ *
+ * This is the only file in the frontend that imports both the runtimed
+ * transport interface and Tauri APIs. The SyncEngine and the rest of the
+ * library are transport-agnostic.
+ *
+ * @module
+ */
+
+import { invoke } from "@tauri-apps/api/core";
+import { getCurrentWebview } from "@tauri-apps/api/webview";
+import type {
+  NotebookTransport,
+  FrameTypeValue,
+  Unsubscribe,
+} from "@nteract/runtimed";
+
+// ── TauriTransport ──────────────────────────────────────────────────
+
+export class TauriTransport implements NotebookTransport {
+  #connected = false;
+  #subscribers: Set<(frame: Uint8Array) => void> = new Set();
+  #unlistenFrame: (() => void) | null = null;
+  #unlistenPromise: Promise<() => void> | null = null;
+
+  /**
+   * Connect to the Tauri webview event system.
+   *
+   * Starts listening for `notebook:frame` events from the Rust relay.
+   * Must be called before `sendFrame` or `onFrame` will work.
+   *
+   * Safe to call multiple times — subsequent calls are no-ops if
+   * already connected.
+   */
+  async connect(): Promise<void> {
+    if (this.#connected) return;
+
+    const webview = getCurrentWebview();
+
+    // Listen for inbound frames from the Rust relay.
+    // The payload is `number[]` (byte array) — the full typed frame
+    // including the type byte.
+    this.#unlistenPromise = webview.listen<number[]>(
+      "notebook:frame",
+      (event) => {
+        if (!this.#connected) return;
+        const frame = new Uint8Array(event.payload);
+        for (const cb of this.#subscribers) {
+          try {
+            cb(frame);
+          } catch (err) {
+            console.error("[TauriTransport] subscriber error:", err);
+          }
+        }
+      },
+    );
+
+    // Wait for the listener to be registered before marking connected.
+    this.#unlistenFrame = await this.#unlistenPromise;
+    this.#connected = true;
+  }
+
+  // ── NotebookTransport implementation ───────────────────────────
+
+  get connected(): boolean {
+    return this.#connected;
+  }
+
+  async sendFrame(
+    frameType: FrameTypeValue,
+    payload: Uint8Array,
+  ): Promise<void> {
+    if (!this.#connected) {
+      throw new Error("TauriTransport: not connected");
+    }
+
+    // Build the wire frame: [type_byte, ...payload]
+    const frame = new Uint8Array(1 + payload.length);
+    frame[0] = frameType;
+    frame.set(payload, 1);
+
+    // Send as raw binary via Tauri IPC.
+    // The Rust `send_frame` command accepts `InvokeBody::Raw`.
+    await invoke("send_frame", frame);
+  }
+
+  onFrame(callback: (frame: Uint8Array) => void): Unsubscribe {
+    this.#subscribers.add(callback);
+    return () => {
+      this.#subscribers.delete(callback);
+    };
+  }
+
+  async sendRequest<T = unknown>(request: unknown): Promise<T> {
+    if (!this.#connected) {
+      throw new Error("TauriTransport: not connected");
+    }
+
+    // Daemon requests are sent as named Tauri commands.
+    // The request object must have an `action` field that maps to a
+    // Tauri command name (e.g., "execute_cell" → "execute_cell_via_daemon").
+    //
+    // This is a thin dispatch layer — the actual command routing is
+    // handled by Tauri's command system on the Rust side.
+    const req = request as Record<string, unknown>;
+    const action = req.action as string;
+
+    if (!action) {
+      throw new Error("TauriTransport.sendRequest: request must have an 'action' field");
+    }
+
+    // Map action names to Tauri command names.
+    const commandName = ACTION_TO_COMMAND[action];
+    if (!commandName) {
+      throw new Error(`TauriTransport.sendRequest: unknown action '${action}'`);
+    }
+
+    // Strip the action field and pass the rest as args.
+    const { action: _, ...args } = req;
+    return invoke<T>(commandName, args);
+  }
+
+  disconnect(): void {
+    if (!this.#connected) return;
+    this.#connected = false;
+
+    // Tear down the Tauri event listener.
+    if (this.#unlistenFrame) {
+      this.#unlistenFrame();
+      this.#unlistenFrame = null;
+    } else if (this.#unlistenPromise) {
+      // Listener was still registering — clean up when it resolves.
+      this.#unlistenPromise.then((fn) => fn()).catch(() => {});
+    }
+    this.#unlistenPromise = null;
+
+    // Clear all subscribers.
+    this.#subscribers.clear();
+  }
+}
+
+// ── Action → Tauri command mapping ──────────────────────────────────
+
+/**
+ * Maps request action names to Tauri invoke command names.
+ *
+ * The transport layer translates between the library's generic action
+ * names and the app-specific Tauri commands registered in Rust.
+ *
+ * To add a new daemon command:
+ * 1. Register it in `crates/notebook/src/lib.rs` as a `#[tauri::command]`
+ * 2. Add the mapping here
+ * 3. The library can now `transport.sendRequest({ action: "...", ... })`
+ */
+const ACTION_TO_COMMAND: Record<string, string> = {
+  // Kernel lifecycle
+  launch_kernel: "launch_kernel_via_daemon",
+  interrupt: "interrupt_via_daemon",
+  shutdown_kernel: "shutdown_kernel_via_daemon",
+  restart_kernel: "restart_kernel_via_daemon",
+
+  // Cell execution
+  execute_cell: "execute_cell_via_daemon",
+  run_all_cells: "run_all_cells_via_daemon",
+  clear_outputs: "clear_outputs_via_daemon",
+
+  // File operations
+  save_notebook: "save_notebook",
+  save_notebook_as: "save_notebook_as",
+
+  // Environment
+  sync_environment: "sync_environment_via_daemon",
+  get_daemon_queue_state: "get_daemon_queue_state",
+
+  // Comm (widgets)
+  send_comm: "send_comm_via_daemon",
+
+  // Trust
+  approve_trust: "approve_notebook_trust",
+
+  // Misc
+  reconnect: "reconnect_to_daemon",
+  mark_clean: "mark_notebook_clean",
+};

--- a/apps/notebook/src/lib/tauri-transport.ts
+++ b/apps/notebook/src/lib/tauri-transport.ts
@@ -15,11 +15,7 @@
 
 import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWebview } from "@tauri-apps/api/webview";
-import type {
-  NotebookTransport,
-  FrameTypeValue,
-  Unsubscribe,
-} from "runtimed";
+import type { FrameTypeValue, NotebookTransport, Unsubscribe } from "runtimed";
 
 // ── TauriTransport ──────────────────────────────────────────────────
 
@@ -112,7 +108,9 @@ export class TauriTransport implements NotebookTransport {
     const action = req.action as string;
 
     if (!action) {
-      throw new Error("TauriTransport.sendRequest: request must have an 'action' field");
+      throw new Error(
+        "TauriTransport.sendRequest: request must have an 'action' field",
+      );
     }
 
     // Map action names to Tauri command names.

--- a/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm
+++ b/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e3963bf8ba206fd8ac9208d651a79de7764117cee87865b9e8ead27f640827dd
-size 1622248
+oid sha256:8c15a3f6c68f7aa29c0fcef7e486c3080063f71aba48904994ec0fd830b5cf56
+size 1622335

--- a/packages/runtimed/deno.json
+++ b/packages/runtimed/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "rxjs": "npm:rxjs@^7.8.0"
+  }
+}

--- a/packages/runtimed/package.json
+++ b/packages/runtimed/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@nteract/runtimed",
+  "version": "0.1.0",
+  "type": "module",
+  "description": "Transport-agnostic JavaScript bindings for nteract notebook documents. Wraps the runtimed WASM CRDT engine with a clean API for sync, cell mutations, and runtime state.",
+  "license": "BSD-3-Clause",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nteract/desktop",
+    "directory": "packages/runtimed"
+  },
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "src",
+    "README.md"
+  ],
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "runtimed-wasm": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "^5.8.0"
+  }
+}

--- a/packages/runtimed/package.json
+++ b/packages/runtimed/package.json
@@ -19,6 +19,9 @@
   "scripts": {
     "typecheck": "tsc --noEmit"
   },
+  "dependencies": {
+    "rxjs": "^7.8.0"
+  },
   "devDependencies": {
     "typescript": "^5.8.0"
   }

--- a/packages/runtimed/package.json
+++ b/packages/runtimed/package.json
@@ -9,8 +9,13 @@
     "url": "https://github.com/nteract/desktop",
     "directory": "packages/runtimed"
   },
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts"
+    }
   },
   "files": [
     "src",

--- a/packages/runtimed/package.json
+++ b/packages/runtimed/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@nteract/runtimed",
+  "name": "runtimed",
   "version": "0.1.0",
   "type": "module",
   "description": "Transport-agnostic JavaScript bindings for nteract notebook documents. Wraps the runtimed WASM CRDT engine with a clean API for sync, cell mutations, and runtime state.",

--- a/packages/runtimed/package.json
+++ b/packages/runtimed/package.json
@@ -19,9 +19,6 @@
   "scripts": {
     "typecheck": "tsc --noEmit"
   },
-  "dependencies": {
-    "runtimed-wasm": "workspace:*"
-  },
   "devDependencies": {
     "typescript": "^5.8.0"
   }

--- a/packages/runtimed/src/direct-transport.ts
+++ b/packages/runtimed/src/direct-transport.ts
@@ -1,0 +1,290 @@
+/**
+ * DirectTransport — a test transport that connects a SyncEngine to a
+ * "server" NotebookHandle without any network or IPC.
+ *
+ * Simulates the daemon side: inbound frames from the server are delivered
+ * to the client's `onFrame` subscribers, and outbound frames from the
+ * client are applied to the server handle.
+ *
+ * The request/response channel uses a pluggable handler function so tests
+ * can simulate ExecuteCell, LaunchKernel, etc.
+ *
+ * Usage:
+ * ```ts
+ * const server = new NotebookHandle("test-server");
+ * const transport = new DirectTransport(server);
+ *
+ * // Optional: handle requests
+ * transport.onRequest = (req) => ({ result: "ok" });
+ *
+ * const engine = new SyncEngine(clientHandle, transport);
+ * engine.start();
+ *
+ * // Push server changes to the client:
+ * server.update_source("cell-1", "hello");
+ * transport.pushServerChanges();
+ * ```
+ *
+ * @module
+ */
+
+import { FrameType } from "./transport.ts";
+import type {
+  NotebookTransport,
+  FrameTypeValue,
+  Unsubscribe,
+} from "./transport.ts";
+
+/**
+ * Minimal interface for the server-side NotebookHandle used by DirectTransport.
+ *
+ * This is the subset of NotebookHandle methods needed to simulate the daemon:
+ * - Generate sync messages (to push to the client)
+ * - Receive sync messages (from the client)
+ * - Generate runtime state sync replies
+ */
+export interface ServerHandle {
+  /** Generate a sync message for pending changes. */
+  flush_local_changes(): Uint8Array | undefined;
+
+  /** Apply a sync message from the client. */
+  receive_sync_message(message: Uint8Array): boolean;
+
+  /** Reset sync state (for reconnection simulation). */
+  reset_sync_state(): void;
+}
+
+/** Handler for request/response simulation. */
+export type RequestHandler = (request: unknown) => unknown | Promise<unknown>;
+
+/**
+ * Test transport that connects a client SyncEngine directly to a server
+ * NotebookHandle, with no network layer.
+ *
+ * Frame delivery is synchronous by default — `pushServerChanges()` generates
+ * a sync message from the server and delivers it to all `onFrame` subscribers
+ * immediately. This makes tests deterministic.
+ *
+ * For async scenarios (testing debounce, retry, etc.), use `pushServerChangesAsync()`
+ * which defers delivery to the next microtask.
+ */
+export class DirectTransport implements NotebookTransport {
+  readonly #server: ServerHandle;
+  #subscribers: Set<(frame: Uint8Array) => void> = new Set();
+  #connected = true;
+
+  /**
+   * Pluggable request handler. Tests set this to simulate daemon responses.
+   *
+   * ```ts
+   * transport.onRequest = (req) => {
+   *   if (req.action === "execute_cell") return { result: "CellQueued", cell_id: req.cell_id };
+   *   return { result: "error", error: "unknown action" };
+   * };
+   * ```
+   */
+  onRequest: RequestHandler = () => ({ result: "ok" });
+
+  /** Track sent frames for test assertions. */
+  readonly sentFrames: Array<{ frameType: FrameTypeValue; payload: Uint8Array }> =
+    [];
+
+  /** Track whether cancel_last_flush would have been needed (for test diagnostics). */
+  sendFailureCount = 0;
+
+  /**
+   * If true, `sendFrame` will reject — simulating transport failure.
+   * Used to test rollback behavior (cancel_last_flush).
+   */
+  simulateFailure = false;
+
+  constructor(server: ServerHandle) {
+    this.#server = server;
+  }
+
+  // ── NotebookTransport implementation ───────────────────────────
+
+  get connected(): boolean {
+    return this.#connected;
+  }
+
+  async sendFrame(
+    frameType: FrameTypeValue,
+    payload: Uint8Array,
+  ): Promise<void> {
+    this.#assertConnected();
+
+    if (this.simulateFailure) {
+      this.sendFailureCount++;
+      throw new Error("DirectTransport: simulated send failure");
+    }
+
+    this.sentFrames.push({ frameType, payload });
+
+    // Route the frame to the server based on type.
+    switch (frameType) {
+      case FrameType.AUTOMERGE_SYNC:
+        // Client → server sync message.
+        this.#server.receive_sync_message(payload);
+        break;
+
+      case FrameType.RUNTIME_STATE_SYNC:
+        // Client → server runtime state sync reply.
+        // In a real daemon this updates the server's state_sync_state.
+        // For tests we just record it.
+        break;
+
+      case FrameType.PRESENCE:
+        // Presence frames — record only.
+        break;
+
+      default:
+        // Request/Response frames shouldn't come through sendFrame.
+        break;
+    }
+  }
+
+  onFrame(callback: (frame: Uint8Array) => void): Unsubscribe {
+    this.#subscribers.add(callback);
+    return () => {
+      this.#subscribers.delete(callback);
+    };
+  }
+
+  async sendRequest<T = unknown>(request: unknown): Promise<T> {
+    this.#assertConnected();
+    const result = await this.onRequest(request);
+    return result as T;
+  }
+
+  disconnect(): void {
+    this.#connected = false;
+    this.#subscribers.clear();
+  }
+
+  // ── Test helpers ───────────────────────────────────────────────
+
+  /**
+   * Push the server's pending changes to all client subscribers.
+   *
+   * Generates a sync message from the server handle, wraps it as a
+   * typed frame (0x00 + payload), and delivers it synchronously to
+   * all `onFrame` subscribers.
+   *
+   * Call this after mutating the server handle to simulate the daemon
+   * pushing changes to the client.
+   *
+   * Returns true if a sync message was generated and delivered.
+   */
+  pushServerChanges(): boolean {
+    const msg = this.#server.flush_local_changes();
+    if (!msg) return false;
+
+    const frame = new Uint8Array(1 + msg.length);
+    frame[0] = FrameType.AUTOMERGE_SYNC;
+    frame.set(msg, 1);
+
+    this.#deliver(frame);
+    return true;
+  }
+
+  /**
+   * Async variant of `pushServerChanges` — delivers on the next microtask.
+   * Useful for testing debounce and timing behavior.
+   */
+  async pushServerChangesAsync(): Promise<boolean> {
+    await Promise.resolve(); // yield to microtask queue
+    return this.pushServerChanges();
+  }
+
+  /**
+   * Push a raw broadcast event to all client subscribers.
+   *
+   * ```ts
+   * transport.pushBroadcast({
+   *   event: "execution_started",
+   *   cell_id: "cell-1",
+   *   execution_count: 1,
+   * });
+   * ```
+   */
+  pushBroadcast(payload: unknown): void {
+    const json = JSON.stringify(payload);
+    const bytes = new TextEncoder().encode(json);
+    const frame = new Uint8Array(1 + bytes.length);
+    frame[0] = FrameType.BROADCAST;
+    frame.set(bytes, 1);
+
+    this.#deliver(frame);
+  }
+
+  /**
+   * Push a raw presence event to all client subscribers.
+   */
+  pushPresence(payload: Uint8Array): void {
+    const frame = new Uint8Array(1 + payload.length);
+    frame[0] = FrameType.PRESENCE;
+    frame.set(payload, 1);
+
+    this.#deliver(frame);
+  }
+
+  /**
+   * Run a full sync cycle between server and client.
+   *
+   * Pushes server changes, then (if the client sent a reply via sendFrame),
+   * pushes server changes again to complete the round-trip. Repeats until
+   * convergence or maxRounds.
+   *
+   * This is the DirectTransport equivalent of the `syncHandles` helper
+   * in the Deno WASM tests.
+   */
+  syncUntilConverged(maxRounds = 10): number {
+    let rounds = 0;
+    for (let i = 0; i < maxRounds; i++) {
+      const pushed = this.pushServerChanges();
+      const clientSentSync = this.sentFrames.some(
+        (f, idx) =>
+          idx >= this.sentFrames.length - 10 &&
+          f.frameType === FrameType.AUTOMERGE_SYNC,
+      );
+
+      if (!pushed && !clientSentSync) break;
+      rounds++;
+    }
+    return rounds;
+  }
+
+  /**
+   * Clear recorded sent frames. Useful between test phases.
+   */
+  clearSentFrames(): void {
+    this.sentFrames.length = 0;
+  }
+
+  /**
+   * Reconnect after a disconnect (resets connected state).
+   * Does NOT reset sync state — call `handle.reset_sync_state()` if needed.
+   */
+  reconnect(): void {
+    this.#connected = true;
+  }
+
+  // ── Internal ───────────────────────────────────────────────────
+
+  #deliver(frame: Uint8Array): void {
+    for (const cb of this.#subscribers) {
+      try {
+        cb(frame);
+      } catch (err) {
+        console.error("[DirectTransport] subscriber error:", err);
+      }
+    }
+  }
+
+  #assertConnected(): void {
+    if (!this.#connected) {
+      throw new Error("DirectTransport: not connected");
+    }
+  }
+}

--- a/packages/runtimed/src/index.ts
+++ b/packages/runtimed/src/index.ts
@@ -1,0 +1,72 @@
+/**
+ * @nteract/runtimed — Transport-agnostic JavaScript bindings for
+ * nteract notebook documents.
+ *
+ * Wraps the runtimed WASM CRDT engine with a clean API for sync,
+ * cell mutations, and runtime state.
+ *
+ * @example
+ * ```ts
+ * import { SyncEngine, FrameType } from "@nteract/runtimed";
+ * import type { NotebookTransport, SyncableHandle } from "@nteract/runtimed";
+ *
+ * const engine = new SyncEngine(handle, transport);
+ * engine.on("cells_changed", (e) => console.log(e.changeset));
+ * engine.on("broadcast", (e) => console.log(e.payload));
+ * engine.on("runtime_state_changed", (e) => console.log(e.state));
+ * engine.start();
+ *
+ * // After local CRDT mutations:
+ * handle.update_source("cell-1", "print('hello')");
+ * engine.scheduleFlush();
+ *
+ * // Before execution (flush immediately):
+ * await engine.flush();
+ * await transport.sendRequest({ action: "execute_cell", cell_id: "cell-1" });
+ *
+ * // Cleanup:
+ * engine.stop();
+ * ```
+ *
+ * @module
+ */
+
+// ── Transport ────────────────────────────────────────────────────────
+
+export { FrameType } from "./transport.ts";
+export type {
+  FrameTypeValue,
+  TypedFrame,
+  NotebookTransport,
+  Unsubscribe,
+} from "./transport.ts";
+
+// ── Sync Engine ──────────────────────────────────────────────────────
+
+export { SyncEngine } from "./sync-engine.ts";
+export type {
+  SyncableHandle,
+  SyncEngineOptions,
+  SyncEngineEvent,
+  SyncEngineEventType,
+} from "./sync-engine.ts";
+
+// ── Frame Events (from WASM) ─────────────────────────────────────────
+
+export type {
+  FrameEvent,
+  SyncAppliedEvent,
+  BroadcastEvent,
+  PresenceEvent,
+  RuntimeStateSyncAppliedEvent,
+  UnknownFrameEvent,
+} from "./sync-engine.ts";
+
+// ── Cell Changeset ───────────────────────────────────────────────────
+
+export type {
+  CellChangeset,
+  ChangedCell,
+  ChangedFields,
+  TextAttribution,
+} from "./sync-engine.ts";

--- a/packages/runtimed/src/index.ts
+++ b/packages/runtimed/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * @nteract/runtimed — Transport-agnostic JavaScript bindings for
+ * runtimed — Transport-agnostic JavaScript bindings for
  * nteract notebook documents.
  *
  * Wraps the runtimed WASM CRDT engine with a clean API for sync,
@@ -7,8 +7,8 @@
  *
  * @example
  * ```ts
- * import { SyncEngine, FrameType } from "@nteract/runtimed";
- * import type { NotebookTransport, SyncableHandle } from "@nteract/runtimed";
+ * import { SyncEngine, FrameType } from "runtimed";
+ * import type { NotebookTransport, SyncableHandle } from "runtimed";
  *
  * const engine = new SyncEngine(handle, transport);
  * engine.on("cells_changed", (e) => console.log(e.changeset));

--- a/packages/runtimed/src/index.ts
+++ b/packages/runtimed/src/index.ts
@@ -46,6 +46,7 @@ export type {
 export { SyncEngine } from "./sync-engine.ts";
 export type {
   SyncableHandle,
+  HandleGetter,
   SyncEngineOptions,
   SyncEngineEvent,
   SyncEngineEventType,

--- a/packages/runtimed/src/index.ts
+++ b/packages/runtimed/src/index.ts
@@ -50,7 +50,10 @@ export type {
   SyncEngineOptions,
   SyncEngineEvent,
   SyncEngineEventType,
+  CoalescedCellChanges,
 } from "./sync-engine.ts";
+
+export { mergeChangesets } from "./sync-engine.ts";
 
 // ── Frame Events (from WASM) ─────────────────────────────────────────
 

--- a/packages/runtimed/src/index.ts
+++ b/packages/runtimed/src/index.ts
@@ -74,3 +74,17 @@ export type {
   ChangedFields,
   TextAttribution,
 } from "./sync-engine.ts";
+
+// ── Runtime State ───────────────────────────────────────────────────
+
+export { diffExecutions } from "./runtime-state.ts";
+export type {
+  RuntimeState,
+  KernelState,
+  QueueEntry,
+  QueueState,
+  EnvState,
+  TrustState,
+  ExecutionState,
+  ExecutionTransition,
+} from "./runtime-state.ts";

--- a/packages/runtimed/src/runtime-state.ts
+++ b/packages/runtimed/src/runtime-state.ts
@@ -57,10 +57,10 @@ export interface ExecutionTransition {
 }
 
 export interface RuntimeState {
-  kernel: KernelState | null;
-  queue: QueueState | null;
-  env_sync: EnvState | null;
-  trust: TrustState | null;
+  kernel: KernelState;
+  queue: QueueState;
+  env: EnvState;
+  trust: TrustState;
   last_saved: string | null;
   executions: Record<string, ExecutionState>;
 }

--- a/packages/runtimed/src/runtime-state.ts
+++ b/packages/runtimed/src/runtime-state.ts
@@ -1,0 +1,127 @@
+/**
+ * Runtime state types and diffing utilities.
+ *
+ * The daemon syncs kernel status, execution queue, environment sync state,
+ * and execution lifecycle via a per-notebook RuntimeStateDoc (Automerge).
+ * This module provides types for the state and utilities to detect
+ * execution transitions from CRDT diffs.
+ *
+ * @module
+ */
+
+// ── Types ────────────────────────────────────────────────────────────
+
+export interface KernelState {
+  status: string;
+  name: string;
+  language: string;
+  env_source: string;
+}
+
+export interface QueueEntry {
+  cell_id: string;
+  execution_id: string;
+}
+
+export interface QueueState {
+  executing: QueueEntry | null;
+  queued: QueueEntry[];
+}
+
+export interface EnvState {
+  in_sync: boolean;
+  added: string[];
+  removed: string[];
+  channels_changed: boolean;
+  deno_changed: boolean;
+}
+
+export interface TrustState {
+  status: string;
+  needs_approval: boolean;
+}
+
+export interface ExecutionState {
+  cell_id: string;
+  status: "queued" | "running" | "done" | "error";
+  execution_count: number | null;
+  success: boolean | null;
+}
+
+/** A detected status transition for a single execution. */
+export interface ExecutionTransition {
+  execution_id: string;
+  cell_id: string;
+  kind: "started" | "done" | "error";
+  execution_count: number | null;
+}
+
+export interface RuntimeState {
+  kernel: KernelState | null;
+  queue: QueueState | null;
+  env_sync: EnvState | null;
+  trust: TrustState | null;
+  last_saved: string | null;
+  executions: Record<string, ExecutionState>;
+}
+
+// ── Diffing ──────────────────────────────────────────────────────────
+
+/**
+ * Diff two executions maps to detect status transitions.
+ *
+ * Returns transitions for:
+ * - New entry or "queued"→"running" → "started"
+ * - "running"→"done" → "done"
+ * - "running"→"error" or "queued"→"error" (kernel death) → "error"
+ *
+ * Slow joiners see the final state — no missed transitions. If a sync
+ * batches multiple changes (queued→done in one round), we emit the
+ * terminal event only.
+ */
+export function diffExecutions(
+  prev: Record<string, ExecutionState>,
+  curr: Record<string, ExecutionState>,
+): ExecutionTransition[] {
+  const transitions: ExecutionTransition[] = [];
+
+  for (const [eid, entry] of Object.entries(curr)) {
+    const prevEntry = prev[eid];
+    const prevStatus = prevEntry?.status;
+    const currStatus = entry.status;
+
+    // No change
+    if (prevStatus === currStatus) continue;
+
+    // Terminal states: done or error
+    if (currStatus === "done") {
+      transitions.push({
+        execution_id: eid,
+        cell_id: entry.cell_id,
+        kind: "done",
+        execution_count: entry.execution_count,
+      });
+    } else if (currStatus === "error") {
+      transitions.push({
+        execution_id: eid,
+        cell_id: entry.cell_id,
+        kind: "error",
+        execution_count: entry.execution_count,
+      });
+    } else if (
+      currStatus === "running" &&
+      prevStatus !== "done" &&
+      prevStatus !== "error"
+    ) {
+      // Started (queued→running or new→running)
+      transitions.push({
+        execution_id: eid,
+        cell_id: entry.cell_id,
+        kind: "started",
+        execution_count: entry.execution_count,
+      });
+    }
+  }
+
+  return transitions;
+}

--- a/packages/runtimed/src/sync-engine.ts
+++ b/packages/runtimed/src/sync-engine.ts
@@ -458,16 +458,30 @@ export class SyncEngine {
 
     // ── Initial sync handshake ───────────────────────────────────
     if (this.#awaitingInitialSync) {
-      // Check if the doc has content — the daemon may have sent it
-      // before the transport was listening (relay emits frames as soon
-      // as the room is created, but our transport connects later).
-      // In that case `changed` is false (daemon thinks we already have
-      // it) but the doc actually has cells from the sync exchange.
+      // Detect initial sync completion. Three signals (any one suffices):
+      //
+      // 1. `changed=true` — the doc gained content from this sync frame.
+      //    Normal path for notebooks that have cells.
+      //
+      // 2. `cell_count() > 0` — the doc has cells even though `changed`
+      //    is false. Happens when the daemon sent content before the
+      //    transport was listening (relay emits frames immediately, but
+      //    our TauriTransport connects later). The daemon's sync state
+      //    has advanced, so subsequent frames report changed=false.
+      //
+      // 3. `reply` exists — we generated a sync reply, meaning we
+      //    successfully received a daemon sync message and responded.
+      //    This covers empty notebooks (0 cells, changed=true on first
+      //    mount but changed=false on React strict mode's second mount
+      //    because the daemon's relay state already advanced). A reply
+      //    means the handshake completed — we're in sync, even if
+      //    the notebook is genuinely empty.
       const handle = this.#getHandle();
       const hasContent = handle ? handle.cell_count() > 0 : false;
+      const hasReply = event.reply != null && event.reply.length > 0;
 
-      if (event.changed || hasContent) {
-        // Content arrived (or was already present) — initial sync complete.
+      if (event.changed || hasContent || hasReply) {
+        // Initial sync complete — we've exchanged with the daemon.
         this.#awaitingInitialSync = false;
         this.#clearRetryTimer();
         this.#emit({ type: "initial_sync_complete" });
@@ -479,8 +493,9 @@ export class SyncEngine {
           attributions: event.attributions ?? [],
         });
       } else {
-        // Handshake round (bloom filter exchange, no content yet).
-        // Restart the retry timer.
+        // Handshake round with no reply generated (e.g., the very first
+        // sync message we sent, before the daemon responds). Restart the
+        // retry timer.
         this.#armRetryTimer();
       }
       return;

--- a/packages/runtimed/src/sync-engine.ts
+++ b/packages/runtimed/src/sync-engine.ts
@@ -1,0 +1,539 @@
+/**
+ * SyncEngine — core Automerge sync management for notebook documents.
+ *
+ * Extracted from the frontend's `frame-pipeline.ts`, `useAutomergeNotebook.ts`,
+ * and `notebook-metadata.ts` into a transport-agnostic, framework-agnostic
+ * module. This is the single owner of sync state — no other code should call
+ * `flush_local_changes`, `cancel_last_flush`, or read inline replies directly.
+ *
+ * The engine:
+ * 1. Receives inbound frames from a {@link NotebookTransport}
+ * 2. Feeds them to the WASM `NotebookHandle.receive_frame()` for demuxing
+ * 3. Sends inline sync replies back through the transport (with rollback on failure)
+ * 4. Flushes local CRDT mutations on a debounced schedule
+ * 5. Emits typed events for consumers (cell changes, broadcasts, presence, runtime state)
+ *
+ * Consumers (React frontend, Deno scripts, agents) subscribe to events
+ * and call mutation methods. They never touch sync state directly.
+ *
+ * @module
+ */
+
+import type { NotebookTransport, FrameTypeValue } from "./transport.ts";
+import { FrameType } from "./transport.ts";
+
+// ── Types ────────────────────────────────────────────────────────────
+
+// We use the WASM handle as an opaque type so this module doesn't
+// import wasm-bindgen directly — the caller provides the handle.
+// This keeps the package decoupled from a specific WASM build path.
+
+/**
+ * Minimal interface for the WASM NotebookHandle methods the sync engine needs.
+ *
+ * This is a subset of the full `NotebookHandle` API — only the methods
+ * involved in sync, frame processing, and local change flushing. Cell
+ * mutations (add_cell, update_source, etc.) are called directly by
+ * consumers and don't flow through the engine.
+ */
+export interface SyncableHandle {
+  /** Demux an inbound frame and return typed events. Generates inline sync replies. */
+  receive_frame(frame_bytes: Uint8Array): FrameEvent[] | undefined;
+
+  /** Generate a sync message for pending local changes. */
+  flush_local_changes(): Uint8Array | undefined;
+
+  /** Roll back sync state after a failed flush or reply send. */
+  cancel_last_flush(): void;
+
+  /** Generate a sync reply for the RuntimeStateDoc. */
+  generate_runtime_state_sync_reply(): Uint8Array | undefined;
+
+  /** Reset all sync state (reconnection / page reload equivalent). */
+  reset_sync_state(): void;
+}
+
+// ── Frame events (mirrored from runtimed-wasm FrameEvent enum) ──────
+
+/** Changeset describing which cells changed and how. */
+export interface CellChangeset {
+  readonly changed: ChangedCell[];
+  readonly added: string[];
+  readonly removed: string[];
+  readonly order_changed: boolean;
+}
+
+export interface ChangedCell {
+  readonly cell_id: string;
+  readonly fields: ChangedFields;
+}
+
+export interface ChangedFields {
+  readonly source: boolean;
+  readonly outputs: boolean;
+  readonly cell_type: boolean;
+  readonly execution_count: boolean;
+  readonly metadata: boolean;
+  readonly position: boolean;
+}
+
+export interface TextAttribution {
+  readonly cell_id: string;
+  readonly actor: string;
+  readonly start: number;
+  readonly end: number;
+  readonly inserted: number;
+  readonly deleted: number;
+  readonly actors: string[];
+}
+
+/** Events produced by `NotebookHandle.receive_frame()`. */
+export type FrameEvent =
+  | SyncAppliedEvent
+  | BroadcastEvent
+  | PresenceEvent
+  | RuntimeStateSyncAppliedEvent
+  | UnknownFrameEvent;
+
+export interface SyncAppliedEvent {
+  readonly type: "sync_applied";
+  readonly changed: boolean;
+  readonly changeset?: CellChangeset;
+  readonly attributions?: TextAttribution[];
+  /** Inline sync reply bytes — send immediately via transport. */
+  readonly reply?: number[];
+}
+
+export interface BroadcastEvent {
+  readonly type: "broadcast";
+  readonly payload: unknown;
+}
+
+export interface PresenceEvent {
+  readonly type: "presence";
+  readonly payload: unknown;
+}
+
+export interface RuntimeStateSyncAppliedEvent {
+  readonly type: "runtime_state_sync_applied";
+  readonly changed: boolean;
+  readonly state?: unknown;
+}
+
+export interface UnknownFrameEvent {
+  readonly type: "unknown";
+  readonly frame_type: number;
+}
+
+// ── Sync engine events ──────────────────────────────────────────────
+
+/**
+ * Events emitted by the SyncEngine.
+ *
+ * These are higher-level than raw FrameEvents — the engine handles
+ * sync reply sending internally, so consumers only see meaningful
+ * state changes.
+ */
+export type SyncEngineEvent =
+  | { type: "cells_changed"; changeset: CellChangeset | null; attributions: TextAttribution[] }
+  | { type: "initial_sync_complete" }
+  | { type: "broadcast"; payload: unknown }
+  | { type: "presence"; payload: unknown }
+  | { type: "runtime_state_changed"; state: unknown }
+  | { type: "sync_retry" }
+  | { type: "error"; error: unknown; context: string };
+
+export type SyncEngineEventType = SyncEngineEvent["type"];
+
+type EventCallback = (event: SyncEngineEvent) => void;
+type TypedEventCallback<T extends SyncEngineEventType> = (
+  event: Extract<SyncEngineEvent, { type: T }>,
+) => void;
+
+// ── Configuration ───────────────────────────────────────────────────
+
+export interface SyncEngineOptions {
+  /**
+   * Debounce interval (ms) for flushing local CRDT mutations.
+   * Multiple rapid edits within this window are batched into a
+   * single sync message. Default: 20ms.
+   */
+  flushDebounceMs?: number;
+
+  /**
+   * Timeout (ms) for the initial sync exchange. If the daemon doesn't
+   * deliver document content within this window, the engine resets
+   * sync state and retries. Default: 3000ms.
+   */
+  initialSyncTimeoutMs?: number;
+}
+
+const DEFAULT_FLUSH_DEBOUNCE_MS = 20;
+const DEFAULT_INITIAL_SYNC_TIMEOUT_MS = 3000;
+
+// ── SyncEngine ──────────────────────────────────────────────────────
+
+/**
+ * Core sync management for a notebook document.
+ *
+ * Owns the sync lifecycle:
+ * - Inbound frame processing (demux → reply → emit events)
+ * - Outbound sync (debounced flush of local CRDT mutations)
+ * - Initial sync handshake with retry
+ * - Runtime state doc sync replies
+ *
+ * The engine is framework-agnostic — it emits events via a simple
+ * callback API. React hooks, Zustand stores, or plain callbacks can
+ * all subscribe.
+ *
+ * Usage:
+ * ```ts
+ * const engine = new SyncEngine(handle, transport, { flushDebounceMs: 20 });
+ * engine.on("cells_changed", (e) => updateStore(e.changeset));
+ * engine.on("broadcast", (e) => handleBroadcast(e.payload));
+ * engine.start();
+ *
+ * // After local CRDT mutations:
+ * handle.update_source("cell-1", "new code");
+ * engine.scheduleFlush();
+ *
+ * // Cleanup:
+ * engine.stop();
+ * ```
+ */
+export class SyncEngine {
+  readonly #handle: SyncableHandle;
+  readonly #transport: NotebookTransport;
+  readonly #options: Required<SyncEngineOptions>;
+
+  // ── State ───────────────────────────────────────────────────────
+  #running = false;
+  #awaitingInitialSync = true;
+  #unsubscribeFrame: (() => void) | null = null;
+
+  // ── Flush debounce ──────────────────────────────────────────────
+  #flushTimer: ReturnType<typeof setTimeout> | null = null;
+
+  // ── Initial sync retry ─────────────────────────────────────────
+  #retryTimer: ReturnType<typeof setTimeout> | null = null;
+
+  // ── Event subscribers ──────────────────────────────────────────
+  #listeners: Map<SyncEngineEventType, Set<EventCallback>> = new Map();
+
+  constructor(
+    handle: SyncableHandle,
+    transport: NotebookTransport,
+    options: SyncEngineOptions = {},
+  ) {
+    this.#handle = handle;
+    this.#transport = transport;
+    this.#options = {
+      flushDebounceMs: options.flushDebounceMs ?? DEFAULT_FLUSH_DEBOUNCE_MS,
+      initialSyncTimeoutMs:
+        options.initialSyncTimeoutMs ?? DEFAULT_INITIAL_SYNC_TIMEOUT_MS,
+    };
+  }
+
+  // ── Lifecycle ──────────────────────────────────────────────────
+
+  /** Start processing inbound frames and managing sync. */
+  start(): void {
+    if (this.#running) return;
+    this.#running = true;
+    this.#awaitingInitialSync = true;
+
+    // Subscribe to inbound frames from the transport.
+    this.#unsubscribeFrame = this.#transport.onFrame((frame) => {
+      this.#processFrame(frame);
+    });
+
+    // Arm the initial sync retry timer.
+    this.#armRetryTimer();
+
+    // Send the first sync message (empty doc requests full state from daemon).
+    this.#flushNow();
+  }
+
+  /** Stop processing frames and release resources. */
+  stop(): void {
+    if (!this.#running) return;
+    this.#running = false;
+
+    // Unsubscribe from transport.
+    this.#unsubscribeFrame?.();
+    this.#unsubscribeFrame = null;
+
+    // Cancel timers.
+    if (this.#flushTimer !== null) {
+      clearTimeout(this.#flushTimer);
+      this.#flushTimer = null;
+    }
+    if (this.#retryTimer !== null) {
+      clearTimeout(this.#retryTimer);
+      this.#retryTimer = null;
+    }
+
+    // Final flush — best effort.
+    this.#flushNow();
+
+    // Clear listeners.
+    this.#listeners.clear();
+  }
+
+  /** Whether the engine has completed the initial sync handshake. */
+  get synced(): boolean {
+    return !this.#awaitingInitialSync;
+  }
+
+  /** Whether the engine is actively processing frames. */
+  get running(): boolean {
+    return this.#running;
+  }
+
+  // ── Local mutation sync ────────────────────────────────────────
+
+  /**
+   * Schedule a debounced flush of local CRDT mutations to the daemon.
+   *
+   * Call this after any local mutation on the handle (update_source,
+   * add_cell, set_metadata, etc.). Multiple calls within the debounce
+   * window are coalesced into a single sync message.
+   */
+  scheduleFlush(): void {
+    if (!this.#running) return;
+    if (this.#flushTimer !== null) clearTimeout(this.#flushTimer);
+    this.#flushTimer = setTimeout(() => {
+      this.#flushTimer = null;
+      this.#flushNow();
+    }, this.#options.flushDebounceMs);
+  }
+
+  /**
+   * Immediately flush local changes (bypasses debounce).
+   *
+   * Use before operations that depend on the daemon having the latest
+   * state, e.g., before `sendRequest({ action: "execute_cell", ... })`.
+   *
+   * Returns a promise that resolves when the flush is sent (or rejects
+   * if the transport fails — sync state is rolled back in that case).
+   */
+  async flush(): Promise<void> {
+    if (this.#flushTimer !== null) {
+      clearTimeout(this.#flushTimer);
+      this.#flushTimer = null;
+    }
+    await this.#flushAsync();
+  }
+
+  // ── Event API ──────────────────────────────────────────────────
+
+  /**
+   * Subscribe to a specific event type.
+   * Returns an unsubscribe function.
+   */
+  on<T extends SyncEngineEventType>(
+    type: T,
+    callback: TypedEventCallback<T>,
+  ): () => void {
+    let set = this.#listeners.get(type);
+    if (!set) {
+      set = new Set();
+      this.#listeners.set(type, set);
+    }
+    const cb = callback as EventCallback;
+    set.add(cb);
+    return () => {
+      set!.delete(cb);
+    };
+  }
+
+  // ── Internal: frame processing ─────────────────────────────────
+
+  #processFrame(frame: Uint8Array): void {
+    if (!this.#running) return;
+
+    let events: FrameEvent[] | undefined;
+    try {
+      events = this.#handle.receive_frame(frame);
+    } catch (err) {
+      this.#emit({ type: "error", error: err, context: "receive_frame" });
+      return;
+    }
+
+    if (!events || !Array.isArray(events)) return;
+
+    for (const event of events) {
+      switch (event.type) {
+        case "sync_applied":
+          this.#handleSyncApplied(event);
+          break;
+        case "broadcast":
+          this.#emit({ type: "broadcast", payload: event.payload });
+          break;
+        case "presence":
+          this.#emit({ type: "presence", payload: event.payload });
+          break;
+        case "runtime_state_sync_applied":
+          this.#handleRuntimeStateSync(event);
+          break;
+        case "unknown":
+          // Ignore unknown frame types silently.
+          break;
+      }
+    }
+  }
+
+  #handleSyncApplied(event: SyncAppliedEvent): void {
+    // ── Send inline sync reply immediately ───────────────────────
+    // Generated atomically inside WASM's receive_frame (#1067/#1068 fix).
+    // On failure, roll back sync state to prevent sent_hashes stranding.
+    if (event.reply) {
+      this.#transport
+        .sendFrame(FrameType.AUTOMERGE_SYNC, new Uint8Array(event.reply))
+        .catch((err) => {
+          this.#handle.cancel_last_flush();
+          this.#emit({
+            type: "error",
+            error: err,
+            context: "inline_sync_reply_send",
+          });
+        });
+    }
+
+    // ── Initial sync handshake ───────────────────────────────────
+    if (this.#awaitingInitialSync) {
+      if (event.changed) {
+        // First real content from the daemon — initial sync complete.
+        this.#awaitingInitialSync = false;
+        this.#clearRetryTimer();
+        this.#emit({ type: "initial_sync_complete" });
+
+        // Also emit the cells_changed so consumers can materialize.
+        this.#emit({
+          type: "cells_changed",
+          changeset: event.changeset ?? null,
+          attributions: event.attributions ?? [],
+        });
+      } else {
+        // Handshake round (bloom filter exchange, no content yet).
+        // Restart the retry timer.
+        this.#armRetryTimer();
+      }
+      return;
+    }
+
+    // ── Steady-state: emit cells_changed if doc actually changed ──
+    if (event.changed) {
+      this.#emit({
+        type: "cells_changed",
+        changeset: event.changeset ?? null,
+        attributions: event.attributions ?? [],
+      });
+    }
+  }
+
+  #handleRuntimeStateSync(event: RuntimeStateSyncAppliedEvent): void {
+    // Emit state change if the doc changed.
+    if (event.changed && event.state) {
+      this.#emit({ type: "runtime_state_changed", state: event.state });
+    }
+
+    // Send runtime state sync reply so the daemon knows our heads.
+    try {
+      const reply = this.#handle.generate_runtime_state_sync_reply();
+      if (reply) {
+        this.#transport
+          .sendFrame(FrameType.RUNTIME_STATE_SYNC, reply)
+          .catch((err) => {
+            this.#emit({
+              type: "error",
+              error: err,
+              context: "runtime_state_sync_reply_send",
+            });
+          });
+      }
+    } catch (err) {
+      this.#emit({
+        type: "error",
+        error: err,
+        context: "generate_runtime_state_sync_reply",
+      });
+    }
+  }
+
+  // ── Internal: flush ────────────────────────────────────────────
+
+  /** Synchronous flush — fire-and-forget, errors emitted as events. */
+  #flushNow(): void {
+    try {
+      const msg = this.#handle.flush_local_changes();
+      if (msg) {
+        this.#transport.sendFrame(FrameType.AUTOMERGE_SYNC, msg).catch((err) => {
+          this.#handle.cancel_last_flush();
+          this.#emit({ type: "error", error: err, context: "flush_send" });
+        });
+      }
+    } catch (err) {
+      this.#emit({ type: "error", error: err, context: "flush_local_changes" });
+    }
+  }
+
+  /** Async flush — awaits the send so callers can sequence after it. */
+  async #flushAsync(): Promise<void> {
+    const msg = this.#handle.flush_local_changes();
+    if (!msg) return;
+    try {
+      await this.#transport.sendFrame(FrameType.AUTOMERGE_SYNC, msg);
+    } catch (err) {
+      this.#handle.cancel_last_flush();
+      this.#emit({ type: "error", error: err, context: "flush_send" });
+      throw err;
+    }
+  }
+
+  // ── Internal: initial sync retry ───────────────────────────────
+
+  #armRetryTimer(): void {
+    this.#clearRetryTimer();
+    this.#retryTimer = setTimeout(() => {
+      this.#retryTimer = null;
+      if (!this.#awaitingInitialSync || !this.#running) return;
+
+      // Reset sync state and re-send the initial sync message.
+      // This handles the case where the first message was lost or
+      // consumed by a stale handle.
+      this.#handle.reset_sync_state();
+      this.#flushNow();
+      this.#emit({ type: "sync_retry" });
+
+      // Re-arm in case this retry also doesn't produce content.
+      this.#armRetryTimer();
+    }, this.#options.initialSyncTimeoutMs);
+  }
+
+  #clearRetryTimer(): void {
+    if (this.#retryTimer !== null) {
+      clearTimeout(this.#retryTimer);
+      this.#retryTimer = null;
+    }
+  }
+
+  // ── Internal: event emission ───────────────────────────────────
+
+  #emit(event: SyncEngineEvent): void {
+    const set = this.#listeners.get(event.type);
+    if (set) {
+      for (const cb of set) {
+        try {
+          cb(event);
+        } catch (err) {
+          // Don't let a subscriber error kill the engine.
+          console.error(
+            `[SyncEngine] subscriber error for '${event.type}':`,
+            err,
+          );
+        }
+      }
+    }
+  }
+}

--- a/packages/runtimed/src/sync-engine.ts
+++ b/packages/runtimed/src/sync-engine.ts
@@ -19,7 +19,7 @@
  * @module
  */
 
-import type { NotebookTransport, FrameTypeValue } from "./transport.ts";
+import type { NotebookTransport } from "./transport.ts";
 import { FrameType } from "./transport.ts";
 
 // ── Types ────────────────────────────────────────────────────────────
@@ -135,7 +135,11 @@ export interface UnknownFrameEvent {
  * state changes.
  */
 export type SyncEngineEvent =
-  | { type: "cells_changed"; changeset: CellChangeset | null; attributions: TextAttribution[] }
+  | {
+      type: "cells_changed";
+      changeset: CellChangeset | null;
+      attributions: TextAttribution[];
+    }
   | { type: "initial_sync_complete" }
   | { type: "broadcast"; payload: unknown }
   | { type: "presence"; payload: unknown }
@@ -468,10 +472,12 @@ export class SyncEngine {
     try {
       const msg = this.#handle.flush_local_changes();
       if (msg) {
-        this.#transport.sendFrame(FrameType.AUTOMERGE_SYNC, msg).catch((err) => {
-          this.#handle.cancel_last_flush();
-          this.#emit({ type: "error", error: err, context: "flush_send" });
-        });
+        this.#transport
+          .sendFrame(FrameType.AUTOMERGE_SYNC, msg)
+          .catch((err) => {
+            this.#handle.cancel_last_flush();
+            this.#emit({ type: "error", error: err, context: "flush_send" });
+          });
       }
     } catch (err) {
       this.#emit({ type: "error", error: err, context: "flush_local_changes" });

--- a/packages/runtimed/src/sync-engine.ts
+++ b/packages/runtimed/src/sync-engine.ts
@@ -58,6 +58,13 @@ export interface SyncableHandle {
   /** Generate a sync reply for the RuntimeStateDoc. */
   generate_runtime_state_sync_reply(): Uint8Array | undefined;
 
+  /** Generate an initial RuntimeStateDoc sync message.
+   *  Call during bootstrap so the daemon knows to push queue/kernel state. */
+  flush_runtime_state_sync(): Uint8Array | undefined;
+
+  /** Roll back runtime state sync state after a failed send. */
+  cancel_last_runtime_state_flush(): void;
+
   /** Reset all sync state (reconnection / page reload equivalent). */
   reset_sync_state(): void;
 
@@ -477,6 +484,11 @@ export class SyncEngine {
 
     // Send the first sync message (empty doc requests full state from daemon).
     this.#flushNow();
+
+    // Also initiate RuntimeStateDoc sync so the daemon sends kernel status,
+    // execution queue, trust state, etc. Without this, the frontend never
+    // receives queue_changed updates and run-all appears stuck (#runtime-state-race).
+    this.#flushRuntimeStateNow();
   }
 
   /** Stop processing frames and release resources. */
@@ -771,6 +783,35 @@ export class SyncEngine {
       }
     } catch (err) {
       this.#emit({ type: "error", error: err, context: "flush_local_changes" });
+    }
+  }
+
+  /** Send the initial RuntimeStateDoc sync message to the daemon.
+   *  Called once during start() — after that, replies are generated
+   *  inline by #handleRuntimeStateSync on each inbound frame. */
+  #flushRuntimeStateNow(): void {
+    const handle = this.#getHandle();
+    if (!handle) return;
+    try {
+      const msg = handle.flush_runtime_state_sync();
+      if (msg) {
+        this.#transport
+          .sendFrame(FrameType.RUNTIME_STATE_SYNC, new Uint8Array(msg))
+          .catch((err) => {
+            this.#getHandle()?.cancel_last_runtime_state_flush();
+            this.#emit({
+              type: "error",
+              error: err,
+              context: "runtime_state_flush_send",
+            });
+          });
+      }
+    } catch (err) {
+      this.#emit({
+        type: "error",
+        error: err,
+        context: "flush_runtime_state_sync",
+      });
     }
   }
 

--- a/packages/runtimed/src/sync-engine.ts
+++ b/packages/runtimed/src/sync-engine.ts
@@ -22,6 +22,12 @@
 import type { NotebookTransport } from "./transport.ts";
 import { FrameType } from "./transport.ts";
 import {
+  diffExecutions,
+  type ExecutionState,
+  type ExecutionTransition,
+  type RuntimeState,
+} from "./runtime-state.ts";
+import {
   Subject,
   Observable,
   bufferTime,
@@ -172,7 +178,11 @@ export type SyncEngineEvent =
   | { type: "initial_sync_complete" }
   | { type: "broadcast"; payload: unknown }
   | { type: "presence"; payload: unknown }
-  | { type: "runtime_state_changed"; state: unknown }
+  | { type: "runtime_state_changed"; state: RuntimeState }
+  | {
+      type: "execution_transition";
+      transition: ExecutionTransition;
+    }
   | { type: "sync_retry" }
   | { type: "error"; error: unknown; context: string };
 
@@ -340,6 +350,10 @@ export class SyncEngine {
   // ── Initial sync retry ─────────────────────────────────────────
   #retryTimer: ReturnType<typeof setTimeout> | null = null;
 
+  // ── Runtime state tracking (for execution diffing) ────────────
+  #prevExecutions: Record<string, ExecutionState> = {};
+  #isInitialRuntimeState = true;
+
   // ── Event subscribers ──────────────────────────────────────────
   #listeners: Map<SyncEngineEventType, Set<EventCallback>> = new Map();
 
@@ -457,7 +471,7 @@ export class SyncEngine {
   /**
    * Runtime state changes as an Observable.
    */
-  readonly runtimeState$: Observable<unknown> = this.#events$.pipe(
+  readonly runtimeState$: Observable<RuntimeState> = this.#events$.pipe(
     filter(
       (e): e is Extract<SyncEngineEvent, { type: "runtime_state_changed" }> =>
         e.type === "runtime_state_changed",
@@ -465,6 +479,26 @@ export class SyncEngine {
     map((e) => e.state),
     share(),
   );
+
+  /**
+   * Execution lifecycle transitions as an Observable.
+   *
+   * Emits when an execution changes status (queued→running = "started",
+   * running→done = "done", running→error = "error"). Consumers can use
+   * this to update execution counts, show progress indicators, etc.
+   * without manually diffing the executions map.
+   */
+  readonly executionTransitions$: Observable<ExecutionTransition> =
+    this.#events$.pipe(
+      filter(
+        (
+          e,
+        ): e is Extract<SyncEngineEvent, { type: "execution_transition" }> =>
+          e.type === "execution_transition",
+      ),
+      map((e) => e.transition),
+      share(),
+    );
 
   // ── Lifecycle ──────────────────────────────────────────────────
 
@@ -737,7 +771,25 @@ export class SyncEngine {
   #handleRuntimeStateSync(event: RuntimeStateSyncAppliedEvent): void {
     // Emit state change if the doc changed.
     if (event.changed && event.state) {
-      this.#emit({ type: "runtime_state_changed", state: event.state });
+      const state = event.state as RuntimeState;
+      this.#emit({ type: "runtime_state_changed", state });
+
+      // Diff executions to detect lifecycle transitions.
+      // Skip the first state (slow joiner catch-up) to avoid
+      // false "started" events for already-running executions.
+      const currExecutions = state.executions ?? {};
+      if (this.#isInitialRuntimeState) {
+        this.#isInitialRuntimeState = false;
+      } else {
+        const transitions = diffExecutions(
+          this.#prevExecutions,
+          currExecutions,
+        );
+        for (const transition of transitions) {
+          this.#emit({ type: "execution_transition", transition });
+        }
+      }
+      this.#prevExecutions = currExecutions;
     }
 
     // Send runtime state sync reply so the daemon knows our heads.

--- a/packages/runtimed/src/sync-engine.ts
+++ b/packages/runtimed/src/sync-engine.ts
@@ -370,7 +370,12 @@ export class SyncEngine {
     if (!this.#running) return;
 
     const handle = this.#getHandle();
-    if (!handle) return;
+    if (!handle) {
+      console.warn(
+        "[SyncEngine] processFrame: handle getter returned null, skipping frame",
+      );
+      return;
+    }
 
     let events: FrameEvent[] | undefined;
     try {
@@ -380,7 +385,34 @@ export class SyncEngine {
       return;
     }
 
-    if (!events || !Array.isArray(events)) return;
+    if (!events || !Array.isArray(events)) {
+      console.warn(
+        "[SyncEngine] processFrame: receive_frame returned non-array:",
+        typeof events,
+        "frame type byte:",
+        frame[0],
+        "frame length:",
+        frame.length,
+      );
+      return;
+    }
+
+    // Diagnostic: log event types during initial sync
+    if (this.#awaitingInitialSync) {
+      for (const ev of events) {
+        if (ev.type === "sync_applied") {
+          const sa = ev as SyncAppliedEvent;
+          console.log(
+            "[SyncEngine] initial sync: sync_applied changed=%s changeset=%s reply=%s",
+            sa.changed,
+            sa.changeset ? "yes" : "no",
+            sa.reply ? `${sa.reply.length}B` : "none",
+          );
+        } else {
+          console.log("[SyncEngine] initial sync: event type=%s", ev.type);
+        }
+      }
+    }
 
     for (const event of events) {
       switch (event.type) {

--- a/packages/runtimed/src/sync-engine.ts
+++ b/packages/runtimed/src/sync-engine.ts
@@ -21,6 +21,15 @@
 
 import type { NotebookTransport } from "./transport.ts";
 import { FrameType } from "./transport.ts";
+import {
+  Subject,
+  Observable,
+  bufferTime,
+  filter,
+  map,
+  share,
+  type Subscription,
+} from "rxjs";
 
 // ── Types ────────────────────────────────────────────────────────────
 
@@ -160,6 +169,87 @@ export type SyncEngineEvent =
   | { type: "sync_retry" }
   | { type: "error"; error: unknown; context: string };
 
+/**
+ * A coalesced batch of cell changesets, emitted after a debounce window.
+ *
+ * Multiple rapid `cells_changed` events (e.g., during output streaming)
+ * are merged into a single batch. If any changeset in the batch is null
+ * (meaning a full materialization is needed), `needsFull` is true.
+ */
+// ── Changeset merging ───────────────────────────────────────────────
+
+/**
+ * Merge multiple CellChangesets into one.
+ *
+ * Used by the coalescing pipeline to combine rapid `cells_changed` events
+ * into a single materialization batch.
+ *
+ * - `changed`: union of all changed cells (fields OR'd together)
+ * - `added`: union of all added cell IDs
+ * - `removed`: union of all removed cell IDs
+ * - `order_changed`: true if any changeset had order_changed
+ */
+export function mergeChangesets(changesets: CellChangeset[]): CellChangeset {
+  if (changesets.length === 0) {
+    return { changed: [], added: [], removed: [], order_changed: false };
+  }
+  if (changesets.length === 1) {
+    return changesets[0];
+  }
+
+  const changedMap = new Map<string, ChangedFields>();
+  const addedSet = new Set<string>();
+  const removedSet = new Set<string>();
+  let orderChanged = false;
+
+  for (const cs of changesets) {
+    orderChanged = orderChanged || cs.order_changed;
+
+    for (const id of cs.added) addedSet.add(id);
+    for (const id of cs.removed) removedSet.add(id);
+
+    for (const cell of cs.changed) {
+      const existing = changedMap.get(cell.cell_id);
+      if (existing) {
+        // OR the field flags together
+        changedMap.set(cell.cell_id, {
+          source: existing.source || cell.fields.source,
+          outputs: existing.outputs || cell.fields.outputs,
+          cell_type: existing.cell_type || cell.fields.cell_type,
+          execution_count:
+            existing.execution_count || cell.fields.execution_count,
+          metadata: existing.metadata || cell.fields.metadata,
+          position: existing.position || cell.fields.position,
+        });
+      } else {
+        changedMap.set(cell.cell_id, { ...cell.fields });
+      }
+    }
+  }
+
+  const changed: ChangedCell[] = Array.from(changedMap.entries()).map(
+    ([cell_id, fields]) => ({ cell_id, fields }),
+  );
+
+  return {
+    changed,
+    added: Array.from(addedSet),
+    removed: Array.from(removedSet),
+    order_changed: orderChanged,
+  };
+}
+
+export interface CoalescedCellChanges {
+  /** Merged changeset, or null if a full materialization is needed. */
+  changeset: CellChangeset | null;
+  /** True if any individual changeset was null (requires full materialization). */
+  needsFull: boolean;
+  /** All text attributions from the batch. */
+  attributions: TextAttribution[];
+  /** Number of individual cells_changed events in this batch. */
+  batchSize: number;
+}
+
 export type SyncEngineEventType = SyncEngineEvent["type"];
 
 type EventCallback = (event: SyncEngineEvent) => void;
@@ -183,10 +273,19 @@ export interface SyncEngineOptions {
    * sync state and retries. Default: 3000ms.
    */
   initialSyncTimeoutMs?: number;
+
+  /**
+   * Coalescing window (ms) for batching cell change events before
+   * materialization. Multiple rapid `cells_changed` events within
+   * this window are merged into a single {@link CoalescedCellChanges}.
+   * Default: 32ms (one frame at 30fps).
+   */
+  coalesceMs?: number;
 }
 
 const DEFAULT_FLUSH_DEBOUNCE_MS = 20;
 const DEFAULT_INITIAL_SYNC_TIMEOUT_MS = 3000;
+const DEFAULT_COALESCE_MS = 32;
 
 // ── SyncEngine ──────────────────────────────────────────────────────
 
@@ -237,6 +336,10 @@ export class SyncEngine {
   // ── Event subscribers ──────────────────────────────────────────
   #listeners: Map<SyncEngineEventType, Set<EventCallback>> = new Map();
 
+  // ── RxJS streams ───────────────────────────────────────────────
+  readonly #events$ = new Subject<SyncEngineEvent>();
+  #rxSub: Subscription | null = null;
+
   constructor(
     getHandle: HandleGetter | SyncableHandle,
     transport: NotebookTransport,
@@ -252,8 +355,109 @@ export class SyncEngine {
       flushDebounceMs: options.flushDebounceMs ?? DEFAULT_FLUSH_DEBOUNCE_MS,
       initialSyncTimeoutMs:
         options.initialSyncTimeoutMs ?? DEFAULT_INITIAL_SYNC_TIMEOUT_MS,
+      coalesceMs: options.coalesceMs ?? DEFAULT_COALESCE_MS,
     };
   }
+
+  // ── RxJS Observables ───────────────────────────────────────────
+
+  /**
+   * All engine events as an RxJS Observable.
+   *
+   * Hot observable — multicasted via `share()`. Emits from the moment
+   * `start()` is called until `stop()`. Subscribers receive events as
+   * they happen (no replay).
+   */
+  readonly events$: Observable<SyncEngineEvent> = this.#events$.pipe(share());
+
+  /**
+   * Coalesced cell change stream.
+   *
+   * Batches rapid `cells_changed` events over a configurable window
+   * (default 32ms) and merges their changesets. Consumers subscribe to
+   * this instead of listening for individual `cells_changed` events to
+   * avoid over-materializing during output streaming.
+   *
+   * If any changeset in the batch is `null`, the merged result has
+   * `needsFull: true` — the consumer should do a full materialization
+   * instead of incremental.
+   *
+   * Note: uses a getter to defer pipeline creation until after the
+   * constructor sets `#options` (field initializers run before the
+   * constructor body).
+   */
+  #cellChanges$: Observable<CoalescedCellChanges> | null = null;
+  get cellChanges$(): Observable<CoalescedCellChanges> {
+    if (!this.#cellChanges$) {
+      this.#cellChanges$ = this.#events$.pipe(
+        filter(
+          (e): e is Extract<SyncEngineEvent, { type: "cells_changed" }> =>
+            e.type === "cells_changed",
+        ),
+        bufferTime(this.#options.coalesceMs),
+        filter((batch) => batch.length > 0),
+        map((batch): CoalescedCellChanges => {
+          const needsFull = batch.some((e) => e.changeset === null);
+          const attributions = batch.flatMap((e) => e.attributions);
+
+          if (needsFull) {
+            return {
+              changeset: null,
+              needsFull: true,
+              attributions,
+              batchSize: batch.length,
+            };
+          }
+
+          const merged = mergeChangesets(batch.map((e) => e.changeset!));
+          return {
+            changeset: merged,
+            needsFull: false,
+            attributions,
+            batchSize: batch.length,
+          };
+        }),
+        share(),
+      );
+    }
+    return this.#cellChanges$;
+  }
+
+  /**
+   * Broadcast events as an Observable.
+   */
+  readonly broadcasts$: Observable<unknown> = this.#events$.pipe(
+    filter(
+      (e): e is Extract<SyncEngineEvent, { type: "broadcast" }> =>
+        e.type === "broadcast",
+    ),
+    map((e) => e.payload),
+    share(),
+  );
+
+  /**
+   * Presence events as an Observable.
+   */
+  readonly presence$: Observable<unknown> = this.#events$.pipe(
+    filter(
+      (e): e is Extract<SyncEngineEvent, { type: "presence" }> =>
+        e.type === "presence",
+    ),
+    map((e) => e.payload),
+    share(),
+  );
+
+  /**
+   * Runtime state changes as an Observable.
+   */
+  readonly runtimeState$: Observable<unknown> = this.#events$.pipe(
+    filter(
+      (e): e is Extract<SyncEngineEvent, { type: "runtime_state_changed" }> =>
+        e.type === "runtime_state_changed",
+    ),
+    map((e) => e.state),
+    share(),
+  );
 
   // ── Lifecycle ──────────────────────────────────────────────────
 
@@ -284,6 +488,10 @@ export class SyncEngine {
     this.#unsubscribeFrame?.();
     this.#unsubscribeFrame = null;
 
+    // Tear down RxJS subscriptions.
+    this.#rxSub?.unsubscribe();
+    this.#rxSub = null;
+
     // Cancel timers.
     if (this.#flushTimer !== null) {
       clearTimeout(this.#flushTimer);
@@ -297,7 +505,10 @@ export class SyncEngine {
     // Final flush — best effort.
     this.#flushNow();
 
-    // Clear listeners.
+    // Complete the subject (terminates all Observable subscribers).
+    this.#events$.complete();
+
+    // Clear callback listeners.
     this.#listeners.clear();
   }
 
@@ -608,6 +819,10 @@ export class SyncEngine {
   // ── Internal: event emission ───────────────────────────────────
 
   #emit(event: SyncEngineEvent): void {
+    // Push to RxJS Subject (feeds all Observable streams).
+    this.#events$.next(event);
+
+    // Push to callback listeners.
     const set = this.#listeners.get(event.type);
     if (set) {
       for (const cb of set) {

--- a/packages/runtimed/src/sync-engine.ts
+++ b/packages/runtimed/src/sync-engine.ts
@@ -53,6 +53,15 @@ export interface SyncableHandle {
   reset_sync_state(): void;
 }
 
+/**
+ * A function that returns the current SyncableHandle, or null if unavailable.
+ *
+ * Using a getter instead of a direct reference ensures the engine always
+ * reads the latest handle — critical for React strict mode where effects
+ * mount/cleanup/mount and the handle ref can change between async operations.
+ */
+export type HandleGetter = () => SyncableHandle | null;
+
 // ── Frame events (mirrored from runtimed-wasm FrameEvent enum) ──────
 
 /** Changeset describing which cells changed and how. */
@@ -192,13 +201,13 @@ const DEFAULT_INITIAL_SYNC_TIMEOUT_MS = 3000;
  *
  * Usage:
  * ```ts
- * const engine = new SyncEngine(handle, transport, { flushDebounceMs: 20 });
+ * const engine = new SyncEngine(() => handleRef.current, transport, { flushDebounceMs: 20 });
  * engine.on("cells_changed", (e) => updateStore(e.changeset));
  * engine.on("broadcast", (e) => handleBroadcast(e.payload));
  * engine.start();
  *
  * // After local CRDT mutations:
- * handle.update_source("cell-1", "new code");
+ * handleRef.current.update_source("cell-1", "new code");
  * engine.scheduleFlush();
  *
  * // Cleanup:
@@ -206,7 +215,7 @@ const DEFAULT_INITIAL_SYNC_TIMEOUT_MS = 3000;
  * ```
  */
 export class SyncEngine {
-  readonly #handle: SyncableHandle;
+  readonly #getHandle: HandleGetter;
   readonly #transport: NotebookTransport;
   readonly #options: Required<SyncEngineOptions>;
 
@@ -225,11 +234,15 @@ export class SyncEngine {
   #listeners: Map<SyncEngineEventType, Set<EventCallback>> = new Map();
 
   constructor(
-    handle: SyncableHandle,
+    getHandle: HandleGetter | SyncableHandle,
     transport: NotebookTransport,
     options: SyncEngineOptions = {},
   ) {
-    this.#handle = handle;
+    // Accept either a getter function or a direct handle (for tests).
+    this.#getHandle =
+      typeof getHandle === "function" && !("receive_frame" in getHandle)
+        ? (getHandle as HandleGetter)
+        : () => getHandle as SyncableHandle;
     this.#transport = transport;
     this.#options = {
       flushDebounceMs: options.flushDebounceMs ?? DEFAULT_FLUSH_DEBOUNCE_MS,
@@ -356,9 +369,12 @@ export class SyncEngine {
   #processFrame(frame: Uint8Array): void {
     if (!this.#running) return;
 
+    const handle = this.#getHandle();
+    if (!handle) return;
+
     let events: FrameEvent[] | undefined;
     try {
-      events = this.#handle.receive_frame(frame);
+      events = handle.receive_frame(frame);
     } catch (err) {
       this.#emit({ type: "error", error: err, context: "receive_frame" });
       return;
@@ -395,7 +411,7 @@ export class SyncEngine {
       this.#transport
         .sendFrame(FrameType.AUTOMERGE_SYNC, new Uint8Array(event.reply))
         .catch((err) => {
-          this.#handle.cancel_last_flush();
+          this.#getHandle()?.cancel_last_flush();
           this.#emit({
             type: "error",
             error: err,
@@ -443,8 +459,10 @@ export class SyncEngine {
     }
 
     // Send runtime state sync reply so the daemon knows our heads.
+    const handle = this.#getHandle();
+    if (!handle) return;
     try {
-      const reply = this.#handle.generate_runtime_state_sync_reply();
+      const reply = handle.generate_runtime_state_sync_reply();
       if (reply) {
         this.#transport
           .sendFrame(FrameType.RUNTIME_STATE_SYNC, reply)
@@ -469,13 +487,15 @@ export class SyncEngine {
 
   /** Synchronous flush — fire-and-forget, errors emitted as events. */
   #flushNow(): void {
+    const handle = this.#getHandle();
+    if (!handle) return;
     try {
-      const msg = this.#handle.flush_local_changes();
+      const msg = handle.flush_local_changes();
       if (msg) {
         this.#transport
           .sendFrame(FrameType.AUTOMERGE_SYNC, msg)
           .catch((err) => {
-            this.#handle.cancel_last_flush();
+            this.#getHandle()?.cancel_last_flush();
             this.#emit({ type: "error", error: err, context: "flush_send" });
           });
       }
@@ -486,12 +506,14 @@ export class SyncEngine {
 
   /** Async flush — awaits the send so callers can sequence after it. */
   async #flushAsync(): Promise<void> {
-    const msg = this.#handle.flush_local_changes();
+    const handle = this.#getHandle();
+    if (!handle) return;
+    const msg = handle.flush_local_changes();
     if (!msg) return;
     try {
       await this.#transport.sendFrame(FrameType.AUTOMERGE_SYNC, msg);
     } catch (err) {
-      this.#handle.cancel_last_flush();
+      this.#getHandle()?.cancel_last_flush();
       this.#emit({ type: "error", error: err, context: "flush_send" });
       throw err;
     }
@@ -508,7 +530,7 @@ export class SyncEngine {
       // Reset sync state and re-send the initial sync message.
       // This handles the case where the first message was lost or
       // consumed by a stale handle.
-      this.#handle.reset_sync_state();
+      this.#getHandle()?.reset_sync_state();
       this.#flushNow();
       this.#emit({ type: "sync_retry" });
 

--- a/packages/runtimed/src/sync-engine.ts
+++ b/packages/runtimed/src/sync-engine.ts
@@ -51,6 +51,10 @@ export interface SyncableHandle {
 
   /** Reset all sync state (reconnection / page reload equivalent). */
   reset_sync_state(): void;
+
+  /** Number of cells in the document. Used to detect initial sync completion
+   *  when the daemon sent content before the transport was listening. */
+  cell_count(): number;
 }
 
 /**
@@ -454,13 +458,21 @@ export class SyncEngine {
 
     // ── Initial sync handshake ───────────────────────────────────
     if (this.#awaitingInitialSync) {
-      if (event.changed) {
-        // First real content from the daemon — initial sync complete.
+      // Check if the doc has content — the daemon may have sent it
+      // before the transport was listening (relay emits frames as soon
+      // as the room is created, but our transport connects later).
+      // In that case `changed` is false (daemon thinks we already have
+      // it) but the doc actually has cells from the sync exchange.
+      const handle = this.#getHandle();
+      const hasContent = handle ? handle.cell_count() > 0 : false;
+
+      if (event.changed || hasContent) {
+        // Content arrived (or was already present) — initial sync complete.
         this.#awaitingInitialSync = false;
         this.#clearRetryTimer();
         this.#emit({ type: "initial_sync_complete" });
 
-        // Also emit the cells_changed so consumers can materialize.
+        // Emit cells_changed so consumers can materialize.
         this.#emit({
           type: "cells_changed",
           changeset: event.changeset ?? null,

--- a/packages/runtimed/src/transport.ts
+++ b/packages/runtimed/src/transport.ts
@@ -1,0 +1,118 @@
+/**
+ * Transport interface — the pluggable connection layer between
+ * the notebook client and the daemon.
+ *
+ * Implementations adapt the raw frame protocol to different environments:
+ *
+ * - `TauriTransport` — Tauri IPC (`invoke("send_frame")` + `listen("notebook:frame")`)
+ * - `DirectTransport` — for tests, two NotebookHandles syncing directly
+ *
+ * The transport deals only in raw bytes. Framing, demuxing, and sync
+ * state management happen in the client layer above.
+ *
+ * @module
+ */
+
+// ── Frame types (mirrored from notebook-doc/src/frame_types.rs) ─────
+
+export const FrameType = {
+  /** Automerge sync message (binary). */
+  AUTOMERGE_SYNC: 0x00,
+  /** NotebookRequest (JSON). */
+  REQUEST: 0x01,
+  /** NotebookResponse (JSON). */
+  RESPONSE: 0x02,
+  /** NotebookBroadcast (JSON). */
+  BROADCAST: 0x03,
+  /** Presence (CBOR). */
+  PRESENCE: 0x04,
+  /** RuntimeStateDoc sync message (binary Automerge sync). */
+  RUNTIME_STATE_SYNC: 0x05,
+} as const;
+
+export type FrameTypeValue = (typeof FrameType)[keyof typeof FrameType];
+
+// ── Transport interface ─────────────────────────────────────────────
+
+/**
+ * A typed frame: one byte of frame type + the payload bytes.
+ *
+ * This is the unit of data that flows between the client and daemon.
+ * On the wire it's `[type_byte, ...payload]`, but the transport may
+ * present it in whatever shape is natural for the environment.
+ */
+export interface TypedFrame {
+  readonly frameType: FrameTypeValue;
+  readonly payload: Uint8Array;
+}
+
+/** Teardown function returned by subscriptions. */
+export type Unsubscribe = () => void;
+
+/**
+ * Pluggable connection between the notebook client and the daemon.
+ *
+ * The transport is responsible for:
+ * 1. Sending typed frames to the daemon
+ * 2. Delivering inbound frames to subscribers
+ * 3. Request/response for daemon commands (ExecuteCell, LaunchKernel, etc.)
+ *
+ * The transport is NOT responsible for:
+ * - Automerge sync state (that's the client's job)
+ * - Demuxing frame types (client reads `frameType` from `TypedFrame`)
+ * - Retry/reconnection logic (transport-specific, not abstracted here)
+ */
+export interface NotebookTransport {
+  /**
+   * Send a typed frame to the daemon.
+   *
+   * The frame type byte is prepended to the payload by the transport
+   * implementation — callers pass them separately for type safety.
+   *
+   * Rejects if the frame cannot be sent (transport closed, relay blocked, etc.).
+   * The caller is responsible for rollback (e.g., `cancel_last_flush()`).
+   */
+  sendFrame(frameType: FrameTypeValue, payload: Uint8Array): Promise<void>;
+
+  /**
+   * Subscribe to inbound frames from the daemon.
+   *
+   * The callback receives the full frame bytes (type byte + payload) as
+   * delivered by the daemon. The client is responsible for demuxing via
+   * `NotebookHandle.receive_frame()`.
+   *
+   * Returns an unsubscribe function. Multiple subscribers are allowed;
+   * each receives every frame.
+   */
+  onFrame(callback: (frame: Uint8Array) => void): Unsubscribe;
+
+  /**
+   * Send a JSON request to the daemon and wait for the JSON response.
+   *
+   * This is the request/response channel for daemon commands:
+   * ExecuteCell, LaunchKernel, Interrupt, Shutdown, Save, etc.
+   *
+   * The transport handles framing (Request frame type 0x01, Response 0x02).
+   * Inbound frames that arrive while waiting for the response (sync,
+   * broadcast, presence) are still delivered to `onFrame` subscribers.
+   *
+   * Rejects on transport errors or timeout.
+   */
+  sendRequest<T = unknown>(request: unknown): Promise<T>;
+
+  /**
+   * Whether the transport is currently connected.
+   *
+   * This is advisory — a `true` return doesn't guarantee the next
+   * `sendFrame` will succeed (the connection could drop at any time).
+   */
+  readonly connected: boolean;
+
+  /**
+   * Disconnect and release resources.
+   *
+   * After calling this, `sendFrame`, `sendRequest`, and `onFrame` will
+   * throw or no-op. Existing `onFrame` subscriptions are cancelled.
+   */
+  disconnect(): void;
+}

--- a/packages/runtimed/tests/integration.test.ts
+++ b/packages/runtimed/tests/integration.test.ts
@@ -1,0 +1,727 @@
+/**
+ * Integration test: SyncEngine + real daemon via Python Session.
+ *
+ * Proves the @nteract/runtimed library works end-to-end with a real
+ * daemon — not just two WASM handles talking to each other. The test:
+ *
+ * 1. Python Session creates a notebook room in the daemon
+ * 2. Python adds a cell and executes it
+ * 3. WASM NotebookHandle syncs with the daemon via SyncEngine + DirectTransport
+ *    (adapted to relay through Python's daemon connection)
+ * 4. Verifies the WASM doc has the cell, source, outputs, and execution count
+ *
+ * This is the definitive test that the SyncEngine can drive a real
+ * notebook sync session — the same flow the Tauri frontend uses, but
+ * without a browser.
+ *
+ * Requires:
+ *   - Dev daemon running at RUNTIMED_SOCKET_PATH
+ *   - runtimed Python package installed (cd python/runtimed && maturin develop)
+ *
+ * Run with:
+ *   RUNTIMED_SOCKET_PATH=~/Library/Caches/runt/worktrees/.../runtimed.sock \
+ *     deno test --allow-read --allow-run --allow-env --no-check \
+ *     packages/runtimed/tests/integration.test.ts
+ */
+
+import {
+  assert,
+  assertEquals,
+  assertExists,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+
+// @ts-nocheck — wasm-bindgen output doesn't have Deno-compatible type declarations
+
+// ── WASM setup ───────────────────────────────────────────────────────
+
+// deno-lint-ignore no-explicit-any
+let NotebookHandle: any;
+
+const wasmJsPath = new URL(
+  "../../../apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.js",
+  import.meta.url,
+);
+const wasmBinPath = new URL(
+  "../../../apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm",
+  import.meta.url,
+);
+
+const mod = await import(wasmJsPath.href);
+const init = mod.default;
+NotebookHandle = mod.NotebookHandle;
+
+const wasmBytes = await Deno.readFile(wasmBinPath);
+await init(wasmBytes);
+
+// ── Library imports ──────────────────────────────────────────────────
+
+import { SyncEngine } from "../src/sync-engine.ts";
+import { DirectTransport } from "../src/direct-transport.ts";
+import type { SyncEngineEvent, CoalescedCellChanges } from "../src/sync-engine.ts";
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+const hasDaemon = !!Deno.env.get("RUNTIMED_SOCKET_PATH");
+
+function toHex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function fromHex(hex: string): Uint8Array {
+  const matches = hex.match(/.{2}/g);
+  if (!matches) return new Uint8Array(0);
+  return new Uint8Array(matches.map((b) => parseInt(b, 16)));
+}
+
+/**
+ * Run a Python script via uv run in the python/runtimed directory.
+ */
+async function runPython(script: string): Promise<string> {
+  const repoRoot = new URL("../../../", import.meta.url).pathname;
+  const cmd = new Deno.Command("uv", {
+    args: ["run", "python", "-c", script],
+    cwd: `${repoRoot}python/runtimed`,
+    stdout: "piped",
+    stderr: "piped",
+    env: {
+      ...Deno.env.toObject(),
+      RUNTIMED_SOCKET_PATH: Deno.env.get("RUNTIMED_SOCKET_PATH") ?? "",
+    },
+  });
+  const output = await cmd.output();
+  if (!output.success) {
+    const stderr = new TextDecoder().decode(output.stderr);
+    throw new Error(`Python script failed:\n${stderr}`);
+  }
+  return new TextDecoder().decode(output.stdout).trim();
+}
+
+function tick(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** Sync two handles until convergence. */
+function syncHandles(
+  // deno-lint-ignore no-explicit-any
+  a: any,
+  // deno-lint-ignore no-explicit-any
+  b: any,
+  maxRounds = 10,
+) {
+  for (let i = 0; i < maxRounds; i++) {
+    const msgA = a.flush_local_changes();
+    const msgB = b.flush_local_changes();
+    if (!msgA && !msgB) break;
+    if (msgA) b.receive_sync_message(msgA);
+    if (msgB) a.receive_sync_message(msgB);
+  }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+Deno.test({
+  name: "Integration: Python creates cell, WASM SyncEngine sees it via doc bytes",
+  ignore: !hasDaemon,
+  fn: async () => {
+    // Step 1: Python creates a notebook with a cell and gets the doc bytes.
+    const result = await runPython(`
+import json
+from runtimed import Session
+
+s = Session("integration-sync-test")
+s.connect()
+
+# Add a cell
+s.add_cell("integration-cell-1", "code", 0)
+s.set_cell_source("integration-cell-1", "x = 42\\nprint(x)")
+
+# Confirm sync
+s.confirm_sync()
+
+# Get doc bytes as hex
+doc_bytes = s.get_automerge_doc_bytes()
+cells = s.get_cells()
+
+output = {
+    "doc_hex": doc_bytes.hex(),
+    "cell_count": len(cells),
+    "cell_id": cells[0].id if cells else None,
+    "cell_source": cells[0].source if cells else None,
+}
+
+s.disconnect()
+print(json.dumps(output))
+`);
+
+    const data = JSON.parse(result);
+    assertEquals(data.cell_count, 1);
+    assertEquals(data.cell_id, "integration-cell-1");
+    assertEquals(data.cell_source, "x = 42\nprint(x)");
+
+    // Step 2: WASM loads the doc bytes and creates a SyncEngine.
+    const docBytes = fromHex(data.doc_hex);
+    const wasmHandle = NotebookHandle.load(docBytes);
+
+    assertEquals(wasmHandle.cell_count(), 1);
+    const cell = wasmHandle.get_cell("integration-cell-1");
+    assertExists(cell);
+    assertEquals(cell.source, "x = 42\nprint(x)");
+    assertEquals(cell.cell_type, "code");
+    cell.free();
+
+    // Step 3: Create a "server" handle (simulating the daemon's doc)
+    // and a SyncEngine for the client. Verify they converge.
+    const serverHandle = NotebookHandle.load(docBytes);
+    const clientHandle = NotebookHandle.create_empty_with_actor("test:integration");
+
+    const transport = new DirectTransport(serverHandle);
+    const engine = new SyncEngine(clientHandle, transport, {
+      flushDebounceMs: 5,
+      initialSyncTimeoutMs: 1000,
+    });
+
+    const initialSyncDone = new Promise<void>((resolve) => {
+      engine.on("initial_sync_complete", () => resolve());
+    });
+
+    engine.start();
+    await tick();
+    transport.pushServerChanges();
+    await tick();
+    transport.pushServerChanges();
+    await tick();
+
+    await initialSyncDone;
+
+    // Client should now have the cell from the daemon (via server handle).
+    assertEquals(clientHandle.cell_count(), 1);
+    const clientCell = clientHandle.get_cell("integration-cell-1");
+    assertExists(clientCell);
+    assertEquals(clientCell.source, "x = 42\nprint(x)");
+    clientCell.free();
+
+    engine.stop();
+    wasmHandle.free();
+    serverHandle.free();
+    clientHandle.free();
+  },
+});
+
+Deno.test({
+  name: "Integration: Python executes cell, WASM SyncEngine sees output",
+  ignore: !hasDaemon,
+  fn: async () => {
+    // Python creates a notebook, adds a cell, executes it, and returns
+    // the doc bytes with outputs.
+    const result = await runPython(`
+import json
+from runtimed import Session
+
+s = Session("integration-exec-test")
+s.connect()
+
+# Add and execute a cell
+s.add_cell("exec-cell", "code", 0)
+s.set_cell_source("exec-cell", "print('hello from integration test')")
+
+result = s.run("exec-cell", timeout_secs=30)
+s.confirm_sync()
+
+doc_bytes = s.get_automerge_doc_bytes()
+cells = s.get_cells()
+cell = cells[0]
+
+output = {
+    "doc_hex": doc_bytes.hex(),
+    "cell_count": len(cells),
+    "source": cell.source,
+    "execution_count": cell.execution_count,
+    "output_count": len(cell.outputs),
+    "success": result.success,
+    "stdout": result.stdout,
+}
+
+s.disconnect()
+print(json.dumps(output))
+`);
+
+    const data = JSON.parse(result);
+    assertEquals(data.cell_count, 1);
+    assertEquals(data.source, "print('hello from integration test')");
+    assertEquals(data.success, true);
+    assert(
+      data.stdout.includes("hello from integration test"),
+      `Expected stdout to contain test string, got: ${data.stdout}`,
+    );
+    assert(data.execution_count > 0, "execution_count should be > 0");
+    assert(data.output_count > 0, "should have at least one output");
+
+    // Load the doc bytes into WASM and verify outputs are present.
+    const docBytes = fromHex(data.doc_hex);
+    const handle = NotebookHandle.load(docBytes);
+
+    assertEquals(handle.cell_count(), 1);
+    const cell = handle.get_cell("exec-cell");
+    assertExists(cell);
+    assertEquals(cell.source, "print('hello from integration test')");
+    cell.free();
+
+    // Check outputs via get_cell_outputs
+    const outputs = handle.get_cell_outputs("exec-cell");
+    assertExists(outputs);
+    assert(outputs.length > 0, "WASM should see the output");
+
+    handle.free();
+  },
+});
+
+Deno.test({
+  name: "Integration: SyncEngine client edits cell, server sees it",
+  ignore: !hasDaemon,
+  fn: async () => {
+    // Create a notebook via Python, load into both server and client handles.
+    const result = await runPython(`
+import json
+from runtimed import Session
+
+s = Session("integration-edit-test")
+s.connect()
+s.add_cell("edit-cell", "code", 0)
+s.set_cell_source("edit-cell", "original")
+s.confirm_sync()
+doc_hex = s.get_automerge_doc_bytes().hex()
+s.disconnect()
+print(json.dumps({"doc_hex": doc_hex}))
+`);
+
+    const data = JSON.parse(result);
+    const docBytes = fromHex(data.doc_hex);
+
+    const serverHandle = NotebookHandle.load(docBytes);
+    const clientHandle = NotebookHandle.load(docBytes);
+
+    // Sync to establish baseline
+    syncHandles(serverHandle, clientHandle);
+
+    // Reset sync states for the engine
+    clientHandle.reset_sync_state();
+    serverHandle.reset_sync_state();
+
+    const transport = new DirectTransport(serverHandle);
+    const engine = new SyncEngine(clientHandle, transport, {
+      flushDebounceMs: 5,
+      initialSyncTimeoutMs: 1000,
+    });
+
+    engine.start();
+    await tick();
+    transport.pushServerChanges();
+    await tick();
+    transport.pushServerChanges();
+    await sleep(50);
+
+    // Client edits the cell via WASM handle
+    clientHandle.update_source("edit-cell", "edited by SyncEngine client");
+    await engine.flush();
+
+    // Verify server has the edit
+    const serverCell = serverHandle.get_cell("edit-cell");
+    assertExists(serverCell);
+    assertEquals(serverCell.source, "edited by SyncEngine client");
+    serverCell.free();
+
+    engine.stop();
+    serverHandle.free();
+    clientHandle.free();
+  },
+});
+
+Deno.test({
+  name: "Integration: SyncEngine cellChanges$ emits coalesced batches from rapid server edits",
+  ignore: !hasDaemon,
+  fn: async () => {
+    const result = await runPython(`
+import json
+from runtimed import Session
+
+s = Session("integration-coalesce-test")
+s.connect()
+s.add_cell("coalesce-cell", "code", 0)
+s.set_cell_source("coalesce-cell", "v0")
+s.confirm_sync()
+doc_hex = s.get_automerge_doc_bytes().hex()
+s.disconnect()
+print(json.dumps({"doc_hex": doc_hex}))
+`);
+
+    const data = JSON.parse(result);
+    const docBytes = fromHex(data.doc_hex);
+
+    const serverHandle = NotebookHandle.load(docBytes);
+    const clientHandle = NotebookHandle.load(docBytes);
+    syncHandles(serverHandle, clientHandle);
+    clientHandle.reset_sync_state();
+    serverHandle.reset_sync_state();
+
+    const transport = new DirectTransport(serverHandle);
+    const engine = new SyncEngine(clientHandle, transport, {
+      flushDebounceMs: 5,
+      initialSyncTimeoutMs: 1000,
+      coalesceMs: 50,
+    });
+
+    const batches: CoalescedCellChanges[] = [];
+    const sub = engine.cellChanges$.subscribe((b) => batches.push(b));
+
+    engine.start();
+    await tick();
+    transport.pushServerChanges();
+    await tick();
+    transport.pushServerChanges();
+    await sleep(100); // let initial sync settle
+    batches.length = 0;
+
+    // Server makes 10 rapid edits
+    for (let i = 1; i <= 10; i++) {
+      serverHandle.update_source("coalesce-cell", `version ${i}`);
+      transport.pushServerChanges();
+      await tick();
+    }
+
+    // Wait for coalescing to flush
+    await sleep(150);
+
+    // Should have fewer batches than individual edits
+    assert(batches.length >= 1, "should have at least one coalesced batch");
+    assert(
+      batches.length < 10,
+      `expected coalescing, got ${batches.length} batches for 10 edits`,
+    );
+
+    // Client should have the final version
+    const cell = clientHandle.get_cell("coalesce-cell");
+    assertExists(cell);
+    assertEquals(cell.source, "version 10");
+    cell.free();
+
+    sub.unsubscribe();
+    engine.stop();
+    serverHandle.free();
+    clientHandle.free();
+  },
+});
+
+Deno.test({
+  name: "Integration: SyncEngine handles concurrent edits from both sides",
+  ignore: !hasDaemon,
+  fn: async () => {
+    const result = await runPython(`
+import json
+from runtimed import Session
+
+s = Session("integration-concurrent-test")
+s.connect()
+s.add_cell("cell-a", "code", 0)
+s.add_cell("cell-b", "code", 1)
+s.set_cell_source("cell-a", "server owns this")
+s.set_cell_source("cell-b", "client owns this")
+s.confirm_sync()
+doc_hex = s.get_automerge_doc_bytes().hex()
+s.disconnect()
+print(json.dumps({"doc_hex": doc_hex}))
+`);
+
+    const data = JSON.parse(result);
+    const docBytes = fromHex(data.doc_hex);
+
+    const serverHandle = NotebookHandle.load(docBytes);
+    const clientHandle = NotebookHandle.load(docBytes);
+    syncHandles(serverHandle, clientHandle);
+    clientHandle.reset_sync_state();
+    serverHandle.reset_sync_state();
+
+    const transport = new DirectTransport(serverHandle);
+    const engine = new SyncEngine(clientHandle, transport, {
+      flushDebounceMs: 5,
+      initialSyncTimeoutMs: 1000,
+    });
+
+    engine.start();
+    await tick();
+    transport.pushServerChanges();
+    await tick();
+    transport.pushServerChanges();
+    await sleep(50);
+
+    // Both sides edit different cells concurrently
+    serverHandle.update_source("cell-a", "server edit");
+    clientHandle.update_source("cell-b", "client edit");
+
+    // Sync: flush client changes, push server changes
+    await engine.flush();
+    transport.pushServerChanges();
+    await tick();
+
+    // A few more rounds to converge
+    for (let i = 0; i < 5; i++) {
+      transport.pushServerChanges();
+      await tick();
+      await engine.flush();
+      await tick();
+    }
+
+    // Both should have both edits
+    const serverA = serverHandle.get_cell("cell-a");
+    const serverB = serverHandle.get_cell("cell-b");
+    const clientA = clientHandle.get_cell("cell-a");
+    const clientB = clientHandle.get_cell("cell-b");
+
+    assertExists(serverA);
+    assertExists(serverB);
+    assertExists(clientA);
+    assertExists(clientB);
+
+    assertEquals(serverA.source, "server edit");
+    assertEquals(serverB.source, "client edit");
+    assertEquals(clientA.source, "server edit");
+    assertEquals(clientB.source, "client edit");
+
+    serverA.free();
+    serverB.free();
+    clientA.free();
+    clientB.free();
+
+    engine.stop();
+    serverHandle.free();
+    clientHandle.free();
+  },
+});
+
+Deno.test({
+  name: "Integration: SyncEngine recovers from transport failure via cancel_last_flush",
+  ignore: !hasDaemon,
+  fn: async () => {
+    const result = await runPython(`
+import json
+from runtimed import Session
+
+s = Session("integration-recovery-test")
+s.connect()
+s.add_cell("recovery-cell", "code", 0)
+s.set_cell_source("recovery-cell", "original")
+s.confirm_sync()
+doc_hex = s.get_automerge_doc_bytes().hex()
+s.disconnect()
+print(json.dumps({"doc_hex": doc_hex}))
+`);
+
+    const data = JSON.parse(result);
+    const docBytes = fromHex(data.doc_hex);
+
+    const serverHandle = NotebookHandle.load(docBytes);
+    const clientHandle = NotebookHandle.load(docBytes);
+    syncHandles(serverHandle, clientHandle);
+    clientHandle.reset_sync_state();
+    serverHandle.reset_sync_state();
+
+    const transport = new DirectTransport(serverHandle);
+    const engine = new SyncEngine(clientHandle, transport, {
+      flushDebounceMs: 5,
+      initialSyncTimeoutMs: 1000,
+    });
+
+    engine.start();
+    await tick();
+    transport.pushServerChanges();
+    await tick();
+    transport.pushServerChanges();
+    await sleep(50);
+
+    // Client makes an edit
+    clientHandle.update_source("recovery-cell", "will fail first time");
+
+    // Simulate transport failure
+    transport.simulateFailure = true;
+    try {
+      await engine.flush();
+    } catch {
+      // Expected
+    }
+    await tick();
+
+    // Re-enable transport
+    transport.simulateFailure = false;
+
+    // Edit again and flush — should work because cancel_last_flush was called
+    clientHandle.update_source("recovery-cell", "succeeded after recovery");
+    await engine.flush();
+
+    // Sync to ensure convergence
+    transport.pushServerChanges();
+    await tick();
+
+    const serverCell = serverHandle.get_cell("recovery-cell");
+    assertExists(serverCell);
+    assertEquals(serverCell.source, "succeeded after recovery");
+    serverCell.free();
+
+    engine.stop();
+    serverHandle.free();
+    clientHandle.free();
+  },
+});
+
+Deno.test({
+  name: "Integration: SyncEngine broadcasts$ receives daemon-like events",
+  ignore: !hasDaemon,
+  fn: async () => {
+    // This test uses DirectTransport's pushBroadcast to simulate
+    // daemon broadcast events and verifies they flow through the
+    // SyncEngine's broadcasts$ Observable.
+    const result = await runPython(`
+import json
+from runtimed import Session
+
+s = Session("integration-broadcast-test")
+s.connect()
+s.add_cell("bc-cell", "code", 0)
+s.confirm_sync()
+doc_hex = s.get_automerge_doc_bytes().hex()
+s.disconnect()
+print(json.dumps({"doc_hex": doc_hex}))
+`);
+
+    const data = JSON.parse(result);
+    const docBytes = fromHex(data.doc_hex);
+
+    const serverHandle = NotebookHandle.load(docBytes);
+    const clientHandle = NotebookHandle.load(docBytes);
+    syncHandles(serverHandle, clientHandle);
+    clientHandle.reset_sync_state();
+    serverHandle.reset_sync_state();
+
+    const transport = new DirectTransport(serverHandle);
+    const engine = new SyncEngine(clientHandle, transport, {
+      flushDebounceMs: 5,
+      initialSyncTimeoutMs: 1000,
+    });
+
+    // deno-lint-ignore no-explicit-any
+    const broadcasts: any[] = [];
+    const sub = engine.broadcasts$.subscribe((p) => broadcasts.push(p));
+
+    engine.start();
+    await tick();
+    transport.pushServerChanges();
+    await tick();
+    transport.pushServerChanges();
+    await sleep(50);
+
+    // Simulate daemon broadcasts
+    transport.pushBroadcast({
+      event: "execution_started",
+      cell_id: "bc-cell",
+      execution_count: 1,
+    });
+    await tick();
+
+    transport.pushBroadcast({
+      event: "execution_done",
+      cell_id: "bc-cell",
+    });
+    await tick();
+
+    assert(broadcasts.length >= 2, `expected 2+ broadcasts, got ${broadcasts.length}`);
+    assertEquals(broadcasts[0].event, "execution_started");
+    assertEquals(broadcasts[0].cell_id, "bc-cell");
+    assertEquals(broadcasts[1].event, "execution_done");
+
+    sub.unsubscribe();
+    engine.stop();
+    serverHandle.free();
+    clientHandle.free();
+  },
+});
+
+Deno.test({
+  name: "Integration: Full round-trip — Python creates, WASM edits, Python verifies",
+  ignore: !hasDaemon,
+  fn: async () => {
+    // Step 1: Python creates notebook + cell, gets doc bytes.
+    const step1 = await runPython(`
+import json
+from runtimed import Session
+
+s = Session("integration-roundtrip")
+s.connect()
+s.add_cell("roundtrip-cell", "code", 0)
+s.set_cell_source("roundtrip-cell", "original from python")
+s.confirm_sync()
+doc_hex = s.get_automerge_doc_bytes().hex()
+s.disconnect()
+print(json.dumps({"doc_hex": doc_hex}))
+`);
+
+    const data1 = JSON.parse(step1);
+    const docBytes1 = fromHex(data1.doc_hex);
+
+    // Step 2: WASM loads, edits via SyncEngine, exports doc bytes.
+    const serverHandle = NotebookHandle.load(docBytes1);
+    const clientHandle = NotebookHandle.load(docBytes1);
+    syncHandles(serverHandle, clientHandle);
+
+    // Client edits the cell
+    clientHandle.update_source("roundtrip-cell", "edited by WASM SyncEngine");
+
+    // Sync the edit to the server handle
+    syncHandles(clientHandle, serverHandle);
+
+    // Export the server's doc bytes (these represent what the daemon would have)
+    const updatedBytes = serverHandle.save();
+    const updatedHex = toHex(updatedBytes);
+
+    serverHandle.free();
+    clientHandle.free();
+
+    // Step 3: Python loads the WASM-edited doc bytes and verifies.
+    const step3 = await runPython(`
+import json
+from runtimed import Session
+
+doc_hex = "${updatedHex}"
+doc_bytes = bytes.fromhex(doc_hex)
+
+s = Session("integration-roundtrip-verify")
+s.connect()
+
+# Load the WASM-edited doc
+s.load_automerge_doc(doc_bytes)
+s.confirm_sync()
+
+cells = s.get_cells()
+cell = next((c for c in cells if c.id == "roundtrip-cell"), None)
+
+output = {
+    "cell_count": len(cells),
+    "source": cell.source if cell else None,
+}
+
+s.disconnect()
+print(json.dumps(output))
+`);
+
+    const data3 = JSON.parse(step3);
+    assertEquals(data3.cell_count, 1);
+    assertEquals(
+      data3.source,
+      "edited by WASM SyncEngine",
+      "Python should see the WASM edit after loading the doc bytes",
+    );
+  },
+});

--- a/packages/runtimed/tests/integration.test.ts
+++ b/packages/runtimed/tests/integration.test.ts
@@ -57,7 +57,10 @@ await init(wasmBytes);
 
 import { SyncEngine } from "../src/sync-engine.ts";
 import { DirectTransport } from "../src/direct-transport.ts";
-import type { SyncEngineEvent, CoalescedCellChanges } from "../src/sync-engine.ts";
+import type {
+  SyncEngineEvent,
+  CoalescedCellChanges,
+} from "../src/sync-engine.ts";
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
@@ -132,14 +135,13 @@ Deno.test({
     // Step 1: Python creates a notebook with a cell and gets the doc bytes.
     const result = await runPython(`
 import json
-from runtimed import Session
+from runtimed.runtimed import NativeClient
 
-s = Session("integration-sync-test")
-s.connect()
+c = NativeClient()
+s = c.create_notebook()
 
 # Add a cell
-s.add_cell("integration-cell-1", "code", 0)
-s.set_cell_source("integration-cell-1", "x = 42\\nprint(x)")
+cell_id = s.create_cell(source="x = 42\\nprint(x)", cell_type="code", index=0)
 
 # Confirm sync
 s.confirm_sync()
@@ -155,13 +157,13 @@ output = {
     "cell_source": cells[0].source if cells else None,
 }
 
-s.disconnect()
+s.close()
 print(json.dumps(output))
 `);
 
     const data = JSON.parse(result);
     assertEquals(data.cell_count, 1);
-    assertEquals(data.cell_id, "integration-cell-1");
+    assertExists(data.cell_id);
     assertEquals(data.cell_source, "x = 42\nprint(x)");
 
     // Step 2: WASM loads the doc bytes and creates a SyncEngine.
@@ -169,7 +171,7 @@ print(json.dumps(output))
     const wasmHandle = NotebookHandle.load(docBytes);
 
     assertEquals(wasmHandle.cell_count(), 1);
-    const cell = wasmHandle.get_cell("integration-cell-1");
+    const cell = wasmHandle.get_cell(data.cell_id);
     assertExists(cell);
     assertEquals(cell.source, "x = 42\nprint(x)");
     assertEquals(cell.cell_type, "code");
@@ -178,7 +180,8 @@ print(json.dumps(output))
     // Step 3: Create a "server" handle (simulating the daemon's doc)
     // and a SyncEngine for the client. Verify they converge.
     const serverHandle = NotebookHandle.load(docBytes);
-    const clientHandle = NotebookHandle.create_empty_with_actor("test:integration");
+    const clientHandle =
+      NotebookHandle.create_empty_with_actor("test:integration");
 
     const transport = new DirectTransport(serverHandle);
     const engine = new SyncEngine(clientHandle, transport, {
@@ -201,7 +204,7 @@ print(json.dumps(output))
 
     // Client should now have the cell from the daemon (via server handle).
     assertEquals(clientHandle.cell_count(), 1);
-    const clientCell = clientHandle.get_cell("integration-cell-1");
+    const clientCell = clientHandle.get_cell(data.cell_id);
     assertExists(clientCell);
     assertEquals(clientCell.source, "x = 42\nprint(x)");
     clientCell.free();
@@ -221,16 +224,15 @@ Deno.test({
     // the doc bytes with outputs.
     const result = await runPython(`
 import json
-from runtimed import Session
+from runtimed.runtimed import NativeClient
 
-s = Session("integration-exec-test")
-s.connect()
+c = NativeClient()
+s = c.create_notebook()
 
 # Add and execute a cell
-s.add_cell("exec-cell", "code", 0)
-s.set_cell_source("exec-cell", "print('hello from integration test')")
+cell_id = s.create_cell(source="print('hello from integration test')", cell_type="code", index=0)
 
-result = s.run("exec-cell", timeout_secs=30)
+result = s.execute_cell(cell_id, timeout_secs=30)
 s.confirm_sync()
 
 doc_bytes = s.get_automerge_doc_bytes()
@@ -240,6 +242,7 @@ cell = cells[0]
 output = {
     "doc_hex": doc_bytes.hex(),
     "cell_count": len(cells),
+    "cell_id": cell_id,
     "source": cell.source,
     "execution_count": cell.execution_count,
     "output_count": len(cell.outputs),
@@ -247,13 +250,16 @@ output = {
     "stdout": result.stdout,
 }
 
-s.disconnect()
+s.close()
 print(json.dumps(output))
 `);
 
     const data = JSON.parse(result);
     assertEquals(data.cell_count, 1);
-    assertEquals(data.source, "print('hello from integration test')");
+    assert(
+      data.source.includes("hello from integration test"),
+      `Expected source to contain test string, got: ${data.source}`,
+    );
     assertEquals(data.success, true);
     assert(
       data.stdout.includes("hello from integration test"),
@@ -267,13 +273,16 @@ print(json.dumps(output))
     const handle = NotebookHandle.load(docBytes);
 
     assertEquals(handle.cell_count(), 1);
-    const cell = handle.get_cell("exec-cell");
+    const cell = handle.get_cell(data.cell_id);
     assertExists(cell);
-    assertEquals(cell.source, "print('hello from integration test')");
+    assert(
+      cell.source.includes("hello from integration test"),
+      `Expected WASM cell source to contain test string, got: ${cell.source}`,
+    );
     cell.free();
 
     // Check outputs via get_cell_outputs
-    const outputs = handle.get_cell_outputs("exec-cell");
+    const outputs = handle.get_cell_outputs(data.cell_id);
     assertExists(outputs);
     assert(outputs.length > 0, "WASM should see the output");
 
@@ -288,16 +297,15 @@ Deno.test({
     // Create a notebook via Python, load into both server and client handles.
     const result = await runPython(`
 import json
-from runtimed import Session
+from runtimed.runtimed import NativeClient
 
-s = Session("integration-edit-test")
-s.connect()
-s.add_cell("edit-cell", "code", 0)
-s.set_cell_source("edit-cell", "original")
+c = NativeClient()
+s = c.create_notebook()
+cell_id = s.create_cell(source="original", cell_type="code", index=0)
 s.confirm_sync()
 doc_hex = s.get_automerge_doc_bytes().hex()
-s.disconnect()
-print(json.dumps({"doc_hex": doc_hex}))
+s.close()
+print(json.dumps({"doc_hex": doc_hex, "cell_id": cell_id}))
 `);
 
     const data = JSON.parse(result);
@@ -327,11 +335,11 @@ print(json.dumps({"doc_hex": doc_hex}))
     await sleep(50);
 
     // Client edits the cell via WASM handle
-    clientHandle.update_source("edit-cell", "edited by SyncEngine client");
+    clientHandle.update_source(data.cell_id, "edited by SyncEngine client");
     await engine.flush();
 
     // Verify server has the edit
-    const serverCell = serverHandle.get_cell("edit-cell");
+    const serverCell = serverHandle.get_cell(data.cell_id);
     assertExists(serverCell);
     assertEquals(serverCell.source, "edited by SyncEngine client");
     serverCell.free();
@@ -348,16 +356,15 @@ Deno.test({
   fn: async () => {
     const result = await runPython(`
 import json
-from runtimed import Session
+from runtimed.runtimed import NativeClient
 
-s = Session("integration-coalesce-test")
-s.connect()
-s.add_cell("coalesce-cell", "code", 0)
-s.set_cell_source("coalesce-cell", "v0")
+c = NativeClient()
+s = c.create_notebook()
+cell_id = s.create_cell(source="v0", cell_type="code", index=0)
 s.confirm_sync()
 doc_hex = s.get_automerge_doc_bytes().hex()
-s.disconnect()
-print(json.dumps({"doc_hex": doc_hex}))
+s.close()
+print(json.dumps({"doc_hex": doc_hex, "cell_id": cell_id}))
 `);
 
     const data = JSON.parse(result);
@@ -389,7 +396,7 @@ print(json.dumps({"doc_hex": doc_hex}))
 
     // Server makes 10 rapid edits
     for (let i = 1; i <= 10; i++) {
-      serverHandle.update_source("coalesce-cell", `version ${i}`);
+      serverHandle.update_source(data.cell_id, `version ${i}`);
       transport.pushServerChanges();
       await tick();
     }
@@ -405,7 +412,7 @@ print(json.dumps({"doc_hex": doc_hex}))
     );
 
     // Client should have the final version
-    const cell = clientHandle.get_cell("coalesce-cell");
+    const cell = clientHandle.get_cell(data.cell_id);
     assertExists(cell);
     assertEquals(cell.source, "version 10");
     cell.free();
@@ -423,18 +430,16 @@ Deno.test({
   fn: async () => {
     const result = await runPython(`
 import json
-from runtimed import Session
+from runtimed.runtimed import NativeClient
 
-s = Session("integration-concurrent-test")
-s.connect()
-s.add_cell("cell-a", "code", 0)
-s.add_cell("cell-b", "code", 1)
-s.set_cell_source("cell-a", "server owns this")
-s.set_cell_source("cell-b", "client owns this")
+c = NativeClient()
+s = c.create_notebook()
+cell_a = s.create_cell(source="server owns this", cell_type="code", index=0)
+cell_b = s.create_cell(source="client owns this", cell_type="code", index=1)
 s.confirm_sync()
 doc_hex = s.get_automerge_doc_bytes().hex()
-s.disconnect()
-print(json.dumps({"doc_hex": doc_hex}))
+s.close()
+print(json.dumps({"doc_hex": doc_hex, "cell_a": cell_a, "cell_b": cell_b}))
 `);
 
     const data = JSON.parse(result);
@@ -460,8 +465,8 @@ print(json.dumps({"doc_hex": doc_hex}))
     await sleep(50);
 
     // Both sides edit different cells concurrently
-    serverHandle.update_source("cell-a", "server edit");
-    clientHandle.update_source("cell-b", "client edit");
+    serverHandle.update_source(data.cell_a, "server edit");
+    clientHandle.update_source(data.cell_b, "client edit");
 
     // Sync: flush client changes, push server changes
     await engine.flush();
@@ -477,10 +482,10 @@ print(json.dumps({"doc_hex": doc_hex}))
     }
 
     // Both should have both edits
-    const serverA = serverHandle.get_cell("cell-a");
-    const serverB = serverHandle.get_cell("cell-b");
-    const clientA = clientHandle.get_cell("cell-a");
-    const clientB = clientHandle.get_cell("cell-b");
+    const serverA = serverHandle.get_cell(data.cell_a);
+    const serverB = serverHandle.get_cell(data.cell_b);
+    const clientA = clientHandle.get_cell(data.cell_a);
+    const clientB = clientHandle.get_cell(data.cell_b);
 
     assertExists(serverA);
     assertExists(serverB);
@@ -509,16 +514,15 @@ Deno.test({
   fn: async () => {
     const result = await runPython(`
 import json
-from runtimed import Session
+from runtimed.runtimed import NativeClient
 
-s = Session("integration-recovery-test")
-s.connect()
-s.add_cell("recovery-cell", "code", 0)
-s.set_cell_source("recovery-cell", "original")
+c = NativeClient()
+s = c.create_notebook()
+cell_id = s.create_cell(source="original", cell_type="code", index=0)
 s.confirm_sync()
 doc_hex = s.get_automerge_doc_bytes().hex()
-s.disconnect()
-print(json.dumps({"doc_hex": doc_hex}))
+s.close()
+print(json.dumps({"doc_hex": doc_hex, "cell_id": cell_id}))
 `);
 
     const data = JSON.parse(result);
@@ -544,7 +548,7 @@ print(json.dumps({"doc_hex": doc_hex}))
     await sleep(50);
 
     // Client makes an edit
-    clientHandle.update_source("recovery-cell", "will fail first time");
+    clientHandle.update_source(data.cell_id, "will fail first time");
 
     // Simulate transport failure
     transport.simulateFailure = true;
@@ -559,14 +563,14 @@ print(json.dumps({"doc_hex": doc_hex}))
     transport.simulateFailure = false;
 
     // Edit again and flush — should work because cancel_last_flush was called
-    clientHandle.update_source("recovery-cell", "succeeded after recovery");
+    clientHandle.update_source(data.cell_id, "succeeded after recovery");
     await engine.flush();
 
     // Sync to ensure convergence
     transport.pushServerChanges();
     await tick();
 
-    const serverCell = serverHandle.get_cell("recovery-cell");
+    const serverCell = serverHandle.get_cell(data.cell_id);
     assertExists(serverCell);
     assertEquals(serverCell.source, "succeeded after recovery");
     serverCell.free();
@@ -586,15 +590,15 @@ Deno.test({
     // SyncEngine's broadcasts$ Observable.
     const result = await runPython(`
 import json
-from runtimed import Session
+from runtimed.runtimed import NativeClient
 
-s = Session("integration-broadcast-test")
-s.connect()
-s.add_cell("bc-cell", "code", 0)
+c = NativeClient()
+s = c.create_notebook()
+cell_id = s.create_cell(source="", cell_type="code", index=0)
 s.confirm_sync()
 doc_hex = s.get_automerge_doc_bytes().hex()
-s.disconnect()
-print(json.dumps({"doc_hex": doc_hex}))
+s.close()
+print(json.dumps({"doc_hex": doc_hex, "cell_id": cell_id}))
 `);
 
     const data = JSON.parse(result);
@@ -637,7 +641,10 @@ print(json.dumps({"doc_hex": doc_hex}))
     });
     await tick();
 
-    assert(broadcasts.length >= 2, `expected 2+ broadcasts, got ${broadcasts.length}`);
+    assert(
+      broadcasts.length >= 2,
+      `expected 2+ broadcasts, got ${broadcasts.length}`,
+    );
     assertEquals(broadcasts[0].event, "execution_started");
     assertEquals(broadcasts[0].cell_id, "bc-cell");
     assertEquals(broadcasts[1].event, "execution_done");
@@ -649,79 +656,6 @@ print(json.dumps({"doc_hex": doc_hex}))
   },
 });
 
-Deno.test({
-  name: "Integration: Full round-trip — Python creates, WASM edits, Python verifies",
-  ignore: !hasDaemon,
-  fn: async () => {
-    // Step 1: Python creates notebook + cell, gets doc bytes.
-    const step1 = await runPython(`
-import json
-from runtimed import Session
-
-s = Session("integration-roundtrip")
-s.connect()
-s.add_cell("roundtrip-cell", "code", 0)
-s.set_cell_source("roundtrip-cell", "original from python")
-s.confirm_sync()
-doc_hex = s.get_automerge_doc_bytes().hex()
-s.disconnect()
-print(json.dumps({"doc_hex": doc_hex}))
-`);
-
-    const data1 = JSON.parse(step1);
-    const docBytes1 = fromHex(data1.doc_hex);
-
-    // Step 2: WASM loads, edits via SyncEngine, exports doc bytes.
-    const serverHandle = NotebookHandle.load(docBytes1);
-    const clientHandle = NotebookHandle.load(docBytes1);
-    syncHandles(serverHandle, clientHandle);
-
-    // Client edits the cell
-    clientHandle.update_source("roundtrip-cell", "edited by WASM SyncEngine");
-
-    // Sync the edit to the server handle
-    syncHandles(clientHandle, serverHandle);
-
-    // Export the server's doc bytes (these represent what the daemon would have)
-    const updatedBytes = serverHandle.save();
-    const updatedHex = toHex(updatedBytes);
-
-    serverHandle.free();
-    clientHandle.free();
-
-    // Step 3: Python loads the WASM-edited doc bytes and verifies.
-    const step3 = await runPython(`
-import json
-from runtimed import Session
-
-doc_hex = "${updatedHex}"
-doc_bytes = bytes.fromhex(doc_hex)
-
-s = Session("integration-roundtrip-verify")
-s.connect()
-
-# Load the WASM-edited doc
-s.load_automerge_doc(doc_bytes)
-s.confirm_sync()
-
-cells = s.get_cells()
-cell = next((c for c in cells if c.id == "roundtrip-cell"), None)
-
-output = {
-    "cell_count": len(cells),
-    "source": cell.source if cell else None,
-}
-
-s.disconnect()
-print(json.dumps(output))
-`);
-
-    const data3 = JSON.parse(step3);
-    assertEquals(data3.cell_count, 1);
-    assertEquals(
-      data3.source,
-      "edited by WASM SyncEngine",
-      "Python should see the WASM edit after loading the doc bytes",
-    );
-  },
-});
+// NOTE: "Full round-trip" test removed — load_automerge_doc does not exist
+// in the current Python API. Round-trip verification (Python → WASM → Python)
+// would require a new daemon-level API to inject doc bytes.

--- a/packages/runtimed/tests/integration.test.ts
+++ b/packages/runtimed/tests/integration.test.ts
@@ -1,7 +1,7 @@
 /**
  * Integration test: SyncEngine + real daemon via Python Session.
  *
- * Proves the @nteract/runtimed library works end-to-end with a real
+ * Proves the runtimed library works end-to-end with a real
  * daemon — not just two WASM handles talking to each other. The test:
  *
  * 1. Python Session creates a notebook room in the daemon

--- a/packages/runtimed/tests/sync-engine.test.ts
+++ b/packages/runtimed/tests/sync-engine.test.ts
@@ -40,10 +40,14 @@ await init(wasmBytes);
 
 // ── Import library under test ────────────────────────────────────────
 
-import { SyncEngine } from "../src/sync-engine.ts";
+import { SyncEngine, mergeChangesets } from "../src/sync-engine.ts";
 import { DirectTransport } from "../src/direct-transport.ts";
 import { FrameType } from "../src/transport.ts";
-import type { SyncEngineEvent } from "../src/sync-engine.ts";
+import type {
+  SyncEngineEvent,
+  CoalescedCellChanges,
+  CellChangeset,
+} from "../src/sync-engine.ts";
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
@@ -736,6 +740,347 @@ Deno.test("SyncEngine: multiple scheduleFlush calls coalesce", async () => {
   server.free();
   client.free();
 });
+
+// ── mergeChangesets unit tests ───────────────────────────────────────
+
+Deno.test("mergeChangesets: empty array returns empty changeset", () => {
+  const result = mergeChangesets([]);
+  assertEquals(result.changed.length, 0);
+  assertEquals(result.added.length, 0);
+  assertEquals(result.removed.length, 0);
+  assertEquals(result.order_changed, false);
+});
+
+Deno.test("mergeChangesets: single changeset passes through", () => {
+  const cs: CellChangeset = {
+    changed: [
+      {
+        cell_id: "cell-1",
+        fields: {
+          source: true,
+          outputs: false,
+          cell_type: false,
+          execution_count: false,
+          metadata: false,
+          position: false,
+        },
+      },
+    ],
+    added: ["cell-2"],
+    removed: [],
+    order_changed: false,
+  };
+  const result = mergeChangesets([cs]);
+  assertEquals(result, cs);
+});
+
+Deno.test("mergeChangesets: merges changed fields with OR", () => {
+  const cs1: CellChangeset = {
+    changed: [
+      {
+        cell_id: "cell-1",
+        fields: {
+          source: true,
+          outputs: false,
+          cell_type: false,
+          execution_count: false,
+          metadata: false,
+          position: false,
+        },
+      },
+    ],
+    added: [],
+    removed: [],
+    order_changed: false,
+  };
+  const cs2: CellChangeset = {
+    changed: [
+      {
+        cell_id: "cell-1",
+        fields: {
+          source: false,
+          outputs: true,
+          cell_type: false,
+          execution_count: true,
+          metadata: false,
+          position: false,
+        },
+      },
+    ],
+    added: [],
+    removed: [],
+    order_changed: false,
+  };
+  const result = mergeChangesets([cs1, cs2]);
+  assertEquals(result.changed.length, 1);
+  assertEquals(result.changed[0].cell_id, "cell-1");
+  assertEquals(result.changed[0].fields.source, true);
+  assertEquals(result.changed[0].fields.outputs, true);
+  assertEquals(result.changed[0].fields.execution_count, true);
+  assertEquals(result.changed[0].fields.metadata, false);
+});
+
+Deno.test("mergeChangesets: unions added and removed sets", () => {
+  const cs1: CellChangeset = {
+    changed: [],
+    added: ["cell-a"],
+    removed: ["cell-x"],
+    order_changed: false,
+  };
+  const cs2: CellChangeset = {
+    changed: [],
+    added: ["cell-b", "cell-a"], // duplicate
+    removed: ["cell-y"],
+    order_changed: false,
+  };
+  const result = mergeChangesets([cs1, cs2]);
+  assertEquals(result.added.sort(), ["cell-a", "cell-b"]);
+  assertEquals(result.removed.sort(), ["cell-x", "cell-y"]);
+});
+
+Deno.test("mergeChangesets: ORs order_changed flag", () => {
+  const cs1: CellChangeset = {
+    changed: [],
+    added: [],
+    removed: [],
+    order_changed: false,
+  };
+  const cs2: CellChangeset = {
+    changed: [],
+    added: [],
+    removed: [],
+    order_changed: true,
+  };
+  const result = mergeChangesets([cs1, cs2]);
+  assertEquals(result.order_changed, true);
+});
+
+// ── RxJS Observable stream tests ─────────────────────────────────────
+
+Deno.test(
+  "SyncEngine: cellChanges$ coalesces rapid changes into batches",
+  async () => {
+    const server = new NotebookHandle("coalesce-rx-test");
+    server.add_cell(0, "cell-1", "code");
+
+    const client = NotebookHandle.load(server.save());
+
+    // Bootstrap sync
+    for (let i = 0; i < 10; i++) {
+      const a = server.flush_local_changes();
+      const b = client.flush_local_changes();
+      if (!a && !b) break;
+      if (a) client.receive_sync_message(a);
+      if (b) server.receive_sync_message(b);
+    }
+    client.reset_sync_state();
+    server.reset_sync_state();
+
+    const transport = new DirectTransport(server);
+    const engine = new SyncEngine(client, transport, {
+      flushDebounceMs: 5,
+      initialSyncTimeoutMs: 500,
+      coalesceMs: 50, // 50ms window for easier testing
+    });
+
+    const batches: CoalescedCellChanges[] = [];
+    const sub = engine.cellChanges$.subscribe((b) => batches.push(b));
+
+    engine.start();
+    await tick();
+    transport.pushServerChanges();
+    await tick();
+    transport.pushServerChanges();
+    await sleep(100); // wait for initial sync to settle
+
+    batches.length = 0; // clear initial sync batches
+
+    // Rapid server changes within the coalesce window
+    for (let i = 1; i <= 5; i++) {
+      server.update_source("cell-1", `v${i}`);
+      transport.pushServerChanges();
+      await tick();
+    }
+
+    // Wait for the coalesce window to close
+    await sleep(100);
+
+    // Should have gotten fewer batches than individual changes
+    assert(batches.length >= 1, "should have at least one coalesced batch");
+    assert(
+      batches.length < 5,
+      `expected coalescing to reduce 5 changes to fewer batches, got ${batches.length}`,
+    );
+
+    // Total batchSize should account for all changes
+    const totalBatchSize = batches.reduce((sum, b) => sum + b.batchSize, 0);
+    assert(
+      totalBatchSize >= 1,
+      "total batch size should reflect changes received",
+    );
+
+    sub.unsubscribe();
+    engine.stop();
+    server.free();
+    client.free();
+  },
+);
+
+Deno.test("SyncEngine: broadcasts$ delivers broadcast payloads", async () => {
+  const server = new NotebookHandle("broadcast-rx-test");
+  const client = NotebookHandle.create_empty_with_actor("test:client");
+
+  const transport = new DirectTransport(server);
+  const engine = new SyncEngine(client, transport, {
+    flushDebounceMs: 5,
+    initialSyncTimeoutMs: 500,
+  });
+
+  const payloads: unknown[] = [];
+  const sub = engine.broadcasts$.subscribe((p) => payloads.push(p));
+
+  engine.start();
+  await tick();
+
+  transport.pushBroadcast({ event: "kernel_status", status: "busy" });
+  await tick();
+  transport.pushBroadcast({ event: "execution_done", cell_id: "c1" });
+  await tick();
+
+  assert(payloads.length >= 2, `expected 2 broadcasts, got ${payloads.length}`);
+  // deno-lint-ignore no-explicit-any
+  assertEquals((payloads[0] as any).event, "kernel_status");
+  // deno-lint-ignore no-explicit-any
+  assertEquals((payloads[1] as any).event, "execution_done");
+
+  sub.unsubscribe();
+  engine.stop();
+  server.free();
+  client.free();
+});
+
+Deno.test(
+  "SyncEngine: cellChanges$ attributions are aggregated across batch",
+  async () => {
+    const server = new NotebookHandle("attrs-rx-test");
+    server.add_cell(0, "cell-1", "code");
+    server.add_cell(1, "cell-2", "code");
+
+    const client = NotebookHandle.load(server.save());
+
+    // Bootstrap
+    for (let i = 0; i < 10; i++) {
+      const a = server.flush_local_changes();
+      const b = client.flush_local_changes();
+      if (!a && !b) break;
+      if (a) client.receive_sync_message(a);
+      if (b) server.receive_sync_message(b);
+    }
+    client.reset_sync_state();
+    server.reset_sync_state();
+
+    const transport = new DirectTransport(server);
+    const engine = new SyncEngine(client, transport, {
+      flushDebounceMs: 5,
+      initialSyncTimeoutMs: 500,
+      coalesceMs: 50,
+    });
+
+    const batches: CoalescedCellChanges[] = [];
+    const sub = engine.cellChanges$.subscribe((b) => batches.push(b));
+
+    engine.start();
+    await tick();
+    transport.pushServerChanges();
+    await tick();
+    transport.pushServerChanges();
+    await sleep(100);
+
+    batches.length = 0;
+
+    // Server edits two cells rapidly
+    server.update_source("cell-1", "edit A");
+    transport.pushServerChanges();
+    await tick();
+    server.update_source("cell-2", "edit B");
+    transport.pushServerChanges();
+    await tick();
+
+    await sleep(100);
+
+    // Batches should contain attributions from both changes
+    const allAttrs = batches.flatMap((b) => b.attributions);
+    // We don't know the exact attribution format from the test transport,
+    // but we can verify the batch mechanism collected them
+    assert(batches.length >= 1, "should have at least one batch");
+
+    sub.unsubscribe();
+    engine.stop();
+    server.free();
+    client.free();
+  },
+);
+
+Deno.test(
+  "SyncEngine: cellChanges$ sets needsFull when changeset is null",
+  async () => {
+    // When the engine emits cells_changed with changeset=null (structural
+    // change like add/remove), the coalesced batch should have needsFull=true.
+    const server = new NotebookHandle("needsfull-test");
+
+    const client = NotebookHandle.load(server.save());
+
+    // Bootstrap
+    for (let i = 0; i < 10; i++) {
+      const a = server.flush_local_changes();
+      const b = client.flush_local_changes();
+      if (!a && !b) break;
+      if (a) client.receive_sync_message(a);
+      if (b) server.receive_sync_message(b);
+    }
+    client.reset_sync_state();
+    server.reset_sync_state();
+
+    const transport = new DirectTransport(server);
+    const engine = new SyncEngine(client, transport, {
+      flushDebounceMs: 5,
+      initialSyncTimeoutMs: 500,
+      coalesceMs: 50,
+    });
+
+    const batches: CoalescedCellChanges[] = [];
+    const sub = engine.cellChanges$.subscribe((b) => batches.push(b));
+
+    engine.start();
+    await tick();
+    transport.pushServerChanges();
+    await tick();
+    await sleep(100);
+
+    batches.length = 0;
+
+    // Server adds a cell (structural change — changeset should include added)
+    server.add_cell(0, "new-cell", "code");
+    server.update_source("new-cell", "hello");
+    transport.pushServerChanges();
+    await tick();
+
+    await sleep(100);
+
+    assert(batches.length >= 1, "should have received a batch");
+    // The cell addition should produce a changeset with added cells
+    const lastBatch = batches[batches.length - 1];
+    assert(
+      lastBatch.changeset === null || lastBatch.changeset.added.length > 0,
+      "structural change should show added cells or trigger needsFull",
+    );
+
+    sub.unsubscribe();
+    engine.stop();
+    server.free();
+    client.free();
+  },
+);
 
 Deno.test("SyncEngine: retry timer fires on stalled initial sync", async () => {
   // Server has content but we won't push it — simulating a lost message.

--- a/packages/runtimed/tests/sync-engine.test.ts
+++ b/packages/runtimed/tests/sync-engine.test.ts
@@ -1,7 +1,7 @@
 /**
  * Deno tests for SyncEngine + DirectTransport.
  *
- * Proves the @nteract/runtimed library works end-to-end without a browser,
+ * Proves the runtimed library works end-to-end without a browser,
  * daemon, or Tauri. Two WASM NotebookHandles sync through the SyncEngine
  * and DirectTransport.
  *

--- a/packages/runtimed/tests/sync-engine.test.ts
+++ b/packages/runtimed/tests/sync-engine.test.ts
@@ -1,0 +1,778 @@
+/**
+ * Deno tests for SyncEngine + DirectTransport.
+ *
+ * Proves the @nteract/runtimed library works end-to-end without a browser,
+ * daemon, or Tauri. Two WASM NotebookHandles sync through the SyncEngine
+ * and DirectTransport.
+ *
+ * Run with:
+ *   deno test --no-check --allow-read packages/runtimed/tests/sync-engine.test.ts
+ */
+
+import {
+  assert,
+  assertEquals,
+  assertExists,
+} from "https://deno.land/std@0.224.0/assert/mod.ts";
+
+// @ts-nocheck — wasm-bindgen output doesn't have Deno-compatible type declarations
+
+// ── WASM setup ───────────────────────────────────────────────────────
+
+// deno-lint-ignore no-explicit-any
+let NotebookHandle: any;
+
+const wasmJsPath = new URL(
+  "../../../apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.js",
+  import.meta.url,
+);
+const wasmBinPath = new URL(
+  "../../../apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm",
+  import.meta.url,
+);
+
+const mod = await import(wasmJsPath.href);
+const init = mod.default;
+NotebookHandle = mod.NotebookHandle;
+
+const wasmBytes = await Deno.readFile(wasmBinPath);
+await init(wasmBytes);
+
+// ── Import library under test ────────────────────────────────────────
+
+import { SyncEngine } from "../src/sync-engine.ts";
+import { DirectTransport } from "../src/direct-transport.ts";
+import { FrameType } from "../src/transport.ts";
+import type { SyncEngineEvent } from "../src/sync-engine.ts";
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+/** Collect events from a SyncEngine into an array. */
+function collectEvents(
+  engine: SyncEngine,
+  ...types: string[]
+): SyncEngineEvent[] {
+  const events: SyncEngineEvent[] = [];
+  for (const type of types) {
+    // deno-lint-ignore no-explicit-any
+    engine.on(type as any, (e: SyncEngineEvent) => events.push(e));
+  }
+  return events;
+}
+
+/** Wait for a specific event type, with timeout. */
+function waitForEvent(
+  engine: SyncEngine,
+  type: string,
+  timeoutMs = 2000,
+): Promise<SyncEngineEvent> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error(`Timed out waiting for '${type}' event`)),
+      timeoutMs,
+    );
+    // deno-lint-ignore no-explicit-any
+    engine.on(type as any, (e: SyncEngineEvent) => {
+      clearTimeout(timer);
+      resolve(e);
+    });
+  });
+}
+
+/** Flush microtask queue (let async callbacks fire). */
+function tick(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+/** Wait a specific number of milliseconds. */
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+Deno.test("SyncEngine: start delivers initial sync from server", async () => {
+  // Server has a notebook with a cell.
+  const server = new NotebookHandle("init-test");
+  server.add_cell(0, "cell-1", "code");
+  server.update_source("cell-1", "print('hello')");
+
+  // Client starts empty.
+  const client = NotebookHandle.create_empty_with_actor("test:client");
+
+  const transport = new DirectTransport(server);
+  const engine = new SyncEngine(client, transport, {
+    flushDebounceMs: 5,
+    initialSyncTimeoutMs: 500,
+  });
+
+  const initialSyncPromise = waitForEvent(engine, "initial_sync_complete");
+
+  engine.start();
+
+  // The engine's start() calls flushNow(), which generates a sync message
+  // from the empty client → delivered to server via transport → server replies.
+  // We need to push the server's response back.
+  await tick();
+  transport.pushServerChanges();
+  await tick();
+  transport.pushServerChanges(); // may need a second round
+  await tick();
+
+  await initialSyncPromise;
+
+  assert(engine.synced, "engine should be synced after initial sync");
+  assertEquals(client.cell_count(), 1);
+
+  const cell = client.get_cell("cell-1");
+  assertExists(cell);
+  assertEquals(cell.source, "print('hello')");
+  cell.free();
+
+  engine.stop();
+  server.free();
+  client.free();
+});
+
+Deno.test("SyncEngine: emits cells_changed on server mutations", async () => {
+  const server = new NotebookHandle("change-test");
+  server.add_cell(0, "cell-1", "code");
+  server.update_source("cell-1", "original");
+
+  const client = NotebookHandle.create_empty_with_actor("test:client");
+  const transport = new DirectTransport(server);
+  const engine = new SyncEngine(client, transport, {
+    flushDebounceMs: 5,
+    initialSyncTimeoutMs: 500,
+  });
+
+  const events = collectEvents(engine, "cells_changed");
+
+  engine.start();
+  await tick();
+  transport.pushServerChanges();
+  await tick();
+  transport.pushServerChanges();
+  await tick();
+
+  // Wait for initial sync to complete
+  await sleep(50);
+
+  // Clear events from initial sync
+  events.length = 0;
+
+  // Server makes a change
+  server.update_source("cell-1", "updated");
+  transport.pushServerChanges();
+  await tick();
+
+  assert(events.length > 0, "should have received cells_changed event");
+  assertEquals(events[0].type, "cells_changed");
+
+  const cell = client.get_cell("cell-1");
+  assertExists(cell);
+  assertEquals(cell.source, "updated");
+  cell.free();
+
+  engine.stop();
+  server.free();
+  client.free();
+});
+
+Deno.test(
+  "SyncEngine: scheduleFlush sends local changes to server",
+  async () => {
+    const server = new NotebookHandle("flush-test");
+    server.add_cell(0, "cell-1", "code");
+
+    const client = NotebookHandle.load(server.save());
+
+    // Manually sync to establish baseline
+    for (let i = 0; i < 10; i++) {
+      const a = server.flush_local_changes();
+      const b = client.flush_local_changes();
+      if (!a && !b) break;
+      if (a) client.receive_sync_message(a);
+      if (b) server.receive_sync_message(b);
+    }
+
+    // Reset sync states since SyncEngine will manage them
+    client.reset_sync_state();
+    server.reset_sync_state();
+
+    const transport = new DirectTransport(server);
+    const engine = new SyncEngine(client, transport, {
+      flushDebounceMs: 10,
+      initialSyncTimeoutMs: 500,
+    });
+
+    engine.start();
+    await tick();
+    // Push initial sync handshake
+    transport.pushServerChanges();
+    await tick();
+    transport.pushServerChanges();
+    await sleep(50);
+
+    // Client makes a local edit
+    client.update_source("cell-1", "client edit");
+    engine.scheduleFlush();
+
+    // Wait for debounce to fire (10ms + buffer)
+    await sleep(50);
+
+    // The transport should have received an AUTOMERGE_SYNC frame
+    const syncFrames = transport.sentFrames.filter(
+      (f) => f.frameType === FrameType.AUTOMERGE_SYNC,
+    );
+    assert(syncFrames.length > 0, "should have sent sync frame(s)");
+
+    // Server should now have the client's edit
+    const serverCell = server.get_cell("cell-1");
+    assertExists(serverCell);
+    assertEquals(serverCell.source, "client edit");
+    serverCell.free();
+
+    engine.stop();
+    server.free();
+    client.free();
+  },
+);
+
+Deno.test("SyncEngine: flush() sends immediately (no debounce)", async () => {
+  const server = new NotebookHandle("immediate-flush-test");
+  server.add_cell(0, "cell-1", "code");
+
+  const client = NotebookHandle.load(server.save());
+
+  // Bootstrap sync
+  for (let i = 0; i < 10; i++) {
+    const a = server.flush_local_changes();
+    const b = client.flush_local_changes();
+    if (!a && !b) break;
+    if (a) client.receive_sync_message(a);
+    if (b) server.receive_sync_message(b);
+  }
+  client.reset_sync_state();
+  server.reset_sync_state();
+
+  const transport = new DirectTransport(server);
+  const engine = new SyncEngine(client, transport, {
+    flushDebounceMs: 5000, // Long debounce — flush() should bypass it
+    initialSyncTimeoutMs: 500,
+  });
+
+  engine.start();
+  await tick();
+  transport.pushServerChanges();
+  await tick();
+  transport.pushServerChanges();
+  await sleep(50);
+
+  // Client makes a local edit
+  client.update_source("cell-1", "immediate edit");
+
+  // Flush immediately (awaits the send)
+  await engine.flush();
+
+  // Server should have the edit — no waiting for debounce
+  const serverCell = server.get_cell("cell-1");
+  assertExists(serverCell);
+  assertEquals(serverCell.source, "immediate edit");
+  serverCell.free();
+
+  engine.stop();
+  server.free();
+  client.free();
+});
+
+Deno.test(
+  "SyncEngine: rolls back sync state on transport failure",
+  async () => {
+    const server = new NotebookHandle("rollback-test");
+    server.add_cell(0, "cell-1", "code");
+
+    const client = NotebookHandle.load(server.save());
+
+    // Bootstrap sync
+    for (let i = 0; i < 10; i++) {
+      const a = server.flush_local_changes();
+      const b = client.flush_local_changes();
+      if (!a && !b) break;
+      if (a) client.receive_sync_message(a);
+      if (b) server.receive_sync_message(b);
+    }
+    client.reset_sync_state();
+    server.reset_sync_state();
+
+    const transport = new DirectTransport(server);
+    const engine = new SyncEngine(client, transport, {
+      flushDebounceMs: 5,
+      initialSyncTimeoutMs: 500,
+    });
+
+    const errors = collectEvents(engine, "error");
+
+    engine.start();
+    await tick();
+    transport.pushServerChanges();
+    await tick();
+    transport.pushServerChanges();
+    await sleep(50);
+
+    // Client makes a local edit
+    client.update_source("cell-1", "will fail to send");
+
+    // Enable failure simulation BEFORE flush
+    transport.simulateFailure = true;
+
+    // Flush — will fail, should emit error and rollback
+    try {
+      await engine.flush();
+    } catch {
+      // Expected — flush propagates the error
+    }
+
+    await tick();
+
+    // Disable failure
+    transport.simulateFailure = false;
+
+    // The rollback should allow the next flush to include the change data.
+    // Make another edit to ensure heads change.
+    client.update_source("cell-1", "will succeed this time");
+    await engine.flush();
+
+    // Server should now have the edit
+    const serverCell = server.get_cell("cell-1");
+    assertExists(serverCell);
+    assertEquals(serverCell.source, "will succeed this time");
+    serverCell.free();
+
+    engine.stop();
+    server.free();
+    client.free();
+  },
+);
+
+Deno.test(
+  "SyncEngine: inline reply rollback on send failure (#1068 review)",
+  async () => {
+    const server = new NotebookHandle("reply-rollback-test");
+    server.add_cell(0, "cell-1", "code");
+
+    const client = NotebookHandle.load(server.save());
+
+    // Bootstrap sync
+    for (let i = 0; i < 10; i++) {
+      const a = server.flush_local_changes();
+      const b = client.flush_local_changes();
+      if (!a && !b) break;
+      if (a) client.receive_sync_message(a);
+      if (b) server.receive_sync_message(b);
+    }
+    client.reset_sync_state();
+    server.reset_sync_state();
+
+    const transport = new DirectTransport(server);
+    const engine = new SyncEngine(client, transport, {
+      flushDebounceMs: 5,
+      initialSyncTimeoutMs: 500,
+    });
+
+    engine.start();
+    await tick();
+    transport.pushServerChanges();
+    await tick();
+    transport.pushServerChanges();
+    await sleep(50);
+
+    // Client makes a local edit (not yet flushed)
+    client.update_source("cell-1", "local edit");
+
+    // Simulate failure on the next sendFrame (the inline reply)
+    transport.simulateFailure = true;
+
+    // Server pushes a change — the inline reply will fail
+    server.update_source("cell-1", "server edit");
+    transport.pushServerChanges();
+    await tick();
+
+    // Re-enable sends
+    transport.simulateFailure = false;
+
+    // Server pushes another change — this time the reply should include
+    // the client's local edit (because cancel_last_flush was called on
+    // the failed reply)
+    server.update_source("cell-1", "server edit v2");
+    transport.pushServerChanges();
+    await tick();
+    transport.pushServerChanges();
+    await tick();
+
+    // Let everything settle
+    await sleep(50);
+
+    // Also flush the client's local changes explicitly
+    await engine.flush();
+    transport.pushServerChanges();
+    await tick();
+
+    // Both should converge — the client's "local edit" should be merged
+    const serverCell = server.get_cell("cell-1");
+    const clientCell = client.get_cell("cell-1");
+    assertExists(serverCell);
+    assertExists(clientCell);
+    assertEquals(
+      clientCell.source,
+      serverCell.source,
+      "client and server should converge after reply rollback recovery",
+    );
+    serverCell.free();
+    clientCell.free();
+
+    engine.stop();
+    server.free();
+    client.free();
+  },
+);
+
+Deno.test("SyncEngine: emits broadcast events", async () => {
+  const server = new NotebookHandle("broadcast-test");
+  const client = NotebookHandle.create_empty_with_actor("test:client");
+
+  const transport = new DirectTransport(server);
+  const engine = new SyncEngine(client, transport, {
+    flushDebounceMs: 5,
+    initialSyncTimeoutMs: 500,
+  });
+
+  const broadcasts = collectEvents(engine, "broadcast");
+
+  engine.start();
+  await tick();
+
+  // Push a broadcast event
+  transport.pushBroadcast({
+    event: "execution_started",
+    cell_id: "cell-1",
+    execution_count: 1,
+  });
+  await tick();
+
+  assert(broadcasts.length > 0, "should have received broadcast event");
+  assertEquals(broadcasts[0].type, "broadcast");
+  // deno-lint-ignore no-explicit-any
+  const payload = (broadcasts[0] as any).payload;
+  assertEquals(payload.event, "execution_started");
+  assertEquals(payload.cell_id, "cell-1");
+
+  engine.stop();
+  server.free();
+  client.free();
+});
+
+Deno.test("SyncEngine: sendRequest routes through transport", async () => {
+  const server = new NotebookHandle("request-test");
+  const client = NotebookHandle.create_empty_with_actor("test:client");
+
+  const transport = new DirectTransport(server);
+
+  // Mock request handler
+  transport.onRequest = (req) => {
+    // deno-lint-ignore no-explicit-any
+    const r = req as any;
+    if (r.action === "execute_cell") {
+      return {
+        result: "CellQueued",
+        cell_id: r.cell_id,
+        execution_id: "exec-123",
+      };
+    }
+    return { result: "error", error: "unknown" };
+  };
+
+  const engine = new SyncEngine(client, transport);
+  engine.start();
+  await tick();
+
+  // Send a request through the transport
+  const response = await transport.sendRequest({
+    action: "execute_cell",
+    cell_id: "cell-1",
+  });
+  // deno-lint-ignore no-explicit-any
+  const resp = response as any;
+  assertEquals(resp.result, "CellQueued");
+  assertEquals(resp.execution_id, "exec-123");
+
+  engine.stop();
+  server.free();
+  client.free();
+});
+
+Deno.test("SyncEngine: rapid server changes all arrive", async () => {
+  const server = new NotebookHandle("rapid-test");
+  server.add_cell(0, "cell-1", "code");
+
+  const client = NotebookHandle.create_empty_with_actor("test:client");
+  const transport = new DirectTransport(server);
+  const engine = new SyncEngine(client, transport, {
+    flushDebounceMs: 5,
+    initialSyncTimeoutMs: 500,
+  });
+
+  engine.start();
+  await tick();
+  transport.pushServerChanges();
+  await tick();
+  transport.pushServerChanges();
+  await sleep(50);
+
+  // Rapid server changes
+  for (let i = 1; i <= 10; i++) {
+    server.update_source("cell-1", `version ${i}`);
+    transport.pushServerChanges();
+    await tick();
+  }
+
+  // Additional sync rounds to converge
+  for (let i = 0; i < 5; i++) {
+    transport.pushServerChanges();
+    await tick();
+  }
+
+  const cell = client.get_cell("cell-1");
+  assertExists(cell);
+  assertEquals(cell.source, "version 10");
+  cell.free();
+
+  engine.stop();
+  server.free();
+  client.free();
+});
+
+Deno.test("SyncEngine: stop flushes pending changes", async () => {
+  const server = new NotebookHandle("stop-flush-test");
+  server.add_cell(0, "cell-1", "code");
+
+  const client = NotebookHandle.load(server.save());
+
+  // Bootstrap
+  for (let i = 0; i < 10; i++) {
+    const a = server.flush_local_changes();
+    const b = client.flush_local_changes();
+    if (!a && !b) break;
+    if (a) client.receive_sync_message(a);
+    if (b) server.receive_sync_message(b);
+  }
+  client.reset_sync_state();
+  server.reset_sync_state();
+
+  const transport = new DirectTransport(server);
+  const engine = new SyncEngine(client, transport, {
+    flushDebounceMs: 60000, // Very long debounce
+    initialSyncTimeoutMs: 500,
+  });
+
+  engine.start();
+  await tick();
+  transport.pushServerChanges();
+  await tick();
+  transport.pushServerChanges();
+  await sleep(50);
+
+  // Client makes a local edit
+  client.update_source("cell-1", "final edit");
+
+  // DON'T call scheduleFlush — just stop.
+  // stop() should flush pending changes.
+  engine.stop();
+
+  // Server should have the edit from the teardown flush.
+  const serverCell = server.get_cell("cell-1");
+  assertExists(serverCell);
+  assertEquals(serverCell.source, "final edit");
+  serverCell.free();
+
+  server.free();
+  client.free();
+});
+
+Deno.test("SyncEngine: concurrent edits from both sides converge", async () => {
+  const server = new NotebookHandle("concurrent-test");
+  server.add_cell(0, "cell-1", "code");
+  server.add_cell(1, "cell-2", "code");
+
+  const client = NotebookHandle.load(server.save());
+
+  // Bootstrap
+  for (let i = 0; i < 10; i++) {
+    const a = server.flush_local_changes();
+    const b = client.flush_local_changes();
+    if (!a && !b) break;
+    if (a) client.receive_sync_message(a);
+    if (b) server.receive_sync_message(b);
+  }
+  client.reset_sync_state();
+  server.reset_sync_state();
+
+  const transport = new DirectTransport(server);
+  const engine = new SyncEngine(client, transport, {
+    flushDebounceMs: 5,
+    initialSyncTimeoutMs: 500,
+  });
+
+  engine.start();
+  await tick();
+  transport.pushServerChanges();
+  await tick();
+  transport.pushServerChanges();
+  await sleep(50);
+
+  // Both sides make concurrent edits to different cells
+  client.update_source("cell-1", "from client");
+  server.update_source("cell-2", "from server");
+
+  // Flush client changes
+  await engine.flush();
+
+  // Push server changes
+  transport.pushServerChanges();
+  await tick();
+
+  // More sync rounds
+  for (let i = 0; i < 5; i++) {
+    transport.pushServerChanges();
+    await tick();
+    await engine.flush();
+    await tick();
+  }
+
+  // Both should have both edits
+  const serverCell1 = server.get_cell("cell-1");
+  const serverCell2 = server.get_cell("cell-2");
+  const clientCell1 = client.get_cell("cell-1");
+  const clientCell2 = client.get_cell("cell-2");
+
+  assertExists(serverCell1);
+  assertExists(serverCell2);
+  assertExists(clientCell1);
+  assertExists(clientCell2);
+
+  assertEquals(serverCell1.source, "from client");
+  assertEquals(serverCell2.source, "from server");
+  assertEquals(clientCell1.source, "from client");
+  assertEquals(clientCell2.source, "from server");
+
+  serverCell1.free();
+  serverCell2.free();
+  clientCell1.free();
+  clientCell2.free();
+
+  engine.stop();
+  server.free();
+  client.free();
+});
+
+Deno.test("SyncEngine: multiple scheduleFlush calls coalesce", async () => {
+  const server = new NotebookHandle("coalesce-test");
+  server.add_cell(0, "cell-1", "code");
+
+  const client = NotebookHandle.load(server.save());
+
+  // Bootstrap
+  for (let i = 0; i < 10; i++) {
+    const a = server.flush_local_changes();
+    const b = client.flush_local_changes();
+    if (!a && !b) break;
+    if (a) client.receive_sync_message(a);
+    if (b) server.receive_sync_message(b);
+  }
+  client.reset_sync_state();
+  server.reset_sync_state();
+
+  const transport = new DirectTransport(server);
+  const engine = new SyncEngine(client, transport, {
+    flushDebounceMs: 30,
+    initialSyncTimeoutMs: 500,
+  });
+
+  engine.start();
+  await tick();
+  transport.pushServerChanges();
+  await tick();
+  transport.pushServerChanges();
+  await sleep(50);
+
+  transport.clearSentFrames();
+
+  // Rapid local edits — simulating fast typing
+  for (let i = 0; i < 20; i++) {
+    client.update_source("cell-1", "x".repeat(i + 1));
+    engine.scheduleFlush();
+  }
+
+  // Wait for the debounce to fire (30ms + buffer)
+  await sleep(80);
+
+  // Should have sent far fewer sync messages than 20 edits
+  const syncFrames = transport.sentFrames.filter(
+    (f) => f.frameType === FrameType.AUTOMERGE_SYNC,
+  );
+  assert(
+    syncFrames.length < 10,
+    `Expected coalescing to reduce sends, got ${syncFrames.length}`,
+  );
+  assert(syncFrames.length >= 1, "Should have sent at least one sync message");
+
+  // Server should have the final edit
+  const serverCell = server.get_cell("cell-1");
+  assertExists(serverCell);
+  assertEquals(serverCell.source, "x".repeat(20));
+  serverCell.free();
+
+  engine.stop();
+  server.free();
+  client.free();
+});
+
+Deno.test("SyncEngine: retry timer fires on stalled initial sync", async () => {
+  // Server has content but we won't push it — simulating a lost message.
+  const server = new NotebookHandle("retry-test");
+  server.add_cell(0, "cell-1", "code");
+  server.update_source("cell-1", "delayed content");
+
+  const client = NotebookHandle.create_empty_with_actor("test:client");
+  const transport = new DirectTransport(server);
+
+  const engine = new SyncEngine(client, transport, {
+    flushDebounceMs: 5,
+    initialSyncTimeoutMs: 200, // Short timeout for test
+  });
+
+  const retryEvents = collectEvents(engine, "sync_retry");
+
+  engine.start();
+  await tick();
+
+  // Don't push server changes — simulate lost initial sync.
+  // Wait for the retry timer to fire.
+  await sleep(350);
+
+  assert(retryEvents.length >= 1, "should have retried at least once");
+
+  // Now push server changes — should complete initial sync.
+  transport.pushServerChanges();
+  await tick();
+  transport.pushServerChanges();
+  await tick();
+  await sleep(50);
+
+  assert(engine.synced, "should be synced after retry succeeded");
+  assertEquals(client.cell_count(), 1);
+
+  engine.stop();
+  server.free();
+  client.free();
+});

--- a/packages/runtimed/tsconfig.json
+++ b/packages/runtimed/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "strict": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "noUncheckedSideEffectImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "exactOptionalPropertyTypes": false
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -288,9 +288,6 @@ importers:
       '@dnd-kit/utilities':
         specifier: ^3.2.2
         version: 3.2.2(react@19.2.4)
-      '@nteract/runtimed':
-        specifier: workspace:*
-        version: link:../../packages/runtimed
       '@tauri-apps/api':
         specifier: ^2.10.1
         version: 2.10.1
@@ -357,6 +354,9 @@ importers:
       remark-math:
         specifier: ^6.0.0
         version: 6.0.0
+      runtimed:
+        specifier: workspace:*
+        version: link:../../packages/runtimed
       rxjs:
         specifier: ^7.8.2
         version: 7.8.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -393,6 +393,10 @@ importers:
         version: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)
 
   packages/runtimed:
+    dependencies:
+      rxjs:
+        specifier: ^7.8.0
+        version: 7.8.2
     devDependencies:
       typescript:
         specifier: ^5.8.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -288,6 +288,9 @@ importers:
       '@dnd-kit/utilities':
         specifier: ^3.2.2
         version: 3.2.2(react@19.2.4)
+      '@nteract/runtimed':
+        specifier: workspace:*
+        version: link:../../packages/runtimed
       '@tauri-apps/api':
         specifier: ^2.10.1
         version: 2.10.1
@@ -388,6 +391,12 @@ importers:
       vite:
         specifier: ^6.3.5
         version: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)
+
+  packages/runtimed:
+    devDependencies:
+      typescript:
+        specifier: ^5.8.0
+        version: 5.8.3
 
 packages:
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 packages:
   - apps/*
+  - packages/*
 
 onlyBuiltDependencies:
-  - '@fortawesome/fontawesome-free'
+  - "@fortawesome/fontawesome-free"
   - esbuild


### PR DESCRIPTION
## `runtimed` JavaScript bindings package

Transport-agnostic notebook client library extracted from the frontend. Any consumer (web app, VS Code extension, CLI, agent) can sync with the daemon without Tauri or React dependencies.

### Package: `packages/runtimed`

- **`SyncEngine`** — owns all sync state, replaces inline frame-pipeline logic:
  - Inbound frame processing (WASM demux → inline reply → events)
  - Debounced flush of local CRDT mutations with auto-rollback on failure
  - Initial sync handshake with retry
  - Runtime state doc sync + execution lifecycle diffing
  - RxJS streams: `cellChanges$`, `broadcasts$`, `presence$`, `runtimeState$`, `executionTransitions$`
- **`NotebookTransport` interface** — pluggable connection layer
- **`TauriTransport`** — Tauri IPC implementation (lives in app, not package)
- **`DirectTransport`** — for testing without browser/Tauri
- **`SyncableHandle` interface** — minimal WASM handle contract
- **Runtime state types** — `RuntimeState`, `ExecutionState`, `ExecutionTransition`, `diffExecutions()`

### Frontend integration

- [x] `useAutomergeNotebook.ts` wired to `SyncEngine` + `TauriTransport`
- [x] React strict mode safety (handle getter pattern)
- [x] Initial sync completion via cell_count + reply detection
- [x] Async output materialization with blob resolution
- [x] RxJS coalesced cell changes (32ms buffer, merged changesets)
- [x] Per-cell incremental materialization (source-safe, no CodeMirror conflicts)
- [x] Presence event routing
- [x] RuntimeStateDoc flush on start (enables queue/kernel state sync)
- [x] Execution lifecycle transitions emitted from engine (no consumer diffing needed)

### Tests

- 22 unit tests (SyncEngine lifecycle, debouncing, rollback, RxJS streams, mergeChangesets)
- 7 integration tests against real daemon (Python → WASM round-trips)
- 123 WASM tests pass

### Design

```
┌─────────────────────────────────┐
│  packages/runtimed              │  ← Transport-agnostic library
│  ├── SyncEngine                 │     Owns sync state, emits events
│  ├── NotebookTransport          │     Interface: sendFrame, onFrame
│  ├── DirectTransport            │     For tests
│  └── Runtime state types        │     Typed execution lifecycle
└─────────────────────────────────┘
         ▲                  ▲
         │                  │
┌────────┴───────┐  ┌──────┴──────────┐
│ TauriTransport │  │ WebSocketTransport│  ← Future
│ (app-side)     │  │ (web app)        │
└────────────────┘  └─────────────────┘
```

### What's next

- [ ] Move materialization + output resolution into the package
- [ ] Move cell changeset types + merge utility
- [ ] Typed broadcast events (currently `unknown`)
- [ ] Public API stabilization