### PR TITLE
fix(ui): restore symmetric padding on output row to align with code

### DIFF
--- a/src/components/cell/CellContainer.tsx
+++ b/src/components/cell/CellContainer.tsx
@@ -135,7 +135,7 @@ export const CellContainer = forwardRef<HTMLDivElement, CellContainerProps>(
                 />
                 <div
                   className={cn(
-                    "min-w-0 flex-1 py-2 pl-6 pr-6 transition-opacity duration-150",
+                    "min-w-0 flex-1 py-2 transition-opacity duration-150",
                     !isFocused && !isPreviousCellFromFocused && !isNextCellFromFocused && "opacity-70",
                   )}
                 >

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -463,10 +463,16 @@ export function OutputArea({
   // Hide the entire output area when only preloading (no visible outputs)
   const isPreloadOnly = showPreloadedIframe && outputs.length === 0;
 
+  // pl-6 aligns the output left edge with the code editor indent.
+  // pr-9 compensates for the right gutter (w-10) so that centered
+  // content (widgets, plots) appears visually centered between the
+  // code indent and the right edge. The CellContainer output wrapper
+  // has no horizontal padding — it must live here because the iframe
+  // ignores padding on its parent container.
   return (
     <div
       data-slot="output-area"
-      className={cn("output-area", isPreloadOnly && "hidden", className)}
+      className={cn("output-area pl-6 pr-9", isPreloadOnly && "hidden", className)}
     >
       {/* Collapse toggle */}
       {hasCollapseControl && (


### PR DESCRIPTION
## Summary

Followup to #1233. The padding needs to live on OutputArea (where the iframe respects it), not on CellContainer's output wrapper (where iframes ignore it).

- CellContainer output wrapper: stripped horizontal padding
- OutputArea: `pl-6` aligns left edge with code indent, `pr-9` compensates for the right gutter so centered content (widgets, plots) appears visually centered

## Test plan

- [x] Text outputs (print, tracebacks) left-align with code indent
- [x] Widget outputs (anywidget) center symmetrically
- [x] Markdown preview centering unaffected (uses codeContent slot)