### PR TITLE
fix(ui): align hidden output badge with source badges

### DIFF
--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -314,7 +314,7 @@ export const CodeCell = memo(function CodeCell({
                     }
                   }}
                   className={cn(
-                    "inline-flex items-center gap-1 px-2 py-0.5 text-sm font-mono text-muted-foreground hover:text-foreground bg-muted/50 hover:bg-muted rounded transition-colors",
+                    "inline-flex items-center gap-1 px-2 py-0.5 text-sm text-muted-foreground hover:text-foreground bg-muted/50 hover:bg-muted rounded transition-colors",
                     (isExecuting || isGroupExecuting) && "animate-pulse",
                   )}
                   title={
@@ -368,11 +368,11 @@ export const CodeCell = memo(function CodeCell({
         }
         outputContent={
           isOutputsHidden && cell.outputs.length > 0 ? (
-            <div className="flex items-center justify-start">
+            <div className="flex items-center justify-start mt-0.5 pl-6">
               <button
                 type="button"
                 onClick={() => onToggleOutputsHidden?.(false)}
-                className="inline-flex items-center gap-1 px-2 py-0.5 text-xs text-muted-foreground hover:text-foreground bg-muted/50 hover:bg-muted rounded transition-colors"
+                className="inline-flex items-center gap-1 px-2 py-0.5 text-sm text-muted-foreground hover:text-foreground bg-muted/50 hover:bg-muted rounded transition-colors"
                 title="Show outputs"
               >
                 <span>


### PR DESCRIPTION
## Summary

Follow-up to #1251 — the hidden output badge ("N outputs") was not updated to match the sizing, alignment, and font consistency of the hidden source and "Cell hidden" badges.

**Changes:**
- Remove `font-mono` from "Cell hidden" badge so it uses the UI font (sans-serif), matching the design intent
- Increase hidden output badge from `text-xs` to `text-sm` to match other badges
- Add `mt-0.5` and `pl-6` to the hidden output wrapper for vertical centering and left-alignment with the code content area

<!-- Screenshots: before/after of hidden cell badges -->

## Verification

- [ ] Open a notebook with hidden cells (both source and outputs hidden) — "Cell hidden" badge uses the UI font
- [ ] Hide a cell's source — the source preview badge still uses monospace font
- [ ] Hide a cell's outputs — the "N outputs" badge is the same size and left-aligned with the source badges above it

_PR submitted by @rgbkrk's agent, Quill_