### PR TITLE
fix(xtask): run pnpm install in cmd_build before frontend build

### DIFF
--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -588,6 +588,7 @@ fn cmd_build(rust_only: bool) {
     require_tauri();
     if !rust_only {
         require_pnpm();
+        ensure_pnpm_install();
     }
 
     // Phase 0: Build the MCP widget HTML before any Rust compilation.


### PR DESCRIPTION
## Summary

- `cargo xtask build` on a fresh clone fails because `pnpm build` runs without `node_modules` populated
- `cmd_dev` already called `ensure_pnpm_install()` before `cmd_build()`, but running `cargo xtask build` directly skipped it
- Adds the same smart `ensure_pnpm_install()` check inside `cmd_build` so it's self-contained — the check is cheap (compares mtimes) and no-ops when deps are already up to date

## Test plan

- [ ] `cargo xtask build` on a fresh clone succeeds without manual `pnpm install`
- [ ] `cargo xtask build --rust-only` still skips pnpm entirely
- [ ] `cargo xtask dev --skip-install` still skips pnpm install (the redundant call in `cmd_build` is a no-op since `cmd_dev` already ran it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)