### PR TITLE
fix(editor): adjust cell top padding for visually centered single-line code

### DIFF
--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -454,7 +454,6 @@ export const CodeCell = memo(function CodeCell({
                 keyMap={keyMap}
                 extensions={editorExtensions}
                 placeholder="Enter code..."
-
                 autoFocus={isFocused}
               />
             )}

--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -454,7 +454,7 @@ export const CodeCell = memo(function CodeCell({
                 keyMap={keyMap}
                 extensions={editorExtensions}
                 placeholder="Enter code..."
-                className="min-h-[2rem]"
+
                 autoFocus={isFocused}
               />
             )}

--- a/src/components/cell/CellContainer.tsx
+++ b/src/components/cell/CellContainer.tsx
@@ -86,7 +86,7 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
         onMouseDown={onFocus}
       >
         {/* Gutter area - action content only (ribbon moves to content rows for segmented) */}
-        <div className="flex w-10 flex-shrink-0 flex-col items-end justify-start gap-0.5 pr-1 pt-3 select-none">
+        <div className="flex w-10 flex-shrink-0 flex-col items-end justify-start gap-0.5 pr-1 pt-4 select-none">
           {gutterContent}
           {presenceIndicators}
         </div>
@@ -105,7 +105,7 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
                   isDragging && "cursor-grabbing",
                 )}
               />
-              <div className="min-w-0 flex-1 pb-3 pl-6 pr-3">{codeContent}</div>
+              <div className="min-w-0 flex-1 pt-1.5 pb-3 pl-6 pr-3">{codeContent}</div>
               {/* Code row right gutter */}
               {rightGutterContent && (
                 <div
@@ -167,7 +167,7 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
                   isDragging && "cursor-grabbing",
                 )}
               />
-              <div className="min-w-0 flex-1 pb-3 pl-6 pr-3">{children}</div>
+              <div className="min-w-0 flex-1 pt-1.5 pb-3 pl-6 pr-3">{children}</div>
             </div>
             {/* Right margin for legacy layout */}
             {rightGutterContent && (

--- a/src/components/editor/extensions.ts
+++ b/src/components/editor/extensions.ts
@@ -29,9 +29,6 @@ export const notebookEditorTheme = EditorView.theme({
   // (overrides theme's background)
   "&.cm-editor": {
     backgroundColor: "transparent",
-    // Pull the editor up to compensate for the extra .cm-content paddingTop
-    // that reserves space for peer cursor labels above line 1.
-    marginTop: "-0.5rem",
   },
   // Remove focus dotted outline
   "&.cm-focused": {
@@ -40,7 +37,7 @@ export const notebookEditorTheme = EditorView.theme({
   // Top padding inside editor so peer cursor labels have room above line 1
   // Flag is ~19px tall (11px font × 1.2 line-height + 4px padding + 1px margin)
   ".cm-content": {
-    paddingTop: "1.25rem",
+    paddingTop: "0.625rem",
   },
   // Reset line padding so code aligns with output areas
   // (CodeMirror's base theme adds "padding: 0 2px 0 6px" to .cm-line)

--- a/src/components/editor/extensions.ts
+++ b/src/components/editor/extensions.ts
@@ -29,6 +29,9 @@ export const notebookEditorTheme = EditorView.theme({
   // (overrides theme's background)
   "&.cm-editor": {
     backgroundColor: "transparent",
+    // Pull the editor up to compensate for the extra .cm-content paddingTop
+    // that reserves space for peer cursor labels above line 1.
+    marginTop: "-0.75rem",
   },
   // Remove focus dotted outline
   "&.cm-focused": {
@@ -37,7 +40,7 @@ export const notebookEditorTheme = EditorView.theme({
   // Top padding inside editor so peer cursor labels have room above line 1
   // Flag is ~19px tall (11px font × 1.2 line-height + 4px padding + 1px margin)
   ".cm-content": {
-    paddingTop: "0.625rem",
+    paddingTop: "1.375rem",
   },
   // Reset line padding so code aligns with output areas
   // (CodeMirror's base theme adds "padding: 0 2px 0 6px" to .cm-line)


### PR DESCRIPTION
## Summary

- Rebalances `.cm-content` paddingTop (`1.25rem` → `1.375rem`) and `.cm-editor` marginTop (`-0.5rem` → `-0.75rem`) so peer cursor labels above line 1 are not clipped while keeping single-line code visually centered
- Restores `pt-1.5` on cell content wrappers and bumps gutter `pt-3` → `pt-4` to align the execution count with the first code line
- Removes unnecessary `min-h-[2rem]` from the CodeCell editor wrapper

## Before / After

<!-- Add screenshots here -->

## Verification

- [ ] Single-line code cells look visually centered (code + execution count aligned)
- [ ] Multi-line cells still look correct with no extra top gap
- [ ] Peer cursor labels on line 1 are fully visible (not clipped)
- [ ] Markdown cells render with correct spacing
- [ ] Creating a new empty cell has reasonable height

_PR submitted by @rgbkrk's agent, Quill_