### PR TITLE
fix(mcp): avoid unnecessary reconnect loop on daemon PID change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6064,6 +6064,7 @@ dependencies = [
 name = "runt-mcp"
 version = "0.2.0"
 dependencies = [
+ "chrono",
  "dirs 5.0.1",
  "fancy-regex 0.14.0",
  "notebook-doc",

--- a/crates/runt-mcp/Cargo.toml
+++ b/crates/runt-mcp/Cargo.toml
@@ -26,3 +26,6 @@ regex = "1"
 fancy-regex = "0.14"
 uuid = { version = "1", features = ["v4"] }
 tracing = "0.1"
+
+[dev-dependencies]
+chrono = "0.4"

--- a/crates/runt-mcp/src/health.rs
+++ b/crates/runt-mcp/src/health.rs
@@ -102,18 +102,18 @@ pub async fn daemon_health_monitor(
                                 return EXIT_DAEMON_UPGRADED;
                             }
                             if current.pid != info.pid {
-                                // Same version, different PID — daemon restarted.
-                                // Transition to Reconnecting so we rejoin the notebook
-                                // session once the new daemon is fully ready.
+                                // Same version, different PID — daemon restarted but is
+                                // already reachable (this ping succeeded). Stay Connected
+                                // so tools aren't blocked, and rejoin the session inline.
                                 info!(
-                                    "Daemon restarted (same version {}, PID {} → {}), will rejoin session",
+                                    "Daemon restarted (same version {}, PID {} → {}), rejoining session",
                                     info.version, info.pid, current.pid
                                 );
-                                *state = DaemonState::Reconnecting {
-                                    since: Instant::now(),
-                                    attempt: 0,
-                                    last_info: Some(info.clone()),
+                                *state = DaemonState::Connected {
+                                    info: current.clone(),
                                 };
+                                drop(state);
+                                auto_rejoin_session(&socket_path, &session, &peer_label).await;
                             }
                         }
                     }

--- a/crates/runt-mcp/src/health.rs
+++ b/crates/runt-mcp/src/health.rs
@@ -210,7 +210,16 @@ pub async fn daemon_health_monitor(
     }
 }
 
+/// Maximum retries for auto-rejoin. The daemon may answer pings before notebook
+/// connections are fully ready, so we retry a few times with short delays.
+const REJOIN_MAX_RETRIES: u32 = 3;
+const REJOIN_RETRY_DELAY: Duration = Duration::from_secs(1);
+
 /// Attempt to re-join the active notebook session after daemon reconnection.
+///
+/// Retries up to [`REJOIN_MAX_RETRIES`] times with [`REJOIN_RETRY_DELAY`] between
+/// attempts, since the daemon may respond to pings before it is ready to accept
+/// notebook sync connections.
 async fn auto_rejoin_session(
     socket_path: &Path,
     session: &Arc<RwLock<Option<NotebookSession>>>,
@@ -232,24 +241,101 @@ async fn auto_rejoin_session(
     *session.write().await = None;
 
     let label = peer_label.read().await.clone();
-    match notebook_sync::connect::connect(socket_path.to_path_buf(), notebook_id.clone(), &label)
-        .await
-    {
-        Ok(result) => {
-            // Announce presence
-            crate::presence::announce(&result.handle, &label).await;
 
-            let new_session = NotebookSession {
-                handle: result.handle,
-                broadcast_rx: result.broadcast_rx,
-                notebook_id: notebook_id.clone(),
-            };
-            *session.write().await = Some(new_session);
-            info!("Auto-rejoined notebook session: {notebook_id}");
+    for attempt in 0..=REJOIN_MAX_RETRIES {
+        match notebook_sync::connect::connect(
+            socket_path.to_path_buf(),
+            notebook_id.clone(),
+            &label,
+        )
+        .await
+        {
+            Ok(result) => {
+                crate::presence::announce(&result.handle, &label).await;
+
+                let new_session = NotebookSession {
+                    handle: result.handle,
+                    broadcast_rx: result.broadcast_rx,
+                    notebook_id: notebook_id.clone(),
+                };
+                *session.write().await = Some(new_session);
+                info!("Auto-rejoined notebook session: {notebook_id}");
+                return;
+            }
+            Err(e) => {
+                if attempt < REJOIN_MAX_RETRIES {
+                    warn!(
+                        "Failed to rejoin notebook {notebook_id} (attempt {}, retrying in {}s): {e}",
+                        attempt + 1,
+                        REJOIN_RETRY_DELAY.as_secs(),
+                    );
+                    tokio::time::sleep(REJOIN_RETRY_DELAY).await;
+                } else {
+                    warn!(
+                        "Failed to auto-rejoin notebook {notebook_id} after {} attempts: {e}",
+                        attempt + 1
+                    );
+                    // Session stays None — tools will prompt user to re-join
+                }
+            }
         }
-        Err(e) => {
-            warn!("Failed to auto-rejoin notebook {notebook_id}: {e}");
-            // Session stays None — tools will prompt user to re-join
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+
+    fn test_daemon_info() -> DaemonInfo {
+        DaemonInfo {
+            endpoint: "/tmp/test.sock".to_string(),
+            pid: 1234,
+            version: "1.0.0".to_string(),
+            started_at: Utc::now(),
+            blob_port: None,
+            worktree_path: None,
+            workspace_description: None,
+        }
+    }
+
+    #[test]
+    fn backoff_grows_exponentially_then_caps() {
+        assert_eq!(backoff_duration(0), Duration::from_secs(1));
+        assert_eq!(backoff_duration(1), Duration::from_secs(2));
+        assert_eq!(backoff_duration(2), Duration::from_secs(4));
+        assert_eq!(backoff_duration(3), Duration::from_secs(8));
+        assert_eq!(backoff_duration(4), Duration::from_secs(16));
+        // Capped at BACKOFF_CAP (30s) from attempt 5 onward
+        assert_eq!(backoff_duration(5), Duration::from_secs(30));
+        assert_eq!(backoff_duration(6), Duration::from_secs(30));
+        assert_eq!(backoff_duration(100), Duration::from_secs(30));
+    }
+
+    #[test]
+    fn backoff_does_not_overflow() {
+        // u32::MAX should not panic; saturating_mul handles overflow
+        let d = backoff_duration(u32::MAX);
+        assert!(d <= BACKOFF_CAP);
+    }
+
+    #[test]
+    fn reconnecting_message_only_in_reconnecting_state() {
+        let connected = DaemonState::Connected {
+            info: test_daemon_info(),
+        };
+        assert!(connected.reconnecting_message().is_none());
+
+        let reconnecting = DaemonState::Reconnecting {
+            since: Instant::now(),
+            attempt: 3,
+            last_info: None,
+        };
+        if let Some(msg) = reconnecting.reconnecting_message() {
+            assert!(msg.contains("attempt 3"));
+            assert!(msg.contains("Daemon is restarting"));
+        } else {
+            panic!("Reconnecting state should produce a message");
         }
     }
 }


### PR DESCRIPTION
## Summary

When the daemon restarts with the same version but a different PID, the health monitor's ping succeeds (the new daemon is reachable), yet it transitions to `Reconnecting` state. This blocks all MCP tools with "Daemon is restarting" and risks cascading exponential backoff if subsequent pings fail during the brief daemon initialization window — observed growing to 500+ seconds elapsed.

Two changes:

1. **Stay `Connected` on PID change** — when a PID change is detected via a successful ping, update the daemon info and rejoin the session inline instead of entering `Reconnecting`. Tools remain unblocked throughout.

2. **Retry `auto_rejoin_session`** — the daemon may answer pings before notebook sync connections are fully ready. `auto_rejoin_session` now retries up to 3 times with 1-second delays, covering this warm-up window. This benefits both the PID-change path and the existing `Reconnecting → Connected` path.

Closes #1522

## Verification

- [ ] Start an MCP session (`runt mcp` or via Claude Code)
- [ ] Use any tool to confirm connectivity
- [ ] Restart the daemon (`runt daemon stop`, wait for auto-restart)
- [ ] Use a tool again — should succeed within ~5 seconds without "Daemon is restarting" error
- [ ] Kill the daemon process to verify genuine-outage backoff still works (tools should show "Daemon is restarting" and recover once daemon returns)

_PR submitted by @rgbkrk's agent, Quill_