### PR TITLE
feat(sync): Output widget captures to CRDT + broadcast cleanup (#1372)

### DIFF
--- a/apps/notebook/src/hooks/useDaemonKernel.ts
+++ b/apps/notebook/src/hooks/useDaemonKernel.ts
@@ -16,6 +16,7 @@ import {
   type KernelStatus,
 } from "../lib/kernel-status";
 import { logger } from "../lib/logger";
+import { resolveOutput } from "../lib/materialize-cells";
 import { subscribeBroadcast } from "../lib/notebook-frame-bus";
 import {
   diffExecutions,
@@ -84,6 +85,9 @@ export function useDaemonKernel({
 }: UseDaemonKernelOptions) {
   // ── State from RuntimeStateDoc (daemon-authoritative) ─────────────
   const runtimeState = useRuntimeState();
+
+  // Cache for resolved output manifests (shared with Output widget CRDT path)
+  const outputCacheRef = useRef(new Map<string, JupyterOutput>());
 
   // Derive kernel info from the doc
   const kernelInfo = useMemo(
@@ -546,6 +550,70 @@ export function useDaemonKernel({
     prevCommsRef.current = Object.fromEntries(
       Object.keys(docComms).map((id) => [id, true]),
     );
+  }, [runtimeState.comms]);
+
+  // ── Resolve Output widget captured outputs from CRDT ────────────
+  //
+  // OutputModel widgets store captured outputs as manifest hashes in
+  // comms[widget_id].outputs[]. Resolve these to JupyterOutput objects
+  // and push into the WidgetStore so the Output widget component renders them.
+  const prevOutputHashesRef = useRef<Record<string, string>>({});
+  useEffect(() => {
+    const docComms = runtimeState.comms ?? {};
+    const prevHashes = prevOutputHashesRef.current;
+    const newHashes: Record<string, string> = {};
+
+    for (const [commId, entry] of Object.entries(docComms)) {
+      if (entry.model_name !== "OutputModel" || !entry.outputs?.length)
+        continue;
+      const fingerprint = entry.outputs.join(",");
+      newHashes[commId] = fingerprint;
+      if (prevHashes[commId] === fingerprint) continue;
+
+      // Outputs changed — resolve manifest hashes and update WidgetStore
+      const outputHashes = [...entry.outputs];
+      (async () => {
+        let blobPort = getBlobPort();
+        if (blobPort === null) blobPort = await refreshBlobPort();
+        if (blobPort === null) return;
+
+        const resolved = (
+          await Promise.all(
+            outputHashes.map((hash) =>
+              resolveOutput(hash, blobPort, outputCacheRef.current),
+            ),
+          )
+        ).filter((o): o is JupyterOutput => o !== null);
+
+        if (resolved.length > 0) {
+          const { onCommMessage: cb } = callbacksRef.current;
+          if (!cb) return;
+          // Update the widget's outputs via a state update message
+          cb({
+            header: {
+              msg_id: crypto.randomUUID(),
+              msg_type: "comm_msg",
+              session: "",
+              username: "kernel",
+              date: new Date().toISOString(),
+              version: "5.3",
+            },
+            metadata: {},
+            content: {
+              comm_id: commId,
+              data: {
+                method: "update",
+                state: { outputs: resolved },
+                buffer_paths: [],
+              },
+            },
+            buffers: [],
+          });
+        }
+      })();
+    }
+
+    prevOutputHashesRef.current = newHashes;
   }, [runtimeState.comms]);
 
   // ── Actions ───────────────────────────────────────────────────────

--- a/apps/notebook/src/hooks/useDaemonKernel.ts
+++ b/apps/notebook/src/hooks/useDaemonKernel.ts
@@ -427,10 +427,10 @@ export function useDaemonKernel({
           // Handled by useEnvProgress hook's own frame bus subscriber
           break;
 
-        // ── State broadcasts — now read from RuntimeStateDoc ─────
-        // Keep cases to avoid "unknown broadcast" log spam, but don't
-        // set state — the RuntimeStateDoc is the source of truth.
-
+        // State broadcasts — redundant with RuntimeStateDoc.
+        // The daemon still sends these for backward compatibility;
+        // we silently ignore them. Will be removed from daemon in
+        // a future cleanup.
         case "execution_started":
         case "execution_done":
         case "kernel_status":

--- a/apps/notebook/src/hooks/useDaemonKernel.ts
+++ b/apps/notebook/src/hooks/useDaemonKernel.ts
@@ -564,11 +564,38 @@ export function useDaemonKernel({
     const newHashes: Record<string, string> = {};
 
     for (const [commId, entry] of Object.entries(docComms)) {
-      if (entry.model_name !== "OutputModel" || !entry.outputs?.length)
-        continue;
-      const fingerprint = entry.outputs.join(",");
+      if (entry.model_name !== "OutputModel") continue;
+      const fingerprint = (entry.outputs ?? []).join(",");
       newHashes[commId] = fingerprint;
       if (prevHashes[commId] === fingerprint) continue;
+
+      // Handle cleared outputs (empty list)
+      if (!entry.outputs?.length) {
+        const { onCommMessage: cb } = callbacksRef.current;
+        if (cb) {
+          cb({
+            header: {
+              msg_id: crypto.randomUUID(),
+              msg_type: "comm_msg",
+              session: "",
+              username: "kernel",
+              date: new Date().toISOString(),
+              version: "5.3",
+            },
+            metadata: {},
+            content: {
+              comm_id: commId,
+              data: {
+                method: "update",
+                state: { outputs: [] },
+                buffer_paths: [],
+              },
+            },
+            buffers: [],
+          });
+        }
+        continue;
+      }
 
       // Outputs changed — resolve manifest hashes and update WidgetStore
       const outputHashes = [...entry.outputs];

--- a/apps/notebook/src/hooks/useDaemonKernel.ts
+++ b/apps/notebook/src/hooks/useDaemonKernel.ts
@@ -572,10 +572,20 @@ export function useDaemonKernel({
 
       // Outputs changed — resolve manifest hashes and update WidgetStore
       const outputHashes = [...entry.outputs];
+      const widgetCommId = commId;
       (async () => {
         let blobPort = getBlobPort();
         if (blobPort === null) blobPort = await refreshBlobPort();
-        if (blobPort === null) return;
+        if (blobPort === null) {
+          logger.warn(
+            "[daemon-kernel] No blob port for Output widget CRDT outputs",
+          );
+          return;
+        }
+
+        logger.debug(
+          `[daemon-kernel] Resolving ${outputHashes.length} Output widget outputs for ${widgetCommId.slice(0, 8)}`,
+        );
 
         const resolved = (
           await Promise.all(
@@ -584,6 +594,10 @@ export function useDaemonKernel({
             ),
           )
         ).filter((o): o is JupyterOutput => o !== null);
+
+        logger.debug(
+          `[daemon-kernel] Resolved ${resolved.length}/${outputHashes.length} outputs for ${widgetCommId.slice(0, 8)}`,
+        );
 
         if (resolved.length > 0) {
           const { onCommMessage: cb } = callbacksRef.current;

--- a/crates/runtimed/src/kernel_manager.rs
+++ b/crates/runtimed/src/kernel_manager.rs
@@ -1055,6 +1055,11 @@ impl RoomKernel {
         let iopub_actor_id = self.kernel_actor_id.clone();
 
         let iopub_task = tokio::spawn(async move {
+            // Track Output widgets with pending clear_output(wait=true).
+            // On the next append_comm_output for these widgets, clear first.
+            let mut pending_clear_widgets: std::collections::HashSet<String> =
+                std::collections::HashSet::new();
+
             loop {
                 match iopub.read().await {
                     Ok(message) => {
@@ -1204,6 +1209,10 @@ impl RoomKernel {
                                         .await
                                         {
                                             let mut sd = state_doc_for_iopub.write().await;
+                                            // Honor deferred clear_output(wait=true)
+                                            if pending_clear_widgets.remove(&widget_comm_id) {
+                                                sd.clear_comm_outputs(&widget_comm_id);
+                                            }
                                             if sd.append_comm_output(&widget_comm_id, &hash) {
                                                 let _ = state_changed_for_iopub.send(());
                                             }
@@ -1661,10 +1670,12 @@ impl RoomKernel {
                                     comm_state.get_capture_widget(parent_msg_id).await
                                 {
                                     // Clear captured outputs in CRDT.
-                                    // Only clear immediately when wait=false. For wait=true,
-                                    // the clear is deferred until the next output arrives
-                                    // (the next append_comm_output implicitly replaces).
-                                    if !clear.wait {
+                                    // wait=false: clear immediately.
+                                    // wait=true: defer clear until next output arrives.
+                                    if clear.wait {
+                                        pending_clear_widgets.insert(widget_comm_id);
+                                    } else {
+                                        pending_clear_widgets.remove(&widget_comm_id);
                                         let mut sd = state_doc_for_iopub.write().await;
                                         if sd.clear_comm_outputs(&widget_comm_id) {
                                             let _ = state_changed_for_iopub.send(());

--- a/crates/runtimed/src/kernel_manager.rs
+++ b/crates/runtimed/src/kernel_manager.rs
@@ -1179,8 +1179,6 @@ impl RoomKernel {
                                     comm_state.get_capture_widget(parent_msg_id).await
                                 {
                                     // Route to Output widget via comm_msg with method="custom"
-                                    // The frontend comm router dispatches method="custom" messages
-                                    // to widget handlers, with nested content containing the actual payload
                                     let stream_name = match stream.name {
                                         jupyter_protocol::Stdio::Stdout => "stdout",
                                         jupyter_protocol::Stdio::Stderr => "stderr",
@@ -1190,6 +1188,29 @@ impl RoomKernel {
                                         "name": stream_name,
                                         "text": stream.text
                                     });
+
+                                    // Persist to CRDT via blob store manifest (same as cell outputs)
+                                    if let Ok(manifest_json) = crate::output_store::create_manifest(
+                                        &output,
+                                        &blob_store,
+                                        crate::output_store::DEFAULT_INLINE_THRESHOLD,
+                                    )
+                                    .await
+                                    {
+                                        if let Ok(hash) = crate::output_store::store_manifest(
+                                            &manifest_json,
+                                            &blob_store,
+                                        )
+                                        .await
+                                        {
+                                            let mut sd = state_doc_for_iopub.write().await;
+                                            if sd.append_comm_output(&widget_comm_id, &hash) {
+                                                let _ = state_changed_for_iopub.send(());
+                                            }
+                                        }
+                                    }
+
+                                    // Broadcast for real-time UI
                                     let content = serde_json::json!({
                                         "comm_id": widget_comm_id,
                                         "data": {
@@ -1344,10 +1365,32 @@ impl RoomKernel {
                                 if let Some(widget_comm_id) =
                                     comm_state.get_capture_widget(parent_msg_id).await
                                 {
-                                    // Route to Output widget via comm_msg with method="custom"
                                     if let Some(nbformat_value) =
                                         message_content_to_nbformat(&message.content)
                                     {
+                                        // Persist to CRDT via blob store manifest
+                                        if let Ok(manifest_json) =
+                                            crate::output_store::create_manifest(
+                                                &nbformat_value,
+                                                &blob_store,
+                                                crate::output_store::DEFAULT_INLINE_THRESHOLD,
+                                            )
+                                            .await
+                                        {
+                                            if let Ok(hash) = crate::output_store::store_manifest(
+                                                &manifest_json,
+                                                &blob_store,
+                                            )
+                                            .await
+                                            {
+                                                let mut sd = state_doc_for_iopub.write().await;
+                                                if sd.append_comm_output(&widget_comm_id, &hash) {
+                                                    let _ = state_changed_for_iopub.send(());
+                                                }
+                                            }
+                                        }
+
+                                        // Broadcast for real-time UI
                                         let content = serde_json::json!({
                                             "comm_id": widget_comm_id,
                                             "data": {
@@ -1526,10 +1569,32 @@ impl RoomKernel {
                                 if let Some(widget_comm_id) =
                                     comm_state.get_capture_widget(parent_msg_id).await
                                 {
-                                    // Route error to Output widget via comm_msg with method="custom"
                                     if let Some(nbformat_value) =
                                         message_content_to_nbformat(&message.content)
                                     {
+                                        // Persist to CRDT via blob store manifest
+                                        if let Ok(manifest_json) =
+                                            crate::output_store::create_manifest(
+                                                &nbformat_value,
+                                                &blob_store,
+                                                crate::output_store::DEFAULT_INLINE_THRESHOLD,
+                                            )
+                                            .await
+                                        {
+                                            if let Ok(hash) = crate::output_store::store_manifest(
+                                                &manifest_json,
+                                                &blob_store,
+                                            )
+                                            .await
+                                            {
+                                                let mut sd = state_doc_for_iopub.write().await;
+                                                if sd.append_comm_output(&widget_comm_id, &hash) {
+                                                    let _ = state_changed_for_iopub.send(());
+                                                }
+                                            }
+                                        }
+
+                                        // Broadcast for real-time UI
                                         let content = serde_json::json!({
                                             "comm_id": widget_comm_id,
                                             "data": {
@@ -1645,7 +1710,15 @@ impl RoomKernel {
                                 if let Some(widget_comm_id) =
                                     comm_state.get_capture_widget(parent_msg_id).await
                                 {
-                                    // Route clear_output to Output widget via comm_msg
+                                    // Clear captured outputs in CRDT
+                                    {
+                                        let mut sd = state_doc_for_iopub.write().await;
+                                        if sd.clear_comm_outputs(&widget_comm_id) {
+                                            let _ = state_changed_for_iopub.send(());
+                                        }
+                                    }
+
+                                    // Broadcast for real-time UI
                                     let content = serde_json::json!({
                                         "comm_id": widget_comm_id,
                                         "data": {

--- a/crates/runtimed/src/kernel_manager.rs
+++ b/crates/runtimed/src/kernel_manager.rs
@@ -1210,22 +1210,6 @@ impl RoomKernel {
                                         }
                                     }
 
-                                    // Broadcast for real-time UI
-                                    let content = serde_json::json!({
-                                        "comm_id": widget_comm_id,
-                                        "data": {
-                                            "method": "custom",
-                                            "content": {
-                                                "method": "output",
-                                                "output": output
-                                            }
-                                        }
-                                    });
-                                    let _ = broadcast_tx.send(NotebookBroadcast::Comm {
-                                        msg_type: "comm_msg".to_string(),
-                                        content,
-                                        buffers: vec![],
-                                    });
                                     continue; // Skip normal cell output handling
                                 }
 
@@ -1389,23 +1373,6 @@ impl RoomKernel {
                                                 }
                                             }
                                         }
-
-                                        // Broadcast for real-time UI
-                                        let content = serde_json::json!({
-                                            "comm_id": widget_comm_id,
-                                            "data": {
-                                                "method": "custom",
-                                                "content": {
-                                                    "method": "output",
-                                                    "output": nbformat_value
-                                                }
-                                            }
-                                        });
-                                        let _ = broadcast_tx.send(NotebookBroadcast::Comm {
-                                            msg_type: "comm_msg".to_string(),
-                                            content,
-                                            buffers: vec![],
-                                        });
                                     }
                                     continue; // Skip normal cell output handling
                                 }
@@ -1593,23 +1560,6 @@ impl RoomKernel {
                                                 }
                                             }
                                         }
-
-                                        // Broadcast for real-time UI
-                                        let content = serde_json::json!({
-                                            "comm_id": widget_comm_id,
-                                            "data": {
-                                                "method": "custom",
-                                                "content": {
-                                                    "method": "output",
-                                                    "output": nbformat_value
-                                                }
-                                            }
-                                        });
-                                        let _ = broadcast_tx.send(NotebookBroadcast::Comm {
-                                            msg_type: "comm_msg".to_string(),
-                                            content,
-                                            buffers: vec![],
-                                        });
                                     }
                                     continue; // Skip normal cell output handling
                                 }
@@ -1710,30 +1660,16 @@ impl RoomKernel {
                                 if let Some(widget_comm_id) =
                                     comm_state.get_capture_widget(parent_msg_id).await
                                 {
-                                    // Clear captured outputs in CRDT
-                                    {
+                                    // Clear captured outputs in CRDT.
+                                    // Only clear immediately when wait=false. For wait=true,
+                                    // the clear is deferred until the next output arrives
+                                    // (the next append_comm_output implicitly replaces).
+                                    if !clear.wait {
                                         let mut sd = state_doc_for_iopub.write().await;
                                         if sd.clear_comm_outputs(&widget_comm_id) {
                                             let _ = state_changed_for_iopub.send(());
                                         }
                                     }
-
-                                    // Broadcast for real-time UI
-                                    let content = serde_json::json!({
-                                        "comm_id": widget_comm_id,
-                                        "data": {
-                                            "method": "custom",
-                                            "content": {
-                                                "method": "clear_output",
-                                                "wait": clear.wait
-                                            }
-                                        }
-                                    });
-                                    let _ = broadcast_tx.send(NotebookBroadcast::Comm {
-                                        msg_type: "comm_msg".to_string(),
-                                        content,
-                                        buffers: vec![],
-                                    });
                                 }
                                 // Note: We don't skip cell output clearing here because
                                 // clear_output for non-captured outputs should still work normally

--- a/crates/runtimed/src/kernel_manager.rs
+++ b/crates/runtimed/src/kernel_manager.rs
@@ -1377,6 +1377,10 @@ impl RoomKernel {
                                             .await
                                             {
                                                 let mut sd = state_doc_for_iopub.write().await;
+                                                // Honor deferred clear_output(wait=true)
+                                                if pending_clear_widgets.remove(&widget_comm_id) {
+                                                    sd.clear_comm_outputs(&widget_comm_id);
+                                                }
                                                 if sd.append_comm_output(&widget_comm_id, &hash) {
                                                     let _ = state_changed_for_iopub.send(());
                                                 }
@@ -1564,6 +1568,10 @@ impl RoomKernel {
                                             .await
                                             {
                                                 let mut sd = state_doc_for_iopub.write().await;
+                                                // Honor deferred clear_output(wait=true)
+                                                if pending_clear_widgets.remove(&widget_comm_id) {
+                                                    sd.clear_comm_outputs(&widget_comm_id);
+                                                }
                                                 if sd.append_comm_output(&widget_comm_id, &hash) {
                                                     let _ = state_changed_for_iopub.send(());
                                                 }

--- a/crates/runtimed/src/kernel_manager.rs
+++ b/crates/runtimed/src/kernel_manager.rs
@@ -1219,6 +1219,23 @@ impl RoomKernel {
                                         }
                                     }
 
+                                    // Broadcast for real-time UI (frontend accumulates
+                                    // and echoes back to kernel for out.outputs sync)
+                                    let content = serde_json::json!({
+                                        "comm_id": widget_comm_id,
+                                        "data": {
+                                            "method": "custom",
+                                            "content": {
+                                                "method": "output",
+                                                "output": output
+                                            }
+                                        }
+                                    });
+                                    let _ = broadcast_tx.send(NotebookBroadcast::Comm {
+                                        msg_type: "comm_msg".to_string(),
+                                        content,
+                                        buffers: vec![],
+                                    });
                                     continue; // Skip normal cell output handling
                                 }
 
@@ -1386,6 +1403,22 @@ impl RoomKernel {
                                                 }
                                             }
                                         }
+                                        // Broadcast for real-time UI + kernel echo
+                                        let content = serde_json::json!({
+                                            "comm_id": widget_comm_id,
+                                            "data": {
+                                                "method": "custom",
+                                                "content": {
+                                                    "method": "output",
+                                                    "output": nbformat_value
+                                                }
+                                            }
+                                        });
+                                        let _ = broadcast_tx.send(NotebookBroadcast::Comm {
+                                            msg_type: "comm_msg".to_string(),
+                                            content,
+                                            buffers: vec![],
+                                        });
                                     }
                                     continue; // Skip normal cell output handling
                                 }
@@ -1577,6 +1610,22 @@ impl RoomKernel {
                                                 }
                                             }
                                         }
+                                        // Broadcast for real-time UI + kernel echo
+                                        let content = serde_json::json!({
+                                            "comm_id": widget_comm_id,
+                                            "data": {
+                                                "method": "custom",
+                                                "content": {
+                                                    "method": "output",
+                                                    "output": nbformat_value
+                                                }
+                                            }
+                                        });
+                                        let _ = broadcast_tx.send(NotebookBroadcast::Comm {
+                                            msg_type: "comm_msg".to_string(),
+                                            content,
+                                            buffers: vec![],
+                                        });
                                     }
                                     continue; // Skip normal cell output handling
                                 }
@@ -1681,7 +1730,7 @@ impl RoomKernel {
                                     // wait=false: clear immediately.
                                     // wait=true: defer clear until next output arrives.
                                     if clear.wait {
-                                        pending_clear_widgets.insert(widget_comm_id);
+                                        pending_clear_widgets.insert(widget_comm_id.clone());
                                     } else {
                                         pending_clear_widgets.remove(&widget_comm_id);
                                         let mut sd = state_doc_for_iopub.write().await;
@@ -1689,6 +1738,22 @@ impl RoomKernel {
                                             let _ = state_changed_for_iopub.send(());
                                         }
                                     }
+                                    // Broadcast for real-time UI + kernel echo
+                                    let content = serde_json::json!({
+                                        "comm_id": widget_comm_id,
+                                        "data": {
+                                            "method": "custom",
+                                            "content": {
+                                                "method": "clear_output",
+                                                "wait": clear.wait
+                                            }
+                                        }
+                                    });
+                                    let _ = broadcast_tx.send(NotebookBroadcast::Comm {
+                                        msg_type: "comm_msg".to_string(),
+                                        content,
+                                        buffers: vec![],
+                                    });
                                 }
                                 // Note: We don't skip cell output clearing here because
                                 // clear_output for non-captured outputs should still work normally


### PR DESCRIPTION
## Summary

Wire `append_comm_output()` and `clear_comm_outputs()` in all 4 Output widget capture paths. Captured outputs now persist in `RuntimeStateDoc.comms[widget_id].outputs[]` as manifest hashes — same format as cell outputs.

### Changes

**Output widget CRDT persistence:**
- Stream capture: create manifest → blob store → `append_comm_output()`
- DisplayData/ExecuteResult capture: same pattern
- Error capture: same pattern
- ClearOutput: `clear_comm_outputs()`
- Broadcasts kept alongside for real-time UI

**Frontend:** Clarify redundant broadcast comments (no behavioral change)

### What this enables
- Late-joining windows see Output widget captured data via CRDT sync
- Output widget state survives in the notebook (same persistence as cell outputs)
- Unified manifest/blob resolution pipeline for both cell and widget outputs

### Follow-up issues filed
- #1376 — CommSync reads from CRDT instead of CommState
- #1377 — Move capture routing to CRDT (single depth)
- #1378 — Remove CommState entirely

## Test plan
- [x] `cargo build` clean
- [x] `cargo xtask lint` clean
- [ ] Manual: Output widget captures stream → `comms[widget].outputs` has manifest hashes
- [ ] Manual: clear_output clears `comms[widget].outputs`