### PR TITLE
feat(service): migrate daemon registration to SMAppService on macOS 13+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ Untitled*.ipynb
 # Local environment
 .env
 
+# Generated launch agent plists (built by xtask for Tauri bundling)
+crates/notebook/launch-agents/
+
 # OS-generated files
 .DS_Store
 .AppleDouble

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4146,6 +4146,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-service-management"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b213642d6959cc6023ceb1217aa595eaaf09b8094ce95127c103cab611fe65e8"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-security",
+]
+
+[[package]]
 name = "objc2-ui-kit"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6170,6 +6183,7 @@ dependencies = [
  "schemars 1.2.1",
  "serde",
  "serde_json",
+ "smappservice-rs",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
@@ -6959,6 +6973,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "smappservice-rs"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52703b97a53101cf5d4580e0737aaa634ce1fdcfc123c16b2a9658e358013488"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+ "objc2-service-management",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/crates/runt-workspace/src/lib.rs
+++ b/crates/runt-workspace/src/lib.rs
@@ -642,6 +642,31 @@ pub fn launchd_start() -> Result<(), String> {
     launchd_bootstrap(&plist, &domain)
 }
 
+/// Kickstart the daemon's launchd service.
+///
+/// Unlike `launchd_start()` which uses `bootstrap` (requires a plist file),
+/// `kickstart` works for SMAppService-registered agents where the plist is
+/// inside the app bundle and managed by the system. The `-k` flag kills any
+/// currently running instance before starting a new one.
+#[cfg(target_os = "macos")]
+pub fn launchd_kickstart() -> Result<(), String> {
+    let uid = launchd_uid()?;
+    let label = daemon_launchd_label();
+    let service_target = format!("gui/{uid}/{label}");
+
+    let output = Command::new("launchctl")
+        .args(["kickstart", "-k", &service_target])
+        .output()
+        .map_err(|e| format!("Failed to run launchctl kickstart: {e}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("launchctl kickstart failed: {}", stderr.trim()));
+    }
+
+    Ok(())
+}
+
 /// Check whether the daemon's launchd service is currently loaded.
 #[cfg(target_os = "macos")]
 pub fn launchd_is_loaded() -> Result<bool, String> {

--- a/crates/runtimed-client/Cargo.toml
+++ b/crates/runtimed-client/Cargo.toml
@@ -28,6 +28,9 @@ automerge = "0.7"
 schemars = { workspace = true }
 ts-rs = { workspace = true }
 
+[target.'cfg(target_os = "macos")'.dependencies]
+smappservice-rs = "0.1"
+
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 

--- a/crates/runtimed-client/src/service.rs
+++ b/crates/runtimed-client/src/service.rs
@@ -174,24 +174,6 @@ impl ServiceManager {
             return Err(ServiceError::BinaryNotFound(source_binary.clone()));
         }
 
-        // macOS 13+: Use SMAppService for in-bundle binaries
-        #[cfg(target_os = "macos")]
-        if should_use_smappservice(source_binary) {
-            self.config.binary_path = source_binary.clone();
-            info!(
-                "[service] Using SMAppService for in-bundle binary at {:?}",
-                self.config.binary_path
-            );
-
-            // Clean up legacy plist and standalone binary from older installs
-            self.cleanup_legacy_install();
-            Self::cleanup_legacy_binary();
-
-            smappservice_register(source_binary, &self.config.log_path)?;
-            info!("[service] Service installed via SMAppService");
-            return Ok(());
-        }
-
         if Self::is_in_app_bundle(source_binary) {
             // Source is inside an app bundle — point the plist directly at it.
             self.config.binary_path = source_binary.clone();
@@ -208,8 +190,23 @@ impl ServiceManager {
             self.atomic_copy_binary(source_binary)?;
         }
 
-        // Create service configuration (legacy plist path)
+        // Always write the legacy plist — launchctl start/stop depend on it
         self.create_service_config()?;
+
+        // macOS 13+: Additionally register via SMAppService for Login Items
+        // visibility and automatic cleanup on app deletion. Best-effort:
+        // if the bundle is read-only (e.g. running from DMG), we skip
+        // SMAppService and rely on the legacy plist alone.
+        #[cfg(target_os = "macos")]
+        if should_use_smappservice(source_binary) {
+            match smappservice_register(source_binary, &self.config.log_path) {
+                Ok(()) => info!("[service] Additionally registered via SMAppService"),
+                Err(e) => info!(
+                    "[service] SMAppService registration skipped ({}), legacy plist is active",
+                    e
+                ),
+            }
+        }
 
         info!("[service] Service installed successfully");
         Ok(())
@@ -318,9 +315,8 @@ impl ServiceManager {
     ///
     /// This is used when the notebook app detects a version mismatch between
     /// the running daemon and the bundled version. On macOS 13+ with in-bundle
-    /// binaries, uses SMAppService to re-register (unregister + register),
-    /// which picks up the new binary. On older macOS or non-bundle binaries,
-    /// falls back to the legacy plist + launchctl approach.
+    /// binaries, additionally re-registers via SMAppService. The legacy plist
+    /// is always updated to keep launchctl start/stop working.
     pub fn upgrade(&mut self, source_binary: &PathBuf) -> ServiceResult<()> {
         if !source_binary.exists() {
             return Err(ServiceError::BinaryNotFound(source_binary.clone()));
@@ -330,21 +326,6 @@ impl ServiceManager {
 
         // Stop the running daemon (ignore errors - may not be running)
         self.stop().ok();
-
-        // macOS 13+: Use SMAppService for in-bundle binaries
-        #[cfg(target_os = "macos")]
-        if should_use_smappservice(source_binary) {
-            self.config.binary_path = source_binary.clone();
-            info!("[service] Upgrading via SMAppService (in-bundle binary)");
-
-            // Clean up legacy plist from older installs during migration
-            self.cleanup_legacy_install();
-            Self::cleanup_legacy_binary();
-
-            smappservice_register(source_binary, &self.config.log_path)?;
-            info!("[service] Upgrade via SMAppService completed");
-            return Ok(());
-        }
 
         if Self::is_in_app_bundle(source_binary) {
             // Source is inside an app bundle — point the plist directly at it.
@@ -356,10 +337,18 @@ impl ServiceManager {
             self.atomic_copy_binary(source_binary)?;
         }
 
-        // Recreate service config to apply any template changes (e.g., new env vars,
-        // or to migrate the plist from a standalone path to an in-bundle path)
+        // Always recreate the legacy plist for launchctl start/stop
         self.create_service_config()?;
         info!("[service] Updated service config");
+
+        // macOS 13+: Additionally re-register via SMAppService (best-effort)
+        #[cfg(target_os = "macos")]
+        if should_use_smappservice(source_binary) {
+            match smappservice_register(source_binary, &self.config.log_path) {
+                Ok(()) => info!("[service] Re-registered via SMAppService"),
+                Err(e) => info!("[service] SMAppService re-registration skipped ({})", e),
+            }
+        }
 
         // Use launchd_start() which always does bootout+bootstrap, not
         // start() which uses ensure_loaded (a no-op if KeepAlive already
@@ -377,26 +366,6 @@ impl ServiceManager {
     /// Check whether a path is inside a macOS `.app` bundle.
     fn is_in_app_bundle(path: &Path) -> bool {
         path.to_string_lossy().contains(".app/Contents/MacOS/")
-    }
-
-    /// Remove the legacy plist from `~/Library/LaunchAgents/` and stop the
-    /// launchd service.
-    ///
-    /// Best-effort: called during migration to SMAppService to clean up the
-    /// old registration. Logs on failure but never errors.
-    #[cfg(target_os = "macos")]
-    fn cleanup_legacy_install(&self) {
-        // Stop the legacy launchd service if loaded
-        runt_workspace::launchd_stop().ok();
-
-        // Remove the legacy plist
-        let path = plist_path();
-        if path.exists() {
-            match std::fs::remove_file(&path) {
-                Ok(()) => info!("[service] Removed legacy plist at {:?}", path),
-                Err(e) => info!("[service] Could not remove legacy plist {:?}: {}", path, e),
-            }
-        }
     }
 
     /// Remove the legacy standalone binary from `~/.local/share/runt/bin/`.
@@ -850,14 +819,35 @@ fn is_macos_13_or_later() -> bool {
 
 /// Whether to use SMAppService for a given binary path.
 ///
-/// Returns true only when:
+/// Returns true only when ALL of:
 /// 1. Running on macOS 13+
-/// 2. The binary is inside a `.app` bundle
+/// 2. The target binary is inside a `.app` bundle
+/// 3. The calling process (`current_exe`) is inside the SAME `.app` bundle
 ///
-/// CLI installs and older macOS versions always use the legacy path.
+/// Condition 3 is critical: SMAppService resolves the plist relative to the
+/// calling process's main bundle. If `runt` (the CLI) calls SMAppService,
+/// it would resolve against the CLI's bundle, not the notebook app's bundle.
+/// Only the Tauri app or its sidecar `runtimed` should call SMAppService.
+///
+/// CLI installs, standalone binaries, and older macOS always use legacy launchctl.
 #[cfg(target_os = "macos")]
 fn should_use_smappservice(binary: &Path) -> bool {
-    ServiceManager::is_in_app_bundle(binary) && is_macos_13_or_later()
+    if !ServiceManager::is_in_app_bundle(binary) || !is_macos_13_or_later() {
+        return false;
+    }
+
+    // Verify the calling process is in the same app bundle as the target binary
+    let Ok(current_exe) = std::env::current_exe() else {
+        return false;
+    };
+    let Some(target_bundle) = app_bundle_root(binary) else {
+        return false;
+    };
+    let Some(caller_bundle) = app_bundle_root(&current_exe) else {
+        return false;
+    };
+
+    target_bundle == caller_bundle
 }
 
 /// Resolve the app bundle root from a binary path inside `Contents/MacOS/`.
@@ -1093,33 +1083,12 @@ fn windows_startup_path() -> PathBuf {
 /// Get the path to the service configuration file.
 /// Used by doctor command for diagnostics.
 ///
-/// On macOS, checks whether the service is registered via SMAppService
-/// (by querying its status) and returns the in-bundle plist path if so.
-/// Otherwise returns the legacy `~/Library/LaunchAgents/` path.
+/// On macOS, always returns the legacy `~/Library/LaunchAgents/` plist path.
+/// The legacy plist is always written (even when SMAppService is also used)
+/// to keep launchctl start/stop working.
 pub fn service_config_path() -> PathBuf {
     #[cfg(target_os = "macos")]
     {
-        // Check if SMAppService is actually registered (not just whether
-        // we *could* use it). This avoids misreporting the plist location
-        // when the installed service is still legacy.
-        if smappservice_is_registered() {
-            if let Ok(exe) = std::env::current_exe() {
-                if let Some(bundle_root) = app_bundle_root(&exe) {
-                    return bundle_root
-                        .join("Contents/Library/LaunchAgents")
-                        .join(smappservice_plist_filename());
-                }
-            }
-            // If we can't determine the bundle root, check the plist path
-            // recorded by runt-workspace (it parses the installed plist).
-            if let Some(binary) = runt_workspace::plist_binary_path() {
-                if let Some(bundle_root) = app_bundle_root(&binary) {
-                    return bundle_root
-                        .join("Contents/Library/LaunchAgents")
-                        .join(smappservice_plist_filename());
-                }
-            }
-        }
         plist_path()
     }
     #[cfg(target_os = "linux")]

--- a/crates/runtimed-client/src/service.rs
+++ b/crates/runtimed-client/src/service.rs
@@ -276,10 +276,20 @@ impl ServiceManager {
         // SMAppService resolves against the calling process's bundle, so this
         // only works when called from the notebook app, not from `runt` CLI.
         #[cfg(target_os = "macos")]
-        if should_use_smappservice(&self.config.binary_path) {
-            match smappservice_unregister() {
-                Ok(()) => {}
-                Err(e) => info!("[service] SMAppService unregister skipped ({})", e),
+        {
+            if should_use_smappservice(&self.config.binary_path) {
+                match smappservice_unregister() {
+                    Ok(()) => {}
+                    Err(e) => info!("[service] SMAppService unregister skipped ({})", e),
+                }
+            } else if is_macos_13_or_later() && Self::is_in_app_bundle(&self.config.binary_path) {
+                // CLI is uninstalling an app-bundle daemon on macOS 13+.
+                // We can't call SMAppService from here, so warn the user.
+                info!(
+                    "[service] Note: The Login Item entry in System Settings may \
+                     persist until the app is deleted or you disable it manually \
+                     in System Settings > General > Login Items."
+                );
             }
         }
 

--- a/crates/runtimed-client/src/service.rs
+++ b/crates/runtimed-client/src/service.rs
@@ -637,20 +637,12 @@ impl ServiceManager {
 
     #[cfg(target_os = "macos")]
     fn start_macos(&self) -> ServiceResult<()> {
-        // SMAppService agents are started automatically by the system on
-        // register(). If already registered, re-registering is a no-op.
-        if smappservice_is_registered() {
-            info!("[service] SMAppService agent is registered (auto-started by system)");
-            return Ok(());
-        }
-
-        // If we should use SMAppService but aren't registered yet, register now
-        if should_use_smappservice(&self.config.binary_path) {
-            smappservice_register(&self.config.binary_path, &self.config.log_path)?;
-            return Ok(());
-        }
-
-        // Legacy launchctl path
+        // SMAppService-registered agents are managed by the system — the
+        // agent starts automatically at login and after crashes. We still
+        // use launchctl to ensure the service is loaded for immediate start.
+        // We do NOT call smappservice_register() here because start() may
+        // be called from `runt` (the CLI), whose current_exe is different
+        // from the daemon binary.
         let bootstrapped =
             runt_workspace::launchd_ensure_loaded().map_err(ServiceError::StartFailed)?;
 
@@ -664,15 +656,12 @@ impl ServiceManager {
 
     #[cfg(target_os = "macos")]
     fn stop_macos(&self) -> ServiceResult<()> {
-        // For SMAppService agents, unregister stops the agent. We then
-        // re-register to keep it installed (stop != uninstall).
-        if smappservice_is_registered() {
-            smappservice_unregister(&self.config.binary_path)?;
-            info!("[service] Stopped SMAppService agent");
-            return Ok(());
-        }
-
-        // Legacy launchctl path
+        // Use launchctl bootout to stop the running daemon process.
+        // This works for both SMAppService-registered and legacy agents.
+        // Crucially, we do NOT call smappservice_unregister() here —
+        // unregister both stops and removes the registration, making
+        // is_installed() return false and preventing auto-start at login.
+        // stop() should only stop the process, not remove the service.
         runt_workspace::launchd_stop().map_err(ServiceError::StopFailed)?;
 
         info!("[service] Stopped launchd service");
@@ -1104,16 +1093,27 @@ fn windows_startup_path() -> PathBuf {
 /// Get the path to the service configuration file.
 /// Used by doctor command for diagnostics.
 ///
-/// On macOS, returns the in-bundle plist path if SMAppService is active,
-/// otherwise the legacy `~/Library/LaunchAgents/` path.
+/// On macOS, checks whether the service is registered via SMAppService
+/// (by querying its status) and returns the in-bundle plist path if so.
+/// Otherwise returns the legacy `~/Library/LaunchAgents/` path.
 pub fn service_config_path() -> PathBuf {
     #[cfg(target_os = "macos")]
     {
-        // If the current binary is in an app bundle on macOS 13+, return
-        // the in-bundle plist path
-        if let Ok(exe) = std::env::current_exe() {
-            if should_use_smappservice(&exe) {
+        // Check if SMAppService is actually registered (not just whether
+        // we *could* use it). This avoids misreporting the plist location
+        // when the installed service is still legacy.
+        if smappservice_is_registered() {
+            if let Ok(exe) = std::env::current_exe() {
                 if let Some(bundle_root) = app_bundle_root(&exe) {
+                    return bundle_root
+                        .join("Contents/Library/LaunchAgents")
+                        .join(smappservice_plist_filename());
+                }
+            }
+            // If we can't determine the bundle root, check the plist path
+            // recorded by runt-workspace (it parses the installed plist).
+            if let Some(binary) = runt_workspace::plist_binary_path() {
+                if let Some(bundle_root) = app_bundle_root(&binary) {
                     return bundle_root
                         .join("Contents/Library/LaunchAgents")
                         .join(smappservice_plist_filename());

--- a/crates/runtimed-client/src/service.rs
+++ b/crates/runtimed-client/src/service.rs
@@ -1184,6 +1184,74 @@ mod tests {
         }
     }
 
+    /// Verify macOS version detection returns a boolean without panicking
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn test_macos_version_detection() {
+        // Should not panic
+        let result = is_macos_13_or_later();
+        // On CI/dev machines running macOS 13+, this should be true
+        // We just check it doesn't panic — the exact value depends on the host
+        let _ = result;
+    }
+
+    /// Verify app_bundle_root extracts the correct bundle path
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn test_app_bundle_root() {
+        let binary = PathBuf::from("/Applications/nteract.app/Contents/MacOS/runtimed");
+        let root = app_bundle_root(&binary);
+        assert_eq!(root, Some(PathBuf::from("/Applications/nteract.app")));
+
+        let binary = PathBuf::from("/Users/test/Desktop/My App.app/Contents/MacOS/daemon");
+        let root = app_bundle_root(&binary);
+        assert_eq!(root, Some(PathBuf::from("/Users/test/Desktop/My App.app")));
+
+        // Non-bundle path returns None
+        let binary = PathBuf::from("/usr/local/bin/runtimed");
+        assert_eq!(app_bundle_root(&binary), None);
+    }
+
+    /// Verify SMAppService plist contains BundleProgram key
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn test_smappservice_plist_contains_bundle_program() {
+        let log_path = PathBuf::from("/tmp/test.log");
+        let content = generate_smappservice_plist("Contents/MacOS/runtimed", &log_path).unwrap();
+
+        assert!(
+            content.contains("<key>BundleProgram</key>"),
+            "SMAppService plist must contain BundleProgram key"
+        );
+        assert!(
+            content.contains("<string>Contents/MacOS/runtimed</string>"),
+            "BundleProgram should be the bundle-relative path"
+        );
+        assert!(
+            content.contains("<key>HOME</key>"),
+            "Plist must contain HOME env var"
+        );
+        assert!(
+            content.contains("<key>Label</key>"),
+            "Plist must contain Label key"
+        );
+        assert!(
+            content.contains("<key>KeepAlive</key>"),
+            "Plist must contain KeepAlive key"
+        );
+    }
+
+    /// Verify should_use_smappservice returns false for non-bundle paths
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn test_should_use_smappservice_non_bundle() {
+        let binary = PathBuf::from("/usr/local/bin/runtimed");
+        assert!(
+            !should_use_smappservice(&binary),
+            "Non-bundle paths should never use SMAppService"
+        );
+    }
+
     /// Verify the Linux systemd template includes HOME env var
     #[test]
     #[cfg(target_os = "linux")]

--- a/crates/runtimed-client/src/service.rs
+++ b/crates/runtimed-client/src/service.rs
@@ -174,6 +174,37 @@ impl ServiceManager {
             return Err(ServiceError::BinaryNotFound(source_binary.clone()));
         }
 
+        // macOS 13+: Use SMAppService for in-bundle binaries (preferred).
+        // The plist must already be in the signed bundle at build time.
+        // On success, remove the legacy plist to avoid dual-registration
+        // (which would let the daemon start even when Login Items is disabled).
+        #[cfg(target_os = "macos")]
+        if should_use_smappservice(source_binary) {
+            self.config.binary_path = source_binary.clone();
+            info!(
+                "[service] Using SMAppService for in-bundle binary at {:?}",
+                self.config.binary_path
+            );
+            Self::cleanup_legacy_binary();
+
+            match smappservice_register() {
+                Ok(()) => {
+                    // Remove legacy plist to avoid dual-registration
+                    self.remove_legacy_plist();
+                    info!("[service] Service installed via SMAppService");
+                    return Ok(());
+                }
+                Err(e) => {
+                    // SMAppService failed (e.g. unsigned dev build) — fall
+                    // through to legacy plist registration
+                    info!(
+                        "[service] SMAppService failed ({}), falling back to legacy plist",
+                        e
+                    );
+                }
+            }
+        }
+
         if Self::is_in_app_bundle(source_binary) {
             // Source is inside an app bundle — point the plist directly at it.
             self.config.binary_path = source_binary.clone();
@@ -190,23 +221,8 @@ impl ServiceManager {
             self.atomic_copy_binary(source_binary)?;
         }
 
-        // Always write the legacy plist — launchctl start/stop depend on it
+        // Legacy plist registration
         self.create_service_config()?;
-
-        // macOS 13+: Additionally register via SMAppService for Login Items
-        // visibility and automatic cleanup on app deletion. Best-effort:
-        // if the bundle is read-only (e.g. running from DMG), we skip
-        // SMAppService and rely on the legacy plist alone.
-        #[cfg(target_os = "macos")]
-        if should_use_smappservice(source_binary) {
-            match smappservice_register(source_binary, &self.config.log_path) {
-                Ok(()) => info!("[service] Additionally registered via SMAppService"),
-                Err(e) => info!(
-                    "[service] SMAppService registration skipped ({}), legacy plist is active",
-                    e
-                ),
-            }
-        }
 
         info!("[service] Service installed successfully");
         Ok(())
@@ -274,7 +290,7 @@ impl ServiceManager {
         // macOS: Unregister SMAppService agent if registered
         #[cfg(target_os = "macos")]
         if smappservice_is_registered() {
-            smappservice_unregister(&self.config.binary_path)?;
+            smappservice_unregister()?;
         }
 
         // Remove legacy service configuration (plist / systemd / windows)
@@ -315,8 +331,7 @@ impl ServiceManager {
     ///
     /// This is used when the notebook app detects a version mismatch between
     /// the running daemon and the bundled version. On macOS 13+ with in-bundle
-    /// binaries, additionally re-registers via SMAppService. The legacy plist
-    /// is always updated to keep launchctl start/stop working.
+    /// binaries, re-registers via SMAppService then kickstarts.
     pub fn upgrade(&mut self, source_binary: &PathBuf) -> ServiceResult<()> {
         if !source_binary.exists() {
             return Err(ServiceError::BinaryNotFound(source_binary.clone()));
@@ -327,32 +342,43 @@ impl ServiceManager {
         // Stop the running daemon (ignore errors - may not be running)
         self.stop().ok();
 
+        // macOS 13+: Use SMAppService for in-bundle binaries
+        #[cfg(target_os = "macos")]
+        if should_use_smappservice(source_binary) {
+            self.config.binary_path = source_binary.clone();
+            Self::cleanup_legacy_binary();
+
+            match smappservice_register() {
+                Ok(()) => {
+                    self.remove_legacy_plist();
+                    // Kickstart the agent (SMAppService doesn't auto-start
+                    // on re-register if it was stopped)
+                    runt_workspace::launchd_kickstart().map_err(ServiceError::StartFailed)?;
+                    info!("[service] Upgrade via SMAppService completed");
+                    return Ok(());
+                }
+                Err(e) => {
+                    info!(
+                        "[service] SMAppService failed ({}), falling back to legacy",
+                        e
+                    );
+                }
+            }
+        }
+
         if Self::is_in_app_bundle(source_binary) {
-            // Source is inside an app bundle — point the plist directly at it.
             self.config.binary_path = source_binary.clone();
             info!("[service] In-bundle binary, skipping copy");
             Self::cleanup_legacy_binary();
         } else {
-            // Standalone binary (Linux, Windows, edge cases) — atomically replace.
             self.atomic_copy_binary(source_binary)?;
         }
 
-        // Always recreate the legacy plist for launchctl start/stop
+        // Legacy plist registration
         self.create_service_config()?;
         info!("[service] Updated service config");
 
-        // macOS 13+: Additionally re-register via SMAppService (best-effort)
-        #[cfg(target_os = "macos")]
-        if should_use_smappservice(source_binary) {
-            match smappservice_register(source_binary, &self.config.log_path) {
-                Ok(()) => info!("[service] Re-registered via SMAppService"),
-                Err(e) => info!("[service] SMAppService re-registration skipped ({})", e),
-            }
-        }
-
-        // Use launchd_start() which always does bootout+bootstrap, not
-        // start() which uses ensure_loaded (a no-op if KeepAlive already
-        // restarted the old binary during the stop→copy window).
+        // Use launchd_start() which always does bootout+bootstrap
         #[cfg(target_os = "macos")]
         runt_workspace::launchd_start().map_err(ServiceError::StartFailed)?;
 
@@ -366,6 +392,25 @@ impl ServiceManager {
     /// Check whether a path is inside a macOS `.app` bundle.
     fn is_in_app_bundle(path: &Path) -> bool {
         path.to_string_lossy().contains(".app/Contents/MacOS/")
+    }
+
+    /// Remove the legacy plist from `~/Library/LaunchAgents/`.
+    ///
+    /// Best-effort: called after successful SMAppService registration to avoid
+    /// dual-registration. If both the legacy plist and SMAppService are active,
+    /// disabling Login Items in System Settings won't actually stop auto-start.
+    #[cfg(target_os = "macos")]
+    fn remove_legacy_plist(&self) {
+        // Stop the legacy launchd registration if loaded
+        runt_workspace::launchd_stop().ok();
+
+        let path = plist_path();
+        if path.exists() {
+            match std::fs::remove_file(&path) {
+                Ok(()) => info!("[service] Removed legacy plist at {:?}", path),
+                Err(e) => info!("[service] Could not remove legacy plist {:?}: {}", path, e),
+            }
+        }
     }
 
     /// Remove the legacy standalone binary from `~/.local/share/runt/bin/`.
@@ -606,12 +651,19 @@ impl ServiceManager {
 
     #[cfg(target_os = "macos")]
     fn start_macos(&self) -> ServiceResult<()> {
-        // SMAppService-registered agents are managed by the system — the
-        // agent starts automatically at login and after crashes. We still
-        // use launchctl to ensure the service is loaded for immediate start.
-        // We do NOT call smappservice_register() here because start() may
-        // be called from `runt` (the CLI), whose current_exe is different
-        // from the daemon binary.
+        // If SMAppService is registered, use kickstart (works without a
+        // legacy plist in ~/Library/LaunchAgents/).
+        if smappservice_is_registered() {
+            if runt_workspace::launchd_is_loaded().unwrap_or(false) {
+                info!("[service] SMAppService agent already loaded");
+                return Ok(());
+            }
+            runt_workspace::launchd_kickstart().map_err(ServiceError::StartFailed)?;
+            info!("[service] Started SMAppService agent via kickstart");
+            return Ok(());
+        }
+
+        // Legacy path: bootstrap from ~/Library/LaunchAgents/ plist
         let bootstrapped =
             runt_workspace::launchd_ensure_loaded().map_err(ServiceError::StartFailed)?;
 
@@ -873,119 +925,23 @@ fn smappservice_plist_filename() -> String {
     format!("{}.plist", daemon_launchd_label())
 }
 
-/// Generate the plist content for SMAppService registration.
+/// Register the launch agent via SMAppService.
 ///
-/// Unlike the legacy plist, this uses `BundleProgram` (a bundle-relative path)
-/// instead of `ProgramArguments` with an absolute path. `BundleProgram` is
-/// required by SMAppService and specifies the executable relative to the
-/// bundle root (e.g. `Contents/MacOS/runtimed`).
+/// The plist must already exist inside the app bundle at
+/// `Contents/Library/LaunchAgents/<label>.plist` — it is generated at
+/// build time by `cargo xtask build-app` and signed with the bundle.
+/// This function only calls `SMAppService.agent(plistName:).register()`.
 #[cfg(target_os = "macos")]
-fn generate_smappservice_plist(
-    bundle_program: &str,
-    log_path: &Path,
-) -> Result<String, ServiceError> {
-    let home = dirs::home_dir().ok_or_else(|| {
-        ServiceError::InstallFailed("Cannot determine home directory for service install".into())
-    })?;
-    let home_str = home.to_string_lossy();
-    let user = std::env::var("USER").unwrap_or_else(|_| "unknown".into());
-
-    let log_level = match runt_workspace::build_channel() {
-        runt_workspace::BuildChannel::Nightly => {
-            "info,notebook_sync=debug,runtimed::notebook_sync_server=debug"
-        }
-        runt_workspace::BuildChannel::Stable => "warn",
-    };
-
-    Ok(format!(
-        r#"<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-    <key>Label</key>
-    <string>{label}</string>
-    <key>BundleProgram</key>
-    <string>{bundle_program}</string>
-    <key>ProgramArguments</key>
-    <array>
-        <string>{bundle_program}</string>
-        <string>--log-level</string>
-        <string>{log_level}</string>
-    </array>
-    <key>RunAtLoad</key>
-    <true/>
-    <key>KeepAlive</key>
-    <dict>
-        <key>Crashed</key>
-        <true/>
-    </dict>
-    <key>StandardOutPath</key>
-    <string>{log}</string>
-    <key>StandardErrorPath</key>
-    <string>{log}</string>
-    <key>EnvironmentVariables</key>
-    <dict>
-        <key>HOME</key>
-        <string>{home}</string>
-        <key>USER</key>
-        <string>{user}</string>
-        <key>PATH</key>
-        <string>{home}/.local/bin:/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin</string>
-    </dict>
-</dict>
-</plist>
-"#,
-        label = daemon_launchd_label(),
-        bundle_program = bundle_program,
-        log_level = log_level,
-        log = log_path.display(),
-        home = home_str,
-        user = user,
-    ))
-}
-
-/// Write the SMAppService plist into the app bundle and register it.
-///
-/// The plist is placed at `<bundle>/Contents/Library/LaunchAgents/<label>.plist`.
-/// Then `SMAppService.agent(plistName:).register()` is called to register the
-/// agent with the system.
-#[cfg(target_os = "macos")]
-fn smappservice_register(binary: &Path, log_path: &Path) -> ServiceResult<()> {
+fn smappservice_register() -> ServiceResult<()> {
     use smappservice_rs::{AppService, ServiceType};
 
-    let bundle_root = app_bundle_root(binary)
-        .ok_or_else(|| ServiceError::InstallFailed("Cannot determine app bundle root".into()))?;
-
-    // Compute bundle-relative path: e.g. "Contents/MacOS/runtimed"
-    let binary_str = binary.to_string_lossy();
-    let bundle_root_str = bundle_root.to_string_lossy();
-    let bundle_program = binary_str
-        .strip_prefix(&*bundle_root_str)
-        .and_then(|s| s.strip_prefix('/'))
-        .ok_or_else(|| {
-            ServiceError::InstallFailed(format!(
-                "Binary {:?} is not inside bundle {:?}",
-                binary, bundle_root
-            ))
-        })?;
-
-    let plist_content = generate_smappservice_plist(bundle_program, log_path)?;
-
-    // Write plist into the bundle at Contents/Library/LaunchAgents/
-    let launch_agents_dir = bundle_root.join("Contents/Library/LaunchAgents");
-    std::fs::create_dir_all(&launch_agents_dir)?;
-
     let plist_filename = smappservice_plist_filename();
-    let plist_path = launch_agents_dir.join(&plist_filename);
-    std::fs::write(&plist_path, plist_content)?;
-    info!("[service] Wrote SMAppService plist to {:?}", plist_path);
-
-    // Register via SMAppService
     let service = AppService::new(ServiceType::Agent {
         plist_name: &plist_filename,
     });
 
-    // Unregister first to handle upgrades (plist content may have changed)
+    // Unregister first to handle upgrades (plist content may have changed
+    // between app versions). Best-effort — may fail if not registered.
     let _ = service.unregister();
 
     service
@@ -997,8 +953,11 @@ fn smappservice_register(binary: &Path, log_path: &Path) -> ServiceResult<()> {
 }
 
 /// Unregister the SMAppService agent.
+///
+/// Does not modify the plist inside the app bundle — that is part of the
+/// signed bundle and should not be touched at runtime.
 #[cfg(target_os = "macos")]
-fn smappservice_unregister(binary: &Path) -> ServiceResult<()> {
+fn smappservice_unregister() -> ServiceResult<()> {
     use smappservice_rs::{AppService, ServiceType};
 
     let plist_filename = smappservice_plist_filename();
@@ -1011,18 +970,6 @@ fn smappservice_unregister(binary: &Path) -> ServiceResult<()> {
         .map_err(|e| ServiceError::StopFailed(format!("SMAppService unregister failed: {e}")))?;
 
     info!("[service] Unregistered agent via SMAppService");
-
-    // Clean up the plist from the bundle
-    if let Some(bundle_root) = app_bundle_root(binary) {
-        let plist_path = bundle_root
-            .join("Contents/Library/LaunchAgents")
-            .join(&plist_filename);
-        if plist_path.exists() {
-            std::fs::remove_file(&plist_path)?;
-            info!("[service] Removed SMAppService plist {:?}", plist_path);
-        }
-    }
-
     Ok(())
 }
 
@@ -1181,32 +1128,18 @@ mod tests {
         assert_eq!(app_bundle_root(&binary), None);
     }
 
-    /// Verify SMAppService plist contains BundleProgram key
+    /// Verify SMAppService plist filename is channel-specific
     #[test]
     #[cfg(target_os = "macos")]
-    fn test_smappservice_plist_contains_bundle_program() {
-        let log_path = PathBuf::from("/tmp/test.log");
-        let content = generate_smappservice_plist("Contents/MacOS/runtimed", &log_path).unwrap();
-
+    fn test_smappservice_plist_filename() {
+        let filename = smappservice_plist_filename();
         assert!(
-            content.contains("<key>BundleProgram</key>"),
-            "SMAppService plist must contain BundleProgram key"
+            filename.ends_with(".plist"),
+            "Plist filename should end with .plist: {filename}"
         );
         assert!(
-            content.contains("<string>Contents/MacOS/runtimed</string>"),
-            "BundleProgram should be the bundle-relative path"
-        );
-        assert!(
-            content.contains("<key>HOME</key>"),
-            "Plist must contain HOME env var"
-        );
-        assert!(
-            content.contains("<key>Label</key>"),
-            "Plist must contain Label key"
-        );
-        assert!(
-            content.contains("<key>KeepAlive</key>"),
-            "Plist must contain KeepAlive key"
+            filename.contains("runtimed"),
+            "Plist filename should contain 'runtimed': {filename}"
         );
     }
 

--- a/crates/runtimed-client/src/service.rs
+++ b/crates/runtimed-client/src/service.rs
@@ -1,9 +1,27 @@
 //! Cross-platform service management for runtimed.
 //!
 //! Handles installation and management of the daemon as a system service:
-//! - macOS: launchd user agent (channel-specific `io.nteract.runtimed*.plist`)
+//! - macOS 13+: SMAppService agent registration (plist inside the app bundle)
+//! - macOS <13: launchd user agent (plist in `~/Library/LaunchAgents/`)
 //! - Linux: systemd user service (channel-specific `runtimed*.service`)
 //! - Windows: Startup shortcut
+//!
+//! ## macOS registration strategy
+//!
+//! On macOS 13 (Ventura) and later, when the daemon binary lives inside an app
+//! bundle, we use `SMAppService` to register the launch agent. Benefits:
+//!
+//! - The agent appears in System Settings → Login Items (transparency)
+//! - The agent is automatically cleaned up when the app is deleted
+//! - Uses Apple's recommended framework
+//!
+//! The plist is placed at `Contents/Library/LaunchAgents/` inside the app
+//! bundle and uses the `BundleProgram` key (bundle-relative path) instead of
+//! `ProgramArguments` with an absolute path.
+//!
+//! On macOS <13, or when the binary is not inside an app bundle (e.g. CLI
+//! install), we fall back to the legacy approach: writing a plist to
+//! `~/Library/LaunchAgents/` and using `launchctl` directly.
 
 use std::path::{Path, PathBuf};
 
@@ -139,14 +157,39 @@ impl ServiceManager {
 
     /// Install the daemon as a system service.
     ///
-    /// On macOS, if the source binary is inside an app bundle, the plist is
-    /// pointed directly at it — no copy is needed. This avoids the macOS
-    /// "App Management" permission prompt and code-signature issues during
-    /// upgrades. If the source is a custom path (e.g. `--binary /path/to/runtimed`),
-    /// it is honored and copied to the configured install location as before.
+    /// On macOS 13+ with an in-bundle binary, uses `SMAppService` to register
+    /// the launch agent. The plist is placed inside the app bundle at
+    /// `Contents/Library/LaunchAgents/` and registered via the modern API.
+    ///
+    /// On macOS <13, or when the source binary is outside an app bundle, falls
+    /// back to the legacy approach: writing a plist to `~/Library/LaunchAgents/`
+    /// and using `launchctl` directly.
+    ///
+    /// On macOS (any version), if the source binary is inside an app bundle,
+    /// the plist is pointed directly at it — no copy is needed. If the source
+    /// is a custom path (e.g. `--binary /path/to/runtimed`), it is honored and
+    /// copied to the configured install location.
     pub fn install(&mut self, source_binary: &PathBuf) -> ServiceResult<()> {
         if !source_binary.exists() {
             return Err(ServiceError::BinaryNotFound(source_binary.clone()));
+        }
+
+        // macOS 13+: Use SMAppService for in-bundle binaries
+        #[cfg(target_os = "macos")]
+        if should_use_smappservice(source_binary) {
+            self.config.binary_path = source_binary.clone();
+            info!(
+                "[service] Using SMAppService for in-bundle binary at {:?}",
+                self.config.binary_path
+            );
+
+            // Clean up legacy plist and standalone binary from older installs
+            self.cleanup_legacy_install();
+            Self::cleanup_legacy_binary();
+
+            smappservice_register(source_binary, &self.config.log_path)?;
+            info!("[service] Service installed via SMAppService");
+            return Ok(());
         }
 
         if Self::is_in_app_bundle(source_binary) {
@@ -165,7 +208,7 @@ impl ServiceManager {
             self.atomic_copy_binary(source_binary)?;
         }
 
-        // Create service configuration
+        // Create service configuration (legacy plist path)
         self.create_service_config()?;
 
         info!("[service] Service installed successfully");
@@ -224,11 +267,20 @@ impl ServiceManager {
     }
 
     /// Uninstall the daemon service.
+    ///
+    /// On macOS 13+, unregisters via SMAppService if registered. Also cleans
+    /// up any legacy plist in `~/Library/LaunchAgents/` for migration.
     pub fn uninstall(&self) -> ServiceResult<()> {
         // Stop the service first
         self.stop().ok();
 
-        // Remove service configuration
+        // macOS: Unregister SMAppService agent if registered
+        #[cfg(target_os = "macos")]
+        if smappservice_is_registered() {
+            smappservice_unregister(&self.config.binary_path)?;
+        }
+
+        // Remove legacy service configuration (plist / systemd / windows)
         self.remove_service_config()?;
 
         // Determine what binary the plist was pointing at (if readable)
@@ -265,9 +317,10 @@ impl ServiceManager {
     /// Upgrade the daemon binary by stopping, replacing, and restarting.
     ///
     /// This is used when the notebook app detects a version mismatch between
-    /// the running daemon and the bundled version. On macOS with in-bundle
-    /// binaries, the binary is already updated (the app was replaced), so this
-    /// just regenerates the plist and restarts launchd.
+    /// the running daemon and the bundled version. On macOS 13+ with in-bundle
+    /// binaries, uses SMAppService to re-register (unregister + register),
+    /// which picks up the new binary. On older macOS or non-bundle binaries,
+    /// falls back to the legacy plist + launchctl approach.
     pub fn upgrade(&mut self, source_binary: &PathBuf) -> ServiceResult<()> {
         if !source_binary.exists() {
             return Err(ServiceError::BinaryNotFound(source_binary.clone()));
@@ -277,6 +330,21 @@ impl ServiceManager {
 
         // Stop the running daemon (ignore errors - may not be running)
         self.stop().ok();
+
+        // macOS 13+: Use SMAppService for in-bundle binaries
+        #[cfg(target_os = "macos")]
+        if should_use_smappservice(source_binary) {
+            self.config.binary_path = source_binary.clone();
+            info!("[service] Upgrading via SMAppService (in-bundle binary)");
+
+            // Clean up legacy plist from older installs during migration
+            self.cleanup_legacy_install();
+            Self::cleanup_legacy_binary();
+
+            smappservice_register(source_binary, &self.config.log_path)?;
+            info!("[service] Upgrade via SMAppService completed");
+            return Ok(());
+        }
 
         if Self::is_in_app_bundle(source_binary) {
             // Source is inside an app bundle — point the plist directly at it.
@@ -309,6 +377,26 @@ impl ServiceManager {
     /// Check whether a path is inside a macOS `.app` bundle.
     fn is_in_app_bundle(path: &Path) -> bool {
         path.to_string_lossy().contains(".app/Contents/MacOS/")
+    }
+
+    /// Remove the legacy plist from `~/Library/LaunchAgents/` and stop the
+    /// launchd service.
+    ///
+    /// Best-effort: called during migration to SMAppService to clean up the
+    /// old registration. Logs on failure but never errors.
+    #[cfg(target_os = "macos")]
+    fn cleanup_legacy_install(&self) {
+        // Stop the legacy launchd service if loaded
+        runt_workspace::launchd_stop().ok();
+
+        // Remove the legacy plist
+        let path = plist_path();
+        if path.exists() {
+            match std::fs::remove_file(&path) {
+                Ok(()) => info!("[service] Removed legacy plist at {:?}", path),
+                Err(e) => info!("[service] Could not remove legacy plist {:?}: {}", path, e),
+            }
+        }
     }
 
     /// Remove the legacy standalone binary from `~/.local/share/runt/bin/`.
@@ -385,10 +473,13 @@ impl ServiceManager {
     }
 
     /// Check if the service is installed.
+    ///
+    /// On macOS, checks both SMAppService registration (macOS 13+) and the
+    /// legacy plist in `~/Library/LaunchAgents/`.
     pub fn is_installed(&self) -> bool {
         #[cfg(target_os = "macos")]
         {
-            plist_path().exists()
+            smappservice_is_registered() || plist_path().exists()
         }
 
         #[cfg(target_os = "linux")]
@@ -546,6 +637,20 @@ impl ServiceManager {
 
     #[cfg(target_os = "macos")]
     fn start_macos(&self) -> ServiceResult<()> {
+        // SMAppService agents are started automatically by the system on
+        // register(). If already registered, re-registering is a no-op.
+        if smappservice_is_registered() {
+            info!("[service] SMAppService agent is registered (auto-started by system)");
+            return Ok(());
+        }
+
+        // If we should use SMAppService but aren't registered yet, register now
+        if should_use_smappservice(&self.config.binary_path) {
+            smappservice_register(&self.config.binary_path, &self.config.log_path)?;
+            return Ok(());
+        }
+
+        // Legacy launchctl path
         let bootstrapped =
             runt_workspace::launchd_ensure_loaded().map_err(ServiceError::StartFailed)?;
 
@@ -559,6 +664,15 @@ impl ServiceManager {
 
     #[cfg(target_os = "macos")]
     fn stop_macos(&self) -> ServiceResult<()> {
+        // For SMAppService agents, unregister stops the agent. We then
+        // re-register to keep it installed (stop != uninstall).
+        if smappservice_is_registered() {
+            smappservice_unregister(&self.config.binary_path)?;
+            info!("[service] Stopped SMAppService agent");
+            return Ok(());
+        }
+
+        // Legacy launchctl path
         runt_workspace::launchd_stop().map_err(ServiceError::StopFailed)?;
 
         info!("[service] Stopped launchd service");
@@ -711,8 +825,247 @@ Set WshShell = Nothing
     }
 }
 
+// ============================================================================
+// macOS SMAppService support (macOS 13+ Ventura)
+// ============================================================================
+
+/// Check whether the current macOS version is 13.0 (Ventura) or later.
+///
+/// SMAppService was introduced in macOS 13. On older versions we fall back to
+/// the legacy `launchctl` plist approach.
+#[cfg(target_os = "macos")]
+fn is_macos_13_or_later() -> bool {
+    let output = std::process::Command::new("sw_vers")
+        .args(["-productVersion"])
+        .output()
+        .ok();
+
+    let Some(output) = output else {
+        return false;
+    };
+    if !output.status.success() {
+        return false;
+    }
+
+    let version_str = String::from_utf8_lossy(&output.stdout);
+    let version_str = version_str.trim();
+
+    // Parse major version from "13.0" or "14.2.1" etc.
+    version_str
+        .split('.')
+        .next()
+        .and_then(|major| major.parse::<u32>().ok())
+        .map(|major| major >= 13)
+        .unwrap_or(false)
+}
+
+/// Whether to use SMAppService for a given binary path.
+///
+/// Returns true only when:
+/// 1. Running on macOS 13+
+/// 2. The binary is inside a `.app` bundle
+///
+/// CLI installs and older macOS versions always use the legacy path.
+#[cfg(target_os = "macos")]
+fn should_use_smappservice(binary: &Path) -> bool {
+    ServiceManager::is_in_app_bundle(binary) && is_macos_13_or_later()
+}
+
+/// Resolve the app bundle root from a binary path inside `Contents/MacOS/`.
+///
+/// Given `/Applications/nteract.app/Contents/MacOS/runtimed`, returns
+/// `/Applications/nteract.app`.
+#[cfg(target_os = "macos")]
+fn app_bundle_root(binary: &Path) -> Option<PathBuf> {
+    let s = binary.to_string_lossy();
+    let idx = s.find(".app/Contents/MacOS/")?;
+    // Include the ".app" in the path
+    let end = idx + ".app".len();
+    Some(PathBuf::from(&s[..end]))
+}
+
+/// Get the plist filename for SMAppService registration.
+///
+/// This is just the filename (e.g. `io.nteract.runtimed.plist`), not a full
+/// path. SMAppService looks for this file inside
+/// `Contents/Library/LaunchAgents/` of the app bundle.
+#[cfg(target_os = "macos")]
+fn smappservice_plist_filename() -> String {
+    format!("{}.plist", daemon_launchd_label())
+}
+
+/// Generate the plist content for SMAppService registration.
+///
+/// Unlike the legacy plist, this uses `BundleProgram` (a bundle-relative path)
+/// instead of `ProgramArguments` with an absolute path. `BundleProgram` is
+/// required by SMAppService and specifies the executable relative to the
+/// bundle root (e.g. `Contents/MacOS/runtimed`).
+#[cfg(target_os = "macos")]
+fn generate_smappservice_plist(
+    bundle_program: &str,
+    log_path: &Path,
+) -> Result<String, ServiceError> {
+    let home = dirs::home_dir().ok_or_else(|| {
+        ServiceError::InstallFailed("Cannot determine home directory for service install".into())
+    })?;
+    let home_str = home.to_string_lossy();
+    let user = std::env::var("USER").unwrap_or_else(|_| "unknown".into());
+
+    let log_level = match runt_workspace::build_channel() {
+        runt_workspace::BuildChannel::Nightly => {
+            "info,notebook_sync=debug,runtimed::notebook_sync_server=debug"
+        }
+        runt_workspace::BuildChannel::Stable => "warn",
+    };
+
+    Ok(format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>{label}</string>
+    <key>BundleProgram</key>
+    <string>{bundle_program}</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>{bundle_program}</string>
+        <string>--log-level</string>
+        <string>{log_level}</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <dict>
+        <key>Crashed</key>
+        <true/>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>{log}</string>
+    <key>StandardErrorPath</key>
+    <string>{log}</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>{home}</string>
+        <key>USER</key>
+        <string>{user}</string>
+        <key>PATH</key>
+        <string>{home}/.local/bin:/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin</string>
+    </dict>
+</dict>
+</plist>
+"#,
+        label = daemon_launchd_label(),
+        bundle_program = bundle_program,
+        log_level = log_level,
+        log = log_path.display(),
+        home = home_str,
+        user = user,
+    ))
+}
+
+/// Write the SMAppService plist into the app bundle and register it.
+///
+/// The plist is placed at `<bundle>/Contents/Library/LaunchAgents/<label>.plist`.
+/// Then `SMAppService.agent(plistName:).register()` is called to register the
+/// agent with the system.
+#[cfg(target_os = "macos")]
+fn smappservice_register(binary: &Path, log_path: &Path) -> ServiceResult<()> {
+    use smappservice_rs::{AppService, ServiceType};
+
+    let bundle_root = app_bundle_root(binary)
+        .ok_or_else(|| ServiceError::InstallFailed("Cannot determine app bundle root".into()))?;
+
+    // Compute bundle-relative path: e.g. "Contents/MacOS/runtimed"
+    let binary_str = binary.to_string_lossy();
+    let bundle_root_str = bundle_root.to_string_lossy();
+    let bundle_program = binary_str
+        .strip_prefix(&*bundle_root_str)
+        .and_then(|s| s.strip_prefix('/'))
+        .ok_or_else(|| {
+            ServiceError::InstallFailed(format!(
+                "Binary {:?} is not inside bundle {:?}",
+                binary, bundle_root
+            ))
+        })?;
+
+    let plist_content = generate_smappservice_plist(bundle_program, log_path)?;
+
+    // Write plist into the bundle at Contents/Library/LaunchAgents/
+    let launch_agents_dir = bundle_root.join("Contents/Library/LaunchAgents");
+    std::fs::create_dir_all(&launch_agents_dir)?;
+
+    let plist_filename = smappservice_plist_filename();
+    let plist_path = launch_agents_dir.join(&plist_filename);
+    std::fs::write(&plist_path, plist_content)?;
+    info!("[service] Wrote SMAppService plist to {:?}", plist_path);
+
+    // Register via SMAppService
+    let service = AppService::new(ServiceType::Agent {
+        plist_name: &plist_filename,
+    });
+
+    // Unregister first to handle upgrades (plist content may have changed)
+    let _ = service.unregister();
+
+    service
+        .register()
+        .map_err(|e| ServiceError::InstallFailed(format!("SMAppService register failed: {e}")))?;
+
+    info!("[service] Registered agent via SMAppService");
+    Ok(())
+}
+
+/// Unregister the SMAppService agent.
+#[cfg(target_os = "macos")]
+fn smappservice_unregister(binary: &Path) -> ServiceResult<()> {
+    use smappservice_rs::{AppService, ServiceType};
+
+    let plist_filename = smappservice_plist_filename();
+    let service = AppService::new(ServiceType::Agent {
+        plist_name: &plist_filename,
+    });
+
+    service
+        .unregister()
+        .map_err(|e| ServiceError::StopFailed(format!("SMAppService unregister failed: {e}")))?;
+
+    info!("[service] Unregistered agent via SMAppService");
+
+    // Clean up the plist from the bundle
+    if let Some(bundle_root) = app_bundle_root(binary) {
+        let plist_path = bundle_root
+            .join("Contents/Library/LaunchAgents")
+            .join(&plist_filename);
+        if plist_path.exists() {
+            std::fs::remove_file(&plist_path)?;
+            info!("[service] Removed SMAppService plist {:?}", plist_path);
+        }
+    }
+
+    Ok(())
+}
+
+/// Check if an SMAppService agent is registered.
+#[cfg(target_os = "macos")]
+fn smappservice_is_registered() -> bool {
+    use smappservice_rs::{AppService, ServiceStatus, ServiceType};
+
+    let plist_filename = smappservice_plist_filename();
+    let service = AppService::new(ServiceType::Agent {
+        plist_name: &plist_filename,
+    });
+
+    matches!(service.status(), ServiceStatus::Enabled)
+}
+
 // Platform-specific paths
 
+/// Path to the legacy plist in `~/Library/LaunchAgents/`.
+///
+/// Used on macOS <13 and for non-bundle installs. On macOS 13+, the plist
+/// lives inside the app bundle instead (see `smappservice_register`).
 #[cfg(target_os = "macos")]
 fn plist_path() -> PathBuf {
     dirs::home_dir()
@@ -750,9 +1103,23 @@ fn windows_startup_path() -> PathBuf {
 
 /// Get the path to the service configuration file.
 /// Used by doctor command for diagnostics.
+///
+/// On macOS, returns the in-bundle plist path if SMAppService is active,
+/// otherwise the legacy `~/Library/LaunchAgents/` path.
 pub fn service_config_path() -> PathBuf {
     #[cfg(target_os = "macos")]
     {
+        // If the current binary is in an app bundle on macOS 13+, return
+        // the in-bundle plist path
+        if let Ok(exe) = std::env::current_exe() {
+            if should_use_smappservice(&exe) {
+                if let Some(bundle_root) = app_bundle_root(&exe) {
+                    return bundle_root
+                        .join("Contents/Library/LaunchAgents")
+                        .join(smappservice_plist_filename());
+                }
+            }
+        }
         plist_path()
     }
     #[cfg(target_os = "linux")]

--- a/crates/runtimed-client/src/service.rs
+++ b/crates/runtimed-client/src/service.rs
@@ -174,39 +174,7 @@ impl ServiceManager {
             return Err(ServiceError::BinaryNotFound(source_binary.clone()));
         }
 
-        // macOS 13+: Use SMAppService for in-bundle binaries (preferred).
-        // The plist must already be in the signed bundle at build time.
-        // On success, remove the legacy plist to avoid dual-registration
-        // (which would let the daemon start even when Login Items is disabled).
-        #[cfg(target_os = "macos")]
-        if should_use_smappservice(source_binary) {
-            self.config.binary_path = source_binary.clone();
-            info!(
-                "[service] Using SMAppService for in-bundle binary at {:?}",
-                self.config.binary_path
-            );
-            Self::cleanup_legacy_binary();
-
-            match smappservice_register() {
-                Ok(()) => {
-                    // Remove legacy plist to avoid dual-registration
-                    self.remove_legacy_plist();
-                    info!("[service] Service installed via SMAppService");
-                    return Ok(());
-                }
-                Err(e) => {
-                    // SMAppService failed (e.g. unsigned dev build) — fall
-                    // through to legacy plist registration
-                    info!(
-                        "[service] SMAppService failed ({}), falling back to legacy plist",
-                        e
-                    );
-                }
-            }
-        }
-
         if Self::is_in_app_bundle(source_binary) {
-            // Source is inside an app bundle — point the plist directly at it.
             self.config.binary_path = source_binary.clone();
             info!(
                 "[service] Using in-bundle binary at {:?}",
@@ -214,15 +182,30 @@ impl ServiceManager {
             );
             Self::cleanup_legacy_binary();
         } else {
-            // Custom or non-bundle path — copy the binary to the install location
             if let Some(parent) = self.config.binary_path.parent() {
                 std::fs::create_dir_all(parent)?;
             }
             self.atomic_copy_binary(source_binary)?;
         }
 
-        // Legacy plist registration
+        // Always write the legacy plist — launchctl start/stop and the CLI
+        // `runt daemon doctor` depend on it. This is the primary registration.
         self.create_service_config()?;
+
+        // macOS 13+: Additionally register via SMAppService for Login Items
+        // visibility. Best-effort — if the bundle is unsigned, read-only,
+        // or the plist isn't in the bundle yet, we skip it silently.
+        // The legacy plist above is always the fallback.
+        #[cfg(target_os = "macos")]
+        if should_use_smappservice(source_binary) {
+            match smappservice_register() {
+                Ok(()) => info!("[service] Also registered via SMAppService (Login Items)"),
+                Err(e) => info!(
+                    "[service] SMAppService registration skipped ({}), legacy plist is active",
+                    e
+                ),
+            }
+        }
 
         info!("[service] Service installed successfully");
         Ok(())
@@ -281,16 +264,23 @@ impl ServiceManager {
 
     /// Uninstall the daemon service.
     ///
-    /// On macOS 13+, unregisters via SMAppService if registered. Also cleans
-    /// up any legacy plist in `~/Library/LaunchAgents/` for migration.
+    /// On macOS 13+, if called from the app bundle, also unregisters the
+    /// SMAppService agent. If called from the CLI, only the legacy plist
+    /// is removed (the SMAppService registration is cleaned up when the
+    /// app is deleted).
     pub fn uninstall(&self) -> ServiceResult<()> {
         // Stop the service first
         self.stop().ok();
 
-        // macOS: Unregister SMAppService agent if registered
+        // macOS 13+: Unregister SMAppService agent if we're in the app bundle.
+        // SMAppService resolves against the calling process's bundle, so this
+        // only works when called from the notebook app, not from `runt` CLI.
         #[cfg(target_os = "macos")]
-        if smappservice_is_registered() {
-            smappservice_unregister()?;
+        if should_use_smappservice(&self.config.binary_path) {
+            match smappservice_unregister() {
+                Ok(()) => {}
+                Err(e) => info!("[service] SMAppService unregister skipped ({})", e),
+            }
         }
 
         // Remove legacy service configuration (plist / systemd / windows)
@@ -342,30 +332,6 @@ impl ServiceManager {
         // Stop the running daemon (ignore errors - may not be running)
         self.stop().ok();
 
-        // macOS 13+: Use SMAppService for in-bundle binaries
-        #[cfg(target_os = "macos")]
-        if should_use_smappservice(source_binary) {
-            self.config.binary_path = source_binary.clone();
-            Self::cleanup_legacy_binary();
-
-            match smappservice_register() {
-                Ok(()) => {
-                    self.remove_legacy_plist();
-                    // Kickstart the agent (SMAppService doesn't auto-start
-                    // on re-register if it was stopped)
-                    runt_workspace::launchd_kickstart().map_err(ServiceError::StartFailed)?;
-                    info!("[service] Upgrade via SMAppService completed");
-                    return Ok(());
-                }
-                Err(e) => {
-                    info!(
-                        "[service] SMAppService failed ({}), falling back to legacy",
-                        e
-                    );
-                }
-            }
-        }
-
         if Self::is_in_app_bundle(source_binary) {
             self.config.binary_path = source_binary.clone();
             info!("[service] In-bundle binary, skipping copy");
@@ -374,9 +340,18 @@ impl ServiceManager {
             self.atomic_copy_binary(source_binary)?;
         }
 
-        // Legacy plist registration
+        // Always update the legacy plist
         self.create_service_config()?;
         info!("[service] Updated service config");
+
+        // macOS 13+: Re-register via SMAppService (best-effort)
+        #[cfg(target_os = "macos")]
+        if should_use_smappservice(source_binary) {
+            match smappservice_register() {
+                Ok(()) => info!("[service] Re-registered via SMAppService"),
+                Err(e) => info!("[service] SMAppService re-registration skipped ({})", e),
+            }
+        }
 
         // Use launchd_start() which always does bootout+bootstrap
         #[cfg(target_os = "macos")]
@@ -392,25 +367,6 @@ impl ServiceManager {
     /// Check whether a path is inside a macOS `.app` bundle.
     fn is_in_app_bundle(path: &Path) -> bool {
         path.to_string_lossy().contains(".app/Contents/MacOS/")
-    }
-
-    /// Remove the legacy plist from `~/Library/LaunchAgents/`.
-    ///
-    /// Best-effort: called after successful SMAppService registration to avoid
-    /// dual-registration. If both the legacy plist and SMAppService are active,
-    /// disabling Login Items in System Settings won't actually stop auto-start.
-    #[cfg(target_os = "macos")]
-    fn remove_legacy_plist(&self) {
-        // Stop the legacy launchd registration if loaded
-        runt_workspace::launchd_stop().ok();
-
-        let path = plist_path();
-        if path.exists() {
-            match std::fs::remove_file(&path) {
-                Ok(()) => info!("[service] Removed legacy plist at {:?}", path),
-                Err(e) => info!("[service] Could not remove legacy plist {:?}: {}", path, e),
-            }
-        }
     }
 
     /// Remove the legacy standalone binary from `~/.local/share/runt/bin/`.
@@ -488,12 +444,13 @@ impl ServiceManager {
 
     /// Check if the service is installed.
     ///
-    /// On macOS, checks both SMAppService registration (macOS 13+) and the
-    /// legacy plist in `~/Library/LaunchAgents/`.
+    /// On macOS, checks the legacy plist in `~/Library/LaunchAgents/`.
+    /// The legacy plist is always written (even when SMAppService is also used),
+    /// so this is reliable from any calling context.
     pub fn is_installed(&self) -> bool {
         #[cfg(target_os = "macos")]
         {
-            smappservice_is_registered() || plist_path().exists()
+            plist_path().exists()
         }
 
         #[cfg(target_os = "linux")]
@@ -651,19 +608,9 @@ impl ServiceManager {
 
     #[cfg(target_os = "macos")]
     fn start_macos(&self) -> ServiceResult<()> {
-        // If SMAppService is registered, use kickstart (works without a
-        // legacy plist in ~/Library/LaunchAgents/).
-        if smappservice_is_registered() {
-            if runt_workspace::launchd_is_loaded().unwrap_or(false) {
-                info!("[service] SMAppService agent already loaded");
-                return Ok(());
-            }
-            runt_workspace::launchd_kickstart().map_err(ServiceError::StartFailed)?;
-            info!("[service] Started SMAppService agent via kickstart");
-            return Ok(());
-        }
-
-        // Legacy path: bootstrap from ~/Library/LaunchAgents/ plist
+        // The legacy plist is always available (even when SMAppService is
+        // also registered), so use the standard ensure_loaded path which
+        // works from both the app and the CLI.
         let bootstrapped =
             runt_workspace::launchd_ensure_loaded().map_err(ServiceError::StartFailed)?;
 
@@ -973,25 +920,12 @@ fn smappservice_unregister() -> ServiceResult<()> {
     Ok(())
 }
 
-/// Check if an SMAppService agent is registered.
-#[cfg(target_os = "macos")]
-fn smappservice_is_registered() -> bool {
-    use smappservice_rs::{AppService, ServiceStatus, ServiceType};
-
-    let plist_filename = smappservice_plist_filename();
-    let service = AppService::new(ServiceType::Agent {
-        plist_name: &plist_filename,
-    });
-
-    matches!(service.status(), ServiceStatus::Enabled)
-}
-
 // Platform-specific paths
 
-/// Path to the legacy plist in `~/Library/LaunchAgents/`.
+/// Path to the plist in `~/Library/LaunchAgents/`.
 ///
-/// Used on macOS <13 and for non-bundle installs. On macOS 13+, the plist
-/// lives inside the app bundle instead (see `smappservice_register`).
+/// Always written by install/upgrade. On macOS 13+ with SMAppService,
+/// this plist coexists with the in-bundle plist (additive registration).
 #[cfg(target_os = "macos")]
 fn plist_path() -> PathBuf {
     dirs::home_dir()

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -1070,12 +1070,18 @@ fn build_with_bundle(bundle: &str) {
     // Build runtimed daemon binary for bundling (release mode for distribution)
     build_runtimed_daemon(true);
 
+    // Generate the SMAppService launch agent plist for inclusion in the bundle.
+    // This must happen before `cargo tauri build` so the plist is signed with
+    // the app bundle (modifying Contents/ after signing invalidates the signature).
+    generate_launch_agent_plist();
+
     // Build frontend
     println!("Building frontend...");
     run_frontend_build(false);
 
     // Build Tauri app
     println!("Building Tauri app ({bundle} bundle)...");
+    let tauri_config = launch_agent_tauri_config();
     run_cmd(
         "cargo",
         &[
@@ -1084,11 +1090,112 @@ fn build_with_bundle(bundle: &str) {
             "--bundles",
             bundle,
             "--config",
-            r#"{"build":{"beforeBuildCommand":""}}"#,
+            &tauri_config,
         ],
     );
 
     println!("Build complete!");
+}
+
+/// Build a Tauri `--config` override JSON that:
+/// 1. Disables `beforeBuildCommand` (we already built the frontend)
+/// 2. Includes the launch agent plist in the macOS bundle
+///
+/// The plist is included at `Contents/Library/LaunchAgents/<label>.plist`
+/// so SMAppService can find it. The files map is channel-specific since
+/// the label differs between stable and nightly.
+fn launch_agent_tauri_config() -> String {
+    let label = runt_workspace::daemon_launchd_label();
+    let plist_filename = format!("{label}.plist");
+    let bundle_dest = format!("Library/LaunchAgents/{plist_filename}");
+    let source_path = format!("./launch-agents/{plist_filename}");
+
+    // Build the config JSON with serde_json to avoid escaping issues
+    let config = serde_json::json!({
+        "build": {
+            "beforeBuildCommand": ""
+        },
+        "bundle": {
+            "macOS": {
+                "files": {
+                    bundle_dest: source_path
+                }
+            }
+        }
+    });
+
+    config.to_string()
+}
+
+/// Generate the launch agent plist for SMAppService registration.
+///
+/// On macOS 13+, SMAppService looks for the plist inside the app bundle at
+/// `Contents/Library/LaunchAgents/<label>.plist`. This function generates the
+/// plist with channel-specific values and writes it to `crates/notebook/launch-agents/`
+/// where `tauri.conf.json` picks it up via `bundle.macOS.files`.
+///
+/// The plist uses `BundleProgram` (bundle-relative path) instead of absolute
+/// `ProgramArguments`, as required by SMAppService.
+#[allow(clippy::expect_used)] // xtask is a dev tool; panics with context are fine
+fn generate_launch_agent_plist() {
+    let label = runt_workspace::daemon_launchd_label();
+    let daemon_binary = runt_workspace::daemon_binary_basename();
+
+    let log_level = match runt_workspace::build_channel() {
+        runt_workspace::BuildChannel::Nightly => {
+            "info,notebook_sync=debug,runtimed::notebook_sync_server=debug"
+        }
+        runt_workspace::BuildChannel::Stable => "warn",
+    };
+
+    // BundleProgram is relative to the .app bundle root
+    let bundle_program = format!("Contents/MacOS/{daemon_binary}");
+
+    // Note: StandardOutPath/StandardErrorPath are omitted because they
+    // require absolute paths and we can't know HOME at build time. The
+    // daemon manages its own log file internally and falls back to /tmp
+    // if HOME is unavailable.
+
+    let plist_content = format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>{label}</string>
+    <key>BundleProgram</key>
+    <string>{bundle_program}</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>{bundle_program}</string>
+        <string>--log-level</string>
+        <string>{log_level}</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <dict>
+        <key>Crashed</key>
+        <true/>
+    </dict>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin</string>
+    </dict>
+</dict>
+</plist>
+"#,
+    );
+
+    let output_dir = Path::new("crates/notebook/launch-agents");
+    fs::create_dir_all(output_dir).expect("Failed to create launch-agents directory");
+
+    let plist_filename = format!("{label}.plist");
+    let output_path = output_dir.join(&plist_filename);
+    fs::write(&output_path, plist_content).expect("Failed to write launch agent plist");
+
+    println!("Generated launch agent plist: {}", output_path.display());
 }
 
 /// Build runtimed and install it into the running launchd/systemd service.

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -1151,10 +1151,16 @@ fn generate_launch_agent_plist() {
     // BundleProgram is relative to the .app bundle root
     let bundle_program = format!("Contents/MacOS/{daemon_binary}");
 
-    // Note: StandardOutPath/StandardErrorPath are omitted because they
-    // require absolute paths and we can't know HOME at build time. The
-    // daemon manages its own log file internally and falls back to /tmp
-    // if HOME is unavailable.
+    // Note: HOME, USER, StandardOutPath, and StandardErrorPath are omitted
+    // because they require the user's home directory which isn't known at
+    // build time. This plist is only used on macOS 13+ where launchd's
+    // user-domain agent loading reliably sets HOME and USER. The daemon
+    // also manages its own log file internally and falls back to /tmp.
+    //
+    // This plist is additive — the legacy ~/Library/LaunchAgents/ plist
+    // (which includes HOME, USER, and ~/.local/bin in PATH) is always
+    // also written at install time and is the primary one used by
+    // launchctl start/stop.
 
     let plist_content = format!(
         r#"<?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
## Summary

- On macOS 13+ (Ventura), when installing from an app bundle, additionally register the daemon via `SMAppService` so it appears in **System Settings > Login Items** and is automatically cleaned up when the app is deleted
- Add build-time plist generation (`cargo xtask build-app`) that creates the SMAppService plist in `Contents/Library/LaunchAgents/` inside the signed app bundle
- The legacy `~/Library/LaunchAgents/` plist is always written as the primary registration mechanism -- SMAppService is purely additive
- Add `launchd_kickstart()` to `runt-workspace` for restarting SMAppService-registered agents
- `smappservice-rs` crate provides the Rust-to-ObjC bridge for `SMAppService` APIs

## Architecture

**SMAppService is additive, not replacing.** The legacy plist approach is preserved in full:

| Flow | Legacy plist | SMAppService |
|------|-------------|-------------|
| `install()` | Always written | Best-effort registration |
| `upgrade()` | Always updated | Best-effort re-registration |
| `start()` | `launchctl bootstrap` | N/A (launchctl works for both) |
| `stop()` | `launchctl bootout` | N/A (launchctl works for both) |
| `uninstall()` | Always removed | Unregistered if called from app bundle |
| `is_installed()` | Checks legacy plist | N/A |

**Why additive?** SMAppService APIs resolve against the *calling process's* main bundle. The `runt` CLI is a different binary and can't call SMAppService meaningfully. Keeping the legacy plist ensures all CLI-based workflows (`runt daemon start/stop/doctor`) continue working unchanged.

**Build-time plist:** Generated by `cargo xtask build-app` and included in the Tauri bundle via `--config` override before code signing. Uses `BundleProgram` (bundle-relative path) as required by SMAppService.

**Same-bundle safety:** `should_use_smappservice()` verifies that `current_exe()` is in the same `.app` bundle as the target binary, preventing the CLI from accidentally calling SMAppService against the wrong bundle.

## Test plan

- [x] `cargo check -p runtimed-client -p runtimed -p notebook -p xtask` compiles clean
- [x] `cargo test -p runtimed-client` passes (91 tests, including new SMAppService tests)
- [x] `cargo xtask lint` passes
- [ ] Manual: Install from app bundle on macOS 13+ and verify agent appears in System Settings > Login Items
- [ ] Manual: Verify `runt daemon start/stop/status/doctor` work from CLI after SMAppService install
- [ ] Manual: Verify CLI `runtimed install` (non-bundle) still uses legacy path only
- [ ] Manual: Upgrade from legacy-only install and verify SMAppService registration is added
- [ ] Manual: Uninstall from CLI and verify warning about Login Item persistence