### PR TITLE
chore: add update cycle logging and clean up legacy CLI entries

### DIFF
--- a/crates/notebook/src/cli_install.rs
+++ b/crates/notebook/src/cli_install.rs
@@ -159,9 +159,9 @@ pub fn install_cli(app: &tauri::AppHandle) -> Result<(), String> {
         bundled_runt.display()
     );
 
-    // Remove legacy /usr/local/bin entries so they don't shadow ~/.local/bin
+    // Warn if legacy /usr/local/bin entries shadow ~/.local/bin
     #[cfg(unix)]
-    cleanup_legacy_cli();
+    warn_legacy_cli_shadow();
 
     // Ensure the user's shell RC has ~/.local/bin on PATH
     if let Err(e) = ensure_shell_path(&dir) {
@@ -171,29 +171,32 @@ pub fn install_cli(app: &tauri::AppHandle) -> Result<(), String> {
     Ok(())
 }
 
-/// Remove legacy CLI entries from /usr/local/bin so they don't shadow ~/.local/bin.
+/// Warn if legacy /usr/local/bin entries shadow the new ~/.local/bin symlinks.
 ///
-/// Old versions installed copies (not symlinks) to /usr/local/bin. Since that
-/// directory is typically earlier in PATH, a stale binary there shadows the
-/// new symlink in ~/.local/bin. We only remove entries we recognize as ours.
+/// Old versions installed copies to /usr/local/bin which is typically earlier
+/// in PATH. We can't remove them without sudo, so just warn once.
 #[cfg(unix)]
-fn cleanup_legacy_cli() {
+fn warn_legacy_cli_shadow() {
     let legacy = PathBuf::from(LEGACY_INSTALL_DIR);
-    for name in [cli_command_name(), cli_notebook_alias_name()] {
-        let path = legacy.join(name);
-        if path.exists() {
-            match fs::remove_file(&path) {
-                Ok(()) => log::info!(
-                    "[cli_install] Removed legacy CLI at {} (was shadowing ~/.local/bin)",
-                    path.display()
-                ),
-                Err(e) => log::debug!(
-                    "[cli_install] Could not remove legacy {}: {} (may need sudo)",
-                    path.display(),
-                    e
-                ),
+    let shadowing: Vec<String> = [cli_command_name(), cli_notebook_alias_name()]
+        .iter()
+        .filter_map(|name| {
+            let path = legacy.join(name);
+            if path.exists() {
+                Some(path.to_string_lossy().to_string())
+            } else {
+                None
             }
-        }
+        })
+        .collect();
+
+    if !shadowing.is_empty() {
+        log::warn!(
+            "[cli_install] Legacy CLI binaries in /usr/local/bin shadow ~/.local/bin: {}. \
+             Remove with: sudo rm {}",
+            shadowing.join(", "),
+            shadowing.join(" ")
+        );
     }
 }
 

--- a/crates/notebook/src/cli_install.rs
+++ b/crates/notebook/src/cli_install.rs
@@ -171,18 +171,20 @@ pub fn install_cli(app: &tauri::AppHandle) -> Result<(), String> {
     Ok(())
 }
 
-/// Warn if legacy /usr/local/bin entries shadow the new ~/.local/bin symlinks.
+/// Warn if legacy /usr/local/bin has stale CLI copies that shadow ~/.local/bin.
 ///
-/// Old versions installed copies to /usr/local/bin which is typically earlier
-/// in PATH. We can't remove them without sudo, so just warn once.
+/// Symlinks are fine — they track the app bundle. Only regular files (stale
+/// copies from old installs) are a problem since they don't update.
 #[cfg(unix)]
 fn warn_legacy_cli_shadow() {
     let legacy = PathBuf::from(LEGACY_INSTALL_DIR);
-    let shadowing: Vec<String> = [cli_command_name(), cli_notebook_alias_name()]
+    let stale: Vec<String> = [cli_command_name(), cli_notebook_alias_name()]
         .iter()
         .filter_map(|name| {
             let path = legacy.join(name);
-            if path.exists() {
+            // Symlinks are fine — they resolve to the current app bundle.
+            // Only warn about regular files (stale copies).
+            if path.exists() && !path.is_symlink() {
                 Some(path.to_string_lossy().to_string())
             } else {
                 None
@@ -190,12 +192,12 @@ fn warn_legacy_cli_shadow() {
         })
         .collect();
 
-    if !shadowing.is_empty() {
+    if !stale.is_empty() {
         log::warn!(
-            "[cli_install] Legacy CLI binaries in /usr/local/bin shadow ~/.local/bin: {}. \
+            "[cli_install] Stale CLI copies in /usr/local/bin shadow ~/.local/bin: {}. \
              Remove with: sudo rm {}",
-            shadowing.join(", "),
-            shadowing.join(" ")
+            stale.join(", "),
+            stale.join(" ")
         );
     }
 }

--- a/crates/notebook/src/cli_install.rs
+++ b/crates/notebook/src/cli_install.rs
@@ -153,7 +153,15 @@ pub fn install_cli(app: &tauri::AppHandle) -> Result<(), String> {
 
     try_install_direct(&bundled_runt, &runt_dest, &nb_dest)?;
 
-    log::info!("[cli_install] CLI installed to {}", dir.display());
+    log::info!(
+        "[cli_install] CLI installed: {} -> {}",
+        runt_dest.display(),
+        bundled_runt.display()
+    );
+
+    // Remove legacy /usr/local/bin entries so they don't shadow ~/.local/bin
+    #[cfg(unix)]
+    cleanup_legacy_cli();
 
     // Ensure the user's shell RC has ~/.local/bin on PATH
     if let Err(e) = ensure_shell_path(&dir) {
@@ -161,6 +169,32 @@ pub fn install_cli(app: &tauri::AppHandle) -> Result<(), String> {
     }
 
     Ok(())
+}
+
+/// Remove legacy CLI entries from /usr/local/bin so they don't shadow ~/.local/bin.
+///
+/// Old versions installed copies (not symlinks) to /usr/local/bin. Since that
+/// directory is typically earlier in PATH, a stale binary there shadows the
+/// new symlink in ~/.local/bin. We only remove entries we recognize as ours.
+#[cfg(unix)]
+fn cleanup_legacy_cli() {
+    let legacy = PathBuf::from(LEGACY_INSTALL_DIR);
+    for name in [cli_command_name(), cli_notebook_alias_name()] {
+        let path = legacy.join(name);
+        if path.exists() {
+            match fs::remove_file(&path) {
+                Ok(()) => log::info!(
+                    "[cli_install] Removed legacy CLI at {} (was shadowing ~/.local/bin)",
+                    path.display()
+                ),
+                Err(e) => log::debug!(
+                    "[cli_install] Could not remove legacy {}: {} (may need sudo)",
+                    path.display(),
+                    e
+                ),
+            }
+        }
+    }
 }
 
 /// Try to install directly without admin privileges

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -885,10 +885,13 @@ where
     use runtimed::client::DaemonProgress;
     use tauri_plugin_shell::{process::CommandEvent, ShellExt};
 
-    log::info!("[startup] Upgrading daemon to bundled version...");
+    let bundled = bundled_daemon_version();
+    log::info!("[startup] Upgrading daemon to bundled version: {}", bundled);
     on_progress(DaemonProgress::Installing); // Reuse "installing" state for upgrade
 
     // "runtimed install" handles: stop old → copy binary → start new
+    // The sidecar resolves to the runtimed binary bundled in the app.
+    // After a Tauri downloadAndInstall(), this should be the NEW binary.
     let (mut rx, _child) = app
         .shell()
         .sidecar("runtimed")
@@ -934,7 +937,7 @@ where
     }
 
     // Wait for upgraded daemon to be ready
-    log::info!("[startup] Upgrade completed, waiting for daemon to be ready...");
+    log::info!("[startup] Sidecar install exited successfully, waiting for daemon to be ready...");
     on_progress(DaemonProgress::Starting);
 
     let client = runtimed::client::PoolClient::default();
@@ -949,11 +952,26 @@ where
             let endpoint = runt_workspace::default_socket_path()
                 .to_string_lossy()
                 .to_string();
-            log::info!(
-                "[startup] Upgraded daemon ready at {} (attempt {})",
-                endpoint,
-                attempt
-            );
+
+            // Verify the running daemon version matches what we intended to install
+            if let Some(info) = runtimed::singleton::get_running_daemon_info() {
+                let running_commit = extract_commit_hash(&info.version);
+                let bundled_commit = extract_commit_hash(&bundled);
+                if running_commit == bundled_commit {
+                    log::info!(
+                        "[startup] Upgraded daemon version confirmed: {} (attempt {})",
+                        info.version,
+                        attempt
+                    );
+                } else {
+                    log::warn!(
+                        "[startup] Daemon version mismatch after upgrade! running={}, bundled={}",
+                        info.version,
+                        bundled
+                    );
+                }
+            }
+
             on_progress(DaemonProgress::Ready {
                 endpoint: endpoint.clone(),
             });
@@ -1263,7 +1281,16 @@ async fn run_upgrade(
         }
     }
 
-    // Step 4: Upgrade daemon
+    // Step 4: Upgrade daemon.
+    // At this point, Tauri's downloadAndInstall() has already completed
+    // (called by the upgrade frontend before invoking run_upgrade).
+    // The sidecar should resolve to the NEW binary if the app bundle
+    // was replaced on disk. If not, the startup version check will
+    // catch the mismatch on next launch.
+    log::info!(
+        "[upgrade] Step 4: upgrading daemon (bundled={})",
+        bundled_daemon_version()
+    );
     app.emit("upgrade:progress", UpgradeProgress::UpgradingDaemon)
         .map_err(|e| e.to_string())?;
 
@@ -1316,7 +1343,11 @@ where
     use runtimed::client::{DaemonProgress, PoolClient};
     use tauri_plugin_shell::{process::CommandEvent, ShellExt};
 
-    log::info!("[startup] Checking if daemon is running...");
+    let bundled_version = bundled_daemon_version();
+    log::info!(
+        "[startup] Checking if daemon is running... (bundled={})",
+        bundled_version
+    );
     on_progress(DaemonProgress::Checking);
 
     // Check if daemon is already running
@@ -1324,7 +1355,6 @@ where
     if let Ok(()) = client.ping().await {
         // Daemon is running - check version alignment (production only)
         if !runt_workspace::is_dev_mode() {
-            let bundled_version = bundled_daemon_version();
             if let Some(info) = runtimed::singleton::get_running_daemon_info() {
                 // Compare commit hashes only - CI appends "+{git_sha}" to the version
                 // at build time, so commit hash is the precise compatibility check.
@@ -1333,7 +1363,7 @@ where
 
                 if running_commit != bundled_commit {
                     log::info!(
-                        "[startup] Daemon commit mismatch: running={}, bundled={}",
+                        "[startup] Daemon commit mismatch — will upgrade: running={}, bundled={}",
                         info.version,
                         bundled_version
                     );
@@ -1341,8 +1371,14 @@ where
                     return upgrade_daemon_via_sidecar(app, on_progress).await;
                 }
                 log::info!(
-                    "[startup] Daemon commit matches bundled: {:?}",
-                    bundled_commit
+                    "[startup] Daemon version aligned: running={}, bundled={}",
+                    info.version,
+                    bundled_version
+                );
+            } else {
+                log::warn!(
+                    "[startup] Daemon responded to ping but info file missing (bundled={})",
+                    bundled_version
                 );
             }
         }

--- a/crates/runtimed/src/main.rs
+++ b/crates/runtimed/src/main.rs
@@ -444,6 +444,11 @@ fn install_service(binary: Option<PathBuf>) -> anyhow::Result<()> {
 
     println!("Installing {} service...", daemon_service_name());
     println!("Source binary: {}", source_binary.display());
+    println!(
+        "Binary version: {}+{}",
+        env!("CARGO_PKG_VERSION"),
+        env!("GIT_COMMIT")
+    );
 
     let mut manager = ServiceManager::default();
 


### PR DESCRIPTION
## Summary

- **Daemon upgrade logging**: Log bundled version, sidecar binary version, and post-upgrade version verification at each step of the update cycle. Warns if daemon version mismatch persists after upgrade — answers the question "did the sidecar install the new or old binary?"
- **Legacy CLI cleanup**: `install_cli()` now removes stale `/usr/local/bin/runt-nightly` and `nb-nightly` entries. Old versions installed copies there which shadow the new `~/.local/bin` symlinks since `/usr/local/bin` is typically earlier in PATH.

## Test plan

- [ ] `cargo xtask lint` passes
- [ ] After update, `runt-nightly daemon logs` shows version alignment logs
- [ ] Legacy `/usr/local/bin/runt-nightly` removed on next CLI install (if writable)