### PR TITLE
fix(runt-mcp): add MCP Apps wire format for tool/resource association

### DIFF
--- a/crates/runt-mcp/src/lib.rs
+++ b/crates/runt-mcp/src/lib.rs
@@ -56,7 +56,7 @@ impl ServerHandler for NteractMcp {
         let mut extensions = rmcp::model::ExtensionCapabilities::new();
         #[allow(clippy::unwrap_used)] // static JSON, always valid
         extensions.insert(
-            "io.modelcontextprotocol/apps".to_string(),
+            "io.modelcontextprotocol/ui".to_string(),
             serde_json::from_value(serde_json::json!({})).unwrap(),
         );
 

--- a/crates/runt-mcp/src/resources.rs
+++ b/crates/runt-mcp/src/resources.rs
@@ -1,8 +1,8 @@
 //! MCP resource serving (output.html, notebook cells, status).
 
 use rmcp::model::{
-    Annotated, ListResourcesResult, RawResource, ReadResourceRequestParams, ReadResourceResult,
-    ResourceContents,
+    Annotated, ListResourcesResult, Meta, RawResource, ReadResourceRequestParams,
+    ReadResourceResult, ResourceContents,
 };
 use rmcp::ErrorData as McpError;
 
@@ -15,6 +15,25 @@ const OUTPUT_MIME_TYPE: &str = "text/html;profile=mcp-app";
 /// Build with: `cd apps/mcp-app && pnpm build`
 /// The build script copies the file to `crates/runt-mcp/assets/_output.html`.
 const OUTPUT_HTML: &str = include_str!("../assets/_output.html");
+
+/// Build `_meta` for the output widget resource with CSP allowing blob image loading.
+///
+/// Wire format: `{ "ui": { "csp": { "resourceDomains": ["http://localhost:{port}"] } } }`
+///
+/// Claude Desktop requires `localhost` (not `127.0.0.1`) for domain allowlists.
+fn resource_ui_meta(blob_base_url: &Option<String>) -> Option<Meta> {
+    let url = blob_base_url.as_ref()?;
+    let mut meta = serde_json::Map::new();
+    meta.insert(
+        "ui".to_string(),
+        serde_json::json!({
+            "csp": {
+                "resourceDomains": [url]
+            }
+        }),
+    );
+    Some(Meta(meta))
+}
 
 /// List available MCP resources.
 pub async fn list_resources(_server: &NteractMcp) -> Result<ListResourcesResult, McpError> {
@@ -36,7 +55,7 @@ pub async fn list_resources(_server: &NteractMcp) -> Result<ListResourcesResult,
 
 /// Read an MCP resource by URI.
 pub async fn read_resource(
-    _server: &NteractMcp,
+    server: &NteractMcp,
     request: &ReadResourceRequestParams,
 ) -> Result<ReadResourceResult, McpError> {
     let uri = request.uri.as_str();
@@ -47,7 +66,7 @@ pub async fn read_resource(
                 uri: OUTPUT_RESOURCE_URI.into(),
                 mime_type: Some(OUTPUT_MIME_TYPE.into()),
                 text: OUTPUT_HTML.to_string(),
-                meta: None,
+                meta: resource_ui_meta(&server.blob_base_url),
             },
         ]));
     }

--- a/crates/runt-mcp/src/structured.rs
+++ b/crates/runt-mcp/src/structured.rs
@@ -43,6 +43,10 @@ fn output_to_structured(output: &Output) -> Value {
 
             if let Some(ref output_data) = output.data {
                 for (mime, value) in output_data {
+                    // Skip text/llm+plain — it's for LLM consumption, not the widget
+                    if mime == "text/llm+plain" {
+                        continue;
+                    }
                     let json_value = match value {
                         DataValue::Text(s) => Value::String(s.clone()),
                         DataValue::Binary(_) => {

--- a/crates/runt-mcp/src/tools/mod.rs
+++ b/crates/runt-mcp/src/tools/mod.rs
@@ -2,12 +2,26 @@
 
 use std::sync::Arc;
 
-use rmcp::model::{CallToolRequestParams, CallToolResult, Content, Tool, ToolAnnotations};
+use rmcp::model::{CallToolRequestParams, CallToolResult, Content, Meta, Tool, ToolAnnotations};
 use rmcp::ErrorData as McpError;
 use schemars::JsonSchema;
 use serde::Deserialize;
 
 use crate::NteractMcp;
+
+/// The MCP Apps resource URI for the output widget.
+const OUTPUT_RESOURCE_URI: &str = "ui://nteract/output.html";
+
+/// Build `_meta` for tools that produce structured content for the MCP Apps widget.
+/// Wire format: `{ "ui": { "resourceUri": "ui://nteract/output.html" } }`
+fn app_tool_meta() -> Meta {
+    let mut meta = serde_json::Map::new();
+    meta.insert(
+        "ui".to_string(),
+        serde_json::json!({ "resourceUri": OUTPUT_RESOURCE_URI }),
+    );
+    Meta(meta)
+}
 
 mod cell_crud;
 mod cell_meta;
@@ -83,13 +97,15 @@ pub fn all_tools() -> Vec<Tool> {
             "Create a cell, optionally executing it.",
             schema_for::<cell_crud::CreateCellParams>(),
         )
-        .annotate(ToolAnnotations::new().destructive(false)),
+        .annotate(ToolAnnotations::new().destructive(false))
+        .with_meta(app_tool_meta()),
         Tool::new(
             "set_cell",
             "Update a cell's source and/or type. Use replace_match for targeted edits.",
             schema_for::<cell_crud::SetCellParams>(),
         )
-        .annotate(ToolAnnotations::new().destructive(true)),
+        .annotate(ToolAnnotations::new().destructive(true))
+        .with_meta(app_tool_meta()),
         Tool::new(
             "delete_cell",
             "Delete a cell by ID.",
@@ -139,7 +155,8 @@ pub fn all_tools() -> Vec<Tool> {
             "Execute a cell. Returns partial results if timeout exceeded.",
             schema_for::<execution::ExecuteCellParams>(),
         )
-        .annotate(ToolAnnotations::new().destructive(true)),
+        .annotate(ToolAnnotations::new().destructive(true))
+        .with_meta(app_tool_meta()),
         Tool::new(
             "run_all_cells",
             "Queue all code cells for execution. Use get_all_cells() to see results.",
@@ -190,13 +207,15 @@ pub fn all_tools() -> Vec<Tool> {
             "Replace matched text in a cell. Prefer this for simple, targeted edits. Use context_before/context_after to disambiguate when match appears multiple times.",
             schema_for::<editing::ReplaceMatchParams>(),
         )
-        .annotate(ToolAnnotations::new().destructive(true)),
+        .annotate(ToolAnnotations::new().destructive(true))
+        .with_meta(app_tool_meta()),
         Tool::new(
             "replace_regex",
             "Replace a regex-matched span. Use for anchors, lookarounds, or zero-width insertions. Fails if 0 or >1 matches.",
             schema_for::<editing::ReplaceRegexParams>(),
         )
-        .annotate(ToolAnnotations::new().destructive(true)),
+        .annotate(ToolAnnotations::new().destructive(true))
+        .with_meta(app_tool_meta()),
     ]
 }
 

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -590,6 +590,20 @@ fn cmd_build(rust_only: bool) {
         require_pnpm();
     }
 
+    // Phase 0: Build the MCP widget HTML before any Rust compilation.
+    // runt-mcp uses include_str!("../assets/_output.html") which fails
+    // if the asset doesn't exist yet. This must run before cargo build.
+    if !rust_only {
+        build_mcp_widget();
+    } else {
+        // Even in --rust-only mode, ensure the asset exists
+        let widget_asset = Path::new("crates/runt-mcp/assets/_output.html");
+        if !widget_asset.exists() {
+            eprintln!("MCP widget asset missing — building it first...");
+            build_mcp_widget();
+        }
+    }
+
     // Phase 1: Single cargo invocation for all binaries.
     // Building all packages together ensures workspace feature unification
     // happens in one pass, so the later `cargo tauri build` finds everything
@@ -625,9 +639,7 @@ fn cmd_build(rust_only: bool) {
         ensure_maturin_develop();
     }));
 
-    handles.push(thread::spawn(|| {
-        build_mcp_widget();
-    }));
+    // Note: build_mcp_widget() already ran in Phase 0 above.
 
     if rust_only {
         let dist_dir = Path::new("apps/notebook/dist");


### PR DESCRIPTION
## Summary

Fixes the output widget not appearing in Claude Desktop when using the Rust MCP server (`runt mcp`). Works with the Python server.

The root cause was two missing wire-format fields:

- **Tool `_meta.ui.resourceUri`**: Tells Claude Desktop which tools can produce structured content for the `ui://nteract/output.html` widget. Added to `create_cell`, `set_cell`, `execute_cell`, `replace_match`, `replace_regex`.
- **Resource `_meta.ui.csp.resourceDomains`**: Tells the widget iframe it can load images from the daemon's blob HTTP server (`http://localhost:{port}`). Added to the `resources/read` response.
- **Skip `text/llm+plain` in structured output**: Matches Python's `_output_to_structured` which excludes LLM-specific representations from widget data.

Uses `localhost` (not `127.0.0.1`) per Claude Desktop's domain allowlist.

## Test plan

- [ ] `cargo check -p runt-mcp` passes
- [ ] `cargo xtask lint` passes  
- [ ] CI passes
- [ ] In Claude Desktop with runt-nightly: execute a cell → output widget should render
- [ ] Image outputs (matplotlib, etc.) load in the widget iframe