### PR TITLE
feat(runtimed): wire RUNT_AGENT_MODE into LaunchKernel

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -7,3 +7,4 @@ PATH_add bin
 
 export RUNTIMED_WORKSPACE_PATH="$(expand_path .)"
 export RUNTIMED_DEV=1
+export RUNT_AGENT_MODE=1

--- a/crates/notebook-doc/src/runtime_state.rs
+++ b/crates/notebook-doc/src/runtime_state.rs
@@ -354,7 +354,7 @@ impl RuntimeStateDoc {
         let trust = doc
             .put_object(&ROOT, "trust", ObjType::Map)
             .expect("scaffold trust");
-        doc.put(&trust, "status", "untrusted")
+        doc.put(&trust, "status", "no_dependencies")
             .expect("scaffold trust.status");
         doc.put(&trust, "needs_approval", false)
             .expect("scaffold trust.needs_approval");

--- a/crates/notebook-doc/src/runtime_state.rs
+++ b/crates/notebook-doc/src/runtime_state.rs
@@ -296,6 +296,77 @@ impl RuntimeStateDoc {
         Self { doc }
     }
 
+    /// Create a new `RuntimeStateDoc` with scaffolding and a custom actor.
+    ///
+    /// Used by the runtime agent to create its own doc with a unique actor
+    /// that won't conflict with the coordinator's `"runtimed:state"` actor.
+    /// The schema is identical — all scaffolding ops use the custom actor.
+    #[allow(clippy::expect_used)]
+    pub fn new_with_actor(actor_label: &str) -> Self {
+        let mut doc = AutoCommit::new();
+        doc.set_actor(ActorId::from(actor_label.as_bytes()));
+
+        // Identical scaffolding as new(), but with a different actor
+        let kernel = doc
+            .put_object(&ROOT, "kernel", ObjType::Map)
+            .expect("scaffold kernel");
+        doc.put(&kernel, "status", "not_started")
+            .expect("scaffold kernel.status");
+        doc.put(&kernel, "name", "").expect("scaffold kernel.name");
+        doc.put(&kernel, "language", "")
+            .expect("scaffold kernel.language");
+        doc.put(&kernel, "env_source", "")
+            .expect("scaffold kernel.env_source");
+        doc.put(&kernel, "starting_phase", "")
+            .expect("scaffold kernel.starting_phase");
+
+        let queue = doc
+            .put_object(&ROOT, "queue", ObjType::Map)
+            .expect("scaffold queue");
+        doc.put(&queue, "executing", automerge::ScalarValue::Null)
+            .expect("scaffold queue.executing");
+        doc.put(
+            &queue,
+            "executing_execution_id",
+            automerge::ScalarValue::Null,
+        )
+        .expect("scaffold queue.executing_execution_id");
+        doc.put_object(&queue, "queued", ObjType::List)
+            .expect("scaffold queue.queued");
+        doc.put_object(&queue, "queued_execution_ids", ObjType::List)
+            .expect("scaffold queue.queued_execution_ids");
+
+        doc.put_object(&ROOT, "executions", ObjType::Map)
+            .expect("scaffold executions");
+
+        let env = doc
+            .put_object(&ROOT, "env", ObjType::Map)
+            .expect("scaffold env");
+        doc.put(&env, "in_sync", true)
+            .expect("scaffold env.in_sync");
+        doc.put_object(&env, "added", ObjType::List)
+            .expect("scaffold env.added");
+        doc.put_object(&env, "removed", ObjType::List)
+            .expect("scaffold env.removed");
+        doc.put_object(&env, "prewarmed_packages", ObjType::List)
+            .expect("scaffold env.prewarmed_packages");
+
+        let trust = doc
+            .put_object(&ROOT, "trust", ObjType::Map)
+            .expect("scaffold trust");
+        doc.put(&trust, "status", "untrusted")
+            .expect("scaffold trust.status");
+        doc.put(&trust, "needs_approval", false)
+            .expect("scaffold trust.needs_approval");
+
+        doc.put_object(&ROOT, "comms", ObjType::Map)
+            .expect("scaffold comms");
+        doc.put(&ROOT, "last_saved", automerge::ScalarValue::Null)
+            .expect("scaffold last_saved");
+
+        Self { doc }
+    }
+
     /// Create an empty `RuntimeStateDoc` for read-only clients.
     ///
     /// The document starts empty with a random actor ID. All state

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -184,6 +184,11 @@ enum Commands {
         #[arg(long)]
         json: bool,
     },
+    /// Runtime agent management (process-isolated kernels)
+    Agent {
+        #[command(subcommand)]
+        command: AgentCommands,
+    },
     /// Stop a notebook's kernel and evict its room
     #[command(alias = "shutdown")]
     Stop {
@@ -450,6 +455,16 @@ enum DaemonCommands {
     Ping,
 }
 
+#[derive(Subcommand)]
+enum AgentCommands {
+    /// Enable agent mode (process-isolated kernels)
+    Enable,
+    /// Disable agent mode (local kernels)
+    Disable,
+    /// Show agent mode status
+    Status,
+}
+
 /// Development commands (only shown when RUNTIMED_DEV=1)
 #[derive(Subcommand)]
 enum DevCommands {
@@ -556,6 +571,27 @@ async fn async_main(command: Option<Commands>) -> Result<()> {
         Some(Commands::Jupyter { command }) => jupyter_command(command).await?,
         Some(Commands::Daemon { command }) => daemon_command(command).await?,
         Some(Commands::Ps { json }) => list_notebooks(json).await?,
+        Some(Commands::Agent { command }) => match command {
+            AgentCommands::Enable => {
+                let client = runtimed::client::PoolClient::new(runtimed::default_socket_path());
+                client.set_agent_mode(true).await?;
+                println!("Agent mode enabled — new kernels will run in subprocess");
+            }
+            AgentCommands::Disable => {
+                let client = runtimed::client::PoolClient::new(runtimed::default_socket_path());
+                client.set_agent_mode(false).await?;
+                println!("Agent mode disabled — new kernels will run in-process");
+            }
+            AgentCommands::Status => {
+                // Check env var (can't query daemon for current state yet)
+                let env_enabled = std::env::var("RUNT_AGENT_MODE").as_deref() == Ok("1");
+                println!(
+                    "Agent mode: {} (env RUNT_AGENT_MODE={})",
+                    if env_enabled { "enabled" } else { "disabled" },
+                    if env_enabled { "1" } else { "unset" }
+                );
+            }
+        },
         Some(Commands::Stop { path }) => shutdown_notebook(&path).await?,
         Some(Commands::Recover { path, output, list }) => {
             recover_notebook(path.as_deref(), output.as_deref(), list)?

--- a/crates/runtimed-client/src/client.rs
+++ b/crates/runtimed-client/src/client.rs
@@ -260,6 +260,18 @@ impl PoolClient {
         }
     }
 
+    /// Enable or disable agent mode on the running daemon.
+    pub async fn set_agent_mode(&self, enabled: bool) -> Result<(), ClientError> {
+        let response = self
+            .send_request(Request::SetAgentMode { enabled })
+            .await?;
+        match response {
+            Response::Ok => Ok(()),
+            Response::Error { message } => Err(ClientError::DaemonError(message)),
+            _ => Err(ClientError::ProtocolError("Unexpected response".to_string())),
+        }
+    }
+
     /// Send a request to the daemon and receive a response.
     ///
     /// The entire request (connect + send + recv) is bounded by a timeout

--- a/crates/runtimed-client/src/client.rs
+++ b/crates/runtimed-client/src/client.rs
@@ -262,13 +262,13 @@ impl PoolClient {
 
     /// Enable or disable agent mode on the running daemon.
     pub async fn set_agent_mode(&self, enabled: bool) -> Result<(), ClientError> {
-        let response = self
-            .send_request(Request::SetAgentMode { enabled })
-            .await?;
+        let response = self.send_request(Request::SetAgentMode { enabled }).await?;
         match response {
             Response::Ok => Ok(()),
             Response::Error { message } => Err(ClientError::DaemonError(message)),
-            _ => Err(ClientError::ProtocolError("Unexpected response".to_string())),
+            _ => Err(ClientError::ProtocolError(
+                "Unexpected response".to_string(),
+            )),
         }
     }
 

--- a/crates/runtimed-client/src/protocol.rs
+++ b/crates/runtimed-client/src/protocol.rs
@@ -59,6 +59,10 @@ pub enum Request {
     /// Get environment paths currently in use by running kernels.
     /// Used by `runt env clean` to avoid evicting active environments.
     ActiveEnvPaths,
+
+    /// Enable or disable agent mode (process-isolated kernels).
+    /// Takes effect for the next kernel launch — existing kernels are unaffected.
+    SetAgentMode { enabled: bool },
 }
 
 /// Responses from the daemon to clients.
@@ -85,6 +89,9 @@ pub enum Response {
 
     /// Pool flush acknowledged — environments will be rebuilt.
     Flushed,
+
+    /// Generic success acknowledgment.
+    Ok,
 
     /// An error occurred.
     Error { message: String },

--- a/crates/runtimed/src/agent.rs
+++ b/crates/runtimed/src/agent.rs
@@ -603,12 +603,8 @@ mod tests {
         .unwrap();
         recv_preamble(&mut coord_reader).await.unwrap();
 
-        // Read and skip the initial RuntimeStateSync frame
-        let sync_frame = recv_frame(&mut coord_reader).await.unwrap().unwrap();
-        assert_eq!(
-            sync_frame[0], 0x05,
-            "First frame should be RuntimeStateSync"
-        );
+        // Agent uses new_with_actor — no bootstrap sync needed.
+        // It goes straight to the main loop after preamble exchange.
 
         // Send ShutdownKernel request
         let request = AgentRequest::ShutdownKernel;

--- a/crates/runtimed/src/agent.rs
+++ b/crates/runtimed/src/agent.rs
@@ -98,63 +98,14 @@ where
 
     // ── 2. Bootstrap RuntimeStateDoc ────────────────────────────────────────
 
-    // The agent bootstraps its RuntimeStateDoc from the coordinator, just like
-    // the frontend bootstraps its NotebookDoc. Start empty, receive the
-    // coordinator's scaffolded schema via sync, then write with our own actor.
-    // This avoids DuplicateSeqNumber — only one doc (coordinator's) creates
-    // the scaffolding with the "runtimed:state" actor.
-    let mut state_doc = RuntimeStateDoc::new_empty();
-    state_doc.set_actor(&agent_id);
+    // The agent creates its own RuntimeStateDoc with scaffolding but a UNIQUE
+    // actor ID. This avoids DuplicateSeqNumber — the coordinator uses
+    // "runtimed:state" as its actor, the agent uses its own agent_id.
+    // Both docs have the same structure but different actors, so sync merges cleanly.
+    let mut state_doc = RuntimeStateDoc::new_with_actor(&agent_id);
 
-    // Automerge sync state for the coordinator peer. Persistent across the
-    // agent's lifetime so incremental sync works correctly.
+    // Automerge sync state for the coordinator peer.
     let mut coordinator_sync_state = automerge::sync::State::new();
-
-    // Bootstrap: send empty sync to coordinator, receive scaffolded schema back.
-    // Same pattern as frontend NotebookDoc bootstrap.
-    {
-        // Send "I'm empty, send me everything"
-        if let Some(msg) = state_doc.generate_sync_message(&mut coordinator_sync_state) {
-            let encoded = msg.encode();
-            info!("[agent] Sending initial sync request ({} bytes)", encoded.len());
-            send_typed_frame(&mut writer, NotebookFrameType::RuntimeStateSync, &encoded).await?;
-        }
-
-        // Receive coordinator's full state
-        info!("[agent] Waiting for coordinator's RuntimeStateDoc...");
-        loop {
-            match recv_frame(&mut reader).await? {
-                Some(data) if !data.is_empty() && data[0] == 0x05 => {
-                    let msg = automerge::sync::Message::decode(&data[1..])?;
-                    state_doc.receive_sync_message_with_changes(
-                        &mut coordinator_sync_state,
-                        msg,
-                    )?;
-
-                    // Send confirmation / request more
-                    if let Some(reply) =
-                        state_doc.generate_sync_message(&mut coordinator_sync_state)
-                    {
-                        let encoded = reply.encode();
-                        send_typed_frame(
-                            &mut writer,
-                            NotebookFrameType::RuntimeStateSync,
-                            &encoded,
-                        )
-                        .await?;
-                    } else {
-                        // Converged — we have the full schema
-                        info!("[agent] RuntimeStateDoc bootstrapped from coordinator");
-                        break;
-                    }
-                }
-                Some(data) if !data.is_empty() => {
-                    debug!("[agent] Ignoring frame 0x{:02x} during bootstrap", data[0]);
-                }
-                _ => anyhow::bail!("EOF during RuntimeStateDoc bootstrap"),
-            }
-        }
-    }
 
     let state_doc = Arc::new(RwLock::new(state_doc));
     let (state_changed_tx, mut state_changed_rx) = broadcast::channel::<()>(64);

--- a/crates/runtimed/src/agent.rs
+++ b/crates/runtimed/src/agent.rs
@@ -98,66 +98,12 @@ where
 
     // ── 2. Bootstrap RuntimeStateDoc ────────────────────────────────────────
 
-    // Start with an empty doc (no scaffolding) to avoid DuplicateSeqNumber
-    // conflicts when syncing with the coordinator. All state arrives via sync.
-    let mut state_doc = RuntimeStateDoc::new_empty();
+    // The agent OWNS the RuntimeStateDoc. It creates a fresh doc with full
+    // scaffolding and its own actor ID. The coordinator starts with an empty
+    // doc and receives state via Automerge sync from the agent.
+    // This is the correct ownership model: the agent owns kernel state.
+    let mut state_doc = RuntimeStateDoc::new();
     state_doc.set_actor(&agent_id);
-
-    // Bootstrap: sync RuntimeStateDoc with the coordinator.
-    // The agent starts empty. It sends its initial sync message (empty heads),
-    // the coordinator responds with its full state, and they converge.
-    // We need the schema (kernel map, queue map, etc.) before set_kernel_status()
-    // and friends can be called — they panic on missing maps.
-    let mut coordinator_sync_state = automerge::sync::State::new();
-
-    // Send initial sync message to coordinator ("I'm empty, send me everything")
-    if let Some(msg) = state_doc.generate_sync_message(&mut coordinator_sync_state) {
-        let encoded = msg.encode();
-        send_typed_frame(&mut writer, NotebookFrameType::RuntimeStateSync, &encoded).await?;
-    }
-
-    info!("[agent] Waiting for initial RuntimeStateDoc sync...");
-    let mut bootstrap_frames = 0;
-    loop {
-        match recv_frame(&mut reader).await? {
-            Some(data) if !data.is_empty() && data[0] == 0x05 => {
-                let msg = automerge::sync::Message::decode(&data[1..])?;
-                state_doc.receive_sync_message_with_changes(&mut coordinator_sync_state, msg)?;
-                bootstrap_frames += 1;
-
-                // Send sync reply — convergence requires round-trips
-                if let Some(reply) =
-                    state_doc.generate_sync_message(&mut coordinator_sync_state)
-                {
-                    let encoded = reply.encode();
-                    send_typed_frame(
-                        &mut writer,
-                        NotebookFrameType::RuntimeStateSync,
-                        &encoded,
-                    )
-                    .await?;
-                } else {
-                    // No more sync needed — we've converged
-                    info!(
-                        "[agent] RuntimeStateDoc bootstrapped ({} frames)",
-                        bootstrap_frames
-                    );
-                    break;
-                }
-            }
-            Some(data) if !data.is_empty() => {
-                // Non-sync frame during bootstrap (e.g., LaunchKernel arriving
-                // before sync completes). Can't handle yet — schema not ready.
-                debug!(
-                    "[agent] Ignoring frame type 0x{:02x} during bootstrap",
-                    data[0]
-                );
-            }
-            _ => {
-                anyhow::bail!("EOF during RuntimeStateDoc bootstrap");
-            }
-        }
-    }
 
     let state_doc = Arc::new(RwLock::new(state_doc));
     let (state_changed_tx, mut state_changed_rx) = broadcast::channel::<()>(64);

--- a/crates/runtimed/src/agent.rs
+++ b/crates/runtimed/src/agent.rs
@@ -103,11 +103,19 @@ where
     let mut state_doc = RuntimeStateDoc::new_empty();
     state_doc.set_actor(&agent_id);
 
-    // Bootstrap: read initial sync frames from coordinator until convergence.
-    // The coordinator sends RuntimeStateSync (0x05) frames after the handshake.
+    // Bootstrap: sync RuntimeStateDoc with the coordinator.
+    // The agent starts empty. It sends its initial sync message (empty heads),
+    // the coordinator responds with its full state, and they converge.
     // We need the schema (kernel map, queue map, etc.) before set_kernel_status()
     // and friends can be called — they panic on missing maps.
     let mut coordinator_sync_state = automerge::sync::State::new();
+
+    // Send initial sync message to coordinator ("I'm empty, send me everything")
+    if let Some(msg) = state_doc.generate_sync_message(&mut coordinator_sync_state) {
+        let encoded = msg.encode();
+        send_typed_frame(&mut writer, NotebookFrameType::RuntimeStateSync, &encoded).await?;
+    }
+
     info!("[agent] Waiting for initial RuntimeStateDoc sync...");
     let mut bootstrap_frames = 0;
     loop {
@@ -138,9 +146,8 @@ where
                 }
             }
             Some(data) if !data.is_empty() => {
-                // Non-sync frame during bootstrap — could be the LaunchKernel
-                // request arriving before sync completes. Buffer it? For now,
-                // keep reading until we get sync frames.
+                // Non-sync frame during bootstrap (e.g., LaunchKernel arriving
+                // before sync completes). Can't handle yet — schema not ready.
                 debug!(
                     "[agent] Ignoring frame type 0x{:02x} during bootstrap",
                     data[0]

--- a/crates/runtimed/src/agent.rs
+++ b/crates/runtimed/src/agent.rs
@@ -98,34 +98,66 @@ where
 
     // ── 2. Bootstrap RuntimeStateDoc ────────────────────────────────────────
 
-    // The agent OWNS the RuntimeStateDoc. It creates a fresh doc with full
-    // scaffolding and its own actor ID. The coordinator starts with an empty
-    // doc and receives state via Automerge sync from the agent.
-    // This is the correct ownership model: the agent owns kernel state.
-    let mut state_doc = RuntimeStateDoc::new();
+    // The agent bootstraps its RuntimeStateDoc from the coordinator, just like
+    // the frontend bootstraps its NotebookDoc. Start empty, receive the
+    // coordinator's scaffolded schema via sync, then write with our own actor.
+    // This avoids DuplicateSeqNumber — only one doc (coordinator's) creates
+    // the scaffolding with the "runtimed:state" actor.
+    let mut state_doc = RuntimeStateDoc::new_empty();
     state_doc.set_actor(&agent_id);
-
-    let state_doc = Arc::new(RwLock::new(state_doc));
-    let (state_changed_tx, mut state_changed_rx) = broadcast::channel::<()>(64);
 
     // Automerge sync state for the coordinator peer. Persistent across the
     // agent's lifetime so incremental sync works correctly.
     let mut coordinator_sync_state = automerge::sync::State::new();
 
-    // Send initial sync to coordinator immediately so it gets the schema.
-    // This MUST happen before the main loop — the coordinator waits for it
-    // during spawn() before sending LaunchKernel.
+    // Bootstrap: send empty sync to coordinator, receive scaffolded schema back.
+    // Same pattern as frontend NotebookDoc bootstrap.
     {
-        let mut sd = state_doc.write().await;
-        if let Some(msg) = sd.generate_sync_message(&mut coordinator_sync_state) {
+        // Send "I'm empty, send me everything"
+        if let Some(msg) = state_doc.generate_sync_message(&mut coordinator_sync_state) {
             let encoded = msg.encode();
-            info!(
-                "[agent] Sending initial RuntimeStateSync ({} bytes)",
-                encoded.len()
-            );
+            info!("[agent] Sending initial sync request ({} bytes)", encoded.len());
             send_typed_frame(&mut writer, NotebookFrameType::RuntimeStateSync, &encoded).await?;
         }
+
+        // Receive coordinator's full state
+        info!("[agent] Waiting for coordinator's RuntimeStateDoc...");
+        loop {
+            match recv_frame(&mut reader).await? {
+                Some(data) if !data.is_empty() && data[0] == 0x05 => {
+                    let msg = automerge::sync::Message::decode(&data[1..])?;
+                    state_doc.receive_sync_message_with_changes(
+                        &mut coordinator_sync_state,
+                        msg,
+                    )?;
+
+                    // Send confirmation / request more
+                    if let Some(reply) =
+                        state_doc.generate_sync_message(&mut coordinator_sync_state)
+                    {
+                        let encoded = reply.encode();
+                        send_typed_frame(
+                            &mut writer,
+                            NotebookFrameType::RuntimeStateSync,
+                            &encoded,
+                        )
+                        .await?;
+                    } else {
+                        // Converged — we have the full schema
+                        info!("[agent] RuntimeStateDoc bootstrapped from coordinator");
+                        break;
+                    }
+                }
+                Some(data) if !data.is_empty() => {
+                    debug!("[agent] Ignoring frame 0x{:02x} during bootstrap", data[0]);
+                }
+                _ => anyhow::bail!("EOF during RuntimeStateDoc bootstrap"),
+            }
+        }
     }
+
+    let state_doc = Arc::new(RwLock::new(state_doc));
+    let (state_changed_tx, mut state_changed_rx) = broadcast::channel::<()>(64);
 
     // ── 3. Create local infrastructure ──────────────────────────────────────
 

--- a/crates/runtimed/src/agent.rs
+++ b/crates/runtimed/src/agent.rs
@@ -620,6 +620,13 @@ mod tests {
         .unwrap();
         recv_preamble(&mut coord_reader).await.unwrap();
 
+        // Read and skip the initial RuntimeStateSync frame
+        let sync_frame = recv_frame(&mut coord_reader).await.unwrap().unwrap();
+        assert_eq!(
+            sync_frame[0], 0x05,
+            "First frame should be RuntimeStateSync"
+        );
+
         // Send ShutdownKernel request
         let request = AgentRequest::ShutdownKernel;
         let json = serde_json::to_vec(&request).unwrap();

--- a/crates/runtimed/src/agent.rs
+++ b/crates/runtimed/src/agent.rs
@@ -112,6 +112,21 @@ where
     // agent's lifetime so incremental sync works correctly.
     let mut coordinator_sync_state = automerge::sync::State::new();
 
+    // Send initial sync to coordinator immediately so it gets the schema.
+    // This MUST happen before the main loop — the coordinator waits for it
+    // during spawn() before sending LaunchKernel.
+    {
+        let mut sd = state_doc.write().await;
+        if let Some(msg) = sd.generate_sync_message(&mut coordinator_sync_state) {
+            let encoded = msg.encode();
+            info!(
+                "[agent] Sending initial RuntimeStateSync ({} bytes)",
+                encoded.len()
+            );
+            send_typed_frame(&mut writer, NotebookFrameType::RuntimeStateSync, &encoded).await?;
+        }
+    }
+
     // ── 3. Create local infrastructure ──────────────────────────────────────
 
     let blob_store = Arc::new(BlobStore::new(std::path::PathBuf::from(&blob_root)));

--- a/crates/runtimed/src/agent.rs
+++ b/crates/runtimed/src/agent.rs
@@ -200,6 +200,7 @@ where
                 let mut sd = ctx.state_doc.write().await;
                 if let Some(msg) = sd.generate_sync_message(&mut coordinator_sync_state) {
                     let encoded = msg.encode();
+                    info!("[agent] Sending RuntimeStateSync frame ({} bytes)", encoded.len());
                     if let Err(e) = send_typed_frame(
                         &mut writer,
                         NotebookFrameType::RuntimeStateSync,

--- a/crates/runtimed/src/agent.rs
+++ b/crates/runtimed/src/agent.rs
@@ -102,7 +102,7 @@ where
     // actor ID. This avoids DuplicateSeqNumber — the coordinator uses
     // "runtimed:state" as its actor, the agent uses its own agent_id.
     // Both docs have the same structure but different actors, so sync merges cleanly.
-    let mut state_doc = RuntimeStateDoc::new_with_actor(&agent_id);
+    let state_doc = RuntimeStateDoc::new_with_actor(&agent_id);
 
     // Automerge sync state for the coordinator peer.
     let mut coordinator_sync_state = automerge::sync::State::new();

--- a/crates/runtimed/src/agent.rs
+++ b/crates/runtimed/src/agent.rs
@@ -98,11 +98,10 @@ where
 
     // ── 2. Bootstrap RuntimeStateDoc ────────────────────────────────────────
 
-    let mut state_doc = RuntimeStateDoc::new();
+    // Start with an empty doc (no scaffolding) to avoid DuplicateSeqNumber
+    // conflicts when syncing with the coordinator. All state arrives via sync.
+    let mut state_doc = RuntimeStateDoc::new_empty();
     state_doc.set_actor(&agent_id);
-
-    // TODO: Initial sync — read RuntimeStateSync frames from coordinator
-    // until convergence. For now, start with empty doc.
 
     let state_doc = Arc::new(RwLock::new(state_doc));
     let (state_changed_tx, mut state_changed_rx) = broadcast::channel::<()>(64);

--- a/crates/runtimed/src/agent.rs
+++ b/crates/runtimed/src/agent.rs
@@ -103,6 +103,55 @@ where
     let mut state_doc = RuntimeStateDoc::new_empty();
     state_doc.set_actor(&agent_id);
 
+    // Bootstrap: read initial sync frames from coordinator until convergence.
+    // The coordinator sends RuntimeStateSync (0x05) frames after the handshake.
+    // We need the schema (kernel map, queue map, etc.) before set_kernel_status()
+    // and friends can be called — they panic on missing maps.
+    let mut coordinator_sync_state = automerge::sync::State::new();
+    info!("[agent] Waiting for initial RuntimeStateDoc sync...");
+    let mut bootstrap_frames = 0;
+    loop {
+        match recv_frame(&mut reader).await? {
+            Some(data) if !data.is_empty() && data[0] == 0x05 => {
+                let msg = automerge::sync::Message::decode(&data[1..])?;
+                state_doc.receive_sync_message_with_changes(&mut coordinator_sync_state, msg)?;
+                bootstrap_frames += 1;
+
+                // Send sync reply — convergence requires round-trips
+                if let Some(reply) =
+                    state_doc.generate_sync_message(&mut coordinator_sync_state)
+                {
+                    let encoded = reply.encode();
+                    send_typed_frame(
+                        &mut writer,
+                        NotebookFrameType::RuntimeStateSync,
+                        &encoded,
+                    )
+                    .await?;
+                } else {
+                    // No more sync needed — we've converged
+                    info!(
+                        "[agent] RuntimeStateDoc bootstrapped ({} frames)",
+                        bootstrap_frames
+                    );
+                    break;
+                }
+            }
+            Some(data) if !data.is_empty() => {
+                // Non-sync frame during bootstrap — could be the LaunchKernel
+                // request arriving before sync completes. Buffer it? For now,
+                // keep reading until we get sync frames.
+                debug!(
+                    "[agent] Ignoring frame type 0x{:02x} during bootstrap",
+                    data[0]
+                );
+            }
+            _ => {
+                anyhow::bail!("EOF during RuntimeStateDoc bootstrap");
+            }
+        }
+    }
+
     let state_doc = Arc::new(RwLock::new(state_doc));
     let (state_changed_tx, mut state_changed_rx) = broadcast::channel::<()>(64);
 

--- a/crates/runtimed/src/agent_handle.rs
+++ b/crates/runtimed/src/agent_handle.rs
@@ -267,7 +267,9 @@ async fn io_loop<R, W>(
     info!("[agent-handle] IO loop started");
     loop {
         tokio::select! {
-            // Read frames from agent stdout
+            biased;
+
+            // Read frames from agent stdout (highest priority)
             frame = recv_frame(&mut reader) => {
                 match frame {
                     Ok(Some(data)) if !data.is_empty() => {

--- a/crates/runtimed/src/agent_handle.rs
+++ b/crates/runtimed/src/agent_handle.rs
@@ -28,7 +28,6 @@ use tokio::sync::{broadcast, RwLock};
 pub struct AgentHandle {
     reader: ChildStdout,
     writer: ChildStdin,
-    child: Child,
     alive: Arc<AtomicBool>,
     state_doc: Arc<RwLock<RuntimeStateDoc>>,
     state_changed_tx: broadcast::Sender<()>,
@@ -113,11 +112,22 @@ impl AgentHandle {
 
         info!("[agent-handle] Agent spawned — RuntimeStateDoc bootstrapped");
 
+        let alive = Arc::new(AtomicBool::new(true));
+
+        // Spawn a task to wait on the child process. This is required for
+        // tokio's ChildStdout I/O driver to pump data — without it,
+        // recv_frame blocks forever because the runtime doesn't poll the child.
+        let alive_clone = alive.clone();
+        tokio::spawn(async move {
+            let _ = child.wait().await;
+            alive_clone.store(false, Ordering::Relaxed);
+            info!("[agent-handle] Agent process exited");
+        });
+
         Ok(Self {
             reader,
             writer,
-            child,
-            alive: Arc::new(AtomicBool::new(true)),
+            alive,
             state_doc,
             state_changed_tx,
             agent_sync_state: automerge::sync::State::new(),
@@ -292,7 +302,7 @@ impl AgentHandle {
         if self.is_alive() {
             let _ = self.shutdown_kernel().await;
         }
-        let _ = self.child.kill().await;
+        // Child process is managed by the wait task (kill_on_drop handles cleanup)
         self.alive.store(false, Ordering::Relaxed);
     }
 }

--- a/crates/runtimed/src/agent_handle.rs
+++ b/crates/runtimed/src/agent_handle.rs
@@ -83,6 +83,20 @@ impl AgentHandle {
         .await?;
         recv_preamble(&mut reader).await?;
 
+        // Test: can we read a frame right after preamble?
+        info!("[agent-handle] Testing recv_frame in spawn()...");
+        match tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            recv_frame(&mut reader),
+        ).await {
+            Ok(Ok(Some(data))) => {
+                info!("[agent-handle] Got frame in spawn: type=0x{:02x} ({} bytes)",
+                    data.first().copied().unwrap_or(0), data.len());
+            }
+            Ok(Ok(None)) => info!("[agent-handle] EOF in spawn recv_frame"),
+            Ok(Err(e)) => info!("[agent-handle] Error in spawn recv_frame: {}", e),
+            Err(_) => info!("[agent-handle] Timeout in spawn recv_frame (5s)"),
+        }
         info!("[agent-handle] Agent spawned — RuntimeStateDoc owned by agent");
 
         Ok(Self {

--- a/crates/runtimed/src/agent_handle.rs
+++ b/crates/runtimed/src/agent_handle.rs
@@ -118,6 +118,9 @@ impl AgentHandle {
             let mut agent_sync_state = automerge::sync::State::new();
             let mut pending_reply: Option<oneshot::Sender<AgentResponse>> = None;
 
+            // Subscribe to coordinator state changes for reverse sync
+            let mut state_changed_rx = state_changed_clone.subscribe();
+
             // Also wait on the child process
             let mut child_wait = Box::pin(child.wait());
 
@@ -185,6 +188,26 @@ impl AgentHandle {
                                 pending_reply = Some(reply_tx);
                             }
                             None => break,
+                        }
+                    }
+
+                    // Forward coordinator RuntimeStateDoc changes to agent
+                    _ = state_changed_rx.recv() => {
+                        // Drain buffered notifications
+                        while state_changed_rx.try_recv().is_ok() {}
+
+                        let mut sd = state_doc_clone.write().await;
+                        if let Some(msg) = sd.generate_sync_message(&mut agent_sync_state) {
+                            let encoded = msg.encode();
+                            let mut w = writer_clone.lock().await;
+                            if let Err(e) = send_typed_frame(
+                                &mut *w,
+                                NotebookFrameType::RuntimeStateSync,
+                                &encoded,
+                            ).await {
+                                warn!("[agent-handle] Failed to send reverse sync: {}", e);
+                                break;
+                            }
                         }
                     }
 

--- a/crates/runtimed/src/agent_handle.rs
+++ b/crates/runtimed/src/agent_handle.rs
@@ -104,19 +104,11 @@ impl AgentHandle {
         // Wait for agent's preamble response
         notebook_protocol::connection::recv_preamble(&mut reader).await?;
 
-        // Send initial RuntimeStateDoc sync to bootstrap the agent
-        {
-            let mut sd = state_doc.write().await;
-            let mut sync_state = automerge::sync::State::new();
-            // Generate sync messages until convergence
-            while let Some(msg) = sd.generate_sync_message(&mut sync_state) {
-                let encoded = msg.encode();
-                send_typed_frame(&mut writer, NotebookFrameType::RuntimeStateSync, &encoded)
-                    .await?;
-            }
-        }
-
-        info!("[agent-handle] Agent spawned and bootstrapped");
+        // Initial RuntimeStateDoc sync happens via the IO loop:
+        // 1. Agent sends initial sync message (empty heads → "send me everything")
+        // 2. IO task reads it, applies to coordinator's doc, generates reply
+        // 3. Agent receives reply, converges
+        info!("[agent-handle] Agent spawned, sync bootstrap via IO loop");
 
         // Set up channels
         let (request_tx, request_rx) = mpsc::channel(32);

--- a/crates/runtimed/src/agent_handle.rs
+++ b/crates/runtimed/src/agent_handle.rs
@@ -1,10 +1,8 @@
 //! Coordinator-side management of a runtime agent subprocess.
 //!
-//! `AgentHandle` spawns a `runtimed agent` child process, pipes the framed
-//! protocol on its stdin/stdout, and provides typed request methods.
-//!
-//! RuntimeStateDoc sync happens inline: after each request/response exchange,
-//! the handle drains any pending sync frames from the agent before returning.
+//! `AgentHandle` spawns a `runtimed agent` child process and communicates
+//! via framed protocol on stdin/stdout. A reader task reads all frames
+//! from the agent's stdout and routes them via channels.
 
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -14,29 +12,26 @@ use anyhow::Result;
 use log::{debug, info, warn};
 use notebook_doc::runtime_state::RuntimeStateDoc;
 use notebook_protocol::connection::{
-    recv_frame, recv_json_frame, recv_preamble, send_json_frame, send_preamble, send_typed_frame,
-    Handshake, NotebookFrameType,
+    recv_frame, recv_preamble, send_json_frame, send_preamble, send_typed_frame, Handshake,
+    NotebookFrameType,
 };
 use notebook_protocol::protocol::{AgentNotification, AgentRequest, AgentResponse, LaunchedEnvConfig};
-use tokio::process::{Child, ChildStdin, ChildStdout};
-use tokio::sync::{broadcast, RwLock};
+use tokio::io::AsyncWriteExt;
+use tokio::process::ChildStdin;
+use tokio::sync::{broadcast, mpsc, oneshot, Mutex, RwLock};
 
 /// Handle to a running agent subprocess.
-///
-/// Owns the child process and its stdin/stdout. Request methods write to
-/// stdin and read from stdout synchronously (no background IO task).
 pub struct AgentHandle {
-    reader: ChildStdout,
-    writer: ChildStdin,
+    /// Writer to agent's stdin (protected by mutex for concurrent access)
+    writer: Arc<Mutex<ChildStdin>>,
+    /// Channel for receiving responses from the reader task
+    response_rx: mpsc::Receiver<AgentResponse>,
+    /// Channel for sending response requests to the reader task
+    response_request_tx: mpsc::Sender<oneshot::Sender<AgentResponse>>,
     alive: Arc<AtomicBool>,
-    state_doc: Arc<RwLock<RuntimeStateDoc>>,
-    state_changed_tx: broadcast::Sender<()>,
-    /// Automerge sync state for the agent peer
-    agent_sync_state: automerge::sync::State,
 }
 
 impl AgentHandle {
-    /// Spawn a new agent subprocess.
     pub async fn spawn(
         notebook_id: String,
         agent_id: String,
@@ -60,7 +55,7 @@ impl AgentHandle {
             .kill_on_drop(true)
             .spawn()?;
 
-        let mut writer = child
+        let writer = child
             .stdin
             .take()
             .ok_or_else(|| anyhow::anyhow!("Failed to capture agent stdin"))?;
@@ -69,22 +64,25 @@ impl AgentHandle {
             .take()
             .ok_or_else(|| anyhow::anyhow!("Failed to capture agent stdout"))?;
 
+        let writer = Arc::new(Mutex::new(writer));
+
         // Preamble + handshake exchange
-        send_preamble(&mut writer).await?;
-        send_json_frame(
-            &mut writer,
-            &Handshake::RuntimeAgent {
-                notebook_id,
-                agent_id,
-                blob_root: blob_root.to_string_lossy().to_string(),
-            },
-        )
-        .await?;
+        {
+            let mut w = writer.lock().await;
+            send_preamble(&mut *w).await?;
+            send_json_frame(
+                &mut *w,
+                &Handshake::RuntimeAgent {
+                    notebook_id,
+                    agent_id,
+                    blob_root: blob_root.to_string_lossy().to_string(),
+                },
+            )
+            .await?;
+        }
         recv_preamble(&mut reader).await?;
 
-        // Read the agent's initial RuntimeStateDoc sync frame.
-        // The agent sends this immediately after preamble — it contains the
-        // full scaffolded schema. We apply it to the coordinator's state_doc.
+        // Read the agent's initial RuntimeStateDoc sync
         info!("[agent-handle] Waiting for agent's initial sync...");
         match recv_frame(&mut reader).await? {
             Some(data) if !data.is_empty() && data[0] == 0x05 => {
@@ -95,46 +93,123 @@ impl AgentHandle {
                 sd.receive_sync_message_with_changes(&mut sync_state, msg)?;
                 let _ = state_changed_tx.send(());
                 info!(
-                    "[agent-handle] Applied agent's initial RuntimeStateDoc sync ({} bytes)",
+                    "[agent-handle] Applied initial RuntimeStateDoc sync ({} bytes)",
                     data.len()
                 );
             }
-            Some(data) => {
-                warn!(
-                    "[agent-handle] Expected RuntimeStateSync (0x05), got 0x{:02x}",
-                    data.first().copied().unwrap_or(0)
-                );
-            }
-            None => {
-                anyhow::bail!("Agent EOF before initial sync");
+            _ => {
+                anyhow::bail!("Expected RuntimeStateSync from agent");
             }
         }
 
-        info!("[agent-handle] Agent spawned — RuntimeStateDoc bootstrapped");
-
         let alive = Arc::new(AtomicBool::new(true));
+        let (response_request_tx, mut response_request_rx) =
+            mpsc::channel::<oneshot::Sender<AgentResponse>>(8);
+        let (response_tx, response_rx) = mpsc::channel::<AgentResponse>(8);
 
-        // Spawn a task to wait on the child process. This is required for
-        // tokio's ChildStdout I/O driver to pump data — without it,
-        // recv_frame blocks forever because the runtime doesn't poll the child.
+        // Spawn reader task — reads ALL frames from agent stdout.
+        // This task owns `reader` and never gives it up. Frames are routed
+        // via channels. This works because the task is spawned from the same
+        // async context where `reader` was created.
         let alive_clone = alive.clone();
+        let state_doc_clone = state_doc.clone();
+        let state_changed_clone = state_changed_tx.clone();
+        let writer_clone = writer.clone();
         tokio::spawn(async move {
-            let _ = child.wait().await;
+            let mut agent_sync_state = automerge::sync::State::new();
+            let mut pending_reply: Option<oneshot::Sender<AgentResponse>> = None;
+
+            // Also wait on the child process
+            let mut child_wait = Box::pin(child.wait());
+
+            loop {
+                tokio::select! {
+                    biased;
+
+                    // Read frames from agent stdout
+                    frame = recv_frame(&mut reader) => {
+                        match frame {
+                            Ok(Some(data)) if !data.is_empty() => {
+                                let frame_type = data[0];
+                                let payload = &data[1..];
+
+                                match frame_type {
+                                    // AgentResponse
+                                    0x02 => {
+                                        if let Ok(response) = serde_json::from_slice::<AgentResponse>(payload) {
+                                            if let Some(reply) = pending_reply.take() {
+                                                let _ = reply.send(response);
+                                            } else {
+                                                let _ = response_tx.send(response).await;
+                                            }
+                                        }
+                                    }
+                                    // RuntimeStateSync
+                                    0x05 => {
+                                        if let Ok(msg) = automerge::sync::Message::decode(payload) {
+                                            let mut sd = state_doc_clone.write().await;
+                                            if let Ok(changed) = sd.receive_sync_message_with_changes(
+                                                &mut agent_sync_state, msg,
+                                            ) {
+                                                if changed {
+                                                    let _ = state_changed_clone.send(());
+                                                }
+                                            }
+                                            // Send sync reply
+                                            if let Some(reply_msg) = sd.generate_sync_message(&mut agent_sync_state) {
+                                                let encoded = reply_msg.encode();
+                                                let mut w = writer_clone.lock().await;
+                                                let _ = send_typed_frame(&mut *w, NotebookFrameType::RuntimeStateSync, &encoded).await;
+                                            }
+                                        }
+                                    }
+                                    // AgentNotification
+                                    0x03 => {
+                                        if let Ok(AgentNotification::KernelDied) = serde_json::from_slice(payload) {
+                                            warn!("[agent-handle] Agent kernel died");
+                                        }
+                                    }
+                                    _ => {}
+                                }
+                            }
+                            _ => {
+                                info!("[agent-handle] Agent stdout closed");
+                                break;
+                            }
+                        }
+                    }
+
+                    // Accept response request from send_request callers
+                    req = response_request_rx.recv() => {
+                        match req {
+                            Some(reply_tx) => {
+                                pending_reply = Some(reply_tx);
+                            }
+                            None => break,
+                        }
+                    }
+
+                    // Wait for child exit
+                    _ = &mut child_wait => {
+                        info!("[agent-handle] Agent process exited");
+                        break;
+                    }
+                }
+            }
+
             alive_clone.store(false, Ordering::Relaxed);
-            info!("[agent-handle] Agent process exited");
         });
 
+        info!("[agent-handle] Agent spawned — reader task started");
+
         Ok(Self {
-            reader,
             writer,
+            response_rx,
+            response_request_tx,
             alive,
-            state_doc,
-            state_changed_tx,
-            agent_sync_state: automerge::sync::State::new(),
         })
     }
 
-    /// Send a request and wait for the response, draining sync frames.
     async fn send_request(&mut self, request: AgentRequest) -> Result<AgentResponse> {
         if !self.alive.load(Ordering::Relaxed) {
             return Ok(AgentResponse::Error {
@@ -142,91 +217,24 @@ impl AgentHandle {
             });
         }
 
+        // Register for the response BEFORE sending the request
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.response_request_tx
+            .send(reply_tx)
+            .await
+            .map_err(|_| anyhow::anyhow!("Reader task closed"))?;
+
         // Send request
         let json = serde_json::to_vec(&request)?;
-        send_typed_frame(&mut self.writer, NotebookFrameType::Request, &json).await?;
-
-        // Read frames until we get the response, processing sync frames along the way
-        loop {
-            match recv_frame(&mut self.reader).await {
-                Ok(Some(data)) if !data.is_empty() => {
-                    let frame_type = data[0];
-                    let payload = &data[1..];
-
-                    match frame_type {
-                        // AgentResponse
-                        0x02 => {
-                            let response: AgentResponse = serde_json::from_slice(payload)?;
-                            return Ok(response);
-                        }
-                        // RuntimeStateSync — process inline
-                        0x05 => {
-                            self.apply_sync_frame(payload).await;
-                        }
-                        // AgentNotification
-                        0x03 => {
-                            if let Ok(notification) =
-                                serde_json::from_slice::<AgentNotification>(payload)
-                            {
-                                match notification {
-                                    AgentNotification::KernelDied => {
-                                        warn!("[agent-handle] Agent kernel died");
-                                    }
-                                }
-                            }
-                        }
-                        _ => {
-                            debug!(
-                                "[agent-handle] Ignoring frame type 0x{:02x}",
-                                frame_type
-                            );
-                        }
-                    }
-                }
-                Ok(Some(_)) => {} // empty frame
-                Ok(None) => {
-                    self.alive.store(false, Ordering::Relaxed);
-                    anyhow::bail!("Agent exited while waiting for response");
-                }
-                Err(e) => {
-                    self.alive.store(false, Ordering::Relaxed);
-                    anyhow::bail!("Agent read error: {}", e);
-                }
-            }
+        {
+            let mut w = self.writer.lock().await;
+            send_typed_frame(&mut *w, NotebookFrameType::Request, &json).await?;
         }
-    }
 
-    /// Apply a RuntimeStateSync frame from the agent.
-    async fn apply_sync_frame(&mut self, payload: &[u8]) {
-        if let Ok(msg) = automerge::sync::Message::decode(payload) {
-            let mut sd = self.state_doc.write().await;
-            if let Ok(changed) =
-                sd.receive_sync_message_with_changes(&mut self.agent_sync_state, msg)
-            {
-                if changed {
-                    debug!("[agent-handle] RuntimeStateDoc changed, notifying peers");
-                    let _ = self.state_changed_tx.send(());
-                }
-            }
-
-            // Send sync reply if needed
-            if let Some(reply) = sd.generate_sync_message(&mut self.agent_sync_state) {
-                let encoded = reply.encode();
-                if let Err(e) =
-                    send_typed_frame(&mut self.writer, NotebookFrameType::RuntimeStateSync, &encoded)
-                        .await
-                {
-                    warn!("[agent-handle] Failed to send sync reply: {}", e);
-                }
-            }
-        }
-    }
-
-    /// Drain any pending sync frames from the agent (non-blocking).
-    /// Call after operations that trigger agent-side state changes.
-    pub async fn drain_sync(&mut self) {
-        // TODO: non-blocking read of any pending frames
-        // For now, sync happens inline during send_request
+        // Wait for response
+        reply_rx
+            .await
+            .map_err(|_| anyhow::anyhow!("Reader task dropped response"))
     }
 
     pub async fn launch_kernel(
@@ -302,7 +310,6 @@ impl AgentHandle {
         if self.is_alive() {
             let _ = self.shutdown_kernel().await;
         }
-        // Child process is managed by the wait task (kill_on_drop handles cleanup)
         self.alive.store(false, Ordering::Relaxed);
     }
 }

--- a/crates/runtimed/src/agent_handle.rs
+++ b/crates/runtimed/src/agent_handle.rs
@@ -101,12 +101,16 @@ impl AgentHandle {
             }
 
             // Send our full state back to the agent
+            let mut sync_count = 0;
             while let Some(reply) = sd.generate_sync_message(&mut sync_state) {
                 let encoded = reply.encode();
+                info!("[agent-handle] Sending sync reply ({} bytes)", encoded.len());
                 let mut w = writer.lock().await;
                 send_typed_frame(&mut *w, NotebookFrameType::RuntimeStateSync, &encoded)
                     .await?;
+                sync_count += 1;
             }
+            info!("[agent-handle] Sent {} sync messages to agent", sync_count);
 
             // Read agent's confirmation (it now has our schema)
             match tokio::time::timeout(

--- a/crates/runtimed/src/agent_handle.rs
+++ b/crates/runtimed/src/agent_handle.rs
@@ -264,7 +264,29 @@ async fn io_loop<R, W>(
     // Subscribe to state_doc changes for reverse sync (coordinator → agent)
     let mut state_changed_rx = state_changed_tx.subscribe();
 
-    info!("[agent-handle] IO loop started");
+    info!("[agent-handle] IO loop started, reading first frame...");
+    // Try reading the first frame OUTSIDE the select to verify stdout works
+    match recv_frame(&mut reader).await {
+        Ok(Some(first_frame)) => {
+            info!(
+                "[agent-handle] First frame from agent: type=0x{:02x} ({} bytes)",
+                first_frame.first().copied().unwrap_or(0),
+                first_frame.len()
+            );
+        }
+        Ok(None) => {
+            info!("[agent-handle] Agent stdout EOF on first read");
+            alive.store(false, Ordering::Relaxed);
+            return;
+        }
+        Err(e) => {
+            warn!("[agent-handle] Error reading first frame: {}", e);
+            alive.store(false, Ordering::Relaxed);
+            return;
+        }
+    }
+
+    info!("[agent-handle] Entering main IO loop");
     loop {
         tokio::select! {
             biased;

--- a/crates/runtimed/src/agent_handle.rs
+++ b/crates/runtimed/src/agent_handle.rs
@@ -81,24 +81,50 @@ impl AgentHandle {
         }
         recv_preamble(&mut reader).await?;
 
-        // Read the agent's initial RuntimeStateDoc sync
-        info!("[agent-handle] Waiting for agent's initial sync...");
-        match recv_frame(&mut reader).await? {
-            Some(data) if !data.is_empty() && data[0] == 0x05 => {
-                let payload = &data[1..];
-                let msg = automerge::sync::Message::decode(payload)?;
-                let mut sd = state_doc.write().await;
-                let mut sync_state = automerge::sync::State::new();
-                sd.receive_sync_message_with_changes(&mut sync_state, msg)?;
-                let _ = state_changed_tx.send(());
-                info!(
-                    "[agent-handle] Applied initial RuntimeStateDoc sync ({} bytes)",
-                    data.len()
-                );
+        // Bootstrap RuntimeStateDoc sync — bidirectional exchange.
+        // The agent starts with an empty doc and sends its initial sync
+        // ("I'm empty, send me everything"). We respond with our full
+        // scaffolded state. The agent applies it and confirms convergence.
+        // This is the same pattern the frontend uses for NotebookDoc.
+        info!("[agent-handle] Bootstrapping RuntimeStateDoc sync...");
+        {
+            let mut sd = state_doc.write().await;
+            let mut sync_state = automerge::sync::State::new();
+
+            // Read agent's initial sync (empty heads)
+            match recv_frame(&mut reader).await? {
+                Some(data) if !data.is_empty() && data[0] == 0x05 => {
+                    let msg = automerge::sync::Message::decode(&data[1..])?;
+                    sd.receive_sync_message_with_changes(&mut sync_state, msg)?;
+                }
+                _ => anyhow::bail!("Expected RuntimeStateSync from agent"),
             }
-            _ => {
-                anyhow::bail!("Expected RuntimeStateSync from agent");
+
+            // Send our full state back to the agent
+            while let Some(reply) = sd.generate_sync_message(&mut sync_state) {
+                let encoded = reply.encode();
+                let mut w = writer.lock().await;
+                send_typed_frame(&mut *w, NotebookFrameType::RuntimeStateSync, &encoded)
+                    .await?;
             }
+
+            // Read agent's confirmation (it now has our schema)
+            match tokio::time::timeout(
+                std::time::Duration::from_secs(5),
+                recv_frame(&mut reader),
+            )
+            .await
+            {
+                Ok(Ok(Some(data))) if !data.is_empty() && data[0] == 0x05 => {
+                    let msg = automerge::sync::Message::decode(&data[1..])?;
+                    sd.receive_sync_message_with_changes(&mut sync_state, msg)?;
+                }
+                _ => {
+                    // Agent may converge without a final message — acceptable
+                }
+            }
+
+            info!("[agent-handle] RuntimeStateDoc sync complete");
         }
 
         let alive = Arc::new(AtomicBool::new(true));

--- a/crates/runtimed/src/agent_handle.rs
+++ b/crates/runtimed/src/agent_handle.rs
@@ -86,8 +86,8 @@ impl AgentHandle {
             .take()
             .ok_or_else(|| anyhow::anyhow!("Failed to capture agent stdout"))?;
 
-        let mut writer = BufWriter::new(child_stdin);
-        let mut reader = BufReader::new(child_stdout);
+        let mut writer = child_stdin;
+        let mut reader = child_stdout;
 
         // Send preamble + handshake
         send_preamble(&mut writer).await?;

--- a/crates/runtimed/src/agent_handle.rs
+++ b/crates/runtimed/src/agent_handle.rs
@@ -9,14 +9,15 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use anyhow::Result;
-use log::{debug, info, warn};
+use log::{info, warn};
 use notebook_doc::runtime_state::RuntimeStateDoc;
 use notebook_protocol::connection::{
     recv_frame, recv_preamble, send_json_frame, send_preamble, send_typed_frame, Handshake,
     NotebookFrameType,
 };
-use notebook_protocol::protocol::{AgentNotification, AgentRequest, AgentResponse, LaunchedEnvConfig};
-use tokio::io::AsyncWriteExt;
+use notebook_protocol::protocol::{
+    AgentNotification, AgentRequest, AgentResponse, LaunchedEnvConfig,
+};
 use tokio::process::ChildStdin;
 use tokio::sync::{broadcast, mpsc, oneshot, Mutex, RwLock};
 
@@ -24,9 +25,7 @@ use tokio::sync::{broadcast, mpsc, oneshot, Mutex, RwLock};
 pub struct AgentHandle {
     /// Writer to agent's stdin (protected by mutex for concurrent access)
     writer: Arc<Mutex<ChildStdin>>,
-    /// Channel for receiving responses from the reader task
-    response_rx: mpsc::Receiver<AgentResponse>,
-    /// Channel for sending response requests to the reader task
+    /// Channel for requesting a response from the reader task
     response_request_tx: mpsc::Sender<oneshot::Sender<AgentResponse>>,
     alive: Arc<AtomicBool>,
 }
@@ -105,7 +104,7 @@ impl AgentHandle {
         let alive = Arc::new(AtomicBool::new(true));
         let (response_request_tx, mut response_request_rx) =
             mpsc::channel::<oneshot::Sender<AgentResponse>>(8);
-        let (response_tx, response_rx) = mpsc::channel::<AgentResponse>(8);
+        // No unsolicited response channel needed — all responses go through oneshot
 
         // Spawn reader task — reads ALL frames from agent stdout.
         // This task owns `reader` and never gives it up. Frames are routed
@@ -140,7 +139,7 @@ impl AgentHandle {
                                             if let Some(reply) = pending_reply.take() {
                                                 let _ = reply.send(response);
                                             } else {
-                                                let _ = response_tx.send(response).await;
+                                                warn!("[agent-handle] Response with no pending request");
                                             }
                                         }
                                     }
@@ -204,7 +203,6 @@ impl AgentHandle {
 
         Ok(Self {
             writer,
-            response_rx,
             response_request_tx,
             alive,
         })

--- a/crates/runtimed/src/agent_handle.rs
+++ b/crates/runtimed/src/agent_handle.rs
@@ -83,21 +83,35 @@ impl AgentHandle {
         .await?;
         recv_preamble(&mut reader).await?;
 
-        // Test: can we read a frame right after preamble?
-        info!("[agent-handle] Testing recv_frame in spawn()...");
-        match tokio::time::timeout(
-            std::time::Duration::from_secs(5),
-            recv_frame(&mut reader),
-        ).await {
-            Ok(Ok(Some(data))) => {
-                info!("[agent-handle] Got frame in spawn: type=0x{:02x} ({} bytes)",
-                    data.first().copied().unwrap_or(0), data.len());
+        // Read the agent's initial RuntimeStateDoc sync frame.
+        // The agent sends this immediately after preamble — it contains the
+        // full scaffolded schema. We apply it to the coordinator's state_doc.
+        info!("[agent-handle] Waiting for agent's initial sync...");
+        match recv_frame(&mut reader).await? {
+            Some(data) if !data.is_empty() && data[0] == 0x05 => {
+                let payload = &data[1..];
+                let msg = automerge::sync::Message::decode(payload)?;
+                let mut sd = state_doc.write().await;
+                let mut sync_state = automerge::sync::State::new();
+                sd.receive_sync_message_with_changes(&mut sync_state, msg)?;
+                let _ = state_changed_tx.send(());
+                info!(
+                    "[agent-handle] Applied agent's initial RuntimeStateDoc sync ({} bytes)",
+                    data.len()
+                );
             }
-            Ok(Ok(None)) => info!("[agent-handle] EOF in spawn recv_frame"),
-            Ok(Err(e)) => info!("[agent-handle] Error in spawn recv_frame: {}", e),
-            Err(_) => info!("[agent-handle] Timeout in spawn recv_frame (5s)"),
+            Some(data) => {
+                warn!(
+                    "[agent-handle] Expected RuntimeStateSync (0x05), got 0x{:02x}",
+                    data.first().copied().unwrap_or(0)
+                );
+            }
+            None => {
+                anyhow::bail!("Agent EOF before initial sync");
+            }
         }
-        info!("[agent-handle] Agent spawned — RuntimeStateDoc owned by agent");
+
+        info!("[agent-handle] Agent spawned — RuntimeStateDoc bootstrapped");
 
         Ok(Self {
             reader,

--- a/crates/runtimed/src/agent_handle.rs
+++ b/crates/runtimed/src/agent_handle.rs
@@ -264,6 +264,7 @@ async fn io_loop<R, W>(
     // Subscribe to state_doc changes for reverse sync (coordinator → agent)
     let mut state_changed_rx = state_changed_tx.subscribe();
 
+    info!("[agent-handle] IO loop started");
     loop {
         tokio::select! {
             // Read frames from agent stdout

--- a/crates/runtimed/src/agent_handle.rs
+++ b/crates/runtimed/src/agent_handle.rs
@@ -293,12 +293,14 @@ async fn io_loop<R, W>(
 
                             // RuntimeStateSync (0x05)
                             0x05 => {
+                                debug!("[agent-handle] Received RuntimeStateSync ({} bytes)", payload.len());
                                 if let Ok(msg) = automerge::sync::Message::decode(payload) {
                                     let mut sd = state_doc.write().await;
                                     if let Ok(changed) = sd.receive_sync_message_with_changes(
                                         &mut agent_sync_state, msg,
                                     ) {
                                         if changed {
+                                            debug!("[agent-handle] RuntimeStateDoc changed, notifying peers");
                                             let _ = state_changed_tx.send(());
                                         }
                                     }

--- a/crates/runtimed/src/agent_handle.rs
+++ b/crates/runtimed/src/agent_handle.rs
@@ -54,7 +54,7 @@ impl AgentHandle {
             .kill_on_drop(true)
             .spawn()?;
 
-        let writer = child
+        let mut writer = child
             .stdin
             .take()
             .ok_or_else(|| anyhow::anyhow!("Failed to capture agent stdin"))?;
@@ -63,22 +63,17 @@ impl AgentHandle {
             .take()
             .ok_or_else(|| anyhow::anyhow!("Failed to capture agent stdout"))?;
 
-        let writer = Arc::new(Mutex::new(writer));
-
-        // Preamble + handshake exchange
-        {
-            let mut w = writer.lock().await;
-            send_preamble(&mut *w).await?;
-            send_json_frame(
-                &mut *w,
-                &Handshake::RuntimeAgent {
-                    notebook_id,
-                    agent_id,
-                    blob_root: blob_root.to_string_lossy().to_string(),
-                },
-            )
-            .await?;
-        }
+        // Preamble + handshake exchange (before wrapping writer in Arc<Mutex>)
+        send_preamble(&mut writer).await?;
+        send_json_frame(
+            &mut writer,
+            &Handshake::RuntimeAgent {
+                notebook_id,
+                agent_id,
+                blob_root: blob_root.to_string_lossy().to_string(),
+            },
+        )
+        .await?;
         recv_preamble(&mut reader).await?;
 
         // Bootstrap RuntimeStateDoc sync — bidirectional exchange.
@@ -105,8 +100,7 @@ impl AgentHandle {
             while let Some(reply) = sd.generate_sync_message(&mut sync_state) {
                 let encoded = reply.encode();
                 info!("[agent-handle] Sending sync reply ({} bytes)", encoded.len());
-                let mut w = writer.lock().await;
-                send_typed_frame(&mut *w, NotebookFrameType::RuntimeStateSync, &encoded)
+                send_typed_frame(&mut writer, NotebookFrameType::RuntimeStateSync, &encoded)
                     .await?;
                 sync_count += 1;
             }
@@ -130,6 +124,9 @@ impl AgentHandle {
 
             info!("[agent-handle] RuntimeStateDoc sync complete");
         }
+
+        // Now wrap writer in Arc<Mutex> for shared access with reader task
+        let writer = Arc::new(Mutex::new(writer));
 
         let alive = Arc::new(AtomicBool::new(true));
         let (response_request_tx, mut response_request_rx) =

--- a/crates/runtimed/src/agent_handle.rs
+++ b/crates/runtimed/src/agent_handle.rs
@@ -1,20 +1,10 @@
 //! Coordinator-side management of a runtime agent subprocess.
 //!
 //! `AgentHandle` spawns a `runtimed agent` child process, pipes the framed
-//! protocol on its stdin/stdout, syncs RuntimeStateDoc bidirectionally, and
-//! detects agent exit.
+//! protocol on its stdin/stdout, and provides typed request methods.
 //!
-//! ## Data flow
-//!
-//! ```text
-//! Coordinator                          Agent subprocess
-//! ──────────                          ─────────────────
-//! AgentRequest (0x01) ──stdin──►      handle_agent_request()
-//! ◄──stdout── AgentResponse (0x02)
-//! ◄──stdout── RuntimeStateSync (0x05)  kernel writes state_doc
-//! RuntimeStateSync (0x05) ──stdin──►  comm state from frontend
-//! ◄──stdout── Broadcast (0x03)         KernelDied notification
-//! ```
+//! RuntimeStateDoc sync happens inline: after each request/response exchange,
+//! the handle drains any pending sync frames from the agent before returning.
 
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -24,35 +14,30 @@ use anyhow::Result;
 use log::{debug, info, warn};
 use notebook_doc::runtime_state::RuntimeStateDoc;
 use notebook_protocol::connection::{
-    recv_frame, send_json_frame, send_preamble, send_typed_frame, Handshake, NotebookFrameType,
+    recv_frame, recv_json_frame, recv_preamble, send_json_frame, send_preamble, send_typed_frame,
+    Handshake, NotebookFrameType,
 };
-use notebook_protocol::protocol::{
-    AgentNotification, AgentRequest, AgentResponse, LaunchedEnvConfig,
-};
-use tokio::io::{AsyncRead, AsyncWrite, BufReader, BufWriter};
-use tokio::process::{Child, Command};
-use tokio::sync::{broadcast, mpsc, oneshot, RwLock};
+use notebook_protocol::protocol::{AgentNotification, AgentRequest, AgentResponse, LaunchedEnvConfig};
+use tokio::process::{Child, ChildStdin, ChildStdout};
+use tokio::sync::{broadcast, RwLock};
 
 /// Handle to a running agent subprocess.
 ///
-/// Provides typed methods for sending requests and automatically manages
-/// RuntimeStateDoc sync between coordinator and agent.
+/// Owns the child process and its stdin/stdout. Request methods write to
+/// stdin and read from stdout synchronously (no background IO task).
 pub struct AgentHandle {
-    /// Channel for sending requests to the IO task (which writes to stdin).
-    request_tx: mpsc::Sender<(AgentRequest, oneshot::Sender<AgentResponse>)>,
-    /// Whether the agent process is still alive.
-    alive: Arc<AtomicBool>,
-    /// Handle to the IO task for cleanup.
-    io_task: tokio::task::JoinHandle<()>,
-    /// Handle to the child process.
+    reader: ChildStdout,
+    writer: ChildStdin,
     child: Child,
+    alive: Arc<AtomicBool>,
+    state_doc: Arc<RwLock<RuntimeStateDoc>>,
+    state_changed_tx: broadcast::Sender<()>,
+    /// Automerge sync state for the agent peer
+    agent_sync_state: automerge::sync::State,
 }
 
 impl AgentHandle {
-    /// Spawn a new agent subprocess and set up bidirectional communication.
-    ///
-    /// The coordinator sends the preamble + `RuntimeAgent` handshake, then
-    /// starts the IO task for frame multiplexing and RuntimeStateDoc sync.
+    /// Spawn a new agent subprocess.
     pub async fn spawn(
         notebook_id: String,
         agent_id: String,
@@ -61,7 +46,6 @@ impl AgentHandle {
         state_changed_tx: broadcast::Sender<()>,
         _broadcast_tx: broadcast::Sender<notebook_protocol::protocol::NotebookBroadcast>,
     ) -> Result<Self> {
-        // Find the current binary — agent runs as `runtimed agent`
         let exe = std::env::current_exe()?;
         info!(
             "[agent-handle] Spawning agent: {} agent (notebook_id={})",
@@ -69,7 +53,7 @@ impl AgentHandle {
             notebook_id
         );
 
-        let mut child = Command::new(&exe)
+        let mut child = tokio::process::Command::new(&exe)
             .arg("agent")
             .stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::piped())
@@ -77,80 +61,138 @@ impl AgentHandle {
             .kill_on_drop(true)
             .spawn()?;
 
-        let child_stdin = child
+        let mut writer = child
             .stdin
             .take()
             .ok_or_else(|| anyhow::anyhow!("Failed to capture agent stdin"))?;
-        let child_stdout = child
+        let mut reader = child
             .stdout
             .take()
             .ok_or_else(|| anyhow::anyhow!("Failed to capture agent stdout"))?;
 
-        let mut writer = child_stdin;
-        let mut reader = child_stdout;
-
-        // Send preamble + handshake
+        // Preamble + handshake exchange
         send_preamble(&mut writer).await?;
         send_json_frame(
             &mut writer,
             &Handshake::RuntimeAgent {
-                notebook_id: notebook_id.clone(),
-                agent_id: agent_id.clone(),
+                notebook_id,
+                agent_id,
                 blob_root: blob_root.to_string_lossy().to_string(),
             },
         )
         .await?;
+        recv_preamble(&mut reader).await?;
 
-        // Wait for agent's preamble response
-        notebook_protocol::connection::recv_preamble(&mut reader).await?;
-
-        // The agent owns the RuntimeStateDoc — it creates a fully scaffolded doc
-        // and syncs it to the coordinator via the IO loop. No bootstrap sync needed
-        // here. The IO task handles bidirectional sync naturally.
         info!("[agent-handle] Agent spawned — RuntimeStateDoc owned by agent");
 
-        // Set up channels
-        let (request_tx, request_rx) = mpsc::channel(32);
-        let alive = Arc::new(AtomicBool::new(true));
-
-        // Spawn the IO task
-        let io_task = tokio::spawn(io_loop(
+        Ok(Self {
             reader,
             writer,
-            request_rx,
+            child,
+            alive: Arc::new(AtomicBool::new(true)),
             state_doc,
             state_changed_tx,
-            alive.clone(),
-        ));
-
-        Ok(Self {
-            request_tx,
-            alive,
-            io_task,
-            child,
+            agent_sync_state: automerge::sync::State::new(),
         })
     }
 
-    /// Send a request to the agent and wait for the response.
-    async fn send_request(&self, request: AgentRequest) -> Result<AgentResponse> {
+    /// Send a request and wait for the response, draining sync frames.
+    async fn send_request(&mut self, request: AgentRequest) -> Result<AgentResponse> {
         if !self.alive.load(Ordering::Relaxed) {
             return Ok(AgentResponse::Error {
                 error: "Agent is not running".to_string(),
             });
         }
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.request_tx
-            .send((request, reply_tx))
-            .await
-            .map_err(|_| anyhow::anyhow!("Agent IO task closed"))?;
-        reply_rx
-            .await
-            .map_err(|_| anyhow::anyhow!("Agent IO task dropped response"))
+
+        // Send request
+        let json = serde_json::to_vec(&request)?;
+        send_typed_frame(&mut self.writer, NotebookFrameType::Request, &json).await?;
+
+        // Read frames until we get the response, processing sync frames along the way
+        loop {
+            match recv_frame(&mut self.reader).await {
+                Ok(Some(data)) if !data.is_empty() => {
+                    let frame_type = data[0];
+                    let payload = &data[1..];
+
+                    match frame_type {
+                        // AgentResponse
+                        0x02 => {
+                            let response: AgentResponse = serde_json::from_slice(payload)?;
+                            return Ok(response);
+                        }
+                        // RuntimeStateSync — process inline
+                        0x05 => {
+                            self.apply_sync_frame(payload).await;
+                        }
+                        // AgentNotification
+                        0x03 => {
+                            if let Ok(notification) =
+                                serde_json::from_slice::<AgentNotification>(payload)
+                            {
+                                match notification {
+                                    AgentNotification::KernelDied => {
+                                        warn!("[agent-handle] Agent kernel died");
+                                    }
+                                }
+                            }
+                        }
+                        _ => {
+                            debug!(
+                                "[agent-handle] Ignoring frame type 0x{:02x}",
+                                frame_type
+                            );
+                        }
+                    }
+                }
+                Ok(Some(_)) => {} // empty frame
+                Ok(None) => {
+                    self.alive.store(false, Ordering::Relaxed);
+                    anyhow::bail!("Agent exited while waiting for response");
+                }
+                Err(e) => {
+                    self.alive.store(false, Ordering::Relaxed);
+                    anyhow::bail!("Agent read error: {}", e);
+                }
+            }
+        }
     }
 
-    /// Launch a kernel in the agent subprocess.
+    /// Apply a RuntimeStateSync frame from the agent.
+    async fn apply_sync_frame(&mut self, payload: &[u8]) {
+        if let Ok(msg) = automerge::sync::Message::decode(payload) {
+            let mut sd = self.state_doc.write().await;
+            if let Ok(changed) =
+                sd.receive_sync_message_with_changes(&mut self.agent_sync_state, msg)
+            {
+                if changed {
+                    debug!("[agent-handle] RuntimeStateDoc changed, notifying peers");
+                    let _ = self.state_changed_tx.send(());
+                }
+            }
+
+            // Send sync reply if needed
+            if let Some(reply) = sd.generate_sync_message(&mut self.agent_sync_state) {
+                let encoded = reply.encode();
+                if let Err(e) =
+                    send_typed_frame(&mut self.writer, NotebookFrameType::RuntimeStateSync, &encoded)
+                        .await
+                {
+                    warn!("[agent-handle] Failed to send sync reply: {}", e);
+                }
+            }
+        }
+    }
+
+    /// Drain any pending sync frames from the agent (non-blocking).
+    /// Call after operations that trigger agent-side state changes.
+    pub async fn drain_sync(&mut self) {
+        // TODO: non-blocking read of any pending frames
+        // For now, sync happens inline during send_request
+    }
+
     pub async fn launch_kernel(
-        &self,
+        &mut self,
         kernel_type: &str,
         env_source: &str,
         notebook_path: Option<&str>,
@@ -166,9 +208,8 @@ impl AgentHandle {
         .await
     }
 
-    /// Execute a cell in the agent's kernel.
     pub async fn execute_cell(
-        &self,
+        &mut self,
         cell_id: &str,
         code: &str,
         execution_id: &str,
@@ -181,23 +222,19 @@ impl AgentHandle {
         .await
     }
 
-    /// Interrupt the currently executing cell.
-    pub async fn interrupt(&self) -> Result<AgentResponse> {
+    pub async fn interrupt(&mut self) -> Result<AgentResponse> {
         self.send_request(AgentRequest::InterruptExecution).await
     }
 
-    /// Shutdown the agent's kernel.
-    pub async fn shutdown_kernel(&self) -> Result<AgentResponse> {
+    pub async fn shutdown_kernel(&mut self) -> Result<AgentResponse> {
         self.send_request(AgentRequest::ShutdownKernel).await
     }
 
-    /// Send a comm message to the agent's kernel.
-    pub async fn send_comm(&self, message: serde_json::Value) -> Result<AgentResponse> {
+    pub async fn send_comm(&mut self, message: serde_json::Value) -> Result<AgentResponse> {
         self.send_request(AgentRequest::SendComm { message }).await
     }
 
-    /// Request code completions.
-    pub async fn complete(&self, code: &str, cursor_pos: usize) -> Result<AgentResponse> {
+    pub async fn complete(&mut self, code: &str, cursor_pos: usize) -> Result<AgentResponse> {
         self.send_request(AgentRequest::Complete {
             code: code.to_string(),
             cursor_pos,
@@ -205,9 +242,8 @@ impl AgentHandle {
         .await
     }
 
-    /// Search kernel input history.
     pub async fn get_history(
-        &self,
+        &mut self,
         pattern: Option<&str>,
         n: i32,
         unique: bool,
@@ -220,221 +256,15 @@ impl AgentHandle {
         .await
     }
 
-    /// Check if the agent process is still alive.
     pub fn is_alive(&self) -> bool {
         self.alive.load(Ordering::Relaxed)
     }
 
-    /// Shutdown the agent process.
     pub async fn shutdown(&mut self) {
-        // Try graceful shutdown first
         if self.is_alive() {
             let _ = self.shutdown_kernel().await;
         }
-        // Kill the child process
         let _ = self.child.kill().await;
         self.alive.store(false, Ordering::Relaxed);
-        // Abort the IO task
-        self.io_task.abort();
     }
-}
-
-/// Main IO loop for the agent handle.
-///
-/// Reads frames from the agent's stdout, routes responses to pending
-/// request waiters, applies RuntimeStateDoc sync, and handles notifications.
-/// Also writes outgoing requests and RuntimeStateDoc sync to the agent's stdin.
-async fn io_loop<R, W>(
-    mut reader: R,
-    mut writer: W,
-    mut request_rx: mpsc::Receiver<(AgentRequest, oneshot::Sender<AgentResponse>)>,
-    state_doc: Arc<RwLock<RuntimeStateDoc>>,
-    state_changed_tx: broadcast::Sender<()>,
-    alive: Arc<AtomicBool>,
-) where
-    R: AsyncRead + Unpin,
-    W: AsyncWrite + Unpin,
-{
-    // Pending response waiter — only one request at a time (sequential dispatch).
-    let mut pending_reply: Option<oneshot::Sender<AgentResponse>> = None;
-
-    // Automerge sync state for the agent peer
-    let mut agent_sync_state = automerge::sync::State::new();
-
-    // Subscribe to state_doc changes for reverse sync (coordinator → agent)
-    let mut state_changed_rx = state_changed_tx.subscribe();
-
-    info!("[agent-handle] IO loop started, reading first frame...");
-    // Try reading the first frame OUTSIDE the select to verify stdout works
-    match recv_frame(&mut reader).await {
-        Ok(Some(first_frame)) => {
-            info!(
-                "[agent-handle] First frame from agent: type=0x{:02x} ({} bytes)",
-                first_frame.first().copied().unwrap_or(0),
-                first_frame.len()
-            );
-        }
-        Ok(None) => {
-            info!("[agent-handle] Agent stdout EOF on first read");
-            alive.store(false, Ordering::Relaxed);
-            return;
-        }
-        Err(e) => {
-            warn!("[agent-handle] Error reading first frame: {}", e);
-            alive.store(false, Ordering::Relaxed);
-            return;
-        }
-    }
-
-    info!("[agent-handle] Entering main IO loop");
-    loop {
-        tokio::select! {
-            biased;
-
-            // Read frames from agent stdout (highest priority)
-            frame = recv_frame(&mut reader) => {
-                match frame {
-                    Ok(Some(data)) if !data.is_empty() => {
-                        let frame_type = data[0];
-                        let payload = &data[1..];
-
-                        match frame_type {
-                            // AgentResponse (0x02)
-                            0x02 => {
-                                if let Some(reply) = pending_reply.take() {
-                                    match serde_json::from_slice::<AgentResponse>(payload) {
-                                        Ok(response) => { let _ = reply.send(response); }
-                                        Err(e) => {
-                                            warn!("[agent-handle] Failed to parse response: {}", e);
-                                            let _ = reply.send(AgentResponse::Error {
-                                                error: format!("Failed to parse agent response: {}", e),
-                                            });
-                                        }
-                                    }
-                                } else {
-                                    warn!("[agent-handle] Received response with no pending request");
-                                }
-                            }
-
-                            // RuntimeStateSync (0x05)
-                            0x05 => {
-                                debug!("[agent-handle] Received RuntimeStateSync ({} bytes)", payload.len());
-                                if let Ok(msg) = automerge::sync::Message::decode(payload) {
-                                    let mut sd = state_doc.write().await;
-                                    if let Ok(changed) = sd.receive_sync_message_with_changes(
-                                        &mut agent_sync_state, msg,
-                                    ) {
-                                        if changed {
-                                            debug!("[agent-handle] RuntimeStateDoc changed, notifying peers");
-                                            let _ = state_changed_tx.send(());
-                                        }
-                                    }
-
-                                    // Generate reply sync message if needed
-                                    if let Some(reply_msg) = sd.generate_sync_message(&mut agent_sync_state) {
-                                        let encoded = reply_msg.encode();
-                                        if let Err(e) = send_typed_frame(
-                                            &mut writer,
-                                            NotebookFrameType::RuntimeStateSync,
-                                            &encoded,
-                                        ).await {
-                                            warn!("[agent-handle] Failed to send sync reply: {}", e);
-                                            break;
-                                        }
-                                    }
-                                }
-                            }
-
-                            // AgentNotification (0x03)
-                            0x03 => {
-                                if let Ok(notification) = serde_json::from_slice::<AgentNotification>(payload) {
-                                    match notification {
-                                        AgentNotification::KernelDied => {
-                                            warn!("[agent-handle] Agent reported kernel died");
-                                            // State is already in RuntimeStateDoc via sync
-                                        }
-                                    }
-                                }
-                            }
-
-                            _ => {
-                                debug!("[agent-handle] Ignoring frame type 0x{:02x}", frame_type);
-                            }
-                        }
-                    }
-                    Ok(Some(_)) => {} // empty frame
-                    Ok(None) => {
-                        info!("[agent-handle] Agent stdout EOF — process exited");
-                        break;
-                    }
-                    Err(e) => {
-                        warn!("[agent-handle] Agent stdout read error: {}", e);
-                        break;
-                    }
-                }
-            }
-
-            // Send requests to agent stdin (only when no pending reply)
-            request = async {
-                if pending_reply.is_some() {
-                    // Block until the current request is answered
-                    std::future::pending::<Option<(AgentRequest, oneshot::Sender<AgentResponse>)>>().await
-                } else {
-                    request_rx.recv().await
-                }
-            } => {
-                match request {
-                    Some((req, reply)) => {
-                        let json = match serde_json::to_vec(&req) {
-                            Ok(j) => j,
-                            Err(e) => {
-                                let _ = reply.send(AgentResponse::Error {
-                                    error: format!("Failed to serialize request: {}", e),
-                                });
-                                continue;
-                            }
-                        };
-                        if let Err(e) = send_typed_frame(
-                            &mut writer,
-                            NotebookFrameType::Request,
-                            &json,
-                        ).await {
-                            warn!("[agent-handle] Failed to send request to agent: {}", e);
-                            let _ = reply.send(AgentResponse::Error {
-                                error: format!("Failed to send to agent: {}", e),
-                            });
-                            break;
-                        }
-                        pending_reply = Some(reply);
-                    }
-                    None => {
-                        info!("[agent-handle] Request channel closed, shutting down IO");
-                        break;
-                    }
-                }
-            }
-
-            // Forward coordinator RuntimeStateDoc changes to agent
-            _ = state_changed_rx.recv() => {
-                // Drain buffered notifications
-                while state_changed_rx.try_recv().is_ok() {}
-
-                let mut sd = state_doc.write().await;
-                if let Some(msg) = sd.generate_sync_message(&mut agent_sync_state) {
-                    let encoded = msg.encode();
-                    if let Err(e) = send_typed_frame(
-                        &mut writer,
-                        NotebookFrameType::RuntimeStateSync,
-                        &encoded,
-                    ).await {
-                        warn!("[agent-handle] Failed to send state sync to agent: {}", e);
-                        break;
-                    }
-                }
-            }
-        }
-    }
-
-    alive.store(false, Ordering::Relaxed);
-    info!("[agent-handle] IO loop exited");
 }

--- a/crates/runtimed/src/agent_handle.rs
+++ b/crates/runtimed/src/agent_handle.rs
@@ -76,54 +76,11 @@ impl AgentHandle {
         .await?;
         recv_preamble(&mut reader).await?;
 
-        // Bootstrap RuntimeStateDoc sync — bidirectional exchange.
-        // The agent starts with an empty doc and sends its initial sync
-        // ("I'm empty, send me everything"). We respond with our full
-        // scaffolded state. The agent applies it and confirms convergence.
-        // This is the same pattern the frontend uses for NotebookDoc.
-        info!("[agent-handle] Bootstrapping RuntimeStateDoc sync...");
-        {
-            let mut sd = state_doc.write().await;
-            let mut sync_state = automerge::sync::State::new();
-
-            // Read agent's initial sync (empty heads)
-            match recv_frame(&mut reader).await? {
-                Some(data) if !data.is_empty() && data[0] == 0x05 => {
-                    let msg = automerge::sync::Message::decode(&data[1..])?;
-                    sd.receive_sync_message_with_changes(&mut sync_state, msg)?;
-                }
-                _ => anyhow::bail!("Expected RuntimeStateSync from agent"),
-            }
-
-            // Send our full state back to the agent
-            let mut sync_count = 0;
-            while let Some(reply) = sd.generate_sync_message(&mut sync_state) {
-                let encoded = reply.encode();
-                info!("[agent-handle] Sending sync reply ({} bytes)", encoded.len());
-                send_typed_frame(&mut writer, NotebookFrameType::RuntimeStateSync, &encoded)
-                    .await?;
-                sync_count += 1;
-            }
-            info!("[agent-handle] Sent {} sync messages to agent", sync_count);
-
-            // Read agent's confirmation (it now has our schema)
-            match tokio::time::timeout(
-                std::time::Duration::from_secs(5),
-                recv_frame(&mut reader),
-            )
-            .await
-            {
-                Ok(Ok(Some(data))) if !data.is_empty() && data[0] == 0x05 => {
-                    let msg = automerge::sync::Message::decode(&data[1..])?;
-                    sd.receive_sync_message_with_changes(&mut sync_state, msg)?;
-                }
-                _ => {
-                    // Agent may converge without a final message — acceptable
-                }
-            }
-
-            info!("[agent-handle] RuntimeStateDoc sync complete");
-        }
+        // Both coordinator and agent have their own scaffolded RuntimeStateDoc
+        // with different actors. No bootstrap sync needed — the reader task
+        // handles bidirectional sync once it starts. The docs will merge
+        // naturally via Automerge CRDT (same structure, different actors).
+        info!("[agent-handle] Agent spawned — sync via reader task");
 
         // Now wrap writer in Arc<Mutex> for shared access with reader task
         let writer = Arc::new(Mutex::new(writer));

--- a/crates/runtimed/src/agent_handle.rs
+++ b/crates/runtimed/src/agent_handle.rs
@@ -104,11 +104,58 @@ impl AgentHandle {
         // Wait for agent's preamble response
         notebook_protocol::connection::recv_preamble(&mut reader).await?;
 
-        // Initial RuntimeStateDoc sync happens via the IO loop:
-        // 1. Agent sends initial sync message (empty heads → "send me everything")
-        // 2. IO task reads it, applies to coordinator's doc, generates reply
-        // 3. Agent receives reply, converges
-        info!("[agent-handle] Agent spawned, sync bootstrap via IO loop");
+        // Bootstrap RuntimeStateDoc sync before starting IO loop.
+        // The agent sends its initial sync message (empty heads → "send me everything"),
+        // we respond with the full doc state, and the agent converges.
+        // This MUST happen before the IO task starts, otherwise the LaunchKernel
+        // request can race with the sync bootstrap.
+        {
+            let mut sd = state_doc.write().await;
+            let mut sync_state = automerge::sync::State::new();
+
+            // Read the agent's initial sync message
+            loop {
+                match recv_frame(&mut reader).await? {
+                    Some(data) if !data.is_empty() && data[0] == 0x05 => {
+                        let msg = automerge::sync::Message::decode(&data[1..])?;
+                        sd.receive_sync_message_with_changes(&mut sync_state, msg)?;
+
+                        // Generate reply with our full state
+                        while let Some(reply) = sd.generate_sync_message(&mut sync_state) {
+                            let encoded = reply.encode();
+                            send_typed_frame(
+                                &mut writer,
+                                NotebookFrameType::RuntimeStateSync,
+                                &encoded,
+                            )
+                            .await?;
+                        }
+                        break;
+                    }
+                    Some(_) => continue, // ignore non-sync frames during bootstrap
+                    None => anyhow::bail!("Agent EOF during sync bootstrap"),
+                }
+            }
+
+            // Read agent's sync reply (convergence confirmation)
+            match tokio::time::timeout(
+                std::time::Duration::from_secs(5),
+                recv_frame(&mut reader),
+            )
+            .await
+            {
+                Ok(Ok(Some(data))) if !data.is_empty() && data[0] == 0x05 => {
+                    let msg = automerge::sync::Message::decode(&data[1..])?;
+                    sd.receive_sync_message_with_changes(&mut sync_state, msg)?;
+                }
+                _ => {
+                    // Agent may have converged without a final reply — that's ok
+                    debug!("[agent-handle] No final sync reply from agent (may have converged)");
+                }
+            }
+        }
+
+        info!("[agent-handle] Agent spawned and RuntimeStateDoc synced");
 
         // Set up channels
         let (request_tx, request_rx) = mpsc::channel(32);

--- a/crates/runtimed/src/agent_handle.rs
+++ b/crates/runtimed/src/agent_handle.rs
@@ -104,58 +104,10 @@ impl AgentHandle {
         // Wait for agent's preamble response
         notebook_protocol::connection::recv_preamble(&mut reader).await?;
 
-        // Bootstrap RuntimeStateDoc sync before starting IO loop.
-        // The agent sends its initial sync message (empty heads → "send me everything"),
-        // we respond with the full doc state, and the agent converges.
-        // This MUST happen before the IO task starts, otherwise the LaunchKernel
-        // request can race with the sync bootstrap.
-        {
-            let mut sd = state_doc.write().await;
-            let mut sync_state = automerge::sync::State::new();
-
-            // Read the agent's initial sync message
-            loop {
-                match recv_frame(&mut reader).await? {
-                    Some(data) if !data.is_empty() && data[0] == 0x05 => {
-                        let msg = automerge::sync::Message::decode(&data[1..])?;
-                        sd.receive_sync_message_with_changes(&mut sync_state, msg)?;
-
-                        // Generate reply with our full state
-                        while let Some(reply) = sd.generate_sync_message(&mut sync_state) {
-                            let encoded = reply.encode();
-                            send_typed_frame(
-                                &mut writer,
-                                NotebookFrameType::RuntimeStateSync,
-                                &encoded,
-                            )
-                            .await?;
-                        }
-                        break;
-                    }
-                    Some(_) => continue, // ignore non-sync frames during bootstrap
-                    None => anyhow::bail!("Agent EOF during sync bootstrap"),
-                }
-            }
-
-            // Read agent's sync reply (convergence confirmation)
-            match tokio::time::timeout(
-                std::time::Duration::from_secs(5),
-                recv_frame(&mut reader),
-            )
-            .await
-            {
-                Ok(Ok(Some(data))) if !data.is_empty() && data[0] == 0x05 => {
-                    let msg = automerge::sync::Message::decode(&data[1..])?;
-                    sd.receive_sync_message_with_changes(&mut sync_state, msg)?;
-                }
-                _ => {
-                    // Agent may have converged without a final reply — that's ok
-                    debug!("[agent-handle] No final sync reply from agent (may have converged)");
-                }
-            }
-        }
-
-        info!("[agent-handle] Agent spawned and RuntimeStateDoc synced");
+        // The agent owns the RuntimeStateDoc — it creates a fully scaffolded doc
+        // and syncs it to the coordinator via the IO loop. No bootstrap sync needed
+        // here. The IO task handles bidirectional sync naturally.
+        info!("[agent-handle] Agent spawned — RuntimeStateDoc owned by agent");
 
         // Set up channels
         let (request_tx, request_rx) = mpsc::channel(32);

--- a/crates/runtimed/src/blob_store.rs
+++ b/crates/runtimed/src/blob_store.rs
@@ -15,7 +15,7 @@
 //! directory and renamed into place, so readers never see partial writes.
 
 use std::io;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -44,6 +44,11 @@ impl BlobStore {
     /// The directory is created lazily on first `put()`.
     pub fn new(root: PathBuf) -> Self {
         Self { root }
+    }
+
+    /// Get the root directory of this blob store.
+    pub fn root(&self) -> &Path {
+        &self.root
     }
 
     /// Store `data` with the given `media_type`.

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -1896,6 +1896,7 @@ impl Daemon {
         let mut paths = std::collections::HashSet::new();
         let rooms = self.notebook_rooms.lock().await;
         for room in rooms.values() {
+            // Check local kernel
             let kernel_guard = room.kernel.lock().await;
             if let Some(ref kernel) = *kernel_guard {
                 if kernel.is_running() {
@@ -1903,6 +1904,12 @@ impl Daemon {
                         paths.insert(env_path.clone());
                     }
                 }
+            }
+            drop(kernel_guard);
+
+            // Check agent-backed kernel
+            if let Some(ref env_path) = *room.agent_env_path.read().await {
+                paths.insert(env_path.clone());
             }
         }
         paths

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -347,6 +347,9 @@ pub struct Daemon {
     uv_pool: Mutex<Pool>,
     conda_pool: Mutex<Pool>,
     shutdown: Arc<Mutex<bool>>,
+    /// Runtime feature flag: kernel execution via agent subprocess.
+    /// Toggled via `runt agent enable` / `runt agent disable`.
+    pub agent_mode: Arc<std::sync::atomic::AtomicBool>,
     /// Notifier to wake up accept loops on shutdown.
     shutdown_notify: Arc<Notify>,
     /// Singleton lock - kept alive while daemon is running.
@@ -399,6 +402,9 @@ impl Daemon {
 
         let blob_store = Arc::new(BlobStore::new(config.blob_store_dir.clone()));
 
+        // Initialize agent mode from env var
+        let agent_mode = std::env::var("RUNT_AGENT_MODE").as_deref() == Ok("1");
+
         Ok(Arc::new(Self {
             uv_pool: Mutex::new(Pool::new(config.uv_pool_size, config.max_age_secs)),
             conda_pool: Mutex::new(Pool::new(config.conda_pool_size, config.max_age_secs)),
@@ -413,6 +419,7 @@ impl Daemon {
             blob_store,
             blob_port: Mutex::new(None),
             notebook_rooms: Arc::new(Mutex::new(HashMap::new())),
+            agent_mode: Arc::new(std::sync::atomic::AtomicBool::new(agent_mode)),
         }))
     }
 

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -1879,6 +1879,15 @@ impl Daemon {
                     self.collect_active_env_paths().await.into_iter().collect();
                 Response::ActiveEnvPaths { paths }
             }
+            Request::SetAgentMode { enabled } => {
+                self.agent_mode
+                    .store(enabled, std::sync::atomic::Ordering::Relaxed);
+                info!(
+                    "[runtimed] Agent mode {}",
+                    if enabled { "ENABLED" } else { "DISABLED" }
+                );
+                Response::Ok
+            }
         }
     }
 

--- a/crates/runtimed/src/main.rs
+++ b/crates/runtimed/src/main.rs
@@ -337,8 +337,12 @@ async fn main() -> anyhow::Result<()> {
         }
         Some(Commands::Agent) => {
             // Agent mode: communicate over stdin/stdout using framed protocol.
-            // Logs go to stderr only.
-            runtimed::agent::run_agent(tokio::io::stdin(), tokio::io::stdout())
+            // Use tokio::fs::File from raw fd to avoid tokio::io::stdout()
+            // buffering issues that prevent frames from being read by the parent.
+            use std::os::unix::io::FromRawFd;
+            let stdin = unsafe { tokio::fs::File::from_raw_fd(0) };
+            let stdout = unsafe { tokio::fs::File::from_raw_fd(1) };
+            runtimed::agent::run_agent(stdin, stdout)
                 .await
                 .map_err(|e| {
                     eprintln!("[agent] Fatal: {}", e);

--- a/crates/runtimed/src/main.rs
+++ b/crates/runtimed/src/main.rs
@@ -337,17 +337,29 @@ async fn main() -> anyhow::Result<()> {
         }
         Some(Commands::Agent) => {
             // Agent mode: communicate over stdin/stdout using framed protocol.
-            // Use tokio::fs::File from raw fd to avoid tokio::io::stdout()
-            // buffering issues that prevent frames from being read by the parent.
-            use std::os::unix::io::FromRawFd;
-            let stdin = unsafe { tokio::fs::File::from_raw_fd(0) };
-            let stdout = unsafe { tokio::fs::File::from_raw_fd(1) };
-            runtimed::agent::run_agent(stdin, stdout)
-                .await
-                .map_err(|e| {
-                    eprintln!("[agent] Fatal: {}", e);
-                    e
-                })
+            #[cfg(unix)]
+            {
+                // Use tokio::fs::File from raw fd to avoid tokio::io::stdout()
+                // buffering issues that prevent frames from being read by the parent.
+                use std::os::unix::io::FromRawFd;
+                let stdin = unsafe { tokio::fs::File::from_raw_fd(0) };
+                let stdout = unsafe { tokio::fs::File::from_raw_fd(1) };
+                runtimed::agent::run_agent(stdin, stdout)
+                    .await
+                    .map_err(|e| {
+                        eprintln!("[agent] Fatal: {}", e);
+                        e
+                    })
+            }
+            #[cfg(not(unix))]
+            {
+                runtimed::agent::run_agent(tokio::io::stdin(), tokio::io::stdout())
+                    .await
+                    .map_err(|e| {
+                        eprintln!("[agent] Fatal: {}", e);
+                        e
+                    })
+            }
         }
     }
 }

--- a/crates/runtimed/src/main.rs
+++ b/crates/runtimed/src/main.rs
@@ -388,6 +388,9 @@ async fn run_daemon(
     info!("  Blob store: {:?}", config.blob_store_dir);
     info!("  UV pool size: {}", config.uv_pool_size);
     info!("  Conda pool size: {}", config.conda_pool_size);
+    if std::env::var("RUNT_AGENT_MODE").as_deref() == Ok("1") {
+        info!("  Agent mode: ENABLED (kernels run in subprocess)");
+    }
 
     let daemon = match Daemon::new(config) {
         Ok(d) => d,

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -81,12 +81,14 @@ pub(crate) fn catch_automerge_panic<T>(label: &str, f: impl FnOnce() -> T) -> Re
     }
 }
 
-/// Check if agent mode is enabled for kernel execution.
+/// Check if agent mode is enabled on the daemon.
 ///
-/// Requires explicit opt-in via `RUNT_AGENT_MODE=1`.
-/// Agent mode is experimental and not yet enabled by default.
-fn is_agent_mode_enabled() -> bool {
-    std::env::var("RUNT_AGENT_MODE").as_deref() == Ok("1")
+/// Reads the daemon's in-memory flag, which is initialized from
+/// `RUNT_AGENT_MODE=1` and can be toggled at runtime via the pool IPC.
+fn is_agent_mode_enabled(daemon: &crate::daemon::Daemon) -> bool {
+    daemon
+        .agent_mode
+        .load(std::sync::atomic::Ordering::Relaxed)
 }
 
 /// Trust state for a notebook room.
@@ -3033,7 +3035,7 @@ async fn auto_launch_kernel(
     let prewarmed_packages = launched_config.prewarmed_packages.clone();
 
     // Agent mode: spawn subprocess instead of local kernel
-    if is_agent_mode_enabled() {
+    if is_agent_mode_enabled(&daemon) {
         info!("[notebook-sync] Agent mode: spawning agent subprocess for auto-launch");
 
         let nb_id = notebook_id.to_string();
@@ -3836,7 +3838,7 @@ async fn handle_notebook_request(
             // Check if agent mode is enabled.
             // Default: ON in dev mode (RUNTIMED_DEV=1), OFF in production.
             // Override: RUNT_AGENT_MODE=1 to force on, RUNT_AGENT_MODE=0 to force off.
-            if is_agent_mode_enabled() {
+            if is_agent_mode_enabled(&daemon) {
                 info!("[notebook-sync] RUNT_AGENT_MODE=1: spawning agent subprocess");
 
                 let notebook_id = room.notebook_path.read().await.display().to_string();

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -3036,14 +3036,6 @@ async fn auto_launch_kernel(
     if is_agent_mode_enabled() {
         info!("[notebook-sync] Agent mode: spawning agent subprocess for auto-launch");
 
-        // Replace the room's RuntimeStateDoc with an empty one.
-        // The agent owns the RuntimeStateDoc — it creates a scaffolded doc
-        // and syncs it to us. We start empty to avoid DuplicateSeqNumber.
-        {
-            let mut sd = room.state_doc.write().await;
-            *sd = RuntimeStateDoc::new_empty();
-        }
-
         let nb_id = notebook_id.to_string();
         let agent_id = format!("rt:agent:{}", &uuid::Uuid::new_v4().to_string()[..8]);
 
@@ -3073,6 +3065,14 @@ async fn auto_launch_kernel(
                     Ok(notebook_protocol::protocol::AgentResponse::KernelLaunched {
                         env_source: es,
                     }) => {
+                        // Agent launched successfully — the agent owns RuntimeStateDoc.
+                        // Replace coordinator's copy with empty so agent's sync populates it.
+                        // This is safe now because we know the agent is alive and will sync.
+                        {
+                            let mut sd = room.state_doc.write().await;
+                            *sd = RuntimeStateDoc::new_empty();
+                        }
+
                         let mut agent_guard = room.agent_handle.lock().await;
                         *agent_guard = Some(agent);
                         drop(kernel_guard);
@@ -3080,17 +3080,6 @@ async fn auto_launch_kernel(
 
                         publish_kernel_state_presence(room, presence::KernelStatus::Idle, &es)
                             .await;
-
-                        {
-                            let mut sd = room.state_doc.write().await;
-                            let mut changed = false;
-                            changed |= sd.set_kernel_status("idle");
-                            changed |= sd.set_kernel_info(kernel_type, kernel_type, &es);
-                            changed |= sd.set_prewarmed_packages(&prewarmed_packages);
-                            if changed {
-                                let _ = room.state_changed_tx.send(());
-                            }
-                        }
 
                         info!(
                             "[notebook-sync] Auto-launch via agent succeeded: {} kernel with {} environment",
@@ -3858,12 +3847,6 @@ async fn handle_notebook_request(
             if is_agent_mode_enabled() {
                 info!("[notebook-sync] RUNT_AGENT_MODE=1: spawning agent subprocess");
 
-                // Replace state_doc with empty — agent owns it
-                {
-                    let mut sd = room.state_doc.write().await;
-                    *sd = RuntimeStateDoc::new_empty();
-                }
-
                 let notebook_id = room.notebook_path.read().await.display().to_string();
                 let agent_id = format!("rt:agent:{}", &uuid::Uuid::new_v4().to_string()[..8]);
 
@@ -3891,6 +3874,13 @@ async fn handle_notebook_request(
                             Ok(notebook_protocol::protocol::AgentResponse::KernelLaunched {
                                 env_source: es,
                             }) => {
+                                // Agent launched — replace state_doc with empty
+                                // so agent's sync populates it cleanly.
+                                {
+                                    let mut sd = room.state_doc.write().await;
+                                    *sd = RuntimeStateDoc::new_empty();
+                                }
+
                                 let mut agent_guard = room.agent_handle.lock().await;
                                 *agent_guard = Some(agent);
                                 drop(kernel_guard);

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -83,16 +83,10 @@ pub(crate) fn catch_automerge_panic<T>(label: &str, f: impl FnOnce() -> T) -> Re
 
 /// Check if agent mode is enabled for kernel execution.
 ///
-/// - `RUNT_AGENT_MODE=1` → force ON
-/// - `RUNT_AGENT_MODE=0` → force OFF
-/// - unset + `RUNTIMED_DEV=1` → ON (dev mode default)
-/// - unset + production → OFF
+/// Requires explicit opt-in via `RUNT_AGENT_MODE=1`.
+/// Agent mode is experimental and not yet enabled by default.
 fn is_agent_mode_enabled() -> bool {
-    match std::env::var("RUNT_AGENT_MODE").as_deref() {
-        Ok("1") => true,
-        Ok("0") => false,
-        _ => std::env::var("RUNTIMED_DEV").as_deref() == Ok("1"),
-    }
+    std::env::var("RUNT_AGENT_MODE").as_deref() == Ok("1")
 }
 
 /// Trust state for a notebook room.

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -3067,6 +3067,15 @@ async fn auto_launch_kernel(
                     Ok(notebook_protocol::protocol::AgentResponse::KernelLaunched {
                         env_source: es,
                     }) => {
+                        // Replace coordinator's state_doc with empty to avoid
+                        // DuplicateSeqNumber when syncing with the agent.
+                        // The agent owns the scaffolded doc; we start fresh.
+                        {
+                            let mut sd = room.state_doc.write().await;
+                            *sd = RuntimeStateDoc::new_empty();
+                            sd.set_actor("coordinator:state");
+                        }
+
                         let mut agent_guard = room.agent_handle.lock().await;
                         *agent_guard = Some(agent);
                         drop(kernel_guard);
@@ -3869,10 +3878,11 @@ async fn handle_notebook_request(
                                 env_source: es,
                             }) => {
                                 // Agent launched — replace state_doc with empty
-                                // so agent's sync populates it cleanly.
+                                // to avoid DuplicateSeqNumber with agent's doc.
                                 {
                                     let mut sd = room.state_doc.write().await;
                                     *sd = RuntimeStateDoc::new_empty();
+                                    sd.set_actor("coordinator:state");
                                 }
 
                                 let mut agent_guard = room.agent_handle.lock().await;

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -1135,8 +1135,15 @@ impl NotebookRoom {
 
     /// Check if this room has an active kernel.
     pub async fn has_kernel(&self) -> bool {
+        // Check local kernel first
         let kernel = self.kernel.lock().await;
-        kernel.as_ref().is_some_and(|k| k.is_running())
+        if kernel.as_ref().is_some_and(|k| k.is_running()) {
+            return true;
+        }
+        drop(kernel);
+        // Check agent handle
+        let agent = self.agent_handle.lock().await;
+        agent.as_ref().is_some_and(|a| a.is_alive())
     }
 
     /// Get kernel info if a kernel is running.
@@ -4246,6 +4253,59 @@ async fn handle_notebook_request(
         }
 
         NotebookRequest::RunAllCells {} => {
+            // Agent path — read all cells, send each to agent
+            {
+                let agent_guard = room.agent_handle.lock().await;
+                if let Some(ref agent) = *agent_guard {
+                    let cells = {
+                        let doc = room.doc.read().await;
+                        doc.get_cells()
+                    };
+
+                    let mut queued = Vec::new();
+                    for cell in cells {
+                        if cell.cell_type == "code" {
+                            let execution_id = uuid::Uuid::new_v4().to_string();
+                            match agent
+                                .execute_cell(&cell.id, &cell.source, &execution_id)
+                                .await
+                            {
+                                Ok(notebook_protocol::protocol::AgentResponse::CellQueued {
+                                    cell_id,
+                                    execution_id,
+                                }) => {
+                                    queued.push(QueueEntry {
+                                        cell_id,
+                                        execution_id,
+                                    });
+                                }
+                                Ok(notebook_protocol::protocol::AgentResponse::Error { error }) => {
+                                    return NotebookResponse::Error {
+                                        error: format!(
+                                            "Agent failed to queue cell {}: {}",
+                                            cell.id, error
+                                        ),
+                                    };
+                                }
+                                _ => {}
+                            }
+                        }
+                    }
+
+                    // Stamp execution_ids in NotebookDoc
+                    {
+                        let mut doc = room.doc.write().await;
+                        for entry in &queued {
+                            let _ = doc.set_execution_id(&entry.cell_id, Some(&entry.execution_id));
+                        }
+                        let _ = room.changed_tx.send(());
+                    }
+
+                    return NotebookResponse::AllCellsQueued { queued };
+                }
+            }
+
+            // Local kernel path
             let mut kernel_guard = room.kernel.lock().await;
             if let Some(ref mut kernel) = *kernel_guard {
                 // Read all cells from the synced Automerge document

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -81,6 +81,20 @@ pub(crate) fn catch_automerge_panic<T>(label: &str, f: impl FnOnce() -> T) -> Re
     }
 }
 
+/// Check if agent mode is enabled for kernel execution.
+///
+/// - `RUNT_AGENT_MODE=1` → force ON
+/// - `RUNT_AGENT_MODE=0` → force OFF
+/// - unset + `RUNTIMED_DEV=1` → ON (dev mode default)
+/// - unset + production → OFF
+fn is_agent_mode_enabled() -> bool {
+    match std::env::var("RUNT_AGENT_MODE").as_deref() {
+        Ok("1") => true,
+        Ok("0") => false,
+        _ => std::env::var("RUNTIMED_DEV").as_deref() == Ok("1"),
+    }
+}
+
 /// Trust state for a notebook room.
 /// Tracks whether the notebook's dependencies are trusted for auto-launch.
 #[derive(Debug, Clone)]
@@ -3024,6 +3038,87 @@ async fn auto_launch_kernel(
     // Save prewarmed packages before launched_config is moved into kernel.launch()
     let prewarmed_packages = launched_config.prewarmed_packages.clone();
 
+    // Agent mode: spawn subprocess instead of local kernel
+    if is_agent_mode_enabled() {
+        info!("[notebook-sync] Agent mode: spawning agent subprocess for auto-launch");
+
+        let nb_id = notebook_id.to_string();
+        let agent_id = format!("rt:agent:{}", &uuid::Uuid::new_v4().to_string()[..8]);
+
+        match crate::agent_handle::AgentHandle::spawn(
+            nb_id,
+            agent_id,
+            room.blob_store.root().to_path_buf(),
+            room.state_doc.clone(),
+            room.state_changed_tx.clone(),
+            room.kernel_broadcast_tx.clone(),
+        )
+        .await
+        {
+            Ok(agent) => {
+                // Send LaunchKernel to the agent
+                match agent
+                    .launch_kernel(
+                        kernel_type,
+                        &env_source,
+                        notebook_path_opt
+                            .as_deref()
+                            .map(|p| p.to_str().unwrap_or("")),
+                        launched_config.clone(),
+                    )
+                    .await
+                {
+                    Ok(notebook_protocol::protocol::AgentResponse::KernelLaunched {
+                        env_source: es,
+                    }) => {
+                        let mut agent_guard = room.agent_handle.lock().await;
+                        *agent_guard = Some(agent);
+                        drop(kernel_guard);
+                        drop(agent_guard);
+
+                        publish_kernel_state_presence(room, presence::KernelStatus::Idle, &es)
+                            .await;
+
+                        {
+                            let mut sd = room.state_doc.write().await;
+                            let mut changed = false;
+                            changed |= sd.set_kernel_status("idle");
+                            changed |= sd.set_kernel_info(kernel_type, kernel_type, &es);
+                            changed |= sd.set_prewarmed_packages(&prewarmed_packages);
+                            if changed {
+                                let _ = room.state_changed_tx.send(());
+                            }
+                        }
+
+                        info!(
+                            "[notebook-sync] Auto-launch via agent succeeded: {} kernel with {} environment",
+                            kernel_type, es
+                        );
+                        return;
+                    }
+                    Ok(notebook_protocol::protocol::AgentResponse::Error { error }) => {
+                        warn!(
+                            "[notebook-sync] Agent kernel launch failed: {} — falling back to local",
+                            error
+                        );
+                        // Fall through to local launch below
+                    }
+                    _ => {
+                        warn!("[notebook-sync] Unexpected agent response — falling back to local");
+                        // Fall through to local launch below
+                    }
+                }
+            }
+            Err(e) => {
+                warn!(
+                    "[notebook-sync] Failed to spawn agent: {} — falling back to local kernel",
+                    e
+                );
+                // Fall through to local launch below
+            }
+        }
+    }
+
     match kernel
         .launch(
             kernel_type,
@@ -3755,8 +3850,10 @@ async fn handle_notebook_request(
                 }
             }
 
-            // Check if agent mode is enabled
-            if std::env::var("RUNT_AGENT_MODE").as_deref() == Ok("1") {
+            // Check if agent mode is enabled.
+            // Default: ON in dev mode (RUNTIMED_DEV=1), OFF in production.
+            // Override: RUNT_AGENT_MODE=1 to force on, RUNT_AGENT_MODE=0 to force off.
+            if is_agent_mode_enabled() {
                 info!("[notebook-sync] RUNT_AGENT_MODE=1: spawning agent subprocess");
 
                 let notebook_id = room.notebook_path.read().await.display().to_string();

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -3067,14 +3067,10 @@ async fn auto_launch_kernel(
                     Ok(notebook_protocol::protocol::AgentResponse::KernelLaunched {
                         env_source: es,
                     }) => {
-                        // Replace coordinator's state_doc with empty to avoid
-                        // DuplicateSeqNumber when syncing with the agent.
-                        // The agent owns the scaffolded doc; we start fresh.
-                        {
-                            let mut sd = room.state_doc.write().await;
-                            *sd = RuntimeStateDoc::new_empty();
-                            sd.set_actor("coordinator:state");
-                        }
+                        // No state_doc replacement needed — the agent bootstrapped
+                        // FROM the coordinator's doc (like frontend NotebookDoc).
+                        // The coordinator keeps its scaffolded doc; the agent
+                        // writes with a different actor. No DuplicateSeqNumber.
 
                         let mut agent_guard = room.agent_handle.lock().await;
                         *agent_guard = Some(agent);
@@ -3879,12 +3875,6 @@ async fn handle_notebook_request(
                             }) => {
                                 // Agent launched — replace state_doc with empty
                                 // to avoid DuplicateSeqNumber with agent's doc.
-                                {
-                                    let mut sd = room.state_doc.write().await;
-                                    *sd = RuntimeStateDoc::new_empty();
-                                    sd.set_actor("coordinator:state");
-                                }
-
                                 let mut agent_guard = room.agent_handle.lock().await;
                                 *agent_guard = Some(agent);
                                 drop(kernel_guard);

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -3063,7 +3063,7 @@ async fn auto_launch_kernel(
         )
         .await
         {
-            Ok(agent) => {
+            Ok(mut agent) => {
                 // Send LaunchKernel to the agent
                 match agent
                     .launch_kernel(
@@ -3883,7 +3883,7 @@ async fn handle_notebook_request(
                 )
                 .await
                 {
-                    Ok(agent) => {
+                    Ok(mut agent) => {
                         // Send LaunchKernel to the agent
                         match agent
                             .launch_kernel(
@@ -4095,8 +4095,8 @@ async fn handle_notebook_request(
 
             // Check for agent-backed kernel first
             {
-                let agent_guard = room.agent_handle.lock().await;
-                if let Some(ref agent) = *agent_guard {
+                let mut agent_guard = room.agent_handle.lock().await;
+                if let Some(ref mut agent) = *agent_guard {
                     let execution_id = uuid::Uuid::new_v4().to_string();
                     // Stamp execution_id on the cell before sending to agent
                     {
@@ -4245,8 +4245,8 @@ async fn handle_notebook_request(
         NotebookRequest::InterruptExecution {} => {
             // Agent path
             {
-                let agent_guard = room.agent_handle.lock().await;
-                if let Some(ref agent) = *agent_guard {
+                let mut agent_guard = room.agent_handle.lock().await;
+                if let Some(ref mut agent) = *agent_guard {
                     return match agent.interrupt().await {
                         Ok(_) => NotebookResponse::InterruptSent {},
                         Err(e) => NotebookResponse::Error {
@@ -4366,8 +4366,8 @@ async fn handle_notebook_request(
         NotebookRequest::RunAllCells {} => {
             // Agent path — read all cells, send each to agent
             {
-                let agent_guard = room.agent_handle.lock().await;
-                if let Some(ref agent) = *agent_guard {
+                let mut agent_guard = room.agent_handle.lock().await;
+                if let Some(ref mut agent) = *agent_guard {
                     let cells = {
                         let doc = room.doc.read().await;
                         doc.get_cells()
@@ -4506,8 +4506,8 @@ async fn handle_notebook_request(
         NotebookRequest::SendComm { message } => {
             // Agent path
             {
-                let agent_guard = room.agent_handle.lock().await;
-                if let Some(ref agent) = *agent_guard {
+                let mut agent_guard = room.agent_handle.lock().await;
+                if let Some(ref mut agent) = *agent_guard {
                     return match agent.send_comm(message).await {
                         Ok(_) => NotebookResponse::Ok {},
                         Err(e) => NotebookResponse::Error {
@@ -4556,8 +4556,8 @@ async fn handle_notebook_request(
         NotebookRequest::GetHistory { pattern, n, unique } => {
             // Agent path
             {
-                let agent_guard = room.agent_handle.lock().await;
-                if let Some(ref agent) = *agent_guard {
+                let mut agent_guard = room.agent_handle.lock().await;
+                if let Some(ref mut agent) = *agent_guard {
                     return match agent.get_history(pattern.as_deref(), n, unique).await {
                         Ok(notebook_protocol::protocol::AgentResponse::HistoryResult {
                             entries,
@@ -4591,8 +4591,8 @@ async fn handle_notebook_request(
         NotebookRequest::Complete { code, cursor_pos } => {
             // Agent path
             {
-                let agent_guard = room.agent_handle.lock().await;
-                if let Some(ref agent) = *agent_guard {
+                let mut agent_guard = room.agent_handle.lock().await;
+                if let Some(ref mut agent) = *agent_guard {
                     return match agent.complete(&code, cursor_pos).await {
                         Ok(notebook_protocol::protocol::AgentResponse::CompletionResult {
                             items,

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -3065,14 +3065,6 @@ async fn auto_launch_kernel(
                     Ok(notebook_protocol::protocol::AgentResponse::KernelLaunched {
                         env_source: es,
                     }) => {
-                        // Agent launched successfully — the agent owns RuntimeStateDoc.
-                        // Replace coordinator's copy with empty so agent's sync populates it.
-                        // This is safe now because we know the agent is alive and will sync.
-                        {
-                            let mut sd = room.state_doc.write().await;
-                            *sd = RuntimeStateDoc::new_empty();
-                        }
-
                         let mut agent_guard = room.agent_handle.lock().await;
                         *agent_guard = Some(agent);
                         drop(kernel_guard);

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -86,9 +86,7 @@ pub(crate) fn catch_automerge_panic<T>(label: &str, f: impl FnOnce() -> T) -> Re
 /// Reads the daemon's in-memory flag, which is initialized from
 /// `RUNT_AGENT_MODE=1` and can be toggled at runtime via the pool IPC.
 fn is_agent_mode_enabled(daemon: &crate::daemon::Daemon) -> bool {
-    daemon
-        .agent_mode
-        .load(std::sync::atomic::Ordering::Relaxed)
+    daemon.agent_mode.load(std::sync::atomic::Ordering::Relaxed)
 }
 
 /// Trust state for a notebook room.
@@ -893,6 +891,8 @@ pub struct NotebookRoom {
     /// instead of the local `RoomKernel`. Set by `LaunchKernel` when
     /// `RUNT_AGENT_MODE=1`.
     pub agent_handle: Arc<Mutex<Option<crate::agent_handle::AgentHandle>>>,
+    /// Environment path used by an agent-backed kernel, for GC protection.
+    pub agent_env_path: Arc<RwLock<Option<PathBuf>>>,
 }
 
 /// Maximum number of snapshots to keep per notebook hash.
@@ -1076,6 +1076,7 @@ impl NotebookRoom {
             state_doc,
             state_changed_tx,
             agent_handle: Arc::new(Mutex::new(None)),
+            agent_env_path: Arc::new(RwLock::new(None)),
         }
     }
 
@@ -1140,6 +1141,7 @@ impl NotebookRoom {
             state_doc,
             state_changed_tx,
             agent_handle: Arc::new(Mutex::new(None)),
+            agent_env_path: Arc::new(RwLock::new(None)),
         }
     }
 
@@ -1156,20 +1158,37 @@ impl NotebookRoom {
         agent.as_ref().is_some_and(|a| a.is_alive())
     }
 
-    /// Get kernel info if a kernel is running.
+    /// Get kernel info if a kernel is running (local or agent-backed).
+    ///
+    /// For agent-backed kernels, reads from RuntimeStateDoc (source of truth).
     pub async fn kernel_info(&self) -> Option<(String, String, String)> {
+        // Check local kernel first
         let kernel = self.kernel.lock().await;
-        kernel.as_ref().and_then(|k| {
+        if let Some(k) = kernel.as_ref() {
             if k.is_running() {
-                Some((
+                return Some((
                     k.kernel_type().to_string(),
                     k.env_source().to_string(),
                     k.status().to_string(),
-                ))
-            } else {
-                None
+                ));
             }
-        })
+        }
+        drop(kernel);
+
+        // Check agent — read from RuntimeStateDoc
+        let agent = self.agent_handle.lock().await;
+        if agent.as_ref().is_some_and(|a| a.is_alive()) {
+            let sd = self.state_doc.read().await;
+            let state = sd.read_state();
+            if state.kernel.status != "not_started" && !state.kernel.status.is_empty() {
+                return Some((
+                    state.kernel.name.clone(),
+                    state.kernel.env_source.clone(),
+                    state.kernel.status.clone(),
+                ));
+            }
+        }
+        None
     }
 }
 
@@ -3077,6 +3096,12 @@ async fn auto_launch_kernel(
                         drop(kernel_guard);
                         drop(agent_guard);
 
+                        // Store env path for GC protection
+                        if let Some(ref env) = pooled_env {
+                            let mut ep = room.agent_env_path.write().await;
+                            *ep = Some(env.venv_path.clone());
+                        }
+
                         publish_kernel_state_presence(room, presence::KernelStatus::Idle, &es)
                             .await;
 
@@ -4302,20 +4327,35 @@ async fn handle_notebook_request(
         }
 
         NotebookRequest::GetKernelInfo {} => {
+            // Try local kernel first, then RuntimeStateDoc (covers agent mode)
             let kernel_guard = room.kernel.lock().await;
             if let Some(ref kernel) = *kernel_guard {
                 if kernel.is_running() {
-                    NotebookResponse::KernelInfo {
+                    return NotebookResponse::KernelInfo {
                         kernel_type: Some(kernel.kernel_type().to_string()),
                         env_source: Some(kernel.env_source().to_string()),
                         status: kernel.status().to_string(),
-                    }
-                } else {
-                    NotebookResponse::KernelInfo {
-                        kernel_type: None,
-                        env_source: None,
-                        status: "not_started".to_string(),
-                    }
+                    };
+                }
+            }
+            drop(kernel_guard);
+
+            // Read from RuntimeStateDoc (works for both local and agent-backed kernels)
+            let sd = room.state_doc.read().await;
+            let state = sd.read_state();
+            if state.kernel.status != "not_started" && !state.kernel.status.is_empty() {
+                NotebookResponse::KernelInfo {
+                    kernel_type: if state.kernel.name.is_empty() {
+                        None
+                    } else {
+                        Some(state.kernel.name)
+                    },
+                    env_source: if state.kernel.env_source.is_empty() {
+                        None
+                    } else {
+                        Some(state.kernel.env_source)
+                    },
+                    status: state.kernel.status,
                 }
             } else {
                 NotebookResponse::KernelInfo {
@@ -4327,17 +4367,33 @@ async fn handle_notebook_request(
         }
 
         NotebookRequest::GetQueueState {} => {
+            // Try local kernel first
             let kernel_guard = room.kernel.lock().await;
             if let Some(ref kernel) = *kernel_guard {
-                NotebookResponse::QueueState {
+                return NotebookResponse::QueueState {
                     executing: kernel.executing_entry(),
                     queued: kernel.queued_cells(),
-                }
-            } else {
-                NotebookResponse::QueueState {
-                    executing: None,
-                    queued: vec![],
-                }
+                };
+            }
+            drop(kernel_guard);
+
+            // Read from RuntimeStateDoc (works for agent-backed kernels)
+            let sd = room.state_doc.read().await;
+            let state = sd.read_state();
+            NotebookResponse::QueueState {
+                executing: state.queue.executing.map(|e| QueueEntry {
+                    cell_id: e.cell_id,
+                    execution_id: e.execution_id,
+                }),
+                queued: state
+                    .queue
+                    .queued
+                    .into_iter()
+                    .map(|e| QueueEntry {
+                        cell_id: e.cell_id,
+                        execution_id: e.execution_id,
+                    })
+                    .collect(),
             }
         }
 
@@ -7684,6 +7740,7 @@ mod tests {
             state_doc,
             state_changed_tx,
             agent_handle: Arc::new(Mutex::new(None)),
+            agent_env_path: Arc::new(RwLock::new(None)),
         };
 
         (room, notebook_path)

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -3042,6 +3042,14 @@ async fn auto_launch_kernel(
     if is_agent_mode_enabled() {
         info!("[notebook-sync] Agent mode: spawning agent subprocess for auto-launch");
 
+        // Replace the room's RuntimeStateDoc with an empty one.
+        // The agent owns the RuntimeStateDoc — it creates a scaffolded doc
+        // and syncs it to us. We start empty to avoid DuplicateSeqNumber.
+        {
+            let mut sd = room.state_doc.write().await;
+            *sd = RuntimeStateDoc::new_empty();
+        }
+
         let nb_id = notebook_id.to_string();
         let agent_id = format!("rt:agent:{}", &uuid::Uuid::new_v4().to_string()[..8]);
 
@@ -3855,6 +3863,12 @@ async fn handle_notebook_request(
             // Override: RUNT_AGENT_MODE=1 to force on, RUNT_AGENT_MODE=0 to force off.
             if is_agent_mode_enabled() {
                 info!("[notebook-sync] RUNT_AGENT_MODE=1: spawning agent subprocess");
+
+                // Replace state_doc with empty — agent owns it
+                {
+                    let mut sd = room.state_doc.write().await;
+                    *sd = RuntimeStateDoc::new_empty();
+                }
 
                 let notebook_id = room.notebook_path.read().await.display().to_string();
                 let agent_id = format!("rt:agent:{}", &uuid::Uuid::new_v4().to_string()[..8]);

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -3748,6 +3748,89 @@ async fn handle_notebook_request(
                 }
             }
 
+            // Check if agent mode is enabled
+            if std::env::var("RUNT_AGENT_MODE").as_deref() == Ok("1") {
+                info!("[notebook-sync] RUNT_AGENT_MODE=1: spawning agent subprocess");
+
+                let notebook_id = room.notebook_path.read().await.display().to_string();
+                let agent_id = format!("rt:agent:{}", &uuid::Uuid::new_v4().to_string()[..8]);
+
+                match crate::agent_handle::AgentHandle::spawn(
+                    notebook_id,
+                    agent_id,
+                    room.blob_store.root().to_path_buf(),
+                    room.state_doc.clone(),
+                    room.state_changed_tx.clone(),
+                    room.kernel_broadcast_tx.clone(),
+                )
+                .await
+                {
+                    Ok(agent) => {
+                        // Send LaunchKernel to the agent
+                        match agent
+                            .launch_kernel(
+                                &resolved_kernel_type,
+                                &resolved_env_source,
+                                notebook_path.as_deref().map(|p| p.to_str().unwrap_or("")),
+                                launched_config.clone(),
+                            )
+                            .await
+                        {
+                            Ok(notebook_protocol::protocol::AgentResponse::KernelLaunched {
+                                env_source: es,
+                            }) => {
+                                let mut agent_guard = room.agent_handle.lock().await;
+                                *agent_guard = Some(agent);
+                                drop(kernel_guard);
+                                drop(agent_guard);
+
+                                publish_kernel_state_presence(
+                                    room,
+                                    presence::KernelStatus::Idle,
+                                    &es,
+                                )
+                                .await;
+
+                                return NotebookResponse::KernelLaunched {
+                                    kernel_type: resolved_kernel_type,
+                                    env_source: es,
+                                    launched_config,
+                                };
+                            }
+                            Ok(notebook_protocol::protocol::AgentResponse::Error { error }) => {
+                                reset_starting_state(room).await;
+                                return NotebookResponse::Error {
+                                    error: format!("Agent kernel launch failed: {}", error),
+                                };
+                            }
+                            Ok(_) => {
+                                reset_starting_state(room).await;
+                                return NotebookResponse::Error {
+                                    error: "Unexpected agent response".to_string(),
+                                };
+                            }
+                            Err(e) => {
+                                reset_starting_state(room).await;
+                                return NotebookResponse::Error {
+                                    error: format!("Agent communication error: {}", e),
+                                };
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        warn!(
+                            "[notebook-sync] Failed to spawn agent, falling back to local: {}",
+                            e
+                        );
+                        reset_starting_state(room).await;
+                        return NotebookResponse::Error {
+                            error: format!("Failed to spawn agent: {}", e),
+                        };
+                    }
+                }
+            }
+
+            // Local kernel path
             match kernel
                 .launch(
                     &resolved_kernel_type,

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -3791,6 +3791,25 @@ async fn handle_notebook_request(
                                 )
                                 .await;
 
+                                // Write kernel status + info + prewarmed packages
+                                // to RuntimeStateDoc (mirrors the local launch path)
+                                {
+                                    let mut sd = room.state_doc.write().await;
+                                    let mut changed = false;
+                                    changed |= sd.set_kernel_status("idle");
+                                    changed |= sd.set_kernel_info(
+                                        &resolved_kernel_type,
+                                        &resolved_kernel_type,
+                                        &es,
+                                    );
+                                    changed |= sd.set_prewarmed_packages(
+                                        &launched_config.prewarmed_packages,
+                                    );
+                                    if changed {
+                                        let _ = room.state_changed_tx.send(());
+                                    }
+                                }
+
                                 return NotebookResponse::KernelLaunched {
                                     kernel_type: resolved_kernel_type,
                                     env_source: es,
@@ -3819,13 +3838,10 @@ async fn handle_notebook_request(
                     }
                     Err(e) => {
                         warn!(
-                            "[notebook-sync] Failed to spawn agent, falling back to local: {}",
+                            "[notebook-sync] Failed to spawn agent: {} — falling back to local kernel",
                             e
                         );
-                        reset_starting_state(room).await;
-                        return NotebookResponse::Error {
-                            error: format!("Failed to spawn agent: {}", e),
-                        };
+                        // Fall through to local kernel.launch() below
                     }
                 }
             }

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -1319,3 +1319,81 @@ async fn test_pipe_mode_preserves_frame_order() {
     pool_client.shutdown().await.ok();
     let _ = tokio::time::timeout(Duration::from_secs(2), daemon_handle).await;
 }
+
+/// Test that agent mode spawns a subprocess and can dispatch cell execution.
+///
+/// Sets RUNT_AGENT_MODE=1, creates a notebook, connects, and verifies
+/// the agent mode code path is exercised. Note: actual kernel execution
+/// requires a Python env (pool size is 0 in test config), so we verify
+/// the dispatch path rather than full execution.
+#[tokio::test]
+#[cfg(unix)]
+async fn test_agent_mode_dispatch() {
+    // Enable agent mode for this test
+    std::env::set_var("RUNT_AGENT_MODE", "1");
+
+    let temp_dir = TempDir::new().unwrap();
+    let config = test_config(&temp_dir);
+    let socket_path = config.socket_path.clone();
+
+    let daemon = Daemon::new(config).unwrap();
+    let daemon_handle = tokio::spawn(async move {
+        daemon.run().await.ok();
+    });
+
+    let pool_client = PoolClient::new(socket_path.clone());
+    assert!(wait_for_daemon(&pool_client, Duration::from_secs(5)).await);
+
+    // Create a notebook
+    let result = connect::connect_create(socket_path.clone(), "python", None, "test")
+        .await
+        .unwrap();
+    let client = result.handle;
+
+    // Add a cell
+    client.add_cell_after("c1", "code", None).unwrap();
+    client.update_source("c1", "print('agent test')").unwrap();
+
+    // Wait for sync
+    let mut watcher = client.subscribe();
+    for _ in 0..5 {
+        match tokio::time::timeout(Duration::from_millis(200), watcher.changed()).await {
+            Ok(Ok(())) => {}
+            _ => break,
+        }
+    }
+
+    // Verify cell exists
+    let cells = client.get_cells();
+    assert!(!cells.is_empty(), "Should have at least one cell");
+    assert_eq!(cells[0].id, "c1");
+
+    // Try to execute — may fail with NoKernel since pool is empty,
+    // but the agent dispatch path should be exercised
+    let response = client
+        .send_request(NotebookRequest::ExecuteCell {
+            cell_id: "c1".to_string(),
+        })
+        .await
+        .unwrap();
+
+    // With pool_size=0, we expect NoKernel (no env to give the agent)
+    // or an error from the agent failing to launch.
+    // The important thing is we didn't panic.
+    match &response {
+        NotebookResponse::CellQueued { .. } => {
+            // Agent launched and queued — great!
+        }
+        NotebookResponse::NoKernel {} | NotebookResponse::Error { .. } => {
+            // Expected with empty pool — agent couldn't get an env
+        }
+        _ => {
+            panic!("Unexpected response in agent mode: {:?}", response);
+        }
+    }
+
+    // Cleanup
+    std::env::remove_var("RUNT_AGENT_MODE");
+    pool_client.shutdown().await.ok();
+    let _ = tokio::time::timeout(Duration::from_secs(2), daemon_handle).await;
+}


### PR DESCRIPTION
## Summary

Activates the agent subprocess path behind `RUNT_AGENT_MODE=1` env var.

When set, LaunchKernel spawns an `AgentHandle` subprocess instead of creating a local `RoomKernel`. The coordinator still handles:
- Env resolution (pool, inline deps, PEP 723, project files)
- Trust verification
- Starting phase transitions in RuntimeStateDoc

The resolved config is sent to the agent via `AgentRequest::LaunchKernel`.

Also adds `BlobStore::root()` accessor.

## Test plan

- [ ] Default (no env var): existing behavior unchanged
- [ ] `RUNT_AGENT_MODE=1`: kernel launches via agent subprocess
- [ ] Execute cells, verify outputs appear
- [ ] `cargo xtask lint` / `cargo test`

Part of #1333, #832