### PR TITLE
fix(runt-mcp): use dynamic peer label in presence updates

### DIFF
--- a/crates/runt-mcp/src/presence.rs
+++ b/crates/runt-mcp/src/presence.rs
@@ -7,16 +7,20 @@
 use notebook_doc::presence::{self, CursorPosition};
 use notebook_sync::handle::DocHandle;
 
-/// Peer label shown in the frontend presence UI.
-const PEER_LABEL: &str = "Agent";
-
 /// Emit a cursor position (line, column in a cell).
 ///
 /// Shows a blinking cursor in the notebook app at the specified position.
-pub async fn emit_cursor(handle: &DocHandle, cell_id: &str, line: u32, column: u32) {
+/// `peer_label` is the MCP client's display name (e.g. "Claude Code").
+pub async fn emit_cursor(
+    handle: &DocHandle,
+    cell_id: &str,
+    line: u32,
+    column: u32,
+    peer_label: &str,
+) {
     let data = presence::encode_cursor_update_labeled(
         "local",
-        Some(PEER_LABEL),
+        Some(peer_label),
         &CursorPosition {
             cell_id: cell_id.to_string(),
             line,
@@ -29,8 +33,22 @@ pub async fn emit_cursor(handle: &DocHandle, cell_id: &str, line: u32, column: u
 /// Emit a cell focus (agent is working on this cell, no specific cursor).
 ///
 /// Shows a presence dot on the cell without a blinking cursor.
-pub async fn emit_focus(handle: &DocHandle, cell_id: &str) {
-    let data = presence::encode_focus_update_labeled("local", Some(PEER_LABEL), cell_id);
+/// `peer_label` is the MCP client's display name (e.g. "Claude Code").
+pub async fn emit_focus(handle: &DocHandle, cell_id: &str, peer_label: &str) {
+    let data = presence::encode_focus_update_labeled("local", Some(peer_label), cell_id);
+    let _ = handle.send_presence(data).await;
+}
+
+/// Announce presence immediately after connecting to a notebook.
+///
+/// Without this, the peer is invisible in the presence UI until it performs
+/// an action that emits presence (e.g. editing a cell).
+pub async fn announce(handle: &DocHandle, peer_label: &str) {
+    let data = if let Some(cell_id) = handle.first_cell_id() {
+        presence::encode_focus_update_labeled("local", Some(peer_label), &cell_id)
+    } else {
+        presence::encode_custom_update_labeled("local", Some(peer_label), &[])
+    };
     let _ = handle.send_presence(data).await;
 }
 

--- a/crates/runt-mcp/src/tools/cell_crud.rs
+++ b/crates/runt-mcp/src/tools/cell_crud.rs
@@ -140,8 +140,9 @@ pub async fn create_cell(
     let _ = handle.confirm_sync().await;
 
     // Cursor at end of source (shows "finished typing")
+    let peer_label = server.get_peer_label().await;
     let (end_line, end_col) = crate::presence::offset_to_line_col(source, source.len());
-    crate::presence::emit_cursor(handle, &cell_id, end_line, end_col).await;
+    crate::presence::emit_cursor(handle, &cell_id, end_line, end_col, &peer_label).await;
 
     if and_run && cell_type == "code" {
         let result = execution::execute_and_wait(
@@ -214,8 +215,9 @@ pub async fn set_cell(
         let _ = handle.confirm_sync().await;
 
         // Cursor at end of new source
+        let peer_label = server.get_peer_label().await;
         let (end_line, end_col) = crate::presence::offset_to_line_col(src, src.len());
-        crate::presence::emit_cursor(handle, cell_id, end_line, end_col).await;
+        crate::presence::emit_cursor(handle, cell_id, end_line, end_col, &peer_label).await;
     }
     if let Some(ct) = cell_type {
         handle
@@ -258,7 +260,8 @@ pub async fn delete_cell(
         }
     };
 
-    crate::presence::emit_focus(&session.handle, cell_id).await;
+    let peer_label = server.get_peer_label().await;
+    crate::presence::emit_focus(&session.handle, cell_id, &peer_label).await;
 
     let deleted = session
         .handle
@@ -298,7 +301,8 @@ pub async fn move_cell(
         .move_cell(cell_id, after_cell_id)
         .map_err(|e| McpError::internal_error(format!("Failed to move cell: {e}"), None))?;
 
-    crate::presence::emit_focus(&session.handle, cell_id).await;
+    let peer_label = server.get_peer_label().await;
+    crate::presence::emit_focus(&session.handle, cell_id, &peer_label).await;
 
     let result = serde_json::json!({
         "cell_id": cell_id,
@@ -326,7 +330,8 @@ pub async fn clear_outputs(
         }
     };
 
-    crate::presence::emit_focus(&session.handle, cell_id).await;
+    let peer_label = server.get_peer_label().await;
+    crate::presence::emit_focus(&session.handle, cell_id, &peer_label).await;
 
     let cleared = session
         .handle

--- a/crates/runt-mcp/src/tools/editing.rs
+++ b/crates/runt-mcp/src/tools/editing.rs
@@ -125,7 +125,8 @@ pub async fn replace_match(
     let new_source = crate::editing::apply_replacement(&source, &span, content);
     let end_offset = span.start + content.len();
     let (line, col) = crate::presence::offset_to_line_col(&new_source, end_offset);
-    crate::presence::emit_cursor(handle, cell_id, line, col).await;
+    let peer_label = server.get_peer_label().await;
+    crate::presence::emit_cursor(handle, cell_id, line, col, &peer_label).await;
 
     if and_run {
         let result = execution::execute_and_wait(
@@ -211,7 +212,8 @@ pub async fn replace_regex(
     let new_source = crate::editing::apply_replacement(&source, &span, content);
     let end_offset = span.start + content.len();
     let (line, col) = crate::presence::offset_to_line_col(&new_source, end_offset);
-    crate::presence::emit_cursor(handle, cell_id, line, col).await;
+    let peer_label = server.get_peer_label().await;
+    crate::presence::emit_cursor(handle, cell_id, line, col, &peer_label).await;
 
     if and_run {
         let result = execution::execute_and_wait(

--- a/crates/runt-mcp/src/tools/execution.rs
+++ b/crates/runt-mcp/src/tools/execution.rs
@@ -62,7 +62,8 @@ pub async fn execute_cell(
         return tool_error(&format!("Cell not found: {cell_id}"));
     }
 
-    crate::presence::emit_focus(handle, cell_id).await;
+    let peer_label = server.get_peer_label().await;
+    crate::presence::emit_focus(handle, cell_id, &peer_label).await;
 
     let result = execution::execute_and_wait(
         handle,

--- a/crates/runt-mcp/src/tools/session.rs
+++ b/crates/runt-mcp/src/tools/session.rs
@@ -203,6 +203,10 @@ pub async fn join_notebook(
                 "cells": cells_summary,
             });
 
+            // Announce presence so the peer is visible immediately
+            let peer_label = server.get_peer_label().await;
+            crate::presence::announce(handle, &peer_label).await;
+
             let session = NotebookSession {
                 handle: result.handle,
                 notebook_id,
@@ -259,6 +263,10 @@ pub async fn open_notebook(
                 "cells": cells_summary,
             });
 
+            // Announce presence so the peer is visible immediately
+            let peer_label = server.get_peer_label().await;
+            crate::presence::announce(handle, &peer_label).await;
+
             let session = NotebookSession {
                 handle: result.handle,
                 notebook_id,
@@ -291,6 +299,11 @@ pub async fn create_notebook(
     {
         Ok(result) => {
             let notebook_id = result.handle.notebook_id().to_string();
+
+            // Announce presence so the peer is visible immediately
+            let peer_label = server.get_peer_label().await;
+            crate::presence::announce(&result.handle, &peer_label).await;
+
             // Add dependencies if specified
             let deps: Vec<String> = request
                 .arguments


### PR DESCRIPTION
## Summary

The Rust MCP server (`runt mcp`) always showed "Agent" as the peer label in the notebook presence UI, even after #1309 added MCP client name sniffing. The sniffed name was correctly passed as the Automerge `actor_label` during connect, but the **presence module** that emits cursor/focus updates during cell operations still used a hardcoded `const PEER_LABEL: &str = "Agent"`.

- Remove hardcoded `PEER_LABEL` constant from `presence.rs`; `emit_cursor()` and `emit_focus()` now accept a dynamic `peer_label` parameter
- Thread `server.get_peer_label().await` through all 8 presence call sites in `cell_crud`, `editing`, and `execution` tools
- Add `presence::announce()` to emit an initial presence update after `join_notebook`, `open_notebook`, and `create_notebook` — matching the Python server's `announce_presence()` so the peer is visible immediately upon connecting

## Verification

- [ ] Open a notebook in the app, then connect via `runt mcp` (e.g. through Claude Code or another MCP client)
- [ ] Verify the presence indicator shows the MCP client's name (e.g. "Claude Code") instead of "Agent"
- [ ] Verify the presence dot appears immediately after joining (not only after the first cell edit)
- [ ] Edit a cell via MCP and confirm cursor presence still shows the correct label

_PR submitted by @rgbkrk's agent, Quill_