### PR TITLE
fix(nteract): graceful deprecation offramp for Python MCP server

### DIFF
--- a/python/nteract/src/nteract/_mcp_server.py
+++ b/python/nteract/src/nteract/_mcp_server.py
@@ -622,8 +622,31 @@ class NteractServer:
     over ``self``, so FastMCP sees clean function signatures.
     """
 
-    def __init__(self, *, channel: str | None = None, no_show: bool = False):
-        self.mcp = FastMCP("nteract")
+    def __init__(
+        self,
+        *,
+        channel: str | None = None,
+        no_show: bool = False,
+        deprecated: bool = False,
+    ):
+        self._deprecated = deprecated
+        self.mcp = FastMCP(
+            "nteract",
+            instructions=(
+                "nteract MCP server for AI-powered Jupyter notebooks. "
+                "Use list_active_notebooks to discover open notebooks, "
+                "then join_notebook or open_notebook to start working."
+                + (
+                    "\n\nNOTE: This Python MCP server is deprecated. "
+                    "For the best experience, install the nteract desktop app "
+                    "from https://nteract.io and update your MCP config to: "
+                    f"`{'runt-nightly' if channel == 'nightly' else 'runt'} mcp` "
+                    "(instead of `uvx nteract`)."
+                    if deprecated
+                    else ""
+                )
+            ),
+        )
         self._notebook: runtimed.Notebook | None = None
         self._client: runtimed.Client | None = None
         self._client_name: str | None = None
@@ -779,6 +802,27 @@ class NteractServer:
     def _register_tools(self, *, no_show: bool = False) -> None:  # noqa: C901
         srv = self
         _tool_app = AppConfig(resource_uri=_WIDGET_RESOURCE_URI)
+
+        if srv._deprecated:
+
+            @srv.mcp.tool(annotations=ToolAnnotations(readOnlyHint=True))
+            async def migration_guide() -> str:
+                """The Python nteract MCP server is deprecated.
+
+                Call this tool for steps to switch to `runt mcp`.
+                """
+                binary_name = "runt-nightly" if srv._channel == "nightly" else "runt"
+                return (
+                    "The `nteract` Python package (`uvx nteract`) is deprecated.\n\n"
+                    "To migrate:\n"
+                    f"1. Install the nteract desktop app from https://nteract.io\n"
+                    f"2. Update your MCP config to: `{binary_name} mcp`\n"
+                    f"   Instead of: `uvx nteract`\n\n"
+                    f"For Claude Code:\n"
+                    f"  `claude mcp remove nteract`\n"
+                    f"  `claude mcp add nteract -- {binary_name} mcp`\n\n"
+                    "The Rust MCP server is faster and actively maintained."
+                )
 
         # -- Session management --
 
@@ -1729,7 +1773,7 @@ def main():
     parser.add_argument(
         "--legacy",
         action="store_true",
-        help="Use the built-in Python MCP server instead of runt mcp.",
+        help="Use the built-in Python MCP server (deprecated) instead of runt mcp.",
     )
     args = parser.parse_args()
 
@@ -1753,23 +1797,16 @@ def main():
             # execvp never returns
         else:
             binary_name = "runt-nightly" if channel == "nightly" else "runt"
-            app_name = "nteract Nightly" if channel == "nightly" else "nteract"
             print(
-                f"Error: {binary_name} not found.\n\n"
-                f"Install {app_name} from https://nteract.io to use this MCP server.\n"
-                f"The app puts {binary_name} on your PATH during installation.\n"
-                f"\n"
-                f"To use the built-in Python MCP server instead, run:\n"
-                f"  nteract --legacy\n",
+                f"[nteract] {binary_name} not found, falling back to built-in Python MCP server.",
                 file=sys.stderr,
             )
-            raise SystemExit(1)
 
-    # Legacy path: run the built-in Python MCP server directly
+    # Legacy / fallback path: run the built-in Python MCP server directly
     if (args.nightly or args.stable) and not os.environ.get("RUNTIMED_SOCKET_PATH"):
         os.environ["RUNTIMED_SOCKET_PATH"] = runtimed.socket_path_for_channel(channel)
 
-    server = NteractServer(channel=channel, no_show=args.no_show)
+    server = NteractServer(channel=channel, no_show=args.no_show, deprecated=True)
 
     logging.basicConfig(
         level=logging.INFO,

--- a/python/nteract/tests/test_smoke.py
+++ b/python/nteract/tests/test_smoke.py
@@ -1,5 +1,6 @@
 """Smoke tests to verify the package can be imported."""
 
+import asyncio
 from unittest.mock import patch
 
 
@@ -18,12 +19,69 @@ def test_mcp_server_import():
     assert server.mcp.name == "nteract"
 
 
+def test_migration_guide_tool_when_deprecated():
+    """deprecated=True registers a migration_guide tool."""
+    from nteract._mcp_server import NteractServer
+
+    server = NteractServer(deprecated=True)
+    tool_names = [t.name for t in asyncio.run(server.mcp.list_tools())]
+    assert "migration_guide" in tool_names
+
+
+def test_no_migration_guide_tool_when_not_deprecated():
+    """deprecated=False does not register migration_guide."""
+    from nteract._mcp_server import NteractServer
+
+    server = NteractServer(deprecated=False)
+    tool_names = [t.name for t in asyncio.run(server.mcp.list_tools())]
+    assert "migration_guide" not in tool_names
+
+
+def test_instructions_include_deprecation_when_deprecated():
+    """Server instructions mention deprecation when deprecated=True."""
+    from nteract._mcp_server import NteractServer
+
+    server = NteractServer(deprecated=True)
+    assert "deprecated" in server.mcp.instructions.lower()
+
+
+def test_instructions_no_deprecation_when_not_deprecated():
+    """Server instructions do not mention deprecation when deprecated=False."""
+    from nteract._mcp_server import NteractServer
+
+    server = NteractServer(deprecated=False)
+    assert "deprecated" not in (server.mcp.instructions or "").lower()
+
+
+def test_fallback_when_runt_not_found():
+    """When runt is not found, main() falls back to Python server instead of exiting."""
+    from nteract._mcp_server import main
+
+    with (
+        patch("nteract._mcp_server._find_runt_binary", return_value=None),
+        patch("nteract._mcp_server.NteractServer") as MockServer,
+        patch("sys.argv", ["nteract"]),
+    ):
+        instance = MockServer.return_value
+        instance.mcp.run.side_effect = KeyboardInterrupt
+        instance.cleanup = lambda: None
+        try:
+            main()
+        except SystemExit as e:
+            # Should exit 130 (KeyboardInterrupt), NOT 1
+            assert e.code == 130, f"Expected exit code 130 (fallback), got {e.code}"
+        MockServer.assert_called_once()
+        _, kwargs = MockServer.call_args
+        assert kwargs["deprecated"] is True
+
+
 def test_keyboard_interrupt_exits_130():
     """Ctrl+C should exit with code 130 (Unix SIGINT convention), not dump a traceback."""
     from nteract._mcp_server import main
 
-    with patch("nteract._mcp_server.NteractServer") as MockServer, patch(
-        "sys.argv", ["nteract", "--legacy"]
+    with (
+        patch("nteract._mcp_server.NteractServer") as MockServer,
+        patch("sys.argv", ["nteract", "--legacy"]),
     ):
         instance = MockServer.return_value
         instance.mcp.run.side_effect = KeyboardInterrupt


### PR DESCRIPTION
## Summary

- When `runt` binary isn't found, fall back to the built-in Python MCP server instead of hard-exiting with code 1
- Add a `migration_guide` tool that surfaces deprecation notice and concrete migration steps through tool descriptions (visible to agents/users, unlike stderr)
- Add deprecation note to FastMCP server instructions (visible to clients like Claude Code that surface them)
- Both are channel-aware (`runt` vs `runt-nightly`)

Fixes the breakage introduced in #1317 for `uvx nteract` users who don't have the desktop app installed.

## Test plan

- [x] 8 smoke tests pass (`uv run pytest python/nteract/tests/ -v`)
- [x] `cargo xtask lint` clean
- [ ] CI passes
- [ ] Manual: `uvx nteract --legacy` shows `migration_guide` in tool list