### PR TITLE
fix(notebook): make cell-ui-state store StrictMode-safe

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -2,7 +2,14 @@ import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { getCurrentWebview } from "@tauri-apps/api/webview";
 import { getCurrentWindow } from "@tauri-apps/api/window";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { IsolationTest } from "@/components/isolated";
 import { MediaProvider } from "@/components/outputs/media-provider";
 import { setCrdtCommWriter } from "@/components/widgets/crdt-comm-writer";
@@ -42,6 +49,7 @@ import { useTrust } from "./hooks/useTrust";
 import { useUpdater } from "./hooks/useUpdater";
 import { startAttributionDispatch } from "./lib/attribution-registry";
 import {
+  flushCellUIState,
   setExecutingCellIds as storeSetExecutingCellIds,
   setFocusedCellId as storeSetFocusedCellId,
   setQueuedCellIds as storeSetQueuedCellIds,
@@ -334,19 +342,23 @@ function AppContent() {
   const queuedCellIds = new Set(queueState.queued.map((e) => e.cell_id));
 
   // ── Sync transient UI state into the cell-ui-state store ────────────
-  // These are module-level setters, not React state — they feed
-  // useSyncExternalStore hooks in cell components so renderCell
-  // doesn't need these as dependencies.
+  // Two-phase update for StrictMode safety:
   //
-  // Called during render (not in useLayoutEffect) so the store is
-  // current by the time child components render. The setters have
-  // equality guards that skip emit() when values haven't changed,
-  // preventing the cross-component setState cascade that React flags.
+  // Phase 1 (render): Assign module-level variables so child
+  // useSyncExternalStore snapshots return current values. Equality
+  // guards make this idempotent — same inputs produce no mutation.
+  //
+  // Phase 2 (commit): useLayoutEffect calls flushCellUIState() to
+  // notify subscribers. Discarded renders never trigger notifications.
   storeSetFocusedCellId(focusedCellId);
   storeSetExecutingCellIds(executingCellIds);
   storeSetQueuedCellIds(queuedCellIds);
   storeSetSearchQuery(globalFind.query);
   storeSetSearchCurrentMatch(globalFind.currentMatch);
+
+  useLayoutEffect(() => {
+    flushCellUIState();
+  });
 
   // When kernel is running and we know the env source, use it to determine panel type.
   // This handles: both-deps (backend picks based on preference), pixi (auto-detected, no metadata).

--- a/apps/notebook/src/lib/cell-ui-state.ts
+++ b/apps/notebook/src/lib/cell-ui-state.ts
@@ -32,21 +32,16 @@ function emit(subs: Set<() => void>): void {
   for (const cb of subs) cb();
 }
 
-// Subscriber sets that need deferred notification.
-const _pendingEmits = new Set<Set<() => void>>();
-let _emitScheduled = false;
+// Subscriber sets dirtied during the current render pass.
+// Flushed by useLayoutEffect in AppContent — never during render itself.
+const _dirtySubscribers = new Set<Set<() => void>>();
 
-function deferEmit(subs: Set<() => void>): void {
-  _pendingEmits.add(subs);
-  if (!_emitScheduled) {
-    _emitScheduled = true;
-    queueMicrotask(() => {
-      _emitScheduled = false;
-      const batch = [..._pendingEmits];
-      _pendingEmits.clear();
-      for (const s of batch) emit(s);
-    });
-  }
+/** Flush pending subscriber notifications. Call from useLayoutEffect. */
+export function flushCellUIState(): void {
+  if (_dirtySubscribers.size === 0) return;
+  const batch = [..._dirtySubscribers];
+  _dirtySubscribers.clear();
+  for (const subs of batch) emit(subs);
 }
 
 function setsEqual(a: Set<string>, b: Set<string>): boolean {
@@ -57,42 +52,42 @@ function setsEqual(a: Set<string>, b: Set<string>): boolean {
 
 // ── Setters ─────────────────────────────────────────────────────────────
 //
-// Two-phase update pattern for compatibility with React's render rules:
+// Two-phase update pattern for StrictMode safety:
 //
-// 1. Assign the variable immediately — so useSyncExternalStore snapshot
-//    functions return the current value during the same render cycle.
-// 2. Defer subscriber notification via queueMicrotask — so React doesn't
-//    see a cross-component setState during render. Subscribers re-render
-//    on the next microtask, which is still before the browser paints.
+// 1. Assign the variable immediately during render — so useSyncExternalStore
+//    snapshot functions return current values when children render.
+// 2. Mark the subscriber set as dirty. Actual notification is deferred to
+//    useLayoutEffect (commit phase) via flushCellUIState(), so discarded
+//    renders never trigger subscriber notifications.
 
 export function setFocusedCellId(id: string | null): void {
   if (id === _focusedCellId) return;
   _focusedCellId = id;
-  deferEmit(_focusSubscribers);
+  _dirtySubscribers.add(_focusSubscribers);
 }
 
 export function setExecutingCellIds(ids: Set<string>): void {
   if (setsEqual(_executingCellIds, ids)) return;
   _executingCellIds = ids;
-  deferEmit(_executingSubscribers);
+  _dirtySubscribers.add(_executingSubscribers);
 }
 
 export function setQueuedCellIds(ids: Set<string>): void {
   if (setsEqual(_queuedCellIds, ids)) return;
   _queuedCellIds = ids;
-  deferEmit(_queuedSubscribers);
+  _dirtySubscribers.add(_queuedSubscribers);
 }
 
 export function setSearchQuery(query: string | undefined): void {
   if (query === _searchQuery) return;
   _searchQuery = query;
-  deferEmit(_searchQuerySubscribers);
+  _dirtySubscribers.add(_searchQuerySubscribers);
 }
 
 export function setSearchCurrentMatch(match: FindMatch | null): void {
   if (_searchCurrentMatch === match) return;
   _searchCurrentMatch = match;
-  deferEmit(_searchMatchSubscribers);
+  _dirtySubscribers.add(_searchMatchSubscribers);
 }
 
 // ── Snapshot readers (non-reactive) ─────────────────────────────────────


### PR DESCRIPTION
## Summary

Moves subscriber notifications in the `cell-ui-state` store from `queueMicrotask` to `useLayoutEffect`, so discarded renders under React StrictMode never trigger stale subscriber notifications.

- **`cell-ui-state.ts`**: Replaced the `deferEmit` / `queueMicrotask` batching infrastructure with a `_dirtySubscribers` set and an exported `flushCellUIState()` flush function. Setters still assign module-level variables immediately during render (needed for child `useSyncExternalStore` snapshot freshness) but now mark subscriber sets as dirty instead of scheduling microtask notifications.
- **`App.tsx`**: Added a `useLayoutEffect` in `AppContent` that calls `flushCellUIState()` after every commit, ensuring subscriber notifications only fire for committed renders.

Render-phase variable writes remain idempotent via equality guards — same inputs produce no mutation, so StrictMode double-renders are a no-op.

Closes #1361

## Verification

- [ ] Open a notebook, click between cells — focus ring updates correctly
- [ ] Execute a cell — executing/queued indicators appear and clear
- [ ] Use Cmd+F find/replace — search highlights and match navigation work
- [ ] Rapid focus changes across many cells — no stale focus indicators

_PR submitted by @rgbkrk's agent, Quill_