### PR TITLE
fix(ci): skip Python checks gracefully when no source changes

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -12,14 +12,6 @@ on:
     tags:
       - "python-v*"
   pull_request:
-    paths:
-      - "pyproject.toml"
-      - "python/runtimed/**"
-      - "python/nteract/**"
-      - "python/gremlin/**"
-      - "crates/runtimed-py/**"
-      - "crates/runtimed/**"
-      - ".github/workflows/python-package.yml"
   workflow_dispatch:
 
 concurrency:
@@ -33,8 +25,34 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  # Detect whether Python/Rust sources changed. When they haven't
+  # (e.g. a docs-only or .gitignore PR), the expensive jobs are
+  # skipped but still report a passing status so required checks
+  # don't block the merge queue.
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      python: ${{ steps.filter.outputs.python }}
+    steps:
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            python:
+              - 'pyproject.toml'
+              - 'python/runtimed/**'
+              - 'python/nteract/**'
+              - 'python/gremlin/**'
+              - 'crates/runtimed-py/**'
+              - 'crates/runtimed/**'
+              - '.github/workflows/python-package.yml'
+
   python-lint-and-test:
     name: Python Lint & Unit Tests
+    needs: changes
+    if: needs.changes.outputs.python == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -73,7 +91,17 @@ jobs:
         working-directory: python/runtimed
         run: uv run pytest tests/test_session_unit.py tests/test_binary.py tests/test_ipython_bridge.py -v --tb=short
 
+  python-lint-and-test-skip:
+    name: Python Lint & Unit Tests
+    needs: changes
+    if: needs.changes.outputs.python != 'true' && github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Skipped — no Python/Rust changes"
+
   nteract-test:
+    needs: changes
+    if: needs.changes.outputs.python == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -92,7 +120,17 @@ jobs:
         run: uv run pytest --ignore=tests/test_mcp_integration.py
         working-directory: python/nteract
 
+  nteract-test-skip:
+    name: nteract-test
+    needs: changes
+    if: needs.changes.outputs.python != 'true' && github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Skipped — no Python/Rust changes"
+
   macos:
+    needs: changes
+    if: needs.changes.outputs.python == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ${{ matrix.platform.runner }}
     strategy:
       matrix:
@@ -137,6 +175,8 @@ jobs:
           path: python/runtimed/dist
 
   linux:
+    needs: changes
+    if: needs.changes.outputs.python == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
The `Python Lint & Unit Tests` and `nteract-test` jobs are required status checks but only trigger on Python/Rust path changes. PRs that touch other files (e.g. `.gitignore` in #1164) get stuck because the required check never reports a status.

Uses `dorny/paths-filter` to detect changes, then either runs the real job or a lightweight skip job that reports the same check name. Tag pushes and `workflow_dispatch` always run the full suite.

_PR submitted by @rgbkrk's agent Quill, via Zed_