### PR TITLE
fix: initiate RuntimeStateDoc sync during bootstrap to prevent kernel status stuck on not_started

### DIFF
--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -114,6 +114,7 @@ export function useAutomergeNotebook() {
     if (stateMsg) {
       sendFrame(frame_types.RUNTIME_STATE_SYNC, stateMsg).catch(
         (e: unknown) => {
+          handle.cancel_last_runtime_state_flush();
           logger.warn(
             "[automerge-notebook] runtime state sync to relay failed:",
             e,

--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -105,6 +105,22 @@ export function useAutomergeNotebook() {
         logger.warn("[automerge-notebook] sync to relay failed:", e);
       });
     }
+
+    // Also initiate RuntimeStateDoc sync so the daemon sends kernel status,
+    // trust state, etc. Without this, if the daemon's initial RuntimeStateSync
+    // frame arrived before the WASM handle was ready, the frontend would stay
+    // stuck on "not_started" with no way to recover (#runtime-state-race).
+    const stateMsg = handle.flush_runtime_state_sync();
+    if (stateMsg) {
+      sendFrame(frame_types.RUNTIME_STATE_SYNC, stateMsg).catch(
+        (e: unknown) => {
+          logger.warn(
+            "[automerge-notebook] runtime state sync to relay failed:",
+            e,
+          );
+        },
+      );
+    }
   }, []);
 
   /** Sync re-read cells from WASM (cache-only, no blob fetches). */

--- a/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.d.ts
+++ b/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.d.ts
@@ -90,6 +90,16 @@ export class NotebookHandle {
      */
     cancel_last_flush(): void;
     /**
+     * Roll back runtime-state sync state after a failed
+     * `flush_runtime_state_sync()` delivery.
+     *
+     * Mirrors `cancel_last_flush()` for the notebook doc: clears
+     * `in_flight` and `sent_hashes` on `state_sync_state` so the next
+     * `flush_runtime_state_sync()` or `generate_runtime_state_sync_reply()`
+     * produces a message instead of returning `None`.
+     */
+    cancel_last_runtime_state_flush(): void;
+    /**
      * Get the number of cells in the document.
      */
     cell_count(): number;
@@ -167,6 +177,10 @@ export class NotebookHandle {
      * Without this, if the daemon's initial `RuntimeStateSync` frame arrives
      * before the WASM handle is ready, the kernel status is never synced
      * and the frontend stays stuck on "not_started".
+     *
+     * If the returned message cannot be delivered, the caller MUST call
+     * `cancel_last_runtime_state_flush()` to prevent `sent_hashes` from
+     * permanently filtering out the undelivered state data.
      */
     flush_runtime_state_sync(): Uint8Array | undefined;
     /**
@@ -540,6 +554,7 @@ export interface InitOutput {
     readonly notebookhandle_receive_sync_message: (a: number, b: number, c: number, d: number) => void;
     readonly notebookhandle_save: (a: number, b: number) => void;
     readonly notebookhandle_flush_runtime_state_sync: (a: number, b: number) => void;
+    readonly notebookhandle_cancel_last_runtime_state_flush: (a: number) => void;
     readonly notebookhandle_get_runtime_state: (a: number) => number;
     readonly notebookhandle_reset_sync_state: (a: number) => void;
     readonly notebookhandle_receive_frame: (a: number, b: number, c: number) => number;

--- a/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.d.ts
+++ b/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.d.ts
@@ -160,6 +160,16 @@ export class NotebookHandle {
      */
     flush_local_changes(): Uint8Array | undefined;
     /**
+     * Generate an initial RuntimeStateDoc sync message.
+     *
+     * Call this during bootstrap (alongside `flush_local_changes` for the
+     * notebook doc) so the daemon knows we need the full RuntimeStateDoc.
+     * Without this, if the daemon's initial `RuntimeStateSync` frame arrives
+     * before the WASM handle is ready, the kernel status is never synced
+     * and the frontend stays stuck on "not_started".
+     */
+    flush_runtime_state_sync(): Uint8Array | undefined;
+    /**
      * Generate a sync reply for the RuntimeStateDoc.
      * Called immediately after each `RuntimeStateSyncApplied` event
      * so the daemon knows which state the client has received.
@@ -529,7 +539,7 @@ export interface InitOutput {
     readonly notebookhandle_cancel_last_flush: (a: number) => void;
     readonly notebookhandle_receive_sync_message: (a: number, b: number, c: number, d: number) => void;
     readonly notebookhandle_save: (a: number, b: number) => void;
-    readonly notebookhandle_generate_runtime_state_sync_reply: (a: number, b: number) => void;
+    readonly notebookhandle_flush_runtime_state_sync: (a: number, b: number) => void;
     readonly notebookhandle_get_runtime_state: (a: number) => number;
     readonly notebookhandle_reset_sync_state: (a: number) => void;
     readonly notebookhandle_receive_frame: (a: number, b: number, c: number) => number;
@@ -537,6 +547,7 @@ export interface InitOutput {
     readonly encode_selection_presence: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number, i: number) => void;
     readonly encode_focus_presence: (a: number, b: number, c: number, d: number, e: number) => void;
     readonly encode_clear_channel_presence: (a: number, b: number, c: number, d: number, e: number) => void;
+    readonly notebookhandle_generate_runtime_state_sync_reply: (a: number, b: number) => void;
     readonly __wbindgen_export: (a: number, b: number) => number;
     readonly __wbindgen_export2: (a: number, b: number, c: number, d: number) => number;
     readonly __wbindgen_export3: (a: number) => void;

--- a/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.js
+++ b/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.js
@@ -364,6 +364,18 @@ export class NotebookHandle {
         wasm.notebookhandle_cancel_last_flush(this.__wbg_ptr);
     }
     /**
+     * Roll back runtime-state sync state after a failed
+     * `flush_runtime_state_sync()` delivery.
+     *
+     * Mirrors `cancel_last_flush()` for the notebook doc: clears
+     * `in_flight` and `sent_hashes` on `state_sync_state` so the next
+     * `flush_runtime_state_sync()` or `generate_runtime_state_sync_reply()`
+     * produces a message instead of returning `None`.
+     */
+    cancel_last_runtime_state_flush() {
+        wasm.notebookhandle_cancel_last_runtime_state_flush(this.__wbg_ptr);
+    }
+    /**
      * Get the number of cells in the document.
      * @returns {number}
      */
@@ -579,6 +591,10 @@ export class NotebookHandle {
      * Without this, if the daemon's initial `RuntimeStateSync` frame arrives
      * before the WASM handle is ready, the kernel status is never synced
      * and the frontend stays stuck on "not_started".
+     *
+     * If the returned message cannot be delivered, the caller MUST call
+     * `cancel_last_runtime_state_flush()` to prevent `sent_hashes` from
+     * permanently filtering out the undelivered state data.
      * @returns {Uint8Array | undefined}
      */
     flush_runtime_state_sync() {

--- a/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.js
+++ b/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.js
@@ -572,6 +572,32 @@ export class NotebookHandle {
         }
     }
     /**
+     * Generate an initial RuntimeStateDoc sync message.
+     *
+     * Call this during bootstrap (alongside `flush_local_changes` for the
+     * notebook doc) so the daemon knows we need the full RuntimeStateDoc.
+     * Without this, if the daemon's initial `RuntimeStateSync` frame arrives
+     * before the WASM handle is ready, the kernel status is never synced
+     * and the frontend stays stuck on "not_started".
+     * @returns {Uint8Array | undefined}
+     */
+    flush_runtime_state_sync() {
+        try {
+            const retptr = wasm.__wbindgen_add_to_stack_pointer(-16);
+            wasm.notebookhandle_flush_runtime_state_sync(retptr, this.__wbg_ptr);
+            var r0 = getDataViewMemory0().getInt32(retptr + 4 * 0, true);
+            var r1 = getDataViewMemory0().getInt32(retptr + 4 * 1, true);
+            let v1;
+            if (r0 !== 0) {
+                v1 = getArrayU8FromWasm0(r0, r1).slice();
+                wasm.__wbindgen_export4(r0, r1 * 1, 1);
+            }
+            return v1;
+        } finally {
+            wasm.__wbindgen_add_to_stack_pointer(16);
+        }
+    }
+    /**
      * Generate a sync reply for the RuntimeStateDoc.
      * Called immediately after each `RuntimeStateSyncApplied` event
      * so the daemon knows which state the client has received.

--- a/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm
+++ b/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:404e2184a981b11e724ed0a51d188b3c5c1553c03f25cab9388af7c20c8434ba
-size 1613063
+oid sha256:a10cf92caca30ba1996c0e48ac430085b387a0d8d08da3a81244442535de0f38
+size 1613225

--- a/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm
+++ b/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:68eddb9a5b6a05c976f2bde2575bd6e1c1f71c151604f6dd313a5a29d22eca49
-size 1613020
+oid sha256:404e2184a981b11e724ed0a51d188b3c5c1553c03f25cab9388af7c20c8434ba
+size 1613063

--- a/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm.d.ts
+++ b/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm.d.ts
@@ -71,7 +71,7 @@ export const notebookhandle_flush_local_changes: (a: number, b: number) => void;
 export const notebookhandle_cancel_last_flush: (a: number) => void;
 export const notebookhandle_receive_sync_message: (a: number, b: number, c: number, d: number) => void;
 export const notebookhandle_save: (a: number, b: number) => void;
-export const notebookhandle_generate_runtime_state_sync_reply: (a: number, b: number) => void;
+export const notebookhandle_flush_runtime_state_sync: (a: number, b: number) => void;
 export const notebookhandle_get_runtime_state: (a: number) => number;
 export const notebookhandle_reset_sync_state: (a: number) => void;
 export const notebookhandle_receive_frame: (a: number, b: number, c: number) => number;
@@ -79,6 +79,7 @@ export const encode_cursor_presence: (a: number, b: number, c: number, d: number
 export const encode_selection_presence: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number, i: number) => void;
 export const encode_focus_presence: (a: number, b: number, c: number, d: number, e: number) => void;
 export const encode_clear_channel_presence: (a: number, b: number, c: number, d: number, e: number) => void;
+export const notebookhandle_generate_runtime_state_sync_reply: (a: number, b: number) => void;
 export const __wbindgen_export: (a: number, b: number) => number;
 export const __wbindgen_export2: (a: number, b: number, c: number, d: number) => number;
 export const __wbindgen_export3: (a: number) => void;

--- a/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm.d.ts
+++ b/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm.d.ts
@@ -72,6 +72,7 @@ export const notebookhandle_cancel_last_flush: (a: number) => void;
 export const notebookhandle_receive_sync_message: (a: number, b: number, c: number, d: number) => void;
 export const notebookhandle_save: (a: number, b: number) => void;
 export const notebookhandle_flush_runtime_state_sync: (a: number, b: number) => void;
+export const notebookhandle_cancel_last_runtime_state_flush: (a: number) => void;
 export const notebookhandle_get_runtime_state: (a: number) => number;
 export const notebookhandle_reset_sync_state: (a: number) => void;
 export const notebookhandle_receive_frame: (a: number, b: number, c: number) => number;

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -864,10 +864,26 @@ impl NotebookHandle {
     /// Without this, if the daemon's initial `RuntimeStateSync` frame arrives
     /// before the WASM handle is ready, the kernel status is never synced
     /// and the frontend stays stuck on "not_started".
+    ///
+    /// If the returned message cannot be delivered, the caller MUST call
+    /// `cancel_last_runtime_state_flush()` to prevent `sent_hashes` from
+    /// permanently filtering out the undelivered state data.
     pub fn flush_runtime_state_sync(&mut self) -> Option<Vec<u8>> {
         self.state_doc
             .generate_sync_message(&mut self.state_sync_state)
             .map(|msg| msg.encode())
+    }
+
+    /// Roll back runtime-state sync state after a failed
+    /// `flush_runtime_state_sync()` delivery.
+    ///
+    /// Mirrors `cancel_last_flush()` for the notebook doc: clears
+    /// `in_flight` and `sent_hashes` on `state_sync_state` so the next
+    /// `flush_runtime_state_sync()` or `generate_runtime_state_sync_reply()`
+    /// produces a message instead of returning `None`.
+    pub fn cancel_last_runtime_state_flush(&mut self) {
+        self.state_sync_state.in_flight = false;
+        self.state_sync_state.sent_hashes.clear();
     }
 
     /// Read the current runtime state snapshot from the WASM doc.

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -857,6 +857,19 @@ impl NotebookHandle {
             .map(|msg| msg.encode())
     }
 
+    /// Generate an initial RuntimeStateDoc sync message.
+    ///
+    /// Call this during bootstrap (alongside `flush_local_changes` for the
+    /// notebook doc) so the daemon knows we need the full RuntimeStateDoc.
+    /// Without this, if the daemon's initial `RuntimeStateSync` frame arrives
+    /// before the WASM handle is ready, the kernel status is never synced
+    /// and the frontend stays stuck on "not_started".
+    pub fn flush_runtime_state_sync(&mut self) -> Option<Vec<u8>> {
+        self.state_doc
+            .generate_sync_message(&mut self.state_sync_state)
+            .map(|msg| msg.encode())
+    }
+
     /// Read the current runtime state snapshot from the WASM doc.
     pub fn get_runtime_state(&self) -> JsValue {
         let state = self.state_doc.read_state();

--- a/crates/runtimed-wasm/tests/deno_smoke_test.ts
+++ b/crates/runtimed-wasm/tests/deno_smoke_test.ts
@@ -1072,6 +1072,106 @@ Deno.test(
   },
 );
 
+// ── Regression tests: #1074 — RuntimeStateDoc sync race ──────────────
+
+Deno.test(
+  "Fix #1074: flush_runtime_state_sync produces initial message from fresh handle",
+  () => {
+    // A freshly-created handle has an empty RuntimeStateDoc.
+    // flush_runtime_state_sync() should produce a sync message so the
+    // daemon knows we need the full state (kernel status, trust, etc.).
+    const handle = NotebookHandle.create_empty_with_actor("test:bootstrap");
+
+    const msg = handle.flush_runtime_state_sync();
+    assert(
+      msg !== undefined,
+      "flush_runtime_state_sync should produce a message from a fresh handle",
+    );
+
+    // Calling again without receiving anything — in_flight blocks it
+    const msg2 = handle.flush_runtime_state_sync();
+    assertEquals(
+      msg2,
+      undefined,
+      "second flush should return undefined (in_flight)",
+    );
+
+    handle.free();
+  },
+);
+
+Deno.test(
+  "Fix #1074: cancel_last_runtime_state_flush recovers from failed send",
+  () => {
+    // Mirrors the cancel_last_flush test from #1068 but for state_sync_state.
+    // If the RUNTIME_STATE_SYNC send fails, cancel clears in_flight and
+    // sent_hashes so the next flush produces a fresh message.
+    const handle = NotebookHandle.create_empty_with_actor("test:cancel");
+
+    // First flush — generates a message (advances state_sync_state)
+    const msg1 = handle.flush_runtime_state_sync();
+    assert(msg1 !== undefined, "first flush should produce a message");
+
+    // Simulate delivery failure — message is DROPPED
+    // Call cancel to roll back state_sync_state
+    handle.cancel_last_runtime_state_flush();
+
+    // Now flush again — should produce a NEW message
+    const msg2 = handle.flush_runtime_state_sync();
+    assert(
+      msg2 !== undefined,
+      "after cancel_last_runtime_state_flush, flush should produce a message",
+    );
+
+    handle.free();
+  },
+);
+
+Deno.test(
+  "Fix #1074: WITHOUT cancel, dropped RuntimeStateSync stalls (documents danger)",
+  () => {
+    // Documents the dangerous behavior: if cancel_last_runtime_state_flush
+    // is NOT called after a failed send, state_sync_state retains stale
+    // in_flight/sent_hashes and subsequent flushes return undefined.
+    const handle = NotebookHandle.create_empty_with_actor("test:no-cancel");
+
+    // First flush — advances state_sync_state
+    const msg1 = handle.flush_runtime_state_sync();
+    assert(msg1 !== undefined);
+
+    // Simulate delivery failure — DELIBERATELY do NOT cancel
+    // in_flight is now true, blocking future flushes
+
+    const msg2 = handle.flush_runtime_state_sync();
+    assertEquals(
+      msg2,
+      undefined,
+      "without cancel, in_flight blocks the next flush",
+    );
+
+    // Even generate_runtime_state_sync_reply is affected (same sync state)
+    // because in_flight prevents message generation.
+    // The only recovery without cancel is reset_sync_state.
+    if (msg2 === undefined) {
+      console.warn(
+        "CONFIRMED: without cancel_last_runtime_state_flush on dropped " +
+          "RuntimeStateSync, subsequent flushes return undefined. " +
+          "Kernel status stays stuck at not_started until page reload.",
+      );
+    }
+
+    // Nuclear recovery always works
+    handle.reset_sync_state();
+    const msg3 = handle.flush_runtime_state_sync();
+    assert(
+      msg3 !== undefined,
+      "reset_sync_state must always recover RuntimeStateDoc sync",
+    );
+
+    handle.free();
+  },
+);
+
 Deno.test("Sync: source edit character-level merge", () => {
   const server = new NotebookHandle("sync-test");
   server.add_cell(0, "cell-1", "code");


### PR DESCRIPTION
# Fix: RuntimeStateDoc sync race on notebook open

## Problem

When opening a notebook, the daemon correctly auto-launches the kernel (`runt-nightly ps` shows it as `idle`), but the frontend stays stuck showing "not started" — sometimes indefinitely, until the user manually runs a cell.

## Root Cause

There's a race condition in the frontend's `RuntimeStateDoc` sync:

1. **Tauri backend** connects to the daemon, relay starts forwarding frames
2. **Daemon** immediately sends initial `AutomergeSync` + `RuntimeStateSync` frames (containing kernel status)
3. **Frontend** is still loading WASM (`await wasmReady` in bootstrap)
4. Frames arrive at the frame pipeline but `getHandle()` returns `null` → **frames silently dropped**
5. WASM loads, bootstrap creates handle, `syncToRelay()` sends `AUTOMERGE_SYNC`
6. Daemon replies with all cells → **cells appear** ✅
7. **No one re-requests `RuntimeStateSync`** → kernel status stuck at `"not_started"` forever ❌

The notebook doc recovers because `syncToRelay()` sends a fresh `AUTOMERGE_SYNC` message (telling the daemon "I have nothing"), which prompts the daemon to reply with everything. But there was **no equivalent for the `RuntimeStateDoc`**.

## Fix

- **`crates/runtimed-wasm/src/lib.rs`** — Add `flush_runtime_state_sync()` to the WASM `NotebookHandle`. Generates an initial Automerge sync message for the `RuntimeStateDoc` (saying "I have nothing, send me everything").

- **`apps/notebook/src/hooks/useAutomergeNotebook.ts`** — Call `flush_runtime_state_sync()` in `syncToRelay()` alongside the existing `flush_local_changes()`, sending the result as a `RUNTIME_STATE_SYNC` frame. This ensures the daemon sends back the full kernel status, trust state, queue state, etc., even if the initial frame was missed.

The retry path (`retrySyncToRelay`) also benefits since it calls `reset_sync_state()` (which resets both doc and state sync states) followed by `syncToRelay()`.

## Testing

- Verified `runt-nightly ps` confirms daemon auto-launches kernels correctly
- `runt-nightly diagnostics` shows daemon is healthy
- WASM rebuilt with `wasm-pack build` — new method appears in generated `.js`, `.d.ts`, and `.wasm`
- No TypeScript or Rust diagnostics