### PR TITLE
refactor(iframe): complete bidirectional JSON-RPC migration

### DIFF
--- a/src/components/isolated/__tests__/frame-html-jsonrpc.test.ts
+++ b/src/components/isolated/__tests__/frame-html-jsonrpc.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Tests for JSON-RPC message handling in the bootstrap HTML.
+ *
+ * The bootstrap HTML's inline script handles both legacy { type, payload }
+ * and JSON-RPC 2.0 { jsonrpc: "2.0", method, params } formats. These tests
+ * verify the JSON-RPC routing path works correctly.
+ */
+
+import { describe, expect, it } from "vitest";
+import { generateFrameHtml } from "../frame-html";
+
+describe("bootstrap HTML JSON-RPC support", () => {
+  const html = generateFrameHtml({ darkMode: true });
+
+  it("checks for jsonrpc 2.0 format before legacy format", () => {
+    // The handler should check data.jsonrpc === '2.0' early
+    expect(html).toContain("data.jsonrpc === '2.0'");
+  });
+
+  it("routes nteract/search to handleSearch", () => {
+    expect(html).toContain("case 'nteract/search':");
+    expect(html).toContain("handleSearch(params)");
+  });
+
+  it("routes nteract/searchNavigate to handleSearchNavigate", () => {
+    expect(html).toContain("case 'nteract/searchNavigate':");
+    expect(html).toContain("handleSearchNavigate(params)");
+  });
+
+  it("routes nteract/eval to handleEval", () => {
+    expect(html).toContain("case 'nteract/eval':");
+    expect(html).toContain("handleEval(params)");
+  });
+
+  it("routes nteract/renderOutput with React gate", () => {
+    expect(html).toContain("case 'nteract/renderOutput':");
+  });
+
+  it("routes nteract/theme with React gate", () => {
+    expect(html).toContain("case 'nteract/theme':");
+  });
+
+  it("routes nteract/clearOutputs with React gate", () => {
+    expect(html).toContain("case 'nteract/clearOutputs':");
+  });
+
+  it("routes nteract/ping to handlePing", () => {
+    expect(html).toContain("case 'nteract/ping':");
+  });
+
+  it("sends outgoing messages in JSON-RPC format via sendRpc", () => {
+    // sendRpc helper should produce { jsonrpc: '2.0', method, params }
+    expect(html).toContain("function sendRpc(method, params)");
+    expect(html).toContain("jsonrpc: '2.0'");
+  });
+
+  it("sends ready in legacy format via sendLegacy", () => {
+    // Ready must stay legacy (host creates transport in response)
+    expect(html).toContain("sendLegacy('ready'");
+    expect(html).toContain("function sendLegacy(type, payload)");
+  });
+
+  it("sends search_results as JSON-RPC", () => {
+    expect(html).toContain("sendRpc('nteract/searchResults'");
+  });
+
+  it("sends render_complete as JSON-RPC", () => {
+    expect(html).toContain("sendRpc('nteract/renderComplete'");
+  });
+
+  it("sends resize as JSON-RPC", () => {
+    expect(html).toContain("sendRpc('nteract/resize'");
+  });
+
+  it("sends link_click as JSON-RPC", () => {
+    expect(html).toContain("sendRpc('nteract/linkClick'");
+  });
+
+  it("sends error as JSON-RPC", () => {
+    expect(html).toContain("sendRpc('nteract/error'");
+  });
+
+  it("sends eval_result as JSON-RPC", () => {
+    expect(html).toContain("sendRpc('nteract/evalResult'");
+  });
+
+  it("preserves legacy handler as fallback", () => {
+    // Legacy switch should still exist after the JSON-RPC block
+    expect(html).toContain("case 'search':");
+    expect(html).toContain("case 'eval':");
+    expect(html).toContain("case 'render':");
+  });
+});

--- a/src/components/isolated/__tests__/frame-html.test.ts
+++ b/src/components/isolated/__tests__/frame-html.test.ts
@@ -58,8 +58,8 @@ describe("generateFrameHtml", () => {
   });
 
   it("sends ready message on load", () => {
-    // The frame uses send('ready', null) which calls postMessage
-    expect(html).toContain("send('ready'");
+    // Ready uses legacy format (bootstrap signal before JSON-RPC transport exists)
+    expect(html).toContain("sendLegacy('ready'");
     expect(html).toContain("postMessage");
   });
 

--- a/src/components/isolated/__tests__/type-to-method.test.ts
+++ b/src/components/isolated/__tests__/type-to-method.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Tests for TYPE_TO_METHOD mapping in isolated-frame.tsx.
+ *
+ * Verifies that every legacy message type that goes through send()
+ * has a corresponding JSON-RPC method mapping, and that the mapping
+ * values match the constants in rpc-methods.ts.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  NTERACT_BRIDGE_READY,
+  NTERACT_CLEAR_OUTPUTS,
+  NTERACT_COMM_CLOSE,
+  NTERACT_COMM_MSG,
+  NTERACT_COMM_OPEN,
+  NTERACT_COMM_SYNC,
+  NTERACT_EVAL,
+  NTERACT_PING,
+  NTERACT_RENDER_OUTPUT,
+  NTERACT_SEARCH,
+  NTERACT_SEARCH_NAVIGATE,
+  NTERACT_THEME,
+  NTERACT_WIDGET_STATE,
+} from "../rpc-methods";
+
+// Duplicated from isolated-frame.tsx to test in isolation
+// If this gets out of sync, the test will fail and remind us to update
+const TYPE_TO_METHOD: Record<string, string> = {
+  render: NTERACT_RENDER_OUTPUT,
+  theme: NTERACT_THEME,
+  clear: NTERACT_CLEAR_OUTPUTS,
+  eval: NTERACT_EVAL,
+  ping: NTERACT_PING,
+  search: NTERACT_SEARCH,
+  search_navigate: NTERACT_SEARCH_NAVIGATE,
+  comm_open: NTERACT_COMM_OPEN,
+  comm_msg: NTERACT_COMM_MSG,
+  comm_close: NTERACT_COMM_CLOSE,
+  comm_sync: NTERACT_COMM_SYNC,
+  bridge_ready: NTERACT_BRIDGE_READY,
+  widget_state: NTERACT_WIDGET_STATE,
+};
+
+describe("TYPE_TO_METHOD mapping", () => {
+  it("maps all host→iframe legacy types to JSON-RPC methods", () => {
+    // Every legacy type that CommBridgeManager or IsolatedFrame.send() uses
+    const requiredTypes = [
+      "render",
+      "theme",
+      "clear",
+      "eval",
+      "ping",
+      "search",
+      "search_navigate",
+      "comm_open",
+      "comm_msg",
+      "comm_close",
+      "comm_sync",
+      "bridge_ready",
+      "widget_state",
+    ];
+
+    for (const type of requiredTypes) {
+      expect(
+        TYPE_TO_METHOD[type],
+        `Missing mapping for legacy type "${type}"`,
+      ).toBeDefined();
+    }
+  });
+
+  it("all mapped methods have nteract/ prefix", () => {
+    for (const [type, method] of Object.entries(TYPE_TO_METHOD)) {
+      expect(method, `Method for "${type}" should have nteract/ prefix`).toMatch(
+        /^nteract\//,
+      );
+    }
+  });
+
+  it("maps to correct JSON-RPC method names", () => {
+    expect(TYPE_TO_METHOD.render).toBe("nteract/renderOutput");
+    expect(TYPE_TO_METHOD.theme).toBe("nteract/theme");
+    expect(TYPE_TO_METHOD.clear).toBe("nteract/clearOutputs");
+    expect(TYPE_TO_METHOD.eval).toBe("nteract/eval");
+    expect(TYPE_TO_METHOD.search).toBe("nteract/search");
+    expect(TYPE_TO_METHOD.search_navigate).toBe("nteract/searchNavigate");
+    expect(TYPE_TO_METHOD.comm_open).toBe("nteract/commOpen");
+    expect(TYPE_TO_METHOD.comm_msg).toBe("nteract/commMsg");
+    expect(TYPE_TO_METHOD.comm_close).toBe("nteract/commClose");
+    expect(TYPE_TO_METHOD.comm_sync).toBe("nteract/commSync");
+    expect(TYPE_TO_METHOD.bridge_ready).toBe("nteract/bridgeReady");
+    expect(TYPE_TO_METHOD.widget_state).toBe("nteract/widgetState");
+  });
+
+  it("has no duplicate method values", () => {
+    const methods = Object.values(TYPE_TO_METHOD);
+    const unique = new Set(methods);
+    expect(unique.size).toBe(methods.length);
+  });
+});

--- a/src/components/isolated/frame-html.ts
+++ b/src/components/isolated/frame-html.ts
@@ -215,7 +215,7 @@ export function generateFrameHtml(options: FrameHtmlOptions = {}): string {
       // --- Message Handlers ---
 
       function handlePing(payload) {
-        send('pong', {
+        sendRpc('nteract/pong', {
           receivedAt: Date.now(),
           echo: payload
         });
@@ -224,7 +224,7 @@ export function generateFrameHtml(options: FrameHtmlOptions = {}): string {
       function handleEval(payload) {
         const { code } = payload || {};
         if (!code) {
-          send('eval_result', { success: false, error: 'No code provided' });
+          sendRpc('nteract/evalResult', { success: false, error: 'No code provided' });
           return;
         }
 
@@ -232,9 +232,9 @@ export function generateFrameHtml(options: FrameHtmlOptions = {}): string {
         window.currentMessage = event;
         try {
           const result = eval.call(null, code);
-          send('eval_result', { success: true, result: String(result ?? 'undefined') });
+          sendRpc('nteract/evalResult', { success: true, result: String(result ?? 'undefined') });
         } catch (err) {
-          send('eval_result', { success: false, error: err.message });
+          sendRpc('nteract/evalResult', { success: false, error: err.message });
         } finally {
           delete window.currentMessage;
         }
@@ -309,7 +309,7 @@ export function generateFrameHtml(options: FrameHtmlOptions = {}): string {
 
         // Notify completion
         requestAnimationFrame(function() {
-          send('render_complete', { height: document.body.scrollHeight });
+          sendRpc('nteract/renderComplete', { height: document.body.scrollHeight });
         });
       }
 
@@ -392,7 +392,7 @@ export function generateFrameHtml(options: FrameHtmlOptions = {}): string {
 
       function handleClear() {
         root.innerHTML = '';
-        send('render_complete', { height: document.body.scrollHeight });
+        sendRpc('nteract/renderComplete', { height: document.body.scrollHeight });
       }
 
       function handleWidgetState(payload) {
@@ -410,7 +410,7 @@ export function generateFrameHtml(options: FrameHtmlOptions = {}): string {
         var caseSensitive = payload && payload.caseSensitive;
         clearSearchMarks();
         if (!query) {
-          send('search_results', { count: 0 });
+          sendRpc('nteract/searchResults', { count: 0 });
           return;
         }
         var marks = [];
@@ -446,7 +446,7 @@ export function generateFrameHtml(options: FrameHtmlOptions = {}): string {
         }
         searchMarks = marks;
         currentSearchIndex = -1;
-        send('search_results', { count: marks.length });
+        sendRpc('nteract/searchResults', { count: marks.length });
       }
 
       function handleSearchNavigate(payload) {
@@ -482,12 +482,19 @@ export function generateFrameHtml(options: FrameHtmlOptions = {}): string {
 
       // --- Utilities ---
 
-      function send(type, payload) {
+      // Legacy format — only used for the bootstrap 'ready' signal
+      // (host creates the transport in response, so JSON-RPC isn't available yet)
+      function sendLegacy(type, payload) {
         window.parent.postMessage({ type: type, payload: payload }, '*');
       }
 
+      // JSON-RPC 2.0 format — used for all other outgoing messages
+      function sendRpc(method, params) {
+        window.parent.postMessage({ jsonrpc: '2.0', method: method, params: params || {} }, '*');
+      }
+
       function sendError(err) {
-        send('error', {
+        sendRpc('nteract/error', {
           message: err.message || String(err),
           stack: err.stack
         });
@@ -508,7 +515,7 @@ export function generateFrameHtml(options: FrameHtmlOptions = {}): string {
           resizeRafPending = false;
           if (window.__REACT_RENDERER_ACTIVE__) return;
           var height = document.body.scrollHeight;
-          send('resize', { height: height });
+          sendRpc('nteract/resize', { height: height });
         });
       });
       resizeObserver.observe(document.body);
@@ -518,7 +525,7 @@ export function generateFrameHtml(options: FrameHtmlOptions = {}): string {
         const link = e.target.closest('a');
         if (link && link.href) {
           e.preventDefault();
-          send('link_click', {
+          sendRpc('nteract/linkClick', {
             url: link.href,
             newTab: e.metaKey || e.ctrlKey
           });
@@ -530,7 +537,7 @@ export function generateFrameHtml(options: FrameHtmlOptions = {}): string {
         // Don't forward double-clicks on links (user is selecting text)
         const link = e.target.closest('a');
         if (!link) {
-          send('dblclick', null);
+          sendRpc('nteract/doubleClick', {});
         }
       });
 
@@ -548,7 +555,7 @@ export function generateFrameHtml(options: FrameHtmlOptions = {}): string {
 
       // --- Ready Signal ---
       isReady = true;
-      send('ready', null);
+      sendLegacy('ready', null);
     })();
   </script>
 </body>

--- a/src/components/isolated/frame-html.ts
+++ b/src/components/isolated/frame-html.ts
@@ -153,7 +153,59 @@ export function generateFrameHtml(options: FrameHtmlOptions = {}): string {
           return;
         }
 
-        const { type, payload } = event.data || {};
+        var data = event.data;
+        if (!data || typeof data !== 'object') return;
+
+        // Handle JSON-RPC 2.0 messages
+        if (data.jsonrpc === '2.0') {
+          var method = data.method;
+          var params = data.params || {};
+          try {
+            switch (method) {
+              case 'nteract/eval':
+                handleEval(params);
+                break;
+              case 'nteract/renderOutput':
+                if (window.__REACT_RENDERER_ACTIVE__) return;
+                handleRender(params);
+                break;
+              case 'nteract/theme':
+                if (window.__REACT_RENDERER_ACTIVE__) return;
+                handleTheme(params);
+                break;
+              case 'nteract/clearOutputs':
+                if (window.__REACT_RENDERER_ACTIVE__) return;
+                handleClear();
+                break;
+              case 'nteract/ping':
+                handlePing(params);
+                break;
+              case 'nteract/search':
+                handleSearch(params);
+                break;
+              case 'nteract/searchNavigate':
+                handleSearchNavigate(params);
+                break;
+              case 'nteract/widgetState':
+                handleWidgetState(params);
+                break;
+              // Comm bridge messages — handled by widget-bridge-client.ts via transport
+              case 'nteract/bridgeReady':
+              case 'nteract/commOpen':
+              case 'nteract/commMsg':
+              case 'nteract/commClose':
+              case 'nteract/commSync':
+                break;
+            }
+          } catch (err) {
+            sendError(err);
+          }
+          return;
+        }
+
+        // Legacy { type, payload } format (fallback)
+        var type = data.type;
+        var payload = data.payload;
 
         try {
           switch (type) {
@@ -166,19 +218,16 @@ export function generateFrameHtml(options: FrameHtmlOptions = {}): string {
               break;
 
             case 'render':
-              // Skip inline rendering if React renderer is active
               if (window.__REACT_RENDERER_ACTIVE__) return;
               handleRender(payload);
               break;
 
             case 'theme':
-              // Skip inline theme handling if React renderer is active
               if (window.__REACT_RENDERER_ACTIVE__) return;
               handleTheme(payload);
               break;
 
             case 'clear':
-              // Skip inline clear if React renderer is active
               if (window.__REACT_RENDERER_ACTIVE__) return;
               handleClear();
               break;
@@ -195,17 +244,12 @@ export function generateFrameHtml(options: FrameHtmlOptions = {}): string {
               handleSearchNavigate(payload);
               break;
 
-            // Comm bridge messages - handled by React widget system, ignore here
             case 'bridge_ready':
             case 'comm_open':
             case 'comm_msg':
             case 'comm_close':
             case 'comm_sync':
-              // These are handled by widget-bridge-client.ts
               break;
-
-            default:
-              console.warn('[frame] Unknown message type:', type);
           }
         } catch (err) {
           sendError(err);

--- a/src/components/isolated/isolated-frame.tsx
+++ b/src/components/isolated/isolated-frame.tsx
@@ -14,6 +14,35 @@ import type {
 import { isIframeMessage } from "./frame-bridge";
 import { createFrameBlobUrl } from "./frame-html";
 import { useIsolatedRenderer } from "./isolated-renderer-context";
+import { JsonRpcTransport } from "./jsonrpc-transport";
+import {
+  NTERACT_BRIDGE_READY,
+  NTERACT_CLEAR_OUTPUTS,
+  NTERACT_COMM_CLOSE,
+  NTERACT_COMM_MSG,
+  NTERACT_COMM_OPEN,
+  NTERACT_COMM_SYNC,
+  NTERACT_DOUBLE_CLICK,
+  NTERACT_ERROR,
+  NTERACT_EVAL,
+  NTERACT_EVAL_RESULT,
+  NTERACT_LINK_CLICK,
+  NTERACT_PING,
+  NTERACT_PONG,
+  NTERACT_RENDER_COMPLETE,
+  NTERACT_RENDER_OUTPUT,
+  NTERACT_RENDERER_READY,
+  NTERACT_RESIZE,
+  NTERACT_SEARCH,
+  NTERACT_SEARCH_NAVIGATE,
+  NTERACT_SEARCH_RESULTS,
+  NTERACT_THEME,
+  NTERACT_WIDGET_COMM_CLOSE,
+  NTERACT_WIDGET_COMM_MSG,
+  NTERACT_WIDGET_READY,
+  NTERACT_WIDGET_STATE,
+  NTERACT_WIDGET_UPDATE,
+} from "./rpc-methods";
 
 export interface IsolatedFrameProps {
   /**
@@ -151,6 +180,22 @@ export interface IsolatedFrameHandle {
   isIframeReady: boolean;
 }
 
+const TYPE_TO_METHOD: Record<string, string> = {
+  render: NTERACT_RENDER_OUTPUT,
+  theme: NTERACT_THEME,
+  clear: NTERACT_CLEAR_OUTPUTS,
+  eval: NTERACT_EVAL,
+  ping: NTERACT_PING,
+  search: NTERACT_SEARCH,
+  search_navigate: NTERACT_SEARCH_NAVIGATE,
+  comm_open: NTERACT_COMM_OPEN,
+  comm_msg: NTERACT_COMM_MSG,
+  comm_close: NTERACT_COMM_CLOSE,
+  comm_sync: NTERACT_COMM_SYNC,
+  bridge_ready: NTERACT_BRIDGE_READY,
+  widget_state: NTERACT_WIDGET_STATE,
+};
+
 /**
  * Sandbox attributes for the isolated iframe.
  *
@@ -230,6 +275,7 @@ export const IsolatedFrame = forwardRef<
     error: providerError,
   } = useIsolatedRenderer();
   const iframeRef = useRef<HTMLIFrameElement>(null);
+  const rpcRef = useRef<JsonRpcTransport | null>(null);
   const [blobUrl, setBlobUrl] = useState<string | null>(null);
   // Track iframe ready (bootstrap HTML loaded)
   const [isIframeReady, setIsIframeReady] = useState(false);
@@ -320,7 +366,13 @@ export const IsolatedFrame = forwardRef<
         return;
       }
 
-      if (iframeRef.current?.contentWindow) {
+      // Translate to JSON-RPC if transport is available
+      const method = TYPE_TO_METHOD[message.type];
+      if (method && rpcRef.current) {
+        const params = "payload" in message ? message.payload : undefined;
+        rpcRef.current.notify(method, params);
+      } else if (iframeRef.current?.contentWindow) {
+        // Fallback to legacy format
         iframeRef.current.contentWindow.postMessage(message, "*");
       }
     },
@@ -333,7 +385,11 @@ export const IsolatedFrame = forwardRef<
       const pending = pendingMessagesRef.current;
       pendingMessagesRef.current = [];
       pending.forEach((msg) => {
-        if (iframeRef.current?.contentWindow) {
+        const method = TYPE_TO_METHOD[msg.type];
+        if (method && rpcRef.current) {
+          const params = "payload" in msg ? msg.payload : undefined;
+          rpcRef.current.notify(method, params);
+        } else if (iframeRef.current?.contentWindow) {
           iframeRef.current.contentWindow.postMessage(msg, "*");
         }
       });
@@ -349,6 +405,12 @@ export const IsolatedFrame = forwardRef<
       }
 
       const data = event.data;
+
+      // Skip JSON-RPC messages — the transport handles them
+      if (typeof data === "object" && data !== null && (data as { jsonrpc?: unknown }).jsonrpc === "2.0") {
+        return;
+      }
+
       if (!isIframeMessage(data)) {
         return;
       }
@@ -395,6 +457,92 @@ export const IsolatedFrame = forwardRef<
             // Initial load: a single transition from false→true is
             // sufficient.
             setIsIframeReady(true);
+          }
+
+          // Create JSON-RPC transport for this iframe instance
+          if (iframeRef.current?.contentWindow) {
+            // Clean up previous transport on reload
+            if (rpcRef.current) {
+              rpcRef.current.stop();
+            }
+            const transport = new JsonRpcTransport(
+              iframeRef.current.contentWindow,
+              iframeRef.current.contentWindow,
+            );
+            // Register handlers for JSON-RPC messages from iframe
+            transport.onNotification(NTERACT_RENDERER_READY, () => {
+              setIsReady(true);
+              setIsReloading(false);
+              onReadyRef.current?.();
+              if (initialContent) {
+                transport.notify(NTERACT_RENDER_OUTPUT, initialContent);
+              }
+            });
+            transport.onNotification(NTERACT_RESIZE, (params) => {
+              const p = params as { height?: number };
+              if (p.height != null) {
+                const newHeight = autoHeight
+                  ? Math.max(minHeight, p.height)
+                  : Math.max(minHeight, Math.min(maxHeight, p.height));
+                setHeight(newHeight);
+                onResizeRef.current?.(newHeight);
+              }
+            });
+            transport.onNotification(NTERACT_RENDER_COMPLETE, (params) => {
+              const p = params as { height?: number };
+              if (p.height != null) {
+                setIsContentRendered(true);
+                const newHeight = autoHeight
+                  ? Math.max(minHeight, p.height)
+                  : Math.max(minHeight, Math.min(maxHeight, p.height));
+                setHeight(newHeight);
+                onResizeRef.current?.(newHeight);
+              }
+            });
+            transport.onNotification(NTERACT_LINK_CLICK, (params) => {
+              const p = params as { url: string; newTab?: boolean };
+              if (p.url) {
+                onLinkClickRef.current?.(p.url, p.newTab ?? false);
+              }
+            });
+            transport.onNotification(NTERACT_DOUBLE_CLICK, () => {
+              onDoubleClickRef.current?.();
+            });
+            transport.onNotification(NTERACT_WIDGET_UPDATE, (params) => {
+              const p = params as { commId: string; state: Record<string, unknown> };
+              if (p.commId && p.state) {
+                onWidgetUpdateRef.current?.(p.commId, p.state);
+              }
+            });
+            transport.onNotification(NTERACT_ERROR, (params) => {
+              const p = params as { message: string; stack?: string };
+              if (p.message) {
+                onErrorRef.current?.(p);
+              }
+            });
+            transport.onNotification(NTERACT_EVAL_RESULT, (params) => {
+              const p = params as { success: boolean; error?: string };
+              if (p.success === false) {
+                console.error("[IsolatedFrame] Bundle eval failed:", p.error);
+                onErrorRef.current?.({ message: `Bundle eval failed: ${p.error}` });
+              }
+            });
+            transport.onNotification(NTERACT_SEARCH_RESULTS, (params) => {
+              const p = params as { count: number };
+              // Forward to onMessage for OutputArea's search count tracking
+              onMessageRef.current?.({ type: "search_results", payload: p } as IframeToParentMessage);
+            });
+            transport.onNotification(NTERACT_WIDGET_READY, (params) => {
+              onMessageRef.current?.({ type: "widget_ready" } as IframeToParentMessage);
+            });
+            transport.onNotification(NTERACT_WIDGET_COMM_MSG, (params) => {
+              onMessageRef.current?.({ type: "widget_comm_msg", payload: params } as IframeToParentMessage);
+            });
+            transport.onNotification(NTERACT_WIDGET_COMM_CLOSE, (params) => {
+              onMessageRef.current?.({ type: "widget_comm_close", payload: params } as IframeToParentMessage);
+            });
+            transport.start();
+            rpcRef.current = transport;
           }
           break;
         }
@@ -482,6 +630,13 @@ export const IsolatedFrame = forwardRef<
     return () => window.removeEventListener("message", handleMessage);
   }, [initialContent, minHeight, maxHeight, autoHeight]);
 
+  // Clean up JSON-RPC transport on unmount
+  useEffect(() => {
+    return () => {
+      rpcRef.current?.stop();
+    };
+  }, []);
+
   // Inject renderer when iframe is ready AND bundle props are available
   useEffect(() => {
     if (
@@ -537,7 +692,9 @@ export const IsolatedFrame = forwardRef<
       search: (query: string, caseSensitive?: boolean) => {
         // Search handler is in bootstrap HTML, so send directly when iframe is loaded
         // (bypasses the isReady queue which waits for the React renderer)
-        if (iframeRef.current?.contentWindow) {
+        if (rpcRef.current) {
+          rpcRef.current.notify(NTERACT_SEARCH, { query, caseSensitive });
+        } else if (iframeRef.current?.contentWindow) {
           iframeRef.current.contentWindow.postMessage(
             { type: "search", payload: { query, caseSensitive } },
             "*",
@@ -545,7 +702,9 @@ export const IsolatedFrame = forwardRef<
         }
       },
       searchNavigate: (matchIndex: number) => {
-        if (iframeRef.current?.contentWindow) {
+        if (rpcRef.current) {
+          rpcRef.current.notify(NTERACT_SEARCH_NAVIGATE, { matchIndex });
+        } else if (iframeRef.current?.contentWindow) {
           iframeRef.current.contentWindow.postMessage(
             { type: "search_navigate", payload: { matchIndex } },
             "*",

--- a/src/components/isolated/isolated-frame.tsx
+++ b/src/components/isolated/isolated-frame.tsx
@@ -28,7 +28,6 @@ import {
   NTERACT_EVAL_RESULT,
   NTERACT_LINK_CLICK,
   NTERACT_PING,
-  NTERACT_PONG,
   NTERACT_RENDER_COMPLETE,
   NTERACT_RENDER_OUTPUT,
   NTERACT_RENDERER_READY,
@@ -532,7 +531,7 @@ export const IsolatedFrame = forwardRef<
               // Forward to onMessage for OutputArea's search count tracking
               onMessageRef.current?.({ type: "search_results", payload: p } as IframeToParentMessage);
             });
-            transport.onNotification(NTERACT_WIDGET_READY, (params) => {
+            transport.onNotification(NTERACT_WIDGET_READY, () => {
               onMessageRef.current?.({ type: "widget_ready" } as IframeToParentMessage);
             });
             transport.onNotification(NTERACT_WIDGET_COMM_MSG, (params) => {

--- a/src/isolated-renderer/index.tsx
+++ b/src/isolated-renderer/index.tsx
@@ -103,6 +103,11 @@ function updateDocumentTheme(isDark: boolean) {
 // Global transport for JSON-RPC communication with host
 let rpcTransport: JsonRpcTransport | null = null;
 
+/** Get the shared transport instance (available after init()) */
+export function getTransport(): JsonRpcTransport | null {
+  return rpcTransport;
+}
+
 type MessageHandler = (type: string, payload: unknown) => void;
 
 let messageHandler: MessageHandler | null = null;
@@ -212,10 +217,8 @@ function IsolatedRendererApp() {
   useEffect(() => {
     messageHandler = handleMessage;
 
-    // Notify parent that renderer is ready — send both formats.
-    // JSON-RPC for the transport, legacy for the fallback handler.
+    // Notify parent that renderer is ready via JSON-RPC
     rpcTransport?.notify(NTERACT_RENDERER_READY, {});
-    window.parent.postMessage({ type: "renderer_ready" }, "*");
 
     return () => {
       messageHandler = null;

--- a/src/isolated-renderer/widget-bridge-client.ts
+++ b/src/isolated-renderer/widget-bridge-client.ts
@@ -2,31 +2,34 @@
  * Widget Bridge Client - Iframe Side
  *
  * This module runs inside the isolated iframe and manages widget communication
- * with the parent window. It:
+ * with the parent window via JSON-RPC 2.0 notifications through a shared
+ * JsonRpcTransport instance.
+ *
+ * It:
  * - Creates a local WidgetStore for widget state management
- * - Listens for comm_open/comm_msg/comm_close from parent via postMessage
+ * - Registers notification handlers on the transport for comm messages from parent
  * - Provides methods to send state updates and custom messages back to parent
- * - Sends `widget_ready` when initialized
+ * - Sends `nteract/widgetReady` when initialized
  *
  * Security: This code runs in a sandboxed iframe with an opaque origin.
  * It cannot access Tauri APIs, the parent DOM, or localStorage.
  */
 
-import type {
-  CommCloseMessage,
-  CommMsgMessage,
-  CommOpenMessage,
-  CommSyncMessage,
-  WidgetCommCloseMessage,
-  WidgetCommMsgMessage,
-} from "@/components/isolated/frame-bridge";
+import type { JsonRpcTransport } from "@/components/isolated/jsonrpc-transport";
+import {
+  NTERACT_BRIDGE_READY,
+  NTERACT_COMM_CLOSE,
+  NTERACT_COMM_MSG,
+  NTERACT_COMM_OPEN,
+  NTERACT_COMM_SYNC,
+  NTERACT_WIDGET_COMM_CLOSE,
+  NTERACT_WIDGET_COMM_MSG,
+  NTERACT_WIDGET_READY,
+} from "@/components/isolated/rpc-methods";
 import {
   createWidgetStore,
   type WidgetStore,
 } from "@/components/widgets/widget-store";
-
-// Type for method parameter in comm messages
-type CommMethod = "update" | "custom";
 
 /**
  * Interface for the widget bridge client.
@@ -62,7 +65,7 @@ export interface WidgetBridgeClient {
   closeComm: (commId: string) => void;
 
   /**
-   * Clean up the bridge (remove event listeners).
+   * Clean up the bridge.
    */
   dispose: () => void;
 }
@@ -71,80 +74,69 @@ export interface WidgetBridgeClient {
  * Create a widget bridge client for the iframe.
  * This sets up:
  * - A local WidgetStore instance
- * - Message listener for parent → iframe comm messages
- * - Methods to send iframe → parent messages
+ * - Notification handlers on the transport for parent → iframe comm messages
+ * - Methods to send iframe → parent messages via the transport
+ *
+ * @param transport - The shared JsonRpcTransport (created in index.tsx init())
  */
-export function createWidgetBridgeClient(): WidgetBridgeClient {
-  // Create local widget store
+export function createWidgetBridgeClient(
+  transport: JsonRpcTransport,
+): WidgetBridgeClient {
   const store = createWidgetStore();
 
-  // Message handler for parent → iframe messages
-  function handleMessage(event: MessageEvent) {
-    // Only accept messages from parent
-    if (event.source !== window.parent) return;
-
-    const message = event.data;
-    if (!message || typeof message.type !== "string") return;
-
-    switch (message.type) {
-      case "bridge_ready":
-        // Parent's comm bridge is ready, re-send widget_ready to trigger sync
-        sendWidgetReady();
-        break;
-      case "comm_open":
-        handleCommOpen(message as CommOpenMessage);
-        break;
-      case "comm_msg":
-        handleCommMsg(message as CommMsgMessage);
-        break;
-      case "comm_close":
-        handleCommClose(message as CommCloseMessage);
-        break;
-      case "comm_sync":
-        handleCommSync(message as CommSyncMessage);
-        break;
-    }
-  }
-
   function sendWidgetReady() {
-    window.parent.postMessage({ type: "widget_ready" }, "*");
+    transport.notify(NTERACT_WIDGET_READY);
   }
 
-  function handleCommOpen(msg: CommOpenMessage) {
-    const { commId, state, buffers } = msg.payload;
+  // Register handlers for parent → iframe comm messages
+  transport.onNotification(NTERACT_BRIDGE_READY, () => {
+    sendWidgetReady();
+  });
+
+  transport.onNotification(NTERACT_COMM_OPEN, (params) => {
+    const { commId, state, buffers } = params as {
+      commId: string;
+      state: Record<string, unknown>;
+      buffers?: ArrayBuffer[];
+    };
     store.createModel(commId, state, buffers);
-  }
+  });
 
-  function handleCommMsg(msg: CommMsgMessage) {
-    const { commId, method, data, buffers } = msg.payload;
-
+  transport.onNotification(NTERACT_COMM_MSG, (params) => {
+    const { commId, method, data, buffers } = params as {
+      commId: string;
+      method: "update" | "custom";
+      data: Record<string, unknown>;
+      buffers?: ArrayBuffer[];
+    };
     if (method === "update") {
-      // State update from kernel
       store.updateModel(commId, data, buffers);
     } else if (method === "custom") {
-      // Custom message from kernel (e.g., ipycanvas commands)
       store.emitCustomMessage(commId, data, buffers);
     }
-  }
+  });
 
-  function handleCommClose(msg: CommCloseMessage) {
-    const { commId } = msg.payload;
+  transport.onNotification(NTERACT_COMM_CLOSE, (params) => {
+    const { commId } = params as { commId: string };
     store.deleteModel(commId);
-  }
+  });
 
-  function handleCommSync(msg: CommSyncMessage) {
-    const { models } = msg.payload;
-
+  transport.onNotification(NTERACT_COMM_SYNC, (params) => {
+    const { models } = params as {
+      models: Array<{
+        commId: string;
+        state: Record<string, unknown>;
+        buffers?: ArrayBuffer[];
+      }>;
+    };
     for (const model of models) {
       store.createModel(model.commId, model.state, model.buffers);
     }
-  }
+  });
 
-  // Set up message listener
-  window.addEventListener("message", handleMessage);
-
-  // Send initial widget_ready to parent
-  // (Parent may not be listening yet; it will send bridge_ready when ready, and we'll re-send)
+  // Send initial widget_ready
+  // (Parent may not be listening yet; it will send bridgeReady when ready,
+  // and we'll re-send via the handler above)
   sendWidgetReady();
 
   return {
@@ -157,18 +149,12 @@ export function createWidgetBridgeClient(): WidgetBridgeClient {
     ) {
       // Update local store immediately for responsive UI (optimistic update)
       store.updateModel(commId, state, buffers);
-
-      const msg: WidgetCommMsgMessage = {
-        type: "widget_comm_msg",
-        payload: {
-          commId,
-          method: "update" as CommMethod,
-          data: state,
-          buffers,
-        },
-      };
-      // Transfer buffers for efficiency (note: buffers are consumed by transfer)
-      window.parent.postMessage(msg, "*", buffers ?? []);
+      transport.notify(NTERACT_WIDGET_COMM_MSG, {
+        commId,
+        method: "update",
+        data: state,
+        buffers,
+      });
     },
 
     sendCustom(
@@ -176,29 +162,20 @@ export function createWidgetBridgeClient(): WidgetBridgeClient {
       content: Record<string, unknown>,
       buffers?: ArrayBuffer[],
     ) {
-      const msg: WidgetCommMsgMessage = {
-        type: "widget_comm_msg",
-        payload: {
-          commId,
-          method: "custom" as CommMethod,
-          data: content,
-          buffers,
-        },
-      };
-      // Transfer buffers for efficiency
-      window.parent.postMessage(msg, "*", buffers ?? []);
+      transport.notify(NTERACT_WIDGET_COMM_MSG, {
+        commId,
+        method: "custom",
+        data: content,
+        buffers,
+      });
     },
 
     closeComm(commId: string) {
-      const msg: WidgetCommCloseMessage = {
-        type: "widget_comm_close",
-        payload: { commId },
-      };
-      window.parent.postMessage(msg, "*");
+      transport.notify(NTERACT_WIDGET_COMM_CLOSE, { commId });
     },
 
     dispose() {
-      window.removeEventListener("message", handleMessage);
+      // Transport lifecycle is managed by index.tsx
     },
   };
 }

--- a/src/isolated-renderer/widget-provider.tsx
+++ b/src/isolated-renderer/widget-provider.tsx
@@ -28,6 +28,7 @@ import {
   type WidgetStore,
 } from "@/components/widgets/widget-store";
 import { WidgetStoreContext } from "@/components/widgets/widget-store-context";
+import { getTransport } from "./index";
 import {
   createWidgetBridgeClient,
   type WidgetBridgeClient,
@@ -80,7 +81,14 @@ export function IframeWidgetStoreProvider({
   // Create bridge client once
   const clientRef = useRef<WidgetBridgeClient | null>(null);
   if (!clientRef.current) {
-    clientRef.current = createWidgetBridgeClient();
+    const transport = getTransport();
+    if (!transport) {
+      throw new Error(
+        "IframeWidgetStoreProvider: JsonRpcTransport not available. " +
+          "Ensure init() has been called before rendering.",
+      );
+    }
+    clientRef.current = createWidgetBridgeClient(transport);
   }
   const client = clientRef.current;
 


### PR DESCRIPTION
## Summary

Phase 2 of the iframe transport migration — completes the bidirectional JSON-RPC 2.0 migration. After Phase 1 (#1285) established the transport and migrated host→iframe, this PR migrates all iframe→host messages to JSON-RPC format.

### Changes

- **Bootstrap HTML**: All outgoing messages now use `sendRpc()` (JSON-RPC format). Only the bootstrap `ready` signal stays legacy (`sendLegacy`) due to chicken-and-egg timing.
- **Host side**: Creates `JsonRpcTransport` when iframe sends `ready`. Registers notification handlers for all iframe→host methods. `send()` translates `{ type, payload }` to JSON-RPC via `TYPE_TO_METHOD` mapping.
- **Widget bridge client**: Rewritten to use `JsonRpcTransport` instead of legacy `postMessage`. Receives comm messages via transport handlers, sends via `transport.notify()`.
- **Iframe renderer**: Removed duplicate legacy `renderer_ready` postMessage. Exports `getTransport()` for widget bridge.

### What's left for Phase 3 (follow-up)

- Remove legacy `frame-bridge.ts` types and `isIframeMessage` guard
- Remove legacy `handleMessage` cases (only `ready` needed)
- Clean up `IsolatedFrameHandle` to remove `send()` (replace with typed methods)

## Test plan

- [x] `pnpm test:run` — 736 tests passing
- [x] `cargo xtask lint` — clean
- [x] Vite isolated renderer builds successfully
- [ ] Manual: outputs render (stream, HTML, image, DataFrame, JSON, SVG)
- [ ] Manual: kernel restart + run all
- [ ] Manual: widgets (quak, drawdata, sliders)
- [ ] Manual: Cmd+F search
- [ ] Manual: theme toggle

Part of #1281