### PR TITLE
feat(runtimed): expose get_automerge_doc_bytes and confirm_sync on Session

### DIFF
--- a/crates/runtimed-py/src/async_session.rs
+++ b/crates/runtimed-py/src/async_session.rs
@@ -1164,19 +1164,15 @@ impl AsyncSession {
     /// Get the raw Automerge document bytes from the local replica.
     fn get_automerge_doc_bytes<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let state = Arc::clone(&self.state);
-        future_into_py(
-            py,
-            async move { session_core::get_automerge_doc_bytes(&state).await },
-        )
+        future_into_py(py, async move {
+            session_core::get_automerge_doc_bytes(&state).await
+        })
     }
 
     /// Confirm that the daemon has merged all local changes.
     fn confirm_sync<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let state = Arc::clone(&self.state);
-        future_into_py(
-            py,
-            async move { session_core::confirm_sync(&state).await },
-        )
+        future_into_py(py, async move { session_core::confirm_sync(&state).await })
     }
 
     // =========================================================================

--- a/crates/runtimed-py/src/async_session.rs
+++ b/crates/runtimed-py/src/async_session.rs
@@ -1158,6 +1158,28 @@ impl AsyncSession {
     }
 
     // =========================================================================
+    // Low-level sync (for testing / cross-impl verification)
+    // =========================================================================
+
+    /// Get the raw Automerge document bytes from the local replica.
+    fn get_automerge_doc_bytes<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let state = Arc::clone(&self.state);
+        future_into_py(
+            py,
+            async move { session_core::get_automerge_doc_bytes(&state).await },
+        )
+    }
+
+    /// Confirm that the daemon has merged all local changes.
+    fn confirm_sync<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let state = Arc::clone(&self.state);
+        future_into_py(
+            py,
+            async move { session_core::confirm_sync(&state).await },
+        )
+    }
+
+    // =========================================================================
     // Synchronous reads (for Python wrapper's sync properties)
     // =========================================================================
     // These use blocking_lock() to read directly from the local Automerge

--- a/crates/runtimed-py/src/session.rs
+++ b/crates/runtimed-py/src/session.rs
@@ -942,6 +942,34 @@ impl Session {
     }
 
     // =========================================================================
+    // Low-level sync (for testing / cross-impl verification)
+    // =========================================================================
+
+    /// Get the raw Automerge document bytes from the local replica.
+    ///
+    /// Returns the full serialized document as `bytes`. Useful for
+    /// cross-implementation testing (e.g., loading WASM-side).
+    fn get_automerge_doc_bytes<'py>(
+        &self,
+        py: Python<'py>,
+    ) -> PyResult<Bound<'py, pyo3::types::PyBytes>> {
+        let bytes = self
+            .runtime
+            .block_on(session_core::get_automerge_doc_bytes(&self.state))?;
+        Ok(pyo3::types::PyBytes::new(py, &bytes))
+    }
+
+    /// Confirm that the daemon has merged all local changes.
+    ///
+    /// Blocks until the daemon acknowledges our local heads. Called
+    /// internally by execute_cell, but exposed for tests that need
+    /// an explicit sync barrier.
+    fn confirm_sync(&self) -> PyResult<()> {
+        self.runtime
+            .block_on(session_core::confirm_sync(&self.state))
+    }
+
+    // =========================================================================
     // Repr, context manager, close
     // =========================================================================
 

--- a/crates/runtimed-py/src/session_core.rs
+++ b/crates/runtimed-py/src/session_core.rs
@@ -1615,9 +1615,7 @@ pub(crate) async fn get_metadata(
 /// Calls `doc.save()` on the underlying `AutoCommit`, returning the full
 /// serialized Automerge document. Useful for cross-implementation
 /// compatibility testing (e.g., loading the bytes in WASM).
-pub(crate) async fn get_automerge_doc_bytes(
-    state: &Arc<Mutex<SessionState>>,
-) -> PyResult<Vec<u8>> {
+pub(crate) async fn get_automerge_doc_bytes(state: &Arc<Mutex<SessionState>>) -> PyResult<Vec<u8>> {
     let st = state.lock().await;
     let handle = st
         .handle

--- a/crates/runtimed-py/src/session_core.rs
+++ b/crates/runtimed-py/src/session_core.rs
@@ -1606,6 +1606,42 @@ pub(crate) async fn get_metadata(
     Ok(handle.get_metadata_string(key))
 }
 
+// =========================================================================
+// Low-level sync (for testing / cross-impl verification)
+// =========================================================================
+
+/// Export the raw Automerge document bytes from the local replica.
+///
+/// Calls `doc.save()` on the underlying `AutoCommit`, returning the full
+/// serialized Automerge document. Useful for cross-implementation
+/// compatibility testing (e.g., loading the bytes in WASM).
+pub(crate) async fn get_automerge_doc_bytes(
+    state: &Arc<Mutex<SessionState>>,
+) -> PyResult<Vec<u8>> {
+    let st = state.lock().await;
+    let handle = st
+        .handle
+        .as_ref()
+        .ok_or_else(|| to_py_err("Not connected"))?;
+
+    handle.with_doc(|doc| doc.save()).map_err(to_py_err)
+}
+
+/// Confirm that the daemon has merged all local changes.
+///
+/// Blocks until the daemon's shared_heads include our local heads,
+/// ensuring the daemon sees all local mutations (cell creates, source
+/// updates, etc.) before proceeding.
+pub(crate) async fn confirm_sync(state: &Arc<Mutex<SessionState>>) -> PyResult<()> {
+    let st = state.lock().await;
+    let handle = st
+        .handle
+        .as_ref()
+        .ok_or_else(|| to_py_err("Not connected"))?;
+
+    handle.confirm_sync().await.map_err(to_py_err)
+}
+
 /// Save the notebook to disk.
 /// Result of a save operation, containing the saved path and optionally
 /// a new notebook_id if the daemon re-keyed the room (ephemeral → file-path).

--- a/crates/runtimed-wasm/tests/cross_impl_test.ts
+++ b/crates/runtimed-wasm/tests/cross_impl_test.ts
@@ -169,10 +169,10 @@ Deno.test({
     // Baseline: prove the Python Session (Rust automerge) works end-to-end
     const result = await runPython(`
 import json
-from runtimed import Session
+from runtimed.runtimed import NativeClient
 
-s = Session("cross-baseline")
-s.connect()
+c = NativeClient()
+s = c.join_notebook("cross-baseline")
 s.start_kernel(kernel_type="python", env_source="auto")
 
 cell_id = s.create_cell('print("baseline")', cell_type="code")
@@ -210,10 +210,10 @@ Deno.test({
     // create its own cell and check the round-trip
     const result = await runPython(`
 import json
-from runtimed import Session
+from runtimed.runtimed import NativeClient
 
-s = Session("wasm-compat-check")
-s.connect()
+c = NativeClient()
+s = c.join_notebook("wasm-compat-check")
 
 # Create a cell via Rust automerge
 cell_id = s.create_cell("x = 42", cell_type="code")
@@ -246,10 +246,10 @@ Deno.test({
     // and modify a doc that was produced by saving a Rust-created doc.
     const result = await runPython(`
 import json
-from runtimed import Session
+from runtimed.runtimed import NativeClient
 
-s = Session("cross-exec")
-s.connect()
+c = NativeClient()
+s = c.join_notebook("cross-exec")
 s.start_kernel(kernel_type="python", env_source="auto")
 
 cell_id = s.create_cell('print("cross-impl verified!")', cell_type="code")
@@ -290,17 +290,17 @@ Deno.test({
     // the Rust-side doc will contain cells our WASM can read.
     const result = await runPython(`
 import json, time
-from runtimed import Session
+from runtimed.runtimed import NativeClient
+
+c = NativeClient()
 
 # First session creates cells
-s1 = Session("multi-peer-test")
-s1.connect()
+s1 = c.join_notebook("multi-peer-test")
 
 cell1 = s1.create_cell("# cell from peer 1", cell_type="code")
 
 # Second session joins the same room
-s2 = Session("multi-peer-test")
-s2.connect()
+s2 = c.join_notebook("multi-peer-test")
 
 # Give sync a moment
 time.sleep(0.5)
@@ -338,5 +338,38 @@ print(json.dumps({
 
     // Same cell IDs on both sides
     assertEquals(parsed.s1_ids.sort(), parsed.s2_ids.sort());
+  },
+});
+
+Deno.test({
+  name: "Cross-impl: WASM can load doc bytes exported from Python Session via daemon",
+  ignore: !hasDaemon,
+  fn: async () => {
+    // Python creates a cell via the daemon (Rust automerge), confirms sync,
+    // and exports the raw Automerge doc bytes. WASM loads those bytes and
+    // verifies byte-level compatibility.
+    const docHex = await runPython(`
+from runtimed.runtimed import NativeClient
+
+c = NativeClient()
+s = c.join_notebook("export-bytes-test")
+cell_id = s.create_cell("x = 42", cell_type="code")
+s.confirm_sync()
+doc_bytes = s.get_automerge_doc_bytes()
+print(doc_bytes.hex())
+`);
+
+    const docBytes = fromHex(docHex);
+    assert(docBytes.length > 0, "doc bytes should be non-empty");
+
+    const handle = NotebookHandle.load(docBytes);
+    assertEquals(handle.cell_count(), 1);
+
+    const cells = handle.get_cells();
+    assertEquals(cells[0].source, "x = 42");
+    assertEquals(cells[0].cell_type, "code");
+
+    for (const c of cells) c.free();
+    handle.free();
   },
 });


### PR DESCRIPTION
## Summary

- Adds `get_automerge_doc_bytes()` and `confirm_sync()` to `Session` and `AsyncSession` for WASM cross-implementation testing
- Updates `cross_impl_test.ts` to use `NativeClient().join_notebook()` instead of the non-existent `Session("id")` constructor
- Adds a new cross-impl test that exports daemon doc bytes from Python and loads them in WASM

Session remains **out of `__all__`** — no public API surface change.

## Test plan

- [x] `cargo check -p runtimed-py` passes
- [x] `cargo xtask lint` passes (pre-existing warnings only)
- [ ] Smoke test with running daemon:
  ```python
  from runtimed.runtimed import NativeClient
  c = NativeClient()
  s = c.join_notebook("test-room")
  s.create_cell(source="print(42)", cell_type="code")
  s.confirm_sync()
  print(len(s.get_automerge_doc_bytes()))
  ```
- [ ] `deno test` cross_impl_test.ts with daemon running