### PR TITLE
ci: run checks on all PRs, pin Deno to 2.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -133,7 +132,7 @@ jobs:
       - name: Install Deno
         uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.x
+          deno-version: "2.4"
 
       - name: Run runtimed-wasm Deno tests
         run: deno test --allow-read --allow-env --no-check crates/runtimed-wasm/tests/


### PR DESCRIPTION
## Summary

- Run the Build workflow on PRs targeting **any branch**, not just main. This catches CI issues on PR-to-PR workflows (like the `--parallel=false` breakage in #1099 that wasn't caught until #1097 ran against main).
- Pin Deno from `v2.x` to `2.4` to match local dev (2.4.3) and avoid flag compatibility differences across minor versions.

## Test plan

- [x] This PR itself validates — CI should run on it despite targeting main (tests the trigger change)