### PR TITLE
fix(widgets): render Output widget captured outputs via CRDT state

### DIFF
--- a/apps/notebook/src/hooks/useDaemonKernel.ts
+++ b/apps/notebook/src/hooks/useDaemonKernel.ts
@@ -45,7 +45,12 @@ import { isManifestHash } from "../lib/manifest-resolution";
  *
  * Only triggers for OutputModel widgets (`_model_name === "OutputModel"`).
  * Other widgets may have an `outputs` field with different semantics.
+ *
+ * Uses a generation counter per comm_id to discard stale async completions
+ * when a newer CRDT update arrives before the old fetch finishes.
  */
+const _outputResolveGen = new Map<string, number>();
+
 function resolveCommOutputHashes(
   commId: string,
   state: Record<string, unknown>,
@@ -57,7 +62,11 @@ function resolveCommOutputHashes(
   if (state._model_name !== "OutputModel") return;
 
   const outputs = state.outputs;
-  if (!Array.isArray(outputs) || outputs.length === 0) return;
+  if (!Array.isArray(outputs) || outputs.length === 0) {
+    // Bump generation so any in-flight fetch is discarded
+    _outputResolveGen.set(commId, (_outputResolveGen.get(commId) ?? 0) + 1);
+    return;
+  }
 
   // Verify all entries are manifest hashes (64-char hex strings).
   // If not, this is unexpected — log and skip.
@@ -78,10 +87,18 @@ function resolveCommOutputHashes(
   const blobPort = getBlobPort();
   if (blobPort === null) return; // Will retry on next CRDT update
 
+  // Bump generation — any older in-flight fetch will check and bail
+  const gen = (_outputResolveGen.get(commId) ?? 0) + 1;
+  _outputResolveGen.set(commId, gen);
+
   void (async () => {
     const resolved = await Promise.all(
       (outputs as string[]).map((h) => resolveOutputString(h, blobPort)),
     );
+
+    // Discard if a newer CRDT update superseded us
+    if (_outputResolveGen.get(commId) !== gen) return;
+
     const resolvedOutputs = resolved.filter(
       (o): o is JupyterOutput => o !== null,
     );

--- a/apps/notebook/src/hooks/useDaemonKernel.ts
+++ b/apps/notebook/src/hooks/useDaemonKernel.ts
@@ -35,6 +35,80 @@ import type {
   JupyterOutput,
 } from "../types";
 import { resolveOutputString } from "./useManifestResolver";
+import { isManifestHash } from "../lib/manifest-resolution";
+
+/**
+ * If an OutputModel's `state.outputs` contains manifest hash strings, resolve
+ * them asynchronously to JupyterOutput objects and deliver a follow-up
+ * comm_msg(update) with the resolved outputs. This mirrors how cell outputs
+ * are resolved from the CRDT.
+ *
+ * Only triggers for OutputModel widgets (`_model_name === "OutputModel"`).
+ * Other widgets may have an `outputs` field with different semantics.
+ */
+function resolveCommOutputHashes(
+  commId: string,
+  state: Record<string, unknown>,
+  callbacksRef: {
+    readonly current: { onCommMessage?: (msg: JupyterMessage) => void };
+  },
+): void {
+  // Only resolve for OutputModel widgets
+  if (state._model_name !== "OutputModel") return;
+
+  const outputs = state.outputs;
+  if (!Array.isArray(outputs) || outputs.length === 0) return;
+
+  // Verify all entries are manifest hashes (64-char hex strings).
+  // If not, this is unexpected — log and skip.
+  const allHashes = outputs.every(
+    (o) => typeof o === "string" && isManifestHash(o),
+  );
+  if (!allHashes) {
+    if (outputs.some((o) => typeof o !== "string")) {
+      // Already resolved objects — skip silently
+      return;
+    }
+    logger.warn(
+      `[comm-sync] OutputModel ${commId}: state.outputs contains unexpected format, skipping resolution`,
+    );
+    return;
+  }
+
+  const blobPort = getBlobPort();
+  if (blobPort === null) return; // Will retry on next CRDT update
+
+  void (async () => {
+    const resolved = await Promise.all(
+      (outputs as string[]).map((h) => resolveOutputString(h, blobPort)),
+    );
+    const resolvedOutputs = resolved.filter(
+      (o): o is JupyterOutput => o !== null,
+    );
+    const cb = callbacksRef.current?.onCommMessage;
+    if (cb) {
+      cb({
+        header: {
+          msg_id: crypto.randomUUID(),
+          msg_type: "comm_msg",
+          session: "",
+          username: "kernel",
+          date: new Date().toISOString(),
+          version: "5.3",
+        },
+        metadata: {},
+        content: {
+          comm_id: commId,
+          data: {
+            method: "update",
+            state: { outputs: resolvedOutputs },
+          },
+        },
+        buffers: [],
+      });
+    }
+  })();
+}
 
 /** Kernel status from daemon */
 export type DaemonKernelStatus = KernelStatus;
@@ -526,6 +600,11 @@ export function useDaemonKernel({
       onCommMessage(msg);
       nextComms[commId] = entry;
       nextJson[commId] = JSON.stringify(entry.state);
+
+      // Resolve Output widget manifest hashes in state.outputs to JupyterOutput objects.
+      // The daemon writes manifest hashes (same format as execution outputs);
+      // we resolve them here so the iframe receives ready-to-render outputs.
+      resolveCommOutputHashes(commId, entry.state, callbacksRef);
     }
 
     // State changes — synthesize comm_msg(update)
@@ -560,6 +639,9 @@ export function useDaemonKernel({
             buffers: [],
           };
           onCommMessage(msg);
+
+          // Resolve Output widget manifest hashes in state.outputs
+          resolveCommOutputHashes(commId, entry.state, callbacksRef);
         }
       }
     }

--- a/apps/notebook/src/hooks/useDaemonKernel.ts
+++ b/apps/notebook/src/hooks/useDaemonKernel.ts
@@ -17,6 +17,7 @@ import {
   type KernelStatus,
 } from "../lib/kernel-status";
 import { logger } from "../lib/logger";
+import { isManifestHash } from "../lib/manifest-resolution";
 import { subscribeBroadcast } from "../lib/notebook-frame-bus";
 import {
   type CommDocEntry,
@@ -35,7 +36,6 @@ import type {
   JupyterOutput,
 } from "../types";
 import { resolveOutputString } from "./useManifestResolver";
-import { isManifestHash } from "../lib/manifest-resolution";
 
 /**
  * If an OutputModel's `state.outputs` contains manifest hash strings, resolve

--- a/crates/runtimed/src/kernel_manager.rs
+++ b/crates/runtimed/src/kernel_manager.rs
@@ -1257,6 +1257,24 @@ impl RoomKernel {
                                             // Read the full outputs list and sync to kernel
                                             if let Some(entry) = sd.get_comm(&widget_comm_id) {
                                                 let output_hashes = entry.outputs.clone();
+
+                                                // Write manifest hashes to state.outputs so the
+                                                // frontend CRDT watcher picks them up (it diffs
+                                                // entry.state, not entry.outputs).
+                                                let hashes_json = serde_json::Value::Array(
+                                                    output_hashes
+                                                        .iter()
+                                                        .map(|h| {
+                                                            serde_json::Value::String(h.clone())
+                                                        })
+                                                        .collect(),
+                                                );
+                                                sd.set_comm_state_property(
+                                                    &widget_comm_id,
+                                                    "outputs",
+                                                    &hashes_json,
+                                                );
+
                                                 drop(sd); // Release lock before async work
 
                                                 // Resolve manifest hashes to nbformat JSON
@@ -1294,8 +1312,7 @@ impl RoomKernel {
                                         }
                                     }
 
-                                    // No broadcast needed — frontend reads from CRDT
-                                    // comms[widget_id].outputs[] via the comms watcher.
+                                    // Frontend reads from CRDT state.outputs via the comms watcher.
                                     continue; // Skip normal cell output handling
                                 }
 
@@ -1434,7 +1451,7 @@ impl RoomKernel {
                                 }
                             }
 
-                            // DisplayData and ExecuteResult are appended normally
+                            // DisplayData and ExecuteResult are appended normally.
                             JupyterMessageContent::DisplayData(_)
                             | JupyterMessageContent::ExecuteResult(_) => {
                                 // Check if this output should go to an Output widget
@@ -1476,6 +1493,22 @@ impl RoomKernel {
                                                 // Read full outputs and sync to kernel
                                                 if let Some(entry) = sd.get_comm(&widget_comm_id) {
                                                     let output_hashes = entry.outputs.clone();
+
+                                                    // Write manifest hashes to state.outputs for frontend
+                                                    let hashes_json = serde_json::Value::Array(
+                                                        output_hashes
+                                                            .iter()
+                                                            .map(|h| {
+                                                                serde_json::Value::String(h.clone())
+                                                            })
+                                                            .collect(),
+                                                    );
+                                                    sd.set_comm_state_property(
+                                                        &widget_comm_id,
+                                                        "outputs",
+                                                        &hashes_json,
+                                                    );
+
                                                     drop(sd);
                                                     let mut resolved_outputs = Vec::new();
                                                     for h in &output_hashes {
@@ -1502,7 +1535,7 @@ impl RoomKernel {
                                                 }
                                             }
                                         }
-                                        // No broadcast — frontend reads from CRDT.
+                                        // Frontend reads from CRDT state.outputs.
                                     }
                                     continue; // Skip normal cell output handling
                                 }
@@ -1722,6 +1755,22 @@ impl RoomKernel {
                                                 // Read full outputs and sync to kernel
                                                 if let Some(entry) = sd.get_comm(&widget_comm_id) {
                                                     let output_hashes = entry.outputs.clone();
+
+                                                    // Write manifest hashes to state.outputs for frontend
+                                                    let hashes_json = serde_json::Value::Array(
+                                                        output_hashes
+                                                            .iter()
+                                                            .map(|h| {
+                                                                serde_json::Value::String(h.clone())
+                                                            })
+                                                            .collect(),
+                                                    );
+                                                    sd.set_comm_state_property(
+                                                        &widget_comm_id,
+                                                        "outputs",
+                                                        &hashes_json,
+                                                    );
+
                                                     drop(sd);
                                                     let mut resolved_outputs = Vec::new();
                                                     for h in &output_hashes {
@@ -1748,7 +1797,7 @@ impl RoomKernel {
                                                 }
                                             }
                                         }
-                                        // No broadcast — frontend reads from CRDT.
+                                        // Frontend reads from CRDT state.outputs.
                                     }
                                     continue; // Skip normal cell output handling
                                 }
@@ -1873,6 +1922,12 @@ impl RoomKernel {
                                         if sd.clear_comm_outputs(&widget_comm_id) {
                                             let _ = state_changed_for_iopub.send(());
                                         }
+                                        // Clear state.outputs for frontend
+                                        sd.set_comm_state_property(
+                                            &widget_comm_id,
+                                            "outputs",
+                                            &serde_json::json!([]),
+                                        );
                                         drop(sd);
                                         // Sync empty outputs to kernel
                                         let _ = iopub_cmd_tx


### PR DESCRIPTION
## Summary
- Output widget (`ipywidgets.Output`) wasn't rendering captured outputs — showed empty box
- Root cause: daemon stored manifest hashes in separate `comms[id].outputs` CRDT field, but frontend CRDT watcher only diffs `comms[id].state`
- Daemon now writes manifest hashes to `state.outputs` (same format as `executions[id].outputs`)
- Frontend resolves hashes via blob store using the same `resolveOutputString()` used for cell outputs
- Only triggers for OutputModel widgets; guards against other widgets that may have `outputs` field

## Test plan
- [ ] `ipywidgets.Output` with `print()` — text renders in UI
- [ ] `display(HTML(...))` inside Output — HTML renders
- [ ] `plt.show()` inside Output — image renders via blob URL
- [ ] `out.clear_output()` — clears rendered content
- [ ] `out.clear_output(wait=True)` then new output — replaces correctly
- [ ] Non-Output widgets with `outputs` field — not affected
- [ ] `cargo test -p runtimed` passes
- [ ] JS tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)