### PR TITLE
fix: close peer connections in session context managers and on MCP shutdown

### DIFF
--- a/crates/runtimed-py/src/async_session.rs
+++ b/crates/runtimed-py/src/async_session.rs
@@ -1229,6 +1229,15 @@ impl AsyncSession {
         })
     }
 
+    /// Safety net: drop the connection when the Python object is garbage-collected.
+    /// Uses `try_lock` to avoid blocking the GC thread.
+    fn __del__(&self) {
+        if let Ok(mut st) = self.state.try_lock() {
+            st.handle = None;
+            st.broadcast_rx = None;
+        }
+    }
+
     fn __repr__(&self) -> String {
         format!("AsyncSession(id={})", self.notebook_id)
     }
@@ -1245,6 +1254,12 @@ impl AsyncSession {
         _exc_val: Option<&Bound<'_, PyAny>>,
         _exc_tb: Option<&Bound<'_, PyAny>>,
     ) -> PyResult<Bound<'py, PyAny>> {
-        future_into_py(py, async move { Ok(false) })
+        let state = Arc::clone(&self.state);
+        future_into_py(py, async move {
+            let mut st = state.lock().await;
+            st.handle = None;
+            st.broadcast_rx = None;
+            Ok(false)
+        })
     }
 }

--- a/crates/runtimed-py/src/session.rs
+++ b/crates/runtimed-py/src/session.rs
@@ -891,6 +891,15 @@ impl Session {
     // Repr, context manager, close
     // =========================================================================
 
+    /// Safety net: drop the connection when the Python object is garbage-collected.
+    /// Uses `try_lock` to avoid blocking the GC thread.
+    fn __del__(&self) {
+        if let Ok(mut st) = self.state.try_lock() {
+            st.handle = None;
+            st.broadcast_rx = None;
+        }
+    }
+
     fn __repr__(&self) -> String {
         let state = self.runtime.block_on(self.state.lock());
         let status = if state.kernel_started {
@@ -914,6 +923,9 @@ impl Session {
         _exc_val: Option<&Bound<'_, PyAny>>,
         _exc_tb: Option<&Bound<'_, PyAny>>,
     ) -> PyResult<bool> {
+        let mut st = self.runtime.block_on(self.state.lock());
+        st.handle = None;
+        st.broadcast_rx = None;
         Ok(false)
     }
 

--- a/python/nteract/src/nteract/_mcp_server.py
+++ b/python/nteract/src/nteract/_mcp_server.py
@@ -1515,6 +1515,38 @@ async def resource_rooms() -> str:
 # =============================================================================
 
 
+def _cleanup() -> None:
+    """Best-effort cleanup of the active notebook session on exit.
+
+    Drops references to the notebook and client so that ``__del__`` on the
+    underlying session objects can close the daemon connection.  We also
+    attempt an explicit async ``close()`` when possible.
+    """
+    global _notebook, _client
+    nb = _notebook
+    _notebook = None
+    _client = None
+    if nb is not None:
+        try:
+            import asyncio
+
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
+                loop = None
+
+            if loop is not None and loop.is_running():
+                # We're inside a running event loop (e.g. atexit during async
+                # shutdown).  Schedule the close but don't await — the __del__
+                # safety net will handle it if this doesn't complete.
+                loop.create_task(nb.close())
+            else:
+                # No running loop — create one for the cleanup call.
+                asyncio.run(nb.close())
+        except Exception:
+            pass
+
+
 def main():
     """Run the MCP server."""
     logging.basicConfig(
@@ -1522,10 +1554,15 @@ def main():
         format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
         stream=sys.stderr,
     )
+    import atexit
+
+    atexit.register(_cleanup)
     try:
         mcp.run(transport="stdio")
     except KeyboardInterrupt:
         sys.exit(130)
+    finally:
+        _cleanup()
 
 
 if __name__ == "__main__":

--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -19,6 +19,7 @@ Environment variables:
 """
 
 import asyncio
+import gc
 import inspect
 import os
 import subprocess
@@ -2652,6 +2653,160 @@ class TestPresence:
         """Can query remote cursors via AsyncSession."""
         cursors = await async_session.get_remote_cursors()
         assert isinstance(cursors, list)
+
+
+# ============================================================================
+# Peer cleanup regression tests
+# ============================================================================
+
+
+class TestPeerCleanup:
+    """Regression tests for peer cleanup via __exit__, __aexit__, and __del__.
+
+    Ensures that closing or garbage-collecting a Session / AsyncSession
+    properly decrements the daemon's active_peers counter.  Without these
+    fixes, phantom peers keep rooms alive indefinitely.
+
+    See: https://github.com/nteract/desktop/pull/1123
+    """
+
+    # -- helpers ----------------------------------------------------------
+
+    @staticmethod
+    def _peers_eq_factory_async(async_client, notebook_id, n):
+        """Return an async callable that checks active_peers == n."""
+
+        async def check():
+            rooms = await async_client.list_active_notebooks()
+            room = next((r for r in rooms if r["notebook_id"] == notebook_id), None)
+            return room is not None and room["active_peers"] == n
+
+        return check
+
+    @staticmethod
+    def _peers_eq_factory_sync(client, notebook_id, n):
+        """Return a callable that checks active_peers == n."""
+
+        def check():
+            rooms = client.list_active_notebooks()
+            room = next((r for r in rooms if r["notebook_id"] == notebook_id), None)
+            return room is not None and room["active_peers"] == n
+
+        return check
+
+    # -- async context manager --------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_async_aexit_decrements_peers(self, async_client):
+        """AsyncSession.__aexit__ decrements active_peers."""
+        session1 = await async_client.create_notebook(runtime="python")
+        notebook_id = session1.notebook_id
+
+        try:
+            # Join a second peer via async-with; __aexit__ should close it.
+            async with await async_client.join_notebook(notebook_id):
+                await async_wait_for_sync(
+                    self._peers_eq_factory_async(async_client, notebook_id, 2),
+                    description="2 peers connected",
+                )
+
+            # __aexit__ has fired — peer count should drop back to 1.
+            await async_wait_for_sync(
+                self._peers_eq_factory_async(async_client, notebook_id, 1),
+                description="peers == 1 after __aexit__",
+            )
+        finally:
+            await session1.close()
+
+    # -- sync context manager ---------------------------------------------
+
+    def test_sync_exit_decrements_peers(self, client):
+        """Session.__exit__ decrements active_peers."""
+        session1 = client.create_notebook(runtime="python")
+        notebook_id = session1.notebook_id
+
+        try:
+            # Join a second peer via with-statement; __exit__ should close it.
+            with client.join_notebook(notebook_id):
+                wait_for_sync(
+                    self._peers_eq_factory_sync(client, notebook_id, 2),
+                    description="2 peers connected",
+                )
+
+            # __exit__ has fired — peer count should drop back to 1.
+            wait_for_sync(
+                self._peers_eq_factory_sync(client, notebook_id, 1),
+                description="peers == 1 after __exit__",
+            )
+        finally:
+            session1.close()
+
+    # -- __del__ / garbage collection -------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_del_decrements_peers(self, async_client):
+        """__del__ via GC closes connection when session is not explicitly closed."""
+        session1 = await async_client.create_notebook(runtime="python")
+        notebook_id = session1.notebook_id
+        session2 = await async_client.join_notebook(notebook_id)
+
+        try:
+            await async_wait_for_sync(
+                self._peers_eq_factory_async(async_client, notebook_id, 2),
+                description="2 peers connected",
+            )
+
+            # Drop all references — __del__ should fire on GC.
+            del session2
+            gc.collect()
+
+            await async_wait_for_sync(
+                self._peers_eq_factory_async(async_client, notebook_id, 1),
+                description="peers == 1 after __del__ / GC",
+            )
+        finally:
+            await session1.close()
+
+    # -- cross-notebook phantom peer --------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_cross_notebook_peer_released_on_gc(self, async_client):
+        """Peer for notebook B created from A's context cleans up on GC.
+
+        Regression test for the scenario:
+          1. Connect to A.ipynb
+          2. From A's kernel, create/open B.ipynb
+          3. A's reference to B goes out of scope
+          4. B's peer count must decrement
+
+        Previously B's phantom peer lived until A's kernel process died.
+        """
+        session_a = await async_client.create_notebook(runtime="python")
+
+        # Simulate "from inside A's kernel, open notebook B"
+        session_b = await async_client.create_notebook(runtime="python")
+        notebook_b_id = session_b.notebook_id
+
+        # Keep B alive with a separate peer (simulates the UI or another agent)
+        keeper = await async_client.join_notebook(notebook_b_id)
+
+        try:
+            await async_wait_for_sync(
+                self._peers_eq_factory_async(async_client, notebook_b_id, 2),
+                description="B has 2 peers",
+            )
+
+            # "A's kernel goes away" — drop the session_b reference.
+            del session_b
+            gc.collect()
+
+            await async_wait_for_sync(
+                self._peers_eq_factory_async(async_client, notebook_b_id, 1),
+                description="B drops to 1 peer after A's ref is GC'd",
+            )
+        finally:
+            await keeper.close()
+            await session_a.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

`Session.__exit__` and `AsyncSession.__aexit__` in runtimed-py were no-ops — they returned without closing the daemon connection. This caused phantom peers to linger in notebook rooms.

A particularly fun manifestation:

1. Connect to **A.ipynb** (UI or MCP agent)
2. Create **B.ipynb** using `runtimed` from within A's kernel
3. Close **A.ipynb**

**B.ipynb** keeps its phantom peer alive until A.ipynb's kernel process is fully evicted, because the `Session` object for B lives in A's kernel memory and never gets `close()`d.

Additionally, the MCP server had no shutdown cleanup — it relied entirely on process death for the OS to close the Unix socket.

## Changes

### runtimed-py: Fix context managers (`session.rs`, `async_session.rs`)

- **`Session.__exit__`**: Now drops `handle` and `broadcast_rx` (same as `close()`) before returning
- **`AsyncSession.__aexit__`**: Same — drops handle and broadcast_rx in the async future

### runtimed-py: Add `__del__` safety net

- Both `Session` and `AsyncSession` now implement `__del__` using `try_lock()` to avoid blocking/deadlocking the GC thread
- This catches the case where session objects are garbage-collected without an explicit `close()` or context manager — e.g. a `Notebook` object created in a cell that goes out of scope

### MCP server: Shutdown cleanup (`_mcp_server.py`)

- New `_cleanup()` function that nulls out `_notebook` and `_client` globals and attempts an explicit async `close()` on the notebook
- Registered via `atexit.register()` for normal exit
- Also called in a `finally` block in `main()` for `KeyboardInterrupt` and other exit paths

## How cleanup now works at each layer

| Scenario | Before | After |
|---|---|---|
| `async with session:` / `with session:` | ❌ No-op | ✅ Calls `close()` |
| Session object garbage-collected | ❌ Connection leaked until process exit | ✅ `__del__` drops connection |
| MCP server exits | ❌ Relied on OS socket cleanup | ✅ Explicit `close()` via atexit + finally |
| Process dies | ✅ OS closes socket, daemon detects EOF | ✅ Same (unchanged) |
