### PR TITLE
feat(runt-mcp): add show_notebook tool

### DIFF
--- a/crates/runt-mcp/src/tools/mod.rs
+++ b/crates/runt-mcp/src/tools/mod.rs
@@ -100,6 +100,12 @@ pub fn all_tools() -> Vec<Tool> {
                 .idempotent(true)
                 .open_world(true),
         ),
+        Tool::new(
+            "show_notebook",
+            "Open the notebook in the nteract desktop app. The notebook must be running in the daemon.",
+            schema_for::<session::ShowNotebookParams>(),
+        )
+        .annotate(ToolAnnotations::new().read_only(true).open_world(false)),
         // -- Cell read --
         Tool::new(
             "get_cell",
@@ -298,6 +304,7 @@ pub async fn dispatch(
         "open_notebook" => session::open_notebook(server, request).await,
         "create_notebook" => session::create_notebook(server, request).await,
         "save_notebook" => session::save_notebook(server, request).await,
+        "show_notebook" => session::show_notebook(server, request).await,
         // Cell read
         "get_cell" => cell_read::get_cell(server, request).await,
         "get_all_cells" => cell_read::get_all_cells(server, request).await,

--- a/crates/runt-mcp/src/tools/session.rs
+++ b/crates/runt-mcp/src/tools/session.rs
@@ -145,6 +145,14 @@ pub struct CreateNotebookParams {
 
 #[allow(dead_code)]
 #[derive(Debug, Deserialize, JsonSchema)]
+pub struct ShowNotebookParams {
+    /// Notebook ID to show. Defaults to current session's notebook.
+    #[serde(default)]
+    pub notebook_id: Option<String>,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize, JsonSchema)]
 pub struct SaveNotebookParams {
     /// Path to save the notebook to. If None, saves to original location.
     #[serde(default)]
@@ -428,4 +436,60 @@ pub async fn save_notebook(
         Ok(resp) => tool_error(&format!("Unexpected response: {resp:?}")),
         Err(e) => tool_error(&format!("Failed to save notebook: {e}")),
     }
+}
+
+/// Open the notebook in the nteract desktop app.
+pub async fn show_notebook(
+    server: &NteractMcp,
+    request: &CallToolRequestParams,
+) -> Result<CallToolResult, McpError> {
+    // Resolve notebook_id from param or current session
+    let target = match arg_str(request, "notebook_id") {
+        Some(id) => id.to_string(),
+        None => {
+            let session = server.session.read().await;
+            match session.as_ref() {
+                Some(s) => s.notebook_id.clone(),
+                None => {
+                    return tool_error(
+                        "No notebook_id provided and no active session. \
+                         Use list_active_notebooks() to find a notebook_id, \
+                         or connect to one first.",
+                    )
+                }
+            }
+        }
+    };
+
+    // Validate notebook is active in daemon
+    let client = PoolClient::new(server.socket_path.clone());
+    let rooms = client
+        .list_rooms()
+        .await
+        .map_err(|e| McpError::internal_error(format!("Failed to list notebooks: {e}"), None))?;
+    if !rooms.iter().any(|r| r.notebook_id == target) {
+        return tool_error(&format!(
+            "Notebook '{}' is not currently running. \
+             Use list_active_notebooks() to see active notebooks.",
+            target
+        ));
+    }
+
+    // Validate it's a file-backed notebook (absolute path)
+    if !std::path::Path::new(&target).is_absolute() {
+        return tool_error(&format!(
+            "Notebook '{}' is an untitled notebook (not saved to disk). \
+             Use save_notebook(path) first, then call show_notebook().",
+            target
+        ));
+    }
+
+    // Launch the app using the binary's build channel.
+    // NOTE: If RUNTIMED_SOCKET_PATH points at a different channel's daemon,
+    // this may open the wrong app. That's a known dev-only edge case.
+    runt_workspace::open_notebook_app(Some(std::path::Path::new(&target)), &[])
+        .map_err(|e| McpError::internal_error(format!("Failed to open app: {e}"), None))?;
+
+    let result = serde_json::json!({ "notebook_id": target, "opened": true });
+    tool_success(&serde_json::to_string_pretty(&result).unwrap_or_default())
 }


### PR DESCRIPTION
## Summary

Adds `show_notebook` to the Rust MCP server (`runt mcp`), bringing it to 27 tools — matching the Python nteract MCP server. The tool opens a notebook in the nteract desktop app after validating it's active in the daemon and saved to disk.

- Accepts optional `notebook_id` param, defaulting to the current session's notebook
- Validates the notebook is running in the daemon and is file-backed (not untitled)
- Launches the desktop app via `runt_workspace::open_notebook_app`

## Verification

- [ ] `runt mcp` lists 27 tools (was 26)
- [ ] `show_notebook` with an active file-backed notebook opens the desktop app
- [ ] `show_notebook` with no session and no `notebook_id` returns an error
- [ ] `show_notebook` with an untitled notebook returns an error prompting `save_notebook` first

_PR submitted by @rgbkrk's agent, Quill_