### PR TITLE
fix: pass notebook path as document arg to macOS `open` command

### DIFF
--- a/crates/runt-workspace/src/lib.rs
+++ b/crates/runt-workspace/src/lib.rs
@@ -237,14 +237,20 @@ fn open_notebook_installed(path: Option<&Path>, extra_args: &[&str]) -> Result<(
         let spawn_result = {
             let mut cmd = Command::new("open");
             cmd.arg("-a").arg(app_name);
-            if path.is_some() || !extra_args.is_empty() {
-                cmd.arg("--args");
-            }
+            // Pass the notebook path as a document argument (before --args)
+            // so macOS delivers it via Apple Events (kAEOpenDocuments) whether
+            // the app is freshly launched or already running. Putting the path
+            // after --args only works on fresh launch; for a running app macOS
+            // ignores --args and just activates the existing instance without
+            // opening the file.
             if let Some(p) = path {
                 cmd.arg(p);
             }
-            for arg in extra_args {
-                cmd.arg(arg);
+            if !extra_args.is_empty() {
+                cmd.arg("--args");
+                for arg in extra_args {
+                    cmd.arg(arg);
+                }
             }
             cmd.spawn()
         };


### PR DESCRIPTION
## Problem

`show_notebook()` navigates to the wrong notebook after `save_notebook()` re-keys an ephemeral session.

### Repro steps
1. Create a notebook via MCP `create_notebook()` — gets ephemeral UUID.
2. Save it via `save_notebook(path=".../claude-hacking.ipynb")` — daemon re-keys session from UUID → file path.
3. Call `show_notebook()` — **expected:** opens `claude-hacking.ipynb`. **Actual:** brings focus to the previously active notebook (`div.ipynb`).

The MCP tool returns `{"opened": true}` with the correct `notebook_id`, but the desktop app never receives the file path.

## Root cause

In `open_notebook_installed`, the notebook path was placed **after** `--args` in the macOS `open` command:

```
open -a "nteract Nightly" --args /path/to/notebook.ipynb
```

The `--args` flag tells `open` that all subsequent arguments are CLI arguments for the application — these are only delivered when the app is **freshly launched**. When the app is **already running**, macOS ignores `--args` entirely and just activates the existing instance. The file path is never delivered to the app, so it simply shows whatever was previously focused.

## Fix

Pass the notebook path as a **document** argument (before `--args`) so macOS treats it as a file to open via Apple Events (`kAEOpenDocuments`):

```
open -a "nteract Nightly" /path/to/notebook.ipynb
```

This is delivered to Tauri as `RunEvent::Opened { urls }` whether the app is freshly launched or already running. The existing `Opened` handler correctly looks up or creates a window for the file.

## Note

The triage report also mentions an autosave persistence issue (cells not persisted after re-key). That appears to be a separate daemon-side problem and is not addressed here.