### PR TITLE
fix(ci): split runtimed-py unit and integration tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -628,19 +628,14 @@ jobs:
           path: e2e-logs/
           retention-days: 7
 
-  # Python daemon integration tests
-  runtimed-py-integration:
-    name: runtimed-py Integration Tests
+  # Python unit tests — no daemon needed, no dependency on build-linux
+  runtimed-py-unit:
+    name: runtimed-py Unit Tests
     runs-on: ubuntu-latest
-    needs: [changes, build-linux]
+    needs: [changes]
     if: needs.changes.outputs.source_changed == 'true'
     steps:
       - uses: actions/checkout@v6
-
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libxdo-dev
 
       - name: Install rust
         uses: dsherret/rust-toolchain-file@v1
@@ -648,15 +643,6 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: ubuntu-latest
-
-      - name: Download Linux Rust binaries
-        uses: actions/download-artifact@v4
-        with:
-          name: linux-rust-binaries
-          path: .
-
-      - name: Make binaries executable
-        run: chmod +x target/release/runtimed target/release/runt
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -667,7 +653,33 @@ jobs:
 
       - name: Run unit tests
         working-directory: python/runtimed
-        run: uv run pytest tests/test_session_unit.py -v --tb=short
+        run: uv run pytest tests/test_session_unit.py tests/test_binary.py tests/test_ipython_bridge.py -v --tb=short
+
+  # Python daemon integration tests — builds its own runtimed binary
+  runtimed-py-integration:
+    name: runtimed-py Integration Tests
+    runs-on: ubuntu-latest
+    needs: [changes]
+    if: needs.changes.outputs.source_changed == 'true'
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install rust
+        uses: dsherret/rust-toolchain-file@v1
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ubuntu-latest
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Build runtimed binary
+        run: cargo build --release -p runtimed -p runt-cli
+
+      - name: Build runtimed-py
+        working-directory: python/runtimed
+        run: uv run maturin develop --manifest-path ../../crates/runtimed-py/Cargo.toml
 
       - name: Run integration tests
         timeout-minutes: 30

--- a/python/runtimed/tests/test_session_unit.py
+++ b/python/runtimed/tests/test_session_unit.py
@@ -61,6 +61,8 @@ class TestModuleExports:
             # Standalone functions
             "default_socket_path",
             "show_notebook_app",
+            "show_notebook_app_for_channel",
+            "socket_path_for_channel",
         }
         assert set(runtimed.__all__) == expected
 


### PR DESCRIPTION
The `runtimed-py-integration` job was doing double duty — running unit tests *and* integration tests in a single job gated on `build-linux`. This meant unit tests couldn't run until the full Linux release build (including UI build + Tauri) completed.

**Changes:**

- **`runtimed-py-unit`** — new job, depends only on `changes`. Runs `maturin develop` then all non-daemon tests (`test_session_unit.py`, `test_binary.py`, `test_ipython_bridge.py`). No system deps, no binary downloads, starts immediately.

- **`runtimed-py-integration`** — no longer depends on `build-linux`. Builds `runtimed` and `runt` itself via `cargo build --release`. Drops the unnecessary `libgtk-3-dev`/`libwebkit2gtk-4.1-dev` system deps (those are Tauri-only). Still shares the Rust cache.

- **Fixes `test_all_exports`** — adds `socket_path_for_channel` and `show_notebook_app_for_channel` to the expected set.

_PR submitted by @rgbkrk's agent Quill, via Zed_