### PR TITLE
fix(sync): prevent execute race with in-flight debounced flush

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -622,7 +622,14 @@ function AppContent() {
           }
         }
       } finally {
-        executingCellsRef.current.delete(cellId);
+        // Hold the guard briefly to prevent rapid re-queueing.
+        // The daemon returns CellQueued immediately (~30ms), but
+        // the cell may still be executing. A 1s hold prevents
+        // accidental double-execution from rapid keypresses while
+        // still allowing intentional re-runs.
+        setTimeout(() => {
+          executingCellsRef.current.delete(cellId);
+        }, 1000);
       }
     },
     [flushSync, kernelStatus, tryStartKernel, executeCell],

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -184,6 +184,9 @@ function AppContent() {
   // Guard against concurrent Run All / Restart & Run All operations (#982)
   const runAllInFlightRef = useRef(false);
 
+  // Guard against duplicate per-cell execute requests (rapid Shift+Enter)
+  const executingCellsRef = useRef(new Set<string>());
+
   // Notebook runtime type — reactive read from WASM Automerge doc.
   // Re-renders automatically when metadata changes (bootstrap, sync, writes).
   const detectedRuntime = useDetectRuntime();
@@ -573,25 +576,53 @@ function AppContent() {
       const cell = getNotebookCellsSnapshot().find((c) => c.id === cellId);
       if (!cell || cell.cell_type !== "code") return;
 
-      // Flush pending source sync so daemon has latest code before executing
-      await flushSync();
-
-      // No explicit ClearOutputs IPC needed — the daemon clears outputs
-      // on execute_input and the SyncEngine injects a clear changeset
-      // when the RuntimeStateDoc reports execution started.
-
-      // Start kernel via daemon if not running, then queue cell.
-      if (kernelStatus === KERNEL_STATUS.NOT_STARTED) {
-        const started = await tryStartKernel();
-        // Only block execution when trust approval is pending.
-        // For startup races (e.g. daemon already auto-starting), still try execute.
-        if (!started && pendingKernelStartRef.current) return;
+      // Dedup guard: skip if this cell already has an execute in flight.
+      if (executingCellsRef.current.has(cellId)) {
+        logger.debug("[App] handleExecuteCell: already in flight for", cellId);
+        return;
       }
-      const response = await executeCell(cellId);
-      if (response.result === "error") {
-        logger.error("[App] handleExecuteCell: daemon error", response.error);
-      } else if (response.result === "no_kernel") {
-        logger.warn("[App] handleExecuteCell: no kernel available");
+      executingCellsRef.current.add(cellId);
+
+      try {
+        // Flush pending source sync so daemon has latest code before executing.
+        // flushAndWait() guarantees any in-flight debounced flush has landed,
+        // then sends remaining changes and awaits delivery.
+        await flushSync();
+
+        // No explicit ClearOutputs IPC needed — the daemon clears outputs
+        // on execute_input and the SyncEngine injects a clear changeset
+        // when the RuntimeStateDoc reports execution started.
+
+        // Start kernel via daemon if not running, then queue cell.
+        if (kernelStatus === KERNEL_STATUS.NOT_STARTED) {
+          const started = await tryStartKernel();
+          // Only block execution when trust approval is pending.
+          // For startup races (e.g. daemon already auto-starting), still try execute.
+          if (!started && pendingKernelStartRef.current) return;
+        }
+        const response = await executeCell(cellId);
+        if (response.result === "error") {
+          logger.error("[App] handleExecuteCell: daemon error", response.error);
+        } else if (response.result === "no_kernel") {
+          // Kernel died — try to restart and retry once.
+          logger.warn("[App] handleExecuteCell: no kernel, attempting restart");
+          const restarted = await tryStartKernel();
+          if (restarted) {
+            const retry = await executeCell(cellId);
+            if (retry.result === "error") {
+              logger.error(
+                "[App] handleExecuteCell: daemon error after restart",
+                retry.error,
+              );
+            } else if (retry.result === "no_kernel") {
+              logger.error(
+                "[App] handleExecuteCell: still no kernel after restart",
+              );
+            }
+          }
+        }
+      } finally {
+        executingCellsRef.current.delete(cellId);
       }
     },
     [flushSync, kernelStatus, tryStartKernel, executeCell],

--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -1,7 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { SyncableHandle } from "runtimed";
-import { FrameType, SyncEngine } from "runtimed";
+import { SyncEngine } from "runtimed";
 import { concatMap, from, switchMap } from "rxjs";
 import { getBlobPort, refreshBlobPort } from "../lib/blob-port";
 import { materializeChangeset } from "../lib/frame-pipeline";
@@ -446,25 +446,21 @@ export function useAutomergeNotebook() {
 
   // ── Sync flush ────��────────────────────────────────────────────────
 
-  /** Flush pending debounced sync immediately (call before execute/save). */
+  /**
+   * Flush pending sync immediately (call before execute/save).
+   *
+   * Delegates to the SyncEngine's `flushAndWait()` which:
+   * 1. Awaits any in-flight debounced flush (prevents race where the debounce
+   *    timer claims changes but its IPC hasn't completed yet).
+   * 2. Flushes remaining local changes and awaits delivery.
+   */
   const flushSync = useCallback(async () => {
-    const handle = handleRef.current;
-    const transport = transportRef.current;
-    if (!handle || !transport) {
-      logger.debug("[flushSync] skipped: no handle/transport");
+    const engine = engineRef.current;
+    if (!engine) {
+      logger.debug("[flushSync] skipped: no engine");
       return;
     }
-
-    const msg = handle.flush_local_changes();
-    if (msg) {
-      logger.debug(`[flushSync] sending ${msg.byteLength}B sync message`);
-      try {
-        await transport.sendFrame(FrameType.AUTOMERGE_SYNC, msg);
-      } catch (e) {
-        handle.cancel_last_flush();
-        logger.warn("[flushSync] failed, rolled back sync state", e);
-      }
-    }
+    await engine.flushAndWait();
   }, []);
 
   // ── File operations ────────────────────────────────────────────────

--- a/packages/runtimed/src/sync-engine.ts
+++ b/packages/runtimed/src/sync-engine.ts
@@ -103,6 +103,9 @@ export class SyncEngine {
   private readonly frameIn$ = new Subject<number[]>();
   private readonly flushRequest$ = new Subject<void>();
 
+  /** Promise for the most recent fire-and-forget flush (debounced path). */
+  private inflightFlush: Promise<void> | null = null;
+
   // ── Public observables ───────────────────────────────────────────
 
   /**
@@ -581,7 +584,7 @@ export class SyncEngine {
       this.opts.logger.debug(
         `[sync-engine] flushing sync message (${msg.byteLength}B)`,
       );
-      this.opts.transport
+      const done = this.opts.transport
         .sendFrame(FrameType.AUTOMERGE_SYNC, msg)
         .catch((e: unknown) => {
           handle.cancel_last_flush();
@@ -590,6 +593,8 @@ export class SyncEngine {
             e,
           );
         });
+      // Track the in-flight flush so flushAndWait() can await it.
+      this.inflightFlush = done;
     }
 
     // Also flush RuntimeStateDoc sync so the daemon sends kernel status,
@@ -607,6 +612,52 @@ export class SyncEngine {
             e,
           );
         });
+    }
+  }
+
+  /**
+   * Flush local changes and wait for delivery.
+   *
+   * Unlike `flush()` (fire-and-forget), this method:
+   * 1. Awaits any in-flight debounced flush that may have already claimed
+   *    changes from `flush_local_changes()`.
+   * 2. Flushes any remaining local changes and awaits delivery.
+   *
+   * Use before execute/save to guarantee the daemon has the latest source.
+   */
+  async flushAndWait(): Promise<void> {
+    // Wait for any in-flight debounced flush to land first.
+    if (this.inflightFlush) {
+      await this.inflightFlush;
+      this.inflightFlush = null;
+    }
+
+    const handle = this.opts.getHandle();
+    if (!handle) return;
+
+    // Flush any remaining notebook doc changes (may be none if debounce got them).
+    const msg = handle.flush_local_changes();
+    if (msg) {
+      this.opts.logger.debug(
+        `[sync-engine] flushAndWait: sending ${msg.byteLength}B sync message`,
+      );
+      try {
+        await this.opts.transport.sendFrame(FrameType.AUTOMERGE_SYNC, msg);
+      } catch (e) {
+        handle.cancel_last_flush();
+        this.opts.logger.warn("[sync-engine] flushAndWait: sync to relay failed:", e);
+      }
+    }
+
+    // Also flush RuntimeStateDoc sync.
+    const stateMsg = handle.flush_runtime_state_sync();
+    if (stateMsg) {
+      try {
+        await this.opts.transport.sendFrame(FrameType.RUNTIME_STATE_SYNC, stateMsg);
+      } catch (e) {
+        handle.cancel_last_runtime_state_flush();
+        this.opts.logger.warn("[sync-engine] flushAndWait: runtime state sync failed:", e);
+      }
     }
   }
 

--- a/packages/runtimed/src/sync-engine.ts
+++ b/packages/runtimed/src/sync-engine.ts
@@ -626,10 +626,16 @@ export class SyncEngine {
    * Use before execute/save to guarantee the daemon has the latest source.
    */
   async flushAndWait(): Promise<void> {
-    // Wait for any in-flight debounced flush to land first.
-    if (this.inflightFlush) {
-      await this.inflightFlush;
-      this.inflightFlush = null;
+    // Drain all in-flight debounced flushes. A new debounced flush can
+    // start while we're awaiting the current one (the 20ms timer fires
+    // independently), so loop until stable.
+    while (this.inflightFlush) {
+      const current = this.inflightFlush;
+      await current;
+      // Only clear if no newer flush replaced it while we awaited.
+      if (this.inflightFlush === current) {
+        this.inflightFlush = null;
+      }
     }
 
     const handle = this.opts.getHandle();


### PR DESCRIPTION
## Summary

When typing quickly and pressing Shift+Enter, the daemon could execute stale cell source (e.g. `pri` instead of `print('hey')`). The root cause: `SyncEngine.flush()` (called by the 20ms debounce timer) is fire-and-forget — if the debounce claimed changes from `flush_local_changes()` but its IPC hadn't landed yet, `flushSync()` would return with nothing to send, letting `executeCell()` race past the still-in-flight sync frame.

## Changes

- **`packages/runtimed/src/sync-engine.ts`**: Track the in-flight debounced flush promise. Add `flushAndWait()` that awaits it before flushing remaining changes with an awaited send.
- **`apps/notebook/src/hooks/useAutomergeNotebook.ts`**: `flushSync()` now delegates to `engine.flushAndWait()` instead of independently calling `flush_local_changes()` (which could race with the debounce timer).
- **`apps/notebook/src/App.tsx`**: Add per-cell `executingCellsRef` dedup guard to prevent rapid Shift+Enter from flooding the daemon with duplicate ExecuteCell requests. Auto-restart kernel and retry once when `executeCell` returns `no_kernel`.

## Verification

- [ ] Create a new Untitled notebook, type `print("hello")` and immediately press Shift+Enter — verify the full source executes (not a partial string like `pri`)
- [ ] Rapidly press Shift+Enter multiple times on the same cell — verify only one execution fires, no kernel crash
- [ ] Shut down the kernel manually, then press Shift+Enter — verify the kernel auto-restarts and the cell executes
- [ ] Verify `Restart and Run All` still works correctly
- [ ] Verify save (Cmd+S) still works

_PR submitted by @rgbkrk's agent, Quill_