### PR TITLE
chore: remove dead protocol variants (SetAgentMode, ExecuteCell, CellQueued)

### DIFF
--- a/crates/notebook-protocol/src/protocol.rs
+++ b/crates/notebook-protocol/src/protocol.rs
@@ -545,14 +545,6 @@ pub enum AgentRequest {
         env_vars: std::collections::HashMap<String, String>,
     },
 
-    /// Execute a cell. The coordinator reads source from NotebookDoc
-    /// and passes it here — the agent has no NotebookDoc access.
-    ExecuteCell {
-        cell_id: String,
-        code: String,
-        execution_id: String,
-    },
-
     /// Interrupt the currently executing cell.
     InterruptExecution,
 
@@ -579,12 +571,6 @@ pub enum AgentRequest {
 pub enum AgentResponse {
     /// Kernel launched successfully.
     KernelLaunched { env_source: String },
-
-    /// Cell queued for execution.
-    CellQueued {
-        cell_id: String,
-        execution_id: String,
-    },
 
     /// Code completion result.
     CompletionResult {

--- a/crates/runtimed-client/src/protocol.rs
+++ b/crates/runtimed-client/src/protocol.rs
@@ -59,10 +59,6 @@ pub enum Request {
     /// Get environment paths currently in use by running kernels.
     /// Used by `runt env clean` to avoid evicting active environments.
     ActiveEnvPaths,
-
-    /// Enable or disable agent mode (process-isolated kernels).
-    /// Takes effect for the next kernel launch — existing kernels are unaffected.
-    SetAgentMode { enabled: bool },
 }
 
 /// Responses from the daemon to clients.

--- a/crates/runtimed/src/agent.rs
+++ b/crates/runtimed/src/agent.rs
@@ -359,14 +359,6 @@ async fn handle_agent_request(request: AgentRequest, ctx: &AgentContext) -> Agen
             }
         }
 
-        AgentRequest::ExecuteCell { .. } => {
-            // ExecuteCell is CRDT-driven — should not arrive as RPC.
-            warn!("[agent] Received ExecuteCell RPC — this should be CRDT-driven");
-            AgentResponse::Error {
-                error: "ExecuteCell is CRDT-driven, not RPC".to_string(),
-            }
-        }
-
         AgentRequest::InterruptExecution => {
             let mut guard = ctx.kernel.lock().await;
             if let Some(ref mut k) = *guard {

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -1906,11 +1906,6 @@ impl Daemon {
                     self.collect_active_env_paths().await.into_iter().collect();
                 Response::ActiveEnvPaths { paths }
             }
-            Request::SetAgentMode { .. } => {
-                // Agent mode is now unconditional — this request is a no-op.
-                // Kept for wire compatibility; will be removed in a future version.
-                Response::Ok
-            }
         }
     }
 


### PR DESCRIPTION
## Summary

Removes dead wire protocol variants now that agent mode is unconditional and execution is CRDT-driven. **-31 lines**.

- `Request::SetAgentMode` — toggle no longer exists
- `AgentRequest::ExecuteCell` — execution is CRDT-driven via RuntimeStateDoc queue entries
- `AgentResponse::CellQueued` — coordinator writes queue entries directly, no agent acknowledgment needed
- Dead `ExecuteCell` match arm in `agent.rs`
- No-op `SetAgentMode` handler in `daemon.rs`

Part of #1436.

## Test plan

- [x] `cargo check` — all crates clean
- [x] `cargo xtask lint` — passes
- [x] `cargo test -p runtimed` — 184 lib + 22 integration tests pass
- [ ] CI