### PR TITLE
fix(ui): restore symmetric padding on output row to align with code

### DIFF
--- a/src/components/cell/CellContainer.tsx
+++ b/src/components/cell/CellContainer.tsx
@@ -135,7 +135,7 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
                 />
                 <div
                   className={cn(
-                    "min-w-0 flex-1 py-2 pr-3 transition-opacity duration-150",
+                    "min-w-0 flex-1 py-2 pl-6 pr-6 transition-opacity duration-150",
                     !isFocused && !isPreviousCellFromFocused && !isNextCellFromFocused && "opacity-70",
                   )}
                 >


### PR DESCRIPTION
## Summary

#1232 removed `pl-6` from the output row to center widgets, but this also left-flushed text outputs (stream, error, plain text) against the ribbon.

**Fix:** Restore symmetric `pl-6 pr-6` on the output content area so outputs align their left edge with the code editor indent and get equal breathing room on the right.

## Test plan

- [ ] Text outputs (print, error tracebacks) left-align with code indent
- [ ] Widget outputs (anywidget, plotly) center within the padded area
- [ ] Image outputs render with symmetric margins