### PR TITLE
feat(runtimed): runtime agent module — sync-only subprocess main loop

### DIFF
--- a/crates/runtimed/src/agent.rs
+++ b/crates/runtimed/src/agent.rs
@@ -302,8 +302,10 @@ async fn handle_agent_request(request: AgentRequest, ctx: &AgentContext) -> Agen
 
             // Reconstruct PooledEnv from launched_config paths if available.
             let pooled_env = launched_config.venv_path.as_ref().and_then(|venv| {
-                launched_config.python_path.as_ref().map(|python| {
-                    runtimed_client::PooledEnv {
+                launched_config
+                    .python_path
+                    .as_ref()
+                    .map(|python| runtimed_client::PooledEnv {
                         env_type: if env_source.starts_with("conda") {
                             runtimed_client::EnvType::Conda
                         } else {
@@ -312,14 +314,19 @@ async fn handle_agent_request(request: AgentRequest, ctx: &AgentContext) -> Agen
                         venv_path: venv.clone(),
                         python_path: python.clone(),
                         prewarmed_packages: launched_config.prewarmed_packages.clone(),
-                    }
-                })
+                    })
             });
 
             let nb_path = notebook_path.as_deref().map(std::path::Path::new);
 
             match k
-                .launch(&kernel_type, &env_source, nb_path, pooled_env, launched_config)
+                .launch(
+                    &kernel_type,
+                    &env_source,
+                    nb_path,
+                    pooled_env,
+                    launched_config,
+                )
                 .await
             {
                 Ok(()) => {

--- a/crates/runtimed/src/agent.rs
+++ b/crates/runtimed/src/agent.rs
@@ -1,0 +1,500 @@
+//! Process-isolated runtime agent.
+//!
+//! The agent is a subprocess spawned by the coordinator (daemon) that owns
+//! the kernel lifecycle, IOPub processing, execution queue, and RuntimeStateDoc
+//! writes. It communicates with the coordinator over stdin/stdout using the
+//! existing framed protocol.
+//!
+//! ## Sync-only architecture
+//!
+//! The agent does **not** forward `NotebookBroadcast` messages. All kernel
+//! state changes (outputs, execution lifecycle, queue, comms, kernel status)
+//! flow through RuntimeStateDoc Automerge sync (frame 0x05). The only
+//! explicit messages are `AgentNotification` for things the coordinator must
+//! act on outside of RuntimeStateDoc (writing to NotebookDoc, cleaning up
+//! the agent handle).
+//!
+//! ## Protocol
+//!
+//! - Frame 0x01: `AgentRequest` (coordinator → agent)
+//! - Frame 0x02: `AgentResponse` (agent → coordinator)
+//! - Frame 0x03: `AgentNotification` (agent → coordinator, rare)
+//! - Frame 0x05: `RuntimeStateSync` (bidirectional Automerge sync)
+//!
+//! ## Lifecycle
+//!
+//! 1. Coordinator spawns agent, sends preamble + `Handshake::RuntimeAgent`
+//! 2. Agent bootstraps RuntimeStateDoc via initial sync (frame 0x05)
+//! 3. Agent creates RoomKernel with local channels
+//! 4. Main select loop: stdin frames, RuntimeStateDoc changes, QueueCommands
+//! 5. On shutdown or coordinator disconnect, agent exits
+
+use std::sync::Arc;
+
+use log::{debug, info, warn};
+use notebook_doc::presence::PresenceState;
+use notebook_doc::runtime_state::RuntimeStateDoc;
+use notebook_protocol::connection::{
+    recv_frame, recv_json_frame, recv_preamble, send_preamble, send_typed_frame, Handshake,
+    NotebookFrameType,
+};
+use notebook_protocol::protocol::{AgentRequest, AgentResponse};
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::sync::{broadcast, RwLock};
+
+use crate::blob_store::BlobStore;
+use crate::kernel_manager::{QueueCommand, RoomKernel};
+
+/// Shared agent state passed to request/command handlers.
+struct AgentContext {
+    kernel: Arc<tokio::sync::Mutex<Option<RoomKernel>>>,
+    state_doc: Arc<RwLock<RuntimeStateDoc>>,
+    state_changed_tx: broadcast::Sender<()>,
+    blob_store: Arc<BlobStore>,
+    /// RoomKernel requires a broadcast_tx at construction. The agent creates
+    /// a channel but never reads from it — all state flows via CRDT sync.
+    broadcast_tx: broadcast::Sender<notebook_protocol::protocol::NotebookBroadcast>,
+    presence: Arc<RwLock<PresenceState>>,
+    presence_tx: broadcast::Sender<(String, Vec<u8>)>,
+}
+
+/// Run the runtime agent on the given stdin/stdout streams.
+///
+/// This is the agent's main entry point. It reads the handshake from stdin,
+/// bootstraps its RuntimeStateDoc, and enters the main event loop.
+pub async fn run_agent<R, W>(mut reader: R, mut writer: W) -> anyhow::Result<()>
+where
+    R: AsyncRead + Unpin + Send + 'static,
+    W: AsyncWrite + Unpin + Send + 'static,
+{
+    // ── 1. Read preamble + handshake ────────────────────────────────────────
+
+    recv_preamble(&mut reader).await?;
+    let handshake: Handshake = recv_json_frame(&mut reader)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("EOF before handshake"))?;
+
+    let (notebook_id, agent_id, blob_root) = match handshake {
+        Handshake::RuntimeAgent {
+            notebook_id,
+            agent_id,
+            blob_root,
+        } => (notebook_id, agent_id, blob_root),
+        other => {
+            anyhow::bail!(
+                "Expected RuntimeAgent handshake, got {:?}",
+                std::mem::discriminant(&other)
+            );
+        }
+    };
+
+    info!(
+        "[agent] Starting agent_id={} notebook_id={} blob_root={}",
+        agent_id, notebook_id, blob_root
+    );
+
+    // Send preamble back to coordinator (confirms protocol version)
+    send_preamble(&mut writer).await?;
+
+    // ── 2. Bootstrap RuntimeStateDoc ────────────────────────────────────────
+
+    let mut state_doc = RuntimeStateDoc::new();
+    state_doc.set_actor(&agent_id);
+
+    // TODO: Initial sync — read RuntimeStateSync frames from coordinator
+    // until convergence. For now, start with empty doc.
+
+    let state_doc = Arc::new(RwLock::new(state_doc));
+    let (state_changed_tx, mut state_changed_rx) = broadcast::channel::<()>(64);
+
+    // Automerge sync state for the coordinator peer. Persistent across the
+    // agent's lifetime so incremental sync works correctly.
+    let mut coordinator_sync_state = automerge::sync::State::new();
+
+    // ── 3. Create local infrastructure ──────────────────────────────────────
+
+    let blob_store = Arc::new(BlobStore::new(std::path::PathBuf::from(&blob_root)));
+
+    // RoomKernel requires a broadcast channel even though we don't forward
+    // broadcasts. The kernel's IOPub task sends on it; we just don't read.
+    let (broadcast_tx, _broadcast_rx) =
+        broadcast::channel::<notebook_protocol::protocol::NotebookBroadcast>(16);
+
+    // Presence — kernel writes status here but we rely on RuntimeStateDoc
+    // sync for propagation, not presence frames.
+    let presence = Arc::new(RwLock::new(PresenceState::new()));
+    let (presence_tx, _presence_rx) = broadcast::channel::<(String, Vec<u8>)>(16);
+
+    let ctx = AgentContext {
+        kernel: Arc::new(tokio::sync::Mutex::new(None)),
+        state_doc,
+        state_changed_tx,
+        blob_store,
+        broadcast_tx,
+        presence,
+        presence_tx,
+    };
+
+    // QueueCommand receiver — starts as None. After LaunchKernel, populated
+    // with the kernel's actual cmd_rx (taken via kernel.take_cmd_rx()).
+    let mut cmd_rx: Option<tokio::sync::mpsc::Receiver<QueueCommand>> = None;
+
+    info!("[agent] Infrastructure ready, entering main loop");
+
+    // ── 4. Main event loop ──────────────────────────────────────────────────
+    //
+    // Three input sources:
+    //   - stdin: AgentRequest frames (0x01), RuntimeStateSync frames (0x05)
+    //   - cmd_rx: QueueCommands from kernel IOPub/shell tasks
+    //   - state_changed_rx: RuntimeStateDoc mutations to sync to coordinator
+    //
+    // Output (stdout): AgentResponse (0x02), AgentNotification (0x03),
+    //   RuntimeStateSync (0x05)
+
+    loop {
+        tokio::select! {
+            // Read next frame from coordinator (stdin)
+            frame = recv_frame(&mut reader) => {
+                match frame {
+                    Ok(Some(data)) => {
+                        if let Err(e) = handle_stdin_frame(
+                            &data,
+                            &mut writer,
+                            &ctx,
+                            &mut coordinator_sync_state,
+                            &mut cmd_rx,
+                        ).await {
+                            warn!("[agent] Error handling stdin frame: {}", e);
+                        }
+                    }
+                    Ok(None) => {
+                        info!("[agent] EOF on stdin, shutting down");
+                        break;
+                    }
+                    Err(e) => {
+                        info!("[agent] stdin read error (coordinator disconnected?): {}", e);
+                        break;
+                    }
+                }
+            }
+
+            // Process QueueCommands from kernel tasks
+            Some(command) = async {
+                match cmd_rx.as_mut() {
+                    Some(rx) => rx.recv().await,
+                    None => std::future::pending().await,
+                }
+            } => {
+                if let Err(e) = handle_queue_command(command, &ctx).await {
+                    warn!("[agent] Error handling queue command: {}", e);
+                }
+            }
+
+            // Sync RuntimeStateDoc changes to coordinator
+            _ = state_changed_rx.recv() => {
+                // Drain any buffered notifications
+                while state_changed_rx.try_recv().is_ok() {}
+
+                // Generate sync message and send as frame 0x05
+                let mut sd = ctx.state_doc.write().await;
+                if let Some(msg) = sd.generate_sync_message(&mut coordinator_sync_state) {
+                    let encoded = msg.encode();
+                    if let Err(e) = send_typed_frame(
+                        &mut writer,
+                        NotebookFrameType::RuntimeStateSync,
+                        &encoded,
+                    ).await {
+                        warn!("[agent] Failed to send RuntimeStateSync: {}", e);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    // ── 5. Cleanup ──────────────────────────────────────────────────────────
+
+    info!("[agent] Shutting down");
+    let mut guard = ctx.kernel.lock().await;
+    if let Some(ref mut k) = *guard {
+        k.shutdown().await.ok();
+    }
+
+    Ok(())
+}
+
+/// Handle a typed frame received from the coordinator on stdin.
+async fn handle_stdin_frame<W: AsyncWrite + Unpin>(
+    data: &[u8],
+    writer: &mut W,
+    ctx: &AgentContext,
+    coordinator_sync_state: &mut automerge::sync::State,
+    cmd_rx: &mut Option<tokio::sync::mpsc::Receiver<QueueCommand>>,
+) -> anyhow::Result<()> {
+    if data.is_empty() {
+        return Ok(());
+    }
+
+    let frame_type = data[0];
+    let payload = &data[1..];
+
+    match frame_type {
+        // AgentRequest (0x01)
+        0x01 => {
+            let request: AgentRequest = serde_json::from_slice(payload)?;
+            let response = handle_agent_request(request, ctx).await;
+
+            // After successful launch, take the kernel's cmd_rx so the
+            // main loop can start processing execution lifecycle events.
+            if matches!(response, AgentResponse::KernelLaunched { .. }) {
+                let mut guard = ctx.kernel.lock().await;
+                if let Some(ref mut k) = *guard {
+                    *cmd_rx = k.take_cmd_rx();
+                }
+            }
+
+            let json = serde_json::to_vec(&response)?;
+            send_typed_frame(writer, NotebookFrameType::Response, &json).await?;
+        }
+
+        // RuntimeStateSync (0x05)
+        0x05 => {
+            // Coordinator is sending RuntimeStateDoc changes (e.g., comm state
+            // from frontend, trust state). Apply to our local replica.
+            let mut sd = ctx.state_doc.write().await;
+            let sync_message = automerge::sync::Message::decode(payload)?;
+            if sd.receive_sync_message_with_changes(coordinator_sync_state, sync_message)? {
+                let _ = ctx.state_changed_tx.send(());
+            }
+        }
+
+        other => {
+            debug!("[agent] Ignoring unknown frame type 0x{:02x}", other);
+        }
+    }
+
+    Ok(())
+}
+
+/// Handle an AgentRequest and return an AgentResponse.
+async fn handle_agent_request(request: AgentRequest, ctx: &AgentContext) -> AgentResponse {
+    match request {
+        AgentRequest::LaunchKernel {
+            kernel_type,
+            env_source,
+            notebook_path,
+            launched_config,
+            env_vars: _,
+        } => {
+            info!(
+                "[agent] LaunchKernel: type={} source={}",
+                kernel_type, env_source
+            );
+
+            let mut k = RoomKernel::new(
+                ctx.broadcast_tx.clone(),
+                ctx.blob_store.clone(),
+                ctx.state_doc.clone(),
+                ctx.state_changed_tx.clone(),
+                ctx.presence.clone(),
+                ctx.presence_tx.clone(),
+            );
+
+            // Reconstruct PooledEnv from launched_config paths if available.
+            let pooled_env = launched_config.venv_path.as_ref().and_then(|venv| {
+                launched_config.python_path.as_ref().map(|python| {
+                    runtimed_client::PooledEnv {
+                        env_type: if env_source.starts_with("conda") {
+                            runtimed_client::EnvType::Conda
+                        } else {
+                            runtimed_client::EnvType::Uv
+                        },
+                        venv_path: venv.clone(),
+                        python_path: python.clone(),
+                        prewarmed_packages: launched_config.prewarmed_packages.clone(),
+                    }
+                })
+            });
+
+            let nb_path = notebook_path.as_deref().map(std::path::Path::new);
+
+            match k
+                .launch(&kernel_type, &env_source, nb_path, pooled_env, launched_config)
+                .await
+            {
+                Ok(()) => {
+                    let es = k.env_source().to_string();
+                    let mut guard = ctx.kernel.lock().await;
+                    *guard = Some(k);
+                    AgentResponse::KernelLaunched { env_source: es }
+                }
+                Err(e) => AgentResponse::Error {
+                    error: format!("Failed to launch kernel: {}", e),
+                },
+            }
+        }
+
+        AgentRequest::ExecuteCell {
+            cell_id,
+            code,
+            execution_id: _,
+        } => {
+            let mut guard = ctx.kernel.lock().await;
+            if let Some(ref mut k) = *guard {
+                match k.queue_cell(cell_id.clone(), code).await {
+                    Ok(eid) => AgentResponse::CellQueued {
+                        cell_id,
+                        execution_id: eid,
+                    },
+                    Err(e) => AgentResponse::Error {
+                        error: format!("Failed to queue cell: {}", e),
+                    },
+                }
+            } else {
+                AgentResponse::Error {
+                    error: "No kernel running".to_string(),
+                }
+            }
+        }
+
+        AgentRequest::InterruptExecution => {
+            let mut guard = ctx.kernel.lock().await;
+            if let Some(ref mut k) = *guard {
+                match k.interrupt().await {
+                    Ok(()) => AgentResponse::Ok,
+                    Err(e) => AgentResponse::Error {
+                        error: format!("Failed to interrupt: {}", e),
+                    },
+                }
+            } else {
+                AgentResponse::Error {
+                    error: "No kernel running".to_string(),
+                }
+            }
+        }
+
+        AgentRequest::ShutdownKernel => {
+            let mut guard = ctx.kernel.lock().await;
+            if let Some(ref mut k) = *guard {
+                k.shutdown().await.ok();
+                *guard = None;
+                AgentResponse::Ok
+            } else {
+                AgentResponse::Ok
+            }
+        }
+
+        AgentRequest::SendComm { message } => {
+            let mut guard = ctx.kernel.lock().await;
+            if let Some(ref mut k) = *guard {
+                match k.send_comm_message(message).await {
+                    Ok(()) => AgentResponse::Ok,
+                    Err(e) => AgentResponse::Error {
+                        error: format!("Failed to send comm: {}", e),
+                    },
+                }
+            } else {
+                AgentResponse::Error {
+                    error: "No kernel running".to_string(),
+                }
+            }
+        }
+
+        AgentRequest::Complete { code, cursor_pos } => {
+            let mut guard = ctx.kernel.lock().await;
+            if let Some(ref mut k) = *guard {
+                match k.complete(code, cursor_pos).await {
+                    Ok((items, cursor_start, cursor_end)) => AgentResponse::CompletionResult {
+                        items,
+                        cursor_start,
+                        cursor_end,
+                    },
+                    Err(e) => AgentResponse::Error {
+                        error: format!("Failed to complete: {}", e),
+                    },
+                }
+            } else {
+                AgentResponse::Error {
+                    error: "No kernel running".to_string(),
+                }
+            }
+        }
+
+        AgentRequest::GetHistory { pattern, n, unique } => {
+            let mut guard = ctx.kernel.lock().await;
+            if let Some(ref mut k) = *guard {
+                match k.get_history(pattern, n, unique).await {
+                    Ok(entries) => AgentResponse::HistoryResult { entries },
+                    Err(e) => AgentResponse::Error {
+                        error: format!("Failed to get history: {}", e),
+                    },
+                }
+            } else {
+                AgentResponse::Error {
+                    error: "No kernel running".to_string(),
+                }
+            }
+        }
+    }
+}
+
+/// Handle a QueueCommand from the kernel's IOPub/shell/heartbeat tasks.
+///
+/// Most kernel state is already in RuntimeStateDoc and syncs automatically.
+/// This handler only deals with events that need explicit coordinator action.
+async fn handle_queue_command(command: QueueCommand, ctx: &AgentContext) -> anyhow::Result<()> {
+    match command {
+        QueueCommand::ExecutionDone {
+            cell_id,
+            execution_id,
+        } => {
+            debug!("[agent] ExecutionDone for {} ({})", cell_id, execution_id);
+            let mut guard = ctx.kernel.lock().await;
+            if let Some(ref mut k) = *guard {
+                if let Err(e) = k.execution_done(&cell_id, &execution_id).await {
+                    warn!("[agent] execution_done error: {}", e);
+                }
+            }
+            // RuntimeStateDoc changes sync automatically via frame 0x05
+        }
+
+        QueueCommand::CellError {
+            cell_id,
+            execution_id,
+        } => {
+            debug!(
+                "[agent] CellError: cell={} execution={}",
+                cell_id, execution_id
+            );
+            // Stop-on-error: clear remaining queue in RuntimeStateDoc
+            let mut guard = ctx.kernel.lock().await;
+            if let Some(ref mut k) = *guard {
+                k.clear_queue();
+                let mut sd = ctx.state_doc.write().await;
+                sd.set_queue(None, &[]);
+                let _ = ctx.state_changed_tx.send(());
+            }
+        }
+
+        QueueCommand::KernelDied => {
+            warn!("[agent] Kernel died");
+            // Write error state to RuntimeStateDoc — syncs to coordinator
+            // automatically. The coordinator also detects child exit.
+            let mut sd = ctx.state_doc.write().await;
+            sd.set_kernel_status("error");
+            sd.set_queue(None, &[]);
+            let _ = ctx.state_changed_tx.send(());
+        }
+
+        QueueCommand::SendCommUpdate { comm_id, state } => {
+            let mut guard = ctx.kernel.lock().await;
+            if let Some(ref mut k) = *guard {
+                if let Err(e) = k.send_comm_update(&comm_id, state).await {
+                    warn!("[agent] Failed to send comm update: {}", e);
+                }
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/crates/runtimed/src/agent.rs
+++ b/crates/runtimed/src/agent.rs
@@ -344,11 +344,16 @@ async fn handle_agent_request(request: AgentRequest, ctx: &AgentContext) -> Agen
         AgentRequest::ExecuteCell {
             cell_id,
             code,
-            execution_id: _,
+            execution_id,
         } => {
             let mut guard = ctx.kernel.lock().await;
             if let Some(ref mut k) = *guard {
-                match k.queue_cell(cell_id.clone(), code).await {
+                // Use the coordinator's execution_id to keep NotebookDoc
+                // and RuntimeStateDoc in sync.
+                match k
+                    .queue_cell_with_id(cell_id.clone(), code, execution_id)
+                    .await
+                {
                     Ok(eid) => AgentResponse::CellQueued {
                         cell_id,
                         execution_id: eid,
@@ -473,11 +478,15 @@ async fn handle_queue_command(command: QueueCommand, ctx: &AgentContext) -> anyh
                 "[agent] CellError: cell={} execution={}",
                 cell_id, execution_id
             );
-            // Stop-on-error: clear remaining queue in RuntimeStateDoc
+            // Stop-on-error: clear remaining queue and mark cleared executions as failed
             let mut guard = ctx.kernel.lock().await;
             if let Some(ref mut k) = *guard {
-                k.clear_queue();
+                let cleared = k.clear_queue();
                 let mut sd = ctx.state_doc.write().await;
+                // Mark each cleared execution as error so callers aren't stuck waiting
+                for entry in &cleared {
+                    sd.set_execution_done(&entry.execution_id, false);
+                }
                 sd.set_queue(None, &[]);
                 let _ = ctx.state_changed_tx.send(());
             }

--- a/crates/runtimed/src/agent.rs
+++ b/crates/runtimed/src/agent.rs
@@ -514,3 +514,112 @@ async fn handle_queue_command(command: QueueCommand, ctx: &AgentContext) -> anyh
 
     Ok(())
 }
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use notebook_protocol::connection::{
+        recv_frame, recv_preamble, send_json_frame, send_preamble, send_typed_frame,
+        NotebookFrameType,
+    };
+    use tokio::io::duplex;
+
+    /// Test that the agent reads the handshake and responds with preamble.
+    #[tokio::test]
+    async fn test_agent_handshake() {
+        let (coordinator_stream, agent_stream) = duplex(8192);
+        let (agent_reader, agent_writer) = tokio::io::split(agent_stream);
+        let (mut coord_reader, mut coord_writer) = tokio::io::split(coordinator_stream);
+
+        let agent_task = tokio::spawn(async move { run_agent(agent_reader, agent_writer).await });
+
+        // Coordinator sends preamble + handshake
+        send_preamble(&mut coord_writer).await.unwrap();
+        send_json_frame(
+            &mut coord_writer,
+            &Handshake::RuntimeAgent {
+                notebook_id: "test-notebook".to_string(),
+                agent_id: "rt:agent:test".to_string(),
+                blob_root: "/tmp/test-blobs".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+
+        // Agent should respond with preamble
+        recv_preamble(&mut coord_reader).await.unwrap();
+
+        // Agent is now in its main loop — abort it
+        agent_task.abort();
+    }
+
+    /// Test that the agent rejects non-RuntimeAgent handshakes.
+    #[tokio::test]
+    async fn test_agent_rejects_wrong_handshake() {
+        let (coordinator_stream, agent_stream) = duplex(8192);
+        let (agent_reader, agent_writer) = tokio::io::split(agent_stream);
+        let (mut _coord_reader, mut coord_writer) = tokio::io::split(coordinator_stream);
+
+        let agent_task = tokio::spawn(async move { run_agent(agent_reader, agent_writer).await });
+
+        // Send wrong handshake type
+        send_preamble(&mut coord_writer).await.unwrap();
+        send_json_frame(&mut coord_writer, &Handshake::Pool)
+            .await
+            .unwrap();
+
+        let result = tokio::time::timeout(std::time::Duration::from_secs(5), agent_task)
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert!(
+            result.is_err(),
+            "Agent should reject non-RuntimeAgent handshake"
+        );
+    }
+
+    /// Test that the agent responds to a ShutdownKernel request (no kernel running → Ok).
+    #[tokio::test]
+    async fn test_agent_shutdown_request() {
+        let (coordinator_stream, agent_stream) = duplex(8192);
+        let (agent_reader, agent_writer) = tokio::io::split(agent_stream);
+        let (mut coord_reader, mut coord_writer) = tokio::io::split(coordinator_stream);
+
+        let agent_task = tokio::spawn(async move { run_agent(agent_reader, agent_writer).await });
+
+        // Handshake
+        send_preamble(&mut coord_writer).await.unwrap();
+        send_json_frame(
+            &mut coord_writer,
+            &Handshake::RuntimeAgent {
+                notebook_id: "test-notebook".to_string(),
+                agent_id: "rt:agent:test".to_string(),
+                blob_root: "/tmp/test-blobs".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+        recv_preamble(&mut coord_reader).await.unwrap();
+
+        // Send ShutdownKernel request
+        let request = AgentRequest::ShutdownKernel;
+        let json = serde_json::to_vec(&request).unwrap();
+        send_typed_frame(&mut coord_writer, NotebookFrameType::Request, &json)
+            .await
+            .unwrap();
+
+        // Read response
+        let response_frame = recv_frame(&mut coord_reader).await.unwrap().unwrap();
+        assert_eq!(response_frame[0], 0x02, "Should be a Response frame");
+        let response: AgentResponse = serde_json::from_slice(&response_frame[1..]).unwrap();
+        assert!(
+            matches!(response, AgentResponse::Ok),
+            "ShutdownKernel with no kernel should return Ok"
+        );
+
+        // Clean up
+        agent_task.abort();
+    }
+}

--- a/crates/runtimed/src/agent_handle.rs
+++ b/crates/runtimed/src/agent_handle.rs
@@ -1,0 +1,415 @@
+//! Coordinator-side management of a runtime agent subprocess.
+//!
+//! `AgentHandle` spawns a `runtimed agent` child process, pipes the framed
+//! protocol on its stdin/stdout, syncs RuntimeStateDoc bidirectionally, and
+//! detects agent exit.
+//!
+//! ## Data flow
+//!
+//! ```text
+//! Coordinator                          Agent subprocess
+//! ──────────                          ─────────────────
+//! AgentRequest (0x01) ──stdin──►      handle_agent_request()
+//! ◄──stdout── AgentResponse (0x02)
+//! ◄──stdout── RuntimeStateSync (0x05)  kernel writes state_doc
+//! RuntimeStateSync (0x05) ──stdin──►  comm state from frontend
+//! ◄──stdout── Broadcast (0x03)         KernelDied notification
+//! ```
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use anyhow::Result;
+use log::{debug, info, warn};
+use notebook_doc::runtime_state::RuntimeStateDoc;
+use notebook_protocol::connection::{
+    recv_frame, send_json_frame, send_preamble, send_typed_frame, Handshake, NotebookFrameType,
+};
+use notebook_protocol::protocol::{
+    AgentNotification, AgentRequest, AgentResponse, LaunchedEnvConfig,
+};
+use tokio::io::{AsyncRead, AsyncWrite, BufReader, BufWriter};
+use tokio::process::{Child, Command};
+use tokio::sync::{broadcast, mpsc, oneshot, RwLock};
+
+/// Handle to a running agent subprocess.
+///
+/// Provides typed methods for sending requests and automatically manages
+/// RuntimeStateDoc sync between coordinator and agent.
+pub struct AgentHandle {
+    /// Channel for sending requests to the IO task (which writes to stdin).
+    request_tx: mpsc::Sender<(AgentRequest, oneshot::Sender<AgentResponse>)>,
+    /// Whether the agent process is still alive.
+    alive: Arc<AtomicBool>,
+    /// Handle to the IO task for cleanup.
+    io_task: tokio::task::JoinHandle<()>,
+    /// Handle to the child process.
+    child: Child,
+}
+
+impl AgentHandle {
+    /// Spawn a new agent subprocess and set up bidirectional communication.
+    ///
+    /// The coordinator sends the preamble + `RuntimeAgent` handshake, then
+    /// starts the IO task for frame multiplexing and RuntimeStateDoc sync.
+    pub async fn spawn(
+        notebook_id: String,
+        agent_id: String,
+        blob_root: PathBuf,
+        state_doc: Arc<RwLock<RuntimeStateDoc>>,
+        state_changed_tx: broadcast::Sender<()>,
+        _broadcast_tx: broadcast::Sender<notebook_protocol::protocol::NotebookBroadcast>,
+    ) -> Result<Self> {
+        // Find the current binary — agent runs as `runtimed agent`
+        let exe = std::env::current_exe()?;
+        info!(
+            "[agent-handle] Spawning agent: {} agent (notebook_id={})",
+            exe.display(),
+            notebook_id
+        );
+
+        let mut child = Command::new(&exe)
+            .arg("agent")
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::inherit())
+            .kill_on_drop(true)
+            .spawn()?;
+
+        let child_stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| anyhow::anyhow!("Failed to capture agent stdin"))?;
+        let child_stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| anyhow::anyhow!("Failed to capture agent stdout"))?;
+
+        let mut writer = BufWriter::new(child_stdin);
+        let mut reader = BufReader::new(child_stdout);
+
+        // Send preamble + handshake
+        send_preamble(&mut writer).await?;
+        send_json_frame(
+            &mut writer,
+            &Handshake::RuntimeAgent {
+                notebook_id: notebook_id.clone(),
+                agent_id: agent_id.clone(),
+                blob_root: blob_root.to_string_lossy().to_string(),
+            },
+        )
+        .await?;
+
+        // Wait for agent's preamble response
+        notebook_protocol::connection::recv_preamble(&mut reader).await?;
+
+        // Send initial RuntimeStateDoc sync to bootstrap the agent
+        {
+            let mut sd = state_doc.write().await;
+            let mut sync_state = automerge::sync::State::new();
+            // Generate sync messages until convergence
+            while let Some(msg) = sd.generate_sync_message(&mut sync_state) {
+                let encoded = msg.encode();
+                send_typed_frame(&mut writer, NotebookFrameType::RuntimeStateSync, &encoded)
+                    .await?;
+            }
+        }
+
+        info!("[agent-handle] Agent spawned and bootstrapped");
+
+        // Set up channels
+        let (request_tx, request_rx) = mpsc::channel(32);
+        let alive = Arc::new(AtomicBool::new(true));
+
+        // Spawn the IO task
+        let io_task = tokio::spawn(io_loop(
+            reader,
+            writer,
+            request_rx,
+            state_doc,
+            state_changed_tx,
+            alive.clone(),
+        ));
+
+        Ok(Self {
+            request_tx,
+            alive,
+            io_task,
+            child,
+        })
+    }
+
+    /// Send a request to the agent and wait for the response.
+    async fn send_request(&self, request: AgentRequest) -> Result<AgentResponse> {
+        if !self.alive.load(Ordering::Relaxed) {
+            return Ok(AgentResponse::Error {
+                error: "Agent is not running".to_string(),
+            });
+        }
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.request_tx
+            .send((request, reply_tx))
+            .await
+            .map_err(|_| anyhow::anyhow!("Agent IO task closed"))?;
+        reply_rx
+            .await
+            .map_err(|_| anyhow::anyhow!("Agent IO task dropped response"))
+    }
+
+    /// Launch a kernel in the agent subprocess.
+    pub async fn launch_kernel(
+        &self,
+        kernel_type: &str,
+        env_source: &str,
+        notebook_path: Option<&str>,
+        launched_config: LaunchedEnvConfig,
+    ) -> Result<AgentResponse> {
+        self.send_request(AgentRequest::LaunchKernel {
+            kernel_type: kernel_type.to_string(),
+            env_source: env_source.to_string(),
+            notebook_path: notebook_path.map(String::from),
+            launched_config,
+            env_vars: Default::default(),
+        })
+        .await
+    }
+
+    /// Execute a cell in the agent's kernel.
+    pub async fn execute_cell(
+        &self,
+        cell_id: &str,
+        code: &str,
+        execution_id: &str,
+    ) -> Result<AgentResponse> {
+        self.send_request(AgentRequest::ExecuteCell {
+            cell_id: cell_id.to_string(),
+            code: code.to_string(),
+            execution_id: execution_id.to_string(),
+        })
+        .await
+    }
+
+    /// Interrupt the currently executing cell.
+    pub async fn interrupt(&self) -> Result<AgentResponse> {
+        self.send_request(AgentRequest::InterruptExecution).await
+    }
+
+    /// Shutdown the agent's kernel.
+    pub async fn shutdown_kernel(&self) -> Result<AgentResponse> {
+        self.send_request(AgentRequest::ShutdownKernel).await
+    }
+
+    /// Send a comm message to the agent's kernel.
+    pub async fn send_comm(&self, message: serde_json::Value) -> Result<AgentResponse> {
+        self.send_request(AgentRequest::SendComm { message }).await
+    }
+
+    /// Request code completions.
+    pub async fn complete(&self, code: &str, cursor_pos: usize) -> Result<AgentResponse> {
+        self.send_request(AgentRequest::Complete {
+            code: code.to_string(),
+            cursor_pos,
+        })
+        .await
+    }
+
+    /// Search kernel input history.
+    pub async fn get_history(
+        &self,
+        pattern: Option<&str>,
+        n: i32,
+        unique: bool,
+    ) -> Result<AgentResponse> {
+        self.send_request(AgentRequest::GetHistory {
+            pattern: pattern.map(String::from),
+            n,
+            unique,
+        })
+        .await
+    }
+
+    /// Check if the agent process is still alive.
+    pub fn is_alive(&self) -> bool {
+        self.alive.load(Ordering::Relaxed)
+    }
+
+    /// Shutdown the agent process.
+    pub async fn shutdown(&mut self) {
+        // Try graceful shutdown first
+        if self.is_alive() {
+            let _ = self.shutdown_kernel().await;
+        }
+        // Kill the child process
+        let _ = self.child.kill().await;
+        self.alive.store(false, Ordering::Relaxed);
+        // Abort the IO task
+        self.io_task.abort();
+    }
+}
+
+/// Main IO loop for the agent handle.
+///
+/// Reads frames from the agent's stdout, routes responses to pending
+/// request waiters, applies RuntimeStateDoc sync, and handles notifications.
+/// Also writes outgoing requests and RuntimeStateDoc sync to the agent's stdin.
+async fn io_loop<R, W>(
+    mut reader: R,
+    mut writer: W,
+    mut request_rx: mpsc::Receiver<(AgentRequest, oneshot::Sender<AgentResponse>)>,
+    state_doc: Arc<RwLock<RuntimeStateDoc>>,
+    state_changed_tx: broadcast::Sender<()>,
+    alive: Arc<AtomicBool>,
+) where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    // Pending response waiter — only one request at a time (sequential dispatch).
+    let mut pending_reply: Option<oneshot::Sender<AgentResponse>> = None;
+
+    // Automerge sync state for the agent peer
+    let mut agent_sync_state = automerge::sync::State::new();
+
+    // Subscribe to state_doc changes for reverse sync (coordinator → agent)
+    let mut state_changed_rx = state_changed_tx.subscribe();
+
+    loop {
+        tokio::select! {
+            // Read frames from agent stdout
+            frame = recv_frame(&mut reader) => {
+                match frame {
+                    Ok(Some(data)) if !data.is_empty() => {
+                        let frame_type = data[0];
+                        let payload = &data[1..];
+
+                        match frame_type {
+                            // AgentResponse (0x02)
+                            0x02 => {
+                                if let Some(reply) = pending_reply.take() {
+                                    match serde_json::from_slice::<AgentResponse>(payload) {
+                                        Ok(response) => { let _ = reply.send(response); }
+                                        Err(e) => {
+                                            warn!("[agent-handle] Failed to parse response: {}", e);
+                                            let _ = reply.send(AgentResponse::Error {
+                                                error: format!("Failed to parse agent response: {}", e),
+                                            });
+                                        }
+                                    }
+                                } else {
+                                    warn!("[agent-handle] Received response with no pending request");
+                                }
+                            }
+
+                            // RuntimeStateSync (0x05)
+                            0x05 => {
+                                if let Ok(msg) = automerge::sync::Message::decode(payload) {
+                                    let mut sd = state_doc.write().await;
+                                    if let Ok(changed) = sd.receive_sync_message_with_changes(
+                                        &mut agent_sync_state, msg,
+                                    ) {
+                                        if changed {
+                                            let _ = state_changed_tx.send(());
+                                        }
+                                    }
+
+                                    // Generate reply sync message if needed
+                                    if let Some(reply_msg) = sd.generate_sync_message(&mut agent_sync_state) {
+                                        let encoded = reply_msg.encode();
+                                        if let Err(e) = send_typed_frame(
+                                            &mut writer,
+                                            NotebookFrameType::RuntimeStateSync,
+                                            &encoded,
+                                        ).await {
+                                            warn!("[agent-handle] Failed to send sync reply: {}", e);
+                                            break;
+                                        }
+                                    }
+                                }
+                            }
+
+                            // AgentNotification (0x03)
+                            0x03 => {
+                                if let Ok(notification) = serde_json::from_slice::<AgentNotification>(payload) {
+                                    match notification {
+                                        AgentNotification::KernelDied => {
+                                            warn!("[agent-handle] Agent reported kernel died");
+                                            // State is already in RuntimeStateDoc via sync
+                                        }
+                                    }
+                                }
+                            }
+
+                            _ => {
+                                debug!("[agent-handle] Ignoring frame type 0x{:02x}", frame_type);
+                            }
+                        }
+                    }
+                    Ok(Some(_)) => {} // empty frame
+                    Ok(None) => {
+                        info!("[agent-handle] Agent stdout EOF — process exited");
+                        break;
+                    }
+                    Err(e) => {
+                        warn!("[agent-handle] Agent stdout read error: {}", e);
+                        break;
+                    }
+                }
+            }
+
+            // Send requests to agent stdin
+            request = request_rx.recv() => {
+                match request {
+                    Some((req, reply)) => {
+                        let json = match serde_json::to_vec(&req) {
+                            Ok(j) => j,
+                            Err(e) => {
+                                let _ = reply.send(AgentResponse::Error {
+                                    error: format!("Failed to serialize request: {}", e),
+                                });
+                                continue;
+                            }
+                        };
+                        if let Err(e) = send_typed_frame(
+                            &mut writer,
+                            NotebookFrameType::Request,
+                            &json,
+                        ).await {
+                            warn!("[agent-handle] Failed to send request to agent: {}", e);
+                            let _ = reply.send(AgentResponse::Error {
+                                error: format!("Failed to send to agent: {}", e),
+                            });
+                            break;
+                        }
+                        pending_reply = Some(reply);
+                    }
+                    None => {
+                        info!("[agent-handle] Request channel closed, shutting down IO");
+                        break;
+                    }
+                }
+            }
+
+            // Forward coordinator RuntimeStateDoc changes to agent
+            _ = state_changed_rx.recv() => {
+                // Drain buffered notifications
+                while state_changed_rx.try_recv().is_ok() {}
+
+                let mut sd = state_doc.write().await;
+                if let Some(msg) = sd.generate_sync_message(&mut agent_sync_state) {
+                    let encoded = msg.encode();
+                    if let Err(e) = send_typed_frame(
+                        &mut writer,
+                        NotebookFrameType::RuntimeStateSync,
+                        &encoded,
+                    ).await {
+                        warn!("[agent-handle] Failed to send state sync to agent: {}", e);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    alive.store(false, Ordering::Relaxed);
+    info!("[agent-handle] IO loop exited");
+}

--- a/crates/runtimed/src/agent_handle.rs
+++ b/crates/runtimed/src/agent_handle.rs
@@ -356,8 +356,15 @@ async fn io_loop<R, W>(
                 }
             }
 
-            // Send requests to agent stdin
-            request = request_rx.recv() => {
+            // Send requests to agent stdin (only when no pending reply)
+            request = async {
+                if pending_reply.is_some() {
+                    // Block until the current request is answered
+                    std::future::pending::<Option<(AgentRequest, oneshot::Sender<AgentResponse>)>>().await
+                } else {
+                    request_rx.recv().await
+                }
+            } => {
                 match request {
                     Some((req, reply)) => {
                         let json = match serde_json::to_vec(&req) {

--- a/crates/runtimed/src/kernel_manager.rs
+++ b/crates/runtimed/src/kernel_manager.rs
@@ -657,6 +657,14 @@ impl RoomKernel {
         });
     }
 
+    /// Take the QueueCommand receiver from the kernel.
+    ///
+    /// Used by the agent subprocess to handle commands in its own select loop
+    /// instead of calling `start_command_loop()`. Returns `None` if already taken.
+    pub fn take_cmd_rx(&mut self) -> Option<mpsc::Receiver<QueueCommand>> {
+        self.cmd_rx.take()
+    }
+
     /// Get the kernel type.
     pub fn kernel_type(&self) -> &str {
         &self.kernel_type

--- a/crates/runtimed/src/kernel_manager.rs
+++ b/crates/runtimed/src/kernel_manager.rs
@@ -2494,12 +2494,36 @@ impl RoomKernel {
         Ok(())
     }
 
+    /// Queue a cell for execution with a pre-assigned execution_id.
+    ///
+    /// Used by the agent subprocess where the coordinator already generated
+    /// and stamped the execution_id on the cell in NotebookDoc.
+    pub async fn queue_cell_with_id(
+        &mut self,
+        cell_id: String,
+        code: String,
+        execution_id: String,
+    ) -> Result<String> {
+        self.queue_cell_inner(cell_id, code, Some(execution_id))
+            .await
+    }
+
     /// Queue a cell for execution.
     ///
     /// Idempotent: if the cell is already executing or queued, returns the
     /// existing `execution_id` instead of generating a new one.
     /// Returns the `execution_id` for this execution.
     pub async fn queue_cell(&mut self, cell_id: String, code: String) -> Result<String> {
+        self.queue_cell_inner(cell_id, code, None).await
+    }
+
+    /// Internal queue implementation. If `execution_id` is None, generates a new one.
+    async fn queue_cell_inner(
+        &mut self,
+        cell_id: String,
+        code: String,
+        execution_id: Option<String>,
+    ) -> Result<String> {
         // Idempotent: return existing execution_id if already executing or queued
         if let Some((ref cid, ref eid)) = self.executing {
             if cid == &cell_id {
@@ -2518,7 +2542,7 @@ impl RoomKernel {
             return Ok(existing.execution_id.clone());
         }
 
-        let execution_id = Uuid::new_v4().to_string();
+        let execution_id = execution_id.unwrap_or_else(|| Uuid::new_v4().to_string());
         info!(
             "[kernel-manager] Queuing cell: {} (execution_id={})",
             cell_id, execution_id

--- a/crates/runtimed/src/lib.rs
+++ b/crates/runtimed/src/lib.rs
@@ -18,6 +18,7 @@ pub use runtimed_client::*;
 // Server-only modules (not in runtimed-client)
 // ============================================================================
 
+pub mod agent;
 pub mod blob_server;
 pub mod blob_store;
 pub mod daemon;

--- a/crates/runtimed/src/lib.rs
+++ b/crates/runtimed/src/lib.rs
@@ -19,6 +19,7 @@ pub use runtimed_client::*;
 // ============================================================================
 
 pub mod agent;
+pub mod agent_handle;
 pub mod blob_server;
 pub mod blob_store;
 pub mod daemon;

--- a/crates/runtimed/src/main.rs
+++ b/crates/runtimed/src/main.rs
@@ -102,6 +102,10 @@ enum Commands {
     /// [DEPRECATED] Use 'runt daemon flush' instead
     #[command(hide = true)]
     FlushPool,
+
+    /// Run as a runtime agent subprocess (internal, used by coordinator)
+    #[command(hide = true)]
+    Agent,
 }
 
 /// Get a log path that works even when HOME is not set.
@@ -330,6 +334,16 @@ async fn main() -> anyhow::Result<()> {
                 cli_command_name()
             );
             flush_pool().await
+        }
+        Some(Commands::Agent) => {
+            // Agent mode: communicate over stdin/stdout using framed protocol.
+            // Logs go to stderr only.
+            runtimed::agent::run_agent(tokio::io::stdin(), tokio::io::stdout())
+                .await
+                .map_err(|e| {
+                    eprintln!("[agent] Fatal: {}", e);
+                    e
+                })
         }
     }
 }

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -878,6 +878,11 @@ pub struct NotebookRoom {
     /// Notification channel for RuntimeStateDoc changes.
     /// Peer sync loops subscribe to push RuntimeStateSync frames.
     pub state_changed_tx: broadcast::Sender<()>,
+    /// Optional agent handle for process-isolated kernel execution.
+    /// When set, kernel requests are routed to the agent subprocess
+    /// instead of the local `RoomKernel`. Set by `LaunchKernel` when
+    /// `RUNT_AGENT_MODE=1`.
+    pub agent_handle: Arc<Mutex<Option<crate::agent_handle::AgentHandle>>>,
 }
 
 /// Maximum number of snapshots to keep per notebook hash.
@@ -1060,6 +1065,7 @@ impl NotebookRoom {
             watcher_shutdown_tx: Mutex::new(None),
             state_doc,
             state_changed_tx,
+            agent_handle: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -1123,6 +1129,7 @@ impl NotebookRoom {
             watcher_shutdown_tx: Mutex::new(None),
             state_doc,
             state_changed_tx,
+            agent_handle: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -3869,7 +3876,41 @@ async fn handle_notebook_request(
                 };
             }
 
-            // Queue the user's source immediately — no formatter delay.
+            // Check for agent-backed kernel first
+            {
+                let agent_guard = room.agent_handle.lock().await;
+                if let Some(ref agent) = *agent_guard {
+                    let execution_id = uuid::Uuid::new_v4().to_string();
+                    // Stamp execution_id on the cell before sending to agent
+                    {
+                        let mut doc = room.doc.write().await;
+                        let _ = doc.set_execution_id(&cell_id, Some(&execution_id));
+                        let _ = room.changed_tx.send(());
+                    }
+                    return match agent.execute_cell(&cell_id, &source, &execution_id).await {
+                        Ok(resp) => match resp {
+                            notebook_protocol::protocol::AgentResponse::CellQueued {
+                                cell_id,
+                                execution_id,
+                            } => NotebookResponse::CellQueued {
+                                cell_id,
+                                execution_id,
+                            },
+                            notebook_protocol::protocol::AgentResponse::Error { error } => {
+                                NotebookResponse::Error { error }
+                            }
+                            _ => NotebookResponse::Error {
+                                error: "Unexpected agent response".to_string(),
+                            },
+                        },
+                        Err(e) => NotebookResponse::Error {
+                            error: format!("Agent error: {}", e),
+                        },
+                    };
+                }
+            }
+
+            // Local kernel path: queue the user's source immediately — no formatter delay.
             // Formatting is applied afterward via fork+merge (see below).
             // This is safe because ruff/deno fmt are semantic no-ops:
             // the formatted code produces identical outputs.
@@ -3985,6 +4026,19 @@ async fn handle_notebook_request(
         }
 
         NotebookRequest::InterruptExecution {} => {
+            // Agent path
+            {
+                let agent_guard = room.agent_handle.lock().await;
+                if let Some(ref agent) = *agent_guard {
+                    return match agent.interrupt().await {
+                        Ok(_) => NotebookResponse::InterruptSent {},
+                        Err(e) => NotebookResponse::Error {
+                            error: format!("Agent interrupt error: {}", e),
+                        },
+                    };
+                }
+            }
+            // Local kernel path
             let mut kernel_guard = room.kernel.lock().await;
             if let Some(ref mut kernel) = *kernel_guard {
                 match kernel.interrupt().await {
@@ -3999,6 +4053,16 @@ async fn handle_notebook_request(
         }
 
         NotebookRequest::ShutdownKernel {} => {
+            // Agent path
+            {
+                let mut agent_guard = room.agent_handle.lock().await;
+                if let Some(ref mut agent) = *agent_guard {
+                    agent.shutdown().await;
+                    *agent_guard = None;
+                    return NotebookResponse::KernelShuttingDown {};
+                }
+            }
+            // Local kernel path
             let mut kernel_guard = room.kernel.lock().await;
             if let Some(ref mut kernel) = *kernel_guard {
                 let env_source = kernel.env_source().to_string();
@@ -4170,6 +4234,19 @@ async fn handle_notebook_request(
         }
 
         NotebookRequest::SendComm { message } => {
+            // Agent path
+            {
+                let agent_guard = room.agent_handle.lock().await;
+                if let Some(ref agent) = *agent_guard {
+                    return match agent.send_comm(message).await {
+                        Ok(_) => NotebookResponse::Ok {},
+                        Err(e) => NotebookResponse::Error {
+                            error: format!("Agent comm error: {}", e),
+                        },
+                    };
+                }
+            }
+            // Local kernel path
             let is_state_update = message
                 .get("content")
                 .and_then(|c| c.get("data"))
@@ -4207,6 +4284,27 @@ async fn handle_notebook_request(
         }
 
         NotebookRequest::GetHistory { pattern, n, unique } => {
+            // Agent path
+            {
+                let agent_guard = room.agent_handle.lock().await;
+                if let Some(ref agent) = *agent_guard {
+                    return match agent.get_history(pattern.as_deref(), n, unique).await {
+                        Ok(notebook_protocol::protocol::AgentResponse::HistoryResult {
+                            entries,
+                        }) => NotebookResponse::HistoryResult { entries },
+                        Ok(notebook_protocol::protocol::AgentResponse::Error { error }) => {
+                            NotebookResponse::Error { error }
+                        }
+                        Ok(_) => NotebookResponse::Error {
+                            error: "Unexpected agent response".to_string(),
+                        },
+                        Err(e) => NotebookResponse::Error {
+                            error: format!("Agent error: {}", e),
+                        },
+                    };
+                }
+            }
+            // Local kernel path
             let mut kernel_guard = room.kernel.lock().await;
             if let Some(ref mut kernel) = *kernel_guard {
                 match kernel.get_history(pattern, n, unique).await {
@@ -4221,6 +4319,33 @@ async fn handle_notebook_request(
         }
 
         NotebookRequest::Complete { code, cursor_pos } => {
+            // Agent path
+            {
+                let agent_guard = room.agent_handle.lock().await;
+                if let Some(ref agent) = *agent_guard {
+                    return match agent.complete(&code, cursor_pos).await {
+                        Ok(notebook_protocol::protocol::AgentResponse::CompletionResult {
+                            items,
+                            cursor_start,
+                            cursor_end,
+                        }) => NotebookResponse::CompletionResult {
+                            items,
+                            cursor_start,
+                            cursor_end,
+                        },
+                        Ok(notebook_protocol::protocol::AgentResponse::Error { error }) => {
+                            NotebookResponse::Error { error }
+                        }
+                        Ok(_) => NotebookResponse::Error {
+                            error: "Unexpected agent response".to_string(),
+                        },
+                        Err(e) => NotebookResponse::Error {
+                            error: format!("Agent error: {}", e),
+                        },
+                    };
+                }
+            }
+            // Local kernel path
             let mut kernel_guard = room.kernel.lock().await;
             if let Some(ref mut kernel) = *kernel_guard {
                 match kernel.complete(code, cursor_pos).await {
@@ -7310,6 +7435,7 @@ mod tests {
             watcher_shutdown_tx: Mutex::new(None),
             state_doc,
             state_changed_tx,
+            agent_handle: Arc::new(Mutex::new(None)),
         };
 
         (room, notebook_path)


### PR DESCRIPTION
## Summary

**Draft PR** — Process-isolated runtime agent infrastructure (#1333, part of #832).

Three commits building up the agent architecture:

### 1. Agent module (`agent.rs`) — subprocess main loop
- Sync-only: no broadcast forwarding, all state via RuntimeStateDoc CRDT sync (frame 0x05)
- `AgentContext` struct, request dispatch, QueueCommand handling
- Hidden `runtimed agent` subcommand
- `RoomKernel::take_cmd_rx()` for agent command loop

### 2. Agent handle (`agent_handle.rs`) — coordinator-side management
- Spawns `runtimed agent` with piped stdin/stdout
- Bidirectional RuntimeStateDoc sync via persistent `sync::State`
- Sequential request/response dispatch with oneshot channels
- Child exit detection

### 3. KernelBackend dispatch — route requests to local or agent
- `agent_handle` field on `NotebookRoom`
- Pre-check dispatch for: ExecuteCell, InterruptExecution, ShutdownKernel, SendComm, Complete, GetHistory
- Falls through to existing local RoomKernel when no agent present

### What's missing
- [ ] Wire `RUNT_AGENT_MODE=1` env var into LaunchKernel to spawn agent
- [ ] Integration test: spawn agent end-to-end
- [ ] RunAllCells dispatch to agent
- [ ] GetKernelInfo / GetQueueState agent paths
- [ ] ClearOutputs agent path

### Verified
- [x] `cargo build` — clean
- [x] `cargo clippy -D warnings` — zero warnings
- [x] `cargo test -p runtimed --lib` — 184 tests pass
- [x] Live test: local kernel still works, save resolves execution_count correctly

Part of #1406, #1407, #1408, #1333, #832