### PR TITLE
chore: bump version to 2.0.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3696,7 +3696,7 @@ dependencies = [
 
 [[package]]
 name = "notebook"
-version = "2.0.6"
+version = "2.0.7"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5966,7 +5966,7 @@ dependencies = [
 
 [[package]]
 name = "runt-cli"
-version = "2.0.6"
+version = "2.0.7"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6044,7 +6044,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed"
-version = "2.0.6"
+version = "2.0.7"
 dependencies = [
  "alacritty_terminal",
  "anyhow",

--- a/crates/notebook/Cargo.toml
+++ b/crates/notebook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notebook"
-version = "2.0.6"
+version = "2.0.7"
 edition.workspace = true
 description = "Tauri-based notebook UI for Jupyter kernels"
 repository.workspace = true

--- a/crates/notebook/tauri.conf.json
+++ b/crates/notebook/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "nteract",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "identifier": "org.nteract.desktop",
   "build": {
     "devUrl": "http://localhost:5174",

--- a/crates/runt/Cargo.toml
+++ b/crates/runt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runt-cli"
-version = "2.0.6"
+version = "2.0.7"
 edition.workspace = true
 description = "CLI for Jupyter Runtimes — bundled with nteract"
 repository.workspace = true

--- a/crates/runtimed/Cargo.toml
+++ b/crates/runtimed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed"
-version = "2.0.6"
+version = "2.0.7"
 edition.workspace = true
 description = "Central daemon for managing Jupyter runtimes and prewarmed environments"
 repository.workspace = true

--- a/python/nteract/pyproject.toml
+++ b/python/nteract/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nteract"
-version = "2.0.6"
+version = "2.0.7"
 description = "Bring AI to Jupyter notebooks. MCP server for Claude, ChatGPT, Gemini, OpenCode and any agent."
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/python/runtimed/pyproject.toml
+++ b/python/runtimed/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "runtimed"
-version = "2.0.6"
+version = "2.0.7"
 description = "Python toolkit for Jupyter runtimes, powered by runtimed Rust binaries"
 readme = "README.md"
 license = "BSD-3-Clause"


### PR DESCRIPTION
## Summary

Bump all published artifacts from 2.0.6 to 2.0.7.

Changes since 2.0.6:
- fix(mcp-supervisor): instant stdio init, always use runt mcp (#1315)
- feat(mcp-supervisor): proxy upstream MCP client identity to child (#1316)
- docs: recommend runt mcp, make Python nteract a thin launcher (#1317)
- feat(runt-mcp): add show_notebook tool (#1314)

## Test plan

- [x] `cargo check` passes (Cargo.lock updated)
- [x] All version sources in sync