### PR TITLE
chore(frontend): update stale RxJS docs and add SyncEngine tests

### DIFF
--- a/.claude/rules/crdt-mutations.md
+++ b/.claude/rules/crdt-mutations.md
@@ -36,7 +36,7 @@ All persistent notebook state lives in the Automerge document. The React cell st
 User does something in the UI -> write to WASM CRDT handle -> sync to daemon -> materialization updates the store.
 
 ```
-User action -> WASM handle mutation -> sourceSync$ (debounced) -> daemon
+User action -> WASM handle mutation -> scheduleFlush() (debounced) -> daemon
                                      -> store update (instant feedback)
 ```
 

--- a/.claude/rules/frontend-architecture.md
+++ b/.claude/rules/frontend-architecture.md
@@ -114,7 +114,7 @@ The frontend has a single ingress point for daemon frames. All data flows throug
 
 ## Mutation Flow
 
-Cell mutations go through the WASM handle for instant response. Source edits are batched via `debouncedSyncToRelay` (20ms), with `flushSync()` before execute/save. Fast path for typing: `updateCellSource()` -> WASM `update_source()` -> `updateCellById()` (one cell, one subscriber) -> debounced sync.
+Cell mutations go through the WASM handle for instant response. Source edits are batched via `engine.scheduleFlush()` (20ms debounce), with `engine.flush()` before execute/save. Fast path for typing: `updateCellSource()` -> WASM `update_source()` -> `updateCellById()` (one cell, one subscriber) -> debounced sync.
 
 Execution requests go to the daemon via dedicated Tauri commands (`execute_cell_via_daemon`, etc.).
 

--- a/contributing/crdt-mutation-guide.md
+++ b/contributing/crdt-mutation-guide.md
@@ -29,7 +29,7 @@ All persistent notebook state lives in the Automerge document. The React cell st
 The user does something in the UI → write to the WASM CRDT handle → sync to daemon → materialization updates the store.
 
 ```
-User action → WASM handle mutation → sourceSync$ (debounced) → daemon
+User action → WASM handle mutation → scheduleFlush() (debounced) → daemon
                                    → store update (instant feedback)
 ```
 

--- a/contributing/frontend-architecture.md
+++ b/contributing/frontend-architecture.md
@@ -195,7 +195,7 @@ Security boundary for untrusted HTML/widget outputs. See [iframe-isolation.md](i
 
 ### Mutation flow
 
-Cell mutations (add, delete, edit) go through the WASM handle for instant response. Source edits are batched via `debouncedSyncToRelay` (20ms), with `flushSync()` before execute/save. The fast path for typing: `updateCellSource()` → WASM `update_source()` → `updateCellById()` (one cell, one subscriber) → debounced sync to daemon.
+Cell mutations (add, delete, edit) go through the WASM handle for instant response. Source edits are batched via `engine.scheduleFlush()` (20ms debounce), with `engine.flush()` before execute/save. The fast path for typing: `updateCellSource()` → WASM `update_source()` → `updateCellById()` (one cell, one subscriber) → debounced sync to daemon.
 
 Execution requests go to the daemon via dedicated Tauri commands (`execute_cell_via_daemon`, etc.).
 

--- a/contributing/protocol.md
+++ b/contributing/protocol.md
@@ -162,7 +162,7 @@ Both sides use the same Rust `automerge = "0.7"` crate, which guarantees schema 
 User types in cell
   → React calls WASM handle.update_source(cell_id, text)
   → WASM applies mutation locally (instant)
-  → debouncedSyncToRelay (20ms batch) → handle.generate_sync_message() → sync bytes
+  → engine.scheduleFlush() (20ms debounce) → flush_local_changes() → sync bytes
   → sendFrame(frame_types.AUTOMERGE_SYNC, msg) → raw binary via tauri::ipc::Request
   → Tauri send_frame dispatches by type → relay pipes to daemon socket
   → Daemon applies sync, updates canonical doc

--- a/packages/runtimed/tests/sync-engine.test.ts
+++ b/packages/runtimed/tests/sync-engine.test.ts
@@ -235,6 +235,37 @@ describe("SyncEngine", () => {
       expect(handle.reset_sync_state).toHaveBeenCalled();
       engine.stop();
     });
+
+    it("handshake round restarts the retry timer via switchMap", () => {
+      (handle.receive_frame as ReturnType<typeof vi.fn>).mockReturnValue([
+        syncAppliedEvent({ changed: false }),
+      ]);
+      (handle.flush_local_changes as ReturnType<typeof vi.fn>).mockReturnValue(
+        new Uint8Array([1, 2, 3]),
+      );
+
+      const engine = createEngine();
+      engine.start();
+
+      // First handshake round at t=0 — arms the 3s retry timer
+      transport.deliver(Array.from([0x00, 1]));
+
+      // Advance 2.5s — timer not yet fired
+      advanceBy(scheduler, 2500);
+      expect(handle.reset_sync_state).not.toHaveBeenCalled();
+
+      // Another handshake round restarts the 3s timer (switchMap)
+      transport.deliver(Array.from([0x00, 2]));
+
+      // Advance 2.5s more (5s total, but only 2.5s since last round)
+      advanceBy(scheduler, 2500);
+      expect(handle.reset_sync_state).not.toHaveBeenCalled();
+
+      // Advance 1s more (3.5s since last round — past 3s timeout)
+      advanceBy(scheduler, 1000);
+      expect(handle.reset_sync_state).toHaveBeenCalled();
+      engine.stop();
+    });
   });
 
   // ── Broadcasts ────────────────────────────────────────────────
@@ -375,6 +406,141 @@ describe("SyncEngine", () => {
       transport.deliver(Array.from([0x00, 2]));
       advanceBy(scheduler, 50);
 
+      expect(emissions).toHaveLength(1);
+      expect(emissions[0]).toBeNull();
+      engine.stop();
+    });
+
+    it("merges multiple frames within the 32ms coalescing window", () => {
+      let callCount = 0;
+      const changesets: CellChangeset[] = [
+        { changed: [{ cell_id: "c1", fields: { source: true } }], added: [], removed: [], order_changed: false },
+        { changed: [{ cell_id: "c2", fields: { outputs: true } }], added: [], removed: [], order_changed: false },
+        { changed: [{ cell_id: "c1", fields: { metadata: true } }], added: [], removed: [], order_changed: false },
+      ];
+
+      (handle.receive_frame as ReturnType<typeof vi.fn>).mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          return [syncAppliedEvent({ changed: true })]; // initial sync
+        }
+        // Return different changesets for each subsequent frame
+        return [syncAppliedEvent({ changed: true, changeset: changesets[callCount - 2] })];
+      });
+
+      const engine = createEngine();
+      engine.start();
+
+      // Complete initial sync
+      transport.deliver(Array.from([0x00, 1]));
+
+      const emissions: (CellChangeset | null)[] = [];
+      engine.cellChanges$.subscribe((cs) => emissions.push(cs));
+
+      // Send 3 frames within the 32ms window
+      transport.deliver(Array.from([0x00, 2]));
+      advanceBy(scheduler, 10);
+      transport.deliver(Array.from([0x00, 3]));
+      advanceBy(scheduler, 10);
+      transport.deliver(Array.from([0x00, 4]));
+
+      // Advance past coalescing window
+      advanceBy(scheduler, 50);
+
+      // Should get a single merged emission
+      expect(emissions).toHaveLength(1);
+      const cs = emissions[0]!;
+      expect(cs).not.toBeNull();
+
+      // c1 should have source + metadata merged, c2 should have outputs
+      const c1 = cs.changed.find((c) => c.cell_id === "c1");
+      const c2 = cs.changed.find((c) => c.cell_id === "c2");
+      expect(c1).toBeDefined();
+      expect(c1!.fields.source).toBe(true);
+      expect(c1!.fields.metadata).toBe(true);
+      expect(c2).toBeDefined();
+      expect(c2!.fields.outputs).toBe(true);
+      engine.stop();
+    });
+
+    it("emits separately for frames in different coalescing windows", () => {
+      let callCount = 0;
+      (handle.receive_frame as ReturnType<typeof vi.fn>).mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          return [syncAppliedEvent({ changed: true })]; // initial sync
+        }
+        return [
+          syncAppliedEvent({
+            changed: true,
+            changeset: {
+              changed: [{ cell_id: `c${callCount}`, fields: { source: true } }],
+              added: [],
+              removed: [],
+              order_changed: false,
+            },
+          }),
+        ];
+      });
+
+      const engine = createEngine();
+      engine.start();
+      transport.deliver(Array.from([0x00, 1])); // initial sync
+
+      const emissions: (CellChangeset | null)[] = [];
+      engine.cellChanges$.subscribe((cs) => emissions.push(cs));
+
+      // First frame + flush its coalescing window
+      transport.deliver(Array.from([0x00, 2]));
+      advanceBy(scheduler, 50);
+      expect(emissions).toHaveLength(1);
+
+      // Second frame in a new coalescing window
+      transport.deliver(Array.from([0x00, 3]));
+      advanceBy(scheduler, 50);
+      expect(emissions).toHaveLength(2);
+
+      engine.stop();
+    });
+
+    it("mixed null and valid changeset in same window forces full materialization", () => {
+      let callCount = 0;
+      (handle.receive_frame as ReturnType<typeof vi.fn>).mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          return [syncAppliedEvent({ changed: true })]; // initial sync
+        }
+        if (callCount === 2) {
+          // Valid changeset
+          return [
+            syncAppliedEvent({
+              changed: true,
+              changeset: {
+                changed: [{ cell_id: "c1", fields: { source: true } }],
+                added: [],
+                removed: [],
+                order_changed: false,
+              },
+            }),
+          ];
+        }
+        // No changeset (null) — forces full materialization
+        return [syncAppliedEvent({ changed: true })];
+      });
+
+      const engine = createEngine();
+      engine.start();
+      transport.deliver(Array.from([0x00, 1])); // initial sync
+
+      const emissions: (CellChangeset | null)[] = [];
+      engine.cellChanges$.subscribe((cs) => emissions.push(cs));
+
+      // Send valid changeset and null changeset within same window
+      transport.deliver(Array.from([0x00, 2]));
+      transport.deliver(Array.from([0x00, 3]));
+      advanceBy(scheduler, 50);
+
+      // Should emit null (full materialization needed)
       expect(emissions).toHaveLength(1);
       expect(emissions[0]).toBeNull();
       engine.stop();
@@ -590,6 +756,37 @@ describe("SyncEngine", () => {
       expect(syncFrames).toHaveLength(1);
       engine.stop();
     });
+
+    it("scheduleFlush() resets debounce timer on each call", () => {
+      const syncMsg = new Uint8Array([1]);
+      (handle.flush_local_changes as ReturnType<typeof vi.fn>).mockReturnValue(syncMsg);
+
+      const engine = createEngine();
+      engine.start();
+
+      // First call at t=0
+      engine.scheduleFlush();
+
+      // Advance 15ms (not yet past 20ms debounce)
+      advanceBy(scheduler, 15);
+      expect(transport.sentFrames).toHaveLength(0);
+
+      // Second call resets the timer at t=15
+      engine.scheduleFlush();
+
+      // Advance 15ms more (t=30, but only 15ms since last call)
+      advanceBy(scheduler, 15);
+      expect(transport.sentFrames).toHaveLength(0);
+
+      // Advance 10ms more (t=40, 25ms since last call — past 20ms debounce)
+      advanceBy(scheduler, 10);
+
+      const syncFrames = transport.sentFrames.filter(
+        (f) => f.frameType === FrameType.AUTOMERGE_SYNC,
+      );
+      expect(syncFrames).toHaveLength(1);
+      engine.stop();
+    });
   });
 
   // ── resetAndResync ────────────────────────────────────────────
@@ -701,6 +898,90 @@ describe("SyncEngine", () => {
       nullEngine.scheduleFlush();
       nullEngine.resetAndResync();
       nullEngine.stop();
+    });
+
+    it("handle becomes null mid-pipeline after initial sync", () => {
+      let returnHandle: SyncableHandle | null = handle;
+
+      (handle.receive_frame as ReturnType<typeof vi.fn>).mockReturnValue([
+        syncAppliedEvent({ changed: true }),
+      ]);
+
+      const engine = new SyncEngine({
+        getHandle: () => returnHandle,
+        transport,
+        scheduler,
+      });
+      engine.start();
+
+      // Complete initial sync with valid handle
+      transport.deliver(Array.from([0x00, 1]));
+
+      // Now null out the handle
+      returnHandle = null;
+
+      // Deliver frame — should not crash
+      transport.deliver(Array.from([0x00, 2]));
+      advanceBy(scheduler, 50);
+
+      // Flush — should not crash or send frames
+      transport.clearSentFrames();
+      engine.flush();
+      expect(transport.sentFrames).toHaveLength(0);
+      engine.stop();
+    });
+  });
+
+  // ── Multicast (frameEvents$ share) ─────────────────────────────
+
+  describe("frameEvents$ multicast", () => {
+    it("delivers events to multiple subscribers via shared observable", () => {
+      const broadcastPayload = { event: "kernel_status", status: "idle" };
+      const presencePayload = { type: "update", peer: "alice" };
+
+      (handle.receive_frame as ReturnType<typeof vi.fn>).mockReturnValue([
+        broadcastEvent(broadcastPayload),
+        presenceEvent(presencePayload),
+      ]);
+
+      const engine = createEngine();
+      engine.start();
+
+      const broadcasts: unknown[] = [];
+      const presences: unknown[] = [];
+      engine.broadcasts$.subscribe((p) => broadcasts.push(p));
+      engine.presence$.subscribe((p) => presences.push(p));
+
+      // Single frame produces both event types
+      transport.deliver(Array.from([0x03, 1]));
+
+      expect(broadcasts).toHaveLength(1);
+      expect(broadcasts[0]).toEqual(broadcastPayload);
+      expect(presences).toHaveLength(1);
+      expect(presences[0]).toEqual(presencePayload);
+      engine.stop();
+    });
+  });
+
+  // ── Edge cases ─────────────────────────────────────────────────
+
+  describe("edge cases", () => {
+    it("frame delivered after stop() does not crash or emit", () => {
+      (handle.receive_frame as ReturnType<typeof vi.fn>).mockReturnValue([
+        broadcastEvent({ event: "test" }),
+      ]);
+
+      const engine = createEngine();
+      engine.start();
+
+      const received: unknown[] = [];
+      engine.broadcasts$.subscribe((p) => received.push(p));
+
+      // Stop and then deliver — should not crash
+      engine.stop();
+      transport.deliver(Array.from([0x03, 1]));
+
+      expect(received).toHaveLength(0);
     });
   });
 


### PR DESCRIPTION
## Summary

The RxJS pipeline cleanup from #1072 is largely complete — `sourceSync$` and `syncReply$` were removed in prior PRs, and all heavy stream logic is consolidated in `SyncEngine`. This PR fixes stale documentation that still referenced the old APIs and adds test coverage for under-tested RxJS behaviors.

Closes #1072

## Changes

**Doc fixes (5 files):** Replaced references to removed `sourceSync$` and `debouncedSyncToRelay` with current `scheduleFlush()` / `flush()` APIs in contributing guides and `.claude/rules/`.

**New SyncEngine tests (8 tests):**
- Coalescing: multiple frames within 32ms merge; separate windows emit separately; mixed null forces full materialization
- Debounce: `scheduleFlush()` timer resets on each call
- Retry: handshake round restarts 3s retry timer via switchMap
- Multicast: `frameEvents$` `share()` delivers to both `broadcasts$` and `presence$` subscribers
- Edge cases: frame after `stop()`; handle becomes null mid-pipeline

## Verification

- [ ] New tests pass in CI
- [ ] Lint passes in CI
- [ ] Doc references to `scheduleFlush()` / `flush()` are accurate with current `SyncEngine` API

_PR submitted by @rgbkrk's agent, Quill_