### PR TITLE
feat(cli): add system-wide CLI installation via menu

### DIFF
--- a/crates/notebook/src/cli_install.rs
+++ b/crates/notebook/src/cli_install.rs
@@ -502,9 +502,17 @@ fn install_with_privilege_escalation(
     nb_script: &str,
 ) -> Result<(), String> {
     // Build the shell script that will run with admin privileges.
-    // We create the symlink for runt and write the nb wrapper script.
+    // We create the directory (may not exist on clean installs), symlink runt,
+    // and write the nb wrapper script.
+    let dir = shell_escape(
+        runt_dest
+            .parent()
+            .ok_or("Invalid install destination")?
+            .to_string_lossy()
+            .as_ref(),
+    );
     let shell_cmd = format!(
-        "rm -f {runt} {nb} && ln -s {src} {runt} && printf '%s' {nb_escaped} > {nb} && chmod 755 {nb}",
+        "mkdir -p {dir} && rm -f {runt} {nb} && ln -s {src} {runt} && printf '%s' {nb_escaped} > {nb} && chmod 755 {nb}",
         src = shell_escape(bundled_runt.to_string_lossy().as_ref()),
         runt = shell_escape(runt_dest.to_string_lossy().as_ref()),
         nb = shell_escape(nb_dest.to_string_lossy().as_ref()),
@@ -542,8 +550,15 @@ fn install_with_privilege_escalation(
     nb_dest: &std::path::Path,
     nb_script: &str,
 ) -> Result<(), String> {
+    let dir = shell_escape(
+        runt_dest
+            .parent()
+            .ok_or("Invalid install destination")?
+            .to_string_lossy()
+            .as_ref(),
+    );
     let shell_cmd = format!(
-        "rm -f {runt} {nb} && ln -s {src} {runt} && printf '%s' {nb_escaped} > {nb} && chmod 755 {nb}",
+        "mkdir -p {dir} && rm -f {runt} {nb} && ln -s {src} {runt} && printf '%s' {nb_escaped} > {nb} && chmod 755 {nb}",
         src = shell_escape(bundled_runt.to_string_lossy().as_ref()),
         runt = shell_escape(runt_dest.to_string_lossy().as_ref()),
         nb = shell_escape(nb_dest.to_string_lossy().as_ref()),
@@ -576,7 +591,8 @@ fn install_with_privilege_escalation(
     _nb_script: &str,
 ) -> Result<(), String> {
     // On Windows, use PowerShell's Start-Process with -Verb RunAs for UAC elevation.
-    // We copy the binary (symlinks need admin and have compat issues on Windows).
+    // We copy the runt binary and create a .cmd wrapper for nb (since copying the
+    // binary would just give another runt instance, not a notebook shorthand).
     // Use a temp file for error reporting since Start-Process -Verb RunAs doesn't
     // propagate the inner process exit code.
     let install_dir = runt_dest
@@ -586,18 +602,21 @@ fn install_with_privilege_escalation(
         .replace('\'', "''");
     let src = bundled_runt.to_string_lossy().replace('\'', "''");
     let runt = runt_dest.to_string_lossy().replace('\'', "''");
-    let nb = nb_dest.to_string_lossy().replace('\'', "''");
+    // nb on Windows is a .cmd wrapper that calls runt notebook
+    let nb_cmd = nb_dest.with_extension("cmd");
+    let nb = nb_cmd.to_string_lossy().replace('\'', "''");
+    let cli_cmd = runt_workspace::cli_command_name();
 
     let err_file = std::env::temp_dir().join("nteract-cli-install-err.txt");
     let err_path = err_file.to_string_lossy().replace('\'', "''");
 
-    // The elevated script: create dir, copy files, add to system PATH, write errors
+    // The elevated script: create dir, copy runt, write nb.cmd wrapper, add to PATH
     let ps_cmd = format!(
         "$ErrorActionPreference='Stop'; try {{ \
          New-Item -ItemType Directory -Force -Path '{install_dir}' | Out-Null; \
          Remove-Item -Force -ErrorAction SilentlyContinue '{runt}','{nb}'; \
          Copy-Item '{src}' '{runt}'; \
-         Copy-Item '{src}' '{nb}'; \
+         Set-Content -Path '{nb}' -Value '@echo off`r`n{cli_cmd} notebook %*' -Encoding ASCII; \
          $path = [Environment]::GetEnvironmentVariable('Path','Machine'); \
          if ($path -notlike '*{install_dir}*') {{ \
            [Environment]::SetEnvironmentVariable('Path', $path + ';{install_dir}', 'Machine') \

--- a/crates/notebook/src/cli_install.rs
+++ b/crates/notebook/src/cli_install.rs
@@ -398,6 +398,26 @@ pub fn ensure_cli_current(app: &tauri::AppHandle) {
         } else {
             log::info!("[cli_install] CLI updated successfully");
         }
+
+        // Check system-wide install too. We can't silently refresh it (requires
+        // admin privileges), but we can log a warning so diagnostics catch it.
+        if is_cli_installed_system() {
+            let system_dir = PathBuf::from(SYSTEM_INSTALL_DIR);
+            let system_runt = system_dir.join(cli_command_name());
+            if let Some(bundled) = get_bundled_runt_path(app) {
+                let system_size = fs::metadata(&system_runt).map(|m| m.len()).unwrap_or(0);
+                let bundled_size = fs::metadata(&bundled).map(|m| m.len()).unwrap_or(0);
+                if system_size != bundled_size {
+                    log::warn!(
+                        "[cli_install] System-wide {} is stale (size {} vs bundled {}). \
+                         It will be updated on next in-app upgrade, or re-run Install CLI from the menu.",
+                        system_runt.display(),
+                        system_size,
+                        bundled_size
+                    );
+                }
+            }
+        }
     }
 }
 
@@ -513,26 +533,6 @@ pub fn install_cli_system(app: &tauri::AppHandle) -> Result<(), String> {
         cli_command_name(),
         cli_command_name()
     );
-
-    // Check for existing commands that aren't ours before overwriting.
-    // If the marker file is missing but the commands exist, something else
-    // put them there (Homebrew, manual install, another tool named "nb", etc.).
-    let marker_path = dir.join(system_install_marker());
-    if !marker_path.exists() {
-        let existing: Vec<&str> = [&runt_dest, &nb_dest]
-            .iter()
-            .filter(|p| p.exists())
-            .map(|p| p.file_name().unwrap_or_default().to_str().unwrap_or("?"))
-            .collect();
-        if !existing.is_empty() {
-            return Err(format!(
-                "Existing commands found in {}: {}. These don't appear to be managed by nteract \
-                 (no marker file). Remove them manually first, or use the ~/.local/bin install.",
-                SYSTEM_INSTALL_DIR,
-                existing.join(", ")
-            ));
-        }
-    }
 
     install_with_privilege_escalation(&bundled_runt, &runt_dest, &nb_dest, &nb_script)?;
 

--- a/crates/notebook/src/cli_install.rs
+++ b/crates/notebook/src/cli_install.rs
@@ -403,7 +403,7 @@ pub fn ensure_cli_current(app: &tauri::AppHandle) {
 
 /// Check if the CLI is already installed (checks user-local, system-wide, and legacy locations).
 pub fn is_cli_installed() -> bool {
-    is_cli_installed_local() || is_cli_installed_system()
+    is_cli_installed_local() || is_cli_installed_system() || is_cli_installed_legacy()
 }
 
 /// Check if the CLI is installed to the user-local directory (`~/.local/bin`).
@@ -414,14 +414,31 @@ pub fn is_cli_installed_local() -> bool {
     dir.join(cli_name).exists() && dir.join(nb_name).exists()
 }
 
-/// Marker file placed by system-wide install to distinguish our managed copy
-/// from binaries installed by other means (Homebrew, manual, etc.).
-const SYSTEM_INSTALL_MARKER: &str = ".nteract-managed";
+/// Check if the CLI has a legacy install in `/usr/local/bin` (pre-system-wide era).
+pub fn is_cli_installed_legacy() -> bool {
+    #[cfg(unix)]
+    {
+        let legacy = PathBuf::from(LEGACY_INSTALL_DIR);
+        let cli_name = cli_command_name();
+        let nb_name = cli_notebook_alias_name();
+        legacy.join(cli_name).exists() && legacy.join(nb_name).exists()
+    }
+    #[cfg(not(unix))]
+    {
+        false
+    }
+}
+
+/// Channel-specific marker file placed by system-wide install to distinguish
+/// our managed copy from binaries installed by other means (Homebrew, manual, etc.).
+fn system_install_marker() -> String {
+    format!(".nteract-managed-{}", cli_command_name())
+}
 
 /// Check if the CLI is installed system-wide by nteract (looks for our marker file).
 pub fn is_cli_installed_system() -> bool {
     PathBuf::from(SYSTEM_INSTALL_DIR)
-        .join(SYSTEM_INSTALL_MARKER)
+        .join(system_install_marker())
         .exists()
 }
 
@@ -524,7 +541,7 @@ fn install_with_privilege_escalation(
         runt_dest
             .parent()
             .ok_or("Invalid install destination")?
-            .join(SYSTEM_INSTALL_MARKER)
+            .join(system_install_marker())
             .to_string_lossy()
             .as_ref(),
     );
@@ -595,7 +612,7 @@ fn install_with_privilege_escalation(
         runt_dest
             .parent()
             .ok_or("Invalid install destination")?
-            .join(SYSTEM_INSTALL_MARKER)
+            .join(system_install_marker())
             .to_string_lossy()
             .as_ref(),
     );
@@ -649,7 +666,7 @@ fn install_with_privilege_escalation(
     let nb = nb_cmd.to_string_lossy().replace('\'', "''");
     let cli_cmd = runt_workspace::cli_command_name();
 
-    let marker = SYSTEM_INSTALL_MARKER.replace('\'', "''");
+    let marker = system_install_marker().replace('\'', "''");
 
     let err_file = std::env::temp_dir().join("nteract-cli-install-err.txt");
     let err_path = err_file.to_string_lossy().replace('\'', "''");

--- a/crates/notebook/src/cli_install.rs
+++ b/crates/notebook/src/cli_install.rs
@@ -456,6 +456,158 @@ pub fn install_cli(app: &tauri::AppHandle) -> Result<(), String> {
     Ok(())
 }
 
+/// System-wide install directory.
+const SYSTEM_INSTALL_DIR: &str = if cfg!(unix) {
+    "/usr/local/bin"
+} else {
+    "C:\\Program Files\\nteract"
+};
+
+/// Install the CLI system-wide to `/usr/local/bin` (Unix) or `C:\Program Files\nteract`
+/// (Windows) using OS privilege escalation.
+/// Returns Ok(()) on success, Err with message on failure.
+pub fn install_cli_system(app: &tauri::AppHandle) -> Result<(), String> {
+    let bundled_runt = get_bundled_runt_path(app)
+        .ok_or_else(|| "Could not find bundled runt binary".to_string())?;
+
+    let dir = PathBuf::from(SYSTEM_INSTALL_DIR);
+    let runt_dest = dir.join(cli_command_name());
+    let nb_dest = dir.join(cli_notebook_alias_name());
+
+    // Build the nb wrapper script content
+    let nb_script = format!(
+        "#!/bin/bash\n# {} - open notebooks faster than you can say {} notebook\nexec {} notebook \"$@\"\n",
+        cli_notebook_alias_name(),
+        cli_command_name(),
+        cli_command_name()
+    );
+
+    install_with_privilege_escalation(&bundled_runt, &runt_dest, &nb_dest, &nb_script)?;
+
+    log::info!(
+        "[cli_install] CLI installed system-wide: {} -> {}",
+        runt_dest.display(),
+        bundled_runt.display()
+    );
+
+    Ok(())
+}
+
+/// Install CLI commands to a privileged directory using OS-specific escalation.
+#[cfg(target_os = "macos")]
+fn install_with_privilege_escalation(
+    bundled_runt: &std::path::Path,
+    runt_dest: &std::path::Path,
+    nb_dest: &std::path::Path,
+    nb_script: &str,
+) -> Result<(), String> {
+    // Build the shell script that will run with admin privileges.
+    // We create the symlink for runt and write the nb wrapper script.
+    let shell_cmd = format!(
+        "rm -f {runt} {nb} && ln -s {src} {runt} && printf '%s' {nb_escaped} > {nb} && chmod 755 {nb}",
+        src = shell_escape(bundled_runt.to_string_lossy().as_ref()),
+        runt = shell_escape(runt_dest.to_string_lossy().as_ref()),
+        nb = shell_escape(nb_dest.to_string_lossy().as_ref()),
+        nb_escaped = shell_escape(nb_script),
+    );
+
+    let output = std::process::Command::new("osascript")
+        .arg("-e")
+        .arg(format!(
+            "do shell script \"{}\" with administrator privileges",
+            shell_cmd.replace('\\', "\\\\").replace('"', "\\\"")
+        ))
+        .output()
+        .map_err(|e| format!("Failed to run privilege escalation: {}", e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        // User clicked "Cancel" in the authorization dialog
+        if stderr.contains("User canceled")
+            || stderr.contains("user canceled")
+            || stderr.contains("-128")
+        {
+            return Err("Installation cancelled.".to_string());
+        }
+        return Err(format!("Privilege escalation failed: {}", stderr.trim()));
+    }
+
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn install_with_privilege_escalation(
+    bundled_runt: &std::path::Path,
+    runt_dest: &std::path::Path,
+    nb_dest: &std::path::Path,
+    nb_script: &str,
+) -> Result<(), String> {
+    let shell_cmd = format!(
+        "rm -f {runt} {nb} && ln -s {src} {runt} && printf '%s' {nb_escaped} > {nb} && chmod 755 {nb}",
+        src = shell_escape(bundled_runt.to_string_lossy().as_ref()),
+        runt = shell_escape(runt_dest.to_string_lossy().as_ref()),
+        nb = shell_escape(nb_dest.to_string_lossy().as_ref()),
+        nb_escaped = shell_escape(nb_script),
+    );
+
+    let output = std::process::Command::new("pkexec")
+        .arg("sh")
+        .arg("-c")
+        .arg(&shell_cmd)
+        .output()
+        .map_err(|e| format!("Failed to run privilege escalation: {}", e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if stderr.contains("dismissed") || stderr.contains("Not authorized") {
+            return Err("Installation cancelled.".to_string());
+        }
+        return Err(format!("Privilege escalation failed: {}", stderr.trim()));
+    }
+
+    Ok(())
+}
+
+#[cfg(target_os = "windows")]
+fn install_with_privilege_escalation(
+    bundled_runt: &std::path::Path,
+    runt_dest: &std::path::Path,
+    nb_dest: &std::path::Path,
+    _nb_script: &str,
+) -> Result<(), String> {
+    // On Windows, use PowerShell's Start-Process with -Verb RunAs for UAC elevation.
+    // We copy the binary (symlinks need admin and have compat issues on Windows).
+    let ps_cmd = format!(
+        "Remove-Item -Force -ErrorAction SilentlyContinue '{runt}','{nb}'; Copy-Item '{src}' '{runt}'; Copy-Item '{src}' '{nb}'",
+        src = bundled_runt.to_string_lossy().replace('\'', "''"),
+        runt = runt_dest.to_string_lossy().replace('\'', "''"),
+        nb = nb_dest.to_string_lossy().replace('\'', "''"),
+    );
+
+    let output = std::process::Command::new("powershell")
+        .args([
+            "-Command",
+            &format!(
+                "Start-Process powershell -Verb RunAs -Wait -ArgumentList '-Command','{}'",
+                ps_cmd.replace('\'', "''")
+            ),
+        ])
+        .output()
+        .map_err(|e| format!("Failed to run privilege escalation: {}", e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("Privilege escalation failed: {}", stderr.trim()));
+    }
+
+    Ok(())
+}
+
+/// Escape a string for use inside a single-quoted shell argument.
+fn shell_escape(s: &str) -> String {
+    format!("'{}'", s.replace('\'', "'\\''"))
+}
+
 /// Warn if legacy /usr/local/bin has stale CLI copies that shadow ~/.local/bin.
 ///
 /// Symlinks are fine — they track the app bundle. Only regular files (stale

--- a/crates/notebook/src/cli_install.rs
+++ b/crates/notebook/src/cli_install.rs
@@ -514,6 +514,26 @@ pub fn install_cli_system(app: &tauri::AppHandle) -> Result<(), String> {
         cli_command_name()
     );
 
+    // Check for existing commands that aren't ours before overwriting.
+    // If the marker file is missing but the commands exist, something else
+    // put them there (Homebrew, manual install, another tool named "nb", etc.).
+    let marker_path = dir.join(system_install_marker());
+    if !marker_path.exists() {
+        let existing: Vec<&str> = [&runt_dest, &nb_dest]
+            .iter()
+            .filter(|p| p.exists())
+            .map(|p| p.file_name().unwrap_or_default().to_str().unwrap_or("?"))
+            .collect();
+        if !existing.is_empty() {
+            return Err(format!(
+                "Existing commands found in {}: {}. These don't appear to be managed by nteract \
+                 (no marker file). Remove them manually first, or use the ~/.local/bin install.",
+                SYSTEM_INSTALL_DIR,
+                existing.join(", ")
+            ));
+        }
+    }
+
     install_with_privilege_escalation(&bundled_runt, &runt_dest, &nb_dest, &nb_script)?;
 
     log::info!(

--- a/crates/notebook/src/cli_install.rs
+++ b/crates/notebook/src/cli_install.rs
@@ -471,7 +471,13 @@ pub fn install_cli_system(app: &tauri::AppHandle) -> Result<(), String> {
         .ok_or_else(|| "Could not find bundled runt binary".to_string())?;
 
     let dir = PathBuf::from(SYSTEM_INSTALL_DIR);
-    let runt_dest = dir.join(cli_command_name());
+    // On Windows, executables need the .exe extension to be discoverable via PATH
+    let runt_name = if cfg!(windows) {
+        format!("{}.exe", cli_command_name())
+    } else {
+        cli_command_name().to_string()
+    };
+    let runt_dest = dir.join(runt_name);
     let nb_dest = dir.join(cli_notebook_alias_name());
 
     // Build the nb wrapper script content
@@ -485,7 +491,7 @@ pub fn install_cli_system(app: &tauri::AppHandle) -> Result<(), String> {
     install_with_privilege_escalation(&bundled_runt, &runt_dest, &nb_dest, &nb_script)?;
 
     log::info!(
-        "[cli_install] CLI installed system-wide: {} -> {}",
+        "[cli_install] CLI installed system-wide: {} (copied from {})",
         runt_dest.display(),
         bundled_runt.display()
     );
@@ -502,8 +508,8 @@ fn install_with_privilege_escalation(
     nb_script: &str,
 ) -> Result<(), String> {
     // Build the shell script that will run with admin privileges.
-    // We create the directory (may not exist on clean installs), symlink runt,
-    // and write the nb wrapper script.
+    // We copy the binary (not symlink) so the install is durable even if the
+    // app bundle is moved, unmounted, or accessed by another user account.
     let dir = shell_escape(
         runt_dest
             .parent()
@@ -512,7 +518,7 @@ fn install_with_privilege_escalation(
             .as_ref(),
     );
     let shell_cmd = format!(
-        "mkdir -p {dir} && rm -f {runt} {nb} && ln -s {src} {runt} && printf '%s' {nb_escaped} > {nb} && chmod 755 {nb}",
+        "mkdir -p {dir} && rm -f {runt} {nb} && cp {src} {runt} && chmod 755 {runt} && printf '%s' {nb_escaped} > {nb} && chmod 755 {nb}",
         src = shell_escape(bundled_runt.to_string_lossy().as_ref()),
         runt = shell_escape(runt_dest.to_string_lossy().as_ref()),
         nb = shell_escape(nb_dest.to_string_lossy().as_ref()),
@@ -558,7 +564,7 @@ fn install_with_privilege_escalation(
             .as_ref(),
     );
     let shell_cmd = format!(
-        "mkdir -p {dir} && rm -f {runt} {nb} && ln -s {src} {runt} && printf '%s' {nb_escaped} > {nb} && chmod 755 {nb}",
+        "mkdir -p {dir} && rm -f {runt} {nb} && cp {src} {runt} && chmod 755 {runt} && printf '%s' {nb_escaped} > {nb} && chmod 755 {nb}",
         src = shell_escape(bundled_runt.to_string_lossy().as_ref()),
         runt = shell_escape(runt_dest.to_string_lossy().as_ref()),
         nb = shell_escape(nb_dest.to_string_lossy().as_ref()),

--- a/crates/notebook/src/cli_install.rs
+++ b/crates/notebook/src/cli_install.rs
@@ -414,15 +414,15 @@ pub fn is_cli_installed_local() -> bool {
     dir.join(cli_name).exists() && dir.join(nb_name).exists()
 }
 
-/// Check if the CLI is installed system-wide (`/usr/local/bin` or equivalent).
+/// Marker file placed by system-wide install to distinguish our managed copy
+/// from binaries installed by other means (Homebrew, manual, etc.).
+const SYSTEM_INSTALL_MARKER: &str = ".nteract-managed";
+
+/// Check if the CLI is installed system-wide by nteract (looks for our marker file).
 pub fn is_cli_installed_system() -> bool {
-    let dir = PathBuf::from(SYSTEM_INSTALL_DIR);
-    let runt_name = if cfg!(windows) {
-        format!("{}.exe", cli_command_name())
-    } else {
-        cli_command_name().to_string()
-    };
-    dir.join(runt_name).exists()
+    PathBuf::from(SYSTEM_INSTALL_DIR)
+        .join(SYSTEM_INSTALL_MARKER)
+        .exists()
 }
 
 /// Install the CLI to `~/.local/bin` (no admin privileges needed).
@@ -520,27 +520,47 @@ fn install_with_privilege_escalation(
             .to_string_lossy()
             .as_ref(),
     );
+    let marker = shell_escape(
+        runt_dest
+            .parent()
+            .ok_or("Invalid install destination")?
+            .join(SYSTEM_INSTALL_MARKER)
+            .to_string_lossy()
+            .as_ref(),
+    );
     let shell_cmd = format!(
-        "mkdir -p {dir} && rm -f {runt} {nb} && cp {src} {runt} && chmod 755 {runt} && printf '%s' {nb_escaped} > {nb} && chmod 755 {nb}",
+        "mkdir -p {dir} && rm -f {runt} {nb} && cp {src} {runt} && chmod 755 {runt} && printf '%s' {nb_escaped} > {nb} && chmod 755 {nb} && touch {marker}",
         src = shell_escape(bundled_runt.to_string_lossy().as_ref()),
         runt = shell_escape(runt_dest.to_string_lossy().as_ref()),
         nb = shell_escape(nb_dest.to_string_lossy().as_ref()),
         nb_escaped = shell_escape(nb_script),
     );
 
-    // Escape for AppleScript string: backslashes, double quotes, and newlines
-    let escaped = shell_cmd
+    // Escape for AppleScript do shell script string. Single quotes inside
+    // shell_escape output don't need extra escaping for AppleScript double-quote
+    // context, but backslashes and double quotes do. Newlines within single-quoted
+    // shell strings are valid and preserved by the shell, but the AppleScript
+    // "do shell script" string literal doesn't support them directly — we need
+    // to split the script into lines joined by AppleScript string concatenation.
+    // Simpler: write the shell command to a temp file and execute that.
+    let temp_script = std::env::temp_dir().join("nteract-cli-install.sh");
+    fs::write(&temp_script, &shell_cmd)
+        .map_err(|e| format!("Failed to write install script: {}", e))?;
+
+    let escaped_script_path = temp_script
+        .to_string_lossy()
         .replace('\\', "\\\\")
-        .replace('"', "\\\"")
-        .replace('\n', "\\n");
+        .replace('"', "\\\"");
     let output = std::process::Command::new("osascript")
         .arg("-e")
         .arg(format!(
-            "do shell script \"{}\" with administrator privileges",
-            escaped
+            "do shell script \"sh '{escaped_script_path}'\" with administrator privileges"
         ))
         .output()
         .map_err(|e| format!("Failed to run privilege escalation: {}", e))?;
+
+    // Clean up temp script
+    let _ = fs::remove_file(&temp_script);
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -571,8 +591,16 @@ fn install_with_privilege_escalation(
             .to_string_lossy()
             .as_ref(),
     );
+    let marker = shell_escape(
+        runt_dest
+            .parent()
+            .ok_or("Invalid install destination")?
+            .join(SYSTEM_INSTALL_MARKER)
+            .to_string_lossy()
+            .as_ref(),
+    );
     let shell_cmd = format!(
-        "mkdir -p {dir} && rm -f {runt} {nb} && cp {src} {runt} && chmod 755 {runt} && printf '%s' {nb_escaped} > {nb} && chmod 755 {nb}",
+        "mkdir -p {dir} && rm -f {runt} {nb} && cp {src} {runt} && chmod 755 {runt} && printf '%s' {nb_escaped} > {nb} && chmod 755 {nb} && touch {marker}",
         src = shell_escape(bundled_runt.to_string_lossy().as_ref()),
         runt = shell_escape(runt_dest.to_string_lossy().as_ref()),
         nb = shell_escape(nb_dest.to_string_lossy().as_ref()),
@@ -621,6 +649,8 @@ fn install_with_privilege_escalation(
     let nb = nb_cmd.to_string_lossy().replace('\'', "''");
     let cli_cmd = runt_workspace::cli_command_name();
 
+    let marker = SYSTEM_INSTALL_MARKER.replace('\'', "''");
+
     let err_file = std::env::temp_dir().join("nteract-cli-install-err.txt");
     let err_path = err_file.to_string_lossy().replace('\'', "''");
 
@@ -632,6 +662,7 @@ fn install_with_privilege_escalation(
          Remove-Item -Force -ErrorAction SilentlyContinue '{runt}','{nb}'; \
          Copy-Item '{src}' '{runt}'; \
          Set-Content -Path '{nb}' -Value \"@echo off`r`n{cli_cmd} notebook %*\" -Encoding ASCII; \
+         New-Item -ItemType File -Force -Path '{install_dir}\\{marker}' | Out-Null; \
          $path = [Environment]::GetEnvironmentVariable('Path','Machine'); \
          if ($path -notlike '*{install_dir}*') {{ \
            [Environment]::SetEnvironmentVariable('Path', $path + ';{install_dir}', 'Machine'); \

--- a/crates/notebook/src/cli_install.rs
+++ b/crates/notebook/src/cli_install.rs
@@ -415,9 +415,15 @@ pub fn is_cli_installed_local() -> bool {
 }
 
 /// Check if the CLI has a legacy install in `/usr/local/bin` (pre-system-wide era).
+/// Returns false if the system-wide marker is present (that's a managed install,
+/// not a legacy one).
 pub fn is_cli_installed_legacy() -> bool {
     #[cfg(unix)]
     {
+        // If the system-wide marker exists, this is a managed install, not legacy
+        if is_cli_installed_system() {
+            return false;
+        }
         let legacy = PathBuf::from(LEGACY_INSTALL_DIR);
         let cli_name = cli_command_name();
         let nb_name = cli_notebook_alias_name();
@@ -553,16 +559,32 @@ fn install_with_privilege_escalation(
         nb_escaped = shell_escape(nb_script),
     );
 
-    // Escape for AppleScript do shell script string. Single quotes inside
-    // shell_escape output don't need extra escaping for AppleScript double-quote
-    // context, but backslashes and double quotes do. Newlines within single-quoted
-    // shell strings are valid and preserved by the shell, but the AppleScript
-    // "do shell script" string literal doesn't support them directly — we need
-    // to split the script into lines joined by AppleScript string concatenation.
-    // Simpler: write the shell command to a temp file and execute that.
-    let temp_script = std::env::temp_dir().join("nteract-cli-install.sh");
-    fs::write(&temp_script, &shell_cmd)
-        .map_err(|e| format!("Failed to write install script: {}", e))?;
+    // Write the shell command to a secure temp file to avoid multiline string
+    // issues in AppleScript. Use a unique filename and restrict permissions to
+    // prevent TOCTOU attacks (another process replacing the script before osascript
+    // executes it with admin privileges).
+    let temp_script =
+        std::env::temp_dir().join(format!("nteract-cli-install-{}.sh", std::process::id()));
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut file = fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o700)
+            .open(&temp_script)
+            .or_else(|_| {
+                // File might exist from a previous failed attempt
+                let _ = fs::remove_file(&temp_script);
+                fs::OpenOptions::new()
+                    .write(true)
+                    .create_new(true)
+                    .mode(0o700)
+                    .open(&temp_script)
+            })
+            .map_err(|e| format!("Failed to create install script: {}", e))?;
+        file.write_all(shell_cmd.as_bytes())
+            .map_err(|e| format!("Failed to write install script: {}", e))?;
+    }
 
     let escaped_script_path = temp_script
         .to_string_lossy()

--- a/crates/notebook/src/cli_install.rs
+++ b/crates/notebook/src/cli_install.rs
@@ -704,7 +704,7 @@ fn install_with_privilege_escalation(
          New-Item -ItemType File -Force -Path '{install_dir}\\{marker}' | Out-Null; \
          $path = [Environment]::GetEnvironmentVariable('Path','Machine'); \
          if ($path -notlike '*{install_dir}*') {{ \
-           [Environment]::SetEnvironmentVariable('Path', $path + ';{install_dir}', 'Machine'); \
+           [Environment]::SetEnvironmentVariable('Path', '{install_dir};' + $path, 'Machine'); \
            Add-Type -Namespace Win32 -Name NativeMethods -MemberDefinition '[DllImport(\"user32.dll\", SetLastError=true, CharSet=CharSet.Auto)] public static extern IntPtr SendMessageTimeout(IntPtr hWnd, uint Msg, UIntPtr wParam, string lParam, uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);'; \
            $r = [UIntPtr]::Zero; \
            [Win32.NativeMethods]::SendMessageTimeout([IntPtr]0xFFFF, 0x1A, [UIntPtr]::Zero, 'Environment', 2, 5000, [ref]$r) | Out-Null \

--- a/crates/notebook/src/cli_install.rs
+++ b/crates/notebook/src/cli_install.rs
@@ -407,7 +407,7 @@ pub fn is_cli_installed() -> bool {
 }
 
 /// Check if the CLI is installed to the user-local directory (`~/.local/bin`).
-fn is_cli_installed_local() -> bool {
+pub fn is_cli_installed_local() -> bool {
     let cli_name = cli_command_name();
     let nb_name = cli_notebook_alias_name();
     let dir = install_dir();
@@ -528,11 +528,16 @@ fn install_with_privilege_escalation(
         nb_escaped = shell_escape(nb_script),
     );
 
+    // Escape for AppleScript string: backslashes, double quotes, and newlines
+    let escaped = shell_cmd
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('\n', "\\n");
     let output = std::process::Command::new("osascript")
         .arg("-e")
         .arg(format!(
             "do shell script \"{}\" with administrator privileges",
-            shell_cmd.replace('\\', "\\\\").replace('"', "\\\"")
+            escaped
         ))
         .output()
         .map_err(|e| format!("Failed to run privilege escalation: {}", e))?;
@@ -626,7 +631,7 @@ fn install_with_privilege_escalation(
          New-Item -ItemType Directory -Force -Path '{install_dir}' | Out-Null; \
          Remove-Item -Force -ErrorAction SilentlyContinue '{runt}','{nb}'; \
          Copy-Item '{src}' '{runt}'; \
-         Set-Content -Path '{nb}' -Value '@echo off`r`n{cli_cmd} notebook %*' -Encoding ASCII; \
+         Set-Content -Path '{nb}' -Value \"@echo off`r`n{cli_cmd} notebook %*\" -Encoding ASCII; \
          $path = [Environment]::GetEnvironmentVariable('Path','Machine'); \
          if ($path -notlike '*{install_dir}*') {{ \
            [Environment]::SetEnvironmentVariable('Path', $path + ';{install_dir}', 'Machine'); \

--- a/crates/notebook/src/cli_install.rs
+++ b/crates/notebook/src/cli_install.rs
@@ -457,7 +457,7 @@ pub fn install_cli(app: &tauri::AppHandle) -> Result<(), String> {
 }
 
 /// System-wide install directory.
-const SYSTEM_INSTALL_DIR: &str = if cfg!(unix) {
+pub const SYSTEM_INSTALL_DIR: &str = if cfg!(unix) {
     "/usr/local/bin"
 } else {
     "C:\\Program Files\\nteract"
@@ -577,11 +577,33 @@ fn install_with_privilege_escalation(
 ) -> Result<(), String> {
     // On Windows, use PowerShell's Start-Process with -Verb RunAs for UAC elevation.
     // We copy the binary (symlinks need admin and have compat issues on Windows).
+    // Use a temp file for error reporting since Start-Process -Verb RunAs doesn't
+    // propagate the inner process exit code.
+    let install_dir = runt_dest
+        .parent()
+        .ok_or("Invalid install destination")?
+        .to_string_lossy()
+        .replace('\'', "''");
+    let src = bundled_runt.to_string_lossy().replace('\'', "''");
+    let runt = runt_dest.to_string_lossy().replace('\'', "''");
+    let nb = nb_dest.to_string_lossy().replace('\'', "''");
+
+    let err_file = std::env::temp_dir().join("nteract-cli-install-err.txt");
+    let err_path = err_file.to_string_lossy().replace('\'', "''");
+
+    // The elevated script: create dir, copy files, add to system PATH, write errors
     let ps_cmd = format!(
-        "Remove-Item -Force -ErrorAction SilentlyContinue '{runt}','{nb}'; Copy-Item '{src}' '{runt}'; Copy-Item '{src}' '{nb}'",
-        src = bundled_runt.to_string_lossy().replace('\'', "''"),
-        runt = runt_dest.to_string_lossy().replace('\'', "''"),
-        nb = nb_dest.to_string_lossy().replace('\'', "''"),
+        "$ErrorActionPreference='Stop'; try {{ \
+         New-Item -ItemType Directory -Force -Path '{install_dir}' | Out-Null; \
+         Remove-Item -Force -ErrorAction SilentlyContinue '{runt}','{nb}'; \
+         Copy-Item '{src}' '{runt}'; \
+         Copy-Item '{src}' '{nb}'; \
+         $path = [Environment]::GetEnvironmentVariable('Path','Machine'); \
+         if ($path -notlike '*{install_dir}*') {{ \
+           [Environment]::SetEnvironmentVariable('Path', $path + ';{install_dir}', 'Machine') \
+         }}; \
+         Remove-Item -Force -ErrorAction SilentlyContinue '{err_path}' \
+         }} catch {{ $_.Exception.Message | Out-File '{err_path}' -Encoding utf8 }}"
     );
 
     let output = std::process::Command::new("powershell")
@@ -598,6 +620,15 @@ fn install_with_privilege_escalation(
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         return Err(format!("Privilege escalation failed: {}", stderr.trim()));
+    }
+
+    // Check the error file written by the elevated script
+    if err_file.exists() {
+        let err_msg = fs::read_to_string(&err_file).unwrap_or_default();
+        let _ = fs::remove_file(&err_file);
+        if !err_msg.trim().is_empty() {
+            return Err(format!("Installation failed: {}", err_msg.trim()));
+        }
     }
 
     Ok(())

--- a/crates/notebook/src/cli_install.rs
+++ b/crates/notebook/src/cli_install.rs
@@ -401,25 +401,28 @@ pub fn ensure_cli_current(app: &tauri::AppHandle) {
     }
 }
 
-/// Check if the CLI is already installed (checks both new and legacy locations).
+/// Check if the CLI is already installed (checks user-local, system-wide, and legacy locations).
 pub fn is_cli_installed() -> bool {
+    is_cli_installed_local() || is_cli_installed_system()
+}
+
+/// Check if the CLI is installed to the user-local directory (`~/.local/bin`).
+fn is_cli_installed_local() -> bool {
     let cli_name = cli_command_name();
     let nb_name = cli_notebook_alias_name();
+    let dir = install_dir();
+    dir.join(cli_name).exists() && dir.join(nb_name).exists()
+}
 
-    let new_dir = install_dir();
-    if new_dir.join(cli_name).exists() && new_dir.join(nb_name).exists() {
-        return true;
-    }
-
-    #[cfg(unix)]
-    {
-        let legacy = PathBuf::from(LEGACY_INSTALL_DIR);
-        if legacy.join(cli_name).exists() && legacy.join(nb_name).exists() {
-            return true;
-        }
-    }
-
-    false
+/// Check if the CLI is installed system-wide (`/usr/local/bin` or equivalent).
+pub fn is_cli_installed_system() -> bool {
+    let dir = PathBuf::from(SYSTEM_INSTALL_DIR);
+    let runt_name = if cfg!(windows) {
+        format!("{}.exe", cli_command_name())
+    } else {
+        cli_command_name().to_string()
+    };
+    dir.join(runt_name).exists()
 }
 
 /// Install the CLI to `~/.local/bin` (no admin privileges needed).
@@ -616,7 +619,8 @@ fn install_with_privilege_escalation(
     let err_file = std::env::temp_dir().join("nteract-cli-install-err.txt");
     let err_path = err_file.to_string_lossy().replace('\'', "''");
 
-    // The elevated script: create dir, copy runt, write nb.cmd wrapper, add to PATH
+    // The elevated script: create dir, copy runt, write nb.cmd wrapper, add to PATH,
+    // then broadcast WM_SETTINGCHANGE so new shells pick up the PATH change.
     let ps_cmd = format!(
         "$ErrorActionPreference='Stop'; try {{ \
          New-Item -ItemType Directory -Force -Path '{install_dir}' | Out-Null; \
@@ -625,7 +629,10 @@ fn install_with_privilege_escalation(
          Set-Content -Path '{nb}' -Value '@echo off`r`n{cli_cmd} notebook %*' -Encoding ASCII; \
          $path = [Environment]::GetEnvironmentVariable('Path','Machine'); \
          if ($path -notlike '*{install_dir}*') {{ \
-           [Environment]::SetEnvironmentVariable('Path', $path + ';{install_dir}', 'Machine') \
+           [Environment]::SetEnvironmentVariable('Path', $path + ';{install_dir}', 'Machine'); \
+           Add-Type -Namespace Win32 -Name NativeMethods -MemberDefinition '[DllImport(\"user32.dll\", SetLastError=true, CharSet=CharSet.Auto)] public static extern IntPtr SendMessageTimeout(IntPtr hWnd, uint Msg, UIntPtr wParam, string lParam, uint fuFlags, uint uTimeout, out UIntPtr lpdwResult);'; \
+           $r = [UIntPtr]::Zero; \
+           [Win32.NativeMethods]::SendMessageTimeout([IntPtr]0xFFFF, 0x1A, [UIntPtr]::Zero, 'Environment', 2, 5000, [ref]$r) | Out-Null \
          }}; \
          Remove-Item -Force -ErrorAction SilentlyContinue '{err_path}' \
          }} catch {{ $_.Exception.Message | Out-File '{err_path}' -Encoding utf8 }}"

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -4703,13 +4703,14 @@ pub fn run(
                     let app_handle = app.clone();
                     tauri::async_runtime::spawn(async move {
                         // Show confirmation dialog first
+                        let install_dir = crate::cli_install::SYSTEM_INSTALL_DIR;
                         let confirmed =
                             tauri_plugin_dialog::DialogExt::dialog(&app_handle)
-                                .message(
-                                    "This will install the CLI commands to /usr/local/bin, which requires administrator privileges.\n\n\
+                                .message(format!(
+                                    "This will install the CLI commands to {install_dir}, which requires administrator privileges.\n\n\
                                      This is useful for corporate/MDM environments or multi-user machines. \
                                      Most users should use the regular \"Install in PATH\" option instead.",
-                                )
+                                ))
                                 .title("Install System-Wide?")
                                 .kind(tauri_plugin_dialog::MessageDialogKind::Info)
                                 .buttons(tauri_plugin_dialog::MessageDialogButtons::OkCancelCustom(
@@ -4735,8 +4736,10 @@ pub fn run(
                                 );
                                 let cli_cmd = runt_workspace::cli_command_name();
                                 let nb_cmd = runt_workspace::cli_notebook_alias_name();
+                                let install_dir =
+                                    crate::cli_install::SYSTEM_INSTALL_DIR;
                                 let success_message = format!(
-                                    "The '{cli_cmd}' and '{nb_cmd}' commands have been installed to /usr/local/bin.\n\nOpen a new terminal and run: {cli_cmd} --help"
+                                    "The '{cli_cmd}' and '{nb_cmd}' commands have been installed to {install_dir}.\n\nOpen a new terminal and run: {cli_cmd} --help"
                                 );
                                 let _ = tauri_plugin_dialog::DialogExt::dialog(&app_handle)
                                     .message(success_message)

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -1310,7 +1310,8 @@ async fn run_upgrade(
 
     // Step 5: Re-install CLI if it was previously installed (ensures Windows
     // copies and Unix symlinks point at the new app bundle).
-    if cli_install::is_cli_installed() {
+    // Only check the local install — system-wide is handled separately below.
+    if cli_install::is_cli_installed_local() {
         match cli_install::install_cli(&app) {
             Ok(()) => log::info!("[upgrade] CLI re-installed successfully"),
             Err(e) => log::warn!("[upgrade] CLI re-install failed (non-fatal): {}", e),

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -1316,6 +1316,17 @@ async fn run_upgrade(
             Err(e) => log::warn!("[upgrade] CLI re-install failed (non-fatal): {}", e),
         }
     }
+    // Also update the system-wide copy if one exists (it's a copy, not a
+    // symlink, so it won't auto-update with the app bundle).
+    if cli_install::is_cli_installed_system() {
+        match cli_install::install_cli_system(&app) {
+            Ok(()) => log::info!("[upgrade] System-wide CLI re-installed successfully"),
+            Err(e) => log::warn!(
+                "[upgrade] System-wide CLI re-install failed (non-fatal): {}",
+                e
+            ),
+        }
+    }
 
     // Step 6: Signal ready
     app.emit("upgrade:progress", UpgradeProgress::Ready)

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -1310,16 +1310,14 @@ async fn run_upgrade(
 
     // Step 5: Re-install CLI if it was previously installed (ensures Windows
     // copies and Unix symlinks point at the new app bundle).
-    // Check local or legacy installs — system-wide is handled separately below.
-    // Legacy installs get migrated to ~/.local/bin by install_cli().
+    // Local installs: symlinks updated, legacy installs migrated to ~/.local/bin.
     if cli_install::is_cli_installed_local() || cli_install::is_cli_installed_legacy() {
         match cli_install::install_cli(&app) {
-            Ok(()) => log::info!("[upgrade] CLI re-installed successfully"),
-            Err(e) => log::warn!("[upgrade] CLI re-install failed (non-fatal): {}", e),
+            Ok(()) => log::info!("[upgrade] Local CLI re-installed successfully"),
+            Err(e) => log::warn!("[upgrade] Local CLI re-install failed (non-fatal): {}", e),
         }
     }
-    // Also update the system-wide copy if one exists (it's a copy, not a
-    // symlink, so it won't auto-update with the app bundle).
+    // System-wide installs are copies (not symlinks), so they need updating too.
     if cli_install::is_cli_installed_system() {
         match cli_install::install_cli_system(&app) {
             Ok(()) => log::info!("[upgrade] System-wide CLI re-installed successfully"),
@@ -4678,53 +4676,14 @@ pub fn run(
                 crate::menu::MENU_INSTALL_CLI => {
                     let app_handle = app.clone();
                     tauri::async_runtime::spawn(async move {
-                        let result = tauri::async_runtime::spawn_blocking({
-                            let app_handle = app_handle.clone();
-                            move || crate::cli_install::install_cli(&app_handle)
-                        })
-                        .await;
-
-                        match result {
-                            Ok(Ok(())) => {
-                                log::info!("[cli_install] CLI installed successfully");
-                                let cli_cmd = runt_workspace::cli_command_name();
-                                let nb_cmd = runt_workspace::cli_notebook_alias_name();
-                                let success_message = format!(
-                                    "The '{cli_cmd}' and '{nb_cmd}' commands have been installed to ~/.local/bin.\n\nOpen a new terminal and run: {cli_cmd} --help"
-                                );
-                                let _ = tauri_plugin_dialog::DialogExt::dialog(&app_handle)
-                                    .message(success_message)
-                                    .title("CLI Installed")
-                                    .kind(tauri_plugin_dialog::MessageDialogKind::Info)
-                                    .blocking_show();
-                            }
-                            Ok(Err(e)) => {
-                                log::error!("[cli_install] CLI installation failed: {}", e);
-                                let _ = tauri_plugin_dialog::DialogExt::dialog(&app_handle)
-                                    .message(format!("Failed to install CLI: {}", e))
-                                    .title("Installation Failed")
-                                    .kind(tauri_plugin_dialog::MessageDialogKind::Error)
-                                    .blocking_show();
-                            }
-                            Err(e) => {
-                                log::error!("[cli_install] CLI install task panicked: {}", e);
-                            }
-                        }
-                    });
-                }
-                crate::menu::MENU_INSTALL_CLI_SYSTEM => {
-                    let app_handle = app.clone();
-                    tauri::async_runtime::spawn(async move {
-                        // Show confirmation dialog first
+                        // Show confirmation dialog — this requires admin privileges
                         let install_dir = crate::cli_install::SYSTEM_INSTALL_DIR;
                         let confirmed =
                             tauri_plugin_dialog::DialogExt::dialog(&app_handle)
                                 .message(format!(
-                                    "This will install the CLI commands to {install_dir}, which requires administrator privileges.\n\n\
-                                     This is useful for corporate/MDM environments or multi-user machines. \
-                                     Most users should use the regular \"Install in PATH\" option instead.",
+                                    "This will install the CLI commands to {install_dir}, which requires administrator privileges.",
                                 ))
-                                .title("Install System-Wide?")
+                                .title("Install CLI?")
                                 .kind(tauri_plugin_dialog::MessageDialogKind::Info)
                                 .buttons(tauri_plugin_dialog::MessageDialogButtons::OkCancelCustom(
                                     "Install".to_string(),
@@ -4744,43 +4703,30 @@ pub fn run(
 
                         match result {
                             Ok(Ok(())) => {
-                                log::info!(
-                                    "[cli_install] CLI installed system-wide successfully"
-                                );
+                                log::info!("[cli_install] CLI installed successfully");
                                 let cli_cmd = runt_workspace::cli_command_name();
                                 let nb_cmd = runt_workspace::cli_notebook_alias_name();
-                                let install_dir =
-                                    crate::cli_install::SYSTEM_INSTALL_DIR;
                                 let success_message = format!(
                                     "The '{cli_cmd}' and '{nb_cmd}' commands have been installed to {install_dir}.\n\nOpen a new terminal and run: {cli_cmd} --help"
                                 );
                                 let _ = tauri_plugin_dialog::DialogExt::dialog(&app_handle)
                                     .message(success_message)
-                                    .title("CLI Installed System-Wide")
+                                    .title("CLI Installed")
                                     .kind(tauri_plugin_dialog::MessageDialogKind::Info)
                                     .blocking_show();
                             }
                             Ok(Err(e)) => {
-                                log::error!(
-                                    "[cli_install] System-wide CLI installation failed: {}",
-                                    e
-                                );
+                                log::error!("[cli_install] CLI installation failed: {}", e);
                                 if e != "Installation cancelled." {
                                     let _ = tauri_plugin_dialog::DialogExt::dialog(&app_handle)
-                                        .message(format!(
-                                            "Failed to install CLI system-wide: {}",
-                                            e
-                                        ))
+                                        .message(format!("Failed to install CLI: {}", e))
                                         .title("Installation Failed")
                                         .kind(tauri_plugin_dialog::MessageDialogKind::Error)
                                         .blocking_show();
                                 }
                             }
                             Err(e) => {
-                                log::error!(
-                                    "[cli_install] System-wide CLI install task panicked: {}",
-                                    e
-                                );
+                                log::error!("[cli_install] CLI install task panicked: {}", e);
                             }
                         }
                     });

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -1310,8 +1310,9 @@ async fn run_upgrade(
 
     // Step 5: Re-install CLI if it was previously installed (ensures Windows
     // copies and Unix symlinks point at the new app bundle).
-    // Only check the local install — system-wide is handled separately below.
-    if cli_install::is_cli_installed_local() {
+    // Check local or legacy installs — system-wide is handled separately below.
+    // Legacy installs get migrated to ~/.local/bin by install_cli().
+    if cli_install::is_cli_installed_local() || cli_install::is_cli_installed_legacy() {
         match cli_install::install_cli(&app) {
             Ok(()) => log::info!("[upgrade] CLI re-installed successfully"),
             Err(e) => log::warn!("[upgrade] CLI re-install failed (non-fatal): {}", e),

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -4699,6 +4699,76 @@ pub fn run(
                         }
                     });
                 }
+                crate::menu::MENU_INSTALL_CLI_SYSTEM => {
+                    let app_handle = app.clone();
+                    tauri::async_runtime::spawn(async move {
+                        // Show confirmation dialog first
+                        let confirmed =
+                            tauri_plugin_dialog::DialogExt::dialog(&app_handle)
+                                .message(
+                                    "This will install the CLI commands to /usr/local/bin, which requires administrator privileges.\n\n\
+                                     This is useful for corporate/MDM environments or multi-user machines. \
+                                     Most users should use the regular \"Install in PATH\" option instead.",
+                                )
+                                .title("Install System-Wide?")
+                                .kind(tauri_plugin_dialog::MessageDialogKind::Info)
+                                .buttons(tauri_plugin_dialog::MessageDialogButtons::OkCancelCustom(
+                                    "Install".to_string(),
+                                    "Cancel".to_string(),
+                                ))
+                                .blocking_show();
+
+                        if !confirmed {
+                            return;
+                        }
+
+                        let result = tauri::async_runtime::spawn_blocking({
+                            let app_handle = app_handle.clone();
+                            move || crate::cli_install::install_cli_system(&app_handle)
+                        })
+                        .await;
+
+                        match result {
+                            Ok(Ok(())) => {
+                                log::info!(
+                                    "[cli_install] CLI installed system-wide successfully"
+                                );
+                                let cli_cmd = runt_workspace::cli_command_name();
+                                let nb_cmd = runt_workspace::cli_notebook_alias_name();
+                                let success_message = format!(
+                                    "The '{cli_cmd}' and '{nb_cmd}' commands have been installed to /usr/local/bin.\n\nOpen a new terminal and run: {cli_cmd} --help"
+                                );
+                                let _ = tauri_plugin_dialog::DialogExt::dialog(&app_handle)
+                                    .message(success_message)
+                                    .title("CLI Installed System-Wide")
+                                    .kind(tauri_plugin_dialog::MessageDialogKind::Info)
+                                    .blocking_show();
+                            }
+                            Ok(Err(e)) => {
+                                log::error!(
+                                    "[cli_install] System-wide CLI installation failed: {}",
+                                    e
+                                );
+                                if e != "Installation cancelled." {
+                                    let _ = tauri_plugin_dialog::DialogExt::dialog(&app_handle)
+                                        .message(format!(
+                                            "Failed to install CLI system-wide: {}",
+                                            e
+                                        ))
+                                        .title("Installation Failed")
+                                        .kind(tauri_plugin_dialog::MessageDialogKind::Error)
+                                        .blocking_show();
+                                }
+                            }
+                            Err(e) => {
+                                log::error!(
+                                    "[cli_install] System-wide CLI install task panicked: {}",
+                                    e
+                                );
+                            }
+                        }
+                    });
+                }
                 crate::menu::MENU_INSTALL_CLAUDE_EXT => {
                     let app_handle = app.clone();
                     match crate::mcpb_install::install_mcpb(&app_handle) {

--- a/crates/notebook/src/menu.rs
+++ b/crates/notebook/src/menu.rs
@@ -38,7 +38,6 @@ pub const MENU_CLEAR_ALL_OUTPUTS: &str = "clear_all_outputs";
 
 // Menu item IDs for CLI installation and settings
 pub const MENU_INSTALL_CLI: &str = "install_cli";
-pub const MENU_INSTALL_CLI_SYSTEM: &str = "install_cli_system";
 pub const MENU_INSTALL_CLAUDE_EXT: &str = "install_claude_ext";
 pub const MENU_CHECK_FOR_UPDATES: &str = "check_for_updates";
 pub const MENU_SETTINGS: &str = "settings";
@@ -64,13 +63,6 @@ pub fn about_menu_label() -> String {
 pub fn install_cli_menu_label() -> String {
     format!(
         "Install '{}' Command in PATH...",
-        runt_workspace::cli_command_name()
-    )
-}
-
-pub fn install_cli_system_menu_label() -> String {
-    format!(
-        "Install '{}' System-Wide...",
         runt_workspace::cli_command_name()
     )
 }
@@ -102,7 +94,6 @@ pub fn create_menu(
     let about_metadata = build_about_metadata();
     let about_label = about_menu_label();
     let install_cli_label = install_cli_menu_label();
-    let install_cli_system_label = install_cli_system_menu_label();
 
     // App menu (macOS standard - shows app name)
     let app_menu = Submenu::new(app, app_name(), true)?;
@@ -116,13 +107,6 @@ pub fn create_menu(
         app,
         MENU_INSTALL_CLI,
         install_cli_label.as_str(),
-        true,
-        None::<&str>,
-    )?)?;
-    app_menu.append(&MenuItem::with_id(
-        app,
-        MENU_INSTALL_CLI_SYSTEM,
-        install_cli_system_label.as_str(),
         true,
         None::<&str>,
     )?)?;

--- a/crates/notebook/src/menu.rs
+++ b/crates/notebook/src/menu.rs
@@ -38,6 +38,7 @@ pub const MENU_CLEAR_ALL_OUTPUTS: &str = "clear_all_outputs";
 
 // Menu item IDs for CLI installation and settings
 pub const MENU_INSTALL_CLI: &str = "install_cli";
+pub const MENU_INSTALL_CLI_SYSTEM: &str = "install_cli_system";
 pub const MENU_INSTALL_CLAUDE_EXT: &str = "install_claude_ext";
 pub const MENU_CHECK_FOR_UPDATES: &str = "check_for_updates";
 pub const MENU_SETTINGS: &str = "settings";
@@ -63,6 +64,13 @@ pub fn about_menu_label() -> String {
 pub fn install_cli_menu_label() -> String {
     format!(
         "Install '{}' Command in PATH...",
+        runt_workspace::cli_command_name()
+    )
+}
+
+pub fn install_cli_system_menu_label() -> String {
+    format!(
+        "Install '{}' System-Wide...",
         runt_workspace::cli_command_name()
     )
 }
@@ -94,6 +102,7 @@ pub fn create_menu(
     let about_metadata = build_about_metadata();
     let about_label = about_menu_label();
     let install_cli_label = install_cli_menu_label();
+    let install_cli_system_label = install_cli_system_menu_label();
 
     // App menu (macOS standard - shows app name)
     let app_menu = Submenu::new(app, app_name(), true)?;
@@ -107,6 +116,13 @@ pub fn create_menu(
         app,
         MENU_INSTALL_CLI,
         install_cli_label.as_str(),
+        true,
+        None::<&str>,
+    )?)?;
+    app_menu.append(&MenuItem::with_id(
+        app,
+        MENU_INSTALL_CLI_SYSTEM,
+        install_cli_system_label.as_str(),
         true,
         None::<&str>,
     )?)?;


### PR DESCRIPTION
## Summary

Single menu item: **"Install 'runt' Command in PATH..."** installs CLI commands to `/usr/local/bin` (Unix) or `C:\Program Files\nteract` (Windows) using OS privilege escalation. Matches the VS Code "Shell Command: Install 'code' in PATH" pattern.

The local `~/.local/bin` symlink is created silently on launch via `ensure_cli_current()` (#1514) — no menu item needed for that.

## Design

### Privilege escalation per platform
- **macOS**: `osascript` with `do shell script ... with administrator privileges` via a secure temp script (PID-based unique filename, mode 0700)
- **Linux**: `pkexec`
- **Windows**: `Start-Process powershell -Verb RunAs` with error reporting via temp file, `.cmd` wrapper for `nb`, prepends install dir to system PATH, broadcasts `WM_SETTINGCHANGE`

### Managed install detection
Creates a channel-specific marker file (`.nteract-managed-runt` or `.nteract-managed-runt-nightly`) in the install directory to distinguish nteract-managed system installs from Homebrew/manual installs. Prevents the app from clobbering installs it doesn't own.

### Upgrade path
- Local installs (`~/.local/bin`): symlinks updated automatically
- System-wide installs (`/usr/local/bin`): copies refreshed during app upgrade
- Legacy installs (no marker): migrated to `~/.local/bin`

## Review iterations
8 rounds of codex review on the original implementation, then consolidated from two menu items to one.

## Test plan
- [ ] "Install 'runt' Command in PATH..." shows confirmation dialog
- [ ] Cancelling confirmation or OS auth prompt is handled gracefully
- [ ] Successful install creates `runt` and `nb` in `/usr/local/bin` with marker file
- [ ] `runt` and `nb` commands work after install
- [ ] App upgrade refreshes the system-wide copy
- [ ] Legacy `/usr/local/bin` installs (no marker) still get migrated to `~/.local/bin`
- [ ] Local `~/.local/bin` symlink is unaffected by this menu item