### PR TITLE
fix(vega): add error handling and switch to canvas renderer

### DIFF
--- a/src/components/isolated/iframe-libraries.ts
+++ b/src/components/isolated/iframe-libraries.ts
@@ -116,6 +116,7 @@ export async function injectLibraries(
     const code = await loadLibraryCode(name);
     // Idempotent guard inside the iframe (belt + suspenders with injectedSet)
     const guard = `__LIB_${name.toUpperCase()}__`;
+    console.debug(`[iframe-libraries] injecting "${name}" (${(code.length / 1024).toFixed(0)}KB)`);
     frame.eval(
       `if(!window.${guard}){window.${guard}=true;\n${code}\n}`,
     );

--- a/src/components/outputs/__tests__/vega-output.test.tsx
+++ b/src/components/outputs/__tests__/vega-output.test.tsx
@@ -50,7 +50,7 @@ describe("VegaOutput", () => {
     expect(el).toBeInstanceOf(HTMLDivElement);
     expect(spec.background).toBe("transparent");
     expect(opts.actions).toBe(false);
-    expect(opts.renderer).toBe("svg");
+    expect(opts.renderer).toBe("canvas");
   });
 
   it("forces transparent background on the spec", () => {

--- a/src/components/outputs/vega-output.tsx
+++ b/src/components/outputs/vega-output.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
 
 interface VegaOutputProps {
@@ -14,7 +14,7 @@ interface VegaView {
 function embedOptions(isDark: boolean) {
   return {
     actions: false,
-    renderer: "svg" as const,
+    renderer: "canvas" as const,
     theme: isDark ? ("dark" as const) : undefined,
   };
 }
@@ -28,8 +28,11 @@ function embedOptions(isDark: boolean) {
  */
 export function VegaOutput({ data, className }: VegaOutputProps) {
   const containerRef = useRef<HTMLDivElement>(null);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
+    setError(null);
+
     // biome-ignore lint/suspicious/noExplicitAny: vega-embed is injected as a global
     const vegaEmbed = (window as any).vegaEmbed;
     if (!containerRef.current || !data || !vegaEmbed) return;
@@ -48,6 +51,10 @@ export function VegaOutput({ data, className }: VegaOutputProps) {
       (result: { view: VegaView }) => {
         view = result.view;
       },
+      (err: Error) => {
+        console.error("[VegaOutput] embed failed:", err);
+        setError(err.message || String(err));
+      },
     );
 
     const themeObserver = new MutationObserver(() => {
@@ -56,6 +63,9 @@ export function VegaOutput({ data, className }: VegaOutputProps) {
       vegaEmbed(el, spec, embedOptions(nowDark)).then(
         (result: { view: VegaView }) => {
           view = result.view;
+        },
+        (err: Error) => {
+          console.error("[VegaOutput] embed failed on theme change:", err);
         },
       );
     });
@@ -72,11 +82,27 @@ export function VegaOutput({ data, className }: VegaOutputProps) {
 
   if (!data) return null;
 
+  // biome-ignore lint/suspicious/noExplicitAny: vega-embed is injected as a global
+  const vegaEmbed = (window as any).vegaEmbed;
+  if (!vegaEmbed) {
+    return (
+      <div className="text-sm text-muted-foreground py-2">
+        Vega library not loaded — chart cannot be rendered.
+      </div>
+    );
+  }
+
   return (
     <div
       ref={containerRef}
       data-slot="vega-output"
-      className={cn("not-prose py-2 max-w-full", className)}
-    />
+      className={cn("not-prose py-2 max-w-full overflow-visible", className)}
+    >
+      {error && (
+        <div className="text-sm text-destructive py-1">
+          Vega rendering error: {error}
+        </div>
+      )}
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

- Add `.catch()` to both `vegaEmbed()` calls — previously errors were silently swallowed, making intermittent Altair interactive mode failures invisible
- Show error state in the output area when vega-embed fails, and a fallback message when the library isn't loaded
- Switch from `renderer: "svg"` to `renderer: "canvas"` — canvas is vega-embed's default and handles interactive signals (zoom/pan/selections from `.interactive()`) more reliably
- Add `overflow-visible` to the vega container so tooltips and interactive brush overlays aren't clipped by the iframe body's `overflow: hidden`
- Add `console.debug` logging for library injection to help diagnose injection failures

## Test plan

- [x] `pnpm test:run` passes (40/40 test files)
- [x] `cargo xtask lint` passes
- [ ] Manual: Altair `.interactive()` chart — zoom/pan should work
- [ ] Manual: Altair selection (brush, click) — selections should work
- [ ] Manual: Basic chart without interactivity renders normally
- [ ] Manual: Tooltips visible and not clipped
- [ ] Manual: If vega-embed fails, error is visible in output area