### PR TITLE
fix(editor): peer cursor label visible on line 1

### DIFF
--- a/src/components/cell/CellContainer.tsx
+++ b/src/components/cell/CellContainer.tsx
@@ -105,7 +105,7 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
                   isDragging && "cursor-grabbing",
                 )}
               />
-              <div className="min-w-0 flex-1 py-3 pl-6 pr-3">{codeContent}</div>
+              <div className="min-w-0 flex-1 pb-3 pl-6 pr-3">{codeContent}</div>
               {/* Code row right gutter */}
               {rightGutterContent && (
                 <div
@@ -167,7 +167,7 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
                   isDragging && "cursor-grabbing",
                 )}
               />
-              <div className="min-w-0 flex-1 py-3 pl-6 pr-3">{children}</div>
+              <div className="min-w-0 flex-1 pb-3 pl-6 pr-3">{children}</div>
             </div>
             {/* Right margin for legacy layout */}
             {rightGutterContent && (

--- a/src/components/editor/extensions.ts
+++ b/src/components/editor/extensions.ts
@@ -34,6 +34,10 @@ export const notebookEditorTheme = EditorView.theme({
   "&.cm-focused": {
     outline: "none",
   },
+  // Top padding inside editor so peer cursor labels have room above line 1
+  ".cm-content": {
+    paddingTop: "0.75rem",
+  },
   // Reset line padding so code aligns with output areas
   // (CodeMirror's base theme adds "padding: 0 2px 0 6px" to .cm-line)
   ".cm-line": {


### PR DESCRIPTION
## Summary

Remote peer cursor labels (e.g. "cursor-bot") were invisible when the cursor was on line 1 of a cell. The label renders above the cursor via `bottom: 100%`, but on line 1 it got clipped by the editor's scroll container.

The fix moves the top padding from the external cell wrapper (`py-3` → `pb-3`) into CodeMirror's `.cm-content` (`paddingTop: 0.75rem`). This gives the label room to render inside the scrollable area without changing the visual layout — the editor background is transparent so the padding is invisible.

## Before / After

<!-- Add screenshots showing the cursor label on line 1 before and after -->

## Verification

- [ ] Open a notebook with a remote peer cursor on **line 1** of a cell — label should be visible
- [ ] Peer cursor on **line 2+** still shows the label above as before
- [ ] Cell vertical spacing looks unchanged (no visual regression)
- [ ] Gutter alignment (play button, execution count) still lines up with code

_PR submitted by @rgbkrk's agent, Quill_