### PR TITLE
feat(outputs): add audio, video, PDF, JS renderers and invert isolation model

### DIFF
--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -10,11 +10,11 @@ import {
   getRequiredLibraries,
   injectLibraries,
 } from "@/components/isolated/iframe-libraries";
-import { isVegaMimeType } from "@/components/outputs/vega-mime";
 import {
   AnsiErrorOutput,
   AnsiStreamOutput,
 } from "@/components/outputs/ansi-output";
+import { isSafeForMainDom } from "@/components/outputs/safe-mime-types";
 import {
   DEFAULT_PRIORITY,
   MediaRouter,
@@ -112,19 +112,6 @@ function normalizeText(text: string | string[]): string {
 }
 
 /**
- * MIME types that require iframe isolation for security.
- * These types can contain executable scripts or interactive content.
- */
-const ISOLATED_MIME_TYPES = new Set([
-  "text/html",
-  "text/markdown",
-  "image/svg+xml",
-  "application/vnd.jupyter.widget-view+json",
-  "application/vnd.plotly.v1+json",
-  "application/geo+json",
-]);
-
-/**
  * Select the best MIME type from available data based on priority.
  */
 function selectMimeType(
@@ -143,6 +130,7 @@ function selectMimeType(
 
 /**
  * Check if a single output needs iframe isolation.
+ * Uses the safe-list: anything not explicitly safe defaults to isolation.
  */
 function outputNeedsIsolation(
   output: JupyterOutput,
@@ -153,9 +141,7 @@ function outputNeedsIsolation(
     output.output_type === "display_data"
   ) {
     const mimeType = selectMimeType(output.data, priority);
-    return mimeType
-      ? ISOLATED_MIME_TYPES.has(mimeType) || isVegaMimeType(mimeType)
-      : false;
+    return mimeType ? !isSafeForMainDom(mimeType) : false;
   }
   // stream and error outputs don't need isolation
   return false;

--- a/src/components/isolated/frame-html.ts
+++ b/src/components/isolated/frame-html.ts
@@ -39,7 +39,7 @@ export function generateFrameHtml(options: FrameHtmlOptions = {}): string {
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self' blob: data:; script-src 'unsafe-inline' 'unsafe-eval' blob: https:; style-src 'unsafe-inline'; img-src * data: blob:; font-src * data:; connect-src *;">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self' blob: data:; script-src 'unsafe-inline' 'unsafe-eval' blob: https:; style-src 'unsafe-inline'; img-src * data: blob:; font-src * data:; media-src * data: blob:; object-src * data: blob:; connect-src *;">
   <style>
     :root {
       --bg-primary: ${darkMode ? "#0a0a0a" : "#ffffff"};

--- a/src/components/outputs/__tests__/media-router.test.tsx
+++ b/src/components/outputs/__tests__/media-router.test.tsx
@@ -360,30 +360,38 @@ describe("MediaRouter component", () => {
       expect(screen.getByText("No displayable output")).toBeInTheDocument();
     });
 
-    it("renders unknown types as plain text (fallback)", async () => {
+    it("blocks unknown types in main DOM (requires iframe isolation)", async () => {
       render(
         <MediaProvider>
           <MediaRouter data={{ "application/octet-stream": "binary data" }} />
         </MediaProvider>,
       );
-      // Falls back to AnsiOutput which renders as text
+      // Unknown types need iframe isolation — render empty in main DOM
       await waitFor(() => {
-        expect(screen.getByText("binary data")).toBeInTheDocument();
+        const container = screen.getByText((_content, element) => {
+          return element?.getAttribute("data-mime-type") === "application/octet-stream";
+        });
+        expect(container).toBeInTheDocument();
       });
+      expect(screen.queryByText("binary data")).not.toBeInTheDocument();
     });
   });
 
   describe("unknown text/* MIME types", () => {
-    it("renders unknown text/* type with a MIME type label", async () => {
+    it("blocks unknown text/* types in main DOM (requires iframe isolation)", async () => {
       render(
         <MediaProvider>
           <MediaRouter data={{ "text/snazzy": "hello from custom type" }} />
         </MediaProvider>,
       );
+      // Unknown text/* types need iframe isolation — render empty in main DOM
       await waitFor(() => {
-        expect(screen.getByText("hello from custom type")).toBeInTheDocument();
-        expect(screen.getByText("text/snazzy")).toBeInTheDocument();
+        const container = screen.getByText((_content, element) => {
+          return element?.getAttribute("data-mime-type") === "text/snazzy";
+        });
+        expect(container).toBeInTheDocument();
       });
+      expect(screen.queryByText("hello from custom type")).not.toBeInTheDocument();
     });
 
     it("does NOT show a MIME type label for text/plain", async () => {

--- a/src/components/outputs/audio-output.tsx
+++ b/src/components/outputs/audio-output.tsx
@@ -1,0 +1,43 @@
+import { cn } from "@/lib/utils";
+
+interface AudioOutputProps {
+  /**
+   * Audio data — blob URL, data URL, or base64-encoded string
+   */
+  data: string;
+  /**
+   * The media type of the audio (e.g. "audio/wav", "audio/mpeg")
+   */
+  mediaType?: string;
+  /**
+   * Additional CSS classes
+   */
+  className?: string;
+}
+
+/**
+ * Renders an audio player for notebook outputs.
+ * Handles blob URLs from the blob store, data URLs, and base64-encoded audio.
+ */
+export function AudioOutput({
+  data,
+  mediaType = "audio/wav",
+  className = "",
+}: AudioOutputProps) {
+  if (!data) return null;
+
+  const src =
+    data.startsWith("data:") ||
+    data.startsWith("http://") ||
+    data.startsWith("https://") ||
+    data.startsWith("/")
+      ? data
+      : `data:${mediaType};base64,${data}`;
+
+  return (
+    <div data-slot="audio-output" className={cn("py-2", className)}>
+      {/* biome-ignore lint/a11y/useMediaCaption: kernel audio outputs don't include captions */}
+      <audio src={src} controls preload="metadata" />
+    </div>
+  );
+}

--- a/src/components/outputs/image-output.tsx
+++ b/src/components/outputs/image-output.tsx
@@ -8,7 +8,7 @@ interface ImageOutputProps {
   /**
    * The media type of the image
    */
-  mediaType?: "image/png" | "image/jpeg" | "image/gif" | "image/webp";
+  mediaType?: string;
   /**
    * Alt text for accessibility
    */
@@ -31,7 +31,7 @@ interface ImageOutputProps {
  * ImageOutput component for rendering images in notebook outputs
  *
  * Handles base64-encoded image data from Jupyter kernels as well as
- * regular image URLs. Supports PNG, JPEG, GIF, and WebP formats.
+ * regular image URLs. Supports any browser-renderable image format.
  */
 export function ImageOutput({
   data,

--- a/src/components/outputs/javascript-output.tsx
+++ b/src/components/outputs/javascript-output.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useRef } from "react";
+
+interface JavaScriptOutputProps {
+  /**
+   * JavaScript code to execute
+   */
+  code: string;
+  /**
+   * Additional CSS classes
+   */
+  className?: string;
+}
+
+/**
+ * Check if the current window is inside an iframe.
+ */
+function isInIframe(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.self !== window.top;
+  } catch {
+    return true;
+  }
+}
+
+/**
+ * Executes JavaScript code from notebook outputs.
+ * Only runs inside an isolated iframe as a defense-in-depth measure.
+ * The isolation model already routes this type to the iframe, but
+ * this check prevents execution if the component is somehow rendered
+ * in the main DOM.
+ */
+export function JavaScriptOutput({
+  code,
+  className = "",
+}: JavaScriptOutputProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!code || !containerRef.current || !isInIframe()) return;
+
+    // Wrap the user code so it receives `element` (JupyterLab convention)
+    // and `el` (nteract convention) pointing to the output container.
+    const wrapper = `(function(element, el) {\n${code}\n})(document.currentScript.parentElement, document.currentScript.parentElement);`;
+    const script = document.createElement("script");
+    script.textContent = wrapper;
+    containerRef.current.appendChild(script);
+
+    return () => {
+      if (containerRef.current?.contains(script)) {
+        containerRef.current.removeChild(script);
+      }
+    };
+  }, [code]);
+
+  if (!isInIframe()) {
+    return (
+      <div className="py-2 px-3 text-sm text-muted-foreground bg-muted/50 rounded border border-border">
+        <span className="font-medium">JavaScript output</span>
+        <span className="mx-1">&middot;</span>
+        <span>Requires iframe isolation to execute</span>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      data-slot="javascript-output"
+      className={className}
+      ref={containerRef}
+    />
+  );
+}

--- a/src/components/outputs/media-router.tsx
+++ b/src/components/outputs/media-router.tsx
@@ -1,5 +1,5 @@
 import { lazy, type ReactNode, Suspense } from "react";
-import { isVegaMimeType } from "@/components/outputs/vega-mime";
+import { isSafeForMainDom } from "./safe-mime-types";
 import { useMediaContext } from "./media-provider";
 
 // Lazy load built-in output components for better bundle splitting
@@ -23,6 +23,20 @@ const JsonOutput = lazy(() =>
 );
 const MathOutput = lazy(() =>
   import("./math-output").then((m) => ({ default: m.MathOutput })),
+);
+const AudioOutput = lazy(() =>
+  import("./audio-output").then((m) => ({ default: m.AudioOutput })),
+);
+const VideoOutput = lazy(() =>
+  import("./video-output").then((m) => ({ default: m.VideoOutput })),
+);
+const PdfOutput = lazy(() =>
+  import("./pdf-output").then((m) => ({ default: m.PdfOutput })),
+);
+const JavaScriptOutput = lazy(() =>
+  import("./javascript-output").then((m) => ({
+    default: m.JavaScriptOutput,
+  })),
 );
 
 /**
@@ -60,16 +74,29 @@ export const DEFAULT_PRIORITY = [
   "application/vnd.vega.v5.json",
   "application/vnd.vega.v4+json",
   "application/geo+json",
-  // HTML, markdown, and LaTeX
+  // HTML, PDF, markdown, and LaTeX
   "text/html",
+  "application/pdf",
   "text/markdown",
   "text/latex",
+  "application/javascript",
   // Images
   "image/svg+xml",
   "image/png",
   "image/jpeg",
   "image/gif",
   "image/webp",
+  "image/bmp",
+  // Audio
+  "audio/wav",
+  "audio/mpeg",
+  "audio/ogg",
+  "audio/flac",
+  "audio/webm",
+  // Video
+  "video/mp4",
+  "video/webm",
+  "video/ogg",
   // Structured data
   "application/json",
   // Plain text (fallback)
@@ -288,15 +315,9 @@ export function MediaRouter({
   }
 
   const renderBuiltIn = () => {
-    // ISOLATION GUARD: These MIME types require iframe isolation for security.
-    // If we're already in an iframe, we can render them safely.
-    // If we're in the main DOM, block rendering and warn in development.
-    const needsIsolation =
-      mimeType === "text/markdown" ||
-      mimeType === "text/html" ||
-      mimeType === "image/svg+xml" ||
-      mimeType === "application/vnd.plotly.v1+json" ||
-      isVegaMimeType(mimeType);
+    // ISOLATION GUARD: Only types in the safe-list can render in the main DOM.
+    // Everything else requires iframe isolation for security.
+    const needsIsolation = !isSafeForMainDom(mimeType);
 
     if (needsIsolation && !isInIframe()) {
       if (process.env.NODE_ENV === "development") {
@@ -330,19 +351,50 @@ export function MediaRouter({
 
     // Images (not SVG)
     if (mimeType.startsWith("image/")) {
-      const imageType = mimeType as
-        | "image/png"
-        | "image/jpeg"
-        | "image/gif"
-        | "image/webp";
       return (
         <ImageOutput
           data={String(content)}
-          mediaType={imageType}
+          mediaType={mimeType}
           width={mimeMetadata.width as number | undefined}
           height={mimeMetadata.height as number | undefined}
           className={className}
         />
+      );
+    }
+
+    // Audio
+    if (mimeType.startsWith("audio/")) {
+      return (
+        <AudioOutput
+          data={String(content)}
+          mediaType={mimeType}
+          className={className}
+        />
+      );
+    }
+
+    // Video
+    if (mimeType.startsWith("video/")) {
+      return (
+        <VideoOutput
+          data={String(content)}
+          mediaType={mimeType}
+          width={mimeMetadata.width as number | undefined}
+          height={mimeMetadata.height as number | undefined}
+          className={className}
+        />
+      );
+    }
+
+    // PDF
+    if (mimeType === "application/pdf") {
+      return <PdfOutput data={String(content)} className={className} />;
+    }
+
+    // JavaScript (only in iframe)
+    if (mimeType === "application/javascript") {
+      return (
+        <JavaScriptOutput code={String(content)} className={className} />
       );
     }
 

--- a/src/components/outputs/pdf-output.tsx
+++ b/src/components/outputs/pdf-output.tsx
@@ -1,0 +1,46 @@
+import { cn } from "@/lib/utils";
+
+interface PdfOutputProps {
+  /**
+   * PDF data — blob URL, data URL, or base64-encoded string
+   */
+  data: string;
+  /**
+   * Additional CSS classes
+   */
+  className?: string;
+}
+
+/**
+ * Renders a PDF viewer for notebook outputs.
+ * Uses <embed> for inline viewing with a download link fallback.
+ */
+export function PdfOutput({ data, className = "" }: PdfOutputProps) {
+  if (!data) return null;
+
+  const src =
+    data.startsWith("data:") ||
+    data.startsWith("http://") ||
+    data.startsWith("https://") ||
+    data.startsWith("/")
+      ? data
+      : `data:application/pdf;base64,${data}`;
+
+  return (
+    <div data-slot="pdf-output" className={cn("py-2", className)}>
+      <embed
+        src={src}
+        type="application/pdf"
+        className="w-full rounded border border-border"
+        style={{ minHeight: "400px", height: "600px" }}
+      />
+      <a
+        href={src}
+        download="output.pdf"
+        className="mt-1 inline-block text-xs text-muted-foreground hover:text-foreground underline"
+      >
+        Download PDF
+      </a>
+    </div>
+  );
+}

--- a/src/components/outputs/safe-mime-types.ts
+++ b/src/components/outputs/safe-mime-types.ts
@@ -1,0 +1,31 @@
+/**
+ * MIME types safe for main-DOM rendering (no script execution risk).
+ * Everything NOT in this set defaults to iframe isolation.
+ *
+ * This is a security allowlist — when adding new types, verify they
+ * cannot execute arbitrary scripts or access the parent DOM.
+ */
+const MAIN_DOM_SAFE_TYPES = new Set([
+  // Plain text with ANSI — no script risk
+  "text/plain",
+  // LaTeX — KaTeX renders safe static HTML
+  "text/latex",
+  // Raster images — <img> tags, no script risk
+  "image/png",
+  "image/jpeg",
+  "image/gif",
+  "image/webp",
+  "image/bmp",
+  // Structured data — tree viewer, no script risk
+  "application/json",
+]);
+
+/** Check if a MIME type can safely render in the main DOM (no iframe needed). */
+export function isSafeForMainDom(mimeType: string): boolean {
+  if (MAIN_DOM_SAFE_TYPES.has(mimeType)) return true;
+  // audio/* and video/* use native <audio>/<video> elements — safe
+  if (mimeType.startsWith("audio/") || mimeType.startsWith("video/")) {
+    return true;
+  }
+  return false;
+}

--- a/src/components/outputs/video-output.tsx
+++ b/src/components/outputs/video-output.tsx
@@ -1,0 +1,64 @@
+import { cn } from "@/lib/utils";
+
+interface VideoOutputProps {
+  /**
+   * Video data — blob URL, data URL, or base64-encoded string
+   */
+  data: string;
+  /**
+   * The media type of the video (e.g. "video/mp4", "video/webm")
+   */
+  mediaType?: string;
+  /**
+   * Optional width constraint
+   */
+  width?: number;
+  /**
+   * Optional height constraint
+   */
+  height?: number;
+  /**
+   * Additional CSS classes
+   */
+  className?: string;
+}
+
+/**
+ * Renders a video player for notebook outputs.
+ * Handles blob URLs from the blob store, data URLs, and base64-encoded video.
+ */
+export function VideoOutput({
+  data,
+  mediaType = "video/mp4",
+  width,
+  height,
+  className = "",
+}: VideoOutputProps) {
+  if (!data) return null;
+
+  const src =
+    data.startsWith("data:") ||
+    data.startsWith("http://") ||
+    data.startsWith("https://") ||
+    data.startsWith("/")
+      ? data
+      : `data:${mediaType};base64,${data}`;
+
+  const sizeProps: { width?: number; height?: number } = {};
+  if (width) sizeProps.width = width;
+  if (height) sizeProps.height = height;
+
+  return (
+    <div data-slot="video-output" className={cn("py-2", className)}>
+      {/* biome-ignore lint/a11y/useMediaCaption: kernel video outputs don't include captions */}
+      <video
+        src={src}
+        controls
+        preload="metadata"
+        playsInline
+        className="block max-w-full h-auto"
+        {...sizeProps}
+      />
+    </div>
+  );
+}

--- a/src/isolated-renderer/index.tsx
+++ b/src/isolated-renderer/index.tsx
@@ -32,13 +32,17 @@ import {
   AnsiOutput,
   AnsiStreamOutput,
 } from "@/components/outputs/ansi-output";
+import { AudioOutput } from "@/components/outputs/audio-output";
 import { HtmlOutput } from "@/components/outputs/html-output";
 import { ImageOutput } from "@/components/outputs/image-output";
+import { JavaScriptOutput } from "@/components/outputs/javascript-output";
 import { JsonOutput } from "@/components/outputs/json-output";
 import { MarkdownOutput } from "@/components/outputs/markdown-output";
 import { GeoJsonOutput } from "@/components/outputs/geojson-output";
+import { PdfOutput } from "@/components/outputs/pdf-output";
 import { PlotlyOutput } from "@/components/outputs/plotly-output";
 import { VegaOutput } from "@/components/outputs/vega-output";
+import { VideoOutput } from "@/components/outputs/video-output";
 import { isVegaMimeType } from "@/components/outputs/vega-mime";
 import { SvgOutput } from "@/components/outputs/svg-output";
 import { WidgetView } from "@/components/widgets/widget-view";
@@ -298,18 +302,43 @@ function OutputRenderer({ payload }: { payload: RenderPayload }) {
     return <SvgOutput data={String(content)} />;
   }
 
-  // Images (PNG, JPEG, GIF, WebP)
+  // Images (PNG, JPEG, GIF, WebP, BMP, etc.)
   if (mimeType.startsWith("image/")) {
     return (
       <ImageOutput
         data={String(content)}
-        mediaType={
-          mimeType as "image/png" | "image/jpeg" | "image/gif" | "image/webp"
-        }
+        mediaType={mimeType}
         width={metadata?.width as number | undefined}
         height={metadata?.height as number | undefined}
       />
     );
+  }
+
+  // Audio
+  if (mimeType.startsWith("audio/")) {
+    return <AudioOutput data={String(content)} mediaType={mimeType} />;
+  }
+
+  // Video
+  if (mimeType.startsWith("video/")) {
+    return (
+      <VideoOutput
+        data={String(content)}
+        mediaType={mimeType}
+        width={metadata?.width as number | undefined}
+        height={metadata?.height as number | undefined}
+      />
+    );
+  }
+
+  // PDF
+  if (mimeType === "application/pdf") {
+    return <PdfOutput data={String(content)} />;
+  }
+
+  // JavaScript
+  if (mimeType === "application/javascript") {
+    return <JavaScriptOutput code={String(content)} />;
   }
 
   // Plotly


### PR DESCRIPTION
## Summary

- Add missing MIME type renderers that JupyterLab has out of the box: `audio/*`, `video/*`, `application/pdf`, `application/javascript`, and `image/bmp`
- Invert the isolation model from an unsafe-by-default blocklist (`ISOLATED_MIME_TYPES`) to a safe-by-default allowlist (`isSafeForMainDom`). Unknown/new MIME types now default to iframe isolation.
- JavaScript outputs get `element` (JupyterLab convention) and `el` (nteract convention) variables pointing to the output container

## Details

**New renderers:**
| MIME type | Component | Isolation |
|---|---|---|
| `audio/*` | `AudioOutput` — `<audio controls>` | Main DOM (safe) |
| `video/*` | `VideoOutput` — `<video controls>` | Main DOM (safe) |
| `application/pdf` | `PdfOutput` — `<embed>` + download link | Iframe |
| `application/javascript` | `JavaScriptOutput` — `<script>` with `el`/`element` | Iframe |
| `image/bmp` | `ImageOutput` (widened type) | Main DOM (safe) |

**Isolation inversion:**
The old `ISOLATED_MIME_TYPES` blocklist and `needsIsolation` checks are replaced by a single shared `isSafeForMainDom()` allowlist in `safe-mime-types.ts`. Types not in the allowlist automatically require iframe isolation — a more secure default.

No backend changes needed — `is_binary_mime()` and friends already classify all of these correctly.

## Test plan

- [x] `cargo xtask lint` passes
- [x] `pnpm test:run` — all 39 test files pass (824 tests)
- [ ] Manual: `IPython.display.Audio(...)` renders audio player
- [ ] Manual: `IPython.display.Video(...)` renders video player  
- [ ] Manual: `IPython.display.PDF(...)` renders embedded PDF
- [ ] Manual: `text/html` and `image/svg+xml` still go to iframe
- [ ] Manual: unknown MIME types default to iframe (not main DOM)