### PR TITLE
fix(runtimed-py): resolve relative paths in join_notebook

### DIFF
--- a/crates/runtimed-py/src/async_client.rs
+++ b/crates/runtimed-py/src/async_client.rs
@@ -8,7 +8,7 @@ use pyo3::prelude::*;
 use pyo3_async_runtimes::tokio::future_into_py;
 
 use crate::async_session::AsyncSession;
-use crate::daemon_paths::get_socket_path;
+use crate::daemon_paths::{get_socket_path, resolve_notebook_path};
 use crate::error::to_py_err;
 
 /// Room info data for async serialization (avoids needing GIL inside future).
@@ -241,8 +241,11 @@ impl AsyncClient {
 
     /// Join an existing notebook room by ID and return a connected AsyncSession.
     ///
+    /// Relative paths (e.g. ``"notebook.ipynb"``) are resolved to absolute
+    /// paths so they match the canonical room keys used by the daemon.
+    ///
     /// Args:
-    ///     notebook_id: The notebook room ID to join.
+    ///     notebook_id: The notebook room ID to join (UUID or file path).
     ///     peer_label: Optional label override (defaults to client's peer_label).
     #[pyo3(signature = (notebook_id, peer_label=None))]
     fn join_notebook<'py>(
@@ -253,7 +256,7 @@ impl AsyncClient {
     ) -> PyResult<Bound<'py, PyAny>> {
         let label = peer_label.or_else(|| self.peer_label.clone());
         let socket_path = self.socket_path.clone();
-        let notebook_id = notebook_id.to_string();
+        let notebook_id = resolve_notebook_path(notebook_id);
         future_into_py(py, async move {
             AsyncSession::join_notebook_async(socket_path, notebook_id, label).await
         })

--- a/crates/runtimed-py/src/client.rs
+++ b/crates/runtimed-py/src/client.rs
@@ -12,6 +12,25 @@ use tokio::runtime::Runtime;
 use crate::error::to_py_err;
 use crate::session::Session;
 
+/// Resolve a notebook identifier to a canonical path when it looks like a file path.
+///
+/// UUIDs and opaque identifiers pass through unchanged. Relative paths like
+/// `"notebook.ipynb"` are resolved against the current working directory so
+/// they match the canonical keys the daemon uses for notebook rooms.
+fn resolve_notebook_path(notebook_id: &str) -> String {
+    if uuid::Uuid::parse_str(notebook_id).is_ok() {
+        return notebook_id.to_string();
+    }
+    let path = std::path::Path::new(notebook_id);
+    if let Ok(canonical) = std::fs::canonicalize(path) {
+        return canonical.to_string_lossy().to_string();
+    }
+    if let Ok(absolute) = std::path::absolute(path) {
+        return absolute.to_string_lossy().to_string();
+    }
+    notebook_id.to_string()
+}
+
 /// Synchronous native client for the runtimed daemon.
 ///
 /// Low-level client — the Python `runtimed.Client` wraps this to return
@@ -167,13 +186,17 @@ impl Client {
 
     /// Join an existing notebook room by ID and return a connected Session.
     ///
+    /// Relative paths (e.g. ``"notebook.ipynb"``) are resolved to absolute
+    /// paths so they match the canonical room keys used by the daemon.
+    ///
     /// Args:
-    ///     notebook_id: The notebook room ID to join.
+    ///     notebook_id: The notebook room ID to join (UUID or file path).
     ///     peer_label: Optional label override (defaults to client's peer_label).
     #[pyo3(signature = (notebook_id, peer_label=None))]
     fn join_notebook(&self, notebook_id: &str, peer_label: Option<String>) -> PyResult<Session> {
         let label = peer_label.or_else(|| self.peer_label.clone());
-        Session::join_notebook_with_socket(self.socket_path.clone(), notebook_id, label)
+        let resolved = resolve_notebook_path(notebook_id);
+        Session::join_notebook_with_socket(self.socket_path.clone(), &resolved, label)
     }
 
     fn __repr__(&self) -> String {

--- a/crates/runtimed-py/src/client.rs
+++ b/crates/runtimed-py/src/client.rs
@@ -9,27 +9,9 @@ use pyo3::prelude::*;
 use pyo3::types::PyDict;
 use tokio::runtime::Runtime;
 
+use crate::daemon_paths::resolve_notebook_path;
 use crate::error::to_py_err;
 use crate::session::Session;
-
-/// Resolve a notebook identifier to a canonical path when it looks like a file path.
-///
-/// UUIDs and opaque identifiers pass through unchanged. Relative paths like
-/// `"notebook.ipynb"` are resolved against the current working directory so
-/// they match the canonical keys the daemon uses for notebook rooms.
-fn resolve_notebook_path(notebook_id: &str) -> String {
-    if uuid::Uuid::parse_str(notebook_id).is_ok() {
-        return notebook_id.to_string();
-    }
-    let path = std::path::Path::new(notebook_id);
-    if let Ok(canonical) = std::fs::canonicalize(path) {
-        return canonical.to_string_lossy().to_string();
-    }
-    if let Ok(absolute) = std::path::absolute(path) {
-        return absolute.to_string_lossy().to_string();
-    }
-    notebook_id.to_string()
-}
 
 /// Synchronous native client for the runtimed daemon.
 ///

--- a/crates/runtimed-py/src/daemon_paths.rs
+++ b/crates/runtimed-py/src/daemon_paths.rs
@@ -2,6 +2,25 @@
 
 use std::path::{Path, PathBuf};
 
+/// Resolve a notebook identifier to a canonical path when it looks like a file path.
+///
+/// UUIDs and opaque identifiers pass through unchanged. Relative paths like
+/// `"notebook.ipynb"` are resolved against the current working directory so
+/// they match the canonical keys the daemon uses for notebook rooms.
+pub fn resolve_notebook_path(notebook_id: &str) -> String {
+    if uuid::Uuid::parse_str(notebook_id).is_ok() {
+        return notebook_id.to_string();
+    }
+    let path = Path::new(notebook_id);
+    if let Ok(canonical) = std::fs::canonicalize(path) {
+        return canonical.to_string_lossy().to_string();
+    }
+    if let Ok(absolute) = std::path::absolute(path) {
+        return absolute.to_string_lossy().to_string();
+    }
+    notebook_id.to_string()
+}
+
 /// Get the daemon socket path, respecting RUNTIMED_SOCKET_PATH env var.
 pub fn get_socket_path() -> PathBuf {
     if let Ok(p) = std::env::var("RUNTIMED_SOCKET_PATH") {

--- a/python/runtimed/src/runtimed/_client.py
+++ b/python/runtimed/src/runtimed/_client.py
@@ -50,7 +50,11 @@ class Client:
         return Notebook(session)
 
     async def join_notebook(self, notebook_id: str, peer_label: str | None = None) -> Notebook:
-        """Join an existing notebook room by ID."""
+        """Join an existing notebook room by ID.
+
+        Relative paths (e.g. ``"notebook.ipynb"``) are resolved to absolute
+        paths so they match the canonical room keys used by the daemon.
+        """
         session = await self._native.join_notebook(notebook_id, peer_label)
         return Notebook(session)
 


### PR DESCRIPTION
## Summary

When `join_notebook("notebook.ipynb")` is called with a relative or short path, the daemon receives the string as-is. Since rooms are keyed by canonical absolute paths (set during `open_notebook` or `save_as`), the short name doesn't match any existing room — so the daemon creates a fresh empty room instead of joining the existing one.

This adds a `resolve_notebook_path` helper in the Rust Python bindings that canonicalizes relative paths before sending the handshake. UUIDs pass through unchanged.

Closes #1114

## Verification

* [ ] Create a notebook, add a cell with content, save it to a known path
* [ ] `join_notebook("filename.ipynb")` from the same directory returns the cell content (not empty)
* [ ] `join_notebook` by full absolute path still works
* [ ] `join_notebook` by UUID still works
* [ ] MCP `join_notebook` tool works with short names (uses same Rust bindings)

_PR submitted by @rgbkrk's agent, Quill_