### PR TITLE
fix(presence): prevent stale cursor positions when moving between cells

### DIFF
--- a/apps/notebook/src/lib/__tests__/presence-sender.test.ts
+++ b/apps/notebook/src/lib/__tests__/presence-sender.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { EditorState } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -19,7 +20,7 @@ describe("presenceSenderExtension", () => {
     vi.useRealTimers();
   });
 
-  function createView(doc: string) {
+  function createView(doc: string, focused = true) {
     const state = EditorState.create({
       doc,
       extensions: [
@@ -29,7 +30,16 @@ describe("presenceSenderExtension", () => {
         }),
       ],
     });
-    return new EditorView({ state });
+    const v = new EditorView({ state });
+    // In jsdom, hasFocus is always false — override for test control.
+    if (focused) {
+      Object.defineProperty(v, "hasFocus", {
+        value: true,
+        writable: true,
+        configurable: true,
+      });
+    }
+    return v;
   }
 
   it("sends cursor position when selection changes to a point", () => {
@@ -120,5 +130,35 @@ describe("presenceSenderExtension", () => {
     });
 
     expect(onSelection).toHaveBeenCalledWith("cell-1", 0, 2, 1, 3);
+  });
+
+  it("does not send stale cursor from throttle after editor loses focus", () => {
+    view = createView("hello");
+
+    // First change — sent immediately, starts throttle window
+    view.dispatch({ selection: { anchor: 1 } });
+    expect(onCursor).toHaveBeenCalledTimes(1);
+
+    // Second change within throttle — marks pendingUpdate
+    view.dispatch({ selection: { anchor: 3 } });
+    expect(onCursor).toHaveBeenCalledTimes(1);
+
+    // Simulate losing focus (user clicked into another cell)
+    (view as Record<string, unknown>).hasFocus = false;
+
+    // Advance past throttle interval
+    vi.advanceTimersByTime(75);
+
+    // The pending update should NOT have been sent — the editor lost focus
+    expect(onCursor).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not send cursor when selection changes in unfocused editor", () => {
+    view = createView("hello", false);
+
+    view.dispatch({ selection: { anchor: 2 } });
+
+    // Should not send — editor is unfocused
+    expect(onCursor).not.toHaveBeenCalled();
   });
 });

--- a/apps/notebook/src/lib/__tests__/presence-sender.test.ts
+++ b/apps/notebook/src/lib/__tests__/presence-sender.test.ts
@@ -144,7 +144,7 @@ describe("presenceSenderExtension", () => {
     expect(onCursor).toHaveBeenCalledTimes(1);
 
     // Simulate losing focus (user clicked into another cell)
-    (view as Record<string, unknown>).hasFocus = false;
+    (view as unknown as Record<string, unknown>).hasFocus = false;
 
     // Advance past throttle interval
     vi.advanceTimersByTime(75);

--- a/apps/notebook/src/lib/cursor-registry.ts
+++ b/apps/notebook/src/lib/cursor-registry.ts
@@ -341,6 +341,10 @@ function handlePresence(payload: unknown): void {
 
 // ── Lifecycle ────────────────────────────────────────────────────────
 
+/** Reconciliation interval — re-dispatches all cells from canonical peer
+ * state to correct any rendering that diverged from the registry. */
+const RECONCILE_INTERVAL_MS = 5_000;
+
 /**
  * Start dispatching presence events to registered CodeMirror EditorViews.
  *
@@ -353,8 +357,18 @@ export function startCursorDispatch(peerId: string): () => void {
 
   const unsubscribe = subscribePresence(handlePresence);
 
+  // Periodic reconciliation: re-dispatch every registered cell from the
+  // canonical peers map. This self-heals if individual update messages
+  // were lost, misordered, or if the rendering diverged from state.
+  const reconcileTimer = setInterval(() => {
+    for (const cellId of editors.keys()) {
+      dispatchToCell(cellId);
+    }
+  }, RECONCILE_INTERVAL_MS);
+
   return () => {
     unsubscribe();
+    clearInterval(reconcileTimer);
     localPeerId = null;
     peers.clear();
     // Clear all editors' cursors on shutdown

--- a/apps/notebook/src/lib/presence-sender.ts
+++ b/apps/notebook/src/lib/presence-sender.ts
@@ -39,8 +39,10 @@ export function presenceSenderExtension(
   let pendingUpdate = false;
 
   return EditorView.updateListener.of((update) => {
-    // Only act on selection changes
-    if (!update.selectionSet) return;
+    // Only act on selection changes in focused editors — an unfocused editor
+    // must never send presence, otherwise the throttle timer can fire after
+    // the user moves to another cell and re-broadcast a stale position.
+    if (!update.selectionSet || !update.view.hasFocus) return;
 
     // If a timer is pending, mark that we have a pending update
     if (throttleTimer) {
@@ -53,10 +55,15 @@ export function presenceSenderExtension(
 
     throttleTimer = setTimeout(() => {
       throttleTimer = null;
-      // If there was a pending update during the throttle window, send it now
+      // If there was a pending update during the throttle window, send it
+      // now — but only if the editor still has focus. If the user clicked
+      // into a different cell during the throttle window, skip the send
+      // to avoid overwriting their new cursor position with a stale one.
       if (pendingUpdate) {
         pendingUpdate = false;
-        sendPresence(update.view, cellId, callbacks);
+        if (update.view.hasFocus) {
+          sendPresence(update.view, cellId, callbacks);
+        }
       }
     }, THROTTLE_MS);
   });


### PR DESCRIPTION
## Summary

When two notebook windows are open on the same file, cursor labels from remote peers would accumulate in old cells instead of clearing when the user moved between cells. The root cause was the `presenceSenderExtension`'s 75ms throttle timer firing after a user left a cell, re-broadcasting a stale cursor position that overwrote the new cell's position on remote peers.

- **presence-sender**: Add `hasFocus` guards so unfocused editors never send presence — both at the update listener entry and inside the throttle callback
- **cursor-registry**: Add periodic 5s reconciliation that re-dispatches all registered cells from canonical peer state, self-healing any rendering that diverged
- **presence-sender tests**: Fix missing `@vitest-environment jsdom` directive, add tests for throttle-after-blur and unfocused-editor scenarios

## Verification

- [ ] Open the same notebook in two windows side-by-side
- [ ] In one window, click between cells — confirm the other window shows the cursor label only in the current cell (no stale labels left behind)
- [ ] Type rapidly in one window, then quickly click to another cell — confirm no ghost cursor appears in the old cell on the other window
- [ ] Wait ~5 seconds after any cursor weirdness — confirm reconciliation clears any stale state

_PR submitted by @rgbkrk's agent, Quill_