### PR TITLE
fix(build): refuse placeholder _output.html in release builds

### DIFF
--- a/crates/runt-mcp/build.rs
+++ b/crates/runt-mcp/build.rs
@@ -4,6 +4,9 @@
 //! The real asset is built by `apps/mcp-app/build-html.js` (via `cargo xtask
 //! build` or `pnpm build` in `apps/mcp-app`). This build script only creates
 //! a minimal placeholder when the file is missing.
+//!
+//! **Release builds refuse the placeholder** — shipping a stub instead of the
+//! real output renderer would be a silent regression.
 
 use std::path::Path;
 
@@ -13,7 +16,15 @@ fn main() {
     // Re-run if the file is created or deleted externally.
     println!("cargo:rerun-if-changed=assets/_output.html");
 
+    let is_release = std::env::var("PROFILE").unwrap_or_default() == "release";
+
     if !asset.exists() {
+        if is_release {
+            panic!(
+                "assets/_output.html is missing — cannot build runt-mcp in release mode \
+                 without the real output renderer. Run `cargo xtask build` first."
+            );
+        }
         std::fs::create_dir_all("assets").ok();
         std::fs::write(
             asset,


### PR DESCRIPTION
## Summary

Follow-up to #1387. The build.rs stub is fine for `cargo check` in dev worktrees, but shipping a placeholder instead of the real output renderer would be a silent regression.

Release builds now panic with a clear error directing the developer to run `cargo xtask build` first. Debug builds still get the stub as before.

## Test plan
- [x] `cargo check -p runt-mcp` (debug) still succeeds with stub
- [x] `cargo check -p runt-mcp --release` fails with clear error when asset missing
- [x] `cargo xtask lint` passes