### PR TITLE
chore: bump version to 2.0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3696,7 +3696,7 @@ dependencies = [
 
 [[package]]
 name = "notebook"
-version = "2.0.4"
+version = "2.0.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5966,7 +5966,7 @@ dependencies = [
 
 [[package]]
 name = "runt-cli"
-version = "2.0.4"
+version = "2.0.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6044,7 +6044,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed"
-version = "2.0.4"
+version = "2.0.5"
 dependencies = [
  "alacritty_terminal",
  "anyhow",

--- a/crates/notebook/Cargo.toml
+++ b/crates/notebook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notebook"
-version = "2.0.4"
+version = "2.0.5"
 edition.workspace = true
 description = "Tauri-based notebook UI for Jupyter kernels"
 repository.workspace = true

--- a/crates/notebook/tauri.conf.json
+++ b/crates/notebook/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "nteract",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "identifier": "org.nteract.desktop",
   "build": {
     "devUrl": "http://localhost:5174",

--- a/crates/runt/Cargo.toml
+++ b/crates/runt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runt-cli"
-version = "2.0.4"
+version = "2.0.5"
 edition.workspace = true
 description = "CLI for Jupyter Runtimes — bundled with nteract"
 repository.workspace = true

--- a/crates/runtimed/Cargo.toml
+++ b/crates/runtimed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed"
-version = "2.0.4"
+version = "2.0.5"
 edition.workspace = true
 description = "Central daemon for managing Jupyter runtimes and prewarmed environments"
 repository.workspace = true

--- a/python/runtimed/pyproject.toml
+++ b/python/runtimed/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "runtimed"
-version = "2.0.4"
+version = "2.0.5"
 description = "Python toolkit for Jupyter runtimes, powered by runtimed Rust binaries"
 readme = "README.md"
 license = "BSD-3-Clause"


### PR DESCRIPTION
## Summary

Version bump for stable release. All five version sources updated: `2.0.4` → `2.0.5`.

### Changes since 2.0.4

- **feat(runt-mcp)**: Full Python MCP output format parity (#1299)
- **fix(runt-mcp)**: MCP Apps wire format — correct extension ID, tool `_meta.ui`, resource CSP (#1300)
- **fix(xtask)**: Build MCP widget HTML before cargo compilation (#1300)
- **feat(notebook)**: "Install Extension for Claude" one-click menu item (#1301)
- **docs(mcpb)**: Enriched manifests with tool listing and descriptions (#1302)
- **fix(runt-mcp)**: Skip structured_content for empty outputs (#1303)

### Files bumped

- `crates/runtimed/Cargo.toml`
- `crates/runt/Cargo.toml`
- `crates/notebook/Cargo.toml`
- `crates/notebook/tauri.conf.json`
- `python/runtimed/pyproject.toml`
- `Cargo.lock`

## Test plan

- [ ] CI passes
- [ ] After merge: `git tag v2.0.5 && git push origin v2.0.5` triggers stable release