### PR TITLE
feat(runt): add ratatui-based notebook TUI (`runt tui`)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,7 +61,7 @@ dependencies = [
  "rustix-openpty",
  "serde",
  "signal-hook",
- "unicode-width 0.2.2",
+ "unicode-width 0.2.0",
  "vte",
  "windows-sys 0.59.0",
 ]
@@ -111,6 +111,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "ansi-to-tui"
+version = "8.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e42366bb9d958f042bf58f0a85e1b2d091997c1257ca49bddd7e4827aadc65fd"
+dependencies = [
+ "nom 8.0.0",
+ "ratatui-core",
+ "simdutf8",
+ "smallvec",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -321,6 +334,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -445,12 +467,27 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec 0.6.3",
+]
+
+[[package]]
+name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
 ]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit-vec"
@@ -733,6 +770,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -949,6 +995,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "compact_str"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "compression-codecs"
 version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -994,6 +1054,15 @@ name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "cookie"
@@ -1107,6 +1176,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags 2.11.0",
+ "crossterm_winapi",
+ "derive_more 2.1.1",
+ "document-features",
+ "futures-core",
+ "mio",
+ "parking_lot",
+ "rustix 1.1.3",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1129,6 +1226,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "211f05e03c7d03754740fd9e585de910a095d6b99f8bcfffdef8319fa02a8331"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "csscolorparser"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
+dependencies = [
+ "lab",
+ "phf 0.11.3",
 ]
 
 [[package]]
@@ -1264,6 +1371,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
+name = "deltae"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1290,7 +1403,29 @@ version = "0.99.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
 dependencies = [
- "convert_case",
+ "convert_case 0.4.0",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case 0.10.0",
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -1420,6 +1555,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -1599,6 +1743,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "euclid"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1611,11 +1764,21 @@ dependencies = [
 
 [[package]]
 name = "fancy-regex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+dependencies = [
+ "bit-set 0.5.3",
+ "regex",
+]
+
+[[package]]
+name = "fancy-regex"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298"
 dependencies = [
- "bit-set",
+ "bit-set 0.8.0",
  "regex-automata",
  "regex-syntax",
 ]
@@ -1626,7 +1789,7 @@ version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "998b056554fbe42e03ae0e152895cd1a7e1002aec800fdc6635d20270260c46f"
 dependencies = [
- "bit-set",
+ "bit-set 0.8.0",
  "regex-automata",
  "regex-syntax",
 ]
@@ -1679,6 +1842,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1694,6 +1868,18 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "finl_unicode"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "fixedbitset"
@@ -2079,7 +2265,7 @@ version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
 dependencies = [
- "unicode-width 0.2.2",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -2834,6 +3020,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "infer"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2860,6 +3055,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+dependencies = [
+ "darling 0.23.0",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3101,6 +3309,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "kasuari"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
+dependencies = [
+ "hashbrown 0.16.1",
+ "portable-atomic",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "kernel-env"
 version = "0.1.0"
 dependencies = [
@@ -3199,6 +3418,12 @@ dependencies = [
  "indexmap 2.13.0",
  "selectors",
 ]
+
+[[package]]
+name = "lab"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f"
 
 [[package]]
 name = "lazy-regex"
@@ -3340,6 +3565,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "line-clipping"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
+dependencies = [
+ "bitflags 2.11.0",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3356,6 +3590,12 @@ name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
@@ -3386,6 +3626,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3396,6 +3645,16 @@ name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
+name = "mac_address"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
+dependencies = [
+ "nix 0.29.0",
+ "winapi",
+]
 
 [[package]]
 name = "malloc_buf"
@@ -3496,6 +3755,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "memmem"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15"
+
+[[package]]
 name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3519,6 +3784,12 @@ dependencies = [
  "cc",
  "walkdir",
 ]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "minisign-verify"
@@ -3648,6 +3919,19 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
@@ -3678,6 +3962,16 @@ checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
 name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
 version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
@@ -3691,7 +3985,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2de2bc5b451bfedaef92c90b8939a8fff5770bdcc1fafd6239d086aab8fa6b29"
 dependencies = [
- "nom",
+ "nom 8.0.0",
 ]
 
 [[package]]
@@ -3842,6 +4136,17 @@ name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "num-integer"
@@ -4217,6 +4522,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "os_pipe"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4340,7 +4654,7 @@ checksum = "31095ca1f396e3de32745f42b20deef7bc09077f918b085307e8eab6ddd8fb9c"
 dependencies = [
  "once_cell",
  "serde",
- "unicode-width 0.2.2",
+ "unicode-width 0.2.0",
  "unscanny",
  "version-ranges",
 ]
@@ -4361,7 +4675,7 @@ dependencies = [
  "serde",
  "smallvec",
  "thiserror 1.0.69",
- "unicode-width 0.2.2",
+ "unicode-width 0.2.0",
  "url",
  "urlencoding",
  "version-ranges",
@@ -4374,12 +4688,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+dependencies = [
+ "pest",
+ "sha2 0.10.9",
+]
+
+[[package]]
 name = "petgraph"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
- "fixedbitset",
+ "fixedbitset 0.5.7",
  "hashbrown 0.15.5",
  "indexmap 2.13.0",
  "serde",
@@ -4771,8 +5128,8 @@ version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
 dependencies = [
- "bit-set",
- "bit-vec",
+ "bit-set 0.8.0",
+ "bit-vec 0.8.0",
  "bitflags 2.11.0",
  "num-traits",
  "rand 0.9.2",
@@ -5152,6 +5509,91 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1ce67fb8ba4446454d1c8dbaeda0557ff5e94d39d5e5ed7f10a65eb4c8266bc"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "ratatui-crossterm",
+ "ratatui-macros",
+ "ratatui-termwiz",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
+dependencies = [
+ "bitflags 2.11.0",
+ "compact_str",
+ "hashbrown 0.16.1",
+ "indoc",
+ "itertools 0.14.0",
+ "kasuari",
+ "lru",
+ "strum",
+ "thiserror 2.0.18",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "ratatui-crossterm"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "577c9b9f652b4c121fb25c6a391dd06406d3b092ba68827e6d2f09550edc54b3"
+dependencies = [
+ "cfg-if",
+ "crossterm",
+ "instability",
+ "ratatui-core",
+]
+
+[[package]]
+name = "ratatui-macros"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7f1342a13e83e4bb9d0b793d0ea762be633f9582048c892ae9041ef39c936f4"
+dependencies = [
+ "ratatui-core",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-termwiz"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f76fe0bd0ed4295f0321b1676732e2454024c15a35d01904ddb315afd3d545c"
+dependencies = [
+ "ratatui-core",
+ "termwiz",
+]
+
+[[package]]
+name = "ratatui-widgets"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
+dependencies = [
+ "bitflags 2.11.0",
+ "hashbrown 0.16.1",
+ "indoc",
+ "instability",
+ "itertools 0.14.0",
+ "line-clipping",
+ "ratatui-core",
+ "strum",
+ "time",
+ "unicode-segmentation",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "rattler"
 version = "0.39.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5246,7 +5688,7 @@ dependencies = [
  "itertools 0.14.0",
  "lazy-regex",
  "memmap2",
- "nom",
+ "nom 8.0.0",
  "nom-language",
  "purl",
  "rattler_digest",
@@ -5522,7 +5964,7 @@ checksum = "bd96ff7990366c336bd9b03e8cc4e8f38c2cfc1957c5276dc256b9f4463b694b"
 dependencies = [
  "archspec",
  "libloading 0.9.0",
- "nom",
+ "nom 8.0.0",
  "once_cell",
  "plist",
  "rattler_conda_types",
@@ -5968,10 +6410,12 @@ dependencies = [
 name = "runt-cli"
 version = "2.0.6"
 dependencies = [
+ "ansi-to-tui",
  "anyhow",
  "chrono",
  "clap",
  "colored",
+ "crossterm",
  "dirs 5.0.1",
  "flate2",
  "futures",
@@ -5979,8 +6423,11 @@ dependencies = [
  "kernel-env",
  "libc",
  "notebook-doc",
+ "notebook-protocol",
+ "notebook-sync",
  "notify",
  "petname",
+ "ratatui",
  "rmcp",
  "rpassword",
  "runt-mcp",
@@ -6485,7 +6932,7 @@ checksum = "0c37578180969d00692904465fb7f6b3d50b9a2b952b87c23d0e2e5cb5013416"
 dependencies = [
  "bitflags 1.3.2",
  "cssparser",
- "derive_more",
+ "derive_more 0.99.20",
  "fxhash",
  "log",
  "phf 0.8.0",
@@ -6838,6 +7285,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6982,6 +7440,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "string_cache"
@@ -7683,6 +8147,69 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminfo"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
+dependencies = [
+ "fnv",
+ "nom 7.1.3",
+ "phf 0.11.3",
+ "phf_codegen 0.11.3",
+]
+
+[[package]]
+name = "termios"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "termwiz"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
+dependencies = [
+ "anyhow",
+ "base64 0.22.1",
+ "bitflags 2.11.0",
+ "fancy-regex 0.11.0",
+ "filedescriptor",
+ "finl_unicode",
+ "fixedbitset 0.4.2",
+ "hex",
+ "lazy_static",
+ "libc",
+ "log",
+ "memmem",
+ "nix 0.29.0",
+ "num-derive",
+ "num-traits",
+ "ordered-float",
+ "pest",
+ "pest_derive",
+ "phf 0.11.3",
+ "sha2 0.10.9",
+ "signal-hook",
+ "siphasher 1.0.2",
+ "terminfo",
+ "termios",
+ "thiserror 1.0.69",
+ "ucd-trie",
+ "unicode-segmentation",
+ "vtparse",
+ "wezterm-bidi",
+ "wezterm-blob-leases",
+ "wezterm-color-types",
+ "wezterm-dynamic",
+ "wezterm-input-types",
+ "winapi",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8140,6 +8667,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
 name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8214,6 +8747,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
+name = "unicode-truncate"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
+dependencies = [
+ "itertools 0.14.0",
+ "unicode-segmentation",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8221,9 +8765,9 @@ checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
-version = "0.2.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unicode-xid"
@@ -8316,6 +8860,7 @@ version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
 dependencies = [
+ "atomic",
  "getrandom 0.4.1",
  "js-sys",
  "rand 0.9.2",
@@ -8407,6 +8952,15 @@ dependencies = [
  "log",
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "vtparse"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
+dependencies = [
+ "utf8parse",
 ]
 
 [[package]]
@@ -8806,6 +9360,78 @@ dependencies = [
  "thiserror 2.0.18",
  "windows 0.61.3",
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "wezterm-bidi"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0a6e355560527dd2d1cf7890652f4f09bb3433b6aadade4c9b5ed76de5f3ec"
+dependencies = [
+ "log",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-blob-leases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
+dependencies = [
+ "getrandom 0.3.4",
+ "mac_address",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
+ "uuid",
+]
+
+[[package]]
+name = "wezterm-color-types"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de81ef35c9010270d63772bebef2f2d6d1f2d20a983d27505ac850b8c4b4296"
+dependencies = [
+ "csscolorparser",
+ "deltae",
+ "lazy_static",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-dynamic"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
+dependencies = [
+ "log",
+ "ordered-float",
+ "strsim",
+ "thiserror 1.0.69",
+ "wezterm-dynamic-derive",
+]
+
+[[package]]
+name = "wezterm-dynamic-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c0cf2d539c645b448eaffec9ec494b8b19bd5077d9e58cb1ae7efece8d575b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "wezterm-input-types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7012add459f951456ec9d6c7e6fc340b1ce15d6fc9629f8c42853412c029e57e"
+dependencies = [
+ "bitflags 1.3.2",
+ "euclid",
+ "lazy_static",
+ "serde",
+ "wezterm-dynamic",
 ]
 
 [[package]]

--- a/crates/runt/Cargo.toml
+++ b/crates/runt/Cargo.toml
@@ -40,6 +40,11 @@ flate2 = "1"
 notify = "8"
 tar = "0.4"
 walkdir = "2"
+notebook-protocol = { path = "../notebook-protocol" }
+notebook-sync = { path = "../notebook-sync" }
+ratatui = "0.30"
+crossterm = { version = "0.29", features = ["event-stream"] }
+ansi-to-tui = "8"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -7,6 +7,7 @@ use serde::Serialize;
 use std::time::Duration;
 use tabled::{settings::Style, Table, Tabled};
 mod kernel_client;
+mod tui;
 
 use crate::kernel_client::KernelClient;
 use runtimelib::{
@@ -188,6 +189,11 @@ enum Commands {
     #[command(alias = "shutdown")]
     Stop {
         /// Path to the notebook file, or notebook ID (UUID) for untitled notebooks
+        path: PathBuf,
+    },
+    /// Open a notebook in a terminal UI
+    Tui {
+        /// Path to notebook file
         path: PathBuf,
     },
 
@@ -555,6 +561,7 @@ async fn async_main(command: Option<Commands>) -> Result<()> {
         Some(Commands::Daemon { command }) => daemon_command(command).await?,
         Some(Commands::Ps { json }) => list_notebooks(json).await?,
         Some(Commands::Stop { path }) => shutdown_notebook(&path).await?,
+        Some(Commands::Tui { path }) => tui::run(path).await?,
         Some(Commands::Recover { path, output, list }) => {
             recover_notebook(path.as_deref(), output.as_deref(), list)?
         }

--- a/crates/runt/src/tui/mod.rs
+++ b/crates/runt/src/tui/mod.rs
@@ -60,9 +60,7 @@ pub async fn run(path: PathBuf) -> Result<()> {
     }
 
     // Get our peer ID for presence broadcasts
-    let peer_id = handle
-        .get_actor_id()
-        .unwrap_or_else(|_| label.clone());
+    let peer_id = handle.get_actor_id().unwrap_or_else(|_| label.clone());
 
     // Install panic hook to restore terminal
     let original_hook = std::panic::take_hook();
@@ -239,13 +237,13 @@ async fn handle_edit_key(key: KeyEvent, app: &mut App, handle: &notebook_sync::D
     use state::CursorDir;
 
     // Helper: apply a splice to the CRDT if the edit produced one
-    let apply_splice =
-        |splice: Option<state::Splice>, app: &App, handle: &notebook_sync::DocHandle| {
-            if let (Some(splice), Some(cell_id)) = (splice, app.selected_cell_id()) {
-                let _ =
-                    handle.splice_source(cell_id, splice.index, splice.delete_count, &splice.text);
-            }
-        };
+    let apply_splice = |splice: Option<state::Splice>,
+                        app: &App,
+                        handle: &notebook_sync::DocHandle| {
+        if let (Some(splice), Some(cell_id)) = (splice, app.selected_cell_id()) {
+            let _ = handle.splice_source(cell_id, splice.index, splice.delete_count, &splice.text);
+        }
+    };
 
     match (key.modifiers, key.code) {
         // Exit edit mode

--- a/crates/runt/src/tui/mod.rs
+++ b/crates/runt/src/tui/mod.rs
@@ -1,0 +1,130 @@
+mod state;
+mod ui;
+
+use std::io::stdout;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use anyhow::Result;
+use crossterm::event::{Event, EventStream, KeyCode, KeyEvent, KeyModifiers};
+use crossterm::terminal::{EnterAlternateScreen, LeaveAlternateScreen};
+use futures::StreamExt;
+use ratatui::backend::CrosstermBackend;
+use ratatui::Terminal;
+
+use notebook_protocol::protocol::NotebookRequest;
+use notebook_sync::connect::{connect_open, OpenResult};
+
+use state::App;
+
+pub async fn run(path: PathBuf) -> Result<()> {
+    // Resolve socket path and blob paths for output resolution
+    let socket_path = runtimed::daemon_paths::get_socket_path();
+    let (blob_base_url, blob_store_path) =
+        runtimed::daemon_paths::get_blob_paths_async(&socket_path).await;
+
+    // Connect to daemon
+    let OpenResult {
+        handle,
+        mut broadcast_rx,
+        cells,
+        ..
+    } = connect_open(socket_path, path.clone(), "tui:runt").await?;
+
+    // Build initial state
+    let mut app = App::from_cells(
+        cells,
+        &path.display().to_string(),
+        &blob_base_url,
+        &blob_store_path,
+    )
+    .await;
+
+    // Read initial runtime state
+    if let Ok(rs) = handle.get_runtime_state() {
+        app.update_runtime_state(rs);
+    }
+
+    // Install panic hook to restore terminal
+    let original_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |panic| {
+        crossterm::terminal::disable_raw_mode().ok();
+        crossterm::execute!(std::io::stderr(), LeaveAlternateScreen).ok();
+        original_hook(panic);
+    }));
+
+    // Setup terminal
+    crossterm::terminal::enable_raw_mode()?;
+    crossterm::execute!(stdout(), EnterAlternateScreen)?;
+    let mut terminal = Terminal::new(CrosstermBackend::new(stdout()))?;
+    terminal.clear()?;
+
+    // Event loop
+    let mut crossterm_events = EventStream::new();
+    let mut tick = tokio::time::interval(Duration::from_millis(33)); // ~30fps
+    let mut refresh = tokio::time::interval(Duration::from_millis(500));
+
+    loop {
+        tokio::select! {
+            maybe_event = crossterm_events.next() => {
+                if let Some(Ok(Event::Key(key))) = maybe_event {
+                    handle_key(key, &mut app, &handle).await;
+                }
+            }
+            Some(broadcast) = broadcast_rx.recv() => {
+                app.apply_broadcast(broadcast);
+            }
+            _ = refresh.tick() => {
+                if let Ok(rs) = handle.get_runtime_state() {
+                    app.update_runtime_state(rs);
+                }
+            }
+            _ = tick.tick() => {
+                terminal.draw(|f| ui::render(f, &app))?;
+            }
+        }
+
+        if app.should_quit {
+            break;
+        }
+    }
+
+    // Cleanup
+    crossterm::terminal::disable_raw_mode()?;
+    crossterm::execute!(stdout(), LeaveAlternateScreen)?;
+    terminal.show_cursor()?;
+
+    Ok(())
+}
+
+async fn handle_key(key: KeyEvent, app: &mut App, handle: &notebook_sync::DocHandle) {
+    match (key.modifiers, key.code) {
+        // Quit
+        (_, KeyCode::Char('q')) if key.modifiers == KeyModifiers::NONE => {
+            app.should_quit = true;
+        }
+        (KeyModifiers::CONTROL, KeyCode::Char('c')) => {
+            app.should_quit = true;
+        }
+
+        // Navigation
+        (_, KeyCode::Char('j')) | (_, KeyCode::Down) => app.select_next(),
+        (_, KeyCode::Char('k')) | (_, KeyCode::Up) => app.select_prev(),
+        (_, KeyCode::Char('g')) if key.modifiers == KeyModifiers::NONE => app.select_first(),
+        (_, KeyCode::Char('G')) | (KeyModifiers::SHIFT, KeyCode::Char('g')) => app.select_last(),
+
+        // Execute: Ctrl+Enter
+        (KeyModifiers::CONTROL, KeyCode::Enter) => {
+            if let Some(cell_id) = app.selected_cell_id() {
+                let cell_id = cell_id.to_string();
+                // Ensure daemon has latest source
+                let _ = handle.confirm_sync().await;
+                let _ = handle
+                    .send_request(NotebookRequest::ExecuteCell { cell_id })
+                    .await;
+            }
+        }
+
+        _ => {}
+    }
+}

--- a/crates/runt/src/tui/mod.rs
+++ b/crates/runt/src/tui/mod.rs
@@ -6,18 +6,32 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use anyhow::Result;
-use crossterm::event::{Event, EventStream, KeyCode, KeyEvent, KeyModifiers};
+use crossterm::event::{
+    Event, EventStream, KeyCode, KeyEvent, KeyModifiers, KeyboardEnhancementFlags,
+    PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
+};
 use crossterm::terminal::{EnterAlternateScreen, LeaveAlternateScreen};
 use futures::StreamExt;
 use ratatui::backend::CrosstermBackend;
 use ratatui::Terminal;
 
+use notebook_doc::presence::{encode_cursor_update_labeled, CursorPosition};
 use notebook_protocol::protocol::NotebookRequest;
 use notebook_sync::connect::{connect_open, OpenResult};
 
 use state::App;
 
+/// Get username for actor label: "$USER:console"
+fn actor_label() -> String {
+    let user = std::env::var("USER")
+        .or_else(|_| std::env::var("USERNAME"))
+        .unwrap_or_else(|_| "unknown".to_string());
+    format!("{}:console", user)
+}
+
 pub async fn run(path: PathBuf) -> Result<()> {
+    let label = actor_label();
+
     // Resolve socket path and blob paths for output resolution
     let socket_path = runtimed::daemon_paths::get_socket_path();
     let (blob_base_url, blob_store_path) =
@@ -29,7 +43,7 @@ pub async fn run(path: PathBuf) -> Result<()> {
         mut broadcast_rx,
         cells,
         ..
-    } = connect_open(socket_path, path.clone(), "tui:runt").await?;
+    } = connect_open(socket_path, path.clone(), &label).await?;
 
     // Build initial state
     let mut app = App::from_cells(
@@ -45,9 +59,15 @@ pub async fn run(path: PathBuf) -> Result<()> {
         app.update_runtime_state(rs);
     }
 
+    // Get our peer ID for presence broadcasts
+    let peer_id = handle
+        .get_actor_id()
+        .unwrap_or_else(|_| label.clone());
+
     // Install panic hook to restore terminal
     let original_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |panic| {
+        crossterm::execute!(std::io::stderr(), PopKeyboardEnhancementFlags).ok();
         crossterm::terminal::disable_raw_mode().ok();
         crossterm::execute!(std::io::stderr(), LeaveAlternateScreen).ok();
         original_hook(panic);
@@ -56,8 +76,19 @@ pub async fn run(path: PathBuf) -> Result<()> {
     // Setup terminal
     crossterm::terminal::enable_raw_mode()?;
     crossterm::execute!(stdout(), EnterAlternateScreen)?;
+    // Enable kitty keyboard protocol for Shift+Enter detection.
+    // Silently ignored if the terminal doesn't support it.
+    let keyboard_enhanced = crossterm::execute!(
+        stdout(),
+        PushKeyboardEnhancementFlags(KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES)
+    )
+    .is_ok();
+    eprintln!("[tui] keyboard_enhanced={keyboard_enhanced}");
     let mut terminal = Terminal::new(CrosstermBackend::new(stdout()))?;
     terminal.clear()?;
+
+    // Subscribe to document changes (fires on both local and remote CRDT mutations)
+    let mut snapshot_rx = handle.subscribe();
 
     // Event loop
     let mut crossterm_events = EventStream::new();
@@ -68,11 +99,19 @@ pub async fn run(path: PathBuf) -> Result<()> {
         tokio::select! {
             maybe_event = crossterm_events.next() => {
                 if let Some(Ok(Event::Key(key))) = maybe_event {
-                    handle_key(key, &mut app, &handle).await;
+                    // Debug: log Enter-related key events to stderr
+                    if key.code == KeyCode::Enter {
+                        eprintln!("[tui] Enter key: modifiers={:?} kind={:?} state={:?}", key.modifiers, key.kind, key.state);
+                    }
+                    handle_key(key, &mut app, &handle, &peer_id, &label).await;
                 }
             }
             Some(broadcast) = broadcast_rx.recv() => {
                 app.apply_broadcast(broadcast);
+            }
+            Ok(()) = snapshot_rx.changed() => {
+                let snapshot = snapshot_rx.borrow_and_update().clone();
+                app.apply_snapshot(snapshot, &blob_base_url, &blob_store_path).await;
             }
             _ = refresh.tick() => {
                 if let Ok(rs) = handle.get_runtime_state() {
@@ -90,6 +129,9 @@ pub async fn run(path: PathBuf) -> Result<()> {
     }
 
     // Cleanup
+    if keyboard_enhanced {
+        crossterm::execute!(stdout(), PopKeyboardEnhancementFlags).ok();
+    }
     crossterm::terminal::disable_raw_mode()?;
     crossterm::execute!(stdout(), LeaveAlternateScreen)?;
     terminal.show_cursor()?;
@@ -97,10 +139,73 @@ pub async fn run(path: PathBuf) -> Result<()> {
     Ok(())
 }
 
-async fn handle_key(key: KeyEvent, app: &mut App, handle: &notebook_sync::DocHandle) {
+async fn handle_key(
+    key: KeyEvent,
+    app: &mut App,
+    handle: &notebook_sync::DocHandle,
+    peer_id: &str,
+    label: &str,
+) {
+    use state::Mode;
+
+    match app.mode {
+        Mode::Normal => handle_normal_key(key, app, handle).await,
+        Mode::Edit => handle_edit_key(key, app, handle).await,
+    }
+
+    // Emit cursor presence when in edit mode
+    if app.mode == Mode::Edit {
+        emit_cursor_presence(app, handle, peer_id, label).await;
+    }
+}
+
+async fn emit_cursor_presence(
+    app: &App,
+    handle: &notebook_sync::DocHandle,
+    peer_id: &str,
+    label: &str,
+) {
+    if let Some(cell_id) = app.selected_cell_id() {
+        let pos = CursorPosition {
+            cell_id: cell_id.to_string(),
+            line: app.cursor.line as u32,
+            column: app.cursor.col as u32,
+        };
+        let data = encode_cursor_update_labeled(peer_id, Some(label), &pos);
+        let _ = handle.send_presence(data).await;
+    }
+}
+
+/// Execute the selected cell: confirm sync, send request, move down.
+/// Spawns the actual request as a background task so the TUI doesn't block.
+fn execute_selected(app: &mut App, handle: &notebook_sync::DocHandle) {
+    if let Some(cell_id) = app.selected_cell_id() {
+        let cell_id = cell_id.to_string();
+        let handle = handle.clone();
+        tokio::spawn(async move {
+            if let Err(e) = handle.confirm_sync().await {
+                eprintln!("[tui] confirm_sync failed: {e}");
+            }
+            match handle
+                .send_request(NotebookRequest::ExecuteCell {
+                    cell_id: cell_id.clone(),
+                })
+                .await
+            {
+                Ok(_resp) => {}
+                Err(e) => {
+                    eprintln!("[tui] execute request failed for {cell_id}: {e}");
+                }
+            }
+        });
+        app.select_next();
+    }
+}
+
+async fn handle_normal_key(key: KeyEvent, app: &mut App, handle: &notebook_sync::DocHandle) {
     match (key.modifiers, key.code) {
         // Quit
-        (_, KeyCode::Char('q')) if key.modifiers == KeyModifiers::NONE => {
+        (KeyModifiers::NONE, KeyCode::Char('q')) => {
             app.should_quit = true;
         }
         (KeyModifiers::CONTROL, KeyCode::Char('c')) => {
@@ -108,21 +213,89 @@ async fn handle_key(key: KeyEvent, app: &mut App, handle: &notebook_sync::DocHan
         }
 
         // Navigation
-        (_, KeyCode::Char('j')) | (_, KeyCode::Down) => app.select_next(),
-        (_, KeyCode::Char('k')) | (_, KeyCode::Up) => app.select_prev(),
-        (_, KeyCode::Char('g')) if key.modifiers == KeyModifiers::NONE => app.select_first(),
-        (_, KeyCode::Char('G')) | (KeyModifiers::SHIFT, KeyCode::Char('g')) => app.select_last(),
+        (_, KeyCode::Char('j')) | (KeyModifiers::NONE, KeyCode::Down) => app.select_next(),
+        (_, KeyCode::Char('k')) | (KeyModifiers::NONE, KeyCode::Up) => app.select_prev(),
+        (KeyModifiers::NONE, KeyCode::Char('g')) => app.select_first(),
+        (KeyModifiers::SHIFT, KeyCode::Char('G')) => app.select_last(),
 
-        // Execute: Ctrl+Enter
-        (KeyModifiers::CONTROL, KeyCode::Enter) => {
-            if let Some(cell_id) = app.selected_cell_id() {
-                let cell_id = cell_id.to_string();
-                // Ensure daemon has latest source
-                let _ = handle.confirm_sync().await;
-                let _ = handle
-                    .send_request(NotebookRequest::ExecuteCell { cell_id })
-                    .await;
+        // Execute: Shift+Enter
+        (KeyModifiers::SHIFT, KeyCode::Enter) => {
+            execute_selected(app, handle);
+        }
+
+        // Enter edit mode: Enter or i
+        (KeyModifiers::NONE, KeyCode::Enter) => {
+            app.enter_edit_mode();
+        }
+        (KeyModifiers::NONE, KeyCode::Char('i')) => {
+            app.enter_edit_mode();
+        }
+
+        _ => {}
+    }
+}
+
+async fn handle_edit_key(key: KeyEvent, app: &mut App, handle: &notebook_sync::DocHandle) {
+    use state::CursorDir;
+
+    // Helper: apply a splice to the CRDT if the edit produced one
+    let apply_splice =
+        |splice: Option<state::Splice>, app: &App, handle: &notebook_sync::DocHandle| {
+            if let (Some(splice), Some(cell_id)) = (splice, app.selected_cell_id()) {
+                let _ =
+                    handle.splice_source(cell_id, splice.index, splice.delete_count, &splice.text);
             }
+        };
+
+    match (key.modifiers, key.code) {
+        // Exit edit mode
+        (_, KeyCode::Esc) => {
+            app.exit_edit_mode();
+        }
+
+        // Shift+Enter: save + execute + move down
+        (KeyModifiers::SHIFT, KeyCode::Enter) => {
+            if let Some(_cell_id) = app.exit_edit_mode() {
+                execute_selected(app, handle);
+            }
+        }
+
+        // Newline
+        (KeyModifiers::NONE, KeyCode::Enter) => {
+            let splice = app.edit_insert_newline();
+            apply_splice(splice, app, handle);
+        }
+
+        // Backspace
+        (_, KeyCode::Backspace) => {
+            let splice = app.edit_backspace();
+            apply_splice(splice, app, handle);
+        }
+
+        // Delete
+        (_, KeyCode::Delete) => {
+            let splice = app.edit_delete();
+            apply_splice(splice, app, handle);
+        }
+
+        // Cursor movement (no CRDT change)
+        (_, KeyCode::Left) => app.edit_move_cursor(CursorDir::Left),
+        (_, KeyCode::Right) => app.edit_move_cursor(CursorDir::Right),
+        (_, KeyCode::Up) => app.edit_move_cursor(CursorDir::Up),
+        (_, KeyCode::Down) => app.edit_move_cursor(CursorDir::Down),
+        (_, KeyCode::Home) => app.edit_move_cursor(CursorDir::Home),
+        (_, KeyCode::End) => app.edit_move_cursor(CursorDir::End),
+
+        // Tab → 4 spaces
+        (_, KeyCode::Tab) => {
+            let splice = app.edit_insert_str("    ");
+            apply_splice(splice, app, handle);
+        }
+
+        // Regular character input
+        (KeyModifiers::NONE | KeyModifiers::SHIFT, KeyCode::Char(c)) => {
+            let splice = app.edit_insert_char(c);
+            apply_splice(splice, app, handle);
         }
 
         _ => {}

--- a/crates/runt/src/tui/state.rs
+++ b/crates/runt/src/tui/state.rs
@@ -5,6 +5,20 @@ use notebook_protocol::protocol::NotebookBroadcast;
 use runtimed::output_resolver::{output_from_json, resolve_cell_outputs};
 use runtimed::resolved_output::Output;
 
+/// Current interaction mode.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Mode {
+    Normal,
+    Edit,
+}
+
+/// Cursor position in the editor.
+#[derive(Clone, Debug, Default)]
+pub struct Cursor {
+    pub line: usize,
+    pub col: usize,
+}
+
 /// Application state for the TUI.
 pub struct App {
     pub cells: Vec<CellView>,
@@ -14,6 +28,11 @@ pub struct App {
     pub kernel_language: String,
     pub notebook_path: String,
     pub should_quit: bool,
+    pub mode: Mode,
+    pub cursor: Cursor,
+    /// Working copy of the source being edited (separate from the cell source
+    /// so we can discard on Esc without writing back).
+    pub edit_buffer: Vec<String>,
     _blob_base_url: Option<String>,
     _blob_store_path: Option<PathBuf>,
 }
@@ -90,6 +109,9 @@ impl App {
             kernel_language: String::new(),
             notebook_path: path.to_string(),
             should_quit: false,
+            mode: Mode::Normal,
+            cursor: Cursor::default(),
+            edit_buffer: Vec::new(),
             _blob_base_url: blob_base_url.clone(),
             _blob_store_path: blob_store_path.clone(),
         }
@@ -155,6 +177,26 @@ impl App {
         self.kernel_language = state.kernel.language;
     }
 
+    /// Rebuild cell views from a fresh document snapshot (e.g. when a remote peer adds/removes cells).
+    pub async fn apply_snapshot(
+        &mut self,
+        snapshot: notebook_sync::NotebookSnapshot,
+        blob_base_url: &Option<String>,
+        blob_store_path: &Option<PathBuf>,
+    ) {
+        let mut cell_views = Vec::with_capacity(snapshot.cells.len());
+        for cell_snapshot in snapshot.cells.iter().cloned() {
+            let outputs =
+                resolve_cell_outputs(&cell_snapshot.outputs, blob_base_url, blob_store_path).await;
+            cell_views.push(CellView::from_snapshot(cell_snapshot, outputs));
+        }
+        self.cells = cell_views;
+        // Clamp selection
+        if self.selected >= self.cells.len() && !self.cells.is_empty() {
+            self.selected = self.cells.len() - 1;
+        }
+    }
+
     pub fn select_next(&mut self) {
         if self.selected + 1 < self.cells.len() {
             self.selected += 1;
@@ -180,4 +222,226 @@ impl App {
     pub fn selected_cell_id(&self) -> Option<&str> {
         self.cells.get(self.selected).map(|c| c.id.as_str())
     }
+
+    // ── Edit mode ──────────────────────────────────────────────
+
+    /// Enter edit mode for the selected cell.
+    pub fn enter_edit_mode(&mut self) {
+        if let Some(cell) = self.cells.get(self.selected) {
+            self.edit_buffer = cell.source.lines().map(String::from).collect();
+            if self.edit_buffer.is_empty() {
+                self.edit_buffer.push(String::new());
+            }
+            self.cursor = Cursor { line: 0, col: 0 };
+            self.mode = Mode::Edit;
+        }
+    }
+
+    /// Exit edit mode, syncing the local cell source from the edit buffer.
+    pub fn exit_edit_mode(&mut self) -> Option<String> {
+        if self.mode != Mode::Edit {
+            return None;
+        }
+        let new_source = self.edit_buffer.join("\n");
+        if let Some(cell) = self.cells.get_mut(self.selected) {
+            cell.source = new_source;
+        }
+        self.mode = Mode::Normal;
+        self.selected_cell_id().map(|s| s.to_string())
+    }
+
+    /// Get the flat char offset of the cursor in the edit buffer.
+    /// Lines are joined by '\n', so line N starts at sum of (len of lines 0..N) + N newlines.
+    fn cursor_char_offset(&self) -> usize {
+        let mut offset = 0;
+        for (i, line) in self.edit_buffer.iter().enumerate() {
+            if i == self.cursor.line {
+                offset += self.cursor.col;
+                break;
+            }
+            offset += line.chars().count() + 1; // +1 for '\n'
+        }
+        offset
+    }
+
+    /// Insert a character at the cursor. Returns a splice op.
+    pub fn edit_insert_char(&mut self, c: char) -> Option<Splice> {
+        let offset = self.cursor_char_offset();
+        if let Some(line) = self.edit_buffer.get_mut(self.cursor.line) {
+            let byte_idx = char_to_byte_index(line, self.cursor.col);
+            line.insert(byte_idx, c);
+            self.cursor.col += 1;
+            return Some(Splice {
+                index: offset,
+                delete_count: 0,
+                text: c.to_string(),
+            });
+        }
+        None
+    }
+
+    /// Insert a newline at the cursor. Returns a splice op.
+    pub fn edit_insert_newline(&mut self) -> Option<Splice> {
+        let offset = self.cursor_char_offset();
+        if let Some(line) = self.edit_buffer.get(self.cursor.line) {
+            let byte_idx = char_to_byte_index(line, self.cursor.col);
+            let rest = line[byte_idx..].to_string();
+            self.edit_buffer[self.cursor.line] = line[..byte_idx].to_string();
+            self.edit_buffer.insert(self.cursor.line + 1, rest);
+            self.cursor.line += 1;
+            self.cursor.col = 0;
+            return Some(Splice {
+                index: offset,
+                delete_count: 0,
+                text: "\n".to_string(),
+            });
+        }
+        None
+    }
+
+    /// Delete the character before the cursor (backspace). Returns a splice op.
+    pub fn edit_backspace(&mut self) -> Option<Splice> {
+        if self.cursor.col > 0 {
+            self.cursor.col -= 1;
+            let offset = self.cursor_char_offset();
+            if let Some(line) = self.edit_buffer.get_mut(self.cursor.line) {
+                let byte_idx = char_to_byte_index(line, self.cursor.col);
+                let next_byte_idx = char_to_byte_index(line, self.cursor.col + 1);
+                line.replace_range(byte_idx..next_byte_idx, "");
+                return Some(Splice {
+                    index: offset,
+                    delete_count: 1,
+                    text: String::new(),
+                });
+            }
+        } else if self.cursor.line > 0 {
+            // Join with previous line — delete the '\n' before this line
+            self.cursor.line -= 1;
+            self.cursor.col = self.edit_buffer[self.cursor.line].chars().count();
+            let offset = self.cursor_char_offset();
+            let current = self.edit_buffer.remove(self.cursor.line + 1);
+            self.edit_buffer[self.cursor.line].push_str(&current);
+            return Some(Splice {
+                index: offset,
+                delete_count: 1,
+                text: String::new(),
+            });
+        }
+        None
+    }
+
+    /// Delete the character at the cursor (delete key). Returns a splice op.
+    pub fn edit_delete(&mut self) -> Option<Splice> {
+        let offset = self.cursor_char_offset();
+        if let Some(line) = self.edit_buffer.get_mut(self.cursor.line) {
+            let char_count = line.chars().count();
+            if self.cursor.col < char_count {
+                let byte_idx = char_to_byte_index(line, self.cursor.col);
+                let next_byte_idx = char_to_byte_index(line, self.cursor.col + 1);
+                line.replace_range(byte_idx..next_byte_idx, "");
+                return Some(Splice {
+                    index: offset,
+                    delete_count: 1,
+                    text: String::new(),
+                });
+            } else if self.cursor.line + 1 < self.edit_buffer.len() {
+                // Join with next line — delete the '\n'
+                let next = self.edit_buffer.remove(self.cursor.line + 1);
+                self.edit_buffer[self.cursor.line].push_str(&next);
+                return Some(Splice {
+                    index: offset,
+                    delete_count: 1,
+                    text: String::new(),
+                });
+            }
+        }
+        None
+    }
+
+    /// Insert multiple characters (e.g. tab = 4 spaces). Returns a splice op.
+    pub fn edit_insert_str(&mut self, s: &str) -> Option<Splice> {
+        let offset = self.cursor_char_offset();
+        if let Some(line) = self.edit_buffer.get_mut(self.cursor.line) {
+            let byte_idx = char_to_byte_index(line, self.cursor.col);
+            line.insert_str(byte_idx, s);
+            self.cursor.col += s.chars().count();
+            return Some(Splice {
+                index: offset,
+                delete_count: 0,
+                text: s.to_string(),
+            });
+        }
+        None
+    }
+
+    /// Move cursor in edit mode.
+    pub fn edit_move_cursor(&mut self, dir: CursorDir) {
+        match dir {
+            CursorDir::Left => {
+                if self.cursor.col > 0 {
+                    self.cursor.col -= 1;
+                }
+            }
+            CursorDir::Right => {
+                if let Some(line) = self.edit_buffer.get(self.cursor.line) {
+                    if self.cursor.col < line.chars().count() {
+                        self.cursor.col += 1;
+                    }
+                }
+            }
+            CursorDir::Up => {
+                if self.cursor.line > 0 {
+                    self.cursor.line -= 1;
+                    self.clamp_cursor_col();
+                }
+            }
+            CursorDir::Down => {
+                if self.cursor.line + 1 < self.edit_buffer.len() {
+                    self.cursor.line += 1;
+                    self.clamp_cursor_col();
+                }
+            }
+            CursorDir::Home => {
+                self.cursor.col = 0;
+            }
+            CursorDir::End => {
+                if let Some(line) = self.edit_buffer.get(self.cursor.line) {
+                    self.cursor.col = line.chars().count();
+                }
+            }
+        }
+    }
+
+    fn clamp_cursor_col(&mut self) {
+        if let Some(line) = self.edit_buffer.get(self.cursor.line) {
+            let max_col = line.chars().count();
+            if self.cursor.col > max_col {
+                self.cursor.col = max_col;
+            }
+        }
+    }
+}
+
+/// A splice operation to send to the CRDT.
+pub struct Splice {
+    pub index: usize,
+    pub delete_count: usize,
+    pub text: String,
+}
+
+pub enum CursorDir {
+    Left,
+    Right,
+    Up,
+    Down,
+    Home,
+    End,
+}
+
+/// Convert a char-based column to a byte index in a string.
+fn char_to_byte_index(s: &str, char_idx: usize) -> usize {
+    s.char_indices()
+        .nth(char_idx)
+        .map(|(i, _)| i)
+        .unwrap_or(s.len())
 }

--- a/crates/runt/src/tui/state.rs
+++ b/crates/runt/src/tui/state.rs
@@ -1,0 +1,183 @@
+use std::path::PathBuf;
+
+use notebook_doc::CellSnapshot;
+use notebook_protocol::protocol::NotebookBroadcast;
+use runtimed::output_resolver::{output_from_json, resolve_cell_outputs};
+use runtimed::resolved_output::Output;
+
+/// Application state for the TUI.
+pub struct App {
+    pub cells: Vec<CellView>,
+    pub selected: usize,
+    pub scroll_offset: u16,
+    pub kernel_status: String,
+    pub kernel_language: String,
+    pub notebook_path: String,
+    pub should_quit: bool,
+    _blob_base_url: Option<String>,
+    _blob_store_path: Option<PathBuf>,
+}
+
+/// A cell ready for display.
+pub struct CellView {
+    pub id: String,
+    pub cell_type: String,
+    pub source: String,
+    pub execution_count: Option<i64>,
+    pub outputs: Vec<Output>,
+}
+
+impl CellView {
+    fn from_snapshot(snapshot: CellSnapshot, outputs: Vec<Output>) -> Self {
+        let execution_count = snapshot.execution_count.parse::<i64>().ok();
+        Self {
+            id: snapshot.id,
+            cell_type: snapshot.cell_type,
+            source: snapshot.source,
+            execution_count,
+            outputs,
+        }
+    }
+
+    /// Extract displayable text from an output.
+    pub fn output_text(output: &Output) -> String {
+        match output.output_type.as_str() {
+            "stream" => output.text.clone().unwrap_or_default(),
+            "execute_result" | "display_data" => {
+                if let Some(data) = &output.data {
+                    if let Some(runtimed::resolved_output::DataValue::Text(s)) =
+                        data.get("text/plain")
+                    {
+                        return s.clone();
+                    }
+                }
+                String::new()
+            }
+            "error" => {
+                let mut lines = Vec::new();
+                if let (Some(ename), Some(evalue)) = (&output.ename, &output.evalue) {
+                    lines.push(format!("{}: {}", ename, evalue));
+                }
+                if let Some(tb) = &output.traceback {
+                    lines.extend(tb.iter().cloned());
+                }
+                lines.join("\n")
+            }
+            _ => String::new(),
+        }
+    }
+}
+
+impl App {
+    /// Build initial state from cell snapshots, resolving outputs.
+    pub async fn from_cells(
+        cells: Vec<CellSnapshot>,
+        path: &str,
+        blob_base_url: &Option<String>,
+        blob_store_path: &Option<PathBuf>,
+    ) -> Self {
+        let mut cell_views = Vec::with_capacity(cells.len());
+        for snapshot in cells {
+            let outputs =
+                resolve_cell_outputs(&snapshot.outputs, blob_base_url, blob_store_path).await;
+            cell_views.push(CellView::from_snapshot(snapshot, outputs));
+        }
+        Self {
+            cells: cell_views,
+            selected: 0,
+            scroll_offset: 0,
+            kernel_status: "not_started".to_string(),
+            kernel_language: String::new(),
+            notebook_path: path.to_string(),
+            should_quit: false,
+            _blob_base_url: blob_base_url.clone(),
+            _blob_store_path: blob_store_path.clone(),
+        }
+    }
+
+    /// Apply a broadcast event from the daemon.
+    pub fn apply_broadcast(&mut self, broadcast: NotebookBroadcast) {
+        match broadcast {
+            NotebookBroadcast::KernelStatus { status, .. } => {
+                self.kernel_status = status;
+            }
+            NotebookBroadcast::ExecutionStarted {
+                cell_id,
+                execution_count,
+                ..
+            } => {
+                if let Some(cell) = self.cells.iter_mut().find(|c| c.id == cell_id) {
+                    cell.execution_count = Some(execution_count);
+                    cell.outputs.clear();
+                }
+            }
+            NotebookBroadcast::Output {
+                cell_id,
+                output_json,
+                output_index,
+                ..
+            } => {
+                if let Some(cell) = self.cells.iter_mut().find(|c| c.id == cell_id) {
+                    if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(&output_json) {
+                        if let Some(output_type) =
+                            parsed.get("output_type").and_then(|v| v.as_str())
+                        {
+                            if let Some(output) = output_from_json(output_type, &parsed) {
+                                if let Some(idx) = output_index {
+                                    if idx < cell.outputs.len() {
+                                        cell.outputs[idx] = output;
+                                    } else {
+                                        cell.outputs.push(output);
+                                    }
+                                } else {
+                                    cell.outputs.push(output);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            NotebookBroadcast::OutputsCleared { cell_id } => {
+                if let Some(cell) = self.cells.iter_mut().find(|c| c.id == cell_id) {
+                    cell.outputs.clear();
+                }
+            }
+            NotebookBroadcast::KernelError { error } => {
+                self.kernel_status = format!("error: {}", error);
+            }
+            _ => {}
+        }
+    }
+
+    /// Update kernel status from RuntimeState.
+    pub fn update_runtime_state(&mut self, state: notebook_doc::runtime_state::RuntimeState) {
+        self.kernel_status = state.kernel.status;
+        self.kernel_language = state.kernel.language;
+    }
+
+    pub fn select_next(&mut self) {
+        if self.selected + 1 < self.cells.len() {
+            self.selected += 1;
+        }
+    }
+
+    pub fn select_prev(&mut self) {
+        if self.selected > 0 {
+            self.selected -= 1;
+        }
+    }
+
+    pub fn select_first(&mut self) {
+        self.selected = 0;
+    }
+
+    pub fn select_last(&mut self) {
+        if !self.cells.is_empty() {
+            self.selected = self.cells.len() - 1;
+        }
+    }
+
+    pub fn selected_cell_id(&self) -> Option<&str> {
+        self.cells.get(self.selected).map(|c| c.id.as_str())
+    }
+}

--- a/crates/runt/src/tui/ui.rs
+++ b/crates/runt/src/tui/ui.rs
@@ -22,7 +22,7 @@ pub fn render(frame: &mut Frame, app: &App) {
 
     render_top_bar(frame, app, top_bar);
     render_cells(frame, app, cell_area);
-    render_bottom_bar(frame, bottom_bar);
+    render_bottom_bar(frame, app, bottom_bar);
 }
 
 fn render_top_bar(frame: &mut Frame, app: &App, area: Rect) {
@@ -94,7 +94,7 @@ fn render_cells(frame: &mut Frame, app: &App, area: Rect) {
         .cells
         .iter()
         .enumerate()
-        .map(|(i, cell)| cell_height(cell, area.width, i == app.selected))
+        .map(|(i, cell)| cell_height(cell, area.width, i == app.selected, app))
         .collect();
 
     // Find the y-offset so the selected cell is visible
@@ -135,15 +135,21 @@ fn render_cells(frame: &mut Frame, app: &App, area: Rect) {
 
         if render_height > 0 {
             let cell_area = Rect::new(area.x, render_y, area.width, render_height);
-            render_cell(frame, cell, cell_area, i == app.selected);
+            render_cell(frame, cell, cell_area, i == app.selected, app);
         }
 
         y += h;
     }
 }
 
-fn cell_height(cell: &CellView, width: u16, _selected: bool) -> u16 {
-    let source_lines = cell.source.lines().count().max(1) as u16;
+fn cell_height(cell: &CellView, width: u16, _selected: bool, app: &App) -> u16 {
+    use super::state::Mode;
+
+    let source_lines = if _selected && app.mode == Mode::Edit {
+        app.edit_buffer.len().max(1) as u16
+    } else {
+        cell.source.lines().count().max(1) as u16
+    };
     // Prompt line (In [N]:) + source block (with borders = +2) + output lines + 1 gap
     let border_overhead: u16 = 2; // top + bottom border
     let source_height = source_lines + border_overhead;
@@ -169,12 +175,15 @@ fn cell_height(cell: &CellView, width: u16, _selected: bool) -> u16 {
     source_height + output_height + 1 // +1 gap between cells
 }
 
-fn render_cell(frame: &mut Frame, cell: &CellView, area: Rect, selected: bool) {
+fn render_cell(frame: &mut Frame, cell: &CellView, area: Rect, selected: bool, app: &App) {
+    use super::state::Mode;
+
     if area.height == 0 {
         return;
     }
 
     let is_code = cell.cell_type == "code";
+    let is_editing = selected && app.mode == Mode::Edit;
 
     // Prompt text
     let prompt = if is_code {
@@ -186,14 +195,22 @@ fn render_cell(frame: &mut Frame, cell: &CellView, area: Rect, selected: bool) {
         "Md:".to_string()
     };
 
-    let prompt_width = 9; // "In [99]: " — fixed width for alignment
+    let prompt_width = 9;
 
     // Selection marker
-    let marker = if selected { "► " } else { "  " };
+    let marker = if is_editing {
+        "* "
+    } else if selected {
+        "► "
+    } else {
+        "  "
+    };
     let left_margin = marker.len() + prompt_width;
 
     // Source block
-    let border_style = if selected {
+    let border_style = if is_editing {
+        Style::default().fg(Color::Yellow)
+    } else if selected {
         Style::default().fg(Color::Cyan)
     } else {
         Style::default().fg(Color::DarkGray)
@@ -203,15 +220,26 @@ fn render_cell(frame: &mut Frame, cell: &CellView, area: Rect, selected: bool) {
         .borders(Borders::ALL)
         .border_style(border_style);
 
-    let source_text = Paragraph::new(cell.source.as_str())
+    // Use edit buffer when editing, otherwise cell source
+    let source_str = if is_editing {
+        app.edit_buffer.join("\n")
+    } else {
+        cell.source.clone()
+    };
+
+    let source_text = Paragraph::new(source_str.as_str())
         .block(source_block)
         .wrap(Wrap { trim: false });
 
-    let source_lines = cell.source.lines().count().max(1) as u16;
-    let source_height = (source_lines + 2).min(area.height); // +2 for borders
+    let source_lines = source_str.lines().count().max(1) as u16;
+    let source_height = (source_lines + 2).min(area.height);
 
     // Render prompt
-    let prompt_style = if selected {
+    let prompt_style = if is_editing {
+        Style::default()
+            .fg(Color::Yellow)
+            .add_modifier(Modifier::BOLD)
+    } else if selected {
         Style::default()
             .fg(Color::Cyan)
             .add_modifier(Modifier::BOLD)
@@ -220,7 +248,14 @@ fn render_cell(frame: &mut Frame, cell: &CellView, area: Rect, selected: bool) {
     };
 
     let prompt_line = Line::from(vec![
-        Span::styled(marker, Style::default().fg(Color::Cyan)),
+        Span::styled(
+            marker,
+            Style::default().fg(if is_editing {
+                Color::Yellow
+            } else {
+                Color::Cyan
+            }),
+        ),
         Span::styled(
             format!("{:>width$}", prompt, width = prompt_width),
             prompt_style,
@@ -242,6 +277,15 @@ fn render_cell(frame: &mut Frame, cell: &CellView, area: Rect, selected: bool) {
             source_text,
             Rect::new(source_x, area.y, source_w, source_height),
         );
+    }
+
+    // Position cursor when editing (+1 for border)
+    if is_editing {
+        let cursor_x = source_x + 1 + app.cursor.col as u16;
+        let cursor_y = area.y + 1 + app.cursor.line as u16;
+        if cursor_x < area.x + area.width && cursor_y < area.y + area.height {
+            frame.set_cursor_position((cursor_x, cursor_y));
+        }
     }
 
     // Render outputs below source
@@ -339,17 +383,37 @@ fn render_outputs(frame: &mut Frame, cell: &CellView, x: u16, y: u16, width: u16
     }
 }
 
-fn render_bottom_bar(frame: &mut Frame, area: Rect) {
-    let hints = Line::from(vec![
-        Span::styled(" j/k", Style::default().add_modifier(Modifier::BOLD)),
-        Span::raw(":navigate  "),
-        Span::styled("Ctrl+Enter", Style::default().add_modifier(Modifier::BOLD)),
-        Span::raw(":execute  "),
-        Span::styled("g/G", Style::default().add_modifier(Modifier::BOLD)),
-        Span::raw(":first/last  "),
-        Span::styled("q", Style::default().add_modifier(Modifier::BOLD)),
-        Span::raw(":quit"),
-    ]);
+fn render_bottom_bar(frame: &mut Frame, app: &App, area: Rect) {
+    use super::state::Mode;
+
+    let hints = match app.mode {
+        Mode::Normal => Line::from(vec![
+            Span::styled(" j/k", Style::default().add_modifier(Modifier::BOLD)),
+            Span::raw(":navigate  "),
+            Span::styled("i/Enter", Style::default().add_modifier(Modifier::BOLD)),
+            Span::raw(":edit  "),
+            Span::styled("Shift+Enter", Style::default().add_modifier(Modifier::BOLD)),
+            Span::raw(":execute  "),
+            Span::styled("g/G", Style::default().add_modifier(Modifier::BOLD)),
+            Span::raw(":first/last  "),
+            Span::styled("q", Style::default().add_modifier(Modifier::BOLD)),
+            Span::raw(":quit"),
+        ]),
+        Mode::Edit => Line::from(vec![
+            Span::styled(
+                " -- EDIT -- ",
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled("Esc", Style::default().add_modifier(Modifier::BOLD)),
+            Span::raw(":done  "),
+            Span::styled("Shift+Enter", Style::default().add_modifier(Modifier::BOLD)),
+            Span::raw(":run & move down  "),
+            Span::styled("Tab", Style::default().add_modifier(Modifier::BOLD)),
+            Span::raw(":indent"),
+        ]),
+    };
 
     frame.render_widget(
         Paragraph::new(hints).style(Style::default().bg(Color::DarkGray).fg(Color::White)),

--- a/crates/runt/src/tui/ui.rs
+++ b/crates/runt/src/tui/ui.rs
@@ -1,0 +1,368 @@
+use ansi_to_tui::IntoText;
+use ratatui::{
+    layout::{Constraint, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span, Text},
+    widgets::{Block, Borders, Paragraph, Wrap},
+    Frame,
+};
+
+use super::state::{App, CellView};
+
+/// Render the entire TUI.
+pub fn render(frame: &mut Frame, app: &App) {
+    let area = frame.area();
+
+    let [top_bar, cell_area, bottom_bar] = Layout::vertical([
+        Constraint::Length(1),
+        Constraint::Min(1),
+        Constraint::Length(1),
+    ])
+    .areas(area);
+
+    render_top_bar(frame, app, top_bar);
+    render_cells(frame, app, cell_area);
+    render_bottom_bar(frame, bottom_bar);
+}
+
+fn render_top_bar(frame: &mut Frame, app: &App, area: Rect) {
+    let path = shorten_path(&app.notebook_path);
+
+    let status_color = match app.kernel_status.as_str() {
+        "idle" => Color::Green,
+        "busy" => Color::Yellow,
+        "starting" => Color::Cyan,
+        "not_started" => Color::DarkGray,
+        _ if app.kernel_status.starts_with("error") => Color::Red,
+        _ => Color::White,
+    };
+
+    let lang = if app.kernel_language.is_empty() {
+        String::new()
+    } else {
+        format!(" ({})", app.kernel_language)
+    };
+
+    let status_text = format!(" kernel: {}{} ", app.kernel_status, lang);
+    let status_len = status_text.len() as u16;
+    let path_max = area.width.saturating_sub(status_len);
+
+    let path_display = if path.len() as u16 > path_max {
+        format!(
+            "...{}",
+            &path[path.len().saturating_sub(path_max as usize - 3)..]
+        )
+    } else {
+        path.clone()
+    };
+
+    let line = Line::from(vec![
+        Span::styled(
+            format!(" {}", path_display),
+            Style::default().add_modifier(Modifier::BOLD),
+        ),
+        Span::raw(
+            " ".repeat(
+                area.width
+                    .saturating_sub(path_display.len() as u16 + 1 + status_len)
+                    as usize,
+            ),
+        ),
+        Span::styled(
+            status_text,
+            Style::default()
+                .fg(status_color)
+                .add_modifier(Modifier::BOLD),
+        ),
+    ]);
+
+    frame.render_widget(
+        Paragraph::new(line).style(Style::default().bg(Color::DarkGray).fg(Color::White)),
+        area,
+    );
+}
+
+fn render_cells(frame: &mut Frame, app: &App, area: Rect) {
+    if app.cells.is_empty() {
+        let empty = Paragraph::new("  No cells").style(Style::default().fg(Color::DarkGray));
+        frame.render_widget(empty, area);
+        return;
+    }
+
+    // Calculate heights for each cell and find the scroll position
+    let cell_heights: Vec<u16> = app
+        .cells
+        .iter()
+        .enumerate()
+        .map(|(i, cell)| cell_height(cell, area.width, i == app.selected))
+        .collect();
+
+    // Find the y-offset so the selected cell is visible
+    let total_before_selected: u16 = cell_heights[..app.selected].iter().sum();
+    let selected_height = cell_heights[app.selected];
+    let visible_height = area.height;
+
+    let scroll_y = if total_before_selected < app.scroll_offset {
+        total_before_selected
+    } else if total_before_selected + selected_height > app.scroll_offset + visible_height {
+        (total_before_selected + selected_height).saturating_sub(visible_height)
+    } else {
+        app.scroll_offset
+    };
+
+    // Render cells into a virtual canvas, then clip to the viewport
+    let mut y: u16 = 0;
+    for (i, cell) in app.cells.iter().enumerate() {
+        let h = cell_heights[i];
+        let cell_top = y;
+        let cell_bottom = y + h;
+
+        // Skip if entirely above viewport
+        if cell_bottom <= scroll_y {
+            y += h;
+            continue;
+        }
+        // Stop if entirely below viewport
+        if cell_top >= scroll_y + visible_height {
+            break;
+        }
+
+        // Calculate clipped region
+        let render_y = area.y + cell_top.saturating_sub(scroll_y);
+        let render_height = h
+            .min(scroll_y + visible_height - cell_top.max(scroll_y))
+            .min(area.y + area.height - render_y);
+
+        if render_height > 0 {
+            let cell_area = Rect::new(area.x, render_y, area.width, render_height);
+            render_cell(frame, cell, cell_area, i == app.selected);
+        }
+
+        y += h;
+    }
+}
+
+fn cell_height(cell: &CellView, width: u16, _selected: bool) -> u16 {
+    let source_lines = cell.source.lines().count().max(1) as u16;
+    // Prompt line (In [N]:) + source block (with borders = +2) + output lines + 1 gap
+    let border_overhead: u16 = 2; // top + bottom border
+    let source_height = source_lines + border_overhead;
+
+    let output_lines: u16 = cell
+        .outputs
+        .iter()
+        .map(|o| {
+            let text = CellView::output_text(o);
+            let lines = text.lines().count().max(0) as u16;
+            // Limit output display to prevent massive cells
+            lines.min(20)
+        })
+        .sum();
+
+    let output_height = if output_lines > 0 {
+        output_lines + 1 // +1 for the Out[N]: prompt
+    } else {
+        0
+    };
+
+    let _ = width; // reserved for wrapping calc
+    source_height + output_height + 1 // +1 gap between cells
+}
+
+fn render_cell(frame: &mut Frame, cell: &CellView, area: Rect, selected: bool) {
+    if area.height == 0 {
+        return;
+    }
+
+    let is_code = cell.cell_type == "code";
+
+    // Prompt text
+    let prompt = if is_code {
+        match cell.execution_count {
+            Some(n) => format!("In [{}]:", n),
+            None => "In [ ]:".to_string(),
+        }
+    } else {
+        "Md:".to_string()
+    };
+
+    let prompt_width = 9; // "In [99]: " — fixed width for alignment
+
+    // Selection marker
+    let marker = if selected { "► " } else { "  " };
+    let left_margin = marker.len() + prompt_width;
+
+    // Source block
+    let border_style = if selected {
+        Style::default().fg(Color::Cyan)
+    } else {
+        Style::default().fg(Color::DarkGray)
+    };
+
+    let source_block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(border_style);
+
+    let source_text = Paragraph::new(cell.source.as_str())
+        .block(source_block)
+        .wrap(Wrap { trim: false });
+
+    let source_lines = cell.source.lines().count().max(1) as u16;
+    let source_height = (source_lines + 2).min(area.height); // +2 for borders
+
+    // Render prompt
+    let prompt_style = if selected {
+        Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(Color::Blue)
+    };
+
+    let prompt_line = Line::from(vec![
+        Span::styled(marker, Style::default().fg(Color::Cyan)),
+        Span::styled(
+            format!("{:>width$}", prompt, width = prompt_width),
+            prompt_style,
+        ),
+    ]);
+
+    if area.height >= 1 {
+        frame.render_widget(
+            Paragraph::new(prompt_line),
+            Rect::new(area.x, area.y, left_margin as u16, 1),
+        );
+    }
+
+    // Render source
+    let source_x = area.x + left_margin as u16;
+    let source_w = area.width.saturating_sub(left_margin as u16 + 1);
+    if source_w > 2 && source_height > 0 {
+        frame.render_widget(
+            source_text,
+            Rect::new(source_x, area.y, source_w, source_height),
+        );
+    }
+
+    // Render outputs below source
+    if is_code && !cell.outputs.is_empty() {
+        let output_y = area.y + source_height;
+        let remaining = area.height.saturating_sub(source_height);
+        if remaining > 0 {
+            render_outputs(frame, cell, area.x, output_y, area.width, remaining);
+        }
+    }
+}
+
+fn render_outputs(frame: &mut Frame, cell: &CellView, x: u16, y: u16, width: u16, max_height: u16) {
+    let left_margin = 11u16; // align with source
+
+    let mut current_y = y;
+
+    for output in &cell.outputs {
+        if current_y >= y + max_height {
+            break;
+        }
+
+        let is_error = output.output_type == "error";
+        let is_stderr = output.name.as_deref() == Some("stderr");
+
+        let raw_text = CellView::output_text(output);
+        if raw_text.is_empty() {
+            continue;
+        }
+
+        // Convert ANSI to ratatui Text
+        let styled_text = raw_text
+            .as_bytes()
+            .into_text()
+            .unwrap_or_else(|_| Text::raw(&raw_text));
+
+        // Limit lines
+        let max_lines = (y + max_height - current_y) as usize;
+        let total_lines = styled_text.lines.len();
+        let display_lines = total_lines.min(max_lines).min(20);
+
+        let truncated: Text = if display_lines < total_lines {
+            let mut lines: Vec<Line> = styled_text
+                .lines
+                .into_iter()
+                .take(display_lines - 1)
+                .collect();
+            lines.push(Line::from(Span::styled(
+                format!("  ... ({} more lines)", total_lines - display_lines + 1),
+                Style::default().fg(Color::DarkGray),
+            )));
+            Text::from(lines)
+        } else {
+            styled_text
+        };
+
+        // Output prompt for first output
+        if current_y == y {
+            let out_prompt = if let Some(n) = cell.execution_count {
+                format!("Out[{}]:", n)
+            } else {
+                "Out:".to_string()
+            };
+            let prompt_style = if is_error || is_stderr {
+                Style::default().fg(Color::Red)
+            } else {
+                Style::default().fg(Color::Red).add_modifier(Modifier::DIM)
+            };
+            frame.render_widget(
+                Paragraph::new(Span::styled(
+                    format!("  {:>width$}", out_prompt, width = 9),
+                    prompt_style,
+                )),
+                Rect::new(x, current_y, left_margin, 1),
+            );
+        }
+
+        let output_style = if is_error || is_stderr {
+            Style::default().fg(Color::Red)
+        } else {
+            Style::default()
+        };
+
+        let out_w = width.saturating_sub(left_margin + 1);
+        if out_w > 0 {
+            frame.render_widget(
+                Paragraph::new(truncated)
+                    .style(output_style)
+                    .wrap(Wrap { trim: false }),
+                Rect::new(x + left_margin, current_y, out_w, display_lines as u16),
+            );
+        }
+
+        current_y += display_lines as u16;
+    }
+}
+
+fn render_bottom_bar(frame: &mut Frame, area: Rect) {
+    let hints = Line::from(vec![
+        Span::styled(" j/k", Style::default().add_modifier(Modifier::BOLD)),
+        Span::raw(":navigate  "),
+        Span::styled("Ctrl+Enter", Style::default().add_modifier(Modifier::BOLD)),
+        Span::raw(":execute  "),
+        Span::styled("g/G", Style::default().add_modifier(Modifier::BOLD)),
+        Span::raw(":first/last  "),
+        Span::styled("q", Style::default().add_modifier(Modifier::BOLD)),
+        Span::raw(":quit"),
+    ]);
+
+    frame.render_widget(
+        Paragraph::new(hints).style(Style::default().bg(Color::DarkGray).fg(Color::White)),
+        area,
+    );
+}
+
+fn shorten_path(path: &str) -> String {
+    if let Some(home) = dirs::home_dir() {
+        let home_str = home.to_string_lossy();
+        if path.starts_with(home_str.as_ref()) {
+            return format!("~{}", &path[home_str.len()..]);
+        }
+    }
+    path.to_string()
+}


### PR DESCRIPTION
## Summary

Adds a terminal UI for viewing and interacting with notebooks, powered by [ratatui](https://ratatui.rs/). Connect to any active notebook with `runt tui <path>` to navigate cells, edit source, execute code, and see ANSI-styled outputs — all from the terminal.

- Connects to the daemon via `notebook-sync`, receives live cell/output updates
- Kitty keyboard protocol for Shift+Enter detection (execute + move down)
- Collaborative presence: broadcasts cursor position as `$USER:console`
- Cell editing with splice-based CRDT updates (not full-source replacement)
- ANSI escape code → ratatui `Style` conversion for rich kernel output
- IPython-style `In [N]` / `Out [N]` prompts with execution count and status indicators

### Keybindings

| Key | Normal Mode | Edit Mode |
|-----|------------|-----------|
| `j` / `k` | Navigate cells | — |
| `Enter` | Enter edit mode | Newline |
| `Shift+Enter` | Execute + move down | Execute + exit edit |
| `Escape` | — | Exit edit mode |
| `g` / `G` | First / last cell | — |
| `q` | Quit | — |

### New dependencies

`ratatui`, `crossterm`, `ansi-to-tui` added to `runt-cli`.

![TUI screenshot placeholder](placeholder)

## Verification

- [ ] `runt tui example.ipynb` connects to daemon and displays cells
- [ ] Navigate cells with `j`/`k`, `g`/`G`
- [ ] Enter edit mode, type code, exit with `Escape`
- [ ] Shift+Enter executes cell (requires kitty keyboard protocol — Ghostty, WezTerm, kitty)
- [ ] Kernel status shown in header, execution counts update after runs
- [ ] ANSI-colored output renders correctly (e.g. rich/colorama output)
- [ ] Open same notebook in desktop app — verify presence cursor from TUI appears

_PR submitted by @rgbkrk's agent, Quill_