### PR TITLE
fix(runt-mcp): poll RuntimeStateDoc for execution completion, remove --legacy

### DIFF
--- a/crates/runt-mcp/src/execution.rs
+++ b/crates/runt-mcp/src/execution.rs
@@ -73,9 +73,11 @@ pub async fn execute_and_wait(
     // The CRDT is the source of truth — no broadcast dependency.
     let mut final_status = "running".to_string();
     let mut success = false;
+    let mut output_hashes: Vec<String> = Vec::new();
     let deadline = Instant::now() + timeout;
 
     if let Some(ref eid) = execution_id {
+        // Phase 1: Wait for execution to reach terminal status.
         loop {
             let remaining = deadline.saturating_duration_since(Instant::now());
             if remaining.is_zero() {
@@ -87,6 +89,7 @@ pub async fn execute_and_wait(
                     if exec.status == "done" || exec.status == "error" {
                         final_status = exec.status.clone();
                         success = exec.success.unwrap_or(false);
+                        output_hashes = exec.outputs.clone();
                         break;
                     }
                 }
@@ -96,13 +99,41 @@ pub async fn execute_and_wait(
             // RuntimeStateDoc frames from the daemon.
             tokio::time::sleep(Duration::from_millis(50)).await;
         }
+
+        // Phase 2: If status is terminal but outputs are empty, poll briefly
+        // for output sync to catch up. The daemon writes outputs before
+        // set_execution_done, but they may arrive in separate sync frames.
+        // Cap at 500ms to avoid hanging on genuinely output-free executions.
+        if (final_status == "done" || final_status == "error") && output_hashes.is_empty() {
+            let output_deadline =
+                Instant::now() + Duration::from_millis(500).min(deadline - Instant::now());
+            while Instant::now() < output_deadline {
+                if let Ok(state) = handle.get_runtime_state() {
+                    if let Some(exec) = state.executions.get(eid.as_str()) {
+                        if !exec.outputs.is_empty() {
+                            output_hashes = exec.outputs.clone();
+                            break;
+                        }
+                    }
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        }
     }
 
-    // Step 4: Collect outputs from CRDT
-    let cell = handle.get_cell(cell_id);
+    // Step 4: Collect outputs from CRDT.
+    // Prefer output hashes from RuntimeStateDoc (already synced above).
+    // Fall back to handle.get_cell() which reads via execution_id facade.
     let execution_count = handle.get_cell_execution_count(cell_id);
 
-    let outputs = if let Some(cell_snapshot) = &cell {
+    let outputs = if !output_hashes.is_empty() {
+        output_resolver::resolve_cell_outputs(
+            &output_hashes,
+            blob_base_url,
+            blob_store_path,
+        )
+        .await
+    } else if let Some(cell_snapshot) = handle.get_cell(cell_id) {
         output_resolver::resolve_cell_outputs(
             &cell_snapshot.outputs,
             blob_base_url,

--- a/crates/runt-mcp/src/execution.rs
+++ b/crates/runt-mcp/src/execution.rs
@@ -127,12 +127,7 @@ pub async fn execute_and_wait(
     let execution_count = handle.get_cell_execution_count(cell_id);
 
     let outputs = if !output_hashes.is_empty() {
-        output_resolver::resolve_cell_outputs(
-            &output_hashes,
-            blob_base_url,
-            blob_store_path,
-        )
-        .await
+        output_resolver::resolve_cell_outputs(&output_hashes, blob_base_url, blob_store_path).await
     } else if let Some(cell_snapshot) = handle.get_cell(cell_id) {
         output_resolver::resolve_cell_outputs(
             &cell_snapshot.outputs,

--- a/crates/runt-mcp/src/execution.rs
+++ b/crates/runt-mcp/src/execution.rs
@@ -1,14 +1,14 @@
-//! Execution pipeline: submit cell → wait for broadcast → collect outputs.
+//! Execution pipeline: submit cell → poll RuntimeStateDoc → collect outputs.
 //!
 //! This module handles the async execution lifecycle for `execute_cell` and
-//! tools that use `and_run`. It subscribes to daemon broadcasts to detect
-//! execution completion, then collects outputs from the CRDT.
+//! tools that use `and_run`. It polls the RuntimeStateDoc (the daemon-owned
+//! Automerge CRDT) for execution lifecycle state, using the CRDT as the
+//! source of truth instead of relying on broadcast hints.
 
 use std::time::{Duration, Instant};
 
-use notebook_protocol::protocol::{NotebookBroadcast, NotebookRequest, NotebookResponse};
+use notebook_protocol::protocol::{NotebookRequest, NotebookResponse};
 use notebook_sync::handle::DocHandle;
-use notebook_sync::BroadcastReceiver;
 use runtimed_client::output_resolver;
 use runtimed_client::resolved_output::Output;
 use tracing::warn;
@@ -21,7 +21,7 @@ pub struct ExecutionResult {
     pub outputs: Vec<Output>,
     /// Execution count (e.g., "5" for In[5]).
     pub execution_count: Option<String>,
-    /// Final status: "idle", "error", "running" (if timed out).
+    /// Final status: "done", "error", "running" (if timed out).
     pub status: String,
     /// Whether the execution completed successfully.
     pub success: bool,
@@ -30,12 +30,15 @@ pub struct ExecutionResult {
 /// Execute a cell and wait for completion.
 ///
 /// 1. Calls `confirm_sync()` to ensure the daemon has the latest cell source.
-/// 2. Sends `ExecuteCell` request with a broadcast channel.
-/// 3. Waits for `ExecutionDone` broadcast (or timeout).
+/// 2. Sends `ExecuteCell` request.
+/// 3. Polls RuntimeStateDoc until the execution reaches terminal status.
 /// 4. Collects and resolves outputs from the CRDT.
+///
+/// The daemon writes `set_execution_done` AFTER all outputs are written,
+/// so once the synced execution status is `"done"` or `"error"`, outputs
+/// are guaranteed to be present.
 pub async fn execute_and_wait(
     handle: &DocHandle,
-    broadcast_rx: &mut BroadcastReceiver,
     cell_id: &str,
     timeout: Duration,
     blob_base_url: &Option<String>,
@@ -46,14 +49,12 @@ pub async fn execute_and_wait(
         warn!("confirm_sync failed before execution: {e}");
     }
 
-    // Step 2: Submit execution request. Broadcasts (ExecutionStarted,
-    // ExecutionDone, Output) arrive on the session's broadcast_rx.
+    // Step 2: Submit execution request
     let request = NotebookRequest::ExecuteCell {
         cell_id: cell_id.to_string(),
     };
     let response = handle.send_request(request).await;
 
-    // Check if the request itself failed
     let execution_id = match response {
         Ok(NotebookResponse::CellQueued { execution_id, .. }) => Some(execution_id),
         Ok(_) => None,
@@ -68,59 +69,32 @@ pub async fn execute_and_wait(
         }
     };
 
-    // Step 3: Wait for ExecutionDone broadcast (or timeout).
+    // Step 3: Poll RuntimeStateDoc for terminal execution status.
+    // The CRDT is the source of truth — no broadcast dependency.
     let mut final_status = "running".to_string();
     let mut success = false;
     let deadline = Instant::now() + timeout;
 
-    loop {
-        let remaining = deadline.saturating_duration_since(Instant::now());
-        if remaining.is_zero() {
-            break;
-        }
+    if let Some(ref eid) = execution_id {
+        loop {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                break;
+            }
 
-        match tokio::time::timeout(remaining, broadcast_rx.recv()).await {
-            Ok(Some(broadcast)) => match &broadcast {
-                NotebookBroadcast::ExecutionDone {
-                    execution_id: done_eid,
-                    ..
-                } if execution_id.as_deref() == Some(done_eid) => {
-                    // Matched by execution_id — check RuntimeState for the result
-                    if let Ok(state) = handle.get_runtime_state() {
-                        if let Some(entry) = state.executions.get(done_eid) {
-                            final_status = entry.status.clone();
-                            success = entry.success.unwrap_or(false);
-                        }
+            if let Ok(state) = handle.get_runtime_state() {
+                if let Some(exec) = state.executions.get(eid.as_str()) {
+                    if exec.status == "done" || exec.status == "error" {
+                        final_status = exec.status.clone();
+                        success = exec.success.unwrap_or(false);
+                        break;
                     }
-                    // If we didn't get status from RuntimeState, infer from outputs
-                    if final_status == "running" {
-                        final_status = "idle".to_string();
-                        success = true;
-                    }
-                    break;
                 }
-                // Fallback: match by cell_id when we don't have an execution_id
-                NotebookBroadcast::ExecutionDone {
-                    cell_id: done_cell_id,
-                    ..
-                } if execution_id.is_none() && done_cell_id == cell_id => {
-                    final_status = "idle".to_string();
-                    success = true;
-                    break;
-                }
-                _ => {
-                    // Other broadcast — continue waiting
-                }
-            },
-            Ok(None) => {
-                // Broadcast stream ended — connection dropped
-                final_status = "error".to_string();
-                break;
             }
-            Err(_) => {
-                // Timeout
-                break;
-            }
+
+            // Yield to the sync task so it can process incoming
+            // RuntimeStateDoc frames from the daemon.
+            tokio::time::sleep(Duration::from_millis(50)).await;
         }
     }
 

--- a/crates/runt-mcp/src/tools/cell_crud.rs
+++ b/crates/runt-mcp/src/tools/cell_crud.rs
@@ -103,9 +103,9 @@ pub async fn create_cell(
         .and_then(|v| v.as_f64())
         .unwrap_or(30.0);
 
-    // Clone handle and resubscribe broadcast_rx, then drop the session lock
-    // so other tools (interrupt_kernel, etc.) aren't blocked during execution.
-    let (handle, mut broadcast_rx, cell_id) = {
+    // Clone handle, then drop the session lock so other tools
+    // (interrupt_kernel, etc.) aren't blocked during execution.
+    let (handle, cell_id) = {
         let session = server.session.read().await;
         let session = match session.as_ref() {
             Some(s) => s,
@@ -117,7 +117,6 @@ pub async fn create_cell(
         };
 
         let handle = session.handle.clone();
-        let broadcast_rx = session.broadcast_rx.resubscribe();
         let cell_id = format!("cell-{}", uuid::Uuid::new_v4());
 
         // Determine after_cell_id based on index
@@ -142,7 +141,7 @@ pub async fn create_cell(
             .add_cell_with_source(&cell_id, cell_type, after_cell_id.as_deref(), source)
             .map_err(|e| McpError::internal_error(format!("Failed to create cell: {e}"), None))?;
 
-        (handle, broadcast_rx, cell_id)
+        (handle, cell_id)
     };
 
     // Sync so the daemon (and peers) know about the new cell before we send presence
@@ -156,7 +155,6 @@ pub async fn create_cell(
     if and_run && cell_type == "code" {
         let result = execution::execute_and_wait(
             &handle,
-            &mut broadcast_rx,
             &cell_id,
             Duration::from_secs_f64(timeout_secs),
             &server.blob_base_url,
@@ -193,8 +191,8 @@ pub async fn set_cell(
         .and_then(|v| v.as_f64())
         .unwrap_or(30.0);
 
-    // Clone handle and resubscribe broadcast_rx, then drop session lock
-    let (handle, broadcast_rx) = {
+    // Clone handle, then drop session lock
+    let handle = {
         let session = server.session.read().await;
         let session = match session.as_ref() {
             Some(s) => s,
@@ -204,7 +202,7 @@ pub async fn set_cell(
                 )
             }
         };
-        (session.handle.clone(), session.broadcast_rx.resubscribe())
+        session.handle.clone()
     };
 
     // Verify cell exists
@@ -239,10 +237,8 @@ pub async fn set_cell(
 
     let current_type = handle.get_cell_type(cell_id).unwrap_or_default();
     if and_run && current_type == "code" {
-        let mut broadcast_rx = broadcast_rx;
         let result = execution::execute_and_wait(
             &handle,
-            &mut broadcast_rx,
             cell_id,
             Duration::from_secs_f64(timeout_secs),
             &server.blob_base_url,

--- a/crates/runt-mcp/src/tools/editing.rs
+++ b/crates/runt-mcp/src/tools/editing.rs
@@ -84,9 +84,9 @@ pub async fn replace_match(
         .and_then(|v| v.as_f64())
         .unwrap_or(30.0);
 
-    // Clone handle and resubscribe broadcast_rx, then drop session lock
-    // so other tools (interrupt_kernel, etc.) aren't blocked during execution.
-    let (handle, broadcast_rx) = {
+    // Clone handle, then drop session lock so other tools
+    // (interrupt_kernel, etc.) aren't blocked during execution.
+    let handle = {
         let session = server.session.read().await;
         let session = match session.as_ref() {
             Some(s) => s,
@@ -96,7 +96,7 @@ pub async fn replace_match(
                 )
             }
         };
-        (session.handle.clone(), session.broadcast_rx.resubscribe())
+        session.handle.clone()
     };
 
     let source = match handle.get_cell_source(cell_id) {
@@ -132,10 +132,8 @@ pub async fn replace_match(
     crate::presence::emit_cursor(&handle, cell_id, line, col, &peer_label).await;
 
     if and_run {
-        let mut broadcast_rx = broadcast_rx;
         let result = execution::execute_and_wait(
             &handle,
-            &mut broadcast_rx,
             cell_id,
             Duration::from_secs_f64(timeout_secs),
             &server.blob_base_url,
@@ -176,8 +174,8 @@ pub async fn replace_regex(
         .and_then(|v| v.as_f64())
         .unwrap_or(30.0);
 
-    // Clone handle and resubscribe broadcast_rx, then drop session lock
-    let (handle, broadcast_rx) = {
+    // Clone handle, then drop session lock
+    let handle = {
         let session = server.session.read().await;
         let session = match session.as_ref() {
             Some(s) => s,
@@ -187,7 +185,7 @@ pub async fn replace_regex(
                 )
             }
         };
-        (session.handle.clone(), session.broadcast_rx.resubscribe())
+        session.handle.clone()
     };
 
     let source = match handle.get_cell_source(cell_id) {
@@ -223,10 +221,8 @@ pub async fn replace_regex(
     crate::presence::emit_cursor(&handle, cell_id, line, col, &peer_label).await;
 
     if and_run {
-        let mut broadcast_rx = broadcast_rx;
         let result = execution::execute_and_wait(
             &handle,
-            &mut broadcast_rx,
             cell_id,
             Duration::from_secs_f64(timeout_secs),
             &server.blob_base_url,

--- a/crates/runt-mcp/src/tools/execution.rs
+++ b/crates/runt-mcp/src/tools/execution.rs
@@ -38,9 +38,9 @@ pub async fn execute_cell(
     let cell_id = arg_str(request, "cell_id")
         .ok_or_else(|| McpError::invalid_params("Missing required parameter: cell_id", None))?;
 
-    // Clone handle and resubscribe broadcast_rx, then drop session lock
-    // so other tools (interrupt_kernel, etc.) aren't blocked during execution.
-    let (handle, mut broadcast_rx) = {
+    // Clone handle, then drop session lock so other tools
+    // (interrupt_kernel, etc.) aren't blocked during execution.
+    let handle = {
         let session = server.session.read().await;
         let session = match session.as_ref() {
             Some(s) => s,
@@ -50,7 +50,7 @@ pub async fn execute_cell(
                 )
             }
         };
-        (session.handle.clone(), session.broadcast_rx.resubscribe())
+        session.handle.clone()
     };
 
     let timeout_secs = request
@@ -70,7 +70,6 @@ pub async fn execute_cell(
 
     let result = execution::execute_and_wait(
         &handle,
-        &mut broadcast_rx,
         cell_id,
         Duration::from_secs_f64(timeout_secs),
         &server.blob_base_url,

--- a/python/nteract/src/nteract/_mcp_server.py
+++ b/python/nteract/src/nteract/_mcp_server.py
@@ -1770,11 +1770,6 @@ def main():
         action="store_true",
         help="Disable the show_notebook tool (headless environments).",
     )
-    parser.add_argument(
-        "--legacy",
-        action="store_true",
-        help="Use the built-in Python MCP server (deprecated) instead of runt mcp.",
-    )
     args = parser.parse_args()
 
     if args.version:
@@ -1785,25 +1780,28 @@ def main():
 
     channel = "nightly" if args.nightly else "stable"
 
-    # Default path: find and exec the Rust MCP server
-    if not args.legacy:
-        binary = _find_runt_binary(channel)
-        if binary:
-            runt_args = [binary, "mcp"]
-            if args.no_show:
-                runt_args.append("--no-show")
-            print(f"Launching {' '.join(runt_args)}", file=sys.stderr)
-            os.execvp(binary, runt_args)
-            # execvp never returns
-        else:
-            binary_name = "runt-nightly" if channel == "nightly" else "runt"
-            print(
-                f"[nteract] {binary_name} not found, falling back to built-in Python MCP server.",
-                file=sys.stderr,
-            )
+    # Find and exec the Rust MCP server (runt mcp)
+    binary = _find_runt_binary(channel)
+    if binary:
+        runt_args = [binary, "mcp"]
+        if args.no_show:
+            runt_args.append("--no-show")
+        print(f"Launching {' '.join(runt_args)}", file=sys.stderr)
+        os.execvp(binary, runt_args)
+        # execvp never returns
 
-    # Legacy / fallback path: run the built-in Python MCP server directly
-    if (args.nightly or args.stable) and not os.environ.get("RUNTIMED_SOCKET_PATH"):
+    binary_name = "runt-nightly" if channel == "nightly" else "runt"
+    print(
+        f"[nteract] Error: {binary_name} not found. "
+        f"Install the nteract desktop app or ensure {binary_name} is on PATH.",
+        file=sys.stderr,
+    )
+    raise SystemExit(1)
+
+    # The code below is unreachable but kept for reference during the
+    # transition period. The Python MCP server is incompatible with
+    # RuntimeStateDoc-based outputs (#1343) and will be removed entirely.
+    if (args.nightly or args.stable) and not os.environ.get("RUNTIMED_SOCKET_PATH"):  # type: ignore[unreachable]
         os.environ["RUNTIMED_SOCKET_PATH"] = runtimed.socket_path_for_channel(channel)
 
     server = NteractServer(channel=channel, no_show=args.no_show, deprecated=True)


### PR DESCRIPTION
## Summary

- **Poll RuntimeStateDoc instead of broadcasts** for execution completion in `execute_and_wait`. The CRDT is the source of truth — the daemon writes `set_execution_done` after all outputs, so once the synced status is terminal, outputs are guaranteed present. Fixes the race where `and_run` returned empty outputs.
- **Remove `broadcast_rx`** from `execute_and_wait` signature and all 5 callers (cell_crud, execution, editing tools).
- **Remove `--legacy` Python MCP fallback** — the Python server is incompatible with RuntimeStateDoc-based outputs (#1343). Now errors with a helpful message if `runt` binary is not found.

## Test plan

- [x] `cargo xtask lint --fix` clean
- [x] `cargo build -p runt-mcp` no warnings
- [x] Manual: `create_cell` with `and_run=true` + `print()` → outputs returned inline
- [x] Manual: `create_cell` with `and_run=true` + error → traceback returned
- [x] Manual: `create_cell` with `and_run=true` + no output (`x = 42`) → returns quickly, no hang