### PR TITLE
fix(protocol): skip unknown frame types instead of killing connection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3757,6 +3757,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "kernel-env",
+ "log",
  "notebook-doc",
  "serde",
  "serde_json",

--- a/crates/notebook-protocol/Cargo.toml
+++ b/crates/notebook-protocol/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 [dependencies]
 anyhow = { workspace = true }
 kernel-env = { path = "../kernel-env", default-features = false }
+log = "0.4"
 notebook-doc = { path = "../notebook-doc" }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/notebook-protocol/src/connection.rs
+++ b/crates/notebook-protocol/src/connection.rs
@@ -293,27 +293,39 @@ pub async fn send_typed_json_frame<W: AsyncWrite + Unpin, T: Serialize>(
 
 /// Receive a typed notebook frame.
 /// Returns `None` on clean disconnect (EOF).
+/// Unknown frame types are logged and skipped for forward compatibility.
 pub async fn recv_typed_frame<R: AsyncRead + Unpin>(
     reader: &mut R,
 ) -> std::io::Result<Option<TypedNotebookFrame>> {
-    let Some(data) = recv_frame(reader).await? else {
-        return Ok(None);
-    };
+    loop {
+        let Some(data) = recv_frame(reader).await? else {
+            return Ok(None);
+        };
 
-    if data.is_empty() {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::InvalidData,
-            "empty frame",
-        ));
+        if data.is_empty() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "empty frame",
+            ));
+        }
+
+        match NotebookFrameType::try_from(data[0]) {
+            Ok(frame_type) => {
+                return Ok(Some(TypedNotebookFrame {
+                    frame_type,
+                    payload: data[1..].to_vec(),
+                }));
+            }
+            Err(_) => {
+                log::warn!(
+                    "Skipping unknown notebook frame type 0x{:02x} ({} bytes payload)",
+                    data[0],
+                    data.len() - 1,
+                );
+                continue;
+            }
+        }
     }
-
-    let frame_type = NotebookFrameType::try_from(data[0])?;
-    let payload = data[1..].to_vec();
-
-    Ok(Some(TypedNotebookFrame {
-        frame_type,
-        payload,
-    }))
 }
 
 /// Send a length-prefixed frame.


### PR DESCRIPTION
## Summary

- `recv_typed_frame` now loops internally — when it reads a frame with an unrecognized type byte, it logs a warning (hex byte + payload size) and skips to the next frame instead of returning an error
- This preserves forward compatibility: a newer client or daemon can introduce new frame types without causing reconnect loops on older peers
- Outgoing paths (Tauri `send_frame_bytes`, relay `ForwardFrame`) correctly continue to reject unknown types — we should never *send* something we don't understand

## Verification

- [ ] Connect a client to a daemon and confirm normal sync/execute/presence still works
- [ ] Simulate an unknown frame type byte on the wire and confirm the connection stays alive (warning logged, frame skipped)

_PR submitted by @rgbkrk's agent, Quill_