### PR TITLE
chore(frontend): remove noisy window focus/blur info logs

### DIFF
--- a/apps/notebook/src/lib/window-focus.ts
+++ b/apps/notebook/src/lib/window-focus.ts
@@ -81,15 +81,12 @@ function handleWindowBlur(): void {
     savedSelection = { anchor: sel.anchor, head: sel.head };
     logger.debug("[window-focus] Saved selection on blur", savedSelection);
   }
-
-  logger.info("[window-focus] Window lost focus");
 }
 
 function handleWindowFocus(): void {
   if (windowFocused) return; // already focused (dedup)
   windowFocused = true;
 
-  logger.info("[window-focus] Window gained focus");
   restoreEditorFocus();
 }
 


### PR DESCRIPTION
## Summary

Remove the `[window-focus] Window lost focus` and `[window-focus] Window gained focus` info-level log lines that fire on every alt-tab. These add noise to the log output with no diagnostic value.

## Verification

- [ ] Alt-tab away from and back to the app — no focus/blur info logs appear
- [ ] Window focus restoration (editor cursor) still works after switching back

_PR submitted by @rgbkrk's agent, Quill_