### PR TITLE
feat(frontend): virtualized cell list with pretext height estimation

### DIFF
--- a/apps/notebook/package.json
+++ b/apps/notebook/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@chenglou/pretext": "^0.0.4",
     "@codemirror/autocomplete": "^6.20.0",
     "@codemirror/commands": "^6.10.2",
     "@codemirror/lang-html": "^6.4.11",

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -445,7 +445,7 @@ function NotebookViewContent({
     useVirtualCells({
       cellIds,
       scrollContainerRef: containerRef,
-      overscan: 4,
+      overscan: 16,
       isDragging: activeId !== null,
       forceInclude,
     });
@@ -840,7 +840,7 @@ function NotebookViewContent({
   return (
     <div
       ref={containerRef}
-      className="flex-1 overflow-y-auto overflow-x-clip overscroll-x-contain pl-8 pr-2"
+      className="flex-1 overflow-y-auto overflow-x-clip overscroll-x-contain pb-16 pl-8 pr-2"
       style={{ contain: "paint", overflowAnchor: "none" }}
       onScroll={onScroll}
       data-notebook-synced={!isLoading && cellIds.length > 0}

--- a/apps/notebook/src/components/NotebookView.tsx
+++ b/apps/notebook/src/components/NotebookView.tsx
@@ -27,9 +27,15 @@ import {
   EditorRegistryProvider,
   useEditorRegistry,
 } from "../hooks/useEditorRegistry";
+import { useVirtualCells } from "../hooks/useVirtualCells";
+import {
+  setMeasuredCellHeight,
+  updateHeightCache,
+} from "../lib/cell-height-cache";
 import { useFocusedCellId, useSearchCurrentMatch } from "../lib/cell-ui-state";
 import { logger } from "../lib/logger";
 import {
+  getCellById,
   getNotebookCellsSnapshot,
   useCell,
   useMaterializeVersion,
@@ -271,6 +277,7 @@ function SortableCell({
   cellId,
   nextCellId,
   index,
+  top,
   renderCell,
   onAddCell,
   onDeleteCell,
@@ -279,6 +286,8 @@ function SortableCell({
   cellId: string;
   nextCellId?: string;
   index: number;
+  /** Absolute top offset in px (from cell height cache). */
+  top: number;
   renderCell: (
     cell: NotebookCell,
     index: number,
@@ -291,6 +300,7 @@ function SortableCell({
 }) {
   const cell = useCell(cellId);
   const nextCell = useCell(nextCellId ?? "");
+  const measureRef = useRef<HTMLDivElement | null>(null);
   const {
     attributes,
     listeners,
@@ -301,10 +311,36 @@ function SortableCell({
   } = useSortable({ id: cellId });
 
   const style: React.CSSProperties = {
+    position: "absolute",
+    top,
+    left: 0,
+    right: 0,
     transform: DndCSS.Transform.toString(transform),
     transition,
-    order: index,
   };
+
+  // Measure actual cell height via ResizeObserver for scroll accuracy
+  useEffect(() => {
+    const el = measureRef.current;
+    if (!el) return;
+    const ro = new ResizeObserver((entries) => {
+      const height =
+        entries[0]?.borderBoxSize?.[0]?.blockSize ??
+        el.getBoundingClientRect().height;
+      setMeasuredCellHeight(cellId, height);
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [cellId]);
+
+  // Combined ref for dnd-kit and measurement
+  const combinedRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      setNodeRef(node);
+      measureRef.current = node;
+    },
+    [setNodeRef],
+  );
 
   // Combine listeners and attributes for the drag handle
   // This enables keyboard-initiated dragging (Space/Enter + arrows)
@@ -314,7 +350,7 @@ function SortableCell({
   };
 
   if (isHiddenInGroup) {
-    return <div ref={setNodeRef} style={style} />;
+    return <div ref={combinedRef} style={style} />;
   }
 
   const cellType = cell?.cell_type ?? "code";
@@ -322,7 +358,7 @@ function SortableCell({
   const nextCellType = nextCell?.cell_type ?? cellType;
 
   return (
-    <div ref={setNodeRef} style={style}>
+    <div ref={combinedRef} style={style}>
       {index === 0 && (
         <CellAdder afterCellId={null} onAdd={onAddCell} cellType={cellType} />
       )}
@@ -385,6 +421,35 @@ function NotebookViewContent({
   // Drag-and-drop state
   const [activeId, setActiveId] = useState<string | null>(null);
 
+  // ── Height cache ─────────────────────────────────────────────────────
+  // Feed cell data to the height cache for pretext-based height estimation.
+  // Re-runs on structural changes and materializations (output/source changes).
+  // biome-ignore lint/correctness/useExhaustiveDependencies: materializeVersion triggers re-read of cell data via getCellById
+  useEffect(() => {
+    const cellMap = new Map<string, NotebookCell>();
+    for (const id of cellIds) {
+      const cell = getCellById(id);
+      if (cell) cellMap.set(id, cell);
+    }
+    updateHeightCache(cellMap);
+  }, [cellIds, materializeVersion]);
+
+  // ── Virtual cells ────────────────────────────────────────────────────
+  const forceInclude = useMemo(() => {
+    const ids: string[] = [];
+    if (searchCurrentMatch) ids.push(searchCurrentMatch.cellId);
+    return ids;
+  }, [searchCurrentMatch]);
+
+  const { visibleCellIds, totalHeight, cellOffsets, onScroll } =
+    useVirtualCells({
+      cellIds,
+      scrollContainerRef: containerRef,
+      overscan: 4,
+      isDragging: activeId !== null,
+      forceInclude,
+    });
+
   // Configure dnd-kit sensors
   const sensors = useSensors(
     useSensor(PointerSensor, {
@@ -428,12 +493,14 @@ function NotebookViewContent({
     [cellIds, onMoveCell],
   );
 
-  // IMPORTANT: Stable DOM order — do NOT replace with cellIds.map() directly.
-  // Cells are rendered in sorted-ID order so React never calls insertBefore on
-  // existing DOM nodes. Visual ordering uses CSS `order` on each cell wrapper.
-  // Without this, moving a cell causes browsers to reload iframes (destroying
-  // content, widgets, and theme state). See CLAUDE.md § "Cell List Stable DOM Order".
-  const stableDomOrder = useMemo(() => [...cellIds].sort(), [cellIds]);
+  // Stable DOM order filtered to only visible cells. Absolute positioning means
+  // adding/removing cells never triggers insertBefore on siblings (safer than
+  // the old flex+order approach for iframes). We still sort by ID for React
+  // key stability.
+  const stableDomOrder = useMemo(
+    () => [...cellIds].filter((id) => visibleCellIds.has(id)).sort(),
+    [cellIds, visibleCellIds],
+  );
 
   // Map cell ID → visual index for O(1) lookup
   const cellIdToIndex = useMemo(() => {
@@ -773,8 +840,9 @@ function NotebookViewContent({
   return (
     <div
       ref={containerRef}
-      className="flex-1 overflow-y-auto overflow-x-clip overscroll-x-contain py-4 pl-8 pr-2"
+      className="flex-1 overflow-y-auto overflow-x-clip overscroll-x-contain pl-8 pr-2"
       style={{ contain: "paint", overflowAnchor: "none" }}
+      onScroll={onScroll}
       data-notebook-synced={!isLoading && cellIds.length > 0}
       data-cell-count={cellIds.length}
     >
@@ -819,7 +887,7 @@ function NotebookViewContent({
             items={cellIds}
             strategy={verticalListSortingStrategy}
           >
-            <div style={{ display: "flex", flexDirection: "column" }}>
+            <div style={{ position: "relative", height: totalHeight }}>
               {stableDomOrder.map((cellId) => {
                 const index = cellIdToIndex.get(cellId) ?? 0;
                 const group = hiddenGroups.get(cellId);
@@ -829,6 +897,7 @@ function NotebookViewContent({
                     cellId={cellId}
                     nextCellId={cellIds[index + 1]}
                     index={index}
+                    top={cellOffsets.get(cellId) ?? 0}
                     renderCell={renderCell}
                     onAddCell={onAddCell}
                     onDeleteCell={onDeleteCell}

--- a/apps/notebook/src/hooks/useVirtualCells.ts
+++ b/apps/notebook/src/hooks/useVirtualCells.ts
@@ -1,0 +1,235 @@
+/**
+ * useVirtualCells — compute which cells to render for a virtualized cell list.
+ *
+ * Uses the cell height cache (pretext-measured heights) and the current scroll
+ * position to binary-search the visible range. Returns only the cell IDs that
+ * should be mounted in the DOM, plus layout metadata for absolute positioning.
+ *
+ * Binary search algorithm adapted from @chenglou/pretext's findVisibleRange
+ * in the markdown-chat demo.
+ */
+
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useSyncExternalStore,
+} from "react";
+import {
+  getCumulativeOffsets,
+  getHeightVersion,
+  getTotalHeight,
+  setContainerWidth,
+  subscribeHeightChanges,
+} from "../lib/cell-height-cache";
+import { useFocusedCellId } from "../lib/cell-ui-state";
+
+// ── Binary search ──────────────────────────────────────────────────────
+
+/**
+ * Find the range of cells visible in the viewport.
+ * offsets[i] = top of cell i, offsets[i+1] = bottom of cell i.
+ */
+function findVisibleRange(
+  offsets: Float64Array,
+  scrollTop: number,
+  viewportHeight: number,
+): { start: number; end: number } {
+  const count = offsets.length - 1; // number of cells
+  if (count === 0) return { start: 0, end: 0 };
+
+  const minY = scrollTop;
+  const maxY = scrollTop + viewportHeight;
+
+  // Find first cell whose bottom edge > scrollTop
+  let low = 0;
+  let high = count;
+  while (low < high) {
+    const mid = (low + high) >> 1;
+    if (offsets[mid + 1] > minY) {
+      high = mid;
+    } else {
+      low = mid + 1;
+    }
+  }
+  const start = low;
+
+  // Find first cell whose top edge >= scrollTop + viewportHeight
+  low = start;
+  high = count;
+  while (low < high) {
+    const mid = (low + high) >> 1;
+    if (offsets[mid] >= maxY) {
+      high = mid;
+    } else {
+      low = mid + 1;
+    }
+  }
+
+  return { start, end: low };
+}
+
+// ── Scroll state ───────────────────────────────────────────────────────
+
+/** Lightweight scroll position tracking without React re-renders. */
+function useScrollPosition(containerRef: React.RefObject<HTMLElement | null>) {
+  const scrollTop = useRef(0);
+  const clientHeight = useRef(0);
+  const version = useRef(0);
+  const subscribers = useRef(new Set<() => void>());
+
+  const onScroll = useCallback(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const newScrollTop = el.scrollTop;
+    const newClientHeight = el.clientHeight;
+    if (
+      newScrollTop === scrollTop.current &&
+      newClientHeight === clientHeight.current
+    )
+      return;
+    scrollTop.current = newScrollTop;
+    clientHeight.current = newClientHeight;
+    version.current++;
+    for (const cb of subscribers.current) cb();
+  }, [containerRef]);
+
+  const subscribe = useCallback((cb: () => void) => {
+    subscribers.current.add(cb);
+    return () => subscribers.current.delete(cb);
+  }, []);
+
+  const getSnapshot = useCallback(() => version.current, []);
+
+  return { scrollTop, clientHeight, onScroll, subscribe, getSnapshot };
+}
+
+// ── Main hook ──────────────────────────────────────────────────────────
+
+interface UseVirtualCellsOptions {
+  cellIds: string[];
+  scrollContainerRef: React.RefObject<HTMLElement | null>;
+  /** Number of cells to render above/below the viewport. Default 4. */
+  overscan?: number;
+  /** Whether drag is active — disables virtualization. */
+  isDragging?: boolean;
+  /** Additional cell IDs to always render (search matches, executing cells, etc.). */
+  forceInclude?: string[];
+}
+
+interface UseVirtualCellsResult {
+  /** Cell IDs to actually mount in the DOM. */
+  visibleCellIds: Set<string>;
+  /** Total scrollable height in px. */
+  totalHeight: number;
+  /** Map from cellId → top offset in px. */
+  cellOffsets: Map<string, number>;
+  /** Scroll event handler — attach to the scroll container. */
+  onScroll: () => void;
+}
+
+export function useVirtualCells({
+  cellIds,
+  scrollContainerRef,
+  overscan = 4,
+  isDragging = false,
+  forceInclude,
+}: UseVirtualCellsOptions): UseVirtualCellsResult {
+  const focusedCellId = useFocusedCellId();
+  const scroll = useScrollPosition(scrollContainerRef);
+
+  // Subscribe to both scroll changes and height cache changes
+  const subscribe = useCallback(
+    (cb: () => void) => {
+      const unsub1 = scroll.subscribe(cb);
+      const unsub2 = subscribeHeightChanges(cb);
+      return () => {
+        unsub1();
+        unsub2();
+      };
+    },
+    [scroll],
+  );
+
+  // Combined version — changes when scroll or heights change
+  const getSnapshot = useCallback(
+    () => scroll.getSnapshot() + getHeightVersion() * 1e9,
+    [scroll],
+  );
+
+  // Track container width for pretext layout
+  useEffect(() => {
+    const el = scrollContainerRef.current;
+    if (!el) return;
+    const ro = new ResizeObserver((entries) => {
+      const width = entries[0]?.contentRect.width;
+      if (width !== undefined) setContainerWidth(width);
+    });
+    ro.observe(el);
+    // Initial measurement
+    setContainerWidth(el.clientWidth);
+    return () => ro.disconnect();
+  }, [scrollContainerRef]);
+
+  // Subscribe so React re-renders when the visible range changes
+  useSyncExternalStore(subscribe, getSnapshot);
+
+  // Compute offsets, visible range, and force-includes
+  return useMemo(() => {
+    const offsets = getCumulativeOffsets(cellIds);
+    const totalHeight = getTotalHeight(cellIds);
+
+    // Build cellId → offset map for all cells (needed for absolute positioning)
+    const cellOffsets = new Map<string, number>();
+    for (let i = 0; i < cellIds.length; i++) {
+      cellOffsets.set(cellIds[i], offsets[i]);
+    }
+
+    // During drag, render all cells
+    if (isDragging) {
+      return {
+        visibleCellIds: new Set(cellIds),
+        totalHeight,
+        cellOffsets,
+        onScroll: scroll.onScroll,
+      };
+    }
+
+    // Binary search for visible range
+    const { start, end } = findVisibleRange(
+      offsets,
+      scroll.scrollTop.current,
+      scroll.clientHeight.current || 800, // fallback before first measure
+    );
+
+    // Expand by overscan
+    const overscanStart = Math.max(0, start - overscan);
+    const overscanEnd = Math.min(cellIds.length, end + overscan);
+
+    // Build visible set
+    const visibleCellIds = new Set<string>();
+    for (let i = overscanStart; i < overscanEnd; i++) {
+      visibleCellIds.add(cellIds[i]);
+    }
+
+    // Force-include focused cell
+    if (focusedCellId) {
+      visibleCellIds.add(focusedCellId);
+    }
+
+    // Force-include additional cells (search matches, executing, etc.)
+    if (forceInclude) {
+      for (const id of forceInclude) {
+        visibleCellIds.add(id);
+      }
+    }
+
+    return {
+      visibleCellIds,
+      totalHeight,
+      cellOffsets,
+      onScroll: scroll.onScroll,
+    };
+  }, [cellIds, isDragging, focusedCellId, forceInclude, scroll, overscan]);
+}

--- a/apps/notebook/src/lib/cell-height-cache.ts
+++ b/apps/notebook/src/lib/cell-height-cache.ts
@@ -1,0 +1,341 @@
+/**
+ * Cell height cache — pretext-based height estimation for virtualized rendering.
+ *
+ * Uses @chenglou/pretext to measure code cell source heights without DOM.
+ * Output heights are estimated by type until the cell renders, at which point
+ * a ResizeObserver measurement replaces the estimate.
+ *
+ * Same useSyncExternalStore pattern as notebook-cells.ts.
+ */
+
+import { layout, type PreparedText, prepare } from "@chenglou/pretext";
+import type { JupyterOutput, NotebookCell } from "../types";
+
+// ── Constants ──────────────────────────────────────────────────────────
+
+/** Font shorthand matching the CodeMirror editor CSS. */
+const CODE_FONT = '14px "SF Mono", Consolas, Monaco, "Andale Mono", monospace';
+
+/** CodeMirror default line height factor. */
+const CODE_LINE_HEIGHT = 19.6; // 14px × 1.4
+
+/** Estimated cell chrome: gutter, padding, adder row between cells. */
+const DEFAULT_CHROME_HEIGHT = 84;
+
+/** Markdown cell chrome (no output area). */
+const MARKDOWN_CHROME_HEIGHT = 56;
+
+// ── Output height estimation defaults ──────────────────────────────────
+
+const OUTPUT_HEIGHT_DEFAULTS: Record<string, number> = {
+  "text/html": 200,
+  "image/png": 300,
+  "image/jpeg": 300,
+  "image/svg+xml": 250,
+  "image/gif": 200,
+  "application/vnd.vegalite.v5+json": 350,
+  "application/vnd.vegalite.v4+json": 350,
+  "application/vnd.vegalite.v3+json": 350,
+  "application/vnd.plotly.v1+json": 400,
+  "application/pdf": 500,
+  "text/markdown": 100,
+  "text/latex": 80,
+  "application/vnd.jupyter.widget-view+json": 200,
+};
+const DEFAULT_OUTPUT_ESTIMATE = 150;
+
+// ── Per-cell entry ─────────────────────────────────────────────────────
+
+interface CellHeightEntry {
+  sourceHeight: number;
+  outputHeight: number;
+  chromeHeight: number;
+  totalHeight: number;
+  /** Cached pretext PreparedText handle. null for markdown/raw with no source. */
+  prepared: PreparedText | null;
+  /** The source string that was prepared (for change detection). */
+  preparedSource: string;
+  /** Whether outputHeight came from a DOM measurement vs estimation. */
+  outputMeasured: boolean;
+}
+
+// ── State ──────────────────────────────────────────────────────────────
+
+const _entries = new Map<string, CellHeightEntry>();
+let _containerWidth = 600; // reasonable initial guess
+let _version = 0;
+const _subscribers = new Set<() => void>();
+
+function emit(): void {
+  _version++;
+  for (const cb of _subscribers) cb();
+}
+
+// ── Public subscription API ────────────────────────────────────────────
+
+export function subscribeHeightChanges(cb: () => void): () => void {
+  _subscribers.add(cb);
+  return () => _subscribers.delete(cb);
+}
+
+export function getHeightVersion(): number {
+  return _version;
+}
+
+// ── Height queries ─────────────────────────────────────────────────────
+
+/** Get the total height of all cells in order. */
+export function getTotalHeight(cellIds: string[]): number {
+  let total = 0;
+  for (const id of cellIds) {
+    total += _entries.get(id)?.totalHeight ?? DEFAULT_CHROME_HEIGHT;
+  }
+  return total;
+}
+
+/**
+ * Build cumulative offsets array for binary search.
+ * offsets[i] = top position of cell i (sum of heights of cells 0..i-1).
+ * offsets[cellIds.length] = total height.
+ */
+export function getCumulativeOffsets(cellIds: string[]): Float64Array {
+  const offsets = new Float64Array(cellIds.length + 1);
+  let y = 0;
+  for (let i = 0; i < cellIds.length; i++) {
+    offsets[i] = y;
+    y += _entries.get(cellIds[i])?.totalHeight ?? DEFAULT_CHROME_HEIGHT;
+  }
+  offsets[cellIds.length] = y;
+  return offsets;
+}
+
+/** Get height of a single cell. */
+export function getCellHeight(cellId: string): number {
+  return _entries.get(cellId)?.totalHeight ?? DEFAULT_CHROME_HEIGHT;
+}
+
+// ── Preparation ────────────────────────────────────────────────────────
+
+function prepareSource(source: string): PreparedText | null {
+  if (!source) return null;
+  return prepare(source, CODE_FONT, { whiteSpace: "pre-wrap" });
+}
+
+function computeSourceHeight(
+  prepared: PreparedText | null,
+  width: number,
+): number {
+  if (!prepared) return 0;
+  // Reserve at least one line of space even for empty-ish cells
+  const contentWidth = Math.max(width - 88, 100); // gutter + ribbon + padding
+  const { height } = layout(prepared, contentWidth, CODE_LINE_HEIGHT);
+  return height;
+}
+
+function estimateOutputHeight(outputs: JupyterOutput[]): number {
+  if (outputs.length === 0) return 0;
+
+  let total = 0;
+  for (const output of outputs) {
+    if (output.output_type === "stream") {
+      // Use pretext for stream text
+      const text = output.text;
+      if (text) {
+        const p = prepare(text, CODE_FONT, { whiteSpace: "pre-wrap" });
+        const contentWidth = Math.max(_containerWidth - 88, 100);
+        total += layout(p, contentWidth, CODE_LINE_HEIGHT).height;
+      } else {
+        total += CODE_LINE_HEIGHT;
+      }
+    } else if (output.output_type === "error") {
+      // Estimate from traceback lines
+      const lineCount = output.traceback?.length ?? 1;
+      total += lineCount * CODE_LINE_HEIGHT * 2; // traceback lines tend to be multi-line
+    } else {
+      // display_data / execute_result — inspect MIME types
+      const data = output.data;
+      if (data) {
+        // Use the highest-priority MIME type for estimation
+        if ("text/plain" in data && Object.keys(data).length === 1) {
+          const text = data["text/plain"] as string;
+          const p = prepare(text, CODE_FONT, { whiteSpace: "pre-wrap" });
+          const contentWidth = Math.max(_containerWidth - 88, 100);
+          total += layout(p, contentWidth, CODE_LINE_HEIGHT).height;
+        } else {
+          // Find the best estimate from the MIME type
+          let estimated = false;
+          for (const mime of Object.keys(data)) {
+            if (mime in OUTPUT_HEIGHT_DEFAULTS) {
+              total += OUTPUT_HEIGHT_DEFAULTS[mime];
+              estimated = true;
+              break;
+            }
+          }
+          if (!estimated) {
+            total += DEFAULT_OUTPUT_ESTIMATE;
+          }
+        }
+      } else {
+        total += DEFAULT_OUTPUT_ESTIMATE;
+      }
+    }
+  }
+  return total;
+}
+
+function buildEntry(cell: NotebookCell): CellHeightEntry {
+  const prepared = cell.source ? prepareSource(cell.source) : null;
+  const sourceHeight = computeSourceHeight(prepared, _containerWidth);
+
+  const outputs = cell.cell_type === "code" ? cell.outputs : [];
+  const outputHeight = estimateOutputHeight(outputs);
+
+  const chromeHeight =
+    cell.cell_type === "code" ? DEFAULT_CHROME_HEIGHT : MARKDOWN_CHROME_HEIGHT;
+
+  return {
+    sourceHeight,
+    outputHeight,
+    chromeHeight,
+    totalHeight: sourceHeight + outputHeight + chromeHeight,
+    prepared,
+    preparedSource: cell.source,
+    outputMeasured: false,
+  };
+}
+
+// ── Public mutation API ────────────────────────────────────────────────
+
+/** Initialize or update the cache for a batch of cells. */
+export function updateHeightCache(cells: Map<string, NotebookCell>): void {
+  let changed = false;
+
+  for (const [id, cell] of cells) {
+    const existing = _entries.get(id);
+
+    // Skip if source unchanged and outputs haven't changed
+    if (existing && existing.preparedSource === cell.source) {
+      // Check if outputs changed (code cells only)
+      if (cell.cell_type === "code" && !existing.outputMeasured) {
+        const newOutputHeight = estimateOutputHeight(cell.outputs);
+        if (newOutputHeight !== existing.outputHeight) {
+          existing.outputHeight = newOutputHeight;
+          existing.totalHeight =
+            existing.sourceHeight + newOutputHeight + existing.chromeHeight;
+          changed = true;
+        }
+      }
+      continue;
+    }
+
+    _entries.set(id, buildEntry(cell));
+    changed = true;
+  }
+
+  // Remove entries for cells that no longer exist
+  for (const id of _entries.keys()) {
+    if (!cells.has(id)) {
+      _entries.delete(id);
+      changed = true;
+    }
+  }
+
+  if (changed) emit();
+}
+
+/**
+ * Called by ResizeObserver when a cell's actual DOM height is measured.
+ * Replaces the estimated output height with the real one.
+ */
+export function setMeasuredHeight(
+  cellId: string,
+  measuredOutputHeight: number,
+): void {
+  const entry = _entries.get(cellId);
+  if (!entry) return;
+
+  // Only update if the measurement differs meaningfully (>1px)
+  if (
+    entry.outputMeasured &&
+    Math.abs(entry.outputHeight - measuredOutputHeight) < 1
+  ) {
+    return;
+  }
+
+  entry.outputHeight = measuredOutputHeight;
+  entry.outputMeasured = true;
+  entry.totalHeight =
+    entry.sourceHeight + entry.outputHeight + entry.chromeHeight;
+  emit();
+}
+
+/**
+ * Called by ResizeObserver for the full cell container height.
+ * Derives chrome height from the first measurement.
+ */
+export function setMeasuredCellHeight(
+  cellId: string,
+  totalMeasured: number,
+): void {
+  const entry = _entries.get(cellId);
+  if (!entry) return;
+
+  // If we have both source and output measurements, derive chrome
+  if (entry.outputMeasured) {
+    const derivedChrome =
+      totalMeasured - entry.sourceHeight - entry.outputHeight;
+    if (derivedChrome > 0 && Math.abs(derivedChrome - entry.chromeHeight) > 2) {
+      entry.chromeHeight = derivedChrome;
+    }
+  }
+
+  // Always update total from measurement when available
+  if (Math.abs(entry.totalHeight - totalMeasured) > 1) {
+    entry.totalHeight = totalMeasured;
+    emit();
+  }
+}
+
+/** Mark a cell's output as unmeasured (e.g., after re-execution). */
+export function invalidateOutputHeight(cellId: string): void {
+  const entry = _entries.get(cellId);
+  if (entry) {
+    entry.outputMeasured = false;
+  }
+}
+
+/**
+ * Update container width and re-layout all cells.
+ * This is the hot resize path — pure arithmetic, ~0.0002ms per cell.
+ */
+export function setContainerWidth(width: number): void {
+  if (Math.abs(width - _containerWidth) < 1) return;
+  _containerWidth = width;
+
+  let changed = false;
+  for (const entry of _entries.values()) {
+    if (entry.prepared) {
+      const newSourceHeight = computeSourceHeight(entry.prepared, width);
+      if (newSourceHeight !== entry.sourceHeight) {
+        entry.sourceHeight = newSourceHeight;
+        // Re-estimate outputs that use pretext (text/plain, stream)
+        // For measured outputs, keep the measured value
+        if (!entry.outputMeasured) {
+          entry.totalHeight =
+            newSourceHeight + entry.outputHeight + entry.chromeHeight;
+        } else {
+          entry.totalHeight =
+            newSourceHeight + entry.outputHeight + entry.chromeHeight;
+        }
+        changed = true;
+      }
+    }
+  }
+
+  if (changed) emit();
+}
+
+/** Get the current container width. */
+export function getContainerWidth(): number {
+  return _containerWidth;
+}

--- a/apps/notebook/src/lib/window-focus.ts
+++ b/apps/notebook/src/lib/window-focus.ts
@@ -133,6 +133,11 @@ function restoreEditorFocus(): void {
       view.contentDOM.blur();
     }
     view.focus();
+    // Force CM to re-measure and repaint its viewport. Without this,
+    // WKWebView may not composite the editor layer after window
+    // reactivation, causing the editor to appear blank until user
+    // interaction triggers a repaint.
+    view.requestMeasure();
   } catch (e) {
     logger.warn("[window-focus] Focus cycle failed:", e);
     return;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -277,6 +277,9 @@ importers:
 
   apps/notebook:
     dependencies:
+      '@chenglou/pretext':
+        specifier: ^0.0.4
+        version: 0.0.4
       '@codemirror/autocomplete':
         specifier: ^6.20.0
         version: 6.20.1
@@ -529,6 +532,9 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@chenglou/pretext@0.0.4':
+    resolution: {integrity: sha512-FnPAFMid1/p1j2V2gRPUVBarGUIb2PhkkC9YNnTOfPtTDgHKh8siO8PP9pCxpFfYlcodWPJpE1UbSHGQqt8pQQ==}
 
   '@codemirror/autocomplete@6.20.1':
     resolution: {integrity: sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A==}
@@ -5458,6 +5464,8 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@chenglou/pretext@0.0.4': {}
 
   '@codemirror/autocomplete@6.20.1':
     dependencies:


### PR DESCRIPTION
## Summary

- **Virtualizes the notebook cell list** — only cells in/near the viewport are mounted in the DOM
- Uses [`@chenglou/pretext`](https://github.com/chenglou/pretext) for pure-arithmetic text height measurement (~0.0002ms/cell) to compute scroll positions without DOM
- Switches from `flex + CSS order` to `position: absolute` — eliminates iframe `insertBefore` risk entirely
- Binary search for visible range (adapted from pretext's markdown-chat demo)
- Self-correcting height estimates: pretext estimates on first pass, ResizeObserver measurements replace them once rendered
- Overscan of 16 cells above/below viewport to prevent flicker on scroll entry

### New files
| File | Purpose |
|------|---------|
| `cell-height-cache.ts` | Pretext-based height estimation store — `prepare()` with `pre-wrap` for code cells, MIME-type estimation for outputs, ResizeObserver self-correction |
| `useVirtualCells.ts` | Virtual window hook — binary search visible range, force-include for focused/search/executing cells, RAF-coalesced scroll |

### Key decisions
- DnD disables virtualization during drag (short-lived, safe fallback)
- Widget remount is safe (CRDT-backed state)
- Focused, executing, and search-match cells are always force-rendered
- Absolute positioning makes iframe lifecycle safer than the old flex+order approach

Closes #1212

## Test plan

- [ ] Open a notebook with 20+ cells, scroll through — no blank gaps or jumps
- [ ] Run a cell with large output while cursor is in the editor — viewport stays pinned
- [ ] Drag-and-drop a cell — still works
- [ ] Cmd+Tab away and back — no visual glitches
- [ ] Resize window — cells reflow correctly
- [ ] Keyboard nav to offscreen cell — scrolls to it
- [ ] Global find highlights in offscreen cells — scrolls to match
- [ ] Markdown cells don't flicker when scrolling into view