### PR TITLE
fix(python): accept string cell IDs in move_after()

### DIFF
--- a/python/runtimed/src/runtimed/_cell.py
+++ b/python/runtimed/src/runtimed/_cell.py
@@ -176,9 +176,14 @@ class CellHandle:
         """Delete this cell from the document."""
         await self._session.delete_cell(self._id)
 
-    async def move_after(self, other: CellHandle | None = None) -> CellHandle:
+    async def move_after(self, other: CellHandle | str | None = None) -> CellHandle:
         """Move this cell after another cell (or to the beginning if None)."""
-        after_id = other._id if other else None
+        if isinstance(other, str):
+            after_id = other
+        elif other is not None:
+            after_id = other._id
+        else:
+            after_id = None
         await self._session.move_cell(self._id, after_id)
         return self
 


### PR DESCRIPTION
## Summary

`CellHandle.move_after()` only accepted `CellHandle | None`, so passing a string cell ID (e.g. `cell.id`) produced a cryptic `AttributeError: 'str' object has no attribute '_id'`. The underlying Rust session method already works with `&str`, so the Python layer now accepts `CellHandle | str | None` and resolves accordingly.

Closes #1128

## Verification

- [ ] `await last.move_after(first.id)` moves the cell (string ID)
- [ ] `await last.move_after(first)` still works (CellHandle)
- [ ] `await last.move_after(None)` still works (move to beginning)
- [ ] `await last.move_after()` still works (no argument, same as None)

_PR submitted by @rgbkrk's agent, Quill_