### PR TITLE
fix(runt-mcp): skip structured_content when cell has no outputs

### DIFF
--- a/crates/runt-mcp/src/tools/cell_crud.rs
+++ b/crates/runt-mcp/src/tools/cell_crud.rs
@@ -360,27 +360,33 @@ async fn build_execution_result(
 
     // Build structured content for MCP Apps widget using the protocol's
     // structured_content field instead of a text-based fallback.
+    // Only send structured content when there are outputs to render.
+    // Empty outputs show "No output" in the widget, which is noisy.
     let cell_snapshot = handle.get_cell(&result.cell_id);
     let structured_content = if let Some(snap) = cell_snapshot {
-        let outputs = runtimed_client::output_resolver::resolve_cell_outputs(
-            &snap.outputs,
-            &server.blob_base_url,
-            &server.blob_store_path,
-        )
-        .await;
-        let resolved = runtimed_client::resolved_output::ResolvedCell {
-            id: snap.id,
-            cell_type: snap.cell_type,
-            position: snap.position,
-            source: snap.source,
-            execution_count: snap.execution_count.parse().ok(),
-            outputs,
-            metadata_json: serde_json::to_string(&snap.metadata).unwrap_or_default(),
-        };
-        Some(structured::cell_structured_content(
-            &resolved,
-            &result.status,
-        ))
+        if snap.outputs.is_empty() {
+            None
+        } else {
+            let outputs = runtimed_client::output_resolver::resolve_cell_outputs(
+                &snap.outputs,
+                &server.blob_base_url,
+                &server.blob_store_path,
+            )
+            .await;
+            let resolved = runtimed_client::resolved_output::ResolvedCell {
+                id: snap.id,
+                cell_type: snap.cell_type,
+                position: snap.position,
+                source: snap.source,
+                execution_count: snap.execution_count.parse().ok(),
+                outputs,
+                metadata_json: serde_json::to_string(&snap.metadata).unwrap_or_default(),
+            };
+            Some(structured::cell_structured_content(
+                &resolved,
+                &result.status,
+            ))
+        }
     } else {
         None
     };

--- a/crates/runt-mcp/src/tools/editing.rs
+++ b/crates/runt-mcp/src/tools/editing.rs
@@ -275,27 +275,32 @@ async fn build_execution_result(
 
     // Build structured content for MCP Apps widget using the protocol's
     // structured_content field instead of a text-based fallback.
+    // Only send structured content when there are outputs to render.
     let cell_snapshot = handle.get_cell(&result.cell_id);
     let structured_content = if let Some(snap) = cell_snapshot {
-        let outputs = runtimed_client::output_resolver::resolve_cell_outputs(
-            &snap.outputs,
-            &server.blob_base_url,
-            &server.blob_store_path,
-        )
-        .await;
-        let resolved = runtimed_client::resolved_output::ResolvedCell {
-            id: snap.id,
-            cell_type: snap.cell_type,
-            position: snap.position,
-            source: snap.source,
-            execution_count: snap.execution_count.parse().ok(),
-            outputs,
-            metadata_json: serde_json::to_string(&snap.metadata).unwrap_or_default(),
-        };
-        Some(structured::cell_structured_content(
-            &resolved,
-            &result.status,
-        ))
+        if snap.outputs.is_empty() {
+            None
+        } else {
+            let outputs = runtimed_client::output_resolver::resolve_cell_outputs(
+                &snap.outputs,
+                &server.blob_base_url,
+                &server.blob_store_path,
+            )
+            .await;
+            let resolved = runtimed_client::resolved_output::ResolvedCell {
+                id: snap.id,
+                cell_type: snap.cell_type,
+                position: snap.position,
+                source: snap.source,
+                execution_count: snap.execution_count.parse().ok(),
+                outputs,
+                metadata_json: serde_json::to_string(&snap.metadata).unwrap_or_default(),
+            };
+            Some(structured::cell_structured_content(
+                &resolved,
+                &result.status,
+            ))
+        }
     } else {
         None
     };

--- a/crates/runt-mcp/src/tools/execution.rs
+++ b/crates/runt-mcp/src/tools/execution.rs
@@ -86,27 +86,32 @@ pub async fn execute_cell(
 
     // Build structured content for MCP Apps widget using the protocol's
     // structured_content field instead of a text-based fallback.
+    // Only send structured content when there are outputs to render.
     let cell_snapshot = handle.get_cell(&result.cell_id);
     let structured_content = if let Some(snap) = cell_snapshot {
-        let outputs = runtimed_client::output_resolver::resolve_cell_outputs(
-            &snap.outputs,
-            &server.blob_base_url,
-            &server.blob_store_path,
-        )
-        .await;
-        let resolved = runtimed_client::resolved_output::ResolvedCell {
-            id: snap.id,
-            cell_type: snap.cell_type,
-            position: snap.position,
-            source: snap.source,
-            execution_count: snap.execution_count.parse().ok(),
-            outputs,
-            metadata_json: serde_json::to_string(&snap.metadata).unwrap_or_default(),
-        };
-        Some(structured::cell_structured_content(
-            &resolved,
-            &result.status,
-        ))
+        if snap.outputs.is_empty() {
+            None
+        } else {
+            let outputs = runtimed_client::output_resolver::resolve_cell_outputs(
+                &snap.outputs,
+                &server.blob_base_url,
+                &server.blob_store_path,
+            )
+            .await;
+            let resolved = runtimed_client::resolved_output::ResolvedCell {
+                id: snap.id,
+                cell_type: snap.cell_type,
+                position: snap.position,
+                source: snap.source,
+                execution_count: snap.execution_count.parse().ok(),
+                outputs,
+                metadata_json: serde_json::to_string(&snap.metadata).unwrap_or_default(),
+            };
+            Some(structured::cell_structured_content(
+                &resolved,
+                &result.status,
+            ))
+        }
     } else {
         None
     };


### PR DESCRIPTION
## Summary

Cells with no outputs (create_cell without and_run, `import numpy`, etc.) were sending empty `structured_content`, causing the MCP Apps widget to render a "No output" placeholder in Claude Desktop. Now `structured_content` is only set when the cell actually has outputs to display.

Applied to all three code paths that build structured content: `cell_crud::build_execution_result`, `execution::execute_cell`, and `editing::build_edit_execution_result`.

## Test plan

- [ ] `create_cell` without `and_run` → no widget shown
- [ ] `create_cell(and_run=true)` with `import numpy` → no widget shown  
- [ ] `execute_cell` with output (e.g. `print("hi")`) → widget renders normally
- [ ] CI passes