### PR TITLE
fix(runtimed): resolve orphaned executions in CellError handler

### DIFF
--- a/crates/runtimed/src/kernel_manager.rs
+++ b/crates/runtimed/src/kernel_manager.rs
@@ -2030,6 +2030,7 @@ impl RoomKernel {
                 let mut sd = self.state_doc.write().await;
                 let mut changed = sd.set_execution_done(execution_id, success);
                 changed |= sd.set_queue(None, &doc_queued);
+                changed |= sd.trim_executions(128) > 0;
                 if changed {
                     let _ = self.state_changed_tx.send(());
                 }

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -47,7 +47,7 @@ use crate::protocol::{
     EnvSyncDiff, NotebookBroadcast, NotebookRequest, NotebookResponse, QueueEntry,
 };
 use notebook_doc::presence::{self, PresenceState};
-use notebook_doc::runtime_state::RuntimeStateDoc;
+use notebook_doc::runtime_state::{QueueEntry as DocQueueEntry, RuntimeStateDoc};
 
 /// Capacity for the per-room kernel broadcast channel. Sized to absorb bursts
 /// of output messages (e.g. fast-printing cells) so slower peers trigger a
@@ -2487,23 +2487,38 @@ async fn auto_launch_kernel(
                                 );
                                 // Mark the execution as errored so execution_done() knows
                                 // to write success=false to the RuntimeStateDoc.
-                                let mut guard = room_kernel.lock().await;
-                                if let Some(ref mut k) = *guard {
-                                    k.mark_execution_error();
-                                    // Clear the queue to stop execution on error, which matches
-                                    // the behavior of manually-launched kernel handler.
-                                    let cleared = k.clear_queue();
-                                    if !cleared.is_empty() {
-                                        info!(
-                                            "[notebook-sync] Cleared {} queued cells due to error",
-                                            cleared.len()
-                                        );
+                                let (executing_entry, cleared) = {
+                                    let mut guard = room_kernel.lock().await;
+                                    if let Some(ref mut k) = *guard {
+                                        k.mark_execution_error();
+                                        // Clear the queue to stop execution on error, which matches
+                                        // the behavior of manually-launched kernel handler.
+                                        let cleared = k.clear_queue();
+                                        if !cleared.is_empty() {
+                                            info!(
+                                                "[notebook-sync] Cleared {} queued cells due to error",
+                                                cleared.len()
+                                            );
+                                        }
+                                        let exec = k.executing_entry().map(|e| DocQueueEntry {
+                                            cell_id: e.cell_id,
+                                            execution_id: e.execution_id,
+                                        });
+                                        (exec, cleared)
+                                    } else {
+                                        (None, vec![])
                                     }
-                                }
-                                // Write cleared queue to state doc
+                                };
+                                // Write cleared queue to state doc and mark
+                                // cleared executions as errored.
                                 {
                                     let mut sd = room_state_doc.write().await;
-                                    if sd.set_queue(None, &[]) {
+                                    let mut changed = sd.set_queue(executing_entry.as_ref(), &[]);
+                                    for entry in &cleared {
+                                        changed |=
+                                            sd.set_execution_done(&entry.execution_id, false);
+                                    }
+                                    if changed {
                                         let _ = room_state_changed_tx.send(());
                                     }
                                 }
@@ -3307,22 +3322,39 @@ async fn handle_notebook_request(
                                         );
                                         // Mark the execution as errored so execution_done() knows
                                         // to write success=false to the RuntimeStateDoc.
-                                        let mut guard = room_kernel.lock().await;
-                                        if let Some(ref mut k) = *guard {
-                                            k.mark_execution_error();
-                                            // Clear the queue to stop execution on error
-                                            let cleared = k.clear_queue();
-                                            if !cleared.is_empty() {
-                                                info!(
-                                                    "[notebook-sync] Cleared {} queued cells due to error",
-                                                    cleared.len()
-                                                );
+                                        let (executing_entry, cleared) = {
+                                            let mut guard = room_kernel.lock().await;
+                                            if let Some(ref mut k) = *guard {
+                                                k.mark_execution_error();
+                                                // Clear the queue to stop execution on error
+                                                let cleared = k.clear_queue();
+                                                if !cleared.is_empty() {
+                                                    info!(
+                                                        "[notebook-sync] Cleared {} queued cells due to error",
+                                                        cleared.len()
+                                                    );
+                                                }
+                                                let exec =
+                                                    k.executing_entry().map(|e| DocQueueEntry {
+                                                        cell_id: e.cell_id,
+                                                        execution_id: e.execution_id,
+                                                    });
+                                                (exec, cleared)
+                                            } else {
+                                                (None, vec![])
                                             }
-                                        }
-                                        // Write cleared queue to state doc
+                                        };
+                                        // Write cleared queue to state doc and mark
+                                        // cleared executions as errored.
                                         {
                                             let mut sd = room_state_doc.write().await;
-                                            if sd.set_queue(None, &[]) {
+                                            let mut changed =
+                                                sd.set_queue(executing_entry.as_ref(), &[]);
+                                            for entry in &cleared {
+                                                changed |= sd
+                                                    .set_execution_done(&entry.execution_id, false);
+                                            }
+                                            if changed {
                                                 let _ = room_state_changed_tx.send(());
                                             }
                                         }


### PR DESCRIPTION
## Summary

- **CellError handler now marks cleared queue entries as done** in the RuntimeStateDoc, preventing orphaned executions stuck at "queued" status forever. Mirrors the existing `KernelDied` handler pattern.
- **Preserves executing entry** in `set_queue()` instead of passing `None`, which was prematurely clearing the "executing" field while the cell was still running. This matches the intent documented in `clear_queue()` at kernel_manager.rs:2342.
- **Caps executions map at 128 entries** via `trim_executions()` in `execution_done()`, preventing unbounded growth of the RuntimeStateDoc.

## Context

The daemon was panicking with automerge `MissingOps` after cell errors followed by continued execution. The CellError handler cleared the queue but never finalized the cleared entries in the state doc, leaving orphaned execution entries that accumulated and destabilized the automerge document.

## Test plan

- [x] `cargo check -p runtimed` — compiles
- [x] `cargo test -p notebook-doc` — 235 tests pass (includes `trim_executions` tests)
- [x] `cargo test -p runtimed --lib` — 283 tests pass
- [x] `cargo xtask lint` — clean
- [ ] Manual: open notebook with Deno, run a cell that errors, then run more cells — daemon should not crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)