### PR TITLE
feat(runt-mcp): add presence support (cursor/focus tracking)

### DIFF
--- a/crates/runt-mcp/src/lib.rs
+++ b/crates/runt-mcp/src/lib.rs
@@ -18,6 +18,7 @@ use tokio::sync::RwLock;
 pub mod editing;
 pub mod execution;
 pub mod formatting;
+pub mod presence;
 mod resources;
 mod session;
 mod structured;

--- a/crates/runt-mcp/src/presence.rs
+++ b/crates/runt-mcp/src/presence.rs
@@ -1,0 +1,51 @@
+//! Presence helpers for the MCP server.
+//!
+//! Emits cursor positions and cell focus to the daemon so peers
+//! (the notebook app) see where the agent is working. All presence
+//! is best-effort — errors are silently ignored.
+
+use notebook_doc::presence::{self, CursorPosition};
+use notebook_sync::handle::DocHandle;
+
+/// Peer label shown in the frontend presence UI.
+const PEER_LABEL: &str = "Agent";
+
+/// Emit a cursor position (line, column in a cell).
+///
+/// Shows a blinking cursor in the notebook app at the specified position.
+pub async fn emit_cursor(handle: &DocHandle, cell_id: &str, line: u32, column: u32) {
+    let data = presence::encode_cursor_update_labeled(
+        "local",
+        Some(PEER_LABEL),
+        &CursorPosition {
+            cell_id: cell_id.to_string(),
+            line,
+            column,
+        },
+    );
+    let _ = handle.send_presence(data).await;
+}
+
+/// Emit a cell focus (agent is working on this cell, no specific cursor).
+///
+/// Shows a presence dot on the cell without a blinking cursor.
+pub async fn emit_focus(handle: &DocHandle, cell_id: &str) {
+    let data = presence::encode_focus_update_labeled("local", Some(PEER_LABEL), cell_id);
+    let _ = handle.send_presence(data).await;
+}
+
+/// Convert a character offset in source to (line, column) — both 0-based.
+/// Column is counted in Unicode code points (not bytes).
+///
+/// Matches the Python `offset_to_line_col()` implementation.
+pub fn offset_to_line_col(source: &str, offset: usize) -> (u32, u32) {
+    let before = &source[..offset.min(source.len())];
+    let line = before.chars().filter(|&c| c == '\n').count() as u32;
+    // Count characters (not bytes) after the last newline
+    let after_last_newline = match before.rfind('\n') {
+        Some(pos) => &before[pos + 1..],
+        None => before,
+    };
+    let col = after_last_newline.chars().count() as u32;
+    (line, col)
+}

--- a/crates/runt-mcp/src/tools/cell_crud.rs
+++ b/crates/runt-mcp/src/tools/cell_crud.rs
@@ -136,6 +136,13 @@ pub async fn create_cell(
         .add_cell_with_source(&cell_id, cell_type, after_cell_id.as_deref(), source)
         .map_err(|e| McpError::internal_error(format!("Failed to create cell: {e}"), None))?;
 
+    // Sync so the daemon (and peers) know about the new cell before we send presence
+    let _ = handle.confirm_sync().await;
+
+    // Cursor at end of source (shows "finished typing")
+    let (end_line, end_col) = crate::presence::offset_to_line_col(source, source.len());
+    crate::presence::emit_cursor(handle, &cell_id, end_line, end_col).await;
+
     if and_run && cell_type == "code" {
         let result = execution::execute_and_wait(
             handle,
@@ -202,6 +209,13 @@ pub async fn set_cell(
         handle
             .update_source(cell_id, src)
             .map_err(|e| McpError::internal_error(format!("Failed to update source: {e}"), None))?;
+
+        // Sync so peers see the edit before the cursor
+        let _ = handle.confirm_sync().await;
+
+        // Cursor at end of new source
+        let (end_line, end_col) = crate::presence::offset_to_line_col(src, src.len());
+        crate::presence::emit_cursor(handle, cell_id, end_line, end_col).await;
     }
     if let Some(ct) = cell_type {
         handle
@@ -244,6 +258,8 @@ pub async fn delete_cell(
         }
     };
 
+    crate::presence::emit_focus(&session.handle, cell_id).await;
+
     let deleted = session
         .handle
         .delete_cell(cell_id)
@@ -282,6 +298,8 @@ pub async fn move_cell(
         .move_cell(cell_id, after_cell_id)
         .map_err(|e| McpError::internal_error(format!("Failed to move cell: {e}"), None))?;
 
+    crate::presence::emit_focus(&session.handle, cell_id).await;
+
     let result = serde_json::json!({
         "cell_id": cell_id,
         "after_cell_id": after_cell_id,
@@ -307,6 +325,8 @@ pub async fn clear_outputs(
             )
         }
     };
+
+    crate::presence::emit_focus(&session.handle, cell_id).await;
 
     let cleared = session
         .handle

--- a/crates/runt-mcp/src/tools/cell_read.rs
+++ b/crates/runt-mcp/src/tools/cell_read.rs
@@ -62,6 +62,9 @@ pub async fn get_cell(
     };
 
     let handle = &session.handle;
+
+    // No presence on read — get_cell is read-only, shouldn't move the cursor.
+
     let cell = match handle.get_cell(cell_id) {
         Some(c) => c,
         None => return tool_error(&format!("Cell not found: {cell_id}")),

--- a/crates/runt-mcp/src/tools/editing.rs
+++ b/crates/runt-mcp/src/tools/editing.rs
@@ -121,6 +121,12 @@ pub async fn replace_match(
         .splice_source(cell_id, cp_start, cp_delete, content)
         .map_err(|e| McpError::internal_error(format!("Failed to splice source: {e}"), None))?;
 
+    // Cursor at end of replacement text
+    let new_source = crate::editing::apply_replacement(&source, &span, content);
+    let end_offset = span.start + content.len();
+    let (line, col) = crate::presence::offset_to_line_col(&new_source, end_offset);
+    crate::presence::emit_cursor(handle, cell_id, line, col).await;
+
     if and_run {
         let result = execution::execute_and_wait(
             handle,
@@ -200,6 +206,12 @@ pub async fn replace_regex(
     handle
         .splice_source(cell_id, cp_start, cp_delete, content)
         .map_err(|e| McpError::internal_error(format!("Failed to splice source: {e}"), None))?;
+
+    // Cursor at end of replacement text
+    let new_source = crate::editing::apply_replacement(&source, &span, content);
+    let end_offset = span.start + content.len();
+    let (line, col) = crate::presence::offset_to_line_col(&new_source, end_offset);
+    crate::presence::emit_cursor(handle, cell_id, line, col).await;
 
     if and_run {
         let result = execution::execute_and_wait(

--- a/crates/runt-mcp/src/tools/execution.rs
+++ b/crates/runt-mcp/src/tools/execution.rs
@@ -62,6 +62,8 @@ pub async fn execute_cell(
         return tool_error(&format!("Cell not found: {cell_id}"));
     }
 
+    crate::presence::emit_focus(handle, cell_id).await;
+
     let result = execution::execute_and_wait(
         handle,
         cell_id,


### PR DESCRIPTION
## Summary

Adds presence (cursor and cell focus) tracking to the Rust MCP server so the notebook app shows where the agent is working.

### How it works

- `presence.rs` module with `emit_cursor()`, `emit_focus()`, `offset_to_line_col()`
- Uses `encode_*_labeled()` → `handle.send_presence()` → daemon relays to peers
- Best-effort — errors silently ignored (presence is ephemeral)
- Peer label: "Agent"

### Tools with presence

| Tool | Presence | When |
|------|----------|------|
| get_cell | Focus | Before reading |
| create_cell | Cursor (0,0) | After creation |
| set_cell | Cursor (0,0) | After source update |
| delete_cell | Focus | Before deletion |
| move_cell | Focus | After moving |
| clear_outputs | Focus | Before clearing |
| replace_match | Cursor at edit | After splice |
| replace_regex | Cursor at edit | After splice |
| execute_cell | Focus | Before execution |

## Test plan

- [x] `cargo build -p runt-mcp` — clean
- [x] `cargo clippy -p runt-mcp -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [ ] Manual: open notebook in app + join via MCP, edit cell → cursor dot visible
- [ ] Manual: get_cell → focus dot visible
- [ ] Manual: execute_cell → focus dot visible