### PR TITLE
fix(notebook): prevent edit wipe when multiple peers are connected

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -136,6 +136,7 @@ function AppContent() {
     flushSync,
     getHandle,
     triggerSync,
+    localActor,
   } = useAutomergeNotebook();
 
   // Global find (Cmd+F)
@@ -1217,6 +1218,7 @@ function AppContent() {
           getHandle={getHandle}
           onSyncNeeded={triggerSync}
           setDirty={setDirty}
+          localActor={localActor}
         >
           <NotebookView
             cellIds={cellIds}

--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -510,6 +510,8 @@ export function useAutomergeNotebook() {
   // Trigger a debounced sync to the daemon (same Subject the old
   // updateCellSource used via sourceSync$).
   const triggerSync = useCallback(() => sourceSync$.current.next(), []);
+  // Stable local actor label for filtering self-echo text attributions.
+  const localActor = `human:${sessionIdRef.current}`;
 
   return {
     cellIds,
@@ -536,5 +538,6 @@ export function useAutomergeNotebook() {
     // CRDT bridge context deps
     getHandle,
     triggerSync,
+    localActor,
   };
 }

--- a/apps/notebook/src/hooks/useCrdtBridge.tsx
+++ b/apps/notebook/src/hooks/useCrdtBridge.tsx
@@ -43,6 +43,8 @@ interface CrdtBridgeContextValue {
   onSyncNeeded: () => void;
   /** Mark the notebook as dirty (unsaved changes). */
   setDirty: (dirty: boolean) => void;
+  /** Local actor label (e.g. "human:abcd1234") for filtering self-echo attributions. */
+  localActor: string;
 }
 
 const CrdtBridgeContext = createContext<CrdtBridgeContextValue | null>(null);
@@ -53,6 +55,7 @@ interface CrdtBridgeProviderProps {
   getHandle: () => NotebookHandle | null;
   onSyncNeeded: () => void;
   setDirty: (dirty: boolean) => void;
+  localActor: string;
   children: ReactNode;
 }
 
@@ -60,6 +63,7 @@ export function CrdtBridgeProvider({
   getHandle,
   onSyncNeeded,
   setDirty,
+  localActor,
   children,
 }: CrdtBridgeProviderProps) {
   // Stable ref so the context value doesn't change on every render.
@@ -67,10 +71,12 @@ export function CrdtBridgeProvider({
     getHandle,
     onSyncNeeded,
     setDirty,
+    localActor,
   });
   valueRef.current.getHandle = getHandle;
   valueRef.current.onSyncNeeded = onSyncNeeded;
   valueRef.current.setDirty = setDirty;
+  valueRef.current.localActor = localActor;
 
   // The context value object itself is stable (same ref every render).
   const value = valueRef.current;
@@ -151,10 +157,18 @@ export function useCrdtBridge(cellId: string): {
         ),
       );
 
-      // Filter to attributions for this cell.
+      // Filter to attributions for this cell, skipping self-echo.
+      // When the UI's own edits echo back through the daemon (amplified
+      // by other peers' sync rounds), they produce attributions where the
+      // only actor is the local human actor. CodeMirror already has these
+      // changes, so applying them again would corrupt the editor state.
+      const localActor = ctxRef.current.localActor;
       const changes: RemoteChange[] = [];
       for (const attr of event.attributions) {
         if (attr.cell_id !== cellId) continue;
+        if (attr.actors.length === 1 && attr.actors[0] === localActor) {
+          continue;
+        }
         changes.push({
           index: attr.index,
           text: attr.text,

--- a/apps/notebook/src/lib/crdt-editor-bridge.ts
+++ b/apps/notebook/src/lib/crdt-editor-bridge.ts
@@ -265,6 +265,19 @@ export function createCrdtBridge(config: CrdtBridgeConfig): CrdtBridge {
     // them to CM would be an echo.
     if (isProcessingOutbound) return;
 
+    // If CodeMirror and WASM are already in sync, skip — the changes
+    // are already reflected. This guards against stale text_attributions
+    // from delayed sync convergence (e.g., after the app returns from
+    // background with multiple peers connected). Without this check,
+    // patches computed from WASM's pre-merge state can have indices
+    // that don't match CM's current state, wiping the user's edits.
+    const handle = getHandle();
+    if (handle) {
+      const wasmSource = handle.get_cell_source(cellId);
+      const cmSource = view.state.doc.toString();
+      if (wasmSource === cmSource) return;
+    }
+
     try {
       // Apply each change as a separate dispatch so positions are
       // cumulative (each change's index is relative to the doc state

--- a/apps/notebook/src/lib/frame-pipeline.ts
+++ b/apps/notebook/src/lib/frame-pipeline.ts
@@ -443,7 +443,16 @@ async function materializeFromBatch(
           cache,
           getCellById(cellId),
         );
-        if (cell) updateCellById(cellId, () => cell);
+        if (cell) {
+          // Preserve store source when changeset says source didn't change.
+          // WASM source may include a CRDT merge that hasn't been applied
+          // to CodeMirror yet — using it would desync the store from CM.
+          if (!fields.source) {
+            const existing = getCellById(cellId);
+            if (existing) cell.source = existing.source;
+          }
+          updateCellById(cellId, () => cell);
+        }
       } else {
         // Cache miss — resolve this cell's outputs async (fetch manifests
         // from blob store) without re-serializing the entire document.
@@ -483,14 +492,21 @@ async function materializeFromBatch(
         }));
       }
     } else {
-      // No output changes — always use fast sync path.
+      // No output changes — fast sync path.
       const cell = materializeCellFromWasm(
         handle,
         cellId,
         cache,
         getCellById(cellId),
       );
-      if (cell) updateCellById(cellId, () => cell);
+      if (cell) {
+        // Preserve store source when changeset says source didn't change.
+        if (!fields.source) {
+          const existing = getCellById(cellId);
+          if (existing) cell.source = existing.source;
+        }
+        updateCellById(cellId, () => cell);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- **Convergence guard**: Before applying remote text changes to CodeMirror, check if CM and WASM source already match — skip if so (changes already reflected)
- **Self-echo actor filter**: Skip text_attributions where the only actor is the local human session (echoes of own typing that CM already has)
- **Fast-path source preservation**: Cache-hit and no-output fast paths now preserve the store's existing source when `fields.source` is false, matching the async output path

## Test plan

- [ ] Open a notebook, type in a cell — basic editing works
- [ ] Connect with MCP, edit a cell from both sides, switch away and come back — characters should not disappear
- [ ] Execute cells — outputs appear correctly (fast-path materialization not broken)
- [ ] Rapid typing while MCP is connected — no garbled or duplicated text