### PR TITLE
fix: unique Vite port per worktree + add `.mcp.json`

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -6,5 +6,4 @@
 PATH_add bin
 
 export RUNTIMED_WORKSPACE_PATH="$(expand_path .)"
-export RUNTIMED_VITE_PORT="${CONDUCTOR_PORT:-5174}"
 export RUNTIMED_DEV=1

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "nteract": {
+      "command": "cargo",
+      "args": ["run", "-p", "mcp-supervisor"],
+      "env": {
+        "RUNTIMED_DEV": "1"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Two small DX fixes

### 1. Fix Vite port collisions across worktrees

`.envrc` had:
```
export RUNTIMED_VITE_PORT="${CONDUCTOR_PORT:-5174}"
```

Every worktree fell back to port 5174 since `CONDUCTOR_PORT` is never set, causing `cargo xtask notebook --attach` to fail when multiple worktrees are running Vite.

**Fix:** Remove the hardcoded override. With it gone, the Rust tooling (`xtask`, supervisor) derives a unique port from `RUNTIMED_WORKSPACE_PATH` via `runt_workspace::vite_port_for_workspace()`, which hashes the worktree path into the 5100–9999 range. Each worktree gets a stable, unique port automatically.

### 2. Add `.mcp.json`

Adds the supervisor MCP server config so Claude Code (and any other client that reads `.mcp.json`) can discover the nteract MCP supervisor automatically. Matches the existing Zed config in `.zed/settings.json`.