### PR TITLE
chore(nix): update pnpmDeps hash

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -5,13 +5,6 @@ on:
     branches: [main]
     paths:
       - 'pnpm-lock.yaml'
-      - 'Cargo.lock'
-      - 'flake.nix'
-      - 'flake.lock'
-  pull_request:
-    paths:
-      - 'pnpm-lock.yaml'
-      - 'Cargo.lock'
       - 'flake.nix'
       - 'flake.lock'
   workflow_dispatch:
@@ -88,26 +81,8 @@ jobs:
             gh pr create \
               --title "chore(nix): update pnpmDeps hash" \
               --body "Automated update of the pnpmDeps hash in flake.nix. Triggered because pnpm-lock.yaml changed and the pre-fetched offline store hash is stale." \
-              --head "$BRANCH" \
-              --label "nix"
+              --head "$BRANCH"
           else
             echo "PR #$EXISTING already exists, branch updated via force-push"
           fi
 
-  check:
-    name: Verify Nix build
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: cachix/install-nix-action@v27
-        with:
-          extra_nix_config: |
-            experimental-features = nix-command flakes
-
-      - name: Check pnpmDeps hash
-        run: nix build .#pnpmDeps --no-link
-
-      - name: Check flake evaluates
-        run: nix flake check --no-build

--- a/flake.nix
+++ b/flake.nix
@@ -97,7 +97,7 @@
           src = filteredSrc;
           fetcherVersion = 2;
           # Update with: nix build .#pnpmDeps 2>&1 | grep 'got:'
-          hash = "sha256-KNXaoPgtExg6T5HnvWkoNHHyqlQz4aJHLTCZJlt0CCU=";
+          hash = "sha256-17ivYUyT5QzpvVe63YSCotZarU9SENjwJuClU9ZH/Zw=";
         };
 
         jsBuild = pkgs.stdenv.mkDerivation {


### PR DESCRIPTION
Stop triggering the nix workflow on Cargo.lock and pnpm-lock.yaml for pull requests, this would just fail, we can have warnings but it's just simple to never let it run.