### PR TITLE
fix(mcp): reduce output size for audio, viz, and large MIME types

### DIFF
--- a/crates/runt-mcp/src/structured.rs
+++ b/crates/runt-mcp/src/structured.rs
@@ -7,10 +7,6 @@
 use runtimed_client::resolved_output::{DataValue, Output, ResolvedCell};
 use serde_json::{json, Value};
 
-/// Maximum inline size (bytes) for a single MIME entry in structured content.
-/// Entries larger than this are replaced with blob URLs or skipped.
-const MAX_INLINE_BYTES: usize = 8 * 1024;
-
 /// Check if a MIME type is a visualization spec (Plotly, Vega-Lite, Vega).
 fn is_viz_mime(mime: &str) -> bool {
     mime == "application/vnd.plotly.v1+json"
@@ -19,13 +15,6 @@ fn is_viz_mime(mime: &str) -> bool {
         || (mime.starts_with("application/vnd.vega.v")
             && !mime.starts_with("application/vnd.vegalite.")
             && (mime.ends_with("+json") || mime.ends_with(".json")))
-}
-
-/// Check if a JSON value exceeds the inline size limit when serialized.
-fn json_exceeds_limit(v: &Value) -> bool {
-    // Quick heuristic: serialize and check length.
-    // For very large values, to_string is cheaper than to_string_pretty.
-    serde_json::to_string(v).is_ok_and(|s| s.len() > MAX_INLINE_BYTES)
 }
 
 /// Return a blob URL for the given MIME type, or None to skip the entry.
@@ -70,17 +59,18 @@ fn output_to_structured(output: &Output) -> Value {
         }
         "display_data" | "execute_result" => {
             let mut data = serde_json::Map::new();
-            let has_blob_urls = output.blob_urls.is_some();
 
             if let Some(ref output_data) = output.data {
-                // Check if the output has a richer primary MIME type, so we can
-                // skip text/html (which often contains massive base64 data URIs
-                // for audio or redundant chart HTML).
-                let has_rich_primary = output_data.keys().any(|m| {
-                    is_viz_mime(m)
-                        || m.starts_with("image/")
-                        || m.starts_with("audio/")
-                        || m.starts_with("video/")
+                // Check if the output has a raster image that the MCP app can
+                // render directly (png/jpeg/gif/webp via blob URL). When true,
+                // we can safely skip text/html (which is often a massive base64
+                // data URI for audio, or redundant chart HTML that duplicates
+                // the image).
+                let has_renderable_image = output_data.keys().any(|m| {
+                    matches!(
+                        m.as_str(),
+                        "image/png" | "image/jpeg" | "image/gif" | "image/webp"
+                    )
                 });
 
                 for (mime, value) in output_data {
@@ -89,10 +79,17 @@ fn output_to_structured(output: &Output) -> Value {
                         continue;
                     }
 
-                    // Skip text/html when richer types are available — it's a
-                    // fallback representation that often contains inline base64
-                    // data URIs (audio) or redundant chart HTML (plotly).
-                    if mime == "text/html" && has_rich_primary {
+                    // Skip text/html when the MCP app can render a raster image
+                    // instead. This avoids sending large base64 data URIs (audio
+                    // HTML embeds) or redundant chart HTML alongside the image.
+                    if mime == "text/html" && has_renderable_image {
+                        continue;
+                    }
+
+                    // Skip viz JSON specs — the MCP app doesn't render them, and
+                    // they're large (tens of KB). The app uses text/html or image
+                    // fallbacks for display.
+                    if is_viz_mime(mime) {
                         continue;
                     }
 
@@ -101,23 +98,8 @@ fn output_to_structured(output: &Output) -> Value {
                             // For binary data, use blob URL if available
                             blob_url_or_skip(output, mime)
                         }
-                        DataValue::Json(v) => {
-                            // For viz JSON specs and large JSON, use blob URL
-                            // instead of sending the full spec inline.
-                            if is_viz_mime(mime) || json_exceeds_limit(v) {
-                                blob_url_or_skip(output, mime)
-                            } else {
-                                Some(v.clone())
-                            }
-                        }
-                        DataValue::Text(s) => {
-                            // For large text (e.g. SVG), use blob URL if available
-                            if s.len() > MAX_INLINE_BYTES && has_blob_urls {
-                                blob_url_or_skip(output, mime)
-                            } else {
-                                Some(Value::String(s.clone()))
-                            }
-                        }
+                        DataValue::Json(v) => Some(v.clone()),
+                        DataValue::Text(s) => Some(Value::String(s.clone())),
                     };
 
                     if let Some(jv) = json_value {

--- a/crates/runt-mcp/src/structured.rs
+++ b/crates/runt-mcp/src/structured.rs
@@ -7,6 +7,36 @@
 use runtimed_client::resolved_output::{DataValue, Output, ResolvedCell};
 use serde_json::{json, Value};
 
+/// Maximum inline size (bytes) for a single MIME entry in structured content.
+/// Entries larger than this are replaced with blob URLs or skipped.
+const MAX_INLINE_BYTES: usize = 8 * 1024;
+
+/// Check if a MIME type is a visualization spec (Plotly, Vega-Lite, Vega).
+fn is_viz_mime(mime: &str) -> bool {
+    mime == "application/vnd.plotly.v1+json"
+        || (mime.starts_with("application/vnd.vegalite.v")
+            && (mime.ends_with("+json") || mime.ends_with(".json")))
+        || (mime.starts_with("application/vnd.vega.v")
+            && !mime.starts_with("application/vnd.vegalite.")
+            && (mime.ends_with("+json") || mime.ends_with(".json")))
+}
+
+/// Check if a JSON value exceeds the inline size limit when serialized.
+fn json_exceeds_limit(v: &Value) -> bool {
+    // Quick heuristic: serialize and check length.
+    // For very large values, to_string is cheaper than to_string_pretty.
+    serde_json::to_string(v).is_ok_and(|s| s.len() > MAX_INLINE_BYTES)
+}
+
+/// Return a blob URL for the given MIME type, or None to skip the entry.
+fn blob_url_or_skip(output: &Output, mime: &str) -> Option<Value> {
+    output
+        .blob_urls
+        .as_ref()
+        .and_then(|urls| urls.get(mime))
+        .map(|url| Value::String(url.clone()))
+}
+
 /// Build the structuredContent JSON for a resolved cell.
 pub fn cell_structured_content(cell: &ResolvedCell, status: &str) -> Value {
     json!({
@@ -40,30 +70,59 @@ fn output_to_structured(output: &Output) -> Value {
         }
         "display_data" | "execute_result" => {
             let mut data = serde_json::Map::new();
+            let has_blob_urls = output.blob_urls.is_some();
 
             if let Some(ref output_data) = output.data {
+                // Check if the output has a richer primary MIME type, so we can
+                // skip text/html (which often contains massive base64 data URIs
+                // for audio or redundant chart HTML).
+                let has_rich_primary = output_data.keys().any(|m| {
+                    is_viz_mime(m)
+                        || m.starts_with("image/")
+                        || m.starts_with("audio/")
+                        || m.starts_with("video/")
+                });
+
                 for (mime, value) in output_data {
                     // Skip text/llm+plain — it's for LLM consumption, not the widget
                     if mime == "text/llm+plain" {
                         continue;
                     }
+
+                    // Skip text/html when richer types are available — it's a
+                    // fallback representation that often contains inline base64
+                    // data URIs (audio) or redundant chart HTML (plotly).
+                    if mime == "text/html" && has_rich_primary {
+                        continue;
+                    }
+
                     let json_value = match value {
-                        DataValue::Text(s) => Value::String(s.clone()),
                         DataValue::Binary(_) => {
                             // For binary data, use blob URL if available
-                            if let Some(ref urls) = output.blob_urls {
-                                if let Some(url) = urls.get(mime) {
-                                    Value::String(url.clone())
-                                } else {
-                                    continue;
-                                }
+                            blob_url_or_skip(output, mime)
+                        }
+                        DataValue::Json(v) => {
+                            // For viz JSON specs and large JSON, use blob URL
+                            // instead of sending the full spec inline.
+                            if is_viz_mime(mime) || json_exceeds_limit(v) {
+                                blob_url_or_skip(output, mime)
                             } else {
-                                continue;
+                                Some(v.clone())
                             }
                         }
-                        DataValue::Json(v) => v.clone(),
+                        DataValue::Text(s) => {
+                            // For large text (e.g. SVG), use blob URL if available
+                            if s.len() > MAX_INLINE_BYTES && has_blob_urls {
+                                blob_url_or_skip(output, mime)
+                            } else {
+                                Some(Value::String(s.clone()))
+                            }
+                        }
                     };
-                    data.insert(mime.clone(), json_value);
+
+                    if let Some(jv) = json_value {
+                        data.insert(mime.clone(), jv);
+                    }
                 }
             }
 

--- a/crates/runtimed-client/src/output_resolver.rs
+++ b/crates/runtimed-client/src/output_resolver.rs
@@ -213,19 +213,13 @@ pub fn json_data_to_datavalues(
     data: &serde_json::Map<String, Value>,
 ) -> HashMap<String, DataValue> {
     let mut output_data = HashMap::new();
-    let mut has_image = false;
 
     for (mime, value) in data {
         let dv = match mime_kind(mime) {
             MimeKind::Binary => {
                 if let Some(s) = value.as_str() {
                     match base64::engine::general_purpose::STANDARD.decode(s) {
-                        Ok(bytes) => {
-                            if mime.starts_with("image/") {
-                                has_image = true;
-                            }
-                            DataValue::Binary(bytes)
-                        }
+                        Ok(bytes) => DataValue::Binary(bytes),
                         Err(_) => DataValue::Text(s.to_string()),
                     }
                 } else {
@@ -253,34 +247,12 @@ pub fn json_data_to_datavalues(
         output_data.insert(mime.clone(), dv);
     }
 
-    // Synthesize text/llm+plain for binary images
-    if has_image && !output_data.contains_key("text/llm+plain") {
-        let mut parts: Vec<String> = Vec::new();
-        if let Some(DataValue::Text(ref plain)) = output_data.get("text/plain") {
-            parts.push(plain.clone());
-        }
-        for (mime, dv) in &output_data {
-            if let DataValue::Binary(bytes) = dv {
-                if mime.starts_with("image/") {
-                    parts.push(format!(
-                        "Image output ({}, {} KB)",
-                        mime,
-                        bytes.len() / 1024
-                    ));
-                }
-            }
-        }
-        output_data.insert(
-            "text/llm+plain".to_string(),
-            DataValue::Text(parts.join("\n")),
-        );
-    }
-
-    // Synthesize text/llm+plain for visualization specs (Plotly, Vega-Lite, Vega)
+    // Synthesis priority: viz > heavy types > binary media.
+    // Viz summaries are more useful than "Image output (image/png, X KB)" when
+    // both exist (e.g. Altair emits png fallback + vegalite+json).
     synthesize_llm_plain_for_viz(&mut output_data);
-
-    // Synthesize text/llm+plain for other heavy types (SVG, HTML, large JSON)
     synthesize_llm_plain_for_heavy_types(&mut output_data);
+    synthesize_llm_plain_for_binary_media(&mut output_data);
 
     output_data
 }
@@ -302,7 +274,6 @@ pub async fn output_from_manifest(
         "display_data" | "execute_result" => {
             let data_map = manifest.get("data")?.as_object()?;
             let mut output_data = HashMap::new();
-            let mut image_descriptions: Vec<String> = Vec::new();
             let mut blob_urls_map: HashMap<String, String> = HashMap::new();
             let mut blob_paths_map: HashMap<String, String> = HashMap::new();
 
@@ -332,42 +303,20 @@ pub async fn output_from_manifest(
                         }
                     }
 
-                    // Record binary image metadata for LLM description
-                    if let DataValue::Binary(ref bytes) = content {
-                        if mime_type.starts_with("image/") {
-                            let size_kb = bytes.len() / 1024;
-                            let mut desc = format!("Image output ({}, {} KB)", mime_type, size_kb);
-                            if let Some(url) = blob_urls_map.get(mime_type) {
-                                desc.push_str(&format!("\n{}", url));
-                            } else if let Some(path) = blob_paths_map.get(mime_type) {
-                                desc.push_str(&format!("\n{}", path));
-                            }
-                            image_descriptions.push(desc);
-                        }
-                    }
-
                     output_data.insert(mime_type.clone(), content);
                 }
             }
 
-            // Synthesize text/llm+plain for binary images
-            if !image_descriptions.is_empty() && !output_data.contains_key("text/llm+plain") {
-                let mut parts: Vec<String> = Vec::new();
-                if let Some(DataValue::Text(ref plain)) = output_data.get("text/plain") {
-                    parts.push(plain.clone());
-                }
-                parts.extend(image_descriptions);
-                output_data.insert(
-                    "text/llm+plain".to_string(),
-                    DataValue::Text(parts.join("\n")),
-                );
-            }
-
-            // Synthesize text/llm+plain for visualization specs (Plotly, Vega-Lite, Vega)
+            // Synthesis priority: viz > heavy types > binary media.
+            // Viz summaries are more useful than "Image output (image/png, X KB)" when
+            // both exist (e.g. Altair emits png fallback + vegalite+json).
             synthesize_llm_plain_for_viz(&mut output_data);
-
-            // Synthesize text/llm+plain for other heavy types (SVG, HTML, large JSON)
             synthesize_llm_plain_for_heavy_types(&mut output_data);
+            synthesize_llm_plain_for_binary_media_with_urls(
+                &mut output_data,
+                &blob_urls_map,
+                &blob_paths_map,
+            );
 
             let mut output = if output_type == "execute_result" {
                 let execution_count = manifest.get("execution_count")?.as_i64()?;
@@ -599,6 +548,101 @@ fn synthesize_llm_plain_for_heavy_types(output_data: &mut HashMap<String, DataVa
     if let Some(DataValue::Json(ref val)) = output_data.get("application/json") {
         if let Some(summary) = repr_llm::summarize_json(val) {
             descriptions.push(summary);
+        }
+    }
+
+    if descriptions.is_empty() {
+        return;
+    }
+
+    let mut parts: Vec<String> = Vec::new();
+    if let Some(DataValue::Text(ref plain)) = output_data.get("text/plain") {
+        parts.push(plain.clone());
+    }
+    parts.extend(descriptions);
+    output_data.insert(
+        "text/llm+plain".to_string(),
+        DataValue::Text(parts.join("\n")),
+    );
+}
+
+// ── Binary media synthesis ──────────────────────────────────────────
+
+/// Synthesize `text/llm+plain` for binary media types (images, audio, video).
+///
+/// Produces a short description like "Image output (image/png, 45 KB)" or
+/// "Audio output (audio/wav, 118 KB)". Skips if `text/llm+plain` already
+/// exists (viz or heavy-type synthesis already ran).
+fn synthesize_llm_plain_for_binary_media(output_data: &mut HashMap<String, DataValue>) {
+    if output_data.contains_key("text/llm+plain") {
+        return;
+    }
+
+    let mut descriptions: Vec<String> = Vec::new();
+    for (mime, dv) in output_data.iter() {
+        if let DataValue::Binary(bytes) = dv {
+            let label = if mime.starts_with("image/") {
+                "Image"
+            } else if mime.starts_with("audio/") {
+                "Audio"
+            } else if mime.starts_with("video/") {
+                "Video"
+            } else {
+                "Binary"
+            };
+            descriptions.push(format!(
+                "{label} output ({mime}, {} KB)",
+                bytes.len() / 1024
+            ));
+        }
+    }
+
+    if descriptions.is_empty() {
+        return;
+    }
+
+    let mut parts: Vec<String> = Vec::new();
+    if let Some(DataValue::Text(ref plain)) = output_data.get("text/plain") {
+        parts.push(plain.clone());
+    }
+    parts.extend(descriptions);
+    output_data.insert(
+        "text/llm+plain".to_string(),
+        DataValue::Text(parts.join("\n")),
+    );
+}
+
+/// Like [`synthesize_llm_plain_for_binary_media`] but appends blob URLs when available.
+///
+/// Used by `output_from_manifest` where blob URL maps are already computed.
+fn synthesize_llm_plain_for_binary_media_with_urls(
+    output_data: &mut HashMap<String, DataValue>,
+    blob_urls: &HashMap<String, String>,
+    blob_paths: &HashMap<String, String>,
+) {
+    if output_data.contains_key("text/llm+plain") {
+        return;
+    }
+
+    let mut descriptions: Vec<String> = Vec::new();
+    for (mime, dv) in output_data.iter() {
+        if let DataValue::Binary(bytes) = dv {
+            let label = if mime.starts_with("image/") {
+                "Image"
+            } else if mime.starts_with("audio/") {
+                "Audio"
+            } else if mime.starts_with("video/") {
+                "Video"
+            } else {
+                "Binary"
+            };
+            let mut desc = format!("{label} output ({mime}, {} KB)", bytes.len() / 1024);
+            if let Some(url) = blob_urls.get(mime) {
+                desc.push_str(&format!("\n{url}"));
+            } else if let Some(path) = blob_paths.get(mime) {
+                desc.push_str(&format!("\n{path}"));
+            }
+            descriptions.push(desc);
         }
     }
 


### PR DESCRIPTION
## Summary

- **Fix Altair synthesis priority**: Altair emits both `image/png` (fallback) and `application/vnd.vegalite.v5+json`. Image synthesis fired first, set `text/llm+plain` to "Image output (image/png, 45 KB)", blocking the viz summary. Reordered: viz > heavy types > binary media.
- **Add audio/video `text/llm+plain` synthesis**: Only `image/*` binary types had synthesis. Audio/video outputs (e.g. `IPython.display.Audio`) now get "Audio output (audio/wav, 118 KB)" with blob URL instead of no summary.
- **Minimize structured content**: The MCP Apps widget structured content sent everything inline — `text/html` with base64 data URIs (118K+ for audio), full Plotly/Vega JSON specs (tens of KB). Now uses blob URLs for heavy types, matching the existing pattern for binary data.

Found during stress testing session that produced a 19MB conversation JSONL, driven by inline Plotly JSON blobs and audio base64.

## Test plan

- [ ] `cargo test -p runtimed-client -p runt-mcp -p repr-llm` passes
- [ ] `cargo xtask lint` passes
- [ ] MCP: execute cell with `IPython.display.Audio` → verify text output is summary, not base64
- [ ] MCP: execute cell with Altair chart (emits both png + vegalite) → verify `text/llm+plain` is viz summary
- [ ] MCP: execute cell with Plotly → verify structured content uses blob URL for JSON spec
- [ ] MCP: verify `get_cell` response size is small for all three