### PR TITLE
fix(editor): force tile rebuild to fix initial cell height discrepancy

### DIFF
--- a/src/components/editor/codemirror-editor.tsx
+++ b/src/components/editor/codemirror-editor.tsx
@@ -258,10 +258,15 @@ export const CodeMirrorEditor = forwardRef<
 
       viewRef.current = view;
 
-      if (autoFocus) {
-        // Defer focus to the next frame so the DOM is settled.
-        requestAnimationFrame(() => view.focus());
-      }
+      // Force CM to measure actual line heights on the first frame,
+      // avoiding a quick snap on first keystroke from when
+      // estimated heights differ from measured heights.
+      requestAnimationFrame(() => {
+        view.requestMeasure();
+        if (autoFocus) {
+          view.focus();
+        }
+      });
 
       return () => {
         viewRef.current = null;

--- a/src/components/editor/codemirror-editor.tsx
+++ b/src/components/editor/codemirror-editor.tsx
@@ -258,11 +258,21 @@ export const CodeMirrorEditor = forwardRef<
 
       viewRef.current = view;
 
-      // Force CM to measure actual line heights on the first frame,
-      // avoiding a quick snap on first keystroke from when
-      // estimated heights differ from measured heights.
+      // Toggling the placeholder forces a decoration change that triggers
+      // updateInner(), rebuilding the line tiles. Without this, the initial
+      // tile DOM renders a few pixels too tall — CM's measure cycle alone
+      // won't call updateInner() when the viewport hasn't changed.
       requestAnimationFrame(() => {
-        view.requestMeasure();
+        if (placeholder) {
+          view.dispatch({
+            effects: placeholderCompartment.current.reconfigure([]),
+          });
+          view.dispatch({
+            effects: placeholderCompartment.current.reconfigure(
+              placeholderExt(placeholder),
+            ),
+          });
+        }
         if (autoFocus) {
           view.focus();
         }


### PR DESCRIPTION
New cells rendered a few pixels too tall until the first keystroke, then stayed correct — even after deleting back to empty.

The previous fix (`requestMeasure()` in a rAF) was a no-op. CM6's `viewState.measure()` gates content re-measurement on `mustMeasureContent || contentDOMHeight != domRect.height` — both already consumed/unchanged by the time our rAF fires. And for single-line auto-height editors, the viewport never changes, so a `Height` flag alone never triggers `docView.updateInner()`.

The fix toggles the placeholder compartment off/on in the rAF. This produces a decoration change → `findChangedDeco()` adds to `changedRanges` → `updateInner()` rebuilds the line tiles, normalizing the line-box layout.

_PR submitted by @rgbkrk's agent Quill, via Zed_