### PR TITLE
fix(logging): rotate log files on startup for clean per-session logs

### DIFF
--- a/crates/mcp-supervisor/src/main.rs
+++ b/crates/mcp-supervisor/src/main.rs
@@ -1551,10 +1551,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let project_root_for_log = resolve_project_root();
     let log_dir = project_root_for_log.join(".context");
     let _ = std::fs::create_dir_all(&log_dir);
+
+    // Rotate previous session's log so the current file only contains this session.
+    // Keeps one old copy (.log.1) for debugging daemon-restart-on-failure scenarios.
+    let inkwell_log_path = log_dir.join("inkwell.log");
+    if inkwell_log_path.exists() {
+        let _ = std::fs::rename(&inkwell_log_path, log_dir.join("inkwell.log.1"));
+    }
+
     let log_file = OpenOptions::new()
         .create(true)
         .append(true)
-        .open(log_dir.join("inkwell.log"))
+        .open(&inkwell_log_path)
         .ok();
 
     let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -2910,13 +2910,20 @@ async fn diagnostics_command(output_dir: Option<PathBuf>) -> Result<()> {
     let enc = GzEncoder::new(file, Compression::default());
     let mut tar = tar::Builder::new(enc);
 
-    // 1. Daemon log
+    // 1. Daemon log (current session)
     let daemon_log = runtimed::default_log_path();
     if daemon_log.exists() {
         tar.append_path_with_name(&daemon_log, "runtimed.log")?;
         println!("  {} runtimed.log", "✓".green());
     } else {
         println!("  {} runtimed.log (not found)", "–".yellow());
+    }
+
+    // 1b. Previous session log (preserved across daemon restart for crash diagnosis)
+    let prev_daemon_log = daemon_log.with_extension("log.1");
+    if prev_daemon_log.exists() {
+        tar.append_path_with_name(&prev_daemon_log, "runtimed.log.1")?;
+        println!("  {} runtimed.log.1 (previous session)", "✓".green());
     }
 
     // 2. Notebook log

--- a/crates/runtimed/src/main.rs
+++ b/crates/runtimed/src/main.rs
@@ -142,14 +142,6 @@ fn early_log(msg: &str) {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    // Log startup diagnostics BEFORE anything else - helps debug launchd issues
-    early_log(&format!(
-        "runtimed starting: pid={}, HOME={:?}, USER={:?}",
-        std::process::id(),
-        std::env::var("HOME").ok(),
-        std::env::var("USER").ok()
-    ));
-
     // Install panic hook to ensure panics are logged to the daemon log file.
     // Uses early_log_path() which falls back to /tmp if HOME is not set.
     std::panic::set_hook(Box::new(|panic_info| {
@@ -187,6 +179,26 @@ async fn main() -> anyhow::Result<()> {
     if let Some(parent) = log_path.parent() {
         std::fs::create_dir_all(parent).ok();
     }
+
+    // Rotate the previous session's log so the current file only contains
+    // this daemon run. Keeps one old copy (.log.1) for crash diagnosis via
+    // `runt diagnostics`. Only runs on the daemon path — subcommands like
+    // `status` or `install` must not touch the live log.
+    if matches!(cli.command, None | Some(Commands::Run { .. })) {
+        let prev = log_path.with_extension("log.1");
+        let _ = std::fs::rename(&log_path, &prev);
+    }
+
+    // Log startup diagnostics after rotation so the breadcrumb lands in the
+    // current session's log file, not in .log.1. The panic hook above still
+    // catches crashes before this point.
+    early_log(&format!(
+        "runtimed starting: pid={}, HOME={:?}, USER={:?}",
+        std::process::id(),
+        std::env::var("HOME").ok(),
+        std::env::var("USER").ok()
+    ));
+
     let log_file = std::fs::OpenOptions::new()
         .create(true)
         .append(true)


### PR DESCRIPTION
Rotate `runtimed.log` and `inkwell.log` to `.log.1` on process startup so the current log file only contains the current session.

**Problem:** When an agent runs `runt diagnostics` or reads daemon logs, old entries from previous sessions are mixed in. The agent can't distinguish "this just happened" from "this happened 3 days ago" and chases stale errors.

**Fix:** A single `rename` call before opening the log file for writing. Previous session is preserved as `.log.1` for crash diagnosis.

Changes:
- **`runtimed/src/main.rs`** — rotate `runtimed.log` → `runtimed.log.1` on daemon start
- **`mcp-supervisor/src/main.rs`** — rotate `inkwell.log` → `inkwell.log.1` on supervisor start
- **`runt/src/main.rs`** — include `runtimed.log.1` in `runt diagnostics` archive

_PR submitted by @rgbkrk's agent Quill, via Zed_