### PR TITLE
fix(wasm): make sync changed-flag test robust to bloom filter races

### DIFF
--- a/crates/runtimed-wasm/tests/deno_smoke_test.ts
+++ b/crates/runtimed-wasm/tests/deno_smoke_test.ts
@@ -1280,17 +1280,21 @@ Deno.test("Sync: load from bytes + incremental sync with changed flag", () => {
   daemon.add_cell(1, "new-cell", "markdown");
   daemon.update_source("new-cell", "# New section");
 
-  // Generate sync message from daemon
-  const msg = daemon.flush_local_changes();
-  assertExists(msg, "Daemon should have sync message after mutation");
-
-  // WASM receives and should report changed=true
-  const changed = wasm.receive_sync_message(msg);
-  assertEquals(
-    changed,
-    true,
-    "receive_sync_message should return true when doc changes",
-  );
+  // Sync the new content. The sync protocol uses bloom filters internally,
+  // so a single message may not carry the change data (bloom false positive
+  // can cause a multi-round exchange). Use the full sync loop to be robust.
+  let sawChange = false;
+  for (let i = 0; i < 10; i++) {
+    const msgD = daemon.flush_local_changes();
+    const msgW = wasm.flush_local_changes();
+    if (!msgD && !msgW) break;
+    if (msgD) {
+      const changed = wasm.receive_sync_message(msgD);
+      if (changed) sawChange = true;
+    }
+    if (msgW) daemon.receive_sync_message(msgW);
+  }
+  assert(sawChange, "receive_sync_message should return true at least once when doc changes");
 
   // WASM should now have the new cell
   assertEquals(wasm.cell_count(), 2);


### PR DESCRIPTION
## Summary

The WASM test "Sync: load from bytes + incremental sync with changed flag" was flaking in CI. It assumed a single `flush_local_changes()` → `receive_sync_message()` would always deliver the change data in one shot. Automerge's sync protocol uses bloom filters internally, and false positives can cause the first message to omit change data, requiring a multi-round exchange.

Replaced the single-message assertion with a full sync loop that tracks whether `receive_sync_message` ever reported `changed=true`, matching how the protocol actually works in production. The end-state assertions (cell count, content) remain unchanged.

## Verification

- [ ] WASM tests pass: `deno test --allow-read --allow-env --no-check crates/runtimed-wasm/tests/`
- [ ] The previously-flaky test "Sync: load from bytes + incremental sync with changed flag" passes consistently

_PR submitted by @rgbkrk's agent, Quill_