### PR TITLE
fix(notebook): dedup session entries to prevent startup crash

### DIFF
--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -3727,6 +3727,17 @@ pub fn run(notebook_path: Option<PathBuf>, runtime: Option<Runtime>) -> anyhow::
         }]
     };
 
+    // Deduplicate by label — if the same notebook path was open in multiple
+    // windows, session restore regenerates the same deterministic label for
+    // each, which would crash registry.insert() with "Context already exists".
+    let startup_windows = {
+        let mut seen = std::collections::HashSet::new();
+        startup_windows
+            .into_iter()
+            .filter(|sw| seen.insert(sw.label.clone()))
+            .collect::<Vec<_>>()
+    };
+
     // If session restore yielded no valid windows, fall back to a fresh notebook
     let startup_windows = if !needs_onboarding && startup_windows.is_empty() {
         vec![StartupWindow {

--- a/crates/notebook/src/session.rs
+++ b/crates/notebook/src/session.rs
@@ -460,4 +460,33 @@ mod tests {
         assert!(labels.contains(&"notebook-real"));
         assert!(!labels.contains(&"notebook-ghost"));
     }
+
+    /// Regression test: if the session file contains two entries for the same
+    /// notebook path (e.g., same notebook was open in two windows with different
+    /// labels), `window_label_for_session()` produces the same deterministic
+    /// label for both. Without dedup at restore time, the second
+    /// `registry.insert()` would crash with "Context already exists".
+    #[test]
+    fn test_duplicate_path_produces_same_label() {
+        let path = PathBuf::from("/Users/test/notebooks/div.ipynb");
+
+        let ws1 = WindowSession {
+            label: "notebook-c79d8e59".to_string(),
+            path: Some(path.clone()),
+            env_id: None,
+            runtime: "python".to_string(),
+            scale_factor: None,
+        };
+        let ws2 = WindowSession {
+            label: "notebook-c79d8e59-ab123456".to_string(),
+            path: Some(path),
+            env_id: None,
+            runtime: "python".to_string(),
+            scale_factor: None,
+        };
+
+        let label1 = window_label_for_session(&ws1);
+        let label2 = window_label_for_session(&ws2);
+        assert_eq!(label1, label2, "same path must produce same label");
+    }
 }


### PR DESCRIPTION
## Summary

After a machine restart, the app could show "Cannot Open Notebook — Context already exists for window" and become completely stuck. This happened when the session file contained duplicate entries for the same notebook path (e.g., the same notebook was open in two windows before shutdown).

On restore, `window_label_for_session()` regenerates deterministic labels from the path hash alone — so two entries for the same path produce the same label, and the second `registry.insert()` crashes startup.

This PR deduplicates `startup_windows` by label after session restore, before registry insertion.

<!-- Screenshot placeholder: before/after of the startup crash -->

## Verification

- [ ] Create a `session.json` in the app's config directory with two entries pointing to the same `.ipynb` path (different labels, same `path` field)
- [ ] Launch the app — confirm it opens normally with one window for that notebook instead of crashing
- [ ] Open a notebook, then open the same notebook in a second window, quit, relaunch — confirm session restores without error
- [ ] Normal session restore (multiple different notebooks) still works as expected

_PR submitted by @rgbkrk's agent, Quill_