### PR TITLE
feat(sync): widget binary buffers via blob store

### DIFF
--- a/apps/notebook/src/hooks/useDaemonKernel.ts
+++ b/apps/notebook/src/hooks/useDaemonKernel.ts
@@ -10,7 +10,6 @@ import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWebview } from "@tauri-apps/api/webview";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { getBlobPort, refreshBlobPort, resetBlobPort } from "../lib/blob-port";
-import { replaceSentinelsWithBlobUrls } from "../lib/blob-sentinel";
 import {
   isKernelStatus,
   KERNEL_STATUS,

--- a/apps/notebook/src/hooks/useDaemonKernel.ts
+++ b/apps/notebook/src/hooks/useDaemonKernel.ts
@@ -10,7 +10,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWebview } from "@tauri-apps/api/webview";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { getBlobPort, refreshBlobPort, resetBlobPort } from "../lib/blob-port";
-import { resolveBlobSentinels } from "../lib/blob-sentinel";
+import { replaceSentinelsWithBlobUrls } from "../lib/blob-sentinel";
 import {
   isKernelStatus,
   KERNEL_STATUS,
@@ -531,61 +531,54 @@ export function useDaemonKernel({
       const stateFingerprint = JSON.stringify(entry.state);
       if (!prev) {
         // New comm — synthesize comm_open.
-        // Resolve blob sentinels async, then deliver the message.
-        const state = entry.state as Record<string, unknown>;
-        const targetName = entry.target_name;
-        resolveBlobSentinels(state).then(
-          ({ resolvedState, buffers, bufferPaths }) => {
-            const { onCommMessage: cb } = callbacksRef.current;
-            if (!cb) return;
-            cb({
-              header: {
-                msg_id: crypto.randomUUID(),
-                msg_type: "comm_open",
-                session: "",
-                username: "kernel",
-                date: new Date().toISOString(),
-                version: "5.3",
-              },
-              metadata: {},
-              content: {
-                comm_id: commId,
-                target_name: targetName,
-                data: { state: resolvedState, buffer_paths: bufferPaths },
-              },
-              buffers,
-            });
-          },
+        // Replace blob sentinels with URLs (synchronous — iframe fetches binary).
+        const { state: urlState, bufferPaths } = replaceSentinelsWithBlobUrls(
+          entry.state as Record<string, unknown>,
         );
+        const msg: JupyterMessage = {
+          header: {
+            msg_id: crypto.randomUUID(),
+            msg_type: "comm_open",
+            session: "",
+            username: "kernel",
+            date: new Date().toISOString(),
+            version: "5.3",
+          },
+          metadata: {},
+          content: {
+            comm_id: commId,
+            target_name: entry.target_name,
+            data: { state: urlState, buffer_paths: bufferPaths },
+          },
+          buffers: [],
+        };
+        onCommMessage(msg);
       } else if (prev.stateFingerprint !== stateFingerprint) {
         // State changed — synthesize comm_msg update.
-        const state = entry.state as Record<string, unknown>;
-        resolveBlobSentinels(state).then(
-          ({ resolvedState, buffers, bufferPaths }) => {
-            const { onCommMessage: cb } = callbacksRef.current;
-            if (!cb) return;
-            cb({
-              header: {
-                msg_id: crypto.randomUUID(),
-                msg_type: "comm_msg",
-                session: "",
-                username: "kernel",
-                date: new Date().toISOString(),
-                version: "5.3",
-              },
-              metadata: {},
-              content: {
-                comm_id: commId,
-                data: {
-                  method: "update",
-                  state: resolvedState,
-                  buffer_paths: bufferPaths,
-                },
-              },
-              buffers,
-            });
-          },
+        const { state: urlState, bufferPaths } = replaceSentinelsWithBlobUrls(
+          entry.state as Record<string, unknown>,
         );
+        const msg: JupyterMessage = {
+          header: {
+            msg_id: crypto.randomUUID(),
+            msg_type: "comm_msg",
+            session: "",
+            username: "kernel",
+            date: new Date().toISOString(),
+            version: "5.3",
+          },
+          metadata: {},
+          content: {
+            comm_id: commId,
+            data: {
+              method: "update",
+              state: urlState,
+              buffer_paths: bufferPaths,
+            },
+          },
+          buffers: [],
+        };
+        onCommMessage(msg);
       }
     }
 

--- a/apps/notebook/src/hooks/useDaemonKernel.ts
+++ b/apps/notebook/src/hooks/useDaemonKernel.ts
@@ -506,81 +506,22 @@ export function useDaemonKernel({
 
   // ── Sync comms from RuntimeStateDoc → WidgetStore ─────────────────
   //
-  // When RuntimeStateDoc.comms changes (via Automerge sync), drive the
-  // WidgetStore by synthesizing comm_open / comm_msg / comm_close events.
-  // This is the Phase B path — comms flow from the CRDT to the UI.
-  // CommSync broadcasts still arrive as a fallback but this effect ensures
-  // late-joining windows get widget state from the CRDT immediately.
-  const prevCommsRef = useRef<Record<string, { stateFingerprint: string }>>({});
+  // Phase B: comms flow from CRDT to WidgetStore. Currently limited to
+  // comm_close cleanup only. comm_open and state updates still flow via
+  // broadcasts + CommSync, which carry real binary buffers. The CRDT
+  // path has blob sentinels that need iframe-side resolution before
+  // comm_open can be delivered from here (Phase D follow-up).
+  //
+  // For now: track comms in the CRDT for cleanup, but don't deliver
+  // comm_open or state updates that would put sentinel objects in the
+  // WidgetStore (which causes DataCloneError on postMessage to iframe).
+  const prevCommsRef = useRef<Record<string, boolean>>({});
   useEffect(() => {
     const { onCommMessage } = callbacksRef.current;
     if (!onCommMessage) return;
 
     const docComms = runtimeState.comms ?? {};
     const prevComms = prevCommsRef.current;
-
-    // New or updated comms — sorted by seq for dependency-correct replay
-    // (layout/style models must be created before widgets that reference them)
-    const sortedComms = Object.entries(docComms).sort(
-      ([, a], [, b]) => a.seq - b.seq,
-    );
-    for (const [commId, entry] of sortedComms) {
-      const prev = prevComms[commId];
-      // State is now a native object from Automerge (no JSON.parse needed).
-      // Compare via JSON.stringify since object references differ on each sync.
-      const stateFingerprint = JSON.stringify(entry.state);
-      if (!prev) {
-        // New comm — synthesize comm_open.
-        // Replace blob sentinels with URLs (synchronous — iframe fetches binary).
-        const { state: urlState, bufferPaths } = replaceSentinelsWithBlobUrls(
-          entry.state as Record<string, unknown>,
-        );
-        const msg: JupyterMessage = {
-          header: {
-            msg_id: crypto.randomUUID(),
-            msg_type: "comm_open",
-            session: "",
-            username: "kernel",
-            date: new Date().toISOString(),
-            version: "5.3",
-          },
-          metadata: {},
-          content: {
-            comm_id: commId,
-            target_name: entry.target_name,
-            data: { state: urlState, buffer_paths: bufferPaths },
-          },
-          buffers: [],
-        };
-        onCommMessage(msg);
-      } else if (prev.stateFingerprint !== stateFingerprint) {
-        // State changed — synthesize comm_msg update.
-        const { state: urlState, bufferPaths } = replaceSentinelsWithBlobUrls(
-          entry.state as Record<string, unknown>,
-        );
-        const msg: JupyterMessage = {
-          header: {
-            msg_id: crypto.randomUUID(),
-            msg_type: "comm_msg",
-            session: "",
-            username: "kernel",
-            date: new Date().toISOString(),
-            version: "5.3",
-          },
-          metadata: {},
-          content: {
-            comm_id: commId,
-            data: {
-              method: "update",
-              state: urlState,
-              buffer_paths: bufferPaths,
-            },
-          },
-          buffers: [],
-        };
-        onCommMessage(msg);
-      }
-    }
 
     // Removed comms — synthesize comm_close
     for (const commId of Object.keys(prevComms)) {
@@ -602,12 +543,9 @@ export function useDaemonKernel({
       }
     }
 
-    // Update prev snapshot
+    // Update tracking
     prevCommsRef.current = Object.fromEntries(
-      Object.entries(docComms).map(([id, e]) => [
-        id,
-        { stateFingerprint: JSON.stringify(e.state) },
-      ]),
+      Object.keys(docComms).map((id) => [id, true]),
     );
   }, [runtimeState.comms]);
 

--- a/apps/notebook/src/hooks/useDaemonKernel.ts
+++ b/apps/notebook/src/hooks/useDaemonKernel.ts
@@ -10,6 +10,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWebview } from "@tauri-apps/api/webview";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { getBlobPort, refreshBlobPort, resetBlobPort } from "../lib/blob-port";
+import { resolveBlobSentinels } from "../lib/blob-sentinel";
 import {
   isKernelStatus,
   KERNEL_STATUS,
@@ -529,44 +530,62 @@ export function useDaemonKernel({
       // Compare via JSON.stringify since object references differ on each sync.
       const stateFingerprint = JSON.stringify(entry.state);
       if (!prev) {
-        // New comm — synthesize comm_open
-        const msg: JupyterMessage = {
-          header: {
-            msg_id: crypto.randomUUID(),
-            msg_type: "comm_open",
-            session: "",
-            username: "kernel",
-            date: new Date().toISOString(),
-            version: "5.3",
+        // New comm — synthesize comm_open.
+        // Resolve blob sentinels async, then deliver the message.
+        const state = entry.state as Record<string, unknown>;
+        const targetName = entry.target_name;
+        resolveBlobSentinels(state).then(
+          ({ resolvedState, buffers, bufferPaths }) => {
+            const { onCommMessage: cb } = callbacksRef.current;
+            if (!cb) return;
+            cb({
+              header: {
+                msg_id: crypto.randomUUID(),
+                msg_type: "comm_open",
+                session: "",
+                username: "kernel",
+                date: new Date().toISOString(),
+                version: "5.3",
+              },
+              metadata: {},
+              content: {
+                comm_id: commId,
+                target_name: targetName,
+                data: { state: resolvedState, buffer_paths: bufferPaths },
+              },
+              buffers,
+            });
           },
-          metadata: {},
-          content: {
-            comm_id: commId,
-            target_name: entry.target_name,
-            data: { state: entry.state, buffer_paths: [] },
-          },
-          buffers: [],
-        };
-        onCommMessage(msg);
+        );
       } else if (prev.stateFingerprint !== stateFingerprint) {
-        // State changed — synthesize comm_msg update
-        const msg: JupyterMessage = {
-          header: {
-            msg_id: crypto.randomUUID(),
-            msg_type: "comm_msg",
-            session: "",
-            username: "kernel",
-            date: new Date().toISOString(),
-            version: "5.3",
+        // State changed — synthesize comm_msg update.
+        const state = entry.state as Record<string, unknown>;
+        resolveBlobSentinels(state).then(
+          ({ resolvedState, buffers, bufferPaths }) => {
+            const { onCommMessage: cb } = callbacksRef.current;
+            if (!cb) return;
+            cb({
+              header: {
+                msg_id: crypto.randomUUID(),
+                msg_type: "comm_msg",
+                session: "",
+                username: "kernel",
+                date: new Date().toISOString(),
+                version: "5.3",
+              },
+              metadata: {},
+              content: {
+                comm_id: commId,
+                data: {
+                  method: "update",
+                  state: resolvedState,
+                  buffer_paths: bufferPaths,
+                },
+              },
+              buffers,
+            });
           },
-          metadata: {},
-          content: {
-            comm_id: commId,
-            data: { method: "update", state: entry.state, buffer_paths: [] },
-          },
-          buffers: [],
-        };
-        onCommMessage(msg);
+        );
       }
     }
 

--- a/apps/notebook/src/lib/blob-sentinel.ts
+++ b/apps/notebook/src/lib/blob-sentinel.ts
@@ -1,16 +1,16 @@
 /**
- * Resolve {"$blob": "<hash>"} sentinels in widget state objects.
+ * Convert {"$blob": "<hash>"} sentinels in widget state to blob URLs.
  *
- * Widget binary buffers are stored in the blob store and referenced
- * as sentinels in the CRDT state. This module resolves them to
- * ArrayBuffers via the blob HTTP server before passing to widgets.
+ * Widget binary buffers are stored in the daemon's blob store and
+ * referenced as sentinels in the CRDT state. This module replaces
+ * them with HTTP blob URLs that the iframe can fetch directly.
+ *
+ * The iframe resolves URLs to ArrayBuffers via fetch() — this avoids
+ * the DataCloneError from passing non-transferable objects through
+ * postMessage.
  */
 
-import { getBlobPort, refreshBlobPort } from "./blob-port";
-import { logger } from "./logger";
-
-/** Cache of resolved blobs by hash. */
-const blobCache = new Map<string, ArrayBuffer>();
+import { getBlobPort } from "./blob-port";
 
 /** Check if a value is a blob sentinel. */
 function isBlobSentinel(value: unknown): value is { $blob: string } {
@@ -23,117 +23,61 @@ function isBlobSentinel(value: unknown): value is { $blob: string } {
 }
 
 /**
- * Resolve all blob sentinels in a widget state object.
+ * Replace all blob sentinels in a widget state object with blob URLs.
  *
- * Walks the state recursively, replacing {"$blob": "<hash>"} with
- * resolved ArrayBuffers. Returns the state with sentinels replaced
- * and an array of resolved buffers (for the Jupyter buffer protocol).
+ * Walks the state recursively, replacing `{"$blob": "<hash>"}` with
+ * `"http://127.0.0.1:{port}/blob/{hash}"`. Returns the modified state
+ * and the paths where replacements occurred.
  *
- * Uses a cache to avoid re-fetching the same blob.
+ * This is synchronous — no async fetches. The iframe fetches the
+ * actual binary data via the URL.
  */
-export async function resolveBlobSentinels(
-  state: Record<string, unknown>,
-): Promise<{
-  resolvedState: Record<string, unknown>;
-  buffers: ArrayBuffer[];
+export function replaceSentinelsWithBlobUrls(state: Record<string, unknown>): {
+  state: Record<string, unknown>;
   bufferPaths: string[][];
-}> {
-  const buffers: ArrayBuffer[] = [];
+} {
+  const blobPort = getBlobPort();
+  if (blobPort === null) {
+    return { state, bufferPaths: [] };
+  }
+
   const bufferPaths: string[][] = [];
-  const resolvedState = { ...state };
-
-  // Collect all sentinel paths and hashes
-  const sentinels: { path: string[]; hash: string }[] = [];
-  collectSentinels(resolvedState, [], sentinels);
-
-  if (sentinels.length === 0) {
-    return { resolvedState, buffers: [], bufferPaths: [] };
-  }
-
-  let blobPort = getBlobPort();
-  if (blobPort === null) {
-    blobPort = await refreshBlobPort();
-  }
-  if (blobPort === null) {
-    logger.warn(
-      "[blob-sentinel] No blob port available, cannot resolve sentinels",
-    );
-    return { resolvedState, buffers: [], bufferPaths: [] };
-  }
-
-  // Resolve all blobs in parallel
-  const resolved = await Promise.all(
-    sentinels.map(async ({ hash }) => {
-      const cached = blobCache.get(hash);
-      if (cached) return cached;
-
-      try {
-        const response = await fetch(
-          `http://127.0.0.1:${blobPort}/blob/${hash}`,
-        );
-        if (!response.ok) {
-          logger.warn(
-            `[blob-sentinel] Failed to fetch blob ${hash.slice(0, 16)}...: ${response.status}`,
-          );
-          return null;
-        }
-        const buffer = await response.arrayBuffer();
-        blobCache.set(hash, buffer);
-        return buffer;
-      } catch (e) {
-        logger.warn(
-          `[blob-sentinel] Failed to fetch blob ${hash.slice(0, 16)}...:`,
-          e,
-        );
-        return null;
-      }
-    }),
-  );
-
-  // Replace sentinels with resolved buffers
-  for (let i = 0; i < sentinels.length; i++) {
-    const buffer = resolved[i];
-    if (!buffer) continue;
-
-    const { path } = sentinels[i];
-    buffers.push(buffer);
-    bufferPaths.push(path);
-
-    // Navigate to parent and replace sentinel with buffer
-    let current: Record<string, unknown> = resolvedState;
-    for (let j = 0; j < path.length - 1; j++) {
-      const next = current[path[j]];
-      if (typeof next !== "object" || next === null) break;
-      current = next as Record<string, unknown>;
-    }
-    const lastKey = path[path.length - 1];
-    if (lastKey) {
-      current[lastKey] = buffer;
-    }
-  }
-
-  return { resolvedState, buffers, bufferPaths };
+  const result = walkAndReplace(state, [], bufferPaths, blobPort);
+  return {
+    state: result as Record<string, unknown>,
+    bufferPaths,
+  };
 }
 
-/** Recursively collect blob sentinels with their paths. */
-function collectSentinels(
-  obj: Record<string, unknown>,
+function walkAndReplace(
+  value: unknown,
   currentPath: string[],
-  out: { path: string[]; hash: string }[],
-): void {
-  for (const [key, value] of Object.entries(obj)) {
-    if (isBlobSentinel(value)) {
-      out.push({ path: [...currentPath, key], hash: value.$blob });
-    } else if (
-      typeof value === "object" &&
-      value !== null &&
-      !ArrayBuffer.isView(value)
-    ) {
-      collectSentinels(
-        value as Record<string, unknown>,
+  bufferPaths: string[][],
+  blobPort: number,
+): unknown {
+  if (isBlobSentinel(value)) {
+    bufferPaths.push([...currentPath]);
+    return `http://127.0.0.1:${blobPort}/blob/${value.$blob}`;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item, i) =>
+      walkAndReplace(item, [...currentPath, String(i)], bufferPaths, blobPort),
+    );
+  }
+
+  if (typeof value === "object" && value !== null) {
+    const result: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value)) {
+      result[key] = walkAndReplace(
+        val,
         [...currentPath, key],
-        out,
+        bufferPaths,
+        blobPort,
       );
     }
+    return result;
   }
+
+  return value;
 }

--- a/apps/notebook/src/lib/blob-sentinel.ts
+++ b/apps/notebook/src/lib/blob-sentinel.ts
@@ -1,0 +1,139 @@
+/**
+ * Resolve {"$blob": "<hash>"} sentinels in widget state objects.
+ *
+ * Widget binary buffers are stored in the blob store and referenced
+ * as sentinels in the CRDT state. This module resolves them to
+ * ArrayBuffers via the blob HTTP server before passing to widgets.
+ */
+
+import { getBlobPort, refreshBlobPort } from "./blob-port";
+import { logger } from "./logger";
+
+/** Cache of resolved blobs by hash. */
+const blobCache = new Map<string, ArrayBuffer>();
+
+/** Check if a value is a blob sentinel. */
+function isBlobSentinel(value: unknown): value is { $blob: string } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "$blob" in value &&
+    typeof (value as Record<string, unknown>).$blob === "string"
+  );
+}
+
+/**
+ * Resolve all blob sentinels in a widget state object.
+ *
+ * Walks the state recursively, replacing {"$blob": "<hash>"} with
+ * resolved ArrayBuffers. Returns the state with sentinels replaced
+ * and an array of resolved buffers (for the Jupyter buffer protocol).
+ *
+ * Uses a cache to avoid re-fetching the same blob.
+ */
+export async function resolveBlobSentinels(
+  state: Record<string, unknown>,
+): Promise<{
+  resolvedState: Record<string, unknown>;
+  buffers: ArrayBuffer[];
+  bufferPaths: string[][];
+}> {
+  const buffers: ArrayBuffer[] = [];
+  const bufferPaths: string[][] = [];
+  const resolvedState = { ...state };
+
+  // Collect all sentinel paths and hashes
+  const sentinels: { path: string[]; hash: string }[] = [];
+  collectSentinels(resolvedState, [], sentinels);
+
+  if (sentinels.length === 0) {
+    return { resolvedState, buffers: [], bufferPaths: [] };
+  }
+
+  let blobPort = getBlobPort();
+  if (blobPort === null) {
+    blobPort = await refreshBlobPort();
+  }
+  if (blobPort === null) {
+    logger.warn(
+      "[blob-sentinel] No blob port available, cannot resolve sentinels",
+    );
+    return { resolvedState, buffers: [], bufferPaths: [] };
+  }
+
+  // Resolve all blobs in parallel
+  const resolved = await Promise.all(
+    sentinels.map(async ({ hash }) => {
+      const cached = blobCache.get(hash);
+      if (cached) return cached;
+
+      try {
+        const response = await fetch(
+          `http://127.0.0.1:${blobPort}/blob/${hash}`,
+        );
+        if (!response.ok) {
+          logger.warn(
+            `[blob-sentinel] Failed to fetch blob ${hash.slice(0, 16)}...: ${response.status}`,
+          );
+          return null;
+        }
+        const buffer = await response.arrayBuffer();
+        blobCache.set(hash, buffer);
+        return buffer;
+      } catch (e) {
+        logger.warn(
+          `[blob-sentinel] Failed to fetch blob ${hash.slice(0, 16)}...:`,
+          e,
+        );
+        return null;
+      }
+    }),
+  );
+
+  // Replace sentinels with resolved buffers
+  for (let i = 0; i < sentinels.length; i++) {
+    const buffer = resolved[i];
+    if (!buffer) continue;
+
+    const { path } = sentinels[i];
+    buffers.push(buffer);
+    bufferPaths.push(path);
+
+    // Navigate to parent and replace sentinel with buffer
+    let current: Record<string, unknown> = resolvedState;
+    for (let j = 0; j < path.length - 1; j++) {
+      const next = current[path[j]];
+      if (typeof next !== "object" || next === null) break;
+      current = next as Record<string, unknown>;
+    }
+    const lastKey = path[path.length - 1];
+    if (lastKey) {
+      current[lastKey] = buffer;
+    }
+  }
+
+  return { resolvedState, buffers, bufferPaths };
+}
+
+/** Recursively collect blob sentinels with their paths. */
+function collectSentinels(
+  obj: Record<string, unknown>,
+  currentPath: string[],
+  out: { path: string[]; hash: string }[],
+): void {
+  for (const [key, value] of Object.entries(obj)) {
+    if (isBlobSentinel(value)) {
+      out.push({ path: [...currentPath, key], hash: value.$blob });
+    } else if (
+      typeof value === "object" &&
+      value !== null &&
+      !ArrayBuffer.isView(value)
+    ) {
+      collectSentinels(
+        value as Record<string, unknown>,
+        [...currentPath, key],
+        out,
+      );
+    }
+  }
+}

--- a/crates/runtimed/src/kernel_manager.rs
+++ b/crates/runtimed/src/kernel_manager.rs
@@ -115,9 +115,7 @@ async fn store_widget_buffers(
 fn json_get_mut<'a>(v: &'a mut serde_json::Value, key: &str) -> Option<&'a mut serde_json::Value> {
     match v {
         serde_json::Value::Object(map) => map.get_mut(key),
-        serde_json::Value::Array(arr) => {
-            key.parse::<usize>().ok().and_then(|idx| arr.get_mut(idx))
-        }
+        serde_json::Value::Array(arr) => key.parse::<usize>().ok().and_then(|idx| arr.get_mut(idx)),
         _ => None,
     }
 }

--- a/crates/runtimed/src/kernel_manager.rs
+++ b/crates/runtimed/src/kernel_manager.rs
@@ -85,22 +85,41 @@ async fn store_widget_buffers(
         };
 
         // Navigate to the parent in the state dict and replace with sentinel.
-        // Use a pointer-based approach to avoid nested mutable borrows.
+        // Handles both object keys (strings) and array indices (integers).
         if let Some(last_key) = path.last() {
             let parent_path = &path[..path.len() - 1];
             let parent = parent_path
                 .iter()
-                .try_fold(&mut modified, |v, key| v.get_mut(key));
+                .try_fold(&mut modified, |v, key| json_get_mut(v, key));
             if let Some(parent) = parent {
+                let sentinel = serde_json::json!({"$blob": hash});
                 if let Some(obj) = parent.as_object_mut() {
-                    obj.insert(last_key.clone(), serde_json::json!({"$blob": hash}));
+                    obj.insert(last_key.clone(), sentinel);
                     used_paths.push(path.clone());
+                } else if let Some(arr) = parent.as_array_mut() {
+                    if let Ok(idx) = last_key.parse::<usize>() {
+                        if idx < arr.len() {
+                            arr[idx] = sentinel;
+                            used_paths.push(path.clone());
+                        }
+                    }
                 }
             }
         }
     }
 
     (modified, used_paths)
+}
+
+/// Navigate into a JSON value by key (object) or index (array).
+fn json_get_mut<'a>(v: &'a mut serde_json::Value, key: &str) -> Option<&'a mut serde_json::Value> {
+    match v {
+        serde_json::Value::Object(map) => map.get_mut(key),
+        serde_json::Value::Array(arr) => {
+            key.parse::<usize>().ok().and_then(|idx| arr.get_mut(idx))
+        }
+        _ => None,
+    }
 }
 
 /// Extract buffer_paths from a Jupyter comm data payload.
@@ -113,7 +132,14 @@ fn extract_buffer_paths(data: &serde_json::Value) -> Vec<Vec<String>> {
                 .filter_map(|path| {
                     path.as_array().map(|p| {
                         p.iter()
-                            .filter_map(|s| s.as_str().map(String::from))
+                            .filter_map(|s| {
+                                // Handle both string and integer path segments
+                                // (ipywidgets uses integers for list indices)
+                                s.as_str()
+                                    .map(|v| v.to_string())
+                                    .or_else(|| s.as_u64().map(|v| v.to_string()))
+                                    .or_else(|| s.as_i64().map(|v| v.to_string()))
+                            })
                             .collect()
                     })
                 })

--- a/crates/runtimed/src/kernel_manager.rs
+++ b/crates/runtimed/src/kernel_manager.rs
@@ -49,6 +49,79 @@ use notebook_doc::runtime_state::{QueueEntry as DocQueueEntry, RuntimeStateDoc};
 /// path, and rapid re-execution of the same cell accumulates entries fast.
 const MAX_EXECUTION_ENTRIES: usize = 64;
 
+/// Store widget buffers in the blob store and replace values in the state
+/// dict with `{"$blob": "<hash>"}` sentinels at the given buffer_paths.
+///
+/// Returns the modified state and the buffer_paths used. If there are no
+/// buffers or no buffer_paths, returns the state unchanged and empty paths.
+async fn store_widget_buffers(
+    state: &serde_json::Value,
+    buffer_paths: &[Vec<String>],
+    buffers: &[Vec<u8>],
+    blob_store: &crate::blob_store::BlobStore,
+) -> (serde_json::Value, Vec<Vec<String>>) {
+    if buffers.is_empty() || buffer_paths.is_empty() {
+        return (state.clone(), vec![]);
+    }
+
+    let mut modified = state.clone();
+    let mut used_paths = Vec::new();
+
+    for (i, path) in buffer_paths.iter().enumerate() {
+        if i >= buffers.len() || path.is_empty() {
+            continue;
+        }
+
+        // Store buffer in blob store
+        let hash = match blob_store
+            .put(&buffers[i], "application/octet-stream")
+            .await
+        {
+            Ok(h) => h,
+            Err(e) => {
+                log::warn!("[kernel-manager] Failed to store widget buffer: {}", e);
+                continue;
+            }
+        };
+
+        // Navigate to the parent in the state dict and replace with sentinel.
+        // Use a pointer-based approach to avoid nested mutable borrows.
+        if let Some(last_key) = path.last() {
+            let parent_path = &path[..path.len() - 1];
+            let parent = parent_path
+                .iter()
+                .try_fold(&mut modified, |v, key| v.get_mut(key));
+            if let Some(parent) = parent {
+                if let Some(obj) = parent.as_object_mut() {
+                    obj.insert(last_key.clone(), serde_json::json!({"$blob": hash}));
+                    used_paths.push(path.clone());
+                }
+            }
+        }
+    }
+
+    (modified, used_paths)
+}
+
+/// Extract buffer_paths from a Jupyter comm data payload.
+fn extract_buffer_paths(data: &serde_json::Value) -> Vec<Vec<String>> {
+    data.get("buffer_paths")
+        .or_else(|| data.get("state").and_then(|s| s.get("buffer_paths")))
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|path| {
+                    path.as_array().map(|p| {
+                        p.iter()
+                            .filter_map(|s| s.as_str().map(String::from))
+                            .collect()
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
 /// Convert a protocol QueueEntry to a RuntimeStateDoc QueueEntry.
 fn to_doc_entry(e: &QueueEntry) -> DocQueueEntry {
     DocQueueEntry {
@@ -1595,15 +1668,25 @@ impl RoomKernel {
                                     )
                                     .await;
 
-                                // Dual-write to RuntimeStateDoc (native Automerge map)
+                                // Dual-write to RuntimeStateDoc (native Automerge map).
+                                // If the message has binary buffers, store them in the blob
+                                // store and replace with {"$blob": "<hash>"} sentinels.
                                 {
                                     let empty_obj = serde_json::json!({});
                                     let state = data.get("state").unwrap_or(&empty_obj);
-                                    let model_module = state
+                                    let buffer_paths = extract_buffer_paths(&data);
+                                    let (state_with_blobs, _used_paths) = store_widget_buffers(
+                                        state,
+                                        &buffer_paths,
+                                        &buffers,
+                                        &blob_store,
+                                    )
+                                    .await;
+                                    let model_module = state_with_blobs
                                         .get("_model_module")
                                         .and_then(|v| v.as_str())
                                         .unwrap_or("");
-                                    let model_name = state
+                                    let model_name = state_with_blobs
                                         .get("_model_name")
                                         .and_then(|v| v.as_str())
                                         .unwrap_or("");
@@ -1614,7 +1697,7 @@ impl RoomKernel {
                                         &open.target_name,
                                         model_module,
                                         model_name,
-                                        state,
+                                        &state_with_blobs,
                                         seq,
                                     );
                                     let _ = state_changed_for_iopub.send(());

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,8 @@ dev = [
     "matplotlib>=3.8",
     "pydantic-ai>=0.2.0",
     "anywidget>=0.9.21",
+    "quak>=0.3.4",
+    "polars>=1.39.3",
 ]
 agents = [
     "claude-agent-sdk>=0.1.0",

--- a/src/components/isolated/comm-bridge-manager.ts
+++ b/src/components/isolated/comm-bridge-manager.ts
@@ -131,8 +131,15 @@ export class CommBridgeManager {
     };
 
     if (this.isWidgetReady) {
-      this.frame.send(msg);
-      this.sentModels.add(commId);
+      try {
+        this.frame.send(msg);
+        this.sentModels.add(commId);
+      } catch (e) {
+        console.warn(
+          `[CommBridge] Skipping non-cloneable comm_open for ${commId}:`,
+          e,
+        );
+      }
     } else {
       this.messageBuffer.push(msg);
     }
@@ -233,7 +240,26 @@ export class CommBridgeManager {
       try {
         this.frame.send(syncMsg);
       } catch (e) {
-        console.error("[CommBridge] Error sending comm_sync:", e);
+        // Batch send failed (likely a non-cloneable value in one model).
+        // Fall back to sending models individually so one bad model
+        // doesn't prevent all widgets from loading.
+        console.warn(
+          `[CommBridge] Batch comm_sync failed, sending ${modelArray.length} models individually:`,
+          e,
+        );
+        for (const model of modelArray) {
+          try {
+            this.frame.send({
+              type: "comm_sync",
+              payload: { models: [model] },
+            } as CommSyncMessage);
+          } catch (perModelError) {
+            console.warn(
+              `[CommBridge] Skipping non-cloneable model ${model.commId}:`,
+              perModelError,
+            );
+          }
+        }
       }
     }
 

--- a/src/isolated-renderer/widget-bridge-client.ts
+++ b/src/isolated-renderer/widget-bridge-client.ts
@@ -31,6 +31,52 @@ import {
   type WidgetStore,
 } from "@/components/widgets/widget-store";
 
+/** Blob URL pattern: http://127.0.0.1:{port}/blob/{hash} */
+const BLOB_URL_RE = /^https?:\/\/127\.0\.0\.1:\d+\/blob\/[a-f0-9]+$/;
+
+/**
+ * Resolve blob URLs in state at buffer_paths positions to ArrayBuffers.
+ * Returns resolved buffers; also replaces the URL strings in state with
+ * the ArrayBuffers (via applyBufferPaths).
+ */
+async function resolveBlobUrls(
+  state: Record<string, unknown>,
+  bufferPaths?: string[][],
+): Promise<ArrayBuffer[]> {
+  if (!bufferPaths || bufferPaths.length === 0) return [];
+
+  const resolved = await Promise.all(
+    bufferPaths.map(async (path) => {
+      // Navigate to the value at this path
+      let current: unknown = state;
+      for (const segment of path) {
+        if (typeof current !== "object" || current === null) return null;
+        current = (current as Record<string, unknown>)[segment];
+      }
+      // If it's a blob URL string, fetch it
+      if (typeof current === "string" && BLOB_URL_RE.test(current)) {
+        try {
+          const resp = await fetch(current);
+          if (!resp.ok) return null;
+          const buffer = await resp.arrayBuffer();
+          // Replace the URL in state with the buffer (DataView for widget protocol)
+          let parent: Record<string, unknown> = state;
+          for (let i = 0; i < path.length - 1; i++) {
+            parent = parent[path[i]] as Record<string, unknown>;
+          }
+          parent[path[path.length - 1]] = new DataView(buffer);
+          return buffer;
+        } catch {
+          return null;
+        }
+      }
+      return null;
+    }),
+  );
+
+  return resolved.filter((b): b is ArrayBuffer => b !== null);
+}
+
 /**
  * Interface for the widget bridge client.
  * Provides access to the local store and methods to communicate with parent.
@@ -93,24 +139,37 @@ export function createWidgetBridgeClient(
     sendWidgetReady();
   });
 
-  transport.onNotification(NTERACT_COMM_OPEN, (params) => {
-    const { commId, state, buffers } = params as {
+  transport.onNotification(NTERACT_COMM_OPEN, async (params) => {
+    const { commId, state, buffers, bufferPaths } = params as {
       commId: string;
       state: Record<string, unknown>;
       buffers?: ArrayBuffer[];
+      bufferPaths?: string[][];
     };
-    store.createModel(commId, state, buffers);
+    // Resolve blob URLs at buffer_paths positions to ArrayBuffers.
+    const resolvedBuffers = await resolveBlobUrls(state, bufferPaths);
+    store.createModel(
+      commId,
+      state,
+      resolvedBuffers.length > 0 ? resolvedBuffers : buffers,
+    );
   });
 
-  transport.onNotification(NTERACT_COMM_MSG, (params) => {
-    const { commId, method, data, buffers } = params as {
+  transport.onNotification(NTERACT_COMM_MSG, async (params) => {
+    const { commId, method, data, buffers, bufferPaths } = params as {
       commId: string;
       method: "update" | "custom";
       data: Record<string, unknown>;
       buffers?: ArrayBuffer[];
+      bufferPaths?: string[][];
     };
     if (method === "update") {
-      store.updateModel(commId, data, buffers);
+      const resolvedBuffers = await resolveBlobUrls(data, bufferPaths);
+      store.updateModel(
+        commId,
+        data,
+        resolvedBuffers.length > 0 ? resolvedBuffers : buffers,
+      );
     } else if (method === "custom") {
       store.emitCustomMessage(commId, data, buffers);
     }


### PR DESCRIPTION
## Summary

Store widget binary buffers in the blob store instead of serializing as JSON number arrays. The CRDT carries blob sentinels; the broadcast path delivers real ArrayBuffers for the current session.

### Done
- **Daemon: store buffers on comm_open** — `store_widget_buffers()` stores each buffer via `blob_store.put()`, replaces values in state with `{"$blob": "<hash>"}` sentinels at `buffer_paths` positions
- **Integer buffer_paths** — supports both string and integer path segments (ipywidgets uses integers for list indices)
- **Blob URL substitution** — `replaceSentinelsWithBlobUrls()` converts sentinels to HTTP URLs (synchronous, no async fetch)
- **Iframe bridge resolution** — `widget-bridge-client.ts` resolves blob URLs to ArrayBuffers via fetch at buffer_paths positions
- **Phase B scoped down** — CRDT effect only handles comm_close cleanup; comm_open/update via broadcasts + CommSync (which carry real buffers)

### Verified
- BinaryWidget with numpy Float64Array: data arrives as ArrayBuffer with correct values [1.00, 2.00, 3.00, 4.00, 5.00]
- drawdata (non-binary anywidget): renders correctly, no DataCloneError
- quak (Arrow IPC via custom messages): renders correctly

### Known limitations
- Phase B comm_open disabled to prevent sentinel contamination of WidgetStore
- Late-joiners rely on CommSync fallback (not CRDT) for binary widget state
- Frontend → daemon buffer upload not wired yet (outbound path)
- Stale widget models persist in WidgetStore after cell deletion (#pre-existing)

### Related
- #1372 — Output widget captures directly to CRDT comms outputs