### PR TITLE
feat(settings): add collapsible Feature Flags section with agent mode toggle

### DIFF
--- a/apps/notebook/settings/App.tsx
+++ b/apps/notebook/settings/App.tsx
@@ -1,6 +1,12 @@
-import { AlertCircle, Monitor, Moon, Sun, X } from "lucide-react";
+import { AlertCircle, ChevronDown, Monitor, Moon, Sun, X } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
 import { Slider } from "@/components/ui/slider";
+import { Switch } from "@/components/ui/switch";
 import {
   isKnownPythonEnv,
   isKnownRuntime,
@@ -197,6 +203,22 @@ function PackageBadgeInput({
   );
 }
 
+interface FeatureFlag {
+  id: string;
+  label: string;
+  description: string;
+  settingKey: "agentMode";
+}
+
+const FEATURE_FLAGS: FeatureFlag[] = [
+  {
+    id: "agent_mode",
+    label: "Agent Process",
+    description: "Run kernels in isolated subprocesses",
+    settingKey: "agentMode",
+  },
+];
+
 const themeOptions: { value: ThemeMode; label: string; icon: typeof Sun }[] = [
   { value: "light", label: "Light", icon: Sun },
   { value: "dark", label: "Dark", icon: Moon },
@@ -220,6 +242,8 @@ export default function App() {
     setDefaultCondaPackages,
     keepAliveSecs,
     setKeepAliveSecs,
+    agentMode,
+    setAgentMode,
   } = useSyncedSettings();
 
   return (
@@ -410,6 +434,49 @@ export default function App() {
 
         {/* Advanced */}
         <KeepAliveSlider value={keepAliveSecs} onChange={setKeepAliveSecs} />
+
+        {/* Feature Flags */}
+        <Collapsible className="space-y-2 pt-4 border-t border-border/50">
+          <CollapsibleTrigger className="flex items-center gap-1.5 w-full group">
+            <ChevronDown className="h-3.5 w-3.5 text-muted-foreground transition-transform group-data-[state=closed]:-rotate-90" />
+            <span className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+              Feature Flags
+            </span>
+          </CollapsibleTrigger>
+          <CollapsibleContent className="space-y-3">
+            {FEATURE_FLAGS.length === 0 ? (
+              <p className="text-[11px] text-muted-foreground/70 pl-5">
+                No feature flags available
+              </p>
+            ) : (
+              FEATURE_FLAGS.map((flag) => (
+                <div
+                  key={flag.id}
+                  className="flex items-center justify-between pl-5"
+                >
+                  <div className="space-y-0.5">
+                    <span className="text-sm text-foreground">
+                      {flag.label}
+                    </span>
+                    <p className="text-[10px] text-muted-foreground/70">
+                      {flag.description}
+                    </p>
+                  </div>
+                  <Switch
+                    checked={
+                      flag.settingKey === "agentMode" ? agentMode : false
+                    }
+                    onCheckedChange={(checked) => {
+                      if (flag.settingKey === "agentMode") {
+                        setAgentMode(checked);
+                      }
+                    }}
+                  />
+                </div>
+              ))
+            )}
+          </CollapsibleContent>
+        </Collapsible>
       </div>
     </div>
   );

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slider": "^1.3.6",
     "@radix-ui/react-slot": "^1.2.4",
+    "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-toggle": "^1.1.10",
     "@radix-ui/react-toggle-group": "^1.1.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,9 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.2.4
         version: 1.2.4(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-switch':
+        specifier: ^1.2.6
+        version: 1.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-tabs':
         specifier: ^1.1.13
         version: 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)

--- a/src/bindings/SyncedSettings.ts
+++ b/src/bindings/SyncedSettings.ts
@@ -39,4 +39,10 @@ keep_alive_secs: bigint,
  * Whether the user has completed the first-launch onboarding flow.
  * When false, the app shows the onboarding screen on startup.
  */
-onboarding_completed: boolean, };
+onboarding_completed: boolean, 
+/**
+ * Run kernels in agent subprocesses (process isolation).
+ * When true, each notebook's kernel runs in a separate `runtimed agent`
+ * process. When false, kernels run in-process (default).
+ */
+agent_mode: boolean, };

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -1,0 +1,27 @@
+import * as React from "react";
+import * as SwitchPrimitives from "@radix-ui/react-switch";
+
+import { cn } from "@/lib/utils";
+
+const Switch = React.forwardRef<
+  React.ComponentRef<typeof SwitchPrimitives.Root>,
+  React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>
+>(({ className, ...props }, ref) => (
+  <SwitchPrimitives.Root
+    className={cn(
+      "peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
+      className,
+    )}
+    {...props}
+    ref={ref}
+  >
+    <SwitchPrimitives.Thumb
+      className={cn(
+        "pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0",
+      )}
+    />
+  </SwitchPrimitives.Root>
+));
+Switch.displayName = SwitchPrimitives.Root.displayName;
+
+export { Switch };

--- a/src/hooks/useSyncedSettings.ts
+++ b/src/hooks/useSyncedSettings.ts
@@ -104,6 +104,8 @@ export function useSyncedSettings() {
   >([]);
   // Keep-alive duration in seconds (5s to 7 days)
   const [keepAliveSecs, setKeepAliveSecsState] = useState<number>(30);
+  // Feature flag: agent process isolation
+  const [agentMode, setAgentModeState] = useState<boolean>(false);
 
   // Load initial settings from daemon
   useEffect(() => {
@@ -130,6 +132,9 @@ export function useSyncedSettings() {
           setKeepAliveSecsState(Number(settings.keep_alive_secs));
         } else if (typeof settings.keep_alive_secs === "number") {
           setKeepAliveSecsState(settings.keep_alive_secs);
+        }
+        if (typeof settings.agent_mode === "boolean") {
+          setAgentModeState(settings.agent_mode);
         }
       })
       .catch(() => {
@@ -167,6 +172,9 @@ export function useSyncedSettings() {
         setKeepAliveSecsState(Number(keep_alive_secs));
       } else if (typeof keep_alive_secs === "number") {
         setKeepAliveSecsState(keep_alive_secs);
+      }
+      if (typeof event.payload.agent_mode === "boolean") {
+        setAgentModeState(event.payload.agent_mode);
       }
     });
     return () => {
@@ -230,6 +238,16 @@ export function useSyncedSettings() {
     );
   }, []);
 
+  const setAgentMode = useCallback((enabled: boolean) => {
+    setAgentModeState(enabled);
+    invoke("set_synced_setting", {
+      key: "agent_mode",
+      value: enabled,
+    }).catch((e) =>
+      console.warn("[settings] Failed to persist agent_mode:", e),
+    );
+  }, []);
+
   return {
     theme,
     setTheme,
@@ -243,6 +261,8 @@ export function useSyncedSettings() {
     setDefaultCondaPackages,
     keepAliveSecs,
     setKeepAliveSecs,
+    agentMode,
+    setAgentMode,
   };
 }
 


### PR DESCRIPTION
## Summary

Adds a **Feature Flags** section to the settings UI — collapsed by default, with an empty state when no flags are defined. Currently exposes the "Agent Process" toggle (`agent_mode`) which controls whether kernels run in isolated subprocesses.

The section is data-driven via a `FEATURE_FLAGS` array, so adding or removing flags is a one-line change.

## Changes

- Regenerated `SyncedSettings` TypeScript binding to include `agent_mode: boolean`
- Added Radix Switch UI component
- Wired `agentMode` through `useSyncedSettings` hook (initial load, cross-window sync, persistence)
- Built collapsible Feature Flags section with chevron indicator and empty state

## Screenshots

<!-- Add screenshots of the Feature Flags section collapsed and expanded -->

## Verification

- [ ] Open Settings (Cmd+,), verify Feature Flags section appears collapsed below Advanced
- [ ] Click to expand — "Agent Process" toggle should be visible with description
- [ ] Toggle on, verify daemon logs show `Agent mode ENABLED`
- [ ] Toggle off, verify daemon logs show `Agent mode DISABLED`
- [ ] Open two notebook windows, toggle in one — verify it syncs to the other
- [ ] Remove all entries from `FEATURE_FLAGS` array — verify empty state message appears

_PR submitted by @rgbkrk's agent, Quill_