### PR TITLE
fix(presence): clear stale selections on cursor/focus transitions

### DIFF
--- a/apps/notebook/src/lib/cursor-registry.ts
+++ b/apps/notebook/src/lib/cursor-registry.ts
@@ -246,11 +246,6 @@ function handlePresence(payload: unknown): void {
           affectedCells.add(peer.cursor.cell_id);
           peer.cursor = undefined;
         }
-        // Focus replaces selection
-        if (peer.selection) {
-          affectedCells.add(peer.selection.cell_id);
-          peer.selection = undefined;
-        }
         if (peer.focus && peer.focus.cell_id !== data.cell_id) {
           affectedCells.add(peer.focus.cell_id);
         }

--- a/apps/notebook/src/lib/cursor-registry.ts
+++ b/apps/notebook/src/lib/cursor-registry.ts
@@ -225,6 +225,11 @@ function handlePresence(payload: unknown): void {
           affectedCells.add(peer.focus.cell_id);
           peer.focus = undefined;
         }
+        // Cursor-only means no selection (anchor === head in sender)
+        if (peer.selection) {
+          affectedCells.add(peer.selection.cell_id);
+          peer.selection = undefined;
+        }
         peer.cursor = data;
         affectedCells.add(data.cell_id);
       } else if (msg.channel === "selection") {
@@ -240,6 +245,11 @@ function handlePresence(payload: unknown): void {
         if (peer.cursor) {
           affectedCells.add(peer.cursor.cell_id);
           peer.cursor = undefined;
+        }
+        // Focus replaces selection
+        if (peer.selection) {
+          affectedCells.add(peer.selection.cell_id);
+          peer.selection = undefined;
         }
         if (peer.focus && peer.focus.cell_id !== data.cell_id) {
           affectedCells.add(peer.focus.cell_id);


### PR DESCRIPTION
## Summary

The cursor-registry (hot path for dispatching remote presence to CodeMirror) kept stale selection highlights when receiving cursor-only updates from a peer. The `presenceSenderExtension` sends either a cursor (anchor === head) or a selection (anchor !== head), never both — so receiving a cursor-only update means the peer no longer has a selection. The registry now clears `peer.selection` on cursor-only updates, matching the existing pattern that already clears focus.

Note: the `focus` channel is intentionally left alone — it's a cell-level indicator emitted on execute/clear-outputs and doesn't imply the peer's selection is gone.

## Verification

- [ ] Open the same notebook in two windows side by side
- [ ] In window A, select text in a code cell — window B shows colored selection highlight
- [ ] In window A, click to place cursor (deselect) — window B's selection highlight disappears
- [ ] In window A, select text, then execute (Shift+Enter) — window B still shows the selection (execution doesn't change selection state)

<!-- screenshots of before/after behavior -->

_PR submitted by @rgbkrk's agent, Quill_