### PR TITLE
refactor(sync): coalesced CRDT writes + CommSync removal

### DIFF
--- a/apps/notebook/src/hooks/useDaemonKernel.ts
+++ b/apps/notebook/src/hooks/useDaemonKernel.ts
@@ -20,6 +20,7 @@ import { logger } from "../lib/logger";
 import { resolveOutput } from "../lib/materialize-cells";
 import { subscribeBroadcast } from "../lib/notebook-frame-bus";
 import {
+  type CommDocEntry,
   diffExecutions,
   type ExecutionState,
   type QueueEntry,
@@ -360,32 +361,10 @@ export function useDaemonKernel({
         }
 
         case "comm": {
-          // Comm message from kernel (for widgets).
-          // State contains {"$blob": "hash"} sentinels for binary buffers —
-          // the daemon stores them in the blob store and never sends raw bytes.
-          // We resolve sentinels to blob HTTP URLs before passing to widgets.
+          // Custom comm messages only (buttons, model.send()).
+          // State updates and lifecycle (open/close) flow through CRDT.
           const { onCommMessage } = callbacksRef.current;
           if (onCommMessage) {
-            const content = broadcast.content as Record<string, unknown>;
-            const data = content.data as Record<string, unknown> | undefined;
-            const rawState = data?.state as Record<string, unknown> | undefined;
-
-            // Resolve blob sentinels in state (comm_open and comm_msg update)
-            let resolvedContent = broadcast.content;
-            if (rawState && broadcast.msg_type !== "comm_close") {
-              const { state: resolvedState, bufferPaths } =
-                replaceSentinelsWithBlobUrls(rawState);
-              // Rebuild content.data.state with resolved URLs
-              resolvedContent = {
-                ...content,
-                data: {
-                  ...data,
-                  state: resolvedState,
-                  buffer_paths: bufferPaths,
-                },
-              };
-            }
-
             const msg: JupyterMessage = {
               header: {
                 msg_id: crypto.randomUUID(),
@@ -396,9 +375,7 @@ export function useDaemonKernel({
                 version: "5.3",
               },
               metadata: {},
-              content: resolvedContent,
-              // State updates have blob sentinels (no buffers needed).
-              // Custom comm_msg may still carry raw binary buffers.
+              content: broadcast.content,
               buffers: broadcast.buffers?.length
                 ? broadcast.buffers.map(
                     (arr: number[]) => new Uint8Array(arr).buffer,
@@ -406,71 +383,6 @@ export function useDaemonKernel({
                 : [],
             };
             onCommMessage(msg);
-          }
-          break;
-        }
-
-        case "comm_sync": {
-          // Initial comm state sync from daemon for multi-window widget reconstruction.
-          // Replay all comms as comm_open messages to the widget store.
-          // Must await blob port — CRDT state contains {"$blob": "hash"} sentinels
-          // that need resolution to HTTP URLs before the widget framework sees them.
-          const { onCommMessage } = callbacksRef.current;
-          if (onCommMessage && broadcast.comms) {
-            const comms = broadcast.comms;
-            const replayComms = async () => {
-              let port = getBlobPort();
-              if (!port) {
-                port = await refreshBlobPort();
-              }
-              if (!port) {
-                logger.error(
-                  "[daemon-kernel] Blob port unavailable, cannot replay comm_sync",
-                );
-                return;
-              }
-              if (cancelled) return;
-
-              logger.debug(
-                `[daemon-kernel] comm_sync: replaying ${comms.length} comms`,
-              );
-              const { onCommMessage: handler } = callbacksRef.current;
-              if (!handler) return;
-
-              for (const comm of comms) {
-                const { state: resolvedState, bufferPaths } =
-                  replaceSentinelsWithBlobUrls(
-                    comm.state as Record<string, unknown>,
-                  );
-
-                const msg: JupyterMessage = {
-                  header: {
-                    msg_id: crypto.randomUUID(),
-                    msg_type: "comm_open",
-                    session: "",
-                    username: "kernel",
-                    date: new Date().toISOString(),
-                    version: "5.3",
-                  },
-                  metadata: {},
-                  content: {
-                    comm_id: comm.comm_id,
-                    target_name: comm.target_name,
-                    data: {
-                      state: resolvedState,
-                      buffer_paths: bufferPaths,
-                    },
-                  },
-                  buffers: [],
-                };
-                handler(msg);
-              }
-            };
-            replayComms();
-          } else if (!onCommMessage) {
-            logger.debug(
-              "[daemon-kernel] comm_sync received but onCommMessage not set",
-            );
           }
           break;
         }
@@ -557,22 +469,102 @@ export function useDaemonKernel({
 
   // ── Sync comms from RuntimeStateDoc → WidgetStore ─────────────────
   //
-  // Phase B: comms flow from CRDT to WidgetStore. Currently limited to
-  // comm_close cleanup only. comm_open and state updates still flow via
-  // broadcasts + CommSync, which carry real binary buffers. The CRDT
-  // path has blob sentinels that need iframe-side resolution before
-  // comm_open can be delivered from here (Phase D follow-up).
-  //
-  // For now: track comms in the CRDT for cleanup, but don't deliver
-  // comm_open or state updates that would put sentinel objects in the
-  // WidgetStore (which causes DataCloneError on postMessage to iframe).
-  const prevCommsRef = useRef<Record<string, boolean>>({});
+  // Full lifecycle: the CRDT is the source of truth for widget state.
+  // Detect new comms (comm_open), state changes (comm_msg update),
+  // and removed comms (comm_close) by diffing against previous state.
+  // Blob sentinels in state are resolved to HTTP URLs before delivery.
+  // New comms are sorted by seq for correct widget dependency order.
+  const prevCommsRef = useRef<Record<string, CommDocEntry>>({});
+  const prevCommsJsonRef = useRef<Record<string, string>>({});
   useEffect(() => {
     const { onCommMessage } = callbacksRef.current;
     if (!onCommMessage) return;
 
     const docComms = runtimeState.comms ?? {};
     const prevComms = prevCommsRef.current;
+    const prevJson = prevCommsJsonRef.current;
+    const nextComms: Record<string, CommDocEntry> = {};
+    const nextJson: Record<string, string> = {};
+
+    // Blob port is needed to resolve {"$blob":"hash"} sentinels in state.
+    // Without it, comm_open and state updates would deliver unresolved sentinels
+    // which cause DataCloneError in the widget iframe. Skip delivery and leave
+    // those comms out of prevCommsRef so the next effect run retries them.
+    const hasBlobPort = getBlobPort() !== null;
+
+    // New comms — synthesize comm_open (sorted by seq for dependency order)
+    const newEntries = Object.entries(docComms)
+      .filter(([commId]) => !(commId in prevComms))
+      .sort(([, a], [, b]) => (a.seq ?? 0) - (b.seq ?? 0));
+
+    for (const [commId, entry] of newEntries) {
+      if (!hasBlobPort) continue; // Retry on next CRDT update once port is ready
+      const { state: resolvedState, bufferPaths } =
+        replaceSentinelsWithBlobUrls(entry.state as Record<string, unknown>);
+      const msg: JupyterMessage = {
+        header: {
+          msg_id: crypto.randomUUID(),
+          msg_type: "comm_open",
+          session: "",
+          username: "kernel",
+          date: new Date().toISOString(),
+          version: "5.3",
+        },
+        metadata: {},
+        content: {
+          comm_id: commId,
+          target_name: entry.target_name,
+          data: {
+            state: {
+              ...resolvedState,
+              _model_module: entry.model_module || undefined,
+              _model_name: entry.model_name || undefined,
+            },
+            buffer_paths: bufferPaths,
+          },
+        },
+        buffers: [],
+      };
+      onCommMessage(msg);
+      nextComms[commId] = entry;
+      nextJson[commId] = JSON.stringify(entry.state);
+    }
+
+    // State changes — synthesize comm_msg(update)
+    for (const [commId, entry] of Object.entries(docComms)) {
+      const stateStr = JSON.stringify(entry.state);
+      if (commId in prevComms) {
+        nextComms[commId] = entry;
+        nextJson[commId] = stateStr;
+        if (prevJson[commId] !== stateStr) {
+          const { state: resolvedState, bufferPaths } =
+            replaceSentinelsWithBlobUrls(
+              entry.state as Record<string, unknown>,
+            );
+          const msg: JupyterMessage = {
+            header: {
+              msg_id: crypto.randomUUID(),
+              msg_type: "comm_msg",
+              session: "",
+              username: "kernel",
+              date: new Date().toISOString(),
+              version: "5.3",
+            },
+            metadata: {},
+            content: {
+              comm_id: commId,
+              data: {
+                method: "update",
+                state: resolvedState,
+                buffer_paths: bufferPaths,
+              },
+            },
+            buffers: [],
+          };
+          onCommMessage(msg);
+        }
+      }
+    }
 
     // Removed comms — synthesize comm_close
     for (const commId of Object.keys(prevComms)) {
@@ -594,10 +586,10 @@ export function useDaemonKernel({
       }
     }
 
-    // Update tracking
-    prevCommsRef.current = Object.fromEntries(
-      Object.keys(docComms).map((id) => [id, true]),
-    );
+    // Only track comms that were successfully delivered.
+    // Comms skipped due to missing blob port will be retried on next update.
+    prevCommsRef.current = nextComms;
+    prevCommsJsonRef.current = nextJson;
   }, [runtimeState.comms]);
 
   // ── Resolve Output widget captured outputs from CRDT ────────────

--- a/apps/notebook/src/types.ts
+++ b/apps/notebook/src/types.ts
@@ -142,16 +142,6 @@ export interface EnvironmentYmlInfo {
 // Daemon Broadcast Types (Phase 8: Daemon-owned kernel execution)
 // =============================================================================
 
-/** Snapshot of a comm channel's state for multi-window sync */
-export interface CommSnapshot {
-  comm_id: string;
-  target_name: string;
-  state: Record<string, unknown>;
-  model_module?: string;
-  model_name?: string;
-  buffers?: number[][];
-}
-
 /** Broadcast events from daemon for kernel operations */
 export type DaemonBroadcast =
   | {
@@ -201,10 +191,6 @@ export type DaemonBroadcast =
       msg_type: string; // "comm_open" | "comm_msg" | "comm_close"
       content: Record<string, unknown>;
       buffers: number[][]; // Binary buffers as byte arrays
-    }
-  | {
-      event: "comm_sync";
-      comms: CommSnapshot[]; // All active comms for widget reconstruction
     }
   | ({
       event: "env_progress";

--- a/crates/notebook-doc/src/runtime_state.rs
+++ b/crates/notebook-doc/src/runtime_state.rs
@@ -1345,6 +1345,54 @@ impl RuntimeStateDoc {
         true
     }
 
+    /// Merge a state delta into a comm's state map, skipping no-op writes.
+    ///
+    /// For each key in `delta` (must be a JSON object), reads the current
+    /// value from `comms/{comm_id}/state/{key}` and only writes if it
+    /// differs. This suppresses echo-generated CRDT changes when the
+    /// frontend writes a value → kernel echoes the same value back.
+    ///
+    /// Returns `true` if any property was actually changed.
+    #[allow(clippy::expect_used)]
+    pub fn merge_comm_state_delta(&mut self, comm_id: &str, delta: &serde_json::Value) -> bool {
+        let Some(obj) = delta.as_object() else {
+            return false;
+        };
+        let Some(comms) = self.get_map("comms") else {
+            return false;
+        };
+        let Some((_, entry)) = self.doc.get(&comms, comm_id).ok().flatten() else {
+            return false;
+        };
+        let Some((Value::Object(ObjType::Map), state_id)) =
+            self.doc.get(&entry, "state").ok().flatten()
+        else {
+            return false;
+        };
+
+        let mut any_changed = false;
+        for (key, new_value) in obj {
+            // For scalars, compare before writing to avoid no-op CRDT ops.
+            // Objects/arrays are written unconditionally (rare in widget deltas).
+            let should_write = match new_value {
+                serde_json::Value::Null
+                | serde_json::Value::Bool(_)
+                | serde_json::Value::Number(_)
+                | serde_json::Value::String(_) => {
+                    let current = crate::read_json_value(&self.doc, &state_id, key.as_str());
+                    current.as_ref() != Some(new_value)
+                }
+                _ => true,
+            };
+            if should_write {
+                crate::put_json_at_key(&mut self.doc, &state_id, key, new_value)
+                    .expect("put comm.state.key");
+                any_changed = true;
+            }
+        }
+        any_changed
+    }
+
     /// Set or clear the capture_msg_id for an Output widget.
     ///
     /// When `msg_id` is non-empty, kernel outputs with matching
@@ -2794,5 +2842,50 @@ mod tests {
             "empty outputs must be retained in snapshot"
         );
         assert!(snapshot["exec-1"].is_empty());
+    }
+
+    #[test]
+    fn test_merge_comm_state_delta_skips_same_value() {
+        let mut doc = RuntimeStateDoc::new();
+        let state = serde_json::json!({"value": 42, "label": "hello"});
+        doc.put_comm("w1", "jupyter.widget", "", "", &state, 0);
+
+        // Same values → no change
+        let delta = serde_json::json!({"value": 42, "label": "hello"});
+        assert!(!doc.merge_comm_state_delta("w1", &delta));
+    }
+
+    #[test]
+    fn test_merge_comm_state_delta_writes_changed_value() {
+        let mut doc = RuntimeStateDoc::new();
+        let state = serde_json::json!({"value": 42, "label": "hello"});
+        doc.put_comm("w1", "jupyter.widget", "", "", &state, 0);
+
+        // Different value → change
+        let delta = serde_json::json!({"value": 99});
+        assert!(doc.merge_comm_state_delta("w1", &delta));
+        let updated = doc.read_state();
+        let w1 = &updated.comms["w1"];
+        assert_eq!(w1.state["value"], 99);
+        // Unchanged key preserved
+        assert_eq!(w1.state["label"], "hello");
+    }
+
+    #[test]
+    fn test_merge_comm_state_delta_nonexistent_comm() {
+        let mut doc = RuntimeStateDoc::new();
+        let delta = serde_json::json!({"value": 1});
+        assert!(!doc.merge_comm_state_delta("nonexistent", &delta));
+    }
+
+    #[test]
+    fn test_merge_comm_state_delta_writes_objects_unconditionally() {
+        let mut doc = RuntimeStateDoc::new();
+        let state = serde_json::json!({"nested": {"a": 1}});
+        doc.put_comm("w1", "jupyter.widget", "", "", &state, 0);
+
+        // Object values are always written (no deep comparison)
+        let delta = serde_json::json!({"nested": {"a": 1}});
+        assert!(doc.merge_comm_state_delta("w1", &delta));
     }
 }

--- a/crates/notebook-protocol/src/protocol.rs
+++ b/crates/notebook-protocol/src/protocol.rs
@@ -9,38 +9,6 @@ use serde::{Deserialize, Serialize};
 
 // ── Data structs referenced by protocol enums ───────────────────────────────
 
-/// A snapshot of a comm channel's state.
-///
-/// Stored in the daemon and sent to newly connected clients so they can
-/// reconstruct widget models that were created before they connected.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CommSnapshot {
-    /// The comm_id (unique identifier for this comm channel).
-    pub comm_id: String,
-
-    /// Target name (e.g., "jupyter.widget", "jupyter.widget.version").
-    pub target_name: String,
-
-    /// Current state snapshot (merged from all updates).
-    /// For widgets, this contains the full model state.
-    pub state: serde_json::Value,
-
-    /// Model module (e.g., "@jupyter-widgets/controls", "anywidget").
-    /// Extracted from `_model_module` in state for convenience.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub model_module: Option<String>,
-
-    /// Model name (e.g., "IntSliderModel", "AnyModel").
-    /// Extracted from `_model_name` in state for convenience.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub model_name: Option<String>,
-
-    /// Binary buffers associated with this comm (e.g., for images, arrays).
-    /// Stored inline for simplicity; large buffers could be moved to blob store.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub buffers: Vec<Vec<u8>>,
-}
-
 /// Environment configuration captured at kernel launch time.
 /// Used to detect when notebook metadata has drifted from the running kernel.
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
@@ -501,13 +469,6 @@ pub enum NotebookBroadcast {
         /// Binary buffers (base64-encoded when serialized to JSON)
         #[serde(default)]
         buffers: Vec<Vec<u8>>,
-    },
-
-    /// Initial comm state sync sent to newly connected clients.
-    /// Contains all active comm channels so new windows can reconstruct widgets.
-    CommSync {
-        /// All active comm snapshots
-        comms: Vec<CommSnapshot>,
     },
 
     /// Environment progress update during kernel launch.

--- a/crates/runtimed-client/src/protocol.rs
+++ b/crates/runtimed-client/src/protocol.rs
@@ -14,7 +14,7 @@ use crate::{EnvType, PoolState, PooledEnv};
 
 // Re-export all notebook protocol types from the shared crate.
 pub use notebook_protocol::protocol::{
-    CommSnapshot, CompletionItem, DenoLaunchedConfig, EnvSyncDiff, HistoryEntry, LaunchedEnvConfig,
+    CompletionItem, DenoLaunchedConfig, EnvSyncDiff, HistoryEntry, LaunchedEnvConfig,
     NotebookBroadcast, NotebookRequest, NotebookResponse, QueueEntry,
 };
 
@@ -518,31 +518,5 @@ mod tests {
         let json = serde_json::to_string(&broadcast).unwrap();
         assert!(json.contains("kernel_status"));
         assert!(json.contains("busy"));
-    }
-
-    #[test]
-    fn test_notebook_broadcast_comm_sync() {
-        let comm = CommSnapshot {
-            comm_id: "widget-1".into(),
-            target_name: "jupyter.widget".into(),
-            state: serde_json::json!({"value": 50}),
-            model_module: Some("@jupyter-widgets/controls".into()),
-            model_name: Some("IntSliderModel".into()),
-            buffers: vec![],
-        };
-        let broadcast = NotebookBroadcast::CommSync { comms: vec![comm] };
-        let json = serde_json::to_string(&broadcast).unwrap();
-        assert!(json.contains("comm_sync"));
-        assert!(json.contains("widget-1"));
-        assert!(json.contains("jupyter.widget"));
-
-        let parsed: NotebookBroadcast = serde_json::from_str(&json).unwrap();
-        match parsed {
-            NotebookBroadcast::CommSync { comms } => {
-                assert_eq!(comms.len(), 1);
-                assert_eq!(comms[0].comm_id, "widget-1");
-            }
-            _ => panic!("unexpected broadcast type"),
-        }
     }
 }

--- a/crates/runtimed/src/kernel_manager.rs
+++ b/crates/runtimed/src/kernel_manager.rs
@@ -382,6 +382,10 @@ pub struct RoomKernel {
     process_watcher_task: Option<tokio::task::JoinHandle<()>>,
     /// Handle to the heartbeat monitor task (detects unresponsive kernel)
     heartbeat_task: Option<tokio::task::JoinHandle<()>>,
+    /// Channel for coalesced comm state writes (IOPub → coalesce task).
+    comm_coalesce_tx: Option<mpsc::UnboundedSender<(String, serde_json::Value)>>,
+    /// Handle to the coalescing task for comm state CRDT writes.
+    comm_coalesce_task: Option<tokio::task::JoinHandle<()>>,
     /// Shell writer for sending execute requests
     shell_writer: Option<runtimelib::DealerSendConnection>,
     /// Process group ID for cleanup (Unix only)
@@ -528,6 +532,8 @@ impl RoomKernel {
             shell_reader_task: None,
             process_watcher_task: None,
             heartbeat_task: None,
+            comm_coalesce_tx: None,
+            comm_coalesce_task: None,
             shell_writer: None,
             #[cfg(unix)]
             process_group_id: None,
@@ -1062,6 +1068,11 @@ impl RoomKernel {
         let state_doc_for_iopub = self.state_doc.clone();
         let state_changed_for_iopub = self.state_changed_tx.clone();
         let iopub_actor_id = self.kernel_actor_id.clone();
+
+        // Create coalescing channel early so the IOPub task can capture the sender.
+        // The coalescing task itself is spawned later (after the IOPub task).
+        let (coalesce_tx, coalesce_rx) = mpsc::unbounded_channel::<(String, serde_json::Value)>();
+        let comm_coalesce_tx = Some(coalesce_tx.clone());
 
         let iopub_task = tokio::spawn(async move {
             // Track Output widgets with pending clear_output(wait=true).
@@ -1870,10 +1881,6 @@ impl RoomKernel {
 
                             // Comm messages for widgets (ipywidgets protocol)
                             JupyterMessageContent::CommOpen(open) => {
-                                // Serialize the content to JSON
-                                let content =
-                                    serde_json::to_value(&message.content).unwrap_or_default();
-
                                 // Extract buffers (Vec<Bytes> -> Vec<Vec<u8>>)
                                 let buffers: Vec<Vec<u8>> =
                                     message.buffers.iter().map(|b| b.to_vec()).collect();
@@ -1938,25 +1945,8 @@ impl RoomKernel {
                                     let _ = state_changed_for_iopub.send(());
                                 }
 
-                                // Broadcast with sentinel state — no raw buffers.
-                                // Frontend resolves sentinels to blob HTTP URLs.
-                                let broadcast_content = {
-                                    let mut c = content.clone();
-                                    if let Some(obj) = c.get_mut("data") {
-                                        if let Some(obj) = obj.as_object_mut() {
-                                            obj.insert(
-                                                "state".to_string(),
-                                                state_with_blobs.clone(),
-                                            );
-                                        }
-                                    }
-                                    c
-                                };
-                                let _ = broadcast_tx.send(NotebookBroadcast::Comm {
-                                    msg_type: message.header.msg_type.clone(),
-                                    content: broadcast_content,
-                                    buffers: vec![],
-                                });
+                                // No broadcast — frontend receives comm_open via
+                                // CRDT sync of RuntimeStateDoc comms map.
                             }
 
                             JupyterMessageContent::CommMsg(msg) => {
@@ -2005,79 +1995,56 @@ impl RoomKernel {
                                             let _ = state_changed_for_iopub.send(());
                                         }
 
-                                        // Note: we intentionally do NOT dual-write the full
-                                        // state to RuntimeStateDoc on every comm_msg update.
-                                        // High-frequency widgets (sliders) generate dozens
-                                        // of updates per second, and each CRDT write +
-                                        // sync notification overwhelms the pipeline.
-                                        // The CRDT has the initial state from comm_open,
-                                        // and real-time updates flow via broadcasts.
+                                        // Send state delta to coalescing writer for
+                                        // batched CRDT updates (16ms window).
+                                        // Binary buffers get blob-sentinel treatment
+                                        // so the CRDT stores hashes, not raw bytes.
+                                        let coalesce_delta = if !buffers.is_empty() {
+                                            let buffer_paths = extract_buffer_paths(&data);
+                                            let (state_with_blobs, _) = store_widget_buffers(
+                                                state_delta,
+                                                &buffer_paths,
+                                                &buffers,
+                                                &blob_store,
+                                            )
+                                            .await;
+                                            state_with_blobs
+                                        } else {
+                                            state_delta.clone()
+                                        };
+                                        if let Some(ref tx) = comm_coalesce_tx {
+                                            let _ =
+                                                tx.send((msg.comm_id.0.clone(), coalesce_delta));
+                                        }
                                     }
                                 }
 
-                                // For state updates with binary buffers, store as blob sentinels
-                                // (same pattern as comm_open — avoids DataCloneError).
-                                // For non-state comm_msg (custom messages), preserve raw buffers
-                                // so widgets that depend on binary custom payloads still work.
-                                let (broadcast_content, broadcast_buffers) = if !buffers.is_empty()
-                                    && method == Some("update")
-                                {
-                                    let buffer_paths = extract_buffer_paths(&data);
-                                    if let Some(state_delta) = data.get("state") {
-                                        let (state_with_blobs, _) = store_widget_buffers(
-                                            state_delta,
-                                            &buffer_paths,
-                                            &buffers,
-                                            &blob_store,
-                                        )
-                                        .await;
-                                        let mut c = content.clone();
-                                        if let Some(obj) = c.get_mut("data") {
-                                            if let Some(obj) = obj.as_object_mut() {
-                                                obj.insert("state".to_string(), state_with_blobs);
-                                            }
-                                        }
-                                        (c, vec![])
-                                    } else {
-                                        (content.clone(), buffers.clone())
-                                    }
-                                } else {
-                                    (content.clone(), buffers.clone())
-                                };
-
-                                let _ = broadcast_tx.send(NotebookBroadcast::Comm {
-                                    msg_type: message.header.msg_type.clone(),
-                                    content: broadcast_content,
-                                    buffers: broadcast_buffers,
-                                });
+                                // State updates flow through the CRDT (coalescing writer).
+                                // Custom messages (buttons, model.send()) still need broadcast
+                                // since they are ephemeral events, not persistent state.
+                                if method != Some("update") {
+                                    let _ = broadcast_tx.send(NotebookBroadcast::Comm {
+                                        msg_type: message.header.msg_type.clone(),
+                                        content: content.clone(),
+                                        buffers: buffers.clone(),
+                                    });
+                                }
                             }
 
                             JupyterMessageContent::CommClose(close) => {
-                                debug!(
-                                    "[kernel-manager] Broadcasting comm_close: comm_id={}",
-                                    close.comm_id.0
-                                );
-
-                                // Serialize the content to JSON
-                                let content =
-                                    serde_json::to_value(&message.content).unwrap_or_default();
+                                debug!("[kernel-manager] comm_close: comm_id={}", close.comm_id.0);
 
                                 // Remove from capture cache
                                 capture_cache.retain(|_, cid| cid != &close.comm_id.0);
 
-                                // Dual-write removal to RuntimeStateDoc
+                                // Remove from RuntimeStateDoc — frontend detects
+                                // removal via CRDT watcher and synthesizes comm_close.
                                 {
                                     let mut sd = state_doc_for_iopub.write().await;
                                     if sd.remove_comm(&close.comm_id.0) {
                                         let _ = state_changed_for_iopub.send(());
                                     }
                                 }
-
-                                let _ = broadcast_tx.send(NotebookBroadcast::Comm {
-                                    msg_type: message.header.msg_type.clone(),
-                                    content,
-                                    buffers: vec![],
-                                });
                             }
 
                             _ => {
@@ -2404,12 +2371,65 @@ impl RoomKernel {
             }
         });
 
+        // Spawn coalesced comm state writer — batches comm_msg(update) deltas
+        // into periodic CRDT writes (16ms window) to keep RuntimeStateDoc current
+        // without overwhelming the sync pipeline during rapid slider drags.
+        // Channel was created earlier (before IOPub task) so both tasks share it.
+        let mut coalesce_rx = coalesce_rx;
+        let coalesce_state_doc = self.state_doc.clone();
+        let coalesce_state_changed = self.state_changed_tx.clone();
+        let comm_coalesce_task = tokio::spawn(async move {
+            let mut pending: HashMap<String, serde_json::Value> = HashMap::new();
+            let mut timer = tokio::time::interval(std::time::Duration::from_millis(16));
+            timer.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+            loop {
+                tokio::select! {
+                    msg = coalesce_rx.recv() => {
+                        match msg {
+                            Some((comm_id, delta)) => {
+                                // Merge delta into pending accumulator (last-write-wins per key)
+                                let entry = pending.entry(comm_id)
+                                    .or_insert_with(|| serde_json::json!({}));
+                                if let (Some(existing), Some(new)) =
+                                    (entry.as_object_mut(), delta.as_object())
+                                {
+                                    for (k, v) in new {
+                                        existing.insert(k.clone(), v.clone());
+                                    }
+                                }
+                            }
+                            None => break, // Channel closed, kernel shutting down
+                        }
+                    }
+                    _ = timer.tick() => {
+                        if pending.is_empty() {
+                            continue;
+                        }
+                        let batch = std::mem::take(&mut pending);
+                        let mut sd = coalesce_state_doc.write().await;
+                        let mut any_changed = false;
+                        for (comm_id, delta) in &batch {
+                            if sd.merge_comm_state_delta(comm_id, delta) {
+                                any_changed = true;
+                            }
+                        }
+                        if any_changed {
+                            let _ = coalesce_state_changed.send(());
+                        }
+                    }
+                }
+            }
+        });
+
         // Store state (process_watcher_task already stored immediately after spawn)
         self.connection_info = Some(connection_info);
         self.connection_file = Some(connection_file_path);
         self.iopub_task = Some(iopub_task);
         self.shell_reader_task = Some(shell_reader_task);
         self.heartbeat_task = Some(heartbeat_task);
+        self.comm_coalesce_tx = Some(coalesce_tx);
+        self.comm_coalesce_task = Some(comm_coalesce_task);
         self.shell_writer = Some(shell_writer);
         self.status = KernelStatus::Idle;
 
@@ -2992,6 +3012,11 @@ impl RoomKernel {
         if let Some(task) = self.heartbeat_task.take() {
             task.abort();
         }
+        // Drop sender first so the coalescing task exits, then abort
+        self.comm_coalesce_tx.take();
+        if let Some(task) = self.comm_coalesce_task.take() {
+            task.abort();
+        }
 
         // Try graceful shutdown via shell
         if let Some(mut shell) = self.shell_writer.take() {
@@ -3061,6 +3086,10 @@ impl Drop for RoomKernel {
             task.abort();
         }
         if let Some(task) = self.heartbeat_task.take() {
+            task.abort();
+        }
+        self.comm_coalesce_tx.take();
+        if let Some(task) = self.comm_coalesce_task.take() {
             task.abort();
         }
 

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -44,7 +44,7 @@ use crate::markdown_assets::resolve_markdown_assets;
 use crate::notebook_doc::{notebook_doc_filename, CellSnapshot, NotebookDoc};
 use crate::notebook_metadata::NotebookMetadataSnapshot;
 use crate::protocol::{
-    CommSnapshot, EnvSyncDiff, NotebookBroadcast, NotebookRequest, NotebookResponse, QueueEntry,
+    EnvSyncDiff, NotebookBroadcast, NotebookRequest, NotebookResponse, QueueEntry,
 };
 use notebook_doc::presence::{self, PresenceState};
 use notebook_doc::runtime_state::{QueueEntry as DocQueueEntry, RuntimeStateDoc};
@@ -1705,50 +1705,9 @@ where
         .await?;
     }
 
-    // Phase 1.5: Send comm state sync for widget reconstruction
-    // New clients need active comm channels to render widgets created before they connected.
-    // Reads from RuntimeStateDoc (CRDT) instead of CommState. Binary buffers are stored
-    // as {"$blob": "hash"} sentinels in state — the frontend resolves them to blob URLs.
-    {
-        let sd = room.state_doc.read().await;
-        let crdt_state = sd.read_state();
-        if !crdt_state.comms.is_empty() {
-            // Sort by seq (insertion order) for correct widget dependency replay
-            let mut entries: Vec<_> = crdt_state.comms.into_iter().collect();
-            entries.sort_by_key(|(_, e)| e.seq);
-
-            let comms: Vec<CommSnapshot> = entries
-                .into_iter()
-                .map(|(comm_id, entry)| CommSnapshot {
-                    comm_id,
-                    target_name: entry.target_name,
-                    state: entry.state,
-                    model_module: if entry.model_module.is_empty() {
-                        None
-                    } else {
-                        Some(entry.model_module)
-                    },
-                    model_name: if entry.model_name.is_empty() {
-                        None
-                    } else {
-                        Some(entry.model_name)
-                    },
-                    buffers: vec![],
-                })
-                .collect();
-
-            info!(
-                "[notebook-sync] Sending comm_sync with {} active comms (from CRDT)",
-                comms.len()
-            );
-            connection::send_typed_json_frame(
-                writer,
-                NotebookFrameType::Broadcast,
-                &NotebookBroadcast::CommSync { comms },
-            )
-            .await?;
-        }
-    }
+    // Phase 1.5 (removed): CommSync broadcast is no longer needed.
+    // Late joiners receive widget state via RuntimeStateDoc CRDT sync,
+    // and the frontend CRDT watcher synthesizes comm_open messages.
 
     // Phase 1.6: Send presence snapshot so late joiners see current peer state
     // (kernel status, cursors, selections from other connected peers).


### PR DESCRIPTION
## Summary

Closes #1378. Phases C+D of the widget state CRDT migration (#761):

- **Phase D**: Kernel-initiated `comm_msg(update)` state deltas now write to RuntimeStateDoc via a coalescing task (16ms window), keeping the CRDT current for late joiners. `merge_comm_state_delta()` provides echo suppression — skips no-op writes when the frontend→kernel→IOPub echo returns the same scalar value.
- **Phase C**: `CommSync` broadcast removed — late joiners receive widget state via normal CRDT sync. The frontend CRDT watcher handles full comm lifecycle (open, update, close) with blob sentinel resolution and `seq`-ordered replay. `Comm` broadcasts slimmed to custom messages only (buttons, `model.send()`). `CommSnapshot` struct and `CommSync` variant removed from the wire protocol.

## Test plan

- [ ] Open notebook with slider widget, drag slider, open second window — slider shows current value (not initial)
- [ ] Verify `supervisor_logs` shows coalesced writes at ~60Hz max during rapid slider drags
- [ ] Open notebook with slider + button + output widgets — all widget types work
- [ ] Open second window — widgets appear from CRDT sync (no CommSync in logs)
- [ ] Button clicks still work (custom broadcast path)
- [ ] Kill kernel — comms cleared in both windows
- [ ] `cargo build` + `cargo xtask lint` clean