### PR TITLE
feat(mcp-supervisor): serve cached tools optimistically on startup

### DIFF
--- a/crates/mcp-supervisor/src/main.rs
+++ b/crates/mcp-supervisor/src/main.rs
@@ -704,6 +704,8 @@ impl Supervisor {
                 }
 
                 info!("nteract MCP server restarted successfully");
+                // Unblock any call_tool waiting for the child
+                self.child_ready.notify_waiters();
                 Ok(())
             }
             Err(e) => {
@@ -1820,20 +1822,20 @@ impl ServerHandler for Supervisor {
             // If the child isn't connected yet (tools served from cache),
             // wait for it to come up before forwarding.
             _ => {
-                {
+                // Register the notified future BEFORE checking is_none to
+                // avoid a lost-wakeup race where notify_waiters() fires
+                // between our check and the await.
+                let notified = self.child_ready.notified();
+                let needs_wait = {
                     let state = self.state.read().await;
-                    if state.child_client.is_none() {
-                        drop(state);
-                        info!(
-                            "Tool '{}' called before child ready, waiting...",
-                            request.name
-                        );
-                        let _ = tokio::time::timeout(
-                            Duration::from_secs(60),
-                            self.child_ready.notified(),
-                        )
-                        .await;
-                    }
+                    state.child_client.is_none()
+                };
+                if needs_wait {
+                    info!(
+                        "Tool '{}' called before child ready, waiting...",
+                        request.name
+                    );
+                    let _ = tokio::time::timeout(Duration::from_secs(60), notified).await;
                 }
                 self.forward_tool_call(request).await
             }

--- a/crates/mcp-supervisor/src/main.rs
+++ b/crates/mcp-supervisor/src/main.rs
@@ -494,6 +494,36 @@ impl ManagedProcess {
     }
 }
 
+const TOOL_CACHE_FILENAME: &str = "tool-cache.json";
+
+/// Load cached child tool definitions from disk.
+fn load_cached_tools(project_root: &Path) -> Option<Vec<Tool>> {
+    let path = project_root.join(".context").join(TOOL_CACHE_FILENAME);
+    let data = std::fs::read_to_string(&path).ok()?;
+    match serde_json::from_str::<Vec<Tool>>(&data) {
+        Ok(tools) => Some(tools),
+        Err(e) => {
+            warn!("Failed to parse tool cache at {}: {e}", path.display());
+            None
+        }
+    }
+}
+
+/// Save child tool definitions to disk for optimistic serving on next startup.
+fn save_tool_cache(project_root: &Path, tools: &[Tool]) {
+    let path = project_root.join(".context").join(TOOL_CACHE_FILENAME);
+    match serde_json::to_string_pretty(tools) {
+        Ok(json) => {
+            if let Err(e) = std::fs::write(&path, json) {
+                warn!("Failed to write tool cache to {}: {e}", path.display());
+            } else {
+                info!("Saved {} tools to cache at {}", tools.len(), path.display());
+            }
+        }
+        Err(e) => warn!("Failed to serialize tool cache: {e}"),
+    }
+}
+
 /// Shared state for the supervisor.
 struct SupervisorState {
     /// rmcp client connected to the nteract child process.
@@ -521,6 +551,9 @@ struct SupervisorState {
     tool_list_changed_tx: Option<mpsc::Sender<()>>,
     /// Managed long-running processes (vite dev server, notebook app, etc.).
     managed: HashMap<String, ManagedProcess>,
+    /// Cached child tool definitions, loaded from disk at startup.
+    /// Served optimistically before the child connects.
+    cached_tools: Option<Vec<Tool>>,
 }
 
 impl SupervisorState {
@@ -557,6 +590,12 @@ impl Supervisor {
     fn new_empty(project_root: PathBuf, tool_list_changed_tx: mpsc::Sender<()>) -> Self {
         let log_dir = project_root.join(".context");
         let _ = std::fs::create_dir_all(&log_dir);
+        let cached_tools = load_cached_tools(&project_root);
+        if let Some(ref tools) = cached_tools {
+            info!("Loaded {} cached child tools from disk", tools.len());
+        } else {
+            info!("No tool cache found — child tools will appear after startup");
+        }
         Self {
             state: Arc::new(RwLock::new(SupervisorState {
                 child_client: None,
@@ -571,6 +610,7 @@ impl Supervisor {
                 daemon_child: None,
                 tool_list_changed_tx: Some(tool_list_changed_tx),
                 managed: HashMap::new(),
+                cached_tools,
             })),
             child_ready: Arc::new(Notify::new()),
         }
@@ -649,6 +689,20 @@ impl Supervisor {
                 state.child_client = Some(client);
                 state.restart_count += 1;
                 state.last_error = None;
+
+                // Refresh the tool cache from the new child
+                if let Some(ref client) = state.child_client {
+                    match client.list_tools(None).await {
+                        Ok(child_tools) => {
+                            save_tool_cache(&state.project_root, &child_tools.tools);
+                            state.cached_tools = Some(child_tools.tools);
+                        }
+                        Err(e) => {
+                            warn!("Failed to refresh tool cache after restart: {e}");
+                        }
+                    }
+                }
+
                 info!("nteract MCP server restarted successfully");
                 Ok(())
             }
@@ -1272,32 +1326,29 @@ impl ServerHandler for Supervisor {
                 .unwrap_or_default(),
         ));
 
-        // Wait for the child to be ready if it hasn't connected yet.
-        // This blocks the first tools/list call (typically right after
-        // initialize) until the background init finishes, so the client
-        // sees the full tool set from the start.
-        {
-            let state = self.state.read().await;
-            if state.child_client.is_none() {
-                drop(state);
-                info!("Waiting for child MCP server to connect...");
-                let _ = tokio::time::timeout(Duration::from_secs(30), self.child_ready.notified())
-                    .await;
-            }
-        }
-
-        // Forward to child for its tools
+        // Serve child tools optimistically: live from child if connected,
+        // otherwise from the disk cache. Never block waiting for the child —
+        // the agent sees tools instantly and can plan while the child starts.
         let state = self.state.read().await;
         if let Some(ref client) = state.child_client {
+            // Child is connected — query live tools
             match client.list_tools(None).await {
                 Ok(child_tools) => {
                     tools.extend(child_tools.tools);
                 }
                 Err(e) => {
                     warn!("Failed to list child tools: {e}");
-                    // Still return supervisor tools even if child is down
+                    // Fall back to cache if live query fails
+                    if let Some(ref cached) = state.cached_tools {
+                        info!("Serving {} cached tools (child query failed)", cached.len());
+                        tools.extend(cached.iter().cloned());
+                    }
                 }
             }
+        } else if let Some(ref cached) = state.cached_tools {
+            // Child not ready yet — serve cached tools immediately
+            info!("Serving {} cached tools (child not ready)", cached.len());
+            tools.extend(cached.iter().cloned());
         }
 
         Ok(ListToolsResult {
@@ -1765,8 +1816,27 @@ impl ServerHandler for Supervisor {
                     }
                 }
             }
-            // Everything else → forward to child
-            _ => self.forward_tool_call(request).await,
+            // Everything else → forward to child.
+            // If the child isn't connected yet (tools served from cache),
+            // wait for it to come up before forwarding.
+            _ => {
+                {
+                    let state = self.state.read().await;
+                    if state.child_client.is_none() {
+                        drop(state);
+                        info!(
+                            "Tool '{}' called before child ready, waiting...",
+                            request.name
+                        );
+                        let _ = tokio::time::timeout(
+                            Duration::from_secs(60),
+                            self.child_ready.notified(),
+                        )
+                        .await;
+                    }
+                }
+                self.forward_tool_call(request).await
+            }
         }
     }
 }
@@ -2192,7 +2262,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
         };
 
-        // 2d: Populate state with child client, socket, daemon, and upstream info
+        // 2d: Populate state with child client, socket, daemon, and upstream info.
+        // Then fetch live tools, update the cache, and notify the client.
         {
             let mut state = state_for_init.write().await;
             state.child_client = Some(child_client);
@@ -2200,11 +2271,25 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             state.daemon_child = daemon_child;
             state.upstream_name = upstream_name;
             state.upstream_title = upstream_title;
+
+            // Fetch live tools from the child and update the disk cache
+            if let Some(ref client) = state.child_client {
+                match client.list_tools(None).await {
+                    Ok(child_tools) => {
+                        save_tool_cache(&state.project_root, &child_tools.tools);
+                        state.cached_tools = Some(child_tools.tools);
+                    }
+                    Err(e) => {
+                        warn!("Failed to fetch child tools for cache: {e}");
+                    }
+                }
+            }
         }
-        // Unblock any list_tools call waiting for the child
+        // Unblock any call_tool waiting for the child
         child_ready.notify_waiters();
 
-        // 2e: Notify the client that tools/resources are now available
+        // 2e: Notify the client that tools/resources are now available.
+        // Even if cached tools matched, the child is now live so tool calls work.
         if let Err(e) = peer_for_init.notify_tool_list_changed().await {
             warn!("Failed to send tools/list_changed after init: {e}");
         } else {

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -1223,8 +1223,9 @@ fn cmd_install_daemon() {
 /// This enables isolated daemon instances per git worktree, useful when
 /// developing/testing daemon code across multiple worktrees simultaneously.
 fn cmd_mcp(print_config: bool, release: bool) {
-    ensure_python_env();
-    ensure_maturin_develop();
+    // Skip ensure_python_env/ensure_maturin_develop here — the supervisor
+    // handles maturin develop asynchronously in its background init task.
+    // Removing these saves 5-15s of startup time.
 
     // Build the daemon in the requested mode so the supervisor finds it
     if release {


### PR DESCRIPTION
## Summary

The MCP supervisor previously blocked `list_tools` for up to 30s waiting for the child `runt mcp` process to build and connect. This meant the Claude harness had zero notebook tools during startup — agents couldn't plan with them.

Now the supervisor caches child tool definitions to disk (`.context/tool-cache.json`) on first successful child connection and serves them immediately on subsequent startups. The blocking wait moves from tool *discovery* (`list_tools`) to tool *execution* (`call_tool`), so agents see all 31 notebook tools within milliseconds and can plan while the child is still starting up.

Also removes redundant `ensure_python_env()`/`ensure_maturin_develop()` from `cargo xtask run-mcp` — the supervisor already handles maturin develop asynchronously in its background init, saving 5-15s of xtask startup time.

## Changes

- **Cache helpers**: `load_cached_tools()` / `save_tool_cache()` read/write `.context/tool-cache.json`
- **Optimistic `list_tools`**: Returns cached tools immediately if child isn't connected — never blocks
- **Deferred wait in `call_tool`**: Waits up to 60s for child when a cached tool is actually called
- **Cache refresh**: Updated on child connect, restart, and hot-reload
- **xtask optimization**: Removed redundant pre-build steps from `cmd_mcp`

## Verification

- [ ] Delete `.context/tool-cache.json`, run `cargo xtask run-mcp` — supervisor tools appear instantly, notebook tools appear after child connects, cache file is created
- [ ] Restart supervisor — notebook tools appear instantly from cache on first `tools/list`
- [ ] Call a notebook tool before child is ready — blocks briefly then succeeds once child connects
- [ ] Change a tool definition in `runt-mcp`, let hot-reload trigger — verify cache is updated and `tools/list_changed` is sent

_PR submitted by @rgbkrk's agent, Quill_