### PR TITLE
perf(build): optimize cargo xtask build with single invocation and parallelism

### DIFF
--- a/.claude/skills/build-system/SKILL.md
+++ b/.claude/skills/build-system/SKILL.md
@@ -5,150 +5,47 @@ description: Build, rebuild, and manage build artifacts. Use when building the a
 
 # Build System
 
-## Build Order
+For commands and dev workflows, see `CLAUDE.md` → "Build System" and run `cargo xtask help`.
 
-When `cargo xtask build` runs, it does these steps in order:
+## How `cargo xtask build` works
 
-1. `pnpm install` — install frontend dependencies
-2. `wasm-pack build crates/runtimed-wasm` — build WASM (only if changed; artifacts are committed)
-3. `pnpm --dir apps/notebook build` — build frontend (includes isolated-renderer inline)
-4. `cargo build --release -p runtimed -p runt-cli` — build sidecar binaries
-5. Copy binaries to `crates/notebook/binaries/` — Tauri expects them there
-6. `cargo tauri build` — bundle final app
+Three phases:
 
-## Key Constraints
+1. **Single Rust compilation** — `cargo build -p runtimed -p runt-cli -p mcp-supervisor -p notebook` in one invocation (workspace feature unification happens once, so the final tauri step doesn't recompile). Sidecars (`runtimed`, `runt`) are copied to `crates/notebook/binaries/` for Tauri bundling.
 
-| Constraint | Why |
-|---|---|
-| Frontend must build before Tauri | `tauri.conf.json` `beforeBuildCommand` runs `pnpm --dir apps/notebook build` |
-| `runtimed` + `runt` must exist in `crates/notebook/binaries/` | `tauri.conf.json` lists them in `bundle.externalBin` |
-| `runtimed-wasm` must build before frontend | wasm-pack output in `apps/notebook/src/wasm/runtimed-wasm/`; Vite imports at build time |
-| WASM artifacts are committed | Developers don't need wasm-pack for normal development |
-| `isolated-renderer` built inline | Vite plugin builds it as a virtual module (no separate step) |
-| Python wheel uses maturin | `python/runtimed/pyproject.toml` points maturin at `crates/runtimed-py/Cargo.toml` |
-| `notebook-doc` is shared | Used by `runtimed`, `runtimed-wasm`, and `runtimed-py` |
+2. **Frontend + Python bindings in parallel** — `pnpm build` (TypeScript + Vite) and `maturin develop` (Python `.so`) run concurrently. Both must finish before phase 3.
 
-## Crate Dependency Overview
+3. **Tauri link** — `cargo tauri build --debug --no-bundle` links the notebook binary with embedded frontend assets. Rust is cached from phase 1.
+
+`--rust-only` skips the frontend build in phase 2 and reuses existing `apps/notebook/dist/`.
+
+## Key constraints
+
+- All Rust targets must build in **one** `cargo build` call to avoid feature-unification recompilation.
+- `runtimed` + `runt` must exist in `crates/notebook/binaries/` before the tauri step (`bundle.externalBin`).
+- WASM artifacts are committed and validated (not rebuilt) — `ensure_wasm_resolved()` checks for git-lfs pointers.
+
+## Crate dependency graph
 
 Leaf crates (no internal deps): `tauri-jupyter`, `kernel-launch`, `runt-trust`, `runt-workspace`
 
-Shared crates:
-- `notebook-doc` depends on nothing internal
-- `notebook-protocol` depends on `notebook-doc`, `kernel-env`
-- `notebook-sync` depends on `notebook-doc`, `notebook-protocol`
-- `runtimed` depends on `notebook-doc`, `notebook-protocol`, `kernel-launch`, `kernel-env`, `runt-trust`, `runt-workspace`
+Shared:
+- `notebook-doc` → no internal deps
+- `notebook-protocol` → `notebook-doc`, `kernel-env`
+- `notebook-sync` → `notebook-doc`, `notebook-protocol`
+- `runtimed` → `notebook-doc`, `notebook-protocol`, `kernel-launch`, `kernel-env`, `runt-trust`, `runt-workspace`
 
-App crates:
-- `notebook` (Tauri app) depends on `tauri-jupyter`, `runtimed`, `notebook-sync`, `runt-trust`, `runt-workspace`
-- `runt-cli` depends on `runtimed`, `runt-workspace`
-- `runtimed-py` depends on `runtimed`, `notebook-doc`, `notebook-protocol`, `notebook-sync`, `runt-workspace`
-- `runtimed-wasm` depends on `notebook-doc`
+App binaries:
+- `notebook` (Tauri) → `runtimed`, `notebook-sync`, `runt-trust`, `runt-workspace`
+- `runt-cli` → `runtimed`, `runt-workspace`
+- `runtimed-py` → `runtimed`, `notebook-doc`, `notebook-protocol`, `notebook-sync`, `runt-workspace`
+- `runtimed-wasm` → `notebook-doc`
 
-## WASM Rebuild
+## WASM rebuild
 
 Only needed when changing `crates/runtimed-wasm/` or `crates/notebook-doc/`:
 
 ```bash
 wasm-pack build crates/runtimed-wasm --target web --out-dir ../../apps/notebook/src/wasm/runtimed-wasm
-# Commit the output -- WASM artifacts are checked into the repo
+# Commit the output
 ```
-
-## Development Workflows
-
-### `cargo xtask dev` — One-shot setup + dev
-
-```bash
-cargo xtask dev                          # Full: pnpm install + build + daemon + app
-cargo xtask dev --skip-install --skip-build  # Fast repeat launch
-```
-
-Runs pnpm install, builds everything, starts dev daemon, waits for it, launches notebook.
-
-### `cargo xtask notebook` — Hot reload
-
-```bash
-cargo xtask notebook
-```
-
-Uses Vite dev server on port 5174. React component changes hot-reload instantly. Best for UI development.
-
-### `cargo xtask vite` + `notebook --attach` — Multi-window testing
-
-```bash
-# Terminal 1: Start Vite standalone (stays running)
-cargo xtask vite
-
-# Terminal 2+: Attach Tauri to existing Vite
-cargo xtask notebook --attach
-```
-
-Closing Tauri windows doesn't kill Vite. Useful for collaboration testing.
-
-### `cargo xtask build` + `run` — Debug build
-
-```bash
-cargo xtask build           # Full build (frontend + rust)
-cargo xtask run             # Run the bundled binary
-cargo xtask run path/to/notebook.ipynb  # With specific notebook
-```
-
-Builds debug binary with frontend assets bundled. Emits JS source maps for devtools.
-
-### `cargo xtask build --rust-only` — Fast Rust iteration
-
-```bash
-cargo xtask build              # First time: full build
-cargo xtask build --rust-only  # Subsequent: skip frontend (much faster)
-cargo xtask run
-```
-
-Ideal for daemon development. Build frontend once, iterate on Rust.
-
-### `cargo xtask build-app` / `build-dmg` — Release builds
-
-Mostly CI. Use locally only for testing app bundle structure, file associations, icons.
-
-## Build Cache (sccache)
-
-```bash
-brew install sccache   # macOS
-```
-
-Auto-detected by xtask. Shares compiled artifacts across worktrees. Without it, each worktree rebuilds ~788 crates from scratch.
-
-## Before You Commit
-
-```bash
-cargo xtask lint --fix
-```
-
-Formats Rust, lints/formats TypeScript/JavaScript with Biome, lints/formats Python with ruff. CI rejects PRs that fail.
-
-For check-only mode: `cargo xtask lint`
-
-## Test Notebooks
-
-Test notebooks: `crates/notebook/fixtures/audit-test/`
-Sample notebooks: `crates/notebook/resources/sample-notebooks/`
-
-```bash
-cargo xtask build
-./target/debug/notebook crates/notebook/fixtures/audit-test/1-vanilla.ipynb
-```
-
-## Quick Reference
-
-| Task | Command |
-|------|---------|
-| One-shot setup | `cargo xtask dev` |
-| Hot reload | `cargo xtask notebook` |
-| Standalone Vite | `cargo xtask vite` |
-| Attach to Vite | `cargo xtask notebook --attach` |
-| Full debug build | `cargo xtask build` |
-| Rust-only rebuild | `cargo xtask build --rust-only` |
-| Run bundled binary | `cargo xtask run` |
-| Build release .app | `cargo xtask build-app` |
-| Build release DMG | `cargo xtask build-dmg` |
-| Lint (check) | `cargo xtask lint` |
-| Lint (fix) | `cargo xtask lint --fix` |
-| See all commands | `cargo xtask help` |

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -575,19 +575,41 @@ fn cmd_build(rust_only: bool) {
         require_pnpm();
     }
 
-    // Build runtimed daemon binary for bundling (debug mode for faster builds)
-    build_runtimed_daemon(false);
+    // Phase 1: Single cargo invocation for all binaries.
+    // Building all packages together ensures workspace feature unification
+    // happens in one pass, so the later `cargo tauri build` finds everything
+    // cached instead of recompiling the entire dependency tree.
+    println!("Building all Rust targets (runtimed, runt, mcp-supervisor, notebook)...");
+    run_cmd(
+        "cargo",
+        &[
+            "build",
+            "-p",
+            "runtimed",
+            "-p",
+            "runt-cli",
+            "-p",
+            "mcp-supervisor",
+            "-p",
+            "notebook",
+        ],
+    );
 
-    // Build MCP supervisor binary
-    println!("Building MCP supervisor...");
-    run_cmd("cargo", &["build", "-p", "mcp-supervisor"]);
+    // Copy sidecar binaries for Tauri bundling
+    copy_sidecar_binary("runtimed", false);
+    copy_sidecar_binary("runt", false);
 
-    // Sync Python workspace and build native bindings (runtimed-py)
-    ensure_python_env();
-    ensure_maturin_develop();
+    // Phase 2: Run independent tasks in parallel.
+    // - Python env sync + maturin develop (builds .so for MCP server)
+    // - Frontend build (pnpm/vite, completely independent of Rust)
+    let mut handles: Vec<thread::JoinHandle<()>> = Vec::new();
+
+    handles.push(thread::spawn(|| {
+        ensure_python_env();
+        ensure_maturin_develop();
+    }));
 
     if rust_only {
-        // Check that frontend dist exists
         let dist_dir = Path::new("apps/notebook/dist");
         if !dist_dir.exists() {
             eprintln!("Error: No frontend build found at apps/notebook/dist");
@@ -596,11 +618,21 @@ fn cmd_build(rust_only: bool) {
         }
         println!("Skipping frontend build (--rust-only), reusing existing assets");
     } else {
-        // pnpm build runs: notebook UI
-        println!("Building frontend (notebook)...");
-        run_frontend_build(true);
+        handles.push(thread::spawn(|| {
+            println!("Building frontend (notebook)...");
+            run_frontend_build(true);
+        }));
     }
 
+    for handle in handles {
+        handle.join().unwrap_or_else(|_| {
+            eprintln!("A parallel build task panicked");
+            exit(1);
+        });
+    }
+
+    // Phase 3: Tauri build. With all Rust already compiled and frontend
+    // assets in place, this is mostly a link step.
     println!("Building debug binary (no bundle)...");
     run_cmd(
         "cargo",
@@ -1759,9 +1791,6 @@ fn build_external_binary(package: &str, binary_name: &str, release: bool) {
     let mode = if release { "release" } else { "debug" };
     println!("Building {binary_name} ({mode})...");
 
-    // Get the host target triple
-    let target = get_host_target();
-
     // Build with appropriate profile
     if release {
         run_cmd("cargo", &["build", "--release", "-p", package]);
@@ -1769,7 +1798,14 @@ fn build_external_binary(package: &str, binary_name: &str, release: bool) {
         run_cmd("cargo", &["build", "-p", package]);
     }
 
-    // Determine source and destination paths
+    copy_sidecar_binary(binary_name, release);
+}
+
+/// Copy an already-built binary to the sidecar locations for Tauri bundling.
+/// Copies to both `crates/notebook/binaries/` (for bundle builds) and
+/// `target/{debug,release}/binaries/` (for no-bundle dev builds).
+fn copy_sidecar_binary(binary_name: &str, release: bool) {
+    let target = get_host_target();
     let target_dir = if release {
         "target/release"
     } else {


### PR DESCRIPTION
## Summary

`cargo xtask build` was running 3 separate `cargo build` invocations (runtimed, runt-cli, mcp-supervisor) followed by `maturin develop` and then `cargo tauri build --debug`. The tauri step recompiled the entire dependency tree (~1m35s) because separate cargo invocations resolve workspace features independently, invalidating the cache when the full dependency graph is later unified.

This PR restructures the build into 3 phases:
1. **Single `cargo build`** for all Rust targets (`-p runtimed -p runt-cli -p mcp-supervisor -p notebook`) — feature unification happens once
2. **Parallel** frontend build (`pnpm build`) and Python bindings (`maturin develop`) via `thread::spawn`
3. **Tauri link** step that reuses cached Rust artifacts

Also trims the `.claude/skills/build-system/SKILL.md` from ~160 lines to ~60 by removing content already covered in `CLAUDE.md`.

## Verification

- [ ] Run `cargo xtask build` and confirm it completes successfully
- [ ] Run `cargo xtask build --rust-only` and confirm it still works
- [ ] Run `cargo xtask dev-daemon` to confirm it still uses the original `build_external_binary` path
- [ ] Compare build times before/after (initial test showed ~4m21s → ~1m29s)

_PR submitted by @rgbkrk's agent, Quill_