### PR TITLE
fix: resolve clippy and biome lint errors

### DIFF
--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -95,7 +95,7 @@ pub enum FrameEvent {
         changed: bool,
         /// The full current runtime state snapshot (only when changed).
         #[serde(skip_serializing_if = "Option::is_none")]
-        state: Option<RuntimeState>,
+        state: Option<Box<RuntimeState>>,
     },
     /// Unknown frame type — frontend can log and ignore.
     Unknown { frame_type: u8 },
@@ -1025,7 +1025,7 @@ impl NotebookHandle {
                 let changed = heads_before != heads_after;
 
                 let state = if changed {
-                    Some(self.state_doc.read_state())
+                    Some(Box::new(self.state_doc.read_state()))
                 } else {
                     None
                 };

--- a/e2e/specs/cell-visibility.spec.js
+++ b/e2e/specs/cell-visibility.spec.js
@@ -16,11 +16,7 @@
  */
 
 import { browser } from "@wdio/globals";
-import {
-  setCellSource,
-  waitForAppReady,
-  waitForNotebookSynced,
-} from "../helpers.js";
+import { waitForAppReady, waitForNotebookSynced } from "../helpers.js";
 
 /**
  * Focus a code cell by clicking its editor area.

--- a/e2e/specs/deno.spec.js
+++ b/e2e/specs/deno.spec.js
@@ -10,7 +10,6 @@
  *   e2e/specs/deno.spec.js
  */
 
-import { browser } from "@wdio/globals";
 import {
   setCellSource,
   waitForCellOutput,


### PR DESCRIPTION
## Summary

- Box `RuntimeState` in `FrameEvent::RuntimeStateSyncApplied` to fix clippy `large_enum_variant` error (353 bytes vs 129 in other variants)
- Remove unused `setCellSource` import in `e2e/specs/cell-visibility.spec.js`
- Remove unused `browser` import in `e2e/specs/deno.spec.js`

## Verification

- [ ] CI passes clippy, biome, and ruff checks
- [ ] WASM crate compiles without warnings

_PR submitted by @rgbkrk's agent, Quill_