### PR TITLE
fix(frontend): resolve widget loading race on notebook open

### DIFF
--- a/apps/notebook/src/hooks/useDaemonKernel.ts
+++ b/apps/notebook/src/hooks/useDaemonKernel.ts
@@ -23,7 +23,12 @@ import {
   type NotebookClient,
   type NotebookResponse,
 } from "runtimed";
-import { getBlobPort, refreshBlobPort, resetBlobPort } from "../lib/blob-port";
+import {
+  getBlobPort,
+  refreshBlobPort,
+  resetBlobPort,
+  useBlobPort,
+} from "../lib/blob-port";
 import { replaceSentinelsWithBlobUrls } from "../lib/blob-sentinel";
 import { logger } from "../lib/logger";
 import { subscribeBroadcast } from "../lib/notebook-frame-bus";
@@ -151,6 +156,7 @@ export function useDaemonKernel({
 }: UseDaemonKernelOptions) {
   // ── State from RuntimeStateDoc (daemon-authoritative) ─────────────
   const runtimeState = useRuntimeState();
+  const blobPort = useBlobPort();
 
   const kernelInfo = useMemo(
     () => deriveKernelInfo(runtimeState),
@@ -451,7 +457,7 @@ export function useDaemonKernel({
     if (!commCb) return;
 
     const docComms = runtimeState.comms ?? {};
-    const hasBlobPort = getBlobPort() !== null;
+    const hasBlobPort = blobPort !== null;
 
     const { result, next } = diffComms(commDiffStateRef.current, docComms);
 
@@ -537,7 +543,8 @@ export function useDaemonKernel({
     }
 
     commDiffStateRef.current = next;
-  }, [runtimeState.comms]);
+    // biome-ignore lint/correctness/useExhaustiveDependencies: blobPort triggers retry for comms deferred due to missing blob server
+  }, [runtimeState.comms, blobPort]);
 
   // ── Actions (via NotebookClient) ──────────────────────────────────
 


### PR DESCRIPTION
## Summary

When opening a notebook with previously executed widget cells, widgets could get stuck on "Loading widget..." indefinitely.

**Root cause:** The comm diff effect in `useDaemonKernel` fires when `runtimeState.comms` changes. On first load, if the blob port isn't available yet, deferred comms are removed from tracking to "retry on next CRDT update." But if no further comm state changes arrive, the effect never re-fires.

**Fix:** Add `useBlobPort()` as a reactive dependency so the effect re-runs when the blob port becomes available, picking up the deferred comms.

## Test plan

- [ ] Open a notebook with executed widget cells (sliders, etc.) — widgets render immediately without "Loading widget..."
- [ ] Close and reopen the same notebook — widgets still hydrate from CRDT
- [ ] Execute a new widget cell — still works as before