### PR TITLE
feat(kernel): special-case anywidget as a preset dependency

### DIFF
--- a/crates/kernel-env/src/conda.rs
+++ b/crates/kernel-env/src/conda.rs
@@ -223,9 +223,10 @@ async fn install_conda_env(
 
     specs.push(MatchSpec::from_str("ipykernel", match_spec_options)?);
     specs.push(MatchSpec::from_str("ipywidgets", match_spec_options)?);
+    specs.push(MatchSpec::from_str("anywidget", match_spec_options)?);
 
     for dep in &deps.dependencies {
-        if dep != "ipykernel" && dep != "ipywidgets" {
+        if dep != "ipykernel" && dep != "ipywidgets" && dep != "anywidget" {
             specs.push(MatchSpec::from_str(dep, match_spec_options)?);
         }
     }

--- a/crates/kernel-env/src/uv.rs
+++ b/crates/kernel-env/src/uv.rs
@@ -198,6 +198,7 @@ pub async fn prepare_environment_in(
     let mut packages = vec![
         "ipykernel".to_string(),
         "ipywidgets".to_string(),
+        "anywidget".to_string(),
         "uv".to_string(), // For %uv magic in notebooks
     ];
     packages.extend(deps.dependencies.iter().cloned());

--- a/crates/notebook/src/typosquat.rs
+++ b/crates/notebook/src/typosquat.rs
@@ -162,6 +162,7 @@ const POPULAR_PACKAGES: &[&str] = &[
     "jupyterlab",
     "ipykernel",
     "ipywidgets",
+    "anywidget",
     "nbformat",
     "nbconvert",
     "traitlets",
@@ -307,6 +308,12 @@ mod tests {
         // PyPI normalizes these characters
         assert!(check_typosquat("Numpy").is_none()); // Case insensitive
         assert!(check_typosquat("typing_extensions").is_none()); // _ == -
+    }
+
+    #[test]
+    fn test_anywidget_not_flagged() {
+        // anywidget is a real package, not a typosquat of ipywidgets
+        assert!(check_typosquat("anywidget").is_none());
     }
 
     #[test]

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -139,7 +139,10 @@ fn parse_uv_error(stderr: &str) -> Option<PackageInstallError> {
                 if let Some(pkg) = caps.get(1) {
                     let package_name = pkg.as_str().to_string();
                     // Skip if it's a core package name we're definitely installing
-                    if package_name != "ipykernel" && package_name != "ipywidgets" {
+                    if package_name != "ipykernel"
+                        && package_name != "ipywidgets"
+                        && package_name != "anywidget"
+                    {
                         return Some(PackageInstallError {
                             failed_package: Some(package_name),
                             error_message: stderr.to_string(),
@@ -2309,6 +2312,7 @@ impl Daemon {
                 MatchSpec::from_str("python>=3.13", match_spec_options)?,
                 MatchSpec::from_str("ipykernel", match_spec_options)?,
                 MatchSpec::from_str("ipywidgets", match_spec_options)?,
+                MatchSpec::from_str("anywidget", match_spec_options)?,
             ];
             for pkg in &extra_conda_packages {
                 specs.push(MatchSpec::from_str(pkg, match_spec_options)?);
@@ -2558,6 +2562,7 @@ impl Daemon {
 import ipykernel
 import IPython
 import ipywidgets
+import anywidget
 import traitlets
 import zmq
 from ipykernel.kernelbase import Kernel
@@ -2725,10 +2730,11 @@ print("warmup complete")
             }
         }
 
-        // Build install args: ipykernel + ipywidgets + uv + default packages from settings
+        // Build install args: ipykernel + ipywidgets + anywidget + uv + default packages from settings
         let mut install_packages = vec![
             "ipykernel".to_string(),
             "ipywidgets".to_string(),
+            "anywidget".to_string(),
             "uv".to_string(), // For %uv magic in notebooks
         ];
 
@@ -2775,10 +2781,10 @@ print("warmup complete")
 
                 if let Some(ref err) = parsed_error {
                     if let Some(pkg) = &err.failed_package {
-                        // Check if this is a user-specified package (not ipykernel/ipywidgets)
+                        // Check if this is a user-specified package (not ipykernel/ipywidgets/anywidget)
                         let is_user_package = install_packages
                             .iter()
-                            .skip(2) // Skip ipykernel and ipywidgets
+                            .skip(3) // Skip ipykernel, ipywidgets, and anywidget
                             .any(|p| p == pkg);
 
                         if is_user_package {
@@ -2848,6 +2854,7 @@ print("warmup complete")
 import ipykernel
 import IPython
 import ipywidgets
+import anywidget
 from ipykernel.kernelbase import Kernel
 from ipykernel.ipkernel import IPythonKernel
 print("warmup complete")


### PR DESCRIPTION
## Summary

`anywidget` was being incorrectly flagged as a potential typosquat of `ipywidgets` in the trust dialog. It's a legitimate, widely-used package for creating Jupyter widgets and should be treated as a first-class preset dependency.

**What changed:**
- Added `anywidget` to `POPULAR_PACKAGES` in typosquat detection so it's recognized as a known package
- Added `anywidget` as a preset dependency alongside `ipywidgets` in UV environments, Conda environments, and pool prewarming paths
- Updated error-reporting skip lists and warmup import scripts to include `anywidget`

## Verification

- [ ] Open a notebook that has `anywidget` in its dependencies — trust dialog should **not** show a typosquat warning
- [ ] Create a fresh UV environment — `anywidget` should be pre-installed without being listed in notebook deps

<!-- screenshots of the trust dialog welcome here -->

_PR submitted by @rgbkrk's agent, Quill_