### PR TITLE
feat(runtimed): thread execution_id through protocol and kernel manager

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -313,9 +313,9 @@ function AppContent() {
   // Split queue state into executing (currently running) and queued (waiting).
   // Previously these were merged into one Set — now differentiated for UI.
   const executingCellIds = new Set(
-    queueState.executing ? [queueState.executing] : [],
+    queueState.executing ? [queueState.executing.cell_id] : [],
   );
-  const queuedCellIds = new Set(queueState.queued);
+  const queuedCellIds = new Set(queueState.queued.map((e) => e.cell_id));
 
   // When kernel is running and we know the env source, use it to determine panel type.
   // This handles: both-deps (backend picks based on preference), pixi (auto-detected, no metadata).

--- a/apps/notebook/src/hooks/useDaemonKernel.ts
+++ b/apps/notebook/src/hooks/useDaemonKernel.ts
@@ -17,7 +17,11 @@ import {
 } from "../lib/kernel-status";
 import { logger } from "../lib/logger";
 import { subscribeBroadcast } from "../lib/notebook-frame-bus";
-import { resetRuntimeState, useRuntimeState } from "../lib/runtime-state";
+import {
+  type QueueEntry,
+  resetRuntimeState,
+  useRuntimeState,
+} from "../lib/runtime-state";
 import type {
   DaemonBroadcast,
   DaemonNotebookResponse,
@@ -31,8 +35,8 @@ export type DaemonKernelStatus = KernelStatus;
 
 /** Queue state from daemon */
 export interface DaemonQueueState {
-  executing: string | null;
-  queued: string[];
+  executing: QueueEntry | null;
+  queued: QueueEntry[];
 }
 
 interface UseDaemonKernelOptions {
@@ -92,7 +96,7 @@ export function useDaemonKernel({
       executing: runtimeState.queue.executing,
       queued: runtimeState.queue.queued,
     }),
-    [runtimeState.queue.executing, runtimeState.queue.queued],
+    [runtimeState.queue],
   );
 
   // Derive env sync state from the doc
@@ -229,11 +233,12 @@ export function useDaemonKernel({
   useEffect(() => {
     const prev = prevQueueRef.current;
     prevQueueRef.current = queueState;
-    const executingChanged = prev.executing !== queueState.executing;
+    const executingChanged =
+      prev.executing?.cell_id !== queueState.executing?.cell_id;
     let queuedChanged = prev.queued.length !== queueState.queued.length;
     if (!queuedChanged) {
       for (let i = 0; i < prev.queued.length; i++) {
-        if (prev.queued[i] !== queueState.queued[i]) {
+        if (prev.queued[i]?.cell_id !== queueState.queued[i]?.cell_id) {
           queuedChanged = true;
           break;
         }
@@ -584,7 +589,7 @@ export function useDaemonKernel({
         // for state but kept for backward compatibility.
         return {
           executing: response.executing ?? null,
-          queued: response.queued,
+          queued: response.queued ?? [],
         };
       }
     } catch (e) {
@@ -677,9 +682,11 @@ export function useDaemonKernel({
     /** Send a comm message to the kernel (for widget interactions) */
     sendCommMessage,
     /** Check if a cell is currently executing */
-    isCellExecuting: (cellId: string) => queueState.executing === cellId,
+    isCellExecuting: (cellId: string) =>
+      queueState.executing?.cell_id === cellId,
     /** Check if a cell is in the queue */
     isCellQueued: (cellId: string) =>
-      queueState.executing === cellId || queueState.queued.includes(cellId),
+      queueState.executing?.cell_id === cellId ||
+      queueState.queued.some((entry) => entry.cell_id === cellId),
   };
 }

--- a/apps/notebook/src/lib/runtime-state.ts
+++ b/apps/notebook/src/lib/runtime-state.ts
@@ -20,9 +20,14 @@ export interface KernelState {
   env_source: string;
 }
 
+export interface QueueEntry {
+  cell_id: string;
+  execution_id: string;
+}
+
 export interface QueueState {
-  executing: string | null;
-  queued: string[];
+  executing: QueueEntry | null;
+  queued: QueueEntry[];
 }
 
 export interface EnvState {

--- a/apps/notebook/src/types.ts
+++ b/apps/notebook/src/types.ts
@@ -162,11 +162,13 @@ export type DaemonBroadcast =
   | {
       event: "execution_started";
       cell_id: string;
+      execution_id: string;
       execution_count: number;
     }
   | {
       event: "output";
       cell_id: string;
+      execution_id: string;
       output_type: string; // "stream" | "display_data" | "execute_result" | "error"
       output_json: string; // Serialized output in nbformat shape
     }
@@ -179,11 +181,12 @@ export type DaemonBroadcast =
   | {
       event: "execution_done";
       cell_id: string;
+      execution_id: string;
     }
   | {
       event: "queue_changed";
-      executing?: string;
-      queued: string[];
+      executing?: { cell_id: string; execution_id: string } | null;
+      queued: { cell_id: string; execution_id: string }[];
     }
   | {
       event: "kernel_error";
@@ -234,7 +237,7 @@ export type DaemonNotebookResponse =
       kernel_type: string;
       env_source: string;
     }
-  | { result: "cell_queued"; cell_id: string }
+  | { result: "cell_queued"; cell_id: string; execution_id: string }
   | { result: "outputs_cleared"; cell_id: string }
   | { result: "interrupt_sent" }
   | { result: "kernel_shutting_down" }
@@ -245,8 +248,15 @@ export type DaemonNotebookResponse =
       env_source?: string;
       status: string;
     }
-  | { result: "queue_state"; executing?: string; queued: string[] }
-  | { result: "all_cells_queued"; count: number }
+  | {
+      result: "queue_state";
+      executing?: { cell_id: string; execution_id: string } | null;
+      queued: { cell_id: string; execution_id: string }[];
+    }
+  | {
+      result: "all_cells_queued";
+      queued: { cell_id: string; execution_id: string }[];
+    }
   | { result: "ok" }
   | { result: "error"; error: string }
   | { result: "sync_environment_started"; packages: string[] }

--- a/crates/notebook-doc/src/runtime_state.rs
+++ b/crates/notebook-doc/src/runtime_state.rs
@@ -13,8 +13,10 @@
 //!     language: Str        (e.g. "python", "typescript")
 //!     env_source: Str      (e.g. "uv:prewarmed", "conda:pixi", "deno")
 //!   queue/
-//!     executing: Str|null  (cell_id currently executing)
-//!     queued: List[Str]    (cell_ids waiting)
+//!     executing: Str|null              (cell_id currently executing)
+//!     executing_execution_id: Str|null (execution_id for the executing cell)
+//!     queued: List[Str]                (cell_ids waiting)
+//!     queued_execution_ids: List[Str]  (parallel execution_ids for queued entries)
 //!   env/
 //!     in_sync: bool
 //!     added: List[Str]     (packages in metadata but not in kernel)
@@ -58,11 +60,18 @@ impl Default for KernelState {
     }
 }
 
+/// An entry in the execution queue.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct QueueEntry {
+    pub cell_id: String,
+    pub execution_id: String,
+}
+
 /// Queue state snapshot.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct QueueState {
-    pub executing: Option<String>,
-    pub queued: Vec<String>,
+    pub executing: Option<QueueEntry>,
+    pub queued: Vec<QueueEntry>,
 }
 
 /// Environment sync state snapshot.
@@ -150,8 +159,12 @@ impl RuntimeStateDoc {
             .expect("scaffold queue");
         doc.put(&queue, "executing", ScalarValue::Null)
             .expect("scaffold queue.executing");
+        doc.put(&queue, "executing_execution_id", ScalarValue::Null)
+            .expect("scaffold queue.executing_execution_id");
         doc.put_object(&queue, "queued", ObjType::List)
             .expect("scaffold queue.queued");
+        doc.put_object(&queue, "queued_execution_ids", ObjType::List)
+            .expect("scaffold queue.queued_execution_ids");
 
         // env/
         let env = doc
@@ -365,49 +378,91 @@ impl RuntimeStateDoc {
 
     /// Update queue state. Returns `true` if mutated.
     #[allow(clippy::expect_used)]
-    pub fn set_queue(&mut self, executing: Option<&str>, queued: &[String]) -> bool {
+    pub fn set_queue(&mut self, executing: Option<&QueueEntry>, queued: &[QueueEntry]) -> bool {
         let queue = self.get_map("queue").expect("queue map must exist");
-        let cur_executing = self.read_opt_str(&queue, "executing");
-        let cur_queued = self.read_str_list(&queue, "queued");
+        let cur_exec_cid = self.read_opt_str(&queue, "executing");
+        let cur_exec_eid = self.read_opt_str(&queue, "executing_execution_id");
+        let cur_queued_cids = self.read_str_list(&queue, "queued");
+        let cur_queued_eids = self.read_str_list(&queue, "queued_execution_ids");
 
-        let exec_match = match (&cur_executing, executing) {
+        // Compare executing by both cell_id and execution_id
+        let exec_match = match (&cur_exec_cid, executing) {
             (None, None) => true,
-            (Some(a), Some(b)) => a == b,
+            (Some(cid), Some(entry)) => {
+                cid == &entry.cell_id && cur_exec_eid.as_deref().unwrap_or("") == entry.execution_id
+            }
             _ => false,
         };
 
-        if exec_match && cur_queued.len() == queued.len() && cur_queued == queued {
+        let queued_cids: Vec<&str> = queued.iter().map(|e| e.cell_id.as_str()).collect();
+        let queued_eids: Vec<&str> = queued.iter().map(|e| e.execution_id.as_str()).collect();
+        let cur_cid_refs: Vec<&str> = cur_queued_cids.iter().map(|s| s.as_str()).collect();
+        let cur_eid_refs: Vec<&str> = cur_queued_eids.iter().map(|s| s.as_str()).collect();
+
+        if exec_match && cur_cid_refs == queued_cids && cur_eid_refs == queued_eids {
             return false;
         }
 
+        // Write executing cell_id and execution_id
         match executing {
-            Some(cell_id) => self
-                .doc
-                .put(&queue, "executing", cell_id)
-                .expect("put queue.executing"),
-            None => self
-                .doc
-                .put(&queue, "executing", ScalarValue::Null)
-                .expect("put queue.executing null"),
+            Some(entry) => {
+                self.doc
+                    .put(&queue, "executing", entry.cell_id.as_str())
+                    .expect("put queue.executing");
+                self.doc
+                    .put(
+                        &queue,
+                        "executing_execution_id",
+                        entry.execution_id.as_str(),
+                    )
+                    .expect("put queue.executing_execution_id");
+            }
+            None => {
+                self.doc
+                    .put(&queue, "executing", ScalarValue::Null)
+                    .expect("put queue.executing null");
+                self.doc
+                    .put(&queue, "executing_execution_id", ScalarValue::Null)
+                    .expect("put queue.executing_execution_id null");
+            }
         }
 
-        // Reuse the existing list object to avoid Automerge object churn.
-        let list = self
+        // Reuse existing list objects to avoid Automerge object churn.
+        let cid_list = self
             .doc
             .get(&queue, "queued")
             .expect("get queue.queued")
             .map(|(_, id)| id)
             .expect("queued list must exist");
+        let eid_list = self
+            .doc
+            .get(&queue, "queued_execution_ids")
+            .expect("get queue.queued_execution_ids")
+            .map(|(_, id)| id)
+            .expect("queued_execution_ids list must exist");
+
         // Clear existing entries (reverse order for stable indices)
-        let len = self.doc.length(&list);
-        for i in (0..len).rev() {
-            self.doc.delete(&list, i).expect("delete queued entry");
-        }
-        // Insert new entries
-        for (i, cell_id) in queued.iter().enumerate() {
+        let cid_len = self.doc.length(&cid_list);
+        for i in (0..cid_len).rev() {
             self.doc
-                .insert(&list, i, cell_id.as_str())
+                .delete(&cid_list, i)
+                .expect("delete queued cell_id");
+        }
+        let eid_len = self.doc.length(&eid_list);
+        for i in (0..eid_len).rev() {
+            self.doc
+                .delete(&eid_list, i)
+                .expect("delete queued execution_id");
+        }
+
+        // Insert new entries in both parallel lists
+        for (i, entry) in queued.iter().enumerate() {
+            self.doc
+                .insert(&cid_list, i, entry.cell_id.as_str())
                 .expect("insert queued cell_id");
+            self.doc
+                .insert(&eid_list, i, entry.execution_id.as_str())
+                .expect("insert queued execution_id");
         }
 
         true
@@ -549,9 +604,30 @@ impl RuntimeStateDoc {
 
         let queue_state = queue
             .as_ref()
-            .map(|q| QueueState {
-                executing: self.read_opt_str(q, "executing"),
-                queued: self.read_str_list(q, "queued"),
+            .map(|q| {
+                let executing_cid = self.read_opt_str(q, "executing");
+                let executing_eid = self.read_opt_str(q, "executing_execution_id");
+                let queued_cids = self.read_str_list(q, "queued");
+                let queued_eids = self.read_str_list(q, "queued_execution_ids");
+
+                QueueState {
+                    executing: executing_cid.map(|cid| QueueEntry {
+                        cell_id: cid,
+                        execution_id: executing_eid.unwrap_or_default(),
+                    }),
+                    queued: queued_cids
+                        .into_iter()
+                        .zip(
+                            queued_eids
+                                .into_iter()
+                                .chain(std::iter::repeat(String::new())),
+                        )
+                        .map(|(cid, eid)| QueueEntry {
+                            cell_id: cid,
+                            execution_id: eid,
+                        })
+                        .collect(),
+                }
             })
             .unwrap_or_default();
 
@@ -679,12 +755,33 @@ mod tests {
     #[test]
     fn test_set_queue() {
         let mut doc = RuntimeStateDoc::new();
-        let queued = vec!["cell-2".to_string(), "cell-3".to_string()];
-        assert!(doc.set_queue(Some("cell-1"), &queued));
+        let exec = QueueEntry {
+            cell_id: "cell-1".to_string(),
+            execution_id: "exec-1".to_string(),
+        };
+        let queued = vec![
+            QueueEntry {
+                cell_id: "cell-2".to_string(),
+                execution_id: "exec-2".to_string(),
+            },
+            QueueEntry {
+                cell_id: "cell-3".to_string(),
+                execution_id: "exec-3".to_string(),
+            },
+        ];
+        assert!(doc.set_queue(Some(&exec), &queued));
 
         let state = doc.read_state();
-        assert_eq!(state.queue.executing, Some("cell-1".to_string()));
-        assert_eq!(state.queue.queued, queued);
+        assert_eq!(state.queue.executing.as_ref().unwrap().cell_id, "cell-1");
+        assert_eq!(
+            state.queue.executing.as_ref().unwrap().execution_id,
+            "exec-1"
+        );
+        assert_eq!(state.queue.queued.len(), 2);
+        assert_eq!(state.queue.queued[0].cell_id, "cell-2");
+        assert_eq!(state.queue.queued[0].execution_id, "exec-2");
+        assert_eq!(state.queue.queued[1].cell_id, "cell-3");
+        assert_eq!(state.queue.queued[1].execution_id, "exec-3");
     }
 
     #[test]
@@ -744,9 +841,16 @@ mod tests {
         assert!(!doc.set_kernel_info("k", "python", "uv:prewarmed"));
 
         // Same for queue
-        let q = vec!["a".to_string()];
-        assert!(doc.set_queue(Some("x"), &q));
-        assert!(!doc.set_queue(Some("x"), &q));
+        let exec = QueueEntry {
+            cell_id: "x".to_string(),
+            execution_id: "e1".to_string(),
+        };
+        let q = vec![QueueEntry {
+            cell_id: "a".to_string(),
+            execution_id: "e2".to_string(),
+        }];
+        assert!(doc.set_queue(Some(&exec), &q));
+        assert!(!doc.set_queue(Some(&exec), &q));
 
         // Same for env — defaults are (true, [], [], false, false),
         // so use non-default values to get an initial mutation.
@@ -768,8 +872,20 @@ mod tests {
         daemon_doc.set_kernel_status("busy");
         daemon_doc.set_kernel_info("charming-toucan", "python", "uv:prewarmed");
         daemon_doc.set_queue(
-            Some("cell-1"),
-            &["cell-2".to_string(), "cell-3".to_string()],
+            Some(&QueueEntry {
+                cell_id: "cell-1".to_string(),
+                execution_id: "exec-1".to_string(),
+            }),
+            &[
+                QueueEntry {
+                    cell_id: "cell-2".to_string(),
+                    execution_id: "exec-2".to_string(),
+                },
+                QueueEntry {
+                    cell_id: "cell-3".to_string(),
+                    execution_id: "exec-3".to_string(),
+                },
+            ],
         );
         daemon_doc.set_env_sync(
             false,
@@ -811,7 +927,14 @@ mod tests {
         assert_eq!(daemon_state, client_state);
         assert_eq!(client_state.kernel.status, "busy");
         assert_eq!(client_state.kernel.name, "charming-toucan");
-        assert_eq!(client_state.queue.executing, Some("cell-1".to_string()));
+        assert_eq!(
+            client_state.queue.executing.as_ref().unwrap().cell_id,
+            "cell-1"
+        );
+        assert_eq!(
+            client_state.queue.executing.as_ref().unwrap().execution_id,
+            "exec-1"
+        );
         assert_eq!(client_state.queue.queued.len(), 2);
         assert!(!client_state.env.in_sync);
         assert_eq!(client_state.trust.status, "untrusted");

--- a/crates/notebook-protocol/src/protocol.rs
+++ b/crates/notebook-protocol/src/protocol.rs
@@ -113,6 +113,13 @@ pub struct PoolError {
     pub retry_in_secs: u64,
 }
 
+/// An entry in the execution queue, pairing a cell with its execution.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct QueueEntry {
+    pub cell_id: String,
+    pub execution_id: String,
+}
+
 // ── Helper structs ──────────────────────────────────────────────────────────
 
 /// A single entry from kernel input history.
@@ -325,7 +332,10 @@ pub enum NotebookResponse {
     },
 
     /// Cell queued for execution.
-    CellQueued { cell_id: String },
+    CellQueued {
+        cell_id: String,
+        execution_id: String,
+    },
 
     /// Outputs cleared.
     OutputsCleared { cell_id: String },
@@ -348,14 +358,12 @@ pub enum NotebookResponse {
 
     /// Queue state response.
     QueueState {
-        executing: Option<String>, // cell_id currently executing
-        queued: Vec<String>,       // cell_ids waiting
+        executing: Option<QueueEntry>,
+        queued: Vec<QueueEntry>,
     },
 
     /// All cells queued for execution.
-    AllCellsQueued {
-        count: usize, // number of code cells queued
-    },
+    AllCellsQueued { queued: Vec<QueueEntry> },
 
     /// Notebook saved successfully to disk.
     NotebookSaved {
@@ -451,12 +459,14 @@ pub enum NotebookBroadcast {
     /// Execution started for a cell.
     ExecutionStarted {
         cell_id: String,
+        execution_id: String,
         execution_count: i64,
     },
 
     /// Output produced by a cell.
     Output {
         cell_id: String,
+        execution_id: String,
         output_type: String, // "stream", "display_data", "execute_result", "error"
         output_json: String, // Serialized Jupyter output content
         /// If Some, this is an update to an existing output at the given index.
@@ -473,12 +483,15 @@ pub enum NotebookBroadcast {
     },
 
     /// Execution completed for a cell.
-    ExecutionDone { cell_id: String },
+    ExecutionDone {
+        cell_id: String,
+        execution_id: String,
+    },
 
     /// Queue state changed.
     QueueChanged {
-        executing: Option<String>,
-        queued: Vec<String>,
+        executing: Option<QueueEntry>,
+        queued: Vec<QueueEntry>,
     },
 
     /// Kernel error (failed to launch, crashed, etc.)

--- a/crates/notebook-sync/src/tests.rs
+++ b/crates/notebook-sync/src/tests.rs
@@ -725,7 +725,7 @@ mod integration_tests {
 
         while tokio::time::Instant::now() < deadline {
             match tokio::time::timeout(Duration::from_millis(500), broadcast_rx.recv()).await {
-                Ok(Some(NotebookBroadcast::ExecutionDone { cell_id }))
+                Ok(Some(NotebookBroadcast::ExecutionDone { cell_id, .. }))
                     if cell_id == "cell-exec" =>
                 {
                     got_done = true;

--- a/crates/runtimed-py/src/event_stream.rs
+++ b/crates/runtimed-py/src/event_stream.rs
@@ -115,6 +115,7 @@ impl ExecutionEventStream {
                             NotebookBroadcast::ExecutionStarted {
                                 cell_id: msg_cell_id,
                                 execution_count,
+                                ..
                             } => {
                                 if msg_cell_id == cell_id {
                                     return Ok(ExecutionEvent::execution_started(
@@ -129,6 +130,7 @@ impl ExecutionEventStream {
                                 output_type,
                                 output_json,
                                 output_index,
+                                ..
                             } => {
                                 if msg_cell_id == cell_id {
                                     if signal_only {
@@ -159,6 +161,7 @@ impl ExecutionEventStream {
                             }
                             NotebookBroadcast::ExecutionDone {
                                 cell_id: msg_cell_id,
+                                ..
                             } => {
                                 if msg_cell_id == cell_id {
                                     state.done = true;
@@ -264,6 +267,7 @@ impl ExecutionEventIterator {
                         NotebookBroadcast::ExecutionStarted {
                             cell_id: msg_cell_id,
                             execution_count,
+                            ..
                         } => {
                             if msg_cell_id == cell_id {
                                 return Ok(Some(ExecutionEvent::execution_started(
@@ -277,6 +281,7 @@ impl ExecutionEventIterator {
                             output_type,
                             output_json,
                             output_index,
+                            ..
                         } => {
                             if msg_cell_id == cell_id {
                                 if signal_only {
@@ -303,6 +308,7 @@ impl ExecutionEventIterator {
                         }
                         NotebookBroadcast::ExecutionDone {
                             cell_id: msg_cell_id,
+                            ..
                         } => {
                             if msg_cell_id == cell_id {
                                 state.done = true;

--- a/crates/runtimed-py/src/lib.rs
+++ b/crates/runtimed-py/src/lib.rs
@@ -31,8 +31,8 @@ use error::RuntimedError;
 use event_stream::{ExecutionEventIterator, ExecutionEventStream};
 use output::{
     Cell, CompletionItem, CompletionResult, ExecutionEvent, ExecutionResult, HistoryEntry,
-    NotebookConnectionInfo, Output, PyEnvState, PyKernelState, PyRuntimeState, QueueState,
-    SyncEnvironmentResult,
+    NotebookConnectionInfo, Output, PyEnvState, PyKernelState, PyQueueEntry, PyRuntimeState,
+    QueueState, SyncEnvironmentResult,
 };
 use session::Session;
 use subscription::{EventIteratorSubscription, EventSubscription};
@@ -93,6 +93,7 @@ fn runtimed(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // Completion and queue types
     m.add_class::<CompletionItem>()?;
     m.add_class::<CompletionResult>()?;
+    m.add_class::<PyQueueEntry>()?;
     m.add_class::<QueueState>()?;
     m.add_class::<HistoryEntry>()?;
 

--- a/crates/runtimed-py/src/output.rs
+++ b/crates/runtimed-py/src/output.rs
@@ -542,22 +542,42 @@ impl CompletionResult {
 }
 
 /// Current state of the execution queue.
+/// An entry in the execution queue, pairing a cell with its execution.
+#[pyclass(get_all, skip_from_py_object)]
+#[derive(Clone, Debug)]
+pub struct PyQueueEntry {
+    /// Cell ID
+    pub cell_id: String,
+    /// Execution ID (UUID)
+    pub execution_id: String,
+}
+
+#[pymethods]
+impl PyQueueEntry {
+    fn __repr__(&self) -> String {
+        format!(
+            "QueueEntry(cell_id={}, execution_id={})",
+            self.cell_id, self.execution_id
+        )
+    }
+}
+
 #[pyclass(get_all, skip_from_py_object)]
 #[derive(Clone, Debug)]
 pub struct QueueState {
-    /// Cell ID currently executing (None if idle)
-    pub executing: Option<String>,
-    /// Cell IDs waiting in queue
-    pub queued: Vec<String>,
+    /// Entry currently executing (None if idle)
+    pub executing: Option<PyQueueEntry>,
+    /// Entries waiting in queue
+    pub queued: Vec<PyQueueEntry>,
 }
 
 #[pymethods]
 impl QueueState {
     fn __repr__(&self) -> String {
         match &self.executing {
-            Some(cell_id) => format!(
+            Some(entry) => format!(
                 "QueueState(executing={}, queued={})",
-                cell_id,
+                entry.cell_id,
                 self.queued.len()
             ),
             None => format!("QueueState(idle, queued={})", self.queued.len()),
@@ -833,7 +853,7 @@ impl PyRuntimeState {
             "RuntimeState(kernel={}, queue={}, env={})",
             self.kernel.status,
             match &self.queue.executing {
-                Some(id) => format!("executing={}", id),
+                Some(entry) => format!("executing={}", entry.cell_id),
                 None => format!("idle, queued={}", self.queue.queued.len()),
             },
             if self.env.in_sync {
@@ -855,8 +875,19 @@ impl From<notebook_doc::runtime_state::RuntimeState> for PyRuntimeState {
                 env_source: rs.kernel.env_source,
             },
             queue: QueueState {
-                executing: rs.queue.executing,
-                queued: rs.queue.queued,
+                executing: rs.queue.executing.map(|e| PyQueueEntry {
+                    cell_id: e.cell_id,
+                    execution_id: e.execution_id,
+                }),
+                queued: rs
+                    .queue
+                    .queued
+                    .into_iter()
+                    .map(|e| PyQueueEntry {
+                        cell_id: e.cell_id,
+                        execution_id: e.execution_id,
+                    })
+                    .collect(),
             },
             env: PyEnvState {
                 in_sync: rs.env.in_sync,

--- a/crates/runtimed-py/src/session.rs
+++ b/crates/runtimed-py/src/session.rs
@@ -795,7 +795,8 @@ impl Session {
     }
 
     /// Queue a cell for execution without waiting for the result.
-    fn queue_cell(&self, cell_id: &str) -> PyResult<()> {
+    /// Returns the execution_id for the queued execution.
+    fn queue_cell(&self, cell_id: &str) -> PyResult<String> {
         self.runtime.block_on(session_core::queue_cell(
             &self.state,
             &self.notebook_id,

--- a/crates/runtimed-py/src/session_core.rs
+++ b/crates/runtimed-py/src/session_core.rs
@@ -19,7 +19,7 @@ use crate::daemon_paths::get_socket_path;
 use crate::error::to_py_err;
 use crate::output::{
     Cell, CompletionItem, CompletionResult, ExecutionResult, HistoryEntry, NotebookConnectionInfo,
-    Output, PyRuntimeState, QueueState, SyncEnvironmentResult,
+    Output, PyQueueEntry, PyRuntimeState, QueueState, SyncEnvironmentResult,
 };
 use crate::output_resolver;
 
@@ -1125,7 +1125,7 @@ pub(crate) async fn queue_cell(
     state: &Arc<Mutex<SessionState>>,
     notebook_id: &str,
     cell_id: &str,
-) -> PyResult<()> {
+) -> PyResult<String> {
     // Auto-start kernel if not running (matches execute_cell behavior)
     {
         let st = state.lock().await;
@@ -1154,10 +1154,10 @@ pub(crate) async fn queue_cell(
     };
 
     match response {
-        NotebookResponse::CellQueued { .. } => {
+        NotebookResponse::CellQueued { execution_id, .. } => {
             // Emit focus presence — queuing cell for execution
             emit_focus_presence(state, cell_id).await;
-            Ok(())
+            Ok(execution_id)
         }
         NotebookResponse::Error { error } => Err(to_py_err(error)),
         other => Err(to_py_err(format!("Unexpected response: {:?}", other))),
@@ -1203,8 +1203,12 @@ pub(crate) async fn collect_outputs(
                         kernel_error = Some("Kernel shut down".to_string());
                         true
                     } else {
-                        let in_executing = rs.queue.executing.as_deref() == Some(cell_id);
-                        let in_queued = rs.queue.queued.iter().any(|id| id == cell_id);
+                        let in_executing = rs
+                            .queue
+                            .executing
+                            .as_ref()
+                            .is_some_and(|e| e.cell_id == cell_id);
+                        let in_queued = rs.queue.queued.iter().any(|e| e.cell_id == cell_id);
                         let in_queue = in_executing || in_queued;
 
                         if in_queue {
@@ -1247,6 +1251,7 @@ pub(crate) async fn collect_outputs(
                 {
                     Ok(Some(NotebookBroadcast::ExecutionDone {
                         cell_id: msg_cell_id,
+                        ..
                     })) => {
                         if msg_cell_id == cell_id {
                             log::debug!("[session_core] ExecutionDone broadcast for {}", cell_id);
@@ -1375,7 +1380,8 @@ pub(crate) async fn run_all_cells(
     };
 
     match response {
-        NotebookResponse::AllCellsQueued { count } => {
+        NotebookResponse::AllCellsQueued { queued } => {
+            let count = queued.len();
             // Focus on the last code cell — gives a visual anchor for where execution ends.
             // RunAllCells only queues code cells, so focusing the last code cell (not the
             // last cell overall, which might be markdown/raw) is more accurate.
@@ -2099,7 +2105,19 @@ pub(crate) async fn get_queue_state(state: &Arc<Mutex<SessionState>>) -> PyResul
         .map_err(to_py_err)?;
 
     match response {
-        NotebookResponse::QueueState { executing, queued } => Ok(QueueState { executing, queued }),
+        NotebookResponse::QueueState { executing, queued } => Ok(QueueState {
+            executing: executing.map(|e| PyQueueEntry {
+                cell_id: e.cell_id,
+                execution_id: e.execution_id,
+            }),
+            queued: queued
+                .into_iter()
+                .map(|e| PyQueueEntry {
+                    cell_id: e.cell_id,
+                    execution_id: e.execution_id,
+                })
+                .collect(),
+        }),
         NotebookResponse::Error { error } => Err(to_py_err(error)),
         other => Err(to_py_err(format!("Unexpected response: {:?}", other))),
     }

--- a/crates/runtimed-py/src/subscription.rs
+++ b/crates/runtimed-py/src/subscription.rs
@@ -246,6 +246,7 @@ async fn broadcast_to_event(
         NotebookBroadcast::ExecutionStarted {
             cell_id,
             execution_count,
+            ..
         } => {
             if !cell_ids.is_empty() && !cell_ids.contains(&cell_id) {
                 return None;
@@ -260,6 +261,7 @@ async fn broadcast_to_event(
             output_type,
             output_json,
             output_index,
+            ..
         } => {
             if !cell_ids.is_empty() && !cell_ids.contains(&cell_id) {
                 return None;
@@ -286,7 +288,7 @@ async fn broadcast_to_event(
                 Some(ExecutionEvent::output_signal(&cell_id, output_index))
             }
         }
-        NotebookBroadcast::ExecutionDone { cell_id } => {
+        NotebookBroadcast::ExecutionDone { cell_id, .. } => {
             if !cell_ids.is_empty() && !cell_ids.contains(&cell_id) {
                 return None;
             }

--- a/crates/runtimed/src/kernel_manager.rs
+++ b/crates/runtimed/src/kernel_manager.rs
@@ -34,11 +34,24 @@ use crate::blob_store::BlobStore;
 use crate::comm_state::CommState;
 use crate::notebook_doc::NotebookDoc;
 use crate::output_store::{self, DEFAULT_INLINE_THRESHOLD};
-use crate::protocol::{CompletionItem, HistoryEntry, NotebookBroadcast};
+use crate::protocol::{CompletionItem, HistoryEntry, NotebookBroadcast, QueueEntry};
 use crate::stream_terminal::{StreamOutputState, StreamTerminals};
 use crate::terminal_size::{TERMINAL_COLUMNS_STR, TERMINAL_LINES_STR};
 use crate::{EnvType, PooledEnv};
-use notebook_doc::runtime_state::RuntimeStateDoc;
+use notebook_doc::runtime_state::{QueueEntry as DocQueueEntry, RuntimeStateDoc};
+
+/// Convert a protocol QueueEntry to a RuntimeStateDoc QueueEntry.
+fn to_doc_entry(e: &QueueEntry) -> DocQueueEntry {
+    DocQueueEntry {
+        cell_id: e.cell_id.clone(),
+        execution_id: e.execution_id.clone(),
+    }
+}
+
+/// Convert a slice of protocol QueueEntries to doc QueueEntries.
+fn to_doc_entries(entries: &[QueueEntry]) -> Vec<DocQueueEntry> {
+    entries.iter().map(to_doc_entry).collect()
+}
 
 // ── Launched Environment Config ─────────────────────────────────────────────
 
@@ -192,6 +205,7 @@ async fn update_output_by_display_id_with_manifests(
 #[derive(Debug, Clone)]
 pub struct QueuedCell {
     pub cell_id: String,
+    pub execution_id: String,
     pub code: String,
 }
 
@@ -264,12 +278,12 @@ pub struct RoomKernel {
     process_group_id: Option<i32>,
     /// Kernel ID for the process registry (orphan reaping)
     kernel_id: Option<String>,
-    /// Mapping from msg_id → cell_id for routing iopub messages
-    cell_id_map: Arc<StdMutex<HashMap<String, String>>>,
+    /// Mapping from msg_id → (cell_id, execution_id) for routing iopub messages
+    cell_id_map: Arc<StdMutex<HashMap<String, (String, String)>>>,
     /// Execution queue (pending cells)
     queue: VecDeque<QueuedCell>,
-    /// Currently executing cell
-    executing: Option<String>,
+    /// Currently executing cell: (cell_id, execution_id)
+    executing: Option<(String, String)>,
     /// Current kernel status
     status: KernelStatus,
     /// Broadcast channel for sending outputs to peers
@@ -307,7 +321,10 @@ pub struct RoomKernel {
 #[derive(Debug)]
 pub enum QueueCommand {
     /// A cell finished executing (received status=idle from kernel)
-    ExecutionDone { cell_id: String },
+    ExecutionDone {
+        cell_id: String,
+        execution_id: String,
+    },
     /// A cell produced an error (for stop-on-error behavior)
     CellError { cell_id: String },
     /// The kernel process died (iopub connection lost).
@@ -443,13 +460,27 @@ impl RoomKernel {
     }
 
     /// Get the currently executing cell ID.
-    pub fn executing_cell(&self) -> Option<&String> {
-        self.executing.as_ref()
+    pub fn executing_cell(&self) -> Option<&str> {
+        self.executing.as_ref().map(|(cid, _)| cid.as_str())
     }
 
     /// Get the queued cell IDs.
-    pub fn queued_cells(&self) -> Vec<String> {
-        self.queue.iter().map(|c| c.cell_id.clone()).collect()
+    pub fn queued_cells(&self) -> Vec<QueueEntry> {
+        self.queue
+            .iter()
+            .map(|c| QueueEntry {
+                cell_id: c.cell_id.clone(),
+                execution_id: c.execution_id.clone(),
+            })
+            .collect()
+    }
+
+    /// Get the currently executing entry as a QueueEntry.
+    pub fn executing_entry(&self) -> Option<QueueEntry> {
+        self.executing.as_ref().map(|(cid, eid)| QueueEntry {
+            cell_id: cid.clone(),
+            execution_id: eid.clone(),
+        })
     }
 
     /// Launch a kernel for this room.
@@ -803,11 +834,13 @@ impl RoomKernel {
                             message.parent_header.as_ref().map(|h| &h.msg_id)
                         );
 
-                        // Look up cell_id from msg_id
-                        let cell_id = message
+                        // Look up (cell_id, execution_id) from msg_id
+                        let cell_entry = message
                             .parent_header
                             .as_ref()
                             .and_then(|h| cell_id_map.lock().ok()?.get(&h.msg_id).cloned());
+                        let cell_id = cell_entry.as_ref().map(|(cid, _)| cid.clone());
+                        let execution_id = cell_entry.as_ref().map(|(_, eid)| eid.clone());
 
                         // Handle different message types
                         match &message.content {
@@ -840,9 +873,12 @@ impl RoomKernel {
                                 // Signal execution done when idle
                                 if status.execution_state == jupyter_protocol::ExecutionState::Idle
                                 {
-                                    if let Some(cid) = cell_id {
-                                        let _ = iopub_cmd_tx
-                                            .try_send(QueueCommand::ExecutionDone { cell_id: cid });
+                                    if let Some((cid, eid)) = cell_entry.clone() {
+                                        let _ =
+                                            iopub_cmd_tx.try_send(QueueCommand::ExecutionDone {
+                                                cell_id: cid,
+                                                execution_id: eid,
+                                            });
                                     }
                                 }
                             }
@@ -886,6 +922,7 @@ impl RoomKernel {
                                     let _ =
                                         broadcast_tx.send(NotebookBroadcast::ExecutionStarted {
                                             cell_id: cid.clone(),
+                                            execution_id: execution_id.clone().unwrap_or_default(),
                                             execution_count,
                                         });
                                 }
@@ -1033,6 +1070,7 @@ impl RoomKernel {
 
                                     let _ = broadcast_tx.send(NotebookBroadcast::Output {
                                         cell_id: cid.clone(),
+                                        execution_id: execution_id.clone().unwrap_or_default(),
                                         output_type: "stream".to_string(),
                                         output_json: output_ref,
                                         output_index: broadcast_output_index,
@@ -1148,6 +1186,7 @@ impl RoomKernel {
 
                                         let _ = broadcast_tx.send(NotebookBroadcast::Output {
                                             cell_id: cid.clone(),
+                                            execution_id: execution_id.clone().unwrap_or_default(),
                                             output_type: output_type.to_string(),
                                             output_json: output_ref,
                                             output_index: None,
@@ -1305,6 +1344,7 @@ impl RoomKernel {
 
                                         let _ = broadcast_tx.send(NotebookBroadcast::Output {
                                             cell_id: cid.clone(),
+                                            execution_id: execution_id.clone().unwrap_or_default(),
                                             output_type: "error".to_string(),
                                             output_json: output_ref,
                                             output_index: None,
@@ -1515,10 +1555,12 @@ impl RoomKernel {
 
                         match msg.content {
                             JupyterMessageContent::ExecuteReply(ref reply) => {
-                                // Get cell_id from msg_id mapping
-                                let cell_id = msg.parent_header.as_ref().and_then(|h| {
+                                // Get (cell_id, execution_id) from msg_id mapping
+                                let cell_entry = msg.parent_header.as_ref().and_then(|h| {
                                     shell_cell_id_map.lock().ok()?.get(&h.msg_id).cloned()
                                 });
+                                let cell_id = cell_entry.as_ref().map(|(cid, _)| cid.clone());
+                                let execution_id = cell_entry.as_ref().map(|(_, eid)| eid.clone());
 
                                 // Process page payloads - convert to display_data outputs
                                 // This handles IPython's ? and ?? help commands
@@ -1585,6 +1627,9 @@ impl RoomKernel {
                                             let _ = shell_broadcast_tx.send(
                                                 NotebookBroadcast::Output {
                                                     cell_id: cid.clone(),
+                                                    execution_id: execution_id
+                                                        .clone()
+                                                        .unwrap_or_default(),
                                                     output_type: "display_data".to_string(),
                                                     output_json: output_ref,
                                                     output_index: None,
@@ -1600,6 +1645,9 @@ impl RoomKernel {
                                         let _ = shell_broadcast_tx.send(
                                             NotebookBroadcast::ExecutionDone {
                                                 cell_id: cid.clone(),
+                                                execution_id: execution_id
+                                                    .clone()
+                                                    .unwrap_or_default(),
                                             },
                                         );
                                     }
@@ -1766,45 +1814,59 @@ impl RoomKernel {
 
     /// Queue a cell for execution.
     ///
-    /// Idempotent: if the cell is already executing or queued, this is a no-op.
-    /// This prevents duplicate executions when multiple windows trigger RunAllCells.
-    pub async fn queue_cell(&mut self, cell_id: String, code: String) -> Result<()> {
-        // Skip if already executing or queued (idempotent)
-        if self.executing.as_ref() == Some(&cell_id) {
-            info!(
-                "[kernel-manager] Cell {} already executing, skipping",
-                cell_id
-            );
-            return Ok(());
+    /// Idempotent: if the cell is already executing or queued, returns the
+    /// existing `execution_id` instead of generating a new one.
+    /// Returns the `execution_id` for this execution.
+    pub async fn queue_cell(&mut self, cell_id: String, code: String) -> Result<String> {
+        // Idempotent: return existing execution_id if already executing or queued
+        if let Some((ref cid, ref eid)) = self.executing {
+            if cid == &cell_id {
+                info!(
+                    "[kernel-manager] Cell {} already executing ({}), skipping",
+                    cell_id, eid
+                );
+                return Ok(eid.clone());
+            }
         }
-        if self.queue.iter().any(|c| c.cell_id == cell_id) {
-            info!("[kernel-manager] Cell {} already queued, skipping", cell_id);
-            return Ok(());
+        if let Some(existing) = self.queue.iter().find(|c| c.cell_id == cell_id) {
+            info!(
+                "[kernel-manager] Cell {} already queued ({}), skipping",
+                cell_id, existing.execution_id
+            );
+            return Ok(existing.execution_id.clone());
         }
 
-        info!("[kernel-manager] Queuing cell: {}", cell_id);
+        let execution_id = Uuid::new_v4().to_string();
+        info!(
+            "[kernel-manager] Queuing cell: {} (execution_id={})",
+            cell_id, execution_id
+        );
 
         // Add to queue
         self.queue.push_back(QueuedCell {
             cell_id: cell_id.clone(),
+            execution_id: execution_id.clone(),
             code,
         });
 
         // Broadcast queue state
         let _ = self.broadcast_tx.send(NotebookBroadcast::QueueChanged {
-            executing: self.executing.clone(),
+            executing: self.executing_entry(),
             queued: self.queued_cells(),
         });
 
         {
+            let doc_exec = self.executing_entry().as_ref().map(to_doc_entry);
+            let doc_queued = to_doc_entries(&self.queued_cells());
             let mut sd = self.state_doc.write().await;
-            if sd.set_queue(self.executing.as_deref(), &self.queued_cells()) {
+            if sd.set_queue(doc_exec.as_ref(), &doc_queued) {
                 let _ = self.state_changed_tx.send(());
             }
         }
 
         // Try to process if nothing executing
-        self.process_next().await
+        self.process_next().await?;
+        Ok(execution_id)
     }
 
     /// Clear outputs for a cell (before re-execution).
@@ -1832,11 +1894,11 @@ impl RoomKernel {
             return Err(anyhow::anyhow!("No kernel running"));
         }
 
-        self.executing = Some(cell.cell_id.clone());
+        self.executing = Some((cell.cell_id.clone(), cell.execution_id.clone()));
         self.status = KernelStatus::Busy;
 
         // Collect queue state before borrowing shell_writer
-        let executing = self.executing.clone();
+        let executing = self.executing_entry();
         let queued = self.queued_cells();
 
         // Broadcast queue state
@@ -1845,8 +1907,10 @@ impl RoomKernel {
             .send(NotebookBroadcast::QueueChanged { executing, queued });
 
         {
+            let doc_exec = self.executing_entry().as_ref().map(to_doc_entry);
+            let doc_queued = to_doc_entries(&self.queued_cells());
             let mut sd = self.state_doc.write().await;
-            if sd.set_queue(self.executing.as_deref(), &self.queued_cells()) {
+            if sd.set_queue(doc_exec.as_ref(), &doc_queued) {
                 let _ = self.state_changed_tx.send(());
             }
         }
@@ -1856,41 +1920,49 @@ impl RoomKernel {
         let message: JupyterMessage = request.into();
         let msg_id = message.header.msg_id.clone();
 
-        // Register msg_id → cell_id BEFORE sending.
+        // Register msg_id → (cell_id, execution_id) BEFORE sending.
         // First, remove any old mappings for this cell_id (from previous executions).
         // This bounds the map to one entry per cell, not per execution, while still
         // allowing both shell (execute_reply) and iopub (idle status) to use the mapping.
         {
             let mut map = self.cell_id_map.lock().unwrap();
-            map.retain(|_, v| v != &cell.cell_id);
-            map.insert(msg_id.clone(), cell.cell_id.clone());
+            map.retain(|_, (cid, _)| cid != &cell.cell_id);
+            map.insert(
+                msg_id.clone(),
+                (cell.cell_id.clone(), cell.execution_id.clone()),
+            );
         }
 
         // Now borrow shell_writer mutably
         let shell = self.shell_writer.as_mut().unwrap();
         shell.send(message).await?;
         info!(
-            "[kernel-manager] Sent execute_request: msg_id={} cell_id={}",
-            msg_id, cell.cell_id
+            "[kernel-manager] Sent execute_request: msg_id={} cell_id={} execution_id={}",
+            msg_id, cell.cell_id, cell.execution_id
         );
 
         Ok(())
     }
 
     /// Mark a cell execution as complete and process next.
-    pub async fn execution_done(&mut self, cell_id: &str) -> Result<()> {
-        if self.executing.as_ref() == Some(&cell_id.to_string()) {
+    pub async fn execution_done(&mut self, cell_id: &str, execution_id: &str) -> Result<()> {
+        let matches = self
+            .executing
+            .as_ref()
+            .is_some_and(|(cid, _)| cid == cell_id);
+        if matches {
             self.executing = None;
             self.status = KernelStatus::Idle;
 
             // Note: cell_id_map cleanup happens when a cell is RE-EXECUTED (in
-            // send_execute_request), not here. The shell and iopub channels race,
+            // process_next), not here. The shell and iopub channels race,
             // and both need the mapping. Cleaning up on re-execution bounds the map
             // to one entry per cell while avoiding the race condition.
 
             // Broadcast done
             let _ = self.broadcast_tx.send(NotebookBroadcast::ExecutionDone {
                 cell_id: cell_id.to_string(),
+                execution_id: execution_id.to_string(),
             });
 
             // Broadcast queue state
@@ -1900,8 +1972,9 @@ impl RoomKernel {
             });
 
             {
+                let doc_queued = to_doc_entries(&self.queued_cells());
                 let mut sd = self.state_doc.write().await;
-                if sd.set_queue(None, &self.queued_cells()) {
+                if sd.set_queue(None, &doc_queued) {
                     let _ = self.state_changed_tx.send(());
                 }
             }
@@ -1917,13 +1990,15 @@ impl RoomKernel {
     /// Unblocks the execution queue by clearing the executing cell and queue,
     /// and broadcasts an error status to all connected peers.
     ///
+    /// Returns the (cell_id, execution_id) of the interrupted execution, if any.
+    ///
     /// This method is idempotent - multiple calls (e.g., from both process
     /// watcher and heartbeat monitor) are safe.
-    pub fn kernel_died(&mut self) {
+    pub fn kernel_died(&mut self) -> Option<(String, String)> {
         // Idempotent: if already dead, don't re-broadcast
         if self.status == KernelStatus::Dead {
             debug!("[kernel-manager] kernel_died called but already dead, ignoring");
-            return;
+            return None;
         }
 
         warn!(
@@ -1932,8 +2007,8 @@ impl RoomKernel {
             self.queue.len()
         );
 
-        // Clear executing state so the queue doesn't stay permanently stuck
-        self.executing = None;
+        // Capture the interrupted execution before clearing
+        let interrupted = self.executing.take();
         self.status = KernelStatus::Dead;
 
         // Clear any queued cells — they can't execute without a kernel
@@ -1961,6 +2036,8 @@ impl RoomKernel {
         // Note: state_doc writes for kernel_died happen in the async command
         // processor (notebook_sync_server.rs QueueCommand::KernelDied handler).
         // state_doc.set_kernel_status("error") + set_queue(None, &[])
+
+        interrupted
     }
 
     /// Interrupt the currently executing cell and clear the execution queue.
@@ -2187,18 +2264,25 @@ impl RoomKernel {
     }
 
     /// Clear the execution queue.
-    pub fn clear_queue(&mut self) -> Vec<String> {
-        let cleared: Vec<String> = self.queue.drain(..).map(|c| c.cell_id).collect();
+    pub fn clear_queue(&mut self) -> Vec<QueueEntry> {
+        let cleared: Vec<QueueEntry> = self
+            .queue
+            .drain(..)
+            .map(|c| QueueEntry {
+                cell_id: c.cell_id,
+                execution_id: c.execution_id,
+            })
+            .collect();
 
         // Broadcast queue state
         let _ = self.broadcast_tx.send(NotebookBroadcast::QueueChanged {
-            executing: self.executing.clone(),
+            executing: self.executing_entry(),
             queued: vec![],
         });
 
         // Note: state_doc writes for clear_queue happen in the async command
         // processor (notebook_sync_server.rs QueueCommand::CellError handler).
-        // state_doc.set_queue(self.executing.as_deref(), &[])
+        // state_doc.set_queue(self.executing_entry().as_ref(), &[])
 
         cleared
     }

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -43,7 +43,9 @@ use crate::kernel_manager::{DenoLaunchedConfig, LaunchedEnvConfig, RoomKernel};
 use crate::markdown_assets::resolve_markdown_assets;
 use crate::notebook_doc::{notebook_doc_filename, CellSnapshot, NotebookDoc};
 use crate::notebook_metadata::NotebookMetadataSnapshot;
-use crate::protocol::{EnvSyncDiff, NotebookBroadcast, NotebookRequest, NotebookResponse};
+use crate::protocol::{
+    EnvSyncDiff, NotebookBroadcast, NotebookRequest, NotebookResponse, QueueEntry,
+};
 use notebook_doc::presence::{self, PresenceState};
 use notebook_doc::runtime_state::RuntimeStateDoc;
 
@@ -2253,12 +2255,20 @@ async fn auto_launch_kernel(
                     use crate::kernel_manager::QueueCommand;
                     while let Some(cmd) = cmd_rx.recv().await {
                         match cmd {
-                            QueueCommand::ExecutionDone { cell_id } => {
-                                debug!("[notebook-sync] ExecutionDone for {}", cell_id);
+                            QueueCommand::ExecutionDone {
+                                cell_id,
+                                execution_id,
+                            } => {
+                                debug!(
+                                    "[notebook-sync] ExecutionDone for {} ({})",
+                                    cell_id, execution_id
+                                );
                                 let env_source = {
                                     let mut guard = room_kernel.lock().await;
                                     if let Some(ref mut k) = *guard {
-                                        if let Err(e) = k.execution_done(&cell_id).await {
+                                        if let Err(e) =
+                                            k.execution_done(&cell_id, &execution_id).await
+                                        {
                                             warn!("[notebook-sync] execution_done error: {}", e);
                                         }
                                         Some(k.env_source().to_string())
@@ -2945,15 +2955,20 @@ async fn handle_notebook_request(
                             use crate::kernel_manager::QueueCommand;
                             while let Some(cmd) = cmd_rx.recv().await {
                                 match cmd {
-                                    QueueCommand::ExecutionDone { cell_id } => {
+                                    QueueCommand::ExecutionDone {
+                                        cell_id,
+                                        execution_id,
+                                    } => {
                                         info!(
-                                            "[notebook-sync] Processing ExecutionDone for {}",
-                                            cell_id
+                                            "[notebook-sync] Processing ExecutionDone for {} ({})",
+                                            cell_id, execution_id
                                         );
                                         let env_source = {
                                             let mut guard = room_kernel.lock().await;
                                             if let Some(ref mut k) = *guard {
-                                                if let Err(e) = k.execution_done(&cell_id).await {
+                                                if let Err(e) =
+                                                    k.execution_done(&cell_id, &execution_id).await
+                                                {
                                                     warn!(
                                                         "[notebook-sync] execution_done error: {}",
                                                         e
@@ -3084,7 +3099,10 @@ async fn handle_notebook_request(
             let mut kernel_guard = room.kernel.lock().await;
             if let Some(ref mut kernel) = *kernel_guard {
                 match kernel.queue_cell(cell_id.clone(), code).await {
-                    Ok(()) => NotebookResponse::CellQueued { cell_id },
+                    Ok(execution_id) => NotebookResponse::CellQueued {
+                        cell_id,
+                        execution_id,
+                    },
                     Err(e) => NotebookResponse::Error {
                         error: format!("Failed to queue cell: {}", e),
                     },
@@ -3149,7 +3167,10 @@ async fn handle_notebook_request(
             let mut kernel_guard = room.kernel.lock().await;
             if let Some(ref mut kernel) = *kernel_guard {
                 match kernel.queue_cell(cell_id.clone(), source).await {
-                    Ok(()) => NotebookResponse::CellQueued { cell_id },
+                    Ok(execution_id) => NotebookResponse::CellQueued {
+                        cell_id,
+                        execution_id,
+                    },
                     Err(e) => NotebookResponse::Error {
                         error: format!("Failed to queue cell: {}", e),
                     },
@@ -3274,7 +3295,7 @@ async fn handle_notebook_request(
             let kernel_guard = room.kernel.lock().await;
             if let Some(ref kernel) = *kernel_guard {
                 NotebookResponse::QueueState {
-                    executing: kernel.executing_cell().cloned(),
+                    executing: kernel.executing_entry(),
                     queued: kernel.queued_cells(),
                 }
             } else {
@@ -3293,22 +3314,29 @@ async fn handle_notebook_request(
                 let cells = doc.get_cells();
 
                 // Queue all code cells in document order
-                let mut count = 0;
+                let mut queued = Vec::new();
                 for cell in cells {
                     if cell.cell_type == "code" {
-                        if let Err(e) = kernel
+                        match kernel
                             .queue_cell(cell.id.clone(), cell.source.clone())
                             .await
                         {
-                            return NotebookResponse::Error {
-                                error: format!("Failed to queue cell {}: {}", cell.id, e),
-                            };
+                            Ok(execution_id) => {
+                                queued.push(QueueEntry {
+                                    cell_id: cell.id.clone(),
+                                    execution_id,
+                                });
+                            }
+                            Err(e) => {
+                                return NotebookResponse::Error {
+                                    error: format!("Failed to queue cell {}: {}", cell.id, e),
+                                };
+                            }
                         }
-                        count += 1;
                     }
                 }
 
-                NotebookResponse::AllCellsQueued { count }
+                NotebookResponse::AllCellsQueued { queued }
             } else {
                 NotebookResponse::NoKernel {}
             }

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -2247,6 +2247,7 @@ async fn auto_launch_kernel(
             // Take the command receiver and spawn a task to process execution events
             if let Some(mut cmd_rx) = kernel.take_command_rx() {
                 let room_kernel = room.kernel.clone();
+                let room_broadcast_tx = room.kernel_broadcast_tx.clone();
                 let room_presence = room.presence.clone();
                 let room_presence_tx = room.presence_tx.clone();
                 let room_state_doc = room.state_doc.clone();
@@ -2311,16 +2312,29 @@ async fn auto_launch_kernel(
                             }
                             QueueCommand::KernelDied => {
                                 warn!("[notebook-sync] Kernel died, unblocking execution queue");
-                                let env_source = {
+                                let (env_source, interrupted) = {
                                     let mut guard = room_kernel.lock().await;
                                     if let Some(ref mut k) = *guard {
                                         let es = k.env_source().to_string();
-                                        k.kernel_died();
-                                        Some(es)
+                                        let interrupted = k.kernel_died();
+                                        (Some(es), interrupted)
                                     } else {
-                                        None
+                                        (None, None)
                                     }
                                 };
+                                // Emit ExecutionDone for the interrupted execution so
+                                // clients tracking by execution_id get a terminal signal.
+                                if let Some((cell_id, execution_id)) = interrupted {
+                                    info!(
+                                        "[notebook-sync] Emitting ExecutionDone for interrupted cell {} ({})",
+                                        cell_id, execution_id
+                                    );
+                                    let _ =
+                                        room_broadcast_tx.send(NotebookBroadcast::ExecutionDone {
+                                            cell_id,
+                                            execution_id,
+                                        });
+                                }
                                 // Write error status + cleared queue to state doc
                                 {
                                     let mut sd = room_state_doc.write().await;
@@ -2947,6 +2961,7 @@ async fn handle_notebook_request(
                     // Take the command receiver and spawn a task to process execution events
                     if let Some(mut cmd_rx) = kernel.take_command_rx() {
                         let room_kernel = room.kernel.clone();
+                        let room_broadcast_tx = room.kernel_broadcast_tx.clone();
                         let room_presence = room.presence.clone();
                         let room_presence_tx = room.presence_tx.clone();
                         let room_state_doc = room.state_doc.clone();
@@ -3016,16 +3031,30 @@ async fn handle_notebook_request(
                                     }
                                     QueueCommand::KernelDied => {
                                         warn!("[notebook-sync] Kernel died, unblocking execution queue");
-                                        let env_source = {
+                                        let (env_source, interrupted) = {
                                             let mut guard = room_kernel.lock().await;
                                             if let Some(ref mut k) = *guard {
                                                 let es = k.env_source().to_string();
-                                                k.kernel_died();
-                                                Some(es)
+                                                let interrupted = k.kernel_died();
+                                                (Some(es), interrupted)
                                             } else {
-                                                None
+                                                (None, None)
                                             }
                                         };
+                                        // Emit ExecutionDone for the interrupted execution so
+                                        // clients tracking by execution_id get a terminal signal.
+                                        if let Some((cell_id, execution_id)) = interrupted {
+                                            info!(
+                                                "[notebook-sync] Emitting ExecutionDone for interrupted cell {} ({})",
+                                                cell_id, execution_id
+                                            );
+                                            let _ = room_broadcast_tx.send(
+                                                NotebookBroadcast::ExecutionDone {
+                                                    cell_id,
+                                                    execution_id,
+                                                },
+                                            );
+                                        }
                                         // Write error status + cleared queue to state doc
                                         {
                                             let mut sd = room_state_doc.write().await;

--- a/crates/runtimed/src/protocol.rs
+++ b/crates/runtimed/src/protocol.rs
@@ -14,7 +14,7 @@ use crate::{EnvType, PoolError, PoolStats, PooledEnv};
 // Re-export all notebook protocol types from the shared crate.
 pub use notebook_protocol::protocol::{
     CommSnapshot, CompletionItem, DenoLaunchedConfig, EnvSyncDiff, HistoryEntry, LaunchedEnvConfig,
-    NotebookBroadcast, NotebookRequest, NotebookResponse,
+    NotebookBroadcast, NotebookRequest, NotebookResponse, QueueEntry,
 };
 
 /// Requests that clients can send to the daemon.
@@ -468,6 +468,7 @@ mod tests {
     fn test_notebook_broadcast_output() {
         let broadcast = NotebookBroadcast::Output {
             cell_id: "cell-1".into(),
+            execution_id: "exec-1".into(),
             output_type: "stream".into(),
             output_json: r#"{"name":"stdout","text":"hello\n"}"#.into(),
             output_index: None,
@@ -496,6 +497,7 @@ mod tests {
         // Test with output_index set
         let broadcast_with_index = NotebookBroadcast::Output {
             cell_id: "cell-2".into(),
+            execution_id: "exec-2".into(),
             output_type: "stream".into(),
             output_json: r#"{"name":"stdout","text":"hello\n"}"#.into(),
             output_index: Some(0),

--- a/python/nteract/src/nteract/_mcp_server.py
+++ b/python/nteract/src/nteract/_mcp_server.py
@@ -354,9 +354,9 @@ def _build_cell_status_map(queue_state: QueueState) -> dict[str, str]:
     """Build a cell_id -> status mapping from queue state."""
     cell_status: dict[str, str] = {}
     if queue_state.executing:
-        cell_status[queue_state.executing] = "running"
-    for cid in queue_state.queued:
-        cell_status[cid] = "queued"
+        cell_status[queue_state.executing.cell_id] = "running"
+    for entry in queue_state.queued:
+        cell_status[entry.cell_id] = "queued"
     return cell_status
 
 
@@ -379,9 +379,9 @@ async def _get_single_cell_status(notebook: runtimed.Notebook, cell_id: str) -> 
     """Fetch queue status for a single cell, None on failure."""
     try:
         queue_state = await notebook.queue_state()
-        if queue_state.executing == cell_id:
+        if queue_state.executing and queue_state.executing.cell_id == cell_id:
             return "running"
-        if cell_id in queue_state.queued:
+        if any(entry.cell_id == cell_id for entry in queue_state.queued):
             return "queued"
         return None
     except asyncio.CancelledError:

--- a/python/runtimed/src/runtimed/__init__.py
+++ b/python/runtimed/src/runtimed/__init__.py
@@ -29,6 +29,7 @@ from runtimed.runtimed import (  # noqa: F401
     NativeClient,
     NotebookConnectionInfo,
     Output,
+    PyQueueEntry,
     QueueState,
     RuntimedError,
     RuntimeState,

--- a/python/runtimed/src/runtimed/runtimed.pyi
+++ b/python/runtimed/src/runtimed/runtimed.pyi
@@ -208,17 +208,30 @@ class CompletionResult:
     @property
     def cursor_end(self) -> int: ...
 
+class PyQueueEntry:
+    """An entry in the execution queue."""
+
+    @property
+    def cell_id(self) -> str:
+        """Cell ID."""
+        ...
+
+    @property
+    def execution_id(self) -> str:
+        """Execution ID (UUID)."""
+        ...
+
 class QueueState:
     """Current state of the execution queue."""
 
     @property
-    def executing(self) -> str | None:
-        """Cell ID currently executing (None if idle)."""
+    def executing(self) -> PyQueueEntry | None:
+        """Entry currently executing (None if idle)."""
         ...
 
     @property
-    def queued(self) -> list[str]:
-        """Cell IDs waiting in queue."""
+    def queued(self) -> list[PyQueueEntry]:
+        """Entries waiting in queue."""
         ...
 
 class KernelState:
@@ -562,7 +575,7 @@ class Session:
         timeout_secs: float = 60.0,
     ) -> ExecutionResult: ...
     def run(self, code: str, timeout_secs: float = 60.0) -> ExecutionResult: ...
-    def queue_cell(self, cell_id: str) -> None: ...
+    def queue_cell(self, cell_id: str) -> str: ...
     def stream_execute(
         self,
         cell_id: str,
@@ -734,7 +747,7 @@ class AsyncSession:
     def run(
         self, code: str, timeout_secs: float = 60.0
     ) -> Coroutine[Any, Any, ExecutionResult]: ...
-    def queue_cell(self, cell_id: str) -> Coroutine[Any, Any, None]: ...
+    def queue_cell(self, cell_id: str) -> Coroutine[Any, Any, str]: ...
     def stream_execute(
         self,
         cell_id: str,


### PR DESCRIPTION
## Summary

Closes #1063. Part of #1048.

- Every cell execution gets a UUID `execution_id`, generated in `queue_cell()` and threaded through every protocol message: `CellQueued`, `ExecutionStarted`, `ExecutionDone`, `Output`, `QueueChanged`
- `QueueEntry { cell_id, execution_id }` replaces bare strings in queue representations
- `AllCellsQueued` returns `Vec<QueueEntry>` (one entry per cell) instead of `count`
- Idempotent queue: re-queuing an already-executing/queued cell returns the existing `execution_id`
- RuntimeStateDoc uses parallel Automerge lists for backwards compat with existing docs
- Python bindings expose `PyQueueEntry` and `queue_cell()` returns `execution_id`
- On kernel death, `ExecutionDone` is emitted for the interrupted execution so clients tracking by `execution_id` get a terminal signal

## Test plan

- [x] `cargo build` — full workspace compiles
- [x] `cargo test -p notebook-doc -p runtimed --lib` — 263 tests pass
- [x] `cargo xtask lint` — clean
- [x] Manual: execute cell via MCP, verify `execution_id` in CellQueued and broadcasts
- [x] Manual: run all cells via MCP, verify each gets unique `execution_id`
- [x] Manual: gremlin agent ran 11 turns against live notebook with no protocol errors
- [ ] Manual: re-queue executing cell, verify same `execution_id` returned
- [ ] Python integration tests with execution_id assertions

## Follow-ups (tracked in #1048)

- Python `run_all_cells()` currently discards the returned `Vec<QueueEntry>` and keeps only the count — expose per-cell execution IDs to Python callers
- Make execution lifecycle first-class in the runtime-state doc

_PR submitted by @rgbkrk's agent Quill, via Zed_