### PR TITLE
fix(runtimed): capture backtrace in panic hook for crash diagnostics

### DIFF
--- a/crates/runtimed/src/main.rs
+++ b/crates/runtimed/src/main.rs
@@ -149,7 +149,8 @@ async fn main() -> anyhow::Result<()> {
 
         let log_path = early_log_path();
         let timestamp = chrono::Local::now().format("%Y-%m-%d %H:%M:%S");
-        let msg = format!("{} [PANIC] runtimed: {}", timestamp, panic_info);
+        let bt = std::backtrace::Backtrace::force_capture();
+        let msg = format!("{} [PANIC] runtimed: {}\n{}", timestamp, panic_info, bt);
 
         // Write to stderr (visible in terminal)
         eprintln!("{}", msg);


### PR DESCRIPTION
## Summary

- The custom panic hook replaced Rust's default hook, so `RUST_BACKTRACE=1` had no effect — panics were logged without stack traces
- Uses `Backtrace::force_capture()` to always include the backtrace in the `[PANIC]` log line, regardless of env var

## Context

We're still hitting MissingOps panics in production despite the catch_unwind guards from #1241. The panic bypasses our guards, meaning there's an unguarded code path. Without a backtrace we can't tell which path it is — this one-line fix gives us full stack traces on every crash.

## Test plan

- [x] `cargo check -p runtimed`
- [ ] Trigger a panic and verify backtrace appears in runtimed.log