### PR TITLE
feat(repr-llm): synthesize text/llm+plain for SVG, HTML, and large JSON

### DIFF
--- a/crates/repr-llm/src/json.rs
+++ b/crates/repr-llm/src/json.rs
@@ -1,0 +1,263 @@
+//! Structural summaries of large JSON values for LLM consumption.
+//!
+//! Produces compact descriptions of JSON structure (top-level keys, array lengths)
+//! without including the actual data. Returns `None` for small JSON values that
+//! are fine to pass through directly.
+
+use serde_json::Value;
+
+/// Minimum serialized size (bytes) before we bother summarizing.
+const SIZE_THRESHOLD: usize = 2048;
+
+/// Maximum summary length in characters.
+const MAX_SUMMARY_LEN: usize = 500;
+
+/// Produce a structural summary of a JSON value, or `None` if it's small enough
+/// to pass through directly.
+///
+/// For objects: lists top-level keys with array lengths noted.
+/// For arrays: notes length and summarizes first element structure.
+pub fn summarize_json(value: &Value) -> Option<String> {
+    // Estimate size without full serialization for obviously small values
+    if is_obviously_small(value) {
+        return None;
+    }
+
+    // For borderline cases, serialize to check actual size
+    let serialized_len = serde_json::to_string(value).map(|s| s.len()).unwrap_or(0);
+
+    if serialized_len < SIZE_THRESHOLD {
+        return None;
+    }
+
+    let size_kb = serialized_len / 1024;
+
+    let summary = match value {
+        Value::Object(map) => {
+            let keys_desc = summarize_object_keys(map);
+            format!("JSON object ({size_kb} KB): {keys_desc}")
+        }
+        Value::Array(arr) => {
+            let elem_desc = summarize_array(arr);
+            format!("JSON array ({size_kb} KB): {elem_desc}")
+        }
+        // Scalars (string, number, bool, null) are never large enough to hit the threshold
+        // in practice, but handle gracefully
+        _ => format!("JSON value ({size_kb} KB)"),
+    };
+
+    Some(truncate_summary(&summary))
+}
+
+/// Quick check for values that are obviously small without serializing.
+fn is_obviously_small(value: &Value) -> bool {
+    match value {
+        Value::Null | Value::Bool(_) | Value::Number(_) => true,
+        Value::String(s) => s.len() < SIZE_THRESHOLD,
+        Value::Array(arr) => arr.is_empty(),
+        Value::Object(map) => map.is_empty(),
+    }
+}
+
+/// Summarize an object's top-level keys, noting array lengths.
+fn summarize_object_keys(map: &serde_json::Map<String, Value>) -> String {
+    let mut key_descs: Vec<String> = Vec::new();
+
+    for (key, val) in map {
+        let desc = match val {
+            Value::Array(arr) => format!("{}({} items)", key, arr.len()),
+            Value::Object(inner) => format!("{}({} keys)", key, inner.len()),
+            _ => key.clone(),
+        };
+        key_descs.push(desc);
+    }
+
+    format!("keys=[{}]", key_descs.join(", "))
+}
+
+/// Summarize a top-level array: length and first element structure.
+fn summarize_array(arr: &[Value]) -> String {
+    let len = arr.len();
+    let elem_desc = arr.first().map(describe_element).unwrap_or_default();
+
+    if elem_desc.is_empty() {
+        format!("{len} items")
+    } else {
+        format!("{len} items, each: {elem_desc}")
+    }
+}
+
+/// Describe the structure of a single JSON value (for array element previews).
+fn describe_element(value: &Value) -> String {
+    match value {
+        Value::Object(map) => {
+            let keys: Vec<&str> = map.keys().map(|k| k.as_str()).collect();
+            if keys.len() <= 8 {
+                format!("{{{}}}", keys.join(", "))
+            } else {
+                let shown: Vec<&str> = keys.iter().take(6).copied().collect();
+                format!("{{{}... +{} more}}", shown.join(", "), keys.len() - 6)
+            }
+        }
+        Value::Array(arr) => format!("[{} items]", arr.len()),
+        Value::String(_) => "string".to_string(),
+        Value::Number(_) => "number".to_string(),
+        Value::Bool(_) => "bool".to_string(),
+        Value::Null => "null".to_string(),
+    }
+}
+
+/// Truncate a summary to MAX_SUMMARY_LEN characters.
+fn truncate_summary(s: &str) -> String {
+    if s.chars().count() <= MAX_SUMMARY_LEN {
+        s.to_string()
+    } else {
+        let truncated: String = s.chars().take(MAX_SUMMARY_LEN - 3).collect();
+        format!("{truncated}...")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_small_object_returns_none() {
+        let val = json!({"name": "Alice", "age": 30});
+        assert!(summarize_json(&val).is_none());
+    }
+
+    #[test]
+    fn test_small_array_returns_none() {
+        let val = json!([1, 2, 3]);
+        assert!(summarize_json(&val).is_none());
+    }
+
+    #[test]
+    fn test_empty_values_return_none() {
+        assert!(summarize_json(&json!({})).is_none());
+        assert!(summarize_json(&json!([])).is_none());
+        assert!(summarize_json(&json!(null)).is_none());
+        assert!(summarize_json(&json!(42)).is_none());
+        assert!(summarize_json(&json!(true)).is_none());
+    }
+
+    #[test]
+    fn test_large_object_with_arrays() {
+        // Build a GeoJSON-like object > 2KB
+        let features: Vec<Value> = (0..100)
+            .map(|i| {
+                json!({
+                    "type": "Feature",
+                    "properties": {"name": format!("Place {i}"), "pop": i * 1000},
+                    "geometry": {"type": "Point", "coordinates": [i as f64, i as f64 * 2.0]}
+                })
+            })
+            .collect();
+
+        let val = json!({
+            "type": "FeatureCollection",
+            "features": features,
+            "metadata": {"source": "test"}
+        });
+
+        let result = summarize_json(&val);
+        assert!(result
+            .as_ref()
+            .is_some_and(|s| s.starts_with("JSON object")));
+        assert!(result.as_ref().is_some_and(|s| s.contains("KB")));
+        assert!(result
+            .as_ref()
+            .is_some_and(|s| s.contains("features(100 items)")));
+        assert!(result
+            .as_ref()
+            .is_some_and(|s| s.contains("metadata(1 keys)")));
+    }
+
+    #[test]
+    fn test_large_array_of_objects() {
+        let items: Vec<Value> = (0..200)
+            .map(|i| {
+                json!({
+                    "id": i,
+                    "name": format!("Item {i}"),
+                    "value": i as f64 * 1.5,
+                    "active": i % 2 == 0
+                })
+            })
+            .collect();
+
+        let val = Value::Array(items);
+        let result = summarize_json(&val);
+        assert!(result.as_ref().is_some_and(|s| s.starts_with("JSON array")));
+        assert!(result.as_ref().is_some_and(|s| s.contains("200 items")));
+        assert!(result.as_ref().is_some_and(|s| s.contains("each:")));
+        assert!(result.as_ref().is_some_and(|s| s.contains("id")));
+    }
+
+    #[test]
+    fn test_large_array_of_scalars() {
+        let items: Vec<Value> = (0..500)
+            .map(|i| {
+                json!(format!(
+                    "long string value number {i} with padding to increase size xxxxxxxxxx"
+                ))
+            })
+            .collect();
+        let val = Value::Array(items);
+        let result = summarize_json(&val);
+        assert!(result.as_ref().is_some_and(|s| s.contains("500 items")));
+        assert!(result.as_ref().is_some_and(|s| s.contains("each: string")));
+    }
+
+    #[test]
+    fn test_object_with_nested_objects() {
+        // Build an object with enough nested content to exceed threshold
+        let mut map = serde_json::Map::new();
+        for i in 0..20 {
+            let mut inner = serde_json::Map::new();
+            for j in 0..10 {
+                inner.insert(
+                    format!("field_{j}"),
+                    json!(format!("value_{i}_{j}_padding_xxxxxxxxxx")),
+                );
+            }
+            map.insert(format!("section_{i}"), Value::Object(inner));
+        }
+        let val = Value::Object(map);
+        let result = summarize_json(&val);
+        assert!(result
+            .as_ref()
+            .is_some_and(|s| s.starts_with("JSON object")));
+        assert!(result.as_ref().is_some_and(|s| s.contains("10 keys")));
+    }
+
+    #[test]
+    fn test_summary_truncation() {
+        // Build an object with many keys to test truncation
+        let mut map = serde_json::Map::new();
+        for i in 0..100 {
+            let items: Vec<Value> = (0..50)
+                .map(|j| json!(format!("item_{i}_{j}_padding")))
+                .collect();
+            map.insert(
+                format!("very_long_key_name_number_{i}"),
+                Value::Array(items),
+            );
+        }
+        let val = Value::Object(map);
+        let result = summarize_json(&val);
+        assert!(result.is_some_and(|s| s.chars().count() <= MAX_SUMMARY_LEN));
+    }
+
+    #[test]
+    fn test_describe_element_many_keys() {
+        let mut map = serde_json::Map::new();
+        for i in 0..12 {
+            map.insert(format!("key_{i}"), json!(i));
+        }
+        let desc = describe_element(&Value::Object(map));
+        assert!(desc.contains("more"));
+    }
+}

--- a/crates/repr-llm/src/lib.rs
+++ b/crates/repr-llm/src/lib.rs
@@ -20,12 +20,15 @@
 //! assert!(summary.is_some());
 //! ```
 
+pub mod json;
 pub mod plotly;
 pub(crate) mod stats;
 pub mod vega;
 pub mod vegalite;
 
 use serde_json::Value;
+
+pub use json::summarize_json;
 
 /// Attempt to produce an LLM-friendly text summary from a visualization spec.
 ///

--- a/crates/runt-mcp/src/formatting.rs
+++ b/crates/runt-mcp/src/formatting.rs
@@ -23,6 +23,10 @@ const TEXT_MIME_PRIORITY: &[&str] = &[
     "application/json",
 ];
 
+/// Maximum text size (bytes) before truncation in `best_text_from_data`.
+/// Acts as a safety net for heavy types that don't have `text/llm+plain` synthesis.
+const MAX_TEXT_BYTES: usize = 8 * 1024;
+
 /// Strip ANSI escape codes from text.
 pub fn strip_ansi(text: &str) -> String {
     ANSI_RE.replace_all(text, "").to_string()
@@ -30,17 +34,34 @@ pub fn strip_ansi(text: &str) -> String {
 
 /// Extract the best text representation from an output's data dictionary.
 /// Returns None if no suitable text MIME type is found.
+///
+/// Text exceeding 8 KB is truncated with a size note appended.
 pub fn best_text_from_data(data: &std::collections::HashMap<String, DataValue>) -> Option<String> {
     for mime in TEXT_MIME_PRIORITY {
         if let Some(value) = data.get(*mime) {
-            return match value {
+            let text = match value {
                 DataValue::Text(s) => Some(s.clone()),
                 DataValue::Json(v) => Some(serde_json::to_string_pretty(v).unwrap_or_default()),
                 DataValue::Binary(_) => None,
             };
+            return text.map(|s| truncate_text(&s));
         }
     }
     None
+}
+
+/// Truncate text to `MAX_TEXT_BYTES`, appending a size note if truncated.
+fn truncate_text(s: &str) -> String {
+    if s.len() <= MAX_TEXT_BYTES {
+        return s.to_string();
+    }
+    // Find a char boundary at or before MAX_TEXT_BYTES
+    let mut end = MAX_TEXT_BYTES;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    let total_kb = s.len() / 1024;
+    format!("{}\n... [truncated, {} KB total]", &s[..end], total_kb)
 }
 
 /// Format a single output as text for LLM consumption.

--- a/crates/runtimed-client/src/output_resolver.rs
+++ b/crates/runtimed-client/src/output_resolver.rs
@@ -273,26 +273,10 @@ pub fn json_data_to_datavalues(
     }
 
     // Synthesize text/llm+plain for visualization specs (Plotly, Vega-Lite, Vega)
-    if !output_data.contains_key("text/llm+plain") {
-        let viz_summary = output_data.iter().find_map(|(mime, dv)| {
-            if let DataValue::Json(ref spec) = dv {
-                repr_llm::summarize_viz(mime, spec)
-            } else {
-                None
-            }
-        });
-        if let Some(summary) = viz_summary {
-            let mut parts: Vec<String> = Vec::new();
-            if let Some(DataValue::Text(ref plain)) = output_data.get("text/plain") {
-                parts.push(plain.clone());
-            }
-            parts.push(summary);
-            output_data.insert(
-                "text/llm+plain".to_string(),
-                DataValue::Text(parts.join("\n")),
-            );
-        }
-    }
+    synthesize_llm_plain_for_viz(&mut output_data);
+
+    // Synthesize text/llm+plain for other heavy types (SVG, HTML, large JSON)
+    synthesize_llm_plain_for_heavy_types(&mut output_data);
 
     output_data
 }
@@ -376,26 +360,10 @@ pub async fn output_from_manifest(
             }
 
             // Synthesize text/llm+plain for visualization specs (Plotly, Vega-Lite, Vega)
-            if !output_data.contains_key("text/llm+plain") {
-                let viz_summary = output_data.iter().find_map(|(mime, dv)| {
-                    if let DataValue::Json(ref spec) = dv {
-                        repr_llm::summarize_viz(mime, spec)
-                    } else {
-                        None
-                    }
-                });
-                if let Some(summary) = viz_summary {
-                    let mut parts: Vec<String> = Vec::new();
-                    if let Some(DataValue::Text(ref plain)) = output_data.get("text/plain") {
-                        parts.push(plain.clone());
-                    }
-                    parts.push(summary);
-                    output_data.insert(
-                        "text/llm+plain".to_string(),
-                        DataValue::Text(parts.join("\n")),
-                    );
-                }
-            }
+            synthesize_llm_plain_for_viz(&mut output_data);
+
+            // Synthesize text/llm+plain for other heavy types (SVG, HTML, large JSON)
+            synthesize_llm_plain_for_heavy_types(&mut output_data);
 
             let mut output = if output_type == "execute_result" {
                 let execution_count = manifest.get("execution_count")?.as_i64()?;
@@ -558,4 +526,81 @@ pub async fn resolve_cell_outputs(
         }
     }
     outputs
+}
+
+/// Synthesize `text/llm+plain` from visualization specs (Plotly, Vega-Lite, Vega).
+///
+/// Skips if `text/llm+plain` already exists (author-provided summaries win).
+fn synthesize_llm_plain_for_viz(output_data: &mut HashMap<String, DataValue>) {
+    if output_data.contains_key("text/llm+plain") {
+        return;
+    }
+    let viz_summary = output_data.iter().find_map(|(mime, dv)| {
+        if let DataValue::Json(ref spec) = dv {
+            repr_llm::summarize_viz(mime, spec)
+        } else {
+            None
+        }
+    });
+    if let Some(summary) = viz_summary {
+        let mut parts: Vec<String> = Vec::new();
+        if let Some(DataValue::Text(ref plain)) = output_data.get("text/plain") {
+            parts.push(plain.clone());
+        }
+        parts.push(summary);
+        output_data.insert(
+            "text/llm+plain".to_string(),
+            DataValue::Text(parts.join("\n")),
+        );
+    }
+}
+
+/// Synthesize `text/llm+plain` for heavy non-viz media types.
+///
+/// Handles:
+/// - `image/svg+xml` — always summarize (raw XML is never useful to LLMs)
+/// - `text/html` — summarize only when `text/plain` also exists
+/// - `application/json` — structural summary for large (> 2KB) values
+///
+/// Skips if `text/llm+plain` already exists.
+fn synthesize_llm_plain_for_heavy_types(output_data: &mut HashMap<String, DataValue>) {
+    if output_data.contains_key("text/llm+plain") {
+        return;
+    }
+
+    let has_text_plain = output_data.contains_key("text/plain");
+    let mut descriptions: Vec<String> = Vec::new();
+
+    // SVG: always describe — raw XML is useless to LLMs
+    if let Some(DataValue::Text(ref svg)) = output_data.get("image/svg+xml") {
+        descriptions.push(format!("SVG image output ({} KB)", svg.len() / 1024));
+    }
+
+    // HTML: describe only when text/plain exists (otherwise HTML may be the only repr)
+    if has_text_plain {
+        if let Some(DataValue::Text(ref html)) = output_data.get("text/html") {
+            descriptions.push(format!("HTML output ({} KB)", html.len() / 1024));
+        }
+    }
+
+    // Large JSON: structural summary via repr-llm
+    if let Some(DataValue::Json(ref val)) = output_data.get("application/json") {
+        if let Some(summary) = repr_llm::summarize_json(val) {
+            descriptions.push(summary);
+        }
+    }
+
+    if descriptions.is_empty() {
+        return;
+    }
+
+    let mut parts: Vec<String> = Vec::new();
+    if let Some(DataValue::Text(ref plain)) = output_data.get("text/plain") {
+        parts.push(plain.clone());
+    }
+    parts.extend(descriptions);
+    output_data.insert(
+        "text/llm+plain".to_string(),
+        DataValue::Text(parts.join("\n")),
+    );
 }


### PR DESCRIPTION
## Summary

Extends the `text/llm+plain` synthesis from #1461 to handle additional heavy media types that waste LLM context window:

- **SVG** (`image/svg+xml`): Always synthesize a description — raw SVG XML (50-100KB from matplotlib) is never useful to LLMs
- **HTML** (`text/html`): Synthesize when `text/plain` exists as a better representation (covers pandas DataFrames)
- **Large JSON** (`application/json`): New `repr-llm/json.rs` module produces structural summaries for JSON > 2KB (e.g. `"JSON object (14 KB): keys=[type, features(100 items), metadata]"`)
- **Truncation safety net**: `best_text_from_data` now caps output at 8KB for any type that slips through without synthesis

Also refactors the duplicated viz synthesis logic into shared `synthesize_llm_plain_for_viz()` and `synthesize_llm_plain_for_heavy_types()` helpers called from both the inline JSON and blob manifest resolution paths.

### What changed

- **`crates/repr-llm/src/json.rs`** — new module: structural JSON summarizer with size threshold, key enumeration, array length reporting, and element structure previews
- **`crates/repr-llm/src/lib.rs`** — exports `json` module and `summarize_json`
- **`crates/runtimed-client/src/output_resolver.rs`** — extracted shared synthesis helpers, added heavy-type synthesis after existing viz+image blocks
- **`crates/runt-mcp/src/formatting.rs`** — 8KB truncation safety net in `best_text_from_data`

## Verification

- [ ] Run a matplotlib cell that produces SVG output — `get_cell` should show "SVG image output (N KB)" in `text/llm+plain`, not raw XML
- [ ] Run a pandas DataFrame cell — `text/llm+plain` should use the `text/plain` representation, not the HTML table
- [ ] Display a large JSON object (e.g. GeoJSON with many features) — should see a structural summary like `"JSON object (N KB): keys=[...]"`
- [ ] Provide an author `text/llm+plain` via `display({..., "text/llm+plain": "custom"}, raw=True)` — the custom summary should be preserved, not overwritten

_PR submitted by @rgbkrk's agent, Quill_