### PR TITLE
docs: update agent documentation to match current codebase

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -46,8 +46,23 @@ The Tauri app crate (`crates/notebook/`) is glue -- it wires Tauri commands to d
 | Cell outputs (manifest hashes) | Daemon | Kernel IOPub -> blob store -> hash in doc |
 | Execution count | Daemon | Set on `execute_input` from kernel |
 | Widget state | Daemon (via `CommState`) | Kernel `comm_open`/`comm_msg` |
+| RuntimeStateDoc (kernel status, queue, executions, env, trust) | Daemon | Separate per-notebook Automerge doc synced via frame `0x05` |
 
 Reads are free for both sides. The daemon reads cell source for execution. The frontend reads outputs for rendering. Both use Automerge sync to stay current.
+
+## RuntimeStateDoc
+
+Each notebook room has a daemon-authoritative **RuntimeStateDoc** — a separate Automerge document (frame type `0x05`) that replaces state-carrying broadcasts. It tracks:
+
+- **Kernel state**: status, starting phase (resolving → preparing_env → launching → connecting), name, language, env_source
+- **Execution queue**: executing cell + execution_id, queued entries as `QueueEntry { cell_id, execution_id }`
+- **Execution lifecycle**: per-execution_id map with status (`queued`/`running`/`done`/`error`), execution_count, success
+- **Environment drift**: in_sync flag, added/removed packages
+- **Trust state**: status and needs_approval flag
+
+**The daemon is the sole writer.** Frontend reads via `useRuntimeState()`. Python reads via `notebook.runtime`.
+
+Key files: `crates/notebook-doc/src/runtime_state.rs`, `apps/notebook/src/lib/runtime-state.ts`.
 
 ## Binary vs Text Content -- CRITICAL DISTINCTION
 

--- a/.claude/rules/environments.md
+++ b/.claude/rules/environments.md
@@ -65,6 +65,19 @@ The daemon returns an `env_source` string with `KernelLaunched`:
 - `"uv:inline"` / `"uv:pyproject"` / `"uv:prewarmed"`
 - `"conda:inline"` / `"conda:env_yml"` / `"conda:pixi"` / `"conda:prewarmed"`
 
+## Kernel Starting Phases
+
+When a kernel is starting, the RuntimeStateDoc tracks granular phases via `kernel.starting_phase`:
+
+| Phase | Description |
+|-------|-------------|
+| `"resolving"` | Dependency resolution (reading project files, computing env hash) |
+| `"preparing_env"` | Environment creation or cache lookup (UV install, Conda solve) |
+| `"launching"` | Spawning the kernel process |
+| `"connecting"` | Establishing ZMQ connection to kernel |
+
+Phases are written by the daemon to RuntimeStateDoc. Frontend displays them via `useRuntimeState()`. Cleared when kernel reaches `idle` or `error`.
+
 ## Content-Addressed Caching
 
 Environments are cached by dependency hash so notebooks with identical deps share a single environment.
@@ -78,6 +91,10 @@ Cache hit check: verify `{hash}/bin/python` (Unix) or `{hash}/Scripts/python.exe
 ## Inline Dependency Environments
 
 For notebooks with inline UV deps (`metadata.runt.uv.dependencies`), the daemon creates cached environments in `~/.cache/runt/inline-envs/`. Keyed by hash of sorted dependencies for fast reuse. Cache hit = instant startup.
+
+### PEP 723 Support
+
+`notebook-doc` includes a PEP 723 parser (`crates/notebook-doc/src/pep723.rs`) that extracts inline script metadata from Python cells. This enables reading `# /// script` blocks for dependency declarations within individual cells.
 
 ## Prewarming and Daemon Pool
 

--- a/.claude/rules/logging.md
+++ b/.claude/rules/logging.md
@@ -38,6 +38,10 @@ Use consistent prefixes for filtering:
 - `[kernel-manager]` -- Kernel lifecycle and execution
 - `[comm_*]` -- Widget communication
 
+### Log File Rotation
+
+Daemon logs rotate on startup — each daemon session gets a clean log file. Previous logs are preserved as `runtimed.log.prev`. This makes `runt daemon logs -f` show only the current session.
+
 ### Enabling Debug Logs
 
 ```bash

--- a/.claude/rules/protocol.md
+++ b/.claude/rules/protocol.md
@@ -89,7 +89,7 @@ Only `0x00` (AutomergeSync) and `0x04` (Presence) are valid outgoing types from 
 | `ExecutionStarted { cell_id, execution_count }` | Cell began executing |
 | `Output { cell_id, output_type, output_json, output_index }` | Cell produced output |
 | `ExecutionDone { cell_id }` | Cell execution completed |
-| `QueueChanged { executing, queued }` | Execution queue state changed |
+| `QueueChanged { executing, queued }` | Execution queue state changed (legacy; RuntimeStateDoc is authoritative) |
 | `Comm { msg_type, content, buffers }` | Jupyter comm message (widget) |
 | `CommSync { comms }` | Full widget state snapshot for new clients |
 | `EnvProgress { env_type, phase }` | Environment setup progress |
@@ -128,9 +128,36 @@ Two-tier blob manifest system. When daemon receives kernel output:
 5. Automerge doc stores only the manifest hash in `cell.outputs[]`
 6. Clients resolve from daemon's HTTP blob server (`GET /blob/{hash}`)
 
-## Architectural Direction
+## RuntimeStateDoc (Shipped)
 
-**RuntimeStateDoc** -- State-carrying broadcasts (kernel status, queue, env sync) are being replaced by a daemon-authoritative, per-notebook Automerge doc synced via frame type `0x05`. Clients read via `useRuntimeState()`.
+State-carrying broadcasts (kernel status, queue, env sync, trust) have been replaced by a **daemon-authoritative, per-notebook Automerge document** synced via frame type `0x05`. Clients read via `useRuntimeState()`.
+
+Schema (in `crates/notebook-doc/src/runtime_state.rs`):
+
+| Path | Type | Description |
+|------|------|-------------|
+| `kernel.status` | Str | `"idle"`, `"busy"`, `"starting"`, `"error"`, `"shutdown"`, `"not_started"` |
+| `kernel.starting_phase` | Str | `""`, `"resolving"`, `"preparing_env"`, `"launching"`, `"connecting"` |
+| `kernel.name`, `kernel.language`, `kernel.env_source` | Str | Kernel metadata |
+| `queue.executing` | Str\|null | Cell ID currently executing |
+| `queue.executing_execution_id` | Str\|null | Execution ID for the executing cell |
+| `queue.queued` | List[Str] | Queued cell IDs |
+| `queue.queued_execution_ids` | List[Str] | Parallel execution IDs for queued entries |
+| `executions.{execution_id}` | Map | `{ cell_id, status, execution_count, success }` |
+| `env.in_sync`, `env.added`, `env.removed` | bool/List | Environment drift state |
+| `trust.status`, `trust.needs_approval` | Str/bool | Trust state |
+| `last_saved` | Str\|null | ISO timestamp of last save |
+
+The daemon is the sole writer. Frontends and Python clients read-only via Automerge sync.
+
+### Execution ID Tracking
+
+Each cell execution is assigned a unique `execution_id` (UUID). The `QueueEntry` struct pairs `cell_id` with `execution_id`, enabling:
+- Multiple executions of the same cell to be tracked independently
+- Python `Execution` handle to poll for lifecycle state
+- Frontend to display per-execution progress
+
+## Architectural Direction
 
 **Comms in doc (#761)** -- Widget state will move into `doc.comms/` in the Automerge document, eliminating `CommSync` and several broadcast variants.
 

--- a/.claude/skills/daemon-dev/SKILL.md
+++ b/.claude/skills/daemon-dev/SKILL.md
@@ -138,6 +138,15 @@ crates/runtimed/src/
   settings_doc.rs          — Settings Automerge document, schema, migration
   sync_server.rs           — Settings sync handler
   stream_terminal.rs       — Stream terminal output handling
+  client.rs                — Internal daemon client for programmatic access
+  sync_client.rs           — Sync-flavored client wrapper
+  singleton.rs             — Daemon singleton management (lock file, PID tracking)
+  kernel_pids.rs           — Kernel process ID tracking and cleanup
+  markdown_assets.rs       — Markdown output asset rendering and resolution
+  terminal_size.rs         — Terminal size detection for kernel PTY
+  project_file.rs          — Unified project file discovery (pyproject, pixi, env.yml)
+  runtime.rs               — Runtime enum (Python, Deno) and detection
+  service.rs               — System service install/uninstall (launchd, systemd)
 ```
 
 ## Related Crates
@@ -147,6 +156,48 @@ crates/runtimed/src/
 | `notebook-doc` | `NotebookDoc`: Automerge schema, cell CRUD, per-cell accessors, `CellChangeset` |
 | `notebook-protocol` | Wire types: `NotebookRequest`, `NotebookResponse`, `NotebookBroadcast` |
 | `notebook-sync` | `DocHandle`: sync infrastructure, snapshot watch, per-cell accessors for Python |
+
+## RuntimeStateDoc
+
+Each notebook room has a **RuntimeStateDoc** — a daemon-authoritative Automerge document synced via frame type `0x05`. It replaces state-carrying broadcasts for kernel status, queue, env sync, and trust.
+
+### Schema
+
+```
+ROOT/
+  kernel/
+    status: "idle" | "busy" | "starting" | "error" | "shutdown" | "not_started"
+    starting_phase: "" | "resolving" | "preparing_env" | "launching" | "connecting"
+    name, language, env_source: Str
+  queue/
+    executing: Str|null (cell_id)
+    executing_execution_id: Str|null
+    queued: List[Str] (cell_ids)
+    queued_execution_ids: List[Str]
+  executions/ Map (keyed by execution_id)
+    {id}/ { cell_id, status, execution_count, success }
+  env/ { in_sync, added, removed, channels_changed, deno_changed }
+  trust/ { status, needs_approval }
+  last_saved: Str|null (ISO timestamp)
+```
+
+### Who writes what
+
+- **Daemon only** writes to RuntimeStateDoc (kernel status, queue state, execution lifecycle, env sync, trust)
+- **Frontend reads only** via `useRuntimeState()` hook in `apps/notebook/src/lib/runtime-state.ts`
+- **Python reads** via `notebook.runtime` property (`RuntimeState` class)
+
+Key files: `crates/notebook-doc/src/runtime_state.rs` (schema), `apps/notebook/src/lib/runtime-state.ts` (frontend).
+
+## Execution Lifecycle
+
+Each cell execution is tracked by a unique `execution_id` (UUID):
+
+1. Client sends `ExecuteCell { cell_id }` → daemon generates `execution_id`
+2. Daemon writes `QueueEntry { cell_id, execution_id }` to RuntimeStateDoc queue
+3. When execution starts: status → `"running"`, execution_count assigned
+4. When done: status → `"done"` or `"error"`, success flag set
+5. Python `Execution` handle polls RuntimeStateDoc for lifecycle updates
 
 ## Settings Sync
 

--- a/.claude/skills/python-bindings/SKILL.md
+++ b/.claude/skills/python-bindings/SKILL.md
@@ -51,16 +51,38 @@ async def main():
         print(cell.source)      # "print('hello')"
         print(cell.cell_type)   # "code"
 
-        # Streaming execution (async iterator)
+        # Execution handle (granular lifecycle control)
         cell2 = await notebook.cells.create("for i in range(3): print(i)")
-        async for event in await cell2.stream():
-            print(event)
+        execution = await cell2.execute()
+        print(execution.execution_id)   # UUID
+        print(execution.status)         # "queued" | "running" | "done" | "error"
+        result = await execution.result()  # waits for completion
+
+        # Or queue without waiting
+        execution = await cell2.queue()    # returns Execution immediately
+        await execution.wait()             # explicitly wait later
 
         # Presence (cursor/selection sync)
         await notebook.presence.set_cursor(cell.id, line=0, column=5)
 
 asyncio.run(main())
 ```
+
+### Execution API
+
+`cell.run()` is sugar for `(await cell.execute()).result()`. For granular control use `Execution`:
+
+| Method/Property | Returns | Description |
+|-----------------|---------|-------------|
+| `execution_id` | `str` | UUID for this execution |
+| `status` | `str` | `"queued"`, `"running"`, `"done"`, `"error"` |
+| `done` | `bool` | Whether execution has finished |
+| `success` | `bool \| None` | `None` until done |
+| `execution_count` | `int \| None` | Kernel execution count once started |
+| `result(timeout_secs)` | `Output` | Wait for completion and return output |
+| `wait(timeout_secs)` | `None` | Wait for completion without returning output |
+| `cancel()` | `None` | Cancel the execution |
+| `await execution` | `Output` | Shorthand for `await execution.result()` |
 
 Other `Client` entry points:
 
@@ -114,8 +136,12 @@ await cell.set_source_hidden(True)
 await cell.clear_outputs()
 await cell.delete()
 
-# Runtime state (sync read)
-print(notebook.runtime)
+# Runtime state (sync read from RuntimeStateDoc)
+print(notebook.runtime)               # RuntimeState object
+print(notebook.runtime.kernel)         # KernelState: status, starting_phase, name, language, env_source
+print(notebook.runtime.queue)          # QueueState: executing, queued (list of QueueEntry)
+print(notebook.runtime.env)            # EnvState: in_sync, added, removed
+print(notebook.runtime.executions)     # dict[str, ExecutionState] keyed by execution_id
 
 # Connected peers
 print(notebook.peers)  # list of (peer_id, peer_label)
@@ -159,6 +185,18 @@ uv run nteract
 # Via Inkwell supervisor (recommended, handles lifecycle)
 cargo xtask run-mcp
 ```
+
+### nteract MCP Tools (27 tools)
+
+| Category | Tools |
+|----------|-------|
+| Session | `list_active_notebooks`, `show_notebook`, `join_notebook`, `open_notebook`, `create_notebook`, `save_notebook` |
+| Kernel | `interrupt_kernel`, `restart_kernel` |
+| Dependencies | `add_dependency`, `remove_dependency`, `get_dependencies`, `sync_environment` |
+| Cell CRUD | `create_cell`, `get_cell`, `get_all_cells`, `set_cell`, `delete_cell`, `move_cell` |
+| Cell metadata | `set_cells_source_hidden`, `set_cells_outputs_hidden`, `add_cell_tags`, `remove_cell_tags` |
+| Find/Replace | `replace_match`, `replace_regex` |
+| Execution | `execute_cell`, `run_all_cells`, `clear_outputs` |
 
 Three packages are workspace members:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -228,6 +228,8 @@ cargo xtask run-mcp --print-config
 
 ### nteract MCP Tools (27 tools for notebook interaction)
 
+When Inkwell is active, agents also get the full nteract tool suite. **Use these to audit your own work** — open a notebook, execute cells, and inspect outputs to verify changes actually work before committing.
+
 | Category | Tools |
 |----------|-------|
 | Session | `list_active_notebooks`, `show_notebook`, `join_notebook`, `open_notebook`, `create_notebook`, `save_notebook` |
@@ -237,6 +239,8 @@ cargo xtask run-mcp --print-config
 | Cell metadata | `set_cells_source_hidden`, `set_cells_outputs_hidden`, `add_cell_tags`, `remove_cell_tags` |
 | Find/Replace | `replace_match`, `replace_regex` |
 | Execution | `execute_cell`, `run_all_cells`, `clear_outputs` |
+
+**Audit workflow example:** After modifying daemon or kernel code, use `open_notebook` on a test fixture, `execute_cell` to run it, then `get_cell` to inspect outputs — confirming the change works end-to-end without leaving the agent session.
 
 ### Hot reload
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,8 @@ Codex-specific repo skills live in `.codex/skills/`. Prefer them when the task m
 
 If your MCP client provides `supervisor_status`, `supervisor_restart`, `supervisor_rebuild`, etc., **prefer those over manual terminal commands**. The supervisor manages the dev daemon lifecycle for you — no env vars, no extra terminals.
 
+**Claude Code has Inkwell locally** — the local dev environment connects Claude Code to the MCP supervisor via `cargo xtask run-mcp`. Cloud/CI sessions (e.g. GitHub-hosted agents) do not have Inkwell and must use `cargo xtask` commands directly.
+
 | Instead of… | Use… |
 |-------------|------|
 | `cargo xtask dev-daemon` (in a terminal) | `supervisor_restart(target="daemon")` |
@@ -24,7 +26,7 @@ If your MCP client provides `supervisor_status`, `supervisor_restart`, `supervis
 | `runt daemon logs` | `supervisor_logs` |
 | `cargo xtask vite` | `supervisor_start_vite` |
 
-The supervisor automatically handles per-worktree isolation, env var plumbing, and daemon restarts. You only need the manual commands below when the supervisor isn't available.
+The supervisor automatically handles per-worktree isolation, env var plumbing, and daemon restarts. You only need the manual commands below when the supervisor isn't available (e.g. cloud sessions, CI).
 
 ### Manual commands (when supervisor is not available)
 
@@ -244,7 +246,8 @@ The supervisor watches `python/nteract/src/`, `python/runtimed/src/`, `crates/ru
 
 ### Tool availability
 
-- **Inkwell active** → all supervisor + nteract tools available. **Prefer supervisor tools for daemon lifecycle** — they handle env vars and isolation automatically.
+- **Local Claude Code / Zed / MCP client** → Inkwell active, all supervisor + nteract tools available. **Prefer supervisor tools for daemon lifecycle** — they handle env vars and isolation automatically.
+- **Cloud agents (GitHub, Codex, remote sessions)** → No MCP server, use `cargo xtask` commands directly for build, daemon, and testing.
 - **nteract MCP only** → nteract tools only, no `supervisor_*`. Use manual terminal commands for daemon management.
 - **No MCP server** → use `cargo xtask run-mcp` to set one up
 - **Dev daemon not running** → Inkwell starts it automatically via `supervisor_restart(target="daemon")`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,15 +110,22 @@ Before diving into a subsystem, read the relevant guide:
 
 | Task | Guide |
 |------|-------|
+| High-level architecture | `contributing/architecture.md` |
+| Development setup | `contributing/development.md` |
 | Python bindings / MCP | `contributing/runtimed.md` § Python Bindings |
 | Running tests | `contributing/testing.md` |
+| E2E tests (WebdriverIO) | `contributing/e2e.md` |
 | Frontend architecture | `contributing/frontend-architecture.md` |
+| UI components (Shadcn) | `contributing/ui.md` |
+| nteract Elements library | `contributing/nteract-elements.md` |
 | Wire protocol / sync | `contributing/protocol.md` |
 | Widget system | `contributing/widget-development.md` |
 | Daemon development | `contributing/runtimed.md` |
 | Environment management | `contributing/environments.md` |
 | Output iframe sandbox | `contributing/iframe-isolation.md` |
 | CRDT mutation rules | `contributing/crdt-mutation-guide.md` |
+| TypeScript bindings (ts-rs) | `contributing/typescript-bindings.md` |
+| Logging guidelines | `contributing/logging.md` |
 | Build dependencies | `contributing/build-dependencies.md` |
 | Releasing | `contributing/releasing.md` |
 
@@ -187,6 +194,8 @@ uv run nteract  # Run MCP server from repo root
 ### Python API Notes
 
 - **`Output.data` is typed by MIME kind**: `str` for text MIME types, `bytes` for binary (raw bytes, no base64), `dict` for JSON MIME types. Image outputs include a synthesized `text/llm+plain` key with blob URLs.
+- **Execution API**: `cell.run()` is sugar for `(await cell.execute()).result()`. For granular control use `Execution` handle: `execution = await cell.execute()` → `execution.status`, `execution.execution_id`, `await execution.result()`, `execution.cancel()`. Or `await cell.queue()` to enqueue without waiting.
+- **RuntimeState**: `notebook.runtime` provides sync reads of kernel status, queue, executions, env sync, and trust from the RuntimeStateDoc.
 - Use `default_socket_path()` for the current process or test harness because it respects `RUNTIMED_SOCKET_PATH`.
 - Use `socket_path_for_channel("stable"|"nightly")` only when you must target a specific channel explicitly or discover the other channel; it intentionally ignores `RUNTIMED_SOCKET_PATH`.
 
@@ -204,7 +213,7 @@ cargo xtask run-mcp --print-config
 
 `uv run nteract --stable` and `uv run nteract --nightly` are channel overrides for direct MCP launches. They only seed `RUNTIMED_SOCKET_PATH` when it is unset, and they also control which app `show_notebook` opens. `--no-show` removes the `show_notebook` tool entirely.
 
-### Available MCP tools
+### Supervisor Tools (from Inkwell / `mcp-supervisor`)
 
 | Tool | Purpose |
 |------|---------|
@@ -214,6 +223,18 @@ cargo xtask run-mcp --print-config
 | `supervisor_logs` | Tail the daemon log file |
 | `supervisor_start_vite` | Start the Vite dev server for hot-reload frontend development |
 | `supervisor_stop` | Stop a managed process by name (e.g. `"vite"`) |
+
+### nteract MCP Tools (27 tools for notebook interaction)
+
+| Category | Tools |
+|----------|-------|
+| Session | `list_active_notebooks`, `show_notebook`, `join_notebook`, `open_notebook`, `create_notebook`, `save_notebook` |
+| Kernel | `interrupt_kernel`, `restart_kernel` |
+| Dependencies | `add_dependency`, `remove_dependency`, `get_dependencies`, `sync_environment` |
+| Cell CRUD | `create_cell`, `get_cell`, `get_all_cells`, `set_cell`, `delete_cell`, `move_cell` |
+| Cell metadata | `set_cells_source_hidden`, `set_cells_outputs_hidden`, `add_cell_tags`, `remove_cell_tags` |
+| Find/Replace | `replace_match`, `replace_regex` |
+| Execution | `execute_cell`, `run_all_cells`, `clear_outputs` |
 
 ### Hot reload
 
@@ -228,9 +249,52 @@ The supervisor watches `python/nteract/src/`, `python/runtimed/src/`, `crates/ru
 - **No MCP server** → use `cargo xtask run-mcp` to set one up
 - **Dev daemon not running** → Inkwell starts it automatically via `supervisor_restart(target="daemon")`
 
+## Workspace Crates (15)
+
+| Crate | Purpose |
+|-------|---------|
+| `runtimed` | Central daemon — env pools, notebook sync, kernel execution |
+| `runtimed-py` | Python bindings for daemon (PyO3/maturin) |
+| `runtimed-wasm` | WASM bindings for notebook doc (Automerge, used by frontend) |
+| `notebook` | Tauri desktop app — main GUI, bundles daemon+CLI as sidecars |
+| `notebook-doc` | Shared Automerge schema — cells, outputs, RuntimeStateDoc, PEP 723 |
+| `notebook-protocol` | Wire types — requests, responses, broadcasts |
+| `notebook-sync` | Automerge sync client — `DocHandle`, per-cell Python accessors |
+| `runt` | CLI — daemon management, kernel control, notebook launching |
+| `runt-trust` | Notebook trust (HMAC-SHA256 over dependency metadata) |
+| `runt-workspace` | Per-worktree daemon isolation, socket path management |
+| `kernel-launch` | Kernel launching, tool bootstrapping (deno, uv, ruff via rattler) |
+| `kernel-env` | Python environment management (UV + Conda) with progress reporting |
+| `tauri-jupyter` | Shared Jupyter message types for Tauri/WebView |
+| `mcp-supervisor` | Inkwell — MCP supervisor proxy, daemon/vite lifecycle management |
+| `xtask` | Build system orchestration |
+
 ## Build System (`cargo xtask`)
 
 All build, lint, and dev commands go through `cargo xtask`. **Run `cargo xtask help` at the start of each session** — it's the source of truth.
+
+### Quick Reference
+
+| Category | Command | Description |
+|----------|---------|-------------|
+| Dev | `cargo xtask dev` | Full setup: deps + build + daemon + app |
+| | `cargo xtask notebook` | Hot-reload dev server (Vite on port 5174) |
+| | `cargo xtask notebook --attach` | Attach Tauri to existing Vite server |
+| | `cargo xtask vite` | Start Vite standalone |
+| | `cargo xtask build` | Full debug build (frontend + Rust) |
+| | `cargo xtask build --rust-only` | Rebuild Rust only, reuse frontend |
+| | `cargo xtask run` | Run bundled debug binary |
+| Daemon | `cargo xtask dev-daemon` | Per-worktree dev daemon |
+| | `cargo xtask install-daemon` | Install runtimed as system daemon |
+| MCP | `cargo xtask run-mcp` | Inkwell supervisor (daemon + MCP + auto-restart) |
+| | `cargo xtask run-mcp --print-config` | Print MCP client config JSON |
+| | `cargo xtask dev-mcp` | Direct nteract MCP (no supervisor) |
+| Lint | `cargo xtask lint` | Check formatting (Rust, JS/TS, Python) |
+| | `cargo xtask lint --fix` | Auto-fix formatting |
+| Test | `cargo xtask integration [filter]` | Python integration tests with isolated daemon |
+| | `cargo xtask e2e` | E2E testing (WebdriverIO) |
+| Other | `cargo xtask wasm` | Rebuild runtimed-wasm |
+| | `cargo xtask icons [source.png]` | Generate icon variants |
 
 ## Runtime Daemon (`runtimed`)
 
@@ -309,6 +373,7 @@ The rule: `image/*` → binary (EXCEPT `image/svg+xml` — that's text). `audio/
 | Notebook metadata (deps, runtime) | Frontend WASM | User edits deps, runtime picker |
 | Cell outputs (manifest hashes) | Daemon | Kernel IOPub → blob store → hash in doc |
 | Execution count | Daemon | Set on `execute_input` from kernel |
+| RuntimeStateDoc (kernel, queue, executions, env, trust) | Daemon | Separate Automerge doc, frame type `0x05` |
 
 **Never write to the CRDT in response to a daemon broadcast.** The daemon already wrote. Writing again creates redundant sync traffic and incorrectly marks the notebook as dirty.
 


### PR DESCRIPTION
## Summary

- **AGENTS.md**: Add workspace crate map (15 crates), full xtask command reference table, nteract MCP tools listing (27 tools), RuntimeStateDoc in CRDT ownership table, Execution API notes, 7 missing subsystem guide entries
- **python-bindings skill**: Replace removed `stream()` API with `Execution` handle class (`execute`/`run`/`queue`), add RuntimeState property docs, add nteract MCP tools table
- **daemon-dev skill**: Add 9 missing source modules to code structure, add RuntimeStateDoc schema and execution lifecycle sections
- **protocol rules**: Promote RuntimeStateDoc from "planned" to shipped with full schema, add execution_id tracking section
- **architecture rules**: Add RuntimeStateDoc to state ownership table with full description
- **environments rules**: Add PEP 723 support, kernel starting phases (resolving/preparing_env/launching/connecting)
- **logging rules**: Document log file rotation on daemon startup

## Motivation

The agent-facing documentation had fallen behind the codebase in several areas:
- The Python `stream()` API was removed and replaced by the `Execution` handle class, but skills still showed the old API
- `RuntimeStateDoc` shipped as the authoritative source for kernel status, queue, executions, env sync, and trust — but protocol rules still described it as "being replaced by"
- 9 daemon source modules were missing from the code structure reference
- 27 nteract MCP tools existed but were never listed in any agent doc
- The xtask command table, crate map, and several subsystem guide cross-references were absent from AGENTS.md

## Test plan

- [ ] Verify all file paths referenced in docs exist in the codebase
- [ ] Confirm `Execution` API matches `python/runtimed/src/runtimed/_execution.py`
- [ ] Confirm RuntimeStateDoc schema matches `crates/notebook-doc/src/runtime_state.rs`
- [ ] Confirm nteract MCP tools list matches `python/nteract/src/nteract/_mcp_server.py`
