### PR TITLE
fix(mcp): speed up create_cell and set_cell with and_run

### DIFF
--- a/crates/runt-mcp/src/execution.rs
+++ b/crates/runt-mcp/src/execution.rs
@@ -4,6 +4,7 @@
 //! tools that use `and_run`. It polls the daemon's RuntimeStateDoc to track
 //! execution status and collects outputs from the CRDT once complete.
 
+use std::collections::HashSet;
 use std::time::{Duration, Instant};
 
 use notebook_protocol::protocol::NotebookRequest;
@@ -64,11 +65,28 @@ pub async fn execute_and_wait(
     // RuntimeStateDoc can lag behind the ExecuteCell request, so the cell
     // may not appear in the queue on the first poll. Without this guard
     // we'd immediately declare "done" before execution even starts.
+    //
+    // However, fast executions can complete before the first poll. To handle
+    // this, we snapshot existing execution IDs and check for new completed
+    // entries after a grace period.
     let start = Instant::now();
     let poll_interval = Duration::from_millis(100);
     let mut final_status = "running".to_string();
     let mut success = false;
     let mut seen_in_queue = false;
+
+    // Snapshot execution IDs for this cell before polling, so we can detect
+    // new entries that appeared after our ExecuteCell request.
+    let prior_exec_ids: HashSet<String> = handle
+        .get_runtime_state()
+        .map(|s| {
+            s.executions
+                .iter()
+                .filter(|(_, e)| e.cell_id == cell_id)
+                .map(|(id, _)| id.clone())
+                .collect()
+        })
+        .unwrap_or_default();
 
     loop {
         if start.elapsed() >= timeout {
@@ -104,6 +122,24 @@ pub async fn execute_and_wait(
                     success = true;
                 }
                 break;
+            }
+
+            // Fast-execution fallback: if the cell executed before we ever saw it
+            // in the queue, seen_in_queue stays false and the above check never
+            // triggers. After a grace period, look for a *new* execution entry
+            // (one that wasn't present before we sent ExecuteCell).
+            if !seen_in_queue && start.elapsed() >= Duration::from_millis(500) {
+                if let Some((_, entry)) = state
+                    .executions
+                    .iter()
+                    .find(|(id, e)| e.cell_id == cell_id && !prior_exec_ids.contains(id.as_str()))
+                {
+                    if entry.status != "running" {
+                        final_status = entry.status.clone();
+                        success = entry.success.unwrap_or(false);
+                        break;
+                    }
+                }
             }
         }
     }

--- a/crates/runt-mcp/src/tools/cell_crud.rs
+++ b/crates/runt-mcp/src/tools/cell_crud.rs
@@ -136,15 +136,18 @@ pub async fn create_cell(
         .add_cell_with_source(&cell_id, cell_type, after_cell_id.as_deref(), source)
         .map_err(|e| McpError::internal_error(format!("Failed to create cell: {e}"), None))?;
 
-    // Sync so the daemon (and peers) know about the new cell before we send presence
-    let _ = handle.confirm_sync().await;
+    // When and_run is true, execute_and_wait already calls confirm_sync before
+    // executing, so skip the redundant sync + presence here to avoid ~2-4s overhead.
+    let will_execute = and_run && cell_type == "code";
+    if !will_execute {
+        let _ = handle.confirm_sync().await;
 
-    // Cursor at end of source (shows "finished typing")
-    let peer_label = server.get_peer_label().await;
-    let (end_line, end_col) = crate::presence::offset_to_line_col(source, source.len());
-    crate::presence::emit_cursor(handle, &cell_id, end_line, end_col, &peer_label).await;
+        let peer_label = server.get_peer_label().await;
+        let (end_line, end_col) = crate::presence::offset_to_line_col(source, source.len());
+        crate::presence::emit_cursor(handle, &cell_id, end_line, end_col, &peer_label).await;
+    }
 
-    if and_run && cell_type == "code" {
+    if will_execute {
         let result = execution::execute_and_wait(
             handle,
             &cell_id,
@@ -206,18 +209,22 @@ pub async fn set_cell(
         ));
     }
 
+    let current_type = handle.get_cell_type(cell_id).unwrap_or_default();
+    let will_execute = and_run && current_type == "code";
+
     if let Some(src) = source {
         handle
             .update_source(cell_id, src)
             .map_err(|e| McpError::internal_error(format!("Failed to update source: {e}"), None))?;
 
-        // Sync so peers see the edit before the cursor
-        let _ = handle.confirm_sync().await;
+        // Skip sync + presence when about to execute — execute_and_wait already syncs.
+        if !will_execute {
+            let _ = handle.confirm_sync().await;
 
-        // Cursor at end of new source
-        let peer_label = server.get_peer_label().await;
-        let (end_line, end_col) = crate::presence::offset_to_line_col(src, src.len());
-        crate::presence::emit_cursor(handle, cell_id, end_line, end_col, &peer_label).await;
+            let peer_label = server.get_peer_label().await;
+            let (end_line, end_col) = crate::presence::offset_to_line_col(src, src.len());
+            crate::presence::emit_cursor(handle, cell_id, end_line, end_col, &peer_label).await;
+        }
     }
     if let Some(ct) = cell_type {
         handle
@@ -225,8 +232,9 @@ pub async fn set_cell(
             .map_err(|e| McpError::internal_error(format!("Failed to set cell type: {e}"), None))?;
     }
 
-    let current_type = handle.get_cell_type(cell_id).unwrap_or_default();
-    if and_run && current_type == "code" {
+    // Re-check type after potential cell_type change above
+    let will_execute = and_run && handle.get_cell_type(cell_id).unwrap_or_default() == "code";
+    if will_execute {
         let result = execution::execute_and_wait(
             handle,
             cell_id,


### PR DESCRIPTION
## Summary

- Skip redundant `confirm_sync` call in `create_cell` and `set_cell` when `and_run` is true — `execute_and_wait` already calls it, so the earlier call wasted ~2-4s on a duplicate sync round-trip
- Fix `seen_in_queue` race in the execution polling loop: fast-executing cells could complete before the first 100ms poll, leaving `seen_in_queue` permanently false and spinning until the 30s timeout. Now snapshots prior execution IDs and detects new completed entries after a 500ms grace period

## Verification

- [ ] `create_cell` with `and_run: true` on a fast cell (e.g. `print("hi")`) returns in ~1-2s instead of ~10-30s
- [ ] `create_cell` with `and_run: true` on a slow cell (e.g. `import time; time.sleep(3)`) still waits and returns correct outputs
- [ ] `create_cell` without `and_run` still syncs and emits presence as before
- [ ] `set_cell` with `and_run: true` behaves the same as `create_cell` improvements

_PR submitted by @rgbkrk's agent, Quill_