### PR TITLE
fix(notebook): prevent widget iframe remount on cell add/delete

### DIFF
--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -379,6 +379,11 @@ function NotebookViewContent({
   const containerRef = useRef<HTMLDivElement>(null);
   // Track whether focus change was keyboard-driven (should scroll) or mouse-driven (already visible)
   const focusSourceRef = useRef<"mouse" | "keyboard">("keyboard");
+  // Ref for cellIds so renderCell can read the latest list without
+  // depending on the array identity. This prevents recreating
+  // renderCell (and remounting widget iframes) on structural changes.
+  const cellIdsRef = useRef(cellIds);
+  cellIdsRef.current = cellIds;
   const { focusCell } = useEditorRegistry();
 
   // Track full materializations for cross-cell derived state
@@ -576,15 +581,18 @@ function NotebookViewContent({
 
       const onFocusPrevious = (cursorPosition: "start" | "end") => {
         logger.debug(
-          `[cell-nav] onFocusPrevious called: cell=${cell.id.slice(0, 8)} index=${index} cellIds=${cellIds.map((id) => id.slice(0, 8)).join(",")}`,
+          `[cell-nav] onFocusPrevious called: cell=${cell.id.slice(0, 8)} index=${index} cellIds=${cellIdsRef.current.map((id) => id.slice(0, 8)).join(",")}`,
         );
         focusSourceRef.current = "keyboard";
         let prevIndex = index - 1;
-        while (prevIndex >= 0 && !isVisibleCell(cellIds[prevIndex])) {
+        while (
+          prevIndex >= 0 &&
+          !isVisibleCell(cellIdsRef.current[prevIndex])
+        ) {
           prevIndex--;
         }
         if (prevIndex >= 0) {
-          const prevCellId = cellIds[prevIndex];
+          const prevCellId = cellIdsRef.current[prevIndex];
           logger.debug(
             `[cell-nav] Focusing previous: ${prevCellId.slice(0, 8)}`,
           );
@@ -597,18 +605,18 @@ function NotebookViewContent({
 
       const onFocusNext = (cursorPosition: "start" | "end") => {
         logger.debug(
-          `[cell-nav] onFocusNext called: cell=${cell.id.slice(0, 8)} index=${index} cellIds=${cellIds.map((id) => id.slice(0, 8)).join(",")}`,
+          `[cell-nav] onFocusNext called: cell=${cell.id.slice(0, 8)} index=${index} cellIds=${cellIdsRef.current.map((id) => id.slice(0, 8)).join(",")}`,
         );
         focusSourceRef.current = "keyboard";
         let nextIndex = index + 1;
         while (
-          nextIndex < cellIds.length &&
-          !isVisibleCell(cellIds[nextIndex])
+          nextIndex < cellIdsRef.current.length &&
+          !isVisibleCell(cellIdsRef.current[nextIndex])
         ) {
           nextIndex++;
         }
-        if (nextIndex < cellIds.length) {
-          const nextCellId = cellIds[nextIndex];
+        if (nextIndex < cellIdsRef.current.length) {
+          const nextCellId = cellIdsRef.current[nextIndex];
           logger.debug(`[cell-nav] Focusing next: ${nextCellId.slice(0, 8)}`);
           onFocusCell(nextCellId);
           focusCell(nextCellId, cursorPosition);
@@ -657,7 +665,7 @@ function NotebookViewContent({
             onFocusNext={onFocusNext}
             onInsertCellAfter={() => onAddCell("code", cell.id)}
             onClearPagePayload={() => onClearPagePayload(cell.id)}
-            isLastCell={index === cellIds.length - 1}
+            isLastCell={index === cellIdsRef.current.length - 1}
             dragHandleProps={dragHandleProps}
             isDragging={isDragging}
             onToggleSourceHidden={
@@ -713,7 +721,7 @@ function NotebookViewContent({
             onFocusPrevious={onFocusPrevious}
             onFocusNext={onFocusNext}
             onInsertCellAfter={() => onAddCell("markdown", cell.id)}
-            isLastCell={index === cellIds.length - 1}
+            isLastCell={index === cellIdsRef.current.length - 1}
             dragHandleProps={dragHandleProps}
             isDragging={isDragging}
           />
@@ -737,7 +745,7 @@ function NotebookViewContent({
           onFocusPrevious={onFocusPrevious}
           onFocusNext={onFocusNext}
           onInsertCellAfter={() => onAddCell("code", cell.id)}
-          isLastCell={index === cellIds.length - 1}
+          isLastCell={index === cellIdsRef.current.length - 1}
           dragHandleProps={dragHandleProps}
           isDragging={isDragging}
         />
@@ -753,7 +761,6 @@ function NotebookViewContent({
       runtime,
       searchQuery,
       searchCurrentMatch,
-      cellIds,
       onFocusCell,
       onExecuteCell,
       onInterruptKernel,

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -483,6 +483,8 @@ function NotebookViewContent({
     }
     return groups;
   }, [cellIds, materializeVersion]);
+  const hiddenGroupsRef = useRef(hiddenGroups);
+  hiddenGroupsRef.current = hiddenGroups;
 
   // Compute the cell ID that precedes the focused cell (keeps its output bright)
   const previousCellId = useMemo(() => {
@@ -575,7 +577,7 @@ function NotebookViewContent({
 
       // Navigation callbacks — skip cells that are collapsed into a hidden group
       const isVisibleCell = (id: string) => {
-        const g = hiddenGroups.get(id);
+        const g = hiddenGroupsRef.current.get(id);
         return !g || g.isFirst;
       };
 
@@ -678,19 +680,21 @@ function NotebookViewContent({
                 ? (hidden: boolean) => onSetCellOutputsHidden(cell.id, hidden)
                 : undefined
             }
-            hiddenGroupCount={hiddenGroups.get(cell.id)?.count}
-            hiddenGroupErrorCount={hiddenGroups.get(cell.id)?.errorCount}
+            hiddenGroupCount={hiddenGroupsRef.current.get(cell.id)?.count}
+            hiddenGroupErrorCount={
+              hiddenGroupsRef.current.get(cell.id)?.errorCount
+            }
             isGroupExecuting={
-              hiddenGroups
+              hiddenGroupsRef.current
                 .get(cell.id)
                 ?.groupCellIds.some((id) => executingCellIds.has(id)) ?? false
             }
             onExpandHiddenGroup={
-              hiddenGroups.has(cell.id) &&
+              hiddenGroupsRef.current.has(cell.id) &&
               onSetCellSourceHidden &&
               onSetCellOutputsHidden
                 ? () => {
-                    const group = hiddenGroups.get(cell.id);
+                    const group = hiddenGroupsRef.current.get(cell.id);
                     if (group) {
                       for (const id of group.groupCellIds) {
                         onSetCellSourceHidden(id, false);
@@ -770,7 +774,6 @@ function NotebookViewContent({
       onReportOutputMatchCount,
       onSetCellSourceHidden,
       onSetCellOutputsHidden,
-      hiddenGroups,
       focusCell,
     ],
   );


### PR DESCRIPTION
## Summary

Widget outputs (anywidget, plotly, etc.) were being destroyed and recreated whenever a cell was added or deleted anywhere in the notebook. This caused animations to replay, interactive state to reset, and plots to re-render.

**Root cause:** The `renderCell` callback in `NotebookView` had `cellIds` in its `useCallback` dependency array. Since `cellIds` is a new array on every structural change, the callback was recreated, cascading through the component tree and remounting `IsolatedFrame` iframes.

**Fix:** Use a ref (`cellIdsRef`) so `renderCell` reads the latest cell list without depending on the array identity. Navigation callbacks and `isLastCell` still work correctly via the ref.

## Test plan

- [ ] Open a notebook with an anywidget/plotly output
- [ ] Add a new cell — widget should NOT re-render
- [ ] Delete a cell — widget should NOT re-render
- [ ] Keyboard navigation (arrow keys between cells) should still work
- [ ] Last-cell styling should still apply correctly