### PR TITLE
feat(python): expose is_draining on NotebookInfo for keep-alive visibility

### DIFF
--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -3842,6 +3842,8 @@ struct NotebookTableRow {
     status: String,
     #[tabled(rename = "PEERS")]
     peers: String,
+    #[tabled(rename = "EVICTION")]
+    eviction: String,
 }
 
 async fn list_notebooks(json_output: bool) -> Result<()> {
@@ -3869,6 +3871,10 @@ async fn list_notebooks(json_output: bool) -> Result<()> {
                         env: r.env_source.clone().unwrap_or_else(|| "-".to_string()),
                         status: r.kernel_status.clone().unwrap_or_else(|| "-".to_string()),
                         peers: r.active_peers.to_string(),
+                        eviction: r
+                            .scheduled_eviction
+                            .clone()
+                            .unwrap_or_else(|| "-".to_string()),
                     })
                     .collect();
 

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -3842,8 +3842,6 @@ struct NotebookTableRow {
     status: String,
     #[tabled(rename = "PEERS")]
     peers: String,
-    #[tabled(rename = "EVICTION")]
-    eviction: String,
 }
 
 async fn list_notebooks(json_output: bool) -> Result<()> {
@@ -3871,10 +3869,6 @@ async fn list_notebooks(json_output: bool) -> Result<()> {
                         env: r.env_source.clone().unwrap_or_else(|| "-".to_string()),
                         status: r.kernel_status.clone().unwrap_or_else(|| "-".to_string()),
                         peers: r.active_peers.to_string(),
-                        eviction: r
-                            .scheduled_eviction
-                            .clone()
-                            .unwrap_or_else(|| "-".to_string()),
                     })
                     .collect();
 

--- a/crates/runtimed-py/src/async_client.rs
+++ b/crates/runtimed-py/src/async_client.rs
@@ -19,7 +19,6 @@ struct RoomInfoData {
     kernel_type: Option<String>,
     kernel_status: Option<String>,
     env_source: Option<String>,
-    scheduled_eviction: Option<String>,
 }
 
 impl<'py> pyo3::IntoPyObject<'py> for RoomInfoData {
@@ -40,9 +39,6 @@ impl<'py> pyo3::IntoPyObject<'py> for RoomInfoData {
         }
         if let Some(env_source) = &self.env_source {
             dict.set_item("env_source", env_source)?;
-        }
-        if let Some(scheduled_eviction) = &self.scheduled_eviction {
-            dict.set_item("scheduled_eviction", scheduled_eviction)?;
         }
         Ok(dict)
     }
@@ -141,7 +137,6 @@ impl AsyncClient {
                     kernel_type: room.kernel_type,
                     kernel_status: room.kernel_status,
                     env_source: room.env_source,
-                    scheduled_eviction: room.scheduled_eviction,
                 })
                 .collect();
             Ok(result)

--- a/crates/runtimed-py/src/async_client.rs
+++ b/crates/runtimed-py/src/async_client.rs
@@ -15,6 +15,7 @@ use crate::error::to_py_err;
 struct RoomInfoData {
     notebook_id: String,
     active_peers: usize,
+    had_peers: bool,
     has_kernel: bool,
     kernel_type: Option<String>,
     kernel_status: Option<String>,
@@ -30,6 +31,7 @@ impl<'py> pyo3::IntoPyObject<'py> for RoomInfoData {
         let dict = pyo3::types::PyDict::new(py);
         dict.set_item("notebook_id", &self.notebook_id)?;
         dict.set_item("active_peers", self.active_peers)?;
+        dict.set_item("had_peers", self.had_peers)?;
         dict.set_item("has_kernel", self.has_kernel)?;
         if let Some(kernel_type) = &self.kernel_type {
             dict.set_item("kernel_type", kernel_type)?;
@@ -133,6 +135,7 @@ impl AsyncClient {
                 .map(|room| RoomInfoData {
                     notebook_id: room.notebook_id,
                     active_peers: room.active_peers,
+                    had_peers: room.had_peers,
                     has_kernel: room.has_kernel,
                     kernel_type: room.kernel_type,
                     kernel_status: room.kernel_status,

--- a/crates/runtimed-py/src/async_client.rs
+++ b/crates/runtimed-py/src/async_client.rs
@@ -19,6 +19,7 @@ struct RoomInfoData {
     kernel_type: Option<String>,
     kernel_status: Option<String>,
     env_source: Option<String>,
+    scheduled_eviction: Option<String>,
 }
 
 impl<'py> pyo3::IntoPyObject<'py> for RoomInfoData {
@@ -39,6 +40,9 @@ impl<'py> pyo3::IntoPyObject<'py> for RoomInfoData {
         }
         if let Some(env_source) = &self.env_source {
             dict.set_item("env_source", env_source)?;
+        }
+        if let Some(scheduled_eviction) = &self.scheduled_eviction {
+            dict.set_item("scheduled_eviction", scheduled_eviction)?;
         }
         Ok(dict)
     }
@@ -137,6 +141,7 @@ impl AsyncClient {
                     kernel_type: room.kernel_type,
                     kernel_status: room.kernel_status,
                     env_source: room.env_source,
+                    scheduled_eviction: room.scheduled_eviction,
                 })
                 .collect();
             Ok(result)

--- a/crates/runtimed-py/src/client.rs
+++ b/crates/runtimed-py/src/client.rs
@@ -101,9 +101,6 @@ impl Client {
             if let Some(env_source) = &room.env_source {
                 dict.set_item("env_source", env_source)?;
             }
-            if let Some(scheduled_eviction) = &room.scheduled_eviction {
-                dict.set_item("scheduled_eviction", scheduled_eviction)?;
-            }
             result.push(dict);
         }
         Ok(result)

--- a/crates/runtimed-py/src/client.rs
+++ b/crates/runtimed-py/src/client.rs
@@ -91,6 +91,7 @@ impl Client {
             let dict = PyDict::new(py);
             dict.set_item("notebook_id", &room.notebook_id)?;
             dict.set_item("active_peers", room.active_peers)?;
+            dict.set_item("had_peers", room.had_peers)?;
             dict.set_item("has_kernel", room.has_kernel)?;
             if let Some(kernel_type) = &room.kernel_type {
                 dict.set_item("kernel_type", kernel_type)?;

--- a/crates/runtimed-py/src/client.rs
+++ b/crates/runtimed-py/src/client.rs
@@ -101,6 +101,9 @@ impl Client {
             if let Some(env_source) = &room.env_source {
                 dict.set_item("env_source", env_source)?;
             }
+            if let Some(scheduled_eviction) = &room.scheduled_eviction {
+                dict.set_item("scheduled_eviction", scheduled_eviction)?;
+            }
             result.push(dict);
         }
         Ok(result)

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -1881,6 +1881,7 @@ impl Daemon {
                     room_infos.push(crate::protocol::RoomInfo {
                         notebook_id: notebook_id.clone(),
                         active_peers: room.active_peers.load(std::sync::atomic::Ordering::Relaxed),
+                        had_peers: room.had_peers.load(std::sync::atomic::Ordering::Relaxed),
                         has_kernel: room.has_kernel().await,
                         kernel_type,
                         env_source,

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -1878,6 +1878,11 @@ impl Daemon {
                         .map(|(kt, es, st)| (Some(kt), Some(es), Some(st)))
                         .unwrap_or((None, None, None));
 
+                    let scheduled_eviction = room.scheduled_eviction.read().await.map(|t| {
+                        let dt: chrono::DateTime<chrono::Utc> = t.into();
+                        dt.to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+                    });
+
                     room_infos.push(crate::protocol::RoomInfo {
                         notebook_id: notebook_id.clone(),
                         active_peers: room.active_peers.load(std::sync::atomic::Ordering::Relaxed),
@@ -1885,6 +1890,7 @@ impl Daemon {
                         kernel_type,
                         env_source,
                         kernel_status,
+                        scheduled_eviction,
                     });
                 }
                 Response::RoomsList { rooms: room_infos }

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -1878,11 +1878,6 @@ impl Daemon {
                         .map(|(kt, es, st)| (Some(kt), Some(es), Some(st)))
                         .unwrap_or((None, None, None));
 
-                    let scheduled_eviction = room.scheduled_eviction.read().await.map(|t| {
-                        let dt: chrono::DateTime<chrono::Utc> = t.into();
-                        dt.to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
-                    });
-
                     room_infos.push(crate::protocol::RoomInfo {
                         notebook_id: notebook_id.clone(),
                         active_peers: room.active_peers.load(std::sync::atomic::Ordering::Relaxed),
@@ -1890,7 +1885,6 @@ impl Daemon {
                         kernel_type,
                         env_source,
                         kernel_status,
-                        scheduled_eviction,
                     });
                 }
                 Response::RoomsList { rooms: room_infos }

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -632,6 +632,8 @@ pub struct NotebookRoom {
     pub persist_path: PathBuf,
     /// Number of active peer connections in this room.
     pub active_peers: AtomicUsize,
+    /// Whether at least one peer has ever connected to this room.
+    pub had_peers: AtomicBool,
     /// Optional kernel for this room (Phase 8: daemon-owned execution).
     /// Arc-wrapped so spawned command processor task can access it.
     pub kernel: Arc<Mutex<Option<RoomKernel>>>,
@@ -817,6 +819,7 @@ impl NotebookRoom {
             persist_tx,
             persist_path,
             active_peers: AtomicUsize::new(0),
+            had_peers: AtomicBool::new(false),
             kernel: Arc::new(Mutex::new(None)),
             blob_store,
             trust_state: Arc::new(RwLock::new(trust_state)),
@@ -877,6 +880,7 @@ impl NotebookRoom {
             persist_tx,
             persist_path,
             active_peers: AtomicUsize::new(0),
+            had_peers: AtomicBool::new(false),
             kernel: Arc::new(Mutex::new(None)),
             blob_store,
             trust_state: Arc::new(RwLock::new(trust_state)),
@@ -1059,6 +1063,7 @@ where
     check_and_update_trust_state(&room).await;
 
     room.active_peers.fetch_add(1, Ordering::Relaxed);
+    room.had_peers.store(true, Ordering::Relaxed);
     let peers = room.active_peers.load(Ordering::Relaxed);
     info!(
         "[notebook-sync] Client connected to room {} ({} peer{})",
@@ -6278,6 +6283,7 @@ mod tests {
             persist_tx,
             persist_path,
             active_peers: AtomicUsize::new(0),
+            had_peers: AtomicBool::new(false),
             kernel: Arc::new(Mutex::new(None)),
             blob_store,
             trust_state: Arc::new(RwLock::new(TrustState {

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -653,9 +653,6 @@ pub struct NotebookRoom {
     /// Timestamp when auto-launch was triggered (for grace period on eviction).
     /// If set, the room won't be evicted for 30 seconds to allow client reconnect.
     pub auto_launch_at: Arc<RwLock<Option<std::time::Instant>>>,
-    /// Wall-clock time when this room is scheduled for eviction (all peers disconnected).
-    /// Set when active_peers drops to 0; cleared when a peer reconnects.
-    pub scheduled_eviction: Arc<RwLock<Option<std::time::SystemTime>>>,
     /// Comm channel state for widgets.
     /// Stores active comms so new windows can sync widget models.
     /// Arc-wrapped so it can be shared with the kernel's iopub task.
@@ -827,7 +824,6 @@ impl NotebookRoom {
             nbformat_attachments: Arc::new(RwLock::new(HashMap::new())),
             working_dir: Arc::new(RwLock::new(None)),
             auto_launch_at: Arc::new(RwLock::new(None)),
-            scheduled_eviction: Arc::new(RwLock::new(None)),
             comm_state: Arc::new(CommState::new()),
             is_loading: AtomicBool::new(false),
             last_self_write: Arc::new(AtomicU64::new(0)),
@@ -888,7 +884,6 @@ impl NotebookRoom {
             nbformat_attachments: Arc::new(RwLock::new(HashMap::new())),
             working_dir: Arc::new(RwLock::new(None)),
             auto_launch_at: Arc::new(RwLock::new(None)),
-            scheduled_eviction: Arc::new(RwLock::new(None)),
             comm_state: Arc::new(CommState::new()),
             is_loading: AtomicBool::new(false),
             last_self_write: Arc::new(AtomicU64::new(0)),
@@ -1064,7 +1059,6 @@ where
     check_and_update_trust_state(&room).await;
 
     room.active_peers.fetch_add(1, Ordering::Relaxed);
-    *room.scheduled_eviction.write().await = None;
     let peers = room.active_peers.load(Ordering::Relaxed);
     info!(
         "[notebook-sync] Client connected to room {} ({} peer{})",
@@ -1172,8 +1166,6 @@ where
         // 2. Kernel running with no peers (idle timeout)
         // Without this, rooms with kernels would leak indefinitely.
         let eviction_delay = daemon.room_eviction_delay().await;
-        *room.scheduled_eviction.write().await =
-            Some(std::time::SystemTime::now() + eviction_delay);
         let rooms_for_eviction = rooms.clone();
         let room_for_eviction = room.clone();
         let notebook_id_for_eviction = notebook_id.clone();
@@ -6302,7 +6294,6 @@ mod tests {
             nbformat_attachments: Arc::new(RwLock::new(HashMap::new())),
             working_dir: Arc::new(RwLock::new(None)),
             auto_launch_at: Arc::new(RwLock::new(None)),
-            scheduled_eviction: Arc::new(RwLock::new(None)),
             comm_state: Arc::new(crate::comm_state::CommState::new()),
             is_loading: AtomicBool::new(false),
             last_self_write: Arc::new(AtomicU64::new(0)),

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -653,6 +653,9 @@ pub struct NotebookRoom {
     /// Timestamp when auto-launch was triggered (for grace period on eviction).
     /// If set, the room won't be evicted for 30 seconds to allow client reconnect.
     pub auto_launch_at: Arc<RwLock<Option<std::time::Instant>>>,
+    /// Wall-clock time when this room is scheduled for eviction (all peers disconnected).
+    /// Set when active_peers drops to 0; cleared when a peer reconnects.
+    pub scheduled_eviction: Arc<RwLock<Option<std::time::SystemTime>>>,
     /// Comm channel state for widgets.
     /// Stores active comms so new windows can sync widget models.
     /// Arc-wrapped so it can be shared with the kernel's iopub task.
@@ -824,6 +827,7 @@ impl NotebookRoom {
             nbformat_attachments: Arc::new(RwLock::new(HashMap::new())),
             working_dir: Arc::new(RwLock::new(None)),
             auto_launch_at: Arc::new(RwLock::new(None)),
+            scheduled_eviction: Arc::new(RwLock::new(None)),
             comm_state: Arc::new(CommState::new()),
             is_loading: AtomicBool::new(false),
             last_self_write: Arc::new(AtomicU64::new(0)),
@@ -884,6 +888,7 @@ impl NotebookRoom {
             nbformat_attachments: Arc::new(RwLock::new(HashMap::new())),
             working_dir: Arc::new(RwLock::new(None)),
             auto_launch_at: Arc::new(RwLock::new(None)),
+            scheduled_eviction: Arc::new(RwLock::new(None)),
             comm_state: Arc::new(CommState::new()),
             is_loading: AtomicBool::new(false),
             last_self_write: Arc::new(AtomicU64::new(0)),
@@ -1059,6 +1064,7 @@ where
     check_and_update_trust_state(&room).await;
 
     room.active_peers.fetch_add(1, Ordering::Relaxed);
+    *room.scheduled_eviction.write().await = None;
     let peers = room.active_peers.load(Ordering::Relaxed);
     info!(
         "[notebook-sync] Client connected to room {} ({} peer{})",
@@ -1166,6 +1172,8 @@ where
         // 2. Kernel running with no peers (idle timeout)
         // Without this, rooms with kernels would leak indefinitely.
         let eviction_delay = daemon.room_eviction_delay().await;
+        *room.scheduled_eviction.write().await =
+            Some(std::time::SystemTime::now() + eviction_delay);
         let rooms_for_eviction = rooms.clone();
         let room_for_eviction = room.clone();
         let notebook_id_for_eviction = notebook_id.clone();
@@ -6294,6 +6302,7 @@ mod tests {
             nbformat_attachments: Arc::new(RwLock::new(HashMap::new())),
             working_dir: Arc::new(RwLock::new(None)),
             auto_launch_at: Arc::new(RwLock::new(None)),
+            scheduled_eviction: Arc::new(RwLock::new(None)),
             comm_state: Arc::new(crate::comm_state::CommState::new()),
             is_loading: AtomicBool::new(false),
             last_self_write: Arc::new(AtomicU64::new(0)),

--- a/crates/runtimed/src/protocol.rs
+++ b/crates/runtimed/src/protocol.rs
@@ -127,6 +127,7 @@ pub struct NotebookKernelInfo {
 pub struct RoomInfo {
     pub notebook_id: String,
     pub active_peers: usize,
+    pub had_peers: bool,
     pub has_kernel: bool,
     /// Kernel type if running (e.g., "python", "deno")
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/runtimed/src/protocol.rs
+++ b/crates/runtimed/src/protocol.rs
@@ -137,10 +137,6 @@ pub struct RoomInfo {
     /// Kernel status if running (e.g., "idle", "busy", "starting")
     #[serde(skip_serializing_if = "Option::is_none")]
     pub kernel_status: Option<String>,
-    /// ISO 8601 timestamp of when this room is scheduled for eviction, if any.
-    /// Present only when all peers have disconnected and the keep-alive grace period is running.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub scheduled_eviction: Option<String>,
 }
 
 /// Blob channel request.

--- a/crates/runtimed/src/protocol.rs
+++ b/crates/runtimed/src/protocol.rs
@@ -137,6 +137,10 @@ pub struct RoomInfo {
     /// Kernel status if running (e.g., "idle", "busy", "starting")
     #[serde(skip_serializing_if = "Option::is_none")]
     pub kernel_status: Option<String>,
+    /// ISO 8601 timestamp of when this room is scheduled for eviction, if any.
+    /// Present only when all peers have disconnected and the keep-alive grace period is running.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scheduled_eviction: Option<String>,
 }
 
 /// Blob channel request.

--- a/python/nteract/src/nteract/_mcp_server.py
+++ b/python/nteract/src/nteract/_mcp_server.py
@@ -608,6 +608,7 @@ async def list_active_notebooks() -> list[dict[str, Any]]:
             "has_runtime": info.has_runtime,
             "runtime_type": info.runtime_type,
             "status": info.status,
+            "scheduled_eviction": info.scheduled_eviction,
         }
         for info in notebooks
     ]
@@ -1502,6 +1503,7 @@ async def resource_rooms() -> str:
                     "has_runtime": info.has_runtime,
                     "runtime_type": info.runtime_type,
                     "status": info.status,
+                    "scheduled_eviction": info.scheduled_eviction,
                 }
                 for info in notebooks
             ]

--- a/python/nteract/src/nteract/_mcp_server.py
+++ b/python/nteract/src/nteract/_mcp_server.py
@@ -608,7 +608,7 @@ async def list_active_notebooks() -> list[dict[str, Any]]:
             "has_runtime": info.has_runtime,
             "runtime_type": info.runtime_type,
             "status": info.status,
-            "scheduled_eviction": info.scheduled_eviction,
+            "is_draining": info.is_draining,
         }
         for info in notebooks
     ]
@@ -1503,7 +1503,7 @@ async def resource_rooms() -> str:
                     "has_runtime": info.has_runtime,
                     "runtime_type": info.runtime_type,
                     "status": info.status,
-                    "scheduled_eviction": info.scheduled_eviction,
+                    "is_draining": info.is_draining,
                 }
                 for info in notebooks
             ]

--- a/python/runtimed/src/runtimed/_notebook_info.py
+++ b/python/runtimed/src/runtimed/_notebook_info.py
@@ -24,7 +24,11 @@ class NotebookInfo:
     active_peers: int = 0
     has_runtime: bool = False
     env_source: str | None = None
-    scheduled_eviction: str | None = None
+
+    @property
+    def is_draining(self) -> bool:
+        """True if the room has no connected peers and is in keep-alive countdown."""
+        return self.active_peers == 0
 
     @property
     def name(self) -> str:
@@ -59,7 +63,6 @@ class NotebookInfo:
             active_peers=int(d.get("active_peers", 0)),
             has_runtime=bool(d.get("has_kernel", False)),
             env_source=d.get("env_source"),
-            scheduled_eviction=d.get("scheduled_eviction"),
         )
 
     def __repr__(self) -> str:

--- a/python/runtimed/src/runtimed/_notebook_info.py
+++ b/python/runtimed/src/runtimed/_notebook_info.py
@@ -24,11 +24,12 @@ class NotebookInfo:
     active_peers: int = 0
     has_runtime: bool = False
     env_source: str | None = None
+    had_peers: bool = False
 
     @property
     def is_draining(self) -> bool:
-        """True if the room has no connected peers and is in keep-alive countdown."""
-        return self.active_peers == 0
+        """True if the room previously had peers and is now in keep-alive countdown."""
+        return self.active_peers == 0 and self.had_peers
 
     @property
     def name(self) -> str:
@@ -63,6 +64,7 @@ class NotebookInfo:
             active_peers=int(d.get("active_peers", 0)),
             has_runtime=bool(d.get("has_kernel", False)),
             env_source=d.get("env_source"),
+            had_peers=bool(d.get("had_peers", False)),
         )
 
     def __repr__(self) -> str:

--- a/python/runtimed/src/runtimed/_notebook_info.py
+++ b/python/runtimed/src/runtimed/_notebook_info.py
@@ -24,6 +24,7 @@ class NotebookInfo:
     active_peers: int = 0
     has_runtime: bool = False
     env_source: str | None = None
+    scheduled_eviction: str | None = None
 
     @property
     def name(self) -> str:
@@ -58,6 +59,7 @@ class NotebookInfo:
             active_peers=int(d.get("active_peers", 0)),
             has_runtime=bool(d.get("has_kernel", False)),
             env_source=d.get("env_source"),
+            scheduled_eviction=d.get("scheduled_eviction"),
         )
 
     def __repr__(self) -> str:


### PR DESCRIPTION
## Summary

After all peers disconnect from a notebook, it remains in `list_active_notebooks` during the keep-alive grace period. These entries were indistinguishable from genuinely orphaned notebooks. This adds an `is_draining` derived property to `NotebookInfo` and surfaces it in MCP tool/resource responses.

- Adds `had_peers: AtomicBool` to `NotebookRoom`, set to `true` on first peer connect, threaded through `RoomInfo` → Python bindings
- `is_draining` = `active_peers == 0 and had_peers` — avoids false positives on newly created rooms that haven't had any clients yet

Closes #1116

## Verification

- [ ] Close all windows for a notebook, call `list_active_notebooks` via MCP — entry shows `is_draining: true`
- [ ] Reopen the notebook — `is_draining` becomes `false`
- [ ] Create a new notebook — `is_draining` is `false` (not a false positive)
- [ ] `notebook://rooms` resource also includes the `is_draining` field

_PR submitted by @rgbkrk's agent, Quill_