### PR TITLE
feat(runt-mcp): complete Rust-native MCP server (26 tools)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1611,6 +1611,17 @@ dependencies = [
 
 [[package]]
 name = "fancy-regex"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "fancy-regex"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "998b056554fbe42e03ae0e152895cd1a7e1002aec800fdc6635d20270260c46f"
@@ -4997,7 +5008,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5226,7 +5237,7 @@ dependencies = [
  "chrono",
  "core-foundation",
  "dirs 6.0.0",
- "fancy-regex",
+ "fancy-regex 0.16.2",
  "file_url",
  "fs-err",
  "glob",
@@ -5990,9 +6001,11 @@ dependencies = [
 name = "runt-mcp"
 version = "0.1.0"
 dependencies = [
+ "fancy-regex 0.14.0",
  "notebook-doc",
  "notebook-protocol",
  "notebook-sync",
+ "regex",
  "rmcp",
  "runt-workspace",
  "runtimed-client",
@@ -6001,6 +6014,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/runt-mcp/Cargo.toml
+++ b/crates/runt-mcp/Cargo.toml
@@ -22,5 +22,6 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 schemars = { workspace = true }
 regex = "1"
+fancy-regex = "0.14"
 uuid = { version = "1", features = ["v4"] }
 tracing = "0.1"

--- a/crates/runt-mcp/Cargo.toml
+++ b/crates/runt-mcp/Cargo.toml
@@ -21,4 +21,6 @@ tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 schemars = { workspace = true }
+regex = "1"
+uuid = { version = "1", features = ["v4"] }
 tracing = "0.1"

--- a/crates/runt-mcp/src/editing.rs
+++ b/crates/runt-mcp/src/editing.rs
@@ -1,0 +1,143 @@
+//! Pattern resolution for replace_match and replace_regex tools.
+//!
+//! Ports the Python `_editing.py` logic to Rust. The key contract:
+//! - `replace_match`: exact literal match with optional context disambiguation
+//! - `replace_regex`: Python-compatible regex with MULTILINE flag
+//!
+//! Both require exactly one match to succeed.
+
+use regex::Regex;
+
+/// An edit span in the source text.
+pub struct EditSpan {
+    pub start: usize,
+    pub end: usize,
+}
+
+/// Result of a successful edit.
+pub struct EditResult {
+    /// The new source text after replacement.
+    pub new_source: String,
+    /// The span that was replaced (byte offsets in original source).
+    pub span: EditSpan,
+}
+
+/// Error from pattern resolution.
+#[derive(Debug)]
+pub enum EditError {
+    /// No matches found.
+    NoMatch(String),
+    /// Multiple matches found — need context to disambiguate.
+    AmbiguousMatch { count: usize, offsets: Vec<usize> },
+    /// Invalid regex pattern.
+    InvalidPattern(String),
+}
+
+impl std::fmt::Display for EditError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NoMatch(msg) => write!(f, "{msg}"),
+            Self::AmbiguousMatch { count, offsets } => {
+                write!(
+                    f,
+                    "Found {count} matches (at byte offsets {offsets:?}). Provide context_before/context_after to disambiguate."
+                )
+            }
+            Self::InvalidPattern(msg) => write!(f, "Invalid regex: {msg}"),
+        }
+    }
+}
+
+/// Resolve a literal match with optional context disambiguation.
+///
+/// Returns the byte span of the unique match, or an error.
+pub fn resolve_match(
+    source: &str,
+    match_text: &str,
+    context_before: Option<&str>,
+    context_after: Option<&str>,
+) -> Result<EditSpan, EditError> {
+    if match_text.is_empty() {
+        return Err(EditError::NoMatch(
+            "Match text cannot be empty".to_string(),
+        ));
+    }
+
+    // Build a regex that includes optional context
+    let escaped_match = regex::escape(match_text);
+    let pattern = match (context_before, context_after) {
+        (Some(before), Some(after)) => {
+            format!(
+                "{}{}{}",
+                regex::escape(before),
+                escaped_match,
+                regex::escape(after)
+            )
+        }
+        (Some(before), None) => format!("{}{}", regex::escape(before), escaped_match),
+        (None, Some(after)) => format!("{}{}", escaped_match, regex::escape(after)),
+        (None, None) => escaped_match,
+    };
+
+    let re = Regex::new(&pattern).map_err(|e| EditError::InvalidPattern(e.to_string()))?;
+    let matches: Vec<regex::Match> = re.find_iter(source).collect();
+
+    match matches.len() {
+        0 => Err(EditError::NoMatch(format!(
+            "No match found for '{match_text}'"
+        ))),
+        1 => {
+            let m = &matches[0];
+            // Calculate the offset of the actual match within the full pattern
+            let context_before_len = context_before.map(|s| s.len()).unwrap_or(0);
+            let match_start = m.start() + context_before_len;
+            let match_end = match_start + match_text.len();
+            Ok(EditSpan {
+                start: match_start,
+                end: match_end,
+            })
+        }
+        n => Err(EditError::AmbiguousMatch {
+            count: n,
+            offsets: matches.iter().map(|m| m.start()).collect(),
+        }),
+    }
+}
+
+/// Resolve a regex pattern (Python re.MULTILINE equivalent).
+///
+/// Returns the byte span of the unique match, or an error.
+pub fn resolve_regex(source: &str, pattern: &str) -> Result<EditSpan, EditError> {
+    let re = regex::RegexBuilder::new(pattern)
+        .multi_line(true)
+        .build()
+        .map_err(|e| EditError::InvalidPattern(e.to_string()))?;
+
+    let matches: Vec<regex::Match> = re.find_iter(source).collect();
+
+    match matches.len() {
+        0 => Err(EditError::NoMatch(format!(
+            "No match for pattern /{pattern}/"
+        ))),
+        1 => {
+            let m = &matches[0];
+            Ok(EditSpan {
+                start: m.start(),
+                end: m.end(),
+            })
+        }
+        n => Err(EditError::AmbiguousMatch {
+            count: n,
+            offsets: matches.iter().map(|m| m.start()).collect(),
+        }),
+    }
+}
+
+/// Apply a replacement at the given span.
+pub fn apply_replacement(source: &str, span: &EditSpan, replacement: &str) -> String {
+    let mut result = String::with_capacity(source.len() + replacement.len());
+    result.push_str(&source[..span.start]);
+    result.push_str(replacement);
+    result.push_str(&source[span.end..]);
+    result
+}

--- a/crates/runt-mcp/src/editing.rs
+++ b/crates/runt-mcp/src/editing.rs
@@ -6,9 +6,7 @@
 //!
 //! Both require exactly one match to succeed.
 
-use regex::Regex;
-
-/// An edit span in the source text.
+/// An edit span in the source text (byte offsets).
 pub struct EditSpan {
     pub start: usize,
     pub end: usize,
@@ -58,9 +56,7 @@ pub fn resolve_match(
     context_after: Option<&str>,
 ) -> Result<EditSpan, EditError> {
     if match_text.is_empty() {
-        return Err(EditError::NoMatch(
-            "Match text cannot be empty".to_string(),
-        ));
+        return Err(EditError::NoMatch("Match text cannot be empty".to_string()));
     }
 
     // Build a regex that includes optional context
@@ -79,7 +75,7 @@ pub fn resolve_match(
         (None, None) => escaped_match,
     };
 
-    let re = Regex::new(&pattern).map_err(|e| EditError::InvalidPattern(e.to_string()))?;
+    let re = regex::Regex::new(&pattern).map_err(|e| EditError::InvalidPattern(e.to_string()))?;
     let matches: Vec<regex::Match> = re.find_iter(source).collect();
 
     match matches.len() {
@@ -106,14 +102,18 @@ pub fn resolve_match(
 
 /// Resolve a regex pattern (Python re.MULTILINE equivalent).
 ///
+/// Uses `fancy_regex` to support lookarounds (`(?=...)`, `(?<=...)`, etc.)
+/// that the standard `regex` crate does not handle.
+///
 /// Returns the byte span of the unique match, or an error.
 pub fn resolve_regex(source: &str, pattern: &str) -> Result<EditSpan, EditError> {
-    let re = regex::RegexBuilder::new(pattern)
-        .multi_line(true)
-        .build()
+    // Wrap the user pattern with (?m) for multiline mode (^ and $ match line boundaries).
+    let ml_pattern = format!("(?m){pattern}");
+    let re = fancy_regex::Regex::new(&ml_pattern)
         .map_err(|e| EditError::InvalidPattern(e.to_string()))?;
 
-    let matches: Vec<regex::Match> = re.find_iter(source).collect();
+    // fancy_regex::Regex::find_iter returns Result<Match>, not Match
+    let matches: Vec<fancy_regex::Match> = re.find_iter(source).filter_map(|m| m.ok()).collect();
 
     match matches.len() {
         0 => Err(EditError::NoMatch(format!(
@@ -131,6 +131,14 @@ pub fn resolve_regex(source: &str, pattern: &str) -> Result<EditSpan, EditError>
             offsets: matches.iter().map(|m| m.start()).collect(),
         }),
     }
+}
+
+/// Convert a byte offset in a string to a Unicode code point offset.
+///
+/// The Automerge document uses `TextEncoding::UnicodeCodePoint`, so splice
+/// indices must be code-point counts, not byte offsets.
+pub fn byte_offset_to_codepoint(s: &str, byte_offset: usize) -> usize {
+    s[..byte_offset].chars().count()
 }
 
 /// Apply a replacement at the given span.

--- a/crates/runt-mcp/src/execution.rs
+++ b/crates/runt-mcp/src/execution.rs
@@ -1,0 +1,135 @@
+//! Execution pipeline: submit cell → poll RuntimeState → collect outputs.
+//!
+//! This module handles the async execution lifecycle for `execute_cell` and
+//! tools that use `and_run`. It polls the daemon's RuntimeStateDoc to track
+//! execution status and collects outputs from the CRDT once complete.
+
+use std::time::{Duration, Instant};
+
+use notebook_protocol::protocol::NotebookRequest;
+use notebook_sync::handle::DocHandle;
+use runtimed_client::output_resolver;
+use runtimed_client::resolved_output::Output;
+use tracing::warn;
+
+/// Result of executing a cell.
+pub struct ExecutionResult {
+    /// The cell ID that was executed.
+    pub cell_id: String,
+    /// Resolved outputs from the cell after execution.
+    pub outputs: Vec<Output>,
+    /// Execution count (e.g., "5" for In[5]).
+    pub execution_count: Option<String>,
+    /// Final status: "idle", "error", "running" (if timed out).
+    pub status: String,
+    /// Whether the execution completed successfully.
+    pub success: bool,
+}
+
+/// Execute a cell and wait for completion.
+///
+/// 1. Calls `confirm_sync()` to ensure the daemon has the latest cell source.
+/// 2. Sends `ExecuteCell` request to the daemon.
+/// 3. Polls `RuntimeStateDoc` until the execution completes or times out.
+/// 4. Collects and resolves outputs from the CRDT.
+pub async fn execute_and_wait(
+    handle: &DocHandle,
+    cell_id: &str,
+    timeout: Duration,
+    blob_base_url: &Option<String>,
+    blob_store_path: &Option<std::path::PathBuf>,
+) -> ExecutionResult {
+    // Step 1: Ensure daemon has our latest edits
+    if let Err(e) = handle.confirm_sync().await {
+        warn!("confirm_sync failed before execution: {e}");
+    }
+
+    // Step 2: Submit execution request
+    let request = NotebookRequest::ExecuteCell {
+        cell_id: cell_id.to_string(),
+    };
+    if let Err(_e) = handle.send_request(request).await {
+        return ExecutionResult {
+            cell_id: cell_id.to_string(),
+            outputs: Vec::new(),
+            execution_count: None,
+            status: "error".to_string(),
+            success: false,
+        };
+    }
+
+    // Step 3: Poll RuntimeStateDoc for completion
+    let start = Instant::now();
+    let poll_interval = Duration::from_millis(100);
+    let mut final_status = "running".to_string();
+    let mut success = false;
+
+    loop {
+        if start.elapsed() >= timeout {
+            // Timeout — return partial results
+            break;
+        }
+
+        tokio::time::sleep(poll_interval).await;
+
+        // Read execution state from RuntimeStateDoc
+        if let Ok(state) = handle.get_runtime_state() {
+            // Check if our cell is done by looking at the queue
+            let is_executing = state
+                .queue
+                .executing
+                .as_ref()
+                .is_some_and(|e| e.cell_id == cell_id);
+            let is_queued = state.queue.queued.iter().any(|e| e.cell_id == cell_id);
+
+            if !is_executing && !is_queued {
+                // Execution completed (or was never queued — already done)
+                // Check executions map for the result
+                let exec_entry = state
+                    .executions
+                    .values()
+                    .find(|e| e.cell_id == cell_id);
+
+                if let Some(entry) = exec_entry {
+                    final_status = entry.status.clone();
+                    success = entry.success.unwrap_or(false);
+                } else {
+                    // No execution entry — might have completed before we polled
+                    final_status = "idle".to_string();
+                    success = true;
+                }
+                break;
+            }
+        }
+    }
+
+    // Step 4: Collect outputs from CRDT
+    let cell = handle.get_cell(cell_id);
+    let execution_count = handle.get_cell_execution_count(cell_id);
+
+    let outputs = if let Some(cell_snapshot) = &cell {
+        // Resolve outputs (raw JSON strings from CRDT → resolved Output structs)
+        output_resolver::resolve_cell_outputs(
+            &cell_snapshot.outputs,
+            blob_base_url,
+            blob_store_path,
+        )
+        .await
+    } else {
+        Vec::new()
+    };
+
+    // Determine status from outputs if we didn't get it from RuntimeState
+    if final_status == "idle" && outputs.iter().any(|o| o.output_type == "error") {
+        final_status = "error".to_string();
+        success = false;
+    }
+
+    ExecutionResult {
+        cell_id: cell_id.to_string(),
+        outputs,
+        execution_count,
+        status: final_status,
+        success,
+    }
+}

--- a/crates/runt-mcp/src/execution.rs
+++ b/crates/runt-mcp/src/execution.rs
@@ -58,11 +58,17 @@ pub async fn execute_and_wait(
         };
     }
 
-    // Step 3: Poll RuntimeStateDoc for completion
+    // Step 3: Poll RuntimeStateDoc for completion.
+    //
+    // We track whether we've ever seen the cell in the queue. The
+    // RuntimeStateDoc can lag behind the ExecuteCell request, so the cell
+    // may not appear in the queue on the first poll. Without this guard
+    // we'd immediately declare "done" before execution even starts.
     let start = Instant::now();
     let poll_interval = Duration::from_millis(100);
     let mut final_status = "running".to_string();
     let mut success = false;
+    let mut seen_in_queue = false;
 
     loop {
         if start.elapsed() >= timeout {
@@ -74,7 +80,6 @@ pub async fn execute_and_wait(
 
         // Read execution state from RuntimeStateDoc
         if let Ok(state) = handle.get_runtime_state() {
-            // Check if our cell is done by looking at the queue
             let is_executing = state
                 .queue
                 .executing
@@ -82,13 +87,13 @@ pub async fn execute_and_wait(
                 .is_some_and(|e| e.cell_id == cell_id);
             let is_queued = state.queue.queued.iter().any(|e| e.cell_id == cell_id);
 
-            if !is_executing && !is_queued {
-                // Execution completed (or was never queued — already done)
-                // Check executions map for the result
-                let exec_entry = state
-                    .executions
-                    .values()
-                    .find(|e| e.cell_id == cell_id);
+            if is_executing || is_queued {
+                seen_in_queue = true;
+            }
+
+            if seen_in_queue && !is_executing && !is_queued {
+                // Was in queue, now done — check executions map for the result
+                let exec_entry = state.executions.values().find(|e| e.cell_id == cell_id);
 
                 if let Some(entry) = exec_entry {
                     final_status = entry.status.clone();

--- a/crates/runt-mcp/src/formatting.rs
+++ b/crates/runt-mcp/src/formatting.rs
@@ -1,0 +1,132 @@
+//! Output formatting for MCP tool results.
+//!
+//! Converts notebook outputs to text for LLM consumption, with ANSI stripping
+//! and MIME type priority. Matches the Python MCP server's formatting behavior.
+
+use regex::Regex;
+use std::sync::LazyLock;
+
+use runtimed_client::resolved_output::{DataValue, Output};
+
+/// ANSI escape code regex — matches color codes, cursor movement, OSC sequences.
+#[allow(clippy::expect_used)] // Static regex, always valid
+static ANSI_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"\x1b\[[0-9;]*[A-Za-z]|\x1b\].*?\x07|\x1b\(B").expect("valid ANSI regex")
+});
+
+/// MIME types to try for text output, in priority order.
+/// text/llm+plain is a custom MIME for LLM-friendly representations.
+const TEXT_MIME_PRIORITY: &[&str] = &[
+    "text/llm+plain",
+    "text/markdown",
+    "text/plain",
+    "application/json",
+];
+
+/// Strip ANSI escape codes from text.
+pub fn strip_ansi(text: &str) -> String {
+    ANSI_RE.replace_all(text, "").to_string()
+}
+
+/// Extract the best text representation from an output's data dictionary.
+/// Returns None if no suitable text MIME type is found.
+pub fn best_text_from_data(data: &std::collections::HashMap<String, DataValue>) -> Option<String> {
+    for mime in TEXT_MIME_PRIORITY {
+        if let Some(value) = data.get(*mime) {
+            return match value {
+                DataValue::Text(s) => Some(s.clone()),
+                DataValue::Json(v) => Some(serde_json::to_string_pretty(v).unwrap_or_default()),
+                DataValue::Binary(_) => None,
+            };
+        }
+    }
+    None
+}
+
+/// Format a single output as text for LLM consumption.
+pub fn format_output_text(output: &Output) -> Option<String> {
+    match output.output_type.as_str() {
+        "stream" => {
+            let text = output.text.as_deref().unwrap_or("");
+            let stripped = strip_ansi(text);
+            if stripped.is_empty() {
+                None
+            } else {
+                Some(stripped)
+            }
+        }
+        "error" => {
+            let mut parts = Vec::new();
+            if let Some(ename) = &output.ename {
+                let evalue = output.evalue.as_deref().unwrap_or("");
+                parts.push(format!("{ename}: {evalue}"));
+            }
+            if let Some(traceback) = &output.traceback {
+                let stripped: Vec<String> = traceback.iter().map(|t| strip_ansi(t)).collect();
+                parts.push(stripped.join("\n"));
+            }
+            if parts.is_empty() {
+                None
+            } else {
+                Some(parts.join("\n\n"))
+            }
+        }
+        "display_data" | "execute_result" => {
+            if let Some(data) = &output.data {
+                best_text_from_data(data)
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Format all outputs as a single text string.
+pub fn format_outputs_text(outputs: &[Output]) -> String {
+    outputs
+        .iter()
+        .filter_map(format_output_text)
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Format a compact one-line cell summary.
+pub fn format_cell_summary(
+    index: usize,
+    cell_id: &str,
+    cell_type: &str,
+    source: &str,
+    execution_count: Option<&str>,
+    status: Option<&str>,
+    preview_chars: usize,
+) -> String {
+    let ec = execution_count.unwrap_or("");
+    let st = status.unwrap_or("");
+    let preview = if source.len() > preview_chars {
+        format!("{}…", &source[..preview_chars])
+    } else {
+        source.to_string()
+    };
+    // Replace newlines with ↵ for single-line display
+    let preview = preview.replace('\n', "↵");
+    format!("{index} | {cell_type} | {st} | id={cell_id} | [{ec}] | {preview}")
+}
+
+/// Format a cell header line.
+pub fn format_cell_header(
+    cell_id: &str,
+    cell_type: &str,
+    execution_count: Option<&str>,
+    status: Option<&str>,
+) -> String {
+    let ec_display = execution_count
+        .filter(|s| !s.is_empty())
+        .map(|s| format!("[{s}]"))
+        .unwrap_or_default();
+    let status_display = status
+        .filter(|s| !s.is_empty())
+        .map(|s| format!(" ({s})"))
+        .unwrap_or_default();
+    format!("── {cell_type} {ec_display}{status_display} ── {cell_id}")
+}

--- a/crates/runt-mcp/src/lib.rs
+++ b/crates/runt-mcp/src/lib.rs
@@ -15,6 +15,9 @@ use rmcp::service::{RequestContext, RoleServer};
 use rmcp::{ErrorData as McpError, ServerHandler};
 use tokio::sync::RwLock;
 
+pub mod editing;
+pub mod execution;
+pub mod formatting;
 mod resources;
 mod session;
 mod structured;

--- a/crates/runt-mcp/src/lib.rs
+++ b/crates/runt-mcp/src/lib.rs
@@ -28,10 +28,7 @@ use session::NotebookSession;
 /// The nteract MCP server.
 pub struct NteractMcp {
     socket_path: PathBuf,
-    // Used by output resolver when more tools are ported (execute_cell, etc.)
-    #[allow(dead_code)]
     blob_base_url: Option<String>,
-    #[allow(dead_code)]
     blob_store_path: Option<PathBuf>,
     session: Arc<RwLock<Option<NotebookSession>>>,
 }

--- a/crates/runt-mcp/src/session.rs
+++ b/crates/runt-mcp/src/session.rs
@@ -3,7 +3,7 @@
 use notebook_sync::handle::DocHandle;
 
 /// An active notebook session connected via the daemon.
-#[allow(dead_code)] // Fields read by tool handlers as more tools are ported
+#[allow(dead_code)] // Fields used by tool handlers as more tools are ported
 pub struct NotebookSession {
     /// The Automerge document handle for this notebook.
     pub handle: DocHandle,

--- a/crates/runt-mcp/src/structured.rs
+++ b/crates/runt-mcp/src/structured.rs
@@ -8,7 +8,6 @@ use runtimed_client::resolved_output::{DataValue, Output, ResolvedCell};
 use serde_json::{json, Value};
 
 /// Build the structuredContent JSON for a resolved cell.
-#[allow(dead_code)] // Used when execute_cell and other output tools are ported
 pub fn cell_structured_content(cell: &ResolvedCell, status: &str) -> Value {
     json!({
         "cell": {

--- a/crates/runt-mcp/src/tools/cell_crud.rs
+++ b/crates/runt-mcp/src/tools/cell_crud.rs
@@ -84,7 +84,11 @@ pub async fn create_cell(
     let session = server.session.read().await;
     let session = match session.as_ref() {
         Some(s) => s,
-        None => return tool_error("No active notebook session. Call join_notebook or open_notebook first."),
+        None => {
+            return tool_error(
+                "No active notebook session. Call join_notebook or open_notebook first.",
+            )
+        }
     };
 
     let source = arg_str(request, "source").unwrap_or("");
@@ -129,12 +133,7 @@ pub async fn create_cell(
     };
 
     handle
-        .add_cell_with_source(
-            &cell_id,
-            cell_type,
-            after_cell_id.as_deref(),
-            source,
-        )
+        .add_cell_with_source(&cell_id, cell_type, after_cell_id.as_deref(), source)
         .map_err(|e| McpError::internal_error(format!("Failed to create cell: {e}"), None))?;
 
     if and_run && cell_type == "code" {
@@ -164,7 +163,11 @@ pub async fn set_cell(
     let session = server.session.read().await;
     let session = match session.as_ref() {
         Some(s) => s,
-        None => return tool_error("No active notebook session. Call join_notebook or open_notebook first."),
+        None => {
+            return tool_error(
+                "No active notebook session. Call join_notebook or open_notebook first.",
+            )
+        }
     };
 
     let handle = &session.handle;
@@ -190,7 +193,9 @@ pub async fn set_cell(
         .unwrap_or(30.0);
 
     if source.is_none() && cell_type.is_none() {
-        return tool_success(&format!("Cell \"{cell_id}\" unchanged (no updates specified)"));
+        return tool_success(&format!(
+            "Cell \"{cell_id}\" unchanged (no updates specified)"
+        ));
     }
 
     if let Some(src) = source {
@@ -232,7 +237,11 @@ pub async fn delete_cell(
     let session = server.session.read().await;
     let session = match session.as_ref() {
         Some(s) => s,
-        None => return tool_error("No active notebook session. Call join_notebook or open_notebook first."),
+        None => {
+            return tool_error(
+                "No active notebook session. Call join_notebook or open_notebook first.",
+            )
+        }
     };
 
     let deleted = session
@@ -259,7 +268,11 @@ pub async fn move_cell(
     let session = server.session.read().await;
     let session = match session.as_ref() {
         Some(s) => s,
-        None => return tool_error("No active notebook session. Call join_notebook or open_notebook first."),
+        None => {
+            return tool_error(
+                "No active notebook session. Call join_notebook or open_notebook first.",
+            )
+        }
     };
 
     let after_cell_id = arg_str(request, "after_cell_id");
@@ -288,7 +301,11 @@ pub async fn clear_outputs(
     let session = server.session.read().await;
     let session = match session.as_ref() {
         Some(s) => s,
-        None => return tool_error("No active notebook session. Call join_notebook or open_notebook first."),
+        None => {
+            return tool_error(
+                "No active notebook session. Call join_notebook or open_notebook first.",
+            )
+        }
     };
 
     let cleared = session
@@ -324,11 +341,12 @@ async fn build_execution_result(
         header
     };
 
-    let mut items = vec![Content::text(text)];
+    let items = vec![Content::text(text)];
 
-    // Build structured content for MCP Apps widget
+    // Build structured content for MCP Apps widget using the protocol's
+    // structured_content field instead of a text-based fallback.
     let cell_snapshot = handle.get_cell(&result.cell_id);
-    if let Some(snap) = cell_snapshot {
+    let structured_content = if let Some(snap) = cell_snapshot {
         let outputs = runtimed_client::output_resolver::resolve_cell_outputs(
             &snap.outputs,
             &server.blob_base_url,
@@ -344,10 +362,15 @@ async fn build_execution_result(
             outputs,
             metadata_json: serde_json::to_string(&snap.metadata).unwrap_or_default(),
         };
-        let sc = structured::cell_structured_content(&resolved, &result.status);
-        let sc_json = serde_json::to_string(&sc).unwrap_or_default();
-        items.push(Content::text(format!("\n---structuredContent---\n{sc_json}")));
-    }
+        Some(structured::cell_structured_content(
+            &resolved,
+            &result.status,
+        ))
+    } else {
+        None
+    };
 
-    Ok(CallToolResult::success(items))
+    let mut call_result = CallToolResult::success(items);
+    call_result.structured_content = structured_content;
+    Ok(call_result)
 }

--- a/crates/runt-mcp/src/tools/cell_crud.rs
+++ b/crates/runt-mcp/src/tools/cell_crud.rs
@@ -1,0 +1,353 @@
+//! Cell CRUD tools: create_cell, set_cell, delete_cell, move_cell, clear_outputs.
+
+use std::time::Duration;
+
+use rmcp::model::{CallToolRequestParams, CallToolResult, Content};
+use rmcp::ErrorData as McpError;
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use crate::execution;
+use crate::structured;
+use crate::NteractMcp;
+
+use super::{arg_str, tool_error, tool_success};
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct CreateCellParams {
+    /// Cell source code or markdown content.
+    #[serde(default)]
+    pub source: Option<String>,
+    /// Cell type: "code", "markdown", or "raw".
+    #[serde(default)]
+    pub cell_type: Option<String>,
+    /// Position to insert (0-based index). None appends at end.
+    #[serde(default)]
+    pub index: Option<i64>,
+    /// Execute the cell immediately after creation.
+    #[serde(default)]
+    pub and_run: Option<bool>,
+    /// Max seconds to wait for execution.
+    #[serde(default)]
+    pub timeout_secs: Option<f64>,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SetCellParams {
+    /// The cell ID to update.
+    pub cell_id: String,
+    /// New source code (None to leave unchanged).
+    #[serde(default)]
+    pub source: Option<String>,
+    /// New cell type (None to leave unchanged).
+    #[serde(default)]
+    pub cell_type: Option<String>,
+    /// Execute the cell after changes (code cells only).
+    #[serde(default)]
+    pub and_run: Option<bool>,
+    /// Max seconds to wait for execution.
+    #[serde(default)]
+    pub timeout_secs: Option<f64>,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct DeleteCellParams {
+    /// The cell ID to delete.
+    pub cell_id: String,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct MoveCellParams {
+    /// The cell ID to move.
+    pub cell_id: String,
+    /// Move after this cell, or null for start.
+    #[serde(default)]
+    pub after_cell_id: Option<String>,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ClearOutputsParams {
+    /// The cell ID to clear outputs for.
+    pub cell_id: String,
+}
+
+/// Create a new cell, optionally executing it.
+pub async fn create_cell(
+    server: &NteractMcp,
+    request: &CallToolRequestParams,
+) -> Result<CallToolResult, McpError> {
+    let session = server.session.read().await;
+    let session = match session.as_ref() {
+        Some(s) => s,
+        None => return tool_error("No active notebook session. Call join_notebook or open_notebook first."),
+    };
+
+    let source = arg_str(request, "source").unwrap_or("");
+    let cell_type = arg_str(request, "cell_type").unwrap_or("code");
+    let index = request
+        .arguments
+        .as_ref()
+        .and_then(|a| a.get("index"))
+        .and_then(|v| v.as_i64());
+    let and_run = request
+        .arguments
+        .as_ref()
+        .and_then(|a| a.get("and_run"))
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let timeout_secs = request
+        .arguments
+        .as_ref()
+        .and_then(|a| a.get("timeout_secs"))
+        .and_then(|v| v.as_f64())
+        .unwrap_or(30.0);
+
+    let handle = &session.handle;
+    let cell_id = format!("cell-{}", uuid::Uuid::new_v4());
+
+    // Determine after_cell_id based on index
+    let after_cell_id = if let Some(idx) = index {
+        let cell_ids = handle.get_cell_ids();
+        if idx <= 0 {
+            None // Insert at beginning
+        } else {
+            let idx = (idx as usize).min(cell_ids.len());
+            if idx > 0 {
+                Some(cell_ids[idx - 1].clone())
+            } else {
+                None
+            }
+        }
+    } else {
+        // Append at end
+        handle.last_cell_id()
+    };
+
+    handle
+        .add_cell_with_source(
+            &cell_id,
+            cell_type,
+            after_cell_id.as_deref(),
+            source,
+        )
+        .map_err(|e| McpError::internal_error(format!("Failed to create cell: {e}"), None))?;
+
+    if and_run && cell_type == "code" {
+        let result = execution::execute_and_wait(
+            handle,
+            &cell_id,
+            Duration::from_secs_f64(timeout_secs),
+            &server.blob_base_url,
+            &server.blob_store_path,
+        )
+        .await;
+
+        return build_execution_result(&result, handle, server).await;
+    }
+
+    tool_success(&format!("Created cell: {cell_id}"))
+}
+
+/// Update a cell's source and/or type.
+pub async fn set_cell(
+    server: &NteractMcp,
+    request: &CallToolRequestParams,
+) -> Result<CallToolResult, McpError> {
+    let cell_id = arg_str(request, "cell_id")
+        .ok_or_else(|| McpError::invalid_params("Missing required parameter: cell_id", None))?;
+
+    let session = server.session.read().await;
+    let session = match session.as_ref() {
+        Some(s) => s,
+        None => return tool_error("No active notebook session. Call join_notebook or open_notebook first."),
+    };
+
+    let handle = &session.handle;
+
+    // Verify cell exists
+    if handle.get_cell(cell_id).is_none() {
+        return tool_error(&format!("Cell not found: {cell_id}"));
+    }
+
+    let source = arg_str(request, "source");
+    let cell_type = arg_str(request, "cell_type");
+    let and_run = request
+        .arguments
+        .as_ref()
+        .and_then(|a| a.get("and_run"))
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let timeout_secs = request
+        .arguments
+        .as_ref()
+        .and_then(|a| a.get("timeout_secs"))
+        .and_then(|v| v.as_f64())
+        .unwrap_or(30.0);
+
+    if source.is_none() && cell_type.is_none() {
+        return tool_success(&format!("Cell \"{cell_id}\" unchanged (no updates specified)"));
+    }
+
+    if let Some(src) = source {
+        handle
+            .update_source(cell_id, src)
+            .map_err(|e| McpError::internal_error(format!("Failed to update source: {e}"), None))?;
+    }
+    if let Some(ct) = cell_type {
+        handle
+            .set_cell_type(cell_id, ct)
+            .map_err(|e| McpError::internal_error(format!("Failed to set cell type: {e}"), None))?;
+    }
+
+    let current_type = handle.get_cell_type(cell_id).unwrap_or_default();
+    if and_run && current_type == "code" {
+        let result = execution::execute_and_wait(
+            handle,
+            cell_id,
+            Duration::from_secs_f64(timeout_secs),
+            &server.blob_base_url,
+            &server.blob_store_path,
+        )
+        .await;
+
+        return build_execution_result(&result, handle, server).await;
+    }
+
+    tool_success(&format!("Cell \"{cell_id}\" updated"))
+}
+
+/// Delete a cell by ID.
+pub async fn delete_cell(
+    server: &NteractMcp,
+    request: &CallToolRequestParams,
+) -> Result<CallToolResult, McpError> {
+    let cell_id = arg_str(request, "cell_id")
+        .ok_or_else(|| McpError::invalid_params("Missing required parameter: cell_id", None))?;
+
+    let session = server.session.read().await;
+    let session = match session.as_ref() {
+        Some(s) => s,
+        None => return tool_error("No active notebook session. Call join_notebook or open_notebook first."),
+    };
+
+    let deleted = session
+        .handle
+        .delete_cell(cell_id)
+        .map_err(|e| McpError::internal_error(format!("Failed to delete cell: {e}"), None))?;
+
+    if deleted {
+        let result = serde_json::json!({ "cell_id": cell_id, "deleted": true });
+        tool_success(&serde_json::to_string_pretty(&result).unwrap_or_default())
+    } else {
+        tool_error(&format!("Cell not found: {cell_id}"))
+    }
+}
+
+/// Move a cell to a new position.
+pub async fn move_cell(
+    server: &NteractMcp,
+    request: &CallToolRequestParams,
+) -> Result<CallToolResult, McpError> {
+    let cell_id = arg_str(request, "cell_id")
+        .ok_or_else(|| McpError::invalid_params("Missing required parameter: cell_id", None))?;
+
+    let session = server.session.read().await;
+    let session = match session.as_ref() {
+        Some(s) => s,
+        None => return tool_error("No active notebook session. Call join_notebook or open_notebook first."),
+    };
+
+    let after_cell_id = arg_str(request, "after_cell_id");
+
+    session
+        .handle
+        .move_cell(cell_id, after_cell_id)
+        .map_err(|e| McpError::internal_error(format!("Failed to move cell: {e}"), None))?;
+
+    let result = serde_json::json!({
+        "cell_id": cell_id,
+        "after_cell_id": after_cell_id,
+        "moved": true,
+    });
+    tool_success(&serde_json::to_string_pretty(&result).unwrap_or_default())
+}
+
+/// Clear a cell's outputs.
+pub async fn clear_outputs(
+    server: &NteractMcp,
+    request: &CallToolRequestParams,
+) -> Result<CallToolResult, McpError> {
+    let cell_id = arg_str(request, "cell_id")
+        .ok_or_else(|| McpError::invalid_params("Missing required parameter: cell_id", None))?;
+
+    let session = server.session.read().await;
+    let session = match session.as_ref() {
+        Some(s) => s,
+        None => return tool_error("No active notebook session. Call join_notebook or open_notebook first."),
+    };
+
+    let cleared = session
+        .handle
+        .clear_outputs(cell_id)
+        .map_err(|e| McpError::internal_error(format!("Failed to clear outputs: {e}"), None))?;
+
+    if cleared {
+        let result = serde_json::json!({ "cell_id": cell_id, "cleared": true });
+        tool_success(&serde_json::to_string_pretty(&result).unwrap_or_default())
+    } else {
+        tool_error(&format!("Cell not found: {cell_id}"))
+    }
+}
+
+/// Build a CallToolResult from an ExecutionResult, including structured content.
+async fn build_execution_result(
+    result: &execution::ExecutionResult,
+    handle: &notebook_sync::handle::DocHandle,
+    server: &NteractMcp,
+) -> Result<CallToolResult, McpError> {
+    let header = crate::formatting::format_cell_header(
+        &result.cell_id,
+        "code",
+        result.execution_count.as_deref(),
+        Some(&result.status),
+    );
+
+    let output_text = crate::formatting::format_outputs_text(&result.outputs);
+    let text = if !output_text.is_empty() {
+        format!("{header}\n\n{output_text}")
+    } else {
+        header
+    };
+
+    let mut items = vec![Content::text(text)];
+
+    // Build structured content for MCP Apps widget
+    let cell_snapshot = handle.get_cell(&result.cell_id);
+    if let Some(snap) = cell_snapshot {
+        let outputs = runtimed_client::output_resolver::resolve_cell_outputs(
+            &snap.outputs,
+            &server.blob_base_url,
+            &server.blob_store_path,
+        )
+        .await;
+        let resolved = runtimed_client::resolved_output::ResolvedCell {
+            id: snap.id,
+            cell_type: snap.cell_type,
+            position: snap.position,
+            source: snap.source,
+            execution_count: snap.execution_count.parse().ok(),
+            outputs,
+            metadata_json: serde_json::to_string(&snap.metadata).unwrap_or_default(),
+        };
+        let sc = structured::cell_structured_content(&resolved, &result.status);
+        let sc_json = serde_json::to_string(&sc).unwrap_or_default();
+        items.push(Content::text(format!("\n---structuredContent---\n{sc_json}")));
+    }
+
+    Ok(CallToolResult::success(items))
+}

--- a/crates/runt-mcp/src/tools/cell_meta.rs
+++ b/crates/runt-mcp/src/tools/cell_meta.rs
@@ -1,0 +1,241 @@
+//! Cell metadata tools: add_cell_tags, remove_cell_tags, set_cells_source_hidden, set_cells_outputs_hidden.
+
+use rmcp::model::{CallToolRequestParams, CallToolResult};
+use rmcp::ErrorData as McpError;
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use crate::NteractMcp;
+
+use super::{arg_str, tool_error, tool_success};
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct AddCellTagsParams {
+    /// ID of the cell.
+    pub cell_id: String,
+    /// Tags to add.
+    pub tags: Vec<String>,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct RemoveCellTagsParams {
+    /// ID of the cell.
+    pub cell_id: String,
+    /// Tags to remove.
+    pub tags: Vec<String>,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SetCellsSourceHiddenParams {
+    /// IDs of cells to update.
+    pub cell_ids: Vec<String>,
+    /// True to hide source, False to show.
+    pub hidden: bool,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SetCellsOutputsHiddenParams {
+    /// IDs of cells to update.
+    pub cell_ids: Vec<String>,
+    /// True to hide outputs, False to show.
+    pub hidden: bool,
+}
+
+/// Add tags to a cell's metadata. Existing tags are preserved.
+pub async fn add_cell_tags(
+    server: &NteractMcp,
+    request: &CallToolRequestParams,
+) -> Result<CallToolResult, McpError> {
+    let cell_id = arg_str(request, "cell_id")
+        .ok_or_else(|| McpError::invalid_params("Missing required parameter: cell_id", None))?;
+
+    let session = server.session.read().await;
+    let session = match session.as_ref() {
+        Some(s) => s,
+        None => return tool_error("No active notebook session. Call join_notebook or open_notebook first."),
+    };
+
+    let handle = &session.handle;
+
+    // Get existing tags from cell metadata
+    let metadata = match handle.get_cell_metadata(cell_id) {
+        Some(m) => m,
+        None => return tool_error(&format!("Cell {cell_id} not found")),
+    };
+
+    let existing_tags: Vec<String> = metadata
+        .get("tags")
+        .and_then(|t| t.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    // Parse new tags from request
+    let new_tags: Vec<String> = request
+        .arguments
+        .as_ref()
+        .and_then(|a| a.get("tags"))
+        .and_then(|v| serde_json::from_value::<Vec<String>>(v.clone()).ok())
+        .unwrap_or_default();
+
+    // Merge: keep existing, add new ones that aren't already present
+    let mut merged = existing_tags;
+    for tag in &new_tags {
+        if !merged.contains(tag) {
+            merged.push(tag.clone());
+        }
+    }
+
+    let tag_refs: Vec<&str> = merged.iter().map(|s| s.as_str()).collect();
+    handle
+        .set_cell_tags(cell_id, &tag_refs)
+        .map_err(|e| McpError::internal_error(format!("Failed to set tags: {e}"), None))?;
+
+    tool_success(&format!("Tags for {cell_id}: {merged:?}"))
+}
+
+/// Remove tags from a cell's metadata.
+pub async fn remove_cell_tags(
+    server: &NteractMcp,
+    request: &CallToolRequestParams,
+) -> Result<CallToolResult, McpError> {
+    let cell_id = arg_str(request, "cell_id")
+        .ok_or_else(|| McpError::invalid_params("Missing required parameter: cell_id", None))?;
+
+    let session = server.session.read().await;
+    let session = match session.as_ref() {
+        Some(s) => s,
+        None => return tool_error("No active notebook session. Call join_notebook or open_notebook first."),
+    };
+
+    let handle = &session.handle;
+
+    let metadata = match handle.get_cell_metadata(cell_id) {
+        Some(m) => m,
+        None => return tool_error(&format!("Cell {cell_id} not found")),
+    };
+
+    let existing_tags: Vec<String> = metadata
+        .get("tags")
+        .and_then(|t| t.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let tags_to_remove: Vec<String> = request
+        .arguments
+        .as_ref()
+        .and_then(|a| a.get("tags"))
+        .and_then(|v| serde_json::from_value::<Vec<String>>(v.clone()).ok())
+        .unwrap_or_default();
+
+    let filtered: Vec<String> = existing_tags
+        .into_iter()
+        .filter(|t| !tags_to_remove.contains(t))
+        .collect();
+
+    let tag_refs: Vec<&str> = filtered.iter().map(|s| s.as_str()).collect();
+    handle
+        .set_cell_tags(cell_id, &tag_refs)
+        .map_err(|e| McpError::internal_error(format!("Failed to set tags: {e}"), None))?;
+
+    tool_success(&format!("Tags for {cell_id}: {filtered:?}"))
+}
+
+/// Hide or show the source of one or more cells.
+pub async fn set_cells_source_hidden(
+    server: &NteractMcp,
+    request: &CallToolRequestParams,
+) -> Result<CallToolResult, McpError> {
+    let session = server.session.read().await;
+    let session = match session.as_ref() {
+        Some(s) => s,
+        None => return tool_error("No active notebook session. Call join_notebook or open_notebook first."),
+    };
+
+    let cell_ids: Vec<String> = request
+        .arguments
+        .as_ref()
+        .and_then(|a| a.get("cell_ids"))
+        .and_then(|v| serde_json::from_value::<Vec<String>>(v.clone()).ok())
+        .unwrap_or_default();
+
+    let hidden = request
+        .arguments
+        .as_ref()
+        .and_then(|a| a.get("hidden"))
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    let handle = &session.handle;
+    let mut not_found = Vec::new();
+
+    for cell_id in &cell_ids {
+        match handle.set_cell_source_hidden(cell_id, hidden) {
+            Ok(true) => {}
+            Ok(false) => not_found.push(cell_id.as_str()),
+            Err(_) => not_found.push(cell_id.as_str()),
+        }
+    }
+
+    let updated = cell_ids.len() - not_found.len();
+    let mut msg = format!("Set source_hidden={hidden} on {updated} cell(s)");
+    if !not_found.is_empty() {
+        msg.push_str(&format!("; not found: {not_found:?}"));
+    }
+    tool_success(&msg)
+}
+
+/// Hide or show the outputs of one or more cells.
+pub async fn set_cells_outputs_hidden(
+    server: &NteractMcp,
+    request: &CallToolRequestParams,
+) -> Result<CallToolResult, McpError> {
+    let session = server.session.read().await;
+    let session = match session.as_ref() {
+        Some(s) => s,
+        None => return tool_error("No active notebook session. Call join_notebook or open_notebook first."),
+    };
+
+    let cell_ids: Vec<String> = request
+        .arguments
+        .as_ref()
+        .and_then(|a| a.get("cell_ids"))
+        .and_then(|v| serde_json::from_value::<Vec<String>>(v.clone()).ok())
+        .unwrap_or_default();
+
+    let hidden = request
+        .arguments
+        .as_ref()
+        .and_then(|a| a.get("hidden"))
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    let handle = &session.handle;
+    let mut not_found = Vec::new();
+
+    for cell_id in &cell_ids {
+        match handle.set_cell_outputs_hidden(cell_id, hidden) {
+            Ok(true) => {}
+            Ok(false) => not_found.push(cell_id.as_str()),
+            Err(_) => not_found.push(cell_id.as_str()),
+        }
+    }
+
+    let updated = cell_ids.len() - not_found.len();
+    let mut msg = format!("Set outputs_hidden={hidden} on {updated} cell(s)");
+    if !not_found.is_empty() {
+        msg.push_str(&format!("; not found: {not_found:?}"));
+    }
+    tool_success(&msg)
+}

--- a/crates/runt-mcp/src/tools/cell_meta.rs
+++ b/crates/runt-mcp/src/tools/cell_meta.rs
@@ -56,7 +56,11 @@ pub async fn add_cell_tags(
     let session = server.session.read().await;
     let session = match session.as_ref() {
         Some(s) => s,
-        None => return tool_error("No active notebook session. Call join_notebook or open_notebook first."),
+        None => {
+            return tool_error(
+                "No active notebook session. Call join_notebook or open_notebook first.",
+            )
+        }
     };
 
     let handle = &session.handle;
@@ -112,7 +116,11 @@ pub async fn remove_cell_tags(
     let session = server.session.read().await;
     let session = match session.as_ref() {
         Some(s) => s,
-        None => return tool_error("No active notebook session. Call join_notebook or open_notebook first."),
+        None => {
+            return tool_error(
+                "No active notebook session. Call join_notebook or open_notebook first.",
+            )
+        }
     };
 
     let handle = &session.handle;
@@ -160,7 +168,11 @@ pub async fn set_cells_source_hidden(
     let session = server.session.read().await;
     let session = match session.as_ref() {
         Some(s) => s,
-        None => return tool_error("No active notebook session. Call join_notebook or open_notebook first."),
+        None => {
+            return tool_error(
+                "No active notebook session. Call join_notebook or open_notebook first.",
+            )
+        }
     };
 
     let cell_ids: Vec<String> = request
@@ -204,7 +216,11 @@ pub async fn set_cells_outputs_hidden(
     let session = server.session.read().await;
     let session = match session.as_ref() {
         Some(s) => s,
-        None => return tool_error("No active notebook session. Call join_notebook or open_notebook first."),
+        None => {
+            return tool_error(
+                "No active notebook session. Call join_notebook or open_notebook first.",
+            )
+        }
     };
 
     let cell_ids: Vec<String> = request

--- a/crates/runt-mcp/src/tools/cell_read.rs
+++ b/crates/runt-mcp/src/tools/cell_read.rs
@@ -1,0 +1,271 @@
+//! Read-only cell tools: get_cell, get_all_cells.
+
+use rmcp::model::{CallToolRequestParams, CallToolResult, Content};
+use rmcp::ErrorData as McpError;
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use runtimed_client::output_resolver;
+
+use crate::formatting;
+use crate::NteractMcp;
+
+use super::{arg_str, tool_error, tool_success};
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct GetCellParams {
+    /// The cell ID to retrieve.
+    pub cell_id: String,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct GetAllCellsParams {
+    /// Output format: "summary" (default), "json", or "rich".
+    #[serde(default = "default_format")]
+    pub format: Option<String>,
+    /// Starting cell index (0-based).
+    #[serde(default)]
+    pub start: Option<i64>,
+    /// Number of cells to return (null = all).
+    #[serde(default)]
+    pub count: Option<i64>,
+    /// Include output previews in summary format.
+    #[serde(default)]
+    pub include_outputs: Option<bool>,
+    /// Max chars for source preview in summary format.
+    #[serde(default)]
+    pub preview_chars: Option<i64>,
+}
+
+fn default_format() -> Option<String> {
+    Some("summary".to_string())
+}
+
+/// Get a single cell by ID with source and outputs.
+pub async fn get_cell(
+    server: &NteractMcp,
+    request: &CallToolRequestParams,
+) -> Result<CallToolResult, McpError> {
+    let cell_id = arg_str(request, "cell_id")
+        .ok_or_else(|| McpError::invalid_params("Missing required parameter: cell_id", None))?;
+
+    let session = server.session.read().await;
+    let session = match session.as_ref() {
+        Some(s) => s,
+        None => return tool_error("No active notebook session. Call join_notebook or open_notebook first."),
+    };
+
+    let handle = &session.handle;
+    let cell = match handle.get_cell(cell_id) {
+        Some(c) => c,
+        None => return tool_error(&format!("Cell not found: {cell_id}")),
+    };
+
+    // Resolve outputs
+    let outputs = output_resolver::resolve_cell_outputs(
+        &cell.outputs,
+        &server.blob_base_url,
+        &server.blob_store_path,
+    )
+    .await;
+
+    // Get execution status from RuntimeState
+    let status = get_cell_status(handle, cell_id);
+
+    let header = formatting::format_cell_header(
+        &cell.id,
+        &cell.cell_type,
+        Some(&cell.execution_count),
+        status.as_deref(),
+    );
+
+    let output_text = formatting::format_outputs_text(&outputs);
+
+    let text = if !cell.source.is_empty() && !output_text.is_empty() {
+        format!("{header}\n\n{}\n\n───────────────────\n\n{output_text}", cell.source)
+    } else if !cell.source.is_empty() {
+        format!("{header}\n\n{}", cell.source)
+    } else if !output_text.is_empty() {
+        format!("{header}\n\n{output_text}")
+    } else {
+        header
+    };
+
+    Ok(CallToolResult::success(vec![Content::text(text)]))
+}
+
+/// Get all cells with configurable format.
+pub async fn get_all_cells(
+    server: &NteractMcp,
+    request: &CallToolRequestParams,
+) -> Result<CallToolResult, McpError> {
+    let session = server.session.read().await;
+    let session = match session.as_ref() {
+        Some(s) => s,
+        None => return tool_error("No active notebook session. Call join_notebook or open_notebook first."),
+    };
+
+    let format = arg_str(request, "format").unwrap_or("summary");
+    let start = request
+        .arguments
+        .as_ref()
+        .and_then(|a| a.get("start"))
+        .and_then(|v| v.as_i64())
+        .unwrap_or(0) as usize;
+    let count = request
+        .arguments
+        .as_ref()
+        .and_then(|a| a.get("count"))
+        .and_then(|v| v.as_i64())
+        .map(|v| v as usize);
+    let include_outputs = request
+        .arguments
+        .as_ref()
+        .and_then(|a| a.get("include_outputs"))
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let preview_chars = request
+        .arguments
+        .as_ref()
+        .and_then(|a| a.get("preview_chars"))
+        .and_then(|v| v.as_i64())
+        .unwrap_or(60) as usize;
+
+    let handle = &session.handle;
+    let cells = handle.get_cells();
+    let end = match count {
+        Some(c) => (start + c).min(cells.len()),
+        None => cells.len(),
+    };
+    let slice = &cells[start.min(cells.len())..end.min(cells.len())];
+
+    // Build cell status map from RuntimeState
+    let cell_status_map = build_cell_status_map(handle);
+
+    match format {
+        "json" => {
+            let mut json_cells = Vec::new();
+            for cell in slice {
+                let status = cell_status_map.get(&cell.id).map(String::as_str);
+                let ec: Option<i64> = cell.execution_count.parse().ok();
+                json_cells.push(serde_json::json!({
+                    "cell_id": cell.id,
+                    "cell_type": cell.cell_type,
+                    "execution_count": ec,
+                    "source": cell.source,
+                    "outputs": [],
+                    "status": status,
+                }));
+            }
+            let text = serde_json::to_string_pretty(&json_cells).unwrap_or_default();
+            Ok(CallToolResult::success(vec![Content::text(text)]))
+        }
+        "rich" => {
+            let mut items = Vec::new();
+            for cell in slice {
+                let status = cell_status_map.get(&cell.id).map(String::as_str);
+                let outputs = output_resolver::resolve_cell_outputs(
+                    &cell.outputs,
+                    &server.blob_base_url,
+                    &server.blob_store_path,
+                )
+                .await;
+                let header = formatting::format_cell_header(
+                    &cell.id,
+                    &cell.cell_type,
+                    Some(&cell.execution_count),
+                    status,
+                );
+                let output_text = formatting::format_outputs_text(&outputs);
+                let text = if !cell.source.is_empty() {
+                    format!("{header}\n\n{}", cell.source)
+                } else {
+                    header
+                };
+                items.push(Content::text(text));
+                if !output_text.is_empty() {
+                    items.push(Content::text(output_text));
+                }
+            }
+            Ok(CallToolResult::success(items))
+        }
+        _ => {
+            // summary format
+            let mut lines = Vec::new();
+            for (i, cell) in slice.iter().enumerate() {
+                let status = cell_status_map.get(&cell.id).map(String::as_str);
+                let line = formatting::format_cell_summary(
+                    start + i,
+                    &cell.id,
+                    &cell.cell_type,
+                    &cell.source,
+                    Some(&cell.execution_count),
+                    status,
+                    preview_chars,
+                );
+                if include_outputs && !cell.outputs.is_empty() {
+                    let outputs = output_resolver::resolve_cell_outputs(
+                        &cell.outputs,
+                        &server.blob_base_url,
+                        &server.blob_store_path,
+                    )
+                    .await;
+                    let output_text = formatting::format_outputs_text(&outputs);
+                    if !output_text.is_empty() {
+                        let output_line = output_text.replace('\n', " ");
+                        let output_preview = if output_line.len() > preview_chars {
+                            format!("{}...", &output_line[..preview_chars])
+                        } else {
+                            output_line
+                        };
+                        lines.push(format!("{line}\n  └─ {output_preview}"));
+                    } else {
+                        lines.push(line);
+                    }
+                } else {
+                    lines.push(line);
+                }
+            }
+            tool_success(&lines.join("\n"))
+        }
+    }
+}
+
+/// Get cell execution status from RuntimeState.
+fn get_cell_status(
+    handle: &notebook_sync::handle::DocHandle,
+    cell_id: &str,
+) -> Option<String> {
+    if let Ok(state) = handle.get_runtime_state() {
+        if state
+            .queue
+            .executing
+            .as_ref()
+            .is_some_and(|e| e.cell_id == cell_id)
+        {
+            return Some("running".to_string());
+        }
+        if state.queue.queued.iter().any(|e| e.cell_id == cell_id) {
+            return Some("queued".to_string());
+        }
+    }
+    None
+}
+
+/// Build a map of cell_id -> status from RuntimeState.
+fn build_cell_status_map(
+    handle: &notebook_sync::handle::DocHandle,
+) -> std::collections::HashMap<String, String> {
+    let mut map = std::collections::HashMap::new();
+    if let Ok(state) = handle.get_runtime_state() {
+        if let Some(ref e) = state.queue.executing {
+            map.insert(e.cell_id.clone(), "running".to_string());
+        }
+        for e in &state.queue.queued {
+            map.insert(e.cell_id.clone(), "queued".to_string());
+        }
+    }
+    map
+}

--- a/crates/runt-mcp/src/tools/cell_read.rs
+++ b/crates/runt-mcp/src/tools/cell_read.rs
@@ -54,7 +54,11 @@ pub async fn get_cell(
     let session = server.session.read().await;
     let session = match session.as_ref() {
         Some(s) => s,
-        None => return tool_error("No active notebook session. Call join_notebook or open_notebook first."),
+        None => {
+            return tool_error(
+                "No active notebook session. Call join_notebook or open_notebook first.",
+            )
+        }
     };
 
     let handle = &session.handle;
@@ -84,7 +88,10 @@ pub async fn get_cell(
     let output_text = formatting::format_outputs_text(&outputs);
 
     let text = if !cell.source.is_empty() && !output_text.is_empty() {
-        format!("{header}\n\n{}\n\n───────────────────\n\n{output_text}", cell.source)
+        format!(
+            "{header}\n\n{}\n\n───────────────────\n\n{output_text}",
+            cell.source
+        )
     } else if !cell.source.is_empty() {
         format!("{header}\n\n{}", cell.source)
     } else if !output_text.is_empty() {
@@ -104,7 +111,11 @@ pub async fn get_all_cells(
     let session = server.session.read().await;
     let session = match session.as_ref() {
         Some(s) => s,
-        None => return tool_error("No active notebook session. Call join_notebook or open_notebook first."),
+        None => {
+            return tool_error(
+                "No active notebook session. Call join_notebook or open_notebook first.",
+            )
+        }
     };
 
     let format = arg_str(request, "format").unwrap_or("summary");
@@ -150,12 +161,20 @@ pub async fn get_all_cells(
             for cell in slice {
                 let status = cell_status_map.get(&cell.id).map(String::as_str);
                 let ec: Option<i64> = cell.execution_count.parse().ok();
+
+                // Parse raw output JSON strings from the CRDT into serde_json::Value
+                let output_values: Vec<serde_json::Value> = cell
+                    .outputs
+                    .iter()
+                    .filter_map(|raw| serde_json::from_str(raw).ok())
+                    .collect();
+
                 json_cells.push(serde_json::json!({
                     "cell_id": cell.id,
                     "cell_type": cell.cell_type,
                     "execution_count": ec,
                     "source": cell.source,
-                    "outputs": [],
+                    "outputs": output_values,
                     "status": status,
                 }));
             }
@@ -234,10 +253,7 @@ pub async fn get_all_cells(
 }
 
 /// Get cell execution status from RuntimeState.
-fn get_cell_status(
-    handle: &notebook_sync::handle::DocHandle,
-    cell_id: &str,
-) -> Option<String> {
+fn get_cell_status(handle: &notebook_sync::handle::DocHandle, cell_id: &str) -> Option<String> {
     if let Ok(state) = handle.get_runtime_state() {
         if state
             .queue

--- a/crates/runt-mcp/src/tools/deps.rs
+++ b/crates/runt-mcp/src/tools/deps.rs
@@ -44,7 +44,11 @@ pub async fn add_dependency(
     let session = server.session.read().await;
     let session = match session.as_ref() {
         Some(s) => s,
-        None => return tool_error("No active notebook session. Call join_notebook or open_notebook first."),
+        None => {
+            return tool_error(
+                "No active notebook session. Call join_notebook or open_notebook first.",
+            )
+        }
     };
 
     session
@@ -73,15 +77,17 @@ pub async fn remove_dependency(
     let session = server.session.read().await;
     let session = match session.as_ref() {
         Some(s) => s,
-        None => return tool_error("No active notebook session. Call join_notebook or open_notebook first."),
+        None => {
+            return tool_error(
+                "No active notebook session. Call join_notebook or open_notebook first.",
+            )
+        }
     };
 
     session
         .handle
         .remove_uv_dependency(package)
-        .map_err(|e| {
-            McpError::internal_error(format!("Failed to remove dependency: {e}"), None)
-        })?;
+        .map_err(|e| McpError::internal_error(format!("Failed to remove dependency: {e}"), None))?;
 
     let deps = get_deps_list(&session.handle);
 
@@ -100,7 +106,11 @@ pub async fn get_dependencies(
     let session = server.session.read().await;
     let session = match session.as_ref() {
         Some(s) => s,
-        None => return tool_error("No active notebook session. Call join_notebook or open_notebook first."),
+        None => {
+            return tool_error(
+                "No active notebook session. Call join_notebook or open_notebook first.",
+            )
+        }
     };
 
     let deps = get_deps_list(&session.handle);
@@ -117,7 +127,11 @@ pub async fn sync_environment(
     let session = server.session.read().await;
     let session = match session.as_ref() {
         Some(s) => s,
-        None => return tool_error("No active notebook session. Call join_notebook or open_notebook first."),
+        None => {
+            return tool_error(
+                "No active notebook session. Call join_notebook or open_notebook first.",
+            )
+        }
     };
 
     let handle = &session.handle;

--- a/crates/runt-mcp/src/tools/deps.rs
+++ b/crates/runt-mcp/src/tools/deps.rs
@@ -1,0 +1,181 @@
+//! Dependency management tools: add_dependency, remove_dependency, get_dependencies, sync_environment.
+
+use rmcp::model::{CallToolRequestParams, CallToolResult};
+use rmcp::ErrorData as McpError;
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use notebook_protocol::protocol::{NotebookRequest, NotebookResponse};
+
+use crate::NteractMcp;
+
+use super::{arg_str, tool_error, tool_success};
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct AddDependencyParams {
+    /// Package to add (e.g. "pandas>=2.0").
+    pub package: String,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct RemoveDependencyParams {
+    /// Package to remove.
+    pub package: String,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct GetDependenciesParams {}
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SyncEnvironmentParams {}
+
+/// Add a package dependency.
+pub async fn add_dependency(
+    server: &NteractMcp,
+    request: &CallToolRequestParams,
+) -> Result<CallToolResult, McpError> {
+    let package = arg_str(request, "package")
+        .ok_or_else(|| McpError::invalid_params("Missing required parameter: package", None))?;
+
+    let session = server.session.read().await;
+    let session = match session.as_ref() {
+        Some(s) => s,
+        None => return tool_error("No active notebook session. Call join_notebook or open_notebook first."),
+    };
+
+    session
+        .handle
+        .add_uv_dependency(package)
+        .map_err(|e| McpError::internal_error(format!("Failed to add dependency: {e}"), None))?;
+
+    // Read back current dependencies
+    let deps = get_deps_list(&session.handle);
+
+    let result = serde_json::json!({
+        "dependencies": deps,
+        "added": package,
+    });
+    tool_success(&serde_json::to_string_pretty(&result).unwrap_or_default())
+}
+
+/// Remove a package dependency.
+pub async fn remove_dependency(
+    server: &NteractMcp,
+    request: &CallToolRequestParams,
+) -> Result<CallToolResult, McpError> {
+    let package = arg_str(request, "package")
+        .ok_or_else(|| McpError::invalid_params("Missing required parameter: package", None))?;
+
+    let session = server.session.read().await;
+    let session = match session.as_ref() {
+        Some(s) => s,
+        None => return tool_error("No active notebook session. Call join_notebook or open_notebook first."),
+    };
+
+    session
+        .handle
+        .remove_uv_dependency(package)
+        .map_err(|e| {
+            McpError::internal_error(format!("Failed to remove dependency: {e}"), None)
+        })?;
+
+    let deps = get_deps_list(&session.handle);
+
+    let result = serde_json::json!({
+        "dependencies": deps,
+        "removed": package,
+    });
+    tool_success(&serde_json::to_string_pretty(&result).unwrap_or_default())
+}
+
+/// Get the notebook's current package dependencies.
+pub async fn get_dependencies(
+    server: &NteractMcp,
+    _request: &CallToolRequestParams,
+) -> Result<CallToolResult, McpError> {
+    let session = server.session.read().await;
+    let session = match session.as_ref() {
+        Some(s) => s,
+        None => return tool_error("No active notebook session. Call join_notebook or open_notebook first."),
+    };
+
+    let deps = get_deps_list(&session.handle);
+
+    let result = serde_json::json!({ "dependencies": deps });
+    tool_success(&serde_json::to_string_pretty(&result).unwrap_or_default())
+}
+
+/// Hot-install new dependencies without restarting.
+pub async fn sync_environment(
+    server: &NteractMcp,
+    _request: &CallToolRequestParams,
+) -> Result<CallToolResult, McpError> {
+    let session = server.session.read().await;
+    let session = match session.as_ref() {
+        Some(s) => s,
+        None => return tool_error("No active notebook session. Call join_notebook or open_notebook first."),
+    };
+
+    let handle = &session.handle;
+
+    // Ensure daemon has latest metadata
+    if let Err(e) = handle.confirm_sync().await {
+        tracing::warn!("confirm_sync failed before sync_environment: {e}");
+    }
+
+    match handle
+        .send_request(NotebookRequest::SyncEnvironment {})
+        .await
+    {
+        Ok(NotebookResponse::SyncEnvironmentComplete {
+            synced_packages, ..
+        }) => {
+            let result = serde_json::json!({
+                "success": true,
+                "synced_packages": synced_packages,
+            });
+            tool_success(&serde_json::to_string_pretty(&result).unwrap_or_default())
+        }
+        Ok(NotebookResponse::SyncEnvironmentStarted { packages }) => {
+            // Sync started but hasn't completed yet — return started status
+            let result = serde_json::json!({
+                "success": true,
+                "synced_packages": packages,
+            });
+            tool_success(&serde_json::to_string_pretty(&result).unwrap_or_default())
+        }
+        Ok(NotebookResponse::SyncEnvironmentFailed {
+            error,
+            needs_restart,
+        }) => {
+            let result = serde_json::json!({
+                "success": false,
+                "error": error,
+                "needs_restart": needs_restart,
+            });
+            tool_success(&serde_json::to_string_pretty(&result).unwrap_or_default())
+        }
+        Ok(NotebookResponse::Error { error }) => {
+            let result = serde_json::json!({
+                "success": false,
+                "error": error,
+                "needs_restart": true,
+            });
+            tool_success(&serde_json::to_string_pretty(&result).unwrap_or_default())
+        }
+        Ok(_) => tool_success(&serde_json::json!({ "success": true }).to_string()),
+        Err(e) => tool_error(&format!("Failed to sync environment: {e}")),
+    }
+}
+
+/// Read UV dependencies from notebook metadata.
+fn get_deps_list(handle: &notebook_sync::handle::DocHandle) -> Vec<String> {
+    handle
+        .get_notebook_metadata()
+        .map(|m| m.uv_dependencies().to_vec())
+        .unwrap_or_default()
+}

--- a/crates/runt-mcp/src/tools/editing.rs
+++ b/crates/runt-mcp/src/tools/editing.rs
@@ -1,0 +1,274 @@
+//! Editing tools: replace_match, replace_regex.
+
+use std::time::Duration;
+
+use rmcp::model::{CallToolRequestParams, CallToolResult, Content};
+use rmcp::ErrorData as McpError;
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use crate::editing;
+use crate::execution;
+use crate::formatting;
+use crate::structured;
+use crate::NteractMcp;
+
+use super::{arg_str, tool_error};
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ReplaceMatchParams {
+    /// The cell ID to edit.
+    pub cell_id: String,
+    /// Literal text to find (must match exactly once).
+    #[serde(rename = "match")]
+    pub match_text: String,
+    /// Literal replacement text.
+    pub content: String,
+    /// Text that must appear before the match.
+    #[serde(default)]
+    pub context_before: Option<String>,
+    /// Text that must appear after the match.
+    #[serde(default)]
+    pub context_after: Option<String>,
+    /// Execute the cell immediately after edit.
+    #[serde(default)]
+    pub and_run: Option<bool>,
+    /// Max seconds to wait for execution.
+    #[serde(default)]
+    pub timeout_secs: Option<f64>,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ReplaceRegexParams {
+    /// The cell ID to edit.
+    pub cell_id: String,
+    /// Regex pattern (must match exactly once). MULTILINE enabled.
+    pub pattern: String,
+    /// Literal replacement text.
+    pub content: String,
+    /// Execute the cell immediately after edit.
+    #[serde(default)]
+    pub and_run: Option<bool>,
+    /// Max seconds to wait for execution.
+    #[serde(default)]
+    pub timeout_secs: Option<f64>,
+}
+
+/// Replace matched text in a cell.
+pub async fn replace_match(
+    server: &NteractMcp,
+    request: &CallToolRequestParams,
+) -> Result<CallToolResult, McpError> {
+    let cell_id = arg_str(request, "cell_id")
+        .ok_or_else(|| McpError::invalid_params("Missing required parameter: cell_id", None))?;
+    let match_text = arg_str(request, "match")
+        .ok_or_else(|| McpError::invalid_params("Missing required parameter: match", None))?;
+    let content = arg_str(request, "content")
+        .ok_or_else(|| McpError::invalid_params("Missing required parameter: content", None))?;
+
+    let context_before = arg_str(request, "context_before").filter(|s| !s.is_empty());
+    let context_after = arg_str(request, "context_after").filter(|s| !s.is_empty());
+
+    let and_run = request
+        .arguments
+        .as_ref()
+        .and_then(|a| a.get("and_run"))
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let timeout_secs = request
+        .arguments
+        .as_ref()
+        .and_then(|a| a.get("timeout_secs"))
+        .and_then(|v| v.as_f64())
+        .unwrap_or(30.0);
+
+    let session = server.session.read().await;
+    let session = match session.as_ref() {
+        Some(s) => s,
+        None => return tool_error("No active notebook session. Call join_notebook or open_notebook first."),
+    };
+
+    let handle = &session.handle;
+
+    let source = match handle.get_cell_source(cell_id) {
+        Some(s) => s,
+        None => return tool_error(&format!("Cell \"{cell_id}\" not found")),
+    };
+
+    // Resolve the match
+    let span = match editing::resolve_match(&source, match_text, context_before, context_after) {
+        Ok(span) => span,
+        Err(e) => {
+            return Err(McpError::internal_error(
+                format!("{e} (source_length={})", source.len()),
+                None,
+            ));
+        }
+    };
+
+    // Apply the splice
+    let delete_count = span.end - span.start;
+    handle
+        .splice_source(cell_id, span.start, delete_count, content)
+        .map_err(|e| McpError::internal_error(format!("Failed to splice source: {e}"), None))?;
+
+    if and_run {
+        let result = execution::execute_and_wait(
+            handle,
+            cell_id,
+            Duration::from_secs_f64(timeout_secs),
+            &server.blob_base_url,
+            &server.blob_store_path,
+        )
+        .await;
+        return build_execution_result(&result, handle, server).await;
+    }
+
+    // Return diff
+    let old_text = &source[span.start..span.end];
+    let diff = format_edit_diff(cell_id, old_text, content);
+    Ok(CallToolResult::success(vec![Content::text(diff)]))
+}
+
+/// Replace a regex-matched span in a cell.
+pub async fn replace_regex(
+    server: &NteractMcp,
+    request: &CallToolRequestParams,
+) -> Result<CallToolResult, McpError> {
+    let cell_id = arg_str(request, "cell_id")
+        .ok_or_else(|| McpError::invalid_params("Missing required parameter: cell_id", None))?;
+    let pattern = arg_str(request, "pattern")
+        .ok_or_else(|| McpError::invalid_params("Missing required parameter: pattern", None))?;
+    let content = arg_str(request, "content")
+        .ok_or_else(|| McpError::invalid_params("Missing required parameter: content", None))?;
+
+    let and_run = request
+        .arguments
+        .as_ref()
+        .and_then(|a| a.get("and_run"))
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let timeout_secs = request
+        .arguments
+        .as_ref()
+        .and_then(|a| a.get("timeout_secs"))
+        .and_then(|v| v.as_f64())
+        .unwrap_or(30.0);
+
+    let session = server.session.read().await;
+    let session = match session.as_ref() {
+        Some(s) => s,
+        None => return tool_error("No active notebook session. Call join_notebook or open_notebook first."),
+    };
+
+    let handle = &session.handle;
+
+    let source = match handle.get_cell_source(cell_id) {
+        Some(s) => s,
+        None => return tool_error(&format!("Cell \"{cell_id}\" not found")),
+    };
+
+    // Resolve the regex
+    let span = match editing::resolve_regex(&source, pattern) {
+        Ok(span) => span,
+        Err(e) => {
+            return Err(McpError::internal_error(
+                format!("{e} (source_length={})", source.len()),
+                None,
+            ));
+        }
+    };
+
+    // Apply the splice
+    let delete_count = span.end - span.start;
+    handle
+        .splice_source(cell_id, span.start, delete_count, content)
+        .map_err(|e| McpError::internal_error(format!("Failed to splice source: {e}"), None))?;
+
+    if and_run {
+        let result = execution::execute_and_wait(
+            handle,
+            cell_id,
+            Duration::from_secs_f64(timeout_secs),
+            &server.blob_base_url,
+            &server.blob_store_path,
+        )
+        .await;
+        return build_execution_result(&result, handle, server).await;
+    }
+
+    // Return diff
+    let old_text = &source[span.start..span.end];
+    let diff = format_edit_diff(cell_id, old_text, content);
+    Ok(CallToolResult::success(vec![Content::text(diff)]))
+}
+
+/// Format a unified diff for an edit operation.
+fn format_edit_diff(cell_id: &str, old_text: &str, new_text: &str) -> String {
+    let old_lines: Vec<&str> = old_text.lines().collect();
+    let new_lines: Vec<&str> = new_text.lines().collect();
+
+    let mut diff_parts = Vec::new();
+    diff_parts.push(format!("Edited cell \"{cell_id}\":"));
+    diff_parts.push("--- before".to_string());
+    diff_parts.push("+++ after".to_string());
+
+    for line in &old_lines {
+        diff_parts.push(format!("-{line}"));
+    }
+    for line in &new_lines {
+        diff_parts.push(format!("+{line}"));
+    }
+
+    diff_parts.join("\n")
+}
+
+/// Build a CallToolResult from an ExecutionResult with structured content.
+async fn build_execution_result(
+    result: &execution::ExecutionResult,
+    handle: &notebook_sync::handle::DocHandle,
+    server: &NteractMcp,
+) -> Result<CallToolResult, McpError> {
+    let header = formatting::format_cell_header(
+        &result.cell_id,
+        "code",
+        result.execution_count.as_deref(),
+        Some(&result.status),
+    );
+
+    let output_text = formatting::format_outputs_text(&result.outputs);
+    let text = if !output_text.is_empty() {
+        format!("{header}\n\n{output_text}")
+    } else {
+        header
+    };
+
+    let mut items = vec![Content::text(text)];
+
+    // Build structured content for MCP Apps widget
+    let cell_snapshot = handle.get_cell(&result.cell_id);
+    if let Some(snap) = cell_snapshot {
+        let outputs = runtimed_client::output_resolver::resolve_cell_outputs(
+            &snap.outputs,
+            &server.blob_base_url,
+            &server.blob_store_path,
+        )
+        .await;
+        let resolved = runtimed_client::resolved_output::ResolvedCell {
+            id: snap.id,
+            cell_type: snap.cell_type,
+            position: snap.position,
+            source: snap.source,
+            execution_count: snap.execution_count.parse().ok(),
+            outputs,
+            metadata_json: serde_json::to_string(&snap.metadata).unwrap_or_default(),
+        };
+        let sc = structured::cell_structured_content(&resolved, &result.status);
+        let sc_json = serde_json::to_string(&sc).unwrap_or_default();
+        items.push(Content::text(format!("\n---structuredContent---\n{sc_json}")));
+    }
+
+    Ok(CallToolResult::success(items))
+}

--- a/crates/runt-mcp/src/tools/editing.rs
+++ b/crates/runt-mcp/src/tools/editing.rs
@@ -87,7 +87,11 @@ pub async fn replace_match(
     let session = server.session.read().await;
     let session = match session.as_ref() {
         Some(s) => s,
-        None => return tool_error("No active notebook session. Call join_notebook or open_notebook first."),
+        None => {
+            return tool_error(
+                "No active notebook session. Call join_notebook or open_notebook first.",
+            )
+        }
     };
 
     let handle = &session.handle;
@@ -108,10 +112,13 @@ pub async fn replace_match(
         }
     };
 
-    // Apply the splice
-    let delete_count = span.end - span.start;
+    // Convert byte offsets to code point offsets for Automerge splice
+    let cp_start = editing::byte_offset_to_codepoint(&source, span.start);
+    let cp_end = editing::byte_offset_to_codepoint(&source, span.end);
+    let cp_delete = cp_end - cp_start;
+
     handle
-        .splice_source(cell_id, span.start, delete_count, content)
+        .splice_source(cell_id, cp_start, cp_delete, content)
         .map_err(|e| McpError::internal_error(format!("Failed to splice source: {e}"), None))?;
 
     if and_run {
@@ -160,7 +167,11 @@ pub async fn replace_regex(
     let session = server.session.read().await;
     let session = match session.as_ref() {
         Some(s) => s,
-        None => return tool_error("No active notebook session. Call join_notebook or open_notebook first."),
+        None => {
+            return tool_error(
+                "No active notebook session. Call join_notebook or open_notebook first.",
+            )
+        }
     };
 
     let handle = &session.handle;
@@ -181,10 +192,13 @@ pub async fn replace_regex(
         }
     };
 
-    // Apply the splice
-    let delete_count = span.end - span.start;
+    // Convert byte offsets to code point offsets for Automerge splice
+    let cp_start = editing::byte_offset_to_codepoint(&source, span.start);
+    let cp_end = editing::byte_offset_to_codepoint(&source, span.end);
+    let cp_delete = cp_end - cp_start;
+
     handle
-        .splice_source(cell_id, span.start, delete_count, content)
+        .splice_source(cell_id, cp_start, cp_delete, content)
         .map_err(|e| McpError::internal_error(format!("Failed to splice source: {e}"), None))?;
 
     if and_run {
@@ -245,11 +259,12 @@ async fn build_execution_result(
         header
     };
 
-    let mut items = vec![Content::text(text)];
+    let items = vec![Content::text(text)];
 
-    // Build structured content for MCP Apps widget
+    // Build structured content for MCP Apps widget using the protocol's
+    // structured_content field instead of a text-based fallback.
     let cell_snapshot = handle.get_cell(&result.cell_id);
-    if let Some(snap) = cell_snapshot {
+    let structured_content = if let Some(snap) = cell_snapshot {
         let outputs = runtimed_client::output_resolver::resolve_cell_outputs(
             &snap.outputs,
             &server.blob_base_url,
@@ -265,10 +280,15 @@ async fn build_execution_result(
             outputs,
             metadata_json: serde_json::to_string(&snap.metadata).unwrap_or_default(),
         };
-        let sc = structured::cell_structured_content(&resolved, &result.status);
-        let sc_json = serde_json::to_string(&sc).unwrap_or_default();
-        items.push(Content::text(format!("\n---structuredContent---\n{sc_json}")));
-    }
+        Some(structured::cell_structured_content(
+            &resolved,
+            &result.status,
+        ))
+    } else {
+        None
+    };
 
-    Ok(CallToolResult::success(items))
+    let mut call_result = CallToolResult::success(items);
+    call_result.structured_content = structured_content;
+    Ok(call_result)
 }

--- a/crates/runt-mcp/src/tools/execution.rs
+++ b/crates/runt-mcp/src/tools/execution.rs
@@ -1,0 +1,142 @@
+//! Execution tools: execute_cell, run_all_cells.
+
+use std::time::Duration;
+
+use rmcp::model::{CallToolRequestParams, CallToolResult, Content};
+use rmcp::ErrorData as McpError;
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use notebook_protocol::protocol::NotebookRequest;
+
+use crate::execution;
+use crate::formatting;
+use crate::structured;
+use crate::NteractMcp;
+
+use super::{arg_str, tool_error, tool_success};
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ExecuteCellParams {
+    /// The cell ID to execute.
+    pub cell_id: String,
+    /// Max seconds to wait; returns partial results if exceeded.
+    #[serde(default)]
+    pub timeout_secs: Option<f64>,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct RunAllCellsParams {}
+
+/// Execute a cell and return results (with structured content for MCP Apps).
+pub async fn execute_cell(
+    server: &NteractMcp,
+    request: &CallToolRequestParams,
+) -> Result<CallToolResult, McpError> {
+    let cell_id = arg_str(request, "cell_id")
+        .ok_or_else(|| McpError::invalid_params("Missing required parameter: cell_id", None))?;
+
+    let session = server.session.read().await;
+    let session = match session.as_ref() {
+        Some(s) => s,
+        None => return tool_error("No active notebook session. Call join_notebook or open_notebook first."),
+    };
+
+    let timeout_secs = request
+        .arguments
+        .as_ref()
+        .and_then(|a| a.get("timeout_secs"))
+        .and_then(|v| v.as_f64())
+        .unwrap_or(30.0);
+
+    let handle = &session.handle;
+
+    // Verify cell exists
+    if handle.get_cell(cell_id).is_none() {
+        return tool_error(&format!("Cell not found: {cell_id}"));
+    }
+
+    let result = execution::execute_and_wait(
+        handle,
+        cell_id,
+        Duration::from_secs_f64(timeout_secs),
+        &server.blob_base_url,
+        &server.blob_store_path,
+    )
+    .await;
+
+    // Format text content
+    let header = formatting::format_cell_header(
+        &result.cell_id,
+        "code",
+        result.execution_count.as_deref(),
+        Some(&result.status),
+    );
+    let output_text = formatting::format_outputs_text(&result.outputs);
+    let text = if !output_text.is_empty() {
+        format!("{header}\n\n{output_text}")
+    } else {
+        header
+    };
+
+    let mut items = vec![Content::text(text)];
+
+    // Build structured content for MCP Apps widget
+    let cell_snapshot = handle.get_cell(&result.cell_id);
+    if let Some(snap) = cell_snapshot {
+        let outputs = runtimed_client::output_resolver::resolve_cell_outputs(
+            &snap.outputs,
+            &server.blob_base_url,
+            &server.blob_store_path,
+        )
+        .await;
+        let resolved = runtimed_client::resolved_output::ResolvedCell {
+            id: snap.id,
+            cell_type: snap.cell_type,
+            position: snap.position,
+            source: snap.source,
+            execution_count: snap.execution_count.parse().ok(),
+            outputs,
+            metadata_json: serde_json::to_string(&snap.metadata).unwrap_or_default(),
+        };
+        let sc = structured::cell_structured_content(&resolved, &result.status);
+        let sc_json = serde_json::to_string(&sc).unwrap_or_default();
+        items.push(Content::text(format!("\n---structuredContent---\n{sc_json}")));
+    }
+
+    Ok(CallToolResult::success(items))
+}
+
+/// Queue all code cells for execution.
+pub async fn run_all_cells(
+    server: &NteractMcp,
+    _request: &CallToolRequestParams,
+) -> Result<CallToolResult, McpError> {
+    let session = server.session.read().await;
+    let session = match session.as_ref() {
+        Some(s) => s,
+        None => return tool_error("No active notebook session. Call join_notebook or open_notebook first."),
+    };
+
+    let handle = &session.handle;
+
+    // Ensure daemon has latest source
+    if let Err(e) = handle.confirm_sync().await {
+        tracing::warn!("confirm_sync failed before run_all_cells: {e}");
+    }
+
+    match handle.send_request(NotebookRequest::RunAllCells {}).await {
+        Ok(_) => {
+            let count = handle
+                .get_cells()
+                .iter()
+                .filter(|c| c.cell_type == "code")
+                .count();
+            let result = serde_json::json!({ "status": "queued", "count": count });
+            tool_success(&serde_json::to_string_pretty(&result).unwrap_or_default())
+        }
+        Err(e) => tool_error(&format!("Failed to run all cells: {e}")),
+    }
+}

--- a/crates/runt-mcp/src/tools/execution.rs
+++ b/crates/runt-mcp/src/tools/execution.rs
@@ -41,7 +41,11 @@ pub async fn execute_cell(
     let session = server.session.read().await;
     let session = match session.as_ref() {
         Some(s) => s,
-        None => return tool_error("No active notebook session. Call join_notebook or open_notebook first."),
+        None => {
+            return tool_error(
+                "No active notebook session. Call join_notebook or open_notebook first.",
+            )
+        }
     };
 
     let timeout_secs = request
@@ -81,11 +85,12 @@ pub async fn execute_cell(
         header
     };
 
-    let mut items = vec![Content::text(text)];
+    let items = vec![Content::text(text)];
 
-    // Build structured content for MCP Apps widget
+    // Build structured content for MCP Apps widget using the protocol's
+    // structured_content field instead of a text-based fallback.
     let cell_snapshot = handle.get_cell(&result.cell_id);
-    if let Some(snap) = cell_snapshot {
+    let structured_content = if let Some(snap) = cell_snapshot {
         let outputs = runtimed_client::output_resolver::resolve_cell_outputs(
             &snap.outputs,
             &server.blob_base_url,
@@ -101,12 +106,17 @@ pub async fn execute_cell(
             outputs,
             metadata_json: serde_json::to_string(&snap.metadata).unwrap_or_default(),
         };
-        let sc = structured::cell_structured_content(&resolved, &result.status);
-        let sc_json = serde_json::to_string(&sc).unwrap_or_default();
-        items.push(Content::text(format!("\n---structuredContent---\n{sc_json}")));
-    }
+        Some(structured::cell_structured_content(
+            &resolved,
+            &result.status,
+        ))
+    } else {
+        None
+    };
 
-    Ok(CallToolResult::success(items))
+    let mut call_result = CallToolResult::success(items);
+    call_result.structured_content = structured_content;
+    Ok(call_result)
 }
 
 /// Queue all code cells for execution.
@@ -117,7 +127,11 @@ pub async fn run_all_cells(
     let session = server.session.read().await;
     let session = match session.as_ref() {
         Some(s) => s,
-        None => return tool_error("No active notebook session. Call join_notebook or open_notebook first."),
+        None => {
+            return tool_error(
+                "No active notebook session. Call join_notebook or open_notebook first.",
+            )
+        }
     };
 
     let handle = &session.handle;

--- a/crates/runt-mcp/src/tools/kernel.rs
+++ b/crates/runt-mcp/src/tools/kernel.rs
@@ -1,0 +1,125 @@
+//! Kernel management tools: interrupt_kernel, restart_kernel.
+
+use rmcp::model::{CallToolRequestParams, CallToolResult};
+use rmcp::ErrorData as McpError;
+
+use notebook_protocol::protocol::{NotebookRequest, NotebookResponse};
+
+use crate::NteractMcp;
+
+use super::{tool_error, tool_success};
+
+/// Interrupt the currently executing cell.
+pub async fn interrupt_kernel(
+    server: &NteractMcp,
+    _request: &CallToolRequestParams,
+) -> Result<CallToolResult, McpError> {
+    let session = server.session.read().await;
+    let session = match session.as_ref() {
+        Some(s) => s,
+        None => return tool_error("No active notebook session. Call join_notebook or open_notebook first."),
+    };
+
+    match session
+        .handle
+        .send_request(NotebookRequest::InterruptExecution {})
+        .await
+    {
+        Ok(_) => {
+            let result = serde_json::json!({ "interrupted": true });
+            tool_success(&serde_json::to_string_pretty(&result).unwrap_or_default())
+        }
+        Err(e) => tool_error(&format!("Failed to interrupt kernel: {e}")),
+    }
+}
+
+/// Restart the kernel, clearing all state.
+pub async fn restart_kernel(
+    server: &NteractMcp,
+    _request: &CallToolRequestParams,
+) -> Result<CallToolResult, McpError> {
+    let session = server.session.read().await;
+    let session = match session.as_ref() {
+        Some(s) => s,
+        None => return tool_error("No active notebook session. Call join_notebook or open_notebook first."),
+    };
+
+    let handle = &session.handle;
+
+    // Step 1: Shutdown existing kernel
+    match handle
+        .send_request(NotebookRequest::ShutdownKernel {})
+        .await
+    {
+        Ok(_) | Err(_) => {
+            // Even if shutdown fails (no kernel), proceed to launch
+        }
+    }
+
+    // Brief pause for shutdown to complete
+    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
+    // Step 2: Read kernel type from RuntimeState or default to python
+    let kernel_type = handle
+        .get_runtime_state()
+        .ok()
+        .and_then(|s| {
+            let name = s.kernel.name;
+            if name.is_empty() { None } else { Some(name) }
+        })
+        .unwrap_or_else(|| "python".to_string());
+
+    // Step 3: Launch kernel
+    let env_source = if kernel_type == "deno" {
+        "deno".to_string()
+    } else {
+        "uv:inline".to_string()
+    };
+
+    let notebook_path = if session.notebook_id.contains('/') || session.notebook_id.contains('\\') {
+        Some(session.notebook_id.clone())
+    } else {
+        None
+    };
+
+    match handle
+        .send_request(NotebookRequest::LaunchKernel {
+            kernel_type: kernel_type.clone(),
+            env_source: env_source.clone(),
+            notebook_path,
+        })
+        .await
+    {
+        Ok(NotebookResponse::KernelLaunched { .. })
+        | Ok(NotebookResponse::KernelAlreadyRunning { .. }) => {
+            // Poll RuntimeState for kernel to become ready
+            let start = std::time::Instant::now();
+            let timeout = std::time::Duration::from_secs(120);
+            loop {
+                if start.elapsed() >= timeout {
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+                if let Ok(state) = handle.get_runtime_state() {
+                    if state.kernel.status == "idle" || state.kernel.status == "busy" {
+                        break;
+                    }
+                    if state.kernel.status == "error" {
+                        return tool_error("Kernel failed to start");
+                    }
+                }
+            }
+
+            let result = serde_json::json!({
+                "restarted": true,
+                "env_source": env_source,
+            });
+            tool_success(&serde_json::to_string_pretty(&result).unwrap_or_default())
+        }
+        Ok(NotebookResponse::Error { error }) => {
+            tool_error(&format!("Failed to restart kernel: {error}"))
+        }
+        Ok(_) => tool_success(&serde_json::json!({ "restarted": true }).to_string()),
+        Err(e) => tool_error(&format!("Failed to restart kernel: {e}")),
+    }
+}

--- a/crates/runt-mcp/src/tools/kernel.rs
+++ b/crates/runt-mcp/src/tools/kernel.rs
@@ -17,7 +17,11 @@ pub async fn interrupt_kernel(
     let session = server.session.read().await;
     let session = match session.as_ref() {
         Some(s) => s,
-        None => return tool_error("No active notebook session. Call join_notebook or open_notebook first."),
+        None => {
+            return tool_error(
+                "No active notebook session. Call join_notebook or open_notebook first.",
+            )
+        }
     };
 
     match session
@@ -41,7 +45,11 @@ pub async fn restart_kernel(
     let session = server.session.read().await;
     let session = match session.as_ref() {
         Some(s) => s,
-        None => return tool_error("No active notebook session. Call join_notebook or open_notebook first."),
+        None => {
+            return tool_error(
+                "No active notebook session. Call join_notebook or open_notebook first.",
+            )
+        }
     };
 
     let handle = &session.handle;
@@ -59,22 +67,41 @@ pub async fn restart_kernel(
     // Brief pause for shutdown to complete
     tokio::time::sleep(std::time::Duration::from_millis(500)).await;
 
-    // Step 2: Read kernel type from RuntimeState or default to python
-    let kernel_type = handle
-        .get_runtime_state()
-        .ok()
-        .and_then(|s| {
-            let name = s.kernel.name;
-            if name.is_empty() { None } else { Some(name) }
-        })
-        .unwrap_or_else(|| "python".to_string());
+    // Step 2: Read kernel type and env_source from RuntimeState before launching
+    let (kernel_type, env_source) = {
+        let state = handle.get_runtime_state().ok();
+        let kernel_type = state
+            .as_ref()
+            .and_then(|s| {
+                let name = &s.kernel.name;
+                if name.is_empty() {
+                    None
+                } else {
+                    Some(name.clone())
+                }
+            })
+            .unwrap_or_else(|| "python".to_string());
+        let env_source = state
+            .as_ref()
+            .and_then(|s| {
+                let src = &s.kernel.env_source;
+                if src.is_empty() {
+                    None
+                } else {
+                    Some(src.clone())
+                }
+            })
+            .unwrap_or_else(|| {
+                if kernel_type == "deno" {
+                    "deno".to_string()
+                } else {
+                    "uv:inline".to_string()
+                }
+            });
+        (kernel_type, env_source)
+    };
 
     // Step 3: Launch kernel
-    let env_source = if kernel_type == "deno" {
-        "deno".to_string()
-    } else {
-        "uv:inline".to_string()
-    };
 
     let notebook_path = if session.notebook_id.contains('/') || session.notebook_id.contains('\\') {
         Some(session.notebook_id.clone())

--- a/crates/runt-mcp/src/tools/mod.rs
+++ b/crates/runt-mcp/src/tools/mod.rs
@@ -9,6 +9,13 @@ use serde::Deserialize;
 
 use crate::NteractMcp;
 
+mod cell_crud;
+mod cell_meta;
+mod cell_read;
+mod deps;
+mod editing;
+mod execution;
+mod kernel;
 mod session;
 
 /// Helper to generate a tool's input schema from a type.
@@ -45,6 +52,151 @@ pub fn all_tools() -> Vec<Tool> {
             schema_for::<session::OpenNotebookParams>(),
         )
         .annotate(ToolAnnotations::new().destructive(false)),
+        Tool::new(
+            "create_notebook",
+            "Create a new notebook with optional pre-installed dependencies. The kernel starts automatically. Call save_notebook(path) to persist to disk.",
+            schema_for::<session::CreateNotebookParams>(),
+        )
+        .annotate(ToolAnnotations::new().destructive(false)),
+        Tool::new(
+            "save_notebook",
+            "Save notebook to disk. The daemon automatically re-keys ephemeral rooms to the saved file path.",
+            schema_for::<session::SaveNotebookParams>(),
+        )
+        .annotate(ToolAnnotations::new().destructive(false)),
+        // -- Cell read --
+        Tool::new(
+            "get_cell",
+            "Get a cell's source and outputs by ID.",
+            schema_for::<cell_read::GetCellParams>(),
+        )
+        .annotate(ToolAnnotations::new().read_only(true)),
+        Tool::new(
+            "get_all_cells",
+            "Get all cells. Use summary (default) for discovery, get_cell() for details. Formats: 'summary', 'json', 'rich'.",
+            schema_for::<cell_read::GetAllCellsParams>(),
+        )
+        .annotate(ToolAnnotations::new().read_only(true)),
+        // -- Cell CRUD --
+        Tool::new(
+            "create_cell",
+            "Create a cell, optionally executing it.",
+            schema_for::<cell_crud::CreateCellParams>(),
+        )
+        .annotate(ToolAnnotations::new().destructive(false)),
+        Tool::new(
+            "set_cell",
+            "Update a cell's source and/or type. Use replace_match for targeted edits.",
+            schema_for::<cell_crud::SetCellParams>(),
+        )
+        .annotate(ToolAnnotations::new().destructive(true)),
+        Tool::new(
+            "delete_cell",
+            "Delete a cell by ID.",
+            schema_for::<cell_crud::DeleteCellParams>(),
+        )
+        .annotate(ToolAnnotations::new().destructive(true)),
+        Tool::new(
+            "move_cell",
+            "Move a cell to a new position.",
+            schema_for::<cell_crud::MoveCellParams>(),
+        )
+        .annotate(ToolAnnotations::new().destructive(true)),
+        Tool::new(
+            "clear_outputs",
+            "Clear a cell's outputs.",
+            schema_for::<cell_crud::ClearOutputsParams>(),
+        )
+        .annotate(ToolAnnotations::new().destructive(true)),
+        // -- Cell metadata --
+        Tool::new(
+            "add_cell_tags",
+            "Add tags to a cell's metadata. Existing tags are preserved.",
+            schema_for::<cell_meta::AddCellTagsParams>(),
+        )
+        .annotate(ToolAnnotations::new().destructive(true)),
+        Tool::new(
+            "remove_cell_tags",
+            "Remove tags from a cell's metadata.",
+            schema_for::<cell_meta::RemoveCellTagsParams>(),
+        )
+        .annotate(ToolAnnotations::new().destructive(true)),
+        Tool::new(
+            "set_cells_source_hidden",
+            "Hide or show the source (code input) of one or more cells.",
+            schema_for::<cell_meta::SetCellsSourceHiddenParams>(),
+        )
+        .annotate(ToolAnnotations::new().destructive(true)),
+        Tool::new(
+            "set_cells_outputs_hidden",
+            "Hide or show the outputs of one or more cells.",
+            schema_for::<cell_meta::SetCellsOutputsHiddenParams>(),
+        )
+        .annotate(ToolAnnotations::new().destructive(true)),
+        // -- Execution --
+        Tool::new(
+            "execute_cell",
+            "Execute a cell. Returns partial results if timeout exceeded.",
+            schema_for::<execution::ExecuteCellParams>(),
+        )
+        .annotate(ToolAnnotations::new().destructive(true)),
+        Tool::new(
+            "run_all_cells",
+            "Queue all code cells for execution. Use get_all_cells() to see results.",
+            schema_for::<EmptyParams>(),
+        )
+        .annotate(ToolAnnotations::new().destructive(true)),
+        // -- Kernel --
+        Tool::new(
+            "interrupt_kernel",
+            "Interrupt the currently executing cell.",
+            schema_for::<EmptyParams>(),
+        )
+        .annotate(ToolAnnotations::new().destructive(true)),
+        Tool::new(
+            "restart_kernel",
+            "Restart kernel, clearing all state. Use after dependency changes.",
+            schema_for::<EmptyParams>(),
+        )
+        .annotate(ToolAnnotations::new().destructive(true)),
+        // -- Dependencies --
+        Tool::new(
+            "add_dependency",
+            "Add a package dependency (e.g. 'pandas>=2.0'). Call sync_environment() to install.",
+            schema_for::<deps::AddDependencyParams>(),
+        )
+        .annotate(ToolAnnotations::new().destructive(true)),
+        Tool::new(
+            "remove_dependency",
+            "Remove a package dependency. Requires restart_kernel() to take effect.",
+            schema_for::<deps::RemoveDependencyParams>(),
+        )
+        .annotate(ToolAnnotations::new().destructive(true)),
+        Tool::new(
+            "get_dependencies",
+            "Get the notebook's current package dependencies.",
+            schema_for::<deps::GetDependenciesParams>(),
+        )
+        .annotate(ToolAnnotations::new().read_only(true)),
+        Tool::new(
+            "sync_environment",
+            "Hot-install new dependencies without restarting. Use restart_kernel() if this fails.",
+            schema_for::<EmptyParams>(),
+        )
+        .annotate(ToolAnnotations::new().destructive(true)),
+        // -- Editing --
+        Tool::new(
+            "replace_match",
+            "Replace matched text in a cell. Prefer this for simple, targeted edits. Use context_before/context_after to disambiguate when match appears multiple times.",
+            schema_for::<editing::ReplaceMatchParams>(),
+        )
+        .annotate(ToolAnnotations::new().destructive(true)),
+        Tool::new(
+            "replace_regex",
+            "Replace a regex-matched span. Use for anchors, lookarounds, or zero-width insertions. Fails if 0 or >1 matches.",
+            schema_for::<editing::ReplaceRegexParams>(),
+        )
+        .annotate(ToolAnnotations::new().destructive(true)),
     ]
 }
 
@@ -54,9 +206,40 @@ pub async fn dispatch(
     request: &CallToolRequestParams,
 ) -> Result<CallToolResult, McpError> {
     match request.name.as_ref() {
+        // Session
         "list_active_notebooks" => session::list_active_notebooks(server).await,
         "join_notebook" => session::join_notebook(server, request).await,
         "open_notebook" => session::open_notebook(server, request).await,
+        "create_notebook" => session::create_notebook(server, request).await,
+        "save_notebook" => session::save_notebook(server, request).await,
+        // Cell read
+        "get_cell" => cell_read::get_cell(server, request).await,
+        "get_all_cells" => cell_read::get_all_cells(server, request).await,
+        // Cell CRUD
+        "create_cell" => cell_crud::create_cell(server, request).await,
+        "set_cell" => cell_crud::set_cell(server, request).await,
+        "delete_cell" => cell_crud::delete_cell(server, request).await,
+        "move_cell" => cell_crud::move_cell(server, request).await,
+        "clear_outputs" => cell_crud::clear_outputs(server, request).await,
+        // Cell metadata
+        "add_cell_tags" => cell_meta::add_cell_tags(server, request).await,
+        "remove_cell_tags" => cell_meta::remove_cell_tags(server, request).await,
+        "set_cells_source_hidden" => cell_meta::set_cells_source_hidden(server, request).await,
+        "set_cells_outputs_hidden" => cell_meta::set_cells_outputs_hidden(server, request).await,
+        // Execution
+        "execute_cell" => execution::execute_cell(server, request).await,
+        "run_all_cells" => execution::run_all_cells(server, request).await,
+        // Kernel
+        "interrupt_kernel" => kernel::interrupt_kernel(server, request).await,
+        "restart_kernel" => kernel::restart_kernel(server, request).await,
+        // Dependencies
+        "add_dependency" => deps::add_dependency(server, request).await,
+        "remove_dependency" => deps::remove_dependency(server, request).await,
+        "get_dependencies" => deps::get_dependencies(server, request).await,
+        "sync_environment" => deps::sync_environment(server, request).await,
+        // Editing
+        "replace_match" => editing::replace_match(server, request).await,
+        "replace_regex" => editing::replace_regex(server, request).await,
         _ => Err(McpError::invalid_params(
             format!("Unknown tool: {}", request.name),
             None,

--- a/crates/runt-mcp/src/tools/session.rs
+++ b/crates/runt-mcp/src/tools/session.rs
@@ -12,6 +12,8 @@ use runtimed_client::client::PoolClient;
 use crate::session::NotebookSession;
 use crate::NteractMcp;
 
+use notebook_protocol::protocol::{NotebookRequest, NotebookResponse};
+
 use super::{arg_str, tool_error, tool_success};
 
 #[allow(dead_code)] // Fields used by schemars for tool input schema generation
@@ -26,6 +28,28 @@ pub struct JoinNotebookParams {
 pub struct OpenNotebookParams {
     /// Path to the notebook file on disk.
     pub path: String,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct CreateNotebookParams {
+    /// Runtime type: "python" or "deno".
+    #[serde(default)]
+    pub runtime: Option<String>,
+    /// Working directory for the kernel.
+    #[serde(default)]
+    pub working_dir: Option<String>,
+    /// Python packages to pre-install.
+    #[serde(default)]
+    pub dependencies: Option<Vec<String>>,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SaveNotebookParams {
+    /// Path to save the notebook to. If None, saves to original location.
+    #[serde(default)]
+    pub path: Option<String>,
 }
 
 /// List all active notebook sessions.
@@ -132,5 +156,150 @@ pub async fn open_notebook(
             )]))
         }
         Err(e) => tool_error(&format!("Failed to open notebook '{}': {}", path, e)),
+    }
+}
+
+/// Create a new notebook with optional dependencies.
+pub async fn create_notebook(
+    server: &NteractMcp,
+    request: &CallToolRequestParams,
+) -> Result<CallToolResult, McpError> {
+    let runtime = arg_str(request, "runtime").unwrap_or("python");
+    let working_dir = arg_str(request, "working_dir").map(std::path::PathBuf::from);
+
+    match notebook_sync::connect::connect_create(
+        server.socket_path.clone(),
+        runtime,
+        working_dir,
+        "runt-mcp",
+    )
+    .await
+    {
+        Ok(result) => {
+            let notebook_id = result.handle.notebook_id().to_string();
+            // Add dependencies if specified
+            let deps: Vec<String> = request
+                .arguments
+                .as_ref()
+                .and_then(|a| a.get("dependencies"))
+                .and_then(|v| serde_json::from_value::<Vec<String>>(v.clone()).ok())
+                .unwrap_or_default();
+
+            if runtime == "python" {
+                for dep in &deps {
+                    let _ = result.handle.add_uv_dependency(dep);
+                }
+            }
+
+            let session = NotebookSession {
+                handle: result.handle,
+                notebook_id: notebook_id.clone(),
+            };
+            *server.session.write().await = Some(session);
+
+            // If dependencies were added, restart kernel to pick them up
+            if !deps.is_empty() && runtime == "python" {
+                let session = server.session.read().await;
+                if let Some(s) = session.as_ref() {
+                    // Shutdown and relaunch
+                    let _ = s
+                        .handle
+                        .send_request(NotebookRequest::ShutdownKernel {})
+                        .await;
+                    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+                    let _ = s
+                        .handle
+                        .send_request(NotebookRequest::LaunchKernel {
+                            kernel_type: runtime.to_string(),
+                            env_source: "uv:inline".to_string(),
+                            notebook_path: None,
+                        })
+                        .await;
+                }
+            }
+
+            let info = serde_json::json!({
+                "notebook_id": notebook_id,
+                "runtime": { "language": runtime },
+                "dependencies": deps,
+            });
+
+            Ok(CallToolResult::success(vec![Content::text(
+                serde_json::to_string_pretty(&info).unwrap_or_default(),
+            )]))
+        }
+        Err(e) => tool_error(&format!("Failed to create notebook: {}", e)),
+    }
+}
+
+/// Save notebook to disk.
+pub async fn save_notebook(
+    server: &NteractMcp,
+    request: &CallToolRequestParams,
+) -> Result<CallToolResult, McpError> {
+    let path = arg_str(request, "path").map(|s| s.to_string());
+
+    // Clone the handle and notebook_id so we can drop the read guard
+    let (handle, notebook_id) = {
+        let session = server.session.read().await;
+        match session.as_ref() {
+            Some(s) => (s.handle.clone(), s.notebook_id.clone()),
+            None => {
+                return tool_error(
+                    "No active notebook session. Call join_notebook or open_notebook first.",
+                )
+            }
+        }
+    };
+
+    // Ensure daemon has latest
+    if let Err(e) = handle.confirm_sync().await {
+        tracing::warn!("confirm_sync failed before save: {e}");
+    }
+
+    match handle
+        .send_request(NotebookRequest::SaveNotebook {
+            format_cells: false,
+            path: path.clone(),
+        })
+        .await
+    {
+        Ok(NotebookResponse::NotebookSaved {
+            path: saved_path,
+            new_notebook_id,
+        }) => {
+            let mut result = serde_json::json!({
+                "path": saved_path,
+                "notebook_id": new_notebook_id.as_deref().unwrap_or(&notebook_id),
+            });
+
+            // If room was re-keyed, update our session
+            if let Some(new_id) = &new_notebook_id {
+                let mut write = server.session.write().await;
+                if let Some(ref mut s) = *write {
+                    let old_id = s.notebook_id.clone();
+                    s.notebook_id = new_id.clone();
+                    result["previous_notebook_id"] = serde_json::json!(old_id);
+                }
+            }
+
+            Ok(CallToolResult::success(vec![Content::text(
+                serde_json::to_string_pretty(&result).unwrap_or_default(),
+            )]))
+        }
+        Ok(NotebookResponse::Error { error }) => {
+            if path.is_none()
+                && (error.contains("Read-only") || error.contains("Failed to write"))
+            {
+                tool_error(
+                    "No path specified. For notebooks created with create_notebook(), \
+                     you must provide a path (e.g., save_notebook(path='/path/to/file.ipynb'))",
+                )
+            } else {
+                tool_error(&format!("Failed to save notebook: {error}"))
+            }
+        }
+        Ok(resp) => tool_error(&format!("Unexpected response: {resp:?}")),
+        Err(e) => tool_error(&format!("Failed to save notebook: {e}")),
     }
 }

--- a/crates/runt-mcp/src/tools/session.rs
+++ b/crates/runt-mcp/src/tools/session.rs
@@ -288,8 +288,7 @@ pub async fn save_notebook(
             )]))
         }
         Ok(NotebookResponse::Error { error }) => {
-            if path.is_none()
-                && (error.contains("Read-only") || error.contains("Failed to write"))
+            if path.is_none() && (error.contains("Read-only") || error.contains("Failed to write"))
             {
                 tool_error(
                     "No path specified. For notebooks created with create_notebook(), \


### PR DESCRIPTION
## Summary

Completes the Rust-native MCP server with all 26 tools, achieving full parity with the Python `uv run nteract` server. No Python overhead, direct Automerge access, pure tokio async.

### Tools implemented (26 total)

| Category | Tools | Count |
|----------|-------|-------|
| Session | list_active_notebooks, join_notebook, open_notebook, create_notebook, save_notebook | 5 |
| Cell CRUD | create_cell, set_cell, delete_cell, move_cell, clear_outputs | 5 |
| Cell Read | get_cell, get_all_cells | 2 |
| Cell Metadata | add_cell_tags, remove_cell_tags, set_cells_source_hidden, set_cells_outputs_hidden | 4 |
| Execution | execute_cell, run_all_cells | 2 |
| Kernel | interrupt_kernel, restart_kernel | 2 |
| Dependencies | add_dependency, remove_dependency, get_dependencies, sync_environment | 4 |
| Editing | replace_match, replace_regex | 2 |

### Architecture

- **Foundation modules**: formatting.rs (ANSI stripping, MIME priority), execution.rs (poll RuntimeStateDoc), editing.rs (pattern resolution)
- **Direct DocHandle access**: Cell mutations are microsecond-scale (no channel/IPC overhead)
- **Daemon IPC via send_request()**: Kernel ops, saves, environment sync
- **confirm_sync()**: Called before execution to ensure daemon has latest source
- **Structured content**: execute_cell returns MCP Apps widget data (blob URLs for images)

### Testing

Enable with `NTERACT_RUST_MCP=1` env var in the supervisor. Default remains Python server.

## Test plan

- [x] `cargo build -p runt-mcp -p runt-cli` — clean
- [x] `cargo clippy -p runt-mcp -- -D warnings` — clean
- [x] list_active_notebooks, join_notebook, open_notebook
- [x] create_notebook, save_notebook (with room re-keying)
- [x] create_cell (markdown + code, with and_run)
- [x] set_cell, delete_cell, move_cell
- [x] get_cell (full content + resolved outputs)
- [x] get_all_cells (summary format)
- [x] add_cell_tags
- [x] replace_match (with and_run)
- [x] replace_regex (with diff output)
- [x] execute_cell (stream, image, error outputs + structured content)
- [x] run_all_cells
- [x] interrupt_kernel, restart_kernel
- [x] add_dependency, get_dependencies
- [x] Live multi-peer editing (agent + human watching in app)

### Known gaps (follow-up)

- Presence (cursor/focus tracking) — `send_presence()` API exists, not yet wired
- `show_notebook` — GUI-only, excluded from Rust server