### PR TITLE
feat(ui): keep next cell at full opacity alongside current and previous

### DIFF
--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -109,6 +109,8 @@ interface CodeCellProps {
   isLastCell?: boolean;
   /** Whether this cell is immediately before the focused cell */
   isPreviousCellFromFocused?: boolean;
+  /** Whether this cell is immediately after the focused cell */
+  isNextCellFromFocused?: boolean;
   /** Props for dnd-kit drag handle (applied to ribbon) */
   dragHandleProps?: Record<string, unknown>;
   /** Whether this cell is currently being dragged */
@@ -147,6 +149,7 @@ export const CodeCell = memo(function CodeCell({
   onClearPagePayload,
   isLastCell = false,
   isPreviousCellFromFocused,
+  isNextCellFromFocused,
   dragHandleProps,
   isDragging,
   onToggleSourceHidden,
@@ -385,6 +388,7 @@ export const CodeCell = memo(function CodeCell({
         cellType="code"
         isFocused={isFocused}
         isPreviousCellFromFocused={isPreviousCellFromFocused}
+        isNextCellFromFocused={isNextCellFromFocused}
         onFocus={onFocus}
         gutterContent={gutterContent}
         rightGutterContent={rightGutterContent}

--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -43,6 +43,8 @@ interface MarkdownCellProps {
   isLastCell?: boolean;
   /** Whether this cell is immediately before the focused cell */
   isPreviousCellFromFocused?: boolean;
+  /** Whether this cell is immediately after the focused cell */
+  isNextCellFromFocused?: boolean;
   /** Props for dnd-kit drag handle (applied to ribbon) */
   dragHandleProps?: Record<string, unknown>;
   /** Whether this cell is currently being dragged */
@@ -60,6 +62,7 @@ export const MarkdownCell = memo(function MarkdownCell({
   onInsertCellAfter,
   isLastCell = false,
   isPreviousCellFromFocused,
+  isNextCellFromFocused,
   dragHandleProps,
   isDragging,
 }: MarkdownCellProps) {
@@ -407,6 +410,7 @@ export const MarkdownCell = memo(function MarkdownCell({
       cellType="markdown"
       isFocused={isFocused}
       isPreviousCellFromFocused={isPreviousCellFromFocused}
+      isNextCellFromFocused={isNextCellFromFocused}
       onFocus={onFocus}
       presenceIndicators={<CellPresenceIndicators cellId={cell.id} />}
       dragHandleProps={dragHandleProps}

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -486,6 +486,15 @@ function NotebookViewContent({
     return focusedIndex > 0 ? cellIds[focusedIndex - 1] : null;
   }, [focusedCellId, cellIds]);
 
+  // Compute the cell ID that follows the focused cell (keeps its output bright)
+  const nextCellId = useMemo(() => {
+    if (!focusedCellId) return null;
+    const focusedIndex = cellIds.indexOf(focusedCellId);
+    return focusedIndex >= 0 && focusedIndex < cellIds.length - 1
+      ? cellIds[focusedIndex + 1]
+      : null;
+  }, [focusedCellId, cellIds]);
+
   // Prevent horizontal scroll drift (can happen during text selection)
   useEffect(() => {
     const container = containerRef.current;
@@ -626,6 +635,7 @@ function NotebookViewContent({
             language={language}
             isFocused={isFocused}
             isPreviousCellFromFocused={cell.id === previousCellId}
+            isNextCellFromFocused={cell.id === nextCellId}
             isExecuting={isExecuting}
             isQueued={isQueued}
             pagePayload={pagePayload}
@@ -693,6 +703,7 @@ function NotebookViewContent({
             cell={cell}
             isFocused={isFocused}
             isPreviousCellFromFocused={cell.id === previousCellId}
+            isNextCellFromFocused={cell.id === nextCellId}
             searchQuery={searchQuery}
             onFocus={() => {
               focusSourceRef.current = "mouse";
@@ -716,6 +727,7 @@ function NotebookViewContent({
           cell={cell}
           isFocused={isFocused}
           isPreviousCellFromFocused={cell.id === previousCellId}
+          isNextCellFromFocused={cell.id === nextCellId}
           searchQuery={searchQuery}
           onFocus={() => {
             focusSourceRef.current = "mouse";
@@ -734,6 +746,7 @@ function NotebookViewContent({
     [
       focusedCellId,
       previousCellId,
+      nextCellId,
       executingCellIds,
       queuedCellIds,
       pagePayloads,

--- a/apps/notebook/src/components/RawCell.tsx
+++ b/apps/notebook/src/components/RawCell.tsx
@@ -33,6 +33,7 @@ interface RawCellProps {
   onInsertCellAfter?: () => void;
   isLastCell?: boolean;
   isPreviousCellFromFocused?: boolean;
+  isNextCellFromFocused?: boolean;
   dragHandleProps?: Record<string, unknown>;
   isDragging?: boolean;
 }
@@ -48,6 +49,7 @@ export const RawCell = memo(function RawCell({
   onInsertCellAfter,
   isLastCell = false,
   isPreviousCellFromFocused,
+  isNextCellFromFocused,
   dragHandleProps,
   isDragging,
 }: RawCellProps) {
@@ -187,6 +189,7 @@ export const RawCell = memo(function RawCell({
       cellType="raw"
       isFocused={isFocused}
       isPreviousCellFromFocused={isPreviousCellFromFocused}
+      isNextCellFromFocused={isNextCellFromFocused}
       onFocus={onFocus}
       presenceIndicators={<CellPresenceIndicators cellId={cell.id} />}
       dragHandleProps={dragHandleProps}

--- a/src/components/cell/CellContainer.tsx
+++ b/src/components/cell/CellContainer.tsx
@@ -27,6 +27,8 @@ interface CellContainerProps {
   customGutterColors?: Record<string, GutterColorConfig>;
   /** Whether this cell is immediately before the focused cell (keeps output bright) */
   isPreviousCellFromFocused?: boolean;
+  /** Whether this cell is immediately after the focused cell (keeps output bright) */
+  isNextCellFromFocused?: boolean;
   /** Props for dnd-kit drag handle (applied to ribbon) */
   dragHandleProps?: Record<string, unknown>;
   /** Whether this cell is currently being dragged */
@@ -51,6 +53,7 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
       presenceIndicators,
       customGutterColors,
       isPreviousCellFromFocused = false,
+      isNextCellFromFocused = false,
       dragHandleProps,
       isDragging = false,
       className,
@@ -135,7 +138,7 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
                 <div
                   className={cn(
                     "min-w-0 flex-1 py-2 pl-6 pr-3 transition-opacity duration-150",
-                    !isFocused && !isPreviousCellFromFocused && "opacity-70",
+                    !isFocused && !isPreviousCellFromFocused && !isNextCellFromFocused && "opacity-70",
                   )}
                 >
                   {outputContent}


### PR DESCRIPTION
## Summary

Extends the cell output opacity behavior so the cell **after** the focused cell also stays at full opacity, creating a 3-cell bright window (previous → current → next) instead of the previous 2-cell window. All other cells remain dimmed at 70% opacity.

Adds a `nextCellId` memo in `NotebookView` (mirroring the existing `previousCellId`), threads `isNextCellFromFocused` through `CodeCell`, `MarkdownCell`, and `RawCell`, and includes it in `CellContainer`'s opacity condition.

![Next cell opacity](placeholder-for-screenshot)

## Verification

- [ ] Open a notebook with 4+ cells
- [ ] Click on a middle cell — confirm the previous, current, and next cell outputs are all at full opacity
- [ ] Click on the first cell — confirm no error, and the next cell stays bright
- [ ] Click on the last cell — confirm no error, and the previous cell stays bright
- [ ] Cells 2+ away from focused cell should be visibly dimmed

_PR submitted by @rgbkrk's agent, Quill_