### PR TITLE
fix(mcp): ensure RuntimeStateDoc sync before reading cell outputs

### DIFF
--- a/crates/runt-mcp/src/tools/cell_read.rs
+++ b/crates/runt-mcp/src/tools/cell_read.rs
@@ -65,10 +65,19 @@ pub async fn get_cell(
 
     // No presence on read — get_cell is read-only, shouldn't move the cursor.
 
-    let cell = match handle.get_cell(cell_id) {
+    let mut cell = match handle.get_cell(cell_id) {
         Some(c) => c,
         None => return tool_error(&format!("Cell not found: {cell_id}")),
     };
+
+    // If the cell has been executed but outputs haven't synced yet,
+    // force a sync round-trip to process pending RuntimeStateSync frames.
+    if cell.outputs.is_empty() && !cell.execution_count.is_empty() && cell.execution_count != "0" {
+        let _ = handle.confirm_sync().await;
+        if let Some(c) = handle.get_cell(cell_id) {
+            cell = c;
+        }
+    }
 
     // Resolve outputs
     let outputs = output_resolver::resolve_cell_outputs(

--- a/crates/runt-mcp/src/tools/cell_read.rs
+++ b/crates/runt-mcp/src/tools/cell_read.rs
@@ -72,7 +72,11 @@ pub async fn get_cell(
 
     // If the cell has been executed but outputs haven't synced yet,
     // force a sync round-trip to process pending RuntimeStateSync frames.
-    if cell.outputs.is_empty() && !cell.execution_count.is_empty() && cell.execution_count != "0" {
+    if cell.outputs.is_empty()
+        && !cell.execution_count.is_empty()
+        && cell.execution_count != "0"
+        && cell.execution_count != "null"
+    {
         let _ = handle.confirm_sync().await;
         if let Some(c) = handle.get_cell(cell_id) {
             cell = c;

--- a/crates/runt-mcp/src/tools/session.rs
+++ b/crates/runt-mcp/src/tools/session.rs
@@ -205,6 +205,11 @@ pub async fn join_notebook(
     {
         Ok(result) => {
             let handle = &result.handle;
+
+            // Ensure initial sync converges — this processes any pending
+            // RuntimeStateSync frames so outputs are available immediately.
+            let _ = handle.confirm_sync().await;
+
             let runtime_info = collect_runtime_info(handle).await;
             let deps = get_dependencies(handle);
             let cells_summary = format_cell_summaries(handle);
@@ -266,6 +271,11 @@ pub async fn open_notebook(
         Ok(result) => {
             let handle = &result.handle;
             let notebook_id = handle.notebook_id().to_string();
+
+            // Ensure initial sync converges — this processes any pending
+            // RuntimeStateSync frames so outputs are available immediately.
+            let _ = handle.confirm_sync().await;
+
             let runtime_info = collect_runtime_info(handle).await;
             let deps = get_dependencies(handle);
             let cells_summary = format_cell_summaries(handle);


### PR DESCRIPTION
## Summary

- `get_cell` was returning cells without outputs because the RuntimeStateDoc (which stores outputs keyed by execution_id) hadn't fully synced after `join_notebook` / `open_notebook`
- The initial Automerge sync for the notebook doc converged, but RuntimeStateSync frames containing outputs were still pending in the background sync task
- Added `confirm_sync()` in `join_notebook` and `open_notebook` to ensure sync convergence before returning the session
- Added a conditional fallback in `get_cell`: if a cell has an execution count but no outputs, forces one more sync round-trip before reading

## Test plan

- [x] Open a notebook with saved outputs via MCP (`open_notebook`), call `get_cell` — outputs now appear immediately
- [x] Join an existing notebook via MCP (`join_notebook`), call `get_cell` — outputs appear
- [x] Execute a cell, then `get_cell` — outputs from live execution appear
- [ ] Verify no regression in `execute_cell` tool (which already waits for outputs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)