### PR TITLE
fix(mcp-app): remove 'No output' placeholder from widget

### DIFF
--- a/apps/mcp-app/src/mcp-app.ts
+++ b/apps/mcp-app/src/mcp-app.ts
@@ -145,9 +145,25 @@ function render(data: NteractContent) {
   root.innerHTML = "";
   const cells = data.cells || (data.cell ? [data.cell] : []);
   if (cells.length === 0) {
-    root.innerHTML = '<div class="empty-state">No output</div>';
+    // No cell data — hide the widget entirely (no "No output" placeholder)
     return;
   }
+
+  // Check if any cell has actual outputs to display
+  const hasOutputs = cells.some(c => c.outputs?.length > 0);
+  if (!hasOutputs) {
+    // Cells exist but no outputs (e.g., import statements, assignments).
+    // Show a minimal status indicator instead of the noisy "No output" box.
+    const status = cells[0]?.status;
+    if (status === "error") {
+      root.innerHTML = '<div class="status-indicator status-error">✗ Error</div>';
+    } else if (status === "running") {
+      root.innerHTML = '<div class="status-indicator status-running">◐ Running…</div>';
+    }
+    // For "idle" with no outputs, show nothing — clean and quiet.
+    return;
+  }
+
   for (const cell of cells) {
     root.appendChild(renderCell(cell));
   }
@@ -159,7 +175,8 @@ const app = new App({ name: "nteract", version: "0.1.0" });
 
 app.ontoolresult = (result: CallToolResult) => {
   const content = result.structuredContent as NteractContent | undefined;
-  render(content ?? {});
+  if (!content) return; // No structured content — don't render anything
+  render(content);
 };
 
 app.onhostcontextchanged = (ctx: McpUiHostContext) => {

--- a/apps/mcp-app/src/style.css
+++ b/apps/mcp-app/src/style.css
@@ -136,8 +136,17 @@ body {
   color: var(--fg-muted);
 }
 
-.empty-state {
+.status-indicator {
   text-align: center;
-  padding: 24px;
+  padding: 8px;
+  font-size: 13px;
+  color: var(--fg-muted);
+}
+
+.status-error {
+  color: var(--error-fg);
+}
+
+.status-running {
   color: var(--fg-muted);
 }


### PR DESCRIPTION
## Summary

The MCP Apps widget was showing a noisy "No output" box for cells with no outputs (create_cell, import statements, assignments). Now:

- **No structured_content** → widget stays blank (no render call at all)
- **Cell with empty outputs + idle** → nothing shown (clean, quiet)
- **Cell with error status** → shows "✗ Error"
- **Cell with running status** → shows "◐ Running…"
- **Cell with actual outputs** → renders normally

Fixes the UX for both the Rust (`runt mcp`) and Python (`uv run nteract`) MCP servers.

## Test plan

- [ ] `create_cell` without `and_run` → no widget box
- [ ] `execute_cell` with `import numpy` → no widget box
- [ ] `execute_cell` with `print("hi")` → widget renders output
- [ ] `execute_cell` with error → widget shows error output
- [ ] CI passes