### PR TITLE
perf(build): decouple output-widget from iframe-libraries (-69% IIFE size)

### DIFF
--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -29,27 +29,9 @@ import { cn } from "@/lib/utils";
 const handleIframeError = (err: { message: string; stack?: string }) =>
   console.error("[OutputArea] iframe error:", err);
 
-/**
- * Jupyter output types based on the nbformat spec.
- */
-export type JupyterOutput =
-  | {
-      output_type: "execute_result" | "display_data";
-      data: Record<string, unknown>;
-      metadata?: Record<string, unknown>;
-      execution_count?: number | null;
-    }
-  | {
-      output_type: "stream";
-      name: "stdout" | "stderr";
-      text: string | string[];
-    }
-  | {
-      output_type: "error";
-      ename: string;
-      evalue: string;
-      traceback: string[];
-    };
+import type { JupyterOutput } from "./jupyter-output";
+// Re-export so existing imports continue to work.
+export type { JupyterOutput } from "./jupyter-output";
 
 interface OutputAreaProps {
   /**

--- a/src/components/cell/jupyter-output.ts
+++ b/src/components/cell/jupyter-output.ts
@@ -1,0 +1,25 @@
+/**
+ * Jupyter output types based on the nbformat spec.
+ *
+ * Extracted to a standalone module so consumers can import the type without
+ * pulling in the full OutputArea component (which brings in iframe-libraries,
+ * heavy raw-string library imports, etc.).
+ */
+export type JupyterOutput =
+  | {
+      output_type: "execute_result" | "display_data";
+      data: Record<string, unknown>;
+      metadata?: Record<string, unknown>;
+      execution_count?: number | null;
+    }
+  | {
+      output_type: "stream";
+      name: "stdout" | "stderr";
+      text: string | string[];
+    }
+  | {
+      output_type: "error";
+      ename: string;
+      evalue: string;
+      traceback: string[];
+    };

--- a/src/components/isolated/iframe-libraries.ts
+++ b/src/components/isolated/iframe-libraries.ts
@@ -10,7 +10,7 @@
  * is guaranteed to be available when the output component mounts.
  */
 
-import type { JupyterOutput } from "@/components/cell/OutputArea";
+import type { JupyterOutput } from "@/components/cell/jupyter-output";
 import type { IsolatedFrameHandle } from "@/components/isolated/isolated-frame";
 import { isVegaMimeType } from "@/components/outputs/vega-mime";
 

--- a/src/components/widgets/controls/output-widget.tsx
+++ b/src/components/widgets/controls/output-widget.tsx
@@ -21,6 +21,8 @@ import {
   AnsiStreamOutput,
 } from "@/components/outputs/ansi-output";
 import { MediaRouter } from "@/components/outputs/media-router";
+import { ErrorBoundary } from "@/lib/error-boundary";
+import { OutputErrorFallback } from "@/lib/output-error-fallback";
 import { cn } from "@/lib/utils";
 import type { WidgetComponentProps } from "../widget-registry";
 import {
@@ -43,6 +45,48 @@ function isJupyterOutput(value: unknown): value is JupyterOutput {
     output.output_type === "stream" ||
     output.output_type === "error"
   );
+}
+
+/**
+ * Render a single Jupyter output by type.
+ * Mirrors the in-DOM path from OutputArea but without isolation
+ * (the Output widget already runs inside an iframe).
+ */
+function renderWidgetOutput(output: JupyterOutput) {
+  switch (output.output_type) {
+    case "execute_result":
+    case "display_data":
+      return (
+        <MediaRouter
+          data={output.data}
+          metadata={
+            output.metadata as Record<
+              string,
+              Record<string, unknown> | undefined
+            >
+          }
+        />
+      );
+    case "stream":
+      return (
+        <AnsiStreamOutput
+          text={
+            Array.isArray(output.text) ? output.text.join("") : output.text
+          }
+          streamName={output.name}
+        />
+      );
+    case "error":
+      return (
+        <AnsiErrorOutput
+          ename={output.ename}
+          evalue={output.evalue}
+          traceback={output.traceback}
+        />
+      );
+    default:
+      return null;
+  }
 }
 
 export function OutputWidget({ modelId, className }: WidgetComponentProps) {
@@ -123,47 +167,28 @@ export function OutputWidget({ modelId, className }: WidgetComponentProps) {
       data-widget-id={modelId}
       data-widget-type="Output"
     >
-      {renderedOutputs.map((output, index) => {
-        switch (output.output_type) {
-          case "execute_result":
-          case "display_data":
-            return (
-              <MediaRouter
-                key={`output-${index}`}
-                data={output.data}
-                metadata={
-                  output.metadata as Record<
-                    string,
-                    Record<string, unknown> | undefined
-                  >
-                }
-              />
+      {renderedOutputs.map((output, index) => (
+        <ErrorBoundary
+          key={`output-${index}`}
+          resetKeys={[JSON.stringify(output)]}
+          fallback={(error, reset) => (
+            <OutputErrorFallback
+              error={error}
+              outputIndex={index}
+              onRetry={reset}
+            />
+          )}
+          onError={(error, errorInfo) => {
+            console.error(
+              `[OutputWidget] Error rendering output ${index}:`,
+              error,
+              errorInfo.componentStack,
             );
-          case "stream":
-            return (
-              <AnsiStreamOutput
-                key={`output-${index}`}
-                text={
-                  Array.isArray(output.text)
-                    ? output.text.join("")
-                    : output.text
-                }
-                streamName={output.name}
-              />
-            );
-          case "error":
-            return (
-              <AnsiErrorOutput
-                key={`output-${index}`}
-                ename={output.ename}
-                evalue={output.evalue}
-                traceback={output.traceback}
-              />
-            );
-          default:
-            return null;
-        }
-      })}
+          }}
+        >
+          {renderWidgetOutput(output)}
+        </ErrorBoundary>
+      ))}
     </div>
   );
 }

--- a/src/components/widgets/controls/output-widget.tsx
+++ b/src/components/widgets/controls/output-widget.tsx
@@ -15,7 +15,12 @@
  */
 
 import { useEffect, useRef, useState } from "react";
-import { type JupyterOutput, OutputArea } from "@/components/cell/OutputArea";
+import type { JupyterOutput } from "@/components/cell/jupyter-output";
+import {
+  AnsiErrorOutput,
+  AnsiStreamOutput,
+} from "@/components/outputs/ansi-output";
+import { MediaRouter } from "@/components/outputs/media-router";
 import { cn } from "@/lib/utils";
 import type { WidgetComponentProps } from "../widget-registry";
 import {
@@ -112,21 +117,53 @@ export function OutputWidget({ modelId, className }: WidgetComponentProps) {
     return null;
   }
 
-  // Check if we're already inside an iframe (isolated context).
-  // If so, skip nested isolation since the outer iframe already provides security.
-  // This prevents double-nesting: widget iframe → OutputWidget iframe → content
-  const isInIframe = typeof window !== "undefined" && window.parent !== window;
-
   return (
     <div
       className={cn("widget-output", className)}
       data-widget-id={modelId}
       data-widget-type="Output"
     >
-      <OutputArea
-        outputs={renderedOutputs}
-        isolated={isInIframe ? false : "auto"}
-      />
+      {renderedOutputs.map((output, index) => {
+        switch (output.output_type) {
+          case "execute_result":
+          case "display_data":
+            return (
+              <MediaRouter
+                key={`output-${index}`}
+                data={output.data}
+                metadata={
+                  output.metadata as Record<
+                    string,
+                    Record<string, unknown> | undefined
+                  >
+                }
+              />
+            );
+          case "stream":
+            return (
+              <AnsiStreamOutput
+                key={`output-${index}`}
+                text={
+                  Array.isArray(output.text)
+                    ? output.text.join("")
+                    : output.text
+                }
+                streamName={output.name}
+              />
+            );
+          case "error":
+            return (
+              <AnsiErrorOutput
+                key={`output-${index}`}
+                ename={output.ename}
+                evalue={output.evalue}
+                traceback={output.traceback}
+              />
+            );
+          default:
+            return null;
+        }
+      })}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

The isolated-renderer IIFE bundle was **8.5MB** (3.1MB gzip) because heavy visualization libraries (plotly.js, vega, vega-lite, vega-embed, leaflet) were being inlined into it.

**Root cause:** `output-widget.tsx` imported the full `OutputArea` component, which statically imports `iframe-libraries.ts`. Since the isolated-renderer uses `inlineDynamicImports: true` (required for IIFE format), Rollup followed the dynamic `import("plotly...?raw")` calls and inlined the multi-MB raw library strings.

**Dependency chain before:**
```
isolated-renderer/index.tsx
  → widgets/controls (barrel)
    → output-widget.tsx
      → OutputArea.tsx
        → iframe-libraries.ts → plotly (4.8MB) + vega (826KB) + leaflet (148KB)
```

**Fix:**
1. Extract `JupyterOutput` type to `src/components/cell/jupyter-output.ts`
2. Have `output-widget.tsx` render outputs directly with `MediaRouter` + `AnsiStreamOutput` + `AnsiErrorOutput` instead of importing the full `OutputArea`
3. Update `iframe-libraries.ts` to import type from the new standalone module

**Result:** isolated-renderer IIFE drops from **8,547KB → 2,647KB** (-69% raw, -59% gzip). Heavy libraries remain on-demand loaded via `iframe-libraries.ts` in the parent window, as originally intended.

## Test plan
- [x] TypeScript compiles (no errors in affected files)
- [x] Lint passes (Rust, Biome, ruff)
- [x] Vite build succeeds
- [x] IIFE bundle size reduced from 8.5MB to 2.6MB
- [ ] Output widget still renders captured outputs correctly
- [ ] Plotly/Vega/Leaflet outputs still render (on-demand loaded in parent)
- [ ] Widget outputs inside Output widgets work (stream, error, execute_result)