### PR TITLE
refactor(daemon): rename Agent → RuntimeAgent

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -147,7 +147,7 @@ Settings (theme, default_runtime, etc.) sync via a **separate Automerge document
 Widget state lives in **RuntimeStateDoc** (`doc.comms/` Automerge map):
 - **Daemon:** Writes comm state from kernel IOPub (`comm_open`/`comm_msg(update)`/`comm_close`). State updates coalesce in a 16ms batch writer.
 - **Frontend:** `WidgetStore` in `widget-store.ts` -- per-model subscriptions, IPY_MODEL_ reference resolution. Populated by a CRDT watcher that diffs `runtimeState.comms` and synthesizes Jupyter comm messages.
-- **Frontend → Kernel:** State updates write to RuntimeStateDoc via CRDT writer. The agent diffs comm state on each sync and forwards deltas to the kernel.
+- **Frontend → Kernel:** State updates write to RuntimeStateDoc via CRDT writer. The runtime agent diffs comm state on each sync and forwards deltas to the kernel.
 
 New clients receive widget state via normal RuntimeStateDoc CRDT sync (frame `0x05`). Custom widget messages (buttons, etc.) still use `NotebookBroadcast::Comm` as ephemeral events.
 

--- a/.claude/rules/widget-development.md
+++ b/.claude/rules/widget-development.md
@@ -20,7 +20,7 @@ Widget state lives in the **RuntimeStateDoc** CRDT (`doc.comms/` Automerge map).
 
 - **Daemon:** Writes comm state on `comm_open`/`comm_msg(update)`/`comm_close` from kernel IOPub. State updates go through a 16ms coalescing writer to avoid overwhelming CRDT sync.
 - **Frontend:** `WidgetStore` in `widget-store.ts` -- per-model subscriptions, IPY_MODEL_ reference resolution, custom message buffering. Populated by a CRDT watcher in `useDaemonKernel.ts` that diffs `runtimeState.comms` and synthesizes Jupyter comm messages.
-- **Frontend → Kernel:** Built-in widget state updates write to RuntimeStateDoc via `getCrdtCommWriter()`. The agent diffs comm state on each sync and forwards deltas to the kernel.
+- **Frontend → Kernel:** Built-in widget state updates write to RuntimeStateDoc via `getCrdtCommWriter()`. The runtime agent diffs comm state on each sync and forwards deltas to the kernel.
 
 New clients receive widget state via normal RuntimeStateDoc CRDT sync (frame `0x05`). Custom widget messages (button clicks, etc.) still use `NotebookBroadcast::Comm` since they're ephemeral events, not persistent state.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -293,7 +293,7 @@ The supervisor watches source directories and auto-restarts the child on changes
 
 | Crate | Purpose |
 |-------|---------|
-| `runtimed` | Central daemon — env pools, notebook sync, agent subprocess coordination |
+| `runtimed` | Central daemon — env pools, notebook sync, runtime agent subprocess coordination |
 | `runtimed-client` | Shared client library — output resolution, daemon paths, pool client |
 | `runtimed-py` | Python bindings for daemon (PyO3/maturin) |
 | `runtimed-wasm` | WASM bindings for notebook doc (Automerge, used by frontend) |
@@ -466,10 +466,10 @@ The rule: `image/*` → binary (EXCEPT `image/svg+xml` — that's text). `audio/
 | Cell source | Frontend WASM | Local-first, character-level merge |
 | Cell position, type, metadata | Frontend WASM | User-initiated via UI |
 | Notebook metadata (deps, runtime) | Frontend WASM | User edits deps, runtime picker |
-| Cell outputs (manifest hashes) | Agent subprocess | Kernel IOPub → blob store → hash in RuntimeStateDoc |
-| Execution count | Agent subprocess | Set on `execute_input` from kernel |
-| Execution queue (source, seq, status) | Coordinator writes `queued`, agent transitions to `running`/`done` | CRDT-driven execution — no RPC for cell execution |
-| RuntimeStateDoc (kernel, queue, executions, env, trust) | Agent + Coordinator | Separate Automerge doc, frame type `0x05` |
+| Cell outputs (manifest hashes) | Runtime agent subprocess | Kernel IOPub → blob store → hash in RuntimeStateDoc |
+| Execution count | Runtime agent subprocess | Set on `execute_input` from kernel |
+| Execution queue (source, seq, status) | Coordinator writes `queued`, runtime agent transitions to `running`/`done` | CRDT-driven execution — no RPC for cell execution |
+| RuntimeStateDoc (kernel, queue, executions, env, trust) | Runtime agent + Coordinator | Separate Automerge doc, frame type `0x05` |
 
 **Never write to the CRDT in response to a daemon broadcast.** The daemon already wrote. Writing again creates redundant sync traffic and incorrectly marks the notebook as dirty.
 

--- a/contributing/architecture.md
+++ b/contributing/architecture.md
@@ -149,7 +149,7 @@ Key files:
 
 ### 6. Process-Isolated Kernel Execution
 
-Every kernel runs in a separate **agent subprocess** (`runtimed agent`) that connects back to the daemon's Unix socket as an Automerge peer. The daemon coordinator handles environment resolution and spawns the agent; the agent owns the kernel process and writes outputs to RuntimeStateDoc.
+Every kernel runs in a separate **runtime agent subprocess** (`runtimed runtime-agent`) that connects back to the daemon's Unix socket as an Automerge peer. The daemon coordinator handles environment resolution and spawns the runtime agent; the runtime agent owns the kernel process and writes outputs to RuntimeStateDoc.
 
 ```
 ┌────────────────────────────────────────────────────┐
@@ -162,16 +162,16 @@ Every kernel runs in a separate **agent subprocess** (`runtimed agent`) that con
            │ Unix socket (standard peer protocol)
            ▼
 ┌────────────────────────────────────────────────────┐
-│ Agent subprocess (runtimed agent)                  │
+│ Runtime agent subprocess (runtimed runtime-agent)  │
 │  Connects as Automerge peer, watches CRDT queue    │
 │  Owns kernel process (ZMQ), IOPub, outputs         │
 │  Writes results back via RuntimeStateDoc sync      │
 └────────────────────────────────────────────────────┘
 ```
 
-**CRDT-driven execution:** The coordinator writes execution entries (with source code and a monotonic sequence number) to RuntimeStateDoc. The agent discovers new entries via Automerge sync, sorts by sequence number, and executes. No RPC needed for execution — it's pure state sync.
+**CRDT-driven execution:** The coordinator writes execution entries (with source code and a monotonic sequence number) to RuntimeStateDoc. The runtime agent discovers new entries via Automerge sync, sorts by sequence number, and executes. No RPC needed for execution — it's pure state sync.
 
-**RPC for lifecycle:** `LaunchKernel`, `InterruptExecution`, `ShutdownKernel`, `Complete`, `GetHistory`, and `SendComm` use `AgentRequest`/`AgentResponse` frames (0x01/0x02) over the socket.
+**RPC for lifecycle:** `LaunchKernel`, `InterruptExecution`, `ShutdownKernel`, `Complete`, `GetHistory`, and `SendComm` use `RuntimeAgentRequest`/`RuntimeAgentResponse` frames (0x01/0x02) over the socket.
 
 **Implications:**
 - Clients request kernel launch; they don't spawn kernels directly
@@ -179,11 +179,11 @@ Every kernel runs in a separate **agent subprocess** (`runtimed agent`) that con
 - Tool availability is the daemon's responsibility (bootstrap via rattler if needed)
 - Clients are stateless with respect to runtime resources
 - Each kernel is sandboxable at the OS level (process isolation enables future cgroup/seatbelt)
-- Agents can survive temporary disconnection and sync outputs on reconnect
+- Runtime agents can survive temporary disconnection and sync outputs on reconnect
 
 ### 7. Reuse Existing Protocols
 
-New components should connect using existing protocols rather than inventing special transports. The agent subprocess is a regular Unix socket peer — same handshake, same frame types, same Automerge sync as frontends and MCP servers. Execution state flows through the same RuntimeStateDoc CRDT that frontends already subscribe to.
+New components should connect using existing protocols rather than inventing special transports. The runtime agent subprocess is a regular Unix socket peer — same handshake, same frame types, same Automerge sync as frontends and MCP servers. Execution state flows through the same RuntimeStateDoc CRDT that frontends already subscribe to.
 
 **Implications:**
 - New runtime backends (SSH remote, containerized) connect via the same socket protocol
@@ -261,14 +261,14 @@ The frontend now owns a local Automerge doc via `runtimed-wasm` WASM bindings, m
 
 ## References
 
-- `crates/notebook-protocol/src/protocol.rs` — Canonical wire types: `NotebookRequest`, `NotebookResponse`, `NotebookBroadcast`, `AgentRequest`, `AgentResponse`
+- `crates/notebook-protocol/src/protocol.rs` — Canonical wire types: `NotebookRequest`, `NotebookResponse`, `NotebookBroadcast`, `RuntimeAgentRequest`, `RuntimeAgentResponse`
 - `crates/notebook-doc/src/lib.rs` — `NotebookDoc`: Automerge schema, cell CRUD, output writes, per-cell accessors
 - `crates/notebook-doc/src/diff.rs` — `CellChangeset`: structural diff from Automerge patches
 - `crates/notebook-doc/src/runtime_state.rs` — `RuntimeStateDoc`: kernel status, execution queue/lifecycle, env sync, comms
 - `crates/notebook-sync/src/handle.rs` — `DocHandle`: sync infrastructure, per-cell accessors for Python clients
-- `crates/runtimed/src/notebook_sync_server.rs` — `NotebookRoom`, room lifecycle, agent sync handler, CRDT execution queue
-- `crates/runtimed/src/agent.rs` — Agent subprocess: Unix socket peer, CRDT queue watching, kernel ownership
-- `crates/runtimed/src/agent_handle.rs` — Coordinator-side agent process management (spawn + monitor)
+- `crates/runtimed/src/notebook_sync_server.rs` — `NotebookRoom`, room lifecycle, runtime agent sync handler, CRDT execution queue
+- `crates/runtimed/src/runtime_agent.rs` — Runtime agent subprocess: Unix socket peer, CRDT queue watching, kernel ownership
+- `crates/runtimed/src/runtime_agent_handle.rs` — Coordinator-side runtime agent process management (spawn + monitor)
 - `crates/runtimed/src/kernel_manager.rs` — `RoomKernel`: kernel process lifecycle, execution queue, IOPub output routing
 - `crates/runtimed/src/comm_state.rs` — Widget comm state + Output widget capture routing
 - `crates/runtimed/src/output_store.rs` — Output manifest creation/resolution, `is_binary_mime()`, `ContentRef`

--- a/contributing/protocol.md
+++ b/contributing/protocol.md
@@ -339,7 +339,7 @@ The daemon writes kernel status, execution queue, and environment sync drift. Cl
 
 ### Comms in doc (#761) — Done
 
-Widget state now lives in `doc.comms/` in RuntimeStateDoc. The daemon writes comm entries from kernel IOPub, and new clients receive widget state via normal CRDT sync. `CommSync` broadcast has been removed. The `Comm` broadcast variant is limited to custom messages (ephemeral events like button clicks). Frontend-originated widget state updates write to the CRDT, and the agent diffs comm state on each sync to forward deltas to the kernel.
+Widget state now lives in `doc.comms/` in RuntimeStateDoc. The daemon writes comm entries from kernel IOPub, and new clients receive widget state via normal CRDT sync. `CommSync` broadcast has been removed. The `Comm` broadcast variant is limited to custom messages (ephemeral events like button clicks). Frontend-originated widget state updates write to the CRDT, and the runtime agent diffs comm state on each sync to forward deltas to the kernel.
 
 ## Key Source Files
 

--- a/contributing/runtimed.md
+++ b/contributing/runtimed.md
@@ -47,13 +47,13 @@ The daemon provides a single coordinating entity that prewarms environments in t
               └─────────────────────────────────┘
 ```
 
-### Kernel Execution via Agent Subprocess
+### Kernel Execution via Runtime Agent Subprocess
 
-Every kernel runs in a separate `runtimed agent` subprocess. The daemon coordinator resolves environments and spawns the agent; the agent connects back to the daemon socket as a regular Automerge peer.
+Every kernel runs in a separate `runtimed runtime-agent` subprocess. The daemon coordinator resolves environments and spawns the runtime agent; the runtime agent connects back to the daemon socket as a regular Automerge peer.
 
 ```
-Coordinator                    RuntimeStateDoc              Agent Peer
-───────────                    ───────────────              ──────────
+Coordinator                    RuntimeStateDoc              Runtime Agent Peer
+───────────                    ───────────────              ──────────────────
 ExecuteCell request arrives
   ↓
 writes execution entry     →   executions/{eid}:          → watches queue
@@ -66,7 +66,7 @@ writes execution entry     →   executions/{eid}:          → watches queue
                                  outputs: [hash1, hash2]
 ```
 
-Execution is CRDT-driven — the coordinator writes execution entries (with source + sequence number) to RuntimeStateDoc. The agent discovers new entries via Automerge sync and processes them in order. RPC (`AgentRequest`/`AgentResponse`) is only used for lifecycle operations: `LaunchKernel`, `InterruptExecution`, `ShutdownKernel`, `Complete`, `GetHistory`, `SendComm`.
+Execution is CRDT-driven — the coordinator writes execution entries (with source + sequence number) to RuntimeStateDoc. The runtime agent discovers new entries via Automerge sync and processes them in order. RPC (`RuntimeAgentRequest`/`RuntimeAgentResponse`) is only used for lifecycle operations: `LaunchKernel`, `InterruptExecution`, `ShutdownKernel`, `Complete`, `GetHistory`, `SendComm`.
 
 **Key components:**
 
@@ -86,7 +86,7 @@ Execution is CRDT-driven — the coordinator writes execution entries (with sour
 
 ### Default: Let the notebook start it
 
-The notebook app automatically connects to or starts the daemon on launch. The daemon is required — all kernels run as agent subprocesses connected to the daemon via Unix socket.
+The notebook app automatically connects to or starts the daemon on launch. The daemon is required — all kernels run as runtime agent subprocesses connected to the daemon via Unix socket.
 
 The notebook app calls `ensure_daemon_via_sidecar()` (a private function in `crates/notebook/src/lib.rs`) which takes a `tauri::AppHandle` and a progress callback to start and connect to the daemon.
 
@@ -229,8 +229,8 @@ crates/runtimed/
 │   ├── main.rs                  # Daemon CLI entry point
 │   ├── daemon.rs                # Daemon state, pool management, connection routing
 │   ├── notebook_sync_server.rs  # NotebookRoom, room lifecycle, autosave, re-keying, sync loop
-│   ├── agent.rs                 # Agent subprocess: Unix socket peer, CRDT queue watching, kernel ownership
-│   ├── agent_handle.rs          # Coordinator-side agent process management (spawn + monitor)
+│   ├── runtime_agent.rs         # Runtime agent subprocess: Unix socket peer, CRDT queue watching, kernel ownership
+│   ├── runtime_agent_handle.rs  # Coordinator-side runtime agent process management (spawn + monitor)
 │   ├── kernel_manager.rs        # RoomKernel: kernel lifecycle, execution queue, IOPub output routing
 │   ├── kernel_pids.rs           # Kernel PID tracking and orphan reaping
 │   ├── comm_state.rs            # Widget comm state + Output widget capture routing

--- a/crates/notebook-doc/src/runtime_state.rs
+++ b/crates/notebook-doc/src/runtime_state.rs
@@ -70,10 +70,10 @@ pub struct KernelState {
     pub language: String,
     #[serde(default)]
     pub env_source: String,
-    /// ID of the agent subprocess that owns this kernel (e.g., "rt:agent:a1b2c3d4").
-    /// Used for provenance — identifying which agent is running and detecting stale agents.
+    /// ID of the runtime agent subprocess that owns this kernel (e.g., "rt:agent:a1b2c3d4").
+    /// Used for provenance — identifying which runtime agent is running and detecting stale ones.
     #[serde(default)]
-    pub agent_id: String,
+    pub runtime_agent_id: String,
 }
 
 impl Default for KernelState {
@@ -84,7 +84,7 @@ impl Default for KernelState {
             name: String::new(),
             language: String::new(),
             env_source: String::new(),
-            agent_id: String::new(),
+            runtime_agent_id: String::new(),
         }
     }
 }
@@ -127,7 +127,7 @@ pub struct ExecutionState {
     #[serde(default)]
     pub source: Option<String>,
     /// Queue sequence number for ordering.
-    /// Monotonic counter owned by the coordinator; the agent sorts
+    /// Monotonic counter owned by the coordinator; the runtime agent sorts
     /// queued entries by this to determine execution order.
     #[serde(default)]
     pub seq: Option<u64>,
@@ -253,8 +253,8 @@ impl RuntimeStateDoc {
             .expect("scaffold kernel.language");
         doc.put(&kernel, "env_source", "")
             .expect("scaffold kernel.env_source");
-        doc.put(&kernel, "agent_id", "")
-            .expect("scaffold kernel.agent_id");
+        doc.put(&kernel, "runtime_agent_id", "")
+            .expect("scaffold kernel.runtime_agent_id");
         doc.put(&kernel, "starting_phase", "")
             .expect("scaffold kernel.starting_phase");
 
@@ -333,8 +333,8 @@ impl RuntimeStateDoc {
             .expect("scaffold kernel.language");
         doc.put(&kernel, "env_source", "")
             .expect("scaffold kernel.env_source");
-        doc.put(&kernel, "agent_id", "")
-            .expect("scaffold kernel.agent_id");
+        doc.put(&kernel, "runtime_agent_id", "")
+            .expect("scaffold kernel.runtime_agent_id");
         doc.put(&kernel, "starting_phase", "")
             .expect("scaffold kernel.starting_phase");
 
@@ -682,17 +682,17 @@ impl RuntimeStateDoc {
         true
     }
 
-    /// Set the agent ID that owns this kernel. Returns `true` if mutated.
+    /// Set the runtime agent ID that owns this kernel. Returns `true` if mutated.
     #[allow(clippy::expect_used)]
-    pub fn set_agent_id(&mut self, agent_id: &str) -> bool {
+    pub fn set_runtime_agent_id(&mut self, runtime_agent_id: &str) -> bool {
         let kernel = self.get_map("kernel").expect("kernel map must exist");
-        let current = self.read_str(&kernel, "agent_id");
-        if current == agent_id {
+        let current = self.read_str(&kernel, "runtime_agent_id");
+        if current == runtime_agent_id {
             return false;
         }
         self.doc
-            .put(&kernel, "agent_id", agent_id)
-            .expect("put kernel.agent_id");
+            .put(&kernel, "runtime_agent_id", runtime_agent_id)
+            .expect("put kernel.runtime_agent_id");
         true
     }
 
@@ -834,9 +834,10 @@ impl RuntimeStateDoc {
 
     /// Create a new execution entry with source code and queue sequence number.
     ///
-    /// Used by the coordinator to queue executions for the agent. The source is
-    /// stored as an audit log, and `seq` determines execution order. The agent
-    /// discovers new entries via CRDT sync and processes them in `seq` order.
+    /// Used by the coordinator to queue executions for the runtime agent. The
+    /// source is stored as an audit log, and `seq` determines execution order.
+    /// The runtime agent discovers new entries via CRDT sync and processes them
+    /// in `seq` order.
     pub fn create_execution_with_source(
         &mut self,
         execution_id: &str,
@@ -1018,7 +1019,7 @@ impl RuntimeStateDoc {
 
     /// Get execution entries with `status == "queued"`, sorted by `seq`.
     ///
-    /// Used by the agent to discover new work via CRDT sync. Returns
+    /// Used by the runtime agent to discover new work via CRDT sync. Returns
     /// `(execution_id, ExecutionState)` pairs in execution order.
     pub fn get_queued_executions(&self) -> Vec<(String, ExecutionState)> {
         let state = self.read_state();
@@ -1726,7 +1727,7 @@ impl RuntimeStateDoc {
                 name: self.read_str(k, "name"),
                 language: self.read_str(k, "language"),
                 env_source: self.read_str(k, "env_source"),
-                agent_id: self.read_str(k, "agent_id"),
+                runtime_agent_id: self.read_str(k, "runtime_agent_id"),
             })
             .unwrap_or_default();
 

--- a/crates/notebook-protocol/src/connection.rs
+++ b/crates/notebook-protocol/src/connection.rs
@@ -78,14 +78,14 @@ pub enum Handshake {
         path: String,
     },
 
-    /// Runtime agent handshake. Sent by the coordinator to a spawned agent
-    /// subprocess on its stdin. The agent reads this, bootstraps its
-    /// RuntimeStateDoc, and begins processing kernel requests.
+    /// Runtime agent handshake. Sent by the coordinator to a spawned runtime
+    /// agent subprocess on its stdin. The runtime agent reads this, bootstraps
+    /// its RuntimeStateDoc, and begins processing kernel requests.
     RuntimeAgent {
         /// Notebook room to attach to.
         notebook_id: String,
-        /// Unique agent identifier (e.g., "rt:agent:a1b2c3d4").
-        agent_id: String,
+        /// Unique runtime agent identifier (e.g., "rt:agent:a1b2c3d4").
+        runtime_agent_id: String,
         /// Filesystem path to the shared blob store root
         /// (e.g., "~/.cache/runt/blobs/").
         blob_root: String,

--- a/crates/notebook-protocol/src/protocol.rs
+++ b/crates/notebook-protocol/src/protocol.rs
@@ -520,22 +520,22 @@ pub enum NotebookBroadcast {
     },
 }
 
-// ── Agent protocol types ───────────────────────────────────────────────────
+// ── Runtime agent protocol types ──────────────────────────────────────────
 //
-// These types define the coordinator↔agent wire contract for process-isolated
-// runtime agents (#1333). The agent subprocess communicates over stdin/stdout
-// using the same framed protocol (frame types 0x01/0x02/0x03 for JSON,
-// 0x05 for RuntimeStateDoc sync).
+// These types define the coordinator↔runtime-agent wire contract for
+// process-isolated runtime agents (#1333). The runtime agent subprocess
+// communicates over stdin/stdout using the same framed protocol (frame
+// types 0x01/0x02/0x03 for JSON, 0x05 for RuntimeStateDoc sync).
 
 /// Requests from coordinator to runtime agent (frame type 0x01).
 ///
-/// The coordinator mediates between frontend requests and the agent.
-/// Environment preparation happens in the coordinator; the agent receives
-/// a ready-to-launch configuration.
+/// The coordinator mediates between frontend requests and the runtime agent.
+/// Environment preparation happens in the coordinator; the runtime agent
+/// receives a ready-to-launch configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "action", rename_all = "snake_case")]
 #[allow(clippy::large_enum_variant)]
-pub enum AgentRequest {
+pub enum RuntimeAgentRequest {
     /// Launch a kernel with the given configuration.
     /// Environment is already prepared by the coordinator.
     LaunchKernel {
@@ -552,12 +552,13 @@ pub enum AgentRequest {
     /// Interrupt the currently executing cell.
     InterruptExecution,
 
-    /// Shutdown the kernel. The agent process stays alive for potential restart.
+    /// Shutdown the kernel. The runtime agent process stays alive for potential restart.
     ShutdownKernel,
 
     /// Restart the kernel: shut down the current kernel, create a new one,
-    /// re-launch. Same agent process, same socket connection. The coordinator
-    /// sends this instead of spawning a new agent when one is already connected.
+    /// re-launch. Same runtime agent process, same socket connection. The
+    /// coordinator sends this instead of spawning a new runtime agent when
+    /// one is already connected.
     RestartKernel {
         kernel_type: String,
         env_source: String,
@@ -589,11 +590,11 @@ pub enum AgentRequest {
 /// Responses from runtime agent to coordinator (frame type 0x02).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "result", rename_all = "snake_case")]
-pub enum AgentResponse {
+pub enum RuntimeAgentResponse {
     /// Kernel launched successfully.
     KernelLaunched { env_source: String },
 
-    /// Kernel restarted successfully (same agent, new kernel).
+    /// Kernel restarted successfully (same runtime agent, new kernel).
     KernelRestarted { env_source: String },
 
     /// Code completion result.

--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -614,23 +614,23 @@ impl Daemon {
         };
 
         for (notebook_id, room) in drained_rooms {
-            // Shut down agent via RPC before dropping handle
+            // Shut down runtime agent via RPC before dropping handle
             {
-                let has_agent = room.agent_request_tx.lock().await.is_some();
-                if has_agent {
+                let has_runtime_agent = room.runtime_agent_request_tx.lock().await.is_some();
+                if has_runtime_agent {
                     info!(
-                        "[runtimed] Shutting down agent for notebook on exit: {}",
+                        "[runtimed] Shutting down runtime agent for notebook on exit: {}",
                         notebook_id
                     );
-                    let _ = crate::notebook_sync_server::send_agent_request(
+                    let _ = crate::notebook_sync_server::send_runtime_agent_request(
                         &room,
-                        notebook_protocol::protocol::AgentRequest::ShutdownKernel,
+                        notebook_protocol::protocol::RuntimeAgentRequest::ShutdownKernel,
                     )
                     .await;
                 }
-                let mut agent_guard = room.agent_handle.lock().await;
-                *agent_guard = None;
-                let mut tx = room.agent_request_tx.lock().await;
+                let mut ra_guard = room.runtime_agent_handle.lock().await;
+                *ra_guard = None;
+                let mut tx = room.runtime_agent_request_tx.lock().await;
                 *tx = None;
             }
         }
@@ -1216,12 +1216,12 @@ impl Daemon {
             }
             Handshake::RuntimeAgent {
                 notebook_id,
-                agent_id,
+                runtime_agent_id,
                 blob_root: _,
             } => {
                 info!(
-                    "[runtimed] Agent connecting via socket: notebook={} agent={}",
-                    notebook_id, agent_id
+                    "[runtimed] Runtime agent connecting via socket: notebook={} runtime_agent={}",
+                    notebook_id, runtime_agent_id
                 );
                 let room = {
                     let rooms = self.notebook_rooms.lock().await;
@@ -1230,12 +1230,12 @@ impl Daemon {
                 match room {
                     Some(room) => {
                         let (reader, writer) = tokio::io::split(stream);
-                        crate::notebook_sync_server::handle_agent_sync_connection(
+                        crate::notebook_sync_server::handle_runtime_agent_sync_connection(
                             reader,
                             writer,
                             room,
                             notebook_id,
-                            agent_id,
+                            runtime_agent_id,
                         )
                         .await;
                         Ok(())
@@ -1983,25 +1983,26 @@ impl Daemon {
             Request::ShutdownNotebook { notebook_id } => {
                 let mut rooms = self.notebook_rooms.lock().await;
                 if let Some(room) = rooms.remove(&notebook_id) {
-                    // Shut down agent via RPC before dropping handle.
-                    // AgentHandle doesn't own the Child (it's in a background
+                    // Shut down runtime agent via RPC before dropping handle.
+                    // RuntimeAgentHandle doesn't own the Child (it's in a background
                     // task), so dropping the handle alone doesn't kill it.
                     {
-                        let has_agent = room.agent_request_tx.lock().await.is_some();
-                        if has_agent {
+                        let has_runtime_agent =
+                            room.runtime_agent_request_tx.lock().await.is_some();
+                        if has_runtime_agent {
                             info!(
-                                "[runtimed] Shutting down agent for notebook: {}",
+                                "[runtimed] Shutting down runtime agent for notebook: {}",
                                 notebook_id
                             );
-                            let _ = crate::notebook_sync_server::send_agent_request(
+                            let _ = crate::notebook_sync_server::send_runtime_agent_request(
                                 &room,
-                                notebook_protocol::protocol::AgentRequest::ShutdownKernel,
+                                notebook_protocol::protocol::RuntimeAgentRequest::ShutdownKernel,
                             )
                             .await;
                         }
-                        let mut agent_guard = room.agent_handle.lock().await;
-                        *agent_guard = None;
-                        let mut tx = room.agent_request_tx.lock().await;
+                        let mut ra_guard = room.runtime_agent_handle.lock().await;
+                        *ra_guard = None;
+                        let mut tx = room.runtime_agent_request_tx.lock().await;
                         *tx = None;
                     }
                     info!("[runtimed] Evicted room for notebook: {}", notebook_id);
@@ -2024,8 +2025,8 @@ impl Daemon {
         let mut paths = std::collections::HashSet::new();
         let rooms = self.notebook_rooms.lock().await;
         for room in rooms.values() {
-            // Check agent-backed kernel
-            if let Some(ref env_path) = *room.agent_env_path.read().await {
+            // Check runtime-agent-backed kernel
+            if let Some(ref env_path) = *room.runtime_agent_env_path.read().await {
                 paths.insert(env_path.clone());
             }
         }

--- a/crates/runtimed/src/lib.rs
+++ b/crates/runtimed/src/lib.rs
@@ -18,8 +18,6 @@ pub use runtimed_client::*;
 // Server-only modules (not in runtimed-client)
 // ============================================================================
 
-pub mod agent;
-pub mod agent_handle;
 pub mod blob_server;
 pub mod blob_store;
 pub mod daemon;
@@ -30,6 +28,8 @@ pub mod markdown_assets;
 pub mod notebook_sync_server;
 pub mod output_store;
 pub mod project_file;
+pub mod runtime_agent;
+pub mod runtime_agent_handle;
 pub mod singleton;
 pub mod stream_terminal;
 pub mod sync_server;

--- a/crates/runtimed/src/main.rs
+++ b/crates/runtimed/src/main.rs
@@ -104,17 +104,17 @@ enum Commands {
     FlushPool,
 
     /// Run as a runtime agent subprocess (internal, used by coordinator)
-    #[command(hide = true)]
-    Agent {
+    #[command(hide = true, name = "runtime-agent")]
+    RuntimeAgent {
         /// Daemon socket path to connect to
         #[arg(long)]
         socket: PathBuf,
         /// Notebook ID to attach to
         #[arg(long)]
         notebook_id: String,
-        /// Agent ID
+        /// Runtime agent ID
         #[arg(long)]
-        agent_id: String,
+        runtime_agent_id: String,
         /// Blob store root path
         #[arg(long)]
         blob_root: PathBuf,
@@ -348,17 +348,22 @@ async fn main() -> anyhow::Result<()> {
             );
             flush_pool().await
         }
-        Some(Commands::Agent {
+        Some(Commands::RuntimeAgent {
             socket,
             notebook_id,
-            agent_id,
+            runtime_agent_id,
             blob_root,
-        }) => runtimed::agent::run_agent(socket, notebook_id, agent_id, blob_root)
-            .await
-            .map_err(|e| {
-                eprintln!("[agent] Fatal: {}", e);
-                e
-            }),
+        }) => runtimed::runtime_agent::run_runtime_agent(
+            socket,
+            notebook_id,
+            runtime_agent_id,
+            blob_root,
+        )
+        .await
+        .map_err(|e| {
+            eprintln!("[runtime-agent] Fatal: {}", e);
+            e
+        }),
     }
 }
 

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -81,33 +81,34 @@ pub(crate) fn catch_automerge_panic<T>(label: &str, f: impl FnOnce() -> T) -> Re
     }
 }
 
-/// Sender half of the agent RPC channel.
-type AgentRequestSender = tokio::sync::mpsc::Sender<(
-    notebook_protocol::protocol::AgentRequest,
-    tokio::sync::oneshot::Sender<notebook_protocol::protocol::AgentResponse>,
+/// Sender half of the runtime agent RPC channel.
+type RuntimeAgentRequestSender = tokio::sync::mpsc::Sender<(
+    notebook_protocol::protocol::RuntimeAgentRequest,
+    tokio::sync::oneshot::Sender<notebook_protocol::protocol::RuntimeAgentResponse>,
 )>;
 
-/// Send an RPC request to the agent via its sync connection.
+/// Send an RPC request to the runtime agent via its sync connection.
 ///
-/// The agent's sync handler receives the request as a frame 0x01 and sends
-/// the response as frame 0x02. Returns error if no agent is connected.
-pub(crate) async fn send_agent_request(
+/// The runtime agent's sync handler receives the request as a frame 0x01 and
+/// sends the response as frame 0x02. Returns error if no runtime agent is
+/// connected.
+pub(crate) async fn send_runtime_agent_request(
     room: &NotebookRoom,
-    request: notebook_protocol::protocol::AgentRequest,
-) -> anyhow::Result<notebook_protocol::protocol::AgentResponse> {
+    request: notebook_protocol::protocol::RuntimeAgentRequest,
+) -> anyhow::Result<notebook_protocol::protocol::RuntimeAgentResponse> {
     let tx = {
-        let guard = room.agent_request_tx.lock().await;
+        let guard = room.runtime_agent_request_tx.lock().await;
         guard
             .clone()
-            .ok_or_else(|| anyhow::anyhow!("Agent not connected"))?
+            .ok_or_else(|| anyhow::anyhow!("Runtime agent not connected"))?
     };
     let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
     tx.send((request, reply_tx))
         .await
-        .map_err(|_| anyhow::anyhow!("Agent disconnected"))?;
+        .map_err(|_| anyhow::anyhow!("Runtime agent disconnected"))?;
     reply_rx
         .await
-        .map_err(|_| anyhow::anyhow!("Agent dropped reply"))
+        .map_err(|_| anyhow::anyhow!("Runtime agent dropped reply"))
 }
 
 /// Trust state for a notebook room.
@@ -310,7 +311,7 @@ fn build_launched_config(
         }
         _ => {
             // All other Python env sources (conda:env_yml, etc.)
-            // use pooled environments — store paths so the agent can reconstruct.
+            // use pooled environments — store paths so the runtime agent can reconstruct.
             config.venv_path = venv_path;
             config.python_path = python_path;
             if let Some(pkgs) = prewarmed_packages {
@@ -569,8 +570,8 @@ async fn check_and_broadcast_sync_state(room: &NotebookRoom) {
         return;
     };
 
-    // Read launched_config from room (set when agent launched/restarted)
-    let launched_guard = room.agent_launched_config.read().await;
+    // Read launched_config from room (set when runtime agent launched/restarted)
+    let launched_guard = room.runtime_agent_launched_config.read().await;
     let Some(ref launched) = *launched_guard else {
         return;
     };
@@ -1040,29 +1041,30 @@ pub struct NotebookRoom {
     /// Notification channel for RuntimeStateDoc changes.
     /// Peer sync loops subscribe to push RuntimeStateSync frames.
     pub state_changed_tx: broadcast::Sender<()>,
-    /// Handle to the agent subprocess that owns this notebook's kernel.
-    /// Set by `LaunchKernel` or `auto_launch_kernel` when the agent is spawned.
-    pub agent_handle: Arc<Mutex<Option<crate::agent_handle::AgentHandle>>>,
-    /// Environment path used by an agent-backed kernel, for GC protection.
-    pub agent_env_path: Arc<RwLock<Option<PathBuf>>>,
+    /// Handle to the runtime agent subprocess that owns this notebook's kernel.
+    /// Set by `LaunchKernel` or `auto_launch_kernel` when spawned.
+    pub runtime_agent_handle: Arc<Mutex<Option<crate::runtime_agent_handle::RuntimeAgentHandle>>>,
+    /// Environment path used by a runtime-agent-backed kernel, for GC protection.
+    pub runtime_agent_env_path: Arc<RwLock<Option<PathBuf>>>,
     /// The environment config used at kernel launch. Stored so
     /// check_and_broadcast_sync_state can detect dependency drift
-    /// without accessing the agent's kernel directly.
-    pub agent_launched_config: Arc<RwLock<Option<LaunchedEnvConfig>>>,
+    /// without accessing the runtime agent's kernel directly.
+    pub runtime_agent_launched_config: Arc<RwLock<Option<LaunchedEnvConfig>>>,
     /// Channel for sending RPC requests (LaunchKernel, Interrupt, etc.) to the
-    /// agent's sync connection. Set when agent connects via socket, cleared on
-    /// agent disconnect.
-    pub agent_request_tx: Arc<Mutex<Option<AgentRequestSender>>>,
-    /// Fires when the agent establishes its sync connection.
+    /// runtime agent's sync connection. Set when runtime agent connects via
+    /// socket, cleared on disconnect.
+    pub runtime_agent_request_tx: Arc<Mutex<Option<RuntimeAgentRequestSender>>>,
+    /// Fires when the runtime agent establishes its sync connection.
     /// Uses `watch(false)` → `true` to avoid lost wakeups.
-    agent_connected_tx: Arc<tokio::sync::watch::Sender<bool>>,
+    runtime_agent_connected_tx: Arc<tokio::sync::watch::Sender<bool>>,
     /// Monotonic counter for execution queue ordering.
     /// The coordinator bumps this for each ExecuteCell and stamps the seq
-    /// on the execution entry. The agent sorts by seq to determine order.
+    /// on the execution entry. The runtime agent sorts by seq to determine order.
     pub next_queue_seq: Arc<std::sync::atomic::AtomicU64>,
-    /// The agent_id of the currently expected agent. Used by the sync handler
-    /// to validate connections and prevent stale cleanup from clobbering state.
-    pub current_agent_id: Arc<RwLock<Option<String>>>,
+    /// The runtime_agent_id of the currently expected runtime agent. Used by the
+    /// sync handler to validate connections and prevent stale cleanup from
+    /// clobbering state.
+    pub current_runtime_agent_id: Arc<RwLock<Option<String>>>,
 }
 
 /// Maximum number of snapshots to keep per notebook hash.
@@ -1244,16 +1246,16 @@ impl NotebookRoom {
             watcher_shutdown_tx: Mutex::new(None),
             state_doc,
             state_changed_tx,
-            agent_handle: Arc::new(Mutex::new(None)),
-            agent_env_path: Arc::new(RwLock::new(None)),
-            agent_launched_config: Arc::new(RwLock::new(None)),
-            agent_request_tx: Arc::new(Mutex::new(None)),
-            agent_connected_tx: {
+            runtime_agent_handle: Arc::new(Mutex::new(None)),
+            runtime_agent_env_path: Arc::new(RwLock::new(None)),
+            runtime_agent_launched_config: Arc::new(RwLock::new(None)),
+            runtime_agent_request_tx: Arc::new(Mutex::new(None)),
+            runtime_agent_connected_tx: {
                 let (tx, _) = tokio::sync::watch::channel(false);
                 Arc::new(tx)
             },
             next_queue_seq: Arc::new(std::sync::atomic::AtomicU64::new(0)),
-            current_agent_id: Arc::new(RwLock::new(None)),
+            current_runtime_agent_id: Arc::new(RwLock::new(None)),
         }
     }
 
@@ -1316,33 +1318,33 @@ impl NotebookRoom {
             watcher_shutdown_tx: Mutex::new(None),
             state_doc,
             state_changed_tx,
-            agent_handle: Arc::new(Mutex::new(None)),
-            agent_env_path: Arc::new(RwLock::new(None)),
-            agent_launched_config: Arc::new(RwLock::new(None)),
-            agent_request_tx: Arc::new(Mutex::new(None)),
-            agent_connected_tx: {
+            runtime_agent_handle: Arc::new(Mutex::new(None)),
+            runtime_agent_env_path: Arc::new(RwLock::new(None)),
+            runtime_agent_launched_config: Arc::new(RwLock::new(None)),
+            runtime_agent_request_tx: Arc::new(Mutex::new(None)),
+            runtime_agent_connected_tx: {
                 let (tx, _) = tokio::sync::watch::channel(false);
                 Arc::new(tx)
             },
             next_queue_seq: Arc::new(std::sync::atomic::AtomicU64::new(0)),
-            current_agent_id: Arc::new(RwLock::new(None)),
+            current_runtime_agent_id: Arc::new(RwLock::new(None)),
         }
     }
 
     /// Check if this room has an active kernel.
     pub async fn has_kernel(&self) -> bool {
-        // Check agent handle (agent mode is unconditional)
-        let agent = self.agent_handle.lock().await;
-        agent.as_ref().is_some_and(|a| a.is_alive())
+        // Check runtime agent handle
+        let ra = self.runtime_agent_handle.lock().await;
+        ra.as_ref().is_some_and(|a| a.is_alive())
     }
 
-    /// Get kernel info if a kernel is running (agent-backed).
+    /// Get kernel info if a kernel is running (runtime-agent-backed).
     ///
-    /// Reads from RuntimeStateDoc (source of truth in agent mode).
+    /// Reads from RuntimeStateDoc (source of truth for runtime agent).
     pub async fn kernel_info(&self) -> Option<(String, String, String)> {
-        // Check agent — read from RuntimeStateDoc
-        let agent = self.agent_handle.lock().await;
-        if agent.as_ref().is_some_and(|a| a.is_alive()) {
+        // Check runtime agent — read from RuntimeStateDoc
+        let ra = self.runtime_agent_handle.lock().await;
+        if ra.as_ref().is_some_and(|a| a.is_alive()) {
             let sd = self.state_doc.read().await;
             let state = sd.read_state();
             if state.kernel.status != "not_started" && !state.kernel.status.is_empty() {
@@ -1454,43 +1456,43 @@ pub fn get_or_create_room(
 /// doc bytes are flushed via debounced persistence.
 ///
 /// Uses v2 typed frames protocol (with first-byte type indicator).
-/// Handle an agent subprocess that connected back to the daemon's Unix socket.
+/// Handle a runtime agent subprocess that connected back to the daemon's Unix socket.
 ///
-/// The agent is a special peer that owns the kernel for this notebook room.
-/// It receives RPC requests (LaunchKernel, Interrupt, etc.) via frame 0x01
-/// and watches RuntimeStateDoc for queued executions via frame 0x05.
+/// The runtime agent is a special peer that owns the kernel for this notebook
+/// room. It receives RPC requests (LaunchKernel, Interrupt, etc.) via frame
+/// 0x01 and watches RuntimeStateDoc for queued executions via frame 0x05.
 ///
 /// This handler:
 /// 1. Performs initial NotebookDoc + RuntimeStateDoc sync
-/// 2. Sets up the `agent_request_tx` channel on the room
-/// 3. Fires `agent_connected` to unblock LaunchKernel
+/// 2. Sets up the `runtime_agent_request_tx` channel on the room
+/// 3. Fires `runtime_agent_connected` to unblock LaunchKernel
 /// 4. Enters a sync loop relaying frames bidirectionally
-pub async fn handle_agent_sync_connection<R, W>(
+pub async fn handle_runtime_agent_sync_connection<R, W>(
     mut reader: R,
     mut writer: W,
     room: Arc<NotebookRoom>,
     notebook_id: String,
-    agent_id: String,
+    runtime_agent_id: String,
 ) where
     R: tokio::io::AsyncRead + Unpin + Send,
     W: tokio::io::AsyncWrite + Unpin + Send,
 {
     use notebook_protocol::connection::{recv_typed_frame, send_typed_frame, NotebookFrameType};
-    use notebook_protocol::protocol::{AgentRequest, AgentResponse};
+    use notebook_protocol::protocol::{RuntimeAgentRequest, RuntimeAgentResponse};
 
     info!(
-        "[notebook-sync] Agent sync connection: notebook={} agent={}",
-        notebook_id, agent_id
+        "[notebook-sync] Runtime agent sync connection: notebook={} runtime_agent={}",
+        notebook_id, runtime_agent_id
     );
 
     // Validate provenance — reject stale agents
     {
-        let expected = room.current_agent_id.read().await;
+        let expected = room.current_runtime_agent_id.read().await;
         if let Some(ref expected_id) = *expected {
-            if *expected_id != agent_id {
+            if *expected_id != runtime_agent_id {
                 warn!(
-                    "[notebook-sync] Rejecting stale agent {} (expected {})",
-                    agent_id, expected_id
+                    "[notebook-sync] Rejecting stale runtime agent {} (expected {})",
+                    runtime_agent_id, expected_id
                 );
                 return;
             }
@@ -1532,31 +1534,34 @@ pub async fn handle_agent_sync_connection<R, W>(
     }
 
     // ── 3. Set up request channel ────────────────────────────────────
-    let (agent_tx, mut agent_rx) = tokio::sync::mpsc::channel::<(
-        AgentRequest,
-        tokio::sync::oneshot::Sender<AgentResponse>,
+    let (ra_tx, mut ra_rx) = tokio::sync::mpsc::channel::<(
+        RuntimeAgentRequest,
+        tokio::sync::oneshot::Sender<RuntimeAgentResponse>,
     )>(16);
     {
-        let mut tx_guard = room.agent_request_tx.lock().await;
-        *tx_guard = Some(agent_tx);
+        let mut tx_guard = room.runtime_agent_request_tx.lock().await;
+        *tx_guard = Some(ra_tx);
     }
 
     // ── 4. Set provenance + signal connected ──────────────────────────
     {
-        let mut id = room.current_agent_id.write().await;
-        *id = Some(agent_id.clone());
+        let mut id = room.current_runtime_agent_id.write().await;
+        *id = Some(runtime_agent_id.clone());
     }
-    let _ = room.agent_connected_tx.send(true);
-    info!("[notebook-sync] Agent connected and ready: {}", agent_id);
+    let _ = room.runtime_agent_connected_tx.send(true);
+    info!(
+        "[notebook-sync] Runtime agent connected and ready: {}",
+        runtime_agent_id
+    );
 
     // ── 5. Sync loop ─────────────────────────────────────────────────
     let mut changed_rx = room.changed_tx.subscribe();
     let mut state_changed_rx = room.state_changed_tx.subscribe();
-    let mut pending_reply: Option<tokio::sync::oneshot::Sender<AgentResponse>> = None;
+    let mut pending_reply: Option<tokio::sync::oneshot::Sender<RuntimeAgentResponse>> = None;
 
     loop {
         tokio::select! {
-            // Frames from agent
+            // Frames from runtime agent
             frame = recv_typed_frame(&mut reader) => {
                 match frame {
                     Ok(Some(typed_frame)) => {
@@ -1601,7 +1606,7 @@ pub async fn handle_agent_sync_connection<R, W>(
                             }
                             NotebookFrameType::Response => {
                                 // Agent responded to an RPC request
-                                if let Ok(response) = serde_json::from_slice::<AgentResponse>(&typed_frame.payload) {
+                                if let Ok(response) = serde_json::from_slice::<RuntimeAgentResponse>(&typed_frame.payload) {
                                     if let Some(reply) = pending_reply.take() {
                                         let _ = reply.send(response);
                                     } else {
@@ -1625,7 +1630,7 @@ pub async fn handle_agent_sync_connection<R, W>(
                 }
             }
 
-            // NotebookDoc changes (from other peers) → sync to agent
+            // NotebookDoc changes (from other peers) → sync to runtime agent
             _ = changed_rx.recv() => {
                 while changed_rx.try_recv().is_ok() {}
                 let mut doc = room.doc.write().await;
@@ -1636,13 +1641,13 @@ pub async fn handle_agent_sync_connection<R, W>(
                         NotebookFrameType::AutomergeSync,
                         &encoded,
                     ).await {
-                        warn!("[notebook-sync] Failed to sync doc to agent: {}", e);
+                        warn!("[notebook-sync] Failed to sync doc to runtime agent: {}", e);
                         break;
                     }
                 }
             }
 
-            // RuntimeStateDoc changes → sync to agent
+            // RuntimeStateDoc changes → sync to runtime agent
             _ = state_changed_rx.recv() => {
                 while state_changed_rx.try_recv().is_ok() {}
                 let mut sd = room.state_doc.write().await;
@@ -1653,19 +1658,19 @@ pub async fn handle_agent_sync_connection<R, W>(
                         NotebookFrameType::RuntimeStateSync,
                         &encoded,
                     ).await {
-                        warn!("[notebook-sync] Failed to sync state to agent: {}", e);
+                        warn!("[notebook-sync] Failed to sync state to runtime agent: {}", e);
                         break;
                     }
                 }
             }
 
-            // RPC requests to forward to agent (only accept when no reply is pending
+            // RPC requests to forward to runtime agent (only accept when no reply is pending
             // to serialize RPCs and prevent overwriting the reply slot)
-            Some((request, reply_tx)) = agent_rx.recv(), if pending_reply.is_none() => {
+            Some((request, reply_tx)) = ra_rx.recv(), if pending_reply.is_none() => {
                 let json = match serde_json::to_vec(&request) {
                     Ok(j) => j,
                     Err(e) => {
-                        let _ = reply_tx.send(AgentResponse::Error {
+                        let _ = reply_tx.send(RuntimeAgentResponse::Error {
                             error: format!("Serialize error: {}", e),
                         });
                         continue;
@@ -1676,7 +1681,7 @@ pub async fn handle_agent_sync_connection<R, W>(
                     NotebookFrameType::Request,
                     &json,
                 ).await {
-                    let _ = reply_tx.send(AgentResponse::Error {
+                    let _ = reply_tx.send(RuntimeAgentResponse::Error {
                         error: format!("Send error: {}", e),
                     });
                     break;
@@ -1686,22 +1691,25 @@ pub async fn handle_agent_sync_connection<R, W>(
         }
     }
 
-    // Cleanup: only clear state if we're still the current agent.
-    // A stale agent disconnecting after a new one connected must not
-    // clobber the new agent's channel.
+    // Cleanup: only clear state if we're still the current runtime agent.
+    // A stale runtime agent disconnecting after a new one connected must not
+    // clobber the new runtime agent's channel.
     {
-        let expected = room.current_agent_id.read().await;
-        let is_current = expected.as_deref() == Some(&agent_id);
+        let expected = room.current_runtime_agent_id.read().await;
+        let is_current = expected.as_deref() == Some(&runtime_agent_id);
         if is_current {
-            let mut tx_guard = room.agent_request_tx.lock().await;
+            let mut tx_guard = room.runtime_agent_request_tx.lock().await;
             *tx_guard = None;
-            let _ = room.agent_connected_tx.send(false);
-            // Clear agent_handle so LaunchKernel spawns a new agent
-            let mut guard = room.agent_handle.lock().await;
+            let _ = room.runtime_agent_connected_tx.send(false);
+            // Clear runtime_agent_handle so LaunchKernel spawns a new runtime agent
+            let mut guard = room.runtime_agent_handle.lock().await;
             *guard = None;
         }
     }
-    info!("[notebook-sync] Agent sync connection closed: {}", agent_id);
+    info!(
+        "[notebook-sync] Runtime agent sync connection closed: {}",
+        runtime_agent_id
+    );
 }
 
 ///
@@ -1935,20 +1943,24 @@ where
             let mut rooms_guard = rooms_for_eviction.lock().await;
             // Re-check under lock
             if room_for_eviction.active_peers.load(Ordering::Relaxed) == 0 {
-                // Shut down agent subprocess if running. AgentHandle::spawn
+                // Shut down runtime agent subprocess if running. RuntimeAgentHandle::spawn
                 // moves Child into a background task, so kill_on_drop doesn't
                 // trigger on room drop — we need explicit shutdown via RPC.
                 {
-                    let has_agent = room_for_eviction.agent_request_tx.lock().await.is_some();
-                    if has_agent {
-                        let _ = send_agent_request(
+                    let has_runtime_agent = room_for_eviction
+                        .runtime_agent_request_tx
+                        .lock()
+                        .await
+                        .is_some();
+                    if has_runtime_agent {
+                        let _ = send_runtime_agent_request(
                             &room_for_eviction,
-                            notebook_protocol::protocol::AgentRequest::ShutdownKernel,
+                            notebook_protocol::protocol::RuntimeAgentRequest::ShutdownKernel,
                         )
                         .await;
-                        let mut guard = room_for_eviction.agent_handle.lock().await;
+                        let mut guard = room_for_eviction.runtime_agent_handle.lock().await;
                         *guard = None;
-                        let mut tx = room_for_eviction.agent_request_tx.lock().await;
+                        let mut tx = room_for_eviction.runtime_agent_request_tx.lock().await;
                         *tx = None;
                     }
                 }
@@ -2488,7 +2500,7 @@ where
                                     };
 
                                     // If client sent changes, notify all peers.
-                                    // Comm state forwarding to kernel: the agent diffs
+                                    // Comm state forwarding to kernel: the runtime agent diffs
                                     // comm state before/after each RuntimeStateSync and
                                     // sends changed properties to the kernel via send_comm_update.
                                     if had_changes {
@@ -2991,8 +3003,8 @@ async fn reset_starting_state(room: &NotebookRoom) {
     if changed {
         let _ = room.state_changed_tx.send(());
     }
-    // Clear stale agent handle so auto-launch can retry
-    let mut guard = room.agent_handle.lock().await;
+    // Clear stale runtime agent handle so auto-launch can retry
+    let mut guard = room.runtime_agent_handle.lock().await;
     *guard = None;
 }
 
@@ -3041,11 +3053,11 @@ async fn auto_launch_kernel(
 
     // Check RuntimeStateDoc — skip if already starting or running
     {
-        // Skip if agent already exists (another auto-launch won the race)
+        // Skip if runtime agent already exists (another auto-launch won the race)
         // or kernel is already running
-        let has_agent = room.agent_handle.lock().await.is_some();
-        if has_agent {
-            debug!("[notebook-sync] Auto-launch skipped: agent already exists");
+        let has_runtime_agent = room.runtime_agent_handle.lock().await.is_some();
+        if has_runtime_agent {
+            debug!("[notebook-sync] Auto-launch skipped: runtime agent already exists");
             return;
         }
     }
@@ -3066,7 +3078,7 @@ async fn auto_launch_kernel(
         }
     }
 
-    // Create new kernel (used for pool env acquisition; execution is agent-backed)
+    // Create new kernel (used for pool env acquisition; execution is runtime-agent-backed)
     let _kernel = RoomKernel::new(
         room.kernel_broadcast_tx.clone(),
         room.blob_store.clone(),
@@ -3519,31 +3531,31 @@ async fn auto_launch_kernel(
         }
     }
 
-    // (prewarmed_packages no longer needed — agent handles its own launch config)
+    // (prewarmed_packages no longer needed — runtime agent handles its own launch config)
 
-    // Spawn agent subprocess for kernel execution
+    // Spawn runtime agent subprocess for kernel execution
     {
-        info!("[notebook-sync] Agent mode: spawning agent subprocess for auto-launch");
+        info!("[notebook-sync] Spawning runtime agent subprocess for auto-launch");
 
         let nb_id = notebook_id.to_string();
-        let agent_id = format!("rt:agent:{}", &uuid::Uuid::new_v4().to_string()[..8]);
+        let runtime_agent_id = format!("rt:agent:{}", &uuid::Uuid::new_v4().to_string()[..8]);
         let socket_path = daemon.socket_path().clone();
 
-        match crate::agent_handle::AgentHandle::spawn(
+        match crate::runtime_agent_handle::RuntimeAgentHandle::spawn(
             nb_id,
-            agent_id.clone(),
+            runtime_agent_id.clone(),
             room.blob_store.root().to_path_buf(),
             socket_path,
         )
         .await
         {
-            Ok(agent) => {
+            Ok(ra) => {
                 // Store handle and set provenance
                 {
-                    let mut agent_guard = room.agent_handle.lock().await;
-                    *agent_guard = Some(agent);
-                    let mut id = room.current_agent_id.write().await;
-                    *id = Some(agent_id.clone());
+                    let mut ra_guard = room.runtime_agent_handle.lock().await;
+                    *ra_guard = Some(ra);
+                    let mut id = room.current_runtime_agent_id.write().await;
+                    *id = Some(runtime_agent_id.clone());
                 }
 
                 // Write "connecting" phase — fills the gap between spawn and connect
@@ -3554,9 +3566,9 @@ async fn auto_launch_kernel(
                     }
                 }
 
-                // Wait for agent to establish its sync connection
+                // Wait for runtime agent to establish its sync connection
                 match tokio::time::timeout(std::time::Duration::from_secs(30), async {
-                    room.agent_connected_tx
+                    room.runtime_agent_connected_tx
                         .subscribe()
                         .wait_for(|v| *v)
                         .await
@@ -3574,30 +3586,31 @@ async fn auto_launch_kernel(
                     }
                 }
 
-                // Send LaunchKernel RPC via the agent's sync connection
-                let launch_request = notebook_protocol::protocol::AgentRequest::LaunchKernel {
-                    kernel_type: kernel_type.to_string(),
-                    env_source: env_source.clone(),
-                    notebook_path: notebook_path_opt
-                        .as_deref()
-                        .map(|p| p.to_str().unwrap_or("").to_string()),
-                    launched_config: launched_config.clone(),
-                    env_vars: Default::default(),
-                };
+                // Send LaunchKernel RPC via the runtime agent's sync connection
+                let launch_request =
+                    notebook_protocol::protocol::RuntimeAgentRequest::LaunchKernel {
+                        kernel_type: kernel_type.to_string(),
+                        env_source: env_source.clone(),
+                        notebook_path: notebook_path_opt
+                            .as_deref()
+                            .map(|p| p.to_str().unwrap_or("").to_string()),
+                        launched_config: launched_config.clone(),
+                        env_vars: Default::default(),
+                    };
 
-                match send_agent_request(room, launch_request).await {
-                    Ok(notebook_protocol::protocol::AgentResponse::KernelLaunched {
+                match send_runtime_agent_request(room, launch_request).await {
+                    Ok(notebook_protocol::protocol::RuntimeAgentResponse::KernelLaunched {
                         env_source: es,
                     }) => {
                         // Store env path for GC protection
                         if let Some(ref env) = pooled_env {
-                            let mut ep = room.agent_env_path.write().await;
+                            let mut ep = room.runtime_agent_env_path.write().await;
                             *ep = Some(env.venv_path.clone());
                         }
 
                         // Store launched config for env sync drift detection
                         {
-                            let mut lc = room.agent_launched_config.write().await;
+                            let mut lc = room.runtime_agent_launched_config.write().await;
                             *lc = Some(launched_config.clone());
                         }
 
@@ -3611,7 +3624,7 @@ async fn auto_launch_kernel(
                             let mut changed = false;
                             changed |= sd.set_kernel_status("idle");
                             changed |= sd.set_kernel_info(kernel_type, kernel_type, &es);
-                            changed |= sd.set_agent_id(&agent_id);
+                            changed |= sd.set_runtime_agent_id(&runtime_agent_id);
                             if changed {
                                 let _ = room.state_changed_tx.send(());
                             }
@@ -3626,16 +3639,18 @@ async fn auto_launch_kernel(
                         }
 
                         info!(
-                            "[notebook-sync] Auto-launch via agent succeeded: {} kernel with {} environment",
+                            "[notebook-sync] Auto-launch via runtime agent succeeded: {} kernel with {} environment",
                             kernel_type, es
                         );
                     }
-                    Ok(notebook_protocol::protocol::AgentResponse::Error { error }) => {
+                    Ok(notebook_protocol::protocol::RuntimeAgentResponse::Error { error }) => {
                         warn!("[notebook-sync] Agent kernel launch failed: {}", error);
                         reset_starting_state(room).await;
                     }
                     Ok(_) => {
-                        warn!("[notebook-sync] Unexpected agent response during auto-launch");
+                        warn!(
+                            "[notebook-sync] Unexpected runtime agent response during auto-launch"
+                        );
                         reset_starting_state(room).await;
                     }
                     Err(e) => {
@@ -3645,7 +3660,7 @@ async fn auto_launch_kernel(
                 }
             }
             Err(e) => {
-                warn!("[notebook-sync] Failed to spawn agent: {}", e);
+                warn!("[notebook-sync] Failed to spawn runtime agent: {}", e);
                 reset_starting_state(room).await;
             }
         }
@@ -3918,7 +3933,7 @@ async fn handle_notebook_request(
                 }
             }
 
-            // Create new kernel (used for pool env acquisition; execution is agent-backed)
+            // Create new kernel (used for pool env acquisition; execution is runtime-agent-backed)
             let _kernel = RoomKernel::new(
                 room.kernel_broadcast_tx.clone(),
                 room.blob_store.clone(),
@@ -4402,14 +4417,14 @@ async fn handle_notebook_request(
                 }
             }
 
-            // If agent is already connected, restart kernel in-place
+            // If runtime agent is already connected, restart kernel in-place
             // (handles the shutdown → launch sequence without subprocess respawn)
             {
-                let has_agent = room.agent_request_tx.lock().await.is_some();
-                if has_agent {
+                let has_runtime_agent = room.runtime_agent_request_tx.lock().await.is_some();
+                if has_runtime_agent {
                     info!("[notebook-sync] Agent connected — sending RestartKernel");
                     let restart_request =
-                        notebook_protocol::protocol::AgentRequest::RestartKernel {
+                        notebook_protocol::protocol::RuntimeAgentRequest::RestartKernel {
                             kernel_type: resolved_kernel_type.clone(),
                             env_source: resolved_env_source.clone(),
                             notebook_path: notebook_path
@@ -4418,13 +4433,15 @@ async fn handle_notebook_request(
                             launched_config: launched_config.clone(),
                             env_vars: Default::default(),
                         };
-                    match send_agent_request(room, restart_request).await {
-                        Ok(notebook_protocol::protocol::AgentResponse::KernelRestarted {
-                            env_source: es,
-                        }) => {
+                    match send_runtime_agent_request(room, restart_request).await {
+                        Ok(
+                            notebook_protocol::protocol::RuntimeAgentResponse::KernelRestarted {
+                                env_source: es,
+                            },
+                        ) => {
                             // Store launched config for env sync drift detection
                             {
-                                let mut lc = room.agent_launched_config.write().await;
+                                let mut lc = room.runtime_agent_launched_config.write().await;
                                 *lc = Some(launched_config.clone());
                             }
 
@@ -4441,7 +4458,7 @@ async fn handle_notebook_request(
                                 );
                                 changed |=
                                     sd.set_prewarmed_packages(&launched_config.prewarmed_packages);
-                                // agent_id doesn't change on restart — same agent
+                                // runtime_agent_id doesn't change on restart — same runtime agent
                                 if changed {
                                     let _ = room.state_changed_tx.send(());
                                 }
@@ -4461,7 +4478,7 @@ async fn handle_notebook_request(
                                 launched_config,
                             };
                         }
-                        Ok(notebook_protocol::protocol::AgentResponse::Error { error }) => {
+                        Ok(notebook_protocol::protocol::RuntimeAgentResponse::Error { error }) => {
                             reset_starting_state(room).await;
                             return NotebookResponse::Error {
                                 error: format!("Agent restart failed: {}", error),
@@ -4470,40 +4487,42 @@ async fn handle_notebook_request(
                         Ok(_) => {
                             reset_starting_state(room).await;
                             return NotebookResponse::Error {
-                                error: "Unexpected agent response to RestartKernel".to_string(),
+                                error: "Unexpected runtime agent response to RestartKernel"
+                                    .to_string(),
                             };
                         }
                         Err(e) => {
                             warn!(
-                                "[notebook-sync] RestartKernel RPC failed: {} — spawning new agent",
+                                "[notebook-sync] RestartKernel RPC failed: {} — spawning new runtime agent",
                                 e
                             );
-                            // Fall through to spawn new agent below
+                            // Fall through to spawn new runtime agent below
                         }
                     }
                 }
             }
 
-            // Spawn agent subprocess for kernel execution
+            // Spawn runtime agent subprocess for kernel execution
             {
-                info!("[notebook-sync] Spawning agent subprocess");
+                info!("[notebook-sync] Spawning runtime agent subprocess");
 
                 let notebook_id = room.notebook_path.read().await.display().to_string();
-                let agent_id = format!("rt:agent:{}", &uuid::Uuid::new_v4().to_string()[..8]);
+                let runtime_agent_id =
+                    format!("rt:agent:{}", &uuid::Uuid::new_v4().to_string()[..8]);
                 let socket_path = daemon.socket_path().clone();
 
-                match crate::agent_handle::AgentHandle::spawn(
+                match crate::runtime_agent_handle::RuntimeAgentHandle::spawn(
                     notebook_id,
-                    agent_id,
+                    runtime_agent_id,
                     room.blob_store.root().to_path_buf(),
                     socket_path,
                 )
                 .await
                 {
-                    Ok(agent) => {
+                    Ok(ra) => {
                         {
-                            let mut agent_guard = room.agent_handle.lock().await;
-                            *agent_guard = Some(agent);
+                            let mut ra_guard = room.runtime_agent_handle.lock().await;
+                            *ra_guard = Some(ra);
                         }
 
                         // Write "connecting" phase — fills the gap between spawn and connect
@@ -4514,9 +4533,9 @@ async fn handle_notebook_request(
                             }
                         }
 
-                        // Wait for agent to connect back via socket
+                        // Wait for runtime agent to connect back via socket
                         match tokio::time::timeout(std::time::Duration::from_secs(30), async {
-                            room.agent_connected_tx
+                            room.runtime_agent_connected_tx
                                 .subscribe()
                                 .wait_for(|v| *v)
                                 .await
@@ -4535,7 +4554,7 @@ async fn handle_notebook_request(
 
                         // Send LaunchKernel RPC
                         let launch_request =
-                            notebook_protocol::protocol::AgentRequest::LaunchKernel {
+                            notebook_protocol::protocol::RuntimeAgentRequest::LaunchKernel {
                                 kernel_type: resolved_kernel_type.clone(),
                                 env_source: resolved_env_source.clone(),
                                 notebook_path: notebook_path
@@ -4545,13 +4564,15 @@ async fn handle_notebook_request(
                                 env_vars: Default::default(),
                             };
 
-                        match send_agent_request(room, launch_request).await {
-                            Ok(notebook_protocol::protocol::AgentResponse::KernelLaunched {
-                                env_source: es,
-                            }) => {
+                        match send_runtime_agent_request(room, launch_request).await {
+                            Ok(
+                                notebook_protocol::protocol::RuntimeAgentResponse::KernelLaunched {
+                                    env_source: es,
+                                },
+                            ) => {
                                 // Store launched config for env sync drift detection
                                 {
-                                    let mut lc = room.agent_launched_config.write().await;
+                                    let mut lc = room.runtime_agent_launched_config.write().await;
                                     *lc = Some(launched_config.clone());
                                 }
 
@@ -4576,8 +4597,10 @@ async fn handle_notebook_request(
                                     changed |= sd.set_prewarmed_packages(
                                         &launched_config.prewarmed_packages,
                                     );
-                                    if let Some(ref aid) = *room.current_agent_id.read().await {
-                                        changed |= sd.set_agent_id(aid);
+                                    if let Some(ref aid) =
+                                        *room.current_runtime_agent_id.read().await
+                                    {
+                                        changed |= sd.set_runtime_agent_id(aid);
                                     }
                                     if changed {
                                         let _ = room.state_changed_tx.send(());
@@ -4598,7 +4621,9 @@ async fn handle_notebook_request(
                                     launched_config,
                                 }
                             }
-                            Ok(notebook_protocol::protocol::AgentResponse::Error { error }) => {
+                            Ok(notebook_protocol::protocol::RuntimeAgentResponse::Error {
+                                error,
+                            }) => {
                                 reset_starting_state(room).await;
                                 NotebookResponse::Error {
                                     error: format!("Agent kernel launch failed: {}", error),
@@ -4607,7 +4632,7 @@ async fn handle_notebook_request(
                             Ok(_) => {
                                 reset_starting_state(room).await;
                                 NotebookResponse::Error {
-                                    error: "Unexpected agent response".to_string(),
+                                    error: "Unexpected runtime agent response".to_string(),
                                 }
                             }
                             Err(e) => {
@@ -4621,7 +4646,7 @@ async fn handle_notebook_request(
                     Err(e) => {
                         reset_starting_state(room).await;
                         NotebookResponse::Error {
-                            error: format!("Failed to spawn agent: {}", e),
+                            error: format!("Failed to spawn runtime agent: {}", e),
                         }
                     }
                 }
@@ -4663,13 +4688,13 @@ async fn handle_notebook_request(
             }
 
             // Agent-backed kernel: write execution to RuntimeStateDoc queue.
-            // The agent discovers it via CRDT sync and executes.
-            // Check agent_request_tx (not agent_handle) to ensure the agent's
+            // The runtime agent discovers it via CRDT sync and executes.
+            // Check runtime_agent_request_tx (not runtime_agent_handle) to ensure the runtime agent's
             // sync connection is still live — a stale handle with no connection
             // would leave queued executions orphaned.
             {
-                let has_agent = room.agent_request_tx.lock().await.is_some();
-                if has_agent {
+                let has_runtime_agent = room.runtime_agent_request_tx.lock().await.is_some();
+                if has_runtime_agent {
                     // Check if kernel is shut down — return NoKernel instead
                     // of silently queuing into a dead kernel
                     {
@@ -4749,7 +4774,7 @@ async fn handle_notebook_request(
                 }
             }
 
-            // No agent available — kernel not running
+            // No runtime agent available — kernel not running
             NotebookResponse::NoKernel {}
         }
 
@@ -4793,11 +4818,11 @@ async fn handle_notebook_request(
 
         NotebookRequest::InterruptExecution {} => {
             // Agent path: send RPC via sync connection
-            let has_agent = room.agent_request_tx.lock().await.is_some();
-            if has_agent {
-                match send_agent_request(
+            let has_runtime_agent = room.runtime_agent_request_tx.lock().await.is_some();
+            if has_runtime_agent {
+                match send_runtime_agent_request(
                     room,
-                    notebook_protocol::protocol::AgentRequest::InterruptExecution,
+                    notebook_protocol::protocol::RuntimeAgentRequest::InterruptExecution,
                 )
                 .await
                 {
@@ -4812,17 +4837,17 @@ async fn handle_notebook_request(
         }
 
         NotebookRequest::ShutdownKernel {} => {
-            // Send shutdown RPC but keep the agent alive — the agent stays
+            // Send shutdown RPC but keep the runtime agent alive — it stays
             // connected for potential RestartKernel. The kernel process dies
-            // but the agent subprocess and socket connection remain.
-            let has_agent = room.agent_request_tx.lock().await.is_some();
-            if has_agent {
-                let _ = send_agent_request(
+            // but the runtime agent subprocess and socket connection remain.
+            let has_runtime_agent = room.runtime_agent_request_tx.lock().await.is_some();
+            if has_runtime_agent {
+                let _ = send_runtime_agent_request(
                     room,
-                    notebook_protocol::protocol::AgentRequest::ShutdownKernel,
+                    notebook_protocol::protocol::RuntimeAgentRequest::ShutdownKernel,
                 )
                 .await;
-                // Keep agent alive (agent_handle + agent_request_tx stay set)
+                // Keep runtime agent alive (runtime_agent_handle + runtime_agent_request_tx stay set)
                 // so LaunchKernel can send RestartKernel. ExecuteCell/RunAllCells
                 // check kernel.status from RuntimeStateDoc and return NoKernel
                 // when status is "shutdown".
@@ -4844,7 +4869,7 @@ async fn handle_notebook_request(
         }
 
         NotebookRequest::GetKernelInfo {} => {
-            // Read from RuntimeStateDoc (source of truth in agent mode)
+            // Read from RuntimeStateDoc (source of truth for runtime agent)
             let sd = room.state_doc.read().await;
             let state = sd.read_state();
             if state.kernel.status != "not_started" && !state.kernel.status.is_empty() {
@@ -4871,7 +4896,7 @@ async fn handle_notebook_request(
         }
 
         NotebookRequest::GetQueueState {} => {
-            // Read from RuntimeStateDoc (source of truth in agent mode)
+            // Read from RuntimeStateDoc (source of truth for runtime agent)
             let sd = room.state_doc.read().await;
             let state = sd.read_state();
             NotebookResponse::QueueState {
@@ -4894,8 +4919,8 @@ async fn handle_notebook_request(
         NotebookRequest::RunAllCells {} => {
             // Agent path — write all cells to RuntimeStateDoc queue
             {
-                let has_agent = room.agent_request_tx.lock().await.is_some();
-                if has_agent {
+                let has_runtime_agent = room.runtime_agent_request_tx.lock().await.is_some();
+                if has_runtime_agent {
                     // Check if kernel is shut down
                     {
                         let sd = room.state_doc.read().await;
@@ -4941,17 +4966,17 @@ async fn handle_notebook_request(
                 }
             }
 
-            // No agent available — kernel not running
+            // No runtime agent available — kernel not running
             NotebookResponse::NoKernel {}
         }
 
         NotebookRequest::SendComm { message } => {
             // Agent path: forward comm message via RPC
-            let has_agent = room.agent_request_tx.lock().await.is_some();
-            if has_agent {
-                match send_agent_request(
+            let has_runtime_agent = room.runtime_agent_request_tx.lock().await.is_some();
+            if has_runtime_agent {
+                match send_runtime_agent_request(
                     room,
-                    notebook_protocol::protocol::AgentRequest::SendComm {
+                    notebook_protocol::protocol::RuntimeAgentRequest::SendComm {
                         message: message.clone(),
                     },
                 )
@@ -4969,11 +4994,11 @@ async fn handle_notebook_request(
 
         NotebookRequest::GetHistory { pattern, n, unique } => {
             // Agent path: forward via RPC
-            let has_agent = room.agent_request_tx.lock().await.is_some();
-            if has_agent {
-                match send_agent_request(
+            let has_runtime_agent = room.runtime_agent_request_tx.lock().await.is_some();
+            if has_runtime_agent {
+                match send_runtime_agent_request(
                     room,
-                    notebook_protocol::protocol::AgentRequest::GetHistory {
+                    notebook_protocol::protocol::RuntimeAgentRequest::GetHistory {
                         pattern: pattern.clone(),
                         n,
                         unique,
@@ -4981,14 +5006,14 @@ async fn handle_notebook_request(
                 )
                 .await
                 {
-                    Ok(notebook_protocol::protocol::AgentResponse::HistoryResult { entries }) => {
-                        NotebookResponse::HistoryResult { entries }
-                    }
-                    Ok(notebook_protocol::protocol::AgentResponse::Error { error }) => {
+                    Ok(notebook_protocol::protocol::RuntimeAgentResponse::HistoryResult {
+                        entries,
+                    }) => NotebookResponse::HistoryResult { entries },
+                    Ok(notebook_protocol::protocol::RuntimeAgentResponse::Error { error }) => {
                         NotebookResponse::Error { error }
                     }
                     Ok(_) => NotebookResponse::Error {
-                        error: "Unexpected agent response".to_string(),
+                        error: "Unexpected runtime agent response".to_string(),
                     },
                     Err(e) => NotebookResponse::Error {
                         error: format!("Agent error: {}", e),
@@ -5001,18 +5026,18 @@ async fn handle_notebook_request(
 
         NotebookRequest::Complete { code, cursor_pos } => {
             // Agent path: forward via RPC
-            let has_agent = room.agent_request_tx.lock().await.is_some();
-            if has_agent {
-                match send_agent_request(
+            let has_runtime_agent = room.runtime_agent_request_tx.lock().await.is_some();
+            if has_runtime_agent {
+                match send_runtime_agent_request(
                     room,
-                    notebook_protocol::protocol::AgentRequest::Complete {
+                    notebook_protocol::protocol::RuntimeAgentRequest::Complete {
                         code: code.clone(),
                         cursor_pos,
                     },
                 )
                 .await
                 {
-                    Ok(notebook_protocol::protocol::AgentResponse::CompletionResult {
+                    Ok(notebook_protocol::protocol::RuntimeAgentResponse::CompletionResult {
                         items,
                         cursor_start,
                         cursor_end,
@@ -5021,11 +5046,11 @@ async fn handle_notebook_request(
                         cursor_start,
                         cursor_end,
                     },
-                    Ok(notebook_protocol::protocol::AgentResponse::Error { error }) => {
+                    Ok(notebook_protocol::protocol::RuntimeAgentResponse::Error { error }) => {
                         NotebookResponse::Error { error }
                     }
                     Ok(_) => NotebookResponse::Error {
-                        error: "Unexpected agent response".to_string(),
+                        error: "Unexpected runtime agent response".to_string(),
                     },
                     Err(e) => NotebookResponse::Error {
                         error: format!("Agent error: {}", e),
@@ -5148,7 +5173,7 @@ async fn handle_notebook_request(
 async fn handle_sync_environment(room: &NotebookRoom) -> NotebookResponse {
     // Read launched config from room
     let launched = {
-        let guard = room.agent_launched_config.read().await;
+        let guard = room.runtime_agent_launched_config.read().await;
         match &*guard {
             Some(lc) => lc.clone(),
             None => {
@@ -5238,8 +5263,8 @@ async fn handle_sync_environment(room: &NotebookRoom) -> NotebookResponse {
         };
     }
 
-    // Send SyncEnvironment to the agent
-    let sync_request = notebook_protocol::protocol::AgentRequest::SyncEnvironment {
+    // Send SyncEnvironment to the runtime agent
+    let sync_request = notebook_protocol::protocol::RuntimeAgentRequest::SyncEnvironment {
         packages: packages_to_install.clone(),
     };
 
@@ -5256,11 +5281,13 @@ async fn handle_sync_environment(room: &NotebookRoom) -> NotebookResponse {
             }),
         });
 
-    match send_agent_request(room, sync_request).await {
-        Ok(notebook_protocol::protocol::AgentResponse::EnvironmentSynced { synced_packages }) => {
-            // Update agent_launched_config to include new packages
+    match send_runtime_agent_request(room, sync_request).await {
+        Ok(notebook_protocol::protocol::RuntimeAgentResponse::EnvironmentSynced {
+            synced_packages,
+        }) => {
+            // Update runtime_agent_launched_config to include new packages
             {
-                let mut lc = room.agent_launched_config.write().await;
+                let mut lc = room.runtime_agent_launched_config.write().await;
                 if let Some(ref mut config) = *lc {
                     // Promote prewarmed to uv:inline baseline if needed
                     if config.uv_deps.is_none() {
@@ -5293,14 +5320,14 @@ async fn handle_sync_environment(room: &NotebookRoom) -> NotebookResponse {
 
             NotebookResponse::SyncEnvironmentComplete { synced_packages }
         }
-        Ok(notebook_protocol::protocol::AgentResponse::Error { error }) => {
+        Ok(notebook_protocol::protocol::RuntimeAgentResponse::Error { error }) => {
             NotebookResponse::SyncEnvironmentFailed {
                 error,
                 needs_restart: true,
             }
         }
         Ok(_) => NotebookResponse::SyncEnvironmentFailed {
-            error: "Unexpected agent response".to_string(),
+            error: "Unexpected runtime agent response".to_string(),
             needs_restart: true,
         },
         Err(e) => NotebookResponse::SyncEnvironmentFailed {
@@ -8059,16 +8086,16 @@ mod tests {
             watcher_shutdown_tx: Mutex::new(None),
             state_doc,
             state_changed_tx,
-            agent_handle: Arc::new(Mutex::new(None)),
-            agent_env_path: Arc::new(RwLock::new(None)),
-            agent_launched_config: Arc::new(RwLock::new(None)),
-            agent_request_tx: Arc::new(Mutex::new(None)),
-            agent_connected_tx: {
+            runtime_agent_handle: Arc::new(Mutex::new(None)),
+            runtime_agent_env_path: Arc::new(RwLock::new(None)),
+            runtime_agent_launched_config: Arc::new(RwLock::new(None)),
+            runtime_agent_request_tx: Arc::new(Mutex::new(None)),
+            runtime_agent_connected_tx: {
                 let (tx, _) = tokio::sync::watch::channel(false);
                 Arc::new(tx)
             },
             next_queue_seq: Arc::new(std::sync::atomic::AtomicU64::new(0)),
-            current_agent_id: Arc::new(RwLock::new(None)),
+            current_runtime_agent_id: Arc::new(RwLock::new(None)),
         };
 
         (room, notebook_path)

--- a/crates/runtimed/src/runtime_agent.rs
+++ b/crates/runtimed/src/runtime_agent.rs
@@ -1,32 +1,33 @@
 //! Process-isolated runtime agent.
 //!
-//! The agent is a subprocess spawned by the coordinator (daemon) that owns
-//! the kernel lifecycle, IOPub processing, execution queue, and RuntimeStateDoc
-//! writes. It connects back to the daemon's Unix socket as a regular peer.
+//! The runtime agent is a subprocess spawned by the coordinator (daemon) that
+//! owns the kernel lifecycle, IOPub processing, execution queue, and
+//! RuntimeStateDoc writes. It connects back to the daemon's Unix socket as a
+//! regular peer.
 //!
 //! ## CRDT-driven execution
 //!
-//! The agent does NOT receive execution requests via RPC. Instead, the
-//! coordinator writes execution entries (with source code and sequence
-//! numbers) to RuntimeStateDoc. The agent discovers new entries via
-//! Automerge sync and executes them in seq order.
+//! The runtime agent does NOT receive execution requests via RPC. Instead, the
+//! coordinator writes execution entries (with source code and sequence numbers)
+//! to RuntimeStateDoc. The runtime agent discovers new entries via Automerge
+//! sync and executes them in seq order.
 //!
 //! ## Protocol
 //!
 //! Standard peer protocol over Unix socket:
 //! - Frame 0x00: AutomergeSync (NotebookDoc sync, for completions context)
-//! - Frame 0x01: AgentRequest (coordinator → agent, for LaunchKernel/Interrupt/etc.)
-//! - Frame 0x02: AgentResponse (agent → coordinator)
+//! - Frame 0x01: RuntimeAgentRequest (coordinator → runtime agent)
+//! - Frame 0x02: RuntimeAgentResponse (runtime agent → coordinator)
 //! - Frame 0x05: RuntimeStateSync (bidirectional, carries execution queue + outputs)
 //!
 //! ## Lifecycle
 //!
-//! 1. Agent connects to daemon socket, sends `Handshake::RuntimeAgent`
+//! 1. Runtime agent connects to daemon socket, sends `Handshake::RuntimeAgent`
 //! 2. Initial sync for NotebookDoc and RuntimeStateDoc
-//! 3. Agent waits for `LaunchKernel` RPC
+//! 3. Runtime agent waits for `LaunchKernel` RPC
 //! 4. Main select loop: socket frames, QueueCommands, RuntimeStateDoc changes
 //! 5. Watches for new `status=queued` execution entries after each sync
-//! 6. On shutdown or daemon disconnect, agent exits
+//! 6. On shutdown or daemon disconnect, runtime agent exits
 
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
@@ -39,14 +40,14 @@ use notebook_protocol::connection::{
     recv_typed_frame, send_json_frame, send_preamble, send_typed_frame, Handshake,
     NotebookFrameType,
 };
-use notebook_protocol::protocol::{AgentRequest, AgentResponse};
+use notebook_protocol::protocol::{RuntimeAgentRequest, RuntimeAgentResponse};
 use tokio::sync::{broadcast, RwLock};
 
 use crate::blob_store::BlobStore;
 use crate::kernel_manager::{QueueCommand, RoomKernel};
 
-/// Shared agent state passed to request/command handlers.
-struct AgentContext {
+/// Shared runtime agent state passed to request/command handlers.
+struct RuntimeAgentContext {
     kernel: Arc<tokio::sync::Mutex<Option<RoomKernel>>>,
     state_doc: Arc<RwLock<RuntimeStateDoc>>,
     state_changed_tx: broadcast::Sender<()>,
@@ -58,15 +59,15 @@ struct AgentContext {
 }
 
 /// Run the runtime agent, connecting to the daemon socket as a peer.
-pub async fn run_agent(
+pub async fn run_runtime_agent(
     socket_path: PathBuf,
     notebook_id: String,
-    agent_id: String,
+    runtime_agent_id: String,
     blob_root: PathBuf,
 ) -> anyhow::Result<()> {
     info!(
-        "[agent] Starting agent_id={} notebook_id={} socket={}",
-        agent_id,
+        "[runtime-agent] Starting runtime_agent_id={} notebook_id={} socket={}",
+        runtime_agent_id,
         notebook_id,
         socket_path.display()
     );
@@ -100,17 +101,17 @@ pub async fn run_agent(
         &mut writer,
         &Handshake::RuntimeAgent {
             notebook_id: notebook_id.clone(),
-            agent_id: agent_id.clone(),
+            runtime_agent_id: runtime_agent_id.clone(),
             blob_root: blob_root.display().to_string(),
         },
     )
     .await?;
 
-    info!("[agent] Connected to daemon, handshake sent");
+    info!("[runtime-agent] Connected to daemon, handshake sent");
 
     // ── 2. Bootstrap RuntimeStateDoc ───────────────────────────────────────
 
-    let state_doc = RuntimeStateDoc::new_with_actor(&agent_id);
+    let state_doc = RuntimeStateDoc::new_with_actor(&runtime_agent_id);
     let mut coordinator_sync_state = automerge::sync::State::new();
     let state_doc = Arc::new(RwLock::new(state_doc));
     let (state_changed_tx, mut state_changed_rx) = broadcast::channel::<()>(64);
@@ -123,7 +124,7 @@ pub async fn run_agent(
     let presence = Arc::new(RwLock::new(PresenceState::new()));
     let (presence_tx, _presence_rx) = broadcast::channel::<(String, Vec<u8>)>(16);
 
-    let ctx = AgentContext {
+    let ctx = RuntimeAgentContext {
         kernel: Arc::new(tokio::sync::Mutex::new(None)),
         state_doc,
         state_changed_tx,
@@ -136,7 +137,7 @@ pub async fn run_agent(
 
     let mut cmd_rx: Option<tokio::sync::mpsc::Receiver<QueueCommand>> = None;
 
-    info!("[agent] Infrastructure ready, entering main loop");
+    info!("[runtime-agent] Infrastructure ready, entering main loop");
 
     // ── 4. Main event loop ─────────────────────────────────────────────────
 
@@ -147,13 +148,13 @@ pub async fn run_agent(
                 match frame {
                     Ok(Some(typed_frame)) => {
                         match typed_frame.frame_type {
-                            // AgentRequest (RPC: LaunchKernel, Interrupt, etc.)
+                            // RuntimeAgentRequest RPC: LaunchKernel, Interrupt, etc.
                             NotebookFrameType::Request => {
-                                if let Ok(request) = serde_json::from_slice::<AgentRequest>(&typed_frame.payload) {
-                                    let response = handle_agent_request(request, &ctx).await;
+                                if let Ok(request) = serde_json::from_slice::<RuntimeAgentRequest>(&typed_frame.payload) {
+                                    let response = handle_runtime_agent_request(request, &ctx).await;
 
                                     // After launch/restart, take cmd_rx from kernel
-                                    if matches!(response, AgentResponse::KernelLaunched { .. } | AgentResponse::KernelRestarted { .. }) {
+                                    if matches!(response, RuntimeAgentResponse::KernelLaunched { .. } | RuntimeAgentResponse::KernelRestarted { .. }) {
                                         let mut guard = ctx.kernel.lock().await;
                                         if let Some(ref mut k) = *guard {
                                             cmd_rx = k.take_cmd_rx();
@@ -193,7 +194,7 @@ pub async fn run_agent(
                                                 if let Some(ref mut k) = *guard {
                                                     for (comm_id, delta) in &comm_updates {
                                                         if let Err(e) = k.send_comm_update(comm_id, delta.clone()).await {
-                                                            warn!("[agent] Failed to forward comm state to kernel: {}", e);
+                                                            warn!("[runtime-agent] Failed to forward comm state to kernel: {}", e);
                                                         }
                                                     }
                                                 }
@@ -213,13 +214,13 @@ pub async fn run_agent(
                                                             ).await {
                                                                 Ok(_) => {
                                                                     info!(
-                                                                        "[agent] Queued cell {} (execution {})",
+                                                                        "[runtime-agent] Queued cell {} (execution {})",
                                                                         exec.cell_id, eid
                                                                     );
                                                                 }
                                                                 Err(e) => {
                                                                     warn!(
-                                                                        "[agent] Failed to queue cell {}: {}",
+                                                                        "[runtime-agent] Failed to queue cell {}: {}",
                                                                         exec.cell_id, e
                                                                     );
                                                                 }
@@ -248,23 +249,23 @@ pub async fn run_agent(
 
                             // AutomergeSync (NotebookDoc — for completions context)
                             NotebookFrameType::AutomergeSync => {
-                                // The agent doesn't need NotebookDoc state for execution
+                                // The runtime agent doesn't need NotebookDoc state for execution
                                 // (source comes from execution entries), but it may be
                                 // useful for completions context in the future.
-                                debug!("[agent] Received NotebookDoc sync frame (ignored for now)");
+                                debug!("[runtime-agent] Received NotebookDoc sync frame (ignored for now)");
                             }
 
                             _ => {
-                                debug!("[agent] Ignoring frame type {:?}", typed_frame.frame_type);
+                                debug!("[runtime-agent] Ignoring frame type {:?}", typed_frame.frame_type);
                             }
                         }
                     }
                     Ok(None) => {
-                        info!("[agent] Daemon disconnected (EOF)");
+                        info!("[runtime-agent] Daemon disconnected (EOF)");
                         break;
                     }
                     Err(e) => {
-                        info!("[agent] Socket read error: {}", e);
+                        info!("[runtime-agent] Socket read error: {}", e);
                         break;
                     }
                 }
@@ -278,7 +279,7 @@ pub async fn run_agent(
                 }
             } => {
                 if let Err(e) = handle_queue_command(command, &ctx).await {
-                    warn!("[agent] Error handling queue command: {}", e);
+                    warn!("[runtime-agent] Error handling queue command: {}", e);
                 }
             }
 
@@ -294,7 +295,7 @@ pub async fn run_agent(
                         NotebookFrameType::RuntimeStateSync,
                         &encoded,
                     ).await {
-                        warn!("[agent] Failed to send RuntimeStateSync: {}", e);
+                        warn!("[runtime-agent] Failed to send RuntimeStateSync: {}", e);
                         break;
                     }
                 }
@@ -304,7 +305,7 @@ pub async fn run_agent(
 
     // ── 5. Cleanup ─────────────────────────────────────────────────────────
 
-    info!("[agent] Shutting down");
+    info!("[runtime-agent] Shutting down");
     let mut guard = ctx.kernel.lock().await;
     if let Some(ref mut k) = *guard {
         k.shutdown().await.ok();
@@ -313,14 +314,17 @@ pub async fn run_agent(
     Ok(())
 }
 
-/// Handle an AgentRequest and return an AgentResponse.
+/// Handle a `RuntimeAgentRequest` and return a `RuntimeAgentResponse`.
 ///
 /// Note: ExecuteCell is NOT handled here — execution is CRDT-driven.
 /// The coordinator writes execution entries to RuntimeStateDoc, and the
-/// agent picks them up via sync.
-async fn handle_agent_request(request: AgentRequest, ctx: &AgentContext) -> AgentResponse {
+/// runtime agent picks them up via sync.
+async fn handle_runtime_agent_request(
+    request: RuntimeAgentRequest,
+    ctx: &RuntimeAgentContext,
+) -> RuntimeAgentResponse {
     match request {
-        AgentRequest::LaunchKernel {
+        RuntimeAgentRequest::LaunchKernel {
             kernel_type,
             env_source,
             notebook_path,
@@ -328,7 +332,7 @@ async fn handle_agent_request(request: AgentRequest, ctx: &AgentContext) -> Agen
             env_vars: _,
         } => {
             info!(
-                "[agent] LaunchKernel: type={} source={}",
+                "[runtime-agent] LaunchKernel: type={} source={}",
                 kernel_type, env_source
             );
 
@@ -373,15 +377,15 @@ async fn handle_agent_request(request: AgentRequest, ctx: &AgentContext) -> Agen
                     let es = k.env_source().to_string();
                     let mut guard = ctx.kernel.lock().await;
                     *guard = Some(k);
-                    AgentResponse::KernelLaunched { env_source: es }
+                    RuntimeAgentResponse::KernelLaunched { env_source: es }
                 }
-                Err(e) => AgentResponse::Error {
+                Err(e) => RuntimeAgentResponse::Error {
                     error: format!("Failed to launch kernel: {}", e),
                 },
             }
         }
 
-        AgentRequest::RestartKernel {
+        RuntimeAgentRequest::RestartKernel {
             kernel_type,
             env_source,
             notebook_path,
@@ -389,7 +393,7 @@ async fn handle_agent_request(request: AgentRequest, ctx: &AgentContext) -> Agen
             env_vars: _,
         } => {
             info!(
-                "[agent] RestartKernel: type={} source={}",
+                "[runtime-agent] RestartKernel: type={} source={}",
                 kernel_type, env_source
             );
 
@@ -449,100 +453,102 @@ async fn handle_agent_request(request: AgentRequest, ctx: &AgentContext) -> Agen
                     let es = k.env_source().to_string();
                     let mut guard = ctx.kernel.lock().await;
                     *guard = Some(k);
-                    AgentResponse::KernelRestarted { env_source: es }
+                    RuntimeAgentResponse::KernelRestarted { env_source: es }
                 }
-                Err(e) => AgentResponse::Error {
+                Err(e) => RuntimeAgentResponse::Error {
                     error: format!("Failed to restart kernel: {}", e),
                 },
             }
         }
 
-        AgentRequest::InterruptExecution => {
+        RuntimeAgentRequest::InterruptExecution => {
             let mut guard = ctx.kernel.lock().await;
             if let Some(ref mut k) = *guard {
                 match k.interrupt().await {
-                    Ok(()) => AgentResponse::Ok,
-                    Err(e) => AgentResponse::Error {
+                    Ok(()) => RuntimeAgentResponse::Ok,
+                    Err(e) => RuntimeAgentResponse::Error {
                         error: format!("Failed to interrupt: {}", e),
                     },
                 }
             } else {
-                AgentResponse::Error {
+                RuntimeAgentResponse::Error {
                     error: "No kernel running".to_string(),
                 }
             }
         }
 
-        AgentRequest::ShutdownKernel => {
+        RuntimeAgentRequest::ShutdownKernel => {
             let mut guard = ctx.kernel.lock().await;
             if let Some(ref mut k) = *guard {
                 k.shutdown().await.ok();
                 *guard = None;
-                AgentResponse::Ok
+                RuntimeAgentResponse::Ok
             } else {
-                AgentResponse::Ok
+                RuntimeAgentResponse::Ok
             }
         }
 
-        AgentRequest::SendComm { message } => {
+        RuntimeAgentRequest::SendComm { message } => {
             let mut guard = ctx.kernel.lock().await;
             if let Some(ref mut k) = *guard {
                 match k.send_comm_message(message).await {
-                    Ok(()) => AgentResponse::Ok,
-                    Err(e) => AgentResponse::Error {
+                    Ok(()) => RuntimeAgentResponse::Ok,
+                    Err(e) => RuntimeAgentResponse::Error {
                         error: format!("Failed to send comm: {}", e),
                     },
                 }
             } else {
-                AgentResponse::Error {
+                RuntimeAgentResponse::Error {
                     error: "No kernel running".to_string(),
                 }
             }
         }
 
-        AgentRequest::Complete { code, cursor_pos } => {
+        RuntimeAgentRequest::Complete { code, cursor_pos } => {
             let mut guard = ctx.kernel.lock().await;
             if let Some(ref mut k) = *guard {
                 match k.complete(code, cursor_pos).await {
-                    Ok((items, cursor_start, cursor_end)) => AgentResponse::CompletionResult {
-                        items,
-                        cursor_start,
-                        cursor_end,
-                    },
-                    Err(e) => AgentResponse::Error {
+                    Ok((items, cursor_start, cursor_end)) => {
+                        RuntimeAgentResponse::CompletionResult {
+                            items,
+                            cursor_start,
+                            cursor_end,
+                        }
+                    }
+                    Err(e) => RuntimeAgentResponse::Error {
                         error: format!("Failed to complete: {}", e),
                     },
                 }
             } else {
-                AgentResponse::Error {
+                RuntimeAgentResponse::Error {
                     error: "No kernel running".to_string(),
                 }
             }
         }
 
-        AgentRequest::GetHistory { pattern, n, unique } => {
+        RuntimeAgentRequest::GetHistory { pattern, n, unique } => {
             let mut guard = ctx.kernel.lock().await;
             if let Some(ref mut k) = *guard {
                 match k.get_history(pattern, n, unique).await {
-                    Ok(entries) => AgentResponse::HistoryResult { entries },
-                    Err(e) => AgentResponse::Error {
+                    Ok(entries) => RuntimeAgentResponse::HistoryResult { entries },
+                    Err(e) => RuntimeAgentResponse::Error {
                         error: format!("Failed to get history: {}", e),
                     },
                 }
             } else {
-                AgentResponse::Error {
+                RuntimeAgentResponse::Error {
                     error: "No kernel running".to_string(),
                 }
             }
         }
 
-        AgentRequest::SyncEnvironment { packages } => {
-            info!("[agent] SyncEnvironment: installing {:?}", packages);
+        RuntimeAgentRequest::SyncEnvironment { packages } => {
+            info!("[runtime-agent] SyncEnvironment: installing {:?}", packages);
             let guard = ctx.kernel.lock().await;
             if let Some(ref kernel) = *guard {
                 let es = kernel.env_source().to_string();
                 if !es.starts_with("uv:") {
-                    return AgentResponse::Error {
+                    return RuntimeAgentResponse::Error {
                         error: "Hot-sync only supported for UV environments".to_string(),
                     };
                 }
@@ -552,7 +558,7 @@ async fn handle_agent_request(request: AgentRequest, ctx: &AgentContext) -> Agen
                 let venv_path = match &launched.venv_path {
                     Some(p) => p.clone(),
                     None => {
-                        return AgentResponse::Error {
+                        return RuntimeAgentResponse::Error {
                             error: "No venv path available".to_string(),
                         };
                     }
@@ -560,7 +566,7 @@ async fn handle_agent_request(request: AgentRequest, ctx: &AgentContext) -> Agen
                 let python_path = match &launched.python_path {
                     Some(p) => p.clone(),
                     None => {
-                        return AgentResponse::Error {
+                        return RuntimeAgentResponse::Error {
                             error: "No python path available".to_string(),
                         };
                     }
@@ -574,15 +580,15 @@ async fn handle_agent_request(request: AgentRequest, ctx: &AgentContext) -> Agen
                 };
 
                 match kernel_env::uv::sync_dependencies(&uv_env, &packages).await {
-                    Ok(()) => AgentResponse::EnvironmentSynced {
+                    Ok(()) => RuntimeAgentResponse::EnvironmentSynced {
                         synced_packages: packages,
                     },
-                    Err(e) => AgentResponse::Error {
+                    Err(e) => RuntimeAgentResponse::Error {
                         error: format!("Failed to install packages: {}", e),
                     },
                 }
             } else {
-                AgentResponse::Error {
+                RuntimeAgentResponse::Error {
                     error: "No kernel running".to_string(),
                 }
             }
@@ -591,17 +597,23 @@ async fn handle_agent_request(request: AgentRequest, ctx: &AgentContext) -> Agen
 }
 
 /// Handle a QueueCommand from the kernel's IOPub/shell/heartbeat tasks.
-async fn handle_queue_command(command: QueueCommand, ctx: &AgentContext) -> anyhow::Result<()> {
+async fn handle_queue_command(
+    command: QueueCommand,
+    ctx: &RuntimeAgentContext,
+) -> anyhow::Result<()> {
     match command {
         QueueCommand::ExecutionDone {
             cell_id,
             execution_id,
         } => {
-            debug!("[agent] ExecutionDone for {} ({})", cell_id, execution_id);
+            debug!(
+                "[runtime-agent] ExecutionDone for {} ({})",
+                cell_id, execution_id
+            );
             let mut guard = ctx.kernel.lock().await;
             if let Some(ref mut k) = *guard {
                 if let Err(e) = k.execution_done(&cell_id, &execution_id).await {
-                    warn!("[agent] execution_done error: {}", e);
+                    warn!("[runtime-agent] execution_done error: {}", e);
                 }
             }
         }
@@ -611,7 +623,7 @@ async fn handle_queue_command(command: QueueCommand, ctx: &AgentContext) -> anyh
             execution_id,
         } => {
             debug!(
-                "[agent] CellError: cell={} execution={}",
+                "[runtime-agent] CellError: cell={} execution={}",
                 cell_id, execution_id
             );
             let mut guard = ctx.kernel.lock().await;
@@ -628,7 +640,7 @@ async fn handle_queue_command(command: QueueCommand, ctx: &AgentContext) -> anyh
         }
 
         QueueCommand::KernelDied => {
-            warn!("[agent] Kernel died");
+            warn!("[runtime-agent] Kernel died");
             let mut sd = ctx.state_doc.write().await;
             sd.set_kernel_status("error");
             sd.set_queue(None, &[]);
@@ -639,7 +651,7 @@ async fn handle_queue_command(command: QueueCommand, ctx: &AgentContext) -> anyh
             let mut guard = ctx.kernel.lock().await;
             if let Some(ref mut k) = *guard {
                 if let Err(e) = k.send_comm_update(&comm_id, state).await {
-                    warn!("[agent] Failed to send comm update: {}", e);
+                    warn!("[runtime-agent] Failed to send comm update: {}", e);
                 }
             }
         }

--- a/crates/runtimed/src/runtime_agent_handle.rs
+++ b/crates/runtimed/src/runtime_agent_handle.rs
@@ -1,8 +1,9 @@
 //! Coordinator-side management of a runtime agent subprocess.
 //!
-//! `AgentHandle` spawns a `runtimed agent` child process that connects back
-//! to the daemon's Unix socket as a regular peer. The handle only monitors
-//! the child process lifecycle — all communication happens via the socket.
+//! `RuntimeAgentHandle` spawns a `runtimed runtime-agent` child process that
+//! connects back to the daemon's Unix socket as a regular peer. The handle
+//! only monitors the child process lifecycle — all communication happens via
+//! the socket.
 
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -11,41 +12,41 @@ use std::sync::Arc;
 use anyhow::Result;
 use log::{info, warn};
 
-/// Handle to a running agent subprocess.
+/// Handle to a running runtime agent subprocess.
 ///
-/// The agent connects back to the daemon's Unix socket as a peer.
+/// The runtime agent connects back to the daemon's Unix socket as a peer.
 /// This handle only spawns and monitors the child process — it does
 /// not manage any communication channels.
-pub struct AgentHandle {
+pub struct RuntimeAgentHandle {
     alive: Arc<AtomicBool>,
 }
 
-impl AgentHandle {
-    /// Spawn an agent subprocess that will connect back to the daemon socket.
+impl RuntimeAgentHandle {
+    /// Spawn a runtime agent subprocess that will connect back to the daemon socket.
     ///
-    /// The agent is given the socket path, notebook ID, agent ID, and blob root
-    /// as CLI arguments. It connects to the daemon socket and joins the notebook
-    /// room as a `RuntimeAgent` peer.
+    /// The runtime agent is given the socket path, notebook ID, runtime agent ID,
+    /// and blob root as CLI arguments. It connects to the daemon socket and joins
+    /// the notebook room as a `RuntimeAgent` peer.
     pub async fn spawn(
         notebook_id: String,
-        agent_id: String,
+        runtime_agent_id: String,
         blob_root: PathBuf,
         socket_path: PathBuf,
     ) -> Result<Self> {
         let exe = std::env::current_exe()?;
         info!(
-            "[agent-handle] Spawning agent: {} agent --notebook-id {} (socket: {})",
+            "[runtime-agent-handle] Spawning runtime agent: {} runtime-agent --notebook-id {} (socket: {})",
             exe.display(),
             notebook_id,
             socket_path.display(),
         );
 
         let mut child = tokio::process::Command::new(&exe)
-            .arg("agent")
+            .arg("runtime-agent")
             .arg("--notebook-id")
             .arg(&notebook_id)
-            .arg("--agent-id")
-            .arg(&agent_id)
+            .arg("--runtime-agent-id")
+            .arg(&runtime_agent_id)
             .arg("--blob-root")
             .arg(blob_root.as_os_str())
             .arg("--socket")
@@ -56,23 +57,29 @@ impl AgentHandle {
             .kill_on_drop(true)
             .spawn()?;
 
-        info!("[agent-handle] Agent spawned (pid={:?})", child.id());
+        info!(
+            "[runtime-agent-handle] Runtime agent spawned (pid={:?})",
+            child.id()
+        );
 
         let alive = Arc::new(AtomicBool::new(true));
 
         // Monitor child process exit
         let alive_clone = alive.clone();
-        let agent_id_clone = agent_id.clone();
+        let runtime_agent_id_clone = runtime_agent_id.clone();
         tokio::spawn(async move {
             match child.wait().await {
                 Ok(status) => {
                     info!(
-                        "[agent-handle] Agent {} exited with status: {}",
-                        agent_id_clone, status
+                        "[runtime-agent-handle] Runtime agent {} exited with status: {}",
+                        runtime_agent_id_clone, status
                     );
                 }
                 Err(e) => {
-                    warn!("[agent-handle] Agent {} wait error: {}", agent_id_clone, e);
+                    warn!(
+                        "[runtime-agent-handle] Runtime agent {} wait error: {}",
+                        runtime_agent_id_clone, e
+                    );
                 }
             }
             alive_clone.store(false, Ordering::Relaxed);
@@ -81,7 +88,7 @@ impl AgentHandle {
         Ok(Self { alive })
     }
 
-    /// Check if the agent process is still running.
+    /// Check if the runtime agent process is still running.
     pub fn is_alive(&self) -> bool {
         self.alive.load(Ordering::Relaxed)
     }

--- a/crates/runtimed/tests/integration.rs
+++ b/crates/runtimed/tests/integration.rs
@@ -1333,17 +1333,17 @@ async fn test_pipe_mode_preserves_frame_order() {
     let _ = tokio::time::timeout(Duration::from_secs(2), daemon_handle).await;
 }
 
-/// Test that agent mode spawns a subprocess and can dispatch cell execution.
+/// Test that runtime agent mode spawns a subprocess and can dispatch cell execution.
 ///
-/// Sets RUNT_AGENT_MODE=1, creates a notebook, connects, and verifies
-/// the agent mode code path is exercised. Note: actual kernel execution
+/// Sets RUNT_RUNTIME_AGENT_MODE=1, creates a notebook, connects, and verifies
+/// the runtime agent code path is exercised. Note: actual kernel execution
 /// requires a Python env (pool size is 0 in test config), so we verify
 /// the dispatch path rather than full execution.
 #[tokio::test]
 #[cfg(unix)]
-async fn test_agent_mode_dispatch() {
-    // Enable agent mode for this test
-    std::env::set_var("RUNT_AGENT_MODE", "1");
+async fn test_runtime_agent_dispatch() {
+    // Enable runtime agent mode for this test
+    std::env::set_var("RUNT_RUNTIME_AGENT_MODE", "1");
 
     let temp_dir = TempDir::new().unwrap();
     let config = test_config(&temp_dir);
@@ -1365,7 +1365,9 @@ async fn test_agent_mode_dispatch() {
 
     // Add a cell
     client.add_cell_after("c1", "code", None).unwrap();
-    client.update_source("c1", "print('agent test')").unwrap();
+    client
+        .update_source("c1", "print('runtime agent test')")
+        .unwrap();
 
     // Wait for sync
     let mut watcher = client.subscribe();
@@ -1382,7 +1384,7 @@ async fn test_agent_mode_dispatch() {
     assert_eq!(cells[0].id, "c1");
 
     // Try to execute — may fail with NoKernel since pool is empty,
-    // but the agent dispatch path should be exercised
+    // but the runtime agent dispatch path should be exercised
     let response = client
         .send_request(NotebookRequest::ExecuteCell {
             cell_id: "c1".to_string(),
@@ -1390,23 +1392,23 @@ async fn test_agent_mode_dispatch() {
         .await
         .unwrap();
 
-    // With pool_size=0, we expect NoKernel (no env to give the agent)
-    // or an error from the agent failing to launch.
+    // With pool_size=0, we expect NoKernel (no env to give the runtime agent)
+    // or an error from the runtime agent failing to launch.
     // The important thing is we didn't panic.
     match &response {
         NotebookResponse::CellQueued { .. } => {
-            // Agent launched and queued — great!
+            // Runtime agent launched and queued — great!
         }
         NotebookResponse::NoKernel {} | NotebookResponse::Error { .. } => {
-            // Expected with empty pool — agent couldn't get an env
+            // Expected with empty pool — runtime agent couldn't get an env
         }
         _ => {
-            panic!("Unexpected response in agent mode: {:?}", response);
+            panic!("Unexpected response in runtime agent mode: {:?}", response);
         }
     }
 
     // Cleanup
-    std::env::remove_var("RUNT_AGENT_MODE");
+    std::env::remove_var("RUNT_RUNTIME_AGENT_MODE");
     pool_client.shutdown().await.ok();
     let _ = tokio::time::timeout(Duration::from_secs(2), daemon_handle).await;
 }


### PR DESCRIPTION
## Summary

- Renames the runtime agent subprocess from "Agent" to "RuntimeAgent" across the entire codebase to disambiguate from AI agents (Claude, gremlin, MCP clients) that are first-class users of the system
- File renames: `agent.rs` → `runtime_agent.rs`, `agent_handle.rs` → `runtime_agent_handle.rs`
- Type renames: `AgentRequest` → `RuntimeAgentRequest`, `AgentResponse` → `RuntimeAgentResponse`, `AgentHandle` → `RuntimeAgentHandle`, etc.
- CLI subcommand: `runtimed agent` → `runtimed runtime-agent`
- CRDT key: `kernel.agent_id` → `kernel.runtime_agent_id` (safe — RuntimeStateDoc is ephemeral, scaffolded fresh each daemon session)
- AI agent references (gremlin, MCP `peer_label`, docs about Claude/Zed agents) are intentionally preserved

## Test plan

- [x] `cargo check --workspace` passes
- [x] `cargo xtask lint --fix` clean
- [ ] CI passes (Rust build, clippy, tests)
- [ ] Manual smoke test: launch notebook, execute cells, verify runtime agent subprocess spawns and connects