### PR TITLE
fix(runtimed): re-read metadata after hot-sync instead of using stale snapshot

### DIFF
--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -4052,28 +4052,30 @@ async fn handle_sync_environment(room: &NotebookRoom) -> NotebookResponse {
                     );
 
                     // Verify kernel wasn't swapped during async install (race protection).
-                    // Re-read metadata from the doc (NOT the stale pre-install snapshot)
-                    // so the kernel's launched config reflects any dependency edits the
-                    // user made while the install was running.
-                    let fresh_metadata =
-                        resolve_metadata_snapshot(room, Some(&notebook_path)).await;
+                    // Update launched deps to reflect what's actually installed:
+                    // the original baseline + what we just installed. We do NOT
+                    // re-read from the doc — the user may have edited deps during
+                    // the install, and those edits aren't installed yet. The next
+                    // check_and_broadcast_sync_state will detect the remaining drift.
                     let launch_id_matched = {
                         let mut kernel_guard = room.kernel.lock().await;
                         if let Some(ref mut kernel) = *kernel_guard {
-                            // Check launch_id still matches - if kernel was restarted, skip update
                             let current_launch_id = kernel.launched_config().launch_id.clone();
                             if current_launch_id != launch_id {
                                 warn!(
                                     "[notebook-sync] Kernel was swapped during hot-sync, skipping update"
                                 );
-                                // Still report success - packages were installed to the old env
-                                // User will see sync banner again for the new kernel
                                 false
                             } else {
-                                let metadata = fresh_metadata.as_ref().unwrap_or(&current_metadata);
-                                if let Some(ref uv) = metadata.runt.uv {
-                                    kernel.update_launched_uv_deps(uv.dependencies.clone());
+                                // Build the new baseline: what was launched + what we installed
+                                let mut installed_deps =
+                                    launched.uv_deps.clone().unwrap_or_default();
+                                for pkg in &packages_to_install {
+                                    if !installed_deps.contains(pkg) {
+                                        installed_deps.push(pkg.clone());
+                                    }
                                 }
+                                kernel.update_launched_uv_deps(installed_deps);
                                 true
                             }
                         } else {

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -4051,8 +4051,12 @@ async fn handle_sync_environment(room: &NotebookRoom) -> NotebookResponse {
                         packages_to_install
                     );
 
-                    // Verify kernel wasn't swapped during async install (race protection)
-                    // Update the kernel's launched config so future sync checks are accurate
+                    // Verify kernel wasn't swapped during async install (race protection).
+                    // Re-read metadata from the doc (NOT the stale pre-install snapshot)
+                    // so the kernel's launched config reflects any dependency edits the
+                    // user made while the install was running.
+                    let fresh_metadata =
+                        resolve_metadata_snapshot(room, Some(&notebook_path)).await;
                     let launch_id_matched = {
                         let mut kernel_guard = room.kernel.lock().await;
                         if let Some(ref mut kernel) = *kernel_guard {
@@ -4066,8 +4070,9 @@ async fn handle_sync_environment(room: &NotebookRoom) -> NotebookResponse {
                                 // User will see sync banner again for the new kernel
                                 false
                             } else {
-                                if let Some(ref current_uv) = current_metadata.runt.uv {
-                                    kernel.update_launched_uv_deps(current_uv.dependencies.clone());
+                                let metadata = fresh_metadata.as_ref().unwrap_or(&current_metadata);
+                                if let Some(ref uv) = metadata.runt.uv {
+                                    kernel.update_launched_uv_deps(uv.dependencies.clone());
                                 }
                                 true
                             }


### PR DESCRIPTION
## Summary

Closes #1220

`handle_sync_environment` reads notebook metadata, then calls `uv::sync_dependencies()` which can take **minutes** installing packages. After the install completes, it used the stale pre-install `current_metadata` to update the kernel's launched deps config via `update_launched_uv_deps`. If the user edited dependencies during the install, the kernel config would have incorrect data — either including packages that were never installed, or missing packages that were.

**Fix:** Compute the new baseline from `launched.uv_deps + packages_to_install` — exactly what's actually installed in the environment. No doc read needed. The next `check_and_broadcast_sync_state` compares this baseline against the current doc metadata and correctly detects any remaining drift (e.g., user added scipy while numpy was being installed).

### Why not fork+merge?

This function doesn't write to the notebook CRDT doc (`room.doc`) — it only reads from it. The writes go to:
- Kernel in-memory state (`update_launched_uv_deps`) — must reflect what's *installed*, not what the doc says
- RuntimeStateDoc (`state_doc.set_env_sync`) — simple boolean, no concurrent edit risk

### Why not re-read from the doc?

The kernel's launched config must reflect what's actually in the environment, not what the user currently wants. If the user adds `scipy` while `numpy` is installing, `scipy` isn't installed yet — recording it in launched deps would make `compute_env_sync_diff` think the env already has it, suppressing the next sync.

## Test plan

- [x] `cargo build` — compiles clean
- [x] `cargo xtask lint --fix` — all checks pass
- [x] `cargo test -p runtimed --lib` — 283 unit tests pass