### PR TITLE
fix: add agent_mode to SyncedSettings in notebook crate

### DIFF
--- a/crates/notebook/src/settings.rs
+++ b/crates/notebook/src/settings.rs
@@ -80,6 +80,10 @@ pub fn load_settings() -> SyncedSettings {
             .get("onboarding_completed")
             .and_then(|v| serde_json::from_value(v.clone()).ok())
             .unwrap_or(true),
+        agent_mode: json
+            .get("agent_mode")
+            .and_then(|v| serde_json::from_value(v.clone()).ok())
+            .unwrap_or(false),
     }
 }
 
@@ -110,6 +114,7 @@ mod tests {
             conda: CondaDefaults::default(),
             keep_alive_secs: 30,
             onboarding_completed: false,
+            agent_mode: false,
         };
 
         let json = serde_json::to_string(&settings).unwrap();
@@ -253,6 +258,10 @@ mod tests {
                 .get("onboarding_completed")
                 .and_then(|v| serde_json::from_value(v.clone()).ok())
                 .unwrap_or(defaults.onboarding_completed),
+            agent_mode: json_val
+                .get("agent_mode")
+                .and_then(|v| serde_json::from_value(v.clone()).ok())
+                .unwrap_or(defaults.agent_mode),
         };
         // Valid fields are preserved
         assert_eq!(settings.theme, ThemeMode::Dark);


### PR DESCRIPTION
Missing field caused all 3 nightly notebook builds to fail. Critical fix.