### PR TITLE
feat(runtimed): first-class pixi kernel support via pixi run

### DIFF
--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -126,7 +126,7 @@ export function NotebookToolbar({
       ? envSource &&
         (kernelStatus === KERNEL_STATUS.IDLE ||
           kernelStatus === KERNEL_STATUS.BUSY)
-        ? envSource.startsWith("conda:pixi")
+        ? envSource.startsWith("pixi:")
           ? "pixi"
           : envSource.startsWith("conda")
             ? "conda"

--- a/apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx
+++ b/apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx
@@ -211,12 +211,12 @@ describe("NotebookToolbar", () => {
       expect(toggle.dataset.envManager).toBe("conda");
     });
 
-    it("shows pixi badge for conda:pixi envSource", () => {
+    it("shows pixi badge for pixi:toml envSource", () => {
       render(
         <NotebookToolbar
           {...baseProps}
           runtime="python"
-          envSource="conda:pixi:/some/env"
+          envSource="pixi:toml"
           kernelStatus={KERNEL_STATUS.IDLE}
         />,
       );

--- a/contributing/environments.md
+++ b/contributing/environments.md
@@ -194,7 +194,7 @@ sequenceDiagram
             DM-->>DM: env_source = "uv:pyproject"
         else pixi.toml found
             PF-->>DM: DetectedProjectFile{PixiToml}
-            DM-->>DM: env_source = "conda:pixi"
+            DM-->>DM: env_source = "pixi:toml"
         else environment.yml found
             PF-->>DM: DetectedProjectFile{EnvironmentYml}
             DM-->>DM: env_source = "conda:env_yml"
@@ -478,7 +478,7 @@ Three UI components manage dependencies for different runtimes:
 
 The kernel lifecycle is managed by `useDaemonKernel.ts`, which:
 - Listens for `notebook:broadcast` events (re-emitted by `useAutomergeNotebook` after WASM frame demux)
-- Captures the `env_source` string (e.g. `"uv:pyproject"`, `"conda:pixi"`) from `KernelLaunched` responses
+- Captures the `env_source` string (e.g. `"uv:pyproject"`, `"pixi:toml"`) from `KernelLaunched` responses
 - Tracks kernel status and execution queue
 - Provides `launchKernel()`, `executeCell()`, `syncEnvironment()` methods
 - Runs auto-launch detection on notebook open

--- a/crates/kernel-launch/src/tools.rs
+++ b/crates/kernel-launch/src/tools.rs
@@ -817,6 +817,42 @@ pub async fn get_uv_path() -> Result<PathBuf> {
     }
 }
 
+/// Global cache for the pixi binary path.
+static PIXI_PATH: OnceCell<Arc<Result<PathBuf, String>>> = OnceCell::const_new();
+
+/// Get the path to the pixi binary, checking system PATH first then bootstrapping.
+///
+/// Results are cached for subsequent calls.
+pub async fn get_pixi_path() -> Result<PathBuf> {
+    let result = PIXI_PATH
+        .get_or_init(|| async {
+            // 1. Check for system pixi on PATH
+            if let Ok(output) = tokio::process::Command::new("pixi")
+                .arg("--version")
+                .output()
+                .await
+            {
+                if output.status.success() {
+                    info!("Using system pixi");
+                    return Arc::new(Ok(PathBuf::from("pixi")));
+                }
+            }
+
+            // 2. Bootstrap via rattler from conda-forge
+            info!("Bootstrapping pixi via rattler from conda-forge...");
+            match bootstrap_tool("pixi", None).await {
+                Ok(tool) => Arc::new(Ok(tool.binary_path)),
+                Err(e) => Arc::new(Err(e.to_string())),
+            }
+        })
+        .await;
+
+    match result.as_ref() {
+        Ok(path) => Ok(path.clone()),
+        Err(e) => Err(anyhow!("{}", e)),
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {

--- a/crates/runtimed/src/kernel_manager.rs
+++ b/crates/runtimed/src/kernel_manager.rs
@@ -896,6 +896,33 @@ impl RoomKernel {
                         cmd.stderr(Stdio::piped());
                         cmd
                     }
+                    "pixi:toml" => {
+                        // Use `pixi run` in the project directory
+                        let pixi_path = kernel_launch::tools::get_pixi_path().await?;
+                        info!(
+                            "[kernel-manager] Starting Python kernel with pixi run (env_source: {})",
+                            env_source
+                        );
+                        let mut cmd = tokio::process::Command::new(&pixi_path);
+                        cmd.args([
+                            "run",
+                            "python",
+                            "-Xfrozen_modules=off",
+                            "-m",
+                            "ipykernel_launcher",
+                            "-f",
+                        ]);
+                        cmd.arg(&connection_file_path);
+                        cmd.stdout(Stdio::null());
+                        cmd.stderr(Stdio::piped());
+                        // Set working dir so pixi discovers pixi.toml
+                        if let Some(nb_path) = notebook_path {
+                            if let Some(parent) = nb_path.parent() {
+                                cmd.current_dir(parent);
+                            }
+                        }
+                        cmd
+                    }
                     _ => {
                         // Prewarmed - use pooled environment
                         let pooled_env = env.ok_or_else(|| {

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -235,7 +235,7 @@ fn build_launched_config(
             }
         }
         _ => {
-            // All other Python env sources (conda:pixi, conda:env_yml, etc.)
+            // All other Python env sources (conda:env_yml, etc.)
             // use pooled environments — store paths so the agent can reconstruct.
             config.venv_path = venv_path;
             config.python_path = python_path;
@@ -3033,6 +3033,7 @@ async fn auto_launch_kernel(
                 || env_source == "uv:inline"
                 || env_source == "uv:pep723"
                 || env_source == "conda:inline"
+                || env_source == "pixi:toml"
             {
                 info!(
                     "[notebook-sync] Auto-launch: {} prepares its own env, no pool env needed",
@@ -3091,6 +3092,7 @@ async fn auto_launch_kernel(
                     || env_source == "uv:inline"
                     || env_source == "uv:pep723"
                     || env_source == "conda:inline"
+                    || env_source == "pixi:toml"
                 {
                     info!(
                         "[notebook-sync] Auto-launch: {} prepares its own env, no pool env needed",
@@ -3901,7 +3903,7 @@ async fn handle_notebook_request(
                             };
                         }
                     },
-                    "uv:pyproject" | "uv:inline" | "uv:pep723" | "conda:inline" => {
+                    "uv:pyproject" | "uv:inline" | "uv:pep723" | "conda:inline" | "pixi:toml" => {
                         // These sources prepare their own environments, no pooled env needed
                         info!(
                             "[notebook-sync] LaunchKernel: {} prepares its own env, no pool env",

--- a/crates/runtimed/src/project_file.rs
+++ b/crates/runtimed/src/project_file.rs
@@ -29,7 +29,7 @@ impl DetectedProjectFile {
     pub fn to_env_source(&self) -> &'static str {
         match self.kind {
             ProjectFileKind::PyprojectToml => "uv:pyproject",
-            ProjectFileKind::PixiToml => "conda:pixi",
+            ProjectFileKind::PixiToml => "pixi:toml",
             ProjectFileKind::EnvironmentYml => "conda:env_yml",
         }
     }
@@ -135,7 +135,7 @@ mod tests {
         assert!(found.is_some());
         let found = found.unwrap();
         assert_eq!(found.kind, ProjectFileKind::PixiToml);
-        assert_eq!(found.to_env_source(), "conda:pixi");
+        assert_eq!(found.to_env_source(), "pixi:toml");
     }
 
     #[test]

--- a/python/runtimed/tests/test_daemon_integration.py
+++ b/python/runtimed/tests/test_daemon_integration.py
@@ -1514,10 +1514,10 @@ class TestProjectFileDetection:
         assert result.success, f"Failed to import httpx from pyproject env: {result.stderr}"
 
     async def test_pixi_auto_detection(self, session, isolated_fixtures):
-        """notebook_path near pixi.toml auto-detects conda:pixi.
+        """notebook_path near pixi.toml auto-detects pixi:toml.
 
-        The conda:pixi env_source is detected, and a pooled conda env
-        is used to launch the kernel.
+        The pixi:toml env_source is detected and the kernel launches
+        via pixi run.
         """
         notebook_path = str(isolated_fixtures / "pixi-project" / "6-pixi.ipynb")
 
@@ -1529,13 +1529,13 @@ class TestProjectFileDetection:
             session,
             kernel_type="python",
             env_source="auto",
-            expected_env_source="conda:pixi",
+            expected_env_source="pixi:toml",
             notebook_path=notebook_path,
             retries=8,
             delay=2.0,
         )
 
-        assert await session.env_source() == "conda:pixi"
+        assert await session.env_source() == "pixi:toml"
 
         # Kernel should be functional
         result = await session.execute_cell(


### PR DESCRIPTION
## Summary

Fixes #1462 — pixi projects were detected but broken. Kernels launched with a generic conda pool env instead of pixi's actual environment.

### What changed

- **New `pixi:` backend** — renamed `conda:pixi` → `pixi:toml`. Pixi is its own tool, not a conda variant.
- **`pixi run` kernel launch** — uses `pixi run python -m ipykernel_launcher` so pixi handles env sync, lockfile resolution, and activation automatically. Same pattern as `uv:pyproject`.
- **Bootstrap pixi** — `get_pixi_path()` checks system PATH first, falls back to rattler bootstrap from conda-forge.
- **Skip pool env** — pixi resolves its own environment, no conda pool needed.

### Tested

Created pixi project with `pixi init && pixi add ipykernel python`, launched notebook:
- Kernel runs in `.pixi/envs/default` (pixi's env, not pool)
- Python 3.14.3 from conda-forge
- Pixi-managed dependencies available

### Future work (tracked in #1462)
- "Install ipykernel" button when pixi project lacks it
- Pixi as `default_python_env` option in settings
- `pixi:inline` for notebook-level pixi deps
- Env drift detection for pixi.toml changes

## Test plan
- [x] `cargo check` / `cargo xtask lint` — clean
- [x] `cargo test -p runtimed` — 187 lib tests pass
- [x] Manual: pixi project → kernel launches with `pixi:toml` env_source
- [x] Daemon logs confirm `pixi run` path
- [ ] CI