### PR TITLE
chore: bump all package versions to 2.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3102,7 +3102,7 @@ dependencies = [
 
 [[package]]
 name = "kernel-env"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "dirs 5.0.1",
@@ -3127,7 +3127,7 @@ dependencies = [
 
 [[package]]
 name = "kernel-launch"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "dirs 5.0.1",
@@ -3454,7 +3454,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mcp-supervisor"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "dirs 5.0.1",
  "libc",
@@ -3696,7 +3696,7 @@ dependencies = [
 
 [[package]]
 name = "notebook"
-version = "2.0.8"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3736,7 +3736,7 @@ dependencies = [
 
 [[package]]
 name = "notebook-doc"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "automerge",
  "ciborium",
@@ -3753,7 +3753,7 @@ dependencies = [
 
 [[package]]
 name = "notebook-protocol"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "kernel-env",
@@ -3766,7 +3766,7 @@ dependencies = [
 
 [[package]]
 name = "notebook-sync"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "automerge",
  "log",
@@ -5967,7 +5967,7 @@ dependencies = [
 
 [[package]]
 name = "runt-cli"
-version = "2.0.8"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -6000,7 +6000,7 @@ dependencies = [
 
 [[package]]
 name = "runt-mcp"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "fancy-regex 0.14.0",
  "notebook-doc",
@@ -6020,7 +6020,7 @@ dependencies = [
 
 [[package]]
 name = "runt-trust"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "dirs 5.0.1",
  "hex",
@@ -6035,7 +6035,7 @@ dependencies = [
 
 [[package]]
 name = "runt-workspace"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "core-foundation",
  "dirs 5.0.1",
@@ -6045,7 +6045,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed"
-version = "2.0.8"
+version = "2.1.0"
 dependencies = [
  "alacritty_terminal",
  "anyhow",
@@ -6105,7 +6105,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed-client"
-version = "2.0.4"
+version = "2.1.0"
 dependencies = [
  "automerge",
  "base64 0.22.1",
@@ -6130,7 +6130,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed-py"
-version = "2.0.5"
+version = "2.1.0"
 dependencies = [
  "base64 0.22.1",
  "kernel-env",
@@ -6151,7 +6151,7 @@ dependencies = [
 
 [[package]]
 name = "runtimed-wasm"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "automerge",
  "getrandom 0.2.17",

--- a/crates/kernel-env/Cargo.toml
+++ b/crates/kernel-env/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kernel-env"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 description = "Python environment management (UV + Conda) with progress reporting"
 repository.workspace = true

--- a/crates/kernel-launch/Cargo.toml
+++ b/crates/kernel-launch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kernel-launch"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 description = "Shared kernel launching and tool bootstrapping for nteract"
 repository.workspace = true

--- a/crates/mcp-supervisor/Cargo.toml
+++ b/crates/mcp-supervisor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mcp-supervisor"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 description = "nteract-dev — MCP supervisor that proxies to the nteract MCP server with auto-restart, file watching, and daemon management"
 repository.workspace = true

--- a/crates/notebook-doc/Cargo.toml
+++ b/crates/notebook-doc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notebook-doc"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 description = "Shared Automerge notebook document types and operations, used by both runtimed (daemon) and runtimed-wasm (frontend)"
 repository.workspace = true

--- a/crates/notebook-protocol/Cargo.toml
+++ b/crates/notebook-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notebook-protocol"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 description = "Shared wire protocol types for notebook sync (client and server)"
 repository.workspace = true

--- a/crates/notebook-sync/Cargo.toml
+++ b/crates/notebook-sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notebook-sync"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 description = "Automerge-based notebook sync client with direct document access"
 repository.workspace = true

--- a/crates/notebook/Cargo.toml
+++ b/crates/notebook/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "notebook"
-version = "2.0.8"
+version = "2.1.0"
 edition.workspace = true
 description = "Tauri-based notebook UI for Jupyter kernels"
 repository.workspace = true

--- a/crates/notebook/tauri.conf.json
+++ b/crates/notebook/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "nteract",
-  "version": "2.0.8",
+  "version": "2.1.0",
   "identifier": "org.nteract.desktop",
   "build": {
     "devUrl": "http://localhost:5174",

--- a/crates/runt-mcp/Cargo.toml
+++ b/crates/runt-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runt-mcp"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 description = "Rust-native MCP server for nteract notebook interaction"
 repository.workspace = true

--- a/crates/runt-trust/Cargo.toml
+++ b/crates/runt-trust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runt-trust"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 description = "Notebook trust verification using HMAC signatures over dependency metadata"
 repository.workspace = true

--- a/crates/runt-workspace/Cargo.toml
+++ b/crates/runt-workspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runt-workspace"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 description = "Workspace and dev mode utilities for Runt"
 repository.workspace = true

--- a/crates/runt/Cargo.toml
+++ b/crates/runt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runt-cli"
-version = "2.0.8"
+version = "2.1.0"
 edition.workspace = true
 description = "CLI for Jupyter Runtimes — bundled with nteract"
 repository.workspace = true

--- a/crates/runtimed-client/Cargo.toml
+++ b/crates/runtimed-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed-client"
-version = "2.0.4"
+version = "2.1.0"
 edition.workspace = true
 description = "Client library for communicating with the runtimed daemon"
 repository.workspace = true

--- a/crates/runtimed-py/Cargo.toml
+++ b/crates/runtimed-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed-py"
-version = "2.0.5"
+version = "2.1.0"
 edition = "2021"
 description = "Python bindings for runtimed daemon client"
 repository.workspace = true

--- a/crates/runtimed-wasm/Cargo.toml
+++ b/crates/runtimed-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed-wasm"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/runtimed/Cargo.toml
+++ b/crates/runtimed/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtimed"
-version = "2.0.8"
+version = "2.1.0"
 edition.workspace = true
 description = "Central daemon for managing Jupyter runtimes and prewarmed environments"
 repository.workspace = true

--- a/python/nteract/pyproject.toml
+++ b/python/nteract/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nteract"
-version = "2.0.8"
+version = "2.1.0"
 description = "Bring AI to Jupyter notebooks. MCP server for Claude, ChatGPT, Gemini, OpenCode and any agent."
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/python/runtimed/pyproject.toml
+++ b/python/runtimed/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "runtimed"
-version = "2.0.8"
+version = "2.1.0"
 description = "Python toolkit for Jupyter runtimes, powered by runtimed Rust binaries"
 readme = "README.md"
 license = "BSD-3-Clause"


### PR DESCRIPTION
## Summary

Bumps all package versions for the 2.1.0 release:

- **Shipping packages → 2.1.0**: `runtimed`, `runt-cli`, `notebook`, `runtimed-py`, `runtimed-client`, `nteract` (Python), `runtimed` (Python), and `tauri.conf.json`
- **Internal crates → 0.2.0**: `runt-mcp`, `mcp-supervisor`, `notebook-doc`, `notebook-protocol`, `notebook-sync`, `runtimed-wasm`, `runt-trust`, `runt-workspace`, `kernel-launch`, `kernel-env`

Previously `runtimed-py` (2.0.5) and `runtimed-client` (2.0.4) were behind the main version — this aligns everything to 2.1.0.

## Verification

- [ ] `cargo check` compiles cleanly
- [ ] `cargo test` passes
- [ ] `cargo xtask lint` passes
- [ ] App launches and reports 2.1.0 in About/version info

_PR submitted by @rgbkrk's agent, Quill_