### PR TITLE
refactor(deps): remove stale dep-sync code from local-kernel era

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -217,13 +217,9 @@ function AppContent() {
     hasDependencies: hasUvDependencies,
     isUvConfigured,
     loading: depsLoading,
-    syncedWhileRunning,
-    needsKernelRestart,
     addDependency,
     removeDependency,
     clearAllDependencies: clearAllUvDeps,
-    syncState,
-    syncNow,
     pyprojectInfo,
     pyprojectDeps,
     importFromPyproject,
@@ -235,10 +231,6 @@ function AppContent() {
     hasDependencies: hasCondaDependencies,
     isCondaConfigured,
     loading: condaDepsLoading,
-    syncing: condaSyncing,
-    syncState: condaSyncState,
-    syncedWhileRunning: condaSyncedWhileRunning,
-    needsKernelRestart: condaNeedsKernelRestart,
     addDependency: addCondaDependency,
     removeDependency: removeCondaDependency,
     clearAllDependencies: clearAllCondaDeps,
@@ -246,7 +238,6 @@ function AppContent() {
     setPython: setCondaPython,
     environmentYmlInfo,
     environmentYmlDeps,
-    syncNow: syncCondaNow,
     pixiInfo,
     importFromPixi,
   } = useCondaDependencies();
@@ -405,8 +396,7 @@ function AppContent() {
   }, [envSyncState, progressError, progressReset]);
 
   // Derive sync state from daemon's envSyncState for inline environments
-  // This overrides the disabled syncState from useDependencies/useCondaDependencies
-  // Also shows for prewarmed kernels when user adds inline deps (prewarmed→inline drift)
+  // Also shows for prewarmed kernels when user adds inline deps (prewarmed->inline drift)
   const uvDerivedSyncState: EnvSyncState | null = useMemo(() => {
     // Show for uv:inline or uv:prewarmed (when user adds deps to prewarmed kernel)
     const isUvEnv =
@@ -1182,15 +1172,12 @@ function AppContent() {
               channels={condaDependencies?.channels ?? []}
               python={condaDependencies?.python ?? null}
               loading={condaDepsLoading}
-              syncing={condaSyncing}
-              syncState={condaDerivedSyncState ?? condaSyncState}
-              syncedWhileRunning={condaSyncedWhileRunning}
-              needsKernelRestart={condaNeedsKernelRestart}
+              syncState={condaDerivedSyncState}
               onAdd={addCondaDependency}
               onRemove={removeCondaDependency}
               onSetChannels={setCondaChannels}
               onSetPython={setCondaPython}
-              onSyncNow={condaDerivedSyncState ? handleSyncDeps : syncCondaNow}
+              onSyncNow={handleSyncDeps}
               onRetryLaunch={tryStartKernel}
               envProgress={envProgress.envType === "conda" ? envProgress : null}
               onResetProgress={envProgress.reset}
@@ -1208,12 +1195,10 @@ function AppContent() {
               dependencies={dependencies?.dependencies ?? []}
               requiresPython={dependencies?.requires_python ?? null}
               loading={depsLoading}
-              syncedWhileRunning={syncedWhileRunning}
-              needsKernelRestart={needsKernelRestart}
               onAdd={addDependency}
               onRemove={removeDependency}
-              syncState={uvDerivedSyncState ?? syncState}
-              onSyncNow={uvDerivedSyncState ? handleSyncDeps : syncNow}
+              syncState={uvDerivedSyncState}
+              onSyncNow={handleSyncDeps}
               pyprojectInfo={pyprojectInfo}
               pyprojectDeps={pyprojectDeps}
               onImportFromPyproject={importFromPyproject}

--- a/apps/notebook/src/components/CondaDependencyHeader.tsx
+++ b/apps/notebook/src/components/CondaDependencyHeader.tsx
@@ -23,10 +23,7 @@ interface CondaDependencyHeaderProps {
   channels: string[];
   python: string | null;
   loading: boolean;
-  syncing: boolean;
   syncState: CondaSyncState | null;
-  syncedWhileRunning: boolean;
-  needsKernelRestart: boolean;
   onAdd: (pkg: string) => Promise<void>;
   onRemove: (pkg: string) => Promise<void>;
   onSetChannels: (channels: string[]) => Promise<void>;
@@ -54,10 +51,7 @@ export function CondaDependencyHeader({
   channels,
   python,
   loading,
-  syncing,
   syncState,
-  syncedWhileRunning,
-  needsKernelRestart,
   onAdd,
   onRemove,
   onSetChannels,
@@ -189,7 +183,7 @@ export function CondaDependencyHeader({
               <div className="flex items-center gap-1 shrink-0">
                 <button
                   type="button"
-                  disabled={syncing || loading}
+                  disabled={loading}
                   onClick={() => {
                     onResetProgress?.();
                     (onRetryLaunch ?? onSyncNow)();
@@ -220,29 +214,6 @@ export function CondaDependencyHeader({
           <div className="mb-3 flex items-center gap-2 rounded bg-emerald-500/10 px-2 py-1.5 text-xs text-emerald-700 dark:text-emerald-400">
             <Check className="h-3.5 w-3.5 shrink-0" />
             <span>Environment synced — dependencies are ready to use</span>
-          </div>
-        )}
-
-        {/* Sync notice */}
-        {syncedWhileRunning && (
-          <div className="mb-3 flex items-start gap-2 rounded bg-muted/80 px-2 py-1.5 text-xs text-muted-foreground">
-            <Info className="h-3.5 w-3.5 mt-0.5 shrink-0" />
-            <span>
-              Dependencies synced to environment. New packages can be imported
-              now. Re-initialize the environment if you updated existing
-              packages.
-            </span>
-          </div>
-        )}
-
-        {/* Kernel restart needed notice */}
-        {needsKernelRestart && (
-          <div className="mb-3 flex items-start gap-2 rounded bg-amber-500/10 px-2 py-1.5 text-xs text-amber-700 dark:text-amber-400">
-            <Info className="h-3.5 w-3.5 mt-0.5 shrink-0" />
-            <span>
-              Re-initialize the environment to use these dependencies. Conda
-              environments need a fresh environment after changes.
-            </span>
           </div>
         )}
 
@@ -298,7 +269,7 @@ export function CondaDependencyHeader({
         )}
 
         {/* Environment drift notice - kernel restart needed */}
-        {syncState?.status === "dirty" && !needsKernelRestart && (
+        {syncState?.status === "dirty" && (
           <div className="mb-3 flex items-center justify-between rounded bg-amber-500/10 px-2 py-1.5 text-xs text-amber-700 dark:text-amber-400">
             <div className="flex items-center gap-2">
               <Info className="h-3.5 w-3.5 shrink-0" />
@@ -309,12 +280,12 @@ export function CondaDependencyHeader({
             <button
               type="button"
               onClick={onSyncNow}
-              disabled={syncing}
+              disabled={loading}
               data-testid="deps-restart-button"
               className="flex items-center gap-1 rounded bg-amber-600 px-2 py-0.5 text-white text-xs font-medium hover:bg-amber-700 transition-colors disabled:opacity-50"
             >
               <RefreshCw
-                className={`h-3 w-3 ${syncing ? "animate-spin" : ""}`}
+                className={`h-3 w-3 ${loading ? "animate-spin" : ""}`}
               />
               Re-initialize
             </button>

--- a/apps/notebook/src/components/DependencyHeader.tsx
+++ b/apps/notebook/src/components/DependencyHeader.tsx
@@ -18,8 +18,6 @@ interface DependencyHeaderProps {
   dependencies: string[];
   requiresPython: string | null;
   loading: boolean;
-  syncedWhileRunning: boolean;
-  needsKernelRestart: boolean;
   onAdd: (pkg: string) => Promise<void>;
   onRemove: (pkg: string) => Promise<void>;
   // Environment sync state
@@ -42,8 +40,6 @@ export function DependencyHeader({
   dependencies,
   requiresPython,
   loading,
-  syncedWhileRunning,
-  needsKernelRestart,
   onAdd,
   onRemove,
   syncState,
@@ -92,29 +88,6 @@ export function DependencyHeader({
           <div className="mb-3 flex items-center gap-2 rounded bg-emerald-500/10 px-2 py-1.5 text-xs text-emerald-700 dark:text-emerald-400">
             <Check className="h-3.5 w-3.5 shrink-0" />
             <span>Environment synced — dependencies are ready to use</span>
-          </div>
-        )}
-
-        {/* Sync notice */}
-        {syncedWhileRunning && (
-          <div className="mb-3 flex items-start gap-2 rounded bg-muted/80 px-2 py-1.5 text-xs text-muted-foreground">
-            <Info className="h-3.5 w-3.5 mt-0.5 shrink-0" />
-            <span>
-              Dependencies synced to environment. New packages can be imported
-              now. Re-initialize the environment if you updated existing
-              packages.
-            </span>
-          </div>
-        )}
-
-        {/* Kernel restart needed notice */}
-        {needsKernelRestart && (
-          <div className="mb-3 flex items-start gap-2 rounded bg-amber-500/10 px-2 py-1.5 text-xs text-amber-700 dark:text-amber-400">
-            <Info className="h-3.5 w-3.5 mt-0.5 shrink-0" />
-            <span>
-              Re-initialize the environment to use these dependencies. The
-              current kernel wasn&apos;t started with dependency management.
-            </span>
           </div>
         )}
 

--- a/apps/notebook/src/hooks/useCondaDependencies.ts
+++ b/apps/notebook/src/hooks/useCondaDependencies.ts
@@ -50,14 +50,6 @@ export type CondaSyncState =
 
 export function useCondaDependencies() {
   const [loading, setLoading] = useState(false);
-  // Track if deps were synced to a running kernel (user may need to restart for some changes)
-  const [syncedWhileRunning, setSyncedWhileRunning] = useState(false);
-  // Track if user added deps but kernel isn't conda-managed (needs restart)
-  const [needsKernelRestart, setNeedsKernelRestart] = useState(false);
-  // Sync state for "Sync Now" button
-  const [syncState, setSyncState] = useState<CondaSyncState | null>(null);
-  // Whether a sync is in progress (separate from loading so input stays enabled)
-  const [syncing, setSyncing] = useState(false);
   // pixi.toml detection
   const [pixiInfo, setPixiInfo] = useState<PixiInfo | null>(null);
 
@@ -115,37 +107,6 @@ export function useCondaDependencies() {
     }
   }, []);
 
-  // Check sync state between declared deps and the running kernel
-  // NOTE: Hot-sync functionality was removed with local kernel mode.
-  // In daemon mode, the kernel restarts with new deps. Sync state is always null.
-  const checkSyncState = useCallback(async () => {
-    // Sync state not available in daemon mode - always null
-    setSyncState(null);
-  }, []);
-
-  // Try to sync deps to running kernel
-  // NOTE: Hot-sync to a running kernel was removed with local kernel mode.
-  // In daemon mode, users need to restart the kernel to pick up new deps.
-  const syncToKernel = useCallback(async (): Promise<boolean> => {
-    // Hot-sync not available in daemon mode - kernel restart required
-    logger.info(
-      "[conda] Hot-sync not available in daemon mode, restart kernel to apply changes",
-    );
-    setNeedsKernelRestart(true);
-    return false;
-  }, []);
-
-  // Explicit sync function for "Sync Now" button — does NOT block the input
-  const syncNow = useCallback(async (): Promise<boolean> => {
-    setSyncing(true);
-    try {
-      const synced = await syncToKernel();
-      return synced;
-    } finally {
-      setSyncing(false);
-    }
-  }, [syncToKernel]);
-
   const addDependency = useCallback(
     async (pkg: string) => {
       if (!pkg.trim()) return;
@@ -153,14 +114,13 @@ export function useCondaDependencies() {
       try {
         await addCondaDepWasm(pkg.trim());
         await resignTrust();
-        await checkSyncState();
       } catch (e) {
         logger.error("Failed to add conda dependency:", e);
       } finally {
         setLoading(false);
       }
     },
-    [resignTrust, checkSyncState],
+    [resignTrust],
   );
 
   const removeDependency = useCallback(
@@ -169,14 +129,13 @@ export function useCondaDependencies() {
       try {
         await removeCondaDepWasm(pkg);
         await resignTrust();
-        await checkSyncState();
       } catch (e) {
         logger.error("Failed to remove conda dependency:", e);
       } finally {
         setLoading(false);
       }
     },
-    [resignTrust, checkSyncState],
+    [resignTrust],
   );
 
   // Remove the entire conda dependency section from notebook metadata
@@ -191,13 +150,6 @@ export function useCondaDependencies() {
       setLoading(false);
     }
   }, [resignTrust]);
-
-  // Clear the synced notice (e.g., when kernel restarts)
-  const clearSyncNotice = useCallback(() => {
-    setSyncedWhileRunning(false);
-    setNeedsKernelRestart(false);
-    setSyncState(null);
-  }, []);
 
   const setChannels = useCallback(
     async (channels: string[]) => {
@@ -253,19 +205,13 @@ export function useCondaDependencies() {
     hasDependencies,
     isCondaConfigured,
     loading,
-    syncing,
-    syncState,
-    syncedWhileRunning,
-    needsKernelRestart,
     pixiInfo,
     addDependency,
     removeDependency,
     clearAllDependencies,
     setChannels,
     setPython,
-    syncNow,
     importFromPixi,
-    clearSyncNotice,
     // environment.yml support
     environmentYmlInfo,
     environmentYmlDeps,

--- a/apps/notebook/src/hooks/useDependencies.ts
+++ b/apps/notebook/src/hooks/useDependencies.ts
@@ -48,12 +48,6 @@ export interface PyProjectInfo {
 
 export function useDependencies() {
   const [loading, setLoading] = useState(false);
-  // Track if deps were synced to a running kernel (user may need to restart for some changes)
-  const [syncedWhileRunning, setSyncedWhileRunning] = useState(false);
-  // Track if user added deps but kernel isn't uv-managed (needs restart)
-  const [needsKernelRestart, setNeedsKernelRestart] = useState(false);
-  // Environment sync state (dirty detection)
-  const [syncState, setSyncState] = useState<EnvSyncState | null>(null);
 
   // pyproject.toml state
   const [pyprojectInfo, setPyprojectInfo] = useState<PyProjectInfo | null>(
@@ -62,14 +56,6 @@ export function useDependencies() {
   const [pyprojectDeps, setPyprojectDeps] = useState<PyProjectDeps | null>(
     null,
   );
-
-  // Check sync state between declared deps and running kernel
-  // NOTE: Hot-sync functionality was removed with local kernel mode.
-  // In daemon mode, the kernel restarts with new deps. Sync state is always null.
-  const checkSyncState = useCallback(async () => {
-    // Sync state not available in daemon mode - always null
-    setSyncState(null);
-  }, []);
 
   // Detect pyproject on mount
   useEffect(() => {
@@ -97,33 +83,6 @@ export function useDependencies() {
     }
   }, []);
 
-  // Try to sync deps to running kernel
-  // NOTE: Hot-sync to a running kernel was removed with local kernel mode.
-  // In daemon mode, users need to restart the kernel to pick up new deps.
-  const syncToKernel = useCallback(async (): Promise<boolean> => {
-    // Hot-sync not available in daemon mode - kernel restart required
-    logger.info(
-      "[deps] Hot-sync not available in daemon mode, restart kernel to apply changes",
-    );
-    setNeedsKernelRestart(true);
-    return false;
-  }, []);
-
-  // Explicit sync function for "Sync Now" button
-  const syncNow = useCallback(async (): Promise<boolean> => {
-    setLoading(true);
-    try {
-      const synced = await syncToKernel();
-      if (synced) {
-        // Refresh sync state after successful sync
-        await checkSyncState();
-      }
-      return synced;
-    } finally {
-      setLoading(false);
-    }
-  }, [syncToKernel, checkSyncState]);
-
   const addDependency = useCallback(
     async (pkg: string) => {
       if (!pkg.trim()) return;
@@ -131,14 +90,13 @@ export function useDependencies() {
       try {
         await addUvDependency(pkg.trim());
         await resignTrust();
-        await checkSyncState();
       } catch (e) {
         logger.error("Failed to add dependency:", e);
       } finally {
         setLoading(false);
       }
     },
-    [resignTrust, checkSyncState],
+    [resignTrust],
   );
 
   const removeDependency = useCallback(
@@ -147,14 +105,13 @@ export function useDependencies() {
       try {
         await removeUvDependency(pkg);
         await resignTrust();
-        await checkSyncState();
       } catch (e) {
         logger.error("Failed to remove dependency:", e);
       } finally {
         setLoading(false);
       }
     },
-    [resignTrust, checkSyncState],
+    [resignTrust],
   );
 
   // Remove the entire uv dependency section from notebook metadata
@@ -169,12 +126,6 @@ export function useDependencies() {
       setLoading(false);
     }
   }, [resignTrust]);
-
-  // Clear the synced notice (e.g., when kernel restarts)
-  const clearSyncNotice = useCallback(() => {
-    setSyncedWhileRunning(false);
-    setNeedsKernelRestart(false);
-  }, []);
 
   const setRequiresPython = useCallback(
     async (version: string | null) => {
@@ -262,19 +213,12 @@ export function useDependencies() {
     hasDependencies,
     isUvConfigured,
     loading,
-    syncedWhileRunning,
-    needsKernelRestart,
 
     addDependency,
     removeDependency,
     clearAllDependencies,
     setRequiresPython,
     setPrerelease,
-    clearSyncNotice,
-    // Environment sync state
-    syncState,
-    syncNow,
-    checkSyncState,
     // pyproject.toml support
     pyprojectInfo,
     pyprojectDeps,


### PR DESCRIPTION
## Summary
Closes #669

- Remove dead `syncToKernel`, `checkSyncState`, `syncNow`, `needsKernelRestart`, `syncedWhileRunning`, and `clearSyncNotice` from `useDependencies` and `useCondaDependencies` hooks
- Remove corresponding dead props and JSX from `DependencyHeader` and `CondaDependencyHeader`
- Simplify `App.tsx` prop passing — daemon-derived sync state is now the only path (no fallback to dead hook state)

These were vestiges of the removed local-kernel hot-sync flow. The actual sync now lives in `App.tsx`'s `handleSyncDeps` callback backed by `RuntimeStateDoc`.

## Test plan
- [ ] TypeScript compiles with no errors
- [ ] Lint passes
- [ ] UV dependency add/remove still works in the UI
- [ ] Conda dependency add/remove still works
- [ ] Sync state banners still appear when deps drift
- [ ] Re-initialize button still works