### PR TITLE
refactor(runtimed): decouple RoomKernel from NotebookDoc

### DIFF
--- a/crates/runtimed/src/kernel_manager.rs
+++ b/crates/runtimed/src/kernel_manager.rs
@@ -371,8 +371,8 @@ pub struct RoomKernel {
     connection_file: Option<PathBuf>,
     /// Session ID for Jupyter protocol
     session_id: String,
-    /// Automerge actor ID for kernel writes to NotebookDoc (e.g. "rt:kernel:a1b2c3d4").
-    /// Set on forks before mutating so output writes carry kernel provenance.
+    /// Automerge actor ID for kernel writes (e.g. "rt:kernel:a1b2c3d4").
+    /// Set on RuntimeStateDoc forks before mutating so output writes carry kernel provenance.
     kernel_actor_id: String,
     /// Handle to the iopub listener task
     iopub_task: Option<tokio::task::JoinHandle<()>>,
@@ -411,12 +411,6 @@ pub struct RoomKernel {
     cmd_tx: Option<mpsc::Sender<QueueCommand>>,
     /// Command receiver for queue state updates (polled by sync server)
     cmd_rx: Option<mpsc::Receiver<QueueCommand>>,
-    /// Automerge document for persisting outputs
-    doc: Arc<RwLock<NotebookDoc>>,
-    /// Channel to send doc bytes to debounced persistence task (watch keeps latest)
-    persist_tx: watch::Sender<Option<Vec<u8>>>,
-    /// Channel to notify peers of document changes
-    changed_tx: broadcast::Sender<()>,
     /// Blob store for output manifests
     blob_store: Arc<BlobStore>,
     /// Monotonic counter for comm insertion order (written to RuntimeStateDoc).
@@ -461,6 +455,13 @@ pub enum QueueCommand {
     SendCommUpdate {
         comm_id: String,
         state: serde_json::Value,
+    },
+    /// The kernel reported an execution count (from execute_input).
+    /// The coordinator writes it to NotebookDoc for persistence.
+    ExecutionCountSet {
+        cell_id: String,
+        execution_id: String,
+        execution_count: i64,
     },
 }
 
@@ -508,9 +509,6 @@ impl RoomKernel {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         broadcast_tx: broadcast::Sender<NotebookBroadcast>,
-        doc: Arc<RwLock<NotebookDoc>>,
-        persist_tx: watch::Sender<Option<Vec<u8>>>,
-        changed_tx: broadcast::Sender<()>,
         blob_store: Arc<BlobStore>,
         state_doc: Arc<RwLock<RuntimeStateDoc>>,
         state_changed_tx: broadcast::Sender<()>,
@@ -545,9 +543,6 @@ impl RoomKernel {
             broadcast_tx,
             cmd_tx: None,
             cmd_rx: None,
-            doc,
-            persist_tx,
-            changed_tx,
             blob_store,
             comm_seq: Arc::new(AtomicU64::new(0)),
             pending_history: Arc::new(StdMutex::new(HashMap::new())),
@@ -567,7 +562,13 @@ impl RoomKernel {
     ///
     /// Must be called after `launch()`. The `kernel_arc` is needed because the
     /// spawned task locks it to call `execution_done()` and friends.
-    pub fn start_command_loop(&mut self, kernel_arc: Arc<tokio::sync::Mutex<Option<RoomKernel>>>) {
+    pub fn start_command_loop(
+        &mut self,
+        kernel_arc: Arc<tokio::sync::Mutex<Option<RoomKernel>>>,
+        doc: Arc<RwLock<NotebookDoc>>,
+        persist_tx: watch::Sender<Option<Vec<u8>>>,
+        changed_tx: broadcast::Sender<()>,
+    ) {
         let Some(mut cmd_rx) = self.cmd_rx.take() else {
             return;
         };
@@ -656,6 +657,24 @@ impl RoomKernel {
                             )
                             .await;
                         }
+                    }
+                    QueueCommand::ExecutionCountSet {
+                        cell_id,
+                        execution_id: _,
+                        execution_count,
+                    } => {
+                        let mut doc_guard = doc.write().await;
+                        if let Err(e) =
+                            doc_guard.set_execution_count(&cell_id, &execution_count.to_string())
+                        {
+                            warn!(
+                                "[notebook-sync] Failed to set execution_count in doc: {}",
+                                e
+                            );
+                        }
+                        let bytes = doc_guard.save();
+                        let _ = changed_tx.send(());
+                        let _ = persist_tx.send(Some(bytes));
                     }
                 }
             }
@@ -1059,9 +1078,6 @@ impl RoomKernel {
         let broadcast_tx = self.broadcast_tx.clone();
         let cell_id_map = self.cell_id_map.clone();
         let iopub_cmd_tx = cmd_tx.clone();
-        let doc = self.doc.clone();
-        let persist_tx = self.persist_tx.clone();
-        let changed_tx = self.changed_tx.clone();
         let blob_store = self.blob_store.clone();
         let comm_seq = self.comm_seq.clone();
         let stream_terminals = self.stream_terminals.clone();
@@ -1156,37 +1172,26 @@ impl RoomKernel {
 
                             JupyterMessageContent::ExecuteInput(input) => {
                                 if let Some(ref cid) = cell_id {
-                                    // No need to clear terminal state here — each execution_id
-                                    // gets its own fresh terminal emulator, and the new execution_id
-                                    // won't have any terminal state yet.
-
-                                    // Set execution count in the notebook doc (cell metadata).
-                                    // Outputs no longer live in the notebook doc — they're in
-                                    // RuntimeStateDoc keyed by execution_id, so no clear needed.
                                     let execution_count = input.execution_count.0 as i64;
-                                    let persist_bytes = {
-                                        let mut doc_guard = doc.write().await;
-                                        if let Err(e) = doc_guard
-                                            .set_execution_count(cid, &execution_count.to_string())
-                                        {
-                                            warn!(
-                                                "[kernel-manager] Failed to set execution_count in doc: {}",
-                                                e
-                                            );
-                                        }
-                                        let bytes = doc_guard.save();
-                                        let _ = changed_tx.send(());
-                                        bytes
-                                    };
-                                    let _ = persist_tx.send(Some(persist_bytes));
 
-                                    // Write execution_count to RuntimeStateDoc
+                                    // Write execution_count to RuntimeStateDoc (source of truth)
                                     if let Some(ref eid) = execution_id {
                                         let mut sd = state_doc_for_iopub.write().await;
                                         if sd.set_execution_count(eid, execution_count) {
                                             let _ = state_changed_for_iopub.send(());
                                         }
                                     }
+
+                                    // Tell the coordinator to persist execution_count in
+                                    // NotebookDoc (for .ipynb export). The kernel no longer
+                                    // writes to NotebookDoc directly.
+                                    let _ = iopub_cmd_tx
+                                        .send(QueueCommand::ExecutionCountSet {
+                                            cell_id: cid.clone(),
+                                            execution_id: execution_id.clone().unwrap_or_default(),
+                                            execution_count,
+                                        })
+                                        .await;
 
                                     let _ =
                                         broadcast_tx.send(NotebookBroadcast::ExecutionStarted {
@@ -1370,7 +1375,15 @@ impl RoomKernel {
                                     // the updated entry isn't the last output.
                                     let broadcast_output_index = {
                                         let mut sd = state_doc_for_iopub.write().await;
-                                        sd.merge(&mut fork).ok();
+                                        if let Err(e) =
+                                            crate::notebook_sync_server::catch_automerge_panic(
+                                                "iopub-stream-output-merge",
+                                                || sd.merge(&mut fork),
+                                            )
+                                        {
+                                            warn!("{}", e);
+                                            sd.rebuild_from_save();
+                                        }
 
                                         let broadcast_idx = match &upsert_result {
                                             Ok((updated, output_index)) => {
@@ -1560,7 +1573,15 @@ impl RoomKernel {
 
                                         {
                                             let mut sd = state_doc_for_iopub.write().await;
-                                            sd.merge(&mut fork).ok();
+                                            if let Err(e) =
+                                                crate::notebook_sync_server::catch_automerge_panic(
+                                                    "iopub-output-merge",
+                                                    || sd.merge(&mut fork),
+                                                )
+                                            {
+                                                warn!("{}", e);
+                                                sd.rebuild_from_save();
+                                            }
                                             let _ = state_changed_for_iopub.send(());
                                         }
 
@@ -1602,7 +1623,13 @@ impl RoomKernel {
                                         let mut sd = state_doc_for_iopub.write().await;
                                         match updated {
                                             Ok(true) => {
-                                                sd.merge(&mut fork).ok();
+                                                if let Err(e) = crate::notebook_sync_server::catch_automerge_panic(
+                                                    "iopub-display-update-merge",
+                                                    || sd.merge(&mut fork),
+                                                ) {
+                                                    warn!("{}", e);
+                                                    sd.rebuild_from_save();
+                                                }
                                                 debug!(
                                                     "[kernel-manager] Updated display_id={}",
                                                     display_id
@@ -1770,7 +1797,15 @@ impl RoomKernel {
 
                                         {
                                             let mut sd = state_doc_for_iopub.write().await;
-                                            sd.merge(&mut fork).ok();
+                                            if let Err(e) =
+                                                crate::notebook_sync_server::catch_automerge_panic(
+                                                    "iopub-error-output-merge",
+                                                    || sd.merge(&mut fork),
+                                                )
+                                            {
+                                                warn!("{}", e);
+                                                sd.rebuild_from_save();
+                                            }
                                             let _ = state_changed_for_iopub.send(());
                                         }
 
@@ -2071,8 +2106,6 @@ impl RoomKernel {
         let shell_cell_id_map = self.cell_id_map.clone();
         let shell_pending_history = self.pending_history.clone();
         let shell_pending_completions = self.pending_completions.clone();
-        // Additional resources for handling page payloads (IPython ? and ?? help)
-        let _shell_doc = self.doc.clone();
         let shell_state_doc = self.state_doc.clone();
         let shell_state_changed_tx = self.state_changed_tx.clone();
         let shell_blob_store = self.blob_store.clone();
@@ -2156,7 +2189,13 @@ impl RoomKernel {
 
                                             {
                                                 let mut sd = shell_state_doc.write().await;
-                                                sd.merge(&mut fork).ok();
+                                                if let Err(e) = crate::notebook_sync_server::catch_automerge_panic(
+                                                    "shell-output-merge",
+                                                    || sd.merge(&mut fork),
+                                                ) {
+                                                    warn!("{}", e);
+                                                    sd.rebuild_from_save();
+                                                }
                                                 let _ = shell_state_changed_tx.send(());
                                             }
 
@@ -3090,9 +3129,6 @@ mod tests {
     fn test_room_kernel_new() {
         let tmp = tempfile::TempDir::new().unwrap();
         let (tx, _rx) = broadcast::channel(16);
-        let (changed_tx, _changed_rx) = broadcast::channel(16);
-        let (persist_tx, _persist_rx) = watch::channel::<Option<Vec<u8>>>(None);
-        let doc = Arc::new(RwLock::new(NotebookDoc::new("test-notebook")));
         let blob_store = Arc::new(BlobStore::new(tmp.path().join("blobs")));
         let state_doc = Arc::new(RwLock::new(RuntimeStateDoc::new()));
         let (state_changed_tx, _state_changed_rx) = broadcast::channel(16);
@@ -3100,9 +3136,6 @@ mod tests {
         let (presence_tx, _presence_rx) = broadcast::channel(16);
         let kernel = RoomKernel::new(
             tx,
-            doc,
-            persist_tx,
-            changed_tx,
             blob_store,
             state_doc,
             state_changed_tx,

--- a/crates/runtimed/src/kernel_manager.rs
+++ b/crates/runtimed/src/kernel_manager.rs
@@ -660,21 +660,27 @@ impl RoomKernel {
                     }
                     QueueCommand::ExecutionCountSet {
                         cell_id,
-                        execution_id: _,
+                        execution_id,
                         execution_count,
                     } => {
+                        // Guard against stale writes: only update if the cell's
+                        // current execution_id matches. A ClearOutputs or new
+                        // execution may have already moved the cell forward.
                         let mut doc_guard = doc.write().await;
-                        if let Err(e) =
-                            doc_guard.set_execution_count(&cell_id, &execution_count.to_string())
-                        {
-                            warn!(
-                                "[notebook-sync] Failed to set execution_count in doc: {}",
-                                e
-                            );
+                        let current_eid = doc_guard.get_execution_id(&cell_id);
+                        if current_eid.as_deref() == Some(&execution_id) {
+                            if let Err(e) = doc_guard
+                                .set_execution_count(&cell_id, &execution_count.to_string())
+                            {
+                                warn!(
+                                    "[notebook-sync] Failed to set execution_count in doc: {}",
+                                    e
+                                );
+                            }
+                            let bytes = doc_guard.save();
+                            let _ = changed_tx.send(());
+                            let _ = persist_tx.send(Some(bytes));
                         }
-                        let bytes = doc_guard.save();
-                        let _ = changed_tx.send(());
-                        let _ = persist_tx.send(Some(bytes));
                     }
                 }
             }
@@ -1373,7 +1379,7 @@ impl RoomKernel {
                                     // and broadcast. The fork's index is where the upsert
                                     // actually wrote — using merged len()-1 would be wrong if
                                     // the updated entry isn't the last output.
-                                    let broadcast_output_index = {
+                                    let merge_ok = {
                                         let mut sd = state_doc_for_iopub.write().await;
                                         if let Err(e) =
                                             crate::notebook_sync_server::catch_automerge_panic(
@@ -1383,9 +1389,14 @@ impl RoomKernel {
                                         {
                                             warn!("{}", e);
                                             sd.rebuild_from_save();
+                                            false
+                                        } else {
+                                            true
                                         }
+                                    };
 
-                                        let broadcast_idx = match &upsert_result {
+                                    if merge_ok {
+                                        let broadcast_output_index = match &upsert_result {
                                             Ok((updated, output_index)) => {
                                                 let mut terminals = stream_terminals.lock().await;
                                                 terminals.set_output_state(
@@ -1412,16 +1423,14 @@ impl RoomKernel {
                                         };
 
                                         let _ = state_changed_for_iopub.send(());
-                                        broadcast_idx
-                                    };
-
-                                    let _ = broadcast_tx.send(NotebookBroadcast::Output {
-                                        cell_id: cid.clone(),
-                                        execution_id: eid,
-                                        output_type: "stream".to_string(),
-                                        output_json: output_ref,
-                                        output_index: broadcast_output_index,
-                                    });
+                                        let _ = broadcast_tx.send(NotebookBroadcast::Output {
+                                            cell_id: cid.clone(),
+                                            execution_id: eid,
+                                            output_type: "stream".to_string(),
+                                            output_json: output_ref,
+                                            output_index: broadcast_output_index,
+                                        });
+                                    }
                                 }
                             }
 
@@ -1571,7 +1580,7 @@ impl RoomKernel {
                                             );
                                         }
 
-                                        {
+                                        let merge_ok = {
                                             let mut sd = state_doc_for_iopub.write().await;
                                             if let Err(e) =
                                                 crate::notebook_sync_server::catch_automerge_panic(
@@ -1581,17 +1590,22 @@ impl RoomKernel {
                                             {
                                                 warn!("{}", e);
                                                 sd.rebuild_from_save();
+                                                false
+                                            } else {
+                                                let _ = state_changed_for_iopub.send(());
+                                                true
                                             }
-                                            let _ = state_changed_for_iopub.send(());
-                                        }
+                                        };
 
-                                        let _ = broadcast_tx.send(NotebookBroadcast::Output {
-                                            cell_id: cid.clone(),
-                                            execution_id: eid,
-                                            output_type: output_type.to_string(),
-                                            output_json: output_ref,
-                                            output_index: None,
-                                        });
+                                        if merge_ok {
+                                            let _ = broadcast_tx.send(NotebookBroadcast::Output {
+                                                cell_id: cid.clone(),
+                                                execution_id: eid,
+                                                output_type: output_type.to_string(),
+                                                output_json: output_ref,
+                                                output_index: None,
+                                            });
+                                        }
                                     }
                                 }
                             }
@@ -1619,7 +1633,7 @@ impl RoomKernel {
                                     )
                                     .await;
 
-                                    {
+                                    let merge_ok = {
                                         let mut sd = state_doc_for_iopub.write().await;
                                         match updated {
                                             Ok(true) => {
@@ -1629,35 +1643,42 @@ impl RoomKernel {
                                                 ) {
                                                     warn!("{}", e);
                                                     sd.rebuild_from_save();
+                                                    false
+                                                } else {
+                                                    debug!(
+                                                        "[kernel-manager] Updated display_id={}",
+                                                        display_id
+                                                    );
+                                                    true
                                                 }
-                                                debug!(
-                                                    "[kernel-manager] Updated display_id={}",
-                                                    display_id
-                                                );
                                             }
                                             Ok(false) => {
                                                 error!(
                                                     "[kernel-manager] No output found for display_id={}",
                                                     display_id
                                                 );
+                                                false
                                             }
                                             Err(e) => {
                                                 error!(
                                                     "[kernel-manager] Failed to update display: {}",
                                                     e
                                                 );
+                                                false
                                             }
                                         }
-                                        let _ = state_changed_for_iopub.send(());
-                                    }
+                                    };
 
-                                    // Broadcast for immediate UI update
-                                    let _ = broadcast_tx.send(NotebookBroadcast::DisplayUpdate {
-                                        display_id: display_id.clone(),
-                                        data: serde_json::to_value(&update.data)
-                                            .unwrap_or_default(),
-                                        metadata: update.metadata.clone(),
-                                    });
+                                    if merge_ok {
+                                        let _ = state_changed_for_iopub.send(());
+                                        let _ =
+                                            broadcast_tx.send(NotebookBroadcast::DisplayUpdate {
+                                                display_id: display_id.clone(),
+                                                data: serde_json::to_value(&update.data)
+                                                    .unwrap_or_default(),
+                                                metadata: update.metadata.clone(),
+                                            });
+                                    }
                                 }
                             }
 
@@ -1795,7 +1816,7 @@ impl RoomKernel {
                                             );
                                         }
 
-                                        {
+                                        let merge_ok = {
                                             let mut sd = state_doc_for_iopub.write().await;
                                             if let Err(e) =
                                                 crate::notebook_sync_server::catch_automerge_panic(
@@ -1805,17 +1826,22 @@ impl RoomKernel {
                                             {
                                                 warn!("{}", e);
                                                 sd.rebuild_from_save();
+                                                false
+                                            } else {
+                                                let _ = state_changed_for_iopub.send(());
+                                                true
                                             }
-                                            let _ = state_changed_for_iopub.send(());
-                                        }
+                                        };
 
-                                        let _ = broadcast_tx.send(NotebookBroadcast::Output {
-                                            cell_id: cid.clone(),
-                                            execution_id: eid.clone(),
-                                            output_type: "error".to_string(),
-                                            output_json: output_ref,
-                                            output_index: None,
-                                        });
+                                        if merge_ok {
+                                            let _ = broadcast_tx.send(NotebookBroadcast::Output {
+                                                cell_id: cid.clone(),
+                                                execution_id: eid.clone(),
+                                                output_type: "error".to_string(),
+                                                output_json: output_ref,
+                                                output_index: None,
+                                            });
+                                        }
                                     }
 
                                     // Signal cell error for stop-on-error
@@ -2187,7 +2213,7 @@ impl RoomKernel {
                                                 );
                                             }
 
-                                            {
+                                            let merge_ok = {
                                                 let mut sd = shell_state_doc.write().await;
                                                 if let Err(e) = crate::notebook_sync_server::catch_automerge_panic(
                                                     "shell-output-merge",
@@ -2195,22 +2221,27 @@ impl RoomKernel {
                                                 ) {
                                                     warn!("{}", e);
                                                     sd.rebuild_from_save();
+                                                    false
+                                                } else {
+                                                    let _ = shell_state_changed_tx.send(());
+                                                    true
                                                 }
-                                                let _ = shell_state_changed_tx.send(());
-                                            }
+                                            };
 
-                                            // Broadcast to all windows
-                                            let _ = shell_broadcast_tx.send(
-                                                NotebookBroadcast::Output {
-                                                    cell_id: cid.clone(),
-                                                    execution_id: execution_id
-                                                        .clone()
-                                                        .unwrap_or_default(),
-                                                    output_type: "display_data".to_string(),
-                                                    output_json: output_ref,
-                                                    output_index: None,
-                                                },
-                                            );
+                                            if merge_ok {
+                                                // Broadcast to all windows
+                                                let _ = shell_broadcast_tx.send(
+                                                    NotebookBroadcast::Output {
+                                                        cell_id: cid.clone(),
+                                                        execution_id: execution_id
+                                                            .clone()
+                                                            .unwrap_or_default(),
+                                                        output_type: "display_data".to_string(),
+                                                        output_json: output_ref,
+                                                        output_index: None,
+                                                    },
+                                                );
+                                            }
                                         }
                                     }
                                 }

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -2635,9 +2635,6 @@ async fn auto_launch_kernel(
     // Create new kernel
     let mut kernel = RoomKernel::new(
         room.kernel_broadcast_tx.clone(),
-        room.doc.clone(),
-        room.persist_tx.clone(),
-        room.changed_tx.clone(),
         room.blob_store.clone(),
         room.state_doc.clone(),
         room.state_changed_tx.clone(),
@@ -3028,7 +3025,12 @@ async fn auto_launch_kernel(
             let es = kernel.env_source().to_string();
 
             // Take the command receiver and spawn a task to process execution events
-            kernel.start_command_loop(room.kernel.clone());
+            kernel.start_command_loop(
+                room.kernel.clone(),
+                room.doc.clone(),
+                room.persist_tx.clone(),
+                room.changed_tx.clone(),
+            );
 
             *kernel_guard = Some(kernel);
 
@@ -3331,9 +3333,6 @@ async fn handle_notebook_request(
             // Create new kernel
             let mut kernel = RoomKernel::new(
                 room.kernel_broadcast_tx.clone(),
-                room.doc.clone(),
-                room.persist_tx.clone(),
-                room.changed_tx.clone(),
                 room.blob_store.clone(),
                 room.state_doc.clone(),
                 room.state_changed_tx.clone(),
@@ -3757,7 +3756,12 @@ async fn handle_notebook_request(
                     let es = kernel.env_source().to_string();
 
                     // Take the command receiver and spawn a task to process execution events
-                    kernel.start_command_loop(room.kernel.clone());
+                    kernel.start_command_loop(
+                        room.kernel.clone(),
+                        room.doc.clone(),
+                        room.persist_tx.clone(),
+                        room.changed_tx.clone(),
+                    );
 
                     *kernel_guard = Some(kernel);
                     // Drop the kernel lock before awaiting the presence update


### PR DESCRIPTION
## Summary

First step of #832 (runtime agents) — implements #1332.

- **Moves `execution_count` write** from the kernel's IOPub task to the coordinator's command loop via a new `QueueCommand::ExecutionCountSet` variant. The kernel now writes `execution_count` to RuntimeStateDoc only (source of truth) and tells the coordinator to persist it in NotebookDoc for `.ipynb` export.
- **Removes `doc`, `persist_tx`, `changed_tx`** from `RoomKernel` struct — the kernel no longer holds any reference to NotebookDoc. This is the prerequisite for making RoomKernel a proper Automerge peer.
- **Replaces 5x `.merge().ok()`** in `kernel_manager.rs` with `catch_automerge_panic` + `warn!` + `rebuild_from_save()`. Merge failures were previously silent — now logged with descriptive labels (`iopub-stream-output-merge`, `iopub-output-merge`, `iopub-display-update-merge`, `iopub-error-output-merge`, `shell-output-merge`).

### State ownership after this change

| State | Writer | Where |
|-------|--------|-------|
| Cell `execution_count` | Coordinator (via `QueueCommand`) | NotebookDoc |
| Execution entry `execution_count` | Kernel IOPub | RuntimeStateDoc |
| Cell outputs (manifests) | Kernel IOPub | RuntimeStateDoc |
| Kernel status, queue, comms | Kernel | RuntimeStateDoc |
| Cell source, position, metadata | Frontend WASM | NotebookDoc |

The kernel's remaining doc dependency is `Arc<RwLock<RuntimeStateDoc>>` (shared with coordinator). Separating that is the domain of #1333 (process-isolated agent).

## Test plan

- [x] `cargo build` — compiles clean
- [x] `cargo xtask lint --fix` — no issues
- [x] `cargo test -p runtimed --lib` — 184 unit tests pass
- [x] `cargo test -p notebook-doc --lib` — 281 unit tests pass
- [ ] `cargo xtask integration` — needs running daemon
- [ ] Manual: open notebook, execute cell, verify `execution_count` appears in gutter
- [ ] Manual: verify `.ipynb` save includes `execution_count`

Closes #1332
Part of #832