### PR TITLE
feat(claude): add Biome LSP plugin for JS/TS code intelligence

### DIFF
--- a/.claude/plugins/.claude-plugin/marketplace.json
+++ b/.claude/plugins/.claude-plugin/marketplace.json
@@ -1,0 +1,17 @@
+{
+  "name": "nteract-plugins",
+  "owner": {
+    "name": "nteract"
+  },
+  "metadata": {
+    "description": "Claude Code plugins for the nteract desktop project"
+  },
+  "plugins": [
+    {
+      "name": "biome-lsp",
+      "source": "./biome-lsp",
+      "description": "Biome language server for JavaScript/TypeScript code intelligence",
+      "version": "1.0.0"
+    }
+  ]
+}

--- a/.claude/plugins/biome-lsp/.claude-plugin/plugin.json
+++ b/.claude/plugins/biome-lsp/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "biome-lsp",
+  "description": "Biome language server for JavaScript/TypeScript code intelligence",
+  "version": "1.0.0"
+}

--- a/.claude/plugins/biome-lsp/.lsp.json
+++ b/.claude/plugins/biome-lsp/.lsp.json
@@ -1,0 +1,14 @@
+{
+  "biome": {
+    "command": "npx",
+    "args": ["@biomejs/biome", "lsp-proxy"],
+    "extensionToLanguage": {
+      ".js": "javascript",
+      ".jsx": "javascriptreact",
+      ".ts": "typescript",
+      ".tsx": "typescriptreact",
+      ".json": "json",
+      ".jsonc": "jsonc"
+    }
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,15 +1,13 @@
 {
-  "hooks": {
-    "SessionStart": [
-      {
-        "matcher": "startup",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR\"/scripts/linux_cloud_dev.sh"
-          }
-        ]
+  "enabledPlugins": {
+    "biome-lsp@nteract-plugins": true
+  },
+  "extraKnownMarketplaces": {
+    "nteract-plugins": {
+      "source": {
+        "source": "directory",
+        "path": "./.claude/plugins"
       }
-    ]
+    }
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -74,8 +74,9 @@ crates/notebook/fixtures/**/uv.lock
 !.claude/rules/**
 !.claude/skills/
 !.claude/skills/**
-# Keep settings local (not shared)
-.claude/settings.json
+!.claude/plugins/
+!.claude/plugins/**
+# Keep local settings private
 .claude/settings.local.json
 .claude/scheduled_tasks.lock
 


### PR DESCRIPTION
## Summary

- Adds a Biome LSP plugin so Claude Code gets real-time lint and format diagnostics for JS/TS files, using the project's existing `biome.json` configuration
- Creates an `nteract-plugins` marketplace in `.claude/plugins/` as the distribution mechanism
- Shares `.claude/settings.json` via version control with `extraKnownMarketplaces` and `enabledPlugins`, so the plugin is automatically available to all developers — no manual setup needed
- Removes the stale `SessionStart` cloud dev hook that was previously in settings

## Verification

- [ ] New Claude Code session picks up biome-lsp (check `/plugin` status)
- [ ] Biome diagnostics appear after editing a `.ts`/`.tsx` file with a lint issue

_PR submitted by @rgbkrk's agent, Quill_