### PR TITLE
fix(cli): show Pixi pool in daemon status output

### DIFF
--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -1721,6 +1721,27 @@ async fn daemon_command(command: DaemonCommands) -> Result<()> {
                         conda_colored,
                         conda_warming_text
                     );
+
+                    let pixi_total = state.pixi.available + state.pixi.warming;
+                    let pixi_status = format!("{}/{} ready", state.pixi.available, pixi_total);
+                    let pixi_colored = if state.pixi.warming > 0 {
+                        pixi_status.yellow()
+                    } else {
+                        pixi_status.green()
+                    };
+                    let pixi_warming_text = if state.pixi.warming > 0 {
+                        format!(" ({} warming)", state.pixi.warming)
+                            .dimmed()
+                            .to_string()
+                    } else {
+                        String::new()
+                    };
+                    println!(
+                        "  {:<8} {}{}",
+                        "Pixi:".bold(),
+                        pixi_colored,
+                        pixi_warming_text
+                    );
                 }
             }
         }


### PR DESCRIPTION
## Summary

- Added Pixi pool to the human-readable `daemon status` output, matching UV and Conda
- The Pixi pool was already present in `--json` output but missing from the display formatter

```
Pool:
  UV:      3/3 ready
  Conda:   3/3 ready
  Pixi:    2/2 ready    ← new
```

## Test plan

- [ ] `runt daemon status` shows Pixi pool with correct counts
- [ ] `runt daemon status --json` still includes Pixi (unchanged)

Closes #1527