### PR TITLE
feat: persist agent_mode in settings doc

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -7,4 +7,3 @@ PATH_add bin
 
 export RUNTIMED_WORKSPACE_PATH="$(expand_path .)"
 export RUNTIMED_DEV=1
-export RUNT_AGENT_MODE=1

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -583,12 +583,14 @@ async fn async_main(command: Option<Commands>) -> Result<()> {
                 println!("Agent mode disabled — new kernels will run in-process");
             }
             AgentCommands::Status => {
-                // Check env var (can't query daemon for current state yet)
-                let env_enabled = std::env::var("RUNT_AGENT_MODE").as_deref() == Ok("1");
+                // Read from settings doc (persisted)
+                let settings_path = runtimed::default_settings_doc_path();
+                let settings =
+                    runtimed::settings_doc::SettingsDoc::load_or_create(&settings_path, None);
+                let enabled = settings.get_all().agent_mode;
                 println!(
-                    "Agent mode: {} (env RUNT_AGENT_MODE={})",
-                    if env_enabled { "enabled" } else { "disabled" },
-                    if env_enabled { "1" } else { "unset" }
+                    "Agent mode: {}",
+                    if enabled { "enabled" } else { "disabled" }
                 );
             }
         },

--- a/crates/runtimed-client/src/settings_doc.rs
+++ b/crates/runtimed-client/src/settings_doc.rs
@@ -178,6 +178,12 @@ pub struct SyncedSettings {
     /// When false, the app shows the onboarding screen on startup.
     #[serde(default)]
     pub onboarding_completed: bool,
+
+    /// Run kernels in agent subprocesses (process isolation).
+    /// When true, each notebook's kernel runs in a separate `runtimed agent`
+    /// process. When false, kernels run in-process (default).
+    #[serde(default)]
+    pub agent_mode: bool,
 }
 
 impl Default for SyncedSettings {
@@ -190,6 +196,7 @@ impl Default for SyncedSettings {
             conda: CondaDefaults::default(),
             keep_alive_secs: DEFAULT_KEEP_ALIVE_SECS,
             onboarding_completed: false,
+            agent_mode: false,
         }
     }
 }
@@ -248,6 +255,8 @@ impl SettingsDoc {
         );
         // Store onboarding_completed as boolean
         let _ = doc.put(automerge::ROOT, "onboarding_completed", false);
+        // Store agent_mode as boolean
+        let _ = doc.put(automerge::ROOT, "agent_mode", false);
 
         // Nested uv map with empty package list
         if let Ok(uv_id) = doc.put_object(automerge::ROOT, "uv", ObjType::Map) {
@@ -343,6 +352,10 @@ impl SettingsDoc {
         // onboarding_completed: boolean
         if let Some(completed) = json.get("onboarding_completed").and_then(|v| v.as_bool()) {
             settings.put_bool("onboarding_completed", completed);
+        }
+        // agent_mode: boolean
+        if let Some(agent) = json.get("agent_mode").and_then(|v| v.as_bool()) {
+            settings.put_bool("agent_mode", agent);
         }
 
         let uv_packages = Self::extract_packages_from_json(json, "uv");
@@ -714,6 +727,7 @@ impl SettingsDoc {
                 // Check if this is an existing user by looking for other settings
                 self.get("theme").is_some() || self.get("default_runtime").is_some()
             }),
+            agent_mode: self.get_bool("agent_mode").unwrap_or(false),
         }
     }
 
@@ -794,6 +808,19 @@ impl SettingsDoc {
                     current, completed
                 );
                 self.put_bool("onboarding_completed", completed);
+                changed = true;
+            }
+        }
+
+        // agent_mode: boolean
+        if let Some(agent) = json.get("agent_mode").and_then(|v| v.as_bool()) {
+            let current = self.get_bool("agent_mode");
+            if current != Some(agent) {
+                info!(
+                    "[settings] apply_json_changes: agent_mode changed {:?} -> {}",
+                    current, agent
+                );
+                self.put_bool("agent_mode", agent);
                 changed = true;
             }
         }
@@ -1453,5 +1480,40 @@ mod tests {
 
         // Missing key is not the same as null
         assert!(!doc.is_null("keep_alive_secs"));
+    }
+
+    #[test]
+    fn test_agent_mode_default_off() {
+        let doc = SettingsDoc::new();
+        let settings = doc.get_all();
+        assert!(!settings.agent_mode, "agent_mode should default to false");
+    }
+
+    #[test]
+    fn test_agent_mode_toggle_persists() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+
+        // Create settings, enable agent mode, save
+        let mut doc = SettingsDoc::new();
+        assert!(!doc.get_all().agent_mode);
+        doc.put_bool("agent_mode", true);
+        doc.save_to_file(tmp.path()).unwrap();
+
+        // Load from disk — should still be enabled
+        let loaded = SettingsDoc::load_or_create(tmp.path(), None);
+        assert!(loaded.get_all().agent_mode, "agent_mode should persist");
+    }
+
+    #[test]
+    fn test_agent_mode_json_migration() {
+        let json: serde_json::Value = serde_json::json!({
+            "agent_mode": true,
+            "default_runtime": "python"
+        });
+        let doc = SettingsDoc::from_json(&json);
+        assert!(
+            doc.get_all().agent_mode,
+            "agent_mode should migrate from JSON"
+        );
     }
 }

--- a/crates/runtimed-client/src/sync_client.rs
+++ b/crates/runtimed-client/src/sync_client.rs
@@ -441,6 +441,7 @@ pub fn get_all_from_doc(doc: &AutoCommit) -> SyncedSettings {
         // assume they're upgrading from before onboarding was added → treat as completed
         onboarding_completed: get_bool("onboarding_completed")
             .unwrap_or_else(|| get_str("theme").is_some() || get_str("default_runtime").is_some()),
+        agent_mode: get_bool("agent_mode").unwrap_or(false),
     }
 }
 

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -402,8 +402,8 @@ impl Daemon {
 
         let blob_store = Arc::new(BlobStore::new(config.blob_store_dir.clone()));
 
-        // Initialize agent mode from env var
-        let agent_mode = std::env::var("RUNT_AGENT_MODE").as_deref() == Ok("1");
+        // Initialize agent mode from persisted settings
+        let agent_mode = settings.get_all().agent_mode;
 
         Ok(Arc::new(Self {
             uv_pool: Mutex::new(Pool::new(config.uv_pool_size, config.max_age_secs)),
@@ -1882,6 +1882,12 @@ impl Daemon {
             Request::SetAgentMode { enabled } => {
                 self.agent_mode
                     .store(enabled, std::sync::atomic::Ordering::Relaxed);
+                // Persist to settings doc so it survives daemon restarts
+                {
+                    let mut settings = self.settings.blocking_write();
+                    settings.put_bool("agent_mode", enabled);
+                    let _ = settings.save_to_file(&crate::default_settings_doc_path());
+                }
                 info!(
                     "[runtimed] Agent mode {}",
                     if enabled { "ENABLED" } else { "DISABLED" }

--- a/crates/runtimed/src/main.rs
+++ b/crates/runtimed/src/main.rs
@@ -388,12 +388,16 @@ async fn run_daemon(
     info!("  Blob store: {:?}", config.blob_store_dir);
     info!("  UV pool size: {}", config.uv_pool_size);
     info!("  Conda pool size: {}", config.conda_pool_size);
-    if std::env::var("RUNT_AGENT_MODE").as_deref() == Ok("1") {
-        info!("  Agent mode: ENABLED (kernels run in subprocess)");
-    }
+    // Agent mode status is logged after daemon initialization
+    // (reads from persisted settings)
 
     let daemon = match Daemon::new(config) {
-        Ok(d) => d,
+        Ok(d) => {
+            if d.agent_mode.load(std::sync::atomic::Ordering::Relaxed) {
+                info!("  Agent mode: ENABLED (kernels run in subprocess)");
+            }
+            d
+        }
         Err(e) => {
             // Another daemon is already running — this is expected during
             // launchd double-start races, NOT a crash. Exit 0 so launchd's

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -81,10 +81,10 @@ pub(crate) fn catch_automerge_panic<T>(label: &str, f: impl FnOnce() -> T) -> Re
     }
 }
 
-/// Check if agent mode is enabled on the daemon.
+/// Check if agent mode is enabled.
 ///
-/// Reads the daemon's in-memory flag, which is initialized from
-/// `RUNT_AGENT_MODE=1` and can be toggled at runtime via the pool IPC.
+/// Reads from the daemon's in-memory flag, which is initialized from
+/// the persisted settings doc and toggled via `runt agent enable/disable`.
 fn is_agent_mode_enabled(daemon: &crate::daemon::Daemon) -> bool {
     daemon.agent_mode.load(std::sync::atomic::Ordering::Relaxed)
 }


### PR DESCRIPTION
Agent mode now persists across daemon restarts via the settings doc.

- `runt agent enable` → writes to settings, daemon reads on startup
- Removed RUNT_AGENT_MODE env var (can't set on launchd daemons)
- 3 new tests for persistence

Fixes the bug where agent mode was lost on every daemon restart.