### PR TITLE
fix(mcp): fix dependency pipeline for all env types (uv, conda, pixi)

### DIFF
--- a/crates/notebook-sync/src/handle.rs
+++ b/crates/notebook-sync/src/handle.rs
@@ -398,6 +398,16 @@ impl DocHandle {
         self.with_notebook_doc(|nd| nd.remove_conda_dependency(pkg))
     }
 
+    /// Add a Pixi dependency, deduplicating by package name.
+    pub fn add_pixi_dependency(&self, pkg: &str) -> Result<(), SyncError> {
+        self.with_notebook_doc(|nd| nd.add_pixi_dependency(pkg))
+    }
+
+    /// Remove a Pixi dependency by package name. Returns true if removed.
+    pub fn remove_pixi_dependency(&self, pkg: &str) -> Result<bool, SyncError> {
+        self.with_notebook_doc(|nd| nd.remove_pixi_dependency(pkg))
+    }
+
     /// Get a single cell by ID from the latest snapshot.
     pub fn get_cell(&self, cell_id: &str) -> Option<notebook_doc::CellSnapshot> {
         let snapshot = self.snapshot_rx.borrow();

--- a/crates/runt-mcp/src/tools/deps.rs
+++ b/crates/runt-mcp/src/tools/deps.rs
@@ -16,6 +16,10 @@ use super::{arg_str, tool_error, tool_success};
 pub struct AddDependencyParams {
     /// Package to add (e.g. "pandas>=2.0").
     pub package: String,
+    /// Action after adding: "none" (just record, default), "sync" (hot-install, UV only),
+    /// or "restart" (restart kernel with new deps).
+    #[serde(default)]
+    pub after: Option<String>,
 }
 
 #[allow(dead_code)]
@@ -33,31 +37,195 @@ pub struct GetDependenciesParams {}
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct SyncEnvironmentParams {}
 
-/// Add a package dependency.
+/// Detect the active package manager for a notebook from its env_source or metadata.
+/// Each notebook has exactly one env manager type.
+pub(crate) fn detect_package_manager(handle: &notebook_sync::handle::DocHandle) -> String {
+    // Priority 1: env_source from running kernel
+    if let Ok(state) = handle.get_runtime_state() {
+        let src = &state.kernel.env_source;
+        if src.starts_with("conda:") {
+            return "conda".to_string();
+        }
+        if src.starts_with("pixi:") {
+            return "pixi".to_string();
+        }
+        if src.starts_with("uv:") {
+            return "uv".to_string();
+        }
+    }
+    // Priority 2: existing metadata deps
+    if let Some(meta) = handle.get_notebook_metadata() {
+        if !meta.pixi_dependencies().is_empty() {
+            return "pixi".to_string();
+        }
+        if !meta.conda_dependencies().is_empty() {
+            return "conda".to_string();
+        }
+    }
+    // Default
+    "uv".to_string()
+}
+
+/// Add a dependency using the appropriate package manager, return error string on failure.
+pub(crate) fn add_dep_for_manager(
+    handle: &notebook_sync::handle::DocHandle,
+    package: &str,
+    manager: &str,
+) -> Result<(), String> {
+    match manager {
+        "conda" => handle
+            .add_conda_dependency(package)
+            .map_err(|e| format!("Failed to add conda dependency: {e}")),
+        "pixi" => handle
+            .add_pixi_dependency(package)
+            .map_err(|e| format!("Failed to add pixi dependency: {e}")),
+        _ => handle
+            .add_uv_dependency(package)
+            .map_err(|e| format!("Failed to add uv dependency: {e}")),
+    }
+}
+
+/// Remove a dependency using the appropriate package manager.
+fn remove_dep_for_manager(
+    handle: &notebook_sync::handle::DocHandle,
+    package: &str,
+    manager: &str,
+) -> Result<bool, String> {
+    match manager {
+        "conda" => handle
+            .remove_conda_dependency(package)
+            .map_err(|e| format!("Failed to remove conda dependency: {e}")),
+        "pixi" => handle
+            .remove_pixi_dependency(package)
+            .map_err(|e| format!("Failed to remove pixi dependency: {e}")),
+        _ => handle
+            .remove_uv_dependency(package)
+            .map_err(|e| format!("Failed to remove uv dependency: {e}")),
+    }
+}
+
+/// Add a package dependency. Auto-detects the notebook's package manager (uv, conda, or pixi).
 pub async fn add_dependency(
     server: &NteractMcp,
     request: &CallToolRequestParams,
 ) -> Result<CallToolResult, McpError> {
     let package = arg_str(request, "package")
         .ok_or_else(|| McpError::invalid_params("Missing required parameter: package", None))?;
+    let after = arg_str(request, "after").unwrap_or("none");
 
     let handle = require_handle!(server);
 
-    handle
-        .add_uv_dependency(package)
-        .map_err(|e| McpError::internal_error(format!("Failed to add dependency: {e}"), None))?;
+    let manager = detect_package_manager(&handle);
+
+    add_dep_for_manager(&handle, package, &manager)
+        .map_err(|e| McpError::internal_error(e, None))?;
+
+    // Ensure daemon has the metadata change before any follow-up action
+    if let Err(e) = handle.confirm_sync().await {
+        tracing::warn!("confirm_sync failed after add_dependency: {e}");
+    }
 
     // Read back current dependencies
-    let deps = get_deps_list(&handle);
+    let deps = get_deps_for_manager(&handle, &manager);
 
-    let result = serde_json::json!({
+    let mut result = serde_json::json!({
         "dependencies": deps,
         "added": package,
+        "package_manager": manager,
     });
+
+    match after {
+        "sync" => {
+            // Attempt hot-install (UV only; conda/pixi will report needs_restart)
+            match handle
+                .send_request(NotebookRequest::SyncEnvironment {})
+                .await
+            {
+                Ok(NotebookResponse::SyncEnvironmentComplete {
+                    synced_packages, ..
+                }) => {
+                    result["sync"] = serde_json::json!({
+                        "success": true,
+                        "synced_packages": synced_packages,
+                    });
+                }
+                Ok(NotebookResponse::SyncEnvironmentStarted { packages }) => {
+                    result["sync"] = serde_json::json!({
+                        "success": true,
+                        "synced_packages": packages,
+                    });
+                }
+                Ok(NotebookResponse::SyncEnvironmentFailed {
+                    error,
+                    needs_restart,
+                }) => {
+                    result["sync"] = serde_json::json!({
+                        "success": false,
+                        "error": error,
+                        "needs_restart": needs_restart,
+                    });
+                }
+                Ok(NotebookResponse::Error { error }) => {
+                    result["sync"] = serde_json::json!({
+                        "success": false,
+                        "error": error,
+                        "needs_restart": true,
+                    });
+                }
+                Ok(_) => {
+                    result["sync"] = serde_json::json!({ "success": true });
+                }
+                Err(e) => {
+                    result["sync"] = serde_json::json!({
+                        "success": false,
+                        "error": format!("Failed to sync: {e}"),
+                        "needs_restart": true,
+                    });
+                }
+            }
+        }
+        "restart" => {
+            // Shutdown + relaunch with auto-detect
+            let _ = handle
+                .send_request(NotebookRequest::ShutdownKernel {})
+                .await;
+            tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+            match handle
+                .send_request(NotebookRequest::LaunchKernel {
+                    kernel_type: "python".to_string(),
+                    env_source: "auto".to_string(),
+                    notebook_path: None,
+                })
+                .await
+            {
+                Ok(NotebookResponse::KernelLaunched { env_source, .. }) => {
+                    result["restart"] = serde_json::json!({
+                        "success": true,
+                        "env_source": env_source,
+                    });
+                }
+                Ok(NotebookResponse::Error { error }) => {
+                    result["restart"] = serde_json::json!({
+                        "success": false,
+                        "error": error,
+                    });
+                }
+                Err(e) => {
+                    result["restart"] = serde_json::json!({
+                        "success": false,
+                        "error": format!("Failed to restart: {e}"),
+                    });
+                }
+                _ => {}
+            }
+        }
+        _ => {} // "none" — just record the dep
+    }
+
     tool_success(&serde_json::to_string_pretty(&result).unwrap_or_default())
 }
 
-/// Remove a package dependency.
+/// Remove a package dependency. Auto-detects the notebook's package manager.
 pub async fn remove_dependency(
     server: &NteractMcp,
     request: &CallToolRequestParams,
@@ -67,15 +235,23 @@ pub async fn remove_dependency(
 
     let handle = require_handle!(server);
 
-    handle
-        .remove_uv_dependency(package)
-        .map_err(|e| McpError::internal_error(format!("Failed to remove dependency: {e}"), None))?;
+    let manager = detect_package_manager(&handle);
 
-    let deps = get_deps_list(&handle);
+    let removed = remove_dep_for_manager(&handle, package, &manager)
+        .map_err(|e| McpError::internal_error(e, None))?;
+
+    // Ensure daemon has the metadata change
+    if let Err(e) = handle.confirm_sync().await {
+        tracing::warn!("confirm_sync failed after remove_dependency: {e}");
+    }
+
+    let deps = get_deps_for_manager(&handle, &manager);
 
     let result = serde_json::json!({
         "dependencies": deps,
         "removed": package,
+        "was_present": removed,
+        "package_manager": manager,
     });
     tool_success(&serde_json::to_string_pretty(&result).unwrap_or_default())
 }
@@ -87,7 +263,8 @@ pub async fn get_dependencies(
 ) -> Result<CallToolResult, McpError> {
     let handle = require_handle!(server);
 
-    let deps = get_deps_list(&handle);
+    let manager = detect_package_manager(&handle);
+    let deps = get_deps_for_manager(&handle, &manager);
 
     // Include prewarmed packages from RuntimeStateDoc when available
     let prewarmed = handle
@@ -96,7 +273,10 @@ pub async fn get_dependencies(
         .map(|s| s.env.prewarmed_packages)
         .unwrap_or_default();
 
-    let mut result = serde_json::json!({ "dependencies": deps });
+    let mut result = serde_json::json!({
+        "dependencies": deps,
+        "package_manager": manager,
+    });
     if !prewarmed.is_empty() {
         result["available_packages"] = serde_json::json!(prewarmed);
     }
@@ -160,10 +340,14 @@ pub async fn sync_environment(
     }
 }
 
-/// Read UV dependencies from notebook metadata.
-fn get_deps_list(handle: &notebook_sync::handle::DocHandle) -> Vec<String> {
+/// Read dependencies for the detected package manager.
+fn get_deps_for_manager(handle: &notebook_sync::handle::DocHandle, manager: &str) -> Vec<String> {
     handle
         .get_notebook_metadata()
-        .map(|m| m.uv_dependencies().to_vec())
+        .map(|m| match manager {
+            "conda" => m.conda_dependencies().to_vec(),
+            "pixi" => m.pixi_dependencies().to_vec(),
+            _ => m.uv_dependencies().to_vec(),
+        })
         .unwrap_or_default()
 }

--- a/crates/runt-mcp/src/tools/kernel.rs
+++ b/crates/runt-mcp/src/tools/kernel.rs
@@ -58,10 +58,16 @@ pub async fn restart_kernel(
     // Brief pause for shutdown to complete
     tokio::time::sleep(std::time::Duration::from_millis(500)).await;
 
-    // Step 2: Read kernel type and env_source from RuntimeState before launching
-    let (kernel_type, env_source) = {
+    // Ensure daemon has latest metadata (deps may have changed since last sync)
+    if let Err(e) = handle.confirm_sync().await {
+        tracing::warn!("confirm_sync failed before restart_kernel launch: {e}");
+    }
+
+    // Step 2: Determine kernel type from RuntimeState, but let daemon auto-detect env_source
+    // from notebook metadata. This ensures newly added deps are picked up on restart.
+    let kernel_type = {
         let state = handle.get_runtime_state().ok();
-        let kernel_type = state
+        state
             .as_ref()
             .and_then(|s| {
                 let name = &s.kernel.name;
@@ -71,25 +77,12 @@ pub async fn restart_kernel(
                     Some(name.clone())
                 }
             })
-            .unwrap_or_else(|| "python".to_string());
-        let env_source = state
-            .as_ref()
-            .and_then(|s| {
-                let src = &s.kernel.env_source;
-                if src.is_empty() {
-                    None
-                } else {
-                    Some(src.clone())
-                }
-            })
-            .unwrap_or_else(|| {
-                if kernel_type == "deno" {
-                    "deno".to_string()
-                } else {
-                    "uv:inline".to_string()
-                }
-            });
-        (kernel_type, env_source)
+            .unwrap_or_else(|| "python".to_string())
+    };
+    let env_source = if kernel_type == "deno" {
+        "deno".to_string()
+    } else {
+        "auto".to_string()
     };
 
     // Step 3: Launch kernel

--- a/crates/runt-mcp/src/tools/mod.rs
+++ b/crates/runt-mcp/src/tools/mod.rs
@@ -101,7 +101,7 @@ pub fn all_tools() -> Vec<Tool> {
         ),
         Tool::new(
             "create_notebook",
-            "Create a new notebook with optional pre-installed dependencies. The kernel starts automatically. Call save_notebook(path) to persist to disk.",
+            "Create a new notebook with optional pre-installed dependencies. Supports uv (default), conda, or pixi via package_manager param. The kernel starts automatically with deps installed. Call save_notebook(path) to persist to disk.",
             schema_for::<session::CreateNotebookParams>(),
         )
         .annotate(ToolAnnotations::new().destructive(false).open_world(false)),
@@ -258,7 +258,7 @@ pub fn all_tools() -> Vec<Tool> {
         // -- Dependencies --
         Tool::new(
             "add_dependency",
-            "Add a package dependency (e.g. 'pandas>=2.0'). Call sync_environment() to install.",
+            "Add a package dependency (e.g. 'pandas>=2.0'). Auto-detects package manager (uv, conda, or pixi). Use after='sync' to hot-install (UV only) or after='restart' to restart kernel with new deps.",
             schema_for::<deps::AddDependencyParams>(),
         )
         .annotate(
@@ -269,7 +269,7 @@ pub fn all_tools() -> Vec<Tool> {
         ),
         Tool::new(
             "remove_dependency",
-            "Remove a package dependency. Requires restart_kernel() to take effect.",
+            "Remove a package dependency. Auto-detects package manager. Requires restart_kernel() to take effect.",
             schema_for::<deps::RemoveDependencyParams>(),
         )
         .annotate(

--- a/crates/runt-mcp/src/tools/session.rs
+++ b/crates/runt-mcp/src/tools/session.rs
@@ -146,9 +146,12 @@ pub struct CreateNotebookParams {
     /// Working directory for the kernel.
     #[serde(default)]
     pub working_dir: Option<String>,
-    /// Python packages to pre-install.
+    /// Packages to pre-install.
     #[serde(default)]
     pub dependencies: Option<Vec<String>>,
+    /// Package manager for dependencies: "uv" (default), "conda", or "pixi".
+    #[serde(default)]
+    pub package_manager: Option<String>,
 }
 
 #[allow(dead_code)]
@@ -340,9 +343,11 @@ pub async fn create_notebook(
                 .and_then(|v| serde_json::from_value::<Vec<String>>(v.clone()).ok())
                 .unwrap_or_default();
 
-            if runtime == "python" {
+            let pkg_manager = arg_str(request, "package_manager").unwrap_or("uv");
+
+            if runtime != "deno" {
                 for dep in &deps {
-                    let _ = result.handle.add_uv_dependency(dep);
+                    let _ = super::deps::add_dep_for_manager(&result.handle, dep, pkg_manager);
                 }
             }
 
@@ -353,11 +358,16 @@ pub async fn create_notebook(
             };
             *server.session.write().await = Some(session);
 
-            // If dependencies were added, restart kernel to pick them up
-            if !deps.is_empty() && runtime == "python" {
+            // If dependencies were added, ensure daemon has them and restart kernel
+            if !deps.is_empty() && runtime != "deno" {
                 let session = server.session.read().await;
                 if let Some(s) = session.as_ref() {
-                    // Shutdown and relaunch
+                    // Ensure daemon has the dep metadata before restarting
+                    if let Err(e) = s.handle.confirm_sync().await {
+                        tracing::warn!("confirm_sync failed before create_notebook relaunch: {e}");
+                    }
+
+                    // Shutdown and relaunch with auto-detect (daemon reads deps from metadata)
                     let _ = s
                         .handle
                         .send_request(NotebookRequest::ShutdownKernel {})
@@ -367,10 +377,28 @@ pub async fn create_notebook(
                         .handle
                         .send_request(NotebookRequest::LaunchKernel {
                             kernel_type: runtime.to_string(),
-                            env_source: "uv:inline".to_string(),
+                            env_source: "auto".to_string(),
                             notebook_path: None,
                         })
                         .await;
+
+                    // Wait for kernel to become ready
+                    let start = std::time::Instant::now();
+                    let timeout = std::time::Duration::from_secs(120);
+                    loop {
+                        if start.elapsed() >= timeout {
+                            break;
+                        }
+                        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+                        if let Ok(state) = s.handle.get_runtime_state() {
+                            if state.kernel.status == "idle" || state.kernel.status == "busy" {
+                                break;
+                            }
+                            if state.kernel.status == "error" {
+                                break;
+                            }
+                        }
+                    }
                 }
             }
 
@@ -378,6 +406,7 @@ pub async fn create_notebook(
                 "notebook_id": notebook_id,
                 "runtime": { "language": runtime },
                 "dependencies": deps,
+                "package_manager": pkg_manager,
             });
 
             Ok(CallToolResult::success(vec![Content::text(


### PR DESCRIPTION
## Summary

Three compounding bugs prevented dependencies from working via MCP tools:

- **sync_environment race**: `add_dependency` wrote deps to the CRDT but didn't `confirm_sync()`, so the daemon might not have the metadata when `sync_environment` ran
- **restart_kernel stale env_source**: read `"uv:prewarmed"` from RuntimeStateDoc and passed it verbatim — daemon skipped auto-detect and ignored new deps
- **create_notebook hardcoded UV**: only supported UV, hardcoded `"uv:inline"` for kernel relaunch, didn't wait for kernel ready

Fixes:
- `confirm_sync()` after every dep mutation (add/remove) and before kernel relaunch
- `restart_kernel` sends `"auto"` env_source so daemon re-detects from metadata
- `create_notebook` supports `package_manager` param (uv/conda/pixi), uses `"auto"` env_source, waits for kernel ready
- `add_dependency` auto-detects the notebook's env manager and accepts optional `after` param (`"none"`, `"sync"`, `"restart"`)
- All dep responses include `package_manager` so agents know the env type
- Added pixi dependency wrappers to `DocHandle`

## Test plan

- [ ] `create_notebook(dependencies=["requests"])` → kernel starts with requests installed
- [ ] `add_dependency("numpy", after="sync")` → hot-installed without restart
- [ ] `add_dependency("scipy", after="restart")` → kernel restarts with scipy
- [ ] `restart_kernel()` after adding deps → kernel comes back with all deps
- [ ] `get_dependencies()` → shows deps with `package_manager` field
- [ ] `create_notebook(dependencies=["numpy"], package_manager="conda")` → conda notebook
- [ ] Opening existing notebooks with deps still works

Closes #1523
Ref #1510