### PR TITLE
fix(runtimed-py): preserve cursor presence through cell execution

### DIFF
--- a/crates/runtimed-py/src/session_core.rs
+++ b/crates/runtimed-py/src/session_core.rs
@@ -1199,8 +1199,9 @@ pub(crate) async fn queue_cell(
 
     match response {
         NotebookResponse::CellQueued { execution_id, .. } => {
-            // Emit focus presence — queuing cell for execution
-            emit_focus_presence(state, cell_id).await;
+            // Don't emit focus here — it would overwrite any cursor presence
+            // set by a prior edit (e.g. splice_source, set_source). The cursor
+            // from the edit should persist through execution.
             Ok(execution_id)
         }
         NotebookResponse::Error { error } => Err(to_py_err(error)),
@@ -1483,9 +1484,8 @@ pub(crate) async fn run_all_cells(
                             .map(|c| c.id.clone())
                     })
                 };
-                if let Some(cell_id) = last_code_cell_id {
-                    emit_focus_presence(state, &cell_id).await;
-                }
+                // Don't emit focus — it would overwrite any existing cursor presence.
+                let _ = last_code_cell_id;
             }
             Ok(count)
         }

--- a/python/nteract/src/nteract/_mcp_server.py
+++ b/python/nteract/src/nteract/_mcp_server.py
@@ -678,7 +678,9 @@ class NteractServer:
         self, cell_id: str, timeout_secs: float = 30.0
     ) -> list[ContentItem]:
         notebook = await self._get_notebook()
-        await self._send_cell_focus(cell_id)
+        # Don't emit focus here — it would overwrite any cursor presence
+        # set by a prior edit (e.g. replace_match, set_cell). The cursor
+        # from the edit should persist through execution.
         cell = notebook.cells.get_by_id(cell_id)
 
         execution = await cell.execute()


### PR DESCRIPTION
## Summary

When an agent edits a cell then executes it (e.g. `replace_match` with `and_run=True`), the agent's cursor would disappear because execution emitted **focus** presence, which overwrites cursor presence on the frontend. This removes focus emissions from the execution path so the cursor set by the edit persists.

Three focus emissions removed:
- `queue_cell()` in `session_core.rs` — no longer overwrites cursor after `CellQueued`
- `run_all_cells()` in `session_core.rs` — same
- `_execute_cell_internal()` in `_mcp_server.py` — same

Source-editing operations (`create_cell`, `set_source`, `splice_source`, `append_source`) already emit cursor at end of source, simulating a paste. Those cursors now survive execution.

## Verification

- [ ] Open a notebook in nteract, have an agent use `replace_match` with `and_run=True` — agent cursor stays visible at edit position
- [ ] Use standalone `execute_cell` — no presence change, prior cursor state preserved
- [ ] Use `create_cell` with `and_run=True` — cursor stays at end of new cell source
- [ ] `run_all_cells` — no cursor displacement

_PR submitted by @rgbkrk's agent, Quill_