### PR TITLE
fix(mcp): read execution_count from RuntimeStateDoc instead of stale NotebookDoc

### DIFF
--- a/crates/runt-mcp/src/execution.rs
+++ b/crates/runt-mcp/src/execution.rs
@@ -125,7 +125,29 @@ pub async fn execute_and_wait(
     // Prefer output hashes from RuntimeStateDoc (already synced above).
     // Fall back to handle.get_cell() which reads via execution_id facade.
 
-    let execution_count = handle.get_cell_execution_count(cell_id);
+    // Get execution_count from RuntimeStateDoc (the source of truth).
+    // The NotebookDoc cell's execution_count field is stale since execution
+    // state was moved to RuntimeStateDoc.
+    let execution_count = if let Some(ref eid) = execution_id {
+        handle
+            .get_runtime_state()
+            .ok()
+            .and_then(|state| {
+                state
+                    .executions
+                    .get(eid.as_str())
+                    .and_then(|e| e.execution_count)
+            })
+            .map(|c| c.to_string())
+    } else {
+        // Fallback: find most recent execution for this cell with an execution_count
+        let ec = crate::tools::cell_read::get_cell_execution_count_from_runtime(handle, cell_id);
+        if ec.is_empty() {
+            None
+        } else {
+            Some(ec)
+        }
+    };
 
     let comms = handle.get_runtime_state().ok().map(|rs| rs.comms);
     let outputs = if !output_hashes.is_empty() {

--- a/crates/runt-mcp/src/tools/cell_read.rs
+++ b/crates/runt-mcp/src/tools/cell_read.rs
@@ -60,13 +60,12 @@ pub async fn get_cell(
         None => return tool_error(&format!("Cell not found: {cell_id}")),
     };
 
+    // Get execution_count from RuntimeStateDoc (the source of truth)
+    let ec = get_cell_execution_count_from_runtime(&handle, cell_id);
+
     // If the cell has been executed but outputs haven't synced yet,
     // force a sync round-trip to process pending RuntimeStateSync frames.
-    if cell.outputs.is_empty()
-        && !cell.execution_count.is_empty()
-        && cell.execution_count != "0"
-        && cell.execution_count != "null"
-    {
+    if cell.outputs.is_empty() && !ec.is_empty() {
         let _ = handle.confirm_sync().await;
         if let Some(c) = handle.get_cell(cell_id) {
             cell = c;
@@ -86,12 +85,13 @@ pub async fn get_cell(
     // Get execution status from RuntimeState
     let status = get_cell_status(&handle, cell_id);
 
-    let header = formatting::format_cell_header(
-        &cell.id,
-        &cell.cell_type,
-        Some(&cell.execution_count),
-        status.as_deref(),
-    );
+    let ec_display = if ec.is_empty() {
+        None
+    } else {
+        Some(ec.as_str())
+    };
+    let header =
+        formatting::format_cell_header(&cell.id, &cell.cell_type, ec_display, status.as_deref());
 
     // Return multiple Content items: header+source, then one per output
     let mut items = Vec::new();
@@ -148,8 +148,9 @@ pub async fn get_all_cells(
     };
     let slice = &cells[start.min(cells.len())..end.min(cells.len())];
 
-    // Build cell status map and comms from RuntimeState
+    // Build cell status map, execution count map, and comms from RuntimeState
     let cell_status_map = build_cell_status_map(&handle);
+    let cell_ec_map = build_cell_execution_count_map(&handle);
     let comms = handle.get_runtime_state().ok().map(|rs| rs.comms);
 
     match format {
@@ -157,7 +158,7 @@ pub async fn get_all_cells(
             let mut json_cells = Vec::new();
             for cell in slice {
                 let status = cell_status_map.get(&cell.id).map(String::as_str);
-                let ec: Option<i64> = cell.execution_count.parse().ok();
+                let ec: Option<i64> = cell_ec_map.get(&cell.id).and_then(|s| s.parse().ok());
 
                 // Resolve outputs through the output resolver so that
                 // text/llm+plain is synthesized and viz specs are summarized.
@@ -197,6 +198,7 @@ pub async fn get_all_cells(
             let mut items = Vec::new();
             for cell in slice {
                 let status = cell_status_map.get(&cell.id).map(String::as_str);
+                let ec = cell_ec_map.get(&cell.id).map(String::as_str);
                 let outputs = output_resolver::resolve_cell_outputs(
                     &cell.outputs,
                     &server.blob_base_url,
@@ -204,12 +206,7 @@ pub async fn get_all_cells(
                     comms.as_ref(),
                 )
                 .await;
-                let header = formatting::format_cell_header(
-                    &cell.id,
-                    &cell.cell_type,
-                    Some(&cell.execution_count),
-                    status,
-                );
+                let header = formatting::format_cell_header(&cell.id, &cell.cell_type, ec, status);
                 let output_text = formatting::format_outputs_text(&outputs);
                 let text = if !cell.source.is_empty() {
                     format!("{header}\n\n{}", cell.source)
@@ -228,12 +225,13 @@ pub async fn get_all_cells(
             let mut lines = Vec::new();
             for (i, cell) in slice.iter().enumerate() {
                 let status = cell_status_map.get(&cell.id).map(String::as_str);
+                let ec = cell_ec_map.get(&cell.id).map(String::as_str);
                 let line = formatting::format_cell_summary(
                     start + i,
                     &cell.id,
                     &cell.cell_type,
                     &cell.source,
-                    Some(&cell.execution_count),
+                    ec,
                     status,
                     preview_chars,
                 );
@@ -272,6 +270,31 @@ pub async fn get_all_cells(
     }
 }
 
+/// Get the execution_count for a cell from RuntimeStateDoc.
+///
+/// Looks at the executions map for the most recent execution of this cell
+/// that has an execution_count set (from the kernel's execute_input message).
+/// Returns an empty string if no execution_count is found, matching the
+/// convention used by formatting functions.
+pub fn get_cell_execution_count_from_runtime(
+    handle: &notebook_sync::handle::DocHandle,
+    cell_id: &str,
+) -> String {
+    if let Ok(state) = handle.get_runtime_state() {
+        if let Some(exec) = state
+            .executions
+            .values()
+            .filter(|e| e.cell_id == cell_id && e.execution_count.is_some())
+            .max_by_key(|e| e.execution_count)
+        {
+            if let Some(count) = exec.execution_count {
+                return count.to_string();
+            }
+        }
+    }
+    String::new()
+}
+
 /// Get cell execution status from RuntimeState.
 ///
 /// Checks queue first (running/queued), then falls back to the executions
@@ -303,6 +326,36 @@ fn get_cell_status(handle: &notebook_sync::handle::DocHandle, cell_id: &str) -> 
         }
     }
     None
+}
+
+/// Build a map of cell_id -> execution_count string from RuntimeState.
+///
+/// For each cell, finds the most recent execution with an execution_count
+/// and stores it as a string (e.g. "5"). Cells without execution_count
+/// are absent from the map.
+pub fn build_cell_execution_count_map(
+    handle: &notebook_sync::handle::DocHandle,
+) -> std::collections::HashMap<String, String> {
+    let mut map: std::collections::HashMap<String, (i64, String)> =
+        std::collections::HashMap::new();
+    if let Ok(state) = handle.get_runtime_state() {
+        for exec in state.executions.values() {
+            if let Some(count) = exec.execution_count {
+                let entry = map.entry(exec.cell_id.clone());
+                match entry {
+                    std::collections::hash_map::Entry::Vacant(e) => {
+                        e.insert((count, count.to_string()));
+                    }
+                    std::collections::hash_map::Entry::Occupied(mut e) => {
+                        if count > e.get().0 {
+                            e.insert((count, count.to_string()));
+                        }
+                    }
+                }
+            }
+        }
+    }
+    map.into_iter().map(|(k, (_, v))| (k, v)).collect()
 }
 
 /// Build a map of cell_id -> status from RuntimeState.

--- a/crates/runt-mcp/src/tools/mod.rs
+++ b/crates/runt-mcp/src/tools/mod.rs
@@ -42,7 +42,7 @@ fn app_tool_meta() -> Meta {
 
 mod cell_crud;
 mod cell_meta;
-mod cell_read;
+pub(crate) mod cell_read;
 mod deps;
 mod editing;
 mod execution;
@@ -418,12 +418,18 @@ pub async fn build_execution_result(
                 comms.as_ref(),
             )
             .await;
+            let ec_str = cell_read::get_cell_execution_count_from_runtime(handle, &snap.id);
+            let ec: Option<i64> = if ec_str.is_empty() {
+                None
+            } else {
+                ec_str.parse().ok()
+            };
             let resolved = runtimed_client::resolved_output::ResolvedCell {
                 id: snap.id,
                 cell_type: snap.cell_type,
                 position: snap.position,
                 source: snap.source,
-                execution_count: snap.execution_count.parse().ok(),
+                execution_count: ec,
                 outputs,
                 metadata_json: serde_json::to_string(&snap.metadata).unwrap_or_default(),
             };

--- a/crates/runt-mcp/src/tools/session.rs
+++ b/crates/runt-mcp/src/tools/session.rs
@@ -102,17 +102,19 @@ fn get_dependencies(handle: &notebook_sync::handle::DocHandle) -> Vec<String> {
 fn format_cell_summaries(handle: &notebook_sync::handle::DocHandle) -> String {
     let cells = handle.get_cells();
     let cell_status_map = crate::tools::cell_read::build_cell_status_map(handle);
+    let cell_ec_map = crate::tools::cell_read::build_cell_execution_count_map(handle);
     cells
         .iter()
         .enumerate()
         .map(|(i, cell)| {
             let status = cell_status_map.get(&cell.id).map(String::as_str);
+            let ec = cell_ec_map.get(&cell.id).map(String::as_str);
             formatting::format_cell_summary(
                 i,
                 &cell.id,
                 &cell.cell_type,
                 &cell.source,
-                Some(&cell.execution_count),
+                ec,
                 status,
                 60,
             )


### PR DESCRIPTION
## Summary

- MCP tools (`get_cell`, `get_all_cells`, `execute_cell`, `show_notebook`, `join_notebook`) always returned `execution_count: null` because they read from `CellSnapshot.execution_count` on the NotebookDoc, which is permanently `"null"` since execution state moved to RuntimeStateDoc.
- The daemon correctly writes `execution_count` to RuntimeStateDoc's executions map via `set_execution_count()` when it receives `execute_input` from the kernel, but the MCP server never read from there.
- All MCP code paths now resolve `execution_count` from RuntimeStateDoc by finding the most recent execution for each cell with an execution_count set.

## Changes

- **`crates/runt-mcp/src/tools/cell_read.rs`**: Added `get_cell_execution_count_from_runtime()` and `build_cell_execution_count_map()` helpers that read from RuntimeStateDoc. Updated `get_cell` and `get_all_cells` (all three formats: summary, json, rich) to use them.
- **`crates/runt-mcp/src/execution.rs`**: `execute_and_wait` now reads execution_count from RuntimeStateDoc using the execution_id when available, falling back to the cell-level lookup.
- **`crates/runt-mcp/src/tools/mod.rs`**: `build_execution_result` uses the new helper for structured content execution_count. Made `cell_read` module `pub(crate)` so `execution.rs` can access it.
- **`crates/runt-mcp/src/tools/session.rs`**: `format_cell_summaries` (used by `join_notebook`/`open_notebook`) uses the new execution_count map.

## Test plan

- [x] `cargo test -p runt-mcp` passes
- [x] `cargo test -p notebook-doc` passes
- [x] `cargo xtask lint` passes
- [ ] Manual verification: open a notebook, execute cells, confirm `get_cell` and `execute_cell` return correct execution_count values (e.g., `[3]` instead of `null`)