### PR TITLE
fix(runt-mcp): clarify replace_regex tool description semantics

### DIFF
--- a/crates/runt-mcp/src/tools/editing.rs
+++ b/crates/runt-mcp/src/tools/editing.rs
@@ -44,7 +44,7 @@ pub struct ReplaceMatchParams {
 pub struct ReplaceRegexParams {
     /// The cell ID to edit.
     pub cell_id: String,
-    /// Regex pattern (must match exactly once). MULTILINE ((?m)) enabled by default — ^/$ match line boundaries. DOTALL is off — . does not match \n unless you add (?s).
+    /// Regex pattern (must match exactly once). MULTILINE ((?m)) enabled by default — ^/$ match line boundaries, use \z for end-of-string. DOTALL is off — . does not match \n unless you add (?s).
     pub pattern: String,
     /// Literal replacement text — not interpreted as a regex or escape sequence. To insert a newline, use an actual newline character in the JSON string.
     pub content: String,

--- a/crates/runt-mcp/src/tools/editing.rs
+++ b/crates/runt-mcp/src/tools/editing.rs
@@ -44,9 +44,9 @@ pub struct ReplaceMatchParams {
 pub struct ReplaceRegexParams {
     /// The cell ID to edit.
     pub cell_id: String,
-    /// Regex pattern (must match exactly once). MULTILINE enabled.
+    /// Regex pattern (must match exactly once). MULTILINE ((?m)) enabled by default — ^/$ match line boundaries. DOTALL is off — . does not match \n unless you add (?s).
     pub pattern: String,
-    /// Literal replacement text.
+    /// Literal replacement text — not interpreted as a regex or escape sequence. To insert a newline, use an actual newline character in the JSON string.
     pub content: String,
     /// Execute the cell immediately after edit.
     #[serde(default)]

--- a/crates/runt-mcp/src/tools/mod.rs
+++ b/crates/runt-mcp/src/tools/mod.rs
@@ -284,7 +284,7 @@ pub fn all_tools() -> Vec<Tool> {
         .with_meta(app_tool_meta()),
         Tool::new(
             "replace_regex",
-            "Replace a regex-matched span. Use for anchors, lookarounds, or zero-width insertions. Fails if 0 or >1 matches.",
+            "Replace a regex-matched span (fancy-regex engine, Rust). Use for anchors, lookarounds, or zero-width insertions. Fails if 0 or >1 matches. Replacement content is literal (no escape interpretation — use actual newline chars, not \\n).",
             schema_for::<editing::ReplaceRegexParams>(),
         )
         .annotate(ToolAnnotations::new().destructive(false).open_world(false))


### PR DESCRIPTION
## Summary

- Clarifies that `replace_regex` uses the **fancy-regex** engine (Rust) in the tool description
- Documents that `(?m)` (MULTILINE) is enabled by default and `(?s)` (DOTALL) is not, in the `pattern` param description
- Explicitly states that replacement `content` is literal — no escape interpretation — so agents know to use actual newline characters in JSON instead of `\n`

Closes #1347

## Verification

- [ ] Restart the MCP server and confirm `replace_regex` tool listing shows the updated description and param docs
- [ ] Use `replace_regex` with an actual newline in the `content` JSON string and confirm it inserts correctly

_PR submitted by @rgbkrk's agent, Quill_