### PR TITLE
fix(ci): build MCP widget HTML before all runt-cli compilations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -421,6 +421,17 @@ jobs:
         with:
           shared-key: ${{ matrix.platform.runner }}
 
+      # Build MCP output widget HTML (needed by runt-mcp's include_str!)
+      - uses: pnpm/action-setup@v4
+        if: needs.changes.outputs.source_changed == 'true' && (github.event_name != 'pull_request' || matrix.platform.run_on_pr)
+      - uses: actions/setup-node@v4
+        if: needs.changes.outputs.source_changed == 'true' && (github.event_name != 'pull_request' || matrix.platform.run_on_pr)
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm --filter nteract-mcp-app install && pnpm --filter nteract-mcp-app run build
+        if: needs.changes.outputs.source_changed == 'true' && (github.event_name != 'pull_request' || matrix.platform.run_on_pr)
+
       - name: Build external binaries
         if: needs.changes.outputs.source_changed == 'true' && (github.event_name != 'pull_request' || matrix.platform.run_on_pr)
         shell: bash

--- a/.github/workflows/pr-binary-generation.yml
+++ b/.github/workflows/pr-binary-generation.yml
@@ -182,6 +182,10 @@ jobs:
       - name: Generate icons
         run: cargo xtask icons
 
+      # Build MCP output widget HTML (needed by runt-mcp's include_str!)
+      - name: Build MCP output widget
+        run: pnpm --filter nteract-mcp-app install && pnpm --filter nteract-mcp-app run build
+
       - name: Build external binaries (Unix)
         if: runner.os != 'Windows'
         shell: bash

--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -124,6 +124,10 @@ jobs:
           echo "Setting version to: ${VERSION}"
           sed -i "s/^version = .*/version = \"${VERSION}\"/" crates/runt/Cargo.toml
 
+      # Build MCP output widget HTML (needed by runt-mcp's include_str!)
+      - name: Build MCP output widget
+        run: pnpm --filter nteract-mcp-app install && pnpm --filter nteract-mcp-app run build
+
       - name: Build for Linux x64
         run: cargo build --release --target x86_64-unknown-linux-gnu -p runt-cli
 
@@ -190,6 +194,10 @@ jobs:
           VERSION="${{ needs.compute-version.outputs.version }}"
           echo "Setting version to: ${VERSION}"
           sed -i '' "s/^version = .*/version = \"${VERSION}\"/" crates/runt/Cargo.toml
+
+      # Build MCP output widget HTML (needed by runt-mcp's include_str!)
+      - name: Build MCP output widget
+        run: pnpm --filter nteract-mcp-app install && pnpm --filter nteract-mcp-app run build
 
       - name: Build for macOS ARM64
         run: cargo build --release --target aarch64-apple-darwin -p runt-cli
@@ -309,6 +317,10 @@ jobs:
             ICON_SOURCE="crates/notebook/icons/source-nightly.png"
           fi
           cargo xtask icons "$ICON_SOURCE"
+
+      # Build MCP output widget HTML (needed by runt-mcp's include_str!)
+      - name: Build MCP output widget
+        run: pnpm --filter nteract-mcp-app install && pnpm --filter nteract-mcp-app run build
 
       - name: Build external binaries
         run: |
@@ -460,6 +472,10 @@ jobs:
           }
           cargo xtask icons $iconSource
 
+      # Build MCP output widget HTML (needed by runt-mcp's include_str!)
+      - name: Build MCP output widget
+        run: pnpm --filter nteract-mcp-app install && pnpm --filter nteract-mcp-app run build
+
       - name: Build external binaries
         shell: bash
         run: |
@@ -590,6 +606,10 @@ jobs:
             ICON_SOURCE="crates/notebook/icons/source-nightly.png"
           fi
           cargo xtask icons "$ICON_SOURCE"
+
+      # Build MCP output widget HTML (needed by runt-mcp's include_str!)
+      - name: Build MCP output widget
+        run: pnpm --filter nteract-mcp-app install && pnpm --filter nteract-mcp-app run build
 
       - name: Build external binaries
         run: |


### PR DESCRIPTION
## Summary

`runt-mcp` uses `include_str!("../assets/_output.html")` which must exist at compile time. Several CI jobs that build `runt-cli` were missing the widget build step, which would cause compilation failures.

### Jobs fixed

- **build.yml**: Platform build matrix (macOS/Windows) — was missing
- **release-common.yml**: All 5 release jobs (Linux CLI, macOS CLI, macOS notebook, Windows notebook, Linux notebook)
- **pr-binary-generation.yml**: PR binary build job

### What was already covered

- build.yml: Windows clippy, Linux release build, Clippy & Tests (Linux) — added in #1289

## Test plan

- [x] Every `cargo build --release -p runt-cli` is preceded by widget build
- [ ] CI passes on all platforms