### PR TITLE
fix(test): add retry for flaky wasm-integration tests

### DIFF
--- a/packages/runtimed/tests/wasm-integration.test.ts
+++ b/packages/runtimed/tests/wasm-integration.test.ts
@@ -24,7 +24,7 @@ import { type WasmHarness, createWasmHarness, initWasm } from "./wasm-harness";
 
 // ── Test suite ──────────────────────────────────────────────────────
 
-describe("WASM integration: real frames through SyncEngine", () => {
+describe("WASM integration: real frames through SyncEngine", { retry: 3 }, () => {
   let h: WasmHarness;
 
   beforeEach(async () => {


### PR DESCRIPTION
## Summary
- Adds `retry: 3` to the WASM integration test suite's `describe` block
- These tests use `VirtualTimeScheduler` coalescing windows that are timing-sensitive and fail intermittently in CI ([example](https://github.com/nteract/desktop/actions/runs/23981112342/job/69945583030?pr=1447))

## Test plan
- [x] `pnpm vitest run packages/runtimed/tests/wasm-integration.test.ts` passes
- [x] `cargo xtask lint` passes