### PR TITLE
feat(isolated-renderer): migrate plotly to renderer plugin API

### DIFF
--- a/apps/notebook/src/vite-env.d.ts
+++ b/apps/notebook/src/vite-env.d.ts
@@ -14,3 +14,8 @@ declare module "virtual:renderer-plugin/vega" {
   export const code: string;
   export const css: string;
 }
+
+declare module "virtual:renderer-plugin/plotly" {
+  export const code: string;
+  export const css: string;
+}

--- a/apps/notebook/vite-plugin-isolated-renderer.ts
+++ b/apps/notebook/vite-plugin-isolated-renderer.ts
@@ -56,6 +56,10 @@ export function isolatedRendererPlugin(
     __dirname,
     "../../src/isolated-renderer/vega-renderer.tsx",
   );
+  const plotlyEntry = path.resolve(
+    __dirname,
+    "../../src/isolated-renderer/plotly-renderer.tsx",
+  );
 
   let rendererCode = "";
   let rendererCss = "";
@@ -63,6 +67,8 @@ export function isolatedRendererPlugin(
   let markdownRendererCss = "";
   let vegaRendererCode = "";
   let vegaRendererCss = "";
+  let plotlyRendererCode = "";
+  let plotlyRendererCss = "";
   let buildPromise: Promise<void> | null = null;
 
   // Directories to watch for changes that should trigger rebuild
@@ -80,6 +86,8 @@ export function isolatedRendererPlugin(
     markdownRendererCss = "";
     vegaRendererCode = "";
     vegaRendererCss = "";
+    plotlyRendererCode = "";
+    plotlyRendererCss = "";
   }
 
   /** Build a renderer plugin as CJS with React externalized. */
@@ -275,14 +283,17 @@ export function isolatedRendererPlugin(
     }
 
     // --- Build renderer plugins (CJS, React externalized) ---
-    const [markdownPlugin, vegaPlugin] = await Promise.all([
+    const [markdownPlugin, vegaPlugin, plotlyPlugin] = await Promise.all([
       buildRendererPlugin(markdownEntry, "markdown-renderer", srcDir),
       buildRendererPlugin(vegaEntry, "vega-renderer", srcDir),
+      buildRendererPlugin(plotlyEntry, "plotly-renderer", srcDir),
     ]);
     markdownRendererCode = markdownPlugin.code;
     markdownRendererCss = markdownPlugin.css;
     vegaRendererCode = vegaPlugin.code;
     vegaRendererCss = vegaPlugin.css;
+    plotlyRendererCode = plotlyPlugin.code;
+    plotlyRendererCss = plotlyPlugin.css;
   }
 
   return {
@@ -339,6 +350,12 @@ export const css = ${JSON.stringify(markdownRendererCss)};
         return `
 export const code = ${JSON.stringify(vegaRendererCode)};
 export const css = ${JSON.stringify(vegaRendererCss)};
+`;
+      }
+      if (pluginName === "plotly") {
+        return `
+export const code = ${JSON.stringify(plotlyRendererCode)};
+export const css = ${JSON.stringify(plotlyRendererCss)};
 `;
       }
     },

--- a/src/components/isolated/iframe-libraries.ts
+++ b/src/components/isolated/iframe-libraries.ts
@@ -6,11 +6,11 @@
  * when an output actually needs them.
  *
  * Two injection mechanisms:
- * - **Renderer plugins** (markdown, vega): CJS modules loaded via
+ * - **Renderer plugins** (markdown, vega, plotly): CJS modules loaded via
  *   `frame.installRenderer()`. The iframe's plugin loader provides a shared React
  *   instance and a registration API. No globals needed.
- * - **Legacy eval libraries** (plotly, leaflet): Raw JS strings injected via
- *   `frame.eval()` that set window globals (e.g., `window.Plotly`). These will
+ * - **Legacy eval libraries** (leaflet): Raw JS strings injected via
+ *   `frame.eval()` that set window globals (e.g., `window.L`). These will
  *   migrate to the renderer plugin API in future PRs.
  */
 
@@ -29,7 +29,7 @@ const MIME_LIBRARIES: Record<string, string> = {
 };
 
 /** Libraries that use the renderer plugin API instead of legacy eval. */
-const RENDERER_PLUGINS = new Set(["markdown", "vega"]);
+const RENDERER_PLUGINS = new Set(["markdown", "vega", "plotly"]);
 
 function libraryForMime(mime: string): string | undefined {
   if (MIME_LIBRARIES[mime]) return MIME_LIBRARIES[mime];
@@ -54,8 +54,8 @@ function loadLibrary(name: string): Promise<{ code: string; css?: string }> {
         return { code, css: css || undefined };
       }
       case "plotly": {
-        const mod = await import("plotly-raw");
-        return { code: mod.default };
+        const { code, css } = await import("virtual:renderer-plugin/plotly");
+        return { code, css: css || undefined };
       }
       case "vega": {
         const { code, css } = await import("virtual:renderer-plugin/vega");

--- a/src/isolated-renderer/index.tsx
+++ b/src/isolated-renderer/index.tsx
@@ -43,7 +43,6 @@ import { JavaScriptOutput } from "@/components/outputs/javascript-output";
 import { JsonOutput } from "@/components/outputs/json-output";
 import { GeoJsonOutput } from "@/components/outputs/geojson-output";
 import { PdfOutput } from "@/components/outputs/pdf-output";
-import { PlotlyOutput } from "@/components/outputs/plotly-output";
 import { VideoOutput } from "@/components/outputs/video-output";
 import { SvgOutput } from "@/components/outputs/svg-output";
 import { WidgetView } from "@/components/widgets/widget-view";
@@ -479,13 +478,6 @@ function OutputRenderer({ payload }: { payload: RenderPayload }) {
   // JavaScript
   if (mimeType === "application/javascript") {
     return <JavaScriptOutput code={String(content)} />;
-  }
-
-  // Plotly
-  if (mimeType === "application/vnd.plotly.v1+json") {
-    const plotlyData =
-      typeof content === "string" ? JSON.parse(content) : content;
-    return <PlotlyOutput data={plotlyData} />;
   }
 
   // GeoJSON

--- a/src/isolated-renderer/plotly-renderer.tsx
+++ b/src/isolated-renderer/plotly-renderer.tsx
@@ -1,0 +1,149 @@
+/**
+ * Plotly Renderer Plugin
+ *
+ * On-demand renderer plugin for application/vnd.plotly.v1+json outputs.
+ * Bundles plotly.js directly — no window.Plotly global.
+ * Loaded into the isolated iframe via the renderer plugin API.
+ */
+
+import Plotly from "plotly.js-dist-min";
+import { useEffect, useRef } from "react";
+import { cn } from "@/lib/utils";
+
+// --- Theme helpers ---
+
+const DARK_TEXT = "rgba(200, 200, 200, 1)";
+const LIGHT_TEXT = "rgba(68, 68, 68, 1)";
+
+function darkLayoutOverrides(isDark: boolean): Record<string, unknown> {
+  const textColor = isDark ? DARK_TEXT : LIGHT_TEXT;
+  const gridColor = isDark
+    ? "rgba(255, 255, 255, 0.1)"
+    : "rgba(0, 0, 0, 0.1)";
+
+  return {
+    paper_bgcolor: "transparent",
+    plot_bgcolor: isDark ? "rgba(30, 30, 30, 1)" : "rgba(255, 255, 255, 1)",
+    font: { color: textColor },
+    xaxis: {
+      gridcolor: gridColor,
+      zerolinecolor: gridColor,
+      color: textColor,
+    },
+    yaxis: {
+      gridcolor: gridColor,
+      zerolinecolor: gridColor,
+      color: textColor,
+    },
+    legend: { font: { color: textColor } },
+    colorway: isDark
+      ? [
+          "#636efa",
+          "#ef553b",
+          "#00cc96",
+          "#ab63fa",
+          "#ffa15a",
+          "#19d3f3",
+          "#ff6692",
+          "#b6e880",
+          "#ff97ff",
+          "#fecb52",
+        ]
+      : undefined,
+  };
+}
+
+// --- Types ---
+
+interface PlotlyData {
+  data: unknown[];
+  layout?: Record<string, unknown>;
+  config?: Record<string, unknown>;
+  frames?: unknown[];
+}
+
+interface RendererProps {
+  data: unknown;
+  metadata?: Record<string, unknown>;
+  mimeType: string;
+}
+
+// --- PlotlyRenderer component ---
+
+function PlotlyRenderer({ data: rawData }: RendererProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const data =
+    typeof rawData === "string"
+      ? (JSON.parse(rawData) as PlotlyData)
+      : (rawData as PlotlyData);
+
+  useEffect(() => {
+    if (!containerRef.current || !data?.data) return;
+
+    const el = containerRef.current;
+    const isDark = document.documentElement.classList.contains("dark");
+
+    const layout: Record<string, unknown> = {
+      ...data.layout,
+      ...darkLayoutOverrides(isDark),
+      autosize: true,
+    };
+
+    const config: Record<string, unknown> = {
+      responsive: true,
+      displaylogo: false,
+      modeBarButtonsToRemove: ["toImage"],
+      ...data.config,
+    };
+
+    Plotly.newPlot(el, {
+      data: data.data as Plotly.Data[],
+      layout: layout as Partial<Plotly.Layout>,
+      config: config as Partial<Plotly.Config>,
+      frames: data.frames as Plotly.Frame[],
+    });
+
+    const resizeObserver = new ResizeObserver(() => {
+      Plotly.Plots.resize(el);
+    });
+    resizeObserver.observe(el);
+
+    const themeObserver = new MutationObserver(() => {
+      const nowDark = document.documentElement.classList.contains("dark");
+      Plotly.relayout(el, darkLayoutOverrides(nowDark));
+    });
+    themeObserver.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class"],
+    });
+
+    return () => {
+      resizeObserver.disconnect();
+      themeObserver.disconnect();
+      Plotly.purge(el);
+    };
+  }, [data]);
+
+  if (!data?.data) return null;
+
+  return (
+    <div
+      ref={containerRef}
+      data-slot="plotly-output"
+      className={cn("not-prose py-2 max-w-full")}
+      style={{ minHeight: 400 }}
+    />
+  );
+}
+
+// --- Plugin install ---
+
+export function install(ctx: {
+  register: (
+    mimeTypes: string[],
+    component: React.ComponentType<RendererProps>,
+  ) => void;
+}) {
+  ctx.register(["application/vnd.plotly.v1+json"], PlotlyRenderer);
+}


### PR DESCRIPTION
## Summary

Migrates Plotly rendering from the `window.Plotly` global to the renderer plugin API. The plotly plugin bundles `plotly.js-dist-min` directly via esbuild as a self-contained CJS module — no more raw UMD eval setting `window.Plotly`.

Follows the same pattern as markdown (#1519) and vega (#1521).

### Changes

- **New `plotly-renderer.tsx`** — Self-contained Plotly renderer plugin that imports plotly.js directly. Includes dark/light theme overrides and responsive resize handling.
- **`vite-plugin-isolated-renderer.ts`** — Added plotly to the parallel plugin build.  New `virtual:renderer-plugin/plotly` module for code splitting.
- **`iframe-libraries.ts`** — Plotly moved from legacy eval to `RENDERER_PLUGINS` set.
- **`isolated-renderer/index.tsx`** — Removed `PlotlyOutput` import and `application/vnd.plotly.v1+json` case; handled by plugin registry.

### Bundle impact

Plotly's ~4.8MB chunk now loads only when a plotly output appears. The core IIFE is unchanged at ~2.6MB.

### Note on `text/html` Plotly outputs

Plotly backends that emit `text/html` expecting `window.Plotly` to be pre-loaded were already broken before this change (plotly.js was only injected for the `application/vnd.plotly.v1+json` MIME type). Filed #1533 to track future work on detecting and injecting plotly for HTML outputs.

## Verification

- [ ] Open a notebook with plotly output (e.g., `plotly.express` scatter plot) — renders correctly
- [ ] Toggle dark/light theme with a plotly chart visible — colors update
- [ ] Resize the window with a plotly chart — chart resizes responsively
- [ ] Markdown, Vega, Leaflet, and widget outputs still work
- [ ] Verify network tab shows plotly chunk loading only when plotly outputs appear

_PR submitted by @rgbkrk's agent, Quill_