### PR TITLE
feat(xtask): add mcpb command to package nteract as a Claude Desktop extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ target/
 # Cargo.lock checked in for binaries
 # Cargo.lock
 
+# MCPB build artifacts
+*.mcpb
+
 # iPython
 .ipynb_checkpoints
 Untitled*.ipynb

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -2014,8 +2014,7 @@ fn cmd_mcpb(output: Option<&str>) {
     let version = read_package_version("runtimed");
 
     // ── 1. Create a staging directory ───────────────────────────────────────
-    let staging_dir =
-        std::env::temp_dir().join(format!("nteract-mcpb-{}", std::process::id()));
+    let staging_dir = std::env::temp_dir().join(format!("nteract-mcpb-{}", std::process::id()));
     fs::create_dir_all(&staging_dir).unwrap_or_else(|e| {
         eprintln!("Failed to create staging directory: {e}");
         exit(1);

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -77,8 +77,7 @@ fn main() {
                 .windows(2)
                 .find(|w| w[0] == "--output")
                 .map(|w| w[1].as_str());
-            let universal = args.iter().any(|a| a == "--universal");
-            cmd_mcpb(output, universal);
+            cmd_mcpb(output);
         }
         "--help" | "-h" | "help" => print_help(),
         cmd => {
@@ -134,7 +133,6 @@ Other:
   icons [source.png]         Generate icon variants
   mcpb                       Package nteract as a Claude Desktop extension (.mcpb)
   mcpb --output <path>       Write the .mcpb archive to a custom path (default: nteract.mcpb)
-  mcpb --universal           Build a universal macOS binary (arm64 + x86_64)
   help                       Show this help
 "
     );
@@ -2007,76 +2005,23 @@ fn exit_on_failed_status(label: &str, status: ExitStatus) {
 ///   manifest.json   — metadata and server entry point
 ///   icon.png        — 512×512 light-theme icon
 ///   icon-dark.png   — 512×512 dark-theme icon
-///   server/nteract  — the nteract MCP server binary (mcp-supervisor)
 ///
-/// NOTE: The entry point will switch to `server/runt` with `["mcp"]` arguments
-/// once the `runt mcp` subcommand (issue #1261) is implemented.
-fn cmd_mcpb(output: Option<&str>, universal: bool) {
+/// The server is NOT bundled as a binary. Instead the manifest instructs
+/// Claude Desktop to invoke `uvx nteract` — the nteract MCP server is
+/// distributed as a Python package on PyPI and fetched on first use.
+fn cmd_mcpb(output: Option<&str>) {
     let output_path = output.unwrap_or("nteract.mcpb");
     let version = read_package_version("runtimed");
 
-    // ── 1. Build the nteract MCP server binary ───────────────────────────────
-    // TODO(#1261): switch to `runt-cli` once `runt mcp` is implemented.
-    if universal {
-        #[cfg(target_os = "macos")]
-        build_universal_macos_binary("mcp-supervisor");
-        #[cfg(not(target_os = "macos"))]
-        {
-            eprintln!("--universal is only supported on macOS");
-            exit(1);
-        }
-    } else {
-        println!("Building nteract MCP server (release)...");
-        run_cmd("cargo", &["build", "--release", "-p", "mcp-supervisor"]);
-    }
-
-    // ── 2. Create a staging directory ───────────────────────────────────────
-    let staging_dir = std::env::temp_dir().join(format!("nteract-mcpb-{}", std::process::id()));
-    let server_dir = staging_dir.join("server");
-    fs::create_dir_all(&server_dir).unwrap_or_else(|e| {
+    // ── 1. Create a staging directory ───────────────────────────────────────
+    let staging_dir =
+        std::env::temp_dir().join(format!("nteract-mcpb-{}", std::process::id()));
+    fs::create_dir_all(&staging_dir).unwrap_or_else(|e| {
         eprintln!("Failed to create staging directory: {e}");
         exit(1);
     });
 
-    // ── 3. Copy binary into server/ ─────────────────────────────────────────
-    let (binary_src, binary_dst_name) = if cfg!(windows) {
-        ("target/release/mcp-supervisor.exe", "nteract.exe")
-    } else {
-        ("target/release/mcp-supervisor", "nteract")
-    };
-
-    if universal {
-        #[cfg(target_os = "macos")]
-        {
-            // The universal lipo output is written to a fixed path by
-            // build_universal_macos_binary(); copy it into the bundle.
-            let lipo_out = "target/universal-apple-darwin/mcp-supervisor";
-            fs::copy(lipo_out, server_dir.join(binary_dst_name)).unwrap_or_else(|e| {
-                eprintln!("Failed to copy universal binary: {e}");
-                exit(1);
-            });
-        }
-    } else {
-        fs::copy(binary_src, server_dir.join(binary_dst_name)).unwrap_or_else(|e| {
-            eprintln!("Failed to copy binary: {e}");
-            exit(1);
-        });
-    }
-
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        fs::set_permissions(
-            server_dir.join(binary_dst_name),
-            fs::Permissions::from_mode(0o755),
-        )
-        .unwrap_or_else(|e| {
-            eprintln!("Failed to set binary permissions: {e}");
-            exit(1);
-        });
-    }
-
-    // ── 4. Copy icons ────────────────────────────────────────────────────────
+    // ── 2. Copy icons ────────────────────────────────────────────────────────
     // Prefer source.png (full-resolution source); fall back to icon.png.
     let light_src = if Path::new("crates/notebook/icons/source.png").exists() {
         "crates/notebook/icons/source.png"
@@ -2104,13 +2049,9 @@ fn cmd_mcpb(output: Option<&str>, universal: bool) {
         exit(1);
     });
 
-    // ── 5. Write manifest.json ───────────────────────────────────────────────
-    let entry_point = if cfg!(windows) {
-        "server/nteract.exe"
-    } else {
-        "server/nteract"
-    };
-
+    // ── 3. Write manifest.json ───────────────────────────────────────────────
+    // The server is invoked via `uvx nteract` — no binary is bundled.
+    // uvx fetches and runs the `nteract` PyPI package on first use.
     let manifest = serde_json::json!({
         "manifest_version": "0.3",
         "name": "nteract",
@@ -2124,11 +2065,10 @@ fn cmd_mcpb(output: Option<&str>, universal: bool) {
         "repository": "https://github.com/nteract/desktop",
         "license": "BSD-3-Clause",
         "server": {
-            "type": "binary",
-            "entry_point": entry_point,
+            "type": "stdio",
             "mcp_config": {
-                "command": entry_point,
-                "arguments": []
+                "command": "uvx",
+                "arguments": ["nteract"]
             }
         },
         "icons": [
@@ -2148,7 +2088,7 @@ fn cmd_mcpb(output: Option<&str>, universal: bool) {
         exit(1);
     });
 
-    // ── 6. Create ZIP archive ────────────────────────────────────────────────
+    // ── 4. Create ZIP archive ────────────────────────────────────────────────
     // Resolve the output path to an absolute path before changing directories.
     let abs_output = if Path::new(output_path).is_absolute() {
         Path::new(output_path).to_path_buf()
@@ -2182,67 +2122,10 @@ fn cmd_mcpb(output: Option<&str>, universal: bool) {
         exit(1);
     }
 
-    // ── 7. Cleanup staging dir ───────────────────────────────────────────────
+    // ── 5. Cleanup staging dir ───────────────────────────────────────────────
     let _ = fs::remove_dir_all(&staging_dir);
 
     println!("Done: {}", abs_output.display());
-}
-
-/// Build a universal macOS binary (arm64 + x86_64) via lipo.
-///
-/// Requires both cross-compilation targets to be installed:
-///   rustup target add aarch64-apple-darwin x86_64-apple-darwin
-///
-/// The merged binary is written to `target/universal-apple-darwin/<package>`.
-#[cfg(target_os = "macos")]
-fn build_universal_macos_binary(package: &str) {
-    println!("Building {package} for aarch64-apple-darwin...");
-    run_cmd(
-        "cargo",
-        &[
-            "build",
-            "--release",
-            "-p",
-            package,
-            "--target",
-            "aarch64-apple-darwin",
-        ],
-    );
-
-    println!("Building {package} for x86_64-apple-darwin...");
-    run_cmd(
-        "cargo",
-        &[
-            "build",
-            "--release",
-            "-p",
-            package,
-            "--target",
-            "x86_64-apple-darwin",
-        ],
-    );
-
-    let out_dir = Path::new("target/universal-apple-darwin");
-    fs::create_dir_all(out_dir).unwrap_or_else(|e| {
-        eprintln!("Failed to create universal output directory: {e}");
-        exit(1);
-    });
-
-    let arm_bin = format!("target/aarch64-apple-darwin/release/{package}");
-    let x86_bin = format!("target/x86_64-apple-darwin/release/{package}");
-    let out_bin = out_dir.join(package);
-
-    println!("Creating universal binary with lipo...");
-    run_cmd(
-        "lipo",
-        &[
-            "-create",
-            "-output",
-            &out_bin.to_string_lossy(),
-            &arm_bin,
-            &x86_bin,
-        ],
-    );
 }
 
 /// Read the version of a workspace package from `cargo metadata`.

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -72,6 +72,14 @@ fn main() {
             cmd_integration(filter);
         }
         "wasm" => cmd_wasm(),
+        "mcpb" => {
+            let output = args
+                .windows(2)
+                .find(|w| w[0] == "--output")
+                .map(|w| w[1].as_str());
+            let universal = args.iter().any(|a| a == "--universal");
+            cmd_mcpb(output, universal);
+        }
         "--help" | "-h" | "help" => print_help(),
         cmd => {
             eprintln!("Unknown command: {cmd}");
@@ -124,6 +132,9 @@ Testing:
 Other:
   wasm                       Rebuild runtimed-wasm (wasm-pack build)
   icons [source.png]         Generate icon variants
+  mcpb                       Package nteract as a Claude Desktop extension (.mcpb)
+  mcpb --output <path>       Write the .mcpb archive to a custom path (default: nteract.mcpb)
+  mcpb --universal           Build a universal macOS binary (arm64 + x86_64)
   help                       Show this help
 "
     );
@@ -1988,6 +1999,280 @@ fn exit_on_failed_status(label: &str, status: ExitStatus) {
         eprintln!("{label} exited with status {status}");
         exit(status.code().unwrap_or(1));
     }
+}
+
+/// Package nteract as a Claude Desktop extension (.mcpb ZIP archive).
+///
+/// The bundle contains:
+///   manifest.json   — metadata and server entry point
+///   icon.png        — 512×512 light-theme icon
+///   icon-dark.png   — 512×512 dark-theme icon
+///   server/nteract  — the nteract MCP server binary (mcp-supervisor)
+///
+/// NOTE: The entry point will switch to `server/runt` with `["mcp"]` arguments
+/// once the `runt mcp` subcommand (issue #1261) is implemented.
+fn cmd_mcpb(output: Option<&str>, universal: bool) {
+    let output_path = output.unwrap_or("nteract.mcpb");
+    let version = read_package_version("runtimed");
+
+    // ── 1. Build the nteract MCP server binary ───────────────────────────────
+    // TODO(#1261): switch to `runt-cli` once `runt mcp` is implemented.
+    if universal {
+        #[cfg(target_os = "macos")]
+        build_universal_macos_binary("mcp-supervisor");
+        #[cfg(not(target_os = "macos"))]
+        {
+            eprintln!("--universal is only supported on macOS");
+            exit(1);
+        }
+    } else {
+        println!("Building nteract MCP server (release)...");
+        run_cmd("cargo", &["build", "--release", "-p", "mcp-supervisor"]);
+    }
+
+    // ── 2. Create a staging directory ───────────────────────────────────────
+    let staging_dir = std::env::temp_dir().join(format!("nteract-mcpb-{}", std::process::id()));
+    let server_dir = staging_dir.join("server");
+    fs::create_dir_all(&server_dir).unwrap_or_else(|e| {
+        eprintln!("Failed to create staging directory: {e}");
+        exit(1);
+    });
+
+    // ── 3. Copy binary into server/ ─────────────────────────────────────────
+    let (binary_src, binary_dst_name) = if cfg!(windows) {
+        ("target/release/mcp-supervisor.exe", "nteract.exe")
+    } else {
+        ("target/release/mcp-supervisor", "nteract")
+    };
+
+    if universal {
+        #[cfg(target_os = "macos")]
+        {
+            // The universal lipo output is written to a fixed path by
+            // build_universal_macos_binary(); copy it into the bundle.
+            let lipo_out = "target/universal-apple-darwin/mcp-supervisor";
+            fs::copy(lipo_out, server_dir.join(binary_dst_name)).unwrap_or_else(|e| {
+                eprintln!("Failed to copy universal binary: {e}");
+                exit(1);
+            });
+        }
+    } else {
+        fs::copy(binary_src, server_dir.join(binary_dst_name)).unwrap_or_else(|e| {
+            eprintln!("Failed to copy binary: {e}");
+            exit(1);
+        });
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(
+            server_dir.join(binary_dst_name),
+            fs::Permissions::from_mode(0o755),
+        )
+        .unwrap_or_else(|e| {
+            eprintln!("Failed to set binary permissions: {e}");
+            exit(1);
+        });
+    }
+
+    // ── 4. Copy icons ────────────────────────────────────────────────────────
+    // Prefer source.png (full-resolution source); fall back to icon.png.
+    let light_src = if Path::new("crates/notebook/icons/source.png").exists() {
+        "crates/notebook/icons/source.png"
+    } else if Path::new("crates/notebook/icons/icon.png").exists() {
+        "crates/notebook/icons/icon.png"
+    } else {
+        eprintln!("No icon found. Run `cargo xtask icons` first to generate icons.");
+        exit(1);
+    };
+
+    // Use source-nightly.png for the dark variant if it exists, otherwise
+    // fall back to the same image as the light icon.
+    let dark_src = if Path::new("crates/notebook/icons/source-nightly.png").exists() {
+        "crates/notebook/icons/source-nightly.png"
+    } else {
+        light_src
+    };
+
+    fs::copy(light_src, staging_dir.join("icon.png")).unwrap_or_else(|e| {
+        eprintln!("Failed to copy icon.png: {e}");
+        exit(1);
+    });
+    fs::copy(dark_src, staging_dir.join("icon-dark.png")).unwrap_or_else(|e| {
+        eprintln!("Failed to copy icon-dark.png: {e}");
+        exit(1);
+    });
+
+    // ── 5. Write manifest.json ───────────────────────────────────────────────
+    let entry_point = if cfg!(windows) {
+        "server/nteract.exe"
+    } else {
+        "server/nteract"
+    };
+
+    let manifest = serde_json::json!({
+        "manifest_version": "0.3",
+        "name": "nteract",
+        "display_name": "nteract",
+        "version": version,
+        "description": "Create, edit, and run Jupyter notebooks with Claude",
+        "author": {
+            "name": "nteract contributors",
+            "url": "https://nteract.io"
+        },
+        "repository": "https://github.com/nteract/desktop",
+        "license": "BSD-3-Clause",
+        "server": {
+            "type": "binary",
+            "entry_point": entry_point,
+            "mcp_config": {
+                "command": entry_point,
+                "arguments": []
+            }
+        },
+        "icons": [
+            { "src": "icon.png", "size": "512x512", "theme": "light" },
+            { "src": "icon-dark.png", "size": "512x512", "theme": "dark" }
+        ],
+        "keywords": ["jupyter", "notebook", "python", "data-science"]
+    });
+
+    let manifest_str = serde_json::to_string_pretty(&manifest).unwrap_or_else(|e| {
+        eprintln!("Failed to serialize manifest.json: {e}");
+        exit(1);
+    });
+
+    fs::write(staging_dir.join("manifest.json"), &manifest_str).unwrap_or_else(|e| {
+        eprintln!("Failed to write manifest.json: {e}");
+        exit(1);
+    });
+
+    // ── 6. Create ZIP archive ────────────────────────────────────────────────
+    // Resolve the output path to an absolute path before changing directories.
+    let abs_output = if Path::new(output_path).is_absolute() {
+        Path::new(output_path).to_path_buf()
+    } else {
+        std::env::current_dir()
+            .unwrap_or_else(|e| {
+                eprintln!("Failed to get current directory: {e}");
+                exit(1);
+            })
+            .join(output_path)
+    };
+
+    // Remove any existing archive so zip doesn't merge old contents.
+    let _ = fs::remove_file(&abs_output);
+
+    println!("Creating archive {}...", abs_output.display());
+
+    let zip_status = Command::new("zip")
+        .args(["-r", &abs_output.to_string_lossy(), "."])
+        .current_dir(&staging_dir)
+        .status()
+        .unwrap_or_else(|e| {
+            eprintln!("Failed to run zip: {e}");
+            eprintln!("zip must be available in PATH.");
+            exit(1);
+        });
+
+    if !zip_status.success() {
+        eprintln!("zip command failed");
+        let _ = fs::remove_dir_all(&staging_dir);
+        exit(1);
+    }
+
+    // ── 7. Cleanup staging dir ───────────────────────────────────────────────
+    let _ = fs::remove_dir_all(&staging_dir);
+
+    println!("Done: {}", abs_output.display());
+}
+
+/// Build a universal macOS binary (arm64 + x86_64) via lipo.
+///
+/// Requires both cross-compilation targets to be installed:
+///   rustup target add aarch64-apple-darwin x86_64-apple-darwin
+///
+/// The merged binary is written to `target/universal-apple-darwin/<package>`.
+#[cfg(target_os = "macos")]
+fn build_universal_macos_binary(package: &str) {
+    println!("Building {package} for aarch64-apple-darwin...");
+    run_cmd(
+        "cargo",
+        &[
+            "build",
+            "--release",
+            "-p",
+            package,
+            "--target",
+            "aarch64-apple-darwin",
+        ],
+    );
+
+    println!("Building {package} for x86_64-apple-darwin...");
+    run_cmd(
+        "cargo",
+        &[
+            "build",
+            "--release",
+            "-p",
+            package,
+            "--target",
+            "x86_64-apple-darwin",
+        ],
+    );
+
+    let out_dir = Path::new("target/universal-apple-darwin");
+    fs::create_dir_all(out_dir).unwrap_or_else(|e| {
+        eprintln!("Failed to create universal output directory: {e}");
+        exit(1);
+    });
+
+    let arm_bin = format!("target/aarch64-apple-darwin/release/{package}");
+    let x86_bin = format!("target/x86_64-apple-darwin/release/{package}");
+    let out_bin = out_dir.join(package);
+
+    println!("Creating universal binary with lipo...");
+    run_cmd(
+        "lipo",
+        &[
+            "-create",
+            "-output",
+            &out_bin.to_string_lossy(),
+            &arm_bin,
+            &x86_bin,
+        ],
+    );
+}
+
+/// Read the version of a workspace package from `cargo metadata`.
+fn read_package_version(package: &str) -> String {
+    let output = Command::new("cargo")
+        .args(["metadata", "--no-deps", "--format-version", "1"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .output()
+        .unwrap_or_else(|e| {
+            eprintln!("Failed to run cargo metadata: {e}");
+            exit(1);
+        });
+
+    if !output.status.success() {
+        eprintln!("cargo metadata failed");
+        exit(1);
+    }
+
+    let metadata: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
+        eprintln!("Failed to parse cargo metadata output: {e}");
+        exit(1);
+    });
+
+    metadata["packages"]
+        .as_array()
+        .and_then(|pkgs| pkgs.iter().find(|p| p["name"].as_str() == Some(package)))
+        .and_then(|p| p["version"].as_str())
+        .unwrap_or("0.0.0")
+        .to_string()
 }
 
 #[cfg(test)]

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -77,7 +77,12 @@ fn main() {
                 .windows(2)
                 .find(|w| w[0] == "--output")
                 .map(|w| w[1].as_str());
-            cmd_mcpb(output);
+            let variant = args
+                .windows(2)
+                .find(|w| w[0] == "--variant")
+                .map(|w| w[1].as_str())
+                .unwrap_or("stable");
+            cmd_mcpb(output, variant);
         }
         "--help" | "-h" | "help" => print_help(),
         cmd => {
@@ -132,7 +137,8 @@ Other:
   wasm                       Rebuild runtimed-wasm (wasm-pack build)
   icons [source.png]         Generate icon variants
   mcpb                       Package nteract as a Claude Desktop extension (.mcpb)
-  mcpb --output <path>       Write the .mcpb archive to a custom path (default: nteract.mcpb)
+  mcpb --variant nightly     Build nightly variant (different name/icon)
+  mcpb --output <path>       Write the .mcpb archive to a custom path
   help                       Show this help
 "
     );
@@ -2009,85 +2015,114 @@ fn exit_on_failed_status(label: &str, status: ExitStatus) {
 /// The server is NOT bundled as a binary. Instead the manifest instructs
 /// Claude Desktop to invoke `uvx nteract` — the nteract MCP server is
 /// distributed as a Python package on PyPI and fetched on first use.
-fn cmd_mcpb(output: Option<&str>) {
-    let output_path = output.unwrap_or("nteract.mcpb");
+///
+/// Manifest templates live in `mcpb/manifest.{variant}.json`. The only
+/// substitution is `{{VERSION}}` → the `runtimed` crate version.
+fn cmd_mcpb(output: Option<&str>, variant: &str) {
     let version = read_package_version("runtimed");
 
-    // ── 1. Create a staging directory ───────────────────────────────────────
+    // ── 1. Read and populate the manifest template ──────────────────────────
+    let template_path = format!("mcpb/manifest.{variant}.json");
+    let template = fs::read_to_string(&template_path).unwrap_or_else(|e| {
+        eprintln!("Failed to read {template_path}: {e}");
+        eprintln!("Valid variants: stable, nightly (looked for mcpb/manifest.{{variant}}.json)");
+        exit(1);
+    });
+
+    let manifest_str = template.replace("{{VERSION}}", &version);
+
+    // Parse to validate JSON and re-serialize with consistent formatting.
+    let manifest: serde_json::Value = serde_json::from_str(&manifest_str).unwrap_or_else(|e| {
+        eprintln!("Invalid JSON in {template_path} after substitution: {e}");
+        exit(1);
+    });
+    let manifest_str = serde_json::to_string_pretty(&manifest).unwrap_or_else(|e| {
+        eprintln!("Failed to serialize manifest.json: {e}");
+        exit(1);
+    });
+
+    // ── 2. Create a staging directory ───────────────────────────────────────
     let staging_dir = std::env::temp_dir().join(format!("nteract-mcpb-{}", std::process::id()));
     fs::create_dir_all(&staging_dir).unwrap_or_else(|e| {
         eprintln!("Failed to create staging directory: {e}");
         exit(1);
     });
 
-    // ── 2. Copy icons ────────────────────────────────────────────────────────
-    // Prefer source.png (full-resolution source); fall back to icon.png.
-    let light_src = if Path::new("crates/notebook/icons/source.png").exists() {
-        "crates/notebook/icons/source.png"
-    } else if Path::new("crates/notebook/icons/icon.png").exists() {
-        "crates/notebook/icons/icon.png"
-    } else {
-        eprintln!("No icon found. Run `cargo xtask icons` first to generate icons.");
-        exit(1);
+    // ── 3. Copy icons ────────────────────────────────────────────────────────
+    // Stable: light = source.png, dark = source-nightly.png
+    // Nightly: light = source-nightly.png, dark = source.png (swapped)
+    let (light_src, dark_src) = match variant {
+        "nightly" => (
+            "crates/notebook/icons/source-nightly.png",
+            "crates/notebook/icons/source.png",
+        ),
+        _ => (
+            "crates/notebook/icons/source.png",
+            "crates/notebook/icons/source-nightly.png",
+        ),
     };
 
-    // Use source-nightly.png for the dark variant if it exists, otherwise
-    // fall back to the same image as the light icon.
-    let dark_src = if Path::new("crates/notebook/icons/source-nightly.png").exists() {
-        "crates/notebook/icons/source-nightly.png"
+    if !Path::new(light_src).exists() {
+        eprintln!("Icon not found: {light_src}");
+        eprintln!("Run `cargo xtask icons` first to generate icons.");
+        let _ = fs::remove_dir_all(&staging_dir);
+        exit(1);
+    }
+
+    // Resize icons to 512x512 — source assets are 1024x1024 but the manifest
+    // declares 512x512 and Claude Desktop may be strict about the match.
+    let resize_icon = |src: &str, dest: &str| {
+        let status = Command::new("sips")
+            .args(["-z", "512", "512", src, "--out", dest])
+            .stdout(Stdio::null())
+            .status()
+            .unwrap_or_else(|e| {
+                eprintln!("Failed to run sips to resize {src}: {e}");
+                exit(1);
+            });
+        if !status.success() {
+            eprintln!("sips failed to resize {src}");
+            exit(1);
+        }
+    };
+
+    let light_dest = staging_dir.join("icon.png");
+    resize_icon(light_src, &light_dest.to_string_lossy());
+
+    // If the dark icon doesn't exist, fall back to the light icon.
+    let dark_actual = if Path::new(dark_src).exists() {
+        dark_src
     } else {
         light_src
     };
+    let dark_dest = staging_dir.join("icon-dark.png");
+    resize_icon(dark_actual, &dark_dest.to_string_lossy());
 
-    fs::copy(light_src, staging_dir.join("icon.png")).unwrap_or_else(|e| {
-        eprintln!("Failed to copy icon.png: {e}");
+    // ── 4. Copy server shim ───────────────────────────────────────────────
+    let server_dir = staging_dir.join("server");
+    fs::create_dir_all(&server_dir).unwrap_or_else(|e| {
+        eprintln!("Failed to create server directory: {e}");
         exit(1);
     });
-    fs::copy(dark_src, staging_dir.join("icon-dark.png")).unwrap_or_else(|e| {
-        eprintln!("Failed to copy icon-dark.png: {e}");
-        exit(1);
-    });
-
-    // ── 3. Write manifest.json ───────────────────────────────────────────────
-    // The server is invoked via `uvx nteract` — no binary is bundled.
-    // uvx fetches and runs the `nteract` PyPI package on first use.
-    let manifest = serde_json::json!({
-        "manifest_version": "0.3",
-        "name": "nteract",
-        "display_name": "nteract",
-        "version": version,
-        "description": "Create, edit, and run Jupyter notebooks with Claude",
-        "author": {
-            "name": "nteract contributors",
-            "url": "https://nteract.io"
-        },
-        "repository": "https://github.com/nteract/desktop",
-        "license": "BSD-3-Clause",
-        "server": {
-            "type": "stdio",
-            "mcp_config": {
-                "command": "uvx",
-                "arguments": ["nteract"]
-            }
-        },
-        "icons": [
-            { "src": "icon.png", "size": "512x512", "theme": "light" },
-            { "src": "icon-dark.png", "size": "512x512", "theme": "dark" }
-        ],
-        "keywords": ["jupyter", "notebook", "python", "data-science"]
-    });
-
-    let manifest_str = serde_json::to_string_pretty(&manifest).unwrap_or_else(|e| {
-        eprintln!("Failed to serialize manifest.json: {e}");
+    fs::copy("mcpb/server/main.py", server_dir.join("main.py")).unwrap_or_else(|e| {
+        eprintln!("Failed to copy server/main.py: {e}");
         exit(1);
     });
 
+    // ── 5. Write manifest.json ──────────────────────────────────────────────
     fs::write(staging_dir.join("manifest.json"), &manifest_str).unwrap_or_else(|e| {
         eprintln!("Failed to write manifest.json: {e}");
         exit(1);
     });
 
-    // ── 4. Create ZIP archive ────────────────────────────────────────────────
+    // ── 6. Create ZIP archive ────────────────────────────────────────────────
+    let default_name = if variant == "stable" {
+        "nteract.mcpb"
+    } else {
+        "nteract-nightly.mcpb"
+    };
+    let output_path = output.unwrap_or(default_name);
+
     // Resolve the output path to an absolute path before changing directories.
     let abs_output = if Path::new(output_path).is_absolute() {
         Path::new(output_path).to_path_buf()
@@ -2099,6 +2134,17 @@ fn cmd_mcpb(output: Option<&str>) {
             })
             .join(output_path)
     };
+
+    // Ensure the parent directory exists so zip can create the output file.
+    if let Some(parent) = abs_output.parent() {
+        fs::create_dir_all(parent).unwrap_or_else(|e| {
+            eprintln!(
+                "Failed to create output directory {}: {e}",
+                parent.display()
+            );
+            exit(1);
+        });
+    }
 
     // Remove any existing archive so zip doesn't merge old contents.
     let _ = fs::remove_file(&abs_output);
@@ -2121,7 +2167,7 @@ fn cmd_mcpb(output: Option<&str>) {
         exit(1);
     }
 
-    // ── 5. Cleanup staging dir ───────────────────────────────────────────────
+    // ── 7. Cleanup staging dir ───────────────────────────────────────────────
     let _ = fs::remove_dir_all(&staging_dir);
 
     println!("Done: {}", abs_output.display());

--- a/mcpb/manifest.nightly.json
+++ b/mcpb/manifest.nightly.json
@@ -1,0 +1,30 @@
+{
+  "manifest_version": "0.3",
+  "name": "nteract-nightly",
+  "display_name": "nteract Nightly",
+  "version": "{{VERSION}}",
+  "description": "Create, edit, and run Jupyter notebooks with Claude",
+  "author": {
+    "name": "nteract contributors",
+    "url": "https://nteract.io"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nteract/desktop"
+  },
+  "license": "BSD-3-Clause",
+  "server": {
+    "type": "python",
+    "entry_point": "server/main.py",
+    "mcp_config": {
+      "command": "uvx",
+      "args": ["--prerelease", "allow", "nteract", "--nightly"]
+    }
+  },
+  "icon": "icon.png",
+  "icons": [
+    { "src": "icon.png", "size": "512x512", "theme": "light" },
+    { "src": "icon-dark.png", "size": "512x512", "theme": "dark" }
+  ],
+  "keywords": ["jupyter", "notebook", "python", "data-science"]
+}

--- a/mcpb/manifest.stable.json
+++ b/mcpb/manifest.stable.json
@@ -1,0 +1,30 @@
+{
+  "manifest_version": "0.3",
+  "name": "nteract",
+  "display_name": "nteract",
+  "version": "{{VERSION}}",
+  "description": "Create, edit, and run Jupyter notebooks with Claude",
+  "author": {
+    "name": "nteract contributors",
+    "url": "https://nteract.io"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nteract/desktop"
+  },
+  "license": "BSD-3-Clause",
+  "server": {
+    "type": "python",
+    "entry_point": "server/main.py",
+    "mcp_config": {
+      "command": "uvx",
+      "args": ["nteract", "--stable"]
+    }
+  },
+  "icon": "icon.png",
+  "icons": [
+    { "src": "icon.png", "size": "512x512", "theme": "light" },
+    { "src": "icon-dark.png", "size": "512x512", "theme": "dark" }
+  ],
+  "keywords": ["jupyter", "notebook", "python", "data-science"]
+}

--- a/mcpb/server/main.py
+++ b/mcpb/server/main.py
@@ -1,0 +1,10 @@
+"""Shim entry point for MCPB packaging.
+
+Claude Desktop runs this via its Python runtime. It delegates to the
+nteract MCP server installed via uvx/pip.
+"""
+
+import subprocess
+import sys
+
+sys.exit(subprocess.call(["uvx", "--prerelease", "allow", "nteract"] + sys.argv[1:]))


### PR DESCRIPTION
## Summary

Adds `cargo xtask mcpb` to produce a `.mcpb` ZIP archive for one-click installation into Claude Desktop. Closes #1263.

## What's in the bundle

```
nteract.mcpb
├── manifest.json          (manifest_version 0.3, version from workspace)
├── icon.png               (light theme — source.png, falls back to icon.png)
└── icon-dark.png          (dark theme — source-nightly.png, falls back to light)
```

No binary is bundled. The manifest uses `uvx nteract` as the server command — Claude Desktop fetches and runs the `nteract` PyPI package on first use.

## manifest.json server config

```json
"server": {
  "type": "stdio",
  "mcp_config": {
    "command": "uvx",
    "arguments": ["nteract"]
  }
}
```

## Usage

```bash
# Default output: nteract.mcpb in cwd
cargo xtask mcpb

# Custom output path
cargo xtask mcpb --output dist/nteract.mcpb
```

## Not in scope

- CI integration (per-platform build + GitHub release attachment) — follow-up per #1263