### PR TITLE
feat(protocol): add version assertion when CLI connects to daemon

### DIFF
--- a/crates/notebook-protocol/src/connection.rs
+++ b/crates/notebook-protocol/src/connection.rs
@@ -172,11 +172,16 @@ pub async fn recv_preamble<R: AsyncRead + Unpin>(reader: &mut R) -> std::io::Res
 
     let version = buf[4];
     if version != PROTOCOL_VERSION as u8 {
+        let direction = if (version as u32) > PROTOCOL_VERSION {
+            "The daemon is newer than this client. Please update the CLI (or reinstall the app)."
+        } else {
+            "The daemon is older than this client. Please update the daemon: runt daemon doctor --fix"
+        };
         return Err(std::io::Error::new(
             std::io::ErrorKind::InvalidData,
             format!(
-                "protocol version mismatch: expected {}, got {}",
-                PROTOCOL_VERSION, version
+                "protocol version mismatch: daemon has v{}, client expects v{}. {}",
+                version, PROTOCOL_VERSION, direction
             ),
         ));
     }

--- a/crates/notebook-sync/src/connect.rs
+++ b/crates/notebook-sync/src/connect.rs
@@ -203,7 +203,8 @@ pub async fn connect_with_options(
     let caps_data = connection::recv_frame(&mut reader)
         .await?
         .ok_or_else(|| SyncError::Protocol("Connection closed during handshake".into()))?;
-    let _caps: ProtocolCapabilities = serde_json::from_slice(&caps_data)?;
+    let caps: ProtocolCapabilities = serde_json::from_slice(&caps_data)?;
+    check_daemon_protocol_version(&caps);
 
     // Initial Automerge sync exchange — start from the standard notebook
     // skeleton so load_incremental takes the incremental path.
@@ -658,8 +659,9 @@ pub async fn connect_relay(
     let caps_data = connection::recv_frame(&mut reader)
         .await?
         .ok_or_else(|| SyncError::Protocol("Connection closed during handshake".into()))?;
-    let _caps: ProtocolCapabilities = serde_json::from_slice(&caps_data)
+    let caps: ProtocolCapabilities = serde_json::from_slice(&caps_data)
         .map_err(|e| SyncError::Protocol(format!("Parse capabilities: {}", e)))?;
+    check_daemon_protocol_version(&caps);
 
     // Receive initial metadata frame (may be empty)
     let _initial_data = connection::recv_frame(&mut reader)
@@ -819,4 +821,30 @@ where
     }
 
     Ok(())
+}
+
+/// Log version info from a daemon's `ProtocolCapabilities` response.
+///
+/// Warns on protocol version mismatch but does not error — the preamble
+/// already hard-rejects incompatible protocol versions, so any connection
+/// that gets this far has a matching wire format. This check surfaces
+/// version differences for debugging (e.g., a daemon rebuilt from a
+/// different commit).
+fn check_daemon_protocol_version(caps: &ProtocolCapabilities) {
+    let expected = notebook_protocol::connection::PROTOCOL_VERSION;
+
+    if let Some(remote) = caps.protocol_version {
+        if remote != expected {
+            log::warn!(
+                "[notebook-sync] Daemon protocol version ({}) differs from client ({}). \
+                 This connection may behave unexpectedly.",
+                remote,
+                expected,
+            );
+        }
+    }
+
+    if let Some(ref ver) = caps.daemon_version {
+        debug!("[notebook-sync] Connected to daemon version {}", ver);
+    }
 }

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -1552,15 +1552,16 @@ async fn daemon_command(command: DaemonCommands) -> Result<()> {
     match command {
         DaemonCommands::Status { json } => {
             let installed = manager.is_installed();
-            let running = if daemon_info.is_some() {
+            let pong_info = if daemon_info.is_some() {
                 // Use timeout to prevent hanging on stale daemon.json
-                tokio::time::timeout(Duration::from_secs(3), client.ping())
+                tokio::time::timeout(Duration::from_secs(3), client.ping_version())
                     .await
-                    .map(|r| r.is_ok())
-                    .unwrap_or(false)
+                    .ok()
+                    .and_then(|r| r.ok())
             } else {
-                false
+                None
             };
+            let running = pong_info.is_some();
             let stats = if running {
                 client.status().await.ok()
             } else {
@@ -1586,6 +1587,8 @@ async fn daemon_command(command: DaemonCommands) -> Result<()> {
                     "installed": installed,
                     "running": running,
                     "dev_mode": is_dev,
+                    "protocol_version": pong_info.as_ref().and_then(|p| p.protocol_version),
+                    "daemon_version": pong_info.as_ref().and_then(|p| p.daemon_version.clone()),
                     "daemon_info": daemon_info,
                     "pool_stats": stats,
                     "paths": {
@@ -1656,6 +1659,15 @@ async fn daemon_command(command: DaemonCommands) -> Result<()> {
                     println!();
                     println!("{:<19} {}", "PID:".bold(), info.pid);
                     println!("{:<19} {}", "Version:".bold(), info.version);
+                    if let Some(ref pong) = pong_info {
+                        if let Some(pv) = pong.protocol_version {
+                            println!("{:<19} v{}", "Protocol:".bold(), pv);
+                        }
+                        // Warn on protocol version mismatch
+                        if let Err(msg) = pong.check_protocol_version() {
+                            println!("{:<19} {}", "Warning:".bold(), msg.yellow());
+                        }
+                    }
                     if let Some(port) = info.blob_port {
                         println!(
                             "{:<19} {}",

--- a/crates/runtimed-client/src/client.rs
+++ b/crates/runtimed-client/src/client.rs
@@ -58,6 +58,48 @@ pub struct InspectResult {
     pub kernel_info: Option<crate::protocol::NotebookKernelInfo>,
 }
 
+/// Version information returned by a daemon ping.
+#[derive(Debug, Clone)]
+pub struct PongInfo {
+    /// Numeric protocol version (matches `PROTOCOL_VERSION` in connection.rs).
+    /// `None` if the daemon is too old to include this field.
+    pub protocol_version: Option<u32>,
+    /// Daemon version string (e.g., "2.0.0+abc123").
+    /// `None` if the daemon is too old to include this field.
+    pub daemon_version: Option<String>,
+}
+
+impl PongInfo {
+    /// Check whether the daemon's protocol version is compatible with this client.
+    ///
+    /// Returns `Ok(())` if compatible, or an `Err` with an actionable message
+    /// explaining the mismatch. If the daemon didn't report a protocol version
+    /// (old daemon), this logs a warning but does not error — backward
+    /// compatibility is preserved.
+    pub fn check_protocol_version(&self) -> Result<(), String> {
+        let expected = notebook_protocol::connection::PROTOCOL_VERSION;
+
+        match self.protocol_version {
+            Some(remote) if remote == expected => Ok(()),
+            Some(remote) if remote > expected => Err(format!(
+                "Daemon is running protocol version {remote}, but this CLI expects version {expected}. \
+                 Please update the CLI (or reinstall the app) to match the daemon."
+            )),
+            Some(remote) => Err(format!(
+                "Daemon is running protocol version {remote}, but this CLI expects version {expected}. \
+                 Please update the daemon: runt daemon doctor --fix"
+            )),
+            None => {
+                log::warn!(
+                    "[pool-client] Daemon did not report a protocol version — \
+                     it may be outdated. Consider updating: runt daemon doctor --fix"
+                );
+                Ok(())
+            }
+        }
+    }
+}
+
 /// Error type for client operations.
 #[derive(Debug, thiserror::Error)]
 pub enum ClientError {
@@ -108,9 +150,24 @@ impl PoolClient {
 
     /// Ping the daemon to check if it's alive.
     pub async fn ping(&self) -> Result<(), ClientError> {
+        self.ping_version().await.map(|_| ())
+    }
+
+    /// Ping the daemon and return its version info.
+    ///
+    /// Returns `Ok(PongInfo)` with the daemon's protocol version and
+    /// version string. Old daemons that send a bare `Pong` (no fields)
+    /// will have `None` for both fields.
+    pub async fn ping_version(&self) -> Result<PongInfo, ClientError> {
         let response = self.send_request(Request::Ping).await?;
         match response {
-            Response::Pong => Ok(()),
+            Response::Pong {
+                protocol_version,
+                daemon_version,
+            } => Ok(PongInfo {
+                protocol_version,
+                daemon_version,
+            }),
             Response::Error { message } => Err(ClientError::DaemonError(message)),
             _ => Err(ClientError::ProtocolError(
                 "Unexpected response".to_string(),
@@ -422,7 +479,13 @@ where
     if crate::is_dev_mode() {
         info!("[pool-client] Development mode: checking for worktree daemon...");
 
-        if client.ping().await.is_ok() {
+        if let Ok(pong) = client.ping_version().await {
+            if let Err(msg) = pong.check_protocol_version() {
+                warn!("[pool-client] {}", msg);
+            }
+            if let Some(ref ver) = pong.daemon_version {
+                info!("[pool-client] Dev daemon version: {}", ver);
+            }
             if let Some(info) = get_running_daemon_info() {
                 emit(DaemonProgress::Ready {
                     endpoint: info.endpoint.clone(),

--- a/crates/runtimed-client/src/protocol.rs
+++ b/crates/runtimed-client/src/protocol.rs
@@ -78,7 +78,19 @@ pub enum Response {
     Stats { state: PoolState },
 
     /// Pong response to ping.
-    Pong,
+    ///
+    /// Includes version metadata so clients can detect version mismatches
+    /// early (before attempting notebook sync or other operations).
+    /// All fields are optional for backward compatibility with older daemons.
+    Pong {
+        /// Numeric protocol version (matches `PROTOCOL_VERSION` in connection.rs).
+        /// Bump only on breaking wire-format changes.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        protocol_version: Option<u32>,
+        /// Daemon version string (e.g., "2.0.0+abc123").
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        daemon_version: Option<String>,
+    },
 
     /// Shutdown acknowledged.
     ShuttingDown,
@@ -322,10 +334,37 @@ mod tests {
 
     #[test]
     fn test_response_pong() {
-        assert!(matches!(
-            roundtrip_response(&Response::Pong),
-            Response::Pong
-        ));
+        let resp = Response::Pong {
+            protocol_version: Some(2),
+            daemon_version: Some("2.0.0+abc123".into()),
+        };
+        match roundtrip_response(&resp) {
+            Response::Pong {
+                protocol_version,
+                daemon_version,
+            } => {
+                assert_eq!(protocol_version, Some(2));
+                assert_eq!(daemon_version.as_deref(), Some("2.0.0+abc123"));
+            }
+            _ => panic!("unexpected response type"),
+        }
+    }
+
+    #[test]
+    fn test_response_pong_without_version() {
+        // Old daemons send Pong without version fields — backward compat
+        let json = r#"{"type":"pong"}"#;
+        let resp: Response = serde_json::from_str(json).unwrap();
+        match resp {
+            Response::Pong {
+                protocol_version,
+                daemon_version,
+            } => {
+                assert_eq!(protocol_version, None);
+                assert_eq!(daemon_version, None);
+            }
+            _ => panic!("unexpected response type"),
+        }
     }
 
     #[test]

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -1864,7 +1864,10 @@ impl Daemon {
                 Response::Stats { state }
             }
 
-            Request::Ping => Response::Pong,
+            Request::Ping => Response::Pong {
+                protocol_version: Some(notebook_protocol::connection::PROTOCOL_VERSION),
+                daemon_version: Some(crate::daemon_version().to_string()),
+            },
 
             Request::Shutdown => {
                 self.trigger_shutdown().await;


### PR DESCRIPTION
## Summary

- Add `protocol_version` and `daemon_version` fields to the pool `Pong` response, so clients learn the daemon's version immediately on ping
- Add `PoolClient::ping_version()` returning `PongInfo` with `check_protocol_version()` that produces actionable error messages (e.g., "please update the daemon" vs "please update the CLI")
- Improve the preamble version mismatch error message to indicate which side is outdated
- Log daemon version in notebook-sync when receiving `ProtocolCapabilities` (was previously discarded as `_caps`)
- Show protocol version in `runt daemon status` output (both human-readable and JSON)
- Warn on protocol mismatch in `ensure_daemon_running` dev mode path

All new fields are `Option` with `#[serde(default)]` — old daemons that send bare `{"type":"pong"}` still deserialize correctly, preserving backward compatibility.

## Test plan

- [x] `cargo test -p notebook-protocol -p runtimed-client -p notebook-sync` passes (88 tests)
- [x] `cargo xtask lint` passes
- [x] New tests: `test_response_pong` verifies round-trip with version fields, `test_response_pong_without_version` verifies backward compat with old bare Pong
- [ ] Manual: `runt daemon status` shows Protocol line with version number
- [ ] Manual: connect old CLI to new daemon (or vice versa) — verify actionable error message