### PR TITLE
feat(output): add text/latex MIME type renderer with KaTeX

### DIFF
--- a/src/components/outputs/math-output.tsx
+++ b/src/components/outputs/math-output.tsx
@@ -1,5 +1,5 @@
 import katex from "katex";
-import { useMemo } from "react";
+import { useEffect, useRef } from "react";
 import { cn } from "@/lib/utils";
 
 import "katex/dist/katex.min.css";
@@ -23,7 +23,6 @@ function parseLatex(raw: string): { latex: string; displayMode: boolean } {
   if (trimmed.startsWith("$") && trimmed.endsWith("$")) {
     return { latex: trimmed.slice(1, -1).trim(), displayMode: true };
   }
-  // \begin{...} environments and bare LaTeX — display mode
   return { latex: trimmed, displayMode: true };
 }
 
@@ -34,33 +33,17 @@ function parseLatex(raw: string): { latex: string; displayMode: boolean } {
  * KaTeX output is safe static HTML — no iframe isolation needed.
  */
 export function MathOutput({ content, className }: MathOutputProps) {
-  const html = useMemo(() => {
-    if (!content.trim()) return null;
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!ref.current || !content.trim()) return;
     const { latex, displayMode } = parseLatex(content);
-    try {
-      return katex.renderToString(latex, {
-        displayMode,
-        throwOnError: false,
-        trust: true,
-      });
-    } catch {
-      return null;
-    }
+    katex.render(latex, ref.current, {
+      displayMode,
+      throwOnError: false,
+      trust: true,
+    });
   }, [content]);
 
-  if (!html) {
-    return (
-      <pre className={cn("whitespace-pre-wrap text-sm", className)}>
-        {content}
-      </pre>
-    );
-  }
-
-  return (
-    <div
-      data-slot="math-output"
-      className={cn("py-1", className)}
-      dangerouslySetInnerHTML={{ __html: html }}
-    />
-  );
+  return <div data-slot="math-output" className={cn("py-1", className)} ref={ref} />;
 }

--- a/src/components/outputs/math-output.tsx
+++ b/src/components/outputs/math-output.tsx
@@ -1,0 +1,66 @@
+import katex from "katex";
+import { useMemo } from "react";
+import { cn } from "@/lib/utils";
+
+import "katex/dist/katex.min.css";
+
+interface MathOutputProps {
+  /** Raw LaTeX string, possibly wrapped in $...$ or $$...$$ delimiters */
+  content: string;
+  className?: string;
+}
+
+/**
+ * Strip $/$$ delimiters and detect display mode.
+ * Sympy wraps in `$\displaystyle ...$`, other CAS may use `$$...$$`.
+ * Raw LaTeX without delimiters defaults to display mode.
+ */
+function parseLatex(raw: string): { latex: string; displayMode: boolean } {
+  const trimmed = raw.trim();
+  if (trimmed.startsWith("$$") && trimmed.endsWith("$$")) {
+    return { latex: trimmed.slice(2, -2).trim(), displayMode: true };
+  }
+  if (trimmed.startsWith("$") && trimmed.endsWith("$")) {
+    return { latex: trimmed.slice(1, -1).trim(), displayMode: true };
+  }
+  // \begin{...} environments and bare LaTeX — display mode
+  return { latex: trimmed, displayMode: true };
+}
+
+/**
+ * Renders a `text/latex` MIME output using KaTeX.
+ *
+ * Used for display_data / execute_result from CAS kernels (sympy, Sage, etc.).
+ * KaTeX output is safe static HTML — no iframe isolation needed.
+ */
+export function MathOutput({ content, className }: MathOutputProps) {
+  const html = useMemo(() => {
+    if (!content.trim()) return null;
+    const { latex, displayMode } = parseLatex(content);
+    try {
+      return katex.renderToString(latex, {
+        displayMode,
+        throwOnError: false,
+        trust: true,
+      });
+    } catch {
+      return null;
+    }
+  }, [content]);
+
+  if (!html) {
+    return (
+      <pre className={cn("whitespace-pre-wrap text-sm", className)}>
+        {content}
+      </pre>
+    );
+  }
+
+  return (
+    <div
+      data-slot="math-output"
+      className={cn("py-1", className)}
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  );
+}

--- a/src/components/outputs/media-router.tsx
+++ b/src/components/outputs/media-router.tsx
@@ -21,6 +21,9 @@ const SvgOutput = lazy(() =>
 const JsonOutput = lazy(() =>
   import("./json-output").then((m) => ({ default: m.JsonOutput })),
 );
+const MathOutput = lazy(() =>
+  import("./math-output").then((m) => ({ default: m.MathOutput })),
+);
 
 /**
  * Check if the current window is inside an iframe
@@ -57,9 +60,10 @@ export const DEFAULT_PRIORITY = [
   "application/vnd.vega.v5.json",
   "application/vnd.vega.v4+json",
   "application/geo+json",
-  // HTML and markdown
+  // HTML, markdown, and LaTeX
   "text/html",
   "text/markdown",
+  "text/latex",
   // Images
   "image/svg+xml",
   "image/png",
@@ -307,6 +311,11 @@ export function MediaRouter({
     // Text/Markdown (only renders when in iframe)
     if (mimeType === "text/markdown") {
       return <MarkdownOutput content={String(content)} className={className} />;
+    }
+
+    // LaTeX math (KaTeX, rendered in-DOM — safe static HTML)
+    if (mimeType === "text/latex") {
+      return <MathOutput content={String(content)} className={className} />;
     }
 
     // HTML (only renders when in iframe)


### PR DESCRIPTION
## Summary
- Add `MathOutput` component that renders `text/latex` MIME type using KaTeX directly
- Add `text/latex` to the MIME priority list in `MediaRouter`
- Renders in-DOM (no iframe isolation needed — KaTeX output is safe static HTML)

Fixes sympy/Sage `display()` output showing as plain text instead of rendered math.

## Test plan
- [ ] Open a notebook with `from sympy import *; init_printing(); display(Eq(exp(I * pi) + 1, 0))`
- [ ] Confirm LaTeX renders as formatted math, not plain text
- [ ] Confirm markdown LaTeX (e.g. `$e^{i\pi} + 1 = 0$`) still renders correctly