### PR TITLE
feat(runtimed): agent-internal kernel restart + provenance

### DIFF
--- a/crates/notebook-doc/src/runtime_state.rs
+++ b/crates/notebook-doc/src/runtime_state.rs
@@ -70,6 +70,10 @@ pub struct KernelState {
     pub language: String,
     #[serde(default)]
     pub env_source: String,
+    /// ID of the agent subprocess that owns this kernel (e.g., "rt:agent:a1b2c3d4").
+    /// Used for provenance — identifying which agent is running and detecting stale agents.
+    #[serde(default)]
+    pub agent_id: String,
 }
 
 impl Default for KernelState {
@@ -80,6 +84,7 @@ impl Default for KernelState {
             name: String::new(),
             language: String::new(),
             env_source: String::new(),
+            agent_id: String::new(),
         }
     }
 }
@@ -248,6 +253,8 @@ impl RuntimeStateDoc {
             .expect("scaffold kernel.language");
         doc.put(&kernel, "env_source", "")
             .expect("scaffold kernel.env_source");
+        doc.put(&kernel, "agent_id", "")
+            .expect("scaffold kernel.agent_id");
         doc.put(&kernel, "starting_phase", "")
             .expect("scaffold kernel.starting_phase");
 
@@ -326,6 +333,8 @@ impl RuntimeStateDoc {
             .expect("scaffold kernel.language");
         doc.put(&kernel, "env_source", "")
             .expect("scaffold kernel.env_source");
+        doc.put(&kernel, "agent_id", "")
+            .expect("scaffold kernel.agent_id");
         doc.put(&kernel, "starting_phase", "")
             .expect("scaffold kernel.starting_phase");
 
@@ -670,6 +679,20 @@ impl RuntimeStateDoc {
         self.doc
             .put(&kernel, "env_source", env_source)
             .expect("put kernel.env_source");
+        true
+    }
+
+    /// Set the agent ID that owns this kernel. Returns `true` if mutated.
+    #[allow(clippy::expect_used)]
+    pub fn set_agent_id(&mut self, agent_id: &str) -> bool {
+        let kernel = self.get_map("kernel").expect("kernel map must exist");
+        let current = self.read_str(&kernel, "agent_id");
+        if current == agent_id {
+            return false;
+        }
+        self.doc
+            .put(&kernel, "agent_id", agent_id)
+            .expect("put kernel.agent_id");
         true
     }
 
@@ -1717,6 +1740,7 @@ impl RuntimeStateDoc {
                 name: self.read_str(k, "name"),
                 language: self.read_str(k, "language"),
                 env_source: self.read_str(k, "env_source"),
+                agent_id: self.read_str(k, "agent_id"),
             })
             .unwrap_or_default();
 

--- a/crates/notebook-protocol/src/protocol.rs
+++ b/crates/notebook-protocol/src/protocol.rs
@@ -548,8 +548,21 @@ pub enum AgentRequest {
     /// Interrupt the currently executing cell.
     InterruptExecution,
 
-    /// Shutdown the kernel and exit the agent process.
+    /// Shutdown the kernel. The agent process stays alive for potential restart.
     ShutdownKernel,
+
+    /// Restart the kernel: shut down the current kernel, create a new one,
+    /// re-launch. Same agent process, same socket connection. The coordinator
+    /// sends this instead of spawning a new agent when one is already connected.
+    RestartKernel {
+        kernel_type: String,
+        env_source: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        notebook_path: Option<String>,
+        launched_config: LaunchedEnvConfig,
+        #[serde(default)]
+        env_vars: std::collections::HashMap<String, String>,
+    },
 
     /// Send a comm message to the kernel (widget interactions).
     SendComm { message: serde_json::Value },
@@ -571,6 +584,9 @@ pub enum AgentRequest {
 pub enum AgentResponse {
     /// Kernel launched successfully.
     KernelLaunched { env_source: String },
+
+    /// Kernel restarted successfully (same agent, new kernel).
+    KernelRestarted { env_source: String },
 
     /// Code completion result.
     CompletionResult {

--- a/crates/runtimed/src/agent.rs
+++ b/crates/runtimed/src/agent.rs
@@ -54,6 +54,7 @@ struct AgentContext {
     broadcast_tx: broadcast::Sender<notebook_protocol::protocol::NotebookBroadcast>,
     presence: Arc<RwLock<PresenceState>>,
     presence_tx: broadcast::Sender<(String, Vec<u8>)>,
+    seen_execution_ids: Arc<tokio::sync::Mutex<HashSet<String>>>,
 }
 
 /// Run the runtime agent, connecting to the daemon socket as a peer.
@@ -130,10 +131,10 @@ pub async fn run_agent(
         broadcast_tx,
         presence,
         presence_tx,
+        seen_execution_ids: Arc::new(tokio::sync::Mutex::new(HashSet::new())),
     };
 
     let mut cmd_rx: Option<tokio::sync::mpsc::Receiver<QueueCommand>> = None;
-    let mut seen_execution_ids: HashSet<String> = HashSet::new();
 
     info!("[agent] Infrastructure ready, entering main loop");
 
@@ -151,8 +152,8 @@ pub async fn run_agent(
                                 if let Ok(request) = serde_json::from_slice::<AgentRequest>(&typed_frame.payload) {
                                     let response = handle_agent_request(request, &ctx).await;
 
-                                    // After launch, take cmd_rx from kernel
-                                    if matches!(response, AgentResponse::KernelLaunched { .. }) {
+                                    // After launch/restart, take cmd_rx from kernel
+                                    if matches!(response, AgentResponse::KernelLaunched { .. } | AgentResponse::KernelRestarted { .. }) {
                                         let mut guard = ctx.kernel.lock().await;
                                         if let Some(ref mut k) = *guard {
                                             cmd_rx = k.take_cmd_rx();
@@ -179,8 +180,9 @@ pub async fn run_agent(
                                             let queued = sd.get_queued_executions();
                                             drop(sd); // release write lock before queuing
 
+                                            let mut seen = ctx.seen_execution_ids.lock().await;
                                             for (eid, exec) in queued {
-                                                if seen_execution_ids.insert(eid.clone()) {
+                                                if seen.insert(eid.clone()) {
                                                     if let Some(ref source) = exec.source {
                                                         let mut guard = ctx.kernel.lock().await;
                                                         if let Some(ref mut k) = *guard {
@@ -355,6 +357,82 @@ async fn handle_agent_request(request: AgentRequest, ctx: &AgentContext) -> Agen
                 }
                 Err(e) => AgentResponse::Error {
                     error: format!("Failed to launch kernel: {}", e),
+                },
+            }
+        }
+
+        AgentRequest::RestartKernel {
+            kernel_type,
+            env_source,
+            notebook_path,
+            launched_config,
+            env_vars: _,
+        } => {
+            info!(
+                "[agent] RestartKernel: type={} source={}",
+                kernel_type, env_source
+            );
+
+            // Shut down existing kernel
+            {
+                let mut guard = ctx.kernel.lock().await;
+                if let Some(ref mut k) = *guard {
+                    k.shutdown().await.ok();
+                }
+                *guard = None;
+            }
+
+            // Clear seen execution IDs so new RunAllCells entries are picked up
+            {
+                let mut seen = ctx.seen_execution_ids.lock().await;
+                seen.clear();
+            }
+
+            let mut k = RoomKernel::new(
+                ctx.broadcast_tx.clone(),
+                ctx.blob_store.clone(),
+                ctx.state_doc.clone(),
+                ctx.state_changed_tx.clone(),
+                ctx.presence.clone(),
+                ctx.presence_tx.clone(),
+            );
+
+            let pooled_env = launched_config.venv_path.as_ref().and_then(|venv| {
+                launched_config
+                    .python_path
+                    .as_ref()
+                    .map(|python| runtimed_client::PooledEnv {
+                        env_type: if env_source.starts_with("conda") {
+                            runtimed_client::EnvType::Conda
+                        } else {
+                            runtimed_client::EnvType::Uv
+                        },
+                        venv_path: venv.clone(),
+                        python_path: python.clone(),
+                        prewarmed_packages: launched_config.prewarmed_packages.clone(),
+                    })
+            });
+
+            let nb_path = notebook_path.as_deref().map(std::path::Path::new);
+
+            match k
+                .launch(
+                    &kernel_type,
+                    &env_source,
+                    nb_path,
+                    pooled_env,
+                    launched_config,
+                )
+                .await
+            {
+                Ok(()) => {
+                    let es = k.env_source().to_string();
+                    let mut guard = ctx.kernel.lock().await;
+                    *guard = Some(k);
+                    AgentResponse::KernelRestarted { env_source: es }
+                }
+                Err(e) => AgentResponse::Error {
+                    error: format!("Failed to restart kernel: {}", e),
                 },
             }
         }

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -841,6 +841,9 @@ pub struct NotebookRoom {
     /// The coordinator bumps this for each ExecuteCell and stamps the seq
     /// on the execution entry. The agent sorts by seq to determine order.
     pub next_queue_seq: Arc<std::sync::atomic::AtomicU64>,
+    /// The agent_id of the currently expected agent. Used by the sync handler
+    /// to validate connections and prevent stale cleanup from clobbering state.
+    pub current_agent_id: Arc<RwLock<Option<String>>>,
 }
 
 /// Maximum number of snapshots to keep per notebook hash.
@@ -1031,6 +1034,7 @@ impl NotebookRoom {
                 Arc::new(tx)
             },
             next_queue_seq: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+            current_agent_id: Arc::new(RwLock::new(None)),
         }
     }
 
@@ -1102,6 +1106,7 @@ impl NotebookRoom {
                 Arc::new(tx)
             },
             next_queue_seq: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+            current_agent_id: Arc::new(RwLock::new(None)),
         }
     }
 
@@ -1259,6 +1264,20 @@ pub async fn handle_agent_sync_connection<R, W>(
         notebook_id, agent_id
     );
 
+    // Validate provenance — reject stale agents
+    {
+        let expected = room.current_agent_id.read().await;
+        if let Some(ref expected_id) = *expected {
+            if *expected_id != agent_id {
+                warn!(
+                    "[notebook-sync] Rejecting stale agent {} (expected {})",
+                    agent_id, expected_id
+                );
+                return;
+            }
+        }
+    }
+
     // ── 1. Initial NotebookDoc sync ──────────────────────────────────
     let mut doc_sync_state = automerge::sync::State::new();
     {
@@ -1303,7 +1322,11 @@ pub async fn handle_agent_sync_connection<R, W>(
         *tx_guard = Some(agent_tx);
     }
 
-    // ── 4. Signal that the agent is connected ────────────────────────
+    // ── 4. Set provenance + signal connected ──────────────────────────
+    {
+        let mut id = room.current_agent_id.write().await;
+        *id = Some(agent_id.clone());
+    }
     let _ = room.agent_connected_tx.send(true);
     info!("[notebook-sync] Agent connected and ready: {}", agent_id);
 
@@ -1444,12 +1467,21 @@ pub async fn handle_agent_sync_connection<R, W>(
         }
     }
 
-    // Cleanup: clear the request channel and reset connected signal
+    // Cleanup: only clear state if we're still the current agent.
+    // A stale agent disconnecting after a new one connected must not
+    // clobber the new agent's channel.
     {
-        let mut tx_guard = room.agent_request_tx.lock().await;
-        *tx_guard = None;
+        let expected = room.current_agent_id.read().await;
+        let is_current = expected.as_deref() == Some(&agent_id);
+        if is_current {
+            let mut tx_guard = room.agent_request_tx.lock().await;
+            *tx_guard = None;
+            let _ = room.agent_connected_tx.send(false);
+            // Clear agent_handle so LaunchKernel spawns a new agent
+            let mut guard = room.agent_handle.lock().await;
+            *guard = None;
+        }
     }
-    let _ = room.agent_connected_tx.send(false);
     info!("[notebook-sync] Agent sync connection closed: {}", agent_id);
 }
 
@@ -3181,10 +3213,12 @@ async fn auto_launch_kernel(
         .await
         {
             Ok(agent) => {
-                // Store handle and wait for agent to connect back via socket
+                // Store handle and set provenance
                 {
                     let mut agent_guard = room.agent_handle.lock().await;
                     *agent_guard = Some(agent);
+                    let mut id = room.current_agent_id.write().await;
+                    *id = Some(agent_id.clone());
                 }
 
                 // Wait for agent to establish its sync connection
@@ -3240,6 +3274,7 @@ async fn auto_launch_kernel(
                             let mut changed = false;
                             changed |= sd.set_kernel_status("idle");
                             changed |= sd.set_kernel_info(kernel_type, kernel_type, &es);
+                            changed |= sd.set_agent_id(&agent_id);
                             if changed {
                                 let _ = room.state_changed_tx.send(());
                             }
@@ -3908,9 +3943,76 @@ async fn handle_notebook_request(
                 }
             }
 
+            // If agent is already connected, restart kernel in-place
+            // (handles the shutdown → launch sequence without subprocess respawn)
+            {
+                let has_agent = room.agent_request_tx.lock().await.is_some();
+                if has_agent {
+                    info!("[notebook-sync] Agent connected — sending RestartKernel");
+                    let restart_request =
+                        notebook_protocol::protocol::AgentRequest::RestartKernel {
+                            kernel_type: resolved_kernel_type.clone(),
+                            env_source: resolved_env_source.clone(),
+                            notebook_path: notebook_path
+                                .as_deref()
+                                .map(|p| p.to_str().unwrap_or("").to_string()),
+                            launched_config: launched_config.clone(),
+                            env_vars: Default::default(),
+                        };
+                    match send_agent_request(room, restart_request).await {
+                        Ok(notebook_protocol::protocol::AgentResponse::KernelRestarted {
+                            env_source: es,
+                        }) => {
+                            publish_kernel_state_presence(room, presence::KernelStatus::Idle, &es)
+                                .await;
+                            {
+                                let mut sd = room.state_doc.write().await;
+                                let mut changed = false;
+                                changed |= sd.set_kernel_status("idle");
+                                changed |= sd.set_kernel_info(
+                                    &resolved_kernel_type,
+                                    &resolved_kernel_type,
+                                    &es,
+                                );
+                                changed |=
+                                    sd.set_prewarmed_packages(&launched_config.prewarmed_packages);
+                                // agent_id doesn't change on restart — same agent
+                                if changed {
+                                    let _ = room.state_changed_tx.send(());
+                                }
+                            }
+                            return NotebookResponse::KernelLaunched {
+                                kernel_type: resolved_kernel_type,
+                                env_source: es,
+                                launched_config,
+                            };
+                        }
+                        Ok(notebook_protocol::protocol::AgentResponse::Error { error }) => {
+                            reset_starting_state(room).await;
+                            return NotebookResponse::Error {
+                                error: format!("Agent restart failed: {}", error),
+                            };
+                        }
+                        Ok(_) => {
+                            reset_starting_state(room).await;
+                            return NotebookResponse::Error {
+                                error: "Unexpected agent response to RestartKernel".to_string(),
+                            };
+                        }
+                        Err(e) => {
+                            warn!(
+                                "[notebook-sync] RestartKernel RPC failed: {} — spawning new agent",
+                                e
+                            );
+                            // Fall through to spawn new agent below
+                        }
+                    }
+                }
+            }
+
             // Spawn agent subprocess for kernel execution
             {
-                info!("[notebook-sync] Agent mode: spawning agent subprocess");
+                info!("[notebook-sync] Spawning agent subprocess");
 
                 let notebook_id = room.notebook_path.read().await.display().to_string();
                 let agent_id = format!("rt:agent:{}", &uuid::Uuid::new_v4().to_string()[..8]);
@@ -3988,6 +4090,9 @@ async fn handle_notebook_request(
                                     changed |= sd.set_prewarmed_packages(
                                         &launched_config.prewarmed_packages,
                                     );
+                                    if let Some(ref aid) = *room.current_agent_id.read().await {
+                                        changed |= sd.set_agent_id(aid);
+                                    }
                                     if changed {
                                         let _ = room.state_changed_tx.send(());
                                     }
@@ -4076,6 +4181,16 @@ async fn handle_notebook_request(
             {
                 let has_agent = room.agent_request_tx.lock().await.is_some();
                 if has_agent {
+                    // Check if kernel is shut down — return NoKernel instead
+                    // of silently queuing into a dead kernel
+                    {
+                        let sd = room.state_doc.read().await;
+                        let status = sd.read_state().kernel.status;
+                        if status == "shutdown" || status == "error" {
+                            return NotebookResponse::NoKernel {};
+                        }
+                    }
+
                     // Idempotency: if the cell already has a queued execution,
                     // return the existing execution_id instead of creating a new one.
                     {
@@ -4208,7 +4323,9 @@ async fn handle_notebook_request(
         }
 
         NotebookRequest::ShutdownKernel {} => {
-            // Agent path: send shutdown RPC, then clear handle
+            // Send shutdown RPC but keep the agent alive — the agent stays
+            // connected for potential RestartKernel. The kernel process dies
+            // but the agent subprocess and socket connection remain.
             let has_agent = room.agent_request_tx.lock().await.is_some();
             if has_agent {
                 let _ = send_agent_request(
@@ -4216,12 +4333,21 @@ async fn handle_notebook_request(
                     notebook_protocol::protocol::AgentRequest::ShutdownKernel,
                 )
                 .await;
-                // Clear both handle and request channel so subsequent
-                // ExecuteCell/Complete/etc. fall through to NoKernel
-                let mut guard = room.agent_handle.lock().await;
-                *guard = None;
-                let mut tx_guard = room.agent_request_tx.lock().await;
-                *tx_guard = None;
+                // Keep agent alive (agent_handle + agent_request_tx stay set)
+                // so LaunchKernel can send RestartKernel. ExecuteCell/RunAllCells
+                // check kernel.status from RuntimeStateDoc and return NoKernel
+                // when status is "shutdown".
+                //
+                // Update RuntimeStateDoc to reflect shutdown
+                {
+                    let mut sd = room.state_doc.write().await;
+                    let mut changed = false;
+                    changed |= sd.set_kernel_status("shutdown");
+                    changed |= sd.set_queue(None, &[]);
+                    if changed {
+                        let _ = room.state_changed_tx.send(());
+                    }
+                }
                 NotebookResponse::KernelShuttingDown {}
             } else {
                 NotebookResponse::NoKernel {}
@@ -4281,6 +4407,15 @@ async fn handle_notebook_request(
             {
                 let has_agent = room.agent_request_tx.lock().await.is_some();
                 if has_agent {
+                    // Check if kernel is shut down
+                    {
+                        let sd = room.state_doc.read().await;
+                        let status = sd.read_state().kernel.status;
+                        if status == "shutdown" || status == "error" {
+                            return NotebookResponse::NoKernel {};
+                        }
+                    }
+
                     let cells = {
                         let doc = room.doc.read().await;
                         doc.get_cells()
@@ -7270,6 +7405,7 @@ mod tests {
                 Arc::new(tx)
             },
             next_queue_seq: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+            current_agent_id: Arc::new(RwLock::new(None)),
         };
 
         (room, notebook_path)


### PR DESCRIPTION
## Summary

Fixes "restart and run all" hang — the most common notebook workflow for reproducibility.

### Root cause
`ShutdownKernel` cleared `agent_handle`/`agent_request_tx` immediately, but the old agent process was still alive on its socket. When `LaunchKernel` spawned a new agent, the old agent's sync handler cleanup raced with the new agent's connection, clobbering state. The kernel never reached "idle".

### Fix: Agent-internal restart
The agent now restarts its kernel internally via `RestartKernel` RPC — same process, same socket. No new subprocess spawn for restarts.

**Flow:** `ShutdownKernel` → agent kills kernel but stays alive → `LaunchKernel` detects existing agent → sends `RestartKernel` → agent launches fresh kernel → `RunAllCells` → execution entries flow via CRDT → outputs appear.

Zombie agents from crash/spawn races are possible but harmless — provenance validation (`current_agent_id`) rejects stale agents at the sync handler, so they can't access RuntimeStateDoc or the notebook. They linger until `kill_on_drop` reaps them when the `AgentHandle` is dropped.

### Changes
- **Protocol**: `AgentRequest::RestartKernel` + `AgentResponse::KernelRestarted`
- **Agent**: `RestartKernel` handler (shutdown → clear seen_execution_ids → launch new kernel). `seen_execution_ids` moved to `AgentContext` for restart access.
- **Coordinator**: `ShutdownKernel` keeps agent alive (kernel dies, process stays). `LaunchKernel` sends `RestartKernel` when agent exists. Falls through to spawn if RPC fails.
- **Provenance**: `current_agent_id` on `NotebookRoom` — set when agent connects (not on spawn). Sync handler validates on connect, only clears state on cleanup if ID matches.
- **RuntimeStateDoc**: `agent_id` in kernel state for visibility.
- **Post-shutdown safety**: `ExecuteCell`/`RunAllCells` check `kernel.status` from RuntimeStateDoc — return `NoKernel` when status is "shutdown" or "error".

## Test plan
- [x] `cargo check` / `cargo xtask lint` — clean
- [x] `cargo test -p runtimed` — 184 lib + 22 integration pass
- [x] Manual: create notebook → execute → restart → run all → both cells produce correct output
- [x] Daemon logs confirm `RestartKernel` RPC path (not subprocess respawn)
- [x] Codex review P1 + P2 addressed
- [ ] CI (including E2E)