### PR TITLE
fix(build): add build.rs stub for runt-mcp _output.html in fresh worktrees

### DIFF
--- a/crates/runt-mcp/build.rs
+++ b/crates/runt-mcp/build.rs
@@ -1,0 +1,28 @@
+//! Ensure `assets/_output.html` exists so `include_str!` in `resources.rs`
+//! never fails during `cargo check` or `cargo build` in a fresh worktree.
+//!
+//! The real asset is built by `apps/mcp-app/build-html.js` (via `cargo xtask
+//! build` or `pnpm build` in `apps/mcp-app`). This build script only creates
+//! a minimal placeholder when the file is missing.
+
+use std::path::Path;
+
+fn main() {
+    let asset = Path::new("assets/_output.html");
+
+    // Re-run if the file is created or deleted externally.
+    println!("cargo:rerun-if-changed=assets/_output.html");
+
+    if !asset.exists() {
+        std::fs::create_dir_all("assets").ok();
+        std::fs::write(
+            asset,
+            concat!(
+                "<!DOCTYPE html><html><head><meta charset=\"utf-8\"></head>",
+                "<body><p>Placeholder &mdash; run <code>cargo xtask build</code> ",
+                "to generate the real output renderer.</p></body></html>",
+            ),
+        )
+        .ok();
+    }
+}


### PR DESCRIPTION
## Summary

`include_str!("../assets/_output.html")` in `crates/runt-mcp/src/resources.rs` fails during `cargo check` or `cargo build` in a fresh worktree (or any checkout where `cargo xtask build` hasn't been run) because the asset is gitignored and only generated by `apps/mcp-app/build-html.js`.

This adds a `build.rs` to `runt-mcp` that creates a minimal placeholder HTML when the file is missing, so any `cargo` invocation succeeds in a fresh checkout. The real asset is still generated by `cargo xtask build` or `pnpm build` in `apps/mcp-app`.

This was discovered when agent worktrees (`.claude/worktrees/`) ran `cargo xtask lint` — the Rust clippy step failed because the asset didn't exist.

## Test plan
- [x] `cargo check -p runt-mcp` passes with real asset present
- [x] `cargo check -p runt-mcp` passes after deleting `_output.html` (stub generated)
- [x] `cargo xtask lint` passes
- [x] Stub is overwritten when real build runs
- [ ] Worktree agent can `cargo check` without manual `xtask build` first