### PR TITLE
docs(agents): update Codex-facing daemon and MCP workflow docs

### DIFF
--- a/.codex/skills/nteract-daemon-dev/SKILL.md
+++ b/.codex/skills/nteract-daemon-dev/SKILL.md
@@ -10,10 +10,11 @@ Use this skill to avoid talking to the wrong daemon and to keep daemon-backed ve
 ## Workflow
 
 1. Prefer `supervisor_*` tools when they are available.
-2. Otherwise, treat the worktree daemon as mandatory for daemon-backed verification.
-3. Export `RUNTIMED_DEV=1` and `RUNTIMED_WORKSPACE_PATH="$(pwd)"` before any manual `runt` command.
-4. Start or restart the daemon before validating changes in `crates/runtimed/**`, notebook sync paths, or Python integration flows.
-5. Derive `RUNTIMED_SOCKET_PATH` from `./target/debug/runt daemon status --json` before running Python or cross-implementation tests.
+2. Decide whether you are validating the default nightly source flow or an explicit stable flow. Source builds are nightly unless `RUNT_BUILD_CHANNEL=stable`.
+3. Otherwise, treat the worktree daemon as mandatory for daemon-backed verification.
+4. Export `RUNTIMED_DEV=1` and `RUNTIMED_WORKSPACE_PATH="$(pwd)"` before any manual `runt` command.
+5. Start or restart the daemon before validating changes in `crates/runtimed/**`, notebook sync paths, or Python integration flows.
+6. Derive `RUNTIMED_SOCKET_PATH` from `./target/debug/runt daemon status --json` before running Python or cross-implementation tests.
 
 ## Guardrails
 
@@ -21,6 +22,7 @@ Use this skill to avoid talking to the wrong daemon and to keep daemon-backed ve
 - Never assume the system daemon is correct for a repo worktree.
 - Never run the notebook GUI from an agent terminal; let the human launch it.
 - If a test or script depends on notebook execution, blob resolution, or MCP server behavior, confirm it is pointed at the worktree daemon first.
+- Use `default_socket_path()` for the current process. Reach for `socket_path_for_channel(...)` only when you intentionally need stable/nightly discovery that ignores `RUNTIMED_SOCKET_PATH`.
 
 ## Quick Start
 

--- a/.codex/skills/nteract-daemon-dev/references/daemon-workflows.md
+++ b/.codex/skills/nteract-daemon-dev/references/daemon-workflows.md
@@ -9,10 +9,20 @@ export RUNTIMED_DEV=1
 export RUNTIMED_WORKSPACE_PATH="$(pwd)"
 ```
 
+Source builds default to the nightly channel. To validate stable-specific names or paths from source, prefix the relevant commands with `RUNT_BUILD_CHANNEL=stable`.
+
 Start the worktree daemon:
 
 ```bash
 cargo xtask dev-daemon
+```
+
+Force the stable flow from source:
+
+```bash
+RUNT_BUILD_CHANNEL=stable cargo xtask dev-daemon
+RUNT_BUILD_CHANNEL=stable cargo xtask notebook
+RUNT_BUILD_CHANNEL=stable cargo xtask run-mcp
 ```
 
 Check status or logs:
@@ -35,6 +45,8 @@ export RUNTIMED_SOCKET_PATH="$(
   | python3 -c 'import sys,json; print(json.load(sys.stdin)["socket_path"])'
 )"
 ```
+
+Use `default_socket_path()` when you want code to honor that exported socket. Use `socket_path_for_channel("stable"|"nightly")` only for explicit cross-channel discovery.
 
 ## When to start your own daemon
 

--- a/.codex/skills/nteract-python-bindings/SKILL.md
+++ b/.codex/skills/nteract-python-bindings/SKILL.md
@@ -10,9 +10,10 @@ Use this skill when Python behavior depends on both Rust extension state and dae
 ## Workflow
 
 1. Identify whether the task targets the workspace venv or the test venv.
-2. Rebuild bindings into the correct venv before trusting results from Python or MCP code.
-3. Use the worktree daemon, not the system daemon, for daemon-backed tests.
-4. Re-run the narrowest relevant test or command after rebuilding.
+2. Decide whether the task should follow the default nightly source flow or an explicit stable flow (`RUNT_BUILD_CHANNEL=stable`).
+3. Rebuild bindings into the correct venv before trusting results from Python or MCP code.
+4. Use the worktree daemon, not the system daemon, for daemon-backed tests.
+5. Re-run the narrowest relevant test or command after rebuilding.
 
 ## Core Rules
 
@@ -20,6 +21,9 @@ Use this skill when Python behavior depends on both Rust extension state and dae
 - Use `python/runtimed/.venv` for isolated pytest integration runs.
 - Set `VIRTUAL_ENV` explicitly when running `maturin develop`; otherwise it is easy to rebuild into the wrong venv.
 - If outputs, blobs, or notebook execution look wrong, verify `RUNTIMED_SOCKET_PATH` before assuming the bindings are broken.
+- `default_socket_path()` is for the current process and respects `RUNTIMED_SOCKET_PATH`.
+- `socket_path_for_channel("stable"|"nightly")` is for explicit channel targeting and ignores `RUNTIMED_SOCKET_PATH`.
+- `nteract --stable` and `nteract --nightly` only seed `RUNTIMED_SOCKET_PATH` when it is unset; the flag also controls which app `show_notebook` launches.
 
 ## Quick Start
 

--- a/.codex/skills/nteract-python-bindings/references/bindings-workflows.md
+++ b/.codex/skills/nteract-python-bindings/references/bindings-workflows.md
@@ -7,6 +7,8 @@ Use these venvs intentionally:
 - `.venv` at the repo root: workspace venv for `uv run nteract`, `gremlin`, and general development
 - `python/runtimed/.venv`: test venv for pytest integration runs
 
+Source builds default to the nightly channel. Prefix `cargo xtask ...` with `RUNT_BUILD_CHANNEL=stable` only when you are intentionally validating stable daemon/app behavior.
+
 ## Rebuild into the workspace venv
 
 Use this for MCP server work and most local development:
@@ -53,6 +55,17 @@ uv run nteract
 ```
 
 If the MCP supervisor is available, prefer `cargo xtask run-mcp` or the supervisor tools instead of a manual launch.
+
+Channel overrides for direct launches:
+
+```bash
+uv run nteract --nightly
+uv run nteract --stable
+```
+
+Those flags only set `RUNTIMED_SOCKET_PATH` when it is currently unset. If `cargo xtask dev-mcp`, `cargo xtask run-mcp`, or your shell already exported `RUNTIMED_SOCKET_PATH`, that explicit socket wins.
+
+Use `default_socket_path()` for current-process resolution. Use `socket_path_for_channel("stable"|"nightly")` only when you need an explicit channel path that ignores `RUNTIMED_SOCKET_PATH`.
 
 ## Common failure mode
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,9 +178,17 @@ The UV workspace root is the **repository root** — `pyproject.toml` and `.venv
 uv run nteract  # Run MCP server from repo root
 ```
 
+### Stable vs Nightly
+
+- Source builds default to the `nightly` channel. Only `RUNT_BUILD_CHANNEL=stable` opts a source-built `cargo xtask` or `cargo` flow into stable names, app launch behavior, and cache/socket namespaces.
+- Use the default nightly flow for normal repo development. Opt into stable only when you are specifically validating stable branding, stable socket/cache paths, or stable app-launch behavior.
+- `cargo xtask dev-daemon`, `cargo xtask notebook`, `cargo xtask run`, `cargo xtask run-mcp`, and `cargo xtask dev-mcp` all follow `RUNT_BUILD_CHANNEL`.
+
 ### Python API Notes
 
 - **`Output.data` is typed by MIME kind**: `str` for text MIME types, `bytes` for binary (raw bytes, no base64), `dict` for JSON MIME types. Image outputs include a synthesized `text/llm+plain` key with blob URLs.
+- Use `default_socket_path()` for the current process or test harness because it respects `RUNTIMED_SOCKET_PATH`.
+- Use `socket_path_for_channel("stable"|"nightly")` only when you must target a specific channel explicitly or discover the other channel; it intentionally ignores `RUNTIMED_SOCKET_PATH`.
 
 ## MCP Server (Local Development)
 
@@ -193,6 +201,8 @@ cargo xtask run-mcp
 # Or print config JSON for your MCP client
 cargo xtask run-mcp --print-config
 ```
+
+`uv run nteract --stable` and `uv run nteract --nightly` are channel overrides for direct MCP launches. They only seed `RUNTIMED_SOCKET_PATH` when it is unset, and they also control which app `show_notebook` opens. `--no-show` removes the `show_notebook` tool entirely.
 
 ### Available MCP tools
 

--- a/contributing/development.md
+++ b/contributing/development.md
@@ -214,7 +214,7 @@ RUNTIMED_DEV=1 cargo xtask notebook
 ./target/debug/runt daemon logs -f          # Tail logs (uses correct log path in dev mode)
 ```
 
-Per-worktree state is stored in `<cache>/runt-nightly/worktrees/{hash}/` (macOS: `~/Library/Caches/`, Linux: `~/.cache/`).
+Per-worktree state is stored in `<cache>/{cache_namespace}/worktrees/{hash}/` (macOS: `~/Library/Caches/`, Linux: `~/.cache/`). Source builds default to `runt-nightly`; set `RUNT_BUILD_CHANNEL=stable` only when you intentionally need the stable flow.
 
 **For AI agents:** If `supervisor_*` tools are available, prefer those — they handle env vars and daemon lifecycle automatically. Otherwise, use `./target/debug/runt` directly (see "Agent Access to Dev Daemon" in CLAUDE.md). When using a raw terminal (not Zed tasks), set the env vars manually:
 
@@ -305,6 +305,8 @@ test-only venv).
 uv run nteract                     # from repo root
 uv run --directory . nteract       # equivalent, explicit
 ```
+
+For direct launches, `--stable` and `--nightly` are mutually exclusive channel overrides. They only set `RUNTIMED_SOCKET_PATH` when it is unset, and they also control which app the `show_notebook` tool opens.
 
 ### Inkwell supervisor (recommended)
 

--- a/contributing/runtimed.md
+++ b/contributing/runtimed.md
@@ -51,13 +51,15 @@ The daemon provides a single coordinating entity that prewarms environments in t
 
 | Component | Purpose | Location |
 |-----------|---------|----------|
-| Unix socket | IPC endpoint | `~/Library/Caches/runt/runtimed.sock` (macOS) / `~/.cache/runt/runtimed.sock` (Linux) |
-| Lock file | Singleton guarantee | `~/Library/Caches/runt/daemon.lock` (macOS) / `~/.cache/runt/daemon.lock` (Linux) |
-| Info file | Discovery (PID, endpoint) | `~/Library/Caches/runt/daemon.json` (macOS) / `~/.cache/runt/daemon.json` (Linux) |
-| Environments | Prewarmed venvs | `~/Library/Caches/runt/envs/` (macOS) / `~/.cache/runt/envs/` (Linux) |
-| Blob store | Content-addressed outputs | `~/Library/Caches/runt/blobs/` (macOS) / `~/.cache/runt/blobs/` (Linux) |
-| Notebook docs | Persisted Automerge docs | `~/Library/Caches/runt/notebook-docs/` (macOS) / `~/.cache/runt/notebook-docs/` (Linux) |
-| Snapshots | Pre-delete safety copies | `~/Library/Caches/runt/notebook-docs/snapshots/` (macOS) / `~/.cache/runt/notebook-docs/snapshots/` (Linux) |
+| Unix socket | IPC endpoint | `~/Library/Caches/<cache_namespace>/runtimed.sock` (macOS) / `~/.cache/<cache_namespace>/runtimed.sock` (Linux) |
+| Lock file | Singleton guarantee | `~/Library/Caches/<cache_namespace>/daemon.lock` (macOS) / `~/.cache/<cache_namespace>/daemon.lock` (Linux) |
+| Info file | Discovery (PID, endpoint) | `~/Library/Caches/<cache_namespace>/daemon.json` (macOS) / `~/.cache/<cache_namespace>/daemon.json` (Linux) |
+| Environments | Prewarmed venvs | `~/Library/Caches/<cache_namespace>/envs/` (macOS) / `~/.cache/<cache_namespace>/envs/` (Linux) |
+| Blob store | Content-addressed outputs | `~/Library/Caches/<cache_namespace>/blobs/` (macOS) / `~/.cache/<cache_namespace>/blobs/` (Linux) |
+| Notebook docs | Persisted Automerge docs | `~/Library/Caches/<cache_namespace>/notebook-docs/` (macOS) / `~/.cache/<cache_namespace>/notebook-docs/` (Linux) |
+| Snapshots | Pre-delete safety copies | `~/Library/Caches/<cache_namespace>/notebook-docs/snapshots/` (macOS) / `~/.cache/<cache_namespace>/notebook-docs/snapshots/` (Linux) |
+
+`<cache_namespace>` is `runt` for stable builds and `runt-nightly` for nightly builds. Source builds default to nightly unless `RUNT_BUILD_CHANNEL=stable`.
 
 ## Development Workflow
 
@@ -78,7 +80,7 @@ cargo xtask install-daemon
 This builds runtimed in release mode, stops the running service, replaces the binary, and restarts it. You can verify the version with:
 
 ```bash
-cat ~/.cache/runt/daemon.json   # check "version" field
+cargo run -p runt-cli -- daemon status --json | jq -r '.daemon_info.version'
 ```
 
 ### Fast iteration: Daemon + bundled notebook
@@ -115,6 +117,17 @@ cargo xtask run                   # Run the bundled binary
 ```
 
 The `--rust-only` flag skips `pnpm build`, reusing the existing frontend assets in `apps/notebook/dist/`. This is much faster when you're only changing Rust code.
+
+### Stable vs nightly from source
+
+Source-built binaries default to the nightly channel. That affects daemon cache/socket namespaces, CLI/app naming, and default app launch behavior. Only set `RUNT_BUILD_CHANNEL=stable` when you are intentionally validating the stable flow:
+
+```bash
+RUNT_BUILD_CHANNEL=stable cargo xtask dev-daemon
+RUNT_BUILD_CHANNEL=stable cargo xtask build --rust-only
+RUNT_BUILD_CHANNEL=stable cargo xtask run
+RUNT_BUILD_CHANNEL=stable cargo xtask run-mcp
+```
 
 ### Testing
 
@@ -317,6 +330,10 @@ asyncio.run(main())
 
 See [docs/python-bindings.md](../docs/python-bindings.md) for the full API reference.
 
+### Socket helper choice
+
+Use `default_socket_path()` when you want the current process to honor `RUNTIMED_SOCKET_PATH` and otherwise follow its build channel. Use `socket_path_for_channel("stable"|"nightly")` only for explicit channel targeting or cross-channel discovery; it intentionally ignores `RUNTIMED_SOCKET_PATH`.
+
 ### Output.data Typing
 
 `Output.data` is a `dict[str, str | bytes | dict]`. The value type depends on the MIME type:
@@ -347,17 +364,19 @@ The Python bindings respect the `RUNTIMED_SOCKET_PATH` environment variable. Thi
 
 **System daemon (default):**
 ```python
-# Connects to system daemon at ~/Library/Caches/runt/runtimed.sock
+# Connects using default_socket_path(), which follows the current build
+# channel unless RUNTIMED_SOCKET_PATH is already set.
 client = runtimed.Client()
 ```
 
 **Worktree daemon (for development):**
 ```bash
-# Find your worktree daemon socket
-cat ~/Library/Caches/runt/worktrees/*/daemon.json | grep -A1 worktree_path
-
-# Set the socket path before running Python
-export RUNTIMED_SOCKET_PATH="/Users/you/Library/Caches/runt/worktrees/{hash}/runtimed.sock"
+# Find and export your current worktree daemon socket
+export RUNTIMED_SOCKET_PATH="$(
+  RUNTIMED_DEV=1 RUNTIMED_WORKSPACE_PATH="$(pwd)" \
+  ./target/debug/runt daemon status --json \
+  | jq -r '.socket_path'
+)"
 python your_script.py
 ```
 
@@ -368,8 +387,11 @@ python your_script.py
 cargo xtask dev-daemon
 
 # Find and export the socket path (Terminal 2)
-export RUNTIMED_SOCKET_PATH=$(cat ~/Library/Caches/runt/worktrees/*/daemon.json | \
-  jq -r 'select(.worktree_path == "'$(pwd)'") | .endpoint')
+export RUNTIMED_SOCKET_PATH="$(
+  RUNTIMED_DEV=1 RUNTIMED_WORKSPACE_PATH="$(pwd)" \
+  ./target/debug/runt daemon status --json \
+  | jq -r '.socket_path'
+)"
 
 # Now Python bindings will use the worktree daemon
 python -c "import asyncio, runtimed; asyncio.run(runtimed.Client().ping())"
@@ -381,11 +403,11 @@ python -c "import asyncio, runtimed; asyncio.run(runtimed.Client().ping())"
 
 ```bash
 # Check what's holding the lock
-cat ~/.cache/runt/daemon.json
-lsof ~/.cache/runt/daemon.lock
+cat ~/.cache/<cache_namespace>/daemon.json
+lsof ~/.cache/<cache_namespace>/daemon.lock
 
 # If stale (crashed daemon), remove manually
-rm ~/.cache/runt/daemon.lock ~/.cache/runt/daemon.json
+rm ~/.cache/<cache_namespace>/daemon.lock ~/.cache/<cache_namespace>/daemon.json
 ```
 
 ### Pool not replenishing
@@ -394,7 +416,7 @@ Check that uv/conda are installed and working:
 
 ```bash
 uv --version
-ls -la ~/.cache/runt/envs/
+ls -la ~/.cache/<cache_namespace>/envs/
 ```
 
 ### Python bindings: "Failed to parse output" errors
@@ -407,10 +429,14 @@ If `session.run()` returns outputs like `Output(stream, stderr: "Failed to parse
 
 ```bash
 # Find your worktree daemon
-cat ~/Library/Caches/runt/worktrees/*/daemon.json | jq -r '.worktree_path + " -> " + .endpoint'
+./target/debug/runt dev worktrees
 
 # Export the matching socket path
-export RUNTIMED_SOCKET_PATH="/Users/you/Library/Caches/runt/worktrees/{hash}/runtimed.sock"
+export RUNTIMED_SOCKET_PATH="$(
+  RUNTIMED_DEV=1 RUNTIMED_WORKSPACE_PATH="$(pwd)" \
+  ./target/debug/runt daemon status --json \
+  | jq -r '.socket_path'
+)"
 ```
 
 ### Python bindings: get_cell() returns empty outputs
@@ -431,6 +457,8 @@ When shipped as a release build, the daemon installs as a system service that st
 ### Managing the System Daemon
 
 These commands manage the **system daemon** (production). For development, use `cargo xtask dev-daemon` instead — it provides per-worktree isolation and doesn't interfere with the system daemon.
+
+Examples below use the stable channel names. Nightly builds use the `-nightly` variants such as `runt-nightly`, `runtimed-nightly`, and `io.nteract.runtimed.nightly`.
 
 **Cross-platform:**
 ```bash
@@ -467,8 +495,10 @@ systemctl --user start runtimed.service
 **Key paths (macOS):**
 | File | Path |
 |------|------|
-| Installed binary | `~/Library/Application Support/runt/bin/runtimed` |
-| Service config | `~/Library/LaunchAgents/io.nteract.runtimed.plist` |
-| Socket | `~/Library/Caches/runt/runtimed.sock` |
-| Daemon info | `~/Library/Caches/runt/daemon.json` |
-| Logs | `~/Library/Caches/runt/runtimed.log` |
+| Installed binary | `~/Library/Application Support/<cache_namespace>/bin/<daemon_binary_basename>` |
+| Service config | `~/Library/LaunchAgents/<daemon_launchd_label>.plist` |
+| Socket | `~/Library/Caches/<cache_namespace>/runtimed.sock` |
+| Daemon info | `~/Library/Caches/<cache_namespace>/daemon.json` |
+| Logs | `~/Library/Caches/<cache_namespace>/runtimed.log` |
+
+For stable, these expand to `runt`, `runtimed`, and `io.nteract.runtimed`. For nightly, they expand to `runt-nightly`, `runtimed-nightly`, and `io.nteract.runtimed.nightly`.

--- a/contributing/testing.md
+++ b/contributing/testing.md
@@ -184,6 +184,8 @@ VIRTUAL_ENV=../../python/runtimed/.venv maturin develop
 
 > **Tip:** The workspace venv at `.venv` (repo root) is a separate concern — the MCP server and other workspace tooling use it. To install the bindings there instead, run `VIRTUAL_ENV=../../.venv maturin develop` from `crates/runtimed-py`.
 
+Source-built daemon and MCP flows default to the nightly channel. Set `RUNT_BUILD_CHANNEL=stable` only when a test is intentionally validating stable-specific naming or paths.
+
 Configuration in `conftest.py` defines markers and daemon detection.
 
 **Test categories:**
@@ -204,12 +206,18 @@ pytest python/runtimed/tests/test_session_unit.py -v
 # Skip integration tests
 SKIP_INTEGRATION_TESTS=1 pytest python/runtimed/tests/ -v
 
-# Integration tests (requires running dev daemon)
-pytest python/runtimed/tests/test_daemon_integration.py -v
+# Integration tests (requires running dev daemon and an explicit socket)
+RUNTIMED_SOCKET_PATH="$(
+  RUNTIMED_DEV=1 RUNTIMED_WORKSPACE_PATH="$(pwd)" \
+  ./target/debug/runt daemon status --json \
+  | python3 -c 'import sys,json; print(json.load(sys.stdin)["socket_path"])'
+)" pytest python/runtimed/tests/test_daemon_integration.py -v
 
 # CI mode (spawns its own daemon)
 RUNTIMED_INTEGRATION_TEST=1 pytest python/runtimed/tests/ -v
 ```
+
+When Python code should honor that exported socket, use `default_socket_path()`. Use `socket_path_for_channel("stable"|"nightly")` only for tests that intentionally target a specific release channel.
 
 **Writing tests:**
 

--- a/python/nteract/README.md
+++ b/python/nteract/README.md
@@ -95,7 +95,11 @@ You can open the same notebook in the [nteract desktop app](https://nteract.io) 
 | `--version` | Print version and exit |
 | `--nightly` | Connect to the nightly daemon and open nightly app |
 | `--stable` | Connect to the stable daemon and open stable app |
-| `--no-show` | Disable the `show_notebook` tool (for headless environments) |
+| `--no-show` | Do not register the `show_notebook` tool (for headless environments) |
+
+By default, `nteract` lets `runtimed.default_socket_path()` choose the socket. That means `RUNTIMED_SOCKET_PATH` wins when it is set; otherwise the package's build channel decides.
+
+`--stable` and `--nightly` are mutually exclusive convenience overrides. When `RUNTIMED_SOCKET_PATH` is unset, they set it to `runtimed.socket_path_for_channel(...)`. When `RUNTIMED_SOCKET_PATH` is already set, the explicit env var wins. In either case, the selected flag still controls which desktop app `show_notebook` tries to launch.
 
 ## Architecture
 

--- a/python/runtimed/README.md
+++ b/python/runtimed/README.md
@@ -14,6 +14,8 @@ pip install runtimed
 
 The stable release matches the [nteract desktop stable app](https://nteract.io). If you're running the nightly desktop app, install the pre-release to match: `pip install --pre runtimed` (or `uv pip install --prerelease allow runtimed`). The nightly build automatically discovers the nightly daemon socket.
 
+`Client()` and the high-level Python API use `default_socket_path()` by default. That helper respects `RUNTIMED_SOCKET_PATH`, so exported test or MCP sockets take precedence over the package's default channel.
+
 ## Quick Start
 
 > All examples use `await` — run them inside `asyncio.run(main())`, a Jupyter notebook, or a Python REPL with top-level await (e.g. `python -m asyncio`).
@@ -69,6 +71,18 @@ notebook = await client.open_notebook("/path/to/notebook.ipynb")
 notebook = await client.create_notebook(runtime="python")
 notebook = await client.join_notebook(notebook_id)
 ```
+
+If you need to target a specific release channel instead of the current process default:
+
+```python
+import os
+import runtimed
+
+os.environ["RUNTIMED_SOCKET_PATH"] = runtimed.socket_path_for_channel("nightly")
+client = runtimed.Client()
+```
+
+Use `default_socket_path()` for normal current-process behavior. Use `socket_path_for_channel("stable"|"nightly")` only for explicit channel targeting or cross-channel discovery because it intentionally ignores `RUNTIMED_SOCKET_PATH`.
 
 ### Notebook
 


### PR DESCRIPTION
## Summary
- clarify that source builds default to the nightly channel and document when to opt into `RUNT_BUILD_CHANNEL=stable`
- document when to use `default_socket_path()` versus `socket_path_for_channel(...)`
- update agent skills and contributing docs with current `nteract` CLI flag behavior and socket precedence
- replace stale hard-coded daemon path examples with channel-aware guidance and current worktree commands

## Testing
- Not run (not requested)