### PR TITLE
feat(mcp): add per-session file logging for runt mcp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6237,6 +6237,8 @@ dependencies = [
  "tar",
  "tempfile",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
  "uuid",
  "walkdir",
 ]

--- a/crates/runt-workspace/src/lib.rs
+++ b/crates/runt-workspace/src/lib.rs
@@ -906,6 +906,18 @@ pub fn default_notebook_log_path() -> PathBuf {
     daemon_base_dir().join("notebook.log")
 }
 
+/// Get the directory for MCP server session logs.
+///
+/// Multiple MCP server instances can run concurrently (one per agent),
+/// so each session gets its own log file in this directory.
+///
+/// macOS:  `~/Library/Caches/runt[-nightly]/mcp-logs/`
+/// Linux:  `~/.cache/runt[-nightly]/mcp-logs/`
+/// Dev:    `{cache}/runt[-nightly]/worktrees/{hash}/mcp-logs/`
+pub fn mcp_logs_dir() -> PathBuf {
+    daemon_base_dir().join("mcp-logs")
+}
+
 /// Get the default directory for saving notebooks.
 ///
 /// In dev mode with a workspace path: tries `{workspace}/notebooks/` first,

--- a/crates/runt/Cargo.toml
+++ b/crates/runt/Cargo.toml
@@ -39,6 +39,8 @@ chrono = { version = "0.4", default-features = false, features = ["std", "clock"
 flate2 = "1"
 notify = "8"
 tar = "0.4"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 walkdir = "2"
 
 [dev-dependencies]

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -650,6 +650,48 @@ async fn async_main(command: Option<Commands>) -> Result<()> {
 }
 
 async fn run_mcp_server(no_show: bool) -> Result<()> {
+    // ── Initialize file logging ──────────────────────────────────────
+    // MCP servers use stdio for the JSON-RPC protocol, so we log to a
+    // file only. Each session gets its own file (date + short random ID)
+    // to support multiple concurrent MCP server instances.
+    let log_dir = runt_workspace::mcp_logs_dir();
+    let _ = std::fs::create_dir_all(&log_dir);
+
+    let session_id = &uuid::Uuid::new_v4().to_string()[..8];
+    let date = chrono::Local::now().format("%Y-%m-%d");
+    let log_filename = format!("{date}-{session_id}.log");
+    let log_path = log_dir.join(&log_filename);
+
+    // Prune logs older than 7 days
+    prune_old_mcp_logs(&log_dir, 7);
+
+    if let Ok(log_file) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_path)
+    {
+        use tracing_subscriber::layer::SubscriberExt;
+        use tracing_subscriber::util::SubscriberInitExt;
+
+        let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
+            .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
+        let file_layer = tracing_subscriber::fmt::layer()
+            .with_writer(std::sync::Mutex::new(log_file))
+            .with_ansi(false);
+
+        tracing_subscriber::registry()
+            .with(env_filter)
+            .with(file_layer)
+            .init();
+
+        tracing::info!(
+            pid = std::process::id(),
+            log = %log_path.display(),
+            "MCP server starting"
+        );
+    }
+
+    // ── Server setup ─────────────────────────────────────────────────
     let socket_path = runtimed_client::daemon_paths::get_socket_path();
     let (blob_base_url, blob_store_path) =
         runtimed_client::daemon_paths::get_blob_paths_async(&socket_path).await;
@@ -716,6 +758,29 @@ async fn run_mcp_server(no_show: bool) -> Result<()> {
     }
 
     Ok(())
+}
+
+/// Delete MCP log files older than `max_age_days` days.
+fn prune_old_mcp_logs(dir: &std::path::Path, max_age_days: u64) {
+    let cutoff =
+        std::time::SystemTime::now() - std::time::Duration::from_secs(max_age_days * 24 * 60 * 60);
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("log") {
+            continue;
+        }
+        if let Ok(meta) = path.metadata() {
+            if let Ok(modified) = meta.modified() {
+                if modified < cutoff {
+                    let _ = std::fs::remove_file(&path);
+                }
+            }
+        }
+    }
 }
 
 async fn jupyter_command(command: JupyterCommands) -> Result<()> {
@@ -3309,18 +3374,58 @@ async fn diagnostics_command(output_dir: Option<PathBuf>) -> Result<()> {
         );
     }
 
-    // 3. daemon status --json
+    // 3. MCP server session logs (most recent 10 by mtime)
+    let mcp_dir = runt_workspace::mcp_logs_dir();
+    if mcp_dir.is_dir() {
+        let mut log_files: Vec<_> = std::fs::read_dir(&mcp_dir)
+            .into_iter()
+            .flatten()
+            .flatten()
+            .filter(|e| {
+                e.path()
+                    .extension()
+                    .and_then(|ext| ext.to_str())
+                    .is_some_and(|ext| ext == "log")
+            })
+            .filter_map(|e| {
+                let mtime = e.metadata().ok()?.modified().ok()?;
+                Some((e.path(), mtime))
+            })
+            .collect();
+        log_files.sort_by(|a, b| b.1.cmp(&a.1)); // newest first
+        let selected: Vec<_> = log_files.into_iter().take(10).collect();
+
+        if selected.is_empty() {
+            println!("  {} mcp-logs/ (empty)", "–".yellow());
+        } else {
+            for (path, _) in &selected {
+                if let Some(name) = path.file_name() {
+                    let archive_name = format!("mcp-logs/{}", name.to_string_lossy());
+                    tar.append_path_with_name(path, &archive_name)?;
+                }
+            }
+            println!(
+                "  {} mcp-logs/ ({} session logs)",
+                "✓".green(),
+                selected.len()
+            );
+        }
+    } else {
+        println!("  {} mcp-logs/ (not found)", "–".yellow());
+    }
+
+    // 4. daemon status --json
     let exe = std::env::current_exe()?;
     let status_output = capture_command_output(&exe, &["daemon", "status", "--json"]);
     tar_add_bytes(&mut tar, "daemon-status.json", &status_output)?;
     println!("  {} daemon-status.json", "✓".green());
 
-    // 4. doctor --json
+    // 5. doctor --json
     let doctor_output = capture_command_output(&exe, &["doctor", "--json"]);
     tar_add_bytes(&mut tar, "doctor.json", &doctor_output)?;
     println!("  {} doctor.json", "✓".green());
 
-    // 5. system-info.json
+    // 6. system-info.json
     let system_info = collect_system_info();
     let system_json = serde_json::to_string_pretty(&system_info)?;
     tar_add_bytes(&mut tar, "system-info.json", system_json.as_bytes())?;

--- a/crates/runt/src/main.rs
+++ b/crates/runt/src/main.rs
@@ -670,6 +670,16 @@ async fn run_mcp_server(no_show: bool) -> Result<()> {
         .append(true)
         .open(&log_path)
     {
+        // Hold a shared flock for the process lifetime so the pruner
+        // (which tries an exclusive lock) skips files still in use.
+        #[cfg(unix)]
+        {
+            use std::os::unix::io::AsRawFd;
+            unsafe {
+                libc::flock(log_file.as_raw_fd(), libc::LOCK_SH | libc::LOCK_NB);
+            }
+        }
+
         use tracing_subscriber::layer::SubscriberExt;
         use tracing_subscriber::util::SubscriberInitExt;
 
@@ -761,6 +771,10 @@ async fn run_mcp_server(no_show: bool) -> Result<()> {
 }
 
 /// Delete MCP log files older than `max_age_days` days.
+///
+/// On Unix, skips files that are still held open by a running MCP server
+/// (detected via a non-blocking exclusive flock — active servers hold a
+/// shared lock).
 fn prune_old_mcp_logs(dir: &std::path::Path, max_age_days: u64) {
     let cutoff =
         std::time::SystemTime::now() - std::time::Duration::from_secs(max_age_days * 24 * 60 * 60);
@@ -776,11 +790,37 @@ fn prune_old_mcp_logs(dir: &std::path::Path, max_age_days: u64) {
         if let Ok(meta) = path.metadata() {
             if let Ok(modified) = meta.modified() {
                 if modified < cutoff {
+                    #[cfg(unix)]
+                    if is_file_locked(&path) {
+                        continue;
+                    }
                     let _ = std::fs::remove_file(&path);
                 }
             }
         }
     }
+}
+
+/// Check if a file is held open by another process via flock.
+///
+/// Returns true if an exclusive lock cannot be acquired (another process
+/// holds a shared lock), meaning the file is still in use.
+#[cfg(unix)]
+fn is_file_locked(path: &std::path::Path) -> bool {
+    use std::os::unix::io::AsRawFd;
+    let Ok(file) = std::fs::File::open(path) else {
+        return false;
+    };
+    let rc = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+    if rc != 0 {
+        // EWOULDBLOCK — another process holds a shared lock
+        return true;
+    }
+    // Lock succeeded — no one else has it. Unlock immediately.
+    unsafe {
+        libc::flock(file.as_raw_fd(), libc::LOCK_UN);
+    }
+    false
 }
 
 async fn jupyter_command(command: JupyterCommands) -> Result<()> {

--- a/crates/runtimed-client/src/lib.rs
+++ b/crates/runtimed-client/src/lib.rs
@@ -45,8 +45,8 @@ pub use runt_workspace::{
     daemon_base_dir_for, daemon_binary_basename, daemon_binary_basename_for, daemon_launchd_label,
     daemon_service_basename, default_notebook_log_path, default_socket_path, desktop_display_name,
     desktop_display_name_for, desktop_product_name, get_workspace_name, get_workspace_path,
-    is_dev_mode, open_notebook_app_for_channel, session_state_path, settings_json_path,
-    socket_path_for_channel, worktree_hash, BuildChannel,
+    is_dev_mode, mcp_logs_dir, open_notebook_app_for_channel, session_state_path,
+    settings_json_path, socket_path_for_channel, worktree_hash, BuildChannel,
 };
 
 /// Get the default log path for the daemon.


### PR DESCRIPTION
## Summary

- `runt mcp` now writes structured logs to per-session files in the OS-appropriate cache directory (`~/Library/Caches/runt[-nightly]/mcp-logs/` on macOS, `~/.cache/runt[-nightly]/mcp-logs/` on Linux)
- Each session gets its own file named `{date}-{session-id}.log` to support multiple concurrent MCP server instances (one per agent)
- Logs older than 7 days are pruned on startup
- `runt diagnostics` now collects the 10 most recent MCP session logs into the diagnostic tarball

Motivated by the sync stall bug in #1553 — the MCP server had zero persistent logging, making post-hoc debugging impossible.

## Test plan

- [ ] `cargo check -p runt-cli -p runt-workspace` compiles
- [ ] `cargo xtask lint` passes
- [ ] Run `runt mcp` (ctrl-C to stop) — verify log file created in `mcp_logs_dir()` with correct naming
- [ ] Run `runt mcp` twice concurrently — verify two separate log files
- [ ] Run `runt diagnostics` — verify MCP logs appear in the tarball
- [ ] Inspect log file contents — should have startup breadcrumb and tracing output


🤖 Generated with [Claude Code](https://claude.com/claude-code)