### PR TITLE
fix(wasm): preserve UTF-16 encoding across sync bootstrap

### DIFF
--- a/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm
+++ b/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:318be98674411a7702c19ed2838537e34fdf0d9985ee6a6efb49bfab3e72a872
-size 1613339
+oid sha256:c04984a5d97712fbdff86f7d0354a2cf79f532919d9321d5bc62d5ff5ee3d51e
+size 1613476

--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -662,13 +662,24 @@ impl NotebookDoc {
         }
     }
 
-    /// Create an empty sync-only bootstrap document with a specific text encoding.
+    /// Create a sync-only bootstrap document with a specific text encoding.
     ///
     /// Use `TextEncoding::Utf16CodeUnit` for the WASM/CodeMirror frontend.
+    ///
+    /// Seeds the document with a single marker operation so that
+    /// `automerge::Automerge::is_empty()` returns false.  Without this,
+    /// the first `receive_sync_message` / `load_incremental` call hits a
+    /// fast-path that replaces `*self` with a freshly-loaded doc using
+    /// **default** `LoadOptions` — discarding the encoding we set here.
+    /// A non-empty doc takes the normal incremental-apply path which
+    /// preserves the encoding.
     pub fn empty_with_encoding(encoding: TextEncoding) -> Self {
-        Self {
-            doc: AutoCommit::new_with_encoding(encoding),
-        }
+        let mut doc = AutoCommit::new_with_encoding(encoding);
+        // Marker op: keeps encoding alive across the first sync.
+        // The daemon also writes schema_version = 2, so the CRDT
+        // merge converges to the same value with no conflict.
+        let _ = doc.put(automerge::ROOT, "schema_version", SCHEMA_VERSION);
+        Self { doc }
     }
 
     /// Create an empty sync-only bootstrap document with a specific actor identity.


### PR DESCRIPTION
Fixes emoji deletion eating extra characters (e.g., backspacing 🌍 from `print("hello world 🌍")` produced `print("hello world )` — missing the closing `"`).

## Root cause

PR #1078 set `TextEncoding::Utf16CodeUnit` on the WASM `NotebookHandle` constructors. This worked for handles that never sync, but **every real frontend session** creates an empty bootstrap handle and syncs from the daemon. Automerge's `load_incremental` has a [fast path for empty documents](https://github.com/automerge/automerge/blob/main/rust/automerge/src/automerge.rs#L838-L850) that does `*self = Self::load_with_options(data, LoadOptions::new())` — replacing the entire doc object with one using **default** `LoadOptions` (= `UnicodeCodePoint` encoding), discarding the UTF-16 encoding we set.

## Fix

Seed the bootstrap doc with a single marker operation (`schema_version = 2`) so `is_empty()` returns false. This forces `load_incremental` to take the normal incremental-apply path which preserves the encoding. The daemon also writes `schema_version = 2`, so the CRDT merge converges with no conflict.

## Verification

- Deno probe confirms encoding survives full sync round-trip ✅
- 223 notebook-doc tests ✅
- 71 splice_source tests ✅  
- 50 smoke tests ✅
- Manual test: backspacing 🌍 in `print("hello world 🌍")` now correctly produces `print("hello world ")` ✅

This is a classic: [nteract/archived-desktop-app#1706](https://github.com/nteract/archived-desktop-app/issues/1706) (2017), [jupyter/jupyter_client#259](https://github.com/jupyter/jupyter_client/issues/259) (2017) — surrogate pair handling, round 3.

Also includes diagnostic logging in the CRDT bridge (will remove before ship).

_PR submitted by @rgbkrk's agent Quill, via Zed_