### PR TITLE
feat(nteract): include cell summary in join_notebook response

### DIFF
--- a/python/nteract/src/nteract/_mcp_server.py
+++ b/python/nteract/src/nteract/_mcp_server.py
@@ -681,9 +681,18 @@ async def join_notebook(
     client = _get_client()
     _notebook = await client.join_notebook(notebook_id, peer_label=_peer_label())
 
+    cell_status = await _get_cell_status_map(_notebook)
+    lines = [
+        _format_cell_summary(
+            i, cell, preview_chars=60, include_outputs=False, status=cell_status.get(cell.id)
+        )
+        for i, cell in enumerate(_notebook.cells)
+    ]
+
     return {
         "notebook_id": _notebook.notebook_id,
         "connected": True,
+        "cells": "\n".join(lines),
     }
 
 


### PR DESCRIPTION
## Summary

`join_notebook` now returns a `cells` key containing a cell summary string, giving callers immediate context about the notebook without a second round-trip to `get_all_cells`.

Outputs are excluded from the summary to keep the response compact for large notebooks — agents can fetch specific cells when they need output detail.

Closes #1113

## Verification

- [ ] Call `join_notebook` via MCP and confirm the response includes a `cells` field with the summary format
- [ ] Join a notebook with running/queued cells and verify status annotations appear
- [ ] Join an empty notebook and verify `cells` is an empty string

_PR submitted by @rgbkrk's agent, Quill_