### PR TITLE
fix(sync): process RuntimeStateSync frames during request/response wait

### DIFF
--- a/crates/notebook-sync/src/sync_task.rs
+++ b/crates/notebook-sync/src/sync_task.rs
@@ -726,12 +726,22 @@ async fn wait_for_response<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
                 }
             }
 
+            // Process all other frame types (RuntimeStateSync, Presence, etc.)
+            // while waiting for the response. Dropping these frames would stall
+            // the Automerge sync protocol — the daemon marks sent messages as
+            // in_flight, and generate_sync_message() returns None until the peer
+            // acknowledges. A dropped RuntimeStateSync causes permanent sync
+            // stall for RuntimeStateDoc (no execution results, no status updates).
             _ => {
-                // Ignore other frame types while waiting for response
-                debug!(
-                    "[notebook-sync] Ignoring {:?} frame while waiting for response ({})",
-                    frame.frame_type, notebook_id
-                );
+                handle_incoming_frame(
+                    &frame,
+                    doc,
+                    writer,
+                    snapshot_tx,
+                    broadcast_tx,
+                    notebook_id,
+                )
+                .await;
             }
         }
     }

--- a/crates/notebook-sync/src/sync_task.rs
+++ b/crates/notebook-sync/src/sync_task.rs
@@ -733,15 +733,8 @@ async fn wait_for_response<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>(
             // acknowledges. A dropped RuntimeStateSync causes permanent sync
             // stall for RuntimeStateDoc (no execution results, no status updates).
             _ => {
-                handle_incoming_frame(
-                    &frame,
-                    doc,
-                    writer,
-                    snapshot_tx,
-                    broadcast_tx,
-                    notebook_id,
-                )
-                .await;
+                handle_incoming_frame(&frame, doc, writer, snapshot_tx, broadcast_tx, notebook_id)
+                    .await;
             }
         }
     }


### PR DESCRIPTION
## Summary

- **Bug**: `wait_for_response()` in `notebook-sync` silently dropped `RuntimeStateSync` frames while waiting for daemon responses, causing permanent RuntimeStateDoc sync stalls
- **Root cause**: Automerge's sync protocol sets `in_flight=true` when a message is sent; `generate_sync_message()` returns `None` until the peer acknowledges. A dropped frame means the ack never comes — no further execution results, status updates, or outputs are ever pushed to that peer
- **Trigger**: Kernel restart generates RuntimeStateDoc updates (kernel status, env sync) that race with subsequent MCP client requests. If a `RuntimeStateSync` frame arrives during `wait_for_response`, it was dropped, deadlocking the sync permanently
- **Fix**: Delegate to `handle_incoming_frame()` in the catch-all arm, matching the pattern already used by `confirm_sync_impl` and the main sync loop

## Reproduction

Hard to reproduce reliably — requires a `RuntimeStateSync` frame to arrive during the narrow window of `wait_for_response`. Observed after: heavy notebook use (10+ cells, multiple output types) → `add_dependency(after="sync")` fails with `needs_restart` → manual `restart_kernel()` → subsequent `execute_cell` calls permanently stuck at "running".

`join_notebook` recovered because it creates a fresh connection with a new `sync::State`, breaking the deadlocked `in_flight` flag.

## Test plan

- [ ] Verify `cargo check -p notebook-sync` passes
- [ ] Run existing sync integration tests
- [ ] Manual: create notebook → execute cells → add dep requiring restart → restart kernel → execute cells (should no longer stall)
- [ ] Verify `wait_for_response` now processes RuntimeStateSync, Presence, and PoolStateSync frames during request waits


🤖 Generated with [Claude Code](https://claude.com/claude-code)