### PR TITLE
chore: bump all versions to 2.0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3696,7 +3696,7 @@ dependencies = [
 
 [[package]]
 name = "notebook"
-version = "2.0.5"
+version = "2.0.6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5966,7 +5966,7 @@ dependencies = [
 
 [[package]]
 name = "runt-cli"
-version = "2.0.5"
+version = "2.0.6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6044,7 +6044,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed"
-version = "2.0.5"
+version = "2.0.6"
 dependencies = [
  "alacritty_terminal",
  "anyhow",

--- a/contributing/releasing.md
+++ b/contributing/releasing.md
@@ -30,7 +30,7 @@ These are just incrementing integers. They evolve independently from each other 
 
 ## Bumping Versions
 
-All four version sources must stay in sync. When preparing a release:
+All six version sources must stay in sync. When preparing a release:
 
 ```bash
 # Update all of these to the same version:
@@ -39,6 +39,7 @@ All four version sources must stay in sync. When preparing a release:
 #   crates/notebook/Cargo.toml
 #   crates/notebook/tauri.conf.json
 #   python/runtimed/pyproject.toml
+#   python/nteract/pyproject.toml
 
 # Then let Cargo.lock catch up:
 cargo check

--- a/crates/notebook/Cargo.toml
+++ b/crates/notebook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notebook"
-version = "2.0.5"
+version = "2.0.6"
 edition.workspace = true
 description = "Tauri-based notebook UI for Jupyter kernels"
 repository.workspace = true

--- a/crates/notebook/tauri.conf.json
+++ b/crates/notebook/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "nteract",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "identifier": "org.nteract.desktop",
   "build": {
     "devUrl": "http://localhost:5174",

--- a/crates/runt/Cargo.toml
+++ b/crates/runt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runt-cli"
-version = "2.0.5"
+version = "2.0.6"
 edition.workspace = true
 description = "CLI for Jupyter Runtimes — bundled with nteract"
 repository.workspace = true

--- a/crates/runtimed/Cargo.toml
+++ b/crates/runtimed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed"
-version = "2.0.5"
+version = "2.0.6"
 edition.workspace = true
 description = "Central daemon for managing Jupyter runtimes and prewarmed environments"
 repository.workspace = true

--- a/python/nteract/pyproject.toml
+++ b/python/nteract/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nteract"
-version = "2.0.4"
+version = "2.0.5"
 description = "Bring AI to Jupyter notebooks. MCP server for Claude, ChatGPT, Gemini, OpenCode and any agent."
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/python/nteract/pyproject.toml
+++ b/python/nteract/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nteract"
-version = "2.0.5"
+version = "2.0.6"
 description = "Bring AI to Jupyter notebooks. MCP server for Claude, ChatGPT, Gemini, OpenCode and any agent."
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/python/runtimed/pyproject.toml
+++ b/python/runtimed/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "runtimed"
-version = "2.0.5"
+version = "2.0.6"
 description = "Python toolkit for Jupyter runtimes, powered by runtimed Rust binaries"
 readme = "README.md"
 license = "BSD-3-Clause"


### PR DESCRIPTION
## Summary

Bumps all six version sources to `2.0.6` for a clean stable release. The `v2.0.5` stable release partially failed because `python/nteract/pyproject.toml` was missed in the version bump — it was still at `2.0.4`, causing a PyPI upload conflict.

Also adds `python/nteract/pyproject.toml` to the version bump checklist in `contributing/releasing.md` so this doesn't happen again.

### Files bumped (2.0.5 → 2.0.6)

- `crates/runtimed/Cargo.toml`
- `crates/runt/Cargo.toml`
- `crates/notebook/Cargo.toml`
- `crates/notebook/tauri.conf.json`
- `python/runtimed/pyproject.toml`
- `python/nteract/pyproject.toml`

## After merge

1. Nightly to verify
2. `git tag v2.0.6 && git push origin v2.0.6` for stable