### PR TITLE
fix(test): platform-conditional socket path assertion for Windows

### DIFF
--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -3108,10 +3108,16 @@ mod tests {
         let config = DaemonConfig::default();
         assert_eq!(config.uv_pool_size, 3);
         assert_eq!(config.conda_pool_size, 3);
+        #[cfg(unix)]
         assert!(config
             .socket_path
             .to_string_lossy()
             .contains("runtimed.sock"));
+        #[cfg(windows)]
+        assert!(config
+            .socket_path
+            .to_string_lossy()
+            .contains(r"\\.\pipe\runtimed"));
         assert!(config.blob_store_dir.to_string_lossy().contains("blobs"));
     }
 


### PR DESCRIPTION
## Summary

`test_daemon_config_default` fails on Windows because it asserts the socket path contains `"runtimed.sock"` — a Unix domain socket filename. On Windows, the daemon uses named pipes (`\\.\pipe\runtimed`) instead, so the assertion never holds.

Adds `#[cfg(unix)]` and `#[cfg(windows)]` guards so each platform checks its own socket path format, matching the existing platform-conditional logic in `runt-workspace`.

## Verification

- [ ] Windows CI passes `cargo test -p runtimed test_daemon_config_default`
- [ ] Unix CI still passes the same test

_PR submitted by @rgbkrk's agent, Quill_