### PR TITLE
feat(mcp): support bulk clear_outputs with optional cell_ids

### DIFF
--- a/crates/notebook/src/mcpb_install.rs
+++ b/crates/notebook/src/mcpb_install.rs
@@ -79,7 +79,7 @@ pub fn install_mcpb(app: &tauri::AppHandle) -> Result<PathBuf, String> {
             { "name": "set_cell", "description": "Update a cell's source and/or type" },
             { "name": "delete_cell", "description": "Delete a cell" },
             { "name": "move_cell", "description": "Move a cell to a new position" },
-            { "name": "clear_outputs", "description": "Clear a cell's outputs" },
+            { "name": "clear_outputs", "description": "Clear cell outputs by cell_ids, or all outputs if omitted" },
             { "name": "execute_cell", "description": "Execute a cell and return results" },
             { "name": "run_all_cells", "description": "Queue all code cells for execution" },
             { "name": "interrupt_kernel", "description": "Interrupt the currently executing cell" },

--- a/crates/runt-mcp/src/tools/cell_crud.rs
+++ b/crates/runt-mcp/src/tools/cell_crud.rs
@@ -343,10 +343,10 @@ pub async fn clear_outputs(
         }
     };
 
-    // If cell_ids provided and non-empty, clear those; otherwise clear all.
+    // If cell_ids provided, clear those (empty list = no-op); otherwise clear all.
     let cell_ids: Vec<String> = match explicit_ids {
-        Some(ids) if !ids.is_empty() => ids,
-        _ => session.handle.get_cell_ids(),
+        Some(ids) => ids,
+        None => session.handle.get_cell_ids(),
     };
 
     let peer_label = server.get_peer_label().await;

--- a/crates/runt-mcp/src/tools/cell_crud.rs
+++ b/crates/runt-mcp/src/tools/cell_crud.rs
@@ -327,11 +327,15 @@ pub async fn clear_outputs(
     server: &NteractMcp,
     request: &CallToolRequestParams,
 ) -> Result<CallToolResult, McpError> {
-    let explicit_ids: Option<Vec<String>> = request
-        .arguments
-        .as_ref()
-        .and_then(|a| a.get("cell_ids"))
-        .and_then(|v| serde_json::from_value(v.clone()).ok());
+    // Parse cell_ids; reject malformed values instead of falling back to clear-all.
+    let explicit_ids: Option<Vec<String>> =
+        match request.arguments.as_ref().and_then(|a| a.get("cell_ids")) {
+            Some(v) => Some(serde_json::from_value(v.clone()).map_err(|e| {
+                let msg = format!("cell_ids must be an array of strings: {e}");
+                McpError::invalid_params(msg, None)
+            })?),
+            None => None,
+        };
 
     let session = server.session.read().await;
     let session = match session.as_ref() {
@@ -348,6 +352,19 @@ pub async fn clear_outputs(
         Some(ids) => ids,
         None => session.handle.get_cell_ids(),
     };
+
+    // Validate that all requested cell IDs exist in the notebook.
+    if !cell_ids.is_empty() {
+        let all_ids = session.handle.get_cell_ids();
+        let unknown: Vec<&str> = cell_ids
+            .iter()
+            .filter(|id| !all_ids.contains(id))
+            .map(|s| s.as_str())
+            .collect();
+        if !unknown.is_empty() {
+            return tool_error(&format!("Unknown cell IDs: {}", unknown.join(", ")));
+        }
+    }
 
     let peer_label = server.get_peer_label().await;
     let mut cleared = Vec::new();

--- a/crates/runt-mcp/src/tools/cell_crud.rs
+++ b/crates/runt-mcp/src/tools/cell_crud.rs
@@ -74,8 +74,8 @@ pub struct MoveCellParams {
 #[allow(dead_code)]
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct ClearOutputsParams {
-    /// The cell ID to clear outputs for.
-    pub cell_id: String,
+    /// Cell IDs to clear outputs for. If omitted or empty, clears outputs for ALL cells (destructive).
+    pub cell_ids: Option<Vec<String>>,
 }
 
 /// Create a new cell, optionally executing it.
@@ -327,8 +327,11 @@ pub async fn clear_outputs(
     server: &NteractMcp,
     request: &CallToolRequestParams,
 ) -> Result<CallToolResult, McpError> {
-    let cell_id = arg_str(request, "cell_id")
-        .ok_or_else(|| McpError::invalid_params("Missing required parameter: cell_id", None))?;
+    let explicit_ids: Option<Vec<String>> = request
+        .arguments
+        .as_ref()
+        .and_then(|a| a.get("cell_ids"))
+        .and_then(|v| serde_json::from_value(v.clone()).ok());
 
     let session = server.session.read().await;
     let session = match session.as_ref() {
@@ -340,24 +343,42 @@ pub async fn clear_outputs(
         }
     };
 
-    let peer_label = server.get_peer_label().await;
-    crate::presence::emit_focus(&session.handle, cell_id, &peer_label).await;
+    // If cell_ids provided and non-empty, clear those; otherwise clear all.
+    let cell_ids: Vec<String> = match explicit_ids {
+        Some(ids) if !ids.is_empty() => ids,
+        _ => session.handle.get_cell_ids(),
+    };
 
-    // Send ClearOutputs request to the daemon — outputs live in RuntimeStateDoc,
-    // so the daemon handles clearing the execution_id pointer and outputs.
-    match session
-        .handle
-        .send_request(NotebookRequest::ClearOutputs {
-            cell_id: cell_id.to_string(),
-        })
-        .await
-    {
-        Ok(_) => {
-            let result = serde_json::json!({ "cell_id": cell_id, "cleared": true });
-            tool_success(&serde_json::to_string_pretty(&result).unwrap_or_default())
+    let peer_label = server.get_peer_label().await;
+    let mut cleared = Vec::new();
+    let mut failed = Vec::new();
+
+    for id in &cell_ids {
+        crate::presence::emit_focus(&session.handle, id, &peer_label).await;
+
+        match session
+            .handle
+            .send_request(NotebookRequest::ClearOutputs {
+                cell_id: id.clone(),
+            })
+            .await
+        {
+            Ok(_) => cleared.push(id.as_str()),
+            Err(e) => failed.push(format!("{id}: {e}")),
         }
-        Err(e) => tool_error(&format!("Failed to clear outputs: {e}")),
     }
+
+    if !failed.is_empty() {
+        return tool_error(&format!(
+            "Cleared {}/{} cells. Failures: {}",
+            cleared.len(),
+            cell_ids.len(),
+            failed.join(", ")
+        ));
+    }
+
+    let result = serde_json::json!({ "cleared": cleared.len() });
+    tool_success(&serde_json::to_string_pretty(&result).unwrap_or_default())
 }
 
 /// Build a CallToolResult from an ExecutionResult, including structured content.

--- a/crates/runt-mcp/src/tools/mod.rs
+++ b/crates/runt-mcp/src/tools/mod.rs
@@ -153,7 +153,7 @@ pub fn all_tools() -> Vec<Tool> {
         ),
         Tool::new(
             "clear_outputs",
-            "Clear a cell's outputs.",
+            "Clear cell outputs. Pass cell_ids to clear specific cells, or omit to clear ALL outputs (destructive).",
             schema_for::<cell_crud::ClearOutputsParams>(),
         )
         .annotate(


### PR DESCRIPTION
## Summary
- `clear_outputs` now accepts an optional `cell_ids: string[]` parameter
- Pass specific cell IDs to clear those cells, or omit to clear ALL outputs
- Already annotated as `destructive(true)` in MCP tool annotations
- Updated tool description and mcpb install manifest

## Test plan
- [ ] Call `clear_outputs` with no args — should clear all cell outputs
- [ ] Call `clear_outputs` with `cell_ids: ["id1", "id2"]` — should clear only those cells
- [ ] Call `clear_outputs` with `cell_ids: []` — should clear all (empty = omitted)
- [ ] Verify MCP clients see the updated schema (cell_ids is optional array)

🤖 Generated with [Claude Code](https://claude.com/claude-code)