### PR TITLE
Add Codex MCP supervisor config for nteract

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,6 @@
+[mcp_servers.nteract]
+command = "cargo"
+args = ["run", "-p", "mcp-supervisor"]
+
+[mcp_servers.nteract.env]
+RUNTIMED_DEV = "1"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ Codex-specific repo skills live in `.codex/skills/`. Prefer them when the task m
 
 If your MCP client provides `supervisor_status`, `supervisor_restart`, `supervisor_rebuild`, etc., **prefer those over manual terminal commands**. The supervisor manages the dev daemon lifecycle for you — no env vars, no extra terminals.
 
-**Claude Code has Inkwell locally** — the local dev environment connects Claude Code to the MCP supervisor via `cargo xtask run-mcp`. Cloud/CI sessions (e.g. GitHub-hosted agents) do not have Inkwell and must use `cargo xtask` commands directly.
+**Claude Code has Inkwell locally** — the local dev environment connects Claude Code to the MCP supervisor via `cargo xtask run-mcp`. Codex app/CLI can use the same supervisor when this repo's project-scoped `.codex/config.toml` is enabled in a trusted workspace. If your current environment does not expose the supervisor tools, use the manual `cargo xtask` commands below.
 
 | Instead of… | Use… |
 |-------------|------|
@@ -213,6 +213,8 @@ cargo xtask run-mcp
 cargo xtask run-mcp --print-config
 ```
 
+For Codex app/CLI, this repository also includes a project-scoped MCP config in `.codex/config.toml` that points at the same `mcp-supervisor` server.
+
 `uv run nteract --stable` and `uv run nteract --nightly` are channel overrides for direct MCP launches. They only seed `RUNTIMED_SOCKET_PATH` when it is unset, and they also control which app `show_notebook` opens. `--no-show` removes the `show_notebook` tool entirely.
 
 ### Supervisor Tools (from Inkwell / `mcp-supervisor`)
@@ -250,8 +252,8 @@ The supervisor watches `python/nteract/src/`, `python/runtimed/src/`, `crates/ru
 
 ### Tool availability
 
-- **Local Claude Code / Zed / MCP client** → Inkwell active, all supervisor + nteract tools available. **Prefer supervisor tools for daemon lifecycle** — they handle env vars and isolation automatically.
-- **Cloud agents (GitHub, Codex, remote sessions)** → No MCP server, use `cargo xtask` commands directly for build, daemon, and testing.
+- **Local Claude Code / Zed / Codex app/CLI with MCP configured** → Inkwell active, all supervisor + nteract tools available. **Prefer supervisor tools for daemon lifecycle** — they handle env vars and isolation automatically.
+- **Environments without supervisor tools** → use `cargo xtask` commands directly for build, daemon, and testing.
 - **nteract MCP only** → nteract tools only, no `supervisor_*`. Use manual terminal commands for daemon management.
 - **No MCP server** → use `cargo xtask run-mcp` to set one up
 - **Dev daemon not running** → Inkwell starts it automatically via `supervisor_restart(target="daemon")`

--- a/contributing/development.md
+++ b/contributing/development.md
@@ -327,10 +327,21 @@ This:
 5. Proxies all tool calls + injects `supervisor_*` management tools
 6. Watches source files and hot-reloads on changes
 
-For your MCP client config (Zed, Claude Desktop, etc.):
+For your MCP client config (Zed, Claude Desktop, Codex, etc.):
 
 ```bash
 cargo xtask run-mcp --print-config
+```
+
+Codex app/CLI can read a project-scoped `.codex/config.toml`. This repo includes one that mirrors the same supervisor setup:
+
+```toml
+[mcp_servers.nteract]
+command = "cargo"
+args = ["run", "-p", "mcp-supervisor"]
+
+[mcp_servers.nteract.env]
+RUNTIMED_DEV = "1"
 ```
 
 Or configure `.zed/settings.json` directly (gitignored):


### PR DESCRIPTION
## Summary
- add a project-scoped `.codex/config.toml` that points Codex at `mcp-supervisor`
- document Codex MCP setup alongside existing Claude/Zed guidance
- replace unverified environment-specific claims in `AGENTS.md` with capability-based wording

## Testing
- Not run (not requested)