### PR TITLE
test(sync-engine): regression coverage for output clearing lifecycle

### DIFF
--- a/apps/notebook/src/lib/__tests__/frame-pipeline.test.ts
+++ b/apps/notebook/src/lib/__tests__/frame-pipeline.test.ts
@@ -1,9 +1,100 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi, beforeEach } from "vitest";
 import {
   type CellChangeset,
   type ChangedFields,
   mergeChangesets,
 } from "../cell-changeset";
+import { materializeChangeset, type MaterializeDeps } from "../frame-pipeline";
+import type { JupyterOutput } from "../../types";
+
+// ── Mocks ──────────────────────────────────────────────────────────────
+
+// Mock notebook-cells: getCellById returns a stored cell, updateCellById
+// captures what the pipeline writes to the store.
+const cellStore = new Map<string, Record<string, unknown>>();
+const updateCalls: Array<{ cellId: string; cell: Record<string, unknown> }> =
+  [];
+
+vi.mock("../notebook-cells", () => ({
+  getCellById: (id: string) => cellStore.get(id) ?? null,
+  updateCellById: (id: string, fn: (prev: Record<string, unknown>) => Record<string, unknown>) => {
+    const prev = cellStore.get(id) ?? {};
+    const next = fn(prev);
+    cellStore.set(id, next);
+    updateCalls.push({ cellId: id, cell: next });
+  },
+}));
+
+vi.mock("../notebook-metadata", () => ({
+  notifyMetadataChanged: vi.fn(),
+}));
+
+vi.mock("../blob-port", () => ({
+  getBlobPort: () => 12345,
+  refreshBlobPort: () => Promise.resolve(12345),
+}));
+
+vi.mock("../logger", () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+// Mock materialize-cells: materializeCellFromWasm builds a cell from the
+// handle's per-field accessors. isManifestHash and resolveOutput handle
+// the cache-miss path.
+vi.mock("../materialize-cells", () => ({
+  isManifestHash: (s: string) => s.startsWith("sha256:"),
+  materializeCellFromWasm: (
+    handle: Record<string, (id: string) => unknown>,
+    cellId: string,
+    cache: Map<string, JupyterOutput>,
+    _prev?: Record<string, unknown>,
+  ) => {
+    const cellType = handle.get_cell_type(cellId);
+    if (!cellType) return null;
+    const source = (handle.get_cell_source(cellId) as string) ?? "";
+    const ecStr = handle.get_cell_execution_count(cellId) as string;
+    const ec = !ecStr || ecStr === "null" ? null : Number.parseInt(ecStr, 10);
+    const rawOutputs = (handle.get_cell_outputs(cellId) as string[]) ?? [];
+    const outputs = rawOutputs
+      .map((o: string) => cache.get(o) ?? null)
+      .filter((o: JupyterOutput | null): o is JupyterOutput => o !== null);
+    const metadata = (handle.get_cell_metadata(cellId) as Record<string, unknown>) ?? {};
+    return {
+      id: cellId,
+      cell_type: cellType,
+      source,
+      execution_count: ec,
+      outputs,
+      metadata,
+    };
+  },
+  resolveOutput: async (
+    outputStr: string,
+    _blobPort: number,
+    cache: Map<string, JupyterOutput>,
+  ) => {
+    // Simulate async blob resolution — check cache, test-level registry,
+    // or parse JSON.
+    const cached = cache.get(outputStr);
+    if (cached) return cached;
+    // Check test-level registry for sha256 hashes
+    const registered = blobRegistry.get(outputStr);
+    if (registered) {
+      cache.set(outputStr, registered);
+      return registered;
+    }
+    try {
+      const parsed = JSON.parse(outputStr) as JupyterOutput;
+      cache.set(outputStr, parsed);
+      return parsed;
+    } catch {
+      return null;
+    }
+  },
+}));
+
+// Test-level registry for simulating blob server responses for sha256 hashes.
+const blobRegistry = new Map<string, JupyterOutput>();
 
 // ---------------------------------------------------------------------------
 // mergeChangesets — merges two CellChangesets produced by successive WASM
@@ -245,5 +336,270 @@ describe("mergeChangesets", () => {
     }
     expect(acc.changed).toHaveLength(100);
     expect(acc.added).toHaveLength(10);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// materializeChangeset — processes coalesced CellChangesets from the
+// SyncEngine and writes the resulting cells to the React store.
+// ---------------------------------------------------------------------------
+
+describe("materializeChangeset", () => {
+  // Mock handle factory
+  function createMockHandle(cells: Record<string, {
+    type?: string;
+    source?: string;
+    outputs?: string[];
+    execution_count?: string;
+    metadata?: Record<string, unknown>;
+  }>) {
+    return {
+      get_cell_type: vi.fn((id: string) => cells[id]?.type ?? "code"),
+      get_cell_source: vi.fn((id: string) => cells[id]?.source ?? ""),
+      get_cell_outputs: vi.fn((id: string) => cells[id]?.outputs ?? []),
+      get_cell_execution_count: vi.fn(
+        (id: string) => cells[id]?.execution_count ?? "null",
+      ),
+      get_cell_metadata: vi.fn((id: string) => cells[id]?.metadata ?? {}),
+    } as unknown as import("../../wasm/runtimed-wasm/runtimed_wasm.js").NotebookHandle;
+  }
+
+  function createDeps(
+    handle: ReturnType<typeof createMockHandle>,
+    outputCache?: Map<string, JupyterOutput>,
+  ): MaterializeDeps {
+    return {
+      getHandle: () => handle,
+      materializeCells: vi.fn(),
+      outputCache: outputCache ?? new Map(),
+    };
+  }
+
+  beforeEach(() => {
+    cellStore.clear();
+    updateCalls.length = 0;
+    blobRegistry.clear();
+  });
+
+  it("clears cell when WASM returns empty outputs", async () => {
+    const handle = createMockHandle({
+      c1: { outputs: [], execution_count: "null" },
+    });
+    const deps = createDeps(handle);
+
+    await materializeChangeset(
+      {
+        changed: [
+          { cell_id: "c1", fields: { outputs: true, execution_count: true } },
+        ],
+        added: [],
+        removed: [],
+        order_changed: false,
+      },
+      deps,
+    );
+
+    expect(updateCalls).toHaveLength(1);
+    expect(updateCalls[0].cellId).toBe("c1");
+    expect(updateCalls[0].cell).toMatchObject({
+      outputs: [],
+      execution_count: null,
+    });
+  });
+
+  it("restores final outputs from WASM via cache", async () => {
+    const streamOutput: JupyterOutput = {
+      output_type: "stream",
+      name: "stdout",
+      text: "hello\n",
+    };
+    const cache = new Map<string, JupyterOutput>();
+    cache.set("out-hash-1", streamOutput);
+
+    const handle = createMockHandle({
+      c1: { outputs: ["out-hash-1"], execution_count: "5" },
+    });
+    const deps = createDeps(handle, cache);
+
+    await materializeChangeset(
+      {
+        changed: [
+          { cell_id: "c1", fields: { outputs: true, execution_count: true } },
+        ],
+        added: [],
+        removed: [],
+        order_changed: false,
+      },
+      deps,
+    );
+
+    expect(updateCalls).toHaveLength(1);
+    expect(updateCalls[0].cell).toMatchObject({
+      outputs: [streamOutput],
+      execution_count: 5,
+    });
+  });
+
+  it("preserves source when fields.source is false", async () => {
+    // Pre-populate store with existing source
+    cellStore.set("c1", {
+      id: "c1",
+      cell_type: "code",
+      source: "print('original')",
+      outputs: [],
+      execution_count: null,
+      metadata: {},
+    });
+
+    const handle = createMockHandle({
+      c1: {
+        source: "print('from-wasm')",
+        outputs: [],
+        execution_count: "3",
+      },
+    });
+    const deps = createDeps(handle);
+
+    await materializeChangeset(
+      {
+        changed: [
+          {
+            cell_id: "c1",
+            fields: { outputs: true, execution_count: true },
+            // source is NOT in fields — should preserve store source
+          },
+        ],
+        added: [],
+        removed: [],
+        order_changed: false,
+      },
+      deps,
+    );
+
+    expect(updateCalls).toHaveLength(1);
+    // Source should be the original from the store, not from WASM
+    expect(updateCalls[0].cell.source).toBe("print('original')");
+  });
+
+  it("restores error output on reconciliation", async () => {
+    const errorOutput: JupyterOutput = {
+      output_type: "error",
+      ename: "ZeroDivisionError",
+      evalue: "division by zero",
+      traceback: ["Traceback...", "ZeroDivisionError: division by zero"],
+    };
+    const cache = new Map<string, JupyterOutput>();
+    cache.set("err-hash-1", errorOutput);
+
+    const handle = createMockHandle({
+      c1: { outputs: ["err-hash-1"], execution_count: "2" },
+    });
+    const deps = createDeps(handle, cache);
+
+    await materializeChangeset(
+      {
+        changed: [
+          { cell_id: "c1", fields: { outputs: true, execution_count: true } },
+        ],
+        added: [],
+        removed: [],
+        order_changed: false,
+      },
+      deps,
+    );
+
+    expect(updateCalls).toHaveLength(1);
+    expect(updateCalls[0].cell.outputs).toEqual([errorOutput]);
+    expect(updateCalls[0].cell.execution_count).toBe(2);
+  });
+
+  it("falls back to full materialization for null changeset", async () => {
+    const handle = createMockHandle({});
+    const deps = createDeps(handle);
+
+    await materializeChangeset(null, deps);
+
+    expect(deps.materializeCells).toHaveBeenCalledWith(handle);
+  });
+
+  it("falls back to full materialization for structural changes", async () => {
+    const handle = createMockHandle({});
+    const deps = createDeps(handle);
+
+    await materializeChangeset(
+      {
+        changed: [],
+        added: ["new-cell"],
+        removed: [],
+        order_changed: false,
+      },
+      deps,
+    );
+
+    expect(deps.materializeCells).toHaveBeenCalledWith(handle);
+  });
+
+  it("resolves uncached manifest hashes via async blob fetch", async () => {
+    const execResult: JupyterOutput = {
+      output_type: "execute_result",
+      data: { "text/plain": "42" },
+      metadata: {},
+      execution_count: 1,
+    };
+
+    // Use a sha256: hash so isManifestHash returns true. The output cache
+    // is empty so allCached=false, triggering the async resolution path.
+    // The blobRegistry simulates the blob server returning this output.
+    const hash = "sha256:abc123";
+    blobRegistry.set(hash, execResult);
+    const cache = new Map<string, JupyterOutput>();
+
+    const handle = createMockHandle({
+      c1: {
+        outputs: [hash],
+        execution_count: "1",
+        source: "6 * 7",
+      },
+    });
+    const deps = createDeps(handle, cache);
+
+    await materializeChangeset(
+      {
+        changed: [
+          { cell_id: "c1", fields: { outputs: true, source: true } },
+        ],
+        added: [],
+        removed: [],
+        order_changed: false,
+      },
+      deps,
+    );
+
+    expect(updateCalls).toHaveLength(1);
+    expect(updateCalls[0].cell.outputs).toEqual([execResult]);
+    expect(updateCalls[0].cell.source).toBe("6 * 7");
+  });
+
+  it("returns early when handle is null", async () => {
+    const deps: MaterializeDeps = {
+      getHandle: () => null,
+      materializeCells: vi.fn(),
+      outputCache: new Map(),
+    };
+
+    await materializeChangeset(
+      {
+        changed: [
+          { cell_id: "c1", fields: { outputs: true } },
+        ],
+        added: [],
+        removed: [],
+        order_changed: false,
+      },
+      deps,
+    );
+
+    expect(updateCalls).toHaveLength(0);
+    expect(deps.materializeCells).not.toHaveBeenCalled();
   });
 });

--- a/apps/notebook/src/lib/__tests__/frame-pipeline.test.ts
+++ b/apps/notebook/src/lib/__tests__/frame-pipeline.test.ts
@@ -1,11 +1,11 @@
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { JupyterOutput } from "../../types";
 import {
   type CellChangeset,
   type ChangedFields,
   mergeChangesets,
 } from "../cell-changeset";
-import { materializeChangeset, type MaterializeDeps } from "../frame-pipeline";
-import type { JupyterOutput } from "../../types";
+import { type MaterializeDeps, materializeChangeset } from "../frame-pipeline";
 
 // ── Mocks ──────────────────────────────────────────────────────────────
 
@@ -17,7 +17,10 @@ const updateCalls: Array<{ cellId: string; cell: Record<string, unknown> }> =
 
 vi.mock("../notebook-cells", () => ({
   getCellById: (id: string) => cellStore.get(id) ?? null,
-  updateCellById: (id: string, fn: (prev: Record<string, unknown>) => Record<string, unknown>) => {
+  updateCellById: (
+    id: string,
+    fn: (prev: Record<string, unknown>) => Record<string, unknown>,
+  ) => {
     const prev = cellStore.get(id) ?? {};
     const next = fn(prev);
     cellStore.set(id, next);
@@ -58,7 +61,8 @@ vi.mock("../materialize-cells", () => ({
     const outputs = rawOutputs
       .map((o: string) => cache.get(o) ?? null)
       .filter((o: JupyterOutput | null): o is JupyterOutput => o !== null);
-    const metadata = (handle.get_cell_metadata(cellId) as Record<string, unknown>) ?? {};
+    const metadata =
+      (handle.get_cell_metadata(cellId) as Record<string, unknown>) ?? {};
     return {
       id: cellId,
       cell_type: cellType,
@@ -346,13 +350,18 @@ describe("mergeChangesets", () => {
 
 describe("materializeChangeset", () => {
   // Mock handle factory
-  function createMockHandle(cells: Record<string, {
-    type?: string;
-    source?: string;
-    outputs?: string[];
-    execution_count?: string;
-    metadata?: Record<string, unknown>;
-  }>) {
+  function createMockHandle(
+    cells: Record<
+      string,
+      {
+        type?: string;
+        source?: string;
+        outputs?: string[];
+        execution_count?: string;
+        metadata?: Record<string, unknown>;
+      }
+    >,
+  ) {
     return {
       get_cell_type: vi.fn((id: string) => cells[id]?.type ?? "code"),
       get_cell_source: vi.fn((id: string) => cells[id]?.source ?? ""),
@@ -565,9 +574,7 @@ describe("materializeChangeset", () => {
 
     await materializeChangeset(
       {
-        changed: [
-          { cell_id: "c1", fields: { outputs: true, source: true } },
-        ],
+        changed: [{ cell_id: "c1", fields: { outputs: true, source: true } }],
         added: [],
         removed: [],
         order_changed: false,
@@ -589,9 +596,7 @@ describe("materializeChangeset", () => {
 
     await materializeChangeset(
       {
-        changed: [
-          { cell_id: "c1", fields: { outputs: true } },
-        ],
+        changed: [{ cell_id: "c1", fields: { outputs: true } }],
         added: [],
         removed: [],
         order_changed: false,

--- a/crates/notebook/fixtures/audit-test/15-run-all-output-lifecycle.ipynb
+++ b/crates/notebook/fixtures/audit-test/15-run-all-output-lifecycle.ipynb
@@ -1,0 +1,53 @@
+{
+  "cells": [
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "cell-slow",
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "stale-output-1\n"
+          ]
+        }
+      ],
+      "source": [
+        "import time; time.sleep(2); print('cell-1-done')"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "cell-fast",
+      "metadata": {},
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "stale-output-2\n"
+          ]
+        }
+      ],
+      "source": [
+        "print('cell-2-done')"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.12.0"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/e2e/specs/run-all-output-lifecycle.spec.js
+++ b/e2e/specs/run-all-output-lifecycle.spec.js
@@ -50,14 +50,16 @@ describe("Run All Output Lifecycle", () => {
     // disappear before new execution starts.
     await browser.pause(500);
 
-    // While cell 1 is running (2s sleep), cell 2 should not show stale output.
-    // Check that at least one cell has been cleared (no "stale-output" text).
-    const cell2MidRun = await cells[1]
-      .$('[data-testid="cell-output"]')
-      .catch(() => null);
-    if (cell2MidRun && (await cell2MidRun.isExisting())) {
-      const midText = await cell2MidRun.getText();
-      expect(midText).not.toContain("stale-output-2");
+    // While cell 1 is running (2s sleep), neither cell should show stale output.
+    // Both cells' outputs should have been cleared up front by Run All.
+    for (let i = 0; i < 2; i++) {
+      const outputEl = await cells[i]
+        .$('[data-testid="cell-output"]')
+        .catch(() => null);
+      if (outputEl && (await outputEl.isExisting())) {
+        const midText = await outputEl.getText();
+        expect(midText).not.toContain(`stale-output-${i + 1}`);
+      }
     }
 
     // Wait for cell 1 to complete (2s sleep + buffer)

--- a/e2e/specs/run-all-output-lifecycle.spec.js
+++ b/e2e/specs/run-all-output-lifecycle.spec.js
@@ -1,0 +1,71 @@
+/**
+ * E2E Test: Run All Output Lifecycle
+ *
+ * Verifies that Run All clears all cells' stale outputs up front and
+ * shows new outputs as each cell completes. Regression test for the
+ * rapid ctrl-enter output loss bug (PR #1201).
+ *
+ * Fixture: 15-run-all-output-lifecycle.ipynb
+ *   - Cell 1: sleep(2) + print (slow — keeps cell 2 queued)
+ *   - Cell 2: print (fast)
+ *   - Both cells have pre-existing stale outputs in the fixture
+ *
+ * Run with: cargo xtask e2e test-fixture \
+ *   crates/notebook/fixtures/audit-test/15-run-all-output-lifecycle.ipynb \
+ *   e2e/specs/run-all-output-lifecycle.spec.js
+ */
+
+import { browser } from "@wdio/globals";
+import {
+  waitForAppReady,
+  waitForCellOutput,
+  waitForKernelReady,
+  waitForNotebookSynced,
+} from "../helpers.js";
+
+describe("Run All Output Lifecycle", () => {
+  it("should load and reach idle", async () => {
+    await waitForAppReady();
+    await waitForKernelReady(300000);
+    await waitForNotebookSynced();
+  });
+
+  it("Run All should clear stale outputs and show new results", async () => {
+    const cells = await $$('[data-cell-type="code"]');
+    expect(cells.length).toBeGreaterThanOrEqual(2);
+
+    // Verify stale outputs are visible from the fixture
+    const cell1OutputBefore = await waitForCellOutput(cells[0], 10000);
+    expect(cell1OutputBefore).toContain("stale-output-1");
+
+    const cell2OutputBefore = await waitForCellOutput(cells[1], 10000);
+    expect(cell2OutputBefore).toContain("stale-output-2");
+
+    // Click "Run All"
+    const runAllButton = await $('[data-testid="run-all-button"]');
+    await runAllButton.waitForClickable({ timeout: 5000 });
+    await runAllButton.click();
+
+    // Wait briefly for the clear to propagate — stale outputs should
+    // disappear before new execution starts.
+    await browser.pause(500);
+
+    // While cell 1 is running (2s sleep), cell 2 should not show stale output.
+    // Check that at least one cell has been cleared (no "stale-output" text).
+    const cell2MidRun = await cells[1]
+      .$('[data-testid="cell-output"]')
+      .catch(() => null);
+    if (cell2MidRun && (await cell2MidRun.isExisting())) {
+      const midText = await cell2MidRun.getText();
+      expect(midText).not.toContain("stale-output-2");
+    }
+
+    // Wait for cell 1 to complete (2s sleep + buffer)
+    const cell1Output = await waitForCellOutput(cells[0], 30000);
+    expect(cell1Output).toContain("cell-1-done");
+
+    // Wait for cell 2 to complete
+    const cell2Output = await waitForCellOutput(cells[1], 30000);
+    expect(cell2Output).toContain("cell-2-done");
+  });
+});

--- a/packages/runtimed/src/sync-engine.ts
+++ b/packages/runtimed/src/sync-engine.ts
@@ -16,6 +16,7 @@
  */
 
 import {
+  type SchedulerLike,
   bufferTime,
   concatMap,
   debounceTime,
@@ -85,12 +86,15 @@ export interface SyncEngineOptions {
 
   /** Optional logger (defaults to silent). */
   logger?: SyncEngineLogger;
+
+  /** Optional RxJS scheduler for time-based operators (for testing). */
+  scheduler?: SchedulerLike;
 }
 
 // ── SyncEngine ───────────────────────────────────────────────────────
 
 export class SyncEngine {
-  private readonly opts: Required<SyncEngineOptions>;
+  private readonly opts: Required<Pick<SyncEngineOptions, "getHandle" | "transport" | "logger">> & Pick<SyncEngineOptions, "scheduler">;
   private subscription: Subscription | null = null;
   private awaitingInitialSync = true;
   private prevExecutions: Record<string, ExecutionState> = {};
@@ -145,6 +149,7 @@ export class SyncEngine {
     this.opts = {
       ...opts,
       logger: opts.logger ?? nullLogger,
+      scheduler: opts.scheduler,
     };
 
     // Expose as readonly Observable (hide Subject internals)
@@ -298,7 +303,7 @@ export class SyncEngine {
     sub.add(
       retrySync$
         .pipe(
-          switchMap(() => timer(SYNC_RETRY_MS)),
+          switchMap(() => timer(SYNC_RETRY_MS, this.opts.scheduler)),
           filter(() => this.awaitingInitialSync),
         )
         .subscribe(() => {
@@ -312,7 +317,7 @@ export class SyncEngine {
     sub.add(
       materialize$
         .pipe(
-          bufferTime(COALESCE_MS),
+          bufferTime(COALESCE_MS, this.opts.scheduler),
           filter((batch) => batch.length > 0),
           concatMap((batch) => {
             // Merge all changesets in the batch
@@ -452,7 +457,7 @@ export class SyncEngine {
     // ── Debounced outbound flush ──────────────────────────────────
 
     sub.add(
-      this.flushRequest$.pipe(debounceTime(FLUSH_DEBOUNCE_MS)).subscribe(() => {
+      this.flushRequest$.pipe(debounceTime(FLUSH_DEBOUNCE_MS, this.opts.scheduler)).subscribe(() => {
         this.flush();
       }),
     );

--- a/packages/runtimed/tests/sync-engine.test.ts
+++ b/packages/runtimed/tests/sync-engine.test.ts
@@ -3,10 +3,12 @@
  *
  * Proves the engine's lifecycle, coalescing, rollback, retry, and
  * observable emission without requiring WASM or a real daemon.
+ *
+ * Time-dependent tests use RxJS VirtualTimeScheduler instead of vi.useFakeTimers.
  */
 
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
-import { firstValueFrom } from "rxjs";
+import { VirtualTimeScheduler, VirtualAction } from "rxjs";
 import { SyncEngine } from "../src/sync-engine";
 import { DirectTransport } from "../src/direct-transport";
 import { FrameType } from "../src/transport";
@@ -67,6 +69,34 @@ function runtimeStateSyncEvent(state: RuntimeState): FrameEvent {
   return { type: "runtime_state_sync_applied", changed: true, state };
 }
 
+function makeRuntimeState(
+  executions: Record<
+    string,
+    { cell_id: string; status: string; execution_count: number | null; success: boolean | null }
+  >,
+): RuntimeState {
+  return {
+    kernel: {
+      status: "idle",
+      starting_phase: "",
+      name: "python3",
+      language: "python",
+      env_source: "",
+    },
+    queue: { executing: null, queued: [] },
+    env: {
+      in_sync: true,
+      added: [],
+      removed: [],
+      channels_changed: false,
+      deno_changed: false,
+    },
+    trust: { status: "trusted", needs_approval: false },
+    last_saved: null,
+    executions: executions as RuntimeState["executions"],
+  };
+}
+
 const EMPTY_CHANGESET: CellChangeset = {
   changed: [],
   added: [],
@@ -74,34 +104,50 @@ const EMPTY_CHANGESET: CellChangeset = {
   order_changed: false,
 };
 
+// ── Helper: advance scheduler to a given time ───────────────────────
+
+/**
+ * Advance the virtual clock by `ms` milliseconds.
+ *
+ * Sets `maxFrames` so `flush()` stops at the target time instead of
+ * spinning forever on repeating operators like `bufferTime`.
+ */
+function advanceBy(scheduler: VirtualTimeScheduler, ms: number): void {
+  const target = scheduler.frame + ms;
+  scheduler.maxFrames = target;
+  scheduler.schedule(() => {}, ms);
+  scheduler.flush();
+}
+
 // ── Tests ────────────────────────────────────────────────────────────
 
 describe("SyncEngine", () => {
   let handle: SyncableHandle;
   let server: ReturnType<typeof createMockServerHandle>;
   let transport: DirectTransport;
-  let engine: SyncEngine;
+  let scheduler: VirtualTimeScheduler;
 
   beforeEach(() => {
-    vi.useFakeTimers();
     handle = createMockHandle();
     server = createMockServerHandle();
     transport = new DirectTransport(server);
-    engine = new SyncEngine({
-      getHandle: () => handle,
-      transport,
-    });
+    scheduler = new VirtualTimeScheduler(VirtualAction, Infinity);
   });
 
-  afterEach(() => {
-    engine.stop();
-    vi.useRealTimers();
-  });
+  /** Helper: create engine with the VirtualTimeScheduler injected */
+  function createEngine(opts?: { getHandle?: () => SyncableHandle | null }): SyncEngine {
+    return new SyncEngine({
+      getHandle: opts?.getHandle ?? (() => handle),
+      transport,
+      scheduler,
+    });
+  }
 
   // ── Lifecycle ──────────────────────────────────────────────────
 
   describe("lifecycle", () => {
     it("starts and stops cleanly", () => {
+      const engine = createEngine();
       expect(engine.running).toBe(false);
       engine.start();
       expect(engine.running).toBe(true);
@@ -110,12 +156,15 @@ describe("SyncEngine", () => {
     });
 
     it("start is idempotent", () => {
+      const engine = createEngine();
       engine.start();
       engine.start(); // should not throw or double-subscribe
       expect(engine.running).toBe(true);
+      engine.stop();
     });
 
     it("stop is idempotent", () => {
+      const engine = createEngine();
       engine.start();
       engine.stop();
       engine.stop(); // should not throw
@@ -126,23 +175,12 @@ describe("SyncEngine", () => {
   // ── Initial sync ──────────────────────────────────────────────
 
   describe("initial sync", () => {
-    it("emits initialSyncComplete$ when changed:true arrives", async () => {
+    it("emits initialSyncComplete$ when changed:true arrives", () => {
       (handle.receive_frame as ReturnType<typeof vi.fn>).mockReturnValue([
         syncAppliedEvent({ changed: true }),
       ]);
 
-      engine.start();
-
-      const completed = firstValueFrom(engine.initialSyncComplete$);
-      transport.deliver(Array.from([0x00, 1, 2, 3])); // dummy frame
-      await completed; // should resolve
-    });
-
-    it("does not emit initialSyncComplete$ on changed:false", async () => {
-      (handle.receive_frame as ReturnType<typeof vi.fn>).mockReturnValue([
-        syncAppliedEvent({ changed: false }),
-      ]);
-
+      const engine = createEngine();
       engine.start();
 
       let completed = false;
@@ -151,11 +189,31 @@ describe("SyncEngine", () => {
       });
 
       transport.deliver(Array.from([0x00, 1, 2, 3]));
-      await vi.advanceTimersByTimeAsync(100);
-      expect(completed).toBe(false);
+      expect(completed).toBe(true);
+      engine.stop();
     });
 
-    it("retries sync after timeout when initial sync stalls", async () => {
+    it("does not emit initialSyncComplete$ on changed:false", () => {
+      (handle.receive_frame as ReturnType<typeof vi.fn>).mockReturnValue([
+        syncAppliedEvent({ changed: false }),
+      ]);
+
+      const engine = createEngine();
+      engine.start();
+
+      let completed = false;
+      engine.initialSyncComplete$.subscribe(() => {
+        completed = true;
+      });
+
+      transport.deliver(Array.from([0x00, 1, 2, 3]));
+      advanceBy(scheduler, 100);
+
+      expect(completed).toBe(false);
+      engine.stop();
+    });
+
+    it("retries sync after timeout when initial sync stalls", () => {
       // First frame: changed:false (handshake, no content)
       (handle.receive_frame as ReturnType<typeof vi.fn>).mockReturnValue([
         syncAppliedEvent({ changed: false }),
@@ -166,35 +224,41 @@ describe("SyncEngine", () => {
         new Uint8Array([1, 2, 3]),
       );
 
+      const engine = createEngine();
       engine.start();
       transport.deliver(Array.from([0x00, 1, 2, 3]));
 
       // Advance past the 3s retry timeout
-      await vi.advanceTimersByTimeAsync(3100);
+      advanceBy(scheduler, 3100);
 
       // Engine should have called reset_sync_state + flush for retry
       expect(handle.reset_sync_state).toHaveBeenCalled();
+      engine.stop();
     });
   });
 
   // ── Broadcasts ────────────────────────────────────────────────
 
   describe("broadcasts", () => {
-    it("emits broadcast payloads on broadcasts$", async () => {
+    it("emits broadcast payloads on broadcasts$", () => {
       const broadcastPayload = { event: "kernel_status", status: "busy" };
       (handle.receive_frame as ReturnType<typeof vi.fn>).mockReturnValue([
         broadcastEvent(broadcastPayload),
       ]);
 
+      const engine = createEngine();
       engine.start();
 
-      const received = firstValueFrom(engine.broadcasts$);
-      transport.deliver(Array.from([0x03, 1])); // dummy frame
-      const payload = await received;
-      expect(payload).toEqual(broadcastPayload);
+      const received: unknown[] = [];
+      engine.broadcasts$.subscribe((p) => received.push(p));
+
+      transport.deliver(Array.from([0x03, 1]));
+      expect(received).toHaveLength(1);
+      expect(received[0]).toEqual(broadcastPayload);
+      engine.stop();
     });
 
-    it("emits text_attribution as broadcast", async () => {
+    it("emits text_attribution as broadcast", () => {
       const attributions = [
         { cell_id: "c1", index: 0, text: "hi", deleted: 0, actors: ["a"] },
       ];
@@ -202,40 +266,48 @@ describe("SyncEngine", () => {
         syncAppliedEvent({ changed: true, attributions }),
       ]);
 
+      const engine = createEngine();
       engine.start();
 
-      const received = firstValueFrom(engine.broadcasts$);
+      const received: unknown[] = [];
+      engine.broadcasts$.subscribe((p) => received.push(p));
+
       transport.deliver(Array.from([0x00, 1]));
-      const payload = await received;
-      expect(payload).toEqual({
+      expect(received).toHaveLength(1);
+      expect(received[0]).toEqual({
         type: "text_attribution",
         attributions,
       });
+      engine.stop();
     });
   });
 
   // ── Presence ──────────────────────────────────────────────────
 
   describe("presence", () => {
-    it("emits presence payloads on presence$", async () => {
+    it("emits presence payloads on presence$", () => {
       const presencePayload = { type: "update", peer: "alice", cursor: {} };
       (handle.receive_frame as ReturnType<typeof vi.fn>).mockReturnValue([
         presenceEvent(presencePayload),
       ]);
 
+      const engine = createEngine();
       engine.start();
 
-      const received = firstValueFrom(engine.presence$);
+      const received: unknown[] = [];
+      engine.presence$.subscribe((p) => received.push(p));
+
       transport.deliver(Array.from([0x04, 1]));
-      const payload = await received;
-      expect(payload).toEqual(presencePayload);
+      expect(received).toHaveLength(1);
+      expect(received[0]).toEqual(presencePayload);
+      engine.stop();
     });
   });
 
   // ── Cell changes (coalescing) ─────────────────────────────────
 
   describe("cellChanges$", () => {
-    it("emits coalesced changesets after initial sync", async () => {
+    it("emits coalesced changesets after initial sync", () => {
       let callCount = 0;
       (handle.receive_frame as ReturnType<typeof vi.fn>).mockImplementation(() => {
         callCount++;
@@ -257,28 +329,31 @@ describe("SyncEngine", () => {
         ];
       });
 
+      const engine = createEngine();
       engine.start();
 
       // Complete initial sync
       transport.deliver(Array.from([0x00, 1]));
-      await vi.advanceTimersByTimeAsync(0);
 
       // Subscribe to cell changes
-      const changePromise = firstValueFrom(engine.cellChanges$);
+      const emissions: (CellChangeset | null)[] = [];
+      engine.cellChanges$.subscribe((cs) => emissions.push(cs));
 
       // Send steady-state frame
       transport.deliver(Array.from([0x00, 2]));
 
       // Advance past coalescing window (32ms)
-      await vi.advanceTimersByTimeAsync(50);
+      advanceBy(scheduler, 50);
 
-      const changeset = await changePromise;
+      expect(emissions).toHaveLength(1);
+      const changeset = emissions[0];
       expect(changeset).not.toBeNull();
       expect(changeset!.changed[0].cell_id).toBe("c1");
       expect(changeset!.changed[0].fields.source).toBe(true);
+      engine.stop();
     });
 
-    it("emits null changeset when WASM has no changeset", async () => {
+    it("emits null changeset when WASM has no changeset", () => {
       let callCount = 0;
       (handle.receive_frame as ReturnType<typeof vi.fn>).mockImplementation(() => {
         callCount++;
@@ -288,25 +363,28 @@ describe("SyncEngine", () => {
         return [syncAppliedEvent({ changed: true })]; // no changeset
       });
 
+      const engine = createEngine();
       engine.start();
 
       // Complete initial sync
       transport.deliver(Array.from([0x00, 1]));
-      await vi.advanceTimersByTimeAsync(0);
 
-      const changePromise = firstValueFrom(engine.cellChanges$);
+      const emissions: (CellChangeset | null)[] = [];
+      engine.cellChanges$.subscribe((cs) => emissions.push(cs));
+
       transport.deliver(Array.from([0x00, 2]));
-      await vi.advanceTimersByTimeAsync(50);
+      advanceBy(scheduler, 50);
 
-      const changeset = await changePromise;
-      expect(changeset).toBeNull();
+      expect(emissions).toHaveLength(1);
+      expect(emissions[0]).toBeNull();
+      engine.stop();
     });
   });
 
   // ── Runtime state ─────────────────────────────────────────────
 
   describe("runtimeState$", () => {
-    it("emits runtime state on state sync", async () => {
+    it("emits runtime state on state sync", () => {
       const state: RuntimeState = {
         kernel: {
           status: "busy",
@@ -332,20 +410,25 @@ describe("SyncEngine", () => {
         runtimeStateSyncEvent(state),
       ]);
 
+      const engine = createEngine();
       engine.start();
 
-      const received = firstValueFrom(engine.runtimeState$);
+      const received: RuntimeState[] = [];
+      engine.runtimeState$.subscribe((s) => received.push(s));
+
       transport.deliver(Array.from([0x05, 1]));
-      const result = await received;
-      expect(result.kernel.status).toBe("busy");
-      expect(result.kernel.name).toBe("python3");
+
+      expect(received).toHaveLength(1);
+      expect(received[0].kernel.status).toBe("busy");
+      expect(received[0].kernel.name).toBe("python3");
+      engine.stop();
     });
   });
 
   // ── Execution transitions ─────────────────────────────────────
 
   describe("executionTransitions$", () => {
-    it("detects started transition", async () => {
+    it("detects started transition", () => {
       const state: RuntimeState = {
         kernel: {
           status: "busy",
@@ -378,15 +461,20 @@ describe("SyncEngine", () => {
         runtimeStateSyncEvent(state),
       ]);
 
+      const engine = createEngine();
       engine.start();
 
-      const received = firstValueFrom(engine.executionTransitions$);
+      const received: import("../src/runtime-state").ExecutionTransition[][] = [];
+      engine.executionTransitions$.subscribe((t) => received.push(t));
+
       transport.deliver(Array.from([0x05, 1]));
-      const transitions = await received;
-      expect(transitions).toHaveLength(1);
-      expect(transitions[0].kind).toBe("started");
-      expect(transitions[0].cell_id).toBe("c1");
-      expect(transitions[0].execution_id).toBe("exec-1");
+
+      expect(received).toHaveLength(1);
+      expect(received[0]).toHaveLength(1);
+      expect(received[0][0].kind).toBe("started");
+      expect(received[0][0].cell_id).toBe("c1");
+      expect(received[0][0].execution_id).toBe("exec-1");
+      engine.stop();
     });
   });
 
@@ -399,6 +487,7 @@ describe("SyncEngine", () => {
         syncAppliedEvent({ changed: true, reply }),
       ]);
 
+      const engine = createEngine();
       engine.start();
       transport.deliver(Array.from([0x00, 1]));
 
@@ -407,6 +496,7 @@ describe("SyncEngine", () => {
         (f) => f.frameType === FrameType.AUTOMERGE_SYNC,
       );
       expect(syncFrames.length).toBeGreaterThanOrEqual(1);
+      engine.stop();
     });
 
     it("rolls back sync state on send failure", async () => {
@@ -416,13 +506,15 @@ describe("SyncEngine", () => {
       ]);
 
       transport.simulateFailure = true;
+      const engine = createEngine();
       engine.start();
       transport.deliver(Array.from([0x00, 1]));
 
       // Let the promise rejection propagate
-      await vi.advanceTimersByTimeAsync(0);
+      await Promise.resolve();
 
       expect(handle.cancel_last_flush).toHaveBeenCalled();
+      engine.stop();
     });
   });
 
@@ -433,6 +525,7 @@ describe("SyncEngine", () => {
       const syncMsg = new Uint8Array([1, 2, 3]);
       (handle.flush_local_changes as ReturnType<typeof vi.fn>).mockReturnValue(syncMsg);
 
+      const engine = createEngine();
       engine.start();
       engine.flush();
 
@@ -441,12 +534,14 @@ describe("SyncEngine", () => {
       );
       expect(syncFrames).toHaveLength(1);
       expect(syncFrames[0].payload).toEqual(syncMsg);
+      engine.stop();
     });
 
     it("flush() also sends RuntimeStateDoc sync", () => {
       const stateMsg = new Uint8Array([4, 5, 6]);
       (handle.flush_runtime_state_sync as ReturnType<typeof vi.fn>).mockReturnValue(stateMsg);
 
+      const engine = createEngine();
       engine.start();
       engine.flush();
 
@@ -455,6 +550,7 @@ describe("SyncEngine", () => {
       );
       expect(stateFrames).toHaveLength(1);
       expect(stateFrames[0].payload).toEqual(stateMsg);
+      engine.stop();
     });
 
     it("flush() rolls back on transport failure", async () => {
@@ -462,17 +558,20 @@ describe("SyncEngine", () => {
       (handle.flush_local_changes as ReturnType<typeof vi.fn>).mockReturnValue(syncMsg);
 
       transport.simulateFailure = true;
+      const engine = createEngine();
       engine.start();
       engine.flush();
 
-      await vi.advanceTimersByTimeAsync(0);
+      await Promise.resolve();
       expect(handle.cancel_last_flush).toHaveBeenCalled();
+      engine.stop();
     });
 
-    it("scheduleFlush() debounces at 20ms", async () => {
+    it("scheduleFlush() debounces at 20ms", () => {
       const syncMsg = new Uint8Array([1]);
       (handle.flush_local_changes as ReturnType<typeof vi.fn>).mockReturnValue(syncMsg);
 
+      const engine = createEngine();
       engine.start();
       engine.scheduleFlush();
       engine.scheduleFlush();
@@ -482,13 +581,14 @@ describe("SyncEngine", () => {
       expect(transport.sentFrames).toHaveLength(0);
 
       // Advance past debounce (20ms)
-      await vi.advanceTimersByTimeAsync(25);
+      advanceBy(scheduler, 25);
 
       // Should have flushed exactly once
       const syncFrames = transport.sentFrames.filter(
         (f) => f.frameType === FrameType.AUTOMERGE_SYNC,
       );
       expect(syncFrames).toHaveLength(1);
+      engine.stop();
     });
   });
 
@@ -499,22 +599,25 @@ describe("SyncEngine", () => {
       const syncMsg = new Uint8Array([7, 8, 9]);
       (handle.flush_local_changes as ReturnType<typeof vi.fn>).mockReturnValue(syncMsg);
 
+      const engine = createEngine();
       engine.start();
       engine.resetAndResync();
 
       expect(handle.reset_sync_state).toHaveBeenCalled();
       expect(transport.sentFrames.length).toBeGreaterThanOrEqual(1);
+      engine.stop();
     });
   });
 
   // ── resetForBootstrap ─────────────────────────────────────────
 
   describe("resetForBootstrap", () => {
-    it("emits initialSyncComplete$ again after resetForBootstrap + changed:true", async () => {
+    it("emits initialSyncComplete$ again after resetForBootstrap + changed:true", () => {
       (handle.receive_frame as ReturnType<typeof vi.fn>).mockReturnValue([
         syncAppliedEvent({ changed: true }),
       ]);
 
+      const engine = createEngine();
       engine.start();
 
       // Track all emissions
@@ -525,7 +628,6 @@ describe("SyncEngine", () => {
 
       // Complete first initial sync
       transport.deliver(Array.from([0x00, 1]));
-      await vi.advanceTimersByTimeAsync(0);
       expect(emitCount).toBe(1);
 
       // Simulate daemon:ready — reset for a new bootstrap cycle
@@ -533,11 +635,11 @@ describe("SyncEngine", () => {
 
       // Second initial sync should emit again
       transport.deliver(Array.from([0x00, 2]));
-      await vi.advanceTimersByTimeAsync(0);
       expect(emitCount).toBe(2);
+      engine.stop();
     });
 
-    it("does not emit cellChanges$ during initial sync phase", async () => {
+    it("does not emit cellChanges$ during initial sync phase", () => {
       let callCount = 0;
       (handle.receive_frame as ReturnType<typeof vi.fn>).mockImplementation(() => {
         callCount++;
@@ -554,6 +656,7 @@ describe("SyncEngine", () => {
         ];
       });
 
+      const engine = createEngine();
       engine.start();
 
       let cellChangeCount = 0;
@@ -563,12 +666,12 @@ describe("SyncEngine", () => {
 
       // First frame completes initial sync — should NOT go to cellChanges$
       transport.deliver(Array.from([0x00, 1]));
-      await vi.advanceTimersByTimeAsync(50);
+      advanceBy(scheduler, 50);
       expect(cellChangeCount).toBe(0);
 
       // After initial sync, steady-state frames go to cellChanges$
       transport.deliver(Array.from([0x00, 2]));
-      await vi.advanceTimersByTimeAsync(50);
+      advanceBy(scheduler, 50);
       expect(cellChangeCount).toBe(1);
 
       // Reset for bootstrap — back to initial sync phase
@@ -576,8 +679,9 @@ describe("SyncEngine", () => {
 
       // This frame should NOT go to cellChanges$ (awaiting initial sync)
       transport.deliver(Array.from([0x00, 3]));
-      await vi.advanceTimersByTimeAsync(50);
+      advanceBy(scheduler, 50);
       expect(cellChangeCount).toBe(1); // unchanged
+      engine.stop();
     });
   });
 
@@ -588,6 +692,7 @@ describe("SyncEngine", () => {
       const nullEngine = new SyncEngine({
         getHandle: () => null,
         transport,
+        scheduler,
       });
 
       nullEngine.start();
@@ -596,6 +701,265 @@ describe("SyncEngine", () => {
       nullEngine.scheduleFlush();
       nullEngine.resetAndResync();
       nullEngine.stop();
+    });
+  });
+
+  // ── Execution lifecycle changesets ─────────────────────────────
+
+  describe("execution lifecycle changesets", () => {
+    // Registry to map frame bytes → FrameEvents for runtime state frames
+    let runtimeStateFrameRegistry: Map<string, FrameEvent[]>;
+    let runtimeStateFrameCounter: number;
+
+    beforeEach(() => {
+      runtimeStateFrameRegistry = new Map();
+      runtimeStateFrameCounter = 0;
+    });
+
+    function deliverRuntimeState(state: RuntimeState): void {
+      runtimeStateFrameCounter++;
+      const frameBytes = [0x05, runtimeStateFrameCounter];
+      const key = Array.from(frameBytes).join(",");
+      runtimeStateFrameRegistry.set(key, [runtimeStateSyncEvent(state)]);
+      transport.deliver(frameBytes);
+    }
+
+    /**
+     * Helper: complete initial sync so the engine enters steady state.
+     * Sets up handle.receive_frame to route runtime state frames via the registry,
+     * and automerge sync frames through the standard initial sync path.
+     */
+    function setupWithInitialSync(): SyncEngine {
+      let callCount = 0;
+      (handle.receive_frame as ReturnType<typeof vi.fn>).mockImplementation(
+        (bytes: Uint8Array) => {
+          // Route based on frame type byte
+          const frameType = bytes[0];
+
+          if (frameType === 0x05) {
+            // Runtime state sync frame — look up from registry
+            const key = Array.from(bytes).join(",");
+            const events = runtimeStateFrameRegistry.get(key);
+            if (events) return events;
+            return [];
+          }
+
+          // Automerge sync frame
+          callCount++;
+          if (callCount === 1) {
+            return [syncAppliedEvent({ changed: true })];
+          }
+          return [syncAppliedEvent({ changed: true })];
+        },
+      );
+
+      const engine = createEngine();
+      engine.start();
+
+      // Complete initial sync
+      transport.deliver(Array.from([0x00, 1]));
+
+      return engine;
+    }
+
+    it("started transition injects clear changeset into cellChanges$", () => {
+      const engine = setupWithInitialSync();
+
+      const emissions: (CellChangeset | null)[] = [];
+      engine.cellChanges$.subscribe((cs) => emissions.push(cs));
+
+      // Deliver runtime state with a new "running" execution
+      deliverRuntimeState(
+        makeRuntimeState({
+          e1: { cell_id: "c1", status: "running", execution_count: 1, success: null },
+        }),
+      );
+
+      // Flush scheduler past coalescing window
+      advanceBy(scheduler, 50);
+
+      expect(emissions).toHaveLength(1);
+      expect(emissions[0]).not.toBeNull();
+      const cs = emissions[0]!;
+      expect(cs.changed).toHaveLength(1);
+      expect(cs.changed[0].cell_id).toBe("c1");
+      expect(cs.changed[0].fields.outputs).toBe(true);
+      expect(cs.changed[0].fields.execution_count).toBe(true);
+      engine.stop();
+    });
+
+    it("done transition injects reconciliation changeset", () => {
+      const engine = setupWithInitialSync();
+
+      // Deliver "running" first to establish prev state
+      deliverRuntimeState(
+        makeRuntimeState({
+          e1: { cell_id: "c1", status: "running", execution_count: 1, success: null },
+        }),
+      );
+
+      // Flush past coalescing to clear the "started" emission
+      advanceBy(scheduler, 50);
+
+      const emissions: (CellChangeset | null)[] = [];
+      engine.cellChanges$.subscribe((cs) => emissions.push(cs));
+
+      // Now deliver "done"
+      deliverRuntimeState(
+        makeRuntimeState({
+          e1: { cell_id: "c1", status: "done", execution_count: 1, success: true },
+        }),
+      );
+
+      advanceBy(scheduler, 50);
+
+      expect(emissions).toHaveLength(1);
+      expect(emissions[0]).not.toBeNull();
+      const cs = emissions[0]!;
+      expect(cs.changed).toHaveLength(1);
+      expect(cs.changed[0].cell_id).toBe("c1");
+      expect(cs.changed[0].fields.outputs).toBe(true);
+      expect(cs.changed[0].fields.execution_count).toBe(true);
+      engine.stop();
+    });
+
+    it("error transition injects reconciliation changeset", () => {
+      const engine = setupWithInitialSync();
+
+      // Deliver "running" first to establish prev state
+      deliverRuntimeState(
+        makeRuntimeState({
+          e1: { cell_id: "c1", status: "running", execution_count: 1, success: null },
+        }),
+      );
+
+      // Flush past coalescing
+      advanceBy(scheduler, 50);
+
+      const emissions: (CellChangeset | null)[] = [];
+      engine.cellChanges$.subscribe((cs) => emissions.push(cs));
+
+      // Now deliver "error"
+      deliverRuntimeState(
+        makeRuntimeState({
+          e1: { cell_id: "c1", status: "error", execution_count: 1, success: false },
+        }),
+      );
+
+      advanceBy(scheduler, 50);
+
+      expect(emissions).toHaveLength(1);
+      expect(emissions[0]).not.toBeNull();
+      const cs = emissions[0]!;
+      expect(cs.changed).toHaveLength(1);
+      expect(cs.changed[0].cell_id).toBe("c1");
+      expect(cs.changed[0].fields.outputs).toBe(true);
+      expect(cs.changed[0].fields.execution_count).toBe(true);
+      engine.stop();
+    });
+
+    it("multiple transitions in one update coalesce into single emission", () => {
+      const engine = setupWithInitialSync();
+
+      // Set up prev state with e2 running
+      deliverRuntimeState(
+        makeRuntimeState({
+          e2: { cell_id: "c2", status: "running", execution_count: 1, success: null },
+        }),
+      );
+
+      // Flush past coalescing
+      advanceBy(scheduler, 50);
+
+      const emissions: (CellChangeset | null)[] = [];
+      engine.cellChanges$.subscribe((cs) => emissions.push(cs));
+
+      // Deliver update with e1 newly started and e2 done
+      deliverRuntimeState(
+        makeRuntimeState({
+          e1: { cell_id: "c1", status: "running", execution_count: 2, success: null },
+          e2: { cell_id: "c2", status: "done", execution_count: 1, success: true },
+        }),
+      );
+
+      advanceBy(scheduler, 50);
+
+      // Should get a single coalesced emission covering both cells
+      expect(emissions).toHaveLength(1);
+      expect(emissions[0]).not.toBeNull();
+      const cs = emissions[0]!;
+      expect(cs.changed).toHaveLength(2);
+      const cellIds = cs.changed.map((c) => c.cell_id).sort();
+      expect(cellIds).toEqual(["c1", "c2"]);
+      engine.stop();
+    });
+
+    it("unchanged runtime state does not inject changesets", () => {
+      const engine = setupWithInitialSync();
+
+      const state = makeRuntimeState({
+        e1: { cell_id: "c1", status: "running", execution_count: 1, success: null },
+      });
+
+      // Deliver state first time
+      deliverRuntimeState(state);
+
+      // Flush past coalescing to process the first emission
+      advanceBy(scheduler, 50);
+
+      const emissions: (CellChangeset | null)[] = [];
+      engine.cellChanges$.subscribe((cs) => emissions.push(cs));
+
+      // Deliver same state again — no transitions, no changeset
+      deliverRuntimeState(state);
+
+      advanceBy(scheduler, 50);
+
+      expect(emissions).toHaveLength(0);
+      engine.stop();
+    });
+
+    it("runtime state transitions flow through even before initial sync completes", () => {
+      // Set up handle that does NOT complete initial sync on automerge frames
+      (handle.receive_frame as ReturnType<typeof vi.fn>).mockImplementation(
+        (bytes: Uint8Array) => {
+          const frameType = bytes[0];
+
+          if (frameType === 0x05) {
+            const key = Array.from(bytes).join(",");
+            const events = runtimeStateFrameRegistry.get(key);
+            if (events) return events;
+            return [];
+          }
+
+          // Automerge sync — always changed:false (never completes initial sync)
+          return [syncAppliedEvent({ changed: false })];
+        },
+      );
+
+      const engine = createEngine();
+      engine.start();
+
+      // Deliver a sync frame that does NOT complete initial sync
+      transport.deliver(Array.from([0x00, 1]));
+
+      const cellEmissions: (CellChangeset | null)[] = [];
+      engine.cellChanges$.subscribe((cs) => cellEmissions.push(cs));
+
+      // Deliver runtime state with a transition — this should still inject into cellChanges$
+      deliverRuntimeState(
+        makeRuntimeState({
+          e1: { cell_id: "c1", status: "running", execution_count: 1, success: null },
+        }),
+      );
+
+      advanceBy(scheduler, 50);
+
+      // Runtime state lifecycle changesets are NOT gated by initial sync
+      expect(cellEmissions).toHaveLength(1);
+      expect(cellEmissions[0]).not.toBeNull();
+      expect(cellEmissions[0]!.changed[0].cell_id).toBe("c1");
+      engine.stop();
     });
   });
 });


### PR DESCRIPTION
## Summary

- Add three layers of regression tests for the execution lifecycle output clearing from #1201
- Migrate SyncEngine timing tests from `vi.useFakeTimers` to RxJS `VirtualTimeScheduler` for deterministic virtual time
- Add `scheduler` option to `SyncEngine` for testability — zero runtime behavior change (optional, defaults to async scheduler)

## Layer 1: SyncEngine unit tests (43 total, +6 new)

Migrated all timing-dependent tests to `VirtualTimeScheduler` and added:
- `"started"` transition injects clear changeset into `cellChanges$`
- `"done"` transition injects reconciliation changeset
- `"error"` transition injects reconciliation changeset
- Multiple transitions in one update coalesce into single emission
- Unchanged runtime state does not inject changesets
- Runtime state transitions flow through even before initial sync completes

## Layer 2: App-side materialization tests (20 total, +8 new)

Expanded `frame-pipeline.test.ts` with `materializeChangeset` tests:
- Clears cell when WASM returns empty outputs
- Restores final outputs from WASM via cache
- Preserves source when `fields.source` is false
- Restores error output on reconciliation
- Falls back to full materialization for null changeset / structural changes
- Resolves uncached manifest hashes via async blob fetch
- Returns early when handle is null

## Layer 3: Fixture E2E

New fixture `15-run-all-output-lifecycle.ipynb` + spec:
- Two cells with pre-existing stale outputs
- Cell 1 sleeps 2s (keeps cell 2 queued)
- Verifies Run All clears stale outputs, cell 2 stays blank while queued, both show new outputs

## Test plan

- [x] `npx vitest run` — 566 tests passing
- [x] `npx biome check` — clean
- [ ] CI: JS Tests & Benchmarks
- [ ] CI: E2E Run All Output Lifecycle (new fixture spec)