### PR TITLE
feat(outputs): label unknown text/* MIME types to distinguish from text/plain

### DIFF
--- a/src/components/outputs/__tests__/media-router.test.tsx
+++ b/src/components/outputs/__tests__/media-router.test.tsx
@@ -373,6 +373,32 @@ describe("MediaRouter component", () => {
     });
   });
 
+  describe("unknown text/* MIME types", () => {
+    it("renders unknown text/* type with a MIME type label", async () => {
+      render(
+        <MediaProvider>
+          <MediaRouter data={{ "text/snazzy": "hello from custom type" }} />
+        </MediaProvider>,
+      );
+      await waitFor(() => {
+        expect(screen.getByText("hello from custom type")).toBeInTheDocument();
+        expect(screen.getByText("text/snazzy")).toBeInTheDocument();
+      });
+    });
+
+    it("does NOT show a MIME type label for text/plain", async () => {
+      render(
+        <MediaProvider>
+          <MediaRouter data={{ "text/plain": "regular plain text" }} />
+        </MediaProvider>,
+      );
+      await waitFor(() => {
+        expect(screen.getByText("regular plain text")).toBeInTheDocument();
+      });
+      expect(screen.queryByText("text/plain")).not.toBeInTheDocument();
+    });
+  });
+
   describe("custom renderers", () => {
     it("uses custom renderer when provided", () => {
       render(

--- a/src/components/outputs/media-router.tsx
+++ b/src/components/outputs/media-router.tsx
@@ -368,6 +368,18 @@ export function MediaRouter({
       );
     }
 
+    // Unknown text/* types — render with a MIME type label for distinction
+    if (mimeType.startsWith("text/")) {
+      return (
+        <div>
+          <span className="inline-block mb-1 px-1.5 py-0.5 text-[10px] font-mono text-muted-foreground bg-muted rounded">
+            {mimeType}
+          </span>
+          <AnsiOutput className={className}>{String(content)}</AnsiOutput>
+        </div>
+      );
+    }
+
     // Fallback: render as plain text
     return <AnsiOutput className={className}>{String(content)}</AnsiOutput>;
   };

--- a/src/isolated-renderer/index.tsx
+++ b/src/isolated-renderer/index.tsx
@@ -284,6 +284,29 @@ function OutputRenderer({ payload }: { payload: RenderPayload }) {
     return <AnsiOutput>{String(content)}</AnsiOutput>;
   }
 
+  // Unknown text/* types — render with a MIME type label for distinction
+  if (mimeType.startsWith("text/")) {
+    return (
+      <div>
+        <span
+          style={{
+            display: "inline-block",
+            marginBottom: "4px",
+            padding: "1px 6px",
+            fontSize: "10px",
+            fontFamily: "monospace",
+            color: "var(--text-secondary)",
+            background: "var(--bg-secondary)",
+            borderRadius: "4px",
+          }}
+        >
+          {mimeType}
+        </span>
+        <AnsiOutput>{String(content)}</AnsiOutput>
+      </div>
+    );
+  }
+
   // Fallback: render as plain text
   return (
     <pre style={{ whiteSpace: "pre-wrap", wordWrap: "break-word" }}>


### PR DESCRIPTION
## Summary

Unknown `text/*` MIME types (e.g. `text/snazzy`) were rendered identically to `text/plain`, with no visual distinction. Now they display a small monospace MIME type badge above the content so users can identify the actual media type.

Changes in both the main DOM `MediaRouter` and the sandboxed iframe `OutputRenderer` to ensure consistent behavior across rendering paths.

Closes #863

## Verification

- [ ] Run `display({"text/snazzy": "hello from a custom type"}, raw=True)` — output shows a `text/snazzy` badge above the text
- [ ] Run `print("hello")` — `text/plain` output renders normally with **no** badge
- [ ] Verify the badge appears in both fresh notebooks and reopened sessions

<!-- Screenshots of the MIME badge rendering -->

_PR submitted by @rgbkrk's agent, Quill_