### PR TITLE
fix(frontend): prevent scroll jump during widget slider interaction

### DIFF
--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -774,7 +774,7 @@ function NotebookViewContent({
     <div
       ref={containerRef}
       className="flex-1 overflow-y-auto overflow-x-clip overscroll-x-contain py-4 pl-8 pr-2"
-      style={{ contain: "paint" }}
+      style={{ contain: "paint", overflowAnchor: "none" }}
       data-notebook-synced={!isLoading && cellIds.length > 0}
       data-cell-count={cellIds.length}
     >

--- a/apps/notebook/src/lib/window-focus.ts
+++ b/apps/notebook/src/lib/window-focus.ts
@@ -105,6 +105,12 @@ function handleWindowFocus(): void {
  * during the focus event.
  */
 function restoreEditorFocus(): void {
+  // Don't steal focus from iframe interactions (user may be in a widget)
+  if (document.activeElement instanceof HTMLIFrameElement) {
+    logger.debug("[window-focus] Skipping restore — iframe has focus");
+    return;
+  }
+
   if (!savedView?.dom?.isConnected) {
     savedView = null;
     savedSelection = null;


### PR DESCRIPTION
## Summary

When dragging an `@interact` slider (or any widget that triggers rapid output updates), the notebook viewport would jump to a CodeMirror editor. The root cause is the browser's [scroll anchoring](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-anchor) algorithm — when the iframe output resizes during a widget update cycle, the browser picks a CM `contenteditable` div as an anchor and adjusts scroll position to keep it visible.

- **Disable browser scroll anchoring** on the notebook scroll container (`overflow-anchor: none`). All intentional scrolling already uses explicit `scrollIntoView` calls (keyboard nav, Shift+Enter, search), so this is safe.
- **Guard `restoreEditorFocus()`** in `window-focus.ts` to skip when an iframe has focus, preventing an edge case where Tauri window focus events could steal focus from widget interactions.

## Verification

- [ ] Open a notebook with an `@interact` slider that produces matplotlib output (e.g. polygon demo)
- [ ] Drag the slider rapidly — viewport should stay pinned to the output, not jump to a code cell
- [ ] Cmd+Tab away and back while interacting with a widget — focus should remain in the widget
- [ ] Arrow key / Shift+Enter cell navigation still scrolls cells into view correctly

_PR submitted by @rgbkrk's agent, Quill_