### PR TITLE
refactor(sync): CommSync reads from RuntimeStateDoc instead of CommState

### DIFF
--- a/apps/notebook/src/hooks/useDaemonKernel.ts
+++ b/apps/notebook/src/hooks/useDaemonKernel.ts
@@ -10,6 +10,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWebview } from "@tauri-apps/api/webview";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { getBlobPort, refreshBlobPort, resetBlobPort } from "../lib/blob-port";
+import { replaceSentinelsWithBlobUrls } from "../lib/blob-sentinel";
 import {
   isKernelStatus,
   KERNEL_STATUS,
@@ -389,6 +390,14 @@ export function useDaemonKernel({
               `[daemon-kernel] comm_sync: replaying ${broadcast.comms.length} comms`,
             );
             for (const comm of broadcast.comms) {
+              // Resolve {"$blob": "hash"} sentinels in state to blob HTTP URLs.
+              // The CRDT stores binary buffers as blob sentinels; the frontend
+              // fetches them directly from the blob server via GET /blob/{hash}.
+              const { state: resolvedState, bufferPaths } =
+                replaceSentinelsWithBlobUrls(
+                  comm.state as Record<string, unknown>,
+                );
+
               // Synthesize a comm_open message for each active comm
               const msg: JupyterMessage = {
                 header: {
@@ -404,14 +413,11 @@ export function useDaemonKernel({
                   comm_id: comm.comm_id,
                   target_name: comm.target_name,
                   data: {
-                    state: comm.state,
-                    buffer_paths: [],
+                    state: resolvedState,
+                    buffer_paths: bufferPaths,
                   },
                 },
-                // Convert buffers if present
-                buffers: comm.buffers
-                  ? comm.buffers.map((arr) => new Uint8Array(arr).buffer)
-                  : [],
+                buffers: [],
               };
               onCommMessage(msg);
             }

--- a/apps/notebook/src/hooks/useDaemonKernel.ts
+++ b/apps/notebook/src/hooks/useDaemonKernel.ts
@@ -382,45 +382,62 @@ export function useDaemonKernel({
         }
 
         case "comm_sync": {
-          // Initial comm state sync from daemon for multi-window widget reconstruction
-          // Replay all comms as comm_open messages to the widget store
+          // Initial comm state sync from daemon for multi-window widget reconstruction.
+          // Replay all comms as comm_open messages to the widget store.
+          // Must await blob port — CRDT state contains {"$blob": "hash"} sentinels
+          // that need resolution to HTTP URLs before the widget framework sees them.
           const { onCommMessage } = callbacksRef.current;
           if (onCommMessage && broadcast.comms) {
-            logger.debug(
-              `[daemon-kernel] comm_sync: replaying ${broadcast.comms.length} comms`,
-            );
-            for (const comm of broadcast.comms) {
-              // Resolve {"$blob": "hash"} sentinels in state to blob HTTP URLs.
-              // The CRDT stores binary buffers as blob sentinels; the frontend
-              // fetches them directly from the blob server via GET /blob/{hash}.
-              const { state: resolvedState, bufferPaths } =
-                replaceSentinelsWithBlobUrls(
-                  comm.state as Record<string, unknown>,
+            const comms = broadcast.comms;
+            const replayComms = async () => {
+              let port = getBlobPort();
+              if (!port) {
+                port = await refreshBlobPort();
+              }
+              if (!port) {
+                logger.error(
+                  "[daemon-kernel] Blob port unavailable, cannot replay comm_sync",
                 );
+                return;
+              }
+              if (cancelled) return;
 
-              // Synthesize a comm_open message for each active comm
-              const msg: JupyterMessage = {
-                header: {
-                  msg_id: crypto.randomUUID(),
-                  msg_type: "comm_open",
-                  session: "",
-                  username: "kernel",
-                  date: new Date().toISOString(),
-                  version: "5.3",
-                },
-                metadata: {},
-                content: {
-                  comm_id: comm.comm_id,
-                  target_name: comm.target_name,
-                  data: {
-                    state: resolvedState,
-                    buffer_paths: bufferPaths,
+              logger.debug(
+                `[daemon-kernel] comm_sync: replaying ${comms.length} comms`,
+              );
+              const { onCommMessage: handler } = callbacksRef.current;
+              if (!handler) return;
+
+              for (const comm of comms) {
+                const { state: resolvedState, bufferPaths } =
+                  replaceSentinelsWithBlobUrls(
+                    comm.state as Record<string, unknown>,
+                  );
+
+                const msg: JupyterMessage = {
+                  header: {
+                    msg_id: crypto.randomUUID(),
+                    msg_type: "comm_open",
+                    session: "",
+                    username: "kernel",
+                    date: new Date().toISOString(),
+                    version: "5.3",
                   },
-                },
-                buffers: [],
-              };
-              onCommMessage(msg);
-            }
+                  metadata: {},
+                  content: {
+                    comm_id: comm.comm_id,
+                    target_name: comm.target_name,
+                    data: {
+                      state: resolvedState,
+                      buffer_paths: bufferPaths,
+                    },
+                  },
+                  buffers: [],
+                };
+                handler(msg);
+              }
+            };
+            replayComms();
           } else if (!onCommMessage) {
             logger.debug(
               "[daemon-kernel] comm_sync received but onCommMessage not set",

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -38,7 +38,7 @@ use tokio::sync::{broadcast, oneshot, watch, Mutex, RwLock};
 use notify_debouncer_mini::DebounceEventResult;
 
 use crate::blob_store::BlobStore;
-use crate::comm_state::CommState;
+use crate::comm_state::{CommSnapshot, CommState};
 use crate::connection::{self, NotebookFrameType};
 use crate::kernel_manager::{DenoLaunchedConfig, LaunchedEnvConfig, RoomKernel};
 use crate::markdown_assets::resolve_markdown_assets;
@@ -1710,12 +1710,39 @@ where
     }
 
     // Phase 1.5: Send comm state sync for widget reconstruction
-    // New clients need active comm channels to render widgets created before they connected
+    // New clients need active comm channels to render widgets created before they connected.
+    // Reads from RuntimeStateDoc (CRDT) instead of CommState. Binary buffers are stored
+    // as {"$blob": "hash"} sentinels in state — the frontend resolves them to blob URLs.
     {
-        let comms = room.comm_state.get_all().await;
-        if !comms.is_empty() {
+        let sd = room.state_doc.read().await;
+        let crdt_state = sd.read_state();
+        if !crdt_state.comms.is_empty() {
+            // Sort by seq (insertion order) for correct widget dependency replay
+            let mut entries: Vec<_> = crdt_state.comms.into_iter().collect();
+            entries.sort_by_key(|(_, e)| e.seq);
+
+            let comms: Vec<CommSnapshot> = entries
+                .into_iter()
+                .map(|(comm_id, entry)| CommSnapshot {
+                    comm_id,
+                    target_name: entry.target_name,
+                    state: entry.state,
+                    model_module: if entry.model_module.is_empty() {
+                        None
+                    } else {
+                        Some(entry.model_module)
+                    },
+                    model_name: if entry.model_name.is_empty() {
+                        None
+                    } else {
+                        Some(entry.model_name)
+                    },
+                    buffers: vec![],
+                })
+                .collect();
+
             info!(
-                "[notebook-sync] Sending comm_sync with {} active comms",
+                "[notebook-sync] Sending comm_sync with {} active comms (from CRDT)",
                 comms.len()
             );
             connection::send_typed_json_frame(


### PR DESCRIPTION
## Summary

- Switch CommSync broadcast to read from RuntimeStateDoc CRDT instead of in-memory CommState, removing one of two CommState readers toward #1378 elimination
- Binary buffers pass through as `{"$blob": "hash"}` sentinels — frontend resolves to blob HTTP URLs via `replaceSentinelsWithBlobUrls()`, no more piping raw bytes through Tauri
- Comm entries sorted by `seq` for correct widget dependency replay order

Closes #1376. Follow-ons: #1377, #1378, #1381.

## Test plan

- [x] `cargo build -p runtimed` — compiles clean
- [x] `cargo test -p runtimed` — all 21 tests pass
- [x] `cargo xtask lint --fix` — no issues
- [ ] Manual: open notebook with widgets, open second window — widgets appear via CommSync
- [ ] Manual: widget with binary buffers (e.g. image widget) renders in second window via blob URLs