### PR TITLE
refactor(runtimed): rename Notebook.shutdown/close to stop_runtime/disconnect

### DIFF
--- a/docs/python-bindings.md
+++ b/docs/python-bindings.md
@@ -103,7 +103,7 @@ async with await client.create_notebook() as notebook:
     await notebook.start(runtime="deno")
     await notebook.restart()
     await notebook.interrupt()
-    await notebook.shutdown()
+    await notebook.stop_runtime()
 
     # Save
     path = await notebook.save()
@@ -281,7 +281,7 @@ async for event in await cell.stream():
 await nb.presence.set_cursor(cell.id, line=0, column=5)
 peers = nb.peers  # sync read — list of (peer_id, label) tuples
 
-await nb.close()
+await nb.disconnect()
 ```
 
 ### Internal: Native Session API

--- a/python/nteract/src/nteract/_mcp_server.py
+++ b/python/nteract/src/nteract/_mcp_server.py
@@ -700,9 +700,9 @@ class NteractServer:
                     loop = None
 
                 if loop is not None and loop.is_running():
-                    loop.create_task(nb.close())
+                    loop.create_task(nb.disconnect())
                 else:
-                    asyncio.run(nb.close())
+                    asyncio.run(nb.disconnect())
             except Exception:
                 pass
 
@@ -795,7 +795,7 @@ class NteractServer:
 
             if srv._notebook is not None:
                 with contextlib.suppress(Exception):
-                    await srv._notebook.close()
+                    await srv._notebook.disconnect()
 
             client = srv._get_client()
             srv._notebook = await client.join_notebook(notebook_id, peer_label=srv._peer_label())
@@ -829,7 +829,7 @@ class NteractServer:
 
             if srv._notebook is not None:
                 with contextlib.suppress(Exception):
-                    await srv._notebook.close()
+                    await srv._notebook.disconnect()
 
             client = srv._get_client()
             srv._notebook = await client.open_notebook(path, peer_label=srv._peer_label())
@@ -872,7 +872,7 @@ class NteractServer:
 
             if srv._notebook is not None:
                 with contextlib.suppress(Exception):
-                    await srv._notebook.close()
+                    await srv._notebook.disconnect()
 
             client = srv._get_client()
             srv._notebook = await client.create_notebook(

--- a/python/runtimed/src/runtimed/_notebook.py
+++ b/python/runtimed/src/runtimed/_notebook.py
@@ -85,8 +85,8 @@ class Notebook:
         """
         await self._session.start_kernel(runtime, env_source, notebook_path)
 
-    async def shutdown(self) -> None:
-        """Shut down the runtime."""
+    async def stop_runtime(self) -> None:
+        """Stop the runtime (kernel). The session remains connected."""
         await self._session.shutdown_kernel()
 
     async def restart(self, wait_for_ready: bool = True) -> list[str]:
@@ -109,8 +109,8 @@ class Notebook:
         """Get the execution queue state (currently executing + queued cells)."""
         return await self._session.get_queue_state()
 
-    async def close(self) -> None:
-        """Close the notebook session."""
+    async def disconnect(self) -> None:
+        """Disconnect from the notebook session."""
         await self._session.close()
 
     # ── Dependency management ────────────────────────────────────────
@@ -166,7 +166,7 @@ class Notebook:
         return self
 
     async def __aexit__(self, *args) -> None:
-        await self.close()
+        await self.disconnect()
 
     def _repr_markdown_(self) -> str:
         nid = self.notebook_id[:12]
@@ -179,11 +179,11 @@ class Notebook:
             "| Properties (sync) | Async methods |\n"
             "|-|-|\n"
             "| `cells` `peers` | `save()` `save_as()` |\n"
-            "| `presence` `runtime` | `start()` `shutdown()` `restart()` |\n"
+            "| `presence` `runtime` | `start()` `stop_runtime()` `restart()` |\n"
             "| `notebook_id` | `interrupt()` `run_all()` |\n"
             "| | `add_dependency()` `remove_dependency()` |\n"
             "| | `get_dependencies()` `sync_environment()` |\n"
-            "| | `is_connected()` `queue_state()` `close()` |\n"
+            "| | `is_connected()` `queue_state()` `disconnect()` |\n"
         )
 
     def __repr__(self) -> str:

--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -1636,10 +1636,10 @@ async def notebook(daemon_process):
     nb = await client.create_notebook()
     yield nb
     try:
-        await nb.shutdown()
+        await nb.stop_runtime()
     except Exception:
         pass
-    await nb.close()
+    await nb.disconnect()
 
 
 @pytest.fixture
@@ -1655,10 +1655,10 @@ async def two_notebooks(daemon_process):
     yield nb1, nb2
     for nb in [nb1, nb2]:
         try:
-            await nb.shutdown()
+            await nb.stop_runtime()
         except Exception:
             pass
-        await nb.close()
+        await nb.disconnect()
 
 
 class TestBasicConnectivity:

--- a/scripts/chaos-gremlin.py
+++ b/scripts/chaos-gremlin.py
@@ -286,7 +286,7 @@ async def run_single_gremlin(
         await asyncio.sleep(delay + random.uniform(0, delay))
 
     print(f"{prefix} Done: {rounds} rounds, {errors} errors")
-    await notebook.close()
+    await notebook.disconnect()
     return errors
 
 
@@ -324,7 +324,7 @@ async def async_main(
                 cell_type="code",
             )
             print(f"   Created: {notebook_id[:8]}")
-            await notebook.close()
+            await notebook.disconnect()
 
     print(f"   Target: {notebook_id}")
     print()
@@ -373,7 +373,7 @@ async def async_main(
             outs = len(cell.outputs) if cell.outputs else 0
             ec = cell.execution_count
             print(f"   [{i}] {cell.cell_type} ec={ec} outs={outs}: {src}")
-        await notebook.close()
+        await notebook.disconnect()
     except Exception as e:
         print(f"   (failed to read final state: {e})")
 


### PR DESCRIPTION
## Summary

Renames two methods on the `Notebook` class to better reflect what they actually do:

- `shutdown()` → `stop_runtime()` — stops the kernel, session stays connected
- `close()` → `disconnect()` — drops the session connection to the daemon

The underlying `Session.shutdown_kernel()` and `Session.close()` are unchanged — their names are already accurate at that abstraction level.

Closes #1147

## Verification

- [ ] `await notebook.stop_runtime()` stops the kernel; notebook remains in `list_active_notebooks`
- [ ] `await notebook.disconnect()` drops the session; `async with` context manager still works
- [ ] MCP server correctly disconnects when switching notebooks (`join_notebook`, `open_notebook`, `create_notebook`)

_PR submitted by @rgbkrk's agent, Quill_