### PR TITLE
fix(notebook-sync): complete recovery in client-side panic guards

### DIFF
--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -936,9 +936,11 @@ impl NotebookDoc {
     /// This is the document-level equivalent of automerge-repo's
     /// `decodeSyncState(encodeSyncState(state))` round-trip hack.
     pub fn rebuild_from_save(&mut self) -> bool {
+        let actor = self.doc.get_actor().clone();
         let bytes = self.doc.save();
         match AutoCommit::load(&bytes) {
-            Ok(doc) => {
+            Ok(mut doc) => {
+                doc.set_actor(actor);
                 self.doc = doc;
                 true
             }

--- a/crates/notebook-doc/src/runtime_state.rs
+++ b/crates/notebook-doc/src/runtime_state.rs
@@ -306,9 +306,11 @@ impl RuntimeStateDoc {
     /// Used after catching an automerge panic (upstream MissingOps bug in
     /// `collector.rs`). See `NotebookDoc::rebuild_from_save` for details.
     pub fn rebuild_from_save(&mut self) -> bool {
+        let actor = self.doc.get_actor().clone();
         let bytes = self.doc.save();
         match AutoCommit::load(&bytes) {
-            Ok(doc) => {
+            Ok(mut doc) => {
+                doc.set_actor(actor);
                 self.doc = doc;
                 true
             }

--- a/crates/notebook-sync/src/sync_task.rs
+++ b/crates/notebook-sync/src/sync_task.rs
@@ -29,9 +29,30 @@ use tokio::sync::{broadcast, mpsc, oneshot};
 use notebook_protocol::connection::{self, NotebookFrameType};
 use notebook_protocol::protocol::{NotebookBroadcast, NotebookRequest, NotebookResponse};
 
+use automerge::AutoCommit;
+
 use crate::error::SyncError;
 use crate::shared::SharedDocState;
 use crate::snapshot::NotebookSnapshot;
+
+/// Rebuild a `SharedDocState` after an automerge panic by round-tripping
+/// save→load to clear corrupted internal indices, then resetting the
+/// peer sync state to force a fresh handshake with the daemon.
+fn rebuild_shared_doc_state(state: &mut SharedDocState) {
+    let actor = state.doc.get_actor().clone();
+    let bytes = state.doc.save();
+    match AutoCommit::load(&bytes) {
+        Ok(mut doc) => {
+            doc.set_actor(actor);
+            state.doc = doc;
+            state.peer_state = sync::State::new();
+            info!("[notebook-sync] Rebuilt doc and reset sync state after automerge panic");
+        }
+        Err(e) => {
+            warn!("[notebook-sync] Failed to rebuild doc after panic: {}", e);
+        }
+    }
+}
 
 /// Commands that require socket I/O (not document mutations).
 ///
@@ -355,6 +376,9 @@ async fn handle_incoming_frame<W: AsyncWrite + Unpin>(
                              (upstream bug automerge/automerge#1187): {}",
                             notebook_id, msg
                         );
+                        // Rebuild doc via save→load to clear corrupted indices,
+                        // then reset peer state to force a fresh sync handshake.
+                        rebuild_shared_doc_state(&mut state);
                         return;
                     }
                 }
@@ -370,6 +394,7 @@ async fn handle_incoming_frame<W: AsyncWrite + Unpin>(
                              (upstream MissingOps bug)",
                             notebook_id
                         );
+                        rebuild_shared_doc_state(&mut state);
                         None
                     }
                 }
@@ -622,6 +647,7 @@ async fn wait_for_response<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
                                  (upstream bug): {}",
                                 notebook_id, msg
                             );
+                            rebuild_shared_doc_state(&mut state);
                             continue;
                         }
                     }
@@ -635,6 +661,7 @@ async fn wait_for_response<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
                                 "[notebook-sync] generate_sync_message panicked in wait_for_response for {}",
                                 notebook_id
                             );
+                            rebuild_shared_doc_state(&mut state);
                             None
                         }
                     }


### PR DESCRIPTION
## Summary

Addresses two issues from Codex review of #1241:

- **P1**: Client-side `catch_unwind` in `sync_task.rs` only logged the panic without rebuilding the doc or resetting `peer_state`, leaving the session permanently desynced. Now calls `rebuild_shared_doc_state()` which does save→load + peer_state reset, matching the daemon-side recovery pattern.
- **P2**: `rebuild_from_save()` used plain `AutoCommit::load()` which assigns a fresh random actor, losing the deterministic actor label (e.g. `"runtimed"`, `"runtimed:state"`). Now preserves the actor ID across the save→load round-trip.

## Test plan

- [x] `cargo check -p notebook-doc -p notebook-sync`
- [x] `cargo test -p notebook-doc` — 245 tests pass
- [x] `cargo test -p notebook-sync` — 31 tests pass
- [x] `cargo xtask lint` — clean