### PR TITLE
chore: bump version to 2.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3678,7 +3678,7 @@ dependencies = [
 
 [[package]]
 name = "notebook"
-version = "2.0.2"
+version = "2.0.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5889,7 +5889,7 @@ dependencies = [
 
 [[package]]
 name = "runt-cli"
-version = "2.0.2"
+version = "2.0.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5944,7 +5944,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed"
-version = "2.0.2"
+version = "2.0.3"
 dependencies = [
  "alacritty_terminal",
  "anyhow",

--- a/crates/notebook/Cargo.toml
+++ b/crates/notebook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notebook"
-version = "2.0.2"
+version = "2.0.3"
 edition.workspace = true
 description = "Tauri-based notebook UI for Jupyter kernels"
 repository.workspace = true

--- a/crates/notebook/tauri.conf.json
+++ b/crates/notebook/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "nteract",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "identifier": "org.nteract.desktop",
   "build": {
     "devUrl": "http://localhost:5174",

--- a/crates/runt/Cargo.toml
+++ b/crates/runt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runt-cli"
-version = "2.0.2"
+version = "2.0.3"
 edition.workspace = true
 description = "CLI for Jupyter Runtimes — bundled with nteract"
 repository.workspace = true

--- a/crates/runtimed/Cargo.toml
+++ b/crates/runtimed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed"
-version = "2.0.2"
+version = "2.0.3"
 edition.workspace = true
 description = "Central daemon for managing Jupyter runtimes and prewarmed environments"
 repository.workspace = true

--- a/python/nteract/pyproject.toml
+++ b/python/nteract/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nteract"
-version = "2.0.2"
+version = "2.0.3"
 description = "Bring AI to Jupyter notebooks. MCP server for Claude, ChatGPT, Gemini, OpenCode and any agent."
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/python/runtimed/pyproject.toml
+++ b/python/runtimed/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "runtimed"
-version = "2.0.2"
+version = "2.0.3"
 description = "Python toolkit for Jupyter runtimes, powered by runtimed Rust binaries"
 readme = "README.md"
 license = "BSD-3-Clause"


### PR DESCRIPTION
## Summary

Bump all artifact versions from 2.0.2 → 2.0.3.

## Files bumped

| File | Artifact |
|------|----------|
| `crates/runtimed/Cargo.toml` | Daemon |
| `crates/runt/Cargo.toml` | CLI |
| `crates/notebook/Cargo.toml` | Desktop app |
| `crates/notebook/tauri.conf.json` | Desktop app (Tauri) |
| `python/runtimed/pyproject.toml` | Python bindings |
| `python/nteract/pyproject.toml` | MCP server |
| `Cargo.lock` | Lock file |