### PR TITLE
feat(crdt): granular actor IDs for daemon forks, suppress automated attributions

### DIFF
--- a/apps/notebook/src/lib/attribution-registry.ts
+++ b/apps/notebook/src/lib/attribution-registry.ts
@@ -141,8 +141,11 @@ function dispatchAttributionMarks(
     // Skip automated daemon changes (formatting, file watcher, kernel
     // display updates). The text is applied via CRDT sync, but the
     // visual animation (fade-in, underline sweep) is distracting for
-    // non-human edits. Human and agent actors don't start with "runtimed:".
-    if (attr.actors.every((a) => a.startsWith("runtimed:"))) continue;
+    // non-human edits. Daemon actors are either the bare "runtimed" or
+    // scoped like "runtimed:ruff". Human and agent actors use different
+    // prefixes (e.g., "agent:claude:...", "human").
+    if (attr.actors.every((a) => a === "runtimed" || a.startsWith("runtimed:")))
+      continue;
 
     const docLen = view.state.doc.length;
     const from = Math.min(attr.index, docLen);

--- a/apps/notebook/src/lib/attribution-registry.ts
+++ b/apps/notebook/src/lib/attribution-registry.ts
@@ -138,6 +138,12 @@ function dispatchAttributionMarks(
     // Skip pure deletions — nothing to highlight (the text is gone)
     if (attr.text.length === 0) continue;
 
+    // Skip automated daemon changes (formatting, file watcher, kernel
+    // display updates). The text is applied via CRDT sync, but the
+    // visual animation (fade-in, underline sweep) is distracting for
+    // non-human edits. Human and agent actors don't start with "runtimed:".
+    if (attr.actors.every((a) => a.startsWith("runtimed:"))) continue;
+
     const docLen = view.state.doc.length;
     const from = Math.min(attr.index, docLen);
     const to = Math.min(attr.index + attr.text.length, docLen);

--- a/crates/runtimed/src/kernel_manager.rs
+++ b/crates/runtimed/src/kernel_manager.rs
@@ -1233,7 +1233,9 @@ impl RoomKernel {
                                     // write lock during potentially slow blob store operations.
                                     let mut fork = {
                                         let mut doc_guard = doc.write().await;
-                                        doc_guard.fork()
+                                        let mut f = doc_guard.fork();
+                                        f.set_actor("runtimed:kernel");
+                                        f
                                     };
 
                                     let updated = update_output_by_display_id_with_manifests(

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -312,7 +312,8 @@ async fn process_markdown_assets(room: &NotebookRoom) {
             .filter(|cell| cell.cell_type == "markdown")
             .map(|cell| (cell.id, cell.source, cell.resolved_assets))
             .collect();
-        let fork = doc.fork();
+        let mut fork = doc.fork();
+        fork.set_actor("runtimed:assets");
         (cells, fork)
     };
 
@@ -3528,6 +3529,8 @@ async fn handle_notebook_request(
                             if let Some(runtime) = detect_room_runtime(&room_clone).await {
                                 if let Some(formatted) = format_source(&source, &runtime).await {
                                     let mut fork = fork;
+                                    let actor = formatter_actor(&runtime);
+                                    fork.set_actor(&actor);
                                     if fork.update_source(&cell_id_clone, &formatted).is_ok() {
                                         let mut doc = room_clone.doc.write().await;
                                         let _ = doc.merge(&mut fork);
@@ -3739,6 +3742,8 @@ async fn handle_notebook_request(
                 tokio::spawn(async move {
                     if let Some(runtime) = detect_room_runtime(&room_clone).await {
                         let mut fork = fork;
+                        let actor = formatter_actor(&runtime);
+                        fork.set_actor(&actor);
                         let mut any_formatted = false;
                         for (cell_id, source) in &cell_sources {
                             if let Some(fmt) = format_source(source, &runtime).await {
@@ -4218,6 +4223,15 @@ async fn format_source(source: &str, runtime: &str) -> Option<String> {
     }
 }
 
+/// Map a runtime name to its formatter's CRDT actor label.
+fn formatter_actor(runtime: &str) -> String {
+    let tool = match runtime {
+        "python" => "ruff",
+        other => other, // "deno" stays "deno"
+    };
+    format!("runtimed:{tool}")
+}
+
 /// Detect the runtime from room metadata, returning "python", "deno", or None.
 async fn detect_room_runtime(room: &NotebookRoom) -> Option<String> {
     let doc = room.doc.read().await;
@@ -4258,7 +4272,9 @@ async fn format_notebook_cells(room: &NotebookRoom) -> Result<usize, String> {
     // live doc, and Automerge's text CRDT merges them cleanly.
     let mut fork = {
         let mut doc = room.doc.write().await;
-        doc.fork()
+        let mut f = doc.fork();
+        f.set_actor(&formatter_actor(&runtime));
+        f
     };
 
     let mut formatted_count = 0;
@@ -5808,6 +5824,7 @@ async fn apply_ipynb_changes(
         } else {
             doc.fork()
         };
+        fork.set_actor("runtimed:filesystem");
 
         // Delete all current cells and re-add in external order on the fork
         for cell in &current_cells {
@@ -5875,7 +5892,10 @@ async fn apply_ipynb_changes(
     // (e.g., background formatting) rather than overwriting them.
     let save_heads = room.last_save_heads.read().await.clone();
     let mut source_fork = if !save_heads.is_empty() {
-        doc.fork_at(&save_heads).ok()
+        doc.fork_at(&save_heads).ok().map(|mut f| {
+            f.set_actor("runtimed:filesystem");
+            f
+        })
     } else {
         None
     };


### PR DESCRIPTION
## Summary

Sets specific actor labels on CRDT forks so changes are attributed to their source, and suppresses the text attribution animation for automated daemon changes.

### Daemon-side: granular actors

Previously all daemon mutations used the single `"runtimed"` actor. Now each fork sets a specific actor before mutating:

| Actor | Source |
|-------|--------|
| `runtimed:ruff` | Python cell formatting |
| `runtimed:deno` | Deno cell formatting |
| `runtimed:filesystem` | File watcher external changes |
| `runtimed:assets` | Markdown asset resolution |
| `runtimed:kernel` | UpdateDisplayData from kernel IOPub |

### Frontend-side: suppress animation for `runtimed:*`

The text attribution animation (fade-in opacity, colored underline sweep) is suppressed for changes where all actors start with `runtimed:`. The text still arrives via CRDT sync — only the visual decoration is skipped. Human and agent edits (which don't start with `runtimed:`) still show the full attribution flow.

## Files changed

- `crates/runtimed/src/notebook_sync_server.rs` — `set_actor()` on all fork sites + `formatter_actor()` helper
- `crates/runtimed/src/kernel_manager.rs` — `set_actor("runtimed:kernel")` on UpdateDisplayData fork
- `apps/notebook/src/lib/attribution-registry.ts` — skip `runtimed:*` attributions in `dispatchAttributionMarks`

## Test plan

- [x] `cargo build` — compiles clean
- [x] `cargo xtask lint --fix` — all checks pass
- [x] `cargo test -p runtimed --lib` — 283 unit tests pass
- [ ] Manual: execute a cell, verify formatting changes don't show attribution animation
- [ ] Manual: type in a cell from another window/agent, verify attribution animation still shows