### PR TITLE
fix(notebook): ref-ify previousCellId/nextCellId to prevent widget remount

### DIFF
--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -492,6 +492,8 @@ function NotebookViewContent({
     const focusedIndex = cellIds.indexOf(focusedCellId);
     return focusedIndex > 0 ? cellIds[focusedIndex - 1] : null;
   }, [focusedCellId, cellIds]);
+  const previousCellIdRef = useRef(previousCellId);
+  previousCellIdRef.current = previousCellId;
 
   // Compute the cell ID that follows the focused cell (keeps its output bright)
   const nextCellId = useMemo(() => {
@@ -501,6 +503,8 @@ function NotebookViewContent({
       ? cellIds[focusedIndex + 1]
       : null;
   }, [focusedCellId, cellIds]);
+  const nextCellIdRef = useRef(nextCellId);
+  nextCellIdRef.current = nextCellId;
 
   // Prevent horizontal scroll drift (can happen during text selection)
   useEffect(() => {
@@ -695,8 +699,8 @@ function NotebookViewContent({
             cell={cell}
             language={language}
             isFocused={isFocused}
-            isPreviousCellFromFocused={cell.id === previousCellId}
-            isNextCellFromFocused={cell.id === nextCellId}
+            isPreviousCellFromFocused={cell.id === previousCellIdRef.current}
+            isNextCellFromFocused={cell.id === nextCellIdRef.current}
             isExecuting={isExecuting}
             isQueued={isQueued}
             pagePayload={pagePayload}
@@ -766,8 +770,8 @@ function NotebookViewContent({
             key={cell.id}
             cell={cell}
             isFocused={isFocused}
-            isPreviousCellFromFocused={cell.id === previousCellId}
-            isNextCellFromFocused={cell.id === nextCellId}
+            isPreviousCellFromFocused={cell.id === previousCellIdRef.current}
+            isNextCellFromFocused={cell.id === nextCellIdRef.current}
             searchQuery={searchQuery}
             onFocus={() => {
               focusSourceRef.current = "mouse";
@@ -811,8 +815,6 @@ function NotebookViewContent({
     },
     [
       focusedCellId,
-      previousCellId,
-      nextCellId,
       executingCellIds,
       queuedCellIds,
       pagePayloads,


### PR DESCRIPTION
## Summary

Followup to #1231. Widget iframes were still remounting on cell add/delete because `previousCellId` and `nextCellId` were in `renderCell`'s `useCallback` dependency array. Both are derived from `cellIds` (via `useMemo`), so they change identity on every structural edit.

**Fix:** Use refs, same pattern as `cellIdsRef` and `hiddenGroupsRef` from #1231. The opacity styling (`isPreviousCellFromFocused`, `isNextCellFromFocused`) still reads the latest values via the ref.

### Remaining `renderCell` deps audit

After this fix, the deps that can change on structural edits are fully ref-ified:

| Dep | Changes on cell add? | Ref-ified? |
|-----|---------------------|------------|
| `cellIds` | Yes | Yes (#1231) |
| `hiddenGroups` | Yes (derived from cellIds) | Yes (#1231) |
| `previousCellId` | Yes (derived from cellIds) | Yes (this PR) |
| `nextCellId` | Yes (derived from cellIds) | Yes (this PR) |
| `focusedCellId` | No | N/A |
| `executingCellIds` | No | N/A |
| `queuedCellIds` | No | N/A |
| `pagePayloads` | No | N/A |
| Callbacks (`onFocusCell`, etc.) | No (stable) | N/A |

## Test plan

- [ ] Open notebook with widget output (anywidget, plotly)
- [ ] Add a new cell — widget should NOT re-render
- [ ] Delete a cell — widget should NOT re-render
- [ ] Focus different cells — opacity dimming still works
- [ ] Keyboard navigation still works