### PR TITLE
fix(frontend): force CodeMirror repaint on window reactivation

### DIFF
--- a/apps/notebook/src/lib/window-focus.ts
+++ b/apps/notebook/src/lib/window-focus.ts
@@ -133,6 +133,11 @@ function restoreEditorFocus(): void {
       view.contentDOM.blur();
     }
     view.focus();
+    // Force CM to re-measure and repaint its viewport. Without this,
+    // WKWebView may not composite the editor layer after window
+    // reactivation, causing the editor to appear blank until user
+    // interaction triggers a repaint.
+    view.requestMeasure();
   } catch (e) {
     logger.warn("[window-focus] Focus cycle failed:", e);
     return;


### PR DESCRIPTION
## Summary

- Adds `view.requestMeasure()` after the blur→focus cycle in `window-focus.ts` to force CodeMirror to re-measure and repaint its viewport on window reactivation
- Fixes an issue where the CM editor appears blank momentarily when clicking back into the app, caused by WKWebView not flushing the compositor layer after the window regains focus

## Test plan

- [ ] Cmd+Tab away from the notebook and back — editor should remain visible without needing to click
- [ ] Click on another app window, then click back into the notebook — no blank flash
- [ ] Verify keystrokes still work immediately on window refocus (existing behavior preserved)