### PR TITLE
refactor: redirect notebook/runt/runtimed-py imports to source crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3588,6 +3588,8 @@ dependencies = [
  "log",
  "nbformat",
  "nix 0.30.1",
+ "notebook-doc",
+ "notebook-protocol",
  "notebook-sync",
  "pathdiff",
  "pyproject-toml",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5733,6 +5733,7 @@ dependencies = [
  "jupyter-protocol",
  "kernel-env",
  "libc",
+ "notebook-doc",
  "notify",
  "petname",
  "rpassword",

--- a/crates/notebook/Cargo.toml
+++ b/crates/notebook/Cargo.toml
@@ -32,6 +32,8 @@ uuid = { workspace = true }
 tokio = { workspace = true }
 anyhow = { workspace = true }
 runtimed = { path = "../runtimed" }
+notebook-doc = { path = "../notebook-doc" }
+notebook-protocol = { path = "../notebook-protocol" }
 notebook-sync = { path = "../notebook-sync" }
 runt-trust = { path = "../runt-trust" }
 runt-workspace = { path = "../runt-workspace" }

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -15,8 +15,10 @@ pub mod uv_env;
 
 pub use runtimed::runtime::Runtime;
 
+use notebook_protocol::protocol::{
+    CompletionItem, HistoryEntry, NotebookRequest, NotebookResponse,
+};
 use notebook_sync::RelayHandle;
-use runtimed::protocol::{CompletionItem, HistoryEntry, NotebookRequest, NotebookResponse};
 
 use log::{debug, info, warn};
 use serde::Serialize;
@@ -271,7 +273,7 @@ where
 /// Returns the deserialized NotebookMetadataSnapshot, or None if not available.
 async fn get_metadata_snapshot(
     handle: &RelayHandle,
-) -> Option<runtimed::notebook_metadata::NotebookMetadataSnapshot> {
+) -> Option<notebook_doc::metadata::NotebookMetadataSnapshot> {
     match handle
         .send_request(NotebookRequest::GetMetadataSnapshot {})
         .await
@@ -286,7 +288,7 @@ async fn get_metadata_snapshot(
 /// Write a NotebookMetadataSnapshot to the daemon's canonical Automerge doc.
 async fn set_metadata_snapshot(
     handle: &RelayHandle,
-    snapshot: &runtimed::notebook_metadata::NotebookMetadataSnapshot,
+    snapshot: &notebook_doc::metadata::NotebookMetadataSnapshot,
 ) -> Result<(), String> {
     let snapshot_json =
         serde_json::to_string(snapshot).map_err(|e| format!("serialize metadata: {}", e))?;
@@ -334,7 +336,7 @@ async fn set_raw_trust_in_metadata(
 /// Reconstruct an nbformat Metadata from a NotebookMetadataSnapshot.
 /// Used to bridge sync-handle metadata to extraction functions that expect nbformat types.
 fn metadata_from_snapshot(
-    snapshot: &runtimed::notebook_metadata::NotebookMetadataSnapshot,
+    snapshot: &notebook_doc::metadata::NotebookMetadataSnapshot,
 ) -> nbformat::v4::Metadata {
     let mut metadata = nbformat::v4::Metadata {
         kernelspec: snapshot
@@ -366,11 +368,11 @@ fn metadata_from_snapshot(
 }
 
 /// Helper to create a default empty NotebookMetadataSnapshot.
-fn default_metadata_snapshot() -> runtimed::notebook_metadata::NotebookMetadataSnapshot {
-    runtimed::notebook_metadata::NotebookMetadataSnapshot {
+fn default_metadata_snapshot() -> notebook_doc::metadata::NotebookMetadataSnapshot {
+    notebook_doc::metadata::NotebookMetadataSnapshot {
         kernelspec: None,
         language_info: None,
-        runt: runtimed::notebook_metadata::RuntMetadata {
+        runt: notebook_doc::metadata::RuntMetadata {
             schema_version: "1".to_string(),
             env_id: None,
             uv: None,
@@ -389,8 +391,8 @@ fn default_metadata_snapshot() -> runtimed::notebook_metadata::NotebookMetadataS
 /// locally then need to push it to the daemon as a typed snapshot.
 fn snapshot_from_nbformat(
     metadata: &nbformat::v4::Metadata,
-) -> runtimed::notebook_metadata::NotebookMetadataSnapshot {
-    use runtimed::notebook_metadata::*;
+) -> notebook_doc::metadata::NotebookMetadataSnapshot {
+    use notebook_doc::metadata::*;
 
     let kernelspec = metadata.kernelspec.as_ref().map(|ks| KernelspecSnapshot {
         name: ks.name.clone(),
@@ -490,7 +492,7 @@ async fn initialize_notebook_sync_open(
 ) -> Result<(), String> {
     let current_generation = sync_generation.fetch_add(1, Ordering::SeqCst) + 1;
 
-    let socket_path = runtimed::default_socket_path();
+    let socket_path = runt_workspace::default_socket_path();
     info!(
         "[notebook-sync] Opening notebook via daemon: {} ({})",
         path.display(),
@@ -551,7 +553,7 @@ async fn initialize_notebook_sync_create(
 ) -> Result<(), String> {
     let current_generation = sync_generation.fetch_add(1, Ordering::SeqCst) + 1;
 
-    let socket_path = runtimed::default_socket_path();
+    let socket_path = runt_workspace::default_socket_path();
     info!(
         "[notebook-sync] Creating notebook via daemon: runtime={}, working_dir={:?}, notebook_id_hint={:?} ({})",
         runtime,
@@ -830,7 +832,7 @@ where
         });
 
         if client.ping().await.is_ok() {
-            let endpoint = runtimed::default_socket_path()
+            let endpoint = runt_workspace::default_socket_path()
                 .to_string_lossy()
                 .to_string();
             log::info!(
@@ -1198,7 +1200,7 @@ where
     let client = PoolClient::default();
     if let Ok(()) = client.ping().await {
         // Daemon is running - check version alignment (production only)
-        if !runtimed::is_dev_mode() {
+        if !runt_workspace::is_dev_mode() {
             let bundled_version = bundled_daemon_version();
             if let Some(info) = runtimed::singleton::get_running_daemon_info() {
                 // Compare commit hashes only - CI appends "+{git_sha}" to the version
@@ -1222,7 +1224,7 @@ where
             }
         }
 
-        let endpoint = runtimed::default_socket_path()
+        let endpoint = runt_workspace::default_socket_path()
             .to_string_lossy()
             .to_string();
         log::info!("[startup] Daemon already running at {}", endpoint);
@@ -1233,7 +1235,7 @@ where
     }
 
     // In dev mode, don't auto-install - user should run dev-daemon manually
-    if runtimed::is_dev_mode() {
+    if runt_workspace::is_dev_mode() {
         log::info!("[startup] Dev mode: daemon not running, skipping auto-install");
         let guidance = "Start it with: cargo xtask dev-daemon".to_string();
         on_progress(DaemonProgress::Failed {
@@ -1242,7 +1244,7 @@ where
         });
         return Err(format!(
             "Dev daemon not running at {:?}. {}",
-            runtimed::default_socket_path(),
+            runt_workspace::default_socket_path(),
             guidance
         ));
     }
@@ -1310,7 +1312,7 @@ where
         });
 
         if client.ping().await.is_ok() {
-            let endpoint = runtimed::default_socket_path()
+            let endpoint = runt_workspace::default_socket_path()
                 .to_string_lossy()
                 .to_string();
             log::info!(
@@ -1389,7 +1391,7 @@ async fn get_daemon_info() -> Option<DaemonInfoForBanner> {
             .and_then(|v| v.as_str())
             .map(|s| s.to_string())
             .unwrap_or_else(|| {
-                runtimed::default_socket_path()
+                runt_workspace::default_socket_path()
                     .to_string_lossy()
                     .to_string()
             });
@@ -1404,7 +1406,7 @@ async fn get_daemon_info() -> Option<DaemonInfoForBanner> {
         } else {
             socket_path_full
         };
-        let is_dev_mode = runtimed::is_dev_mode();
+        let is_dev_mode = runt_workspace::is_dev_mode();
         Some(DaemonInfoForBanner {
             version,
             socket_path,
@@ -1834,7 +1836,7 @@ fn create_notebook_window_for_daemon(
         {
             format!("notebook-{}", &id[..8.min(id.len())])
         } else if let Some(ref p) = path {
-            let hash = runtimed::worktree_hash(p);
+            let hash = runt_workspace::worktree_hash(p);
             format!("notebook-{}", &hash[..8])
         } else {
             format!("notebook-{}", uuid::Uuid::new_v4())
@@ -2491,7 +2493,7 @@ async fn reconnect_to_daemon(
             info!("[daemon-kernel] Daemon appears dead: {}", e);
 
             // In dev mode, don't attempt recovery - show helpful guidance
-            if runtimed::is_dev_mode() {
+            if runt_workspace::is_dev_mode() {
                 reset_flag();
                 return Err(
                     "Dev daemon not running. Start it with: cargo xtask dev-daemon".to_string(),
@@ -2627,7 +2629,7 @@ async fn send_frame_bytes(
     let guard = notebook_sync.lock().await;
     let handle = guard.as_ref().ok_or("Not connected to daemon")?;
 
-    use runtimed::notebook_doc::frame_types;
+    use notebook_doc::frame_types;
 
     let frame_type = frame_data[0];
     let payload = &frame_data[1..];
@@ -3080,7 +3082,7 @@ async fn get_synced_settings() -> Result<runtimed::settings_doc::SyncedSettings,
 /// after receiving the sync message.
 #[tauri::command]
 async fn set_synced_setting(key: String, value: serde_json::Value) -> Result<(), String> {
-    let socket_path = runtimed::default_socket_path();
+    let socket_path = runt_workspace::default_socket_path();
     let mut client = runtimed::sync_client::SyncClient::connect_with_timeout(
         socket_path,
         std::time::Duration::from_millis(500),
@@ -3325,7 +3327,7 @@ async fn get_default_save_directory() -> Result<String, String> {
 async fn run_settings_sync(app: tauri::AppHandle) {
     use tauri::Emitter;
 
-    let socket_path = runtimed::default_socket_path();
+    let socket_path = runt_workspace::default_socket_path();
 
     loop {
         match runtimed::sync_client::SyncClient::connect(socket_path.clone()).await {
@@ -3580,7 +3582,7 @@ fn correct_window_scale(window: &tauri::WebviewWindow, saved_scale_factor: Optio
 /// for project file detection (pyproject.toml, pixi.toml, environment.yaml).
 pub fn run(notebook_path: Option<PathBuf>, runtime: Option<Runtime>) -> anyhow::Result<()> {
     // Initialize logging - write to both stderr and log file (same pattern as runtimed)
-    let log_path = runtimed::default_notebook_log_path();
+    let log_path = runt_workspace::default_notebook_log_path();
     if let Some(parent) = log_path.parent() {
         std::fs::create_dir_all(parent).ok();
     }
@@ -3669,7 +3671,7 @@ pub fn run(notebook_path: Option<PathBuf>, runtime: Option<Runtime>) -> anyhow::
             .and_then(|n| n.to_str())
             .unwrap_or("Untitled.ipynb")
             .to_string();
-        let hash = runtimed::worktree_hash(path);
+        let hash = runt_workspace::worktree_hash(path);
         vec![StartupWindow {
             label: format!("notebook-{}", &hash[..8]),
             title,

--- a/crates/notebook/src/session.rs
+++ b/crates/notebook/src/session.rs
@@ -52,7 +52,7 @@ pub(crate) fn save_session<R: tauri::Runtime>(
     registry: &WindowNotebookRegistry,
     app: &tauri::AppHandle<R>,
 ) -> Result<(), String> {
-    save_session_to(registry, app, &runtimed::session_state_path())
+    save_session_to(registry, app, &runt_workspace::session_state_path())
 }
 
 /// Save the current session state to a specific path.
@@ -160,7 +160,7 @@ fn write_session(windows: Vec<WindowSession>, dest: &std::path::Path) -> Result<
 /// - Session is too old (> 24 hours)
 /// - Session file is corrupted
 pub fn load_session() -> Option<SessionState> {
-    load_session_from(&runtimed::session_state_path())
+    load_session_from(&runt_workspace::session_state_path())
 }
 
 /// Load session state from a specific path.
@@ -209,7 +209,7 @@ pub(crate) fn load_session_from(path: &std::path::Path) -> Option<SessionState> 
 /// Used for one-time migrations (e.g., renaming stale window labels) where
 /// the session data is needed even if it would be too old for restore.
 pub fn load_session_ignoring_age() -> Option<SessionState> {
-    let path = runtimed::session_state_path();
+    let path = runt_workspace::session_state_path();
     if !path.exists() {
         return None;
     }
@@ -219,7 +219,7 @@ pub fn load_session_ignoring_age() -> Option<SessionState> {
 
 /// Delete the session file after successful restore.
 pub fn clear_session() {
-    clear_session_at(&runtimed::session_state_path());
+    clear_session_at(&runt_workspace::session_state_path());
 }
 
 /// Delete a specific session file.
@@ -239,7 +239,7 @@ pub(crate) fn clear_session_at(path: &std::path::Path) {
 pub fn window_label_for_session(session: &WindowSession) -> String {
     if let Some(path) = &session.path {
         // Hash the path for a stable label
-        let hash = runtimed::worktree_hash(path);
+        let hash = runt_workspace::worktree_hash(path);
         format!("notebook-{}", &hash[..8])
     } else if let Some(env_id) = &session.env_id {
         // Use env_id prefix for untitled notebooks
@@ -254,8 +254,8 @@ pub fn window_label_for_session(session: &WindowSession) -> String {
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
+    use crate::Runtime;
     use crate::WindowNotebookContext;
-    use runtimed::runtime::Runtime;
     use std::path::PathBuf;
     use std::sync::atomic::{AtomicBool, AtomicU64};
     use std::sync::{Arc, Mutex};

--- a/crates/notebook/src/settings.rs
+++ b/crates/notebook/src/settings.rs
@@ -20,7 +20,7 @@ pub use runtimed::settings_doc::{CondaDefaults, PythonEnvType, ThemeMode, UvDefa
 
 /// Get the path to the settings file
 fn settings_path() -> PathBuf {
-    runtimed::settings_json_path()
+    runt_workspace::settings_json_path()
 }
 
 /// Load settings from disk, returning defaults if file doesn't exist.
@@ -163,7 +163,7 @@ mod tests {
     #[test]
     fn test_settings_path_is_valid() {
         let path = settings_path();
-        let expected = format!("{}/settings.json", runtimed::config_namespace());
+        let expected = format!("{}/settings.json", runt_workspace::config_namespace());
         assert!(path.ends_with(&expected));
     }
 

--- a/crates/runt-workspace/src/lib.rs
+++ b/crates/runt-workspace/src/lib.rs
@@ -658,6 +658,91 @@ fn ensure_dir_exists(dir: &Path) -> Result<(), String> {
     }
 }
 
+// ============================================================================
+// Socket and Config Path Helpers
+// ============================================================================
+
+/// Get the default endpoint path for runtimed using the compile-time channel.
+///
+/// Respects `RUNTIMED_SOCKET_PATH` if set. Otherwise delegates to
+/// `socket_path_for_channel(build_channel())`.
+pub fn default_socket_path() -> PathBuf {
+    if let Some(path) = socket_path_from_env() {
+        return path;
+    }
+    socket_path_for_channel(build_channel())
+}
+
+/// Get the endpoint path for a specific channel's daemon.
+///
+/// On Unix: `~/.cache/{namespace}/runtimed.sock` (or per-worktree in dev mode).
+/// On Windows: `\\.\pipe\{daemon_name}` (with worktree hash suffix in dev mode).
+///
+/// Does **not** check `RUNTIMED_SOCKET_PATH` — that's an override for the
+/// caller's own daemon, not for cross-channel discovery.
+#[cfg(unix)]
+pub fn socket_path_for_channel(channel: BuildChannel) -> PathBuf {
+    daemon_base_dir_for(channel).join("runtimed.sock")
+}
+
+/// Get the endpoint path for a specific channel's daemon (Windows).
+#[cfg(windows)]
+pub fn socket_path_for_channel(channel: BuildChannel) -> PathBuf {
+    let pipe_name = daemon_binary_basename_for(channel);
+    if is_dev_mode() {
+        if let Some(worktree) = get_workspace_path() {
+            let hash = worktree_hash(&worktree);
+            return PathBuf::from(format!(r"\\.\pipe\{}-{}", pipe_name, hash));
+        }
+    }
+    PathBuf::from(format!(r"\\.\pipe\{}", pipe_name))
+}
+
+/// Check `RUNTIMED_SOCKET_PATH` env var and return the path if valid.
+fn socket_path_from_env() -> Option<PathBuf> {
+    let p = std::env::var("RUNTIMED_SOCKET_PATH").ok()?;
+    let p = p.trim();
+    if p.is_empty() {
+        return None;
+    }
+    let path = PathBuf::from(p);
+    if let Some(parent) = path.parent() {
+        if parent.exists() {
+            return Some(path);
+        }
+        panic!(
+            "RUNTIMED_SOCKET_PATH directory does not exist: {}",
+            parent.display()
+        );
+    }
+    Some(path)
+}
+
+/// Get the path to the JSON settings file (for migration and fallback).
+pub fn settings_json_path() -> PathBuf {
+    dirs::config_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(config_namespace())
+        .join("settings.json")
+}
+
+/// Get the path to the session state file.
+///
+/// In dev mode: stored per-worktree for isolation during development.
+/// In production: stored in config directory alongside settings.
+pub fn session_state_path() -> PathBuf {
+    if is_dev_mode() {
+        // Per-worktree session for dev isolation
+        daemon_base_dir().join("session.json")
+    } else {
+        // Production: config directory
+        dirs::config_dir()
+            .unwrap_or_else(|| PathBuf::from("."))
+            .join(config_namespace())
+            .join("session.json")
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {

--- a/crates/runt/Cargo.toml
+++ b/crates/runt/Cargo.toml
@@ -22,6 +22,7 @@ uuid = { workspace = true }
 jupyter-protocol = { workspace = true }
 runtimelib = { workspace = true, features = ["tokio-runtime", "aws-lc-rs"] }
 runtimed = { path = "../runtimed" }
+notebook-doc = { path = "../notebook-doc" }
 runt-workspace = { path = "../runt-workspace" }
 kernel-env = { path = "../kernel-env" }
 clap = { version = "4.5.1", features = ["derive", "color"] }

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -4028,7 +4028,7 @@ fn find_latest_snapshot(snapshots_dir: &std::path::Path, stem: &str) -> Option<s
 }
 
 /// Export a NotebookDoc to .ipynb JSON.
-fn doc_to_ipynb(doc: &runtimed::notebook_doc::NotebookDoc) -> serde_json::Value {
+fn doc_to_ipynb(doc: &notebook_doc::NotebookDoc) -> serde_json::Value {
     let cells = doc.get_cells();
     let metadata_snapshot = doc.get_metadata_snapshot();
 
@@ -4133,7 +4133,7 @@ fn recover_notebook(
     output: Option<&std::path::Path>,
     list: bool,
 ) -> Result<()> {
-    use runtimed::notebook_doc::{notebook_doc_filename, NotebookDoc};
+    use notebook_doc::{notebook_doc_filename, NotebookDoc};
 
     if list {
         let dirs = all_notebook_docs_dirs();
@@ -4384,7 +4384,7 @@ mod tests {
 
     #[test]
     fn test_find_automerge_file_live_doc() {
-        use runtimed::notebook_doc::NotebookDoc;
+        use notebook_doc::NotebookDoc;
 
         let tmp = tempfile::tempdir().unwrap();
         let docs_dir = tmp.path().to_path_buf();
@@ -4403,7 +4403,7 @@ mod tests {
 
     #[test]
     fn test_find_automerge_file_snapshot_fallback() {
-        use runtimed::notebook_doc::NotebookDoc;
+        use notebook_doc::NotebookDoc;
 
         let tmp = tempfile::tempdir().unwrap();
         let docs_dir = tmp.path().to_path_buf();
@@ -4457,7 +4457,7 @@ mod tests {
 
     #[test]
     fn test_notebook_doc_filename_deterministic() {
-        use runtimed::notebook_doc::notebook_doc_filename;
+        use notebook_doc::notebook_doc_filename;
 
         let path = "/Users/test/notebook.ipynb";
         let a = notebook_doc_filename(path);
@@ -4474,7 +4474,7 @@ mod tests {
 
     #[test]
     fn test_doc_to_ipynb_basic() {
-        use runtimed::notebook_doc::NotebookDoc;
+        use notebook_doc::NotebookDoc;
 
         let mut doc = NotebookDoc::new("test");
         doc.add_cell(0, "cell-1", "code").unwrap();
@@ -4513,7 +4513,7 @@ mod tests {
 
     #[test]
     fn test_doc_to_ipynb_multiline_source() {
-        use runtimed::notebook_doc::NotebookDoc;
+        use notebook_doc::NotebookDoc;
 
         let mut doc = NotebookDoc::new("test");
         doc.add_cell(0, "cell-1", "code").unwrap();
@@ -4531,7 +4531,7 @@ mod tests {
 
     #[test]
     fn test_doc_to_ipynb_empty_source() {
-        use runtimed::notebook_doc::NotebookDoc;
+        use notebook_doc::NotebookDoc;
 
         let mut doc = NotebookDoc::new("test");
         doc.add_cell(0, "cell-1", "code").unwrap();

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -1480,14 +1480,14 @@ async fn daemon_command(command: DaemonCommands) -> Result<()> {
             } else {
                 None
             };
-            let is_dev = runtimed::is_dev_mode();
+            let is_dev = runt_workspace::is_dev_mode();
 
             // Get socket path from daemon info or default
             let socket_path = daemon_info
                 .as_ref()
                 .map(|i| i.endpoint.clone())
                 .unwrap_or_else(|| {
-                    runtimed::default_socket_path()
+                    runt_workspace::default_socket_path()
                         .to_string_lossy()
                         .to_string()
                 });
@@ -1855,7 +1855,7 @@ async fn doctor_command(
     ) -> DoctorReport {
         // Get expected paths - use service.rs paths for consistency
         let binary_path = runtimed::service::default_binary_path();
-        let socket_path = runtimed::default_socket_path();
+        let socket_path = runt_workspace::default_socket_path();
         let daemon_json_path = runtimed::singleton::daemon_info_path();
         let service_config_path = runtimed::service::service_config_path();
 
@@ -2275,7 +2275,7 @@ async fn doctor_command(
 
     // Get paths for fix operations
     let binary_path = runtimed::service::default_binary_path();
-    let socket_path = runtimed::default_socket_path();
+    let socket_path = runt_workspace::default_socket_path();
     let daemon_json_path = runtimed::singleton::daemon_info_path();
     let service_config_path = runtimed::service::service_config_path();
 
@@ -2927,7 +2927,7 @@ async fn diagnostics_command(output_dir: Option<PathBuf>) -> Result<()> {
     }
 
     // 2. Notebook log
-    let notebook_log = runtimed::default_notebook_log_path();
+    let notebook_log = runt_workspace::default_notebook_log_path();
     if notebook_log.exists() {
         tar.append_path_with_name(&notebook_log, "notebook.log")?;
         println!("  {} notebook.log", "✓".green());

--- a/crates/runtimed-py/src/async_session.rs
+++ b/crates/runtimed-py/src/async_session.rs
@@ -677,7 +677,7 @@ impl AsyncSession {
         future_into_py(py, async move {
             session_core::connect(&state, &notebook_id).await?;
             let mut snapshot = session_core::get_notebook_metadata(&state).await?;
-            snapshot.kernelspec = Some(runtimed::notebook_metadata::KernelspecSnapshot {
+            snapshot.kernelspec = Some(notebook_doc::metadata::KernelspecSnapshot {
                 name,
                 display_name,
                 language,

--- a/crates/runtimed-py/src/daemon_paths.rs
+++ b/crates/runtimed-py/src/daemon_paths.rs
@@ -26,7 +26,7 @@ pub fn get_socket_path() -> PathBuf {
     if let Ok(p) = std::env::var("RUNTIMED_SOCKET_PATH") {
         PathBuf::from(p)
     } else {
-        runtimed::default_socket_path()
+        runt_workspace::default_socket_path()
     }
 }
 

--- a/crates/runtimed-py/src/lib.rs
+++ b/crates/runtimed-py/src/lib.rs
@@ -47,16 +47,16 @@ fn show_notebook_app(notebook_path: Option<PathBuf>) -> PyResult<()> {
 /// In dev mode (RUNTIMED_WORKSPACE_PATH set), returns the per-worktree socket path.
 #[pyfunction]
 fn default_socket_path() -> String {
-    ::runtimed::default_socket_path()
+    runt_workspace::default_socket_path()
         .to_string_lossy()
         .to_string()
 }
 
 /// Parse a channel name string into a BuildChannel enum.
-fn parse_channel(channel: &str) -> PyResult<::runtimed::BuildChannel> {
+fn parse_channel(channel: &str) -> PyResult<runt_workspace::BuildChannel> {
     match channel {
-        "stable" => Ok(::runtimed::BuildChannel::Stable),
-        "nightly" => Ok(::runtimed::BuildChannel::Nightly),
+        "stable" => Ok(runt_workspace::BuildChannel::Stable),
+        "nightly" => Ok(runt_workspace::BuildChannel::Nightly),
         _ => Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
             "channel must be \"stable\" or \"nightly\", got {:?}",
             channel
@@ -78,7 +78,7 @@ fn parse_channel(channel: &str) -> PyResult<::runtimed::BuildChannel> {
 #[pyfunction]
 fn socket_path_for_channel(channel: &str) -> PyResult<String> {
     let ch = parse_channel(channel)?;
-    Ok(::runtimed::socket_path_for_channel(ch)
+    Ok(runt_workspace::socket_path_for_channel(ch)
         .to_string_lossy()
         .to_string())
 }

--- a/crates/runtimed-py/src/output.rs
+++ b/crates/runtimed-py/src/output.rs
@@ -316,7 +316,7 @@ impl Cell {
 
     /// Create a Cell from a CellSnapshot without resolving outputs.
     /// Use `from_snapshot_with_outputs` to include resolved outputs.
-    pub fn from_snapshot(snapshot: runtimed::notebook_doc::CellSnapshot) -> Self {
+    pub fn from_snapshot(snapshot: notebook_doc::CellSnapshot) -> Self {
         // Parse execution_count from JSON string ("5" or "null")
         let execution_count = snapshot.execution_count.parse::<i64>().ok();
         let metadata_json =
@@ -335,7 +335,7 @@ impl Cell {
 
     /// Create a Cell from a CellSnapshot with pre-resolved outputs.
     pub fn from_snapshot_with_outputs(
-        snapshot: runtimed::notebook_doc::CellSnapshot,
+        snapshot: notebook_doc::CellSnapshot,
         outputs: Vec<Output>,
     ) -> Self {
         let execution_count = snapshot.execution_count.parse::<i64>().ok();

--- a/crates/runtimed/src/lib.rs
+++ b/crates/runtimed/src/lib.rs
@@ -55,9 +55,10 @@ pub mod terminal_size;
 pub use runt_workspace::{
     build_channel, cache_namespace, cache_namespace_for, config_namespace, daemon_base_dir,
     daemon_base_dir_for, daemon_binary_basename, daemon_binary_basename_for, daemon_launchd_label,
-    daemon_service_basename, default_notebook_log_path, desktop_display_name,
+    daemon_service_basename, default_notebook_log_path, default_socket_path, desktop_display_name,
     desktop_display_name_for, desktop_product_name, get_workspace_name, get_workspace_path,
-    is_dev_mode, open_notebook_app_for_channel, worktree_hash, BuildChannel,
+    is_dev_mode, open_notebook_app_for_channel, session_state_path, settings_json_path,
+    socket_path_for_channel, worktree_hash, BuildChannel,
 };
 
 /// Get the default log path for the daemon.
@@ -133,62 +134,6 @@ pub struct PoolError {
     pub retry_in_secs: u64,
 }
 
-/// Get the default endpoint path for runtimed using the compile-time channel.
-///
-/// Respects `RUNTIMED_SOCKET_PATH` if set. Otherwise delegates to
-/// `socket_path_for_channel(build_channel())`.
-pub fn default_socket_path() -> PathBuf {
-    if let Some(path) = socket_path_from_env() {
-        return path;
-    }
-    socket_path_for_channel(build_channel())
-}
-
-/// Get the endpoint path for a specific channel's daemon.
-///
-/// On Unix: `~/.cache/{namespace}/runtimed.sock` (or per-worktree in dev mode).
-/// On Windows: `\\.\pipe\{daemon_name}` (with worktree hash suffix in dev mode).
-///
-/// Does **not** check `RUNTIMED_SOCKET_PATH` — that's an override for the
-/// caller's own daemon, not for cross-channel discovery.
-#[cfg(unix)]
-pub fn socket_path_for_channel(channel: BuildChannel) -> PathBuf {
-    daemon_base_dir_for(channel).join("runtimed.sock")
-}
-
-/// Get the endpoint path for a specific channel's daemon (Windows).
-#[cfg(windows)]
-pub fn socket_path_for_channel(channel: BuildChannel) -> PathBuf {
-    let pipe_name = daemon_binary_basename_for(channel);
-    if is_dev_mode() {
-        if let Some(worktree) = get_workspace_path() {
-            let hash = worktree_hash(&worktree);
-            return PathBuf::from(format!(r"\\.\pipe\{}-{}", pipe_name, hash));
-        }
-    }
-    PathBuf::from(format!(r"\\.\pipe\{}", pipe_name))
-}
-
-/// Check `RUNTIMED_SOCKET_PATH` env var and return the path if valid.
-fn socket_path_from_env() -> Option<PathBuf> {
-    let p = std::env::var("RUNTIMED_SOCKET_PATH").ok()?;
-    let p = p.trim();
-    if p.is_empty() {
-        return None;
-    }
-    let path = PathBuf::from(p);
-    if let Some(parent) = path.parent() {
-        if parent.exists() {
-            return Some(path);
-        }
-        panic!(
-            "RUNTIMED_SOCKET_PATH directory does not exist: {}",
-            parent.display()
-        );
-    }
-    Some(path)
-}
-
 /// Get the default cache directory for environments.
 pub fn default_cache_dir() -> PathBuf {
     daemon_base_dir().join("envs")
@@ -212,31 +157,6 @@ pub fn connections_dir() -> PathBuf {
 /// Get the default path for the persisted Automerge settings document.
 pub fn default_settings_doc_path() -> PathBuf {
     daemon_base_dir().join("settings.automerge")
-}
-
-/// Get the path to the JSON settings file (for migration and fallback).
-pub fn settings_json_path() -> PathBuf {
-    dirs::config_dir()
-        .unwrap_or_else(|| PathBuf::from("."))
-        .join(config_namespace())
-        .join("settings.json")
-}
-
-/// Get the path to the session state file.
-///
-/// In dev mode: stored per-worktree for isolation during development.
-/// In production: stored in config directory alongside settings.
-pub fn session_state_path() -> PathBuf {
-    if is_dev_mode() {
-        // Per-worktree session for dev isolation
-        daemon_base_dir().join("session.json")
-    } else {
-        // Production: config directory
-        dirs::config_dir()
-            .unwrap_or_else(|| PathBuf::from("."))
-            .join(config_namespace())
-            .join("session.json")
-    }
 }
 
 /// Get the path to the settings JSON Schema file.


### PR DESCRIPTION
## Summary

- **Redirect imports to canonical source crates** across `notebook`, `runt` CLI, and `runtimed-py`:
  - Protocol types (`NotebookRequest`, `CompletionItem`, etc.) → `notebook-protocol`
  - Metadata types (`NotebookMetadataSnapshot`, etc.) → `notebook-doc`
  - Workspace utilities (`is_dev_mode`, `worktree_hash`, `default_notebook_log_path`) → `runt-workspace`
- **Move socket/config path helpers** from `runtimed` to `runt-workspace`: `default_socket_path`, `socket_path_for_channel`, `settings_json_path`, `session_state_path`
- Backward-compatible re-exports remain in `runtimed` so existing callers are unaffected

This makes the dependency graph honest — the notebook app no longer appears tightly coupled to the daemon for types that actually live in shared crates.

## Verification

- [ ] App launches and opens a notebook normally
- [ ] `runt daemon status` still resolves the correct socket path
- [ ] Session restore works across app restart

_PR submitted by @rgbkrk's agent, Quill_