### PR TITLE
feat(nteract): add --nightly flag and consolidate README for 2.x stable

### DIFF
--- a/python/nteract/README.md
+++ b/python/nteract/README.md
@@ -15,14 +15,24 @@ We're in the preliminary stages of hooking up the realtime system from nteract/d
 #### Claude Code
 
 ```bash
-# Stable desktop 1.4.x / stable MCP
+# Stable
 claude mcp add nteract -- uvx nteract
+
+# Nightly
+claude mcp add nteract-nightly -- uvx --prerelease allow nteract --nightly
 ```
 
-For desktop nightly / the upcoming 2.x transition, use the prerelease MCP package and nightly socket:
+#### Manual JSON config
 
-```bash
-claude mcp add nteract-nightly -- env RUNTIMED_SOCKET_PATH="$HOME/Library/Caches/runt-nightly/runtimed.sock" uvx --prerelease allow nteract
+```json
+{
+  "mcpServers": {
+    "nteract": {
+      "command": "uvx",
+      "args": ["nteract"]
+    }
+  }
+}
 ```
 
 That's it. Now Claude can execute Python code, create visualizations, and work with your data.
@@ -49,54 +59,6 @@ Claude will:
 4. Show you the results
 
 You can open the same notebook in the [nteract desktop app](https://nteract.io) to see changes in real-time and collaborate with the AI.
-
-## Installation
-
-Stable line for desktop `1.4.x`:
-
-```bash
-uvx nteract
-```
-
-Prerelease line for desktop nightly / 2.x transition:
-
-```bash
-uvx --prerelease allow nteract
-```
-
-## Claude Code Setup
-
-Add stable `nteract` as an MCP server:
-
-```bash
-claude mcp add nteract -- uvx nteract
-```
-
-Or manually add to your Claude configuration:
-
-```json
-{
-  "mcpServers": {
-    "nteract": {
-      "command": "uvx",
-      "args": ["nteract"]
-    }
-  }
-}
-```
-
-### Using with Nightly
-
-If you're using nteract desktop nightly builds, point at the nightly socket and allow prereleases:
-
-```bash
-claude mcp add nteract -- env RUNTIMED_SOCKET_PATH="$HOME/Library/Caches/runt-nightly/runtimed.sock" uvx --prerelease allow nteract
-```
-
-### Release Tracks
-
-- `main` publishes prerelease `nteract` builds for the 2.x transition and tracks `runtimed 2.x` prereleases.
-- `release/1.9.x` is the stable maintenance line for desktop `1.4.x` and stays on `runtimed 1.9.0`.
 
 ## Available Tools
 
@@ -125,6 +87,13 @@ claude mcp add nteract -- env RUNTIMED_SOCKET_PATH="$HOME/Library/Caches/runt-ni
 | `remove_dependency` | Remove a dependency |
 | `get_dependencies` | List current dependencies |
 | `sync_environment` | Hot-install new deps without restart |
+
+### CLI Flags
+
+| Flag | Description |
+|------|-------------|
+| `--nightly` | Connect to the nightly daemon socket instead of stable |
+| `--no-show` | Disable the `show_notebook` tool (for headless environments) |
 
 ## Architecture
 

--- a/python/nteract/src/nteract/_mcp_server.py
+++ b/python/nteract/src/nteract/_mcp_server.py
@@ -45,6 +45,18 @@ mcp = FastMCP("nteract")
 # This is useful for headless environments where no desktop app is available.
 _no_show = "--no-show" in sys.argv
 
+# When --nightly is passed, point at the nightly daemon socket automatically.
+# This avoids the need for `env RUNTIMED_SOCKET_PATH=... uvx nteract`.
+if "--nightly" in sys.argv and not os.environ.get("RUNTIMED_SOCKET_PATH"):
+    import platform
+
+    if platform.system() == "Darwin":
+        _nightly_sock = os.path.expanduser("~/Library/Caches/runt-nightly/runtimed.sock")
+    else:
+        _cache = os.environ.get("XDG_CACHE_HOME", os.path.expanduser("~/.cache"))
+        _nightly_sock = os.path.join(_cache, "runt-nightly", "runtimed.sock")
+    os.environ["RUNTIMED_SOCKET_PATH"] = _nightly_sock
+
 
 # ── Peer label for remote cursors ─────────────────────────────────────
 # The MCP initialize handshake includes clientInfo with `name` and

--- a/python/runtimed/README.md
+++ b/python/runtimed/README.md
@@ -12,7 +12,7 @@ Python bindings for the [nteract](https://nteract.io) runtime daemon. Execute co
 pip install runtimed
 ```
 
-> **Note:** The 2.0 release is currently in pre-release. Use `pip install --pre runtimed` (or `uv pip install --prerelease allow runtimed`) to get the latest 2.x build matching the nteract desktop nightly.
+> **Nightly builds:** To track the nteract desktop nightly, use `pip install --pre runtimed` (or `uv pip install --prerelease allow runtimed`).
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary

- Add `--nightly` CLI flag to the MCP server so users can do `claude mcp add nteract-nightly -- uvx --prerelease allow nteract --nightly` instead of manually wrapping with `env RUNTIMED_SOCKET_PATH=...`
- Consolidate redundant README sections (Installation, Claude Code Setup, Using with Nightly, Release Tracks) into a single Quick Start
- Update runtimed README to reflect 2.x as the stable line, nightly requiring `--pre`

## Verification

* [ ] `claude mcp add nteract-nightly -- uvx --prerelease allow nteract --nightly` connects to the nightly daemon
* [ ] `claude mcp add nteract -- uvx nteract` still connects to the stable daemon
* [ ] `--nightly` respects an explicitly-set `RUNTIMED_SOCKET_PATH` (env var takes precedence)
* [ ] README renders correctly on PyPI / GitHub

_PR submitted by @rgbkrk's agent, Quill_