### PR TITLE
refactor(sync): daemon sends Output widget outputs directly to kernel

### DIFF
--- a/apps/notebook/src/hooks/useDaemonKernel.ts
+++ b/apps/notebook/src/hooks/useDaemonKernel.ts
@@ -17,7 +17,6 @@ import {
   type KernelStatus,
 } from "../lib/kernel-status";
 import { logger } from "../lib/logger";
-import { resolveOutput } from "../lib/materialize-cells";
 import { subscribeBroadcast } from "../lib/notebook-frame-bus";
 import {
   type CommDocEntry,
@@ -89,7 +88,6 @@ export function useDaemonKernel({
   const runtimeState = useRuntimeState();
 
   // Cache for resolved output manifests (shared with Output widget CRDT path)
-  const outputCacheRef = useRef(new Map<string, JupyterOutput>());
 
   // Derive kernel info from the doc
   const kernelInfo = useMemo(
@@ -590,111 +588,6 @@ export function useDaemonKernel({
     // Comms skipped due to missing blob port will be retried on next update.
     prevCommsRef.current = nextComms;
     prevCommsJsonRef.current = nextJson;
-  }, [runtimeState.comms]);
-
-  // ── Resolve Output widget captured outputs from CRDT ────────────
-  //
-  // OutputModel widgets store captured outputs as manifest hashes in
-  // comms[widget_id].outputs[]. Resolve these to JupyterOutput objects
-  // and push into the WidgetStore so the Output widget component renders them.
-  const prevOutputHashesRef = useRef<Record<string, string>>({});
-  useEffect(() => {
-    const docComms = runtimeState.comms ?? {};
-    const prevHashes = prevOutputHashesRef.current;
-    const newHashes: Record<string, string> = {};
-
-    for (const [commId, entry] of Object.entries(docComms)) {
-      if (entry.model_name !== "OutputModel") continue;
-      const fingerprint = (entry.outputs ?? []).join(",");
-      newHashes[commId] = fingerprint;
-      if (prevHashes[commId] === fingerprint) continue;
-
-      // Handle cleared outputs (empty list)
-      if (!entry.outputs?.length) {
-        const { onCommMessage: cb } = callbacksRef.current;
-        if (cb) {
-          cb({
-            header: {
-              msg_id: crypto.randomUUID(),
-              msg_type: "comm_msg",
-              session: "",
-              username: "kernel",
-              date: new Date().toISOString(),
-              version: "5.3",
-            },
-            metadata: {},
-            content: {
-              comm_id: commId,
-              data: {
-                method: "update",
-                state: { outputs: [] },
-                buffer_paths: [],
-              },
-            },
-            buffers: [],
-          });
-        }
-        continue;
-      }
-
-      // Outputs changed — resolve manifest hashes and update WidgetStore
-      const outputHashes = [...entry.outputs];
-      const widgetCommId = commId;
-      (async () => {
-        let blobPort = getBlobPort();
-        if (blobPort === null) blobPort = await refreshBlobPort();
-        if (blobPort === null) {
-          logger.warn(
-            "[daemon-kernel] No blob port for Output widget CRDT outputs",
-          );
-          return;
-        }
-
-        logger.debug(
-          `[daemon-kernel] Resolving ${outputHashes.length} Output widget outputs for ${widgetCommId.slice(0, 8)}`,
-        );
-
-        const resolved = (
-          await Promise.all(
-            outputHashes.map((hash) =>
-              resolveOutput(hash, blobPort, outputCacheRef.current),
-            ),
-          )
-        ).filter((o): o is JupyterOutput => o !== null);
-
-        logger.debug(
-          `[daemon-kernel] Resolved ${resolved.length}/${outputHashes.length} outputs for ${widgetCommId.slice(0, 8)}`,
-        );
-
-        if (resolved.length > 0) {
-          const { onCommMessage: cb } = callbacksRef.current;
-          if (!cb) return;
-          // Update the widget's outputs via a state update message
-          cb({
-            header: {
-              msg_id: crypto.randomUUID(),
-              msg_type: "comm_msg",
-              session: "",
-              username: "kernel",
-              date: new Date().toISOString(),
-              version: "5.3",
-            },
-            metadata: {},
-            content: {
-              comm_id: commId,
-              data: {
-                method: "update",
-                state: { outputs: resolved },
-                buffer_paths: [],
-              },
-            },
-            buffers: [],
-          });
-        }
-      })();
-    }
-
-    prevOutputHashesRef.current = newHashes;
   }, [runtimeState.comms]);
 
   // ── Actions ───────────────────────────────────────────────────────

--- a/crates/runtimed/src/kernel_manager.rs
+++ b/crates/runtimed/src/kernel_manager.rs
@@ -1283,23 +1283,8 @@ impl RoomKernel {
                                         }
                                     }
 
-                                    // Broadcast for real-time UI — the frontend still needs
-                                    // to display captured outputs in the Output widget.
-                                    let content = serde_json::json!({
-                                        "comm_id": widget_comm_id,
-                                        "data": {
-                                            "method": "custom",
-                                            "content": {
-                                                "method": "output",
-                                                "output": output
-                                            }
-                                        }
-                                    });
-                                    let _ = broadcast_tx.send(NotebookBroadcast::Comm {
-                                        msg_type: "comm_msg".to_string(),
-                                        content,
-                                        buffers: vec![],
-                                    });
+                                    // No broadcast needed — frontend reads from CRDT
+                                    // comms[widget_id].outputs[] via the comms watcher.
                                     continue; // Skip normal cell output handling
                                 }
 
@@ -1495,22 +1480,7 @@ impl RoomKernel {
                                                 }
                                             }
                                         }
-                                        // Broadcast for real-time UI
-                                        let content = serde_json::json!({
-                                            "comm_id": widget_comm_id,
-                                            "data": {
-                                                "method": "custom",
-                                                "content": {
-                                                    "method": "output",
-                                                    "output": nbformat_value
-                                                }
-                                            }
-                                        });
-                                        let _ = broadcast_tx.send(NotebookBroadcast::Comm {
-                                            msg_type: "comm_msg".to_string(),
-                                            content,
-                                            buffers: vec![],
-                                        });
+                                        // No broadcast — frontend reads from CRDT.
                                     }
                                     continue; // Skip normal cell output handling
                                 }
@@ -1730,22 +1700,7 @@ impl RoomKernel {
                                                 }
                                             }
                                         }
-                                        // Broadcast for real-time UI
-                                        let content = serde_json::json!({
-                                            "comm_id": widget_comm_id,
-                                            "data": {
-                                                "method": "custom",
-                                                "content": {
-                                                    "method": "output",
-                                                    "output": nbformat_value
-                                                }
-                                            }
-                                        });
-                                        let _ = broadcast_tx.send(NotebookBroadcast::Comm {
-                                            msg_type: "comm_msg".to_string(),
-                                            content,
-                                            buffers: vec![],
-                                        });
+                                        // No broadcast — frontend reads from CRDT.
                                     }
                                     continue; // Skip normal cell output handling
                                 }
@@ -1857,23 +1812,20 @@ impl RoomKernel {
                                         if sd.clear_comm_outputs(&widget_comm_id) {
                                             let _ = state_changed_for_iopub.send(());
                                         }
+                                        drop(sd);
+                                        // Sync empty outputs to kernel
+                                        let _ = iopub_cmd_tx
+                                            .send(QueueCommand::SendCommUpdate {
+                                                comm_id: widget_comm_id.clone(),
+                                                state: serde_json::json!({
+                                                    "outputs": [],
+                                                }),
+                                            })
+                                            .await;
                                     }
-                                    // Broadcast for real-time UI + kernel echo
-                                    let content = serde_json::json!({
-                                        "comm_id": widget_comm_id,
-                                        "data": {
-                                            "method": "custom",
-                                            "content": {
-                                                "method": "clear_output",
-                                                "wait": clear.wait
-                                            }
-                                        }
-                                    });
-                                    let _ = broadcast_tx.send(NotebookBroadcast::Comm {
-                                        msg_type: "comm_msg".to_string(),
-                                        content,
-                                        buffers: vec![],
-                                    });
+                                    // No broadcast — CRDT clear_comm_outputs handles
+                                    // frontend update. For wait=true, outputs are
+                                    // cleared on next append_comm_output.
                                 }
                                 // Note: We don't skip cell output clearing here because
                                 // clear_output for non-captured outputs should still work normally

--- a/src/components/widgets/__tests__/output-widget.test.tsx
+++ b/src/components/widgets/__tests__/output-widget.test.tsx
@@ -23,7 +23,7 @@ describe("OutputWidget", () => {
     }
   });
 
-  it("renders output messages received via custom comm messages", async () => {
+  it("renders outputs from widget store state", async () => {
     const store = createWidgetStore();
     store.createModel("output-1", {
       _model_name: "OutputModel",
@@ -48,26 +48,35 @@ describe("OutputWidget", () => {
 
     await act(async () => {});
 
+    // Simulate daemon writing resolved outputs to widget state
+    // (via CRDT watcher → WidgetStore updateModel)
     act(() => {
-      store.emitCustomMessage("output-1", {
-        method: "output",
-        output: {
-          output_type: "stream",
-          name: "stdout",
-          text: "Clicked!",
-        },
+      store.updateModel("output-1", {
+        outputs: [
+          {
+            output_type: "stream",
+            name: "stdout",
+            text: "Clicked!",
+          },
+        ],
       });
     });
 
     expect(await screen.findByText("Clicked!")).toBeInTheDocument();
   });
 
-  it("supports clear_output(wait=true) semantics", async () => {
+  it("clears outputs when state is updated with empty array", async () => {
     const store = createWidgetStore();
     store.createModel("output-1", {
       _model_name: "OutputModel",
       _model_module: "@jupyter-widgets/output",
-      outputs: [],
+      outputs: [
+        {
+          output_type: "stream",
+          name: "stdout",
+          text: "First",
+        },
+      ],
     });
 
     render(
@@ -85,32 +94,13 @@ describe("OutputWidget", () => {
       </WidgetStoreContext.Provider>,
     );
 
-    await act(async () => {});
+    expect(await screen.findByText("First")).toBeInTheDocument();
 
+    // Simulate clear_output via state update (CRDT path)
     act(() => {
-      store.emitCustomMessage("output-1", {
-        method: "output",
-        output: {
-          output_type: "stream",
-          name: "stdout",
-          text: "First",
-        },
-      });
-      store.emitCustomMessage("output-1", {
-        method: "clear_output",
-        wait: true,
-      });
-      store.emitCustomMessage("output-1", {
-        method: "output",
-        output: {
-          output_type: "stream",
-          name: "stdout",
-          text: "Second",
-        },
-      });
+      store.updateModel("output-1", { outputs: [] });
     });
 
-    expect(await screen.findByText("Second")).toBeInTheDocument();
     expect(screen.queryByText("First")).not.toBeInTheDocument();
   });
 });

--- a/src/components/widgets/controls/output-widget.tsx
+++ b/src/components/widgets/controls/output-widget.tsx
@@ -6,15 +6,13 @@
  * Media rendering configuration (custom renderers, priority) is
  * inherited from MediaProvider context if present.
  *
- * Note: The Output widget protocol is particularly complex. Rather than
- * simply setting outputs on the model from Python, Jupyter sends outputs
- * as custom messages that must be accumulated client-side. This includes
- * handling clear_output(wait=True) which defers clearing until the next
- * output arrives. We sync rendered state back to the model to keep
- * Python's `out.outputs` in sync with what's displayed.
+ * The daemon handles all output capture and kernel synchronization:
+ * - Captured outputs are stored as manifest hashes in the CRDT
+ * - The daemon resolves hashes and sends state to kernel directly
+ * - The frontend reads outputs from WidgetStore (fed by CRDT watcher)
+ * No frontend echo or custom message accumulation is needed.
  */
 
-import { useEffect, useRef, useState } from "react";
 import type { JupyterOutput } from "@/components/cell/jupyter-output";
 import {
   AnsiErrorOutput,
@@ -25,27 +23,7 @@ import { ErrorBoundary } from "@/lib/error-boundary";
 import { OutputErrorFallback } from "@/lib/output-error-fallback";
 import { cn } from "@/lib/utils";
 import type { WidgetComponentProps } from "../widget-registry";
-import {
-  useWidgetModelValue,
-  useWidgetStoreRequired,
-} from "../widget-store-context";
-
-interface OutputCustomMessage {
-  method?: unknown;
-  output?: unknown;
-  wait?: unknown;
-}
-
-function isJupyterOutput(value: unknown): value is JupyterOutput {
-  if (!value || typeof value !== "object") return false;
-  const output = value as Partial<JupyterOutput>;
-  return (
-    output.output_type === "execute_result" ||
-    output.output_type === "display_data" ||
-    output.output_type === "stream" ||
-    output.output_type === "error"
-  );
-}
+import { useWidgetModelValue } from "../widget-store-context";
 
 /**
  * Render a single Jupyter output by type.
@@ -90,74 +68,10 @@ function renderWidgetOutput(output: JupyterOutput) {
 }
 
 export function OutputWidget({ modelId, className }: WidgetComponentProps) {
-  const { store, sendUpdate } = useWidgetStoreRequired();
-  const stateOutputs =
+  const outputs =
     useWidgetModelValue<JupyterOutput[]>(modelId, "outputs") ?? [];
-  const stateOutputsRef = useRef(stateOutputs);
-  const shouldClearOnNextOutputRef = useRef(false);
-  const [renderedOutputs, setRenderedOutputs] =
-    useState<JupyterOutput[]>(stateOutputs);
-  const renderedOutputsRef = useRef(renderedOutputs);
 
-  useEffect(() => {
-    stateOutputsRef.current = stateOutputs;
-    renderedOutputsRef.current = stateOutputs;
-    setRenderedOutputs(stateOutputs);
-  }, [stateOutputs]);
-
-  useEffect(() => {
-    renderedOutputsRef.current = renderedOutputs;
-  }, [renderedOutputs]);
-
-  useEffect(() => {
-    let replayingBufferedMessages = true;
-
-    const unsubscribe = store.subscribeToCustomMessage(modelId, (content) => {
-      const message = content as OutputCustomMessage;
-      const method =
-        typeof message.method === "string" ? message.method : undefined;
-
-      // OutputModel may have already synchronized state.outputs.
-      // Skip initial buffered custom messages in that case to avoid duplicates.
-      if (replayingBufferedMessages && stateOutputsRef.current.length > 0) {
-        return;
-      }
-
-      if (method === "clear_output") {
-        const wait = Boolean(message.wait);
-        if (wait) {
-          shouldClearOnNextOutputRef.current = true;
-        } else {
-          shouldClearOnNextOutputRef.current = false;
-          renderedOutputsRef.current = [];
-          setRenderedOutputs([]);
-          // Keep Python-side `out.outputs` in sync with displayed output state.
-          sendUpdate(modelId, { outputs: [] });
-        }
-        return;
-      }
-
-      if (method !== "output" || !isJupyterOutput(message.output)) {
-        return;
-      }
-      const nextOutput: JupyterOutput = message.output;
-
-      const prev = renderedOutputsRef.current;
-      const next = shouldClearOnNextOutputRef.current
-        ? [nextOutput]
-        : [...prev, nextOutput];
-      shouldClearOnNextOutputRef.current = false;
-      renderedOutputsRef.current = next;
-      setRenderedOutputs(next);
-      // Keep Python-side `out.outputs` in sync with displayed output state.
-      sendUpdate(modelId, { outputs: next });
-    });
-
-    replayingBufferedMessages = false;
-    return unsubscribe;
-  }, [modelId, sendUpdate, store]);
-
-  if (renderedOutputs.length === 0) {
+  if (outputs.length === 0) {
     return null;
   }
 
@@ -167,7 +81,7 @@ export function OutputWidget({ modelId, className }: WidgetComponentProps) {
       data-widget-id={modelId}
       data-widget-type="Output"
     >
-      {renderedOutputs.map((output, index) => (
+      {outputs.map((output, index) => (
         <ErrorBoundary
           key={`output-${index}`}
           resetKeys={[JSON.stringify(output)]}


### PR DESCRIPTION
## Summary

Closes #1381. Eliminates the frontend round-trip for Output widget state sync.

**Before:** daemon captures output → CRDT write → broadcast to frontend → frontend resolves hashes → frontend echoes back to kernel via WidgetStore → sendUpdate round-trip

**After:** daemon captures output → CRDT write → SendCommUpdate to kernel directly. Frontend reads from CRDT via comms watcher. No echo, no broadcast, no round-trip.

Changes:
- Remove `prevOutputHashesRef` effect from `useDaemonKernel.ts` (frontend no longer resolves/echoes output hashes)
- Simplify `OutputWidget` component to pure render from WidgetStore state (remove custom message handler, sendUpdate echo, accumulated state tracking)
- Remove synthetic `comm_msg(custom, method: "output")` broadcasts from daemon (3 sites: stream, display_data, execute_result)
- Remove synthetic `comm_msg(custom, method: "clear_output")` broadcast from daemon
- Add `SendCommUpdate` for `clear_output(wait=false)` to sync empty outputs to kernel

Net: **-267 lines**, **+26 lines**

## Test plan

- [ ] Open notebook, run `out = ipywidgets.Output(); display(out); with out: print("hello")` — "hello" appears in widget
- [ ] Open second window — Output widget shows same content via CRDT
- [ ] Run `out.clear_output()` — both windows clear
- [ ] Run `with out: display(HTML("<b>bold</b>"))` — rich output renders
- [ ] `cargo build` + `cargo xtask lint` clean