### PR TITLE
feat(python): improve API discoverability with _repr_markdown_ and callable guards

### DIFF
--- a/python/runtimed/src/runtimed/_cell.py
+++ b/python/runtimed/src/runtimed/_cell.py
@@ -17,6 +17,21 @@ if TYPE_CHECKING:
     )
 
 
+class _HintList(list):
+    """List that gives a helpful error if accidentally called."""
+
+    __slots__ = ("_attr",)
+
+    def __init__(self, items, attr: str):
+        super().__init__(items)
+        self._attr = attr
+
+    def __call__(self, *a, **kw):
+        raise TypeError(
+            f"'{self._attr}' is a property, not a method — drop the parentheses: .{self._attr}"
+        )
+
+
 class CellHandle:
     """A live reference to a cell in the notebook document.
 
@@ -48,9 +63,9 @@ class CellHandle:
         """Resolved outputs (sync — may do disk I/O for blob resolution)."""
         try:
             cell = self._session.get_cell_sync(self._id)
-            return cell.outputs
+            return _HintList(cell.outputs, "outputs")
         except _RuntimedError:
-            return []
+            return _HintList([], "outputs")
 
     @property
     def execution_count(self) -> int | None:
@@ -78,9 +93,9 @@ class CellHandle:
     def tags(self) -> list[str]:
         """Cell tags (sync read). Uses Rust Cell helpers for key resolution."""
         try:
-            return self._session.get_cell_sync(self._id).tags
+            return _HintList(self._session.get_cell_sync(self._id).tags, "tags")
         except _RuntimedError:
-            return []
+            return _HintList([], "tags")
 
     @property
     def source_hidden(self) -> bool:
@@ -187,6 +202,25 @@ class CellHandle:
         await self._session.set_cell_outputs_hidden(self._id, hidden)
         return self
 
+    def _repr_markdown_(self) -> str:
+        src = self.source
+        preview = (src[:60] + "...") if len(src) > 60 else src
+        preview = preview.replace("\n", "\\n")
+        return (
+            f"**Cell** `{self._id[:8]}` ({self.cell_type})\n\n"
+            f"```\n{preview}\n```\n\n"
+            "| Properties (sync) | Async methods |\n"
+            "|-|-|\n"
+            "| `source` | `set_source()` `append()` `splice()` |\n"
+            "| `cell_type` | `set_type()` |\n"
+            "| `outputs` | `execute()` `run()` `queue()` `clear_outputs()` |\n"
+            "| `execution_count` | `delete()` `move_after()` |\n"
+            "| `metadata` `tags` | `set_tags()` |\n"
+            "| `source_hidden` `outputs_hidden` | "
+            "`set_source_hidden()` `set_outputs_hidden()` |\n"
+            "| `id` `snapshot()` | |\n"
+        )
+
     def __repr__(self) -> str:
         return f"Cell({self._id[:8]}, {self.cell_type})"
 
@@ -231,7 +265,7 @@ class CellCollection:
     @property
     def ids(self) -> list[str]:
         """All cell IDs in document order (sync)."""
-        return self._session.get_cell_ids_sync()
+        return _HintList(self._session.get_cell_ids_sync(), "ids")
 
     def __getitem__(self, cell_id: str) -> CellHandle:
         """cells['cell-id'] — sugar for get_by_id."""
@@ -269,6 +303,18 @@ class CellCollection:
         """Insert a new cell at a specific position."""
         cell_id = await self._session.create_cell(source, cell_type, index)
         return self._handle(cell_id)
+
+    def _repr_markdown_(self) -> str:
+        n = len(self)
+        lines = [
+            f"**Cells** ({n} cell{'s' if n != 1 else ''})\n",
+            "| Properties / sync methods | Async methods |",
+            "|-|-|",
+            "| `ids` `len()` `iter()` | `create()` `insert_at()` |",
+            "| `get_by_id()` `get_by_index()` `find()` | |",
+            "| `cells['id']` `'id' in cells` | |",
+        ]
+        return "\n".join(lines) + "\n"
 
     def __repr__(self) -> str:
         return f"Cells({len(self)})"

--- a/python/runtimed/src/runtimed/_cell.py
+++ b/python/runtimed/src/runtimed/_cell.py
@@ -206,9 +206,11 @@ class CellHandle:
         src = self.source
         preview = (src[:60] + "...") if len(src) > 60 else src
         preview = preview.replace("\n", "\\n")
+        # Use an indented code block — immune to backticks in source
+        indented = "    " + preview
         return (
             f"**Cell** `{self._id[:8]}` ({self.cell_type})\n\n"
-            f"```\n{preview}\n```\n\n"
+            f"{indented}\n\n"
             "| Properties (sync) | Async methods |\n"
             "|-|-|\n"
             "| `source` | `set_source()` `append()` `splice()` |\n"

--- a/python/runtimed/src/runtimed/_client.py
+++ b/python/runtimed/src/runtimed/_client.py
@@ -90,5 +90,16 @@ class Client:
     async def __aexit__(self, *exc: object) -> None:
         await self.close()
 
+    def _repr_markdown_(self) -> str:
+        return (
+            "**Client** — async interface to the runtimed daemon\n\n"
+            "| Async methods |\n"
+            "|-|\n"
+            "| `open_notebook()` `create_notebook()` `join_notebook()` |\n"
+            "| `list_active_notebooks()` |\n"
+            "| `ping()` `is_running()` `status()` |\n"
+            "| `flush_pool()` `close()` |\n"
+        )
+
     def __repr__(self) -> str:
         return "Client()"

--- a/python/runtimed/src/runtimed/_notebook.py
+++ b/python/runtimed/src/runtimed/_notebook.py
@@ -168,5 +168,23 @@ class Notebook:
     async def __aexit__(self, *args) -> None:
         await self.close()
 
+    def _repr_markdown_(self) -> str:
+        nid = self.notebook_id[:12]
+        n_cells = len(self.cells)
+        peers = self.peers
+        return (
+            f"**Notebook** `{nid}` — "
+            f"{n_cells} cell{'s' if n_cells != 1 else ''}, "
+            f"{len(peers)} peer{'s' if len(peers) != 1 else ''}\n\n"
+            "| Properties (sync) | Async methods |\n"
+            "|-|-|\n"
+            "| `cells` `peers` | `save()` `save_as()` |\n"
+            "| `presence` `runtime` | `start()` `shutdown()` `restart()` |\n"
+            "| `notebook_id` | `interrupt()` `run_all()` |\n"
+            "| | `add_dependency()` `remove_dependency()` |\n"
+            "| | `get_dependencies()` `sync_environment()` |\n"
+            "| | `is_connected()` `queue_state()` `close()` |\n"
+        )
+
     def __repr__(self) -> str:
         return f"Notebook({self.notebook_id[:12]})"


### PR DESCRIPTION
## Summary

Improves discoverability of the runtimed Python API by making the property-vs-method distinction visible at call time.

- Add `_repr_markdown_` to `Notebook`, `CellCollection`, `CellHandle`, and `Client` — renders a quick-reference table of properties (sync) vs methods (async) when displayed in a notebook cell
- Add `_HintList` wrapper for list-returning properties (`ids`, `outputs`, `tags`) that raises a clear `TypeError` when accidentally called: `'ids' is a property, not a method — drop the parentheses: .ids`

Closes #1115

## Verification

* [ ] Display a `Notebook` object in a notebook cell and verify the markdown table renders with properties and methods
* [ ] Display `notebook.cells` and a `CellHandle` to verify their markdown tables
* [ ] Call `notebook.cells.ids()` (with parentheses) and verify the error message says to drop the parentheses
* [ ] Confirm `notebook.cells.ids` (without parentheses) still returns a normal list
* [ ] Verify `cell.outputs()` and `cell.tags()` also produce the helpful error

_PR submitted by @rgbkrk's agent, Quill_