### PR TITLE
feat: pre-compute renderer plugins at materialization, fix output widgets

### DIFF
--- a/apps/notebook/src/components/CodeCell.tsx
+++ b/apps/notebook/src/components/CodeCell.tsx
@@ -389,6 +389,7 @@ export const CodeCell = memo(function CodeCell({
             <OutputArea
               outputs={cell.outputs}
               cellId={cell.id}
+              requiredPlugins={cell.requiredPlugins}
               preloadIframe
               searchQuery={searchQuery}
               onSearchMatchCount={onSearchMatchCount}

--- a/apps/notebook/src/hooks/useAutomergeNotebook.ts
+++ b/apps/notebook/src/hooks/useAutomergeNotebook.ts
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import type { SyncableHandle } from "runtimed";
 import { SyncEngine } from "runtimed";
 import { concatMap, from, switchMap } from "rxjs";
+import { preWarmPlugins } from "@/components/isolated/iframe-libraries";
 import { getBlobPort, refreshBlobPort } from "../lib/blob-port";
 import { materializeChangeset } from "../lib/frame-pipeline";
 import { logger } from "../lib/logger";
@@ -110,6 +111,11 @@ export function useAutomergeNotebook() {
       blobPort,
       outputCacheRef.current,
     );
+    // Pre-warm plugin cache so iframe rendering doesn't wait for async loads
+    const allPlugins = newCells.flatMap((c) =>
+      c.cell_type === "code" ? c.requiredPlugins : [],
+    );
+    if (allPlugins.length > 0) preWarmPlugins(allPlugins);
     replaceNotebookCells(newCells);
     logger.debug(
       `[automerge-notebook] Full materialization: ${snapshots.length} cells in ${(performance.now() - start).toFixed(1)}ms`,

--- a/apps/notebook/src/lib/__tests__/materialize-cells.test.ts
+++ b/apps/notebook/src/lib/__tests__/materialize-cells.test.ts
@@ -351,6 +351,7 @@ describe("cellSnapshotsToNotebookCells", () => {
       source: "print('hello')",
       execution_count: 1,
       outputs: [{ output_type: "stream", name: "stdout", text: "hello\n" }],
+      requiredPlugins: [],
       metadata: {},
     });
   });
@@ -366,6 +367,7 @@ describe("cellSnapshotsToNotebookCells", () => {
       source: "x = 1",
       execution_count: 3,
       outputs: [],
+      requiredPlugins: [],
       metadata: {},
     });
   });

--- a/apps/notebook/src/lib/frame-pipeline.ts
+++ b/apps/notebook/src/lib/frame-pipeline.ts
@@ -6,6 +6,7 @@
  * transforms coalesced CellChangesets into React store updates.
  */
 
+import { preWarmPlugins } from "@/components/isolated/iframe-libraries";
 import { computeRequiredPlugins } from "@/lib/renderer-plugins";
 import type { JupyterOutput } from "../types";
 import type { NotebookHandle } from "../wasm/runtimed-wasm/runtimed_wasm.js";
@@ -142,13 +143,17 @@ export async function materializeChangeset(
           ? (handle.get_cell_source(cellId) ?? "")
           : (existingCell?.source ?? handle.get_cell_source(cellId) ?? "");
 
+        const plugins = computeRequiredPlugins(resolved);
+        // Pre-warm plugin cache so OutputArea.injectLibraries() resolves instantly
+        preWarmPlugins(plugins);
+
         updateCellById(cellId, () => ({
           id: cellId,
           cell_type: "code" as const,
           source,
           execution_count: Number.isNaN(ec) ? null : ec,
           outputs: resolved,
-          requiredPlugins: computeRequiredPlugins(resolved),
+          requiredPlugins: plugins,
           metadata,
         }));
       }

--- a/apps/notebook/src/lib/frame-pipeline.ts
+++ b/apps/notebook/src/lib/frame-pipeline.ts
@@ -6,6 +6,7 @@
  * transforms coalesced CellChangesets into React store updates.
  */
 
+import { computeRequiredPlugins } from "@/lib/renderer-plugins";
 import type { JupyterOutput } from "../types";
 import type { NotebookHandle } from "../wasm/runtimed-wasm/runtimed_wasm.js";
 import { getBlobPort, refreshBlobPort } from "./blob-port";
@@ -147,6 +148,7 @@ export async function materializeChangeset(
           source,
           execution_count: Number.isNaN(ec) ? null : ec,
           outputs: resolved,
+          requiredPlugins: computeRequiredPlugins(resolved),
           metadata,
         }));
       }

--- a/apps/notebook/src/lib/materialize-cells.ts
+++ b/apps/notebook/src/lib/materialize-cells.ts
@@ -1,3 +1,4 @@
+import { computeRequiredPlugins } from "@/lib/renderer-plugins";
 import type { JupyterOutput, NotebookCell } from "../types";
 import type { NotebookHandle } from "../wasm/runtimed-wasm/runtimed_wasm.js";
 import { logger } from "./logger";
@@ -171,6 +172,7 @@ export function cellSnapshotsToNotebookCellsSync(
         source: snap.source,
         execution_count: ec,
         outputs: resolvedOutputs,
+        requiredPlugins: computeRequiredPlugins(resolvedOutputs),
         metadata,
       };
     }
@@ -236,6 +238,7 @@ export async function cellSnapshotsToNotebookCells(
           source: snap.source,
           execution_count: ec,
           outputs: resolvedOutputs,
+          requiredPlugins: computeRequiredPlugins(resolvedOutputs),
           metadata,
         };
       }
@@ -317,6 +320,7 @@ export function materializeCellFromWasm(
       source,
       execution_count: executionCount,
       outputs,
+      requiredPlugins: computeRequiredPlugins(outputs),
       metadata,
     };
   }

--- a/apps/notebook/src/types.ts
+++ b/apps/notebook/src/types.ts
@@ -7,6 +7,8 @@ export interface CodeCell {
   source: string;
   execution_count: number | null;
   outputs: JupyterOutput[];
+  /** Renderer plugins required by this cell's outputs (e.g., ["plotly", "vega"]). */
+  requiredPlugins: string[];
   metadata: CellMetadata;
 }
 

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -7,6 +7,7 @@ import {
   type IsolatedFrameHandle,
 } from "@/components/isolated";
 import { injectLibraries } from "@/components/isolated/iframe-libraries";
+import { computeRequiredPlugins } from "@/lib/renderer-plugins";
 import {
   AnsiErrorOutput,
   AnsiStreamOutput,
@@ -356,10 +357,43 @@ export function OutputArea({
     // Must happen before clear+render so the installRenderer messages arrive first.
     // Clear the tracking set on each call — a reloaded iframe has a fresh registry.
     injectedLibsRef.current.clear();
-    if (requiredPlugins && requiredPlugins.length > 0) {
+
+    // Collect plugins from the cell's direct outputs
+    const allPlugins = new Set(requiredPlugins ?? []);
+
+    // Also scan output widgets for captured outputs that need plugins.
+    // A cell may output a widget view (application/vnd.jupyter.widget-view+json)
+    // whose OutputModel.outputs contain plotly/vega/etc MIME types.
+    if (widgetContext?.store) {
+      for (const output of outputs) {
+        if (
+          (output.output_type === "execute_result" ||
+            output.output_type === "display_data") &&
+          output.data?.["application/vnd.jupyter.widget-view+json"]
+        ) {
+          const widgetData = output.data[
+            "application/vnd.jupyter.widget-view+json"
+          ] as { model_id?: string };
+          if (widgetData?.model_id) {
+            const model = widgetContext.store.getModel(widgetData.model_id);
+            if (model?.modelName === "OutputModel" && model.state.outputs) {
+              const widgetOutputs = model.state.outputs as Array<{
+                output_type: string;
+                data?: Record<string, unknown>;
+              }>;
+              for (const p of computeRequiredPlugins(widgetOutputs)) {
+                allPlugins.add(p);
+              }
+            }
+          }
+        }
+      }
+    }
+
+    if (allPlugins.size > 0) {
       await injectLibraries(
         frameRef.current,
-        requiredPlugins,
+        allPlugins,
         injectedLibsRef.current,
       );
       // Stale check: if outputs changed while we were loading the plugin,

--- a/src/components/cell/OutputArea.tsx
+++ b/src/components/cell/OutputArea.tsx
@@ -6,10 +6,7 @@ import {
   IsolatedFrame,
   type IsolatedFrameHandle,
 } from "@/components/isolated";
-import {
-  getRequiredLibraries,
-  injectLibraries,
-} from "@/components/isolated/iframe-libraries";
+import { injectLibraries } from "@/components/isolated/iframe-libraries";
 import {
   AnsiErrorOutput,
   AnsiStreamOutput,
@@ -42,6 +39,11 @@ interface OutputAreaProps {
    * Cell ID for stable output keys in the iframe (enables smooth updates).
    */
   cellId?: string;
+  /**
+   * Pre-computed renderer plugins required by this cell's outputs.
+   * When provided, skips MIME scanning at render time.
+   */
+  requiredPlugins?: string[];
   /**
    * Whether the output area is collapsed.
    */
@@ -258,6 +260,7 @@ function renderOutput(
 export function OutputArea({
   outputs,
   cellId,
+  requiredPlugins,
   collapsed = false,
   onToggleCollapse,
   maxHeight,
@@ -349,22 +352,17 @@ export function OutputArea({
     // Use ref to avoid adding darkMode to deps which would cause re-renders on theme toggle
     frameRef.current.setTheme(darkModeRef.current);
 
-    // Inject any heavy libraries required by the outputs (e.g. plotly.js).
-    // Must happen before clear+render so the eval messages arrive first.
-    // Clear the tracking set on each call — a new or reloaded iframe won't
-    // have the previously-injected globals, so we must re-inject.
+    // Install renderer plugins required by the outputs (e.g. plotly, vega).
+    // Must happen before clear+render so the installRenderer messages arrive first.
+    // Clear the tracking set on each call — a reloaded iframe has a fresh registry.
     injectedLibsRef.current.clear();
-    const neededLibs = getRequiredLibraries(
-      outputs,
-      (data) => selectMimeType(data, priority),
-    );
-    if (neededLibs.length > 0) {
+    if (requiredPlugins && requiredPlugins.length > 0) {
       await injectLibraries(
         frameRef.current,
-        neededLibs,
+        requiredPlugins,
         injectedLibsRef.current,
       );
-      // Stale check: if outputs changed while we were loading the library,
+      // Stale check: if outputs changed while we were loading the plugin,
       // bail — a newer handleFrameReady call is already in flight.
       if (gen !== renderGenRef.current) return;
     }

--- a/src/components/isolated/iframe-libraries.ts
+++ b/src/components/isolated/iframe-libraries.ts
@@ -13,23 +13,7 @@
 
 import type { JupyterOutput } from "@/components/cell/jupyter-output";
 import type { IsolatedFrameHandle } from "@/components/isolated/isolated-frame";
-import { isVegaMimeType } from "@/components/outputs/vega-mime";
-
-/**
- * Map of MIME types to the renderer plugin name they require.
- * Extend this when adding support for new visualization libraries.
- */
-const MIME_PLUGINS: Record<string, string> = {
-  "text/markdown": "markdown",
-  "application/vnd.plotly.v1+json": "plotly",
-  "application/geo+json": "leaflet",
-};
-
-function pluginForMime(mime: string): string | undefined {
-  if (MIME_PLUGINS[mime]) return MIME_PLUGINS[mime];
-  if (isVegaMimeType(mime)) return "vega";
-  return undefined;
-}
+import { pluginForMime } from "@/lib/renderer-plugins";
 
 /** Cache of plugin code promises (shared across all iframes). */
 const pluginCache = new Map<string, Promise<{ code: string; css?: string }>>();

--- a/src/components/isolated/iframe-libraries.ts
+++ b/src/components/isolated/iframe-libraries.ts
@@ -53,6 +53,17 @@ function loadPlugin(name: string): Promise<{ code: string; css?: string }> {
 }
 
 /**
+ * Pre-warm the plugin cache for the given plugin names.
+ * Fetches plugin code from virtual modules without installing into any iframe.
+ * Use at materialization time so that later injectLibraries() calls resolve instantly.
+ */
+export function preWarmPlugins(pluginNames: Iterable<string>): void {
+  for (const name of pluginNames) {
+    loadPlugin(name);
+  }
+}
+
+/**
  * Scan outputs for MIME types that require a renderer plugin.
  * Returns deduplicated plugin names.
  */

--- a/src/components/outputs/media-router.tsx
+++ b/src/components/outputs/media-router.tsx
@@ -1,4 +1,5 @@
 import { lazy, type ReactNode, Suspense } from "react";
+import { getRenderer } from "@/lib/renderer-registry";
 import { isSafeForMainDom } from "./safe-mime-types";
 import { useMediaContext } from "./media-provider";
 
@@ -327,6 +328,20 @@ export function MediaRouter({
         );
       }
       return null;
+    }
+
+    // Check the renderer plugin registry (populated by on-demand plugins
+    // like plotly, vega, leaflet, markdown). This allows output widgets to
+    // render rich MIME types using any plugin already installed in the iframe.
+    const PluginRenderer = getRenderer(mimeType);
+    if (PluginRenderer) {
+      return (
+        <PluginRenderer
+          data={content}
+          metadata={mimeMetadata}
+          mimeType={mimeType}
+        />
+      );
     }
 
     // Text/Markdown (only renders when in iframe)

--- a/src/isolated-renderer/index.tsx
+++ b/src/isolated-renderer/index.tsx
@@ -57,32 +57,17 @@ import "@/components/widgets/controls";
 // On-demand renderer plugins register React components for specific MIME types.
 // Plugins are CJS modules loaded via installRendererPlugin(). The custom
 // require shim provides the shared React instance so hooks work correctly.
+//
+// The registry lives in @/lib/renderer-registry so that both OutputRenderer
+// and MediaRouter (used by output widgets) can look up installed renderers.
 
 import type { ComponentType } from "react";
-
-interface RendererProps {
-  data: unknown;
-  metadata?: Record<string, unknown>;
-  mimeType: string;
-}
-
-const rendererRegistry = new Map<string, ComponentType<RendererProps>>();
-const rendererPatterns: Array<{
-  test: (mime: string) => boolean;
-  component: ComponentType<RendererProps>;
-}> = [];
-
-/** Look up a renderer by exact match first, then pattern matchers. */
-function getRenderer(
-  mimeType: string,
-): ComponentType<RendererProps> | undefined {
-  const exact = rendererRegistry.get(mimeType);
-  if (exact) return exact;
-  for (const entry of rendererPatterns) {
-    if (entry.test(mimeType)) return entry.component;
-  }
-  return undefined;
-}
+import {
+  type RendererProps,
+  getRenderer,
+  registerRenderer,
+  registerRendererPattern,
+} from "@/lib/renderer-registry";
 
 /**
  * Load and install a renderer plugin.
@@ -127,14 +112,8 @@ function installRendererPlugin(code: string, css?: string) {
   }
 
   install({
-    register(mimeTypes, component) {
-      for (const mt of mimeTypes) {
-        rendererRegistry.set(mt, component);
-      }
-    },
-    registerPattern(test, component) {
-      rendererPatterns.push({ test, component });
-    },
+    register: registerRenderer,
+    registerPattern: registerRendererPattern,
   });
 
   if (css) {

--- a/src/lib/renderer-plugins.ts
+++ b/src/lib/renderer-plugins.ts
@@ -1,0 +1,61 @@
+/**
+ * Shared MIME type → renderer plugin mapping.
+ *
+ * Used by both the materialization layer (to pre-compute requiredPlugins)
+ * and iframe-libraries.ts (to load and install plugins on demand).
+ *
+ * This module has NO dependencies on React, Vite virtual modules, or
+ * iframe APIs — it's pure data mapping, safe to import anywhere.
+ */
+
+import { isVegaMimeType } from "@/components/outputs/vega-mime";
+
+/**
+ * Map of exact MIME types to the renderer plugin name they require.
+ * Extend this when adding support for new visualization libraries.
+ */
+const MIME_PLUGINS: Record<string, string> = {
+  "text/markdown": "markdown",
+  "application/vnd.plotly.v1+json": "plotly",
+  "application/geo+json": "leaflet",
+};
+
+/**
+ * Determine which renderer plugin (if any) is needed for a given MIME type.
+ * Returns the plugin name (e.g., "plotly", "vega") or undefined if no plugin is needed.
+ */
+export function pluginForMime(mime: string): string | undefined {
+  if (MIME_PLUGINS[mime]) return MIME_PLUGINS[mime];
+  if (isVegaMimeType(mime)) return "vega";
+  return undefined;
+}
+
+/**
+ * Scan Jupyter outputs and return the deduplicated set of renderer plugin
+ * names required to render them.
+ *
+ * This is a pure data function — it doesn't load or install anything.
+ * Use it at materialization time to pre-compute which plugins a cell needs.
+ */
+export function computeRequiredPlugins(
+  outputs: Array<{
+    output_type: string;
+    data?: Record<string, unknown>;
+  }>,
+): string[] {
+  const plugins = new Set<string>();
+  for (const output of outputs) {
+    if (
+      output.output_type === "execute_result" ||
+      output.output_type === "display_data"
+    ) {
+      if (output.data) {
+        for (const mime of Object.keys(output.data)) {
+          const plugin = pluginForMime(mime);
+          if (plugin) plugins.add(plugin);
+        }
+      }
+    }
+  }
+  return Array.from(plugins);
+}

--- a/src/lib/renderer-registry.ts
+++ b/src/lib/renderer-registry.ts
@@ -1,0 +1,54 @@
+/**
+ * Renderer plugin registry — shared lookup for MIME type → React component.
+ *
+ * The registry is populated by installRendererPlugin() in the isolated
+ * renderer and queried by both OutputRenderer and MediaRouter. This module
+ * exists so both consumers can access the registry without circular imports.
+ *
+ * Inside the isolated iframe IIFE, all imports resolve to the same module
+ * instance, so the registry state is shared automatically.
+ */
+
+import type { ComponentType } from "react";
+
+export interface RendererProps {
+  data: unknown;
+  metadata?: Record<string, unknown>;
+  mimeType: string;
+}
+
+const exactMatches = new Map<string, ComponentType<RendererProps>>();
+const patternMatchers: Array<{
+  test: (mime: string) => boolean;
+  component: ComponentType<RendererProps>;
+}> = [];
+
+/** Register a component for exact MIME type matches. */
+export function registerRenderer(
+  mimeTypes: string[],
+  component: ComponentType<RendererProps>,
+): void {
+  for (const mt of mimeTypes) {
+    exactMatches.set(mt, component);
+  }
+}
+
+/** Register a component for pattern-based MIME type matching. */
+export function registerRendererPattern(
+  test: (mime: string) => boolean,
+  component: ComponentType<RendererProps>,
+): void {
+  patternMatchers.push({ test, component });
+}
+
+/** Look up a renderer by exact match first, then pattern matchers. */
+export function getRenderer(
+  mimeType: string,
+): ComponentType<RendererProps> | undefined {
+  const exact = exactMatches.get(mimeType);
+  if (exact) return exact;
+  for (const entry of patternMatchers) {
+    if (entry.test(mimeType)) return entry.component;
+  }
+  return undefined;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,9 +1,28 @@
-import { defineConfig } from "vitest/config";
+import { defineConfig, type Plugin } from "vitest/config";
 import path from "path";
 import { rawLibPlugin } from "./apps/notebook/vite-plugin-raw-lib";
 
+/** Stub virtual:renderer-plugin/* modules for tests (real builds use the Vite plugin). */
+function rendererPluginStub(): Plugin {
+  const prefix = "virtual:renderer-plugin/";
+  return {
+    name: "renderer-plugin-stub",
+    resolveId(id) {
+      if (id.startsWith(prefix)) return `\0${id}`;
+    },
+    load(id) {
+      if (id.startsWith(`\0${prefix}`)) {
+        return 'export const code = ""; export const css = "";';
+      }
+    },
+  };
+}
+
 export default defineConfig({
-  plugins: [rawLibPlugin(path.resolve(__dirname, "./node_modules"))],
+  plugins: [
+    rawLibPlugin(path.resolve(__dirname, "./node_modules")),
+    rendererPluginStub(),
+  ],
   test: {
     environment: "jsdom",
     include: [


### PR DESCRIPTION
## Summary

Moves renderer plugin detection from React render time to the materialization layer, and hooks `MediaRouter` into the renderer plugin registry. This enables output widgets (`ipywidgets.Output`) to render rich MIME types using installed plugins instead of falling through to raw JSON.

### Architecture Change

Before: `OutputArea` scanned output MIME types at render time → async loaded plugins → installed into iframe → rendered. Output widgets bypassed this entirely (`MediaRouter` didn't know about plugins).

After: Plugin requirements are computed as data during materialization → cache pre-warmed → `OutputArea` installs from cache instantly → `MediaRouter` checks the shared registry for any MIME type. Output widgets benefit when plugins are already installed.

### Known limitation: late-arriving widget outputs

If an output widget's captured outputs arrive *after* the cell's iframe is already mounted (e.g., `OutputModel.outputs` gains a plugin-backed MIME type later), the plugin may not be installed in time. The app-layer scan in `OutputArea.handleFrameReady` only runs on initial mount and cell output changes — it doesn't subscribe to widget model state changes.

The proper fix is to compute `requiredPlugins` as derived data in the runtimed/WASM layer, flowing through the same rxjs reactive pipeline as outputs. That way any consumer (Tauri app, future web viewer) gets plugin requirements as part of the data stream. Filed for follow-up.

### Changes by commit

1. **Extract shared MIME→plugin mapping** — New `src/lib/renderer-plugins.ts` with `pluginForMime()` and `computeRequiredPlugins()`. Pure data, no React/iframe deps.

2. **Add `requiredPlugins` to `CodeCell`** — Computed during all three materialization paths (async, sync, incremental). Available as cell data before React renders.

3. **Shared renderer registry** — New `src/lib/renderer-registry.ts` extracted from the isolated renderer's module-private registry. Both `OutputRenderer` and `MediaRouter` access the same registry.

4. **MediaRouter checks registry** — When running inside the iframe, `MediaRouter` checks the renderer plugin registry before its built-in MIME type switch. Output widgets now render plotly/vega/leaflet/markdown using any installed plugin.

5. **Pre-warm plugin cache** — After materialization (initial load + incremental sync), `preWarmPlugins()` fetches plugin code from virtual modules into the cache.

6. **Scan widget outputs** — `OutputArea.handleFrameReady` scans `OutputModel` widgets referenced by the cell's outputs and installs their required plugins too.

## Verification

- [ ] Normal cell outputs still render correctly (plotly, vega, markdown, leaflet)
- [ ] Output widget containing a plotly chart renders as a chart when the widget and its outputs are available at initial render time
- [ ] Theme switching works for outputs inside output widgets
- [ ] Notebooks without rich outputs load without fetching plugin chunks

_PR submitted by @rgbkrk's agent, Quill_