### PR TITLE
fix(python): announce presence on connect so peers are visible

### DIFF
--- a/crates/notebook-doc/src/presence.rs
+++ b/crates/notebook-doc/src/presence.rs
@@ -311,6 +311,20 @@ pub fn encode_custom_update(peer_id: &str, data: &[u8]) -> Result<Vec<u8>, Prese
     })
 }
 
+/// Encode a custom channel update message with an optional peer label.
+pub fn encode_custom_update_labeled(
+    peer_id: &str,
+    peer_label: Option<&str>,
+    data: &[u8],
+) -> Vec<u8> {
+    encode_message(&PresenceMessage::Update {
+        peer_id: peer_id.to_string(),
+        peer_label: peer_label.map(|s| s.to_string()),
+        data: ChannelData::Custom(data.to_vec()),
+    })
+    .expect("CBOR encoding of custom update should not fail")
+}
+
 /// Encode a heartbeat message.
 pub fn encode_heartbeat(peer_id: &str) -> Vec<u8> {
     encode_message(&PresenceMessage::Heartbeat {

--- a/crates/runtimed-py/src/async_session.rs
+++ b/crates/runtimed-py/src/async_session.rs
@@ -69,10 +69,12 @@ impl AsyncSession {
         path: String,
         peer_label: Option<String>,
     ) -> PyResult<Self> {
+        let peer_label = Some(peer_label.unwrap_or_else(session_core::default_peer_label));
         let actor_label = peer_label.as_deref().map(session_core::make_actor_label);
         let (notebook_id, mut state, _info) =
             session_core::connect_open(socket_path, &path, actor_label.as_deref()).await?;
         state.peer_label = peer_label.clone();
+        session_core::announce_presence(&state).await;
         Ok(Self::from_state(notebook_id, state, peer_label))
     }
 
@@ -83,6 +85,7 @@ impl AsyncSession {
         working_dir: Option<PathBuf>,
         peer_label: Option<String>,
     ) -> PyResult<Self> {
+        let peer_label = Some(peer_label.unwrap_or_else(session_core::default_peer_label));
         let actor_label = peer_label.as_deref().map(session_core::make_actor_label);
         let (notebook_id, mut state, _info) = session_core::connect_create(
             socket_path,
@@ -92,6 +95,7 @@ impl AsyncSession {
         )
         .await?;
         state.peer_label = peer_label.clone();
+        session_core::announce_presence(&state).await;
         Ok(Self::from_state(notebook_id, state, peer_label))
     }
 
@@ -101,6 +105,7 @@ impl AsyncSession {
         notebook_id: String,
         peer_label: Option<String>,
     ) -> PyResult<Self> {
+        let peer_label = Some(peer_label.unwrap_or_else(session_core::default_peer_label));
         let actor_label = peer_label.as_deref().map(session_core::make_actor_label);
         let mut state = SessionState::new();
         state.peer_label = peer_label.clone();
@@ -112,6 +117,7 @@ impl AsyncSession {
         let state = Arc::try_unwrap(state_arc)
             .map_err(|_| to_py_err("Failed to unwrap session state"))?
             .into_inner();
+        session_core::announce_presence(&state).await;
 
         Ok(Self::from_state(notebook_id, state, peer_label))
     }

--- a/crates/runtimed-py/src/async_session.rs
+++ b/crates/runtimed-py/src/async_session.rs
@@ -199,6 +199,11 @@ impl AsyncSession {
             .unwrap_or_else(|| self.notebook_id.clone());
         future_into_py(py, async move {
             session_core::connect(&state, &effective_id).await?;
+            // Announce presence so the daemon registers this peer immediately
+            {
+                let st = state.lock().await;
+                session_core::announce_presence(&st).await;
+            }
             // Spawn background task to update notebook_id if a peer re-keys the room
             {
                 let st = state.lock().await;

--- a/crates/runtimed-py/src/session.rs
+++ b/crates/runtimed-py/src/session.rs
@@ -226,6 +226,11 @@ impl Session {
             .unwrap_or_else(|| self.notebook_id.clone());
         self.runtime
             .block_on(session_core::connect(&self.state, &effective_id))?;
+        // Announce presence so the daemon registers this peer immediately
+        self.runtime.block_on(async {
+            let st = self.state.lock().await;
+            session_core::announce_presence(&st).await;
+        });
         // Spawn background task to update notebook_id if a peer re-keys the room
         self.runtime.block_on(async {
             let st = self.state.lock().await;

--- a/crates/runtimed-py/src/session.rs
+++ b/crates/runtimed-py/src/session.rs
@@ -46,6 +46,7 @@ impl Session {
         path: &str,
         peer_label: Option<String>,
     ) -> PyResult<Self> {
+        let peer_label = Some(peer_label.unwrap_or_else(session_core::default_peer_label));
         let runtime = Runtime::new().map_err(to_py_err)?;
         let actor_label = peer_label.as_deref().map(session_core::make_actor_label);
 
@@ -56,6 +57,7 @@ impl Session {
         ))?;
 
         state.peer_label = peer_label.clone();
+        runtime.block_on(session_core::announce_presence(&state));
 
         // Keep the runtime alive — the sync task was spawned on it during
         // connect_open. Dropping the runtime would cancel the sync task and
@@ -86,6 +88,7 @@ impl Session {
             }
         }
 
+        let peer_label = Some(peer_label.unwrap_or_else(session_core::default_peer_label));
         let runtime = Runtime::new().map_err(to_py_err)?;
         let working_dir_buf = working_dir.map(PathBuf::from);
         let actor_label = peer_label.as_deref().map(session_core::make_actor_label);
@@ -98,6 +101,7 @@ impl Session {
         ))?;
 
         state.peer_label = peer_label.clone();
+        runtime.block_on(session_core::announce_presence(&state));
 
         Self::from_state_with_runtime(runtime, notebook_id, state, peer_label)
     }
@@ -108,6 +112,7 @@ impl Session {
         notebook_id: &str,
         peer_label: Option<String>,
     ) -> PyResult<Self> {
+        let peer_label = Some(peer_label.unwrap_or_else(session_core::default_peer_label));
         let actor_label = peer_label.as_deref().map(session_core::make_actor_label);
 
         let mut state = SessionState::new();
@@ -125,6 +130,7 @@ impl Session {
         let state = Arc::try_unwrap(state_arc)
             .map_err(|_| to_py_err("Failed to unwrap session state"))?
             .into_inner();
+        runtime.block_on(session_core::announce_presence(&state));
 
         Self::from_state_with_runtime(runtime, notebook_id.to_string(), state, peer_label)
     }

--- a/crates/runtimed-py/src/session_core.rs
+++ b/crates/runtimed-py/src/session_core.rs
@@ -87,6 +87,15 @@ impl SessionState {
     }
 }
 
+/// Generate a default peer label when none is provided.
+///
+/// Produces `"peer-<short_random>"`, e.g. `"peer-ab12cd34"`, so each
+/// unnamed session is still distinguishable in the peers list.
+pub(crate) fn default_peer_label() -> String {
+    let short_id = &uuid::Uuid::new_v4().simple().to_string()[..8];
+    format!("peer-{}", short_id)
+}
+
 /// Build an actor label from a peer display name.
 ///
 /// The format is `"agent:<lowercased_name>:<short_random>"`, e.g.
@@ -191,6 +200,26 @@ pub(crate) async fn connect_with_socket(
     hydrate_kernel_state(&mut st);
 
     Ok(())
+}
+
+/// Send an initial presence message so the daemon registers this peer immediately.
+///
+/// Without this, the peer is invisible in `.peers` until it performs an action
+/// that emits presence (e.g. editing a cell). Call after `peer_label` is set.
+pub(crate) async fn announce_presence(state: &SessionState) {
+    let handle = match state.handle.as_ref() {
+        Some(h) => h,
+        None => return,
+    };
+    let peer_label = state.peer_label.as_deref();
+    let first_cell_id = handle.first_cell_id();
+
+    let data = if let Some(cell_id) = first_cell_id {
+        notebook_doc::presence::encode_focus_update_labeled("local", peer_label, &cell_id)
+    } else {
+        notebook_doc::presence::encode_custom_update_labeled("local", peer_label, &[])
+    };
+    let _ = handle.send_presence(data).await;
 }
 
 /// Populate `kernel_started`, `kernel_type`, and `env_source` from the


### PR DESCRIPTION
## Summary

- Python SDK peers were invisible in `.peers` because no initial presence message was sent after connecting — the daemon only registers a peer when it receives a presence frame
- All connect paths (`create_notebook`, `open_notebook`, `join_notebook`) now send an initial presence announcement immediately after connecting
- Peers without an explicit `peer_label` get a unique `peer-<random>` default instead of the ambiguous bare `"peer"`

Closes #1127

## Verification

- [ ] Create two peers on the same notebook with explicit labels and confirm both appear in each other's `.peers`
  ```python
  nb = await client.create_notebook(peer_label="alice")
  peer2 = await client.join_notebook(nb.notebook_id, peer_label="bob")
  # After ~0.5s:
  # nb.peers should include bob
  # peer2.peers should include alice
  ```
- [ ] Create peers without labels and confirm they get unique `peer-XXXX` names instead of bare `"peer"`

_PR submitted by @rgbkrk's agent, Quill_