### PR TITLE
fix(security): allow HTTPS stylesheets in output iframe CSP

### DIFF
--- a/src/components/isolated/frame-html.ts
+++ b/src/components/isolated/frame-html.ts
@@ -39,7 +39,7 @@ export function generateFrameHtml(options: FrameHtmlOptions = {}): string {
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self' blob: data:; script-src 'unsafe-inline' 'unsafe-eval' blob: https:; style-src 'unsafe-inline'; img-src * data: blob:; font-src * data:; media-src * data: blob:; object-src * data: blob:; connect-src *;">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self' blob: data:; script-src 'unsafe-inline' 'unsafe-eval' blob: https:; style-src 'unsafe-inline' https:; img-src * data: blob:; font-src * data:; media-src * data: blob:; object-src * data: blob:; connect-src *;">
   <style>
     :root {
       --bg-primary: ${darkMode ? "#0a0a0a" : "#ffffff"};


### PR DESCRIPTION
## Summary

- Adds `https:` to the `style-src` CSP directive in the isolated output iframe
- Unblocks folium and other libraries that load CSS from CDNs (jsdelivr, cdnjs, etc.)
- Consistent with `script-src` which already allows `https:`
- Iframes remain sandboxed without `allow-same-origin` — no security posture change

Addresses #1494

## Test plan

- [ ] Folium map renders correctly (tiles + styled controls)
- [ ] Existing outputs still render (Vega, Plotly, matplotlib, widgets)
- [ ] No `allow-same-origin` in sandbox (CI test)