### PR TITLE
chore: remove agent_mode toggle infrastructure

### DIFF
--- a/apps/notebook/settings/App.tsx
+++ b/apps/notebook/settings/App.tsx
@@ -207,7 +207,7 @@ interface FeatureFlag {
   id: string;
   label: string;
   description: string;
-  settingKey: "agentMode";
+  settingKey: string;
 }
 
 const FEATURE_FLAGS: FeatureFlag[] = [];
@@ -235,8 +235,6 @@ export default function App() {
     setDefaultCondaPackages,
     keepAliveSecs,
     setKeepAliveSecs,
-    agentMode,
-    setAgentMode,
   } = useSyncedSettings();
 
   return (
@@ -452,14 +450,8 @@ export default function App() {
                     </p>
                   </div>
                   <Switch
-                    checked={
-                      flag.settingKey === "agentMode" ? agentMode : false
-                    }
-                    onCheckedChange={(checked) => {
-                      if (flag.settingKey === "agentMode") {
-                        setAgentMode(checked);
-                      }
-                    }}
+                    checked={false}
+                    onCheckedChange={() => {}}
                   />
                 </div>
               ))}

--- a/crates/notebook/src/settings.rs
+++ b/crates/notebook/src/settings.rs
@@ -80,10 +80,6 @@ pub fn load_settings() -> SyncedSettings {
             .get("onboarding_completed")
             .and_then(|v| serde_json::from_value(v.clone()).ok())
             .unwrap_or(true),
-        agent_mode: json
-            .get("agent_mode")
-            .and_then(|v| serde_json::from_value(v.clone()).ok())
-            .unwrap_or(false),
     }
 }
 
@@ -114,7 +110,6 @@ mod tests {
             conda: CondaDefaults::default(),
             keep_alive_secs: 30,
             onboarding_completed: false,
-            agent_mode: false,
         };
 
         let json = serde_json::to_string(&settings).unwrap();
@@ -258,10 +253,6 @@ mod tests {
                 .get("onboarding_completed")
                 .and_then(|v| serde_json::from_value(v.clone()).ok())
                 .unwrap_or(defaults.onboarding_completed),
-            agent_mode: json_val
-                .get("agent_mode")
-                .and_then(|v| serde_json::from_value(v.clone()).ok())
-                .unwrap_or(defaults.agent_mode),
         };
         // Valid fields are preserved
         assert_eq!(settings.theme, ThemeMode::Dark);

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -184,11 +184,6 @@ enum Commands {
         #[arg(long)]
         json: bool,
     },
-    /// Runtime agent management (process-isolated kernels)
-    Agent {
-        #[command(subcommand)]
-        command: AgentCommands,
-    },
     /// Stop a notebook's kernel and evict its room
     #[command(alias = "shutdown")]
     Stop {
@@ -458,16 +453,6 @@ enum DaemonCommands {
     Ping,
 }
 
-#[derive(Subcommand)]
-enum AgentCommands {
-    /// Enable agent mode (process-isolated kernels)
-    Enable,
-    /// Disable agent mode (local kernels)
-    Disable,
-    /// Show agent mode status
-    Status,
-}
-
 /// Development commands (only shown when RUNTIMED_DEV=1)
 #[derive(Subcommand)]
 enum DevCommands {
@@ -574,29 +559,6 @@ async fn async_main(command: Option<Commands>) -> Result<()> {
         Some(Commands::Jupyter { command }) => jupyter_command(command).await?,
         Some(Commands::Daemon { command }) => daemon_command(command).await?,
         Some(Commands::Ps { json }) => list_notebooks(json).await?,
-        Some(Commands::Agent { command }) => match command {
-            AgentCommands::Enable => {
-                let client = runtimed::client::PoolClient::new(runtimed::default_socket_path());
-                client.set_agent_mode(true).await?;
-                println!("Agent mode enabled — new kernels will run in subprocess");
-            }
-            AgentCommands::Disable => {
-                let client = runtimed::client::PoolClient::new(runtimed::default_socket_path());
-                client.set_agent_mode(false).await?;
-                println!("Agent mode disabled — new kernels will run in-process");
-            }
-            AgentCommands::Status => {
-                // Read from settings doc (persisted)
-                let settings_path = runtimed::default_settings_doc_path();
-                let settings =
-                    runtimed::settings_doc::SettingsDoc::load_or_create(&settings_path, None);
-                let enabled = settings.get_all().agent_mode;
-                println!(
-                    "Agent mode: {}",
-                    if enabled { "enabled" } else { "disabled" }
-                );
-            }
-        },
         Some(Commands::Stop { path }) => shutdown_notebook(&path).await?,
         Some(Commands::Recover { path, output, list }) => {
             recover_notebook(path.as_deref(), output.as_deref(), list)?

--- a/crates/runtimed-client/src/client.rs
+++ b/crates/runtimed-client/src/client.rs
@@ -260,18 +260,6 @@ impl PoolClient {
         }
     }
 
-    /// Enable or disable agent mode on the running daemon.
-    pub async fn set_agent_mode(&self, enabled: bool) -> Result<(), ClientError> {
-        let response = self.send_request(Request::SetAgentMode { enabled }).await?;
-        match response {
-            Response::Ok => Ok(()),
-            Response::Error { message } => Err(ClientError::DaemonError(message)),
-            _ => Err(ClientError::ProtocolError(
-                "Unexpected response".to_string(),
-            )),
-        }
-    }
-
     /// Send a request to the daemon and receive a response.
     ///
     /// The entire request (connect + send + recv) is bounded by a timeout

--- a/crates/runtimed-client/src/settings_doc.rs
+++ b/crates/runtimed-client/src/settings_doc.rs
@@ -178,12 +178,6 @@ pub struct SyncedSettings {
     /// When false, the app shows the onboarding screen on startup.
     #[serde(default)]
     pub onboarding_completed: bool,
-
-    /// Run kernels in agent subprocesses (process isolation).
-    /// When true, each notebook's kernel runs in a separate `runtimed agent`
-    /// process. When false, kernels run in-process (default).
-    #[serde(default)]
-    pub agent_mode: bool,
 }
 
 impl Default for SyncedSettings {
@@ -196,7 +190,6 @@ impl Default for SyncedSettings {
             conda: CondaDefaults::default(),
             keep_alive_secs: DEFAULT_KEEP_ALIVE_SECS,
             onboarding_completed: false,
-            agent_mode: false,
         }
     }
 }
@@ -255,8 +248,6 @@ impl SettingsDoc {
         );
         // Store onboarding_completed as boolean
         let _ = doc.put(automerge::ROOT, "onboarding_completed", false);
-        // Store agent_mode as boolean
-        let _ = doc.put(automerge::ROOT, "agent_mode", false);
 
         // Nested uv map with empty package list
         if let Ok(uv_id) = doc.put_object(automerge::ROOT, "uv", ObjType::Map) {
@@ -353,11 +344,6 @@ impl SettingsDoc {
         if let Some(completed) = json.get("onboarding_completed").and_then(|v| v.as_bool()) {
             settings.put_bool("onboarding_completed", completed);
         }
-        // agent_mode: boolean
-        if let Some(agent) = json.get("agent_mode").and_then(|v| v.as_bool()) {
-            settings.put_bool("agent_mode", agent);
-        }
-
         let uv_packages = Self::extract_packages_from_json(json, "uv");
         if !uv_packages.is_empty() {
             settings.put_list("uv.default_packages", &uv_packages);
@@ -727,7 +713,6 @@ impl SettingsDoc {
                 // Check if this is an existing user by looking for other settings
                 self.get("theme").is_some() || self.get("default_runtime").is_some()
             }),
-            agent_mode: self.get_bool("agent_mode").unwrap_or(false),
         }
     }
 
@@ -808,19 +793,6 @@ impl SettingsDoc {
                     current, completed
                 );
                 self.put_bool("onboarding_completed", completed);
-                changed = true;
-            }
-        }
-
-        // agent_mode: boolean
-        if let Some(agent) = json.get("agent_mode").and_then(|v| v.as_bool()) {
-            let current = self.get_bool("agent_mode");
-            if current != Some(agent) {
-                info!(
-                    "[settings] apply_json_changes: agent_mode changed {:?} -> {}",
-                    current, agent
-                );
-                self.put_bool("agent_mode", agent);
                 changed = true;
             }
         }
@@ -1480,40 +1452,5 @@ mod tests {
 
         // Missing key is not the same as null
         assert!(!doc.is_null("keep_alive_secs"));
-    }
-
-    #[test]
-    fn test_agent_mode_default_off() {
-        let doc = SettingsDoc::new();
-        let settings = doc.get_all();
-        assert!(!settings.agent_mode, "agent_mode should default to false");
-    }
-
-    #[test]
-    fn test_agent_mode_toggle_persists() {
-        let tmp = tempfile::NamedTempFile::new().unwrap();
-
-        // Create settings, enable agent mode, save
-        let mut doc = SettingsDoc::new();
-        assert!(!doc.get_all().agent_mode);
-        doc.put_bool("agent_mode", true);
-        doc.save_to_file(tmp.path()).unwrap();
-
-        // Load from disk — should still be enabled
-        let loaded = SettingsDoc::load_or_create(tmp.path(), None);
-        assert!(loaded.get_all().agent_mode, "agent_mode should persist");
-    }
-
-    #[test]
-    fn test_agent_mode_json_migration() {
-        let json: serde_json::Value = serde_json::json!({
-            "agent_mode": true,
-            "default_runtime": "python"
-        });
-        let doc = SettingsDoc::from_json(&json);
-        assert!(
-            doc.get_all().agent_mode,
-            "agent_mode should migrate from JSON"
-        );
     }
 }

--- a/crates/runtimed-client/src/sync_client.rs
+++ b/crates/runtimed-client/src/sync_client.rs
@@ -441,7 +441,6 @@ pub fn get_all_from_doc(doc: &AutoCommit) -> SyncedSettings {
         // assume they're upgrading from before onboarding was added → treat as completed
         onboarding_completed: get_bool("onboarding_completed")
             .unwrap_or_else(|| get_str("theme").is_some() || get_str("default_runtime").is_some()),
-        agent_mode: get_bool("agent_mode").unwrap_or(false),
     }
 }
 

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -347,9 +347,6 @@ pub struct Daemon {
     uv_pool: Mutex<Pool>,
     conda_pool: Mutex<Pool>,
     shutdown: Arc<Mutex<bool>>,
-    /// Runtime feature flag: kernel execution via agent subprocess.
-    /// Toggled via `runt agent enable` / `runt agent disable`.
-    pub agent_mode: Arc<std::sync::atomic::AtomicBool>,
     /// Notifier to wake up accept loops on shutdown.
     shutdown_notify: Arc<Notify>,
     /// Singleton lock - kept alive while daemon is running.
@@ -407,9 +404,6 @@ impl Daemon {
 
         let blob_store = Arc::new(BlobStore::new(config.blob_store_dir.clone()));
 
-        // Initialize agent mode from persisted settings
-        let agent_mode = settings.get_all().agent_mode;
-
         Ok(Arc::new(Self {
             uv_pool: Mutex::new(Pool::new(config.uv_pool_size, config.max_age_secs)),
             conda_pool: Mutex::new(Pool::new(config.conda_pool_size, config.max_age_secs)),
@@ -424,7 +418,6 @@ impl Daemon {
             blob_store,
             blob_port: Mutex::new(None),
             notebook_rooms: Arc::new(Mutex::new(HashMap::new())),
-            agent_mode: Arc::new(std::sync::atomic::AtomicBool::new(agent_mode)),
         }))
     }
 
@@ -1913,19 +1906,9 @@ impl Daemon {
                     self.collect_active_env_paths().await.into_iter().collect();
                 Response::ActiveEnvPaths { paths }
             }
-            Request::SetAgentMode { enabled } => {
-                self.agent_mode
-                    .store(enabled, std::sync::atomic::Ordering::Relaxed);
-                // Persist to settings doc so it survives daemon restarts
-                {
-                    let mut settings = self.settings.write().await;
-                    settings.put_bool("agent_mode", enabled);
-                    let _ = settings.save_to_file(&crate::default_settings_doc_path());
-                }
-                info!(
-                    "[runtimed] Agent mode {}",
-                    if enabled { "ENABLED" } else { "DISABLED" }
-                );
+            Request::SetAgentMode { .. } => {
+                // Agent mode is now unconditional — this request is a no-op.
+                // Kept for wire compatibility; will be removed in a future version.
                 Response::Ok
             }
         }

--- a/crates/runtimed/src/main.rs
+++ b/crates/runtimed/src/main.rs
@@ -386,16 +386,8 @@ async fn run_daemon(
     info!("  Blob store: {:?}", config.blob_store_dir);
     info!("  UV pool size: {}", config.uv_pool_size);
     info!("  Conda pool size: {}", config.conda_pool_size);
-    // Agent mode status is logged after daemon initialization
-    // (reads from persisted settings)
-
     let daemon = match Daemon::new(config) {
-        Ok(d) => {
-            if d.agent_mode.load(std::sync::atomic::Ordering::Relaxed) {
-                info!("  Agent mode: ENABLED (kernels run in subprocess)");
-            }
-            d
-        }
+        Ok(d) => d,
         Err(e) => {
             // Another daemon is already running — this is expected during
             // launchd double-start races, NOT a crash. Exit 0 so launchd's

--- a/src/bindings/SyncedSettings.ts
+++ b/src/bindings/SyncedSettings.ts
@@ -39,10 +39,4 @@ keep_alive_secs: bigint,
  * Whether the user has completed the first-launch onboarding flow.
  * When false, the app shows the onboarding screen on startup.
  */
-onboarding_completed: boolean, 
-/**
- * Run kernels in agent subprocesses (process isolation).
- * When true, each notebook's kernel runs in a separate `runtimed agent`
- * process. When false, kernels run in-process (default).
- */
-agent_mode: boolean, };
+onboarding_completed: boolean, };

--- a/src/hooks/useSyncedSettings.ts
+++ b/src/hooks/useSyncedSettings.ts
@@ -104,8 +104,6 @@ export function useSyncedSettings() {
   >([]);
   // Keep-alive duration in seconds (5s to 7 days)
   const [keepAliveSecs, setKeepAliveSecsState] = useState<number>(30);
-  // Feature flag: agent process isolation
-  const [agentMode, setAgentModeState] = useState<boolean>(false);
 
   // Load initial settings from daemon
   useEffect(() => {
@@ -132,9 +130,6 @@ export function useSyncedSettings() {
           setKeepAliveSecsState(Number(settings.keep_alive_secs));
         } else if (typeof settings.keep_alive_secs === "number") {
           setKeepAliveSecsState(settings.keep_alive_secs);
-        }
-        if (typeof settings.agent_mode === "boolean") {
-          setAgentModeState(settings.agent_mode);
         }
       })
       .catch(() => {
@@ -172,9 +167,6 @@ export function useSyncedSettings() {
         setKeepAliveSecsState(Number(keep_alive_secs));
       } else if (typeof keep_alive_secs === "number") {
         setKeepAliveSecsState(keep_alive_secs);
-      }
-      if (typeof event.payload.agent_mode === "boolean") {
-        setAgentModeState(event.payload.agent_mode);
       }
     });
     return () => {
@@ -238,16 +230,6 @@ export function useSyncedSettings() {
     );
   }, []);
 
-  const setAgentMode = useCallback((enabled: boolean) => {
-    setAgentModeState(enabled);
-    invoke("set_synced_setting", {
-      key: "agent_mode",
-      value: enabled,
-    }).catch((e) =>
-      console.warn("[settings] Failed to persist agent_mode:", e),
-    );
-  }, []);
-
   return {
     theme,
     setTheme,
@@ -261,8 +243,6 @@ export function useSyncedSettings() {
     setDefaultCondaPackages,
     keepAliveSecs,
     setKeepAliveSecs,
-    agentMode,
-    setAgentMode,
   };
 }
 


### PR DESCRIPTION
## Summary

Removes all agent_mode toggle infrastructure now that agent mode is unconditional. **-190 lines** across 10 files.

### Removed
- `daemon.agent_mode` AtomicBool + initialization + startup logging
- `SyncedSettings.agent_mode` field + scaffolding + JSON migration + diff tracking + 3 tests
- `PoolClient::set_agent_mode()` method
- `runt agent enable/disable/status` CLI commands + `AgentCommands` enum
- `agentMode` / `setAgentMode` state + callbacks in `useSyncedSettings.ts`
- `agent_mode` from `SyncedSettings.ts` TypeScript binding
- `agent_mode` from notebook crate's `Settings` struct

### Kept (wire compat)
- `Request::SetAgentMode` protocol variant — handler returns `Ok` (no-op)

Part of #1436.

## Test plan

- [x] `cargo check` — all affected crates clean
- [x] `cargo xtask lint` — all checks pass
- [ ] CI