### PR TITLE
fix(sync): drain stale response frames after relay timeout

### DIFF
--- a/crates/notebook-sync/src/relay_task.rs
+++ b/crates/notebook-sync/src/relay_task.rs
@@ -210,30 +210,14 @@ async fn send_request_impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
                 "[relay] Request timed out after {}s: {:?}",
                 timeout_secs, request
             );
-            // Drain stale response frames to prevent request-response desync.
-            // The daemon may send a belated Response after the relay gives up;
-            // consuming it here keeps the socket stream clean for the next request.
-            let drain_deadline = tokio::time::Instant::now() + Duration::from_millis(200);
-            loop {
-                let remaining =
-                    drain_deadline.saturating_duration_since(tokio::time::Instant::now());
-                if remaining.is_zero() {
-                    break;
-                }
-                match tokio::time::timeout(remaining, connection::recv_typed_frame(reader)).await {
-                    Ok(Ok(Some(frame))) => {
-                        if frame.frame_type == NotebookFrameType::Response {
-                            warn!(
-                                "[relay] Drained stale response ({} bytes) after timeout",
-                                frame.payload.len()
-                            );
-                        } else {
-                            pipe_frame(frame_tx, &frame);
-                        }
-                    }
-                    _ => break, // Timeout, EOF, or error — done draining
-                }
-            }
+            // NOTE: We intentionally do NOT drain stale response frames here.
+            // `recv_typed_frame` uses `read_exact` internally, which is not
+            // cancellation-safe — wrapping it in `tokio::time::timeout` could
+            // cancel mid-frame and corrupt the stream. The relay timeout (7s)
+            // exceeds the daemon's kernel-level timeout (5s), so the daemon
+            // always responds before the relay gives up. Any stale Response
+            // frames that reach the select loop are harmlessly discarded by
+            // `pipe_frame`.
             Err(SyncError::Timeout)
         }
     }

--- a/crates/notebook-sync/src/relay_task.rs
+++ b/crates/notebook-sync/src/relay_task.rs
@@ -186,13 +186,14 @@ async fn send_request_impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
         .map_err(SyncError::Io)?;
 
     // Determine timeout based on request type.
-    // Completions get a short timeout — they should be fast or not at all,
-    // and a long wait blocks the entire relay (no other commands can be
-    // processed while we wait for the response frame).
+    // Completions use 7s — the daemon's kernel-level timeout is 5s, so the
+    // daemon always responds within ~5s. The extra 2s margin ensures the
+    // relay never independently times out during normal operation (only on
+    // daemon crash/hang). A long wait blocks the entire relay.
     let timeout_secs = match request {
         notebook_protocol::protocol::NotebookRequest::LaunchKernel { .. } => 300,
         notebook_protocol::protocol::NotebookRequest::SyncEnvironment { .. } => 300,
-        notebook_protocol::protocol::NotebookRequest::Complete { .. } => 5,
+        notebook_protocol::protocol::NotebookRequest::Complete { .. } => 7,
         _ => 30,
     };
 
@@ -209,6 +210,30 @@ async fn send_request_impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
                 "[relay] Request timed out after {}s: {:?}",
                 timeout_secs, request
             );
+            // Drain stale response frames to prevent request-response desync.
+            // The daemon may send a belated Response after the relay gives up;
+            // consuming it here keeps the socket stream clean for the next request.
+            let drain_deadline = tokio::time::Instant::now() + Duration::from_millis(200);
+            loop {
+                let remaining =
+                    drain_deadline.saturating_duration_since(tokio::time::Instant::now());
+                if remaining.is_zero() {
+                    break;
+                }
+                match tokio::time::timeout(remaining, connection::recv_typed_frame(reader)).await {
+                    Ok(Ok(Some(frame))) => {
+                        if frame.frame_type == NotebookFrameType::Response {
+                            warn!(
+                                "[relay] Drained stale response ({} bytes) after timeout",
+                                frame.payload.len()
+                            );
+                        } else {
+                            pipe_frame(frame_tx, &frame);
+                        }
+                    }
+                    _ => break, // Timeout, EOF, or error — done draining
+                }
+            }
             Err(SyncError::Timeout)
         }
     }


### PR DESCRIPTION
## Summary

- Fixes relay request-response desync caused by completion timeouts
- When a completion request timed out (5s), the daemon's belated error response sat on the socket and was consumed by the next request — e.g. `handleExecuteCell` would receive `"Failed to get completions: Completion request timed out"` instead of `CellQueued`
- Bumps relay completion timeout from 5s to 7s (daemon's kernel-level timeout is 5s, so it always responds first)
- Adds a 200ms drain loop after any relay timeout to consume stale Response frames before returning to the select loop

## Test plan

- [ ] Open a notebook with slow cells (e.g. SymPy), execute cells, then trigger tab completion while kernel is busy
- [ ] Verify no `"Not piping Response frame"` in daemon logs after completion timeout
- [ ] Verify subsequent execute_cell requests succeed after a completion timeout
- [ ] `cargo test -p notebook-sync` passes