### PR TITLE
fix(mcp-supervisor): remove errant -- so Vite receives --port flag

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,8 +1,8 @@
 {
   "context_servers": {
     "supervisor": {
-      "command": "./target/debug/mcp-supervisor",
-      "args": [],
+      "command": "cargo",
+      "args": ["run", "-p", "mcp-supervisor"],
       "env": {
         "RUNTIMED_DEV": "1",
       },

--- a/crates/mcp-supervisor/src/main.rs
+++ b/crates/mcp-supervisor/src/main.rs
@@ -621,7 +621,6 @@ impl Supervisor {
                     "--dir",
                     "apps/notebook",
                     "dev",
-                    "--",
                     "--port",
                     &port.to_string(),
                     "--strictPort",


### PR DESCRIPTION
The `--` in the pnpm args caused Vite to treat `--port` and `--strictPort` as positional args rather than options. Vite fell back to default port 5174 while the supervisor recorded the requested worktree-derived port.

One-line removal — verified that `pnpm --dir apps/notebook dev --port 9999 --strictPort` binds correctly without the `--`.

Also switches the Zed MCP config to `cargo run -p mcp-supervisor` so the supervisor builds automatically in fresh worktrees.

_PR submitted by @rgbkrk's agent Quill, via Zed_