### PR TITLE
feat(outputs): support plotly's application/vnd.plotly.v1+json MIME type

### DIFF
--- a/apps/notebook/package.json
+++ b/apps/notebook/package.json
@@ -9,7 +9,6 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "runtimed": "workspace:*",
     "@codemirror/autocomplete": "^6.20.0",
     "@codemirror/commands": "^6.10.2",
     "@codemirror/lang-html": "^6.4.11",
@@ -48,6 +47,7 @@
     "rehype-raw": "^7.0.0",
     "remark-gfm": "^4.0.1",
     "remark-math": "^6.0.0",
+    "runtimed": "workspace:*",
     "rxjs": "^7.8.2",
     "tailwind-merge": "^3.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "katex": "^0.16.28",
     "lezer-toml": "^1.0.0",
     "lucide-react": "^0.513.0",
+    "plotly.js-dist-min": "^3.4.0",
     "radix-ui": "^1.4.3",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,6 +143,9 @@ importers:
       lucide-react:
         specifier: ^0.513.0
         version: 0.513.0(react@19.2.4)
+      plotly.js-dist-min:
+        specifier: ^3.4.0
+        version: 3.4.0
       radix-ui:
         specifier: ^1.4.3
         version: 1.4.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -4061,6 +4064,9 @@ packages:
   pkce-challenge@5.0.1:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
+
+  plotly.js-dist-min@3.4.0:
+    resolution: {integrity: sha512-eo7xh7oyE9fFoE/wintgmvfOjvTKwCb3wRf9ShQv90du4n+EVkOY7w5qEkmUS9SSkHRnAw8sk/0QI7wEc5U+8Q==}
 
   postcss@8.5.8:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
@@ -9168,6 +9174,8 @@ snapshots:
   picomatch@4.0.3: {}
 
   pkce-challenge@5.0.1: {}
+
+  plotly.js-dist-min@3.4.0: {}
 
   postcss@8.5.8:
     dependencies:

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -7,6 +7,10 @@ import {
   type IsolatedFrameHandle,
 } from "@/components/isolated";
 import {
+  getRequiredLibraries,
+  injectLibraries,
+} from "@/components/isolated/iframe-libraries";
+import {
   AnsiErrorOutput,
   AnsiStreamOutput,
 } from "@/components/outputs/ansi-output";
@@ -294,6 +298,7 @@ export function OutputArea({
   const frameRef = useRef<IsolatedFrameHandle>(null);
   const bridgeRef = useRef<CommBridgeManager | null>(null);
   const inDomOutputRef = useRef<HTMLDivElement>(null);
+  const injectedLibsRef = useRef(new Set<string>());
   const searchQueryRef = useRef(searchQuery);
   searchQueryRef.current = searchQuery;
 
@@ -343,7 +348,7 @@ export function OutputArea({
   );
 
   // Callback when frame is ready - set up bridge and render outputs
-  const handleFrameReady = useCallback(() => {
+  const handleFrameReady = useCallback(async () => {
     if (!frameRef.current) return;
 
     // Set up comm bridge if we have widgets and widget context
@@ -360,6 +365,22 @@ export function OutputArea({
     // Ensure theme is in sync before re-rendering (fixes theme drift after cell moves)
     // Use ref to avoid adding darkMode to deps which would cause re-renders on theme toggle
     frameRef.current.setTheme(darkModeRef.current);
+
+    // Inject any heavy libraries required by the outputs (e.g. plotly.js).
+    // Must happen before clear+render so the eval messages arrive first.
+    // The idempotent guard inside the iframe prevents double-loading even if
+    // injectedLibsRef is stale (e.g. after iframe recreation).
+    const neededLibs = getRequiredLibraries(
+      outputs,
+      (data) => selectMimeType(data, priority),
+    );
+    if (neededLibs.length > 0) {
+      await injectLibraries(
+        frameRef.current,
+        neededLibs,
+        injectedLibsRef.current,
+      );
+    }
 
     // Clear existing content
     frameRef.current.clear();

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -299,6 +299,7 @@ export function OutputArea({
   const bridgeRef = useRef<CommBridgeManager | null>(null);
   const inDomOutputRef = useRef<HTMLDivElement>(null);
   const injectedLibsRef = useRef(new Set<string>());
+  const renderGenRef = useRef(0);
   const searchQueryRef = useRef(searchQuery);
   searchQueryRef.current = searchQuery;
 
@@ -351,6 +352,10 @@ export function OutputArea({
   const handleFrameReady = useCallback(async () => {
     if (!frameRef.current) return;
 
+    // Bump generation so any in-flight async handleFrameReady from a
+    // previous outputs snapshot will bail out after it awaits.
+    const gen = ++renderGenRef.current;
+
     // Set up comm bridge if we have widgets and widget context
     if (shouldUseBridge && widgetContext && !bridgeRef.current) {
       bridgeRef.current = new CommBridgeManager({
@@ -368,8 +373,9 @@ export function OutputArea({
 
     // Inject any heavy libraries required by the outputs (e.g. plotly.js).
     // Must happen before clear+render so the eval messages arrive first.
-    // The idempotent guard inside the iframe prevents double-loading even if
-    // injectedLibsRef is stale (e.g. after iframe recreation).
+    // Clear the tracking set on each call — a new or reloaded iframe won't
+    // have the previously-injected globals, so we must re-inject.
+    injectedLibsRef.current.clear();
     const neededLibs = getRequiredLibraries(
       outputs,
       (data) => selectMimeType(data, priority),
@@ -380,6 +386,9 @@ export function OutputArea({
         neededLibs,
         injectedLibsRef.current,
       );
+      // Stale check: if outputs changed while we were loading the library,
+      // bail — a newer handleFrameReady call is already in flight.
+      if (gen !== renderGenRef.current) return;
     }
 
     // Clear existing content

--- a/src/components/isolated/frame-html.ts
+++ b/src/components/isolated/frame-html.ts
@@ -568,6 +568,9 @@ export function generateFrameHtml(options: FrameHtmlOptions = {}): string {
       document.addEventListener('click', function(e) {
         const link = e.target.closest('a');
         if (link && link.href) {
+          // Allow download links (e.g. plotly "Download as PNG") to proceed
+          // natively — the iframe sandbox has allow-downloads enabled.
+          if (link.hasAttribute('download')) return;
           e.preventDefault();
           sendRpc('nteract/linkClick', {
             url: link.href,

--- a/src/components/isolated/frame-html.ts
+++ b/src/components/isolated/frame-html.ts
@@ -568,9 +568,6 @@ export function generateFrameHtml(options: FrameHtmlOptions = {}): string {
       document.addEventListener('click', function(e) {
         const link = e.target.closest('a');
         if (link && link.href) {
-          // Allow download links (e.g. plotly "Download as PNG") to proceed
-          // natively — the iframe sandbox has allow-downloads enabled.
-          if (link.hasAttribute('download')) return;
           e.preventDefault();
           sendRpc('nteract/linkClick', {
             url: link.href,

--- a/src/components/isolated/iframe-libraries.ts
+++ b/src/components/isolated/iframe-libraries.ts
@@ -1,0 +1,94 @@
+/**
+ * On-demand library loading for isolated iframes.
+ *
+ * Heavy libraries (plotly.js, etc.) are NOT bundled into the isolated renderer
+ * IIFE. Instead, they are lazy-loaded as raw strings from the parent app and
+ * injected into iframes via `eval` only when an output actually needs them.
+ *
+ * The eval message is processed synchronously by the iframe's bootstrap before
+ * any subsequent render messages, so the library global (e.g. `window.Plotly`)
+ * is guaranteed to be available when the output component mounts.
+ */
+
+import type { JupyterOutput } from "@/components/cell/OutputArea";
+import type { IsolatedFrameHandle } from "@/components/isolated/isolated-frame";
+
+/**
+ * Map of MIME types to the library name they require.
+ * Extend this when adding support for new heavy visualization libraries.
+ */
+const MIME_LIBRARIES: Record<string, string> = {
+  "application/vnd.plotly.v1+json": "plotly",
+};
+
+/** Cache of library code promises (shared across all iframes). */
+const codeCache = new Map<string, Promise<string>>();
+
+/**
+ * Lazy-load a library's source code as a raw string.
+ * The returned string is a self-contained script that sets a global
+ * (e.g. `window.Plotly`) when eval'd.
+ */
+function loadLibraryCode(name: string): Promise<string> {
+  const cached = codeCache.get(name);
+  if (cached) return cached;
+
+  const promise = (async (): Promise<string> => {
+    switch (name) {
+      case "plotly": {
+        const mod = await import("plotly.js-dist-min/plotly.min.js?raw");
+        return mod.default;
+      }
+      default:
+        throw new Error(`Unknown iframe library: ${name}`);
+    }
+  })();
+
+  codeCache.set(name, promise);
+  return promise;
+}
+
+/**
+ * Scan outputs for MIME types that require a heavy library.
+ * Returns deduplicated library names.
+ */
+export function getRequiredLibraries(
+  outputs: JupyterOutput[],
+  selectMimeType: (data: Record<string, unknown>) => string | null,
+): string[] {
+  const libs = new Set<string>();
+  for (const output of outputs) {
+    if (
+      output.output_type === "execute_result" ||
+      output.output_type === "display_data"
+    ) {
+      const mime = selectMimeType(output.data);
+      if (mime) {
+        const lib = MIME_LIBRARIES[mime];
+        if (lib) libs.add(lib);
+      }
+    }
+  }
+  return Array.from(libs);
+}
+
+/**
+ * Inject required libraries into an iframe via eval.
+ * Idempotent per iframe — tracks what has been injected via `injectedSet`.
+ */
+export async function injectLibraries(
+  frame: IsolatedFrameHandle,
+  libraryNames: Iterable<string>,
+  injectedSet: Set<string>,
+): Promise<void> {
+  for (const name of libraryNames) {
+    if (injectedSet.has(name)) continue;
+    const code = await loadLibraryCode(name);
+    // Idempotent guard inside the iframe (belt + suspenders with injectedSet)
+    const guard = `__LIB_${name.toUpperCase()}__`;
+    frame.eval(
+      `if(!window.${guard}){window.${guard}=true;\n${code}\n}`,
+    );
+    injectedSet.add(name);
+  }
+}

--- a/src/components/outputs/__tests__/plotly-output.test.tsx
+++ b/src/components/outputs/__tests__/plotly-output.test.tsx
@@ -80,8 +80,9 @@ describe("PlotlyOutput", () => {
     render(<PlotlyOutput data={sampleData} />);
 
     const [, , layout] = mockPlotly.newPlot.mock.calls[0];
-    expect(layout.template).toBe("plotly_dark");
-    expect(layout.plot_bgcolor).toBe("rgba(30,30,30,1)");
+    expect(layout.plot_bgcolor).toBe("rgba(30, 30, 30, 1)");
+    expect(layout.font.color).toBe("rgba(200, 200, 200, 1)");
+    expect(layout.paper_bgcolor).toBe("transparent");
 
     document.documentElement.classList.remove("dark");
   });
@@ -91,8 +92,8 @@ describe("PlotlyOutput", () => {
     render(<PlotlyOutput data={sampleData} />);
 
     const [, , layout] = mockPlotly.newPlot.mock.calls[0];
-    expect(layout.template).toBeUndefined();
-    expect(layout.plot_bgcolor).toBe("rgba(255,255,255,1)");
+    expect(layout.plot_bgcolor).toBe("rgba(255, 255, 255, 1)");
+    expect(layout.font.color).toBe("rgba(68, 68, 68, 1)");
   });
 
   it("merges user config with defaults", () => {

--- a/src/components/outputs/__tests__/plotly-output.test.tsx
+++ b/src/components/outputs/__tests__/plotly-output.test.tsx
@@ -37,17 +37,17 @@ describe("PlotlyOutput", () => {
     layout: { title: "Test" },
   };
 
-  it("calls Plotly.newPlot with data, layout, and config", () => {
+  it("calls Plotly.newPlot with figure object including data, layout, and config", () => {
     render(<PlotlyOutput data={sampleData} />);
 
     expect(mockPlotly.newPlot).toHaveBeenCalledTimes(1);
-    const [el, data, layout, config] = mockPlotly.newPlot.mock.calls[0];
+    const [el, figure] = mockPlotly.newPlot.mock.calls[0];
     expect(el).toBeInstanceOf(HTMLDivElement);
-    expect(data).toEqual(sampleData.data);
-    expect(layout.title).toBe("Test");
-    expect(layout.autosize).toBe(true);
-    expect(config.responsive).toBe(true);
-    expect(config.displaylogo).toBe(false);
+    expect(figure.data).toEqual(sampleData.data);
+    expect(figure.layout.title).toBe("Test");
+    expect(figure.layout.autosize).toBe(true);
+    expect(figure.config.responsive).toBe(true);
+    expect(figure.config.displaylogo).toBe(false);
   });
 
   it("renders nothing when data is empty", () => {
@@ -79,10 +79,10 @@ describe("PlotlyOutput", () => {
     document.documentElement.classList.add("dark");
     render(<PlotlyOutput data={sampleData} />);
 
-    const [, , layout] = mockPlotly.newPlot.mock.calls[0];
-    expect(layout.plot_bgcolor).toBe("rgba(30, 30, 30, 1)");
-    expect(layout.font.color).toBe("rgba(200, 200, 200, 1)");
-    expect(layout.paper_bgcolor).toBe("transparent");
+    const [, figure] = mockPlotly.newPlot.mock.calls[0];
+    expect(figure.layout.plot_bgcolor).toBe("rgba(30, 30, 30, 1)");
+    expect(figure.layout.font.color).toBe("rgba(200, 200, 200, 1)");
+    expect(figure.layout.paper_bgcolor).toBe("transparent");
 
     document.documentElement.classList.remove("dark");
   });
@@ -91,9 +91,9 @@ describe("PlotlyOutput", () => {
     document.documentElement.classList.remove("dark");
     render(<PlotlyOutput data={sampleData} />);
 
-    const [, , layout] = mockPlotly.newPlot.mock.calls[0];
-    expect(layout.plot_bgcolor).toBe("rgba(255, 255, 255, 1)");
-    expect(layout.font.color).toBe("rgba(68, 68, 68, 1)");
+    const [, figure] = mockPlotly.newPlot.mock.calls[0];
+    expect(figure.layout.plot_bgcolor).toBe("rgba(255, 255, 255, 1)");
+    expect(figure.layout.font.color).toBe("rgba(68, 68, 68, 1)");
   });
 
   it("merges user config with defaults", () => {
@@ -103,11 +103,22 @@ describe("PlotlyOutput", () => {
     };
     render(<PlotlyOutput data={dataWithConfig} />);
 
-    const [, , , config] = mockPlotly.newPlot.mock.calls[0];
+    const [, figure] = mockPlotly.newPlot.mock.calls[0];
     // User config overrides defaults
-    expect(config.scrollZoom).toBe(true);
-    expect(config.displaylogo).toBe(true);
+    expect(figure.config.scrollZoom).toBe(true);
+    expect(figure.config.displaylogo).toBe(true);
     // Default is preserved
-    expect(config.responsive).toBe(true);
+    expect(figure.config.responsive).toBe(true);
+  });
+
+  it("passes animation frames to Plotly.newPlot", () => {
+    const animatedData = {
+      ...sampleData,
+      frames: [{ data: [{ y: [7, 8, 9] }], name: "frame1" }],
+    };
+    render(<PlotlyOutput data={animatedData} />);
+
+    const [, figure] = mockPlotly.newPlot.mock.calls[0];
+    expect(figure.frames).toEqual(animatedData.frames);
   });
 });

--- a/src/components/outputs/__tests__/plotly-output.test.tsx
+++ b/src/components/outputs/__tests__/plotly-output.test.tsx
@@ -1,0 +1,112 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PlotlyOutput } from "../plotly-output";
+
+// Polyfill ResizeObserver for jsdom
+if (typeof globalThis.ResizeObserver === "undefined") {
+  globalThis.ResizeObserver = class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof globalThis.ResizeObserver;
+}
+
+// Mock window.Plotly (injected by the iframe library loader in production)
+const mockPlotly = {
+  newPlot: vi.fn(),
+  relayout: vi.fn(),
+  purge: vi.fn(),
+  Plots: { resize: vi.fn() },
+};
+
+beforeEach(() => {
+  // biome-ignore lint/suspicious/noExplicitAny: test mock
+  (window as any).Plotly = mockPlotly;
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  // biome-ignore lint/suspicious/noExplicitAny: test cleanup
+  delete (window as any).Plotly;
+});
+
+describe("PlotlyOutput", () => {
+  const sampleData = {
+    data: [{ type: "scatter", x: [1, 2, 3], y: [4, 5, 6] }],
+    layout: { title: "Test" },
+  };
+
+  it("calls Plotly.newPlot with data, layout, and config", () => {
+    render(<PlotlyOutput data={sampleData} />);
+
+    expect(mockPlotly.newPlot).toHaveBeenCalledTimes(1);
+    const [el, data, layout, config] = mockPlotly.newPlot.mock.calls[0];
+    expect(el).toBeInstanceOf(HTMLDivElement);
+    expect(data).toEqual(sampleData.data);
+    expect(layout.title).toBe("Test");
+    expect(layout.autosize).toBe(true);
+    expect(config.responsive).toBe(true);
+    expect(config.displaylogo).toBe(false);
+  });
+
+  it("renders nothing when data is empty", () => {
+    const { container } = render(
+      <PlotlyOutput data={{ data: [] }} />,
+    );
+    // Component renders the container div but Plotly.newPlot is not called
+    // because useEffect sees data.data is empty array (truthy), but newPlot
+    // should still be called for an empty array — plotly handles it.
+    // The key contract: returns null when data prop itself is null/undefined.
+    expect(container.firstChild).toBeTruthy();
+  });
+
+  it("returns null when data prop has no data array", () => {
+    const { container } = render(
+      // biome-ignore lint/suspicious/noExplicitAny: testing edge case
+      <PlotlyOutput data={null as any} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("calls Plotly.purge on unmount", () => {
+    const { unmount } = render(<PlotlyOutput data={sampleData} />);
+    unmount();
+    expect(mockPlotly.purge).toHaveBeenCalledTimes(1);
+  });
+
+  it("applies dark theme when document has dark class", () => {
+    document.documentElement.classList.add("dark");
+    render(<PlotlyOutput data={sampleData} />);
+
+    const [, , layout] = mockPlotly.newPlot.mock.calls[0];
+    expect(layout.template).toBe("plotly_dark");
+    expect(layout.plot_bgcolor).toBe("rgba(30,30,30,1)");
+
+    document.documentElement.classList.remove("dark");
+  });
+
+  it("uses light theme by default", () => {
+    document.documentElement.classList.remove("dark");
+    render(<PlotlyOutput data={sampleData} />);
+
+    const [, , layout] = mockPlotly.newPlot.mock.calls[0];
+    expect(layout.template).toBeUndefined();
+    expect(layout.plot_bgcolor).toBe("rgba(255,255,255,1)");
+  });
+
+  it("merges user config with defaults", () => {
+    const dataWithConfig = {
+      ...sampleData,
+      config: { scrollZoom: true, displaylogo: true },
+    };
+    render(<PlotlyOutput data={dataWithConfig} />);
+
+    const [, , , config] = mockPlotly.newPlot.mock.calls[0];
+    // User config overrides defaults
+    expect(config.scrollZoom).toBe(true);
+    expect(config.displaylogo).toBe(true);
+    // Default is preserved
+    expect(config.responsive).toBe(true);
+  });
+});

--- a/src/components/outputs/media-router.tsx
+++ b/src/components/outputs/media-router.tsx
@@ -283,7 +283,8 @@ export function MediaRouter({
     const needsIsolation =
       mimeType === "text/markdown" ||
       mimeType === "text/html" ||
-      mimeType === "image/svg+xml";
+      mimeType === "image/svg+xml" ||
+      mimeType === "application/vnd.plotly.v1+json";
 
     if (needsIsolation && !isInIframe()) {
       if (process.env.NODE_ENV === "development") {

--- a/src/components/outputs/plotly-output.tsx
+++ b/src/components/outputs/plotly-output.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useRef } from "react";
+import { cn } from "@/lib/utils";
+
+interface PlotlyData {
+  data: unknown[];
+  layout?: Record<string, unknown>;
+  config?: Record<string, unknown>;
+}
+
+interface PlotlyOutputProps {
+  data: PlotlyData;
+  className?: string;
+}
+
+/**
+ * Render a Plotly chart inside an isolated iframe.
+ *
+ * This component expects `window.Plotly` to be available — it is injected
+ * by the parent app via the iframe library loader before the render message
+ * is sent. It does NOT import plotly.js directly, keeping it out of the
+ * isolated renderer IIFE bundle.
+ */
+export function PlotlyOutput({ data, className }: PlotlyOutputProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    // biome-ignore lint/suspicious/noExplicitAny: plotly.js is injected as a global
+    const Plotly = (window as any).Plotly;
+    if (!containerRef.current || !data?.data || !Plotly) return;
+
+    const el = containerRef.current;
+    const isDark = document.documentElement.classList.contains("dark");
+
+    const layout: Record<string, unknown> = {
+      ...data.layout,
+      template: isDark ? "plotly_dark" : undefined,
+      paper_bgcolor: "transparent",
+      plot_bgcolor: isDark ? "rgba(30,30,30,1)" : "rgba(255,255,255,1)",
+      autosize: true,
+    };
+
+    const config: Record<string, unknown> = {
+      responsive: true,
+      displaylogo: false,
+      ...data.config,
+    };
+
+    Plotly.newPlot(el, data.data, layout, config);
+
+    const resizeObserver = new ResizeObserver(() => {
+      Plotly.Plots.resize(el);
+    });
+    resizeObserver.observe(el);
+
+    const themeObserver = new MutationObserver(() => {
+      const nowDark = document.documentElement.classList.contains("dark");
+      Plotly.relayout(el, {
+        template: nowDark ? "plotly_dark" : undefined,
+        paper_bgcolor: "transparent",
+        plot_bgcolor: nowDark ? "rgba(30,30,30,1)" : "rgba(255,255,255,1)",
+      });
+    });
+    themeObserver.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class"],
+    });
+
+    return () => {
+      resizeObserver.disconnect();
+      themeObserver.disconnect();
+      Plotly.purge(el);
+    };
+  }, [data]);
+
+  if (!data?.data) return null;
+
+  return (
+    <div
+      ref={containerRef}
+      data-slot="plotly-output"
+      className={cn("not-prose py-2 max-w-full", className)}
+      style={{ minHeight: 400 }}
+    />
+  );
+}

--- a/src/components/outputs/plotly-output.tsx
+++ b/src/components/outputs/plotly-output.tsx
@@ -30,6 +30,7 @@ interface PlotlyData {
   data: unknown[];
   layout?: Record<string, unknown>;
   config?: Record<string, unknown>;
+  frames?: unknown[];
 }
 
 interface PlotlyOutputProps {
@@ -69,7 +70,9 @@ export function PlotlyOutput({ data, className }: PlotlyOutputProps) {
       ...data.config,
     };
 
-    Plotly.newPlot(el, data.data, layout, config);
+    // Use the object form of newPlot so that animation frames are included.
+    // The 4-arg form (el, data, layout, config) drops the frames key.
+    Plotly.newPlot(el, { data: data.data, layout, config, frames: data.frames });
 
     const resizeObserver = new ResizeObserver(() => {
       Plotly.Plots.resize(el);

--- a/src/components/outputs/plotly-output.tsx
+++ b/src/components/outputs/plotly-output.tsx
@@ -65,6 +65,7 @@ export function PlotlyOutput({ data, className }: PlotlyOutputProps) {
     const config: Record<string, unknown> = {
       responsive: true,
       displaylogo: false,
+      modeBarButtonsToRemove: ["toImage"],
       ...data.config,
     };
 

--- a/src/components/outputs/plotly-output.tsx
+++ b/src/components/outputs/plotly-output.tsx
@@ -1,6 +1,31 @@
 import { useEffect, useRef } from "react";
 import { cn } from "@/lib/utils";
 
+const DARK_TEXT = "rgba(200, 200, 200, 1)";
+const LIGHT_TEXT = "rgba(68, 68, 68, 1)";
+
+function darkLayoutOverrides(isDark: boolean): Record<string, unknown> {
+  const textColor = isDark ? DARK_TEXT : LIGHT_TEXT;
+  const gridColor = isDark
+    ? "rgba(255, 255, 255, 0.1)"
+    : "rgba(0, 0, 0, 0.1)";
+
+  return {
+    paper_bgcolor: "transparent",
+    plot_bgcolor: isDark ? "rgba(30, 30, 30, 1)" : "rgba(255, 255, 255, 1)",
+    font: { color: textColor },
+    xaxis: { gridcolor: gridColor, zerolinecolor: gridColor, color: textColor },
+    yaxis: { gridcolor: gridColor, zerolinecolor: gridColor, color: textColor },
+    legend: { font: { color: textColor } },
+    colorway: isDark
+      ? [
+          "#636efa", "#ef553b", "#00cc96", "#ab63fa", "#ffa15a",
+          "#19d3f3", "#ff6692", "#b6e880", "#ff97ff", "#fecb52",
+        ]
+      : undefined,
+  };
+}
+
 interface PlotlyData {
   data: unknown[];
   layout?: Record<string, unknown>;
@@ -33,9 +58,7 @@ export function PlotlyOutput({ data, className }: PlotlyOutputProps) {
 
     const layout: Record<string, unknown> = {
       ...data.layout,
-      template: isDark ? "plotly_dark" : undefined,
-      paper_bgcolor: "transparent",
-      plot_bgcolor: isDark ? "rgba(30,30,30,1)" : "rgba(255,255,255,1)",
+      ...darkLayoutOverrides(isDark),
       autosize: true,
     };
 
@@ -54,11 +77,7 @@ export function PlotlyOutput({ data, className }: PlotlyOutputProps) {
 
     const themeObserver = new MutationObserver(() => {
       const nowDark = document.documentElement.classList.contains("dark");
-      Plotly.relayout(el, {
-        template: nowDark ? "plotly_dark" : undefined,
-        paper_bgcolor: "transparent",
-        plot_bgcolor: nowDark ? "rgba(30,30,30,1)" : "rgba(255,255,255,1)",
-      });
+      Plotly.relayout(el, darkLayoutOverrides(nowDark));
     });
     themeObserver.observe(document.documentElement, {
       attributes: true,

--- a/src/isolated-renderer/index.tsx
+++ b/src/isolated-renderer/index.tsx
@@ -36,6 +36,7 @@ import { HtmlOutput } from "@/components/outputs/html-output";
 import { ImageOutput } from "@/components/outputs/image-output";
 import { JsonOutput } from "@/components/outputs/json-output";
 import { MarkdownOutput } from "@/components/outputs/markdown-output";
+import { PlotlyOutput } from "@/components/outputs/plotly-output";
 import { SvgOutput } from "@/components/outputs/svg-output";
 import { WidgetView } from "@/components/widgets/widget-view";
 // Import widget support
@@ -306,6 +307,13 @@ function OutputRenderer({ payload }: { payload: RenderPayload }) {
         height={metadata?.height as number | undefined}
       />
     );
+  }
+
+  // Plotly
+  if (mimeType === "application/vnd.plotly.v1+json") {
+    const plotlyData =
+      typeof content === "string" ? JSON.parse(content) : content;
+    return <PlotlyOutput data={plotlyData} />;
   }
 
   // JSON


### PR DESCRIPTION
## Summary

Adds a renderer for `application/vnd.plotly.v1+json` so that `fig.show()`, `renderer="plotly_mimetype"`, and `renderer="nteract"` display interactive plotly charts instead of raw JSON.

Uses an **on-demand iframe library loading pattern** — plotly.js (~3.5MB) is lazy-loaded as a raw string and injected via `eval` only into iframes that actually render a plotly output, keeping the base isolated renderer IIFE lean for all other output types. This pattern is extensible to future heavy libraries (vega-embed, katex, etc.).

## Changes

- **`src/components/isolated/iframe-libraries.ts`** (new) — generic lazy loader that maps MIME types to heavy libraries and injects them into iframes on demand via the existing `eval` mechanism
- **`src/components/outputs/plotly-output.tsx`** (new) — PlotlyOutput component using `window.Plotly` (injected global, not a static import), with dark/light theme support and responsive resize
- **`src/components/cell/OutputArea.tsx`** — calls `injectLibraries()` before rendering isolated outputs
- **`src/isolated-renderer/index.tsx`** — routes `application/vnd.plotly.v1+json` to PlotlyOutput
- **`src/components/outputs/media-router.tsx`** — adds plotly to the isolation guard
- **`package.json`** — adds `plotly.js-dist-min` dependency

## Verification

- [ ] `fig.show()` renders an interactive plotly chart (not raw JSON)
- [ ] `renderer="plotly_mimetype"` and `renderer="nteract"` both work
- [ ] Chart responds to dark/light theme toggle
- [ ] Chart resizes when window is resized
- [ ] Plain text / image outputs do NOT load plotly.js (check iframe sources in devtools)

<!-- Screenshot placeholder: plotly chart rendering in nteract -->

Closes #1255

_PR submitted by @rgbkrk's agent, Quill_