### PR TITLE
fix(runt-mcp): match Python MCP server output format for full parity

### DIFF
--- a/crates/runt-mcp/src/formatting.rs
+++ b/crates/runt-mcp/src/formatting.rs
@@ -136,9 +136,11 @@ pub fn format_cell_summary(
     // Source preview — collapse to single line, strip whitespace
     if !source.is_empty() {
         let source_line: String = source.split_whitespace().collect::<Vec<_>>().join(" ");
-        let preview = if source_line.len() > preview_chars {
-            let remaining = source_line.len() - preview_chars;
-            format!("{}…[+{remaining} chars]", &source_line[..preview_chars])
+        let char_count = source_line.chars().count();
+        let preview = if char_count > preview_chars {
+            let truncated: String = source_line.chars().take(preview_chars).collect();
+            let remaining = char_count - preview_chars;
+            format!("{truncated}…[+{remaining} chars]")
         } else {
             source_line
         };

--- a/crates/runt-mcp/src/formatting.rs
+++ b/crates/runt-mcp/src/formatting.rs
@@ -82,16 +82,30 @@ pub fn format_output_text(output: &Output) -> Option<String> {
     }
 }
 
-/// Format all outputs as a single text string.
+/// Format all outputs as a single text string (double-newline separated).
 pub fn format_outputs_text(outputs: &[Output]) -> String {
     outputs
         .iter()
         .filter_map(format_output_text)
         .collect::<Vec<_>>()
-        .join("\n")
+        .join("\n\n")
 }
 
-/// Format a compact one-line cell summary.
+/// Convert outputs to separate Content items (one per output).
+/// This gives MCP clients richer structure than a single concatenated string.
+pub fn outputs_to_content_items(outputs: &[Output]) -> Vec<rmcp::model::Content> {
+    outputs
+        .iter()
+        .filter_map(format_output_text)
+        .map(rmcp::model::Content::text)
+        .collect()
+}
+
+/// Format a compact one-line cell summary (matches Python _format_cell_summary).
+///
+/// Example output:
+///   0 | markdown | id=cell-1be2a179 | # Crate Download Analysis
+///   1 | code | running | id=cell-e18fcc2a | exec=4 | import requests…[+45 chars]
 pub fn format_cell_summary(
     index: usize,
     cell_id: &str,
@@ -101,32 +115,71 @@ pub fn format_cell_summary(
     status: Option<&str>,
     preview_chars: usize,
 ) -> String {
-    let ec = execution_count.unwrap_or("");
-    let st = status.unwrap_or("");
-    let preview = if source.len() > preview_chars {
-        format!("{}…", &source[..preview_chars])
-    } else {
-        source.to_string()
-    };
-    // Replace newlines with ↵ for single-line display
-    let preview = preview.replace('\n', "↵");
-    format!("{index} | {cell_type} | {st} | id={cell_id} | [{ec}] | {preview}")
+    let mut parts = vec![index.to_string(), cell_type.to_string()];
+
+    // Status (running/queued) comes before id, like in Python
+    if let Some(st) = status {
+        if !st.is_empty() {
+            parts.push(st.to_string());
+        }
+    }
+
+    parts.push(format!("id={cell_id}"));
+
+    // execution_count as exec=N (only for code cells with a value)
+    if let Some(ec) = execution_count {
+        if !ec.is_empty() && cell_type == "code" {
+            parts.push(format!("exec={ec}"));
+        }
+    }
+
+    // Source preview — collapse to single line, strip whitespace
+    if !source.is_empty() {
+        let source_line: String = source.split_whitespace().collect::<Vec<_>>().join(" ");
+        let preview = if source_line.len() > preview_chars {
+            let remaining = source_line.len() - preview_chars;
+            format!("{}…[+{remaining} chars]", &source_line[..preview_chars])
+        } else {
+            source_line
+        };
+        parts.push(preview);
+    }
+
+    parts.join(" | ")
 }
 
-/// Format a cell header line.
+/// Format a cell header line (matches Python _format_header).
+///
+/// Example: ━━━ cell-abc12345 (code) ✓ idle [3] ━━━
 pub fn format_cell_header(
     cell_id: &str,
     cell_type: &str,
     execution_count: Option<&str>,
     status: Option<&str>,
 ) -> String {
-    let ec_display = execution_count
-        .filter(|s| !s.is_empty())
-        .map(|s| format!("[{s}]"))
-        .unwrap_or_default();
-    let status_display = status
-        .filter(|s| !s.is_empty())
-        .map(|s| format!(" ({s})"))
-        .unwrap_or_default();
-    format!("── {cell_type} {ec_display}{status_display} ── {cell_id}")
+    let mut parts = vec![format!("━━━ {cell_id}")];
+
+    parts.push(format!("({cell_type})"));
+
+    if let Some(st) = status {
+        if !st.is_empty() {
+            let icon = match st {
+                "idle" => "✓",
+                "error" => "✗",
+                "running" => "◐",
+                "queued" => "⧗",
+                _ => "?",
+            };
+            parts.push(format!("{icon} {st}"));
+        }
+    }
+
+    if let Some(ec) = execution_count {
+        if !ec.is_empty() {
+            parts.push(format!("[{ec}]"));
+        }
+    }
+
+    parts.push("━━━".to_string());
+    parts.join(" ")
 }

--- a/crates/runt-mcp/src/tools/cell_crud.rs
+++ b/crates/runt-mcp/src/tools/cell_crud.rs
@@ -354,14 +354,9 @@ async fn build_execution_result(
         Some(&result.status),
     );
 
-    let output_text = crate::formatting::format_outputs_text(&result.outputs);
-    let text = if !output_text.is_empty() {
-        format!("{header}\n\n{output_text}")
-    } else {
-        header
-    };
-
-    let items = vec![Content::text(text)];
+    // Multiple Content items: header, then one per output (matches Python)
+    let mut items = vec![Content::text(header)];
+    items.extend(crate::formatting::outputs_to_content_items(&result.outputs));
 
     // Build structured content for MCP Apps widget using the protocol's
     // structured_content field instead of a text-based fallback.

--- a/crates/runt-mcp/src/tools/cell_read.rs
+++ b/crates/runt-mcp/src/tools/cell_read.rs
@@ -244,9 +244,12 @@ pub async fn get_all_cells(
                         // Collapse to single line (matches Python format)
                         let output_line: String =
                             output_text.split_whitespace().collect::<Vec<_>>().join(" ");
-                        let output_preview = if output_line.len() > preview_chars {
-                            let remaining = output_line.len() - preview_chars;
-                            format!("{}…[+{remaining} chars]", &output_line[..preview_chars])
+                        let char_count = output_line.chars().count();
+                        let output_preview = if char_count > preview_chars {
+                            let truncated: String =
+                                output_line.chars().take(preview_chars).collect();
+                            let remaining = char_count - preview_chars;
+                            format!("{truncated}…[+{remaining} chars]")
                         } else {
                             output_line
                         };

--- a/crates/runt-mcp/src/tools/cell_read.rs
+++ b/crates/runt-mcp/src/tools/cell_read.rs
@@ -88,22 +88,19 @@ pub async fn get_cell(
         status.as_deref(),
     );
 
-    let output_text = formatting::format_outputs_text(&outputs);
+    // Return multiple Content items: header+source, then one per output
+    let mut items = Vec::new();
 
-    let text = if !cell.source.is_empty() && !output_text.is_empty() {
-        format!(
-            "{header}\n\n{}\n\n───────────────────\n\n{output_text}",
-            cell.source
-        )
-    } else if !cell.source.is_empty() {
-        format!("{header}\n\n{}", cell.source)
-    } else if !output_text.is_empty() {
-        format!("{header}\n\n{output_text}")
+    if !cell.source.is_empty() {
+        items.push(Content::text(format!("{header}\n\n{}", cell.source)));
     } else {
-        header
-    };
+        items.push(Content::text(header));
+    }
 
-    Ok(CallToolResult::success(vec![Content::text(text)]))
+    // Each output as a separate Content item (matches Python _cell_to_content)
+    items.extend(formatting::outputs_to_content_items(&outputs));
+
+    Ok(CallToolResult::success(items))
 }
 
 /// Get all cells with configurable format.
@@ -172,6 +169,13 @@ pub async fn get_all_cells(
                     .filter_map(|raw| serde_json::from_str(raw).ok())
                     .collect();
 
+                // Extract tags from cell metadata
+                let tags: Vec<String> = cell
+                    .metadata
+                    .get("tags")
+                    .and_then(|v| serde_json::from_value::<Vec<String>>(v.clone()).ok())
+                    .unwrap_or_default();
+
                 json_cells.push(serde_json::json!({
                     "cell_id": cell.id,
                     "cell_type": cell.cell_type,
@@ -179,6 +183,7 @@ pub async fn get_all_cells(
                     "source": cell.source,
                     "outputs": output_values,
                     "status": status,
+                    "tags": tags,
                 }));
             }
             let text = serde_json::to_string_pretty(&json_cells).unwrap_or_default();
@@ -236,9 +241,12 @@ pub async fn get_all_cells(
                     .await;
                     let output_text = formatting::format_outputs_text(&outputs);
                     if !output_text.is_empty() {
-                        let output_line = output_text.replace('\n', " ");
+                        // Collapse to single line (matches Python format)
+                        let output_line: String =
+                            output_text.split_whitespace().collect::<Vec<_>>().join(" ");
                         let output_preview = if output_line.len() > preview_chars {
-                            format!("{}...", &output_line[..preview_chars])
+                            let remaining = output_line.len() - preview_chars;
+                            format!("{}…[+{remaining} chars]", &output_line[..preview_chars])
                         } else {
                             output_line
                         };
@@ -274,7 +282,7 @@ fn get_cell_status(handle: &notebook_sync::handle::DocHandle, cell_id: &str) -> 
 }
 
 /// Build a map of cell_id -> status from RuntimeState.
-fn build_cell_status_map(
+pub fn build_cell_status_map(
     handle: &notebook_sync::handle::DocHandle,
 ) -> std::collections::HashMap<String, String> {
     let mut map = std::collections::HashMap::new();

--- a/crates/runt-mcp/src/tools/execution.rs
+++ b/crates/runt-mcp/src/tools/execution.rs
@@ -73,21 +73,16 @@ pub async fn execute_cell(
     )
     .await;
 
-    // Format text content
+    // Format as multiple Content items: header, then one per output
     let header = formatting::format_cell_header(
         &result.cell_id,
         "code",
         result.execution_count.as_deref(),
         Some(&result.status),
     );
-    let output_text = formatting::format_outputs_text(&result.outputs);
-    let text = if !output_text.is_empty() {
-        format!("{header}\n\n{output_text}")
-    } else {
-        header
-    };
 
-    let items = vec![Content::text(text)];
+    let mut items = vec![Content::text(header)];
+    items.extend(formatting::outputs_to_content_items(&result.outputs));
 
     // Build structured content for MCP Apps widget using the protocol's
     // structured_content field instead of a text-based fallback.

--- a/crates/runt-mcp/src/tools/session.rs
+++ b/crates/runt-mcp/src/tools/session.rs
@@ -9,12 +9,111 @@ use serde::Deserialize;
 
 use runtimed_client::client::PoolClient;
 
+use crate::formatting;
 use crate::session::NotebookSession;
 use crate::NteractMcp;
 
 use notebook_protocol::protocol::{NotebookRequest, NotebookResponse};
 
 use super::{arg_str, tool_error, tool_success};
+
+/// Collect runtime info from RuntimeStateDoc, polling briefly for it to sync.
+/// Matches Python's `_collect_runtime_info()`.
+async fn collect_runtime_info(handle: &notebook_sync::handle::DocHandle) -> serde_json::Value {
+    // Poll up to ~500ms for RuntimeStateDoc to sync after join
+    let mut info = read_runtime_info(handle);
+    if info
+        .get("kernel_status")
+        .and_then(|v| v.as_str())
+        .unwrap_or("not_started")
+        == "not_started"
+    {
+        for _ in 0..5 {
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            info = read_runtime_info(handle);
+            let status = info
+                .get("kernel_status")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            if status != "not_started" && status != "unknown" && !status.is_empty() {
+                break;
+            }
+        }
+    }
+    info
+}
+
+/// Read runtime info snapshot from the handle's RuntimeStateDoc.
+fn read_runtime_info(handle: &notebook_sync::handle::DocHandle) -> serde_json::Value {
+    let mut info = serde_json::Map::new();
+    match handle.get_runtime_state() {
+        Ok(state) => {
+            info.insert(
+                "kernel_status".into(),
+                serde_json::json!(state.kernel.status),
+            );
+            if !state.kernel.language.is_empty() {
+                info.insert("language".into(), serde_json::json!(state.kernel.language));
+            }
+            if !state.kernel.name.is_empty() {
+                info.insert("kernel_name".into(), serde_json::json!(state.kernel.name));
+            }
+            if !state.kernel.env_source.is_empty() {
+                info.insert(
+                    "env_source".into(),
+                    serde_json::json!(state.kernel.env_source),
+                );
+                let env_source = &state.kernel.env_source;
+                if env_source.starts_with("conda:") {
+                    info.insert("package_manager".into(), serde_json::json!("conda"));
+                } else if env_source.starts_with("uv:") {
+                    info.insert("package_manager".into(), serde_json::json!("uv"));
+                } else if env_source == "deno" {
+                    info.insert("package_manager".into(), serde_json::json!("deno"));
+                }
+            }
+            if !state.env.in_sync {
+                info.insert("env_in_sync".into(), serde_json::json!(false));
+            }
+        }
+        Err(_) => {
+            info.insert("kernel_status".into(), serde_json::json!("unknown"));
+        }
+    }
+    serde_json::Value::Object(info)
+}
+
+/// Get dependencies from notebook metadata.
+fn get_dependencies(handle: &notebook_sync::handle::DocHandle) -> Vec<String> {
+    handle
+        .get_notebook_metadata()
+        .and_then(|m| m.runt.uv)
+        .map(|uv| uv.dependencies)
+        .unwrap_or_default()
+}
+
+/// Format cell summaries for join/open response.
+fn format_cell_summaries(handle: &notebook_sync::handle::DocHandle) -> String {
+    let cells = handle.get_cells();
+    let cell_status_map = crate::tools::cell_read::build_cell_status_map(handle);
+    cells
+        .iter()
+        .enumerate()
+        .map(|(i, cell)| {
+            let status = cell_status_map.get(&cell.id).map(String::as_str);
+            formatting::format_cell_summary(
+                i,
+                &cell.id,
+                &cell.cell_type,
+                &cell.source,
+                Some(&cell.execution_count),
+                status,
+                60,
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
 
 #[allow(dead_code)] // Fields used by schemars for tool input schema generation
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -91,11 +190,18 @@ pub async fn join_notebook(
     .await
     {
         Ok(result) => {
-            let info = format!(
-                "Joined notebook: {} ({} cells)",
-                result.handle.notebook_id(),
-                result.handle.get_cell_ids().len()
-            );
+            let handle = &result.handle;
+            let runtime_info = collect_runtime_info(handle).await;
+            let deps = get_dependencies(handle);
+            let cells_summary = format_cell_summaries(handle);
+
+            let response = serde_json::json!({
+                "notebook_id": handle.notebook_id(),
+                "connected": true,
+                "runtime": runtime_info,
+                "dependencies": deps,
+                "cells": cells_summary,
+            });
 
             let session = NotebookSession {
                 handle: result.handle,
@@ -103,7 +209,9 @@ pub async fn join_notebook(
             };
             *server.session.write().await = Some(session);
 
-            tool_success(&info)
+            Ok(CallToolResult::success(vec![Content::text(
+                serde_json::to_string_pretty(&response).unwrap_or_default(),
+            )]))
         }
         Err(e) => tool_error(&format!("Failed to join notebook: {}", e)),
     }
@@ -137,12 +245,18 @@ pub async fn open_notebook(
     .await
     {
         Ok(result) => {
-            let cell_count = result.handle.get_cell_ids().len();
-            let notebook_id = result.handle.notebook_id().to_string();
-            let info = serde_json::json!({
+            let handle = &result.handle;
+            let notebook_id = handle.notebook_id().to_string();
+            let runtime_info = collect_runtime_info(handle).await;
+            let deps = get_dependencies(handle);
+            let cells_summary = format_cell_summaries(handle);
+
+            let response = serde_json::json!({
                 "notebook_id": notebook_id,
-                "cell_count": cell_count,
-                "status": "connected"
+                "path": abs_path.to_string_lossy(),
+                "runtime": runtime_info,
+                "dependencies": deps,
+                "cells": cells_summary,
             });
 
             let session = NotebookSession {
@@ -152,7 +266,7 @@ pub async fn open_notebook(
             *server.session.write().await = Some(session);
 
             Ok(CallToolResult::success(vec![Content::text(
-                serde_json::to_string_pretty(&info).unwrap_or_default(),
+                serde_json::to_string_pretty(&response).unwrap_or_default(),
             )]))
         }
         Err(e) => tool_error(&format!("Failed to open notebook '{}': {}", path, e)),


### PR DESCRIPTION
## Summary

Brings `runt mcp` tool responses to full parity with the Python MCP server (`uv run nteract`):

- **`join_notebook` / `open_notebook`**: Now return `{notebook_id, runtime, dependencies, cells}` with kernel status, env_source, package_manager, and cell summaries — was just a confirmation string / minimal JSON
- **`get_cell` / `execute_cell`**: Return multiple `Content` items (header + one per output) instead of a single concatenated string, giving MCP clients richer structure for reasoning
- **Cell header format**: Matches Python's `━━━ cell-id (type) ✓ status [N] ━━━` with status icons (✓/✗/◐/⧗)
- **Cell summary format**: Uses `exec=N`, collapses whitespace, and `…[+N chars]` truncation matching Python
- **`get_all_cells` JSON**: Adds `tags` from cell metadata (was missing)
- **Output separator**: `\n\n` between outputs (was `\n`)
- **Runtime info polling**: `collect_runtime_info()` polls up to 500ms for RuntimeStateDoc to sync after join (matches Python's `_collect_runtime_info()`)

## Test plan

- [ ] `cargo check -p runt-mcp` passes
- [ ] `cargo xtask lint` passes
- [ ] CI passes
- [ ] Open a notebook via `runt mcp`, verify `join_notebook` returns runtime/deps/cells
- [ ] Execute a cell, verify multiple Content items returned (header separate from output)
- [ ] `get_all_cells(format="json")` includes `tags` array