### PR TITLE
feat(repr-llm): synthesize text/llm+plain for viz outputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5671,6 +5671,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "repr-llm"
+version = "0.1.0"
+dependencies = [
+ "log",
+ "serde_json",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6115,6 +6123,7 @@ dependencies = [
  "log",
  "notebook-doc",
  "notebook-protocol",
+ "repr-llm",
  "reqwest 0.12.28",
  "runt-workspace",
  "schemars 1.2.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "crates/runtimed-wasm",
     "crates/mcp-supervisor",
     "crates/runt-mcp",
+    "crates/repr-llm",
 ]
 default-members = ["crates/notebook"]
 resolver = "2"

--- a/crates/repr-llm/Cargo.toml
+++ b/crates/repr-llm/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "repr-llm"
+version = "0.1.0"
+edition.workspace = true
+description = "LLM-friendly text summaries of structured visualization specs"
+repository.workspace = true
+license.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+serde_json = { workspace = true }
+log = "0.4"

--- a/crates/repr-llm/src/lib.rs
+++ b/crates/repr-llm/src/lib.rs
@@ -1,0 +1,134 @@
+//! LLM-friendly text summaries of structured visualization specs.
+//!
+//! This crate produces compact, informative text representations of Plotly,
+//! Vega-Lite, and Vega chart specs. These summaries are designed for LLM
+//! consumption — compressing ~10k chars of JSON into ~300 chars of structured
+//! text while preserving the information agents need to reason about charts.
+//!
+//! # Usage
+//!
+//! ```
+//! use repr_llm::summarize_viz;
+//! use serde_json::json;
+//!
+//! let spec = json!({
+//!     "data": [{"type": "bar", "x": ["A", "B"], "y": [1, 2]}],
+//!     "layout": {"title": "Example"}
+//! });
+//!
+//! let summary = summarize_viz("application/vnd.plotly.v1+json", &spec);
+//! assert!(summary.is_some());
+//! ```
+
+pub mod plotly;
+pub(crate) mod stats;
+pub mod vega;
+pub mod vegalite;
+
+use serde_json::Value;
+
+/// Attempt to produce an LLM-friendly text summary from a visualization spec.
+///
+/// Returns `Some(summary)` if the MIME type is a recognized visualization format
+/// (Plotly, Vega-Lite, or Vega), `None` otherwise.
+pub fn summarize_viz(mime: &str, spec: &Value) -> Option<String> {
+    if is_plotly_mime(mime) {
+        Some(plotly::summarize(spec))
+    } else if is_vegalite_mime(mime) {
+        Some(vegalite::summarize(spec))
+    } else if is_vega_mime(mime) {
+        Some(vega::summarize(spec))
+    } else {
+        None
+    }
+}
+
+/// Check if a MIME type is Plotly JSON.
+fn is_plotly_mime(mime: &str) -> bool {
+    mime == "application/vnd.plotly.v1+json"
+}
+
+/// Check if a MIME type is Vega-Lite JSON (any version).
+fn is_vegalite_mime(mime: &str) -> bool {
+    mime.starts_with("application/vnd.vegalite.v")
+        && (mime.ends_with("+json") || mime.ends_with(".json"))
+}
+
+/// Check if a MIME type is Vega JSON (any version, excluding Vega-Lite).
+fn is_vega_mime(mime: &str) -> bool {
+    mime.starts_with("application/vnd.vega.v")
+        && !mime.starts_with("application/vnd.vegalite.")
+        && (mime.ends_with("+json") || mime.ends_with(".json"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_plotly_mime() {
+        assert!(is_plotly_mime("application/vnd.plotly.v1+json"));
+        assert!(!is_plotly_mime("application/json"));
+        assert!(!is_plotly_mime("application/vnd.vegalite.v5+json"));
+    }
+
+    #[test]
+    fn test_vegalite_mime() {
+        assert!(is_vegalite_mime("application/vnd.vegalite.v3+json"));
+        assert!(is_vegalite_mime("application/vnd.vegalite.v4+json"));
+        assert!(is_vegalite_mime("application/vnd.vegalite.v5+json"));
+        assert!(is_vegalite_mime("application/vnd.vegalite.v5.json"));
+        assert!(is_vegalite_mime("application/vnd.vegalite.v6+json"));
+        assert!(!is_vegalite_mime("application/vnd.vega.v5+json"));
+    }
+
+    #[test]
+    fn test_vega_mime() {
+        assert!(is_vega_mime("application/vnd.vega.v4+json"));
+        assert!(is_vega_mime("application/vnd.vega.v5+json"));
+        assert!(is_vega_mime("application/vnd.vega.v5.json"));
+        assert!(is_vega_mime("application/vnd.vega.v6+json"));
+        assert!(!is_vega_mime("application/vnd.vegalite.v5+json"));
+    }
+
+    #[test]
+    fn test_summarize_plotly() {
+        let spec = json!({
+            "data": [{"type": "bar", "x": ["a"], "y": [1]}],
+            "layout": {"title": "Test"}
+        });
+        let result = summarize_viz("application/vnd.plotly.v1+json", &spec);
+        assert!(result.is_some());
+        assert!(result.as_ref().is_some_and(|s| s.contains("Plotly")));
+    }
+
+    #[test]
+    fn test_summarize_vegalite() {
+        let spec = json!({
+            "mark": "bar",
+            "encoding": {"x": {"field": "a", "type": "nominal"}}
+        });
+        let result = summarize_viz("application/vnd.vegalite.v5+json", &spec);
+        assert!(result.is_some());
+        assert!(result.as_ref().is_some_and(|s| s.contains("Vega-Lite")));
+    }
+
+    #[test]
+    fn test_summarize_vega() {
+        let spec = json!({
+            "marks": [{"type": "rect"}],
+            "data": [{"name": "table"}]
+        });
+        let result = summarize_viz("application/vnd.vega.v5+json", &spec);
+        assert!(result.is_some());
+        assert!(result.as_ref().is_some_and(|s| s.contains("Vega chart")));
+    }
+
+    #[test]
+    fn test_summarize_unknown_mime() {
+        let spec = json!({"key": "value"});
+        assert!(summarize_viz("application/json", &spec).is_none());
+        assert!(summarize_viz("text/plain", &spec).is_none());
+    }
+}

--- a/crates/repr-llm/src/plotly.rs
+++ b/crates/repr-llm/src/plotly.rs
@@ -5,7 +5,8 @@
 use serde_json::Value;
 
 use crate::stats::{
-    compute_stats, detect_trend, extract_numbers, extract_title, fmt_num, format_inline_pairs,
+    compute_stats, detect_trend, extract_numbers, extract_numbers_positional, extract_title,
+    fmt_num,
 };
 
 /// Summarize a Plotly spec into an LLM-friendly text representation.
@@ -181,18 +182,30 @@ fn summarize_bar(trace: &Value) -> String {
         _ => return "no data".to_string(),
     };
 
-    let labels: Vec<&str> = labels_arr.iter().filter_map(|v| v.as_str()).collect();
-    let values = extract_numbers(values_arr);
+    // Use positional extraction to maintain index alignment with labels
+    let values_pos = extract_numbers_positional(values_arr);
 
-    if labels.is_empty() || values.is_empty() {
+    // Pair labels with values, skipping entries where either is missing
+    let pairs: Vec<(&str, f64)> = labels_arr
+        .iter()
+        .zip(values_pos.iter())
+        .filter_map(|(label, value)| Some((label.as_str()?, (*value)?)))
+        .collect();
+
+    if pairs.is_empty() {
         return format!("n={}", labels_arr.len().max(values_arr.len()));
     }
 
-    let n = labels.len().min(values.len());
+    let n = pairs.len();
     if n <= 20 {
-        format!("{{ {} }}", format_inline_pairs(&labels[..n], &values[..n]))
+        let formatted: Vec<String> = pairs
+            .iter()
+            .map(|(l, v)| format!("{}: {}", l, fmt_num(*v)))
+            .collect();
+        format!("{{ {} }}", formatted.join(", "))
     } else {
-        let stats = compute_stats(&values);
+        let values_only: Vec<f64> = pairs.iter().map(|(_, v)| *v).collect();
+        let stats = compute_stats(&values_only);
         match stats {
             Some(s) => format!(
                 "n={}; range=[{}, {}], mean={}",
@@ -216,20 +229,26 @@ fn summarize_pie(trace: &Value) -> String {
         _ => return "no data".to_string(),
     };
 
-    let labels: Vec<&str> = labels_arr.iter().filter_map(|v| v.as_str()).collect();
-    let values = extract_numbers(values_arr);
+    // Use positional extraction to maintain index alignment with labels
+    let values_pos = extract_numbers_positional(values_arr);
 
-    if labels.is_empty() || values.is_empty() {
+    // Pair labels with values, skipping entries where either is missing
+    let pairs: Vec<(&str, f64)> = labels_arr
+        .iter()
+        .zip(values_pos.iter())
+        .filter_map(|(label, value)| Some((label.as_str()?, (*value)?)))
+        .collect();
+
+    if pairs.is_empty() {
         return format!("n={}", labels_arr.len().max(values_arr.len()));
     }
 
-    let total: f64 = values.iter().sum();
-    let n = labels.len().min(values.len());
+    let total: f64 = pairs.iter().map(|(_, v)| v).sum();
+    let n = pairs.len();
 
     if n <= 15 && total > 0.0 {
-        let parts: Vec<String> = labels[..n]
+        let parts: Vec<String> = pairs
             .iter()
-            .zip(values[..n].iter())
             .map(|(l, v)| {
                 let pct = v / total * 100.0;
                 format!("{}: {} ({:.0}%)", l, fmt_num(*v), pct)
@@ -241,35 +260,74 @@ fn summarize_pie(trace: &Value) -> String {
     }
 }
 
+/// Classify the x-axis of a scatter trace.
+enum XAxis<'a> {
+    /// String labels (dates, categories)
+    Strings(&'a [Value]),
+    /// Numeric values
+    Numeric(&'a [Value]),
+    /// No x-axis provided
+    None,
+}
+
 /// Summarize a scatter/line trace.
+///
+/// Handles both numeric and string x-axes (e.g., dates like "2024-01").
 fn summarize_scatter(trace: &Value) -> String {
-    let x_arr = match trace.get("x").and_then(|v| v.as_array()) {
-        Some(arr) => arr,
-        None => return "no data".to_string(),
-    };
     let y_arr = match trace.get("y").and_then(|v| v.as_array()) {
         Some(arr) => arr,
         None => return "no data".to_string(),
     };
 
-    let x_vals = extract_numbers(x_arr);
     let y_vals = extract_numbers(y_arr);
-    let n = x_vals.len().min(y_vals.len());
+    if y_vals.is_empty() {
+        return "no data".to_string();
+    }
+
+    let x_axis = match trace.get("x").and_then(|v| v.as_array()) {
+        Some(arr) if arr.first().is_some_and(|v| v.is_string()) => XAxis::Strings(arr),
+        Some(arr) => XAxis::Numeric(arr),
+        None => XAxis::None,
+    };
+
+    let n = match &x_axis {
+        XAxis::Strings(x) | XAxis::Numeric(x) => x.len().min(y_vals.len()),
+        XAxis::None => y_vals.len(),
+    };
 
     if n == 0 {
         return "no data".to_string();
     }
 
     if n <= 15 {
-        // Inline all points
-        let pairs: Vec<String> = x_vals[..n]
-            .iter()
-            .zip(y_vals[..n].iter())
-            .map(|(x, y)| format!("({}, {})", fmt_num(*x), fmt_num(*y)))
-            .collect();
+        let pairs: Vec<String> = match &x_axis {
+            XAxis::Strings(x) => x
+                .iter()
+                .zip(y_vals.iter())
+                .take(n)
+                .map(|(x, y)| {
+                    let label = x.as_str().unwrap_or("?");
+                    format!("({}, {})", label, fmt_num(*y))
+                })
+                .collect(),
+            XAxis::Numeric(x) => {
+                let x_vals = extract_numbers(x);
+                x_vals
+                    .iter()
+                    .zip(y_vals.iter())
+                    .take(n)
+                    .map(|(x, y)| format!("({}, {})", fmt_num(*x), fmt_num(*y)))
+                    .collect()
+            }
+            XAxis::None => y_vals
+                .iter()
+                .take(n)
+                .enumerate()
+                .map(|(i, y)| format!("({}, {})", i, fmt_num(*y)))
+                .collect(),
+        };
         format!("n={}: {}", n, pairs.join(", "))
     } else {
-        // Stats + trend + endpoints
         let y_stats = compute_stats(&y_vals);
         let trend = detect_trend(&y_vals);
         let first_y = y_vals.first().copied().unwrap_or(0.0);
@@ -280,10 +338,20 @@ fn summarize_scatter(trace: &Value) -> String {
             0.0
         };
 
+        let x_context = match &x_axis {
+            XAxis::Strings(x) => {
+                let first_x = x.first().and_then(|v| v.as_str()).unwrap_or("?");
+                let last_x = x.last().and_then(|v| v.as_str()).unwrap_or("?");
+                format!("; x: {}..{}", first_x, last_x)
+            }
+            _ => String::new(),
+        };
+
         match y_stats {
             Some(s) => format!(
-                "n={}; y: range=[{}, {}], mean={}; trend: {}; first={}, last={} ({:+.1}%)",
+                "n={}{}; y: range=[{}, {}], mean={}; trend: {}; first={}, last={} ({:+.1}%)",
                 n,
+                x_context,
                 fmt_num(s.min),
                 fmt_num(s.max),
                 fmt_num(s.mean),
@@ -654,5 +722,117 @@ mod tests {
         });
         let result = summarize(&spec);
         assert!(result.contains("Axes: x=Time, y=Value"));
+    }
+
+    // Regression: string x-axis (dates) should not produce "no data"
+    #[test]
+    fn test_scatter_string_x_axis() {
+        let spec = json!({
+            "data": [{
+                "type": "scatter",
+                "mode": "lines",
+                "x": ["2024-01", "2024-02", "2024-03"],
+                "y": [10, 20, 30]
+            }],
+            "layout": {"title": "Monthly"}
+        });
+        let result = summarize(&spec);
+        assert!(
+            result.contains("(line)"),
+            "should classify as line: {}",
+            result
+        );
+        assert!(
+            !result.contains("no data"),
+            "string x should not be 'no data': {}",
+            result
+        );
+        assert!(
+            result.contains("2024-01"),
+            "should include date labels: {}",
+            result
+        );
+        assert!(result.contains("30"), "should include y values: {}", result);
+    }
+
+    // Regression: large time-series with string x-axis should show stats + x range
+    #[test]
+    fn test_scatter_string_x_axis_large() {
+        let x: Vec<String> = (0..50).map(|i| format!("2024-W{:02}", i + 1)).collect();
+        let y: Vec<f64> = (0..50).map(|i| 100.0 + i as f64 * 2.0).collect();
+        let spec = json!({
+            "data": [{"type": "scatter", "mode": "lines", "x": x, "y": y}],
+            "layout": {"title": "Weekly"}
+        });
+        let result = summarize(&spec);
+        assert!(!result.contains("no data"), "should have data: {}", result);
+        assert!(result.contains("n=50"), "should show count: {}", result);
+        assert!(
+            result.contains("trend: increasing"),
+            "should detect trend: {}",
+            result
+        );
+        assert!(
+            result.contains("2024-W01"),
+            "should show first x label: {}",
+            result
+        );
+        assert!(
+            result.contains("2024-W50"),
+            "should show last x label: {}",
+            result
+        );
+    }
+
+    // Regression: null values in bar chart should not misalign labels
+    #[test]
+    fn test_bar_with_nulls() {
+        let spec = json!({
+            "data": [{
+                "type": "bar",
+                "x": ["A", "B", "C"],
+                "y": [1, null, 3]
+            }],
+            "layout": {"title": "Sparse"}
+        });
+        let result = summarize(&spec);
+        // B should be skipped entirely, not assigned C's value
+        assert!(result.contains("A: 1"), "should have A=1: {}", result);
+        assert!(result.contains("C: 3"), "should have C=3: {}", result);
+        assert!(
+            !result.contains("B: 3"),
+            "B should not get C's value: {}",
+            result
+        );
+        assert!(!result.contains("B: 1"), "B should not appear: {}", result);
+    }
+
+    // Regression: null values in pie chart should not misalign labels
+    #[test]
+    fn test_pie_with_nulls() {
+        let spec = json!({
+            "data": [{
+                "type": "pie",
+                "labels": ["Alpha", "Beta", "Gamma"],
+                "values": [10, null, 30]
+            }],
+            "layout": {"title": "Sparse Pie"}
+        });
+        let result = summarize(&spec);
+        assert!(
+            result.contains("Alpha: 10"),
+            "should have Alpha=10: {}",
+            result
+        );
+        assert!(
+            result.contains("Gamma: 30"),
+            "should have Gamma=30: {}",
+            result
+        );
+        assert!(
+            !result.contains("Beta: 30"),
+            "Beta should not get Gamma's value: {}",
+            result
+        );
     }
 }

--- a/crates/repr-llm/src/plotly.rs
+++ b/crates/repr-llm/src/plotly.rs
@@ -1,0 +1,658 @@
+//! Plotly visualization summarization.
+//!
+//! Walks a Plotly JSON spec and produces a compact text summary suitable for LLMs.
+
+use serde_json::Value;
+
+use crate::stats::{
+    compute_stats, detect_trend, extract_numbers, extract_title, fmt_num, format_inline_pairs,
+};
+
+/// Summarize a Plotly spec into an LLM-friendly text representation.
+pub fn summarize(spec: &Value) -> String {
+    let mut lines = Vec::new();
+
+    let layout = spec.get("layout");
+    let title = layout.and_then(|l| l.get("title")).and_then(extract_title);
+
+    let traces = match spec.get("data").and_then(|d| d.as_array()) {
+        Some(arr) => arr,
+        None => {
+            // No data array — minimal fallback
+            if let Some(t) = title {
+                return format!("Plotly chart: \"{}\"", t);
+            }
+            return "Plotly chart (no data)".to_string();
+        }
+    };
+
+    // Determine dominant chart type for header
+    let trace_types: Vec<&str> = traces
+        .iter()
+        .filter_map(|t| t.get("type").and_then(|v| v.as_str()))
+        .collect();
+    let dominant_type = dominant_chart_type(&trace_types);
+
+    // Header line
+    let header = match title {
+        Some(t) => format!("Plotly {} chart: \"{}\"", dominant_type, t),
+        None => format!("Plotly {} chart", dominant_type),
+    };
+    lines.push(header);
+
+    // Axis labels
+    if let Some(l) = layout {
+        let x_label = l
+            .get("xaxis")
+            .and_then(|a| a.get("title"))
+            .and_then(extract_title);
+        let y_label = l
+            .get("yaxis")
+            .and_then(|a| a.get("title"))
+            .and_then(extract_title);
+        if x_label.is_some() || y_label.is_some() {
+            lines.push(format!(
+                "Axes: x={}, y={}",
+                x_label.unwrap_or("(unlabeled)"),
+                y_label.unwrap_or("(unlabeled)")
+            ));
+        }
+    }
+
+    // Traces
+    lines.push(format!("Traces: {}", traces.len()));
+    for (i, trace) in traces.iter().enumerate() {
+        let trace_type = trace
+            .get("type")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown");
+        let trace_name = trace.get("name").and_then(|v| v.as_str()).unwrap_or("");
+
+        let display_type = classify_trace_type(trace);
+        let summary = summarize_trace(trace, trace_type);
+
+        let name_part = if trace_name.is_empty() {
+            if traces.len() > 1 {
+                format!("[trace {}]", i + 1)
+            } else {
+                String::new()
+            }
+        } else {
+            format!("[{}]", trace_name)
+        };
+
+        if name_part.is_empty() {
+            lines.push(format!("  ({}) {}", display_type, summary));
+        } else {
+            lines.push(format!("  {} ({}) {}", name_part, display_type, summary));
+        }
+    }
+
+    lines.join("\n")
+}
+
+/// Classify a trace into a display type (e.g., "line" vs "scatter").
+fn classify_trace_type(trace: &Value) -> &str {
+    let trace_type = trace
+        .get("type")
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown");
+
+    match trace_type {
+        "scatter" | "scattergl" => {
+            let mode = trace.get("mode").and_then(|v| v.as_str()).unwrap_or("");
+            if mode.contains("lines") {
+                "line"
+            } else {
+                "scatter"
+            }
+        }
+        "choroplethmapbox" => "choropleth",
+        other => other,
+    }
+}
+
+/// Determine the dominant chart type from trace types.
+fn dominant_chart_type(trace_types: &[&str]) -> String {
+    if trace_types.is_empty() {
+        return "unknown".to_string();
+    }
+    if trace_types.len() == 1 {
+        return trace_types[0].to_string();
+    }
+
+    // Count occurrences
+    let mut counts: Vec<(&str, usize)> = Vec::new();
+    for &t in trace_types {
+        if let Some(entry) = counts.iter_mut().find(|(name, _)| *name == t) {
+            entry.1 += 1;
+        } else {
+            counts.push((t, 1));
+        }
+    }
+    counts.sort_by(|a, b| b.1.cmp(&a.1));
+
+    if counts.len() == 1 {
+        counts[0].0.to_string()
+    } else {
+        // Multiple types — list them
+        counts
+            .iter()
+            .map(|(name, _)| *name)
+            .collect::<Vec<_>>()
+            .join("+")
+    }
+}
+
+/// Summarize a single trace based on its type.
+fn summarize_trace(trace: &Value, trace_type: &str) -> String {
+    match trace_type {
+        "bar" => summarize_bar(trace),
+        "pie" => summarize_pie(trace),
+        "scatter" | "scattergl" => summarize_scatter(trace),
+        "heatmap" => summarize_heatmap(trace),
+        "choropleth" | "choroplethmapbox" => summarize_choropleth(trace),
+        _ => summarize_generic(trace, trace_type),
+    }
+}
+
+/// Summarize a bar trace.
+fn summarize_bar(trace: &Value) -> String {
+    let x_arr = trace.get("x").and_then(|v| v.as_array());
+    let y_arr = trace.get("y").and_then(|v| v.as_array());
+
+    let (labels_arr, values_arr) = match (x_arr, y_arr) {
+        (Some(x), Some(y)) => {
+            // Determine which is categories and which is values
+            // If x has strings, x=categories, y=values; otherwise y=categories, x=values
+            let x_is_strings = x.first().is_some_and(|v| v.is_string());
+            if x_is_strings {
+                (x, y)
+            } else {
+                // Could be horizontal bar — check if y has strings
+                let y_is_strings = y.first().is_some_and(|v| v.is_string());
+                if y_is_strings {
+                    (y, x)
+                } else {
+                    (x, y)
+                }
+            }
+        }
+        _ => return "no data".to_string(),
+    };
+
+    let labels: Vec<&str> = labels_arr.iter().filter_map(|v| v.as_str()).collect();
+    let values = extract_numbers(values_arr);
+
+    if labels.is_empty() || values.is_empty() {
+        return format!("n={}", labels_arr.len().max(values_arr.len()));
+    }
+
+    let n = labels.len().min(values.len());
+    if n <= 20 {
+        format!("{{ {} }}", format_inline_pairs(&labels[..n], &values[..n]))
+    } else {
+        let stats = compute_stats(&values);
+        match stats {
+            Some(s) => format!(
+                "n={}; range=[{}, {}], mean={}",
+                n,
+                fmt_num(s.min),
+                fmt_num(s.max),
+                fmt_num(s.mean)
+            ),
+            None => format!("n={}", n),
+        }
+    }
+}
+
+/// Summarize a pie trace.
+fn summarize_pie(trace: &Value) -> String {
+    let labels_arr = trace.get("labels").and_then(|v| v.as_array());
+    let values_arr = trace.get("values").and_then(|v| v.as_array());
+
+    let (labels_arr, values_arr) = match (labels_arr, values_arr) {
+        (Some(l), Some(v)) => (l, v),
+        _ => return "no data".to_string(),
+    };
+
+    let labels: Vec<&str> = labels_arr.iter().filter_map(|v| v.as_str()).collect();
+    let values = extract_numbers(values_arr);
+
+    if labels.is_empty() || values.is_empty() {
+        return format!("n={}", labels_arr.len().max(values_arr.len()));
+    }
+
+    let total: f64 = values.iter().sum();
+    let n = labels.len().min(values.len());
+
+    if n <= 15 && total > 0.0 {
+        let parts: Vec<String> = labels[..n]
+            .iter()
+            .zip(values[..n].iter())
+            .map(|(l, v)| {
+                let pct = v / total * 100.0;
+                format!("{}: {} ({:.0}%)", l, fmt_num(*v), pct)
+            })
+            .collect();
+        format!("{{ {} }}", parts.join(", "))
+    } else {
+        format!("n={} slices, total={}", n, fmt_num(total))
+    }
+}
+
+/// Summarize a scatter/line trace.
+fn summarize_scatter(trace: &Value) -> String {
+    let x_arr = match trace.get("x").and_then(|v| v.as_array()) {
+        Some(arr) => arr,
+        None => return "no data".to_string(),
+    };
+    let y_arr = match trace.get("y").and_then(|v| v.as_array()) {
+        Some(arr) => arr,
+        None => return "no data".to_string(),
+    };
+
+    let x_vals = extract_numbers(x_arr);
+    let y_vals = extract_numbers(y_arr);
+    let n = x_vals.len().min(y_vals.len());
+
+    if n == 0 {
+        return "no data".to_string();
+    }
+
+    if n <= 15 {
+        // Inline all points
+        let pairs: Vec<String> = x_vals[..n]
+            .iter()
+            .zip(y_vals[..n].iter())
+            .map(|(x, y)| format!("({}, {})", fmt_num(*x), fmt_num(*y)))
+            .collect();
+        format!("n={}: {}", n, pairs.join(", "))
+    } else {
+        // Stats + trend + endpoints
+        let y_stats = compute_stats(&y_vals);
+        let trend = detect_trend(&y_vals);
+        let first_y = y_vals.first().copied().unwrap_or(0.0);
+        let last_y = y_vals.last().copied().unwrap_or(0.0);
+        let pct_change = if first_y.abs() > f64::EPSILON {
+            (last_y - first_y) / first_y.abs() * 100.0
+        } else {
+            0.0
+        };
+
+        match y_stats {
+            Some(s) => format!(
+                "n={}; y: range=[{}, {}], mean={}; trend: {}; first={}, last={} ({:+.1}%)",
+                n,
+                fmt_num(s.min),
+                fmt_num(s.max),
+                fmt_num(s.mean),
+                trend,
+                fmt_num(first_y),
+                fmt_num(last_y),
+                pct_change
+            ),
+            None => format!("n={}", n),
+        }
+    }
+}
+
+/// Summarize a heatmap trace.
+fn summarize_heatmap(trace: &Value) -> String {
+    let z_arr = match trace.get("z").and_then(|v| v.as_array()) {
+        Some(arr) => arr,
+        None => return "no data".to_string(),
+    };
+
+    let rows = z_arr.len();
+    let cols = z_arr
+        .first()
+        .and_then(|r| r.as_array())
+        .map_or(0, |a| a.len());
+
+    let x_labels: Option<Vec<&str>> = trace
+        .get("x")
+        .and_then(|v| v.as_array())
+        .map(|arr| arr.iter().filter_map(|v| v.as_str()).collect());
+    let y_labels: Option<Vec<&str>> = trace
+        .get("y")
+        .and_then(|v| v.as_array())
+        .map(|arr| arr.iter().filter_map(|v| v.as_str()).collect());
+
+    if rows <= 6 && cols <= 6 {
+        // Full labeled matrix
+        let mut matrix_lines = Vec::new();
+        for (i, row) in z_arr.iter().enumerate() {
+            if let Some(row_arr) = row.as_array() {
+                let row_label = y_labels
+                    .as_ref()
+                    .and_then(|labels| labels.get(i).copied())
+                    .unwrap_or("?");
+                let cells: Vec<String> = row_arr
+                    .iter()
+                    .enumerate()
+                    .map(|(j, v)| {
+                        let col_label = x_labels
+                            .as_ref()
+                            .and_then(|labels| labels.get(j).copied())
+                            .unwrap_or("?");
+                        format!("{}:{}", col_label, fmt_num(v.as_f64().unwrap_or(0.0)))
+                    })
+                    .collect();
+                matrix_lines.push(format!("  {}: {}", row_label, cells.join(", ")));
+            }
+        }
+        format!("matrix {}x{}\n{}", rows, cols, matrix_lines.join("\n"))
+    } else {
+        // Shape + range
+        let all_values: Vec<f64> = z_arr
+            .iter()
+            .filter_map(|row| row.as_array())
+            .flat_map(|row| row.iter().filter_map(|v| v.as_f64()))
+            .filter(|v| v.is_finite())
+            .collect();
+
+        match compute_stats(&all_values) {
+            Some(s) => format!(
+                "matrix {}x{}, range=[{}, {}], mean={}",
+                rows,
+                cols,
+                fmt_num(s.min),
+                fmt_num(s.max),
+                fmt_num(s.mean)
+            ),
+            None => format!("matrix {}x{}", rows, cols),
+        }
+    }
+}
+
+/// Summarize a choropleth trace.
+fn summarize_choropleth(trace: &Value) -> String {
+    let locations = trace.get("locations").and_then(|v| v.as_array());
+    let z_arr = trace
+        .get("z")
+        .and_then(|v| v.as_array())
+        .or_else(|| trace.get("values").and_then(|v| v.as_array()));
+
+    let (locations, z_arr) = match (locations, z_arr) {
+        (Some(l), Some(z)) => (l, z),
+        _ => return "no data".to_string(),
+    };
+
+    let loc_names: Vec<&str> = locations.iter().filter_map(|v| v.as_str()).collect();
+    let z_vals = extract_numbers(z_arr);
+    let n = loc_names.len().min(z_vals.len());
+
+    if n == 0 {
+        return "no data".to_string();
+    }
+
+    let stats = compute_stats(&z_vals);
+
+    // Find top/bottom 3
+    let mut indexed: Vec<(usize, f64)> = z_vals[..n].iter().copied().enumerate().collect();
+    indexed.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+
+    let top3: Vec<String> = indexed
+        .iter()
+        .take(3)
+        .filter_map(|(i, v)| {
+            loc_names
+                .get(*i)
+                .map(|name| format!("{}={}", name, fmt_num(*v)))
+        })
+        .collect();
+
+    let bottom3: Vec<String> = indexed
+        .iter()
+        .rev()
+        .take(3)
+        .filter_map(|(i, v)| {
+            loc_names
+                .get(*i)
+                .map(|name| format!("{}={}", name, fmt_num(*v)))
+        })
+        .collect();
+
+    match stats {
+        Some(s) => format!(
+            "n={}, range=[{}, {}]; highest: {}; lowest: {}",
+            n,
+            fmt_num(s.min),
+            fmt_num(s.max),
+            top3.join(", "),
+            bottom3.join(", ")
+        ),
+        None => format!("n={}", n),
+    }
+}
+
+/// Generic fallback for unknown trace types.
+fn summarize_generic(trace: &Value, trace_type: &str) -> String {
+    // Try to determine data size from common fields
+    let n = ["x", "y", "z", "values", "labels", "locations"]
+        .iter()
+        .filter_map(|key| trace.get(key)?.as_array().map(|a| a.len()))
+        .max();
+
+    match n {
+        Some(n) => format!("{} data points", n),
+        None => trace_type.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_bar_small() {
+        let spec = json!({
+            "data": [{
+                "type": "bar",
+                "x": ["Sun", "Sat", "Thur", "Fri"],
+                "y": [21.41, 20.44, 17.68, 17.15]
+            }],
+            "layout": {"title": "Tips by Day"}
+        });
+        let result = summarize(&spec);
+        assert!(result.contains("Plotly bar chart: \"Tips by Day\""));
+        assert!(result.contains("Sun: 21.41"));
+        assert!(result.contains("Fri: 17.15"));
+    }
+
+    #[test]
+    fn test_bar_large() {
+        let x: Vec<String> = (0..25).map(|i| format!("cat_{}", i)).collect();
+        let y: Vec<f64> = (0..25).map(|i| i as f64 * 2.0).collect();
+        let spec = json!({
+            "data": [{"type": "bar", "x": x, "y": y}],
+            "layout": {"title": "Many Bars"}
+        });
+        let result = summarize(&spec);
+        assert!(result.contains("n=25"));
+        assert!(result.contains("range="));
+    }
+
+    #[test]
+    fn test_pie() {
+        let spec = json!({
+            "data": [{
+                "type": "pie",
+                "labels": ["Engineering", "Sales", "Marketing", "Support"],
+                "values": [45, 28, 17, 10]
+            }],
+            "layout": {"title": "Department Size"}
+        });
+        let result = summarize(&spec);
+        assert!(result.contains("Plotly pie chart"));
+        assert!(result.contains("Engineering: 45 (45%)"));
+        assert!(result.contains("Support: 10 (10%)"));
+    }
+
+    #[test]
+    fn test_scatter_small() {
+        let spec = json!({
+            "data": [{
+                "type": "scatter",
+                "x": [1, 2, 3, 4, 5],
+                "y": [2, 4, 6, 8, 10]
+            }],
+            "layout": {"title": "Linear"}
+        });
+        let result = summarize(&spec);
+        assert!(result.contains("scatter"));
+        assert!(result.contains("n=5"));
+        assert!(result.contains("(1, 2)"));
+        assert!(result.contains("(5, 10)"));
+    }
+
+    #[test]
+    fn test_scatter_large() {
+        let x: Vec<f64> = (0..50).map(|i| i as f64).collect();
+        let y: Vec<f64> = (0..50).map(|i| i as f64 * 2.0 + 1.0).collect();
+        let spec = json!({
+            "data": [{
+                "type": "scatter",
+                "mode": "markers",
+                "x": x,
+                "y": y
+            }],
+            "layout": {"title": "Large Scatter"}
+        });
+        let result = summarize(&spec);
+        assert!(result.contains("n=50"));
+        assert!(result.contains("trend: increasing"));
+    }
+
+    #[test]
+    fn test_line_chart() {
+        let spec = json!({
+            "data": [{
+                "type": "scatter",
+                "mode": "lines+markers",
+                "x": [1, 2, 3],
+                "y": [10, 20, 30]
+            }],
+            "layout": {"title": "Trend"}
+        });
+        let result = summarize(&spec);
+        // Should classify as "line" not "scatter"
+        assert!(result.contains("(line)"));
+    }
+
+    #[test]
+    fn test_heatmap_small() {
+        let spec = json!({
+            "data": [{
+                "type": "heatmap",
+                "x": ["a", "b", "c"],
+                "y": ["x", "y", "z"],
+                "z": [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+            }],
+            "layout": {"title": "Correlation"}
+        });
+        let result = summarize(&spec);
+        assert!(result.contains("matrix 3x3"));
+        assert!(result.contains("a:1"));
+    }
+
+    #[test]
+    fn test_heatmap_large() {
+        let z: Vec<Vec<f64>> = (0..10)
+            .map(|i| (0..10).map(|j| (i * 10 + j) as f64).collect())
+            .collect();
+        let spec = json!({
+            "data": [{"type": "heatmap", "z": z}],
+            "layout": {"title": "Big Heatmap"}
+        });
+        let result = summarize(&spec);
+        assert!(result.contains("matrix 10x10"));
+        assert!(result.contains("range="));
+    }
+
+    #[test]
+    fn test_choropleth() {
+        let spec = json!({
+            "data": [{
+                "type": "choropleth",
+                "locations": ["USA", "CAN", "MEX", "BRA", "ARG"],
+                "z": [100, 80, 60, 40, 20]
+            }],
+            "layout": {"title": "GDP"}
+        });
+        let result = summarize(&spec);
+        assert!(result.contains("n=5"));
+        assert!(result.contains("highest:"));
+        assert!(result.contains("USA=100"));
+    }
+
+    #[test]
+    fn test_no_title() {
+        let spec = json!({
+            "data": [{"type": "bar", "x": ["a", "b"], "y": [1, 2]}],
+            "layout": {}
+        });
+        let result = summarize(&spec);
+        assert!(result.contains("Plotly bar chart"));
+        assert!(!result.contains("\"\""));
+    }
+
+    #[test]
+    fn test_multi_trace() {
+        let spec = json!({
+            "data": [
+                {"type": "scatter", "name": "Series A", "x": [1, 2], "y": [3, 4]},
+                {"type": "scatter", "name": "Series B", "x": [1, 2], "y": [5, 6]}
+            ],
+            "layout": {"title": "Comparison"}
+        });
+        let result = summarize(&spec);
+        assert!(result.contains("Traces: 2"));
+        assert!(result.contains("[Series A]"));
+        assert!(result.contains("[Series B]"));
+    }
+
+    #[test]
+    fn test_fallback_unknown_type() {
+        let spec = json!({
+            "data": [{"type": "sunburst", "values": [1, 2, 3]}],
+            "layout": {"title": "Sunburst"}
+        });
+        let result = summarize(&spec);
+        assert!(result.contains("sunburst"));
+        assert!(result.contains("3 data points"));
+    }
+
+    #[test]
+    fn test_no_data() {
+        let spec = json!({"layout": {"title": "Empty"}});
+        let result = summarize(&spec);
+        assert!(result.contains("Plotly chart: \"Empty\""));
+    }
+
+    #[test]
+    fn test_title_as_object() {
+        let spec = json!({
+            "data": [{"type": "bar", "x": ["a"], "y": [1]}],
+            "layout": {"title": {"text": "Object Title", "font": {"size": 14}}}
+        });
+        let result = summarize(&spec);
+        assert!(result.contains("\"Object Title\""));
+    }
+
+    #[test]
+    fn test_axis_labels() {
+        let spec = json!({
+            "data": [{"type": "scatter", "x": [1], "y": [2]}],
+            "layout": {
+                "title": "Test",
+                "xaxis": {"title": "Time"},
+                "yaxis": {"title": {"text": "Value"}}
+            }
+        });
+        let result = summarize(&spec);
+        assert!(result.contains("Axes: x=Time, y=Value"));
+    }
+}

--- a/crates/repr-llm/src/plotly.rs
+++ b/crates/repr-llm/src/plotly.rs
@@ -5,8 +5,7 @@
 use serde_json::Value;
 
 use crate::stats::{
-    compute_stats, detect_trend, extract_numbers, extract_numbers_positional, extract_title,
-    fmt_num,
+    compute_stats, detect_trend, extract_numbers_positional, extract_title, fmt_num,
 };
 
 /// Summarize a Plotly spec into an LLM-friendly text representation.
@@ -273,16 +272,15 @@ enum XAxis<'a> {
 /// Summarize a scatter/line trace.
 ///
 /// Handles both numeric and string x-axes (e.g., dates like "2024-01").
+/// Uses positional extraction for y-values to maintain alignment with x.
 fn summarize_scatter(trace: &Value) -> String {
     let y_arr = match trace.get("y").and_then(|v| v.as_array()) {
         Some(arr) => arr,
         None => return "no data".to_string(),
     };
 
-    let y_vals = extract_numbers(y_arr);
-    if y_vals.is_empty() {
-        return "no data".to_string();
-    }
+    // Use positional extraction to preserve alignment with x-axis
+    let y_pos = extract_numbers_positional(y_arr);
 
     let x_axis = match trace.get("x").and_then(|v| v.as_array()) {
         Some(arr) if arr.first().is_some_and(|v| v.is_string()) => XAxis::Strings(arr),
@@ -290,43 +288,45 @@ fn summarize_scatter(trace: &Value) -> String {
         None => XAxis::None,
     };
 
-    let n = match &x_axis {
-        XAxis::Strings(x) | XAxis::Numeric(x) => x.len().min(y_vals.len()),
-        XAxis::None => y_vals.len(),
+    // Build aligned (x_repr, y_val) pairs, skipping entries where y is null.
+    // For numeric x, also skip where x is null.
+    let pairs: Vec<(String, f64)> = match &x_axis {
+        XAxis::Strings(x) => x
+            .iter()
+            .zip(y_pos.iter())
+            .filter_map(|(xv, yv)| {
+                let label = xv.as_str().unwrap_or("?");
+                Some((label.to_string(), (*yv)?))
+            })
+            .collect(),
+        XAxis::Numeric(x) => {
+            let x_pos = extract_numbers_positional(x);
+            x_pos
+                .iter()
+                .zip(y_pos.iter())
+                .filter_map(|(xv, yv)| Some((fmt_num((*xv)?), (*yv)?)))
+                .collect()
+        }
+        XAxis::None => y_pos
+            .iter()
+            .enumerate()
+            .filter_map(|(i, yv)| Some((i.to_string(), (*yv)?)))
+            .collect(),
     };
 
-    if n == 0 {
+    if pairs.is_empty() {
         return "no data".to_string();
     }
 
+    let n = pairs.len();
+    let y_vals: Vec<f64> = pairs.iter().map(|(_, y)| *y).collect();
+
     if n <= 15 {
-        let pairs: Vec<String> = match &x_axis {
-            XAxis::Strings(x) => x
-                .iter()
-                .zip(y_vals.iter())
-                .take(n)
-                .map(|(x, y)| {
-                    let label = x.as_str().unwrap_or("?");
-                    format!("({}, {})", label, fmt_num(*y))
-                })
-                .collect(),
-            XAxis::Numeric(x) => {
-                let x_vals = extract_numbers(x);
-                x_vals
-                    .iter()
-                    .zip(y_vals.iter())
-                    .take(n)
-                    .map(|(x, y)| format!("({}, {})", fmt_num(*x), fmt_num(*y)))
-                    .collect()
-            }
-            XAxis::None => y_vals
-                .iter()
-                .take(n)
-                .enumerate()
-                .map(|(i, y)| format!("({}, {})", i, fmt_num(*y)))
-                .collect(),
-        };
-        format!("n={}: {}", n, pairs.join(", "))
+        let formatted: Vec<String> = pairs
+            .iter()
+            .map(|(x, y)| format!("({}, {})", x, fmt_num(*y)))
+            .collect();
+        format!("n={}: {}", n, formatted.join(", "))
     } else {
         let y_stats = compute_stats(&y_vals);
         let trend = detect_trend(&y_vals);
@@ -447,27 +447,35 @@ fn summarize_choropleth(trace: &Value) -> String {
         _ => return "no data".to_string(),
     };
 
-    let loc_names: Vec<&str> = locations.iter().filter_map(|v| v.as_str()).collect();
-    let z_vals = extract_numbers(z_arr);
-    let n = loc_names.len().min(z_vals.len());
+    // Use positional extraction to maintain alignment with location names
+    let z_pos = extract_numbers_positional(z_arr);
 
-    if n == 0 {
+    // Pair locations with z-values, skipping entries where either is missing
+    let pairs: Vec<(&str, f64)> = locations
+        .iter()
+        .zip(z_pos.iter())
+        .filter_map(|(loc, z)| Some((loc.as_str()?, (*z)?)))
+        .collect();
+
+    if pairs.is_empty() {
         return "no data".to_string();
     }
 
+    let n = pairs.len();
+    let z_vals: Vec<f64> = pairs.iter().map(|(_, v)| *v).collect();
     let stats = compute_stats(&z_vals);
 
     // Find top/bottom 3
-    let mut indexed: Vec<(usize, f64)> = z_vals[..n].iter().copied().enumerate().collect();
+    let mut indexed: Vec<(usize, f64)> = z_vals.iter().copied().enumerate().collect();
     indexed.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
 
     let top3: Vec<String> = indexed
         .iter()
         .take(3)
         .filter_map(|(i, v)| {
-            loc_names
+            pairs
                 .get(*i)
-                .map(|name| format!("{}={}", name, fmt_num(*v)))
+                .map(|(name, _)| format!("{}={}", name, fmt_num(*v)))
         })
         .collect();
 
@@ -476,9 +484,9 @@ fn summarize_choropleth(trace: &Value) -> String {
         .rev()
         .take(3)
         .filter_map(|(i, v)| {
-            loc_names
+            pairs
                 .get(*i)
-                .map(|name| format!("{}={}", name, fmt_num(*v)))
+                .map(|(name, _)| format!("{}={}", name, fmt_num(*v)))
         })
         .collect();
 
@@ -832,6 +840,74 @@ mod tests {
         assert!(
             !result.contains("Beta: 30"),
             "Beta should not get Gamma's value: {}",
+            result
+        );
+    }
+
+    // Regression: null y-values in scatter should not misalign with x
+    #[test]
+    fn test_scatter_with_null_y() {
+        let spec = json!({
+            "data": [{
+                "type": "scatter",
+                "x": [1, 2, 3],
+                "y": [10, null, 30]
+            }],
+            "layout": {"title": "Sparse Scatter"}
+        });
+        let result = summarize(&spec);
+        // x=2 should be skipped, not paired with y=30
+        assert!(result.contains("(1, 10)"), "should have (1,10): {}", result);
+        assert!(result.contains("(3, 30)"), "should have (3,30): {}", result);
+        assert!(
+            !result.contains("(2, 30)"),
+            "x=2 should not get y=30: {}",
+            result
+        );
+    }
+
+    // Regression: null x-values in scatter should skip those points
+    #[test]
+    fn test_scatter_with_null_x() {
+        let spec = json!({
+            "data": [{
+                "type": "scatter",
+                "x": [1, null, 3],
+                "y": [10, 20, 30]
+            }],
+            "layout": {"title": "Sparse X"}
+        });
+        let result = summarize(&spec);
+        assert!(result.contains("(1, 10)"), "should have (1,10): {}", result);
+        assert!(result.contains("(3, 30)"), "should have (3,30): {}", result);
+        assert!(
+            !result.contains("(3, 20)"),
+            "x=3 should not get y=20: {}",
+            result
+        );
+    }
+
+    // Regression: null z-values in choropleth should not misalign locations
+    #[test]
+    fn test_choropleth_with_nulls() {
+        let spec = json!({
+            "data": [{
+                "type": "choropleth",
+                "locations": ["USA", "CAN", "MEX"],
+                "z": [100, null, 60]
+            }],
+            "layout": {"title": "Sparse Map"}
+        });
+        let result = summarize(&spec);
+        assert!(
+            result.contains("USA=100"),
+            "should have USA=100: {}",
+            result
+        );
+        assert!(result.contains("MEX=60"), "should have MEX=60: {}", result);
+        assert!(
+            !result.contains("CAN=60"),
+            "CAN should not get MEX's value: {}",
             result
         );
     }

--- a/crates/repr-llm/src/stats.rs
+++ b/crates/repr-llm/src/stats.rs
@@ -12,6 +12,7 @@ pub struct NumericStats {
 }
 
 /// Extract f64 values from a JSON array, skipping nulls and non-numeric entries.
+#[allow(dead_code)]
 pub fn extract_numbers(arr: &[Value]) -> Vec<f64> {
     arr.iter()
         .filter_map(|v| v.as_f64())

--- a/crates/repr-llm/src/stats.rs
+++ b/crates/repr-llm/src/stats.rs
@@ -19,6 +19,16 @@ pub fn extract_numbers(arr: &[Value]) -> Vec<f64> {
         .collect()
 }
 
+/// Extract f64 values preserving position — returns `None` for nulls/non-numeric entries.
+///
+/// Use this instead of `extract_numbers` when you need to maintain index alignment
+/// with a parallel array (e.g., labels and values).
+pub fn extract_numbers_positional(arr: &[Value]) -> Vec<Option<f64>> {
+    arr.iter()
+        .map(|v| v.as_f64().filter(|f| f.is_finite()))
+        .collect()
+}
+
 /// Compute basic descriptive statistics for a numeric slice.
 pub fn compute_stats(values: &[f64]) -> Option<NumericStats> {
     if values.is_empty() {
@@ -124,16 +134,6 @@ pub fn fmt_num(v: f64) -> String {
 /// Extract a title from a JSON value that can be either a string or `{"text": "..."}`.
 pub fn extract_title(v: &Value) -> Option<&str> {
     v.as_str().or_else(|| v.get("text")?.as_str())
-}
-
-/// Format a list of string values as a compact inline representation.
-pub fn format_inline_pairs(labels: &[&str], values: &[f64]) -> String {
-    labels
-        .iter()
-        .zip(values.iter())
-        .map(|(l, v)| format!("{}: {}", l, fmt_num(*v)))
-        .collect::<Vec<_>>()
-        .join(", ")
 }
 
 #[cfg(test)]

--- a/crates/repr-llm/src/stats.rs
+++ b/crates/repr-llm/src/stats.rs
@@ -1,0 +1,262 @@
+//! Shared numeric helpers for visualization summarization.
+
+use serde_json::Value;
+
+/// Basic descriptive statistics for a numeric series.
+#[allow(dead_code)]
+pub struct NumericStats {
+    pub min: f64,
+    pub max: f64,
+    pub mean: f64,
+    pub count: usize,
+}
+
+/// Extract f64 values from a JSON array, skipping nulls and non-numeric entries.
+pub fn extract_numbers(arr: &[Value]) -> Vec<f64> {
+    arr.iter()
+        .filter_map(|v| v.as_f64())
+        .filter(|v| v.is_finite())
+        .collect()
+}
+
+/// Compute basic descriptive statistics for a numeric slice.
+pub fn compute_stats(values: &[f64]) -> Option<NumericStats> {
+    if values.is_empty() {
+        return None;
+    }
+    let count = values.len();
+    let mut min = f64::INFINITY;
+    let mut max = f64::NEG_INFINITY;
+    let mut sum = 0.0;
+    for &v in values {
+        if v < min {
+            min = v;
+        }
+        if v > max {
+            max = v;
+        }
+        sum += v;
+    }
+    Some(NumericStats {
+        min,
+        max,
+        mean: sum / count as f64,
+        count,
+    })
+}
+
+/// Detect the overall trend direction of a numeric series.
+///
+/// Uses a simple linear regression sign. Returns one of:
+/// "increasing", "decreasing", "flat", or "mixed" (for very short/noisy data).
+pub fn detect_trend(values: &[f64]) -> &'static str {
+    if values.len() < 2 {
+        return "flat";
+    }
+
+    let n = values.len() as f64;
+    let mut sum_x = 0.0;
+    let mut sum_y = 0.0;
+    let mut sum_xy = 0.0;
+    let mut sum_xx = 0.0;
+
+    for (i, &y) in values.iter().enumerate() {
+        let x = i as f64;
+        sum_x += x;
+        sum_y += y;
+        sum_xy += x * y;
+        sum_xx += x * x;
+    }
+
+    let denom = n * sum_xx - sum_x * sum_x;
+    if denom.abs() < f64::EPSILON {
+        return "flat";
+    }
+
+    let slope = (n * sum_xy - sum_x * sum_y) / denom;
+
+    // Normalize slope relative to the mean to determine significance
+    let mean = sum_y / n;
+    if mean.abs() < f64::EPSILON {
+        return "flat";
+    }
+    let relative_slope = slope / mean.abs();
+
+    if relative_slope > 0.01 {
+        "increasing"
+    } else if relative_slope < -0.01 {
+        "decreasing"
+    } else {
+        "flat"
+    }
+}
+
+/// Format a float concisely for display.
+///
+/// - Whole numbers: no decimal point (e.g., `42`)
+/// - Small numbers: up to 2 decimal places (e.g., `3.17`)
+/// - Large numbers: scientific notation (e.g., `1.4e+04`)
+pub fn fmt_num(v: f64) -> String {
+    if !v.is_finite() {
+        return v.to_string();
+    }
+    let abs = v.abs();
+    if abs == 0.0 {
+        return "0".to_string();
+    }
+    // Use scientific notation for very large or very small values
+    if abs >= 1e6 || (abs < 0.01 && abs > 0.0) {
+        // Format with limited precision in scientific notation
+        let s = format!("{:.2e}", v);
+        return s;
+    }
+    // Check if it's effectively a whole number
+    if (v - v.round()).abs() < 1e-9 {
+        return format!("{}", v as i64);
+    }
+    // Otherwise, up to 2 decimal places, strip trailing zeros
+    let s = format!("{:.2}", v);
+    let s = s.trim_end_matches('0');
+    let s = s.trim_end_matches('.');
+    s.to_string()
+}
+
+/// Extract a title from a JSON value that can be either a string or `{"text": "..."}`.
+pub fn extract_title(v: &Value) -> Option<&str> {
+    v.as_str().or_else(|| v.get("text")?.as_str())
+}
+
+/// Format a list of string values as a compact inline representation.
+pub fn format_inline_pairs(labels: &[&str], values: &[f64]) -> String {
+    labels
+        .iter()
+        .zip(values.iter())
+        .map(|(l, v)| format!("{}: {}", l, fmt_num(*v)))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::approx_constant)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_numbers() {
+        let arr = vec![
+            Value::from(1.0),
+            Value::Null,
+            Value::from(2.5),
+            Value::from("not a number"),
+            Value::from(3.0),
+        ];
+        assert_eq!(extract_numbers(&arr), vec![1.0, 2.5, 3.0]);
+    }
+
+    #[test]
+    fn test_extract_numbers_empty() {
+        assert_eq!(extract_numbers(&[]), Vec::<f64>::new());
+    }
+
+    #[test]
+    fn test_compute_stats() {
+        let stats = compute_stats(&[1.0, 2.0, 3.0, 4.0, 5.0]).expect("should have stats");
+        assert!((stats.min - 1.0).abs() < f64::EPSILON);
+        assert!((stats.max - 5.0).abs() < f64::EPSILON);
+        assert!((stats.mean - 3.0).abs() < f64::EPSILON);
+        assert_eq!(stats.count, 5);
+    }
+
+    #[test]
+    fn test_compute_stats_empty() {
+        assert!(compute_stats(&[]).is_none());
+    }
+
+    #[test]
+    fn test_compute_stats_single() {
+        let stats = compute_stats(&[42.0]).expect("should have stats");
+        assert!((stats.min - 42.0).abs() < f64::EPSILON);
+        assert!((stats.max - 42.0).abs() < f64::EPSILON);
+        assert!((stats.mean - 42.0).abs() < f64::EPSILON);
+        assert_eq!(stats.count, 1);
+    }
+
+    #[test]
+    fn test_detect_trend_increasing() {
+        assert_eq!(
+            detect_trend(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]),
+            "increasing"
+        );
+    }
+
+    #[test]
+    fn test_detect_trend_decreasing() {
+        assert_eq!(
+            detect_trend(&[8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0]),
+            "decreasing"
+        );
+    }
+
+    #[test]
+    fn test_detect_trend_flat() {
+        assert_eq!(detect_trend(&[5.0, 5.0, 5.0, 5.0, 5.0]), "flat");
+    }
+
+    #[test]
+    fn test_detect_trend_single() {
+        assert_eq!(detect_trend(&[1.0]), "flat");
+    }
+
+    #[test]
+    fn test_fmt_num_integer() {
+        assert_eq!(fmt_num(42.0), "42");
+    }
+
+    #[test]
+    fn test_fmt_num_decimal() {
+        assert_eq!(fmt_num(3.17), "3.17");
+    }
+
+    #[test]
+    fn test_fmt_num_trailing_zero() {
+        assert_eq!(fmt_num(2.50), "2.5");
+    }
+
+    #[test]
+    fn test_fmt_num_large() {
+        assert_eq!(fmt_num(14000.0), "14000");
+    }
+
+    #[test]
+    fn test_fmt_num_very_large() {
+        assert_eq!(fmt_num(1400000.0), "1.40e6");
+    }
+
+    #[test]
+    fn test_fmt_num_zero() {
+        assert_eq!(fmt_num(0.0), "0");
+    }
+
+    #[test]
+    fn test_fmt_num_negative() {
+        assert_eq!(fmt_num(-3.17), "-3.17");
+    }
+
+    #[test]
+    fn test_extract_title_string() {
+        let v = Value::from("My Title");
+        assert_eq!(extract_title(&v), Some("My Title"));
+    }
+
+    #[test]
+    fn test_extract_title_object() {
+        let v = serde_json::json!({"text": "My Title", "font": {"size": 14}});
+        assert_eq!(extract_title(&v), Some("My Title"));
+    }
+
+    #[test]
+    fn test_extract_title_missing() {
+        let v = serde_json::json!(42);
+        assert_eq!(extract_title(&v), None);
+    }
+}

--- a/crates/repr-llm/src/vega.rs
+++ b/crates/repr-llm/src/vega.rs
@@ -1,0 +1,151 @@
+//! Vega visualization summarization.
+//!
+//! Vega specs are more complex than Vega-Lite (imperative transforms, custom marks).
+//! We provide a simpler fallback summary: marks, data sources, and signals.
+
+use serde_json::Value;
+
+use crate::stats::extract_title;
+
+/// Summarize a Vega spec into an LLM-friendly text representation.
+pub fn summarize(spec: &Value) -> String {
+    let mut lines = Vec::new();
+
+    let title = spec.get("title").and_then(extract_title);
+
+    // Extract mark types
+    let mark_types = extract_mark_types(spec);
+    // Extract data source names
+    let data_names = extract_data_names(spec);
+
+    // Header
+    let header = match title {
+        Some(t) => format!("Vega chart: \"{}\"", t),
+        None => "Vega chart".to_string(),
+    };
+    lines.push(header);
+
+    if !mark_types.is_empty() {
+        lines.push(format!("Marks: [{}]", mark_types.join(", ")));
+    }
+
+    if !data_names.is_empty() {
+        lines.push(format!("Data sources: [{}]", data_names.join(", ")));
+    }
+
+    // Extract signals (interactive parameters)
+    let signals = extract_signal_names(spec);
+    if !signals.is_empty() {
+        lines.push(format!("Signals: [{}]", signals.join(", ")));
+    }
+
+    lines.join("\n")
+}
+
+/// Extract mark types from a Vega spec.
+fn extract_mark_types(spec: &Value) -> Vec<String> {
+    let marks = match spec.get("marks").and_then(|v| v.as_array()) {
+        Some(arr) => arr,
+        None => return Vec::new(),
+    };
+
+    marks
+        .iter()
+        .filter_map(|m| {
+            m.get("type")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string())
+        })
+        .collect()
+}
+
+/// Extract data source names from a Vega spec.
+fn extract_data_names(spec: &Value) -> Vec<String> {
+    let data = match spec.get("data").and_then(|v| v.as_array()) {
+        Some(arr) => arr,
+        None => return Vec::new(),
+    };
+
+    data.iter()
+        .filter_map(|d| {
+            d.get("name")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string())
+        })
+        .collect()
+}
+
+/// Extract signal names from a Vega spec.
+fn extract_signal_names(spec: &Value) -> Vec<String> {
+    let signals = match spec.get("signals").and_then(|v| v.as_array()) {
+        Some(arr) => arr,
+        None => return Vec::new(),
+    };
+
+    signals
+        .iter()
+        .filter_map(|s| {
+            s.get("name")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string())
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_basic_vega() {
+        let spec = json!({
+            "title": "My Vega Chart",
+            "marks": [
+                {"type": "rect"},
+                {"type": "text"}
+            ],
+            "data": [
+                {"name": "source"},
+                {"name": "stats"}
+            ]
+        });
+        let result = summarize(&spec);
+        assert!(result.contains("Vega chart: \"My Vega Chart\""));
+        assert!(result.contains("Marks: [rect, text]"));
+        assert!(result.contains("Data sources: [source, stats]"));
+    }
+
+    #[test]
+    fn test_with_signals() {
+        let spec = json!({
+            "marks": [{"type": "symbol"}],
+            "data": [{"name": "points"}],
+            "signals": [
+                {"name": "hover", "value": null},
+                {"name": "zoom", "value": 1}
+            ]
+        });
+        let result = summarize(&spec);
+        assert!(result.contains("Signals: [hover, zoom]"));
+    }
+
+    #[test]
+    fn test_no_marks() {
+        let spec = json!({
+            "title": "Empty",
+            "data": [{"name": "src"}]
+        });
+        let result = summarize(&spec);
+        assert!(result.contains("Vega chart: \"Empty\""));
+        assert!(!result.contains("Marks:"));
+        assert!(result.contains("Data sources: [src]"));
+    }
+
+    #[test]
+    fn test_minimal() {
+        let spec = json!({});
+        let result = summarize(&spec);
+        assert_eq!(result, "Vega chart");
+    }
+}

--- a/crates/repr-llm/src/vegalite.rs
+++ b/crates/repr-llm/src/vegalite.rs
@@ -1,0 +1,318 @@
+//! Vega-Lite visualization summarization.
+//!
+//! Walks a Vega-Lite JSON spec and produces a compact text summary suitable for LLMs.
+
+use serde_json::Value;
+
+use crate::stats::extract_title;
+
+/// Summarize a Vega-Lite spec into an LLM-friendly text representation.
+pub fn summarize(spec: &Value) -> String {
+    // Check for composite views (layer, concat, etc.)
+    if let Some(layers) = spec.get("layer").and_then(|v| v.as_array()) {
+        return summarize_composite(spec, "layered", layers);
+    }
+    if let Some(charts) = spec.get("hconcat").and_then(|v| v.as_array()) {
+        return summarize_composite(spec, "horizontal concat", charts);
+    }
+    if let Some(charts) = spec.get("vconcat").and_then(|v| v.as_array()) {
+        return summarize_composite(spec, "vertical concat", charts);
+    }
+    if let Some(charts) = spec.get("concat").and_then(|v| v.as_array()) {
+        return summarize_composite(spec, "concat", charts);
+    }
+
+    summarize_single(spec, 0)
+}
+
+/// Summarize a single (non-composite) Vega-Lite spec.
+fn summarize_single(spec: &Value, indent: usize) -> String {
+    let mut lines = Vec::new();
+    let prefix = "  ".repeat(indent);
+
+    // Mark type
+    let mark = extract_mark(spec);
+
+    // Title
+    let title = spec.get("title").and_then(extract_title);
+
+    // Header line
+    let header = match (mark.as_deref(), title) {
+        (Some(m), Some(t)) => format!("{}Vega-Lite {} chart: \"{}\"", prefix, m, t),
+        (Some(m), None) => format!("{}Vega-Lite {} chart", prefix, m),
+        (None, Some(t)) => format!("{}Vega-Lite chart: \"{}\"", prefix, t),
+        (None, None) => format!("{}Vega-Lite chart", prefix),
+    };
+    lines.push(header);
+
+    // Encoding
+    if let Some(encoding) = spec.get("encoding").and_then(|v| v.as_object()) {
+        let enc_parts: Vec<String> = ENCODING_CHANNELS
+            .iter()
+            .filter_map(|&channel| {
+                let ch = encoding.get(channel)?;
+                let field = ch.get("field").and_then(|v| v.as_str())?;
+                let type_abbrev = ch
+                    .get("type")
+                    .and_then(|v| v.as_str())
+                    .map(abbreviate_type)
+                    .unwrap_or("?");
+                let aggregate = ch
+                    .get("aggregate")
+                    .and_then(|v| v.as_str())
+                    .map(|a| format!(" [{}]", a))
+                    .unwrap_or_default();
+                Some(format!(
+                    "{}={}{} ({})",
+                    channel, field, aggregate, type_abbrev
+                ))
+            })
+            .collect();
+
+        if !enc_parts.is_empty() {
+            lines.push(format!("{}Encoding: {}", prefix, enc_parts.join(", ")));
+        }
+    }
+
+    // Data summary
+    if let Some(data) = spec.get("data") {
+        if let Some(values) = data.get("values").and_then(|v| v.as_array()) {
+            let n = values.len();
+            let fields = extract_data_fields(values);
+            if fields.is_empty() {
+                lines.push(format!("{}Data: {} rows", prefix, n));
+            } else {
+                lines.push(format!(
+                    "{}Data: {} rows, fields: [{}]",
+                    prefix,
+                    n,
+                    fields.join(", ")
+                ));
+            }
+        } else if let Some(url) = data.get("url").and_then(|v| v.as_str()) {
+            lines.push(format!("{}Data: from URL {}", prefix, url));
+        }
+    }
+
+    lines.join("\n")
+}
+
+/// Summarize a composite (layered/concatenated) Vega-Lite spec.
+fn summarize_composite(spec: &Value, kind: &str, sub_specs: &[Value]) -> String {
+    let mut lines = Vec::new();
+
+    let title = spec.get("title").and_then(extract_title);
+    let header = match title {
+        Some(t) => format!(
+            "Vega-Lite {} chart: \"{}\" ({} sub-charts)",
+            kind,
+            t,
+            sub_specs.len()
+        ),
+        None => format!("Vega-Lite {} chart ({} sub-charts)", kind, sub_specs.len()),
+    };
+    lines.push(header);
+
+    // Shared data
+    if let Some(data) = spec.get("data") {
+        if let Some(values) = data.get("values").and_then(|v| v.as_array()) {
+            let fields = extract_data_fields(values);
+            if fields.is_empty() {
+                lines.push(format!("Shared data: {} rows", values.len()));
+            } else {
+                lines.push(format!(
+                    "Shared data: {} rows, fields: [{}]",
+                    values.len(),
+                    fields.join(", ")
+                ));
+            }
+        }
+    }
+
+    for (i, sub) in sub_specs.iter().enumerate() {
+        lines.push(format!("  [{}]:", i + 1));
+        lines.push(summarize_single(sub, 2));
+    }
+
+    lines.join("\n")
+}
+
+/// Extract the mark type from a Vega-Lite spec.
+fn extract_mark(spec: &Value) -> Option<String> {
+    let mark = spec.get("mark")?;
+    if let Some(s) = mark.as_str() {
+        return Some(s.to_string());
+    }
+    mark.get("type")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+}
+
+/// Encoding channels to extract, in priority order.
+const ENCODING_CHANNELS: &[&str] = &[
+    "x", "y", "x2", "y2", "color", "size", "shape", "opacity", "detail", "row", "column", "facet",
+    "text", "tooltip",
+];
+
+/// Abbreviate a Vega-Lite type string.
+fn abbreviate_type(t: &str) -> &str {
+    match t {
+        "quantitative" => "Q",
+        "nominal" => "N",
+        "ordinal" => "O",
+        "temporal" => "T",
+        "geojson" => "Geo",
+        _ => t,
+    }
+}
+
+/// Extract field names from inline data values.
+fn extract_data_fields(values: &[Value]) -> Vec<String> {
+    let first = match values.first() {
+        Some(v) => v,
+        None => return Vec::new(),
+    };
+
+    match first.as_object() {
+        Some(obj) => obj.keys().cloned().collect(),
+        None => Vec::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_basic_bar() {
+        let spec = json!({
+            "mark": "bar",
+            "encoding": {
+                "x": {"field": "category", "type": "nominal"},
+                "y": {"field": "value", "type": "quantitative"}
+            },
+            "title": "Sales by Category"
+        });
+        let result = summarize(&spec);
+        assert!(result.contains("Vega-Lite bar chart: \"Sales by Category\""));
+        assert!(result.contains("x=category (N)"));
+        assert!(result.contains("y=value (Q)"));
+    }
+
+    #[test]
+    fn test_inline_data() {
+        let spec = json!({
+            "mark": "point",
+            "encoding": {
+                "x": {"field": "x", "type": "quantitative"},
+                "y": {"field": "y", "type": "quantitative"}
+            },
+            "data": {
+                "values": [
+                    {"x": 1, "y": 2},
+                    {"x": 3, "y": 4},
+                    {"x": 5, "y": 6}
+                ]
+            }
+        });
+        let result = summarize(&spec);
+        assert!(result.contains("Data: 3 rows"));
+        assert!(result.contains("fields:"));
+    }
+
+    #[test]
+    fn test_url_data() {
+        let spec = json!({
+            "mark": "line",
+            "encoding": {
+                "x": {"field": "date", "type": "temporal"},
+                "y": {"field": "price", "type": "quantitative"}
+            },
+            "data": {"url": "https://example.com/data.csv"}
+        });
+        let result = summarize(&spec);
+        assert!(result.contains("Data: from URL"));
+    }
+
+    #[test]
+    fn test_layered() {
+        let spec = json!({
+            "title": "Overlay",
+            "data": {"values": [{"a": 1}, {"a": 2}]},
+            "layer": [
+                {"mark": "bar", "encoding": {"x": {"field": "a", "type": "quantitative"}}},
+                {"mark": "line", "encoding": {"y": {"field": "a", "type": "quantitative"}}}
+            ]
+        });
+        let result = summarize(&spec);
+        assert!(result.contains("layered chart"));
+        assert!(result.contains("2 sub-charts"));
+        assert!(result.contains("bar"));
+        assert!(result.contains("line"));
+    }
+
+    #[test]
+    fn test_concat() {
+        let spec = json!({
+            "hconcat": [
+                {"mark": "bar", "encoding": {"x": {"field": "a", "type": "nominal"}}},
+                {"mark": "point", "encoding": {"x": {"field": "b", "type": "quantitative"}}}
+            ]
+        });
+        let result = summarize(&spec);
+        assert!(result.contains("horizontal concat"));
+        assert!(result.contains("2 sub-charts"));
+    }
+
+    #[test]
+    fn test_mark_as_object() {
+        let spec = json!({
+            "mark": {"type": "area", "opacity": 0.5},
+            "encoding": {
+                "x": {"field": "date", "type": "temporal"},
+                "y": {"field": "value", "type": "quantitative"}
+            }
+        });
+        let result = summarize(&spec);
+        assert!(result.contains("area chart"));
+    }
+
+    #[test]
+    fn test_color_encoding() {
+        let spec = json!({
+            "mark": "point",
+            "encoding": {
+                "x": {"field": "x", "type": "quantitative"},
+                "y": {"field": "y", "type": "quantitative"},
+                "color": {"field": "species", "type": "nominal"}
+            }
+        });
+        let result = summarize(&spec);
+        assert!(result.contains("color=species (N)"));
+    }
+
+    #[test]
+    fn test_aggregate() {
+        let spec = json!({
+            "mark": "bar",
+            "encoding": {
+                "x": {"field": "category", "type": "nominal"},
+                "y": {"field": "value", "type": "quantitative", "aggregate": "mean"}
+            }
+        });
+        let result = summarize(&spec);
+        assert!(result.contains("y=value [mean] (Q)"));
+    }
+
+    #[test]
+    fn test_no_encoding() {
+        let spec = json!({
+            "mark": "rect",
+            "title": "Empty"
+        });
+        let result = summarize(&spec);
+        assert!(result.contains("Vega-Lite rect chart: \"Empty\""));
+        assert!(!result.contains("Encoding"));
+    }
+}

--- a/crates/runt-mcp/src/tools/cell_read.rs
+++ b/crates/runt-mcp/src/tools/cell_read.rs
@@ -175,11 +175,17 @@ pub async fn get_all_cells(
                 let status = cell_status_map.get(&cell.id).map(String::as_str);
                 let ec: Option<i64> = cell.execution_count.parse().ok();
 
-                // Parse raw output JSON strings from the CRDT into serde_json::Value
-                let output_values: Vec<serde_json::Value> = cell
-                    .outputs
+                // Resolve outputs through the output resolver so that
+                // text/llm+plain is synthesized and viz specs are summarized.
+                let resolved = output_resolver::resolve_cell_outputs(
+                    &cell.outputs,
+                    &server.blob_base_url,
+                    &server.blob_store_path,
+                )
+                .await;
+                let output_texts: Vec<String> = resolved
                     .iter()
-                    .filter_map(|raw| serde_json::from_str(raw).ok())
+                    .filter_map(formatting::format_output_text)
                     .collect();
 
                 // Extract tags from cell metadata
@@ -194,7 +200,7 @@ pub async fn get_all_cells(
                     "cell_type": cell.cell_type,
                     "execution_count": ec,
                     "source": cell.source,
-                    "outputs": output_values,
+                    "outputs": output_texts,
                     "status": status,
                     "tags": tags,
                 }));

--- a/crates/runtimed-client/Cargo.toml
+++ b/crates/runtimed-client/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 notebook-protocol = { path = "../notebook-protocol" }
 notebook-doc = { path = "../notebook-doc" }
 runt-workspace = { path = "../runt-workspace" }
+repr-llm = { path = "../repr-llm" }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/runtimed-client/src/output_resolver.rs
+++ b/crates/runtimed-client/src/output_resolver.rs
@@ -272,6 +272,28 @@ pub fn json_data_to_datavalues(
         );
     }
 
+    // Synthesize text/llm+plain for visualization specs (Plotly, Vega-Lite, Vega)
+    if !output_data.contains_key("text/llm+plain") {
+        let viz_summary = output_data.iter().find_map(|(mime, dv)| {
+            if let DataValue::Json(ref spec) = dv {
+                repr_llm::summarize_viz(mime, spec)
+            } else {
+                None
+            }
+        });
+        if let Some(summary) = viz_summary {
+            let mut parts: Vec<String> = Vec::new();
+            if let Some(DataValue::Text(ref plain)) = output_data.get("text/plain") {
+                parts.push(plain.clone());
+            }
+            parts.push(summary);
+            output_data.insert(
+                "text/llm+plain".to_string(),
+                DataValue::Text(parts.join("\n")),
+            );
+        }
+    }
+
     output_data
 }
 
@@ -351,6 +373,28 @@ pub async fn output_from_manifest(
                     "text/llm+plain".to_string(),
                     DataValue::Text(parts.join("\n")),
                 );
+            }
+
+            // Synthesize text/llm+plain for visualization specs (Plotly, Vega-Lite, Vega)
+            if !output_data.contains_key("text/llm+plain") {
+                let viz_summary = output_data.iter().find_map(|(mime, dv)| {
+                    if let DataValue::Json(ref spec) = dv {
+                        repr_llm::summarize_viz(mime, spec)
+                    } else {
+                        None
+                    }
+                });
+                if let Some(summary) = viz_summary {
+                    let mut parts: Vec<String> = Vec::new();
+                    if let Some(DataValue::Text(ref plain)) = output_data.get("text/plain") {
+                        parts.push(plain.clone());
+                    }
+                    parts.push(summary);
+                    output_data.insert(
+                        "text/llm+plain".to_string(),
+                        DataValue::Text(parts.join("\n")),
+                    );
+                }
             }
 
             let mut output = if output_type == "execute_result" {


### PR DESCRIPTION
## Summary

Adds a new `repr-llm` crate that produces compact, LLM-friendly text summaries of structured visualization specs (Plotly, Vega-Lite, Vega). When a cell produces a chart, the full JSON spec (~10k chars, ~2700 tokens) is compressed into a ~300-char structured summary (~78 tokens) and stored as `text/llm+plain` — the same MIME type already used for binary image descriptions.

### What changed

- **New `crates/repr-llm/` crate** with minimal dependencies (`serde_json` only):
  - `plotly.rs` — per-trace-type summarization (bar, pie, scatter/line, heatmap, choropleth) with small-dataset inlining and large-dataset stats+trend
  - `vegalite.rs` — mark, encoding, and data extraction with recursive layer/concat support
  - `vega.rs` — simpler fallback (marks, data sources, signals)
  - `stats.rs` — shared numeric helpers (stats, trend detection, number formatting)
- **`output_resolver.rs`** — two integration points (inline JSON path + blob manifest path) that call `repr_llm::summarize_viz` when no `text/llm+plain` exists yet. Author-provided summaries always win.

### Design decisions

- Standalone crate (not inlined in `runtimed-client`) so the summarization logic is reusable by future consumers (Python bindings, CLI tools, other MCP servers)
- MIME matching is prefix-based and version-agnostic — automatically handles future Vega-Lite v7, etc.
- The `is_binary_mime` three-way contract is unaffected (Plotly/Vega are already `MimeKind::Json`)

Closes #1460

## Verification

- [ ] `cargo build -p repr-llm` compiles the new crate
- [ ] `cargo test -p repr-llm` passes all 54 unit tests (Plotly chart types, Vega-Lite encoding, Vega marks, numeric helpers)
- [ ] Open a notebook, run a Plotly chart cell, inspect the output — `text/llm+plain` should contain a structured summary instead of the full JSON spec
- [ ] Run a cell with an author-provided `text/llm+plain` (via `display({..., "text/llm+plain": "custom"}, raw=True)`) — the author summary should be preserved, not overwritten

_PR submitted by @rgbkrk's agent, Quill_