### PR TITLE
docs: switch all devs to Rust MCP server (runt mcp) by default

### DIFF
--- a/.claude/rules/mcp-servers.md
+++ b/.claude/rules/mcp-servers.md
@@ -21,6 +21,14 @@ Three nteract MCP servers may be available. Always use the right one:
 3. If `nteract-dev` tools are not available, fall back to `cargo xtask` commands — not to the system MCP servers.
 4. The supervisor tools (`supervisor_status`, `supervisor_restart`, `supervisor_rebuild`, `supervisor_logs`, `supervisor_start_vite`, `supervisor_stop`) are part of the `nteract-dev` server. They manage the dev daemon and build pipeline — prefer them over manual terminal commands.
 
+## Rust vs Python MCP Server
+
+The supervisor can spawn either server behind `nteract-dev`:
+- **Default (Python):** `uv run nteract` — 27 tools including `show_notebook`
+- **Rust mode:** Set `NTERACT_RUST_MCP=1` in `.mcp.json` env — uses `runt mcp` (26 tools, no Python overhead)
+
+The Rust server (`runt-mcp`) uses direct Automerge access via `DocHandle` for microsecond-scale cell mutations and includes presence (cursor/focus tracking). For the installed app, `runt mcp` ships as a sidecar binary — no Python or uv required.
+
 ## System daemon CLI (`runt` / `runt-nightly`)
 
 When running CLI commands against system-installed daemons from a dev environment, **always use `env -i`** to strip dev env vars (`RUNTIMED_DEV`, `RUNTIMED_WORKSPACE_PATH`) that would otherwise redirect commands to the per-worktree dev daemon:

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -4,3 +4,4 @@ args = ["run", "-p", "mcp-supervisor"]
 
 [mcp_servers.nteract-dev.env]
 RUNTIMED_DEV = "1"
+NTERACT_RUST_MCP = "1"

--- a/.mcp.json
+++ b/.mcp.json
@@ -4,7 +4,8 @@
       "command": "cargo",
       "args": ["run", "-p", "mcp-supervisor"],
       "env": {
-        "RUNTIMED_DEV": "1"
+        "RUNTIMED_DEV": "1",
+        "NTERACT_RUST_MCP": "1"
       }
     }
   }

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -5,6 +5,7 @@
       "args": ["run", "-p", "mcp-supervisor"],
       "env": {
         "RUNTIMED_DEV": "1",
+        "NTERACT_RUST_MCP": "1",
       },
     },
   },

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,7 +217,20 @@ Use `nteract-dev` as the MCP server name for this source tree. Keep `nteract` fo
 
 For Codex app/CLI, this repository also includes a project-scoped MCP config in `.codex/config.toml` that points at the same `mcp-supervisor` server using the `nteract-dev` entry name.
 
-`uv run nteract --stable` and `uv run nteract --nightly` are channel overrides for direct MCP launches. They only seed `RUNTIMED_SOCKET_PATH` when it is unset, and they also control which app `show_notebook` opens. `--no-show` removes the `show_notebook` tool entirely.
+### Rust vs Python MCP Server
+
+The supervisor can spawn either the **Rust-native** (`runt mcp`) or **Python** (`uv run nteract`) MCP server:
+
+| Server | How to select | Tools | Notes |
+|--------|---------------|-------|-------|
+| Rust (`runt mcp`) | **Default** — `NTERACT_RUST_MCP=1` in `.mcp.json` | 26 tools | No Python overhead, direct Automerge access, ships with the app |
+| Python (`uv run nteract`) | Remove `NTERACT_RUST_MCP` from env | 27 tools (includes `show_notebook`) | Requires Python + uv + maturin develop |
+
+The repo's `.mcp.json`, `.codex/config.toml`, and `.zed/settings.json` all default to the Rust server. The supervisor auto-builds `runt-cli` on startup and watches `crates/runt-mcp/src/` for hot reload.
+
+`runt mcp` can also be run standalone (no supervisor): `./target/debug/runt mcp`. It reads `RUNTIMED_SOCKET_PATH` for the daemon connection.
+
+For the installed app, `runt mcp` ships as a sidecar binary alongside `runtimed`, so MCP clients can use it directly without Python or uv.
 
 ### Supervisor Tools (from nteract-dev / `mcp-supervisor`)
 
@@ -248,9 +261,11 @@ When nteract-dev is active, agents also get the full nteract tool suite. **Use t
 
 ### Hot reload
 
-The supervisor watches `python/nteract/src/`, `python/runtimed/src/`, `crates/runtimed-py/src/`, and `crates/runtimed/src/`:
-- **Python changes** → child process restarts automatically
-- **Rust changes** → `maturin develop` runs first, then child restarts
+The supervisor watches source directories and auto-restarts the child on changes:
+- **`crates/runt-mcp/src/`** → `cargo build -p runt-cli` + restart (Rust MCP mode)
+- **`crates/runtimed-client/src/`** → `cargo build -p runt-cli` + `maturin develop` + restart (shared code)
+- **`crates/runtimed-py/src/`, `crates/runtimed/src/`** → `maturin develop` + `cargo build` + restart
+- **`python/nteract/src/`, `python/runtimed/src/`** → child restart (Python mode) or background `maturin develop` (Rust mode)
 
 ### Tool availability
 
@@ -260,18 +275,20 @@ The supervisor watches `python/nteract/src/`, `python/runtimed/src/`, `crates/ru
 - **No MCP server** → use `cargo xtask run-mcp` to set one up
 - **Dev daemon not running** → nteract-dev starts it automatically via `supervisor_restart(target="daemon")`
 
-## Workspace Crates (15)
+## Workspace Crates (17)
 
 | Crate | Purpose |
 |-------|---------|
 | `runtimed` | Central daemon — env pools, notebook sync, kernel execution |
+| `runtimed-client` | Shared client library — output resolution, daemon paths, pool client |
 | `runtimed-py` | Python bindings for daemon (PyO3/maturin) |
 | `runtimed-wasm` | WASM bindings for notebook doc (Automerge, used by frontend) |
 | `notebook` | Tauri desktop app — main GUI, bundles daemon+CLI as sidecars |
 | `notebook-doc` | Shared Automerge schema — cells, outputs, RuntimeStateDoc, PEP 723 |
 | `notebook-protocol` | Wire types — requests, responses, broadcasts |
 | `notebook-sync` | Automerge sync client — `DocHandle`, per-cell Python accessors |
-| `runt` | CLI — daemon management, kernel control, notebook launching |
+| `runt` | CLI — daemon management, kernel control, notebook launching, MCP server |
+| `runt-mcp` | Rust-native MCP server — 26 tools for notebook interaction via `runt mcp` |
 | `runt-trust` | Notebook trust (HMAC-SHA256 over dependency metadata) |
 | `runt-workspace` | Per-worktree daemon isolation, socket path management |
 | `kernel-launch` | Kernel launching, tool bootstrapping (deno, uv, ruff via rattler) |

--- a/contributing/runtimed.md
+++ b/contributing/runtimed.md
@@ -92,7 +92,7 @@ When iterating on daemon code, you often want to test changes in the notebook ap
 The supervisor manages the dev daemon for you. No env vars or extra terminals needed.
 
 - `supervisor_restart(target="daemon")` — start or restart the dev daemon after code changes
-- `supervisor_rebuild` — rebuild Python bindings (`maturin develop`) + restart
+- `supervisor_rebuild` — rebuild Rust bindings + Python bindings (`maturin develop`) + restart
 - `supervisor_status` — check daemon status (`daemon_managed: true` confirms it's running)
 - `supervisor_logs` — tail daemon logs
 - `supervisor_start_vite` — start the Vite dev server for hot-reload


### PR DESCRIPTION
## Summary

Switches all MCP client configs to use the Rust-native MCP server (`runt mcp`) by default via `NTERACT_RUST_MCP=1`.

### Config changes

- `.mcp.json` (Claude Code) — added `NTERACT_RUST_MCP=1`
- `.codex/config.toml` (Codex) — added `NTERACT_RUST_MCP=1`
- `.zed/settings.json` (Zed) — added `NTERACT_RUST_MCP=1`

### Docs updated

- **AGENTS.md**: Documented Rust vs Python server selection table, added `runt-mcp` and `runtimed-client` to crate table (15→17), updated hot reload paths for Rust MCP file watching
- **.claude/rules/mcp-servers.md**: Added Rust vs Python MCP section
- **contributing/runtimed.md**: Updated supervisor_rebuild description

### Why

The Rust server has full tool parity (26/27 tools — only `show_notebook` is Python-only), no Python overhead, direct Automerge access, presence tracking, and ships with the installed app. To fall back to Python, remove `NTERACT_RUST_MCP` from the env block.