### PR TITLE
fix(daemon): classify ENOTCONN as normal disconnect, improve frame observability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6163,6 +6163,7 @@ dependencies = [
  "serde_json",
  "wasm-bindgen",
  "wasm-bindgen-test",
+ "web-sys",
 ]
 
 [[package]]

--- a/apps/notebook/src/hooks/useDaemonKernel.ts
+++ b/apps/notebook/src/hooks/useDaemonKernel.ts
@@ -454,9 +454,12 @@ export function useDaemonKernel({
         }
 
         default: {
-          logger.debug(
-            `[daemon-kernel] Unknown broadcast event: ${(broadcast as { event: string }).event}`,
-          );
+          const event = (broadcast as { event?: string }).event;
+          // Internal SyncEngine broadcasts (e.g. text_attribution) use
+          // "type" not "event" — skip logging for those.
+          if (event !== undefined) {
+            logger.debug(`[daemon-kernel] Unknown broadcast event: ${event}`);
+          }
         }
       }
     });

--- a/crates/runtimed-wasm/Cargo.toml
+++ b/crates/runtimed-wasm/Cargo.toml
@@ -18,6 +18,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-wasm-bindgen = "0.6"
 log = "0.4"
+web-sys = { version = "0.3", features = ["console"] }
 getrandom = { version = "0.3", features = ["wasm_js"] }
 getrandom_02 = { package = "getrandom", version = "0.2", features = ["js"] }
 

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -1080,18 +1080,36 @@ impl NotebookHandle {
             }
             frame_types::BROADCAST => {
                 // Parse JSON broadcast payload
-                let Ok(value) = serde_json::from_slice::<serde_json::Value>(payload) else {
-                    return JsValue::UNDEFINED;
+                let value = match serde_json::from_slice::<serde_json::Value>(payload) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        web_sys::console::warn_1(
+                            &format!("[wasm] broadcast frame parse failed: {e}").into(),
+                        );
+                        return JsValue::UNDEFINED;
+                    }
                 };
                 events.push(FrameEvent::Broadcast { payload: value });
             }
             frame_types::PRESENCE => {
                 // Decode CBOR presence and convert to JSON value for the frontend
-                let Ok(msg) = presence::decode_message(payload) else {
-                    return JsValue::UNDEFINED;
+                let msg = match presence::decode_message(payload) {
+                    Ok(m) => m,
+                    Err(e) => {
+                        web_sys::console::warn_1(
+                            &format!("[wasm] presence frame decode failed: {e}").into(),
+                        );
+                        return JsValue::UNDEFINED;
+                    }
                 };
-                let Ok(value) = serde_json::to_value(&msg) else {
-                    return JsValue::UNDEFINED;
+                let value = match serde_json::to_value(&msg) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        web_sys::console::warn_1(
+                            &format!("[wasm] presence frame serialize failed: {e}").into(),
+                        );
+                        return JsValue::UNDEFINED;
+                    }
                 };
                 events.push(FrameEvent::Presence { payload: value });
             }

--- a/crates/runtimed/src/sync_server.rs
+++ b/crates/runtimed/src/sync_server.rs
@@ -22,6 +22,7 @@ pub(crate) fn is_connection_closed(e: &anyhow::Error) -> bool {
             std::io::ErrorKind::ConnectionReset
                 | std::io::ErrorKind::BrokenPipe
                 | std::io::ErrorKind::UnexpectedEof
+                | std::io::ErrorKind::NotConnected
         )
     } else {
         false


### PR DESCRIPTION
## Summary

Diagnostics from both stable and nightly daemons during a demo session revealed three issues:

- **Stable daemon** logged a spurious `[ERROR] Connection error: Socket is not connected (os error 57)` from a stale settings sync connection. `is_connection_closed()` didn't classify `ENOTCONN` as a normal disconnect, so it was logged at ERROR level instead of being silently ignored like `ConnectionReset` and `BrokenPipe`.
- **Nightly frontend** spammed `[daemon-kernel] Unknown broadcast event: undefined` because internal SyncEngine broadcasts (`text_attribution`) use `{type: ...}` not `{event: ...}`, and the `useDaemonKernel` switch read `broadcast.event`.
- **WASM `receive_frame()`** silently returned `undefined` on broadcast/presence parse failures with no logging, making frame corruption invisible.

## Changes

- `crates/runtimed/src/sync_server.rs` — Add `NotConnected` to `is_connection_closed()` match arms
- `apps/notebook/src/hooks/useDaemonKernel.ts` — Skip "Unknown broadcast" log when `event` is undefined (internal SyncEngine broadcasts)
- `crates/runtimed-wasm/src/lib.rs` — Log parse/decode errors via `console.warn()` before returning undefined
- `crates/runtimed-wasm/Cargo.toml` — Add `web-sys` dependency with `console` feature

## Verification

- [ ] Open a notebook with text content, confirm no "Unknown broadcast event: undefined" debug spam in console
- [ ] Abruptly disconnect a client from the daemon, confirm no ERROR-level log for ENOTCONN
- [ ] Trigger a WASM frame parse failure (e.g. malformed broadcast), confirm `console.warn` appears in devtools

_PR submitted by @rgbkrk's agent, Quill_