### PR TITLE
feat(runtimed): scoped auto-detect for restart (auto:uv / auto:conda)

### DIFF
--- a/crates/runtimed-py/src/session_core.rs
+++ b/crates/runtimed-py/src/session_core.rs
@@ -539,11 +539,14 @@ pub(crate) async fn restart_kernel(
 
     // Re-launch with the same kernel_type and env_source as before,
     // falling back to "python" / "auto" if no kernel was previously running.
-    // UV prewarmed envs use "auto" on restart so the daemon re-checks metadata
-    // and picks up any deps added after launch (e.g. via add_dependency).
+    // Prewarmed envs use scoped auto-detect on restart so the daemon re-checks
+    // metadata and picks up any deps added after launch (e.g. via add_dependency),
+    // while staying within the original package manager family.
     let restart_kernel_type = prev_kernel_type.unwrap_or_else(|| "python".to_string());
     let restart_env_source = match prev_env_source.as_deref() {
-        Some("uv:prewarmed") | None => "auto".to_string(),
+        Some("uv:prewarmed") => "auto:uv".to_string(),
+        Some("conda:prewarmed") => "auto:conda".to_string(),
+        None => "auto".to_string(),
         Some(s) => s.to_string(),
     };
 
@@ -2286,5 +2289,37 @@ mod tests {
             Some("notebooks/test.ipynb"),
             "spawn_rekey_watcher should update notebook_id_override on RoomRenamed"
         );
+    }
+
+    /// Helper that mirrors the restart env_source mapping logic in restart_kernel().
+    fn restart_env_source(prev: Option<&str>) -> String {
+        match prev {
+            Some("uv:prewarmed") => "auto:uv".to_string(),
+            Some("conda:prewarmed") => "auto:conda".to_string(),
+            None => "auto".to_string(),
+            Some(s) => s.to_string(),
+        }
+    }
+
+    #[test]
+    fn test_restart_env_source_uv_prewarmed() {
+        assert_eq!(restart_env_source(Some("uv:prewarmed")), "auto:uv");
+    }
+
+    #[test]
+    fn test_restart_env_source_conda_prewarmed() {
+        assert_eq!(restart_env_source(Some("conda:prewarmed")), "auto:conda");
+    }
+
+    #[test]
+    fn test_restart_env_source_none_defaults_to_unscoped_auto() {
+        assert_eq!(restart_env_source(None), "auto");
+    }
+
+    #[test]
+    fn test_restart_env_source_explicit_passes_through() {
+        assert_eq!(restart_env_source(Some("uv:inline")), "uv:inline");
+        assert_eq!(restart_env_source(Some("conda:inline")), "conda:inline");
+        assert_eq!(restart_env_source(Some("uv:pyproject")), "uv:pyproject");
     }
 }

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -165,6 +165,12 @@ fn build_launched_config(
             config.venv_path = venv_path;
             config.python_path = python_path;
         }
+        "conda:prewarmed" => {
+            // Store paths so hot-sync can install deps into the prewarmed conda env
+            // conda_deps stays None to indicate no baseline deps were installed
+            config.venv_path = venv_path;
+            config.python_path = python_path;
+        }
         _ => {}
     }
 
@@ -2847,6 +2853,8 @@ async fn handle_notebook_request(
             let resolved_env_source = if resolved_kernel_type == "deno" {
                 if !env_source.is_empty()
                     && env_source != "auto"
+                    && env_source != "auto:uv"
+                    && env_source != "auto:conda"
                     && env_source != "deno"
                     && env_source != "prewarmed"
                 {
@@ -2859,14 +2867,44 @@ async fn handle_notebook_request(
                     info!("[notebook-sync] Deno kernel detected, using 'deno' env_source");
                 }
                 "deno".to_string()
-            } else if env_source == "auto" || env_source.is_empty() || env_source == "prewarmed" {
-                // Auto-detect Python environment
+            } else if env_source == "auto"
+                || env_source == "auto:uv"
+                || env_source == "auto:conda"
+                || env_source.is_empty()
+                || env_source == "prewarmed"
+            {
+                // Auto-detect Python environment, optionally scoped to a package manager family.
+                // "auto:uv" constrains to UV sources, "auto:conda" to conda sources.
+                let auto_scope = if env_source == "auto:uv" {
+                    Some("uv")
+                } else if env_source == "auto:conda" {
+                    Some("conda")
+                } else {
+                    None
+                };
 
                 // Priority 1: Check inline deps in notebook metadata (filter out "deno" - we're resolving Python env)
-                if let Some(inline_source) = metadata_snapshot
-                    .as_ref()
-                    .and_then(check_inline_deps)
-                    .filter(|s| s != "deno")
+                // When scoped, check the target family directly instead of relying on
+                // check_inline_deps() which has UV-first priority and would miss conda
+                // deps in notebooks that have both UV and conda dependency blocks.
+                if let Some(inline_source) =
+                    metadata_snapshot
+                        .as_ref()
+                        .and_then(|snap| match auto_scope {
+                            Some("uv") => snap
+                                .runt
+                                .uv
+                                .as_ref()
+                                .filter(|uv| !uv.dependencies.is_empty())
+                                .map(|_| "uv:inline".to_string()),
+                            Some("conda") => snap
+                                .runt
+                                .conda
+                                .as_ref()
+                                .filter(|c| !c.dependencies.is_empty())
+                                .map(|_| "conda:inline".to_string()),
+                            _ => check_inline_deps(snap).filter(|s| s != "deno"),
+                        })
                 {
                     info!(
                         "[notebook-sync] Found inline deps in notebook metadata -> {}",
@@ -2876,7 +2914,10 @@ async fn handle_notebook_request(
                 } else {
                     // Priority 2: Check PEP 723 script blocks in cell source
                     // Only parsed if metadata check above didn't find inline deps (lazy evaluation).
-                    let has_pep723_deps = {
+                    // Skipped for conda scope — we only have uv:pep723 today (#1176).
+                    let has_pep723_deps = if auto_scope == Some("conda") {
+                        false
+                    } else {
                         let cells = room.doc.read().await.get_cells();
                         match notebook_doc::pep723::find_pep723_in_cells(&cells) {
                             Ok(Some(ref m)) if !m.dependencies.is_empty() => true,
@@ -2896,9 +2937,21 @@ async fn handle_notebook_request(
                         "uv:pep723".to_string()
                     }
                     // Priority 3: Detect project files near notebook path
-                    else if let Some(detected) = notebook_path
-                        .as_ref()
-                        .and_then(|path| crate::project_file::detect_project_file(path))
+                    else if let Some(detected) =
+                        notebook_path.as_ref().and_then(|path| match auto_scope {
+                            Some("uv") => crate::project_file::find_nearest_project_file(
+                                path,
+                                &[crate::project_file::ProjectFileKind::PyprojectToml],
+                            ),
+                            Some("conda") => crate::project_file::find_nearest_project_file(
+                                path,
+                                &[
+                                    crate::project_file::ProjectFileKind::PixiToml,
+                                    crate::project_file::ProjectFileKind::EnvironmentYml,
+                                ],
+                            ),
+                            _ => crate::project_file::detect_project_file(path),
+                        })
                     {
                         info!(
                             "[notebook-sync] Auto-detected project file: {:?} -> {}",
@@ -2907,10 +2960,17 @@ async fn handle_notebook_request(
                         );
                         detected.to_env_source().to_string()
                     }
-                    // Priority 4: Fall back to prewarmed
+                    // Priority 4: Fall back to prewarmed (scoped to family)
                     else {
-                        info!("[notebook-sync] No project file detected, using prewarmed");
-                        "uv:prewarmed".to_string()
+                        let fallback = match auto_scope {
+                            Some("conda") => "conda:prewarmed",
+                            _ => "uv:prewarmed",
+                        };
+                        info!(
+                            "[notebook-sync] No project file detected, using {}",
+                            fallback
+                        );
+                        fallback.to_string()
                     }
                 }
             } else {
@@ -7917,20 +7977,25 @@ mod tests {
     }
 
     #[test]
-    fn test_build_launched_config_conda_prewarmed_no_paths() {
-        // conda:prewarmed falls through to the default branch — no paths stored
+    fn test_build_launched_config_conda_prewarmed_stores_paths() {
+        // conda:prewarmed stores paths so hot-sync can install deps later
+        let venv = PathBuf::from("/tmp/conda-env");
+        let python = PathBuf::from("/tmp/conda-env/bin/python");
         let config = build_launched_config(
             "python",
             "conda:prewarmed",
             None,
             None,
-            Some(PathBuf::from("/tmp/conda-env")),
-            Some(PathBuf::from("/tmp/conda-env/bin/python")),
+            Some(venv.clone()),
+            Some(python.clone()),
         );
-        assert!(config.venv_path.is_none());
-        assert!(config.python_path.is_none());
+        assert_eq!(config.venv_path.as_ref(), Some(&venv));
+        assert_eq!(config.python_path.as_ref(), Some(&python));
         assert!(config.uv_deps.is_none());
-        assert!(config.conda_deps.is_none());
+        assert!(
+            config.conda_deps.is_none(),
+            "prewarmed should not set conda_deps"
+        );
     }
 
     // ── check_and_broadcast_sync_state tests ──────────────────────────────


### PR DESCRIPTION
## Summary

Adds `auto:uv` and `auto:conda` env_source variants so prewarmed kernels re-evaluate metadata on restart while staying within their original package manager family. Previously only `uv:prewarmed` was remapped to unscoped `auto` on restart — `conda:prewarmed` passed through as-is, skipping re-evaluation entirely. With unscoped `auto`, `conda:prewarmed` kernels could also incorrectly resolve to a UV environment when no metadata markers exist.

Each priority step in the daemon's auto-detect chain is now filtered by scope: inline deps are checked directly for the target family (avoiding the UV-first priority in `check_inline_deps()`), PEP 723 is skipped for conda scope (#1176), project file detection uses family-filtered kinds, and the fallback uses the scoped prewarmed variant. Also stores venv/python paths in `LaunchedEnvConfig` for `conda:prewarmed`, mirroring `uv:prewarmed` from #1134 to enable future conda hot-sync.

Closes #1136

## Verification

- [ ] Launch a notebook with a UV prewarmed kernel, add a dependency via `add_dependency`, restart — verify it picks up the dep as `uv:inline`
- [ ] Launch a notebook with a conda prewarmed kernel, add a conda dependency, restart — verify it picks up the dep as `conda:inline` (not `uv:inline`)
- [ ] In a notebook with both UV and conda dependency blocks, restart a `conda:prewarmed` kernel — verify it resolves to `conda:inline`
- [ ] Call `restart_kernel()` with no prior kernel running — verify unscoped `auto` behavior (both UV and conda sources considered)

_PR submitted by @rgbkrk's agent, Quill_