### PR TITLE
fix(notebook): add content hashes to Vite output for cache busting

### DIFF
--- a/apps/notebook/vite.config.ts
+++ b/apps/notebook/vite.config.ts
@@ -77,9 +77,9 @@ export default defineConfig(({ command }) => {
           feedback: path.resolve(__dirname, "feedback/index.html"),
         },
         output: {
-          entryFileNames: "assets/[name].js",
-          chunkFileNames: "assets/[name].js",
-          assetFileNames: "assets/[name].[ext]",
+          entryFileNames: "assets/[name]-[hash].js",
+          chunkFileNames: "assets/[name]-[hash].js",
+          assetFileNames: "assets/[name]-[hash].[ext]",
         },
       },
     },


### PR DESCRIPTION
## Summary

Adds content hashes to Vite build output filenames to prevent stale cached assets after app upgrade.

### Problem

WKWebView (macOS) maintains a persistent disk cache that survives app restart. With deterministic filenames (`assets/index.js`), the webview serves the cached old version even after the binary is upgraded. Users see bugs that were already fixed until they fully restart.

### Fix

3-character change in `vite.config.ts`:
```diff
-entryFileNames: "assets/[name].js",
+entryFileNames: "assets/[name]-[hash].js",
```

Each build produces unique filenames (`main-BUXZFcE2.js`). The HTML entry point references the new names, so the webview loads fresh assets regardless of cache state.

## Test plan

- [x] `pnpm build` produces hashed filenames
- [ ] CI