### PR TITLE
fix(iframe): strip sourcemap comments from raw library imports

### DIFF
--- a/apps/notebook/vite-plugin-raw-lib.ts
+++ b/apps/notebook/vite-plugin-raw-lib.ts
@@ -1,0 +1,59 @@
+/**
+ * Vite plugin that loads library files as raw strings with sourcemap comments stripped.
+ *
+ * Vega v6+ packages use restrictive "exports" fields that block deep imports
+ * like `vega/build/vega.min.js?raw`. This plugin resolves virtual module names
+ * (e.g. "vega-raw") to the actual files, reads them from disk, strips any
+ * `//# sourceMappingURL=...` directives, and returns the content as a default
+ * export string.
+ *
+ * Stripping sourcemap comments prevents iframes from making 404 network requests
+ * for `.map` files that don't exist at the blob URL origin. See #1464.
+ */
+
+import fs from "fs/promises";
+import path from "path";
+import type { Plugin } from "vite";
+
+/** Matches JS-style sourceMappingURL comments: //# sourceMappingURL=foo.js.map */
+const SOURCEMAP_JS = /\/\/[#@]\s*sourceMappingURL=\S+/g;
+/** Matches CSS-style sourceMappingURL comments: /*# sourceMappingURL=foo.css.map *​/ */
+const SOURCEMAP_CSS = /\/\*[#@]\s*sourceMappingURL=\S+\s*\*\//g;
+
+const PREFIX = "\0raw-lib:";
+
+export function rawLibPlugin(nodeModulesDir: string): Plugin {
+	const mapping: Record<string, string> = {
+		"vega-raw": path.join(nodeModulesDir, "vega/build/vega.min.js"),
+		"vega-lite-raw": path.join(
+			nodeModulesDir,
+			"vega-lite/build/vega-lite.min.js",
+		),
+		"vega-embed-raw": path.join(
+			nodeModulesDir,
+			"vega-embed/build/vega-embed.min.js",
+		),
+		"plotly-raw": path.join(
+			nodeModulesDir,
+			"plotly.js-dist-min/plotly.min.js",
+		),
+		"leaflet-js-raw": path.join(nodeModulesDir, "leaflet/dist/leaflet.js"),
+		"leaflet-css-raw": path.join(nodeModulesDir, "leaflet/dist/leaflet.css"),
+	};
+
+	return {
+		name: "raw-lib",
+		resolveId(source) {
+			const filePath = mapping[source];
+			if (filePath) return `${PREFIX}${filePath}`;
+			return null;
+		},
+		async load(id) {
+			if (!id.startsWith(PREFIX)) return null;
+			const filePath = id.slice(PREFIX.length);
+			let content = await fs.readFile(filePath, "utf-8");
+			content = content.replace(SOURCEMAP_JS, "").replace(SOURCEMAP_CSS, "");
+			return `export default ${JSON.stringify(content)};`;
+		},
+	};
+}

--- a/apps/notebook/vite-plugin-raw-lib.ts
+++ b/apps/notebook/vite-plugin-raw-lib.ts
@@ -45,12 +45,16 @@ export function rawLibPlugin(nodeModulesDir: string): Plugin {
 		name: "raw-lib",
 		resolveId(source) {
 			const filePath = mapping[source];
-			if (filePath) return `${PREFIX}${filePath}`;
+			// Always resolve with a .js suffix so Vite treats the virtual module
+			// as JavaScript — without this, .css paths get routed through Vite's
+			// CSS pipeline which chokes on the `export default` wrapper.
+			if (filePath) return `${PREFIX}${filePath}.js`;
 			return null;
 		},
 		async load(id) {
 			if (!id.startsWith(PREFIX)) return null;
-			const filePath = id.slice(PREFIX.length);
+			// Strip the .js suffix we added in resolveId to recover the real path
+			const filePath = id.slice(PREFIX.length, -".js".length);
 			let content = await fs.readFile(filePath, "utf-8");
 			content = content.replace(SOURCEMAP_JS, "").replace(SOURCEMAP_CSS, "");
 			return `export default ${JSON.stringify(content)};`;

--- a/apps/notebook/vite.config.ts
+++ b/apps/notebook/vite.config.ts
@@ -2,38 +2,9 @@ import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import path from "path";
 import { visualizer } from "rollup-plugin-visualizer";
-import { defineConfig, type Plugin } from "vite";
+import { defineConfig } from "vite";
 import { isolatedRendererPlugin } from "./vite-plugin-isolated-renderer";
-
-/**
- * Vega packages (v6+) use restrictive "exports" fields that block deep imports
- * like `vega/build/vega.min.js?raw`. This plugin resolves virtual module names
- * (vega-raw, vega-lite-raw, vega-embed-raw) to the actual UMD build files with
- * the ?raw suffix so they load as strings for iframe injection.
- */
-function vegaRawPlugin(nodeModulesDir: string): Plugin {
-  const mapping: Record<string, string> = {
-    "vega-raw": path.join(nodeModulesDir, "vega/build/vega.min.js"),
-    "vega-lite-raw": path.join(
-      nodeModulesDir,
-      "vega-lite/build/vega-lite.min.js",
-    ),
-    "vega-embed-raw": path.join(
-      nodeModulesDir,
-      "vega-embed/build/vega-embed.min.js",
-    ),
-    "leaflet-js-raw": path.join(nodeModulesDir, "leaflet/dist/leaflet.js"),
-    "leaflet-css-raw": path.join(nodeModulesDir, "leaflet/dist/leaflet.css"),
-  };
-  return {
-    name: "vega-raw-resolve",
-    resolveId(source) {
-      const filePath = mapping[source];
-      if (filePath) return `${filePath}?raw`;
-      return null;
-    },
-  };
-}
+import { rawLibPlugin } from "./vite-plugin-raw-lib";
 
 export default defineConfig(({ command }) => {
   const debugBundleSourceMapsEnabled =
@@ -45,7 +16,7 @@ export default defineConfig(({ command }) => {
     plugins: [
       react(),
       tailwindcss(),
-      vegaRawPlugin(path.resolve(__dirname, "../../node_modules")),
+      rawLibPlugin(path.resolve(__dirname, "../../node_modules")),
       isolatedRendererPlugin({
         minify: command !== "serve",
         sourcemap: isolatedRendererSourceMapsEnabled ? "inline" : false,

--- a/src/components/isolated/__tests__/raw-lib-sourcemaps.test.ts
+++ b/src/components/isolated/__tests__/raw-lib-sourcemaps.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Verify that raw library imports have sourceMappingURL comments stripped.
+ *
+ * When libraries are eval()'d inside sandboxed iframes, the browser attempts
+ * to fetch .map files referenced by sourceMappingURL comments. Since the
+ * iframes use blob: URLs, these requests fail with 404s and leak network
+ * traffic. The rawLibPlugin strips these comments at build time. See #1464.
+ */
+
+import { describe, expect, it } from "vitest";
+
+describe("raw library sourcemap stripping", () => {
+	it("vega libraries do not contain sourceMappingURL", async () => {
+		const [vegaMod, vegaLiteMod, vegaEmbedMod] = await Promise.all([
+			import("vega-raw"),
+			import("vega-lite-raw"),
+			import("vega-embed-raw"),
+		]);
+
+		for (const mod of [vegaMod, vegaLiteMod, vegaEmbedMod]) {
+			expect(mod.default).not.toMatch(/sourceMappingURL/);
+		}
+	});
+
+	it("plotly does not contain sourceMappingURL", async () => {
+		const mod = await import("plotly-raw");
+		expect(mod.default).not.toMatch(/sourceMappingURL/);
+	});
+
+	it("leaflet does not contain sourceMappingURL", async () => {
+		const [jsMod, cssMod] = await Promise.all([
+			import("leaflet-js-raw"),
+			import("leaflet-css-raw"),
+		]);
+
+		for (const mod of [jsMod, cssMod]) {
+			expect(mod.default).not.toMatch(/sourceMappingURL/);
+		}
+	});
+});

--- a/src/components/isolated/iframe-libraries.ts
+++ b/src/components/isolated/iframe-libraries.ts
@@ -44,7 +44,7 @@ function loadLibraryCode(name: string): Promise<string> {
   const promise = (async (): Promise<string> => {
     switch (name) {
       case "plotly": {
-        const mod = await import("plotly.js-dist-min/plotly.min.js?raw");
+        const mod = await import("plotly-raw");
         return mod.default;
       }
       case "vega": {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -3,7 +3,7 @@
 // KaTeX CSS type declaration for side-effect imports
 declare module "katex/dist/katex.min.css";
 
-// Vega UMD builds loaded as raw strings via vegaRawPlugin (see vite.config.ts).
+// Vega UMD builds loaded as raw strings via rawLibPlugin (see vite-plugin-raw-lib.ts).
 // These virtual modules bypass restrictive "exports" fields in vega v6+ packages.
 declare module "vega-raw" {
   const content: string;
@@ -18,7 +18,13 @@ declare module "vega-embed-raw" {
   export default content;
 }
 
-// Leaflet JS and CSS loaded as raw strings via vegaRawPlugin (see vite.config.ts).
+// Plotly loaded as raw string via rawLibPlugin (see vite-plugin-raw-lib.ts).
+declare module "plotly-raw" {
+  const content: string;
+  export default content;
+}
+
+// Leaflet JS and CSS loaded as raw strings via rawLibPlugin (see vite-plugin-raw-lib.ts).
 declare module "leaflet-js-raw" {
   const content: string;
   export default content;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,37 +1,9 @@
 import { defineConfig } from "vitest/config";
 import path from "path";
-import type { Plugin } from "vite";
-
-/**
- * Mirror of vegaRawPlugin from vite.config.ts for vitest.
- * Resolves vega-raw/vega-lite-raw/vega-embed-raw to the UMD builds with ?raw.
- */
-function vegaRawPlugin(nodeModulesDir: string): Plugin {
-  const mapping: Record<string, string> = {
-    "vega-raw": path.join(nodeModulesDir, "vega/build/vega.min.js"),
-    "vega-lite-raw": path.join(
-      nodeModulesDir,
-      "vega-lite/build/vega-lite.min.js",
-    ),
-    "vega-embed-raw": path.join(
-      nodeModulesDir,
-      "vega-embed/build/vega-embed.min.js",
-    ),
-    "leaflet-js-raw": path.join(nodeModulesDir, "leaflet/dist/leaflet.js"),
-    "leaflet-css-raw": path.join(nodeModulesDir, "leaflet/dist/leaflet.css"),
-  };
-  return {
-    name: "vega-raw-resolve",
-    resolveId(source) {
-      const filePath = mapping[source];
-      if (filePath) return `${filePath}?raw`;
-      return null;
-    },
-  };
-}
+import { rawLibPlugin } from "./apps/notebook/vite-plugin-raw-lib";
 
 export default defineConfig({
-  plugins: [vegaRawPlugin(path.resolve(__dirname, "./node_modules"))],
+  plugins: [rawLibPlugin(path.resolve(__dirname, "./node_modules"))],
   test: {
     environment: "jsdom",
     include: [


### PR DESCRIPTION
## Summary

When vega/altair charts render in notebook iframes, the browser makes outbound 404 requests for `vega-lite.min.js.map` and `vega-embed.min.js.map` because the upstream `.min.js` files contain `//# sourceMappingURL=...` comments. These get `eval()`'d inside sandboxed iframes where the `.map` files don't exist, leaking network traffic.

This PR refactors the duplicated `vegaRawPlugin` (from `vite.config.ts` and `vitest.config.ts`) into a shared `rawLibPlugin` with a Vite `load` hook that reads library files from disk and strips sourcemap comments at build time. Also migrates plotly's standalone `?raw` import to use the same plugin for consistency.

Closes #1464

## Changes

- **`apps/notebook/vite-plugin-raw-lib.ts`** — new shared plugin that strips `//# sourceMappingURL` (JS) and `/*# sourceMappingURL` (CSS) comments during the Vite load phase
- **`apps/notebook/vite.config.ts`** / **`vitest.config.ts`** — replaced inline `vegaRawPlugin` duplicates with the shared `rawLibPlugin`
- **`src/components/isolated/iframe-libraries.ts`** — migrated plotly import from `?raw` to `plotly-raw` virtual module
- **`src/vite-env.d.ts`** — added `plotly-raw` type declaration
- **`src/components/isolated/__tests__/raw-lib-sourcemaps.test.ts`** — new test asserting no `sourceMappingURL` in any raw library import

## Verification

- [ ] Open a notebook, run the altair brush-select chart from the issue, confirm no 404 sourcemap requests in devtools Network tab
- [ ] Vega, plotly, and leaflet outputs all render correctly
- [ ] No new console errors related to library loading

_PR submitted by @rgbkrk's agent, Quill_