### PR TITLE
feat(kernel-env): pre-install nbformat in all Python runtimes

### DIFF
--- a/crates/kernel-env/src/conda.rs
+++ b/crates/kernel-env/src/conda.rs
@@ -224,9 +224,10 @@ async fn install_conda_env(
     specs.push(MatchSpec::from_str("ipykernel", match_spec_options)?);
     specs.push(MatchSpec::from_str("ipywidgets", match_spec_options)?);
     specs.push(MatchSpec::from_str("anywidget", match_spec_options)?);
+    specs.push(MatchSpec::from_str("nbformat", match_spec_options)?);
 
     for dep in &deps.dependencies {
-        if dep != "ipykernel" && dep != "ipywidgets" && dep != "anywidget" {
+        if dep != "ipykernel" && dep != "ipywidgets" && dep != "anywidget" && dep != "nbformat" {
             specs.push(MatchSpec::from_str(dep, match_spec_options)?);
         }
     }
@@ -636,6 +637,7 @@ import sys
 import ipykernel
 import IPython
 import ipywidgets
+import nbformat
 import traitlets
 import zmq
 from ipykernel.kernelbase import Kernel

--- a/crates/kernel-env/src/uv.rs
+++ b/crates/kernel-env/src/uv.rs
@@ -199,6 +199,7 @@ pub async fn prepare_environment_in(
         "ipykernel".to_string(),
         "ipywidgets".to_string(),
         "anywidget".to_string(),
+        "nbformat".to_string(),
         "uv".to_string(), // For %uv magic in notebooks
     ];
     packages.extend(deps.dependencies.iter().cloned());
@@ -558,6 +559,7 @@ import sys
 import ipykernel
 import IPython
 import ipywidgets
+import nbformat
 import traitlets
 import zmq
 from ipykernel.kernelbase import Kernel

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -2313,6 +2313,7 @@ impl Daemon {
             "ipykernel".to_string(),
             "ipywidgets".to_string(),
             "anywidget".to_string(),
+            "nbformat".to_string(),
         ];
         conda_install_packages.extend(extra_conda_packages.clone());
 
@@ -2323,6 +2324,7 @@ impl Daemon {
                 MatchSpec::from_str("ipykernel", match_spec_options)?,
                 MatchSpec::from_str("ipywidgets", match_spec_options)?,
                 MatchSpec::from_str("anywidget", match_spec_options)?,
+                MatchSpec::from_str("nbformat", match_spec_options)?,
             ];
             for pkg in &extra_conda_packages {
                 specs.push(MatchSpec::from_str(pkg, match_spec_options)?);
@@ -2567,6 +2569,7 @@ import ipykernel
 import IPython
 import ipywidgets
 import anywidget
+import nbformat
 import traitlets
 import zmq
 from ipykernel.kernelbase import Kernel
@@ -2761,6 +2764,7 @@ print("warmup complete")
             "ipykernel".to_string(),
             "ipywidgets".to_string(),
             "anywidget".to_string(),
+            "nbformat".to_string(),
             "uv".to_string(), // For %uv magic in notebooks
         ];
 
@@ -2881,6 +2885,7 @@ import ipykernel
 import IPython
 import ipywidgets
 import anywidget
+import nbformat
 from ipykernel.kernelbase import Kernel
 from ipykernel.ipkernel import IPythonKernel
 print("warmup complete")


### PR DESCRIPTION
## Summary

- Adds `nbformat` to the base package set for both UV and conda environments, alongside the existing `ipykernel`, `ipywidgets`, and `anywidget`
- Adds `import nbformat` to all warmup scripts for `.pyc` pre-compilation
- Updates the conda dedup filter to skip `nbformat` when it appears in user dependencies

Plotly requires `nbformat` at runtime for its MIME renderer, but it isn't a transitive dependency — users hit an import error on first use. Since `nbformat` is small and broadly useful, it belongs in the base set.

## Verification

- [ ] Open a notebook with a fresh UV environment (no user deps), run `import nbformat` — succeeds without adding it as a dependency
- [ ] Open a notebook with a fresh conda environment, run `import nbformat` — succeeds
- [ ] Run `import plotly.express as px; fig = px.scatter(x=[1,2,3], y=[1,2,3]); fig` in a notebook with plotly added as a dependency — works without manually adding nbformat
- [ ] Verify daemon logs show `nbformat` in the warmup import sequence

_PR submitted by @rgbkrk's agent, Quill_