### PR TITLE
fix(test): use named pipe path for Windows integration tests

### DIFF
--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -61,8 +61,21 @@ fn write_test_ipynb(path: &std::path::Path, cells: &[(&str, &str, &str, Vec<&str
 
 /// Create a test daemon configuration with a unique socket and lock path.
 fn test_config(temp_dir: &TempDir) -> DaemonConfig {
+    // Windows named pipes must use \\.\pipe\ prefix, not filesystem paths
+    #[cfg(windows)]
+    let socket_path = {
+        let unique = temp_dir
+            .path()
+            .file_name()
+            .unwrap_or_default()
+            .to_string_lossy();
+        std::path::PathBuf::from(format!(r"\\.\pipe\runtimed-test-{}", unique))
+    };
+    #[cfg(not(windows))]
+    let socket_path = temp_dir.path().join("test-runtimed.sock");
+
     DaemonConfig {
-        socket_path: temp_dir.path().join("test-runtimed.sock"),
+        socket_path,
         cache_dir: temp_dir.path().join("envs"),
         blob_store_dir: temp_dir.path().join("blobs"),
         notebook_docs_dir: temp_dir.path().join("notebook-docs"),


### PR DESCRIPTION
## Summary

Windows integration tests (19/21 failing) all timed out at `wait_for_daemon` because the test config used a filesystem path for the socket (`C:\...\test-runtimed.sock`), but Windows named pipes require the `\\.\pipe\` prefix.

### Fix

On Windows, `test_config` now generates `\\.\pipe\runtimed-test-{unique}` instead of joining the temp dir with `.sock`.

### Root cause

This has been failing since at least #1449 (and possibly earlier). The daemon couldn't bind to an invalid pipe path, so it never started, and every test that depended on a running daemon failed.

## Test plan

- [x] Unix tests still pass (22/22)
- [x] `cargo xtask lint` clean
- [ ] CI — Windows tests should pass now