### PR TITLE
fix(runt-mcp): match execution broadcasts by execution_id and drop session lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3696,7 +3696,7 @@ dependencies = [
 
 [[package]]
 name = "notebook"
-version = "2.0.7"
+version = "2.0.8"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5967,7 +5967,7 @@ dependencies = [
 
 [[package]]
 name = "runt-cli"
-version = "2.0.7"
+version = "2.0.8"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6045,7 +6045,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed"
-version = "2.0.7"
+version = "2.0.8"
 dependencies = [
  "alacritty_terminal",
  "anyhow",
@@ -6130,7 +6130,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed-py"
-version = "2.0.4"
+version = "2.0.5"
 dependencies = [
  "base64 0.22.1",
  "kernel-env",

--- a/crates/notebook/Cargo.toml
+++ b/crates/notebook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notebook"
-version = "2.0.7"
+version = "2.0.8"
 edition.workspace = true
 description = "Tauri-based notebook UI for Jupyter kernels"
 repository.workspace = true

--- a/crates/notebook/tauri.conf.json
+++ b/crates/notebook/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "nteract",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "identifier": "org.nteract.desktop",
   "build": {
     "devUrl": "http://localhost:5174",

--- a/crates/runt-mcp/src/execution.rs
+++ b/crates/runt-mcp/src/execution.rs
@@ -82,16 +82,14 @@ pub async fn execute_and_wait(
         match tokio::time::timeout(remaining, broadcast_rx.recv()).await {
             Ok(Some(broadcast)) => match &broadcast {
                 NotebookBroadcast::ExecutionDone {
-                    cell_id: done_cell_id,
+                    execution_id: done_eid,
                     ..
-                } if done_cell_id == cell_id => {
-                    // Check RuntimeState for the result
+                } if execution_id.as_deref() == Some(done_eid) => {
+                    // Matched by execution_id — check RuntimeState for the result
                     if let Ok(state) = handle.get_runtime_state() {
-                        if let Some(eid) = &execution_id {
-                            if let Some(entry) = state.executions.get(eid) {
-                                final_status = entry.status.clone();
-                                success = entry.success.unwrap_or(false);
-                            }
+                        if let Some(entry) = state.executions.get(done_eid) {
+                            final_status = entry.status.clone();
+                            success = entry.success.unwrap_or(false);
                         }
                     }
                     // If we didn't get status from RuntimeState, infer from outputs
@@ -99,6 +97,15 @@ pub async fn execute_and_wait(
                         final_status = "idle".to_string();
                         success = true;
                     }
+                    break;
+                }
+                // Fallback: match by cell_id when we don't have an execution_id
+                NotebookBroadcast::ExecutionDone {
+                    cell_id: done_cell_id,
+                    ..
+                } if execution_id.is_none() && done_cell_id == cell_id => {
+                    final_status = "idle".to_string();
+                    success = true;
                     break;
                 }
                 _ => {

--- a/crates/runt-mcp/src/tools/cell_crud.rs
+++ b/crates/runt-mcp/src/tools/cell_crud.rs
@@ -81,16 +81,6 @@ pub async fn create_cell(
     server: &NteractMcp,
     request: &CallToolRequestParams,
 ) -> Result<CallToolResult, McpError> {
-    let mut session = server.session.write().await;
-    let session = match session.as_mut() {
-        Some(s) => s,
-        None => {
-            return tool_error(
-                "No active notebook session. Call join_notebook or open_notebook first.",
-            )
-        }
-    };
-
     let source = arg_str(request, "source").unwrap_or("");
     let cell_type = arg_str(request, "cell_type").unwrap_or("code");
     let index = request
@@ -111,30 +101,47 @@ pub async fn create_cell(
         .and_then(|v| v.as_f64())
         .unwrap_or(30.0);
 
-    let handle = &session.handle;
-    let cell_id = format!("cell-{}", uuid::Uuid::new_v4());
-
-    // Determine after_cell_id based on index
-    let after_cell_id = if let Some(idx) = index {
-        let cell_ids = handle.get_cell_ids();
-        if idx <= 0 {
-            None // Insert at beginning
-        } else {
-            let idx = (idx as usize).min(cell_ids.len());
-            if idx > 0 {
-                Some(cell_ids[idx - 1].clone())
-            } else {
-                None
+    // Clone handle and resubscribe broadcast_rx, then drop the session lock
+    // so other tools (interrupt_kernel, etc.) aren't blocked during execution.
+    let (handle, mut broadcast_rx, cell_id) = {
+        let session = server.session.read().await;
+        let session = match session.as_ref() {
+            Some(s) => s,
+            None => {
+                return tool_error(
+                    "No active notebook session. Call join_notebook or open_notebook first.",
+                )
             }
-        }
-    } else {
-        // Append at end
-        handle.last_cell_id()
-    };
+        };
 
-    handle
-        .add_cell_with_source(&cell_id, cell_type, after_cell_id.as_deref(), source)
-        .map_err(|e| McpError::internal_error(format!("Failed to create cell: {e}"), None))?;
+        let handle = session.handle.clone();
+        let broadcast_rx = session.broadcast_rx.resubscribe();
+        let cell_id = format!("cell-{}", uuid::Uuid::new_v4());
+
+        // Determine after_cell_id based on index
+        let after_cell_id = if let Some(idx) = index {
+            let cell_ids = handle.get_cell_ids();
+            if idx <= 0 {
+                None // Insert at beginning
+            } else {
+                let idx = (idx as usize).min(cell_ids.len());
+                if idx > 0 {
+                    Some(cell_ids[idx - 1].clone())
+                } else {
+                    None
+                }
+            }
+        } else {
+            // Append at end
+            handle.last_cell_id()
+        };
+
+        handle
+            .add_cell_with_source(&cell_id, cell_type, after_cell_id.as_deref(), source)
+            .map_err(|e| McpError::internal_error(format!("Failed to create cell: {e}"), None))?;
+
+        (handle, broadcast_rx, cell_id)
+    };
 
     // Sync so the daemon (and peers) know about the new cell before we send presence
     let _ = handle.confirm_sync().await;
@@ -142,12 +149,12 @@ pub async fn create_cell(
     // Cursor at end of source (shows "finished typing")
     let peer_label = server.get_peer_label().await;
     let (end_line, end_col) = crate::presence::offset_to_line_col(source, source.len());
-    crate::presence::emit_cursor(handle, &cell_id, end_line, end_col, &peer_label).await;
+    crate::presence::emit_cursor(&handle, &cell_id, end_line, end_col, &peer_label).await;
 
     if and_run && cell_type == "code" {
         let result = execution::execute_and_wait(
-            handle,
-            &mut session.broadcast_rx,
+            &handle,
+            &mut broadcast_rx,
             &cell_id,
             Duration::from_secs_f64(timeout_secs),
             &server.blob_base_url,
@@ -155,7 +162,7 @@ pub async fn create_cell(
         )
         .await;
 
-        return build_execution_result(&result, handle, server).await;
+        return build_execution_result(&result, &handle, server).await;
     }
 
     tool_success(&format!("Created cell: {cell_id}"))
@@ -168,23 +175,6 @@ pub async fn set_cell(
 ) -> Result<CallToolResult, McpError> {
     let cell_id = arg_str(request, "cell_id")
         .ok_or_else(|| McpError::invalid_params("Missing required parameter: cell_id", None))?;
-
-    let mut session = server.session.write().await;
-    let session = match session.as_mut() {
-        Some(s) => s,
-        None => {
-            return tool_error(
-                "No active notebook session. Call join_notebook or open_notebook first.",
-            )
-        }
-    };
-
-    let handle = &session.handle;
-
-    // Verify cell exists
-    if handle.get_cell(cell_id).is_none() {
-        return tool_error(&format!("Cell not found: {cell_id}"));
-    }
 
     let source = arg_str(request, "source");
     let cell_type = arg_str(request, "cell_type");
@@ -200,6 +190,25 @@ pub async fn set_cell(
         .and_then(|a| a.get("timeout_secs"))
         .and_then(|v| v.as_f64())
         .unwrap_or(30.0);
+
+    // Clone handle and resubscribe broadcast_rx, then drop session lock
+    let (handle, broadcast_rx) = {
+        let session = server.session.read().await;
+        let session = match session.as_ref() {
+            Some(s) => s,
+            None => {
+                return tool_error(
+                    "No active notebook session. Call join_notebook or open_notebook first.",
+                )
+            }
+        };
+        (session.handle.clone(), session.broadcast_rx.resubscribe())
+    };
+
+    // Verify cell exists
+    if handle.get_cell(cell_id).is_none() {
+        return tool_error(&format!("Cell not found: {cell_id}"));
+    }
 
     if source.is_none() && cell_type.is_none() {
         return tool_success(&format!(
@@ -218,7 +227,7 @@ pub async fn set_cell(
         // Cursor at end of new source
         let peer_label = server.get_peer_label().await;
         let (end_line, end_col) = crate::presence::offset_to_line_col(src, src.len());
-        crate::presence::emit_cursor(handle, cell_id, end_line, end_col, &peer_label).await;
+        crate::presence::emit_cursor(&handle, cell_id, end_line, end_col, &peer_label).await;
     }
     if let Some(ct) = cell_type {
         handle
@@ -228,9 +237,10 @@ pub async fn set_cell(
 
     let current_type = handle.get_cell_type(cell_id).unwrap_or_default();
     if and_run && current_type == "code" {
+        let mut broadcast_rx = broadcast_rx;
         let result = execution::execute_and_wait(
-            handle,
-            &mut session.broadcast_rx,
+            &handle,
+            &mut broadcast_rx,
             cell_id,
             Duration::from_secs_f64(timeout_secs),
             &server.blob_base_url,
@@ -238,7 +248,7 @@ pub async fn set_cell(
         )
         .await;
 
-        return build_execution_result(&result, handle, server).await;
+        return build_execution_result(&result, &handle, server).await;
     }
 
     tool_success(&format!("Cell \"{cell_id}\" updated"))

--- a/crates/runt-mcp/src/tools/editing.rs
+++ b/crates/runt-mcp/src/tools/editing.rs
@@ -84,17 +84,20 @@ pub async fn replace_match(
         .and_then(|v| v.as_f64())
         .unwrap_or(30.0);
 
-    let mut session = server.session.write().await;
-    let session = match session.as_mut() {
-        Some(s) => s,
-        None => {
-            return tool_error(
-                "No active notebook session. Call join_notebook or open_notebook first.",
-            )
-        }
+    // Clone handle and resubscribe broadcast_rx, then drop session lock
+    // so other tools (interrupt_kernel, etc.) aren't blocked during execution.
+    let (handle, broadcast_rx) = {
+        let session = server.session.read().await;
+        let session = match session.as_ref() {
+            Some(s) => s,
+            None => {
+                return tool_error(
+                    "No active notebook session. Call join_notebook or open_notebook first.",
+                )
+            }
+        };
+        (session.handle.clone(), session.broadcast_rx.resubscribe())
     };
-
-    let handle = &session.handle;
 
     let source = match handle.get_cell_source(cell_id) {
         Some(s) => s,
@@ -126,19 +129,20 @@ pub async fn replace_match(
     let end_offset = span.start + content.len();
     let (line, col) = crate::presence::offset_to_line_col(&new_source, end_offset);
     let peer_label = server.get_peer_label().await;
-    crate::presence::emit_cursor(handle, cell_id, line, col, &peer_label).await;
+    crate::presence::emit_cursor(&handle, cell_id, line, col, &peer_label).await;
 
     if and_run {
+        let mut broadcast_rx = broadcast_rx;
         let result = execution::execute_and_wait(
-            handle,
-            &mut session.broadcast_rx,
+            &handle,
+            &mut broadcast_rx,
             cell_id,
             Duration::from_secs_f64(timeout_secs),
             &server.blob_base_url,
             &server.blob_store_path,
         )
         .await;
-        return build_execution_result(&result, handle, server).await;
+        return build_execution_result(&result, &handle, server).await;
     }
 
     // Return diff
@@ -172,17 +176,19 @@ pub async fn replace_regex(
         .and_then(|v| v.as_f64())
         .unwrap_or(30.0);
 
-    let mut session = server.session.write().await;
-    let session = match session.as_mut() {
-        Some(s) => s,
-        None => {
-            return tool_error(
-                "No active notebook session. Call join_notebook or open_notebook first.",
-            )
-        }
+    // Clone handle and resubscribe broadcast_rx, then drop session lock
+    let (handle, broadcast_rx) = {
+        let session = server.session.read().await;
+        let session = match session.as_ref() {
+            Some(s) => s,
+            None => {
+                return tool_error(
+                    "No active notebook session. Call join_notebook or open_notebook first.",
+                )
+            }
+        };
+        (session.handle.clone(), session.broadcast_rx.resubscribe())
     };
-
-    let handle = &session.handle;
 
     let source = match handle.get_cell_source(cell_id) {
         Some(s) => s,
@@ -214,19 +220,20 @@ pub async fn replace_regex(
     let end_offset = span.start + content.len();
     let (line, col) = crate::presence::offset_to_line_col(&new_source, end_offset);
     let peer_label = server.get_peer_label().await;
-    crate::presence::emit_cursor(handle, cell_id, line, col, &peer_label).await;
+    crate::presence::emit_cursor(&handle, cell_id, line, col, &peer_label).await;
 
     if and_run {
+        let mut broadcast_rx = broadcast_rx;
         let result = execution::execute_and_wait(
-            handle,
-            &mut session.broadcast_rx,
+            &handle,
+            &mut broadcast_rx,
             cell_id,
             Duration::from_secs_f64(timeout_secs),
             &server.blob_base_url,
             &server.blob_store_path,
         )
         .await;
-        return build_execution_result(&result, handle, server).await;
+        return build_execution_result(&result, &handle, server).await;
     }
 
     // Return diff

--- a/crates/runt-mcp/src/tools/execution.rs
+++ b/crates/runt-mcp/src/tools/execution.rs
@@ -38,14 +38,19 @@ pub async fn execute_cell(
     let cell_id = arg_str(request, "cell_id")
         .ok_or_else(|| McpError::invalid_params("Missing required parameter: cell_id", None))?;
 
-    let mut session = server.session.write().await;
-    let session = match session.as_mut() {
-        Some(s) => s,
-        None => {
-            return tool_error(
-                "No active notebook session. Call join_notebook or open_notebook first.",
-            )
-        }
+    // Clone handle and resubscribe broadcast_rx, then drop session lock
+    // so other tools (interrupt_kernel, etc.) aren't blocked during execution.
+    let (handle, mut broadcast_rx) = {
+        let session = server.session.read().await;
+        let session = match session.as_ref() {
+            Some(s) => s,
+            None => {
+                return tool_error(
+                    "No active notebook session. Call join_notebook or open_notebook first.",
+                )
+            }
+        };
+        (session.handle.clone(), session.broadcast_rx.resubscribe())
     };
 
     let timeout_secs = request
@@ -55,19 +60,17 @@ pub async fn execute_cell(
         .and_then(|v| v.as_f64())
         .unwrap_or(30.0);
 
-    let handle = &session.handle;
-
     // Verify cell exists
     if handle.get_cell(cell_id).is_none() {
         return tool_error(&format!("Cell not found: {cell_id}"));
     }
 
     let peer_label = server.get_peer_label().await;
-    crate::presence::emit_focus(handle, cell_id, &peer_label).await;
+    crate::presence::emit_focus(&handle, cell_id, &peer_label).await;
 
     let result = execution::execute_and_wait(
-        handle,
-        &mut session.broadcast_rx,
+        &handle,
+        &mut broadcast_rx,
         cell_id,
         Duration::from_secs_f64(timeout_secs),
         &server.blob_base_url,

--- a/crates/runt/Cargo.toml
+++ b/crates/runt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runt-cli"
-version = "2.0.7"
+version = "2.0.8"
 edition.workspace = true
 description = "CLI for Jupyter Runtimes — bundled with nteract"
 repository.workspace = true

--- a/crates/runtimed-py/Cargo.toml
+++ b/crates/runtimed-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed-py"
-version = "2.0.4"
+version = "2.0.5"
 edition = "2021"
 description = "Python bindings for runtimed daemon client"
 repository.workspace = true

--- a/crates/runtimed/Cargo.toml
+++ b/crates/runtimed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed"
-version = "2.0.7"
+version = "2.0.8"
 edition.workspace = true
 description = "Central daemon for managing Jupyter runtimes and prewarmed environments"
 repository.workspace = true

--- a/python/nteract/pyproject.toml
+++ b/python/nteract/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nteract"
-version = "2.0.7"
+version = "2.0.8"
 description = "Bring AI to Jupyter notebooks. MCP server for Claude, ChatGPT, Gemini, OpenCode and any agent."
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/python/runtimed/pyproject.toml
+++ b/python/runtimed/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "runtimed"
-version = "2.0.7"
+version = "2.0.8"
 description = "Python toolkit for Jupyter runtimes, powered by runtimed Rust binaries"
 readme = "README.md"
 license = "BSD-3-Clause"


### PR DESCRIPTION
## Summary

Follow-up to #1344 — fixes two regressions caught by Codex review:

- **Match `ExecutionDone` by `execution_id`** instead of `cell_id`. Stale broadcasts from prior executions of the same cell (run_all_cells, timed-out runs, app-initiated execution) could be consumed as the completion signal, returning before the current execution finishes.
- **Drop session lock before execution wait**. Callers now clone `DocHandle` and `resubscribe()` a local `BroadcastReceiver`, releasing the session `RwLock` before `execute_and_wait`. This allows `interrupt_kernel`, `restart_kernel`, and other tools to proceed while execution is in flight.

Also bumps all package versions (patch):
- nteract (PyPI): 2.0.7 → 2.0.8
- runtimed (PyPI): 2.0.7 → 2.0.8  
- runtimed-py: 2.0.4 → 2.0.5
- notebook (Tauri app): 2.0.7 → 2.0.8
- runt-cli: 2.0.7 → 2.0.8
- runtimed (daemon): 2.0.7 → 2.0.8

## Test plan

- [x] `create_cell` with `and_run: true` for `print("hello")`, `1+1`, `1/0` — all return instantly
- [x] `import time; time.sleep(2)` returns in ~2s
- [ ] Verify `interrupt_kernel` works during a long-running `execute_cell`
- [ ] Verify re-executing the same cell doesn't match stale broadcasts