### PR TITLE
Update docs and agent guides to match current build, testing, and runtime behavior

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -87,7 +87,7 @@ Three implementations **MUST stay in sync**. Update all three when changing MIME
 | Location | Language | Function |
 |----------|----------|----------|
 | `crates/runtimed/src/output_store.rs` | Rust | `is_binary_mime()` |
-| `crates/runtimed-py/src/output_resolver.rs` | Rust | `is_binary_mime()` |
+| `crates/runtimed-client/src/output_resolver.rs` | Rust | `mime_kind()` |
 | `apps/notebook/src/lib/manifest-resolution.ts` | TypeScript | `isBinaryMime()` |
 
 Classification rules:
@@ -169,7 +169,7 @@ Never pass code directly in execution requests. The correct flow: write to the C
 | `crates/runtimed/src/output_store.rs` | Manifest creation/resolution, `is_binary_mime()`, `ContentRef` |
 | `crates/runtimed/src/blob_store.rs` | Content-addressed storage |
 | `crates/runtimed/src/blob_server.rs` | HTTP server for blob retrieval |
-| `crates/runtimed-py/src/output_resolver.rs` | Python-side resolution, `is_binary_mime()` |
+| `crates/runtimed-client/src/output_resolver.rs` | Shared Rust resolution, `mime_kind()` |
 | `apps/notebook/src/lib/manifest-resolution.ts` | Frontend resolution, `isBinaryMime()` |
 | `apps/notebook/src/lib/materialize-cells.ts` | WASM -> React conversion |
 | `apps/notebook/src/lib/notebook-cells.ts` | Split cell store, per-cell subscriptions |

--- a/.claude/rules/iframe-isolation.md
+++ b/.claude/rules/iframe-isolation.md
@@ -43,46 +43,26 @@ The iframe's message handler validates `event.source !== window.parent` to rejec
 |-----------|----------|---------|
 | `IsolatedFrame` | `src/components/isolated/isolated-frame.tsx` | Manages blob URL lifecycle |
 | `CommBridgeManager` | `src/components/isolated/comm-bridge-manager.ts` | Parent-side: syncs widget state to iframe |
-| `WidgetBridgeClient` | `src/isolated-renderer/widget-bridge-client.ts` | Iframe-side: receives comm messages |
+| `jsonrpc-transport.ts` | `src/components/isolated/jsonrpc-transport.ts` | JSON-RPC 2.0 transport over `postMessage` |
+| `rpc-methods.ts` | `src/components/isolated/rpc-methods.ts` | Shared widget bridge method constants |
+| `WidgetBridgeClient` | `src/isolated-renderer/widget-bridge-client.ts` | Iframe-side JSON-RPC widget bridge |
 | `frame-html.ts` | `src/components/isolated/frame-html.ts` | Generates bootstrap HTML for iframe |
-| `frame-bridge.ts` | `src/components/isolated/frame-bridge.ts` | Message type definitions and guards |
+| `frame-bridge.ts` | `src/components/isolated/frame-bridge.ts` | Legacy frame message definitions and guards |
 
 The isolated renderer bundle is built inline via Vite plugin (`apps/notebook/vite-plugin-isolated-renderer.ts`) and provided via `IsolatedRendererProvider` context.
 
 ## Message Protocol
 
-### Parent -> Iframe
+Two layers coexist:
 
-| Message | Purpose |
-|---------|---------|
-| `eval` | Bootstrap: inject React renderer bundle |
-| `render` | Render output content (HTML, markdown, etc.) |
-| `theme` | Sync dark/light mode |
-| `clear` | Clear all outputs |
-| `comm_open` | Forward widget creation from kernel |
-| `comm_msg` | Forward state update or custom message |
-| `comm_close` | Forward widget destruction |
-| `comm_sync` | Bulk sync all existing models on ready |
-| `bridge_ready` | Signal parent bridge is initialized |
-| `ping` | Liveness check |
-| `search` | Trigger in-iframe text search |
+1. **Frame bootstrap/render messages** in `frame-bridge.ts` handle events like
+   `eval`, `render`, `theme`, `clear`, `resize`, `link_click`, and search flow.
+2. **Widget sync traffic** uses JSON-RPC 2.0 over `postMessage`, implemented by
+   `jsonrpc-transport.ts` and `rpc-methods.ts`.
 
-### Iframe -> Parent
-
-| Message | Purpose |
-|---------|---------|
-| `ready` | Bootstrap HTML loaded |
-| `renderer_ready` | React bundle initialized |
-| `widget_ready` | Widget system ready for comm_sync |
-| `resize` | Content height changed |
-| `error` | JavaScript error occurred |
-| `link_click` | User clicked a link |
-| `widget_comm_msg` | Widget state update (forward to kernel) |
-| `widget_comm_close` | Widget close request |
-| `pong` | Response to ping |
-| `render_complete` | Content finished rendering |
-| `dblclick` | Double-click event (for cell editing) |
-| `search_results` | Search match count/position info |
+The JSON-RPC widget methods include:
+- Parent -> iframe: `nteract/bridgeReady`, `nteract/commOpen`, `nteract/commMsg`, `nteract/commClose`, `nteract/commSync`
+- Iframe -> parent: `nteract/widgetReady`, `nteract/widgetCommMsg`, `nteract/widgetCommClose`
 
 ### Widget Sync Flow
 
@@ -90,11 +70,11 @@ The isolated renderer bundle is built inline via Vite plugin (`apps/notebook/vit
 2. Iframe sends `ready`
 3. Parent sends `eval` (React bundle)
 4. Iframe sends `renderer_ready`
-5. CommBridgeManager sends `bridge_ready`
-6. Iframe sends `widget_ready`
-7. CommBridgeManager sends `comm_sync` (all existing models)
+5. CommBridgeManager sends `nteract/bridgeReady`
+6. Iframe sends `nteract/widgetReady`
+7. CommBridgeManager sends `nteract/commSync` (all existing models)
 8. Iframe renders widgets
-9. Bidirectional updates via `comm_msg` / `widget_comm_msg`
+9. Bidirectional widget updates flow through JSON-RPC notifications
 
 ## Critical Code Paths for Review
 

--- a/.claude/rules/logging.md
+++ b/.claude/rules/logging.md
@@ -76,7 +76,7 @@ logger.error("[component] Failure:", error);
 ### Log Level Behavior
 
 - **Nightly**: All levels (`debug`, `info`, `warn`, `error`) enabled by default
-- **Stable**: `logger.debug()` suppressed; `info`, `warn`, `error` always enabled
+- **Stable**: `logger.debug()` still goes through the logger, but the Rust-side filter usually drops it; `info`, `warn`, `error` remain visible
 - Level filter applied server-side by `tauri-plugin-log`
 
 ### What NOT to Log at Info Level
@@ -86,21 +86,12 @@ logger.error("[component] Failure:", error);
 - Internal state (blob port resolution, queue state)
 - Success cases for routine operations (hot-sync succeeded)
 
-### Enabling Debug Logs
+### Seeing Frontend Debug Logs
 
-In the browser console:
-```javascript
-localStorage.setItem('runt:debug', 'true');
-// Reload the page
-```
-
-To disable:
-```javascript
-localStorage.removeItem('runt:debug');
-// Reload the page
-```
-
-Debug mode is always enabled in development (`import.meta.env.DEV`).
+There is no `localStorage` debug toggle in the current app. Frontend logs go
+through `apps/notebook/src/lib/logger.ts`, and in development
+(`import.meta.env.DEV`) `attachConsole()` mirrors them into browser devtools.
+In packaged builds, visibility is controlled by the Rust-side app log level.
 
 ## Adding New Logging
 

--- a/.claude/rules/mcp-servers.md
+++ b/.claude/rules/mcp-servers.md
@@ -19,7 +19,7 @@ Three nteract MCP servers may be available. Always use the right one:
 1. **Always prefer `nteract-dev`** (`mcp__nteract-dev__*` tools) for development work in this repo. It connects to the per-worktree dev daemon and includes supervisor tools for managing the build/daemon lifecycle.
 2. **Never use `nteract-nightly` or `nteract` for development.** They connect to system-installed daemons and will not reflect your source changes.
 3. If `nteract-dev` tools are not available, fall back to `cargo xtask` commands — not to the system MCP servers.
-4. The supervisor tools (`supervisor_status`, `supervisor_restart`, `supervisor_rebuild`, `supervisor_logs`, `supervisor_start_vite`, `supervisor_stop`) are part of the `nteract-dev` server. They manage the dev daemon and build pipeline — prefer them over manual terminal commands.
+4. The supervisor tools (`supervisor_status`, `supervisor_restart`, `supervisor_rebuild`, `supervisor_logs`, `supervisor_vite_logs`, `supervisor_start_vite`, `supervisor_stop`, `supervisor_set_mode`) are part of the `nteract-dev` server. They manage the dev daemon and build pipeline — prefer them over manual terminal commands.
 
 ## MCP Server
 

--- a/.claude/rules/widget-development.md
+++ b/.claude/rules/widget-development.md
@@ -10,9 +10,9 @@ paths:
 
 Widgets run inside a security-isolated iframe. The parent window owns the WidgetStore and proxies Jupyter comm messages through the CommBridgeManager via postMessage. The iframe has no access to `window.__TAURI__` or parent DOM.
 
-**Parent window:** Kernel (via daemon) <-> WidgetStore (state management) <-> CommBridgeManager (routes messages) <-> postMessage boundary
+**Parent window:** Kernel (via daemon) <-> WidgetStore (state management) <-> CommBridgeManager (routes messages) <-> JSON-RPC `postMessage` boundary
 
-**Isolated iframe:** WidgetBridgeClient (receives msgs) <-> Widget Components (React renders)
+**Isolated iframe:** WidgetBridgeClient (JSON-RPC bridge) <-> Widget Components (React renders)
 
 ### Current State Architecture
 
@@ -35,8 +35,10 @@ New clients receive a `CommSync` broadcast (snapshot of all active widgets) on c
 | `src/components/widgets/anywidget-view.tsx` | AFM loader for anywidget ESM modules |
 | `src/components/widgets/widget-view.tsx` | Renders widgets by looking up registry |
 | `src/components/isolated/comm-bridge-manager.ts` | Routes comm messages between store and iframe |
-| `src/components/isolated/frame-bridge.ts` | Message protocol types and guards |
-| `src/isolated-renderer/widget-bridge-client.ts` | Iframe-side message handler |
+| `src/components/isolated/frame-bridge.ts` | Legacy frame message types and guards |
+| `src/components/isolated/jsonrpc-transport.ts` | JSON-RPC 2.0 transport over `postMessage` |
+| `src/components/isolated/rpc-methods.ts` | Shared widget bridge method constants |
+| `src/isolated-renderer/widget-bridge-client.ts` | Iframe-side JSON-RPC widget bridge |
 
 ## WidgetStore API
 
@@ -133,12 +135,9 @@ Anywidgets use ESM modules loaded at runtime. `anywidget-view.tsx` detects `_esm
 
 **Unit tests:** `src/components/widgets/__tests__/`
 
-**Enable debug logging:**
-```javascript
-// Browser console
-localStorage.setItem("runt:debug", "true");
-// Reload the page
-```
+**Frontend debug logs:** In development builds, `apps/notebook/src/lib/logger.ts`
+calls `attachConsole()` so frontend logs appear in browser devtools. There is no
+`localStorage` debug toggle in the current app.
 
 **Daemon comm logs:**
 ```bash
@@ -146,5 +145,5 @@ runt daemon logs -f | grep -i comm
 ```
 
 **Troubleshooting:**
-- Widget not rendering: Check iframe console, verify `comm_sync` was sent (look for `[CommBridge]` logs), check if type is in `ISOLATED_MIME_TYPES`
+- Widget not rendering: Check iframe console, verify `nteract/commSync` was sent and the iframe answered with `nteract/widgetReady`
 - Widget not receiving updates: Check custom message forwarding, verify `subscribeToModelCustomMessages` is called

--- a/.claude/skills/architecture-review/SKILL.md
+++ b/.claude/skills/architecture-review/SKILL.md
@@ -38,11 +38,11 @@ These are settled decisions. Treat them as given:
    `allow-same-origin`, blob URL origin isolation).
 6. **Content-addressed blob store** for outputs (binary data stays out of the CRDT).
 7. **Rust daemon** as the stateful backend (not an in-process library).
-8. **Python bindings (PyO3/maturin)** for the SDK and MCP server.
+8. **Python bindings (PyO3/maturin)** for the SDK and convenience wrappers around the runtime tooling.
 
 ## What Currently Exists
 
-The system is split into 15 Rust crates, a React/TypeScript frontend, and 3
+The system is split into 16 Rust crates, a React/TypeScript frontend, and 3
 Python packages. The major architectural seams are:
 
 ### Daemon ↔ Client Protocol

--- a/.claude/skills/build-system/SKILL.md
+++ b/.claude/skills/build-system/SKILL.md
@@ -27,7 +27,7 @@ Three phases:
 
 ## Crate dependency graph
 
-Leaf crates (no internal deps): `tauri-jupyter`, `kernel-launch`, `runt-trust`, `runt-workspace`
+Leaf crates (no internal deps): `kernel-launch`, `runt-trust`, `runt-workspace`
 
 Shared:
 - `notebook-doc` → no internal deps
@@ -36,9 +36,10 @@ Shared:
 - `runtimed` → `notebook-doc`, `notebook-protocol`, `kernel-launch`, `kernel-env`, `runt-trust`, `runt-workspace`
 
 App binaries:
-- `notebook` (Tauri) → `runtimed`, `notebook-sync`, `runt-trust`, `runt-workspace`
-- `runt-cli` → `runtimed`, `runt-workspace`
-- `runtimed-py` → `runtimed`, `notebook-doc`, `notebook-protocol`, `notebook-sync`, `runt-workspace`
+- `notebook` (Tauri) → `runtimed-client`, `notebook-doc`, `notebook-protocol`, `notebook-sync`, `runt-trust`, `runt-workspace`
+- `runt-cli` → `runtimed-client`, `notebook-doc`, `runt-workspace`, `kernel-env`, `runt-mcp`
+- `runtimed` → `runtimed-client`, `notebook-doc`, `notebook-protocol`, `kernel-launch`, `kernel-env`, `runt-trust`, `runt-workspace`
+- `runtimed-py` → `runtimed-client`, `notebook-doc`, `notebook-protocol`, `kernel-env`, `notebook-sync`, `runt-workspace`
 - `runtimed-wasm` → `notebook-doc`
 
 ## WASM rebuild

--- a/.claude/skills/daemon-dev/SKILL.md
+++ b/.claude/skills/daemon-dev/SKILL.md
@@ -141,26 +141,16 @@ let mut doc = room.doc.write().await;
 doc.merge(&mut fork).ok();
 ```
 
-For changes relative to a saved snapshot (e.g., file watcher):
-```rust
-let mut fork = doc.fork_at(&save_heads)?;
-fork.update_source(&cell_id, &disk_source).ok();
-doc.merge(&mut fork).ok();
-```
-
 For synchronous mutation blocks (no `.await` between fork and merge), prefer the helpers:
 ```rust
 doc.fork_and_merge(|fork| {
     fork.update_source(&cell_id, &new_source);
 });
-
-// Or at a historic point (e.g., file watcher at last save)
-doc.fork_at_and_merge(&save_heads, |fork| {
-    fork.update_source(&cell_id, &disk_source);
-})?;
 ```
 
-Key methods on `NotebookDoc`: `fork()`, `fork_at(heads)`, `get_heads()`, `merge()`, `fork_and_merge(f)`, `fork_at_and_merge(heads, f)`.
+Do not use `fork_at(...)` in current daemon code paths. The file watcher now compares against `last_save_sources` and uses `fork()` at current heads because `fork_at(...)` can trigger automerge/automerge#1327 on complex text histories.
+
+Key methods on `NotebookDoc`: `fork()`, `get_heads()`, `merge()`, `fork_and_merge(f)`.
 
 All async CRDT mutation paths in the daemon are now protected — see #1216.
 
@@ -171,7 +161,6 @@ crates/runtimed/src/
   lib.rs                   — Public types, path helpers
   main.rs                  — CLI entry point
   daemon.rs                — Daemon state, pool management, connection routing
-  protocol.rs              — BlobRequest/BlobResponse + re-exports
   notebook_sync_server.rs  — NotebookRoom, room lifecycle, autosave, re-keying
   kernel_manager.rs        — RoomKernel: lifecycle, execution queue, IOPub routing
   comm_state.rs            — Widget comm state + Output widget capture routing
@@ -179,18 +168,19 @@ crates/runtimed/src/
   blob_store.rs            — Content-addressed blob store with metadata sidecars
   blob_server.rs           — HTTP read server for blobs
   inline_env.rs            — Inline dependency environment caching
-  settings_doc.rs          — Settings Automerge document, schema, migration
-  sync_server.rs           — Settings sync handler
   stream_terminal.rs       — Stream terminal output handling
-  client.rs                — Internal daemon client for programmatic access
-  sync_client.rs           — Sync-flavored client wrapper
   singleton.rs             — Daemon singleton management (lock file, PID tracking)
   kernel_pids.rs           — Kernel process ID tracking and cleanup
   markdown_assets.rs       — Markdown output asset rendering and resolution
   terminal_size.rs         — Terminal size detection for kernel PTY
   project_file.rs          — Unified project file discovery (pyproject, pixi, env.yml)
+crates/runtimed-client/src/
+  client.rs                — Client APIs used by Python bindings and MCP
+  protocol.rs              — Client-side protocol helpers and typed request wrappers
+  settings_doc.rs          — Settings Automerge document, schema, migration
+  sync_client.rs           — Settings sync client wrapper
+  service.rs               — System service install/uninstall helpers
   runtime.rs               — Runtime enum (Python, Deno) and detection
-  service.rs               — System service install/uninstall (launchd, systemd)
 ```
 
 ## Related Crates
@@ -247,7 +237,7 @@ Each cell execution is tracked by a unique `execution_id` (UUID):
 
 Settings are synced via a **separate Automerge document** (not the notebook doc). The daemon holds the canonical copy and persists to disk. Any window can write; all others receive changes via sync.
 
-Key files: `crates/runtimed/src/settings_doc.rs` (schema), `src/hooks/useSyncedSettings.ts` (frontend).
+Key files: `crates/runtimed-client/src/settings_doc.rs` (schema), `src/hooks/useSyncedSettings.ts` (frontend).
 
 ## Troubleshooting
 

--- a/.claude/skills/frontend-dev/SKILL.md
+++ b/.claude/skills/frontend-dev/SKILL.md
@@ -166,10 +166,12 @@ cargo xtask dev-mcp
 |------|---------|
 | `supervisor_status` | Child process, daemon, restart count, last error |
 | `supervisor_restart` | Restart child or daemon |
-| `supervisor_rebuild` | `maturin develop` into `.venv` + restart |
+| `supervisor_rebuild` | Rebuild the daemon binary plus Rust Python bindings, then restart the daemon and MCP child |
 | `supervisor_logs` | Tail daemon log file |
+| `supervisor_vite_logs` | Tail Vite dev server log file |
 | `supervisor_start_vite` | Start Vite dev server for hot-reload frontend dev |
 | `supervisor_stop` | Stop a managed process by name |
+| `supervisor_set_mode` | Switch the managed daemon between `debug` and `release` builds |
 
 ### Hot Reload
 

--- a/.claude/skills/frontend-dev/SKILL.md
+++ b/.claude/skills/frontend-dev/SKILL.md
@@ -124,7 +124,7 @@ RUNTIMED_DEV=1 cargo xtask notebook      # Terminal 2
 cargo xtask run-mcp
 ```
 
-Starts dev daemon, syncs venv, builds Python bindings, spawns nteract MCP server, proxies tool calls, watches for file changes, hot-reloads.
+Starts the dev daemon, launches the dev-only `nteract-dev` supervisor, spawns a child `runt mcp`, proxies notebook tool calls, watches for file changes, and hot-reloads. Python bindings are rebuilt when the watched Rust paths require it.
 
 For editor config:
 

--- a/.claude/skills/releasing/SKILL.md
+++ b/.claude/skills/releasing/SKILL.md
@@ -8,7 +8,7 @@ disable-model-invocation: true
 
 ## Version Scheme
 
-All published artifacts share the same version (semver). Four sources must stay in sync:
+All published artifacts share the same version (semver). Five sources must stay in sync:
 
 | Artifact | Version source |
 |---|---|
@@ -16,6 +16,7 @@ All published artifacts share the same version (semver). Four sources must stay 
 | `runt` CLI | `crates/runt/Cargo.toml` |
 | `runtimed` daemon | `crates/runtimed/Cargo.toml` |
 | `runtimed` Python package | `python/runtimed/pyproject.toml` |
+| `nteract` Python package | `python/nteract/pyproject.toml` |
 
 ### Internal Compatibility Markers
 
@@ -35,6 +36,7 @@ These evolve independently from each other and from the artifact version.
 #   crates/notebook/Cargo.toml
 #   crates/notebook/tauri.conf.json
 #   python/runtimed/pyproject.toml
+#   python/nteract/pyproject.toml
 
 # Then let Cargo.lock catch up:
 cargo check

--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -9,7 +9,7 @@ description: Run and write tests. Use when running tests, writing new tests, deb
 
 | Type | Location | Command | Framework |
 |------|----------|---------|-----------|
-| E2E | `e2e/specs/` | `./e2e/dev.sh test` | WebdriverIO + Mocha |
+| E2E | `e2e/specs/` | `cargo xtask e2e test` | WebdriverIO + Mocha |
 | Frontend unit | `src/**/__tests__/`, `apps/notebook/src/**/__tests__/` | `pnpm test` | Vitest + jsdom |
 | Rust unit | inline `#[cfg(test)]` | `cargo test` | built-in |
 | CLI behavior | `crates/runt/tests/*.hone` | `cargo hone test` | Hone (not yet published) |
@@ -125,26 +125,21 @@ RUNTIMED_INTEGRATION_TEST=1 pytest python/runtimed/tests/ -v
 ### Running (Native Mode)
 
 ```bash
-./e2e/dev.sh cycle          # Build + start + test
-./e2e/dev.sh build          # Build with WebDriver support
-./e2e/dev.sh start          # Start app with WebDriver server
-./e2e/dev.sh test           # Smoke test only
-./e2e/dev.sh test all       # All non-fixture specs
-./e2e/dev.sh stop           # Stop the running app
+cargo xtask e2e build       # Build with WebDriver support
+cargo xtask e2e test        # Smoke/default E2E run
+cargo xtask e2e test-all    # Full suite, including fixture coverage
 ```
 
-**Important:** Use `./e2e/dev.sh build` (not plain `cargo build`) — Tauri embeds frontend assets.
+**Important:** Use `cargo xtask e2e build` (not plain `cargo build`) — the E2E binary embeds frontend assets and enables the webdriver feature.
 
 ### Fixture Tests
 
 Fixture tests open a specific notebook and get a fresh app instance per test:
 
 ```bash
-./e2e/dev.sh test-fixture \
+cargo xtask e2e test-fixture \
   crates/notebook/fixtures/audit-test/1-vanilla.ipynb \
   e2e/specs/prewarmed-uv.spec.js
-
-./e2e/dev.sh test-fixtures   # Run all fixture tests
 ```
 
 ### Current Fixture Mapping
@@ -163,14 +158,14 @@ Fixture tests open a specific notebook and get a fresh app instance per test:
 1. Choose or create a fixture notebook in `crates/notebook/fixtures/audit-test/`
 2. Create the spec at `e2e/specs/my-feature.spec.js`
 3. Add to `FIXTURE_SPECS` in `e2e/wdio.conf.js`
-4. Add to `test-fixtures` in `e2e/dev.sh`
+4. Add it to the fixture coverage in `crates/xtask/src/main.rs` if it should participate in `cargo xtask e2e test-all`
 5. Add to CI in `.github/workflows/build.yml`
-6. Verify locally with `./e2e/dev.sh test-fixture`
+6. Verify locally with `cargo xtask e2e test-fixture ...`
 
 ### Adding a New Regular Test
 
 1. Create the spec at `e2e/specs/my-feature.spec.js`
-2. `test all` picks up `*.spec.js` files automatically (anything not in `FIXTURE_SPECS`)
+2. `cargo xtask e2e test` picks up non-fixture `*.spec.js` files automatically (anything not in `FIXTURE_SPECS`)
 
 ### Shared Helpers (e2e/helpers.js)
 
@@ -211,8 +206,8 @@ Other: `[data-cell-type="code"]`, `[data-cell-type="markdown"]`, `.cm-content[co
 
 ### Troubleshooting
 
-- **"E2E binary not found"** — Run `./e2e/dev.sh build` or `./e2e/dev.sh build-full`.
-- **"No WebDriver server on port 4444"** — Start the app first (`./e2e/dev.sh start`) or use `cycle`.
+- **"E2E binary not found"** — Run `cargo xtask e2e build`.
+- **"No WebDriver server on port 4445"** — Run `cargo xtask e2e test` / `test-fixture` so xtask launches the app and waits for the embedded webdriver server.
 - **"Malformed type for elementId"** — wry text-selector bug. Use `data-testid` selectors.
 - **Timeout errors** — Kernel startup is slow on first run. Use 60s+ timeouts.
 - **Flaky tests** — Use `waitUntil()` not `pause()`, use `typeSlowly()`, use `data-testid`.

--- a/.claude/skills/typescript-bindings/SKILL.md
+++ b/.claude/skills/typescript-bindings/SKILL.md
@@ -13,8 +13,8 @@ TypeScript types in `src/bindings/` are auto-generated from Rust structs and enu
 
 | Rust File | Generated Types |
 |-----------|-----------------|
-| `crates/runtimed/src/settings_doc.rs` | `ThemeMode`, `PythonEnvType`, `UvDefaults`, `CondaDefaults`, `SyncedSettings` |
-| `crates/runtimed/src/runtime.rs` | `Runtime` |
+| `crates/runtimed-client/src/settings_doc.rs` | `ThemeMode`, `PythonEnvType`, `UvDefaults`, `CondaDefaults`, `SyncedSettings` |
+| `crates/runtimed-client/src/runtime.rs` | `Runtime` |
 
 ## How It Works
 
@@ -132,7 +132,7 @@ function Settings() {
 | File | Role |
 |------|------|
 | `.cargo/config.toml` | Sets `TS_RS_EXPORT_DIR` |
-| `crates/runtimed/src/settings_doc.rs` | Main source of settings types |
-| `crates/runtimed/src/runtime.rs` | Runtime enum |
+| `crates/runtimed-client/src/settings_doc.rs` | Main source of settings types |
+| `crates/runtimed-client/src/runtime.rs` | Runtime enum |
 | `src/bindings/index.ts` | Re-exports all generated types |
 | `src/hooks/useSyncedSettings.ts` | Consumes the generated types |

--- a/.claude/skills/verify-changes/SKILL.md
+++ b/.claude/skills/verify-changes/SKILL.md
@@ -50,7 +50,7 @@ If narrow tests pass and you have `supervisor_*` and `open_notebook`/`execute_ce
 1. `create_notebook`
 2. `create_cell` with source `# round-trip test`
 3. `get_cell` — verify source matches exactly
-4. `set_cell_source` to change source
+4. `set_cell` to change source
 5. `get_cell` — verify source updated
 
 ### For MCP server changes (`python/nteract/`):

--- a/.codex/skills/nteract-daemon-dev/references/daemon-workflows.md
+++ b/.codex/skills/nteract-daemon-dev/references/daemon-workflows.md
@@ -65,6 +65,8 @@ If the MCP supervisor is available, prefer:
 - `supervisor_restart(target="daemon")`
 - `supervisor_status`
 - `supervisor_logs`
+- `supervisor_vite_logs` when you need the Vite side of a hot-reload session
+- `supervisor_set_mode` when you intentionally need the managed daemon in `release` instead of `debug`
 
 These avoid manual env-var mistakes.
 

--- a/.codex/skills/nteract-notebook-sync/references/crdt-ownership.md
+++ b/.codex/skills/nteract-notebook-sync/references/crdt-ownership.md
@@ -19,9 +19,9 @@ Any daemon code that reads from the CRDT doc, does async work (subprocess, I/O, 
 
 - **Async pattern:** `fork()` before the `.await`, mutate the fork, `merge()` after. The fork must be created *before* async work starts.
 - **Sync pattern:** `doc.fork_and_merge(|fork| { ... })` — handles fork/merge ordering automatically.
-- **Historic point:** `doc.fork_at_and_merge(&save_heads, |fork| { ... })` — for external content relative to a known save point.
+- **Historic save comparison:** compare against `last_save_sources`, then `fork()` at current heads and `merge()`. Avoid `fork_at(...)` in current daemon paths because of automerge/automerge#1327.
 
-Key methods on `NotebookDoc`: `fork()`, `fork_at(heads)`, `get_heads()`, `merge()`, `fork_and_merge(f)`, `fork_at_and_merge(heads, f)`.
+Key methods on `NotebookDoc`: `fork()`, `get_heads()`, `merge()`, `fork_and_merge(f)`.
 
 ## Common review questions
 

--- a/.codex/skills/nteract-notebook-sync/references/output-and-protocol.md
+++ b/.codex/skills/nteract-notebook-sync/references/output-and-protocol.md
@@ -19,7 +19,7 @@ When changing the wire handshake or typed frame semantics, also inspect:
 Keep these implementations in sync when changing text-vs-binary rules:
 
 - `crates/runtimed/src/output_store.rs`
-- `crates/runtimed-py/src/output_resolver.rs`
+- `crates/runtimed-client/src/output_resolver.rs`
 - `apps/notebook/src/lib/manifest-resolution.ts`
 
 Important rule: `image/svg+xml` is text, not binary.

--- a/.codex/skills/nteract-testing/references/test-matrix.md
+++ b/.codex/skills/nteract-testing/references/test-matrix.md
@@ -6,7 +6,7 @@
 - `crates/runtimed-wasm/**`, `apps/notebook/src/wasm/**`, notebook sync plumbing: start with `deno test --allow-read --allow-env --no-check crates/runtimed-wasm/tests/`
 - `apps/notebook/src/**` or shared frontend code: start with `pnpm test:run`
 - `python/runtimed/**`, `python/nteract/**`, `crates/runtimed-py/**`: start with targeted pytest or `uv run nteract`
-- `e2e/**` or cross-window UX flows: use `./e2e/dev.sh ...`
+- `e2e/**` or cross-window UX flows: use `cargo xtask e2e ...`
 
 ## Commands
 
@@ -49,9 +49,10 @@ python/runtimed/.venv/bin/python -m pytest python/runtimed/tests/test_daemon_int
 E2E:
 
 ```bash
-./e2e/dev.sh build
-./e2e/dev.sh start
-./e2e/dev.sh test
+cargo xtask e2e build
+cargo xtask e2e test
+# or a targeted fixture/spec pair:
+cargo xtask e2e test-fixture crates/notebook/fixtures/audit-test/1-vanilla.ipynb e2e/specs/prewarmed-uv.spec.js
 ```
 
 ## Gotchas
@@ -59,4 +60,4 @@ E2E:
 - `crates/runtimed-wasm/tests/cross_impl_test.ts` touches `Deno.env` at module scope, so it needs `--allow-env` even before daemon-backed cases run.
 - Some Deno tests type-check poorly in spite of working at runtime; `--no-check` is often the intended mode in this repo.
 - Python integration failures are often socket-selection problems before they are logic regressions.
-- E2E flows require the repo’s helper scripts; do not replace them with ad hoc Tauri launch commands.
+- E2E flows should go through `cargo xtask e2e ...`; it builds the webdriver-enabled binary, launches the app on port `4445`, and runs `pnpm test:e2e` with the right wiring.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -271,7 +271,7 @@ The supervisor watches source directories and auto-restarts the child on changes
 - **No MCP server** → use `cargo xtask run-mcp` to set one up
 - **Dev daemon not running** → nteract-dev starts it automatically via `supervisor_restart(target="daemon")`
 
-## Workspace Crates (17)
+## Workspace Crates (16)
 
 | Crate | Purpose |
 |-------|---------|
@@ -284,12 +284,11 @@ The supervisor watches source directories and auto-restarts the child on changes
 | `notebook-protocol` | Wire types — requests, responses, broadcasts |
 | `notebook-sync` | Automerge sync client — `DocHandle`, per-cell Python accessors |
 | `runt` | CLI — daemon management, kernel control, notebook launching, MCP server |
-| `runt-mcp` | Rust-native MCP server — 26 tools for notebook interaction via `runt mcp` |
+| `runt-mcp` | Rust-native MCP server — 27 tools for notebook interaction via `runt mcp` |
 | `runt-trust` | Notebook trust (HMAC-SHA256 over dependency metadata) |
 | `runt-workspace` | Per-worktree daemon isolation, socket path management |
 | `kernel-launch` | Kernel launching, tool bootstrapping (deno, uv, ruff via rattler) |
 | `kernel-env` | Python environment management (UV + Conda) with progress reporting |
-| `tauri-jupyter` | Shared Jupyter message types for Tauri/WebView |
 | `mcp-supervisor` | nteract-dev — MCP supervisor proxy, daemon/vite lifecycle management |
 | `xtask` | Build system orchestration |
 
@@ -302,23 +301,30 @@ All build, lint, and dev commands go through `cargo xtask`. **Run `cargo xtask h
 | Category | Command | Description |
 |----------|---------|-------------|
 | Dev | `cargo xtask dev` | Full setup: deps + build + daemon + app |
+| | `cargo xtask dev --skip-build` | Reuse existing build artifacts before launch |
+| | `cargo xtask dev --skip-install` | Reuse existing pnpm install before launch |
 | | `cargo xtask notebook` | Hot-reload dev server (Vite on port 5174) |
 | | `cargo xtask notebook --attach` | Attach Tauri to existing Vite server |
 | | `cargo xtask vite` | Start Vite standalone |
 | | `cargo xtask build` | Full debug build (frontend + Rust) |
 | | `cargo xtask build --rust-only` | Rebuild Rust only, reuse frontend |
 | | `cargo xtask run` | Run bundled debug binary |
+| Release | `cargo xtask build-app` | Build the desktop app bundle with icons |
+| | `cargo xtask build-dmg` | Build a DMG bundle (CI/release packaging) |
 | Daemon | `cargo xtask dev-daemon` | Per-worktree dev daemon |
+| | `cargo xtask dev-daemon --release` | Run the per-worktree daemon in release mode |
 | | `cargo xtask install-daemon` | Install runtimed as system daemon |
 | MCP | `cargo xtask run-mcp` | nteract-dev supervisor (daemon + MCP + auto-restart) |
 | | `cargo xtask run-mcp --print-config` | Print MCP client config JSON |
 | | `cargo xtask dev-mcp` | Direct nteract MCP (no supervisor) |
+| | `cargo xtask dev-mcp --print-config` | Print direct MCP client config JSON |
 | Lint | `cargo xtask lint` | Check formatting (Rust, JS/TS, Python) |
 | | `cargo xtask lint --fix` | Auto-fix formatting |
 | Test | `cargo xtask integration [filter]` | Python integration tests with isolated daemon |
 | | `cargo xtask e2e` | E2E testing (WebdriverIO) |
 | Other | `cargo xtask wasm` | Rebuild runtimed-wasm |
 | | `cargo xtask icons [source.png]` | Generate icon variants |
+| | `cargo xtask mcpb` | Package nteract as a Claude Desktop extension (`.mcpb`) |
 
 ## Runtime Daemon (`runtimed`)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,10 +30,10 @@ The supervisor automatically handles per-worktree isolation, env var plumbing, a
 
 ### Manual commands (when supervisor is not available)
 
-All commands that interact with the dev daemon require two env vars. Without them you'll hit the system daemon and cause problems.
+For raw terminal commands, opt into dev mode explicitly. `RUNTIMED_DEV=1` is what enables per-worktree daemon isolation. `RUNTIMED_WORKSPACE_PATH` is the safest way to pin the current worktree, though binaries launched from the repo root can also discover the worktree via git.
 
 ```bash
-# ── Dev daemon env vars (required for ALL dev commands) ────────────
+# ── Recommended env vars for raw dev-daemon commands ───────────────
 export RUNTIMED_DEV=1
 export RUNTIMED_WORKSPACE_PATH="$(pwd)"
 ```
@@ -232,10 +232,12 @@ For the installed app, `runt mcp` ships as a sidecar binary alongside `runtimed`
 |------|---------|
 | `supervisor_status` | Check child process, daemon, build mode, restart count, last error |
 | `supervisor_restart` | Restart child (`target="child"`) or daemon (`target="daemon"`) |
-| `supervisor_rebuild` | Run `maturin develop` to rebuild Rust Python bindings, then restart |
+| `supervisor_rebuild` | Rebuild the daemon binary and Rust Python bindings, restart the daemon, then restart the MCP child |
 | `supervisor_logs` | Tail the daemon log file |
+| `supervisor_vite_logs` | Tail the Vite dev server log file |
 | `supervisor_start_vite` | Start the Vite dev server for hot-reload frontend development |
 | `supervisor_stop` | Stop a managed process by name (e.g. `"vite"`) |
+| `supervisor_set_mode` | Switch the managed daemon between `debug` and `release` builds and restart it |
 
 ### nteract MCP Tools (27 tools for notebook interaction)
 
@@ -411,7 +413,7 @@ Three implementations **must stay in sync** — if you change MIME classificatio
 | Location | Language | Function |
 |----------|----------|----------|
 | `crates/runtimed/src/output_store.rs` | Rust | `is_binary_mime()` |
-| `crates/runtimed-py/src/output_resolver.rs` | Rust | `is_binary_mime()` |
+| `crates/runtimed-client/src/output_resolver.rs` | Rust | `mime_kind()` |
 | `apps/notebook/src/lib/manifest-resolution.ts` | TypeScript | `isBinaryMime()` |
 
 The rule: `image/*` → binary (EXCEPT `image/svg+xml` — that's text). `audio/*`, `video/*` → binary. `application/*` → binary by default (EXCEPT json, javascript, xml, and `+json`/`+xml` suffixes). `text/*` → always text.

--- a/contributing/architecture.md
+++ b/contributing/architecture.md
@@ -107,7 +107,7 @@ Three implementations **must stay in sync** — if you change the classification
 | Location | Language | Function |
 |----------|----------|----------|
 | `crates/runtimed/src/output_store.rs` | Rust | `is_binary_mime()` |
-| `crates/runtimed-py/src/output_resolver.rs` | Rust | `is_binary_mime()` |
+| `crates/runtimed-client/src/output_resolver.rs` | Rust | `mime_kind()` |
 | `apps/notebook/src/lib/manifest-resolution.ts` | TypeScript | `isBinaryMime()` |
 
 The rule:
@@ -143,7 +143,7 @@ Key files:
 - `crates/runtimed/src/output_store.rs` — Manifest creation/resolution, `is_binary_mime()`, `ContentRef`
 - `crates/runtimed/src/blob_store.rs` — Content-addressed storage with atomic writes
 - `crates/runtimed/src/blob_server.rs` — HTTP server (`GET /blob/{hash}`, serves raw bytes with correct `Content-Type`)
-- `crates/runtimed-py/src/output_resolver.rs` — Python-side manifest resolution, `is_binary_mime()`
+- `crates/runtimed-client/src/output_resolver.rs` — Shared Rust manifest resolution, `mime_kind()`, Python/MCP consumers
 - `apps/notebook/src/lib/manifest-resolution.ts` — Frontend resolution, `isBinaryMime()`, `resolveContentRef()`
 - `apps/notebook/src/lib/materialize-cells.ts` — Assembles cells with resolved outputs
 

--- a/contributing/build-dependencies.md
+++ b/contributing/build-dependencies.md
@@ -74,14 +74,14 @@ here is what happens under the hood:
 
 ```mermaid
 graph LR
-    A["1. pnpm install"] --> W["2. wasm-pack build<br/>crates/runtimed-wasm"]
-    W --> C["3. pnpm --dir apps/notebook build<br/>(includes isolated-renderer)"]
-    C --> D["4. cargo build --release<br/>-p runtimed -p runt-cli"]
-    D --> E["5. Copy binaries to<br/>crates/notebook/binaries/"]
-    E --> F["6. cargo tauri build"]
+    A["1. pnpm install"] --> M["2. Build MCP widget HTML<br/>crates/runt-mcp/assets/_output.html"]
+    M --> R["3. cargo build<br/>-p runtimed -p runt-cli -p mcp-supervisor -p notebook"]
+    R --> E["4. Copy sidecar binaries<br/>for Tauri bundling"]
+    E --> P["5. In parallel:<br/>uv sync + maturin develop<br/>and pnpm frontend build"]
+    P --> F["6. cargo tauri build<br/>or debug link step"]
 
     classDef step fill:#f3e5f5,stroke:#7b1fa2
-    class A,W,C,D,E,F step
+    class A,M,R,E,P,F step
 ```
 
 ## Rust Crate Dependency Graph

--- a/contributing/build-dependencies.md
+++ b/contributing/build-dependencies.md
@@ -18,8 +18,8 @@ graph TD
     end
 
     subgraph "Rust Crates (Cargo workspace)"
-        TJ["tauri-jupyter<br/><i>shared Jupyter types</i>"]
         ND["notebook-doc<br/><i>shared Automerge doc ops</i>"]
+        RTC["runtimed-client<br/><i>shared client/runtime helpers</i>"]
         RD["runtimed (lib + bin)<br/><i>daemon</i>"]
         RC["runt-cli (bin: runt)<br/><i>CLI</i>"]
         NB["notebook (Tauri app)<br/><i>main app</i>"]
@@ -38,13 +38,14 @@ graph TD
     RWASM -->|"wasm-pack output in<br/>apps/notebook/src/wasm/"| NUI
 
     %% Rust crate dependencies (path deps in Cargo.toml)
-    TJ -->|"path dep"| NB
     ND -->|"path dep"| RD
     ND -->|"path dep"| RWASM
     ND -->|"path dep"| RDPY
-    RD -->|"path dep"| NB
-    RD -->|"path dep"| RC
-    RD -->|"path dep"| RDPY
+    ND -->|"path dep"| RTC
+    RTC -->|"path dep"| NB
+    RTC -->|"path dep"| RC
+    RTC -->|"path dep"| RD
+    RTC -->|"path dep"| RDPY
 
     %% External binary bundling (not a Cargo dep — a Tauri bundle dep)
     RD -.->|"binary copied to<br/>crates/notebook/binaries/"| APP
@@ -63,7 +64,7 @@ graph TD
     classDef artifact fill:#e8f5e9,stroke:#2e7d32
 
     class NUI frontend
-    class TJ,ND,RD,RC,NB,XT,RWASM,RDPY rust
+    class ND,RTC,RD,RC,NB,XT,RWASM,RDPY rust
     class APP,PY artifact
 ```
 
@@ -90,8 +91,8 @@ Shows only the Cargo `path` dependencies between workspace members:
 
 ```mermaid
 graph BT
-    TJ["tauri-jupyter"]
     RD["runtimed"]
+    RTC["runtimed-client"]
     RC["runt-cli"]
     NB["notebook"]
     ND["notebook-doc"]
@@ -105,39 +106,47 @@ graph BT
     RDPY["runtimed-py"]
     RWASM["runtimed-wasm"]
 
-    NB -->|"depends on"| TJ
-    NB -->|"depends on"| RD
+    NB -->|"depends on"| RTC
+    NB -->|"depends on"| ND
+    NB -->|"depends on"| NP
     NB -->|"depends on"| NS
     NB -->|"depends on"| RT
     NB -->|"depends on"| RW
-    RC -->|"depends on"| RD
+    RC -->|"depends on"| RTC
+    RC -->|"depends on"| ND
     RC -->|"depends on"| RW
+    RC -->|"depends on"| KE
     RD -->|"depends on"| ND
     RD -->|"depends on"| NP
+    RD -->|"depends on"| RTC
     RD -->|"depends on"| KL
     RD -->|"depends on"| KE
     RD -->|"depends on"| RT
     RD -->|"depends on"| RW
-    RDPY -->|"depends on"| RD
+    RDPY -->|"depends on"| RTC
     RDPY -->|"depends on"| ND
     RDPY -->|"depends on"| NP
     RDPY -->|"depends on"| NS
     RDPY -->|"depends on"| RW
+    RDPY -->|"depends on"| KE
     RWASM -->|"depends on"| ND
     NP -->|"depends on"| ND
     NP -->|"depends on"| KE
     NS -->|"depends on"| ND
     NS -->|"depends on"| NP
-    KE -->|"depends on"| KL
+    NS -->|"depends on"| RTC
+    RTC -->|"depends on"| ND
+    RTC -->|"depends on"| NP
+    RTC -->|"depends on"| RW
 
     classDef standalone fill:#fff9c4,stroke:#f9a825
     classDef leaf fill:#c8e6c9,stroke:#388e3c
     classDef shared fill:#e3f2fd,stroke:#1976d2
 
-    class TJ,KL,KE,RT,RW,RWASM standalone
+    class KL,KE,RT,RW,RWASM standalone
     class XT standalone
     class NB,RC,RDPY leaf
-    class RD,ND,NP,NS shared
+    class RD,RTC,ND,NP,NS shared
 ```
 
 ## Key Points

--- a/contributing/crdt-mutation-guide.md
+++ b/contributing/crdt-mutation-guide.md
@@ -124,7 +124,7 @@ doc.merge(&mut fork).ok();
 
 **Why this matters:** Without fork+merge, the async gap is a data loss window. If a user types while ruff formats, or another peer edits while the file watcher processes, the write-back silently overwrites those changes. Fork+merge lets Automerge's text CRDT compose both sets of changes.
 
-**`fork_at(heads)`** is for changes relative to a known historic point (e.g., the file watcher forking at the last save point so disk content merges cleanly with post-save CRDT changes).
+**Do not use `fork_at(heads)` / `fork_at_and_merge(...)` in daemon mutation paths right now.** `fork_at(...)` currently triggers automerge/automerge#1327 (`MissingOps` in the change collector) on documents with interleaved text splices and merges. For file-watcher and other external-content merges, compare against the saved-on-disk baseline (`last_save_sources`), then `fork()` at current heads and `merge()`.
 
 ### Helpers for Synchronous Blocks
 
@@ -137,10 +137,6 @@ doc.fork_and_merge(|fork| {
     fork.set_cell_resolved_assets("cell-2", &assets);
 });
 
-// Fork at a historic point (e.g., file watcher at last save)
-doc.fork_at_and_merge(&save_heads, |fork| {
-    fork.update_source("cell-1", &disk_source);
-})?;
 ```
 
 These encapsulate the fork-before/merge-after pattern. For **async** work between fork and merge, use `fork()` and `merge()` directly — the fork must be created before the `.await` and merged after.
@@ -153,8 +149,8 @@ All async CRDT mutation paths in the daemon are now protected:
 |------|-----------|
 | ExecuteCell / RunAllCells formatting | `fork()` before `tokio::spawn`, merge in task |
 | `format_notebook_cells` (Cmd+S) | `fork()` before format loop, merge after |
-| File watcher source updates | `fork_at(last_save_heads)` + merge |
-| File watcher order-changed rebuild | `fork_at(last_save_heads)` + merge |
+| File watcher source updates | Compare against `last_save_sources`, then `fork()` + merge |
+| File watcher order-changed rebuild | Compare against `last_save_sources`, then `fork()` + merge |
 | `UpdateDisplayData` IOPub | `fork()` before blob I/O, merge after |
 | `process_markdown_assets` | `fork()` before async resolution, merge after |
 | `handle_sync_environment` | Fresh read (no CRDT write, only in-memory state) |

--- a/contributing/development.md
+++ b/contributing/development.md
@@ -141,9 +141,9 @@ pnpm build          # Build notebook UI (isolated-renderer built inline)
 cargo build         # Build Rust
 ```
 
-> **Note:** If you've changed `crates/runtimed-wasm/`, you need to run
-> `wasm-pack build crates/runtimed-wasm --target web --out-dir ../../apps/notebook/src/wasm/runtimed-wasm`
-> before `pnpm build`. `cargo xtask build` handles this automatically.
+> **Note:** If you've changed `crates/runtimed-wasm/`, rebuild it explicitly with
+> `cargo xtask wasm` (or the equivalent `wasm-pack build ...` command) before `pnpm build`.
+> Normal `cargo xtask build` only verifies that the committed WASM artifact exists; it does not regenerate it for you.
 
 ## Test Notebooks
 
@@ -172,8 +172,10 @@ If you have the repo-local `nteract-dev` MCP entry configured, the daemon is man
 
 - `supervisor_restart(target="daemon")` — start or restart the dev daemon
 - `supervisor_status` — check daemon status (includes `daemon_managed: true/false`)
-- `supervisor_rebuild` — rebuild Python bindings + restart
+- `supervisor_rebuild` — rebuild the daemon binary plus Rust Python bindings, then restart the daemon and MCP child
 - `supervisor_logs` — tail daemon logs
+- `supervisor_vite_logs` — tail the Vite dev server log file
+- `supervisor_set_mode` — switch the managed daemon between `debug` and `release`
 
 No env vars or extra terminals needed. nteract-dev handles per-worktree isolation automatically.
 
@@ -369,10 +371,12 @@ These tools are always available, even when the Python child is down:
 |------|---------|
 | `supervisor_status` | Child process, daemon, restart count, last error |
 | `supervisor_restart` | Restart child or daemon |
-| `supervisor_rebuild` | `maturin develop` into `.venv` + restart (after Rust changes) |
+| `supervisor_rebuild` | Rebuild the daemon binary plus Rust Python bindings, then restart the daemon and MCP child |
 | `supervisor_logs` | Tail the daemon log file |
+| `supervisor_vite_logs` | Tail the Vite dev server log file |
 | `supervisor_start_vite` | Start the Vite dev server for hot-reload frontend development |
 | `supervisor_stop` | Stop a managed process by name (e.g. `"vite"`) |
+| `supervisor_set_mode` | Switch the managed daemon between `debug` and `release` builds |
 
 #### Hot reload
 

--- a/contributing/development.md
+++ b/contributing/development.md
@@ -380,11 +380,14 @@ These tools are always available, even when the Python child is down:
 
 #### Hot reload
 
-The supervisor watches `python/nteract/src/`, `python/runtimed/src/`,
-`crates/runtimed-py/src/`, and `crates/runtimed/src/`:
+The supervisor watches `crates/runt-mcp/src/`, `crates/runtimed-client/src/`,
+`python/nteract/src/`, `python/runtimed/src/`, `crates/runtimed-py/src/`, and
+`crates/runtimed/src/`:
 
+- **`crates/runt-mcp/src/`** → `cargo build -p runt-cli`, then child restart
+- **`crates/runtimed-client/src/`** → `cargo build -p runt-cli` + `maturin develop`, then child restart
 - **Python changes** → child restarts automatically
-- **Rust changes** → `maturin develop` runs first, then child restarts
+- **Daemon / bindings Rust changes** → `maturin develop` runs first, then child restarts
 - **Behavior changes** take effect immediately on the next tool call
 - **New/removed tools** may take a moment for the client to discover
 
@@ -403,15 +406,17 @@ cargo xtask dev-mcp
 
 ### How it works
 
-The MCP server is a pure Python package (`python/nteract/`) that depends on
-`runtimed` (PyO3 bindings in `python/runtimed/`, built from
-`crates/runtimed-py/`). Both are workspace members of the repo-root
-`pyproject.toml`, so `uv sync` installs them into `.venv` at the repo root.
+`nteract-dev` is the **dev-only supervisor server** for this source tree. It
+exposes the extra `supervisor_*` tools itself, then proxies the regular notebook
+tools from a child `runt mcp` process launched inside the supervisor. That child
+is the Rust-native MCP implementation from `crates/runt-mcp/`, not a Python MCP
+server.
 
-The nteract-dev supervisor (`crates/mcp-supervisor/`) uses the `rmcp` Rust SDK to
-act as both an MCP server (facing the client) and an MCP client (facing the
-Python child process). It spawns the child via `uv run --directory . nteract`
-from the repo root.
+The Python workspace packages still matter for local development: `python/runtimed/`
+provides the PyO3 bindings, and `python/nteract/` is the convenience wrapper that
+finds and launches `runt mcp` outside the supervisor flow. Both are workspace
+members of the repo-root `pyproject.toml`, so `uv sync` installs them into `.venv`
+at the repo root.
 
 ## Before You Commit
 

--- a/contributing/e2e.md
+++ b/contributing/e2e.md
@@ -11,21 +11,15 @@ Two modes:
 
 ### Native Mode (macOS)
 
-The `e2e/dev.sh` script handles everything:
+Use the xtask E2E entrypoints:
 
 ```bash
-# Full cycle: build + start + test
-./e2e/dev.sh cycle
-
-# Step by step:
-./e2e/dev.sh build       # Build with WebDriver support (embeds frontend)
-./e2e/dev.sh start       # Start app with WebDriver server (foreground)
-./e2e/dev.sh test        # Smoke test (smoke.spec.js only)
-./e2e/dev.sh test all    # All non-fixture specs
-./e2e/dev.sh stop        # Stop the running app
+cargo xtask e2e build       # Build the webdriver-enabled app
+cargo xtask e2e test        # Smoke/default E2E run
+cargo xtask e2e test-all    # Full suite, including fixture coverage
 ```
 
-**Important:** Use `./e2e/dev.sh build` (or `cargo xtask build-e2e`) instead of plain `cargo build`. The Tauri build embeds frontend assets into the binary — a plain `cargo build` would try to connect to a Vite dev server.
+`cargo xtask e2e ...` handles app launch, waits for the embedded WebDriver server on port `4445`, runs `pnpm test:e2e`, and then cleans up. The older `cargo xtask build-e2e` alias still exists, but it is deprecated.
 
 #### Fixture Tests
 
@@ -33,42 +27,32 @@ Fixture tests open a specific notebook and get a fresh app instance per test:
 
 ```bash
 # Run a single fixture test
-./e2e/dev.sh test-fixture \
+cargo xtask e2e test-fixture \
   crates/notebook/fixtures/audit-test/1-vanilla.ipynb \
   e2e/specs/prewarmed-uv.spec.js
 
-# Run all fixture tests (fresh app per test, exits 1 if any fail)
-./e2e/dev.sh test-fixtures
+# Run the full suite (includes fixture coverage)
+cargo xtask e2e test-all
 ```
 
-#### All dev.sh Commands
+#### xtask E2E Commands
 
 | Command | Description |
 |---------|-------------|
-| `build` | Rebuild Rust binary (incremental, embeds frontend) |
-| `build-full` | Full rebuild (frontend + sidecars + Rust) |
-| `start` | Start app with WebDriver server (foreground) |
-| `stop` | Stop the running app |
-| `restart` | Stop + start |
-| `test [spec\|all]` | Run E2E tests (default: smoke.spec.js only) |
+| `cargo xtask e2e build` | Build the webdriver-enabled binary |
+| `cargo xtask e2e test` | Run the default non-fixture E2E set |
 | `test-fixture <nb> <spec>` | Run a fixture test (fresh app per test) |
-| `test-fixtures` | Run all fixture tests |
-| `test-untitled-pyproject` | Test untitled notebook with pyproject.toml (CWD = fixture dir) |
-| `cycle` | Build + start + test in one shot |
-| `status` | Check if WebDriver server is running |
-| `daemon` | Check if E2E daemon is running |
-| `session` | Create a session and print ID |
-| `exec 'js'` | Execute JS in the app |
+| `cargo xtask e2e test-all` | Run the default suite plus fixture coverage |
 
 ### Port Configuration
 
-The WebDriver port uses this fallback chain (same in `dev.sh` and `wdio.conf.js`):
+The WebDriver port uses this fallback chain (same in `wdio.conf.js`):
 
 ```
-WEBDRIVER_PORT > CONDUCTOR_PORT > PORT > 4444
+WEBDRIVER_PORT > CONDUCTOR_PORT > PORT > 4445
 ```
 
-Most contributors don't need to set anything — the default `4444` works fine.
+Most contributors don't need to set anything — the default `4445` works fine.
 
 ### Docker Mode (CI / Linux)
 
@@ -85,7 +69,7 @@ docker compose --profile dev run --rm tauri-e2e-shell
 
 There are two kinds of E2E specs:
 
-**Regular specs** run against whatever notebook the app opens by default. They share a single app instance during `./e2e/dev.sh test all`. Good for testing general UI features that don't depend on specific notebook content.
+**Regular specs** run against whatever notebook the app opens by default. They share a single app instance during `cargo xtask e2e test`. Good for testing general UI features that don't depend on specific notebook content.
 
 **Fixture specs** require a specific notebook (`NOTEBOOK_PATH` env var) and get a fresh app instance per test. Each is listed in `FIXTURE_SPECS` in `wdio.conf.js` so it's automatically excluded from the default `test all` run.
 
@@ -154,12 +138,7 @@ Multiple specs can reuse the same fixture notebook — each gets its own fresh a
    ];
    ```
 
-4. **Add to `test-fixtures`** in `e2e/dev.sh`:
-   ```bash
-   $0 test-fixture \
-     crates/notebook/fixtures/audit-test/1-vanilla.ipynb \
-     e2e/specs/my-feature.spec.js || FAIL=1
-   ```
+4. **Add to the fixture coverage list** in `crates/xtask/src/main.rs` if it should run under `cargo xtask e2e test-all`.
 
 5. **Add to CI** in `.github/workflows/build.yml`:
    ```yaml
@@ -171,8 +150,8 @@ Multiple specs can reuse the same fixture notebook — each gets its own fresh a
 
 6. **Verify locally:**
    ```bash
-   ./e2e/dev.sh build
-   ./e2e/dev.sh test-fixture \
+   cargo xtask e2e build
+   cargo xtask e2e test-fixture \
      crates/notebook/fixtures/audit-test/1-vanilla.ipynb \
      e2e/specs/my-feature.spec.js
    ```
@@ -180,7 +159,7 @@ Multiple specs can reuse the same fixture notebook — each gets its own fresh a
 ### Checklist: New Regular Test
 
 1. Create the spec at `e2e/specs/my-feature.spec.js` (same structure, no `Requires:` comment).
-2. That's it — `test all` picks up `*.spec.js` files automatically (anything not in `FIXTURE_SPECS`).
+2. That's it — `cargo xtask e2e test` picks up `*.spec.js` files automatically (anything not in `FIXTURE_SPECS`).
 
 ## Shared Helpers
 
@@ -541,50 +520,36 @@ const result = await browser.execute(() => {
 await browser.pause(5000);
 ```
 
-### dev.sh Shortcuts
-
-```bash
-# Quick JS evaluation against the running app
-./e2e/dev.sh exec 'return document.title'
-
-# Check if WebDriver is up
-./e2e/dev.sh status
-```
-
 ## Troubleshooting
 
 ### "E2E binary not found"
 
-The WebDriver-enabled binary hasn't been built yet. `dev.sh` will tell you exactly what to run:
+The WebDriver-enabled binary hasn't been built yet:
 
 ```bash
-./e2e/dev.sh build       # fast: recompiles Rust only (skips frontend)
-./e2e/dev.sh build-full  # full: rebuilds frontend + sidecars + Rust
+cargo xtask e2e build
 ```
 
-Use `build-full` the first time or after changing React components (e.g., adding `data-testid`). After that, `build` is much faster for Rust-only changes.
+If frontend assets changed, run a fresh `cargo xtask build` or `pnpm build` before the E2E build.
 
-### "No WebDriver server on port 4444"
+### "No WebDriver server on port 4445"
 
-You ran `./e2e/dev.sh test` without starting the app first. The `test` command connects to an already-running app — it does **not** start one.
+If you are using `cargo xtask e2e test` or `test-fixture`, xtask should start the app for you. If you are running `pnpm test:e2e` directly, make sure a webdriver-enabled app is already running on the expected port.
 
-Either:
-- Start the app in one terminal (`./e2e/dev.sh start`) and run tests in another (`./e2e/dev.sh test`)
-- Use `./e2e/dev.sh cycle` to build + start + test in one shot
-- Use `./e2e/dev.sh test-fixture` which starts a fresh app instance automatically
-
-**Key distinction:** `test` requires a running app. `test-fixture` manages its own app lifecycle.
+Preferred fix:
+- Use `cargo xtask e2e test` for the default suite
+- Use `cargo xtask e2e test-fixture <notebook> <spec>` for fixture runs
 
 ### "Notebook file not found" / "Spec file not found"
 
-Paths are relative to the project root. `dev.sh` will list available fixtures and specs when it can't find a file.
+Paths are relative to the project root.
 
 ```bash
 # Correct:
-./e2e/dev.sh test-fixture crates/notebook/fixtures/audit-test/1-vanilla.ipynb e2e/specs/prewarmed-uv.spec.js
+cargo xtask e2e test-fixture crates/notebook/fixtures/audit-test/1-vanilla.ipynb e2e/specs/prewarmed-uv.spec.js
 
 # Wrong — don't use absolute paths or paths from other directories:
-./e2e/dev.sh test-fixture /Users/me/runt/crates/notebook/fixtures/audit-test/1-vanilla.ipynb ...
+cargo xtask e2e test-fixture /Users/me/runt/crates/notebook/fixtures/audit-test/1-vanilla.ipynb ...
 ```
 
 ### "Malformed type for elementId parameter"
@@ -602,16 +567,16 @@ You're hitting the wry text-selector bug. Replace `$("button*=Text")` with `$('[
 If you see many `Request failed with status 500` or connection errors, the app is not running or not listening on the expected port. Check:
 
 ```bash
-./e2e/dev.sh status    # should print JSON response, not "Not running"
+curl -s http://localhost:4445/status
 ```
 
-The port fallback chain is `WEBDRIVER_PORT > CONDUCTOR_PORT > PORT > 4444`. If you're in a worktree with `CONDUCTOR_PORT` set, tests will use that port — make sure the app was started with the same port.
+The port fallback chain is `WEBDRIVER_PORT > CONDUCTOR_PORT > PORT > 4445`. If you're in a worktree with `CONDUCTOR_PORT` set, tests will use that port — make sure the app was started with the same port.
 
 ### Timeout Errors
 
 - Kernel startup is slow on first run — increase timeout to 60s
 - Environment creation can take 2+ minutes — fixture tests default to 120s
-- Check if the app loaded correctly with `./e2e/dev.sh status`
+- Check if the app loaded correctly with `curl -s http://localhost:4445/status`
 
 ### Flaky Tests
 

--- a/contributing/e2e.md
+++ b/contributing/e2e.md
@@ -57,11 +57,12 @@ Most contributors don't need to set anything — the default `4445` works fine.
 ### Docker Mode (CI / Linux)
 
 ```bash
-pnpm test:e2e:docker
-
-# Interactive debugging
 docker compose --profile dev run --rm tauri-e2e-shell
 ```
+
+There is no dedicated `pnpm test:e2e:docker` script in this repo. CI runs the
+driver/container setup around the normal `pnpm test:e2e` command. For local
+Linux debugging, open the shell above and run the same E2E commands from there.
 
 ## Test Types
 
@@ -91,13 +92,14 @@ Use a regular test when:
 | `2-uv-inline.ipynb` | `trust-dialog-dismiss.spec.js` | Trust dialog dismiss flow |
 | `3-conda-inline.ipynb` | `conda-inline.spec.js` | Conda inline dependency resolution |
 | `10-deno.ipynb` | `deno.spec.js` | Deno kernel start + TypeScript execution |
+| `14-cell-visibility.ipynb` | `cell-visibility.spec.js` | Source/output visibility toggles with existing outputs |
+| `15-run-all-output-lifecycle.ipynb` | `run-all-output-lifecycle.spec.js` | Run-all behavior with stale outputs present |
 | `pyproject-project/5-pyproject.ipynb` | `uv-pyproject.spec.js` | pyproject.toml environment detection |
 | *(untitled)* | `untitled-pyproject.spec.js` | pyproject.toml detection from CWD (requires `test-untitled-pyproject`) |
 
 **Regular specs** (run against default app, not fixtures):
 - `smoke.spec.js` — Basic cell execution and output
 - `tab-completion.spec.js` — Tab completion in code cells
-- `cell-visibility.spec.js` — Source/output visibility toggles
 
 Multiple specs can reuse the same fixture notebook — each gets its own fresh app instance.
 

--- a/contributing/environments.md
+++ b/contributing/environments.md
@@ -21,6 +21,7 @@ Notebook opened
   │   ├─ "python" / "python3" ─────────── Resolve Python environment:
   │   │   │
   │   │   ├─ Has inline deps? ─────────── Use UV or Conda with those deps
+  │   │   ├─ Has PEP 723 script block? ── Use cached UV env from cell source (`uv:pep723`)
   │   │   │
   │   │   ├─ Closest project file?        (walk up from notebook, stop at .git / home)
   │   │   │   ├─ pyproject.toml ───────── Use `uv run` (project's .venv)
@@ -178,6 +179,10 @@ sequenceDiagram
         DM->>IE: prepare_uv_inline_env(deps)
         IE-->>DM: PreparedEnv{python_path}
         DM-->>DM: env_source = "uv:inline"
+    else Has PEP 723 script block in cell source
+        DM->>IE: prepare_uv_inline_env(pep723_deps)
+        IE-->>DM: PreparedEnv{python_path}
+        DM-->>DM: env_source = "uv:pep723"
     else Has inline Conda deps (metadata.conda.dependencies)
         DM->>IE: prepare_conda_inline_env(deps)
         IE-->>DM: PreparedEnv{python_path}
@@ -298,7 +303,7 @@ The diagrams show two main layers:
 
 1. **Frontend** (blue) — React hooks that invoke Tauri commands and listen for `notebook:broadcast` events (kernel status, execution lifecycle) and `notebook:frame` events (document state including outputs via Automerge sync, demuxed by WASM). `useDaemonKernel.ts` handles kernel lifecycle via the daemon. The daemon sends `Output` broadcasts and `useDaemonKernel.ts` processes them (blob resolution), but the `onOutput` rendering callback is a no-op — output **rendering** is driven by Automerge sync (`materializeCells`).
 
-2. **runtimed Daemon** (indigo) — A singleton background process that owns kernel processes and manages prewarmed UV and Conda environment pools. The daemon runs the detection priority chain: inline deps first, then closest project file, then prewarmed pool. Communicates via length-prefixed JSON over Unix domain sockets (or Windows named pipes). Also runs an Automerge CRDT sync server for cross-window settings and notebook state.
+2. **runtimed Daemon** (indigo) — A singleton background process that owns kernel processes and manages prewarmed UV and Conda environment pools. The daemon runs the detection priority chain: metadata inline deps first, then PEP 723 cell metadata (`uv:pep723`), then closest project file, then prewarmed pool. Communicates via length-prefixed JSON over Unix domain sockets (or Windows named pipes). Also runs an Automerge CRDT sync server for cross-window settings and notebook state.
 
 3. **External Tools** (grey) — `uv` for pip-compatible package management, `rattler` for conda solving/installing, and `deno` for TypeScript notebooks.
 
@@ -332,7 +337,7 @@ For Python notebooks, the daemon resolves which environment to use:
 | 2 | Closest project file | Single walk-up via `project_file::find_nearest_project_file` | Depends on file type |
 | 3 | User preference | Prewarmed UV or Conda env from pool | Shared pool env |
 
-For step 2, the walk-up checks for `pyproject.toml`, `pixi.toml`, and `environment.yml`/`environment.yaml` at **each directory level**, starting from the notebook's location. The first (closest) match wins. When multiple project files exist in the same directory, the tiebreaker order is: pyproject.toml > pixi.toml > environment.yml.
+For step 2, the walk-up checks for `pyproject.toml`, `pixi.toml`, and `environment.yml`/`environment.yaml` at **each directory level**, starting from the notebook's location. The first (closest) match wins. When multiple project files exist in the same directory, the tiebreaker order is: pyproject.toml > pixi.toml > environment.yml > environment.yaml.
 
 The walk-up stops at `.git` boundaries and the user's home directory, preventing cross-repository project file pollution.
 

--- a/contributing/frontend-architecture.md
+++ b/contributing/frontend-architecture.md
@@ -201,7 +201,10 @@ Execution requests go to the daemon via dedicated Tauri commands (`execute_cell_
 
 ### CellChangeset types
 
-The `CellChangeset` from WASM (`notebook-doc/src/diff.rs`) has TypeScript mirrors defined inline in `apps/notebook/src/hooks/useAutomergeNotebook.ts` (module-private; tests duplicate them in `apps/notebook/src/lib/__tests__/cell-changeset.test.ts`):
+The `CellChangeset` shape originates in Rust (`notebook-doc/src/diff.rs`), but
+the current TypeScript source of truth lives in `packages/runtimed/src/cell-changeset.ts`.
+The notebook app re-exports those helpers through `apps/notebook/src/lib/cell-changeset.ts`
+and `apps/notebook/src/lib/frame-pipeline.ts`:
 - `CellChangeset` — `{ changed, added, removed, order_changed }`
 - `ChangedCell` — `{ cell_id, fields }` where `fields` has boolean flags per field (`source`, `outputs`, `execution_count`, `cell_type`, `metadata`, `position`, `resolved_assets`)
 - `mergeChangesets()` — union semantics for the coalescing window

--- a/contributing/iframe-isolation.md
+++ b/contributing/iframe-isolation.md
@@ -109,9 +109,11 @@ This prevents other windows/iframes from injecting messages.
 |-----------|----------|---------|
 | `IsolatedFrame` | `src/components/isolated/isolated-frame.tsx` | React component that manages blob URL lifecycle |
 | `CommBridgeManager` | `src/components/isolated/comm-bridge-manager.ts` | Parent-side: syncs widget state to iframe |
-| `WidgetBridgeClient` | `src/isolated-renderer/widget-bridge-client.ts` | Iframe-side: receives comm messages (via `createWidgetBridgeClient`) |
+| `jsonrpc-transport.ts` | `src/components/isolated/jsonrpc-transport.ts` | JSON-RPC 2.0 transport over `postMessage` |
+| `rpc-methods.ts` | `src/components/isolated/rpc-methods.ts` | Shared widget bridge method constants |
+| `WidgetBridgeClient` | `src/isolated-renderer/widget-bridge-client.ts` | Iframe-side JSON-RPC widget bridge (via `createWidgetBridgeClient`) |
 | `frame-html.ts` | `src/components/isolated/frame-html.ts` | Generates bootstrap HTML for iframe |
-| `frame-bridge.ts` | `src/components/isolated/frame-bridge.ts` | Message type definitions |
+| `frame-bridge.ts` | `src/components/isolated/frame-bridge.ts` | Legacy frame message definitions |
 
 ### Renderer Bundle
 
@@ -119,57 +121,29 @@ The isolated renderer code is built inline during the notebook app build via the
 
 ## Message Protocol
 
-All communication uses structured `postMessage` calls.
+Two message layers coexist:
 
-### Parent → Iframe
+1. **Frame bootstrap/render messages** in `frame-bridge.ts` cover output rendering,
+   theming, resize notifications, link clicks, and in-iframe search flow.
+2. **Widget sync traffic** uses JSON-RPC 2.0 over `postMessage`, implemented by
+   `jsonrpc-transport.ts` and `rpc-methods.ts`.
 
-| Message | Purpose |
-|---------|---------|
-| `eval` | Bootstrap: inject React renderer bundle |
-| `render` | Render output content (HTML, markdown, etc.) |
-| `theme` | Sync dark/light mode |
-| `clear` | Clear all outputs |
-| `comm_open` | Forward widget creation from kernel |
-| `comm_msg` | Forward state update or custom message |
-| `comm_close` | Forward widget destruction |
-| `comm_sync` | Bulk sync all existing models on ready |
-| `bridge_ready` | Signal parent bridge is initialized |
-| `widget_state` | Send widget state to iframe |
-| `ping` | Liveness check |
-| `search` | Trigger in-iframe text search |
-| `search_navigate` | Navigate between search matches |
-
-### Iframe → Parent
-
-| Message | Purpose |
-|---------|---------|
-| `ready` | Bootstrap HTML loaded |
-| `renderer_ready` | React bundle initialized |
-| `widget_ready` | Widget system ready for comm_sync |
-| `resize` | Content height changed |
-| `error` | JavaScript error occurred |
-| `link_click` | User clicked a link |
-| `widget_comm_msg` | Widget state update (forward to kernel) |
-| `widget_comm_close` | Widget close request |
-| `pong` | Response to `ping` |
-| `eval_result` | Result of eval'd script |
-| `render_complete` | Content finished rendering |
-| `dblclick` | Double-click event (for cell editing) |
-| `widget_update` | Widget display update |
-| `search_results` | Search match count/position info |
+The JSON-RPC widget methods include:
+- Parent → iframe: `nteract/bridgeReady`, `nteract/commOpen`, `nteract/commMsg`, `nteract/commClose`, `nteract/commSync`
+- Iframe → parent: `nteract/widgetReady`, `nteract/widgetCommMsg`, `nteract/widgetCommClose`
 
 ### Widget Sync Flow
 
 ```
 1. IsolatedFrame mounts
 2. Iframe sends: ready
-3. Parent sends: eval (React bundle)
-4. Iframe sends: renderer_ready
-5. CommBridgeManager sends: bridge_ready
-6. Iframe sends: widget_ready
-7. CommBridgeManager sends: comm_sync (all existing models)
+3. Parent sends: `eval` (React bundle)
+4. Iframe sends: `renderer_ready`
+5. CommBridgeManager sends: `nteract/bridgeReady`
+6. Iframe sends: `nteract/widgetReady`
+7. CommBridgeManager sends: `nteract/commSync` (all existing models)
 8. Iframe renders widgets
-9. Bidirectional updates via comm_msg / widget_comm_msg
+9. Bidirectional widget updates flow through JSON-RPC notifications
 ```
 
 ## Critical Code Paths
@@ -194,7 +168,8 @@ The `subscribeToModelCustomMessages` method was added to support anywidgets like
 ### 4. Type Guard Whitelist
 **File:** `src/components/isolated/frame-bridge.ts` — `isIframeMessage`
 
-The `isIframeMessage` function whitelists valid message types. New message types must be added here.
+The `isIframeMessage` function whitelists the legacy frame-bridge message types.
+JSON-RPC widget methods are defined separately in `rpc-methods.ts`.
 
 ## Code Review Checklist
 
@@ -239,14 +214,14 @@ Press `Cmd+Shift+I` in debug builds to open the isolation test panel.
 ### Widget Not Rendering
 
 1. Check console for errors in iframe (may need to inspect iframe in DevTools)
-2. Verify `comm_sync` was sent (look for `[CommBridge]` logs)
-3. Check if widget type is in `ISOLATED_MIME_TYPES`
+2. Verify `nteract/commSync` was sent and the iframe answered with `nteract/widgetReady`
+3. Check `jsonrpc-transport.ts` / `rpc-methods.ts` if the bridge handshake changed
 
 ### Widget Not Receiving Updates
 
 1. Check if custom messages are being forwarded
 2. Look for `subscribeToModelCustomMessages` being called
-3. Verify kernel is sending `comm_msg` with correct comm_id
+3. Verify kernel comm traffic is being translated into `nteract/commMsg` notifications with the correct `commId`
 
 ### Theme Not Syncing
 

--- a/contributing/logging.md
+++ b/contributing/logging.md
@@ -83,7 +83,7 @@ logger.error("[component] Failure:", error);
 ### Log Level Behavior
 
 - **Nightly**: All levels (`debug`, `info`, `warn`, `error`) are enabled by default
-- **Stable**: `logger.debug()` is suppressed; `info`, `warn`, `error` are always enabled
+- **Stable**: `logger.debug()` still sends through the logger, but the Rust-side log filter typically drops it; `info`, `warn`, `error` remain visible
 - The level filter is applied server-side by `tauri-plugin-log`, not in JavaScript
 
 ### What NOT to Log at Info Level
@@ -93,21 +93,13 @@ logger.error("[component] Failure:", error);
 - Internal state (blob port resolution, queue state)
 - Success cases for routine operations (hot-sync succeeded)
 
-### Enabling Debug Logs
+### Seeing Frontend Debug Logs
 
-In the browser console:
-```javascript
-localStorage.setItem('runt:debug', 'true');
-// Reload the page
-```
-
-To disable:
-```javascript
-localStorage.removeItem('runt:debug');
-// Reload the page
-```
-
-Debug mode is always enabled in development (`import.meta.env.DEV`).
+There is no `localStorage` debug toggle in the current app. Frontend logs always
+go through `apps/notebook/src/lib/logger.ts`, and in development
+(`import.meta.env.DEV`) `attachConsole()` mirrors them into the browser devtools
+console. In packaged builds, visibility is controlled by the Rust-side app log
+level from `tauri-plugin-log`.
 
 ## Adding New Logging
 

--- a/contributing/releasing.md
+++ b/contributing/releasing.md
@@ -4,7 +4,7 @@ How versioning, releases, and publishing work across the project.
 
 ## Version Scheme
 
-All published artifacts share the same version and follow semver:
+The repo keeps a shared semver source version across its release inputs, but CI stamps desktop/CLI artifacts with channel-specific suffixes at publish time:
 
 | Artifact | Where | Version source |
 |---|---|---|
@@ -12,6 +12,7 @@ All published artifacts share the same version and follow semver:
 | `runt` CLI | GitHub Releases | `crates/runt/Cargo.toml` |
 | `runtimed` daemon | Bundled in app + Python wheel | `crates/runtimed/Cargo.toml` |
 | `runtimed` Python package | PyPI | `python/runtimed/pyproject.toml` |
+| `nteract` Python package | PyPI | `python/nteract/pyproject.toml` |
 
 Standard semver rules apply:
 
@@ -62,13 +63,13 @@ This triggers `release-stable.yml` → `release-common.yml`, which:
 
 1. Builds the desktop app (macOS, Windows, Linux)
 2. Builds `runt` CLI binaries
-3. Builds Python wheels at the version in `pyproject.toml` (no alpha stamp)
+3. Builds desktop/CLI artifacts with a CI-stamped stable suffix (`-stable.{timestamp}`) while keeping stable Python packages at the plain `pyproject.toml` version
 4. Publishes wheels to PyPI (stable release)
 5. Creates a GitHub Release with all artifacts
 6. Updates the `stable-latest` Tauri updater channel
 7. Posts to Discord
 
-The stable release publishes the Python package to PyPI at the exact version from `pyproject.toml`. This means tagging `v2.1.0` also ships `runtimed==2.1.0` on PyPI — no separate Python tag needed.
+The stable release publishes the Python packages to PyPI at the exact versions from `python/runtimed/pyproject.toml` and `python/nteract/pyproject.toml`. Desktop and CLI artifacts are stamped during the workflow, so the release tag is not the final desktop/CLI artifact version string.
 
 ### Nightly Release
 
@@ -98,14 +99,14 @@ git tag python-v2.1.1
 git push origin python-v2.1.1
 ```
 
-This builds macOS + Linux wheels and publishes to PyPI. Use this when you need to ship a Python patch without cutting a new desktop release.
+This builds macOS and Linux Python artifacts for both `runtimed` and `nteract`, then publishes them to PyPI. Use this when you need to ship a Python patch without cutting a new desktop release.
 
 ## Tag Reference
 
 | Tag pattern | Workflow | What it publishes |
 |---|---|---|
 | `v*` | `release-stable.yml` | Desktop app + CLI + Python (stable) |
-| `python-v*` | `python-package.yml` | Python wheels only |
+| `python-v*` | `python-package.yml` | Python packages only (`runtimed` + `nteract`) |
 | _(cron)_ | `release-nightly.yml` | Desktop app + CLI + Python (pre-release) |
 
 ## Protocol Version Changes

--- a/contributing/runtimed.md
+++ b/contributing/runtimed.md
@@ -92,10 +92,12 @@ When iterating on daemon code, you often want to test changes in the notebook ap
 The supervisor manages the dev daemon for you. No env vars or extra terminals needed.
 
 - `supervisor_restart(target="daemon")` — start or restart the dev daemon after code changes
-- `supervisor_rebuild` — rebuild Rust bindings + Python bindings (`maturin develop`) + restart
+- `supervisor_rebuild` — rebuild the daemon binary plus Rust Python bindings, then restart the daemon and MCP child
 - `supervisor_status` — check daemon status (`daemon_managed: true` confirms it's running)
 - `supervisor_logs` — tail daemon logs
+- `supervisor_vite_logs` — tail the Vite dev server log file
 - `supervisor_start_vite` — start the Vite dev server for hot-reload
+- `supervisor_set_mode` — switch the managed daemon between `debug` and `release`
 
 Then build and run the app normally:
 ```bash
@@ -202,16 +204,9 @@ These are critical for performance — `get_cells()` materializes every cell's s
 ```
 crates/runtimed/
 ├── src/
-│   ├── lib.rs                   # Public types, path helpers (default_socket_path, etc.)
-│   ├── main.rs                  # CLI entry point (run, install, status, etc.)
+│   ├── lib.rs                   # Daemon crate + backward-compatible re-exports from runtimed-client
+│   ├── main.rs                  # Daemon CLI entry point
 │   ├── daemon.rs                # Daemon state, pool management, connection routing
-│   ├── protocol.rs              # BlobRequest/BlobResponse + re-exports from notebook-protocol
-│   ├── client.rs                # PoolClient for pool operations
-│   ├── singleton.rs             # File-based locking for single instance
-│   ├── service.rs               # Cross-platform service installation (launchd/systemd)
-│   ├── settings_doc.rs          # Settings Automerge document, schema, migration
-│   ├── sync_server.rs           # Settings sync handler
-│   ├── sync_client.rs           # Settings sync client library
 │   ├── notebook_sync_server.rs  # NotebookRoom, room lifecycle, autosave, re-keying, sync loop
 │   ├── kernel_manager.rs        # RoomKernel: kernel lifecycle, execution queue, IOPub output routing
 │   ├── kernel_pids.rs           # Kernel PID tracking and orphan reaping
@@ -223,10 +218,18 @@ crates/runtimed/
 │   ├── project_file.rs          # Project file detection (pyproject.toml, pixi.toml, etc.)
 │   ├── markdown_assets.rs       # Markdown image/asset resolution and rewriting
 │   ├── stream_terminal.rs       # Stream terminal output handling (carriage return, ANSI)
-│   ├── runtime.rs               # Runtime enum definition (Python/Deno/Other)
 │   └── terminal_size.rs         # Terminal size tracking
-└── tests/
-    └── integration.rs           # Integration tests (daemon, pool, settings sync, notebook sync)
+├── tests/
+│   └── integration.rs           # Integration tests (daemon, pool, settings sync, notebook sync)
+crates/runtimed-client/
+├── src/client.rs                # Pool/notebook client APIs
+├── src/protocol.rs              # Client-side protocol helpers and typed request wrappers
+├── src/settings_doc.rs          # Settings Automerge document, schema, migration
+├── src/singleton.rs             # File-based daemon discovery/locking helpers
+├── src/sync_client.rs           # Settings sync client library
+└── src/service.rs               # Cross-platform service install/uninstall helpers
+crates/runt-workspace/
+└── src/lib.rs                   # Build-channel naming, socket/cache paths, dev/worktree detection
 ```
 
 **Related crates** (shared across daemon, WASM, Python):
@@ -448,7 +451,7 @@ If `session.run()` shows outputs but `session.get_cell()` returns `outputs=[]`:
 
 ## Shipped App Behavior
 
-When shipped as a release build, the daemon installs as a system service that starts at login. This is handled by `crates/runtimed/src/service.rs`:
+When shipped as a release build, the daemon installs as a system service that starts at login. The cross-platform install/uninstall helpers live in `crates/runtimed-client/src/service.rs` and are used by the CLI/app flows:
 
 - **macOS**: launchd plist in `~/Library/LaunchAgents/`
 - **Linux**: systemd user service in `~/.config/systemd/user/`

--- a/contributing/testing.md
+++ b/contributing/testing.md
@@ -6,7 +6,7 @@ This guide covers all test types in the codebase. For E2E tests specifically, se
 
 | Type | Location | Command | Framework |
 |------|----------|---------|-----------|
-| E2E | `e2e/specs/` | `./e2e/dev.sh test` | WebdriverIO + Mocha |
+| E2E | `e2e/specs/` | `cargo xtask e2e test` | WebdriverIO + Mocha |
 | Frontend unit | `src/**/__tests__/`, `apps/notebook/src/**/__tests__/` | `pnpm test` | Vitest + jsdom |
 | Rust unit | inline `#[cfg(test)]` | `cargo test` | built-in |
 | CLI behavior | `crates/runt/tests/*.hone` | `cargo hone test` | Hone (not yet published) |
@@ -194,7 +194,7 @@ Configuration in `conftest.py` defines markers and daemon detection.
 |------|------|-----------------|
 | `test_session_unit.py` | Unit | No |
 | `test_daemon_integration.py` | Integration | Yes |
-| `test_ipython_bridge.py` | Integration | Yes |
+| `test_ipython_bridge.py` | Unit-style bridge test | No |
 | `test_binary.py` | Binary/CLI | No |
 
 **Running tests:**
@@ -253,9 +253,9 @@ See [e2e.md](e2e.md) for the full guide.
 Quick start:
 
 ```bash
-./e2e/dev.sh cycle          # Build + start + test
-./e2e/dev.sh test           # Smoke test only
-./e2e/dev.sh test all       # All non-fixture specs
+cargo xtask e2e build       # Build the webdriver-enabled app
+cargo xtask e2e test        # Smoke/default E2E run
+cargo xtask e2e test-all    # All regular + fixture specs
 ```
 
 ## Test Philosophy

--- a/contributing/typescript-bindings.md
+++ b/contributing/typescript-bindings.md
@@ -10,8 +10,8 @@ The `ts-rs` crate generates TypeScript type definitions from Rust types annotate
 
 | Rust File | Generated Types |
 |-----------|-----------------|
-| `crates/runtimed/src/settings_doc.rs` | `ThemeMode`, `PythonEnvType`, `UvDefaults`, `CondaDefaults`, `SyncedSettings` |
-| `crates/runtimed/src/runtime.rs` | `Runtime` |
+| `crates/runtimed-client/src/settings_doc.rs` | `ThemeMode`, `PythonEnvType`, `UvDefaults`, `CondaDefaults`, `SyncedSettings` |
+| `crates/runtimed-client/src/runtime.rs` | `Runtime` |
 
 ## How It Works
 
@@ -136,7 +136,7 @@ function Settings() {
 | File | Role |
 |------|------|
 | `.cargo/config.toml` | Sets `TS_RS_EXPORT_DIR` |
-| `crates/runtimed/src/settings_doc.rs` | Main source of settings types |
-| `crates/runtimed/src/runtime.rs` | Runtime enum |
+| `crates/runtimed-client/src/settings_doc.rs` | Main source of settings types |
+| `crates/runtimed-client/src/runtime.rs` | Runtime enum |
 | `src/bindings/index.ts` | Re-exports all generated types |
 | `src/hooks/useSyncedSettings.ts` | Consumes the generated types |

--- a/contributing/widget-development.md
+++ b/contributing/widget-development.md
@@ -25,12 +25,15 @@ This guide covers widget system internals for developers. For user-facing widget
 │                                                                         │
 │  ┌─────────────────┐         ┌──────────────────┐                      │
 │  │ WidgetBridge    │◄───────►│ Widget Components │                      │
-│  │ (receives msgs) │         │ (React renders)   │                      │
+│  │ (JSON-RPC 2.0)  │         │ (React renders)   │                      │
 │  └─────────────────┘         └──────────────────┘                      │
 └─────────────────────────────────────────────────────────────────────────┘
 ```
 
-Widgets run inside a security-isolated iframe. The parent window owns the WidgetStore and proxies Jupyter comm messages through the CommBridgeManager.
+Widgets run inside a security-isolated iframe. The parent window owns the
+WidgetStore and proxies Jupyter comm messages through the CommBridgeManager.
+Across the iframe boundary, widget traffic now uses JSON-RPC 2.0 over
+`postMessage` via `jsonrpc-transport.ts` and `rpc-methods.ts`.
 
 ## Key Files
 
@@ -43,8 +46,10 @@ Widgets run inside a security-isolated iframe. The parent window owns the Widget
 | `src/components/widgets/anywidget-view.tsx` | AFM loader for anywidget ESM modules |
 | `src/components/widgets/widget-view.tsx` | Renders widgets by looking up registry |
 | `src/components/isolated/comm-bridge-manager.ts` | Routes comm messages between store and iframe |
-| `src/components/isolated/frame-bridge.ts` | Message protocol types and guards |
-| `src/isolated-renderer/widget-bridge-client.ts` | Iframe-side message handler |
+| `src/components/isolated/frame-bridge.ts` | Legacy message types and guards for frame bootstrap/render events |
+| `src/components/isolated/jsonrpc-transport.ts` | JSON-RPC 2.0 transport over `postMessage` |
+| `src/components/isolated/rpc-methods.ts` | Shared widget bridge method names |
+| `src/isolated-renderer/widget-bridge-client.ts` | Iframe-side JSON-RPC widget bridge |
 
 ## WidgetStore API
 
@@ -98,7 +103,7 @@ Widget communication follows the Jupyter Comm protocol:
 
 The CommBridgeManager:
 1. Subscribes to WidgetStore changes
-2. Forwards model updates to the isolated iframe via postMessage
+2. Forwards model updates to the isolated iframe via JSON-RPC notifications
 3. Receives iframe messages and routes them to kernel or store
 
 ## Adding a New Built-in Widget
@@ -203,13 +208,9 @@ display(slider)
 
 ## Debugging
 
-Enable widget debug logging:
-
-```typescript
-// In browser console — enables all frontend debug logging
-localStorage.setItem("runt:debug", "true");
-// Reload the page for it to take effect
-```
+There is no `localStorage` widget-debug toggle in the current app. Use the
+browser devtools console in development builds, where `logger.ts` calls
+`attachConsole()`, and use daemon logs for comm-level tracing:
 
 Watch for comm messages in the daemon logs:
 

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -20,8 +20,9 @@ This means Python and Deno notebooks can coexist in the same project directory �
 For Python notebooks, nteract Desktop looks for dependencies in this order:
 
 1. **Inline dependencies** stored in the notebook itself
-2. **Closest project file** — nteract Desktop walks up from the notebook's directory looking for `pyproject.toml`, `pixi.toml`, or `environment.yml`/`environment.yaml`. The closest match wins, regardless of file type. If the same directory has multiple project files, the tiebreaker is: pyproject.toml > pixi.toml > environment.yml > environment.yaml
-3. If none found, a **prewarmed environment** with just the basics
+2. **PEP 723 script metadata** embedded in Python cell source (`# /// script` blocks) — nteract Desktop creates a cached UV environment from those dependencies
+3. **Closest project file** — nteract Desktop walks up from the notebook's directory looking for `pyproject.toml`, `pixi.toml`, or `environment.yml`/`environment.yaml`. The closest match wins, regardless of file type. If the same directory has multiple project files, the tiebreaker is: pyproject.toml > pixi.toml > environment.yml > environment.yaml
+4. If none found, a **prewarmed environment** with just the basics
 
 The search stops at git repository boundaries and your home directory, so project files from unrelated repos won't interfere.
 
@@ -34,6 +35,8 @@ The simplest way to manage packages. Dependencies are stored directly in the not
 **Adding packages**: Use the dependency panel in the sidebar to add, remove, or sync packages. UV dependencies use pip-style package names (`pandas`, `numpy>=2.0`). Conda dependencies support conda channels.
 
 **How it's stored**: Dependencies live in the notebook's JSON metadata under `metadata.runt.uv.dependencies` (for UV/pip packages) or `metadata.runt.conda.dependencies` (for conda packages). Legacy notebooks may use `metadata.uv` / `metadata.conda` directly — these are still read as fallbacks.
+
+Python notebooks can also declare dependencies directly in cell source via a PEP 723 `# /// script` block. When present, nteract Desktop treats those as UV dependencies and prepares a cached environment with `env_source = "uv:pep723"`.
 
 ## Working with pyproject.toml
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -51,19 +51,12 @@ For persistent verbose logging, you can modify the launch agent/service configur
 
 The notebook app logs to the webview console (View > Developer > Developer Tools).
 
-### Enabling Debug Mode
+### Viewing Frontend Debug Logs
 
-By default, routine operations are not logged in production. To enable verbose logging:
-
-1. Open the webview console (Cmd+Option+I)
-2. Run: `localStorage.setItem('runt:debug', 'true')`
-3. Reload the page
-
-To disable:
-```javascript
-localStorage.removeItem('runt:debug');
-// Reload the page
-```
+There is no `localStorage` debug toggle in the current app. In development,
+frontend logs are mirrored into the webview console via `attachConsole()` in
+`apps/notebook/src/lib/logger.ts`. In packaged builds, what you see is governed
+by the app-side log level from `tauri-plugin-log`.
 
 ### Log Prefixes
 
@@ -83,7 +76,7 @@ runt daemon logs -n 50 | grep -i error
 
 ### Outputs Not Displaying
 
-Enable debug mode and check for manifest resolution errors in the webview console.
+Check the webview console in a development build for manifest resolution errors.
 
 ### Environment Issues
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -12,8 +12,10 @@ The daemon (`runtimed`) logs to a file that persists across sessions.
 |----------|------|
 | macOS | `~/Library/Caches/runt/runtimed.log` |
 | Linux | `~/.cache/runt/runtimed.log` |
-| Dev mode (macOS) | `~/Library/Caches/runt-nightly/worktrees/{hash}/runtimed.log` |
-| Dev mode (Linux) | `~/.cache/runt-nightly/worktrees/{hash}/runtimed.log` |
+| Dev mode (macOS) | `~/Library/Caches/{cache_namespace}/worktrees/{hash}/runtimed.log` |
+| Dev mode (Linux) | `~/.cache/{cache_namespace}/worktrees/{hash}/runtimed.log` |
+
+Source builds default to the `runt-nightly` cache namespace. If you intentionally build with `RUNT_BUILD_CHANNEL=stable`, the namespace is `runt` instead.
 
 ### Viewing Logs
 

--- a/docs/runtimed.md
+++ b/docs/runtimed.md
@@ -170,11 +170,11 @@ Auto-upgrade: the client detects version mismatches and replaces the binary.
 | File | Role |
 |------|------|
 | `daemon.rs` | Daemon state, pool management, warming loops, connection routing |
-| `protocol.rs` | Request/Response enums, BlobRequest/BlobResponse |
-| `connection.rs` | Unified framing, handshake enum, send/recv helpers |
-| `client.rs` | Client library (PoolClient) for notebook apps |
-| `singleton.rs` | File locking, DaemonInfo discovery |
-| `service.rs` | Platform-specific install/start/stop |
+| `crates/notebook-protocol/src/protocol.rs` | Notebook request/response/broadcast wire types |
+| `crates/notebook-protocol/src/connection.rs` | Unified framing, handshake enum, send/recv helpers |
+| `crates/runtimed-client/src/client.rs` | Client library (`PoolClient`, notebook clients) |
+| `crates/runtimed-client/src/singleton.rs` | File locking, `DaemonInfo` discovery |
+| `crates/runtimed-client/src/service.rs` | Platform-specific install/start/stop helpers |
 | `main.rs` | CLI entry point |
 
 ---
@@ -258,7 +258,7 @@ See source for full definition (includes `working_dir`, `nbformat_attachments`, 
 2. Client sends `Handshake::NotebookSync { notebook_id }`, then exchanges Automerge sync messages
 3. Additional windows join the same room, incrementing `active_peers`
 4. Changes from any peer -> applied under write lock -> persisted to disk (outside lock) -> broadcast to all other peers
-5. Last peer disconnects -> `active_peers` hits 0 -> room evicted from map (doc already on disk)
+5. Last peer disconnects -> `active_peers` hits 0 -> delayed eviction begins (`keep_alive_secs`, default 30s); if no peer reconnects, the kernel shuts down and the room is removed
 
 **Persistence**: Documents saved to `~/.cache/runt/notebook-docs/{sha256(notebook_id)}.automerge`. SHA-256 hashing sanitizes notebook IDs (which may be file paths with special characters) into safe filenames. Persistence runs after every sync message, with serialization inside the write lock and disk I/O outside it.
 
@@ -274,11 +274,11 @@ See source for full definition (includes `working_dir`, `nbformat_attachments`, 
 
 | File | Role |
 |------|------|
-| `settings_doc.rs` | Settings Automerge document, schema, migration |
-| `sync_server.rs` | Settings sync handler |
-| `sync_client.rs` | Settings sync client library |
+| `crates/runtimed-client/src/settings_doc.rs` | Settings Automerge document, schema, migration |
+| `crates/runtimed/src/sync_server.rs` | Settings sync handler |
+| `crates/runtimed-client/src/sync_client.rs` | Settings sync client library |
 | `crates/notebook-doc/src/lib.rs` | Notebook Automerge document, cell CRUD, text editing, persistence |
-| `notebook_sync_server.rs` | Room-based notebook sync, peer management, eviction |
+| `crates/runtimed/src/notebook_sync_server.rs` | Room-based notebook sync, peer management, eviction |
 | `crates/notebook-sync/src/relay.rs` | Relay handle for notebook sync connections |
 
 ---
@@ -449,12 +449,12 @@ pub enum BlobResponse {
 |------|------|
 | `crates/notebook-protocol/src/connection.rs` | Unified framing, handshake enum, send/recv helpers |
 | `daemon.rs` | Single accept loop, `route_connection()` dispatcher |
-| `client.rs` | Uses `Handshake::Pool` |
-| `sync_client.rs` | Uses `Handshake::SettingsSync` |
-| `sync_server.rs` | Handler function (no longer owns accept loop) |
+| `crates/runtimed-client/src/client.rs` | Uses `Handshake::Pool` |
+| `crates/runtimed-client/src/sync_client.rs` | Uses `Handshake::SettingsSync` |
+| `crates/runtimed/src/sync_server.rs` | Handler function (no longer owns accept loop) |
 | `crates/notebook-sync/src/connect.rs` | Uses `Handshake::NotebookSync` for relay connections |
-| `notebook_sync_server.rs` | Handler function, room lookup |
-| `protocol.rs` | `BlobRequest`/`BlobResponse` enums |
+| `crates/runtimed/src/notebook_sync_server.rs` | Handler function, room lookup |
+| `crates/runtimed-client/src/protocol.rs` | `BlobRequest`/`BlobResponse` enums |
 
 ---
 
@@ -678,7 +678,7 @@ This needs a loading state per output (while manifest is being fetched) and cach
 
 ### Python bindings: MIME type contract
 
-The Python bindings (`crates/runtimed-py/src/output_resolver.rs`) resolve manifests and ContentRefs into native Python values, typed by MIME category:
+The Python bindings delegate output resolution to `crates/runtimed-client/src/output_resolver.rs`, which resolves manifests and ContentRefs into native Python values, typed by MIME category:
 
 | MIME category | Python type | Examples |
 |---------------|-------------|----------|
@@ -692,7 +692,7 @@ Key differences from the frontend path:
 - **JSON types return native dicts.** `application/json` and `*+json` ContentRefs are parsed into Python dicts/lists, not returned as JSON strings.
 - **`text/llm+plain` synthesis.** When an output contains binary image data but no `text/llm+plain` entry, the output resolver synthesizes one. The synthesized text includes the image MIME type, size in KB, and — when available — the blob URL (`http://localhost:{port}/blob/{hash}`). This gives LLM-based agents a text representation of image outputs without requiring them to consume raw bytes.
 
-The MIME classification logic (`mime_kind()`) is shared conceptually with the TypeScript frontend (`isBinaryMime()` in `apps/notebook/src/lib/manifest-resolution.ts`) and the Rust output store (`is_binary_mime()` in `crates/runtimed/src/output_store.rs`), though each consumer uses its own copy.
+The MIME classification logic is implemented in `mime_kind()` in `crates/runtimed-client/src/output_resolver.rs`, mirrored by `isBinaryMime()` in `apps/notebook/src/lib/manifest-resolution.ts`, and kept aligned with `is_binary_mime()` in `crates/runtimed/src/output_store.rs`.
 
 ### Key files
 
@@ -701,7 +701,7 @@ The MIME classification logic (`mime_kind()`) is shared conceptually with the Ty
 | `crates/runtimed/src/output_store.rs` | Manifest construction, ContentRef, inlining threshold |
 | `crates/runtimed/src/blob_server.rs` | HTTP read server (`GET /blob/{hash}`, `GET /health`) |
 | `crates/runtimed/src/kernel_manager.rs` | iopub listener constructs manifests and stores blobs |
-| `crates/runtimed-py/src/output_resolver.rs` | Python bindings: manifest resolution, MIME typing, `text/llm+plain` synthesis |
+| `crates/runtimed-client/src/output_resolver.rs` | Shared manifest resolution, MIME typing, `text/llm+plain` synthesis used by Python/MCP consumers |
 | `src/components/cell/OutputArea.tsx` | Fetch manifests, resolve blob URLs |
 | `apps/notebook/src/hooks/useManifestResolver.ts` | Hook for fetching/caching output manifests |
 
@@ -765,7 +765,7 @@ The daemon owns kernel processes and the output pipeline. Notebook windows are v
 
 ```
 Notebook window (thin view)
-  +-- sends LaunchKernel/QueueCell/RunAll to daemon
+  +-- sends LaunchKernel/ExecuteCell/RunAllCells to daemon
   +-- receives broadcasts (KernelStatus, Output, ExecutionStarted)
   +-- syncs cell source via Automerge
   +-- renders outputs from Automerge doc

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -47,7 +47,7 @@ Environment-specific settings (packages, future: channels) live under `uv/` and 
 
 ## Settings File
 
-Settings are persisted to a JSON file shared across all notebook windows. Both the daemon and the notebook app write the same nested JSON format.
+Settings are persisted to a JSON file shared across all notebook windows. The daemon is the sole writer; the notebook app reads the same nested JSON format as a fallback when the daemon is unavailable.
 
 | Platform | Path |
 |----------|------|


### PR DESCRIPTION
## Summary
- align contributing docs, repo docs, and agent guidance with current `xtask`, supervisor, and E2E workflows
- update runtime and bindings references to the current `runtimed-client` ownership and MIME-classification paths
- replace stale CRDT guidance around `fork_at(...)` with the current `fork()`/`merge()` guidance
- document current environment resolution, including PEP 723 handling and updated release/versioning behavior

## Testing
- `cargo xtask lint`