### PR TITLE
revert: remove handle reuse from bootstrap, keep transaction ordering fix only

### DIFF
--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -155,39 +155,24 @@ export function useAutomergeNotebook() {
 
   // ── Bootstrap ──────────────────────────────────────────────────────
 
-  const bootstrap = useCallback(
-    async (forceNew = false) => {
-      await wasmReady;
+  const bootstrap = useCallback(async () => {
+    await wasmReady;
 
-      // Reuse existing handle if one exists — critical for React strict mode
-      // which runs mount/cleanup/mount. Creating a new handle on the second
-      // mount would free the first (synced) handle, leaving CodeMirror with
-      // content that doesn't match the new (empty) handle. The magic plugin
-      // (%%html) then fires DOM mutations against the empty handle → crash.
-      //
-      // forceNew=true is used by daemon:ready (actual reconnection) where
-      // we genuinely need a fresh handle for a new daemon session.
-      let handle = handleRef.current;
-      if (!handle || forceNew) {
-        handleRef.current?.free();
-        handle = NotebookHandle.create_empty_with_actor(
-          `human:${sessionIdRef.current}`,
-        );
-        handleRef.current = handle;
-        setNotebookHandle(handle);
-      }
+    const handle = NotebookHandle.create_empty_with_actor(
+      `human:${sessionIdRef.current}`,
+    );
 
-      awaitingInitialSyncRef.current = true;
-      setIsLoading(true);
+    handleRef.current?.free();
+    handleRef.current = handle;
+    setNotebookHandle(handle);
 
-      syncToRelay(handle);
-      logger.info(
-        "[automerge-notebook] Bootstrap: empty handle, awaiting sync",
-      );
-      return true;
-    },
-    [syncToRelay],
-  );
+    awaitingInitialSyncRef.current = true;
+    setIsLoading(true);
+
+    syncToRelay(handle);
+    logger.info("[automerge-notebook] Bootstrap: empty handle, awaiting sync");
+    return true;
+  }, [syncToRelay]);
 
   // ── Lifecycle (single effect) ──────────────────────────────────────
 
@@ -215,7 +200,7 @@ export function useAutomergeNotebook() {
           awaitingInitialSyncRef.current = true;
           setIsLoading(true);
           return from(
-            bootstrap(true).catch((err: unknown) => {
+            bootstrap().catch((err: unknown) => {
               logger.error(
                 "[automerge-notebook] lifecycle bootstrap failed:",
                 err,
@@ -276,20 +261,16 @@ export function useAutomergeNotebook() {
       sourceSyncSub.unsubscribe();
       clearOutputsSub.unsubscribe();
 
-      // Flush pending local changes (but do NOT free the handle).
-      // The handle survives React strict mode's cleanup/re-mount cycle.
-      // It's only freed when bootstrap creates a replacement (daemon:ready)
-      // or on true unmount (component removed from tree). Freeing here
-      // would leave CodeMirror with content from the synced handle while
-      // the second mount creates an empty handle — causing splice_source
-      // "index out of bounds" crashes on magic cells (%%html).
+      // Flush pending local changes before freeing handle.
       if (handleRef.current) {
         syncToRelay(handleRef.current);
       }
 
-      // Reset stores but keep handleRef alive.
       resetNotebookCells();
       resetRuntimeState();
+      setNotebookHandle(null);
+      handleRef.current?.free();
+      handleRef.current = null;
     };
   }, [bootstrap, materializeCells, syncToRelay]);
 


### PR DESCRIPTION
Reverts the handle reuse change from #1076 that was accidentally included alongside the transaction ordering fix.

The handle reuse (surviving React strict mode by not freeing the WASM handle in cleanup) may cause CRDT text duplication — when the reused handle already has content and CodeMirror reinitializes, both can write the same source, producing duplicate characters (observed as `pprint` instead of `print` during concurrent editing with emoji in source).

The transaction ordering fix in `crdt-editor-bridge.ts` (the actual fix for the `%%html` crash) is NOT affected — it landed in #1076 and stays on main.