### PR TITLE
fix(mcp): upgrade rmcp from 0.16 to 1.3 for protocol version compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -421,6 +421,17 @@ jobs:
         with:
           shared-key: ${{ matrix.platform.runner }}
 
+      # Build MCP output widget HTML (needed by runt-mcp's include_str!)
+      - uses: pnpm/action-setup@v4
+        if: needs.changes.outputs.source_changed == 'true' && (github.event_name != 'pull_request' || matrix.platform.run_on_pr)
+      - uses: actions/setup-node@v4
+        if: needs.changes.outputs.source_changed == 'true' && (github.event_name != 'pull_request' || matrix.platform.run_on_pr)
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm --filter nteract-mcp-app install && pnpm --filter nteract-mcp-app run build
+        if: needs.changes.outputs.source_changed == 'true' && (github.event_name != 'pull_request' || matrix.platform.run_on_pr)
+
       - name: Build external binaries
         if: needs.changes.outputs.source_changed == 'true' && (github.event_name != 'pull_request' || matrix.platform.run_on_pr)
         shell: bash

--- a/.github/workflows/pr-binary-generation.yml
+++ b/.github/workflows/pr-binary-generation.yml
@@ -182,6 +182,10 @@ jobs:
       - name: Generate icons
         run: cargo xtask icons
 
+      # Build MCP output widget HTML (needed by runt-mcp's include_str!)
+      - name: Build MCP output widget
+        run: pnpm --filter nteract-mcp-app install && pnpm --filter nteract-mcp-app run build
+
       - name: Build external binaries (Unix)
         if: runner.os != 'Windows'
         shell: bash

--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -124,6 +124,10 @@ jobs:
           echo "Setting version to: ${VERSION}"
           sed -i "s/^version = .*/version = \"${VERSION}\"/" crates/runt/Cargo.toml
 
+      # Build MCP output widget HTML (needed by runt-mcp's include_str!)
+      - name: Build MCP output widget
+        run: pnpm --filter nteract-mcp-app install && pnpm --filter nteract-mcp-app run build
+
       - name: Build for Linux x64
         run: cargo build --release --target x86_64-unknown-linux-gnu -p runt-cli
 
@@ -190,6 +194,10 @@ jobs:
           VERSION="${{ needs.compute-version.outputs.version }}"
           echo "Setting version to: ${VERSION}"
           sed -i '' "s/^version = .*/version = \"${VERSION}\"/" crates/runt/Cargo.toml
+
+      # Build MCP output widget HTML (needed by runt-mcp's include_str!)
+      - name: Build MCP output widget
+        run: pnpm --filter nteract-mcp-app install && pnpm --filter nteract-mcp-app run build
 
       - name: Build for macOS ARM64
         run: cargo build --release --target aarch64-apple-darwin -p runt-cli
@@ -309,6 +317,10 @@ jobs:
             ICON_SOURCE="crates/notebook/icons/source-nightly.png"
           fi
           cargo xtask icons "$ICON_SOURCE"
+
+      # Build MCP output widget HTML (needed by runt-mcp's include_str!)
+      - name: Build MCP output widget
+        run: pnpm --filter nteract-mcp-app install && pnpm --filter nteract-mcp-app run build
 
       - name: Build external binaries
         run: |
@@ -460,6 +472,10 @@ jobs:
           }
           cargo xtask icons $iconSource
 
+      # Build MCP output widget HTML (needed by runt-mcp's include_str!)
+      - name: Build MCP output widget
+        run: pnpm --filter nteract-mcp-app install && pnpm --filter nteract-mcp-app run build
+
       - name: Build external binaries
         shell: bash
         run: |
@@ -590,6 +606,10 @@ jobs:
             ICON_SOURCE="crates/notebook/icons/source-nightly.png"
           fi
           cargo xtask icons "$ICON_SOURCE"
+
+      # Build MCP output widget HTML (needed by runt-mcp's include_str!)
+      - name: Build MCP output widget
+        run: pnpm --filter nteract-mcp-app install && pnpm --filter nteract-mcp-app run build
 
       - name: Build external binaries
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5889,9 +5889,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "0.16.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4c9c94680f75470ee8083a0667988b5d7b5beb70b9f998a8e51de7c682ce60"
+checksum = "2231b2c085b371c01bc90c0e6c1cab8834711b6394533375bdbf870b0166d419"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -5913,9 +5913,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "0.16.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90c23c8f26cae4da838fbc3eadfaecf2d549d97c04b558e7bd90526a9c28b42a"
+checksum = "36ea0e100fadf81be85d7ff70f86cd805c7572601d4ab2946207f36540854b43"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",

--- a/crates/mcp-supervisor/Cargo.toml
+++ b/crates/mcp-supervisor/Cargo.toml
@@ -12,7 +12,7 @@ name = "mcp-supervisor"
 path = "src/main.rs"
 
 [dependencies]
-rmcp = { version = "0.16", features = ["server", "client", "transport-child-process", "transport-io"] }
+rmcp = { version = "1.3", features = ["server", "client", "transport-child-process", "transport-io"] }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/mcp-supervisor/src/main.rs
+++ b/crates/mcp-supervisor/src/main.rs
@@ -457,14 +457,10 @@ struct NteractClientHandler;
 
 impl ClientHandler for NteractClientHandler {
     fn get_info(&self) -> rmcp::model::ClientInfo {
-        rmcp::model::ClientInfo {
-            client_info: Implementation {
-                name: "nteract-dev".into(),
-                version: env!("CARGO_PKG_VERSION").into(),
-                ..Default::default()
-            },
-            ..Default::default()
-        }
+        rmcp::model::ClientInfo::new(
+            Default::default(),
+            Implementation::new("nteract-dev", env!("CARGO_PKG_VERSION")),
+        )
     }
 }
 
@@ -1143,30 +1139,27 @@ struct SetModeParams {
 /// MCP ServerHandler that proxies to the nteract child + injects supervisor tools.
 impl ServerHandler for Supervisor {
     fn get_info(&self) -> ServerInfo {
-        ServerInfo {
-            protocol_version: Default::default(),
-            capabilities: ServerCapabilities::builder()
+        ServerInfo::new(
+            ServerCapabilities::builder()
                 .enable_tools()
                 .enable_resources()
                 .enable_resources_list_changed()
                 .build(),
-            server_info: Implementation {
-                name: "nteract-dev".into(),
-                version: env!("CARGO_PKG_VERSION").into(),
-                ..Default::default()
-            },
-            instructions: Some(
-                "nteract-dev — MCP supervisor proxying to the nteract notebook server. \
-                 Includes supervisor_status, supervisor_restart, supervisor_rebuild, \
-                 supervisor_logs, supervisor_start_vite, and supervisor_stop tools \
-                 for managing the server lifecycle and dev environment. \
-                 File watching is active: Python changes hot-reload instantly, \
-                 Rust changes trigger maturin develop + reload. Changed tool \
-                 behavior takes effect immediately; new/removed tools may take \
-                 a moment for the client to discover."
-                    .into(),
-            ),
-        }
+        )
+        .with_server_info(Implementation::new(
+            "nteract-dev",
+            env!("CARGO_PKG_VERSION"),
+        ))
+        .with_instructions(
+            "nteract-dev — MCP supervisor proxying to the nteract notebook server. \
+             Includes supervisor_status, supervisor_restart, supervisor_rebuild, \
+             supervisor_logs, supervisor_start_vite, and supervisor_stop tools \
+             for managing the server lifecycle and dev environment. \
+             File watching is active: Python changes hot-reload instantly, \
+             Rust changes trigger maturin develop + reload. Changed tool \
+             behavior takes effect immediately; new/removed tools may take \
+             a moment for the client to discover.",
+        )
     }
 
     async fn list_tools(

--- a/crates/runt-mcp/Cargo.toml
+++ b/crates/runt-mcp/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 workspace = true
 
 [dependencies]
-rmcp = { version = "0.16", features = ["server", "transport-io"] }
+rmcp = { version = "1.3", features = ["server", "transport-io"] }
 runtimed-client = { path = "../runtimed-client" }
 notebook-protocol = { path = "../notebook-protocol" }
 notebook-sync = { path = "../notebook-sync" }

--- a/crates/runt-mcp/src/lib.rs
+++ b/crates/runt-mcp/src/lib.rs
@@ -60,25 +60,19 @@ impl ServerHandler for NteractMcp {
             serde_json::from_value(serde_json::json!({})).unwrap(),
         );
 
-        ServerInfo {
-            protocol_version: Default::default(),
-            capabilities: ServerCapabilities::builder()
+        ServerInfo::new(
+            ServerCapabilities::builder()
                 .enable_tools()
                 .enable_resources()
                 .enable_extensions_with(extensions)
                 .build(),
-            server_info: Implementation {
-                name: "nteract".into(),
-                version: env!("CARGO_PKG_VERSION").into(),
-                ..Default::default()
-            },
-            instructions: Some(
-                "nteract MCP server for AI-powered Jupyter notebooks. \
-                 Use list_active_notebooks to discover open notebooks, \
-                 then join_notebook or open_notebook to start working."
-                    .into(),
-            ),
-        }
+        )
+        .with_server_info(Implementation::new("nteract", env!("CARGO_PKG_VERSION")))
+        .with_instructions(
+            "nteract MCP server for AI-powered Jupyter notebooks. \
+             Use list_active_notebooks to discover open notebooks, \
+             then join_notebook or open_notebook to start working.",
+        )
     }
 
     async fn list_tools(

--- a/crates/runt-mcp/src/resources.rs
+++ b/crates/runt-mcp/src/resources.rs
@@ -42,14 +42,14 @@ pub async fn read_resource(
     let uri = request.uri.as_str();
 
     if uri == OUTPUT_RESOURCE_URI {
-        return Ok(ReadResourceResult {
-            contents: vec![ResourceContents::TextResourceContents {
+        return Ok(ReadResourceResult::new(vec![
+            ResourceContents::TextResourceContents {
                 uri: OUTPUT_RESOURCE_URI.into(),
                 mime_type: Some(OUTPUT_MIME_TYPE.into()),
                 text: OUTPUT_HTML.to_string(),
                 meta: None,
-            }],
-        });
+            },
+        ]));
     }
 
     Err(McpError::resource_not_found(

--- a/crates/runt/Cargo.toml
+++ b/crates/runt/Cargo.toml
@@ -26,7 +26,7 @@ notebook-doc = { path = "../notebook-doc", features = ["persistence"] }
 runt-workspace = { path = "../runt-workspace" }
 runt-mcp = { path = "../runt-mcp" }
 kernel-env = { path = "../kernel-env" }
-rmcp = { version = "0.16", features = ["server", "transport-io"] }
+rmcp = { version = "1.3", features = ["server", "transport-io"] }
 clap = { version = "4.5.1", features = ["derive", "color"] }
 colored = "2"
 tokio = { version = "1", features = ["full"] }

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -644,7 +644,7 @@ async fn run_mcp_server() -> Result<()> {
     let (blob_base_url, blob_store_path) =
         runtimed_client::daemon_paths::get_blob_paths_async(&socket_path).await;
 
-    use rmcp::ServiceExt;
+    use rmcp::service::ServiceExt;
     let server = runt_mcp::NteractMcp::new(socket_path, blob_base_url, blob_store_path);
     let transport = rmcp::transport::io::stdio();
     let handle = server.serve(transport).await?;


### PR DESCRIPTION
## Summary

Upgrades rmcp from 0.16 to 1.3 across all three MCP crates. The old version advertised MCP protocol version `2025-03-26` which Claude Desktop doesn't accept — it expects `2025-11-25`.

### Changes

- `runt-mcp/Cargo.toml`: 0.16 → 1.3
- `mcp-supervisor/Cargo.toml`: 0.16 → 1.3
- `runt/Cargo.toml`: 0.16 → 1.3
- Fix non-exhaustive struct construction (ServerInfo, Implementation, ClientInfo, ReadResourceResult)
- Fix ServiceExt import path

## Test plan

- [x] `cargo build -p runt-mcp -p mcp-supervisor -p runt-cli` — clean
- [x] `cargo clippy` — clean
- [ ] CI passes
- [ ] Nightly release builds and connects in Claude Desktop