### PR TITLE
fix(crdt): prevent bootstrap skeleton from shadowing daemon metadata

### DIFF
--- a/.claude/rules/crdt-mutations.md
+++ b/.claude/rules/crdt-mutations.md
@@ -105,3 +105,5 @@ The bridge uses `externalChangeAnnotation` to prevent echo: inbound changes are 
 4. **Do not bypass the bridge for source text.** The CodeMirror bridge handles character-level sync. Using `update_source` (Myers diff) from the UI would conflict with the bridge's splice tracking.
 
 5. **Do not mutate the doc directly after an async gap.** If you read doc state, await something, then write back, use `NotebookDoc::fork()` before the async work and `merge()` after. For synchronous blocks, use `doc.fork_and_merge(|fork| { ... })`. See `contributing/crdt-mutation-guide.md` for the full pattern.
+
+6. **Do not `put_object()` at a key that another peer also creates.** Two independent `put_object(ROOT, "cells", Map)` from different actors create two distinct Map objects -- an Automerge conflict. One wins; the loser's children become invisible. Document structure must be created by exactly one peer (the daemon). Other peers receive it via sync. This is why `bootstrap()` only seeds `schema_version`, not the full skeleton.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -413,6 +413,14 @@ text splices and merges. See automerge/automerge#1327. Use `fork()` instead.
 
 **Key methods on `NotebookDoc`:** `fork()`, `get_heads()`, `merge()`, `fork_and_merge(f)`.
 
+### No Independent `put_object` on Shared Keys
+
+**Never call `put_object()` on a key that another peer also creates.** Two independent `put_object(ROOT, "cells", Map)` calls from different actors create two distinct Automerge Map objects at the same key — a conflict. Automerge picks one winner; the loser's children become invisible.
+
+This is why `NotebookDoc::bootstrap()` only writes `schema_version` (a scalar). It does **not** create `cells` or `metadata` maps — those are created once by the daemon in `new_inner()` and arrive at other peers via sync. If bootstrap also created them, the daemon's populated maps (with cells, deps, etc.) could be shadowed by the bootstrap's empty maps depending on conflict resolution order.
+
+**Rule:** Document structure (Maps, Lists at well-known keys) must be created by exactly one peer — the daemon. All other peers receive it via Automerge sync. Scalars at the same key are safe (identical values converge).
+
 ### The `is_binary_mime` Contract
 
 Three implementations **must stay in sync** — if you change MIME classification, update all three:

--- a/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm
+++ b/apps/notebook/src/wasm/runtimed-wasm/runtimed_wasm_bg.wasm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:41e6b94d169fee7f15ad543aa0b7932573528111b0cebfdbfb24b418a5e38339
-size 1660043
+oid sha256:4b92eb1ce9234a912a877454b8db183fd1be4b113086abf720067eb5e0d1786b
+size 1659970

--- a/contributing/crdt-mutation-guide.md
+++ b/contributing/crdt-mutation-guide.md
@@ -101,6 +101,8 @@ The bridge uses `externalChangeAnnotation` to prevent echo: inbound changes are 
 
 5. **Don't mutate the doc directly after an async gap.** If you read doc state, await something (subprocess, network, I/O), then write back, use `fork()` + `merge()` instead. Direct mutation after an async gap overwrites concurrent edits. See below.
 
+6. **Don't `put_object()` at a key that another peer also creates.** Two independent `put_object(ROOT, "cells", Map)` calls from different Automerge actors create two *distinct* Map objects at the same key — an Automerge conflict. One wins; the loser's children (cells, deps, etc.) become invisible. Document structure (Maps, Lists at well-known keys like `cells` and `metadata`) must be created by exactly one peer — the daemon, in `new_inner()`. All other peers receive it via Automerge sync. This is why `NotebookDoc::bootstrap()` only seeds `schema_version` (a scalar), not the full document skeleton.
+
 ## Fork+Merge for Async Mutations (Daemon-Side)
 
 When daemon code needs to read from the CRDT, do async work, and write results back, it **must** fork the doc before the async work and merge afterward. This treats the daemon's changes as concurrent with any edits that arrived during the async gap.

--- a/crates/notebook-doc/src/lib.rs
+++ b/crates/notebook-doc/src/lib.rs
@@ -833,22 +833,21 @@ impl NotebookDoc {
     /// encoding or actor we set.  A non-empty doc takes the normal
     /// incremental-apply path which preserves all settings.
     ///
-    /// Because the daemon creates the same structure, the CRDT merge
-    /// converges to identical values with no conflicts.
+    /// The daemon creates these maps in `new_inner()`. We must NOT create
+    /// `cells` or `metadata` maps here — if we do, Automerge sees two
+    /// concurrent `put_object` operations at the same key from different
+    /// actors, creating a conflict. If our empty map wins, the daemon's
+    /// populated map (with cells or dependencies) becomes invisible.
     pub fn bootstrap(encoding: TextEncoding, actor_label: &str) -> Self {
         let mut doc = AutoCommit::new_with_encoding(encoding);
         doc.set_actor(ActorId::from(actor_label.as_bytes()));
 
-        // Seed the standard notebook skeleton — schema_version, empty cells
-        // map, and empty metadata map.  The daemon writes these too, so the
-        // CRDT merge converges with no conflicts.
-        //
-        // NOTE: We intentionally do NOT set a default runtime here.  The
-        // runtime is determined by the notebook file or user choice, not
-        // hardcoded in the bootstrap skeleton.
+        // Seed with a single scalar so Automerge's is_empty() returns false.
+        // This prevents load_incremental's empty-doc fast-path from replacing
+        // *self with a default-options doc, which would discard our encoding
+        // and actor settings. The daemon's cells and metadata maps arrive
+        // via normal Automerge sync — no need to create them here.
         let _ = doc.put(automerge::ROOT, "schema_version", SCHEMA_VERSION);
-        let _ = doc.put_object(automerge::ROOT, "cells", ObjType::Map);
-        let _ = doc.put_object(automerge::ROOT, "metadata", ObjType::Map);
 
         Self { doc }
     }
@@ -2315,22 +2314,22 @@ mod tests {
 
     #[test]
     fn test_empty_doc_has_bootstrap_skeleton() {
-        // empty() now delegates to bootstrap(), which seeds the doc with
-        // schema_version, an empty cells map, and an empty metadata map.
+        // bootstrap() seeds only schema_version — no cells or metadata maps.
+        // Those are created by the daemon and arrive via Automerge sync.
         let doc = NotebookDoc::bootstrap(TextEncoding::UnicodeCodePoint, "test");
-        assert_eq!(doc.notebook_id(), None); // bootstrap doesn't set notebook_id
+        assert_eq!(doc.notebook_id(), None);
         assert_eq!(doc.cell_count(), 0);
         assert_eq!(doc.get_cells(), vec![]);
         assert_eq!(doc.schema_version(), Some(SCHEMA_VERSION));
-        // Bootstrap does NOT set a default runtime — that's determined by
-        // the notebook file or user choice.
+        // No metadata map exists before sync — reads return None gracefully.
         assert_eq!(doc.get_metadata("runtime"), None);
+        assert!(doc.get_metadata_snapshot().is_none());
     }
 
     #[test]
     fn test_empty_doc_set_metadata() {
         let mut doc = NotebookDoc::bootstrap(TextEncoding::UnicodeCodePoint, "test");
-        // set_metadata should work even without a pre-existing metadata map
+        // set_metadata should create the metadata map on demand
         let result = doc.set_metadata("runtime", "python");
         assert!(result.is_ok());
         assert_eq!(doc.get_metadata("runtime"), Some("python".to_string()));
@@ -2367,6 +2366,188 @@ mod tests {
         let cell = empty.get_cell("cell-1").unwrap();
         assert_eq!(cell.source, "print('hello')");
         assert_eq!(empty.notebook_id(), Some("test-notebook".to_string()));
+    }
+
+    /// Regression test: MCP-added deps must survive when a second bootstrap
+    /// peer (the app frontend) joins.
+    ///
+    /// Reproduces the exact production scenario:
+    /// 1. Daemon creates notebook (new_with_actor → creates metadata map)
+    /// 2. MCP agent bootstraps, syncs, then adds 10 deps
+    /// 3. MCP syncs deps back to daemon
+    /// 4. App frontend bootstraps and syncs — deps must survive
+    ///
+    /// Before the fix, bootstrap() created `metadata: {}` which competed
+    /// with the daemon's metadata map via Automerge conflict resolution.
+    /// If the bootstrap's empty map won, deps became invisible.
+    #[test]
+    fn test_bootstrap_sync_preserves_daemon_metadata() {
+        use automerge::sync;
+
+        fn sync_peers(
+            a: &mut NotebookDoc,
+            a_state: &mut sync::State,
+            b: &mut NotebookDoc,
+            b_state: &mut sync::State,
+        ) {
+            for _ in 0..10 {
+                let msg_a = a.generate_sync_message(a_state);
+                let msg_b = b.generate_sync_message(b_state);
+                if msg_a.is_none() && msg_b.is_none() {
+                    break;
+                }
+                if let Some(m) = msg_a {
+                    b.receive_sync_message(b_state, m).unwrap();
+                }
+                if let Some(m) = msg_b {
+                    a.receive_sync_message(a_state, m).unwrap();
+                }
+            }
+        }
+
+        // Step 1: Daemon creates notebook
+        let mut daemon = NotebookDoc::new_with_actor("test-notebook", "runtimed");
+
+        // Step 2: MCP agent bootstraps and syncs with daemon
+        let mut mcp = NotebookDoc::bootstrap(TextEncoding::UnicodeCodePoint, "mcp:nteract-nightly");
+        let mut daemon_mcp_state = sync::State::new();
+        let mut mcp_state = sync::State::new();
+        sync_peers(&mut daemon, &mut daemon_mcp_state, &mut mcp, &mut mcp_state);
+
+        // Step 3: MCP adds deps (writes to its local doc, syncs to daemon)
+        for dep in &[
+            "matplotlib",
+            "pandas",
+            "numpy",
+            "pillow",
+            "ipywidgets",
+            "plotly",
+            "altair",
+            "vega_datasets",
+            "sympy",
+            "rich",
+        ] {
+            mcp.add_uv_dependency(dep).unwrap();
+        }
+        sync_peers(&mut daemon, &mut daemon_mcp_state, &mut mcp, &mut mcp_state);
+
+        // Verify daemon has deps after MCP sync
+        let daemon_snap = daemon.get_metadata_snapshot().unwrap();
+        assert_eq!(
+            daemon_snap.runt.uv.as_ref().unwrap().dependencies.len(),
+            10,
+            "Daemon must have 10 deps after MCP sync"
+        );
+
+        // Step 4: App frontend bootstraps and syncs — the critical test
+        let mut frontend =
+            NotebookDoc::bootstrap(TextEncoding::UnicodeCodePoint, "human:kyle:tab-1");
+        let mut daemon_fe_state = sync::State::new();
+        let mut fe_state = sync::State::new();
+        sync_peers(
+            &mut daemon,
+            &mut daemon_fe_state,
+            &mut frontend,
+            &mut fe_state,
+        );
+
+        // Frontend must see all 10 deps
+        let fe_snap = frontend.get_metadata_snapshot().unwrap();
+        assert_eq!(
+            fe_snap.runt.uv.as_ref().unwrap().dependencies.len(),
+            10,
+            "Frontend must see all 10 deps after bootstrap sync"
+        );
+
+        // Daemon must still have all 10 deps (not corrupted by frontend sync)
+        let daemon_snap2 = daemon.get_metadata_snapshot().unwrap();
+        assert_eq!(
+            daemon_snap2.runt.uv.as_ref().unwrap().dependencies.len(),
+            10,
+            "Daemon deps must survive frontend bootstrap sync"
+        );
+    }
+
+    /// Verify that old-style bootstrap creates metadata conflicts but
+    /// the fixed bootstrap does not.
+    #[test]
+    fn test_old_bootstrap_creates_metadata_conflict_fixed_does_not() {
+        use automerge::sync;
+
+        fn sync_raw(
+            a: &mut AutoCommit,
+            a_state: &mut sync::State,
+            b: &mut AutoCommit,
+            b_state: &mut sync::State,
+        ) {
+            for _ in 0..10 {
+                let msg_a = a.sync().generate_sync_message(a_state);
+                let msg_b = b.sync().generate_sync_message(b_state);
+                if msg_a.is_none() && msg_b.is_none() {
+                    break;
+                }
+                if let Some(m) = msg_a {
+                    b.sync().receive_sync_message(b_state, m).unwrap();
+                }
+                if let Some(m) = msg_b {
+                    a.sync().receive_sync_message(a_state, m).unwrap();
+                }
+            }
+        }
+
+        // --- Part 1: old bootstrap creates a conflict ---
+        let mut daemon1 = NotebookDoc::new_with_actor("test", "runtimed");
+        daemon1.add_uv_dependency("numpy").unwrap();
+
+        let mut old_bootstrap = AutoCommit::new();
+        old_bootstrap.set_actor(ActorId::from(b"old-style-peer"));
+        let _ = old_bootstrap.put(automerge::ROOT, "schema_version", SCHEMA_VERSION);
+        let _ = old_bootstrap.put_object(automerge::ROOT, "cells", ObjType::Map);
+        let _ = old_bootstrap.put_object(automerge::ROOT, "metadata", ObjType::Map);
+
+        let mut ds1 = sync::State::new();
+        let mut bs1 = sync::State::new();
+        sync_raw(daemon1.doc_mut(), &mut ds1, &mut old_bootstrap, &mut bs1);
+
+        let old_conflicts: Vec<_> = old_bootstrap
+            .get_all(automerge::ROOT, "metadata")
+            .unwrap_or_default();
+        assert!(
+            old_conflicts.len() >= 2,
+            "Old bootstrap must create metadata conflict, got {} values",
+            old_conflicts.len()
+        );
+
+        // --- Part 2: fixed bootstrap does NOT create a conflict ---
+        let mut daemon2 = NotebookDoc::new_with_actor("test2", "runtimed");
+        daemon2.add_uv_dependency("numpy").unwrap();
+
+        let new_bootstrap = NotebookDoc::bootstrap(TextEncoding::UnicodeCodePoint, "fixed-peer");
+        let mut new_doc = new_bootstrap.into_inner();
+        let mut ds2 = sync::State::new();
+        let mut ns = sync::State::new();
+        sync_raw(daemon2.doc_mut(), &mut ds2, &mut new_doc, &mut ns);
+
+        let new_conflicts: Vec<_> = new_doc
+            .get_all(automerge::ROOT, "metadata")
+            .unwrap_or_default();
+        assert_eq!(
+            new_conflicts.len(),
+            1,
+            "Fixed bootstrap must not create metadata conflict"
+        );
+
+        // And deps are definitely visible
+        let doc = NotebookDoc::wrap(new_doc);
+        assert_eq!(
+            doc.get_metadata_snapshot()
+                .unwrap()
+                .runt
+                .uv
+                .unwrap()
+                .dependencies,
+            vec!["numpy"]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- MCP-added dependencies were invisible in the frontend's inline dependency list, even though the "Re-initialize" banner (which reads from RuntimeStateDoc) correctly showed them
- Root cause: `NotebookDoc::bootstrap()` created empty `cells` and `metadata` maps. When a sync client joined a notebook where the daemon already had deps, Automerge saw concurrent `put_object` operations at the same key from different actors — a conflict where the bootstrap's empty map could win, making the daemon's children (deps, cells) invisible
- Fix: bootstrap now only seeds `schema_version` (a scalar). The daemon's `cells` and `metadata` maps arrive via normal Automerge sync
- Documents a new CRDT invariant: document structure (Maps/Lists at well-known keys) must be created by exactly one peer — the daemon

## Verification

- [ ] Create a notebook via MCP `create_notebook` with dependencies (e.g. 10 packages)
- [ ] Open it in the app via `show_notebook`
- [ ] Inline dependency list shows all packages (not "No inline dependencies")
- [ ] "Re-initialize" banner count matches the inline list
- [ ] Adding/removing deps from the UI still works after the change
- [ ] Opening an existing `.ipynb` file with deps shows them correctly

_PR submitted by @rgbkrk's agent, Quill_