### PR TITLE
fix(release): stamp runtimed version and re-install CLI on upgrade

### DIFF
--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -123,6 +123,7 @@ jobs:
           VERSION="${{ needs.compute-version.outputs.version }}"
           echo "Setting version to: ${VERSION}"
           sed -i "s/^version = .*/version = \"${VERSION}\"/" crates/runt/Cargo.toml
+          sed -i "s/^version = .*/version = \"${VERSION}\"/" crates/runtimed/Cargo.toml
 
       # Build MCP output widget HTML (needed by runt-mcp's include_str!)
       - name: Build MCP output widget
@@ -194,6 +195,7 @@ jobs:
           VERSION="${{ needs.compute-version.outputs.version }}"
           echo "Setting version to: ${VERSION}"
           sed -i '' "s/^version = .*/version = \"${VERSION}\"/" crates/runt/Cargo.toml
+          sed -i '' "s/^version = .*/version = \"${VERSION}\"/" crates/runtimed/Cargo.toml
 
       # Build MCP output widget HTML (needed by runt-mcp's include_str!)
       - name: Build MCP output widget
@@ -308,6 +310,7 @@ jobs:
           sed -i '' "s/\"identifier\": \"[^\"]*\"/\"identifier\": \"${BUNDLE_ID}\"/" crates/notebook/tauri.conf.json
           sed -i '' "s#https://github.com/nteract/desktop/releases/download/stable-latest/latest.json#https://github.com/nteract/desktop/releases/download/${{ inputs.updater_channel_tag }}/latest.json#" crates/notebook/tauri.conf.json
           sed -i '' "s/^version = .*/version = \"${VERSION}\"/" crates/runt/Cargo.toml
+          sed -i '' "s/^version = .*/version = \"${VERSION}\"/" crates/runtimed/Cargo.toml
 
       - name: Generate Icons
         run: |
@@ -597,6 +600,7 @@ jobs:
           sed -i "s/\"identifier\": \"[^\"]*\"/\"identifier\": \"${BUNDLE_ID}\"/" crates/notebook/tauri.conf.json
           sed -i "s#https://github.com/nteract/desktop/releases/download/stable-latest/latest.json#https://github.com/nteract/desktop/releases/download/${{ inputs.updater_channel_tag }}/latest.json#" crates/notebook/tauri.conf.json
           sed -i "s/^version = .*/version = \"${VERSION}\"/" crates/runt/Cargo.toml
+          sed -i "s/^version = .*/version = \"${VERSION}\"/" crates/runtimed/Cargo.toml
 
       - name: Generate Icons
         run: |

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -1188,7 +1188,16 @@ async fn run_upgrade(
         return Err(e);
     }
 
-    // Step 5: Signal ready
+    // Step 5: Re-install CLI if it was previously installed (ensures Windows
+    // copies and Unix symlinks point at the new app bundle).
+    if cli_install::is_cli_installed() {
+        match cli_install::install_cli(&app) {
+            Ok(()) => log::info!("[upgrade] CLI re-installed successfully"),
+            Err(e) => log::warn!("[upgrade] CLI re-install failed (non-fatal): {}", e),
+        }
+    }
+
+    // Step 6: Signal ready
     app.emit("upgrade:progress", UpgradeProgress::Ready)
         .map_err(|e| e.to_string())?;
 

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -2292,11 +2292,7 @@ async fn doctor_command(
                 None
             };
             let bundled_ver = find_bundled_runtimed().and_then(|p| get_binary_version(&p));
-            let cli_ver = format!(
-                "{}+{}",
-                env!("CARGO_PKG_VERSION"),
-                env!("GIT_COMMIT")
-            );
+            let cli_ver = format!("{}+{}", env!("CARGO_PKG_VERSION"), env!("GIT_COMMIT"));
 
             // Build detail string showing all available versions
             let mut parts = Vec::new();

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -2292,9 +2292,15 @@ async fn doctor_command(
                 None
             };
             let bundled_ver = find_bundled_runtimed().and_then(|p| get_binary_version(&p));
+            let cli_ver = format!(
+                "{}+{}",
+                env!("CARGO_PKG_VERSION"),
+                env!("GIT_COMMIT")
+            );
 
             // Build detail string showing all available versions
             let mut parts = Vec::new();
+            parts.push(format!("cli={}", cli_ver));
             if let Some(ref v) = installed_ver {
                 parts.push(format!("installed={}", v));
             }
@@ -2314,8 +2320,10 @@ async fn doctor_command(
                         .as_ref()
                         .map(|b| b == run && b == inst)
                         .unwrap_or(true);
+                    // CLI must also match the running daemon
+                    let cli_match = cli_ver == *run;
 
-                    if installed_match && bundled_match {
+                    if installed_match && bundled_match && cli_match {
                         CheckResult {
                             path: String::new(),
                             status: "ok".to_string(),


### PR DESCRIPTION
## Summary
- The release workflow only stamped `crates/runt/Cargo.toml` with the release version string, leaving `runtimed` at the bare Cargo.toml version. This caused the CLI and daemon to have different version strings after an upgrade (e.g. `2.0.8-stable.202604010637` vs `2.0.8+85cdf7e`), leading to protocol desync — the CLI sent `pool_state_subscribe` messages the daemon couldn't deserialize, which disrupted the sync relay and caused the UI to get stuck showing "busy" after kernel execution completed.
- Stamps `crates/runtimed/Cargo.toml` in all 4 release build steps alongside the existing `runt` stamp
- Adds CLI version to `runt doctor` version_match check so CLI/daemon mismatches are detected
- Re-installs CLI during the upgrade flow so Windows copies and Unix symlinks stay in sync with the new app bundle

## Test plan
- [ ] Verify nightly/stable release builds produce matching version strings for `runt --version` and `runtimed --version`
- [ ] Run `runt doctor` with mismatched CLI/daemon versions and confirm it reports `mismatch`
- [ ] Test upgrade flow on macOS (symlink re-created) and Windows (binary re-copied)
- [ ] Confirm `runt doctor` shows `cli=...` in version detail output

🤖 Generated with [Claude Code](https://claude.com/claude-code)