### PR TITLE
feat(runtimed): agent as Unix socket peer with CRDT-driven execution

### DIFF
--- a/crates/notebook-doc/src/runtime_state.rs
+++ b/crates/notebook-doc/src/runtime_state.rs
@@ -117,6 +117,15 @@ pub struct ExecutionState {
     /// Output manifest hashes for this execution.
     #[serde(default)]
     pub outputs: Vec<String>,
+    /// Source code that was executed (audit log).
+    /// Set by the coordinator when creating the execution entry.
+    #[serde(default)]
+    pub source: Option<String>,
+    /// Queue sequence number for ordering.
+    /// Monotonic counter owned by the coordinator; the agent sorts
+    /// queued entries by this to determine execution order.
+    #[serde(default)]
+    pub seq: Option<u64>,
 }
 
 /// Environment sync state snapshot.
@@ -800,6 +809,61 @@ impl RuntimeStateDoc {
         true
     }
 
+    /// Create a new execution entry with source code and queue sequence number.
+    ///
+    /// Used by the coordinator to queue executions for the agent. The source is
+    /// stored as an audit log, and `seq` determines execution order. The agent
+    /// discovers new entries via CRDT sync and processes them in `seq` order.
+    pub fn create_execution_with_source(
+        &mut self,
+        execution_id: &str,
+        cell_id: &str,
+        source: &str,
+        seq: u64,
+    ) -> bool {
+        let executions = self
+            .get_map("executions")
+            .expect("executions map must exist");
+
+        // Don't overwrite if it already exists (idempotent)
+        if self
+            .doc
+            .get(&executions, execution_id)
+            .ok()
+            .flatten()
+            .is_some()
+        {
+            return false;
+        }
+
+        let entry = self
+            .doc
+            .put_object(&executions, execution_id, ObjType::Map)
+            .expect("put execution entry");
+        self.doc
+            .put(&entry, "cell_id", cell_id)
+            .expect("put execution.cell_id");
+        self.doc
+            .put(&entry, "status", "queued")
+            .expect("put execution.status");
+        self.doc
+            .put(&entry, "execution_count", ScalarValue::Null)
+            .expect("put execution.execution_count");
+        self.doc
+            .put(&entry, "success", ScalarValue::Null)
+            .expect("put execution.success");
+        self.doc
+            .put_object(&entry, "outputs", ObjType::List)
+            .expect("put execution.outputs");
+        self.doc
+            .put(&entry, "source", source)
+            .expect("put execution.source");
+        self.doc
+            .put(&entry, "seq", ScalarValue::Uint(seq))
+            .expect("put execution.seq");
+        true
+    }
+
     /// Mark an execution as running.
     ///
     /// The execution_count is not known yet at this point — it arrives later
@@ -902,13 +966,46 @@ impl RuntimeStateDoc {
 
         let outputs = self.read_str_list(&entry, "outputs");
 
+        let source = self.read_opt_str(&entry, "source");
+
+        let seq = self
+            .doc
+            .get(&entry, "seq")
+            .ok()
+            .flatten()
+            .and_then(|(value, _)| match value {
+                Value::Scalar(s) => match s.as_ref() {
+                    ScalarValue::Uint(n) => Some(*n),
+                    ScalarValue::Int(n) => Some(*n as u64),
+                    _ => None,
+                },
+                _ => None,
+            });
+
         Some(ExecutionState {
             cell_id,
             status,
             execution_count,
             success,
             outputs,
+            source,
+            seq,
         })
+    }
+
+    /// Get execution entries with `status == "queued"`, sorted by `seq`.
+    ///
+    /// Used by the agent to discover new work via CRDT sync. Returns
+    /// `(execution_id, ExecutionState)` pairs in execution order.
+    pub fn get_queued_executions(&self) -> Vec<(String, ExecutionState)> {
+        let state = self.read_state();
+        let mut queued: Vec<(String, ExecutionState)> = state
+            .executions
+            .into_iter()
+            .filter(|(_, exec)| exec.status == "queued")
+            .collect();
+        queued.sort_by_key(|(_, exec)| exec.seq.unwrap_or(u64::MAX));
+        queued
     }
 
     // ── Output storage (keyed by execution_id) ──────────────────────
@@ -2100,6 +2197,38 @@ mod tests {
     }
 
     #[test]
+    fn test_create_execution_with_source() {
+        let mut doc = RuntimeStateDoc::new();
+        assert!(doc.create_execution_with_source("exec-1", "cell-1", "x = 42", 0));
+
+        let es = doc.get_execution("exec-1").unwrap();
+        assert_eq!(es.cell_id, "cell-1");
+        assert_eq!(es.status, "queued");
+        assert_eq!(es.source, Some("x = 42".to_string()));
+        assert_eq!(es.seq, Some(0));
+    }
+
+    #[test]
+    fn test_get_queued_executions_sorted_by_seq() {
+        let mut doc = RuntimeStateDoc::new();
+        doc.create_execution_with_source("exec-3", "cell-3", "z = 3", 2);
+        doc.create_execution_with_source("exec-1", "cell-1", "x = 1", 0);
+        doc.create_execution_with_source("exec-2", "cell-2", "y = 2", 1);
+
+        let queued = doc.get_queued_executions();
+        assert_eq!(queued.len(), 3);
+        assert_eq!(queued[0].0, "exec-1");
+        assert_eq!(queued[1].0, "exec-2");
+        assert_eq!(queued[2].0, "exec-3");
+
+        // Transition one to running — should no longer appear
+        doc.set_execution_running("exec-1");
+        let queued = doc.get_queued_executions();
+        assert_eq!(queued.len(), 2);
+        assert_eq!(queued[0].0, "exec-2");
+    }
+
+    #[test]
     fn test_create_execution_idempotent() {
         let mut doc = RuntimeStateDoc::new();
         assert!(doc.create_execution("exec-1", "cell-1"));
@@ -2795,6 +2924,8 @@ mod tests {
                 execution_count: Some(1),
                 success: Some(true),
                 outputs: vec!["hash1".to_string()],
+                source: None,
+                seq: None,
             },
         );
         let (changed, _) = diff_execution_outputs(&prev, &execs);
@@ -2813,6 +2944,8 @@ mod tests {
                 execution_count: None,
                 success: None,
                 outputs: vec![],
+                source: None,
+                seq: None,
             },
         );
         let (changed, _) = diff_execution_outputs(&prev, &execs);
@@ -2832,6 +2965,8 @@ mod tests {
                 execution_count: Some(1),
                 success: Some(true),
                 outputs: vec![],
+                source: None,
+                seq: None,
             },
         );
         let (changed, _) = diff_execution_outputs(&prev, &execs);
@@ -2854,6 +2989,8 @@ mod tests {
                 execution_count: Some(1),
                 success: Some(true),
                 outputs: vec!["hash1".to_string()],
+                source: None,
+                seq: None,
             },
         );
         let (changed, snapshot) = diff_execution_outputs(&prev, &execs);
@@ -2873,6 +3010,8 @@ mod tests {
                 execution_count: None,
                 success: None,
                 outputs: vec![],
+                source: None,
+                seq: None,
             },
         );
         let (changed, snapshot) = diff_execution_outputs(&snapshot, &execs);
@@ -2904,6 +3043,8 @@ mod tests {
                 execution_count: Some(1),
                 success: Some(true),
                 outputs: vec![],
+                source: None,
+                seq: None,
             },
         );
 

--- a/crates/runtimed/src/agent.rs
+++ b/crates/runtimed/src/agent.rs
@@ -2,44 +2,44 @@
 //!
 //! The agent is a subprocess spawned by the coordinator (daemon) that owns
 //! the kernel lifecycle, IOPub processing, execution queue, and RuntimeStateDoc
-//! writes. It communicates with the coordinator over stdin/stdout using the
-//! existing framed protocol.
+//! writes. It connects back to the daemon's Unix socket as a regular peer.
 //!
-//! ## Sync-only architecture
+//! ## CRDT-driven execution
 //!
-//! The agent does **not** forward `NotebookBroadcast` messages. All kernel
-//! state changes (outputs, execution lifecycle, queue, comms, kernel status)
-//! flow through RuntimeStateDoc Automerge sync (frame 0x05). The only
-//! explicit messages are `AgentNotification` for things the coordinator must
-//! act on outside of RuntimeStateDoc (writing to NotebookDoc, cleaning up
-//! the agent handle).
+//! The agent does NOT receive execution requests via RPC. Instead, the
+//! coordinator writes execution entries (with source code and sequence
+//! numbers) to RuntimeStateDoc. The agent discovers new entries via
+//! Automerge sync and executes them in seq order.
 //!
 //! ## Protocol
 //!
-//! - Frame 0x01: `AgentRequest` (coordinator → agent)
-//! - Frame 0x02: `AgentResponse` (agent → coordinator)
-//! - Frame 0x03: `AgentNotification` (agent → coordinator, rare)
-//! - Frame 0x05: `RuntimeStateSync` (bidirectional Automerge sync)
+//! Standard peer protocol over Unix socket:
+//! - Frame 0x00: AutomergeSync (NotebookDoc sync, for completions context)
+//! - Frame 0x01: AgentRequest (coordinator → agent, for LaunchKernel/Interrupt/etc.)
+//! - Frame 0x02: AgentResponse (agent → coordinator)
+//! - Frame 0x05: RuntimeStateSync (bidirectional, carries execution queue + outputs)
 //!
 //! ## Lifecycle
 //!
-//! 1. Coordinator spawns agent, sends preamble + `Handshake::RuntimeAgent`
-//! 2. Agent bootstraps RuntimeStateDoc via initial sync (frame 0x05)
-//! 3. Agent creates RoomKernel with local channels
-//! 4. Main select loop: stdin frames, RuntimeStateDoc changes, QueueCommands
-//! 5. On shutdown or coordinator disconnect, agent exits
+//! 1. Agent connects to daemon socket, sends `Handshake::RuntimeAgent`
+//! 2. Initial sync for NotebookDoc and RuntimeStateDoc
+//! 3. Agent waits for `LaunchKernel` RPC
+//! 4. Main select loop: socket frames, QueueCommands, RuntimeStateDoc changes
+//! 5. Watches for new `status=queued` execution entries after each sync
+//! 6. On shutdown or daemon disconnect, agent exits
 
+use std::collections::HashSet;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use log::{debug, info, warn};
 use notebook_doc::presence::PresenceState;
 use notebook_doc::runtime_state::RuntimeStateDoc;
 use notebook_protocol::connection::{
-    recv_frame, recv_json_frame, recv_preamble, send_preamble, send_typed_frame, Handshake,
+    recv_typed_frame, send_json_frame, send_preamble, send_typed_frame, Handshake,
     NotebookFrameType,
 };
 use notebook_protocol::protocol::{AgentRequest, AgentResponse};
-use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::sync::{broadcast, RwLock};
 
 use crate::blob_store::BlobStore;
@@ -51,76 +51,56 @@ struct AgentContext {
     state_doc: Arc<RwLock<RuntimeStateDoc>>,
     state_changed_tx: broadcast::Sender<()>,
     blob_store: Arc<BlobStore>,
-    /// RoomKernel requires a broadcast_tx at construction. The agent creates
-    /// a channel but never reads from it — all state flows via CRDT sync.
     broadcast_tx: broadcast::Sender<notebook_protocol::protocol::NotebookBroadcast>,
     presence: Arc<RwLock<PresenceState>>,
     presence_tx: broadcast::Sender<(String, Vec<u8>)>,
 }
 
-/// Run the runtime agent on the given stdin/stdout streams.
-///
-/// This is the agent's main entry point. It reads the handshake from stdin,
-/// bootstraps its RuntimeStateDoc, and enters the main event loop.
-pub async fn run_agent<R, W>(mut reader: R, mut writer: W) -> anyhow::Result<()>
-where
-    R: AsyncRead + Unpin + Send + 'static,
-    W: AsyncWrite + Unpin + Send + 'static,
-{
-    // ── 1. Read preamble + handshake ────────────────────────────────────────
-
-    recv_preamble(&mut reader).await?;
-    let handshake: Handshake = recv_json_frame(&mut reader)
-        .await?
-        .ok_or_else(|| anyhow::anyhow!("EOF before handshake"))?;
-
-    let (notebook_id, agent_id, blob_root) = match handshake {
-        Handshake::RuntimeAgent {
-            notebook_id,
-            agent_id,
-            blob_root,
-        } => (notebook_id, agent_id, blob_root),
-        other => {
-            anyhow::bail!(
-                "Expected RuntimeAgent handshake, got {:?}",
-                std::mem::discriminant(&other)
-            );
-        }
-    };
-
+/// Run the runtime agent, connecting to the daemon socket as a peer.
+pub async fn run_agent(
+    socket_path: PathBuf,
+    notebook_id: String,
+    agent_id: String,
+    blob_root: PathBuf,
+) -> anyhow::Result<()> {
     info!(
-        "[agent] Starting agent_id={} notebook_id={} blob_root={}",
-        agent_id, notebook_id, blob_root
+        "[agent] Starting agent_id={} notebook_id={} socket={}",
+        agent_id,
+        notebook_id,
+        socket_path.display()
     );
 
-    // Send preamble back to coordinator (confirms protocol version)
+    // ── 1. Connect to daemon socket ────────────────────────────────────────
+
+    let stream = tokio::net::UnixStream::connect(&socket_path).await?;
+    let (mut reader, mut writer) = tokio::io::split(stream);
+
+    // Send preamble + RuntimeAgent handshake
     send_preamble(&mut writer).await?;
+    send_json_frame(
+        &mut writer,
+        &Handshake::RuntimeAgent {
+            notebook_id: notebook_id.clone(),
+            agent_id: agent_id.clone(),
+            blob_root: blob_root.display().to_string(),
+        },
+    )
+    .await?;
 
-    // ── 2. Bootstrap RuntimeStateDoc ────────────────────────────────────────
+    info!("[agent] Connected to daemon, handshake sent");
 
-    // The agent creates its own RuntimeStateDoc with scaffolding but a UNIQUE
-    // actor ID. This avoids DuplicateSeqNumber — the coordinator uses
-    // "runtimed:state" as its actor, the agent uses its own agent_id.
-    // Both docs have the same structure but different actors, so sync merges cleanly.
+    // ── 2. Bootstrap RuntimeStateDoc ───────────────────────────────────────
+
     let state_doc = RuntimeStateDoc::new_with_actor(&agent_id);
-
-    // Automerge sync state for the coordinator peer.
     let mut coordinator_sync_state = automerge::sync::State::new();
-
     let state_doc = Arc::new(RwLock::new(state_doc));
     let (state_changed_tx, mut state_changed_rx) = broadcast::channel::<()>(64);
 
-    // ── 3. Create local infrastructure ──────────────────────────────────────
+    // ── 3. Create local infrastructure ─────────────────────────────────────
 
-    let blob_store = Arc::new(BlobStore::new(std::path::PathBuf::from(&blob_root)));
-
-    // RoomKernel requires a broadcast channel even though we don't forward
-    // broadcasts. The kernel's IOPub task sends on it; we just don't read.
+    let blob_store = Arc::new(BlobStore::new(blob_root));
     let (broadcast_tx, _broadcast_rx) =
         broadcast::channel::<notebook_protocol::protocol::NotebookBroadcast>(16);
-
-    // Presence — kernel writes status here but we rely on RuntimeStateDoc
-    // sync for propagation, not presence frames.
     let presence = Arc::new(RwLock::new(PresenceState::new()));
     let (presence_tx, _presence_rx) = broadcast::channel::<(String, Vec<u8>)>(16);
 
@@ -134,44 +114,117 @@ where
         presence_tx,
     };
 
-    // QueueCommand receiver — starts as None. After LaunchKernel, populated
-    // with the kernel's actual cmd_rx (taken via kernel.take_cmd_rx()).
     let mut cmd_rx: Option<tokio::sync::mpsc::Receiver<QueueCommand>> = None;
+    let mut seen_execution_ids: HashSet<String> = HashSet::new();
 
     info!("[agent] Infrastructure ready, entering main loop");
 
-    // ── 4. Main event loop ──────────────────────────────────────────────────
-    //
-    // Three input sources:
-    //   - stdin: AgentRequest frames (0x01), RuntimeStateSync frames (0x05)
-    //   - cmd_rx: QueueCommands from kernel IOPub/shell tasks
-    //   - state_changed_rx: RuntimeStateDoc mutations to sync to coordinator
-    //
-    // Output (stdout): AgentResponse (0x02), AgentNotification (0x03),
-    //   RuntimeStateSync (0x05)
+    // ── 4. Main event loop ─────────────────────────────────────────────────
 
     loop {
         tokio::select! {
-            // Read next frame from coordinator (stdin)
-            frame = recv_frame(&mut reader) => {
+            // Read frames from daemon socket
+            frame = recv_typed_frame(&mut reader) => {
                 match frame {
-                    Ok(Some(data)) => {
-                        if let Err(e) = handle_stdin_frame(
-                            &data,
-                            &mut writer,
-                            &ctx,
-                            &mut coordinator_sync_state,
-                            &mut cmd_rx,
-                        ).await {
-                            warn!("[agent] Error handling stdin frame: {}", e);
+                    Ok(Some(typed_frame)) => {
+                        match typed_frame.frame_type {
+                            // AgentRequest (RPC: LaunchKernel, Interrupt, etc.)
+                            NotebookFrameType::Request => {
+                                if let Ok(request) = serde_json::from_slice::<AgentRequest>(&typed_frame.payload) {
+                                    let response = handle_agent_request(request, &ctx).await;
+
+                                    // After launch, take cmd_rx from kernel
+                                    if matches!(response, AgentResponse::KernelLaunched { .. }) {
+                                        let mut guard = ctx.kernel.lock().await;
+                                        if let Some(ref mut k) = *guard {
+                                            cmd_rx = k.take_cmd_rx();
+                                        }
+                                    }
+
+                                    let json = serde_json::to_vec(&response)?;
+                                    send_typed_frame(&mut writer, NotebookFrameType::Response, &json).await?;
+                                }
+                            }
+
+                            // RuntimeStateSync — apply coordinator's changes, check for new queue entries
+                            NotebookFrameType::RuntimeStateSync => {
+                                if let Ok(msg) = automerge::sync::Message::decode(&typed_frame.payload) {
+                                    let mut sd = ctx.state_doc.write().await;
+                                    if let Ok(changed) = sd.receive_sync_message_with_changes(
+                                        &mut coordinator_sync_state,
+                                        msg,
+                                    ) {
+                                        if changed {
+                                            let _ = ctx.state_changed_tx.send(());
+
+                                            // Check for new queued executions
+                                            let queued = sd.get_queued_executions();
+                                            drop(sd); // release write lock before queuing
+
+                                            for (eid, exec) in queued {
+                                                if seen_execution_ids.insert(eid.clone()) {
+                                                    if let Some(ref source) = exec.source {
+                                                        let mut guard = ctx.kernel.lock().await;
+                                                        if let Some(ref mut k) = *guard {
+                                                            match k.queue_cell_with_id(
+                                                                exec.cell_id.clone(),
+                                                                source.clone(),
+                                                                eid.clone(),
+                                                            ).await {
+                                                                Ok(_) => {
+                                                                    info!(
+                                                                        "[agent] Queued cell {} (execution {})",
+                                                                        exec.cell_id, eid
+                                                                    );
+                                                                }
+                                                                Err(e) => {
+                                                                    warn!(
+                                                                        "[agent] Failed to queue cell {}: {}",
+                                                                        exec.cell_id, e
+                                                                    );
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        } else {
+                                            drop(sd);
+                                        }
+                                    }
+
+                                    // Send sync reply
+                                    let mut sd = ctx.state_doc.write().await;
+                                    if let Some(reply) = sd.generate_sync_message(&mut coordinator_sync_state) {
+                                        let encoded = reply.encode();
+                                        let _ = send_typed_frame(
+                                            &mut writer,
+                                            NotebookFrameType::RuntimeStateSync,
+                                            &encoded,
+                                        ).await;
+                                    }
+                                }
+                            }
+
+                            // AutomergeSync (NotebookDoc — for completions context)
+                            NotebookFrameType::AutomergeSync => {
+                                // The agent doesn't need NotebookDoc state for execution
+                                // (source comes from execution entries), but it may be
+                                // useful for completions context in the future.
+                                debug!("[agent] Received NotebookDoc sync frame (ignored for now)");
+                            }
+
+                            _ => {
+                                debug!("[agent] Ignoring frame type {:?}", typed_frame.frame_type);
+                            }
                         }
                     }
                     Ok(None) => {
-                        info!("[agent] EOF on stdin, shutting down");
+                        info!("[agent] Daemon disconnected (EOF)");
                         break;
                     }
                     Err(e) => {
-                        info!("[agent] stdin read error (coordinator disconnected?): {}", e);
+                        info!("[agent] Socket read error: {}", e);
                         break;
                     }
                 }
@@ -191,14 +244,11 @@ where
 
             // Sync RuntimeStateDoc changes to coordinator
             _ = state_changed_rx.recv() => {
-                // Drain any buffered notifications
                 while state_changed_rx.try_recv().is_ok() {}
 
-                // Generate sync message and send as frame 0x05
                 let mut sd = ctx.state_doc.write().await;
                 if let Some(msg) = sd.generate_sync_message(&mut coordinator_sync_state) {
                     let encoded = msg.encode();
-                    info!("[agent] Sending RuntimeStateSync frame ({} bytes)", encoded.len());
                     if let Err(e) = send_typed_frame(
                         &mut writer,
                         NotebookFrameType::RuntimeStateSync,
@@ -212,7 +262,7 @@ where
         }
     }
 
-    // ── 5. Cleanup ──────────────────────────────────────────────────────────
+    // ── 5. Cleanup ─────────────────────────────────────────────────────────
 
     info!("[agent] Shutting down");
     let mut guard = ctx.kernel.lock().await;
@@ -223,60 +273,11 @@ where
     Ok(())
 }
 
-/// Handle a typed frame received from the coordinator on stdin.
-async fn handle_stdin_frame<W: AsyncWrite + Unpin>(
-    data: &[u8],
-    writer: &mut W,
-    ctx: &AgentContext,
-    coordinator_sync_state: &mut automerge::sync::State,
-    cmd_rx: &mut Option<tokio::sync::mpsc::Receiver<QueueCommand>>,
-) -> anyhow::Result<()> {
-    if data.is_empty() {
-        return Ok(());
-    }
-
-    let frame_type = data[0];
-    let payload = &data[1..];
-
-    match frame_type {
-        // AgentRequest (0x01)
-        0x01 => {
-            let request: AgentRequest = serde_json::from_slice(payload)?;
-            let response = handle_agent_request(request, ctx).await;
-
-            // After successful launch, take the kernel's cmd_rx so the
-            // main loop can start processing execution lifecycle events.
-            if matches!(response, AgentResponse::KernelLaunched { .. }) {
-                let mut guard = ctx.kernel.lock().await;
-                if let Some(ref mut k) = *guard {
-                    *cmd_rx = k.take_cmd_rx();
-                }
-            }
-
-            let json = serde_json::to_vec(&response)?;
-            send_typed_frame(writer, NotebookFrameType::Response, &json).await?;
-        }
-
-        // RuntimeStateSync (0x05)
-        0x05 => {
-            // Coordinator is sending RuntimeStateDoc changes (e.g., comm state
-            // from frontend, trust state). Apply to our local replica.
-            let mut sd = ctx.state_doc.write().await;
-            let sync_message = automerge::sync::Message::decode(payload)?;
-            if sd.receive_sync_message_with_changes(coordinator_sync_state, sync_message)? {
-                let _ = ctx.state_changed_tx.send(());
-            }
-        }
-
-        other => {
-            debug!("[agent] Ignoring unknown frame type 0x{:02x}", other);
-        }
-    }
-
-    Ok(())
-}
-
 /// Handle an AgentRequest and return an AgentResponse.
+///
+/// Note: ExecuteCell is NOT handled here — execution is CRDT-driven.
+/// The coordinator writes execution entries to RuntimeStateDoc, and the
+/// agent picks them up via sync.
 async fn handle_agent_request(request: AgentRequest, ctx: &AgentContext) -> AgentResponse {
     match request {
         AgentRequest::LaunchKernel {
@@ -300,7 +301,6 @@ async fn handle_agent_request(request: AgentRequest, ctx: &AgentContext) -> Agen
                 ctx.presence_tx.clone(),
             );
 
-            // Reconstruct PooledEnv from launched_config paths if available.
             let pooled_env = launched_config.venv_path.as_ref().and_then(|venv| {
                 launched_config
                     .python_path
@@ -341,31 +341,11 @@ async fn handle_agent_request(request: AgentRequest, ctx: &AgentContext) -> Agen
             }
         }
 
-        AgentRequest::ExecuteCell {
-            cell_id,
-            code,
-            execution_id,
-        } => {
-            let mut guard = ctx.kernel.lock().await;
-            if let Some(ref mut k) = *guard {
-                // Use the coordinator's execution_id to keep NotebookDoc
-                // and RuntimeStateDoc in sync.
-                match k
-                    .queue_cell_with_id(cell_id.clone(), code, execution_id)
-                    .await
-                {
-                    Ok(eid) => AgentResponse::CellQueued {
-                        cell_id,
-                        execution_id: eid,
-                    },
-                    Err(e) => AgentResponse::Error {
-                        error: format!("Failed to queue cell: {}", e),
-                    },
-                }
-            } else {
-                AgentResponse::Error {
-                    error: "No kernel running".to_string(),
-                }
+        AgentRequest::ExecuteCell { .. } => {
+            // ExecuteCell is CRDT-driven — should not arrive as RPC.
+            warn!("[agent] Received ExecuteCell RPC — this should be CRDT-driven");
+            AgentResponse::Error {
+                error: "ExecuteCell is CRDT-driven, not RPC".to_string(),
             }
         }
 
@@ -451,9 +431,6 @@ async fn handle_agent_request(request: AgentRequest, ctx: &AgentContext) -> Agen
 }
 
 /// Handle a QueueCommand from the kernel's IOPub/shell/heartbeat tasks.
-///
-/// Most kernel state is already in RuntimeStateDoc and syncs automatically.
-/// This handler only deals with events that need explicit coordinator action.
 async fn handle_queue_command(command: QueueCommand, ctx: &AgentContext) -> anyhow::Result<()> {
     match command {
         QueueCommand::ExecutionDone {
@@ -467,7 +444,6 @@ async fn handle_queue_command(command: QueueCommand, ctx: &AgentContext) -> anyh
                     warn!("[agent] execution_done error: {}", e);
                 }
             }
-            // RuntimeStateDoc changes sync automatically via frame 0x05
         }
 
         QueueCommand::CellError {
@@ -478,12 +454,10 @@ async fn handle_queue_command(command: QueueCommand, ctx: &AgentContext) -> anyh
                 "[agent] CellError: cell={} execution={}",
                 cell_id, execution_id
             );
-            // Stop-on-error: clear remaining queue and mark cleared executions as failed
             let mut guard = ctx.kernel.lock().await;
             if let Some(ref mut k) = *guard {
                 let cleared = k.clear_queue();
                 let mut sd = ctx.state_doc.write().await;
-                // Mark each cleared execution as error so callers aren't stuck waiting
                 for entry in &cleared {
                     sd.set_execution_done(&entry.execution_id, false);
                 }
@@ -494,8 +468,6 @@ async fn handle_queue_command(command: QueueCommand, ctx: &AgentContext) -> anyh
 
         QueueCommand::KernelDied => {
             warn!("[agent] Kernel died");
-            // Write error state to RuntimeStateDoc — syncs to coordinator
-            // automatically. The coordinator also detects child exit.
             let mut sd = ctx.state_doc.write().await;
             sd.set_kernel_status("error");
             sd.set_queue(None, &[]);
@@ -513,116 +485,4 @@ async fn handle_queue_command(command: QueueCommand, ctx: &AgentContext) -> anyh
     }
 
     Ok(())
-}
-
-#[cfg(test)]
-#[allow(clippy::unwrap_used)]
-mod tests {
-    use super::*;
-    use notebook_protocol::connection::{
-        recv_frame, recv_preamble, send_json_frame, send_preamble, send_typed_frame,
-        NotebookFrameType,
-    };
-    use tokio::io::duplex;
-
-    /// Test that the agent reads the handshake and responds with preamble.
-    #[tokio::test]
-    async fn test_agent_handshake() {
-        let (coordinator_stream, agent_stream) = duplex(8192);
-        let (agent_reader, agent_writer) = tokio::io::split(agent_stream);
-        let (mut coord_reader, mut coord_writer) = tokio::io::split(coordinator_stream);
-
-        let agent_task = tokio::spawn(async move { run_agent(agent_reader, agent_writer).await });
-
-        // Coordinator sends preamble + handshake
-        send_preamble(&mut coord_writer).await.unwrap();
-        send_json_frame(
-            &mut coord_writer,
-            &Handshake::RuntimeAgent {
-                notebook_id: "test-notebook".to_string(),
-                agent_id: "rt:agent:test".to_string(),
-                blob_root: "/tmp/test-blobs".to_string(),
-            },
-        )
-        .await
-        .unwrap();
-
-        // Agent should respond with preamble
-        recv_preamble(&mut coord_reader).await.unwrap();
-
-        // Agent is now in its main loop — abort it
-        agent_task.abort();
-    }
-
-    /// Test that the agent rejects non-RuntimeAgent handshakes.
-    #[tokio::test]
-    async fn test_agent_rejects_wrong_handshake() {
-        let (coordinator_stream, agent_stream) = duplex(8192);
-        let (agent_reader, agent_writer) = tokio::io::split(agent_stream);
-        let (mut _coord_reader, mut coord_writer) = tokio::io::split(coordinator_stream);
-
-        let agent_task = tokio::spawn(async move { run_agent(agent_reader, agent_writer).await });
-
-        // Send wrong handshake type
-        send_preamble(&mut coord_writer).await.unwrap();
-        send_json_frame(&mut coord_writer, &Handshake::Pool)
-            .await
-            .unwrap();
-
-        let result = tokio::time::timeout(std::time::Duration::from_secs(5), agent_task)
-            .await
-            .unwrap()
-            .unwrap();
-
-        assert!(
-            result.is_err(),
-            "Agent should reject non-RuntimeAgent handshake"
-        );
-    }
-
-    /// Test that the agent responds to a ShutdownKernel request (no kernel running → Ok).
-    #[tokio::test]
-    async fn test_agent_shutdown_request() {
-        let (coordinator_stream, agent_stream) = duplex(8192);
-        let (agent_reader, agent_writer) = tokio::io::split(agent_stream);
-        let (mut coord_reader, mut coord_writer) = tokio::io::split(coordinator_stream);
-
-        let agent_task = tokio::spawn(async move { run_agent(agent_reader, agent_writer).await });
-
-        // Handshake
-        send_preamble(&mut coord_writer).await.unwrap();
-        send_json_frame(
-            &mut coord_writer,
-            &Handshake::RuntimeAgent {
-                notebook_id: "test-notebook".to_string(),
-                agent_id: "rt:agent:test".to_string(),
-                blob_root: "/tmp/test-blobs".to_string(),
-            },
-        )
-        .await
-        .unwrap();
-        recv_preamble(&mut coord_reader).await.unwrap();
-
-        // Agent uses new_with_actor — no bootstrap sync needed.
-        // It goes straight to the main loop after preamble exchange.
-
-        // Send ShutdownKernel request
-        let request = AgentRequest::ShutdownKernel;
-        let json = serde_json::to_vec(&request).unwrap();
-        send_typed_frame(&mut coord_writer, NotebookFrameType::Request, &json)
-            .await
-            .unwrap();
-
-        // Read response
-        let response_frame = recv_frame(&mut coord_reader).await.unwrap().unwrap();
-        assert_eq!(response_frame[0], 0x02, "Should be a Response frame");
-        let response: AgentResponse = serde_json::from_slice(&response_frame[1..]).unwrap();
-        assert!(
-            matches!(response, AgentResponse::Ok),
-            "ShutdownKernel with no kernel should return Ok"
-        );
-
-        // Clean up
-        agent_task.abort();
-    }
 }

--- a/crates/runtimed/src/agent.rs
+++ b/crates/runtimed/src/agent.rs
@@ -72,7 +72,25 @@ pub async fn run_agent(
 
     // ── 1. Connect to daemon socket ────────────────────────────────────────
 
+    #[cfg(unix)]
     let stream = tokio::net::UnixStream::connect(&socket_path).await?;
+
+    #[cfg(windows)]
+    let stream = {
+        let pipe_name = socket_path.to_string_lossy().to_string();
+        let mut attempts = 0u32;
+        loop {
+            match tokio::net::windows::named_pipe::ClientOptions::new().open(&pipe_name) {
+                Ok(client) => break client,
+                Err(_) if attempts < 10 => {
+                    attempts += 1;
+                    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+                }
+                Err(e) => return Err(e.into()),
+            }
+        }
+    };
+
     let (mut reader, mut writer) = tokio::io::split(stream);
 
     // Send preamble + RuntimeAgent handshake

--- a/crates/runtimed/src/agent_handle.rs
+++ b/crates/runtimed/src/agent_handle.rs
@@ -1,8 +1,8 @@
 //! Coordinator-side management of a runtime agent subprocess.
 //!
-//! `AgentHandle` spawns a `runtimed agent` child process and communicates
-//! via framed protocol on stdin/stdout. A reader task reads all frames
-//! from the agent's stdout and routes them via channels.
+//! `AgentHandle` spawns a `runtimed agent` child process that connects back
+//! to the daemon's Unix socket as a regular peer. The handle only monitors
+//! the child process lifecycle — all communication happens via the socket.
 
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -10,311 +10,79 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use log::{info, warn};
-use notebook_doc::runtime_state::RuntimeStateDoc;
-use notebook_protocol::connection::{
-    recv_frame, recv_preamble, send_json_frame, send_preamble, send_typed_frame, Handshake,
-    NotebookFrameType,
-};
-use notebook_protocol::protocol::{
-    AgentNotification, AgentRequest, AgentResponse, LaunchedEnvConfig,
-};
-use tokio::process::ChildStdin;
-use tokio::sync::{broadcast, mpsc, oneshot, Mutex, RwLock};
 
 /// Handle to a running agent subprocess.
+///
+/// The agent connects back to the daemon's Unix socket as a peer.
+/// This handle only spawns and monitors the child process — it does
+/// not manage any communication channels.
 pub struct AgentHandle {
-    /// Writer to agent's stdin (protected by mutex for concurrent access)
-    writer: Arc<Mutex<ChildStdin>>,
-    /// Channel for requesting a response from the reader task
-    response_request_tx: mpsc::Sender<oneshot::Sender<AgentResponse>>,
     alive: Arc<AtomicBool>,
 }
 
 impl AgentHandle {
+    /// Spawn an agent subprocess that will connect back to the daemon socket.
+    ///
+    /// The agent is given the socket path, notebook ID, agent ID, and blob root
+    /// as CLI arguments. It connects to the daemon socket and joins the notebook
+    /// room as a `RuntimeAgent` peer.
     pub async fn spawn(
         notebook_id: String,
         agent_id: String,
         blob_root: PathBuf,
-        state_doc: Arc<RwLock<RuntimeStateDoc>>,
-        state_changed_tx: broadcast::Sender<()>,
-        _broadcast_tx: broadcast::Sender<notebook_protocol::protocol::NotebookBroadcast>,
+        socket_path: PathBuf,
     ) -> Result<Self> {
         let exe = std::env::current_exe()?;
         info!(
-            "[agent-handle] Spawning agent: {} agent (notebook_id={})",
+            "[agent-handle] Spawning agent: {} agent --notebook-id {} (socket: {})",
             exe.display(),
-            notebook_id
+            notebook_id,
+            socket_path.display(),
         );
 
         let mut child = tokio::process::Command::new(&exe)
             .arg("agent")
-            .stdin(std::process::Stdio::piped())
-            .stdout(std::process::Stdio::piped())
+            .arg("--notebook-id")
+            .arg(&notebook_id)
+            .arg("--agent-id")
+            .arg(&agent_id)
+            .arg("--blob-root")
+            .arg(blob_root.as_os_str())
+            .arg("--socket")
+            .arg(socket_path.as_os_str())
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::inherit())
             .kill_on_drop(true)
             .spawn()?;
 
-        let mut writer = child
-            .stdin
-            .take()
-            .ok_or_else(|| anyhow::anyhow!("Failed to capture agent stdin"))?;
-        let mut reader = child
-            .stdout
-            .take()
-            .ok_or_else(|| anyhow::anyhow!("Failed to capture agent stdout"))?;
-
-        // Preamble + handshake exchange (before wrapping writer in Arc<Mutex>)
-        send_preamble(&mut writer).await?;
-        send_json_frame(
-            &mut writer,
-            &Handshake::RuntimeAgent {
-                notebook_id,
-                agent_id,
-                blob_root: blob_root.to_string_lossy().to_string(),
-            },
-        )
-        .await?;
-        recv_preamble(&mut reader).await?;
-
-        // Both coordinator and agent have their own scaffolded RuntimeStateDoc
-        // with different actors. No bootstrap sync needed — the reader task
-        // handles bidirectional sync once it starts. The docs will merge
-        // naturally via Automerge CRDT (same structure, different actors).
-        info!("[agent-handle] Agent spawned — sync via reader task");
-
-        // Now wrap writer in Arc<Mutex> for shared access with reader task
-        let writer = Arc::new(Mutex::new(writer));
+        info!("[agent-handle] Agent spawned (pid={:?})", child.id());
 
         let alive = Arc::new(AtomicBool::new(true));
-        let (response_request_tx, mut response_request_rx) =
-            mpsc::channel::<oneshot::Sender<AgentResponse>>(8);
-        // No unsolicited response channel needed — all responses go through oneshot
 
-        // Spawn reader task — reads ALL frames from agent stdout.
-        // This task owns `reader` and never gives it up. Frames are routed
-        // via channels. This works because the task is spawned from the same
-        // async context where `reader` was created.
+        // Monitor child process exit
         let alive_clone = alive.clone();
-        let state_doc_clone = state_doc.clone();
-        let state_changed_clone = state_changed_tx.clone();
-        let writer_clone = writer.clone();
+        let agent_id_clone = agent_id.clone();
         tokio::spawn(async move {
-            let mut agent_sync_state = automerge::sync::State::new();
-            let mut pending_reply: Option<oneshot::Sender<AgentResponse>> = None;
-
-            // Subscribe to coordinator state changes for reverse sync
-            let mut state_changed_rx = state_changed_clone.subscribe();
-
-            // Also wait on the child process
-            let mut child_wait = Box::pin(child.wait());
-
-            loop {
-                tokio::select! {
-                    biased;
-
-                    // Read frames from agent stdout
-                    frame = recv_frame(&mut reader) => {
-                        match frame {
-                            Ok(Some(data)) if !data.is_empty() => {
-                                let frame_type = data[0];
-                                let payload = &data[1..];
-
-                                match frame_type {
-                                    // AgentResponse
-                                    0x02 => {
-                                        if let Ok(response) = serde_json::from_slice::<AgentResponse>(payload) {
-                                            if let Some(reply) = pending_reply.take() {
-                                                let _ = reply.send(response);
-                                            } else {
-                                                warn!("[agent-handle] Response with no pending request");
-                                            }
-                                        }
-                                    }
-                                    // RuntimeStateSync
-                                    0x05 => {
-                                        if let Ok(msg) = automerge::sync::Message::decode(payload) {
-                                            let mut sd = state_doc_clone.write().await;
-                                            if let Ok(changed) = sd.receive_sync_message_with_changes(
-                                                &mut agent_sync_state, msg,
-                                            ) {
-                                                if changed {
-                                                    let _ = state_changed_clone.send(());
-                                                }
-                                            }
-                                            // Send sync reply
-                                            if let Some(reply_msg) = sd.generate_sync_message(&mut agent_sync_state) {
-                                                let encoded = reply_msg.encode();
-                                                let mut w = writer_clone.lock().await;
-                                                let _ = send_typed_frame(&mut *w, NotebookFrameType::RuntimeStateSync, &encoded).await;
-                                            }
-                                        }
-                                    }
-                                    // AgentNotification
-                                    0x03 => {
-                                        if let Ok(AgentNotification::KernelDied) = serde_json::from_slice(payload) {
-                                            warn!("[agent-handle] Agent kernel died");
-                                        }
-                                    }
-                                    _ => {}
-                                }
-                            }
-                            _ => {
-                                info!("[agent-handle] Agent stdout closed");
-                                break;
-                            }
-                        }
-                    }
-
-                    // Accept response request from send_request callers
-                    req = response_request_rx.recv() => {
-                        match req {
-                            Some(reply_tx) => {
-                                pending_reply = Some(reply_tx);
-                            }
-                            None => break,
-                        }
-                    }
-
-                    // Forward coordinator RuntimeStateDoc changes to agent
-                    _ = state_changed_rx.recv() => {
-                        // Drain buffered notifications
-                        while state_changed_rx.try_recv().is_ok() {}
-
-                        let mut sd = state_doc_clone.write().await;
-                        if let Some(msg) = sd.generate_sync_message(&mut agent_sync_state) {
-                            let encoded = msg.encode();
-                            let mut w = writer_clone.lock().await;
-                            if let Err(e) = send_typed_frame(
-                                &mut *w,
-                                NotebookFrameType::RuntimeStateSync,
-                                &encoded,
-                            ).await {
-                                warn!("[agent-handle] Failed to send reverse sync: {}", e);
-                                break;
-                            }
-                        }
-                    }
-
-                    // Wait for child exit
-                    _ = &mut child_wait => {
-                        info!("[agent-handle] Agent process exited");
-                        break;
-                    }
+            match child.wait().await {
+                Ok(status) => {
+                    info!(
+                        "[agent-handle] Agent {} exited with status: {}",
+                        agent_id_clone, status
+                    );
+                }
+                Err(e) => {
+                    warn!("[agent-handle] Agent {} wait error: {}", agent_id_clone, e);
                 }
             }
-
             alive_clone.store(false, Ordering::Relaxed);
         });
 
-        info!("[agent-handle] Agent spawned — reader task started");
-
-        Ok(Self {
-            writer,
-            response_request_tx,
-            alive,
-        })
+        Ok(Self { alive })
     }
 
-    async fn send_request(&mut self, request: AgentRequest) -> Result<AgentResponse> {
-        if !self.alive.load(Ordering::Relaxed) {
-            return Ok(AgentResponse::Error {
-                error: "Agent is not running".to_string(),
-            });
-        }
-
-        // Register for the response BEFORE sending the request
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.response_request_tx
-            .send(reply_tx)
-            .await
-            .map_err(|_| anyhow::anyhow!("Reader task closed"))?;
-
-        // Send request
-        let json = serde_json::to_vec(&request)?;
-        {
-            let mut w = self.writer.lock().await;
-            send_typed_frame(&mut *w, NotebookFrameType::Request, &json).await?;
-        }
-
-        // Wait for response
-        reply_rx
-            .await
-            .map_err(|_| anyhow::anyhow!("Reader task dropped response"))
-    }
-
-    pub async fn launch_kernel(
-        &mut self,
-        kernel_type: &str,
-        env_source: &str,
-        notebook_path: Option<&str>,
-        launched_config: LaunchedEnvConfig,
-    ) -> Result<AgentResponse> {
-        self.send_request(AgentRequest::LaunchKernel {
-            kernel_type: kernel_type.to_string(),
-            env_source: env_source.to_string(),
-            notebook_path: notebook_path.map(String::from),
-            launched_config,
-            env_vars: Default::default(),
-        })
-        .await
-    }
-
-    pub async fn execute_cell(
-        &mut self,
-        cell_id: &str,
-        code: &str,
-        execution_id: &str,
-    ) -> Result<AgentResponse> {
-        self.send_request(AgentRequest::ExecuteCell {
-            cell_id: cell_id.to_string(),
-            code: code.to_string(),
-            execution_id: execution_id.to_string(),
-        })
-        .await
-    }
-
-    pub async fn interrupt(&mut self) -> Result<AgentResponse> {
-        self.send_request(AgentRequest::InterruptExecution).await
-    }
-
-    pub async fn shutdown_kernel(&mut self) -> Result<AgentResponse> {
-        self.send_request(AgentRequest::ShutdownKernel).await
-    }
-
-    pub async fn send_comm(&mut self, message: serde_json::Value) -> Result<AgentResponse> {
-        self.send_request(AgentRequest::SendComm { message }).await
-    }
-
-    pub async fn complete(&mut self, code: &str, cursor_pos: usize) -> Result<AgentResponse> {
-        self.send_request(AgentRequest::Complete {
-            code: code.to_string(),
-            cursor_pos,
-        })
-        .await
-    }
-
-    pub async fn get_history(
-        &mut self,
-        pattern: Option<&str>,
-        n: i32,
-        unique: bool,
-    ) -> Result<AgentResponse> {
-        self.send_request(AgentRequest::GetHistory {
-            pattern: pattern.map(String::from),
-            n,
-            unique,
-        })
-        .await
-    }
-
+    /// Check if the agent process is still running.
     pub fn is_alive(&self) -> bool {
         self.alive.load(Ordering::Relaxed)
-    }
-
-    pub async fn shutdown(&mut self) {
-        if self.is_alive() {
-            let _ = self.shutdown_kernel().await;
-        }
-        self.alive.store(false, Ordering::Relaxed);
     }
 }

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -378,6 +378,11 @@ pub struct DaemonAlreadyRunning {
 }
 
 impl Daemon {
+    /// Get the daemon's Unix socket path.
+    pub fn socket_path(&self) -> &PathBuf {
+        &self.config.socket_path
+    }
+
     /// Create a new daemon with the given configuration.
     ///
     /// Returns an error if another daemon is already running.
@@ -1154,11 +1159,40 @@ impl Daemon {
                 self.handle_create_notebook(stream, runtime, working_dir, notebook_id)
                     .await
             }
-            Handshake::RuntimeAgent { .. } => {
-                // Runtime agent handshake is for agent subprocesses, not daemon
-                // socket connections. Reject it here.
-                warn!("[runtimed] Received RuntimeAgent handshake on daemon socket — rejecting");
-                Ok(())
+            Handshake::RuntimeAgent {
+                notebook_id,
+                agent_id,
+                blob_root: _,
+            } => {
+                info!(
+                    "[runtimed] Agent connecting via socket: notebook={} agent={}",
+                    notebook_id, agent_id
+                );
+                let room = {
+                    let rooms = self.notebook_rooms.lock().await;
+                    rooms.get(&notebook_id).cloned()
+                };
+                match room {
+                    Some(room) => {
+                        let (reader, writer) = tokio::io::split(stream);
+                        crate::notebook_sync_server::handle_agent_sync_connection(
+                            reader,
+                            writer,
+                            room,
+                            notebook_id,
+                            agent_id,
+                        )
+                        .await;
+                        Ok(())
+                    }
+                    None => {
+                        warn!(
+                            "[runtimed] Agent connected to unknown room: {}",
+                            notebook_id
+                        );
+                        Ok(())
+                    }
+                }
             }
         }
     }

--- a/crates/runtimed/src/main.rs
+++ b/crates/runtimed/src/main.rs
@@ -105,7 +105,20 @@ enum Commands {
 
     /// Run as a runtime agent subprocess (internal, used by coordinator)
     #[command(hide = true)]
-    Agent,
+    Agent {
+        /// Daemon socket path to connect to
+        #[arg(long)]
+        socket: PathBuf,
+        /// Notebook ID to attach to
+        #[arg(long)]
+        notebook_id: String,
+        /// Agent ID
+        #[arg(long)]
+        agent_id: String,
+        /// Blob store root path
+        #[arg(long)]
+        blob_root: PathBuf,
+    },
 }
 
 /// Get a log path that works even when HOME is not set.
@@ -335,32 +348,17 @@ async fn main() -> anyhow::Result<()> {
             );
             flush_pool().await
         }
-        Some(Commands::Agent) => {
-            // Agent mode: communicate over stdin/stdout using framed protocol.
-            #[cfg(unix)]
-            {
-                // Use tokio::fs::File from raw fd to avoid tokio::io::stdout()
-                // buffering issues that prevent frames from being read by the parent.
-                use std::os::unix::io::FromRawFd;
-                let stdin = unsafe { tokio::fs::File::from_raw_fd(0) };
-                let stdout = unsafe { tokio::fs::File::from_raw_fd(1) };
-                runtimed::agent::run_agent(stdin, stdout)
-                    .await
-                    .map_err(|e| {
-                        eprintln!("[agent] Fatal: {}", e);
-                        e
-                    })
-            }
-            #[cfg(not(unix))]
-            {
-                runtimed::agent::run_agent(tokio::io::stdin(), tokio::io::stdout())
-                    .await
-                    .map_err(|e| {
-                        eprintln!("[agent] Fatal: {}", e);
-                        e
-                    })
-            }
-        }
+        Some(Commands::Agent {
+            socket,
+            notebook_id,
+            agent_id,
+            blob_root,
+        }) => runtimed::agent::run_agent(socket, notebook_id, agent_id, blob_root)
+            .await
+            .map_err(|e| {
+                eprintln!("[agent] Fatal: {}", e);
+                e
+            }),
     }
 }
 

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -4640,8 +4640,12 @@ async fn handle_notebook_request(
                         notebook_protocol::protocol::AgentRequest::ShutdownKernel,
                     )
                     .await;
+                    // Clear both handle and request channel so subsequent
+                    // ExecuteCell/Complete/etc. fall through to NoKernel
                     let mut guard = room.agent_handle.lock().await;
                     *guard = None;
+                    let mut tx_guard = room.agent_request_tx.lock().await;
+                    *tx_guard = None;
                     return NotebookResponse::KernelShuttingDown {};
                 }
             }

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -81,12 +81,41 @@ pub(crate) fn catch_automerge_panic<T>(label: &str, f: impl FnOnce() -> T) -> Re
     }
 }
 
+/// Sender half of the agent RPC channel.
+type AgentRequestSender = tokio::sync::mpsc::Sender<(
+    notebook_protocol::protocol::AgentRequest,
+    tokio::sync::oneshot::Sender<notebook_protocol::protocol::AgentResponse>,
+)>;
+
 /// Check if agent mode is enabled.
 ///
 /// Reads from the daemon's in-memory flag, which is initialized from
 /// the persisted settings doc and toggled via `runt agent enable/disable`.
 fn is_agent_mode_enabled(daemon: &crate::daemon::Daemon) -> bool {
     daemon.agent_mode.load(std::sync::atomic::Ordering::Relaxed)
+}
+
+/// Send an RPC request to the agent via its sync connection.
+///
+/// The agent's sync handler receives the request as a frame 0x01 and sends
+/// the response as frame 0x02. Returns error if no agent is connected.
+async fn send_agent_request(
+    room: &NotebookRoom,
+    request: notebook_protocol::protocol::AgentRequest,
+) -> anyhow::Result<notebook_protocol::protocol::AgentResponse> {
+    let tx = {
+        let guard = room.agent_request_tx.lock().await;
+        guard
+            .clone()
+            .ok_or_else(|| anyhow::anyhow!("Agent not connected"))?
+    };
+    let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+    tx.send((request, reply_tx))
+        .await
+        .map_err(|_| anyhow::anyhow!("Agent disconnected"))?;
+    reply_rx
+        .await
+        .map_err(|_| anyhow::anyhow!("Agent dropped reply"))
 }
 
 /// Trust state for a notebook room.
@@ -889,10 +918,21 @@ pub struct NotebookRoom {
     /// Optional agent handle for process-isolated kernel execution.
     /// When set, kernel requests are routed to the agent subprocess
     /// instead of the local `RoomKernel`. Set by `LaunchKernel` when
-    /// `RUNT_AGENT_MODE=1`.
+    /// agent mode is enabled.
     pub agent_handle: Arc<Mutex<Option<crate::agent_handle::AgentHandle>>>,
     /// Environment path used by an agent-backed kernel, for GC protection.
     pub agent_env_path: Arc<RwLock<Option<PathBuf>>>,
+    /// Channel for sending RPC requests (LaunchKernel, Interrupt, etc.) to the
+    /// agent's sync connection. Set when agent connects via socket, cleared on
+    /// agent disconnect.
+    pub agent_request_tx: Arc<Mutex<Option<AgentRequestSender>>>,
+    /// Fires when the agent establishes its sync connection.
+    /// LaunchKernel waits on this after spawning the agent process.
+    pub agent_connected: Arc<tokio::sync::Notify>,
+    /// Monotonic counter for execution queue ordering.
+    /// The coordinator bumps this for each ExecuteCell and stamps the seq
+    /// on the execution entry. The agent sorts by seq to determine order.
+    pub next_queue_seq: Arc<std::sync::atomic::AtomicU64>,
 }
 
 /// Maximum number of snapshots to keep per notebook hash.
@@ -1077,6 +1117,9 @@ impl NotebookRoom {
             state_changed_tx,
             agent_handle: Arc::new(Mutex::new(None)),
             agent_env_path: Arc::new(RwLock::new(None)),
+            agent_request_tx: Arc::new(Mutex::new(None)),
+            agent_connected: Arc::new(tokio::sync::Notify::new()),
+            next_queue_seq: Arc::new(std::sync::atomic::AtomicU64::new(0)),
         }
     }
 
@@ -1142,6 +1185,9 @@ impl NotebookRoom {
             state_changed_tx,
             agent_handle: Arc::new(Mutex::new(None)),
             agent_env_path: Arc::new(RwLock::new(None)),
+            agent_request_tx: Arc::new(Mutex::new(None)),
+            agent_connected: Arc::new(tokio::sync::Notify::new()),
+            next_queue_seq: Arc::new(std::sync::atomic::AtomicU64::new(0)),
         }
     }
 
@@ -1289,6 +1335,227 @@ pub fn get_or_create_room(
 /// doc bytes are flushed via debounced persistence.
 ///
 /// Uses v2 typed frames protocol (with first-byte type indicator).
+/// Handle an agent subprocess that connected back to the daemon's Unix socket.
+///
+/// The agent is a special peer that owns the kernel for this notebook room.
+/// It receives RPC requests (LaunchKernel, Interrupt, etc.) via frame 0x01
+/// and watches RuntimeStateDoc for queued executions via frame 0x05.
+///
+/// This handler:
+/// 1. Performs initial NotebookDoc + RuntimeStateDoc sync
+/// 2. Sets up the `agent_request_tx` channel on the room
+/// 3. Fires `agent_connected` to unblock LaunchKernel
+/// 4. Enters a sync loop relaying frames bidirectionally
+pub async fn handle_agent_sync_connection<R, W>(
+    mut reader: R,
+    mut writer: W,
+    room: Arc<NotebookRoom>,
+    notebook_id: String,
+    agent_id: String,
+) where
+    R: tokio::io::AsyncRead + Unpin + Send,
+    W: tokio::io::AsyncWrite + Unpin + Send,
+{
+    use notebook_protocol::connection::{recv_typed_frame, send_typed_frame, NotebookFrameType};
+    use notebook_protocol::protocol::{AgentRequest, AgentResponse};
+
+    info!(
+        "[notebook-sync] Agent sync connection: notebook={} agent={}",
+        notebook_id, agent_id
+    );
+
+    // ── 1. Initial NotebookDoc sync ──────────────────────────────────
+    let mut doc_sync_state = automerge::sync::State::new();
+    {
+        let mut doc = room.doc.write().await;
+        // Generate our sync message (full doc state for fresh peer)
+        if let Some(msg) = doc.generate_sync_message(&mut doc_sync_state) {
+            let encoded = msg.encode();
+            if let Err(e) =
+                send_typed_frame(&mut writer, NotebookFrameType::AutomergeSync, &encoded).await
+            {
+                warn!("[notebook-sync] Agent initial doc sync send failed: {}", e);
+                return;
+            }
+        }
+    }
+
+    // ── 2. Initial RuntimeStateDoc sync ──────────────────────────────
+    let mut state_sync_state = automerge::sync::State::new();
+    {
+        let mut sd = room.state_doc.write().await;
+        if let Some(msg) = sd.generate_sync_message(&mut state_sync_state) {
+            let encoded = msg.encode();
+            if let Err(e) =
+                send_typed_frame(&mut writer, NotebookFrameType::RuntimeStateSync, &encoded).await
+            {
+                warn!(
+                    "[notebook-sync] Agent initial state sync send failed: {}",
+                    e
+                );
+                return;
+            }
+        }
+    }
+
+    // ── 3. Set up request channel ────────────────────────────────────
+    let (agent_tx, mut agent_rx) = tokio::sync::mpsc::channel::<(
+        AgentRequest,
+        tokio::sync::oneshot::Sender<AgentResponse>,
+    )>(16);
+    {
+        let mut tx_guard = room.agent_request_tx.lock().await;
+        *tx_guard = Some(agent_tx);
+    }
+
+    // ── 4. Signal that the agent is connected ────────────────────────
+    room.agent_connected.notify_waiters();
+    info!("[notebook-sync] Agent connected and ready: {}", agent_id);
+
+    // ── 5. Sync loop ─────────────────────────────────────────────────
+    let mut changed_rx = room.changed_tx.subscribe();
+    let mut state_changed_rx = room.state_changed_tx.subscribe();
+    let mut pending_reply: Option<tokio::sync::oneshot::Sender<AgentResponse>> = None;
+
+    loop {
+        tokio::select! {
+            // Frames from agent
+            frame = recv_typed_frame(&mut reader) => {
+                match frame {
+                    Ok(Some(typed_frame)) => {
+                        match typed_frame.frame_type {
+                            NotebookFrameType::AutomergeSync => {
+                                if let Ok(msg) = automerge::sync::Message::decode(&typed_frame.payload) {
+                                    let mut doc = room.doc.write().await;
+                                    if doc.receive_sync_message(&mut doc_sync_state, msg).is_ok() {
+                                        let _ = room.changed_tx.send(());
+                                    }
+                                    // Send sync reply
+                                    if let Some(reply) = doc.generate_sync_message(&mut doc_sync_state) {
+                                        let encoded = reply.encode();
+                                        let _ = send_typed_frame(
+                                            &mut writer,
+                                            NotebookFrameType::AutomergeSync,
+                                            &encoded,
+                                        ).await;
+                                    }
+                                }
+                            }
+                            NotebookFrameType::RuntimeStateSync => {
+                                if let Ok(msg) = automerge::sync::Message::decode(&typed_frame.payload) {
+                                    let mut sd = room.state_doc.write().await;
+                                    if let Ok(changed) = sd.receive_sync_message_with_changes(
+                                        &mut state_sync_state, msg,
+                                    ) {
+                                        if changed {
+                                            let _ = room.state_changed_tx.send(());
+                                        }
+                                    }
+                                    // Send sync reply
+                                    if let Some(reply) = sd.generate_sync_message(&mut state_sync_state) {
+                                        let encoded = reply.encode();
+                                        let _ = send_typed_frame(
+                                            &mut writer,
+                                            NotebookFrameType::RuntimeStateSync,
+                                            &encoded,
+                                        ).await;
+                                    }
+                                }
+                            }
+                            NotebookFrameType::Response => {
+                                // Agent responded to an RPC request
+                                if let Ok(response) = serde_json::from_slice::<AgentResponse>(&typed_frame.payload) {
+                                    if let Some(reply) = pending_reply.take() {
+                                        let _ = reply.send(response);
+                                    } else {
+                                        warn!("[notebook-sync] Agent response with no pending request");
+                                    }
+                                }
+                            }
+                            _ => {
+                                debug!("[notebook-sync] Agent sent unexpected frame type: {:?}", typed_frame.frame_type);
+                            }
+                        }
+                    }
+                    Ok(None) => {
+                        info!("[notebook-sync] Agent disconnected (EOF)");
+                        break;
+                    }
+                    Err(e) => {
+                        info!("[notebook-sync] Agent disconnected: {}", e);
+                        break;
+                    }
+                }
+            }
+
+            // NotebookDoc changes (from other peers) → sync to agent
+            _ = changed_rx.recv() => {
+                while changed_rx.try_recv().is_ok() {}
+                let mut doc = room.doc.write().await;
+                if let Some(msg) = doc.generate_sync_message(&mut doc_sync_state) {
+                    let encoded = msg.encode();
+                    if let Err(e) = send_typed_frame(
+                        &mut writer,
+                        NotebookFrameType::AutomergeSync,
+                        &encoded,
+                    ).await {
+                        warn!("[notebook-sync] Failed to sync doc to agent: {}", e);
+                        break;
+                    }
+                }
+            }
+
+            // RuntimeStateDoc changes → sync to agent
+            _ = state_changed_rx.recv() => {
+                while state_changed_rx.try_recv().is_ok() {}
+                let mut sd = room.state_doc.write().await;
+                if let Some(msg) = sd.generate_sync_message(&mut state_sync_state) {
+                    let encoded = msg.encode();
+                    if let Err(e) = send_typed_frame(
+                        &mut writer,
+                        NotebookFrameType::RuntimeStateSync,
+                        &encoded,
+                    ).await {
+                        warn!("[notebook-sync] Failed to sync state to agent: {}", e);
+                        break;
+                    }
+                }
+            }
+
+            // RPC requests to forward to agent
+            Some((request, reply_tx)) = agent_rx.recv() => {
+                let json = match serde_json::to_vec(&request) {
+                    Ok(j) => j,
+                    Err(e) => {
+                        let _ = reply_tx.send(AgentResponse::Error {
+                            error: format!("Serialize error: {}", e),
+                        });
+                        continue;
+                    }
+                };
+                if let Err(e) = send_typed_frame(
+                    &mut writer,
+                    NotebookFrameType::Request,
+                    &json,
+                ).await {
+                    let _ = reply_tx.send(AgentResponse::Error {
+                        error: format!("Send error: {}", e),
+                    });
+                    break;
+                }
+                pending_reply = Some(reply_tx);
+            }
+        }
+    }
+
+    // Cleanup: clear the request channel so callers know agent is gone
+    {
+        let mut tx_guard = room.agent_request_tx.lock().await;
+        *tx_guard = None;
+    }
+    info!("[notebook-sync] Agent sync connection closed: {}", agent_id);
+}
+
 ///
 /// If `skip_capabilities` is true, the ProtocolCapabilities frame is not sent.
 /// This is used for OpenNotebook/CreateNotebook handshakes where the protocol
@@ -3069,42 +3336,56 @@ async fn auto_launch_kernel(
 
         let nb_id = notebook_id.to_string();
         let agent_id = format!("rt:agent:{}", &uuid::Uuid::new_v4().to_string()[..8]);
+        let socket_path = daemon.socket_path().clone();
 
         match crate::agent_handle::AgentHandle::spawn(
             nb_id,
-            agent_id,
+            agent_id.clone(),
             room.blob_store.root().to_path_buf(),
-            room.state_doc.clone(),
-            room.state_changed_tx.clone(),
-            room.kernel_broadcast_tx.clone(),
+            socket_path,
         )
         .await
         {
-            Ok(mut agent) => {
-                // Send LaunchKernel to the agent
-                match agent
-                    .launch_kernel(
-                        kernel_type,
-                        &env_source,
-                        notebook_path_opt
-                            .as_deref()
-                            .map(|p| p.to_str().unwrap_or("")),
-                        launched_config.clone(),
-                    )
-                    .await
+            Ok(agent) => {
+                // Store handle and wait for agent to connect back via socket
                 {
+                    let mut agent_guard = room.agent_handle.lock().await;
+                    *agent_guard = Some(agent);
+                }
+
+                // Wait for agent to establish its sync connection
+                match tokio::time::timeout(
+                    std::time::Duration::from_secs(30),
+                    room.agent_connected.notified(),
+                )
+                .await
+                {
+                    Ok(()) => {
+                        info!("[notebook-sync] Agent connected, sending LaunchKernel");
+                    }
+                    Err(_) => {
+                        warn!("[notebook-sync] Agent failed to connect within 30s");
+                        reset_starting_state(room).await;
+                        return;
+                    }
+                }
+
+                // Send LaunchKernel RPC via the agent's sync connection
+                let launch_request = notebook_protocol::protocol::AgentRequest::LaunchKernel {
+                    kernel_type: kernel_type.to_string(),
+                    env_source: env_source.clone(),
+                    notebook_path: notebook_path_opt
+                        .as_deref()
+                        .map(|p| p.to_str().unwrap_or("").to_string()),
+                    launched_config: launched_config.clone(),
+                    env_vars: Default::default(),
+                };
+
+                match send_agent_request(room, launch_request).await {
                     Ok(notebook_protocol::protocol::AgentResponse::KernelLaunched {
                         env_source: es,
                     }) => {
-                        // No state_doc replacement needed — the agent bootstrapped
-                        // FROM the coordinator's doc (like frontend NotebookDoc).
-                        // The coordinator keeps its scaffolded doc; the agent
-                        // writes with a different actor. No DuplicateSeqNumber.
-
-                        let mut agent_guard = room.agent_handle.lock().await;
-                        *agent_guard = Some(agent);
                         drop(kernel_guard);
-                        drop(agent_guard);
 
                         // Store env path for GC protection
                         if let Some(ref env) = pooled_env {
@@ -3122,15 +3403,19 @@ async fn auto_launch_kernel(
                         return;
                     }
                     Ok(notebook_protocol::protocol::AgentResponse::Error { error }) => {
-                        warn!(
-                            "[notebook-sync] Agent kernel launch failed: {} — falling back to local",
-                            error
-                        );
-                        // Fall through to local launch below
+                        warn!("[notebook-sync] Agent kernel launch failed: {}", error);
+                        reset_starting_state(room).await;
+                        return;
                     }
-                    _ => {
-                        warn!("[notebook-sync] Unexpected agent response — falling back to local");
-                        // Fall through to local launch below
+                    Ok(_) => {
+                        warn!("[notebook-sync] Unexpected agent response during auto-launch");
+                        reset_starting_state(room).await;
+                        return;
+                    }
+                    Err(e) => {
+                        warn!("[notebook-sync] Agent communication error: {}", e);
+                        reset_starting_state(room).await;
+                        return;
                     }
                 }
             }
@@ -3876,44 +4161,60 @@ async fn handle_notebook_request(
             }
 
             // Check if agent mode is enabled.
-            // Default: ON in dev mode (RUNTIMED_DEV=1), OFF in production.
-            // Override: RUNT_AGENT_MODE=1 to force on, RUNT_AGENT_MODE=0 to force off.
             if is_agent_mode_enabled(&daemon) {
-                info!("[notebook-sync] RUNT_AGENT_MODE=1: spawning agent subprocess");
+                info!("[notebook-sync] Agent mode: spawning agent subprocess");
 
                 let notebook_id = room.notebook_path.read().await.display().to_string();
                 let agent_id = format!("rt:agent:{}", &uuid::Uuid::new_v4().to_string()[..8]);
+                let socket_path = daemon.socket_path().clone();
 
                 match crate::agent_handle::AgentHandle::spawn(
                     notebook_id,
                     agent_id,
                     room.blob_store.root().to_path_buf(),
-                    room.state_doc.clone(),
-                    room.state_changed_tx.clone(),
-                    room.kernel_broadcast_tx.clone(),
+                    socket_path,
                 )
                 .await
                 {
-                    Ok(mut agent) => {
-                        // Send LaunchKernel to the agent
-                        match agent
-                            .launch_kernel(
-                                &resolved_kernel_type,
-                                &resolved_env_source,
-                                notebook_path.as_deref().map(|p| p.to_str().unwrap_or("")),
-                                launched_config.clone(),
-                            )
-                            .await
+                    Ok(agent) => {
                         {
+                            let mut agent_guard = room.agent_handle.lock().await;
+                            *agent_guard = Some(agent);
+                        }
+
+                        // Wait for agent to connect back via socket
+                        match tokio::time::timeout(
+                            std::time::Duration::from_secs(30),
+                            room.agent_connected.notified(),
+                        )
+                        .await
+                        {
+                            Ok(()) => {}
+                            Err(_) => {
+                                reset_starting_state(room).await;
+                                return NotebookResponse::Error {
+                                    error: "Agent failed to connect within 30s".to_string(),
+                                };
+                            }
+                        }
+
+                        // Send LaunchKernel RPC
+                        let launch_request =
+                            notebook_protocol::protocol::AgentRequest::LaunchKernel {
+                                kernel_type: resolved_kernel_type.clone(),
+                                env_source: resolved_env_source.clone(),
+                                notebook_path: notebook_path
+                                    .as_deref()
+                                    .map(|p| p.to_str().unwrap_or("").to_string()),
+                                launched_config: launched_config.clone(),
+                                env_vars: Default::default(),
+                            };
+
+                        match send_agent_request(room, launch_request).await {
                             Ok(notebook_protocol::protocol::AgentResponse::KernelLaunched {
                                 env_source: es,
                             }) => {
-                                // Agent launched — replace state_doc with empty
-                                // to avoid DuplicateSeqNumber with agent's doc.
-                                let mut agent_guard = room.agent_handle.lock().await;
-                                *agent_guard = Some(agent);
                                 drop(kernel_guard);
-                                drop(agent_guard);
 
                                 publish_kernel_state_presence(
                                     room,
@@ -3923,7 +4224,7 @@ async fn handle_notebook_request(
                                 .await;
 
                                 // Write kernel status + info + prewarmed packages
-                                // to RuntimeStateDoc (mirrors the local launch path)
+                                // to RuntimeStateDoc
                                 {
                                     let mut sd = room.state_doc.write().await;
                                     let mut changed = false;
@@ -4106,36 +4407,61 @@ async fn handle_notebook_request(
                 };
             }
 
-            // Check for agent-backed kernel first
+            // Agent-backed kernel: write execution to RuntimeStateDoc queue.
+            // The agent discovers it via CRDT sync and executes.
             {
-                let mut agent_guard = room.agent_handle.lock().await;
-                if let Some(ref mut agent) = *agent_guard {
+                let agent_guard = room.agent_handle.lock().await;
+                if agent_guard.is_some() {
                     let execution_id = uuid::Uuid::new_v4().to_string();
-                    // Stamp execution_id on the cell before sending to agent
+                    let seq = room
+                        .next_queue_seq
+                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
+                    // Stamp execution_id on the cell in NotebookDoc
                     {
                         let mut doc = room.doc.write().await;
                         let _ = doc.set_execution_id(&cell_id, Some(&execution_id));
                         let _ = room.changed_tx.send(());
                     }
-                    return match agent.execute_cell(&cell_id, &source, &execution_id).await {
-                        Ok(resp) => match resp {
-                            notebook_protocol::protocol::AgentResponse::CellQueued {
-                                cell_id,
-                                execution_id,
-                            } => NotebookResponse::CellQueued {
-                                cell_id,
-                                execution_id,
-                            },
-                            notebook_protocol::protocol::AgentResponse::Error { error } => {
-                                NotebookResponse::Error { error }
+
+                    // Write execution entry with source to RuntimeStateDoc
+                    {
+                        let mut sd = room.state_doc.write().await;
+                        sd.create_execution_with_source(&execution_id, &cell_id, &source, seq);
+                        let _ = room.state_changed_tx.send(());
+                    }
+
+                    // Best-effort background formatting via fork+merge
+                    let fork = {
+                        let mut doc = room.doc.write().await;
+                        doc.fork()
+                    };
+                    let room_clone = Arc::clone(room);
+                    let cell_id_clone = cell_id.clone();
+                    let source_clone = source.clone();
+                    tokio::spawn(async move {
+                        if let Some(runtime) = detect_room_runtime(&room_clone).await {
+                            if let Some(formatted) = format_source(&source_clone, &runtime).await {
+                                let mut fork = fork;
+                                let actor = formatter_actor(&runtime);
+                                fork.set_actor(&actor);
+                                if fork.update_source(&cell_id_clone, &formatted).is_ok() {
+                                    let mut doc = room_clone.doc.write().await;
+                                    if let Err(e) = catch_automerge_panic("format-merge", || {
+                                        doc.merge(&mut fork)
+                                    }) {
+                                        warn!("{}", e);
+                                        doc.rebuild_from_save();
+                                    }
+                                    let _ = room_clone.changed_tx.send(());
+                                }
                             }
-                            _ => NotebookResponse::Error {
-                                error: "Unexpected agent response".to_string(),
-                            },
-                        },
-                        Err(e) => NotebookResponse::Error {
-                            error: format!("Agent error: {}", e),
-                        },
+                        }
+                    });
+
+                    return NotebookResponse::CellQueued {
+                        cell_id,
+                        execution_id,
                     };
                 }
             }
@@ -4256,11 +4582,16 @@ async fn handle_notebook_request(
         }
 
         NotebookRequest::InterruptExecution {} => {
-            // Agent path
+            // Agent path: send RPC via sync connection
             {
-                let mut agent_guard = room.agent_handle.lock().await;
-                if let Some(ref mut agent) = *agent_guard {
-                    return match agent.interrupt().await {
+                let agent_guard = room.agent_handle.lock().await;
+                if agent_guard.is_some() {
+                    return match send_agent_request(
+                        room,
+                        notebook_protocol::protocol::AgentRequest::InterruptExecution,
+                    )
+                    .await
+                    {
                         Ok(_) => NotebookResponse::InterruptSent {},
                         Err(e) => NotebookResponse::Error {
                             error: format!("Agent interrupt error: {}", e),
@@ -4283,12 +4614,18 @@ async fn handle_notebook_request(
         }
 
         NotebookRequest::ShutdownKernel {} => {
-            // Agent path
+            // Agent path: send shutdown RPC, then clear handle
             {
-                let mut agent_guard = room.agent_handle.lock().await;
-                if let Some(ref mut agent) = *agent_guard {
-                    agent.shutdown().await;
-                    *agent_guard = None;
+                let agent_guard = room.agent_handle.lock().await;
+                if agent_guard.is_some() {
+                    let _ = send_agent_request(
+                        room,
+                        notebook_protocol::protocol::AgentRequest::ShutdownKernel,
+                    )
+                    .await;
+                    drop(agent_guard);
+                    let mut guard = room.agent_handle.lock().await;
+                    *guard = None;
                     return NotebookResponse::KernelShuttingDown {};
                 }
             }
@@ -4408,51 +4745,39 @@ async fn handle_notebook_request(
         }
 
         NotebookRequest::RunAllCells {} => {
-            // Agent path — read all cells, send each to agent
+            // Agent path — write all cells to RuntimeStateDoc queue
             {
-                let mut agent_guard = room.agent_handle.lock().await;
-                if let Some(ref mut agent) = *agent_guard {
+                let agent_guard = room.agent_handle.lock().await;
+                if agent_guard.is_some() {
                     let cells = {
                         let doc = room.doc.read().await;
                         doc.get_cells()
                     };
 
                     let mut queued = Vec::new();
-                    for cell in cells {
-                        if cell.cell_type == "code" {
-                            let execution_id = uuid::Uuid::new_v4().to_string();
-                            match agent
-                                .execute_cell(&cell.id, &cell.source, &execution_id)
-                                .await
-                            {
-                                Ok(notebook_protocol::protocol::AgentResponse::CellQueued {
-                                    cell_id,
+                    {
+                        let mut sd = room.state_doc.write().await;
+                        let mut doc = room.doc.write().await;
+                        for cell in &cells {
+                            if cell.cell_type == "code" {
+                                let execution_id = uuid::Uuid::new_v4().to_string();
+                                let seq = room
+                                    .next_queue_seq
+                                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                                sd.create_execution_with_source(
+                                    &execution_id,
+                                    &cell.id,
+                                    &cell.source,
+                                    seq,
+                                );
+                                let _ = doc.set_execution_id(&cell.id, Some(&execution_id));
+                                queued.push(QueueEntry {
+                                    cell_id: cell.id.clone(),
                                     execution_id,
-                                }) => {
-                                    queued.push(QueueEntry {
-                                        cell_id,
-                                        execution_id,
-                                    });
-                                }
-                                Ok(notebook_protocol::protocol::AgentResponse::Error { error }) => {
-                                    return NotebookResponse::Error {
-                                        error: format!(
-                                            "Agent failed to queue cell {}: {}",
-                                            cell.id, error
-                                        ),
-                                    };
-                                }
-                                _ => {}
+                                });
                             }
                         }
-                    }
-
-                    // Stamp execution_ids in NotebookDoc
-                    {
-                        let mut doc = room.doc.write().await;
-                        for entry in &queued {
-                            let _ = doc.set_execution_id(&entry.cell_id, Some(&entry.execution_id));
-                        }
+                        let _ = room.state_changed_tx.send(());
                         let _ = room.changed_tx.send(());
                     }
 
@@ -4550,9 +4875,16 @@ async fn handle_notebook_request(
         NotebookRequest::SendComm { message } => {
             // Agent path
             {
-                let mut agent_guard = room.agent_handle.lock().await;
-                if let Some(ref mut agent) = *agent_guard {
-                    return match agent.send_comm(message).await {
+                let agent_guard = room.agent_handle.lock().await;
+                if agent_guard.is_some() {
+                    return match send_agent_request(
+                        room,
+                        notebook_protocol::protocol::AgentRequest::SendComm {
+                            message: message.clone(),
+                        },
+                    )
+                    .await
+                    {
                         Ok(_) => NotebookResponse::Ok {},
                         Err(e) => NotebookResponse::Error {
                             error: format!("Agent comm error: {}", e),
@@ -4600,9 +4932,18 @@ async fn handle_notebook_request(
         NotebookRequest::GetHistory { pattern, n, unique } => {
             // Agent path
             {
-                let mut agent_guard = room.agent_handle.lock().await;
-                if let Some(ref mut agent) = *agent_guard {
-                    return match agent.get_history(pattern.as_deref(), n, unique).await {
+                let agent_guard = room.agent_handle.lock().await;
+                if agent_guard.is_some() {
+                    return match send_agent_request(
+                        room,
+                        notebook_protocol::protocol::AgentRequest::GetHistory {
+                            pattern: pattern.clone(),
+                            n,
+                            unique,
+                        },
+                    )
+                    .await
+                    {
                         Ok(notebook_protocol::protocol::AgentResponse::HistoryResult {
                             entries,
                         }) => NotebookResponse::HistoryResult { entries },
@@ -4635,9 +4976,17 @@ async fn handle_notebook_request(
         NotebookRequest::Complete { code, cursor_pos } => {
             // Agent path
             {
-                let mut agent_guard = room.agent_handle.lock().await;
-                if let Some(ref mut agent) = *agent_guard {
-                    return match agent.complete(&code, cursor_pos).await {
+                let agent_guard = room.agent_handle.lock().await;
+                if agent_guard.is_some() {
+                    return match send_agent_request(
+                        room,
+                        notebook_protocol::protocol::AgentRequest::Complete {
+                            code: code.clone(),
+                            cursor_pos,
+                        },
+                    )
+                    .await
+                    {
                         Ok(notebook_protocol::protocol::AgentResponse::CompletionResult {
                             items,
                             cursor_start,
@@ -7751,6 +8100,9 @@ mod tests {
             state_changed_tx,
             agent_handle: Arc::new(Mutex::new(None)),
             agent_env_path: Arc::new(RwLock::new(None)),
+            agent_request_tx: Arc::new(Mutex::new(None)),
+            agent_connected: Arc::new(tokio::sync::Notify::new()),
+            next_queue_seq: Arc::new(std::sync::atomic::AtomicU64::new(0)),
         };
 
         (room, notebook_path)

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -927,8 +927,8 @@ pub struct NotebookRoom {
     /// agent disconnect.
     pub agent_request_tx: Arc<Mutex<Option<AgentRequestSender>>>,
     /// Fires when the agent establishes its sync connection.
-    /// LaunchKernel waits on this after spawning the agent process.
-    pub agent_connected: Arc<tokio::sync::Notify>,
+    /// Uses `watch(false)` → `true` to avoid lost wakeups.
+    agent_connected_tx: Arc<tokio::sync::watch::Sender<bool>>,
     /// Monotonic counter for execution queue ordering.
     /// The coordinator bumps this for each ExecuteCell and stamps the seq
     /// on the execution entry. The agent sorts by seq to determine order.
@@ -1118,7 +1118,10 @@ impl NotebookRoom {
             agent_handle: Arc::new(Mutex::new(None)),
             agent_env_path: Arc::new(RwLock::new(None)),
             agent_request_tx: Arc::new(Mutex::new(None)),
-            agent_connected: Arc::new(tokio::sync::Notify::new()),
+            agent_connected_tx: {
+                let (tx, _) = tokio::sync::watch::channel(false);
+                Arc::new(tx)
+            },
             next_queue_seq: Arc::new(std::sync::atomic::AtomicU64::new(0)),
         }
     }
@@ -1186,7 +1189,10 @@ impl NotebookRoom {
             agent_handle: Arc::new(Mutex::new(None)),
             agent_env_path: Arc::new(RwLock::new(None)),
             agent_request_tx: Arc::new(Mutex::new(None)),
-            agent_connected: Arc::new(tokio::sync::Notify::new()),
+            agent_connected_tx: {
+                let (tx, _) = tokio::sync::watch::channel(false);
+                Arc::new(tx)
+            },
             next_queue_seq: Arc::new(std::sync::atomic::AtomicU64::new(0)),
         }
     }
@@ -1409,7 +1415,7 @@ pub async fn handle_agent_sync_connection<R, W>(
     }
 
     // ── 4. Signal that the agent is connected ────────────────────────
-    room.agent_connected.notify_waiters();
+    let _ = room.agent_connected_tx.send(true);
     info!("[notebook-sync] Agent connected and ready: {}", agent_id);
 
     // ── 5. Sync loop ─────────────────────────────────────────────────
@@ -1522,8 +1528,9 @@ pub async fn handle_agent_sync_connection<R, W>(
                 }
             }
 
-            // RPC requests to forward to agent
-            Some((request, reply_tx)) = agent_rx.recv() => {
+            // RPC requests to forward to agent (only accept when no reply is pending
+            // to serialize RPCs and prevent overwriting the reply slot)
+            Some((request, reply_tx)) = agent_rx.recv(), if pending_reply.is_none() => {
                 let json = match serde_json::to_vec(&request) {
                     Ok(j) => j,
                     Err(e) => {
@@ -1548,11 +1555,12 @@ pub async fn handle_agent_sync_connection<R, W>(
         }
     }
 
-    // Cleanup: clear the request channel so callers know agent is gone
+    // Cleanup: clear the request channel and reset connected signal
     {
         let mut tx_guard = room.agent_request_tx.lock().await;
         *tx_guard = None;
     }
+    let _ = room.agent_connected_tx.send(false);
     info!("[notebook-sync] Agent sync connection closed: {}", agent_id);
 }
 
@@ -3354,16 +3362,19 @@ async fn auto_launch_kernel(
                 }
 
                 // Wait for agent to establish its sync connection
-                match tokio::time::timeout(
-                    std::time::Duration::from_secs(30),
-                    room.agent_connected.notified(),
-                )
+                match tokio::time::timeout(std::time::Duration::from_secs(30), async {
+                    room.agent_connected_tx
+                        .subscribe()
+                        .wait_for(|v| *v)
+                        .await
+                        .map(|_| ())
+                })
                 .await
                 {
-                    Ok(()) => {
+                    Ok(Ok(_)) => {
                         info!("[notebook-sync] Agent connected, sending LaunchKernel");
                     }
-                    Err(_) => {
+                    Ok(Err(_)) | Err(_) => {
                         warn!("[notebook-sync] Agent failed to connect within 30s");
                         reset_starting_state(room).await;
                         return;
@@ -4183,14 +4194,17 @@ async fn handle_notebook_request(
                         }
 
                         // Wait for agent to connect back via socket
-                        match tokio::time::timeout(
-                            std::time::Duration::from_secs(30),
-                            room.agent_connected.notified(),
-                        )
+                        match tokio::time::timeout(std::time::Duration::from_secs(30), async {
+                            room.agent_connected_tx
+                                .subscribe()
+                                .wait_for(|v| *v)
+                                .await
+                                .map(|_| ())
+                        })
                         .await
                         {
-                            Ok(()) => {}
-                            Err(_) => {
+                            Ok(Ok(_)) => {}
+                            Ok(Err(_)) | Err(_) => {
                                 reset_starting_state(room).await;
                                 return NotebookResponse::Error {
                                     error: "Agent failed to connect within 30s".to_string(),
@@ -4409,9 +4423,12 @@ async fn handle_notebook_request(
 
             // Agent-backed kernel: write execution to RuntimeStateDoc queue.
             // The agent discovers it via CRDT sync and executes.
+            // Check agent_request_tx (not agent_handle) to ensure the agent's
+            // sync connection is still live — a stale handle with no connection
+            // would leave queued executions orphaned.
             {
-                let agent_guard = room.agent_handle.lock().await;
-                if agent_guard.is_some() {
+                let has_agent = room.agent_request_tx.lock().await.is_some();
+                if has_agent {
                     let execution_id = uuid::Uuid::new_v4().to_string();
                     let seq = room
                         .next_queue_seq
@@ -4584,8 +4601,8 @@ async fn handle_notebook_request(
         NotebookRequest::InterruptExecution {} => {
             // Agent path: send RPC via sync connection
             {
-                let agent_guard = room.agent_handle.lock().await;
-                if agent_guard.is_some() {
+                let has_agent = room.agent_request_tx.lock().await.is_some();
+                if has_agent {
                     return match send_agent_request(
                         room,
                         notebook_protocol::protocol::AgentRequest::InterruptExecution,
@@ -4616,14 +4633,13 @@ async fn handle_notebook_request(
         NotebookRequest::ShutdownKernel {} => {
             // Agent path: send shutdown RPC, then clear handle
             {
-                let agent_guard = room.agent_handle.lock().await;
-                if agent_guard.is_some() {
+                let has_agent = room.agent_request_tx.lock().await.is_some();
+                if has_agent {
                     let _ = send_agent_request(
                         room,
                         notebook_protocol::protocol::AgentRequest::ShutdownKernel,
                     )
                     .await;
-                    drop(agent_guard);
                     let mut guard = room.agent_handle.lock().await;
                     *guard = None;
                     return NotebookResponse::KernelShuttingDown {};
@@ -4747,8 +4763,8 @@ async fn handle_notebook_request(
         NotebookRequest::RunAllCells {} => {
             // Agent path — write all cells to RuntimeStateDoc queue
             {
-                let agent_guard = room.agent_handle.lock().await;
-                if agent_guard.is_some() {
+                let has_agent = room.agent_request_tx.lock().await.is_some();
+                if has_agent {
                     let cells = {
                         let doc = room.doc.read().await;
                         doc.get_cells()
@@ -4875,8 +4891,8 @@ async fn handle_notebook_request(
         NotebookRequest::SendComm { message } => {
             // Agent path
             {
-                let agent_guard = room.agent_handle.lock().await;
-                if agent_guard.is_some() {
+                let has_agent = room.agent_request_tx.lock().await.is_some();
+                if has_agent {
                     return match send_agent_request(
                         room,
                         notebook_protocol::protocol::AgentRequest::SendComm {
@@ -4932,8 +4948,8 @@ async fn handle_notebook_request(
         NotebookRequest::GetHistory { pattern, n, unique } => {
             // Agent path
             {
-                let agent_guard = room.agent_handle.lock().await;
-                if agent_guard.is_some() {
+                let has_agent = room.agent_request_tx.lock().await.is_some();
+                if has_agent {
                     return match send_agent_request(
                         room,
                         notebook_protocol::protocol::AgentRequest::GetHistory {
@@ -4976,8 +4992,8 @@ async fn handle_notebook_request(
         NotebookRequest::Complete { code, cursor_pos } => {
             // Agent path
             {
-                let agent_guard = room.agent_handle.lock().await;
-                if agent_guard.is_some() {
+                let has_agent = room.agent_request_tx.lock().await.is_some();
+                if has_agent {
                     return match send_agent_request(
                         room,
                         notebook_protocol::protocol::AgentRequest::Complete {
@@ -8101,7 +8117,10 @@ mod tests {
             agent_handle: Arc::new(Mutex::new(None)),
             agent_env_path: Arc::new(RwLock::new(None)),
             agent_request_tx: Arc::new(Mutex::new(None)),
-            agent_connected: Arc::new(tokio::sync::Notify::new()),
+            agent_connected_tx: {
+                let (tx, _) = tokio::sync::watch::channel(false);
+                Arc::new(tx)
+            },
             next_queue_seq: Arc::new(std::sync::atomic::AtomicU64::new(0)),
         };
 


### PR DESCRIPTION
## Summary

Replaces the stdin/stdout framed protocol between coordinator and agent with a standard Unix socket peer connection. The agent subprocess now connects back to the daemon socket like any other peer, using the existing handshake and frame protocol.

- **CRDT-driven execution**: Coordinator writes execution entries (with source + seq number) to RuntimeStateDoc. Agent discovers new entries via Automerge sync and processes them in seq order. No ExecuteCell RPC.
- **Map-based queue**: Execution entries ARE the queue — no parallel CRDT lists. Coordinator writes `status=queued`, agent transitions to `running`/`done`. Both writers only touch scalar Map fields (clean LWW semantics).
- **Simplified AgentHandle**: 90 lines (was 320). Just spawn + monitor — no reader task, no pending_reply, no stdin/stdout.
- **Execution audit log**: Source code stored in execution entries for traceability.

Eliminates the deadlock race condition that blocked multi-cell execution in the stdin/stdout approach.

Enables future work:
- SSH remote runtimes (#1334) — socket works over network
- Disconnection resilience — agent keeps executing, syncs outputs on reconnect
- Ephemeral markdown execution — any document can queue execution via CRDT

## Test plan

- [x] `cargo check` — full workspace clean, zero warnings
- [x] `cargo test -p notebook-doc` — new execution source/seq tests pass
- [x] `cargo test -p runtimed` — 184 lib + 22 integration tests pass
- [x] `cargo xtask lint` — all checks pass
- [x] End-to-end: create notebook → execute cell → verify output (`x = 42`)
- [x] Multi-cell variable persistence (`y = x * 2` → `y = 84`)
- [ ] CI