### PR TITLE
refactor(runtimed): extract transport-agnostic logic from useDaemonKernel

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -10,6 +10,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { NotebookClient } from "runtimed";
 import { IsolationTest } from "@/components/isolated";
 import { MediaProvider } from "@/components/outputs/media-provider";
 import { setCrdtCommWriter } from "@/components/widgets/crdt-comm-writer";
@@ -61,6 +62,7 @@ import { KERNEL_STATUS } from "./lib/kernel-status";
 import { logger } from "./lib/logger";
 import { getNotebookCellsSnapshot } from "./lib/notebook-cells";
 import { useDetectRuntime } from "./lib/notebook-metadata";
+import { TauriTransport } from "./lib/tauri-transport";
 import { startWindowFocusHandler } from "./lib/window-focus";
 import type { JupyterMessage } from "./types";
 
@@ -269,7 +271,12 @@ function AppContent() {
     [handleWidgetMessage],
   );
 
-  // Clear page payload for a cell (e.g., when dismissed or re-executed)
+  // NotebookClient for sending kernel commands via transport
+  const notebookClient = useMemo(
+    () => new NotebookClient({ transport: new TauriTransport() }),
+    [],
+  );
+
   // Daemon-owned kernel execution
   const {
     kernelStatus,
@@ -286,6 +293,7 @@ function AppContent() {
     runAllCells: daemonRunAllCells,
     sendCommMessage,
   } = useDaemonKernel({
+    client: notebookClient,
     onExecutionCount: handleExecutionCount,
     onExecutionDone: handleExecutionDone,
     onUpdateDisplayData: updateOutputByDisplayId,

--- a/apps/notebook/src/hooks/useDaemonKernel.ts
+++ b/apps/notebook/src/hooks/useDaemonKernel.ts
@@ -1,50 +1,47 @@
 /**
  * Hook for daemon-owned kernel execution.
  *
- * State (kernel status, queue, env sync) is derived from the daemon's
- * RuntimeStateDoc via `useRuntimeState()`. Broadcasts are only used for
- * event callbacks (execution lifecycle, outputs, comms).
+ * Thin React wrapper around transport-agnostic logic from the `runtimed`
+ * package. State (kernel status, queue, env sync) is derived from the
+ * daemon's RuntimeStateDoc. Broadcasts are only used for event callbacks.
  */
 
 import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWebview } from "@tauri-apps/api/webview";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { getBlobPort, refreshBlobPort, resetBlobPort } from "../lib/blob-port";
-import { replaceSentinelsWithBlobUrls } from "../lib/blob-sentinel";
 import {
+  type CommDiffState,
+  type DaemonQueueState,
+  deriveEnvSyncState,
+  deriveKernelInfo,
+  deriveQueueState,
+  detectOutputManifestHashes,
+  diffComms,
   isKernelStatus,
   KERNEL_STATUS,
   type KernelStatus,
-} from "../lib/kernel-status";
+  type NotebookClient,
+  type NotebookResponse,
+} from "runtimed";
+import { getBlobPort, refreshBlobPort, resetBlobPort } from "../lib/blob-port";
+import { replaceSentinelsWithBlobUrls } from "../lib/blob-sentinel";
 import { logger } from "../lib/logger";
-import { isManifestHash } from "../lib/manifest-resolution";
 import { subscribeBroadcast } from "../lib/notebook-frame-bus";
 import {
-  type CommDocEntry,
   diffExecutions,
   type ExecutionState,
-  type QueueEntry,
   type RuntimeState,
   resetRuntimeState,
   setRuntimeState,
   useRuntimeState,
 } from "../lib/runtime-state";
-import type {
-  DaemonBroadcast,
-  DaemonNotebookResponse,
-  JupyterMessage,
-  JupyterOutput,
-} from "../types";
+import type { DaemonBroadcast, JupyterMessage, JupyterOutput } from "../types";
 import { resolveOutputString } from "./useManifestResolver";
 
+// ── Output widget manifest resolution ───────────────────────────────
+
 /**
- * If an OutputModel's `state.outputs` contains manifest hash strings, resolve
- * them asynchronously to JupyterOutput objects and deliver a follow-up
- * comm_msg(update) with the resolved outputs. This mirrors how cell outputs
- * are resolved from the CRDT.
- *
- * Only triggers for OutputModel widgets (`_model_name === "OutputModel"`).
- * Other widgets may have an `outputs` field with different semantics.
+ * Resolve Output widget manifest hashes to JupyterOutput objects.
  *
  * Uses a generation counter per comm_id to discard stale async completions
  * when a newer CRDT update arrives before the old fetch finishes.
@@ -58,45 +55,25 @@ function resolveCommOutputHashes(
     readonly current: { onCommMessage?: (msg: JupyterMessage) => void };
   },
 ): void {
-  // Only resolve for OutputModel widgets
-  if (state._model_name !== "OutputModel") return;
-
-  const outputs = state.outputs;
-  if (!Array.isArray(outputs) || outputs.length === 0) {
-    // Bump generation so any in-flight fetch is discarded
-    _outputResolveGen.set(commId, (_outputResolveGen.get(commId) ?? 0) + 1);
-    return;
-  }
-
-  // Verify all entries are manifest hashes (64-char hex strings).
-  // If not, this is unexpected — log and skip.
-  const allHashes = outputs.every(
-    (o) => typeof o === "string" && isManifestHash(o),
-  );
-  if (!allHashes) {
-    if (outputs.some((o) => typeof o !== "string")) {
-      // Already resolved objects — skip silently
-      return;
+  const detected = detectOutputManifestHashes(state);
+  if (!detected) {
+    // Bump generation so any in-flight fetch is discarded (for OutputModel with empty outputs)
+    if (state._model_name === "OutputModel") {
+      _outputResolveGen.set(commId, (_outputResolveGen.get(commId) ?? 0) + 1);
     }
-    logger.warn(
-      `[comm-sync] OutputModel ${commId}: state.outputs contains unexpected format, skipping resolution`,
-    );
     return;
   }
 
   const blobPort = getBlobPort();
   if (blobPort === null) return; // Will retry on next CRDT update
 
-  // Bump generation — any older in-flight fetch will check and bail
   const gen = (_outputResolveGen.get(commId) ?? 0) + 1;
   _outputResolveGen.set(commId, gen);
 
   void (async () => {
     const resolved = await Promise.all(
-      (outputs as string[]).map((h) => resolveOutputString(h, blobPort)),
+      detected.hashes.map((h) => resolveOutputString(h, blobPort)),
     );
-
-    // Discard if a newer CRDT update superseded us
     if (_outputResolveGen.get(commId) !== gen) return;
 
     const resolvedOutputs = resolved.filter(
@@ -127,27 +104,23 @@ function resolveCommOutputHashes(
   })();
 }
 
-/** Kernel status from daemon */
-export type DaemonKernelStatus = KernelStatus;
+// ── Hook types ──────────────────────────────────────────────────────
 
-/** Queue state from daemon */
-export interface DaemonQueueState {
-  executing: QueueEntry | null;
-  queued: QueueEntry[];
-}
+/** Re-export for backward compatibility */
+export type DaemonKernelStatus = KernelStatus;
+export type { DaemonQueueState } from "runtimed";
 
 interface UseDaemonKernelOptions {
-  /** Called when an output is produced for a cell.
-   * Optional — when omitted, Output broadcast processing (including blob
-   * resolution) is skipped entirely. Sync delivers outputs via materializeCells.
-   * Provide a callback for OutputWidget capture or low-latency streaming. */
+  /** NotebookClient for sending kernel commands via transport. */
+  client: NotebookClient;
+  /** Called when an output is produced for a cell (optional — for OutputWidget capture). */
   onOutput?: (cellId: string, output: JupyterOutput) => void;
   /** Called when execution count is set for a cell */
   onExecutionCount: (cellId: string, count: number) => void;
   /** Called when execution completes for a cell */
   onExecutionDone: (cellId: string) => void;
   /** Called when kernel status changes */
-  onStatusChange?: (status: DaemonKernelStatus, cellId?: string) => void;
+  onStatusChange?: (status: KernelStatus, cellId?: string) => void;
   /** Called when queue state changes */
   onQueueChange?: (state: DaemonQueueState) => void;
   /** Called on kernel error */
@@ -165,6 +138,7 @@ interface UseDaemonKernelOptions {
 }
 
 export function useDaemonKernel({
+  client,
   onOutput,
   onExecutionCount,
   onExecutionDone,
@@ -178,68 +152,24 @@ export function useDaemonKernel({
   // ── State from RuntimeStateDoc (daemon-authoritative) ─────────────
   const runtimeState = useRuntimeState();
 
-  // Cache for resolved output manifests (shared with Output widget CRDT path)
-
-  // Derive kernel info from the doc
   const kernelInfo = useMemo(
-    () => ({
-      kernelType: runtimeState.kernel.language || undefined,
-      envSource: runtimeState.kernel.env_source || undefined,
-    }),
-    [runtimeState.kernel.language, runtimeState.kernel.env_source],
+    () => deriveKernelInfo(runtimeState),
+    [runtimeState],
   );
 
-  // Derive queue state from the doc
-  const queueState: DaemonQueueState = useMemo(
-    () => ({
-      executing: runtimeState.queue.executing,
-      queued: runtimeState.queue.queued,
-    }),
-    [runtimeState.queue],
+  const queueState = useMemo(
+    () => deriveQueueState(runtimeState),
+    [runtimeState],
   );
 
-  // Derive env sync state from the doc
-  const envSyncState = useMemo(() => {
-    // Before any kernel launch, env state is default (in_sync: true, empty lists).
-    // Return null to indicate "unknown" to consumers, matching prior behavior.
-    if (
-      (runtimeState.kernel.status === "not_started" &&
-        !runtimeState.kernel.env_source) ||
-      runtimeState.kernel.status === "shutdown" ||
-      runtimeState.kernel.status === "error"
-    ) {
-      return null;
-    }
-    return {
-      inSync: runtimeState.env.in_sync,
-      diff: runtimeState.env.in_sync
-        ? undefined
-        : {
-            added: runtimeState.env.added,
-            removed: runtimeState.env.removed,
-            channelsChanged: runtimeState.env.channels_changed,
-            denoChanged: runtimeState.env.deno_changed,
-          },
-    };
-  }, [
-    runtimeState.kernel.status,
-    runtimeState.kernel.env_source,
-    runtimeState.env.in_sync,
-    runtimeState.env.added,
-    runtimeState.env.removed,
-    runtimeState.env.channels_changed,
-    runtimeState.env.deno_changed,
-  ]);
+  const envSyncState = useMemo(
+    () => deriveEnvSyncState(runtimeState),
+    [runtimeState],
+  );
 
   // ── Busy throttle ────────────────────────────────────────────────
-  //
-  // The RuntimeStateDoc faithfully records every busy→idle transition
-  // from the kernel, including sub-60ms blips from tab completions.
-  // We apply the same throttle the broadcast path used: only show "busy"
-  // if it persists past a 60ms threshold.
-
   const rawStatus = runtimeState.kernel.status;
-  const [throttledStatus, setThrottledStatus] = useState<DaemonKernelStatus>(
+  const [throttledStatus, setThrottledStatus] = useState<KernelStatus>(
     isKernelStatus(rawStatus) ? rawStatus : KERNEL_STATUS.NOT_STARTED,
   );
   const busyTimerRef = useRef<number | null>(null);
@@ -248,15 +178,11 @@ export function useDaemonKernel({
   useEffect(() => {
     const prev = prevRawStatusRef.current;
     prevRawStatusRef.current = rawStatus;
-
-    // Skip if status didn't actually change
     if (rawStatus === prev) return;
-
     if (!isKernelStatus(rawStatus)) return;
-    const status: DaemonKernelStatus = rawStatus;
+    const status: KernelStatus = rawStatus;
 
     if (status === KERNEL_STATUS.BUSY) {
-      // Throttle busy: only show if it persists past threshold
       if (busyTimerRef.current === null) {
         busyTimerRef.current = window.setTimeout(() => {
           busyTimerRef.current = null;
@@ -264,16 +190,13 @@ export function useDaemonKernel({
         }, 60);
       }
     } else if (status === KERNEL_STATUS.IDLE) {
-      // Cancel pending busy transition if idle arrives quickly
       if (busyTimerRef.current !== null) {
         clearTimeout(busyTimerRef.current);
         busyTimerRef.current = null;
-        // Don't update — stay at current status (probably idle already)
       } else {
         setThrottledStatus(status);
       }
     } else {
-      // Other statuses (starting, error, shutdown, not_started) shown immediately
       if (busyTimerRef.current !== null) {
         clearTimeout(busyTimerRef.current);
         busyTimerRef.current = null;
@@ -289,11 +212,9 @@ export function useDaemonKernel({
     };
   }, [rawStatus]);
 
-  // The externally visible status uses the throttled value
   const kernelStatus = throttledStatus;
 
   // ── Callbacks in refs (avoid effect re-runs) ──────────────────────
-
   const callbacksRef = useRef({
     onOutput,
     onExecutionCount,
@@ -318,7 +239,6 @@ export function useDaemonKernel({
   };
 
   // ── Fire callbacks when derived state changes ─────────────────────
-
   const prevThrottledStatusRef = useRef(kernelStatus);
   useEffect(() => {
     const prev = prevThrottledStatusRef.current;
@@ -348,15 +268,13 @@ export function useDaemonKernel({
     }
   }, [queueState]);
 
-  // ── Execution lifecycle transitions (from CRDT, not broadcasts) ───
-
+  // ── Execution lifecycle transitions (from CRDT) ───────────────────
   const prevExecutionsRef = useRef<Record<string, ExecutionState>>({});
   useEffect(() => {
     const prev = prevExecutionsRef.current;
     const curr = runtimeState.executions;
     prevExecutionsRef.current = curr;
 
-    // Skip the initial empty→populated transition (slow joiner catch-up)
     if (Object.keys(prev).length === 0 && Object.keys(curr).length > 0) {
       return;
     }
@@ -369,35 +287,24 @@ export function useDaemonKernel({
           t.execution_count ?? 0,
         );
       } else {
-        // "done" or "error"
         callbacksRef.current.onExecutionDone(t.cell_id);
       }
     }
   }, [runtimeState.executions]);
 
   // ── Broadcast listener (events only — no state) ──────────────────
-
   useEffect(() => {
     let cancelled = false;
     const webview = getCurrentWebview();
-
-    // Ensure blob port is fresh on mount
     refreshBlobPort();
 
     const unsubscribeBroadcast = subscribeBroadcast((payload) => {
       if (cancelled) return;
-
       const broadcast = payload as DaemonBroadcast;
 
       switch (broadcast.event) {
-        // ── Events that stay as broadcasts ────────────────────────
-
         case "output": {
-          // Skip blob resolution entirely when no onOutput callback is
-          // registered. Sync delivers outputs via materializeCells; the
-          // broadcast path is only needed for OutputWidget capture.
           if (!callbacksRef.current.onOutput) break;
-
           const cellId = broadcast.cell_id;
           const outputJson = broadcast.output_json;
 
@@ -437,10 +344,11 @@ export function useDaemonKernel({
         }
 
         case "display_update": {
-          const { onUpdateDisplayData: cb } = callbacksRef.current;
-          if (cb) {
-            cb(broadcast.display_id, broadcast.data, broadcast.metadata);
-          }
+          callbacksRef.current.onUpdateDisplayData?.(
+            broadcast.display_id,
+            broadcast.data,
+            broadcast.metadata,
+          );
           break;
         }
 
@@ -450,10 +358,8 @@ export function useDaemonKernel({
         }
 
         case "comm": {
-          // Custom comm messages only (buttons, model.send()).
-          // State updates and lifecycle (open/close) flow through CRDT.
-          const { onCommMessage } = callbacksRef.current;
-          if (onCommMessage) {
+          const { onCommMessage: cb } = callbacksRef.current;
+          if (cb) {
             const msg: JupyterMessage = {
               header: {
                 msg_id: crypto.randomUUID(),
@@ -471,19 +377,15 @@ export function useDaemonKernel({
                   )
                 : [],
             };
-            onCommMessage(msg);
+            cb(msg);
           }
           break;
         }
 
         case "env_progress":
-          // Handled by useEnvProgress hook's own frame bus subscriber
           break;
 
-        // State broadcasts — redundant with RuntimeStateDoc.
-        // The daemon still sends these for backward compatibility;
-        // we silently ignore them. Will be removed from daemon in
-        // a future cleanup.
+        // State broadcasts — redundant with RuntimeStateDoc
         case "execution_started":
         case "execution_done":
         case "kernel_status":
@@ -492,24 +394,17 @@ export function useDaemonKernel({
           break;
 
         case "runtime_state_snapshot": {
-          // Eager snapshot from connection setup — apply immediately so the
-          // client has kernel status before the Automerge sync handshake completes.
           setRuntimeState(broadcast.state as RuntimeState);
           break;
         }
 
         case "kernel_error": {
-          // Still consume this broadcast for the detailed error message.
-          // Status is derived from RuntimeStateDoc, but the error string
-          // only arrives via broadcast.
           callbacksRef.current.onKernelError?.(broadcast.error);
           break;
         }
 
         default: {
           const event = (broadcast as { event?: string }).event;
-          // Internal SyncEngine broadcasts (e.g. text_attribution) use
-          // "type" not "event" — skip logging for those.
           if (event !== undefined) {
             logger.debug(`[daemon-kernel] Unknown broadcast event: ${event}`);
           }
@@ -523,10 +418,8 @@ export function useDaemonKernel({
       async () => {
         if (cancelled) return;
         logger.warn("[daemon-kernel] Daemon disconnected, resetting state");
-        // Reset RuntimeStateDoc store — next sync will repopulate
         resetRuntimeState();
         resetBlobPort();
-
         try {
           await invoke("reconnect_to_daemon");
           logger.debug("[daemon-kernel] Reconnected to daemon");
@@ -537,7 +430,6 @@ export function useDaemonKernel({
       },
     );
 
-    // Listen for daemon ready signal
     const unlistenReady = webview.listen("daemon:ready", () => {
       if (cancelled) return;
       logger.debug("[daemon-kernel] Daemon ready");
@@ -556,41 +448,32 @@ export function useDaemonKernel({
     };
   }, []);
 
-  // ── Sync comms from RuntimeStateDoc → WidgetStore ─────────────────
-  //
-  // Full lifecycle: the CRDT is the source of truth for widget state.
-  // Detect new comms (comm_open), state changes (comm_msg update),
-  // and removed comms (comm_close) by diffing against previous state.
-  // Blob sentinels in state are resolved to HTTP URLs before delivery.
-  // New comms are sorted by seq for correct widget dependency order.
-  const prevCommsRef = useRef<Record<string, CommDocEntry>>({});
-  const prevCommsJsonRef = useRef<Record<string, string>>({});
+  // ── Comm state diffing → WidgetStore ──────────────────────────────
+  const commDiffStateRef = useRef<CommDiffState>({
+    comms: {},
+    json: {},
+  });
+
   useEffect(() => {
-    const { onCommMessage } = callbacksRef.current;
-    if (!onCommMessage) return;
+    const { onCommMessage: commCb } = callbacksRef.current;
+    if (!commCb) return;
 
     const docComms = runtimeState.comms ?? {};
-    const prevComms = prevCommsRef.current;
-    const prevJson = prevCommsJsonRef.current;
-    const nextComms: Record<string, CommDocEntry> = {};
-    const nextJson: Record<string, string> = {};
-
-    // Blob port is needed to resolve {"$blob":"hash"} sentinels in state.
-    // Without it, comm_open and state updates would deliver unresolved sentinels
-    // which cause DataCloneError in the widget iframe. Skip delivery and leave
-    // those comms out of prevCommsRef so the next effect run retries them.
     const hasBlobPort = getBlobPort() !== null;
 
-    // New comms — synthesize comm_open (sorted by seq for dependency order)
-    const newEntries = Object.entries(docComms)
-      .filter(([commId]) => !(commId in prevComms))
-      .sort(([, a], [, b]) => (a.seq ?? 0) - (b.seq ?? 0));
+    const { result, next } = diffComms(commDiffStateRef.current, docComms);
 
-    for (const [commId, entry] of newEntries) {
-      if (!hasBlobPort) continue; // Retry on next CRDT update once port is ready
+    // Process opened comms — synthesize comm_open
+    for (const { commId, entry } of result.opened) {
+      if (!hasBlobPort) {
+        // Remove from next state so it retries on next CRDT update
+        delete next.comms[commId];
+        delete next.json[commId];
+        continue;
+      }
       const { state: resolvedState, bufferPaths } =
         replaceSentinelsWithBlobUrls(entry.state as Record<string, unknown>);
-      const msg: JupyterMessage = {
+      commCb({
         header: {
           msg_id: crypto.randomUUID(),
           msg_type: "comm_open",
@@ -613,274 +496,128 @@ export function useDaemonKernel({
           },
         },
         buffers: [],
-      };
-      onCommMessage(msg);
-      nextComms[commId] = entry;
-      nextJson[commId] = JSON.stringify(entry.state);
-
-      // Resolve Output widget manifest hashes in state.outputs to JupyterOutput objects.
-      // The daemon writes manifest hashes (same format as execution outputs);
-      // we resolve them here so the iframe receives ready-to-render outputs.
+      });
       resolveCommOutputHashes(commId, entry.state, callbacksRef);
     }
 
-    // State changes — synthesize comm_msg(update)
-    for (const [commId, entry] of Object.entries(docComms)) {
-      const stateStr = JSON.stringify(entry.state);
-      if (commId in prevComms) {
-        nextComms[commId] = entry;
-        nextJson[commId] = stateStr;
-        if (prevJson[commId] !== stateStr) {
-          const { state: resolvedState, bufferPaths } =
-            replaceSentinelsWithBlobUrls(
-              entry.state as Record<string, unknown>,
-            );
-          const msg: JupyterMessage = {
-            header: {
-              msg_id: crypto.randomUUID(),
-              msg_type: "comm_msg",
-              session: "",
-              username: "kernel",
-              date: new Date().toISOString(),
-              version: "5.3",
-            },
-            metadata: {},
-            content: {
-              comm_id: commId,
-              data: {
-                method: "update",
-                state: resolvedState,
-                buffer_paths: bufferPaths,
-              },
-            },
-            buffers: [],
-          };
-          onCommMessage(msg);
-
-          // Resolve Output widget manifest hashes in state.outputs
-          resolveCommOutputHashes(commId, entry.state, callbacksRef);
-        }
-      }
-    }
-
-    // Removed comms — synthesize comm_close
-    for (const commId of Object.keys(prevComms)) {
-      if (!docComms[commId]) {
-        const msg: JupyterMessage = {
-          header: {
-            msg_id: crypto.randomUUID(),
-            msg_type: "comm_close",
-            session: "",
-            username: "kernel",
-            date: new Date().toISOString(),
-            version: "5.3",
+    // Process updated comms — synthesize comm_msg(update)
+    for (const { commId, entry } of result.updated) {
+      const { state: resolvedState, bufferPaths } =
+        replaceSentinelsWithBlobUrls(entry.state as Record<string, unknown>);
+      commCb({
+        header: {
+          msg_id: crypto.randomUUID(),
+          msg_type: "comm_msg",
+          session: "",
+          username: "kernel",
+          date: new Date().toISOString(),
+          version: "5.3",
+        },
+        metadata: {},
+        content: {
+          comm_id: commId,
+          data: {
+            method: "update",
+            state: resolvedState,
+            buffer_paths: bufferPaths,
           },
-          metadata: {},
-          content: { comm_id: commId },
-          buffers: [],
-        };
-        onCommMessage(msg);
-      }
+        },
+        buffers: [],
+      });
+      resolveCommOutputHashes(commId, entry.state, callbacksRef);
     }
 
-    // Only track comms that were successfully delivered.
-    // Comms skipped due to missing blob port will be retried on next update.
-    prevCommsRef.current = nextComms;
-    prevCommsJsonRef.current = nextJson;
+    // Process closed comms — synthesize comm_close
+    for (const commId of result.closed) {
+      commCb({
+        header: {
+          msg_id: crypto.randomUUID(),
+          msg_type: "comm_close",
+          session: "",
+          username: "kernel",
+          date: new Date().toISOString(),
+          version: "5.3",
+        },
+        metadata: {},
+        content: { comm_id: commId },
+        buffers: [],
+      });
+    }
+
+    commDiffStateRef.current = next;
   }, [runtimeState.comms]);
 
-  // ── Actions ───────────────────────────────────────────────────────
+  // ── Actions (via NotebookClient) ──────────────────────────────────
 
-  /** Launch a kernel via the daemon */
   const launchKernel = useCallback(
-    async (
-      kernelType: string,
-      envSource: string,
-      notebookPath?: string,
-    ): Promise<DaemonNotebookResponse> => {
-      logger.debug("[daemon-kernel] Launching kernel:", kernelType, envSource);
-      // Don't set status manually — the RuntimeStateDoc will update
-      // via sync when the daemon processes the launch.
-
-      try {
-        const response = await invoke<DaemonNotebookResponse>(
-          "launch_kernel_via_daemon",
-          { kernelType, envSource, notebookPath },
-        );
-        return response;
-      } catch (e) {
-        logger.error("[daemon-kernel] Launch failed:", e);
-        throw e;
-      }
-    },
-    [],
+    (kernelType: string, envSource: string, notebookPath?: string) =>
+      client.launchKernel(
+        kernelType,
+        envSource,
+        notebookPath,
+      ) as Promise<NotebookResponse>,
+    [client],
   );
 
-  /** Execute a cell via the daemon (reads source from synced document) */
   const executeCell = useCallback(
-    async (cellId: string): Promise<DaemonNotebookResponse> => {
-      logger.debug("[daemon-kernel] Executing cell:", cellId);
-      try {
-        const response = await invoke<DaemonNotebookResponse>(
-          "execute_cell_via_daemon",
-          { cellId },
-        );
-        return response;
-      } catch (e) {
-        logger.error("[daemon-kernel] Execute failed:", e);
-        throw e;
-      }
-    },
-    [],
+    (cellId: string) => client.executeCell(cellId) as Promise<NotebookResponse>,
+    [client],
   );
 
-  /** Clear outputs for a cell via the daemon */
   const clearOutputs = useCallback(
-    async (cellId: string): Promise<DaemonNotebookResponse> => {
-      try {
-        const response = await invoke<DaemonNotebookResponse>(
-          "clear_outputs_via_daemon",
-          { cellId },
-        );
-        return response;
-      } catch (e) {
-        logger.error("[daemon-kernel] Clear outputs failed:", e);
-        throw e;
-      }
-    },
-    [],
+    (cellId: string) =>
+      client.clearOutputs(cellId) as Promise<NotebookResponse>,
+    [client],
   );
 
-  /** Interrupt kernel execution */
-  const interruptKernel = useCallback(async () => {
-    try {
-      const response = await invoke<DaemonNotebookResponse>(
-        "interrupt_via_daemon",
-      );
-      return response;
-    } catch (e) {
-      logger.error("[daemon-kernel] Interrupt failed:", e);
-      throw e;
-    }
-  }, []);
+  const interruptKernel = useCallback(
+    () => client.interruptKernel() as Promise<NotebookResponse>,
+    [client],
+  );
 
-  /** Shutdown the kernel */
-  const shutdownKernel = useCallback(async () => {
-    try {
-      const response = await invoke<DaemonNotebookResponse>(
-        "shutdown_kernel_via_daemon",
-      );
-      // Don't set status manually — RuntimeStateDoc will update via sync
-      return response;
-    } catch (e) {
-      logger.error("[daemon-kernel] Shutdown failed:", e);
-      throw e;
-    }
-  }, []);
+  const shutdownKernel = useCallback(
+    () => client.shutdownKernel() as Promise<NotebookResponse>,
+    [client],
+  );
 
-  /** Hot-sync environment - install new packages without restart (UV only) */
-  const syncEnvironment = useCallback(async () => {
-    try {
-      const response = await invoke<DaemonNotebookResponse>(
-        "sync_environment_via_daemon",
-      );
-      if (response.result === "error") {
-        logger.error("[daemon-kernel] Sync env failed:", response.error);
-      }
-      return response;
-    } catch (e) {
-      logger.error("[daemon-kernel] Sync environment failed:", e);
-      throw e;
-    }
-  }, []);
+  const syncEnvironment = useCallback(
+    () => client.syncEnvironment() as Promise<NotebookResponse>,
+    [client],
+  );
 
-  /** Run all code cells (daemon reads from synced doc) */
-  const runAllCells = useCallback(async (): Promise<DaemonNotebookResponse> => {
-    logger.debug("[daemon-kernel] Running all cells");
-    try {
-      return await invoke<DaemonNotebookResponse>("run_all_cells_via_daemon");
-    } catch (e) {
-      logger.error("[daemon-kernel] Run all cells failed:", e);
-      throw e;
-    }
-  }, []);
+  const runAllCells = useCallback(
+    () => client.runAllCells() as Promise<NotebookResponse>,
+    [client],
+  );
 
-  /** Send a comm message to the kernel (for widget interactions) */
   const sendCommMessage = useCallback(
-    async (message: {
+    (message: {
       header: Record<string, unknown>;
       parent_header?: Record<string, unknown> | null;
       metadata?: Record<string, unknown>;
       content: Record<string, unknown>;
       buffers?: ArrayBuffer[];
       channel?: string;
-    }): Promise<void> => {
-      const msgType = message.header.msg_type as string;
-      logger.debug("[daemon-kernel] Sending comm message:", msgType);
-      try {
-        // Convert ArrayBuffer[] to number[][] for JSON serialization
-        const buffers: number[][] = (message.buffers ?? []).map((buf) =>
-          Array.from(new Uint8Array(buf)),
-        );
-
-        const fullMessage = {
-          header: message.header,
-          parent_header: message.parent_header ?? null,
-          metadata: message.metadata ?? {},
-          content: message.content,
-          buffers,
-          channel: message.channel ?? "shell",
-        };
-
-        const response = await invoke<DaemonNotebookResponse>(
-          "send_comm_via_daemon",
-          { message: fullMessage },
-        );
-
-        if (response.result === "error") {
-          logger.error("[daemon-kernel] Send comm failed:", response.error);
-        } else if (response.result === "no_kernel") {
-          logger.error("[daemon-kernel] Send comm failed: no kernel running");
-        }
-      } catch (e) {
-        logger.error("[daemon-kernel] Send comm failed:", e);
-        throw e;
-      }
-    },
-    [],
+    }) => client.sendComm(message),
+    [client],
   );
 
   return {
-    /** Current kernel status (with busy throttle applied) */
     kernelStatus,
-    /** Sub-phase detail when status is "starting" */
     startingPhase: runtimeState.kernel.starting_phase,
-    /** Current execution queue state */
     queueState,
-    /** Kernel type and environment source */
     kernelInfo,
-    /** Environment sync state - null if unknown, has inSync and diff if known */
     envSyncState,
-    /** Launch a kernel via the daemon */
     launchKernel,
-    /** Execute a cell (reads source from synced document) */
     executeCell,
-    /** Clear outputs for a cell */
     clearOutputs,
-    /** Interrupt kernel execution */
     interruptKernel,
-    /** Shutdown the kernel */
     shutdownKernel,
-    /** Hot-sync environment - install new packages without restart (UV only) */
     syncEnvironment,
-    /** Run all code cells (daemon reads from synced doc) */
     runAllCells,
-    /** Send a comm message to the kernel (for widget interactions) */
     sendCommMessage,
-    /** Check if a cell is currently executing */
     isCellExecuting: (cellId: string) =>
       queueState.executing?.cell_id === cellId,
-    /** Check if a cell is in the queue */
     isCellQueued: (cellId: string) =>
       queueState.executing?.cell_id === cellId ||
       queueState.queued.some((entry) => entry.cell_id === cellId),

--- a/apps/notebook/src/lib/kernel-status.ts
+++ b/apps/notebook/src/lib/kernel-status.ts
@@ -1,17 +1,12 @@
-export const KERNEL_STATUS = {
-  NOT_STARTED: "not_started",
-  STARTING: "starting",
-  IDLE: "idle",
-  BUSY: "busy",
-  ERROR: "error",
-  SHUTDOWN: "shutdown",
-} as const;
+/**
+ * Kernel status types and UI labels.
+ *
+ * Core types re-exported from runtimed; UI-specific labels live here.
+ */
 
-export type KernelStatus = (typeof KERNEL_STATUS)[keyof typeof KERNEL_STATUS];
+export { isKernelStatus, KERNEL_STATUS, type KernelStatus } from "runtimed";
 
-const KERNEL_STATUS_SET: ReadonlySet<KernelStatus> = new Set(
-  Object.values(KERNEL_STATUS),
-);
+import { KERNEL_STATUS, type KernelStatus } from "runtimed";
 
 export const KERNEL_STATUS_LABELS: Record<KernelStatus, string> = {
   [KERNEL_STATUS.NOT_STARTED]: "initializing",
@@ -21,10 +16,6 @@ export const KERNEL_STATUS_LABELS: Record<KernelStatus, string> = {
   [KERNEL_STATUS.ERROR]: "error",
   [KERNEL_STATUS.SHUTDOWN]: "shutdown",
 };
-
-export function isKernelStatus(value: string): value is KernelStatus {
-  return KERNEL_STATUS_SET.has(value as KernelStatus);
-}
 
 const STARTING_PHASE_LABELS: Record<string, string> = {
   resolving: "resolving environment",

--- a/apps/notebook/src/lib/tauri-transport.ts
+++ b/apps/notebook/src/lib/tauri-transport.ts
@@ -8,7 +8,11 @@
 
 import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWebview } from "@tauri-apps/api/webview";
-import type { FrameListener, NotebookTransport } from "runtimed";
+import type {
+  FrameListener,
+  NotebookRequest,
+  NotebookTransport,
+} from "runtimed";
 
 export class TauriTransport implements NotebookTransport {
   private _connected = true;
@@ -59,6 +63,36 @@ export class TauriTransport implements NotebookTransport {
 
     this.unlisteners.push(unlisten);
     return unlisten;
+  }
+
+  async sendRequest(request: unknown): Promise<unknown> {
+    const req = request as NotebookRequest;
+    switch (req.type) {
+      case "launch_kernel":
+        return invoke("launch_kernel_via_daemon", {
+          kernelType: req.kernel_type,
+          envSource: req.env_source,
+          notebookPath: req.notebook_path,
+        });
+      case "execute_cell":
+        return invoke("execute_cell_via_daemon", { cellId: req.cell_id });
+      case "clear_outputs":
+        return invoke("clear_outputs_via_daemon", { cellId: req.cell_id });
+      case "interrupt":
+        return invoke("interrupt_via_daemon");
+      case "shutdown_kernel":
+        return invoke("shutdown_kernel_via_daemon");
+      case "sync_environment":
+        return invoke("sync_environment_via_daemon");
+      case "run_all_cells":
+        return invoke("run_all_cells_via_daemon");
+      case "send_comm":
+        return invoke("send_comm_via_daemon", { message: req.message });
+      default:
+        throw new Error(
+          `TauriTransport: unknown request type: ${(req as { type: string }).type}`,
+        );
+    }
   }
 
   disconnect(): void {

--- a/packages/runtimed/src/broadcast-types.ts
+++ b/packages/runtimed/src/broadcast-types.ts
@@ -1,0 +1,106 @@
+/**
+ * Typed broadcast interfaces for daemon events.
+ *
+ * Transport-agnostic versions of the broadcast payloads sent by the daemon
+ * via frame type 0x03 (BROADCAST). Provides type guards for filtering
+ * the untyped `broadcasts$` observable into typed sub-streams.
+ */
+
+import type { RuntimeState } from "./runtime-state";
+
+// ── Broadcast interfaces ────────────────────────────────────────────
+
+export interface OutputBroadcast {
+  event: "output";
+  cell_id: string;
+  execution_id: string;
+  output_type: string;
+  output_json: string;
+}
+
+export interface DisplayUpdateBroadcast {
+  event: "display_update";
+  display_id: string;
+  data: Record<string, unknown>;
+  metadata: Record<string, unknown>;
+}
+
+export interface OutputsClearedBroadcast {
+  event: "outputs_cleared";
+  cell_id: string;
+}
+
+export interface CommBroadcast {
+  event: "comm";
+  msg_type: string;
+  content: Record<string, unknown>;
+  buffers: number[][];
+}
+
+export interface KernelErrorBroadcast {
+  event: "kernel_error";
+  error: string;
+}
+
+export interface RuntimeStateSnapshotBroadcast {
+  event: "runtime_state_snapshot";
+  state: RuntimeState;
+}
+
+/** Union of all known broadcast types with an `event` field. */
+export type KnownBroadcast =
+  | OutputBroadcast
+  | DisplayUpdateBroadcast
+  | OutputsClearedBroadcast
+  | CommBroadcast
+  | KernelErrorBroadcast
+  | RuntimeStateSnapshotBroadcast;
+
+// ── Type guards ─────────────────────────────────────────────────────
+
+function hasBroadcastEvent(payload: unknown): payload is { event: string } {
+  return (
+    typeof payload === "object" &&
+    payload !== null &&
+    "event" in payload &&
+    typeof (payload as { event: unknown }).event === "string"
+  );
+}
+
+export function isOutputBroadcast(
+  payload: unknown,
+): payload is OutputBroadcast {
+  return hasBroadcastEvent(payload) && payload.event === "output";
+}
+
+export function isDisplayUpdateBroadcast(
+  payload: unknown,
+): payload is DisplayUpdateBroadcast {
+  return hasBroadcastEvent(payload) && payload.event === "display_update";
+}
+
+export function isOutputsClearedBroadcast(
+  payload: unknown,
+): payload is OutputsClearedBroadcast {
+  return hasBroadcastEvent(payload) && payload.event === "outputs_cleared";
+}
+
+export function isCommBroadcast(
+  payload: unknown,
+): payload is CommBroadcast {
+  return hasBroadcastEvent(payload) && payload.event === "comm";
+}
+
+export function isKernelErrorBroadcast(
+  payload: unknown,
+): payload is KernelErrorBroadcast {
+  return hasBroadcastEvent(payload) && payload.event === "kernel_error";
+}
+
+export function isRuntimeStateSnapshotBroadcast(
+  payload: unknown,
+): payload is RuntimeStateSnapshotBroadcast {
+  return (
+    hasBroadcastEvent(payload) && payload.event === "runtime_state_snapshot"
+  );
+}

--- a/packages/runtimed/src/comm-diff.ts
+++ b/packages/runtimed/src/comm-diff.ts
@@ -1,0 +1,128 @@
+/**
+ * Comm state diffing — pure logic for detecting widget lifecycle changes.
+ *
+ * Diffs previous vs current CRDT comm state to detect:
+ * - New comms (comm_open) — sorted by seq for dependency order
+ * - State changes (comm_msg update)
+ * - Removed comms (comm_close)
+ *
+ * No blob resolution, no JupyterMessage synthesis — callers handle
+ * platform-specific concerns.
+ */
+
+import type { CommDocEntry } from "./runtime-state";
+
+// ── Types ───────────────────────────────────────────────────────────
+
+export interface CommDiffResult {
+  /** New comms, sorted by seq for correct widget dependency order. */
+  opened: Array<{ commId: string; entry: CommDocEntry }>;
+  /** Comms whose state changed (JSON-level diff). */
+  updated: Array<{ commId: string; entry: CommDocEntry }>;
+  /** Comm IDs that were removed. */
+  closed: string[];
+}
+
+export interface CommDiffState {
+  comms: Record<string, CommDocEntry>;
+  json: Record<string, string>;
+}
+
+// ── Manifest hash detection ─────────────────────────────────────────
+
+const MANIFEST_HASH_RE = /^[a-f0-9]{64}$/;
+
+/**
+ * Check if a string looks like a manifest hash (64-char hex SHA-256).
+ */
+export function isManifestHash(s: string): boolean {
+  return MANIFEST_HASH_RE.test(s);
+}
+
+export interface OutputManifestHashes {
+  hashes: string[];
+}
+
+/**
+ * Detect unresolved Output widget manifest hashes in comm state.
+ *
+ * Returns the hashes if `state._model_name === "OutputModel"` and
+ * `state.outputs` contains valid manifest hash strings. Returns null
+ * if not an OutputModel, outputs are empty, or already resolved.
+ */
+export function detectOutputManifestHashes(
+  state: Record<string, unknown>,
+): OutputManifestHashes | null {
+  if (state._model_name !== "OutputModel") return null;
+
+  const outputs = state.outputs;
+  if (!Array.isArray(outputs) || outputs.length === 0) return null;
+
+  // Check all entries are manifest hash strings
+  const allHashes = outputs.every(
+    (o) => typeof o === "string" && isManifestHash(o),
+  );
+  if (!allHashes) return null;
+
+  return { hashes: outputs as string[] };
+}
+
+// ── Diff function ───────────────────────────────────────────────────
+
+/**
+ * Diff previous and current comm state from RuntimeStateDoc.
+ *
+ * Returns the structural diff (opened, updated, closed) and the next
+ * tracking state for the caller to store. The caller decides which
+ * opened/updated comms to include in tracking (e.g., skip comms
+ * that couldn't be delivered due to missing blob port).
+ *
+ * @param prev - Previous tracking state
+ * @param curr - Current comms from RuntimeState
+ */
+export function diffComms(
+  prev: CommDiffState,
+  curr: Record<string, CommDocEntry>,
+): { result: CommDiffResult; next: CommDiffState } {
+  const opened: CommDiffResult["opened"] = [];
+  const updated: CommDiffResult["updated"] = [];
+  const closed: string[] = [];
+
+  const nextComms: Record<string, CommDocEntry> = {};
+  const nextJson: Record<string, string> = {};
+
+  // New comms — sorted by seq for dependency order
+  const newEntries = Object.entries(curr)
+    .filter(([commId]) => !(commId in prev.comms))
+    .sort(([, a], [, b]) => (a.seq ?? 0) - (b.seq ?? 0));
+
+  for (const [commId, entry] of newEntries) {
+    opened.push({ commId, entry });
+    nextComms[commId] = entry;
+    nextJson[commId] = JSON.stringify(entry.state);
+  }
+
+  // State changes for existing comms
+  for (const [commId, entry] of Object.entries(curr)) {
+    const stateStr = JSON.stringify(entry.state);
+    if (commId in prev.comms) {
+      nextComms[commId] = entry;
+      nextJson[commId] = stateStr;
+      if (prev.json[commId] !== stateStr) {
+        updated.push({ commId, entry });
+      }
+    }
+  }
+
+  // Removed comms
+  for (const commId of Object.keys(prev.comms)) {
+    if (!curr[commId]) {
+      closed.push(commId);
+    }
+  }
+
+  return {
+    result: { opened, updated, closed },
+    next: { comms: nextComms, json: nextJson },
+  };
+}

--- a/packages/runtimed/src/derived-state.ts
+++ b/packages/runtimed/src/derived-state.ts
@@ -1,0 +1,159 @@
+/**
+ * Derived state functions and kernel status types.
+ *
+ * Pure functions that derive UI-consumable state from RuntimeState.
+ * No React, no Tauri, no browser APIs.
+ */
+
+import {
+  type Observable,
+  type OperatorFunction,
+  distinctUntilChanged,
+  map,
+  of,
+  switchMap,
+  timer,
+} from "rxjs";
+
+import type { QueueEntry, RuntimeState } from "./runtime-state";
+
+// ── Kernel status ───────────────────────────────────────────────────
+
+export const KERNEL_STATUS = {
+  NOT_STARTED: "not_started",
+  STARTING: "starting",
+  IDLE: "idle",
+  BUSY: "busy",
+  ERROR: "error",
+  SHUTDOWN: "shutdown",
+} as const;
+
+export type KernelStatus = (typeof KERNEL_STATUS)[keyof typeof KERNEL_STATUS];
+
+const KERNEL_STATUS_SET: ReadonlySet<KernelStatus> = new Set(
+  Object.values(KERNEL_STATUS),
+);
+
+export function isKernelStatus(value: string): value is KernelStatus {
+  return KERNEL_STATUS_SET.has(value as KernelStatus);
+}
+
+// ── Derived types ───────────────────────────────────────────────────
+
+export interface KernelInfo {
+  kernelType: string | undefined;
+  envSource: string | undefined;
+}
+
+export interface DaemonQueueState {
+  executing: QueueEntry | null;
+  queued: QueueEntry[];
+}
+
+export interface EnvSyncDiff {
+  added: string[];
+  removed: string[];
+  channelsChanged: boolean;
+  denoChanged: boolean;
+}
+
+export interface EnvSyncState {
+  inSync: boolean;
+  diff?: EnvSyncDiff;
+}
+
+// ── Derivation functions ────────────────────────────────────────────
+
+/** Derive kernel type and environment source from RuntimeState. */
+export function deriveKernelInfo(state: RuntimeState): KernelInfo {
+  return {
+    kernelType: state.kernel.language || undefined,
+    envSource: state.kernel.env_source || undefined,
+  };
+}
+
+/** Derive queue state from RuntimeState. */
+export function deriveQueueState(state: RuntimeState): DaemonQueueState {
+  return {
+    executing: state.queue.executing,
+    queued: state.queue.queued,
+  };
+}
+
+/**
+ * Derive environment sync state from RuntimeState.
+ *
+ * Returns null before kernel launch, on shutdown, or on error — indicating
+ * "unknown" to consumers. Returns the sync state otherwise.
+ */
+export function deriveEnvSyncState(
+  state: RuntimeState,
+): EnvSyncState | null {
+  if (
+    (state.kernel.status === "not_started" && !state.kernel.env_source) ||
+    state.kernel.status === "shutdown" ||
+    state.kernel.status === "error"
+  ) {
+    return null;
+  }
+  return {
+    inSync: state.env.in_sync,
+    diff: state.env.in_sync
+      ? undefined
+      : {
+          added: state.env.added,
+          removed: state.env.removed,
+          channelsChanged: state.env.channels_changed,
+          denoChanged: state.env.deno_changed,
+        },
+  };
+}
+
+// ── Busy throttle ───────────────────────────────────────────────────
+
+const DEFAULT_BUSY_THRESHOLD_MS = 60;
+
+/**
+ * RxJS operator that throttles kernel "busy" status transitions.
+ *
+ * The RuntimeStateDoc records every busy→idle transition, including
+ * sub-60ms blips from tab completions. This operator delays "busy"
+ * by `threshold` ms — if "idle" arrives within that window, the busy
+ * is never emitted, preventing UI flicker.
+ *
+ * Other statuses (starting, error, shutdown, not_started) pass through
+ * immediately and cancel any pending busy.
+ */
+export function throttleBusyStatus(
+  threshold = DEFAULT_BUSY_THRESHOLD_MS,
+): OperatorFunction<string, KernelStatus> {
+  return (source: Observable<string>) =>
+    source.pipe(
+      distinctUntilChanged(),
+      switchMap((raw) => {
+        if (!isKernelStatus(raw)) return of<KernelStatus>(KERNEL_STATUS.NOT_STARTED);
+        if (raw === KERNEL_STATUS.BUSY) {
+          // Delay busy emission — switchMap cancels if next status arrives first
+          return timer(threshold).pipe(map(() => KERNEL_STATUS.BUSY));
+        }
+        // All other statuses emit immediately (and cancel any pending busy via switchMap)
+        return of<KernelStatus>(raw);
+      }),
+      distinctUntilChanged(),
+    );
+}
+
+/**
+ * Derive a throttled kernel status observable from a RuntimeState stream.
+ *
+ * Convenience wrapper: extracts `kernel.status` and applies `throttleBusyStatus()`.
+ */
+export function kernelStatus$(
+  runtimeState$: Observable<RuntimeState>,
+  threshold?: number,
+): Observable<KernelStatus> {
+  return runtimeState$.pipe(
+    map((s) => s.kernel.status),
+    throttleBusyStatus(threshold),
+  );
+}

--- a/packages/runtimed/src/direct-transport.ts
+++ b/packages/runtimed/src/direct-transport.ts
@@ -70,6 +70,13 @@ export class DirectTransport implements NotebookTransport {
    */
   simulateFailure = false;
 
+  /**
+   * Handler for `sendRequest` calls. Set this to provide test responses.
+   * Defaults to returning `{ result: "ok" }` for all requests.
+   */
+  requestHandler: (request: unknown) => Promise<unknown> = () =>
+    Promise.resolve({ result: "ok" });
+
   constructor(server: ServerHandle) {
     this.server = server;
   }
@@ -104,6 +111,13 @@ export class DirectTransport implements NotebookTransport {
     return () => {
       this.subscribers.delete(callback);
     };
+  }
+
+  async sendRequest(request: unknown): Promise<unknown> {
+    if (!this._connected) {
+      throw new Error("DirectTransport: not connected");
+    }
+    return this.requestHandler(request);
   }
 
   disconnect(): void {

--- a/packages/runtimed/src/index.ts
+++ b/packages/runtimed/src/index.ts
@@ -50,6 +50,57 @@ export {
   DEFAULT_POOL_STATE,
 } from "./pool-state";
 
+// Broadcast types
+export {
+  type CommBroadcast,
+  type DisplayUpdateBroadcast,
+  isCommBroadcast,
+  isDisplayUpdateBroadcast,
+  isKernelErrorBroadcast,
+  isOutputBroadcast,
+  isOutputsClearedBroadcast,
+  isRuntimeStateSnapshotBroadcast,
+  type KernelErrorBroadcast,
+  type KnownBroadcast,
+  type OutputBroadcast,
+  type OutputsClearedBroadcast,
+  type RuntimeStateSnapshotBroadcast,
+} from "./broadcast-types";
+
+// Comm diffing
+export {
+  type CommDiffResult,
+  type CommDiffState,
+  detectOutputManifestHashes,
+  diffComms,
+  isManifestHash,
+  type OutputManifestHashes,
+} from "./comm-diff";
+
+// Derived state
+export {
+  type DaemonQueueState,
+  deriveEnvSyncState,
+  deriveKernelInfo,
+  deriveQueueState,
+  type EnvSyncDiff,
+  type EnvSyncState,
+  isKernelStatus,
+  KERNEL_STATUS,
+  kernelStatus$,
+  type KernelInfo,
+  type KernelStatus,
+  throttleBusyStatus,
+} from "./derived-state";
+
+// Notebook client
+export { NotebookClient, type NotebookClientOptions } from "./notebook-client";
+export type {
+  CommRequestMessage,
+  NotebookRequest,
+  NotebookResponse,
+} from "./request-types";
+
 // Testing
 export { DirectTransport } from "./direct-transport";
 export type { ServerHandle } from "./direct-transport";

--- a/packages/runtimed/src/notebook-client.ts
+++ b/packages/runtimed/src/notebook-client.ts
@@ -1,0 +1,187 @@
+/**
+ * NotebookClient — typed kernel command interface.
+ *
+ * Provides typed methods for all kernel operations (execute, launch,
+ * interrupt, etc.) over a pluggable transport. Separate from SyncEngine
+ * because request/response is a different pattern than CRDT sync.
+ *
+ * Zero Tauri / React / browser dependencies.
+ */
+
+import type { SyncEngineLogger } from "./sync-engine";
+import type { NotebookTransport } from "./transport";
+import type {
+  CommRequestMessage,
+  NotebookRequest,
+  NotebookResponse,
+} from "./request-types";
+
+const nullLogger: SyncEngineLogger = {
+  debug() {},
+  info() {},
+  warn() {},
+  error() {},
+};
+
+export interface NotebookClientOptions {
+  transport: NotebookTransport;
+  logger?: SyncEngineLogger;
+}
+
+export class NotebookClient {
+  private readonly transport: NotebookTransport;
+  private readonly log: SyncEngineLogger;
+
+  constructor(opts: NotebookClientOptions) {
+    this.transport = opts.transport;
+    this.log = opts.logger ?? nullLogger;
+  }
+
+  /** Send a typed request and return the response. */
+  async sendRequest(request: NotebookRequest): Promise<NotebookResponse> {
+    return this.transport.sendRequest(request) as Promise<NotebookResponse>;
+  }
+
+  /** Launch a kernel via the daemon. */
+  async launchKernel(
+    kernelType: string,
+    envSource: string,
+    notebookPath?: string,
+  ): Promise<NotebookResponse> {
+    this.log.debug("[notebook-client] Launching kernel:", kernelType, envSource);
+    try {
+      return await this.sendRequest({
+        type: "launch_kernel",
+        kernel_type: kernelType,
+        env_source: envSource,
+        notebook_path: notebookPath,
+      });
+    } catch (e) {
+      this.log.error("[notebook-client] Launch failed:", e);
+      throw e;
+    }
+  }
+
+  /** Execute a cell (daemon reads source from synced document). */
+  async executeCell(cellId: string): Promise<NotebookResponse> {
+    this.log.debug("[notebook-client] Executing cell:", cellId);
+    try {
+      return await this.sendRequest({
+        type: "execute_cell",
+        cell_id: cellId,
+      });
+    } catch (e) {
+      this.log.error("[notebook-client] Execute failed:", e);
+      throw e;
+    }
+  }
+
+  /** Clear outputs for a cell. */
+  async clearOutputs(cellId: string): Promise<NotebookResponse> {
+    try {
+      return await this.sendRequest({
+        type: "clear_outputs",
+        cell_id: cellId,
+      });
+    } catch (e) {
+      this.log.error("[notebook-client] Clear outputs failed:", e);
+      throw e;
+    }
+  }
+
+  /** Interrupt kernel execution. */
+  async interruptKernel(): Promise<NotebookResponse> {
+    try {
+      return await this.sendRequest({ type: "interrupt" });
+    } catch (e) {
+      this.log.error("[notebook-client] Interrupt failed:", e);
+      throw e;
+    }
+  }
+
+  /** Shutdown the kernel. */
+  async shutdownKernel(): Promise<NotebookResponse> {
+    try {
+      return await this.sendRequest({ type: "shutdown_kernel" });
+    } catch (e) {
+      this.log.error("[notebook-client] Shutdown failed:", e);
+      throw e;
+    }
+  }
+
+  /** Hot-sync environment — install new packages without restart (UV only). */
+  async syncEnvironment(): Promise<NotebookResponse> {
+    try {
+      const response = await this.sendRequest({ type: "sync_environment" });
+      if ((response as { result: string }).result === "error") {
+        this.log.error(
+          "[notebook-client] Sync env failed:",
+          (response as { error: string }).error,
+        );
+      }
+      return response;
+    } catch (e) {
+      this.log.error("[notebook-client] Sync environment failed:", e);
+      throw e;
+    }
+  }
+
+  /** Run all code cells (daemon reads from synced doc). */
+  async runAllCells(): Promise<NotebookResponse> {
+    this.log.debug("[notebook-client] Running all cells");
+    try {
+      return await this.sendRequest({ type: "run_all_cells" });
+    } catch (e) {
+      this.log.error("[notebook-client] Run all cells failed:", e);
+      throw e;
+    }
+  }
+
+  /** Send a comm message to the kernel (for widget interactions). */
+  async sendComm(message: {
+    header: Record<string, unknown>;
+    parent_header?: Record<string, unknown> | null;
+    metadata?: Record<string, unknown>;
+    content: Record<string, unknown>;
+    buffers?: ArrayBuffer[];
+    channel?: string;
+  }): Promise<NotebookResponse> {
+    const msgType = message.header.msg_type as string;
+    this.log.debug("[notebook-client] Sending comm message:", msgType);
+    try {
+      // Convert ArrayBuffer[] to number[][] for JSON serialization
+      const buffers: number[][] = (message.buffers ?? []).map((buf) =>
+        Array.from(new Uint8Array(buf)),
+      );
+
+      const fullMessage: CommRequestMessage = {
+        header: message.header,
+        parent_header: message.parent_header ?? null,
+        metadata: message.metadata ?? {},
+        content: message.content,
+        buffers,
+        channel: message.channel ?? "shell",
+      };
+
+      const response = await this.sendRequest({
+        type: "send_comm",
+        message: fullMessage,
+      });
+
+      if ((response as { result: string }).result === "error") {
+        this.log.error(
+          "[notebook-client] Send comm failed:",
+          (response as { error: string }).error,
+        );
+      } else if ((response as { result: string }).result === "no_kernel") {
+        this.log.error(
+          "[notebook-client] Send comm failed: no kernel running",
+        );
+      }
+      return response;
+    } catch (e) {
+      this.log.error("[notebook-client] Send comm failed:", e);
+      throw e;
+    }
+  }
+}

--- a/packages/runtimed/src/request-types.ts
+++ b/packages/runtimed/src/request-types.ts
@@ -1,0 +1,73 @@
+/**
+ * TypeScript equivalents of NotebookRequest/NotebookResponse from
+ * crates/notebook-protocol/src/protocol.rs.
+ *
+ * Only includes variants currently used by the frontend client.
+ * These are transport-agnostic — callers encode them as needed.
+ */
+
+// ── Requests ────────────────────────────────────────────────────────
+
+export type NotebookRequest =
+  | {
+      type: "launch_kernel";
+      kernel_type: string;
+      env_source: string;
+      notebook_path?: string;
+    }
+  | { type: "execute_cell"; cell_id: string }
+  | { type: "clear_outputs"; cell_id: string }
+  | { type: "interrupt" }
+  | { type: "shutdown_kernel" }
+  | { type: "sync_environment" }
+  | { type: "run_all_cells" }
+  | { type: "send_comm"; message: CommRequestMessage };
+
+/** Message shape for send_comm requests. */
+export interface CommRequestMessage {
+  header: Record<string, unknown>;
+  parent_header?: Record<string, unknown> | null;
+  metadata?: Record<string, unknown>;
+  content: Record<string, unknown>;
+  buffers: number[][];
+  channel: string;
+}
+
+// ── Responses ───────────────────────────────────────────────────────
+
+export type NotebookResponse =
+  | { result: "kernel_launched"; kernel_type: string; env_source: string }
+  | {
+      result: "kernel_already_running";
+      kernel_type: string;
+      env_source: string;
+    }
+  | { result: "cell_queued"; cell_id: string; execution_id: string }
+  | { result: "outputs_cleared"; cell_id: string }
+  | { result: "interrupt_sent" }
+  | { result: "kernel_shutting_down" }
+  | { result: "no_kernel" }
+  | {
+      result: "kernel_info";
+      kernel_type?: string;
+      env_source?: string;
+      status: string;
+    }
+  | {
+      result: "queue_state";
+      executing?: { cell_id: string; execution_id: string } | null;
+      queued: { cell_id: string; execution_id: string }[];
+    }
+  | {
+      result: "all_cells_queued";
+      queued: { cell_id: string; execution_id: string }[];
+    }
+  | { result: "ok" }
+  | { result: "error"; error: string }
+  | { result: "sync_environment_started"; packages: string[] }
+  | { result: "sync_environment_complete"; synced_packages: string[] }
+  | {
+      result: "sync_environment_failed";
+      error: string;
+      needs_restart: boolean;
+    };

--- a/packages/runtimed/src/sync-engine.ts
+++ b/packages/runtimed/src/sync-engine.ts
@@ -32,7 +32,21 @@ import {
   timer,
 } from "rxjs";
 
+import {
+  type CommBroadcast,
+  type DisplayUpdateBroadcast,
+  type KernelErrorBroadcast,
+  type OutputBroadcast,
+  type OutputsClearedBroadcast,
+  isCommBroadcast,
+  isDisplayUpdateBroadcast,
+  isKernelErrorBroadcast,
+  isOutputBroadcast,
+  isOutputsClearedBroadcast,
+  isRuntimeStateSnapshotBroadcast,
+} from "./broadcast-types";
 import { type CellChangeset, mergeChangesets } from "./cell-changeset";
+import { type KernelStatus, kernelStatus$ as deriveKernelStatus$ } from "./derived-state";
 import type { FrameEvent, SyncableHandle } from "./handle";
 import type { PoolState } from "./pool-state";
 import {
@@ -134,6 +148,31 @@ export class SyncEngine {
   readonly executionTransitions$: Observable<ExecutionTransition[]>;
 
   /**
+   * Throttled kernel status derived from RuntimeState.
+   *
+   * Applies a 60ms busy throttle to filter sub-60ms busy→idle blips
+   * from tab completions. All other statuses pass through immediately.
+   */
+  readonly kernelStatus$: Observable<KernelStatus>;
+
+  // ── Typed broadcast observables ──────────────────────────────────
+
+  /** Output produced for a cell (includes manifest hash for blob resolution). */
+  readonly outputBroadcasts$: Observable<OutputBroadcast>;
+
+  /** Display data update by display_id. */
+  readonly displayUpdates$: Observable<DisplayUpdateBroadcast>;
+
+  /** Outputs cleared for a cell (from another window/peer). */
+  readonly outputsCleared$: Observable<OutputsClearedBroadcast>;
+
+  /** Custom comm messages (buttons, model.send()). */
+  readonly commBroadcasts$: Observable<CommBroadcast>;
+
+  /** Detailed kernel error message. */
+  readonly kernelErrors$: Observable<KernelErrorBroadcast>;
+
+  /**
    * Fires each time the initial sync handshake completes (daemon has
    * sent document content). Emits once per bootstrap cycle — after
    * `resetForBootstrap()`, the next `changed:true` frame triggers
@@ -168,6 +207,14 @@ export class SyncEngine {
     this.poolState$ = this._poolState$.asObservable();
     this.executionTransitions$ = this._executionTransitions$.asObservable();
     this.initialSyncComplete$ = this._initialSyncComplete$.asObservable();
+    this.kernelStatus$ = deriveKernelStatus$(this.runtimeState$);
+
+    // Typed broadcast sub-observables (derived from broadcasts$)
+    this.outputBroadcasts$ = this.broadcasts$.pipe(filter(isOutputBroadcast));
+    this.displayUpdates$ = this.broadcasts$.pipe(filter(isDisplayUpdateBroadcast));
+    this.outputsCleared$ = this.broadcasts$.pipe(filter(isOutputsClearedBroadcast));
+    this.commBroadcasts$ = this.broadcasts$.pipe(filter(isCommBroadcast));
+    this.kernelErrors$ = this.broadcasts$.pipe(filter(isKernelErrorBroadcast));
   }
 
   // ── Lifecycle ────────────────────────────────────────────────────
@@ -374,6 +421,19 @@ export class SyncEngine {
       frameEvents$
         .pipe(filter((e) => e.type === "presence" && e.payload != null))
         .subscribe((e) => this._presence$.next(e.payload)),
+    );
+
+    // ── Sub-pipeline: runtime_state_snapshot broadcast ─────────────
+    //
+    // Eager snapshot from connection setup — apply immediately so the
+    // client has kernel status before the Automerge sync handshake completes.
+
+    sub.add(
+      this.broadcasts$
+        .pipe(filter(isRuntimeStateSnapshotBroadcast))
+        .subscribe((snapshot) => {
+          this._runtimeState$.next(snapshot.state);
+        }),
     );
 
     // ── Sub-pipeline: sync error recovery ──────────────────────────

--- a/packages/runtimed/src/transport.ts
+++ b/packages/runtimed/src/transport.ts
@@ -64,6 +64,18 @@ export interface NotebookTransport {
    */
   onFrame(callback: FrameListener): () => void;
 
+  /**
+   * Send a typed request to the daemon and await its response.
+   *
+   * The request is a `NotebookRequest` discriminated union. The
+   * transport is responsible for encoding, delivery, and correlation.
+   *
+   * - TauriTransport: maps to Tauri `invoke()` commands
+   * - WebSocketTransport: serializes as frame type 0x01 with correlation ID
+   * - DirectTransport: delegates to a configurable handler
+   */
+  sendRequest(request: unknown): Promise<unknown>;
+
   /** Whether the transport is currently connected. */
   readonly connected: boolean;
 


### PR DESCRIPTION
## Summary

Extracts transport-agnostic kernel logic from the React `useDaemonKernel` hook into the `runtimed` JS package, making it reusable from any JS runtime (WebSocket, Node, tests) without React or Tauri dependencies.

- **Derived state** (`derived-state.ts`): `KernelStatus` types/constants, `deriveKernelInfo()`, `deriveQueueState()`, `deriveEnvSyncState()`, and a `throttleBusyStatus()` RxJS operator for the 60ms busy-idle debounce
- **Typed broadcasts** (`broadcast-types.ts`): Typed interfaces and type guards for daemon broadcasts (`OutputBroadcast`, `CommBroadcast`, `KernelErrorBroadcast`, etc.), replacing the untyped `broadcasts$` observable
- **Comm diffing** (`comm-diff.ts`): Pure `diffComms()` function for detecting widget lifecycle changes (open/update/close), `detectOutputManifestHashes()` for Output widget hash detection, and `isManifestHash()`
- **Kernel commands** (`notebook-client.ts` + `request-types.ts`): `NotebookClient` class with typed methods for all kernel operations, backed by a new `sendRequest()` method on the `NotebookTransport` interface
- **SyncEngine** gains `kernelStatus$`, typed broadcast sub-observables, and `runtime_state_snapshot` wiring
- **`useDaemonKernel`** shrinks from ~889 to ~625 lines, now a thin React wrapper delegating to runtimed APIs
- **`TauriTransport`** implements `sendRequest()` by mapping typed requests to existing `*_via_daemon` Tauri commands

## Verification

- [ ] Open a notebook, launch a kernel, execute cells — kernel status, queue indicators, and execution counts work as before
- [ ] Test Output widget rendering: run a cell with `ipywidgets.Output()`, capture outputs, verify they render
- [ ] Test widget interactions (sliders, buttons) — comm messages route correctly
- [ ] Verify env sync state shows correctly when dependencies drift
- [ ] Kill the daemon — verify disconnection/reconnection handling still works

_PR submitted by @rgbkrk's agent, Quill_