### PR TITLE
fix(notebook): prevent widget iframe re-render on structural changes

### DIFF
--- a/apps/notebook/src/lib/notebook-cells.ts
+++ b/apps/notebook/src/lib/notebook-cells.ts
@@ -168,7 +168,10 @@ function cellsEqual(a: NotebookCell, b: NotebookCell): boolean {
   if (a === b) return true;
   if (a.cell_type !== b.cell_type) return false;
   if (a.source !== b.source) return false;
-  if (!shallowRecordEqual(a.metadata, b.metadata)) return false;
+  // Metadata can contain nested objects (e.g. metadata.jupyter = { source_hidden: true })
+  // that get new references on every WASM deserialization. JSON.stringify handles
+  // arbitrary nesting; WASM serialization produces consistent key ordering.
+  if (JSON.stringify(a.metadata) !== JSON.stringify(b.metadata)) return false;
 
   // cell_type-specific fields
   if (a.cell_type === "code") {
@@ -237,7 +240,20 @@ export function replaceNotebookCells(cells: NotebookCell[]): void {
       // Structurally identical — preserve old reference, skip notification
       newMap.set(cell.id, prev);
     } else {
-      newMap.set(cell.id, cell);
+      // Even when the cell changed (e.g. metadata), preserve the output
+      // array reference if every element is identical. This prevents
+      // OutputArea's handleFrameReady from firing and re-rendering iframes.
+      let stored = cell;
+      if (prev && prev.cell_type === "code" && cell.cell_type === "code") {
+        const prevOutputs = prev.outputs;
+        if (
+          prevOutputs.length === cell.outputs.length &&
+          prevOutputs.every((o, i) => o === cell.outputs[i])
+        ) {
+          stored = { ...cell, outputs: prevOutputs };
+        }
+      }
+      newMap.set(stored.id, stored);
       changedIds.push(cell.id);
       if (!prev || prev.source !== cell.source) {
         anySourceChanged = true;


### PR DESCRIPTION
## Summary

Structural changes (cell add/delete/move) trigger full WASM materialization, which produces new JavaScript object references for nested metadata like `metadata.jupyter`. The shallow `cellsEqual()` comparison treated every cell as "changed," giving `OutputArea` new output array references and causing `handleFrameReady` to clear and re-render every iframe — destroying widget state (anywidget, plotly, etc.).

Two targeted fixes in `notebook-cells.ts`:

1. **Deep metadata comparison** — use `JSON.stringify` instead of `shallowRecordEqual` for metadata in `cellsEqual()`, handling nested objects that get new references on each WASM deserialization.
2. **Output array reuse safety net** — in `replaceNotebookCells`, preserve the old `outputs` array reference when all elements are referentially identical, even when the cell is marked as changed for other reasons. This prevents `OutputArea`'s `handleFrameReady` effect from firing.

## Verification

- [ ] Open a notebook with a widget output (anywidget animation, plotly plot, or similar)
- [ ] Add a new cell above and below the widget cell — widget should **not** flash or re-render
- [ ] Delete a cell adjacent to the widget — widget should **not** flash or re-render
- [ ] Re-execute the widget cell — widget **should** update normally
- [ ] Verify cells with `source_hidden` metadata still collapse/expand correctly

_PR submitted by @rgbkrk's agent, Quill_