### PR TITLE
fix(daemon): pass requested runtime to auto_launch_kernel for CreateNotebook

### DIFF
--- a/crates/runtimed/src/daemon.rs
+++ b/crates/runtimed/src/daemon.rs
@@ -1625,6 +1625,10 @@ impl Daemon {
         // working_dir for untitled notebooks (used for project file detection)
         let working_dir_path = working_dir.map(std::path::PathBuf::from);
 
+        // Use the explicitly requested runtime for auto-launch, not the system default.
+        // This ensures create_notebook(runtime="deno") actually launches a Deno kernel.
+        let requested_runtime: crate::runtime::Runtime = runtime.parse().unwrap_or(default_runtime);
+
         // Continue with normal notebook sync
         crate::notebook_sync_server::handle_notebook_sync_connection(
             reader,
@@ -1632,7 +1636,7 @@ impl Daemon {
             room,
             self.notebook_rooms.clone(),
             notebook_id,
-            default_runtime,
+            requested_runtime,
             default_python_env,
             self.clone(),
             working_dir_path,


### PR DESCRIPTION
## Summary

- When `create_notebook(runtime="deno")` is called via MCP, the daemon was passing `default_runtime` (from user settings, typically Python) to `handle_notebook_sync_connection` instead of the explicitly requested runtime
- This caused `auto_launch_kernel` to launch a Python kernel even though the notebook metadata correctly specified Deno
- The fix parses the requested runtime string into a `Runtime` enum and passes it through, falling back to `default_runtime` only for unrecognized values

One-line fix in `crates/runtimed/src/daemon.rs` — the `CreateNotebook` handler now converts the `runtime: String` param to a `Runtime` value and passes it to the sync connection instead of the system default.

## Test plan

- [ ] `create_notebook(runtime="deno")` via MCP → verify Deno kernel launches (not Python)
- [ ] `create_notebook(runtime="python")` via MCP → verify Python kernel launches (unchanged)
- [ ] `create_notebook()` with no runtime → verify default runtime is used (unchanged)
- [ ] Creating Deno notebook from the UI still works (unchanged — different code path)

Closes #1524