### PR TITLE
fix(wasm-tests): make sync tests resilient to multi-round protocol

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,7 +136,7 @@ jobs:
           deno-version: v2.x
 
       - name: Run runtimed-wasm Deno tests
-        run: deno test --allow-read --allow-env --no-check crates/runtimed-wasm/tests/
+        run: deno test --allow-read --allow-env --no-check --parallel=false crates/runtimed-wasm/tests/
 
   build-ui:
     name: Build shared UI artifacts

--- a/crates/runtimed-wasm/tests/splice_source_test.ts
+++ b/crates/runtimed-wasm/tests/splice_source_test.ts
@@ -88,22 +88,51 @@ function getSource(h: Handle, cellId: string): string {
  * This simulates the relay path: one handle generates a sync message,
  * the other receives it as a frame and returns events with changesets
  * and attributions.
+ *
+ * The Automerge sync protocol may need multiple rounds to deliver changes
+ * (the first round can be a heads-only exchange on some platforms,
+ * especially Linux CI). This runs up to 3 bidirectional rounds and
+ * collects events across all of them, breaking early when a sync_applied
+ * event with changes is found.
  */
 function syncViaFrame(
   from: Handle,
   to: Handle,
   // deno-lint-ignore no-explicit-any
 ): any[] | null {
-  const msg = from.flush_local_changes();
-  if (!msg) return null;
+  // deno-lint-ignore no-explicit-any
+  const allEvents: any[] = [];
 
-  // Build a frame: type byte 0x00 (AUTOMERGE_SYNC) + payload
-  const frame = new Uint8Array(1 + msg.length);
-  frame[0] = 0x00; // AUTOMERGE_SYNC
-  frame.set(msg, 1);
+  for (let round = 0; round < 5; round++) {
+    const fwdMsg = from.flush_local_changes();
+    if (fwdMsg) {
+      const frame = new Uint8Array(1 + fwdMsg.length);
+      frame[0] = 0x00; // AUTOMERGE_SYNC
+      frame.set(fwdMsg, 1);
+      const events = to.receive_frame(frame);
+      if (events) allEvents.push(...events);
+    }
 
-  const events = to.receive_frame(frame);
-  return events ?? null;
+    // Send reply back so the protocol advances
+    const replyMsg = to.flush_local_changes();
+    if (replyMsg) {
+      const replyFrame = new Uint8Array(1 + replyMsg.length);
+      replyFrame[0] = 0x00;
+      replyFrame.set(replyMsg, 1);
+      from.receive_frame(replyFrame);
+    }
+
+    // Break early if we found a sync event with actual changes
+    if (
+      allEvents.some(
+        // deno-lint-ignore no-explicit-any
+        (e: any) => e.type === "sync_applied" && e.changed,
+      )
+    )
+      break;
+  }
+
+  return allEvents.length > 0 ? allEvents : null;
 }
 
 // ── 1. Basic splice operations ───────────────────────────────────────
@@ -688,47 +717,13 @@ Deno.test(
     // Frontend deletes " world"
     frontend.splice_source("c1", 5, 6, "");
 
-    // The sync protocol may need multiple rounds to deliver changes
-    // (first round can be a heads-only exchange on some platforms).
-    // Collect events across up to 3 rounds of frame-based sync.
-    // deno-lint-ignore no-explicit-any
-    const allEvents: any[] = [];
-    for (let round = 0; round < 3; round++) {
-      const fwdMsg = frontend.flush_local_changes();
-      if (fwdMsg) {
-        const frame = new Uint8Array(1 + fwdMsg.length);
-        frame[0] = 0x00;
-        frame.set(fwdMsg, 1);
-        const events = daemon.receive_frame(frame);
-        if (events) allEvents.push(...events);
-      }
-      // Send daemon's reply back to frontend so protocol advances
-      const replyMsg = daemon.flush_local_changes();
-      if (replyMsg) {
-        const replyFrame = new Uint8Array(1 + replyMsg.length);
-        replyFrame[0] = 0x00;
-        replyFrame.set(replyMsg, 1);
-        frontend.receive_frame(replyFrame);
-      }
-      if (
-        allEvents.some(
-          // deno-lint-ignore no-explicit-any
-          (e: any) => e.type === "sync_applied" && e.changed,
-        )
-      )
-        break;
-    }
+    const events = syncViaFrame(frontend, daemon);
+    assertExists(events);
 
-    const syncEvent = allEvents.find(
+    const syncEvent = events.find(
       // deno-lint-ignore no-explicit-any
       (e: any) => e.type === "sync_applied" && e.changed,
     );
-    if (!syncEvent) {
-      console.error(
-        "No sync_applied event with changed:true. All events:",
-        JSON.stringify(allEvents, null, 2),
-      );
-    }
     assertExists(syncEvent);
 
     // deno-lint-ignore no-explicit-any


### PR DESCRIPTION
## Summary

Fixes the intermittent WASM test failures (`changeset: splice_source flags source as changed` and friends).

**Root cause:** Two independent issues compounding:

1. **Automerge multi-round sync:** The sync protocol can require multiple exchanges before changes are delivered (first round is often heads-only on Linux CI). The `syncViaFrame()` helper only did one round.

2. **Test parallelism:** Deno 2.4 appears to parallelize tests even within a single file. The WASM `NotebookHandle` instances share global state, so concurrent tests cause sync events to bleed across test boundaries (~8% failure rate).

**Changes:**

- `syncViaFrame()` now runs up to 5 bidirectional sync rounds, collecting events across all of them and breaking early when a `sync_applied` event with changes is found
- Collapsed the inline multi-round pattern from the deletion attribution test into the shared helper (DRY)
- Added `--parallel=false` to the CI deno test command

**Verification:** 0/80 failures with `--parallel=false` vs ~4/50 without.

## Test plan

- [x] 30/30 local runs pass with `--parallel=false`
- [x] 50/50 local runs pass with `--parallel=false`
- [ ] CI passes on this PR