### PR TITLE
fix(sync): fix output disappearing on structural changes and WASM diff snapshot

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -5,7 +5,6 @@ import { getCurrentWindow } from "@tauri-apps/api/window";
 import {
   useCallback,
   useEffect,
-  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -320,7 +319,6 @@ function AppContent() {
   }, [sendCommMessage]);
 
   // Split queue state into executing (currently running) and queued (waiting).
-  // Previously these were merged into one Set — now differentiated for UI.
   const executingCellIds = new Set(
     queueState.executing ? [queueState.executing.cell_id] : [],
   );
@@ -330,22 +328,16 @@ function AppContent() {
   // These are module-level setters, not React state — they feed
   // useSyncExternalStore hooks in cell components so renderCell
   // doesn't need these as dependencies.
-  // Wrapped in useLayoutEffect to avoid triggering subscriber re-renders
-  // during this component's render (React forbids cross-component setState
-  // during render).
-  useLayoutEffect(() => {
-    storeSetFocusedCellId(focusedCellId);
-    storeSetExecutingCellIds(executingCellIds);
-    storeSetQueuedCellIds(queuedCellIds);
-    storeSetSearchQuery(globalFind.query);
-    storeSetSearchCurrentMatch(globalFind.currentMatch);
-  }, [
-    focusedCellId,
-    executingCellIds,
-    queuedCellIds,
-    globalFind.query,
-    globalFind.currentMatch,
-  ]);
+  //
+  // Called during render (not in useLayoutEffect) so the store is
+  // current by the time child components render. The setters have
+  // equality guards that skip emit() when values haven't changed,
+  // preventing the cross-component setState cascade that React flags.
+  storeSetFocusedCellId(focusedCellId);
+  storeSetExecutingCellIds(executingCellIds);
+  storeSetQueuedCellIds(queuedCellIds);
+  storeSetSearchQuery(globalFind.query);
+  storeSetSearchCurrentMatch(globalFind.currentMatch);
 
   // When kernel is running and we know the env source, use it to determine panel type.
   // This handles: both-deps (backend picks based on preference), pixi (auto-detected, no metadata).

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -2,13 +2,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { getCurrentWebview } from "@tauri-apps/api/webview";
 import { getCurrentWindow } from "@tauri-apps/api/window";
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { IsolationTest } from "@/components/isolated";
 import { MediaProvider } from "@/components/outputs/media-provider";
 import {

--- a/apps/notebook/src/lib/cell-ui-state.ts
+++ b/apps/notebook/src/lib/cell-ui-state.ts
@@ -32,33 +32,67 @@ function emit(subs: Set<() => void>): void {
   for (const cb of subs) cb();
 }
 
-// ── Setters (called from App.tsx render body) ───────────────────────────
+// Subscriber sets that need deferred notification.
+const _pendingEmits = new Set<Set<() => void>>();
+let _emitScheduled = false;
+
+function deferEmit(subs: Set<() => void>): void {
+  _pendingEmits.add(subs);
+  if (!_emitScheduled) {
+    _emitScheduled = true;
+    queueMicrotask(() => {
+      _emitScheduled = false;
+      const batch = [..._pendingEmits];
+      _pendingEmits.clear();
+      for (const s of batch) emit(s);
+    });
+  }
+}
+
+function setsEqual(a: Set<string>, b: Set<string>): boolean {
+  if (a.size !== b.size) return false;
+  for (const v of a) if (!b.has(v)) return false;
+  return true;
+}
+
+// ── Setters ─────────────────────────────────────────────────────────────
+//
+// Two-phase update pattern for compatibility with React's render rules:
+//
+// 1. Assign the variable immediately — so useSyncExternalStore snapshot
+//    functions return the current value during the same render cycle.
+// 2. Defer subscriber notification via queueMicrotask — so React doesn't
+//    see a cross-component setState during render. Subscribers re-render
+//    on the next microtask, which is still before the browser paints.
 
 export function setFocusedCellId(id: string | null): void {
   if (id === _focusedCellId) return;
   _focusedCellId = id;
-  emit(_focusSubscribers);
+  deferEmit(_focusSubscribers);
 }
 
 export function setExecutingCellIds(ids: Set<string>): void {
+  if (setsEqual(_executingCellIds, ids)) return;
   _executingCellIds = ids;
-  emit(_executingSubscribers);
+  deferEmit(_executingSubscribers);
 }
 
 export function setQueuedCellIds(ids: Set<string>): void {
+  if (setsEqual(_queuedCellIds, ids)) return;
   _queuedCellIds = ids;
-  emit(_queuedSubscribers);
+  deferEmit(_queuedSubscribers);
 }
 
 export function setSearchQuery(query: string | undefined): void {
   if (query === _searchQuery) return;
   _searchQuery = query;
-  emit(_searchQuerySubscribers);
+  deferEmit(_searchQuerySubscribers);
 }
 
 export function setSearchCurrentMatch(match: FindMatch | null): void {
+  if (_searchCurrentMatch === match) return;
   _searchCurrentMatch = match;
-  emit(_searchMatchSubscribers);
+  deferEmit(_searchMatchSubscribers);
 }
 
 // ── Snapshot readers (non-reactive) ─────────────────────────────────────

--- a/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.d.ts
+++ b/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.d.ts
@@ -253,6 +253,10 @@ export class NotebookHandle {
     get_cells(): JsCell[];
     /**
      * Get all cells as a JSON string (for bulk materialization).
+     *
+     * Populates each cell's outputs from the RuntimeStateDoc via
+     * the cell's execution_id, since NotebookDoc.get_cells() returns
+     * empty outputs (outputs moved to RuntimeStateDoc in #1343).
      */
     get_cells_json(): string;
     /**

--- a/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.js
+++ b/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm.js
@@ -843,6 +843,10 @@ export class NotebookHandle {
     }
     /**
      * Get all cells as a JSON string (for bulk materialization).
+     *
+     * Populates each cell's outputs from the RuntimeStateDoc via
+     * the cell's execution_id, since NotebookDoc.get_cells() returns
+     * empty outputs (outputs moved to RuntimeStateDoc in #1343).
      * @returns {string}
      */
     get_cells_json() {

--- a/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm
+++ b/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e3cb6114784abc5300ccebae786514a7530e3f9c0869a6628e03f31381470eef
-size 1639477
+oid sha256:31c1a5257719492aeba63b0677750238f15a561bf7a11a99ef0ec82df0fdc862
+size 1643767

--- a/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm
+++ b/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:31c1a5257719492aeba63b0677750238f15a561bf7a11a99ef0ec82df0fdc862
-size 1643767
+oid sha256:f4973c1516f5c1fbf21d3b53aa8e35454cc472347b870b5ba4c923455cbde315
+size 1644010

--- a/crates/notebook-doc/src/runtime_state.rs
+++ b/crates/notebook-doc/src/runtime_state.rs
@@ -1517,6 +1517,43 @@ impl RuntimeStateDoc {
     }
 }
 
+// ── Output diff utility ─────────────────────────────────────────────
+
+/// Diff execution outputs between a previous snapshot and the current state.
+///
+/// Returns `(changed_cell_ids, new_snapshot)` where:
+/// - `changed_cell_ids` lists cells whose outputs changed
+/// - `new_snapshot` is the updated prev_execution_outputs for the next diff
+///
+/// Used by the WASM handle to detect mid-execution output changes
+/// (stream append, display update, error) without re-materializing
+/// all cells.
+pub fn diff_execution_outputs(
+    prev: &HashMap<String, Vec<String>>,
+    current_executions: &HashMap<String, ExecutionState>,
+) -> (Vec<String>, HashMap<String, Vec<String>>) {
+    let mut changed_cells = Vec::new();
+
+    for (eid, exec) in current_executions {
+        let outputs_changed = match prev.get(eid) {
+            None => !exec.outputs.is_empty(),
+            Some(prev_outputs) => prev_outputs != &exec.outputs,
+        };
+        if outputs_changed {
+            changed_cells.push(exec.cell_id.clone());
+        }
+    }
+
+    // Keep ALL executions (even with empty outputs) so the next diff
+    // correctly detects transitions from [] → [hash].
+    let new_snapshot: HashMap<String, Vec<String>> = current_executions
+        .iter()
+        .map(|(eid, e)| (eid.clone(), e.outputs.clone()))
+        .collect();
+
+    (changed_cells, new_snapshot)
+}
+
 // ── Tests ───────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -2410,5 +2447,139 @@ mod tests {
     fn test_new_doc_has_empty_comms() {
         let doc = RuntimeStateDoc::new();
         assert!(doc.read_state().comms.is_empty());
+    }
+
+    // ── Output diff tests ─────────────────────────────────────────
+
+    #[test]
+    fn test_diff_new_output_detected() {
+        let prev = HashMap::new();
+        let mut execs = HashMap::new();
+        execs.insert(
+            "exec-1".to_string(),
+            ExecutionState {
+                cell_id: "cell-1".to_string(),
+                status: "done".to_string(),
+                execution_count: Some(1),
+                success: Some(true),
+                outputs: vec!["hash1".to_string()],
+            },
+        );
+        let (changed, _) = diff_execution_outputs(&prev, &execs);
+        assert_eq!(changed, vec!["cell-1"]);
+    }
+
+    #[test]
+    fn test_diff_empty_to_empty_no_change() {
+        let prev = HashMap::new();
+        let mut execs = HashMap::new();
+        execs.insert(
+            "exec-1".to_string(),
+            ExecutionState {
+                cell_id: "cell-1".to_string(),
+                status: "running".to_string(),
+                execution_count: None,
+                success: None,
+                outputs: vec![],
+            },
+        );
+        let (changed, _) = diff_execution_outputs(&prev, &execs);
+        assert!(changed.is_empty());
+    }
+
+    #[test]
+    fn test_diff_output_cleared_detected() {
+        let mut prev = HashMap::new();
+        prev.insert("exec-1".to_string(), vec!["hash1".to_string()]);
+        let mut execs = HashMap::new();
+        execs.insert(
+            "exec-1".to_string(),
+            ExecutionState {
+                cell_id: "cell-1".to_string(),
+                status: "done".to_string(),
+                execution_count: Some(1),
+                success: Some(true),
+                outputs: vec![],
+            },
+        );
+        let (changed, _) = diff_execution_outputs(&prev, &execs);
+        assert_eq!(changed, vec!["cell-1"]);
+    }
+
+    /// The critical edge case: after outputs are cleared, the snapshot
+    /// must retain the empty outputs so the NEXT diff comparing
+    /// [] vs ["new_hash"] correctly detects the change.
+    #[test]
+    fn test_diff_re_execution_output_after_clear() {
+        // Stage 1: execution has output
+        let prev = HashMap::new();
+        let mut execs = HashMap::new();
+        execs.insert(
+            "exec-1".to_string(),
+            ExecutionState {
+                cell_id: "cell-1".to_string(),
+                status: "done".to_string(),
+                execution_count: Some(1),
+                success: Some(true),
+                outputs: vec!["hash1".to_string()],
+            },
+        );
+        let (changed, snapshot) = diff_execution_outputs(&prev, &execs);
+        assert_eq!(changed, vec!["cell-1"]);
+
+        // Stage 2: outputs cleared (pre-execute)
+        execs.get_mut("exec-1").unwrap().outputs = vec![];
+        let (changed, snapshot) = diff_execution_outputs(&snapshot, &execs);
+        assert_eq!(changed, vec!["cell-1"], "clear should be detected");
+
+        // Stage 3: new execution with empty outputs (just created)
+        execs.insert(
+            "exec-2".to_string(),
+            ExecutionState {
+                cell_id: "cell-1".to_string(),
+                status: "running".to_string(),
+                execution_count: None,
+                success: None,
+                outputs: vec![],
+            },
+        );
+        let (changed, snapshot) = diff_execution_outputs(&snapshot, &execs);
+        assert!(changed.is_empty(), "no output change yet");
+
+        // Stage 4: new output arrives on exec-2
+        execs.get_mut("exec-2").unwrap().outputs = vec!["hash2".to_string()];
+        let (changed, _) = diff_execution_outputs(&snapshot, &execs);
+        assert_eq!(
+            changed,
+            vec!["cell-1"],
+            "new output after clear must be detected"
+        );
+    }
+
+    /// Verify snapshot retains empty outputs (the original bug was
+    /// filtering them out, which broke subsequent diffs).
+    #[test]
+    fn test_diff_snapshot_retains_empty_outputs() {
+        let mut prev = HashMap::new();
+        prev.insert("exec-1".to_string(), vec!["hash1".to_string()]);
+
+        let mut execs = HashMap::new();
+        execs.insert(
+            "exec-1".to_string(),
+            ExecutionState {
+                cell_id: "cell-1".to_string(),
+                status: "done".to_string(),
+                execution_count: Some(1),
+                success: Some(true),
+                outputs: vec![],
+            },
+        );
+
+        let (_, snapshot) = diff_execution_outputs(&prev, &execs);
+        assert!(
+            snapshot.contains_key("exec-1"),
+            "empty outputs must be retained in snapshot"
+        );
+        assert!(snapshot["exec-1"].is_empty());
     }
 }

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -12,7 +12,7 @@ use automerge::Prop;
 use notebook_doc::diff::{diff_cells, CellChangeset};
 use notebook_doc::pool_state::{PoolDoc, PoolState};
 use notebook_doc::presence;
-use notebook_doc::runtime_state::{RuntimeState, RuntimeStateDoc};
+use notebook_doc::runtime_state::{diff_execution_outputs, RuntimeState, RuntimeStateDoc};
 use notebook_doc::{CellSnapshot, NotebookDoc};
 use serde::Serialize;
 use wasm_bindgen::prelude::*;
@@ -1262,29 +1262,11 @@ impl NotebookHandle {
                 // changes (stream append, display update, error).
                 let output_changed_cells = if changed {
                     let current_state = state.as_ref().unwrap();
-                    let mut changed_cells = Vec::new();
-
-                    for (eid, exec) in &current_state.executions {
-                        let prev = self.prev_execution_outputs.get(eid);
-                        let outputs_changed = match prev {
-                            None => !exec.outputs.is_empty(),
-                            Some(prev) => prev != &exec.outputs,
-                        };
-                        if outputs_changed {
-                            changed_cells.push(exec.cell_id.clone());
-                        }
-                    }
-                    // Removed executions (trimmed) don't need notification —
-                    // the cell either has a newer execution or was deleted.
-
-                    // Update snapshot from inline execution outputs
-                    self.prev_execution_outputs = current_state
-                        .executions
-                        .iter()
-                        .filter(|(_, e)| !e.outputs.is_empty())
-                        .map(|(eid, e)| (eid.clone(), e.outputs.clone()))
-                        .collect();
-
+                    let (changed_cells, new_snapshot) = diff_execution_outputs(
+                        &self.prev_execution_outputs,
+                        &current_state.executions,
+                    );
+                    self.prev_execution_outputs = new_snapshot;
                     changed_cells
                 } else {
                     Vec::new()

--- a/crates/runtimed-wasm/src/lib.rs
+++ b/crates/runtimed-wasm/src/lib.rs
@@ -376,8 +376,20 @@ impl NotebookHandle {
     }
 
     /// Get all cells as a JSON string (for bulk materialization).
+    ///
+    /// Populates each cell's outputs from the RuntimeStateDoc via
+    /// the cell's execution_id, since NotebookDoc.get_cells() returns
+    /// empty outputs (outputs moved to RuntimeStateDoc in #1343).
     pub fn get_cells_json(&self) -> String {
-        let cells = self.doc.get_cells();
+        let mut cells = self.doc.get_cells();
+        for cell in &mut cells {
+            if let Some(eid) = self.doc.get_execution_id(&cell.id) {
+                let outputs = self.state_doc.get_outputs(&eid);
+                if !outputs.is_empty() {
+                    cell.outputs = outputs;
+                }
+            }
+        }
         serde_json::to_string(&cells).unwrap_or_else(|_| "[]".to_string())
     }
 


### PR DESCRIPTION
## Summary

Three fixes for output rendering regressions introduced by #1343/#1350/#1351:

- **`get_cells_json()` returns empty outputs** — `NotebookDoc::read_cell()` always returns `outputs: vec![]` since #1343 moved outputs to RuntimeStateDoc. The per-cell `get_cell_outputs()` was updated to read from RuntimeStateDoc, but the bulk `get_cells_json()` path (used by full materialization) was not. Any structural change (add/delete/reorder cell) triggered full materialization → all outputs disappeared.
- **WASM output diff drops empty-output executions** — #1350 added a `.filter(|e| !e.outputs.is_empty())` when building the diff snapshot, causing the next diff to miss output transitions after a clear (pre-re-execute). Extracted `diff_execution_outputs()` into `notebook-doc` as a testable utility and removed the filter.
- **`useLayoutEffect` timing gap for cell-ui-state** — #1351 moved store setters from render to `useLayoutEffect` to fix React's cross-component setState warning, but children saw stale store values for one frame. Fix: assign variables immediately during render, defer subscriber notifications via `queueMicrotask`.

## Test plan

- [x] 5 new unit tests for `diff_execution_outputs` edge cases (clear → re-populate)
- [x] `cargo xtask lint --fix` clean
- [x] WASM rebuilt
- [x] Manual: execute cells, add new cells, re-execute — outputs persist
- [x] Manual: cell navigation (arrow down to create new cell) works correctly
- [x] No React cross-component setState warnings in console