### PR TITLE
fix(mcp): run_all_cells waits for completion with timeout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6064,6 +6064,7 @@ dependencies = [
 name = "runt-mcp"
 version = "0.2.0"
 dependencies = [
+ "dirs 5.0.1",
  "fancy-regex 0.14.0",
  "notebook-doc",
  "notebook-protocol",

--- a/crates/runt-mcp/src/execution.rs
+++ b/crates/runt-mcp/src/execution.rs
@@ -5,7 +5,7 @@
 //! Automerge CRDT) for execution lifecycle state, using the CRDT as the
 //! source of truth instead of relying on broadcast hints.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::time::{Duration, Instant};
 
 use notebook_protocol::protocol::{NotebookRequest, NotebookResponse};
@@ -192,6 +192,9 @@ pub struct RunAllResult {
     pub timed_out: bool,
     /// Overall status: "completed", "error", or "timed_out".
     pub status: String,
+    /// Map of cell_id → execution_id for this run's queued cells.
+    /// Used to scope status lookups to this specific run.
+    pub cell_execution_ids: HashMap<String, String>,
 }
 
 /// Run all cells and wait for completion.
@@ -211,24 +214,29 @@ pub async fn run_all_and_wait(handle: &DocHandle, timeout: Duration) -> RunAllRe
     // Step 2: Submit run-all request
     let response = handle.send_request(NotebookRequest::RunAllCells {}).await;
 
-    let execution_ids: HashSet<String> = match response {
-        Ok(NotebookResponse::AllCellsQueued { queued }) => {
-            queued.into_iter().map(|q| q.execution_id).collect()
-        }
+    let cell_execution_ids: HashMap<String, String> = match response {
+        Ok(NotebookResponse::AllCellsQueued { queued }) => queued
+            .into_iter()
+            .map(|q| (q.cell_id, q.execution_id))
+            .collect(),
         _ => {
             return RunAllResult {
                 timed_out: false,
                 status: "error".to_string(),
+                cell_execution_ids: HashMap::new(),
             };
         }
     };
 
-    if execution_ids.is_empty() {
+    if cell_execution_ids.is_empty() {
         return RunAllResult {
             timed_out: false,
             status: "completed".to_string(),
+            cell_execution_ids: HashMap::new(),
         };
     }
+
+    let execution_ids: HashSet<&str> = cell_execution_ids.values().map(|s| s.as_str()).collect();
 
     // Step 3: Poll RuntimeStateDoc for all execution IDs to reach terminal status.
     let deadline = Instant::now() + timeout;
@@ -244,7 +252,7 @@ pub async fn run_all_and_wait(handle: &DocHandle, timeout: Duration) -> RunAllRe
             all_terminal = execution_ids.iter().all(|eid| {
                 state
                     .executions
-                    .get(eid.as_str())
+                    .get(*eid)
                     .is_some_and(|exec| exec.status == "done" || exec.status == "error")
             });
             if all_terminal {
@@ -261,7 +269,7 @@ pub async fn run_all_and_wait(handle: &DocHandle, timeout: Duration) -> RunAllRe
         execution_ids.iter().any(|eid| {
             state
                 .executions
-                .get(eid.as_str())
+                .get(*eid)
                 .is_some_and(|exec| exec.status == "error")
         })
     });
@@ -275,5 +283,9 @@ pub async fn run_all_and_wait(handle: &DocHandle, timeout: Duration) -> RunAllRe
     }
     .to_string();
 
-    RunAllResult { timed_out, status }
+    RunAllResult {
+        timed_out,
+        status,
+        cell_execution_ids,
+    }
 }

--- a/crates/runt-mcp/src/execution.rs
+++ b/crates/runt-mcp/src/execution.rs
@@ -5,6 +5,7 @@
 //! Automerge CRDT) for execution lifecycle state, using the CRDT as the
 //! source of truth instead of relying on broadcast hints.
 
+use std::collections::HashSet;
 use std::time::{Duration, Instant};
 
 use notebook_protocol::protocol::{NotebookRequest, NotebookResponse};
@@ -183,4 +184,96 @@ pub async fn execute_and_wait(
         status: final_status,
         success,
     }
+}
+
+/// Result of running all cells.
+pub struct RunAllResult {
+    /// Whether the deadline was hit before all cells finished.
+    pub timed_out: bool,
+    /// Overall status: "completed", "error", or "timed_out".
+    pub status: String,
+}
+
+/// Run all cells and wait for completion.
+///
+/// 1. Calls `confirm_sync()` to ensure the daemon has the latest cell sources.
+/// 2. Sends `RunAllCells` request.
+/// 3. Polls RuntimeStateDoc until all queued execution IDs reach terminal status.
+///
+/// Returns a lightweight `RunAllResult` with overall status. The caller should
+/// read the full notebook state after this returns to build the summary view.
+pub async fn run_all_and_wait(handle: &DocHandle, timeout: Duration) -> RunAllResult {
+    // Step 1: Ensure daemon has our latest edits
+    if let Err(e) = handle.confirm_sync().await {
+        warn!("confirm_sync failed before run_all_cells: {e}");
+    }
+
+    // Step 2: Submit run-all request
+    let response = handle.send_request(NotebookRequest::RunAllCells {}).await;
+
+    let execution_ids: HashSet<String> = match response {
+        Ok(NotebookResponse::AllCellsQueued { queued }) => {
+            queued.into_iter().map(|q| q.execution_id).collect()
+        }
+        _ => {
+            return RunAllResult {
+                timed_out: false,
+                status: "error".to_string(),
+            };
+        }
+    };
+
+    if execution_ids.is_empty() {
+        return RunAllResult {
+            timed_out: false,
+            status: "completed".to_string(),
+        };
+    }
+
+    // Step 3: Poll RuntimeStateDoc for all execution IDs to reach terminal status.
+    let deadline = Instant::now() + timeout;
+    let mut all_terminal = false;
+
+    loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+
+        if let Ok(state) = handle.get_runtime_state() {
+            all_terminal = execution_ids.iter().all(|eid| {
+                state
+                    .executions
+                    .get(eid.as_str())
+                    .is_some_and(|exec| exec.status == "done" || exec.status == "error")
+            });
+            if all_terminal {
+                break;
+            }
+        }
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    // Step 4: Derive overall status
+    let timed_out = !all_terminal;
+    let has_error = handle.get_runtime_state().ok().is_some_and(|state| {
+        execution_ids.iter().any(|eid| {
+            state
+                .executions
+                .get(eid.as_str())
+                .is_some_and(|exec| exec.status == "error")
+        })
+    });
+
+    let status = if timed_out {
+        "timed_out"
+    } else if has_error {
+        "error"
+    } else {
+        "completed"
+    }
+    .to_string();
+
+    RunAllResult { timed_out, status }
 }

--- a/crates/runt-mcp/src/tools/execution.rs
+++ b/crates/runt-mcp/src/tools/execution.rs
@@ -7,11 +7,11 @@ use rmcp::ErrorData as McpError;
 use schemars::JsonSchema;
 use serde::Deserialize;
 
-use notebook_protocol::protocol::NotebookRequest;
-
 use crate::execution;
+use crate::formatting;
 use crate::NteractMcp;
 
+use super::cell_read::{build_cell_execution_count_map, build_cell_status_map};
 use super::{arg_str, tool_error, tool_success};
 
 #[allow(dead_code)]
@@ -26,7 +26,11 @@ pub struct ExecuteCellParams {
 
 #[allow(dead_code)]
 #[derive(Debug, Deserialize, JsonSchema)]
-pub struct RunAllCellsParams {}
+pub struct RunAllCellsParams {
+    /// Max seconds to wait for all cells to finish. Default: 300.
+    #[serde(default)]
+    pub timeout_secs: Option<f64>,
+}
 
 /// Execute a cell and return results (with structured content for MCP Apps).
 pub async fn execute_cell(
@@ -65,28 +69,111 @@ pub async fn execute_cell(
     super::build_execution_result(&result, &handle, server).await
 }
 
-/// Queue all code cells for execution.
+/// Execute all code cells in order and wait for completion.
 pub async fn run_all_cells(
     server: &NteractMcp,
-    _request: &CallToolRequestParams,
+    request: &CallToolRequestParams,
 ) -> Result<CallToolResult, McpError> {
     let handle = require_handle!(server);
 
-    // Ensure daemon has latest source
-    if let Err(e) = handle.confirm_sync().await {
-        tracing::warn!("confirm_sync failed before run_all_cells: {e}");
+    let timeout_secs = request
+        .arguments
+        .as_ref()
+        .and_then(|a| a.get("timeout_secs"))
+        .and_then(|v| v.as_f64())
+        .unwrap_or(300.0);
+
+    let result = execution::run_all_and_wait(&handle, Duration::from_secs_f64(timeout_secs)).await;
+
+    // Build the notebook summary view (same format as get_all_cells summary).
+    let cells = handle.get_cells();
+    let cell_status_map = build_cell_status_map(&handle);
+    let cell_ec_map = build_cell_execution_count_map(&handle);
+
+    // Count code cells by status for the header.
+    let mut succeeded = 0usize;
+    let mut errored = 0usize;
+    let mut cancelled = 0usize;
+    let mut running = 0usize;
+    let mut queued = 0usize;
+
+    for cell in &cells {
+        if cell.cell_type != "code" {
+            continue;
+        }
+        let status = cell_status_map.get(&cell.id).map(String::as_str);
+        let ec = cell_ec_map.get(&cell.id);
+        match status {
+            Some("done") => succeeded += 1,
+            Some("error") => {
+                // Cancelled = error status but never actually ran (no execution_count)
+                if ec.is_none() {
+                    cancelled += 1;
+                } else {
+                    errored += 1;
+                }
+            }
+            Some("running") => running += 1,
+            Some("queued") => queued += 1,
+            _ => {}
+        }
     }
 
-    match handle.send_request(NotebookRequest::RunAllCells {}).await {
-        Ok(_) => {
-            let count = handle
-                .get_cells()
-                .iter()
-                .filter(|c| c.cell_type == "code")
-                .count();
-            let result = serde_json::json!({ "status": "queued", "count": count });
-            tool_success(&serde_json::to_string_pretty(&result).unwrap_or_default())
+    // Build status header line.
+    let header = match result.status.as_str() {
+        "timed_out" => {
+            let done = succeeded + errored;
+            let total = done + cancelled + running + queued;
+            let mut parts = vec![format!("{done} completed")];
+            if running > 0 {
+                parts.push(format!("{running} running"));
+            }
+            if queued > 0 {
+                parts.push(format!("{queued} queued"));
+            }
+            format!("Execution timed out ({total} cells: {})", parts.join(", "))
         }
-        Err(e) => tool_error(&format!("Failed to run all cells: {e}")),
+        "error" => {
+            let mut parts = Vec::new();
+            if succeeded > 0 {
+                parts.push(format!("{succeeded} succeeded"));
+            }
+            if errored > 0 {
+                parts.push(format!("{errored} errored"));
+            }
+            if cancelled > 0 {
+                parts.push(format!("{cancelled} cancelled"));
+            }
+            format!("Execution error ({})", parts.join(", "))
+        }
+        _ => {
+            format!("Execution completed ({succeeded} succeeded)")
+        }
+    };
+
+    // Format each cell using the standard summary format.
+    let mut lines = vec![header, String::new()];
+    for (i, cell) in cells.iter().enumerate() {
+        let ec = cell_ec_map.get(&cell.id).map(String::as_str);
+
+        // Remap "error" with no execution_count to "cancelled" for display.
+        let raw_status = cell_status_map.get(&cell.id).map(String::as_str);
+        let display_status = match raw_status {
+            Some("error") if ec.is_none() => Some("cancelled"),
+            other => other,
+        };
+
+        let line = formatting::format_cell_summary(
+            i,
+            &cell.id,
+            &cell.cell_type,
+            &cell.source,
+            ec,
+            display_status,
+            60,
+        );
+        lines.push(line);
     }
+
+    tool_success(&lines.join("\n"))
 }

--- a/crates/runt-mcp/src/tools/execution.rs
+++ b/crates/runt-mcp/src/tools/execution.rs
@@ -11,7 +11,6 @@ use crate::execution;
 use crate::formatting;
 use crate::NteractMcp;
 
-use super::cell_read::{build_cell_execution_count_map, build_cell_status_map};
 use super::{arg_str, tool_error, tool_success};
 
 #[allow(dead_code)]
@@ -86,9 +85,16 @@ pub async fn run_all_cells(
     let result = execution::run_all_and_wait(&handle, Duration::from_secs_f64(timeout_secs)).await;
 
     // Build the notebook summary view (same format as get_all_cells summary).
+    // Status and execution_count are scoped to THIS run's execution IDs to
+    // avoid mixing in historical state from prior runs.
     let cells = handle.get_cells();
-    let cell_status_map = build_cell_status_map(&handle);
-    let cell_ec_map = build_cell_execution_count_map(&handle);
+    let runtime_state = handle.get_runtime_state().ok();
+
+    // Look up this run's execution state for a given cell.
+    let run_exec = |cell_id: &str| -> Option<&notebook_doc::runtime_state::ExecutionState> {
+        let eid = result.cell_execution_ids.get(cell_id)?;
+        runtime_state.as_ref()?.executions.get(eid.as_str())
+    };
 
     // Count code cells by status for the header.
     let mut succeeded = 0usize;
@@ -101,21 +107,21 @@ pub async fn run_all_cells(
         if cell.cell_type != "code" {
             continue;
         }
-        let status = cell_status_map.get(&cell.id).map(String::as_str);
-        let ec = cell_ec_map.get(&cell.id);
-        match status {
-            Some("done") => succeeded += 1,
-            Some("error") => {
-                // Cancelled = error status but never actually ran (no execution_count)
-                if ec.is_none() {
-                    cancelled += 1;
-                } else {
-                    errored += 1;
+        if let Some(exec) = run_exec(&cell.id) {
+            match exec.status.as_str() {
+                "done" => succeeded += 1,
+                "error" => {
+                    // Cancelled = error status but never actually ran (no execution_count)
+                    if exec.execution_count.is_none() {
+                        cancelled += 1;
+                    } else {
+                        errored += 1;
+                    }
                 }
+                "running" => running += 1,
+                "queued" => queued += 1,
+                _ => {}
             }
-            Some("running") => running += 1,
-            Some("queued") => queued += 1,
-            _ => {}
         }
     }
 
@@ -152,23 +158,30 @@ pub async fn run_all_cells(
     };
 
     // Format each cell using the standard summary format.
+    // For code cells in this run, use the run-scoped execution state.
+    // For non-code cells or cells not in this run, show no status.
     let mut lines = vec![header, String::new()];
     for (i, cell) in cells.iter().enumerate() {
-        let ec = cell_ec_map.get(&cell.id).map(String::as_str);
+        let (display_status, ec_str);
 
-        // Remap "error" with no execution_count to "cancelled" for display.
-        let raw_status = cell_status_map.get(&cell.id).map(String::as_str);
-        let display_status = match raw_status {
-            Some("error") if ec.is_none() => Some("cancelled"),
-            other => other,
-        };
+        if let Some(exec) = run_exec(&cell.id) {
+            // Remap "error" with no execution_count to "cancelled" for display.
+            display_status = Some(match exec.status.as_str() {
+                "error" if exec.execution_count.is_none() => "cancelled",
+                other => other,
+            });
+            ec_str = exec.execution_count.map(|c| c.to_string());
+        } else {
+            display_status = None;
+            ec_str = None;
+        }
 
         let line = formatting::format_cell_summary(
             i,
             &cell.id,
             &cell.cell_type,
             &cell.source,
-            ec,
+            ec_str.as_deref(),
             display_status,
             60,
         );

--- a/crates/runt-mcp/src/tools/mod.rs
+++ b/crates/runt-mcp/src/tools/mod.rs
@@ -233,8 +233,8 @@ pub fn all_tools() -> Vec<Tool> {
         .with_meta(app_tool_meta()),
         Tool::new(
             "run_all_cells",
-            "Queue all code cells for execution. Use get_all_cells() to see results.",
-            schema_for::<EmptyParams>(),
+            "Execute all code cells in order, wait for completion, and return the notebook summary. Use get_cell() to inspect specific outputs.",
+            schema_for::<execution::RunAllCellsParams>(),
         )
         .annotate(ToolAnnotations::new().destructive(true).open_world(true)),
         // -- Kernel --


### PR DESCRIPTION
## Summary

`run_all_cells` was fire-and-forget — it queued all cells and returned `{ "status": "queued", "count": N }` immediately. MCP agents had no way to know when cells finished or if they errored, making the tool effectively unusable.

Now `run_all_cells` polls the RuntimeStateDoc CRDT until all queued executions reach terminal status (or timeout), then returns the full notebook summary view with per-cell statuses. Agents can see all cell IDs and selectively call `get_cell()` for details.

Key behaviors:
- Polls every 50ms (same pattern as `execute_cell`)
- Default timeout: 300s (configurable via `timeout_secs` param)
- Cancelled cells (stop-on-error) display as "cancelled" instead of "error"
- Returns the same summary format as `get_all_cells`

Closes #1525

## Verification

- [ ] Create a notebook with 3 code cells (`print("a")`, `raise ValueError("boom")`, `print("c")`), call `run_all_cells` — should wait and return summary showing the error cell and two cancelled cells
- [ ] Create a notebook with simple `print` cells, call `run_all_cells` — should return all succeeded
- [ ] Call `run_all_cells` with `timeout_secs: 0.1` on a `time.sleep(10)` cell — should return timed_out status
- [ ] Verify notebook summary includes markdown cells (without status) alongside code cells

_PR submitted by @rgbkrk's agent, Quill_