### PR TITLE
fix(presence): prevent cursor label clipping on first line of cell

### DIFF
--- a/src/components/editor/extensions.ts
+++ b/src/components/editor/extensions.ts
@@ -29,14 +29,18 @@ export const notebookEditorTheme = EditorView.theme({
   // (overrides theme's background)
   "&.cm-editor": {
     backgroundColor: "transparent",
+    // Pull the editor up to compensate for the extra .cm-content paddingTop
+    // that reserves space for peer cursor labels above line 1.
+    marginTop: "-0.5rem",
   },
   // Remove focus dotted outline
   "&.cm-focused": {
     outline: "none",
   },
   // Top padding inside editor so peer cursor labels have room above line 1
+  // Flag is ~19px tall (11px font × 1.2 line-height + 4px padding + 1px margin)
   ".cm-content": {
-    paddingTop: "0.75rem",
+    paddingTop: "1.25rem",
   },
   // Reset line padding so code aligns with output areas
   // (CodeMirror's base theme adds "padding: 0 2px 0 6px" to .cm-line)


### PR DESCRIPTION
## Summary

- Remote peer cursor labels (the colored name badge above the cursor bar) were clipped when the cursor sat on line 1 of a cell — the `~19px` flag overflowed above the `.cm-scroller` boundary
- Increased `.cm-content` `paddingTop` from `0.75rem` (12px) to `1.25rem` (20px) so the flag fits within the scroller's content area
- Added a compensating `marginTop: -0.5rem` on `.cm-editor` so the first line of code stays aligned with the gutter execution count

## Before / After

<!-- Add screenshots showing the label clipping fix -->

## Verification

- [ ] Connect two peers to the same notebook
- [ ] Place cursor on line 1 of a cell — label should be fully visible above the cursor
- [ ] Place cursor on other lines — label should still appear above as before
- [ ] Verify first line of code aligns with the `[1]:` gutter execution count
- [ ] Scroll within a cell that has `maxHeight` — labels should remain visible

_PR submitted by @rgbkrk's agent, Quill_