### PR TITLE
fix(test): fix flaky autosave rekey test with poll-based assertion

### DIFF
--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -7797,28 +7797,28 @@ mod tests {
         // Signal the change so the autosave debouncer sees it
         let _ = room.changed_tx.send(());
 
-        // 6. Wait for the autosave debouncer to flush.
-        //    Use sleep() instead of advance()+yield_now() — sleep properly
-        //    advances the paused clock AND yields to the runtime, giving all
-        //    spawned tasks (debouncer select! loop, check interval, async
-        //    file write) enough scheduling opportunities to complete.
-        //    Default config: 2s debounce + 500ms check interval, so 3s is
-        //    enough for the debounce window plus a check tick plus the save.
-        tokio::time::sleep(Duration::from_secs(3)).await;
+        // 6. Poll until the autosave debouncer flushes both cells to disk.
+        //    Each sleep(100ms) advances the paused clock and yields to the
+        //    runtime, letting the debouncer make progress. Timeout after 10s
+        //    (well beyond the 2s debounce + 500ms check interval defaults).
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+        let nb = loop {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            let content = tokio::fs::read_to_string(&save_path).await.unwrap();
+            let nb: serde_json::Value = serde_json::from_str(&content).unwrap();
+            if nb["cells"].as_array().is_some_and(|c| c.len() == 2) {
+                break nb;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "Timed out waiting for autosave to flush both cells; got: {}",
+                serde_json::to_string_pretty(&nb["cells"]).unwrap()
+            );
+        };
 
-        // 7. Verify the file on disk contains BOTH cells (initial + post-rekey)
-        let content = tokio::fs::read_to_string(&save_path).await.unwrap();
-        let nb: serde_json::Value = serde_json::from_str(&content).unwrap();
-        let cells = nb["cells"].as_array().expect("cells should be an array");
-        assert_eq!(
-            cells.len(),
-            2,
-            "Both cells should be autosaved; got: {}",
-            serde_json::to_string_pretty(&nb["cells"]).unwrap()
-        );
-
-        // Verify the post-rekey cell's source is present.
+        // 7. Verify the post-rekey cell's source is present.
         // nbformat stores source as an array of strings, e.g. ["y = 2"].
+        let cells = nb["cells"].as_array().unwrap();
         let sources: Vec<String> = cells
             .iter()
             .map(|c| match &c["source"] {

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -7739,7 +7739,6 @@ mod tests {
     /// This is the exact scenario that was broken before the autosave
     /// debouncer was spawned in `rekey_ephemeral_room`.
     #[tokio::test(start_paused = true)]
-    #[ignore = "flaky: single yield_now per advance step starves the autosave debouncer on slow CI"]
     async fn test_rekey_ephemeral_room_starts_autosave() {
         use std::time::Duration;
 
@@ -7798,15 +7797,14 @@ mod tests {
         // Signal the change so the autosave debouncer sees it
         let _ = room.changed_tx.send(());
 
-        // 6. Drive the autosave debouncer through its state machine.
-        //    With `start_paused` we advance time in small steps and yield
-        //    between each so the spawned task can poll its select! branches,
-        //    receive the change, wait for the debounce window, and complete
-        //    the async file write.
-        for _ in 0..100 {
-            tokio::time::advance(Duration::from_millis(100)).await;
-            tokio::task::yield_now().await;
-        }
+        // 6. Wait for the autosave debouncer to flush.
+        //    Use sleep() instead of advance()+yield_now() — sleep properly
+        //    advances the paused clock AND yields to the runtime, giving all
+        //    spawned tasks (debouncer select! loop, check interval, async
+        //    file write) enough scheduling opportunities to complete.
+        //    Default config: 2s debounce + 500ms check interval, so 3s is
+        //    enough for the debounce window plus a check tick plus the save.
+        tokio::time::sleep(Duration::from_secs(3)).await;
 
         // 7. Verify the file on disk contains BOTH cells (initial + post-rekey)
         let content = tokio::fs::read_to_string(&save_path).await.unwrap();


### PR DESCRIPTION
## Summary

- Remove `#[ignore]` from `test_rekey_ephemeral_room_starts_autosave` and fix the underlying timing issue
- Replace the `advance(100ms)` + `yield_now()` loop with a poll loop that checks every 100ms whether the autosave has flushed both cells to disk, with a 10s timeout
- The test now succeeds as soon as the condition is met rather than sleeping a fixed duration — no magic timing constants to get right

The old approach used a single `yield_now()` per `advance()` step, which starved the autosave debouncer's multi-step async pipeline (receive change → debounce wait → check interval tick → async file write) on slower CI runners.

## Verification

* [ ] `Clippy & Tests (Linux)` CI job passes — this is where the test was flaking

_PR submitted by @rgbkrk's agent, Quill_