### PR TITLE
fix(runtimed): adopt fork+merge for UpdateDisplayData IOPub path

### DIFF
--- a/crates/runtimed/src/kernel_manager.rs
+++ b/crates/runtimed/src/kernel_manager.rs
@@ -1229,31 +1229,40 @@ impl RoomKernel {
                             // Supports both manifest hashes and raw JSON (backward compatibility).
                             JupyterMessageContent::UpdateDisplayData(update) => {
                                 if let Some(ref display_id) = update.transient.display_id {
+                                    // Fork before async blob I/O to avoid holding the doc
+                                    // write lock during potentially slow blob store operations.
+                                    let mut fork = {
+                                        let mut doc_guard = doc.write().await;
+                                        doc_guard.fork()
+                                    };
+
+                                    let updated = update_output_by_display_id_with_manifests(
+                                        &mut fork,
+                                        display_id,
+                                        &serde_json::to_value(&update.data).unwrap_or_default(),
+                                        &update.metadata,
+                                        &blob_store,
+                                    )
+                                    .await;
+
                                     let persist_bytes = {
                                         let mut doc_guard = doc.write().await;
-                                        match update_output_by_display_id_with_manifests(
-                                            &mut doc_guard,
-                                            display_id,
-                                            &serde_json::to_value(&update.data).unwrap_or_default(),
-                                            &update.metadata,
-                                            &blob_store,
-                                        )
-                                        .await
-                                        {
+                                        match updated {
                                             Ok(true) => {
+                                                doc_guard.merge(&mut fork).ok();
                                                 debug!(
                                                     "[kernel-manager] Updated display_id={}",
                                                     display_id
                                                 );
                                             }
                                             Ok(false) => {
-                                                warn!(
+                                                error!(
                                                     "[kernel-manager] No output found for display_id={}",
                                                     display_id
                                                 );
                                             }
                                             Err(e) => {
-                                                warn!(
+                                                error!(
                                                     "[kernel-manager] Failed to update display: {}",
                                                     e
                                                 );


### PR DESCRIPTION
## Summary

The `UpdateDisplayData` IOPub handler held the doc write lock for the entire duration of async blob store I/O (manifest fetch, update, store). This blocked all other doc operations (user edits, other IOPub messages, sync) while blob I/O completed, violating the fork+merge invariant.

Now the handler forks the doc before blob work and merges back after, matching the pattern used by background formatting and the file watcher. Also escalates `warn!` to `error!` for failed display updates — stale widget/progress bar state is worth surfacing prominently in logs.

Closes #1221

## Verification

- [ ] Open a notebook that uses `update_display_data` (e.g. tqdm progress bars, plotly widget updates)
- [ ] Confirm progress bars and widget updates render correctly
- [ ] Confirm no regressions with standard cell output display

_PR submitted by @rgbkrk's agent, Quill_