### PR TITLE
fix(runtimed-py): add Execution to unit test expected exports

### DIFF
--- a/python/runtimed/tests/test_session_unit.py
+++ b/python/runtimed/tests/test_session_unit.py
@@ -50,6 +50,7 @@ class TestModuleExports:
         expected = {
             # Primary API
             "Client",
+            "Execution",
             "Notebook",
             "NotebookInfo",
             "CellHandle",


### PR DESCRIPTION
## Summary
- Adds `Execution` to the expected set in `test_all_exports`, fixing the unit test broken by #1101

## Test plan
- [x] `test_all_exports` passes locally