### PR TITLE
fix(sync): UTF-16 encoding, gremlin shutdown, PatchLogMismatch resilience

### DIFF
--- a/.context/investigations/sync-stress-test.md
+++ b/.context/investigations/sync-stress-test.md
@@ -1,0 +1,296 @@
+# Sync Stress Test Investigation
+
+> Handoff doc for the next agent session. Written at the end of a marathon
+> session (4am → 8pm) that covered PR review, sync bug fixes, a JS library
+> spike, a CRDT bridge fix, and chaos gremlin testing.
+
+## What We Built
+
+### 1. Sync fixes (merged to main)
+
+- **#1068** — Inline sync replies in `receive_frame()`. Eliminated the
+  `flushSync` / `syncReply$` consumption race that caused sync head
+  divergence on rapid Ctrl+Enter.
+- **#1070** — Reply rollback on failed inline send (`cancel_last_flush`
+  in the catch block). Codex review finding.
+- **#1076** — CRDT bridge transaction ordering fix. Auto-close-tag
+  (`</div>`) was applied BEFORE the `>` that triggered it because all
+  changes were flattened and reversed. Fix: forward across transactions,
+  reverse within each.
+- **#1077** — Reverted accidental handle-reuse change from #1076 that
+  may have caused text duplication during concurrent editing.
+
+### 2. `runtimed` JS library spike (PR #1073, branch `spike/notebook-client`)
+
+- `packages/runtimed/` — Transport-agnostic sync engine with RxJS
+  coalesced streams (`cellChanges$`, `broadcasts$`, `presence$`,
+  `runtimeState$`)
+- `DirectTransport` — Test harness connecting two WASM handles
+- `TauriTransport` — Tauri IPC adapter
+- `useAutomergeNotebook` wired to SyncEngine
+- 22 unit tests + 7 integration tests (daemon via Python)
+
+### 3. Chaos gremlin (`scripts/chaos-gremlin.py`)
+
+- Async, uses `runtimed.Client` API
+- Weighted random actions: create, execute, delete, edit, move, clear,
+  rapid-execute, read-and-verify
+- Supports multiple concurrent gremlins (`--gremlins N`)
+- Each gremlin connects independently to the daemon
+
+## Bugs Found (not yet fixed)
+
+### Bug A: Unicode position mismatch during concurrent editing
+
+**Severity**: Medium — causes text corruption (`print` → `pprint`,
+`random` → `ranom`)
+
+**Reproduction**: Two or more peers concurrently editing cells that
+contain emoji (🐸, ⚡, etc.). The text CRDT produces duplicate or
+missing characters near emoji boundaries.
+
+**Theory**: CodeMirror counts positions in UTF-16 code units. Automerge
+counts in Unicode scalar values (or bytes). Emoji like 🐸 are 1 scalar
+value but 2 UTF-16 code units. When `splice_source` is called with a
+CodeMirror position that's offset by the emoji width difference, the
+splice lands at the wrong Automerge index.
+
+**How to reproduce**:
+```bash
+# Start the daemon (dev or nightly)
+cargo xtask dev
+
+# In one terminal, open the app and create a cell with emoji:
+#   # 🐸 Hello world
+#   print("test")
+
+# In another terminal, run the gremlin targeting the same notebook:
+RUNTIMED_SOCKET_PATH=<socket> uv run python scripts/chaos-gremlin.py \
+  --notebook-id <id> --gremlins 2 --rounds 20 --delay 0.1
+
+# Check for corrupted source text in the notebook
+```
+
+**Investigation needed**:
+1. Add logging to `splice_source` in the WASM binding that shows:
+   - The cell_id, index, delete_count, text
+   - The current WASM source length
+   - Whether the source contains multi-byte characters
+2. Compare CodeMirror's `fromA`/`toA` positions with the WASM source's
+   character boundaries around emoji
+3. Check if Automerge's `Text::splice` uses byte offsets, char offsets,
+   or grapheme offsets
+4. Check automerge-rs source: `rust/automerge/src/text.rs` or similar
+
+**Possible fixes**:
+- Convert CodeMirror UTF-16 offsets to Automerge scalar offsets before
+  calling `splice_source`
+- Or: have the WASM binding do the conversion internally
+- Or: use `update_source` (full Myers diff) instead of `splice_source`
+  for cells containing multi-byte characters
+
+### Bug B: Daemon graceful shutdown under gremlin load
+
+**Severity**: Low — daemon exits cleanly but the frontend loses connection
+
+**Reproduction**: Run 3+ gremlins simultaneously against a notebook for
+15+ rounds. The daemon sometimes exits with "Ok (graceful shutdown)" —
+it received SIGTERM from somewhere.
+
+**Investigation needed**:
+- Is the nightly auto-updater sending SIGTERM?
+- Is the app's reconnection logic triggering a daemon restart?
+- Check if `runt daemon start` has a watchdog that restarts on error
+
+### Bug C: Frontend desync after gremlin flood
+
+**Severity**: Medium — frontend shows stale/wrong content, needs reload
+
+**Reproduction**: Same as Bug A. After gremlins finish, the frontend may
+show fewer cells than the daemon has, or show cells with wrong content.
+Reloading fixes it.
+
+**Theory**: The coalesced materialization pipeline (32ms bufferTime) may
+drop batches when overwhelmed, or the targeted per-cell update path may
+miss cells that were added/removed during the batch window.
+
+**Investigation needed**:
+1. Add a "sync health check" button/command that compares the frontend's
+   cell store with the WASM handle's cells and reports mismatches
+2. Log the `cellChanges$` batch sizes and whether `needsFull` is true
+3. Check if structural changes (add/remove) during a coalescing window
+   are properly detected
+
+## How to Stress Test
+
+### Prerequisites
+
+```bash
+# Build everything
+cargo xtask build
+
+# For dev daemon: install local Python bindings
+cd python/runtimed && maturin develop && cd ../..
+
+# For nightly daemon: install the matching runtimed wheel
+# Check the nightly version first:
+runt-nightly status  # look for "Version: 2.0.2+436987f" or similar
+# Install the matching alpha release:
+uv pip install runtimed==2.0.3a202603230219  # match your nightly
+
+# Verify the daemon is running
+runt daemon status  # or runt-nightly status
+```
+
+### Test 1: Single gremlin (sanity check)
+
+```bash
+# Start the app
+cargo xtask notebook
+
+# In another terminal, find the notebook ID
+RUNTIMED_SOCKET_PATH=<socket> uv run python -c "
+from runtimed import Client
+import asyncio
+async def main():
+    c = Client()
+    for nb in await c.list_active_notebooks():
+        print(nb)
+asyncio.run(main())
+"
+
+# Run a single gremlin
+uv run python scripts/chaos-gremlin.py --notebook-id <id> --rounds 10 --delay 0.5
+```
+
+**Expected**: All actions succeed. Frontend stays in sync. No crashes.
+
+### Test 2: Multi-gremlin concurrent editing
+
+```bash
+uv run python scripts/chaos-gremlin.py --notebook-id <id> --gremlins 3 --rounds 20 --delay 0.2
+```
+
+**Expected**: Some cell errors (bad code, markdown execute attempts).
+Frontend may lag but should eventually converge. No daemon crashes.
+
+**Watch for**: Text corruption (characters appearing/disappearing),
+cells missing from the frontend, CodeMirror crashes in the console.
+
+### Test 3: Rapid Ctrl+Enter stress
+
+While gremlins are running, rapidly hold Ctrl+Enter on a cell in the
+app. This tests the sync divergence fix (#1068).
+
+**Expected**: Outputs update correctly. No "stale frontend" state.
+The sync should converge even under load.
+
+### Test 4: Gremlin + human concurrent editing
+
+While gremlins are running, actively type in cells in the app. Create
+cells, delete cells, move cells. This is the most realistic stress test.
+
+**Watch for**: Text corruption near emoji, cursor jumps, cells
+disappearing or duplicating.
+
+### Test 5: Nightly build testing
+
+```bash
+# Target the nightly daemon specifically
+# First ensure runtimed version matches the nightly:
+#   uv pip install runtimed==2.0.3a202603230219
+RUNTIMED_SOCKET_PATH=~/Library/Caches/runt-nightly/runtimed.sock \
+  uv run python scripts/chaos-gremlin.py --notebook-id <id> --gremlins 3
+
+# Gather diagnostics after the test
+env -i HOME=$HOME PATH=/usr/local/bin:/usr/bin:/bin runt-nightly diagnostics
+```
+
+The diagnostics archive contains `runtimed.log` (daemon), `notebook.log`
+(Tauri app), `daemon-status.json`, and `system-info.json`.
+
+## Gathering Logs
+
+### Daemon logs
+
+```bash
+# Dev daemon
+tail -f target/debug/runtimed.log
+
+# Nightly daemon (after diagnostics)
+tar xzf ~/Desktop/runt-diagnostics-*.tar.gz -C /tmp/diag
+cat /tmp/diag/runtimed.log
+```
+
+Look for:
+- `Cell error (stop-on-error)` — expected for bad code
+- `WARN` or `ERROR` lines — unexpected issues
+- `Daemon exited` — check if graceful or crash
+
+### Frontend logs
+
+Open the WebKit inspector (Cmd+Option+I in the app) → Console tab.
+
+Key log prefixes:
+- `[SyncEngine]` — sync lifecycle (initial sync, retries)
+- `[crdt-bridge]` — CodeMirror ↔ WASM splice operations
+- `[frame-pipeline]` — inline reply sending, rollback
+- `[automerge-notebook]` — materialization, bootstrap
+- `[daemon-kernel]` — execution, kernel status
+- `CodeMirror plugin crashed` — **this is the bug we're hunting**
+
+### Diagnostic instrumentation
+
+To enable CRDT bridge logging (currently removed, re-add if needed):
+
+```typescript
+// In crdt-editor-bridge.ts, inside update():
+console.warn("[crdt-bridge] OUTBOUND TX", {
+  cellId: cellId.slice(0, 8),
+  userEvent: tr.annotation(Transaction.userEvent) ?? "(none)",
+  editorDocLen: vu.state.doc.length,
+  wasmSourceLen: handle?.get_cell_source(cellId)?.length ?? "null",
+  changes,
+});
+```
+
+## Key Files
+
+| File | What it does |
+|------|-------------|
+| `scripts/chaos-gremlin.py` | Chaos gremlin script |
+| `apps/notebook/src/lib/crdt-editor-bridge.ts` | CodeMirror ↔ WASM bridge (Bug A lives here) |
+| `apps/notebook/src/lib/frame-pipeline.ts` | Inbound frame processing + inline replies |
+| `apps/notebook/src/hooks/useAutomergeNotebook.ts` | Notebook lifecycle + sync |
+| `packages/runtimed/src/sync-engine.ts` | SyncEngine (spike branch) |
+| `packages/runtimed/src/direct-transport.ts` | Test transport (spike branch) |
+| `crates/runtimed-wasm/src/lib.rs` | WASM bindings (splice_source, receive_frame, flush_local_changes) |
+| `crates/runtimed-wasm/tests/deno_smoke_test.ts` | WASM sync tests (45 tests) |
+| `crates/runtimed-wasm/tests/splice_source_test.ts` | Splice tests (66 tests) |
+
+## Branch Map
+
+| Branch | Status | What's on it |
+|--------|--------|-------------|
+| `main` | ✅ | All merged fixes (#1068, #1070, #1076, #1077) |
+| `spike/notebook-client` | Draft PR #1073 | `runtimed` JS library + SyncEngine + TauriTransport |
+| `feat/chaos-gremlins` | This branch | Chaos gremlin script + this investigation doc |
+
+## Session Timeline (for context)
+
+1. 4am — Voice review of execution handle spike (#1052) with nicole voice
+2. 5am — Designed execution log architecture (intents → dropped, keep request/response)
+3. 7am — Updated issues, milestone scoping, cross-references
+4. 8am — Traced frame pipeline architecture (Tauri relay, WASM demux)
+5. 9am — Found sync divergence bug (#1067), filed with root cause analysis
+6. 10am — Built the fix: inline sync replies in receive_frame (#1068)
+7. 11am — Codex review found reply rollback gap → #1070
+8. 12pm — Started `runtimed` JS library spike (SyncEngine, DirectTransport)
+9. 1pm — TauriTransport, wired useAutomergeNotebook to SyncEngine
+10. 2pm — Debugged React strict mode issues (handle lifecycle, initial sync detection)
+11. 3pm — Fixed targeted materialization (don't overwrite CodeMirror source)
+12. 4pm — Added RxJS coalesced streams (cellChanges$, broadcasts$, etc.)
+13. 5pm — Found %%html magic cell crash on main → investigated with instrumentation
+14. 6pm — Root cause: transaction ordering in CRDT bridge → #1076
+15. 7pm — Chaos gremlins: 3 concurrent gremlins killed the nightly in 6 seconds
+16. 8pm — This handoff doc

--- a/.context/investigations/sync-stress-test.md
+++ b/.context/investigations/sync-stress-test.md
@@ -1,8 +1,10 @@
 # Sync Stress Test Investigation
 
-> Handoff doc for the next agent session. Written at the end of a marathon
-> session (4am → 8pm) that covered PR review, sync bug fixes, a JS library
-> spike, a CRDT bridge fix, and chaos gremlin testing.
+> Handoff doc spanning two agent sessions. Session 1 (4am → 8pm) covered
+> PR review, sync bug fixes, a JS library spike, a CRDT bridge fix, and
+> chaos gremlin testing. Session 2 fixed Bug A (unicode positions) and
+> Bug B (daemon shutdown), found a new automerge PatchLogMismatch panic,
+> and ran successful multi-gremlin stress tests against nightly.
 
 ## What We Built
 
@@ -38,69 +40,56 @@
 - Supports multiple concurrent gremlins (`--gremlins N`)
 - Each gremlin connects independently to the daemon
 
-## Bugs Found (not yet fixed)
+## Bugs Found
 
-### Bug A: Unicode position mismatch during concurrent editing
+### Bug A: Unicode position mismatch during concurrent editing — ✅ FIXED (PR #1078)
 
 **Severity**: Medium — causes text corruption (`print` → `pprint`,
 `random` → `ranom`)
 
-**Reproduction**: Two or more peers concurrently editing cells that
-contain emoji (🐸, ⚡, etc.). The text CRDT produces duplicate or
-missing characters near emoji boundaries.
+**Root cause confirmed**: CodeMirror positions are UTF-16 code units.
+Automerge 0.7.4 defaults to `UnicodeCodePoint` encoding (since no
+`utf16-indexing` feature was enabled). Emoji like 🐸 are 1 code point
+but 2 UTF-16 code units, so every emoji before a splice shifted the
+position by 1.
 
-**Theory**: CodeMirror counts positions in UTF-16 code units. Automerge
-counts in Unicode scalar values (or bytes). Emoji like 🐸 are 1 scalar
-value but 2 UTF-16 code units. When `splice_source` is called with a
-CodeMirror position that's offset by the emoji width difference, the
-splice lands at the wrong Automerge index.
+**Fix (PR #1078)**:
+- Automerge 0.7.4 has `TextEncoding::Utf16CodeUnit` — we just weren't
+  using it. Added `AutoCommit::new_with_encoding(Utf16CodeUnit)` to all
+  WASM `NotebookHandle` construction paths (`new`, `create_empty`,
+  `create_empty_with_actor`, `load`).
+- Added encoding-aware constructors to `NotebookDoc` (`new_with_encoding`,
+  `empty_with_encoding`, `load_with_encoding`), re-exported `TextEncoding`.
+- Daemon continues using `UnicodeCodePoint` (correct for Python string
+  indices). Encoding is a local API interpretation — does not affect the
+  wire format, so peers with different encodings sync correctly.
+- Fixed secondary bug: `append_source` used `String::len()` (byte count)
+  instead of automerge's encoding-aware `length()`, which was wrong for
+  non-ASCII text.
+- 5 new regression tests for splice positions after emoji (including
+  cross-peer sync with surrogate pairs).
 
-**How to reproduce**:
-```bash
-# Start the daemon (dev or nightly)
-cargo xtask dev
+**Key insight**: `TextEncoding` in automerge 0.7 is purely a client-side
+position interpretation. The underlying CRDT ops are stored at the
+op-graph level. Two peers with different encodings sync correctly.
 
-# In one terminal, open the app and create a cell with emoji:
-#   # 🐸 Hello world
-#   print("test")
+### Bug B: Daemon graceful shutdown under gremlin load — ✅ FIXED
 
-# In another terminal, run the gremlin targeting the same notebook:
-RUNTIMED_SOCKET_PATH=<socket> uv run python scripts/chaos-gremlin.py \
-  --notebook-id <id> --gremlins 2 --rounds 20 --delay 0.1
+**Severity**: Low (was user error, not a daemon bug)
 
-# Check for corrupted source text in the notebook
-```
+**Root cause**: The chaos gremlin script called `client.shutdown()` in
+the notebook discovery phase and the final state check. `Client.shutdown()`
+sends a "shut down the daemon" RPC — it literally asks the daemon to exit.
+The daemon wasn't crashing; the gremlin was killing it before the test started.
 
-**Investigation needed**:
-1. Add logging to `splice_source` in the WASM binding that shows:
-   - The cell_id, index, delete_count, text
-   - The current WASM source length
-   - Whether the source contains multi-byte characters
-2. Compare CodeMirror's `fromA`/`toA` positions with the WASM source's
-   character boundaries around emoji
-3. Check if Automerge's `Text::splice` uses byte offsets, char offsets,
-   or grapheme offsets
-4. Check automerge-rs source: `rust/automerge/src/text.rs` or similar
+**Fix**: Removed both `client.shutdown()` calls from `chaos-gremlin.py`.
+The Python `Client`'s resources are cleaned up by the garbage collector.
+After the fix, the nightly daemon survived a full 3-gremlin, 20-round
+stress test without issues.
 
-**Possible fixes**:
-- Convert CodeMirror UTF-16 offsets to Automerge scalar offsets before
-  calling `splice_source`
-- Or: have the WASM binding do the conversion internally
-- Or: use `update_source` (full Myers diff) instead of `splice_source`
-  for cells containing multi-byte characters
-
-### Bug B: Daemon graceful shutdown under gremlin load
-
-**Severity**: Low — daemon exits cleanly but the frontend loses connection
-
-**Reproduction**: Run 3+ gremlins simultaneously against a notebook for
-15+ rounds. The daemon sometimes exits with "Ok (graceful shutdown)" —
-it received SIGTERM from somewhere.
-
-**Investigation needed**:
-- Is the nightly auto-updater sending SIGTERM?
-- Is the app's reconnection logic triggering a daemon restart?
-- Check if `runt daemon start` has a watchdog that restarts on error
+**Note for the Python API**: `Client` should probably have a `close()`
+method that disconnects without shutting down the daemon. Currently the
+only cleanup method is `shutdown()` which is destructive.
 
 ### Bug C: Frontend desync after gremlin flood
 
@@ -121,6 +110,48 @@ miss cells that were added/removed during the batch window.
 3. Check if structural changes (add/remove) during a coalescing window
    are properly detected
 
+### Bug D: Automerge PatchLogMismatch panic under concurrent gremlin access (NEW)
+
+**Severity**: High — panics the tokio runtime thread, poisons the Mutex,
+and renders the affected session permanently unusable.
+
+**Reproduction**: 3 concurrent gremlins editing the same notebook.
+Gremlin-1 hit the panic on round 2, after which every operation failed
+with "Document lock poisoned".
+
+**Error**:
+```
+thread 'tokio-runtime-worker' panicked at automerge-0.7.4/src/op_set2/change/batch.rs:817:47:
+called `Result::unwrap()` on an `Err` value: PatchLogMismatch
+```
+
+**Context**: This is inside automerge's internal batch processing.
+The panic occurs in the Python binding's automerge document (client-side,
+not daemon-side). Each gremlin creates its own `Client` and `Notebook`,
+so sessions should be independent — but they share the same tokio runtime
+and something about concurrent sync operations triggers the panic.
+
+**Investigation needed**:
+1. Get a full backtrace (`RUST_BACKTRACE=1`)
+2. Check if the session's `Arc<Mutex<SessionState>>` allows overlapping
+   transactions when multiple async tasks read/write concurrently
+3. Check if `PatchLogMismatch` is a known automerge issue
+4. May need to upgrade automerge or add retry/recovery around the panic
+
+### Bug E: append_source "index out of bounds" for emoji cells (daemon-side)
+
+**Severity**: Medium — the `append()` API silently fails for cells with
+emoji when using the nightly daemon (which lacks the `append_source` fix).
+
+**Root cause**: Same as the secondary fix in Bug A. `append_source` used
+`self.doc.text(&source_id)?.len()` (Rust String byte count = UTF-8 bytes)
+but `splice_text` interprets the index using the document's `TextEncoding`
+(default `UnicodeCodePoint` = char count). For "# 🐸 Gremlin-1" the byte
+count is 17 but the code point count is 14, so the splice index overshoots.
+
+**Status**: Fixed in PR #1078 (uses `self.doc.length(&source_id)` which
+is encoding-aware). Will be resolved once the nightly picks up the fix.
+
 ## How to Stress Test
 
 ### Prerequisites
@@ -132,35 +163,28 @@ cargo xtask build
 # For dev daemon: install local Python bindings
 cd python/runtimed && maturin develop && cd ../..
 
-# For nightly daemon: install the matching runtimed wheel
-# Check the nightly version first:
-runt-nightly status  # look for "Version: 2.0.2+436987f" or similar
-# Install the matching alpha release:
-uv pip install runtimed==2.0.3a202603230219  # match your nightly
+# For nightly daemon: the repo .venv already has runtimed 2.0.2
+# built from source via maturin — this matches the nightly.
+# Use .venv/bin/python (not uv run) to ensure the right bindings.
 
-# Verify the daemon is running
-runt daemon status  # or runt-nightly status
+# Verify the daemon is running (MUST use env -i to avoid dev vars)
+env -i HOME=$HOME PATH=/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin \
+  runt-nightly daemon status
 ```
+
+**Important**: Always use `env -i` when interacting with the nightly
+daemon from a dev worktree. Without it, `RUNTIMED_DEV=1` and
+`RUNTIMED_WORKSPACE_PATH` leak from the shell and you'll hit the dev
+daemon instead of nightly.
 
 ### Test 1: Single gremlin (sanity check)
 
 ```bash
-# Start the app
-cargo xtask notebook
+# Target the nightly daemon explicitly with --socket
+NIGHTLY_SOCK=~/Library/Caches/runt-nightly/runtimed.sock
 
-# In another terminal, find the notebook ID
-RUNTIMED_SOCKET_PATH=<socket> uv run python -c "
-from runtimed import Client
-import asyncio
-async def main():
-    c = Client()
-    for nb in await c.list_active_notebooks():
-        print(nb)
-asyncio.run(main())
-"
-
-# Run a single gremlin
-uv run python scripts/chaos-gremlin.py --notebook-id <id> --rounds 10 --delay 0.5
+# Run a single gremlin (auto-discovers first active notebook or creates one)
+.venv/bin/python scripts/chaos-gremlin.py --socket $NIGHTLY_SOCK --rounds 10 --delay 0.5
 ```
 
 **Expected**: All actions succeed. Frontend stays in sync. No crashes.
@@ -168,7 +192,7 @@ uv run python scripts/chaos-gremlin.py --notebook-id <id> --rounds 10 --delay 0.
 ### Test 2: Multi-gremlin concurrent editing
 
 ```bash
-uv run python scripts/chaos-gremlin.py --notebook-id <id> --gremlins 3 --rounds 20 --delay 0.2
+.venv/bin/python scripts/chaos-gremlin.py --socket $NIGHTLY_SOCK --gremlins 3 --rounds 20 --delay 0.2
 ```
 
 **Expected**: Some cell errors (bad code, markdown execute attempts).
@@ -196,14 +220,13 @@ disappearing or duplicating.
 ### Test 5: Nightly build testing
 
 ```bash
-# Target the nightly daemon specifically
-# First ensure runtimed version matches the nightly:
-#   uv pip install runtimed==2.0.3a202603230219
-RUNTIMED_SOCKET_PATH=~/Library/Caches/runt-nightly/runtimed.sock \
-  uv run python scripts/chaos-gremlin.py --notebook-id <id> --gremlins 3
+# Use --socket to target nightly directly (no env var leakage risk)
+.venv/bin/python scripts/chaos-gremlin.py \
+  --socket ~/Library/Caches/runt-nightly/runtimed.sock --gremlins 3
 
 # Gather diagnostics after the test
-env -i HOME=$HOME PATH=/usr/local/bin:/usr/bin:/bin runt-nightly diagnostics
+env -i HOME=$HOME PATH=/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin \
+  runt-nightly diagnostics
 ```
 
 The diagnostics archive contains `runtimed.log` (daemon), `notebook.log`
@@ -274,9 +297,11 @@ console.warn("[crdt-bridge] OUTBOUND TX", {
 |--------|--------|-------------|
 | `main` | ✅ | All merged fixes (#1068, #1070, #1076, #1077) |
 | `spike/notebook-client` | Draft PR #1073 | `runtimed` JS library + SyncEngine + TauriTransport |
-| `feat/chaos-gremlins` | This branch | Chaos gremlin script + this investigation doc |
+| `feat/chaos-gremlins` | PR #1078 | Bug A fix (UTF-16 encoding), Bug B fix (shutdown), chaos gremlin, this doc |
 
 ## Session Timeline (for context)
+
+### Session 1
 
 1. 4am — Voice review of execution handle spike (#1052) with nicole voice
 2. 5am — Designed execution log architecture (intents → dropped, keep request/response)
@@ -294,3 +319,21 @@ console.warn("[crdt-bridge] OUTBOUND TX", {
 14. 6pm — Root cause: transaction ordering in CRDT bridge → #1076
 15. 7pm — Chaos gremlins: 3 concurrent gremlins killed the nightly in 6 seconds
 16. 8pm — This handoff doc
+
+### Session 2
+
+17. 8pm — Read investigation doc, oriented on nightly daemon (2.0.2+79c2797)
+18. 8:10pm — Single gremlin test passed (10 rounds, 0 errors)
+19. 8:12pm — Daemon died on multi-gremlin test → investigated
+20. 8:15pm — Debugged launchd crash-loop (bootout/bootstrap, env var leakage)
+21. 8:20pm — Dug into automerge 0.7.4 source: found `TextEncoding` enum with
+    `Utf16CodeUnit` support — confirmed Bug A root cause
+22. 8:30pm — Implemented fix: encoding-aware constructors in `notebook-doc`,
+    `Utf16CodeUnit` in WASM binding, `append_source` length fix
+23. 8:40pm — 5 new regression tests, all 344 tests pass, PR #1078 opened
+24. 8:45pm — Found Bug B root cause: `client.shutdown()` in gremlin script
+25. 8:50pm — Fixed Bug B, re-ran 3-gremlin test: daemon survived, 7.3s elapsed
+26. 8:55pm — Found Bug D: `PatchLogMismatch` panic in automerge under
+    concurrent gremlin access, poisons the session Mutex
+27. 9pm — Found Bug E: `append_source` index out of bounds on nightly
+    (same root cause as Bug A secondary fix, nightly doesn't have it yet)

--- a/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm
+++ b/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a10cf92caca30ba1996c0e48ac430085b387a0d8d08da3a81244442535de0f38
-size 1613225
+oid sha256:318be98674411a7702c19ed2838537e34fdf0d9985ee6a6efb49bfab3e72a872
+size 1613339

--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -55,7 +55,11 @@ pub const SCHEMA_VERSION: u64 = 2;
 use automerge::sync;
 use automerge::sync::SyncDoc;
 use automerge::transaction::Transactable;
-use automerge::{ActorId, AutoCommit, AutomergeError, ObjId, ObjType, ReadDoc};
+use automerge::{ActorId, AutoCommit, AutomergeError, LoadOptions, ObjId, ObjType, ReadDoc};
+
+/// Re-export so downstream crates (runtimed-wasm) can set text encoding
+/// without depending on automerge directly.
+pub use automerge::TextEncoding;
 use loro_fractional_index::FractionalIndex;
 use serde::{Deserialize, Serialize};
 
@@ -456,7 +460,18 @@ impl NotebookDoc {
 impl NotebookDoc {
     /// Create a new empty notebook document with the given ID.
     pub fn new(notebook_id: &str) -> Self {
-        Self::new_inner(notebook_id, None)
+        Self::new_inner(notebook_id, None, None)
+    }
+
+    /// Create a new notebook document with a specific text encoding.
+    ///
+    /// Use `TextEncoding::Utf16CodeUnit` when positions come from a UTF-16
+    /// environment (JavaScript / CodeMirror). The daemon should use the
+    /// default (`UnicodeCodePoint`) since Python string indices are code points.
+    /// Encoding is a local interpretation — it does not affect the wire format,
+    /// so peers with different encodings sync correctly.
+    pub fn new_with_encoding(notebook_id: &str, encoding: TextEncoding) -> Self {
+        Self::new_inner(notebook_id, None, Some(encoding))
     }
 
     /// Create a new notebook document with a specific actor identity.
@@ -465,7 +480,7 @@ impl NotebookDoc {
     /// operation in the document — including the schema, cells map, and metadata
     /// scaffolding — is attributed to `actor_label`.
     pub fn new_with_actor(notebook_id: &str, actor_label: &str) -> Self {
-        Self::new_inner(notebook_id, Some(actor_label))
+        Self::new_inner(notebook_id, Some(actor_label), None)
     }
 
     /// Shared constructor: optionally sets the actor before any mutations so
@@ -475,8 +490,15 @@ impl NotebookDoc {
     /// changing the actor, so the actor must be set before the first `put`
     /// call — otherwise the initial change would be attributed to a random
     /// UUID instead of the intended label.
-    fn new_inner(notebook_id: &str, actor_label: Option<&str>) -> Self {
-        let mut doc = AutoCommit::new();
+    fn new_inner(
+        notebook_id: &str,
+        actor_label: Option<&str>,
+        encoding: Option<TextEncoding>,
+    ) -> Self {
+        let mut doc = match encoding {
+            Some(enc) => AutoCommit::new_with_encoding(enc),
+            None => AutoCommit::new(),
+        };
 
         // Set actor *before* any puts so the initial structural change is
         // attributed to the caller, not a throwaway random UUID.
@@ -640,6 +662,15 @@ impl NotebookDoc {
         }
     }
 
+    /// Create an empty sync-only bootstrap document with a specific text encoding.
+    ///
+    /// Use `TextEncoding::Utf16CodeUnit` for the WASM/CodeMirror frontend.
+    pub fn empty_with_encoding(encoding: TextEncoding) -> Self {
+        Self {
+            doc: AutoCommit::new_with_encoding(encoding),
+        }
+    }
+
     /// Create an empty sync-only bootstrap document with a specific actor identity.
     ///
     /// Like `empty()`, but sets the actor ID for edit provenance.
@@ -649,9 +680,22 @@ impl NotebookDoc {
         s
     }
 
+    /// Like `empty_with_encoding()`, but also sets the actor ID for edit provenance.
+    pub fn empty_with_actor_and_encoding(actor_label: &str, encoding: TextEncoding) -> Self {
+        let mut s = Self::empty_with_encoding(encoding);
+        s.set_actor(actor_label);
+        s
+    }
+
     /// Load a notebook document from saved bytes.
     pub fn load(data: &[u8]) -> Result<Self, AutomergeError> {
         let doc = AutoCommit::load(data)?;
+        Ok(Self { doc })
+    }
+
+    /// Load a notebook document from saved bytes with a specific text encoding.
+    pub fn load_with_encoding(data: &[u8], encoding: TextEncoding) -> Result<Self, AutomergeError> {
+        let doc = AutoCommit::load_with_options(data, LoadOptions::new().text_encoding(encoding))?;
         Ok(Self { doc })
     }
 
@@ -1204,7 +1248,7 @@ impl NotebookDoc {
             None => return Ok(false),
         };
 
-        let len = self.doc.text(&source_id)?.len();
+        let len = self.doc.length(&source_id);
         self.doc.splice_text(&source_id, len, 0, text)?;
         Ok(true)
     }

--- a/crates/notebook-sync/src/sync_task.rs
+++ b/crates/notebook-sync/src/sync_task.rs
@@ -17,6 +17,7 @@
 //! Document mutations do NOT go through this task. Callers mutate directly
 //! via `DocHandle::with_doc`. This task is purely for network synchronization.
 
+use std::panic::AssertUnwindSafe;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -319,15 +320,43 @@ async fn handle_incoming_frame<W: AsyncWrite + Unpin>(
                 }
             };
 
-            // Apply and generate ack — lock held only for Automerge operations
+            // Apply and generate ack — lock held only for Automerge operations.
+            //
+            // The receive_sync_message call is wrapped in catch_unwind because
+            // automerge 0.7 has a known panic in BatchApply::apply when the
+            // internal patch log actor table gets out of order during concurrent
+            // sync (automerge/automerge#1187). Without catch_unwind, the panic
+            // poisons the Mutex and renders the session permanently unusable.
+            // By catching it, the MutexGuard drops normally and subsequent
+            // operations can still succeed.
             let ack_bytes = {
                 let mut state = doc.lock().unwrap_or_else(|e| e.into_inner());
-                if let Err(e) = state.receive_sync_message(msg) {
-                    warn!(
-                        "[notebook-sync] Failed to apply sync message for {}: {}",
-                        notebook_id, e
-                    );
-                    return;
+                let recv_result =
+                    std::panic::catch_unwind(AssertUnwindSafe(|| state.receive_sync_message(msg)));
+                match recv_result {
+                    Ok(Ok(())) => {}
+                    Ok(Err(e)) => {
+                        warn!(
+                            "[notebook-sync] Failed to apply sync message for {}: {}",
+                            notebook_id, e
+                        );
+                        return;
+                    }
+                    Err(panic_payload) => {
+                        let msg = if let Some(s) = panic_payload.downcast_ref::<String>() {
+                            s.as_str()
+                        } else if let Some(s) = panic_payload.downcast_ref::<&str>() {
+                            s
+                        } else {
+                            "unknown panic"
+                        };
+                        warn!(
+                            "[notebook-sync] Automerge panicked during sync for {} \
+                             (upstream bug automerge/automerge#1187): {}",
+                            notebook_id, msg
+                        );
+                        return;
+                    }
                 }
                 state.generate_sync_message().map(|msg| msg.encode())
             };

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -206,7 +206,10 @@ impl NotebookHandle {
     #[wasm_bindgen(constructor)]
     pub fn new(notebook_id: &str) -> NotebookHandle {
         NotebookHandle {
-            doc: NotebookDoc::new(notebook_id),
+            doc: NotebookDoc::new_with_encoding(
+                notebook_id,
+                notebook_doc::TextEncoding::Utf16CodeUnit,
+            ),
             sync_state: sync::State::new(),
             state_doc: RuntimeStateDoc::new_empty(),
             state_sync_state: sync::State::new(),
@@ -219,7 +222,7 @@ impl NotebookHandle {
     /// daemon — no `GetDocBytes` needed.
     pub fn create_empty() -> NotebookHandle {
         NotebookHandle {
-            doc: NotebookDoc::empty(),
+            doc: NotebookDoc::empty_with_encoding(notebook_doc::TextEncoding::Utf16CodeUnit),
             sync_state: sync::State::new(),
             state_doc: RuntimeStateDoc::new_empty(),
             state_sync_state: sync::State::new(),
@@ -233,7 +236,10 @@ impl NotebookHandle {
     /// `"agent:claude:<session>"`) that tags all subsequent edits for provenance.
     pub fn create_empty_with_actor(actor_label: &str) -> NotebookHandle {
         NotebookHandle {
-            doc: NotebookDoc::empty_with_actor(actor_label),
+            doc: NotebookDoc::empty_with_actor_and_encoding(
+                actor_label,
+                notebook_doc::TextEncoding::Utf16CodeUnit,
+            ),
             sync_state: sync::State::new(),
             state_doc: RuntimeStateDoc::new_empty(),
             state_sync_state: sync::State::new(),
@@ -243,8 +249,8 @@ impl NotebookHandle {
 
     /// Load a notebook document from saved bytes (e.g., from get_automerge_doc_bytes).
     pub fn load(bytes: &[u8]) -> Result<NotebookHandle, JsError> {
-        let doc =
-            NotebookDoc::load(bytes).map_err(|e| JsError::new(&format!("load failed: {}", e)))?;
+        let doc = NotebookDoc::load_with_encoding(bytes, notebook_doc::TextEncoding::Utf16CodeUnit)
+            .map_err(|e| JsError::new(&format!("load failed: {}", e)))?;
         Ok(NotebookHandle {
             doc,
             sync_state: sync::State::new(),

--- a/crates/runtimed-wasm/tests/splice_source_test.ts
+++ b/crates/runtimed-wasm/tests/splice_source_test.ts
@@ -901,6 +901,73 @@ Deno.test("unicode: accented characters and combining marks", () => {
   h.free();
 });
 
+Deno.test("unicode: splice AFTER emoji uses UTF-16 positions", () => {
+  // 🐸 is U+1F438 — a surrogate pair in UTF-16 (2 code units), but 1 Unicode code point.
+  // In JavaScript, "🐸".length === 2.  If the WASM binding uses code-point indexing
+  // instead of UTF-16 indexing, splicing after the emoji lands at the wrong position.
+  const h = makeHandle("unicode-5", "c1", "🐸 hello");
+  // JS string: 🐸(2) + space(1) + hello(5) = length 8
+  assertEquals("🐸 hello".length, 8);
+  // Insert "!" right after the space (UTF-16 index 3: 2 for 🐸 + 1 for space)
+  h.splice_source("c1", 3, 0, "!");
+  assertEquals(getSource(h, "c1"), "🐸 !hello");
+  h.free();
+});
+
+Deno.test("unicode: delete after emoji uses UTF-16 positions", () => {
+  const h = makeHandle("unicode-6", "c1", "🐸ab");
+  // UTF-16 positions: 🐸 = [0,1], a = 2, b = 3 → length 4
+  assertEquals("🐸ab".length, 4);
+  // Delete 'a' (UTF-16 index 2, delete 1)
+  h.splice_source("c1", 2, 1, "");
+  assertEquals(getSource(h, "c1"), "🐸b");
+  h.free();
+});
+
+Deno.test("unicode: splice between two emoji", () => {
+  const h = makeHandle("unicode-7", "c1", "🐸🔥");
+  // UTF-16: 🐸=[0,1] 🔥=[2,3] → length 4
+  assertEquals("🐸🔥".length, 4);
+  // Insert between the two emoji (UTF-16 index 2)
+  h.splice_source("c1", 2, 0, " and ");
+  assertEquals(getSource(h, "c1"), "🐸 and 🔥");
+  h.free();
+});
+
+Deno.test("unicode: replace text after multiple emoji", () => {
+  const h = makeHandle("unicode-8", "c1", "🐸🔥⚡ test");
+  // UTF-16: 🐸(2) + 🔥(2) + ⚡(1, BMP) + space(1) + test(4) = 10
+  assertEquals("🐸🔥⚡ test".length, 10);
+  // Replace "test" (starts at UTF-16 index 6, length 4) with "done"
+  h.splice_source("c1", 6, 4, "done");
+  assertEquals(getSource(h, "c1"), "🐸🔥⚡ done");
+  h.free();
+});
+
+Deno.test("unicode: sync splice-after-emoji between two handles", () => {
+  const a = makeHandle("unicode-9", "c1", "# 🐸 Hello");
+  const b = NotebookHandle.load(a.save());
+  syncHandles(a, b);
+
+  // UTF-16: #(1) + space(1) + 🐸(2) + space(1) + Hello(5) = 10
+  assertEquals("# 🐸 Hello".length, 10);
+
+  // Peer A: insert " World" after "Hello" (UTF-16 index 10)
+  a.splice_source("c1", 10, 0, " World");
+  syncHandles(a, b);
+  assertEquals(getSource(a, "c1"), "# 🐸 Hello World");
+  assertEquals(getSource(b, "c1"), "# 🐸 Hello World");
+
+  // Peer B: insert "!" after "World" (UTF-16 index 16)
+  b.splice_source("c1", 16, 0, "!");
+  syncHandles(b, a);
+  assertEquals(getSource(a, "c1"), "# 🐸 Hello World!");
+  assertEquals(getSource(b, "c1"), "# 🐸 Hello World!");
+
+  a.free();
+  b.free();
+});
+
 // ── 14. Newline handling ─────────────────────────────────────────────
 
 Deno.test("newlines: insert newline between lines", () => {

--- a/scripts/chaos-gremlin.py
+++ b/scripts/chaos-gremlin.py
@@ -234,7 +234,7 @@ ACTIONS = [
 
 def pick_action():
     """Weighted random action selection."""
-    actions, weights = zip(*ACTIONS)
+    actions, weights = zip(*ACTIONS, strict=True)
     return random.choices(actions, weights=weights, k=1)[0]
 
 

--- a/scripts/chaos-gremlin.py
+++ b/scripts/chaos-gremlin.py
@@ -316,7 +316,6 @@ async def async_main(
             )
             print(f"   Created: {notebook_id[:8]}")
             await notebook.close()
-        await client.shutdown()
 
     print(f"   Target: {notebook_id}")
     print()
@@ -366,7 +365,6 @@ async def async_main(
             ec = cell.execution_count
             print(f"   [{i}] {cell.cell_type} ec={ec} outs={outs}: {src}")
         await notebook.close()
-        await client.shutdown()
     except Exception as e:
         print(f"   (failed to read final state: {e})")
 

--- a/scripts/chaos-gremlin.py
+++ b/scripts/chaos-gremlin.py
@@ -1,0 +1,438 @@
+#!/usr/bin/env python3
+"""Chaos gremlin — randomly mutates a live notebook to stress-test sync.
+
+Connects to a running runtimed daemon and performs random operations:
+creates cells, edits source, executes cells, deletes cells, moves cells,
+clears outputs, and adds markdown. Designed to run alongside a human in
+the nteract desktop app to shake out CRDT sync bugs.
+
+Usage:
+    # Auto-discover dev daemon, join the first active notebook
+    uv run python scripts/chaos-gremlin.py
+
+    # Target nightly daemon (install matching runtimed first)
+    uv pip install runtimed==2.0.3a<YYYYMMDDHHMI>  # match your nightly version
+    RUNTIMED_SOCKET_PATH=~/Library/Caches/runt-nightly/runtimed.sock \
+        uv run python scripts/chaos-gremlin.py
+
+    # Target a specific notebook
+    uv run python scripts/chaos-gremlin.py --notebook-id <id>
+
+    # Launch 3 concurrent gremlins on the same notebook
+    uv run python scripts/chaos-gremlin.py --gremlins 3
+
+    # Control chaos level
+    uv run python scripts/chaos-gremlin.py --rounds 50 --delay 0.5
+
+Note:
+    When targeting the nightly daemon, the runtimed Python package version
+    must match the nightly daemon version. Check with `runt-nightly status`
+    (look for the Version line) and install the matching alpha wheel:
+        uv pip install runtimed==2.0.3a202603230219
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import random
+import sys
+import time
+
+from runtimed import Client
+
+# ── Chaos actions ─────────────────────────────────────────────────────
+
+EMOJI = ["🐸", "🔥", "💥", "🎲", "🧪", "👻", "🌪️", "⚡", "🦆", "🎯"]
+
+CODE_SNIPPETS = [
+    'print("gremlin was here 🐸")',
+    "import random; random.random()",
+    "2 + 2",
+    "[x**2 for x in range(10)]",
+    "import sys; sys.version",
+    'print("".join(__import__("random").choices("abcdef", k=20)))',
+    "import math; math.pi",
+    "list(range(5))",
+    '{"key": "value", "n": 42}',
+    "sum(range(100))",
+    "import datetime; str(datetime.datetime.now())",
+    "len(dir())",
+    "True or False",
+    "type(None).__name__",
+]
+
+MARKDOWN_SNIPPETS = [
+    "# 🐸 Gremlin Section",
+    "## Chaos reigns here",
+    "**bold** and *italic* and `code`",
+    "> A gremlin once said: break everything.",
+    "- item 1\n- item 2\n- item 3",
+    "| col1 | col2 |\n|------|------|\n| a | b |",
+    "### 🧪 Test in progress",
+    "*The gremlin is watching.*",
+]
+
+BAD_CODE = [
+    "this is not valid python",
+    "def f(:\n    pass",
+    "import nonexistent_module_xyz",
+    "1/0",
+    "raise RuntimeError('gremlin attack!')",
+    "[][999]",
+    "print(undefined_variable_xyz)",
+]
+
+
+# ── Action functions ──────────────────────────────────────────────────
+# Each takes (notebook, gremlin_name, log) and returns nothing.
+# They read cell state from notebook.cells as needed.
+
+
+async def action_create_code(notebook, name, log):
+    """Create a new code cell with random content."""
+    snippet = random.choice(CODE_SNIPPETS)
+    emoji = random.choice(EMOJI)
+    source = f"# {emoji} {name}\n{snippet}"
+    cell = await notebook.cells.create(source=source, cell_type="code")
+    log(f"CREATE code: {snippet[:40]}... -> {cell.id[:8]}")
+
+
+async def action_create_markdown(notebook, name, log):
+    """Create a new markdown cell."""
+    source = random.choice(MARKDOWN_SNIPPETS)
+    cell = await notebook.cells.create(source=source, cell_type="markdown")
+    log(f"CREATE markdown: {source[:40]}... -> {cell.id[:8]}")
+
+
+async def action_create_bad_code(notebook, name, log):
+    """Create a cell with intentionally bad code."""
+    source = random.choice(BAD_CODE)
+    cell = await notebook.cells.create(source=f"# {name} bad code\n{source}", cell_type="code")
+    log(f"CREATE bad code: {source[:40]}... -> {cell.id[:8]}")
+
+
+async def action_execute(notebook, name, log):
+    """Execute a random cell."""
+    ids = notebook.cells.ids
+    if not ids:
+        return
+    cell_id = random.choice(ids)
+    cell = notebook.cells[cell_id]
+    log(f"EXECUTE {cell_id[:8]}: {cell.source[:30] if cell.source else '(empty)'}...")
+    try:
+        result = await cell.run(timeout_secs=10)
+        log(f"  -> success={result.success} outs={len(result.outputs)}")
+    except Exception as e:
+        log(f"  -> error: {e}")
+
+
+async def action_delete(notebook, name, log):
+    """Delete a random cell (but keep at least one)."""
+    ids = notebook.cells.ids
+    if len(ids) <= 1:
+        return
+    cell_id = random.choice(ids)
+    log(f"DELETE {cell_id[:8]}")
+    try:
+        await notebook.cells[cell_id].delete()
+    except Exception as e:
+        log(f"  -> error: {e}")
+
+
+async def action_edit_source(notebook, name, log):
+    """Edit a random cell's source by appending a comment."""
+    ids = notebook.cells.ids
+    if not ids:
+        return
+    cell_id = random.choice(ids)
+    cell = notebook.cells[cell_id]
+    source = cell.source
+    if source is None:
+        return
+    emoji = random.choice(EMOJI)
+    comment = f"\n# {emoji} {name} @ {time.strftime('%H:%M:%S')}"
+    try:
+        await cell.append(comment)
+        log(f"EDIT {cell_id[:8]}: appended comment")
+    except Exception as e:
+        log(f"EDIT {cell_id[:8]} error: {e}")
+
+
+async def action_clear_outputs(notebook, name, log):
+    """Clear outputs on a random cell."""
+    ids = notebook.cells.ids
+    if not ids:
+        return
+    cell_id = random.choice(ids)
+    log(f"CLEAR outputs {cell_id[:8]}")
+    try:
+        await notebook.cells[cell_id].clear_outputs()
+    except Exception as e:
+        log(f"  -> error: {e}")
+
+
+async def action_move(notebook, name, log):
+    """Move a random cell to a random position."""
+    ids = notebook.cells.ids
+    if len(ids) < 2:
+        return
+    cell_id = random.choice(ids)
+    other_ids = [i for i in ids if i != cell_id]
+    target_id = random.choice(other_ids)
+    log(f"MOVE {cell_id[:8]} after {target_id[:8]}")
+    try:
+        target_cell = notebook.cells[target_id]
+        await notebook.cells[cell_id].move_after(target_cell)
+    except Exception as e:
+        log(f"  -> error: {e}")
+
+
+async def action_rapid_execute(notebook, name, log):
+    """Rapid-fire queue the same cell multiple times (stress test)."""
+    ids = notebook.cells.ids
+    if not ids:
+        return
+    cell_id = random.choice(ids)
+    count = random.randint(3, 7)
+    log(f"RAPID EXECUTE {cell_id[:8]} x{count}")
+    for i in range(count):
+        try:
+            await notebook.cells[cell_id].queue()
+        except Exception as e:
+            log(f"  -> rapid exec {i + 1} error: {e}")
+            break
+
+
+async def action_read_and_verify(notebook, name, log):
+    """Read all cells and log the state (verifies sync is working)."""
+    ids = notebook.cells.ids
+    log(f"READ: {len(ids)} cells")
+    for i, cell_id in enumerate(ids[:5]):
+        cell = notebook.cells[cell_id]
+        src = cell.source[:30].replace("\n", "\\n") if cell.source else "(empty)"
+        log(f"  [{i}] {cell.cell_type} ec={cell.execution_count}: {src}")
+    if len(ids) > 5:
+        log(f"  ... and {len(ids) - 5} more")
+
+
+# ── Weighted action selection ─────────────────────────────────────────
+
+ACTIONS = [
+    (action_create_code, 20),
+    (action_create_markdown, 5),
+    (action_create_bad_code, 5),
+    (action_execute, 25),
+    (action_delete, 10),
+    (action_edit_source, 15),
+    (action_clear_outputs, 5),
+    (action_move, 5),
+    (action_rapid_execute, 5),
+    (action_read_and_verify, 5),
+]
+
+
+def pick_action():
+    """Weighted random action selection."""
+    actions, weights = zip(*ACTIONS)
+    return random.choices(actions, weights=weights, k=1)[0]
+
+
+# ── Single gremlin coroutine ──────────────────────────────────────────
+
+
+async def run_single_gremlin(
+    gremlin_id: int,
+    notebook_id: str,
+    rounds: int,
+    delay: float,
+    socket_path: str | None = None,
+):
+    """Run one gremlin — connects independently to the daemon."""
+    name = f"Gremlin-{gremlin_id}"
+    prefix = f"[{name}]"
+
+    def log(msg):
+        print(f"  {prefix} {msg}")
+
+    client = Client(socket_path=socket_path, peer_label=name)
+
+    print(f"{prefix} Connecting to notebook {notebook_id[:8]}...")
+    notebook = await client.join_notebook(notebook_id)
+    print(f"{prefix} Connected! Cells: {len(notebook.cells.ids)}")
+
+    errors = 0
+    for i in range(rounds):
+        action = pick_action()
+        action_name = action.__name__.replace("action_", "").upper()
+        emoji = random.choice(EMOJI)
+        print(f"{prefix} [{i + 1:3d}/{rounds}] {emoji} {action_name}")
+
+        try:
+            await action(notebook, name, log)
+        except Exception as e:
+            log(f"💀 CRASH: {e}")
+            errors += 1
+
+        await asyncio.sleep(delay + random.uniform(0, delay))
+
+    print(f"{prefix} Done: {rounds} rounds, {errors} errors")
+    await notebook.close()
+    return errors
+
+
+# ── Main ──────────────────────────────────────────────────────────────
+
+
+async def async_main(
+    socket_path: str | None = None,
+    notebook_id: str | None = None,
+    gremlins: int = 1,
+    rounds: int = 30,
+    delay: float = 0.3,
+    seed: int | None = None,
+):
+    if seed is not None:
+        random.seed(seed)
+
+    print(f"🐸 Chaos Gremlin Pack (count={gremlins}, rounds={rounds}, delay={delay}s)")
+    print(f"   Socket: {socket_path or '(auto-discover)'}")
+
+    # Find or create the target notebook
+    if notebook_id is None:
+        client = Client(socket_path=socket_path)
+        notebooks = await client.list_active_notebooks()
+        if notebooks:
+            notebook_id = notebooks[0].notebook_id
+            print(f"   Joining first active notebook: {notebook_id[:8]}...")
+        else:
+            print("   No active notebooks — creating one...")
+            notebook = await client.create_notebook()
+            notebook_id = notebook.notebook_id
+            # Seed it with a cell
+            await notebook.cells.create(
+                source='# 🐸 Chaos Gremlin Playground\nprint("Let the chaos begin!")',
+                cell_type="code",
+            )
+            print(f"   Created: {notebook_id[:8]}")
+            await notebook.close()
+        await client.shutdown()
+
+    print(f"   Target: {notebook_id}")
+    print()
+
+    # Launch gremlins concurrently — each connects independently
+    t0 = time.monotonic()
+
+    tasks = [
+        run_single_gremlin(
+            gremlin_id=i + 1,
+            notebook_id=notebook_id,
+            rounds=rounds,
+            delay=delay,
+            socket_path=socket_path,
+        )
+        for i in range(gremlins)
+    ]
+
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+
+    elapsed = time.monotonic() - t0
+    total_errors = 0
+    for i, result in enumerate(results):
+        if isinstance(result, Exception):
+            print(f"  Gremlin-{i + 1} FATAL: {result}")
+            total_errors += 1
+        elif isinstance(result, int):
+            total_errors += result
+
+    print()
+    print("=" * 60)
+    print(f"🐸 Chaos complete: {gremlins} gremlins, {rounds} rounds each")
+    print(f"   Total errors: {total_errors}")
+    print(f"   Elapsed: {elapsed:.1f}s")
+    print("=" * 60)
+
+    # Final state check
+    try:
+        client = Client(socket_path=socket_path)
+        notebook = await client.join_notebook(notebook_id)
+        ids = notebook.cells.ids
+        print(f"   Final cells: {len(ids)}")
+        for i, cell_id in enumerate(ids):
+            cell = notebook.cells[cell_id]
+            src = cell.source[:40].replace("\n", "\\n") if cell.source else "(empty)"
+            outs = len(cell.outputs) if cell.outputs else 0
+            ec = cell.execution_count
+            print(f"   [{i}] {cell.cell_type} ec={ec} outs={outs}: {src}")
+        await notebook.close()
+        await client.shutdown()
+    except Exception as e:
+        print(f"   (failed to read final state: {e})")
+
+    print("🐸 Gremlins out.")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog="chaos-gremlin",
+        description="🐸 Randomly mutates a live notebook to stress-test sync",
+    )
+    parser.add_argument(
+        "--notebook-id",
+        default=None,
+        help="Notebook ID to join (default: first active or create new)",
+    )
+    parser.add_argument(
+        "--socket",
+        default=None,
+        help="Daemon socket path (default: auto-discover)",
+    )
+    parser.add_argument(
+        "--gremlins",
+        type=int,
+        default=1,
+        help="Number of concurrent gremlins (default: 1)",
+    )
+    parser.add_argument(
+        "--rounds",
+        type=int,
+        default=30,
+        help="Number of chaos rounds per gremlin (default: 30)",
+    )
+    parser.add_argument(
+        "--delay",
+        type=float,
+        default=0.3,
+        help="Base delay between actions in seconds (default: 0.3)",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=None,
+        help="Random seed for reproducibility",
+    )
+    args = parser.parse_args()
+
+    try:
+        asyncio.run(
+            async_main(
+                socket_path=args.socket,
+                notebook_id=args.notebook_id,
+                gremlins=args.gremlins,
+                rounds=args.rounds,
+                delay=args.delay,
+                seed=args.seed,
+            )
+        )
+    except KeyboardInterrupt:
+        print("\n🐸 Interrupted. Gremlins retreat.")
+    except Exception:
+        import traceback
+
+        traceback.print_exc()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Three sync reliability fixes found during chaos gremlin stress testing against the nightly daemon.

## Fix 1: UTF-16 text encoding for CodeMirror (Bug A)

CodeMirror positions are UTF-16 code units. Automerge was interpreting them as Unicode code points. Emoji like 🐸 (1 code point, 2 UTF-16 units) shifted splice positions, corrupting text during concurrent editing.

Automerge 0.7.4 already has `TextEncoding::Utf16CodeUnit` — we just weren't using it. WASM `NotebookHandle` now creates documents with UTF-16 encoding. The daemon continues using `UnicodeCodePoint` for Python. Encoding is local — doesn't affect sync.

Also fixes `append_source` using `String::len()` (bytes) instead of encoding-aware `length()`.

## Fix 2: Chaos gremlin daemon shutdown (Bug B)

The gremlin script called `client.shutdown()` which sends a "shut down the daemon" RPC. The daemon wasn't crashing under load — the gremlin was killing it.

## Fix 3: Catch automerge PatchLogMismatch panic (Bug D)

Known upstream bug ([automerge/automerge#1187](https://github.com/automerge/automerge/issues/1187)). Under concurrent multi-peer sync, automerge's `BatchApply::apply` panics with `PatchLogMismatch`, poisoning the session Mutex permanently.

Wrapped `receive_sync_message` in `catch_unwind` so the panic is caught, logged, and the session continues operating.

## Test results

- 223 notebook-doc Rust tests ✅
- 31 notebook-sync Rust tests ✅
- 71 splice_source Deno tests ✅ (including 5 new emoji regression tests)
- 50 WASM smoke tests ✅
- 3-gremlin stress test: daemon stable, 30 cells, 0 fatal errors

_PR submitted by @rgbkrk's agent Quill, via Zed_