### PR TITLE
fix(sync-engine): move output clearing into SyncEngine execution lifecycle

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -520,6 +520,10 @@ function AppContent() {
       // Flush pending source sync so daemon has latest code
       await flushSync();
 
+      // Clear all outputs via daemon before restarting so the user sees
+      // every cell go blank up front.
+      await Promise.all(codeCells.map((cell) => clearOutputs(cell.id)));
+
       // Shutdown existing kernel
       await shutdownKernel();
 
@@ -541,6 +545,7 @@ function AppContent() {
       runAllInFlightRef.current = false;
     }
   }, [
+    clearOutputs,
     flushSync,
     shutdownKernel,
     tryStartKernel,
@@ -651,6 +656,10 @@ function AppContent() {
       // Flush pending source sync so daemon has latest code
       await flushSync();
 
+      // Clear all outputs via daemon before queueing so the user sees
+      // every cell go blank up front (not one-at-a-time as they start).
+      await Promise.all(codeCells.map((cell) => clearOutputs(cell.id)));
+
       // Start kernel via daemon if not running
       if (kernelStatus === KERNEL_STATUS.NOT_STARTED) {
         const started = await tryStartKernel();
@@ -673,6 +682,7 @@ function AppContent() {
   }, [
     kernelStatus,
     tryStartKernel,
+    clearOutputs,
     flushSync,
     daemonRunAllCells,
   ]);

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -135,8 +135,6 @@ function AppContent() {
 
     updateOutputByDisplayId,
     applyExecutionCountFromDaemon,
-    clearOutputsLocal,
-    clearAllOutputsLocal,
     clearOutputsFromDaemon,
     setCellSourceHidden,
     setCellOutputsHidden,
@@ -522,11 +520,6 @@ function AppContent() {
       // Flush pending source sync so daemon has latest code
       await flushSync();
 
-      // Clear all outputs via WASM CRDT (syncs to daemon via Automerge)
-      for (const cell of codeCells) {
-        clearOutputsLocal(cell.id);
-      }
-
       // Shutdown existing kernel
       await shutdownKernel();
 
@@ -548,7 +541,6 @@ function AppContent() {
       runAllInFlightRef.current = false;
     }
   }, [
-    clearOutputsLocal,
     flushSync,
     shutdownKernel,
     tryStartKernel,
@@ -595,10 +587,8 @@ function AppContent() {
       // Flush pending source sync so daemon has latest code before executing
       await flushSync();
 
-      // Clear outputs immediately so user sees feedback
-      clearOutputsLocal(cellId);
-
-      // Broadcast clear to other windows
+      // Tell daemon to clear outputs — the SyncEngine will clear the store
+      // when the RuntimeStateDoc reports execution started.
       await clearOutputs(cellId);
 
       // Start kernel via daemon if not running, then queue cell.
@@ -616,7 +606,6 @@ function AppContent() {
       }
     },
     [
-      clearOutputsLocal,
       clearOutputs,
       flushSync,
       kernelStatus,
@@ -662,11 +651,6 @@ function AppContent() {
       // Flush pending source sync so daemon has latest code
       await flushSync();
 
-      // Clear all outputs via WASM CRDT (syncs to daemon via Automerge)
-      for (const cell of codeCells) {
-        clearOutputsLocal(cell.id);
-      }
-
       // Start kernel via daemon if not running
       if (kernelStatus === KERNEL_STATUS.NOT_STARTED) {
         const started = await tryStartKernel();
@@ -689,7 +673,6 @@ function AppContent() {
   }, [
     kernelStatus,
     tryStartKernel,
-    clearOutputsLocal,
     flushSync,
     daemonRunAllCells,
   ]);
@@ -822,13 +805,12 @@ function AppContent() {
         (c) => c.id === focusedCellId,
       );
       if (!cell || cell.cell_type !== "code") return;
-      clearOutputsLocal(focusedCellId);
       await clearOutputs(focusedCellId);
     });
     return () => {
       unlistenPromise.then((unlisten) => unlisten()).catch(() => {});
     };
-  }, [focusedCellId, clearOutputsLocal, clearOutputs]);
+  }, [focusedCellId, clearOutputs]);
 
   // Cell menu: Clear All Outputs
   useEffect(() => {
@@ -836,8 +818,6 @@ function AppContent() {
     const unlistenPromise = webview.listen(
       "menu:clear-all-outputs",
       async () => {
-        // Single WASM call clears all code cells in the CRDT
-        clearAllOutputsLocal();
         // Tell daemon to clear kernel output tracking for each cell
         const codeCells = getNotebookCellsSnapshot().filter(
           (c) => c.cell_type === "code",
@@ -848,7 +828,7 @@ function AppContent() {
     return () => {
       unlistenPromise.then((unlisten) => unlisten()).catch(() => {});
     };
-  }, [clearAllOutputsLocal, clearOutputs]);
+  }, [clearOutputs]);
 
   // Kernel menu: Run All Cells
   useEffect(() => {

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -610,13 +610,7 @@ function AppContent() {
         logger.warn("[App] handleExecuteCell: no kernel available");
       }
     },
-    [
-      clearOutputs,
-      flushSync,
-      kernelStatus,
-      tryStartKernel,
-      executeCell,
-    ],
+    [clearOutputs, flushSync, kernelStatus, tryStartKernel, executeCell],
   );
 
   const handleAddCell = useCallback(

--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -342,39 +342,15 @@ export function useAutomergeNotebook() {
     setDirty(true);
   }, []);
 
-  const clearOutputsLocal = useCallback((cellId: string) => {
-    const handle = handleRef.current;
-    const engine = engineRef.current;
-    if (handle) {
-      handle.clear_outputs(cellId);
-      handle.set_execution_count(cellId, "null");
-      engine?.scheduleFlush();
-      setDirty(true);
-    }
-
-    updateCellById(cellId, (c) =>
-      c.cell_type === "code" ? { ...c, outputs: [], execution_count: null } : c,
-    );
+  const clearOutputsLocal = useCallback((_cellId: string) => {
+    // No-op: the SyncEngine clears outputs via cellChanges$ when the
+    // RuntimeStateDoc reports execution started for this cell. Clearing
+    // here previously caused a CRDT race under rapid ctrl-enter.
   }, []);
 
   const clearAllOutputsLocal = useCallback(() => {
-    const handle = handleRef.current;
-    const engine = engineRef.current;
-    if (!handle) return;
-    const clearedIds: string[] = handle.clear_all_outputs();
-    if (clearedIds.length === 0) return;
-
-    engine?.scheduleFlush();
-    setDirty(true);
-
-    const clearedSet = new Set(clearedIds);
-    updateNotebookCells((prev) =>
-      prev.map((c) =>
-        clearedSet.has(c.id) && c.cell_type === "code"
-          ? { ...c, outputs: [], execution_count: null }
-          : c,
-      ),
-    );
+    // No-op: each cell is cleared individually by the SyncEngine
+    // when the RuntimeStateDoc reports execution started.
   }, []);
 
   const clearOutputsFromDaemon = useCallback((cellId: string) => {

--- a/packages/runtimed/src/sync-engine.ts
+++ b/packages/runtimed/src/sync-engine.ts
@@ -386,6 +386,36 @@ export class SyncEngine {
               this._runtimeState$.next(state);
               if (transitions.length > 0) {
                 this._executionTransitions$.next(transitions);
+
+                // Inject synthetic changesets on execution lifecycle transitions
+                // so the materialization pipeline stays in sync with the CRDT.
+                //
+                // "started": the daemon cleared outputs in the CRDT on
+                //   execute_input — re-read from WASM to show empty outputs.
+                // "done"/"error": reconcile the store with the CRDT's final
+                //   state in case earlier materializations were missed.
+                for (const t of transitions) {
+                  if (t.kind === "started") {
+                    log.debug(
+                      `[sync-engine] execution started for ${t.cell_id.slice(0, 8)} — clearing outputs`,
+                    );
+                  } else {
+                    log.debug(
+                      `[sync-engine] execution ${t.kind} for ${t.cell_id.slice(0, 8)} — reconciling outputs`,
+                    );
+                  }
+                  materialize$.next({
+                    changed: [
+                      {
+                        cell_id: t.cell_id,
+                        fields: { outputs: true, execution_count: true },
+                      },
+                    ],
+                    added: [],
+                    removed: [],
+                    order_changed: false,
+                  });
+                }
               }
             }
 


### PR DESCRIPTION
## Summary

- Rapid ctrl-enter on a cell caused permanent output loss — outputs cleared but never came back even though the daemon completed all executions
- Root cause: `clearOutputsLocal` wrote "clear" mutations to the frontend CRDT that raced with daemon output writes; once the CRDT converged, the materialization pipeline stopped firing and the React store was permanently stale
- Fix: move output clearing into the SyncEngine's execution lifecycle in the `runtimed` JS package, so all consumers benefit

## What changed

**`packages/runtimed/src/sync-engine.ts`** — When `diffExecutions` detects execution transitions, inject synthetic changesets into the `cellChanges$` pipeline:
- `"started"` → re-materialize the cell (daemon has already cleared outputs in the CRDT via `execute_input` IOPub)
- `"done"` / `"error"` → reconciliation changeset to snap the store to the CRDT's final state

**`apps/notebook/src/hooks/useAutomergeNotebook.ts`** — `clearOutputsLocal` and `clearAllOutputsLocal` are now no-ops. They no longer write to the CRDT or the React store.

**`apps/notebook/src/App.tsx`** — Removed `clearOutputsLocal` / `clearAllOutputsLocal` calls from all execute paths. Run All and Restart & Run All now clear outputs up front via daemon IPC (`clearOutputs` per cell) so queued cells go blank immediately rather than one-at-a-time as they start.

## How it works

```
ctrl-enter → flushSync + clearOutputs (daemon IPC) + executeCell (daemon IPC)
  → daemon clears outputs on execute_input, writes new outputs on completion
  → RuntimeStateDoc updates with execution lifecycle
  → SyncEngine sees "started" → injects clear changeset → cellChanges$ → store shows empty
  → SyncEngine sees "done" → injects reconciliation changeset → cellChanges$ → store shows outputs
```

For Run All / Restart & Run All:
```
Run All → clearOutputs per cell (daemon IPC, all cells go blank)
  → daemon queues all cells
  → each cell: SyncEngine "started" → clear, "done" → reconcile
```

## Test plan

- [ ] Rapid ctrl-enter a cell 20+ times → final execution's outputs appear
- [ ] Single ctrl-enter → outputs clear then appear
- [ ] "Clear Outputs" from menu (no execute) → outputs disappear and stay cleared
- [ ] "Clear All Outputs" from menu → all cleared
- [ ] Run All → all cells go blank up front, then outputs appear one-by-one
- [ ] Restart & Run All → same as Run All after kernel restart
- [ ] Slow cell (`time.sleep(5); print("done")`) → outputs clear when kernel starts, appear after 5s
- [ ] `notebook.log` shows `[sync-engine] execution started for ... — clearing outputs`

Relates to #1048