### PR TITLE
fix(notebook): stop aggressive autofocus from stealing focus and causing scroll shifts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,4 +101,3 @@ uv.lock
 .direnv
 result
 .cargo
-test-focus-scroll.ipynb

--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,4 @@ uv.lock
 .direnv
 result
 .cargo
+test-focus-scroll.ipynb

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -377,6 +377,8 @@ function NotebookViewContent({
   onSetCellOutputsHidden,
 }: NotebookViewProps) {
   const containerRef = useRef<HTMLDivElement>(null);
+  // Track whether focus change was keyboard-driven (should scroll) or mouse-driven (already visible)
+  const focusSourceRef = useRef<"mouse" | "keyboard">("keyboard");
   const { focusCell } = useEditorRegistry();
 
   // Track full materializations for cross-cell derived state
@@ -513,6 +515,12 @@ function NotebookViewContent({
 
   useEffect(() => {
     if (!focusedCellId) return;
+    // Only scroll for keyboard-driven focus changes (arrows, shift-enter).
+    // Mouse clicks don't need scrolling — the cell is already visible.
+    if (focusSourceRef.current !== "keyboard") {
+      focusSourceRef.current = "keyboard"; // reset for next time
+      return;
+    }
     const cellEl = containerRef.current?.querySelector(
       `[data-cell-id="${CSS.escape(focusedCellId)}"]`,
     );
@@ -561,6 +569,7 @@ function NotebookViewContent({
         logger.debug(
           `[cell-nav] onFocusPrevious called: cell=${cell.id.slice(0, 8)} index=${index} cellIds=${cellIds.map((id) => id.slice(0, 8)).join(",")}`,
         );
+        focusSourceRef.current = "keyboard";
         let prevIndex = index - 1;
         while (prevIndex >= 0 && !isVisibleCell(cellIds[prevIndex])) {
           prevIndex--;
@@ -581,6 +590,7 @@ function NotebookViewContent({
         logger.debug(
           `[cell-nav] onFocusNext called: cell=${cell.id.slice(0, 8)} index=${index} cellIds=${cellIds.map((id) => id.slice(0, 8)).join(",")}`,
         );
+        focusSourceRef.current = "keyboard";
         let nextIndex = index + 1;
         while (
           nextIndex < cellIds.length &&
@@ -626,7 +636,10 @@ function NotebookViewContent({
                 ? (count: number) => onReportOutputMatchCount(cell.id, count)
                 : undefined
             }
-            onFocus={() => onFocusCell(cell.id)}
+            onFocus={() => {
+              focusSourceRef.current = "mouse";
+              onFocusCell(cell.id);
+            }}
             onExecute={() => onExecuteCell(cell.id)}
             onInterrupt={onInterruptKernel}
             onDelete={() => onDeleteCell(cell.id)}
@@ -681,7 +694,10 @@ function NotebookViewContent({
             isFocused={isFocused}
             isPreviousCellFromFocused={cell.id === previousCellId}
             searchQuery={searchQuery}
-            onFocus={() => onFocusCell(cell.id)}
+            onFocus={() => {
+              focusSourceRef.current = "mouse";
+              onFocusCell(cell.id);
+            }}
             onDelete={() => onDeleteCell(cell.id)}
             onFocusPrevious={onFocusPrevious}
             onFocusNext={onFocusNext}
@@ -701,7 +717,10 @@ function NotebookViewContent({
           isFocused={isFocused}
           isPreviousCellFromFocused={cell.id === previousCellId}
           searchQuery={searchQuery}
-          onFocus={() => onFocusCell(cell.id)}
+          onFocus={() => {
+            focusSourceRef.current = "mouse";
+            onFocusCell(cell.id);
+          }}
           onDelete={() => onDeleteCell(cell.id)}
           onFocusPrevious={onFocusPrevious}
           onFocusNext={onFocusNext}

--- a/src/components/cell/CellContainer.tsx
+++ b/src/components/cell/CellContainer.tsx
@@ -83,10 +83,12 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
           isDragging && "opacity-50",
           className,
         )}
-        onMouseDown={onFocus}
       >
         {/* Gutter area - action content only (ribbon moves to content rows for segmented) */}
-        <div className="flex w-10 flex-shrink-0 flex-col items-end justify-start gap-0.5 pr-1 pt-4 select-none">
+        <div
+          className="flex w-10 flex-shrink-0 flex-col items-end justify-start gap-0.5 pr-1 pt-4 select-none"
+          onMouseDown={onFocus}
+        >
           {gutterContent}
           {presenceIndicators}
         </div>
@@ -94,7 +96,7 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
         {useSegmentedRibbon ? (
           <div className="flex min-w-0 flex-1 flex-col">
             {/* Code row - ribbon + content + right gutter */}
-            <div className="flex">
+            <div className="flex" onMouseDown={onFocus}>
               <div
                 {...dragHandleProps}
                 className={cn(
@@ -120,9 +122,10 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
                 </div>
               )}
             </div>
-            {/* Output row - ribbon + content + right gutter */}
+            {/* Output row - ribbon + content + right gutter
+                onMouseDown sets visual focus (ribbon/bg) without stealing editor focus */}
             {hasOutput && (
-              <div className={cn("flex", hideOutput && "hidden")}>
+              <div className={cn("flex", hideOutput && "hidden")} onMouseDown={onFocus}>
                 <div
                   className={cn(
                     "w-1 transition-colors duration-150",
@@ -156,7 +159,7 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
         ) : (
           <>
             {/* Legacy layout - ribbon + content side by side */}
-            <div className="flex min-w-0 flex-1">
+            <div className="flex min-w-0 flex-1" onMouseDown={onFocus}>
               <div
                 {...dragHandleProps}
                 className={cn(

--- a/src/components/editor/codemirror-editor.tsx
+++ b/src/components/editor/codemirror-editor.tsx
@@ -272,13 +272,12 @@ export const CodeMirrorEditor = forwardRef<
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
-    // Focus when autoFocus becomes true after mount (e.g. notebook
-    // auto-seeds a cell then sets focusedCellId).
-    useEffect(() => {
-      if (autoFocus && viewRef.current && !viewRef.current.hasFocus) {
-        requestAnimationFrame(() => viewRef.current?.focus());
-      }
-    }, [autoFocus]);
+    // Editor focus is handled explicitly:
+    //  - On mount: autoFocus prop (above) focuses via requestAnimationFrame
+    //  - Keyboard nav: focusCell() from useEditorRegistry calls view.focus()
+    //  - Mouse clicks: native DOM focus on the editor element
+    // No post-mount autoFocus effect needed — it caused the editor to steal
+    // focus from outputs/iframes whenever isFocused toggled.
 
     // ── Dynamic reconfiguration via compartments ─────────────────────
 


### PR DESCRIPTION
## Summary

Clicking on plots/iframes in cell outputs caused the CodeMirror editor to steal focus, making interactive outputs unusable. Clicking into an already-visible editor also caused unwanted `scrollIntoView` viewport shifts. Both issues trace back to the autofocus behavior added for shift-enter handling.

## Changes

- **CellContainer**: Moved `onMouseDown` from the outer container to the gutter, code row, and output row individually. Output clicks now set visual focus (ribbon, background, opacity) without the editor grabbing keyboard focus.
- **codemirror-editor**: Removed the post-mount `autoFocus` `useEffect` that called `view.focus()` on every `isFocused` toggle. Keyboard navigation already uses `focusCell()` from the editor registry, and mouse clicks give native DOM focus — the effect was redundant and caused focus stealing.
- **NotebookView**: Gated `scrollIntoView` to keyboard-driven focus changes only (shift-enter, arrow keys) via a `focusSourceRef`. Mouse clicks skip scrolling since the clicked cell is already visible.

Related: #1212 tracks a follow-up for viewport pinning when output growth pushes the focused cell off-screen after shift-enter.

## Verification

- [ ] Click on a plot output — cell visually focuses (ribbon/bg/opacity) but editor does NOT steal focus
- [ ] Click on interactive HTML output (buttons, inputs) — interactions work without editor interference
- [ ] Click into a code editor — cell focuses, NO scroll shift
- [ ] Shift-Enter — executes cell and scrolls next cell into view
- [ ] Arrow keys past cell boundaries — scrolls next cell into view
- [ ] Click gutter (play button / execution count) — cell visually focuses
- [ ] New notebook auto-seeds first cell and focuses its editor

<!-- Add before/after screenshots or recordings here -->

_PR submitted by @rgbkrk's agent, Quill_