### PR TITLE
feat(isolated-renderer): migrate leaflet to plugin API, document system

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,6 +125,7 @@ Before diving into a subsystem, read the relevant guide:
 | Daemon development | `contributing/runtimed.md` |
 | Environment management | `contributing/environments.md` |
 | Output iframe sandbox | `contributing/iframe-isolation.md` |
+| Renderer plugins (markdown, plotly, vega, leaflet) | `contributing/iframe-isolation.md` § Renderer Plugins |
 | CRDT mutation rules | `contributing/crdt-mutation-guide.md` |
 | TypeScript bindings (ts-rs) | `contributing/typescript-bindings.md` |
 | Logging guidelines | `contributing/logging.md` |
@@ -476,6 +477,12 @@ The rule: `image/*` → binary (EXCEPT `image/svg+xml` — that's text). `audio/
 ### Iframe Security
 
 **NEVER add `allow-same-origin` to the iframe sandbox.** This is the single most important security invariant — tested in CI. It would give untrusted notebook outputs full access to Tauri APIs.
+
+### Renderer Plugins (Isolated Iframe)
+
+Heavy output renderers (markdown, plotly, vega, leaflet) are loaded as **on-demand CJS plugins** — not bundled into the core IIFE. Each plugin has its own Vite virtual module (`virtual:renderer-plugin/{name}`) for code splitting. The iframe's CJS loader provides React via a custom `require` shim — no window globals. See `contributing/iframe-isolation.md` § Renderer Plugins for the full architecture and step-by-step guide to adding new plugins.
+
+**Key files:** `src/isolated-renderer/index.tsx` (registry + loader), `src/isolated-renderer/*-renderer.tsx` (plugins), `apps/notebook/vite-plugin-isolated-renderer.ts` (build), `src/components/isolated/iframe-libraries.ts` (on-demand loading).
 
 ### Cell List Stable DOM Order (Iframe Reload Prevention)
 

--- a/apps/notebook/src/vite-env.d.ts
+++ b/apps/notebook/src/vite-env.d.ts
@@ -19,3 +19,8 @@ declare module "virtual:renderer-plugin/plotly" {
   export const code: string;
   export const css: string;
 }
+
+declare module "virtual:renderer-plugin/leaflet" {
+  export const code: string;
+  export const css: string;
+}

--- a/apps/notebook/vite-plugin-isolated-renderer.ts
+++ b/apps/notebook/vite-plugin-isolated-renderer.ts
@@ -60,6 +60,10 @@ export function isolatedRendererPlugin(
     __dirname,
     "../../src/isolated-renderer/plotly-renderer.tsx",
   );
+  const leafletEntry = path.resolve(
+    __dirname,
+    "../../src/isolated-renderer/leaflet-renderer.tsx",
+  );
 
   let rendererCode = "";
   let rendererCss = "";
@@ -69,6 +73,8 @@ export function isolatedRendererPlugin(
   let vegaRendererCss = "";
   let plotlyRendererCode = "";
   let plotlyRendererCss = "";
+  let leafletRendererCode = "";
+  let leafletRendererCss = "";
   let buildPromise: Promise<void> | null = null;
 
   // Directories to watch for changes that should trigger rebuild
@@ -88,6 +94,8 @@ export function isolatedRendererPlugin(
     vegaRendererCss = "";
     plotlyRendererCode = "";
     plotlyRendererCss = "";
+    leafletRendererCode = "";
+    leafletRendererCss = "";
   }
 
   /** Build a renderer plugin as CJS with React externalized. */
@@ -283,17 +291,21 @@ export function isolatedRendererPlugin(
     }
 
     // --- Build renderer plugins (CJS, React externalized) ---
-    const [markdownPlugin, vegaPlugin, plotlyPlugin] = await Promise.all([
-      buildRendererPlugin(markdownEntry, "markdown-renderer", srcDir),
-      buildRendererPlugin(vegaEntry, "vega-renderer", srcDir),
-      buildRendererPlugin(plotlyEntry, "plotly-renderer", srcDir),
-    ]);
+    const [markdownPlugin, vegaPlugin, plotlyPlugin, leafletPlugin] =
+      await Promise.all([
+        buildRendererPlugin(markdownEntry, "markdown-renderer", srcDir),
+        buildRendererPlugin(vegaEntry, "vega-renderer", srcDir),
+        buildRendererPlugin(plotlyEntry, "plotly-renderer", srcDir),
+        buildRendererPlugin(leafletEntry, "leaflet-renderer", srcDir),
+      ]);
     markdownRendererCode = markdownPlugin.code;
     markdownRendererCss = markdownPlugin.css;
     vegaRendererCode = vegaPlugin.code;
     vegaRendererCss = vegaPlugin.css;
     plotlyRendererCode = plotlyPlugin.code;
     plotlyRendererCss = plotlyPlugin.css;
+    leafletRendererCode = leafletPlugin.code;
+    leafletRendererCss = leafletPlugin.css;
   }
 
   return {
@@ -356,6 +368,12 @@ export const css = ${JSON.stringify(vegaRendererCss)};
         return `
 export const code = ${JSON.stringify(plotlyRendererCode)};
 export const css = ${JSON.stringify(plotlyRendererCss)};
+`;
+      }
+      if (pluginName === "leaflet") {
+        return `
+export const code = ${JSON.stringify(leafletRendererCode)};
+export const css = ${JSON.stringify(leafletRendererCss)};
 `;
       }
     },

--- a/contributing/iframe-isolation.md
+++ b/contributing/iframe-isolation.md
@@ -119,6 +119,116 @@ This prevents other windows/iframes from injecting messages.
 
 The isolated renderer code is built inline during the notebook app build via the Vite plugin (`apps/notebook/vite-plugin-isolated-renderer.ts`). The bundle is embedded as a virtual module and provided to `IsolatedFrame` via the `IsolatedRendererProvider` context (accessed internally through the `useIsolatedRenderer()` hook)—no separate build step or HTTP fetch required.
 
+### Renderer Plugins
+
+Heavy output renderers (markdown, plotly, vega, leaflet) are **not** bundled into the core IIFE. Instead, they are built as on-demand **renderer plugins** — CJS modules loaded via `frame.installRenderer()` only when their MIME types appear in cell outputs.
+
+#### Architecture
+
+```
+┌────────────────────────────────┐     ┌──────────────────────────┐
+│  Parent (iframe-libraries.ts)  │     │  Iframe (core renderer)  │
+│                                │     │                          │
+│  1. Scan outputs for MIME types│     │  RendererRegistry (Map)  │
+│  2. loadPlugin("vega")         │     │  + pattern matchers      │
+│     → import("virtual:        │     │                          │
+│        renderer-plugin/vega")  │     │  installRendererPlugin() │
+│  3. frame.installRenderer(     │────▶│    new Function(code)    │
+│       code, css)               │     │    mod.exports.install({ │
+│                                │     │      register,           │
+│                                │     │      registerPattern     │
+│                                │     │    })                    │
+└────────────────────────────────┘     └──────────────────────────┘
+```
+
+**How it works:**
+
+1. `OutputArea` scans cell outputs for MIME types via `getRequiredLibraries()`
+2. Matching plugins are lazy-loaded from their own virtual module (`virtual:renderer-plugin/{name}`)
+3. The parent sends an `nteract/installRenderer` message with the plugin code + CSS
+4. The iframe loads the CJS module via `new Function("module", "exports", "require", code)` with a custom `require` shim that provides the shared React instance
+5. The plugin's `install(ctx)` function registers components for its MIME types
+6. When `OutputRenderer` encounters a MIME type, it checks the registry before the built-in switch
+
+**React sharing:** Plugins declare `react` and `react/jsx-runtime` as external. The iframe's custom `require` shim maps them to the React instance already loaded in the core bundle — no globals, just dependency injection.
+
+**Code splitting:** Each plugin has its own Vite virtual module, so they load independently. A notebook with only markdown outputs never fetches the plotly chunk (~4.8MB).
+
+#### Current Plugins
+
+| Plugin | MIME Type(s) | Virtual Module | Size |
+|--------|-------------|----------------|------|
+| Markdown | `text/markdown` | `virtual:renderer-plugin/markdown` | ~2.2MB |
+| Vega | `application/vnd.vega*.v*` | `virtual:renderer-plugin/vega` | ~865KB |
+| Plotly | `application/vnd.plotly.v1+json` | `virtual:renderer-plugin/plotly` | ~4.8MB |
+| Leaflet | `application/geo+json` | `virtual:renderer-plugin/leaflet` | ~194KB |
+
+#### Adding a New Renderer Plugin
+
+1. **Create the plugin entry** at `src/isolated-renderer/{name}-renderer.tsx`:
+
+```typescript
+import { SomeLibrary } from "some-library";
+import { useEffect, useRef } from "react";
+
+interface RendererProps {
+  data: unknown;
+  metadata?: Record<string, unknown>;
+  mimeType: string;
+}
+
+function MyRenderer({ data }: RendererProps) {
+  // Render using the library...
+}
+
+export function install(ctx: {
+  register: (mimeTypes: string[], component: React.ComponentType<RendererProps>) => void;
+  registerPattern: (test: (mime: string) => boolean, component: React.ComponentType<RendererProps>) => void;
+}) {
+  // Use register() for exact MIME types
+  ctx.register(["application/x-my-type"], MyRenderer);
+  // Or registerPattern() for versioned/regex MIME types
+  ctx.registerPattern((mime) => /^application\/vnd\.mylib\.v\d/.test(mime), MyRenderer);
+}
+```
+
+2. **Add the build step** in `apps/notebook/vite-plugin-isolated-renderer.ts`:
+   - Add the entry path
+   - Add variables for code/css
+   - Add to `invalidateCache()`
+   - Add to the `Promise.all([...buildRendererPlugin()])` call
+   - Add a virtual module case in `load()`
+
+3. **Add the virtual module type** in `apps/notebook/src/vite-env.d.ts`:
+
+```typescript
+declare module "virtual:renderer-plugin/my-renderer" {
+  export const code: string;
+  export const css: string;
+}
+```
+
+4. **Register the MIME type** in `src/components/isolated/iframe-libraries.ts`:
+   - Add to `MIME_PLUGINS` map (or handle in `pluginForMime()` for regex patterns)
+   - Add the import case in `loadPlugin()`
+
+5. **Remove from core bundle** in `src/isolated-renderer/index.tsx`:
+   - Remove the component import
+   - Remove the MIME type case from `OutputRenderer`
+
+#### Key Files
+
+| File | Role |
+|------|------|
+| `src/isolated-renderer/index.tsx` | Core renderer with plugin registry and CJS loader |
+| `src/isolated-renderer/*-renderer.tsx` | Plugin entry points |
+| `apps/notebook/vite-plugin-isolated-renderer.ts` | Builds core IIFE + all plugins |
+| `src/components/isolated/iframe-libraries.ts` | MIME detection and on-demand plugin loading |
+| `src/components/isolated/frame-bridge.ts` | `InstallRendererMessage` type |
+| `src/components/isolated/rpc-methods.ts` | `NTERACT_INSTALL_RENDERER` constant |
+| `src/components/isolated/isolated-frame.tsx` | `installRenderer()` on `IsolatedFrameHandle` |
+| `apps/notebook/src/vite-env.d.ts` | Virtual module type declarations |
+
 ## Message Protocol
 
 Two message layers coexist:

--- a/src/components/isolated/iframe-libraries.ts
+++ b/src/components/isolated/iframe-libraries.ts
@@ -1,17 +1,14 @@
 /**
  * On-demand library loading for isolated iframes.
  *
- * Heavy libraries are NOT bundled into the isolated renderer IIFE. Instead,
- * they are lazy-loaded from the parent app and injected into iframes only
- * when an output actually needs them.
+ * Heavy output renderers are NOT bundled into the isolated renderer IIFE.
+ * Instead, they are built as renderer plugins — CJS modules loaded via
+ * `frame.installRenderer()`. The iframe's plugin loader provides a shared
+ * React instance and a registration API. No window globals needed.
  *
- * Two injection mechanisms:
- * - **Renderer plugins** (markdown, vega, plotly): CJS modules loaded via
- *   `frame.installRenderer()`. The iframe's plugin loader provides a shared React
- *   instance and a registration API. No globals needed.
- * - **Legacy eval libraries** (leaflet): Raw JS strings injected via
- *   `frame.eval()` that set window globals (e.g., `window.L`). These will
- *   migrate to the renderer plugin API in future PRs.
+ * Each plugin has its own virtual module (`virtual:renderer-plugin/{name}`)
+ * so Vite can code-split them into independent chunks that load only when
+ * their MIME types appear in cell outputs.
  */
 
 import type { JupyterOutput } from "@/components/cell/jupyter-output";
@@ -19,32 +16,29 @@ import type { IsolatedFrameHandle } from "@/components/isolated/isolated-frame";
 import { isVegaMimeType } from "@/components/outputs/vega-mime";
 
 /**
- * Map of MIME types to the library name they require.
- * Extend this when adding support for new heavy visualization libraries.
+ * Map of MIME types to the renderer plugin name they require.
+ * Extend this when adding support for new visualization libraries.
  */
-const MIME_LIBRARIES: Record<string, string> = {
+const MIME_PLUGINS: Record<string, string> = {
   "text/markdown": "markdown",
   "application/vnd.plotly.v1+json": "plotly",
   "application/geo+json": "leaflet",
 };
 
-/** Libraries that use the renderer plugin API instead of legacy eval. */
-const RENDERER_PLUGINS = new Set(["markdown", "vega", "plotly"]);
-
-function libraryForMime(mime: string): string | undefined {
-  if (MIME_LIBRARIES[mime]) return MIME_LIBRARIES[mime];
+function pluginForMime(mime: string): string | undefined {
+  if (MIME_PLUGINS[mime]) return MIME_PLUGINS[mime];
   if (isVegaMimeType(mime)) return "vega";
   return undefined;
 }
 
-/** Cache of library code promises (shared across all iframes). */
-const codeCache = new Map<string, Promise<{ code: string; css?: string }>>();
+/** Cache of plugin code promises (shared across all iframes). */
+const pluginCache = new Map<string, Promise<{ code: string; css?: string }>>();
 
 /**
- * Lazy-load a library's code (and optional CSS).
+ * Lazy-load a renderer plugin's code and optional CSS.
  */
-function loadLibrary(name: string): Promise<{ code: string; css?: string }> {
-  const cached = codeCache.get(name);
+function loadPlugin(name: string): Promise<{ code: string; css?: string }> {
+  const cached = pluginCache.get(name);
   if (cached) return cached;
 
   const promise = (async (): Promise<{ code: string; css?: string }> => {
@@ -62,32 +56,27 @@ function loadLibrary(name: string): Promise<{ code: string; css?: string }> {
         return { code, css: css || undefined };
       }
       case "leaflet": {
-        // Load Leaflet JS and CSS. Inject CSS via a <style> tag before the JS runs.
-        const [leafletJs, leafletCss] = await Promise.all([
-          import("leaflet-js-raw"),
-          import("leaflet-css-raw"),
-        ]);
-        const cssInjection = `(function(){var s=document.createElement('style');s.textContent=${JSON.stringify(leafletCss.default)};document.head.appendChild(s);})();`;
-        return { code: `${cssInjection}\n${leafletJs.default}` };
+        const { code, css } = await import("virtual:renderer-plugin/leaflet");
+        return { code, css: css || undefined };
       }
       default:
-        throw new Error(`Unknown iframe library: ${name}`);
+        throw new Error(`Unknown renderer plugin: ${name}`);
     }
   })();
 
-  codeCache.set(name, promise);
+  pluginCache.set(name, promise);
   return promise;
 }
 
 /**
- * Scan outputs for MIME types that require a heavy library.
- * Returns deduplicated library names.
+ * Scan outputs for MIME types that require a renderer plugin.
+ * Returns deduplicated plugin names.
  */
 export function getRequiredLibraries(
   outputs: JupyterOutput[],
   selectMimeType: (data: Record<string, unknown>) => string | null,
 ): string[] {
-  const libs = new Set<string>();
+  const plugins = new Set<string>();
   for (const output of outputs) {
     if (
       output.output_type === "execute_result" ||
@@ -95,20 +84,17 @@ export function getRequiredLibraries(
     ) {
       const mime = selectMimeType(output.data);
       if (mime) {
-        const lib = libraryForMime(mime);
-        if (lib) libs.add(lib);
+        const plugin = pluginForMime(mime);
+        if (plugin) plugins.add(plugin);
       }
     }
   }
-  return Array.from(libs);
+  return Array.from(plugins);
 }
 
 /**
- * Inject required libraries into an iframe.
- * Idempotent per iframe — tracks what has been injected via `injectedSet`.
- *
- * Renderer plugins use `frame.installRenderer()` (CJS module with shared React).
- * Legacy libraries use `frame.eval()` (raw JS setting window globals).
+ * Install required renderer plugins into an iframe.
+ * Idempotent per iframe — tracks what has been installed via `injectedSet`.
  */
 export async function injectLibraries(
   frame: IsolatedFrameHandle,
@@ -117,24 +103,11 @@ export async function injectLibraries(
 ): Promise<void> {
   for (const name of libraryNames) {
     if (injectedSet.has(name)) continue;
-    const lib = await loadLibrary(name);
-
-    if (RENDERER_PLUGINS.has(name)) {
-      // Renderer plugin: use the plugin API (CJS + shared React, no globals)
-      console.debug(
-        `[iframe-libraries] installing renderer plugin "${name}" (${(lib.code.length / 1024).toFixed(0)}KB)`,
-      );
-      frame.installRenderer(lib.code, lib.css);
-    } else {
-      // Legacy: eval raw JS that sets window globals
-      const guard = `__LIB_${name.toUpperCase()}__`;
-      console.debug(
-        `[iframe-libraries] injecting "${name}" (${(lib.code.length / 1024).toFixed(0)}KB)`,
-      );
-      frame.eval(
-        `if(!window.${guard}){window.${guard}=true;\n${lib.code}\n}`,
-      );
-    }
+    const plugin = await loadPlugin(name);
+    console.debug(
+      `[iframe-libraries] installing renderer plugin "${name}" (${(plugin.code.length / 1024).toFixed(0)}KB)`,
+    );
+    frame.installRenderer(plugin.code, plugin.css);
     injectedSet.add(name);
   }
 }

--- a/src/isolated-renderer/index.tsx
+++ b/src/isolated-renderer/index.tsx
@@ -41,7 +41,6 @@ import { HtmlOutput } from "@/components/outputs/html-output";
 import { ImageOutput } from "@/components/outputs/image-output";
 import { JavaScriptOutput } from "@/components/outputs/javascript-output";
 import { JsonOutput } from "@/components/outputs/json-output";
-import { GeoJsonOutput } from "@/components/outputs/geojson-output";
 import { PdfOutput } from "@/components/outputs/pdf-output";
 import { VideoOutput } from "@/components/outputs/video-output";
 import { SvgOutput } from "@/components/outputs/svg-output";
@@ -478,13 +477,6 @@ function OutputRenderer({ payload }: { payload: RenderPayload }) {
   // JavaScript
   if (mimeType === "application/javascript") {
     return <JavaScriptOutput code={String(content)} />;
-  }
-
-  // GeoJSON
-  if (mimeType === "application/geo+json") {
-    const geojsonData =
-      typeof content === "string" ? JSON.parse(content) : content;
-    return <GeoJsonOutput data={geojsonData} />;
   }
 
   // JSON

--- a/src/isolated-renderer/leaflet-renderer.tsx
+++ b/src/isolated-renderer/leaflet-renderer.tsx
@@ -1,0 +1,146 @@
+/**
+ * Leaflet/GeoJSON Renderer Plugin
+ *
+ * On-demand renderer plugin for application/geo+json outputs.
+ * Bundles Leaflet directly — no window.L global.
+ * Loaded into the isolated iframe via the renderer plugin API.
+ *
+ * Leaflet CSS is delivered via the plugin's css channel and injected
+ * as a <style> tag by the iframe's installRendererPlugin() handler.
+ */
+
+import L from "leaflet";
+import "leaflet/dist/leaflet.css";
+import { useEffect, useRef } from "react";
+import { cn } from "@/lib/utils";
+
+// --- Types ---
+
+interface RendererProps {
+  data: unknown;
+  metadata?: Record<string, unknown>;
+  mimeType: string;
+}
+
+// --- GeoJSON Renderer ---
+
+function GeoJsonRenderer({ data: rawData }: RendererProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const data =
+    typeof rawData === "string"
+      ? (JSON.parse(rawData) as Record<string, unknown>)
+      : (rawData as Record<string, unknown>);
+
+  useEffect(() => {
+    if (!containerRef.current || !data) return;
+
+    const el = containerRef.current;
+    const isDark = document.documentElement.classList.contains("dark");
+
+    // Create the map
+    const map = L.map(el, { zoomAnimation: true });
+
+    // Tile layer — CartoDB tiles work without an API key
+    const tileUrl = isDark
+      ? "https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png"
+      : "https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png";
+
+    L.tileLayer(tileUrl, {
+      attribution:
+        '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/">CARTO</a>',
+      maxZoom: 19,
+    }).addTo(map);
+
+    // Style features
+    const featureColor = isDark ? "#818cf8" : "#4f46e5";
+    const geojsonLayer = L.geoJSON(data as GeoJSON.GeoJsonObject, {
+      style: {
+        color: featureColor,
+        weight: 2,
+        fillOpacity: 0.25,
+        fillColor: featureColor,
+      },
+      pointToLayer: (_feature, latlng) => {
+        return L.circleMarker(latlng, {
+          radius: 6,
+          color: featureColor,
+          weight: 2,
+          fillOpacity: 0.5,
+          fillColor: featureColor,
+        });
+      },
+    }).addTo(map);
+
+    // Fit to bounds of the GeoJSON features
+    const bounds = geojsonLayer.getBounds();
+    if (bounds.isValid()) {
+      map.fitBounds(bounds, { padding: [20, 20] });
+    } else {
+      map.setView([0, 0], 2);
+    }
+
+    // Handle resize so map tiles render correctly
+    const resizeObserver = new ResizeObserver(() => {
+      map.invalidateSize();
+    });
+    resizeObserver.observe(el);
+
+    // React to theme changes
+    const themeObserver = new MutationObserver(() => {
+      const nowDark = document.documentElement.classList.contains("dark");
+      const newTileUrl = nowDark
+        ? "https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png"
+        : "https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png";
+      const newColor = nowDark ? "#818cf8" : "#4f46e5";
+
+      // Replace tile layer
+      map.eachLayer((layer) => {
+        if ((layer as L.TileLayer).getTileUrl) layer.remove();
+      });
+      L.tileLayer(newTileUrl, {
+        attribution:
+          '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/">CARTO</a>',
+        maxZoom: 19,
+      }).addTo(map);
+
+      // Update GeoJSON layer style
+      geojsonLayer.setStyle({
+        color: newColor,
+        fillColor: newColor,
+      });
+    });
+    themeObserver.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["class"],
+    });
+
+    return () => {
+      themeObserver.disconnect();
+      resizeObserver.disconnect();
+      map.remove();
+    };
+  }, [data]);
+
+  if (!data) return null;
+
+  return (
+    <div
+      ref={containerRef}
+      data-slot="geojson-output"
+      className={cn("not-prose py-2 max-w-full")}
+      style={{ height: "400px", width: "100%" }}
+    />
+  );
+}
+
+// --- Plugin install ---
+
+export function install(ctx: {
+  register: (
+    mimeTypes: string[],
+    component: React.ComponentType<RendererProps>,
+  ) => void;
+}) {
+  ctx.register(["application/geo+json"], GeoJsonRenderer);
+}


### PR DESCRIPTION
## Summary

Migrates Leaflet (the last legacy eval library) to the renderer plugin API and documents the entire system. With this change, **all four visualization renderers use the plugin API** — the legacy `frame.eval()` path that injected raw UMD strings and set window globals is completely eliminated.

### Leaflet Migration

- **New `leaflet-renderer.tsx`** — Self-contained Leaflet plugin that imports `L` from `leaflet` directly (including CSS). No more `window.L` global.
- **`iframe-libraries.ts` simplified** — Removed the `RENDERER_PLUGINS` set and legacy eval branch entirely. All libraries now use `frame.installRenderer()`. Renamed internals from "library" to "plugin" terminology.
- **`isolated-renderer/index.tsx`** — Removed `GeoJsonOutput` import and `application/geo+json` case.

### Documentation

- **`contributing/iframe-isolation.md`** — Added "Renderer Plugins" section covering architecture diagram, how the CJS loader + custom require shim works, current plugin inventory with sizes, and a complete step-by-step guide for adding new renderer plugins.
- **`CLAUDE.md`** — Added renderer plugins to the subsystem guides table and High-Risk Architecture Invariants section.

### Bundle sizes (final state, across all PRs)

| Chunk | Size | Loading |
|-------|------|---------|
| Core isolated renderer | **2,654 KB** | Always (was 9MB) |
| Markdown plugin | 2,209 KB | On demand |
| Vega plugin | 865 KB | On demand |
| Plotly plugin | 4,845 KB | On demand |
| Leaflet plugin | 194 KB | On demand |

### Legacy eval path: eliminated

No more `frame.eval()` for library injection. No more `window.Plotly`, `window.vegaEmbed`, `window.vega`, `window.vl`, `window.L` globals. All renderers use the CJS plugin API with shared React via dependency injection.

## Verification

- [ ] Open a notebook with GeoJSON output — map renders with tiles and styled features
- [ ] Toggle dark/light theme with a map visible — tiles and feature colors update
- [ ] Markdown, Plotly, Vega, and widget outputs still work
- [ ] Verify no `window.L`, `window.Plotly`, `window.vegaEmbed` globals exist in iframe console

_PR submitted by @rgbkrk's agent, Quill_