### PR TITLE
Update local MCP config docs to use inkwell

### DIFF
--- a/.claude/skills/frontend-dev/SKILL.md
+++ b/.claude/skills/frontend-dev/SKILL.md
@@ -132,6 +132,8 @@ For editor config:
 cargo xtask run-mcp --print-config
 ```
 
+Use `inkwell` as the repo-local MCP server name so it stays distinct from any global/system `nteract` entry.
+
 ### Zed Integration
 
 `.zed/settings.json` (gitignored):
@@ -139,7 +141,7 @@ cargo xtask run-mcp --print-config
 ```json
 {
   "context_servers": {
-    "nteract": {
+    "inkwell": {
       "command": "./target/debug/mcp-supervisor",
       "args": [],
       "env": { "RUNTIMED_DEV": "1" }

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,6 +1,6 @@
-[mcp_servers.nteract]
+[mcp_servers.inkwell]
 command = "cargo"
 args = ["run", "-p", "mcp-supervisor"]
 
-[mcp_servers.nteract.env]
+[mcp_servers.inkwell.env]
 RUNTIMED_DEV = "1"

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,6 +1,6 @@
 {
   "mcpServers": {
-    "nteract": {
+    "inkwell": {
       "command": "cargo",
       "args": ["run", "-p", "mcp-supervisor"],
       "env": {

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,6 +1,6 @@
 {
   "context_servers": {
-    "supervisor": {
+    "inkwell": {
       "command": "cargo",
       "args": ["run", "-p", "mcp-supervisor"],
       "env": {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ Codex-specific repo skills live in `.codex/skills/`. Prefer them when the task m
 
 If your MCP client provides `supervisor_status`, `supervisor_restart`, `supervisor_rebuild`, etc., **prefer those over manual terminal commands**. The supervisor manages the dev daemon lifecycle for you — no env vars, no extra terminals.
 
-**Claude Code has Inkwell locally** — the local dev environment connects Claude Code to the MCP supervisor via `cargo xtask run-mcp`. Codex app/CLI can use the same supervisor when this repo's project-scoped `.codex/config.toml` is enabled in a trusted workspace. If your current environment does not expose the supervisor tools, use the manual `cargo xtask` commands below.
+**Claude Code has Inkwell locally** — the local dev environment connects Claude Code to the repo-local `inkwell` MCP entry via `cargo xtask run-mcp`. Codex app/CLI can use the same server when this repo's project-scoped `.codex/config.toml` is enabled in a trusted workspace. If your current environment does not expose the supervisor tools, use the manual `cargo xtask` commands below.
 
 | Instead of… | Use… |
 |-------------|------|
@@ -213,7 +213,9 @@ cargo xtask run-mcp
 cargo xtask run-mcp --print-config
 ```
 
-For Codex app/CLI, this repository also includes a project-scoped MCP config in `.codex/config.toml` that points at the same `mcp-supervisor` server.
+Use `inkwell` as the MCP server name for this source tree. Keep `nteract` for the global/system-installed MCP server. In clients that namespace tools by server name, that keeps repo-local tools distinct from the global install.
+
+For Codex app/CLI, this repository also includes a project-scoped MCP config in `.codex/config.toml` that points at the same `mcp-supervisor` server using the `inkwell` entry name.
 
 `uv run nteract --stable` and `uv run nteract --nightly` are channel overrides for direct MCP launches. They only seed `RUNTIMED_SOCKET_PATH` when it is unset, and they also control which app `show_notebook` opens. `--no-show` removes the `show_notebook` tool entirely.
 
@@ -252,9 +254,9 @@ The supervisor watches `python/nteract/src/`, `python/runtimed/src/`, `crates/ru
 
 ### Tool availability
 
-- **Local Claude Code / Zed / Codex app/CLI with MCP configured** → Inkwell active, all supervisor + nteract tools available. **Prefer supervisor tools for daemon lifecycle** — they handle env vars and isolation automatically.
+- **Local Claude Code / Zed / Codex app/CLI with MCP configured** → Configure the repo-local MCP entry as `inkwell`. Inkwell exposes all `supervisor_*` tools plus the proxied nteract notebook tools. **Prefer supervisor tools for daemon lifecycle** — they handle env vars and isolation automatically.
 - **Environments without supervisor tools** → use `cargo xtask` commands directly for build, daemon, and testing.
-- **nteract MCP only** → nteract tools only, no `supervisor_*`. Use manual terminal commands for daemon management.
+- **nteract MCP only** → The global/system `nteract` server exposes notebook tools only, with no `supervisor_*`. Use manual terminal commands for daemon management.
 - **No MCP server** → use `cargo xtask run-mcp` to set one up
 - **Dev daemon not running** → Inkwell starts it automatically via `supervisor_restart(target="daemon")`
 

--- a/contributing/development.md
+++ b/contributing/development.md
@@ -166,16 +166,16 @@ In production, the Tauri app auto-installs and manages the system daemon. In dev
 - Your code changes take effect immediately on daemon restart
 - No interference with the system daemon
 
-**With Inkwell supervisor (preferred for agents):**
+**With Inkwell (preferred for agents):**
 
-If you have `supervisor_*` MCP tools available (e.g. in Zed with `mcp-supervisor`), the daemon is managed for you:
+If you have the repo-local `inkwell` MCP entry configured, the daemon is managed for you through the `supervisor_*` tools:
 
 - `supervisor_restart(target="daemon")` — start or restart the dev daemon
 - `supervisor_status` — check daemon status (includes `daemon_managed: true/false`)
 - `supervisor_rebuild` — rebuild Python bindings + restart
 - `supervisor_logs` — tail daemon logs
 
-No env vars or extra terminals needed. The supervisor handles per-worktree isolation automatically.
+No env vars or extra terminals needed. Inkwell handles per-worktree isolation automatically.
 
 **Two-terminal workflow (without supervisor):**
 
@@ -216,7 +216,7 @@ RUNTIMED_DEV=1 cargo xtask notebook
 
 Per-worktree state is stored in `<cache>/{cache_namespace}/worktrees/{hash}/` (macOS: `~/Library/Caches/`, Linux: `~/.cache/`). Source builds default to `runt-nightly`; set `RUNT_BUILD_CHANNEL=stable` only when you intentionally need the stable flow.
 
-**For AI agents:** If `supervisor_*` tools are available, prefer those — they handle env vars and daemon lifecycle automatically. Otherwise, use `./target/debug/runt` directly (see "Agent Access to Dev Daemon" in CLAUDE.md). When using a raw terminal (not Zed tasks), set the env vars manually:
+**For AI agents:** If the repo-local `inkwell` MCP entry is available, prefer its `supervisor_*` tools — they handle env vars and daemon lifecycle automatically. Keep `nteract` as the name for the global/system-installed MCP server. When using a raw terminal (not Zed tasks), set the env vars manually:
 
 ```bash
 export RUNTIMED_DEV=1
@@ -333,14 +333,16 @@ For your MCP client config (Zed, Claude Desktop, Codex, etc.):
 cargo xtask run-mcp --print-config
 ```
 
+Use `inkwell` as the server name for this source tree so it stays distinct from any global/system `nteract` MCP entry.
+
 Codex app/CLI can read a project-scoped `.codex/config.toml`. This repo includes one that mirrors the same supervisor setup:
 
 ```toml
-[mcp_servers.nteract]
+[mcp_servers.inkwell]
 command = "cargo"
 args = ["run", "-p", "mcp-supervisor"]
 
-[mcp_servers.nteract.env]
+[mcp_servers.inkwell.env]
 RUNTIMED_DEV = "1"
 ```
 
@@ -349,7 +351,7 @@ Or configure `.zed/settings.json` directly (gitignored):
 ```json
 {
   "context_servers": {
-    "nteract": {
+    "inkwell": {
       "command": "./target/debug/mcp-supervisor",
       "args": [],
       "env": { "RUNTIMED_DEV": "1" }
@@ -357,6 +359,8 @@ Or configure `.zed/settings.json` directly (gitignored):
   }
 }
 ```
+
+In clients that namespace tools by server name, this keeps repo-local notebook tools separate from the global install while still exposing the same notebook APIs plus the extra `supervisor_*` tools.
 
 #### Supervisor tools
 


### PR DESCRIPTION
## Summary
- rename the repo-local MCP server key from `nteract` or `supervisor` to `inkwell`
- update local agent config examples in `.mcp.json`, `.zed/settings.json`, `AGENTS.md`, and development docs
- clarify that `inkwell` is the source-tree MCP entry while global/system installs remain `nteract`
- keep `mcp-supervisor`, `cargo xtask run-mcp`, and `supervisor_*` tool names unchanged

## Testing
- `cargo xtask lint`