### PR TITLE
fix(runtimed): mark execution error in agent CellError handler

### DIFF
--- a/crates/runtimed/src/agent.rs
+++ b/crates/runtimed/src/agent.rs
@@ -616,6 +616,7 @@ async fn handle_queue_command(command: QueueCommand, ctx: &AgentContext) -> anyh
             );
             let mut guard = ctx.kernel.lock().await;
             if let Some(ref mut k) = *guard {
+                k.mark_execution_error();
                 let cleared = k.clear_queue();
                 let mut sd = ctx.state_doc.write().await;
                 for entry in &cleared {


### PR DESCRIPTION
## Summary

- The agent subprocess's `CellError` handler was missing `mark_execution_error()`, so when `ExecutionDone` fired, `execution_had_error` was still `false` and the daemon wrote `status: "done"` instead of `status: "error"` to RuntimeStateDoc
- This caused MCP tools (`get_cell`, `show_notebook`) to report `status: "done"` for cells that errored (e.g. `1/0`), making it impossible for agents to distinguish success from failure via the status field
- The `notebook_sync_server` path already called `mark_execution_error()` correctly; this one-line fix aligns the agent path

## Test plan

- [ ] `cargo test -p runtimed` passes
- [ ] `cargo test -p notebook-doc` passes
- [ ] `cargo test -p runt-mcp` passes
- [ ] `cargo xtask lint` passes
- [ ] Manual: open a notebook via MCP, execute `1/0`, verify `get_cell` reports `status: "error"` instead of `status: "done"`