### PR TITLE
feat(mcp): return cell summary from open_notebook

### DIFF
--- a/python/nteract/src/nteract/_mcp_server.py
+++ b/python/nteract/src/nteract/_mcp_server.py
@@ -833,9 +833,23 @@ class NteractServer:
 
             client = srv._get_client()
             srv._notebook = await client.open_notebook(path, peer_label=srv._peer_label())
+
+            cell_status = await _get_cell_status_map(srv._notebook)
+            lines = [
+                _format_cell_summary(
+                    i,
+                    cell,
+                    preview_chars=60,
+                    include_outputs=False,
+                    status=cell_status.get(cell.id),
+                )
+                for i, cell in enumerate(srv._notebook.cells)
+            ]
+
             return {
                 "notebook_id": srv._notebook.notebook_id,
                 "path": path,
+                "cells": "\n".join(lines),
             }
 
         @srv.mcp.tool(annotations=ToolAnnotations(destructiveHint=False))

--- a/python/nteract/tests/test_mcp_integration.py
+++ b/python/nteract/tests/test_mcp_integration.py
@@ -464,3 +464,32 @@ async def test_get_all_cells_pagination(mcp_client: ClientSession):
 
     # Index should be 1 (the original index, not reset to 0)
     assert text.startswith("1 |")
+
+
+@pytest.mark.asyncio
+async def test_open_notebook_returns_cells(mcp_client: ClientSession):
+    """open_notebook should return a cell summary like join_notebook."""
+    # Create a notebook with cells so we have something to open
+    result = await mcp_client.call_tool("create_notebook", {})
+    data = _parse_json(result)
+    notebook_id = data["notebook_id"]
+
+    await mcp_client.call_tool("create_cell", {"source": "# Hello", "cell_type": "markdown"})
+    await mcp_client.call_tool("create_cell", {"source": "x = 1"})
+
+    # Save to a temp path so we can reopen it
+    result = await mcp_client.call_tool("save_notebook", {})
+
+    # Reopen the same notebook by path — this closes and reconnects
+    result = await mcp_client.call_tool("open_notebook", {"path": notebook_id})
+    data = _parse_json(result)
+
+    assert "notebook_id" in data
+    assert "path" in data
+    assert "cells" in data
+
+    cells_text = data["cells"]
+    assert "| markdown |" in cells_text
+    assert "| code |" in cells_text
+    assert "# Hello" in cells_text
+    assert "x = 1" in cells_text

--- a/python/nteract/tests/test_mcp_integration.py
+++ b/python/nteract/tests/test_mcp_integration.py
@@ -20,6 +20,7 @@ import asyncio
 import contextlib
 import json
 import re
+from pathlib import Path
 from typing import Any
 
 import anyio
@@ -469,19 +470,16 @@ async def test_get_all_cells_pagination(mcp_client: ClientSession):
 @pytest.mark.asyncio
 async def test_open_notebook_returns_cells(mcp_client: ClientSession):
     """open_notebook should return a cell summary like join_notebook."""
-    # Create a notebook with cells so we have something to open
-    result = await mcp_client.call_tool("create_notebook", {})
-    data = _parse_json(result)
-    notebook_id = data["notebook_id"]
+    fixture = str(
+        Path(__file__).resolve().parents[3]
+        / "crates"
+        / "notebook"
+        / "fixtures"
+        / "audit-test"
+        / "1-vanilla.ipynb"
+    )
 
-    await mcp_client.call_tool("create_cell", {"source": "# Hello", "cell_type": "markdown"})
-    await mcp_client.call_tool("create_cell", {"source": "x = 1"})
-
-    # Save to a temp path so we can reopen it
-    result = await mcp_client.call_tool("save_notebook", {})
-
-    # Reopen the same notebook by path — this closes and reconnects
-    result = await mcp_client.call_tool("open_notebook", {"path": notebook_id})
+    result = await mcp_client.call_tool("open_notebook", {"path": fixture})
     data = _parse_json(result)
 
     assert "notebook_id" in data
@@ -489,7 +487,6 @@ async def test_open_notebook_returns_cells(mcp_client: ClientSession):
     assert "cells" in data
 
     cells_text = data["cells"]
-    assert "| markdown |" in cells_text
+    # 1-vanilla.ipynb has two code cells, one with `import sys`
     assert "| code |" in cells_text
-    assert "# Hello" in cells_text
-    assert "x = 1" in cells_text
+    assert "import sys" in cells_text


### PR DESCRIPTION
## Summary

`open_notebook` now returns a `cells` key with the same cell summary that `join_notebook` already provides. This lets agents orient immediately after opening a notebook without needing an extra `get_all_cells` call.

Reuses the existing `_get_cell_status_map` and `_format_cell_summary` helpers — no new code beyond wiring them into the `open_notebook` handler.

Closes #1149

## Verification

- [ ] Open a notebook via the `open_notebook` MCP tool and confirm the response includes a `cells` field with cell index, type, id, and source preview
- [ ] Open a notebook with running/queued cells and confirm status labels appear in the summary
- [ ] Verify `join_notebook` still returns the same format as before

_PR submitted by @rgbkrk's agent, Quill_