### PR TITLE
feat(runtime): show kernel starting phases in UI

### DIFF
--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -105,9 +105,6 @@ export function NotebookToolbar({
     kernelStatus === KERNEL_STATUS.BUSY ||
     kernelStatus === KERNEL_STATUS.STARTING;
   const kernelStatusText = getKernelStatusLabel(kernelStatus, startingPhase);
-  const isKernelNotStarted =
-    kernelStatus === KERNEL_STATUS.NOT_STARTED ||
-    kernelStatus === KERNEL_STATUS.SHUTDOWN;
   const envErrorMessage = envProgress?.error ?? null;
   const envStatusText = envProgress?.statusText ?? kernelStatusText;
   const kernelStatusDescription = envProgress?.isActive

--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -324,7 +324,10 @@ export function NotebookToolbar({
               kernelStatus === KERNEL_STATUS.BUSY && "bg-amber-500",
               kernelStatus === KERNEL_STATUS.STARTING &&
                 "bg-blue-500 animate-pulse",
-              isKernelNotStarted && "bg-gray-400 dark:bg-gray-500",
+              kernelStatus === KERNEL_STATUS.NOT_STARTED &&
+                "bg-blue-500 animate-pulse",
+              kernelStatus === KERNEL_STATUS.SHUTDOWN &&
+                "bg-gray-400 dark:bg-gray-500",
               (kernelStatus === KERNEL_STATUS.ERROR || envErrorMessage) &&
                 "bg-red-500",
             )}

--- a/apps/notebook/src/hooks/useDaemonKernel.ts
+++ b/apps/notebook/src/hooks/useDaemonKernel.ts
@@ -21,7 +21,9 @@ import {
   diffExecutions,
   type ExecutionState,
   type QueueEntry,
+  type RuntimeState,
   resetRuntimeState,
+  setRuntimeState,
   useRuntimeState,
 } from "../lib/runtime-state";
 import type {
@@ -435,6 +437,13 @@ export function useDaemonKernel({
         case "queue_changed":
         case "env_sync_state":
           break;
+
+        case "runtime_state_snapshot": {
+          // Eager snapshot from connection setup — apply immediately so the
+          // client has kernel status before the Automerge sync handshake completes.
+          setRuntimeState(broadcast.state as RuntimeState);
+          break;
+        }
 
         case "kernel_error": {
           // Still consume this broadcast for the detailed error message.

--- a/apps/notebook/src/lib/__tests__/kernel-status.test.ts
+++ b/apps/notebook/src/lib/__tests__/kernel-status.test.ts
@@ -31,7 +31,9 @@ describe("getKernelStatusLabel", () => {
   });
 
   it("returns human-readable label for not_started", () => {
-    expect(getKernelStatusLabel(KERNEL_STATUS.NOT_STARTED)).toBe("not started");
+    expect(getKernelStatusLabel(KERNEL_STATUS.NOT_STARTED)).toBe(
+      "initializing",
+    );
   });
 });
 

--- a/apps/notebook/src/lib/kernel-status.ts
+++ b/apps/notebook/src/lib/kernel-status.ts
@@ -14,7 +14,7 @@ const KERNEL_STATUS_SET: ReadonlySet<KernelStatus> = new Set(
 );
 
 export const KERNEL_STATUS_LABELS: Record<KernelStatus, string> = {
-  [KERNEL_STATUS.NOT_STARTED]: "not started",
+  [KERNEL_STATUS.NOT_STARTED]: "initializing",
   [KERNEL_STATUS.STARTING]: "starting",
   [KERNEL_STATUS.IDLE]: "idle",
   [KERNEL_STATUS.BUSY]: "busy",

--- a/apps/notebook/src/types.ts
+++ b/apps/notebook/src/types.ts
@@ -221,6 +221,43 @@ export type DaemonBroadcast =
       };
     }
   | {
+      event: "runtime_state_snapshot";
+      state: {
+        kernel: {
+          status: string;
+          starting_phase: string;
+          name: string;
+          language: string;
+          env_source: string;
+        };
+        queue: {
+          executing: { cell_id: string; execution_id: string } | null;
+          queued: { cell_id: string; execution_id: string }[];
+        };
+        env: {
+          in_sync: boolean;
+          added: string[];
+          removed: string[];
+          channels_changed: boolean;
+          deno_changed: boolean;
+        };
+        trust: {
+          status: string;
+          needs_approval: boolean;
+        };
+        last_saved: string | null;
+        executions: Record<
+          string,
+          {
+            cell_id: string;
+            status: string;
+            execution_count: number | null;
+            success: boolean | null;
+          }
+        >;
+      };
+    }
+  | {
       event: "room_renamed";
       new_notebook_id: string;
     }

--- a/crates/notebook-protocol/src/protocol.rs
+++ b/crates/notebook-protocol/src/protocol.rs
@@ -554,4 +554,12 @@ pub enum NotebookBroadcast {
 
     /// Notebook was autosaved to disk by the daemon.
     NotebookAutosaved { path: String },
+
+    /// Eager RuntimeState snapshot sent during connection setup.
+    ///
+    /// Bypasses the Automerge sync handshake so the client has kernel
+    /// status immediately (prevents "not_started" → "idle" jump).
+    RuntimeStateSnapshot {
+        state: notebook_doc::runtime_state::RuntimeState,
+    },
 }

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -1417,6 +1417,21 @@ where
         connection::send_typed_frame(writer, NotebookFrameType::RuntimeStateSync, &encoded).await?;
     }
 
+    // Phase 1.2: Eagerly send RuntimeState snapshot so the client has
+    // kernel status immediately, without waiting for Automerge sync convergence.
+    // The sync handshake takes multiple roundtrips; by the time it completes,
+    // transient states like starting phases may have already passed.
+    {
+        let sd = room.state_doc.read().await;
+        let state = sd.read_state();
+        connection::send_typed_json_frame(
+            writer,
+            NotebookFrameType::Broadcast,
+            &NotebookBroadcast::RuntimeStateSnapshot { state },
+        )
+        .await?;
+    }
+
     // Phase 1.5: Send comm state sync for widget reconstruction
     // New clients need active comm channels to render widgets created before they connected
     {


### PR DESCRIPTION
## Summary

- **Send RuntimeState snapshot during initial connection**: The Automerge sync handshake for RuntimeStateDoc takes multiple roundtrips. During this window, transient kernel states (starting phases) pass unobserved and the frontend stays stuck on "not started". A new `RuntimeStateSnapshot` broadcast is sent immediately after the initial sync message, giving the client kernel status from the first frame.
- **Change default status label to "initializing"**: The `not_started` label now reads "initializing" with a blue pulsing dot instead of a dead gray one, so the UI communicates activity from the moment the notebook opens.
- **Smooth status progression**: The user now sees "initializing" → "resolving environment" → "preparing environment" → "launching kernel" → "idle" instead of "not started" → (nothing) → "idle".

## Verification

- [ ] Open a notebook and observe the toolbar status pill shows "initializing" (blue pulse) immediately, not "not started" (gray)
- [ ] Confirm starting phases ("resolving environment", "preparing environment", etc.) appear in the status pill as the kernel boots
- [ ] Confirm the status transitions smoothly to "idle" (green dot) once the kernel is ready
- [ ] Confirm "shutdown" status still shows a gray dot (not blue pulse)
- [ ] Open a notebook that requires trust approval and confirm the initializing state doesn't interfere with the trust dialog

_PR submitted by @rgbkrk's agent, Quill_