### PR TITLE
fix(ui): center hidden cell and source badges vertically

### DIFF
--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -399,7 +399,7 @@ export const CodeCell = memo(function CodeCell({
           <>
             {/* Source visibility toggle + Editor */}
             {bothHidden ? (
-              <div className="flex justify-start">
+              <div className="flex items-center justify-start min-h-[1.75rem]">
                 <button
                   type="button"
                   onClick={() => {
@@ -436,7 +436,7 @@ export const CodeCell = memo(function CodeCell({
                 </button>
               </div>
             ) : isSourceHidden ? (
-              <div className="flex justify-start">
+              <div className="flex items-center justify-start min-h-[1.75rem]">
                 <button
                   type="button"
                   onClick={() => onToggleSourceHidden?.(false)}
@@ -484,7 +484,7 @@ export const CodeCell = memo(function CodeCell({
         }
         outputContent={
           isOutputsHidden && cell.outputs.length > 0 ? (
-            <div className="flex justify-start">
+            <div className="flex items-center justify-start min-h-[1.75rem]">
               <button
                 type="button"
                 onClick={() => onToggleOutputsHidden?.(false)}


### PR DESCRIPTION
## Summary

The CodeMirror editor recently gained a negative top margin (`marginTop: -0.75rem`) to reserve space for peer cursor labels above line 1. The code content wrapper in `CellContainer` has asymmetric vertical padding (`pt-1.5 pb-3`), which the editor compensates for but the hidden-cell badges do not — causing them to sit off-center toward the top of their row.

This adds `items-center` and `min-h-[1.75rem]` to the three badge wrapper divs (cell hidden, source hidden, outputs hidden) so they vertically center within the code row.

<!-- Before/after screenshots welcome here -->

## Verification

- [ ] Open a notebook, hide a cell's source — the `</>` badge is vertically centered in the row
- [ ] Hide an entire cell — the "Cell hidden" badge is vertically centered
- [ ] Hide outputs on a cell with outputs — the outputs-hidden badge is centered
- [ ] Normal CodeMirror editor cells are visually unaffected

_PR submitted by @rgbkrk's agent, Quill_