### PR TITLE
feat(runtime): clean-room outputs in RuntimeStateDoc

### DIFF
--- a/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.d.ts
+++ b/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.d.ts
@@ -216,6 +216,8 @@ export class NotebookHandle {
     get_actor_id(): string;
     /**
      * Get a single cell by ID, or null if not found.
+     *
+     * Outputs are populated from RuntimeStateDoc when available.
      */
     get_cell(cell_id: string): JsCell | undefined;
     /**
@@ -235,7 +237,8 @@ export class NotebookHandle {
     /**
      * Get a cell's outputs as a native JS array of strings.
      *
-     * Each element is a JSON-encoded Jupyter output object (or manifest hash).
+     * Prefers RuntimeStateDoc outputs (from the latest execution for this cell).
+     * Falls back to the notebook doc if no execution exists in RuntimeStateDoc.
      * Returns undefined if the cell doesn't exist.
      */
     get_cell_outputs(cell_id: string): any;
@@ -253,10 +256,15 @@ export class NotebookHandle {
     get_cell_type(cell_id: string): string | undefined;
     /**
      * Get all cells as an array of JsCell objects.
+     *
+     * Outputs are populated from RuntimeStateDoc when available.
      */
     get_cells(): JsCell[];
     /**
      * Get all cells as a JSON string (for bulk materialization).
+     *
+     * Outputs are populated from RuntimeStateDoc when available, falling
+     * back to the notebook doc for cells without execution entries.
      */
     get_cells_json(): string;
     /**

--- a/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.js
+++ b/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.js
@@ -719,6 +719,8 @@ export class NotebookHandle {
     }
     /**
      * Get a single cell by ID, or null if not found.
+     *
+     * Outputs are populated from RuntimeStateDoc when available.
      * @param {string} cell_id
      * @returns {JsCell | undefined}
      */
@@ -784,7 +786,8 @@ export class NotebookHandle {
     /**
      * Get a cell's outputs as a native JS array of strings.
      *
-     * Each element is a JSON-encoded Jupyter output object (or manifest hash).
+     * Prefers RuntimeStateDoc outputs (from the latest execution for this cell).
+     * Falls back to the notebook doc if no execution exists in RuntimeStateDoc.
      * Returns undefined if the cell doesn't exist.
      * @param {string} cell_id
      * @returns {any}
@@ -866,6 +869,8 @@ export class NotebookHandle {
     }
     /**
      * Get all cells as an array of JsCell objects.
+     *
+     * Outputs are populated from RuntimeStateDoc when available.
      * @returns {JsCell[]}
      */
     get_cells() {
@@ -883,6 +888,9 @@ export class NotebookHandle {
     }
     /**
      * Get all cells as a JSON string (for bulk materialization).
+     *
+     * Outputs are populated from RuntimeStateDoc when available, falling
+     * back to the notebook doc for cells without execution entries.
      * @returns {string}
      */
     get_cells_json() {

--- a/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm
+++ b/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6691320bd6b01b39f1696cfd02d3333d3972643a1528a75d73e5ff60eae14cb9
-size 1635787
+oid sha256:93c91b1df33c6fcf37a6ef09f57c4dffc7754974c6b2a55b9e677fd66228e0e1
+size 1637564

--- a/crates/notebook-doc/src/runtime_state.rs
+++ b/crates/notebook-doc/src/runtime_state.rs
@@ -24,6 +24,7 @@
 //!       status: Str         ("queued" | "running" | "done" | "error")
 //!       execution_count: Int|null
 //!       success: Bool|null
+//!       outputs: List[Str]  (manifest hashes — daemon writes during execution)
 //!   env/
 //!     in_sync: bool
 //!     added: List[Str]     (packages in metadata but not in kernel)
@@ -101,6 +102,9 @@ pub struct ExecutionState {
     /// Whether the execution succeeded (set on completion).
     #[serde(default)]
     pub success: Option<bool>,
+    /// Output manifest hashes for this execution.
+    #[serde(default)]
+    pub outputs: Vec<String>,
 }
 
 /// Environment sync state snapshot.
@@ -638,6 +642,9 @@ impl RuntimeStateDoc {
         self.doc
             .put(&entry, "success", ScalarValue::Null)
             .expect("put execution.success");
+        self.doc
+            .put_object(&entry, "outputs", ObjType::List)
+            .expect("scaffold execution.outputs");
         true
     }
 
@@ -741,12 +748,102 @@ impl RuntimeStateDoc {
                 _ => None,
             });
 
+        let outputs = self.read_str_list(&entry, "outputs");
+
         Some(ExecutionState {
             cell_id,
             status,
             execution_count,
             success,
+            outputs,
         })
+    }
+
+    // ── Execution output methods ──────────────────────────────────
+
+    /// Append an output manifest hash to an execution's outputs list.
+    #[allow(clippy::expect_used)]
+    pub fn append_execution_output(&mut self, execution_id: &str, hash: &str) -> bool {
+        let Some(executions) = self.get_map("executions") else {
+            return false;
+        };
+        let Some((_, entry)) = self.doc.get(&executions, execution_id).ok().flatten() else {
+            return false;
+        };
+        let Some((_, outputs)) = self.doc.get(&entry, "outputs").ok().flatten() else {
+            // Scaffold if missing (backward compat with entries created before outputs existed)
+            let outputs = self
+                .doc
+                .put_object(&entry, "outputs", ObjType::List)
+                .expect("scaffold outputs");
+            self.doc.insert(&outputs, 0, hash).expect("insert output");
+            return true;
+        };
+        let len = self.doc.length(&outputs);
+        self.doc.insert(&outputs, len, hash).expect("append output");
+        true
+    }
+
+    /// Upsert an output at a specific index (for stream terminal updates).
+    ///
+    /// If `index` equals the current length, appends. If `index` is within
+    /// bounds, replaces the existing entry.
+    #[allow(clippy::expect_used)]
+    pub fn upsert_execution_output(
+        &mut self,
+        execution_id: &str,
+        index: usize,
+        hash: &str,
+    ) -> bool {
+        let Some(executions) = self.get_map("executions") else {
+            return false;
+        };
+        let Some((_, entry)) = self.doc.get(&executions, execution_id).ok().flatten() else {
+            return false;
+        };
+        let Some((_, outputs)) = self.doc.get(&entry, "outputs").ok().flatten() else {
+            return false;
+        };
+        let len = self.doc.length(&outputs);
+        if index < len {
+            self.doc.put(&outputs, index, hash).expect("upsert output");
+        } else {
+            self.doc.insert(&outputs, len, hash).expect("append output");
+        }
+        true
+    }
+
+    /// Clear all outputs for an execution.
+    #[allow(clippy::expect_used)]
+    pub fn clear_execution_outputs(&mut self, execution_id: &str) -> bool {
+        let Some(executions) = self.get_map("executions") else {
+            return false;
+        };
+        let Some((_, entry)) = self.doc.get(&executions, execution_id).ok().flatten() else {
+            return false;
+        };
+        let Some((_, outputs)) = self.doc.get(&entry, "outputs").ok().flatten() else {
+            return false;
+        };
+        let len = self.doc.length(&outputs);
+        if len == 0 {
+            return false;
+        }
+        for i in (0..len).rev() {
+            self.doc.delete(&outputs, i).expect("delete output");
+        }
+        true
+    }
+
+    /// Read outputs for an execution.
+    pub fn get_execution_outputs(&self, execution_id: &str) -> Vec<String> {
+        let Some(executions) = self.get_map("executions") else {
+            return Vec::new();
+        };
+        let Some((_, entry)) = self.doc.get(&executions, execution_id).ok().flatten() else {
+            return Vec::new();
+        };
+        self.read_str_list(&entry, "outputs")
     }
 
     /// Remove old executions, keeping the most recent `max` entries.

--- a/crates/notebook-sync/src/handle.rs
+++ b/crates/notebook-sync/src/handle.rs
@@ -148,6 +148,19 @@ impl DocHandle {
         Ok(state.state_doc.read_state())
     }
 
+    /// Get outputs for a cell from RuntimeStateDoc (latest execution).
+    ///
+    /// Returns None if no execution exists or if RuntimeState is unavailable.
+    fn get_runtime_outputs_for_cell(&self, cell_id: &str) -> Option<Vec<String>> {
+        let state = self.get_runtime_state().ok()?;
+        state
+            .executions
+            .values()
+            .filter(|e| e.cell_id == cell_id)
+            .max_by_key(|e| e.execution_count)
+            .map(|e| e.outputs.clone())
+    }
+
     // =====================================================================
     // Document mutations — synchronous, direct, no channels
     // =====================================================================
@@ -399,9 +412,21 @@ impl DocHandle {
     }
 
     /// Get a single cell by ID from the latest snapshot.
+    ///
+    /// Outputs are populated from RuntimeStateDoc when available.
     pub fn get_cell(&self, cell_id: &str) -> Option<notebook_doc::CellSnapshot> {
         let snapshot = self.snapshot_rx.borrow();
-        snapshot.cells.iter().find(|c| c.id == cell_id).cloned()
+        snapshot
+            .cells
+            .iter()
+            .find(|c| c.id == cell_id)
+            .cloned()
+            .map(|mut cell| {
+                if let Some(outputs) = self.get_runtime_outputs_for_cell(&cell.id) {
+                    cell.outputs = outputs;
+                }
+                cell
+            })
     }
 
     /// Get the ordered list of cell IDs from the latest snapshot.
@@ -443,7 +468,12 @@ impl DocHandle {
     }
 
     /// Get a single cell's JSON-encoded outputs.
+    ///
+    /// Prefers RuntimeStateDoc outputs over notebook doc.
     pub fn get_cell_outputs(&self, cell_id: &str) -> Option<Vec<String>> {
+        if let Some(outputs) = self.get_runtime_outputs_for_cell(cell_id) {
+            return Some(outputs);
+        }
         let snapshot = self.snapshot_rx.borrow();
         snapshot
             .cells
@@ -641,8 +671,23 @@ impl DocHandle {
     }
 
     /// Get all cells from the latest snapshot.
+    ///
+    /// Outputs are populated from RuntimeStateDoc when available.
     pub fn get_cells(&self) -> Vec<notebook_doc::CellSnapshot> {
-        self.snapshot_rx.borrow().cells.as_ref().clone()
+        let mut cells = self.snapshot_rx.borrow().cells.as_ref().clone();
+        if let Ok(state) = self.get_runtime_state() {
+            for cell in &mut cells {
+                let latest = state
+                    .executions
+                    .values()
+                    .filter(|e| e.cell_id == cell.id)
+                    .max_by_key(|e| e.execution_count);
+                if let Some(entry) = latest {
+                    cell.outputs = entry.outputs.clone();
+                }
+            }
+        }
+        cells
     }
 
     /// Get the typed notebook metadata from the latest snapshot.

--- a/crates/runtimed-py/src/output.rs
+++ b/crates/runtimed-py/src/output.rs
@@ -910,14 +910,19 @@ pub struct PyExecutionState {
     pub execution_count: Option<i64>,
     /// Whether the execution succeeded (set on completion).
     pub success: Option<bool>,
+    /// Output manifest hashes for this execution.
+    pub outputs: Vec<String>,
 }
 
 #[pymethods]
 impl PyExecutionState {
     fn __repr__(&self) -> String {
         format!(
-            "ExecutionState(cell_id={}, status={}, success={:?})",
-            self.cell_id, self.status, self.success
+            "ExecutionState(cell_id={}, status={}, success={:?}, outputs={})",
+            self.cell_id,
+            self.status,
+            self.success,
+            self.outputs.len()
         )
     }
 
@@ -1012,6 +1017,7 @@ impl From<notebook_doc::runtime_state::RuntimeState> for PyRuntimeState {
                             status: es.status,
                             execution_count: es.execution_count,
                             success: es.success,
+                            outputs: es.outputs,
                         },
                     )
                 })

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -344,18 +344,34 @@ impl NotebookHandle {
     }
 
     /// Get all cells as an array of JsCell objects.
+    ///
+    /// Outputs are populated from RuntimeStateDoc when available.
     pub fn get_cells(&self) -> Vec<JsCell> {
         self.doc
             .get_cells()
             .into_iter()
             .enumerate()
-            .map(JsCell::from)
+            .map(|(idx, mut snap)| {
+                if let Some(outputs) = self.get_runtime_outputs_for_cell(&snap.id) {
+                    snap.outputs = outputs;
+                }
+                JsCell::from((idx, snap))
+            })
             .collect()
     }
 
     /// Get all cells as a JSON string (for bulk materialization).
+    ///
+    /// Outputs are populated from RuntimeStateDoc when available, falling
+    /// back to the notebook doc for cells without execution entries.
     pub fn get_cells_json(&self) -> String {
-        let cells = self.doc.get_cells();
+        let mut cells = self.doc.get_cells();
+        // Override outputs from RuntimeStateDoc
+        for cell in &mut cells {
+            if let Some(outputs) = self.get_runtime_outputs_for_cell(&cell.id) {
+                cell.outputs = outputs;
+            }
+        }
         serde_json::to_string(&cells).unwrap_or_else(|_| "[]".to_string())
     }
 
@@ -381,9 +397,15 @@ impl NotebookHandle {
 
     /// Get a cell's outputs as a native JS array of strings.
     ///
-    /// Each element is a JSON-encoded Jupyter output object (or manifest hash).
+    /// Prefers RuntimeStateDoc outputs (from the latest execution for this cell).
+    /// Falls back to the notebook doc if no execution exists in RuntimeStateDoc.
     /// Returns undefined if the cell doesn't exist.
     pub fn get_cell_outputs(&self, cell_id: &str) -> JsValue {
+        // Try RuntimeStateDoc first
+        if let Some(outputs) = self.get_runtime_outputs_for_cell(cell_id) {
+            return serialize_to_js(&outputs).unwrap_or(JsValue::UNDEFINED);
+        }
+        // Fall back to notebook doc
         match self.doc.get_cell_outputs(cell_id) {
             Some(outputs) => serialize_to_js(&outputs).unwrap_or(JsValue::UNDEFINED),
             None => JsValue::UNDEFINED,
@@ -411,13 +433,20 @@ impl NotebookHandle {
     }
 
     /// Get a single cell by ID, or null if not found.
+    ///
+    /// Outputs are populated from RuntimeStateDoc when available.
     pub fn get_cell(&self, cell_id: &str) -> Option<JsCell> {
         let cells = self.doc.get_cells();
         cells
             .into_iter()
             .enumerate()
             .find(|(_, c)| c.id == cell_id)
-            .map(JsCell::from)
+            .map(|(idx, mut snap)| {
+                if let Some(outputs) = self.get_runtime_outputs_for_cell(&snap.id) {
+                    snap.outputs = outputs;
+                }
+                JsCell::from((idx, snap))
+            })
     }
 
     /// Add a new cell at the given index (backward-compatible API).
@@ -981,6 +1010,21 @@ impl NotebookHandle {
     pub fn get_runtime_state(&self) -> JsValue {
         let state = self.state_doc.read_state();
         serialize_to_js(&state).unwrap_or(JsValue::UNDEFINED)
+    }
+
+    /// Get outputs for a cell from RuntimeStateDoc (latest execution).
+    ///
+    /// Finds the most recent execution for the given cell_id by preferring
+    /// the highest execution_count, then falls back to "running" status.
+    /// Returns None if no execution exists for this cell.
+    fn get_runtime_outputs_for_cell(&self, cell_id: &str) -> Option<Vec<String>> {
+        let state = self.state_doc.read_state();
+        state
+            .executions
+            .values()
+            .filter(|e| e.cell_id == cell_id)
+            .max_by_key(|e| e.execution_count)
+            .map(|e| e.outputs.clone())
     }
 
     /// Reset the sync state. Call this when reconnecting to a new daemon session.

--- a/crates/runtimed/src/kernel_manager.rs
+++ b/crates/runtimed/src/kernel_manager.rs
@@ -133,73 +133,48 @@ fn is_manifest_hash(s: &str) -> bool {
     s.len() == 64 && s.chars().all(|c| c.is_ascii_hexdigit())
 }
 
-/// Update an output by display_id when outputs are manifest hashes.
+/// Update an output by display_id across all executions in RuntimeStateDoc.
 ///
-/// This function iterates through all cells and outputs in the document,
-/// looking for a manifest with a matching display_id. When found, it creates
-/// a new manifest with updated data and replaces the hash in the document.
-///
-/// Returns true if an output was found and updated, false otherwise.
-async fn update_output_by_display_id_with_manifests(
-    doc: &mut NotebookDoc,
+/// Scans all execution outputs for a matching display_id, creates a new manifest
+/// with updated data, and replaces the hash in RuntimeStateDoc.
+async fn update_display_in_runtime_state(
+    state_doc: &Arc<RwLock<RuntimeStateDoc>>,
     display_id: &str,
     new_data: &serde_json::Value,
     new_metadata: &serde_json::Map<String, serde_json::Value>,
     blob_store: &BlobStore,
 ) -> Result<bool, Box<dyn std::error::Error + Send + Sync>> {
-    // Get all outputs from the document
-    let outputs = doc.get_all_outputs();
+    // Read all execution outputs
+    let state = {
+        let sd = state_doc.read().await;
+        sd.read_state()
+    };
 
-    for (cell_id, output_idx, output_str) in outputs {
-        // Check if it's a manifest hash or raw JSON
-        if is_manifest_hash(&output_str) {
-            // Fetch manifest from blob store
-            let manifest_bytes = match blob_store.get(&output_str).await? {
-                Some(bytes) => bytes,
-                None => continue,
-            };
-            let manifest_json = String::from_utf8(manifest_bytes)?;
+    for (eid, entry) in &state.executions {
+        for (idx, output_str) in entry.outputs.iter().enumerate() {
+            if is_manifest_hash(output_str) {
+                let manifest_bytes = match blob_store.get(output_str).await? {
+                    Some(bytes) => bytes,
+                    None => continue,
+                };
+                let manifest_json = String::from_utf8(manifest_bytes)?;
 
-            // Try to update the manifest
-            if let Some(updated_manifest) = output_store::update_manifest_display_data(
-                &manifest_json,
-                display_id,
-                new_data,
-                new_metadata,
-                blob_store,
-                DEFAULT_INLINE_THRESHOLD,
-            )
-            .await?
-            {
-                // Store the updated manifest and get new hash
-                let new_hash = output_store::store_manifest(&updated_manifest, blob_store).await?;
-
-                // Replace the hash in the document
-                doc.replace_output(&cell_id, output_idx, &new_hash)?;
-                return Ok(true);
-            }
-        } else {
-            // Backward compatibility: try parsing as raw JSON
-            let mut output_json: serde_json::Value = match serde_json::from_str(&output_str) {
-                Ok(v) => v,
-                Err(_) => continue,
-            };
-
-            let matches = output_json
-                .get("transient")
-                .and_then(|t| t.get("display_id"))
-                .and_then(|d| d.as_str())
-                == Some(display_id);
-
-            if matches {
-                // Update data and metadata in place
-                output_json["data"] = new_data.clone();
-                output_json["metadata"] = serde_json::Value::Object(new_metadata.clone());
-
-                // Write back
-                let updated_str = output_json.to_string();
-                doc.replace_output(&cell_id, output_idx, &updated_str)?;
-                return Ok(true);
+                if let Some(updated_manifest) = output_store::update_manifest_display_data(
+                    &manifest_json,
+                    display_id,
+                    new_data,
+                    new_metadata,
+                    blob_store,
+                    DEFAULT_INLINE_THRESHOLD,
+                )
+                .await?
+                {
+                    let new_hash =
+                        output_store::store_manifest(&updated_manifest, blob_store).await?;
+                    let mut sd = state_doc.write().await;
+                    sd.upsert_execution_output(eid, idx, &new_hash);
+                    return Ok(true);
+                }
             }
         }
     }
@@ -945,7 +920,6 @@ impl RoomKernel {
         let stream_terminals = self.stream_terminals.clone();
         let state_doc_for_iopub = self.state_doc.clone();
         let state_changed_for_iopub = self.state_changed_tx.clone();
-        let iopub_actor_id = self.kernel_actor_id.clone();
 
         let iopub_task = tokio::spawn(async move {
             loop {
@@ -1024,20 +998,11 @@ impl RoomKernel {
                                         terminals.clear(cid);
                                     }
 
-                                    // Clear outputs and set execution count in Automerge before
-                                    // notifying clients so UI reads the updated value immediately.
-                                    // Clearing outputs here (when execution truly starts) ensures
-                                    // a single source of truth - both frontend and MCP-triggered
-                                    // executions get outputs cleared authoritatively by the daemon.
+                                    // Set execution count in notebook doc (for display).
+                                    // Outputs are now managed in RuntimeStateDoc, not notebook doc.
                                     let execution_count = input.execution_count.0 as i64;
                                     let persist_bytes = {
                                         let mut doc_guard = doc.write().await;
-                                        if let Err(e) = doc_guard.clear_outputs(cid) {
-                                            warn!(
-                                                "[kernel-manager] Failed to clear outputs in doc for cell {}: {}",
-                                                cid, e
-                                            );
-                                        }
                                         if let Err(e) = doc_guard
                                             .set_execution_count(cid, &execution_count.to_string())
                                         {
@@ -1052,12 +1017,12 @@ impl RoomKernel {
                                     };
                                     let _ = persist_tx.send(Some(persist_bytes));
 
-                                    // Write execution_count to RuntimeStateDoc
+                                    // Clear outputs and set execution_count in RuntimeStateDoc
                                     if let Some(ref eid) = execution_id {
                                         let mut sd = state_doc_for_iopub.write().await;
-                                        if sd.set_execution_count(eid, execution_count) {
-                                            let _ = state_changed_for_iopub.send(());
-                                        }
+                                        sd.clear_execution_outputs(eid);
+                                        sd.set_execution_count(eid, execution_count);
+                                        let _ = state_changed_for_iopub.send(());
                                     }
 
                                     let _ =
@@ -1167,63 +1132,48 @@ impl RoomKernel {
                                         }
                                     };
 
-                                    // Fork before upsert so concurrent edits compose
-                                    // via CRDT merge.
-                                    let mut fork = {
-                                        let mut doc_guard = doc.write().await;
-                                        let mut f = doc_guard.fork();
-                                        f.set_actor(&iopub_actor_id);
-                                        f
-                                    };
-
-                                    let upsert_result = fork.upsert_stream_output(
-                                        cid,
-                                        stream_name,
-                                        &output_ref,
-                                        known_state.as_ref(),
-                                    );
-
-                                    // Use the fork's upsert result for terminal state caching
-                                    // and broadcast. The fork's index is where the upsert
-                                    // actually wrote — using merged len()-1 would be wrong if
-                                    // the updated entry isn't the last output. If a rare
-                                    // concurrent clear invalidates the cached index, the next
-                                    // stream chunk safely falls back to append.
-                                    let (persist_bytes, broadcast_output_index) = {
-                                        let mut doc_guard = doc.write().await;
-                                        doc_guard.merge(&mut fork).ok();
-
-                                        let broadcast_idx = match &upsert_result {
-                                            Ok((updated, output_index)) => {
-                                                let mut terminals = stream_terminals.lock().await;
-                                                terminals.set_output_state(
-                                                    cid,
-                                                    stream_name,
-                                                    StreamOutputState {
-                                                        index: *output_index,
-                                                        manifest_hash: output_ref.clone(),
-                                                    },
-                                                );
-                                                if *updated {
-                                                    Some(*output_index)
-                                                } else {
-                                                    None
-                                                }
-                                            }
-                                            Err(e) => {
-                                                warn!(
-                                                    "[kernel-manager] Failed to upsert stream output: {}",
-                                                    e
-                                                );
-                                                None
-                                            }
+                                    // Write stream output to RuntimeStateDoc.
+                                    // Stream outputs upsert: if the terminal state
+                                    // has a known index, update in place; otherwise append.
+                                    let broadcast_output_index = if let Some(ref eid) = execution_id
+                                    {
+                                        let mut sd = state_doc_for_iopub.write().await;
+                                        let idx = if let Some(ref state) = known_state {
+                                            // Update existing stream output at known index
+                                            sd.upsert_execution_output(
+                                                eid,
+                                                state.index,
+                                                &output_ref,
+                                            );
+                                            Some(state.index)
+                                        } else {
+                                            // Append new output
+                                            sd.append_execution_output(eid, &output_ref);
+                                            None
                                         };
+                                        let _ = state_changed_for_iopub.send(());
 
-                                        let bytes = doc_guard.save();
-                                        let _ = changed_tx.send(());
-                                        (bytes, broadcast_idx)
+                                        // Update terminal state with the output index
+                                        let output_index = idx.unwrap_or_else(|| {
+                                            // Get the new length - 1 for the just-appended output
+                                            let outputs = sd.get_execution_outputs(eid);
+                                            outputs.len().saturating_sub(1)
+                                        });
+                                        {
+                                            let mut terminals = stream_terminals.lock().await;
+                                            terminals.set_output_state(
+                                                cid,
+                                                stream_name,
+                                                StreamOutputState {
+                                                    index: output_index,
+                                                    manifest_hash: output_ref.clone(),
+                                                },
+                                            );
+                                        }
+                                        idx
+                                    } else {
+                                        None
                                     };
-                                    let _ = persist_tx.send(Some(persist_bytes));
 
                                     let _ = broadcast_tx.send(NotebookBroadcast::Output {
                                         cell_id: cid.clone(),
@@ -1324,30 +1274,12 @@ impl RoomKernel {
                                             }
                                         };
 
-                                        // Fork before appending so concurrent edits
-                                        // (e.g. from other iopub messages) compose via CRDT merge.
-                                        let mut fork = {
-                                            let mut doc_guard = doc.write().await;
-                                            let mut f = doc_guard.fork();
-                                            f.set_actor(&iopub_actor_id);
-                                            f
-                                        };
-
-                                        if let Err(e) = fork.append_output(cid, &output_ref) {
-                                            warn!(
-                                                "[kernel-manager] Failed to append output to doc: {}",
-                                                e
-                                            );
+                                        // Write output to RuntimeStateDoc
+                                        if let Some(ref eid) = execution_id {
+                                            let mut sd = state_doc_for_iopub.write().await;
+                                            sd.append_execution_output(eid, &output_ref);
+                                            let _ = state_changed_for_iopub.send(());
                                         }
-
-                                        let persist_bytes = {
-                                            let mut doc_guard = doc.write().await;
-                                            doc_guard.merge(&mut fork).ok();
-                                            let bytes = doc_guard.save();
-                                            let _ = changed_tx.send(());
-                                            bytes
-                                        };
-                                        let _ = persist_tx.send(Some(persist_bytes));
 
                                         let _ = broadcast_tx.send(NotebookBroadcast::Output {
                                             cell_id: cid.clone(),
@@ -1361,63 +1293,50 @@ impl RoomKernel {
                             }
 
                             // UpdateDisplayData mutates an existing output in place (e.g., progress bars).
-                            // Find the output by display_id and update it, rather than appending.
-                            // Supports both manifest hashes and raw JSON (backward compatibility).
+                            // Find the output by display_id across all executions in RuntimeStateDoc
+                            // and update it, rather than appending.
                             JupyterMessageContent::UpdateDisplayData(update) => {
                                 if let Some(ref display_id) = update.transient.display_id {
-                                    // Fork before async blob I/O to avoid holding the doc
-                                    // write lock during potentially slow blob store operations.
-                                    let mut fork = {
-                                        let mut doc_guard = doc.write().await;
-                                        let mut f = doc_guard.fork();
-                                        f.set_actor(&iopub_actor_id);
-                                        f
-                                    };
+                                    let new_data =
+                                        serde_json::to_value(&update.data).unwrap_or_default();
+                                    let new_metadata = &update.metadata;
 
-                                    let updated = update_output_by_display_id_with_manifests(
-                                        &mut fork,
+                                    // Scan all execution outputs in RuntimeStateDoc for the display_id
+                                    let result = update_display_in_runtime_state(
+                                        &state_doc_for_iopub,
                                         display_id,
-                                        &serde_json::to_value(&update.data).unwrap_or_default(),
-                                        &update.metadata,
+                                        &new_data,
+                                        new_metadata,
                                         &blob_store,
                                     )
                                     .await;
 
-                                    let persist_bytes = {
-                                        let mut doc_guard = doc.write().await;
-                                        match updated {
-                                            Ok(true) => {
-                                                doc_guard.merge(&mut fork).ok();
-                                                debug!(
-                                                    "[kernel-manager] Updated display_id={}",
-                                                    display_id
-                                                );
-                                            }
-                                            Ok(false) => {
-                                                error!(
-                                                    "[kernel-manager] No output found for display_id={}",
-                                                    display_id
-                                                );
-                                            }
-                                            Err(e) => {
-                                                error!(
-                                                    "[kernel-manager] Failed to update display: {}",
-                                                    e
-                                                );
-                                            }
+                                    match result {
+                                        Ok(true) => {
+                                            let _ = state_changed_for_iopub.send(());
+                                            debug!(
+                                                "[kernel-manager] Updated display_id={}",
+                                                display_id
+                                            );
                                         }
-                                        let bytes = doc_guard.save();
-                                        let _ = changed_tx.send(());
-                                        bytes
-                                    };
-                                    let _ = persist_tx.send(Some(persist_bytes));
+                                        Ok(false) => {
+                                            error!(
+                                                "[kernel-manager] No output found for display_id={}",
+                                                display_id
+                                            );
+                                        }
+                                        Err(e) => {
+                                            error!(
+                                                "[kernel-manager] Failed to update display: {}",
+                                                e
+                                            );
+                                        }
+                                    }
 
                                     // Broadcast for immediate UI update
-                                    // Frontend will receive via Automerge sync, but broadcast for speed
                                     let _ = broadcast_tx.send(NotebookBroadcast::DisplayUpdate {
                                         display_id: display_id.clone(),
-                                        data: serde_json::to_value(&update.data)
-                                            .unwrap_or_default(),
+                                        data: new_data,
                                         metadata: update.metadata.clone(),
                                     });
                                 }
@@ -1501,30 +1420,12 @@ impl RoomKernel {
                                             }
                                         };
 
-                                        // Fork before appending so concurrent edits
-                                        // compose via CRDT merge.
-                                        let mut fork = {
-                                            let mut doc_guard = doc.write().await;
-                                            let mut f = doc_guard.fork();
-                                            f.set_actor(&iopub_actor_id);
-                                            f
-                                        };
-
-                                        if let Err(e) = fork.append_output(cid, &output_ref) {
-                                            warn!(
-                                                "[kernel-manager] Failed to append error output to doc: {}",
-                                                e
-                                            );
+                                        // Write error output to RuntimeStateDoc
+                                        if let Some(ref eid) = execution_id {
+                                            let mut sd = state_doc_for_iopub.write().await;
+                                            sd.append_execution_output(eid, &output_ref);
+                                            let _ = state_changed_for_iopub.send(());
                                         }
-
-                                        let persist_bytes = {
-                                            let mut doc_guard = doc.write().await;
-                                            doc_guard.merge(&mut fork).ok();
-                                            let bytes = doc_guard.save();
-                                            let _ = changed_tx.send(());
-                                            bytes
-                                        };
-                                        let _ = persist_tx.send(Some(persist_bytes));
 
                                         let _ = broadcast_tx.send(NotebookBroadcast::Output {
                                             cell_id: cid.clone(),

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -4598,6 +4598,34 @@ async fn save_notebook_to_disk(
     };
     let nbformat_attachments = room.nbformat_attachments.read().await.clone();
 
+    // Read RuntimeStateDoc to get outputs per execution_id.
+    // Build a cell_id → outputs map from the latest execution per cell.
+    let runtime_outputs: HashMap<String, Vec<String>> = {
+        let sd = room.state_doc.read().await;
+        let state = sd.read_state();
+        let mut cell_outputs: HashMap<String, (Option<i64>, Vec<String>)> = HashMap::new();
+        for entry in state.executions.values() {
+            if entry.outputs.is_empty() {
+                continue;
+            }
+            let existing = cell_outputs.get(&entry.cell_id);
+            let should_replace = match existing {
+                None => true,
+                Some((prev_count, _)) => entry.execution_count > *prev_count,
+            };
+            if should_replace {
+                cell_outputs.insert(
+                    entry.cell_id.clone(),
+                    (entry.execution_count, entry.outputs.clone()),
+                );
+            }
+        }
+        cell_outputs
+            .into_iter()
+            .map(|(cid, (_, outputs))| (cid, outputs))
+            .collect()
+    };
+
     // Reconstruct cells as JSON
     // Cell metadata now comes from the CellSnapshot (populated during load)
     let mut nb_cells = Vec::new();
@@ -4629,9 +4657,13 @@ async fn save_notebook_to_disk(
         });
 
         if cell.cell_type == "code" {
-            // Resolve outputs (may be manifest hashes or raw JSON)
+            // Resolve outputs: prefer RuntimeStateDoc, fall back to notebook doc
+            let output_refs = runtime_outputs
+                .get(&cell.id)
+                .cloned()
+                .unwrap_or_else(|| cell.outputs.clone());
             let mut resolved_outputs = Vec::new();
-            for output_str in &cell.outputs {
+            for output_str in &output_refs {
                 let output_value = resolve_cell_output(output_str, &room.blob_store).await;
                 resolved_outputs.push(output_value);
             }
@@ -5696,6 +5728,23 @@ where
                 doc.set_cell_resolved_assets(&cell.id, resolved_assets)
                     .map_err(|e| format!("Failed to set resolved assets for {}: {}", cell.id, e))?;
             }
+            // Also write outputs to RuntimeStateDoc for loaded cells
+            {
+                let mut sd = room.state_doc.write().await;
+                for (_idx, cell, output_refs, _resolved_assets) in &batch {
+                    if !output_refs.is_empty() {
+                        let synthetic_eid = format!("loaded:{}", cell.id);
+                        sd.create_execution(&synthetic_eid, &cell.id);
+                        sd.set_execution_done(&synthetic_eid, true);
+                        if let Ok(count) = cell.execution_count.parse::<i64>() {
+                            sd.set_execution_count(&synthetic_eid, count);
+                        }
+                        for output_ref in output_refs {
+                            sd.append_execution_output(&synthetic_eid, output_ref);
+                        }
+                    }
+                }
+            }
             match catch_automerge_panic("streaming-load-cells", || {
                 doc.generate_sync_message(peer_state).map(|m| m.encode())
             }) {
@@ -5779,6 +5828,7 @@ pub async fn load_notebook_from_disk(
     doc: &mut NotebookDoc,
     path: &std::path::Path,
     blob_store: &BlobStore,
+    mut state_doc: Option<&mut RuntimeStateDoc>,
 ) -> Result<usize, String> {
     // Read the file
     let content = tokio::fs::read_to_string(path)
@@ -5802,6 +5852,20 @@ pub async fn load_notebook_from_disk(
             .map_err(|e| format!("Failed to update source: {}", e))?;
         if !cell.outputs.is_empty() {
             let output_refs = outputs_to_manifest_refs(&cell.outputs, blob_store).await;
+            // Write outputs to RuntimeStateDoc (primary) with a synthetic execution_id
+            if let Some(ref mut sd) = state_doc {
+                let synthetic_eid = format!("loaded:{}", cell.id);
+                sd.create_execution(&synthetic_eid, &cell.id);
+                sd.set_execution_done(&synthetic_eid, true);
+                for output_ref in &output_refs {
+                    sd.append_execution_output(&synthetic_eid, output_ref);
+                }
+                // Parse execution_count if available
+                if let Ok(count) = cell.execution_count.parse::<i64>() {
+                    sd.set_execution_count(&synthetic_eid, count);
+                }
+            }
+            // Also write to notebook doc for backward compatibility during transition
             doc.set_outputs(&cell.id, &output_refs)
                 .map_err(|e| format!("Failed to set outputs: {}", e))?;
         }
@@ -7622,7 +7686,7 @@ mod tests {
         let notebook_id = ipynb_path.to_string_lossy().to_string();
         let mut doc = crate::notebook_doc::NotebookDoc::new(&notebook_id);
 
-        let count = load_notebook_from_disk(&mut doc, &ipynb_path, &blob_store)
+        let count = load_notebook_from_disk(&mut doc, &ipynb_path, &blob_store, None)
             .await
             .unwrap();
         assert_eq!(count, 3);
@@ -7725,7 +7789,7 @@ mod tests {
         let notebook_id = ipynb_path.to_string_lossy().to_string();
         let mut doc = crate::notebook_doc::NotebookDoc::new(&notebook_id);
 
-        let count = load_notebook_from_disk(&mut doc, &ipynb_path, &blob_store)
+        let count = load_notebook_from_disk(&mut doc, &ipynb_path, &blob_store, None)
             .await
             .unwrap();
         assert_eq!(count, 1);
@@ -7774,7 +7838,7 @@ mod tests {
         let notebook_id = ipynb_path.to_string_lossy().to_string();
         let mut doc = crate::notebook_doc::NotebookDoc::new(&notebook_id);
 
-        let count = load_notebook_from_disk(&mut doc, &ipynb_path, &blob_store)
+        let count = load_notebook_from_disk(&mut doc, &ipynb_path, &blob_store, None)
             .await
             .unwrap();
         assert_eq!(count, 1);

--- a/packages/runtimed/src/runtime-state.ts
+++ b/packages/runtimed/src/runtime-state.ts
@@ -43,6 +43,7 @@ export interface ExecutionState {
   status: "queued" | "running" | "done" | "error";
   execution_count: number | null;
   success: boolean | null;
+  outputs: string[];
 }
 
 /** A detected status transition for a single execution. */

--- a/packages/runtimed/src/sync-engine.ts
+++ b/packages/runtimed/src/sync-engine.ts
@@ -99,6 +99,7 @@ export class SyncEngine {
   private subscription: Subscription | null = null;
   private awaitingInitialSync = true;
   private prevExecutions: Record<string, ExecutionState> = {};
+  private prevOutputSnapshots: Map<string, string[]> = new Map();
 
   // Internal subjects
   private readonly frameIn$ = new Subject<number[]>();
@@ -454,6 +455,25 @@ export class SyncEngine {
             if (transitions.length > 0) {
               this._executionTransitions$.next(transitions);
             }
+            // Also diff outputs for the error recovery path
+            const outputChangedCells = this.diffExecutionOutputs(
+              state.executions,
+            );
+            if (outputChangedCells.size > 0) {
+              for (const cellId of outputChangedCells) {
+                materialize$.next({
+                  changed: [
+                    {
+                      cell_id: cellId,
+                      fields: { outputs: true },
+                    },
+                  ],
+                  added: [],
+                  removed: [],
+                  order_changed: false,
+                });
+              }
+            }
           }
         }),
     );
@@ -482,35 +502,49 @@ export class SyncEngine {
               this._runtimeState$.next(state);
               if (transitions.length > 0) {
                 this._executionTransitions$.next(transitions);
+              }
 
-                // Inject synthetic changesets on execution lifecycle transitions
-                // so the materialization pipeline stays in sync with the CRDT.
-                //
-                // "started": the daemon cleared outputs in the CRDT on
-                //   execute_input — re-read from WASM to show empty outputs.
-                // "done"/"error": reconcile the store with the CRDT's final
-                //   state in case earlier materializations were missed.
-                for (const t of transitions) {
-                  if (t.kind === "started") {
-                    log.debug(
-                      `[sync-engine] execution started for ${t.cell_id.slice(0, 8)} — clearing outputs`,
-                    );
-                  } else {
-                    log.debug(
-                      `[sync-engine] execution ${t.kind} for ${t.cell_id.slice(0, 8)} — reconciling outputs`,
-                    );
-                  }
+              // Diff execution outputs to detect incremental output changes.
+              // This covers both lifecycle transitions (started clears outputs,
+              // done/error reconciles) and mid-execution output arrival.
+              const outputChangedCells = this.diffExecutionOutputs(
+                state.executions,
+              );
+              if (outputChangedCells.size > 0) {
+                for (const cellId of outputChangedCells) {
+                  log.debug(
+                    `[sync-engine] outputs changed for ${cellId.slice(0, 8)}`,
+                  );
                   materialize$.next({
                     changed: [
                       {
-                        cell_id: t.cell_id,
-                        fields: { outputs: true, execution_count: true },
+                        cell_id: cellId,
+                        fields: { outputs: true },
                       },
                     ],
                     added: [],
                     removed: [],
                     order_changed: false,
                   });
+                }
+              }
+
+              // Also inject execution_count changes on lifecycle transitions
+              if (transitions.length > 0) {
+                for (const t of transitions) {
+                  if (t.kind === "started" && !outputChangedCells.has(t.cell_id)) {
+                    materialize$.next({
+                      changed: [
+                        {
+                          cell_id: t.cell_id,
+                          fields: { execution_count: true },
+                        },
+                      ],
+                      added: [],
+                      removed: [],
+                      order_changed: false,
+                    });
+                  }
                 }
               }
             }
@@ -802,5 +836,48 @@ export class SyncEngine {
     this.opts.logger.info("[sync-engine] Resetting for bootstrap");
     this.awaitingInitialSync = true;
     this.prevExecutions = {};
+    this.prevOutputSnapshots = new Map();
+  }
+
+  // ── Output change detection ──────────────────────────────────────
+
+  /**
+   * Diff execution outputs between previous and current state.
+   *
+   * Returns the set of cell_ids whose outputs changed. Compares
+   * the outputs array (manifest hashes) for each execution_id.
+   */
+  private diffExecutionOutputs(
+    executions: Record<string, ExecutionState>,
+  ): Set<string> {
+    const changedCells = new Set<string>();
+
+    for (const [eid, entry] of Object.entries(executions)) {
+      const prev = this.prevOutputSnapshots.get(eid);
+      const curr = entry.outputs;
+
+      if (!prev) {
+        // New execution — only report if it has outputs
+        if (curr.length > 0) {
+          changedCells.add(entry.cell_id);
+        }
+      } else if (
+        prev.length !== curr.length ||
+        prev.some((h, i) => h !== curr[i])
+      ) {
+        changedCells.add(entry.cell_id);
+      }
+
+      this.prevOutputSnapshots.set(eid, curr);
+    }
+
+    // Clean up removed executions
+    for (const eid of this.prevOutputSnapshots.keys()) {
+      if (!(eid in executions)) {
+        this.prevOutputSnapshots.delete(eid);
+      }
+    }
+
+    return changedCells;
   }
 }


### PR DESCRIPTION
## Summary

Clean-room implementation of moving cell outputs from the notebook doc to RuntimeStateDoc (#1343 alternative approach).

- **RuntimeStateDoc schema**: `outputs: List[Str]` on each execution entry
- **Daemon**: IOPub handlers write to RuntimeStateDoc directly (no fork/merge needed)
- **SyncEngine**: diffs output arrays on every RuntimeStateSync frame for incremental detection
- **WASM/DocHandle**: transparent facade reads from RuntimeStateDoc, falls back to notebook doc

### Key differences from #1343
| Aspect | #1343 | This PR |
|--------|-------|---------|
| Output change detection | WASM-side diff (`output_changed_cells`) | TypeScript diff in SyncEngine |
| Serialization | `#[serde(skip_serializing)]` on outputs | No skip — manifest hashes are tiny |
| Detection granularity | Lifecycle transitions only | Every RuntimeStateSync frame |
| Daemon output writes | Fork/merge on RuntimeStateDoc | Synchronous mutations (simpler) |

## Context

This was a clean-room implementation started independently from #1343. Since #1343 has been merged, this PR serves as a showcase of the alternative approach. The improvements here (TypeScript-side diffing, no skip_serializing, incremental detection) could be folded into the merged implementation.

## Test plan
- [x] `cargo test -p notebook-doc -p notebook-sync -p runtimed -p runt-mcp` — 511 tests pass
- [x] `cargo xtask lint` — clean
- [x] WASM rebuilt
- [ ] Manual: execute cell, verify outputs render
- [ ] Manual: rapid re-execution, verify outputs clear/reappear
- [ ] Manual: open .ipynb with outputs, verify they render
- [ ] Manual: save after execution, verify outputs in .ipynb