### PR TITLE
feat(frontend): highlight Restart+Run All when deps are out of sync

### DIFF
--- a/apps/notebook/src/App.tsx
+++ b/apps/notebook/src/App.tsx
@@ -1125,6 +1125,7 @@ function AppContent() {
           onAddCell={handleAddCell}
           onToggleDependencies={() => setDependencyHeaderOpen((prev) => !prev)}
           isDepsOpen={dependencyHeaderOpen}
+          depsOutOfSync={envSyncState ? !envSyncState.inSync : false}
           updateStatus={updateStatus}
           updateVersion={updateVersion}
           onRestartToUpdate={restartToUpdate}

--- a/apps/notebook/src/components/NotebookToolbar.tsx
+++ b/apps/notebook/src/components/NotebookToolbar.tsx
@@ -48,6 +48,7 @@ interface NotebookToolbarProps {
   onToggleDependencies: () => void;
   isDepsOpen?: boolean;
   listKernelspecs?: () => Promise<KernelspecInfo[]>;
+  depsOutOfSync?: boolean;
   updateStatus?: UpdateStatus;
   updateVersion?: string | null;
   onRestartToUpdate?: () => void;
@@ -71,6 +72,7 @@ export function NotebookToolbar({
   onAddCell,
   onToggleDependencies,
   isDepsOpen = false,
+  depsOutOfSync = false,
   listKernelspecs,
   updateStatus,
   updateVersion,
@@ -206,8 +208,17 @@ export function NotebookToolbar({
         <button
           type="button"
           onClick={onRestartAndRunAll}
-          className="flex items-center gap-1 rounded px-2 py-1 text-xs text-foreground transition-colors hover:bg-muted"
-          title="Restart kernel and run all cells"
+          className={cn(
+            "flex items-center gap-1 rounded px-2 py-1 text-xs transition-colors",
+            depsOutOfSync
+              ? "bg-amber-500/10 text-amber-700 ring-1 ring-amber-500/30 hover:bg-amber-500/20 dark:text-amber-400"
+              : "text-foreground hover:bg-muted",
+          )}
+          title={
+            depsOutOfSync
+              ? "Dependencies changed — restart kernel and run all cells"
+              : "Restart kernel and run all cells"
+          }
           data-testid="restart-run-all-button"
         >
           <RotateCcw className="h-3 w-3" />


### PR DESCRIPTION
## Summary
- When dependencies drift from the running kernel, the **Restart + Run All** toolbar button gets an amber highlight (ring + background tint) to surface the recommended action
- Adds `depsOutOfSync` prop to `NotebookToolbar`, derived from `envSyncState.inSync`
- Updates the button tooltip to mention dependency changes when active

Closes #778 — see [triage comment](https://github.com/nteract/desktop/issues/778#issuecomment-4188012389) for full context on what was already addressed.

## Test plan
- [ ] Open a notebook with UV inline deps and a running kernel
- [ ] Add a new package to the dep cell → verify Restart+Run All button shows amber highlight
- [ ] Click Re-initialize → verify highlight disappears once deps are back in sync
- [ ] With deps in sync, verify the button looks normal (no amber)