### PR TITLE
fix(sync): stabilize flaky queue dedup and output sync tests

### DIFF
--- a/crates/notebook-sync/src/handle.rs
+++ b/crates/notebook-sync/src/handle.rs
@@ -575,6 +575,19 @@ impl DocHandle {
         reply_rx.await.map_err(|_| SyncError::Disconnected)?
     }
 
+    /// Flush pending RuntimeStateDoc sync frames from the daemon.
+    ///
+    /// Call before reading RuntimeStateDoc state to ensure the local
+    /// replica reflects the daemon's latest writes.
+    pub async fn confirm_state_sync(&self) -> Result<(), SyncError> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.cmd_tx
+            .send(SyncCommand::ConfirmStateSync { reply: reply_tx })
+            .await
+            .map_err(|_| SyncError::Disconnected)?;
+        reply_rx.await.map_err(|_| SyncError::Disconnected)?
+    }
+
     /// Get all connected peer IDs and labels, sorted by peer ID for stable ordering.
     pub fn get_peers(&self) -> Vec<(String, String)> {
         let state = self.doc.lock().unwrap_or_else(|e| e.into_inner());

--- a/crates/notebook-sync/src/sync_task.rs
+++ b/crates/notebook-sync/src/sync_task.rs
@@ -77,6 +77,15 @@ pub enum SyncCommand {
         reply: oneshot::Sender<Result<(), SyncError>>,
     },
 
+    /// Flush pending RuntimeStateDoc sync frames from the daemon.
+    ///
+    /// Generates and sends a state sync message, then drains incoming
+    /// frames until a short timeout. Since the client is read-only for
+    /// the state doc, this is a flush — not a convergence handshake.
+    ConfirmStateSync {
+        reply: oneshot::Sender<Result<(), SyncError>>,
+    },
+
     /// Send a raw presence frame to the daemon.
     SendPresence {
         data: Vec<u8>,
@@ -254,6 +263,19 @@ where
 
                     SyncCommand::ConfirmSync { reply } => {
                         let result = confirm_sync_impl(
+                            &config.doc,
+                            &mut reader,
+                            &mut writer,
+                            &config.snapshot_tx,
+                            &config.broadcast_tx,
+                            &notebook_id,
+                        )
+                        .await;
+                        let _ = reply.send(result);
+                    }
+
+                    SyncCommand::ConfirmStateSync { reply } => {
+                        let result = confirm_state_sync_impl(
                             &config.doc,
                             &mut reader,
                             &mut writer,
@@ -787,6 +809,49 @@ async fn confirm_sync_impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
         "[notebook-sync] confirm_sync: heads not fully confirmed after 5 rounds for {}",
         notebook_id
     );
+    Ok(())
+}
+
+/// Flush pending RuntimeStateDoc sync frames.
+///
+/// The client never writes to the state doc, so there is no convergence
+/// to negotiate. We send our current heads (so the daemon can reply with
+/// anything we're missing) and then drain frames with a short timeout.
+async fn confirm_state_sync_impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
+    doc: &Arc<Mutex<SharedDocState>>,
+    reader: &mut R,
+    writer: &mut W,
+    snapshot_tx: &Arc<tokio::sync::watch::Sender<NotebookSnapshot>>,
+    broadcast_tx: &broadcast::Sender<NotebookBroadcast>,
+    notebook_id: &str,
+) -> Result<(), SyncError> {
+    // Send our state doc heads so the daemon knows what we have.
+    let msg_bytes = {
+        let mut state = doc.lock().unwrap_or_else(|e| e.into_inner());
+        state.generate_state_sync_message().map(|m| m.encode())
+    };
+    if let Some(bytes) = msg_bytes {
+        connection::send_typed_frame(writer, NotebookFrameType::RuntimeStateSync, &bytes)
+            .await
+            .map_err(SyncError::Io)?;
+    }
+
+    // Drain up to 10 frames with a 200ms per-frame timeout.
+    for _ in 0..10 {
+        match tokio::time::timeout(
+            Duration::from_millis(200),
+            connection::recv_typed_frame(reader),
+        )
+        .await
+        {
+            Ok(Ok(Some(frame))) => {
+                handle_incoming_frame(&frame, doc, writer, snapshot_tx, broadcast_tx, notebook_id)
+                    .await;
+            }
+            _ => break, // timeout, EOF, or error — done draining
+        }
+    }
+
     Ok(())
 }
 

--- a/crates/notebook-sync/src/sync_task.rs
+++ b/crates/notebook-sync/src/sync_task.rs
@@ -848,7 +848,15 @@ async fn confirm_state_sync_impl<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
                 handle_incoming_frame(&frame, doc, writer, snapshot_tx, broadcast_tx, notebook_id)
                     .await;
             }
-            _ => break, // timeout, EOF, or error — done draining
+            Ok(Ok(None)) => {
+                return Err(SyncError::Protocol(
+                    "Connection closed during state sync flush".into(),
+                ));
+            }
+            Ok(Err(e)) => {
+                return Err(SyncError::Io(e));
+            }
+            Err(_) => break, // timeout — done draining
         }
     }
 

--- a/crates/runtimed-py/src/session_core.rs
+++ b/crates/runtimed-py/src/session_core.rs
@@ -1407,6 +1407,7 @@ pub(crate) async fn collect_outputs(
             .ok_or_else(|| to_py_err("Not connected"))?;
 
         handle.confirm_sync().await.map_err(to_py_err)?;
+        handle.confirm_state_sync().await.map_err(to_py_err)?;
 
         let snap = handle.get_cell(cell_id).ok_or_else(|| {
             to_py_err(format!(

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -4711,8 +4711,11 @@ async fn handle_notebook_request(
                     // NotebookDoc owns the cell→execution_id mapping,
                     // RuntimeStateDoc owns execution lifecycle state.
                     {
-                        let doc = room.doc.read().await;
-                        if let Some(eid) = doc.get_execution_id(&cell_id) {
+                        let eid = {
+                            let doc = room.doc.read().await;
+                            doc.get_execution_id(&cell_id)
+                        };
+                        if let Some(eid) = eid {
                             let sd = room.state_doc.read().await;
                             if let Some(exec) = sd.get_execution(&eid) {
                                 if exec.status == "queued" || exec.status == "running" {

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -4705,18 +4705,23 @@ async fn handle_notebook_request(
                         }
                     }
 
-                    // Idempotency: if the cell already has a queued execution,
-                    // return the existing execution_id instead of creating a new one.
+                    // Idempotency: if the cell already has an active (queued or
+                    // running) execution, return the existing execution_id instead
+                    // of creating a new one. Lookup follows the ownership model:
+                    // NotebookDoc owns the cell→execution_id mapping,
+                    // RuntimeStateDoc owns execution lifecycle state.
                     {
-                        let sd = room.state_doc.read().await;
-                        let queued = sd.get_queued_executions();
-                        if let Some((eid, _)) =
-                            queued.iter().find(|(_, exec)| exec.cell_id == cell_id)
-                        {
-                            return NotebookResponse::CellQueued {
-                                cell_id,
-                                execution_id: eid.clone(),
-                            };
+                        let doc = room.doc.read().await;
+                        if let Some(eid) = doc.get_execution_id(&cell_id) {
+                            let sd = room.state_doc.read().await;
+                            if let Some(exec) = sd.get_execution(&eid) {
+                                if exec.status == "queued" || exec.status == "running" {
+                                    return NotebookResponse::CellQueued {
+                                        cell_id,
+                                        execution_id: eid,
+                                    };
+                                }
+                            }
                         }
                     }
 


### PR DESCRIPTION
## Summary

Fixes two flaky integration tests with real timing bugs — not transient infra issues.

- **`test_idempotent_queue_returns_same_execution_id`** — The dedup check only matched `status=="queued"`. If the kernel picks up the cell between two `queue()` calls (transitioning to "running"), the second queue creates a new execution_id. Fixed by looking up the cell's `execution_id` from NotebookDoc → checking RuntimeStateDoc for "queued" or "running", following the ownership model.

- **`test_progress_bar_simulation`** — `confirm_sync()` only syncs the NotebookDoc (frame `0x00`). If it's already converged, it returns immediately without reading pending RuntimeStateSync frames (`0x05`) in the socket buffer. `collect_outputs` then reads stale terminal emulator state. Fixed by adding `ConfirmStateSync` — a drain-style flush that sends our state doc heads and reads pending frames — called in `collect_outputs` Phase 2 before reading outputs.

## Test plan

- [x] `cargo check -p notebook-sync -p runtimed -p runtimed-py` — compiles clean
- [x] `cargo xtask lint --fix` — no new warnings
- [x] Full integration suite passes (102/102, only pre-existing `test_async_shared_kernel_execution` timeout)
- [x] Both target tests pass across two independent full suite runs
- [ ] CI green