### PR TITLE
fix(runt): use plist binary path for version check in doctor

### DIFF
--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -2199,8 +2199,9 @@ async fn doctor_command(
         };
 
         // Check 5: Version comparison
+        // Reuse binary_path from the top of run_checks (plist path on macOS)
+        // rather than default_binary_path(), which may resolve to the wrong binary.
         let version_match = {
-            let binary_path = runtimed::service::default_binary_path();
             let installed_ver = if binary_exists {
                 get_binary_version(&binary_path)
             } else {


### PR DESCRIPTION
## Summary

- Fix `runt daemon doctor` version_match check using the wrong binary path on macOS

## Context

Follow-up to #1256. The version_match check in doctor was calling `default_binary_path()` independently, which resolves to `current_exe()` when running from inside the app bundle. Since `current_exe()` is `runt` (not `runtimed`), `get_binary_version()` failed and version_match showed `[unknown] (installed binary not found)`.

Now reuses the `binary_path` from the top of `run_checks()`, which on macOS reads from the plist (the actual runtimed binary that launchd runs).

## Test plan

- [ ] `env -i HOME=$HOME runt-nightly daemon doctor` shows version_match as `[ok]` instead of `[unknown]`