### PR TITLE
fix(runtimed): enable sync_environment and restart for prewarmed UV envs

### DIFF
--- a/crates/runtimed-py/src/session_core.rs
+++ b/crates/runtimed-py/src/session_core.rs
@@ -510,8 +510,13 @@ pub(crate) async fn restart_kernel(
 
     // Re-launch with the same kernel_type and env_source as before,
     // falling back to "python" / "auto" if no kernel was previously running.
+    // UV prewarmed envs use "auto" on restart so the daemon re-checks metadata
+    // and picks up any deps added after launch (e.g. via add_dependency).
     let restart_kernel_type = prev_kernel_type.unwrap_or_else(|| "python".to_string());
-    let restart_env_source = prev_env_source.unwrap_or_else(|| "auto".to_string());
+    let restart_env_source = match prev_env_source.as_deref() {
+        Some("uv:prewarmed") | None => "auto".to_string(),
+        Some(s) => s.to_string(),
+    };
 
     // Send LaunchKernel with a timeout, collecting progress messages concurrently.
     let mut progress_messages: Vec<String> = Vec::new();

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -7785,6 +7785,58 @@ mod tests {
         assert!(compute_env_sync_diff(&launched, &snapshot).is_none());
     }
 
+    #[test]
+    fn test_build_launched_config_uv_prewarmed_stores_paths() {
+        let venv = PathBuf::from("/tmp/pool/env-abc");
+        let python = PathBuf::from("/tmp/pool/env-abc/bin/python");
+        let config = build_launched_config(
+            "python",
+            "uv:prewarmed",
+            None,
+            None,
+            Some(venv.clone()),
+            Some(python.clone()),
+        );
+        assert_eq!(config.venv_path.as_ref(), Some(&venv));
+        assert_eq!(config.python_path.as_ref(), Some(&python));
+        assert!(config.uv_deps.is_none(), "prewarmed should not set uv_deps");
+    }
+
+    #[test]
+    fn test_compute_env_sync_diff_prewarmed_promoted_to_empty_baseline() {
+        // Simulates handle_sync_environment promoting uv_deps from None to
+        // Some([]) for a prewarmed kernel, then computing the diff.
+        let mut launched = LaunchedEnvConfig {
+            venv_path: Some(PathBuf::from("/tmp/pool/env-abc")),
+            python_path: Some(PathBuf::from("/tmp/pool/env-abc/bin/python")),
+            ..LaunchedEnvConfig::default()
+        };
+        // Promote to empty baseline (what handle_sync_environment does)
+        launched.uv_deps = Some(vec![]);
+
+        let snapshot = snapshot_with_uv(vec!["httpx".to_string()]);
+        let diff = compute_env_sync_diff(&launched, &snapshot).expect("should detect added deps");
+        assert_eq!(diff.added, vec!["httpx".to_string()]);
+        assert!(diff.removed.is_empty());
+    }
+
+    #[test]
+    fn test_build_launched_config_conda_prewarmed_no_paths() {
+        // conda:prewarmed falls through to the default branch — no paths stored
+        let config = build_launched_config(
+            "python",
+            "conda:prewarmed",
+            None,
+            None,
+            Some(PathBuf::from("/tmp/conda-env")),
+            Some(PathBuf::from("/tmp/conda-env/bin/python")),
+        );
+        assert!(config.venv_path.is_none());
+        assert!(config.python_path.is_none());
+        assert!(config.uv_deps.is_none());
+        assert!(config.conda_deps.is_none());
+    }
+
     // ── check_and_broadcast_sync_state tests ──────────────────────────────
 
     #[tokio::test]

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -159,6 +159,12 @@ fn build_launched_config(
                 config.conda_channels = Some(get_inline_conda_channels(snapshot));
             }
         }
+        "uv:prewarmed" => {
+            // Store paths so hot-sync can install deps into the prewarmed venv
+            // uv_deps stays None to indicate no baseline deps were installed
+            config.venv_path = venv_path;
+            config.python_path = python_path;
+        }
         _ => {}
     }
 
@@ -3706,12 +3712,18 @@ async fn handle_sync_environment(room: &NotebookRoom) -> NotebookResponse {
             }
         };
 
-        let launched = kernel.launched_config().clone();
+        let mut launched = kernel.launched_config().clone();
 
-        // Only UV inline deps support hot-sync
+        // For prewarmed UV envs, treat as empty baseline so hot-sync can
+        // install deps added after launch (instead of requiring a restart).
+        if launched.uv_deps.is_none() && kernel.env_source() == "uv:prewarmed" {
+            launched.uv_deps = Some(vec![]);
+        }
+
+        // Hot-sync requires a UV env with tracked deps
         if launched.uv_deps.is_none() {
             return NotebookResponse::SyncEnvironmentFailed {
-                error: "Hot-sync only supported for UV inline dependencies".to_string(),
+                error: "Hot-sync only supported for UV environments".to_string(),
                 needs_restart: true,
             };
         }


### PR DESCRIPTION
## Summary

When a notebook uses a prewarmed UV environment, `add_dependency()` updates metadata but there was no path to actually install the package:

- `sync_environment()` rejected with *"only supported for UV inline dependencies"*
- `restart()` re-sent `"uv:prewarmed"` which grabbed a fresh pool env without the deps

This PR fixes both paths:

- **`build_launched_config`**: store `venv_path`/`python_path` for `uv:prewarmed` so the kernel knows where its env lives
- **`handle_sync_environment`**: when `uv_deps` is `None` and env_source is `uv:prewarmed`, treat as empty baseline — installs new deps into the running prewarmed venv (no restart needed)
- **`session_core::restart_kernel`**: send `"auto"` instead of `"uv:prewarmed"` on restart, so the daemon re-checks metadata and resolves to `uv:inline` when deps have been added

## Follow-up

Scoped auto-detect (`auto:uv` / `auto:conda`) would let restart say "re-evaluate but stay in my package manager family." Filed separately.

## Test plan

- [ ] `add_dependency("httpx")` then `sync_environment()` on a prewarmed UV notebook → package installs into running venv
- [ ] `add_dependency("httpx")` then `restart()` on a prewarmed UV notebook → kernel comes back with httpx available
- [ ] Plain restart (no deps added) on prewarmed UV notebook → still gets a prewarmed env
- [ ] Conda prewarmed restart → preserves `conda:prewarmed` env_source

Closes #1129