### PR TITLE
fix(runtimed): use fork+merge for file watcher order-changed path

### DIFF
--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -5784,6 +5784,13 @@ async fn apply_ipynb_changes(
     // Use fork_at(last_save_heads) + merge so the structural rebuild
     // from disk composes with any post-save CRDT changes (e.g.,
     // background formatting) rather than overwriting them.
+    //
+    // Known limitation: cells inserted or moved locally after the last
+    // save may end up at slightly wrong positions after merge, because
+    // the fork's fractional indices don't account for post-save
+    // insertions. This is cosmetic — source text is preserved, and the
+    // user or agent can reorder manually. Still better than the old
+    // direct-mutation path which would clobber post-save source edits.
     if order_changed {
         debug!("[notebook-watch] Cell order changed, rebuilding cell list");
 

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -5780,53 +5780,67 @@ async fn apply_ipynb_changes(
 
     let mut changed = false;
 
-    // If order changed, we need to rebuild the cell list
-    // This is expensive but necessary to match external order
+    // If order changed, we need to rebuild the cell list.
+    // Use fork_at(last_save_heads) + merge so the structural rebuild
+    // from disk composes with any post-save CRDT changes (e.g.,
+    // background formatting) rather than overwriting them.
     if order_changed {
         debug!("[notebook-watch] Cell order changed, rebuilding cell list");
 
-        // Delete all current cells and re-add in external order
+        let save_heads = room.last_save_heads.read().await.clone();
+        let mut fork = if !save_heads.is_empty() {
+            match doc.fork_at(&save_heads) {
+                Ok(f) => f,
+                Err(_) => doc.fork(),
+            }
+        } else {
+            doc.fork()
+        };
+
+        // Delete all current cells and re-add in external order on the fork
         for cell in &current_cells {
-            let _ = doc.delete_cell(&cell.id);
+            let _ = fork.delete_cell(&cell.id);
         }
 
         for (index, ext_cell) in external_cells.iter().enumerate() {
-            if doc
+            if fork
                 .add_cell(index, &ext_cell.id, &ext_cell.cell_type)
                 .is_ok()
             {
-                let _ = doc.update_source(&ext_cell.id, &ext_cell.source);
+                let _ = fork.update_source(&ext_cell.id, &ext_cell.source);
 
                 // For existing cells with running kernel: preserve current outputs/execution_count
                 // For new cells: always use external values (they don't have in-progress state)
                 if has_running_kernel {
                     if let Some(current) = current_map.get(ext_cell.id.as_str()) {
                         // Existing cell - preserve in-progress state
-                        let _ = doc.set_outputs(&ext_cell.id, &current.outputs);
-                        let _ = doc.set_execution_count(&ext_cell.id, &current.execution_count);
+                        let _ = fork.set_outputs(&ext_cell.id, &current.outputs);
+                        let _ = fork.set_execution_count(&ext_cell.id, &current.execution_count);
                     } else {
                         // New cell - use external values
                         let ext_outputs = converted_outputs
                             .get(ext_cell.id.as_str())
                             .map(|v| v.as_slice())
                             .unwrap_or(&[]);
-                        let _ = doc.set_outputs(&ext_cell.id, ext_outputs);
-                        let _ = doc.set_execution_count(&ext_cell.id, &ext_cell.execution_count);
+                        let _ = fork.set_outputs(&ext_cell.id, ext_outputs);
+                        let _ = fork.set_execution_count(&ext_cell.id, &ext_cell.execution_count);
                     }
                 } else {
                     let ext_outputs = converted_outputs
                         .get(ext_cell.id.as_str())
                         .map(|v| v.as_slice())
                         .unwrap_or(&[]);
-                    let _ = doc.set_outputs(&ext_cell.id, ext_outputs);
-                    let _ = doc.set_execution_count(&ext_cell.id, &ext_cell.execution_count);
+                    let _ = fork.set_outputs(&ext_cell.id, ext_outputs);
+                    let _ = fork.set_execution_count(&ext_cell.id, &ext_cell.execution_count);
                 }
                 let ext_assets = converted_assets
                     .get(ext_cell.id.as_str())
                     .unwrap_or(&empty_assets);
-                let _ = doc.set_cell_resolved_assets(&ext_cell.id, ext_assets);
+                let _ = fork.set_cell_resolved_assets(&ext_cell.id, ext_assets);
             }
         }
+
+        let _ = doc.merge(&mut fork);
         return true;
     }
 


### PR DESCRIPTION
## Summary

Closes #1222

The order-changed branch in `apply_ipynb_changes` deletes all cells and re-adds them in the new external order. Previously this mutated the live doc directly after async asset resolution (manifest conversion, markdown asset resolution), which could overwrite post-save CRDT changes like background formatting.

**Fix:** Use `fork_at(last_save_heads)` + `merge()`, consistent with the source-update path that already uses this pattern. The structural rebuild from disk is treated as concurrent with any post-save CRDT changes, and Automerge composes them.

Falls back to a regular `fork()` if `last_save_heads` is empty or `fork_at` fails.

## Test plan

- [x] `cargo build` — compiles clean
- [x] `cargo xtask lint` — all checks pass
- [x] `cargo test -p runtimed --lib` — 283 unit tests pass