### PR TITLE
feat(pixi): pixi JSON APIs — shell-hook launch, pinned version, pixi info (#1470, #1471)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3141,6 +3141,8 @@ dependencies = [
  "rattler_virtual_packages",
  "reqwest 0.12.28",
  "reqwest-middleware",
+ "serde",
+ "serde_json",
  "sha2 0.10.9",
  "tar",
  "tempfile",

--- a/crates/kernel-launch/Cargo.toml
+++ b/crates/kernel-launch/Cargo.toml
@@ -19,6 +19,9 @@ zip = { version = "2.2", default-features = false, features = ["deflate"] }
 flate2 = "1"
 tar = "0.4"
 
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
 # Conda/rattler for tool bootstrapping
 rattler = { version = "0.39", default-features = false, features = ["native-tls"] }
 rattler_cache = { version = "0.6", default-features = false, features = ["native-tls"] }

--- a/crates/kernel-launch/src/tools.rs
+++ b/crates/kernel-launch/src/tools.rs
@@ -860,6 +860,133 @@ pub async fn get_pixi_path() -> Result<PathBuf> {
     }
 }
 
+// ── Pixi project info via `pixi info --json` ────────────────────────
+
+/// Environment info from `pixi info --json`.
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct PixiEnvironmentInfo {
+    pub name: String,
+    #[serde(default)]
+    pub features: Vec<String>,
+    #[serde(default)]
+    pub dependencies: Vec<String>,
+    #[serde(default)]
+    pub pypi_dependencies: Vec<String>,
+    #[serde(default)]
+    pub channels: Vec<String>,
+    #[serde(default)]
+    pub prefix: Option<String>,
+}
+
+/// Project info from `pixi info --json`.
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct PixiProjectInfo {
+    pub name: Option<String>,
+    pub manifest_path: Option<String>,
+    pub version: Option<String>,
+}
+
+/// Parsed result from `pixi info --json`.
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct PixiInfoResult {
+    pub version: Option<String>,
+    pub project_info: Option<PixiProjectInfo>,
+    #[serde(default)]
+    pub environments_info: Vec<PixiEnvironmentInfo>,
+}
+
+impl PixiInfoResult {
+    /// Check if ipykernel is declared in the default environment's dependencies.
+    pub fn has_ipykernel(&self) -> bool {
+        self.environments_info.iter().any(|env| {
+            env.name == "default"
+                && (env.dependencies.iter().any(|d| d == "ipykernel")
+                    || env.pypi_dependencies.iter().any(|d| d == "ipykernel"))
+        })
+    }
+
+    /// Get the default environment's prefix path.
+    pub fn default_prefix(&self) -> Option<&str> {
+        self.environments_info
+            .iter()
+            .find(|e| e.name == "default")
+            .and_then(|e| e.prefix.as_deref())
+    }
+
+    /// Get all dependency names from the default environment (sorted, for drift detection).
+    pub fn default_deps_snapshot(&self) -> Vec<String> {
+        let Some(env) = self.environments_info.iter().find(|e| e.name == "default") else {
+            return Vec::new();
+        };
+        let mut deps: Vec<String> = env
+            .dependencies
+            .iter()
+            .chain(env.pypi_dependencies.iter())
+            .cloned()
+            .collect();
+        deps.sort();
+        deps
+    }
+}
+
+/// Run `pixi info --json` for a manifest path and parse the result.
+///
+/// The manifest can be either a `pixi.toml` or a `pyproject.toml` with `[tool.pixi]`.
+pub async fn pixi_info(manifest_path: &std::path::Path) -> Result<PixiInfoResult> {
+    let pixi_path = get_pixi_path().await?;
+    let output = tokio::process::Command::new(&pixi_path)
+        .args(["info", "--json", "--manifest-path"])
+        .arg(manifest_path)
+        .output()
+        .await
+        .map_err(|e| anyhow!("failed to run pixi info: {}", e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(anyhow!("pixi info failed: {}", stderr.trim()));
+    }
+
+    let result: PixiInfoResult = serde_json::from_slice(&output.stdout)
+        .map_err(|e| anyhow!("failed to parse pixi info JSON: {}", e))?;
+    Ok(result)
+}
+
+/// Run `pixi shell-hook --json` and return the environment variables.
+///
+/// These env vars can be applied to a `Command` with `cmd.envs()` for
+/// direct Python launch without the `pixi run` wrapper.
+pub async fn pixi_shell_hook(
+    manifest_path: &std::path::Path,
+    environment: Option<&str>,
+) -> Result<std::collections::HashMap<String, String>> {
+    let pixi_path = get_pixi_path().await?;
+    let mut cmd = tokio::process::Command::new(&pixi_path);
+    cmd.args(["shell-hook", "--json", "--manifest-path"]);
+    cmd.arg(manifest_path);
+    if let Some(env_name) = environment {
+        cmd.args(["--environment", env_name]);
+    }
+
+    let output = cmd
+        .output()
+        .await
+        .map_err(|e| anyhow!("failed to run pixi shell-hook: {}", e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(anyhow!("pixi shell-hook failed: {}", stderr.trim()));
+    }
+
+    #[derive(serde::Deserialize)]
+    struct ShellHookResult {
+        environment_variables: std::collections::HashMap<String, String>,
+    }
+
+    let result: ShellHookResult = serde_json::from_slice(&output.stdout)
+        .map_err(|e| anyhow!("failed to parse pixi shell-hook JSON: {}", e))?;
+    Ok(result.environment_variables)
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {

--- a/crates/kernel-launch/src/tools.rs
+++ b/crates/kernel-launch/src/tools.rs
@@ -29,7 +29,7 @@ pub const UV_TARGET_VERSION: &str = "0.10.8";
 
 /// Target pixi version for rattler bootstrap.
 /// Pinned to ensure stable `pixi info --json` and `pixi shell-hook --json` output.
-pub const PIXI_TARGET_VERSION: &str = "0.63";
+pub const PIXI_TARGET_VERSION: &str = "0.66";
 
 /// Minimum acceptable Deno major version for system deno.
 /// If system deno is below this version, we download a newer one.

--- a/crates/kernel-launch/src/tools.rs
+++ b/crates/kernel-launch/src/tools.rs
@@ -27,6 +27,10 @@ pub const DENO_TARGET_VERSION: &str = "2.7.1";
 /// Target UV version for GitHub download.
 pub const UV_TARGET_VERSION: &str = "0.10.8";
 
+/// Target pixi version for rattler bootstrap.
+/// Pinned to ensure stable `pixi info --json` and `pixi shell-hook --json` output.
+pub const PIXI_TARGET_VERSION: &str = "0.63";
+
 /// Minimum acceptable Deno major version for system deno.
 /// If system deno is below this version, we download a newer one.
 pub const DENO_MIN_MAJOR_VERSION: u32 = 2;
@@ -838,9 +842,12 @@ pub async fn get_pixi_path() -> Result<PathBuf> {
                 }
             }
 
-            // 2. Bootstrap via rattler from conda-forge
-            info!("Bootstrapping pixi via rattler from conda-forge...");
-            match bootstrap_tool("pixi", None).await {
+            // 2. Bootstrap via rattler from conda-forge (pinned version)
+            info!(
+                "Bootstrapping pixi {} via rattler from conda-forge...",
+                PIXI_TARGET_VERSION
+            );
+            match bootstrap_tool("pixi", Some(PIXI_TARGET_VERSION)).await {
                 Ok(tool) => Arc::new(Ok(tool.binary_path)),
                 Err(e) => Arc::new(Err(e.to_string())),
             }

--- a/crates/runtimed/src/kernel_manager.rs
+++ b/crates/runtimed/src/kernel_manager.rs
@@ -897,31 +897,91 @@ impl RoomKernel {
                         cmd
                     }
                     "pixi:toml" => {
-                        // Use `pixi run` in the project directory
-                        let pixi_path = kernel_launch::tools::get_pixi_path().await?;
-                        info!(
-                            "[kernel-manager] Starting Python kernel with pixi run (env_source: {})",
-                            env_source
-                        );
-                        let mut cmd = tokio::process::Command::new(&pixi_path);
-                        cmd.args([
-                            "run",
-                            "python",
-                            "-Xfrozen_modules=off",
-                            "-m",
-                            "ipykernel_launcher",
-                            "-f",
-                        ]);
-                        cmd.arg(&connection_file_path);
-                        cmd.stdout(Stdio::null());
-                        cmd.stderr(Stdio::piped());
-                        // Set working dir so pixi discovers pixi.toml
-                        if let Some(nb_path) = notebook_path {
-                            if let Some(parent) = nb_path.parent() {
-                                cmd.current_dir(parent);
+                        // Use pixi shell-hook to get activation env vars, then
+                        // launch Python directly (faster, cleaner signal handling).
+                        // Falls back to `pixi run` if shell-hook fails.
+                        let manifest_path = notebook_path.and_then(|p| {
+                            crate::project_file::detect_project_file(p)
+                                .filter(|d| {
+                                    d.kind == crate::project_file::ProjectFileKind::PixiToml
+                                })
+                                .map(|d| d.path)
+                        });
+
+                        if let Some(ref manifest) = manifest_path {
+                            match kernel_launch::tools::pixi_shell_hook(manifest, None).await {
+                                Ok(env_vars) => {
+                                    // Direct launch: use Python from the pixi prefix
+                                    let python = env_vars
+                                        .get("CONDA_PREFIX")
+                                        .map(|p| {
+                                            std::path::PathBuf::from(p).join("bin").join("python")
+                                        })
+                                        .unwrap_or_else(|| std::path::PathBuf::from("python"));
+                                    info!(
+                                        "[kernel-manager] Starting Python kernel via pixi shell-hook ({})",
+                                        python.display()
+                                    );
+                                    let mut cmd = tokio::process::Command::new(&python);
+                                    cmd.envs(&env_vars);
+                                    cmd.args([
+                                        "-Xfrozen_modules=off",
+                                        "-m",
+                                        "ipykernel_launcher",
+                                        "-f",
+                                    ]);
+                                    cmd.arg(&connection_file_path);
+                                    cmd.stdout(Stdio::null());
+                                    cmd.stderr(Stdio::piped());
+                                    cmd
+                                }
+                                Err(e) => {
+                                    // Fallback: use pixi run (env may not be installed yet)
+                                    warn!(
+                                        "[kernel-manager] pixi shell-hook failed ({}), falling back to pixi run",
+                                        e
+                                    );
+                                    let pixi_path = kernel_launch::tools::get_pixi_path().await?;
+                                    let mut cmd = tokio::process::Command::new(&pixi_path);
+                                    cmd.args([
+                                        "run",
+                                        "python",
+                                        "-Xfrozen_modules=off",
+                                        "-m",
+                                        "ipykernel_launcher",
+                                        "-f",
+                                    ]);
+                                    cmd.arg(&connection_file_path);
+                                    cmd.stdout(Stdio::null());
+                                    cmd.stderr(Stdio::piped());
+                                    if let Some(parent) = manifest.parent() {
+                                        cmd.current_dir(parent);
+                                    }
+                                    cmd
+                                }
                             }
+                        } else {
+                            // No manifest found — fall back to pixi run
+                            let pixi_path = kernel_launch::tools::get_pixi_path().await?;
+                            let mut cmd = tokio::process::Command::new(&pixi_path);
+                            cmd.args([
+                                "run",
+                                "python",
+                                "-Xfrozen_modules=off",
+                                "-m",
+                                "ipykernel_launcher",
+                                "-f",
+                            ]);
+                            cmd.arg(&connection_file_path);
+                            cmd.stdout(Stdio::null());
+                            cmd.stderr(Stdio::piped());
+                            if let Some(nb_path) = notebook_path {
+                                if let Some(parent) = nb_path.parent() {
+                                    cmd.current_dir(parent);
+                                }
+                            }
+                            cmd
                         }
-                        cmd
                     }
                     "pixi:inline" | "pixi:prewarmed" => {
                         // Use pixi exec with -w flags. For pixi:inline, includes

--- a/crates/runtimed/src/kernel_manager.rs
+++ b/crates/runtimed/src/kernel_manager.rs
@@ -915,7 +915,12 @@ impl RoomKernel {
                                     let python = env_vars
                                         .get("CONDA_PREFIX")
                                         .map(|p| {
-                                            std::path::PathBuf::from(p).join("bin").join("python")
+                                            let prefix = std::path::PathBuf::from(p);
+                                            if cfg!(windows) {
+                                                prefix.join("python.exe")
+                                            } else {
+                                                prefix.join("bin").join("python")
+                                            }
                                         })
                                         .unwrap_or_else(|| std::path::PathBuf::from("python"));
                                     info!(

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -3281,7 +3281,14 @@ async fn auto_launch_kernel(
     // For pixi:toml, verify ipykernel is in pixi.toml before launching
     if env_source == "pixi:toml" {
         if let Some(ref detected) = detected_project_file {
-            if !crate::project_file::pixi_toml_has_ipykernel(&detected.path) {
+            let has_ipykernel = match kernel_launch::tools::pixi_info(&detected.path).await {
+                Ok(info) => info.has_ipykernel(),
+                Err(e) => {
+                    warn!("[notebook-sync] pixi info failed, falling back to line scan: {}", e);
+                    crate::project_file::pixi_toml_has_ipykernel(&detected.path)
+                }
+            };
+            if !has_ipykernel {
                 warn!(
                     "[notebook-sync] pixi.toml at {:?} does not declare ipykernel — cannot launch kernel",
                     detected.path
@@ -4046,7 +4053,11 @@ async fn handle_notebook_request(
                         .map(|d| d.path)
                 });
                 if let Some(ref path) = pixi_path {
-                    if !crate::project_file::pixi_toml_has_ipykernel(path) {
+                    let has_ipykernel = match kernel_launch::tools::pixi_info(path).await {
+                        Ok(info) => info.has_ipykernel(),
+                        Err(_) => crate::project_file::pixi_toml_has_ipykernel(path),
+                    };
+                    if !has_ipykernel {
                         warn!(
                             "[notebook-sync] pixi.toml at {:?} does not declare ipykernel",
                             path

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -3284,7 +3284,10 @@ async fn auto_launch_kernel(
             let has_ipykernel = match kernel_launch::tools::pixi_info(&detected.path).await {
                 Ok(info) => info.has_ipykernel(),
                 Err(e) => {
-                    warn!("[notebook-sync] pixi info failed, falling back to line scan: {}", e);
+                    warn!(
+                        "[notebook-sync] pixi info failed, falling back to line scan: {}",
+                        e
+                    );
                     crate::project_file::pixi_toml_has_ipykernel(&detected.path)
                 }
             };


### PR DESCRIPTION
## Summary

Use pixi's JSON APIs for more reliable and faster kernel launch:

### Changes (3 commits)

1. **Pin pixi bootstrap version to 0.63** — ensures stable `--json` output format when pixi is bootstrapped via rattler

2. **Add pixi_info() and pixi_shell_hook() utilities** (#1470) — typed wrappers for `pixi info --json` and `pixi shell-hook --json` in kernel-launch crate. Update daemon ipykernel pre-check to use `pixi_info()` with fallback to text scanner.

3. **Use pixi shell-hook --json for pixi:toml launch** (#1471) — instead of `pixi run python`, get activation env vars from `pixi shell-hook --json` and launch Python directly. Faster startup, cleaner signals. Falls back to `pixi run` if shell-hook fails (env not installed).

### How it works

```
Before: pixi run python -m ipykernel_launcher -f <conn>
         ↓ pixi wrapper subprocess → Python

After:  pixi shell-hook --json → env vars
        .pixi/envs/default/bin/python -m ipykernel_launcher -f <conn>
         ↓ direct Python process with pixi env vars
```

### What's NOT changed (yet)

- pixi:inline and pixi:prewarmed still use `pixi exec -w` (no manifest to shell-hook)
- Tauri `detect_pixi_toml` still uses custom TOML parser (notebook crate doesn't depend on kernel-launch)
- Shell-hook result not cached to disk yet (pixi caches internally at `.pixi/activation-env-v0/`)

## Test plan

- [x] `cargo test -p runtimed --lib` — 195 tests pass
- [x] `cargo check` — full workspace compiles
- [ ] Manual: pixi:toml kernel launches via shell-hook (check logs for "pixi shell-hook")
- [ ] Manual: fallback to pixi run when env not installed

Closes #1470, #1471