### PR TITLE
fix(notebook): remove ClearOutputs IPC from execute paths

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -513,16 +513,8 @@ function AppContent() {
     }
     runAllInFlightRef.current = true;
     try {
-      const codeCells = getNotebookCellsSnapshot().filter(
-        (c) => c.cell_type === "code",
-      );
-
       // Flush pending source sync so daemon has latest code
       await flushSync();
-
-      // Clear all outputs via daemon before restarting so the user sees
-      // every cell go blank up front.
-      await Promise.all(codeCells.map((cell) => clearOutputs(cell.id)));
 
       // Shutdown existing kernel
       await shutdownKernel();
@@ -544,13 +536,7 @@ function AppContent() {
     } finally {
       runAllInFlightRef.current = false;
     }
-  }, [
-    clearOutputs,
-    flushSync,
-    shutdownKernel,
-    tryStartKernel,
-    daemonRunAllCells,
-  ]);
+  }, [flushSync, shutdownKernel, tryStartKernel, daemonRunAllCells]);
 
   // Handle trust approval from dialog
   const handleTrustApprove = useCallback(async () => {
@@ -592,9 +578,9 @@ function AppContent() {
       // Flush pending source sync so daemon has latest code before executing
       await flushSync();
 
-      // Tell daemon to clear outputs — the SyncEngine will clear the store
+      // No explicit ClearOutputs IPC needed — the daemon clears outputs
+      // on execute_input and the SyncEngine injects a clear changeset
       // when the RuntimeStateDoc reports execution started.
-      await clearOutputs(cellId);
 
       // Start kernel via daemon if not running, then queue cell.
       if (kernelStatus === KERNEL_STATUS.NOT_STARTED) {
@@ -610,7 +596,7 @@ function AppContent() {
         logger.warn("[App] handleExecuteCell: no kernel available");
       }
     },
-    [clearOutputs, flushSync, kernelStatus, tryStartKernel, executeCell],
+    [flushSync, kernelStatus, tryStartKernel, executeCell],
   );
 
   const handleAddCell = useCallback(
@@ -641,18 +627,8 @@ function AppContent() {
     }
     runAllInFlightRef.current = true;
     try {
-      // Daemon reads cells from synced Automerge doc
-      const codeCells = getNotebookCellsSnapshot().filter(
-        (c) => c.cell_type === "code",
-      );
-      if (codeCells.length === 0) return;
-
       // Flush pending source sync so daemon has latest code
       await flushSync();
-
-      // Clear all outputs via daemon before queueing so the user sees
-      // every cell go blank up front (not one-at-a-time as they start).
-      await Promise.all(codeCells.map((cell) => clearOutputs(cell.id)));
 
       // Start kernel via daemon if not running
       if (kernelStatus === KERNEL_STATUS.NOT_STARTED) {
@@ -673,13 +649,7 @@ function AppContent() {
     } finally {
       runAllInFlightRef.current = false;
     }
-  }, [
-    kernelStatus,
-    tryStartKernel,
-    clearOutputs,
-    flushSync,
-    daemonRunAllCells,
-  ]);
+  }, [kernelStatus, tryStartKernel, flushSync, daemonRunAllCells]);
 
   const handleRestartAndRunAll = useCallback(async () => {
     // Backend clears outputs and emits cells:outputs_cleared before queuing,

--- a/crates/runtimed-py/src/session_core.rs
+++ b/crates/runtimed-py/src/session_core.rs
@@ -1049,32 +1049,26 @@ pub(crate) async fn move_cell(
 }
 
 /// Clear a cell's outputs.
+///
+/// Writes directly to the Automerge document via DocHandle — no IPC
+/// round-trip through NotebookRequest. The daemon sees the cleared
+/// state via CRDT sync.
 pub(crate) async fn clear_outputs(state: &Arc<Mutex<SessionState>>, cell_id: &str) -> PyResult<()> {
-    let response = {
-        let st = state.lock().await;
-        let handle = st
-            .handle
-            .as_ref()
-            .ok_or_else(|| to_py_err("Not connected"))?;
+    let st = state.lock().await;
+    let handle = st
+        .handle
+        .as_ref()
+        .ok_or_else(|| to_py_err("Not connected"))?;
 
-        // clear_outputs still goes through send_request (daemon clears kernel state too)
-        handle
-            .send_request(NotebookRequest::ClearOutputs {
-                cell_id: cell_id.to_string(),
-            })
-            .await
-            .map_err(to_py_err)?
-    };
+    handle.clear_outputs(cell_id).map_err(to_py_err)?;
+    handle
+        .set_execution_count(cell_id, "null")
+        .map_err(to_py_err)?;
 
-    match response {
-        NotebookResponse::OutputsCleared { .. } => {
-            // Emit focus presence — cell-level operation on outputs, not source
-            emit_focus_presence(state, cell_id).await;
-            Ok(())
-        }
-        NotebookResponse::Error { error } => Err(to_py_err(error)),
-        other => Err(to_py_err(format!("Unexpected response: {:?}", other))),
-    }
+    // Emit focus presence — cell-level operation on outputs, not source
+    drop(st);
+    emit_focus_presence(state, cell_id).await;
+    Ok(())
 }
 
 // =========================================================================


### PR DESCRIPTION
## Summary

- Remove explicit `ClearOutputs` IPC round-trips from ctrl-enter, Run All, and Restart & Run All
- The daemon already clears outputs on `execute_input` (IOPub) and the SyncEngine injects synthetic changesets on execution "started" transitions — the IPC was redundant
- This eliminates the relay timeout bug where `Promise.all` sending `ClearOutputs` for N cells saturated the 32-slot relay command channel

## What was happening

Run All sends `Promise.all(codeCells.map(c => clearOutputs(c.id)))` — N concurrent `ClearOutputs` requests through the relay. The relay processes requests sequentially (blocking in `wait_for_response()`), and the 32-slot command channel fills up. Requests time out after 30s even though the daemon processes them fine.

## What changed

`ClearOutputs` IPC removed from all execute paths. The SyncEngine's execution lifecycle handles clearing per-cell as each starts. Menu "Clear Outputs" and "Clear All Outputs" still use the IPC (no execution to trigger the lifecycle).

**Net: +5/-35 lines.**

## Test plan

- [ ] Ctrl-enter → outputs clear on execute, appear on done
- [ ] Run All with 4+ cells → each cell clears as it starts executing
- [ ] Restart & Run All → same behavior after kernel restart
- [ ] Menu "Clear Outputs" → still works (uses IPC)
- [ ] Menu "Clear All Outputs" → still works (uses IPC)
- [ ] No relay timeouts in `notebook.log`

Relates to #1201