### PR TITLE
fix(ci): group stable changelog entries by ignoring nightly tags

### DIFF
--- a/.github/workflows/release-common.yml
+++ b/.github/workflows/release-common.yml
@@ -810,7 +810,7 @@ jobs:
             # Instead, find the previous stable tag and use an explicit range.
             PREV_STABLE=$(git tag -l 'v*-stable.*' --sort=-creatordate | head -1)
             if [ -n "$PREV_STABLE" ]; then
-              CHANGELOG=$(git-cliff "${PREV_STABLE}..HEAD" --strip header 2>/dev/null || echo "")
+              CHANGELOG=$(git-cliff "${PREV_STABLE}..HEAD" --ignore-tags ".*nightly.*" --strip header 2>/dev/null || echo "")
             else
               CHANGELOG=$(git-cliff --strip header 2>/dev/null || echo "")
             fi


### PR DESCRIPTION
## Summary

Follow-up to #1499. Nightly tags between stable releases caused git-cliff to treat each commit as a separate version, repeating group headings for every commit:

```
### Bug Fixes
- commit A

### Bug Fixes
- commit B
```

Adding `--ignore-tags ".*nightly.*"` collapses the range into one version with proper grouping:

```
### Bug Fixes
- commit A
- commit B
```

## Test plan

- [ ] Next stable release has grouped changelog headings