### PR TITLE
feat(logging): channel-aware verbose defaults for nightly builds

### DIFF
--- a/.claude/rules/logging.md
+++ b/.claude/rules/logging.md
@@ -36,7 +36,15 @@ Use consistent prefixes for filtering:
 - `[runtimed]` -- Daemon core operations
 - `[notebook-sync]` -- Automerge sync server
 - `[kernel-manager]` -- Kernel lifecycle and execution
+- `[doc-handle]` -- CRDT document mutations and requests
 - `[comm_*]` -- Widget communication
+
+### Default Log Levels by Channel
+
+| Channel | Daemon default | Notebook app default |
+|---------|---------------|---------------------|
+| **Nightly** | `info` (with `debug` for sync modules) | `Debug` |
+| **Stable** | `warn` | `Info` |
 
 ### Log File Rotation
 
@@ -45,7 +53,7 @@ Daemon logs rotate on startup — each daemon session gets a clean log file. Pre
 ### Enabling Debug Logs
 
 ```bash
-# All debug logs
+# All debug logs (overrides channel default)
 RUST_LOG=debug cargo xtask dev-daemon
 
 # Specific module
@@ -67,8 +75,9 @@ logger.error("[component] Failure:", error);
 
 ### Log Level Behavior
 
-- `logger.debug()` -- Suppressed in production unless debug mode is enabled
-- `logger.info()`, `logger.warn()`, `logger.error()` -- Always enabled
+- **Nightly**: All levels (`debug`, `info`, `warn`, `error`) enabled by default
+- **Stable**: `logger.debug()` suppressed; `info`, `warn`, `error` always enabled
+- Level filter applied server-side by `tauri-plugin-log`
 
 ### What NOT to Log at Info Level
 

--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -93,6 +93,7 @@ export function useAutomergeNotebook() {
 
   /** Full materialization: WASM doc → resolve manifests → write to store. */
   const materializeCells = useCallback(async (handle: NotebookHandle) => {
+    const start = performance.now();
     const json = handle.get_cells_json();
     const snapshots: CellSnapshot[] = JSON.parse(json);
     let blobPort = getBlobPort();
@@ -105,6 +106,9 @@ export function useAutomergeNotebook() {
       outputCacheRef.current,
     );
     replaceNotebookCells(newCells);
+    logger.debug(
+      `[automerge-notebook] Full materialization: ${snapshots.length} cells in ${(performance.now() - start).toFixed(1)}ms`,
+    );
   }, []);
 
   /** Sync re-read cells from WASM (cache-only, no blob fetches). */
@@ -126,7 +130,12 @@ export function useAutomergeNotebook() {
     (mutate: (handle: NotebookHandle) => boolean) => {
       const handle = handleRef.current;
       const engine = engineRef.current;
-      if (!handle || !engine) return false;
+      if (!handle || !engine) {
+        logger.debug(
+          "[automerge-notebook] commitMutation skipped: no handle/engine",
+        );
+        return false;
+      }
       if (!mutate(handle)) return false;
       rematerializeCellsSync(handle);
       engine.flush();
@@ -185,12 +194,14 @@ export function useAutomergeNotebook() {
 
     // Initial sync completion → full materialization.
     const initialSyncSub = engine.initialSyncComplete$.subscribe(() => {
+      logger.info("[automerge-notebook] Initial sync complete, materializing");
       const handle = handleRef.current;
       if (handle) {
         materializeCells(handle)
           .then(() => {
             setIsLoading(false);
             notifyMetadataChanged();
+            logger.info("[automerge-notebook] Initial materialization done");
           })
           .catch((err: unknown) => {
             logger.warn(
@@ -256,6 +267,7 @@ export function useAutomergeNotebook() {
     const lifecycleSub = fromTauriEvent("daemon:ready")
       .pipe(
         switchMap(() => {
+          logger.info("[automerge-notebook] daemon:ready — re-bootstrapping");
           refreshBlobPort();
           resetNotebookCells();
           resetRuntimeState();
@@ -289,6 +301,7 @@ export function useAutomergeNotebook() {
 
     return () => {
       cancelled = true;
+      logger.info("[automerge-notebook] Cleanup: flushing and stopping engine");
 
       // Flush pending local changes before stopping.
       engine.flush();
@@ -461,10 +474,14 @@ export function useAutomergeNotebook() {
   const flushSync = useCallback(async () => {
     const handle = handleRef.current;
     const transport = transportRef.current;
-    if (!handle || !transport) return;
+    if (!handle || !transport) {
+      logger.debug("[flushSync] skipped: no handle/transport");
+      return;
+    }
 
     const msg = handle.flush_local_changes();
     if (msg) {
+      logger.debug(`[flushSync] sending ${msg.byteLength}B sync message`);
       try {
         await transport.sendFrame(FrameType.AUTOMERGE_SYNC, msg);
       } catch (e) {

--- a/apps/notebook/src/lib/crdt-editor-bridge.ts
+++ b/apps/notebook/src/lib/crdt-editor-bridge.ts
@@ -230,6 +230,9 @@ export function createCrdtBridge(config: CrdtBridgeConfig): CrdtBridge {
             );
             if (!ok) {
               // Cell was deleted or handle is stale — abort all remaining.
+              logger.warn(
+                `[crdt-bridge] splice_source failed for cell=${cellId.slice(0, 8)} at ${fromA}..${toA}, aborting remaining splices`,
+              );
               aborted = true;
               break;
             }
@@ -263,7 +266,12 @@ export function createCrdtBridge(config: CrdtBridgeConfig): CrdtBridge {
     // Skip if we're in the middle of processing outbound changes.
     // The CRDT already has these changes from our splices; applying
     // them to CM would be an echo.
-    if (isProcessingOutbound) return;
+    if (isProcessingOutbound) {
+      logger.debug(
+        `[crdt-bridge] skipping ${changes.length} remote changes (outbound in progress) cell=${cellId.slice(0, 8)}`,
+      );
+      return;
+    }
 
     // If CodeMirror and WASM are already in sync, skip — the changes
     // are already reflected. This guards against stale text_attributions
@@ -275,8 +283,17 @@ export function createCrdtBridge(config: CrdtBridgeConfig): CrdtBridge {
     if (handle) {
       const wasmSource = handle.get_cell_source(cellId);
       const cmSource = view.state.doc.toString();
-      if (wasmSource === cmSource) return;
+      if (wasmSource === cmSource) {
+        logger.debug(
+          `[crdt-bridge] skipping ${changes.length} remote changes (already in sync) cell=${cellId.slice(0, 8)}`,
+        );
+        return;
+      }
     }
+
+    logger.debug(
+      `[crdt-bridge] applying ${changes.length} remote changes to cell=${cellId.slice(0, 8)}`,
+    );
 
     try {
       // Apply each change as a separate dispatch so positions are
@@ -322,6 +339,10 @@ export function createCrdtBridge(config: CrdtBridgeConfig): CrdtBridge {
 
     const currentContent = view.state.doc.toString();
     if (currentContent === source) return;
+
+    logger.debug(
+      `[crdt-bridge] applyFullSource cell=${cellId.slice(0, 8)} (${currentContent.length} → ${source.length} chars)`,
+    );
 
     try {
       view.dispatch({

--- a/apps/notebook/src/lib/frame-pipeline.ts
+++ b/apps/notebook/src/lib/frame-pipeline.ts
@@ -10,6 +10,7 @@ import type { JupyterOutput } from "../types";
 import type { NotebookHandle } from "../wasm/runtimed-wasm/runtimed_wasm.js";
 import { getBlobPort, refreshBlobPort } from "./blob-port";
 import type { CellChangeset } from "./cell-changeset";
+import { logger } from "./logger";
 import {
   isManifestHash,
   materializeCellFromWasm,
@@ -64,6 +65,9 @@ export async function materializeChangeset(
   // ── Full materialization fallback ──────────────────────────────────
 
   if (!changeset) {
+    logger.debug(
+      "[frame-pipeline] full materialization: no changeset from WASM",
+    );
     await deps.materializeCells(handle);
     notifyMetadataChanged();
     return;
@@ -76,6 +80,9 @@ export async function materializeChangeset(
     changeset.removed.length > 0 ||
     changeset.order_changed
   ) {
+    logger.debug(
+      `[frame-pipeline] full materialization: +${changeset.added.length} -${changeset.removed.length} reorder=${changeset.order_changed}`,
+    );
     await deps.materializeCells(handle);
     notifyMetadataChanged();
     return;
@@ -84,6 +91,8 @@ export async function materializeChangeset(
   // ── Per-cell incremental materialization ───────────────────────────
 
   const cache = deps.outputCache;
+  let cacheHits = 0;
+  let cacheMisses = 0;
 
   for (const { cell_id: cellId, fields } of changeset.changed) {
     if (fields.outputs) {
@@ -94,6 +103,7 @@ export async function materializeChangeset(
       );
 
       if (allCached) {
+        cacheHits++;
         // All outputs resolved from cache — fast sync path.
         const cell = materializeCellFromWasm(
           handle,
@@ -109,6 +119,7 @@ export async function materializeChangeset(
           updateCellById(cellId, () => cell);
         }
       } else {
+        cacheMisses++;
         // Cache miss — resolve this cell's outputs async.
         let blobPort = getBlobPort();
         if (blobPort === null) {
@@ -155,6 +166,24 @@ export async function materializeChangeset(
         updateCellById(cellId, () => cell);
       }
     }
+  }
+
+  if (changeset.changed.length > 0) {
+    const fieldSummary = changeset.changed
+      .map((c) => {
+        const f = c.fields;
+        const flags = [
+          f.source && "src",
+          f.outputs && "out",
+          f.execution_count && "ec",
+          f.metadata && "meta",
+        ].filter(Boolean);
+        return `${c.cell_id.slice(0, 8)}(${flags.join(",")})`;
+      })
+      .join(" ");
+    logger.debug(
+      `[frame-pipeline] incremental: ${changeset.changed.length} cells [${fieldSummary}] cache=${cacheHits}hit/${cacheMisses}miss`,
+    );
   }
 
   notifyMetadataChanged();

--- a/contributing/logging.md
+++ b/contributing/logging.md
@@ -29,19 +29,42 @@ use log::{debug, info, warn, error};
 ### Prefixes
 
 Use consistent prefixes for filtering:
+
+**Rust (daemon):**
 - `[runtimed]` - Daemon core operations
 - `[notebook-sync]` - Automerge sync server
 - `[kernel-manager]` - Kernel lifecycle and execution
+- `[doc-handle]` - CRDT document mutations and requests
 - `[comm_*]` - Widget communication
 
-### Enabling Debug Logs
+**TypeScript (frontend):**
+- `[automerge-notebook]` - WASM handle, bootstrap, materialization
+- `[sync-engine]` - Frame processing, sync state, coalescing
+- `[crdt-bridge]` - CodeMirror ↔ CRDT character-level sync
+- `[frame-pipeline]` - Changeset materialization, cache behavior
+- `[daemon-kernel]` - Kernel execution, broadcasts, comms
+- `[flushSync]` - Outbound sync flush
+
+### Default Log Levels by Channel
+
+| Channel | Daemon default | Notebook app default |
+|---------|---------------|---------------------|
+| **Nightly** | `info` (with `debug` for `notebook_sync` and `notebook_sync_server`) | `Debug` |
+| **Stable** | `warn` | `Info` |
+
+Nightly builds are intentionally more verbose to aid debugging in the field. The defaults are channel-aware — no configuration needed.
+
+### Overriding Log Levels
 
 ```bash
-# All debug logs
+# All debug logs (overrides channel default)
 RUST_LOG=debug cargo xtask dev-daemon
 
 # Specific module
 RUST_LOG=runtimed::notebook_sync_server=debug cargo xtask dev-daemon
+
+# Daemon CLI flag (overrides channel default)
+runtimed --log-level debug
 ```
 
 ## TypeScript Logging
@@ -59,8 +82,9 @@ logger.error("[component] Failure:", error);
 
 ### Log Level Behavior
 
-- `logger.debug()` - Suppressed in production unless debug mode is enabled
-- `logger.info()`, `logger.warn()`, `logger.error()` - Always enabled
+- **Nightly**: All levels (`debug`, `info`, `warn`, `error`) are enabled by default
+- **Stable**: `logger.debug()` is suppressed; `info`, `warn`, `error` are always enabled
+- The level filter is applied server-side by `tauri-plugin-log`, not in JavaScript
 
 ### What NOT to Log at Info Level
 

--- a/crates/notebook-sync/src/handle.rs
+++ b/crates/notebook-sync/src/handle.rs
@@ -32,6 +32,7 @@
 use std::sync::{Arc, Mutex};
 
 use automerge::AutoCommit;
+use log::debug;
 use tokio::sync::{mpsc, oneshot, watch};
 
 use notebook_doc::runtime_state::RuntimeState;
@@ -194,6 +195,8 @@ impl DocHandle {
         let mut state = self.doc.lock().map_err(|_| SyncError::LockPoisoned)?;
 
         let result = f(&mut state.doc);
+
+        debug!("[doc-handle] mutation applied ({})", self.notebook_id);
 
         // Publish a fresh snapshot so readers see the mutation immediately.
         // This happens before the sync task sends it to the daemon — local
@@ -516,6 +519,11 @@ impl DocHandle {
         &self,
         request: NotebookRequest,
     ) -> Result<NotebookResponse, SyncError> {
+        debug!(
+            "[doc-handle] send_request: {:?} ({})",
+            std::mem::discriminant(&request),
+            self.notebook_id
+        );
         let (reply_tx, reply_rx) = oneshot::channel();
         self.cmd_tx
             .send(SyncCommand::SendRequest {

--- a/crates/notebook/build.rs
+++ b/crates/notebook/build.rs
@@ -1,6 +1,6 @@
 use serde_json::{json, Value};
 use std::env;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 fn merge_json(base: &mut Value, overlay: Value) {
@@ -14,7 +14,7 @@ fn merge_json(base: &mut Value, overlay: Value) {
     }
 }
 
-fn target_sidecar_path(manifest_dir: &PathBuf, target: &str, binary_name: &str) -> PathBuf {
+fn target_sidecar_path(manifest_dir: &Path, target: &str, binary_name: &str) -> PathBuf {
     let executable_suffix = if target.contains("windows") {
         ".exe"
     } else {
@@ -31,9 +31,13 @@ fn maybe_disable_external_bin_for_local_checks() {
         return;
     }
 
-    let manifest_dir =
-        PathBuf::from(env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR must be set"));
-    let target = env::var("TARGET").expect("TARGET must be set");
+    let Ok(manifest_dir_str) = env::var("CARGO_MANIFEST_DIR") else {
+        return;
+    };
+    let manifest_dir = PathBuf::from(manifest_dir_str);
+    let Ok(target) = env::var("TARGET") else {
+        return;
+    };
 
     let expected_sidecars = [
         target_sidecar_path(&manifest_dir, &target, "runtimed"),
@@ -58,10 +62,9 @@ fn maybe_disable_external_bin_for_local_checks() {
         .and_then(|value| serde_json::from_str(&value).ok())
         .unwrap_or_else(|| json!({}));
     merge_json(&mut config, json!({ "bundle": { "externalBin": [] } }));
-    env::set_var(
-        "TAURI_CONFIG",
-        serde_json::to_string(&config).expect("TAURI_CONFIG override must serialize"),
-    );
+    if let Ok(serialized) = serde_json::to_string(&config) {
+        env::set_var("TAURI_CONFIG", serialized);
+    }
 
     let missing_paths = missing_sidecars
         .iter()

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -3722,7 +3722,10 @@ pub fn run(notebook_path: Option<PathBuf>, runtime: Option<Runtime>) -> anyhow::
                 Target::new(TargetKind::Webview),
             ])
             .timezone_strategy(TimezoneStrategy::UseLocal)
-            .level(log::LevelFilter::Info)
+            .level(match runt_workspace::build_channel() {
+                runt_workspace::BuildChannel::Nightly => log::LevelFilter::Debug,
+                runt_workspace::BuildChannel::Stable => log::LevelFilter::Info,
+            })
             .format(move |out, message, record| {
                 out.finish(format_args!(
                     "{} [{}] {}: {}",

--- a/crates/runtimed/src/main.rs
+++ b/crates/runtimed/src/main.rs
@@ -20,9 +20,9 @@ struct Cli {
     #[command(subcommand)]
     command: Option<Commands>,
 
-    /// Log level
-    #[arg(long, global = true, default_value = "warn")]
-    log_level: String,
+    /// Log level (defaults to "info" on nightly, "warn" on stable)
+    #[arg(long, global = true)]
+    log_level: Option<String>,
 
     /// Run in development mode (per-worktree isolation)
     ///
@@ -204,8 +204,17 @@ async fn main() -> anyhow::Result<()> {
         .append(true)
         .open(&log_path);
 
-    let mut builder =
-        env_logger::Builder::from_env(env_logger::Env::default().default_filter_or(&cli.log_level));
+    let effective_log_level =
+        cli.log_level
+            .unwrap_or_else(|| match runt_workspace::build_channel() {
+                runt_workspace::BuildChannel::Nightly => {
+                    "info,notebook_sync=debug,runtimed::notebook_sync_server=debug".to_string()
+                }
+                runt_workspace::BuildChannel::Stable => "warn".to_string(),
+            });
+    let mut builder = env_logger::Builder::from_env(
+        env_logger::Env::default().default_filter_or(&effective_log_level),
+    );
 
     // If we can open the log file, write to it; otherwise just use stderr
     if let Ok(file) = log_file {

--- a/crates/runtimed/src/service.rs
+++ b/crates/runtimed/src/service.rs
@@ -413,6 +413,8 @@ impl ServiceManager {
     <key>ProgramArguments</key>
     <array>
         <string>{binary}</string>
+        <string>--log-level</string>
+        <string>{log_level}</string>
     </array>
     <key>RunAtLoad</key>
     <true/>
@@ -439,6 +441,11 @@ impl ServiceManager {
 "#,
             label = daemon_launchd_label(),
             binary = self.config.binary_path.display(),
+            log_level = match runt_workspace::build_channel() {
+                runt_workspace::BuildChannel::Nightly =>
+                    "info,notebook_sync=debug,runtimed::notebook_sync_server=debug",
+                runt_workspace::BuildChannel::Stable => "warn",
+            },
             log = self.config.log_path.display(),
             home = home_str,
             user = user,

--- a/packages/runtimed/src/sync-engine.ts
+++ b/packages/runtimed/src/sync-engine.ts
@@ -56,12 +56,14 @@ const FLUSH_DEBOUNCE_MS = 20;
 // ── Logger interface ─────────────────────────────────────────────────
 
 export interface SyncEngineLogger {
+  debug(msg: string, ...args: unknown[]): void;
   info(msg: string, ...args: unknown[]): void;
   warn(msg: string, ...args: unknown[]): void;
   error(msg: string, ...args: unknown[]): void;
 }
 
 const nullLogger: SyncEngineLogger = {
+  debug() {},
   info() {},
   warn() {},
   error() {},
@@ -164,6 +166,7 @@ export class SyncEngine {
    */
   start(): void {
     if (this.subscription) return; // already running
+    this.opts.logger.info("[sync-engine] Starting");
 
     const sub = (this.subscription = new Subscription());
     const log = this.opts.logger;
@@ -187,14 +190,32 @@ export class SyncEngine {
 
     // ── Source: frames → WASM demux → individual FrameEvents ──────
 
+    let frameCount = 0;
+    let lastFrameLogTime = Date.now();
+
     const frameEvents$ = this.frameIn$.pipe(
       mergeMap((payload) => {
         try {
           const handle = this.opts.getHandle();
-          if (!handle) return EMPTY;
+          if (!handle) {
+            log.debug("[sync-engine] frame dropped: no handle");
+            return EMPTY;
+          }
           const bytes = new Uint8Array(payload);
           const result = handle.receive_frame(bytes);
           if (!result || !Array.isArray(result)) return EMPTY;
+
+          // Log frame throughput every 5 seconds
+          frameCount++;
+          const now = Date.now();
+          if (now - lastFrameLogTime >= 5000) {
+            log.debug(
+              `[sync-engine] ${frameCount} frames processed in ${now - lastFrameLogTime}ms (${bytes.length}B last)`,
+            );
+            frameCount = 0;
+            lastFrameLogTime = now;
+          }
+
           return from(result as FrameEvent[]);
         } catch (e) {
           log.warn("[sync-engine] receive_frame failed:", e);
@@ -242,7 +263,10 @@ export class SyncEngine {
             if (this.awaitingInitialSync) {
               if (e.changed) {
                 this.awaitingInitialSync = false;
+                log.info("[sync-engine] Initial sync complete");
                 this._initialSyncComplete$.next();
+              } else {
+                log.debug("[sync-engine] Initial sync round (awaiting content)");
               }
               // Restart retry timer on handshake rounds
               retrySync$.next();
@@ -251,7 +275,17 @@ export class SyncEngine {
 
             // Steady-state: push changeset into coalescing buffer
             if (e.changed) {
-              materialize$.next(e.changeset ?? null);
+              const cs = e.changeset;
+              if (cs) {
+                log.debug(
+                  `[sync-engine] changeset: ${cs.changed.length} changed, ${cs.added.length} added, ${cs.removed.length} removed, order_changed=${cs.order_changed}`,
+                );
+              } else {
+                log.debug(
+                  "[sync-engine] sync_applied with change but no changeset (full materialization needed)",
+                );
+              }
+              materialize$.next(cs ?? null);
             }
             return EMPTY;
           }),
@@ -295,7 +329,17 @@ export class SyncEngine {
               }
             }
 
-            this._cellChanges$.next(needsFull ? null : merged);
+            const result = needsFull ? null : merged;
+            if (needsFull) {
+              log.debug(
+                `[sync-engine] coalesced ${batch.length} changesets → full materialization`,
+              );
+            } else if (result) {
+              log.debug(
+                `[sync-engine] coalesced ${batch.length} changesets → ${result.changed.length} changed, ${result.added.length} added, ${result.removed.length} removed`,
+              );
+            }
+            this._cellChanges$.next(result);
             return EMPTY;
           }),
         )
@@ -334,6 +378,10 @@ export class SyncEngine {
                 state.executions,
               );
               this.prevExecutions = state.executions;
+
+              log.debug(
+                `[sync-engine] runtime state: kernel=${state.kernel?.status ?? "?"}, transitions=${transitions.length}`,
+              );
 
               this._runtimeState$.next(state);
               if (transitions.length > 0) {
@@ -385,6 +433,7 @@ export class SyncEngine {
    */
   stop(): void {
     if (!this.subscription) return;
+    this.opts.logger.info("[sync-engine] Stopping");
     this.subscription.unsubscribe();
     this.subscription = null;
   }
@@ -405,10 +454,16 @@ export class SyncEngine {
    */
   flush(): void {
     const handle = this.opts.getHandle();
-    if (!handle) return;
+    if (!handle) {
+      this.opts.logger.debug("[sync-engine] flush skipped: no handle");
+      return;
+    }
 
     const msg = handle.flush_local_changes();
     if (msg) {
+      this.opts.logger.debug(
+        `[sync-engine] flushing sync message (${msg.byteLength}B)`,
+      );
       this.opts.transport
         .sendFrame(FrameType.AUTOMERGE_SYNC, msg)
         .catch((e: unknown) => {
@@ -468,6 +523,7 @@ export class SyncEngine {
    * next round of frames is treated as a fresh connection.
    */
   resetForBootstrap(): void {
+    this.opts.logger.info("[sync-engine] Resetting for bootstrap");
     this.awaitingInitialSync = true;
     this.prevExecutions = {};
   }


### PR DESCRIPTION
## Summary

- Nightly builds now default to verbose logging across the full stack (daemon, Tauri app, frontend) so CRDT sync issues, frame drops, and materialization gaps are visible in diagnostics without manual `RUST_LOG` overrides
- Stable builds are unaffected — `warn` (daemon) and `Info` (notebook) defaults unchanged
- Added debug-level instrumentation to: SyncEngine frame processing, CRDT editor bridge, changeset materialization pipeline, DocHandle mutations, and the notebook bootstrap lifecycle

## Motivation

After installing a nightly build, cell execution silently stopped working after an in-app webview reload. The daemon log had only a startup line (`warn` default suppressed everything), and the notebook log showed execute requests going out but no outputs coming back. With these changes, the sync head mismatch, frame drops, and materialization failures would all be visible in the diagnostics archive.

## Test plan

- [ ] Build nightly (`cargo xtask build`) and verify `runtimed.log` now shows info-level entries on startup
- [ ] Open a notebook, execute cells, and confirm debug-level CRDT/sync logs appear in `notebook.log`
- [ ] Verify stable channel build (`RUNT_BUILD_CHANNEL=stable cargo check`) still defaults to `warn`/`Info`
- [ ] Run `cargo xtask lint` — pre-existing clippy `expect_used` in build.rs is unrelated
- [ ] Collect diagnostics (`runt-nightly diagnostics`) and verify the archive contains verbose logs