### PR TITLE
feat(sync): dual-write comm state to RuntimeStateDoc (#761 Phase A)

### DIFF
--- a/crates/notebook-doc/src/runtime_state.rs
+++ b/crates/notebook-doc/src/runtime_state.rs
@@ -34,6 +34,14 @@
 //!   trust/
 //!     status: Str          ("trusted" | "untrusted" | "signature_invalid" | "no_dependencies")
 //!     needs_approval: bool
+//!   comms/                 Map (keyed by comm_id)
+//!     {comm_id}/           Map
+//!       target_name: Str
+//!       model_module: Str
+//!       model_name: Str
+//!       state: Str         (JSON-encoded widget state)
+//!       outputs: List[Str] (manifest hashes, OutputModel only)
+//!       seq: Int           (insertion order)
 //!   last_saved: Str|null   (ISO timestamp of last save)
 //! ```
 
@@ -145,6 +153,27 @@ pub struct TrustRuntimeState {
     pub needs_approval: bool,
 }
 
+/// Snapshot of a single comm entry in the RuntimeStateDoc.
+///
+/// Mirrors the daemon's `CommSnapshot` but stores state as a JSON string
+/// (Automerge stores strings, not structured JSON).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CommDocEntry {
+    pub target_name: String,
+    #[serde(default)]
+    pub model_module: String,
+    #[serde(default)]
+    pub model_name: String,
+    /// JSON-encoded widget state.
+    pub state: String,
+    /// Output manifest hashes (OutputModel widgets only).
+    #[serde(default)]
+    pub outputs: Vec<String>,
+    /// Insertion order for dependency-correct replay.
+    #[serde(default)]
+    pub seq: u64,
+}
+
 /// Full runtime state snapshot.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RuntimeState {
@@ -156,6 +185,9 @@ pub struct RuntimeState {
     /// Execution lifecycle entries keyed by execution_id.
     #[serde(default)]
     pub executions: HashMap<String, ExecutionState>,
+    /// Active comm channels keyed by comm_id.
+    #[serde(default)]
+    pub comms: HashMap<String, CommDocEntry>,
 }
 
 // ── RuntimeStateDoc ─────────────────────────────────────────────────
@@ -234,6 +266,10 @@ impl RuntimeStateDoc {
             .expect("scaffold trust.status");
         doc.put(&trust, "needs_approval", false)
             .expect("scaffold trust.needs_approval");
+
+        // comms/ — keyed by comm_id, tracks widget state
+        doc.put_object(&ROOT, "comms", ObjType::Map)
+            .expect("scaffold comms");
 
         // last_saved
         doc.put(&ROOT, "last_saved", ScalarValue::Null)
@@ -401,6 +437,23 @@ impl RuntimeStateDoc {
                 _ => None,
             })
             .unwrap_or(false)
+    }
+
+    /// Read an integer scalar from a map object, defaulting to 0.
+    fn read_i64(&self, obj: &automerge::ObjId, key: &str) -> i64 {
+        self.doc
+            .get(obj, key)
+            .ok()
+            .flatten()
+            .and_then(|(value, _)| match value {
+                Value::Scalar(s) => match s.as_ref() {
+                    ScalarValue::Int(n) => Some(*n),
+                    ScalarValue::Uint(n) => Some(*n as i64),
+                    _ => None,
+                },
+                _ => None,
+            })
+            .unwrap_or(0)
     }
 
     /// Read a List[Str] from a map object.
@@ -1161,6 +1214,157 @@ impl RuntimeStateDoc {
         true
     }
 
+    // ── Comm lifecycle ────────────────────────────────────────────────
+
+    /// Insert or replace a full comm entry (used on `comm_open`).
+    #[allow(clippy::expect_used)]
+    pub fn put_comm(
+        &mut self,
+        comm_id: &str,
+        target_name: &str,
+        model_module: &str,
+        model_name: &str,
+        state_json: &str,
+        seq: u64,
+    ) {
+        let comms = self.get_map("comms").expect("comms map must exist");
+        let entry = self
+            .doc
+            .put_object(&comms, comm_id, ObjType::Map)
+            .expect("put comm entry");
+        self.doc
+            .put(&entry, "target_name", target_name)
+            .expect("put comm.target_name");
+        self.doc
+            .put(&entry, "model_module", model_module)
+            .expect("put comm.model_module");
+        self.doc
+            .put(&entry, "model_name", model_name)
+            .expect("put comm.model_name");
+        self.doc
+            .put(&entry, "state", state_json)
+            .expect("put comm.state");
+        self.doc
+            .put(&entry, "seq", seq as i64)
+            .expect("put comm.seq");
+        self.doc
+            .put_object(&entry, "outputs", ObjType::List)
+            .expect("put comm.outputs");
+    }
+
+    /// Overwrite the state JSON string for an existing comm (used on `comm_msg` update).
+    ///
+    /// Returns `false` if the comm doesn't exist.
+    #[allow(clippy::expect_used)]
+    pub fn update_comm_state(&mut self, comm_id: &str, new_state_json: &str) -> bool {
+        let Some(comms) = self.get_map("comms") else {
+            return false;
+        };
+        let Some((_, entry)) = self.doc.get(&comms, comm_id).ok().flatten() else {
+            return false;
+        };
+        self.doc
+            .put(&entry, "state", new_state_json)
+            .expect("put comm.state");
+        true
+    }
+
+    /// Remove a comm entry (used on `comm_close`).
+    ///
+    /// Returns `false` if the comm doesn't exist.
+    #[allow(clippy::expect_used)]
+    pub fn remove_comm(&mut self, comm_id: &str) -> bool {
+        let Some(comms) = self.get_map("comms") else {
+            return false;
+        };
+        if self.doc.get(&comms, comm_id).ok().flatten().is_none() {
+            return false;
+        }
+        self.doc.delete(&comms, comm_id).expect("delete comm");
+        true
+    }
+
+    /// Remove all comm entries (used on kernel shutdown/restart).
+    ///
+    /// Returns `false` if there were no comms to remove.
+    #[allow(clippy::expect_used)]
+    pub fn clear_comms(&mut self) -> bool {
+        let Some(comms) = self.get_map("comms") else {
+            return false;
+        };
+        let keys: Vec<String> = self.doc.keys(&comms).collect();
+        if keys.is_empty() {
+            return false;
+        }
+        for key in keys {
+            self.doc.delete(&comms, &key).expect("delete comm entry");
+        }
+        true
+    }
+
+    /// Read a single comm entry.
+    pub fn get_comm(&self, comm_id: &str) -> Option<CommDocEntry> {
+        let comms = self.get_map("comms")?;
+        let (_, entry) = self.doc.get(&comms, comm_id).ok().flatten()?;
+        Some(CommDocEntry {
+            target_name: self.read_str(&entry, "target_name"),
+            model_module: self.read_str(&entry, "model_module"),
+            model_name: self.read_str(&entry, "model_name"),
+            state: self.read_str(&entry, "state"),
+            outputs: self.read_str_list(&entry, "outputs"),
+            seq: self.read_i64(&entry, "seq") as u64,
+        })
+    }
+
+    /// Append a manifest hash to a comm's outputs list (OutputModel widgets).
+    ///
+    /// Returns `false` if the comm doesn't exist.
+    #[allow(clippy::expect_used)]
+    pub fn append_comm_output(&mut self, comm_id: &str, manifest_hash: &str) -> bool {
+        let Some(comms) = self.get_map("comms") else {
+            return false;
+        };
+        let Some((_, entry)) = self.doc.get(&comms, comm_id).ok().flatten() else {
+            return false;
+        };
+        let Some((Value::Object(ObjType::List), list_id)) =
+            self.doc.get(&entry, "outputs").ok().flatten()
+        else {
+            return false;
+        };
+        let len = self.doc.length(&list_id);
+        self.doc
+            .insert(&list_id, len, manifest_hash)
+            .expect("append comm output");
+        true
+    }
+
+    /// Clear a comm's outputs list (OutputModel widgets).
+    ///
+    /// Returns `false` if the comm doesn't exist or outputs is already empty.
+    #[allow(clippy::expect_used)]
+    pub fn clear_comm_outputs(&mut self, comm_id: &str) -> bool {
+        let Some(comms) = self.get_map("comms") else {
+            return false;
+        };
+        let Some((_, entry)) = self.doc.get(&comms, comm_id).ok().flatten() else {
+            return false;
+        };
+        let Some((Value::Object(ObjType::List), list_id)) =
+            self.doc.get(&entry, "outputs").ok().flatten()
+        else {
+            return false;
+        };
+        let len = self.doc.length(&list_id);
+        if len == 0 {
+            return false;
+        }
+        for i in (0..len).rev() {
+            self.doc.delete(&list_id, i).expect("clear comm output");
+        }
+        true
+    }
+
     // ── Full state read ─────────────────────────────────────────────
 
     /// Read the full runtime state snapshot.
@@ -1257,6 +1461,20 @@ impl RuntimeStateDoc {
             })
             .unwrap_or_default();
 
+        // Read comms map
+        let comms = self
+            .get_map("comms")
+            .map(|comms_obj| {
+                let mut map = HashMap::new();
+                for key in self.doc.keys(&comms_obj) {
+                    if let Some(entry) = self.get_comm(&key) {
+                        map.insert(key, entry);
+                    }
+                }
+                map
+            })
+            .unwrap_or_default();
+
         RuntimeState {
             kernel: kernel_state,
             queue: queue_state,
@@ -1264,6 +1482,7 @@ impl RuntimeStateDoc {
             trust: trust_state,
             last_saved,
             executions,
+            comms,
         }
     }
 
@@ -2053,5 +2272,143 @@ mod tests {
         let doc = RuntimeStateDoc::new();
         // No execution entry → empty outputs
         assert!(doc.get_outputs("nope").is_empty());
+    }
+
+    // ── Comm tests ────────────────────────────────────────────────
+
+    #[test]
+    fn test_put_comm_roundtrip() {
+        let mut doc = RuntimeStateDoc::new();
+        doc.put_comm(
+            "comm-1",
+            "jupyter.widget",
+            "@jupyter-widgets/controls",
+            "IntSliderModel",
+            r#"{"value":42}"#,
+            0,
+        );
+
+        let entry = doc.get_comm("comm-1").unwrap();
+        assert_eq!(entry.target_name, "jupyter.widget");
+        assert_eq!(entry.model_module, "@jupyter-widgets/controls");
+        assert_eq!(entry.model_name, "IntSliderModel");
+        assert_eq!(entry.state, r#"{"value":42}"#);
+        assert!(entry.outputs.is_empty());
+        assert_eq!(entry.seq, 0);
+    }
+
+    #[test]
+    fn test_put_comm_overwrites() {
+        let mut doc = RuntimeStateDoc::new();
+        doc.put_comm("comm-1", "jupyter.widget", "mod-a", "ModelA", "{}", 0);
+        doc.put_comm("comm-1", "jupyter.widget", "mod-b", "ModelB", "{}", 1);
+
+        let entry = doc.get_comm("comm-1").unwrap();
+        assert_eq!(entry.model_module, "mod-b");
+        assert_eq!(entry.model_name, "ModelB");
+        assert_eq!(entry.seq, 1);
+    }
+
+    #[test]
+    fn test_update_comm_state() {
+        let mut doc = RuntimeStateDoc::new();
+        doc.put_comm("comm-1", "jupyter.widget", "", "", r#"{"value":1}"#, 0);
+
+        assert!(doc.update_comm_state("comm-1", r#"{"value":2}"#));
+        assert_eq!(doc.get_comm("comm-1").unwrap().state, r#"{"value":2}"#);
+    }
+
+    #[test]
+    fn test_update_comm_state_nonexistent() {
+        let mut doc = RuntimeStateDoc::new();
+        assert!(!doc.update_comm_state("nope", "{}"));
+    }
+
+    #[test]
+    fn test_remove_comm() {
+        let mut doc = RuntimeStateDoc::new();
+        doc.put_comm("comm-1", "jupyter.widget", "", "", "{}", 0);
+        assert!(doc.remove_comm("comm-1"));
+        assert!(doc.get_comm("comm-1").is_none());
+    }
+
+    #[test]
+    fn test_remove_comm_nonexistent() {
+        let mut doc = RuntimeStateDoc::new();
+        assert!(!doc.remove_comm("nope"));
+    }
+
+    #[test]
+    fn test_clear_comms() {
+        let mut doc = RuntimeStateDoc::new();
+        doc.put_comm("comm-1", "jupyter.widget", "", "", "{}", 0);
+        doc.put_comm("comm-2", "jupyter.widget", "", "", "{}", 1);
+        assert!(doc.clear_comms());
+        assert!(doc.get_comm("comm-1").is_none());
+        assert!(doc.get_comm("comm-2").is_none());
+    }
+
+    #[test]
+    fn test_clear_comms_empty() {
+        let mut doc = RuntimeStateDoc::new();
+        assert!(!doc.clear_comms());
+    }
+
+    #[test]
+    fn test_comms_in_read_state() {
+        let mut doc = RuntimeStateDoc::new();
+        doc.put_comm("comm-1", "jupyter.widget", "mod", "Slider", r#"{"v":1}"#, 0);
+        doc.put_comm("comm-2", "jupyter.widget", "mod", "Button", r#"{"v":2}"#, 1);
+
+        let state = doc.read_state();
+        assert_eq!(state.comms.len(), 2);
+        assert_eq!(state.comms["comm-1"].model_name, "Slider");
+        assert_eq!(state.comms["comm-2"].model_name, "Button");
+    }
+
+    #[test]
+    fn test_fork_and_merge_comms() {
+        let mut doc = RuntimeStateDoc::new();
+        doc.put_comm("comm-1", "jupyter.widget", "", "", "{}", 0);
+
+        let mut fork = doc.fork();
+        fork.set_actor("runtimed:state:comms");
+        fork.put_comm("comm-2", "jupyter.widget", "", "New", "{}", 1);
+
+        doc.merge(&mut fork).unwrap();
+        assert!(doc.get_comm("comm-1").is_some());
+        assert_eq!(doc.get_comm("comm-2").unwrap().model_name, "New");
+    }
+
+    #[test]
+    fn test_comm_output_append_and_clear() {
+        let mut doc = RuntimeStateDoc::new();
+        doc.put_comm("comm-1", "jupyter.widget", "", "OutputModel", "{}", 0);
+
+        assert!(doc.append_comm_output("comm-1", "hash-a"));
+        assert!(doc.append_comm_output("comm-1", "hash-b"));
+        assert_eq!(
+            doc.get_comm("comm-1").unwrap().outputs,
+            vec!["hash-a", "hash-b"]
+        );
+
+        assert!(doc.clear_comm_outputs("comm-1"));
+        assert!(doc.get_comm("comm-1").unwrap().outputs.is_empty());
+
+        // Clearing already-empty returns false
+        assert!(!doc.clear_comm_outputs("comm-1"));
+    }
+
+    #[test]
+    fn test_comm_output_nonexistent() {
+        let mut doc = RuntimeStateDoc::new();
+        assert!(!doc.append_comm_output("nope", "hash"));
+        assert!(!doc.clear_comm_outputs("nope"));
+    }
+
+    #[test]
+    fn test_new_doc_has_empty_comms() {
+        let doc = RuntimeStateDoc::new();
+        assert!(doc.read_state().comms.is_empty());
     }
 }

--- a/crates/runtimed/src/kernel_manager.rs
+++ b/crates/runtimed/src/kernel_manager.rs
@@ -17,6 +17,7 @@ use std::collections::{HashMap, VecDeque};
 use std::net::Ipv4Addr;
 use std::path::PathBuf;
 use std::process::Stdio;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex as StdMutex};
 
 use anyhow::Result;
@@ -320,6 +321,8 @@ pub struct RoomKernel {
     blob_store: Arc<BlobStore>,
     /// Comm state for widget synchronization across windows
     comm_state: Arc<CommState>,
+    /// Monotonic counter for comm insertion order (dual-write to RuntimeStateDoc).
+    comm_seq: Arc<AtomicU64>,
     /// Pending history requests: msg_id → response channel
     pending_history: Arc<StdMutex<HashMap<String, oneshot::Sender<Vec<HistoryEntry>>>>>,
     /// Pending completion requests: msg_id → response channel
@@ -442,6 +445,7 @@ impl RoomKernel {
             changed_tx,
             blob_store,
             comm_state,
+            comm_seq: Arc::new(AtomicU64::new(0)),
             pending_history: Arc::new(StdMutex::new(HashMap::new())),
             pending_completions: Arc::new(StdMutex::new(HashMap::new())),
             stream_terminals: Arc::new(tokio::sync::Mutex::new(StreamTerminals::new())),
@@ -944,6 +948,7 @@ impl RoomKernel {
         let changed_tx = self.changed_tx.clone();
         let blob_store = self.blob_store.clone();
         let comm_state = self.comm_state.clone();
+        let comm_seq = self.comm_seq.clone();
         let stream_terminals = self.stream_terminals.clone();
         let state_doc_for_iopub = self.state_doc.clone();
         let state_changed_for_iopub = self.state_changed_tx.clone();
@@ -1587,6 +1592,33 @@ impl RoomKernel {
                                     )
                                     .await;
 
+                                // Dual-write to RuntimeStateDoc
+                                {
+                                    let empty_obj = serde_json::json!({});
+                                    let state = data.get("state").unwrap_or(&empty_obj);
+                                    let state_json =
+                                        serde_json::to_string(state).unwrap_or_default();
+                                    let model_module = state
+                                        .get("_model_module")
+                                        .and_then(|v| v.as_str())
+                                        .unwrap_or("");
+                                    let model_name = state
+                                        .get("_model_name")
+                                        .and_then(|v| v.as_str())
+                                        .unwrap_or("");
+                                    let seq = comm_seq.fetch_add(1, Ordering::Relaxed);
+                                    let mut sd = state_doc_for_iopub.write().await;
+                                    sd.put_comm(
+                                        &open.comm_id.0,
+                                        &open.target_name,
+                                        model_module,
+                                        model_name,
+                                        &state_json,
+                                        seq,
+                                    );
+                                    let _ = state_changed_for_iopub.send(());
+                                }
+
                                 let _ = broadcast_tx.send(NotebookBroadcast::Comm {
                                     msg_type: message.header.msg_type.clone(),
                                     content,
@@ -1609,8 +1641,26 @@ impl RoomKernel {
 
                                 debug!("[comm_msg] comm_id={} method={:?}", msg.comm_id.0, method);
                                 if method == Some("update") {
-                                    if let Some(state) = data.get("state") {
-                                        comm_state.on_comm_update(&msg.comm_id.0, state).await;
+                                    if let Some(state_delta) = data.get("state") {
+                                        comm_state
+                                            .on_comm_update(&msg.comm_id.0, state_delta)
+                                            .await;
+
+                                        // Dual-write merged state to RuntimeStateDoc.
+                                        // Read merged state back from CommState (it already
+                                        // applied the delta).
+                                        let all_comms = comm_state.get_all().await;
+                                        if let Some(snapshot) =
+                                            all_comms.iter().find(|c| c.comm_id == msg.comm_id.0)
+                                        {
+                                            let merged_json =
+                                                serde_json::to_string(&snapshot.state)
+                                                    .unwrap_or_default();
+                                            let mut sd = state_doc_for_iopub.write().await;
+                                            if sd.update_comm_state(&msg.comm_id.0, &merged_json) {
+                                                let _ = state_changed_for_iopub.send(());
+                                            }
+                                        }
                                     }
                                 }
 
@@ -1633,6 +1683,14 @@ impl RoomKernel {
 
                                 // Remove from comm state
                                 comm_state.on_comm_close(&close.comm_id.0).await;
+
+                                // Dual-write removal to RuntimeStateDoc
+                                {
+                                    let mut sd = state_doc_for_iopub.write().await;
+                                    if sd.remove_comm(&close.comm_id.0) {
+                                        let _ = state_changed_for_iopub.send(());
+                                    }
+                                }
 
                                 let _ = broadcast_tx.send(NotebookBroadcast::Comm {
                                     msg_type: message.header.msg_type.clone(),

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -2524,6 +2524,12 @@ async fn auto_launch_kernel(
 
     // Clear any stale comm state from a previous kernel (in case it crashed)
     room.comm_state.clear().await;
+    {
+        let mut sd = room.state_doc.write().await;
+        if sd.clear_comms() {
+            let _ = room.state_changed_tx.send(());
+        }
+    }
 
     // Create new kernel
     let mut kernel = RoomKernel::new(
@@ -3162,6 +3168,12 @@ async fn handle_notebook_request(
 
             // Clear any stale comm state from a previous kernel (in case it crashed)
             room.comm_state.clear().await;
+            {
+                let mut sd = room.state_doc.write().await;
+                if sd.clear_comms() {
+                    let _ = room.state_changed_tx.send(());
+                }
+            }
 
             // Trust is approved if user explicitly launches kernel — update RuntimeStateDoc
             // Also set "starting" + "resolving" phase immediately
@@ -3846,6 +3858,12 @@ async fn handle_notebook_request(
                         *kernel_guard = None;
                         // Clear comm state - all widgets become invalid when kernel shuts down
                         room.comm_state.clear().await;
+                        {
+                            let mut sd = room.state_doc.write().await;
+                            if sd.clear_comms() {
+                                let _ = room.state_changed_tx.send(());
+                            }
+                        }
                         // Drop the kernel lock before awaiting the presence update
                         drop(kernel_guard);
                         // Publish shutdown presence so late joiners don't see stale kernel state


### PR DESCRIPTION
## Summary

- Add `comms/` map to RuntimeStateDoc with per-comm entries (target_name, model_module, model_name, state JSON, outputs list, seq)
- Dual-write to RuntimeStateDoc on comm_open, comm_msg update, and comm_close in the IOPub handler
- Clear comms from RuntimeStateDoc on kernel shutdown/restart (3 sites)
- 12 new unit tests for comm CRUD, fork+merge, and read_state integration

## Context

Phase A of #761. No behavior changes — CommSync broadcast stays active as the delivery mechanism. The frontend doesn't read comms from RuntimeStateDoc yet (Phase B). This establishes the schema and proves the dual-write path works.

## Test plan

- [x] `cargo xtask lint --fix` passes
- [x] `cargo build` clean across workspace
- [x] 51 runtime_state tests pass (12 new)
- [x] Manual test: create ipywidgets (slider, button, text, output), update slider value, close button — daemon processes all without errors
- [ ] Codex review