### PR TITLE
refactor(runtimed): move QueueCommand handling into RoomKernel

### DIFF
--- a/crates/runtimed/src/kernel_manager.rs
+++ b/crates/runtimed/src/kernel_manager.rs
@@ -38,6 +38,7 @@ use crate::protocol::{CompletionItem, HistoryEntry, NotebookBroadcast, QueueEntr
 use crate::stream_terminal::{StreamOutputState, StreamTerminals};
 use crate::terminal_size::{TERMINAL_COLUMNS_STR, TERMINAL_LINES_STR};
 use crate::{EnvType, PooledEnv};
+use notebook_doc::presence::{self, PresenceState};
 use notebook_doc::runtime_state::{QueueEntry as DocQueueEntry, RuntimeStateDoc};
 
 /// Maximum execution entries retained in the RuntimeStateDoc.
@@ -271,6 +272,9 @@ pub struct RoomKernel {
     connection_file: Option<PathBuf>,
     /// Session ID for Jupyter protocol
     session_id: String,
+    /// Automerge actor ID for kernel writes to NotebookDoc (e.g. "rt:kernel:a1b2c3d4").
+    /// Set on forks before mutating so output writes carry kernel provenance.
+    kernel_actor_id: String,
     /// Handle to the iopub listener task
     iopub_task: Option<tokio::task::JoinHandle<()>>,
     /// Handle to the shell reader task
@@ -324,6 +328,10 @@ pub struct RoomKernel {
     state_doc: Arc<RwLock<RuntimeStateDoc>>,
     /// Notification channel for RuntimeStateDoc changes.
     state_changed_tx: broadcast::Sender<()>,
+    /// Transient peer state (cursors, selections, kernel status).
+    presence: Arc<RwLock<PresenceState>>,
+    /// Broadcast channel for presence frames (cursor, selection, kernel state).
+    presence_tx: broadcast::Sender<(String, Vec<u8>)>,
 }
 
 /// Commands from iopub/shell handlers for queue state management.
@@ -398,7 +406,11 @@ impl RoomKernel {
         comm_state: Arc<CommState>,
         state_doc: Arc<RwLock<RuntimeStateDoc>>,
         state_changed_tx: broadcast::Sender<()>,
+        presence: Arc<RwLock<PresenceState>>,
+        presence_tx: broadcast::Sender<(String, Vec<u8>)>,
     ) -> Self {
+        let session_id = Uuid::new_v4().to_string();
+        let kernel_actor_id = format!("rt:kernel:{}", &session_id[..8]);
         Self {
             execution_had_error: false,
             kernel_type: String::new(),
@@ -406,7 +418,8 @@ impl RoomKernel {
             launched_config: LaunchedEnvConfig::default(),
             connection_info: None,
             connection_file: None,
-            session_id: Uuid::new_v4().to_string(),
+            session_id,
+            kernel_actor_id,
             iopub_task: None,
             shell_reader_task: None,
             process_watcher_task: None,
@@ -433,16 +446,99 @@ impl RoomKernel {
             env_path: None,
             state_doc,
             state_changed_tx,
+            presence,
+            presence_tx,
         }
     }
 
-    /// Take the command receiver for polling by the sync server.
+    /// Spawn a background task that processes `QueueCommand`s from the kernel's
+    /// iopub/shell/heartbeat tasks. Handles `ExecutionDone`, `CellError`, and
+    /// `KernelDied` for the lifetime of the kernel.
     ///
-    /// This should be called after `launch()` and polled in the sync server's
-    /// select loop. When commands arrive, call the appropriate methods on
-    /// `RoomKernel` (e.g., `execution_done` for `ExecutionDone`).
-    pub fn take_command_rx(&mut self) -> Option<mpsc::Receiver<QueueCommand>> {
-        self.cmd_rx.take()
+    /// Must be called after `launch()`. The `kernel_arc` is needed because the
+    /// spawned task locks it to call `execution_done()` and friends.
+    pub fn start_command_loop(&mut self, kernel_arc: Arc<tokio::sync::Mutex<Option<RoomKernel>>>) {
+        let Some(mut cmd_rx) = self.cmd_rx.take() else {
+            return;
+        };
+
+        let room_broadcast_tx = self.broadcast_tx.clone();
+        let room_presence = self.presence.clone();
+        let room_presence_tx = self.presence_tx.clone();
+        let room_state_doc = self.state_doc.clone();
+        let room_state_changed_tx = self.state_changed_tx.clone();
+
+        tokio::spawn(async move {
+            while let Some(cmd) = cmd_rx.recv().await {
+                match cmd {
+                    QueueCommand::ExecutionDone {
+                        cell_id,
+                        execution_id,
+                    } => {
+                        debug!(
+                            "[notebook-sync] ExecutionDone for {} ({})",
+                            cell_id, execution_id
+                        );
+                        let env_source = {
+                            let mut guard = kernel_arc.lock().await;
+                            if let Some(ref mut k) = *guard {
+                                if let Err(e) = k.execution_done(&cell_id, &execution_id).await {
+                                    warn!("[notebook-sync] execution_done error: {}", e);
+                                }
+                                Some(k.env_source().to_string())
+                            } else {
+                                None
+                            }
+                        };
+                        if let Some(es) = env_source {
+                            crate::notebook_sync_server::update_kernel_presence(
+                                &room_presence,
+                                &room_presence_tx,
+                                presence::KernelStatus::Idle,
+                                &es,
+                            )
+                            .await;
+                        }
+                    }
+                    QueueCommand::CellError {
+                        cell_id,
+                        execution_id,
+                    } => {
+                        debug!(
+                            "[notebook-sync] User code error, halting queue (stop-on-error): cell={} execution={}",
+                            cell_id, execution_id
+                        );
+                        crate::notebook_sync_server::apply_cell_error_to_state_doc(
+                            &kernel_arc,
+                            &room_state_doc,
+                            &room_state_changed_tx,
+                        )
+                        .await;
+                    }
+                    QueueCommand::KernelDied => {
+                        warn!("[notebook-sync] Kernel died, unblocking execution queue");
+                        let env_source =
+                            crate::notebook_sync_server::apply_kernel_died_to_state_doc(
+                                &kernel_arc,
+                                &room_state_doc,
+                                &room_state_changed_tx,
+                                &room_broadcast_tx,
+                            )
+                            .await;
+                        if let Some(es) = env_source {
+                            crate::notebook_sync_server::update_kernel_presence(
+                                &room_presence,
+                                &room_presence_tx,
+                                presence::KernelStatus::Errored,
+                                &es,
+                            )
+                            .await;
+                        }
+                    }
+                }
+            }
+            info!("[notebook-sync] Command receiver closed, kernel likely shutdown");
+        });
     }
 
     /// Get the kernel type.
@@ -849,6 +945,7 @@ impl RoomKernel {
         let stream_terminals = self.stream_terminals.clone();
         let state_doc_for_iopub = self.state_doc.clone();
         let state_changed_for_iopub = self.state_changed_tx.clone();
+        let iopub_actor_id = self.kernel_actor_id.clone();
 
         let iopub_task = tokio::spawn(async move {
             loop {
@@ -1075,7 +1172,7 @@ impl RoomKernel {
                                     let mut fork = {
                                         let mut doc_guard = doc.write().await;
                                         let mut f = doc_guard.fork();
-                                        f.set_actor("runtimed:kernel");
+                                        f.set_actor(&iopub_actor_id);
                                         f
                                     };
 
@@ -1232,7 +1329,7 @@ impl RoomKernel {
                                         let mut fork = {
                                             let mut doc_guard = doc.write().await;
                                             let mut f = doc_guard.fork();
-                                            f.set_actor("runtimed:kernel");
+                                            f.set_actor(&iopub_actor_id);
                                             f
                                         };
 
@@ -1273,7 +1370,7 @@ impl RoomKernel {
                                     let mut fork = {
                                         let mut doc_guard = doc.write().await;
                                         let mut f = doc_guard.fork();
-                                        f.set_actor("runtimed:kernel");
+                                        f.set_actor(&iopub_actor_id);
                                         f
                                     };
 
@@ -1409,7 +1506,7 @@ impl RoomKernel {
                                         let mut fork = {
                                             let mut doc_guard = doc.write().await;
                                             let mut f = doc_guard.fork();
-                                            f.set_actor("runtimed:kernel");
+                                            f.set_actor(&iopub_actor_id);
                                             f
                                         };
 
@@ -1633,6 +1730,7 @@ impl RoomKernel {
         let shell_doc = self.doc.clone();
         let shell_blob_store = self.blob_store.clone();
         let shell_persist_tx = self.persist_tx.clone();
+        let iopub_actor_id = self.kernel_actor_id.clone();
         let shell_changed_tx = self.changed_tx.clone();
 
         let shell_reader_task = tokio::spawn(async move {
@@ -1699,7 +1797,7 @@ impl RoomKernel {
                                             let mut fork = {
                                                 let mut doc_guard = shell_doc.write().await;
                                                 let mut f = doc_guard.fork();
-                                                f.set_actor("runtimed:kernel");
+                                                f.set_actor(&iopub_actor_id);
                                                 f
                                             };
 
@@ -2559,6 +2657,8 @@ mod tests {
         let comm_state = Arc::new(CommState::new());
         let state_doc = Arc::new(RwLock::new(RuntimeStateDoc::new()));
         let (state_changed_tx, _state_changed_rx) = broadcast::channel(16);
+        let presence = Arc::new(RwLock::new(PresenceState::new()));
+        let (presence_tx, _presence_rx) = broadcast::channel(16);
         let kernel = RoomKernel::new(
             tx,
             doc,
@@ -2568,6 +2668,8 @@ mod tests {
             comm_state,
             state_doc,
             state_changed_tx,
+            presence,
+            presence_tx,
         );
 
         assert!(!kernel.is_running());

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -64,7 +64,7 @@ const KERNEL_BROADCAST_CAPACITY: usize = 256;
 ///
 /// After catching a panic, callers should call `rebuild_from_save()` on the
 /// affected doc to round-trip save→load and rebuild clean internal indices.
-fn catch_automerge_panic<T>(label: &str, f: impl FnOnce() -> T) -> Result<T, String> {
+pub(crate) fn catch_automerge_panic<T>(label: &str, f: impl FnOnce() -> T) -> Result<T, String> {
     match std::panic::catch_unwind(AssertUnwindSafe(f)) {
         Ok(val) => Ok(val),
         Err(payload) => {
@@ -497,7 +497,7 @@ async fn check_and_broadcast_sync_state(room: &NotebookRoom) {
 /// Handle CellError: clear queue on the kernel, mark executions as errored
 /// in state_doc using fork+merge to avoid async gaps between the kernel lock
 /// and the state_doc write.
-async fn apply_cell_error_to_state_doc(
+pub(crate) async fn apply_cell_error_to_state_doc(
     room_kernel: &Arc<Mutex<Option<RoomKernel>>>,
     room_state_doc: &Arc<RwLock<RuntimeStateDoc>>,
     room_state_changed_tx: &broadcast::Sender<()>,
@@ -558,7 +558,7 @@ async fn apply_cell_error_to_state_doc(
 
 /// Handle KernelDied: set error status, clear queue, mark all executions
 /// as errored using fork+merge. Returns env_source for presence update.
-async fn apply_kernel_died_to_state_doc(
+pub(crate) async fn apply_kernel_died_to_state_doc(
     room_kernel: &Arc<Mutex<Option<RoomKernel>>>,
     room_state_doc: &Arc<RwLock<RuntimeStateDoc>>,
     room_state_changed_tx: &broadcast::Sender<()>,
@@ -2358,6 +2358,8 @@ async fn auto_launch_kernel(
         room.comm_state.clone(),
         room.state_doc.clone(),
         room.state_changed_tx.clone(),
+        room.presence.clone(),
+        room.presence_tx.clone(),
     );
 
     // Detection priority:
@@ -2735,87 +2737,7 @@ async fn auto_launch_kernel(
             let es = kernel.env_source().to_string();
 
             // Take the command receiver and spawn a task to process execution events
-            if let Some(mut cmd_rx) = kernel.take_command_rx() {
-                let room_kernel = room.kernel.clone();
-                let room_broadcast_tx = room.kernel_broadcast_tx.clone();
-                let room_presence = room.presence.clone();
-                let room_presence_tx = room.presence_tx.clone();
-                let room_state_doc = room.state_doc.clone();
-                let room_state_changed_tx = room.state_changed_tx.clone();
-                tokio::spawn(async move {
-                    use crate::kernel_manager::QueueCommand;
-                    while let Some(cmd) = cmd_rx.recv().await {
-                        match cmd {
-                            QueueCommand::ExecutionDone {
-                                cell_id,
-                                execution_id,
-                            } => {
-                                debug!(
-                                    "[notebook-sync] ExecutionDone for {} ({})",
-                                    cell_id, execution_id
-                                );
-                                let env_source = {
-                                    let mut guard = room_kernel.lock().await;
-                                    if let Some(ref mut k) = *guard {
-                                        if let Err(e) =
-                                            k.execution_done(&cell_id, &execution_id).await
-                                        {
-                                            warn!("[notebook-sync] execution_done error: {}", e);
-                                        }
-                                        Some(k.env_source().to_string())
-                                    } else {
-                                        None
-                                    }
-                                };
-                                // Update presence outside the kernel lock
-                                if let Some(es) = env_source {
-                                    update_kernel_presence(
-                                        &room_presence,
-                                        &room_presence_tx,
-                                        presence::KernelStatus::Idle,
-                                        &es,
-                                    )
-                                    .await;
-                                }
-                            }
-                            QueueCommand::CellError {
-                                cell_id,
-                                execution_id,
-                            } => {
-                                debug!(
-                                    "[notebook-sync] User code error, halting queue (stop-on-error): cell={} execution={}",
-                                    cell_id, execution_id
-                                );
-                                apply_cell_error_to_state_doc(
-                                    &room_kernel,
-                                    &room_state_doc,
-                                    &room_state_changed_tx,
-                                )
-                                .await;
-                            }
-                            QueueCommand::KernelDied => {
-                                warn!("[notebook-sync] Kernel died, unblocking execution queue");
-                                let env_source = apply_kernel_died_to_state_doc(
-                                    &room_kernel,
-                                    &room_state_doc,
-                                    &room_state_changed_tx,
-                                    &room_broadcast_tx,
-                                )
-                                .await;
-                                if let Some(es) = env_source {
-                                    update_kernel_presence(
-                                        &room_presence,
-                                        &room_presence_tx,
-                                        presence::KernelStatus::Errored,
-                                        &es,
-                                    )
-                                    .await;
-                                }
-                            }
-                        }
-                    }
-                });
-            }
+            kernel.start_command_loop(room.kernel.clone());
 
             *kernel_guard = Some(kernel);
 
@@ -2883,7 +2805,7 @@ async fn publish_kernel_state_presence(
 ///
 /// Factored out so spawned tasks (which only hold cloned Arcs) can call it
 /// without needing a full `&NotebookRoom` reference.
-async fn update_kernel_presence(
+pub(crate) async fn update_kernel_presence(
     presence_state: &Arc<RwLock<PresenceState>>,
     presence_tx: &broadcast::Sender<(String, Vec<u8>)>,
     status: presence::KernelStatus,
@@ -3086,6 +3008,8 @@ async fn handle_notebook_request(
                 room.comm_state.clone(),
                 room.state_doc.clone(),
                 room.state_changed_tx.clone(),
+                room.presence.clone(),
+                room.presence_tx.clone(),
             );
             let notebook_path = notebook_path.map(std::path::PathBuf::from);
 
@@ -3499,93 +3423,7 @@ async fn handle_notebook_request(
                     let es = kernel.env_source().to_string();
 
                     // Take the command receiver and spawn a task to process execution events
-                    if let Some(mut cmd_rx) = kernel.take_command_rx() {
-                        let room_kernel = room.kernel.clone();
-                        let room_broadcast_tx = room.kernel_broadcast_tx.clone();
-                        let room_presence = room.presence.clone();
-                        let room_presence_tx = room.presence_tx.clone();
-                        let room_state_doc = room.state_doc.clone();
-                        let room_state_changed_tx = room.state_changed_tx.clone();
-                        tokio::spawn(async move {
-                            use crate::kernel_manager::QueueCommand;
-                            while let Some(cmd) = cmd_rx.recv().await {
-                                match cmd {
-                                    QueueCommand::ExecutionDone {
-                                        cell_id,
-                                        execution_id,
-                                    } => {
-                                        info!(
-                                            "[notebook-sync] Processing ExecutionDone for {} ({})",
-                                            cell_id, execution_id
-                                        );
-                                        let env_source = {
-                                            let mut guard = room_kernel.lock().await;
-                                            if let Some(ref mut k) = *guard {
-                                                if let Err(e) =
-                                                    k.execution_done(&cell_id, &execution_id).await
-                                                {
-                                                    warn!(
-                                                        "[notebook-sync] execution_done error: {}",
-                                                        e
-                                                    );
-                                                }
-                                                Some(k.env_source().to_string())
-                                            } else {
-                                                None
-                                            }
-                                        };
-                                        // Update presence outside the kernel lock
-                                        if let Some(es) = env_source {
-                                            update_kernel_presence(
-                                                &room_presence,
-                                                &room_presence_tx,
-                                                presence::KernelStatus::Idle,
-                                                &es,
-                                            )
-                                            .await;
-                                        }
-                                    }
-                                    QueueCommand::CellError {
-                                        cell_id,
-                                        execution_id,
-                                    } => {
-                                        debug!(
-                                            "[notebook-sync] User code error, halting queue (stop-on-error): cell={} execution={}",
-                                            cell_id, execution_id
-                                        );
-                                        apply_cell_error_to_state_doc(
-                                            &room_kernel,
-                                            &room_state_doc,
-                                            &room_state_changed_tx,
-                                        )
-                                        .await;
-                                    }
-                                    QueueCommand::KernelDied => {
-                                        warn!("[notebook-sync] Kernel died, unblocking execution queue");
-                                        let env_source = apply_kernel_died_to_state_doc(
-                                            &room_kernel,
-                                            &room_state_doc,
-                                            &room_state_changed_tx,
-                                            &room_broadcast_tx,
-                                        )
-                                        .await;
-                                        if let Some(es) = env_source {
-                                            update_kernel_presence(
-                                                &room_presence,
-                                                &room_presence_tx,
-                                                presence::KernelStatus::Errored,
-                                                &es,
-                                            )
-                                            .await;
-                                        }
-                                    }
-                                }
-                            }
-                            info!(
-                                "[notebook-sync] Command receiver closed, kernel likely shutdown"
-                            );
-                        });
-                    }
+                    kernel.start_command_loop(room.kernel.clone());
 
                     *kernel_guard = Some(kernel);
                     // Drop the kernel lock before awaiting the presence update


### PR DESCRIPTION
## Summary

- **Deduplicate QueueCommand handlers**: The identical ~80-line match blocks in `auto_launch_kernel()` and `handle_notebook_request()` are consolidated into `RoomKernel::start_command_loop()`
- **Move command loop into RoomKernel**: The kernel now owns its own lifecycle event processing. `take_command_rx()` is removed; presence fields are added to `RoomKernel` so it can update kernel presence directly
- **Per-kernel Automerge actor ID**: Each kernel gets a distinct actor ID (`rt:kernel:<session_prefix>`) for `NotebookDoc` fork writes, replacing the shared `"runtimed:kernel"` string. Pure provenance, no behavior change
- Three `pub(crate)` visibility bumps (`catch_automerge_panic`, `apply_cell_error_to_state_doc`, `apply_kernel_died_to_state_doc`, `update_kernel_presence`) so `kernel_manager.rs` can call them

Net: **-60 lines**, cleaner agent boundary, kernel self-contained for execution events.

Closes #1331

## Verification

- [ ] Open a notebook, execute cells — outputs appear correctly
- [ ] Kill the kernel process — recovery works, error status shown
- [ ] Run a cell that errors with stop-on-error — queue clears correctly
- [ ] Launch kernel via auto-launch (first peer connect) and explicit request — both paths work

_PR submitted by @rgbkrk's agent, Quill_