### PR TITLE
feat(pixi): dedicated dependency panel, ipykernel pre-check, fix routing

### DIFF
--- a/.claude/rules/environments.md
+++ b/.claude/rules/environments.md
@@ -50,7 +50,7 @@ Walk-up stops at `.git` boundaries and user's home directory.
 | Project file | Backend | Environment Type |
 |-------------|---------|-----------------|
 | `pyproject.toml` | `uv run --with ipykernel` in project dir | Project `.venv/` |
-| `pixi.toml` | Convert pixi deps to `CondaDependencies`, use rattler | Cached by dep hash |
+| `pixi.toml` | `pixi run python -m ipykernel_launcher` in project dir | Pixi-managed env |
 | `environment.yml` | Parse deps, use rattler | Cached by dep hash |
 
 ### Deno Kernel Launching
@@ -63,7 +63,8 @@ Deno kernels do not use environment pools:
 
 The daemon returns an `env_source` string with `KernelLaunched`:
 - `"uv:inline"` / `"uv:pyproject"` / `"uv:prewarmed"`
-- `"conda:inline"` / `"conda:env_yml"` / `"conda:pixi"` / `"conda:prewarmed"`
+- `"conda:inline"` / `"conda:env_yml"` / `"conda:prewarmed"`
+- `"pixi:toml"`
 
 ## Kernel Starting Phases
 
@@ -162,7 +163,8 @@ Changes to dependency metadata structure require updating `crates/runt-trust/src
 | Component | Hook | Manages |
 |-----------|------|---------|
 | `DependencyHeader.tsx` | `useDependencies.ts` | UV deps, pyproject.toml detection |
-| `CondaDependencyHeader.tsx` | `useCondaDependencies.ts` | Conda deps, environment.yml and pixi.toml detection |
+| `CondaDependencyHeader.tsx` | `useCondaDependencies.ts` | Conda deps, environment.yml detection |
+| `PixiDependencyHeader.tsx` | `usePixiDependencies.ts` | Pixi project detection, read-only dep display |
 | `DenoDependencyHeader.tsx` | `useDenoDependencies.ts` | Deno configuration and deno.json detection |
 
 ## Key Files

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -375,14 +375,14 @@ function AppContent() {
           ? "uv"
           : isCondaConfigured || environmentYmlInfo?.has_dependencies
             ? "conda"
-            : pixiInfo?.has_dependencies
+            : pixiInfo?.has_dependencies || pixiInfo?.has_pypi_dependencies
               ? "pixi"
               : null;
 
   // Pre-start hint for the env badge (more specific than envType: distinguishes pixi)
   const envTypeHint = envSource
     ? null // backend has spoken, no hint needed
-    : pixiInfo?.has_dependencies
+    : pixiInfo?.has_dependencies || pixiInfo?.has_pypi_dependencies
       ? ("pixi" as const)
       : envType === "conda"
         ? ("conda" as const)

--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -32,6 +32,7 @@ import { DependencyHeader } from "./components/DependencyHeader";
 import { GlobalFindBar } from "./components/GlobalFindBar";
 import { NotebookToolbar } from "./components/NotebookToolbar";
 import { NotebookView } from "./components/NotebookView";
+import { PixiDependencyHeader } from "./components/PixiDependencyHeader";
 import { PoolErrorBanner } from "./components/PoolErrorBanner";
 import { TrustDialog } from "./components/TrustDialog";
 import { UntrustedBanner } from "./components/UntrustedBanner";
@@ -45,6 +46,7 @@ import { type EnvSyncState, useDependencies } from "./hooks/useDependencies";
 import { useEnvProgress } from "./hooks/useEnvProgress";
 import { useDaemonInfo, useGitInfo } from "./hooks/useGitInfo";
 import { useGlobalFind } from "./hooks/useGlobalFind";
+import { usePixiDependencies } from "./hooks/usePixiDependencies";
 import { usePoolState } from "./hooks/usePoolState";
 import { useTrust } from "./hooks/useTrust";
 import { useUpdater } from "./hooks/useUpdater";
@@ -240,9 +242,10 @@ function AppContent() {
     setPython: setCondaPython,
     environmentYmlInfo,
     environmentYmlDeps,
-    pixiInfo,
-    importFromPixi,
   } = useCondaDependencies();
+
+  // Pixi project detection
+  const { pixiInfo } = usePixiDependencies();
 
   // Deno config detection and settings
   const { denoConfigInfo, flexibleNpmImports, setFlexibleNpmImports } =
@@ -366,11 +369,15 @@ function AppContent() {
     ? "conda"
     : envSource?.startsWith("uv:")
       ? "uv"
-      : isUvConfigured
-        ? "uv"
-        : isCondaConfigured || environmentYmlInfo?.has_dependencies
-          ? "conda"
-          : null;
+      : envSource?.startsWith("pixi:")
+        ? "pixi"
+        : isUvConfigured
+          ? "uv"
+          : isCondaConfigured || environmentYmlInfo?.has_dependencies
+            ? "conda"
+            : pixiInfo?.has_dependencies
+              ? "pixi"
+              : null;
 
   // Pre-start hint for the env badge (more specific than envType: distinguishes pixi)
   const envTypeHint = envSource
@@ -1191,14 +1198,16 @@ function AppContent() {
               onResetProgress={envProgress.reset}
               environmentYmlInfo={environmentYmlInfo}
               environmentYmlDeps={environmentYmlDeps}
-              pixiInfo={pixiInfo}
-              onImportFromPixi={importFromPixi}
               justSynced={justSynced}
             />
           )}
+        {dependencyHeaderOpen && runtime === "python" && envType === "pixi" && (
+          <PixiDependencyHeader pixiInfo={pixiInfo} />
+        )}
         {dependencyHeaderOpen &&
           runtime === "python" &&
-          envType !== "conda" && (
+          envType !== "conda" &&
+          envType !== "pixi" && (
             <DependencyHeader
               dependencies={dependencies?.dependencies ?? []}
               requiresPython={dependencies?.requires_python ?? null}

--- a/apps/notebook/src/components/CondaDependencyHeader.tsx
+++ b/apps/notebook/src/components/CondaDependencyHeader.tsx
@@ -1,7 +1,6 @@
 import {
   AlertCircle,
   Check,
-  Download,
   FileText,
   Info,
   Plus,
@@ -16,7 +15,6 @@ import type {
   EnvironmentYmlInfo,
 } from "../hooks/useCondaDependencies";
 import type { EnvProgressState } from "../hooks/useEnvProgress";
-import type { PixiInfo } from "../types";
 
 interface CondaDependencyHeaderProps {
   dependencies: string[];
@@ -38,10 +36,6 @@ interface CondaDependencyHeaderProps {
   // environment.yml support
   environmentYmlInfo?: EnvironmentYmlInfo | null;
   environmentYmlDeps?: EnvironmentYmlDeps | null;
-  /** Detected pixi.toml info */
-  pixiInfo?: PixiInfo | null;
-  /** Import pixi.toml deps into notebook conda metadata */
-  onImportFromPixi?: () => Promise<void>;
   /** Show success feedback after sync completed */
   justSynced?: boolean;
 }
@@ -62,8 +56,6 @@ export function CondaDependencyHeader({
   onResetProgress,
   environmentYmlInfo,
   environmentYmlDeps,
-  pixiInfo,
-  onImportFromPixi,
   justSynced,
 }: CondaDependencyHeaderProps) {
   const [newDep, setNewDep] = useState("");
@@ -289,43 +281,6 @@ export function CondaDependencyHeader({
               />
               Re-initialize
             </button>
-          </div>
-        )}
-
-        {/* pixi.toml detected banner */}
-        {pixiInfo?.has_dependencies && (
-          <div className="mb-3 rounded bg-muted/80 px-2 py-1.5 text-xs text-muted-foreground">
-            <div className="flex items-center justify-between">
-              <div className="flex items-center gap-2">
-                <FileText className="h-3.5 w-3.5 shrink-0" />
-                <span>
-                  <code className="rounded bg-muted px-1">
-                    {pixiInfo.relative_path}
-                  </code>
-                  {pixiInfo.workspace_name && (
-                    <span className="text-muted-foreground ml-1">
-                      ({pixiInfo.workspace_name})
-                    </span>
-                  )}
-                  <span className="text-muted-foreground ml-1">
-                    · {pixiInfo.dependency_count} dep
-                    {pixiInfo.dependency_count !== 1 ? "s" : ""}
-                  </span>
-                </span>
-              </div>
-              {onImportFromPixi && (
-                <button
-                  type="button"
-                  onClick={onImportFromPixi}
-                  disabled={loading}
-                  className="flex items-center gap-1 text-emerald-600/70 hover:text-emerald-700 dark:text-emerald-400/70 dark:hover:text-emerald-400 transition-colors disabled:opacity-50"
-                  title="Copy pixi.toml deps into notebook metadata for portable sharing"
-                >
-                  <Download className="h-3 w-3" />
-                  Copy to notebook
-                </button>
-              )}
-            </div>
           </div>
         )}
 

--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -386,6 +386,26 @@ export function NotebookToolbar({
             </div>
           </div>
         )}
+      {/* Pixi ipykernel install prompt */}
+      {runtime === "python" &&
+        kernelStatus === KERNEL_STATUS.ERROR &&
+        envSource?.startsWith("pixi:") && (
+          <div className="border-t px-3 py-2">
+            <div className="flex items-start gap-2 text-xs text-amber-700 dark:text-amber-400">
+              <Info className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+              <span>
+                <span className="font-medium">
+                  ipykernel not found in pixi.toml.
+                </span>{" "}
+                Run{" "}
+                <code className="rounded bg-amber-500/20 px-1">
+                  pixi add ipykernel
+                </code>{" "}
+                in your project directory and restart.
+              </span>
+            </div>
+          </div>
+        )}
     </header>
   );
 }

--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -386,10 +386,11 @@ export function NotebookToolbar({
             </div>
           </div>
         )}
-      {/* Pixi ipykernel install prompt */}
+      {/* Pixi ipykernel install prompt — only when daemon signals missing_ipykernel */}
       {runtime === "python" &&
         kernelStatus === KERNEL_STATUS.ERROR &&
-        envSource?.startsWith("pixi:") && (
+        envSource?.startsWith("pixi:") &&
+        startingPhase === "missing_ipykernel" && (
           <div className="border-t px-3 py-2">
             <div className="flex items-start gap-2 text-xs text-amber-700 dark:text-amber-400">
               <Info className="h-3.5 w-3.5 mt-0.5 shrink-0" />

--- a/apps/notebook/src/components/PixiDependencyHeader.tsx
+++ b/apps/notebook/src/components/PixiDependencyHeader.tsx
@@ -1,0 +1,105 @@
+import { FileText, Info, Package, Terminal } from "lucide-react";
+import type { PixiInfo } from "../types";
+import { PixiIcon } from "./icons";
+
+interface PixiDependencyHeaderProps {
+  pixiInfo: PixiInfo | null;
+}
+
+export function PixiDependencyHeader({ pixiInfo }: PixiDependencyHeaderProps) {
+  return (
+    <div className="border-b bg-amber-50/30 dark:bg-amber-950/10">
+      <div className="px-3 py-3">
+        {/* Pixi badge */}
+        <div className="mb-2 flex items-center gap-2">
+          <span className="flex items-center gap-1 rounded bg-amber-500/20 px-1.5 py-0.5 text-xs font-medium text-amber-600 dark:text-amber-400">
+            <PixiIcon className="h-2.5 w-2.5" />
+            Pixi
+          </span>
+          <span className="text-xs text-muted-foreground">Environment</span>
+        </div>
+
+        {/* pixi.toml detected banner */}
+        {pixiInfo && (
+          <div className="mb-3 rounded bg-muted/80 px-2 py-1.5 text-xs text-muted-foreground">
+            <div className="flex items-center gap-2">
+              <FileText className="h-3.5 w-3.5 shrink-0" />
+              <span>
+                Using{" "}
+                <code className="rounded bg-muted px-1">
+                  {pixiInfo.relative_path}
+                </code>
+                {pixiInfo.workspace_name && (
+                  <span className="text-muted-foreground ml-1">
+                    ({pixiInfo.workspace_name})
+                  </span>
+                )}
+              </span>
+            </div>
+
+            {/* Dependency summary */}
+            {(pixiInfo.has_dependencies || pixiInfo.has_pypi_dependencies) && (
+              <div className="mt-1.5 flex gap-2 text-muted-foreground">
+                {pixiInfo.has_dependencies && (
+                  <span className="rounded bg-muted px-1.5 py-0.5">
+                    {pixiInfo.dependency_count} conda dep
+                    {pixiInfo.dependency_count !== 1 ? "s" : ""}
+                  </span>
+                )}
+                {pixiInfo.has_pypi_dependencies && (
+                  <span className="rounded bg-muted px-1.5 py-0.5">
+                    {pixiInfo.pypi_dependency_count} pypi dep
+                    {pixiInfo.pypi_dependency_count !== 1 ? "s" : ""}
+                  </span>
+                )}
+              </div>
+            )}
+
+            {/* Channels */}
+            {pixiInfo.channels.length > 0 && (
+              <div className="mt-1.5 flex items-center gap-1.5 text-muted-foreground">
+                <Package className="h-3 w-3 shrink-0" />
+                {pixiInfo.channels.map((ch) => (
+                  <span key={ch} className="rounded bg-muted px-1.5 py-0.5">
+                    {ch}
+                  </span>
+                ))}
+              </div>
+            )}
+
+            {/* Python version */}
+            {pixiInfo.python && (
+              <div className="mt-1.5 text-muted-foreground">
+                Python: {pixiInfo.python}
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* No pixi.toml found */}
+        {!pixiInfo && (
+          <div className="mb-3 flex items-start gap-2 rounded bg-muted/50 px-2 py-1.5 text-xs text-muted-foreground">
+            <Info className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+            <span>
+              No <code className="rounded bg-muted px-1">pixi.toml</code> found.
+              Run <code className="rounded bg-muted px-1">pixi init</code> to
+              create a pixi project.
+            </span>
+          </div>
+        )}
+
+        {/* Tip */}
+        <div className="flex items-start gap-2 rounded bg-muted/50 px-2 py-1.5 text-xs text-muted-foreground">
+          <Terminal className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+          <span>
+            Manage dependencies with{" "}
+            <code className="rounded bg-muted px-1">
+              pixi add &lt;package&gt;
+            </code>{" "}
+            in your terminal.
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx
+++ b/apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx
@@ -347,7 +347,22 @@ describe("NotebookToolbar", () => {
   });
 
   describe("pixi ipykernel prompt", () => {
-    it("shows pixi prompt when runtime=python, status=error, and envSource starts with pixi:", () => {
+    it("shows pixi prompt when runtime=python, status=error, envSource=pixi:, startingPhase=missing_ipykernel", () => {
+      render(
+        <NotebookToolbar
+          {...baseProps}
+          runtime="python"
+          kernelStatus={KERNEL_STATUS.ERROR}
+          envSource="pixi:toml"
+          startingPhase="missing_ipykernel"
+        />,
+      );
+      expect(
+        screen.getByText(/ipykernel not found in pixi.toml/),
+      ).toBeInTheDocument();
+    });
+
+    it("does not show pixi prompt for generic pixi error (no missing_ipykernel phase)", () => {
       render(
         <NotebookToolbar
           {...baseProps}
@@ -357,8 +372,8 @@ describe("NotebookToolbar", () => {
         />,
       );
       expect(
-        screen.getByText(/ipykernel not found in pixi.toml/),
-      ).toBeInTheDocument();
+        screen.queryByText(/ipykernel not found in pixi.toml/),
+      ).not.toBeInTheDocument();
     });
 
     it("does not show pixi prompt when runtime is deno", () => {
@@ -368,6 +383,7 @@ describe("NotebookToolbar", () => {
           runtime="deno"
           kernelStatus={KERNEL_STATUS.ERROR}
           envSource="pixi:toml"
+          startingPhase="missing_ipykernel"
         />,
       );
       expect(
@@ -382,6 +398,7 @@ describe("NotebookToolbar", () => {
           runtime="python"
           kernelStatus={KERNEL_STATUS.IDLE}
           envSource="pixi:toml"
+          startingPhase="missing_ipykernel"
         />,
       );
       expect(
@@ -396,6 +413,7 @@ describe("NotebookToolbar", () => {
           runtime="python"
           kernelStatus={KERNEL_STATUS.ERROR}
           envSource="uv:prewarmed"
+          startingPhase="missing_ipykernel"
         />,
       );
       expect(

--- a/apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx
+++ b/apps/notebook/src/components/__tests__/notebook-toolbar.test.tsx
@@ -345,4 +345,62 @@ describe("NotebookToolbar", () => {
       expect(screen.queryByText(/Deno not available/)).not.toBeInTheDocument();
     });
   });
+
+  describe("pixi ipykernel prompt", () => {
+    it("shows pixi prompt when runtime=python, status=error, and envSource starts with pixi:", () => {
+      render(
+        <NotebookToolbar
+          {...baseProps}
+          runtime="python"
+          kernelStatus={KERNEL_STATUS.ERROR}
+          envSource="pixi:toml"
+        />,
+      );
+      expect(
+        screen.getByText(/ipykernel not found in pixi.toml/),
+      ).toBeInTheDocument();
+    });
+
+    it("does not show pixi prompt when runtime is deno", () => {
+      render(
+        <NotebookToolbar
+          {...baseProps}
+          runtime="deno"
+          kernelStatus={KERNEL_STATUS.ERROR}
+          envSource="pixi:toml"
+        />,
+      );
+      expect(
+        screen.queryByText(/ipykernel not found in pixi.toml/),
+      ).not.toBeInTheDocument();
+    });
+
+    it("does not show pixi prompt when kernel is not in error", () => {
+      render(
+        <NotebookToolbar
+          {...baseProps}
+          runtime="python"
+          kernelStatus={KERNEL_STATUS.IDLE}
+          envSource="pixi:toml"
+        />,
+      );
+      expect(
+        screen.queryByText(/ipykernel not found in pixi.toml/),
+      ).not.toBeInTheDocument();
+    });
+
+    it("does not show pixi prompt when envSource is not pixi", () => {
+      render(
+        <NotebookToolbar
+          {...baseProps}
+          runtime="python"
+          kernelStatus={KERNEL_STATUS.ERROR}
+          envSource="uv:prewarmed"
+        />,
+      );
+      expect(
+        screen.queryByText(/ipykernel not found in pixi.toml/),
+      ).not.toBeInTheDocument();
+    });
+  });
 });

--- a/apps/notebook/src/hooks/useCondaDependencies.ts
+++ b/apps/notebook/src/hooks/useCondaDependencies.ts
@@ -9,7 +9,6 @@ import {
   setCondaPython as setCondaPythonWasm,
   useCondaDeps,
 } from "../lib/notebook-metadata";
-import type { PixiInfo } from "../types";
 
 export interface CondaDependencies {
   dependencies: string[];
@@ -50,8 +49,6 @@ export type CondaSyncState =
 
 export function useCondaDependencies() {
   const [loading, setLoading] = useState(false);
-  // pixi.toml detection
-  const [pixiInfo, setPixiInfo] = useState<PixiInfo | null>(null);
 
   // environment.yml detection state
   const [environmentYmlInfo, setEnvironmentYmlInfo] =
@@ -82,12 +79,11 @@ export function useCondaDependencies() {
     }
   }, []);
 
-  // Detect environment.yml and pixi.toml on mount
+  // Detect environment.yml on mount
   useEffect(() => {
     invoke<EnvironmentYmlInfo | null>("detect_environment_yml").then(
       setEnvironmentYmlInfo,
     );
-    invoke<PixiInfo | null>("detect_pixi_toml").then(setPixiInfo);
   }, []);
 
   // Load environment.yml deps when we detect one
@@ -187,31 +183,16 @@ export function useCondaDependencies() {
   // True if conda metadata exists (even with empty deps)
   const isCondaConfigured = dependencies !== null;
 
-  // Import pixi.toml deps into notebook conda metadata
-  const importFromPixi = useCallback(async () => {
-    setLoading(true);
-    try {
-      await invoke("import_pixi_dependencies");
-      await resignTrust();
-    } catch (e) {
-      logger.error("Failed to import pixi dependencies:", e);
-    } finally {
-      setLoading(false);
-    }
-  }, [resignTrust]);
-
   return {
     dependencies,
     hasDependencies,
     isCondaConfigured,
     loading,
-    pixiInfo,
     addDependency,
     removeDependency,
     clearAllDependencies,
     setChannels,
     setPython,
-    importFromPixi,
     // environment.yml support
     environmentYmlInfo,
     environmentYmlDeps,

--- a/apps/notebook/src/hooks/usePixiDependencies.ts
+++ b/apps/notebook/src/hooks/usePixiDependencies.ts
@@ -1,0 +1,27 @@
+import { invoke } from "@tauri-apps/api/core";
+import { useEffect, useState } from "react";
+import { logger } from "../lib/logger";
+import type { PixiInfo } from "../types";
+
+/**
+ * Hook for pixi.toml detection.
+ *
+ * Detects pixi.toml near the notebook and returns its info.
+ * Pixi dependencies are managed via `pixi add`/`pixi remove` in the terminal,
+ * not through the notebook metadata — pixi.toml is the source of truth.
+ */
+export function usePixiDependencies() {
+  const [pixiInfo, setPixiInfo] = useState<PixiInfo | null>(null);
+
+  useEffect(() => {
+    invoke<PixiInfo | null>("detect_pixi_toml")
+      .then(setPixiInfo)
+      .catch((e) => {
+        logger.debug("[pixi] Failed to detect pixi.toml:", e);
+      });
+  }, []);
+
+  return {
+    pixiInfo,
+  };
+}

--- a/crates/notebook-doc/src/runtime_state.rs
+++ b/crates/notebook-doc/src/runtime_state.rs
@@ -12,7 +12,7 @@
 //!     starting_phase: Str  ("" | "resolving" | "preparing_env" | "launching" | "connecting")
 //!     name: Str            (e.g. "charming-toucan")
 //!     language: Str        (e.g. "python", "typescript")
-//!     env_source: Str      (e.g. "uv:prewarmed", "conda:pixi", "deno")
+//!     env_source: Str      (e.g. "uv:prewarmed", "pixi:toml", "deno")
 //!   queue/
 //!     executing: Str|null              (cell_id currently executing)
 //!     executing_execution_id: Str|null (execution_id for the executing cell)

--- a/crates/notebook/src/pixi.rs
+++ b/crates/notebook/src/pixi.rs
@@ -317,6 +317,20 @@ impl PixiConfig {
     pub fn has_pypi_dependencies(&self) -> bool {
         !self.pypi_dependencies.is_empty()
     }
+
+    /// Check if ipykernel is declared in either conda or pypi dependencies.
+    pub fn has_ipykernel(&self) -> bool {
+        let check = |deps: &[String]| {
+            deps.iter().any(|d| {
+                let name = d
+                    .split(['=', ' ', '<', '>', '!', ';', '['])
+                    .next()
+                    .unwrap_or(d);
+                name.trim() == "ipykernel"
+            })
+        };
+        check(&self.dependencies) || check(&self.pypi_dependencies)
+    }
 }
 
 #[cfg(test)]
@@ -562,5 +576,57 @@ platforms = ["linux-64"]
         let found = find_pixi_toml(&deep_dir);
         assert!(found.is_some());
         assert_eq!(found.unwrap(), temp.path().join("pixi.toml"));
+    }
+
+    #[test]
+    fn test_has_ipykernel_in_conda_deps() {
+        let config = PixiConfig {
+            path: PathBuf::from("pixi.toml"),
+            workspace_name: None,
+            channels: vec![],
+            dependencies: vec!["python>=3.11".to_string(), "ipykernel".to_string()],
+            pypi_dependencies: vec![],
+            python: None,
+        };
+        assert!(config.has_ipykernel());
+    }
+
+    #[test]
+    fn test_has_ipykernel_in_pypi_deps() {
+        let config = PixiConfig {
+            path: PathBuf::from("pixi.toml"),
+            workspace_name: None,
+            channels: vec![],
+            dependencies: vec!["python>=3.11".to_string()],
+            pypi_dependencies: vec!["ipykernel>=6.0".to_string()],
+            python: None,
+        };
+        assert!(config.has_ipykernel());
+    }
+
+    #[test]
+    fn test_has_ipykernel_missing() {
+        let config = PixiConfig {
+            path: PathBuf::from("pixi.toml"),
+            workspace_name: None,
+            channels: vec![],
+            dependencies: vec!["python>=3.11".to_string(), "numpy".to_string()],
+            pypi_dependencies: vec!["pandas".to_string()],
+            python: None,
+        };
+        assert!(!config.has_ipykernel());
+    }
+
+    #[test]
+    fn test_has_ipykernel_with_version_constraint() {
+        let config = PixiConfig {
+            path: PathBuf::from("pixi.toml"),
+            workspace_name: None,
+            channels: vec![],
+            dependencies: vec!["ipykernel=6.29".to_string()],
+            pypi_dependencies: vec![],
+            python: None,
+        };
+        assert!(config.has_ipykernel());
     }
 }

--- a/crates/runtimed-py/src/output.rs
+++ b/crates/runtimed-py/src/output.rs
@@ -839,7 +839,7 @@ pub struct PyKernelState {
     pub name: String,
     /// Kernel language (e.g. "python", "typescript")
     pub language: String,
-    /// Environment source label (e.g. "uv:prewarmed", "conda:pixi")
+    /// Environment source label (e.g. "uv:prewarmed", "pixi:toml")
     pub env_source: String,
 }
 

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -2969,16 +2969,18 @@ async fn auto_launch_kernel(
     let detection_path = notebook_path_opt
         .as_ref()
         .or(working_dir_for_detection.as_ref());
-    let project_source = detection_path
-        .and_then(|path| crate::project_file::detect_project_file(path))
-        .map(|detected| {
-            info!(
-                "[notebook-sync] Auto-launch: detected project file {:?} -> {}",
-                detected.path,
-                detected.to_env_source()
-            );
-            detected.to_env_source().to_string()
-        });
+    let detected_project_file =
+        detection_path.and_then(|path| crate::project_file::detect_project_file(path));
+    if let Some(ref detected) = detected_project_file {
+        info!(
+            "[notebook-sync] Auto-launch: detected project file {:?} -> {}",
+            detected.path,
+            detected.to_env_source()
+        );
+    }
+    let project_source = detected_project_file
+        .as_ref()
+        .map(|d| d.to_env_source().to_string());
 
     // Determine kernel type and environment
     let (kernel_type, env_source, pooled_env) = match notebook_kernel_type.as_deref() {
@@ -3131,6 +3133,25 @@ async fn auto_launch_kernel(
             ("python", prewarmed.to_string(), pooled_env)
         }
     };
+
+    // For pixi:toml, verify ipykernel is in pixi.toml before launching
+    if env_source == "pixi:toml" {
+        if let Some(ref detected) = detected_project_file {
+            if !crate::project_file::pixi_toml_has_ipykernel(&detected.path) {
+                warn!(
+                    "[notebook-sync] pixi.toml at {:?} does not declare ipykernel — cannot launch kernel",
+                    detected.path
+                );
+                {
+                    let mut sd = room.state_doc.write().await;
+                    sd.set_kernel_status("error");
+                    sd.set_kernel_info("python", "python", &env_source);
+                    let _ = room.state_changed_tx.send(());
+                }
+                return;
+            }
+        }
+    }
 
     // Transition to "preparing_env" phase now that runtime/env has been resolved
     {
@@ -3857,6 +3878,27 @@ async fn handle_notebook_request(
                 // Use explicit env_source (e.g., "uv:inline", "conda:inline")
                 env_source.clone()
             };
+
+            // For pixi:toml, verify ipykernel is declared before launching
+            if resolved_env_source == "pixi:toml" {
+                let pixi_path = notebook_path.as_ref().and_then(|nb| {
+                    crate::project_file::detect_project_file(nb)
+                        .filter(|d| d.kind == crate::project_file::ProjectFileKind::PixiToml)
+                        .map(|d| d.path)
+                });
+                if let Some(ref path) = pixi_path {
+                    if !crate::project_file::pixi_toml_has_ipykernel(path) {
+                        warn!(
+                            "[notebook-sync] pixi.toml at {:?} does not declare ipykernel",
+                            path
+                        );
+                        reset_starting_state(room).await;
+                        return NotebookResponse::Error {
+                            error: "ipykernel not found in pixi.toml — run `pixi add ipykernel` in your project directory".to_string(),
+                        };
+                    }
+                }
+            }
 
             // Transition to "preparing_env" phase
             {

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -3146,6 +3146,7 @@ async fn auto_launch_kernel(
                     let mut sd = room.state_doc.write().await;
                     sd.set_kernel_status("error");
                     sd.set_kernel_info("python", "python", &env_source);
+                    sd.set_starting_phase("missing_ipykernel");
                     let _ = room.state_changed_tx.send(());
                 }
                 return;

--- a/crates/runtimed/src/project_file.rs
+++ b/crates/runtimed/src/project_file.rs
@@ -111,6 +111,27 @@ pub fn detect_project_file(notebook_path: &Path) -> Option<DetectedProjectFile> 
     find_nearest_project_file(notebook_path, &all_kinds)
 }
 
+/// Check if a pixi.toml file declares ipykernel in its dependencies.
+///
+/// Reads the file and checks for `ipykernel` as a TOML key in the
+/// `[dependencies]` or `[pypi-dependencies]` tables. Uses a simple
+/// text scan — if the line starts with `ipykernel` followed by `=` or
+/// whitespace, it's a match. This avoids requiring a TOML parser dep.
+pub fn pixi_toml_has_ipykernel(path: &Path) -> bool {
+    let Ok(content) = std::fs::read_to_string(path) else {
+        return false;
+    };
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("ipykernel")
+            && trimmed["ipykernel".len()..].starts_with(['=', ' ', '\t'])
+        {
+            return true;
+        }
+    }
+    false
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
@@ -163,5 +184,45 @@ mod tests {
         let found = detect_project_file(temp.path());
         assert!(found.is_some());
         assert_eq!(found.unwrap().to_env_source(), "conda:env_yml");
+    }
+
+    #[test]
+    fn test_pixi_toml_has_ipykernel_in_deps() {
+        let temp = TempDir::new().unwrap();
+        write_file(
+            temp.path(),
+            "pixi.toml",
+            "[project]\nname = \"test\"\n\n[dependencies]\npython = \">=3.11\"\nipykernel = \"*\"\n",
+        );
+        assert!(pixi_toml_has_ipykernel(&temp.path().join("pixi.toml")));
+    }
+
+    #[test]
+    fn test_pixi_toml_has_ipykernel_in_pypi_deps() {
+        let temp = TempDir::new().unwrap();
+        write_file(
+            temp.path(),
+            "pixi.toml",
+            "[project]\nname = \"test\"\n\n[pypi-dependencies]\nipykernel = \">=6.0\"\n",
+        );
+        assert!(pixi_toml_has_ipykernel(&temp.path().join("pixi.toml")));
+    }
+
+    #[test]
+    fn test_pixi_toml_missing_ipykernel() {
+        let temp = TempDir::new().unwrap();
+        write_file(
+            temp.path(),
+            "pixi.toml",
+            "[project]\nname = \"test\"\n\n[dependencies]\npython = \">=3.11\"\nnumpy = \"*\"\n",
+        );
+        assert!(!pixi_toml_has_ipykernel(&temp.path().join("pixi.toml")));
+    }
+
+    #[test]
+    fn test_pixi_toml_has_ipykernel_nonexistent_file() {
+        assert!(!pixi_toml_has_ipykernel(Path::new(
+            "/nonexistent/pixi.toml"
+        )));
     }
 }

--- a/docs/runtimed.md
+++ b/docs/runtimed.md
@@ -815,7 +815,7 @@ Detection priority:
 | `metadata.runt.uv.dependencies` | `uv:inline` |
 | `metadata.runt.conda.dependencies` | `conda:inline` |
 | `pyproject.toml` | `uv:pyproject` |
-| `pixi.toml` | `conda:pixi` |
+| `pixi.toml` | `pixi:toml` |
 | `environment.yml` | `conda:env_yml` |
 | No match | `uv:prewarmed` (or `conda:prewarmed` per user pref) |
 

--- a/python/runtimed/src/runtimed/_internals.pyi
+++ b/python/runtimed/src/runtimed/_internals.pyi
@@ -267,7 +267,7 @@ class KernelState:
         ...
     @property
     def env_source(self) -> str:
-        """Environment source label (e.g. "uv:prewarmed", "conda:pixi")."""
+        """Environment source label (e.g. "uv:prewarmed", "pixi:toml")."""
         ...
 
 class EnvState:


### PR DESCRIPTION
## Summary

Addresses codex review findings from #1465 and advances pixi support (#1462):

- **P1 fix**: Pre-check `pixi.toml` for `ipykernel` before kernel launch. When missing, set kernel status to error and show install prompt in toolbar (`pixi add ipykernel`).
- **P2 fix**: Add dedicated `PixiDependencyHeader` component with its own panel (amber-themed, read-only dep list, channels, terminal tip). Route `pixi:toml` envSource to the new panel instead of falling through to UV.
- Remove pixi integration from `CondaDependencyHeader` and `useCondaDependencies` — pixi is no longer a conda sub-feature.
- Fix stale `conda:pixi` references across docs and comments.

## Changes

| Area | Files | What |
|------|-------|------|
| Daemon | `project_file.rs`, `notebook_sync_server.rs` | `pixi_toml_has_ipykernel()`, pre-launch check in auto_launch + LaunchKernel |
| Notebook crate | `pixi.rs` | `has_ipykernel()` method on PixiConfig |
| Frontend | `PixiDependencyHeader.tsx`, `usePixiDependencies.ts` | New pixi panel + hook |
| Frontend | `App.tsx` | `pixi:` envType routing, render PixiDependencyHeader |
| Frontend | `CondaDependencyHeader.tsx`, `useCondaDependencies.ts` | Remove pixi props/detection |
| Frontend | `NotebookToolbar.tsx` | Pixi ipykernel install prompt banner |
| Docs | `environments.md`, `runtimed.md`, comments | `conda:pixi` → `pixi:toml` |

## Test plan

- [x] `cargo test -p runtimed project_file` — 8 tests pass (4 new for ipykernel check)
- [x] `cargo test -p notebook pixi` — has_ipykernel unit tests pass
- [x] `pnpm test:run` — 826 tests pass (4 new pixi toolbar tests)
- [ ] Manual: open notebook in pixi project WITH ipykernel → kernel launches
- [ ] Manual: open notebook in pixi project WITHOUT ipykernel → error + install banner
- [ ] Manual: verify dep panel shows PixiDependencyHeader when pixi:toml active

Closes codex review findings. Follow-up: #1467 for `[tool.pixi]` detection in pyproject.toml.