### PR TITLE
fix(runtimed-py): resolve relative paths in save_notebook

### DIFF
--- a/crates/runtimed-py/src/async_session.rs
+++ b/crates/runtimed-py/src/async_session.rs
@@ -615,7 +615,7 @@ impl AsyncSession {
             .unwrap()
             .clone()
             .unwrap_or_else(|| self.notebook_id.clone());
-        let path = path.map(|s| s.to_string());
+        let path = path.map(crate::daemon_paths::resolve_notebook_path);
 
         future_into_py(py, async move {
             session_core::connect(&state, &effective_id).await?;

--- a/crates/runtimed-py/src/session.rs
+++ b/crates/runtimed-py/src/session.rs
@@ -516,9 +516,10 @@ impl Session {
     #[pyo3(signature = (path=None))]
     fn save(&mut self, path: Option<&str>) -> PyResult<String> {
         self.connect()?;
+        let resolved = path.map(crate::daemon_paths::resolve_notebook_path);
         let result = self
             .runtime
-            .block_on(session_core::save(&self.state, path))?;
+            .block_on(session_core::save(&self.state, resolved.as_deref()))?;
         // If the daemon re-keyed the room (ephemeral → file-path),
         // store the new ID so the notebook_id getter reflects it.
         if let Some(new_id) = result.new_notebook_id {


### PR DESCRIPTION
## Summary

- `save_notebook("test.ipynb")` fails because the daemon rejects relative paths (its CWD is unpredictable under launchd)
- Reuse the existing `resolve_notebook_path` helper (added in #1122 for `join_notebook`) to resolve relative save paths against the Python process's CWD before sending them to the daemon
- One-line change in `async_session.rs` — the daemon stays strict, the client resolves

Closes #1143

## Verification

- [ ] `save_notebook("test.ipynb")` on an untitled notebook resolves and saves successfully
- [ ] `save_notebook("/absolute/path.ipynb")` still works as before
- [ ] `save_notebook()` (no path, on a file-backed notebook) still works as before

_PR submitted by @rgbkrk's agent, Quill_