### PR TITLE
refactor(notebook): decouple renderCell from dynamic state via cell-ui-state store

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -40,6 +40,13 @@ import { usePoolState } from "./hooks/usePoolState";
 import { useTrust } from "./hooks/useTrust";
 import { useUpdater } from "./hooks/useUpdater";
 import { startAttributionDispatch } from "./lib/attribution-registry";
+import {
+  setExecutingCellIds as storeSetExecutingCellIds,
+  setFocusedCellId as storeSetFocusedCellId,
+  setQueuedCellIds as storeSetQueuedCellIds,
+  setSearchCurrentMatch as storeSetSearchCurrentMatch,
+  setSearchQuery as storeSetSearchQuery,
+} from "./lib/cell-ui-state";
 import { startCursorDispatch } from "./lib/cursor-registry";
 import { KERNEL_STATUS } from "./lib/kernel-status";
 import { logger } from "./lib/logger";
@@ -48,14 +55,8 @@ import { useDetectRuntime } from "./lib/notebook-metadata";
 import { startWindowFocusHandler } from "./lib/window-focus";
 import type { JupyterMessage } from "./types";
 
-/** MIME bundle type for page payloads */
+/** MIME bundle type for output data */
 export type MimeBundle = Record<string, unknown>;
-
-/** Page payload data for a cell */
-export interface CellPagePayload {
-  data: MimeBundle;
-  start: number;
-}
 
 /**
  * Module-level reference for daemon comm sending.
@@ -198,11 +199,6 @@ function AppContent() {
     return () => clearTimeout(timer);
   }, [justSynced]);
 
-  // Page payload state: maps cell_id -> payload (transient, not saved)
-  const [pagePayloads, setPagePayloads] = useState<
-    Map<string, CellPagePayload>
-  >(new Map());
-
   // UV Dependency management
   const {
     dependencies,
@@ -271,14 +267,6 @@ function AppContent() {
   );
 
   // Clear page payload for a cell (e.g., when dismissed or re-executed)
-  const clearPagePayload = useCallback((cellId: string) => {
-    setPagePayloads((prev) => {
-      const next = new Map(prev);
-      next.delete(cellId);
-      return next;
-    });
-  }, []);
-
   // Daemon-owned kernel execution
   const {
     kernelStatus,
@@ -327,6 +315,16 @@ function AppContent() {
     queueState.executing ? [queueState.executing.cell_id] : [],
   );
   const queuedCellIds = new Set(queueState.queued.map((e) => e.cell_id));
+
+  // ── Sync transient UI state into the cell-ui-state store ────────────
+  // These are module-level setters, not React state — they feed
+  // useSyncExternalStore hooks in cell components so renderCell
+  // doesn't need these as dependencies.
+  storeSetFocusedCellId(focusedCellId);
+  storeSetExecutingCellIds(executingCellIds);
+  storeSetQueuedCellIds(queuedCellIds);
+  storeSetSearchQuery(globalFind.query);
+  storeSetSearchCurrentMatch(globalFind.currentMatch);
 
   // When kernel is running and we know the env source, use it to determine panel type.
   // This handles: both-deps (backend picks based on preference), pixi (auto-detected, no metadata).
@@ -1184,20 +1182,13 @@ function AppContent() {
           <NotebookView
             cellIds={cellIds}
             isLoading={isLoading}
-            focusedCellId={focusedCellId}
-            executingCellIds={executingCellIds}
-            queuedCellIds={queuedCellIds}
-            pagePayloads={pagePayloads}
             runtime={runtime}
-            searchQuery={globalFind.query}
-            searchCurrentMatch={globalFind.currentMatch}
             onFocusCell={setFocusedCellId}
             onExecuteCell={handleExecuteCell}
             onInterruptKernel={interruptKernel}
             onDeleteCell={deleteCell}
             onAddCell={handleAddCell}
             onMoveCell={moveCell}
-            onClearPagePayload={clearPagePayload}
             onReportOutputMatchCount={globalFind.reportOutputMatchCount}
             onSetCellSourceHidden={setCellSourceHidden}
             onSetCellOutputsHidden={setCellOutputsHidden}

--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -1,5 +1,5 @@
 import type { EditorView, KeyBinding } from "@codemirror/view";
-import { ChevronRight, Code2, EyeOff, X } from "lucide-react";
+import { ChevronRight, Code2, EyeOff } from "lucide-react";
 import {
   lazy,
   memo,
@@ -22,10 +22,7 @@ import type { SupportedLanguage } from "@/components/editor/languages";
 import { remoteCursorsExtension } from "@/components/editor/remote-cursors";
 import { searchHighlight } from "@/components/editor/search-highlight";
 import { textAttributionExtension } from "@/components/editor/text-attribution";
-import { AnsiOutput } from "@/components/outputs/ansi-output";
-import { ErrorBoundary } from "@/lib/error-boundary";
 import { cn } from "@/lib/utils";
-import type { CellPagePayload, MimeBundle } from "../App";
 import { usePresenceContext } from "../contexts/PresenceContext";
 import { useCellKeyboardNavigation } from "../hooks/useCellKeyboardNavigation";
 import { useCrdtBridge } from "../hooks/useCrdtBridge";
@@ -33,6 +30,16 @@ import {
   registerAttributionEditor,
   unregisterAttributionEditor,
 } from "../lib/attribution-registry";
+import {
+  useIsCellExecuting,
+  useIsCellFocused,
+  useIsCellQueued,
+  useIsGroupExecuting,
+  useIsNextCellFromFocused,
+  useIsPreviousCellFromFocused,
+  useSearchActiveOffset,
+  useSearchQuery,
+} from "../lib/cell-ui-state";
 import { registerEditor, unregisterEditor } from "../lib/cursor-registry";
 import { kernelCompletionExtension } from "../lib/kernel-completion";
 import { openUrl } from "../lib/open-url";
@@ -49,55 +56,9 @@ const HistorySearchDialog = lazy(() =>
   })),
 );
 
-/** Page payload display component - Zed REPL style */
-function PagePayloadDisplay({
-  data,
-  onDismiss,
-}: {
-  data: MimeBundle;
-  onDismiss: () => void;
-}) {
-  const htmlContent = data["text/html"];
-  const textContent = data["text/plain"];
-
-  return (
-    <div className="cm-page-payload">
-      <div className="cm-page-payload-content">
-        {typeof htmlContent === "string" ? (
-          <div dangerouslySetInnerHTML={{ __html: htmlContent }} />
-        ) : typeof textContent === "string" ? (
-          <AnsiOutput className="cm-page-payload-text">
-            {textContent}
-          </AnsiOutput>
-        ) : (
-          <pre className="cm-page-payload-text">
-            {JSON.stringify(data, null, 2)}
-          </pre>
-        )}
-      </div>
-      <div className="cm-page-payload-gutter">
-        <button
-          type="button"
-          className="cm-page-payload-dismiss"
-          onClick={onDismiss}
-          title="Dismiss (Escape)"
-        >
-          <X className="h-3 w-3" />
-        </button>
-      </div>
-    </div>
-  );
-}
-
 interface CodeCellProps {
   cell: CodeCellType;
   language?: SupportedLanguage;
-  isFocused: boolean;
-  isExecuting: boolean;
-  isQueued: boolean;
-  pagePayload: CellPagePayload | null;
-  searchQuery?: string;
-  searchActiveOffset?: number;
   onSearchMatchCount?: (count: number) => void;
   onFocus: () => void;
   onExecute: () => void;
@@ -106,12 +67,7 @@ interface CodeCellProps {
   onFocusPrevious?: (cursorPosition: "start" | "end") => void;
   onFocusNext?: (cursorPosition: "start" | "end") => void;
   onInsertCellAfter?: () => void;
-  onClearPagePayload?: () => void;
   isLastCell?: boolean;
-  /** Whether this cell is immediately before the focused cell */
-  isPreviousCellFromFocused?: boolean;
-  /** Whether this cell is immediately after the focused cell */
-  isNextCellFromFocused?: boolean;
   /** Props for dnd-kit drag handle (applied to ribbon) */
   dragHandleProps?: Record<string, unknown>;
   /** Whether this cell is currently being dragged */
@@ -124,8 +80,8 @@ interface CodeCellProps {
   hiddenGroupCount?: number;
   /** Callback to expand all cells in a hidden group */
   onExpandHiddenGroup?: () => void;
-  /** Whether any cell in a hidden group is currently executing */
-  isGroupExecuting?: boolean;
+  /** Cell IDs in this hidden group (for executing indicator) */
+  hiddenGroupCellIds?: string[];
   /** Number of error outputs across all cells in a hidden group */
   hiddenGroupErrorCount?: number;
   /** Content for the right gutter (e.g., delete button, source toggle) */
@@ -135,12 +91,6 @@ interface CodeCellProps {
 export const CodeCell = memo(function CodeCell({
   cell,
   language = "python",
-  isFocused,
-  isExecuting,
-  isQueued,
-  pagePayload,
-  searchQuery,
-  searchActiveOffset = -1,
   onSearchMatchCount,
   onFocus,
   onExecute,
@@ -149,20 +99,26 @@ export const CodeCell = memo(function CodeCell({
   onFocusPrevious,
   onFocusNext,
   onInsertCellAfter,
-  onClearPagePayload,
   isLastCell = false,
-  isPreviousCellFromFocused,
-  isNextCellFromFocused,
   dragHandleProps,
   isDragging,
   onToggleSourceHidden,
   onToggleOutputsHidden,
   hiddenGroupCount,
   onExpandHiddenGroup,
-  isGroupExecuting,
+  hiddenGroupCellIds,
   hiddenGroupErrorCount,
   rightGutterContent,
 }: CodeCellProps) {
+  // Read transient UI state from the store
+  const isFocused = useIsCellFocused(cell.id);
+  const isExecuting = useIsCellExecuting(cell.id);
+  const isQueued = useIsCellQueued(cell.id);
+  const isPreviousCellFromFocused = useIsPreviousCellFromFocused(cell.id);
+  const isNextCellFromFocused = useIsNextCellFromFocused(cell.id);
+  const searchQuery = useSearchQuery();
+  const searchActiveOffset = useSearchActiveOffset(cell.id);
+  const isGroupExecuting = useIsGroupExecuting(hiddenGroupCellIds);
   const editorRef = useRef<CodeMirrorEditorRef>(null);
   const [historyDialogOpen, setHistoryDialogOpen] = useState(false);
   const presence = usePresenceContext();
@@ -225,27 +181,6 @@ export const CodeCell = memo(function CodeCell({
     };
   }, [cell.id]);
 
-  // Handle Escape key to dismiss page payload
-  useEffect(() => {
-    if (!pagePayload || !isFocused) return;
-
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        e.preventDefault();
-        onClearPagePayload?.();
-      }
-    };
-
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [pagePayload, isFocused, onClearPagePayload]);
-
-  // Clear page payload when cell is executed (before new results come in)
-  const handleExecuteWithClear = useCallback(() => {
-    onClearPagePayload?.();
-    onExecute();
-  }, [onExecute, onClearPagePayload]);
-
   // Handle focus next, creating a new cell if at the end
   const handleFocusNextOrCreate = useCallback(
     (cursorPosition: "start" | "end") => {
@@ -262,10 +197,10 @@ export const CodeCell = memo(function CodeCell({
   const navigationKeyMap = useCellKeyboardNavigation({
     onFocusPrevious: onFocusPrevious ?? (() => {}),
     onFocusNext: handleFocusNextOrCreate,
-    onExecute: handleExecuteWithClear,
+    onExecute: onExecute,
     onExecuteAndInsert: onInsertCellAfter
       ? () => {
-          handleExecuteWithClear();
+          onExecute();
           onInsertCellAfter();
         }
       : undefined,
@@ -337,10 +272,6 @@ export const CodeCell = memo(function CodeCell({
     ],
   );
 
-  const handleExecute = useCallback(() => {
-    handleExecuteWithClear();
-  }, [handleExecuteWithClear]);
-
   const handleLinkClick = useCallback((url: string) => openUrl(url), []);
 
   const gutterContent = bothHidden ? null : (
@@ -348,7 +279,7 @@ export const CodeCell = memo(function CodeCell({
       count={cell.execution_count}
       isExecuting={isExecuting}
       isQueued={isQueued}
-      onExecute={handleExecute}
+      onExecute={onExecute}
       onInterrupt={onInterrupt}
     />
   );
@@ -432,25 +363,6 @@ export const CodeCell = memo(function CodeCell({
                 placeholder="Enter code..."
                 autoFocus={isFocused}
               />
-            )}
-
-            {/* Page Payload (documentation from ? or ??) */}
-            {pagePayload && (
-              <div className="px-2 py-1">
-                <ErrorBoundary
-                  resetKeys={[pagePayload.data]}
-                  fallback={() => (
-                    <div className="text-xs text-muted-foreground italic px-1 py-2">
-                      Failed to render documentation
-                    </div>
-                  )}
-                >
-                  <PagePayloadDisplay
-                    data={pagePayload.data}
-                    onDismiss={() => onClearPagePayload?.()}
-                  />
-                </ErrorBoundary>
-              </div>
             )}
           </>
         }

--- a/apps/notebook/src/components/MarkdownCell.tsx
+++ b/apps/notebook/src/components/MarkdownCell.tsx
@@ -28,6 +28,12 @@ import {
   unregisterAttributionEditor,
 } from "../lib/attribution-registry";
 import { useBlobPort } from "../lib/blob-port";
+import {
+  useIsCellFocused,
+  useIsNextCellFromFocused,
+  useIsPreviousCellFromFocused,
+  useSearchQuery,
+} from "../lib/cell-ui-state";
 import { registerEditor, unregisterEditor } from "../lib/cursor-registry";
 import { logger } from "../lib/logger";
 import { rewriteMarkdownAssetRefs } from "../lib/markdown-assets";
@@ -41,18 +47,12 @@ const handleIframeError = (err: { message: string; stack?: string }) =>
 
 interface MarkdownCellProps {
   cell: MarkdownCellType;
-  isFocused: boolean;
-  searchQuery?: string;
   onFocus: () => void;
   onDelete: () => void;
   onFocusPrevious?: (cursorPosition: "start" | "end") => void;
   onFocusNext?: (cursorPosition: "start" | "end") => void;
   onInsertCellAfter?: () => void;
   isLastCell?: boolean;
-  /** Whether this cell is immediately before the focused cell */
-  isPreviousCellFromFocused?: boolean;
-  /** Whether this cell is immediately after the focused cell */
-  isNextCellFromFocused?: boolean;
   /** Props for dnd-kit drag handle (applied to ribbon) */
   dragHandleProps?: Record<string, unknown>;
   /** Whether this cell is currently being dragged */
@@ -63,20 +63,20 @@ interface MarkdownCellProps {
 
 export const MarkdownCell = memo(function MarkdownCell({
   cell,
-  isFocused,
-  searchQuery,
   onFocus,
   onDelete,
   onFocusPrevious,
   onFocusNext,
   onInsertCellAfter,
   isLastCell = false,
-  isPreviousCellFromFocused,
-  isNextCellFromFocused,
   dragHandleProps,
   isDragging,
   rightGutterContent,
 }: MarkdownCellProps) {
+  const isFocused = useIsCellFocused(cell.id);
+  const isPreviousCellFromFocused = useIsPreviousCellFromFocused(cell.id);
+  const isNextCellFromFocused = useIsNextCellFromFocused(cell.id);
+  const searchQuery = useSearchQuery();
   const applyInlineFormatting = useCallback(
     (prefix: string, suffix = prefix) =>
       (view: EditorView) => {

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -22,12 +22,11 @@ import { Button } from "@/components/ui/button";
 import type { Runtime } from "@/hooks/useSyncedSettings";
 import { ErrorBoundary } from "@/lib/error-boundary";
 import { cn } from "@/lib/utils";
-import type { CellPagePayload } from "../App";
 import {
   EditorRegistryProvider,
   useEditorRegistry,
 } from "../hooks/useEditorRegistry";
-import type { FindMatch } from "../hooks/useGlobalFind";
+import { useFocusedCellId, useSearchCurrentMatch } from "../lib/cell-ui-state";
 import { logger } from "../lib/logger";
 import {
   getNotebookCellsSnapshot,
@@ -43,20 +42,13 @@ import { RawCell } from "./RawCell";
 interface NotebookViewProps {
   cellIds: string[];
   isLoading?: boolean;
-  focusedCellId: string | null;
-  executingCellIds: Set<string>;
-  queuedCellIds: Set<string>;
-  pagePayloads: Map<string, CellPagePayload>;
   runtime?: Runtime | null;
-  searchQuery?: string;
-  searchCurrentMatch?: FindMatch | null;
   onFocusCell: (cellId: string) => void;
   onExecuteCell: (cellId: string) => void;
   onInterruptKernel: () => void;
   onDeleteCell: (cellId: string) => void;
   onAddCell: (type: "code" | "markdown", afterCellId?: string | null) => void;
   onMoveCell: (cellId: string, afterCellId?: string | null) => void;
-  onClearPagePayload: (cellId: string) => void;
   onReportOutputMatchCount?: (cellId: string, count: number) => void;
   onSetCellSourceHidden?: (cellId: string, hidden: boolean) => void;
   onSetCellOutputsHidden?: (cellId: string, hidden: boolean) => void;
@@ -358,20 +350,13 @@ function SortableCell({
 function NotebookViewContent({
   cellIds,
   isLoading = false,
-  focusedCellId,
-  executingCellIds,
-  queuedCellIds,
-  pagePayloads,
   runtime = "python",
-  searchQuery,
-  searchCurrentMatch,
   onFocusCell,
   onExecuteCell,
   onInterruptKernel,
   onDeleteCell,
   onAddCell,
   onMoveCell,
-  onClearPagePayload,
   onReportOutputMatchCount,
   onSetCellSourceHidden,
   onSetCellOutputsHidden,
@@ -379,6 +364,10 @@ function NotebookViewContent({
   const containerRef = useRef<HTMLDivElement>(null);
   // Track whether focus change was keyboard-driven (should scroll) or mouse-driven (already visible)
   const focusSourceRef = useRef<"mouse" | "keyboard">("keyboard");
+
+  // Read transient UI state from the store instead of props
+  const focusedCellId = useFocusedCellId();
+  const searchCurrentMatch = useSearchCurrentMatch();
   // Ref for cellIds so renderCell can read the latest list without
   // depending on the array identity. This prevents recreating
   // renderCell (and remounting widget iframes) on structural changes.
@@ -486,22 +475,6 @@ function NotebookViewContent({
   const hiddenGroupsRef = useRef(hiddenGroups);
   hiddenGroupsRef.current = hiddenGroups;
 
-  // Compute the cell ID that precedes the focused cell (keeps its output bright)
-  const previousCellId = useMemo(() => {
-    if (!focusedCellId) return null;
-    const focusedIndex = cellIds.indexOf(focusedCellId);
-    return focusedIndex > 0 ? cellIds[focusedIndex - 1] : null;
-  }, [focusedCellId, cellIds]);
-
-  // Compute the cell ID that follows the focused cell (keeps its output bright)
-  const nextCellId = useMemo(() => {
-    if (!focusedCellId) return null;
-    const focusedIndex = cellIds.indexOf(focusedCellId);
-    return focusedIndex >= 0 && focusedIndex < cellIds.length - 1
-      ? cellIds[focusedIndex + 1]
-      : null;
-  }, [focusedCellId, cellIds]);
-
   // Prevent horizontal scroll drift (can happen during text selection)
   useEffect(() => {
     const container = containerRef.current;
@@ -571,10 +544,6 @@ function NotebookViewContent({
       dragHandleProps?: Record<string, unknown>,
       isDragging?: boolean,
     ) => {
-      const isFocused = cell.id === focusedCellId;
-      const isExecuting = executingCellIds.has(cell.id);
-      const isQueued = queuedCellIds.has(cell.id);
-
       // Navigation callbacks — skip cells that are collapsed into a hidden group
       const isVisibleCell = (id: string) => {
         const g = hiddenGroupsRef.current.get(id);
@@ -679,29 +648,13 @@ function NotebookViewContent({
       }
 
       if (cell.cell_type === "code") {
-        const pagePayload = pagePayloads.get(cell.id) ?? null;
         // Use TypeScript for Deno, IPython otherwise (for magic/shell highlighting)
         const language = runtime === "deno" ? "typescript" : "ipython";
-        // Determine active match offset for this cell's source
-        const activeSourceOffset =
-          searchCurrentMatch &&
-          searchCurrentMatch.cellId === cell.id &&
-          searchCurrentMatch.type === "source"
-            ? searchCurrentMatch.offset
-            : -1;
         return (
           <CodeCell
             key={cell.id}
             cell={cell}
             language={language}
-            isFocused={isFocused}
-            isPreviousCellFromFocused={cell.id === previousCellId}
-            isNextCellFromFocused={cell.id === nextCellId}
-            isExecuting={isExecuting}
-            isQueued={isQueued}
-            pagePayload={pagePayload}
-            searchQuery={searchQuery}
-            searchActiveOffset={activeSourceOffset}
             onSearchMatchCount={
               onReportOutputMatchCount
                 ? (count: number) => onReportOutputMatchCount(cell.id, count)
@@ -717,7 +670,6 @@ function NotebookViewContent({
             onFocusPrevious={onFocusPrevious}
             onFocusNext={onFocusNext}
             onInsertCellAfter={() => onAddCell("code", cell.id)}
-            onClearPagePayload={() => onClearPagePayload(cell.id)}
             isLastCell={index === cellIdsRef.current.length - 1}
             dragHandleProps={dragHandleProps}
             isDragging={isDragging}
@@ -736,10 +688,8 @@ function NotebookViewContent({
             hiddenGroupErrorCount={
               hiddenGroupsRef.current.get(cell.id)?.errorCount
             }
-            isGroupExecuting={
-              hiddenGroupsRef.current
-                .get(cell.id)
-                ?.groupCellIds.some((id) => executingCellIds.has(id)) ?? false
+            hiddenGroupCellIds={
+              hiddenGroupsRef.current.get(cell.id)?.groupCellIds
             }
             onExpandHiddenGroup={
               hiddenGroupsRef.current.has(cell.id) &&
@@ -765,10 +715,6 @@ function NotebookViewContent({
           <MarkdownCell
             key={cell.id}
             cell={cell}
-            isFocused={isFocused}
-            isPreviousCellFromFocused={cell.id === previousCellId}
-            isNextCellFromFocused={cell.id === nextCellId}
-            searchQuery={searchQuery}
             onFocus={() => {
               focusSourceRef.current = "mouse";
               onFocusCell(cell.id);
@@ -790,10 +736,6 @@ function NotebookViewContent({
         <RawCell
           key={cell.id}
           cell={cell}
-          isFocused={isFocused}
-          isPreviousCellFromFocused={cell.id === previousCellId}
-          isNextCellFromFocused={cell.id === nextCellId}
-          searchQuery={searchQuery}
           onFocus={() => {
             focusSourceRef.current = "mouse";
             onFocusCell(cell.id);
@@ -810,21 +752,12 @@ function NotebookViewContent({
       );
     },
     [
-      focusedCellId,
-      previousCellId,
-      nextCellId,
-      executingCellIds,
-      queuedCellIds,
-      pagePayloads,
       runtime,
-      searchQuery,
-      searchCurrentMatch,
       onFocusCell,
       onExecuteCell,
       onInterruptKernel,
       onDeleteCell,
       onAddCell,
-      onClearPagePayload,
       onReportOutputMatchCount,
       onSetCellSourceHidden,
       onSetCellOutputsHidden,

--- a/apps/notebook/src/components/RawCell.tsx
+++ b/apps/notebook/src/components/RawCell.tsx
@@ -22,6 +22,12 @@ import {
   registerAttributionEditor,
   unregisterAttributionEditor,
 } from "../lib/attribution-registry";
+import {
+  useIsCellFocused,
+  useIsNextCellFromFocused,
+  useIsPreviousCellFromFocused,
+  useSearchQuery,
+} from "../lib/cell-ui-state";
 import { registerEditor, unregisterEditor } from "../lib/cursor-registry";
 import { detectRawFormat } from "../lib/detect-raw-format";
 import { presenceSenderExtension } from "../lib/presence-sender";
@@ -30,17 +36,15 @@ import { CellPresenceIndicators } from "./cell/CellPresenceIndicators";
 
 interface RawCellProps {
   cell: RawCellType;
-  isFocused: boolean;
-  searchQuery?: string;
   onFocus: () => void;
   onDelete: () => void;
   onFocusPrevious?: (cursorPosition: "start" | "end") => void;
   onFocusNext?: (cursorPosition: "start" | "end") => void;
   onInsertCellAfter?: () => void;
   isLastCell?: boolean;
-  isPreviousCellFromFocused?: boolean;
-  isNextCellFromFocused?: boolean;
+  /** Props for dnd-kit drag handle (applied to ribbon) */
   dragHandleProps?: Record<string, unknown>;
+  /** Whether this cell is currently being dragged */
   isDragging?: boolean;
   /** Content for the right gutter (e.g., delete button) */
   rightGutterContent?: ReactNode;
@@ -48,20 +52,20 @@ interface RawCellProps {
 
 export const RawCell = memo(function RawCell({
   cell,
-  isFocused,
-  searchQuery,
   onFocus,
   onDelete,
   onFocusPrevious,
   onFocusNext,
   onInsertCellAfter,
   isLastCell = false,
-  isPreviousCellFromFocused,
-  isNextCellFromFocused,
   dragHandleProps,
   isDragging,
   rightGutterContent,
 }: RawCellProps) {
+  const isFocused = useIsCellFocused(cell.id);
+  const isPreviousCellFromFocused = useIsPreviousCellFromFocused(cell.id);
+  const isNextCellFromFocused = useIsNextCellFromFocused(cell.id);
+  const searchQuery = useSearchQuery();
   const editorRef = useRef<CodeMirrorEditorRef>(null);
   const presence = usePresenceContext();
   const { extension: crdtBridgeExt } = useCrdtBridge(cell.id);

--- a/apps/notebook/src/lib/cell-ui-state.ts
+++ b/apps/notebook/src/lib/cell-ui-state.ts
@@ -171,9 +171,7 @@ function subscribeFocusFor(_cellId: string): (cb: () => void) => () => void {
 // Per-cell neighbor: subscribes to both focus changes AND structural changes
 // (cell add/delete/reorder). Without the structural subscription, inserting
 // or deleting a cell next to the focused cell wouldn't update the dimming.
-function subscribeNeighborFor(
-  _cellId: string,
-): (cb: () => void) => () => void {
+function subscribeNeighborFor(_cellId: string): (cb: () => void) => () => void {
   return (cb: () => void) => {
     _focusSubscribers.add(cb);
     const unsubIds = subscribeIds(cb);

--- a/apps/notebook/src/lib/cell-ui-state.ts
+++ b/apps/notebook/src/lib/cell-ui-state.ts
@@ -1,0 +1,301 @@
+import { useMemo, useSyncExternalStore } from "react";
+import type { FindMatch } from "../hooks/useGlobalFind";
+import { getCellIdsSnapshot } from "./notebook-cells";
+
+// ---------------------------------------------------------------------------
+// Transient UI state store for per-cell rendering state.
+//
+// This store holds state that changes frequently (focus, execution, search)
+// but is NOT persisted in the CRDT. Components subscribe to only the slices
+// they need via hooks, so e.g. focusing cell B does not re-render cell A.
+//
+// Same useSyncExternalStore pattern as notebook-cells.ts.
+// ---------------------------------------------------------------------------
+
+// ── Internal state ──────────────────────────────────────────────────────
+
+let _focusedCellId: string | null = null;
+let _executingCellIds: Set<string> = new Set();
+let _queuedCellIds: Set<string> = new Set();
+let _searchQuery: string | undefined; // eslint-disable-line -- intentionally uninitialized alongside siblings
+let _searchCurrentMatch: FindMatch | null = null;
+
+// ── Subscribers ─────────────────────────────────────────────────────────
+
+const _focusSubscribers = new Set<() => void>();
+const _executingSubscribers = new Set<() => void>();
+const _queuedSubscribers = new Set<() => void>();
+const _searchQuerySubscribers = new Set<() => void>();
+const _searchMatchSubscribers = new Set<() => void>();
+
+function emit(subs: Set<() => void>): void {
+  for (const cb of subs) cb();
+}
+
+// ── Setters (called from App.tsx render body) ───────────────────────────
+
+export function setFocusedCellId(id: string | null): void {
+  if (id === _focusedCellId) return;
+  _focusedCellId = id;
+  emit(_focusSubscribers);
+}
+
+export function setExecutingCellIds(ids: Set<string>): void {
+  _executingCellIds = ids;
+  emit(_executingSubscribers);
+}
+
+export function setQueuedCellIds(ids: Set<string>): void {
+  _queuedCellIds = ids;
+  emit(_queuedSubscribers);
+}
+
+export function setSearchQuery(query: string | undefined): void {
+  if (query === _searchQuery) return;
+  _searchQuery = query;
+  emit(_searchQuerySubscribers);
+}
+
+export function setSearchCurrentMatch(match: FindMatch | null): void {
+  _searchCurrentMatch = match;
+  emit(_searchMatchSubscribers);
+}
+
+// ── Snapshot readers (non-reactive) ─────────────────────────────────────
+
+export function getFocusedCellId(): string | null {
+  return _focusedCellId;
+}
+
+// ── Hooks ───────────────────────────────────────────────────────────────
+
+/** Subscribe to the focused cell ID. */
+export function useFocusedCellId(): string | null {
+  return useSyncExternalStore(subscribeFocus, getFocusSnapshot);
+}
+
+/** Returns true only when this specific cell is focused. */
+export function useIsCellFocused(cellId: string): boolean {
+  const subscribe = useMemo(() => subscribeFocusFor(cellId), [cellId]);
+  const getSnapshot = useMemo(() => getIsFocusedSnapshot(cellId), [cellId]);
+  return useSyncExternalStore(subscribe, getSnapshot);
+}
+
+/** Returns true only when this specific cell is executing. */
+export function useIsCellExecuting(cellId: string): boolean {
+  const subscribe = useMemo(() => subscribeExecutingFor(cellId), [cellId]);
+  const getSnapshot = useMemo(() => getIsExecutingSnapshot(cellId), [cellId]);
+  return useSyncExternalStore(subscribe, getSnapshot);
+}
+
+/** Returns true only when this specific cell is queued. */
+export function useIsCellQueued(cellId: string): boolean {
+  const subscribe = useMemo(() => subscribeQueuedFor(cellId), [cellId]);
+  const getSnapshot = useMemo(() => getIsQueuedSnapshot(cellId), [cellId]);
+  return useSyncExternalStore(subscribe, getSnapshot);
+}
+
+/** Subscribe to the search query string. */
+export function useSearchQuery(): string | undefined {
+  return useSyncExternalStore(subscribeSearchQuery, getSearchQuerySnapshot);
+}
+
+/** Subscribe to the current search match. */
+export function useSearchCurrentMatch(): FindMatch | null {
+  return useSyncExternalStore(subscribeSearchMatch, getSearchMatchSnapshot);
+}
+
+/** Returns true when this cell is immediately before the focused cell. */
+export function useIsPreviousCellFromFocused(cellId: string): boolean {
+  const subscribe = useMemo(() => subscribeFocusFor(cellId), [cellId]);
+  const getSnapshot = useMemo(() => getIsPreviousSnapshot(cellId), [cellId]);
+  return useSyncExternalStore(subscribe, getSnapshot);
+}
+
+/** Returns true when this cell is immediately after the focused cell. */
+export function useIsNextCellFromFocused(cellId: string): boolean {
+  const subscribe = useMemo(() => subscribeFocusFor(cellId), [cellId]);
+  const getSnapshot = useMemo(() => getIsNextSnapshot(cellId), [cellId]);
+  return useSyncExternalStore(subscribe, getSnapshot);
+}
+
+/**
+ * Returns the active source search offset for this cell, or -1.
+ * Only re-renders when the search match changes.
+ */
+export function useSearchActiveOffset(cellId: string): number {
+  const subscribe = useMemo(() => subscribeSearchMatchFor(cellId), [cellId]);
+  const getSnapshot = useMemo(
+    () => getSearchActiveOffsetSnapshot(cellId),
+    [cellId],
+  );
+  return useSyncExternalStore(subscribe, getSnapshot);
+}
+
+/**
+ * Returns true if any cell in the given group is executing.
+ * Re-renders when executing state changes.
+ */
+export function useIsGroupExecuting(
+  groupCellIds: string[] | undefined,
+): boolean {
+  const subscribe = useMemo(() => subscribeExecutingForGroup(), []);
+  const getSnapshot = useMemo(
+    () => getIsGroupExecutingSnapshot(groupCellIds),
+    [groupCellIds],
+  );
+  return useSyncExternalStore(subscribe, getSnapshot);
+}
+
+// ── Subscription helpers ────────────────────────────────────────────────
+
+function subscribeFocus(cb: () => void): () => void {
+  _focusSubscribers.add(cb);
+  return () => _focusSubscribers.delete(cb);
+}
+
+function getFocusSnapshot(): string | null {
+  return _focusedCellId;
+}
+
+// Per-cell focus: subscribes to the global focus change, but snapshot
+// returns a boolean — useSyncExternalStore only re-renders when the
+// boolean value changes (i.e. this cell gains or loses focus).
+function subscribeFocusFor(_cellId: string): (cb: () => void) => () => void {
+  return (cb: () => void) => {
+    _focusSubscribers.add(cb);
+    return () => _focusSubscribers.delete(cb);
+  };
+}
+
+function getIsFocusedSnapshot(cellId: string): () => boolean {
+  let prev = _focusedCellId === cellId;
+  return () => {
+    const next = _focusedCellId === cellId;
+    if (next !== prev) prev = next;
+    return prev;
+  };
+}
+
+function getIsPreviousSnapshot(cellId: string): () => boolean {
+  let prev = false;
+  return () => {
+    if (!_focusedCellId) {
+      if (prev) prev = false;
+      return prev;
+    }
+    const ids = getCellIdsSnapshot();
+    const focusedIndex = ids.indexOf(_focusedCellId);
+    const next = focusedIndex > 0 && ids[focusedIndex - 1] === cellId;
+    if (next !== prev) prev = next;
+    return prev;
+  };
+}
+
+function getIsNextSnapshot(cellId: string): () => boolean {
+  let prev = false;
+  return () => {
+    if (!_focusedCellId) {
+      if (prev) prev = false;
+      return prev;
+    }
+    const ids = getCellIdsSnapshot();
+    const focusedIndex = ids.indexOf(_focusedCellId);
+    const next =
+      focusedIndex >= 0 &&
+      focusedIndex < ids.length - 1 &&
+      ids[focusedIndex + 1] === cellId;
+    if (next !== prev) prev = next;
+    return prev;
+  };
+}
+
+function subscribeExecutingFor(
+  _cellId: string,
+): (cb: () => void) => () => void {
+  return (cb: () => void) => {
+    _executingSubscribers.add(cb);
+    return () => _executingSubscribers.delete(cb);
+  };
+}
+
+function getIsExecutingSnapshot(cellId: string): () => boolean {
+  let prev = _executingCellIds.has(cellId);
+  return () => {
+    const next = _executingCellIds.has(cellId);
+    if (next !== prev) prev = next;
+    return prev;
+  };
+}
+
+function subscribeExecutingForGroup(): (cb: () => void) => () => void {
+  return (cb: () => void) => {
+    _executingSubscribers.add(cb);
+    return () => _executingSubscribers.delete(cb);
+  };
+}
+
+function getIsGroupExecutingSnapshot(
+  groupCellIds: string[] | undefined,
+): () => boolean {
+  let prev = false;
+  return () => {
+    const next = groupCellIds?.some((id) => _executingCellIds.has(id)) ?? false;
+    if (next !== prev) prev = next;
+    return prev;
+  };
+}
+
+function subscribeQueuedFor(_cellId: string): (cb: () => void) => () => void {
+  return (cb: () => void) => {
+    _queuedSubscribers.add(cb);
+    return () => _queuedSubscribers.delete(cb);
+  };
+}
+
+function getIsQueuedSnapshot(cellId: string): () => boolean {
+  let prev = _queuedCellIds.has(cellId);
+  return () => {
+    const next = _queuedCellIds.has(cellId);
+    if (next !== prev) prev = next;
+    return prev;
+  };
+}
+
+function subscribeSearchQuery(cb: () => void): () => void {
+  _searchQuerySubscribers.add(cb);
+  return () => _searchQuerySubscribers.delete(cb);
+}
+
+function getSearchQuerySnapshot(): string | undefined {
+  return _searchQuery;
+}
+
+function subscribeSearchMatch(cb: () => void): () => void {
+  _searchMatchSubscribers.add(cb);
+  return () => _searchMatchSubscribers.delete(cb);
+}
+
+function getSearchMatchSnapshot(): FindMatch | null {
+  return _searchCurrentMatch;
+}
+
+function subscribeSearchMatchFor(
+  _cellId: string,
+): (cb: () => void) => () => void {
+  return (cb: () => void) => {
+    _searchMatchSubscribers.add(cb);
+    return () => _searchMatchSubscribers.delete(cb);
+  };
+}
+
+function getSearchActiveOffsetSnapshot(cellId: string): () => number {
+  let prev = -1;
+  return () => {
+    const m = _searchCurrentMatch;
+    const next =
+      m && m.cellId === cellId && m.type === "source" ? m.offset : -1;
+    if (next !== prev) prev = next;
+    return prev;
+  };
+}

--- a/apps/notebook/src/lib/cell-ui-state.ts
+++ b/apps/notebook/src/lib/cell-ui-state.ts
@@ -1,6 +1,6 @@
 import { useMemo, useSyncExternalStore } from "react";
 import type { FindMatch } from "../hooks/useGlobalFind";
-import { getCellIdsSnapshot } from "./notebook-cells";
+import { getCellIdsSnapshot, subscribeIds } from "./notebook-cells";
 
 // ---------------------------------------------------------------------------
 // Transient UI state store for per-cell rendering state.
@@ -107,14 +107,14 @@ export function useSearchCurrentMatch(): FindMatch | null {
 
 /** Returns true when this cell is immediately before the focused cell. */
 export function useIsPreviousCellFromFocused(cellId: string): boolean {
-  const subscribe = useMemo(() => subscribeFocusFor(cellId), [cellId]);
+  const subscribe = useMemo(() => subscribeNeighborFor(cellId), [cellId]);
   const getSnapshot = useMemo(() => getIsPreviousSnapshot(cellId), [cellId]);
   return useSyncExternalStore(subscribe, getSnapshot);
 }
 
 /** Returns true when this cell is immediately after the focused cell. */
 export function useIsNextCellFromFocused(cellId: string): boolean {
-  const subscribe = useMemo(() => subscribeFocusFor(cellId), [cellId]);
+  const subscribe = useMemo(() => subscribeNeighborFor(cellId), [cellId]);
   const getSnapshot = useMemo(() => getIsNextSnapshot(cellId), [cellId]);
   return useSyncExternalStore(subscribe, getSnapshot);
 }
@@ -165,6 +165,22 @@ function subscribeFocusFor(_cellId: string): (cb: () => void) => () => void {
   return (cb: () => void) => {
     _focusSubscribers.add(cb);
     return () => _focusSubscribers.delete(cb);
+  };
+}
+
+// Per-cell neighbor: subscribes to both focus changes AND structural changes
+// (cell add/delete/reorder). Without the structural subscription, inserting
+// or deleting a cell next to the focused cell wouldn't update the dimming.
+function subscribeNeighborFor(
+  _cellId: string,
+): (cb: () => void) => () => void {
+  return (cb: () => void) => {
+    _focusSubscribers.add(cb);
+    const unsubIds = subscribeIds(cb);
+    return () => {
+      _focusSubscribers.delete(cb);
+      unsubIds();
+    };
   };
 }
 

--- a/apps/notebook/src/lib/notebook-cells.ts
+++ b/apps/notebook/src/lib/notebook-cells.ts
@@ -316,6 +316,11 @@ export function getNotebookCellsSnapshot(): NotebookCell[] {
   return _cellIds.map((id) => _cellMap.get(id)!);
 }
 
+/** Read the current cell ID list (no subscription). */
+export function getCellIdsSnapshot(): string[] {
+  return _cellIds;
+}
+
 /** Get a single cell by ID (no subscription). */
 export function getCellById(id: string): NotebookCell | undefined {
   return _cellMap.get(id);

--- a/apps/notebook/src/lib/notebook-cells.ts
+++ b/apps/notebook/src/lib/notebook-cells.ts
@@ -100,7 +100,8 @@ export function useSourceVersion(): number {
 
 // ── Subscription helpers ────────────────────────────────────────────────
 
-function subscribeIds(callback: () => void): () => void {
+/** Subscribe to structural changes (add/delete/move). Exported for cell-ui-state neighbor hooks. */
+export function subscribeIds(callback: () => void): () => void {
   _idsSubscribers.add(callback);
   return () => _idsSubscribers.delete(callback);
 }


### PR DESCRIPTION
## Summary

- Introduces `cell-ui-state.ts` — a `useSyncExternalStore`-backed module for transient UI state (focus, executing, queued, search, previous/next neighbor)
- Cell components (CodeCell, MarkdownCell, RawCell) subscribe to their own slices via per-cell hooks, so focusing cell B no longer re-renders cell A
- `renderCell` dependency array drops from 20 deps to 10 stable references — its identity no longer changes on focus/execution/search, preventing widget iframe remounts
- Removes dead page payload code (`CellPagePayload`, `PagePayloadDisplay`, related state/props) — the daemon handles `?`/`??` responses via outputs

## Test plan

- [ ] Open notebook with anywidget/plotly output — widget should NOT re-render on focus change, cell execution, or search
- [ ] Add/delete cells — widget should NOT re-render
- [ ] Keyboard navigation (arrow keys, shift-enter) still works
- [ ] Output opacity dimming (focused/previous/next) still works
- [ ] Execution count badges and queued indicators still update
- [ ] Global find (Cmd+F) highlights and navigation still work
- [ ] Hidden cell groups expand/collapse correctly, show executing pulse
- [ ] Drag-and-drop reorder still works