### PR TITLE
fix(runt): correct .ipynb association channel logic and integrate into diagnosis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5937,6 +5937,7 @@ dependencies = [
 name = "runt-workspace"
 version = "0.1.0"
 dependencies = [
+ "core-foundation",
  "dirs 5.0.1",
  "hex",
  "sha2 0.10.9",

--- a/crates/runt-workspace/Cargo.toml
+++ b/crates/runt-workspace/Cargo.toml
@@ -10,3 +10,6 @@ license.workspace = true
 dirs = "5"
 hex = "0.4"
 sha2 = "0.10"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+core-foundation = "0.10"

--- a/crates/runt-workspace/src/lib.rs
+++ b/crates/runt-workspace/src/lib.rs
@@ -153,6 +153,13 @@ pub fn bundle_identifier() -> &'static str {
     bundle_identifier_for(build_channel())
 }
 
+/// All valid nteract bundle identifiers (stable + nightly).
+///
+/// Either is acceptable as the default `.ipynb` handler — a source-built
+/// nightly `runt` should not warn about the stable app being the handler.
+pub const NTERACT_BUNDLE_IDENTIFIERS: &[&str] =
+    &["org.nteract.desktop", "org.nteract.desktop.nightly"];
+
 /// Legacy bundle identifiers that should no longer be the default `.ipynb` handler.
 pub const STALE_BUNDLE_IDENTIFIERS: &[&str] = &["com.runtimed.notebook"];
 
@@ -204,14 +211,20 @@ pub fn desktop_app_launch_candidates() -> &'static [&'static str] {
     desktop_app_launch_candidates_for(build_channel())
 }
 
-/// Find the installed `.app` bundle on macOS.
+/// Find the installed `.app` bundle on macOS for the current channel.
 ///
 /// Searches `/Applications/` and `~/Applications/` for known app name candidates.
 /// Returns the first match found.
 #[cfg(target_os = "macos")]
 pub fn find_installed_app_bundle() -> Option<PathBuf> {
+    find_installed_app_bundle_for(build_channel())
+}
+
+/// Find the installed `.app` bundle on macOS for a specific channel.
+#[cfg(target_os = "macos")]
+pub fn find_installed_app_bundle_for(channel: BuildChannel) -> Option<PathBuf> {
     let home_apps = dirs::home_dir().map(|h| h.join("Applications"));
-    for app_name in desktop_app_launch_candidates() {
+    for app_name in desktop_app_launch_candidates_for(channel) {
         let bundle_name = format!("{app_name}.app");
         let system = PathBuf::from("/Applications").join(&bundle_name);
         if system.exists() {
@@ -223,6 +236,29 @@ pub fn find_installed_app_bundle() -> Option<PathBuf> {
                 return Some(user);
             }
         }
+    }
+    None
+}
+
+/// Find any installed nteract app bundle and return its bundle identifier.
+///
+/// Tries the current channel first, then falls back to the other channel.
+/// This ensures a source-built nightly `runt` finds the stable app if that's
+/// what's installed.
+#[cfg(target_os = "macos")]
+pub fn find_any_installed_nteract_bundle() -> Option<(PathBuf, &'static str)> {
+    let current = build_channel();
+    let other = match current {
+        BuildChannel::Stable => BuildChannel::Nightly,
+        BuildChannel::Nightly => BuildChannel::Stable,
+    };
+    // Try current channel first
+    if let Some(path) = find_installed_app_bundle_for(current) {
+        return Some((path, bundle_identifier_for(current)));
+    }
+    // Fall back to other channel
+    if let Some(path) = find_installed_app_bundle_for(other) {
+        return Some((path, bundle_identifier_for(other)));
     }
     None
 }

--- a/crates/runt-workspace/src/lib.rs
+++ b/crates/runt-workspace/src/lib.rs
@@ -82,6 +82,13 @@ fn daemon_launchd_label_for(channel: BuildChannel) -> &'static str {
     }
 }
 
+fn bundle_identifier_for(channel: BuildChannel) -> &'static str {
+    match channel {
+        BuildChannel::Stable => "org.nteract.desktop",
+        BuildChannel::Nightly => "org.nteract.desktop.nightly",
+    }
+}
+
 fn cli_command_name_for(channel: BuildChannel) -> &'static str {
     match channel {
         BuildChannel::Stable => "runt",
@@ -141,6 +148,14 @@ pub fn cli_notebook_alias_name() -> &'static str {
     cli_notebook_alias_name_for(build_channel())
 }
 
+/// macOS bundle identifier for the desktop app.
+pub fn bundle_identifier() -> &'static str {
+    bundle_identifier_for(build_channel())
+}
+
+/// Legacy bundle identifiers that should no longer be the default `.ipynb` handler.
+pub const STALE_BUNDLE_IDENTIFIERS: &[&str] = &["com.runtimed.notebook"];
+
 /// Human-readable channel name for display.
 pub fn channel_display_name() -> &'static str {
     match build_channel() {
@@ -187,6 +202,29 @@ pub fn desktop_app_launch_candidates_for(channel: BuildChannel) -> &'static [&'s
 /// App names to try when launching the desktop notebook app.
 pub fn desktop_app_launch_candidates() -> &'static [&'static str] {
     desktop_app_launch_candidates_for(build_channel())
+}
+
+/// Find the installed `.app` bundle on macOS.
+///
+/// Searches `/Applications/` and `~/Applications/` for known app name candidates.
+/// Returns the first match found.
+#[cfg(target_os = "macos")]
+pub fn find_installed_app_bundle() -> Option<PathBuf> {
+    let home_apps = dirs::home_dir().map(|h| h.join("Applications"));
+    for app_name in desktop_app_launch_candidates() {
+        let bundle_name = format!("{app_name}.app");
+        let system = PathBuf::from("/Applications").join(&bundle_name);
+        if system.exists() {
+            return Some(system);
+        }
+        if let Some(ref home) = home_apps {
+            let user = home.join(&bundle_name);
+            if user.exists() {
+                return Some(user);
+            }
+        }
+    }
+    None
 }
 
 /// Launch the desktop notebook app for a specific channel.
@@ -303,6 +341,117 @@ fn open_notebook_installed_for(
         desktop_display_name_for(channel),
         detail
     ))
+}
+
+// ============================================================================
+// macOS Launch Services (File Associations)
+// ============================================================================
+
+#[cfg(target_os = "macos")]
+pub mod launch_services {
+    use core_foundation::base::TCFType;
+    use core_foundation::string::{CFString, CFStringRef};
+    use std::path::Path;
+    use std::process::Command;
+
+    type OSStatus = i32;
+    type LSRolesMask = u32;
+    #[allow(non_upper_case_globals)]
+    const kLSRolesAll: LSRolesMask = 0xFFFFFFFF;
+
+    #[link(name = "CoreServices", kind = "framework")]
+    extern "C" {
+        static kUTTagClassFilenameExtension: CFStringRef;
+        fn UTTypeCreatePreferredIdentifierForTag(
+            tag_class: CFStringRef,
+            tag: CFStringRef,
+            conforming_to: CFStringRef,
+        ) -> CFStringRef;
+        fn LSCopyDefaultRoleHandlerForContentType(
+            content_type: CFStringRef,
+            role: LSRolesMask,
+        ) -> CFStringRef;
+        fn LSSetDefaultRoleHandlerForContentType(
+            content_type: CFStringRef,
+            role: LSRolesMask,
+            handler_bundle_id: CFStringRef,
+        ) -> OSStatus;
+    }
+
+    /// Resolve the UTI for the `.ipynb` file extension.
+    fn ipynb_uti() -> Option<CFString> {
+        let ext = CFString::new("ipynb");
+        unsafe {
+            let uti = UTTypeCreatePreferredIdentifierForTag(
+                kUTTagClassFilenameExtension,
+                ext.as_concrete_TypeRef(),
+                std::ptr::null(),
+            );
+            if uti.is_null() {
+                return None;
+            }
+            Some(CFString::wrap_under_create_rule(uti))
+        }
+    }
+
+    /// Query the default handler bundle ID for `.ipynb` files.
+    ///
+    /// Returns the lowercase bundle identifier of the app registered as the
+    /// default handler, or `None` if no handler is set.
+    pub fn get_default_ipynb_handler() -> Option<String> {
+        let uti = ipynb_uti()?;
+        unsafe {
+            let handler =
+                LSCopyDefaultRoleHandlerForContentType(uti.as_concrete_TypeRef(), kLSRolesAll);
+            if handler.is_null() {
+                return None;
+            }
+            let cf = CFString::wrap_under_create_rule(handler);
+            Some(cf.to_string().to_lowercase())
+        }
+    }
+
+    /// Set the default handler for `.ipynb` files to the given bundle ID.
+    ///
+    /// Returns `Ok(())` on success, or `Err(status)` with the OSStatus error code.
+    pub fn set_default_ipynb_handler(bundle_id: &str) -> Result<(), i32> {
+        let uti = ipynb_uti().ok_or(-1)?;
+        let handler = CFString::new(bundle_id);
+        let status = unsafe {
+            LSSetDefaultRoleHandlerForContentType(
+                uti.as_concrete_TypeRef(),
+                kLSRolesAll,
+                handler.as_concrete_TypeRef(),
+            )
+        };
+        if status == 0 {
+            Ok(())
+        } else {
+            Err(status)
+        }
+    }
+
+    /// Path to the `lsregister` tool in CoreServices framework.
+    const LSREGISTER_PATH: &str = "/System/Library/Frameworks/CoreServices.framework/Versions/A/Frameworks/LaunchServices.framework/Versions/A/Support/lsregister";
+
+    /// Re-register an app bundle with Launch Services.
+    ///
+    /// This forces Launch Services to re-read the app's Info.plist and update
+    /// its knowledge of file type claims. Equivalent to `lsregister -f <path>`.
+    pub fn register_app_bundle(app_path: &Path) -> Result<(), String> {
+        let output = Command::new(LSREGISTER_PATH)
+            .args(["-f"])
+            .arg(app_path)
+            .output()
+            .map_err(|e| format!("Failed to run lsregister: {e}"))?;
+
+        if output.status.success() {
+            Ok(())
+        } else {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            Err(format!("lsregister failed: {}", stderr.trim()))
+        }
+    }
 }
 
 // ============================================================================
@@ -868,6 +1017,15 @@ mod tests {
         assert_eq!(
             daemon_launchd_label_for(BuildChannel::Nightly),
             "io.nteract.runtimed.nightly"
+        );
+
+        assert_eq!(
+            bundle_identifier_for(BuildChannel::Stable),
+            "org.nteract.desktop"
+        );
+        assert_eq!(
+            bundle_identifier_for(BuildChannel::Nightly),
+            "org.nteract.desktop.nightly"
         );
     }
 

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -2084,15 +2084,20 @@ async fn doctor_command(
         let conflicting_services: Option<CheckResult> = None;
 
         // Check 2e: On macOS, check .ipynb file association
+        // Accept any nteract bundle ID (stable or nightly) as OK — a source-built
+        // nightly runt should not warn about the stable app being the handler.
         #[cfg(target_os = "macos")]
         let file_association = {
-            let expected = runt_workspace::bundle_identifier();
             match runt_workspace::launch_services::get_default_ipynb_handler() {
-                Some(handler) if handler == expected => Some(CheckResult {
-                    path: ".ipynb handler".to_string(),
-                    status: "ok".to_string(),
-                    detail: Some(handler),
-                }),
+                Some(handler)
+                    if runt_workspace::NTERACT_BUNDLE_IDENTIFIERS.contains(&handler.as_str()) =>
+                {
+                    Some(CheckResult {
+                        path: ".ipynb handler".to_string(),
+                        status: "ok".to_string(),
+                        detail: Some(handler),
+                    })
+                }
                 Some(handler)
                     if runt_workspace::STALE_BUNDLE_IDENTIFIERS.contains(&handler.as_str()) =>
                 {
@@ -2261,10 +2266,16 @@ async fn doctor_command(
         let is_quarantined = false;
 
         let version_mismatch = version_match.status == "mismatch";
+        let file_assoc_issue = file_association
+            .as_ref()
+            .map(|c| c.status != "ok")
+            .unwrap_or(false);
 
         // Determine diagnosis
         let diagnosis = if daemon_running_result && version_mismatch {
             "Daemon is running but version mismatch detected. Run 'runt daemon doctor --fix' or restart the app.".to_string()
+        } else if daemon_running_result && file_assoc_issue {
+            "Daemon is healthy but .ipynb file association needs attention. Run 'runt daemon doctor --fix'.".to_string()
         } else if daemon_running_result {
             "Daemon is healthy and running.".to_string()
         } else if !binary_exists && !config_exists {
@@ -2362,11 +2373,11 @@ async fn doctor_command(
     let is_quarantined = false;
 
     // On macOS, check if .ipynb file association needs fixing
+    // Accept any nteract bundle ID (stable or nightly) as OK
     #[cfg(target_os = "macos")]
     let file_assoc_needs_fix = {
-        let expected = runt_workspace::bundle_identifier();
         runt_workspace::launch_services::get_default_ipynb_handler()
-            .map(|h| h != expected)
+            .map(|h| !runt_workspace::NTERACT_BUNDLE_IDENTIFIERS.contains(&h.as_str()))
             .unwrap_or(true) // No handler set → needs fix
     };
     #[cfg(not(target_os = "macos"))]
@@ -2468,22 +2479,27 @@ async fn doctor_command(
         }
 
         // Fix .ipynb file association (macOS only)
+        // Use whichever nteract app is actually installed, not the compile-time channel
         #[cfg(target_os = "macos")]
         if file_assoc_needs_fix {
-            let bundle_id = runt_workspace::bundle_identifier();
-            // Re-register app bundle with Launch Services if installed
-            if let Some(app_path) = runt_workspace::find_installed_app_bundle() {
+            if let Some((app_path, bundle_id)) = runt_workspace::find_any_installed_nteract_bundle()
+            {
+                // Re-register app bundle with Launch Services
                 if let Err(e) = runt_workspace::launch_services::register_app_bundle(&app_path) {
                     eprintln!("Warning: lsregister failed: {e}");
                 }
-            }
-            match runt_workspace::launch_services::set_default_ipynb_handler(bundle_id) {
-                Ok(()) => {
-                    actions_taken.push(format!("Set .ipynb file association to {}", bundle_id));
+                match runt_workspace::launch_services::set_default_ipynb_handler(bundle_id) {
+                    Ok(()) => {
+                        actions_taken.push(format!("Set .ipynb file association to {}", bundle_id));
+                    }
+                    Err(status) => {
+                        eprintln!("Failed to set .ipynb file association (OSStatus {status})");
+                    }
                 }
-                Err(status) => {
-                    eprintln!("Failed to set .ipynb file association (OSStatus {status})");
-                }
+            } else {
+                eprintln!(
+                    "No nteract app bundle found in /Applications or ~/Applications — cannot fix .ipynb association"
+                );
             }
         }
 
@@ -2713,13 +2729,23 @@ async fn doctor_command(
             .map(|c| c.status == "not_loaded" || c.status == "error")
             .unwrap_or(false);
         let version_mismatch = report.version_match.status == "mismatch";
-        let diagnosis_colored = if report.daemon_running.status == "ok" && !version_mismatch {
-            report.diagnosis.green()
-        } else if version_mismatch || report.daemon_state.status == "stale" || launchd_has_issue {
-            report.diagnosis.yellow()
-        } else {
-            report.diagnosis.red()
-        };
+        let file_assoc_issue = report
+            .file_association
+            .as_ref()
+            .map(|c| c.status != "ok")
+            .unwrap_or(false);
+        let diagnosis_colored =
+            if report.daemon_running.status == "ok" && !version_mismatch && !file_assoc_issue {
+                report.diagnosis.green()
+            } else if version_mismatch
+                || report.daemon_state.status == "stale"
+                || launchd_has_issue
+                || file_assoc_issue
+            {
+                report.diagnosis.yellow()
+            } else {
+                report.diagnosis.red()
+            };
         println!("{} {}", "Diagnosis:".bold(), diagnosis_colored);
 
         if !report.actions_taken.is_empty() {
@@ -2728,7 +2754,7 @@ async fn doctor_command(
             for action in &report.actions_taken {
                 println!("  {} {}", "✓".green(), action);
             }
-        } else if report.daemon_running.status != "ok" && !fix {
+        } else if (report.daemon_running.status != "ok" || file_assoc_issue) && !fix {
             println!();
             println!(
                 "{}",

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -1832,6 +1832,8 @@ async fn doctor_command(
         launchd_service: Option<CheckResult>, // macOS only: actual launchd registration state
         #[serde(skip_serializing_if = "Option::is_none")]
         conflicting_services: Option<CheckResult>, // macOS only: stale/conflicting daemon services
+        #[serde(skip_serializing_if = "Option::is_none")]
+        file_association: Option<CheckResult>, // macOS only: .ipynb default handler check
         socket_file: CheckResult,
         daemon_state: CheckResult,
         version_match: CheckResult,
@@ -2081,6 +2083,40 @@ async fn doctor_command(
         #[cfg(not(target_os = "macos"))]
         let conflicting_services: Option<CheckResult> = None;
 
+        // Check 2e: On macOS, check .ipynb file association
+        #[cfg(target_os = "macos")]
+        let file_association = {
+            let expected = runt_workspace::bundle_identifier();
+            match runt_workspace::launch_services::get_default_ipynb_handler() {
+                Some(handler) if handler == expected => Some(CheckResult {
+                    path: ".ipynb handler".to_string(),
+                    status: "ok".to_string(),
+                    detail: Some(handler),
+                }),
+                Some(handler)
+                    if runt_workspace::STALE_BUNDLE_IDENTIFIERS.contains(&handler.as_str()) =>
+                {
+                    Some(CheckResult {
+                        path: ".ipynb handler".to_string(),
+                        status: "stale".to_string(),
+                        detail: Some(format!("{} (legacy)", handler)),
+                    })
+                }
+                Some(handler) => Some(CheckResult {
+                    path: ".ipynb handler".to_string(),
+                    status: "warning".to_string(),
+                    detail: Some(handler),
+                }),
+                None => Some(CheckResult {
+                    path: ".ipynb handler".to_string(),
+                    status: "warning".to_string(),
+                    detail: Some("no default handler for .ipynb".to_string()),
+                }),
+            }
+        };
+        #[cfg(not(target_os = "macos"))]
+        let file_association: Option<CheckResult> = None;
+
         // Check 3: Socket file
         let socket_exists = socket_path.exists();
         let socket_file = CheckResult {
@@ -2262,6 +2298,7 @@ async fn doctor_command(
             plist_home_env,
             launchd_service,
             conflicting_services,
+            file_association,
             socket_file,
             daemon_state,
             version_match,
@@ -2323,6 +2360,18 @@ async fn doctor_command(
     #[cfg(not(target_os = "macos"))]
     #[allow(unused_variables)]
     let is_quarantined = false;
+
+    // On macOS, check if .ipynb file association needs fixing
+    #[cfg(target_os = "macos")]
+    let file_assoc_needs_fix = {
+        let expected = runt_workspace::bundle_identifier();
+        runt_workspace::launch_services::get_default_ipynb_handler()
+            .map(|h| h != expected)
+            .unwrap_or(true) // No handler set → needs fix
+    };
+    #[cfg(not(target_os = "macos"))]
+    #[allow(unused_variables)]
+    let file_assoc_needs_fix = false;
 
     // Check daemon state for fix operations
     let daemon_state_status = if let Some(info) = daemon_info {
@@ -2414,6 +2463,26 @@ async fn doctor_command(
                 }
                 Err(e) => {
                     eprintln!("Failed to reset launchd registration: {e}");
+                }
+            }
+        }
+
+        // Fix .ipynb file association (macOS only)
+        #[cfg(target_os = "macos")]
+        if file_assoc_needs_fix {
+            let bundle_id = runt_workspace::bundle_identifier();
+            // Re-register app bundle with Launch Services if installed
+            if let Some(app_path) = runt_workspace::find_installed_app_bundle() {
+                if let Err(e) = runt_workspace::launch_services::register_app_bundle(&app_path) {
+                    eprintln!("Warning: lsregister failed: {e}");
+                }
+            }
+            match runt_workspace::launch_services::set_default_ipynb_handler(bundle_id) {
+                Ok(()) => {
+                    actions_taken.push(format!("Set .ipynb file association to {}", bundle_id));
+                }
+                Err(status) => {
+                    eprintln!("Failed to set .ipynb file association (OSStatus {status})");
                 }
             }
         }
@@ -2580,6 +2649,18 @@ async fn doctor_command(
                     .detail
                     .as_ref()
                     .map(|d| format!(" {}", d).dimmed().to_string())
+                    .unwrap_or_default()
+            );
+        }
+        if let Some(ref file_assoc_check) = report.file_association {
+            println!(
+                "{:<20} {}{}",
+                "File association:".bold(),
+                colored_status_icon(&file_assoc_check.status),
+                file_assoc_check
+                    .detail
+                    .as_ref()
+                    .map(|d| format!(" ({})", d).dimmed().to_string())
                     .unwrap_or_default()
             );
         }


### PR DESCRIPTION
## Summary

- **Fixes channel mismatch**: The `.ipynb` file association check compared against the compile-time channel's bundle ID (`org.nteract.desktop.nightly` for source builds), causing false warnings when only the stable `nteract.app` was installed. Now accepts any nteract bundle ID (stable or nightly) as OK.
- **Fixes `--fix` targeting wrong bundle**: The fix handler used the compile-time bundle ID rather than the actually installed app. Added `find_any_installed_nteract_bundle()` that searches both channels and returns the bundle ID of whichever app is actually on disk.
- **Integrates into diagnosis**: File association status now feeds into the overall doctor diagnosis text, output coloring (yellow for issues), and the `--fix` suggestion hint. Previously a broken `.ipynb` handler still showed green "healthy".

Closes #1195

## Verification

- [ ] With only stable `nteract.app` installed, `runt doctor` from a source build shows the `.ipynb` handler as OK (not a false warning)
- [ ] With `.ipynb` pointed at a non-nteract app, `runt doctor` shows yellow diagnosis and suggests `--fix`
- [ ] `runt doctor --fix` with `.ipynb` misconfigured sets the handler to the installed app's bundle ID
- [ ] `runt doctor --fix` when no nteract app is installed prints a clear error instead of silently failing

_PR submitted by @rgbkrk's agent, Quill_