### PR TITLE
fix(notebook): reduce Ctrl+Enter dedup guard from 1s to 150ms

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -622,14 +622,12 @@ function AppContent() {
           }
         }
       } finally {
-        // Hold the guard briefly to prevent rapid re-queueing.
-        // The daemon returns CellQueued immediately (~30ms), but
-        // the cell may still be executing. A 1s hold prevents
-        // accidental double-execution from rapid keypresses while
-        // still allowing intentional re-runs.
+        // Brief guard to absorb accidental double-taps. The daemon
+        // queues correctly either way, so this only needs to catch
+        // the sub-150ms "same keypress fired twice" case.
         setTimeout(() => {
           executingCellsRef.current.delete(cellId);
-        }, 1000);
+        }, 150);
       }
     },
     [flushSync, kernelStatus, tryStartKernel, executeCell],


### PR DESCRIPTION
## Summary

- The 1-second cooldown after queueing a cell execution blocked intentional re-runs — pressing Ctrl+Enter again within 1s was silently ignored
- Reduced to 150ms, which still absorbs accidental double-taps but lets you re-execute immediately
- The daemon handles re-queueing correctly regardless, so the frontend guard is purely ergonomic

## Test plan

- [ ] Rapid Ctrl+Enter on same cell: should not double-queue from a single keypress
- [ ] Press Ctrl+Enter, wait ~200ms, press again: should queue a second execution