### PR TITLE
fix(mcp-supervisor): honor CONDUCTOR_PORT for Vite port resolution

### DIFF
--- a/crates/mcp-supervisor/src/main.rs
+++ b/crates/mcp-supervisor/src/main.rs
@@ -717,6 +717,7 @@ impl Supervisor {
         // Phase 2: Derive port and run pnpm install without holding the lock
         let port = std::env::var("RUNTIMED_VITE_PORT")
             .ok()
+            .or_else(|| std::env::var("CONDUCTOR_PORT").ok())
             .and_then(|p| p.parse::<u16>().ok())
             .unwrap_or_else(|| runt_workspace::vite_port_for_workspace(&project_root));
 


### PR DESCRIPTION
## Summary

When running inside Conductor, `supervisor_start_vite` ignored `CONDUCTOR_PORT` and always fell back to a hash-derived port. This meant `cargo xtask notebook --attach` from a Conductor terminal couldn't find the Vite server.

Adds `CONDUCTOR_PORT` as a fallback in the supervisor's port resolution chain (`RUNTIMED_VITE_PORT` → `CONDUCTOR_PORT` → hash-derived), matching the priority order already used by xtask's `resolve_vite_port()` and `vite.config.ts`.

## Verification

- [ ] With `CONDUCTOR_PORT=<port>` in the environment, `supervisor_start_vite` starts Vite on that port
- [ ] `cargo xtask notebook --attach` successfully connects to the supervisor-managed Vite server
- [ ] Without `CONDUCTOR_PORT` set, the hash-derived fallback still works as before

_PR submitted by @rgbkrk's agent, Quill_