### PR TITLE
fix(iframe): clear text selection when focus leaves iframe

### DIFF
--- a/src/components/isolated/frame-html.ts
+++ b/src/components/isolated/frame-html.ts
@@ -593,6 +593,14 @@ export function generateFrameHtml(options: FrameHtmlOptions = {}): string {
         }
       });
 
+      // --- Clear selection on blur ---
+      // When focus leaves this iframe (user clicked elsewhere), clear
+      // any text selection so it doesn't visually persist.
+      window.addEventListener('blur', function() {
+        var sel = window.getSelection();
+        if (sel) sel.removeAllRanges();
+      });
+
       // --- Error Handler ---
       window.addEventListener('error', function(e) {
         sendError(e.error || new Error(e.message));


### PR DESCRIPTION
## Summary

Text selections inside isolated iframes (outputs, rendered markdown, widgets) now clear when the user clicks outside the iframe. Previously, selections persisted visually because the iframe never received a signal that focus had moved away.

The fix adds a `window.blur` listener in the iframe bootstrap HTML that calls `removeAllRanges()`. One line of actual logic — the browser handles the rest.

Closes #1445

## Verification

- [x] Select text inside an output iframe, then click a different cell — selection clears
- [x] Select text in rendered markdown, then click into a code editor — selection clears
- [x] Select text in one output iframe, click into a different output iframe — first selection clears
- [x] Text selection still works normally while interacting within a single iframe
- [ ] Widget interactions (sliders, buttons) are not affected

<!-- Screenshots/recordings go here -->

_PR submitted by @rgbkrk's agent, Quill_