### PR TITLE
chore: remove agent-era protocol leftovers

### DIFF
--- a/crates/notebook-protocol/src/protocol.rs
+++ b/crates/notebook-protocol/src/protocol.rs
@@ -147,16 +147,7 @@ pub enum NotebookRequest {
         notebook_path: Option<String>,
     },
 
-    /// Queue a cell for execution.
-    /// Daemon adds to queue and executes when previous cells complete.
-    #[deprecated(
-        since = "0.1.0",
-        note = "Use ExecuteCell instead - reads source from synced document"
-    )]
-    QueueCell { cell_id: String, code: String },
-
     /// Execute a cell by reading its source from the automerge doc.
-    /// This is the preferred method - ensures execution matches synced document state.
     ExecuteCell { cell_id: String },
 
     /// Clear outputs for a cell (before re-execution).
@@ -603,18 +594,4 @@ pub enum AgentResponse {
 
     /// Error response.
     Error { error: String },
-}
-
-/// Notifications from agent to coordinator (frame type 0x03).
-///
-/// These are sent proactively by the agent when events occur that the
-/// coordinator needs to act on. Most kernel state changes flow via
-/// RuntimeStateDoc sync (frame 0x05) — these cover the exceptions
-/// where the coordinator must write to NotebookDoc or update presence.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(tag = "event", rename_all = "snake_case")]
-pub enum AgentNotification {
-    /// The kernel process died unexpectedly. The coordinator updates
-    /// presence and cleans up the agent handle.
-    KernelDied,
 }

--- a/crates/runtimed-client/src/protocol.rs
+++ b/crates/runtimed-client/src/protocol.rs
@@ -406,27 +406,6 @@ mod tests {
     }
 
     #[test]
-    #[allow(deprecated)]
-    fn test_notebook_request_queue_cell() {
-        let req = NotebookRequest::QueueCell {
-            cell_id: "abc-123".into(),
-            code: "print('hello')".into(),
-        };
-        let json = serde_json::to_string(&req).unwrap();
-        assert!(json.contains("queue_cell"));
-        assert!(json.contains("abc-123"));
-
-        let parsed: NotebookRequest = serde_json::from_str(&json).unwrap();
-        match parsed {
-            NotebookRequest::QueueCell { cell_id, code } => {
-                assert_eq!(cell_id, "abc-123");
-                assert_eq!(code, "print('hello')");
-            }
-            _ => panic!("unexpected request type"),
-        }
-    }
-
-    #[test]
     fn test_notebook_request_execute_cell() {
         let req = NotebookRequest::ExecuteCell {
             cell_id: "cell-456".into(),

--- a/crates/runtimed/src/kernel_manager.rs
+++ b/crates/runtimed/src/kernel_manager.rs
@@ -3,15 +3,11 @@
 // The shell_writer unwrap at line 1713 is guarded by an early-return check at line 1681.
 #![allow(clippy::unwrap_used)]
 
-//! Daemon-owned kernel management for notebook rooms.
+//! Kernel management for runtime agent subprocesses.
 //!
-//! Each notebook room can have one kernel. The daemon owns the kernel lifecycle
-//! and execution queue, broadcasting outputs to all connected peers.
-//!
-//! This replaces the notebook app's local kernel management for Phase 8:
-//! - Execute requests flow through the daemon
-//! - Daemon tracks msg_id → cell_id perfectly
-//! - Outputs broadcast to all windows showing the same notebook
+//! Each agent subprocess owns one kernel. The agent manages the kernel lifecycle
+//! and execution queue, writing outputs to RuntimeStateDoc which syncs to all
+//! connected peers via Automerge.
 
 use std::collections::{HashMap, VecDeque};
 use std::net::Ipv4Addr;

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -820,10 +820,8 @@ pub struct NotebookRoom {
     /// Notification channel for RuntimeStateDoc changes.
     /// Peer sync loops subscribe to push RuntimeStateSync frames.
     pub state_changed_tx: broadcast::Sender<()>,
-    /// Optional agent handle for process-isolated kernel execution.
-    /// When set, kernel requests are routed to the agent subprocess
-    /// instead of the local `RoomKernel`. Set by `LaunchKernel` when
-    /// agent mode is enabled.
+    /// Handle to the agent subprocess that owns this notebook's kernel.
+    /// Set by `LaunchKernel` or `auto_launch_kernel` when the agent is spawned.
     pub agent_handle: Arc<Mutex<Option<crate::agent_handle::AgentHandle>>>,
     /// Environment path used by an agent-backed kernel, for GC protection.
     pub agent_env_path: Arc<RwLock<Option<PathBuf>>>,
@@ -4192,11 +4190,6 @@ async fn handle_notebook_request(
                 }
             }
         }
-
-        #[allow(deprecated)]
-        NotebookRequest::QueueCell { .. } => NotebookResponse::Error {
-            error: "QueueCell is deprecated — use ExecuteCell instead".to_string(),
-        },
 
         NotebookRequest::ExecuteCell { cell_id } => {
             // Read cell source FIRST (before kernel lock) to avoid holding


### PR DESCRIPTION
## Summary

Final sweep of agent-era artifacts. **-61 lines**.

- **Remove `AgentNotification` enum** — defined but never used anywhere
- **Remove `QueueCell` request variant** — the source-in-request anti-pattern. Execution is fully CRDT-driven now (coordinator writes to RuntimeStateDoc, agent picks up via sync)
- **Remove `QueueCell` handler** — was already returning a deprecation error
- **Remove `QueueCell` test** — no longer applicable
- **Update `kernel_manager.rs` module doc** — describes agent subprocess ownership, not daemon-owned management
- **Fix `agent_handle` doc comment** — not a "mode", just how kernels work

## Test plan

- [x] `cargo check` — all crates clean
- [x] `cargo xtask lint` — passes
- [x] `cargo test -p runtimed` — 187 lib + 22 integration pass
- [ ] CI