### PR TITLE
feat(mcp): allow show_notebook on untitled/ephemeral notebooks

### DIFF
--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -3664,7 +3664,11 @@ fn correct_window_scale(window: &tauri::WebviewWindow, saved_scale_factor: Optio
 ///
 /// For untitled notebooks, the current working directory is captured at startup
 /// for project file detection (pyproject.toml, pixi.toml, environment.yaml).
-pub fn run(notebook_path: Option<PathBuf>, runtime: Option<Runtime>) -> anyhow::Result<()> {
+pub fn run(
+    notebook_path: Option<PathBuf>,
+    runtime: Option<Runtime>,
+    notebook_id: Option<String>,
+) -> anyhow::Result<()> {
     // Initialize logging via tauri-plugin-log — unified backend for both Rust
     // log::* macros and frontend JS log calls. Writes to notebook.log, stderr,
     // and forwards to webview console.
@@ -3764,8 +3768,9 @@ pub fn run(notebook_path: Option<PathBuf>, runtime: Option<Runtime>) -> anyhow::
     // Use provided runtime or fall back to user's default from settings
     let runtime = runtime.unwrap_or(app_settings.default_runtime);
 
-    // Try to restore session if no notebook path provided and not onboarding
-    let restored_session = if notebook_path.is_none() && !needs_onboarding {
+    // Try to restore session if no notebook path/id provided and not onboarding
+    let restored_session = if notebook_path.is_none() && notebook_id.is_none() && !needs_onboarding
+    {
         session::load_session()
     } else {
         None
@@ -3799,6 +3804,18 @@ pub fn run(notebook_path: Option<PathBuf>, runtime: Option<Runtime>) -> anyhow::
             label: format!("notebook-{}", &hash[..8]),
             title,
             mode: OpenMode::Open { path: path.clone() },
+            saved_scale_factor: None,
+        }]
+    } else if let Some(ref id) = notebook_id {
+        // CLI --notebook-id: join an existing untitled notebook by UUID
+        vec![StartupWindow {
+            label: format!("notebook-{}", &id[..8.min(id.len())]),
+            title: "Untitled.ipynb".to_string(),
+            mode: OpenMode::Create {
+                runtime: runtime.to_string(),
+                working_dir: working_dir.clone(),
+                notebook_id: Some(id.clone()),
+            },
             saved_scale_factor: None,
         }]
     } else if let Some(ref session) = restored_session {

--- a/crates/notebook/src/main.rs
+++ b/crates/notebook/src/main.rs
@@ -11,12 +11,16 @@ struct Args {
     /// Runtime for new notebooks (python, deno). Falls back to user settings if not specified.
     #[arg(long, short)]
     runtime: Option<Runtime>,
+
+    /// Join an existing untitled notebook by its daemon ID (UUID)
+    #[arg(long)]
+    notebook_id: Option<String>,
 }
 
 fn main() {
     let args = Args::parse();
 
-    if let Err(e) = notebook::run(args.path.clone(), args.runtime) {
+    if let Err(e) = notebook::run(args.path.clone(), args.runtime, args.notebook_id.clone()) {
         // Show native error dialog before exiting
         let title = "Cannot Open Notebook";
         let message = match &args.path {

--- a/crates/runt-mcp/src/tools/session.rs
+++ b/crates/runt-mcp/src/tools/session.rs
@@ -484,20 +484,17 @@ pub async fn show_notebook(
         ));
     }
 
-    // Validate it's a file-backed notebook (absolute path)
-    if !std::path::Path::new(&target).is_absolute() {
-        return tool_error(&format!(
-            "Notebook '{}' is an untitled notebook (not saved to disk). \
-             Use save_notebook(path) first, then call show_notebook().",
-            target
-        ));
-    }
-
     // Launch the app using the binary's build channel.
     // NOTE: If RUNTIMED_SOCKET_PATH points at a different channel's daemon,
     // this may open the wrong app. That's a known dev-only edge case.
-    runt_workspace::open_notebook_app(Some(std::path::Path::new(&target)), &[])
-        .map_err(|e| McpError::internal_error(format!("Failed to open app: {e}"), None))?;
+    let is_file_backed = std::path::Path::new(&target).is_absolute();
+    if is_file_backed {
+        runt_workspace::open_notebook_app(Some(std::path::Path::new(&target)), &[])
+            .map_err(|e| McpError::internal_error(format!("Failed to open app: {e}"), None))?;
+    } else {
+        runt_workspace::open_notebook_app(None, &["--notebook-id", &target])
+            .map_err(|e| McpError::internal_error(format!("Failed to open app: {e}"), None))?;
+    }
 
     let result = serde_json::json!({ "notebook_id": target, "opened": true });
     tool_success(&serde_json::to_string_pretty(&result).unwrap_or_default())

--- a/crates/runt-workspace/src/lib.rs
+++ b/crates/runt-workspace/src/lib.rs
@@ -398,6 +398,12 @@ fn open_notebook_installed_for(
         #[cfg(target_os = "macos")]
         let spawn_result = {
             let mut cmd = Command::new("open");
+            // When there's no file path but we have CLI args (e.g. --notebook-id),
+            // force a new instance with -n. Without this, macOS `open` activates
+            // the running app and silently drops everything after --args.
+            if path.is_none() && !extra_args.is_empty() {
+                cmd.arg("-n");
+            }
             cmd.arg("-a").arg(app_name);
             cmd.args(macos_open_args(path, extra_args));
             cmd.spawn()


### PR DESCRIPTION
## Summary

- Remove the absolute-path gate in `show_notebook` that rejected untitled notebooks
- Add `--notebook-id` CLI flag to the notebook binary so the app can join an existing daemon room by UUID
- Reuse the existing `OpenMode::Create { notebook_id }` path (same as session restore) to open the notebook window

Agents that create notebooks via `create_notebook` get a UUID-based ID. Previously `show_notebook` required saving to disk first — now it works directly on ephemeral notebooks.

## Verification

- [ ] Create an untitled notebook via MCP `create_notebook`, then call `show_notebook` — the desktop app opens with the notebook
- [ ] Call `show_notebook` on a file-backed notebook — existing behavior still works
- [ ] Call `show_notebook` on a notebook ID not in the daemon — returns an appropriate error

_PR submitted by @rgbkrk's agent, Quill_