### PR TITLE
fix(mcp): report execution status and non-text outputs to agents

### DIFF
--- a/crates/runt-mcp/src/formatting.rs
+++ b/crates/runt-mcp/src/formatting.rs
@@ -114,12 +114,43 @@ pub fn format_outputs_text(outputs: &[Output]) -> String {
 
 /// Convert outputs to separate Content items (one per output).
 /// This gives MCP clients richer structure than a single concatenated string.
+/// When outputs exist but have no text representation, appends a summary
+/// so agents know execution produced output they can't see.
 pub fn outputs_to_content_items(outputs: &[Output]) -> Vec<rmcp::model::Content> {
-    outputs
-        .iter()
-        .filter_map(format_output_text)
-        .map(rmcp::model::Content::text)
-        .collect()
+    let mut items: Vec<rmcp::model::Content> = Vec::new();
+    let mut omitted_count = 0usize;
+    let mut omitted_mimes: Vec<String> = Vec::new();
+
+    for output in outputs {
+        if let Some(text) = format_output_text(output) {
+            items.push(rmcp::model::Content::text(text));
+        } else if output.output_type == "display_data" || output.output_type == "execute_result" {
+            omitted_count += 1;
+            if let Some(data) = &output.data {
+                let mimes: Vec<&str> = data
+                    .keys()
+                    .map(|k| k.as_str())
+                    .filter(|k| !k.starts_with("text/llm"))
+                    .collect();
+                if !mimes.is_empty() {
+                    omitted_mimes.push(mimes.join(", "));
+                }
+            }
+        }
+    }
+
+    if omitted_count > 0 {
+        let detail = if omitted_mimes.is_empty() {
+            String::new()
+        } else {
+            format!(" ({})", omitted_mimes.join("; "))
+        };
+        items.push(rmcp::model::Content::text(format!(
+            "[{omitted_count} output(s) with non-text content{detail} — visible in the notebook UI]"
+        )));
+    }
+
+    items
 }
 
 /// Format a compact one-line cell summary (matches Python _format_cell_summary).

--- a/crates/runt-mcp/src/tools/cell_read.rs
+++ b/crates/runt-mcp/src/tools/cell_read.rs
@@ -273,6 +273,10 @@ pub async fn get_all_cells(
 }
 
 /// Get cell execution status from RuntimeState.
+///
+/// Checks queue first (running/queued), then falls back to the executions
+/// map for terminal status (done/error). Without this fallback, agents
+/// cannot distinguish "executed with output" from "never ran."
 fn get_cell_status(handle: &notebook_sync::handle::DocHandle, cell_id: &str) -> Option<String> {
     if let Ok(state) = handle.get_runtime_state() {
         if state
@@ -286,6 +290,17 @@ fn get_cell_status(handle: &notebook_sync::handle::DocHandle, cell_id: &str) -> 
         if state.queue.queued.iter().any(|e| e.cell_id == cell_id) {
             return Some("queued".to_string());
         }
+        // Check executions map for terminal status (most recent execution for this cell)
+        if let Some(exec) = state
+            .executions
+            .values()
+            .filter(|e| e.cell_id == cell_id)
+            .max_by_key(|e| e.execution_count)
+        {
+            if exec.status == "done" || exec.status == "error" {
+                return Some(exec.status.clone());
+            }
+        }
     }
     None
 }
@@ -296,6 +311,14 @@ pub fn build_cell_status_map(
 ) -> std::collections::HashMap<String, String> {
     let mut map = std::collections::HashMap::new();
     if let Ok(state) = handle.get_runtime_state() {
+        // Terminal statuses from executions (written first, active queue overrides below)
+        for exec in state.executions.values() {
+            if exec.status == "done" || exec.status == "error" {
+                map.entry(exec.cell_id.clone())
+                    .or_insert_with(|| exec.status.clone());
+            }
+        }
+        // Active queue statuses override terminal ones
         if let Some(ref e) = state.queue.executing {
             map.insert(e.cell_id.clone(), "running".to_string());
         }


### PR DESCRIPTION
## Summary

- `get_cell_status()` and `build_cell_status_map()` now check the `executions` map in RuntimeStateDoc for terminal status (`done`/`error`). Previously agents couldn't tell "executed with output" from "never ran" once a cell left the queue.
- `outputs_to_content_items()` appends a summary when outputs exist but have no text representation, e.g. `[1 output(s) with non-text content (image/png) — visible in the notebook UI]`

Addresses #1494 (MCP server missing execution status finding)

## Test plan

- [ ] Execute a cell with text output → `get_cell` shows `done` status and output text
- [ ] Execute a cell with only image output → `get_cell` shows `done` status and `[1 output(s) with non-text content ...]`
- [ ] Execute a cell that errors → `get_cell` shows `error` status
- [ ] Cell that was never run → `get_cell` shows no status (same as before)
- [ ] `show_notebook` cell summaries show `done`/`error` for executed cells