### PR TITLE
fix(runtimed): refresh saved sources baseline on order-rebuild path

### DIFF
--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -6098,6 +6098,15 @@ async fn apply_ipynb_changes(
             warn!("{}", e);
             doc.rebuild_from_save();
         }
+
+        // Update saved_sources baseline so subsequent external edits are
+        // detected correctly (same as the non-order-change path).
+        let mut saved = room.last_save_sources.write().await;
+        saved.clear();
+        for ext_cell in external_cells {
+            saved.insert(ext_cell.id.clone(), ext_cell.source.clone());
+        }
+
         return true;
     }
 


### PR DESCRIPTION
## Summary

Updates `last_save_sources` on the order-change early-return path, matching the fix from #1249 for the non-order-change path.

Without this, an external change that reorders cells leaves a stale baseline — subsequent external edits can be misclassified as self-writes, and externally-added cells can become undeletable until the next local save.

## Test plan

- [x] `cargo check -p runtimed`
- [x] `cargo test -p runtimed --lib` — 283 tests pass
- [x] `cargo xtask lint` — clean