### PR TITLE
docs: inline MCP server setup in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,42 @@ pip install nteract
 
 ## MCP Server
 
-For AI agent integration with Jupyter notebooks, see the [nteract MCP server](https://github.com/nteract/nteract).
+The nteract MCP server connects AI assistants to Jupyter notebooks through the daemon. Agents get 27 tools for working with notebooks — executing code, reading and writing cells, managing dependencies, and collaborating in real-time alongside humans in the desktop app.
+
+### Quick Start
+
+#### Claude Code
+
+```bash
+# Stable
+claude mcp add nteract -- uvx nteract
+
+# Nightly
+claude mcp add nteract-nightly -- uvx --prerelease allow nteract --nightly
+```
+
+#### Manual JSON config
+
+```json
+{
+  "mcpServers": {
+    "nteract": {
+      "command": "uvx",
+      "args": ["nteract"]
+    }
+  }
+}
+```
+
+### CLI Flags
+
+| Flag | Description |
+|------|-------------|
+| `--nightly` | Connect to the nightly daemon and open nightly app |
+| `--stable` | Connect to the stable daemon and open stable app |
+| `--no-show` | Do not register the `show_notebook` tool (for headless environments) |
+
+See [`python/nteract/`](python/nteract/) for the full tools reference, architecture, and development guide.
 
 ## Usage
 

--- a/contributing/development.md
+++ b/contributing/development.md
@@ -268,7 +268,7 @@ See [contributing/runtimed.md](./runtimed.md) for full daemon development docs.
 
 ## MCP Server Development
 
-The [nteract MCP server](https://github.com/nteract/nteract) lets AI agents
+The [nteract MCP server](../python/nteract/) lets AI agents
 (Claude, Zed, etc.) interact with notebooks via the daemon. There are two ways
 to run it locally.
 

--- a/contributing/runtimed.md
+++ b/contributing/runtimed.md
@@ -278,7 +278,7 @@ cargo run -p runt-cli -- notebooks            # List open notebooks with kernel 
 
 ## Python Bindings (runtimed-py)
 
-The `runtimed-py` crate provides Python bindings for interacting with the daemon programmatically. This is used by the [nteract MCP server](https://github.com/nteract/nteract) and can be used for testing.
+The `runtimed-py` crate provides Python bindings for interacting with the daemon programmatically. This is used by the [nteract MCP server](../python/nteract/) and can be used for testing.
 
 ### Installation
 


### PR DESCRIPTION
## Summary

- Replace the stale `github.com/nteract/nteract` link in the README MCP section with inline setup instructions — Claude Code one-liner, manual JSON config, and CLI flags
- Fix the same dead link in `contributing/development.md` and `contributing/runtimed.md` to point to `python/nteract/` within the monorepo

## Verification

- [ ] README MCP section renders correctly on GitHub
- [ ] `python/nteract/` relative link resolves from each of the three files
- [ ] No remaining references to `github.com/nteract/nteract` in the repo

_PR submitted by @rgbkrk's agent, Quill_