### PR TITLE
feat(output): add GeoJSON renderer with Leaflet

### DIFF
--- a/apps/notebook/vite-plugin-isolated-renderer.ts
+++ b/apps/notebook/vite-plugin-isolated-renderer.ts
@@ -81,6 +81,8 @@ export function isolatedRendererPlugin(
               "vega-raw": path.join(nodeModules, "vega/build/vega.min.js"),
               "vega-lite-raw": path.join(nodeModules, "vega-lite/build/vega-lite.min.js"),
               "vega-embed-raw": path.join(nodeModules, "vega-embed/build/vega-embed.min.js"),
+              "leaflet-js-raw": path.join(nodeModules, "leaflet/dist/leaflet.js"),
+              "leaflet-css-raw": path.join(nodeModules, "leaflet/dist/leaflet.css"),
             };
             const filePath = mapping[source];
             if (filePath) return `${filePath}?raw`;

--- a/apps/notebook/vite.config.ts
+++ b/apps/notebook/vite.config.ts
@@ -22,6 +22,8 @@ function vegaRawPlugin(nodeModulesDir: string): Plugin {
       nodeModulesDir,
       "vega-embed/build/vega-embed.min.js",
     ),
+    "leaflet-js-raw": path.join(nodeModulesDir, "leaflet/dist/leaflet.js"),
+    "leaflet-css-raw": path.join(nodeModulesDir, "leaflet/dist/leaflet.css"),
   };
   return {
     name: "vega-raw-resolve",

--- a/package.json
+++ b/package.json
@@ -54,12 +54,10 @@
     "cmdk": "^1.1.1",
     "escape-carriage": "^1.3.1",
     "katex": "^0.16.28",
+    "leaflet": "^1.9.4",
     "lezer-toml": "^1.0.0",
     "lucide-react": "^0.513.0",
     "plotly.js-dist-min": "^3.4.0",
-    "vega": "^6.2.0",
-    "vega-embed": "^7.1.0",
-    "vega-lite": "^6.4.2",
     "radix-ui": "^1.4.3",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
@@ -69,7 +67,10 @@
     "rehype-raw": "^7.0.0",
     "remark-gfm": "^4.0.1",
     "remark-math": "^6.0.0",
-    "tailwind-merge": "^3.4.0"
+    "tailwind-merge": "^3.4.0",
+    "vega": "^6.2.0",
+    "vega-embed": "^7.1.0",
+    "vega-lite": "^6.4.2"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.1.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,6 +137,9 @@ importers:
       katex:
         specifier: ^0.16.28
         version: 0.16.38
+      leaflet:
+        specifier: ^1.9.4
+        version: 1.9.4
       lezer-toml:
         specifier: ^1.0.0
         version: 1.0.0
@@ -3587,6 +3590,9 @@ packages:
   lazystream@1.0.1:
     resolution: {integrity: sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==}
     engines: {node: '>= 0.6.3'}
+
+  leaflet@1.9.4:
+    resolution: {integrity: sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==}
 
   lezer-toml@1.0.0:
     resolution: {integrity: sha512-WRzDzRWuXUU2L0RLUSkb5o9nRhMntko8Z2PF6QIHZV+y81RNSZ3XsmECyevYHazA5S9Q4iRLM7njyXNngzILyQ==}
@@ -8775,6 +8781,8 @@ snapshots:
   lazystream@1.0.1:
     dependencies:
       readable-stream: 2.3.8
+
+  leaflet@1.9.4: {}
 
   lezer-toml@1.0.0:
     dependencies:

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -121,6 +121,7 @@ const ISOLATED_MIME_TYPES = new Set([
   "image/svg+xml",
   "application/vnd.jupyter.widget-view+json",
   "application/vnd.plotly.v1+json",
+  "application/geo+json",
 ]);
 
 /**

--- a/src/components/isolated/iframe-libraries.ts
+++ b/src/components/isolated/iframe-libraries.ts
@@ -20,6 +20,7 @@ import { isVegaMimeType } from "@/components/outputs/vega-mime";
  */
 const MIME_LIBRARIES: Record<string, string> = {
   "application/vnd.plotly.v1+json": "plotly",
+  "application/geo+json": "leaflet",
 };
 
 function libraryForMime(mime: string): string | undefined {
@@ -58,6 +59,15 @@ function loadLibraryCode(name: string): Promise<string> {
           import("vega-embed-raw"),
         ]);
         return `${vegaMod.default}\n${vegaLiteMod.default}\n${vegaEmbedMod.default}`;
+      }
+      case "leaflet": {
+        // Load Leaflet JS and CSS. Inject CSS via a <style> tag before the JS runs.
+        const [leafletJs, leafletCss] = await Promise.all([
+          import("leaflet-js-raw"),
+          import("leaflet-css-raw"),
+        ]);
+        const cssInjection = `(function(){var s=document.createElement('style');s.textContent=${JSON.stringify(leafletCss.default)};document.head.appendChild(s);})();`;
+        return `${cssInjection}\n${leafletJs.default}`;
       }
       default:
         throw new Error(`Unknown iframe library: ${name}`);

--- a/src/components/outputs/geojson-output.tsx
+++ b/src/components/outputs/geojson-output.tsx
@@ -26,7 +26,6 @@ export function GeoJsonOutput({ data, className }: GeoJsonOutputProps) {
 
     // Create the map
     const map = L.map(el, {
-      // Disable zoom animation for snappier feel in a notebook cell
       zoomAnimation: true,
     });
 

--- a/src/components/outputs/geojson-output.tsx
+++ b/src/components/outputs/geojson-output.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useRef } from "react";
+import { cn } from "@/lib/utils";
+
+interface GeoJsonOutputProps {
+  data: Record<string, unknown>;
+  className?: string;
+}
+
+/**
+ * Render a GeoJSON map inside an isolated iframe using Leaflet.
+ *
+ * This component expects `window.L` (Leaflet) to be available -- it is
+ * injected by the parent app via the iframe library loader before the
+ * render message is sent.
+ */
+export function GeoJsonOutput({ data, className }: GeoJsonOutputProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    // biome-ignore lint/suspicious/noExplicitAny: Leaflet is injected as a global
+    const L = (window as any).L;
+    if (!containerRef.current || !data || !L) return;
+
+    const el = containerRef.current;
+    const isDark = document.documentElement.classList.contains("dark");
+
+    // Create the map
+    const map = L.map(el, {
+      // Disable zoom animation for snappier feel in a notebook cell
+      zoomAnimation: true,
+    });
+
+    // Tile layer -- CartoDB tiles work without an API key
+    const tileUrl = isDark
+      ? "https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png"
+      : "https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png";
+
+    L.tileLayer(tileUrl, {
+      attribution:
+        '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/">CARTO</a>',
+      maxZoom: 19,
+    }).addTo(map);
+
+    // Style features
+    const featureColor = isDark ? "#818cf8" : "#4f46e5";
+    const geojsonLayer = L.geoJSON(data, {
+      style: {
+        color: featureColor,
+        weight: 2,
+        fillOpacity: 0.25,
+        fillColor: featureColor,
+      },
+      pointToLayer: (
+        _feature: unknown,
+        latlng: { lat: number; lng: number },
+      ) => {
+        return L.circleMarker(latlng, {
+          radius: 6,
+          color: featureColor,
+          weight: 2,
+          fillOpacity: 0.5,
+          fillColor: featureColor,
+        });
+      },
+    }).addTo(map);
+
+    // Fit to bounds of the GeoJSON features
+    const bounds = geojsonLayer.getBounds();
+    if (bounds.isValid()) {
+      map.fitBounds(bounds, { padding: [20, 20] });
+    } else {
+      // Fallback: show the whole world
+      map.setView([0, 0], 2);
+    }
+
+    // Handle resize so the map tiles render correctly
+    const resizeObserver = new ResizeObserver(() => {
+      map.invalidateSize();
+    });
+    resizeObserver.observe(el);
+
+    // React to theme changes
+    const themeObserver = new MutationObserver(() => {
+      const nowDark = document.documentElement.classList.contains("dark");
+      const newTileUrl = nowDark
+        ? "https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png"
+        : "https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png";
+      const newColor = nowDark ? "#818cf8" : "#4f46e5";
+
+      // Replace tile layer
+      map.eachLayer((layer: { _url?: string; remove: () => void }) => {
+        if (layer._url) layer.remove();
+      });
+      L.tileLayer(newTileUrl, {
+        attribution:
+          '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/">CARTO</a>',
+        maxZoom: 19,
+      }).addTo(map);
+
+      // Update GeoJSON layer style
+      geojsonLayer.setStyle({
+        color: newColor,
+        fillColor: newColor,
+      });
+    });
+    themeObserver.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class"],
+    });
+
+    return () => {
+      themeObserver.disconnect();
+      resizeObserver.disconnect();
+      map.remove();
+    };
+  }, [data]);
+
+  if (!data) return null;
+
+  return (
+    <div
+      ref={containerRef}
+      data-slot="geojson-output"
+      className={cn("not-prose py-2 max-w-full", className)}
+      style={{ height: "400px", width: "100%" }}
+    />
+  );
+}

--- a/src/isolated-renderer/index.tsx
+++ b/src/isolated-renderer/index.tsx
@@ -36,6 +36,7 @@ import { HtmlOutput } from "@/components/outputs/html-output";
 import { ImageOutput } from "@/components/outputs/image-output";
 import { JsonOutput } from "@/components/outputs/json-output";
 import { MarkdownOutput } from "@/components/outputs/markdown-output";
+import { GeoJsonOutput } from "@/components/outputs/geojson-output";
 import { PlotlyOutput } from "@/components/outputs/plotly-output";
 import { VegaOutput } from "@/components/outputs/vega-output";
 import { isVegaMimeType } from "@/components/outputs/vega-mime";
@@ -316,6 +317,13 @@ function OutputRenderer({ payload }: { payload: RenderPayload }) {
     const plotlyData =
       typeof content === "string" ? JSON.parse(content) : content;
     return <PlotlyOutput data={plotlyData} />;
+  }
+
+  // GeoJSON
+  if (mimeType === "application/geo+json") {
+    const geojsonData =
+      typeof content === "string" ? JSON.parse(content) : content;
+    return <GeoJsonOutput data={geojsonData} />;
   }
 
   // Vega / Vega-Lite (any version, both +json and .json suffixes)

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -18,6 +18,16 @@ declare module "vega-embed-raw" {
   export default content;
 }
 
+// Leaflet JS and CSS loaded as raw strings via vegaRawPlugin (see vite.config.ts).
+declare module "leaflet-js-raw" {
+  const content: string;
+  export default content;
+}
+declare module "leaflet-css-raw" {
+  const content: string;
+  export default content;
+}
+
 // lezer-toml type declaration (package doesn't properly export types)
 declare module "lezer-toml" {
   import type { LRParser } from "@lezer/lr";

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,6 +17,8 @@ function vegaRawPlugin(nodeModulesDir: string): Plugin {
       nodeModulesDir,
       "vega-embed/build/vega-embed.min.js",
     ),
+    "leaflet-js-raw": path.join(nodeModulesDir, "leaflet/dist/leaflet.js"),
+    "leaflet-css-raw": path.join(nodeModulesDir, "leaflet/dist/leaflet.css"),
   };
   return {
     name: "vega-raw-resolve",


### PR DESCRIPTION
## Summary
Closes #1257

Adds rendering support for `application/geo+json` MIME type outputs using Leaflet in the iframe sandbox.

- Route `application/geo+json` to iframe isolation (`ISOLATED_MIME_TYPES`)
- Inject Leaflet JS + CSS into the iframe via the library injection system (self-contained CSS via dynamic `<style>` tag)
- New `GeoJsonOutput` component with auto-fit bounds, dark/light CartoDB tile layers, circle markers for points, and resize handling
- Uses CartoDB tile provider (no API key required)
- Verified MIME classification: `application/geo+json` is correctly handled as JSON (not binary) via the existing `+json` suffix logic in all three `is_binary_mime`/`mime_kind`/`isBinaryMime` implementations

## Test plan
- [x] TypeScript compiles (no new errors)
- [x] Lint passes (Biome, ruff)
- [x] Existing media-router tests pass (40/40), including GeoJSON MIME selection test
- [ ] GeoJSON output from a Python kernel renders as an interactive map
- [ ] Dark mode switches tile layer
- [ ] Map auto-fits to feature bounds
- [ ] Map resizes correctly with cell
- [ ] Bundle size impact is reasonable (Leaflet is ~40KB gzipped)