### PR TITLE
docs: recommend runt mcp, make Python nteract a thin launcher

### DIFF
--- a/.claude/skills/python-bindings/SKILL.md
+++ b/.claude/skills/python-bindings/SKILL.md
@@ -9,7 +9,7 @@ description: Build, test, and develop Python bindings (runtimed-py, nteract MCP 
 
 | Venv | Path | Purpose | Used by |
 |------|------|---------|---------|
-| Workspace venv | `.venv` (repo root) | Day-to-day dev, MCP server | `uv run nteract`, gremlin agent |
+| Workspace venv | `.venv` (repo root) | Day-to-day dev | `uv run nteract`, gremlin agent |
 | Test venv | `python/runtimed/.venv` | Isolated pytest runs | `pytest` integration tests |
 
 ## Installation
@@ -176,13 +176,16 @@ SKIP_INTEGRATION_TESTS=1 python/runtimed/.venv/bin/python -m pytest python/runti
 
 ## MCP Server
 
-The nteract MCP server (`python/nteract/`) provides programmatic notebook interaction for AI agents.
+The MCP server ships as `runt mcp` (Rust). The Python `nteract` package is a convenience wrapper that finds and launches it.
 
 ```bash
-# Run directly (after uv sync + maturin develop)
+# Run directly (shipped with the desktop app)
+runt mcp
+
+# Or via the Python wrapper
 uv run nteract
 
-# Via nteract-dev supervisor (recommended, handles lifecycle)
+# Via nteract-dev supervisor (recommended for development, handles lifecycle)
 cargo xtask run-mcp
 ```
 
@@ -203,7 +206,7 @@ Three packages are workspace members:
 | Package | Path | Purpose |
 |---------|------|---------|
 | `runtimed` | `python/runtimed` | Python bindings (PyO3/maturin) |
-| `nteract` | `python/nteract` | MCP server |
+| `nteract` | `python/nteract` | MCP server convenience wrapper (launches `runt mcp`) |
 | `gremlin` | `python/gremlin` | Autonomous notebook stress tester |
 
 ## Troubleshooting

--- a/.codex/skills/nteract-python-bindings/SKILL.md
+++ b/.codex/skills/nteract-python-bindings/SKILL.md
@@ -17,7 +17,7 @@ Use this skill when Python behavior depends on both Rust extension state and dae
 
 ## Core Rules
 
-- Use `.venv` at the repo root for `uv run nteract`, MCP server work, and most day-to-day development.
+- Use `.venv` at the repo root for `uv run nteract` and most day-to-day development. The MCP server is `runt mcp` (Rust); the Python `nteract` package is a convenience wrapper.
 - Use `python/runtimed/.venv` for isolated pytest integration runs.
 - Set `VIRTUAL_ENV` explicitly when running `maturin develop`; otherwise it is easy to rebuild into the wrong venv.
 - If outputs, blobs, or notebook execution look wrong, verify `RUNTIMED_SOCKET_PATH` before assuming the bindings are broken.

--- a/.codex/skills/nteract-python-bindings/references/bindings-workflows.md
+++ b/.codex/skills/nteract-python-bindings/references/bindings-workflows.md
@@ -48,22 +48,17 @@ python/runtimed/.venv/bin/python -m pytest python/runtimed/tests/test_daemon_int
 
 ## Run the MCP server
 
-From the repo root:
+The MCP server is `runt mcp` (Rust, shipped with the desktop app). For development:
 
 ```bash
+# Using the built binary directly
+./target/debug/runt mcp
+
+# Or via the Python wrapper (finds and launches runt mcp)
 uv run nteract
 ```
 
 If the MCP supervisor is available, prefer `cargo xtask run-mcp` or the supervisor tools instead of a manual launch.
-
-Channel overrides for direct launches:
-
-```bash
-uv run nteract --nightly
-uv run nteract --stable
-```
-
-Those flags only set `RUNTIMED_SOCKET_PATH` when it is currently unset. If `cargo xtask dev-mcp`, `cargo xtask run-mcp`, or your shell already exported `RUNTIMED_SOCKET_PATH`, that explicit socket wins.
 
 Use `default_socket_path()` for current-process resolution. Use `socket_path_for_channel("stable"|"nightly")` only when you need an explicit channel path that ignores `RUNTIMED_SOCKET_PATH`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,11 +180,12 @@ The UV workspace root is the **repository root** — `pyproject.toml` and `.venv
 | Package | Path | Purpose |
 |---------|------|---------|
 | `runtimed` | `python/runtimed` | Python bindings for the Rust daemon (PyO3/maturin) |
-| `nteract` | `python/nteract` | MCP server for programmatic notebook interaction |
+| `nteract` | `python/nteract` | MCP server convenience wrapper (finds and launches `runt mcp`) |
 | `gremlin` | `python/gremlin` | Autonomous notebook agent for stress testing |
 
 ```bash
-uv run nteract  # Run MCP server from repo root
+runt mcp         # Run MCP server (shipped with the desktop app)
+uv run nteract   # Alternative: finds and launches runt mcp
 ```
 
 ### Stable vs Nightly

--- a/README.md
+++ b/README.md
@@ -10,11 +10,10 @@ Download the latest release from [GitHub Releases](https://github.com/nteract/de
 
 The desktop app bundles everything — `runt` CLI and `runtimed` daemon.
 
-The Python bindings and MCP server are available on PyPI:
+The Python bindings are available on PyPI:
 
 ```bash
 pip install runtimed
-pip install nteract
 ```
 
 ## What's in here
@@ -25,11 +24,11 @@ pip install nteract
 | `runtimed` | Background daemon — environment pools, notebook sync, kernel execution |
 | `runt` | CLI for managing kernels, notebooks, and the daemon |
 | `runtimed` (PyPI) | Python bindings for the daemon |
-| `nteract` (PyPI) | MCP server for AI agent integration with notebooks |
-
 ## MCP Server
 
 The nteract MCP server connects AI assistants to Jupyter notebooks through the daemon. Agents get 27 tools for working with notebooks — executing code, reading and writing cells, managing dependencies, and collaborating in real-time alongside humans in the desktop app.
+
+The MCP server ships with the desktop app as `runt mcp`.
 
 ### Quick Start
 
@@ -37,10 +36,10 @@ The nteract MCP server connects AI assistants to Jupyter notebooks through the d
 
 ```bash
 # Stable
-claude mcp add nteract -- uvx nteract
+claude mcp add nteract -- runt mcp
 
 # Nightly
-claude mcp add nteract-nightly -- uvx --prerelease allow nteract --nightly
+claude mcp add nteract-nightly -- runt-nightly mcp
 ```
 
 #### Manual JSON config
@@ -49,22 +48,20 @@ claude mcp add nteract-nightly -- uvx --prerelease allow nteract --nightly
 {
   "mcpServers": {
     "nteract": {
-      "command": "uvx",
-      "args": ["nteract"]
+      "command": "runt",
+      "args": ["mcp"]
     }
   }
 }
 ```
 
-### CLI Flags
+#### Via PyPI (convenience wrapper)
 
-| Flag | Description |
-|------|-------------|
-| `--nightly` | Connect to the nightly daemon and open nightly app |
-| `--stable` | Connect to the stable daemon and open stable app |
-| `--no-show` | Do not register the `show_notebook` tool (for headless environments) |
+If `runt` isn't on your PATH, the `nteract` PyPI package can find it in the app bundle:
 
-See [`python/nteract/`](python/nteract/) for the full tools reference, architecture, and development guide.
+```bash
+claude mcp add nteract -- uvx nteract
+```
 
 ## Usage
 

--- a/contributing/development.md
+++ b/contributing/development.md
@@ -299,19 +299,20 @@ The `VIRTUAL_ENV` override ensures the `.so` is installed into the workspace
 venv (where the MCP server runs), not into `python/runtimed/.venv` (the
 test-only venv).
 
-**Run the MCP server manually** (after `uv sync` + `maturin develop`):
+**Run the MCP server manually:**
 
 ```bash
-uv run nteract                     # from repo root
-uv run --directory . nteract       # equivalent, explicit
-```
+# Using the built runt binary (preferred)
+./target/debug/runt mcp
 
-For direct launches, `--stable` and `--nightly` are mutually exclusive channel overrides. They only set `RUNTIMED_SOCKET_PATH` when it is unset, and they also control which app the `show_notebook` tool opens.
+# Or via the Python wrapper (finds and launches runt mcp)
+uv run nteract
+```
 
 ### nteract-dev supervisor (recommended)
 
 The **nteract-dev** MCP supervisor (`crates/mcp-supervisor/`) is a stable Rust
-process that proxies to the nteract Python MCP server. It handles daemon
+process that proxies to `runt mcp`. It handles daemon
 lifecycle, auto-restart on crash, and hot-reload on file changes — one command,
 everything works:
 
@@ -321,11 +322,9 @@ cargo xtask run-mcp
 
 This:
 1. Starts the dev daemon if not running
-2. Runs `uv sync` if the venv is stale
-3. Builds Python bindings via `maturin develop` into `.venv`
-4. Spawns the nteract MCP server as a child process
-5. Proxies all tool calls + injects `supervisor_*` management tools
-6. Watches source files and hot-reloads on changes
+2. Builds `runt-cli` and spawns `runt mcp` as a child process
+3. Proxies all tool calls + injects `supervisor_*` management tools
+4. Watches source files and hot-reloads on changes
 
 For your MCP client config (Zed, Claude Desktop, Codex, etc.):
 

--- a/crates/runt-mcp/src/lib.rs
+++ b/crates/runt-mcp/src/lib.rs
@@ -36,6 +36,8 @@ pub struct NteractMcp {
     /// Used as the peer label in notebook sessions so the notebook app shows
     /// "Claude Desktop" or "Claude Code" instead of "Agent".
     peer_label: RwLock<String>,
+    /// When true, the `show_notebook` tool is not registered (headless environments).
+    no_show: bool,
 }
 
 impl NteractMcp {
@@ -51,7 +53,19 @@ impl NteractMcp {
             blob_store_path,
             session: Arc::new(RwLock::new(None)),
             peer_label: RwLock::new("Agent".to_string()),
+            no_show: false,
         }
+    }
+
+    /// Create a new MCP server with `show_notebook` disabled.
+    pub fn new_no_show(
+        socket_path: PathBuf,
+        blob_base_url: Option<String>,
+        blob_store_path: Option<PathBuf>,
+    ) -> Self {
+        let mut server = Self::new(socket_path, blob_base_url, blob_store_path);
+        server.no_show = true;
+        server
     }
 
     /// Get the peer label for notebook connections.
@@ -90,8 +104,12 @@ impl ServerHandler for NteractMcp {
         _request: Option<rmcp::model::PaginatedRequestParams>,
         _context: RequestContext<RoleServer>,
     ) -> Result<ListToolsResult, McpError> {
+        let mut tools = tools::all_tools();
+        if self.no_show {
+            tools.retain(|t| t.name.as_ref() != "show_notebook");
+        }
         Ok(ListToolsResult {
-            tools: tools::all_tools(),
+            tools,
             next_cursor: None,
             meta: None,
         })

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -228,10 +228,12 @@ enum Commands {
     // =========================================================================
     // Development utilities (only shown when RUNTIMED_DEV=1)
     // =========================================================================
-    /// Run as an MCP server (stdin/stdout JSON-RPC).
-    /// Hidden until the Rust MCP server has full tool parity with Python.
-    #[command(hide = true)]
-    Mcp,
+    /// Run as an MCP server (stdin/stdout JSON-RPC)
+    Mcp {
+        /// Do not register the show_notebook tool (for headless environments)
+        #[arg(long)]
+        no_show: bool,
+    },
 
     /// Manage cached Python environments
     Env {
@@ -573,7 +575,7 @@ async fn async_main(command: Option<Commands>) -> Result<()> {
             daemon_command(DaemonCommands::Logs { follow, lines }).await?
         }
         Some(Commands::Diagnostics { output }) => diagnostics_command(output).await?,
-        Some(Commands::Mcp) => run_mcp_server().await?,
+        Some(Commands::Mcp { no_show }) => run_mcp_server(no_show).await?,
         Some(Commands::Env { command }) => env_command(command).await?,
 
         // Development commands (requires RUNTIMED_DEV=1)
@@ -639,13 +641,17 @@ async fn async_main(command: Option<Commands>) -> Result<()> {
     Ok(())
 }
 
-async fn run_mcp_server() -> Result<()> {
+async fn run_mcp_server(no_show: bool) -> Result<()> {
     let socket_path = runtimed_client::daemon_paths::get_socket_path();
     let (blob_base_url, blob_store_path) =
         runtimed_client::daemon_paths::get_blob_paths_async(&socket_path).await;
 
     use rmcp::service::ServiceExt;
-    let server = runt_mcp::NteractMcp::new(socket_path, blob_base_url, blob_store_path);
+    let server = if no_show {
+        runt_mcp::NteractMcp::new_no_show(socket_path, blob_base_url, blob_store_path)
+    } else {
+        runt_mcp::NteractMcp::new(socket_path, blob_base_url, blob_store_path)
+    };
     let transport = rmcp::transport::io::stdio();
     let handle = server.serve(transport).await?;
     handle.waiting().await?;

--- a/python/nteract/README.md
+++ b/python/nteract/README.md
@@ -1,25 +1,23 @@
 # nteract
 
-An MCP (Model Context Protocol) server that connects AI assistants to Jupyter notebooks via the [nteract desktop app](https://nteract.io).
+A convenience wrapper that finds and launches `runt mcp` — the MCP server shipped with the [nteract desktop app](https://nteract.io).
 
 **[Download the nteract desktop app](https://nteract.io)** — you'll need it to see notebooks, collaborate with agents, and manage environments.
 
-> Looking for the old Electron-based nteract desktop app? The source is archived at [nteract/archived-desktop-app](https://github.com/nteract/archived-desktop-app). The new native app is actively developed at [nteract/desktop](https://github.com/nteract/desktop).
-
-## Bringing Agents in the Loop
-
-We're in the preliminary stages of hooking up the realtime system from nteract/desktop to any agent of your choice. Collaborate with agents in notebooks, render interactive elements, and explore data together.
+> The recommended way to add the MCP server is `runt mcp` directly. This PyPI package is a convenience for users who prefer `uvx`.
 
 ### Quick Start
+
+The MCP server ships with the desktop app. After installing, use `runt mcp` directly:
 
 #### Claude Code
 
 ```bash
 # Stable
-claude mcp add nteract -- uvx nteract
+claude mcp add nteract -- runt mcp
 
 # Nightly
-claude mcp add nteract-nightly -- uvx --prerelease allow nteract --nightly
+claude mcp add nteract-nightly -- runt-nightly mcp
 ```
 
 #### Manual JSON config
@@ -28,11 +26,19 @@ claude mcp add nteract-nightly -- uvx --prerelease allow nteract --nightly
 {
   "mcpServers": {
     "nteract": {
-      "command": "uvx",
-      "args": ["nteract"]
+      "command": "runt",
+      "args": ["mcp"]
     }
   }
 }
+```
+
+#### Via this PyPI package
+
+If `runt` isn't on your PATH, this package finds it in the app bundle:
+
+```bash
+claude mcp add nteract -- uvx nteract
 ```
 
 That's it. Now Claude can execute Python code, create visualizations, and work with your data.
@@ -93,13 +99,11 @@ You can open the same notebook in the [nteract desktop app](https://nteract.io) 
 | Flag | Description |
 |------|-------------|
 | `--version` | Print version and exit |
-| `--nightly` | Connect to the nightly daemon and open nightly app |
-| `--stable` | Connect to the stable daemon and open stable app |
-| `--no-show` | Do not register the `show_notebook` tool (for headless environments) |
+| `--nightly` | Use `runt-nightly` (nightly daemon and app) |
+| `--stable` | Use `runt` (stable daemon and app, default) |
+| `--legacy` | Use the built-in Python MCP server instead of `runt mcp` |
 
-By default, `nteract` lets `runtimed.default_socket_path()` choose the socket. That means `RUNTIMED_SOCKET_PATH` wins when it is set; otherwise the package's build channel decides.
-
-`--stable` and `--nightly` are mutually exclusive convenience overrides. When `RUNTIMED_SOCKET_PATH` is unset, they set it to `runtimed.socket_path_for_channel(...)`. When `RUNTIMED_SOCKET_PATH` is already set, the explicit env var wins. In either case, the selected flag still controls which desktop app `show_notebook` tries to launch.
+By default, `nteract` finds and exec's the installed `runt` (or `runt-nightly`) binary. The `--legacy` flag falls back to the built-in Python MCP server.
 
 ## Architecture
 

--- a/python/nteract/src/nteract/_mcp_server.py
+++ b/python/nteract/src/nteract/_mcp_server.py
@@ -1642,8 +1642,65 @@ class NteractServer:
 # =============================================================================
 
 
+def _find_runt_binary(channel: str) -> str | None:
+    """Find the runt binary using the same resolution as mcpb/server/launch.js.
+
+    Search order:
+    1. PATH (covers /usr/local/bin/ where the app installer puts the binary)
+    2. Platform-specific app bundle / install locations
+    """
+    import platform
+    import shutil
+
+    binary_name = "runt-nightly" if channel == "nightly" else "runt"
+    app_bundle_names = (
+        ["nteract Nightly", "nteract-nightly", "nteract (Nightly)"]
+        if channel == "nightly"
+        else ["nteract"]
+    )
+
+    # 1. Check PATH
+    found = shutil.which(binary_name)
+    if found:
+        return found
+
+    # 2. Check platform-specific sidecar / install paths
+    home = os.path.expanduser("~")
+    system = platform.system()
+
+    candidates: list[str] = []
+    if system == "Darwin":
+        for name in app_bundle_names:
+            candidates.append(f"/Applications/{name}.app/Contents/MacOS/{binary_name}")
+            candidates.append(
+                os.path.join(home, f"Applications/{name}.app/Contents/MacOS/{binary_name}")
+            )
+    elif system == "Windows":
+        local_app_data = os.environ.get("LOCALAPPDATA", os.path.join(home, "AppData", "Local"))
+        for name in app_bundle_names:
+            candidates.append(os.path.join(local_app_data, name, f"{binary_name}.exe"))
+            candidates.append(os.path.join(local_app_data, "Programs", name, f"{binary_name}.exe"))
+    else:  # Linux
+        candidates.append(os.path.join(home, ".local", "bin", binary_name))
+        for name in app_bundle_names:
+            slug = name.lower().replace(" ", "-")
+            candidates.append(f"/usr/share/{slug}/{binary_name}")
+            candidates.append(f"/opt/{slug}/{binary_name}")
+
+    for path in candidates:
+        if os.path.isfile(path):
+            return path
+
+    return None
+
+
 def main():
-    """Run the MCP server."""
+    """Launch the nteract MCP server.
+
+    Finds and exec's the installed ``runt mcp`` binary (shipped with the
+    nteract desktop app). Falls back to the built-in Python MCP server if
+    ``runt`` is not installed (``--legacy`` flag forces this).
+    """
     parser = _StderrParser(
         prog="nteract",
         description="nteract MCP server — AI-powered Jupyter notebooks.",
@@ -1669,6 +1726,11 @@ def main():
         action="store_true",
         help="Disable the show_notebook tool (headless environments).",
     )
+    parser.add_argument(
+        "--legacy",
+        action="store_true",
+        help="Use the built-in Python MCP server instead of runt mcp.",
+    )
     args = parser.parse_args()
 
     if args.version:
@@ -1677,13 +1739,34 @@ def main():
         print(f"nteract {version('nteract')}", file=sys.stderr)
         raise SystemExit(0)
 
-    channel: str | None = None
-    if args.nightly:
-        channel = "nightly"
-    elif args.stable:
-        channel = "stable"
+    channel = "nightly" if args.nightly else "stable"
 
-    if channel is not None and not os.environ.get("RUNTIMED_SOCKET_PATH"):
+    # Default path: find and exec the Rust MCP server
+    if not args.legacy:
+        binary = _find_runt_binary(channel)
+        if binary:
+            runt_args = [binary, "mcp"]
+            if args.no_show:
+                runt_args.append("--no-show")
+            print(f"Launching {' '.join(runt_args)}", file=sys.stderr)
+            os.execvp(binary, runt_args)
+            # execvp never returns
+        else:
+            binary_name = "runt-nightly" if channel == "nightly" else "runt"
+            app_name = "nteract Nightly" if channel == "nightly" else "nteract"
+            print(
+                f"Error: {binary_name} not found.\n\n"
+                f"Install {app_name} from https://nteract.io to use this MCP server.\n"
+                f"The app puts {binary_name} on your PATH during installation.\n"
+                f"\n"
+                f"To use the built-in Python MCP server instead, run:\n"
+                f"  nteract --legacy\n",
+                file=sys.stderr,
+            )
+            raise SystemExit(1)
+
+    # Legacy path: run the built-in Python MCP server directly
+    if (args.nightly or args.stable) and not os.environ.get("RUNTIMED_SOCKET_PATH"):
         os.environ["RUNTIMED_SOCKET_PATH"] = runtimed.socket_path_for_channel(channel)
 
     server = NteractServer(channel=channel, no_show=args.no_show)

--- a/python/nteract/tests/test_smoke.py
+++ b/python/nteract/tests/test_smoke.py
@@ -22,7 +22,9 @@ def test_keyboard_interrupt_exits_130():
     """Ctrl+C should exit with code 130 (Unix SIGINT convention), not dump a traceback."""
     from nteract._mcp_server import main
 
-    with patch("nteract._mcp_server.NteractServer") as MockServer, patch("sys.argv", ["nteract"]):
+    with patch("nteract._mcp_server.NteractServer") as MockServer, patch(
+        "sys.argv", ["nteract", "--legacy"]
+    ):
         instance = MockServer.return_value
         instance.mcp.run.side_effect = KeyboardInterrupt
         instance.cleanup = lambda: None


### PR DESCRIPTION
## Summary

- **Unhide `runt mcp`**: The subcommand was hidden pending tool parity with the Python MCP server. Now that `show_notebook` landed (#1314), it has full parity — unhide it.
- **Python launcher**: The `nteract` PyPI entry point now finds the installed `runt` binary (PATH → app bundle sidecar paths) and `execvp`'s `runt mcp`. Same resolution logic as `mcpb/server/launch.js`. Falls back to the built-in Python server with `--legacy`.
- **Docs**: README, AGENTS.md, contributing/development.md, and skills all updated to recommend `runt mcp` as primary, with `uvx nteract` as a convenience alternative.

## Test plan

- [x] `cargo xtask lint --fix` passes
- [x] `runt --help` shows `mcp` as a visible subcommand
- [x] `runt mcp --help` works