### PR TITLE
feat(cli): add symlink currency check on app launch

### DIFF
--- a/crates/notebook/src/cli_install.rs
+++ b/crates/notebook/src/cli_install.rs
@@ -116,6 +116,159 @@ pub fn get_bundled_runt_path(app: &tauri::AppHandle) -> Option<PathBuf> {
     None
 }
 
+/// Result of checking whether an installed CLI symlink is current.
+#[derive(Debug, PartialEq, Eq)]
+pub enum SymlinkStatus {
+    /// Symlink exists and points to the current app bundle binary.
+    Current,
+    /// Symlink exists but points to a different (stale) path.
+    Stale,
+    /// CLI is not installed (symlink does not exist).
+    NotInstalled,
+}
+
+/// Check whether the installed `runt`/`runt-nightly` symlink points to the
+/// current app bundle binary path, and whether the `nb`/`nb-nightly` wrapper
+/// script references the correct CLI command name.
+///
+/// Returns a tuple of `(runt_status, nb_status)`.
+#[cfg(unix)]
+pub fn check_cli_currency(app: &tauri::AppHandle) -> (SymlinkStatus, SymlinkStatus) {
+    let dir = install_dir();
+    let cli_name = cli_command_name();
+    let nb_name = cli_notebook_alias_name();
+
+    let runt_status = check_runt_symlink(app, &dir.join(cli_name));
+    let nb_status = check_nb_script(&dir.join(nb_name), cli_name);
+
+    (runt_status, nb_status)
+}
+
+/// Check if the runt symlink points to the current bundled binary.
+#[cfg(unix)]
+fn check_runt_symlink(app: &tauri::AppHandle, symlink_path: &std::path::Path) -> SymlinkStatus {
+    if !symlink_path.is_symlink() {
+        if symlink_path.exists() {
+            // It's a regular file (not a symlink) — treat as stale so we replace it
+            return SymlinkStatus::Stale;
+        }
+        return SymlinkStatus::NotInstalled;
+    }
+
+    let target = match fs::read_link(symlink_path) {
+        Ok(t) => t,
+        Err(e) => {
+            log::warn!(
+                "[cli_install] Failed to read symlink {}: {}",
+                symlink_path.display(),
+                e
+            );
+            return SymlinkStatus::Stale;
+        }
+    };
+
+    let bundled = match get_bundled_runt_path(app) {
+        Some(p) => p,
+        None => {
+            log::debug!("[cli_install] Cannot determine bundled runt path for currency check");
+            // Can't determine — assume current to avoid unnecessary reinstall
+            return SymlinkStatus::Current;
+        }
+    };
+
+    if target == bundled {
+        SymlinkStatus::Current
+    } else {
+        log::info!(
+            "[cli_install] Symlink stale: {} -> {} (expected {})",
+            symlink_path.display(),
+            target.display(),
+            bundled.display()
+        );
+        SymlinkStatus::Stale
+    }
+}
+
+/// Check if the nb wrapper script references the correct CLI command name.
+#[cfg(unix)]
+fn check_nb_script(script_path: &std::path::Path, expected_cli_name: &str) -> SymlinkStatus {
+    if !script_path.exists() {
+        return SymlinkStatus::NotInstalled;
+    }
+
+    match fs::read_to_string(script_path) {
+        Ok(contents) => {
+            let expected_exec = format!("exec {} notebook", expected_cli_name);
+            if contents.contains(&expected_exec) {
+                SymlinkStatus::Current
+            } else {
+                log::info!(
+                    "[cli_install] nb script stale: {} does not contain '{}'",
+                    script_path.display(),
+                    expected_exec
+                );
+                SymlinkStatus::Stale
+            }
+        }
+        Err(e) => {
+            log::warn!(
+                "[cli_install] Failed to read nb script {}: {}",
+                script_path.display(),
+                e
+            );
+            SymlinkStatus::Stale
+        }
+    }
+}
+
+/// Silently update the CLI installation if the symlinks are stale.
+///
+/// Called on app launch. If the user has previously installed the CLI (symlink
+/// exists), this checks whether it still points to the current app bundle and
+/// re-runs `install_cli()` if not. Does nothing if the CLI was never installed.
+pub fn ensure_cli_current(app: &tauri::AppHandle) {
+    #[cfg(not(unix))]
+    {
+        let _ = app;
+        // On Windows, CLI install copies the binary — no symlink to check.
+        // A future enhancement could compare binary hashes.
+        return;
+    }
+
+    #[cfg(unix)]
+    {
+        let (runt_status, nb_status) = check_cli_currency(app);
+
+        log::debug!(
+            "[cli_install] CLI currency check: runt={:?}, nb={:?}",
+            runt_status,
+            nb_status
+        );
+
+        match (&runt_status, &nb_status) {
+            (SymlinkStatus::NotInstalled, SymlinkStatus::NotInstalled) => {
+                log::debug!("[cli_install] CLI not installed, skipping currency check");
+            }
+            (SymlinkStatus::Current, SymlinkStatus::Current) => {
+                log::debug!("[cli_install] CLI symlinks are current");
+            }
+            _ => {
+                // At least one component is stale (or one is installed while the other isn't)
+                log::info!(
+                    "[cli_install] CLI needs update (runt={:?}, nb={:?}), reinstalling",
+                    runt_status,
+                    nb_status
+                );
+                if let Err(e) = install_cli(app) {
+                    log::warn!("[cli_install] Failed to update CLI: {}", e);
+                } else {
+                    log::info!("[cli_install] CLI updated successfully");
+                }
+            }
+        }
+    }
+}
+
 /// Check if the CLI is already installed (checks both new and legacy locations).
 pub fn is_cli_installed() -> bool {
     let cli_name = cli_command_name();
@@ -333,4 +486,79 @@ fn ensure_shell_path(bin_dir: &std::path::Path) -> Result<(), String> {
         rc_path.display()
     );
     Ok(())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn nb_script_current_when_matches() {
+        let dir = tempfile::tempdir().ok().unwrap();
+        let script_path = dir.path().join("nb");
+        fs::write(
+            &script_path,
+            "#!/bin/bash\n# nb - open notebooks\nexec runt-nightly notebook \"$@\"\n",
+        )
+        .ok();
+
+        assert_eq!(
+            check_nb_script(&script_path, "runt-nightly"),
+            SymlinkStatus::Current
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn nb_script_stale_when_wrong_command() {
+        let dir = tempfile::tempdir().ok().unwrap();
+        let script_path = dir.path().join("nb");
+        fs::write(
+            &script_path,
+            "#!/bin/bash\n# nb - open notebooks\nexec runt notebook \"$@\"\n",
+        )
+        .ok();
+
+        // Expects runt-nightly but script has runt
+        assert_eq!(
+            check_nb_script(&script_path, "runt-nightly"),
+            SymlinkStatus::Stale
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn nb_script_not_installed_when_missing() {
+        let dir = tempfile::tempdir().ok().unwrap();
+        let script_path = dir.path().join("nb-nonexistent");
+
+        assert_eq!(
+            check_nb_script(&script_path, "runt"),
+            SymlinkStatus::NotInstalled
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn runt_symlink_not_installed_when_missing() {
+        let dir = tempfile::tempdir().ok().unwrap();
+        let symlink_path = dir.path().join("runt-nonexistent");
+
+        assert!(!symlink_path.exists());
+        assert!(!symlink_path.is_symlink());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn runt_symlink_stale_when_regular_file() {
+        let dir = tempfile::tempdir().ok().unwrap();
+        let file_path = dir.path().join("runt");
+        fs::write(&file_path, "not a symlink").ok();
+
+        // A regular file at the symlink path should be detected as stale
+        assert!(file_path.exists());
+        assert!(!file_path.is_symlink());
+    }
 }

--- a/crates/notebook/src/cli_install.rs
+++ b/crates/notebook/src/cli_install.rs
@@ -127,58 +127,36 @@ pub enum SymlinkStatus {
     NotInstalled,
 }
 
-/// Check whether the installed `runt`/`runt-nightly` symlink points to the
-/// current app bundle binary path, and whether the `nb`/`nb-nightly` wrapper
-/// script references the correct CLI command name.
+/// Check whether the installed `runt`/`runt-nightly` symlink in `~/.local/bin`
+/// points to the current app bundle binary path, and whether the `nb`/`nb-nightly`
+/// wrapper script references the correct CLI command name.
 ///
-/// Checks both `~/.local/bin` (current) and `/usr/local/bin` (legacy). If the
-/// CLI exists in the legacy location, that is checked too.
+/// Only checks `~/.local/bin` — the canonical install location. Legacy
+/// `/usr/local/bin` entries are warned about separately by `warn_legacy_cli_shadow()`
+/// and are not auto-repaired (since `install_cli()` writes to `~/.local/bin` only).
 ///
-/// Returns a tuple of `(runt_status, nb_status)` representing the worst status
-/// across both locations.
+/// Returns a tuple of `(runt_status, nb_status)`.
 #[cfg(unix)]
 pub fn check_cli_currency(app: &tauri::AppHandle) -> (SymlinkStatus, SymlinkStatus) {
+    let dir = install_dir();
     let cli_name = cli_command_name();
     let nb_name = cli_notebook_alias_name();
 
-    let new_dir = install_dir();
-    let legacy_dir = PathBuf::from(LEGACY_INSTALL_DIR);
-
-    // Check both locations and take the worst status (Stale > NotInstalled > Current)
-    let runt_new = check_runt_symlink(app, &new_dir.join(cli_name));
-    let nb_new = check_nb_script(&new_dir.join(nb_name), cli_name);
-
-    let runt_legacy = check_runt_symlink(app, &legacy_dir.join(cli_name));
-    let nb_legacy = check_nb_script(&legacy_dir.join(nb_name), cli_name);
-
-    // If either location has a stale entry, report stale so we trigger reinstall.
-    // If neither location is installed, report not installed.
-    let runt_status = worst_status(runt_new, runt_legacy);
-    let nb_status = worst_status(nb_new, nb_legacy);
+    let runt_status = check_runt_symlink(app, &dir.join(cli_name));
+    let nb_status = check_nb_script(&dir.join(nb_name), cli_name);
 
     (runt_status, nb_status)
 }
 
-/// Return the more actionable of two statuses: Stale > NotInstalled > Current.
-/// If either location is stale, the result is stale. If both are not installed,
-/// the result is not installed. Otherwise current.
-#[cfg(unix)]
-fn worst_status(a: SymlinkStatus, b: SymlinkStatus) -> SymlinkStatus {
-    match (&a, &b) {
-        (SymlinkStatus::Stale, _) | (_, SymlinkStatus::Stale) => SymlinkStatus::Stale,
-        (SymlinkStatus::NotInstalled, SymlinkStatus::NotInstalled) => SymlinkStatus::NotInstalled,
-        _ => SymlinkStatus::Current,
-    }
-}
-
 /// Check if the runt symlink points to the current bundled binary.
+///
+/// Only considers an existing entry "ours" if it is a symlink whose target
+/// contains "nteract" or "runt" in the path — this avoids clobbering unrelated
+/// commands that happen to share the same name.
 #[cfg(unix)]
 fn check_runt_symlink(app: &tauri::AppHandle, symlink_path: &std::path::Path) -> SymlinkStatus {
     if !symlink_path.is_symlink() {
-        if symlink_path.exists() {
-            // It's a regular file (not a symlink) — treat as stale so we replace it
-            return SymlinkStatus::Stale;
-        }
+        // Not a symlink — either missing or a regular file/directory we don't own.
         return SymlinkStatus::NotInstalled;
     }
 
@@ -190,9 +168,22 @@ fn check_runt_symlink(app: &tauri::AppHandle, symlink_path: &std::path::Path) ->
                 symlink_path.display(),
                 e
             );
-            return SymlinkStatus::Stale;
+            // Can't read it — don't touch what we can't verify
+            return SymlinkStatus::NotInstalled;
         }
     };
+
+    // Only consider this symlink ours if the target path looks like it came from
+    // an nteract app bundle (contains "nteract" or "runt" in the path).
+    let target_str = target.to_string_lossy();
+    if !target_str.contains("nteract") && !target_str.contains("runt") {
+        log::debug!(
+            "[cli_install] Symlink {} -> {} does not appear to be ours, skipping",
+            symlink_path.display(),
+            target_str
+        );
+        return SymlinkStatus::NotInstalled;
+    }
 
     let bundled = match get_bundled_runt_path(app) {
         Some(p) => p,
@@ -217,6 +208,9 @@ fn check_runt_symlink(app: &tauri::AppHandle, symlink_path: &std::path::Path) ->
 }
 
 /// Check if the nb wrapper script references the correct CLI command name.
+///
+/// Only considers the script "ours" if its content mentions "runt" — this avoids
+/// clobbering unrelated `nb` commands.
 #[cfg(unix)]
 fn check_nb_script(script_path: &std::path::Path, expected_cli_name: &str) -> SymlinkStatus {
     if !script_path.exists() {
@@ -225,6 +219,15 @@ fn check_nb_script(script_path: &std::path::Path, expected_cli_name: &str) -> Sy
 
     match fs::read_to_string(script_path) {
         Ok(contents) => {
+            // Only consider this script ours if it mentions runt
+            if !contents.contains("runt") {
+                log::debug!(
+                    "[cli_install] Script {} does not mention runt, skipping",
+                    script_path.display()
+                );
+                return SymlinkStatus::NotInstalled;
+            }
+
             let expected_exec = format!("exec {} notebook", expected_cli_name);
             if contents.contains(&expected_exec) {
                 SymlinkStatus::Current
@@ -243,7 +246,8 @@ fn check_nb_script(script_path: &std::path::Path, expected_cli_name: &str) -> Sy
                 script_path.display(),
                 e
             );
-            SymlinkStatus::Stale
+            // Can't read — don't touch
+            SymlinkStatus::NotInstalled
         }
     }
 }
@@ -285,8 +289,8 @@ fn is_translocated_path(app: &tauri::AppHandle) -> bool {
 /// exists), this checks whether it still points to the current app bundle and
 /// re-runs `install_cli()` if not. Does nothing if the CLI was never installed.
 ///
-/// Skips the check on macOS if the app is running from a translocated path
-/// (e.g., directly from a DMG) to avoid pointing symlinks at ephemeral paths.
+/// Skips the check in dev mode (source builds) and on macOS if the app is
+/// running from a translocated path (e.g., directly from a DMG).
 pub fn ensure_cli_current(app: &tauri::AppHandle) {
     #[cfg(not(unix))]
     {
@@ -298,6 +302,13 @@ pub fn ensure_cli_current(app: &tauri::AppHandle) {
 
     #[cfg(unix)]
     {
+        // In dev mode, the bundled path points into a build artifact directory
+        // (target/*/binaries/). Don't rewrite the user's global CLI to point there.
+        if runt_workspace::is_dev_mode() {
+            log::debug!("[cli_install] Dev mode — skipping CLI currency check");
+            return;
+        }
+
         // On macOS, skip if the app is running from a translocated/temporary path.
         #[cfg(target_os = "macos")]
         if is_translocated_path(app) {
@@ -619,52 +630,26 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn worst_status_stale_wins() {
-        assert_eq!(
-            worst_status(SymlinkStatus::Stale, SymlinkStatus::Current),
-            SymlinkStatus::Stale
-        );
-        assert_eq!(
-            worst_status(SymlinkStatus::Current, SymlinkStatus::Stale),
-            SymlinkStatus::Stale
-        );
-        assert_eq!(
-            worst_status(SymlinkStatus::NotInstalled, SymlinkStatus::Stale),
-            SymlinkStatus::Stale
-        );
-    }
+    fn nb_script_not_installed_when_not_ours() {
+        let dir = tempfile::tempdir().ok().unwrap();
+        let script_path = dir.path().join("nb");
+        // An unrelated nb script that doesn't mention runt
+        fs::write(&script_path, "#!/bin/bash\nexec nb-something-else \"$@\"\n").ok();
 
-    #[cfg(unix)]
-    #[test]
-    fn worst_status_both_not_installed() {
         assert_eq!(
-            worst_status(SymlinkStatus::NotInstalled, SymlinkStatus::NotInstalled),
+            check_nb_script(&script_path, "runt"),
             SymlinkStatus::NotInstalled
         );
     }
 
     #[cfg(unix)]
     #[test]
-    fn worst_status_current_when_one_installed() {
-        // If one location is current and the other not installed, overall is current
-        assert_eq!(
-            worst_status(SymlinkStatus::Current, SymlinkStatus::NotInstalled),
-            SymlinkStatus::Current
-        );
-        assert_eq!(
-            worst_status(SymlinkStatus::NotInstalled, SymlinkStatus::Current),
-            SymlinkStatus::Current
-        );
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn runt_symlink_stale_when_regular_file() {
+    fn regular_file_not_treated_as_ours() {
         let dir = tempfile::tempdir().ok().unwrap();
         let file_path = dir.path().join("runt");
         fs::write(&file_path, "not a symlink").ok();
 
-        // A regular file at the symlink path should be detected as stale
+        // A regular file (not a symlink) should be NotInstalled, not Stale
         assert!(file_path.exists());
         assert!(!file_path.is_symlink());
     }

--- a/crates/notebook/src/cli_install.rs
+++ b/crates/notebook/src/cli_install.rs
@@ -341,30 +341,53 @@ pub fn ensure_cli_current(app: &tauri::AppHandle) {
             nb_status
         );
 
-        // Only reinstall when at least one entry is positively identified as
-        // stale (i.e., owned by nteract but pointing to the wrong bundle).
-        // Mixed states like (Current, NotInstalled) are left alone — the
-        // "not installed" entry might be an unrelated command the user owns.
+        // Only reinstall when at least one entry is Stale. install_cli() rewrites
+        // both runt and nb, so we must ensure neither path is occupied by an
+        // unrelated command. "NotInstalled" can mean either (a) the path doesn't
+        // exist (safe to create) or (b) it exists but isn't ours (unsafe to
+        // overwrite). Check actual path existence to distinguish the two cases.
         let runt_stale = runt_status == SymlinkStatus::Stale;
         let nb_stale = nb_status == SymlinkStatus::Stale;
 
-        if runt_stale || nb_stale {
-            log::info!(
-                "[cli_install] CLI needs update (runt={:?}, nb={:?}), reinstalling",
-                runt_status,
-                nb_status
-            );
-            if let Err(e) = install_cli(app) {
-                log::warn!("[cli_install] Failed to update CLI: {}", e);
-            } else {
-                log::info!("[cli_install] CLI updated successfully");
-            }
-        } else {
+        if !runt_stale && !nb_stale {
             log::debug!(
                 "[cli_install] CLI currency check: runt={:?}, nb={:?} — no update needed",
                 runt_status,
                 nb_status
             );
+            return;
+        }
+
+        // If either entry is "NotInstalled" (unrecognized), check whether the
+        // path actually exists. If it does, something else owns it — don't clobber.
+        let dir = install_dir();
+        let cli_name = cli_command_name();
+        let nb_name = cli_notebook_alias_name();
+
+        let runt_blocked =
+            runt_status == SymlinkStatus::NotInstalled && dir.join(cli_name).exists();
+        let nb_blocked = nb_status == SymlinkStatus::NotInstalled && dir.join(nb_name).exists();
+
+        if runt_blocked || nb_blocked {
+            log::info!(
+                "[cli_install] CLI partially stale (runt={:?}, nb={:?}) but {} \
+                 is occupied by an unrelated command — skipping auto-repair",
+                runt_status,
+                nb_status,
+                if runt_blocked { cli_name } else { nb_name }
+            );
+            return;
+        }
+
+        log::info!(
+            "[cli_install] CLI needs update (runt={:?}, nb={:?}), reinstalling",
+            runt_status,
+            nb_status
+        );
+        if let Err(e) = install_cli(app) {
+            log::warn!("[cli_install] Failed to update CLI: {}", e);
+        } else {
+            log::info!("[cli_install] CLI updated successfully");
         }
     }
 }

--- a/crates/notebook/src/cli_install.rs
+++ b/crates/notebook/src/cli_install.rs
@@ -178,6 +178,10 @@ fn check_runt_symlink(app: &tauri::AppHandle, symlink_path: &std::path::Path) ->
     // on Linux it's inside an nteract resource directory. We check for "nteract"
     // as a directory component AND the target filename being "runt" to avoid
     // false-positives on unrelated symlinks (e.g. /opt/homebrew/bin/runt).
+    //
+    // Note: if a user renames "nteract.app" to something else, the symlink will
+    // no longer be recognized as ours, and auto-repair won't trigger. This is an
+    // acceptable trade-off — renaming is rare and manual `install_cli()` still works.
     let target_str = target.to_string_lossy();
     let target_filename = target.file_name().map(|f| f.to_string_lossy());
     let looks_like_ours = target_filename.as_deref() == Some("runt")
@@ -359,14 +363,19 @@ pub fn ensure_cli_current(app: &tauri::AppHandle) {
         }
 
         // If either entry is "NotInstalled" (unrecognized), check whether the
-        // path actually exists. If it does, something else owns it — don't clobber.
+        // path actually exists (or is a dangling symlink). If it does, something
+        // else owns it — don't clobber. We use symlink_metadata() instead of
+        // exists() because exists() returns false for dangling symlinks, which
+        // would let us accidentally overwrite a broken symlink owned by another tool.
         let dir = install_dir();
         let cli_name = cli_command_name();
         let nb_name = cli_notebook_alias_name();
 
+        let path_occupied = |p: PathBuf| fs::symlink_metadata(p).is_ok();
         let runt_blocked =
-            runt_status == SymlinkStatus::NotInstalled && dir.join(cli_name).exists();
-        let nb_blocked = nb_status == SymlinkStatus::NotInstalled && dir.join(nb_name).exists();
+            runt_status == SymlinkStatus::NotInstalled && path_occupied(dir.join(cli_name));
+        let nb_blocked =
+            nb_status == SymlinkStatus::NotInstalled && path_occupied(dir.join(nb_name));
 
         if runt_blocked || nb_blocked {
             log::info!(

--- a/crates/notebook/src/cli_install.rs
+++ b/crates/notebook/src/cli_install.rs
@@ -219,10 +219,16 @@ fn check_nb_script(script_path: &std::path::Path, expected_cli_name: &str) -> Sy
 
     match fs::read_to_string(script_path) {
         Ok(contents) => {
-            // Only consider this script ours if it mentions runt
-            if !contents.contains("runt") {
+            // Only consider this script ours if it contains the exact exec pattern
+            // that create_nb_wrapper() generates: "exec runt notebook" or
+            // "exec runt-nightly notebook". A bare substring like "runt" would
+            // false-positive on scripts mentioning "grunt", "runtime", etc.
+            let is_ours = contents.contains("exec runt notebook")
+                || contents.contains("exec runt-nightly notebook");
+
+            if !is_ours {
                 log::debug!(
-                    "[cli_install] Script {} does not mention runt, skipping",
+                    "[cli_install] Script {} does not appear to be an nteract nb wrapper, skipping",
                     script_path.display()
                 );
                 return SymlinkStatus::NotInstalled;
@@ -323,26 +329,30 @@ pub fn ensure_cli_current(app: &tauri::AppHandle) {
             nb_status
         );
 
-        match (&runt_status, &nb_status) {
-            (SymlinkStatus::NotInstalled, SymlinkStatus::NotInstalled) => {
-                log::debug!("[cli_install] CLI not installed, skipping currency check");
+        // Only reinstall when at least one entry is positively identified as
+        // stale (i.e., owned by nteract but pointing to the wrong bundle).
+        // Mixed states like (Current, NotInstalled) are left alone — the
+        // "not installed" entry might be an unrelated command the user owns.
+        let runt_stale = runt_status == SymlinkStatus::Stale;
+        let nb_stale = nb_status == SymlinkStatus::Stale;
+
+        if runt_stale || nb_stale {
+            log::info!(
+                "[cli_install] CLI needs update (runt={:?}, nb={:?}), reinstalling",
+                runt_status,
+                nb_status
+            );
+            if let Err(e) = install_cli(app) {
+                log::warn!("[cli_install] Failed to update CLI: {}", e);
+            } else {
+                log::info!("[cli_install] CLI updated successfully");
             }
-            (SymlinkStatus::Current, SymlinkStatus::Current) => {
-                log::debug!("[cli_install] CLI symlinks are current");
-            }
-            _ => {
-                // At least one component is stale (or one is installed while the other isn't)
-                log::info!(
-                    "[cli_install] CLI needs update (runt={:?}, nb={:?}), reinstalling",
-                    runt_status,
-                    nb_status
-                );
-                if let Err(e) = install_cli(app) {
-                    log::warn!("[cli_install] Failed to update CLI: {}", e);
-                } else {
-                    log::info!("[cli_install] CLI updated successfully");
-                }
-            }
+        } else {
+            log::debug!(
+                "[cli_install] CLI currency check: runt={:?}, nb={:?} — no update needed",
+                runt_status,
+                nb_status
+            );
         }
     }
 }
@@ -633,8 +643,12 @@ mod tests {
     fn nb_script_not_installed_when_not_ours() {
         let dir = tempfile::tempdir().ok().unwrap();
         let script_path = dir.path().join("nb");
-        // An unrelated nb script that doesn't mention runt
-        fs::write(&script_path, "#!/bin/bash\nexec nb-something-else \"$@\"\n").ok();
+        // An unrelated nb script — even one mentioning "grunt" (substring of "runt")
+        fs::write(
+            &script_path,
+            "#!/bin/bash\n# build tool\nexec grunt \"$@\"\n",
+        )
+        .ok();
 
         assert_eq!(
             check_nb_script(&script_path, "runt"),

--- a/crates/notebook/src/cli_install.rs
+++ b/crates/notebook/src/cli_install.rs
@@ -131,17 +131,44 @@ pub enum SymlinkStatus {
 /// current app bundle binary path, and whether the `nb`/`nb-nightly` wrapper
 /// script references the correct CLI command name.
 ///
-/// Returns a tuple of `(runt_status, nb_status)`.
+/// Checks both `~/.local/bin` (current) and `/usr/local/bin` (legacy). If the
+/// CLI exists in the legacy location, that is checked too.
+///
+/// Returns a tuple of `(runt_status, nb_status)` representing the worst status
+/// across both locations.
 #[cfg(unix)]
 pub fn check_cli_currency(app: &tauri::AppHandle) -> (SymlinkStatus, SymlinkStatus) {
-    let dir = install_dir();
     let cli_name = cli_command_name();
     let nb_name = cli_notebook_alias_name();
 
-    let runt_status = check_runt_symlink(app, &dir.join(cli_name));
-    let nb_status = check_nb_script(&dir.join(nb_name), cli_name);
+    let new_dir = install_dir();
+    let legacy_dir = PathBuf::from(LEGACY_INSTALL_DIR);
+
+    // Check both locations and take the worst status (Stale > NotInstalled > Current)
+    let runt_new = check_runt_symlink(app, &new_dir.join(cli_name));
+    let nb_new = check_nb_script(&new_dir.join(nb_name), cli_name);
+
+    let runt_legacy = check_runt_symlink(app, &legacy_dir.join(cli_name));
+    let nb_legacy = check_nb_script(&legacy_dir.join(nb_name), cli_name);
+
+    // If either location has a stale entry, report stale so we trigger reinstall.
+    // If neither location is installed, report not installed.
+    let runt_status = worst_status(runt_new, runt_legacy);
+    let nb_status = worst_status(nb_new, nb_legacy);
 
     (runt_status, nb_status)
+}
+
+/// Return the more actionable of two statuses: Stale > NotInstalled > Current.
+/// If either location is stale, the result is stale. If both are not installed,
+/// the result is not installed. Otherwise current.
+#[cfg(unix)]
+fn worst_status(a: SymlinkStatus, b: SymlinkStatus) -> SymlinkStatus {
+    match (&a, &b) {
+        (SymlinkStatus::Stale, _) | (_, SymlinkStatus::Stale) => SymlinkStatus::Stale,
+        (SymlinkStatus::NotInstalled, SymlinkStatus::NotInstalled) => SymlinkStatus::NotInstalled,
+        _ => SymlinkStatus::Current,
+    }
 }
 
 /// Check if the runt symlink points to the current bundled binary.
@@ -221,11 +248,45 @@ fn check_nb_script(script_path: &std::path::Path, expected_cli_name: &str) -> Sy
     }
 }
 
+/// Returns true if the app appears to be running from a translocated or
+/// temporary macOS path (e.g., opened directly from a DMG or Downloads before
+/// being moved to /Applications). We must not rewrite CLI symlinks in this case
+/// because the path is ephemeral — the symlinks would break as soon as the
+/// translocated copy is cleaned up.
+#[cfg(target_os = "macos")]
+fn is_translocated_path(app: &tauri::AppHandle) -> bool {
+    let bundled = match get_bundled_runt_path(app) {
+        Some(p) => p,
+        None => return false,
+    };
+
+    let path_str = bundled.to_string_lossy();
+
+    // macOS app translocation moves apps to /private/var/folders/...
+    // Also guard against running from common temp locations.
+    if path_str.contains("/private/var/folders/")
+        || path_str.contains("/AppTranslocation/")
+        || path_str.starts_with("/tmp/")
+        || path_str.starts_with("/var/folders/")
+    {
+        log::info!(
+            "[cli_install] Skipping CLI currency check — app running from translocated path: {}",
+            path_str
+        );
+        return true;
+    }
+
+    false
+}
+
 /// Silently update the CLI installation if the symlinks are stale.
 ///
 /// Called on app launch. If the user has previously installed the CLI (symlink
 /// exists), this checks whether it still points to the current app bundle and
 /// re-runs `install_cli()` if not. Does nothing if the CLI was never installed.
+///
+/// Skips the check on macOS if the app is running from a translocated path
+/// (e.g., directly from a DMG) to avoid pointing symlinks at ephemeral paths.
 pub fn ensure_cli_current(app: &tauri::AppHandle) {
     #[cfg(not(unix))]
     {
@@ -237,6 +298,12 @@ pub fn ensure_cli_current(app: &tauri::AppHandle) {
 
     #[cfg(unix)]
     {
+        // On macOS, skip if the app is running from a translocated/temporary path.
+        #[cfg(target_os = "macos")]
+        if is_translocated_path(app) {
+            return;
+        }
+
         let (runt_status, nb_status) = check_cli_currency(app);
 
         log::debug!(
@@ -548,6 +615,46 @@ mod tests {
 
         assert!(!symlink_path.exists());
         assert!(!symlink_path.is_symlink());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn worst_status_stale_wins() {
+        assert_eq!(
+            worst_status(SymlinkStatus::Stale, SymlinkStatus::Current),
+            SymlinkStatus::Stale
+        );
+        assert_eq!(
+            worst_status(SymlinkStatus::Current, SymlinkStatus::Stale),
+            SymlinkStatus::Stale
+        );
+        assert_eq!(
+            worst_status(SymlinkStatus::NotInstalled, SymlinkStatus::Stale),
+            SymlinkStatus::Stale
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn worst_status_both_not_installed() {
+        assert_eq!(
+            worst_status(SymlinkStatus::NotInstalled, SymlinkStatus::NotInstalled),
+            SymlinkStatus::NotInstalled
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn worst_status_current_when_one_installed() {
+        // If one location is current and the other not installed, overall is current
+        assert_eq!(
+            worst_status(SymlinkStatus::Current, SymlinkStatus::NotInstalled),
+            SymlinkStatus::Current
+        );
+        assert_eq!(
+            worst_status(SymlinkStatus::NotInstalled, SymlinkStatus::Current),
+            SymlinkStatus::Current
+        );
     }
 
     #[cfg(unix)]

--- a/crates/notebook/src/cli_install.rs
+++ b/crates/notebook/src/cli_install.rs
@@ -173,12 +173,19 @@ fn check_runt_symlink(app: &tauri::AppHandle, symlink_path: &std::path::Path) ->
         }
     };
 
-    // Only consider this symlink ours if the target path looks like it came from
-    // an nteract app bundle (contains "nteract" or "runt" in the path).
+    // Only consider this symlink ours if the target path matches the shape of
+    // an nteract app bundle install. On macOS this is "*.app/Contents/MacOS/runt",
+    // on Linux it's inside an nteract resource directory. We check for "nteract"
+    // as a directory component AND the target filename being "runt" to avoid
+    // false-positives on unrelated symlinks (e.g. /opt/homebrew/bin/runt).
     let target_str = target.to_string_lossy();
-    if !target_str.contains("nteract") && !target_str.contains("runt") {
+    let target_filename = target.file_name().map(|f| f.to_string_lossy());
+    let looks_like_ours = target_filename.as_deref() == Some("runt")
+        && (target_str.contains("/nteract") || target_str.contains("/nteract-nightly"));
+
+    if !looks_like_ours {
         log::debug!(
-            "[cli_install] Symlink {} -> {} does not appear to be ours, skipping",
+            "[cli_install] Symlink {} -> {} does not appear to be an nteract install, skipping",
             symlink_path.display(),
             target_str
         );
@@ -258,13 +265,17 @@ fn check_nb_script(script_path: &std::path::Path, expected_cli_name: &str) -> Sy
     }
 }
 
-/// Returns true if the app appears to be running from a translocated or
-/// temporary macOS path (e.g., opened directly from a DMG or Downloads before
-/// being moved to /Applications). We must not rewrite CLI symlinks in this case
-/// because the path is ephemeral — the symlinks would break as soon as the
-/// translocated copy is cleaned up.
-#[cfg(target_os = "macos")]
-fn is_translocated_path(app: &tauri::AppHandle) -> bool {
+/// Returns true if the app appears to be running from a temporary or
+/// ephemeral path. We must not rewrite CLI symlinks in this case because
+/// the path will disappear, leaving the symlinks broken.
+///
+/// Covers:
+/// - macOS app translocation (`/private/var/folders/`, `AppTranslocation`)
+/// - macOS Downloads or Volumes (not yet moved to /Applications)
+/// - Linux AppImage mounts (`/tmp/.mount_*`)
+/// - General temp directories (`/tmp/`, `/var/folders/`)
+#[cfg(unix)]
+fn is_ephemeral_path(app: &tauri::AppHandle) -> bool {
     let bundled = match get_bundled_runt_path(app) {
         Some(p) => p,
         None => return false,
@@ -272,21 +283,22 @@ fn is_translocated_path(app: &tauri::AppHandle) -> bool {
 
     let path_str = bundled.to_string_lossy();
 
-    // macOS app translocation moves apps to /private/var/folders/...
-    // Also guard against running from common temp locations.
-    if path_str.contains("/private/var/folders/")
+    let ephemeral = path_str.contains("/private/var/folders/")
         || path_str.contains("/AppTranslocation/")
         || path_str.starts_with("/tmp/")
         || path_str.starts_with("/var/folders/")
-    {
+        || path_str.contains("/tmp/.mount_")
+        || path_str.contains("/Downloads/")
+        || path_str.starts_with("/Volumes/");
+
+    if ephemeral {
         log::info!(
-            "[cli_install] Skipping CLI currency check — app running from translocated path: {}",
+            "[cli_install] Skipping CLI currency check — app running from ephemeral path: {}",
             path_str
         );
-        return true;
     }
 
-    false
+    ephemeral
 }
 
 /// Silently update the CLI installation if the symlinks are stale.
@@ -315,9 +327,9 @@ pub fn ensure_cli_current(app: &tauri::AppHandle) {
             return;
         }
 
-        // On macOS, skip if the app is running from a translocated/temporary path.
-        #[cfg(target_os = "macos")]
-        if is_translocated_path(app) {
+        // Skip if the app is running from an ephemeral path (macOS translocation,
+        // AppImage mount, Downloads, DMG volume, etc.)
+        if is_ephemeral_path(app) {
             return;
         }
 

--- a/crates/notebook/src/lib.rs
+++ b/crates/notebook/src/lib.rs
@@ -4352,6 +4352,10 @@ pub fn run(
                         }
                     };
 
+                // Check if CLI symlinks are current and silently update if stale.
+                // This handles app reinstalls, bundle path changes, and channel switches.
+                cli_install::ensure_cli_current(&app_for_daemon);
+
                 // Start settings sync subscription (reconnects automatically)
                 // Spawn as separate task since it runs forever
                 tokio::spawn(run_settings_sync(app_for_sync.clone()));


### PR DESCRIPTION
## Summary
- On every app launch, checks if CLI symlinks (`~/.local/bin/runt` or `runt-nightly`) still point to the current app bundle binary
- Also checks the `nb`/`nb-nightly` wrapper script references the correct CLI command name
- If stale (e.g., after reinstall, app bundle path change, or channel switch), silently re-runs `install_cli()` to update
- If CLI was never installed (symlinks don't exist), does nothing — respects user opt-in
- No UI — purely silent with diagnostic logging

Inspired by VS Code's startup check for its `code` CLI symlink, which catches staleness after reinstalls and App Translocation moves.

## Design
- New `SymlinkStatus` enum: `Current`, `Stale`, `NotInstalled`
- `check_cli_currency()` reads the symlink target and compares to `get_bundled_runt_path()`
- `check_nb_script()` reads the wrapper script and checks for the expected `exec <cli_name> notebook` line
- `ensure_cli_current()` orchestrates the check and calls `install_cli()` if needed
- Called in `lib.rs` startup async block, right after daemon availability check

## Safety guards (from 5 rounds of codex review)
- **Ownership verification**: Only considers a symlink "ours" if target filename is `runt`/`runt-nightly` AND path contains `/nteract`. Uses exact exec pattern matching for nb scripts.
- **Dev mode guard**: Skips entirely when `is_dev_mode()` to avoid repointing global CLI at worktree build artifacts.
- **Ephemeral path guard**: Skips when running from translocated paths, AppImage mounts, Downloads, /Volumes, /tmp.
- **Sibling protection**: Uses `symlink_metadata()` to detect occupied sibling paths (including dangling symlinks) and skips repair if an unrelated command would be clobbered.
- **Only repairs when Stale**: Does nothing if CLI was never installed (NotInstalled) or is already current.

## Test plan
- [x] Unit tests for `check_nb_script()` — current, stale, missing, not-ours cases
- [x] Unit tests for symlink assertions (missing file, regular file handling)
- [x] 6 tests pass, lint clean
- [x] 5 rounds of codex review — all findings addressed