### PR TITLE
fix(mcp): use scoped auto-detect to preserve package manager family on restart

### DIFF
--- a/crates/runt-mcp/src/tools/deps.rs
+++ b/crates/runt-mcp/src/tools/deps.rs
@@ -113,7 +113,17 @@ pub async fn add_dependency(
         .ok_or_else(|| McpError::invalid_params("Missing required parameter: package", None))?;
     let after = arg_str(request, "after").unwrap_or("none");
 
-    let handle = require_handle!(server);
+    let (handle, notebook_id) = {
+        let guard = server.session.read().await;
+        match guard.as_ref() {
+            Some(s) => (s.handle.clone(), s.notebook_id.clone()),
+            None => {
+                return tool_error(
+                    "No active notebook session. Call join_notebook or open_notebook first.",
+                )
+            }
+        }
+    };
 
     let manager = detect_package_manager(&handle);
 
@@ -185,7 +195,26 @@ pub async fn add_dependency(
             }
         }
         "restart" => {
-            // Shutdown + relaunch with auto-detect
+            // Shutdown + relaunch with scoped auto-detect to preserve the
+            // package manager family (auto:uv, auto:conda, auto:pixi)
+            let restart_env_source = match handle
+                .get_runtime_state()
+                .ok()
+                .map(|s| s.kernel.env_source.clone())
+                .as_deref()
+            {
+                Some("uv:prewarmed") => "auto:uv".to_string(),
+                Some("conda:prewarmed") => "auto:conda".to_string(),
+                Some("pixi:prewarmed") => "auto:pixi".to_string(),
+                Some("") | None => "auto".to_string(),
+                Some(s) => s.to_string(),
+            };
+            // Derive notebook_path for project-file-backed envs (uv:pyproject, pixi:toml, etc.)
+            let notebook_path = if notebook_id.contains('/') || notebook_id.contains('\\') {
+                Some(notebook_id.clone())
+            } else {
+                None
+            };
             let _ = handle
                 .send_request(NotebookRequest::ShutdownKernel {})
                 .await;
@@ -193,8 +222,8 @@ pub async fn add_dependency(
             match handle
                 .send_request(NotebookRequest::LaunchKernel {
                     kernel_type: "python".to_string(),
-                    env_source: "auto".to_string(),
-                    notebook_path: None,
+                    env_source: restart_env_source,
+                    notebook_path,
                 })
                 .await
             {

--- a/crates/runt-mcp/src/tools/kernel.rs
+++ b/crates/runt-mcp/src/tools/kernel.rs
@@ -63,11 +63,13 @@ pub async fn restart_kernel(
         tracing::warn!("confirm_sync failed before restart_kernel launch: {e}");
     }
 
-    // Step 2: Determine kernel type from RuntimeState, but let daemon auto-detect env_source
-    // from notebook metadata. This ensures newly added deps are picked up on restart.
-    let kernel_type = {
+    // Step 2: Determine kernel type and env_source from RuntimeState.
+    // Use scoped auto-detect (auto:uv, auto:conda, auto:pixi) to stay within
+    // the original package manager family while re-checking metadata for new deps.
+    // This matches the Python bindings' restart logic in session_core.rs.
+    let (kernel_type, env_source) = {
         let state = handle.get_runtime_state().ok();
-        state
+        let kernel_type = state
             .as_ref()
             .and_then(|s| {
                 let name = &s.kernel.name;
@@ -77,12 +79,15 @@ pub async fn restart_kernel(
                     Some(name.clone())
                 }
             })
-            .unwrap_or_else(|| "python".to_string())
-    };
-    let env_source = if kernel_type == "deno" {
-        "deno".to_string()
-    } else {
-        "auto".to_string()
+            .unwrap_or_else(|| "python".to_string());
+        let env_source = match state.as_ref().map(|s| s.kernel.env_source.as_str()) {
+            Some("uv:prewarmed") => "auto:uv".to_string(),
+            Some("conda:prewarmed") => "auto:conda".to_string(),
+            Some("pixi:prewarmed") => "auto:pixi".to_string(),
+            Some("") | None => "auto".to_string(),
+            Some(s) => s.to_string(),
+        };
+        (kernel_type, env_source)
     };
 
     // Step 3: Launch kernel

--- a/crates/runtimed/src/notebook_sync_server.rs
+++ b/crates/runtimed/src/notebook_sync_server.rs
@@ -3971,6 +3971,7 @@ async fn handle_notebook_request(
                     && env_source != "auto"
                     && env_source != "auto:uv"
                     && env_source != "auto:conda"
+                    && env_source != "auto:pixi"
                     && env_source != "deno"
                     && env_source != "prewarmed"
                 {
@@ -3986,15 +3987,19 @@ async fn handle_notebook_request(
             } else if env_source == "auto"
                 || env_source == "auto:uv"
                 || env_source == "auto:conda"
+                || env_source == "auto:pixi"
                 || env_source.is_empty()
                 || env_source == "prewarmed"
             {
                 // Auto-detect Python environment, optionally scoped to a package manager family.
-                // "auto:uv" constrains to UV sources, "auto:conda" to conda sources.
+                // "auto:uv" constrains to UV sources, "auto:conda" to conda sources,
+                // "auto:pixi" to pixi sources.
                 let auto_scope = if env_source == "auto:uv" {
                     Some("uv")
                 } else if env_source == "auto:conda" {
                     Some("conda")
+                } else if env_source == "auto:pixi" {
+                    Some("pixi")
                 } else {
                     None
                 };
@@ -4019,6 +4024,12 @@ async fn handle_notebook_request(
                                 .as_ref()
                                 .filter(|c| !c.dependencies.is_empty())
                                 .map(|_| "conda:inline".to_string()),
+                            Some("pixi") => snap
+                                .runt
+                                .pixi
+                                .as_ref()
+                                .filter(|p| !p.dependencies.is_empty())
+                                .map(|_| "pixi:inline".to_string()),
                             _ => check_inline_deps(snap).filter(|s| s != "deno"),
                         })
                 {
@@ -4053,6 +4064,7 @@ async fn handle_notebook_request(
                         // Respect explicit scope: auto:uv → uv:pep723, auto:conda → skip (no handler)
                         let pep723_source = match auto_scope {
                             Some("uv") => "uv:pep723",
+                            Some("pixi") => "pixi:pep723",
                             Some("conda") => unreachable!("conda scope skips PEP 723"),
                             _ => {
                                 // Unscoped auto: use default_python_env
@@ -4078,10 +4090,11 @@ async fn handle_notebook_request(
                             ),
                             Some("conda") => crate::project_file::find_nearest_project_file(
                                 path,
-                                &[
-                                    crate::project_file::ProjectFileKind::PixiToml,
-                                    crate::project_file::ProjectFileKind::EnvironmentYml,
-                                ],
+                                &[crate::project_file::ProjectFileKind::EnvironmentYml],
+                            ),
+                            Some("pixi") => crate::project_file::find_nearest_project_file(
+                                path,
+                                &[crate::project_file::ProjectFileKind::PixiToml],
                             ),
                             _ => crate::project_file::detect_project_file(path),
                         })
@@ -4097,6 +4110,7 @@ async fn handle_notebook_request(
                     else {
                         let fallback = match auto_scope {
                             Some("conda") => "conda:prewarmed",
+                            Some("pixi") => "pixi:prewarmed",
                             _ => "uv:prewarmed",
                         };
                         info!(


### PR DESCRIPTION
## Summary

Codex review of #1538 caught two issues:

1. **`restart_kernel` sent unscoped `"auto"`** — UV-first when multiple dep blocks exist, could flip a conda/pixi notebook onto UV after restart
2. **`add_dependency(after="restart")` had the same issue** — unscoped `"auto"` in the LaunchKernel request

Fix: use scoped auto-detect based on the previous `env_source` from RuntimeStateDoc:
- `uv:prewarmed` → `auto:uv`
- `conda:prewarmed` → `auto:conda`
- `pixi:prewarmed` → `auto:pixi`
- Non-prewarmed (e.g. `uv:inline`, `conda:inline`) → preserve as-is
- No kernel / empty → `auto` (unscoped fallback)

This matches the Python bindings' restart logic in `session_core.rs:552-557`.

**Note:** The `detect_package_manager()` helper still defaults to UV when the kernel is stopped and no inline deps exist in metadata. This affects project-file-backed notebooks (pixi.toml, environment.yml) where the manager is only discoverable via the notebook path on disk. This is an inherent limitation when the kernel isn't running — the daemon handles project-file detection during auto-launch, not the MCP layer.

## Test plan

- [ ] Restart a UV notebook → stays on UV
- [ ] Restart a conda notebook → stays on conda (doesn't flip to UV)
- [ ] `add_dependency("pkg", after="restart")` on conda notebook → restarts with conda
- [ ] `add_dependency("pkg", after="restart")` on UV notebook → restarts with UV

Ref #1538