### PR TITLE
feat(pixi): finish sweep — [tool.pixi] detection, drift, inline deps UI

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -444,6 +444,19 @@ function AppContent() {
     };
   }, [envSource, envSyncState]);
 
+  const pixiDerivedSyncState: EnvSyncState | null = useMemo(() => {
+    const isPixiEnv = envSource?.startsWith("pixi:");
+    if (!isPixiEnv || !envSyncState) return null;
+    if (envSource === "pixi:prewarmed" && !envSyncState.diff?.added?.length)
+      return null;
+    if (envSyncState.inSync) return { status: "synced" };
+    return {
+      status: "dirty",
+      added: envSyncState.diff?.added ?? [],
+      removed: envSyncState.diff?.removed ?? [],
+    };
+  }, [envSource, envSyncState]);
+
   // Derive sync state for Deno kernels
   const denoDerivedSyncState: {
     status: "synced" | "dirty";
@@ -1202,7 +1215,13 @@ function AppContent() {
             />
           )}
         {dependencyHeaderOpen && runtime === "python" && envType === "pixi" && (
-          <PixiDependencyHeader pixiInfo={pixiInfo} />
+          <PixiDependencyHeader
+            pixiInfo={pixiInfo}
+            envSource={envSource}
+            syncState={pixiDerivedSyncState}
+            onSyncNow={handleSyncDeps}
+            justSynced={justSynced}
+          />
         )}
         {dependencyHeaderOpen &&
           runtime === "python" &&

--- a/apps/notebook/src/components/PixiDependencyHeader.tsx
+++ b/apps/notebook/src/components/PixiDependencyHeader.tsx
@@ -1,12 +1,75 @@
-import { FileText, Info, Package, Terminal } from "lucide-react";
+import {
+  Check,
+  FileText,
+  Info,
+  Package,
+  Plus,
+  RefreshCw,
+  Terminal,
+  X,
+} from "lucide-react";
+import { type KeyboardEvent, useCallback, useState } from "react";
+import type { EnvSyncState } from "../hooks/useDependencies";
+import {
+  addPixiDependency,
+  removePixiDependency,
+  usePixiDeps,
+} from "../lib/notebook-metadata";
 import type { PixiInfo } from "../types";
 import { PixiIcon } from "./icons";
 
 interface PixiDependencyHeaderProps {
   pixiInfo: PixiInfo | null;
+  envSource: string | null;
+  syncState?: EnvSyncState | null;
+  onSyncNow?: () => Promise<boolean>;
+  justSynced?: boolean;
 }
 
-export function PixiDependencyHeader({ pixiInfo }: PixiDependencyHeaderProps) {
+export function PixiDependencyHeader({
+  pixiInfo,
+  envSource,
+  syncState,
+  onSyncNow,
+  justSynced,
+}: PixiDependencyHeaderProps) {
+  const pixiDeps = usePixiDeps();
+  const isInlineMode =
+    envSource === "pixi:inline" || envSource === "pixi:prewarmed" || !pixiInfo;
+  const [newDep, setNewDep] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const handleAdd = useCallback(async () => {
+    if (newDep.trim()) {
+      setLoading(true);
+      try {
+        await addPixiDependency(newDep.trim());
+      } finally {
+        setLoading(false);
+      }
+      setNewDep("");
+    }
+  }, [newDep]);
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        handleAdd();
+      }
+    },
+    [handleAdd],
+  );
+
+  const handleRemove = useCallback(async (pkg: string) => {
+    setLoading(true);
+    try {
+      await removePixiDependency(pkg);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
   return (
     <div className="border-b bg-amber-50/30 dark:bg-amber-950/10">
       <div className="px-3 py-3">
@@ -16,11 +79,48 @@ export function PixiDependencyHeader({ pixiInfo }: PixiDependencyHeaderProps) {
             <PixiIcon className="h-2.5 w-2.5" />
             Pixi
           </span>
-          <span className="text-xs text-muted-foreground">Environment</span>
+          <span className="text-xs text-muted-foreground">
+            {isInlineMode ? "Dependencies" : "Environment"}
+          </span>
         </div>
 
-        {/* pixi.toml detected banner */}
-        {pixiInfo && (
+        {/* Success feedback after sync */}
+        {justSynced && (
+          <div className="mb-3 flex items-center gap-2 rounded bg-amber-500/10 px-2 py-1.5 text-xs text-amber-700 dark:text-amber-400">
+            <Check className="h-3.5 w-3.5 shrink-0" />
+            <span>Kernel restarted — environment updated</span>
+          </div>
+        )}
+
+        {/* Sync state drift banner */}
+        {syncState?.status === "dirty" && onSyncNow && (
+          <div className="mb-3 flex items-center justify-between rounded bg-amber-500/10 px-2 py-1.5 text-xs text-amber-700 dark:text-amber-400">
+            <div className="flex items-center gap-2">
+              <Info className="h-3.5 w-3.5 shrink-0" />
+              <span>
+                Dependencies changed
+                {syncState.added.length > 0 &&
+                  ` — ${syncState.added.length} added`}
+                {syncState.removed.length > 0 &&
+                  ` — ${syncState.removed.length} removed`}
+              </span>
+            </div>
+            <button
+              type="button"
+              onClick={onSyncNow}
+              disabled={loading}
+              className="flex items-center gap-1 rounded bg-amber-600 px-2 py-0.5 text-white text-xs font-medium hover:bg-amber-700 transition-colors disabled:opacity-50"
+            >
+              <RefreshCw
+                className={`h-3 w-3 ${loading ? "animate-spin" : ""}`}
+              />
+              Restart
+            </button>
+          </div>
+        )}
+
+        {/* pixi.toml detected banner (pixi:toml mode) */}
+        {pixiInfo && !isInlineMode && (
           <div className="mb-3 rounded bg-muted/80 px-2 py-1.5 text-xs text-muted-foreground">
             <div className="flex items-center gap-2">
               <FileText className="h-3.5 w-3.5 shrink-0" />
@@ -37,7 +137,6 @@ export function PixiDependencyHeader({ pixiInfo }: PixiDependencyHeaderProps) {
               </span>
             </div>
 
-            {/* Dependency summary */}
             {(pixiInfo.has_dependencies || pixiInfo.has_pypi_dependencies) && (
               <div className="mt-1.5 flex gap-2 text-muted-foreground">
                 {pixiInfo.has_dependencies && (
@@ -55,7 +154,6 @@ export function PixiDependencyHeader({ pixiInfo }: PixiDependencyHeaderProps) {
               </div>
             )}
 
-            {/* Channels */}
             {pixiInfo.channels.length > 0 && (
               <div className="mt-1.5 flex items-center gap-1.5 text-muted-foreground">
                 <Package className="h-3 w-3 shrink-0" />
@@ -67,7 +165,6 @@ export function PixiDependencyHeader({ pixiInfo }: PixiDependencyHeaderProps) {
               </div>
             )}
 
-            {/* Python version */}
             {pixiInfo.python && (
               <div className="mt-1.5 text-muted-foreground">
                 Python: {pixiInfo.python}
@@ -76,29 +173,80 @@ export function PixiDependencyHeader({ pixiInfo }: PixiDependencyHeaderProps) {
           </div>
         )}
 
-        {/* No pixi.toml found */}
-        {!pixiInfo && (
+        {/* Inline deps list + add/remove (pixi:inline / pixi:prewarmed mode) */}
+        {isInlineMode && (
+          <>
+            {/* Current inline deps */}
+            {pixiDeps && pixiDeps.dependencies.length > 0 && (
+              <div className="mb-2 flex flex-wrap gap-1.5">
+                {pixiDeps.dependencies.map((dep) => (
+                  <div
+                    key={dep}
+                    className="flex items-center gap-1 rounded bg-amber-100 dark:bg-amber-900/30 px-2 py-0.5 text-xs border border-amber-200 dark:border-amber-800"
+                  >
+                    <span>{dep}</span>
+                    <button
+                      type="button"
+                      onClick={() => handleRemove(dep)}
+                      disabled={loading}
+                      className="text-amber-500/50 hover:text-amber-700 dark:hover:text-amber-300 transition-colors disabled:opacity-50"
+                    >
+                      <X className="h-3 w-3" />
+                    </button>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {/* Add dep input */}
+            <div className="mb-3 flex gap-1.5">
+              <input
+                type="text"
+                value={newDep}
+                onChange={(e) => setNewDep(e.target.value)}
+                onKeyDown={handleKeyDown}
+                placeholder="Add conda package..."
+                className="flex-1 rounded border bg-background px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-amber-500"
+              />
+              <button
+                type="button"
+                onClick={handleAdd}
+                disabled={loading || !newDep.trim()}
+                className="flex items-center gap-1 rounded bg-amber-500/20 px-2 py-1 text-xs text-amber-600 dark:text-amber-400 hover:bg-amber-500/30 transition-colors disabled:opacity-50"
+              >
+                <Plus className="h-3 w-3" />
+                Add
+              </button>
+            </div>
+          </>
+        )}
+
+        {/* No pixi.toml and no inline deps — show init tip */}
+        {!pixiInfo && (!pixiDeps || pixiDeps.dependencies.length === 0) && (
           <div className="mb-3 flex items-start gap-2 rounded bg-muted/50 px-2 py-1.5 text-xs text-muted-foreground">
             <Info className="h-3.5 w-3.5 mt-0.5 shrink-0" />
             <span>
               No <code className="rounded bg-muted px-1">pixi.toml</code> found.
-              Run <code className="rounded bg-muted px-1">pixi init</code> to
-              create a pixi project.
+              Add packages above or run{" "}
+              <code className="rounded bg-muted px-1">pixi init</code> in your
+              terminal.
             </span>
           </div>
         )}
 
-        {/* Tip */}
-        <div className="flex items-start gap-2 rounded bg-muted/50 px-2 py-1.5 text-xs text-muted-foreground">
-          <Terminal className="h-3.5 w-3.5 mt-0.5 shrink-0" />
-          <span>
-            Manage dependencies with{" "}
-            <code className="rounded bg-muted px-1">
-              pixi add &lt;package&gt;
-            </code>{" "}
-            in your terminal.
-          </span>
-        </div>
+        {/* Tip for pixi:toml mode */}
+        {!isInlineMode && (
+          <div className="flex items-start gap-2 rounded bg-muted/50 px-2 py-1.5 text-xs text-muted-foreground">
+            <Terminal className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+            <span>
+              Manage dependencies with{" "}
+              <code className="rounded bg-muted px-1">
+                pixi add &lt;package&gt;
+              </code>{" "}
+              in your terminal.
+            </span>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/apps/notebook/src/components/PixiDependencyHeader.tsx
+++ b/apps/notebook/src/components/PixiDependencyHeader.tsx
@@ -35,7 +35,7 @@ export function PixiDependencyHeader({
 }: PixiDependencyHeaderProps) {
   const pixiDeps = usePixiDeps();
   const isInlineMode =
-    envSource === "pixi:inline" || envSource === "pixi:prewarmed" || !pixiInfo;
+    envSource === "pixi:inline" || envSource === "pixi:prewarmed";
   const [newDep, setNewDep] = useState("");
   const [loading, setLoading] = useState(false);
 

--- a/crates/notebook-protocol/src/protocol.rs
+++ b/crates/notebook-protocol/src/protocol.rs
@@ -29,6 +29,15 @@ pub struct LaunchedEnvConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pixi_deps: Option<Vec<String>>,
 
+    /// Pixi project deps snapshot for drift detection (pixi:toml only).
+    /// Combined sorted list of conda + pypi dependency names from pixi.toml.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pixi_toml_deps: Option<Vec<String>>,
+
+    /// Path to the pixi.toml or pyproject.toml with [tool.pixi] (pixi:toml only).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pixi_toml_path: Option<PathBuf>,
+
     /// Deno config (if kernel_type is "deno")
     #[serde(skip_serializing_if = "Option::is_none")]
     pub deno_config: Option<DenoLaunchedConfig>,

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -196,6 +196,39 @@ fn get_inline_conda_channels(snapshot: &NotebookMetadataSnapshot) -> Vec<String>
     vec!["conda-forge".to_string()]
 }
 
+/// Extract dependency entries from a pixi.toml or pyproject.toml with [tool.pixi].
+///
+/// Section-aware: only collects `key = value` lines from `[dependencies]`,
+/// `[pypi-dependencies]`, `[tool.pixi.dependencies]`, `[tool.pixi.pypi-dependencies]`.
+/// Stores the full line (trimmed) so version constraint changes are detected.
+fn extract_pixi_toml_deps(content: &str) -> Vec<String> {
+    let dep_sections = [
+        "[dependencies]",
+        "[pypi-dependencies]",
+        "[tool.pixi.dependencies]",
+        "[tool.pixi.pypi-dependencies]",
+    ];
+    let mut in_dep_section = false;
+    let mut deps = Vec::new();
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with('[') {
+            in_dep_section = dep_sections.iter().any(|s| trimmed.eq_ignore_ascii_case(s));
+            continue;
+        }
+        if in_dep_section
+            && !trimmed.is_empty()
+            && !trimmed.starts_with('#')
+            && trimmed.contains('=')
+        {
+            deps.push(trimmed.to_string());
+        }
+    }
+    deps.sort();
+    deps
+}
+
 /// Build a LaunchedEnvConfig from the current metadata snapshot.
 /// This captures what configuration was used at kernel launch time.
 #[allow(clippy::too_many_arguments)]
@@ -245,32 +278,13 @@ fn build_launched_config(
         }
         "pixi:toml" => {
             // Store pixi.toml deps baseline for drift detection.
-            // Read the pixi.toml (or pyproject.toml with [tool.pixi]) and
-            // extract all dependency names for later comparison.
+            // Parse section-aware: only collect entries from [dependencies],
+            // [pypi-dependencies], [tool.pixi.dependencies], [tool.pixi.pypi-dependencies].
             if let Some(nb_path) = notebook_path {
                 if let Some(detected) = crate::project_file::detect_project_file(nb_path) {
                     if detected.kind == crate::project_file::ProjectFileKind::PixiToml {
                         if let Ok(content) = std::fs::read_to_string(&detected.path) {
-                            let mut deps: Vec<String> = content
-                                .lines()
-                                .filter(|line| {
-                                    let t = line.trim();
-                                    !t.is_empty()
-                                        && !t.starts_with('#')
-                                        && !t.starts_with('[')
-                                        && t.contains('=')
-                                        && !t.starts_with("name")
-                                        && !t.starts_with("version")
-                                        && !t.starts_with("channels")
-                                        && !t.starts_with("platforms")
-                                })
-                                .filter_map(|line| {
-                                    line.split('=').next().map(|n| n.trim().to_string())
-                                })
-                                .filter(|n| !n.is_empty())
-                                .collect();
-                            deps.sort();
-                            deps.dedup();
+                            let deps = extract_pixi_toml_deps(&content);
                             config.pixi_toml_deps = Some(deps);
                             config.pixi_toml_path = Some(detected.path);
                         }
@@ -414,33 +428,27 @@ fn compute_env_sync_diff(
     if let Some(ref launched_toml_deps) = launched.pixi_toml_deps {
         if let Some(ref toml_path) = launched.pixi_toml_path {
             if let Ok(content) = std::fs::read_to_string(toml_path) {
-                let mut current_deps: Vec<String> = content
-                    .lines()
-                    .filter(|line| {
-                        let t = line.trim();
-                        !t.is_empty()
-                            && !t.starts_with('#')
-                            && !t.starts_with('[')
-                            && t.contains('=')
-                            && !t.starts_with("name")
-                            && !t.starts_with("version")
-                            && !t.starts_with("channels")
-                            && !t.starts_with("platforms")
-                    })
-                    .filter_map(|line| line.split('=').next().map(|n| n.trim().to_string()))
-                    .filter(|n| !n.is_empty())
-                    .collect();
-                current_deps.sort();
-                current_deps.dedup();
+                let current_deps = extract_pixi_toml_deps(&content);
 
                 for dep in &current_deps {
                     if !launched_toml_deps.contains(dep) {
-                        added.push(dep.clone());
+                        // Extract just the package name for the UI
+                        let name = dep
+                            .split('=')
+                            .next()
+                            .map(|n| n.trim().to_string())
+                            .unwrap_or_else(|| dep.clone());
+                        added.push(name);
                     }
                 }
                 for dep in launched_toml_deps {
                     if !current_deps.contains(dep) {
-                        removed.push(dep.clone());
+                        let name = dep
+                            .split('=')
+                            .next()
+                            .map(|n| n.trim().to_string())
+                            .unwrap_or_else(|| dep.clone());
+                        removed.push(name);
                     }
                 }
             }

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -206,6 +206,7 @@ fn build_launched_config(
     venv_path: Option<PathBuf>,
     python_path: Option<PathBuf>,
     prewarmed_packages: Option<&[String]>,
+    notebook_path: Option<&std::path::Path>,
 ) -> LaunchedEnvConfig {
     let mut config = LaunchedEnvConfig::default();
 
@@ -239,6 +240,41 @@ fn build_launched_config(
             config.python_path = python_path;
             if let Some(pkgs) = prewarmed_packages {
                 config.prewarmed_packages = pkgs.to_vec();
+            }
+        }
+        "pixi:toml" => {
+            // Store pixi.toml deps baseline for drift detection.
+            // Read the pixi.toml (or pyproject.toml with [tool.pixi]) and
+            // extract all dependency names for later comparison.
+            if let Some(nb_path) = notebook_path {
+                if let Some(detected) = crate::project_file::detect_project_file(nb_path) {
+                    if detected.kind == crate::project_file::ProjectFileKind::PixiToml {
+                        if let Ok(content) = std::fs::read_to_string(&detected.path) {
+                            let mut deps: Vec<String> = content
+                                .lines()
+                                .filter(|line| {
+                                    let t = line.trim();
+                                    !t.is_empty()
+                                        && !t.starts_with('#')
+                                        && !t.starts_with('[')
+                                        && t.contains('=')
+                                        && !t.starts_with("name")
+                                        && !t.starts_with("version")
+                                        && !t.starts_with("channels")
+                                        && !t.starts_with("platforms")
+                                })
+                                .filter_map(|line| {
+                                    line.split('=').next().map(|n| n.trim().to_string())
+                                })
+                                .filter(|n| !n.is_empty())
+                                .collect();
+                            deps.sort();
+                            deps.dedup();
+                            config.pixi_toml_deps = Some(deps);
+                            config.pixi_toml_path = Some(detected.path);
+                        }
+                    }
+                }
             }
         }
         "pixi:inline" => {
@@ -373,6 +409,43 @@ fn compute_env_sync_diff(
         }
     }
 
+    // Check pixi:toml deps (file-based drift)
+    if let Some(ref launched_toml_deps) = launched.pixi_toml_deps {
+        if let Some(ref toml_path) = launched.pixi_toml_path {
+            if let Ok(content) = std::fs::read_to_string(toml_path) {
+                let mut current_deps: Vec<String> = content
+                    .lines()
+                    .filter(|line| {
+                        let t = line.trim();
+                        !t.is_empty()
+                            && !t.starts_with('#')
+                            && !t.starts_with('[')
+                            && t.contains('=')
+                            && !t.starts_with("name")
+                            && !t.starts_with("version")
+                            && !t.starts_with("channels")
+                            && !t.starts_with("platforms")
+                    })
+                    .filter_map(|line| line.split('=').next().map(|n| n.trim().to_string()))
+                    .filter(|n| !n.is_empty())
+                    .collect();
+                current_deps.sort();
+                current_deps.dedup();
+
+                for dep in &current_deps {
+                    if !launched_toml_deps.contains(dep) {
+                        added.push(dep.clone());
+                    }
+                }
+                for dep in launched_toml_deps {
+                    if !current_deps.contains(dep) {
+                        removed.push(dep.clone());
+                    }
+                }
+            }
+        }
+    }
+
     // Check deno config
     if let Some(ref launched_deno) = launched.deno_config {
         if let Some(ref current_deno) = current.runt.deno {
@@ -502,6 +575,7 @@ async fn check_and_broadcast_sync_state(room: &NotebookRoom) {
     let is_tracking = launched.uv_deps.is_some()
         || launched.conda_deps.is_some()
         || launched.pixi_deps.is_some()
+        || launched.pixi_toml_deps.is_some()
         || launched.deno_config.is_some();
 
     if is_tracking {
@@ -3384,6 +3458,7 @@ async fn auto_launch_kernel(
         venv_path,
         python_path,
         prewarmed_pkgs.as_deref(),
+        notebook_path_opt.as_deref(),
     );
 
     // Transition to "launching" phase before starting the kernel process
@@ -4232,6 +4307,7 @@ async fn handle_notebook_request(
                 venv_path,
                 python_path,
                 prewarmed_pkgs.as_deref(),
+                notebook_path.as_deref(),
             );
 
             // Transition to "launching" phase before starting the kernel process
@@ -9454,6 +9530,8 @@ mod tests {
             conda_deps: None,
             conda_channels: None,
             pixi_deps: None,
+            pixi_toml_deps: None,
+            pixi_toml_path: None,
             deno_config: None,
             venv_path: None,
             python_path: None,
@@ -9474,6 +9552,8 @@ mod tests {
             conda_deps: None,
             conda_channels: None,
             pixi_deps: None,
+            pixi_toml_deps: None,
+            pixi_toml_path: None,
             deno_config: None,
             venv_path: None,
             python_path: None,
@@ -9494,6 +9574,8 @@ mod tests {
             conda_deps: None,
             conda_channels: None,
             pixi_deps: None,
+            pixi_toml_deps: None,
+            pixi_toml_path: None,
             deno_config: None,
             venv_path: None,
             python_path: None,
@@ -9513,6 +9595,8 @@ mod tests {
             conda_deps: None,
             conda_channels: None,
             pixi_deps: None,
+            pixi_toml_deps: None,
+            pixi_toml_path: None,
             deno_config: None,
             venv_path: None,
             python_path: None,
@@ -9532,6 +9616,8 @@ mod tests {
             conda_deps: Some(vec!["scipy".to_string()]),
             conda_channels: Some(vec!["conda-forge".to_string()]),
             pixi_deps: None,
+            pixi_toml_deps: None,
+            pixi_toml_path: None,
             deno_config: None,
             venv_path: None,
             python_path: None,
@@ -9570,6 +9656,7 @@ mod tests {
             Some(venv.clone()),
             Some(python.clone()),
             Some(&pkgs),
+            None,
         );
         assert_eq!(config.venv_path.as_ref(), Some(&venv));
         assert_eq!(config.python_path.as_ref(), Some(&python));
@@ -9607,6 +9694,7 @@ mod tests {
             None,
             Some(venv.clone()),
             Some(python.clone()),
+            None,
             None,
         );
         assert_eq!(config.venv_path.as_ref(), Some(&venv));

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -198,6 +198,7 @@ fn get_inline_conda_channels(snapshot: &NotebookMetadataSnapshot) -> Vec<String>
 
 /// Build a LaunchedEnvConfig from the current metadata snapshot.
 /// This captures what configuration was used at kernel launch time.
+#[allow(clippy::too_many_arguments)]
 fn build_launched_config(
     kernel_type: &str,
     env_source: &str,

--- a/crates/runtimed/src/project_file.rs
+++ b/crates/runtimed/src/project_file.rs
@@ -74,6 +74,16 @@ pub fn find_nearest_project_file(
             }
             let candidate = current.join(filename);
             if candidate.exists() {
+                // pyproject.toml with [tool.pixi] should be treated as a pixi project
+                if *kind == ProjectFileKind::PyprojectToml
+                    && kinds.contains(&ProjectFileKind::PixiToml)
+                    && pyproject_has_pixi_section(&candidate)
+                {
+                    return Some(DetectedProjectFile {
+                        path: candidate,
+                        kind: ProjectFileKind::PixiToml,
+                    });
+                }
                 return Some(DetectedProjectFile {
                     path: candidate,
                     kind: kind.clone(),
@@ -111,7 +121,14 @@ pub fn detect_project_file(notebook_path: &Path) -> Option<DetectedProjectFile> 
     find_nearest_project_file(notebook_path, &all_kinds)
 }
 
-/// Check if a pixi.toml file declares ipykernel in its dependencies.
+/// Check if a pyproject.toml contains a `[tool.pixi]` section.
+fn pyproject_has_pixi_section(path: &Path) -> bool {
+    std::fs::read_to_string(path)
+        .map(|c| c.contains("[tool.pixi]") || c.contains("[tool.pixi."))
+        .unwrap_or(false)
+}
+
+/// Check if a pixi.toml (or pyproject.toml with [tool.pixi]) declares ipykernel.
 ///
 /// Reads the file and checks for `ipykernel` as a TOML key in the
 /// `[dependencies]` or `[pypi-dependencies]` tables. Uses a simple
@@ -224,5 +241,62 @@ mod tests {
         assert!(!pixi_toml_has_ipykernel(Path::new(
             "/nonexistent/pixi.toml"
         )));
+    }
+
+    #[test]
+    fn test_pyproject_with_tool_pixi_detected_as_pixi() {
+        let temp = TempDir::new().unwrap();
+        write_file(
+            temp.path(),
+            "pyproject.toml",
+            "[project]\nname = \"test\"\n\n[tool.pixi.project]\nchannels = [\"conda-forge\"]\nplatforms = [\"linux-64\"]\n",
+        );
+
+        let found = detect_project_file(temp.path());
+        assert!(found.is_some());
+        let found = found.unwrap();
+        assert_eq!(found.kind, ProjectFileKind::PixiToml);
+        assert_eq!(found.to_env_source(), "pixi:toml");
+    }
+
+    #[test]
+    fn test_pyproject_without_tool_pixi_detected_as_uv() {
+        let temp = TempDir::new().unwrap();
+        write_file(
+            temp.path(),
+            "pyproject.toml",
+            "[project]\nname = \"test\"\n\n[tool.uv]\ndev-dependencies = []\n",
+        );
+
+        let found = detect_project_file(temp.path());
+        assert!(found.is_some());
+        let found = found.unwrap();
+        assert_eq!(found.kind, ProjectFileKind::PyprojectToml);
+        assert_eq!(found.to_env_source(), "uv:pyproject");
+    }
+
+    #[test]
+    fn test_pyproject_with_both_pixi_and_uv_prefers_pixi() {
+        let temp = TempDir::new().unwrap();
+        write_file(
+            temp.path(),
+            "pyproject.toml",
+            "[project]\nname = \"test\"\n\n[tool.pixi.project]\nchannels = [\"conda-forge\"]\n\n[tool.uv]\ndev-dependencies = []\n",
+        );
+
+        let found = detect_project_file(temp.path());
+        assert!(found.is_some());
+        assert_eq!(found.unwrap().kind, ProjectFileKind::PixiToml);
+    }
+
+    #[test]
+    fn test_ipykernel_in_pyproject_tool_pixi_deps() {
+        let temp = TempDir::new().unwrap();
+        write_file(
+            temp.path(),
+            "pyproject.toml",
+            "[project]\nname = \"test\"\n\n[tool.pixi.dependencies]\nipykernel = \"*\"\nnumpy = \"*\"\n",
+        );
+        assert!(pixi_toml_has_ipykernel(&temp.path().join("pyproject.toml")));
     }
 }


### PR DESCRIPTION
## Summary

Final pixi sweep — closes out remaining pixi issues and completes first-class support.

### Changes (3 commits)

1. **Detect `[tool.pixi]` in pyproject.toml (#1467)** — pyproject.toml with a `[tool.pixi]` section is now treated as `pixi:toml` instead of `uv:pyproject`. Pixi takes priority when both `[tool.pixi]` and `[tool.uv]` exist.

2. **pixi:toml env drift detection** — Stores pixi.toml dep baseline at kernel launch. When the file changes while a kernel is running, the drift banner appears with a "Restart" action.

3. **PixiDependencyHeader inline dep management** — The pixi panel now supports add/remove for pixi:inline mode (conda packages via input field, removable badges). Shows drift banner when deps change. Detects mode automatically: pixi:toml (read-only) vs pixi:inline (editable).

### Issue housekeeping

- Closes #1467 (`[tool.pixi]` in pyproject.toml)
- Closes #1462 (umbrella: first-class pixi support)
- #1472 closed (future feature)
- #1473 closed (already shipped)
- #1470, #1471 kept open (scope soon for stability)

## Test plan

- [x] `cargo test -p runtimed --lib` — 195 tests pass (12 project_file tests including 4 new)
- [x] `pnpm test:run` — 830 tests pass
- [x] `cargo clippy` — clean
- [ ] Manual: pyproject.toml with `[tool.pixi]` → detected as pixi:toml
- [ ] Manual: modify pixi.toml while kernel running → drift banner
- [ ] Manual: pixi:inline mode → add/remove deps in panel