### PR TITLE
feat(notebook-doc): add fork+merge to RuntimeStateDoc, convert error handlers

### DIFF
--- a/crates/notebook-doc/src/runtime_state.rs
+++ b/crates/notebook-doc/src/runtime_state.rs
@@ -307,8 +307,7 @@ impl RuntimeStateDoc {
     /// attributable and don't conflict with the parent's deterministic
     /// `"runtimed:state"` actor ID.
     pub fn set_actor(&mut self, label: &str) {
-        self.doc
-            .set_actor(ActorId::from(label.as_bytes()));
+        self.doc.set_actor(ActorId::from(label.as_bytes()));
     }
 
     // ── Helpers ─────────────────────────────────────────────────────
@@ -1496,7 +1495,10 @@ mod tests {
         doc.merge(&mut fork).unwrap();
 
         let state = doc.read_state();
-        assert_eq!(state.queue.executing.as_ref().map(|e| e.cell_id.as_str()), Some("cell-1"));
+        assert_eq!(
+            state.queue.executing.as_ref().map(|e| e.cell_id.as_str()),
+            Some("cell-1")
+        );
     }
 
     #[test]
@@ -1523,7 +1525,10 @@ mod tests {
 
         let state = doc.read_state();
         assert_eq!(state.kernel.status, "busy");
-        assert_eq!(state.queue.executing.as_ref().map(|e| e.cell_id.as_str()), Some("cell-1"));
+        assert_eq!(
+            state.queue.executing.as_ref().map(|e| e.cell_id.as_str()),
+            Some("cell-1")
+        );
     }
 
     #[test]

--- a/crates/notebook-doc/src/runtime_state.rs
+++ b/crates/notebook-doc/src/runtime_state.rs
@@ -258,6 +258,59 @@ impl RuntimeStateDoc {
         &mut self.doc
     }
 
+    // ── Fork + Merge ────────────────────────────────────────────────
+
+    /// Fork the document at its current state.
+    ///
+    /// Returns a new `RuntimeStateDoc` whose underlying `AutoCommit` is an
+    /// Automerge fork. Changes made on the fork are independent of the
+    /// original — call [`merge`](Self::merge) to reconcile them.
+    ///
+    /// **Important:** Forks inherit the parent's actor ID. Call
+    /// [`set_actor`](Self::set_actor) on the fork to assign a distinct
+    /// identity (e.g., `"runtimed:state:cell-error"`) before making any
+    /// mutations to avoid `DuplicateSeqNumber` errors on merge.
+    pub fn fork(&mut self) -> Self {
+        Self {
+            doc: self.doc.fork(),
+        }
+    }
+
+    /// Merge another `RuntimeStateDoc`'s changes into this one.
+    ///
+    /// Returns the change hashes that were applied. CRDT merge semantics
+    /// apply — concurrent writes to different keys compose cleanly.
+    pub fn merge(
+        &mut self,
+        other: &mut RuntimeStateDoc,
+    ) -> Result<Vec<automerge::ChangeHash>, AutomergeError> {
+        self.doc.merge(&mut other.doc)
+    }
+
+    /// Fork, apply mutations on the fork, and merge back.
+    ///
+    /// Convenience wrapper for synchronous fork+merge blocks. For async
+    /// gaps (where an `.await` separates the read from the write), use
+    /// [`fork`](Self::fork) and [`merge`](Self::merge) directly.
+    pub fn fork_and_merge<F>(&mut self, f: F)
+    where
+        F: FnOnce(&mut RuntimeStateDoc),
+    {
+        let mut fork = self.fork();
+        f(&mut fork);
+        let _ = self.merge(&mut fork);
+    }
+
+    /// Set the actor identity for this document.
+    ///
+    /// Forks should call this with a distinct label so their changes are
+    /// attributable and don't conflict with the parent's deterministic
+    /// `"runtimed:state"` actor ID.
+    pub fn set_actor(&mut self, label: &str) {
+        self.doc
+            .set_actor(ActorId::from(label.as_bytes()));
+    }
+
     // ── Helpers ─────────────────────────────────────────────────────
 
     /// Get the ObjId for a top-level map key.
@@ -1423,5 +1476,83 @@ mod tests {
         assert_eq!(es.status, "done");
         assert_eq!(es.success, Some(true));
         assert_eq!(es.execution_count, Some(3));
+    }
+
+    // ── Fork+Merge Tests ────────────────────────────────────────────
+
+    #[test]
+    fn test_fork_and_merge_basic() {
+        let mut doc = RuntimeStateDoc::new();
+
+        let mut fork = doc.fork();
+        fork.set_actor("runtimed:state:test");
+
+        let entry = QueueEntry {
+            cell_id: "cell-1".to_string(),
+            execution_id: "exec-1".to_string(),
+        };
+        fork.set_queue(Some(&entry), &[]);
+
+        doc.merge(&mut fork).unwrap();
+
+        let state = doc.read_state();
+        assert_eq!(state.queue.executing.as_ref().map(|e| e.cell_id.as_str()), Some("cell-1"));
+    }
+
+    #[test]
+    fn test_fork_and_merge_concurrent_writes() {
+        // Fork, write queue on fork AND kernel status on original,
+        // merge — both changes should be present.
+        let mut doc = RuntimeStateDoc::new();
+
+        let mut fork = doc.fork();
+        fork.set_actor("runtimed:state:test");
+
+        // Write queue on fork
+        let entry = QueueEntry {
+            cell_id: "cell-1".to_string(),
+            execution_id: "exec-1".to_string(),
+        };
+        fork.set_queue(Some(&entry), &[]);
+
+        // Write kernel status on original (concurrent)
+        doc.set_kernel_status("busy");
+
+        // Merge — both changes should compose
+        doc.merge(&mut fork).unwrap();
+
+        let state = doc.read_state();
+        assert_eq!(state.kernel.status, "busy");
+        assert_eq!(state.queue.executing.as_ref().map(|e| e.cell_id.as_str()), Some("cell-1"));
+    }
+
+    #[test]
+    fn test_fork_actor_distinct() {
+        let mut doc = RuntimeStateDoc::new();
+        let mut fork = doc.fork();
+
+        // Fork inherits parent actor — must set a distinct one
+        fork.set_actor("runtimed:state:cell-error");
+
+        // Verify the fork's actor is different from the parent
+        let parent_actor = format!("{}", doc.doc().get_actor());
+        let fork_actor = format!("{}", fork.doc().get_actor());
+        assert_ne!(parent_actor, fork_actor);
+    }
+
+    #[test]
+    fn test_fork_and_merge_closure() {
+        let mut doc = RuntimeStateDoc::new();
+
+        doc.fork_and_merge(|fork| {
+            fork.set_actor("runtimed:state:test");
+            fork.set_kernel_status("error");
+            fork.set_queue(None, &[]);
+            fork.set_execution_done("exec-1", false);
+        });
+
+        let state = doc.read_state();
+        assert_eq!(state.kernel.status, "error");
+        assert!(state.queue.executing.is_none());
     }
 }

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -463,6 +463,121 @@ async fn check_and_broadcast_sync_state(room: &NotebookRoom) {
     }
 }
 
+/// Handle CellError: clear queue on the kernel, mark executions as errored
+/// in state_doc using fork+merge to avoid async gaps between the kernel lock
+/// and the state_doc write.
+async fn apply_cell_error_to_state_doc(
+    room_kernel: &Arc<Mutex<Option<RoomKernel>>>,
+    room_state_doc: &Arc<RwLock<RuntimeStateDoc>>,
+    room_state_changed_tx: &broadcast::Sender<()>,
+) {
+    // Fork state_doc before the kernel lock so mutations compose
+    // with any concurrent state_doc writes.
+    let mut fork = {
+        let mut sd = room_state_doc.write().await;
+        let mut f = sd.fork();
+        f.set_actor("runtimed:state:cell-error");
+        f
+    };
+
+    // Read+mutate kernel state under its own lock
+    let cleared = {
+        let mut guard = room_kernel.lock().await;
+        if let Some(ref mut k) = *guard {
+            k.mark_execution_error();
+            let cleared = k.clear_queue();
+            if !cleared.is_empty() {
+                info!(
+                    "[notebook-sync] Cleared {} queued cells due to error",
+                    cleared.len()
+                );
+            }
+            let exec = k.executing_entry().map(|e| DocQueueEntry {
+                cell_id: e.cell_id,
+                execution_id: e.execution_id,
+            });
+            // Apply queue + execution state to fork (no state_doc lock needed)
+            fork.set_queue(exec.as_ref(), &[]);
+            cleared
+        } else {
+            vec![]
+        }
+    };
+
+    // Mark cleared executions as errored on the fork
+    for entry in &cleared {
+        fork.set_execution_done(&entry.execution_id, false);
+    }
+
+    // Merge fork back — concurrent state_doc writes compose via CRDT
+    {
+        let mut sd = room_state_doc.write().await;
+        if sd.merge(&mut fork).is_ok() {
+            let _ = room_state_changed_tx.send(());
+        }
+    }
+}
+
+/// Handle KernelDied: set error status, clear queue, mark all executions
+/// as errored using fork+merge. Returns env_source for presence update.
+async fn apply_kernel_died_to_state_doc(
+    room_kernel: &Arc<Mutex<Option<RoomKernel>>>,
+    room_state_doc: &Arc<RwLock<RuntimeStateDoc>>,
+    room_state_changed_tx: &broadcast::Sender<()>,
+    room_broadcast_tx: &broadcast::Sender<NotebookBroadcast>,
+) -> Option<String> {
+    // Fork state_doc before the kernel lock
+    let mut fork = {
+        let mut sd = room_state_doc.write().await;
+        let mut f = sd.fork();
+        f.set_actor("runtimed:state:kernel-died");
+        f
+    };
+
+    let (env_source, interrupted, cleared) = {
+        let mut guard = room_kernel.lock().await;
+        if let Some(ref mut k) = *guard {
+            let es = k.env_source().to_string();
+            let (interrupted, cleared) = k.kernel_died();
+            (Some(es), interrupted, cleared)
+        } else {
+            (None, None, vec![])
+        }
+    };
+
+    // Broadcast ExecutionDone for the interrupted execution (no lock needed)
+    if let Some((ref cell_id, ref execution_id)) = interrupted {
+        info!(
+            "[notebook-sync] Emitting ExecutionDone for interrupted cell {} ({})",
+            cell_id, execution_id
+        );
+        let _ = room_broadcast_tx.send(NotebookBroadcast::ExecutionDone {
+            cell_id: cell_id.clone(),
+            execution_id: execution_id.clone(),
+        });
+    }
+
+    // Apply all mutations on the fork
+    fork.set_kernel_status("error");
+    fork.set_queue(None, &[]);
+    if let Some((_, ref execution_id)) = interrupted {
+        fork.set_execution_done(execution_id, false);
+    }
+    for entry in &cleared {
+        fork.set_execution_done(&entry.execution_id, false);
+    }
+
+    // Merge fork back
+    {
+        let mut sd = room_state_doc.write().await;
+        if sd.merge(&mut fork).is_ok() {
+            let _ = room_state_changed_tx.send(());
+        }
+    }
+
+    env_source
+}
+
 /// Re-verify trust from the Automerge doc and update room.trust_state + RuntimeStateDoc.
 ///
 /// Called after every Automerge sync message to detect when the frontend writes
@@ -2485,90 +2600,22 @@ async fn auto_launch_kernel(
                                     "[notebook-sync] Cell error (stop-on-error): {} ({})",
                                     cell_id, execution_id
                                 );
-                                // Mark the execution as errored so execution_done() knows
-                                // to write success=false to the RuntimeStateDoc.
-                                let (executing_entry, cleared) = {
-                                    let mut guard = room_kernel.lock().await;
-                                    if let Some(ref mut k) = *guard {
-                                        k.mark_execution_error();
-                                        // Clear the queue to stop execution on error, which matches
-                                        // the behavior of manually-launched kernel handler.
-                                        let cleared = k.clear_queue();
-                                        if !cleared.is_empty() {
-                                            info!(
-                                                "[notebook-sync] Cleared {} queued cells due to error",
-                                                cleared.len()
-                                            );
-                                        }
-                                        let exec = k.executing_entry().map(|e| DocQueueEntry {
-                                            cell_id: e.cell_id,
-                                            execution_id: e.execution_id,
-                                        });
-                                        (exec, cleared)
-                                    } else {
-                                        (None, vec![])
-                                    }
-                                };
-                                // Write cleared queue to state doc and mark
-                                // cleared executions as errored.
-                                {
-                                    let mut sd = room_state_doc.write().await;
-                                    let mut changed = sd.set_queue(executing_entry.as_ref(), &[]);
-                                    for entry in &cleared {
-                                        changed |=
-                                            sd.set_execution_done(&entry.execution_id, false);
-                                    }
-                                    if changed {
-                                        let _ = room_state_changed_tx.send(());
-                                    }
-                                }
+                                apply_cell_error_to_state_doc(
+                                    &room_kernel,
+                                    &room_state_doc,
+                                    &room_state_changed_tx,
+                                )
+                                .await;
                             }
                             QueueCommand::KernelDied => {
                                 warn!("[notebook-sync] Kernel died, unblocking execution queue");
-                                let (env_source, interrupted, cleared) = {
-                                    let mut guard = room_kernel.lock().await;
-                                    if let Some(ref mut k) = *guard {
-                                        let es = k.env_source().to_string();
-                                        let (interrupted, cleared) = k.kernel_died();
-                                        (Some(es), interrupted, cleared)
-                                    } else {
-                                        (None, None, vec![])
-                                    }
-                                };
-                                // Emit ExecutionDone for the interrupted execution so
-                                // clients tracking by execution_id get a terminal signal.
-                                if let Some((ref cell_id, ref execution_id)) = interrupted {
-                                    info!(
-                                        "[notebook-sync] Emitting ExecutionDone for interrupted cell {} ({})",
-                                        cell_id, execution_id
-                                    );
-                                    let _ =
-                                        room_broadcast_tx.send(NotebookBroadcast::ExecutionDone {
-                                            cell_id: cell_id.clone(),
-                                            execution_id: execution_id.clone(),
-                                        });
-                                }
-                                // Write error status + cleared queue to state doc,
-                                // and mark all interrupted/cleared executions as errored.
-                                {
-                                    let mut sd = room_state_doc.write().await;
-                                    let mut changed = false;
-                                    changed |= sd.set_kernel_status("error");
-                                    changed |= sd.set_queue(None, &[]);
-                                    // Mark the interrupted execution as errored
-                                    if let Some((_, ref execution_id)) = interrupted {
-                                        changed |= sd.set_execution_done(execution_id, false);
-                                    }
-                                    // Mark all cleared queued executions as errored
-                                    for entry in &cleared {
-                                        changed |=
-                                            sd.set_execution_done(&entry.execution_id, false);
-                                    }
-                                    if changed {
-                                        let _ = room_state_changed_tx.send(());
-                                    }
-                                }
-                                // Update presence outside the kernel lock
+                                let env_source = apply_kernel_died_to_state_doc(
+                                    &room_kernel,
+                                    &room_state_doc,
+                                    &room_state_changed_tx,
+                                    &room_broadcast_tx,
+                                )
+                                .await;
                                 if let Some(es) = env_source {
                                     update_kernel_presence(
                                         &room_presence,
@@ -3320,93 +3367,22 @@ async fn handle_notebook_request(
                                             "[notebook-sync] Cell error (stop-on-error): {} ({})",
                                             cell_id, execution_id
                                         );
-                                        // Mark the execution as errored so execution_done() knows
-                                        // to write success=false to the RuntimeStateDoc.
-                                        let (executing_entry, cleared) = {
-                                            let mut guard = room_kernel.lock().await;
-                                            if let Some(ref mut k) = *guard {
-                                                k.mark_execution_error();
-                                                // Clear the queue to stop execution on error
-                                                let cleared = k.clear_queue();
-                                                if !cleared.is_empty() {
-                                                    info!(
-                                                        "[notebook-sync] Cleared {} queued cells due to error",
-                                                        cleared.len()
-                                                    );
-                                                }
-                                                let exec =
-                                                    k.executing_entry().map(|e| DocQueueEntry {
-                                                        cell_id: e.cell_id,
-                                                        execution_id: e.execution_id,
-                                                    });
-                                                (exec, cleared)
-                                            } else {
-                                                (None, vec![])
-                                            }
-                                        };
-                                        // Write cleared queue to state doc and mark
-                                        // cleared executions as errored.
-                                        {
-                                            let mut sd = room_state_doc.write().await;
-                                            let mut changed =
-                                                sd.set_queue(executing_entry.as_ref(), &[]);
-                                            for entry in &cleared {
-                                                changed |= sd
-                                                    .set_execution_done(&entry.execution_id, false);
-                                            }
-                                            if changed {
-                                                let _ = room_state_changed_tx.send(());
-                                            }
-                                        }
+                                        apply_cell_error_to_state_doc(
+                                            &room_kernel,
+                                            &room_state_doc,
+                                            &room_state_changed_tx,
+                                        )
+                                        .await;
                                     }
                                     QueueCommand::KernelDied => {
                                         warn!("[notebook-sync] Kernel died, unblocking execution queue");
-                                        let (env_source, interrupted, cleared) = {
-                                            let mut guard = room_kernel.lock().await;
-                                            if let Some(ref mut k) = *guard {
-                                                let es = k.env_source().to_string();
-                                                let (interrupted, cleared) = k.kernel_died();
-                                                (Some(es), interrupted, cleared)
-                                            } else {
-                                                (None, None, vec![])
-                                            }
-                                        };
-                                        // Emit ExecutionDone for the interrupted execution so
-                                        // clients tracking by execution_id get a terminal signal.
-                                        if let Some((ref cell_id, ref execution_id)) = interrupted {
-                                            info!(
-                                                "[notebook-sync] Emitting ExecutionDone for interrupted cell {} ({})",
-                                                cell_id, execution_id
-                                            );
-                                            let _ = room_broadcast_tx.send(
-                                                NotebookBroadcast::ExecutionDone {
-                                                    cell_id: cell_id.clone(),
-                                                    execution_id: execution_id.clone(),
-                                                },
-                                            );
-                                        }
-                                        // Write error status + cleared queue to state doc,
-                                        // and mark all interrupted/cleared executions as errored.
-                                        {
-                                            let mut sd = room_state_doc.write().await;
-                                            let mut changed = false;
-                                            changed |= sd.set_kernel_status("error");
-                                            changed |= sd.set_queue(None, &[]);
-                                            // Mark the interrupted execution as errored
-                                            if let Some((_, ref execution_id)) = interrupted {
-                                                changed |=
-                                                    sd.set_execution_done(execution_id, false);
-                                            }
-                                            // Mark all cleared queued executions as errored
-                                            for entry in &cleared {
-                                                changed |= sd
-                                                    .set_execution_done(&entry.execution_id, false);
-                                            }
-                                            if changed {
-                                                let _ = room_state_changed_tx.send(());
-                                            }
-                                        }
-                                        // Update presence outside the kernel lock
+                                        let env_source = apply_kernel_died_to_state_doc(
+                                            &room_kernel,
+                                            &room_state_doc,
+                                            &room_state_changed_tx,
+                                            &room_broadcast_tx,
+                                        )
+                                        .await;
                                         if let Some(es) = env_source {
                                             update_kernel_presence(
                                                 &room_presence,


### PR DESCRIPTION
## Summary

- **Adds `fork()`, `merge()`, `fork_and_merge()`, and `set_actor()` to RuntimeStateDoc**, mirroring the NotebookDoc API. Forks must call `set_actor()` with a distinct label before mutating to avoid `DuplicateSeqNumber` errors with the parent's deterministic `"runtimed:state"` actor.
- **Converts CellError and KernelDied handlers** to use fork+merge, eliminating the async gap between reading kernel state (under kernel lock) and writing state_doc (under a separate state_doc lock). Previously, another task could queue new cells or start executing between the two locks.
- **Extracts `apply_cell_error_to_state_doc()` and `apply_kernel_died_to_state_doc()` helpers**, replacing 4 duplicated 30+ line blocks with single-line calls. Net -19 lines.

## Context

RuntimeStateDoc is a per-notebook Automerge document synced to all peers. While daemon-authoritative, the daemon's own concurrent tasks (execution queue processing, error handlers, kernel lifecycle) can race on state_doc writes when they read kernel state under one lock, release it, then write state_doc under another. Fork+merge treats these as concurrent branches that compose via CRDT merge.

Audit of all 20 RuntimeStateDoc write sites found only the CellError/KernelDied handlers have actual async gaps that benefit from fork+merge. Other write sites are either synchronous within a single lock scope (env sync, trust), or safe by design (kernel status transitions).

## Test plan

- [x] `cargo check -p runtimed` — compiles
- [x] `cargo test -p notebook-doc` — 241 tests pass (includes 4 new RuntimeStateDoc fork+merge tests)
- [x] `cargo test -p runtimed --lib` — 283 tests pass
- [x] `cargo xtask lint` — clean
- [ ] Manual: trigger cell errors and kernel crashes, verify state_doc updates correctly

Refs #1216