### PR TITLE
fix(iframe): transparent backgrounds for cell highlight passthrough

### DIFF
--- a/src/components/isolated/frame-html.ts
+++ b/src/components/isolated/frame-html.ts
@@ -35,7 +35,7 @@ export function generateFrameHtml(options: FrameHtmlOptions = {}): string {
   // Start with transparent backgrounds to prevent flash while theme loads
   // Parent will send theme message immediately after iframe is ready
   return `<!DOCTYPE html>
-<html style="background:${darkMode ? "#0a0a0a" : "#ffffff"};color-scheme:${darkMode ? "dark" : "light"}">
+<html style="background:transparent;color-scheme:${darkMode ? "dark" : "light"}">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -61,7 +61,7 @@ export function generateFrameHtml(options: FrameHtmlOptions = {}): string {
       padding: 0;
       font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
       line-height: 1.5;
-      background: var(--bg-primary);
+      background: transparent;
       color: var(--text-primary);
       overflow: hidden;
     }
@@ -420,7 +420,7 @@ export function generateFrameHtml(options: FrameHtmlOptions = {}): string {
           // Set color-scheme for prefers-color-scheme media queries
           rootEl.style.colorScheme = isDark ? 'dark' : 'light';
           // Set CSS variables
-          rootEl.style.setProperty('--bg-primary', isDark ? '#0a0a0a' : '#ffffff');
+          rootEl.style.setProperty('--bg-primary', 'transparent');
           rootEl.style.setProperty('--bg-secondary', isDark ? '#1a1a1a' : '#f5f5f5');
           rootEl.style.setProperty('--text-primary', isDark ? '#e0e0e0' : '#1a1a1a');
           rootEl.style.setProperty('--text-secondary', isDark ? '#a0a0a0' : '#666666');

--- a/src/components/isolated/isolated-frame.tsx
+++ b/src/components/isolated/isolated-frame.tsx
@@ -738,7 +738,7 @@ export const IsolatedFrame = forwardRef<
         opacity: displayOpacity,
         border: "none",
         display: "block",
-        background: darkMode ? "#0a0a0a" : "#ffffff",
+        background: "transparent",
         colorScheme: darkMode ? "dark" : "light",
         // Hide iframe during reload to prevent white flash from blank document.
         // visibility:hidden preserves layout (keeps height) while hiding content.


### PR DESCRIPTION
## What

Iframe outputs and rendered markdown cells had opaque backgrounds that blocked cell focus highlighting from showing through. This makes all iframe backgrounds transparent so the `CellContainer` highlight colors (sky blue for code cells, emerald for markdown) are visible.

## Changes

- **`isolated-frame.tsx`** — iframe element inline `background` → `transparent`
- **`frame-html.ts`** — three spots: `<html>` inline style, `html, body` CSS rule, and the `handleTheme()` `--bg-primary` update all set to `transparent`

Code blocks (`pre`) and table headers retain their `--bg-secondary` backgrounds.

## Verification

- [ ] Focus a code cell with outputs — sky-blue highlight shows through the output iframe
- [ ] Focus a markdown cell — emerald highlight shows through the rendered markdown
- [ ] Code blocks and table headers inside outputs still have their own backgrounds
- [ ] Toggle dark/light mode — both work without flashing

<!-- Screenshot placeholders -->

### Before
<!-- Add screenshot -->

### After
<!-- Add screenshot -->

---

_PR submitted by @rgbkrk's agent, Quill_