### PR TITLE
docs: fix stale references in contributing guides and Zed tasks

### DIFF
--- a/.zed/tasks.json
+++ b/.zed/tasks.json
@@ -73,7 +73,7 @@
   },
   {
     "label": "E2E Build",
-    "command": "./e2e/dev.sh build",
+    "command": "cargo xtask e2e build",
     "env": {
       "RUNTIMED_WORKSPACE_PATH": "$ZED_WORKTREE_ROOT",
     },
@@ -83,7 +83,7 @@
   },
   {
     "label": "E2E Fixture Tests",
-    "command": "./e2e/dev.sh test-fixtures",
+    "command": "cargo xtask e2e test-all",
     "env": {
       "RUNTIMED_WORKSPACE_PATH": "$ZED_WORKTREE_ROOT",
     },
@@ -94,7 +94,7 @@
   },
   {
     "label": "E2E All Tests",
-    "command": "./e2e/dev.sh cycle",
+    "command": "cargo xtask e2e test-all",
     "env": {
       "RUNTIMED_WORKSPACE_PATH": "$ZED_WORKTREE_ROOT",
     },

--- a/contributing/architecture.md
+++ b/contributing/architecture.md
@@ -239,7 +239,7 @@ The frontend now owns a local Automerge doc via `runtimed-wasm` WASM bindings, m
 - `crates/notebook-sync/src/connect.rs` — `connect_open_relay()`, `connect_create_relay()`: transparent byte pipe setup
 - `crates/runtimed-wasm/src/lib.rs` — WASM bindings: local Automerge peer, frame demux, per-cell accessors, `CellChangeset`
 - `crates/notebook/src/lib.rs` — Tauri commands and relay tasks (`send_frame` accepts raw binary via `tauri::ipc::Request`, `setup_sync_receivers`)
-- `crates/notebook-doc/src/frame_types.rs` — Shared frame type constants (0x00–0x04)
+- `crates/notebook-doc/src/frame_types.rs` — Shared frame type constants (0x00–0x05)
 - `apps/notebook/src/lib/frame-types.ts` — Frame type constants + `sendFrame()` binary IPC helper
 - `apps/notebook/src/hooks/useAutomergeNotebook.ts` — WASM handle owner, `scheduleMaterialize`, `CellChangeset` dispatch
 - `apps/notebook/src/lib/materialize-cells.ts` — `materializeCellFromWasm()` (per-cell) + `cellSnapshotsToNotebookCells()` (full)

--- a/contributing/e2e.md
+++ b/contributing/e2e.md
@@ -476,7 +476,7 @@ Same WebdriverIO tests, but the app runs inside a Docker container with
 Configuration is in `e2e/wdio.conf.js`:
 
 - **maxInstances**: 1 (single Tauri app instance)
-- **timeout**: 180000ms per test (3 minutes, for kernel startup scenarios)
+- **timeout**: 780000ms per test (13 minutes, for conda inline env creation on cold CI)
 - **waitforTimeout**: 10000ms for `waitFor*` methods
 - **connectionRetryTimeout**: 120000ms for WebDriver connection
 - **Screenshots**: On failure, saved to `e2e-screenshots/failures/` (configurable via `E2E_SCREENSHOT_DIR`)

--- a/contributing/testing.md
+++ b/contributing/testing.md
@@ -22,6 +22,7 @@ test: {
   include: [
     "src/**/__tests__/**/*.test.{ts,tsx}",
     "apps/notebook/src/**/__tests__/**/*.test.{ts,tsx}",
+    "packages/**/tests/**/*.test.{ts,tsx}",
   ],
   globals: true,
   setupFiles: ["./src/test-setup.ts"],


### PR DESCRIPTION
Fixes leftover stale references found during a full docs audit:

- **`.zed/tasks.json`**: 3 E2E tasks still referenced the deleted `e2e/dev.sh` — now use `cargo xtask e2e`
- **`contributing/architecture.md`**: frame type range said 0x00–0x04, actual is 0x00–0x05 (`RUNTIME_STATE_SYNC`)
- **`contributing/e2e.md`**: Mocha timeout said 180000ms (3 min), actual `wdio.conf.js` value is 780000ms (13 min for cold conda CI)
- **`contributing/testing.md`**: vitest include patterns were missing `packages/**/tests/**/*.test.{ts,tsx}`

_PR submitted by @rgbkrk's agent Quill, via Zed_