### PR TITLE
docs: update architecture docs for agent subprocess execution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -275,7 +275,7 @@ The supervisor watches source directories and auto-restarts the child on changes
 
 | Crate | Purpose |
 |-------|---------|
-| `runtimed` | Central daemon — env pools, notebook sync, kernel execution |
+| `runtimed` | Central daemon — env pools, notebook sync, agent subprocess coordination |
 | `runtimed-client` | Shared client library — output resolution, daemon paths, pool client |
 | `runtimed-py` | Python bindings for daemon (PyO3/maturin) |
 | `runtimed-wasm` | WASM bindings for notebook doc (Automerge, used by frontend) |
@@ -439,9 +439,10 @@ The rule: `image/*` → binary (EXCEPT `image/svg+xml` — that's text). `audio/
 | Cell source | Frontend WASM | Local-first, character-level merge |
 | Cell position, type, metadata | Frontend WASM | User-initiated via UI |
 | Notebook metadata (deps, runtime) | Frontend WASM | User edits deps, runtime picker |
-| Cell outputs (manifest hashes) | Daemon | Kernel IOPub → blob store → hash in doc |
-| Execution count | Daemon | Set on `execute_input` from kernel |
-| RuntimeStateDoc (kernel, queue, executions, env, trust) | Daemon | Separate Automerge doc, frame type `0x05` |
+| Cell outputs (manifest hashes) | Agent subprocess | Kernel IOPub → blob store → hash in RuntimeStateDoc |
+| Execution count | Agent subprocess | Set on `execute_input` from kernel |
+| Execution queue (source, seq, status) | Coordinator writes `queued`, agent transitions to `running`/`done` | CRDT-driven execution — no RPC for cell execution |
+| RuntimeStateDoc (kernel, queue, executions, env, trust) | Agent + Coordinator | Separate Automerge doc, frame type `0x05` |
 
 **Never write to the CRDT in response to a daemon broadcast.** The daemon already wrote. Writing again creates redundant sync traffic and incorrectly marks the notebook as dirty.
 

--- a/contributing/architecture.md
+++ b/contributing/architecture.md
@@ -147,15 +147,49 @@ Key files:
 - `apps/notebook/src/lib/manifest-resolution.ts` — Frontend resolution, `isBinaryMime()`, `resolveContentRef()`
 - `apps/notebook/src/lib/materialize-cells.ts` — Assembles cells with resolved outputs
 
-### 6. Daemon Manages Runtime Resources
+### 6. Process-Isolated Kernel Execution
 
-The daemon owns kernel lifecycle, environment pools, and tooling (ruff, deno, etc.).
+Every kernel runs in a separate **agent subprocess** (`runtimed agent`) that connects back to the daemon's Unix socket as an Automerge peer. The daemon coordinator handles environment resolution and spawns the agent; the agent owns the kernel process and writes outputs to RuntimeStateDoc.
+
+```
+┌────────────────────────────────────────────────────┐
+│ Coordinator (runtimed daemon)                      │
+│  Environment pools, trust, peer sync, persistence  │
+│                                                    │
+│  ExecuteCell → writes execution entry to CRDT      │
+│  (source + seq number in RuntimeStateDoc)          │
+└──────────┬─────────────────────────────────────────┘
+           │ Unix socket (standard peer protocol)
+           ▼
+┌────────────────────────────────────────────────────┐
+│ Agent subprocess (runtimed agent)                  │
+│  Connects as Automerge peer, watches CRDT queue    │
+│  Owns kernel process (ZMQ), IOPub, outputs         │
+│  Writes results back via RuntimeStateDoc sync      │
+└────────────────────────────────────────────────────┘
+```
+
+**CRDT-driven execution:** The coordinator writes execution entries (with source code and a monotonic sequence number) to RuntimeStateDoc. The agent discovers new entries via Automerge sync, sorts by sequence number, and executes. No RPC needed for execution — it's pure state sync.
+
+**RPC for lifecycle:** `LaunchKernel`, `InterruptExecution`, `ShutdownKernel`, `Complete`, `GetHistory`, and `SendComm` use `AgentRequest`/`AgentResponse` frames (0x01/0x02) over the socket.
 
 **Implications:**
 - Clients request kernel launch; they don't spawn kernels directly
 - Environment selection is the daemon's decision based on notebook metadata
 - Tool availability is the daemon's responsibility (bootstrap via rattler if needed)
 - Clients are stateless with respect to runtime resources
+- Each kernel is sandboxable at the OS level (process isolation enables future cgroup/seatbelt)
+- Agents can survive temporary disconnection and sync outputs on reconnect
+
+### 7. Reuse Existing Protocols
+
+New components should connect using existing protocols rather than inventing special transports. The agent subprocess is a regular Unix socket peer — same handshake, same frame types, same Automerge sync as frontends and MCP servers. Execution state flows through the same RuntimeStateDoc CRDT that frontends already subscribe to.
+
+**Implications:**
+- New runtime backends (SSH remote, containerized) connect via the same socket protocol
+- No special framing or serialization for internal components
+- Debugging tools work uniformly (same frame types everywhere)
+- The CRDT is the coordination mechanism — if state can be expressed as a CRDT mutation, prefer that over RPC
 
 ### Crate Boundaries
 
@@ -223,16 +257,19 @@ We are working toward full conformance with these principles.
 | Binary separation | Conformant |
 | Daemon manages resources | Conformant |
 
-The frontend now owns a local Automerge doc via `runtimed-wasm` WASM bindings, making it fully conformant with the canonical-state principle. Cell mutations (edits, reorders, deletes) are applied instantly in WASM with no RPC round-trip, satisfying local-first editing. `ExecuteCell` reads from the synced document. The deprecated `QueueCell` (which accepts code as a parameter) is retained only for `runtimed-py` backwards compatibility.
+The frontend now owns a local Automerge doc via `runtimed-wasm` WASM bindings, making it fully conformant with the canonical-state principle. Cell mutations (edits, reorders, deletes) are applied instantly in WASM with no RPC round-trip, satisfying local-first editing. `ExecuteCell` reads from the synced document.
 
 ## References
 
-- `crates/notebook-protocol/src/protocol.rs` — Canonical wire types: `NotebookRequest`, `NotebookResponse`, `NotebookBroadcast`, `CommSnapshot`
+- `crates/notebook-protocol/src/protocol.rs` — Canonical wire types: `NotebookRequest`, `NotebookResponse`, `NotebookBroadcast`, `AgentRequest`, `AgentResponse`
 - `crates/notebook-doc/src/lib.rs` — `NotebookDoc`: Automerge schema, cell CRUD, output writes, per-cell accessors
 - `crates/notebook-doc/src/diff.rs` — `CellChangeset`: structural diff from Automerge patches
+- `crates/notebook-doc/src/runtime_state.rs` — `RuntimeStateDoc`: kernel status, execution queue/lifecycle, env sync, comms
 - `crates/notebook-sync/src/handle.rs` — `DocHandle`: sync infrastructure, per-cell accessors for Python clients
-- `crates/runtimed/src/notebook_sync_server.rs` — `NotebookRoom`, room lifecycle, autosave debouncer, re-keying, sync loop
-- `crates/runtimed/src/kernel_manager.rs` — Kernel process lifecycle, execution queue, IOPub output routing
+- `crates/runtimed/src/notebook_sync_server.rs` — `NotebookRoom`, room lifecycle, agent sync handler, CRDT execution queue
+- `crates/runtimed/src/agent.rs` — Agent subprocess: Unix socket peer, CRDT queue watching, kernel ownership
+- `crates/runtimed/src/agent_handle.rs` — Coordinator-side agent process management (spawn + monitor)
+- `crates/runtimed/src/kernel_manager.rs` — `RoomKernel`: kernel process lifecycle, execution queue, IOPub output routing
 - `crates/runtimed/src/comm_state.rs` — Widget comm state + Output widget capture routing
 - `crates/runtimed/src/output_store.rs` — Output manifest creation/resolution, `is_binary_mime()`, `ContentRef`
 - `crates/notebook-sync/src/relay.rs` — `RelayHandle`: relay API for forwarding typed frames between WASM and daemon

--- a/contributing/runtimed.md
+++ b/contributing/runtimed.md
@@ -47,6 +47,27 @@ The daemon provides a single coordinating entity that prewarms environments in t
               └─────────────────────────────────┘
 ```
 
+### Kernel Execution via Agent Subprocess
+
+Every kernel runs in a separate `runtimed agent` subprocess. The daemon coordinator resolves environments and spawns the agent; the agent connects back to the daemon socket as a regular Automerge peer.
+
+```
+Coordinator                    RuntimeStateDoc              Agent Peer
+───────────                    ───────────────              ──────────
+ExecuteCell request arrives
+  ↓
+writes execution entry     →   executions/{eid}:          → watches queue
+  (source, seq, status=queued)   status: "queued"            sorts by seq
+                                 source: "x = 42"            executes
+                                 seq: 7
+                                                           ← writes outputs
+                               executions/{eid}:
+                                 status: "done"
+                                 outputs: [hash1, hash2]
+```
+
+Execution is CRDT-driven — the coordinator writes execution entries (with source + sequence number) to RuntimeStateDoc. The agent discovers new entries via Automerge sync and processes them in order. RPC (`AgentRequest`/`AgentResponse`) is only used for lifecycle operations: `LaunchKernel`, `InterruptExecution`, `ShutdownKernel`, `Complete`, `GetHistory`, `SendComm`.
+
 **Key components:**
 
 | Component | Purpose | Location |
@@ -65,7 +86,7 @@ The daemon provides a single coordinating entity that prewarms environments in t
 
 ### Default: Let the notebook start it
 
-The notebook app automatically tries to connect to or start the daemon on launch. If it's not running, the app falls back to in-process prewarming. You don't need to do anything special.
+The notebook app automatically connects to or starts the daemon on launch. The daemon is required — all kernels run as agent subprocesses connected to the daemon via Unix socket.
 
 The notebook app calls `ensure_daemon_via_sidecar()` (a private function in `crates/notebook/src/lib.rs`) which takes a `tauri::AppHandle` and a progress callback to start and connect to the daemon.
 
@@ -208,6 +229,8 @@ crates/runtimed/
 │   ├── main.rs                  # Daemon CLI entry point
 │   ├── daemon.rs                # Daemon state, pool management, connection routing
 │   ├── notebook_sync_server.rs  # NotebookRoom, room lifecycle, autosave, re-keying, sync loop
+│   ├── agent.rs                 # Agent subprocess: Unix socket peer, CRDT queue watching, kernel ownership
+│   ├── agent_handle.rs          # Coordinator-side agent process management (spawn + monitor)
 │   ├── kernel_manager.rs        # RoomKernel: kernel lifecycle, execution queue, IOPub output routing
 │   ├── kernel_pids.rs           # Kernel PID tracking and orphan reaping
 │   ├── comm_state.rs            # Widget comm state + Output widget capture routing


### PR DESCRIPTION
## Summary

Updates architecture documentation to reflect the new agent subprocess execution model (#1431, #1433).

### architecture.md
- **New principle 6**: Process-isolated kernel execution — every kernel runs in a `runtimed agent` subprocess connected via Unix socket as an Automerge peer. Includes CRDT-driven execution diagram.
- **New principle 7**: Reuse existing protocols — the agent uses the same socket protocol, frame types, and Automerge sync as frontends and MCP servers. CRDT as coordination mechanism over RPC.
- Updated references to include `agent.rs`, `agent_handle.rs`, `runtime_state.rs`
- Removed stale `QueueCell` reference

### runtimed.md
- Fixed "in-process prewarming fallback" → daemon is required
- Added kernel execution via agent subprocess section with data flow diagram
- Added `agent.rs` and `agent_handle.rs` to code structure listing

### CLAUDE.md
- Updated `runtimed` crate description (env pools + agent coordination)
- Updated CRDT state ownership table (agent subprocess as writer, execution queue entries)

## Test plan

Docs-only change — no code modified.