### PR TITLE
chore(wasm): rebuild stale WASM bindings

### DIFF
--- a/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm
+++ b/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5dd861d8e3f5b12902f620cc78d8850c16a16bb26d815b7f4302a9bfd601ee0e
-size 1648081
+oid sha256:70b0cb85a6203dc6569df9b46583fffd6b21a58c8ab808f72aea3a9f834c1497
+size 1648281


### PR DESCRIPTION
## Summary

- Rebuild checked-in WASM artifacts that were out of date with the current notebook-doc crate
- Fixes sync failures (cells not found in document) in dev builds on worktrees that hadn't run `cargo xtask wasm`