### PR TITLE
fix(runtimed): downgrade cell error log from warn to debug

### DIFF
--- a/.claude/rules/mcp-servers.md
+++ b/.claude/rules/mcp-servers.md
@@ -33,14 +33,16 @@ The Rust server (`runt-mcp`) uses direct Automerge access via `DocHandle` for mi
 
 When running CLI commands against system-installed daemons from a dev environment, **always use `env -i`** to strip dev env vars (`RUNTIMED_DEV`, `RUNTIMED_WORKSPACE_PATH`) that would otherwise redirect commands to the per-worktree dev daemon:
 
+**Important:** The repo's `bin/runt` (added to PATH by direnv) shadows `/usr/local/bin/runt` and always resolves to the dev build (nightly channel). When targeting system-installed daemons, use absolute paths:
+
 ```bash
 # Nightly system daemon
-env -i PATH="$PATH" HOME="$HOME" runt-nightly diagnostics
-env -i PATH="$PATH" HOME="$HOME" runt-nightly daemon status
+env -i PATH="$PATH" HOME="$HOME" /usr/local/bin/runt-nightly diagnostics
+env -i PATH="$PATH" HOME="$HOME" /usr/local/bin/runt-nightly daemon status
 
 # Stable system daemon
-env -i PATH="$PATH" HOME="$HOME" runt diagnostics
-env -i PATH="$PATH" HOME="$HOME" runt daemon status
+env -i PATH="$PATH" HOME="$HOME" /usr/local/bin/runt diagnostics
+env -i PATH="$PATH" HOME="$HOME" /usr/local/bin/runt daemon status
 ```
 
 For the dev daemon, use `./target/debug/runt` directly (no `env -i` needed — dev env vars are correct).

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -2782,8 +2782,8 @@ async fn auto_launch_kernel(
                                 cell_id,
                                 execution_id,
                             } => {
-                                warn!(
-                                    "[notebook-sync] Cell error (stop-on-error): {} ({})",
+                                debug!(
+                                    "[notebook-sync] User code error, halting queue (stop-on-error): cell={} execution={}",
                                     cell_id, execution_id
                                 );
                                 apply_cell_error_to_state_doc(
@@ -3549,8 +3549,8 @@ async fn handle_notebook_request(
                                         cell_id,
                                         execution_id,
                                     } => {
-                                        warn!(
-                                            "[notebook-sync] Cell error (stop-on-error): {} ({})",
+                                        debug!(
+                                            "[notebook-sync] User code error, halting queue (stop-on-error): cell={} execution={}",
                                             cell_id, execution_id
                                         );
                                         apply_cell_error_to_state_doc(

--- a/python/nteract/src/nteract/_mcp_server.py
+++ b/python/nteract/src/nteract/_mcp_server.py
@@ -28,7 +28,7 @@ from typing import Annotated, Any, Literal, NoReturn
 
 from fastmcp import Context, FastMCP
 from fastmcp.server.apps import AppConfig, ResourceCSP
-from fastmcp.tools.tool import ToolResult
+from fastmcp.tools import ToolResult
 from mcp.types import TextContent, ToolAnnotations
 from pydantic import Field
 

--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -34,6 +34,7 @@ import pytest
 pytest.importorskip("runtimed")
 
 import runtimed
+import runtimed._internals
 
 # ============================================================================
 # Test utilities


### PR DESCRIPTION
## Summary

- Downgrade `CellError` (stop-on-error) log from `warn!` to `debug!` — these are user code errors, not daemon problems. On stable (default level: `warn`), they were the only log entries, making it look like something was wrong with the daemon.
- Reword the message to say "User code error, halting queue" so the intent is clear.
- Update `.claude/rules/mcp-servers.md` to use absolute paths for system CLI binaries, since `bin/runt` (via direnv) shadows `/usr/local/bin/runt`.

Related: #1310 (torn notebook bug filed separately)

## Test plan

- [ ] `cargo check -p runtimed` passes
- [ ] Execute a cell with a runtime error — verify no `warn` in stable logs
- [ ] With `RUST_LOG=debug`, verify the message appears at debug level