### PR TITLE
feat(runtime): add granular starting phases to kernel status

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -272,6 +272,7 @@ function AppContent() {
   // Daemon-owned kernel execution
   const {
     kernelStatus,
+    startingPhase,
     kernelInfo,
     queueState,
     envSyncState,
@@ -1054,6 +1055,7 @@ function AppContent() {
         )}
         <NotebookToolbar
           kernelStatus={kernelStatus}
+          startingPhase={startingPhase}
           envSource={envSource}
           envTypeHint={envTypeHint}
           envProgress={

--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -30,6 +30,7 @@ type EnvBadgeVariant = "uv" | "conda" | "pixi";
 
 interface NotebookToolbarProps {
   kernelStatus: KernelStatus;
+  startingPhase?: string;
   kernelErrorMessage?: string | null;
   envSource: string | null;
   /** Pre-start hint: "uv" | "conda" | "pixi" | null, derived from notebook metadata */
@@ -54,6 +55,7 @@ interface NotebookToolbarProps {
 
 export function NotebookToolbar({
   kernelStatus,
+  startingPhase,
   kernelErrorMessage,
   envSource,
   envTypeHint,
@@ -102,7 +104,7 @@ export function NotebookToolbar({
     kernelStatus === KERNEL_STATUS.IDLE ||
     kernelStatus === KERNEL_STATUS.BUSY ||
     kernelStatus === KERNEL_STATUS.STARTING;
-  const kernelStatusText = getKernelStatusLabel(kernelStatus);
+  const kernelStatusText = getKernelStatusLabel(kernelStatus, startingPhase);
   const isKernelNotStarted =
     kernelStatus === KERNEL_STATUS.NOT_STARTED ||
     kernelStatus === KERNEL_STATUS.SHUTDOWN;

--- a/apps/notebook/src/hooks/useDaemonKernel.ts
+++ b/apps/notebook/src/hooks/useDaemonKernel.ts
@@ -655,6 +655,8 @@ export function useDaemonKernel({
   return {
     /** Current kernel status (with busy throttle applied) */
     kernelStatus,
+    /** Sub-phase detail when status is "starting" */
+    startingPhase: runtimeState.kernel.starting_phase,
     /** Current execution queue state */
     queueState,
     /** Kernel type and environment source */

--- a/apps/notebook/src/lib/kernel-status.ts
+++ b/apps/notebook/src/lib/kernel-status.ts
@@ -26,6 +26,19 @@ export function isKernelStatus(value: string): value is KernelStatus {
   return KERNEL_STATUS_SET.has(value as KernelStatus);
 }
 
-export function getKernelStatusLabel(status: KernelStatus): string {
+const STARTING_PHASE_LABELS: Record<string, string> = {
+  resolving: "resolving environment",
+  preparing_env: "preparing environment",
+  launching: "launching kernel",
+  connecting: "connecting to kernel",
+};
+
+export function getKernelStatusLabel(
+  status: KernelStatus,
+  startingPhase?: string,
+): string {
+  if (status === KERNEL_STATUS.STARTING && startingPhase) {
+    return STARTING_PHASE_LABELS[startingPhase] ?? "starting";
+  }
   return KERNEL_STATUS_LABELS[status];
 }

--- a/apps/notebook/src/lib/runtime-state.ts
+++ b/apps/notebook/src/lib/runtime-state.ts
@@ -15,6 +15,7 @@ import { useSyncExternalStore } from "react";
 
 export interface KernelState {
   status: string;
+  starting_phase: string;
   name: string;
   language: string;
   env_source: string;
@@ -131,6 +132,7 @@ export interface RuntimeState {
 const DEFAULT_RUNTIME_STATE: RuntimeState = {
   kernel: {
     status: "not_started",
+    starting_phase: "",
     name: "",
     language: "",
     env_source: "",

--- a/crates/notebook-doc/src/runtime_state.rs
+++ b/crates/notebook-doc/src/runtime_state.rs
@@ -9,6 +9,7 @@
 //! ROOT/
 //!   kernel/
 //!     status: Str          ("idle" | "busy" | "starting" | "error" | "shutdown" | "not_started")
+//!     starting_phase: Str  ("" | "resolving" | "preparing_env" | "launching" | "connecting")
 //!     name: Str            (e.g. "charming-toucan")
 //!     language: Str        (e.g. "python", "typescript")
 //!     env_source: Str      (e.g. "uv:prewarmed", "conda:pixi", "deno")
@@ -49,6 +50,8 @@ use std::collections::HashMap;
 pub struct KernelState {
     pub status: String,
     #[serde(default)]
+    pub starting_phase: String,
+    #[serde(default)]
     pub name: String,
     #[serde(default)]
     pub language: String,
@@ -60,6 +63,7 @@ impl Default for KernelState {
     fn default() -> Self {
         Self {
             status: "not_started".to_string(),
+            starting_phase: String::new(),
             name: String::new(),
             language: String::new(),
             env_source: String::new(),
@@ -180,6 +184,8 @@ impl RuntimeStateDoc {
             .expect("scaffold kernel.language");
         doc.put(&kernel, "env_source", "")
             .expect("scaffold kernel.env_source");
+        doc.put(&kernel, "starting_phase", "")
+            .expect("scaffold kernel.starting_phase");
 
         // queue/
         let queue = doc
@@ -373,6 +379,8 @@ impl RuntimeStateDoc {
     }
 
     /// Update kernel status. Returns `true` if the doc was mutated.
+    ///
+    /// Automatically clears `starting_phase` when transitioning away from `"starting"`.
     #[allow(clippy::expect_used)]
     pub fn set_kernel_status(&mut self, status: &str) -> bool {
         let kernel = self.get_map("kernel").expect("kernel map must exist");
@@ -383,6 +391,29 @@ impl RuntimeStateDoc {
         self.doc
             .put(&kernel, "status", status)
             .expect("put kernel.status");
+        // Clear starting_phase when leaving "starting"
+        if status != "starting" {
+            let phase = self.read_str(&kernel, "starting_phase");
+            if !phase.is_empty() {
+                self.doc
+                    .put(&kernel, "starting_phase", "")
+                    .expect("clear kernel.starting_phase");
+            }
+        }
+        true
+    }
+
+    /// Update the starting phase sub-status. Returns `true` if the doc was mutated.
+    #[allow(clippy::expect_used)]
+    pub fn set_starting_phase(&mut self, phase: &str) -> bool {
+        let kernel = self.get_map("kernel").expect("kernel map must exist");
+        let current = self.read_str(&kernel, "starting_phase");
+        if current == phase {
+            return false;
+        }
+        self.doc
+            .put(&kernel, "starting_phase", phase)
+            .expect("put kernel.starting_phase");
         true
     }
 
@@ -829,6 +860,7 @@ impl RuntimeStateDoc {
             .as_ref()
             .map(|k| KernelState {
                 status: self.read_str(k, "status"),
+                starting_phase: self.read_str(k, "starting_phase"),
                 name: self.read_str(k, "name"),
                 language: self.read_str(k, "language"),
                 env_source: self.read_str(k, "env_source"),
@@ -1073,6 +1105,38 @@ mod tests {
         let state = doc.read_state();
         assert_eq!(state.trust.status, "trusted");
         assert!(!state.trust.needs_approval);
+    }
+
+    #[test]
+    fn test_set_starting_phase() {
+        let mut doc = RuntimeStateDoc::new();
+        assert!(doc.set_kernel_status("starting"));
+        assert!(doc.set_starting_phase("resolving"));
+        assert_eq!(doc.read_state().kernel.starting_phase, "resolving");
+
+        assert!(doc.set_starting_phase("launching"));
+        assert_eq!(doc.read_state().kernel.starting_phase, "launching");
+
+        // Dedup: same phase is no-op
+        assert!(!doc.set_starting_phase("launching"));
+    }
+
+    #[test]
+    fn test_kernel_status_clears_starting_phase() {
+        let mut doc = RuntimeStateDoc::new();
+        doc.set_kernel_status("starting");
+        doc.set_starting_phase("connecting");
+        assert_eq!(doc.read_state().kernel.starting_phase, "connecting");
+
+        // Transitioning to "idle" should clear starting_phase
+        doc.set_kernel_status("idle");
+        assert_eq!(doc.read_state().kernel.starting_phase, "");
+
+        // Same for error
+        doc.set_kernel_status("starting");
+        doc.set_starting_phase("launching");
+        doc.set_kernel_status("error");
+        assert_eq!(doc.read_state().kernel.starting_phase, "");
     }
 
     #[test]

--- a/crates/runtimed/src/kernel_manager.rs
+++ b/crates/runtimed/src/kernel_manager.rs
@@ -795,6 +795,14 @@ impl RoomKernel {
 
         self.session_id = Uuid::new_v4().to_string();
 
+        // Transition to "connecting" phase — process is alive, now connecting ZMQ
+        {
+            let mut sd = self.state_doc.write().await;
+            if sd.set_starting_phase("connecting") {
+                let _ = self.state_changed_tx.send(());
+            }
+        }
+
         // Create iopub connection and spawn listener
         let mut iopub =
             runtimelib::create_client_iopub_connection(&connection_info, "", &self.session_id)

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -1105,6 +1105,16 @@ where
                 let mut auto_launch_at = room.auto_launch_at.write().await;
                 *auto_launch_at = Some(std::time::Instant::now());
             }
+            // Write "starting" immediately so clients never see stale "not_started"
+            {
+                let mut sd = room.state_doc.write().await;
+                let mut changed = false;
+                changed |= sd.set_kernel_status("starting");
+                changed |= sd.set_starting_phase("resolving");
+                if changed {
+                    let _ = room.state_changed_tx.send(());
+                }
+            }
             // Spawn auto-launch in background so we don't block sync
             let room_clone = room.clone();
             let notebook_id_clone = notebook_id.clone();
@@ -1985,14 +1995,6 @@ async fn auto_launch_kernel(
     // Clear any stale comm state from a previous kernel (in case it crashed)
     room.comm_state.clear().await;
 
-    // Write "starting" to state_doc before launch begins
-    {
-        let mut sd = room.state_doc.write().await;
-        if sd.set_kernel_status("starting") {
-            let _ = room.state_changed_tx.send(());
-        }
-    }
-
     // Create new kernel
     let mut kernel = RoomKernel::new(
         room.kernel_broadcast_tx.clone(),
@@ -2195,6 +2197,14 @@ async fn auto_launch_kernel(
         }
     };
 
+    // Transition to "preparing_env" phase now that runtime/env has been resolved
+    {
+        let mut sd = room.state_doc.write().await;
+        if sd.set_starting_phase("preparing_env") {
+            let _ = room.state_changed_tx.send(());
+        }
+    }
+
     // For inline deps, prepare a cached environment with rich progress
     let progress_handler: std::sync::Arc<dyn kernel_env::ProgressHandler> = std::sync::Arc::new(
         crate::inline_env::BroadcastProgressHandler::new(room.kernel_broadcast_tx.clone()),
@@ -2336,6 +2346,14 @@ async fn auto_launch_kernel(
         venv_path,
         python_path,
     );
+
+    // Transition to "launching" phase before starting the kernel process
+    {
+        let mut sd = room.state_doc.write().await;
+        if sd.set_starting_phase("launching") {
+            let _ = room.state_changed_tx.send(());
+        }
+    }
 
     match kernel
         .launch(
@@ -2734,9 +2752,14 @@ async fn handle_notebook_request(
             room.comm_state.clear().await;
 
             // Trust is approved if user explicitly launches kernel — update RuntimeStateDoc
+            // Also set "starting" + "resolving" phase immediately
             {
                 let mut sd = room.state_doc.write().await;
-                if sd.set_trust("trusted", false) {
+                let mut changed = false;
+                changed |= sd.set_trust("trusted", false);
+                changed |= sd.set_kernel_status("starting");
+                changed |= sd.set_starting_phase("resolving");
+                if changed {
                     let _ = room.state_changed_tx.send(());
                 }
             }
@@ -2849,6 +2872,14 @@ async fn handle_notebook_request(
                 // Use explicit env_source (e.g., "uv:inline", "conda:inline")
                 env_source.clone()
             };
+
+            // Transition to "preparing_env" phase
+            {
+                let mut sd = room.state_doc.write().await;
+                if sd.set_starting_phase("preparing_env") {
+                    let _ = room.state_changed_tx.send(());
+                }
+            }
 
             // Deno kernels don't need pooled environments
             let pooled_env = if resolved_kernel_type == "deno" {
@@ -3069,6 +3100,14 @@ async fn handle_notebook_request(
                 venv_path,
                 python_path,
             );
+
+            // Transition to "launching" phase before starting the kernel process
+            {
+                let mut sd = room.state_doc.write().await;
+                if sd.set_starting_phase("launching") {
+                    let _ = room.state_changed_tx.send(());
+                }
+            }
 
             match kernel
                 .launch(

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -1934,6 +1934,15 @@ fn is_untitled_notebook(notebook_id: &str) -> bool {
     uuid::Uuid::parse_str(notebook_id).is_ok()
 }
 
+/// Reset runtime state to "not_started" (clears any stale starting phase).
+/// Used when an early exit prevents kernel launch after status was set to "starting".
+async fn reset_starting_state(room: &NotebookRoom) {
+    let mut sd = room.state_doc.write().await;
+    if sd.set_kernel_status("not_started") {
+        let _ = room.state_changed_tx.send(());
+    }
+}
+
 /// Auto-launch kernel for a trusted notebook when first peer connects.
 /// This is similar to handle_notebook_request(LaunchKernel) but without a request/response.
 ///
@@ -1950,6 +1959,7 @@ async fn auto_launch_kernel(
     // before we finish launching)
     if room.active_peers.load(std::sync::atomic::Ordering::Relaxed) == 0 {
         debug!("[notebook-sync] Auto-launch aborted: no peers remaining");
+        reset_starting_state(room).await;
         return;
     }
 
@@ -1982,6 +1992,7 @@ async fn auto_launch_kernel(
     if let Some(ref kernel) = *kernel_guard {
         if kernel.is_running() {
             debug!("[notebook-sync] Auto-launch skipped: kernel already running");
+            reset_starting_state(room).await;
             return;
         }
     }
@@ -1989,6 +2000,7 @@ async fn auto_launch_kernel(
     // Re-check peers after acquiring lock (another race check)
     if room.active_peers.load(std::sync::atomic::Ordering::Relaxed) == 0 {
         debug!("[notebook-sync] Auto-launch aborted: no peers (after lock)");
+        reset_starting_state(room).await;
         return;
     }
 
@@ -2118,7 +2130,10 @@ async fn auto_launch_kernel(
             } else {
                 match acquire_pool_env_for_source(&env_source, &daemon, room).await {
                     Some(env) => env,
-                    None => return, // Error already broadcast
+                    None => {
+                        reset_starting_state(room).await;
+                        return;
+                    }
                 }
             };
             ("python", env_source, pooled_env)
@@ -2173,7 +2188,10 @@ async fn auto_launch_kernel(
                 } else {
                     match acquire_pool_env_for_source(&env_source, &daemon, room).await {
                         Some(env) => env,
-                        None => return, // Error already broadcast
+                        None => {
+                            reset_starting_state(room).await;
+                            return;
+                        }
                     }
                 };
                 ("python", env_source, pooled_env)
@@ -2191,7 +2209,10 @@ async fn auto_launch_kernel(
             };
             let pooled_env = match acquire_pool_env_for_source(prewarmed, &daemon, room).await {
                 Some(env) => env,
-                None => return,
+                None => {
+                    reset_starting_state(room).await;
+                    return;
+                }
             };
             ("python", prewarmed.to_string(), pooled_env)
         }
@@ -2240,6 +2261,7 @@ async fn auto_launch_kernel(
                             status: format!("error: Failed to prepare environment: {}", e),
                             cell_id: None,
                         });
+                    reset_starting_state(room).await;
                     return;
                 }
             }
@@ -2282,6 +2304,7 @@ async fn auto_launch_kernel(
                             status: format!("error: Failed to prepare environment: {}", e),
                             cell_id: None,
                         });
+                    reset_starting_state(room).await;
                     return;
                 }
             }
@@ -2325,6 +2348,7 @@ async fn auto_launch_kernel(
                             status: format!("error: Failed to prepare conda environment: {}", e),
                             cell_id: None,
                         });
+                    reset_starting_state(room).await;
                     return;
                 }
             }
@@ -2897,6 +2921,7 @@ async fn handle_notebook_request(
                             Some(env)
                         }
                         None => {
+                            reset_starting_state(room).await;
                             return NotebookResponse::Error {
                                 error: "UV pool empty - no environment available".to_string(),
                             };
@@ -2911,6 +2936,7 @@ async fn handle_notebook_request(
                             Some(env)
                         }
                         None => {
+                            reset_starting_state(room).await;
                             return NotebookResponse::Error {
                                 error: "Conda pool empty - no environment available".to_string(),
                             };
@@ -2930,6 +2956,7 @@ async fn handle_notebook_request(
                             match daemon.take_conda_env().await {
                                 Some(env) => Some(env),
                                 None => {
+                                    reset_starting_state(room).await;
                                     return NotebookResponse::Error {
                                         error: "Conda pool empty".to_string(),
                                     };
@@ -2940,6 +2967,7 @@ async fn handle_notebook_request(
                             match daemon.take_uv_env().await {
                                 Some(env) => Some(env),
                                 None => {
+                                    reset_starting_state(room).await;
                                     return NotebookResponse::Error {
                                         error: "UV pool empty".to_string(),
                                     };
@@ -2967,6 +2995,7 @@ async fn handle_notebook_request(
                             "[notebook-sync] Invalid PEP 723 metadata in notebook: {}",
                             e
                         );
+                        reset_starting_state(room).await;
                         return NotebookResponse::Error {
                             error: format!("Invalid PEP 723 metadata in notebook: {}", e),
                         };
@@ -2999,12 +3028,14 @@ async fn handle_notebook_request(
                         }
                         Err(e) => {
                             error!("[notebook-sync] Failed to prepare PEP 723 env: {}", e);
+                            reset_starting_state(room).await;
                             return NotebookResponse::Error {
                                 error: format!("Failed to prepare PEP 723 environment: {}", e),
                             };
                         }
                     }
                 } else {
+                    reset_starting_state(room).await;
                     return NotebookResponse::Error {
                         error: "No PEP 723 dependencies found in notebook cells for requested env_source \"uv:pep723\""
                             .to_string(),
@@ -3039,6 +3070,7 @@ async fn handle_notebook_request(
                             (env, Some(deps))
                         }
                         Err(e) => {
+                            reset_starting_state(room).await;
                             return NotebookResponse::Error {
                                 error: format!("Failed to prepare inline environment: {}", e),
                             };
@@ -3077,6 +3109,7 @@ async fn handle_notebook_request(
                             (env, Some(deps))
                         }
                         Err(e) => {
+                            reset_starting_state(room).await;
                             return NotebookResponse::Error {
                                 error: format!("Failed to prepare conda inline environment: {}", e),
                             };


### PR DESCRIPTION
## Summary

Adds a `starting_phase` sub-field to `KernelState` in the RuntimeStateDoc, giving users visibility into what's happening during kernel startup instead of a single "starting" label. The toolbar now shows phase-specific text as the kernel progresses through startup.

Fixes a timing race where clients saw stale "not_started" during auto-launch by writing the status before spawning the background task.

**Phases:** `resolving environment` → `preparing environment` → `launching kernel` → `connecting to kernel` → idle

Closes #1124

## Changes

- **`crates/notebook-doc/src/runtime_state.rs`** — Added `starting_phase` field to `KernelState`, `set_starting_phase()` method, auto-clear on status transitions away from "starting"
- **`crates/runtimed/src/notebook_sync_server.rs`** — Moved `set_kernel_status("starting")` before `tokio::spawn` in auto-launch path; added phase transitions in both auto-launch and explicit `LaunchKernel` handlers
- **`crates/runtimed/src/kernel_manager.rs`** — Set "connecting" phase after process spawn, before ZMQ handshake
- **`apps/notebook/src/lib/kernel-status.ts`** — Phase-aware label generation via `STARTING_PHASE_LABELS` map
- **Frontend wiring** — Threaded `startingPhase` through `useDaemonKernel` → `App` → `NotebookToolbar`

## Verification

- [ ] Open a notebook — toolbar shows granular phase labels during startup (e.g. "resolving environment", "launching kernel") instead of just "starting"
- [ ] Toolbar never shows "not started" when auto-launch is in progress
- [ ] Explicitly launching a kernel (via toolbar button) also shows phase progression
- [ ] Once kernel is idle, the status label shows "idle" as before (no stale phase text)
- [ ] Restarting a kernel clears and re-shows phases correctly

<!-- Screenshots of the toolbar showing phase labels during startup -->

_PR submitted by @rgbkrk's agent, Quill_