### PR TITLE
fix(sync): use ReplaySubject so initial sync retry timer always arms

### DIFF
--- a/packages/runtimed/src/sync-engine.ts
+++ b/packages/runtimed/src/sync-engine.ts
@@ -25,6 +25,7 @@ import {
   from,
   mergeMap,
   Observable,
+  ReplaySubject,
   share,
   Subject,
   Subscription,
@@ -238,8 +239,11 @@ export class SyncEngine {
     });
     sub.add(() => unlisten());
 
-    // Subject for the sync retry timer
-    const retrySync$ = new Subject<void>();
+    // ReplaySubject(1) so the initial .next() replays to late subscribers.
+    // A plain Subject would lose the emission since the retry subscriber
+    // is wired up after this point — leaving the retry timer permanently
+    // unarmed when no sync frames arrive (see #1417).
+    const retrySync$ = new ReplaySubject<void>(1);
     sub.add(() => retrySync$.complete());
 
     // Arm the retry timer immediately


### PR DESCRIPTION
## Summary

- Fix first-launch "stuck at Initializing" bug caused by a race between Tauri relay frame emission and JS event subscription
- The `retrySync$` Subject emitted `.next()` before its subscriber existed — the initial emission was lost, so the 3-second retry timer never armed
- Switch to `ReplaySubject(1)` so the emission replays to the late subscriber, guaranteeing recovery within 3 seconds even when the race hits

The race window is widest on first launch with new assets because WebKit must recompile the WASM binary (new hash), making `wasmReady` take longer. On cached launches the window is tiny and sync completes normally.

## Test plan

- [ ] Build with `cargo xtask build`, clear WASM cache (`~/Library/Caches/org.nteract.desktop.nightly/`), launch — should complete init within 3s
- [ ] Verify logs show either immediate sync or retry-then-sync (`[sync-engine] Retrying sync after timeout` → `[sync-engine] Initial sync complete`)
- [ ] Existing unit tests pass (`pnpm test` in packages/runtimed)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)