### PR TITLE
fix(ci): consolidate Python lint and unit tests, fix ty type error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -628,33 +628,6 @@ jobs:
           path: e2e-logs/
           retention-days: 7
 
-  # Python unit tests — no daemon needed, no dependency on build-linux
-  runtimed-py-unit:
-    name: runtimed-py Unit Tests
-    runs-on: ubuntu-latest
-    needs: [changes]
-    if: needs.changes.outputs.source_changed == 'true'
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Install rust
-        uses: dsherret/rust-toolchain-file@v1
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: ubuntu-latest
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-
-      - name: Build runtimed-py
-        working-directory: python/runtimed
-        run: uv run maturin develop --manifest-path ../../crates/runtimed-py/Cargo.toml
-
-      - name: Run unit tests
-        working-directory: python/runtimed
-        run: uv run pytest tests/test_session_unit.py tests/test_binary.py tests/test_ipython_bridge.py -v --tb=short
-
   # Python daemon integration tests — builds its own runtimed binary
   runtimed-py-integration:
     name: runtimed-py Integration Tests

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -33,7 +33,8 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  python-lint:
+  python-lint-and-test:
+    name: Python Lint & Unit Tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -55,6 +56,22 @@ jobs:
 
       - name: Type check
         run: uv run ty check python/
+
+      # runtimed-py unit tests (needs Rust for the native module)
+      - name: Install rust
+        uses: dsherret/rust-toolchain-file@v1
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: python-x86_64-unknown-linux-gnu
+
+      - name: Build runtimed-py
+        working-directory: python/runtimed
+        run: uv run maturin develop --manifest-path ../../crates/runtimed-py/Cargo.toml
+
+      - name: Run runtimed-py unit tests
+        working-directory: python/runtimed
+        run: uv run pytest tests/test_session_unit.py tests/test_binary.py tests/test_ipython_bridge.py -v --tb=short
 
   nteract-test:
     runs-on: ubuntu-latest

--- a/python/nteract/src/nteract/_mcp_server.py
+++ b/python/nteract/src/nteract/_mcp_server.py
@@ -25,7 +25,7 @@ import logging
 import os
 import re
 import sys
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any, Literal, NoReturn
 
 from mcp.server.fastmcp import Context, FastMCP
 from mcp.types import ImageContent, TextContent, ToolAnnotations
@@ -50,7 +50,7 @@ class _StderrParser(argparse.ArgumentParser):
     def _print_message(self, message: str, file: Any = None) -> None:
         super()._print_message(message, file=sys.stderr)
 
-    def exit(self, status: int = 0, message: str | None = None) -> None:  # type: ignore[override]
+    def exit(self, status: int = 0, message: str | None = None) -> NoReturn:
         if message:
             self._print_message(message, sys.stderr)
         raise SystemExit(status)


### PR DESCRIPTION
Follows up on #1140 which split unit/integration tests but left two issues:

**`python-lint` type check failure** — `_StderrParser.exit()` returned `None` instead of `NoReturn`, violating the `ArgumentParser.exit` signature. Fixed the return type and added the import.

**Consolidate Python CI** — Merged the `runtimed-py-unit` job (from `build.yml`) into `python-package.yml` as a combined "Python Lint & Unit Tests" job. One job now runs ruff → ty → maturin develop → pytest. Removes `runtimed-py-unit` from `build.yml` since `python-package.yml` already triggers on all the right paths (`crates/runtimed-py/**`, `crates/runtimed/**`, `python/runtimed/**`).

Integration tests remain in `build.yml` — they're heavyweight and belong with the other long-running CI jobs.

Note: the two integration test failures from #1140 (`test_ansi_colors_preserved` empty stdout, `test_deno_kernel_typescript_features` 60s timeout) are pre-existing flaky tests, not caused by any of these changes.

_PR submitted by @rgbkrk's agent Quill, via Zed_