### PR TITLE
docs: sync AGENTS.md and README.md with current workspace structure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -271,7 +271,7 @@ The supervisor watches source directories and auto-restarts the child on changes
 - **No MCP server** → use `cargo xtask run-mcp` to set one up
 - **Dev daemon not running** → nteract-dev starts it automatically via `supervisor_restart(target="daemon")`
 
-## Workspace Crates (16)
+## Workspace Crates (17)
 
 | Crate | Purpose |
 |-------|---------|
@@ -289,6 +289,7 @@ The supervisor watches source directories and auto-restarts the child on changes
 | `runt-workspace` | Per-worktree daemon isolation, socket path management |
 | `kernel-launch` | Kernel launching, tool bootstrapping (deno, uv, ruff via rattler) |
 | `kernel-env` | Python environment management (UV + Conda) with progress reporting |
+| `repr-llm` | LLM-friendly text summaries of visualization specs (`text/llm+plain` synthesis) |
 | `mcp-supervisor` | nteract-dev — MCP supervisor proxy, daemon/vite lifecycle management |
 | `xtask` | Build system orchestration |
 

--- a/README.md
+++ b/README.md
@@ -117,16 +117,19 @@ nteract/desktop
 │   ├── notebook-doc/      # Shared Automerge document operations (cells, metadata, sync)
 │   ├── notebook-protocol/ # Notebook wire protocol types
 │   ├── notebook-sync/     # Notebook sync layer
-│   ├── tauri-jupyter/     # Shared Tauri/Jupyter utilities
 │   ├── kernel-launch/     # Shared kernel launching API
 │   ├── kernel-env/        # Environment progress reporting
+│   ├── runt-mcp/          # Rust-native MCP server for notebook interaction
 │   ├── runt-trust/        # HMAC trust verification
 │   ├── runt-workspace/    # Workspace detection utilities
+│   ├── runtimed-client/   # Shared client library for daemon communication
+│   ├── repr-llm/          # LLM-friendly text summaries of visualization specs
 │   ├── xtask/             # Build automation tasks
 │   └── mcp-supervisor/    # nteract-dev MCP supervisor for dev workflows
 ├── python/                 # Python packages
 │   ├── runtimed/          # PyPI: runtimed (Python bindings for daemon)
-│   └── nteract/           # PyPI: nteract (MCP server)
+│   ├── nteract/           # PyPI: nteract (MCP server)
+│   └── gremlin/           # Stress-testing agent for nteract notebooks (not published)
 ├── docs/                   # User-facing documentation
 └── contributing/           # Developer guides
 ```
@@ -162,7 +165,7 @@ cargo xtask dev
 | Standalone Vite | `cargo xtask vite` | Multi-window testing (Vite survives window closes) |
 | Attach to Vite | `cargo xtask notebook --attach` | Connect Tauri to already-running Vite |
 | Debug build | `cargo xtask build` | Full debug build (frontend + rust) |
-| E2E debug build | `cargo xtask build-e2e` | Debug build with built-in WebDriver server |
+| E2E debug build | `cargo xtask e2e build` | Debug build with built-in WebDriver server |
 | Rust-only build | `cargo xtask build --rust-only` | Rebuild rust, reuse existing frontend |
 | Run bundled | `cargo xtask run notebook.ipynb` | Run standalone binary |
 | Lint (check) | `cargo xtask lint` | Check formatting and linting across Rust, JS/TS, Python |


### PR DESCRIPTION
## Summary

The workspace has 17 crates in `Cargo.toml` but documentation listed 16. The README project structure also referenced a deleted crate and was missing several others.

**AGENTS.md:**
- Fixed crate count heading from 16 → 17
- Added missing `repr-llm` crate to the workspace crates table

**README.md:**
- Removed nonexistent `crates/tauri-jupyter/` from the project structure tree
- Added missing crates: `runt-mcp/`, `runtimed-client/`, `repr-llm/`
- Added `gremlin/` to the Python packages section
- Replaced deprecated `cargo xtask build-e2e` with `cargo xtask e2e build`

## Verification

- [ ] Crate table in AGENTS.md has 17 rows matching `Cargo.toml` workspace members
- [ ] README project structure tree reflects actual `crates/` and `python/` directory contents
- [ ] No references to `tauri-jupyter` or `build-e2e` remain in README

_PR submitted by @rgbkrk's agent, Quill_