### PR TITLE
feat(output-resolver): synthesize text/llm+plain for widget outputs

### DIFF
--- a/crates/runt-mcp/src/execution.rs
+++ b/crates/runt-mcp/src/execution.rs
@@ -127,13 +127,21 @@ pub async fn execute_and_wait(
 
     let execution_count = handle.get_cell_execution_count(cell_id);
 
+    let comms = handle.get_runtime_state().ok().map(|rs| rs.comms);
     let outputs = if !output_hashes.is_empty() {
-        output_resolver::resolve_cell_outputs(&output_hashes, blob_base_url, blob_store_path).await
+        output_resolver::resolve_cell_outputs(
+            &output_hashes,
+            blob_base_url,
+            blob_store_path,
+            comms.as_ref(),
+        )
+        .await
     } else if let Some(cell_snapshot) = handle.get_cell(cell_id) {
         output_resolver::resolve_cell_outputs(
             &cell_snapshot.outputs,
             blob_base_url,
             blob_store_path,
+            comms.as_ref(),
         )
         .await
     } else {

--- a/crates/runt-mcp/src/tools/cell_read.rs
+++ b/crates/runt-mcp/src/tools/cell_read.rs
@@ -73,11 +73,13 @@ pub async fn get_cell(
         }
     }
 
-    // Resolve outputs
+    // Resolve outputs (with widget state synthesis)
+    let comms = handle.get_runtime_state().ok().map(|rs| rs.comms);
     let outputs = output_resolver::resolve_cell_outputs(
         &cell.outputs,
         &server.blob_base_url,
         &server.blob_store_path,
+        comms.as_ref(),
     )
     .await;
 
@@ -146,8 +148,9 @@ pub async fn get_all_cells(
     };
     let slice = &cells[start.min(cells.len())..end.min(cells.len())];
 
-    // Build cell status map from RuntimeState
+    // Build cell status map and comms from RuntimeState
     let cell_status_map = build_cell_status_map(&handle);
+    let comms = handle.get_runtime_state().ok().map(|rs| rs.comms);
 
     match format {
         "json" => {
@@ -162,6 +165,7 @@ pub async fn get_all_cells(
                     &cell.outputs,
                     &server.blob_base_url,
                     &server.blob_store_path,
+                    comms.as_ref(),
                 )
                 .await;
                 let output_texts: Vec<String> = resolved
@@ -197,6 +201,7 @@ pub async fn get_all_cells(
                     &cell.outputs,
                     &server.blob_base_url,
                     &server.blob_store_path,
+                    comms.as_ref(),
                 )
                 .await;
                 let header = formatting::format_cell_header(
@@ -237,6 +242,7 @@ pub async fn get_all_cells(
                         &cell.outputs,
                         &server.blob_base_url,
                         &server.blob_store_path,
+                        comms.as_ref(),
                     )
                     .await;
                     let output_text = formatting::format_outputs_text(&outputs);

--- a/crates/runt-mcp/src/tools/mod.rs
+++ b/crates/runt-mcp/src/tools/mod.rs
@@ -410,10 +410,12 @@ pub async fn build_execution_result(
         if snap.outputs.is_empty() {
             None
         } else {
+            let comms = handle.get_runtime_state().ok().map(|rs| rs.comms);
             let outputs = runtimed_client::output_resolver::resolve_cell_outputs(
                 &snap.outputs,
                 &server.blob_base_url,
                 &server.blob_store_path,
+                comms.as_ref(),
             )
             .await;
             let resolved = runtimed_client::resolved_output::ResolvedCell {

--- a/crates/runtimed-client/src/output_resolver.rs
+++ b/crates/runtimed-client/src/output_resolver.rs
@@ -681,7 +681,7 @@ pub fn format_widget_summary(
         }
 
         // Text inputs
-        "Text" | "Password" | "Textarea" | "Combobox" => {
+        "Text" | "Textarea" | "Combobox" => {
             let val = entry
                 .state
                 .get("value")
@@ -690,6 +690,12 @@ pub fn format_widget_summary(
             let preview = truncate_str(val, 40);
             format!("{name} {short_id}\u{2026}: {preview:?}")
         }
+
+        // SECURITY: Password widget values must never be included in summaries.
+        // These summaries are sent to LLM/MCP consumers as text/llm+plain, so
+        // exposing the raw value would leak secrets to any downstream agent or
+        // tool that reads cell outputs.
+        "Password" => format!("Password {short_id}\u{2026}: ****"),
 
         // Boolean/toggle
         "Checkbox" | "Valid" | "ToggleButton" => {
@@ -801,15 +807,32 @@ fn resolve_children(state: &Value, comms: &HashMap<String, CommDocEntry>) -> Str
                 .strip_suffix("Model")
                 .unwrap_or(&entry.model_name);
             let short_id = &cid[..6.min(cid.len())];
-            let val = entry
-                .state
-                .get("value")
-                .map(|v| format!(": {}", format_json_compact(v)))
-                .unwrap_or_default();
+            // SECURITY: Never include the value of Password widgets in child
+            // summaries. These flow to LLM/MCP consumers as text/llm+plain
+            // and would leak secrets to downstream agents or tools.
+            let val = if is_secret_widget(&entry.model_name) {
+                String::new()
+            } else {
+                entry
+                    .state
+                    .get("value")
+                    .map(|v| format!(": {}", format_json_compact(v)))
+                    .unwrap_or_default()
+            };
             Some(format!("{name} {short_id}\u{2026}{val}"))
         })
         .collect::<Vec<_>>()
         .join(", ")
+}
+
+/// Returns true for widget types whose values must never appear in summaries.
+///
+/// Password widgets store their raw plaintext value in state. Exposing it in
+/// text/llm+plain would leak secrets to any LLM/MCP consumer that reads cell
+/// outputs. This check is used both in the direct Password summary branch and
+/// in container child resolution to ensure secrets are never surfaced.
+fn is_secret_widget(model_name: &str) -> bool {
+    model_name == "PasswordModel"
 }
 
 /// Get a display string for a state key.

--- a/crates/runtimed-client/src/output_resolver.rs
+++ b/crates/runtimed-client/src/output_resolver.rs
@@ -7,9 +7,13 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 
 use base64::Engine as _;
+use notebook_doc::runtime_state::CommDocEntry;
 use serde_json::Value;
 
 use crate::resolved_output::{DataValue, Output};
+
+/// MIME type for Jupyter widget view references.
+const WIDGET_VIEW_MIME: &str = "application/vnd.jupyter.widget-view+json";
 
 /// Classification of a MIME type for output data.
 ///
@@ -512,16 +516,24 @@ async fn resolve_text_ref(
 }
 
 /// Resolve all outputs for a cell snapshot.
+///
+/// When `comms` is provided, widget view outputs (`application/vnd.jupyter.widget-view+json`)
+/// are resolved to human-readable `text/llm+plain` summaries by looking up the referenced
+/// widget's current state in the comms map.
 pub async fn resolve_cell_outputs(
     raw_outputs: &[String],
     blob_base_url: &Option<String>,
     blob_store_path: &Option<PathBuf>,
+    comms: Option<&HashMap<String, CommDocEntry>>,
 ) -> Vec<Output> {
     let mut outputs = Vec::with_capacity(raw_outputs.len());
     for output_str in raw_outputs {
-        if let Some(output) =
+        if let Some(mut output) =
             resolve_output_string(output_str, blob_base_url, blob_store_path).await
         {
+            if let (Some(comms), Some(ref mut data)) = (comms, &mut output.data) {
+                synthesize_llm_plain_for_widgets(data, comms);
+            }
             outputs.push(output);
         }
     }
@@ -603,4 +615,226 @@ fn synthesize_llm_plain_for_heavy_types(output_data: &mut HashMap<String, DataVa
         "text/llm+plain".to_string(),
         DataValue::Text(parts.join("\n")),
     );
+}
+
+// ── Widget state synthesis ──────────────────────────────────────────
+
+/// Synthesize `text/llm+plain` from widget view references.
+///
+/// When an output contains `application/vnd.jupyter.widget-view+json`,
+/// extracts the `model_id` (which is a comm_id), looks up the widget's
+/// current state from the comms map, and produces a human-readable summary.
+fn synthesize_llm_plain_for_widgets(
+    output_data: &mut HashMap<String, DataValue>,
+    comms: &HashMap<String, CommDocEntry>,
+) {
+    if output_data.contains_key("text/llm+plain") {
+        return;
+    }
+    let model_id = match output_data.get(WIDGET_VIEW_MIME) {
+        Some(DataValue::Json(val)) => val.get("model_id").and_then(|v| v.as_str()),
+        _ => None,
+    };
+    let Some(model_id) = model_id else { return };
+    let Some(entry) = comms.get(model_id) else {
+        return;
+    };
+
+    let summary = format_widget_summary(model_id, entry, comms);
+    output_data.insert("text/llm+plain".to_string(), DataValue::Text(summary));
+}
+
+/// Format a human-readable one-line summary of a widget's current state.
+///
+/// Examples:
+///   `IntSlider 25fdf9…: 2 (0–10)`
+///   `HBox 789abc…: [IntSlider 25fdf9…: 2, Text def012…: "hello"]`
+///   `Output 345678…: 2 output(s)`
+pub fn format_widget_summary(
+    comm_id: &str,
+    entry: &CommDocEntry,
+    comms: &HashMap<String, CommDocEntry>,
+) -> String {
+    let name = entry
+        .model_name
+        .strip_suffix("Model")
+        .unwrap_or(&entry.model_name);
+    let short_id = &comm_id[..6.min(comm_id.len())];
+
+    match name {
+        // Numeric sliders — value + range
+        "IntSlider" | "FloatSlider" | "FloatLogSlider" => {
+            let val = state_display(&entry.state, "value");
+            let min = state_display(&entry.state, "min");
+            let max = state_display(&entry.state, "max");
+            format!("{name} {short_id}\u{2026}: {val} ({min}\u{2013}{max})")
+        }
+        "IntRangeSlider" | "FloatRangeSlider" => {
+            let val = state_display(&entry.state, "value");
+            format!("{name} {short_id}\u{2026}: {val}")
+        }
+
+        // Numeric inputs
+        "IntText" | "FloatText" | "BoundedIntText" | "BoundedFloatText" => {
+            let val = state_display(&entry.state, "value");
+            format!("{name} {short_id}\u{2026}: {val}")
+        }
+
+        // Text inputs
+        "Text" | "Password" | "Textarea" | "Combobox" => {
+            let val = entry
+                .state
+                .get("value")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            let preview = truncate_str(val, 40);
+            format!("{name} {short_id}\u{2026}: {preview:?}")
+        }
+
+        // Boolean/toggle
+        "Checkbox" | "Valid" | "ToggleButton" => {
+            let val = state_display(&entry.state, "value");
+            format!("{name} {short_id}\u{2026}: {val}")
+        }
+
+        // Selection widgets — resolve selected label
+        "Dropdown" | "Select" | "RadioButtons" | "ToggleButtons" | "SelectionSlider" => {
+            let labels = entry
+                .state
+                .get("_options_labels")
+                .and_then(|v| v.as_array());
+            let idx = entry.state.get("index").and_then(|v| v.as_u64());
+            let selected = labels
+                .zip(idx)
+                .and_then(|(l, i)| l.get(i as usize))
+                .and_then(|v| v.as_str());
+            match selected {
+                Some(s) => format!("{name} {short_id}\u{2026}: {s:?}"),
+                None => format!("{name} {short_id}\u{2026}: (no selection)"),
+            }
+        }
+
+        // Multi-select
+        "SelectMultiple" => {
+            let idx = entry
+                .state
+                .get("index")
+                .and_then(|v| v.as_array())
+                .map(|a| a.len())
+                .unwrap_or(0);
+            format!("{name} {short_id}\u{2026}: {idx} selected")
+        }
+
+        // Progress
+        "IntProgress" | "FloatProgress" => {
+            let val = state_display(&entry.state, "value");
+            let max = state_display(&entry.state, "max");
+            format!("{name} {short_id}\u{2026}: {val}/{max}")
+        }
+
+        // Button — show label
+        "Button" => {
+            let desc = entry
+                .state
+                .get("description")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            format!("Button {short_id}\u{2026}: {desc:?}")
+        }
+
+        // Output widget — show captured output count
+        "Output" => {
+            let n = entry.outputs.len();
+            format!("Output {short_id}\u{2026}: {n} output(s)")
+        }
+
+        // Container widgets — show children inline
+        "HBox" | "VBox" | "Box" | "GridBox" | "Tab" | "Accordion" | "Stack" => {
+            let children = resolve_children(&entry.state, comms);
+            format!("{name} {short_id}\u{2026}: [{children}]")
+        }
+
+        // Display widgets
+        "HTML" | "HTMLMath" | "Label" => {
+            let val = entry
+                .state
+                .get("value")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            let preview = truncate_str(val, 60);
+            format!("{name} {short_id}\u{2026}: {preview:?}")
+        }
+        "Image" => format!("Image {short_id}\u{2026}"),
+
+        // Color/Date/Time pickers
+        "ColorPicker" | "DatePicker" | "TimePicker" => {
+            let val = state_display(&entry.state, "value");
+            format!("{name} {short_id}\u{2026}: {val}")
+        }
+
+        // Fallback — show description or value if available
+        _ => match entry.state.get("description").and_then(|v| v.as_str()) {
+            Some(d) if !d.is_empty() => format!("{name} {short_id}\u{2026}: {d:?}"),
+            _ => match entry.state.get("value") {
+                Some(v) => {
+                    format!("{name} {short_id}\u{2026}: {}", format_json_compact(v))
+                }
+                None => format!("{name} {short_id}\u{2026}"),
+            },
+        },
+    }
+}
+
+/// Resolve `IPY_MODEL_xxx` children references to short summaries (one level deep).
+fn resolve_children(state: &Value, comms: &HashMap<String, CommDocEntry>) -> String {
+    let Some(children) = state.get("children").and_then(|v| v.as_array()) else {
+        return String::new();
+    };
+    children
+        .iter()
+        .filter_map(|child| {
+            let ref_str = child.as_str()?;
+            let cid = ref_str.strip_prefix("IPY_MODEL_")?;
+            let entry = comms.get(cid)?;
+            let name = entry
+                .model_name
+                .strip_suffix("Model")
+                .unwrap_or(&entry.model_name);
+            let short_id = &cid[..6.min(cid.len())];
+            let val = entry
+                .state
+                .get("value")
+                .map(|v| format!(": {}", format_json_compact(v)))
+                .unwrap_or_default();
+            Some(format!("{name} {short_id}\u{2026}{val}"))
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// Get a display string for a state key.
+fn state_display(state: &Value, key: &str) -> String {
+    state
+        .get(key)
+        .map(format_json_compact)
+        .unwrap_or_else(|| "?".to_string())
+}
+
+/// Format a JSON value compactly for display.
+fn format_json_compact(v: &Value) -> String {
+    match v {
+        Value::String(s) => format!("{s:?}"),
+        Value::Null => "null".to_string(),
+        other => other.to_string(),
+    }
+}
+
+/// Truncate a string to `max` characters, appending an ellipsis if truncated.
+fn truncate_str(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        s.to_string()
+    } else {
+        let truncated: String = s.chars().take(max).collect();
+        format!("{truncated}\u{2026}")
+    }
 }

--- a/crates/runtimed-py/src/lib.rs
+++ b/crates/runtimed-py/src/lib.rs
@@ -23,8 +23,8 @@ use error::RuntimedError;
 
 use output::{
     Cell, CompletionItem, CompletionResult, ExecutionEvent, ExecutionResult, HistoryEntry,
-    NotebookConnectionInfo, Output, PyEnvState, PyKernelState, PyQueueEntry, PyRuntimeState,
-    QueueState, SyncEnvironmentResult,
+    NotebookConnectionInfo, Output, PyCommDocEntry, PyEnvState, PyKernelState, PyQueueEntry,
+    PyRuntimeState, QueueState, SyncEnvironmentResult,
 };
 
 /// Launch the desktop notebook app, optionally opening a specific notebook.
@@ -132,6 +132,7 @@ fn _internals(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyRuntimeState>()?;
     m.add_class::<PyKernelState>()?;
     m.add_class::<PyEnvState>()?;
+    m.add_class::<PyCommDocEntry>()?;
 
     // Error type
     m.add("RuntimedError", m.py().get_type::<RuntimedError>())?;

--- a/crates/runtimed-py/src/output.rs
+++ b/crates/runtimed-py/src/output.rs
@@ -935,6 +935,51 @@ impl PyExecutionState {
     }
 }
 
+/// A single widget comm entry from the RuntimeStateDoc.
+///
+/// Widget state is stored as a native Automerge map. The `state` property
+/// lazily converts from JSON to a Python dict on access.
+#[pyclass(name = "CommDocEntry", skip_from_py_object)]
+#[derive(Clone, Debug)]
+pub struct PyCommDocEntry {
+    /// Widget protocol target (e.g., "jupyter.widget").
+    #[pyo3(get)]
+    pub target_name: String,
+    /// Widget model module (e.g., "@jupyter-widgets/controls").
+    #[pyo3(get)]
+    pub model_module: String,
+    /// Widget model name (e.g., "IntSliderModel").
+    #[pyo3(get)]
+    pub model_name: String,
+    /// JSON-serialized widget state (lazy-converted to dict via `state` getter).
+    pub state_json: String,
+    /// Output manifest hashes (OutputModel widgets only).
+    #[pyo3(get)]
+    pub outputs: Vec<String>,
+    /// Insertion order for dependency-correct replay.
+    #[pyo3(get)]
+    pub seq: u64,
+}
+
+#[pymethods]
+impl PyCommDocEntry {
+    /// Widget state as a Python dict.
+    #[getter]
+    fn state<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let val: serde_json::Value = serde_json::from_str(&self.state_json)
+            .map_err(|e| pyo3::exceptions::PyValueError::new_err(e.to_string()))?;
+        json_to_py(py, &val)
+    }
+
+    fn __repr__(&self) -> String {
+        let name = self
+            .model_name
+            .strip_suffix("Model")
+            .unwrap_or(&self.model_name);
+        format!("CommDocEntry({name}, target={:?})", self.target_name)
+    }
+}
+
 /// Full runtime state snapshot from the daemon's RuntimeStateDoc.
 #[pyclass(name = "RuntimeState", get_all, skip_from_py_object)]
 #[derive(Clone, Debug)]
@@ -949,13 +994,15 @@ pub struct PyRuntimeState {
     pub last_saved: Option<String>,
     /// Execution lifecycle entries keyed by execution_id.
     pub executions: std::collections::HashMap<String, PyExecutionState>,
+    /// Active comm channels keyed by comm_id.
+    pub comms: std::collections::HashMap<String, PyCommDocEntry>,
 }
 
 #[pymethods]
 impl PyRuntimeState {
     fn __repr__(&self) -> String {
         format!(
-            "RuntimeState(kernel={}, queue={}, env={})",
+            "RuntimeState(kernel={}, queue={}, env={}, comms={})",
             self.kernel.status,
             match &self.queue.executing {
                 Some(entry) => format!("executing={}", entry.cell_id),
@@ -966,6 +1013,7 @@ impl PyRuntimeState {
             } else {
                 "drifted"
             },
+            self.comms.len(),
         )
     }
 
@@ -1020,6 +1068,24 @@ impl From<notebook_doc::runtime_state::RuntimeState> for PyRuntimeState {
                             status: es.status,
                             execution_count: es.execution_count,
                             success: es.success,
+                        },
+                    )
+                })
+                .collect(),
+            comms: rs
+                .comms
+                .into_iter()
+                .map(|(cid, entry)| {
+                    (
+                        cid,
+                        PyCommDocEntry {
+                            target_name: entry.target_name,
+                            model_module: entry.model_module,
+                            model_name: entry.model_name,
+                            state_json: serde_json::to_string(&entry.state)
+                                .unwrap_or_else(|_| "{}".to_string()),
+                            outputs: entry.outputs,
+                            seq: entry.seq,
                         },
                     )
                 })

--- a/crates/runtimed-py/src/output_resolver.rs
+++ b/crates/runtimed-py/src/output_resolver.rs
@@ -2,8 +2,10 @@
 //!
 //! Re-exports are adapted to use the local PyO3 `Output` and `DataValue` types.
 
+use std::collections::HashMap;
 use std::path::PathBuf;
 
+use notebook_doc::runtime_state::CommDocEntry;
 use runtimed::output_resolver as shared;
 
 use crate::output::{DataValue, Output};
@@ -40,8 +42,9 @@ pub async fn resolve_cell_outputs(
     raw_outputs: &[String],
     blob_base_url: &Option<String>,
     blob_store_path: &Option<PathBuf>,
+    comms: Option<&HashMap<String, CommDocEntry>>,
 ) -> Vec<Output> {
-    shared::resolve_cell_outputs(raw_outputs, blob_base_url, blob_store_path)
+    shared::resolve_cell_outputs(raw_outputs, blob_base_url, blob_store_path, comms)
         .await
         .into_iter()
         .map(convert_output)

--- a/crates/runtimed-py/src/session_core.rs
+++ b/crates/runtimed-py/src/session_core.rs
@@ -868,7 +868,7 @@ pub(crate) async fn set_cell_type(
 
 /// Get a single cell by ID, with resolved outputs.
 pub(crate) async fn get_cell(state: &Arc<Mutex<SessionState>>, cell_id: &str) -> PyResult<Cell> {
-    let (snapshot, blob_base_url, blob_store_path) = {
+    let (snapshot, blob_base_url, blob_store_path, comms) = {
         let st = state.lock().await;
         let handle = st
             .handle
@@ -877,24 +877,29 @@ pub(crate) async fn get_cell(state: &Arc<Mutex<SessionState>>, cell_id: &str) ->
 
         let blob_base_url = st.blob_base_url.clone();
         let blob_store_path = st.blob_store_path.clone();
+        let comms = handle.get_runtime_state().ok().map(|rs| rs.comms);
 
         let snapshot = handle
             .get_cell(cell_id)
             .ok_or_else(|| to_py_err(format!("Cell not found: {}", cell_id)))?;
 
-        (snapshot, blob_base_url, blob_store_path)
+        (snapshot, blob_base_url, blob_store_path, comms)
     };
 
-    let outputs =
-        output_resolver::resolve_cell_outputs(&snapshot.outputs, &blob_base_url, &blob_store_path)
-            .await;
+    let outputs = output_resolver::resolve_cell_outputs(
+        &snapshot.outputs,
+        &blob_base_url,
+        &blob_store_path,
+        comms.as_ref(),
+    )
+    .await;
 
     Ok(Cell::from_snapshot_with_outputs(snapshot, outputs))
 }
 
 /// Get all cells with resolved outputs.
 pub(crate) async fn get_cells(state: &Arc<Mutex<SessionState>>) -> PyResult<Vec<Cell>> {
-    let (snapshots, blob_base_url, blob_store_path) = {
+    let (snapshots, blob_base_url, blob_store_path, comms) = {
         let st = state.lock().await;
         let handle = st
             .handle
@@ -903,9 +908,10 @@ pub(crate) async fn get_cells(state: &Arc<Mutex<SessionState>>) -> PyResult<Vec<
 
         let blob_base_url = st.blob_base_url.clone();
         let blob_store_path = st.blob_store_path.clone();
+        let comms = handle.get_runtime_state().ok().map(|rs| rs.comms);
         let snapshots = handle.get_cells();
 
-        (snapshots, blob_base_url, blob_store_path)
+        (snapshots, blob_base_url, blob_store_path, comms)
     };
 
     let mut cells = Vec::with_capacity(snapshots.len());
@@ -914,6 +920,7 @@ pub(crate) async fn get_cells(state: &Arc<Mutex<SessionState>>) -> PyResult<Vec<
             &snapshot.outputs,
             &blob_base_url,
             &blob_store_path,
+            comms.as_ref(),
         )
         .await;
         cells.push(Cell::from_snapshot_with_outputs(snapshot, outputs));
@@ -1390,6 +1397,7 @@ pub(crate) async fn collect_outputs(
     let mut snapshot = None;
     let mut blob_base_url_out = None;
     let mut blob_store_path_out = None;
+    let mut comms_out = None;
 
     for attempt in 0..5 {
         let st = state.lock().await;
@@ -1413,6 +1421,7 @@ pub(crate) async fn collect_outputs(
         if has_outputs || has_ec || attempt >= 4 {
             blob_base_url_out = blob_base_url.clone();
             blob_store_path_out = blob_store_path.clone();
+            comms_out = handle.get_runtime_state().ok().map(|rs| rs.comms);
             snapshot = Some(snap);
             break;
         }
@@ -1429,6 +1438,7 @@ pub(crate) async fn collect_outputs(
         &snapshot.outputs,
         &blob_base_url_out,
         &blob_store_path_out,
+        comms_out.as_ref(),
     )
     .await;
 

--- a/python/runtimed/src/runtimed/_notebook.py
+++ b/python/runtimed/src/runtimed/_notebook.py
@@ -56,9 +56,24 @@ class Notebook:
         """Current runtime state read from the local replica.
 
         Returns a ``RuntimeState`` with ``.kernel``, ``.queue``, ``.env``,
-        and ``.executions`` — useful for polling kernel status or queue depth.
+        ``.executions``, and ``.comms`` — useful for polling kernel status
+        or inspecting widget state.
         """
         return self._session.get_runtime_state_sync()
+
+    @property
+    def widgets(self) -> dict:
+        """Active ipywidgets keyed by comm_id.
+
+        Each value is a ``CommDocEntry`` with ``.model_name``, ``.state``
+        (dict), ``.model_module``, etc. Filters ``runtime.comms`` to entries
+        with ``target_name == "jupyter.widget"``.
+        """
+        return {
+            cid: entry
+            for cid, entry in self.runtime.comms.items()
+            if entry.target_name == "jupyter.widget"
+        }
 
     @property
     def peers(self) -> list[tuple[str, str]]:


### PR DESCRIPTION
## Summary

Widget cell outputs contain `application/vnd.jupyter.widget-view+json` with a `model_id` reference — previously passed through as opaque JSON. The output resolver now looks up the referenced widget's current state from RuntimeStateDoc comms and synthesizes a human-readable `text/llm+plain` summary, following the same pattern used for Plotly/Vega specs and binary images.

This means agents and Python users see widget state contextually in cell outputs:
```
IntSlider 25fdf9…: 2 (0–10)
HBox 789abc…: [IntSlider 25fdf9…: 2, Text def012…: "hello"]
Output 345678…: 2 output(s)
```

Also exposes widget comm state in Python bindings via `notebook.runtime.comms` and a `notebook.widgets` convenience property.

## Changes

- **`runtimed-client/output_resolver.rs`** — `synthesize_llm_plain_for_widgets` + `format_widget_summary` covering sliders, text inputs, checkboxes, dropdowns, buttons, progress bars, containers (one level deep), output widgets, pickers, and a generic fallback. `resolve_cell_outputs` takes an optional `comms` parameter.
- **`runt-mcp/` tools** — All `resolve_cell_outputs` callers pass comms from `handle.get_runtime_state()`
- **`runtimed-py/output.rs`** — New `PyCommDocEntry` class with lazy `.state` → dict conversion; `comms` field on `PyRuntimeState`
- **`runtimed-py/session_core.rs`** — Thread comms through Python output resolution
- **`_notebook.py`** — `notebook.widgets` property filters comms to `target_name == "jupyter.widget"`

## Verification

- [ ] Create a notebook with `ipywidgets.IntSlider(value=5, min=0, max=10)`, execute, then use `get_cell` — output should include `IntSlider …: 5 (0–10)` in text/llm+plain
- [ ] Create an `HBox([IntSlider(), Text(value="hello")])`, verify container summary shows children inline
- [ ] In Python: `notebook.widgets` returns dict keyed by comm_id with `.state` as native dict
- [ ] `notebook.runtime.comms` includes all comm entries (not just ipywidgets)

_PR submitted by @rgbkrk's agent, Quill_