### PR TITLE
fix: add environment pool GC and disk growth prevention

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5736,6 +5736,7 @@ dependencies = [
  "flate2",
  "futures",
  "jupyter-protocol",
+ "kernel-env",
  "libc",
  "notify",
  "petname",

--- a/crates/kernel-env/src/conda.rs
+++ b/crates/kernel-env/src/conda.rs
@@ -122,6 +122,7 @@ pub async fn prepare_environment_in(
     // Cache hit
     if env_path.exists() && python_path.exists() {
         info!("Using cached conda environment at {:?}", env_path);
+        crate::gc::touch_last_used(&env_path).await;
         handler.on_progress(
             "conda",
             EnvProgressPhase::CacheHit {
@@ -161,6 +162,7 @@ pub async fn prepare_environment_in(
         ));
     }
 
+    crate::gc::touch_last_used(&env_path).await;
     handler.on_progress(
         "conda",
         EnvProgressPhase::Ready {

--- a/crates/kernel-env/src/gc.rs
+++ b/crates/kernel-env/src/gc.rs
@@ -126,6 +126,7 @@ pub async fn evict_stale_envs(
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
     use tempfile::TempDir;

--- a/crates/kernel-env/src/gc.rs
+++ b/crates/kernel-env/src/gc.rs
@@ -192,9 +192,13 @@ mod tests {
         tokio::fs::create_dir_all(&pool_dir).await?;
 
         // Evict to max_count=2
-        let deleted =
-            evict_stale_envs(tmp.path(), Duration::from_secs(86400 * 365), 2, &HashSet::new())
-                .await?;
+        let deleted = evict_stale_envs(
+            tmp.path(),
+            Duration::from_secs(86400 * 365),
+            2,
+            &HashSet::new(),
+        )
+        .await?;
 
         // Should have deleted 3 (the 3 oldest)
         assert_eq!(deleted.len(), 3);
@@ -224,8 +228,7 @@ mod tests {
 
         // Evict with max_age=1 day, high max_count
         let deleted =
-            evict_stale_envs(tmp.path(), Duration::from_secs(86400), 100, &HashSet::new())
-                .await?;
+            evict_stale_envs(tmp.path(), Duration::from_secs(86400), 100, &HashSet::new()).await?;
 
         assert_eq!(deleted.len(), 1);
         assert!(!old_dir.exists());

--- a/crates/kernel-env/src/gc.rs
+++ b/crates/kernel-env/src/gc.rs
@@ -126,9 +126,9 @@ pub async fn evict_stale_envs(
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
+    use anyhow::Result;
     use tempfile::TempDir;
 
     #[test]
@@ -142,55 +142,49 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_touch_and_read_last_used() {
-        let tmp = TempDir::new().unwrap();
+    async fn test_touch_and_read_last_used() -> Result<()> {
+        let tmp = TempDir::new()?;
         let env_path = tmp.path().join("abcdef0123456789");
-        tokio::fs::create_dir_all(&env_path).await.unwrap();
+        tokio::fs::create_dir_all(&env_path).await?;
 
         touch_last_used(&env_path).await;
 
         let marker = env_path.join(".last-used");
         assert!(marker.exists());
 
-        let contents = tokio::fs::read_to_string(&marker).await.unwrap();
-        let ts: u64 = contents.trim().parse().unwrap();
-        // Should be within the last few seconds
+        let contents = tokio::fs::read_to_string(&marker).await?;
+        let ts: u64 = contents.trim().parse()?;
         let now = SystemTime::now()
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .unwrap()
+            .duration_since(SystemTime::UNIX_EPOCH)?
             .as_secs();
         assert!(now - ts < 5);
+        Ok(())
     }
 
     #[tokio::test]
-    async fn test_evict_by_count() {
-        let tmp = TempDir::new().unwrap();
+    async fn test_evict_by_count() -> Result<()> {
+        let tmp = TempDir::new()?;
 
         let now = SystemTime::now()
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .unwrap()
+            .duration_since(SystemTime::UNIX_EPOCH)?
             .as_secs();
 
         // Create 5 content-addressed dirs with staggered recent timestamps
         for i in 0..5u64 {
             let name = format!("{:016x}", i);
             let dir = tmp.path().join(&name);
-            tokio::fs::create_dir_all(&dir).await.unwrap();
+            tokio::fs::create_dir_all(&dir).await?;
             // Stagger by 1 hour, all recent
             let ts = now - (4 - i) * 3600;
-            tokio::fs::write(dir.join(".last-used"), ts.to_string())
-                .await
-                .unwrap();
+            tokio::fs::write(dir.join(".last-used"), ts.to_string()).await?;
         }
 
         // Also create a pool dir that should be skipped
         let pool_dir = tmp.path().join("runtimed-uv-test");
-        tokio::fs::create_dir_all(&pool_dir).await.unwrap();
+        tokio::fs::create_dir_all(&pool_dir).await?;
 
         // Evict to max_count=2
-        let deleted = evict_stale_envs(tmp.path(), Duration::from_secs(86400 * 365), 2)
-            .await
-            .unwrap();
+        let deleted = evict_stale_envs(tmp.path(), Duration::from_secs(86400 * 365), 2).await?;
 
         // Should have deleted 3 (the 3 oldest)
         assert_eq!(deleted.len(), 3);
@@ -201,31 +195,29 @@ mod tests {
         // The 2 newest should remain
         assert!(tmp.path().join(format!("{:016x}", 4)).exists());
         assert!(tmp.path().join(format!("{:016x}", 3)).exists());
+        Ok(())
     }
 
     #[tokio::test]
-    async fn test_evict_by_age() {
-        let tmp = TempDir::new().unwrap();
+    async fn test_evict_by_age() -> Result<()> {
+        let tmp = TempDir::new()?;
 
         // Create a dir with a very old timestamp
         let old_dir = tmp.path().join("aaaaaaaaaaaaaaaa");
-        tokio::fs::create_dir_all(&old_dir).await.unwrap();
-        tokio::fs::write(old_dir.join(".last-used"), "1000000")
-            .await
-            .unwrap();
+        tokio::fs::create_dir_all(&old_dir).await?;
+        tokio::fs::write(old_dir.join(".last-used"), "1000000").await?;
 
         // Create a dir with a recent timestamp
         let new_dir = tmp.path().join("bbbbbbbbbbbbbbbb");
-        tokio::fs::create_dir_all(&new_dir).await.unwrap();
+        tokio::fs::create_dir_all(&new_dir).await?;
         touch_last_used(&new_dir).await;
 
         // Evict with max_age=1 day, high max_count
-        let deleted = evict_stale_envs(tmp.path(), Duration::from_secs(86400), 100)
-            .await
-            .unwrap();
+        let deleted = evict_stale_envs(tmp.path(), Duration::from_secs(86400), 100).await?;
 
         assert_eq!(deleted.len(), 1);
         assert!(!old_dir.exists());
         assert!(new_dir.exists());
+        Ok(())
     }
 }

--- a/crates/kernel-env/src/gc.rs
+++ b/crates/kernel-env/src/gc.rs
@@ -56,12 +56,14 @@ fn is_content_addressed_dir(name: &str) -> bool {
 /// Scans `cache_dir` for directories matching the 16-char hex pattern.
 /// Deletes those older than `max_age` or beyond `max_count` (keeping newest).
 /// Skips `runtimed-uv-*` and `runtimed-conda-*` dirs (pool-managed).
+/// Skips any paths in `in_use` (environments backing running kernels).
 ///
 /// Returns the list of deleted directory paths.
 pub async fn evict_stale_envs(
     cache_dir: &Path,
     max_age: Duration,
     max_count: usize,
+    in_use: &std::collections::HashSet<PathBuf>,
 ) -> Result<Vec<PathBuf>> {
     let mut deleted = Vec::new();
 
@@ -82,6 +84,11 @@ pub async fn evict_stale_envs(
 
         let path = entry.path();
         if !path.is_dir() {
+            continue;
+        }
+
+        // Never evict environments that are backing running kernels
+        if in_use.contains(&path) {
             continue;
         }
 
@@ -129,6 +136,7 @@ pub async fn evict_stale_envs(
 mod tests {
     use super::*;
     use anyhow::Result;
+    use std::collections::HashSet;
     use tempfile::TempDir;
 
     #[test]
@@ -184,7 +192,9 @@ mod tests {
         tokio::fs::create_dir_all(&pool_dir).await?;
 
         // Evict to max_count=2
-        let deleted = evict_stale_envs(tmp.path(), Duration::from_secs(86400 * 365), 2).await?;
+        let deleted =
+            evict_stale_envs(tmp.path(), Duration::from_secs(86400 * 365), 2, &HashSet::new())
+                .await?;
 
         // Should have deleted 3 (the 3 oldest)
         assert_eq!(deleted.len(), 3);
@@ -213,7 +223,9 @@ mod tests {
         touch_last_used(&new_dir).await;
 
         // Evict with max_age=1 day, high max_count
-        let deleted = evict_stale_envs(tmp.path(), Duration::from_secs(86400), 100).await?;
+        let deleted =
+            evict_stale_envs(tmp.path(), Duration::from_secs(86400), 100, &HashSet::new())
+                .await?;
 
         assert_eq!(deleted.len(), 1);
         assert!(!old_dir.exists());

--- a/crates/kernel-env/src/gc.rs
+++ b/crates/kernel-env/src/gc.rs
@@ -1,0 +1,230 @@
+//! Garbage collection for content-addressed environment caches.
+//!
+//! Cached environments (UV, Conda, inline) are stored as `{16-char-hash}/`
+//! directories. This module provides:
+//!
+//! - A `.last-used` timestamp file to track when an env was last accessed
+//! - An eviction function that removes envs older than `max_age` or beyond
+//!   `max_count`, keeping the most recently used ones
+
+use anyhow::Result;
+use log::{info, warn};
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+
+/// Touch (create or update) the `.last-used` marker in an environment directory.
+///
+/// Call this on cache hit and on fresh creation so the GC knows when the env
+/// was last accessed.
+pub async fn touch_last_used(env_path: &Path) {
+    let marker = env_path.join(".last-used");
+    // Write current unix timestamp as text for easy debugging
+    let now = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+        .to_string();
+    if let Err(e) = tokio::fs::write(&marker, now.as_bytes()).await {
+        warn!("Failed to update .last-used in {:?}: {}", env_path, e);
+    }
+}
+
+/// Read the last-used time for an environment directory.
+///
+/// Checks `.last-used` marker first, falls back to directory mtime.
+async fn last_used_time(env_path: &Path) -> SystemTime {
+    let marker = env_path.join(".last-used");
+    if let Ok(contents) = tokio::fs::read_to_string(&marker).await {
+        if let Ok(secs) = contents.trim().parse::<u64>() {
+            return SystemTime::UNIX_EPOCH + Duration::from_secs(secs);
+        }
+    }
+    // Fall back to directory mtime
+    tokio::fs::metadata(env_path)
+        .await
+        .and_then(|m| m.modified())
+        .unwrap_or(SystemTime::UNIX_EPOCH)
+}
+
+/// Returns true if `name` looks like a 16-char hex content-addressed hash.
+fn is_content_addressed_dir(name: &str) -> bool {
+    name.len() == 16 && name.chars().all(|c| c.is_ascii_hexdigit())
+}
+
+/// Evict stale content-addressed environments from a cache directory.
+///
+/// Scans `cache_dir` for directories matching the 16-char hex pattern.
+/// Deletes those older than `max_age` or beyond `max_count` (keeping newest).
+/// Skips `runtimed-uv-*` and `runtimed-conda-*` dirs (pool-managed).
+///
+/// Returns the list of deleted directory paths.
+pub async fn evict_stale_envs(
+    cache_dir: &Path,
+    max_age: Duration,
+    max_count: usize,
+) -> Result<Vec<PathBuf>> {
+    let mut deleted = Vec::new();
+
+    if !cache_dir.exists() {
+        return Ok(deleted);
+    }
+
+    let mut entries = tokio::fs::read_dir(cache_dir).await?;
+    let mut candidates: Vec<(PathBuf, SystemTime)> = Vec::new();
+
+    while let Ok(Some(entry)) = entries.next_entry().await {
+        let name = entry.file_name().to_string_lossy().to_string();
+
+        // Only process content-addressed dirs (16-char hex names)
+        if !is_content_addressed_dir(&name) {
+            continue;
+        }
+
+        let path = entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+
+        let last_used = last_used_time(&path).await;
+        candidates.push((path, last_used));
+    }
+
+    // Sort by last-used time descending (newest first)
+    candidates.sort_by(|a, b| b.1.cmp(&a.1));
+
+    let now = SystemTime::now();
+
+    for (i, (path, last_used)) in candidates.iter().enumerate() {
+        let age = now.duration_since(*last_used).unwrap_or_default();
+        let beyond_count = i >= max_count;
+        let beyond_age = age > max_age;
+
+        if beyond_count || beyond_age {
+            info!(
+                "[gc] Evicting cached env {:?} (age: {}h, index: {})",
+                path,
+                age.as_secs() / 3600,
+                i
+            );
+            if let Err(e) = tokio::fs::remove_dir_all(&path).await {
+                warn!("[gc] Failed to remove {:?}: {}", path, e);
+            } else {
+                deleted.push(path.clone());
+            }
+        }
+    }
+
+    if !deleted.is_empty() {
+        info!(
+            "[gc] Evicted {} cached environments from {:?}",
+            deleted.len(),
+            cache_dir
+        );
+    }
+
+    Ok(deleted)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_is_content_addressed_dir() {
+        assert!(is_content_addressed_dir("52cc822d70a6d5d7"));
+        assert!(is_content_addressed_dir("e3b0c44298fc1c14"));
+        assert!(!is_content_addressed_dir("runtimed-uv-abc"));
+        assert!(!is_content_addressed_dir("short"));
+        assert!(!is_content_addressed_dir("52cc822d70a6d5d7extra"));
+        assert!(!is_content_addressed_dir("zzzzzzzzzzzzzzzz"));
+    }
+
+    #[tokio::test]
+    async fn test_touch_and_read_last_used() {
+        let tmp = TempDir::new().unwrap();
+        let env_path = tmp.path().join("abcdef0123456789");
+        tokio::fs::create_dir_all(&env_path).await.unwrap();
+
+        touch_last_used(&env_path).await;
+
+        let marker = env_path.join(".last-used");
+        assert!(marker.exists());
+
+        let contents = tokio::fs::read_to_string(&marker).await.unwrap();
+        let ts: u64 = contents.trim().parse().unwrap();
+        // Should be within the last few seconds
+        let now = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        assert!(now - ts < 5);
+    }
+
+    #[tokio::test]
+    async fn test_evict_by_count() {
+        let tmp = TempDir::new().unwrap();
+
+        let now = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+
+        // Create 5 content-addressed dirs with staggered recent timestamps
+        for i in 0..5u64 {
+            let name = format!("{:016x}", i);
+            let dir = tmp.path().join(&name);
+            tokio::fs::create_dir_all(&dir).await.unwrap();
+            // Stagger by 1 hour, all recent
+            let ts = now - (4 - i) * 3600;
+            tokio::fs::write(dir.join(".last-used"), ts.to_string())
+                .await
+                .unwrap();
+        }
+
+        // Also create a pool dir that should be skipped
+        let pool_dir = tmp.path().join("runtimed-uv-test");
+        tokio::fs::create_dir_all(&pool_dir).await.unwrap();
+
+        // Evict to max_count=2
+        let deleted = evict_stale_envs(tmp.path(), Duration::from_secs(86400 * 365), 2)
+            .await
+            .unwrap();
+
+        // Should have deleted 3 (the 3 oldest)
+        assert_eq!(deleted.len(), 3);
+
+        // Pool dir should still exist
+        assert!(pool_dir.exists());
+
+        // The 2 newest should remain
+        assert!(tmp.path().join(format!("{:016x}", 4)).exists());
+        assert!(tmp.path().join(format!("{:016x}", 3)).exists());
+    }
+
+    #[tokio::test]
+    async fn test_evict_by_age() {
+        let tmp = TempDir::new().unwrap();
+
+        // Create a dir with a very old timestamp
+        let old_dir = tmp.path().join("aaaaaaaaaaaaaaaa");
+        tokio::fs::create_dir_all(&old_dir).await.unwrap();
+        tokio::fs::write(old_dir.join(".last-used"), "1000000")
+            .await
+            .unwrap();
+
+        // Create a dir with a recent timestamp
+        let new_dir = tmp.path().join("bbbbbbbbbbbbbbbb");
+        tokio::fs::create_dir_all(&new_dir).await.unwrap();
+        touch_last_used(&new_dir).await;
+
+        // Evict with max_age=1 day, high max_count
+        let deleted = evict_stale_envs(tmp.path(), Duration::from_secs(86400), 100)
+            .await
+            .unwrap();
+
+        assert_eq!(deleted.len(), 1);
+        assert!(!old_dir.exists());
+        assert!(new_dir.exists());
+    }
+}

--- a/crates/kernel-env/src/lib.rs
+++ b/crates/kernel-env/src/lib.rs
@@ -25,6 +25,7 @@
 //! ```
 
 pub mod conda;
+pub mod gc;
 pub mod progress;
 pub mod uv;
 

--- a/crates/kernel-env/src/uv.rs
+++ b/crates/kernel-env/src/uv.rs
@@ -130,6 +130,7 @@ pub async fn prepare_environment_in(
     // Cache hit
     if venv_path.exists() && python_path.exists() {
         info!("Using cached environment at {:?}", venv_path);
+        crate::gc::touch_last_used(&venv_path).await;
         handler.on_progress(
             "uv",
             EnvProgressPhase::CacheHit {
@@ -201,10 +202,15 @@ pub async fn prepare_environment_in(
     ];
     packages.extend(deps.dependencies.iter().cloned());
 
-    // Build install command args
+    // Build install command args.
+    // Use hardlink mode to share files from uv's global cache,
+    // dramatically reducing per-env disk usage. uv falls back to
+    // copies automatically if hardlinks aren't supported.
     let mut install_args = vec![
         "pip".to_string(),
         "install".to_string(),
+        "--link-mode".to_string(),
+        "hardlink".to_string(),
         "--python".to_string(),
         python_path.to_string_lossy().to_string(),
     ];
@@ -236,6 +242,7 @@ pub async fn prepare_environment_in(
             first_stderr
         );
         let mut retry_args = install_args.clone();
+        // Insert --refresh after "pip install" (index 2), before --link-mode
         retry_args.insert(2, "--refresh".to_string());
         tokio::process::Command::new(&uv_path)
             .args(&retry_args)
@@ -261,6 +268,7 @@ pub async fn prepare_environment_in(
     }
 
     info!("Environment ready at {:?}", venv_path);
+    crate::gc::touch_last_used(&venv_path).await;
     handler.on_progress(
         "uv",
         EnvProgressPhase::Ready {
@@ -288,6 +296,8 @@ pub async fn sync_dependencies(env: &UvEnvironment, deps: &[String]) -> Result<(
     let mut install_args = vec![
         "pip".to_string(),
         "install".to_string(),
+        "--link-mode".to_string(),
+        "hardlink".to_string(),
         "--python".to_string(),
         env.python_path.to_string_lossy().to_string(),
     ];
@@ -363,10 +373,13 @@ pub async fn create_prewarmed_environment_in(
         ));
     }
 
-    // Install ipykernel, ipywidgets, uv, and any extra packages
+    // Install ipykernel, ipywidgets, uv, and any extra packages.
+    // Use hardlink mode to share files from uv's global cache.
     let mut install_args = vec![
         "pip".to_string(),
         "install".to_string(),
+        "--link-mode".to_string(),
+        "hardlink".to_string(),
         "--python".to_string(),
         python_path.to_string_lossy().to_string(),
         "ipykernel".to_string(),
@@ -381,7 +394,7 @@ pub async fn create_prewarmed_environment_in(
     handler.on_progress(
         "uv",
         EnvProgressPhase::InstallingPackages {
-            packages: install_args[4..].to_vec(),
+            packages: install_args[6..].to_vec(),
         },
     );
 

--- a/crates/runt/Cargo.toml
+++ b/crates/runt/Cargo.toml
@@ -23,6 +23,7 @@ jupyter-protocol = { workspace = true }
 runtimelib = { workspace = true, features = ["tokio-runtime", "aws-lc-rs"] }
 runtimed = { path = "../runtimed" }
 runt-workspace = { path = "../runt-workspace" }
+kernel-env = { path = "../kernel-env" }
 clap = { version = "4.5.1", features = ["derive", "color"] }
 colored = "2"
 tokio = { version = "1", features = ["full"] }

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -3723,8 +3723,15 @@ async fn env_clean(
                 let now = std::time::SystemTime::now();
                 for (i, (path, last_used, size)) in candidates.iter().enumerate() {
                     let age = now.duration_since(*last_used).unwrap_or_default();
-                    let would_delete = i >= max_count || age > max_age;
-                    let marker = if would_delete { "DELETE" } else { "keep" };
+                    let would_delete =
+                        (i >= max_count || age > max_age) && !in_use.contains(path);
+                    let marker = if would_delete {
+                        "DELETE"
+                    } else if in_use.contains(path) {
+                        "in-use"
+                    } else {
+                        "keep"
+                    };
                     println!(
                         "    [{}] {} — {} ({}d old)",
                         marker,

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -227,6 +227,12 @@ enum Commands {
     // =========================================================================
     // Development utilities (only shown when RUNTIMED_DEV=1)
     // =========================================================================
+    /// Manage cached Python environments
+    Env {
+        #[command(subcommand)]
+        command: EnvCommands,
+    },
+
     /// Development utilities for runtimed contributors
     #[command(subcommand, hide = true)]
     Dev(DevCommands),
@@ -358,6 +364,30 @@ enum JupyterCommands {
         #[arg(long, default_value = "2")]
         timeout: u64,
         /// Perform a dry run without actually removing files
+        #[arg(long)]
+        dry_run: bool,
+    },
+}
+
+/// Environment management commands
+#[derive(Subcommand)]
+enum EnvCommands {
+    /// Show disk usage for all cached environments
+    Stats,
+    /// List all cached environments with size and age
+    List,
+    /// Remove stale cached environments
+    Clean {
+        /// Remove ALL cached environments (pool + content-addressed + inline)
+        #[arg(long)]
+        all: bool,
+        /// Maximum age in days for cached environments (default: 7)
+        #[arg(long, default_value = "7")]
+        max_age_days: u64,
+        /// Maximum number of cached environments per category (default: 10)
+        #[arg(long, default_value = "10")]
+        max_count: usize,
+        /// Show what would be deleted without actually deleting
         #[arg(long)]
         dry_run: bool,
     },
@@ -537,6 +567,7 @@ async fn async_main(command: Option<Commands>) -> Result<()> {
             daemon_command(DaemonCommands::Logs { follow, lines }).await?
         }
         Some(Commands::Diagnostics { output }) => diagnostics_command(output).await?,
+        Some(Commands::Env { command }) => env_command(command).await?,
 
         // Development commands (requires RUNTIMED_DEV=1)
         Some(Commands::Dev(dev_cmd)) => {
@@ -3405,6 +3436,316 @@ async fn clean_worktree_command(
     if failure_count > 0 {
         eprintln!("{} failed (check permissions)", failure_count);
         std::process::exit(1);
+    }
+
+    Ok(())
+}
+
+// =============================================================================
+// Environment management commands
+// =============================================================================
+
+async fn env_command(command: EnvCommands) -> anyhow::Result<()> {
+    match command {
+        EnvCommands::Stats => env_stats().await,
+        EnvCommands::List => env_list().await,
+        EnvCommands::Clean {
+            all,
+            max_age_days,
+            max_count,
+            dry_run,
+        } => env_clean(all, max_age_days, max_count, dry_run).await,
+    }
+}
+
+/// Cache directories to manage
+struct EnvCacheDir {
+    label: &'static str,
+    path: PathBuf,
+}
+
+fn get_env_cache_dirs() -> Vec<EnvCacheDir> {
+    let base = dirs::cache_dir().unwrap_or_else(|| PathBuf::from("/tmp"));
+    vec![
+        EnvCacheDir {
+            label: "UV envs",
+            path: base.join("runt").join("envs"),
+        },
+        EnvCacheDir {
+            label: "Conda envs",
+            path: base.join("runt").join("conda-envs"),
+        },
+        EnvCacheDir {
+            label: "Inline envs",
+            path: base.join("runt").join("inline-envs"),
+        },
+        EnvCacheDir {
+            label: "UV envs (nightly)",
+            path: base.join("runt-nightly").join("envs"),
+        },
+        EnvCacheDir {
+            label: "Worktrees",
+            path: base.join("runt").join("worktrees"),
+        },
+        EnvCacheDir {
+            label: "Worktrees (nightly)",
+            path: base.join("runt-nightly").join("worktrees"),
+        },
+    ]
+}
+
+async fn env_stats() -> anyhow::Result<()> {
+    println!("Environment cache disk usage:\n");
+
+    let mut total = 0u64;
+    for dir in get_env_cache_dirs() {
+        if !dir.path.exists() {
+            continue;
+        }
+        let size = calculate_dir_size(&dir.path);
+        let count = std::fs::read_dir(&dir.path)
+            .map(|rd| {
+                rd.filter_map(|e| e.ok())
+                    .filter(|e| e.path().is_dir())
+                    .count()
+            })
+            .unwrap_or(0);
+        println!(
+            "  {:20} {:>10}  ({} dirs)  {}",
+            dir.label,
+            format_size(size),
+            count,
+            dir.path.display()
+        );
+        total += size;
+    }
+
+    println!("\n  {:20} {:>10}", "Total", format_size(total));
+    Ok(())
+}
+
+async fn env_list() -> anyhow::Result<()> {
+    let cache_dirs = get_env_cache_dirs();
+
+    for dir in &cache_dirs {
+        if !dir.path.exists() {
+            continue;
+        }
+
+        let mut entries: Vec<(String, u64, std::time::SystemTime)> = Vec::new();
+
+        if let Ok(rd) = std::fs::read_dir(&dir.path) {
+            for entry in rd.filter_map(|e| e.ok()) {
+                let path = entry.path();
+                if !path.is_dir() {
+                    continue;
+                }
+                let name = entry.file_name().to_string_lossy().to_string();
+                let size = calculate_dir_size(&path);
+
+                // Try .last-used, then mtime
+                let last_used =
+                    if let Ok(contents) = std::fs::read_to_string(path.join(".last-used")) {
+                        if let Ok(secs) = contents.trim().parse::<u64>() {
+                            std::time::UNIX_EPOCH + std::time::Duration::from_secs(secs)
+                        } else {
+                            entry
+                                .metadata()
+                                .and_then(|m| m.modified())
+                                .unwrap_or(std::time::UNIX_EPOCH)
+                        }
+                    } else {
+                        entry
+                            .metadata()
+                            .and_then(|m| m.modified())
+                            .unwrap_or(std::time::UNIX_EPOCH)
+                    };
+
+                entries.push((name, size, last_used));
+            }
+        }
+
+        if entries.is_empty() {
+            continue;
+        }
+
+        // Sort by last-used descending
+        entries.sort_by(|a, b| b.2.cmp(&a.2));
+
+        println!("{}  ({})", dir.label, dir.path.display());
+        for (name, size, last_used) in &entries {
+            let age = std::time::SystemTime::now()
+                .duration_since(*last_used)
+                .unwrap_or_default();
+            let age_str = if age.as_secs() < 3600 {
+                format!("{}m ago", age.as_secs() / 60)
+            } else if age.as_secs() < 86400 {
+                format!("{}h ago", age.as_secs() / 3600)
+            } else {
+                format!("{}d ago", age.as_secs() / 86400)
+            };
+            println!("  {:<40} {:>10}  {}", name, format_size(*size), age_str);
+        }
+        println!();
+    }
+
+    Ok(())
+}
+
+async fn env_clean(
+    all: bool,
+    max_age_days: u64,
+    max_count: usize,
+    dry_run: bool,
+) -> anyhow::Result<()> {
+    let max_age = std::time::Duration::from_secs(max_age_days * 86400);
+
+    if all {
+        println!("Removing ALL cached environments...");
+        if dry_run {
+            println!("(dry run — nothing will be deleted)\n");
+        }
+
+        let base = dirs::cache_dir().unwrap_or_else(|| PathBuf::from("/tmp"));
+        let dirs_to_clean = [
+            base.join("runt").join("envs"),
+            base.join("runt").join("conda-envs"),
+            base.join("runt").join("inline-envs"),
+            base.join("runt-nightly").join("envs"),
+        ];
+
+        for dir in &dirs_to_clean {
+            if !dir.exists() {
+                continue;
+            }
+            let size = calculate_dir_size(dir);
+            println!("  {} — {}", dir.display(), format_size(size));
+            if !dry_run {
+                // Remove all subdirectories but keep the directory itself
+                if let Ok(rd) = std::fs::read_dir(dir) {
+                    for entry in rd.filter_map(|e| e.ok()) {
+                        if entry.path().is_dir() {
+                            std::fs::remove_dir_all(entry.path()).ok();
+                        }
+                    }
+                }
+            }
+        }
+
+        if !dry_run {
+            println!("\nDone. Daemon pools will replenish on next warming cycle.");
+        }
+        return Ok(());
+    }
+
+    // Selective eviction
+    let eviction_dirs = [
+        kernel_env::uv::default_cache_dir_uv(),
+        kernel_env::conda::default_cache_dir_conda(),
+        dirs::cache_dir()
+            .unwrap_or_else(|| PathBuf::from("/tmp"))
+            .join("runt")
+            .join("inline-envs"),
+    ];
+
+    if dry_run {
+        println!(
+            "Dry run — showing what would be evicted (max_age={}d, max_count={}):\n",
+            max_age_days, max_count
+        );
+    } else {
+        println!(
+            "Evicting stale environments (max_age={}d, max_count={}):\n",
+            max_age_days, max_count
+        );
+    }
+
+    let mut total_evicted = 0;
+    for dir in &eviction_dirs {
+        if !dir.exists() {
+            continue;
+        }
+        if dry_run {
+            // Show what would be evicted without actually deleting
+            // Use a very large max_count to just show ages
+            println!("  {}:", dir.display());
+            if let Ok(rd) = std::fs::read_dir(dir) {
+                let mut candidates: Vec<(PathBuf, std::time::SystemTime, u64)> = Vec::new();
+                for entry in rd.filter_map(|e| e.ok()) {
+                    let path = entry.path();
+                    let name = entry.file_name().to_string_lossy().to_string();
+                    if name.len() != 16 || !name.chars().all(|c| c.is_ascii_hexdigit()) {
+                        continue;
+                    }
+                    if !path.is_dir() {
+                        continue;
+                    }
+                    let last_used = if let Ok(c) = std::fs::read_to_string(path.join(".last-used"))
+                    {
+                        if let Ok(s) = c.trim().parse::<u64>() {
+                            std::time::UNIX_EPOCH + std::time::Duration::from_secs(s)
+                        } else {
+                            entry
+                                .metadata()
+                                .and_then(|m| m.modified())
+                                .unwrap_or(std::time::UNIX_EPOCH)
+                        }
+                    } else {
+                        entry
+                            .metadata()
+                            .and_then(|m| m.modified())
+                            .unwrap_or(std::time::UNIX_EPOCH)
+                    };
+                    let size = calculate_dir_size(&path);
+                    candidates.push((path, last_used, size));
+                }
+                candidates.sort_by(|a, b| b.1.cmp(&a.1));
+                let now = std::time::SystemTime::now();
+                for (i, (path, last_used, size)) in candidates.iter().enumerate() {
+                    let age = now.duration_since(*last_used).unwrap_or_default();
+                    let would_delete = i >= max_count || age > max_age;
+                    let marker = if would_delete { "DELETE" } else { "keep" };
+                    println!(
+                        "    [{}] {} — {} ({}d old)",
+                        marker,
+                        path.file_name().unwrap_or_default().to_string_lossy(),
+                        format_size(*size),
+                        age.as_secs() / 86400
+                    );
+                    if would_delete {
+                        total_evicted += 1;
+                    }
+                }
+            }
+            println!();
+        } else {
+            match kernel_env::gc::evict_stale_envs(dir, max_age, max_count).await {
+                Ok(deleted) => {
+                    if !deleted.is_empty() {
+                        println!(
+                            "  {}: evicted {} environments",
+                            dir.display(),
+                            deleted.len()
+                        );
+                        total_evicted += deleted.len();
+                    }
+                }
+                Err(e) => {
+                    eprintln!("  {}: error — {}", dir.display(), e);
+                }
+            }
+        }
+    }
+
+    if total_evicted == 0 {
+        println!("Nothing to evict — cache is within limits.");
+    } else if dry_run {
+        println!(
+            "Would evict {} environments. Run without --dry-run to proceed.",
+            total_evicted
+        );
+    } else {
+        println!("\nEvicted {} environments.", total_evicted);
     }
 
     Ok(())

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -3608,6 +3608,9 @@ async fn env_clean(
             println!("(dry run — nothing will be deleted)\n");
         }
 
+        // Query daemon for in-use env paths to protect running kernels
+        let in_use = query_active_env_paths().await;
+
         let base = dirs::cache_dir().unwrap_or_else(|| PathBuf::from("/tmp"));
         let dirs_to_clean = [
             base.join("runt").join("envs"),
@@ -3625,17 +3628,19 @@ async fn env_clean(
             println!("  {} — {}", dir.display(), format_size(size));
             if !dry_run {
                 // Remove content-addressed subdirs only — skip pool envs
-                // (runtimed-uv-*, runtimed-conda-*) which may be backing
-                // live kernels or are managed by the daemon pool.
+                // (runtimed-uv-*, runtimed-conda-*) and envs backing
+                // running kernels.
                 if let Ok(rd) = std::fs::read_dir(dir) {
                     for entry in rd.filter_map(|e| e.ok()) {
                         let name = entry.file_name().to_string_lossy().to_string();
-                        if entry.path().is_dir()
+                        let path = entry.path();
+                        if path.is_dir()
                             && !name.starts_with("runtimed-uv-")
                             && !name.starts_with("runtimed-conda-")
                             && !name.starts_with("prewarm-")
+                            && !in_use.contains(&path)
                         {
-                            std::fs::remove_dir_all(entry.path()).ok();
+                            std::fs::remove_dir_all(&path).ok();
                             total_removed += 1;
                         }
                     }
@@ -3648,6 +3653,10 @@ async fn env_clean(
         }
         return Ok(());
     }
+
+    // Query the daemon for env paths backing running kernels so we
+    // don't evict them. Falls back to empty if daemon isn't reachable.
+    let in_use = query_active_env_paths().await;
 
     // Selective eviction
     let eviction_dirs = [
@@ -3730,10 +3739,7 @@ async fn env_clean(
             }
             println!();
         } else {
-            // CLI doesn't have access to daemon state, so we can't check
-            // which envs are in use. The daemon's GC loop handles that.
-            let no_exclusions = std::collections::HashSet::new();
-            match kernel_env::gc::evict_stale_envs(dir, max_age, max_count, &no_exclusions).await {
+            match kernel_env::gc::evict_stale_envs(dir, max_age, max_count, &in_use).await {
                 Ok(deleted) => {
                     if !deleted.is_empty() {
                         println!(
@@ -3763,6 +3769,29 @@ async fn env_clean(
     }
 
     Ok(())
+}
+
+/// Query the daemon for env paths backing running kernels.
+/// Returns an empty set if the daemon isn't running or unreachable.
+async fn query_active_env_paths() -> std::collections::HashSet<PathBuf> {
+    use runtimed::client::PoolClient;
+    use runtimed::singleton::get_running_daemon_info;
+
+    let info = match get_running_daemon_info() {
+        Some(info) => info,
+        None => return std::collections::HashSet::new(),
+    };
+
+    let client = PoolClient::new(PathBuf::from(&info.endpoint));
+    match tokio::time::timeout(
+        std::time::Duration::from_secs(3),
+        client.active_env_paths(),
+    )
+    .await
+    {
+        Ok(Ok(paths)) => paths.into_iter().collect(),
+        _ => std::collections::HashSet::new(),
+    }
 }
 
 /// Calculate total size of a directory

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -3602,6 +3602,8 @@ async fn env_clean(
 
     if all {
         println!("Removing ALL cached environments...");
+        println!("Note: pool envs (runtimed-uv-*, runtimed-conda-*) are skipped.");
+        println!("      Use 'runt daemon flush' to reset the pool.\n");
         if dry_run {
             println!("(dry run — nothing will be deleted)\n");
         }
@@ -3614,6 +3616,7 @@ async fn env_clean(
             base.join("runt-nightly").join("envs"),
         ];
 
+        let mut total_removed = 0;
         for dir in &dirs_to_clean {
             if !dir.exists() {
                 continue;
@@ -3621,11 +3624,19 @@ async fn env_clean(
             let size = calculate_dir_size(dir);
             println!("  {} — {}", dir.display(), format_size(size));
             if !dry_run {
-                // Remove all subdirectories but keep the directory itself
+                // Remove content-addressed subdirs only — skip pool envs
+                // (runtimed-uv-*, runtimed-conda-*) which may be backing
+                // live kernels or are managed by the daemon pool.
                 if let Ok(rd) = std::fs::read_dir(dir) {
                     for entry in rd.filter_map(|e| e.ok()) {
-                        if entry.path().is_dir() {
+                        let name = entry.file_name().to_string_lossy().to_string();
+                        if entry.path().is_dir()
+                            && !name.starts_with("runtimed-uv-")
+                            && !name.starts_with("runtimed-conda-")
+                            && !name.starts_with("prewarm-")
+                        {
                             std::fs::remove_dir_all(entry.path()).ok();
+                            total_removed += 1;
                         }
                     }
                 }
@@ -3633,7 +3644,7 @@ async fn env_clean(
         }
 
         if !dry_run {
-            println!("\nDone. Daemon pools will replenish on next warming cycle.");
+            println!("\nRemoved {} cached environments.", total_removed);
         }
         return Ok(());
     }
@@ -3719,7 +3730,10 @@ async fn env_clean(
             }
             println!();
         } else {
-            match kernel_env::gc::evict_stale_envs(dir, max_age, max_count).await {
+            // CLI doesn't have access to daemon state, so we can't check
+            // which envs are in use. The daemon's GC loop handles that.
+            let no_exclusions = std::collections::HashSet::new();
+            match kernel_env::gc::evict_stale_envs(dir, max_age, max_count, &no_exclusions).await {
                 Ok(deleted) => {
                     if !deleted.is_empty() {
                         println!(

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -3723,8 +3723,7 @@ async fn env_clean(
                 let now = std::time::SystemTime::now();
                 for (i, (path, last_used, size)) in candidates.iter().enumerate() {
                     let age = now.duration_since(*last_used).unwrap_or_default();
-                    let would_delete =
-                        (i >= max_count || age > max_age) && !in_use.contains(path);
+                    let would_delete = (i >= max_count || age > max_age) && !in_use.contains(path);
                     let marker = if would_delete {
                         "DELETE"
                     } else if in_use.contains(path) {
@@ -3790,12 +3789,7 @@ async fn query_active_env_paths() -> std::collections::HashSet<PathBuf> {
     };
 
     let client = PoolClient::new(PathBuf::from(&info.endpoint));
-    match tokio::time::timeout(
-        std::time::Duration::from_secs(3),
-        client.active_env_paths(),
-    )
-    .await
-    {
+    match tokio::time::timeout(std::time::Duration::from_secs(3), client.active_env_paths()).await {
         Ok(Ok(paths)) => paths.into_iter().collect(),
         _ => std::collections::HashSet::new(),
     }

--- a/crates/runtimed/examples/test_inline_deps.rs
+++ b/crates/runtimed/examples/test_inline_deps.rs
@@ -58,6 +58,7 @@ async fn main() -> anyhow::Result<()> {
         max_age_secs: 3600,
         lock_dir: Some(temp_dir.path().to_path_buf()),
         room_eviction_delay_ms: None,
+        ..Default::default()
     };
     let socket_path = config.socket_path.clone();
     println!("Socket path: {:?}", socket_path);

--- a/crates/runtimed/src/client.rs
+++ b/crates/runtimed/src/client.rs
@@ -167,6 +167,18 @@ impl PoolClient {
         }
     }
 
+    /// Get environment paths currently in use by running kernels.
+    pub async fn active_env_paths(&self) -> Result<Vec<std::path::PathBuf>, ClientError> {
+        let response = self.send_request(Request::ActiveEnvPaths).await?;
+        match response {
+            Response::ActiveEnvPaths { paths } => Ok(paths),
+            Response::Error { message } => Err(ClientError::DaemonError(message)),
+            _ => Err(ClientError::ProtocolError(
+                "Unexpected response".to_string(),
+            )),
+        }
+    }
+
     /// Flush all pooled environments and trigger rebuild with current settings.
     pub async fn flush_pool(&self) -> Result<(), ClientError> {
         let response = self.send_request(Request::FlushPool).await?;

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -959,22 +959,14 @@ impl Daemon {
             );
         }
 
-        // Clean up orphaned pool envs left over from previous daemon runs.
-        // These accumulate because each daemon restart creates fresh UUIDs
-        // and only loads up to `target` from existing dirs on disk.
+        // Clean up orphaned pool envs in a background task so startup
+        // isn't blocked when there are hundreds of stale directories.
         if !orphans.is_empty() {
             info!(
-                "[runtimed] Cleaning up {} orphaned pool environments",
+                "[runtimed] Scheduling cleanup of {} orphaned pool environments",
                 orphans.len()
             );
-            for orphan in orphans {
-                if let Err(e) = tokio::fs::remove_dir_all(&orphan).await {
-                    warn!(
-                        "[runtimed] Failed to remove orphaned env {:?}: {}",
-                        orphan, e
-                    );
-                }
-            }
+            spawn_env_deletions(orphans);
         }
     }
 

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -1911,11 +1911,8 @@ impl Daemon {
             }
 
             Request::ActiveEnvPaths => {
-                let paths: Vec<PathBuf> = self
-                    .collect_active_env_paths()
-                    .await
-                    .into_iter()
-                    .collect();
+                let paths: Vec<PathBuf> =
+                    self.collect_active_env_paths().await.into_iter().collect();
                 Response::ActiveEnvPaths { paths }
             }
         }

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -1909,6 +1909,15 @@ impl Daemon {
                     Response::NotebookShutdown { found: false }
                 }
             }
+
+            Request::ActiveEnvPaths => {
+                let paths: Vec<PathBuf> = self
+                    .collect_active_env_paths()
+                    .await
+                    .into_iter()
+                    .collect();
+                Response::ActiveEnvPaths { paths }
+            }
         }
     }
 

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -1912,6 +1912,23 @@ impl Daemon {
         }
     }
 
+    /// Collect env paths from all running kernels to protect from GC eviction.
+    async fn collect_active_env_paths(&self) -> std::collections::HashSet<PathBuf> {
+        let mut paths = std::collections::HashSet::new();
+        let rooms = self.notebook_rooms.lock().await;
+        for room in rooms.values() {
+            let kernel_guard = room.kernel.lock().await;
+            if let Some(ref kernel) = *kernel_guard {
+                if kernel.is_running() {
+                    if let Some(ref env_path) = kernel.env_path {
+                        paths.insert(env_path.clone());
+                    }
+                }
+            }
+        }
+        paths
+    }
+
     /// Background GC loop for content-addressed environment caches.
     ///
     /// Runs once after a 60-second startup delay, then every 6 hours.
@@ -1937,9 +1954,12 @@ impl Daemon {
         ];
 
         loop {
+            // Collect env paths from all running kernels so GC won't evict them
+            let in_use = self.collect_active_env_paths().await;
+
             let mut total_evicted = 0;
             for dir in &cache_dirs {
-                match kernel_env::gc::evict_stale_envs(dir, max_age, max_count).await {
+                match kernel_env::gc::evict_stale_envs(dir, max_age, max_count, &in_use).await {
                     Ok(deleted) => total_evicted += deleted.len(),
                     Err(e) => {
                         warn!("[runtimed] GC failed for {:?}: {}", dir, e);

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -57,6 +57,11 @@ pub struct DaemonConfig {
     /// Override for room eviction delay (milliseconds). Used in tests.
     /// If None, uses the user's `keep_alive_secs` setting.
     pub room_eviction_delay_ms: Option<u64>,
+    /// Maximum age (in seconds) for content-addressed cached environments.
+    /// Environments older than this are evicted by the GC loop.
+    pub env_cache_max_age_secs: u64,
+    /// Maximum number of content-addressed cached environments per cache directory.
+    pub env_cache_max_count: usize,
 }
 
 impl Default for DaemonConfig {
@@ -71,6 +76,8 @@ impl Default for DaemonConfig {
             max_age_secs: 172800, // 2 days
             lock_dir: None,
             room_eviction_delay_ms: None,
+            env_cache_max_age_secs: 604800, // 7 days
+            env_cache_max_count: 10,
         }
     }
 }
@@ -154,6 +161,24 @@ fn parse_uv_error(stderr: &str) -> Option<PackageInstallError> {
     None
 }
 
+/// Spawn background deletion of environment directories.
+fn spawn_env_deletions(paths: Vec<PathBuf>) {
+    if paths.is_empty() {
+        return;
+    }
+    tokio::spawn(async move {
+        for path in &paths {
+            if let Err(e) = tokio::fs::remove_dir_all(path).await {
+                warn!("[runtimed] Failed to delete stale env {:?}: {}", path, e);
+            }
+        }
+        info!(
+            "[runtimed] Cleaned up {} stale/invalid env directories",
+            paths.len()
+        );
+    });
+}
+
 /// Internal pool state.
 struct Pool {
     /// Available environments ready for use.
@@ -179,36 +204,53 @@ impl Pool {
         }
     }
 
-    /// Prune stale environments.
-    fn prune_stale(&mut self) {
+    /// Prune stale environments, returning paths that should be deleted from disk.
+    fn prune_stale(&mut self) -> Vec<PathBuf> {
         let max_age = std::time::Duration::from_secs(self.max_age_secs);
-        let before = self.available.len();
-        self.available.retain(|e| e.created_at.elapsed() < max_age);
-        let removed = before - self.available.len();
-        if removed > 0 {
-            info!("[runtimed] Pruned {} stale environments", removed);
+        let mut removed_paths = Vec::new();
+        let mut kept = VecDeque::new();
+        for entry in self.available.drain(..) {
+            if entry.created_at.elapsed() < max_age {
+                kept.push_back(entry);
+            } else {
+                removed_paths.push(entry.env.venv_path.clone());
+            }
         }
+        self.available = kept;
+        if !removed_paths.is_empty() {
+            info!(
+                "[runtimed] Pruned {} stale environments",
+                removed_paths.len()
+            );
+        }
+        removed_paths
     }
 
     /// Take an environment from the pool.
-    fn take(&mut self) -> Option<PooledEnv> {
-        self.prune_stale();
+    fn take(&mut self) -> (Option<PooledEnv>, Vec<PathBuf>) {
+        let stale_paths = self.prune_stale();
 
         // Try to get a valid environment, skipping any with missing paths or missing warmup
+        let mut invalid_paths = Vec::new();
         while let Some(entry) = self.available.pop_front() {
             if entry.env.venv_path.exists()
                 && entry.env.python_path.exists()
                 && entry.env.venv_path.join(".warmed").exists()
             {
-                return Some(entry.env);
+                let mut all_paths = stale_paths;
+                all_paths.extend(invalid_paths);
+                return (Some(entry.env), all_paths);
             }
             warn!(
                 "[runtimed] Skipping env with missing path or warmup marker: {:?}",
                 entry.env.venv_path
             );
+            invalid_paths.push(entry.env.venv_path);
         }
 
-        None
+        let mut all_paths = stale_paths;
+        all_paths.extend(invalid_paths);
+        (None, all_paths)
     }
 
     /// Add an environment to the pool (success case).
@@ -511,6 +553,12 @@ impl Daemon {
         let conda_daemon = self.clone();
         tokio::spawn(async move {
             conda_daemon.conda_warming_loop().await;
+        });
+
+        // Spawn the environment GC loop
+        let gc_daemon = self.clone();
+        tokio::spawn(async move {
+            gc_daemon.env_gc_loop().await;
         });
 
         // Spawn the settings.json file watcher
@@ -840,6 +888,7 @@ impl Daemon {
 
         let mut uv_found = 0;
         let mut conda_found = 0;
+        let mut orphans: Vec<PathBuf> = Vec::new();
 
         while let Ok(Some(entry)) = entries.next_entry().await {
             let name = entry.file_name().to_string_lossy().to_string();
@@ -864,6 +913,9 @@ impl Daemon {
                             created_at: Instant::now(),
                         });
                         uv_found += 1;
+                    } else {
+                        // Pool is full — this env is an orphan from a previous daemon run
+                        orphans.push(env_path);
                     }
                 } else {
                     // Invalid env, clean up
@@ -889,6 +941,9 @@ impl Daemon {
                             created_at: Instant::now(),
                         });
                         conda_found += 1;
+                    } else {
+                        // Pool is full — this env is an orphan from a previous daemon run
+                        orphans.push(env_path);
                     }
                 } else {
                     // Invalid env, clean up
@@ -902,6 +957,24 @@ impl Daemon {
                 "[runtimed] Found {} existing UV and {} existing Conda environments",
                 uv_found, conda_found
             );
+        }
+
+        // Clean up orphaned pool envs left over from previous daemon runs.
+        // These accumulate because each daemon restart creates fresh UUIDs
+        // and only loads up to `target` from existing dirs on disk.
+        if !orphans.is_empty() {
+            info!(
+                "[runtimed] Cleaning up {} orphaned pool environments",
+                orphans.len()
+            );
+            for orphan in orphans {
+                if let Err(e) = tokio::fs::remove_dir_all(&orphan).await {
+                    warn!(
+                        "[runtimed] Failed to remove orphaned env {:?}: {}",
+                        orphan, e
+                    );
+                }
+            }
         }
     }
 
@@ -1581,7 +1654,8 @@ impl Daemon {
     /// Returns `Some(PooledEnv)` if an environment is available, `None` otherwise.
     /// Automatically triggers replenishment when an environment is taken.
     pub async fn take_uv_env(self: &Arc<Self>) -> Option<PooledEnv> {
-        let env = self.uv_pool.lock().await.take();
+        let (env, stale_paths) = self.uv_pool.lock().await.take();
+        spawn_env_deletions(stale_paths);
         if let Some(ref e) = env {
             info!(
                 "[runtimed] Took UV env for kernel launch: {:?}",
@@ -1601,7 +1675,8 @@ impl Daemon {
     /// Returns `Some(PooledEnv)` if an environment is available, `None` otherwise.
     /// Automatically triggers replenishment when an environment is taken.
     pub async fn take_conda_env(self: &Arc<Self>) -> Option<PooledEnv> {
-        let env = self.conda_pool.lock().await.take();
+        let (env, stale_paths) = self.conda_pool.lock().await.take();
+        spawn_env_deletions(stale_paths);
         if let Some(ref e) = env {
             info!(
                 "[runtimed] Took Conda env for kernel launch: {:?}",
@@ -1620,10 +1695,11 @@ impl Daemon {
     async fn handle_request(self: Arc<Self>, request: Request) -> Response {
         match request {
             Request::Take { env_type } => {
-                let env = match env_type {
+                let (env, stale_paths) = match env_type {
                     EnvType::Uv => self.uv_pool.lock().await.take(),
                     EnvType::Conda => self.conda_pool.lock().await.take(),
                 };
+                spawn_env_deletions(stale_paths);
 
                 match env {
                     Some(env) => {
@@ -1842,6 +1918,135 @@ impl Daemon {
                 }
             }
         }
+    }
+
+    /// Background GC loop for content-addressed environment caches.
+    ///
+    /// Runs once after a 60-second startup delay, then every 6 hours.
+    /// Evicts stale cached environments from the global UV, Conda, and inline-env
+    /// cache directories based on `env_cache_max_age_secs` and `env_cache_max_count`.
+    async fn env_gc_loop(&self) {
+        // Wait for warming loops to settle before first GC run
+        tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+
+        let max_age = std::time::Duration::from_secs(self.config.env_cache_max_age_secs);
+        let max_count = self.config.env_cache_max_count;
+
+        // Directories to GC. These are the global content-addressed caches
+        // used by kernel-env (not per-worktree pool dirs).
+        let cache_dirs = [
+            kernel_env::uv::default_cache_dir_uv(),
+            kernel_env::conda::default_cache_dir_conda(),
+            // inline-envs: same parent as uv cache but under "inline-envs"
+            dirs::cache_dir()
+                .unwrap_or_else(|| PathBuf::from("/tmp"))
+                .join("runt")
+                .join("inline-envs"),
+        ];
+
+        loop {
+            let mut total_evicted = 0;
+            for dir in &cache_dirs {
+                match kernel_env::gc::evict_stale_envs(dir, max_age, max_count).await {
+                    Ok(deleted) => total_evicted += deleted.len(),
+                    Err(e) => {
+                        warn!("[runtimed] GC failed for {:?}: {}", dir, e);
+                    }
+                }
+            }
+            if total_evicted > 0 {
+                info!(
+                    "[runtimed] GC cycle complete: evicted {} cached environments",
+                    total_evicted
+                );
+            }
+
+            // Clean up stale worktree state directories
+            let worktrees_dir = dirs::cache_dir()
+                .unwrap_or_else(|| PathBuf::from("/tmp"))
+                .join(crate::cache_namespace())
+                .join("worktrees");
+
+            if let Ok(total_cleaned) = Self::cleanup_stale_worktrees(&worktrees_dir).await {
+                if total_cleaned > 0 {
+                    info!(
+                        "[runtimed] Cleaned up {} stale worktree directories",
+                        total_cleaned
+                    );
+                }
+            }
+
+            // Run every 6 hours
+            tokio::time::sleep(std::time::Duration::from_secs(6 * 3600)).await;
+        }
+    }
+
+    /// Clean up worktree state directories where the original git worktree
+    /// path no longer exists and the daemon.json is older than 7 days.
+    async fn cleanup_stale_worktrees(worktrees_dir: &std::path::Path) -> anyhow::Result<usize> {
+        if !worktrees_dir.exists() {
+            return Ok(0);
+        }
+
+        let mut entries = tokio::fs::read_dir(worktrees_dir).await?;
+        let mut cleaned = 0;
+        let grace_period = std::time::Duration::from_secs(7 * 24 * 3600); // 7 days
+
+        while let Ok(Some(entry)) = entries.next_entry().await {
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+
+            let daemon_json = path.join("daemon.json");
+            if !daemon_json.exists() {
+                continue;
+            }
+
+            // Check if daemon.json is old enough (grace period)
+            let mtime = tokio::fs::metadata(&daemon_json)
+                .await
+                .and_then(|m| m.modified())
+                .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
+            let age = std::time::SystemTime::now()
+                .duration_since(mtime)
+                .unwrap_or_default();
+            if age < grace_period {
+                continue;
+            }
+
+            // Read daemon.json to get the worktree_path
+            let contents = match tokio::fs::read_to_string(&daemon_json).await {
+                Ok(c) => c,
+                Err(_) => continue,
+            };
+            let info: serde_json::Value = match serde_json::from_str(&contents) {
+                Ok(v) => v,
+                Err(_) => continue,
+            };
+
+            // Check if the original worktree path still exists
+            if let Some(wt_path) = info.get("worktree_path").and_then(|v| v.as_str()) {
+                if std::path::Path::new(wt_path).exists() {
+                    continue; // Worktree still exists, skip
+                }
+            } else {
+                continue; // No worktree_path field, not a dev worktree
+            }
+
+            // Worktree path is gone and daemon.json is old — safe to delete
+            info!("[runtimed] Removing stale worktree state: {:?}", path);
+            if let Err(e) = tokio::fs::remove_dir_all(&path).await {
+                warn!(
+                    "[runtimed] Failed to remove stale worktree {:?}: {}",
+                    path, e
+                );
+            } else {
+                cleaned += 1;
+            }
+        }
+
+        Ok(cleaned)
     }
 
     /// UV warming loop - maintains the UV pool.
@@ -2520,9 +2725,14 @@ print("warmup complete")
         }
 
         // Install packages (120 second timeout)
+        // Use hardlink mode to share files from uv's global cache,
+        // dramatically reducing per-env disk usage. uv falls back to
+        // copies automatically if hardlinks aren't supported.
         let mut install_args = vec![
             "pip".to_string(),
             "install".to_string(),
+            "--link-mode".to_string(),
+            "hardlink".to_string(),
             "--python".to_string(),
             python_path.to_string_lossy().to_string(),
         ];
@@ -2742,17 +2952,19 @@ mod tests {
 
         assert_eq!(pool.available.len(), 1);
 
-        let taken = pool.take();
+        let (taken, stale) = pool.take();
         assert!(taken.is_some());
         assert_eq!(taken.unwrap().venv_path, env.venv_path);
         assert_eq!(pool.available.len(), 0);
+        assert!(stale.is_empty());
     }
 
     #[test]
     fn test_pool_take_empty() {
         let mut pool = Pool::new(3, 3600);
-        let taken = pool.take();
+        let (taken, stale) = pool.take();
         assert!(taken.is_none());
+        assert!(stale.is_empty());
     }
 
     #[test]
@@ -2776,9 +2988,11 @@ mod tests {
         pool.add(valid_env.clone());
 
         // Take should skip the missing one and return the valid one
-        let taken = pool.take();
+        let (taken, stale) = pool.take();
         assert!(taken.is_some());
         assert_eq!(taken.unwrap().venv_path, valid_env.venv_path);
+        // The missing env path should be in the stale list for cleanup
+        assert!(stale.contains(&PathBuf::from("/nonexistent/path")));
     }
 
     #[test]
@@ -2822,7 +3036,7 @@ mod tests {
         assert_eq!(pool.deficit(), 0); // 3 available = target
 
         // Taking one should increase deficit
-        pool.take();
+        let _ = pool.take();
         assert_eq!(pool.available.len(), 2);
         assert_eq!(pool.deficit(), 1);
     }
@@ -3005,14 +3219,15 @@ mod tests {
         pool.add(unwarmed_env);
 
         // take() should skip the unwarmed env
-        assert!(pool.take().is_none());
+        let (taken, _stale) = pool.take();
+        assert!(taken.is_none());
 
         // Add a properly warmed env
         let warmed_env = create_test_env(&temp_dir, "warmed-env");
         pool.add(warmed_env.clone());
 
         // take() should return the warmed env
-        let taken = pool.take();
+        let (taken, _stale) = pool.take();
         assert!(taken.is_some());
         assert_eq!(taken.unwrap().venv_path, warmed_env.venv_path);
     }

--- a/crates/runtimed/src/kernel_manager.rs
+++ b/crates/runtimed/src/kernel_manager.rs
@@ -257,6 +257,9 @@ pub struct RoomKernel {
     env_source: String,
     /// Environment configuration used at launch (for sync detection)
     launched_config: LaunchedEnvConfig,
+    /// Path to the environment directory backing this kernel (if any).
+    /// Used by the GC to avoid evicting envs that are still in use.
+    pub env_path: Option<PathBuf>,
     /// Connection info for the kernel
     connection_info: Option<ConnectionInfo>,
     /// Path to the connection file
@@ -414,6 +417,7 @@ impl RoomKernel {
             pending_history: Arc::new(StdMutex::new(HashMap::new())),
             pending_completions: Arc::new(StdMutex::new(HashMap::new())),
             stream_terminals: Arc::new(tokio::sync::Mutex::new(StreamTerminals::new())),
+            env_path: None,
             state_doc,
             state_changed_tx,
         }
@@ -510,6 +514,7 @@ impl RoomKernel {
         self.kernel_type = kernel_type.to_string();
         self.env_source = env_source.to_string();
         self.launched_config = launched_config;
+        self.env_path = env.as_ref().map(|e| e.venv_path.clone());
         self.status = KernelStatus::Starting;
 
         // Broadcast starting status

--- a/crates/runtimed/src/protocol.rs
+++ b/crates/runtimed/src/protocol.rs
@@ -8,6 +8,7 @@
 //! BlobResponse, DaemonBroadcast) are defined here.
 
 use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
 
 use crate::{EnvType, PoolError, PoolStats, PooledEnv};
 
@@ -54,6 +55,10 @@ pub enum Request {
         /// The notebook ID (file path used as identifier).
         notebook_id: String,
     },
+
+    /// Get environment paths currently in use by running kernels.
+    /// Used by `runt env clean` to avoid evicting active environments.
+    ActiveEnvPaths,
 }
 
 /// Responses from the daemon to clients.
@@ -104,6 +109,9 @@ pub enum Response {
         /// Whether the notebook was found and shut down.
         found: bool,
     },
+
+    /// Environment paths currently in use by running kernels.
+    ActiveEnvPaths { paths: Vec<PathBuf> },
 }
 
 /// Kernel info for a notebook room.

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -71,6 +71,7 @@ fn test_config(temp_dir: &TempDir) -> DaemonConfig {
         max_age_secs: 3600,
         lock_dir: Some(temp_dir.path().to_path_buf()),
         room_eviction_delay_ms: Some(50), // Fast eviction for tests
+        ..Default::default()
     }
 }
 
@@ -223,6 +224,7 @@ async fn test_singleton_prevents_second_daemon() {
         max_age_secs: 3600,
         lock_dir: Some(temp_dir.path().to_path_buf()),
         room_eviction_delay_ms: Some(50),
+        ..Default::default()
     };
 
     let result = Daemon::new(config2);


### PR DESCRIPTION
## Summary

- **Startup sweep**: on daemon restart, delete orphaned `runtimed-{uv,conda}-*` pool envs beyond pool target — prevents the core disk leak where each restart left old envs on disk. Runs in a background task so it doesn't block startup.
- **`prune_stale()` disk cleanup**: actually delete env directories from disk when evicting stale entries (previously only removed from in-memory pool)
- **`--link-mode hardlink` for uv**: all `uv pip install` commands now hardlink from uv's global cache instead of copying, dramatically reducing per-env disk footprint
- **Content-addressed cache eviction**: new `kernel-env::gc` module with `.last-used` timestamp tracking and `evict_stale_envs()` (default: 7-day max age, 10 max per dir)
- **Background GC loop**: runs every 6 hours in the daemon, evicting stale cached envs from `envs/`, `conda-envs/`, and `inline-envs/`
- **Stale worktree auto-cleanup**: GC loop removes worktree state dirs where the original git worktree path no longer exists (7-day grace period)
- **`runt env` CLI**: new subcommands `stats`, `list`, `clean` for manual environment management

## Context

The environment pool had no GC. Observed 647 GB of cache:
- 273 orphaned pool envs in nightly (target is 6)
- 82 stale worktree dirs (315 GB)
- 89 stale conda-envs, 43 inline-envs in stable

Root causes:
1. `find_existing_environments()` loaded up to `target` on startup, silently ignored extras — orphans accumulated across daemon restarts
2. `prune_stale()` removed entries from memory but never deleted directories from disk
3. Content-addressed envs (`envs/{hash}`, `conda-envs/{hash}`, `inline-envs/{hash}`) had no eviction
4. Stale worktree dirs persisted after git worktrees were deleted
5. uv created full copies — no `--link-mode hardlink` to share from uv's cache

## Test plan

- [x] 263 runtimed unit tests pass (including updated pool tests for new `take()` return type)
- [x] 16 kernel-env tests pass (including 4 new GC tests)
- [x] `cargo clippy` clean
- [x] `cargo xtask lint --fix` passes
- [ ] Manual: restart daemon, verify orphaned pool envs are cleaned on startup
- [ ] Manual: `runt env stats` shows correct disk usage breakdown
- [ ] Manual: `runt env clean --dry-run` previews eviction correctly
- [ ] Manual: verify hardlink mode — `stat` site-packages files should show link count > 1