### PR TITLE
fix(ci): remove invalid --parallel=false from deno test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,7 +136,7 @@ jobs:
           deno-version: v2.x
 
       - name: Run runtimed-wasm Deno tests
-        run: deno test --allow-read --allow-env --no-check --parallel=false crates/runtimed-wasm/tests/
+        run: deno test --allow-read --allow-env --no-check crates/runtimed-wasm/tests/
 
   build-ui:
     name: Build shared UI artifacts


### PR DESCRIPTION
Deno's `--parallel` is a boolean flag (present = on, absent = off). `--parallel=false` is not valid syntax — CI fails with:

```
error: unexpected value 'false' for '--parallel' found; no more were expected
```

Without the flag, tests within a single file already run sequentially. The multi-round `syncViaFrame` from #1098 handles the underlying flakiness.