### PR TITLE
fix(runt-mcp): correct tool annotations for all 26 tools

### DIFF
--- a/crates/runt-mcp/src/tools/mod.rs
+++ b/crates/runt-mcp/src/tools/mod.rs
@@ -81,7 +81,7 @@ pub fn all_tools() -> Vec<Tool> {
             ToolAnnotations::new()
                 .destructive(false)
                 .idempotent(true)
-                .open_world(false),
+                .open_world(true),
         ),
         Tool::new(
             "create_notebook",
@@ -98,7 +98,7 @@ pub fn all_tools() -> Vec<Tool> {
             ToolAnnotations::new()
                 .destructive(false)
                 .idempotent(true)
-                .open_world(false),
+                .open_world(true),
         ),
         // -- Cell read --
         Tool::new(
@@ -207,14 +207,14 @@ pub fn all_tools() -> Vec<Tool> {
             "Execute a cell. Returns partial results if timeout exceeded.",
             schema_for::<execution::ExecuteCellParams>(),
         )
-        .annotate(ToolAnnotations::new().destructive(false).open_world(true))
+        .annotate(ToolAnnotations::new().destructive(true).open_world(true))
         .with_meta(app_tool_meta()),
         Tool::new(
             "run_all_cells",
             "Queue all code cells for execution. Use get_all_cells() to see results.",
             schema_for::<EmptyParams>(),
         )
-        .annotate(ToolAnnotations::new().destructive(false).open_world(true)),
+        .annotate(ToolAnnotations::new().destructive(true).open_world(true)),
         // -- Kernel --
         Tool::new(
             "interrupt_kernel",

--- a/crates/runt-mcp/src/tools/mod.rs
+++ b/crates/runt-mcp/src/tools/mod.rs
@@ -45,6 +45,13 @@ fn schema_for<T: JsonSchema>() -> Arc<serde_json::Map<String, serde_json::Value>
 struct EmptyParams {}
 
 /// Return all registered tools.
+///
+/// Annotation semantics (from MCP spec):
+/// - `read_only` — tool does not modify its environment
+/// - `destructive` — tool may perform destructive (irreversible) updates
+///   (only meaningful when read_only is false)
+/// - `idempotent` — calling repeatedly with the same args has no additional effect
+/// - `open_world` — tool interacts with external entities beyond the notebook
 pub fn all_tools() -> Vec<Tool> {
     vec![
         // -- Session management --
@@ -53,168 +60,228 @@ pub fn all_tools() -> Vec<Tool> {
             "List all open notebook sessions. Returns notebooks currently open by users or other agents. Use join_notebook(notebook_id) to connect to one.",
             schema_for::<EmptyParams>(),
         )
-        .annotate(ToolAnnotations::new().read_only(true)),
+        .annotate(ToolAnnotations::new().read_only(true).open_world(false)),
         Tool::new(
             "join_notebook",
             "Connect to an existing notebook session by ID. The notebook_id comes from list_active_notebooks.",
             schema_for::<session::JoinNotebookParams>(),
         )
-        .annotate(ToolAnnotations::new().destructive(false)),
+        .annotate(
+            ToolAnnotations::new()
+                .destructive(false)
+                .idempotent(true)
+                .open_world(false),
+        ),
         Tool::new(
             "open_notebook",
             "Open a notebook file from disk. Creates a session and connects to it.",
             schema_for::<session::OpenNotebookParams>(),
         )
-        .annotate(ToolAnnotations::new().destructive(false)),
+        .annotate(
+            ToolAnnotations::new()
+                .destructive(false)
+                .idempotent(true)
+                .open_world(false),
+        ),
         Tool::new(
             "create_notebook",
             "Create a new notebook with optional pre-installed dependencies. The kernel starts automatically. Call save_notebook(path) to persist to disk.",
             schema_for::<session::CreateNotebookParams>(),
         )
-        .annotate(ToolAnnotations::new().destructive(false)),
+        .annotate(ToolAnnotations::new().destructive(false).open_world(false)),
         Tool::new(
             "save_notebook",
             "Save notebook to disk. The daemon automatically re-keys ephemeral rooms to the saved file path.",
             schema_for::<session::SaveNotebookParams>(),
         )
-        .annotate(ToolAnnotations::new().destructive(false)),
+        .annotate(
+            ToolAnnotations::new()
+                .destructive(false)
+                .idempotent(true)
+                .open_world(false),
+        ),
         // -- Cell read --
         Tool::new(
             "get_cell",
             "Get a cell's source and outputs by ID.",
             schema_for::<cell_read::GetCellParams>(),
         )
-        .annotate(ToolAnnotations::new().read_only(true)),
+        .annotate(ToolAnnotations::new().read_only(true).open_world(false)),
         Tool::new(
             "get_all_cells",
             "Get all cells. Use summary (default) for discovery, get_cell() for details. Formats: 'summary', 'json', 'rich'.",
             schema_for::<cell_read::GetAllCellsParams>(),
         )
-        .annotate(ToolAnnotations::new().read_only(true)),
+        .annotate(ToolAnnotations::new().read_only(true).open_world(false)),
         // -- Cell CRUD --
         Tool::new(
             "create_cell",
             "Create a cell, optionally executing it.",
             schema_for::<cell_crud::CreateCellParams>(),
         )
-        .annotate(ToolAnnotations::new().destructive(false))
+        .annotate(ToolAnnotations::new().destructive(false).open_world(false))
         .with_meta(app_tool_meta()),
         Tool::new(
             "set_cell",
             "Update a cell's source and/or type. Use replace_match for targeted edits.",
             schema_for::<cell_crud::SetCellParams>(),
         )
-        .annotate(ToolAnnotations::new().destructive(true))
+        .annotate(ToolAnnotations::new().destructive(false).open_world(false))
         .with_meta(app_tool_meta()),
         Tool::new(
             "delete_cell",
             "Delete a cell by ID.",
             schema_for::<cell_crud::DeleteCellParams>(),
         )
-        .annotate(ToolAnnotations::new().destructive(true)),
+        .annotate(ToolAnnotations::new().destructive(true).open_world(false)),
         Tool::new(
             "move_cell",
             "Move a cell to a new position.",
             schema_for::<cell_crud::MoveCellParams>(),
         )
-        .annotate(ToolAnnotations::new().destructive(true)),
+        .annotate(
+            ToolAnnotations::new()
+                .destructive(false)
+                .idempotent(true)
+                .open_world(false),
+        ),
         Tool::new(
             "clear_outputs",
             "Clear a cell's outputs.",
             schema_for::<cell_crud::ClearOutputsParams>(),
         )
-        .annotate(ToolAnnotations::new().destructive(true)),
+        .annotate(
+            ToolAnnotations::new()
+                .destructive(true)
+                .idempotent(true)
+                .open_world(false),
+        ),
         // -- Cell metadata --
         Tool::new(
             "add_cell_tags",
             "Add tags to a cell's metadata. Existing tags are preserved.",
             schema_for::<cell_meta::AddCellTagsParams>(),
         )
-        .annotate(ToolAnnotations::new().destructive(true)),
+        .annotate(
+            ToolAnnotations::new()
+                .destructive(false)
+                .idempotent(true)
+                .open_world(false),
+        ),
         Tool::new(
             "remove_cell_tags",
             "Remove tags from a cell's metadata.",
             schema_for::<cell_meta::RemoveCellTagsParams>(),
         )
-        .annotate(ToolAnnotations::new().destructive(true)),
+        .annotate(
+            ToolAnnotations::new()
+                .destructive(true)
+                .idempotent(true)
+                .open_world(false),
+        ),
         Tool::new(
             "set_cells_source_hidden",
             "Hide or show the source (code input) of one or more cells.",
             schema_for::<cell_meta::SetCellsSourceHiddenParams>(),
         )
-        .annotate(ToolAnnotations::new().destructive(true)),
+        .annotate(
+            ToolAnnotations::new()
+                .destructive(false)
+                .idempotent(true)
+                .open_world(false),
+        ),
         Tool::new(
             "set_cells_outputs_hidden",
             "Hide or show the outputs of one or more cells.",
             schema_for::<cell_meta::SetCellsOutputsHiddenParams>(),
         )
-        .annotate(ToolAnnotations::new().destructive(true)),
+        .annotate(
+            ToolAnnotations::new()
+                .destructive(false)
+                .idempotent(true)
+                .open_world(false),
+        ),
         // -- Execution --
         Tool::new(
             "execute_cell",
             "Execute a cell. Returns partial results if timeout exceeded.",
             schema_for::<execution::ExecuteCellParams>(),
         )
-        .annotate(ToolAnnotations::new().destructive(true))
+        .annotate(ToolAnnotations::new().destructive(false).open_world(true))
         .with_meta(app_tool_meta()),
         Tool::new(
             "run_all_cells",
             "Queue all code cells for execution. Use get_all_cells() to see results.",
             schema_for::<EmptyParams>(),
         )
-        .annotate(ToolAnnotations::new().destructive(true)),
+        .annotate(ToolAnnotations::new().destructive(false).open_world(true)),
         // -- Kernel --
         Tool::new(
             "interrupt_kernel",
             "Interrupt the currently executing cell.",
             schema_for::<EmptyParams>(),
         )
-        .annotate(ToolAnnotations::new().destructive(true)),
+        .annotate(
+            ToolAnnotations::new()
+                .destructive(true)
+                .idempotent(true)
+                .open_world(false),
+        ),
         Tool::new(
             "restart_kernel",
             "Restart kernel, clearing all state. Use after dependency changes.",
             schema_for::<EmptyParams>(),
         )
-        .annotate(ToolAnnotations::new().destructive(true)),
+        .annotate(ToolAnnotations::new().destructive(true).open_world(false)),
         // -- Dependencies --
         Tool::new(
             "add_dependency",
             "Add a package dependency (e.g. 'pandas>=2.0'). Call sync_environment() to install.",
             schema_for::<deps::AddDependencyParams>(),
         )
-        .annotate(ToolAnnotations::new().destructive(true)),
+        .annotate(
+            ToolAnnotations::new()
+                .destructive(false)
+                .idempotent(true)
+                .open_world(false),
+        ),
         Tool::new(
             "remove_dependency",
             "Remove a package dependency. Requires restart_kernel() to take effect.",
             schema_for::<deps::RemoveDependencyParams>(),
         )
-        .annotate(ToolAnnotations::new().destructive(true)),
+        .annotate(
+            ToolAnnotations::new()
+                .destructive(true)
+                .idempotent(true)
+                .open_world(false),
+        ),
         Tool::new(
             "get_dependencies",
             "Get the notebook's current package dependencies.",
             schema_for::<deps::GetDependenciesParams>(),
         )
-        .annotate(ToolAnnotations::new().read_only(true)),
+        .annotate(ToolAnnotations::new().read_only(true).open_world(false)),
         Tool::new(
             "sync_environment",
             "Hot-install new dependencies without restarting. Use restart_kernel() if this fails.",
             schema_for::<EmptyParams>(),
         )
-        .annotate(ToolAnnotations::new().destructive(true)),
+        .annotate(ToolAnnotations::new().destructive(false).open_world(true)),
         // -- Editing --
         Tool::new(
             "replace_match",
             "Replace matched text in a cell. Prefer this for simple, targeted edits. Use context_before/context_after to disambiguate when match appears multiple times.",
             schema_for::<editing::ReplaceMatchParams>(),
         )
-        .annotate(ToolAnnotations::new().destructive(true))
+        .annotate(ToolAnnotations::new().destructive(false).open_world(false))
         .with_meta(app_tool_meta()),
         Tool::new(
             "replace_regex",
             "Replace a regex-matched span. Use for anchors, lookarounds, or zero-width insertions. Fails if 0 or >1 matches.",
             schema_for::<editing::ReplaceRegexParams>(),
         )
-        .annotate(ToolAnnotations::new().destructive(true))
+        .annotate(ToolAnnotations::new().destructive(false).open_world(false))
         .with_meta(app_tool_meta()),
     ]
 }


### PR DESCRIPTION
## Summary

Most tools were incorrectly marked as `destructive: true`. Per the MCP spec, `destructiveHint` means "may perform irreversible updates to its environment." Updated all 26 tools with accurate `readOnlyHint`, `destructiveHint`, `idempotentHint`, and `openWorldHint` annotations.

### Annotation breakdown

| Category | Tools | Annotations |
|----------|-------|-------------|
| **Read-only** | list_active_notebooks, get_cell, get_all_cells, get_dependencies | `readOnly: true` |
| **Destructive** | delete_cell, clear_outputs, remove_cell_tags, interrupt_kernel, restart_kernel, remove_dependency | `destructive: true` (irreversible) |
| **Non-destructive writes** | create_cell, set_cell, move_cell, save_notebook, replace_match, replace_regex, add_cell_tags, set_cells_*_hidden, add_dependency, sync_environment, execute_cell, run_all_cells | `destructive: false` (additive/modifying) |
| **Idempotent** | join/open_notebook, save_notebook, move_cell, clear_outputs, add/remove tags, set_*_hidden, add/remove_dependency, interrupt_kernel | `idempotent: true` |
| **Open world** | execute_cell, run_all_cells, sync_environment | `openWorld: true` (may access network) |

## Test plan

- [ ] CI passes
- [ ] `tools/list` response includes correct annotations for each tool