### PR TITLE
chore: update Cargo.lock after 2.0.4 version bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3678,7 +3678,7 @@ dependencies = [
 
 [[package]]
 name = "notebook"
-version = "2.0.3"
+version = "2.0.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5889,7 +5889,7 @@ dependencies = [
 
 [[package]]
 name = "runt-cli"
-version = "2.0.3"
+version = "2.0.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5945,7 +5945,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed"
-version = "2.0.3"
+version = "2.0.4"
 dependencies = [
  "alacritty_terminal",
  "anyhow",
@@ -6004,7 +6004,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed-py"
-version = "0.1.0"
+version = "2.0.4"
 dependencies = [
  "base64 0.22.1",
  "kernel-env",


### PR DESCRIPTION
## Summary
- Updates Cargo.lock to reflect the 2.0.4 version bump across notebook, runt-cli, runtimed, and runtimed-py crates

## Test plan
- CI passes — this is a lockfile-only change with no code modifications