### PR TITLE
feat(nteract): include runtime info in notebook session responses

### DIFF
--- a/python/nteract/src/nteract/_mcp_server.py
+++ b/python/nteract/src/nteract/_mcp_server.py
@@ -353,8 +353,8 @@ async def _get_single_cell_status(notebook: runtimed.Notebook, cell_id: str) -> 
         return None
 
 
-def _collect_runtime_info(notebook: runtimed.Notebook) -> dict[str, Any]:
-    """Collect runtime info from the notebook's local CRDT replica."""
+def _read_runtime_info(notebook: runtimed.Notebook) -> dict[str, Any]:
+    """Read runtime info snapshot from the notebook's local CRDT replica."""
     info: dict[str, Any] = {}
     try:
         rs = notebook.runtime
@@ -385,6 +385,25 @@ def _collect_runtime_info(notebook: runtimed.Notebook) -> dict[str, Any]:
         if not info:
             info["kernel_status"] = "unknown"
 
+    return info
+
+
+async def _collect_runtime_info(notebook: runtimed.Notebook) -> dict[str, Any]:
+    """Collect runtime info, waiting briefly for the RuntimeStateDoc to sync.
+
+    The daemon writes kernel status (e.g. "starting") to the RuntimeStateDoc
+    after the peer joins, so there's a brief window where the client sees
+    "not_started" even though the kernel is being launched. Poll for up to
+    ~500ms to let the state doc catch up.
+    """
+    info = _read_runtime_info(notebook)
+    if info.get("kernel_status") not in ("not_started", "unknown", ""):
+        return info
+    for _ in range(5):
+        await asyncio.sleep(0.1)
+        info = _read_runtime_info(notebook)
+        if info.get("kernel_status") not in ("not_started", "unknown", ""):
+            return info
     return info
 
 
@@ -861,7 +880,7 @@ class NteractServer:
                 for i, cell in enumerate(srv._notebook.cells)
             ]
 
-            runtime_info = _collect_runtime_info(srv._notebook)
+            runtime_info = await _collect_runtime_info(srv._notebook)
             deps: list[str] = []
             with contextlib.suppress(Exception):
                 deps = await srv._notebook.get_dependencies()
@@ -902,7 +921,7 @@ class NteractServer:
                 for i, cell in enumerate(srv._notebook.cells)
             ]
 
-            runtime_info = _collect_runtime_info(srv._notebook)
+            runtime_info = await _collect_runtime_info(srv._notebook)
             deps: list[str] = []
             with contextlib.suppress(Exception):
                 deps = await srv._notebook.get_dependencies()
@@ -963,7 +982,7 @@ class NteractServer:
                 with contextlib.suppress(Exception):
                     await srv._notebook.restart()
 
-            runtime_info = _collect_runtime_info(srv._notebook)
+            runtime_info = await _collect_runtime_info(srv._notebook)
             if "language" not in runtime_info:
                 runtime_info["language"] = runtime
 

--- a/python/nteract/src/nteract/_mcp_server.py
+++ b/python/nteract/src/nteract/_mcp_server.py
@@ -353,6 +353,41 @@ async def _get_single_cell_status(notebook: runtimed.Notebook, cell_id: str) -> 
         return None
 
 
+def _collect_runtime_info(notebook: runtimed.Notebook) -> dict[str, Any]:
+    """Collect runtime info from the notebook's local CRDT replica."""
+    info: dict[str, Any] = {}
+    try:
+        rs = notebook.runtime
+        kernel = rs.kernel
+
+        info["kernel_status"] = kernel.status
+
+        if kernel.language:
+            info["language"] = kernel.language
+
+        if kernel.name:
+            info["kernel_name"] = kernel.name
+
+        if kernel.env_source:
+            info["env_source"] = kernel.env_source
+            if kernel.env_source.startswith("conda:"):
+                info["package_manager"] = "conda"
+            elif kernel.env_source.startswith("uv:"):
+                info["package_manager"] = "uv"
+            elif kernel.env_source == "deno":
+                info["package_manager"] = "deno"
+
+        env = rs.env
+        if not env.in_sync:
+            info["env_in_sync"] = False
+
+    except Exception:
+        if not info:
+            info["kernel_status"] = "unknown"
+
+    return info
+
+
 def _format_cell_summary(
     index: int,
     cell: runtimed.CellHandle,
@@ -826,9 +861,16 @@ class NteractServer:
                 for i, cell in enumerate(srv._notebook.cells)
             ]
 
+            runtime_info = _collect_runtime_info(srv._notebook)
+            deps: list[str] = []
+            with contextlib.suppress(Exception):
+                deps = await srv._notebook.get_dependencies()
+
             return {
                 "notebook_id": srv._notebook.notebook_id,
                 "connected": True,
+                "runtime": runtime_info,
+                "dependencies": deps,
                 "cells": "\n".join(lines),
             }
 
@@ -860,9 +902,16 @@ class NteractServer:
                 for i, cell in enumerate(srv._notebook.cells)
             ]
 
+            runtime_info = _collect_runtime_info(srv._notebook)
+            deps: list[str] = []
+            with contextlib.suppress(Exception):
+                deps = await srv._notebook.get_dependencies()
+
             return {
                 "notebook_id": srv._notebook.notebook_id,
                 "path": path,
+                "runtime": runtime_info,
+                "dependencies": deps,
                 "cells": "\n".join(lines),
             }
 
@@ -914,9 +963,13 @@ class NteractServer:
                 with contextlib.suppress(Exception):
                     await srv._notebook.restart()
 
+            runtime_info = _collect_runtime_info(srv._notebook)
+            if "language" not in runtime_info:
+                runtime_info["language"] = runtime
+
             return {
                 "notebook_id": srv._notebook.notebook_id,
-                "runtime": runtime,
+                "runtime": runtime_info,
                 "dependencies": dependencies or [],
             }
 

--- a/python/nteract/tests/test_mcp_integration.py
+++ b/python/nteract/tests/test_mcp_integration.py
@@ -163,7 +163,7 @@ async def test_create_notebook_and_cell(mcp_client: ClientSession):
     result = await mcp_client.call_tool("create_notebook", {})
     data = _parse_json(result)
     assert "notebook_id" in data
-    assert data["runtime"] == "python"
+    assert data["runtime"]["language"] == "python"
 
     # Create cell (returns plain text)
     result = await mcp_client.call_tool(


### PR DESCRIPTION
## Summary

- Adds a `_collect_runtime_info` helper that reads `notebook.runtime` from the local CRDT replica and returns a structured dict with kernel status, language, env source, package manager, and env sync state
- `join_notebook`, `open_notebook`, and `create_notebook` MCP tools now return a `runtime` dict and `dependencies` list, giving agents immediate visibility into the notebook's runtime context
- Fields are included only when non-empty, so responses stay concise when the kernel hasn't started yet

## Example response

```json
{
  "runtime": {
    "kernel_status": "idle",
    "language": "python",
    "env_source": "uv:inline",
    "package_manager": "uv",
    "kernel_name": "charming-toucan"
  },
  "dependencies": ["pandas", "requests"]
}
```

## Verification

- [ ] `create_notebook` returns a `runtime` dict with at least `kernel_status` and `language`
- [ ] `open_notebook` on an existing `.ipynb` returns `runtime` and `dependencies`
- [ ] `join_notebook` on an active session returns `runtime` and `dependencies`
- [ ] When kernel is not started, `runtime` gracefully shows `{"kernel_status": "not_started"}`
- [ ] When kernel is running with uv, `package_manager` is `"uv"` and `env_source` is populated

_PR submitted by @rgbkrk's agent, Quill_