### PR TITLE
docs(python): improve PyPI READMEs with download links

### DIFF
--- a/python/nteract/README.md
+++ b/python/nteract/README.md
@@ -1,18 +1,10 @@
-# nteract/nteract
+# nteract
 
-## What's going on?
+An MCP (Model Context Protocol) server that connects AI assistants to Jupyter notebooks via the [nteract desktop app](https://nteract.io).
 
-If you're here looking for the Electron-based nteract desktop app, you can view the source [in this repo](https://github.com/nteract/archived-desktop-app). **That desktop app is not actively maintained.**
+**[Download the nteract desktop app](https://nteract.io)** — you'll need it to see notebooks, collaborate with agents, and manage environments.
 
-We're actively developing the spiritual successor to the nteract desktop app in the [nteract/desktop repo](https://github.com/nteract/desktop).
-
-### The New Desktop App
-
-We're actively developing the spiritual successor to the nteract desktop app in the [nteract/desktop repo](https://github.com/nteract/desktop).
-
-The new app is a native desktop app with instant startup and intelligent environment management.
-
-<img width="1100" height="750" alt="Screenshot 2025-02-27 at 8 33 13 AM" src="https://github.com/user-attachments/assets/06be5ab5-9390-43a9-993a-ccb07ec9139d" />
+> Looking for the old Electron-based nteract desktop app? The source is archived at [nteract/archived-desktop-app](https://github.com/nteract/archived-desktop-app). The new native app is actively developed at [nteract/desktop](https://github.com/nteract/desktop).
 
 ## Bringing Agents in the Loop
 
@@ -56,7 +48,7 @@ Claude will:
 3. Generate visualizations
 4. Show you the results
 
-You can open the same notebook in the [nteract desktop app](https://github.com/nteract/desktop) to see changes in real-time and collaborate with the AI.
+You can open the same notebook in the [nteract desktop app](https://nteract.io) to see changes in real-time and collaborate with the AI.
 
 ## Installation
 

--- a/python/runtimed/README.md
+++ b/python/runtimed/README.md
@@ -1,6 +1,10 @@
 # runtimed
 
-Python toolkit for Jupyter runtimes, powered by runtimed Rust binaries. Execute code, manage kernels, and interact with notebooks programmatically.
+Python bindings for the [nteract](https://nteract.io) runtime daemon. Execute code, manage kernels, and interact with notebooks programmatically.
+
+**[Download the nteract desktop app](https://nteract.io)** — it ships the runtimed daemon and gives you a visual interface for your notebooks.
+
+> **Using runtimed with agents?** The [`nteract` MCP server](https://pypi.org/project/nteract/) is built on runtimed and provides a ready-made agentic interface for AI assistants. It's also a great example of how to use runtimed in practice.
 
 ## Installation
 
@@ -110,7 +114,7 @@ await cell.delete()
 
 ## Requirements
 
-- runtimed daemon running (see [CLAUDE.md](../../CLAUDE.md) — use `cargo xtask dev-daemon` for development or `cargo xtask install-daemon` for the system service)
+- The runtimed daemon, which ships with the [nteract desktop app](https://nteract.io). For development, see the [nteract/desktop repo](https://github.com/nteract/desktop).
 - Python 3.10+
 
 ## Documentation


### PR DESCRIPTION
## Summary
- Remove the screenshot from the nteract README that renders poorly on PyPI
- Add prominent download links to https://nteract.io in both nteract and runtimed READMEs, so users who discover the packages on PyPI know where to get the desktop app
- Point runtimed users to the `nteract` MCP server package as both an agentic interface and a practical usage example
- Clean up redundant intro text and update internal links

## Test plan
- [ ] Verify markdown renders correctly on the PR diff
- [ ] Confirm no broken links