### PR TITLE
fix(mcp): advertise resources.listChanged capability

### DIFF
--- a/crates/mcp-supervisor/src/main.rs
+++ b/crates/mcp-supervisor/src/main.rs
@@ -1065,6 +1065,7 @@ impl ServerHandler for Supervisor {
             capabilities: ServerCapabilities::builder()
                 .enable_tools()
                 .enable_resources()
+                .enable_resources_list_changed()
                 .build(),
             server_info: Implementation {
                 name: "nteract-dev".into(),


### PR DESCRIPTION
## Summary

Follow-up to #1278. The supervisor was sending `resources/list_changed` notifications on child restart but wasn't advertising the `listChanged` capability in `ServerCapabilities`. MCP clients that honor capabilities wouldn't refresh resource listings after a restart.

Adds `.enable_resources_list_changed()` to the capabilities builder.

## Verification

- [ ] `cargo xtask run-mcp` starts and MCP client sees `listChanged` in the resources capability
- [ ] After child restart, client refreshes its resource list

_PR submitted by @rgbkrk's agent, Quill_