### PR TITLE
Local tooling to manage a debian APT channel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,7 @@ uv.lock
 .direnv
 result
 .cargo
+
+# APT publisher secrets
+scripts/apt/.env
+scripts/apt/debs/*.deb

--- a/scripts/apt/.env.example
+++ b/scripts/apt/.env.example
@@ -1,0 +1,9 @@
+CF_ACCOUNT_ID=your-cloudflare-account-id
+AWS_ACCESS_KEY_ID=your-r2-access-key-id
+AWS_SECRET_ACCESS_KEY=your-r2-secret-access-key
+AWS_DEFAULT_REGION=auto
+R2_BUCKET_NAME=your-bucket-name
+R2_PUBLIC_URL=https://apt.nteract.io
+GPG_KEY_ID=your-key-fingerprint-or-email
+GPG_PRIVATE_KEY=base64-encoded-armored-private-key
+# Generate with: gpg --armor --export-secret-keys "$KEY_ID" | base64

--- a/scripts/apt/Dockerfile
+++ b/scripts/apt/Dockerfile
@@ -1,0 +1,19 @@
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        dpkg-dev \
+        gnupg \
+        awscli \
+        gzip \
+        xz-utils \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY publish-apt.sh /usr/local/bin/publish-apt.sh
+COPY prune-packages.py /usr/local/bin/prune-packages.py
+RUN chmod +x /usr/local/bin/publish-apt.sh /usr/local/bin/prune-packages.py
+
+ENTRYPOINT ["/usr/local/bin/publish-apt.sh"]

--- a/scripts/apt/Dockerfile.test
+++ b/scripts/apt/Dockerfile.test
@@ -1,0 +1,24 @@
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+ARG R2_PUBLIC_URL
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        curl \
+        ca-certificates \
+        gnupg \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install the nteract GPG keyring
+RUN curl -fsSL "${R2_PUBLIC_URL}/nteract-keyring.gpg" \
+    | gpg --dearmor -o /usr/share/keyrings/nteract-keyring.gpg
+
+# Add both nightly and stable sources
+RUN echo "deb [arch=amd64 signed-by=/usr/share/keyrings/nteract-keyring.gpg] ${R2_PUBLIC_URL} nightly main" \
+      > /etc/apt/sources.list.d/nteract.list && \
+    echo "deb [arch=amd64 signed-by=/usr/share/keyrings/nteract-keyring.gpg] ${R2_PUBLIC_URL} stable main" \
+      >> /etc/apt/sources.list.d/nteract.list
+
+ENTRYPOINT ["/bin/bash"]

--- a/scripts/apt/README.md
+++ b/scripts/apt/README.md
@@ -1,0 +1,171 @@
+# APT Repository Publisher
+
+Publishes nteract `.deb` packages to a Cloudflare R2-backed APT repository at `apt.nteract.io`. Supports `nightly` and `stable` channels in the same bucket using standard Debian repository layout.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `Dockerfile` | Publisher image — builds the APT index and uploads to R2 |
+| `Dockerfile.test` | Test image — configured to install from the live R2 repo |
+| `publish-apt.sh` | Main publish script, runs inside the publisher container |
+| `prune-packages.py` | Python helper that prunes old nightly versions from the Packages index |
+| `docker-compose.yml` | Defines `publisher` and `test` services |
+| `.env.example` | Template for required credentials |
+| `debs/` | Drop `.deb` files here before publishing (gitignored) |
+
+---
+
+## Local setup
+
+### 1. GPG signing key
+
+The publisher signs the APT index with a GPG key. You can use an existing key or generate a dedicated one.
+
+**Option A — use your existing key:**
+
+```bash
+# Find your fingerprint
+gpg --list-secret-keys --keyid-format long
+
+# Export it (single-line base64, no wrapping)
+gpg --armor --export-secret-keys YOUR_FINGERPRINT | base64 -w 0
+```
+
+Note: if your key has a passphrase you must strip it first, since the script imports it unattended:
+
+```bash
+gpg --edit-key YOUR_FINGERPRINT
+# at the gpg> prompt:
+passwd
+# enter current passphrase, leave new passphrase blank
+```
+
+**Option B — generate a dedicated key (no passphrase):**
+
+```bash
+gpg --batch --gen-key <<EOF
+Key-Type: RSA
+Key-Length: 4096
+Name-Real: nteract
+Name-Email: releases@nteract.io
+Expire-Date: 0
+%no-protection
+EOF
+
+# Get the fingerprint
+gpg --list-secret-keys --keyid-format long releases@nteract.io
+
+# Export as base64
+gpg --armor --export-secret-keys releases@nteract.io | base64 -w 0
+```
+
+### 2. Create `.env`
+
+```bash
+cp scripts/apt/.env.example scripts/apt/.env
+```
+
+Fill in `scripts/apt/.env`:
+
+```
+CF_ACCOUNT_ID=your-cloudflare-account-id
+AWS_ACCESS_KEY_ID=your-r2-access-key-id
+AWS_SECRET_ACCESS_KEY=your-r2-secret-access-key
+AWS_DEFAULT_REGION=auto
+R2_BUCKET_NAME=your-bucket-name
+R2_PUBLIC_URL=https://apt.nteract.io
+GPG_KEY_ID=YOUR_FINGERPRINT
+GPG_PRIVATE_KEY=<output of the base64 export command above>
+```
+
+`R2_ENDPOINT` is derived automatically inside the script as `https://${CF_ACCOUNT_ID}.r2.cloudflarestorage.com` — do not set it manually.
+
+### 3. Copy the `.deb` into the debs folder
+
+```bash
+cp /path/to/nteract-nightly-linux-x64.deb scripts/apt/debs/
+```
+
+---
+
+## Publishing
+
+```bash
+docker compose -f scripts/apt/docker-compose.yml run --build --rm publisher \
+  --channel nightly /workspace/nteract-nightly-linux-x64.deb
+```
+
+For stable:
+
+```bash
+docker compose -f scripts/apt/docker-compose.yml run --build --rm publisher \
+  --channel stable /workspace/nteract-stable-linux-x64.deb
+```
+
+### Retention (nightly only)
+
+Nightly builds keep the 20 most recent versions by default. Override with `--keep-last`:
+
+```bash
+# Keep only the last 5 nightly builds
+docker compose -f scripts/apt/docker-compose.yml run --rm publisher \
+  --channel nightly --keep-last 5 /workspace/nteract-nightly-linux-x64.deb
+```
+
+Stable builds are never pruned — all versions are retained.
+
+---
+
+## Testing the repository
+
+The `test` service builds a fresh Ubuntu container with the nteract APT sources pre-configured. It reads `R2_PUBLIC_URL` from your `.env` at build time.
+
+```bash
+docker compose -f scripts/apt/docker-compose.yml run --build test
+```
+
+Inside the container:
+
+```bash
+# Refresh the index
+apt update
+
+# Check available versions
+apt-cache policy nteract-nightly
+apt-cache policy nteract
+
+# Install
+apt install nteract-nightly
+apt install nteract
+```
+
+Note: the app requires a display (GTK) and will crash with a GTK error if you try to run it inside the container — that's expected. A clean `apt install` with no errors is sufficient to confirm the repository is working.
+
+---
+
+## Repository layout in R2
+
+```
+bucket root  (https://apt.nteract.io)
+│
+├── nteract-keyring.gpg
+│
+├── pool/
+│   └── main/n/nteract/
+│       ├── nteract-nightly_2.0.7-nightly.202603310157_amd64.deb
+│       └── nteract-stable_2.1.0_amd64.deb
+│
+└── dists/
+    ├── nightly/
+    │   ├── Release
+    │   ├── Release.gpg
+    │   ├── InRelease
+    │   └── main/binary-amd64/
+    │       ├── Packages
+    │       ├── Packages.gz
+    │       └── Packages.xz
+    └── stable/
+        └── ...
+```
+

--- a/scripts/apt/docker-compose.yml
+++ b/scripts/apt/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  publisher:
+    build: .
+    env_file: .env
+    volumes:
+      - ./debs:/workspace
+
+  test:
+    build:
+      context: .
+      dockerfile: Dockerfile.test
+      args:
+        R2_PUBLIC_URL: ${R2_PUBLIC_URL}
+    env_file: .env

--- a/scripts/apt/prune-packages.py
+++ b/scripts/apt/prune-packages.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""
+prune-packages.py — prune a Debian Packages file to keep the N newest entries.
+
+Usage:
+    prune-packages.py --packages <path> --keep-last <N> \
+                      --output <path> --delete-list <path>
+
+Reads a merged Packages file, splits it into stanzas, sorts by the Version
+field (lexicographic — the nightly timestamp suffix YYYYMMDDHHMMSS is
+naturally sortable), keeps the newest N, writes the rest's Filename values
+to --delete-list for removal from R2.
+
+No third-party dependencies — stdlib only.
+"""
+
+import argparse
+import sys
+
+
+def parse_stanzas(text: str) -> list[dict]:
+    """Split a Packages file into a list of field dicts, preserving raw text."""
+    stanzas = []
+    for block in text.split("\n\n"):
+        block = block.strip()
+        if not block:
+            continue
+        fields = {}
+        current_key = None
+        for line in block.splitlines():
+            if line.startswith(" ") or line.startswith("\t"):
+                # Continuation line — append to current field value
+                if current_key:
+                    fields[current_key] += "\n" + line
+            elif ":" in line:
+                key, _, value = line.partition(":")
+                current_key = key.strip()
+                fields[current_key] = value.strip()
+        fields["_raw"] = block
+        stanzas.append(fields)
+    return stanzas
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Prune a Debian Packages file.")
+    parser.add_argument("--packages", required=True, help="Path to merged Packages file")
+    parser.add_argument("--keep-last", required=True, type=int, help="Number of versions to keep")
+    parser.add_argument("--output", required=True, help="Path to write pruned Packages file")
+    parser.add_argument("--delete-list", required=True, help="Path to write R2 keys to delete")
+    args = parser.parse_args()
+
+    if args.keep_last < 1:
+        print("ERROR: --keep-last must be a positive integer", file=sys.stderr)
+        sys.exit(1)
+
+    with open(args.packages) as f:
+        text = f.read()
+
+    stanzas = parse_stanzas(text)
+
+    if not stanzas:
+        print("WARNING: No stanzas found in Packages file", file=sys.stderr)
+        open(args.output, "w").close()
+        open(args.delete_list, "w").close()
+        sys.exit(0)
+
+    # Sort by Version field — lexicographic order works for nightly timestamps
+    stanzas.sort(key=lambda s: s.get("Version", ""))
+
+    to_delete = stanzas[: max(0, len(stanzas) - args.keep_last)]
+    to_keep = stanzas[max(0, len(stanzas) - args.keep_last) :]
+
+    print(f"  Total entries:  {len(stanzas)}")
+    print(f"  Keeping:        {len(to_keep)}")
+    print(f"  Pruning:        {len(to_delete)}")
+
+    with open(args.output, "w") as f:
+        f.write("\n\n".join(s["_raw"] for s in to_keep))
+        if to_keep:
+            f.write("\n")
+
+    with open(args.delete_list, "w") as f:
+        for s in to_delete:
+            filename = s.get("Filename", "").strip()
+            if filename:
+                f.write(filename + "\n")
+                print(f"  Queued for deletion: {filename}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/apt/publish-apt.sh
+++ b/scripts/apt/publish-apt.sh
@@ -1,0 +1,355 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# publish-apt.sh — publishes a .deb to a Cloudflare R2-backed APT repository
+# Usage: publish-apt.sh --channel <nightly|stable> [--keep-last <N>] <path-to-deb>
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+CHANNEL=""
+KEEP_LAST=20
+DEB_PATH=""
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --channel)
+      [[ $# -ge 2 ]] || { echo "ERROR: --channel requires an argument" >&2; exit 1; }
+      CHANNEL="$2"
+      shift 2
+      ;;
+    --keep-last)
+      [[ $# -ge 2 ]] || { echo "ERROR: --keep-last requires an argument" >&2; exit 1; }
+      KEEP_LAST="$2"
+      shift 2
+      ;;
+    --help|-h)
+      echo "Usage: publish-apt.sh --channel <nightly|stable> [--keep-last <N>] <path-to-deb>"
+      exit 0
+      ;;
+    -*)
+      echo "ERROR: Unknown option: $1" >&2
+      exit 1
+      ;;
+    *)
+      if [[ -z "$DEB_PATH" ]]; then
+        DEB_PATH="$1"
+      else
+        echo "ERROR: Unexpected positional argument: $1" >&2
+        exit 1
+      fi
+      shift
+      ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# Validate arguments
+# ---------------------------------------------------------------------------
+if [[ -z "$CHANNEL" ]]; then
+  echo "ERROR: --channel is required (nightly or stable)" >&2
+  exit 1
+fi
+
+if [[ "$CHANNEL" != "nightly" && "$CHANNEL" != "stable" ]]; then
+  echo "ERROR: --channel must be 'nightly' or 'stable', got: '$CHANNEL'" >&2
+  exit 1
+fi
+
+if [[ -z "$DEB_PATH" ]]; then
+  echo "ERROR: positional argument <path-to-deb> is required" >&2
+  exit 1
+fi
+
+if [[ ! -f "$DEB_PATH" || ! -r "$DEB_PATH" ]]; then
+  echo "ERROR: .deb file not found or not readable: $DEB_PATH" >&2
+  exit 1
+fi
+
+if ! [[ "$KEEP_LAST" =~ ^[1-9][0-9]*$ ]]; then
+  echo "ERROR: --keep-last must be a positive integer, got: '$KEEP_LAST'" >&2
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Validate required environment variables
+# ---------------------------------------------------------------------------
+: "${CF_ACCOUNT_ID:?ERROR: CF_ACCOUNT_ID is required}"
+: "${AWS_ACCESS_KEY_ID:?ERROR: AWS_ACCESS_KEY_ID is required}"
+: "${AWS_SECRET_ACCESS_KEY:?ERROR: AWS_SECRET_ACCESS_KEY is required}"
+: "${AWS_DEFAULT_REGION:?ERROR: AWS_DEFAULT_REGION is required}"
+: "${R2_BUCKET_NAME:?ERROR: R2_BUCKET_NAME is required}"
+: "${R2_PUBLIC_URL:?ERROR: R2_PUBLIC_URL is required}"
+: "${GPG_KEY_ID:?ERROR: GPG_KEY_ID is required}"
+: "${GPG_PRIVATE_KEY:?ERROR: GPG_PRIVATE_KEY is required}"
+
+R2_ENDPOINT="https://${CF_ACCOUNT_ID}.r2.cloudflarestorage.com"
+
+echo "==> Channel:    $CHANNEL"
+echo "==> Keep last:  $KEEP_LAST"
+echo "==> .deb path:  $DEB_PATH"
+echo "==> R2 bucket:  $R2_BUCKET_NAME"
+echo "==> R2 endpoint: $R2_ENDPOINT"
+
+# ---------------------------------------------------------------------------
+# Step 2: Import GPG key
+# ---------------------------------------------------------------------------
+echo ""
+echo "==> Importing GPG private key..."
+echo "$GPG_PRIVATE_KEY" | base64 -d | gpg --batch --import
+echo "    Import complete. Verifying key is available..."
+
+# Confirm the key we expect is actually in the keyring
+if ! gpg --list-secret-keys "$GPG_KEY_ID" > /dev/null 2>&1; then
+  echo "ERROR: GPG key '$GPG_KEY_ID' not found in keyring after import" >&2
+  exit 1
+fi
+echo "    Secret key verified: $GPG_KEY_ID"
+
+# Export the public key to confirm it's usable
+PUBLIC_KEY=$(gpg --armor --export "$GPG_KEY_ID")
+if [[ -z "$PUBLIC_KEY" ]]; then
+  echo "ERROR: Failed to export public key for '$GPG_KEY_ID'" >&2
+  exit 1
+fi
+echo "    Public key export OK ($(echo "$PUBLIC_KEY" | wc -l) lines)"
+
+# ---------------------------------------------------------------------------
+# Step 3: Extract version from the .deb
+# ---------------------------------------------------------------------------
+echo ""
+echo "==> Extracting version from .deb..."
+VERSION=$(dpkg-deb --field "$DEB_PATH" Version)
+if [[ -z "$VERSION" ]]; then
+  echo "ERROR: Could not extract Version field from $DEB_PATH" >&2
+  exit 1
+fi
+echo "    Version: $VERSION"
+
+# ---------------------------------------------------------------------------
+# Step 4: Derive the versioned pool filename
+# ---------------------------------------------------------------------------
+echo ""
+echo "==> Deriving pool filename..."
+POOL_FILENAME="nteract-${CHANNEL}_${VERSION}_amd64.deb"
+POOL_KEY="pool/main/n/nteract/${POOL_FILENAME}"
+echo "    Pool filename: $POOL_FILENAME"
+echo "    Pool key:      $POOL_KEY"
+
+# ---------------------------------------------------------------------------
+# Step 5: Set up temp working directory
+# ---------------------------------------------------------------------------
+echo ""
+echo "==> Setting up temp working directory..."
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+POOL_DIR="$WORK_DIR/pool/main/n/nteract"
+BINARY_DIR="$WORK_DIR/dists/$CHANNEL/main/binary-amd64"
+DIST_DIR="$WORK_DIR/dists/$CHANNEL"
+
+mkdir -p "$POOL_DIR" "$BINARY_DIR"
+echo "    Work dir: $WORK_DIR"
+
+# ---------------------------------------------------------------------------
+# Step 6: Copy .deb into local pool under versioned name
+# ---------------------------------------------------------------------------
+echo ""
+echo "==> Copying .deb into local pool..."
+cp "$DEB_PATH" "$POOL_DIR/$POOL_FILENAME"
+echo "    Copied to: $POOL_DIR/$POOL_FILENAME"
+
+# ---------------------------------------------------------------------------
+# Step 7: Download existing Packages file from R2
+# ---------------------------------------------------------------------------
+echo ""
+echo "==> Fetching existing Packages file from R2..."
+PACKAGES_KEY="dists/$CHANNEL/main/binary-amd64/Packages"
+if aws s3 cp "s3://$R2_BUCKET_NAME/$PACKAGES_KEY" "$BINARY_DIR/Packages.existing" \
+     --endpoint-url "$R2_ENDPOINT" 2>/dev/null; then
+  EXISTING_COUNT=$(grep -c "^Package:" "$BINARY_DIR/Packages.existing" || true)
+  echo "    Downloaded existing Packages ($EXISTING_COUNT existing entries)"
+else
+  touch "$BINARY_DIR/Packages.existing"
+  echo "    No existing Packages file found (first publish)"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 8: Generate Packages entry for the new .deb
+# ---------------------------------------------------------------------------
+echo ""
+echo "==> Scanning new .deb to generate Packages entry..."
+(cd "$WORK_DIR" && dpkg-scanpackages --arch amd64 pool/ > "$BINARY_DIR/Packages.new")
+echo "    Generated entry:"
+sed 's/^/      /' "$BINARY_DIR/Packages.new"
+
+# ---------------------------------------------------------------------------
+# Step 9: Merge: prepend new entry to existing Packages
+# ---------------------------------------------------------------------------
+echo ""
+echo "==> Merging new entry with existing Packages..."
+cat "$BINARY_DIR/Packages.new" "$BINARY_DIR/Packages.existing" \
+  > "$BINARY_DIR/Packages.merged"
+MERGED_COUNT=$(grep -c "^Package:" "$BINARY_DIR/Packages.merged" || true)
+echo "    Merged Packages has $MERGED_COUNT entries"
+
+# ---------------------------------------------------------------------------
+# Step 10: Retention — nightly only
+# ---------------------------------------------------------------------------
+if [[ "$CHANNEL" == "nightly" ]]; then
+  echo ""
+  echo "==> Pruning nightly entries (keeping last $KEEP_LAST)..."
+  python3 /usr/local/bin/prune-packages.py \
+    --packages   "$BINARY_DIR/Packages.merged" \
+    --keep-last  "$KEEP_LAST" \
+    --output     "$BINARY_DIR/Packages" \
+    --delete-list "$WORK_DIR/to_delete.txt"
+else
+  echo ""
+  echo "==> Stable channel — skipping retention, using full merged Packages..."
+  cp "$BINARY_DIR/Packages.merged" "$BINARY_DIR/Packages"
+  touch "$WORK_DIR/to_delete.txt"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 12: Compress Packages
+# ---------------------------------------------------------------------------
+echo ""
+echo "==> Compressing Packages..."
+gzip  --keep --best "$BINARY_DIR/Packages"
+xz    --keep --best "$BINARY_DIR/Packages"
+echo "    Created Packages.gz and Packages.xz"
+
+# ---------------------------------------------------------------------------
+# Step 13: Generate Release file
+# ---------------------------------------------------------------------------
+echo ""
+echo "==> Generating Release file..."
+
+MD5_LINES=""
+SHA1_LINES=""
+SHA256_LINES=""
+
+for variant in Packages Packages.gz Packages.xz; do
+  FILE="$BINARY_DIR/$variant"
+  SIZE=$(stat -c %s "$FILE")
+  MD5=$(md5sum    "$FILE" | awk '{print $1}')
+  SHA1=$(sha1sum  "$FILE" | awk '{print $1}')
+  SHA256=$(sha256sum "$FILE" | awk '{print $1}')
+  MD5_LINES="${MD5_LINES} ${MD5}  ${SIZE}  main/binary-amd64/${variant}\n"
+  SHA1_LINES="${SHA1_LINES} ${SHA1}  ${SIZE}  main/binary-amd64/${variant}\n"
+  SHA256_LINES="${SHA256_LINES} ${SHA256}  ${SIZE}  main/binary-amd64/${variant}\n"
+done
+
+DATE=$(date -u -R)
+RELEASE="$DIST_DIR/Release"
+
+{
+  echo "Origin: nteract"
+  echo "Label: nteract"
+  echo "Suite: ${CHANNEL}"
+  echo "Codename: ${CHANNEL}"
+  echo "Architectures: amd64"
+  echo "Components: main"
+  echo "Description: nteract desktop application (${CHANNEL} builds)"
+  echo "Date: ${DATE}"
+  echo "MD5Sum:"
+  printf "%b" "$MD5_LINES"
+  echo "SHA1:"
+  printf "%b" "$SHA1_LINES"
+  echo "SHA256:"
+  printf "%b" "$SHA256_LINES"
+} > "$RELEASE"
+echo "    Release file written"
+
+# ---------------------------------------------------------------------------
+# Step 14: Sign Release
+# ---------------------------------------------------------------------------
+echo ""
+echo "==> Signing Release..."
+
+gpg --default-key "$GPG_KEY_ID" \
+    --batch --yes --clearsign \
+    --output "$DIST_DIR/InRelease" \
+    "$DIST_DIR/Release"
+echo "    InRelease written"
+
+gpg --default-key "$GPG_KEY_ID" \
+    --batch --yes --detach-sign --armor \
+    --output "$DIST_DIR/Release.gpg" \
+    "$DIST_DIR/Release"
+echo "    Release.gpg written"
+
+# ---------------------------------------------------------------------------
+# Step 15: Upload new .deb to R2 pool
+# ---------------------------------------------------------------------------
+echo ""
+echo "==> Uploading .deb to R2 pool..."
+aws s3 cp "$POOL_DIR/$POOL_FILENAME" \
+  "s3://$R2_BUCKET_NAME/$POOL_KEY" \
+  --endpoint-url "$R2_ENDPOINT" \
+  --content-type "application/vnd.debian.binary-package"
+echo "    Uploaded: $POOL_KEY"
+
+# ---------------------------------------------------------------------------
+# Step 16: Upload updated index files
+# ---------------------------------------------------------------------------
+echo ""
+echo "==> Uploading index files to R2..."
+rm -f "$BINARY_DIR/Packages.existing" "$BINARY_DIR/Packages.new" "$BINARY_DIR/Packages.merged"
+aws s3 sync "$DIST_DIR" \
+  "s3://$R2_BUCKET_NAME/dists/$CHANNEL/" \
+  --endpoint-url "$R2_ENDPOINT" \
+  --cache-control "no-cache, no-store, must-revalidate" \
+  --delete
+echo "    Index files uploaded"
+
+# ---------------------------------------------------------------------------
+# Step 17: Delete pruned old .debs from R2 (nightly only)
+# ---------------------------------------------------------------------------
+if [[ "$CHANNEL" == "nightly" && -s "$WORK_DIR/to_delete.txt" ]]; then
+  echo ""
+  echo "==> Deleting pruned old versions from R2..."
+  while IFS= read -r old_key; do
+    echo "    Deleting: $old_key"
+    aws s3 rm "s3://$R2_BUCKET_NAME/$old_key" \
+      --endpoint-url "$R2_ENDPOINT" || echo "    WARNING: failed to delete $old_key (non-fatal)"
+  done < "$WORK_DIR/to_delete.txt"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 18: Upload public key (first run only)
+# ---------------------------------------------------------------------------
+echo ""
+echo "==> Checking for public keyring in R2..."
+if ! aws s3 ls "s3://$R2_BUCKET_NAME/nteract-keyring.gpg" \
+     --endpoint-url "$R2_ENDPOINT" > /dev/null 2>&1; then
+  echo "    Not found — uploading public key..."
+  gpg --armor --export "$GPG_KEY_ID" \
+    | aws s3 cp - "s3://$R2_BUCKET_NAME/nteract-keyring.gpg" \
+        --endpoint-url "$R2_ENDPOINT" \
+        --content-type "application/pgp-keys"
+  echo "    Uploaded nteract-keyring.gpg"
+else
+  echo "    Public key already present — skipping"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 19: Print user setup instructions
+# ---------------------------------------------------------------------------
+echo ""
+echo "Done! Published nteract-${CHANNEL} ${VERSION}"
+echo ""
+echo "Users can install with:"
+echo ""
+echo "  curl -fsSL ${R2_PUBLIC_URL}/nteract-keyring.gpg \\"
+echo "    | sudo gpg --dearmor -o /usr/share/keyrings/nteract-keyring.gpg"
+echo ""
+echo "  echo \"deb [arch=amd64 signed-by=/usr/share/keyrings/nteract-keyring.gpg] \\"
+echo "    ${R2_PUBLIC_URL} ${CHANNEL} main\" \\"
+echo "    | sudo tee /etc/apt/sources.list.d/nteract.list"
+echo ""
+echo "  sudo apt update && sudo apt install nteract-${CHANNEL}"


### PR DESCRIPTION
Given an already built .deb file, along with GPG and cloudflare credentials, the apt/Dockerfile can correctly sign the file, append it to the distribution channel, and then push the changes to R2. The script supports both nightly and stable, with the ability to prune old images (for nightly) so we don't carry around too many old builds. The commit also adds a test docker image to validate that searching and installing from apt works correctly

Next steps after this would be to work with the key maintainers to set up a production environment with gpg keys, cloudflare buckets, the final URL's and to make sure the local flow works. Then, we can make a github action to perform the publishing during the CI flow.

Fixes #1320