### PR TITLE
fix(wasm-tests): remove flaky bloom filter assertion in Bug #1067 test

### DIFF
--- a/crates/runtimed-wasm/tests/deno_smoke_test.ts
+++ b/crates/runtimed-wasm/tests/deno_smoke_test.ts
@@ -381,8 +381,11 @@ Deno.test("Bug #1067: consumed sync message causes protocol stall", () => {
   // Step 2: Client receives the server's sync message
   const serverMsg1 = server.flush_local_changes();
   assert(serverMsg1 !== undefined, "server should have a sync message");
-  const changed = client.receive_sync_message(serverMsg1);
-  assert(changed, "client doc should have changed");
+  client.receive_sync_message(serverMsg1);
+  // Note: we don't assert `changed` here — bloom filter false positives
+  // can cause the first message to not carry change data. The changed
+  // flag is tested separately (see "load from bytes + incremental sync
+  // with changed flag" test). This test focuses on protocol recovery.
 
   // Step 3: Client generates a reply — like flushSync() does.
   // This ADVANCES client's sync_state.last_sent_heads.


### PR DESCRIPTION
## Summary

Removes a flaky assertion in the "Bug #1067: consumed sync message causes protocol stall" deno test that intermittently fails in CI.

Automerge's sync protocol uses bloom filters internally — false positives can cause the first sync message to omit change data, requiring additional round-trips. The test assumed a single `flush_local_changes → receive_sync_message` would always report `changed=true`, but this isn't guaranteed. This is the same root cause fixed in #1110 for a different test.

The `changed` flag is not what this test is about — it tests protocol recovery from dropped messages (Steps 3-6). The changed flag already has bloom-filter-robust coverage in the "load from bytes + incremental sync with changed flag" test.

## Verification

- [ ] CI wasm-tests job passes consistently (no more intermittent `AssertionError: client doc should have changed`)
- [ ] All 50 deno_smoke_test cases pass

_PR submitted by @rgbkrk's agent, Quill_