### PR TITLE
feat: extract runtimed JavaScript bindings package

### DIFF
--- a/apps/notebook/package.json
+++ b/apps/notebook/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "runtimed": "workspace:*",
     "@codemirror/autocomplete": "^6.20.0",
     "@codemirror/commands": "^6.10.2",
     "@codemirror/lang-html": "^6.4.11",

--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -1,9 +1,10 @@
 import { invoke } from "@tauri-apps/api/core";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { debounceTime, from, Subject, switchMap } from "rxjs";
+import type { SyncableHandle } from "runtimed";
+import { FrameType, SyncEngine } from "runtimed";
+import { from, switchMap } from "rxjs";
 import { getBlobPort, refreshBlobPort } from "../lib/blob-port";
-import { createFramePipeline } from "../lib/frame-pipeline";
-import { frame_types, sendFrame } from "../lib/frame-types";
+import { materializeChangeset } from "../lib/frame-pipeline";
 import { logger } from "../lib/logger";
 import {
   type CellSnapshot,
@@ -23,10 +24,22 @@ import {
   openNotebookFile,
   saveNotebook,
 } from "../lib/notebook-file-ops";
-import { subscribeBroadcast } from "../lib/notebook-frame-bus";
-import { setNotebookHandle } from "../lib/notebook-metadata";
-import { resetRuntimeState } from "../lib/runtime-state";
+import {
+  emitBroadcast,
+  emitPresence,
+  subscribeBroadcast,
+} from "../lib/notebook-frame-bus";
+import {
+  notifyMetadataChanged,
+  setNotebookHandle,
+} from "../lib/notebook-metadata";
+import {
+  type RuntimeState,
+  resetRuntimeState,
+  setRuntimeState,
+} from "../lib/runtime-state";
 import { fromTauriEvent } from "../lib/tauri-rx";
+import { TauriTransport } from "../lib/tauri-transport";
 import type { DaemonBroadcast, JupyterOutput } from "../types";
 import init, { NotebookHandle } from "../wasm/runtimed-wasm/runtimed_wasm.js";
 
@@ -44,7 +57,7 @@ const wasmReady: Promise<void> = init().then(() => {
  *
  * All document mutations execute instantly inside the WASM Automerge
  * document. The external store is derived from the doc. Sync messages
- * flow through the Tauri relay to the daemon.
+ * flow through the SyncEngine → TauriTransport to the daemon.
  */
 export function useAutomergeNotebook() {
   const cellIds = useCellIds();
@@ -53,12 +66,12 @@ export function useAutomergeNotebook() {
   const [isLoading, setIsLoading] = useState(true);
 
   const handleRef = useRef<NotebookHandle | null>(null);
-  const awaitingInitialSyncRef = useRef(true);
   const sessionIdRef = useRef(crypto.randomUUID().slice(0, 8));
   const outputCacheRef = useRef<Map<string, JupyterOutput>>(new Map());
 
-  // RxJS subjects for debounced outbound sync.
-  const sourceSync$ = useRef(new Subject<void>());
+  // SyncEngine and transport refs — stable across re-renders.
+  const engineRef = useRef<SyncEngine | null>(null);
+  const transportRef = useRef<TauriTransport | null>(null);
 
   // Refresh blob port on mount.
   useEffect(() => {
@@ -94,36 +107,6 @@ export function useAutomergeNotebook() {
     replaceNotebookCells(newCells);
   }, []);
 
-  /** Flush local CRDT changes to the Tauri relay (fire-and-forget).
-   *  Uses flush_local_changes + cancel_last_flush to prevent the sync
-   *  state consumption race from #1067. */
-  const syncToRelay = useCallback((handle: NotebookHandle) => {
-    const msg = handle.flush_local_changes();
-    if (msg) {
-      sendFrame(frame_types.AUTOMERGE_SYNC, msg).catch((e: unknown) => {
-        handle.cancel_last_flush();
-        logger.warn("[automerge-notebook] sync to relay failed:", e);
-      });
-    }
-
-    // Also initiate RuntimeStateDoc sync so the daemon sends kernel status,
-    // trust state, etc. Without this, if the daemon's initial RuntimeStateSync
-    // frame arrived before the WASM handle was ready, the frontend would stay
-    // stuck on "not_started" with no way to recover (#runtime-state-race).
-    const stateMsg = handle.flush_runtime_state_sync();
-    if (stateMsg) {
-      sendFrame(frame_types.RUNTIME_STATE_SYNC, stateMsg).catch(
-        (e: unknown) => {
-          handle.cancel_last_runtime_state_flush();
-          logger.warn(
-            "[automerge-notebook] runtime state sync to relay failed:",
-            e,
-          );
-        },
-      );
-    }
-  }, []);
-
   /** Sync re-read cells from WASM (cache-only, no blob fetches). */
   const rematerializeCellsSync = useCallback((handle: NotebookHandle) => {
     const json = handle.get_cells_json();
@@ -137,23 +120,23 @@ export function useAutomergeNotebook() {
 
   /**
    * Guard + commit helper for WASM mutations.
-   * Returns the handle if ready, or null if bootstrapping.
    * After the mutation callback runs, re-materializes and syncs.
    */
   const commitMutation = useCallback(
     (mutate: (handle: NotebookHandle) => boolean) => {
       const handle = handleRef.current;
-      if (!handle || awaitingInitialSyncRef.current) return false;
+      const engine = engineRef.current;
+      if (!handle || !engine) return false;
       if (!mutate(handle)) return false;
       rematerializeCellsSync(handle);
-      syncToRelay(handle);
+      engine.flush();
       setDirty(true);
       return true;
     },
-    [rematerializeCellsSync, syncToRelay],
+    [rematerializeCellsSync],
   );
 
-  // ── Bootstrap ──────────────────────────────────────────────────────
+  // ── Bootstrap ──��──────────────────────────────────��────────────────
 
   const bootstrap = useCallback(async () => {
     await wasmReady;
@@ -166,38 +149,105 @@ export function useAutomergeNotebook() {
     handleRef.current = handle;
     setNotebookHandle(handle);
 
-    awaitingInitialSyncRef.current = true;
     setIsLoading(true);
 
-    syncToRelay(handle);
+    // Flush initial sync message through the engine.
+    const engine = engineRef.current;
+    if (engine) {
+      engine.resetForBootstrap();
+      engine.flush();
+    }
+
     logger.info("[automerge-notebook] Bootstrap: empty handle, awaiting sync");
     return true;
-  }, [syncToRelay]);
+  }, []);
 
-  // ── Lifecycle (single effect) ──────────────────────────────────────
+  // ── Lifecycle (single effect) ─────────────���────────────────────────
 
   useEffect(() => {
     let cancelled = false;
 
-    awaitingInitialSyncRef.current = true;
-    setIsLoading(true);
-    void bootstrap().catch((error) => {
-      logger.error("[automerge-notebook] Bootstrap failed", error);
-      if (!cancelled) {
-        awaitingInitialSyncRef.current = false;
+    // Create transport and engine for this lifecycle.
+    const transport = new TauriTransport();
+    const engine = new SyncEngine({
+      getHandle: () => handleRef.current as SyncableHandle | null,
+      transport,
+      logger,
+    });
+
+    transportRef.current = transport;
+    engineRef.current = engine;
+
+    // Start the engine (subscribes to transport frames).
+    engine.start();
+
+    // ── Subscribe to SyncEngine observables ───────────────────────
+
+    // Initial sync completion → full materialization.
+    const initialSyncSub = engine.initialSyncComplete$.subscribe(() => {
+      const handle = handleRef.current;
+      if (handle) {
+        materializeCells(handle)
+          .then(() => {
+            setIsLoading(false);
+            notifyMetadataChanged();
+          })
+          .catch((err: unknown) => {
+            logger.warn(
+              "[automerge-notebook] initial materialize failed:",
+              err,
+            );
+            setIsLoading(false);
+          });
+      } else {
         setIsLoading(false);
       }
     });
 
-    // Daemon lifecycle — daemon:ready triggers a fresh bootstrap.
-    // switchMap cancels any in-flight bootstrap on rapid reconnects.
+    // Steady-state cell changes → incremental materialization.
+    const cellChangesSub = engine.cellChanges$.subscribe((changeset) => {
+      materializeChangeset(changeset, {
+        getHandle: () => handleRef.current,
+        materializeCells,
+        outputCache: outputCacheRef.current,
+      }).catch((err: unknown) =>
+        logger.warn("[automerge-notebook] materialize changeset failed:", err),
+      );
+    });
+
+    // Broadcasts → frame bus.
+    const broadcastsSub = engine.broadcasts$.subscribe((payload) =>
+      emitBroadcast(payload),
+    );
+
+    // Presence → frame bus.
+    const presenceSub = engine.presence$.subscribe((payload) =>
+      emitPresence(payload),
+    );
+
+    // Runtime state → store.
+    const runtimeStateSub = engine.runtimeState$.subscribe((state) =>
+      setRuntimeState(state as RuntimeState),
+    );
+
+    // ── Bootstrap ─────────────────────────────────────────────────
+
+    setIsLoading(true);
+    void bootstrap().catch((error) => {
+      logger.error("[automerge-notebook] Bootstrap failed", error);
+      if (!cancelled) {
+        setIsLoading(false);
+      }
+    });
+
+    // ── Daemon lifecycle ────────��─────────────────────────────────
+
     const lifecycleSub = fromTauriEvent("daemon:ready")
       .pipe(
         switchMap(() => {
           refreshBlobPort();
           resetNotebookCells();
           resetRuntimeState();
-          awaitingInitialSyncRef.current = true;
           setIsLoading(true);
           return from(
             bootstrap().catch((err: unknown) => {
@@ -211,36 +261,8 @@ export function useAutomergeNotebook() {
       )
       .subscribe();
 
-    // Inbound frame pipeline (WASM demux → coalesce → materialize → store).
-    const frameSub = createFramePipeline({
-      getHandle: () => handleRef.current,
-      getAwaitingInitialSync: () => awaitingInitialSyncRef.current,
-      setAwaitingInitialSync: (v) => {
-        awaitingInitialSyncRef.current = v;
-      },
-      setIsLoading,
-      materializeCells,
-      outputCache: outputCacheRef.current,
-      retrySyncToRelay: () => {
-        const handle = handleRef.current;
-        if (!handle) return;
-        // Reset sync state so flush_local_changes() produces a fresh
-        // request instead of returning null (which it does when the
-        // handle believes it's already in sync with the peer).
-        handle.reset_sync_state();
-        syncToRelay(handle);
-      },
-    });
+    // ── Bulk output clearing ──────────────────────────────────────
 
-    // Source sync: 20ms debounce for batching rapid keystrokes.
-    const sourceSyncSub = sourceSync$.current
-      .pipe(debounceTime(20))
-      .subscribe(() => {
-        const handle = handleRef.current;
-        if (handle) syncToRelay(handle);
-      });
-
-    // Bulk output clearing (run-all / restart-and-run-all).
     const clearOutputsSub = fromTauriEvent<string[]>(
       "cells:outputs_cleared",
     ).subscribe((payload) => {
@@ -256,15 +278,22 @@ export function useAutomergeNotebook() {
 
     return () => {
       cancelled = true;
-      frameSub.unsubscribe();
+
+      // Flush pending local changes before stopping.
+      engine.flush();
+      engine.stop();
+      transport.disconnect();
+
+      initialSyncSub.unsubscribe();
+      cellChangesSub.unsubscribe();
+      broadcastsSub.unsubscribe();
+      presenceSub.unsubscribe();
+      runtimeStateSub.unsubscribe();
       lifecycleSub.unsubscribe();
-      sourceSyncSub.unsubscribe();
       clearOutputsSub.unsubscribe();
 
-      // Flush pending local changes before freeing handle.
-      if (handleRef.current) {
-        syncToRelay(handleRef.current);
-      }
+      engineRef.current = null;
+      transportRef.current = null;
 
       resetNotebookCells();
       resetRuntimeState();
@@ -272,54 +301,46 @@ export function useAutomergeNotebook() {
       handleRef.current?.free();
       handleRef.current = null;
     };
-  }, [bootstrap, materializeCells, syncToRelay]);
+  }, [bootstrap, materializeCells]);
 
-  // ── Cell mutations ─────────────────────────────────────────────────
+  // ── Cell mutations ─────���───────────────────────────────────────────
 
   const updateCellSource = useCallback((cellId: string, source: string) => {
     const handle = handleRef.current;
-    if (!handle || awaitingInitialSyncRef.current) return;
+    const engine = engineRef.current;
+    if (!handle || !engine) return;
 
     const updated = handle.update_source(cellId, source);
     if (!updated) return;
 
     updateCellById(cellId, (c) => ({ ...c, source }));
-    sourceSync$.current.next();
+    engine.scheduleFlush();
     setDirty(true);
   }, []);
 
-  /**
-   * Clear outputs for a local UI action (Ctrl-Enter, menu clear).
-   * Writes to the CRDT first so the store stays in sync with the
-   * source of truth, then updates the store for instant feedback.
-   */
   const clearOutputsLocal = useCallback((cellId: string) => {
     const handle = handleRef.current;
+    const engine = engineRef.current;
     if (handle) {
       handle.clear_outputs(cellId);
       handle.set_execution_count(cellId, "null");
-      sourceSync$.current.next();
+      engine?.scheduleFlush();
       setDirty(true);
     }
 
-    // Store write for instant visual feedback. Safe because the CRDT
-    // agrees (or will agree once materialization catches up).
     updateCellById(cellId, (c) =>
       c.cell_type === "code" ? { ...c, outputs: [], execution_count: null } : c,
     );
   }, []);
 
-  /**
-   * Clear outputs from every code cell via a single WASM call.
-   * Updates the CRDT atomically, then refreshes the store.
-   */
   const clearAllOutputsLocal = useCallback(() => {
     const handle = handleRef.current;
+    const engine = engineRef.current;
     if (!handle) return;
     const clearedIds: string[] = handle.clear_all_outputs();
     if (clearedIds.length === 0) return;
 
-    sourceSync$.current.next();
+    engine?.scheduleFlush();
     setDirty(true);
 
     const clearedSet = new Set(clearedIds);
@@ -332,11 +353,6 @@ export function useAutomergeNotebook() {
     );
   }, []);
 
-  /**
-   * Apply a daemon output-clear into the store. Store-only —
-   * the daemon already wrote to the CRDT, so we just update the
-   * local store. No CRDT mutation, no sync, no dirty flag.
-   */
   const clearOutputsFromDaemon = useCallback((cellId: string) => {
     updateCellById(cellId, (c) =>
       c.cell_type === "code" ? { ...c, outputs: [], execution_count: null } : c,
@@ -346,8 +362,9 @@ export function useAutomergeNotebook() {
   const addCell = useCallback(
     (cellType: "code" | "markdown" | "raw", afterCellId?: string | null) => {
       const handle = handleRef.current;
+      const engine = engineRef.current;
 
-      if (!handle || awaitingInitialSyncRef.current) {
+      if (!handle || !engine) {
         const placeholderId = crypto.randomUUID();
         return cellType === "code"
           ? {
@@ -369,7 +386,7 @@ export function useAutomergeNotebook() {
       const cellId = crypto.randomUUID();
       handle.add_cell_after(cellId, cellType, afterCellId ?? null);
       rematerializeCellsSync(handle);
-      syncToRelay(handle);
+      engine.flush();
       setFocusedCellId(cellId);
       setDirty(true);
 
@@ -386,7 +403,7 @@ export function useAutomergeNotebook() {
         }
       );
     },
-    [rematerializeCellsSync, syncToRelay],
+    [rematerializeCellsSync],
   );
 
   const moveCell = useCallback(
@@ -427,21 +444,19 @@ export function useAutomergeNotebook() {
     [commitMutation],
   );
 
-  // ── Sync flush ─────────────────────────────────────────────────────
+  // ── Sync flush ────��────────────────────────────────────────────────
 
   /** Flush pending debounced sync immediately (call before execute/save). */
   const flushSync = useCallback(async () => {
     const handle = handleRef.current;
-    if (!handle) return;
-    // Bypasses the debounce; any pending emission becomes a no-op.
+    const transport = transportRef.current;
+    if (!handle || !transport) return;
+
     const msg = handle.flush_local_changes();
     if (msg) {
       try {
-        await sendFrame(frame_types.AUTOMERGE_SYNC, msg);
+        await transport.sendFrame(FrameType.AUTOMERGE_SYNC, msg);
       } catch (e) {
-        // flush_local_changes advanced sync_state (in_flight, sent_hashes).
-        // Cancel to prevent sent_hashes from permanently filtering out
-        // the change data we never delivered (#1067).
         handle.cancel_last_flush();
         logger.warn("[flushSync] failed, rolled back sync state", e);
       }
@@ -459,7 +474,7 @@ export function useAutomergeNotebook() {
 
   const cloneNotebook = useCallback(() => cloneNotebookFile(), []);
 
-  // ── Output overlays (optimistic, pre-sync) ─────────────────────────
+  // ── Output overlays (optimistic, pre-sync) ──────��──────────────────
 
   const updateOutputByDisplayId = useCallback(
     (
@@ -489,10 +504,6 @@ export function useAutomergeNotebook() {
     [],
   );
 
-  /**
-   * Apply a daemon execution-count update into the store. Store-only —
-   * the daemon already wrote to the CRDT.
-   */
   const applyExecutionCountFromDaemon = useCallback(
     (cellId: string, count: number) => {
       updateCellById(cellId, (c) =>
@@ -502,15 +513,10 @@ export function useAutomergeNotebook() {
     [],
   );
 
-  // ── Public interface ───────────────────────────────────────────────
+  // ── Public interface ───────────���───────────────────────────────────
 
-  // ── CRDT bridge deps ───────────────────────────────────────────────
-  // Stable getter for the WASM handle (reads ref at call time).
   const getHandle = useCallback(() => handleRef.current, []);
-  // Trigger a debounced sync to the daemon (same Subject the old
-  // updateCellSource used via sourceSync$).
-  const triggerSync = useCallback(() => sourceSync$.current.next(), []);
-  // Stable local actor label for filtering self-echo text attributions.
+  const triggerSync = useCallback(() => engineRef.current?.scheduleFlush(), []);
   const localActor = `human:${sessionIdRef.current}`;
 
   return {

--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -2,7 +2,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { SyncableHandle } from "runtimed";
 import { FrameType, SyncEngine } from "runtimed";
-import { from, switchMap } from "rxjs";
+import { concatMap, from, switchMap } from "rxjs";
 import { getBlobPort, refreshBlobPort } from "../lib/blob-port";
 import { materializeChangeset } from "../lib/frame-pipeline";
 import { logger } from "../lib/logger";
@@ -205,15 +205,26 @@ export function useAutomergeNotebook() {
     });
 
     // Steady-state cell changes → incremental materialization.
-    const cellChangesSub = engine.cellChanges$.subscribe((changeset) => {
-      materializeChangeset(changeset, {
-        getHandle: () => handleRef.current,
-        materializeCells,
-        outputCache: outputCacheRef.current,
-      }).catch((err: unknown) =>
-        logger.warn("[automerge-notebook] materialize changeset failed:", err),
-      );
-    });
+    // concatMap serializes async work — if a batch awaits blob resolution,
+    // subsequent batches queue rather than overlapping store writes.
+    const cellChangesSub = engine.cellChanges$
+      .pipe(
+        concatMap((changeset) =>
+          from(
+            materializeChangeset(changeset, {
+              getHandle: () => handleRef.current,
+              materializeCells,
+              outputCache: outputCacheRef.current,
+            }).catch((err: unknown) =>
+              logger.warn(
+                "[automerge-notebook] materialize changeset failed:",
+                err,
+              ),
+            ),
+          ),
+        ),
+      )
+      .subscribe();
 
     // Broadcasts → frame bus.
     const broadcastsSub = engine.broadcasts$.subscribe((payload) =>

--- a/apps/notebook/src/lib/cell-changeset.ts
+++ b/apps/notebook/src/lib/cell-changeset.ts
@@ -9,4 +9,4 @@ export {
   type ChangedCell,
   type ChangedFields,
   mergeChangesets,
-} from "runtimed/src/cell-changeset";
+} from "runtimed";

--- a/apps/notebook/src/lib/cell-changeset.ts
+++ b/apps/notebook/src/lib/cell-changeset.ts
@@ -1,67 +1,12 @@
 /**
  * CellChangeset types and merge utilities.
  *
- * Pure module with zero external dependencies — safe to import from
- * unit tests without pulling in Tauri, RxJS, or WASM runtime.
- *
- * Mirrors the Rust `notebook_doc::diff` types serialized from WASM
- * via serde-wasm-bindgen.
+ * Re-exported from the `runtimed` package. This module exists so existing
+ * app imports (`../lib/cell-changeset`) continue to work without changes.
  */
-
-// ── Types ────────────────────────────────────────────────────────────
-
-/** Which fields changed on a cell (only `true` keys are present). */
-export interface ChangedFields {
-  source?: boolean;
-  outputs?: boolean;
-  execution_count?: boolean;
-  cell_type?: boolean;
-  metadata?: boolean;
-  position?: boolean;
-  resolved_assets?: boolean;
-}
-
-export interface ChangedCell {
-  cell_id: string;
-  fields: ChangedFields;
-}
-
-/** Structural diff between two Automerge head sets, produced by WASM `diff_cells`. */
-export interface CellChangeset {
-  changed: ChangedCell[];
-  added: string[];
-  removed: string[];
-  order_changed: boolean;
-}
-
-// ── Utilities ────────────────────────────────────────────────────────
-
-/**
- * Merge two CellChangesets (for coalescing frames across a buffer window).
- *
- * Field unions are additive — if either changeset marks a field as changed,
- * the merged result marks it as changed. Added/removed lists are deduplicated.
- * `order_changed` is true if either input is true.
- */
-export function mergeChangesets(
-  a: CellChangeset,
-  b: CellChangeset,
-): CellChangeset {
-  const changedMap = new Map<string, ChangedFields>();
-  for (const c of [...a.changed, ...b.changed]) {
-    const existing = changedMap.get(c.cell_id);
-    if (existing) {
-      for (const [key, val] of Object.entries(c.fields)) {
-        if (val) (existing as Record<string, boolean>)[key] = true;
-      }
-    } else {
-      changedMap.set(c.cell_id, { ...c.fields });
-    }
-  }
-  return {
-    changed: [...changedMap].map(([cell_id, fields]) => ({ cell_id, fields })),
-    added: [...new Set([...a.added, ...b.added])],
-    removed: [...new Set([...a.removed, ...b.removed])],
-    order_changed: a.order_changed || b.order_changed,
-  };
-}
+export {
+  type CellChangeset,
+  type ChangedCell,
+  type ChangedFields,
+  mergeChangesets,
+} from "runtimed/src/cell-changeset";

--- a/apps/notebook/src/lib/frame-pipeline.ts
+++ b/apps/notebook/src/lib/frame-pipeline.ts
@@ -9,8 +9,7 @@
 import type { JupyterOutput } from "../types";
 import type { NotebookHandle } from "../wasm/runtimed-wasm/runtimed_wasm.js";
 import { getBlobPort, refreshBlobPort } from "./blob-port";
-import { type CellChangeset, mergeChangesets } from "./cell-changeset";
-import { logger } from "./logger";
+import type { CellChangeset } from "./cell-changeset";
 import {
   isManifestHash,
   materializeCellFromWasm,

--- a/apps/notebook/src/lib/frame-pipeline.ts
+++ b/apps/notebook/src/lib/frame-pipeline.ts
@@ -1,44 +1,15 @@
 /**
- * Inbound frame processing pipeline (Pipeline 1).
+ * Materialization helpers for inbound sync batches.
  *
- * Replaces the imperative `notebook:frame` listener, `scheduleMaterialize`,
- * and three timer/accumulator refs from `useAutomergeNotebook` with a
- * declarative RxJS pipeline that splits incoming frames into sub-streams:
- *
- *   1. sync_applied → coalesce (32ms buffer) → materialize → write to store
- *   2. sync_applied attributions → emitBroadcast
- *   3. broadcast → emitBroadcast
- *   4. presence → emitPresence
- *
- * Usage (in useEffect):
- *   const sub = createFramePipeline(deps);
- *   return () => sub.unsubscribe();
- *
- * Web-worker future: the `mergeMap(payload => ...)` that calls WASM
- * `receive_frame` becomes a `switchMap` through the worker bridge. The
- * rest of the pipeline (coalesce, materialize, write to store) stays
- * identical.
+ * The sync pipeline itself lives in the `runtimed` package (SyncEngine).
+ * This module provides the app-specific materialization logic that
+ * transforms coalesced CellChangesets into React store updates.
  */
-
-import {
-  bufferTime,
-  concatMap,
-  EMPTY,
-  filter,
-  from,
-  mergeMap,
-  Subject,
-  Subscription,
-  share,
-  switchMap,
-  timer,
-} from "rxjs";
 
 import type { JupyterOutput } from "../types";
 import type { NotebookHandle } from "../wasm/runtimed-wasm/runtimed_wasm.js";
 import { getBlobPort, refreshBlobPort } from "./blob-port";
 import { type CellChangeset, mergeChangesets } from "./cell-changeset";
-import { frame_types, sendFrame } from "./frame-types";
 import { logger } from "./logger";
 import {
   isManifestHash,
@@ -46,10 +17,7 @@ import {
   resolveOutput,
 } from "./materialize-cells";
 import { getCellById, updateCellById } from "./notebook-cells";
-import { emitBroadcast, emitPresence } from "./notebook-frame-bus";
 import { notifyMetadataChanged } from "./notebook-metadata";
-import { type RuntimeState, setRuntimeState } from "./runtime-state";
-import { fromTauriEvent } from "./tauri-rx";
 
 // Re-export CellChangeset types so existing consumers don't break.
 export type {
@@ -59,353 +27,44 @@ export type {
 } from "./cell-changeset";
 export { mergeChangesets } from "./cell-changeset";
 
-// ── Constants ────────────────────────────────────────────────────────
+// ── Materialization dependencies ─────────────────────────────────────
 
-/** Coalescing window for incoming sync frames (ms). */
-const COALESCE_MS = 32;
-
-/** Timeout before retrying sync if initial sync hasn't produced cells (ms). */
-const SYNC_RETRY_MS = 3000;
-
-// ── Internal types ──────────────────────────────────────────────────
-
-/** Attribution for text changes, produced by WASM sync. */
-interface TextAttribution {
-  cell_id: string;
-  index: number;
-  text: string;
-  deleted: number;
-  actors: string[];
-}
-
-/** Typed event returned by WASM `receive_frame()`. */
-interface FrameEvent {
-  type: string;
-  changed?: boolean;
-  changeset?: CellChangeset;
-  attributions?: TextAttribution[];
-  reply?: number[]; // Inline sync reply bytes from receive_frame (#1067 fix)
-  payload?: unknown;
-  state?: unknown; // RuntimeState from RuntimeStateSyncApplied
-}
-
-// ── Pipeline dependencies ───────────────────────────────────────────
-
-/**
- * External dependencies injected by the hook.
- *
- * Getters read from React refs at event-processing time (not capture
- * time) so the pipeline never holds stale closures across bootstrap
- * cycles (daemon:ready, file-opened, etc.).
- */
-export interface FramePipelineDeps {
+export interface MaterializeDeps {
   /** Read the current WASM handle (null during bootstrap). */
   getHandle: () => NotebookHandle | null;
 
-  /** Check if we're still waiting for the first sync from the daemon. */
-  getAwaitingInitialSync: () => boolean;
-
-  /** Mark initial sync as received. */
-  setAwaitingInitialSync: (value: boolean) => void;
-
-  /** Update the loading state in React. */
-  setIsLoading: (loading: boolean) => void;
-
   /**
    * Full materialization: serialize entire doc → resolve manifests →
-   * write to notebook-cells store. The pipeline calls this for initial
-   * sync and structural changes (add/remove/reorder cells).
+   * write to notebook-cells store.
    */
   materializeCells: (handle: NotebookHandle) => Promise<void>;
 
   /** Shared output manifest cache (mutated in place). */
   outputCache: Map<string, JupyterOutput>;
-
-  /**
-   * Resend the initial sync message. Called by the retry timer when
-   * the first sync exchange didn't produce cells within SYNC_RETRY_MS.
-   * The empty WASM handle's sync message requests the full document.
-   */
-  retrySyncToRelay: () => void;
 }
 
-// ── Pipeline factory ────────────────────────────────────────────────
+// ── Batch materialization ────────────────────────────────────────────
 
 /**
- * Create and subscribe the inbound frame processing pipeline.
- *
- * Returns a `Subscription` — call `.unsubscribe()` to tear down the
- * Tauri event listener, all sub-streams, and the coalescing timer.
- *
- * The pipeline is **cold**: nothing happens until this function is
- * called, and everything is cleaned up when the subscription ends.
- */
-export function createFramePipeline(deps: FramePipelineDeps): Subscription {
-  const subscription = new Subscription();
-
-  // Subject bridging sync_applied events into the coalescing buffer.
-  // Each emission is a CellChangeset (incremental) or null (needs full).
-  const materialize$ = new Subject<CellChangeset | null>();
-
-  // Subject for the sync retry timer. Each emission restarts the timer.
-  // If SYNC_RETRY_MS elapses without a successful initial sync (changed:true),
-  // the pipeline resends sync to recover from lost/consumed messages.
-  const retrySync$ = new Subject<void>();
-
-  // Arm the retry timer immediately — if no sync_applied arrives at all
-  // (e.g., all frames dropped before reaching WASM), this ensures we
-  // still retry after SYNC_RETRY_MS rather than hanging indefinitely.
-  retrySync$.next();
-
-  // ── Source: Tauri frames → WASM demux → individual FrameEvents ────
-
-  const frameEvents$ = fromTauriEvent<number[]>("notebook:frame").pipe(
-    mergeMap((payload) => {
-      try {
-        const handle = deps.getHandle();
-        if (!handle) return EMPTY;
-        const bytes = new Uint8Array(payload);
-        const result = handle.receive_frame(bytes);
-        if (!result || !Array.isArray(result)) return EMPTY;
-        return from(result as FrameEvent[]);
-      } catch (e) {
-        logger.warn("[frame-pipeline] receive_frame failed:", e);
-        return EMPTY;
-      }
-    }),
-    share(), // multicast to all sub-pipelines below
-  );
-
-  // ── Sub-pipeline: sync_applied → initial sync / coalesce ──────────
-
-  subscription.add(
-    frameEvents$
-      .pipe(
-        filter((e) => e.type === "sync_applied"),
-        // concatMap serializes async work (initial materialization) so
-        // we don't send a sync reply before the store is populated.
-        concatMap((e) => {
-          // ── Attributions (fire-and-forget, no async work) ──────────
-          if (e.attributions && e.attributions.length > 0) {
-            emitBroadcast({
-              type: "text_attribution",
-              attributions: e.attributions,
-            });
-          }
-
-          // ── Send inline sync reply immediately ─────────────────────
-          // The reply was generated atomically inside WASM's receive_frame,
-          // eliminating the consumption race from #1067 where a separate
-          // generate_sync_reply() could be preempted by flushSync.
-          //
-          // If delivery fails, roll back sync state (cancel_last_flush)
-          // to prevent sent_hashes from permanently filtering out local
-          // change data the daemon never received. Without this, a client
-          // with unflushed local edits whose reply is dropped enters a
-          // non-converging sync loop (Codex review of #1068).
-          if (e.reply) {
-            sendFrame(
-              frame_types.AUTOMERGE_SYNC,
-              new Uint8Array(e.reply),
-            ).catch((err: unknown) => {
-              const handle = deps.getHandle();
-              if (handle) {
-                handle.cancel_last_flush();
-              }
-              logger.warn(
-                "[frame-pipeline] inline sync reply send failed, rolled back sync state:",
-                err,
-              );
-            });
-          }
-
-          // ── Initial sync: materialize immediately (no coalescing) ──
-          if (deps.getAwaitingInitialSync()) {
-            if (e.changed) {
-              // Sync delivered actual document content — clear the gate
-              // and materialize. This is the success path.
-              deps.setAwaitingInitialSync(false);
-              const handle = deps.getHandle();
-              if (handle) {
-                return from(
-                  deps
-                    .materializeCells(handle)
-                    .then(() => {
-                      deps.setIsLoading(false);
-                      notifyMetadataChanged();
-                    })
-                    .catch((err: unknown) => {
-                      logger.warn(
-                        "[frame-pipeline] initial materialize failed:",
-                        err,
-                      );
-                      deps.setIsLoading(false);
-                    }),
-                );
-              }
-              deps.setIsLoading(false); // Fallback if no handle
-            }
-            // changed:false — Automerge sync protocol handshake round
-            // (exchanging heads/bloom filters, no actual content yet).
-            // Keep awaitingInitialSync=true and isLoading=true so the
-            // user sees the loading state until real content arrives.
-            // Restart the retry timer in case the exchange stalls.
-            retrySync$.next();
-            return EMPTY;
-          }
-
-          // ── Steady-state: push changeset into coalescing buffer ────
-          if (e.changed) {
-            materialize$.next(e.changeset ?? null);
-          }
-          return EMPTY;
-        }),
-      )
-      .subscribe(),
-  );
-
-  // ── Sync retry timer ──────────────────────────────────────────────
-  //
-  // If the initial sync exchange doesn't produce cells within
-  // SYNC_RETRY_MS (e.g., the daemon's response was consumed by a stale
-  // handle during save-as, or the initial sync message was lost), resend
-  // the sync message. The empty WASM handle requests the full document.
-  // switchMap restarts the timer on each changed:false handshake round.
-  subscription.add(
-    retrySync$
-      .pipe(
-        switchMap(() => timer(SYNC_RETRY_MS)),
-        filter(() => deps.getAwaitingInitialSync()),
-      )
-      .subscribe(() => {
-        logger.info("[frame-pipeline] Retrying sync after timeout");
-        deps.retrySyncToRelay();
-      }),
-  );
-
-  // ── Coalescing buffer → materialization ────────────────────────────
-  //
-  // Collects changesets over a COALESCE_MS window, merges them, then
-  // materializes once. Replaces pendingMaterializeTimerRef +
-  // pendingChangesetRef + pendingFullMaterializeRef.
-
-  subscription.add(
-    materialize$
-      .pipe(
-        bufferTime(COALESCE_MS),
-        filter((batch) => batch.length > 0),
-        // concatMap(_, 1) serializes materialization — if a batch takes
-        // longer than COALESCE_MS (e.g. blob resolution), subsequent
-        // batches queue rather than overlapping and racing store writes.
-        concatMap((batch) =>
-          from(
-            materializeFromBatch(batch, deps).catch((err: unknown) =>
-              logger.warn("[frame-pipeline] materialize batch failed:", err),
-            ),
-          ),
-        ),
-      )
-      .subscribe(),
-  );
-
-  // ── Sub-pipeline: broadcasts ───────────────────────────────────────
-
-  subscription.add(
-    frameEvents$
-      .pipe(filter((e) => e.type === "broadcast" && e.payload != null))
-      .subscribe((e) => emitBroadcast(e.payload)),
-  );
-
-  // ── Sub-pipeline: presence ─────────────────────────────────────────
-
-  subscription.add(
-    frameEvents$
-      .pipe(filter((e) => e.type === "presence" && e.payload != null))
-      .subscribe((e) => emitPresence(e.payload)),
-  );
-
-  // ── Sub-pipeline: runtime state sync ───────────────────────────────
-
-  subscription.add(
-    frameEvents$
-      .pipe(
-        filter((e) => e.type === "runtime_state_sync_applied"),
-        concatMap((e) => {
-          // Update the store when state changed
-          if (e.changed && e.state) {
-            setRuntimeState(e.state as RuntimeState);
-          }
-
-          // Send sync reply so the daemon knows our heads
-          const handle = deps.getHandle();
-          if (handle) {
-            try {
-              const reply = handle.generate_runtime_state_sync_reply();
-              if (reply) {
-                return from(
-                  sendFrame(frame_types.RUNTIME_STATE_SYNC, reply).catch(
-                    (err: unknown) =>
-                      logger.warn(
-                        "[frame-pipeline] runtime state sync reply failed:",
-                        err,
-                      ),
-                  ),
-                );
-              }
-            } catch (err) {
-              logger.warn(
-                "[frame-pipeline] generate_runtime_state_sync_reply failed:",
-                err,
-              );
-            }
-          }
-          return EMPTY;
-        }),
-      )
-      .subscribe(),
-  );
-
-  return subscription;
-}
-
-// ── Internal: batch materialization ─────────────────────────────────
-
-/**
- * Process a coalesced batch of changesets.
+ * Process a coalesced CellChangeset from the SyncEngine.
  *
  * Falls back to full materialization when:
- * - Any frame in the batch lacked a changeset (null entry)
- * - The merged changeset includes structural changes (add/remove/reorder)
+ * - The changeset is null (WASM couldn't produce one)
+ * - The changeset includes structural changes (add/remove/reorder)
  *
  * Otherwise performs surgical per-cell updates using the WASM handle's
  * per-field accessors — O(changed cells) rather than O(all cells).
  */
-async function materializeFromBatch(
-  batch: Array<CellChangeset | null>,
-  deps: FramePipelineDeps,
+export async function materializeChangeset(
+  changeset: CellChangeset | null,
+  deps: MaterializeDeps,
 ): Promise<void> {
-  // Read handle at fire time — not capture time — to avoid use-after-free
-  // if bootstrap() replaced/freed the handle during the coalescing window.
   const handle = deps.getHandle();
   if (!handle) return;
 
-  // Merge all changesets in the batch.
-  let merged: CellChangeset | null = null;
-  let needsFull = false;
-
-  for (const cs of batch) {
-    if (cs === null) {
-      needsFull = true;
-    } else if (merged === null) {
-      merged = cs;
-    } else {
-      merged = mergeChangesets(merged, cs);
-    }
-  }
-
   // ── Full materialization fallback ──────────────────────────────────
 
-  if (needsFull || !merged) {
+  if (!changeset) {
     await deps.materializeCells(handle);
     notifyMetadataChanged();
     return;
@@ -414,9 +73,9 @@ async function materializeFromBatch(
   // Structural changes (cells added/removed/reordered) require full
   // materialization — the cell ID list and ordering need updating.
   if (
-    merged.added.length > 0 ||
-    merged.removed.length > 0 ||
-    merged.order_changed
+    changeset.added.length > 0 ||
+    changeset.removed.length > 0 ||
+    changeset.order_changed
   ) {
     await deps.materializeCells(handle);
     notifyMetadataChanged();
@@ -427,7 +86,7 @@ async function materializeFromBatch(
 
   const cache = deps.outputCache;
 
-  for (const { cell_id: cellId, fields } of merged.changed) {
+  for (const { cell_id: cellId, fields } of changeset.changed) {
     if (fields.outputs) {
       // Check if every output for this cell is already cached.
       const rawOutputs: string[] = handle.get_cell_outputs(cellId) ?? [];
@@ -444,9 +103,6 @@ async function materializeFromBatch(
           getCellById(cellId),
         );
         if (cell) {
-          // Preserve store source when changeset says source didn't change.
-          // WASM source may include a CRDT merge that hasn't been applied
-          // to CodeMirror yet — using it would desync the store from CM.
           if (!fields.source) {
             const existing = getCellById(cellId);
             if (existing) cell.source = existing.source;
@@ -454,8 +110,7 @@ async function materializeFromBatch(
           updateCellById(cellId, () => cell);
         }
       } else {
-        // Cache miss — resolve this cell's outputs async (fetch manifests
-        // from blob store) without re-serializing the entire document.
+        // Cache miss — resolve this cell's outputs async.
         let blobPort = getBlobPort();
         if (blobPort === null) {
           blobPort = await refreshBlobPort();
@@ -471,12 +126,6 @@ async function materializeFromBatch(
           !ecStr || ecStr === "null" ? null : Number.parseInt(ecStr, 10);
         const metadata = handle.get_cell_metadata(cellId) ?? {};
 
-        // Preserve the store's source when the changeset says source didn't
-        // change. Reading from WASM after the await is unsafe — the user may
-        // have typed more keystrokes, and the WASM doc could reflect a CRDT
-        // merge that diverges from CodeMirror's state. Using the stale WASM
-        // source would arm @uiw/react-codemirror's typing latch to overwrite
-        // the editor with the stale value on the next typing pause.
         const existingCell = getCellById(cellId);
         const source = fields.source
           ? (handle.get_cell_source(cellId) ?? "")
@@ -500,7 +149,6 @@ async function materializeFromBatch(
         getCellById(cellId),
       );
       if (cell) {
-        // Preserve store source when changeset says source didn't change.
         if (!fields.source) {
           const existing = getCellById(cellId);
           if (existing) cell.source = existing.source;
@@ -510,8 +158,5 @@ async function materializeFromBatch(
     }
   }
 
-  // Always refresh notebook-level metadata after any sync batch.
-  // The Automerge doc may contain metadata-only changes (e.g. dependency
-  // additions via MCP) that don't appear in the cell changeset.
   notifyMetadataChanged();
 }

--- a/apps/notebook/src/lib/runtime-state.ts
+++ b/apps/notebook/src/lib/runtime-state.ts
@@ -1,160 +1,33 @@
 /**
  * Runtime state store — reactive state from the daemon's RuntimeStateDoc.
  *
- * The daemon syncs kernel status, execution queue, environment sync state,
- * and last-saved timestamp via a per-notebook Automerge document. The WASM
- * layer deserializes it into a RuntimeState snapshot. This module holds the
- * latest snapshot and notifies subscribers on change.
- *
- * Components use `useRuntimeState()` to subscribe.
+ * Types and diffing logic live in the `runtimed` package (pure, no React).
+ * This module adds the React-specific store (useSyncExternalStore) on top.
  */
 
 import { useSyncExternalStore } from "react";
 
-// ── Types ────────────────────────────────────────────────────────────
+// Re-export all types from the package so existing imports work.
+export type {
+  EnvState,
+  ExecutionState,
+  ExecutionTransition,
+  KernelState,
+  QueueEntry,
+  QueueState,
+  RuntimeState,
+  TrustState,
+} from "runtimed/src/runtime-state";
 
-export interface KernelState {
-  status: string;
-  starting_phase: string;
-  name: string;
-  language: string;
-  env_source: string;
-}
+export {
+  DEFAULT_RUNTIME_STATE,
+  diffExecutions,
+} from "runtimed/src/runtime-state";
 
-export interface QueueEntry {
-  cell_id: string;
-  execution_id: string;
-}
-
-export interface QueueState {
-  executing: QueueEntry | null;
-  queued: QueueEntry[];
-}
-
-export interface EnvState {
-  in_sync: boolean;
-  added: string[];
-  removed: string[];
-  channels_changed: boolean;
-  deno_changed: boolean;
-}
-
-export interface TrustState {
-  status: string;
-  needs_approval: boolean;
-}
-
-export interface ExecutionState {
-  cell_id: string;
-  status: "queued" | "running" | "done" | "error";
-  execution_count: number | null;
-  success: boolean | null;
-}
-
-/** A detected status transition for a single execution. */
-export interface ExecutionTransition {
-  execution_id: string;
-  cell_id: string;
-  kind: "started" | "done" | "error";
-  execution_count: number | null;
-}
-
-/**
- * Diff two executions maps to detect status transitions.
- *
- * Returns transitions for:
- * - New entry or "queued"→"running" → "started"
- * - "running"→"done" → "done"
- * - "running"→"error" or "queued"→"error" (kernel death) → "error"
- *
- * Slow joiners see the final state — no missed transitions. If a sync
- * batches multiple changes (queued→done in one round), we emit the
- * terminal event only.
- */
-export function diffExecutions(
-  prev: Record<string, ExecutionState>,
-  curr: Record<string, ExecutionState>,
-): ExecutionTransition[] {
-  const transitions: ExecutionTransition[] = [];
-
-  for (const [eid, entry] of Object.entries(curr)) {
-    const prevEntry = prev[eid];
-    const prevStatus = prevEntry?.status;
-    const currStatus = entry.status;
-
-    // No change
-    if (prevStatus === currStatus) continue;
-
-    // Terminal states: done or error
-    if (currStatus === "done") {
-      transitions.push({
-        execution_id: eid,
-        cell_id: entry.cell_id,
-        kind: "done",
-        execution_count: entry.execution_count,
-      });
-    } else if (currStatus === "error") {
-      transitions.push({
-        execution_id: eid,
-        cell_id: entry.cell_id,
-        kind: "error",
-        execution_count: entry.execution_count,
-      });
-    } else if (
-      currStatus === "running" &&
-      prevStatus !== "done" &&
-      prevStatus !== "error"
-    ) {
-      // Started (queued→running or new→running)
-      transitions.push({
-        execution_id: eid,
-        cell_id: entry.cell_id,
-        kind: "started",
-        execution_count: entry.execution_count,
-      });
-    }
-  }
-
-  return transitions;
-}
-
-export interface RuntimeState {
-  kernel: KernelState;
-  queue: QueueState;
-  env: EnvState;
-  trust: TrustState;
-  last_saved: string | null;
-  executions: Record<string, ExecutionState>;
-}
-
-// ── Default state ────────────────────────────────────────────────────
-
-const DEFAULT_RUNTIME_STATE: RuntimeState = {
-  kernel: {
-    status: "not_started",
-    starting_phase: "",
-    name: "",
-    language: "",
-    env_source: "",
-  },
-  queue: {
-    executing: null,
-    queued: [],
-  },
-  env: {
-    in_sync: true,
-    added: [],
-    removed: [],
-    channels_changed: false,
-    deno_changed: false,
-  },
-  trust: {
-    status: "no_dependencies",
-    needs_approval: false,
-  },
-  last_saved: null,
-  executions: {},
-};
+import {
+  DEFAULT_RUNTIME_STATE,
+  type RuntimeState,
+} from "runtimed/src/runtime-state";
 
 // ── Store ────────────────────────────────────────────────────────────
 

--- a/apps/notebook/src/lib/runtime-state.ts
+++ b/apps/notebook/src/lib/runtime-state.ts
@@ -17,17 +17,11 @@ export type {
   QueueState,
   RuntimeState,
   TrustState,
-} from "runtimed/src/runtime-state";
+} from "runtimed";
 
-export {
-  DEFAULT_RUNTIME_STATE,
-  diffExecutions,
-} from "runtimed/src/runtime-state";
+export { DEFAULT_RUNTIME_STATE, diffExecutions } from "runtimed";
 
-import {
-  DEFAULT_RUNTIME_STATE,
-  type RuntimeState,
-} from "runtimed/src/runtime-state";
+import { DEFAULT_RUNTIME_STATE, type RuntimeState } from "runtimed";
 
 // ── Store ────────────────────────────────────────────────────────────
 

--- a/apps/notebook/src/lib/tauri-transport.ts
+++ b/apps/notebook/src/lib/tauri-transport.ts
@@ -1,0 +1,71 @@
+/**
+ * TauriTransport — NotebookTransport implementation for the Tauri desktop app.
+ *
+ * Bridges the runtimed SyncEngine to the daemon via Tauri IPC:
+ *   - sendFrame → invoke("send_frame", bytes)
+ *   - onFrame → getCurrentWebview().listen("notebook:frame")
+ */
+
+import { invoke } from "@tauri-apps/api/core";
+import { getCurrentWebview } from "@tauri-apps/api/webview";
+import type { FrameListener, NotebookTransport } from "runtimed";
+
+export class TauriTransport implements NotebookTransport {
+  private _connected = true;
+  private unlisteners: Array<() => void> = [];
+
+  get connected(): boolean {
+    return this._connected;
+  }
+
+  async sendFrame(frameType: number, payload: Uint8Array): Promise<void> {
+    const frame = new Uint8Array(1 + payload.length);
+    frame[0] = frameType;
+    frame.set(payload, 1);
+    return invoke("send_frame", frame);
+  }
+
+  onFrame(callback: FrameListener): () => void {
+    const webview = getCurrentWebview();
+
+    // webview.listen returns Promise<UnlistenFn>. We track it for cleanup.
+    let unlistenFn: (() => void) | null = null;
+    let cancelled = false;
+
+    const unlistenPromise = webview.listen<number[]>(
+      "notebook:frame",
+      (event) => {
+        callback(event.payload);
+      },
+    );
+
+    unlistenPromise
+      .then((fn) => {
+        if (cancelled) {
+          fn();
+        } else {
+          unlistenFn = fn;
+        }
+      })
+      .catch(() => {});
+
+    const unlisten = () => {
+      cancelled = true;
+      if (unlistenFn) {
+        unlistenFn();
+        unlistenFn = null;
+      }
+    };
+
+    this.unlisteners.push(unlisten);
+    return unlisten;
+  }
+
+  disconnect(): void {
+    this._connected = false;
+    for (const unlisten of this.unlisteners) {
+      unlisten();
+    }
+    this.unlisteners = [];
+  }
+}

--- a/packages/runtimed/package.json
+++ b/packages/runtimed/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "runtimed",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./src/*": "./src/*"
+  },
+  "dependencies": {
+    "rxjs": "^7.8.2"
+  }
+}

--- a/packages/runtimed/src/cell-changeset.ts
+++ b/packages/runtimed/src/cell-changeset.ts
@@ -1,0 +1,67 @@
+/**
+ * CellChangeset types and merge utilities.
+ *
+ * Pure module with zero external dependencies — safe to import from
+ * unit tests without pulling in Tauri, RxJS, or WASM runtime.
+ *
+ * Mirrors the Rust `notebook_doc::diff` types serialized from WASM
+ * via serde-wasm-bindgen.
+ */
+
+// ── Types ────────────────────────────────────────────────────────────
+
+/** Which fields changed on a cell (only `true` keys are present). */
+export interface ChangedFields {
+  source?: boolean;
+  outputs?: boolean;
+  execution_count?: boolean;
+  cell_type?: boolean;
+  metadata?: boolean;
+  position?: boolean;
+  resolved_assets?: boolean;
+}
+
+export interface ChangedCell {
+  cell_id: string;
+  fields: ChangedFields;
+}
+
+/** Structural diff between two Automerge head sets, produced by WASM `diff_cells`. */
+export interface CellChangeset {
+  changed: ChangedCell[];
+  added: string[];
+  removed: string[];
+  order_changed: boolean;
+}
+
+// ── Utilities ────────────────────────────────────────────────────────
+
+/**
+ * Merge two CellChangesets (for coalescing frames across a buffer window).
+ *
+ * Field unions are additive — if either changeset marks a field as changed,
+ * the merged result marks it as changed. Added/removed lists are deduplicated.
+ * `order_changed` is true if either input is true.
+ */
+export function mergeChangesets(
+  a: CellChangeset,
+  b: CellChangeset,
+): CellChangeset {
+  const changedMap = new Map<string, ChangedFields>();
+  for (const c of [...a.changed, ...b.changed]) {
+    const existing = changedMap.get(c.cell_id);
+    if (existing) {
+      for (const [key, val] of Object.entries(c.fields)) {
+        if (val) (existing as Record<string, boolean>)[key] = true;
+      }
+    } else {
+      changedMap.set(c.cell_id, { ...c.fields });
+    }
+  }
+  return {
+    changed: [...changedMap].map(([cell_id, fields]) => ({ cell_id, fields })),
+    added: [...new Set([...a.added, ...b.added])],
+    removed: [...new Set([...a.removed, ...b.removed])],
+    order_changed: a.order_changed || b.order_changed,
+  };
+}

--- a/packages/runtimed/src/direct-transport.ts
+++ b/packages/runtimed/src/direct-transport.ts
@@ -1,0 +1,195 @@
+/**
+ * DirectTransport — test transport that connects a SyncEngine to a
+ * "server" handle without any network or IPC.
+ *
+ * Simulates the daemon side: inbound frames from the server are delivered
+ * to the client's `onFrame` subscribers, and outbound frames from the
+ * client are applied to the server handle.
+ *
+ * Usage:
+ * ```ts
+ * const transport = new DirectTransport(serverHandle);
+ * const engine = new SyncEngine({
+ *   getHandle: () => clientHandle,
+ *   transport,
+ * });
+ * engine.start();
+ *
+ * // Push server changes to the client:
+ * serverHandle.update_source("cell-1", "hello");
+ * transport.pushServerChanges();
+ * ```
+ */
+
+import { FrameType } from "./transport";
+import type { NotebookTransport, FrameListener } from "./transport";
+
+// ── Server handle interface ──────────────────────────────────────────
+
+/**
+ * Minimal interface for the server-side handle used by DirectTransport.
+ *
+ * This is the subset of NotebookHandle methods needed to simulate the daemon:
+ * - Generate sync messages (to push to the client)
+ * - Receive sync messages (from the client)
+ */
+export interface ServerHandle {
+  /** Generate a sync message for pending changes. */
+  flush_local_changes(): Uint8Array | null;
+
+  /** Apply a sync message from the client. Returns whether doc changed. */
+  receive_sync_message(message: Uint8Array): boolean;
+
+  /** Reset sync state (for reconnection simulation). */
+  reset_sync_state(): void;
+}
+
+// ── DirectTransport ──────────────────────────────────────────────────
+
+/**
+ * Test transport connecting a client SyncEngine directly to a server handle.
+ *
+ * Frame delivery is synchronous — `pushServerChanges()` generates a sync
+ * message from the server and delivers it immediately. This makes tests
+ * deterministic.
+ */
+export class DirectTransport implements NotebookTransport {
+  private readonly server: ServerHandle;
+  private subscribers = new Set<FrameListener>();
+  private _connected = true;
+
+  /** Track sent frames for test assertions. */
+  readonly sentFrames: Array<{ frameType: number; payload: Uint8Array }> = [];
+
+  /** Track transport failures for rollback testing. */
+  sendFailureCount = 0;
+
+  /**
+   * If true, `sendFrame` will reject — simulating transport failure.
+   * Used to test rollback behavior (cancel_last_flush).
+   */
+  simulateFailure = false;
+
+  constructor(server: ServerHandle) {
+    this.server = server;
+  }
+
+  // ── NotebookTransport ──────────────────────────────────────────
+
+  get connected(): boolean {
+    return this._connected;
+  }
+
+  async sendFrame(frameType: number, payload: Uint8Array): Promise<void> {
+    if (!this._connected) {
+      throw new Error("DirectTransport: not connected");
+    }
+
+    if (this.simulateFailure) {
+      this.sendFailureCount++;
+      throw new Error("DirectTransport: simulated send failure");
+    }
+
+    this.sentFrames.push({ frameType, payload });
+
+    // Route to server based on frame type.
+    if (frameType === FrameType.AUTOMERGE_SYNC) {
+      this.server.receive_sync_message(payload);
+    }
+    // RUNTIME_STATE_SYNC, PRESENCE, etc. — just record, no server action.
+  }
+
+  onFrame(callback: FrameListener): () => void {
+    this.subscribers.add(callback);
+    return () => {
+      this.subscribers.delete(callback);
+    };
+  }
+
+  disconnect(): void {
+    this._connected = false;
+    this.subscribers.clear();
+  }
+
+  // ── Test helpers ───────────────────────────────────────────────
+
+  /**
+   * Push the server's pending changes to all client subscribers.
+   *
+   * Generates a sync message from the server handle, wraps it as a
+   * typed frame (0x00 prefix + payload), and delivers it to all
+   * `onFrame` subscribers as a `number[]`.
+   *
+   * Returns true if a sync message was generated and delivered.
+   */
+  pushServerChanges(): boolean {
+    const msg = this.server.flush_local_changes();
+    if (!msg) return false;
+
+    const frame = new Uint8Array(1 + msg.length);
+    frame[0] = FrameType.AUTOMERGE_SYNC;
+    frame.set(msg, 1);
+
+    // Deliver as number[] to match Tauri's event payload format.
+    this.deliver(Array.from(frame));
+    return true;
+  }
+
+  /**
+   * Push a broadcast event to all client subscribers.
+   */
+  pushBroadcast(payload: unknown): void {
+    const json = JSON.stringify(payload);
+    const bytes = new TextEncoder().encode(json);
+    const frame = new Uint8Array(1 + bytes.length);
+    frame[0] = FrameType.BROADCAST;
+    frame.set(bytes, 1);
+    this.deliver(Array.from(frame));
+  }
+
+  /**
+   * Push a presence event to all client subscribers.
+   */
+  pushPresence(payload: Uint8Array): void {
+    const frame = new Uint8Array(1 + payload.length);
+    frame[0] = FrameType.PRESENCE;
+    frame.set(payload, 1);
+    this.deliver(Array.from(frame));
+  }
+
+  /**
+   * Deliver a raw frame (number[]) to all subscribers.
+   */
+  deliver(frame: number[]): void {
+    for (const cb of this.subscribers) {
+      try {
+        cb(frame);
+      } catch (err) {
+        console.error("[DirectTransport] subscriber error:", err);
+      }
+    }
+  }
+
+  /**
+   * Run sync cycles between server and client until convergence.
+   */
+  syncUntilConverged(maxRounds = 10): number {
+    let rounds = 0;
+    for (let i = 0; i < maxRounds; i++) {
+      const pushed = this.pushServerChanges();
+      if (!pushed) break;
+      rounds++;
+    }
+    return rounds;
+  }
+
+  /** Clear recorded sent frames. */
+  clearSentFrames(): void {
+    this.sentFrames.length = 0;
+  }
+
+  /** Reconnect after a disconnect. */
+  reconnect(): void {
+    this._connected = true;
+  }
+}

--- a/packages/runtimed/src/handle.ts
+++ b/packages/runtimed/src/handle.ts
@@ -1,0 +1,85 @@
+/**
+ * SyncableHandle — minimal interface for the WASM NotebookHandle.
+ *
+ * The SyncEngine operates against this interface rather than the concrete
+ * WASM class, enabling testing with mocks and future alternative
+ * implementations.
+ *
+ * Methods mirror the subset of `NotebookHandle` used by the sync pipeline.
+ * Cell mutation methods (add_cell, update_source, etc.) are NOT part of
+ * this interface — they're used directly by consumers, not the engine.
+ */
+
+import type { CellChangeset } from "./cell-changeset";
+
+// ── FrameEvent ───────────────────────────────────────────────────────
+
+/** Attribution for text changes, produced by WASM sync. */
+export interface TextAttribution {
+  cell_id: string;
+  index: number;
+  text: string;
+  deleted: number;
+  actors: string[];
+}
+
+/** Typed event returned by WASM `receive_frame()`. */
+export interface FrameEvent {
+  type: string;
+  changed?: boolean;
+  changeset?: CellChangeset;
+  attributions?: TextAttribution[];
+  /** Inline sync reply bytes from receive_frame (#1067 fix). */
+  reply?: number[];
+  payload?: unknown;
+  /** RuntimeState from RuntimeStateSyncApplied. */
+  state?: unknown;
+}
+
+// ── SyncableHandle ───────────────────────────────────────────────────
+
+export interface SyncableHandle {
+  /**
+   * Process an inbound frame from the daemon.
+   *
+   * Returns an array of typed events (sync_applied, broadcast, presence,
+   * runtime_state_sync_applied, unknown).
+   */
+  receive_frame(bytes: Uint8Array): FrameEvent[] | null;
+
+  /**
+   * Flush local Automerge changes into a sync message.
+   *
+   * Returns the message bytes, or null if there are no pending changes.
+   * Advances internal sync state (sent_hashes) — call `cancel_last_flush()`
+   * if the send fails.
+   */
+  flush_local_changes(): Uint8Array | null;
+
+  /**
+   * Roll back the sync state advanced by the last `flush_local_changes()`.
+   *
+   * Prevents sent_hashes from permanently filtering out change data
+   * the daemon never received.
+   */
+  cancel_last_flush(): void;
+
+  /**
+   * Flush RuntimeStateDoc sync message.
+   *
+   * Returns the message bytes, or null if there are no pending changes.
+   */
+  flush_runtime_state_sync(): Uint8Array | null;
+
+  /** Roll back the last RuntimeStateDoc flush. */
+  cancel_last_runtime_state_flush(): void;
+
+  /** Generate a sync reply for the RuntimeStateDoc. */
+  generate_runtime_state_sync_reply(): Uint8Array | null;
+
+  /** Reset sync state so the next flush requests the full document. */
+  reset_sync_state(): void;
+
+  /** Number of cells in the document. */
+  cell_count(): number;
+}

--- a/packages/runtimed/src/index.ts
+++ b/packages/runtimed/src/index.ts
@@ -41,3 +41,7 @@ export {
   DEFAULT_RUNTIME_STATE,
   diffExecutions,
 } from "./runtime-state";
+
+// Testing
+export { DirectTransport } from "./direct-transport";
+export type { ServerHandle } from "./direct-transport";

--- a/packages/runtimed/src/index.ts
+++ b/packages/runtimed/src/index.ts
@@ -1,0 +1,43 @@
+/**
+ * runtimed — transport-agnostic notebook client library.
+ *
+ * Sync with the runtimed daemon from any JS runtime (Tauri, browser,
+ * Node, Deno) without framework-specific dependencies.
+ */
+
+// Core
+export { SyncEngine } from "./sync-engine";
+export type { SyncEngineOptions, SyncEngineLogger } from "./sync-engine";
+
+// Transport
+export type { NotebookTransport, FrameListener } from "./transport";
+export { FrameType, type FrameTypeValue } from "./transport";
+
+// Handle
+export type {
+  SyncableHandle,
+  FrameEvent,
+  TextAttribution,
+} from "./handle";
+
+// Cell changeset
+export {
+  type CellChangeset,
+  type ChangedCell,
+  type ChangedFields,
+  mergeChangesets,
+} from "./cell-changeset";
+
+// Runtime state
+export {
+  type RuntimeState,
+  type KernelState,
+  type QueueEntry,
+  type QueueState,
+  type EnvState,
+  type TrustState,
+  type ExecutionState,
+  type ExecutionTransition,
+  DEFAULT_RUNTIME_STATE,
+  diffExecutions,
+} from "./runtime-state";

--- a/packages/runtimed/src/runtime-state.ts
+++ b/packages/runtimed/src/runtime-state.ts
@@ -1,0 +1,153 @@
+/**
+ * Runtime state types from the daemon's RuntimeStateDoc.
+ *
+ * Pure module — no React, no Tauri. Consumers that need a reactive store
+ * (e.g. React's useSyncExternalStore) build their own on top of these types.
+ */
+
+// ── Types ────────────────────────────────────────────────────────────
+
+export interface KernelState {
+  status: string;
+  starting_phase: string;
+  name: string;
+  language: string;
+  env_source: string;
+}
+
+export interface QueueEntry {
+  cell_id: string;
+  execution_id: string;
+}
+
+export interface QueueState {
+  executing: QueueEntry | null;
+  queued: QueueEntry[];
+}
+
+export interface EnvState {
+  in_sync: boolean;
+  added: string[];
+  removed: string[];
+  channels_changed: boolean;
+  deno_changed: boolean;
+}
+
+export interface TrustState {
+  status: string;
+  needs_approval: boolean;
+}
+
+export interface ExecutionState {
+  cell_id: string;
+  status: "queued" | "running" | "done" | "error";
+  execution_count: number | null;
+  success: boolean | null;
+}
+
+/** A detected status transition for a single execution. */
+export interface ExecutionTransition {
+  execution_id: string;
+  cell_id: string;
+  kind: "started" | "done" | "error";
+  execution_count: number | null;
+}
+
+export interface RuntimeState {
+  kernel: KernelState;
+  queue: QueueState;
+  env: EnvState;
+  trust: TrustState;
+  last_saved: string | null;
+  executions: Record<string, ExecutionState>;
+}
+
+// ── Defaults ─────────────────────────────────────────────────────────
+
+export const DEFAULT_RUNTIME_STATE: RuntimeState = {
+  kernel: {
+    status: "not_started",
+    starting_phase: "",
+    name: "",
+    language: "",
+    env_source: "",
+  },
+  queue: {
+    executing: null,
+    queued: [],
+  },
+  env: {
+    in_sync: true,
+    added: [],
+    removed: [],
+    channels_changed: false,
+    deno_changed: false,
+  },
+  trust: {
+    status: "no_dependencies",
+    needs_approval: false,
+  },
+  last_saved: null,
+  executions: {},
+};
+
+// ── Utilities ────────────────────────────────────────────────────────
+
+/**
+ * Diff two executions maps to detect status transitions.
+ *
+ * Returns transitions for:
+ * - New entry or "queued"→"running" → "started"
+ * - "running"→"done" → "done"
+ * - "running"→"error" or "queued"→"error" (kernel death) → "error"
+ *
+ * Slow joiners see the final state — no missed transitions. If a sync
+ * batches multiple changes (queued→done in one round), we emit the
+ * terminal event only.
+ */
+export function diffExecutions(
+  prev: Record<string, ExecutionState>,
+  curr: Record<string, ExecutionState>,
+): ExecutionTransition[] {
+  const transitions: ExecutionTransition[] = [];
+
+  for (const [eid, entry] of Object.entries(curr)) {
+    const prevEntry = prev[eid];
+    const prevStatus = prevEntry?.status;
+    const currStatus = entry.status;
+
+    // No change
+    if (prevStatus === currStatus) continue;
+
+    // Terminal states: done or error
+    if (currStatus === "done") {
+      transitions.push({
+        execution_id: eid,
+        cell_id: entry.cell_id,
+        kind: "done",
+        execution_count: entry.execution_count,
+      });
+    } else if (currStatus === "error") {
+      transitions.push({
+        execution_id: eid,
+        cell_id: entry.cell_id,
+        kind: "error",
+        execution_count: entry.execution_count,
+      });
+    } else if (
+      currStatus === "running" &&
+      prevStatus !== "done" &&
+      prevStatus !== "error"
+    ) {
+      // Started (queued→running or new→running)
+      transitions.push({
+        execution_id: eid,
+        cell_id: entry.cell_id,
+        kind: "started",
+        execution_count: entry.execution_count,
+      });
+    }
+  }
+
+  return transitions;
+}

--- a/packages/runtimed/src/sync-engine.ts
+++ b/packages/runtimed/src/sync-engine.ts
@@ -1,0 +1,474 @@
+/**
+ * SyncEngine — transport-agnostic notebook sync engine.
+ *
+ * Owns all sync state between a local WASM NotebookHandle and the daemon:
+ *   - Inbound frame processing (WASM demux → typed events)
+ *   - Inline sync reply with rollback on transport failure
+ *   - Initial sync handshake with retry
+ *   - Coalescing buffer (32ms) for cell changesets
+ *   - RuntimeStateDoc sync + execution lifecycle diffing
+ *   - Debounced outbound flush of local CRDT mutations
+ *
+ * Emits typed RxJS observables that consumers subscribe to for
+ * materialization, broadcast dispatch, presence routing, etc.
+ *
+ * Zero Tauri / React / browser dependencies.
+ */
+
+import {
+  bufferTime,
+  concatMap,
+  debounceTime,
+  EMPTY,
+  filter,
+  from,
+  mergeMap,
+  Observable,
+  ReplaySubject,
+  share,
+  Subject,
+  Subscription,
+  switchMap,
+  timer,
+} from "rxjs";
+
+import { type CellChangeset, mergeChangesets } from "./cell-changeset";
+import type { FrameEvent, SyncableHandle } from "./handle";
+import {
+  type ExecutionTransition,
+  type RuntimeState,
+  type ExecutionState,
+  diffExecutions,
+} from "./runtime-state";
+import { FrameType } from "./transport";
+import type { NotebookTransport } from "./transport";
+
+// ── Constants ────────────────────────────────────────────────────────
+
+/** Coalescing window for incoming sync frames (ms). */
+const COALESCE_MS = 32;
+
+/** Timeout before retrying sync if initial sync hasn't produced cells (ms). */
+const SYNC_RETRY_MS = 3000;
+
+/** Debounce interval for outbound source sync (ms). */
+const FLUSH_DEBOUNCE_MS = 20;
+
+// ── Logger interface ─────────────────────────────────────────────────
+
+export interface SyncEngineLogger {
+  info(msg: string, ...args: unknown[]): void;
+  warn(msg: string, ...args: unknown[]): void;
+  error(msg: string, ...args: unknown[]): void;
+}
+
+const nullLogger: SyncEngineLogger = {
+  info() {},
+  warn() {},
+  error() {},
+};
+
+// ── Options ──────────────────────────────────────────────────────────
+
+export interface SyncEngineOptions {
+  /**
+   * Read the current WASM handle (null during bootstrap).
+   *
+   * A getter rather than a direct reference so the engine never holds
+   * a stale handle across bootstrap cycles.
+   */
+  getHandle: () => SyncableHandle | null;
+
+  /** Pluggable transport to the daemon. */
+  transport: NotebookTransport;
+
+  /** Optional logger (defaults to silent). */
+  logger?: SyncEngineLogger;
+}
+
+// ── SyncEngine ───────────────────────────────────────────────────────
+
+export class SyncEngine {
+  private readonly opts: Required<SyncEngineOptions>;
+  private subscription: Subscription | null = null;
+  private awaitingInitialSync = true;
+  private prevExecutions: Record<string, ExecutionState> = {};
+
+  // Internal subjects
+  private readonly frameIn$ = new Subject<number[]>();
+  private readonly flushRequest$ = new Subject<void>();
+
+  // ── Public observables ───────────────────────────────────────────
+
+  /**
+   * Coalesced cell changesets from inbound sync frames.
+   *
+   * Each emission is a merged CellChangeset covering a 32ms window,
+   * or `null` when a full materialization is needed (no changeset
+   * available from WASM).
+   */
+  readonly cellChanges$: Observable<CellChangeset | null>;
+
+  /** Daemon broadcast payloads (kernel status, output, env progress, text attributions). */
+  readonly broadcasts$: Observable<unknown>;
+
+  /** Remote peer presence updates (cursor, selection, snapshot, left, heartbeat). */
+  readonly presence$: Observable<unknown>;
+
+  /** RuntimeState snapshots from the daemon's RuntimeStateDoc. */
+  readonly runtimeState$: Observable<RuntimeState>;
+
+  /** Execution lifecycle transitions detected from RuntimeState diffs. */
+  readonly executionTransitions$: Observable<ExecutionTransition[]>;
+
+  /**
+   * Fires once when the initial sync handshake completes (daemon has
+   * sent document content). Consumers should do their first full
+   * materialization in response.
+   */
+  readonly initialSyncComplete$: Observable<void>;
+
+  // Backing subjects for public observables
+  private readonly _cellChanges$ = new Subject<CellChangeset | null>();
+  private readonly _broadcasts$ = new Subject<unknown>();
+  private readonly _presence$ = new Subject<unknown>();
+  private readonly _runtimeState$ = new Subject<RuntimeState>();
+  private readonly _executionTransitions$ = new Subject<
+    ExecutionTransition[]
+  >();
+  private readonly _initialSyncComplete$ = new ReplaySubject<void>(1);
+
+  constructor(opts: SyncEngineOptions) {
+    this.opts = {
+      ...opts,
+      logger: opts.logger ?? nullLogger,
+    };
+
+    // Expose as readonly Observable (hide Subject internals)
+    this.cellChanges$ = this._cellChanges$.asObservable();
+    this.broadcasts$ = this._broadcasts$.asObservable();
+    this.presence$ = this._presence$.asObservable();
+    this.runtimeState$ = this._runtimeState$.asObservable();
+    this.executionTransitions$ = this._executionTransitions$.asObservable();
+    this.initialSyncComplete$ = this._initialSyncComplete$.asObservable();
+  }
+
+  // ── Lifecycle ────────────────────────────────────────────────────
+
+  /**
+   * Start processing frames from the transport.
+   *
+   * Subscribes to the transport's frame listener and wires up all
+   * internal RxJS pipelines. Call `stop()` to tear everything down.
+   */
+  start(): void {
+    if (this.subscription) return; // already running
+
+    const sub = (this.subscription = new Subscription());
+    const log = this.opts.logger;
+
+    // Wire transport frames into the internal subject
+    const unlisten = this.opts.transport.onFrame((payload) => {
+      this.frameIn$.next(payload);
+    });
+    sub.add(() => unlisten());
+
+    // Subject for the sync retry timer
+    const retrySync$ = new Subject<void>();
+    sub.add(() => retrySync$.complete());
+
+    // Arm the retry timer immediately
+    retrySync$.next();
+
+    // Subject bridging sync_applied events into the coalescing buffer
+    const materialize$ = new Subject<CellChangeset | null>();
+    sub.add(() => materialize$.complete());
+
+    // ── Source: frames → WASM demux → individual FrameEvents ──────
+
+    const frameEvents$ = this.frameIn$.pipe(
+      mergeMap((payload) => {
+        try {
+          const handle = this.opts.getHandle();
+          if (!handle) return EMPTY;
+          const bytes = new Uint8Array(payload);
+          const result = handle.receive_frame(bytes);
+          if (!result || !Array.isArray(result)) return EMPTY;
+          return from(result as FrameEvent[]);
+        } catch (e) {
+          log.warn("[sync-engine] receive_frame failed:", e);
+          return EMPTY;
+        }
+      }),
+      share(),
+    );
+
+    // ── Sub-pipeline: sync_applied → initial sync / coalesce ──────
+
+    sub.add(
+      frameEvents$
+        .pipe(
+          filter((e) => e.type === "sync_applied"),
+          concatMap((e) => {
+            // Attributions → broadcast
+            if (e.attributions && e.attributions.length > 0) {
+              this._broadcasts$.next({
+                type: "text_attribution",
+                attributions: e.attributions,
+              });
+            }
+
+            // Send inline sync reply
+            if (e.reply) {
+              this.opts.transport
+                .sendFrame(
+                  FrameType.AUTOMERGE_SYNC,
+                  new Uint8Array(e.reply),
+                )
+                .catch((err: unknown) => {
+                  const handle = this.opts.getHandle();
+                  if (handle) {
+                    handle.cancel_last_flush();
+                  }
+                  log.warn(
+                    "[sync-engine] inline sync reply send failed, rolled back sync state:",
+                    err,
+                  );
+                });
+            }
+
+            // Initial sync
+            if (this.awaitingInitialSync) {
+              if (e.changed) {
+                this.awaitingInitialSync = false;
+                this._initialSyncComplete$.next();
+                this._initialSyncComplete$.complete();
+              }
+              // Restart retry timer on handshake rounds
+              retrySync$.next();
+              return EMPTY;
+            }
+
+            // Steady-state: push changeset into coalescing buffer
+            if (e.changed) {
+              materialize$.next(e.changeset ?? null);
+            }
+            return EMPTY;
+          }),
+        )
+        .subscribe(),
+    );
+
+    // ── Sync retry timer ──────────────────────────────────────────
+
+    sub.add(
+      retrySync$
+        .pipe(
+          switchMap(() => timer(SYNC_RETRY_MS)),
+          filter(() => this.awaitingInitialSync),
+        )
+        .subscribe(() => {
+          log.info("[sync-engine] Retrying sync after timeout");
+          this.resetAndResync();
+        }),
+    );
+
+    // ── Coalescing buffer → cellChanges$ ──────────────────────────
+
+    sub.add(
+      materialize$
+        .pipe(
+          bufferTime(COALESCE_MS),
+          filter((batch) => batch.length > 0),
+          concatMap((batch) => {
+            // Merge all changesets in the batch
+            let merged: CellChangeset | null = null;
+            let needsFull = false;
+
+            for (const cs of batch) {
+              if (cs === null) {
+                needsFull = true;
+              } else if (merged === null) {
+                merged = cs;
+              } else {
+                merged = mergeChangesets(merged, cs);
+              }
+            }
+
+            this._cellChanges$.next(needsFull ? null : merged);
+            return EMPTY;
+          }),
+        )
+        .subscribe(),
+    );
+
+    // ── Sub-pipeline: broadcasts ──────────────────────────────────
+
+    sub.add(
+      frameEvents$
+        .pipe(filter((e) => e.type === "broadcast" && e.payload != null))
+        .subscribe((e) => this._broadcasts$.next(e.payload)),
+    );
+
+    // ── Sub-pipeline: presence ────────────────────────────────────
+
+    sub.add(
+      frameEvents$
+        .pipe(filter((e) => e.type === "presence" && e.payload != null))
+        .subscribe((e) => this._presence$.next(e.payload)),
+    );
+
+    // ── Sub-pipeline: runtime state sync ──────────────────────────
+
+    sub.add(
+      frameEvents$
+        .pipe(
+          filter((e) => e.type === "runtime_state_sync_applied"),
+          concatMap((e) => {
+            if (e.changed && e.state) {
+              const state = e.state as RuntimeState;
+
+              // Diff executions for lifecycle transitions
+              const transitions = diffExecutions(
+                this.prevExecutions,
+                state.executions,
+              );
+              this.prevExecutions = state.executions;
+
+              this._runtimeState$.next(state);
+              if (transitions.length > 0) {
+                this._executionTransitions$.next(transitions);
+              }
+            }
+
+            // Send sync reply so the daemon knows our heads
+            const handle = this.opts.getHandle();
+            if (handle) {
+              try {
+                const reply = handle.generate_runtime_state_sync_reply();
+                if (reply) {
+                  return from(
+                    this.opts.transport
+                      .sendFrame(FrameType.RUNTIME_STATE_SYNC, reply)
+                      .catch((err: unknown) =>
+                        log.warn(
+                          "[sync-engine] runtime state sync reply failed:",
+                          err,
+                        ),
+                      ),
+                  );
+                }
+              } catch (err) {
+                log.warn(
+                  "[sync-engine] generate_runtime_state_sync_reply failed:",
+                  err,
+                );
+              }
+            }
+            return EMPTY;
+          }),
+        )
+        .subscribe(),
+    );
+
+    // ── Debounced outbound flush ──────────────────────────────────
+
+    sub.add(
+      this.flushRequest$.pipe(debounceTime(FLUSH_DEBOUNCE_MS)).subscribe(() => {
+        this.flush();
+      }),
+    );
+  }
+
+  /**
+   * Stop all pipelines and clean up subscriptions.
+   */
+  stop(): void {
+    if (!this.subscription) return;
+    this.subscription.unsubscribe();
+    this.subscription = null;
+  }
+
+  /** Whether the engine is currently running. */
+  get running(): boolean {
+    return this.subscription !== null;
+  }
+
+  // ── Outbound sync ────────────────────────────────────────────────
+
+  /**
+   * Flush local CRDT mutations to the daemon immediately.
+   *
+   * Sends both the notebook doc sync message and the RuntimeStateDoc
+   * sync message. On transport failure, rolls back sync state to
+   * prevent the consumption race from #1067.
+   */
+  flush(): void {
+    const handle = this.opts.getHandle();
+    if (!handle) return;
+
+    const msg = handle.flush_local_changes();
+    if (msg) {
+      this.opts.transport
+        .sendFrame(FrameType.AUTOMERGE_SYNC, msg)
+        .catch((e: unknown) => {
+          handle.cancel_last_flush();
+          this.opts.logger.warn(
+            "[sync-engine] sync to relay failed:",
+            e,
+          );
+        });
+    }
+
+    // Also flush RuntimeStateDoc sync so the daemon sends kernel status,
+    // trust state, etc. Without this, if the daemon's initial RuntimeStateSync
+    // frame arrived before the WASM handle was ready, the frontend would stay
+    // stuck on "not_started" (#runtime-state-race).
+    const stateMsg = handle.flush_runtime_state_sync();
+    if (stateMsg) {
+      this.opts.transport
+        .sendFrame(FrameType.RUNTIME_STATE_SYNC, stateMsg)
+        .catch((e: unknown) => {
+          handle.cancel_last_runtime_state_flush();
+          this.opts.logger.warn(
+            "[sync-engine] runtime state sync to relay failed:",
+            e,
+          );
+        });
+    }
+  }
+
+  /**
+   * Schedule a debounced flush (for batching rapid keystrokes).
+   *
+   * Each call resets the 20ms debounce timer. Call `flush()` directly
+   * when you need an immediate sync (e.g. before execute or save).
+   */
+  scheduleFlush(): void {
+    this.flushRequest$.next();
+  }
+
+  /**
+   * Reset sync state and resend the initial sync message.
+   *
+   * Used when the initial handshake stalls — resets the WASM handle's
+   * sync state so `flush_local_changes()` produces a fresh request.
+   */
+  resetAndResync(): void {
+    const handle = this.opts.getHandle();
+    if (!handle) return;
+    handle.reset_sync_state();
+    this.flush();
+  }
+
+  /**
+   * Reset the engine for a new bootstrap cycle (e.g. daemon:ready).
+   *
+   * Clears the initial sync gate and execution tracking state so the
+   * next round of frames is treated as a fresh connection.
+   */
+  resetForBootstrap(): void {
+    this.awaitingInitialSync = true;
+    this.prevExecutions = {};
+  }
+}

--- a/packages/runtimed/src/sync-engine.ts
+++ b/packages/runtimed/src/sync-engine.ts
@@ -24,7 +24,6 @@ import {
   from,
   mergeMap,
   Observable,
-  ReplaySubject,
   share,
   Subject,
   Subscription,
@@ -122,9 +121,11 @@ export class SyncEngine {
   readonly executionTransitions$: Observable<ExecutionTransition[]>;
 
   /**
-   * Fires once when the initial sync handshake completes (daemon has
-   * sent document content). Consumers should do their first full
-   * materialization in response.
+   * Fires each time the initial sync handshake completes (daemon has
+   * sent document content). Emits once per bootstrap cycle — after
+   * `resetForBootstrap()`, the next `changed:true` frame triggers
+   * another emission. Consumers should do a full materialization in
+   * response.
    */
   readonly initialSyncComplete$: Observable<void>;
 
@@ -136,7 +137,7 @@ export class SyncEngine {
   private readonly _executionTransitions$ = new Subject<
     ExecutionTransition[]
   >();
-  private readonly _initialSyncComplete$ = new ReplaySubject<void>(1);
+  private readonly _initialSyncComplete$ = new Subject<void>();
 
   constructor(opts: SyncEngineOptions) {
     this.opts = {
@@ -242,7 +243,6 @@ export class SyncEngine {
               if (e.changed) {
                 this.awaitingInitialSync = false;
                 this._initialSyncComplete$.next();
-                this._initialSyncComplete$.complete();
               }
               // Restart retry timer on handshake rounds
               retrySync$.next();

--- a/packages/runtimed/src/transport.ts
+++ b/packages/runtimed/src/transport.ts
@@ -1,0 +1,70 @@
+/**
+ * NotebookTransport interface and frame type constants.
+ *
+ * The transport is the pluggable boundary between the SyncEngine and the
+ * underlying connection to the daemon. Implementations:
+ *   - TauriTransport (desktop app, lives in apps/notebook)
+ *   - DirectTransport (testing, lives in this package)
+ *   - WebSocketTransport (future web app)
+ */
+
+// ── Frame type constants ─────────────────────────────────────────────
+
+/**
+ * Frame type constants matching `notebook_doc::frame_types` in Rust.
+ *
+ * These correspond to the first byte of each typed frame payload on
+ * notebook sync connections.
+ */
+export const FrameType = {
+  /** Automerge sync message (binary). */
+  AUTOMERGE_SYNC: 0x00,
+  /** NotebookRequest (JSON). */
+  REQUEST: 0x01,
+  /** NotebookResponse (JSON). */
+  RESPONSE: 0x02,
+  /** NotebookBroadcast (JSON). */
+  BROADCAST: 0x03,
+  /** Presence (CBOR, see notebook_doc::presence). */
+  PRESENCE: 0x04,
+  /** RuntimeStateSync message (binary Automerge sync for RuntimeStateDoc). */
+  RUNTIME_STATE_SYNC: 0x05,
+} as const;
+
+export type FrameTypeValue = (typeof FrameType)[keyof typeof FrameType];
+
+// ── Transport interface ──────────────────────────────────────────────
+
+/** Callback for receiving inbound frames from the daemon. */
+export type FrameListener = (payload: number[]) => void;
+
+/**
+ * Pluggable connection layer between SyncEngine and the daemon.
+ *
+ * Implementations handle the mechanics of sending/receiving bytes
+ * (Tauri IPC, WebSocket, in-memory for tests) while the SyncEngine
+ * owns all sync logic.
+ */
+export interface NotebookTransport {
+  /**
+   * Send a typed frame to the daemon.
+   *
+   * Prepends the frame type byte to the payload and delivers the
+   * resulting bytes via the underlying connection.
+   */
+  sendFrame(frameType: number, payload: Uint8Array): Promise<void>;
+
+  /**
+   * Register a callback for inbound frames from the daemon.
+   *
+   * Returns an unsubscribe function. The payload is the raw byte array
+   * from the daemon (including frame type prefix, depending on transport).
+   */
+  onFrame(callback: FrameListener): () => void;
+
+  /** Whether the transport is currently connected. */
+  readonly connected: boolean;
+
+  /** Tear down the transport (unlisten, close connections). */
+  disconnect(): void;
+}

--- a/packages/runtimed/tests/sync-engine.test.ts
+++ b/packages/runtimed/tests/sync-engine.test.ts
@@ -510,25 +510,74 @@ describe("SyncEngine", () => {
   // ── resetForBootstrap ─────────────────────────────────────────
 
   describe("resetForBootstrap", () => {
-    it("resets initial sync gate so next changed:true fires initialSyncComplete$", async () => {
-      let callCount = 0;
-      (handle.receive_frame as ReturnType<typeof vi.fn>).mockImplementation(() => {
-        callCount++;
-        return [syncAppliedEvent({ changed: true })];
-      });
+    it("emits initialSyncComplete$ again after resetForBootstrap + changed:true", async () => {
+      (handle.receive_frame as ReturnType<typeof vi.fn>).mockReturnValue([
+        syncAppliedEvent({ changed: true }),
+      ]);
 
       engine.start();
+
+      // Track all emissions
+      let emitCount = 0;
+      engine.initialSyncComplete$.subscribe(() => {
+        emitCount++;
+      });
 
       // Complete first initial sync
       transport.deliver(Array.from([0x00, 1]));
       await vi.advanceTimersByTimeAsync(0);
+      expect(emitCount).toBe(1);
 
-      // Reset for bootstrap — engine should wait for initial sync again
+      // Simulate daemon:ready — reset for a new bootstrap cycle
       engine.resetForBootstrap();
 
-      // The ReplaySubject already completed, but resetForBootstrap should
-      // still allow the engine to process new frames correctly
-      expect(callCount).toBe(1);
+      // Second initial sync should emit again
+      transport.deliver(Array.from([0x00, 2]));
+      await vi.advanceTimersByTimeAsync(0);
+      expect(emitCount).toBe(2);
+    });
+
+    it("does not emit cellChanges$ during initial sync phase", async () => {
+      let callCount = 0;
+      (handle.receive_frame as ReturnType<typeof vi.fn>).mockImplementation(() => {
+        callCount++;
+        return [
+          syncAppliedEvent({
+            changed: true,
+            changeset: {
+              changed: [{ cell_id: "c1", fields: { source: true } }],
+              added: [],
+              removed: [],
+              order_changed: false,
+            },
+          }),
+        ];
+      });
+
+      engine.start();
+
+      let cellChangeCount = 0;
+      engine.cellChanges$.subscribe(() => {
+        cellChangeCount++;
+      });
+
+      // First frame completes initial sync — should NOT go to cellChanges$
+      transport.deliver(Array.from([0x00, 1]));
+      await vi.advanceTimersByTimeAsync(50);
+      expect(cellChangeCount).toBe(0);
+
+      // After initial sync, steady-state frames go to cellChanges$
+      transport.deliver(Array.from([0x00, 2]));
+      await vi.advanceTimersByTimeAsync(50);
+      expect(cellChangeCount).toBe(1);
+
+      // Reset for bootstrap — back to initial sync phase
+      engine.resetForBootstrap();
+
+      // This frame should NOT go to cellChanges$ (awaiting initial sync)
+      transport.deliver(Array.from([0x00, 3]));
+      await vi.advanceTimersByTimeAsync(50);
+      expect(cellChangeCount).toBe(1); // unchanged
     });
   });
 

--- a/packages/runtimed/tests/sync-engine.test.ts
+++ b/packages/runtimed/tests/sync-engine.test.ts
@@ -1,0 +1,742 @@
+/**
+ * SyncEngine unit tests using mock handles.
+ *
+ * Proves the engine's lifecycle, coalescing, rollback, retry, and
+ * observable emission without requiring WASM or a real daemon.
+ */
+
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { firstValueFrom } from "rxjs";
+import { SyncEngine } from "../src/sync-engine";
+import { DirectTransport } from "../src/direct-transport";
+import { FrameType } from "../src/transport";
+import { mergeChangesets } from "../src/cell-changeset";
+import { diffExecutions } from "../src/runtime-state";
+import type { SyncableHandle, FrameEvent } from "../src/handle";
+import type { CellChangeset } from "../src/cell-changeset";
+import type { RuntimeState } from "../src/runtime-state";
+
+// ── Mock factories ──────────────────────────────────────────────────
+
+function createMockHandle(overrides: Partial<SyncableHandle> = {}): SyncableHandle {
+  return {
+    receive_frame: vi.fn(() => []),
+    flush_local_changes: vi.fn(() => null),
+    cancel_last_flush: vi.fn(),
+    flush_runtime_state_sync: vi.fn(() => null),
+    cancel_last_runtime_state_flush: vi.fn(),
+    generate_runtime_state_sync_reply: vi.fn(() => null),
+    reset_sync_state: vi.fn(),
+    cell_count: vi.fn(() => 0),
+    ...overrides,
+  };
+}
+
+function createMockServerHandle() {
+  return {
+    flush_local_changes: vi.fn(() => null),
+    receive_sync_message: vi.fn(() => true),
+    reset_sync_state: vi.fn(),
+  };
+}
+
+function syncAppliedEvent(opts: {
+  changed?: boolean;
+  changeset?: CellChangeset;
+  reply?: number[];
+  attributions?: FrameEvent["attributions"];
+} = {}): FrameEvent {
+  return {
+    type: "sync_applied",
+    changed: opts.changed ?? false,
+    changeset: opts.changeset,
+    reply: opts.reply,
+    attributions: opts.attributions,
+  };
+}
+
+function broadcastEvent(payload: unknown): FrameEvent {
+  return { type: "broadcast", payload };
+}
+
+function presenceEvent(payload: unknown): FrameEvent {
+  return { type: "presence", payload };
+}
+
+function runtimeStateSyncEvent(state: RuntimeState): FrameEvent {
+  return { type: "runtime_state_sync_applied", changed: true, state };
+}
+
+const EMPTY_CHANGESET: CellChangeset = {
+  changed: [],
+  added: [],
+  removed: [],
+  order_changed: false,
+};
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+describe("SyncEngine", () => {
+  let handle: SyncableHandle;
+  let server: ReturnType<typeof createMockServerHandle>;
+  let transport: DirectTransport;
+  let engine: SyncEngine;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    handle = createMockHandle();
+    server = createMockServerHandle();
+    transport = new DirectTransport(server);
+    engine = new SyncEngine({
+      getHandle: () => handle,
+      transport,
+    });
+  });
+
+  afterEach(() => {
+    engine.stop();
+    vi.useRealTimers();
+  });
+
+  // ── Lifecycle ──────────────────────────────────────────────────
+
+  describe("lifecycle", () => {
+    it("starts and stops cleanly", () => {
+      expect(engine.running).toBe(false);
+      engine.start();
+      expect(engine.running).toBe(true);
+      engine.stop();
+      expect(engine.running).toBe(false);
+    });
+
+    it("start is idempotent", () => {
+      engine.start();
+      engine.start(); // should not throw or double-subscribe
+      expect(engine.running).toBe(true);
+    });
+
+    it("stop is idempotent", () => {
+      engine.start();
+      engine.stop();
+      engine.stop(); // should not throw
+      expect(engine.running).toBe(false);
+    });
+  });
+
+  // ── Initial sync ──────────────────────────────────────────────
+
+  describe("initial sync", () => {
+    it("emits initialSyncComplete$ when changed:true arrives", async () => {
+      (handle.receive_frame as ReturnType<typeof vi.fn>).mockReturnValue([
+        syncAppliedEvent({ changed: true }),
+      ]);
+
+      engine.start();
+
+      const completed = firstValueFrom(engine.initialSyncComplete$);
+      transport.deliver(Array.from([0x00, 1, 2, 3])); // dummy frame
+      await completed; // should resolve
+    });
+
+    it("does not emit initialSyncComplete$ on changed:false", async () => {
+      (handle.receive_frame as ReturnType<typeof vi.fn>).mockReturnValue([
+        syncAppliedEvent({ changed: false }),
+      ]);
+
+      engine.start();
+
+      let completed = false;
+      engine.initialSyncComplete$.subscribe(() => {
+        completed = true;
+      });
+
+      transport.deliver(Array.from([0x00, 1, 2, 3]));
+      await vi.advanceTimersByTimeAsync(100);
+      expect(completed).toBe(false);
+    });
+
+    it("retries sync after timeout when initial sync stalls", async () => {
+      // First frame: changed:false (handshake, no content)
+      (handle.receive_frame as ReturnType<typeof vi.fn>).mockReturnValue([
+        syncAppliedEvent({ changed: false }),
+      ]);
+
+      // flush_local_changes returns a sync message for the retry
+      (handle.flush_local_changes as ReturnType<typeof vi.fn>).mockReturnValue(
+        new Uint8Array([1, 2, 3]),
+      );
+
+      engine.start();
+      transport.deliver(Array.from([0x00, 1, 2, 3]));
+
+      // Advance past the 3s retry timeout
+      await vi.advanceTimersByTimeAsync(3100);
+
+      // Engine should have called reset_sync_state + flush for retry
+      expect(handle.reset_sync_state).toHaveBeenCalled();
+    });
+  });
+
+  // ── Broadcasts ────────────────────────────────────────────────
+
+  describe("broadcasts", () => {
+    it("emits broadcast payloads on broadcasts$", async () => {
+      const broadcastPayload = { event: "kernel_status", status: "busy" };
+      (handle.receive_frame as ReturnType<typeof vi.fn>).mockReturnValue([
+        broadcastEvent(broadcastPayload),
+      ]);
+
+      engine.start();
+
+      const received = firstValueFrom(engine.broadcasts$);
+      transport.deliver(Array.from([0x03, 1])); // dummy frame
+      const payload = await received;
+      expect(payload).toEqual(broadcastPayload);
+    });
+
+    it("emits text_attribution as broadcast", async () => {
+      const attributions = [
+        { cell_id: "c1", index: 0, text: "hi", deleted: 0, actors: ["a"] },
+      ];
+      (handle.receive_frame as ReturnType<typeof vi.fn>).mockReturnValue([
+        syncAppliedEvent({ changed: true, attributions }),
+      ]);
+
+      engine.start();
+
+      const received = firstValueFrom(engine.broadcasts$);
+      transport.deliver(Array.from([0x00, 1]));
+      const payload = await received;
+      expect(payload).toEqual({
+        type: "text_attribution",
+        attributions,
+      });
+    });
+  });
+
+  // ── Presence ──────────────────────────────────────────────────
+
+  describe("presence", () => {
+    it("emits presence payloads on presence$", async () => {
+      const presencePayload = { type: "update", peer: "alice", cursor: {} };
+      (handle.receive_frame as ReturnType<typeof vi.fn>).mockReturnValue([
+        presenceEvent(presencePayload),
+      ]);
+
+      engine.start();
+
+      const received = firstValueFrom(engine.presence$);
+      transport.deliver(Array.from([0x04, 1]));
+      const payload = await received;
+      expect(payload).toEqual(presencePayload);
+    });
+  });
+
+  // ── Cell changes (coalescing) ─────────────────────────────────
+
+  describe("cellChanges$", () => {
+    it("emits coalesced changesets after initial sync", async () => {
+      let callCount = 0;
+      (handle.receive_frame as ReturnType<typeof vi.fn>).mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          // First call: initial sync
+          return [syncAppliedEvent({ changed: true })];
+        }
+        // Subsequent calls: steady-state changes
+        return [
+          syncAppliedEvent({
+            changed: true,
+            changeset: {
+              changed: [{ cell_id: "c1", fields: { source: true } }],
+              added: [],
+              removed: [],
+              order_changed: false,
+            },
+          }),
+        ];
+      });
+
+      engine.start();
+
+      // Complete initial sync
+      transport.deliver(Array.from([0x00, 1]));
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Subscribe to cell changes
+      const changePromise = firstValueFrom(engine.cellChanges$);
+
+      // Send steady-state frame
+      transport.deliver(Array.from([0x00, 2]));
+
+      // Advance past coalescing window (32ms)
+      await vi.advanceTimersByTimeAsync(50);
+
+      const changeset = await changePromise;
+      expect(changeset).not.toBeNull();
+      expect(changeset!.changed[0].cell_id).toBe("c1");
+      expect(changeset!.changed[0].fields.source).toBe(true);
+    });
+
+    it("emits null changeset when WASM has no changeset", async () => {
+      let callCount = 0;
+      (handle.receive_frame as ReturnType<typeof vi.fn>).mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          return [syncAppliedEvent({ changed: true })];
+        }
+        return [syncAppliedEvent({ changed: true })]; // no changeset
+      });
+
+      engine.start();
+
+      // Complete initial sync
+      transport.deliver(Array.from([0x00, 1]));
+      await vi.advanceTimersByTimeAsync(0);
+
+      const changePromise = firstValueFrom(engine.cellChanges$);
+      transport.deliver(Array.from([0x00, 2]));
+      await vi.advanceTimersByTimeAsync(50);
+
+      const changeset = await changePromise;
+      expect(changeset).toBeNull();
+    });
+  });
+
+  // ── Runtime state ─────────────────────────────────────────────
+
+  describe("runtimeState$", () => {
+    it("emits runtime state on state sync", async () => {
+      const state: RuntimeState = {
+        kernel: {
+          status: "busy",
+          starting_phase: "",
+          name: "python3",
+          language: "python",
+          env_source: "",
+        },
+        queue: { executing: null, queued: [] },
+        env: {
+          in_sync: true,
+          added: [],
+          removed: [],
+          channels_changed: false,
+          deno_changed: false,
+        },
+        trust: { status: "trusted", needs_approval: false },
+        last_saved: null,
+        executions: {},
+      };
+
+      (handle.receive_frame as ReturnType<typeof vi.fn>).mockReturnValue([
+        runtimeStateSyncEvent(state),
+      ]);
+
+      engine.start();
+
+      const received = firstValueFrom(engine.runtimeState$);
+      transport.deliver(Array.from([0x05, 1]));
+      const result = await received;
+      expect(result.kernel.status).toBe("busy");
+      expect(result.kernel.name).toBe("python3");
+    });
+  });
+
+  // ── Execution transitions ─────────────────────────────────────
+
+  describe("executionTransitions$", () => {
+    it("detects started transition", async () => {
+      const state: RuntimeState = {
+        kernel: {
+          status: "busy",
+          starting_phase: "",
+          name: "python3",
+          language: "python",
+          env_source: "",
+        },
+        queue: { executing: null, queued: [] },
+        env: {
+          in_sync: true,
+          added: [],
+          removed: [],
+          channels_changed: false,
+          deno_changed: false,
+        },
+        trust: { status: "trusted", needs_approval: false },
+        last_saved: null,
+        executions: {
+          "exec-1": {
+            cell_id: "c1",
+            status: "running",
+            execution_count: 1,
+            success: null,
+          },
+        },
+      };
+
+      (handle.receive_frame as ReturnType<typeof vi.fn>).mockReturnValue([
+        runtimeStateSyncEvent(state),
+      ]);
+
+      engine.start();
+
+      const received = firstValueFrom(engine.executionTransitions$);
+      transport.deliver(Array.from([0x05, 1]));
+      const transitions = await received;
+      expect(transitions).toHaveLength(1);
+      expect(transitions[0].kind).toBe("started");
+      expect(transitions[0].cell_id).toBe("c1");
+      expect(transitions[0].execution_id).toBe("exec-1");
+    });
+  });
+
+  // ── Inline sync reply ─────────────────────────────────────────
+
+  describe("sync replies", () => {
+    it("sends inline sync reply via transport", () => {
+      const reply = [10, 20, 30];
+      (handle.receive_frame as ReturnType<typeof vi.fn>).mockReturnValue([
+        syncAppliedEvent({ changed: true, reply }),
+      ]);
+
+      engine.start();
+      transport.deliver(Array.from([0x00, 1]));
+
+      // Check that a sync frame was sent
+      const syncFrames = transport.sentFrames.filter(
+        (f) => f.frameType === FrameType.AUTOMERGE_SYNC,
+      );
+      expect(syncFrames.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("rolls back sync state on send failure", async () => {
+      const reply = [10, 20, 30];
+      (handle.receive_frame as ReturnType<typeof vi.fn>).mockReturnValue([
+        syncAppliedEvent({ changed: true, reply }),
+      ]);
+
+      transport.simulateFailure = true;
+      engine.start();
+      transport.deliver(Array.from([0x00, 1]));
+
+      // Let the promise rejection propagate
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(handle.cancel_last_flush).toHaveBeenCalled();
+    });
+  });
+
+  // ── Outbound flush ────────────────────────────────────────────
+
+  describe("flush", () => {
+    it("flush() sends local changes via transport", () => {
+      const syncMsg = new Uint8Array([1, 2, 3]);
+      (handle.flush_local_changes as ReturnType<typeof vi.fn>).mockReturnValue(syncMsg);
+
+      engine.start();
+      engine.flush();
+
+      const syncFrames = transport.sentFrames.filter(
+        (f) => f.frameType === FrameType.AUTOMERGE_SYNC,
+      );
+      expect(syncFrames).toHaveLength(1);
+      expect(syncFrames[0].payload).toEqual(syncMsg);
+    });
+
+    it("flush() also sends RuntimeStateDoc sync", () => {
+      const stateMsg = new Uint8Array([4, 5, 6]);
+      (handle.flush_runtime_state_sync as ReturnType<typeof vi.fn>).mockReturnValue(stateMsg);
+
+      engine.start();
+      engine.flush();
+
+      const stateFrames = transport.sentFrames.filter(
+        (f) => f.frameType === FrameType.RUNTIME_STATE_SYNC,
+      );
+      expect(stateFrames).toHaveLength(1);
+      expect(stateFrames[0].payload).toEqual(stateMsg);
+    });
+
+    it("flush() rolls back on transport failure", async () => {
+      const syncMsg = new Uint8Array([1, 2, 3]);
+      (handle.flush_local_changes as ReturnType<typeof vi.fn>).mockReturnValue(syncMsg);
+
+      transport.simulateFailure = true;
+      engine.start();
+      engine.flush();
+
+      await vi.advanceTimersByTimeAsync(0);
+      expect(handle.cancel_last_flush).toHaveBeenCalled();
+    });
+
+    it("scheduleFlush() debounces at 20ms", async () => {
+      const syncMsg = new Uint8Array([1]);
+      (handle.flush_local_changes as ReturnType<typeof vi.fn>).mockReturnValue(syncMsg);
+
+      engine.start();
+      engine.scheduleFlush();
+      engine.scheduleFlush();
+      engine.scheduleFlush();
+
+      // No flush yet
+      expect(transport.sentFrames).toHaveLength(0);
+
+      // Advance past debounce (20ms)
+      await vi.advanceTimersByTimeAsync(25);
+
+      // Should have flushed exactly once
+      const syncFrames = transport.sentFrames.filter(
+        (f) => f.frameType === FrameType.AUTOMERGE_SYNC,
+      );
+      expect(syncFrames).toHaveLength(1);
+    });
+  });
+
+  // ── resetAndResync ────────────────────────────────────────────
+
+  describe("resetAndResync", () => {
+    it("resets sync state and flushes", () => {
+      const syncMsg = new Uint8Array([7, 8, 9]);
+      (handle.flush_local_changes as ReturnType<typeof vi.fn>).mockReturnValue(syncMsg);
+
+      engine.start();
+      engine.resetAndResync();
+
+      expect(handle.reset_sync_state).toHaveBeenCalled();
+      expect(transport.sentFrames.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  // ── resetForBootstrap ─────────────────────────────────────────
+
+  describe("resetForBootstrap", () => {
+    it("resets initial sync gate so next changed:true fires initialSyncComplete$", async () => {
+      let callCount = 0;
+      (handle.receive_frame as ReturnType<typeof vi.fn>).mockImplementation(() => {
+        callCount++;
+        return [syncAppliedEvent({ changed: true })];
+      });
+
+      engine.start();
+
+      // Complete first initial sync
+      transport.deliver(Array.from([0x00, 1]));
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Reset for bootstrap — engine should wait for initial sync again
+      engine.resetForBootstrap();
+
+      // The ReplaySubject already completed, but resetForBootstrap should
+      // still allow the engine to process new frames correctly
+      expect(callCount).toBe(1);
+    });
+  });
+
+  // ── Null handle safety ────────────────────────────────────────
+
+  describe("null handle", () => {
+    it("does not crash when handle is null", () => {
+      const nullEngine = new SyncEngine({
+        getHandle: () => null,
+        transport,
+      });
+
+      nullEngine.start();
+      transport.deliver(Array.from([0x00, 1, 2, 3]));
+      nullEngine.flush();
+      nullEngine.scheduleFlush();
+      nullEngine.resetAndResync();
+      nullEngine.stop();
+    });
+  });
+});
+
+// ── DirectTransport tests ──────────────────────────────────────────
+
+describe("DirectTransport", () => {
+  it("delivers frames to subscribers", () => {
+    const server = createMockServerHandle();
+    const transport = new DirectTransport(server);
+
+    const received: number[][] = [];
+    transport.onFrame((payload) => received.push(payload));
+
+    transport.deliver([0x00, 1, 2, 3]);
+    expect(received).toHaveLength(1);
+    expect(received[0]).toEqual([0x00, 1, 2, 3]);
+  });
+
+  it("unsubscribe removes listener", () => {
+    const server = createMockServerHandle();
+    const transport = new DirectTransport(server);
+
+    const received: number[][] = [];
+    const unsub = transport.onFrame((payload) => received.push(payload));
+
+    transport.deliver([1]);
+    unsub();
+    transport.deliver([2]);
+
+    expect(received).toHaveLength(1);
+  });
+
+  it("sendFrame records and routes to server", async () => {
+    const server = createMockServerHandle();
+    const transport = new DirectTransport(server);
+
+    await transport.sendFrame(FrameType.AUTOMERGE_SYNC, new Uint8Array([1, 2]));
+
+    expect(transport.sentFrames).toHaveLength(1);
+    expect(server.receive_sync_message).toHaveBeenCalledWith(new Uint8Array([1, 2]));
+  });
+
+  it("simulateFailure causes sendFrame to reject", async () => {
+    const server = createMockServerHandle();
+    const transport = new DirectTransport(server);
+
+    transport.simulateFailure = true;
+
+    await expect(
+      transport.sendFrame(FrameType.AUTOMERGE_SYNC, new Uint8Array([1])),
+    ).rejects.toThrow("simulated send failure");
+
+    expect(transport.sendFailureCount).toBe(1);
+  });
+
+  it("disconnect prevents further sends", async () => {
+    const server = createMockServerHandle();
+    const transport = new DirectTransport(server);
+
+    transport.disconnect();
+    expect(transport.connected).toBe(false);
+
+    await expect(
+      transport.sendFrame(FrameType.AUTOMERGE_SYNC, new Uint8Array([1])),
+    ).rejects.toThrow("not connected");
+  });
+
+  it("pushBroadcast delivers broadcast frame", () => {
+    const server = createMockServerHandle();
+    const transport = new DirectTransport(server);
+
+    const received: number[][] = [];
+    transport.onFrame((payload) => received.push(payload));
+
+    transport.pushBroadcast({ event: "kernel_status", status: "idle" });
+
+    expect(received).toHaveLength(1);
+    expect(received[0][0]).toBe(FrameType.BROADCAST);
+  });
+
+  it("clearSentFrames resets history", async () => {
+    const server = createMockServerHandle();
+    const transport = new DirectTransport(server);
+
+    await transport.sendFrame(FrameType.AUTOMERGE_SYNC, new Uint8Array([1]));
+    expect(transport.sentFrames).toHaveLength(1);
+
+    transport.clearSentFrames();
+    expect(transport.sentFrames).toHaveLength(0);
+  });
+});
+
+// ── mergeChangesets (moved from app, verify re-export) ────────────
+
+describe("mergeChangesets", () => {
+
+  it("merges two empty changesets", () => {
+    const empty: CellChangeset = {
+      changed: [],
+      added: [],
+      removed: [],
+      order_changed: false,
+    };
+    const result = mergeChangesets(empty, empty);
+    expect(result).toEqual(empty);
+  });
+
+  it("unions changed fields for the same cell", () => {
+    const a: CellChangeset = {
+      changed: [{ cell_id: "c1", fields: { source: true } }],
+      added: [],
+      removed: [],
+      order_changed: false,
+    };
+    const b: CellChangeset = {
+      changed: [{ cell_id: "c1", fields: { outputs: true } }],
+      added: [],
+      removed: [],
+      order_changed: false,
+    };
+    const result = mergeChangesets(a, b);
+    expect(result.changed).toHaveLength(1);
+    expect(result.changed[0].fields.source).toBe(true);
+    expect(result.changed[0].fields.outputs).toBe(true);
+  });
+
+  it("deduplicates added/removed", () => {
+    const a: CellChangeset = {
+      changed: [],
+      added: ["c1"],
+      removed: ["c2"],
+      order_changed: false,
+    };
+    const b: CellChangeset = {
+      changed: [],
+      added: ["c1", "c3"],
+      removed: ["c2"],
+      order_changed: true,
+    };
+    const result = mergeChangesets(a, b);
+    expect(result.added).toEqual(["c1", "c3"]);
+    expect(result.removed).toEqual(["c2"]);
+    expect(result.order_changed).toBe(true);
+  });
+});
+
+// ── diffExecutions (moved from app, verify re-export) ────────────
+
+describe("diffExecutions", () => {
+
+  it("detects started transition", () => {
+    const prev = {};
+    const curr = {
+      "e1": { cell_id: "c1", status: "running" as const, execution_count: 1, success: null },
+    };
+    const transitions = diffExecutions(prev, curr);
+    expect(transitions).toHaveLength(1);
+    expect(transitions[0].kind).toBe("started");
+  });
+
+  it("detects done transition", () => {
+    const prev = {
+      "e1": { cell_id: "c1", status: "running" as const, execution_count: 1, success: null },
+    };
+    const curr = {
+      "e1": { cell_id: "c1", status: "done" as const, execution_count: 1, success: true },
+    };
+    const transitions = diffExecutions(prev, curr);
+    expect(transitions).toHaveLength(1);
+    expect(transitions[0].kind).toBe("done");
+  });
+
+  it("detects error transition", () => {
+    const prev = {
+      "e1": { cell_id: "c1", status: "queued" as const, execution_count: null, success: null },
+    };
+    const curr = {
+      "e1": { cell_id: "c1", status: "error" as const, execution_count: null, success: false },
+    };
+    const transitions = diffExecutions(prev, curr);
+    expect(transitions).toHaveLength(1);
+    expect(transitions[0].kind).toBe("error");
+  });
+
+  it("returns empty for no change", () => {
+    const state = {
+      "e1": { cell_id: "c1", status: "running" as const, execution_count: 1, success: null },
+    };
+    const transitions = diffExecutions(state, state);
+    expect(transitions).toHaveLength(0);
+  });
+});

--- a/packages/runtimed/tsconfig.json
+++ b/packages/runtimed/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -357,6 +357,9 @@ importers:
       remark-math:
         specifier: ^6.0.0
         version: 6.0.0
+      runtimed:
+        specifier: workspace:*
+        version: link:../../packages/runtimed
       rxjs:
         specifier: ^7.8.2
         version: 7.8.2
@@ -391,6 +394,12 @@ importers:
       vite:
         specifier: ^6.3.5
         version: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)
+
+  packages/runtimed:
+    dependencies:
+      rxjs:
+        specifier: ^7.8.2
+        version: 7.8.2
 
 packages:
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 packages:
   - apps/*
+  - packages/*
 
 onlyBuiltDependencies:
   - '@fortawesome/fontawesome-free'

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     include: [
       "src/**/__tests__/**/*.test.{ts,tsx}",
       "apps/notebook/src/**/__tests__/**/*.test.{ts,tsx}",
+      "packages/**/tests/**/*.test.{ts,tsx}",
     ],
     globals: true,
     setupFiles: ["./src/test-setup.ts"],


### PR DESCRIPTION
## Summary

Transport-agnostic notebook client library extracted from the frontend, based on the ideas from #1073 applied to the current codebase.

- **`packages/runtimed`** — new workspace package with zero Tauri/React dependencies
  - `SyncEngine` class: owns all sync state (inbound frame processing, coalescing, initial sync handshake with retry, RuntimeStateDoc sync, execution lifecycle diffing, debounced outbound flush)
  - `NotebookTransport` interface: pluggable connection layer
  - `SyncableHandle` interface: minimal WASM handle contract
  - `CellChangeset` types + `mergeChangesets` (moved from app)
  - `RuntimeState` types + `diffExecutions` (moved from app)
  - `FrameType` constants
  - RxJS observables: `cellChanges$`, `broadcasts$`, `presence$`, `runtimeState$`, `executionTransitions$`, `initialSyncComplete$`
- **`TauriTransport`** — Tauri IPC implementation (app-side, not in package)
- **`useAutomergeNotebook`** rewired to `SyncEngine` + `TauriTransport`
- **`frame-pipeline.ts`** reduced from 517-line pipeline to materialization helper only
- App files re-export from package — all downstream imports preserved

### Architecture

```
packages/runtimed/              <- Transport-agnostic library
├── SyncEngine                  <- Owns sync state, emits events
├── NotebookTransport           <- Interface: sendFrame, onFrame
├── SyncableHandle              <- Minimal WASM handle contract
├── CellChangeset + merge       <- Pure types + utilities
└── RuntimeState + diff         <- Pure types + utilities

apps/notebook/
├── TauriTransport              <- Bridges to Tauri IPC
├── useAutomergeNotebook        <- Creates engine, subscribes to observables
└── frame-pipeline.ts           <- Materialization helper only
```

### What's next

- [ ] `DirectTransport` for testing without Tauri/browser
- [ ] SyncEngine unit tests (lifecycle, coalescing, rollback, retry)
- [ ] Move materialization + output resolution into the package
- [ ] Public API stabilization

## Test plan

- [x] All 515 existing vitest tests pass
- [x] Package type-checks cleanly (`tsc --noEmit`)
- [x] `cargo xtask lint --fix` passes
- [x] No `@tauri-apps` or `react` imports in `packages/runtimed/`
- [ ] Manual smoke test: launch notebook app, verify sync works end-to-end