### PR TITLE
perf(isolated-renderer): always minify renderer plugin builds

### DIFF
--- a/apps/notebook/vite-plugin-isolated-renderer.ts
+++ b/apps/notebook/vite-plugin-isolated-renderer.ts
@@ -98,7 +98,11 @@ export function isolatedRendererPlugin(
     leafletRendererCss = "";
   }
 
-  /** Build a renderer plugin as CJS with React externalized. */
+  /**
+   * Build a renderer plugin as CJS with React externalized.
+   * Always minified — these are string constants containing entire libraries
+   * (plotly alone is 20MB unminified). No debugging value in readable output.
+   */
   async function buildRendererPlugin(
     pluginEntry: string,
     pluginName: string,
@@ -141,8 +145,8 @@ export function isolatedRendererPlugin(
             warn(warning);
           },
         },
-        minify,
-        sourcemap,
+        minify: true,
+        sourcemap: false,
       },
       define: {
         "process.env.NODE_ENV": JSON.stringify("production"),


### PR DESCRIPTION
## Summary

Renderer plugins inherited the parent build's `minify` setting, which is `false` in dev mode. Since plugin code is embedded as string constants containing entire libraries, this inflated dev builds massively:

| Plugin | Minified | Unminified |
|--------|----------|------------|
| Plotly | 4.8 MB | **20.2 MB** |
| Vega | 865 KB | **6.0 MB** |
| Markdown | 2.2 MB | **6.3 MB** |
| Leaflet | 194 KB | **1.3 MB** |
| Core IIFE | 2.6 MB | **9.0 MB** |

Fix: `buildRendererPlugin()` now always sets `minify: true` and `sourcemap: false`. These are eval'd strings inside an iframe — there's no debugging value in readable output. The main app's own code still follows the parent build's minify setting for normal dev workflow.

## Verification

- [ ] Dev build (`cargo xtask build`) produces reasonably sized plugin chunks
- [ ] Production build unchanged

_PR submitted by @rgbkrk's agent, Quill_