### PR TITLE
chore: gate SPLICE and cursor-registry logging behind logger.debug

### DIFF
--- a/apps/notebook/src/lib/crdt-editor-bridge.ts
+++ b/apps/notebook/src/lib/crdt-editor-bridge.ts
@@ -36,6 +36,7 @@ import {
 } from "@codemirror/view";
 import { externalChangeAnnotation } from "@/components/editor/codemirror-editor";
 import type { NotebookHandle } from "../wasm/runtimed-wasm/runtimed_wasm.js";
+import { logger } from "./logger";
 
 // ── Types ────────────────────────────────────────────────────────────
 
@@ -198,7 +199,7 @@ export function createCrdtBridge(config: CrdtBridgeConfig): CrdtBridge {
               docText.slice(Math.max(0, fromA - 4), fromA + deleteCount + 4),
             );
             if (hasNonBMP || wasmSource.length !== docText.length) {
-              console.warn("[crdt-bridge] SPLICE", {
+              logger.debug("[crdt-bridge] SPLICE", {
                 cellId: cellId.slice(0, 8),
                 fromA,
                 toA,

--- a/apps/notebook/src/lib/cursor-registry.ts
+++ b/apps/notebook/src/lib/cursor-registry.ts
@@ -21,6 +21,7 @@ import {
   setRemoteSelections,
 } from "@/components/editor/remote-cursors";
 import { subscribePresence } from "./notebook-frame-bus";
+import { logger } from "./logger";
 
 // ── Types (presence message shapes from WASM decode) ─────────────────
 
@@ -142,7 +143,7 @@ export function unregisterEditor(cellId: string): void {
 function dispatchToCell(cellId: string): void {
   const view = editors.get(cellId);
   if (!view) {
-    console.log(`[cursor-registry] dispatchToCell: no view for ${cellId}`);
+    logger.debug(`[cursor-registry] dispatchToCell: no view for ${cellId}`);
     return;
   }
 
@@ -175,7 +176,7 @@ function dispatchToCell(cellId: string): void {
     }
   }
 
-  console.log(
+  logger.debug(
     `[cursor-registry] dispatchToCell ${cellId}: ${cursors.length} cursors, ${selections.length} selections`,
   );
   setRemoteCursors(view, cursors);

--- a/apps/notebook/src/lib/cursor-registry.ts
+++ b/apps/notebook/src/lib/cursor-registry.ts
@@ -20,8 +20,8 @@ import {
   setRemoteCursors,
   setRemoteSelections,
 } from "@/components/editor/remote-cursors";
-import { subscribePresence } from "./notebook-frame-bus";
 import { logger } from "./logger";
+import { subscribePresence } from "./notebook-frame-bus";
 
 // ── Types (presence message shapes from WASM decode) ─────────────────
 


### PR DESCRIPTION
## Summary

Cleans up noisy `console.log` / `console.warn` calls in release builds by routing them through the existing `logger.debug()` utility, which suppresses output in production unless explicitly enabled via `localStorage.setItem('runt:debug', 'true')`.

## Changes

- **`crdt-editor-bridge.ts`** — `console.warn("[crdt-bridge] SPLICE", ...)` → `logger.debug(...)`. This diagnostic logged on every splice near non-BMP characters or when WASM/CM lengths diverged, producing noise in release console output.
- **`cursor-registry.ts`** — Two `console.log(...)` calls → `logger.debug(...)`. These fired on every cursor dispatch ("no view for …" and "N cursors, M selections"), which is very chatty.

Both files now import `logger` from `./logger`.

## What's kept

All other `console.warn` calls in the frontend are legitimate warnings (settings persistence failures, unknown message types, error handlers, dev-mode-only guards) and were left as-is.