### PR TITLE
refactor(mcp): rename inkwell to nteract-dev

### DIFF
--- a/.claude/rules/mcp-servers.md
+++ b/.claude/rules/mcp-servers.md
@@ -1,0 +1,22 @@
+---
+description: MCP server selection — use the right server for the task
+globs:
+  - "**"
+---
+
+# MCP Server Selection
+
+Three nteract MCP servers may be available. Always use the right one:
+
+| Server | What it is | When to use |
+|--------|-----------|-------------|
+| `nteract-dev` | Dev MCP server with supervisor tools (`supervisor_*`). Manages a per-worktree dev daemon, hot-reloads on code changes. | **Default for all development work.** Use this for notebook interaction, daemon lifecycle, building, and testing. |
+| `nteract-nightly` | System-installed nightly release daemon | Diagnostics and inspection of the installed nightly app. Do NOT use for development. |
+| `nteract` | System-installed stable release daemon (nteract.app) | Diagnostics and inspection of the installed stable app. Do NOT use for development. |
+
+**Rules:**
+
+1. **Always prefer `nteract-dev`** (`mcp__nteract-dev__*` tools) for development work in this repo. It connects to the per-worktree dev daemon and includes supervisor tools for managing the build/daemon lifecycle.
+2. **Never use `nteract-nightly` or `nteract` for development.** They connect to system-installed daemons and will not reflect your source changes.
+3. If `nteract-dev` tools are not available, fall back to `cargo xtask` commands — not to the system MCP servers.
+4. The supervisor tools (`supervisor_status`, `supervisor_restart`, `supervisor_rebuild`, `supervisor_logs`, `supervisor_start_vite`, `supervisor_stop`) are part of the `nteract-dev` server. They manage the dev daemon and build pipeline — prefer them over manual terminal commands.

--- a/.claude/rules/mcp-servers.md
+++ b/.claude/rules/mcp-servers.md
@@ -20,3 +20,19 @@ Three nteract MCP servers may be available. Always use the right one:
 2. **Never use `nteract-nightly` or `nteract` for development.** They connect to system-installed daemons and will not reflect your source changes.
 3. If `nteract-dev` tools are not available, fall back to `cargo xtask` commands — not to the system MCP servers.
 4. The supervisor tools (`supervisor_status`, `supervisor_restart`, `supervisor_rebuild`, `supervisor_logs`, `supervisor_start_vite`, `supervisor_stop`) are part of the `nteract-dev` server. They manage the dev daemon and build pipeline — prefer them over manual terminal commands.
+
+## System daemon CLI (`runt` / `runt-nightly`)
+
+When running CLI commands against system-installed daemons from a dev environment, **always use `env -i`** to strip dev env vars (`RUNTIMED_DEV`, `RUNTIMED_WORKSPACE_PATH`) that would otherwise redirect commands to the per-worktree dev daemon:
+
+```bash
+# Nightly system daemon
+env -i PATH="$PATH" HOME="$HOME" runt-nightly diagnostics
+env -i PATH="$PATH" HOME="$HOME" runt-nightly daemon status
+
+# Stable system daemon
+env -i PATH="$PATH" HOME="$HOME" runt diagnostics
+env -i PATH="$PATH" HOME="$HOME" runt daemon status
+```
+
+For the dev daemon, use `./target/debug/runt` directly (no `env -i` needed — dev env vars are correct).

--- a/.claude/skills/diagnostics/SKILL.md
+++ b/.claude/skills/diagnostics/SKILL.md
@@ -5,20 +5,47 @@ description: Collect and analyze nteract diagnostic logs. Use when debugging iss
 
 # Diagnostics
 
+## Why `env -i`?
+
+In the dev environment, `RUNTIMED_DEV` and `RUNTIMED_WORKSPACE_PATH` are set (by direnv, xtask, or the supervisor). These cause `runt` to target the per-worktree dev daemon. System diagnostics need to target the **system-installed** daemon, so we use `env -i` to strip all env vars except `PATH` and `HOME`.
+
+The repo-local `bin/runt` wrapper is first in `$PATH` — it runs `./target/debug/runt`, which is the dev build. That's fine for quick checks, but for true system diagnostics, call the system binary by its channel-specific name (`runt` for stable, `runt-nightly` for nightly) via `env -i` so dev env vars don't leak through.
+
 ## Collecting Diagnostics
 
-The system nightly daemon runs outside the dev environment, so use `env -i` to avoid picking up dev-mode env vars:
-
+**Nightly channel** (system-installed nteract Nightly.app):
 ```bash
-env -i PATH="/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin" HOME="$HOME" runt-nightly diagnostics
+env -i PATH="$PATH" HOME="$HOME" runt-nightly diagnostics
 ```
 
-For the stable channel:
+**Stable channel** (system-installed nteract.app):
 ```bash
-env -i PATH="/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin" HOME="$HOME" runt diagnostics
+env -i PATH="$PATH" HOME="$HOME" runt diagnostics
+```
+
+**Dev daemon** (per-worktree, no `env -i` needed):
+```bash
+./target/debug/runt diagnostics
 ```
 
 The archive is written to the current directory (falls back to temp if not writable).
+
+## Other Useful Commands
+
+Same `env -i` pattern applies to any system daemon command:
+
+```bash
+# Check system daemon status
+env -i PATH="$PATH" HOME="$HOME" runt-nightly daemon status
+env -i PATH="$PATH" HOME="$HOME" runt daemon status
+
+# List notebooks on system daemon
+env -i PATH="$PATH" HOME="$HOME" runt-nightly notebooks
+env -i PATH="$PATH" HOME="$HOME" runt ps
+
+# Tail system daemon logs
+env -i PATH="$PATH" HOME="$HOME" runt-nightly daemon logs -f
+```
 
 ## Archive Contents
 

--- a/.claude/skills/frontend-dev/SKILL.md
+++ b/.claude/skills/frontend-dev/SKILL.md
@@ -118,7 +118,7 @@ RUNTIMED_DEV=1 cargo xtask notebook      # Terminal 2
 
 ## MCP Server Development
 
-### Inkwell Supervisor (recommended)
+### nteract-dev Supervisor (recommended)
 
 ```bash
 cargo xtask run-mcp
@@ -132,7 +132,7 @@ For editor config:
 cargo xtask run-mcp --print-config
 ```
 
-Use `inkwell` as the repo-local MCP server name so it stays distinct from any global/system `nteract` entry.
+Use `nteract-dev` as the repo-local MCP server name so it stays distinct from any global/system `nteract` entry.
 
 ### Zed Integration
 
@@ -141,7 +141,7 @@ Use `inkwell` as the repo-local MCP server name so it stays distinct from any gl
 ```json
 {
   "context_servers": {
-    "inkwell": {
+    "nteract-dev": {
       "command": "./target/debug/mcp-supervisor",
       "args": [],
       "env": { "RUNTIMED_DEV": "1" }

--- a/.claude/skills/python-bindings/SKILL.md
+++ b/.claude/skills/python-bindings/SKILL.md
@@ -182,7 +182,7 @@ The nteract MCP server (`python/nteract/`) provides programmatic notebook intera
 # Run directly (after uv sync + maturin develop)
 uv run nteract
 
-# Via Inkwell supervisor (recommended, handles lifecycle)
+# Via nteract-dev supervisor (recommended, handles lifecycle)
 cargo xtask run-mcp
 ```
 
@@ -227,4 +227,4 @@ cd crates/runtimed-py
 VIRTUAL_ENV=../../.venv uv run --directory ../../python/runtimed maturin develop
 ```
 
-Or if using Inkwell supervisor, call `supervisor_rebuild`.
+Or if using nteract-dev supervisor, call `supervisor_rebuild`.

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,6 +1,6 @@
-[mcp_servers.inkwell]
+[mcp_servers.nteract-dev]
 command = "cargo"
 args = ["run", "-p", "mcp-supervisor"]
 
-[mcp_servers.inkwell.env]
+[mcp_servers.nteract-dev.env]
 RUNTIMED_DEV = "1"

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,6 +1,6 @@
 {
   "mcpServers": {
-    "inkwell": {
+    "nteract-dev": {
       "command": "cargo",
       "args": ["run", "-p", "mcp-supervisor"],
       "env": {

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,6 +1,6 @@
 {
   "context_servers": {
-    "inkwell": {
+    "nteract-dev": {
       "command": "cargo",
       "args": ["run", "-p", "mcp-supervisor"],
       "env": {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ Codex-specific repo skills live in `.codex/skills/`. Prefer them when the task m
 
 If your MCP client provides `supervisor_status`, `supervisor_restart`, `supervisor_rebuild`, etc., **prefer those over manual terminal commands**. The supervisor manages the dev daemon lifecycle for you — no env vars, no extra terminals.
 
-**Claude Code has Inkwell locally** — the local dev environment connects Claude Code to the repo-local `inkwell` MCP entry via `cargo xtask run-mcp`. Codex app/CLI can use the same server when this repo's project-scoped `.codex/config.toml` is enabled in a trusted workspace. If your current environment does not expose the supervisor tools, use the manual `cargo xtask` commands below.
+**Claude Code has nteract-dev locally** — the local dev environment connects Claude Code to the repo-local `nteract-dev` MCP entry via `cargo xtask run-mcp`. Codex app/CLI can use the same server when this repo's project-scoped `.codex/config.toml` is enabled in a trusted workspace. If your current environment does not expose the supervisor tools, use the manual `cargo xtask` commands below.
 
 | Instead of… | Use… |
 |-------------|------|
@@ -203,7 +203,7 @@ uv run nteract  # Run MCP server from repo root
 
 ## MCP Server (Local Development)
 
-### Inkwell — MCP Supervisor
+### nteract-dev — MCP Supervisor
 
 ```bash
 # Build and run the supervisor (starts daemon if needed)
@@ -213,13 +213,13 @@ cargo xtask run-mcp
 cargo xtask run-mcp --print-config
 ```
 
-Use `inkwell` as the MCP server name for this source tree. Keep `nteract` for the global/system-installed MCP server. In clients that namespace tools by server name, that keeps repo-local tools distinct from the global install.
+Use `nteract-dev` as the MCP server name for this source tree. Keep `nteract` for the global/system-installed MCP server. In clients that namespace tools by server name, that keeps repo-local tools distinct from the global install.
 
-For Codex app/CLI, this repository also includes a project-scoped MCP config in `.codex/config.toml` that points at the same `mcp-supervisor` server using the `inkwell` entry name.
+For Codex app/CLI, this repository also includes a project-scoped MCP config in `.codex/config.toml` that points at the same `mcp-supervisor` server using the `nteract-dev` entry name.
 
 `uv run nteract --stable` and `uv run nteract --nightly` are channel overrides for direct MCP launches. They only seed `RUNTIMED_SOCKET_PATH` when it is unset, and they also control which app `show_notebook` opens. `--no-show` removes the `show_notebook` tool entirely.
 
-### Supervisor Tools (from Inkwell / `mcp-supervisor`)
+### Supervisor Tools (from nteract-dev / `mcp-supervisor`)
 
 | Tool | Purpose |
 |------|---------|
@@ -232,7 +232,7 @@ For Codex app/CLI, this repository also includes a project-scoped MCP config in 
 
 ### nteract MCP Tools (27 tools for notebook interaction)
 
-When Inkwell is active, agents also get the full nteract tool suite. **Use these to audit your own work** — open a notebook, execute cells, and inspect outputs to verify changes actually work before committing.
+When nteract-dev is active, agents also get the full nteract tool suite. **Use these to audit your own work** — open a notebook, execute cells, and inspect outputs to verify changes actually work before committing.
 
 | Category | Tools |
 |----------|-------|
@@ -254,11 +254,11 @@ The supervisor watches `python/nteract/src/`, `python/runtimed/src/`, `crates/ru
 
 ### Tool availability
 
-- **Local Claude Code / Zed / Codex app/CLI with MCP configured** → Configure the repo-local MCP entry as `inkwell`. Inkwell exposes all `supervisor_*` tools plus the proxied nteract notebook tools. **Prefer supervisor tools for daemon lifecycle** — they handle env vars and isolation automatically.
+- **Local Claude Code / Zed / Codex app/CLI with MCP configured** → Configure the repo-local MCP entry as `nteract-dev`. nteract-dev exposes all `supervisor_*` tools plus the proxied nteract notebook tools. **Prefer supervisor tools for daemon lifecycle** — they handle env vars and isolation automatically.
 - **Environments without supervisor tools** → use `cargo xtask` commands directly for build, daemon, and testing.
 - **nteract MCP only** → The global/system `nteract` server exposes notebook tools only, with no `supervisor_*`. Use manual terminal commands for daemon management.
 - **No MCP server** → use `cargo xtask run-mcp` to set one up
-- **Dev daemon not running** → Inkwell starts it automatically via `supervisor_restart(target="daemon")`
+- **Dev daemon not running** → nteract-dev starts it automatically via `supervisor_restart(target="daemon")`
 
 ## Workspace Crates (15)
 
@@ -277,7 +277,7 @@ The supervisor watches `python/nteract/src/`, `python/runtimed/src/`, `crates/ru
 | `kernel-launch` | Kernel launching, tool bootstrapping (deno, uv, ruff via rattler) |
 | `kernel-env` | Python environment management (UV + Conda) with progress reporting |
 | `tauri-jupyter` | Shared Jupyter message types for Tauri/WebView |
-| `mcp-supervisor` | Inkwell — MCP supervisor proxy, daemon/vite lifecycle management |
+| `mcp-supervisor` | nteract-dev — MCP supervisor proxy, daemon/vite lifecycle management |
 | `xtask` | Build system orchestration |
 
 ## Build System (`cargo xtask`)
@@ -297,7 +297,7 @@ All build, lint, and dev commands go through `cargo xtask`. **Run `cargo xtask h
 | | `cargo xtask run` | Run bundled debug binary |
 | Daemon | `cargo xtask dev-daemon` | Per-worktree dev daemon |
 | | `cargo xtask install-daemon` | Install runtimed as system daemon |
-| MCP | `cargo xtask run-mcp` | Inkwell supervisor (daemon + MCP + auto-restart) |
+| MCP | `cargo xtask run-mcp` | nteract-dev supervisor (daemon + MCP + auto-restart) |
 | | `cargo xtask run-mcp --print-config` | Print MCP client config JSON |
 | | `cargo xtask dev-mcp` | Direct nteract MCP (no supervisor) |
 | Lint | `cargo xtask lint` | Check formatting (Rust, JS/TS, Python) |

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ nteract/desktop
 │   ├── runt-trust/        # HMAC trust verification
 │   ├── runt-workspace/    # Workspace detection utilities
 │   ├── xtask/             # Build automation tasks
-│   └── mcp-supervisor/    # Inkwell MCP supervisor for dev workflows
+│   └── mcp-supervisor/    # nteract-dev MCP supervisor for dev workflows
 ├── python/                 # Python packages
 │   ├── runtimed/          # PyPI: runtimed (Python bindings for daemon)
 │   └── nteract/           # PyPI: nteract (MCP server)

--- a/contributing/development.md
+++ b/contributing/development.md
@@ -14,7 +14,7 @@
 | Run with notebook | `cargo xtask run path/to/notebook.ipynb` |
 | Build release .app | `cargo xtask build-app` |
 | Build release DMG | `cargo xtask build-dmg` |
-| MCP supervisor (Inkwell) | `cargo xtask run-mcp` |
+| MCP supervisor (nteract-dev) | `cargo xtask run-mcp` |
 | MCP config JSON | `cargo xtask run-mcp --print-config` |
 | MCP server (no supervisor) | `cargo xtask dev-mcp` |
 | Lint (check mode) | `cargo xtask lint` |
@@ -166,16 +166,16 @@ In production, the Tauri app auto-installs and manages the system daemon. In dev
 - Your code changes take effect immediately on daemon restart
 - No interference with the system daemon
 
-**With Inkwell (preferred for agents):**
+**With nteract-dev (preferred for agents):**
 
-If you have the repo-local `inkwell` MCP entry configured, the daemon is managed for you through the `supervisor_*` tools:
+If you have the repo-local `nteract-dev` MCP entry configured, the daemon is managed for you through the `supervisor_*` tools:
 
 - `supervisor_restart(target="daemon")` — start or restart the dev daemon
 - `supervisor_status` — check daemon status (includes `daemon_managed: true/false`)
 - `supervisor_rebuild` — rebuild Python bindings + restart
 - `supervisor_logs` — tail daemon logs
 
-No env vars or extra terminals needed. Inkwell handles per-worktree isolation automatically.
+No env vars or extra terminals needed. nteract-dev handles per-worktree isolation automatically.
 
 **Two-terminal workflow (without supervisor):**
 
@@ -216,7 +216,7 @@ RUNTIMED_DEV=1 cargo xtask notebook
 
 Per-worktree state is stored in `<cache>/{cache_namespace}/worktrees/{hash}/` (macOS: `~/Library/Caches/`, Linux: `~/.cache/`). Source builds default to `runt-nightly`; set `RUNT_BUILD_CHANNEL=stable` only when you intentionally need the stable flow.
 
-**For AI agents:** If the repo-local `inkwell` MCP entry is available, prefer its `supervisor_*` tools — they handle env vars and daemon lifecycle automatically. Keep `nteract` as the name for the global/system-installed MCP server. When using a raw terminal (not Zed tasks), set the env vars manually:
+**For AI agents:** If the repo-local `nteract-dev` MCP entry is available, prefer its `supervisor_*` tools — they handle env vars and daemon lifecycle automatically. Keep `nteract` as the name for the global/system-installed MCP server. When using a raw terminal (not Zed tasks), set the env vars manually:
 
 ```bash
 export RUNTIMED_DEV=1
@@ -308,9 +308,9 @@ uv run --directory . nteract       # equivalent, explicit
 
 For direct launches, `--stable` and `--nightly` are mutually exclusive channel overrides. They only set `RUNTIMED_SOCKET_PATH` when it is unset, and they also control which app the `show_notebook` tool opens.
 
-### Inkwell supervisor (recommended)
+### nteract-dev supervisor (recommended)
 
-The **Inkwell** MCP supervisor (`crates/mcp-supervisor/`) is a stable Rust
+The **nteract-dev** MCP supervisor (`crates/mcp-supervisor/`) is a stable Rust
 process that proxies to the nteract Python MCP server. It handles daemon
 lifecycle, auto-restart on crash, and hot-reload on file changes — one command,
 everything works:
@@ -333,16 +333,16 @@ For your MCP client config (Zed, Claude Desktop, Codex, etc.):
 cargo xtask run-mcp --print-config
 ```
 
-Use `inkwell` as the server name for this source tree so it stays distinct from any global/system `nteract` MCP entry.
+Use `nteract-dev` as the server name for this source tree so it stays distinct from any global/system `nteract` MCP entry.
 
 Codex app/CLI can read a project-scoped `.codex/config.toml`. This repo includes one that mirrors the same supervisor setup:
 
 ```toml
-[mcp_servers.inkwell]
+[mcp_servers.nteract-dev]
 command = "cargo"
 args = ["run", "-p", "mcp-supervisor"]
 
-[mcp_servers.inkwell.env]
+[mcp_servers.nteract-dev.env]
 RUNTIMED_DEV = "1"
 ```
 
@@ -351,7 +351,7 @@ Or configure `.zed/settings.json` directly (gitignored):
 ```json
 {
   "context_servers": {
-    "inkwell": {
+    "nteract-dev": {
       "command": "./target/debug/mcp-supervisor",
       "args": [],
       "env": { "RUNTIMED_DEV": "1" }
@@ -405,7 +405,7 @@ The MCP server is a pure Python package (`python/nteract/`) that depends on
 `crates/runtimed-py/`). Both are workspace members of the repo-root
 `pyproject.toml`, so `uv sync` installs them into `.venv` at the repo root.
 
-The Inkwell supervisor (`crates/mcp-supervisor/`) uses the `rmcp` Rust SDK to
+The nteract-dev supervisor (`crates/mcp-supervisor/`) uses the `rmcp` Rust SDK to
 act as both an MCP server (facing the client) and an MCP client (facing the
 Python child process). It spawns the child via `uv run --directory . nteract`
 from the repo root.

--- a/contributing/runtimed.md
+++ b/contributing/runtimed.md
@@ -87,7 +87,7 @@ cargo run -p runt-cli -- daemon status --json | jq -r '.daemon_info.version'
 
 When iterating on daemon code, you often want to test changes in the notebook app without rebuilding the frontend.
 
-**With Inkwell supervisor** (if you have `supervisor_*` MCP tools — e.g. in Zed):
+**With nteract-dev supervisor** (if you have `supervisor_*` MCP tools — e.g. in Zed):
 
 The supervisor manages the dev daemon for you. No env vars or extra terminals needed.
 

--- a/crates/mcp-supervisor/Cargo.toml
+++ b/crates/mcp-supervisor/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mcp-supervisor"
 version = "0.1.0"
 edition.workspace = true
-description = "Inkwell — MCP supervisor that proxies to the nteract MCP server with auto-restart, file watching, and daemon management"
+description = "nteract-dev — MCP supervisor that proxies to the nteract MCP server with auto-restart, file watching, and daemon management"
 repository.workspace = true
 license.workspace = true
 publish = false

--- a/crates/mcp-supervisor/src/main.rs
+++ b/crates/mcp-supervisor/src/main.rs
@@ -1,4 +1,4 @@
-//! Inkwell — a stable MCP server that proxies to the nteract MCP server
+//! nteract-dev — a stable MCP server that proxies to the nteract MCP server
 //! and manages the full dev environment (daemon, vite, notebook app).
 //!
 //! Architecture:
@@ -410,7 +410,7 @@ impl ClientHandler for NteractClientHandler {
     fn get_info(&self) -> rmcp::model::ClientInfo {
         rmcp::model::ClientInfo {
             client_info: Implementation {
-                name: "inkwell".into(),
+                name: "nteract-dev".into(),
                 version: env!("CARGO_PKG_VERSION").into(),
                 ..Default::default()
             },
@@ -1022,12 +1022,12 @@ impl ServerHandler for Supervisor {
             protocol_version: Default::default(),
             capabilities: ServerCapabilities::builder().enable_tools().build(),
             server_info: Implementation {
-                name: "inkwell".into(),
+                name: "nteract-dev".into(),
                 version: env!("CARGO_PKG_VERSION").into(),
                 ..Default::default()
             },
             instructions: Some(
-                "Inkwell — MCP supervisor proxying to the nteract notebook server. \
+                "nteract-dev — MCP supervisor proxying to the nteract notebook server. \
                  Includes supervisor_status, supervisor_restart, supervisor_rebuild, \
                  supervisor_logs, supervisor_start_vite, and supervisor_stop tools \
                  for managing the server lifecycle and dev environment. \
@@ -1730,7 +1730,7 @@ fn resolve_project_root() -> PathBuf {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Log to both stderr and a file (.context/inkwell.log)
+    // Log to both stderr and a file (.context/nteract-dev.log)
     // stderr goes to whatever the MCP client captures; the file is
     // readable via supervisor tools for debugging.
     let project_root_for_log = resolve_project_root();
@@ -1739,15 +1739,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Rotate previous session's log so the current file only contains this session.
     // Keeps one old copy (.log.1) for debugging daemon-restart-on-failure scenarios.
-    let inkwell_log_path = log_dir.join("inkwell.log");
-    if inkwell_log_path.exists() {
-        let _ = std::fs::rename(&inkwell_log_path, log_dir.join("inkwell.log.1"));
+    let dev_log_path = log_dir.join("nteract-dev.log");
+    if dev_log_path.exists() {
+        let _ = std::fs::rename(&dev_log_path, log_dir.join("nteract-dev.log.1"));
     }
 
     let log_file = OpenOptions::new()
         .create(true)
         .append(true)
-        .open(&inkwell_log_path)
+        .open(&dev_log_path)
         .ok();
 
     let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -106,7 +106,7 @@ Daemon:
   dev-daemon [--release]     Build and run runtimed in per-worktree dev mode
 
 MCP:
-  run-mcp [--release]        Build and run the Inkwell MCP supervisor (proxy + daemon + auto-restart)
+  run-mcp [--release]        Build and run the nteract-dev MCP supervisor (proxy + daemon + auto-restart)
   run-mcp --print-config     Print MCP client config JSON (for Zed, Claude, etc.)
   dev-mcp                    Build Python bindings and launch nteract MCP server directly (no supervisor)
   dev-mcp --print-config     Print MCP client config JSON (for Zed, Claude, etc.)


### PR DESCRIPTION
## Summary

- Renames the dev MCP server from `inkwell` to `nteract-dev` across all configs, docs, source, and skills
- Adds `.claude/rules/mcp-servers.md` to enforce correct server selection

The `inkwell` name was ambiguous — agents would grab `nteract-nightly` tools instead because the name didn't signal "this is the dev server." The new naming makes the MCP server hierarchy clear:

| Server | Purpose |
|--------|---------|
| `nteract-dev` | Dev MCP server with supervisor tools (this repo) |
| `nteract-nightly` | System-installed nightly daemon (diagnostics) |
| `nteract` | System-installed stable daemon (nteract.app) |

## Files changed

- **Configs:** `.mcp.json`, `.codex/config.toml`, `.zed/settings.json`
- **Rust:** `crates/mcp-supervisor/src/main.rs`, `Cargo.toml`, `crates/xtask/src/main.rs`
- **Docs:** `AGENTS.md`, `README.md`, `contributing/development.md`, `contributing/runtimed.md`
- **Skills:** `.claude/skills/frontend-dev/SKILL.md`, `.claude/skills/python-bindings/SKILL.md`
- **New:** `.claude/rules/mcp-servers.md` (agent rule for server selection)

## Test plan

- [ ] Restart MCP server and confirm it reports as `nteract-dev`
- [ ] Verify Claude Code uses `mcp__nteract-dev__*` tools by default
- [ ] Confirm `cargo xtask run-mcp --print-config` outputs updated name
- [ ] Check logs write to `.context/nteract-dev.log` instead of `.context/inkwell.log`