### PR TITLE
fix(frontend): resolve execution_count from RuntimeState instead of stale NotebookDoc

### DIFF
--- a/apps/notebook/src/hooks/useDaemonKernel.ts
+++ b/apps/notebook/src/hooks/useDaemonKernel.ts
@@ -293,10 +293,7 @@ export function useDaemonKernel({
         // Materialization reads execution_count from RuntimeState directly,
         // so skipping null here avoids a brief flash of "0".
         if (t.execution_count != null) {
-          callbacksRef.current.onExecutionCount(
-            t.cell_id,
-            t.execution_count,
-          );
+          callbacksRef.current.onExecutionCount(t.cell_id, t.execution_count);
         }
       } else {
         callbacksRef.current.onExecutionDone(t.cell_id);

--- a/apps/notebook/src/hooks/useDaemonKernel.ts
+++ b/apps/notebook/src/hooks/useDaemonKernel.ts
@@ -288,10 +288,16 @@ export function useDaemonKernel({
     const transitions = diffExecutions(prev, curr);
     for (const t of transitions) {
       if (t.kind === "started") {
-        callbacksRef.current.onExecutionCount(
-          t.cell_id,
-          t.execution_count ?? 0,
-        );
+        // Only forward when the kernel has actually reported the count
+        // (arrives via execute_input, after the queued→running transition).
+        // Materialization reads execution_count from RuntimeState directly,
+        // so skipping null here avoids a brief flash of "0".
+        if (t.execution_count != null) {
+          callbacksRef.current.onExecutionCount(
+            t.cell_id,
+            t.execution_count,
+          );
+        }
       } else {
         callbacksRef.current.onExecutionDone(t.cell_id);
       }

--- a/apps/notebook/src/lib/materialize-cells.ts
+++ b/apps/notebook/src/lib/materialize-cells.ts
@@ -3,7 +3,7 @@ import type { NotebookHandle } from "../wasm/runtimed-wasm/runtimed_wasm.js";
 import { logger } from "./logger";
 import type { OutputManifest } from "./manifest-resolution";
 import { isManifestHash, resolveManifest } from "./manifest-resolution";
-import { getRuntimeState } from "./runtime-state";
+import { getExecutionCountForCell, getRuntimeState } from "./runtime-state";
 
 export type { ContentRef, OutputManifest } from "./manifest-resolution";
 // Re-export shared manifest types and functions for downstream consumers
@@ -14,25 +14,9 @@ export {
   resolveManifest,
 } from "./manifest-resolution";
 
-/**
- * Resolve execution_count for a cell from the RuntimeState store.
- *
- * The daemon writes execution_count to RuntimeStateDoc (not NotebookDoc),
- * so the WASM handle's get_cell_execution_count always returns "null".
- * This mirrors what runt-mcp's get_cell_execution_count_from_runtime does:
- * find the most recent execution for the cell that has a count set.
- */
+/** Resolve execution_count for a cell from the current RuntimeState snapshot. */
 function getExecutionCountFromRuntime(cellId: string): number | null {
-  const state = getRuntimeState();
-  let best: number | null = null;
-  for (const exec of Object.values(state.executions)) {
-    if (exec.cell_id === cellId && exec.execution_count != null) {
-      if (best === null || exec.execution_count > best) {
-        best = exec.execution_count;
-      }
-    }
-  }
-  return best;
+  return getExecutionCountForCell(getRuntimeState(), cellId);
 }
 
 /**

--- a/apps/notebook/src/lib/materialize-cells.ts
+++ b/apps/notebook/src/lib/materialize-cells.ts
@@ -3,6 +3,7 @@ import type { NotebookHandle } from "../wasm/runtimed-wasm/runtimed_wasm.js";
 import { logger } from "./logger";
 import type { OutputManifest } from "./manifest-resolution";
 import { isManifestHash, resolveManifest } from "./manifest-resolution";
+import { getRuntimeState } from "./runtime-state";
 
 export type { ContentRef, OutputManifest } from "./manifest-resolution";
 // Re-export shared manifest types and functions for downstream consumers
@@ -12,6 +13,27 @@ export {
   resolveDataBundle,
   resolveManifest,
 } from "./manifest-resolution";
+
+/**
+ * Resolve execution_count for a cell from the RuntimeState store.
+ *
+ * The daemon writes execution_count to RuntimeStateDoc (not NotebookDoc),
+ * so the WASM handle's get_cell_execution_count always returns "null".
+ * This mirrors what runt-mcp's get_cell_execution_count_from_runtime does:
+ * find the most recent execution for the cell that has a count set.
+ */
+function getExecutionCountFromRuntime(cellId: string): number | null {
+  const state = getRuntimeState();
+  let best: number | null = null;
+  for (const exec of Object.values(state.executions)) {
+    if (exec.cell_id === cellId && exec.execution_count != null) {
+      if (best === null || exec.execution_count > best) {
+        best = exec.execution_count;
+      }
+    }
+  }
+  return best;
+}
 
 /**
  * Snapshot of a cell from the Automerge document.
@@ -153,11 +175,17 @@ export function cellSnapshotsToNotebookCellsSync(
         })
         .filter((o): o is JupyterOutput => o !== null);
 
+      // Resolve execution_count from RuntimeState (source of truth) rather
+      // than the stale NotebookDoc field which is always "null".
+      const runtimeCount = getExecutionCountFromRuntime(snap.id);
+      const ec =
+        runtimeCount ?? (Number.isNaN(executionCount) ? null : executionCount);
+
       return {
         id: snap.id,
         cell_type: "code" as const,
         source: snap.source,
-        execution_count: Number.isNaN(executionCount) ? null : executionCount,
+        execution_count: ec,
         outputs: resolvedOutputs,
         metadata,
       };
@@ -212,11 +240,17 @@ export async function cellSnapshotsToNotebookCells(
           )
         ).filter((o): o is JupyterOutput => o !== null);
 
+        // Resolve execution_count from RuntimeState (source of truth)
+        const runtimeCount = getExecutionCountFromRuntime(snap.id);
+        const ec =
+          runtimeCount ??
+          (Number.isNaN(executionCount) ? null : executionCount);
+
         return {
           id: snap.id,
           cell_type: "code" as const,
           source: snap.source,
-          execution_count: Number.isNaN(executionCount) ? null : executionCount,
+          execution_count: ec,
           outputs: resolvedOutputs,
           metadata,
         };
@@ -262,10 +296,6 @@ export function materializeCellFromWasm(
   const metadata = handle.get_cell_metadata(cellId) ?? {};
 
   if (cellType === "code") {
-    const ecStr = handle.get_cell_execution_count(cellId);
-    const executionCount =
-      !ecStr || ecStr === "null" ? null : Number.parseInt(ecStr, 10);
-
     const rawOutputs: string[] = handle.get_cell_outputs(cellId) ?? [];
     const resolvedOutputs = rawOutputs
       .map((outputStr: string) => {
@@ -294,11 +324,14 @@ export function materializeCellFromWasm(
       previousCell?.cell_type === "code" ? previousCell.outputs : undefined;
     const outputs = reuseOutputsIfUnchanged(resolvedOutputs, prevOutputs);
 
+    // Resolve execution_count from RuntimeState (source of truth)
+    const executionCount = getExecutionCountFromRuntime(cellId);
+
     return {
       id: cellId,
       cell_type: "code",
       source,
-      execution_count: Number.isNaN(executionCount) ? null : executionCount,
+      execution_count: executionCount,
       outputs,
       metadata,
     };

--- a/apps/notebook/src/lib/runtime-state.ts
+++ b/apps/notebook/src/lib/runtime-state.ts
@@ -20,7 +20,11 @@ export type {
   TrustState,
 } from "runtimed";
 
-export { DEFAULT_RUNTIME_STATE, diffExecutions } from "runtimed";
+export {
+  DEFAULT_RUNTIME_STATE,
+  diffExecutions,
+  getExecutionCountForCell,
+} from "runtimed";
 
 import { DEFAULT_RUNTIME_STATE, type RuntimeState } from "runtimed";
 

--- a/packages/runtimed/src/index.ts
+++ b/packages/runtimed/src/index.ts
@@ -41,6 +41,7 @@ export {
   type RuntimeState,
   type TrustState,
   diffExecutions,
+  getExecutionCountForCell,
 } from "./runtime-state";
 
 // Pool state

--- a/packages/runtimed/src/runtime-state.ts
+++ b/packages/runtimed/src/runtime-state.ts
@@ -134,8 +134,23 @@ export function diffExecutions(
     const prevStatus = prevEntry?.status;
     const currStatus = entry.status;
 
-    // No change
-    if (prevStatus === currStatus) continue;
+    // Same status — check if execution_count arrived (kernel sends
+    // execute_input after the status transitions to "running").
+    if (prevStatus === currStatus) {
+      if (
+        currStatus === "running" &&
+        entry.execution_count != null &&
+        prevEntry?.execution_count == null
+      ) {
+        transitions.push({
+          execution_id: eid,
+          cell_id: entry.cell_id,
+          kind: "started",
+          execution_count: entry.execution_count,
+        });
+      }
+      continue;
+    }
 
     // Terminal states: done or error
     if (currStatus === "done") {

--- a/packages/runtimed/src/runtime-state.ts
+++ b/packages/runtimed/src/runtime-state.ts
@@ -184,3 +184,26 @@ export function diffExecutions(
 
   return transitions;
 }
+
+/**
+ * Resolve the most recent execution_count for a cell from RuntimeState.
+ *
+ * The daemon writes execution_count to RuntimeStateDoc (not NotebookDoc),
+ * so the WASM handle's get_cell_execution_count always returns "null".
+ * This mirrors runt-mcp's get_cell_execution_count_from_runtime: find
+ * the most recent execution for the cell that has a count set.
+ */
+export function getExecutionCountForCell(
+  state: RuntimeState,
+  cellId: string,
+): number | null {
+  let best: number | null = null;
+  for (const exec of Object.values(state.executions)) {
+    if (exec.cell_id === cellId && exec.execution_count != null) {
+      if (best === null || exec.execution_count > best) {
+        best = exec.execution_count;
+      }
+    }
+  }
+  return best;
+}

--- a/packages/runtimed/tests/sync-engine.test.ts
+++ b/packages/runtimed/tests/sync-engine.test.ts
@@ -13,7 +13,7 @@ import { SyncEngine } from "../src/sync-engine";
 import { DirectTransport } from "../src/direct-transport";
 import { FrameType } from "../src/transport";
 import { mergeChangesets } from "../src/cell-changeset";
-import { diffExecutions } from "../src/runtime-state";
+import { diffExecutions, getExecutionCountForCell } from "../src/runtime-state";
 import type { SyncableHandle, FrameEvent } from "../src/handle";
 import type { CellChangeset } from "../src/cell-changeset";
 import type { RuntimeState } from "../src/runtime-state";
@@ -1628,5 +1628,55 @@ describe("diffExecutions", () => {
     };
     const transitions = diffExecutions(prev, curr);
     expect(transitions).toHaveLength(0);
+  });
+});
+
+// ── getExecutionCountForCell ────────────────────────────────────
+
+describe("getExecutionCountForCell", () => {
+  const baseState = {
+    kernel: { status: "idle", starting_phase: "", name: "", language: "", env_source: "" },
+    queue: { executing: null, queued: [] },
+    env: { in_sync: true, added: [], removed: [], channels_changed: false, deno_changed: false, prewarmed_packages: [] },
+    trust: { status: "trusted", needs_approval: false },
+    last_saved: null,
+    comms: {},
+  };
+
+  it("returns null when no executions exist", () => {
+    const state = { ...baseState, executions: {} };
+    expect(getExecutionCountForCell(state, "c1")).toBeNull();
+  });
+
+  it("returns the count for a matching cell", () => {
+    const state = {
+      ...baseState,
+      executions: {
+        "e1": { cell_id: "c1", status: "done" as const, execution_count: 3, success: true },
+      },
+    };
+    expect(getExecutionCountForCell(state, "c1")).toBe(3);
+  });
+
+  it("returns the highest count when multiple executions exist", () => {
+    const state = {
+      ...baseState,
+      executions: {
+        "e1": { cell_id: "c1", status: "done" as const, execution_count: 2, success: true },
+        "e2": { cell_id: "c1", status: "done" as const, execution_count: 5, success: true },
+        "e3": { cell_id: "c1", status: "running" as const, execution_count: null, success: null },
+      },
+    };
+    expect(getExecutionCountForCell(state, "c1")).toBe(5);
+  });
+
+  it("ignores executions for other cells", () => {
+    const state = {
+      ...baseState,
+      executions: {
+        "e1": { cell_id: "c2", status: "done" as const, execution_count: 10, success: true },
+      },
+    };
+    expect(getExecutionCountForCell(state, "c1")).toBeNull();
   });
 });

--- a/packages/runtimed/tests/sync-engine.test.ts
+++ b/packages/runtimed/tests/sync-engine.test.ts
@@ -1605,4 +1605,28 @@ describe("diffExecutions", () => {
     const transitions = diffExecutions(state, state);
     expect(transitions).toHaveLength(0);
   });
+
+  it("detects execution_count arriving while still running", () => {
+    const prev = {
+      "e1": { cell_id: "c1", status: "running" as const, execution_count: null, success: null },
+    };
+    const curr = {
+      "e1": { cell_id: "c1", status: "running" as const, execution_count: 5, success: null },
+    };
+    const transitions = diffExecutions(prev, curr);
+    expect(transitions).toHaveLength(1);
+    expect(transitions[0].kind).toBe("started");
+    expect(transitions[0].execution_count).toBe(5);
+  });
+
+  it("ignores execution_count change when not running", () => {
+    const prev = {
+      "e1": { cell_id: "c1", status: "done" as const, execution_count: null, success: true },
+    };
+    const curr = {
+      "e1": { cell_id: "c1", status: "done" as const, execution_count: 5, success: true },
+    };
+    const transitions = diffExecutions(prev, curr);
+    expect(transitions).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
## Summary

- Materialization was reading execution_count from the NotebookDoc WASM handle, which always returns "null" since execution_count moved to RuntimeStateDoc (#1503 fixed the MCP server side, this fixes the frontend)
- Added `getExecutionCountFromRuntime()` in materialize-cells.ts — mirrors the MCP server's `get_cell_execution_count_from_runtime` pattern
- Extended `diffExecutions()` to detect execution_count arriving after the `queued→running` transition (kernel sends `execute_input` later)
- Only forward `onExecutionCount` when count is non-null to avoid brief "0" flash

## Test plan

- [x] `diffExecutions` tests pass (2 new cases: count arrives while running, count change when done is ignored)
- [ ] Execute a cell — execution count appears in gutter after execution
- [ ] Re-execute — count updates to new value
- [ ] Multiple cells queued — each gets correct count
- [ ] Source edit during execution doesn't lose the count