### PR TITLE
fix(nteract): drop ImageContent from MCP responses, use text/llm+plain

### DIFF
--- a/python/nteract/src/nteract/_mcp_server.py
+++ b/python/nteract/src/nteract/_mcp_server.py
@@ -1277,7 +1277,7 @@ class NteractServer:
         async def get_all_cells(
             format: Annotated[
                 Literal["summary", "json", "rich"],
-                Field(description="'summary' (default), 'json', or 'rich' for full content"),
+                Field(description="'summary' (default), 'json', or 'rich' for full text content"),
             ] = "summary",
             start: Annotated[int, Field(description="Starting cell index (0-based)")] = 0,
             count: Annotated[
@@ -1292,7 +1292,9 @@ class NteractServer:
 
             Args:
                 format: "summary" for compact overview, "json" for structured data,
-                    "rich" for full content with images.
+                    "rich" for full content as text (image outputs use text/llm+plain
+                    descriptions; use the blob URL in the description to read the
+                    image directly if needed).
                 start: Starting cell index for pagination.
                 count: Number of cells to return (None = all remaining).
                 include_outputs: Include output previews in summary format.

--- a/python/nteract/src/nteract/_mcp_server.py
+++ b/python/nteract/src/nteract/_mcp_server.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 
 import argparse
 import asyncio
-import base64
 import contextlib
 import difflib
 import json
@@ -28,7 +27,7 @@ import sys
 from typing import Annotated, Any, Literal, NoReturn
 
 from mcp.server.fastmcp import Context, FastMCP
-from mcp.types import ImageContent, TextContent, ToolAnnotations
+from mcp.types import TextContent, ToolAnnotations
 from pydantic import Field
 
 import runtimed
@@ -37,7 +36,7 @@ from runtimed._internals import QueueState
 logger = logging.getLogger(__name__)
 
 # MCP content types for tool responses
-ContentItem = TextContent | ImageContent
+ContentItem = TextContent
 
 # ── CLI argument parsing ──────────────────────────────────────────────
 # Parsed in main() so that importing the module doesn't blow up when the
@@ -70,87 +69,10 @@ def _strip_ansi(text: str) -> str:
     return _ANSI_RE.sub("", text)
 
 
-# Target budget for a single image in a tool response.  The Claude CLI's
-# stdio JSON buffer is 1 MB, and the API has its own token limits for tool
-# results.  Keeping each image under 100 KB base64 (~75 KB raw) leaves
-# plenty of room for text content alongside it.
-_IMAGE_BUDGET_BYTES = 75_000
-
-# Absolute ceiling — images larger than this after resizing are dropped
-# entirely (e.g. a 10 000×10 000 screenshot).
-_IMAGE_MAX_BYTES = 500_000
-
-# Minimum dimension — never shrink below this (would lose all detail).
-_IMAGE_MIN_DIM = 200
-
 # Text mime type priority for LLM consumption.
 # text/llm+plain is from https://github.com/rgbkrk/repr_llm — a repr designed
 # specifically for language models. text/html is intentionally excluded: it's
 # often bulky embedded JS (e.g. Plotly) that wastes context window.
-
-
-def _fit_image_for_llm(
-    data: bytes,
-    mime: str,
-    budget: int = _IMAGE_BUDGET_BYTES,
-) -> bytes | None:
-    """Resize an image so its raw bytes fit within *budget*.
-
-    Uses Pillow (installed with matplotlib) to progressively shrink the
-    image until it fits.  Returns ``None`` if the image can't be made
-    small enough or Pillow isn't available.
-
-    Only PNG and JPEG are resized; other formats are returned as-is if
-    they already fit, or dropped.
-    """
-    if len(data) <= budget:
-        return data
-
-    try:
-        from io import BytesIO
-
-        from PIL import Image
-    except ImportError:
-        # No Pillow — return as-is if under the hard ceiling, else drop
-        return data if len(data) <= _IMAGE_MAX_BYTES else None
-
-    resizable = mime in ("image/png", "image/jpeg")
-    if not resizable:
-        return data if len(data) <= _IMAGE_MAX_BYTES else None
-
-    try:
-        img = Image.open(BytesIO(data))
-    except Exception:
-        return None
-
-    save_fmt = "PNG" if mime == "image/png" else "JPEG"
-    save_kwargs: dict = {}
-    if save_fmt == "JPEG":
-        save_kwargs["quality"] = 85
-
-    # Progressively halve the longer dimension until we fit
-    for _ in range(8):  # at most 8 halvings (256× reduction)
-        w, h = img.size
-        if w <= _IMAGE_MIN_DIM and h <= _IMAGE_MIN_DIM:
-            break
-
-        new_w = max(w // 2, _IMAGE_MIN_DIM)
-        new_h = max(h // 2, _IMAGE_MIN_DIM)
-        img = img.resize((new_w, new_h), Image.Resampling.LANCZOS)
-
-        buf = BytesIO()
-        img.save(buf, format=save_fmt, **save_kwargs)
-        result = buf.getvalue()
-        if len(result) <= budget:
-            return result
-
-    # Last attempt didn't fit — return it if under the hard ceiling
-    buf = BytesIO()
-    img.save(buf, format=save_fmt, **save_kwargs)
-    result = buf.getvalue()
-    return result if len(result) <= _IMAGE_MAX_BYTES else None
-
-
 _TEXT_MIME_PRIORITY = (
     "text/llm+plain",
     "text/markdown",
@@ -218,10 +140,14 @@ def _format_outputs_text(outputs: list[runtimed.Output]) -> str:
 def _output_to_content(output: runtimed.Output) -> list[ContentItem]:
     """Convert a single output to a list of MCP content items.
 
-    Returns the richest representation for each mime type:
-    - image/png, image/jpeg, image/gif, image/webp → ImageContent
-    - image/svg+xml → TextContent (XML text, not base64)
+    All outputs are returned as TextContent. Image outputs use the
+    text/llm+plain representation (a text description synthesized by the
+    daemon) rather than base64 image data — MCP clients like Claude Code
+    don't render ImageContent inline, so it just wastes context window.
+
+    Mime priority for display_data/execute_result:
     - text/llm+plain, text/markdown, text/plain, application/json → TextContent
+    - image/svg+xml → TextContent (XML text)
     - stream, error → TextContent
 
     text/html is intentionally excluded — it's often bulky embedded JS
@@ -251,23 +177,6 @@ def _output_to_content(output: runtimed.Output) -> list[ContentItem]:
     if output.output_type in ("display_data", "execute_result"):
         if output.data is None:
             return items
-
-        # Images → ImageContent (resize to fit LLM context budget)
-        for mime in ("image/png", "image/jpeg", "image/gif", "image/webp"):
-            if mime in output.data:
-                data = output.data[mime]
-                if isinstance(data, bytes):
-                    fitted = _fit_image_for_llm(data, mime)
-                    if fitted is not None:
-                        b64 = base64.b64encode(fitted).decode("ascii")
-                        items.append(ImageContent(type="image", data=b64, mimeType=mime))
-                elif isinstance(data, str):
-                    # Legacy fallback: already base64-encoded string
-                    raw = base64.b64decode(data)
-                    fitted = _fit_image_for_llm(raw, mime)
-                    if fitted is not None:
-                        b64 = base64.b64encode(fitted).decode("ascii")
-                        items.append(ImageContent(type="image", data=b64, mimeType=mime))
 
         # SVG as text (it's XML, not base64)
         if "image/svg+xml" in output.data:
@@ -1420,11 +1329,7 @@ class NteractServer:
             if format == "rich":
                 items: list[ContentItem] = []
                 for cell in cells:
-                    for item in _cell_to_content(cell, status=cell_status.get(cell.id)):
-                        if isinstance(item, ImageContent):
-                            items.append(TextContent(type="text", text=f"[image: {item.mimeType}]"))
-                        else:
-                            items.append(item)
+                    items.extend(_cell_to_content(cell, status=cell_status.get(cell.id)))
                 return items
 
             lines = [

--- a/python/nteract/tests/test_mcp_integration.py
+++ b/python/nteract/tests/test_mcp_integration.py
@@ -468,6 +468,46 @@ async def test_get_all_cells_pagination(mcp_client: ClientSession):
 
 
 @pytest.mark.asyncio
+async def test_image_output_returns_text_not_image_content(mcp_client: ClientSession):
+    """Image-producing cells should return TextContent (text/llm+plain), not ImageContent.
+
+    MCP clients like Claude Code don't render ImageContent inline — the base64
+    data just wastes context window. The daemon synthesizes a text/llm+plain
+    representation with blob URLs that agents can follow with their Read tool.
+    """
+    await mcp_client.call_tool("create_notebook", {"dependencies": ["matplotlib"]})
+
+    # Create a cell that produces a matplotlib plot
+    result = await mcp_client.call_tool(
+        "create_cell",
+        {
+            "source": (
+                "import matplotlib.pyplot as plt\n"
+                "fig, ax = plt.subplots()\n"
+                "ax.plot([1, 2, 3], [1, 4, 9])\n"
+                "plt.show()"
+            ),
+            "and_run": True,
+            "timeout_secs": 60,
+        },
+    )
+
+    # Every content item must be TextContent — no ImageContent
+    assert result.content, "Expected at least one content item"
+    for item in result.content:
+        assert isinstance(item, TextContent), (
+            f"Expected TextContent, got {type(item).__name__}. "
+            "Image outputs should use text/llm+plain, not ImageContent."
+        )
+
+    # The text/llm+plain representation should include a blob URL pointer
+    text = _get_text(result)
+    assert "blob:" in text or "image" in text.lower(), (
+        "Image output text should include a blob URL or image description"
+    )
+
+
+@pytest.mark.asyncio
 async def test_open_notebook_returns_cells(mcp_client: ClientSession):
     """open_notebook should return a cell summary like join_notebook."""
     fixture = str(


### PR DESCRIPTION
## Summary

- Remove `ImageContent` from all MCP tool responses — MCP clients like Claude Code serialize it as raw JSON instead of rendering it visually, wasting ~65KB of context window per plot
- Image outputs now use the `text/llm+plain` representation (synthesized by the daemon) which gives the LLM a useful text description
- Remove `_fit_image_for_llm` function, image budget constants, `base64` import
- Simplify `get_all_cells` rich format (no more `ImageContent` → placeholder downgrade)

Net: -105 lines, +10 lines.

## Test plan

- [ ] `cargo xtask lint` passes
- [ ] Create a notebook with matplotlib plot via MCP — output is text description, not base64 blob
- [ ] `get_all_cells(format="rich")` returns text for image outputs
- [ ] Non-image outputs (stream, error, JSON) unchanged