### PR TITLE
chore(ci): drop unnecessary runt-cli build from Python integration tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -258,7 +258,7 @@ jobs:
       - name: Build external binaries
         shell: bash
         run: |
-          cargo build --release -p runtimed -p runt-cli
+          cargo build --release -p runtimed -p runt-cli -p notebook
           TARGET=$(rustc --print host-tuple)
           mkdir -p crates/notebook/binaries
           if [[ "$RUNNER_OS" == "Windows" ]]; then
@@ -401,7 +401,7 @@ jobs:
         if: needs.changes.outputs.source_changed == 'true' && (github.event_name != 'pull_request' || matrix.platform.run_on_pr)
         shell: bash
         run: |
-          cargo build --release -p runtimed -p runt-cli
+          cargo build --release -p runtimed -p runt-cli -p notebook
           TARGET=$(rustc --print host-tuple)
           mkdir -p crates/notebook/binaries
           if [[ "$RUNNER_OS" == "Windows" ]]; then
@@ -655,7 +655,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
 
       - name: Build runtimed binary
-        run: cargo build --release -p runtimed -p runt-cli
+        run: cargo build --release -p runtimed
 
       - name: Build runtimed-py
         working-directory: python/runtimed

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -269,9 +269,6 @@ jobs:
             cp target/release/runt "crates/notebook/binaries/runt-$TARGET"
           fi
 
-      - name: Build notebook crate (pre-warm cache for tauri build)
-        run: cargo build --release -p notebook
-
       - name: Clippy (notebook crate)
         run: cargo clippy -p notebook --all-targets -- -D warnings
 
@@ -414,10 +411,6 @@ jobs:
             cp target/release/runtimed "crates/notebook/binaries/runtimed-$TARGET"
             cp target/release/runt "crates/notebook/binaries/runt-$TARGET"
           fi
-
-      - name: Build notebook crate (pre-warm cache for full build)
-        if: needs.changes.outputs.source_changed == 'true' && (github.event_name != 'pull_request' || matrix.platform.run_on_pr)
-        run: cargo build --release -p notebook
 
       - name: Clippy
         if: needs.changes.outputs.source_changed == 'true' && (github.event_name != 'pull_request' || matrix.platform.run_on_pr)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -258,7 +258,7 @@ jobs:
       - name: Build external binaries
         shell: bash
         run: |
-          cargo build --release -p runtimed -p runt-cli -p notebook
+          cargo build --release -p runtimed -p runt-cli
           TARGET=$(rustc --print host-tuple)
           mkdir -p crates/notebook/binaries
           if [[ "$RUNNER_OS" == "Windows" ]]; then
@@ -268,6 +268,9 @@ jobs:
             cp target/release/runtimed "crates/notebook/binaries/runtimed-$TARGET"
             cp target/release/runt "crates/notebook/binaries/runt-$TARGET"
           fi
+
+      - name: Build notebook crate (pre-warm cache for tauri build)
+        run: cargo build --release -p notebook
 
       - name: Clippy (notebook crate)
         run: cargo clippy -p notebook --all-targets -- -D warnings
@@ -401,7 +404,7 @@ jobs:
         if: needs.changes.outputs.source_changed == 'true' && (github.event_name != 'pull_request' || matrix.platform.run_on_pr)
         shell: bash
         run: |
-          cargo build --release -p runtimed -p runt-cli -p notebook
+          cargo build --release -p runtimed -p runt-cli
           TARGET=$(rustc --print host-tuple)
           mkdir -p crates/notebook/binaries
           if [[ "$RUNNER_OS" == "Windows" ]]; then
@@ -411,6 +414,10 @@ jobs:
             cp target/release/runtimed "crates/notebook/binaries/runtimed-$TARGET"
             cp target/release/runt "crates/notebook/binaries/runt-$TARGET"
           fi
+
+      - name: Build notebook crate (pre-warm cache for full build)
+        if: needs.changes.outputs.source_changed == 'true' && (github.event_name != 'pull_request' || matrix.platform.run_on_pr)
+        run: cargo build --release -p notebook
 
       - name: Clippy
         if: needs.changes.outputs.source_changed == 'true' && (github.event_name != 'pull_request' || matrix.platform.run_on_pr)


### PR DESCRIPTION
## Summary

The `runtimed-py-integration` CI job was building both `runtimed` and `runt-cli`, but only the `runtimed` binary is used — the tests spawn the daemon directly and never invoke the `runt` CLI. This was likely left over from when `runt` was bundled into the Python package.

## Verification

- [ ] `runtimed-py Integration Tests` job passes without `runt-cli`

_PR submitted by @rgbkrk's agent, Quill_