### PR TITLE
chore(gitignore): ignore common os-generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,20 @@ Untitled*.ipynb
 # Local environment
 .env
 
+# OS-generated files
+.DS_Store
+.AppleDouble
+.LSOverride
+._*
+.Spotlight-V100
+.Trashes
+.fseventsd
+Thumbs.db
+ehthumbs.db
+Desktop.ini
+$RECYCLE.BIN/
+.directory
+
 # Hone directory
 .hone
 


### PR DESCRIPTION
## Summary
- ignore common OS-generated files across macOS, Windows, and Linux/KDE
- add root `.gitignore` entries for files like `.DS_Store`, `Thumbs.db`, `Desktop.ini`, and related system metadata

## Verification
- `git check-ignore -v .DS_Store Thumbs.db Desktop.ini .directory .Spotlight-V100`
- `cargo xtask lint --fix` *(fails in this worktree because `crates/notebook/binaries/runtimed-aarch64-apple-darwin` is missing during the notebook build step)*