### PR TITLE
fix(nteract): use non-deprecated fastmcp.apps import path

### DIFF
--- a/python/nteract/src/nteract/_mcp_server.py
+++ b/python/nteract/src/nteract/_mcp_server.py
@@ -27,7 +27,7 @@ import sys
 from typing import Annotated, Any, Literal, NoReturn
 
 from fastmcp import Context, FastMCP
-from fastmcp.server.apps import AppConfig, ResourceCSP
+from fastmcp.apps import AppConfig, ResourceCSP
 from fastmcp.tools import ToolResult
 from mcp.types import TextContent, ToolAnnotations
 from pydantic import Field


### PR DESCRIPTION
## Summary

- Update `from fastmcp.server.apps import AppConfig, ResourceCSP` to `from fastmcp.apps import ...` in the nteract Python MCP server, silencing the `FastMCPDeprecationWarning` emitted on startup

## Verification

- [ ] nteract MCP server starts without `FastMCPDeprecationWarning` about `fastmcp.server.apps`

_PR submitted by @rgbkrk's agent, Quill_