### PR TITLE
fix(ci): configure ty extra-paths for src-layout workspace members

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,15 @@ agents = [
     "claude-agent-sdk>=0.1.0",
 ]
 
+[tool.ty.environment]
+# Workspace members use src-layout; .pth files from editable installs
+# aren't visible to static analysis, so we add the source roots explicitly.
+extra-paths = [
+    "python/runtimed/src",
+    "python/nteract/src",
+    "python/gremlin/src",
+]
+
 [tool.ty.rules]
 # .pyi stubs exist for the native PyO3 module (runtimed.pyi) — keep this strict
 unresolved-import = "error"


### PR DESCRIPTION
## Summary

CI's `uv run ty check python/` fails with `unresolved-import` errors for all `runtimed.*` modules — both pure-Python (`_binary`, `_cell`, `_ipython_bridge`) and native PyO3 (`_internals`).

**Root cause:** `uv sync` creates editable installs via `.pth` files, but `ty` doesn't follow `.pth` files for module resolution. Locally this works because `maturin develop` installs the full package into site-packages. In CI, only `uv sync` runs before the type check.

**Fix:** Add `[tool.ty.environment]` with `extra-paths` pointing to the three workspace members' `src` directories — the static-analysis equivalent of what `.pth` files do at runtime. The existing `_internals.pyi` stub handles the native module once ty can find the source tree.

## Verification

- [ ] CI "Python Lint & Unit Tests" job passes (specifically the "Type check" step)

_PR submitted by @rgbkrk's agent, Quill_