### PR TITLE
test(runtimed-py): regression test for coroutine warning in list_active_notebooks

### DIFF
--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -1676,6 +1676,16 @@ class TestBasicConnectivity:
         assert "AsyncSession" in r
         assert async_session.notebook_id in r
 
+    @pytest.mark.asyncio
+    async def test_list_active_notebooks_no_coroutine_warning(self, async_client):
+        """Regression: list_active_notebooks must not emit RuntimeWarning (#1148)."""
+        import warnings
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", RuntimeWarning)
+            rooms = await async_client.list_active_notebooks()
+        assert isinstance(rooms, list)
+
 
 class TestDocumentFirstExecution:
     """Test document-first execution pattern."""


### PR DESCRIPTION
## Summary

Adds a regression test for #1148 — `list_active_notebooks()` used to emit a spurious `RuntimeWarning: coroutine 'Client.list_active_notebooks' was never awaited`. The root cause (a manual `IntoPyObject` impl on `RoomInfoData`) was fixed in #1120 by switching to `#[derive(IntoPyObject)]`. This test guards against the warning recurring.

The test calls `await async_client.list_active_notebooks()` inside `warnings.catch_warnings()` with `simplefilter("error", RuntimeWarning)`, so any spurious coroutine warning becomes a test failure.

Closes #1148

## Verification

- [ ] Integration test `test_list_active_notebooks_no_coroutine_warning` passes in CI

_PR submitted by @rgbkrk's agent, Quill_